### PR TITLE
chore(ci): ignore CVE-2026-4372 (transformers RCE) with documented non-applicability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,8 @@ jobs:
             --ignore-vuln CVE-2026-41488 \
             --ignore-vuln PYSEC-2025-217 \
             --ignore-vuln GHSA-8jfx-5878-hv4v \
-            --ignore-vuln CVE-2025-3000
+            --ignore-vuln CVE-2025-3000 \
+            --ignore-vuln CVE-2026-4372
 
       - name: Mypy type check (core + models)
         run: |

--- a/apps/backend-rag/.pip-audit-ignore.md
+++ b/apps/backend-rag/.pip-audit-ignore.md
@@ -225,3 +225,46 @@ pip-audit --strict --requirement requirements.txt
 ```
 
 When pip-audit shows a Fix Version for CVE-2025-3000, bump torch and drop `--ignore-vuln CVE-2025-3000` from `.github/workflows/tests.yml`.
+
+---
+
+## GHSA-29pf-2h5f-8g72 (CVE-2026-4372) — transformers 4.57.6
+
+**Package:** `transformers` (transitive via `sentence-transformers` / `spacy`)
+**Fix version:** `5.3.0`
+**Ignored:** 2026-07-02
+
+**Summary:** Critical RCE in all transformers < 5.3.0. A malicious model repo
+whose `config.json` carries `_attn_implementation_internal` pointing at an
+attacker-controlled HuggingFace Hub repo id causes
+`AutoModelForCausalLM.from_pretrained()` to download and execute arbitrary
+Python code, bypassing `trust_remote_code`.
+
+**Why not applicable to this codepath:**
+
+1. **No user-supplied model loading anywhere.** The exploit requires the
+   victim to load a model whose `config.json` the attacker controls. Every
+   model id in `apps/backend-rag/` is a pinned trusted default or an
+   operator-controlled setting — never request/user input. Verified 2026-07-02:
+
+   ```bash
+   grep -rn "CrossEncoder\|SentenceTransformer\|from_pretrained" apps/backend-rag/backend --include="*.py"
+   # hits only: core/embeddings.py (default "sentence-transformers/all-MiniLM-L6-v2",
+   # official repo, override only via operator settings), app_factory warm-up of
+   # CrossEncoderReranker (configured model), kb/politics embedder (same default).
+   ```
+
+2. **Production (Fly) does not load the vulnerable path at all.**
+   `app/routers/visa_oracle.py` (lines ~526/685): "cross-encoder not available
+   on Fly" — reranking on Fly uses raw vector-similarity scores; the
+   CrossEncoder/transformers stack is a local-only path.
+
+3. **Residual risk = supply-chain compromise of the pinned official HF repos**
+   (`sentence-transformers/*`, `cross-encoder/*`) — the same accepted risk
+   class as the GHSA-69w3-r845-3855 entry above ("weights from Hugging Face
+   Hub on startup, trusted source").
+
+**Follow-up (the real cure):** bump `transformers` to `>=5.3.0` through the
+weekly dependency process — it is a major bump (4.57 → 5.3) requiring compat
+testing with `sentence-transformers` and `spacy`. Remove this entry when the
+bump lands.


### PR DESCRIPTION
pip-audit fails EVERY PR since CVE-2026-4372 published (critical RCE in transformers <5.3.0 via attacker-controlled model repo config.json). Not applicable here — grounded: (1) no user-supplied model loading anywhere (all model ids pinned trusted defaults or operator settings), (2) Fly production never loads the vulnerable path (cross-encoder is local-only, visa_oracle reranks on raw vector similarity), (3) residual risk = supply-chain of pinned official HF repos, same accepted class as the existing GHSA-69w3-r845-3855 entry. Full reasoning in apps/backend-rag/.pip-audit-ignore.md.

Follow-up (real cure): transformers >=5.3.0 bump via the weekly dependency process (4.57→5.3 major, needs sentence-transformers+spacy compat testing); remove the ignore when it lands.

Operator-approved 2026-07-02. Unblocks the PR queue incl. #1906 (auto-heal watchdog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)