### PR TITLE
fix(reconcile): canon-paired HOME targets are not forks — kill the standing P2

### DIFF
--- a/scripts/launchagent_reconcile.py
+++ b/scripts/launchagent_reconcile.py
@@ -52,6 +52,7 @@ Stdlib-only, runs on macOS system python3 (3.9+).
 from __future__ import annotations
 
 import argparse
+import filecmp
 import json
 import os
 import plistlib
@@ -262,6 +263,19 @@ def reconcile(
     repo_root = repo_dir.resolve()
     deploy_root = (home / "Desktop" / "nuzantara-deploy").resolve()
 
+    # Canon dirs for wrapper scripts (basename match). A HOME target whose repo
+    # canon is byte-identical is NOT a fork — it is the W84-safe placement
+    # (launchd payloads deliberately live OUTSIDE ~/Desktop because launchd can
+    # lose its TCC grant there). The disease is DRIFT, not location.
+    canon_dirs = (repo_infra / "wrappers", repo_dir / "scripts", repo_dir / "infra" / "scripts")
+
+    def _repo_canon_for(target: Path) -> Optional[Path]:
+        for d in canon_dirs:
+            cand = d / target.name
+            if cand.is_file():
+                return cand
+        return None
+
     live: dict = {}      # label -> {file, plist}
     junk: list = []
     archive_dirs: list = []
@@ -304,6 +318,7 @@ def reconcile(
 
     broken_target = []
     home_fork_target = []
+    canon_paired = []
     repo_divergent = []
     repo_symlinked = []
 
@@ -328,7 +343,17 @@ def reconcile(
                 continue
             if _is_under(rp, agents_dir.resolve()):
                 continue
-            home_fork_target.append({"label": label, "file": f.name, "target": t})
+            canon = _repo_canon_for(rp)
+            if canon is not None and filecmp.cmp(str(canon), str(rp), shallow=False):
+                canon_paired.append({"label": label, "file": f.name, "target": t,
+                                     "canon": str(canon.relative_to(repo_root))})
+            else:
+                detail = (
+                    f"DIVERGED from canon {canon.relative_to(repo_root)}" if canon is not None
+                    else "no repo canon (basename not in wrappers/ or scripts/)"
+                )
+                home_fork_target.append({"label": label, "file": f.name, "target": t,
+                                         "detail": detail})
             break
 
         twin = repo_infra / f.name
@@ -358,6 +383,7 @@ def reconcile(
         "present_not_loaded": present_not_loaded,
         "broken_target": broken_target,
         "home_fork_target": home_fork_target,
+        "canon_paired": canon_paired,
         "repo_divergent": repo_divergent,
         "repo_symlinked": repo_symlinked,
     }
@@ -433,7 +459,12 @@ def render_markdown(report: dict, verdicts) -> str:
     )
     section(
         "HOME-fork target (superscar #1)", report["home_fork_target"],
-        lambda h: f"- `{h['label']}` → `{h['target']}` (under $HOME, outside repo/deploy, not a repo symlink)",
+        lambda h: f"- `{h['label']}` → `{h['target']}` ({h.get('detail', 'under $HOME, outside repo/deploy, not a repo symlink')})",
+    )
+    section(
+        "Canon-paired HOME target (byte-identical to repo canon — W84-safe placement, not a fork)",
+        report.get("canon_paired", []),
+        lambda h: f"- `{h['label']}` → `{h['target']}` == `{h['canon']}`",
     )
     section(
         "Repo-divergent (env-specific keys excluded)", report["repo_divergent"],
@@ -539,6 +570,7 @@ def main(argv=None) -> int:
             f"{len(report['present_not_loaded'])} not-loaded, "
             f"{len(report['broken_target'])} broken-target, "
             f"{len(report['home_fork_target'])} home-fork, "
+            f"{len(report.get('canon_paired', []))} canon-paired, "
             f"{len(report['repo_divergent'])} repo-divergent. "
             f"Report: {out}"
             + (f" — APPLIED: deleted {len(deleted)}" if args.apply else "")

--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -400,7 +400,7 @@ DEFAULT_REGISTRY: list[dict] = [
         "machines": ["all"], "tags": ["launchd"], "timeout_sec": 90,
         "severity": "P2", "parse": "category_counts",
         "bad_categories": ["zombie_loaded", "broken_target", "home_fork_target", "repo_divergent"],
-        "ok_categories": ["junk", "present_not_loaded", "repo_symlinked"],
+        "ok_categories": ["junk", "present_not_loaded", "repo_symlinked", "canon_paired"],
         "fix_hint": "scripts/launchagent_reconcile.py (markdown mode) for the full categorized report",
     },
     {

--- a/scripts/tests/test_launchagent_reconcile.py
+++ b/scripts/tests/test_launchagent_reconcile.py
@@ -153,6 +153,47 @@ def test_interpreter_payload_under_home_flagged(world):
     assert [h["target"] for h in r["home_fork_target"]] == [str(payload)]
 
 
+def test_canon_paired_home_target_not_a_fork(world):
+    """A $HOME payload byte-identical to its repo canon (basename match in
+    wrappers/ or scripts/) is the W84-safe placement, not a fork — it must
+    land in canon_paired, NOT home_fork_target."""
+    canon = world["repo"] / "infra" / "launchagents" / "wrappers" / "wrapper.sh"
+    canon.parent.mkdir(parents=True, exist_ok=True)
+    canon.write_text("#!/bin/sh\necho same\n")
+    live = world["home"] / ".nuzantara-cron" / "wrapper.sh"
+    live.parent.mkdir(parents=True)
+    live.write_text("#!/bin/sh\necho same\n")
+    write_plist(
+        world["agents"] / "com.balizero.paired.plist",
+        "com.balizero.paired",
+        program_args=[str(live)],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert r["home_fork_target"] == []
+    assert [c["label"] for c in r["canon_paired"]] == ["com.balizero.paired"]
+    assert r["canon_paired"][0]["canon"] == "infra/launchagents/wrappers/wrapper.sh"
+
+
+def test_canon_diverged_home_target_still_a_fork(world):
+    """Same basename but DIFFERENT bytes = the real disease (drift). Must stay
+    in home_fork_target, with the canon named in the detail."""
+    canon = world["repo"] / "scripts" / "wrapper.sh"
+    canon.parent.mkdir(parents=True, exist_ok=True)
+    canon.write_text("#!/bin/sh\necho repo-version\n")
+    live = world["home"] / ".nuzantara-cron" / "wrapper.sh"
+    live.parent.mkdir(parents=True)
+    live.write_text("#!/bin/sh\necho drifted-version\n")
+    write_plist(
+        world["agents"] / "com.balizero.drifted.plist",
+        "com.balizero.drifted",
+        program_args=[str(live)],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert r["canon_paired"] == []
+    assert [h["label"] for h in r["home_fork_target"]] == ["com.balizero.drifted"]
+    assert "DIVERGED from canon" in r["home_fork_target"][0]["detail"]
+
+
 def test_symlink_into_repo_not_a_fork(world):
     """A $HOME payload that is a symlink into the repo is the CURE for #1,
     not an instance of it."""


### PR DESCRIPTION
The `launchagent_canon` proprioception probe carried a standing P2 on M5: `home_fork_target: 6`. GROUND showed all six live HOME copies are **byte-identical** to their repo canons, and their placement outside `~/Desktop` is the deliberate **W84 mitigation** (launchd loses TCC on `~/Desktop`; the `.bak-w84` files in the same report are that cure's receipts). The probe alarmed on *location*; the superscar-#1 disease is *drift*.

## Change
- `launchagent_reconcile.py`: for every HOME target, look up a repo canon by basename in `infra/launchagents/wrappers/`, `scripts/`, `infra/scripts/`:
  - byte-identical (`filecmp`, deep) → new non-alarming category **`canon_paired`** with the canon path
  - different bytes → stays in `home_fork_target` with `DIVERGED from canon <path>` detail (the real disease keeps alarming)
  - no canon → stays flagged (`no repo canon`)
- `proprioception.py`: `canon_paired` added to the probe's `ok_categories` (parser counts only declared bad categories — older reports stay parseable, scar #9 checked)
- Markdown report gains a "Canon-paired HOME target" section; Telegram summary line includes the count

## Proof
- Tests: innocence AND guilt cases added per the family-#3 antidote — **25 passed**
- Live on M5: `home_fork_target` 6 → 0, `canon_paired` = 6 (all with canon paths), probe verdict **DIVERGED(P2) → RECONCILED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)