### PR TITLE
feat(wr2): deploy-fork content-gate — runtime provenance stamps + deploy-pull outcome (C2 part 1)

### DIFF
--- a/scripts/lib/wr2_runtime_stamp.py
+++ b/scripts/lib/wr2_runtime_stamp.py
@@ -1,0 +1,156 @@
+"""wr2_runtime_stamp — runtime provenance for WR2 organs (C2, deploy-fork content-gate).
+
+The disease (cicatrix #1 / D5, lived 2026-06-30): an organ EXECUTES code that is
+not the code the repo says is deployed — a stale deploy clone, a long-running
+daemon that imported modules before the last pull, or locally-mutated files.
+Exit codes and `launchctl list` cannot see it; only provenance can.
+
+Every stamped organ writes ~/.organism/last_seen/<organ>.runtime.json:
+
+    {ts, pid, host, checkout, head_sha, dirty, stale_modules[], errors[]}
+
+- head_sha        git HEAD of the checkout the process ACTUALLY runs from
+- dirty           `git status --porcelain` non-empty
+- stale_modules   watched module files whose LIVE blob differs from the HEAD
+                  blob (`git hash-object <live>` vs `git rev-parse HEAD:<rel>`)
+                  — content compare, blob-per-file, NEVER mtime/three-dot (W88)
+- errors          provenance gaps (git unavailable, module outside checkout…)
+
+Consumers: wr2_html_render_apply (one-shot worker, stamps per run + gates the
+render), wr2_supervisor (daemon, stamps at startup), wr2_supervisor_watchdog
+(reads the stamps and alerts RUNTIME_STALE when stamp.head_sha ≠ the checkout's
+CURRENT on-disk HEAD — the daemon-running-old-code detector).
+
+Everything here is fail-open: a broken git must never break the organ — it
+degrades to an `errors` entry the watchdog can still see.
+
+Loaded via importlib (scripts/lib is not a package — cf. wr2_reflexion_synthesis).
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# Gate modes for gate_verdict (env WR2_RUNTIME_SHA_GATE).
+GATE_OFF = "off"
+GATE_WARN = "warn"      # default: log-only, zero pipeline effects
+GATE_STRICT = "strict"  # armed separately (PENDING-ARMS): refuse/abort
+
+
+def _git(checkout: Path, *args: str) -> Optional[str]:
+    """git -C <checkout> <args>; None on ANY failure (fail-open)."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(checkout), *args],
+            capture_output=True, text=True, timeout=15,
+        )
+        if out.returncode != 0:
+            return None
+        return out.stdout.strip()
+    except Exception:  # noqa: BLE001 — provenance must never crash the organ
+        return None
+
+
+def current_head(checkout: Path) -> Optional[str]:
+    return _git(Path(checkout), "rev-parse", "HEAD")
+
+
+def compute_runtime_stamp(checkout: Path, modules) -> dict:
+    """Provenance of the code THIS process runs. Never raises."""
+    checkout = Path(checkout).resolve()
+    head = _git(checkout, "rev-parse", "HEAD")
+    dirty_out = _git(checkout, "status", "--porcelain")
+
+    errors = []
+    if head is None:
+        errors.append("git-head-unavailable")
+    dirty = bool(dirty_out) if dirty_out is not None else None
+    if dirty_out is None:
+        errors.append("git-status-unavailable")
+
+    stale = []
+    for m in modules:
+        try:
+            rel = Path(m).resolve().relative_to(checkout)
+        except (ValueError, OSError):
+            errors.append(f"outside-checkout:{Path(m).name}")
+            continue
+        live_blob = _git(checkout, "hash-object", str(checkout / rel))
+        head_blob = _git(checkout, "rev-parse", f"HEAD:{rel.as_posix()}")
+        if live_blob is None or head_blob is None:
+            errors.append(f"blob-unavailable:{rel.as_posix()}")
+            continue
+        if live_blob != head_blob:
+            stale.append(rel.as_posix())
+
+    return {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "pid": os.getpid(),
+        "host": socket.gethostname(),
+        "checkout": str(checkout),
+        "head_sha": head,
+        "dirty": dirty,
+        "stale_modules": stale,
+        "errors": errors,
+    }
+
+
+def write_runtime_stamp(organ_id: str, stamp: dict) -> Optional[Path]:
+    """Atomic write of ~/.organism/last_seen/<organ_id>.runtime.json.
+    Returns the path, or None on failure. Never raises."""
+    try:
+        directory = Path.home() / ".organism" / "last_seen"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"{organ_id}.runtime.json"
+        tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(stamp, separators=(",", ":")) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+        return path
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def read_runtime_stamp(organ_id: str) -> Optional[dict]:
+    """Read a stamp back; None when missing/unreadable (degrade-open)."""
+    try:
+        path = Path.home() / ".organism" / "last_seen" / f"{organ_id}.runtime.json"
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def gate_verdict(mode: str, stamp: dict, disk_head: Optional[str]) -> tuple:
+    """(verdict, reason) for the render-finalize gate.
+
+    verdict ∈ {"ok", "warn", "block"}. "block" happens ONLY in strict mode:
+      - boot provenance impure (dirty / stale modules / no head) — a mutated
+        runtime must not publish (red-team finding #4);
+      - the checkout's on-disk HEAD moved vs the boot stamp (a deploy-pull
+        landed mid-run: the process is now running code that no longer exists
+        on disk).
+    In warn mode (default) the same conditions log a warning and pass —
+    zero live-pipeline behavior change until strict is armed.
+    """
+    if mode == GATE_OFF:
+        return ("ok", "gate off")
+
+    problems = []
+    if stamp.get("head_sha") is None:
+        problems.append("no-head-provenance")
+    if stamp.get("dirty"):
+        problems.append("dirty-checkout")
+    if stamp.get("stale_modules"):
+        problems.append("stale-modules:" + ",".join(stamp["stale_modules"]))
+    if disk_head is not None and stamp.get("head_sha") is not None and disk_head != stamp["head_sha"]:
+        problems.append(f"head-moved:{stamp['head_sha'][:12]}->{disk_head[:12]}")
+
+    if not problems:
+        return ("ok", "provenance clean")
+    reason = "; ".join(problems)
+    return ("block", reason) if mode == GATE_STRICT else ("warn", reason)

--- a/scripts/tests/test_wr2_runtime_stamp.py
+++ b/scripts/tests/test_wr2_runtime_stamp.py
@@ -1,0 +1,235 @@
+"""Unit tests for scripts/lib/wr2_runtime_stamp.py + empirical tests for the
+wr2-deploy-pull.sh C2 additions (outcome heartbeat, guards, flag-gated kickstart).
+
+The stamp tests run against a REAL throwaway git repo — the blob-per-file
+compare (W88) is exactly the thing a mock would lie about.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+LIB_PATH = SCRIPTS_DIR / "lib" / "wr2_runtime_stamp.py"
+DEPLOY_PULL = SCRIPTS_DIR / "wr2-deploy-pull.sh"
+
+spec = importlib.util.spec_from_file_location("wr2_runtime_stamp", LIB_PATH)
+rs = importlib.util.module_from_spec(spec)
+sys.modules["wr2_runtime_stamp"] = rs
+spec.loader.exec_module(rs)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True
+    )
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@t")
+    _git(r, "config", "user.name", "t")
+    (r / "mod.py").write_text("x = 1\n")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "init")
+    return r
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# compute_runtime_stamp
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_clean_checkout_stamp(repo):
+    stamp = rs.compute_runtime_stamp(repo, [repo / "mod.py"])
+    assert stamp["head_sha"] == _git(repo, "rev-parse", "HEAD")
+    assert stamp["dirty"] is False
+    assert stamp["stale_modules"] == []
+    assert stamp["errors"] == []
+
+
+def test_modified_module_is_stale_by_blob(repo):
+    """W88: content compare via blobs — a mutated live file must surface even
+    though HEAD never moved."""
+    (repo / "mod.py").write_text("x = 2\n")
+    stamp = rs.compute_runtime_stamp(repo, [repo / "mod.py"])
+    assert stamp["stale_modules"] == ["mod.py"]
+    assert stamp["dirty"] is True
+
+
+def test_module_outside_checkout_is_error(repo, tmp_path):
+    outside = tmp_path / "elsewhere.py"
+    outside.write_text("y = 1\n")
+    stamp = rs.compute_runtime_stamp(repo, [outside])
+    assert any(e.startswith("outside-checkout:") for e in stamp["errors"])
+    assert stamp["stale_modules"] == []
+
+
+def test_non_git_dir_fails_open(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "mod.py").write_text("x\n")
+    stamp = rs.compute_runtime_stamp(plain, [plain / "mod.py"])
+    assert stamp["head_sha"] is None
+    assert "git-head-unavailable" in stamp["errors"]
+
+
+def test_write_and_read_roundtrip(repo, tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    stamp = rs.compute_runtime_stamp(repo, [])
+    path = rs.write_runtime_stamp("wr2.test_organ", stamp)
+    assert path is not None and path.is_file()
+    back = rs.read_runtime_stamp("wr2.test_organ")
+    assert back["head_sha"] == stamp["head_sha"]
+
+
+def test_read_missing_stamp_degrades_open(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert rs.read_runtime_stamp("wr2.never_written") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# gate_verdict
+# ─────────────────────────────────────────────────────────────────────────
+
+CLEAN = {"head_sha": "a" * 40, "dirty": False, "stale_modules": []}
+DIRTY = {"head_sha": "a" * 40, "dirty": True, "stale_modules": []}
+
+
+def test_gate_off_always_ok():
+    assert rs.gate_verdict("off", DIRTY, "b" * 40)[0] == "ok"
+
+
+def test_gate_clean_ok_in_any_mode():
+    assert rs.gate_verdict("warn", CLEAN, "a" * 40)[0] == "ok"
+    assert rs.gate_verdict("strict", CLEAN, "a" * 40)[0] == "ok"
+
+
+def test_gate_warn_mode_never_blocks():
+    verdict, reason = rs.gate_verdict("warn", DIRTY, "b" * 40)
+    assert verdict == "warn"
+    assert "dirty-checkout" in reason and "head-moved" in reason
+
+
+def test_gate_strict_blocks_on_head_moved():
+    verdict, reason = rs.gate_verdict("strict", CLEAN, "b" * 40)
+    assert verdict == "block"
+    assert "head-moved" in reason
+
+
+def test_gate_strict_blocks_on_stale_modules():
+    stamp = {"head_sha": "a" * 40, "dirty": False, "stale_modules": ["mod.py"]}
+    verdict, reason = rs.gate_verdict("strict", stamp, "a" * 40)
+    assert verdict == "block"
+    assert "stale-modules:mod.py" in reason
+
+
+def test_gate_strict_blocks_on_missing_head():
+    verdict, reason = rs.gate_verdict("strict", {"head_sha": None}, None)
+    assert verdict == "block"
+    assert "no-head-provenance" in reason
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# wr2-deploy-pull.sh — empirical (fake HOME, fake origin, fake launchctl)
+# ─────────────────────────────────────────────────────────────────────────
+
+def _setup_deploy_world(tmp_path):
+    """origin bare repo + deploy clone under a fake HOME."""
+    home = tmp_path / "home"
+    (home / "Desktop").mkdir(parents=True)
+    src = tmp_path / "src"
+    src.mkdir()
+    _git(src, "init", "-q", "-b", "main")
+    _git(src, "config", "user.email", "t@t")
+    _git(src, "config", "user.name", "t")
+    (src / "f.txt").write_text("v1\n")
+    _git(src, "add", ".")
+    _git(src, "commit", "-qm", "v1")
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(src), str(origin)], check=True)
+    deploy = home / "Desktop" / "nuzantara-deploy"
+    subprocess.run(["git", "clone", "-q", str(origin), str(deploy)], check=True)
+    return home, src, origin, deploy
+
+
+def _run_pull(home, extra_env=None, path_prefix=None):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env.pop("TELEGRAM_BOT_TOKEN", None)
+    if path_prefix:
+        env["WR2_DEPLOY_PULL_TEST_PATH_PREFIX"] = str(path_prefix)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(DEPLOY_PULL)], capture_output=True, text=True, env=env, timeout=60
+    )
+
+
+def _outcome(home):
+    p = home / ".organism" / "last_seen" / "wr2.deploy_pull.json"
+    assert p.is_file(), "outcome heartbeat missing — the trap did not fire"
+    return json.loads(p.read_text())
+
+
+def test_deploy_pull_up_to_date_writes_outcome(tmp_path):
+    home, _src, _origin, _deploy = _setup_deploy_world(tmp_path)
+    res = _run_pull(home)
+    assert res.returncode == 0, res.stderr
+    out = _outcome(home)
+    assert out["status"] == "ok:up-to-date"
+    assert out["old_head"] == out["new_head"] != ""
+
+
+def test_deploy_pull_advanced_writes_outcome_and_skips_kickstart(tmp_path):
+    home, src, origin, deploy = _setup_deploy_world(tmp_path)
+    (src / "f.txt").write_text("v2\n")
+    _git(src, "add", ".")
+    _git(src, "commit", "-qm", "v2")
+    _git(src, "push", "-q", str(origin), "main")
+    res = _run_pull(home)
+    assert res.returncode == 0, res.stderr
+    out = _outcome(home)
+    assert out["status"] == "ok:advanced"
+    assert out["advance_count"] == 1
+    assert out["old_head"] != out["new_head"]
+    log = (home / "logs" / "wr2-deploy-pull.log").read_text()
+    assert "kickstart skipped" in log
+
+
+def test_deploy_pull_advanced_kickstarts_when_armed(tmp_path):
+    home, src, origin, deploy = _setup_deploy_world(tmp_path)
+    (src / "f.txt").write_text("v3\n")
+    _git(src, "add", ".")
+    _git(src, "commit", "-qm", "v3")
+    _git(src, "push", "-q", str(origin), "main")
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    calls = tmp_path / "launchctl-calls.txt"
+    fake = fake_bin / "launchctl"
+    fake.write_text(f'#!/bin/sh\necho "$@" >> "{calls}"\n')
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC)
+    res = _run_pull(home, extra_env={"WR2_DEPLOY_PULL_KICKSTART": "1"}, path_prefix=fake_bin)
+    assert res.returncode == 0, res.stderr
+    recorded = calls.read_text()
+    assert "com.balizero.wr2.html-apply" in recorded
+    assert f"kickstart -k gui/{os.getuid()}/com.balizero.wr2.supervisor" in recorded
+    assert "com.balizero.wr2.supervisor-watchdog" in recorded
+
+
+def test_deploy_pull_dirty_clone_is_honest_error(tmp_path):
+    home, _src, _origin, deploy = _setup_deploy_world(tmp_path)
+    (deploy / "f.txt").write_text("local mutation\n")
+    res = _run_pull(home)
+    assert res.returncode == 1
+    assert _outcome(home)["status"] == "error:dirty"

--- a/scripts/wr2-deploy-pull.sh
+++ b/scripts/wr2-deploy-pull.sh
@@ -28,6 +28,28 @@ log() {
     "$(date '+%Y-%m-%d %H:%M:%S WITA')" "$*" >> "$LOG"
 }
 
+# ── C2: deploy outcome heartbeat (~/.organism/last_seen/wr2.deploy_pull.json) ──
+# Written by a trap on EVERY exit path — success, error and unexpected alike.
+# Pre-C2 the puller only touched its private state file, so the organism could
+# not see whether the deploy artery was pumping (red-team finding, 2026-07-02).
+# Status values are fixed keywords → JSON-safe by construction.
+OUTCOME_STATUS="error:unclassified"
+OUTCOME_OLD_HEAD=""
+OUTCOME_NEW_HEAD=""
+OUTCOME_ADVANCE=0
+
+write_outcome() {
+  local rc="${1:-0}"
+  local dir="${HOME}/.organism/last_seen"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  local tmp="${dir}/wr2.deploy_pull.json.tmp.$$"
+  printf '{"ts":"%s","status":"%s","old_head":"%s","new_head":"%s","advance_count":%s,"exit":%s}\n' \
+    "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$OUTCOME_STATUS" "$OUTCOME_OLD_HEAD" \
+    "$OUTCOME_NEW_HEAD" "${OUTCOME_ADVANCE:-0}" "$rc" > "$tmp" 2>/dev/null \
+    && mv "$tmp" "${dir}/wr2.deploy_pull.json" 2>/dev/null || true
+}
+trap 'write_outcome $?' EXIT
+
 if [[ -f "$SECRETS" ]]; then
   TELEGRAM_BOT_TOKEN="$(grep '^TELEGRAM_BOT_TOKEN=' "$SECRETS" | head -1 | cut -d= -f2- | tr -d '"')" || true
   TELEGRAM_OWNER_CHAT_ID="$(grep '^TELEGRAM_OWNER_CHAT_ID=' "$SECRETS" | head -1 | cut -d= -f2- | tr -d '"')" || true
@@ -38,6 +60,7 @@ if command -v flock >/dev/null 2>&1; then
   exec 9>"$LOCK"
   if ! flock -n 9; then
     log "another deploy-pull is in progress, skipping"
+    OUTCOME_STATUS="skipped:lock"
     exit 0
   fi
 fi
@@ -142,19 +165,29 @@ log "deploy-pull start dir=${DEPLOY_DIR}"
 # file (someone re-created a worktree) treat it as missing and re-bootstrap a clone.
 if [[ ! -d "$DEPLOY_DIR/.git" ]]; then
   if [[ -f "$DEPLOY_DIR/.git" ]]; then
-    log "WARN: ${DEPLOY_DIR} is a worktree (.git is a file), not the required clone — removing + recloning"
-    rm -rf "$DEPLOY_DIR" 2>>"$LOG"; git -C "$SOURCE_REPO" worktree prune 2>>"$LOG" || true
+    # rm -rf guard: only ever destroy a path that IS the canonical deploy dir
+    # by name — a mistyped WR2_DEPLOY_DIR must not delete a real worktree.
+    if [[ "$(basename "$DEPLOY_DIR")" == "nuzantara-deploy" ]]; then
+      log "WARN: ${DEPLOY_DIR} is a worktree (.git is a file), not the required clone — removing + recloning"
+      rm -rf "$DEPLOY_DIR" 2>>"$LOG"; git -C "$SOURCE_REPO" worktree prune 2>>"$LOG" || true
+    else
+      log "REFUSING rm -rf: basename(${DEPLOY_DIR}) != nuzantara-deploy"
+      OUTCOME_STATUS="error:deploy-dir-suspect"
+      exit 1
+    fi
   fi
   if ! bootstrap_deploy_clone; then
     log "ERROR: deploy clone missing at ${DEPLOY_DIR}"
     send_telegram "deploy_missing" \
       "WR2 deploy CLONE missing at \`${DEPLOY_DIR}\`. Self-heal failed. Run: \`git clone --branch deploy/main https://github.com/Balizero1987/Teman2.git ~/Desktop/nuzantara-deploy\`"
+    OUTCOME_STATUS="error:clone-missing"
     exit 1
   fi
 fi
 
 cd "$DEPLOY_DIR" || {
   log "ERROR: cannot cd to ${DEPLOY_DIR}"
+  OUTCOME_STATUS="error:cd-failed"
   exit 1
 }
 
@@ -163,6 +196,7 @@ if [[ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]]; then
   log "ERROR: deploy worktree on branch=${CURRENT_BRANCH}, expected ${EXPECTED_BRANCH}"
   send_telegram "wrong_branch" \
     "WR2 deploy worktree on WRONG branch. Expected: \`${EXPECTED_BRANCH}\`. Found: \`${CURRENT_BRANCH}\`. Fix: \`cd ${DEPLOY_DIR} && git checkout ${EXPECTED_BRANCH}\`"
+  OUTCOME_STATUS="error:wrong-branch"
   exit 1
 fi
 
@@ -171,6 +205,7 @@ if [[ -n "$DIRTY" ]]; then
   log "ERROR: deploy worktree has local changes - first dirty entry: ${DIRTY}"
   send_telegram "dirty_worktree" \
     "WR2 deploy worktree DIRTY. First dirty entry: \`${DIRTY}\`. Inspect: \`cd ${DEPLOY_DIR} && git status\`."
+  OUTCOME_STATUS="error:dirty"
   exit 1
 fi
 
@@ -179,6 +214,7 @@ if ! git fetch --quiet origin "$EXPECTED_BRANCH" 2>>"$LOG"; then
     log "ERROR: git fetch failed for both ${EXPECTED_BRANCH} and main"
     send_telegram "fetch_failed" \
       "WR2 deploy-pull: git fetch failed for \`${DEPLOY_DIR}\`. Check network and GitHub auth."
+    OUTCOME_STATUS="error:fetch-failed"
     exit 1
   fi
 fi
@@ -188,13 +224,24 @@ if ! git rev-parse --verify --quiet "$REMOTE_REF" >/dev/null; then
   REMOTE_REF="origin/main"
 fi
 
-LOCAL_HEAD="$(git rev-parse HEAD)"
-REMOTE_HEAD="$(git rev-parse "$REMOTE_REF")"
+LOCAL_HEAD="$(git rev-parse HEAD 2>>"$LOG")"
+REMOTE_HEAD="$(git rev-parse "$REMOTE_REF" 2>>"$LOG")"
+# set -e is off: a failed rev-parse yields an EMPTY var that would otherwise
+# masquerade as divergence/ff errors downstream (red-team finding). Fail here
+# with the real cause instead.
+if [[ -z "$LOCAL_HEAD" || -z "$REMOTE_HEAD" ]]; then
+  log "ERROR: git rev-parse produced empty head (local='${LOCAL_HEAD}' remote='${REMOTE_HEAD}')"
+  OUTCOME_STATUS="error:rev-parse"
+  exit 1
+fi
+OUTCOME_OLD_HEAD="$LOCAL_HEAD"
 if [[ "$LOCAL_HEAD" == "$REMOTE_HEAD" ]]; then
   log "OK: already up-to-date (${LOCAL_HEAD:0:9})"
   state_set "last_status" "ok"
   state_set "last_run_ts" "$(now_epoch)"
   state_set "last_head" "$LOCAL_HEAD"
+  OUTCOME_STATUS="ok:up-to-date"
+  OUTCOME_NEW_HEAD="$LOCAL_HEAD"
   exit 0
 fi
 
@@ -203,6 +250,7 @@ if [[ "$AHEAD" =~ ^[0-9]+$ ]] && (( AHEAD > 0 )); then
   log "ERROR: deploy worktree is ${AHEAD} commit(s) ahead of ${REMOTE_REF} - refusing to merge"
   send_telegram "local_ahead" \
     "WR2 deploy worktree has LOCAL commits: ${AHEAD} ahead of \`${REMOTE_REF}\`. Inspect: \`cd ${DEPLOY_DIR} && git log ${REMOTE_REF}..HEAD\`."
+  OUTCOME_STATUS="error:local-ahead"
   exit 1
 fi
 
@@ -210,6 +258,7 @@ if ! git merge-base --is-ancestor "$LOCAL_HEAD" "$REMOTE_HEAD"; then
   log "ERROR: branches diverged - local=${LOCAL_HEAD:0:9} remote=${REMOTE_HEAD:0:9}"
   send_telegram "diverged" \
     "WR2 deploy-pull: branches DIVERGED. local \`${LOCAL_HEAD:0:9}\`, remote \`${REMOTE_HEAD:0:9}\`. Manual resolution required."
+  OUTCOME_STATUS="error:diverged"
   exit 1
 fi
 
@@ -217,6 +266,7 @@ if ! git merge --ff-only "$REMOTE_REF" >>"$LOG" 2>&1; then
   log "ERROR: git merge --ff-only failed unexpectedly"
   send_telegram "ff_failed" \
     "WR2 deploy-pull: ff-merge failed unexpectedly. Inspect: \`cd ${DEPLOY_DIR} && git status\`."
+  OUTCOME_STATUS="error:ff-failed"
   exit 1
 fi
 
@@ -227,4 +277,31 @@ state_set "last_status" "advanced"
 state_set "last_run_ts" "$(now_epoch)"
 state_set "last_head" "$NEW_HEAD"
 state_set "last_advance_count" "$COMMIT_COUNT"
+OUTCOME_STATUS="ok:advanced"
+OUTCOME_NEW_HEAD="$NEW_HEAD"
+[[ "$COMMIT_COUNT" =~ ^[0-9]+$ ]] && OUTCOME_ADVANCE="$COMMIT_COUNT"
+
+# ── C2 (flag-gated, DEFAULT OFF): wake the organs on the NEW code ────────────
+# The one-shot html-apply worker gets a plain kickstart (its next run imports
+# fresh code). The long-running supervisor + watchdog need `-k` (restart) or
+# they keep executing the pre-pull code forever — the RUNTIME_STALE disease
+# the C2 watchdog probe detects. OFF until armed (PENDING-ARMS ledger):
+#   WR2_DEPLOY_PULL_KICKSTART=1
+if [[ "${WR2_DEPLOY_PULL_KICKSTART:-0}" == "1" ]]; then
+  UID_N="$(id -u)"
+  if launchctl kickstart "gui/${UID_N}/com.balizero.wr2.html-apply" >>"$LOG" 2>&1; then
+    log "kickstart html-apply OK"
+  else
+    log "WARN: kickstart html-apply failed (label not loaded?)"
+  fi
+  for svc in com.balizero.wr2.supervisor com.balizero.wr2.supervisor-watchdog; do
+    if launchctl kickstart -k "gui/${UID_N}/${svc}" >>"$LOG" 2>&1; then
+      log "kickstart -k ${svc} OK (daemon restarted on new code)"
+    else
+      log "WARN: kickstart -k ${svc} failed (label not loaded?)"
+    fi
+  done
+else
+  log "kickstart skipped (WR2_DEPLOY_PULL_KICKSTART != 1)"
+fi
 exit 0

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -30,7 +30,10 @@ Conditions closed here (WR2 wiring v4):
 Kill switch: system_settings.wr2_html_renderer_enabled (missing/!=true => no-op).
 Env: DATABASE_URL (required), WR2_HTML_SHADOW (1=dry-run), WR2_VISION_REQUIRED (1=enforce
 vision fail-closed), WR2_HTML_MAX_ATTEMPTS (circuit breaker, default 3),
-WR2_NOTIFY_RECIPIENTS (comma phones; default the two below), WR2_HTML_HEARTBEAT_SECS (60).
+WR2_NOTIFY_RECIPIENTS (comma phones; default the two below), WR2_HTML_HEARTBEAT_SECS (60),
+WR2_RUNTIME_SHA_GATE (C2 deploy-fork content-gate: off|warn|strict, default warn —
+warn logs provenance problems and proceeds; strict refuses impure boots and aborts
+pre-Drive when HEAD moves mid-run, releasing the lease without burning an attempt).
 """
 
 from __future__ import annotations
@@ -55,6 +58,33 @@ import asyncpg  # noqa: E402
 
 from backend.services.canva_renderer_v2 import _pg  # noqa: E402
 from wr2_html_renderer.claude_vision import VisionTransient  # noqa: E402
+
+# ── C2 runtime provenance (deploy-fork content-gate) — fail-open on any error ──
+# scripts/lib is not a package: importlib load, same pattern as wr2_reflexion_synthesis.
+try:
+    import importlib.util as _ilu  # noqa: E402
+
+    _rs_spec = _ilu.spec_from_file_location(
+        "wr2_runtime_stamp", str(_REPO / "scripts" / "lib" / "wr2_runtime_stamp.py")
+    )
+    runtime_stamp = _ilu.module_from_spec(_rs_spec)
+    _rs_spec.loader.exec_module(runtime_stamp)
+except Exception:  # noqa: BLE001 — provenance must never break the worker
+    runtime_stamp = None
+
+# Load-bearing modules whose LIVE content is compared blob-per-file vs HEAD (W88).
+_WATCHED_MODULES = (
+    Path(__file__),
+    _REPO / "apps" / "backend-rag" / "backend" / "services" / "canva_renderer_v2" / "_pg.py",
+    _REPO / "scripts" / "wr2_html_renderer" / "designer_loop.py",
+)
+# Populated once per run() by the boot stamp; read by the pre-Drive gate.
+_BOOT_STAMP: dict = {}
+
+
+class RuntimeStale(Exception):
+    """Strict runtime-sha gate tripped: NOT a draft defect — released without
+    burning an attempt (same no-burn contract as VisionTransient)."""
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 # Silence httpx/httpcore INFO logs that would otherwise leak the Telegram bot token in the request URL
@@ -567,6 +597,19 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
             if stop.is_set():
                 raise RuntimeError("lease_lost_before_drive")
 
+            # C2 gate — BEFORE Drive, not just before persist (a blocked persist
+            # after an upload still leaves orphan Drive artifacts). Default mode
+            # is 'warn': log-only, zero pipeline effects; 'strict' is armed
+            # separately (PENDING-ARMS ledger).
+            gate_mode = os.environ.get("WR2_RUNTIME_SHA_GATE", "warn").strip().lower()
+            if runtime_stamp is not None and _BOOT_STAMP and gate_mode != "off":
+                disk_head = runtime_stamp.current_head(_REPO)
+                verdict, reason = runtime_stamp.gate_verdict(gate_mode, _BOOT_STAMP, disk_head)
+                if verdict == "warn":
+                    logger.warning("runtime-sha gate: %s (mode=warn, proceeding)", reason)
+                elif verdict == "block":
+                    raise RuntimeStale(reason)
+
             # the render just took ~15 min — main_conn may have been closed idle
             # by the pg-proxy; reconnect before the terminal write so a converged
             # carousel actually reaches status='rendered' (2026-06-12 SCAR).
@@ -615,6 +658,27 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
                     f"Re-open by having them text +62 821-3465-159, then re-enqueue."
                 )
             return f"rendered report={report}"
+        except RuntimeStale as exc:
+            # Deploy landed mid-run / impure provenance in strict mode: the
+            # draft is healthy — release WITHOUT burning an attempt and let the
+            # next (fresh-code) invocation render it.
+            main_conn = await _ensure_live(main_conn, pool_conn_dsn)
+            await main_conn.execute(
+                """
+                UPDATE war_room_drafts
+                   SET status='drafts_imaged_checked', lease_owner=NULL,
+                       lease_acquired_at=NULL, lease_heartbeat_at=NULL, updated_at=NOW()
+                 WHERE id=$1 AND lease_owner=$2 AND status='rendering'
+                """,
+                draft_id, owner,
+            )
+            await _ops_alert(
+                f"WR2 HTML draft={draft_id} aborted by runtime-sha gate (strict): {exc} "
+                f"— draft requeued, no attempt burned. Restart/kickstart the worker "
+                f"so the next run imports the deployed code."
+            )
+            logger.warning("draft %s runtime-stale abort (no attempt burned): %s", draft_id, exc)
+            return f"runtime_stale:{exc}"
         except VisionTransient as exc:
             # transient vision-infra failure (HTTP 429 quota window OR endpoint
             # timeout) — NOT a draft defect. Release the lease WITHOUT touching
@@ -742,7 +806,36 @@ async def run(dry_run: bool = False, draft_id: str | None = None) -> int:
         logger.error("DATABASE_URL not set")
         return 2
 
-    owner = f"html-apply-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    # C2 boot stamp: provenance of the code THIS run imports. One-shot worker →
+    # import-time == run-time; the stamp is per-run truth. Fail-open.
+    gate_mode = os.environ.get("WR2_RUNTIME_SHA_GATE", "warn").strip().lower()
+    if runtime_stamp is not None:
+        _BOOT_STAMP.clear()
+        _BOOT_STAMP.update(runtime_stamp.compute_runtime_stamp(_REPO, _WATCHED_MODULES))
+        runtime_stamp.write_runtime_stamp("wr2.html_apply", _BOOT_STAMP)
+        impure = bool(
+            _BOOT_STAMP.get("dirty")
+            or _BOOT_STAMP.get("stale_modules")
+            or _BOOT_STAMP.get("head_sha") is None
+        )
+        if impure and gate_mode == "strict":
+            detail = (
+                f"dirty={_BOOT_STAMP.get('dirty')} stale={_BOOT_STAMP.get('stale_modules')} "
+                f"head={_BOOT_STAMP.get('head_sha')}"
+            )
+            logger.error("runtime provenance impure, strict gate → refusing to render: %s", detail)
+            await _ops_alert(f"WR2 HTML worker refused to render (strict runtime-sha gate): {detail}")
+            return 3
+        if impure:
+            logger.warning(
+                "runtime provenance impure (gate=%s): dirty=%s stale=%s",
+                gate_mode, _BOOT_STAMP.get("dirty"), _BOOT_STAMP.get("stale_modules"),
+            )
+
+    # The runtime SHA rides in the lease owner (visible in DB per rendering row).
+    # Built ONCE and passed everywhere — the CAS requires exact-string equality.
+    head12 = (_BOOT_STAMP.get("head_sha") or "nohead")[:12]
+    owner = f"html-apply-{os.getpid()}-{uuid.uuid4().hex[:8]}@{head12}"
     # R4.2 drain-loop (P-1): keep fetching batches until the queue is empty so a
     # supervisor kickstart swallowed while we are busy still gets its draft
     # processed this run (restores wr2_supervisor.py:20-22 drain assumption).

--- a/scripts/wr2_supervisor.py
+++ b/scripts/wr2_supervisor.py
@@ -748,9 +748,39 @@ async def _amain() -> None:
     logger.info("wr2_supervisor stopped cleanly")
 
 
+def _write_runtime_stamp_best_effort() -> None:
+    """C2 provenance stamp at daemon startup (deploy-fork content-gate).
+
+    A long-running daemon keeps executing the code it imported at boot; after
+    a deploy-pull the on-disk HEAD moves but the process does not. The stamp
+    records the BOOT provenance so the watchdog can compare it against the
+    checkout's current HEAD and alert RUNTIME_STALE (restart needed). Fail-open:
+    a broken git/lib must never stop the supervisor.
+    """
+    try:
+        import importlib.util
+        from pathlib import Path
+
+        repo = Path(__file__).resolve().parents[1]
+        spec = importlib.util.spec_from_file_location(
+            "wr2_runtime_stamp", str(repo / "scripts" / "lib" / "wr2_runtime_stamp.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        stamp = mod.compute_runtime_stamp(repo, [Path(__file__)])
+        mod.write_runtime_stamp("wr2.supervisor", stamp)
+        logger.info(
+            "runtime stamp written (head=%s dirty=%s stale=%s)",
+            (stamp.get("head_sha") or "?")[:12], stamp.get("dirty"), stamp.get("stale_modules"),
+        )
+    except Exception:  # noqa: BLE001 — provenance must never break the daemon
+        logger.exception("runtime stamp failed (non-fatal)")
+
+
 def main() -> int:
     _configure_logging()
     logger.info("wr2_supervisor starting (pid=%d)", os.getpid())
+    _write_runtime_stamp_best_effort()
     try:
         asyncio.run(_amain())
     except KeyboardInterrupt:


### PR DESCRIPTION
## C2 — Deploy-fork content-gate (cicatrix #1 / D5)

Item C2 of `research/operations/2026-06-30-wr2-next-level-plan.md`. The disease, lived 2026-06-30: organs executing code that is not the code the repo says is deployed (stale deploy clone, daemons running pre-pull imports, locally-mutated files). Exit codes cannot see it — only provenance can.

### What ships here (part 1)
- **`scripts/lib/wr2_runtime_stamp.py`** — per-organ provenance stamp `{head_sha, dirty, stale_modules[]}` → `~/.organism/last_seen/<organ>.runtime.json` (atomic, fail-open). `stale_modules` = live blob ≠ HEAD blob per watched file (`git hash-object` vs `rev-parse HEAD:<rel>` — **W88 content compare**, never mtime/three-dot).
- **`wr2_html_render_apply.py`** — boot stamp per run; runtime SHA rides the lease owner (`…@<head12>`, CAS untouched — string built once per run); gate placed **before the Drive upload** (blocking only at persist still orphans Drive artifacts — red-team #3). `WR2_RUNTIME_SHA_GATE=off|warn|strict`, **default `warn` = log-only, zero pipeline behavior change**. `strict` (armed separately, PENDING-ARMS): refuses impure boots, aborts mid-run HEAD moves via `RuntimeStale` released **without burning an attempt** (no-burn contract, red-team #2). `designer_loop` untouched.
- **`wr2_supervisor.py`** — startup stamp (daemons keep executing boot-time code after every pull; the stamp is what the watchdog will compare).
- **`wr2-deploy-pull.sh`** — outcome heartbeat `wr2.deploy_pull.json` via `trap EXIT` on **every** path (red-team #6); empty-rev-parse guard (red-team #7); `rm -rf` basename guard (red-team #8); flag-gated kickstart (html-apply plain, supervisor/watchdog `-k`) after an advanced pull — `WR2_DEPLOY_PULL_KICKSTART` **default OFF**.

### Part 2 (separate micro-PR after #1920 lands — same watchdog file)
`RUNTIME_STALE` watchdog probe: stamps vs the checkout's current on-disk HEAD → "daemon running old code, restart needed".

### Verification
- `pytest scripts/tests/test_wr2_runtime_stamp.py` → 16 passed: stamp proven against a **real throwaway git repo** (the blob compare is exactly what a mock would lie about) + **empirical deploy-pull runs** (fake HOME/origin: trap proven on up-to-date/advanced/dirty paths; kickstart wiring proven via fake `launchctl` on `WR2_DEPLOY_PULL_TEST_PATH_PREFIX`).
- `scripts/tests/test_wr2_pipeline_consolidation.py` (imports the worker) → 22 passed; `scripts/test_wr2_autopsy_fixes.py` → 29 passed.
- Red-team spalla: Codex GPT-5.5, 9 findings — adopted #2 no-burn exception, #3 pre-Drive gate, #4 impure-boot refusal in strict, #5 owner-string built-once, #6 outcome-on-every-path, #7 rev-parse guards, #8 rm-rf guard; #9 (kickstart ≠ guarantee) documented in the kickstart comment.

### Flight boundaries honored
No live-pipeline behavior change by default (`warn` logs only; kickstart flag OFF; strict OFF). Deploy/arming DEFERRED → PENDING-ARMS ledger. No Instagram publishing anywhere near this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)