### PR TITLE
fix(organism): stop bridging 2 retired organs (false-sick receipts)

### DIFF
--- a/scripts/launchagent-state-bridge.py
+++ b/scripts/launchagent-state-bridge.py
@@ -227,11 +227,12 @@ BRIDGED_LABELS: tuple[BridgedLaunchAgent, ...] = (
         organ_id="intel_lake.shadow_validate_6h",
         daemon=False,
     ),
-    BridgedLaunchAgent(
-        label="com.balizero.l5-2-phase2b-trigger",
-        organ_id="pro.l5_2_phase2b_trigger",
-        daemon=False,
-    ),
+    # pro.l5_2_phase2b_trigger REMOVED 2026-07-02: one-shot LaunchAgent that
+    # fired 2026-06-02 and self-unloads by design (docs/runbooks/
+    # l5-2-phase2b-auto-trigger.md); connectome marks it retired 2026-06-20
+    # (docs/connectome/edges/launchd-pro.yaml). Bridging it produced a
+    # permanent false "label not loaded" → failed receipt.
+    # TAC: research/operations/2026-07-03-heartbeat-organs-tac.md
     BridgedLaunchAgent(
         label="com.balizero.mos-plus.qdrant-indexer",
         organ_id="pro.mos_plus_qdrant_indexer",
@@ -452,11 +453,10 @@ BRIDGED_LABELS: tuple[BridgedLaunchAgent, ...] = (
         organ_id="pro.wa_mirror_launcher",
         daemon=True,
     ),
-    BridgedLaunchAgent(
-        label="com.balizero.wa-viewer",
-        organ_id="pro.wa_viewer",
-        daemon=True,
-    ),
+    # pro.wa_viewer REMOVED 2026-07-02: retired 2026-05-19 (live plist renamed
+    # com.balizero.wa-viewer.plist.retired + label disabled in launchd).
+    # Bridging it produced a permanent false "label not loaded" → failed receipt.
+    # TAC: research/operations/2026-07-03-heartbeat-organs-tac.md
     BridgedLaunchAgent(
         label="com.balizero.wr2.carousel-dispatcher",
         organ_id="wr2.carousel_dispatcher",


### PR DESCRIPTION
## What
Remove `pro.l5_2_phase2b_trigger` and `pro.wa_viewer` from `BRIDGED_LABELS` in `scripts/launchagent-state-bridge.py`.

## Why
Both organs are **retired**, but the bridge kept writing `status=failed` sidecar receipts every 5 minutes, so every session boot flagged them as "breathing but unhealthy":

- `pro.l5_2_phase2b_trigger` — one-shot LaunchAgent that fired 2026-06-02 and **self-unloads by design** (`docs/runbooks/l5-2-phase2b-auto-trigger.md`); the connectome already records it retired 2026-06-20 (`docs/connectome/edges/launchd-pro.yaml:1020`).
- `pro.wa_viewer` — retired 2026-05-19: live plist renamed `com.balizero.wa-viewer.plist.retired` + label disabled in `launchctl print-disabled`.

Root-cause class (cicatrix #2 adjacent): **organ retirement has no propagation to its monitors** — the graveyard lives in the monitor. Part of the heartbeat-organs TAC (report follows in a separate PR: `research/operations/2026-07-03-heartbeat-organs-tac.md`).

## Arming (Pro)
The bridge executes from `~/scripts/launchagent-state-bridge.py` (HOME copy, currently byte-identical to repo). Post-merge: `cp` repo→`~/scripts` (idempotent, `cmp` verified) + delete the 2 leftover sidecar files in `~/.organism/last_seen/`. Tracked in the TAC + PENDING-ARMS.

## Test
`python3 -c "import ast; ast.parse(...)"` OK; entries 90→88; no other repo references to the two organ_ids (grep clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)