### PR TITLE
fix(seo): follow-up to #1963 — keep /_next/static crawlable + sidecar lastmod

### DIFF
--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,0 +1,5 @@
+{
+  "lastModified": "2026-07-02",
+  "sha256": "4067feb9a5863ca60c6b32159be7b82f2f83220c343f09568d32050bd79c3e76",
+  "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file."
+}

--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
   "lastModified": "2026-07-02",
-  "sha256": "4067feb9a5863ca60c6b32159be7b82f2f83220c343f09568d32050bd79c3e76",
-  "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file."
+  "datasetSha256": "sha256:4067feb9a5863ca60c6b32159be7b82f2f83220c343f09568d32050bd79c3e76",
+  "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/apps/mouth/src/app/robots.ts
+++ b/apps/mouth/src/app/robots.ts
@@ -1,5 +1,11 @@
 import type { MetadataRoute } from "next";
 
+// In robots.txt semantics a crawler obeys ONLY the most specific matching
+// user-agent group — specific groups REPLACE the `*` group, they do not
+// inherit from it. Every named group below must therefore carry the full
+// disallow list, or that crawler is silently allowed into /api/, /dashboard
+// and the rest of the workspace (crawl-budget bleed — GSC clean-window
+// investigation 2026-07-03).
 const DISALLOW = [
   "/dashboard",
   "/clients",
@@ -23,57 +29,64 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       // ── Standard crawlers ─────────────────────────────
+      // Googlebot intentionally has no dedicated group: it falls back to `*`
+      // (Google ignores crawl-delay, so a specific group bought nothing and
+      // cost us the disallow list).
       {
         userAgent: "*",
         allow: ["/", "/llms.txt", "/llms-full.txt", "/llms-id.txt"],
         disallow: DISALLOW,
       },
       {
-        userAgent: "Googlebot",
-        allow: ["/"],
-        crawlDelay: 1,
-      },
-      {
         userAgent: "Bingbot",
         allow: ["/"],
+        disallow: DISALLOW,
         crawlDelay: 1,
       },
-      // ── AI crawlers — explicitly welcome ──────────────
+      // ── AI crawlers — explicitly welcome (on public content) ──
       {
         userAgent: ["GPTBot", "OAI-SearchBot"],
         allow: ["/"],
+        disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "ChatGPT-User",
         allow: ["/"],
+        disallow: DISALLOW,
       },
       {
         userAgent: ["ClaudeBot", "anthropic-ai"],
         allow: ["/"],
+        disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "Claude-User",
         allow: ["/"],
+        disallow: DISALLOW,
       },
       {
         userAgent: "PerplexityBot",
         allow: ["/"],
+        disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "Google-Extended",
         allow: ["/"],
+        disallow: DISALLOW,
       },
       {
         userAgent: ["Applebot-Extended", "Amazonbot", "YouBot", "Bytespider"],
         allow: ["/"],
+        disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: ["FacebookBot", "Meta-ExternalAgent", "CCBot", "cohere-ai"],
         allow: ["/"],
+        disallow: DISALLOW,
       },
     ],
     sitemap: "https://balizero.com/sitemap.xml",

--- a/apps/mouth/src/app/robots.ts
+++ b/apps/mouth/src/app/robots.ts
@@ -6,6 +6,13 @@ import type { MetadataRoute } from "next";
 // disallow list, or that crawler is silently allowed into /api/, /dashboard
 // and the rest of the workspace (crawl-budget bleed — GSC clean-window
 // investigation 2026-07-03).
+// /_next/ stays disallowed (build manifests, data routes), but the static
+// assets and the image optimizer MUST stay crawlable: search-engine renderers
+// fetch CSS/JS/images to evaluate the page, and robots-blocked resources
+// degrade rendering (red-team finding 2026-07-05). Longest-match wins, so
+// these allows beat the /_next/ disallow for exactly the asset paths.
+const ALLOW = ["/", "/_next/static/", "/_next/image"];
+
 const DISALLOW = [
   "/dashboard",
   "/clients",
@@ -34,58 +41,58 @@ export default function robots(): MetadataRoute.Robots {
       // cost us the disallow list).
       {
         userAgent: "*",
-        allow: ["/", "/llms.txt", "/llms-full.txt", "/llms-id.txt"],
+        allow: [...ALLOW, "/llms.txt", "/llms-full.txt", "/llms-id.txt"],
         disallow: DISALLOW,
       },
       {
         userAgent: "Bingbot",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 1,
       },
       // ── AI crawlers — explicitly welcome (on public content) ──
       {
         userAgent: ["GPTBot", "OAI-SearchBot"],
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "ChatGPT-User",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
       },
       {
         userAgent: ["ClaudeBot", "anthropic-ai"],
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "Claude-User",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
       },
       {
         userAgent: "PerplexityBot",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "Google-Extended",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
       },
       {
         userAgent: ["Applebot-Extended", "Amazonbot", "YouBot", "Bytespider"],
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: ["FacebookBot", "Meta-ExternalAgent", "CCBot", "cohere-ai"],
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
       },
     ],

--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -11,20 +11,18 @@ import path from "path";
  * Generates XML sitemap for SEO with:
  * - Static pages (homepage, services, team, contact, kbli-explorer)
  * - Service pages (4 main services)
- * - News categories (8 categories)
+ * - News categories
  * - Blog articles (all published articles)
  * - KBLI 2025 codes (1,559 pages)
  * - KBLI sectors index + individual sector pages (~22)
- * Priority scale:
- * - 1.0: Homepage
- * - 0.9: Main service pages
- * - 0.8: Blog articles, KBLI explorer, KBLI codes
- * - 0.7: Service detail pages, news categories, KBLI sectors
  *
- * Change frequency:
- * - daily: News, blog
- * - weekly: Services, KBLI
- * - monthly: Static pages
+ * Signal discipline (GSC clean-window investigation 2026-07-03):
+ * - `priority` and `changeFrequency` are omitted — Google ignores both, and
+ *   inaccurate hints erode sitemap trust.
+ * - `lastModified` is emitted ONLY where we know the real modification event
+ *   (article updatedAt/publishedAt, KBLI data-file mtime). Pages whose real
+ *   lastmod we don't track carry no lastModified at all — a fabricated
+ *   deploy-time date teaches Google to ignore our lastmod entirely.
  */
 
 const baseUrl = "https://balizero.com";
@@ -33,100 +31,28 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const routes: MetadataRoute.Sitemap = [];
 
   // 1. Static pages
-  const staticPages = [
-    {
-      url: `${baseUrl}`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 1.0,
-    },
-    {
-      url: `${baseUrl}/kbli`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/services`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/news`,
-      lastModified: new Date(),
-      changeFrequency: "daily" as const,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/team`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/contact`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/kbli-explorer`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/llms.txt`,
-      lastModified: new Date(),
-      changeFrequency: "daily" as const,
-      priority: 1.0,
-    },
-    {
-      url: `${baseUrl}/llms-full.txt`,
-      lastModified: new Date(),
-      changeFrequency: "daily" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/llms-id.txt`,
-      lastModified: new Date(),
-      changeFrequency: "daily" as const,
-      priority: 0.9,
-    },
+  const staticPaths = [
+    "",
+    "/kbli",
+    "/services",
+    "/news",
+    "/team",
+    "/contact",
+    "/kbli-explorer",
+    "/llms.txt",
+    "/llms-full.txt",
+    "/llms-id.txt",
   ];
-
-  routes.push(...staticPages);
+  routes.push(...staticPaths.map((p) => ({ url: `${baseUrl}${p}` })));
 
   // 2. Service pages (4 main services)
-  const servicePages = [
-    {
-      url: `${baseUrl}/services/visa`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/services/company`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/services/tax`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/services/property`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
+  const servicePaths = [
+    "/services/visa",
+    "/services/company",
+    "/services/tax",
+    "/services/property",
   ];
-
-  routes.push(...servicePages);
+  routes.push(...servicePaths.map((p) => ({ url: `${baseUrl}${p}` })));
 
   // 3. Category pages (match actual routes: /{category})
   const categories = [
@@ -137,15 +63,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "living",
     "trends",
   ];
-
-  const newsCategoryPages = categories.map((category) => ({
-    url: `${baseUrl}/${category}`,
-    lastModified: new Date(),
-    changeFrequency: "daily" as const,
-    priority: 0.7,
-  }));
-
-  routes.push(...newsCategoryPages);
+  routes.push(...categories.map((c) => ({ url: `${baseUrl}/${c}` })));
 
   // 4. Blog articles (from local MDX content, excluding noIndex articles)
   try {
@@ -169,19 +87,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         return true;
       })
       .map((article) => {
-        // Priority: featured editorial (0.9) > ai-enriched (0.8) > basic (0.6)
-        const priority = article.featured
-          ? 0.9
-          : article.aiGenerated
-            ? 0.8
-            : 0.6;
         const entry: MetadataRoute.Sitemap[number] = {
           url: `${baseUrl}/${article.category}/${article.slug}`,
-          lastModified: article.publishedAt
-            ? new Date(article.publishedAt)
-            : new Date(),
-          changeFrequency: "weekly" as const,
-          priority,
+          ...(article.publishedAt
+            ? { lastModified: new Date(article.publishedAt) }
+            : {}),
         };
 
         return entry;
@@ -196,7 +106,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     );
   }
 
-  // 5. KBLI Codes (1,559 pages)
+  // 5. KBLI Codes (1,559 pages) — lastmod is the dataset file's mtime: the
+  // last real content-change event we can attest for these pages.
   try {
     const codes = getAllCodes();
     const kbliDataPath = path.join(
@@ -213,8 +124,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const kbliPages = codes.map((c) => ({
       url: `${baseUrl}/kbli/${c.code}`,
       lastModified: kbliLastModified,
-      changeFrequency: "monthly" as const,
-      priority: 0.8,
     }));
     routes.push(...kbliPages);
   } catch (error) {
@@ -228,61 +137,27 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // 6. Visa funnel pages (balizero.com/visa — consolidated 2026-04-21,
   // was previously at visa.balizero.com; the subdomain now 302-redirects
   // to these canonical paths via middleware.ts).
-  const visaPages = [
-    {
-      url: `${baseUrl}/visa`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/visa/match`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/visa/clock`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/visa/privacy`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/visa/terms`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.5,
-    },
+  const visaPaths = [
+    "/visa",
+    "/visa/match",
+    "/visa/clock",
+    "/visa/privacy",
+    "/visa/terms",
   ];
-  routes.push(...visaPages);
+  routes.push(...visaPaths.map((p) => ({ url: `${baseUrl}${p}` })));
 
   // 7. KBLI Sector pages (/kbli/sectors + /kbli/sectors/[id])
   try {
-    routes.push({
-      url: `${baseUrl}/kbli/sectors`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.8,
-    });
+    routes.push({ url: `${baseUrl}/kbli/sectors` });
 
     const sections = getSections().filter(
       // Exclude sections with no codes AND exclude the sentinel "?" ID that
       // transformCode() emits when sektor_id is null — avoids /kbli/sectors/?
       (s) => s.codeCount > 0 && /^[A-Z]$/.test(s.id),
     );
-    const sectorPages = sections.map((s) => ({
-      url: `${baseUrl}/kbli/sectors/${s.id}`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.7,
-    }));
-    routes.push(...sectorPages);
+    routes.push(
+      ...sections.map((s) => ({ url: `${baseUrl}/kbli/sectors/${s.id}` })),
+    );
   } catch (error) {
     logger.error(
       "[SITEMAP] Failed to load KBLI sectors",

--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -106,18 +106,22 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     );
   }
 
-  // 5. KBLI Codes (1,559 pages) — lastmod is the dataset file's mtime: the
-  // last real content-change event we can attest for these pages.
+  // 5. KBLI Codes (1,559 pages) — lastmod comes from the committed dataset
+  // version sidecar (data/kbli-dataset-version.json), NOT the file mtime:
+  // git/Vercel checkouts stamp clone time on every file, so mtime would
+  // claim all 1,559 pages "modified today" on every deploy — exactly the
+  // fabricated freshness signal this sitemap must not send.
   try {
     const codes = getAllCodes();
-    const kbliDataPath = path.join(
-      process.cwd(),
-      "data",
-      "KBLI_2025_FINAL_CLEAN.json",
-    );
     let kbliLastModified: Date;
     try {
-      kbliLastModified = fs.statSync(kbliDataPath).mtime;
+      const version = JSON.parse(
+        fs.readFileSync(
+          path.join(process.cwd(), "data", "kbli-dataset-version.json"),
+          "utf-8",
+        ),
+      ) as { lastModified: string };
+      kbliLastModified = new Date(version.lastModified);
     } catch {
       kbliLastModified = new Date("2026-06-19");
     }


### PR DESCRIPTION
Red-team fixes that raced #1963's auto-merge (it merged while these were being pushed):

1. **/_next/static must stay crawlable** — #1963 applied the disallow list to every UA group, which newly blocked `/_next/` for Googlebot (via `*`) and named crawlers. Renderers fetch CSS/JS/images to evaluate pages; `Allow: /_next/static/` + `/_next/image` now beat the `/_next/` disallow (longest-match wins).
2. **Sidecar lastmod instead of mtime** — file mtime on git/Vercel checkouts is clone time, not content-change time (verified: local mtime = today vs last dataset commit 2026-07-02). Every deploy claimed all 1,559 KBLI pages "modified today". lastmod now reads the committed `data/kbli-dataset-version.json` (real date + dataset sha256).

`npm run typecheck` ✓. Credit: Codex red-team pass on the SEO offensive diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>