### PR TITLE
feat(mata-garuda): cron-tcc-safe flags + converge 7 HOME-fork crons (HOME-fork #2)

### DIFF
--- a/apps/mata-garuda/infra/launchagents/migrate_crons_to_repo_wrapper.sh
+++ b/apps/mata-garuda/infra/launchagents/migrate_crons_to_repo_wrapper.sh
@@ -37,19 +37,48 @@ for c in "${CRONS[@]}"; do
 done
 
 
-# --- gap.consumer uses a SEPARATE wrapper (matagaruda-gap-consumer.sh) + had a
-# --- dead-worktree MATA_GARUDA_REPO. Repoint to repo wrapper + fix the repo env. ---
-GAP_P="/com.matagaruda.gap.consumer.plist"
-GAP_WRAPPER="/apps/mata-garuda/scripts/matagaruda-gap-consumer.sh"
-if [ -f "" ] && [ -x "" ]; then
-  cp -p "" ".bak-repowrapper-$(date +%Y%m%d-%H%M%S)"
-  /usr/libexec/PlistBuddy -c "Set :ProgramArguments:0 " "" 2>/dev/null || true
-  # kill the dead-worktree repo pointer → main checkout
-  /usr/libexec/PlistBuddy -c "Set :EnvironmentVariables:MATA_GARUDA_REPO /apps/mata-garuda" "" 2>/dev/null || true
-  plutil -lint "$GAP_P" >/dev/null
-  launchctl bootout "gui/$(id -u)/com.matagaruda.gap.consumer" 2>/dev/null || true
-  launchctl bootstrap "gui/$(id -u)" "$GAP_P" 2>/dev/null || echo "    (gap reload deferred)"
-  echo "  migrated gap.consumer → repo wrapper + MATA_GARUDA_REPO=main checkout"
-fi
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 2 (2026-06-30): the 7 remaining mata_garuda crons that used per-cron
+# HOME-fork SHELL wrappers in ~/scripts/. Those cannot be promoted as repo shell
+# scripts (launchd /bin/zsh can't open ~/Desktop under TCC → exit 127, verified
+# A/B). Instead route each through the repo cron-tcc-safe.sh, which execs venv
+# PYTHON (TCC-bypassing) and now carries the per-cron logic via flags
+# (--module / --flock / --window / --source-env). One TCC-safe wrapper, in git.
+#
+# Format: "label-suffix|ProgramArguments after the wrapper path"
+WRAPPED7=(
+  "bridge.adaptive|--module mata_garuda.bridge.nerve --source-env .cell-bridge-state/wa-media.env"
+  "classifier.adaptive|--flock classifier-worker $REPO/apps/mata-garuda/scripts/run_classifier_worker.py"
+  "consumer-lag.check|$REPO/apps/mata-garuda/scripts/check_consumer_lag.py"
+  "gap.consumer|--module mata_garuda.workers.gap_consumer --window 6-22"
+  "ner.adaptive|--flock ner-worker $REPO/apps/mata-garuda/scripts/run_ner_worker.py"
+  "nlm-feeder-stream.hourly|$REPO/apps/mata-garuda/scripts/run_nlm_feeder_stream.py"
+  "pel-cleaner.weekly|--flock pel-cleaner $REPO/apps/mata-garuda/scripts/pel_cleaner.py"
+)
 
-echo "done. HOME-fork wrapper $HOMEFORK is now unused (keep as fallback or rm after a clean cycle)."
+for entry in "${WRAPPED7[@]}"; do
+  suffix="${entry%%|*}"
+  argstr="${entry#*|}"
+  P="$LA/com.matagaruda.$suffix.plist"
+  [ -f "$P" ] || { echo "  skip $suffix (no plist)"; continue; }
+  L=$(/usr/libexec/PlistBuddy -c "Print :Label" "$P" 2>/dev/null)
+  cur=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$P" 2>/dev/null || true)
+  if [ "$cur" = "$REPO_WRAPPER" ]; then echo "  ok   $suffix (already repo wrapper)"; continue; fi
+  cp -p "$P" "$P.bak-repowrapper-$(date +%Y%m%d-%H%M%S)"
+  # rebuild ProgramArguments: [wrapper, <argstr tokens...>]
+  /usr/libexec/PlistBuddy -c "Delete :ProgramArguments" "$P" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c "Add :ProgramArguments array" "$P"
+  /usr/libexec/PlistBuddy -c "Add :ProgramArguments: string $REPO_WRAPPER" "$P"
+  for tok in $argstr; do
+    /usr/libexec/PlistBuddy -c "Add :ProgramArguments: string $tok" "$P"
+  done
+  # gap.consumer carried a dead-.worktrees MATA_GARUDA_REPO override — drop it so
+  # the wrapper's self-locating REPO_ROOT wins (cicatrix #1 dead-worktree).
+  /usr/libexec/PlistBuddy -c "Delete :EnvironmentVariables:MATA_GARUDA_REPO" "$P" 2>/dev/null || true
+  plutil -lint "$P" >/dev/null
+  launchctl bootout "gui/$(id -u)/$L" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$P" 2>/dev/null || echo "    (reload deferred — picks up next run)"
+  echo "  migrated $suffix → repo wrapper ($argstr)"
+done
+
+echo "done. HOME-fork wrappers in $HOME/scripts/ are now unused (keep as fallback or rm after a clean cycle)."

--- a/apps/mata-garuda/scripts/matagaruda-cron-tcc-safe.sh
+++ b/apps/mata-garuda/scripts/matagaruda-cron-tcc-safe.sh
@@ -1,23 +1,75 @@
 #!/bin/zsh
 # Mata Garuda generic cron wrapper — TCC-safe (W19+W20 pattern)
-# Usage: matagaruda-cron-tcc-safe.sh <entry_script_path> [log_label]
 #
-# Eliminates the /bin/bash -lc + source .venv/bin/activate failure that
-# launchd TCC sandbox produced as false-noise in .error.log for at
-# least kg-linker + wr-topic crons (W20 cicatrix 2026-05-22).
+# Usage:
+#   matagaruda-cron-tcc-safe.sh [OPTIONS] <entry> [log_label]
 #
-# Reusable: caller passes entry script. Wrapper does no business logic.
+# <entry> is a .py file path (default) OR, with --module, a python module name.
+# OPTIONS (all optional — without them this behaves EXACTLY as the original
+# <entry.py> [label] form, so the 10 existing repo crons are unaffected):
+#   --module <m>     run `python -m <m>` instead of `python <entry.py>`
+#                    (entry then names the module, e.g. mata_garuda.bridge.nerve)
+#   --flock <name>   single-instance gate via flock(1); a second concurrent run
+#                    exits 75 and is skipped (W7 anti-stacking lesson)
+#   --window <a>-<b> only run when local hour is in [a, b); outside → exit 0
+#                    (gap_consumer operating window 06-22 WITA)
+#   --source-env <f> additionally source <f> (relative to $HOME or absolute)
+#                    before exec (e.g. .cell-bridge-state/wa-media.env, Mythos-P3)
+#
+# Why this wrapper exists at all: under launchd's TCC sandbox, /bin/zsh cannot
+# OPEN a script living under ~/Desktop (macOS TCC) — a bare shell wrapper there
+# dies "/bin/zsh: can't open input file" (exit 127). This wrapper is itself a
+# shell script under ~/Desktop, BUT launchd execs it and it immediately execs
+# the venv PYTHON (adhoc-signed → TCC-bypassing) on the real work. The shell
+# never opens a second ~/Desktop file, so TCC never bites. That is the ONLY
+# TCC-safe shape for repo-resident mata_garuda crons — promoting per-cron shell
+# wrappers into the repo does NOT work (verified 2026-06-30, A/B: ~/Desktop=127,
+# /tmp=runs). This wrapper absorbs the per-cron logic (flock/window/module/env)
+# the 7 HOME-fork shell wrappers used to carry, so they can converge here.
+#
+# Eliminates the /bin/bash -lc + source .venv/bin/activate failure that launchd
+# TCC sandbox produced as false-noise in .error.log (W20 cicatrix 2026-05-22).
 
 set -e
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
-if [ $# -lt 1 ]; then
-    echo "[ERROR] usage: $0 <entry_script_abs_path> [log_label]" >&2
+# ── option parse (additive; defaults preserve the original behavior) ────────
+MODULE=""
+FLOCK_NAME=""
+WINDOW=""
+EXTRA_ENV=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --module)     MODULE="$2"; shift 2 ;;
+        --flock)      FLOCK_NAME="$2"; shift 2 ;;
+        --window)     WINDOW="$2"; shift 2 ;;
+        --source-env) EXTRA_ENV="$2"; shift 2 ;;
+        --) shift; break ;;
+        -*) echo "[ERROR] unknown option: $1" >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
+if [ $# -lt 1 ] && [ -z "$MODULE" ]; then
+    echo "[ERROR] usage: $0 [--module m|--flock n|--window a-b|--source-env f] <entry_or_module> [log_label]" >&2
     exit 2
 fi
 
 ENTRY="$1"
 LABEL="${2:-$(basename "$ENTRY" .py)}"
+
+# ── operating window (exit 0 outside, so launchd records a clean skip) ───────
+if [ -n "$WINDOW" ]; then
+    WIN_START="${WINDOW%-*}"
+    WIN_END="${WINDOW#*-}"
+    HOUR=$(date +%H)
+    # strip leading zero so 08 isn't read as octal
+    HOUR=$((10#$HOUR))
+    if [ "$HOUR" -lt "$WIN_START" ] || [ "$HOUR" -ge "$WIN_END" ]; then
+        echo "[$LABEL] outside operating window ${WIN_START}-${WIN_END} (hour=$HOUR) — skipping"
+        exit 0
+    fi
+fi
 
 # Path-aware: derive repo root from THIS script's location
 # (<repo>/apps/mata-garuda/scripts/matagaruda-cron-tcc-safe.sh).
@@ -32,6 +84,17 @@ if [ -f "$HOME/.nuzantara-secrets.env" ]; then
     set +a
 fi
 
+# Optional extra env file (e.g. cell-bridge-state/wa-media.env, Mythos-P3 —
+# BRIDGE_API_KEY lives there, 0600, not in .nuzantara-secrets.env).
+if [ -n "$EXTRA_ENV" ]; then
+    case "$EXTRA_ENV" in /*) EF="$EXTRA_ENV" ;; *) EF="$HOME/$EXTRA_ENV" ;; esac
+    if [ -f "$EF" ]; then
+        set -a
+        . "$EF"
+        set +a
+    fi
+fi
+
 # Canonical Redis = Pro (127.0.0.1). Was 100.93.236.6 (Mini) → caused
 # the live split-brain: 10 crons read Mini while monitor/archiver/rollup
 # read Pro, and 982 alerts sat unsent. Fixed canonical to Pro 2026-06-30.
@@ -39,12 +102,35 @@ export GARUDA_REDIS_HOST="${GARUDA_REDIS_HOST:-127.0.0.1}"  # canonical=Pro (Zer
 export PYTHONPATH="${PYTHONPATH:-$APP_ROOT}"
 
 [ -x "$VENV_PY" ] || { echo "[ERROR] venv python missing: $VENV_PY" >&2; exit 2; }
-[ -f "$ENTRY" ] || { echo "[ERROR] entry script missing: $ENTRY" >&2; exit 2; }
+if [ -z "$MODULE" ]; then
+    [ -f "$ENTRY" ] || { echo "[ERROR] entry script missing: $ENTRY" >&2; exit 2; }
+fi
 
 cd "$APP_ROOT"
-# W21 fix: do NOT redirect stdout/stderr — let launchd's StandardOutPath
-# and StandardErrorPath capture them separately. The W19+W20 version
-# redirected to ~/logs/matagaruda-${LABEL}.log which merged stdout+stderr
-# into one file, defeating the W8 signal/noise separation purpose.
-# Python -u flag forces unbuffered output for real-time log visibility.
-exec "$VENV_PY" -u "$ENTRY"
+
+# Build the python invocation. -u forces unbuffered output for real-time logs.
+# W21: do NOT redirect stdout/stderr — let launchd's StandardOutPath /
+# StandardErrorPath capture them separately (preserves W8 signal/noise split).
+if [ -n "$MODULE" ]; then
+    set -- "$VENV_PY" -u -m "$MODULE"
+else
+    set -- "$VENV_PY" -u "$ENTRY"
+fi
+
+# ── single-instance gate (flock) ────────────────────────────────────────────
+# A concurrent run exits 75 and is skipped — prevents the W7 cron-stacking
+# (two run_ner_worker.py at once). Degrade gracefully if flock is absent.
+if [ -n "$FLOCK_NAME" ]; then
+    FLOCK_BIN="/opt/homebrew/bin/flock"
+    LOCK="/tmp/matagaruda-${FLOCK_NAME}.lock"
+    if [ -x "$FLOCK_BIN" ]; then
+        # flock runs the command; quote each arg for the -c string
+        CMD=""
+        for a in "$@"; do CMD="$CMD '${a//\'/\'\\\'\'}'"; done
+        exec "$FLOCK_BIN" --nonblock --exclusive --conflict-exit-code 75 "$LOCK" -c "$CMD"
+    else
+        echo "[$LABEL] flock not found at $FLOCK_BIN — running without dedup" >&2
+    fi
+fi
+
+exec "$@"

--- a/apps/mata-garuda/tests/test_cron_wrapper_no_homefork.py
+++ b/apps/mata-garuda/tests/test_cron_wrapper_no_homefork.py
@@ -11,7 +11,10 @@ that class of drift fail CI:
 """
 from __future__ import annotations
 
+import os
 import pathlib
+import stat
+import subprocess
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent          # apps/mata-garuda
 WRAPPER = ROOT / "scripts" / "matagaruda-cron-tcc-safe.sh"
@@ -70,3 +73,93 @@ def test_gap_wrapper_in_repo_and_path_aware():
         "gap wrapper hardcodes a user path — derive REPO from script location"
     # must NOT default REPO to a .worktrees path (the dead-worktree exit-1 bug)
     assert ".worktrees" not in code_s, "gap wrapper defaults REPO to a .worktrees path (dead-worktree risk)"
+
+
+# ── Functional tests for the additive flags (convergence of the 7 HOME-fork
+# shell wrappers onto this one TCC-safe wrapper). A fake VENV_PY captures what
+# the wrapper would exec, so we assert behavior without the real venv. ────────
+class _Harness:
+    """Run the wrapper with a fake venv python that records its argv + cwd."""
+
+    def __init__(self, tmp_path):
+        self.tmp = tmp_path
+        # fake repo layout: <repo>/apps/mata-garuda/{scripts,.venv/bin}
+        self.app = tmp_path / "apps" / "mata-garuda"
+        (self.app / "scripts").mkdir(parents=True)
+        (self.app / ".venv" / "bin").mkdir(parents=True)
+        # copy the real wrapper into the fake scripts dir (so ${0:A:h:h} resolves)
+        self.wrapper = self.app / "scripts" / "matagaruda-cron-tcc-safe.sh"
+        self.wrapper.write_text(WRAPPER.read_text())
+        self.wrapper.chmod(0o755)
+        # fake python: records "$@" and cwd to a marker file, then exit 0
+        self.marker = tmp_path / "exec.log"
+        py = self.app / ".venv" / "bin" / "python"
+        py.write_text(
+            "#!/bin/zsh\n"
+            f'echo "ARGS=$@" >> "{self.marker}"\n'
+            f'echo "CWD=$(pwd)" >> "{self.marker}"\n'
+            "exit 0\n"
+        )
+        py.chmod(0o755)
+
+    def run(self, *args, env=None):
+        e = dict(os.environ)
+        e["HOME"] = str(self.tmp)          # avoid sourcing the real ~/.nuzantara-secrets.env
+        if env:
+            e.update(env)
+        return subprocess.run(
+            ["/bin/zsh", str(self.wrapper), *args],
+            capture_output=True, text=True, env=e, timeout=20,
+        )
+
+    def log(self):
+        return self.marker.read_text() if self.marker.exists() else ""
+
+
+def test_flag_backcompat_plain_entry(tmp_path):
+    """No flags: <entry.py> still execs `python -u <entry.py>` (the 10 existing
+    crons must be unaffected)."""
+    h = _Harness(tmp_path)
+    entry = h.app / "scripts" / "run_thing.py"
+    entry.write_text("print('x')\n")
+    r = h.run(str(entry))
+    assert r.returncode == 0, r.stderr
+    assert "run_thing.py" in h.log()
+    assert "-u" in h.log()
+
+
+def test_flag_module(tmp_path):
+    """--module runs `python -u -m <module>`, never opening a second file."""
+    h = _Harness(tmp_path)
+    r = h.run("--module", "mata_garuda.bridge.nerve", "mata_garuda.bridge.nerve")
+    assert r.returncode == 0, r.stderr
+    assert "-m mata_garuda.bridge.nerve" in h.log()
+
+
+def test_flag_window_skips_outside(tmp_path):
+    """--window 0-0 is an always-closed window → exit 0, python NEVER invoked."""
+    h = _Harness(tmp_path)
+    entry = h.app / "scripts" / "run_thing.py"
+    entry.write_text("x\n")
+    r = h.run("--window", "0-0", str(entry))
+    assert r.returncode == 0
+    assert "skipping" in r.stdout
+    assert h.log() == ""          # python was not executed
+
+
+def test_flag_window_runs_inside(tmp_path):
+    """--window 0-24 is always-open → python IS invoked."""
+    h = _Harness(tmp_path)
+    entry = h.app / "scripts" / "run_thing.py"
+    entry.write_text("x\n")
+    r = h.run("--window", "0-24", str(entry))
+    assert r.returncode == 0, r.stderr
+    assert "run_thing.py" in h.log()
+
+
+def test_flag_unknown_option_errors(tmp_path):
+    """An unknown flag must fail loudly (exit 2), never silently mis-run."""
+    h = _Harness(tmp_path)
+    r = h.run("--bogus", "x")
+    assert r.returncode == 2
+    assert "unknown option" in r.stderr


### PR DESCRIPTION
## What — closes HOME-fork #2 the TCC-correct way

The 7 mata_garuda crons still on per-cron shell wrappers in `~/scripts/` (bridge, classifier, consumer-lag, gap, ner, nlm-feeder, pel-cleaner) **cannot** be promoted as repo shell scripts: under launchd's TCC sandbox `/bin/zsh` cannot open a script under `~/Desktop` → **exit 127** (A/B-proven: same script `~/Desktop`=127, `/tmp`=runs). That's why #1885's promoted shell wrappers were reverted in #1888.

The **one TCC-safe shape** is the existing `cron-tcc-safe.sh`: launchd execs *it*, and it immediately execs the venv **python** (adhoc-signed → TCC-bypassing), never opening a second `~/Desktop` file. So instead of 7 shell wrappers, this teaches that single wrapper the per-cron logic via **additive flags**:

| flag | purpose | used by |
|---|---|---|
| `--module <m>` | `python -u -m <m>` | bridge, gap |
| `--flock <name>` | single-instance gate (dup → exit 75, W7) | classifier, ner, pel |
| `--window <a>-<b>` | skip (exit 0) outside local-hour window | gap (06-22 WITA) |
| `--source-env <f>` | extra env file (cell-bridge-state, Mythos-P3) | bridge |

**Backward-compatible**: with no flags, `<entry.py> [label]` behaves *exactly* as before → the 10 existing repo crons are untouched.

## migrate script
`migrate_crons_to_repo_wrapper.sh` gains a **Part 2** that repoints the 7 plists to `cron-tcc-safe.sh <flags> <entry>` and drops gap.consumer's dead-`.worktrees` `MATA_GARUDA_REPO` override (cicatrix #1 dead-worktree). It also **fixes the prior gap block** whose vars were empty (`[ -f "" ]`) — a silent no-op bug.

## Convergence note
This builds on the parallel Pro session's already-merged work (cron-tcc-safe.sh + the `test_cron_wrapper_no_homefork` lint + the migrate script for the first 10 crons). It extends — not conflicts — with it: same wrapper, same migrate script, +7 crons.

## Tests
5 new functional tests (fake venv-python captures argv): backcompat plain entry, `--module`, `--window` open/closed, unknown-flag errors. + 5 existing lint checks. **10/10 green.** `zsh -n` + `bash -n` clean.

## Runtime step (next, gated on Pro quiescence)
Run the migrate script on Pro + verify real exit codes per cron. Not done here — parallel sessions touch the same LaunchAgents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)