### PR TITLE
feat(wr2): B1 deterministic composition swap — overlong statement-bomb → editorial-text

### DIFF
--- a/scripts/tests/test_wr2_smart_hero.py
+++ b/scripts/tests/test_wr2_smart_hero.py
@@ -239,3 +239,121 @@ def test_photo_fullbleed_skeleton_is_full_bleed_photo_with_body() -> None:
     assert ".scrim" in skel
     # logo present per brand convention
     assert "logo" in skel
+
+
+# ── 6. B1 deterministic composition swap (2026-07-02) ─────────────────────────
+#
+# statement-bomb is a 3-15-word punch layout. A MID cta/statement/closing slide
+# with an over-budget body crams (the "35-word take" failure mode, but on the
+# statement path). B1 swaps that pre-render to editorial-text. The TRUE last
+# slide (index==total) is ALWAYS statement-bomb — Art 9.5 hard rule, closer
+# excluded from the swap by construction.
+
+from wr2_html_renderer.composer import (  # noqa: E402
+    _STATEMENT_BOMB_MAX_WORDS,
+    _slide_body_word_count,
+)
+
+
+def _long_body(n_words: int) -> str:
+    return " ".join(f"word{i}" for i in range(n_words))
+
+
+# guilt: an over-budget MID cta/statement slide swaps to editorial-text ─────────
+
+
+def test_b1_mid_cta_overlong_body_swaps_to_editorial_text() -> None:
+    slide = {"slide_type": "cta", "is_hero_image": False,
+             "body": _long_body(_STATEMENT_BOMB_MAX_WORDS + 10)}
+    assert map_slide_to_family(slide, 5, 8) == "editorial-text"
+
+
+def test_b1_mid_statement_overlong_statement_field_swaps() -> None:
+    # the {{statement}} fill prefers slide["statement"]; the word count must too.
+    slide = {"slide_type": "statement", "is_hero_image": False,
+             "statement": _long_body(_STATEMENT_BOMB_MAX_WORDS + 5),
+             "body": "short"}
+    assert map_slide_to_family(slide, 4, 9) == "editorial-text"
+
+
+def test_b1_mid_closing_overlong_body_swaps() -> None:
+    slide = {"slide_type": "closing", "is_hero_image": False,
+             "body": _long_body(_STATEMENT_BOMB_MAX_WORDS + 1)}
+    assert map_slide_to_family(slide, 6, 9) == "editorial-text"
+
+
+# innocence: the closer, short punches, and non-statement paths are untouched ───
+
+
+def test_b1_true_last_slide_never_swaps_even_when_overlong() -> None:
+    # Art 9.5 hard rule: the closing slide MUST be statement-bomb. Over-length
+    # here is A4's job (drafter regen), NOT a layout swap — B1 must NOT touch it.
+    slide = {"slide_type": "cta", "is_hero_image": False,
+             "body": _long_body(_STATEMENT_BOMB_MAX_WORDS + 50)}
+    assert map_slide_to_family(slide, 8, 8) == "statement-bomb"
+
+
+def test_b1_short_punch_cta_stays_statement_bomb() -> None:
+    # a genuine 3-15 word punch on a mid CTA slide is the layout's intended use.
+    slide = {"slide_type": "cta", "is_hero_image": False,
+             "body": _long_body(8)}
+    assert map_slide_to_family(slide, 5, 8) == "statement-bomb"
+
+
+def test_b1_at_budget_boundary_stays_statement_bomb() -> None:
+    # exactly at the budget (not OVER it) is still a valid punch → no swap.
+    slide = {"slide_type": "statement", "is_hero_image": False,
+             "body": _long_body(_STATEMENT_BOMB_MAX_WORDS)}
+    assert map_slide_to_family(slide, 4, 9) == "statement-bomb"
+
+
+def test_b1_empty_body_cta_stays_statement_bomb() -> None:
+    # absent/empty body (0 words) must never trip the swap.
+    assert map_slide_to_family({"slide_type": "cta"}, 5, 8) == "statement-bomb"
+
+
+def test_b1_does_not_mutate_the_slide_dict() -> None:
+    # map_slide_to_family returns a string; it must NOT write back to the caller's
+    # slide (landmine: render_apply passes the ORIGINAL object downstream).
+    slide = {"slide_type": "cta", "is_hero_image": False,
+             "body": _long_body(_STATEMENT_BOMB_MAX_WORDS + 10)}
+    before = dict(slide)
+    map_slide_to_family(slide, 5, 8)
+    assert slide == before
+
+
+def test_b1_is_idempotent() -> None:
+    # calling twice yields the same family (no hidden state / accumulation).
+    slide = {"slide_type": "cta", "is_hero_image": False,
+             "body": _long_body(_STATEMENT_BOMB_MAX_WORDS + 10)}
+    a = map_slide_to_family(slide, 5, 8)
+    b = map_slide_to_family(slide, 5, 8)
+    assert a == b == "editorial-text"
+
+
+def test_b1_explicit_pin_still_wins_over_swap() -> None:
+    # an explicit RENDERABLE layout_family pin is honoured first (line 118),
+    # so a manual author who pins statement-bomb keeps it — B1 only governs the
+    # AUTO-routing path, not explicit intent.
+    slide = {"slide_type": "cta", "is_hero_image": False,
+             "layout_family": "statement-bomb",
+             "body": _long_body(_STATEMENT_BOMB_MAX_WORDS + 30)}
+    assert map_slide_to_family(slide, 5, 8) == "statement-bomb"
+
+
+def test_b1_swapped_slide_editorial_text_renders_full_body() -> None:
+    # the swap target must actually carry the long body (no message loss): the
+    # editorial-text skeleton has a {{body}} slot, unlike statement-bomb's
+    # {{statement}} punch. This is WHY the swap preserves the content.
+    skel = _extract_skeleton("editorial-text")
+    assert "{{body}}" in skel
+
+
+def test_b1_word_count_helper_matches_statement_fill_precedence() -> None:
+    # helper precedence (statement > headline > body) mirrors the {{statement}}
+    # fill at composition time, so the budget is measured on the rendered text.
+    assert _slide_body_word_count({"statement": "a b c", "headline": "x y",
+                                   "body": "1 2 3 4"}) == 3
+    assert _slide_body_word_count({"headline": "x y", "body": "1 2 3 4"}) == 2
+    assert _slide_body_word_count({"body": "1 2 3 4"}) == 4
+    assert _slide_body_word_count({}) == 0

--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -75,6 +75,24 @@ UNDEFINED_FAMILIES = {
 }
 
 
+# B1 (micro, deterministic composition swap — 2026-07-02):
+# statement-bomb is a 3-15-word punch layout. A CTA/statement/closing-typed MID
+# slide whose body exceeds this budget crams the same way the "35-word take" did
+# (E2E 2026-06-13, see map_slide_to_family). B1 catches that pre-render — a
+# deterministic swap to editorial-text (which reads a long prose body cleanly) —
+# so the scarred designer_loop taxonomy (W82) never has to salvage a crammed
+# statement-bomb with font-shrink whack-a-mole. Budget is generous (the layout
+# tolerates a short 2-line statement) so the swap only fires on real overflow.
+_STATEMENT_BOMB_MAX_WORDS = 18
+
+
+def _slide_body_word_count(slide: dict[str, Any]) -> int:
+    """Words in the text a statement-bomb would actually render (statement/headline/body,
+    same precedence as the {{statement}} fill at composition time)."""
+    text = (slide.get("statement") or slide.get("headline") or slide.get("body") or "")
+    return len(str(text).split())
+
+
 @dataclass
 class SlidePlan:
     index: int  # 1-based
@@ -121,6 +139,20 @@ def map_slide_to_family(slide: dict[str, Any], index: int, total: int) -> str:
         return "cover-photo"
     st = (slide.get("slide_type") or "").lower()
     if index == total or st in {"cta", "closing", "statement"}:
+        # B1 deterministic composition swap: a MID CTA/statement slide whose body
+        # overflows the statement-bomb budget goes to editorial-text instead of
+        # cramming. The TRUE last slide (index == total) is ALWAYS statement-bomb
+        # — Art 9.5 hard rule (statement-bomb closer). Over-length there is the
+        # drafter's job (A4 closer-guard regen), NOT a layout swap: swapping the
+        # closer would break the constitution's mandatory closing statement-bomb.
+        if index != total and _slide_body_word_count(slide) > _STATEMENT_BOMB_MAX_WORDS:
+            logger.info(
+                "B1 composition swap: slide %d/%d (type=%s, %d words) "
+                "statement-bomb -> editorial-text (over %d-word budget)",
+                index, total, st or "?", _slide_body_word_count(slide),
+                _STATEMENT_BOMB_MAX_WORDS,
+            )
+            return "editorial-text"
         return "statement-bomb"
     if slide.get("is_hero_image"):
         return "photo-headline-yellow-sub"


### PR DESCRIPTION
## What

**Level-B auto-cure keystone (micro-B1).** The last open piece of the WR2 next-level plan (C0+A1+A2+A3+A4+B2 already merged).

A MID `cta`/`statement`/`closing` slide whose body overflows the statement-bomb 3-15-word punch budget crammed into the wrong layout, forcing the scarred `designer_loop` taxonomy (W82, 5-day outage) to salvage it with font-shrink whack-a-mole. B1 catches it **PRE-render** in `map_slide_to_family`: a deterministic swap to `editorial-text` (which renders long prose cleanly) when a non-last statement-path slide exceeds `_STATEMENT_BOMB_MAX_WORDS` (18).

This is the self-healing **"salto"** the plan called the composition actuator — a classifier-level lever that bypasses the scarred `designer_loop` entirely. (Reliability/self-healing, **not** RSI.)

## Safety (verified against real code — cicatrix #6)

The spec was coarser than reality: `map_slide_to_family` **already** routes long non-hero "takes" to `editorial-text` (composer.py:132, E2E 2026-06-13). The residual crammer was only the `index==total or slide_type in {cta,closing,statement}` branch, which forced statement-bomb with **no word check**. B1 is therefore narrower and safer than the spec's version:

- **Closer excluded** — `index==total` is ALWAYS statement-bomb (Art 9.5 hard rule). Over-length there is A4's drafter-regen job, not a layout swap.
- **No mutation** — returns a string, never writes back to the slide dict (render_apply passes the original object downstream — the panel's landmine #2, avoided by construction).
- **`is_hero_image` untouched** (statement-path slides aren't hero — panel's landmine #1 moot).
- **Explicit `layout_family` pin still wins first** (manual author intent preserved).
- **`designer_loop.py` UNTOUCHED** (panel constraint).

## Tests

12 new (in `test_wr2_smart_hero.py`): guilt (cta/statement/closing overlong → swap), innocence (closer never swaps, short punch stays, at-budget stays, empty body stays, no-mutation, idempotency, explicit-pin wins, swap target carries `{{body}}`, helper precedence).

**165 green total** — 31 smart-hero+B1 / 22 composer+renderer / 112 render-apply. Zero regression. ruff clean.

## Sequencing note

The 4-LLM panel recommended running B2 ~1 week before B1 to measure the calibrated critic reduces stalls first. Shipped now on explicit operator "go b1". B1 is orthogonal to B2 (pre-render classifier vs critic prompt), so no interference — the sequencing was about data-gathering, not a safety gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)