### PR TITLE
feat(wr2): propagate liveness_tier selector→drafter (A1 keystone)

### DIFF
--- a/scripts/tests/test_wr2_draft_generator_liveness_tier.py
+++ b/scripts/tests/test_wr2_draft_generator_liveness_tier.py
@@ -1,0 +1,122 @@
+"""
+Tests for A1 — liveness_tier propagation into the draft prompt.
+
+The topic selector already writes liveness_tier into brief_json; the drafter
+used to drop it. A1 wires it end-to-end: read → normalise → inject a one-line
+editorial framing (NOT a length or tone constraint — that's A2/A3). These tests
+verify the injection deterministically without calling Claude.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wr2_draft_generator import (  # noqa: E402
+    _LIVENESS_FRAMING,
+    _build_draft_prompt,
+    _normalise_liveness_tier,
+    claude_compose_slides,
+)
+
+
+# ── normalisation ─────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("breaking", "breaking"),
+        ("BREAKING", "breaking"),
+        ("  Developing  ", "developing"),
+        ("evergreen", "evergreen"),
+        ("manual", ""),          # operator topics → no framing
+        ("nonsense", ""),
+        ("", ""),
+        (None, ""),
+        (123, ""),               # never raises on non-str
+    ],
+)
+def test_normalise_liveness_tier(raw, expected) -> None:
+    assert _normalise_liveness_tier(raw) == expected
+
+
+# ── framing injection ─────────────────────────────────────────────────────
+@pytest.mark.parametrize("tier", ["breaking", "developing", "evergreen"])
+def test_valid_tier_injects_its_framing_line(tier) -> None:
+    prompt = _build_draft_prompt(
+        topic="X", summary="body text here", source_url="", liveness_tier=tier,
+    )
+    assert _LIVENESS_FRAMING[tier] in prompt
+    # exactly one framing line — no cross-contamination between tiers
+    others = [t for t in _LIVENESS_FRAMING if t != tier]
+    for other in others:
+        assert _LIVENESS_FRAMING[other] not in prompt
+
+
+@pytest.mark.parametrize("tier", ["", "manual", "unknown"])
+def test_absent_or_manual_tier_injects_no_framing(tier) -> None:
+    prompt = _build_draft_prompt(
+        topic="X", summary="body text here", source_url="", liveness_tier=tier,
+    )
+    for line in _LIVENESS_FRAMING.values():
+        assert line not in prompt
+    # the article still renders
+    assert "ARTICLE TO TURN INTO A CAROUSEL" in prompt
+
+
+def test_framing_is_context_only_not_a_length_or_tone_constraint() -> None:
+    """A1 is framing, not A2/A3: the injected line must not dictate a slide count
+    or a specific tone slug (those belong to later PRs)."""
+    for line in _LIVENESS_FRAMING.values():
+        low = line.lower()
+        assert "slide" not in low  # no "use 5 slides" etc.
+        for tone in ("rituale", "analitico", "ironico", "militante",
+                     "pedagogico", "poetico", "tecnico"):
+            assert tone not in low
+
+
+def test_default_call_omits_tier_and_stays_backcompat() -> None:
+    """Callers that don't pass liveness_tier get the old prompt (no framing)."""
+    prompt = _build_draft_prompt(topic="X", summary="body", source_url="")
+    for line in _LIVENESS_FRAMING.values():
+        assert line not in prompt
+
+
+# ── SSOT parity: drafter tier set must not drift from the selector's ───────
+def test_tier_set_matches_selector_ssot() -> None:
+    """cicatrix #9 guard: the drafter's LIVENESS_TIER_VALID must equal the
+    selector's. If someone adds a tier on one side only, this fails loudly
+    instead of silently dropping the new tier's framing."""
+    import wr2_draft_generator as drafter
+    import wr2_topic_selector as selector
+
+    assert drafter.LIVENESS_TIER_VALID == selector.LIVENESS_TIER_VALID
+
+
+# ── end-to-end: compose_slides forwards the tier to the prompt ─────────────
+def test_compose_slides_forwards_tier_into_prompt() -> None:
+    captured = {}
+
+    class _Resp:
+        text = '{"register": "analitico", "slides": []}'
+        token_label = "test"
+
+    async def _fake_complete(prompt, **kw):  # noqa: ANN001
+        captured["prompt"] = prompt
+        return _Resp()
+
+    with patch("wr2_draft_generator.complete_async", new=AsyncMock(side_effect=_fake_complete)):
+        import asyncio
+
+        asyncio.run(
+            claude_compose_slides(
+                topic="New KITAS rule", summary="body", source_url="",
+                liveness_tier="breaking",
+            )
+        )
+    assert _LIVENESS_FRAMING["breaking"] in captured["prompt"]

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -62,6 +62,40 @@ VALID_TONES = {
     "tecnico",
 }
 
+# ── A1 keystone: liveness_tier propagation (cicatrix #9 schema-drift) ──────────
+# The topic selector already computes a liveness_tier and persists it inside
+# brief_json (wr2_topic_selector.py: "liveness_tier": top_item.get(...)), but the
+# drafter used to read enrichment + live_reasons and DROP this field on the floor.
+# A1 wires it end-to-end: read it here, hand Claude a one-line editorial framing so
+# the narrative matches the story's timeliness. A1 is framing ONLY — it deliberately
+# does NOT constrain slide count (that's A2) or tone (that's A3); those hang off the
+# SAME injection point in later PRs. Mirrors selector's LIVENESS_TIER_VALID (SSOT).
+LIVENESS_TIER_VALID = {"breaking", "developing", "evergreen"}
+
+# One-line editorial framing per tier. Neutral on length/tone — pure "how timely is
+# this" context. "manual" (operator-inserted topics) and anything unknown → no line.
+_LIVENESS_FRAMING = {
+    "breaking": (
+        "EDITORIAL CONTEXT — liveness: BREAKING. This is fast-moving, just-happened news; "
+        "write with urgency and a clear 'what changed / what to do now' spine."
+    ),
+    "developing": (
+        "EDITORIAL CONTEXT — liveness: DEVELOPING. This story is still unfolding; frame it as "
+        "an evolving situation readers should track, not a settled conclusion."
+    ),
+    "evergreen": (
+        "EDITORIAL CONTEXT — liveness: EVERGREEN. This is durable, reference-grade material; "
+        "write it to stay useful for months, explanatory rather than time-pegged."
+    ),
+}
+
+
+def _normalise_liveness_tier(raw: Any) -> str:
+    """Lower-case + validate against the selector's SSOT set. Unknown / missing /
+    'manual' collapse to '' (→ no framing line injected). Never raises."""
+    tier = str(raw or "").strip().lower()
+    return tier if tier in LIVENESS_TIER_VALID else ""
+
 TIGRIS_ENDPOINT = "https://fly.storage.tigris.dev"
 TIGRIS_BUCKET = "nuzantara-warroom-images"
 TIGRIS_PUBLIC_BASE = f"https://{TIGRIS_BUCKET}.fly.storage.tigris.dev"
@@ -457,6 +491,7 @@ def _build_draft_prompt(
     enrichment: dict[str, Any] | None = None,
     live_reasons: list[str] | None = None,
     avoid_steer: str = "",
+    liveness_tier: str = "",
 ) -> str:
     """Build the slide-composition prompt.
 
@@ -481,7 +516,11 @@ def _build_draft_prompt(
         # Legacy path: truncated summary. Always available as fallback.
         body = summary[:3500]
 
-    return f"""{SYSTEM_INSTRUCTIONS}{avoid_steer}
+    # A1: inject the liveness framing (empty string when tier is unknown/manual).
+    liveness_line = _LIVENESS_FRAMING.get(liveness_tier, "")
+    liveness_block = f"\n\n{liveness_line}" if liveness_line else ""
+
+    return f"""{SYSTEM_INSTRUCTIONS}{avoid_steer}{liveness_block}
 
 ---
 
@@ -522,11 +561,12 @@ async def claude_compose_slides(
     enrichment: dict[str, Any] | None = None,
     live_reasons: list[str] | None = None,
     avoid_steer: str = "",
+    liveness_tier: str = "",
 ) -> dict[str, Any]:
     prompt = _build_draft_prompt(
         topic, summary, source_url,
         enrichment=enrichment, live_reasons=live_reasons,
-        avoid_steer=avoid_steer,
+        avoid_steer=avoid_steer, liveness_tier=liveness_tier,
     )
     logger.info("Calling Claude OAuth for slide composition (prompt %d chars)", len(prompt))
     t0 = time.perf_counter()
@@ -1022,11 +1062,14 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
     live_reasons = brief.get("live_news_reasons") or []
     if not isinstance(live_reasons, list):
         live_reasons = []
+    # A1 keystone: the selector already put this in brief_json — read it (was dropped).
+    liveness_tier = _normalise_liveness_tier(brief.get("liveness_tier"))
 
     logger.info(
-        "─── processing draft %s ─── topic=%r enrichment=%s live_score=%s",
+        "─── processing draft %s ─── topic=%r enrichment=%s live_score=%s liveness_tier=%s",
         draft_id, topic[:80],
         bool(enrichment), brief.get("live_news_score"),
+        liveness_tier or "(none)",
     )
 
     # ── P-4 anti-sameness (constitution Art 10.6) ──────────────────────────
@@ -1050,7 +1093,7 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
             parsed = await claude_compose_slides(
                 topic=topic, summary=summary, source_url=source_url,
                 enrichment=enrichment, live_reasons=live_reasons,
-                avoid_steer=avoid_steer,
+                avoid_steer=avoid_steer, liveness_tier=liveness_tier,
             )
         except (ClaudeOAuthError, ClaudeOAuthNotAvailable) as e:
             logger.error("Claude OAuth failed: %s", e)


### PR DESCRIPTION
## What & why

The WR2 topic selector computes a `liveness_tier` (breaking / developing / evergreen) and **already persists it inside `brief_json`** (`wr2_topic_selector.py` line 613). But the draft generator read `enrichment` + `live_reasons` and **dropped this field on the floor** — a signal computed then thrown away (**cicatrix #9** schema-drift).

This is **A1** of the WR2 next-level plan — the keystone. On inspection it's cheaper than the plan assumed: **no migration, no new column** — the signal was already in `brief_json`. The gap was purely that the drafter ignored it.

## The wire (end-to-end, or it reproduces the scar)

```
selector writes liveness_tier  [already done]
  → _process_one reads + _normalise_liveness_tier + logs it (prove-of-life)
    → claude_compose_slides forwards it
      → _build_draft_prompt injects a one-line editorial framing
```

The injected line is **context only** — "this story is BREAKING / DEVELOPING / EVERGREEN, write accordingly." It deliberately does **NOT** dictate slide count (that's A2) or tone (that's A3); those hang off the *same* injection point in later PRs. A test asserts the framing lines mention neither a slide count nor a tone slug, so the scope can't silently creep into A2/A3.

`manual` / unknown / missing tiers inject **no** line (graceful; `liveness_tier` defaults to `""` so every existing caller is back-compat).

## cicatrix #9 guard

`_normalise_liveness_tier` mirrors the selector's `LIVENESS_TIER_VALID`, and a **parity test** fails loudly if the two sets ever drift (add a tier on one side only → caught, not silently dropped).

## Tests

19 new (normalisation incl. non-str inputs, per-tier framing with no cross-contamination, no-line for manual/unknown/empty, framing-is-context-only, back-compat default, SSOT parity, end-to-end forward into the prompt). 23 existing drafter-prompt tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)