### PR TITLE
feat(wa-mirror): resolve group-sender LIDs in wa_lid_phone_resolution

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/241_wa_lid_phone_resolution_group_senders.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/241_wa_lid_phone_resolution_group_senders.sql
@@ -17,7 +17,8 @@
 -- Verified on live nuzantara_dev before shipping: 569 -> 659 rows (+90 resolved),
 -- 0 changed-phone regressions, 0 lost resolutions.
 --
--- squawk-ignore: prefer-robust-stmts  (matview rebuild, no concurrent writers)
+-- Note: this is a full materialized-view rebuild (DROP + CREATE) with no
+-- concurrent writers; the Squawk CI job already excludes prefer-robust-stmts.
 
 DROP MATERIALIZED VIEW IF EXISTS wa_lid_phone_resolution;
 

--- a/apps/backend-rag/backend/db/migrations_v2/241_wa_lid_phone_resolution_group_senders.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/241_wa_lid_phone_resolution_group_senders.sql
@@ -19,6 +19,16 @@
 --
 -- Note: this is a full materialized-view rebuild (DROP + CREATE) with no
 -- concurrent writers; the Squawk CI job already excludes prefer-robust-stmts.
+--
+-- Schema-drift guard: whatsapp_message_context.sender_lid exists on the live
+-- nuzantara_dev DB (added ad-hoc, never versioned) but NO earlier migration
+-- file creates it — so a DB rebuilt purely from migration files (CI test DB)
+-- lacks it and the matview below fails with "column sender_lid does not
+-- exist". Provision it idempotently here (no-op on live, creates on fresh)
+-- so 241 applies against both. Mirrors counterpart_lid VARCHAR(64) from m185.
+
+ALTER TABLE whatsapp_message_context
+  ADD COLUMN IF NOT EXISTS sender_lid VARCHAR(64);
 
 DROP MATERIALIZED VIEW IF EXISTS wa_lid_phone_resolution;
 

--- a/apps/backend-rag/backend/db/migrations_v2/241_wa_lid_phone_resolution_group_senders.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/241_wa_lid_phone_resolution_group_senders.sql
@@ -72,3 +72,28 @@ CREATE UNIQUE INDEX wa_lid_phone_resolution_lid_idx
   ON wa_lid_phone_resolution (counterpart_lid);
 CREATE INDEX wa_lid_phone_resolution_phone_idx
   ON wa_lid_phone_resolution (phone_normalized);
+
+-- === ROLLBACK ===
+-- Restores the v1 definition (counterpart_lid only, no group-sender branch).
+-- DROP MATERIALIZED VIEW IF EXISTS wa_lid_phone_resolution;
+-- CREATE MATERIALIZED VIEW wa_lid_phone_resolution AS
+-- WITH team_phones AS (
+--   SELECT DISTINCT regexp_replace(team_member_phone::text, '\D', '', 'g') AS phone_digits
+--   FROM whatsapp_message_context WHERE team_member_phone IS NOT NULL
+-- ), extracted AS (
+--   SELECT counterpart_lid,
+--          (regexp_matches(raw_baileys_event::text, '([0-9]{8,16})@s\.whatsapp\.net', 'g'))[1] AS phone_digits
+--   FROM whatsapp_message_context
+--   WHERE counterpart_lid IS NOT NULL AND raw_baileys_event <> '{}'::jsonb
+-- ), ranked AS (
+--   SELECT e.counterpart_lid, e.phone_digits, count(*) AS freq,
+--          row_number() OVER (PARTITION BY e.counterpart_lid ORDER BY count(*) DESC) AS rk
+--   FROM extracted e
+--   WHERE NOT EXISTS (SELECT 1 FROM team_phones t WHERE t.phone_digits = e.phone_digits)
+--   GROUP BY e.counterpart_lid, e.phone_digits
+-- )
+-- SELECT counterpart_lid, '+' || phone_digits AS resolved_phone, phone_digits AS phone_normalized,
+--        freq AS occurrences, now() AS computed_at
+-- FROM ranked WHERE rk = 1;
+-- CREATE UNIQUE INDEX wa_lid_phone_resolution_lid_idx ON wa_lid_phone_resolution (counterpart_lid);
+-- CREATE INDEX wa_lid_phone_resolution_phone_idx ON wa_lid_phone_resolution (phone_normalized);

--- a/apps/backend-rag/backend/db/migrations_v2/241_wa_lid_phone_resolution_group_senders.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/241_wa_lid_phone_resolution_group_senders.sql
@@ -1,0 +1,74 @@
+-- 241_wa_lid_phone_resolution_group_senders.sql
+--
+-- Extend the wa_lid_phone_resolution materialized view to also resolve GROUP
+-- SENDER LIDs, not just counterpart LIDs. Until now ~86 group senders showed as
+-- "Contatto sconosciuto" in the WA dashboard even though their real phone was
+-- present in the message key (participant <-> participantAlt pairing).
+--
+-- Also: this view was created ad-hoc directly on the DB and never lived in the
+-- repo. This migration versions it (idempotent DROP + CREATE) so its definition
+-- is finally source-controlled.
+--
+-- v1 branch (unchanged): counterpart_lid, phone anywhere in raw_baileys_event.
+-- v2 branch (new): group sender_lid mapped to phone via the EXACT Baileys key
+--   pairing  key.participant ("<lid>@lid")  <->  key.participantAlt ("<phone>@s.whatsapp.net").
+-- Team-member phones are excluded; the most frequent phone per LID wins (rk=1).
+--
+-- Verified on live nuzantara_dev before shipping: 569 -> 659 rows (+90 resolved),
+-- 0 changed-phone regressions, 0 lost resolutions.
+--
+-- squawk-ignore: prefer-robust-stmts  (matview rebuild, no concurrent writers)
+
+DROP MATERIALIZED VIEW IF EXISTS wa_lid_phone_resolution;
+
+CREATE MATERIALIZED VIEW wa_lid_phone_resolution AS
+WITH team_phones AS (
+  SELECT DISTINCT regexp_replace(team_member_phone::text, '\D', '', 'g') AS phone_digits
+  FROM whatsapp_message_context
+  WHERE team_member_phone IS NOT NULL
+),
+extracted_counterpart AS (
+  SELECT counterpart_lid AS lid,
+         (regexp_matches(raw_baileys_event::text, '([0-9]{8,16})@s\.whatsapp\.net', 'g'))[1] AS phone_digits
+  FROM whatsapp_message_context
+  WHERE counterpart_lid IS NOT NULL
+    AND raw_baileys_event <> '{}'::jsonb
+),
+extracted_sender AS (
+  SELECT sender_lid AS lid,
+         regexp_replace(
+           (raw_baileys_event #>> '{key,participantAlt}'), '@s\.whatsapp\.net$', ''
+         ) AS phone_digits
+  FROM whatsapp_message_context
+  WHERE sender_lid IS NOT NULL
+    AND (raw_baileys_event #>> '{key,participant}') = sender_lid || '@lid'
+    AND (raw_baileys_event #>> '{key,participantAlt}') ~ '^[0-9]{8,16}@s\.whatsapp\.net$'
+),
+combined AS (
+  SELECT lid, phone_digits FROM extracted_counterpart
+  UNION ALL
+  SELECT lid, phone_digits FROM extracted_sender
+),
+ranked AS (
+  SELECT c.lid AS counterpart_lid,
+         c.phone_digits,
+         count(*) AS freq,
+         row_number() OVER (PARTITION BY c.lid ORDER BY count(*) DESC) AS rk
+  FROM combined c
+  WHERE c.phone_digits IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM team_phones t WHERE t.phone_digits = c.phone_digits)
+  GROUP BY c.lid, c.phone_digits
+)
+SELECT counterpart_lid,
+       '+' || phone_digits AS resolved_phone,
+       phone_digits AS phone_normalized,
+       freq AS occurrences,
+       now() AS computed_at
+FROM ranked
+WHERE rk = 1;
+
+-- Indexes match the original definition (UNIQUE lid so REFRESH CONCURRENTLY works).
+CREATE UNIQUE INDEX wa_lid_phone_resolution_lid_idx
+  ON wa_lid_phone_resolution (counterpart_lid);
+CREATE INDEX wa_lid_phone_resolution_phone_idx
+  ON wa_lid_phone_resolution (phone_normalized);


### PR DESCRIPTION
## Problema
Nei gruppi WhatsApp ~86 mittenti apparivano come **"Contatto sconosciuto"** nella dashboard M1, anche se il loro vero numero era nel `key` del messaggio. La matview `wa_lid_phone_resolution` estraeva solo i `counterpart_lid`; i `sender_lid` di gruppo non venivano mai risolti, quindi il join dashboard `lpr_s.counterpart_lid = m.sender_lid` matchava solo i ~55 sender che comparivano anche come counterpart.

## Fix (migration 241)
Ricostruisce la matview con un secondo ramo di estrazione che mappa il LID del mittente-gruppo al suo numero via l'**accoppiamento esatto nel key Baileys**:
```
key.participant    = "<lid>@lid"
key.participantAlt = "<phone>@s.whatsapp.net"
```
Numeri team esclusi, numero più frequente per LID (rk=1). Usare il key-pairing (non una regex larga su tutto il raw) garantisce che ogni LID prenda **il SUO** numero, non un partecipante a caso.

**Bonus**: la matview era creata a mano sul DB e non era mai stata versionata → questa migration ne salva la definizione completa nel repo per la prima volta. Indici come l'originale (UNIQUE su `counterpart_lid` → `REFRESH CONCURRENTLY` per endpoint `/lid-refresh` + cron continua a funzionare).

## Verifica (live `nuzantara_dev`, applicata + refreshata)
- **569 → 659 righe** (+90 risolti); **0** regressioni di numero, **0** perdite.
- Mittenti-gruppo recuperabili non risolti: **86 → 12** (i 12 hanno il numero solo nel body, non nel key-pairing — lasciati non risolti anziché rischiare attribuzione errata).
- `thread.json` dashboard live: un mittente prima sconosciuto ora mostra **"Ingrid Rogall Bachert" / +49…** invece di "Contatto sconosciuto".
- `REFRESH MATERIALIZED VIEW CONCURRENTLY` funziona; `/lid-refresh` → 200 `{"ok":true,"resolved_lids":664}`.

**PII**: risoluzione interamente su Postgres locale Pro (Law 2), nessun numero a LLM cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)