### PR TITLE
docs(seo): KBLI GSC clean-window investigation

### DIFF
--- a/research/marketing/kbli-gsc-clean-window-2026-07-03.md
+++ b/research/marketing/kbli-gsc-clean-window-2026-07-03.md
@@ -1,0 +1,71 @@
+# KBLI GSC Clean-Window Investigation — 2026-07-03
+
+## Scope
+- Filter: balizero.com/kbli/*
+- Window A (pre-rollout): 2026-05-14 – 2026-05-20
+- Window B (post-rollout): 2026-06-09 – 2026-06-15
+- Source: GSC Performance UI + Coverage report (manual export + URL Inspection)
+
+## Aggregate — Site-wide (no filter)
+| Metric | Window A | Window B | Δ% |
+|---|---|---|---|
+| Total clicks | 76 | 70 | -8% |
+| Total impressions | 10.1k | 6.81k | -32.6% |
+| Average CTR | 0.8% | 1% | +25% |
+| Average position | 8.7 | 8 | improved |
+
+**Verdict**: Site-wide health is fine — CTR up, position improved. This rules out a generic Core Update / manual action as root cause.
+
+## Aggregate — /kbli/* filtered (Pages tab)
+| Metric | Window A | Window B |
+|---|---|---|
+| Total clicks | 24 | (incomplete) |
+| Total impressions | 4.15k | (incomplete — near-zero across queries) |
+| Average CTR | 0.6% | — |
+| Average position | 7 | 2 (improved, but low sample) |
+
+**Verdict**: KBLI cluster impressions collapsed almost entirely in Window B (~250 active queries → ~10). Deficit (~3.3k-4.1k impressions) accounts for nearly all of the site-wide drop — confirms this is KBLI-specific, not site-wide.
+
+## Coverage Report (Indexing → Pages, last update 12/06/2026)
+| Reason | Pages |
+|---|---|
+| Alternative page with proper canonical tag | 1,459 |
+| Blocked by robots.txt | 30 |
+| Page with redirect | 18 |
+| Excluded by 'noindex' tag | 8 |
+| Duplicate without user-selected canonical | 5 |
+| Soft 404 | 2 |
+| Crawled - currently not indexed | 200 |
+| Discovered - currently not indexed | 88 |
+| Duplicate, Google chose different canonical | 1 |
+
+- Total not-indexed: 1,811 / Total indexed: 2,899
+- `/kbli/*` share of not-indexed: 97 (Crawled) + 25 (Discovered) = **122 pages**
+- Timeline: "not indexed" area started rising ~24 Apr, peaked ~14 May 2026
+
+## URL Inspection — 5-sample deep dive
+| URL | Status | Canonical | Last crawled | Verdict |
+|---|---|---|---|---|
+| /kbli/10296 | not indexed | user-declared present | 12 Jun | Crawl-priority gap |
+| /kbli/55103 | **indexed** | present | 27 Jun | Control — recrawl → index works fine |
+| /kbli/10314 | not indexed | **N/A** — invalid code, `getCode()` returns null, soft-404 render | 10 Jun | **Not a bug** — code doesn't exist in 1,563 dataset (data model, out of scope) |
+| /kbli/49297 | not indexed | present, confirmed via direct fetch | 13 May (51 days) | Crawl-priority gap |
+| /kbli/85104 | not indexed | present | 13 May (51 days) | Crawl-priority gap |
+
+**Sample verdict: 4/5 = genuine crawl-priority gap (actionable, Subhi scope). 1/5 = invalid code in data model (out of scope, informational note sent to Antonello).**
+
+## Root Cause
+Not a Google Core Update or algorithmic ranking loss. Pattern points to **crawl-budget/priority deprioritization** for long-tail `/kbli/*` pages — Google visits infrequently (40-50+ day gaps for some URLs), and pages not recently recrawled don't get indexed even when canonical/metadata are correct. One isolated case of an invalid KBLI code serving a live "soft 404" URL — not connected to the main pattern.
+
+## Conclusion
+- **KBLI Batch 3 title/meta rewrite: stays PAUSED.** Root cause isn't title/meta quality — it's crawl frequency. Rewriting titles won't fix an indexing gap.
+- Priority shifts to: sitemap priority hints + internal linking density for long-tail KBLI pages, to signal crawl priority to Google.
+
+## Next Action
+1. Audit `apps/mouth/src/app/sitemap.ts` (or equivalent) — verify all 1,563 `/kbli/*` URLs present, check `priority`/`changefreq` values
+2. Audit internal link density to long-tail KBLI pages (orphan pages get recrawled less)
+3. Re-check GSC in 2-3 weeks post-fix to measure recrawl rate improvement
+4. Informational note sent to Antonello re: `10314` invalid code (no action required)
+
+---
+*Investigation conducted: 2026-07-03 · Tools: GSC Performance UI, Coverage report, URL Inspection, direct HTML fetch, codebase grep*


### PR DESCRIPTION
## Insight
KBLI /kbli/* impressions collapsed ~96% between 14-20 May and 9-15 Jun 2026, while site-wide health stayed normal (CTR +25%, position improved). Root cause: crawl-priority gap, not Core Update.

## Studio
Growth Systems — SEO/Analytics investigation, no code change.

## Source
GSC Performance UI (Compare mode) + Coverage report (Indexing > Pages) + URL Inspection (5-URL sample) + direct HTML fetch + codebase grep.

## Methodology
1. Compared query/page-level impressions across two 7-day windows filtered to /kbli/*
2. Cross-checked against site-wide (unfiltered) Performance to rule out generic algorithm drop
3. Pulled Coverage report to quantify not-indexed /kbli/ pages (122 of 1,811 total)
4. URL-inspected 5 sample pages; verified canonical tags via direct fetch and generateMetadata source

## Raw Observations
- Site-wide: clicks 76→70, impressions 10.1k→6.81k, CTR 0.8%→1%, position 8.7→8
- /kbli/ queries: ~250 active queries in Window A collapsed to ~10 in Window B
- Coverage: 97 crawled-not-indexed + 25 discovered-not-indexed /kbli/ pages
- 4/5 sample URLs: valid pages, correct canonical, stale crawl (40-51 days)
- 1/5 sample URL (kbli/10314): invalid code in data model, soft-404, out of scope

## Reasoning Path
Site-wide metrics improving while KBLI-specific impressions collapse rules out Core Update as root cause. Deficit magnitude (~3.3k-4.1k impressions) accounts for nearly all site-wide drop, confirming KBLI-specific cause. Sample URL Inspection shows correct canonicals but long crawl gaps — points to crawl-budget deprioritization, not a code bug.

## Risk
Low — this is a documentation-only PR, no runtime code touched. Risk is informational: incorrect conclusions could misdirect the paused KBLI Batch 3 decision.

## Implication
KBLI Batch 3 title/meta rewrite should stay paused — the bottleneck is crawl frequency, not content quality. Rewriting titles will not fix an indexing gap.

## Recommendation
Prioritize sitemap priority hints and internal linking density for long-tail /kbli/ pages to improve crawl signal, before resuming any content rewrite work.

## Next Action
1. Audit apps/mouth/src/app/sitemap.ts for /kbli/* priority/changefreq values
2. Audit internal link density to long-tail KBLI pages
3. Re-check GSC in 2-3 weeks to measure recrawl improvement