### PR TITLE
feat(infra): migrate cron tier-1 repo pins to claude-sonnet-5 (staged, probed per-agent)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ User writes **colloquial Italian** — translate to precise technical action int
 
 ## 5. Agent/LLM Routing & Bans
 
-**Claude 5 routing (2026-07-02)**: interactive sessions = **Fable 5** (architect/orchestrator/final on-disk gate, max effort — the final gate never cascades to a weaker model; window dead → task SUSPENDS); implementer subagents/workflows = **Sonnet 5** (`claude-sonnet-5`, `model:"sonnet"`); grunt = Haiku 4.5. Cron tier-1 remains `claude-sonnet-4-6` until a staged per-agent migration (tracked in modus PENDING-ARMS). Full arsenal routing: `.claude/skills/modus/SKILL.md` §Arsenal.
+**Claude 5 routing (2026-07-02)**: interactive sessions = **Fable 5** (architect/orchestrator/final on-disk gate, max effort — the final gate never cascades to a weaker model; window dead → task SUSPENDS); implementer subagents/workflows = **Sonnet 5** (`claude-sonnet-5`, `model:"sonnet"`); grunt = Haiku 4.5. Cron tier-1: repo-side pins migrated to `claude-sonnet-5` on 2026-07-03 after per-agent probes (see `research/operations/2026-07-03-sonnet5-cron-migration.md`); LIVE HOME wrappers (`~/scripts/`) still on `claude-sonnet-4-6` until the operator applies the diffs in that doc (tracked in modus PENDING-ARMS). Exception: the nb-agents slug micro-prompt stays 4-6 (probe wobble). Full arsenal routing: `.claude/skills/modus/SKILL.md` §Arsenal.
 
 **Anthropic SDK BANNED.** Never `from anthropic import Anthropic` or `ANTHROPIC_API_KEY`. Sole path: shell out to `claude` CLI with `CLAUDE_CODE_OAUTH_TOKEN` (MAX-plan quota). Refuse any new tool/MCP/cron requiring `ANTHROPIC_API_KEY`. Reference: `apps/backend-rag/backend/llm/claude_oauth_client.py`.
 

--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -223,7 +223,7 @@ def test_run_claude_json_timeout_budget_from_env(monkeypatch):
 
 
 def test_run_claude_json_pins_vision_model(monkeypatch):
-    """Default pins claude-sonnet-4-6; WR2_VISION_MODEL overrides. (No --model
+    """Default pins claude-sonnet-5; WR2_VISION_MODEL overrides. (No --model
     before = CLI default, heavier → 120s timeouts + quota burn.)"""
     import json as _json
 
@@ -239,7 +239,7 @@ def test_run_claude_json_pins_vision_model(monkeypatch):
     monkeypatch.delenv("WR2_VISION_MODEL", raising=False)
     claude_vision._run_claude_json("p", {"type": "object"})
     assert "--model" in captured["cmd"]
-    assert "claude-sonnet-4-6" in captured["cmd"]
+    assert "claude-sonnet-5" in captured["cmd"]
 
     monkeypatch.setenv("WR2_VISION_MODEL", "claude-opus-4-8")
     claude_vision._run_claude_json("p", {"type": "object"})

--- a/infra/eventbus/meta_dispatcher.py
+++ b/infra/eventbus/meta_dispatcher.py
@@ -234,7 +234,7 @@ def _process_action(action: dict, env: EventEnvelope) -> None:
             cmd = [
                 "/Users/nuzantara/scripts/claude-cascade.sh",
                 "Run the canva-apply skill: read canva_pending.json, apply via MCP Canva tools, mark applied.",
-                "--model", "claude-sonnet-4-6",
+                "--model", "claude-sonnet-5",
             ]
             try:
                 # Fire-and-forget: don't block dispatcher loop
@@ -262,7 +262,7 @@ def _process_action(action: dict, env: EventEnvelope) -> None:
         cmd = [
             "/Users/nuzantara/scripts/claude-cascade.sh",
             "Run the canva-apply skill: read canva_pending.json, apply via MCP Canva tools, mark applied.",
-            "--model", "claude-sonnet-4-6",
+            "--model", "claude-sonnet-5",
         ]
         try:
             subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,

--- a/infra/launchagents/wrappers/regulatory-watcher-run.sh
+++ b/infra/launchagents/wrappers/regulatory-watcher-run.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # regulatory-watcher cron wrapper — multi-LLM cascade
-# Order: Claude OAuth (Sonnet 4.6) → Gemini 3.1 Pro free → Codex GPT-5.5 → Ollama qwen3.5:9b local
+# Order: Claude OAuth (Sonnet 5) → Gemini 3.1 Pro free → Codex GPT-5.5 → Ollama qwen3.5:9b local
 # Cost: 0$ (4 tier all subscription/free/local)
 
 # NO `-e`: each tier may exit non-zero and the cascade MUST survive to capture
@@ -38,11 +38,11 @@ USED_LLM=""
 
 # Tier 1: Claude OAuth Sonnet
 echo "[$(date)] tier 1 — claude sonnet" >> "$LOG"
-"$HOME/.local/bin/claude" --print --model claude-sonnet-4-6 "$PROMPT_CLAUDE" >"$TMPOUT" 2>&1
+"$HOME/.local/bin/claude" --print --model claude-sonnet-5 "$PROMPT_CLAUDE" >"$TMPOUT" 2>&1
 EXIT=$?
 if [ $EXIT -eq 0 ] && ! grep -qE "out of extra usage|usage limit|quota exceeded|rate.limit" "$TMPOUT"; then
     SUCCESS=1
-    USED_LLM="claude-sonnet-4-6"
+    USED_LLM="claude-sonnet-5"
 fi
 cat "$TMPOUT" >> "$LOG"
 

--- a/research/operations/2026-07-03-sonnet5-cron-migration.md
+++ b/research/operations/2026-07-03-sonnet5-cron-migration.md
@@ -1,0 +1,121 @@
+# Staged migration: cron/agent tier-1 `claude-sonnet-4-6` → `claude-sonnet-5`
+
+- **Date**: 2026-07-03 (flight session P3, operator airborne — GEAR 2, modus loop)
+- **Mandate**: CLAUDE.md §5 / modus SKILL.md §Arsenal — "Cron tier-1 stays claude-sonnet-4-6 until the staged migration to Sonnet 5 is tested per-agent"
+- **Branch/PR**: `agent/nuzantara/infra/sonnet5-cron`
+- **Probe evidence**: session scratchpad `probes/` + `out/` (18 paired 1-shots, all exit=0)
+
+## TL;DR
+
+Every ACTIVE tier-1 pin was probed with a real prompt-shape 1-shot on both models.
+**8/9 agent shapes SAFE on Sonnet 5** — quality equal or better (yield-optimizer applied all
+R-rules incl. LKPM-in-13-days; ig-metrics-analyst self-identified sample confounds; vision
+critic returned verdicts identical to 4-6 on a real slide). **1 RISKY**: the nb-agents slug
+micro-prompt (3/3 wobble: 7 tokens vs "max 6", meta-leak, context-leak) — stays on 4-6; its
+consumer has no scheduler (dormant) so nothing changes live.
+
+Repo-side pins are migrated in this PR. **LIVE cron still runs the HOME copies** (`~/scripts/`,
+read-only for agents — HOME-fork family #1): the operator one-liners below arm the migration.
+
+## Inventory — every `claude-sonnet-4-6` pin
+
+### Repo-side (migrated in this PR)
+
+| File | Lines | Agent / role | Live? |
+|---|---|---|---|
+| `infra/launchagents/wrappers/regulatory-watcher-run.sh` | 3, 41, 45 | regulatory-watcher tier-1 | plist runs HOME copy (was byte-identical to repo) |
+| `scripts/nb-curator-daily.sh` | 174 | nb-curator claude-cascade FALLBACK (primary brain = agy Flash) | plist runs HOME copy (was byte-identical) |
+| `infra/eventbus/meta_dispatcher.py` | 237, 265 | canva-apply skill dispatch | plist runs HOME copy (`~/scripts/eventbus/meta_dispatcher.py`) — **HOME copy is AHEAD of repo** (`BZ_REDIS_HOST` env param never promoted back) |
+| `scripts/wr2_html_renderer/claude_vision.py` | 222 | WR2 vision critic default (`WR2_VISION_MODEL` overridable) | live from repo (WR2 pipeline) |
+| `scripts/wr3_reflexion_synthesis.py` | 38, 266 | WR3 reflexion weekly tier-1 | **NOT armed**: plist `com.balizero.wr3.reflexion.weekly` runs `~/.claude/skills/bali-zero-brand/wr3/_reflexion-synthesis.py` = 816-byte S7.3 STUB (exit 0, does nothing) |
+| `apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py` | 226, 242 | asserts vision default | updated in same commit (W86 discipline) |
+| `CLAUDE.md` | §5 | routing doctrine line | updated to migration-in-progress state |
+
+Not pins (left untouched): `scripts/cost_baseline.py` (historical cost table),
+`scripts/test_call_llm_deepseek.py` (routing-inference test), docs/, research/, vendor/evoskill,
+apps/backend-rag backend clients (out of mandate scope — separate deploy-gated migration).
+
+### HOME-side LIVE (read-only for agents — operator applies)
+
+| File:line | Agent | Cron | Verdict |
+|---|---|---|---|
+| `~/scripts/regulatory-watcher-run.sh:41,45` | regulatory-watcher | daily 07:00 | SAFE → migrate |
+| `~/scripts/nb-curator-daily.sh:174` | nb-curator (fallback tier) | daily | SAFE → migrate |
+| `~/scripts/wr2-ig-metrics-analyst-run.sh:89` | wr2-ig-metrics-analyst | weekly Mon 06:00 | SAFE → migrate |
+| `~/scripts/competitor-monitor-run.sh:29` | competitor-monitor | monthly d1 09:00 | SAFE → migrate |
+| `~/scripts/yield-optimizer-run.sh:29` | yield-optimizer | weekly Sun 04:00 | SAFE → migrate |
+| `~/scripts/eventbus/meta_dispatcher.py:241,269` | canva-apply dispatch | daemon | SAFE → migrate (sed only — HOME copy ahead of repo, do NOT cp) |
+| `~/scripts/nb-agents-daily-dr.sh:76` | slug micro-prompt | no scheduler found (dormant) | **RISKY → keep 4-6** |
+| `~/scripts/nb-curator-weekly.sh:86`, `~/scripts/run-nb-curator-mode-c.sh:55` | nb-curator weekly/mode-c | plists disabled | dormant — migrate if reactivated |
+| `~/scripts/cron-agent-python/{agent_config.py,tdd_pipeline.py}` | tdd pipeline | no scheduler | dormant — migrate if reactivated |
+| `~/scripts/*.bak-*` | backups | — | leave |
+
+## Probe methodology
+
+For each agent, the format-critical core of its REAL prompt (extracted from the live wrapper /
+`build_synthesis_prompt()` / `_CRITIC_PROMPT`) ran as a sandboxed 1-shot on BOTH models
+(`claude --print --model <m>`), with synthetic non-PII data inline, no Telegram, no live file
+writes. Vision probe used the real `--output-format json --json-schema` invocation on a real
+slide PNG (`docs/wr2/manual-assets/2026-06-13-june-deadlines/slide-01.png`). Baseline sanity:
+regulatory-watcher's ACTUAL production tier-1 run of 2026-07-02 (delta JSON + Telegram, served
+by 4-6) matches the probe shape. 18/18 runs exit=0; Sonnet 5 durations equal or faster on 5/9.
+
+| Probe | 4-6 | Sonnet 5 | Notes |
+|---|---|---|---|
+| regwatch (delta JSON schema, filter, verbatim) | PASS | PASS | S5 semantics perfect (Pergub correctly excluded AND seen); S5 added md fences + trailing prose despite "ONLY JSON" — harmless here (wrapper never parses stdout; agent writes the file via tools) |
+| nbcur (hard limits, SUMMARY line, dup pairs) | PASS | PASS | S5 found exactly the 2 planted dup pairs, clean SUMMARY |
+| igmetrics (insights + confidence grading) | PASS | PASS | S5 explicitly flagged the domain/layout confound — better statistical honesty |
+| compmon (digest structure, material-changes) | PASS | PASS | validator false-FAIL on S5 (bold `**Material changes: yes**` + "Let's Move" apostrophe — MY check was a #3 guard-over-match, model was fine) |
+| yield (R1-R6 rules, no pitch text, no invented names) | PASS | PASS | S5 flawless: R4 LKPM 13-days caught, R6 honestly not fired, correct owner routing |
+| slug (kebab ≤6 words) | PASS | **FAIL 3/3** | 7 tokens; "slug-generation" meta-leak; "nuzantara" context-leak (cwd context injection). 4-6 clean 1/1 |
+| canva (dry-run discipline) | PASS | PASS | weak probe (no live MCP) — risk accepted: prompt is trivial skill dispatch, Sonnet 5 already the fleet implementer tier |
+| wr3refl (lessons JSON, honest thin-signal) | PASS | PASS | S5: 4 lessons all confidence=low, real episode ids |
+| vision (real slide, real schema) | PASS | PASS | verdicts IDENTICAL (passes=false, score=0.15, lever=rerender); S5 found 5 issues vs 3 |
+
+## §Solo-operatore — arming steps (exact diffs)
+
+After this PR merges to main and Pro's main checkout is pulled:
+
+```bash
+# 1. regulatory-watcher + nb-curator (repo copies byte-identical pre-edit → clean cp)
+cp ~/Desktop/nuzantara/infra/launchagents/wrappers/regulatory-watcher-run.sh ~/scripts/regulatory-watcher-run.sh
+cp ~/Desktop/nuzantara/scripts/nb-curator-daily.sh ~/scripts/nb-curator-daily.sh
+
+# 2. Standalone wrappers (no repo counterpart) — in-place sed
+sed -i '' 's/--model claude-sonnet-4-6/--model claude-sonnet-5/' ~/scripts/wr2-ig-metrics-analyst-run.sh
+sed -i '' 's/--model claude-sonnet-4-6/--model claude-sonnet-5/' ~/scripts/competitor-monitor-run.sh
+sed -i '' 's/--model claude-sonnet-4-6/--model claude-sonnet-5/' ~/scripts/yield-optimizer-run.sh
+
+# 3. meta_dispatcher — sed ONLY (HOME copy ahead of repo: BZ_REDIS_HOST param), then restart daemon
+sed -i '' 's/"claude-sonnet-4-6"/"claude-sonnet-5"/g' ~/scripts/eventbus/meta_dispatcher.py
+launchctl kickstart -k gui/$(id -u)/com.balizero.meta-dispatcher   # restart, NOT reinstall (W84)
+
+# DO NOT touch: ~/scripts/nb-agents-daily-dr.sh (RISKY slug — stays 4-6, dormant anyway)
+```
+
+Proof-of-armed (probe the work, not the command): next `~/logs/regulatory-watcher.log` run line
+shows `used: claude-sonnet-5`; ig-metrics/competitor/yield logs show the run completing on the
+new model; `~/logs/meta-dispatcher.log` shows spawn lines post-restart.
+
+Also operator-only:
+- **OAuth token hygiene**: during this session an env inventory printed the 3 numbered
+  `CLAUDE_CODE_OAUTH_TOKEN_N` values in cleartext into the LOCAL session transcript
+  (`~/.claude/projects/...`). Exposure = Pro filesystem only, but if you want zero residue:
+  rotate/refresh the tokens in `~/.nuzantara-secrets.env`.
+- **WR3 reflexion stub** (pre-existing Esiste≠Armato, found during inventory): the weekly plist
+  runs an 816-byte placeholder that exits 0 — the full `scripts/wr3_reflexion_synthesis.py`
+  never runs in cron. Decide: promote the real script into the plist target, or accept the
+  firebreak until WR3 S7.5 lands.
+
+## §Meta-pattern (short — Gear 2)
+
+All friction in this task traces to superscar **#1 HOME-fork** (5 of 6 live pins execute from
+`$HOME`, one live copy AHEAD of repo, one live target is a stub the repo version outgrew) and
+**#3 guard-over-match** (my own probe validator false-failed a healthy output on a bold-prefix
+and an apostrophe — substring matching on form, not fact). The migration itself was the easy part.
+
+## Follow-ups recorded in PENDING-ARMS
+
+1. HOME wrapper sync (operator one-liners above) — the actual arming of this migration.
+2. `~/scripts/eventbus/meta_dispatcher.py` reverse-promotion (BZ_REDIS_HOST param → repo).
+3. WR3 reflexion stub-vs-real decision.

--- a/scripts/nb-curator-daily.sh
+++ b/scripts/nb-curator-daily.sh
@@ -171,7 +171,7 @@ if [ "${NB_CURATOR_BRAIN:-agy}" = "agy" ] && [ -x "$AGY_BIN" ]; then
 fi
 if [ -z "$BRAIN_USED" ]; then
     "$HOME/scripts/claude-cascade.sh" "$MODE_PROMPT" \
-        --model claude-sonnet-4-6 \
+        --model claude-sonnet-5 \
         --agent nb-curator \
         > "$TMPOUT" 2>> "$LOG"
     EXIT=$?

--- a/scripts/wr2_html_renderer/claude_vision.py
+++ b/scripts/wr2_html_renderer/claude_vision.py
@@ -219,7 +219,7 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int | No
     # Pin the vision model (default sonnet: vision-capable + solid editorial
     # judgment, lighter/cheaper than opus so it neither burns the MAX-plan quota
     # window nor trips the 120s timeout). Configurable without a code change.
-    model = os.environ.get("WR2_VISION_MODEL", "claude-sonnet-4-6")
+    model = os.environ.get("WR2_VISION_MODEL", "claude-sonnet-5")
     cmd = [
         _CLAUDE_BIN, "--print",
         "--model", model,

--- a/scripts/wr3_reflexion_synthesis.py
+++ b/scripts/wr3_reflexion_synthesis.py
@@ -35,7 +35,7 @@ THE DELTA GATE (Mythos meta-pattern counter-measure, 2026-06-14):
   mistaking green telemetry for learning. status in {SYNTHESIZED, THIN_SIGNAL,
   NO_INPUT, LLM_FAILED}.
 
-Multi-LLM cascade per CLAUDE.md: Tier 1 Sonnet 4.6 (claude -p), Tier 2 Gemini 3.x
+Multi-LLM cascade per CLAUDE.md: Tier 1 Sonnet 5 (claude -p), Tier 2 Gemini 3.x
 (agy) on quota-exhaust. Cost ceiling $0.15/run (contract).
 
 Exit codes: 0 = ran (incl. honest NO_INPUT), 1 = LLM cascade fully failed with
@@ -263,7 +263,7 @@ def _run_tier(tier: str, prompt: str) -> str | None:
     env = os.environ.copy()
     env.pop("ANTHROPIC_API_KEY", None)  # defense-in-depth: never pay-per-token (CLAUDE.md)
     if tier == "claude":
-        cmd = ["claude", "-p", "--model", "claude-sonnet-4-6"]
+        cmd = ["claude", "-p", "--model", "claude-sonnet-5"]
     else:
         cmd = ["agy", "-p", "--print-timeout", "5m"]
     try:


### PR DESCRIPTION
## Summary
Staged migration of cron/agent tier-1 pins `claude-sonnet-4-6` → `claude-sonnet-5`, per CLAUDE.md §5 / modus §Arsenal ("tracked in PENDING-ARMS when started"). Flight session P3, GEAR 2.

- Inventory of EVERY active pin (repo `infra/` + `scripts/` + LaunchAgent wrappers + HOME `~/scripts` read-only) — full table in `research/operations/2026-07-03-sonnet5-cron-migration.md`
- Per-agent REAL prompt-shape probes on both models (18 paired sandboxed 1-shots, no side effects, synthetic non-PII data): **8/9 SAFE**, 1 RISKY (nb-agents slug micro-prompt 3/3 wobble → stays 4-6; consumer has no scheduler)
- Repo pins bumped: regulatory-watcher wrapper, nb-curator fallback tier, meta_dispatcher canva-apply ×2, WR2 vision default (+ its pin test, same commit), wr3 reflexion tier-1, CLAUDE.md §5 line
- PENDING-ARMS ledger: HOME wrapper sync (operator one-liners in the research doc §Solo-operatore), meta_dispatcher reverse-promotion debt (`BZ_REDIS_HOST` — HOME ahead of repo), WR3 reflexion cron runs an 816-byte stub (pre-existing Esiste≠Armato, surfaced during inventory)

## Probe highlights
- **yield-optimizer** S5: R1-R6 applied flawlessly (LKPM Q2 due in 13d caught, R6 honestly not fired, correct owner routing, zero invented names)
- **vision critic** S5: verdicts IDENTICAL to 4-6 on a real slide (passes=false, score=0.15, lever=rerender)
- **ig-metrics** S5: self-identified the domain/layout confound in the sample — better statistical honesty
- **slug** S5: 7 tokens vs "max 6", meta/context leaks (3/3) → RISKY, kept on 4-6

## Live-arming note
No plist reinstalls (W84/TCC). LIVE cron executes HOME copies until the operator applies the exact diffs in the research doc; proof-of-armed = `used: claude-sonnet-5` in the next wrapper logs.

## Verify
- 112 pytest pass (`test_wr2_html_render_apply.py` full module)
- `py_compile` + `zsh -n` green on all edited scripts
- zero residual `claude-sonnet-4-6` in edited scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)