### PR TITLE
fix(organism): federation alert dispatcher — restore the lost heartbeat writer

### DIFF
--- a/apps/backend-rag/backend/scripts/federation_alert_daemon.py
+++ b/apps/backend-rag/backend/scripts/federation_alert_daemon.py
@@ -15,11 +15,42 @@ mode=observe, dispatch unavailable → no actions, replay on boot.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import logging
 import os
 import sys
+import threading
+import time
+from pathlib import Path
 
 from backend.services.federation_alerts import FADConfig, FederationAlertDaemon
+
+ORGAN_ID = "pro.federation_alert_dispatcher"
+
+
+def _load_organism_heartbeat():
+    """Load scripts/lib/heartbeat.py (repo-root sidecar SSOT) if present.
+
+    The daemon runs on Pro from the repo checkout; on Fly or in tests the
+    lib may be absent — heartbeat degrades to a no-op, never a crash.
+    """
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "scripts" / "lib" / "heartbeat.py"
+        if not candidate.exists():
+            continue
+        spec = importlib.util.spec_from_file_location("nuzantara_heartbeat", candidate)
+        if spec and spec.loader:
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module.organism_heartbeat
+
+    def _noop(*_args, **_kwargs) -> bool:
+        return False
+
+    return _noop
+
+
+organism_heartbeat = _load_organism_heartbeat()
 
 
 def _configure_logging() -> None:
@@ -31,12 +62,25 @@ def _configure_logging() -> None:
     )
 
 
+def _start_heartbeat_thread(interval_s: int = 60) -> None:
+    def _loop() -> None:
+        while True:
+            organism_heartbeat(ORGAN_ID, "ok", "federation alert dispatcher running")
+            time.sleep(interval_s)
+
+    thread = threading.Thread(target=_loop, name="federation-alert-heartbeat", daemon=True)
+    thread.start()
+
+
 async def _main() -> int:
     _configure_logging()
     config = FADConfig.from_env()
     config.assert_required()
     daemon = FederationAlertDaemon(config)
+    organism_heartbeat(ORGAN_ID, "starting", "daemon configured")
+    _start_heartbeat_thread()
     await daemon.start()
+    organism_heartbeat(ORGAN_ID, "ok", "daemon stopped cleanly")
     return 0
 
 
@@ -44,7 +88,11 @@ def main() -> int:
     try:
         return asyncio.run(_main())
     except KeyboardInterrupt:
+        organism_heartbeat(ORGAN_ID, "ok", "keyboard interrupt")
         return 0
+    except Exception as exc:
+        organism_heartbeat(ORGAN_ID, "error", f"{type(exc).__name__}: {exc}")
+        raise
 
 
 if __name__ == "__main__":

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: 6e2e50f189622a4e21a1adf3703752243f2a7e860d32762da38bd23325fce16a
+checksum: b036f58565ac01a47326e48228124a7d1eda0fbe4d0aa058029af23f1b8720f3
 organs:
 - id: infra.postgres
   runtime: fly_machine

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -975,7 +975,7 @@ organs:
   runtime: pro_launchd
   type: daemon
   expected_hb_seconds: 180
-  owner_module: scripts/federation-alert-dispatcher.sh
+  owner_module: apps/backend-rag/backend/scripts/federation_alert_daemon.py
   dependencies: []
   recovery_action: launchctl_kickstart
   recovery_params:


### PR DESCRIPTION
## Root cause
`pro.federation_alert_dispatcher` sidecar froze 2026-06-09 with `status=ok` — the classic green-that-lies (cicatrix #2). Diagnosis on Pro: the daemon **is alive** under launchd (`com.nuzantara.federation-alert-dispatcher`, running since Jul 1), but the code on main **never contained a heartbeat writer**. The writer exists only in the M5 rescue snapshot `74b8af953` (2026-06-07, wip branch, NOT an ancestor of main): the cure was built and never merged — **W81 (built ≠ armed) at code level**.

## What
- Port the field-proven heartbeat hunk: daemon thread writes the sidecar every 60s via `scripts/lib/heartbeat.py` (sidecar-format SSOT, dynamically loaded, no-op where absent — Fly/tests).
- Fix registry drift: `owner_module` pointed to `scripts/federation-alert-dispatcher.sh` (nonexistent) → real module path.

## Probe (executed)
```
ORGANISM_LAST_SEEN_DIR=<scratch> PYTHONPATH=. python -c "from backend.scripts.federation_alert_daemon import organism_heartbeat, ORGAN_ID; ..."
→ write returned: True, file exists: True, content: {"ts":"2026-07-02T07:36:20Z","status":"ok","note":"probe from TAC session"}
```

## Arming (Pro, tracked in PENDING-ARMS + TAC)
The daemon runs from the MAIN checkout (`~/Desktop/nuzantara/apps/backend-rag`). Post-merge it arms at the next `git pull` + daemon restart (operator item — no launchd ops from this session; PENDING-ALIGN:Pro currently blocks the pull on a sibling's untracked file). KeepAlive crash-cycles also pick it up opportunistically.

Part of the heartbeat-organs TAC: `research/operations/2026-07-03-heartbeat-organs-tac.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)