### PR TITLE
feat(mata-garuda): flock + operating-window gates in run_with_heartbeat (class-C cron cutover)

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/heartbeat.py
+++ b/apps/mata-garuda/mata_garuda/workers/heartbeat.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import time
+from datetime import datetime
 from typing import Any, Callable, Mapping
 
 logger = logging.getLogger("mata_garuda.workers.heartbeat")
@@ -64,6 +65,43 @@ def emit_heartbeat(
         return False
 
 
+
+# ── cron-gate helpers (env-driven; absent env → no-op, full back-compat) ──────
+# These absorb the two behaviors the 7 class-C ~/scripts shell wrappers carried
+# (W7 flock single-instance + gap_consumer 06-22 operating window), so those
+# crons can drop the wrapper and run the venv python directly (W84 TCC-safe +
+# repo-tracked, cicatrix #1). fcntl is stdlib — respects mata_garuda's
+# pydantic-only stack rule.
+_FLOCK_TAKEN_EXIT = 75  # matches the shell wrapper's --conflict-exit-code 75
+
+
+def _window_closed(spec: str) -> bool:
+    """spec is 'A-B' (local hours, [A, B)). Return True if NOW is outside it.
+    A malformed spec never gates (returns False) — fail-open, like no window."""
+    try:
+        a_str, _, b_str = spec.partition("-")
+        a, b = int(a_str), int(b_str)
+    except (ValueError, AttributeError):
+        return False
+    hour = datetime.now().hour
+    return hour < a or hour >= b
+
+
+def _acquire_flock(name: str):
+    """Take a non-blocking exclusive lock on /tmp/matagaruda-<name>.lock.
+    Returns the open file handle (keep it alive to hold the lock) or None if the
+    lock is already held by another run. fcntl is POSIX — macOS/Linux only."""
+    import fcntl  # local import: only crons that set MG_FLOCK pay for it
+    path = f"/tmp/matagaruda-{name}.lock"
+    fh = open(path, "w")
+    try:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return fh
+    except OSError:
+        fh.close()
+        return None
+
+
 def run_with_heartbeat(
     organ_id: str,
     fn: "Callable[[], int | None]",
@@ -82,6 +120,28 @@ def run_with_heartbeat(
 
     Returns the worker's exit code (None → 0). Re-raises any exception from `fn`.
     """
+    # ── operating-window gate (MG_WINDOW=A-B local hours) ────────────────────
+    _window = os.environ.get("MG_WINDOW", "").strip()
+    if _window and _window_closed(_window):
+        emit_heartbeat(organ_id, "ok",
+                       metadata={"skipped": "outside_window", "window": _window},
+                       out_dir=out_dir)
+        logger.info("%s outside operating window %s — skipping", organ_id, _window)
+        return 0
+
+    # ── single-instance gate (MG_FLOCK=<name>) — W7 anti cron-stacking ───────
+    _flock_name = os.environ.get("MG_FLOCK", "").strip()
+    _flock_fh = None
+    if _flock_name:
+        _flock_fh = _acquire_flock(_flock_name)
+        if _flock_fh is None:
+            emit_heartbeat(organ_id, "ok",
+                           metadata={"skipped": "flock_held", "flock": _flock_name},
+                           out_dir=out_dir)
+            logger.info("%s another instance holds flock %s — skipping",
+                        organ_id, _flock_name)
+            return _FLOCK_TAKEN_EXIT
+
     status = "ok"
     meta: dict[str, Any] = dict(metadata) if metadata else {}
     rc = 0

--- a/apps/mata-garuda/tests/test_heartbeat_gates.py
+++ b/apps/mata-garuda/tests/test_heartbeat_gates.py
@@ -1,0 +1,90 @@
+"""Tests for the flock + operating-window gates in run_with_heartbeat.
+
+These gates absorb the W7 flock single-instance + gap_consumer 06-22 window that
+the 7 class-C ~/scripts shell wrappers carried, so those crons can drop the
+wrapper and run the venv python directly (W84 TCC-safe + repo-tracked).
+"""
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from mata_garuda.workers import heartbeat as hb
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    # never touch a real ~/.organism sidecar dir; never inherit MG_* from the shell
+    monkeypatch.setenv("ORGANISM_LAST_SEEN_DIR", str(tmp_path / "last_seen"))
+    monkeypatch.delenv("MG_WINDOW", raising=False)
+    monkeypatch.delenv("MG_FLOCK", raising=False)
+    yield
+
+
+def test_no_gates_runs_normally():
+    """No MG_* env → fn runs, exit code passed through (full back-compat)."""
+    calls = []
+    rc = hb.run_with_heartbeat("t.nogate", lambda: (calls.append(1), 0)[1])
+    assert rc == 0
+    assert calls == [1]
+
+
+def test_window_open_runs(monkeypatch):
+    monkeypatch.setenv("MG_WINDOW", "0-24")  # always open
+    calls = []
+    rc = hb.run_with_heartbeat("t.winopen", lambda: (calls.append(1), 0)[1])
+    assert rc == 0 and calls == [1]
+
+
+def test_window_closed_skips(monkeypatch):
+    monkeypatch.setenv("MG_WINDOW", "0-0")  # always closed
+    calls = []
+    rc = hb.run_with_heartbeat("t.winclosed", lambda: (calls.append(1), 0)[1])
+    assert rc == 0
+    assert calls == []  # fn NEVER invoked
+
+
+def test_window_malformed_fails_open(monkeypatch):
+    monkeypatch.setenv("MG_WINDOW", "garbage")  # unparsable → no gate
+    calls = []
+    rc = hb.run_with_heartbeat("t.winbad", lambda: (calls.append(1), 0)[1])
+    assert rc == 0 and calls == [1]
+
+
+def test_window_closed_helper():
+    with mock.patch.object(hb, "datetime") as dt:
+        dt.now.return_value.hour = 23
+        assert hb._window_closed("6-22") is True   # 23 outside [6,22)
+        dt.now.return_value.hour = 10
+        assert hb._window_closed("6-22") is False  # 10 inside
+
+
+def test_flock_free_runs(monkeypatch):
+    monkeypatch.setenv("MG_FLOCK", "test-free-lock")
+    calls = []
+    rc = hb.run_with_heartbeat("t.flockfree", lambda: (calls.append(1), 0)[1])
+    assert rc == 0 and calls == [1]
+
+
+def test_flock_held_skips_75(monkeypatch):
+    """A second run while the lock is held returns 75 and never runs fn."""
+    monkeypatch.setenv("MG_FLOCK", "test-held-lock")
+    holder = hb._acquire_flock("test-held-lock")
+    assert holder is not None  # first acquire succeeds
+    try:
+        calls = []
+        rc = hb.run_with_heartbeat("t.flockheld", lambda: (calls.append(1), 0)[1])
+        assert rc == 75
+        assert calls == []  # fn NEVER invoked while lock held
+    finally:
+        holder.close()
+
+
+def test_flock_released_after_run(monkeypatch):
+    """After a gated run completes, the lock is free for the next run."""
+    monkeypatch.setenv("MG_FLOCK", "test-serial-lock")
+    rc1 = hb.run_with_heartbeat("t.serial1", lambda: 0)
+    rc2 = hb.run_with_heartbeat("t.serial2", lambda: 0)
+    assert rc1 == 0 and rc2 == 0  # second run got the lock (first released it)


### PR DESCRIPTION
Lifts the W7 flock single-instance + gap_consumer 06-22 window out of the 7 class-C `~/scripts` shell wrappers and into `run_with_heartbeat` (the shared entry hook every cron already calls), driven by plist env: `MG_WINDOW=6-22` (skip outside window, exit 0) and `MG_FLOCK=<name>` (fcntl lock, second run exits 75). Both absent-env no-ops (back-compat for the 13 crons already on venv-direct). Lets the 7 class-C crons drop their wrapper → launchd calls venv python directly (TCC-safe + repo-tracked). fcntl/datetime stdlib (pydantic-only rule kept). Tests: 8 new, full suite 1045 passed / 26 skipped.

Follow-up to PR #1897 (venv-direct cutover for the 10 class-B crons). Plist rewrite for the 7 is a separate runtime step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)