### PR TITLE
feat(wr2): outcome-based watchdog probes — C1 (stale lease / state age / manifest gap / weekly silent)

### DIFF
--- a/scripts/tests/test_wr2_supervisor_watchdog.py
+++ b/scripts/tests/test_wr2_supervisor_watchdog.py
@@ -1,14 +1,19 @@
-"""Unit tests for scripts/wr2_supervisor_watchdog.py (Sprint B B3).
+"""Unit tests for scripts/wr2_supervisor_watchdog.py (Sprint B B3 + C1 outcome probes).
 
 Covers:
 - Cooldown semantics (first stale fires, subsequent stale within 24h
   suppress, after 24h fires again).
-- 7-day rolling success-rate computation from telemetry JSONL.
+- 7-day rolling success-rate computation, DB-derived (P-1 S10b re-key —
+  the old telemetry-JSONL tests rotted silently when the module moved to
+  _probe_success_rate_db; rewritten 2026-07-02 with the C1 PR).
 - Tiered alert evaluation (P0 supervisor-down / P0 pipeline-frozen /
-  P1 success-rate-low) given DB + telemetry stubs.
+  P1 success-rate-low) given DB stubs that dispatch BY QUERY CONTENT,
+  not by call order (order-pinned mocks broke on every new probe).
 - Degrade-open behavior when wr2_supervisor_heartbeat is missing.
+- C1 outcome probes (stale lease / state age / manifest gap / weekly
+  silent): innocence AND guilt per probe (cicatrix #3).
 
-DB calls are mocked. No network, no Telegram POST.
+DB calls are mocked. No network, no Telegram POST, no Drive.
 """
 from __future__ import annotations
 
@@ -36,7 +41,6 @@ def wd(tmp_path, monkeypatch):
     spec.loader.exec_module(mod)
     # Redirect persistent paths into the tmp sandbox.
     mod.STATE_PATH = tmp_path / "state.txt"
-    mod.TELEMETRY_PATH = tmp_path / "telemetry.jsonl"
     return mod
 
 
@@ -75,68 +79,74 @@ def test_alert_due_after_cooldown(wd):
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# 7-day success rate from telemetry JSONL
+# 7-day success rate, DB-derived (P-1 S10b)
 # ─────────────────────────────────────────────────────────────────────────
 
-def _write_telemetry(path: Path, rows: list[dict]) -> None:
-    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
-
-
-def test_success_rate_empty_file_returns_100pct(wd):
-    """Empty/missing telemetry → degrade-open (no false alert)."""
-    sr = wd._probe_success_rate_telemetry()
-    assert sr["attempted"] == 0
-    assert sr["rate_pct"] == 100.0
-
-
-def test_success_rate_counts_only_window(wd):
-    """Rows older than 7 days are excluded; only fresh rows count."""
-    from datetime import datetime, timedelta, timezone
-    now = datetime.now(timezone.utc)
-    rows = [
-        # 10 days ago — excluded
-        {"ts": (now - timedelta(days=10)).isoformat(), "outcome": "success"},
-        # Last week — included
-        {"ts": (now - timedelta(days=2)).isoformat(), "outcome": "success"},
-        {"ts": (now - timedelta(days=1)).isoformat(), "outcome": "other"},
-    ]
-    _write_telemetry(wd.TELEMETRY_PATH, rows)
-    sr = wd._probe_success_rate_telemetry()
-    assert sr["attempted"] == 2
-    assert sr["succeeded"] == 1
-    assert sr["rate_pct"] == 50.0
-
-
-def test_success_rate_handles_malformed_lines(wd):
-    """Garbage lines + missing ts/outcome are silently skipped."""
-    from datetime import datetime, timezone
-    now = datetime.now(timezone.utc)
-    path = wd.TELEMETRY_PATH
-    path.write_text(
-        "not json at all\n"
-        '{"no_ts": "skipped"}\n'
-        f'{{"ts": "{now.isoformat()}", "outcome": "success"}}\n'
-        f'{{"ts": "{now.isoformat()}", "outcome": "other"}}\n'
-        "\n"  # blank line
-    )
-    sr = wd._probe_success_rate_telemetry()
-    assert sr["attempted"] == 2
-    assert sr["succeeded"] == 1
-    assert sr["rate_pct"] == 50.0
-
-
-# ─────────────────────────────────────────────────────────────────────────
-# evaluate_once tiered alerts
-# ─────────────────────────────────────────────────────────────────────────
-
-def _make_conn(heartbeat_age, oldest_pending_hours, rendered_recent):
-    """Build a mock asyncpg.Connection with the 3 fetchval responses."""
+def test_success_rate_db_no_data_never_reads_healthy(wd):
+    """0 attempts in the window → no_data=True, rate None — NEVER a 100%
+    (the old telemetry probe's degrade-open 100% went permanently blind)."""
     conn = MagicMock()
-    conn.fetchval = AsyncMock(side_effect=[
-        heartbeat_age,
-        oldest_pending_hours,
-        rendered_recent,
-    ])
+    conn.fetchrow = AsyncMock(return_value={"attempted": 0, "succeeded": 0})
+    sr = asyncio.run(wd._probe_success_rate_db(conn))
+    assert sr["no_data"] is True
+    assert sr["rate_pct"] is None
+
+
+def test_success_rate_db_computes_rate(wd):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"attempted": 4, "succeeded": 2})
+    sr = asyncio.run(wd._probe_success_rate_db(conn))
+    assert sr["no_data"] is False
+    assert sr["rate_pct"] == 50.0
+    assert sr["attempted"] == 4
+
+
+def test_success_rate_db_null_row_is_no_data(wd):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    sr = asyncio.run(wd._probe_success_rate_db(conn))
+    assert sr["no_data"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# evaluate_once tiered alerts — DB stub dispatches by QUERY CONTENT
+# ─────────────────────────────────────────────────────────────────────────
+
+def _make_conn(
+    heartbeat_age=10.0,
+    renderer_enabled=True,
+    oldest_pending_hours=0.1,
+    rendered_recent=3,
+    attempted=5,
+    succeeded=5,
+    ledger_gap=0,
+):
+    """Mock asyncpg.Connection whose fetchval/fetchrow answer by matching the
+    query text — immune to probe-order changes (the old order-pinned
+    side_effect list silently fed the renderer-flag probe a float and
+    disabled half the checks; 2026-07-02)."""
+    conn = MagicMock()
+
+    async def fetchval(query, *args):
+        q = " ".join(query.split())
+        if "wr2_supervisor_heartbeat" in q:
+            return heartbeat_age
+        if "system_settings" in q:
+            return "true" if renderer_enabled else "false"
+        if "MIN(updated_at)" in q:
+            return oldest_pending_hours
+        if "topic_type_log" in q:
+            return ledger_gap
+        if "status = 'rendered'" in q and "COUNT(*)" in q:
+            return rendered_recent
+        raise AssertionError(f"unmocked fetchval: {q[:120]}")
+
+    async def fetchrow(query, *args):
+        return {"attempted": attempted, "succeeded": succeeded}
+
+    conn.fetchval = MagicMock(side_effect=fetchval)
+    conn.fetchrow = MagicMock(side_effect=fetchrow)
+    conn.fetch = AsyncMock(return_value=[])
     return conn
 
 
@@ -183,15 +193,7 @@ def test_evaluate_pipeline_frozen_requires_both_conditions(wd):
 
 def test_evaluate_p1_success_rate_below_threshold(wd):
     """Success rate < 80% over 7d (with ≥5 attempts) fires P1."""
-    from datetime import datetime, timezone
-    now = datetime.now(timezone.utc)
-    rows = (
-        # 6 attempts, 4 success → 66.7% (< 80%)
-        [{"ts": now.isoformat(), "outcome": "success"} for _ in range(4)]
-        + [{"ts": now.isoformat(), "outcome": "other"} for _ in range(2)]
-    )
-    _write_telemetry(wd.TELEMETRY_PATH, rows)
-    conn = _make_conn(heartbeat_age=10, oldest_pending_hours=0.1, rendered_recent=3)
+    conn = _make_conn(attempted=6, succeeded=4)  # 66.7% < 80%
     sent: list[str] = []
     with patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
         asyncio.run(wd._evaluate_once(conn))
@@ -201,11 +203,7 @@ def test_evaluate_p1_success_rate_below_threshold(wd):
 def test_evaluate_p1_silent_with_min_attempts_below_threshold(wd):
     """Below MIN_ATTEMPTS=5, the rate is too noisy — stay quiet even
     if rate looks bad (e.g. 0/1 = 0%)."""
-    from datetime import datetime, timezone
-    now = datetime.now(timezone.utc)
-    rows = [{"ts": now.isoformat(), "outcome": "other"}]
-    _write_telemetry(wd.TELEMETRY_PATH, rows)
-    conn = _make_conn(heartbeat_age=10, oldest_pending_hours=0.1, rendered_recent=3)
+    conn = _make_conn(attempted=1, succeeded=0)
     sent: list[str] = []
     with patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
         asyncio.run(wd._evaluate_once(conn))
@@ -215,11 +213,7 @@ def test_evaluate_p1_silent_with_min_attempts_below_threshold(wd):
 def test_evaluate_silent_when_all_healthy(wd):
     """Heartbeat fresh, pipeline ok, success rate above threshold → no
     Telegram POST and no state mutation."""
-    from datetime import datetime, timezone
-    now = datetime.now(timezone.utc)
-    rows = [{"ts": now.isoformat(), "outcome": "success"} for _ in range(5)]
-    _write_telemetry(wd.TELEMETRY_PATH, rows)
-    conn = _make_conn(heartbeat_age=30, oldest_pending_hours=0.1, rendered_recent=3)
+    conn = _make_conn()
     sent: list[str] = []
     with patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
         asyncio.run(wd._evaluate_once(conn))
@@ -232,14 +226,15 @@ def test_evaluate_silent_when_all_healthy(wd):
 def test_evaluate_degrades_open_on_missing_heartbeat_table(wd):
     """If wr2_supervisor_heartbeat does not exist (migration 161 not yet
     applied), _probe_heartbeat_age returns None → no false P0 alert."""
-    conn = MagicMock()
-    # First call (heartbeat probe) raises UndefinedTableError; subsequent
-    # calls (pipeline) return safe values.
-    conn.fetchval = AsyncMock(side_effect=[
-        asyncpg.UndefinedTableError("relation does not exist"),
-        0.1,  # oldest_pending_hours
-        3,  # rendered_recent
-    ])
+    conn = _make_conn()
+    inner = conn.fetchval.side_effect
+
+    async def fetchval(query, *args):
+        if "wr2_supervisor_heartbeat" in query:
+            raise asyncpg.UndefinedTableError("relation does not exist")
+        return await inner(query, *args)
+
+    conn.fetchval = MagicMock(side_effect=fetchval)
     sent: list[str] = []
     with patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
         asyncio.run(wd._evaluate_once(conn))
@@ -298,3 +293,217 @@ def test_send_telegram_no_plain_retry_on_non_400(wd, monkeypatch):
         wd._send_telegram("hello")  # must not raise
 
     assert len(calls) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# C1 outcome probes — innocence AND guilt per probe (cicatrix #3)
+# ─────────────────────────────────────────────────────────────────────────
+
+def _make_outcome_conn(stale_rows=(), age_rows=(), rendered_rows=(), renderer_enabled=True):
+    """Mock conn for _evaluate_outcome_probes — dispatches by query text."""
+    conn = MagicMock()
+
+    async def fetch(query, *args):
+        q = " ".join(query.split())
+        if "lease_heartbeat_at" in q and "'rendering'" in q:
+            return list(stale_rows)
+        if "GROUP BY status" in q:
+            return list(age_rows)
+        if "drive_url IS NOT NULL" in q:
+            return list(rendered_rows)
+        raise AssertionError(f"unmocked fetch: {q[:120]}")
+
+    async def fetchval(query, *args):
+        if "system_settings" in query:
+            return "true" if renderer_enabled else "false"
+        raise AssertionError(f"unmocked fetchval: {query[:120]}")
+
+    conn.fetch = MagicMock(side_effect=fetch)
+    conn.fetchval = MagicMock(side_effect=fetchval)
+    return conn
+
+
+def _run_outcome(wd, conn):
+    """Run _evaluate_outcome_probes with reflexion pinned healthy (its own
+    tests exercise the real file) and Telegram captured."""
+    sent: list[str] = []
+    with patch.object(wd, "_probe_reflexion_age", lambda: ("ok", 1.0)), \
+         patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
+        asyncio.run(wd._evaluate_outcome_probes(conn))
+    return sent
+
+
+def test_stale_lease_fires_on_dead_heartbeat(wd):
+    conn = _make_outcome_conn(stale_rows=[
+        {"draft_id": "d1", "lease_owner": "html-apply-1-ab", "hb_age_sec": 1200.0, "held_sec": 1300.0},
+    ])
+    sent = _run_outcome(wd, conn)
+    assert any("stale render lease" in m for m in sent)
+    assert wd._state_get("last_alert_stale_lease") is not None
+
+
+def test_stale_lease_innocent_when_no_rows(wd):
+    sent = _run_outcome(wd, _make_outcome_conn())
+    assert sent == []
+
+
+def test_state_age_fires_over_threshold(wd):
+    conn = _make_outcome_conn(age_rows=[
+        {"status": "drafts", "n": 2, "oldest_hours": 7.5},
+    ])
+    sent = _run_outcome(wd, conn)
+    assert any("state-age" in m and "`drafts`" in m for m in sent)
+
+
+def test_state_age_innocent_under_threshold(wd):
+    conn = _make_outcome_conn(age_rows=[
+        {"status": "drafts", "n": 2, "oldest_hours": 1.0},
+    ])
+    assert _run_outcome(wd, conn) == []
+
+
+def test_state_age_unknown_state_always_flagged(wd):
+    """A status outside the known machine is drift (cicatrix #9) — flagged
+    even when young."""
+    conn = _make_outcome_conn(age_rows=[
+        {"status": "briefed_facted", "n": 1, "oldest_hours": 0.1},
+    ])
+    sent = _run_outcome(wd, conn)
+    assert any("UNKNOWN states" in m for m in sent)
+
+
+def test_state_age_checked_backlog_expected_when_renderer_off(wd):
+    """Kill-switched renderer (W46): drafts_imaged_checked backlog is by
+    design — no alert."""
+    conn = _make_outcome_conn(
+        age_rows=[{"status": "drafts_imaged_checked", "n": 5, "oldest_hours": 48.0}],
+        renderer_enabled=False,
+    )
+    assert _run_outcome(wd, conn) == []
+
+
+def test_extract_folder_id():
+    sys.modules.pop("wr2_supervisor_watchdog", None)
+    spec = importlib.util.spec_from_file_location("wr2_supervisor_watchdog", WATCHDOG_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    ok = mod._extract_folder_id("https://drive.google.com/drive/folders/1aB_c-9?usp=drive_link")
+    assert ok == "1aB_c-9"
+    assert mod._extract_folder_id("https://drive.google.com/file/d/xyz/view") is None
+    assert mod._extract_folder_id("") is None
+
+
+def test_manifest_probe_kill_switch_skips(wd):
+    wd.MANIFEST_PROBE_ENABLED = False
+    conn = _make_outcome_conn(rendered_rows=[{"draft_id": "dX", "drive_url": "u"}])
+    result = asyncio.run(wd._probe_manifest_gaps(conn))
+    assert result is None
+
+
+def test_manifest_probe_throttles_within_interval(wd):
+    conn = _make_outcome_conn()
+    first = asyncio.run(wd._probe_manifest_gaps(conn))
+    second = asyncio.run(wd._probe_manifest_gaps(conn))
+    assert first is not None
+    assert second is None  # hourly throttle
+
+
+def test_manifest_gap_fires_when_manifest_missing(wd):
+    conn = _make_outcome_conn(rendered_rows=[
+        {"draft_id": "d7", "drive_url": "https://drive.google.com/drive/folders/FOLD7"},
+    ])
+    with patch.object(wd, "_drive_list_names_sync", lambda fid: {"01.png", "02.png"}):
+        sent = _run_outcome(wd, conn)
+    assert any("rendered-without-manifest" in m and "d7" in m for m in sent)
+
+
+def test_manifest_innocent_when_manifest_present(wd):
+    conn = _make_outcome_conn(rendered_rows=[
+        {"draft_id": "d8", "drive_url": "https://drive.google.com/drive/folders/FOLD8"},
+    ])
+    with patch.object(wd, "_drive_list_names_sync", lambda fid: {"01.png", "manifest.json"}):
+        sent = _run_outcome(wd, conn)
+    assert sent == []
+    assert (wd._state_get("manifest_probe_fail_streak") or 0) == 0
+
+
+def test_manifest_unparseable_url_reported_not_skipped(wd):
+    conn = _make_outcome_conn(rendered_rows=[
+        {"draft_id": "d9", "drive_url": "https://example.com/not-a-folder"},
+    ])
+    sent = _run_outcome(wd, conn)
+    assert any("unparseable" in m and "d9" in m for m in sent)
+
+
+def test_manifest_drive_failure_degrades_open_but_counts_streak(wd):
+    conn = _make_outcome_conn(rendered_rows=[
+        {"draft_id": "dA", "drive_url": "https://drive.google.com/drive/folders/FOLDA"},
+    ])
+
+    def boom(fid):
+        raise RuntimeError("Drive down")
+
+    with patch.object(wd, "_drive_list_names_sync", boom):
+        sent = _run_outcome(wd, conn)
+    assert sent == []  # degrade-open: no false gap alert
+    assert wd._state_get("manifest_probe_fail_streak") == 1
+
+
+def test_manifest_probe_broken_fires_at_streak_threshold(wd):
+    wd._state_set("manifest_probe_fail_streak", wd.MANIFEST_FAIL_STREAK - 1)
+    conn = _make_outcome_conn(rendered_rows=[
+        {"draft_id": "dB", "drive_url": "https://drive.google.com/drive/folders/FOLDB"},
+    ])
+
+    def boom(fid):
+        raise RuntimeError("Drive down")
+
+    with patch.object(wd, "_drive_list_names_sync", boom):
+        sent = _run_outcome(wd, conn)
+    assert any("manifest probe BROKEN" in m for m in sent)
+
+
+def test_reflexion_missing_file_is_alert_state(wd, tmp_path, monkeypatch):
+    """Missing ledger = the never-armed weekly cron (W81) — alert, not skip."""
+    monkeypatch.setenv("WR2_SKILL_DIR", str(tmp_path / "nowhere"))
+    state, age = wd._probe_reflexion_age()
+    assert state == "missing"
+    assert age is None
+
+
+def test_reflexion_fresh_run_ok(wd, tmp_path, monkeypatch):
+    from datetime import datetime, timezone
+    monkeypatch.setenv("WR2_SKILL_DIR", str(tmp_path))
+    (tmp_path / "_reflexion-state.json").write_text(json.dumps([
+        {"run_at": datetime.now(timezone.utc).isoformat(), "loop": "wr2", "status": "NO_INPUT"},
+    ]))
+    state, age = wd._probe_reflexion_age()
+    assert state == "ok"
+    assert age is not None and age < 1
+
+
+def test_reflexion_stale_run_flagged(wd, tmp_path, monkeypatch):
+    from datetime import datetime, timedelta, timezone
+    monkeypatch.setenv("WR2_SKILL_DIR", str(tmp_path))
+    (tmp_path / "_reflexion-state.json").write_text(json.dumps([
+        {"run_at": (datetime.now(timezone.utc) - timedelta(days=12)).isoformat(), "loop": "wr2"},
+    ]))
+    state, age = wd._probe_reflexion_age()
+    assert state == "stale"
+    assert age > 8
+
+
+def test_reflexion_malformed_ledger_flagged(wd, tmp_path, monkeypatch):
+    monkeypatch.setenv("WR2_SKILL_DIR", str(tmp_path))
+    (tmp_path / "_reflexion-state.json").write_text("{not json")
+    state, _age = wd._probe_reflexion_age()
+    assert state == "malformed"
+
+
+def test_weekly_silent_alert_via_evaluate(wd, tmp_path, monkeypatch):
+    monkeypatch.setenv("WR2_SKILL_DIR", str(tmp_path / "nowhere"))
+    conn = _make_outcome_conn()
+    sent: list[str] = []
+    with patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
+        asyncio.run(wd._evaluate_outcome_probes(conn))
+    assert any("weekly reflexion SILENT" in m and "MISSING" in m for m in sent)

--- a/scripts/wr2_supervisor_watchdog.py
+++ b/scripts/wr2_supervisor_watchdog.py
@@ -37,6 +37,42 @@ Cooldown:
       no `topic_type_log` row — the anti-sameness ledger write (best-effort
       in wr2_html_render_apply) silently failed. Closes spec metric M2.
 
+Outcome probes (C1, next-level plan 2026-06-30 — cicatrix #2 "launchd è
+trasporto, non verità"; all READ-ONLY, run right after _evaluate_once):
+
+  P1 STALE_LEASE
+      'rendering' rows whose lease heartbeat went silent (>15min; a live
+      worker renews every 60s) OR held longer than the max render window
+      (>90min — the heartbeat task can keep ticking while the main path
+      hangs on Drive, so heartbeat alone is not health). NULL-safe via
+      COALESCE(lease_heartbeat_at, lease_acquired_at, updated_at):
+      lease_heartbeat_at is nullable (migration 222).
+
+  P2 STATE_AGE
+      Oldest row per NON-terminal state older than threshold (default 6h)
+      — catches ONE stuck stage while the rest of the pipeline flows
+      (pipeline_frozen needs a global zero-render 24h). 'rendering' is
+      excluded (covered by STALE_LEASE: its updated_at is heartbeat-touched).
+      UNKNOWN states (not in the known machine) are always flagged — the
+      state-machine-drift detector (cicatrix #9). When the renderer kill
+      switch is OFF, 'drafts_imaged_checked' backlog is expected (W46) and
+      is not flagged.
+
+  P2 MANIFEST_GAP (hourly throttle, LIMIT 10, 48h window)
+      Drafts at 'rendered' whose Drive folder lacks the C0 manifest.json
+      (PR #1892 writes it under the lease — absence = anomaly). Uses the
+      renderer's own SA-DWD service lazily; every Drive/import failure
+      degrades OPEN (log, no false alert) BUT feeds a fail-streak counter:
+      ≥24 consecutive failed sweeps (≈1 day) fire MANIFEST_PROBE_BROKEN so
+      the probe cannot rot silently (red-team 2026-07-02 finding #5).
+      An unparseable drive_url (no /folders/<id>) is reported as an anomaly.
+
+  P2 WEEKLY_SILENT
+      The WR2 reflexion Delta-Gate ledger (_reflexion-state.json, written
+      by scripts/lib/reflexion.record_run) has no run newer than 8 days —
+      OR the file is missing/malformed. Missing is an ALERT, not a skip:
+      the never-armed cron is exactly the W81 disease this probe hunts.
+
 Dependencies:
   - `wr2_supervisor_heartbeat` table (migration 161)
   - `war_room_drafts` (status, updated_at, drive_url)
@@ -55,8 +91,10 @@ rate = DB-derived over war_room_drafts (0 attempts → NO-DATA, never 100%).
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+import re
 import signal
 import sys
 import urllib.error
@@ -81,6 +119,36 @@ RENDERED_24H_HOURS = float(os.environ.get("WR2_WATCHDOG_RENDERED_HOURS", "24"))
 SUCCESS_WINDOW_DAYS = int(os.environ.get("WR2_WATCHDOG_SUCCESS_WINDOW_DAYS", "7"))
 SUCCESS_THRESHOLD_PCT = float(os.environ.get("WR2_WATCHDOG_SUCCESS_THRESHOLD_PCT", "80"))
 ALERT_COOLDOWN_SEC = int(os.environ.get("WR2_WATCHDOG_ALERT_COOLDOWN_SEC", "86400"))  # 24h
+
+# ── C1 outcome-probe tunables ────────────────────────────────────────────
+LEASE_STALE_MIN = float(os.environ.get("WR2_WATCHDOG_LEASE_STALE_MIN", "15"))
+LEASE_MAX_HELD_MIN = float(os.environ.get("WR2_WATCHDOG_LEASE_MAX_HELD_MIN", "90"))
+STATE_AGE_HOURS = float(os.environ.get("WR2_WATCHDOG_STATE_AGE_HOURS", "6"))
+MANIFEST_PROBE_ENABLED = os.environ.get("WR2_WATCHDOG_MANIFEST_PROBE", "1") != "0"
+MANIFEST_PROBE_INTERVAL_SEC = int(
+    os.environ.get("WR2_WATCHDOG_MANIFEST_PROBE_INTERVAL_SEC", "3600")
+)
+MANIFEST_FAIL_STREAK = int(os.environ.get("WR2_WATCHDOG_MANIFEST_FAIL_STREAK", "24"))
+REFLEXION_STALE_DAYS = float(os.environ.get("WR2_WATCHDOG_REFLEXION_STALE_DAYS", "8"))
+
+# Live state machine (cf. wr2_supervisor.NONTERMINAL_TO_NEXT_STAGE — the dead
+# 'briefed_facted' was removed by P-1 2026-06-11; keeping the lists aligned by
+# ENTITY, not by copy-paste of the old probe's hardcoded set).
+KNOWN_NONTERMINAL_STATUSES = (
+    "briefed",
+    "drafts",
+    "drafts_imaged",
+    "drafts_imaged_facted",
+    "drafts_imaged_checked",
+)
+TERMINAL_STATUSES = (
+    "rendered",
+    "rendered_shadow",
+    "render_failed",
+    "fact_check_failed",
+    "image_failed",
+    "rejected",
+)
 
 STATE_PATH = Path.home() / ".agent" / "decisions" / "state" / "wr2_supervisor_watchdog.state"
 # Ledger-gap probe lower bound: only drafts rendered AFTER S1 shipped count as
@@ -354,6 +422,320 @@ async def _probe_ledger_gap(conn: asyncpg.Connection) -> int:
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# C1 outcome probes (read-only — the watchdog reads the WORK, not the exit code)
+# ─────────────────────────────────────────────────────────────────────────
+
+async def _probe_stale_leases(conn: asyncpg.Connection) -> list[dict[str, Any]]:
+    """'rendering' rows whose lease looks dead OR held past the max render window.
+
+    Two independent conditions (red-team 2026-07-02 finding #1 — "heartbeat is
+    not health": the heartbeat task can keep renewing while the main path hangs):
+      a) heartbeat silent  > LEASE_STALE_MIN  (live worker renews every ~60s)
+      b) lease held        > LEASE_MAX_HELD_MIN (renders take ~13-22min)
+    NULL-safe: lease_heartbeat_at is nullable (migration 222), so COALESCE down
+    to lease_acquired_at then updated_at — a NULL chain must never hide a row.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT id::text AS draft_id,
+               lease_owner,
+               EXTRACT(EPOCH FROM (NOW() - COALESCE(lease_heartbeat_at, lease_acquired_at, updated_at))) AS hb_age_sec,
+               EXTRACT(EPOCH FROM (NOW() - COALESCE(lease_acquired_at, updated_at))) AS held_sec
+          FROM war_room_drafts
+         WHERE status = 'rendering'
+           AND (
+                COALESCE(lease_heartbeat_at, lease_acquired_at, updated_at) < NOW() - $1::interval
+             OR COALESCE(lease_acquired_at, updated_at) < NOW() - $2::interval
+           )
+        """,
+        timedelta(minutes=LEASE_STALE_MIN),
+        timedelta(minutes=LEASE_MAX_HELD_MIN),
+    )
+    return [dict(r) for r in rows]
+
+
+async def _probe_state_ages(
+    conn: asyncpg.Connection, *, renderer_enabled: bool
+) -> dict[str, list[dict[str, Any]]]:
+    """Per-state oldest-row age for every non-terminal state (except 'rendering').
+
+    Returns {"over": [...], "unknown": [...]}:
+      over    — KNOWN non-terminal states whose oldest row exceeds STATE_AGE_HOURS.
+                When the renderer kill switch is OFF, 'drafts_imaged_checked'
+                backlog is by design (W46) and is not flagged.
+      unknown — states outside the known machine (terminal ∪ non-terminal ∪
+                'rendering'): always flagged, whatever their age — a state
+                appearing here means the state machine drifted (cicatrix #9).
+    'rendering' is excluded: its updated_at is touched by every heartbeat, so
+    age-by-updated_at would lie (red-team finding #4); STALE_LEASE covers it.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT status,
+               COUNT(*) AS n,
+               EXTRACT(EPOCH FROM (NOW() - MIN(updated_at))) / 3600.0 AS oldest_hours
+          FROM war_room_drafts
+         WHERE status <> ALL($1::text[])
+         GROUP BY status
+        """,
+        list(TERMINAL_STATUSES) + ["rendering"],
+    )
+    over: list[dict[str, Any]] = []
+    unknown: list[dict[str, Any]] = []
+    for r in rows:
+        entry = {
+            "status": r["status"],
+            "n": int(r["n"]),
+            "oldest_hours": float(r["oldest_hours"] or 0.0),
+        }
+        if r["status"] not in KNOWN_NONTERMINAL_STATUSES:
+            unknown.append(entry)
+            continue
+        if not renderer_enabled and r["status"] == "drafts_imaged_checked":
+            continue  # backlog while kill-switched OFF is the expected state (W46)
+        if entry["oldest_hours"] > STATE_AGE_HOURS:
+            over.append(entry)
+    return {"over": over, "unknown": unknown}
+
+
+_FOLDER_ID_RE = re.compile(r"/folders/([A-Za-z0-9_-]+)")
+
+
+def _extract_folder_id(drive_url: str) -> str | None:
+    """Folder id from a Drive folder webViewLink; None when the URL has no
+    /folders/<id> segment (anomaly — reported, never silently skipped)."""
+    m = _FOLDER_ID_RE.search(drive_url or "")
+    return m.group(1) if m else None
+
+
+def _drive_list_names_sync(folder_id: str) -> set[str]:
+    """Names of every non-trashed child of a Drive folder.
+
+    Mirrors the renderer's own listing shape (supportsAllDrives +
+    includeItemsFromAllDrives — red-team finding #6: omitting either turns
+    shared-drive folders into phantom-empty). Lazy imports so the watchdog
+    stays asyncpg-only when the probe is disabled; runs in a thread.
+    """
+    repo = Path(__file__).resolve().parents[1]
+    backend_root = str(repo / "apps" / "backend-rag")
+    if backend_root not in sys.path:
+        sys.path.insert(0, backend_root)
+    from backend.services.integrations.service_account_drive_service import (  # noqa: PLC0415
+        ServiceAccountDriveService,
+    )
+
+    svc = ServiceAccountDriveService()
+    names: set[str] = set()
+    page_token: str | None = None
+    while True:
+        res = (
+            svc.service.files()
+            .list(
+                q=f"'{folder_id}' in parents and trashed = false",
+                fields="nextPageToken, files(name)",
+                supportsAllDrives=True,
+                includeItemsFromAllDrives=True,
+                pageSize=1000,
+                pageToken=page_token,
+            )
+            .execute()
+        )
+        names.update(f.get("name", "") for f in res.get("files", []))
+        page_token = res.get("nextPageToken")
+        if not page_token:
+            return names
+
+
+async def _probe_manifest_gaps(conn: asyncpg.Connection) -> dict[str, Any] | None:
+    """C0-manifest presence sweep over recently rendered drafts.
+
+    Returns None when skipped (kill switch or hourly throttle not elapsed),
+    else {"missing": [draft_ids], "unparseable": [draft_ids], "checked": n}.
+    Per-draft Drive failures degrade OPEN (a Drive hiccup must not cry wolf)
+    but feed the manifest_probe_fail_streak counter so a probe broken for
+    ≥MANIFEST_FAIL_STREAK consecutive sweeps raises its own alert instead of
+    rotting silently (red-team finding #5).
+    """
+    if not MANIFEST_PROBE_ENABLED:
+        return None
+    now_epoch = int(datetime.now(timezone.utc).timestamp())
+    last = _state_get("last_probe_manifest")
+    if last is not None and (now_epoch - last) < MANIFEST_PROBE_INTERVAL_SEC:
+        return None
+    _state_set("last_probe_manifest", now_epoch)
+
+    rows = await conn.fetch(
+        """
+        SELECT id::text AS draft_id, drive_url
+          FROM war_room_drafts
+         WHERE status = 'rendered'
+           AND drive_url IS NOT NULL
+           AND updated_at > NOW() - INTERVAL '48 hours'
+         ORDER BY updated_at DESC
+         LIMIT 10
+        """
+    )
+    missing: list[str] = []
+    unparseable: list[str] = []
+    probe_failed = False
+    for r in rows:
+        folder_id = _extract_folder_id(r["drive_url"])
+        if folder_id is None:
+            unparseable.append(r["draft_id"])
+            continue
+        try:
+            names = await asyncio.to_thread(_drive_list_names_sync, folder_id)
+        except Exception as e:  # noqa: BLE001 — degrade-open, streak-counted
+            logger.warning("manifest probe: Drive listing failed for %s: %s", r["draft_id"], e)
+            probe_failed = True
+            continue
+        if "manifest.json" not in names:
+            missing.append(r["draft_id"])
+
+    if probe_failed:
+        _state_set("manifest_probe_fail_streak", (_state_get("manifest_probe_fail_streak") or 0) + 1)
+    else:
+        _state_set("manifest_probe_fail_streak", 0)
+    return {"missing": missing, "unparseable": unparseable, "checked": len(rows)}
+
+
+def _probe_reflexion_age() -> tuple[str, float | None]:
+    """State of the WR2 reflexion Delta-Gate ledger.
+
+    Returns (state, age_days): state ∈ {"ok", "stale", "missing", "malformed"}.
+    Missing/malformed are ALERT states, not skips — a ledger that was never
+    written is the never-armed weekly cron (W81), exactly what this hunts.
+    """
+    skill_dir = Path(os.environ.get("WR2_SKILL_DIR", str(Path.home() / ".claude/skills/bali-zero-brand")))
+    state_path = skill_dir / "_reflexion-state.json"
+    if not state_path.is_file():
+        return ("missing", None)
+    try:
+        history = json.loads(state_path.read_text())
+        runs = [h["run_at"] for h in history if isinstance(h, dict) and h.get("run_at")]
+        latest = max(datetime.fromisoformat(ts) for ts in runs)
+        if latest.tzinfo is None:
+            latest = latest.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError, KeyError, json.JSONDecodeError) as e:
+        logger.warning("reflexion ledger unreadable (%s): %s", state_path, e)
+        return ("malformed", None)
+    age_days = (datetime.now(timezone.utc) - latest).total_seconds() / 86400.0
+    return ("stale" if age_days > REFLEXION_STALE_DAYS else "ok", age_days)
+
+
+async def _evaluate_outcome_probes(conn: asyncpg.Connection) -> None:
+    """C1: audit the pipeline's OUTCOME signals (launchd is transport, not truth).
+
+    Kept separate from _evaluate_once so its probe sequence (and the existing
+    tests pinned to it) stays untouched; the run loop calls both back to back.
+    """
+    now_epoch = int(datetime.now(timezone.utc).timestamp())
+
+    # P1 — STALE_LEASE
+    stale = await _probe_stale_leases(conn)
+    if stale:
+        if _alert_due("stale_lease", now_epoch):
+            lines = "\n".join(
+                f"- `{s['draft_id']}` owner=`{s['lease_owner']}` "
+                f"hb {int(s['hb_age_sec'] or 0)}s ago, held {int((s['held_sec'] or 0) / 60)}min"
+                for s in stale[:5]
+            )
+            _send_telegram(
+                "⚠️ *WR2 stale render lease(s)*\n"
+                f"{len(stale)} draft(s) stuck at `rendering` (heartbeat "
+                f">{int(LEASE_STALE_MIN)}min silent or held >{int(LEASE_MAX_HELD_MIN)}min):\n"
+                f"{lines}\n"
+                "A live worker renews every 60s — this lease is dead or the "
+                "worker is hung. Check `~/logs/wr2-html-apply.log`."
+            )
+            _state_set("last_alert_stale_lease", now_epoch)
+            logger.warning("ALERT P1 stale_lease count=%d", len(stale))
+        else:
+            logger.info("stale_lease detected but cooldown active (count=%d)", len(stale))
+    else:
+        logger.debug("leases ok")
+
+    # P2 — STATE_AGE (+ unknown-state drift)
+    renderer_enabled = await _probe_renderer_enabled(conn)
+    ages = await _probe_state_ages(conn, renderer_enabled=renderer_enabled)
+    if ages["over"] or ages["unknown"]:
+        if _alert_due("state_age", now_epoch):
+            parts = []
+            if ages["over"]:
+                parts.append(
+                    "Stuck stages (oldest row per state):\n" + "\n".join(
+                        f"- `{a['status']}`: {a['n']} row(s), oldest {a['oldest_hours']:.1f}h"
+                        for a in ages["over"]
+                    )
+                )
+            if ages["unknown"]:
+                parts.append(
+                    "UNKNOWN states (machine drift — cicatrix #9):\n" + "\n".join(
+                        f"- `{a['status']}`: {a['n']} row(s)" for a in ages["unknown"]
+                    )
+                )
+            _send_telegram("⚠️ *WR2 state-age audit*\n" + "\n".join(parts))
+            _state_set("last_alert_state_age", now_epoch)
+            logger.warning(
+                "ALERT P2 state_age over=%d unknown=%d", len(ages["over"]), len(ages["unknown"])
+            )
+        else:
+            logger.info("state_age findings but cooldown active")
+    else:
+        logger.debug("state ages ok")
+
+    # P2 — MANIFEST_GAP (hourly, degrade-open with fail-streak meta-alert)
+    manifest = await _probe_manifest_gaps(conn)
+    if manifest is not None:
+        gaps = manifest["missing"] + manifest["unparseable"]
+        if gaps and _alert_due("manifest_gap", now_epoch):
+            _send_telegram(
+                "⚠️ *WR2 rendered-without-manifest*\n"
+                f"missing manifest.json: {manifest['missing'] or '—'}\n"
+                f"unparseable drive_url: {manifest['unparseable'] or '—'}\n"
+                f"(checked {manifest['checked']} rendered draft(s), 48h window). "
+                "The C0 render writes the manifest under the lease — absence "
+                "means a partial upload or manual deletion."
+            )
+            _state_set("last_alert_manifest_gap", now_epoch)
+            logger.warning("ALERT P2 manifest_gap gaps=%d", len(gaps))
+        streak = _state_get("manifest_probe_fail_streak") or 0
+        if streak >= MANIFEST_FAIL_STREAK and _alert_due("manifest_probe_broken", now_epoch):
+            _send_telegram(
+                "⚠️ *WR2 manifest probe BROKEN*\n"
+                f"{streak} consecutive sweeps failed to reach Drive — the probe "
+                "is blind, not the pipeline healthy. Check SA credentials / "
+                "googleapiclient availability in the watchdog venv."
+            )
+            _state_set("last_alert_manifest_probe_broken", now_epoch)
+            logger.warning("ALERT P2 manifest_probe_broken streak=%d", streak)
+
+    # P2 — WEEKLY_SILENT (reflexion Delta-Gate ledger)
+    refl_state, refl_age = _probe_reflexion_age()
+    if refl_state != "ok":
+        if _alert_due("weekly_silent", now_epoch):
+            detail = {
+                "stale": f"last run {refl_age:.1f}d ago (threshold {REFLEXION_STALE_DAYS:.0f}d)"
+                if refl_age is not None
+                else "stale",
+                "missing": "ledger file MISSING — the weekly cron may have never run (W81)",
+                "malformed": "ledger file unreadable — the Delta-Gate write is broken",
+            }[refl_state]
+            _send_telegram(
+                "⚠️ *WR2 weekly reflexion SILENT*\n"
+                f"{detail}\n"
+                "`_reflexion-state.json` is the Delta-Gate that kills green-cron "
+                "theater — check `launchctl print gui/$(id -u)/com.balizero.wr2.reflexion`."
+            )
+            _state_set("last_alert_weekly_silent", now_epoch)
+            logger.warning("ALERT P2 weekly_silent state=%s age=%s", refl_state, refl_age)
+        else:
+            logger.info("weekly_silent (%s) but cooldown active", refl_state)
+    else:
+        logger.debug("reflexion ledger ok (age=%.1fd)", refl_age or -1)
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # Alert evaluation
 # ─────────────────────────────────────────────────────────────────────────
 
@@ -513,6 +895,7 @@ async def _run_loop() -> None:
             while not _shutdown_event.is_set():
                 try:
                     await _evaluate_once(conn)
+                    await _evaluate_outcome_probes(conn)
                 except (
                     asyncpg.PostgresError,
                     asyncpg.InterfaceError,  # W29: stale connection after pg-proxy hiccup


### PR DESCRIPTION
## C1 — Watchdog che legge l'OUTCOME, non l'exit-code

Item C1 of `research/operations/2026-06-30-wr2-next-level-plan.md` (LIVELLO C — robustezza). Cicatrix #2: launchd is transport, not truth.

### New probes (all READ-ONLY — DB SELECT, local file, Drive list; zero pipeline mutations)

| Probe | Tier | Fires when |
|---|---|---|
| STALE_LEASE | P1 | `rendering` row heartbeat silent >15min OR lease held >90min (heartbeat ≠ health) |
| STATE_AGE | P2 | oldest row per non-terminal state >6h; UNKNOWN statuses always flagged (machine drift) |
| MANIFEST_GAP | P2 | rendered draft (48h window) whose Drive folder lacks the C0 `manifest.json` (#1892); hourly throttle; fail-streak meta-alert at 24 misses |
| WEEKLY_SILENT | P2 | reflexion Delta-Gate ledger stale >8d, missing, or malformed — missing is an alert (W81 never-armed cron) |

### Also
- Repairs 5 silently-rotten tests (telemetry-era mocks predating the P-1 S10b DB re-key; this test file is not CI-armed). Suite now 37/37.
- New probes isolated in `_evaluate_outcome_probes` — existing `_evaluate_once` sequence untouched.
- Env tunables: `WR2_WATCHDOG_LEASE_STALE_MIN`, `WR2_WATCHDOG_LEASE_MAX_HELD_MIN`, `WR2_WATCHDOG_STATE_AGE_HOURS`, `WR2_WATCHDOG_MANIFEST_PROBE` (kill switch), `WR2_WATCHDOG_REFLEXION_STALE_DAYS`.

### Verification
- `pytest scripts/tests/test_wr2_supervisor_watchdog.py` → 37 passed (innocence AND guilt per probe, cicatrix #3).
- Probe SQL columns verified against migrations 170/222/228 DDL + the exact column set the live `_pg.py` lease paths use. Live-DB probe from this session blocked by Keychain ACL (headless) — arming proof deferred.
- Red-team spalla: Codex GPT-5.5, 10 findings — adopted #1 (held-too-long condition), #2 (NULL-safe COALESCE), #3 (status list drift → entity-aligned lists + unknown-state detector), #4 ('rendering' excluded from state-age), #5 (fail-streak meta-alert), #6 (supportsAllDrives), #7 (unparseable drive_url reported), #10 (missing ledger = alert). Declined #8 (manifest content diff — presence is the C0 contract) and #9 (LIMIT 10 vs volume ~3 drafts/48h) with rationale.

### Arming (DEFERRED — flight session, deploy stays OFF)
Watchdog daemon runs from `~/Desktop/nuzantara-deploy` and reloads only on restart. PENDING-ARMS line added in the ledger; proof-of-armed = first `ALERT`/`ok` outcome-probe lines in `~/logs/wr2_supervisor_watchdog.log` post-restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)