### PR TITLE
fix(seo): red-team follow-up — /_next/static crawlable + sitemap sidecar lastmod

### DIFF
--- a/apps/mouth/src/app/robots.ts
+++ b/apps/mouth/src/app/robots.ts
@@ -6,6 +6,13 @@ import type { MetadataRoute } from "next";
 // disallow list, or that crawler is silently allowed into /api/, /dashboard
 // and the rest of the workspace (crawl-budget bleed — GSC clean-window
 // investigation 2026-07-03).
+// /_next/ stays disallowed (build manifests, data routes), but the static
+// assets and the image optimizer MUST stay crawlable: search-engine renderers
+// fetch CSS/JS/images to evaluate the page, and robots-blocked resources
+// degrade rendering (red-team finding 2026-07-05). Longest-match wins, so
+// these allows beat the /_next/ disallow for exactly the asset paths.
+const ALLOW = ["/", "/_next/static/", "/_next/image"];
+
 const DISALLOW = [
   "/dashboard",
   "/clients",
@@ -34,58 +41,58 @@ export default function robots(): MetadataRoute.Robots {
       // cost us the disallow list).
       {
         userAgent: "*",
-        allow: ["/", "/llms.txt", "/llms-full.txt", "/llms-id.txt"],
+        allow: [...ALLOW, "/llms.txt", "/llms-full.txt", "/llms-id.txt"],
         disallow: DISALLOW,
       },
       {
         userAgent: "Bingbot",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 1,
       },
       // ── AI crawlers — explicitly welcome (on public content) ──
       {
         userAgent: ["GPTBot", "OAI-SearchBot"],
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "ChatGPT-User",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
       },
       {
         userAgent: ["ClaudeBot", "anthropic-ai"],
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "Claude-User",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
       },
       {
         userAgent: "PerplexityBot",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: "Google-Extended",
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
       },
       {
         userAgent: ["Applebot-Extended", "Amazonbot", "YouBot", "Bytespider"],
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
         crawlDelay: 2,
       },
       {
         userAgent: ["FacebookBot", "Meta-ExternalAgent", "CCBot", "cohere-ai"],
-        allow: ["/"],
+        allow: ALLOW,
         disallow: DISALLOW,
       },
     ],

--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -106,18 +106,22 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     );
   }
 
-  // 5. KBLI Codes (1,559 pages) — lastmod is the dataset file's mtime: the
-  // last real content-change event we can attest for these pages.
+  // 5. KBLI Codes (1,559 pages) — lastmod comes from the committed dataset
+  // version sidecar (data/kbli-dataset-version.json), NOT the file mtime:
+  // git/Vercel checkouts stamp clone time on every file, so mtime would
+  // claim all 1,559 pages "modified today" on every deploy — exactly the
+  // fabricated freshness signal this sitemap must not send.
   try {
     const codes = getAllCodes();
-    const kbliDataPath = path.join(
-      process.cwd(),
-      "data",
-      "KBLI_2025_FINAL_CLEAN.json",
-    );
     let kbliLastModified: Date;
     try {
-      kbliLastModified = fs.statSync(kbliDataPath).mtime;
+      const version = JSON.parse(
+        fs.readFileSync(
+          path.join(process.cwd(), "data", "kbli-dataset-version.json"),
+          "utf-8",
+        ),
+      ) as { lastModified: string };
+      kbliLastModified = new Date(version.lastModified);
     } catch {
       kbliLastModified = new Date("2026-06-19");
     }


### PR DESCRIPTION
Replaces #1968, whose branch carried pre-squash #1963 commits and went CONFLICTING after #1963/#1965 merged (W88 continuation-branch trap). Net diff rebuilt clean on current main — final robots.ts/sitemap.ts blobs are byte-identical to the reviewed #1968 tip; the dataset-version sidecar is already on main via #1965.

1. **/_next/static must stay crawlable** — #1963 applied the disallow list to every UA group, newly blocking `/_next/` for Googlebot (via `*`) and named crawlers. Renderers fetch CSS/JS/images to evaluate pages; `Allow: /_next/static/` + `/_next/image` beat the `/_next/` disallow (longest-match wins).
2. **Sitemap lastmod from committed sidecar** — file mtime is clone time on git/Vercel checkouts (verified: local mtime = today vs last dataset commit 2026-07-02); every deploy claimed all 1,559 KBLI pages "modified today". Now reads `data/kbli-dataset-version.json` (real date; vitest hash-guard landed with #1965).

`npm run typecheck` ✓. Credit: Codex red-team pass on the SEO offensive diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>