### PR TITLE
chore(modus): ledger sync — banner proven, align-debts recorded

### DIFF
--- a/.claude/skills/modus/PENDING-ARMS.md
+++ b/.claude/skills/modus/PENDING-ARMS.md
@@ -9,10 +9,10 @@
 
 - opened 2026-07-02 | DeepSeek V4 Pro refuter tier | balance top-up — probed live this day: HTTP 402 Insufficient Balance (2nd consecutive council with the seat dead) | operator | a 1-token chat/completions call returns 200
 - opened 2026-07-02 | escalations receptor (`scripts/hooks/escalations_alert_sessionstart.sh`, PR #1852) | hooks entry ships with the modus PR in repo `.claude/settings.json`; liveness provable only at next session boot per machine | me | a nuzantara session boot shows the "🚨 ESCALATIONS BOARD" block (or a manual run emits valid hook JSON with current board state)
-- opened 2026-07-02 | main-checkout pull on M5 (`~/Desktop/nuzantara`) — modus skill + receptor hook not live there until pulled | PENDING-ALIGN:M5 — live sibling sessions own the dirty main (flowkit work); per ALIGN-FLEET rule never touch sibling state; self-resolves at next routine `git pull` | operator (or next clean session) | `test -f ~/Desktop/nuzantara/.claude/skills/modus/SKILL.md` on M5
 - opened 2026-07-02 | main-checkout pull on Pro (`~/Desktop/nuzantara`) — pull aborts on sibling's untracked `apps/wa-mirror/bridge/group_subject.ts` | PENDING-ALIGN:Pro — sibling wa-mirror/mata-garuda work in flight; self-resolves once the sibling lands or moves the file | operator (or next clean session) | `git -C ~/Desktop/nuzantara rev-parse HEAD` on Pro contains 3509f3e2ab content (blob check)
 
 ## closed (proof recorded)
 
 - closed 2026-07-02 | opus-mythos deprecation banner M5+Pro+Mini | operator ran the idempotent one-liner on all 3 | PROVEN: `grep -c SUPERSEDED` = 2 on M5, Pro, Mini (description prefix + body banner); live skill registry on M5 reloaded with the superseded description
+- closed 2026-07-02 | main-checkout pull on M5 (PENDING-ALIGN:M5) | operator pulled same-day | PROVEN: HEAD `3509f3e2ab`, `.claude/skills/modus/SKILL.md` present, receptor hook wired in `.claude/settings.json`
 - opened 2026-07-02 | 9 dead/unhealthy heartbeat organs (doctrine §8, 2026-06-30) | heartbeat writer/bridge investigation on Pro — restart is NOT the cure | operator | organism_alert boot receptor shows 0 stale-critical organs

--- a/.claude/skills/modus/PENDING-ARMS.md
+++ b/.claude/skills/modus/PENDING-ARMS.md
@@ -9,5 +9,10 @@
 
 - opened 2026-07-02 | DeepSeek V4 Pro refuter tier | balance top-up — probed live this day: HTTP 402 Insufficient Balance (2nd consecutive council with the seat dead) | operator | a 1-token chat/completions call returns 200
 - opened 2026-07-02 | escalations receptor (`scripts/hooks/escalations_alert_sessionstart.sh`, PR #1852) | hooks entry ships with the modus PR in repo `.claude/settings.json`; liveness provable only at next session boot per machine | me | a nuzantara session boot shows the "🚨 ESCALATIONS BOARD" block (or a manual run emits valid hook JSON with current board state)
-- opened 2026-07-02 | opus-mythos deprecation banner on M5 + Pro + Mini (`~/.claude/skills/opus-mythos/SKILL.md`) | the host_boundary hook (correctly) blocks agent writes to `~/.claude` — operator runs the one-liner from the genesis report on each machine; meanwhile repo CLAUDE.md §2/§5 already declare the supersession to every session | operator | `grep -l "SUPERSEDED" ~/.claude/skills/opus-mythos/SKILL.md` returns the file on all 3 machines
+- opened 2026-07-02 | main-checkout pull on M5 (`~/Desktop/nuzantara`) — modus skill + receptor hook not live there until pulled | PENDING-ALIGN:M5 — live sibling sessions own the dirty main (flowkit work); per ALIGN-FLEET rule never touch sibling state; self-resolves at next routine `git pull` | operator (or next clean session) | `test -f ~/Desktop/nuzantara/.claude/skills/modus/SKILL.md` on M5
+- opened 2026-07-02 | main-checkout pull on Pro (`~/Desktop/nuzantara`) — pull aborts on sibling's untracked `apps/wa-mirror/bridge/group_subject.ts` | PENDING-ALIGN:Pro — sibling wa-mirror/mata-garuda work in flight; self-resolves once the sibling lands or moves the file | operator (or next clean session) | `git -C ~/Desktop/nuzantara rev-parse HEAD` on Pro contains 3509f3e2ab content (blob check)
+
+## closed (proof recorded)
+
+- closed 2026-07-02 | opus-mythos deprecation banner M5+Pro+Mini | operator ran the idempotent one-liner on all 3 | PROVEN: `grep -c SUPERSEDED` = 2 on M5, Pro, Mini (description prefix + body banner); live skill registry on M5 reloaded with the superseded description
 - opened 2026-07-02 | 9 dead/unhealthy heartbeat organs (doctrine §8, 2026-06-30) | heartbeat writer/bridge investigation on Pro — restart is NOT the cure | operator | organism_alert boot receptor shows 0 stale-critical organs


### PR DESCRIPTION
Gear 1 bookkeeping on the modus W81 ledger: the opus-mythos deprecation banner is now PROVEN on all 3 machines (operator ran the one-liner; grep count 2 each) → line closed with proof recorded. Adds the two PENDING-ALIGN lines (M5/Pro main-checkout pulls deferred to protect live sibling work) declared in-session during the genesis run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)