### PR TITLE
fix(wr2): idempotent Drive render — upsert + orphan-sweep + manifest (C0)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -7,6 +7,7 @@ tests/unit/services/canva_renderer_v2/test_pg.py.
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
 import urllib.request
 from pathlib import Path
@@ -3247,3 +3248,220 @@ def test_materialize_body_slide_facts_stack_and_centering():
         assert "justify-content:center" in html
         assert "var(--color-accent-yellow)" in html
         assert "[SOURCE" not in html
+
+
+# ── C0: idempotent Drive upload (upsert + orphan-sweep + manifest) ─────────────
+#
+# The bug this closes: the old loop did files().create per PNG per attempt, so a
+# retried/re-rendered draft accreted duplicate files (30 files = 3 attempts x 10).
+# These tests drive the REAL _drive_upload_carousel against an in-memory fake Drive
+# (no network), asserting the folder contents converge to exactly the current set.
+
+
+class _FakeMedia:
+    """Stand-in for MediaIoBaseUpload — just carries the bytes so the fake can store them."""
+
+    def __init__(self, stream, mimetype=None, resumable=False):  # noqa: ANN001
+        self._bytes = stream.read()
+
+
+class _FakeFilesRequest:
+    def __init__(self, fn):  # noqa: ANN001
+        self._fn = fn
+
+    def execute(self):  # noqa: ANN001
+        return self._fn()
+
+
+class _FakeFilesResource:
+    """Minimal Drive files() surface: list (paged), create, update, delete, get."""
+
+    def __init__(self, store):  # noqa: ANN001
+        self._store = store  # {file_id: {"id","name","parents":[...],"bytes":b}}
+        self._seq = 0
+
+    def _next_id(self):
+        self._seq += 1
+        return f"file-{self._seq:04d}"
+
+    def list(self, q=None, fields=None, pageSize=None, pageToken=None, **kw):  # noqa: ANN001,N803
+        def run():
+            files = list(self._store.values())
+            if q and "in parents" in q:
+                parent = q.split("'")[1]
+                files = [f for f in files if parent in f.get("parents", [])]
+            elif q and "mimeType = 'application/vnd.google-apps.folder'" in q:
+                files = []  # no pre-existing folder in these tests → force create path
+            return {"files": [{"id": f["id"], "name": f["name"]} for f in files]}
+
+        return _FakeFilesRequest(run)
+
+    def create(self, body=None, media_body=None, fields=None, **kw):  # noqa: ANN001
+        def run():
+            fid = self._next_id()
+            self._store[fid] = {
+                "id": fid,
+                "name": body["name"],
+                "parents": body.get("parents", []),
+                "bytes": getattr(media_body, "_bytes", b""),
+            }
+            return {"id": fid, "name": body["name"], "webViewLink": f"https://drive/{fid}", "size": "1"}
+
+        return _FakeFilesRequest(run)
+
+    def update(self, fileId=None, media_body=None, fields=None, **kw):  # noqa: ANN001,N803
+        def run():
+            self._store[fileId]["bytes"] = getattr(media_body, "_bytes", b"")
+            return {"id": fileId}
+
+        return _FakeFilesRequest(run)
+
+    def delete(self, fileId=None, **kw):  # noqa: ANN001,N803
+        def run():
+            self._store.pop(fileId, None)
+            return {}
+
+        return _FakeFilesRequest(run)
+
+    def get(self, fileId=None, fields=None, **kw):  # noqa: ANN001,N803
+        def run():
+            f = self._store[fileId]
+            return {"id": f["id"], "name": f["name"], "webViewLink": f"https://drive/{f['id']}"}
+
+        return _FakeFilesRequest(run)
+
+
+class _FakeService:
+    def __init__(self, store):  # noqa: ANN001
+        self._files = _FakeFilesResource(store)
+
+    def files(self):
+        return self._files
+
+
+class _FakeDriveSvc:
+    """Emulates ServiceAccountDriveService for _drive_upload_carousel: a bare `service`
+    plus the create_folder / upload_file_to_folder / get_file_metadata coroutines it calls."""
+
+    def __init__(self, store):  # noqa: ANN001
+        self._store = store
+        self.service = _FakeService(store)
+
+    async def create_folder(self, name):  # noqa: ANN001
+        fid = self.service._files._next_id()
+        self._store[fid] = {"id": fid, "name": name, "parents": ["root"], "bytes": b""}
+        return {"id": fid, "webViewLink": f"https://drive/{fid}"}
+
+    async def upload_file_to_folder(self, folder_id, file_content, file_name, mime_type=None):  # noqa: ANN001
+        fid = self.service._files._next_id()
+        self._store[fid] = {
+            "id": fid, "name": file_name, "parents": [folder_id], "bytes": file_content,
+        }
+        return {"id": fid, "name": file_name, "webViewLink": f"https://drive/{fid}", "size": "1"}
+
+    async def get_file_metadata(self, file_id):  # noqa: ANN001
+        f = self._store[file_id]
+        return {"id": f["id"], "name": f["name"], "webViewLink": f"https://drive/{f['id']}"}
+
+
+def _children_of(store, folder_id, suffix=None):
+    names = [f["name"] for f in store.values() if folder_id in f.get("parents", [])]
+    if suffix:
+        names = [n for n in names if n.endswith(suffix)]
+    return sorted(names)
+
+
+def _folder_id_of(store, draft_id):
+    for f in store.values():
+        if f["name"] == f"WR2-{draft_id}":
+            return f["id"]
+    raise AssertionError("folder not created")
+
+
+def _make_pngs(count):
+    d = Path(tempfile.mkdtemp(prefix="wr2-c0-"))
+    return [
+        (p := d / f"{i:02d}.png", p.write_bytes(f"png-{i}".encode()))[0]
+        for i in range(1, count + 1)
+    ]
+
+
+def test_drive_upload_is_idempotent_no_duplicate_on_rerender(monkeypatch):
+    """Re-rendering the same draft must NOT increase the Drive file count (the 30-dup bug)."""
+    from scripts import wr2_html_render_apply as html
+
+    store: dict = {}
+    monkeypatch.setattr(
+        html, "ServiceAccountDriveService", lambda: _FakeDriveSvc(store), raising=False
+    )
+    # patch the symbol the module imports lazily inside the function
+    import backend.services.integrations.service_account_drive_service as sad
+
+    monkeypatch.setattr(sad, "ServiceAccountDriveService", lambda: _FakeDriveSvc(store))
+    monkeypatch.setattr(html, "MediaIoBaseUpload", _FakeMedia, raising=False)
+    import googleapiclient.http as gh
+
+    monkeypatch.setattr(gh, "MediaIoBaseUpload", _FakeMedia)
+
+    pngs = _make_pngs(8)
+    asyncio.run(html._drive_upload_carousel("draftA", pngs, shadow=False))
+    fid = _folder_id_of(store, "draftA")
+    first = _children_of(store, fid, ".png")
+    ids_first = {f["name"]: f["id"] for f in store.values() if fid in f.get("parents", []) and f["name"].endswith(".png")}
+    assert first == [f"{i:02d}.png" for i in range(1, 9)]
+    assert "manifest.json" in _children_of(store, fid)
+
+    # re-render the SAME draft, SAME pngs
+    asyncio.run(html._drive_upload_carousel("draftA", pngs, shadow=False))
+    second = _children_of(store, fid, ".png")
+    ids_second = {f["name"]: f["id"] for f in store.values() if fid in f.get("parents", []) and f["name"].endswith(".png")}
+
+    assert second == first, "re-render changed the PNG set"
+    assert len(second) == 8, "re-render created duplicates"
+    assert ids_first == ids_second, "file-ids were not stable across re-render (upsert failed)"
+
+
+def test_drive_upload_sweeps_orphans_from_longer_previous_render(monkeypatch):
+    """A previous render made 10 slides; the new one makes 6 → the 4 extra PNGs are swept."""
+    import googleapiclient.http as gh
+
+    import backend.services.integrations.service_account_drive_service as sad
+    from scripts import wr2_html_render_apply as html
+
+    store: dict = {}
+    monkeypatch.setattr(sad, "ServiceAccountDriveService", lambda: _FakeDriveSvc(store))
+    monkeypatch.setattr(gh, "MediaIoBaseUpload", _FakeMedia)
+
+    asyncio.run(html._drive_upload_carousel("draftB", _make_pngs(10), shadow=False))
+    fid = _folder_id_of(store, "draftB")
+    assert len(_children_of(store, fid, ".png")) == 10
+
+    # shorter re-render
+    asyncio.run(html._drive_upload_carousel("draftB", _make_pngs(6), shadow=False))
+    remaining = _children_of(store, fid, ".png")
+    assert remaining == [f"{i:02d}.png" for i in range(1, 7)], remaining
+    assert "07.png" not in remaining and "10.png" not in remaining
+    assert "manifest.json" in _children_of(store, fid)
+
+
+def test_drive_manifest_lists_current_slides_in_order(monkeypatch):
+    import json
+
+    import googleapiclient.http as gh
+
+    import backend.services.integrations.service_account_drive_service as sad
+    from scripts import wr2_html_render_apply as html
+
+    store: dict = {}
+    monkeypatch.setattr(sad, "ServiceAccountDriveService", lambda: _FakeDriveSvc(store))
+    monkeypatch.setattr(gh, "MediaIoBaseUpload", _FakeMedia)
+
+    asyncio.run(html._drive_upload_carousel("draftC", _make_pngs(5), shadow=False))
+    fid = _folder_id_of(store, "draftC")
+    manifest = next(
+        f for f in store.values() if fid in f.get("parents", []) and f["name"] == "manifest.json"
+    )
+    data = json.loads(manifest["bytes"].decode())
+    assert data["draft_id"] == "draftC"
+    assert [s["name"] for s in data["slides"]] == [f"{i:02d}.png" for i in range(1, 6)]
+    assert all(s["file_id"] for s in data["slides"])

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -152,12 +152,75 @@ def _normalize_heroes(slides: list[dict[str, Any]], hero_dir: Path, server: "_He
     return out
 
 
-# ── Drive upload (idempotent-by-name under the single-owner lease) ──────────────
+# ── Drive upload (idempotent — upsert + orphan-sweep + manifest, under the lease) ───
+async def _drive_list_folder_children(svc: Any, folder_id: str) -> list[dict[str, Any]]:
+    """Every non-trashed direct child of the folder as {id, name}. Pages fully so a
+    folder that accreted many duplicate PNGs (the 30-file bug) is drained completely."""
+    import asyncio as _a
+
+    children: list[dict[str, Any]] = []
+    page_token: str | None = None
+    while True:
+        req = svc.service.files().list(
+            q=f"'{folder_id}' in parents and trashed = false",
+            fields="nextPageToken, files(id, name)",
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+            pageSize=1000,
+            pageToken=page_token,
+        )
+        res = await _a.to_thread(req.execute)
+        children.extend(res.get("files", []))
+        page_token = res.get("nextPageToken")
+        if not page_token:
+            break
+    return children
+
+
+async def _drive_upsert_file(
+    svc: Any, folder_id: str, name: str, content: bytes, mime_type: str,
+    existing_id: str | None,
+) -> str:
+    """Update the media of an existing file (stable file-id) or create it. Returns the
+    file-id. Update-in-place is what makes re-render idempotent instead of accreting a
+    new copy every attempt (cicatrix #9: idempotent by ENTITY, not by count)."""
+    import asyncio as _a
+    from io import BytesIO
+
+    from googleapiclient.http import MediaIoBaseUpload  # type: ignore[import-untyped]
+
+    media = MediaIoBaseUpload(BytesIO(content), mimetype=mime_type, resumable=True)
+    if existing_id:
+        req = svc.service.files().update(
+            fileId=existing_id, media_body=media, fields="id", supportsAllDrives=True,
+        )
+        res = await _a.to_thread(req.execute)
+        return res["id"]
+    res = await svc.upload_file_to_folder(
+        folder_id=folder_id, file_content=content, file_name=name, mime_type=mime_type,
+    )
+    return res["id"]
+
+
 async def _drive_upload_carousel(draft_id: str, png_paths: list[Path], shadow: bool) -> str:
-    """Create (or reuse) folder WR2-{draft_id} [shadow: under a WR2-SHADOW root], upload the
-    PNGs as image/png, return the folder webViewLink. Idempotent-by-name: searches first and
-    reuses an existing folder of the same name. Concurrent-create is prevented by the lease
-    (single owner per draft), so search-before-create is the residual dedup (#9)."""
+    """Create (or reuse) folder WR2-{draft_id} [shadow: under a WR2-SHADOW root], then make
+    its contents EXACTLY the current PNG set + a manifest.json, idempotently. Returns the
+    folder webViewLink.
+
+    C0 — three moves that make ``rendered`` mean one canonical set (cicatrix #9 / #2):
+      1. UPSERT each current PNG by name (update media in place if the name already lives in
+         the folder → stable file-id, no new copy per retry). Never a create-then-dup loop.
+      2. ORPHAN-SWEEP: delete children whose name is no longer in the current set (stale PNGs
+         from a longer previous render, or the 30 duplicates from the create-loop bug). Runs
+         AFTER the upserts, so the folder is never momentarily empty.
+      3. MANIFEST: write manifest.json (ordered {name, file_id}) — an audit/prove-of-life
+         artifact the C1 watchdog can assert on ("rendered without manifest" = anomaly). It is
+         NOT a reader contract: the publishers read PNGs from the local render dir, not Drive.
+    Concurrent-create of the folder is prevented by the single-owner lease; search-before-create
+    is the residual dedup."""
+    import asyncio as _a
+    import json as _json
+
     from backend.services.integrations.service_account_drive_service import ServiceAccountDriveService
 
     svc = ServiceAccountDriveService()
@@ -165,13 +228,12 @@ async def _drive_upload_carousel(draft_id: str, png_paths: list[Path], shadow: b
 
     # search-before-create (idempotency under retry/stale-lease re-render)
     folder_id: str | None = None
+    web = ""
     try:
         q = (
             f"name = '{folder_name}' and mimeType = 'application/vnd.google-apps.folder' "
             f"and trashed = false"
         )
-        import asyncio as _a
-
         req = svc.service.files().list(
             q=q, fields="files(id, webViewLink)", supportsAllDrives=True,
             includeItemsFromAllDrives=True, pageSize=1,
@@ -190,14 +252,47 @@ async def _drive_upload_carousel(draft_id: str, png_paths: list[Path], shadow: b
         folder_id = folder["id"]
         web = folder.get("webViewLink", "")
 
+    # Snapshot current children ONCE — drives both upsert (name→id) and sweep.
+    existing = await _drive_list_folder_children(svc, folder_id)
+    by_name: dict[str, str] = {}
+    for child in existing:  # last-writer-wins collapses pre-existing dup names to one id
+        by_name[child["name"]] = child["id"]
+
+    # 1. UPSERT the current PNGs (ordered), collecting the canonical file-ids.
+    manifest_slides: list[dict[str, str]] = []
+    canonical_names: set[str] = set()
     for png in png_paths:
-        content = Path(png).read_bytes()
-        await svc.upload_file_to_folder(
-            folder_id=folder_id,
-            file_content=content,
-            file_name=Path(png).name,
-            mime_type="image/png",  # #10: explicit, the service hardcodes image/jpeg otherwise
+        name = Path(png).name
+        canonical_names.add(name)
+        file_id = await _drive_upsert_file(
+            svc, folder_id, name, Path(png).read_bytes(), "image/png",
+            by_name.get(name),
         )
+        manifest_slides.append({"name": name, "file_id": file_id})
+
+    # 2. MANIFEST (upsert too — the render is the source of truth for its own contents).
+    manifest_name = "manifest.json"
+    canonical_names.add(manifest_name)
+    manifest_body = _json.dumps(
+        {"draft_id": draft_id, "shadow": shadow, "slides": manifest_slides},
+        ensure_ascii=False, indent=2,
+    ).encode("utf-8")
+    await _drive_upsert_file(
+        svc, folder_id, manifest_name, manifest_body, "application/json",
+        by_name.get(manifest_name),
+    )
+
+    # 3. ORPHAN-SWEEP — anything in the folder not in the canonical set is a stale leftover.
+    for child in existing:
+        if child["name"] in canonical_names:
+            continue
+        try:
+            req = svc.service.files().delete(fileId=child["id"], supportsAllDrives=True)
+            await _a.to_thread(req.execute)
+            logger.info("swept stale Drive child %s (%s)", child["name"], child["id"])
+        except Exception as exc:  # a failed sweep must not fail the render
+            logger.warning("orphan-sweep failed for %s: %s", child["name"], exc)
+
     if not web:
         meta = await svc.get_file_metadata(folder_id)
         web = meta.get("webViewLink", f"https://drive.google.com/drive/folders/{folder_id}")


### PR DESCRIPTION
## What & why

`_drive_upload_carousel` in `scripts/wr2_html_render_apply.py` did `files().create` **per PNG per attempt** — so a retried or re-rendered draft accreted duplicate files on Drive. The 30-file case seen live = 3 attempts × 10 slides. `rendered` didn't mean "one canonical set of PNGs"; it meant "at least one set, plus every stale leftover" — confusing to the human at the Telegram gate and gonfia lo storage.

This is **C0** of the WR2 next-level plan (`research/operations/2026-06-30-wr2-next-level-plan.md`) — the robustness foundation.

## The fix — folder converges to EXACTLY the current set, idempotently

1. **Upsert** each current PNG by name — `files().update` media in place when the name already exists (stable file-id, no new copy per retry).
2. **Orphan-sweep** — after the upserts (so the folder is never momentarily empty), delete children whose name is no longer in the current set: stale PNGs from a longer previous render, or the old duplicates.
3. **Manifest** — `manifest.json` (ordered `{name, file_id}`) as a prove-of-life / audit artifact the **C1 watchdog** can assert on ("rendered without manifest" = anomaly).

**Honest scope note (cicatrix #2 — no orphan reader):** the manifest is NOT a reader contract. The IG/Telegram publishers read PNGs from the **local render dir**, not from Drive (verified: `wr2_ig_publish.py` / `wr2_ig_publish_remote.py` glob the local dir; `wr2_supervisor_watchdog.py` uses `drive_url` only as a boolean success signal). The manifest is documented as audit-only so it isn't mistaken for a consumed contract.

Idempotent by **entity, not by count** (cicatrix #9). Concurrent folder-create stays prevented by the single-owner lease.

## Tests

New (in-memory fake Drive, no network):
- re-render keeps the PNG set **and** the file-ids stable (upsert proven, not create)
- a 10→6 re-render sweeps `07-10.png`
- manifest lists the current slides in order with file-ids

`112 passed` (render-apply, +3 new) + `21 passed` (pg-lane `drive_url` path). Import chain OK. Zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)