### PR TITLE
fix(sync): Mini follows most-advanced of pro/main and origin/main

### DIFF
--- a/scripts/mini/mini-git-pull.sh
+++ b/scripts/mini/mini-git-pull.sh
@@ -2,7 +2,7 @@
 # Mini-side periodic git pull for ~/Desktop/nuzantara on main.
 #
 # Runs ON Mini via com.nuzantara.git-pull-main.5min LaunchAgent.
-# Pattern: detect-mismatch → stash → fetch Pro → merge --ff-only → stash pop.
+# Pattern: detect-mismatch → stash → fetch pro+origin → ff to most-advanced → stash pop.
 #
 # Hardened against the 2026-05-06 incident where a tracked symlink in
 # main collided with a 762 MB local directory (.venv) on Mini, causing
@@ -20,9 +20,15 @@
 #   4. Telegram alert on every non-trivial WARN/ERROR via the same
 #      bot used by login-healthcheck (TELEGRAM_BOT_TOKEN secret on Mini).
 #
-# Source-of-truth order:
-#   1. Pro remote (`pro/main`) — catches Pro commits even before GitHub push.
-#   2. GitHub origin (`origin/main`) — fallback when Pro is unreachable.
+# Source-of-truth selection (2026-07-05 fix — M5 era):
+#   Fetch BOTH `pro/main` and `origin/main` (best-effort each), then ff to the
+#   MOST-ADVANCED of the two. The pre-M5 policy was Pro-first with origin only
+#   as unreachable-fallback — it silently left Mini stale whenever Pro was
+#   reachable but itself behind origin (M5 pushes straight to GitHub; on
+#   2026-07-02 Mini sat 13 commits behind origin logging "ahead of pro/main;
+#   skip pull" every 5 min).
+#   If pro/main and origin/main have DIVERGED, prefer origin/main (GitHub is
+#   authoritative) and Telegram-alert so Pro's unpushed work gets human triage.
 #
 # Cron: StartInterval=300 on Mini.
 # Log:  ~/logs/mini-git-pull.log
@@ -168,19 +174,47 @@ if [ "$BRANCH" != "main" ]; then
   exit 0
 fi
 
-# Fetch Pro first. GitHub origin is only fallback because Pro may have commits
-# not pushed to GitHub yet (policy: GitHub is updated by Pro only).
+# Fetch BOTH remotes best-effort, then follow the most-advanced ref. Pro may
+# hold commits not yet pushed to GitHub, and origin may hold commits Pro has
+# not pulled (M5 pushes straight to GitHub) — either side can be ahead.
 PRO_SSH="ssh -o BatchMode=yes -o ConnectTimeout=10 -o IdentitiesOnly=yes -i $HOME/.ssh/id_ed25519"
+PRO_FETCHED=0
+ORIGIN_FETCHED=0
 if GIT_SSH_COMMAND="$PRO_SSH" git fetch --quiet pro main 2>>"$LOG_FILE"; then
+  PRO_FETCHED=1
+else
+  log "WARN: git fetch pro failed"
+fi
+if git fetch --quiet origin main 2>>"$LOG_FILE"; then
+  ORIGIN_FETCHED=1
+else
+  log "WARN: git fetch origin failed"
+fi
+
+if [ "$PRO_FETCHED" = "0" ] && [ "$ORIGIN_FETCHED" = "0" ]; then
+  log "git fetch failed for both pro and origin (network?), skip"
+  telegram_alert "fetch-failed" "Mini could not fetch pro/main or origin/main. Sync skipped."
+  exit 0
+elif [ "$PRO_FETCHED" = "0" ]; then
+  TARGET_REF="origin/main"
+  TARGET_REMOTE="origin"
+elif [ "$ORIGIN_FETCHED" = "0" ]; then
+  TARGET_REF="pro/main"
+  TARGET_REMOTE="pro"
+elif git merge-base --is-ancestor pro/main origin/main 2>/dev/null; then
+  # origin/main contains pro/main (equal counts as ancestor) — origin wins.
+  TARGET_REF="origin/main"
+  TARGET_REMOTE="origin"
+elif git merge-base --is-ancestor origin/main pro/main 2>/dev/null; then
+  # pro/main is strictly ahead (Pro has commits not yet on GitHub).
   TARGET_REF="pro/main"
   TARGET_REMOTE="pro"
 else
-  log "WARN: git fetch pro failed; falling back to origin/main"
-  if ! git fetch --quiet origin main 2>>"$LOG_FILE"; then
-    log "git fetch origin failed too (network?), skip"
-    telegram_alert "fetch-failed" "Mini could not fetch pro/main or origin/main. Sync skipped."
-    exit 0
-  fi
+  # Diverged: Pro has unpushed commits AND origin moved past Pro. Follow
+  # origin (GitHub authoritative); Pro's unpushed work needs human triage.
+  log "WARN: pro/main and origin/main have diverged; following origin/main"
+  telegram_alert "pro-origin-diverged" \
+    "pro/main and origin/main diverged. Mini follows origin/main; Pro has unpushed commits needing manual push/rebase."
   TARGET_REF="origin/main"
   TARGET_REMOTE="origin"
 fi


### PR DESCRIPTION
## Problem

`scripts/mini/mini-git-pull.sh` (LaunchAgent `com.nuzantara.git-pull-main.5min` on Mini) fetched Pro FIRST and fell back to origin only when Pro was **unreachable** ("policy: GitHub is updated by Pro only"). That assumption is pre-M5: M5 now pushes straight to GitHub and Pro can sit behind origin for days. Observed on the 2026-07-02 Mini health-check: Mini silently **13 commits behind origin/main**, cron logging "Local main is ahead of pro/main; skip pull" every 5 min, while Pro itself was 32 behind origin.

## Fix

Fetch BOTH `pro/main` and `origin/main` best-effort, then ff-merge to the **most-advanced** ref:

- `origin/main` contains `pro/main` (or equal) → follow origin
- `pro/main` strictly ahead (Pro has unpushed work) → follow pro (pre-M5 behavior preserved)
- diverged → follow origin (GitHub authoritative) + Telegram alert `pro-origin-diverged` for human triage
- one fetch fails → degrade to the other; both fail → skip + alert (unchanged)

All downstream hardening (type-mismatch gate, flock, tracked-only stash, ff-only merge) untouched.

## Verification

Scratch bare-repo matrix (fake `$HOME`, real script under test, zero side effects): 5 scenarios — origin-ahead / pro-ahead / all-equal-silent / diverged / pro-unreachable — **10/10 assertions green**. `bash -n` clean.

## Post-merge arming (HOME-fork, superscar #1)

The LaunchAgent executes the deployed copy `~/scripts/mini-git-pull.sh`, which self-syncs from the repo only AFTER a successful pull — and the OLD deployed copy won't pull this very commit while Pro is reachable-but-stale (catch-22). One-time arm on Mini right after merge:

    git -C ~/Desktop/nuzantara pull --ff-only origin main && cp ~/Desktop/nuzantara/scripts/mini/mini-git-pull.sh ~/scripts/mini-git-pull.sh

Will be executed from the Mini session as soon as auto-merge lands, then verified on the next 5-min cron tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)