### PR TITLE
fix(organism): pg-to-organism-bridge — authenticate XADD, surface stream degradation

### DIFF
--- a/scripts/pg-to-organism-bridge.py
+++ b/scripts/pg-to-organism-bridge.py
@@ -199,15 +199,26 @@ def _emit_event(event: dict) -> None:
         return
 
     try:
-        subprocess.run(
+        # Local Redis has requirepass since 2026-06-29 — redis-cli honours
+        # REDISCLI_AUTH. Password comes from _load_secrets() (REDIS_PASSWORD).
+        env = os.environ.copy()
+        if env.get("REDIS_PASSWORD"):
+            env.setdefault("REDISCLI_AUTH", env["REDIS_PASSWORD"])
+        proc = subprocess.run(
             [
                 "redis-cli", "XADD", ORGANISM_STREAM_KEY, "*",
                 "data", json.dumps(event, separators=(",", ":"), default=str),
             ],
-            capture_output=True, timeout=2, check=False,
+            capture_output=True, timeout=2, check=False, env=env,
         )
+        reply = (proc.stdout or b"").decode("utf-8", "replace").strip()
+        if proc.returncode != 0 or reply.startswith(("NOAUTH", "WRONGPASS", "ERR", "(error)")):
+            logger.warning(
+                "redis XADD failed (non-fatal, stream degraded): rc=%s reply=%s",
+                proc.returncode, reply[:200],
+            )
     except Exception as exc:
-        logger.debug("redis XADD failed (non-fatal): %s", exc)
+        logger.warning("redis XADD failed (non-fatal): %s", exc)
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Root cause
Same June-29 `requirepass` wall as #1921, invisible variant: `redis-cli XADD organism:events` returns **rc=0** with reply `NOAUTH Authentication required.` — `check=False` swallowed it and the only log was DEBUG. The organism event stream has been dark since 2026-06-29 while the bridge sidecar kept reporting `ok` (cicatrix #2, green-that-lies one level deeper: the heartbeat measures the loop, not the work).

## What
- Pass `REDISCLI_AUTH` (from `REDIS_PASSWORD`, already loaded by `_load_secrets`) to the redis-cli subprocess.
- Inspect returncode AND reply prefix (`NOAUTH`/`WRONGPASS`/`ERR`) → log at WARNING. A degraded stream is now visible in the launchd log.
- Durable JSONL mirror path untouched.

## Probes (executed)
- Innocence: event written to scratch JSONL, content intact.
- Guilt: with no password, warning fires with `rc=0 reply=NOAUTH Authentication required.` — reproduces the live failure verbatim.

## Arming
Daemon (`com.nuzantara.pg-organism-bridge`, KeepAlive) runs from the MAIN checkout → arms at next `git pull` + daemon restart (operator; PENDING-ALIGN:Pro). Operator dependency shared with #1921: `REDIS_PASSWORD` in `~/.nuzantara-secrets.env`.

TAC: `research/operations/2026-07-03-heartbeat-organs-tac.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)