### PR TITLE
fix(seo): use file mtime instead of new Date() for KBLI sitemap lastModified

### DIFF
--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next";
 import { getAllArticles, getNoIndexSlugs } from "@/lib/blog/articles";
 import { getAllCodes, getSections } from "@/lib/kbli-data.server";
 import { logger } from "@/lib/logger";
+import fs from "fs";
+import path from "path";
 
 /**
  * Dynamic Sitemap Generator
@@ -197,9 +199,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // 5. KBLI Codes (1,559 pages)
   try {
     const codes = getAllCodes();
+    const kbliDataPath = path.join(
+      process.cwd(),
+      "data",
+      "KBLI_2025_FINAL_CLEAN.json",
+    );
+    let kbliLastModified: Date;
+    try {
+      kbliLastModified = fs.statSync(kbliDataPath).mtime;
+    } catch {
+      kbliLastModified = new Date("2026-06-19");
+    }
     const kbliPages = codes.map((c) => ({
       url: `${baseUrl}/kbli/${c.code}`,
-      lastModified: new Date(),
+      lastModified: kbliLastModified,
       changeFrequency: "monthly" as const,
       priority: 0.8,
     }));


### PR DESCRIPTION
## Insight
KBLI sitemap set lastModified: new Date() for all 1,559 /kbli/* URLs on every build, signaling false freshness to Google and likely contributing to the crawl-priority gap found in the 3 Jul GSC investigation (122 /kbli/ pages stuck not-indexed, some uncrawled 50+ days).

## Studio
Growth Systems — SEO/sitemap fix, single-file change.

## Source
apps/mouth/src/app/sitemap.ts (lines 197-206), cross-referenced with research/marketing/kbli-gsc-clean-window-2026-07-03.md next-action item 1.

## Methodology
Read sitemap generator, confirmed all KBLI entries shared new Date() at build time. Located actual data source (apps/mouth/data/KBLI_2025_FINAL_CLEAN.json) via kbli-data.ts. Replaced with fs.statSync(...).mtime on the data file, computed once outside the map loop, with static fallback date.

## Raw Observations
- 1,559 KBLI codes all received identical lastModified on every deploy
- Data file has no per-code updatedAt field, only a global metadata.l4_bali_injected date (2026-06-19)
- fs/path were not previously imported in sitemap.ts

## Reasoning Path
Sitemap lastModified is a crawl-priority signal to Google. Marking every page as 'just changed' on every deploy is indistinguishable from spam/noise, likely causing Google to deprioritize genuine change signals for this route — consistent with the crawl-gap pattern found in the 3 Jul investigation (4/5 sampled not-indexed URLs had correct canonicals but 40-51 day crawl gaps).

## Risk
Low. Change is scoped to one try block, does not alter MetadataRoute.Sitemap return type, includes a fallback if fs.statSync fails. No caller depends on kbliPages internals beyond the sitemap output.

## Implication
Sitemap lastModified will now only change when the underlying KBLI dataset file is actually modified, giving Google an honest freshness signal instead of noise on every deploy.

## Recommendation
Merge once CI green. Monitor Coverage report in 2-3 weeks to check whether crawl frequency improves for the 122 flagged /kbli/ pages.

## Next Action
1. Merge this PR
2. Audit internal linking density to long-tail KBLI pages
3. Re-check GSC Coverage report ~2-3 weeks post-merge