### PR TITLE
fix(organism): supervisor redis auth + promote 3 HOME-only wrappers (proprioception)

### DIFF
--- a/apps/organism/organism/emit.py
+++ b/apps/organism/organism/emit.py
@@ -25,7 +25,11 @@ def _get_bus() -> EventBus:
     """Lazy-init EventBus singleton. Overridable in tests via monkeypatch."""
     global _bus_singleton
     if _bus_singleton is None:
-        r = redis.from_url(_REDIS_URL, decode_responses=False)
+        # #1944 pattern: honor REDIS_PASSWORD when the URL carries no password
+        # (conditional: an explicit password=None would clobber an in-URL password)
+        _pw = os.getenv("REDIS_PASSWORD")
+        r = redis.from_url(_REDIS_URL, decode_responses=False,
+                           **({"password": _pw} if _pw else {}))
         _bus_singleton = EventBus(redis=r, jsonl_path=ORGANISM_JSONL_DEFAULT)
     return _bus_singleton
 

--- a/apps/organism/organism/supervisor/daemon.py
+++ b/apps/organism/organism/supervisor/daemon.py
@@ -212,8 +212,15 @@ async def main() -> None:  # pragma: no cover — launchd entrypoint
 
     from organism.actuators import build_actuator_registry
 
+    # #1944 pattern: Pro redis has requirepass since 2026-06-29 — honor
+    # REDIS_PASSWORD from the secrets env when the URL carries no password
+    # (this daemon was crash-looping on AuthenticationError, 98 restarts,
+    # heartbeat mute — found by proprioception organs_heartbeat 2026-07-03).
+    _redis_pw = os.getenv("REDIS_PASSWORD")
     r = _redis.from_url(
         os.getenv("ORGANISM_REDIS_URL", "redis://127.0.0.1:6379/0"),
+        # conditional: an explicit password=None would clobber an in-URL password
+        **({"password": _redis_pw} if _redis_pw else {}),
     )
     rules_path = Path(os.getenv(
         "ORGANISM_RULES_PATH",

--- a/infra/launchagents/wrappers/bz-nlm-autodownload.sh
+++ b/infra/launchagents/wrappers/bz-nlm-autodownload.sh
@@ -1,0 +1,54 @@
+#!/bin/zsh
+# Auto-download NLM artifacts (BZ business analysis IT) to Desktop when ready.
+# Idempotent: writes a .done marker per artifact so it never re-downloads.
+# Self-unloads its LaunchAgent once BOTH artifacts are on disk.
+set -u
+
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+NB="361fcb85-c5ee-41ee-9e35-0535ca9b2198"
+VID_ART="d01a590b-e5d4-4c3f-9a09-0bf3cd57835f"
+SLD_ART="36048596-076f-4b77-9ac4-3a8a55161fcd"
+DESK="$HOME/Desktop"
+STATE="$HOME/.local/state/bz-nlm-autodl"
+LOG="$STATE/autodl.log"
+LABEL="com.balizero.nlm-autodownload"
+mkdir -p "$STATE"
+
+log() { print "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOG"; }
+
+STATUS=$(nlm studio status "$NB" 2>&1)
+
+# --- VIDEO ---
+if [[ ! -f "$STATE/video.done" ]]; then
+  if print -r -- "$STATUS" | grep -iA4 "$VID_ART" | grep -qiE "completed|ready|status.*: *2[^0-9]|\.mp4"; then
+    OUT="$DESK/BZ-Analisi-Business-Gen-Giu-2026-CINEMATIC-IT.mp4"
+    if nlm download video "$NB" --id "$VID_ART" -o "$OUT" --no-progress >> "$LOG" 2>&1 && [[ -s "$OUT" ]]; then
+      touch "$STATE/video.done"; log "VIDEO downloaded -> $OUT ($(du -h "$OUT" | cut -f1))"
+    else
+      log "VIDEO download attempt failed (will retry next tick)"
+    fi
+  else
+    log "video not ready yet"
+  fi
+fi
+
+# --- SLIDES ---
+if [[ ! -f "$STATE/slides.done" ]]; then
+  if print -r -- "$STATUS" | grep -iA4 "$SLD_ART" | grep -qiE "completed|ready|status.*: *2[^0-9]|\.pdf"; then
+    OUT="$DESK/BZ-Analisi-Business-Gen-Giu-2026-SLIDE-IT.pdf"
+    if nlm download slide-deck "$NB" --id "$SLD_ART" -o "$OUT" >> "$LOG" 2>&1 && [[ -s "$OUT" ]]; then
+      touch "$STATE/slides.done"; log "SLIDES downloaded -> $OUT ($(du -h "$OUT" | cut -f1))"
+    else
+      log "SLIDES download attempt failed (will retry next tick)"
+    fi
+  else
+    log "slides not ready yet"
+  fi
+fi
+
+# --- self-unload when both done ---
+if [[ -f "$STATE/video.done" && -f "$STATE/slides.done" ]]; then
+  log "BOTH artifacts on Desktop — unloading LaunchAgent $LABEL"
+  /bin/launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || /bin/launchctl unload "$HOME/Library/LaunchAgents/$LABEL.plist" 2>/dev/null
+fi

--- a/infra/launchagents/wrappers/mlx-server-run.sh
+++ b/infra/launchagents/wrappers/mlx-server-run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# mlx-server-run.sh — keep mlx_lm.server alive as a real blocking supervisor loop.
+# Deliberately NOT a one-shot under launchd KeepAlive (cicatrix #7: KeepAlive on a
+# transient exec = restart storm). This wrapper IS the long-running process; launchd
+# only restarts it if the whole supervisor dies. Lives in ~/scripts, NOT ~/Desktop
+# (cicatrix W84: launchd loses TCC grant to ~/Desktop and dies green-but-dead).
+set -u
+
+MLX_BIN="$HOME/mlx-env/bin/mlx_lm.server"
+MODEL="mlx-community/Qwen3-8B-4bit"
+# Speculative decoding: small draft model proposes tokens, the 8B verifies in batch.
+# Tuned 2026-06-20 via clean serial sweep: num-draft=2 is the sweet spot (+26% on code),
+# beats 3 (+12%) and 5 (-5%, too many rejected drafts). +~0.37GB RAM (24GB host has room).
+DRAFT_MODEL="mlx-community/Qwen3-0.6B-4bit"
+NUM_DRAFT="2"
+HOST="127.0.0.1"
+PORT="8080"
+LOG="$HOME/mlx-server.log"
+
+log() { echo "[$(/bin/date '+%Y-%m-%dT%H:%M:%S')] supervisor: $*" >> "$LOG"; }
+
+if [ ! -x "$MLX_BIN" ]; then
+  log "FATAL: $MLX_BIN not found/executable — exiting so launchd surfaces it"
+  exit 78  # EX_CONFIG: honest hard-fail, not a silent green
+fi
+
+log "starting supervisor for $MODEL on $HOST:$PORT"
+while true; do
+  log "launching mlx_lm.server (model=$MODEL draft=$DRAFT_MODEL num-draft=$NUM_DRAFT)"
+  # Foreground (no &) so this loop blocks on the server's lifetime.
+  "$MLX_BIN" --model "$MODEL" --host "$HOST" --port "$PORT" \
+    --draft-model "$DRAFT_MODEL" --num-draft-tokens "$NUM_DRAFT" >> "$LOG" 2>&1
+  code=$?
+  log "mlx_lm.server exited code=$code — restarting in 5s"
+  sleep 5
+done

--- a/infra/launchagents/wrappers/wr2-queue-pull.sh
+++ b/infra/launchagents/wrappers/wr2-queue-pull.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# wr2-queue-pull.sh — keeps the M5 copy of the WR2 queue in sync with Pro (source of truth).
+# The native WR2 Control.app polls this file from disk; this is the only thing that makes
+# its view track Pro. Pull-only (M5 never writes back). Blocking loop (not KeepAlive-oneshot, scar #7).
+# Lives OUTSIDE ~/Desktop (W84: launchd loses TCC grant on ~/Desktop).
+set -uo pipefail
+LOG="$HOME/logs/wr2-queue-pull.log"
+DEST_DIR="$HOME/Desktop/nuzantara/apps/war-room/output/queue"
+SRC_DIR="/Users/nuzantara/Desktop/nuzantara/apps/war-room/output/queue"
+# WR2 Insights: the analyst reasoning (real findings) lives only on Pro under the skill dir.
+AMEND_DEST="$HOME/.claude/skills/bali-zero-brand/_proposed-amendments"
+AMEND_SRC="/Users/nuzantara/.claude/skills/bali-zero-brand/_proposed-amendments"
+# Carousel render PNGs — synced from Pro (the renderer) from now on, so new caroselli
+# show their cover in the app. Pull-only, additive (never deletes M5-local carousels).
+CAROUSEL_DEST="$HOME/Desktop/nuzantara/apps/war-room/output/carousel"
+CAROUSEL_SRC="/Users/nuzantara/Desktop/nuzantara/apps/war-room/output/carousel"
+INTERVAL="${WR2_QUEUE_PULL_INTERVAL:-300}"
+mkdir -p "$DEST_DIR" "$AMEND_DEST" "$CAROUSEL_DEST"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+while true; do
+  for f in human-review-queue.json queue-archive.json; do
+    tmp="$DEST_DIR/.$f.pull.tmp"
+    if ssh -o ConnectTimeout=10 -o BatchMode=yes pro "cat '$SRC_DIR/$f'" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+      # valida JSON prima di sostituire (mai clobberare con spazzatura)
+      if python3 -c "import json,sys; json.load(open('$tmp'))" 2>/dev/null; then
+        if ! cmp -s "$tmp" "$DEST_DIR/$f" 2>/dev/null; then
+          mv "$tmp" "$DEST_DIR/$f"
+          echo "[$(ts)] updated $f" >> "$LOG"
+        else
+          rm -f "$tmp"   # no change
+        fi
+      else
+        echo "[$(ts)] WARN $f pulled but invalid JSON, kept old" >> "$LOG"
+        rm -f "$tmp"
+      fi
+    else
+      echo "[$(ts)] WARN pull $f failed (Pro unreachable?)" >> "$LOG"
+      rm -f "$tmp"
+    fi
+  done
+
+  # Pull the latest REAL ig-insights amendment (the Insights view reads it). Exclude the
+  # "insufficient-data" stubs. Take the newest by filename date.
+  latest=$(ssh -o ConnectTimeout=10 -o BatchMode=yes pro \
+    "ls -1 '$AMEND_SRC'/*-ig-insights.md 2>/dev/null | grep -v insufficient-data | sort | tail -1" 2>/dev/null)
+  if [ -n "$latest" ]; then
+    bn=$(basename "$latest")
+    tmp="$AMEND_DEST/.$bn.pull.tmp"
+    if ssh -o ConnectTimeout=10 -o BatchMode=yes pro "cat '$latest'" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+      if ! cmp -s "$tmp" "$AMEND_DEST/$bn" 2>/dev/null; then
+        mv "$tmp" "$AMEND_DEST/$bn"
+        echo "[$(ts)] updated insights $bn" >> "$LOG"
+      else
+        rm -f "$tmp"
+      fi
+    else
+      rm -f "$tmp"
+    fi
+  fi
+
+  # Pull new carousel render dirs (PNGs) from Pro. Additive only:
+  #  --ignore-existing  → never re-pull or overwrite a carousel M5 already has
+  #  (no --delete)      → never remove M5-local carousels (M5 is a superset today)
+  # So only carousels NEW on Pro land on M5; existing ones are untouched.
+  if rsync -a --ignore-existing -e "ssh -o ConnectTimeout=10 -o BatchMode=yes" \
+       "pro:$CAROUSEL_SRC/" "$CAROUSEL_DEST/" >/dev/null 2>>"$LOG"; then
+    : # silent on success (rsync is chatty enough on error)
+  else
+    echo "[$(ts)] WARN carousel rsync failed (Pro unreachable?)" >> "$LOG"
+  fi
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
Supervisor on Pro crash-looping (98 restarts, redis AuthenticationError since requirepass 2026-06-29) with heartbeat mute — #1944 pattern applied (conditional REDIS_PASSWORD). Plus reverse-promotion of 3 M5 HOME-only wrappers flagged as home_fork_target by launchagent_reconcile. Tests 325 pass; the single failing timeout test fails identically on clean tree (pre-existing flake).

Post-merge arming: kickstart supervisor on Pro (wrapper already sources secrets env with REDIS_PASSWORD), remove M5 heartbeat relic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)