### PR TITLE
feat(immune): PENDING-ARMS reconciliation report — superscar #2/W81 antidote

### DIFF
--- a/scripts/pending_arms_report.py
+++ b/scripts/pending_arms_report.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""pending_arms_report.py — superscar #2 "Esiste != Armato / Armamento Sospeso" (W81) reconciliation report.
+
+The W81 ledger (`.claude/skills/modus/PENDING-ARMS.md`) records every artifact that was
+BUILT but not yet {merged, installed, propagated, armed, committed}. This script is a
+PURE SIGNALER over that ledger: it parses the open section, ages each entry, and alarms
+on anything TECH-DEBT-classified that has sat unarmed for >48h — while distinguishing
+that from legitimate, pre-declared firebreaks (operator gate / Legge 5 / business
+decision) which are informational only, never an alarm.
+
+It NEVER writes, edits, or otherwise mutates anything — ledger, filesystem, or process
+state. It only reads the ledger and prints a report (markdown by default, --json on
+request). The only way this script affects control flow is its own exit code, and only
+under --strict.
+
+Ledger format (documented in the ledger's own header):
+
+    - opened YYYY-MM-DD | artifact | missing arming step | owner (me|operator) | proof-of-armed
+
+Entries live as markdown list items BEFORE a line starting with `## closed`; closed
+entries (after that heading, starting with `- closed `) are proof-of-armed history and
+are never read by this script.
+
+Usage:
+    python3 scripts/pending_arms_report.py [--ledger PATH] [--now YYYY-MM-DD] [--json] [--strict]
+
+Exit codes:
+    0   always, by default (pure signaler — a report is not a failure)
+    1   only with --strict, and only if >=1 overdue TECH-DEBT entry exists
+    2   ledger file not found, or a CLI argument error (argparse's own exit code)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+# 48h at day-precision: the ledger records opened-dates, not timestamps, so "overdue"
+# is age_days >= 2 (i.e. the entry has survived at least one full day beyond the day
+# it was opened, which is the closest day-precision proxy for >48h — declared here and
+# in every report header so nobody mistakes it for hour-precision).
+OVERDUE_AGE_DAYS = 2
+
+OPENED_RE = re.compile(r"-\s*opened\s+(\d{4}-\d{2}-\d{2})")
+CLOSED_HEADING_PREFIX = "## closed"
+
+CLASS_MALFORMED = "MALFORMED"
+CLASS_FIREBREAK = "FIREBREAK"
+CLASS_OPERATOR_GATED = "OPERATOR-GATED"
+CLASS_TECH_DEBT = "TECH-DEBT"
+
+
+@dataclass
+class Entry:
+    """One parsed open-ledger entry (after continuation-line concatenation)."""
+
+    raw: str
+    opened_date: Optional[date]
+    artifact: str
+    owner: str
+    missing_step: str
+    proof: str
+    malformed: bool
+    malformed_reasons: List[str] = field(default_factory=list)
+    age_days: Optional[int] = None
+    overdue: bool = False
+    cls: str = CLASS_TECH_DEBT
+
+    @property
+    def bucket(self) -> str:
+        """Report/JSON grouping key: MALFORMED > FIREBREAK > {cls}-OVERDUE > FRESH."""
+        if self.cls == CLASS_MALFORMED:
+            return CLASS_MALFORMED
+        if self.cls == CLASS_FIREBREAK:
+            return CLASS_FIREBREAK
+        if self.overdue:
+            return f"{self.cls}-OVERDUE"
+        return "FRESH"
+
+
+def _safe_get(parts: Sequence[str], idx: int) -> str:
+    try:
+        return parts[idx].strip()
+    except IndexError:
+        return ""
+
+
+def _extract_missing_step(parts: Sequence[str]) -> str:
+    """Best-effort recovery of the 'missing arming step' field.
+
+    Well-formed entries have exactly 5 pipe-fields (date-prefix, artifact, missing
+    step, owner, proof). If the free-text itself contains extra '|' characters the
+    split grows past 5 — field[1] (artifact) and the last two fields (owner, proof)
+    stay anchored from the outside in, so everything left in the middle belongs to
+    the missing-arming-step description; rejoin it with '|' to restore it verbatim.
+    """
+    middle = parts[2:-2]
+    if middle:
+        return "|".join(p.strip() for p in middle).strip()
+    return _safe_get(parts, 2)
+
+
+def _truncate(text: str, limit: int = 120) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(limit - 1, 0)].rstrip() + "…"
+
+
+def extract_open_entries(ledger_text: str) -> List[str]:
+    """Return the raw (continuation-concatenated) text of every open-section entry.
+
+    Only lines BEFORE the first line starting with '## closed' are considered. Within
+    that open section, an entry starts at a line starting with '- opened '; any
+    following line that is non-blank, doesn't start a new '- ' list item, and isn't a
+    heading/blockquote is treated as a wrapped continuation and appended (space-joined)
+    to the current entry. A blank line, a new '- ' item, or a heading/blockquote line
+    ends the current entry.
+    """
+    lines = ledger_text.splitlines()
+
+    cutoff = len(lines)
+    for i, line in enumerate(lines):
+        if line.strip().startswith(CLOSED_HEADING_PREFIX):
+            cutoff = i
+            break
+    open_lines = lines[:cutoff]
+
+    entries: List[str] = []
+    current: Optional[str] = None
+
+    def finalize() -> None:
+        nonlocal current
+        if current is not None:
+            entries.append(current)
+        current = None
+
+    for line in open_lines:
+        stripped = line.strip()
+        if stripped.startswith("- opened "):
+            finalize()
+            current = stripped
+        elif stripped.startswith("- "):
+            # some other list item (not a ledger entry) — ends any entry in progress,
+            # is not itself collected.
+            finalize()
+        elif stripped == "":
+            finalize()
+        elif stripped.startswith("#") or stripped.startswith(">"):
+            finalize()
+        else:
+            if current is not None:
+                current = f"{current} {stripped}"
+
+    finalize()
+    return entries
+
+
+def parse_entry(raw: str, now: date) -> Entry:
+    """Parse one raw entry string into a structured, never-crashing Entry."""
+    reasons: List[str] = []
+
+    date_match = OPENED_RE.search(raw)
+    opened_dt: Optional[date] = None
+    if date_match:
+        opened_dt = datetime.strptime(date_match.group(1), "%Y-%m-%d").date()
+    else:
+        reasons.append("no 'opened YYYY-MM-DD' date found")
+
+    parts = raw.split("|")
+    if len(parts) < 3:
+        reasons.append(f"only {len(parts)} pipe-segment(s) (need >= 3)")
+
+    artifact = _safe_get(parts, 1)
+    owner = _safe_get(parts, -2)
+    proof = _safe_get(parts, -1)
+    missing_step = _extract_missing_step(parts)
+
+    age_days: Optional[int] = None
+    overdue = False
+    if opened_dt is not None:
+        age_days = (now - opened_dt).days
+        overdue = age_days >= OVERDUE_AGE_DAYS
+
+    malformed = bool(reasons)
+    if malformed:
+        cls = CLASS_MALFORMED
+    elif "firebreak" in raw.lower():
+        cls = CLASS_FIREBREAK
+    elif "operator" in owner.lower():
+        cls = CLASS_OPERATOR_GATED
+    else:
+        cls = CLASS_TECH_DEBT
+
+    return Entry(
+        raw=raw,
+        opened_date=opened_dt,
+        artifact=artifact,
+        owner=owner,
+        missing_step=missing_step,
+        proof=proof,
+        malformed=malformed,
+        malformed_reasons=reasons,
+        age_days=age_days,
+        overdue=overdue,
+        cls=cls,
+    )
+
+
+def load_entries(ledger_path: Path, now: date) -> List[Entry]:
+    text = ledger_path.read_text(encoding="utf-8")
+    return [parse_entry(raw, now) for raw in extract_open_entries(text)]
+
+
+def compute_counts(entries: List[Entry]) -> Dict[str, int]:
+    buckets = [e.bucket for e in entries]
+    return {
+        "total": len(entries),
+        "tech_debt_overdue": buckets.count(f"{CLASS_TECH_DEBT}-OVERDUE"),
+        "operator_gated_overdue": buckets.count(f"{CLASS_OPERATOR_GATED}-OVERDUE"),
+        "firebreak": buckets.count(CLASS_FIREBREAK),
+        "fresh": buckets.count("FRESH"),
+        "malformed": buckets.count(CLASS_MALFORMED),
+    }
+
+
+def render_report(ledger_path: Path, now: date, entries: List[Entry]) -> str:
+    counts = compute_counts(entries)
+    lines: List[str] = []
+    lines.append("# PENDING-ARMS reconciliation report")
+    lines.append("")
+    lines.append(f"- ledger: `{ledger_path}`")
+    lines.append(
+        f"- now: {now.isoformat()} (day-precision dates; overdue = age_days >= "
+        f"{OVERDUE_AGE_DAYS}, the closest day-precision proxy for >48h)"
+    )
+    lines.append(
+        "- counts: total={total} tech_debt_overdue={tech_debt_overdue} "
+        "operator_gated_overdue={operator_gated_overdue} firebreak={firebreak} "
+        "fresh={fresh} malformed={malformed}".format(**counts)
+    )
+    lines.append("")
+
+    def fmt_entry(e: Entry) -> str:
+        opened = e.opened_date.isoformat() if e.opened_date else "?"
+        age = e.age_days if e.age_days is not None else "?"
+        return (
+            f"- {e.artifact or '(no artifact parsed)'} "
+            f"(opened {opened}, age {age}d, owner={e.owner or '?'}): "
+            f"{_truncate(e.missing_step, 120)}"
+        )
+
+    def fmt_malformed(e: Entry) -> str:
+        reasons = "; ".join(e.malformed_reasons) or "unknown parse failure"
+        return f"- {_truncate(e.raw, 80)}  [reason: {reasons}]"
+
+    def section(title: str, items: List[Entry], formatter) -> None:
+        lines.append(f"## {title}")
+        if not items:
+            lines.append("none")
+        else:
+            for item in items:
+                lines.append(formatter(item))
+        lines.append("")
+
+    by_bucket: Dict[str, List[Entry]] = {}
+    for e in entries:
+        by_bucket.setdefault(e.bucket, []).append(e)
+
+    section(
+        "TECH-DEBT overdue (>48h)",
+        by_bucket.get(f"{CLASS_TECH_DEBT}-OVERDUE", []),
+        fmt_entry,
+    )
+    section(
+        "OPERATOR-GATED overdue",
+        by_bucket.get(f"{CLASS_OPERATOR_GATED}-OVERDUE", []),
+        fmt_entry,
+    )
+    section(
+        "FIREBREAK (legitimate, informational)",
+        by_bucket.get(CLASS_FIREBREAK, []),
+        fmt_entry,
+    )
+    section("Fresh (<48h)", by_bucket.get("FRESH", []), fmt_entry)
+    section("MALFORMED", by_bucket.get(CLASS_MALFORMED, []), fmt_malformed)
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_json(ledger_path: Path, now: date, entries: List[Entry]) -> Dict[str, Any]:
+    return {
+        "now": now.isoformat(),
+        "ledger": str(ledger_path),
+        "counts": compute_counts(entries),
+        "entries": [
+            {
+                "opened": e.opened_date.isoformat() if e.opened_date else None,
+                "age_days": e.age_days,
+                "artifact": e.artifact,
+                "owner": e.owner,
+                "class": e.cls,
+                "overdue": e.overdue,
+                "raw_head": e.raw[:80],
+            }
+            for e in entries
+        ],
+    }
+
+
+def _default_ledger_path() -> Path:
+    # scripts/pending_arms_report.py -> parent = scripts/, parent.parent = repo root.
+    repo_root = Path(__file__).resolve().parent.parent
+    return repo_root / ".claude" / "skills" / "modus" / "PENDING-ARMS.md"
+
+
+def _parse_now(value: Optional[str]) -> date:
+    if value is None:
+        return date.today()
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pending_arms_report.py",
+        description=(
+            "Reconciliation report over the W81 PENDING-ARMS ledger: alarms on "
+            "built-but-not-armed TECH-DEBT entries overdue >48h, separates "
+            "legitimate firebreaks. Pure signaler — never writes anything."
+        ),
+    )
+    parser.add_argument(
+        "--ledger",
+        type=Path,
+        default=None,
+        help="Path to PENDING-ARMS.md (default: <repo-root>/.claude/skills/modus/PENDING-ARMS.md)",
+    )
+    parser.add_argument(
+        "--now",
+        type=str,
+        default=None,
+        help="Override 'today' as YYYY-MM-DD, for deterministic runs/tests.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the markdown report.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 iff >=1 overdue TECH-DEBT entry exists (otherwise always exit 0).",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    ledger_path: Path = args.ledger if args.ledger is not None else _default_ledger_path()
+
+    if not ledger_path.exists():
+        print(
+            f"pending_arms_report: ledger not found: {ledger_path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        now = _parse_now(args.now)
+    except ValueError:
+        print(
+            f"pending_arms_report: invalid --now value {args.now!r}, expected YYYY-MM-DD",
+            file=sys.stderr,
+        )
+        return 2
+
+    entries = load_entries(ledger_path, now)
+
+    if args.json:
+        print(json.dumps(build_json(ledger_path, now, entries), indent=2))
+    else:
+        print(render_report(ledger_path, now, entries), end="")
+
+    if args.strict and any(
+        e.cls == CLASS_TECH_DEBT and e.overdue for e in entries
+    ):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_pending_arms_report.py
+++ b/scripts/tests/test_pending_arms_report.py
@@ -1,0 +1,334 @@
+"""Tests for scripts/pending_arms_report.py — the W81 PENDING-ARMS reconciliation report.
+
+Module is imported via importlib.util.spec_from_file_location (not a package import)
+because scripts/ is a flat bag of standalone tools, not a Python package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "pending_arms_report.py"
+REAL_LEDGER_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / ".claude"
+    / "skills"
+    / "modus"
+    / "PENDING-ARMS.md"
+)
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("pending_arms_report", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+par = _load_module()
+
+NOW = "2026-07-05"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic ledger fixture
+# ---------------------------------------------------------------------------
+
+LEDGER_TEMPLATE = """\
+# modus — PENDING-ARMS (the W81 ledger: built != armed)
+
+> Format: `opened YYYY-MM-DD | artifact | missing arming step | owner (me|operator) | proof-of-armed`
+
+- opened 2026-06-25 | overdue tech debt artifact | wire the hook into settings.json | me | a live session shows the block
+- opened 2026-07-05 | fresh me artifact | needs a restart to pick up | me | next restart log shows it
+- opened 2026-06-20 | overdue operator artifact | waiting on operator GO | operator | operator GO recorded
+- opened 2026-06-01 | firebreak artifact | DELIBERATE FIREBREAK, not tech debt: waiting for signal quality before flip | operator | operator GO + probe
+
+- opened 2026-07-01 | wrapped artifact spanning lines
+  and continuing artifact description | missing step first part
+  missing step continued | me | proof text starts
+  proof continues here
+- opened 2026-06-15 completely malformed line describing something broken with no pipe characters at all
+- opened 2026-07-04 | boundary age one artifact | some step | me | some proof
+- opened 2026-07-03 | boundary age two artifact | some step | me | some proof
+
+## closed (proof recorded)
+
+- closed 2026-01-01 | ancient closed artifact that would be a giant overdue tech-debt entry if the parser leaked past the heading | me | this line must NEVER be counted
+- closed 2026-07-04 | some other closed thing | operator | PROVEN: irrelevant to open parsing
+"""
+
+
+@pytest.fixture()
+def ledger_path(tmp_path: Path) -> Path:
+    p = tmp_path / "PENDING-ARMS.md"
+    p.write_text(LEDGER_TEMPLATE, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def entries(ledger_path: Path):
+    now = par._parse_now(NOW)
+    return par.load_entries(ledger_path, now)
+
+
+def _by_artifact(entries, needle: str):
+    matches = [e for e in entries if needle in e.artifact]
+    assert matches, f"no entry with artifact containing {needle!r} (have: {[e.artifact for e in entries]})"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Parsing scope: only the open section, closed section never touched
+# ---------------------------------------------------------------------------
+
+
+def test_total_entry_count_excludes_closed_section(entries):
+    assert len(entries) == 8
+
+
+def test_closed_section_never_parsed(entries):
+    for e in entries:
+        assert "closed" not in e.artifact.lower()
+        assert "ancient closed artifact" not in e.raw
+    counts = par.compute_counts(entries)
+    # If the closed ancient line leaked in, it would add another overdue tech-debt entry.
+    assert counts["tech_debt_overdue"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_overdue_tech_debt_classification(entries):
+    e = _by_artifact(entries, "overdue tech debt artifact")
+    assert e.cls == par.CLASS_TECH_DEBT
+    assert e.owner == "me"
+    assert e.overdue is True
+    assert e.age_days == 10
+    assert e.bucket == "TECH-DEBT-OVERDUE"
+
+
+def test_fresh_me_classification(entries):
+    e = _by_artifact(entries, "fresh me artifact")
+    assert e.cls == par.CLASS_TECH_DEBT
+    assert e.age_days == 0
+    assert e.overdue is False
+    assert e.bucket == "FRESH"
+
+
+def test_overdue_operator_classification(entries):
+    e = _by_artifact(entries, "overdue operator artifact")
+    assert e.cls == par.CLASS_OPERATOR_GATED
+    assert e.overdue is True
+    assert e.bucket == "OPERATOR-GATED-OVERDUE"
+
+
+def test_overdue_firebreak_classification(entries):
+    e = _by_artifact(entries, "firebreak artifact")
+    assert e.cls == par.CLASS_FIREBREAK
+    assert e.owner == "operator"
+    assert e.overdue is True  # still objectively overdue by age...
+    assert e.bucket == par.CLASS_FIREBREAK  # ...but bucketed as informational, not an alarm
+
+
+def test_multiline_wrapped_entry_concatenated_and_classified(entries):
+    e = _by_artifact(entries, "wrapped artifact spanning lines")
+    assert "and continuing artifact description" in e.artifact
+    assert e.owner == "me"
+    assert "missing step first part" in e.missing_step
+    assert "missing step continued" in e.missing_step
+    assert "proof text starts" in e.proof
+    assert "proof continues here" in e.proof
+    assert e.cls == par.CLASS_TECH_DEBT
+    assert e.overdue is True  # opened 2026-07-01, now 2026-07-05 => age 4
+
+
+def test_malformed_line_reported_not_crashed(entries):
+    malformed = [e for e in entries if e.malformed]
+    assert len(malformed) == 1
+    e = malformed[0]
+    assert e.cls == par.CLASS_MALFORMED
+    assert e.bucket == par.CLASS_MALFORMED
+    assert any("pipe-segment" in r for r in e.malformed_reasons)
+    # opened-date still parses fine for this one; only the pipe count is the defect.
+    assert e.opened_date is not None
+
+
+# ---------------------------------------------------------------------------
+# Overdue boundary: age 1 day = fresh, age 2 days = overdue
+# ---------------------------------------------------------------------------
+
+
+def test_overdue_boundary_age_one_is_fresh(entries):
+    e = _by_artifact(entries, "boundary age one artifact")
+    assert e.age_days == 1
+    assert e.overdue is False
+    assert e.bucket == "FRESH"
+
+
+def test_overdue_boundary_age_two_is_overdue(entries):
+    e = _by_artifact(entries, "boundary age two artifact")
+    assert e.age_days == 2
+    assert e.overdue is True
+    assert e.bucket == "TECH-DEBT-OVERDUE"
+
+
+# ---------------------------------------------------------------------------
+# counts()
+# ---------------------------------------------------------------------------
+
+
+def test_compute_counts_matches_expected_distribution(entries):
+    counts = par.compute_counts(entries)
+    assert counts == {
+        "total": 8,
+        "tech_debt_overdue": 3,  # overdue-tech-debt, wrapped, boundary-age-two
+        "operator_gated_overdue": 1,
+        "firebreak": 1,
+        "fresh": 2,  # fresh-me, boundary-age-one
+        "malformed": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI: --strict exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_strict_exits_1_when_overdue_tech_debt_present(ledger_path, capsys):
+    code = par.main(["--ledger", str(ledger_path), "--now", NOW, "--strict"])
+    assert code == 1
+
+
+def test_strict_exits_0_without_overdue_tech_debt(tmp_path, capsys):
+    only_firebreak_and_operator = """\
+- opened 2026-06-01 | firebreak only artifact | DELIBERATE FIREBREAK not tech debt | operator | operator GO
+- opened 2026-06-10 | operator only artifact | waiting on operator | operator | operator GO recorded
+
+## closed (proof recorded)
+"""
+    p = tmp_path / "PENDING-ARMS.md"
+    p.write_text(only_firebreak_and_operator, encoding="utf-8")
+    code = par.main(["--ledger", str(p), "--now", NOW, "--strict"])
+    assert code == 0
+
+
+def test_non_strict_always_exits_0_even_with_overdue_tech_debt(ledger_path, capsys):
+    code = par.main(["--ledger", str(ledger_path), "--now", NOW])
+    assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI: default markdown report
+# ---------------------------------------------------------------------------
+
+
+def test_report_sections_present_and_populated(ledger_path, capsys):
+    code = par.main(["--ledger", str(ledger_path), "--now", NOW])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "## TECH-DEBT overdue (>48h)" in out
+    assert "## OPERATOR-GATED overdue" in out
+    assert "## FIREBREAK (legitimate, informational)" in out
+    assert "## Fresh (<48h)" in out
+    assert "## MALFORMED" in out
+    assert "overdue tech debt artifact" in out
+    assert "ancient closed artifact" not in out
+
+
+def test_report_empty_section_says_none(tmp_path, capsys):
+    only_fresh = """\
+- opened 2026-07-05 | only fresh artifact | some step | me | some proof
+
+## closed (proof recorded)
+"""
+    p = tmp_path / "PENDING-ARMS.md"
+    p.write_text(only_fresh, encoding="utf-8")
+    code = par.main(["--ledger", str(p), "--now", NOW])
+    assert code == 0
+    out = capsys.readouterr().out
+    # every non-Fresh section should say "none"
+    for heading in (
+        "## TECH-DEBT overdue (>48h)",
+        "## OPERATOR-GATED overdue",
+        "## FIREBREAK (legitimate, informational)",
+        "## MALFORMED",
+    ):
+        section = out.split(heading, 1)[1].splitlines()[1].strip()
+        assert section == "none"
+
+
+# ---------------------------------------------------------------------------
+# CLI: --json structure
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_structure(ledger_path, capsys):
+    code = par.main(["--ledger", str(ledger_path), "--now", NOW, "--json"])
+    assert code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["now"] == NOW
+    assert payload["counts"] == {
+        "total": 8,
+        "tech_debt_overdue": 3,
+        "operator_gated_overdue": 1,
+        "firebreak": 1,
+        "fresh": 2,
+        "malformed": 1,
+    }
+    assert len(payload["entries"]) == 8
+    fields = {"opened", "age_days", "artifact", "owner", "class", "overdue", "raw_head"}
+    for entry in payload["entries"]:
+        assert fields.issubset(entry.keys())
+
+    firebreak_entries = [e for e in payload["entries"] if e["class"] == "FIREBREAK"]
+    assert len(firebreak_entries) == 1
+    assert firebreak_entries[0]["overdue"] is True
+
+
+# ---------------------------------------------------------------------------
+# CLI: missing ledger file
+# ---------------------------------------------------------------------------
+
+
+def test_missing_ledger_exits_2(tmp_path, capsys):
+    missing = tmp_path / "does-not-exist.md"
+    code = par.main(["--ledger", str(missing), "--now", NOW])
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "not found" in err
+
+
+# ---------------------------------------------------------------------------
+# Smoke test against the REAL ledger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not REAL_LEDGER_PATH.exists(),
+    reason=f"real ledger not found at {REAL_LEDGER_PATH} (CI checkout may not have it)",
+)
+def test_smoke_real_ledger_parses_without_exception():
+    now = par._parse_now(NOW)
+    entries = par.load_entries(REAL_LEDGER_PATH, now)
+    assert len(entries) >= 1
+    # never crashes even on malformed entries; every entry has a bucket.
+    for e in entries:
+        assert e.bucket in {
+            par.CLASS_MALFORMED,
+            par.CLASS_FIREBREAK,
+            "TECH-DEBT-OVERDUE",
+            "OPERATOR-GATED-OVERDUE",
+            "FRESH",
+        }


### PR DESCRIPTION
scripts/pending_arms_report.py: the W81 "Armamento Sospeso" antidote made
executable — a reconciliation REPORT that parses the modus PENDING-ARMS
ledger and alarms on built-but-not-armed entries older than 48h,
distinguishing declared FIREBREAKs (legitimate) from OPERATOR-GATED items
and plain TECH-DEBT. Pure signaler by contract: it never writes, edits or
mutates anything; exit 0 always, --strict exits 1 only on overdue tech
debt. Handles wrapped multi-line entries, extra pipes inside fields,
malformed lines (reported, never crash), day-precision dates declared in
the header, --now for deterministic tests, --json for machines.

18 unit tests incl. a smoke test against the real ledger. First live run
(2026-07-05): 7 open entries — 3 TECH-DEBT overdue, 1 OPERATOR-GATED
overdue, 3 FIREBREAK, 0 malformed.

CI: covered by .github/workflows/immune-enforcement.yml (PR #1970).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
