### PR TITLE
feat(wr2): length-per-story-type steer + instrumentation (A2)

### DIFF
--- a/scripts/tests/test_wr2_draft_generator_length_per_tier.py
+++ b/scripts/tests/test_wr2_draft_generator_length_per_tier.py
@@ -1,0 +1,96 @@
+"""
+Tests for A2 — length-per-story-type steer in the draft prompt.
+
+A2 hangs off the same injection point as A1: given the (already-propagated)
+liveness_tier, inject a slide-count steer + a matching closing range, so the
+model stops defaulting to 7 (the Socialinsider engagement trough). A2 is a
+PROMPT steer, not a Python clamp — these tests verify the injected text and
+that its targets stay inside the existing hard guard (6-11).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wr2_draft_generator import (  # noqa: E402
+    _LENGTH_GUIDANCE,
+    _build_draft_prompt,
+    _length_guidance,
+)
+
+# The hard guard in _normalise_slides: len(slides) < 6 or > 11 → reject.
+_GUARD_MIN, _GUARD_MAX = 6, 11
+
+
+def _build(tier: str) -> str:
+    return _build_draft_prompt(
+        topic="X", summary="body text", source_url="", liveness_tier=tier,
+    )
+
+
+# ── guidance selection ─────────────────────────────────────────────────────
+@pytest.mark.parametrize("tier", ["breaking", "developing", "evergreen"])
+def test_valid_tier_injects_its_length_line(tier) -> None:
+    prompt = _build(tier)
+    assert _LENGTH_GUIDANCE[tier] in prompt
+    for other in (t for t in _LENGTH_GUIDANCE if t != tier):
+        assert _LENGTH_GUIDANCE[other] not in prompt
+
+
+@pytest.mark.parametrize("tier", ["", "manual", "unknown"])
+def test_absent_or_manual_tier_injects_no_length_line(tier) -> None:
+    prompt = _build(tier)
+    for line in _LENGTH_GUIDANCE.values():
+        assert line not in prompt
+    assert _length_guidance(tier) == ""
+
+
+# ── closing range matches the guidance (no "9-10" body + "6-8" footer clash) ─
+@pytest.mark.parametrize(
+    "tier,expected_range",
+    [("breaking", "6-7"), ("developing", "7-8"), ("evergreen", "9-10"), ("", "6-8"),
+     ("manual", "6-8")],
+)
+def test_closing_range_matches_tier(tier, expected_range) -> None:
+    prompt = _build(tier)
+    assert f"Produce the full {expected_range} slide JSON NOW" in prompt
+
+
+# ── every target range lives inside the hard guard (never rejected) ─────────
+@pytest.mark.parametrize("tier", ["breaking", "developing", "evergreen", "", "manual"])
+def test_target_range_is_within_hard_guard(tier) -> None:
+    prompt = _build(tier)
+    m = re.search(r"Produce the full (\d+)-(\d+) slide JSON NOW", prompt)
+    assert m, "closing range not found"
+    lo, hi = int(m.group(1)), int(m.group(2))
+    assert _GUARD_MIN <= lo <= hi <= _GUARD_MAX, f"{lo}-{hi} escapes guard {_GUARD_MIN}-{_GUARD_MAX}"
+
+
+def test_breaking_is_shorter_than_evergreen() -> None:
+    """The whole point: breaking steers fewer slides than evergreen."""
+    def _hi(tier: str) -> int:
+        m = re.search(r"Produce the full \d+-(\d+) slide", _build(tier))
+        return int(m.group(1))
+    assert _hi("breaking") < _hi("evergreen")
+
+
+# ── back-compat: no tier → legacy 6-8, no steer lines ──────────────────────
+def test_default_call_is_legacy_6_8() -> None:
+    prompt = _build_draft_prompt(topic="X", summary="b", source_url="")
+    assert "Produce the full 6-8 slide JSON NOW" in prompt
+    for line in _LENGTH_GUIDANCE.values():
+        assert line not in prompt
+
+
+def test_guidance_avoids_hardcoding_a_single_number() -> None:
+    """Steer must be a RANGE nudge, not a rigid 'exactly N' the model can't flex."""
+    for line in _LENGTH_GUIDANCE.values():
+        assert "exactly" not in line.lower()
+        assert re.search(r"\d+-\d+ slides", line), f"no range in: {line!r}"

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -96,6 +96,45 @@ def _normalise_liveness_tier(raw: Any) -> str:
     tier = str(raw or "").strip().lower()
     return tier if tier in LIVENESS_TIER_VALID else ""
 
+
+# ── A2: length-per-story-type (D1×D2) ─────────────────────────────────────────
+# Deep-research (Socialinsider ~3M carousels) put the engagement TROUGH at 7 slides
+# — the exact default the model drifted to — and the peak near 10. So instead of a
+# flat "6-8", steer the count by liveness: breaking news is punchier (fewer, faster
+# slides), evergreen reference material rewards depth (more). This is a PROMPT steer,
+# not a Python clamp: distinct_claims isn't a structured field (it's prose in
+# the_facts/in_practice), so the model — which is reading that prose — is better
+# placed to pick the count than a brittle regex would be.
+#
+# Targets live INSIDE the existing hard guard (_normalise_slides rejects <6 or >11),
+# so A2 never produces a count the guard would reject. The plan's clamp(5,10) floor of
+# 5 is deliberately raised to 6 here: dropping the guard to 5 is a separate, riskier
+# change, out of scope for A2. Ranges: breaking→6-7, developing→7-8, evergreen→9-10.
+#
+# SCOMMESSA-ESTERNA (honest): our own corpus is all-7 → zero internal length signal.
+# This bets on Socialinsider's audience generalising to ours. We instrument slide_count
+# + tier (council_meta) so it's measurable after 4-6 weeks, not optimised blind.
+_LENGTH_GUIDANCE = {
+    "breaking": (
+        "LENGTH — this is breaking news: keep it TIGHT, 6-7 slides. Lead with what "
+        "changed, cut anything that isn't the news or the immediate action."
+    ),
+    "developing": (
+        "LENGTH — this is a developing story: 7-8 slides. Enough to frame the moving "
+        "parts without padding."
+    ),
+    "evergreen": (
+        "LENGTH — this is evergreen reference material: go deeper, 9-10 slides. Use the "
+        "room to explain thoroughly; depth is the point for durable content."
+    ),
+}
+
+
+def _length_guidance(liveness_tier: str) -> str:
+    """The per-tier slide-count steer, or '' for unknown/manual (model keeps 6-8)."""
+    return _LENGTH_GUIDANCE.get(liveness_tier, "")
+
+
 TIGRIS_ENDPOINT = "https://fly.storage.tigris.dev"
 TIGRIS_BUCKET = "nuzantara-warroom-images"
 TIGRIS_PUBLIC_BASE = f"https://{TIGRIS_BUCKET}.fly.storage.tigris.dev"
@@ -516,11 +555,20 @@ def _build_draft_prompt(
         # Legacy path: truncated summary. Always available as fallback.
         body = summary[:3500]
 
-    # A1: inject the liveness framing (empty string when tier is unknown/manual).
-    liveness_line = _LIVENESS_FRAMING.get(liveness_tier, "")
-    liveness_block = f"\n\n{liveness_line}" if liveness_line else ""
+    # A1 framing + A2 length steer (both empty for unknown/manual tier → legacy 6-8).
+    steer_lines = [
+        _LIVENESS_FRAMING.get(liveness_tier, ""),
+        _length_guidance(liveness_tier),
+    ]
+    steer_block = "".join(f"\n\n{line}" for line in steer_lines if line)
 
-    return f"""{SYSTEM_INSTRUCTIONS}{avoid_steer}{liveness_block}
+    # A2: the closing count must not contradict the length steer ("evergreen → 9-10"
+    # while the footer still barks "6-8"). Derive the closing range from the tier.
+    closing_range = {
+        "breaking": "6-7", "developing": "7-8", "evergreen": "9-10",
+    }.get(liveness_tier, "6-8")
+
+    return f"""{SYSTEM_INSTRUCTIONS}{avoid_steer}{steer_block}
 
 ---
 
@@ -535,7 +583,7 @@ Content:
 
 ---
 
-Produce the full 6-8 slide JSON NOW. English content. No text outside the JSON object.
+Produce the full {closing_range} slide JSON NOW. English content. No text outside the JSON object.
 """
 
 
@@ -1155,9 +1203,10 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
         )
 
     logger.info(
-        "Slides composed: register=%s count=%d cover_prompt=%r",
+        "Slides composed: register=%s count=%d liveness_tier=%s cover_prompt=%r",
         register,
         len(slides),
+        liveness_tier or "(none)",
         slides[0]["image_prompt"][:80],
     )
 
@@ -1177,6 +1226,11 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
         "cover_url": cover_url,
         "cover_error": cover_err,
         "composed_at": datetime.now(timezone.utc).isoformat(),
+        # A2 instrumentation: the length bet is on EXTERNAL data (Socialinsider), our
+        # corpus has zero internal length signal. Persist tier + count so after 4-6
+        # weeks we can query whether breaking→6-7 / evergreen→9-10 actually paid off.
+        "liveness_tier": liveness_tier or None,
+        "slide_count": len(slides),
     }
     await _persist_ready(conn, draft_id, register, slides, council_meta)
     logger.info("Draft %s → status=drafts", draft_id)


### PR DESCRIPTION
## What & why

The drafter drifted to ~7 slides — which deep-research (Socialinsider ~3M carousels) pins as the engagement **trough**, with the peak near 10. **A2** steers the slide count by the `liveness_tier` that A1 already propagates, at the same prompt injection point:

| tier | target | rationale |
|---|---|---|
| breaking | **6-7** | punchy — lead with what changed |
| developing | **7-8** | frame the moving parts, no padding |
| evergreen | **9-10** | depth is the point for durable content |

## Design (anchored to the real code)

- **Prompt steer, not a Python clamp.** `distinct_claims` (the plan's formula input) is **not a structured field** — it's prose in `the_facts`/`in_practice`. The model reading that prose picks the count better than a brittle regex would.
- **Closing footer is now tier-derived.** The old footer barked a hardcoded `6-8`; with an evergreen steer of 9-10 that was a contradiction. Fixed.
- **Every target stays inside the existing hard guard** (`_normalise_slides` rejects `<6` / `>11`) — a test asserts this, so A2 never emits a count the guard would reject. The plan's clamp floor of **5 is deliberately raised to 6** here; dropping the guard to 5 is a separate, riskier change (out of scope).

## The honest part — this is an EXTERNAL-data bet, so it's instrumented

Our own corpus is all-7 → **zero internal length signal.** A2 bets that Socialinsider's audience generalises to ours. So `council_meta` now persists `liveness_tier` + `slide_count` (and the log carries the tier) — after 4-6 weeks we can **query whether the map actually paid off** instead of optimising blind.

Unknown/manual tier → legacy `6-8`, no steer (back-compat).

## Tests

19 new (per-tier guidance with no cross-contamination, closing-range matches guidance, every target within the 6-11 guard, `breaking < evergreen`, back-compat legacy 6-8, range-not-rigid-number). 42 existing drafter tests (enriched + A1) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)