### PR TITLE
feat(docs): doc-freshness report + doc-organs system map (doc-organs PR3/3)

### DIFF
--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -1,0 +1,48 @@
+name: Doc Freshness Report
+
+# On-demand only (workflow_dispatch) — report-only signaler, NO schedule by
+# design: W84 proved cron/daemon proliferation fragile; the weekly
+# docs-guardian cron on Pro and manual runs are the cadence. Also triggers
+# on changes to itself/the script/its tests so regressions surface in PR CI.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/doc_freshness_report.py"
+      - "scripts/tests/test_doc_freshness_report.py"
+      - ".github/workflows/doc-freshness.yml"
+
+concurrency:
+  group: doc-freshness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # git-history ages (same requirement as docs-guardian)
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Run unit tests
+        run: |
+          python -m pip install --quiet pytest
+          python -m pytest scripts/tests/test_doc_freshness_report.py -q
+
+      - name: Generate report
+        run: |
+          python scripts/doc_freshness_report.py --write doc-freshness-report.md
+          cat doc-freshness-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: doc-freshness-report
+          path: doc-freshness-report.md
+          retention-days: 30

--- a/research/operations/2026-07-03-doc-organs-map.md
+++ b/research/operations/2026-07-03-doc-organs-map.md
@@ -1,0 +1,170 @@
+---
+date: 2026-07-03
+domain: operations
+client_case: none
+sources:
+  - scripts/docs_sync.py + .github/workflows/docs-sync.yml (read this session)
+  - scripts/docs_audit.py + scripts/docs_guardian.sh + .github/workflows/docs-guardian.yml
+  - scripts/docs_link_fixer.py, scripts/docs_history_analyzer.py, scripts/generate_automations_reference.py
+  - scripts/build_repomap.sh + Pro crontab/LaunchAgents (probed live via ssh)
+  - two parallel disk sweeps (dead-paths, undocumented-organs), 2026-07-02
+  - PRs #1936 (drift fixes), #1939 (generation extension), PR3 (this file + freshness report)
+---
+
+# Documentation-as-organ — system map (GEAR 3, 2026-07-02/03)
+
+**Mandate**: make the system MAPPED and AUTO-DOCUMENTED. Doctrine: hand-written
+docs rot (W86 / doc-drift family) — the deliverable is GENERATION + FRESHNESS
+GATES, not more prose. This file is the map of what exists, what was drifting,
+what changed, and what remains operator-only.
+
+## 1. The doc-organ system (as found on disk, verified this session)
+
+| Organ | Kind | Output | Armed? (probed, not assumed) |
+| ----- | ---- | ------ | ---------------------------- |
+| `scripts/docs_sync.py` (DocSentinel) | generator (DOCSYNC markers) | README.md, docs/AI_ONBOARDING.md — **+ INDEX.md, docs/runbooks/README.md since PR #1939**; CLAUDE.md was a DEAD target (markers removed in F44) until PR #1939 dropped it | ✅ CI gate `docs-sync.yml` (PR+push) + called by docs_guardian.sh |
+| `.github/workflows/docs-sync.yml` | CI gate | fails PR if markers stale | ✅ — **paths extended in #1939** to every generation input (W86 antidote) |
+| `scripts/docs_audit.py` | generator + classifier | docs/DOCS_INVENTORY.md (LIVE/STALE/ARCHIVED, broken links, orphans) — scope: `docs/**/*.md` only | ✅ CI gate `docs-guardian.yml` (PRs touching docs/**) + weekly cron |
+| `scripts/docs_guardian.sh` | weekly cron (L0 inventory, L1 auto-archive PR, L2.5 Claude link-fixer) | auto-PRs | ✅ Pro crontab `0 5 * * 0` via cron-state.sh (probed: `ssh pro crontab -l`) |
+| `scripts/docs_link_fixer.py` | LLM repairer (claude CLI OAuth) | link fixes inside guardian PRs | ✅ via guardian |
+| `scripts/docs_history_analyzer.py` | generator | docs/DOCS_TRENDS.md (monthly trend mining) | ❌ **NOT armed** — no crontab/plist anywhere; output 69d old vs 31d cadence |
+| `scripts/generate_automations_reference.py` | generator (scans LIVE crontab+launchctl on Pro+Mini) | docs/AUTOMATIONS_REFERENCE.md | ⚠️ on-demand only, no cadence — last regen 2026-05-31; root cause of the 45% plist-coverage gap |
+| `scripts/build_repomap.sh` | generator | `~/.nuzantara-repomap.txt` (session context inject) | ✅ `com.nuzantara.repomap.15min` plist on Pro (probed) |
+| `scripts/doc_freshness_report.py` | **NEW (PR3)** reconciliation signaler | markdown/JSON report, 4 sections | on-demand + `doc-freshness.yml` workflow_dispatch; report-only, exit 0 (W81: signaler, not actuator; W84: no new daemon) |
+| INDEX.md | atlas — hand-written narrative **+ generated enumerable section since #1939** | — | narrative part gated only by freshness report |
+| VADEMECUM.md / SYMBIOSIS.md | operator voice (Legge 5 — never rewritten by agents) | — | out of generation scope by design |
+| `scripts/automation_catalog.json` | hand-maintained catalog | — | `_updated: 2026-04-16` — 2.5 months stale |
+
+## 2. Drift measured (evidence, 2026-07-02)
+
+- **15 dead path references** across the atlas: README.md 8 (7 deleted apps +
+  `packages/kb`→`apps/kb`), AI_ONBOARDING.md 4, INDEX.md 1 (`apps/federation`,
+  deleted in 5c06a2fd5), VADEMECUM.md 2 (aspirational, never existed).
+- **AI_ONBOARDING.md onboarded AIs onto a decommissioned machine**: the QUICK
+  START peer-check still targeted Air M4 (`antonellosiano@Nuzantara-9`,
+  decommissioned 2026-05-05) with `[Pro] or [Air]` prefixes.
+- **Hand-written numbers contradicting generated blocks in the same file**:
+  README said "20 apps / 88 routers / 244 services / 10 collections / 93,283
+  documents" while its own DOCSYNC block 2 lines away said 30 / 329 / 635 / 12
+  / 104,154.
+- **A DOCSYNC marker with no generator**: `FEATURE_FLAGS` in README looked
+  auto-synced; no template exists for it (nothing in scripts/, .github/).
+- **4 of 6 docs_sync templates defined but planted nowhere** (BACKEND_STATS,
+  VECTOR_STATS, EMBEDDING_FROZEN, LIVING_ORGANS — the last one lost its home
+  in the T2.7 CLAUDE.md refactor and nobody noticed).
+- **7 apps in NO documentation at all** (autonomous-lab, kb, kbli-navigator,
+  nlm-bridge, openclaw-hgt-coordinator, osint-nexus-ui, team-agent); 9 apps
+  have no README.md.
+- **52/116 LaunchAgent plists documented nowhere** (neither
+  automation_catalog.json nor AUTOMATIONS_REFERENCE.md).
+- **19/33 runbooks orphans** (referenced by no other markdown).
+- **Doc↔code gap** (freshness report §4): 15 apps whose code moved ≥30d after
+  their README was last touched; worst: `apps/evaluator` (README 165d old,
+  code 11d — gap 153d).
+- One behavioral contradiction: AI_ONBOARDING note 3 said "`--no-verify` is
+  OK" vs CLAUDE.md §8.12 "never `--no-verify`".
+
+## 3. What changed (3 small PRs, auto-merged)
+
+1. **PR #1936 — drift fixes** (content only): the 13 fixable dead refs, the
+   Air-M4 onboarding block, the contradicting hand-written stats, the lying
+   FEATURE_FLAGS marker demoted to an honest hand-maintained comment,
+   `--no-verify` note aligned. DOCS_INVENTORY regenerated in the same commit.
+2. **PR #1939 — generation extension**: 4 new stdlib-only extractors in
+   docs_sync.py (`git ls-files`-based for local↔CI determinism): runbooks
+   index → generated `docs/runbooks/README.md` (33 runbooks); workflows meta
+   (anchored to `export const meta`); repo skills frontmatter (YAML
+   folded-scalar aware); LaunchAgent documentation-coverage signaler. INDEX.md
+   gains an auto-generated section (full 30-app table via the replanted
+   LIVING_ORGANS template + workflows + skills + coverage). CI gate paths
+   extended to all generation inputs; 10 unit tests run in the gate.
+   Falsification probe passed: a new tracked runbook flips `--check` to rc=1.
+3. **PR3 — freshness report**: `scripts/doc_freshness_report.py`
+   (deterministic, zero-LLM, report-only): atlas dead-path scan, organ-arming
+   ages vs declared cadence, coverage (plists 55%, apps without README),
+   doc↔code pairing. 6 unit tests incl. innocence AND guilt fixtures (#3
+   family). Armed via `doc-freshness.yml` workflow_dispatch (fetch-depth 0
+   for git ages) + runnable from the existing guardian cron. This map file.
+
+**Numbers (Law 7, before → after)**: atlas dead paths 15 → **0**
+(script-verified); apps enumerated in the atlas 13 → **30** (mechanical);
+runbooks indexed 0 → **33**; markers-without-generator 1 → 0; dead docs_sync
+targets 1 → 0; unplanted templates 4 → 3 (see §5); plist coverage unchanged at
+**55% but now VISIBLE** in INDEX.md and re-measured on every regen.
+
+## 4. §Meta-pattern (the malattia-delle-malattie)
+
+Every finding above is one disease: **documentation is trusted in proportion
+to how auto-generated it LOOKS, not how auto-generated it IS.**
+
+- A DOCSYNC marker with no generator (FEATURE_FLAGS) is the pure form: the
+  costume of automation worn by frozen hand-writing.
+- INDEX.md pointing to "auto-synced metrics in CLAUDE.md" after F44 removed
+  those markers: the POINTER to automation outlived the automation.
+- Hand-written counts beside a generated block: the reader cannot tell which
+  number is alive, so both inherit the credibility of the generated one.
+- AUTOMATIONS_REFERENCE.md: generated once, never re-armed — "generated" in
+  provenance but hand-frozen in behavior (Esiste≠Armato, W81, at the
+  doc layer).
+- LIVING_ORGANS: a working generator whose OUTPUT SLOT was refactored away —
+  automation without a home is indistinguishable from no automation.
+
+The single defective belief: *"writing documentation = documenting"*. A doc
+that enumerates changing reality is a RUNTIME, not an artifact — it needs an
+arming state, a cadence, and a gate, exactly like a daemon. The structural
+antidote shipped here: every enumerable section is either (a) generated with
+its inputs in the CI gate's paths, or (b) explicitly labeled hand-maintained,
+or (c) measured by the freshness report. No fourth state — "looks generated" —
+is allowed to exist.
+
+Corollary (measurement honesty): PR #1939's generated runbook index kills the
+*orphan metric* for runbooks (every runbook now has ≥1 inbound ref) without
+killing the *disease* (nobody contextually points at them). The freshness
+report's doc↔code section keeps the real signal. When a fix satisfies the
+metric, re-derive what the metric was a proxy FOR.
+
+## 5. §Solo-operatore (physical / strategic / operator-only)
+
+1. **VADEMECUM.md aspirational refs** (`PRICING_REFERENCE.md`,
+   `VISA_TYPES_REFERENCE.md`, VADEMECUM:413-414): operator voice (Legge 5) —
+   decide: write those reference docs, or delete the two lines. Not touched
+   by agents.
+2. **Arm docs_history_analyzer.py** (DOCS_TRENDS, monthly): needs a new cron
+   entry — new crons are operator-gated (AUTONOMOUS_OPS L2). Suggested: one
+   line in the Pro crontab next to docs-guardian, monthly.
+3. **Give generate_automations_reference.py a cadence**: it must run on Pro
+   (scans live crontab+launchctl on Pro+Mini via ssh). Suggested: append to
+   the existing docs-guardian Sunday cron line. This single arming closes
+   most of the 45%-undocumented-plist gap mechanically.
+4. **automation_catalog.json strategy call**: hand-maintained, 2.5 months
+   stale, 46 entries vs 117 plists. Either commit to feeding it (it is the
+   declared source in VADEMECUM §1) or demote it and let
+   AUTOMATIONS_REFERENCE.md (generated) be canonical. Contradictory truth
+   sources are the W86 disease at the catalog level.
+5. **9 apps without README.md** (`autonomous-lab`, `cell`, `kb`,
+   `kbli-navigator`, `nlm-bridge`, `openclaw-hgt-coordinator`,
+   `osint-nexus-ui`, `research`, `team-agent`): the generated INDEX table now
+   shows them with an EMPTY role cell — the gap is visible. Writing the
+   READMEs needs owner knowledge of intent (some are operator experiments).
+6. **3 remaining unplanted templates** (BACKEND_STATS, VECTOR_STATS,
+   EMBEDDING_FROZEN): decide to plant (e.g. EMBEDDING_FROZEN into
+   AI_ONBOARDING's frozen-model section) or delete. Left untouched to keep
+   PR #1939 scoped; they are inert but re-create the "defined, planted
+   nowhere" state this mandate found.
+7. **Fleet alignment**: Pro/Mini/M5 main checkouts must pull post-merge —
+   Pro and Mini pulls are hook/sibling-blocked, M5 airborne (existing
+   PENDING-ALIGN lines in `.claude/skills/modus/PENDING-ARMS.md` carry this;
+   the weekly guardian cron on Pro runs from the Pro main checkout, so its
+   docs_sync copy stays v1 until that pull lands — outputs stay correct, it
+   simply won't regenerate the new markers until then).
+
+## 6. Operating rules going forward (the loop, one paragraph)
+
+Adding a runbook / workflow / repo skill / plist / app README → run
+`python scripts/docs_sync.py` in the same commit (the `docs-sync.yml` gate
+fails the PR otherwise — probed, it bites). Weekly: docs-guardian (Pro cron)
+refreshes the inventory, auto-archives orphans, auto-fixes links. On demand /
+suspicion: `python scripts/doc_freshness_report.py` (or the `doc-freshness`
+workflow_dispatch) shows dead paths, un-armed organs, coverage, and doc↔code
+gaps — report-only, the human decides. Hand-written narrative (SYMBIOSIS,
+VADEMECUM, INDEX prose) stays human; everything enumerable is generated.

--- a/scripts/doc_freshness_report.py
+++ b/scripts/doc_freshness_report.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Doc-freshness report — reconciliation signaler for the documentation organs.
+
+Measures what the marker/inventory gates cannot see:
+
+  1. ATLAS DEAD PATHS  — repo-relative references in the atlas files
+                         (INDEX/VADEMECUM/README/AI_ONBOARDING/AUTOMATIONS_REFERENCE)
+                         that no longer exist on disk.
+  2. ORGAN ARMING      — age of each generated doc output vs its declared
+                         cadence (built ≠ armed: an on-demand generator with
+                         no cadence rots silently — W81 family).
+  3. COVERAGE          — enumerable organs vs their catalogs: LaunchAgent
+                         plists documented anywhere; apps without README.
+  4. DOC↔CODE PAIRING  — per-app README age vs the app's code age ("code
+                         moved N days after its doc was last touched").
+
+Report-only by design (W81 antidote: reconciliation-report = signaler, not
+auto-actuator; exit 0 even when findings exist). No daemon (W84) — run on
+demand, via workflow_dispatch CI, or from the weekly docs-guardian cron.
+
+Scope honesty (#3 under-match, declared): only path-shaped tokens (containing
+"/" and starting with a known repo prefix) are checked — bare aspirational
+filenames (e.g. `PRICING_REFERENCE.md` in VADEMECUM) are NOT flagged.
+
+No external dependencies. Python stdlib only.
+
+Usage:
+    python scripts/doc_freshness_report.py            # markdown to stdout
+    python scripts/doc_freshness_report.py --json     # machine-readable
+    python scripts/doc_freshness_report.py --write P  # also write to file P
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+ATLAS_FILES = [
+    "INDEX.md",
+    "VADEMECUM.md",
+    "README.md",
+    "docs/AI_ONBOARDING.md",
+    "docs/AUTOMATIONS_REFERENCE.md",
+]
+
+# Path-shaped tokens must start with one of these to be checked (entity match,
+# not bare substring — #3 family antidote).
+REF_PREFIXES = (
+    "apps/",
+    "scripts/",
+    "docs/",
+    "packages/",
+    "infra/",
+    ".claude/",
+    ".github/",
+    "shared/",
+    "config/",
+    "data/",
+    "research/",
+    # NOT "migrations_v2/": in the docs that token is backend-relative
+    # shorthand (apps/backend-rag/backend/db/migrations_v2/), root-resolution
+    # would flag it falsely (innocence probe, 2026-07-02).
+)
+
+# Declared cadences for generated outputs (organ → (path, cadence_days, generator)).
+# cadence_days=None → no declared cadence: age is reported, verdict NO-CADENCE.
+GENERATED_OUTPUTS = [
+    ("DOCS_INVENTORY", "docs/DOCS_INVENTORY.md", 7, "scripts/docs_audit.py (weekly docs-guardian cron, Pro)"),
+    ("DOCS_TRENDS", "docs/DOCS_TRENDS.md", 31, "scripts/docs_history_analyzer.py (monthly by design — NOT armed)"),
+    ("AUTOMATIONS_REFERENCE", "docs/AUTOMATIONS_REFERENCE.md", None, "scripts/generate_automations_reference.py (on demand)"),
+    ("AUTOMATION_CATALOG", "scripts/automation_catalog.json", None, "hand-maintained JSON"),
+]
+
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+CODE_RE = re.compile(r"`([^`\n]+)`")
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+def _git(args: list[str]) -> str:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return ""
+
+
+def _git_last_commit_ts(pathspecs: list[str]) -> int:
+    """Unix ts of the last commit touching pathspecs, 0 if unknown."""
+    out = _git(["log", "-1", "--format=%ct", "--", *pathspecs]).strip()
+    try:
+        return int(out)
+    except ValueError:
+        return 0
+
+
+def _age_days(ts: int) -> int:
+    if ts <= 0:
+        return -1
+    now = datetime.now(tz=timezone.utc)
+    then = datetime.fromtimestamp(ts, tz=timezone.utc)
+    return (now.date() - then.date()).days
+
+
+def _tracked(prefix: str) -> list[str]:
+    return [l.strip() for l in _git(["ls-files", prefix]).splitlines() if l.strip()]
+
+
+# ---------------------------------------------------------------------------
+# 1. Atlas dead paths
+# ---------------------------------------------------------------------------
+
+def _candidate_refs(doc_rel: str, text: str) -> list[tuple[str, str]]:
+    """Extract (kind, target) candidates: markdown links + path-shaped code tokens."""
+    out: list[tuple[str, str]] = []
+    for m in LINK_RE.finditer(text):
+        out.append(("link", m.group(1).strip()))
+    for m in CODE_RE.finditer(text):
+        out.append(("code", m.group(1).strip()))
+    return out
+
+
+def _normalize(token: str) -> str:
+    """Strip anchors/queries, trailing :line and punctuation."""
+    token = token.split("#", 1)[0].split("?", 1)[0].strip()
+    token = re.sub(r":\d+(-\d+)?$", "", token)  # file.py:12 / file.py:12-30
+    return token.rstrip(").,:;")
+
+
+def _is_checkable_path(token: str) -> bool:
+    if not token or " " in token:
+        return False
+    if token.startswith(("http://", "https://", "mailto:", "#", "/", "~")):
+        return False
+    if any(ch in token for ch in "*?{}$<>|"):
+        return False  # glob / placeholder / expansion — not a literal path
+    if "..." in token:
+        return False
+    if "NNN" in token:
+        # NNN = migration-number naming template (VADEMECUM §migrations).
+        # Plain substring, NOT \bNNN\b: in `NNN_name.sql` the underscore is a
+        # word char, so the word-boundary never matches (caught by tests).
+        return False
+    return "/" in token and token.startswith(REF_PREFIXES)
+
+
+def scan_atlas_dead_paths() -> list[dict[str, str]]:
+    """Dead repo-relative references across the atlas files."""
+    dead: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for rel in ATLAS_FILES:
+        doc = REPO_ROOT / rel
+        if not doc.is_file():
+            dead.append({"doc": rel, "ref": rel, "kind": "atlas-file-missing"})
+            continue
+        text = doc.read_text(encoding="utf-8", errors="ignore")
+        for kind, raw in _candidate_refs(rel, text):
+            token = _normalize(raw)
+            if kind == "link":
+                if token.startswith(("http://", "https://", "mailto:", "#")) or not token:
+                    continue
+                # Links resolve relative to the doc's directory (docs_audit rule)
+                resolved = (doc.parent / token).resolve()
+                try:
+                    rel_resolved = resolved.relative_to(REPO_ROOT.resolve())
+                except ValueError:
+                    continue
+                if not resolved.exists() and (rel, str(rel_resolved)) not in seen:
+                    seen.add((rel, str(rel_resolved)))
+                    dead.append({"doc": rel, "ref": str(rel_resolved), "kind": "link"})
+            else:
+                if not _is_checkable_path(token):
+                    continue
+                if not (REPO_ROOT / token).exists() and (rel, token) not in seen:
+                    seen.add((rel, token))
+                    dead.append({"doc": rel, "ref": token, "kind": "code"})
+    return dead
+
+
+# ---------------------------------------------------------------------------
+# 2. Organ arming (output age vs declared cadence)
+# ---------------------------------------------------------------------------
+
+def scan_organ_arming() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for name, rel, cadence, generator in GENERATED_OUTPUTS:
+        path = REPO_ROOT / rel
+        if not path.exists():
+            rows.append(
+                {"organ": name, "path": rel, "age_days": -1, "cadence_days": cadence,
+                 "verdict": "MISSING", "generator": generator}
+            )
+            continue
+        age = _age_days(_git_last_commit_ts([rel]))
+        if cadence is None:
+            verdict = "NO-CADENCE"
+        elif age < 0:
+            verdict = "UNKNOWN"
+        elif age <= cadence:
+            verdict = "OK"
+        else:
+            verdict = "STALE"
+        rows.append(
+            {"organ": name, "path": rel, "age_days": age, "cadence_days": cadence,
+             "verdict": verdict, "generator": generator}
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# 3. Coverage
+# ---------------------------------------------------------------------------
+
+def scan_coverage() -> dict[str, Any]:
+    labels = [
+        rel.rsplit("/", 1)[-1][: -len(".plist")]
+        for rel in _tracked("infra/launchagents/")
+        if rel.endswith(".plist")
+    ]
+    haystack = ""
+    for rel in ("scripts/automation_catalog.json", "docs/AUTOMATIONS_REFERENCE.md"):
+        p = REPO_ROOT / rel
+        try:
+            haystack += p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+    undocumented = sorted(l for l in labels if l not in haystack)
+
+    app_names: set[str] = set()
+    apps_with_readme: set[str] = set()
+    for rel in _tracked("apps/"):
+        parts = rel.split("/", 2)
+        if len(parts) >= 2 and parts[1]:
+            app_names.add(parts[1])
+        if len(parts) == 3 and parts[2] == "README.md":
+            apps_with_readme.add(parts[1])
+    apps_without_readme = sorted(app_names - apps_with_readme)
+
+    return {
+        "plists_total": len(labels),
+        "plists_undocumented": undocumented,
+        "apps_total": len(app_names),
+        "apps_without_readme": apps_without_readme,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. Doc <-> code pairing
+# ---------------------------------------------------------------------------
+
+def scan_doc_code_pairing(min_gap_days: int = 30, top: int = 15) -> list[dict[str, Any]]:
+    """Apps whose code last moved > min_gap_days AFTER their README's last touch."""
+    app_names: set[str] = set()
+    with_readme: set[str] = set()
+    for rel in _tracked("apps/"):
+        parts = rel.split("/", 2)
+        if len(parts) >= 2 and parts[1]:
+            app_names.add(parts[1])
+        if len(parts) == 3 and parts[2] == "README.md":
+            with_readme.add(parts[1])
+    rows: list[dict[str, Any]] = []
+    for app in sorted(with_readme):
+        readme_ts = _git_last_commit_ts([f"apps/{app}/README.md"])
+        code_ts = _git_last_commit_ts(
+            [f"apps/{app}", f":(exclude)apps/{app}/README.md"]
+        )
+        if readme_ts <= 0 or code_ts <= 0:
+            continue
+        gap = (code_ts - readme_ts) // 86400
+        if gap >= min_gap_days:
+            rows.append(
+                {"app": app, "readme_age_days": _age_days(readme_ts),
+                 "code_age_days": _age_days(code_ts), "gap_days": int(gap)}
+            )
+    rows.sort(key=lambda r: (-r["gap_days"], r["app"]))
+    return rows[:top]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def gather() -> dict[str, Any]:
+    return {
+        "dead_paths": scan_atlas_dead_paths(),
+        "organ_arming": scan_organ_arming(),
+        "coverage": scan_coverage(),
+        "doc_code_pairing": scan_doc_code_pairing(),
+    }
+
+
+def render_markdown(data: dict[str, Any]) -> str:
+    ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    out: list[str] = []
+    out.append("# Doc-Freshness Report")
+    out.append("")
+    out.append(f"_Generated by `scripts/doc_freshness_report.py` · {ts} · report-only (signaler, not gate)_")
+    out.append("")
+
+    dead = data["dead_paths"]
+    out.append(f"## 1. Atlas dead paths ({len(dead)})")
+    out.append("")
+    if dead:
+        out.append("| Doc | Dead reference | Kind |")
+        out.append("| --- | -------------- | ---- |")
+        for d in dead:
+            out.append(f"| {d['doc']} | `{d['ref']}` | {d['kind']} |")
+    else:
+        out.append("None — every path-shaped reference in the atlas resolves on disk.")
+    out.append("")
+
+    out.append("## 2. Organ arming (output age vs declared cadence)")
+    out.append("")
+    out.append("| Organ | Output | Age (d) | Cadence (d) | Verdict | Generator |")
+    out.append("| ----- | ------ | ------: | ----------: | ------- | --------- |")
+    for r in data["organ_arming"]:
+        cad = r["cadence_days"] if r["cadence_days"] is not None else "—"
+        out.append(
+            f"| {r['organ']} | `{r['path']}` | {r['age_days']} | {cad} "
+            f"| **{r['verdict']}** | {r['generator']} |"
+        )
+    out.append("")
+
+    cov = data["coverage"]
+    und = cov["plists_undocumented"]
+    pct = (
+        round(100 * (cov["plists_total"] - len(und)) / cov["plists_total"])
+        if cov["plists_total"]
+        else 0
+    )
+    out.append("## 3. Coverage")
+    out.append("")
+    out.append(
+        f"- LaunchAgents: **{cov['plists_total']} plists tracked**, "
+        f"{len(und)} documented nowhere ({pct}% coverage)."
+    )
+    if und:
+        out.append(f"  - Undocumented: {', '.join('`' + u + '`' for u in und[:20])}"
+                   + (f" … +{len(und) - 20} more" if len(und) > 20 else ""))
+    out.append(
+        f"- Apps: **{cov['apps_total']} tracked**, "
+        f"{len(cov['apps_without_readme'])} without README.md."
+    )
+    if cov["apps_without_readme"]:
+        out.append(
+            "  - No README: "
+            + ", ".join("`" + a + "`" for a in cov["apps_without_readme"])
+        )
+    out.append("")
+
+    pairs = data["doc_code_pairing"]
+    out.append("## 4. Doc↔code pairing (code moved ≥30d after its README)")
+    out.append("")
+    if pairs:
+        out.append("| App | README age (d) | Code age (d) | Gap (d) |")
+        out.append("| --- | -------------: | -----------: | ------: |")
+        for p in pairs:
+            out.append(
+                f"| `apps/{p['app']}` | {p['readme_age_days']} "
+                f"| {p['code_age_days']} | {p['gap_days']} |"
+            )
+    else:
+        out.append("None above threshold.")
+    out.append("")
+    out.append(
+        "> Scope honesty: bare filenames without a path prefix are NOT checked "
+        "(declared under-match, #3 family); repomap liveness is machine-local "
+        "state and out of scope for a repo-side report."
+    )
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Doc-freshness reconciliation report")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of markdown")
+    parser.add_argument("--write", metavar="PATH", help="also write the report to PATH")
+    args = parser.parse_args()
+
+    try:
+        data = gather()
+    except Exception as exc:  # catastrophic only — report-only otherwise
+        print(f"doc_freshness_report: fatal: {exc}", file=sys.stderr)
+        return 2
+
+    output = json.dumps(data, indent=2) if args.json else render_markdown(data)
+    print(output)
+    if args.write:
+        Path(args.write).write_text(output, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_doc_freshness_report.py
+++ b/scripts/tests/test_doc_freshness_report.py
@@ -1,0 +1,117 @@
+"""Tests for scripts/doc_freshness_report.py (report-only signaler)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "doc_freshness_report.py"
+
+_spec = importlib.util.spec_from_file_location("doc_freshness_report", SCRIPT)
+dfr = importlib.util.module_from_spec(_spec)
+sys.modules["doc_freshness_report"] = dfr
+_spec.loader.exec_module(dfr)
+
+
+# ---------------------------------------------------------------------------
+# Reference extraction / normalization (the #3-family unit: innocence AND guilt)
+# ---------------------------------------------------------------------------
+
+def test_normalize_strips_line_numbers_and_punct():
+    assert dfr._normalize("scripts/docs_sync.py:255") == "scripts/docs_sync.py"
+    assert dfr._normalize("apps/foo/bar.py:12-30") == "apps/foo/bar.py"
+    assert dfr._normalize("docs/x.md).") == "docs/x.md"
+    assert dfr._normalize("docs/x.md#anchor") == "docs/x.md"
+
+
+def test_checkable_path_guilt():
+    # Path-shaped, known prefix → must be checked
+    assert dfr._is_checkable_path("apps/federation/")
+    assert dfr._is_checkable_path("scripts/docs_sync.py")
+
+
+def test_checkable_path_innocence():
+    # URLs, globs, placeholders, bare filenames, env-expansions → never checked
+    assert not dfr._is_checkable_path("https://example.com/apps/x")
+    assert not dfr._is_checkable_path("apps/*/README.md")
+    assert not dfr._is_checkable_path("apps/<nome>/README.md")
+    assert not dfr._is_checkable_path("PRICING_REFERENCE.md")  # bare, aspirational
+    assert not dfr._is_checkable_path("$HOME/scripts/x.sh")
+    assert not dfr._is_checkable_path("~/logs/x.log")
+    assert not dfr._is_checkable_path("apps/evaluator/nlm_deep_research/*_state.json")
+    assert not dfr._is_checkable_path("")
+    # NNN naming templates (real false positives caught by the 2026-07-02
+    # innocence probe — parent dirs exist, the basename is a convention)
+    assert not dfr._is_checkable_path(
+        "apps/backend-rag/backend/db/migrations_v2/NNN_name.sql"
+    )
+    assert not dfr._is_checkable_path(
+        "apps/backend-rag/backend/migrations/apply_migration_NNN.py"
+    )
+    # backend-relative shorthand must not be root-resolved
+    assert not dfr._is_checkable_path("migrations_v2/")
+
+
+def test_scan_atlas_flags_known_dead_ref(tmp_path, monkeypatch):
+    # Synthetic atlas: one live ref, one dead code ref, one dead link.
+    root = tmp_path
+    (root / "docs").mkdir()
+    (root / "scripts").mkdir()
+    (root / "scripts" / "real.py").write_text("# real\n")
+    (root / "INDEX.md").write_text(
+        "See `scripts/real.py` and `scripts/ghost.py`.\n"
+        "[dead link](docs/GONE.md)\n"
+        "[url](https://x.com) `apps/*/glob` `BARE.md`\n"
+    )
+    for rel in dfr.ATLAS_FILES[1:]:
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("clean\n")
+    monkeypatch.setattr(dfr, "REPO_ROOT", root)
+    dead = dfr.scan_atlas_dead_paths()
+    refs = {(d["doc"], d["ref"]) for d in dead}
+    assert ("INDEX.md", "scripts/ghost.py") in refs
+    assert ("INDEX.md", "docs/GONE.md") in refs
+    # Innocence: live file, URL, glob, bare filename NOT flagged
+    assert all(r[1] not in ("scripts/real.py", "apps/*/glob", "BARE.md") for r in refs)
+
+
+# ---------------------------------------------------------------------------
+# Smoke on the real repo (the report must run green end-to-end)
+# ---------------------------------------------------------------------------
+
+def test_smoke_real_repo_exit_zero_and_sections():
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr[-500:]
+    for header in (
+        "## 1. Atlas dead paths",
+        "## 2. Organ arming",
+        "## 3. Coverage",
+        "## 4. Doc↔code pairing",
+    ):
+        assert header in proc.stdout
+
+
+def test_json_mode_parses():
+    import json
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert set(data) == {"dead_paths", "organ_arming", "coverage", "doc_code_pairing"}
+    assert data["coverage"]["plists_total"] > 0


### PR DESCRIPTION
## Doc-organs GEAR 3 — PR 3/3: freshness signaler + system map

Completes the arc: #1936 (drift fixes) → #1939 (generation + gates) → this.

### What
- **`scripts/doc_freshness_report.py`** — deterministic, report-only reconciliation signaler (W81: signaler not actuator; W84: no daemon). 4 sections: atlas dead paths / organ arming vs cadence / coverage / doc↔code pairing. Current live findings: DOCS_TRENDS 69d old (generator never armed), 53/117 plists documented nowhere, 15 apps with code ≥30d newer than their README.
- **`doc-freshness.yml`** — workflow_dispatch (on-demand, no schedule) + PR-trigger on its own files; report to step summary + artifact.
- **`research/operations/2026-07-03-doc-organs-map.md`** — the mandate deliverable: full organ map with per-organ armed-state (probed, not assumed), drift evidence, §Meta-pattern, §Solo-operatore (7 operator items).

### Verification
- 6/6 unit tests (innocence AND guilt fixtures — the scanner initially false-flagged 3 VADEMECUM refs; probe → rules → pinned by tests; incl. the `\bNNN\b`-vs-underscore word-boundary trap)
- Real-repo run: exit 0, all 4 sections, **0 atlas dead paths** post-#1936 — the mechanical scanner independently confirms PR1's hand fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)