### PR TITLE
feat(wr2): tone-per-tier (A3) + closer single-line guard (A4)

### DIFF
--- a/scripts/tests/test_wr2_draft_generator_tone_per_tier.py
+++ b/scripts/tests/test_wr2_draft_generator_tone_per_tier.py
@@ -1,0 +1,95 @@
+"""
+Tests for A3 — tone-per-story-type steer in the draft prompt.
+
+A3 nudges the model's register pick by the (already-propagated) liveness_tier,
+at the same injection point as A1/A2. It's a PREFERENCE, not a hard constraint:
+the downstream validator only rejects tones outside VALID_TONES, so A3 must never
+force a tone the validator would later reject, and must leave the model free to
+deviate when the content demands it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wr2_draft_generator import (  # noqa: E402
+    _TONE_PREFERENCE,
+    VALID_TONES,
+    _build_draft_prompt,
+    _tone_guidance,
+)
+
+
+def _build(tier: str) -> str:
+    return _build_draft_prompt(
+        topic="X", summary="body text", source_url="", liveness_tier=tier,
+    )
+
+
+# ── the load-bearing invariant: preferred tones ⊆ VALID_TONES ──────────────
+def test_every_preferred_tone_is_valid() -> None:
+    """A3 can only ever suggest a tone the validator accepts (never a spurious
+    reject). If someone adds a preferred tone not in VALID_TONES, fail loudly."""
+    preferred = {t for prefs in _TONE_PREFERENCE.values() for t in prefs}
+    assert preferred <= VALID_TONES, preferred - VALID_TONES
+
+
+# ── guidance selection ─────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "tier,expected_tones",
+    [
+        ("breaking", ("tecnico", "analitico")),
+        ("developing", ("analitico", "militante")),
+        ("evergreen", ("pedagogico", "rituale")),
+    ],
+)
+def test_valid_tier_injects_its_tone_preference(tier, expected_tones) -> None:
+    prompt = _build(tier)
+    line = _tone_guidance(tier)
+    assert line and line in prompt
+    for tone in expected_tones:
+        assert tone in line
+
+
+@pytest.mark.parametrize("tier", ["", "manual", "unknown"])
+def test_absent_or_manual_tier_injects_no_tone_line(tier) -> None:
+    assert _tone_guidance(tier) == ""
+    prompt = _build(tier)
+    # no "TONE — for this ... story, PREFER" line leaked in
+    assert "PREFER the" not in prompt
+
+
+# ── preference, NOT a hard constraint (cicatrix #3) ────────────────────────
+def test_guidance_is_a_preference_not_a_forced_tone() -> None:
+    """The line must leave an escape hatch, not command a single tone."""
+    for tier in _TONE_PREFERENCE:
+        line = _tone_guidance(tier)
+        low = line.lower()
+        assert "prefer" in low
+        # explicit escape clause so the model can deviate on content grounds
+        assert "only if" in low or "unless" in low
+
+
+def test_breaking_and_evergreen_prefer_different_registers() -> None:
+    """The whole point: timeliness shifts the voice."""
+    assert set(_TONE_PREFERENCE["breaking"]) != set(_TONE_PREFERENCE["evergreen"])
+
+
+# ── back-compat ────────────────────────────────────────────────────────────
+def test_default_call_injects_no_tone_line() -> None:
+    prompt = _build_draft_prompt(topic="X", summary="b", source_url="")
+    assert "PREFER the" not in prompt
+
+
+def test_forbidden_legacy_tones_never_preferred() -> None:
+    """cinico / istituzionale_severo are FORBIDDEN (WR1 legacy) — A3 must not
+    resurrect them via a preference."""
+    preferred = {t for prefs in _TONE_PREFERENCE.values() for t in prefs}
+    assert "cinico" not in preferred
+    assert "istituzionale_severo" not in preferred

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -135,6 +135,41 @@ def _length_guidance(liveness_tier: str) -> str:
     return _LENGTH_GUIDANCE.get(liveness_tier, "")
 
 
+# ── A3: tone-per-story-type (D2 × the most mature organ) ───────────────────────
+# The model already picks ONE of the 7 Council tones from the prompt's TONE
+# REGISTERS block. A3 nudges that pick by liveness_tier so timeliness and voice
+# agree: breaking news reads best as procedural/analytic ("what changed, what to
+# do"), an unfolding story as analytic/militant, durable reference as pedagogic/
+# ritual (explain thoroughly, lasting significance).
+#
+# PREFERENCE, not a hard constraint — deliberately (cicatrix #3 over-match): the
+# downstream validator (_normalise_slides) only rejects a tone that isn't in
+# VALID_TONES, NOT one that's "wrong for the tier". If A3 hard-forced a tone we'd
+# get spurious mismatches when the content genuinely wants another register. So the
+# line says "PREFER x/y; pick another only if the content clearly demands it" and
+# Legge 5 (human publishes) is the final backstop against over-constraint.
+#
+# Preferred tones are a SUBSET of VALID_TONES (asserted by a test) — a preference
+# the validator can never reject.
+_TONE_PREFERENCE = {
+    "breaking": ("tecnico", "analitico"),
+    "developing": ("analitico", "militante"),
+    "evergreen": ("pedagogico", "rituale"),
+}
+
+
+def _tone_guidance(liveness_tier: str) -> str:
+    """Per-tier register preference line, or '' for unknown/manual (model free)."""
+    prefs = _TONE_PREFERENCE.get(liveness_tier)
+    if not prefs:
+        return ""
+    joined = " or ".join(prefs)
+    return (
+        f"TONE — for this {liveness_tier} story, PREFER the {joined} register; pick "
+        "another of the 7 only if the content clearly demands it."
+    )
+
+
 TIGRIS_ENDPOINT = "https://fly.storage.tigris.dev"
 TIGRIS_BUCKET = "nuzantara-warroom-images"
 TIGRIS_PUBLIC_BASE = f"https://{TIGRIS_BUCKET}.fly.storage.tigris.dev"
@@ -555,10 +590,11 @@ def _build_draft_prompt(
         # Legacy path: truncated summary. Always available as fallback.
         body = summary[:3500]
 
-    # A1 framing + A2 length steer (both empty for unknown/manual tier → legacy 6-8).
+    # A1 framing + A2 length + A3 tone steer (all empty for unknown/manual tier).
     steer_lines = [
         _LIVENESS_FRAMING.get(liveness_tier, ""),
         _length_guidance(liveness_tier),
+        _tone_guidance(liveness_tier),
     ]
     steer_block = "".join(f"\n\n{line}" for line in steer_lines if line)
 


### PR DESCRIPTION
Two coupled cabling steps (A3 + A4), same file, same prompt-injection point. A3 landed first; A4 added on the same branch because they're inseparable (both steer the drafter's final output).

## A3 — tone-per-story-type register preference

Nudges the model's register pick by the `liveness_tier` A1 propagates:

| tier | preferred registers |
|---|---|
| breaking | tecnico / analitico |
| developing | analitico / militante |
| evergreen | pedagogico / rituale |

**Preference, NOT a hard constraint** (cicatrix #3): the validator only rejects tones outside `VALID_TONES`, never one "wrong for the tier"; forcing would cause spurious rejects. Load-bearing invariant (tested): every preferred tone ⊆ `VALID_TONES`; forbidden legacy tones (`cinico`/`istituzionale_severo`) never resurrected.

## A4 — closer single-line guard (the slide-8 class)

Constitution 6.6/9.5: the closing slide is a single-line bold statement-bomb. A long closer wraps into a text-brick (recurring slide-8 defect).

The plan said "gate on RENDERED line count" — but the drafter **has no rendered lines** (born from CSS wrapping at render time). The proxy it *does* have is the closer body's **word count**. So A4 = a preventive tier-independent prompt line (closer ≤ `CLOSER_MAX_WORDS`=12) + `_closer_too_long` post-hoc check that drives a **targeted regen** (compress ONLY the closer) in the existing loop.

**WARN + regen, not a hard reject** (operator choice): a slightly-long closer asks the model to compress; it never sends an otherwise-good draft to `render_failed`. Legge 5 is the review-gate backstop.

**WORDS, not characters** (cicatrix #3): a char cap would trip on one long word or a URL — a test asserts a 300-char URL is NOT flagged. Runs BEFORE the anti-sameness block (works with `WR2_ANTIMONOTONE` off, its default) and uses `continue` so it doesn't entangle that regen logic.

## Tests

A3: 11 new. A4: 11 new. Total **83** drafter tests green (enriched + A1 + A2 + A3 + A4), ruff clean, import-chain OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)