### PR TITLE
fix(seo): distribute related-code links to neighbors instead of section head

### DIFF
--- a/apps/mouth/src/lib/kbli-data.test.ts
+++ b/apps/mouth/src/lib/kbli-data.test.ts
@@ -74,6 +74,20 @@ describe("kbli-data", () => {
     expect(getRelatedCodes("00000")).toEqual([]);
   });
 
+  it("distributes related links to neighbors instead of the section head", () => {
+    const sectionCodes = getCodesBySection("C");
+    expect(sectionCodes.length).toBeGreaterThan(20);
+
+    const last = sectionCodes[sectionCodes.length - 1];
+    const relatedCodes = getRelatedCodes(last.code, 6).map((r) => r.code);
+
+    // Neighbor-window: the immediate predecessor is always linked...
+    expect(relatedCodes).toContain(sectionCodes[sectionCodes.length - 2].code);
+    // ...and the old head-of-list fill (which concentrated every inbound
+    // link on the first section codes) no longer happens.
+    expect(relatedCodes).not.toContain(sectionCodes[0].code);
+  });
+
   it("normalizes section metadata and hero styles with safe fallbacks", () => {
     expect(getSectionMeta("i")).toMatchObject({
       nameEn: "Accommodation & Food Service",

--- a/apps/mouth/src/lib/kbli-data.ts
+++ b/apps/mouth/src/lib/kbli-data.ts
@@ -564,8 +564,52 @@ export function getSections(): KBLISection[] {
 }
 
 /**
+ * Walk a code list outward from the target's position, alternating
+ * after/before, feeding each candidate to `push` until it reports full.
+ * Deterministic for a given dataset order.
+ */
+function pickNeighbors(
+  list: KBLICode[],
+  code: string,
+  push: (item: KBLICode) => boolean,
+): void {
+  if (list.length === 0) return;
+
+  const found = list.findIndex((c) => c.code === code);
+  let lo: number;
+  let hi: number;
+  if (found >= 0) {
+    lo = found - 1;
+    hi = found + 1;
+  } else {
+    // Target absent from this list: anchor to where it would sit by code
+    // order so the window stays deterministic.
+    let insertion = list.findIndex((c) => c.code > code);
+    if (insertion === -1) insertion = list.length;
+    lo = insertion - 1;
+    hi = insertion;
+  }
+  let wantMore = true;
+  while (wantMore && (lo >= 0 || hi < list.length)) {
+    if (hi < list.length) {
+      wantMore = push(list[hi]);
+      hi += 1;
+    }
+    if (wantMore && lo >= 0) {
+      wantMore = push(list[lo]);
+      lo -= 1;
+    }
+  }
+}
+
+/**
  * Find related KBLI codes for a given code.
- * Strategy: same 3-digit prefix first, then same section, excluding self.
+ * Strategy: same 3-digit prefix first, then same section, excluding self —
+ * in both phases picking the NEIGHBORS of the target rather than the head
+ * of the list. The previous head-of-list fill gave a handful of head codes
+ * every inbound link while long-tail codes got none; a crawl-starved
+ * cluster needs inbound links distributed across all 1,559 pages
+ * (GSC clean-window investigation 2026-07-03).
  * Returns up to `limit` results (default 6).
  */
 export function getRelatedCodes(code: string, limit: number = 6): KBLICode[] {
@@ -576,28 +620,20 @@ export function getRelatedCodes(code: string, limit: number = 6): KBLICode[] {
 
   const result: KBLICode[] = [];
   const seen = new Set<string>([code]);
+  const push = (item: KBLICode): boolean => {
+    if (result.length < limit && !seen.has(item.code)) {
+      result.push(item);
+      seen.add(item.code);
+    }
+    return result.length < limit;
+  };
 
   // Phase 1: Same 3-digit prefix (most closely related)
-  const prefix3 = code.substring(0, 3);
-  const prefixSiblings = _prefixMap!.get(prefix3) ?? [];
-  for (const sibling of prefixSiblings) {
-    if (result.length >= limit) break;
-    if (!seen.has(sibling.code)) {
-      result.push(sibling);
-      seen.add(sibling.code);
-    }
-  }
+  pickNeighbors(_prefixMap!.get(code.substring(0, 3)) ?? [], code, push);
 
   // Phase 2: Same section (broader relation)
   if (result.length < limit && target.section) {
-    const sectionCodes = _sectionMap!.get(target.section) ?? [];
-    for (const item of sectionCodes) {
-      if (result.length >= limit) break;
-      if (!seen.has(item.code)) {
-        result.push(item);
-        seen.add(item.code);
-      }
-    }
+    pickNeighbors(_sectionMap!.get(target.section) ?? [], code, push);
   }
 
   return result;


### PR DESCRIPTION
## Why

GSC clean-window investigation (2026-07-03, #1949): long-tail `/kbli/*` pages have 40-51 day recrawl gaps. One mechanism in code: `getRelatedCodes` filled its remaining slots from the FIRST codes of the section — head codes collected every inbound link, long-tail codes got none. Internal-link distribution is the main crawl-priority lever we control.

## What

Both phases (3-digit prefix group, section fill) now pick a **deterministic neighbor window** around the target code: every one of the 1,559 pages gets inbound links from its adjacent codes, spreading internal PageRank across the whole cluster.

## Verification

- New regression test pins the behavior (last code of a large section is linked by its predecessor, and no longer links the section head). Suite 7/7 green.
- `npm run typecheck` ✓ · full `next build` ✓
- Pure logic change in `kbli-data.ts` — no template, no content, no regulatory claims touched.

Companion to #1963 (robots/sitemap) and #1965 (full SSG). Part of the SEO/KBLI offensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>