### PR TITLE
feat(wr2): RUNTIME_STALE watchdog probe — C2 part 2

### DIFF
--- a/scripts/tests/test_wr2_supervisor_watchdog.py
+++ b/scripts/tests/test_wr2_supervisor_watchdog.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -324,10 +325,12 @@ def _make_outcome_conn(stale_rows=(), age_rows=(), rendered_rows=(), renderer_en
 
 
 def _run_outcome(wd, conn):
-    """Run _evaluate_outcome_probes with reflexion pinned healthy (its own
-    tests exercise the real file) and Telegram captured."""
+    """Run _evaluate_outcome_probes with reflexion pinned healthy and the
+    runtime-stale probe pinned empty (both have dedicated tests that exercise
+    the real files) and Telegram captured."""
     sent: list[str] = []
     with patch.object(wd, "_probe_reflexion_age", lambda: ("ok", 1.0)), \
+         patch.object(wd, "_probe_runtime_stale", lambda: []), \
          patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
         asyncio.run(wd._evaluate_outcome_probes(conn))
     return sent
@@ -504,6 +507,77 @@ def test_weekly_silent_alert_via_evaluate(wd, tmp_path, monkeypatch):
     monkeypatch.setenv("WR2_SKILL_DIR", str(tmp_path / "nowhere"))
     conn = _make_outcome_conn()
     sent: list[str] = []
-    with patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
+    with patch.object(wd, "_probe_runtime_stale", lambda: []), \
+         patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
         asyncio.run(wd._evaluate_outcome_probes(conn))
     assert any("weekly reflexion SILENT" in m and "MISSING" in m for m in sent)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# C2 RUNTIME_STALE probe — provenance stamps vs checkout on disk
+# ─────────────────────────────────────────────────────────────────────────
+
+def _write_stamp(home: Path, organ: str, **fields):
+    d = home / ".organism" / "last_seen"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{organ}.runtime.json").write_text(json.dumps(fields))
+
+
+def test_runtime_stale_missing_stamps_degrade_open(wd, tmp_path, monkeypatch):
+    monkeypatch.setattr(wd.Path, "home", classmethod(lambda cls: tmp_path))
+    assert wd._probe_runtime_stale() == []
+
+
+def test_runtime_stale_dirty_checkout_flags_even_with_dead_pid(wd, tmp_path, monkeypatch):
+    """dirty/stale-modules are CHECKOUT diseases — the process being gone
+    does not cure the mutated code on disk."""
+    monkeypatch.setattr(wd.Path, "home", classmethod(lambda cls: tmp_path))
+    _write_stamp(tmp_path, "wr2.html_apply",
+                 head_sha="a" * 40, dirty=True, stale_modules=[],
+                 checkout=str(tmp_path), pid=99999999, ts="t")
+    findings = wd._probe_runtime_stale()
+    assert len(findings) == 1
+    assert "dirty-checkout" in findings[0]["problems"][0]
+
+
+def test_runtime_stale_head_moved_with_live_pid_flags(wd, tmp_path, monkeypatch):
+    monkeypatch.setattr(wd.Path, "home", classmethod(lambda cls: tmp_path))
+    _write_stamp(tmp_path, "wr2.supervisor",
+                 head_sha="a" * 40, dirty=False, stale_modules=[],
+                 checkout="/fake/checkout", pid=os.getpid(), ts="t")
+    with patch.object(wd, "_git_head", lambda c: "b" * 40):
+        findings = wd._probe_runtime_stale()
+    assert len(findings) == 1
+    assert any(p.startswith("head-moved:") for p in findings[0]["problems"])
+
+
+def test_runtime_stale_head_moved_dead_pid_is_normal(wd, tmp_path, monkeypatch):
+    """A one-shot worker's stamp outliving its process while the checkout
+    advances is the NORMAL case — no alert (innocence, cicatrix #3)."""
+    monkeypatch.setattr(wd.Path, "home", classmethod(lambda cls: tmp_path))
+    _write_stamp(tmp_path, "wr2.html_apply",
+                 head_sha="a" * 40, dirty=False, stale_modules=[],
+                 checkout="/fake/checkout", pid=99999999, ts="t")
+    with patch.object(wd, "_git_head", lambda c: "b" * 40):
+        assert wd._probe_runtime_stale() == []
+
+
+def test_runtime_stale_clean_stamp_innocent(wd, tmp_path, monkeypatch):
+    monkeypatch.setattr(wd.Path, "home", classmethod(lambda cls: tmp_path))
+    _write_stamp(tmp_path, "wr2.supervisor",
+                 head_sha="a" * 40, dirty=False, stale_modules=[],
+                 checkout="/fake/checkout", pid=os.getpid(), ts="t")
+    with patch.object(wd, "_git_head", lambda c: "a" * 40):
+        assert wd._probe_runtime_stale() == []
+
+
+def test_runtime_stale_alert_via_evaluate(wd):
+    conn = _make_outcome_conn()
+    sent: list[str] = []
+    finding = [{"organ": "wr2.supervisor", "problems": ["head-moved:a->b (live pid 1 on old code)"], "ts": "t"}]
+    with patch.object(wd, "_probe_reflexion_age", lambda: ("ok", 1.0)), \
+         patch.object(wd, "_probe_runtime_stale", lambda: finding), \
+         patch.object(wd, "_send_telegram", lambda text: sent.append(text)):
+        asyncio.run(wd._evaluate_outcome_probes(conn))
+    assert any("runtime provenance" in m and "wr2.supervisor" in m for m in sent)
+    assert wd._state_get("last_alert_runtime_stale") is not None

--- a/scripts/wr2_supervisor_watchdog.py
+++ b/scripts/wr2_supervisor_watchdog.py
@@ -73,6 +73,21 @@ trasporto, non verità"; all READ-ONLY, run right after _evaluate_once):
       OR the file is missing/malformed. Missing is an ALERT, not a skip:
       the never-armed cron is exactly the W81 disease this probe hunts.
 
+  P1 RUNTIME_STALE (C2, deploy-fork content-gate — cicatrix #1/D5)
+      Reads the ~/.organism/last_seen/<organ>.runtime.json provenance
+      stamps written by wr2_html_render_apply (per run) and wr2_supervisor
+      (at daemon startup). Two disease classes:
+        - checkout diseases (dirty / stale_modules): the code on disk is
+          not the code HEAD says — alert regardless of process state;
+        - process disease (head-moved): the stamped pid is STILL ALIVE but
+          the checkout's HEAD moved since its boot — a daemon executing
+          pre-pull code forever; the cure is a restart, and only an alert
+          makes that visible. Dead pid + moved head is the NORMAL one-shot
+          worker case (next run re-stamps) — not flagged.
+      Degrade-open when stamps are missing (C2 organs not armed yet).
+      Reader is inline JSON (no import from scripts/lib) so this probe and
+      the stamp writers can merge/arm in any order.
+
 Dependencies:
   - `wr2_supervisor_heartbeat` table (migration 161)
   - `war_room_drafts` (status, updated_at, drive_url)
@@ -96,6 +111,7 @@ import logging
 import os
 import re
 import signal
+import subprocess
 import sys
 import urllib.error
 import urllib.parse
@@ -599,6 +615,71 @@ async def _probe_manifest_gaps(conn: asyncpg.Connection) -> dict[str, Any] | Non
     return {"missing": missing, "unparseable": unparseable, "checked": len(rows)}
 
 
+RUNTIME_STALE_ORGANS = ("wr2.html_apply", "wr2.supervisor")
+
+
+def _read_runtime_stamp(organ_id: str) -> dict[str, Any] | None:
+    """~/.organism/last_seen/<organ>.runtime.json; None = missing/unreadable
+    (degrade-open — the C2 stamp writers may not be armed yet)."""
+    try:
+        path = Path.home() / ".organism" / "last_seen" / f"{organ_id}.runtime.json"
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _git_head(checkout: str) -> str | None:
+    """Current on-disk HEAD of a checkout; None on any failure (fail-open)."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", checkout, "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return out.stdout.strip() if out.returncode == 0 else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _pid_alive(pid: Any) -> bool:
+    """True if pid is a live process on THIS host (stamps are local files)."""
+    try:
+        os.kill(int(pid), 0)
+        return True
+    except (OSError, TypeError, ValueError):
+        return False
+
+
+def _probe_runtime_stale() -> list[dict[str, Any]]:
+    """C2: organs whose runtime provenance diverges from the checkout on disk.
+
+    checkout diseases (dirty / stale-modules) flag regardless of process
+    state; head-moved flags ONLY when the stamped pid is still alive — a dead
+    one-shot worker whose checkout advanced afterwards is the normal case.
+    """
+    findings: list[dict[str, Any]] = []
+    for organ in RUNTIME_STALE_ORGANS:
+        stamp = _read_runtime_stamp(organ)
+        if not stamp:
+            continue
+        problems: list[str] = []
+        if stamp.get("dirty"):
+            problems.append("dirty-checkout")
+        if stamp.get("stale_modules"):
+            problems.append("stale-modules:" + ",".join(stamp["stale_modules"]))
+        checkout = stamp.get("checkout")
+        head = stamp.get("head_sha")
+        if checkout and head and _pid_alive(stamp.get("pid")):
+            disk = _git_head(checkout)
+            if disk and disk != head:
+                problems.append(
+                    f"head-moved:{head[:12]}->{disk[:12]} (live pid {stamp.get('pid')} on old code)"
+                )
+        if problems:
+            findings.append({"organ": organ, "problems": problems, "ts": stamp.get("ts")})
+    return findings
+
+
 def _probe_reflexion_age() -> tuple[str, float | None]:
     """State of the WR2 reflexion Delta-Gate ledger.
 
@@ -654,6 +735,28 @@ async def _evaluate_outcome_probes(conn: asyncpg.Connection) -> None:
             logger.info("stale_lease detected but cooldown active (count=%d)", len(stale))
     else:
         logger.debug("leases ok")
+
+    # P1 — RUNTIME_STALE (C2): provenance stamps vs the checkout on disk
+    runtime = _probe_runtime_stale()
+    if runtime:
+        if _alert_due("runtime_stale", now_epoch):
+            lines = "\n".join(
+                f"- `{r['organ']}`: {'; '.join(r['problems'])} (stamped {r.get('ts')})"
+                for r in runtime
+            )
+            _send_telegram(
+                "⚠️ *WR2 runtime provenance*\n"
+                f"{lines}\n"
+                "An organ is executing code that diverges from its checkout — "
+                "restart the daemon (`launchctl kickstart -k gui/$(id -u)/"
+                "com.balizero.wr2.supervisor`) or investigate the dirty checkout."
+            )
+            _state_set("last_alert_runtime_stale", now_epoch)
+            logger.warning("ALERT P1 runtime_stale organs=%d", len(runtime))
+        else:
+            logger.info("runtime_stale found but cooldown active (organs=%d)", len(runtime))
+    else:
+        logger.debug("runtime provenance ok")
 
     # P2 — STATE_AGE (+ unknown-state drift)
     renderer_enabled = await _probe_renderer_enabled(conn)


### PR DESCRIPTION
## C2 part 2 — il probe che chiude il content-gate

Part 1 (#1929) writes the provenance stamps; this PR makes the watchdog READ them. P1 `RUNTIME_STALE` fires on:

| Disease | Condition | Flag |
|---|---|---|
| checkout | `dirty` or `stale_modules` in the stamp | always (the process being gone does not cure mutated code on disk) |
| process | stamp `head_sha` ≠ current on-disk HEAD **and stamped pid still alive** | only live pids — a dead one-shot worker whose checkout advanced is the normal case |

- Inline JSON reader, zero imports from `scripts/lib` → merges/arms in any order with #1929; missing stamps degrade-open.
- Alert message names the cure (`launchctl kickstart -k …`) — this is the detector for the daemon-running-old-code disease lived on 2026-06-30 (D5, cicatrix #1).
- Tests: 43/43 (6 new, innocence + guilt per disease class).

Arming: deferred with the rest of C1/C2 (PENDING-ARMS — watchdog daemon restart on Pro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)