### PR TITLE
feat(immune): KeepAlive one-shot plist linter — superscar #7 antidote (stretch)

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -15,9 +15,11 @@ on:
       - "scripts/lint_home_fork.py"
       - "scripts/secrets_permissions_audit.py"
       - "scripts/pending_arms_report.py"
+      - "scripts/lint_plist_keepalive.py"
       - "scripts/tests/test_lint_home_fork.py"
       - "scripts/tests/test_secrets_permissions_audit.py"
       - "scripts/tests/test_pending_arms_report.py"
+      - "scripts/tests/test_lint_plist_keepalive.py"
       - "infra/home-fork/declared-pairs.json"
       - ".github/workflows/immune-enforcement.yml"
 
@@ -43,7 +45,8 @@ jobs:
           for t in \
             scripts/tests/test_lint_home_fork.py \
             scripts/tests/test_secrets_permissions_audit.py \
-            scripts/tests/test_pending_arms_report.py ; do
+            scripts/tests/test_pending_arms_report.py \
+            scripts/tests/test_lint_plist_keepalive.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"
               python -m pytest "$t" -q || fail=1

--- a/infra/launchagents/com.nuzantara.branch-cleanup.weekly.plist
+++ b/infra/launchagents/com.nuzantara.branch-cleanup.weekly.plist
@@ -37,7 +37,7 @@
         <string>/Users/nuzantara</string>
         <key>BRANCH_CLEANUP_ENABLED</key>
         <string>true</string>
-        <!-- NEVER set --apply here; weekly run is report-only. -->
+        <!-- NEVER set the apply flag here; weekly run is report-only. -->
     </dict>
 
     <key>WorkingDirectory</key>

--- a/scripts/lint_plist_keepalive.py
+++ b/scripts/lint_plist_keepalive.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""lint_plist_keepalive.py — executable antidote for superscar #7
+(Daemon-vs-cron KeepAlive misconfig).
+
+THE FAMILY (cicatrix-superscar.md #7 — W67/W67b wa-mirror reconnect storm,
+W60 Fly machine flapping, 2026-04-29 "53 LaunchAgents, only 13% KeepAlive
+correct"): a launchd job is configured `KeepAlive=true` (or a KeepAlive dict
+that isn't the empty/disabled form) while its actual payload is a ONE-SHOT
+script — a wrapper that `exec`s a process which can legitimately exit, or
+that backgrounds its real work with `nohup ... &` and returns. Every time
+the one-shot exits, launchd reads it as "the daemon died" and restarts it —
+and any `nohup`-detached child in the old process group gets SIGTERM'd on
+the way out. The result is a restart storm, not a running daemon.
+
+THE ANTIDOTE, verbatim (cicatrix-superscar.md #7): "sostituire lo
+pseudo-demone con un loop bloccante reale nel wrapper (`while true; do …;
+sleep N; done`) così launchd non cicla mai; oppure, se è davvero un cron,
+StartInterval + niente KeepAlive. Grep `exec ` in tutto ciò che gira
+KeepAlive=true."
+
+This lint makes that grep executable, static, and CI-able: it walks
+TRACKED plists in the repo (never live ~/Library/LaunchAgents — that's
+lint_home_fork.py's job, a different superscar), and for every plist whose
+KeepAlive is truthy, resolves its wrapper script (if that script is itself
+tracked in the repo) and classifies the wrapper body for one-shot smells.
+
+Detection classes:
+  (a) FAIL  — a line matching `^\\s*exec\\s+<payload>` where <payload> is
+              not itself a bare fd-redirection (`exec 9>lockfile`, which is
+              the standard "open a file descriptor" bash idiom, not a
+              process-replacing exec — see Design decision below).
+  (b) FAIL  — `nohup ...` with trailing ` &` backgrounding on the same
+              line (W67: the backgrounded child dies to SIGTERM every
+              KeepAlive restart cycle).
+  (c) WARN  — no (a)/(b) smell AND the wrapper is under 200 lines AND it
+              contains none of the recognized blocking markers (`while
+              true`, `while :`, `sleep infinity`, `wait `, `tail -f`,
+              `caffeinate`). This is *absence of evidence*, not evidence of
+              guilt (a 200+-line orchestrator very plausibly blocks by some
+              means this lint doesn't enumerate) — so it is a WARN, and
+              never fails the build.
+  UNRESOLVED (informational, --verbose only) — payload is a direct binary,
+              an inline `bash -c`/`-lc` shell string, or not resolvable to
+              a tracked file at all. Nothing to read, nothing to classify.
+
+Design decision (fd-redirect carve-out, superscar #3 discipline applied to
+this lint itself): a naive `^\\s*exec\\s` substring match would also fire on
+`exec 9>"${LOCKFILE}"` (open fd 9 for a lockfile) — a real line found in
+this repo's own apps/backend-rag/backend/services/intake/intake-worker-run.sh
+(a genuinely long-running KeepAlive worker). That is a guard-over-match
+(#3 family): matching the word "exec", not the intent "replace this process
+with something that can exit". This lint therefore excludes `exec <fd>>`/
+`exec <fd><` forms from class (a) — see test
+test_classify_innocence_exec_fd_redirect. Every FAIL class ships with an
+innocence test; no guard merges here without one (superscar #3 doctrine).
+
+Payload resolution (best-effort, read-only, never crashes): Program string
+or ProgramArguments list, merged into one argv. `bash -c` / `zsh -lc`
+inline shell strings are UNRESOLVED by construction (there is no separate
+file to read). Otherwise each path-looking argv token is tried in order:
+first as a repo-relative existing path, then (for ~/... and absolute
+/Users/*/... tokens — the HOME-fork bridge shape, superscar #1 W68/W72) by
+basename lookup across the SAME roots this run scanned for plists. The
+first token that resolves wins; a direct binary (venv python, node, fly,
+...) with no resolvable script argument is UNRESOLVED.
+
+Exit contract is a 2-bit mask (deliberately narrower than lint_home_fork's
+1|2|4 — this lint has no third arm):
+    0 = clean · 1 = one or more (a)/(b) findings ·
+    4 = operational error (unparseable/unreadable plist or wrapper — a scan
+        that cannot see is not clean; W84 fail-visible discipline).
+WARN class (c) is printed but NEVER contributes to the exit code.
+
+Scope notes (deliberate): default roots are infra/launchagents,
+scripts/launchd, infra/, apps/ (pruned of node_modules/.venv/.git) — NOT
+bare top-level scripts/, which holds ~300 unrelated automation scripts and
+would make basename lookup noisy and slow. A wrapper that lives directly
+under scripts/ (e.g. scripts/intake_review_reader_run.sh) is UNRESOLVED
+under the default roots; pass `--root scripts` to widen coverage. This is a
+scope limitation, not a bug — verified against this repo's real inventory.
+
+Complementary, not duplicative: scripts/lint_home_fork.py polices the
+live-vs-repo divergence axis (superscar #1); this lint polices the
+KeepAlive-vs-payload-shape axis (superscar #7) on the tracked tree alone.
+Neither reads the other's state.
+
+Tests: scripts/tests/test_lint_plist_keepalive.py.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import re
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_ROOTS: tuple[str, ...] = (
+    "infra/launchagents",
+    "scripts/launchd",
+    "infra",
+    "apps",
+)
+
+_PRUNE_DIRS = {"node_modules", ".venv", ".git"}
+
+# Executed-payload extensions considered "a script" for path-likeness / basename lookup.
+_EXEC_EXTS = {".sh", ".bash", ".zsh", ".py", ".rb", ".pl", ".js", ".mjs"}
+
+_INLINE_SHELL_FLAGS = {"-c", "-lc", "-cl"}
+
+_EXEC_LINE_RE = re.compile(r"^(\s*)exec\s+(\S.*)$")
+_FD_REDIRECT_RE = re.compile(r"^\d*[<>]")
+
+_NOHUP_RE = re.compile(r"\bnohup\b")
+_BG_TRAILING_RE = re.compile(r"(?<!&)&\s*(#.*)?$")
+
+_BLOCKING_MARKERS = (
+    "while true",
+    "while :",
+    "sleep infinity",
+    "wait ",
+    "tail -f",
+    "caffeinate",
+)
+
+_WARN_LINE_LIMIT = 200
+
+_SMELL_EXEC = (
+    "exec replaces the process — if the payload exits, KeepAlive misreads "
+    "it as death and restarts (W67/W60 restart-storm risk)"
+)
+_SMELL_NOHUP = (
+    "nohup ... & backgrounds a child that launchd SIGTERMs on every "
+    "KeepAlive restart cycle (W67 wa-mirror reconnect storm)"
+)
+
+
+# ---------------------------------------------------------------- KeepAlive
+
+
+def is_keepalive_managed(value: Any) -> bool:
+    """True/non-empty-dict = keepalive-managed. Anything else (False, None,
+    missing, empty dict) is not — mirrors the plist's own truthiness rules,
+    kept deliberately simple per the antidote's scope (see module docstring)."""
+    if value is True:
+        return True
+    if isinstance(value, dict):
+        return bool(value)
+    return False
+
+
+# ---------------------------------------------------------------- discovery
+
+
+def _walk_files(root: Path, errors: list[str], suffix: Optional[str] = None) -> list[Path]:
+    """os.walk with node_modules/.venv/.git pruned; unreadable dirs become
+    operational errors (fail-visible), never a silent skip."""
+    found: list[Path] = []
+    if not root.exists():
+        return found
+
+    def _onerror(exc: OSError) -> None:
+        errors.append(f"root unreadable ({type(exc).__name__}): {exc.filename or root}")
+
+    for dirpath, dirnames, filenames in os.walk(root, onerror=_onerror):
+        dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIRS]
+        for fn in filenames:
+            if suffix is None or fn.endswith(suffix):
+                found.append(Path(dirpath) / fn)
+    return found
+
+
+def collect_plists(root_paths: list[Path], errors: list[str]) -> list[Path]:
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for root in root_paths:
+        for path in _walk_files(root, errors, suffix=".plist"):
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            ordered.append(path)
+    return sorted(ordered)
+
+
+def build_basename_index(root_paths: list[Path], errors: list[str]) -> dict[str, list[Path]]:
+    """basename -> tracked file path(s), scoped to the SAME roots scanned for
+    plists — this is the HOME-fork bridge lookup (superscar #1 W68/W72
+    shape): a plist references an absolute/`~` path, we ask "does a
+    same-named file live somewhere in the tracked tree we're scanning?"."""
+    index: dict[str, list[Path]] = {}
+    seen: set[Path] = set()
+    for root in root_paths:
+        for path in _walk_files(root, errors, suffix=None):
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            index.setdefault(path.name, []).append(path)
+    return index
+
+
+# ---------------------------------------------------------------- payload resolution
+
+
+def extract_argv(payload: dict[str, Any]) -> list[str]:
+    """Program string or ProgramArguments list, merged into one argv.
+    ProgramArguments (the fuller argv) wins when both are present."""
+    prog_args = payload.get("ProgramArguments")
+    if isinstance(prog_args, list) and prog_args:
+        return [str(a) for a in prog_args]
+    program = payload.get("Program")
+    if isinstance(program, str) and program:
+        return [program]
+    return []
+
+
+def _has_inline_shell_flag(argv: list[str]) -> bool:
+    return any(arg in _INLINE_SHELL_FLAGS for arg in argv)
+
+
+def _looks_like_path(arg: str) -> bool:
+    if not arg or arg.startswith("-"):
+        return False
+    if arg.startswith("/") or arg.startswith("~"):
+        return True
+    if "/" in arg:
+        return True
+    return Path(arg).suffix.lower() in _EXEC_EXTS
+
+
+def _try_resolve_one(
+    arg: str, repo_root: Path, basename_index: dict[str, list[Path]]
+) -> Optional[Path]:
+    p = Path(arg)
+    if not p.is_absolute() and not arg.startswith("~"):
+        candidate = repo_root / arg
+        if candidate.is_file():
+            return candidate
+    matches = basename_index.get(p.name)
+    if matches:
+        return sorted(matches)[0]
+    return None
+
+
+def resolve_wrapper(
+    argv: list[str], repo_root: Path, basename_index: dict[str, list[Path]]
+) -> tuple[Optional[Path], Optional[str]]:
+    """Returns (wrapper_path, None) on success, or (None, reason) when the
+    payload is UNRESOLVED — a direct binary, an inline -c/-lc shell string,
+    or simply not found among tracked files."""
+    if not argv:
+        return None, "empty-payload"
+    if _has_inline_shell_flag(argv):
+        return None, "inline-shell(-c/-lc)"
+    for arg in argv:
+        if not _looks_like_path(arg):
+            continue
+        candidate = _try_resolve_one(arg, repo_root, basename_index)
+        if candidate is not None:
+            return candidate, None
+    return None, "not-resolvable-in-repo"
+
+
+# ---------------------------------------------------------------- classification
+
+
+def _has_blocking_marker(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in _BLOCKING_MARKERS)
+
+
+def _is_process_exec(rest_of_line: str) -> bool:
+    """False for `exec 9>lockfile` / `exec >log 2>&1` — fd-manipulation, not
+    a process-replacing exec (the superscar #3 carve-out, see docstring)."""
+    stripped = rest_of_line.strip()
+    if not stripped:
+        return False
+    return not _FD_REDIRECT_RE.match(stripped)
+
+
+def classify_wrapper(text: str) -> tuple[list[tuple[int, str]], list[tuple[int, str]], bool]:
+    """Returns (findings, exec_warns, warn).
+
+    findings   = [(line_no, smell)] — class (b) `nohup ... &`: unambiguous
+                 W67 disease (children SIGTERM'd every KeepAlive cycle).
+    exec_warns = [(line_no, smell)] — class (a) `exec ...`: DEMOTED to WARN
+                 after day-1 calibration on the real repo (superscar #3
+                 discipline applied to this very linter): exec-into-a-server
+                 (livekit, wa-mirror node bridge) is the CORRECT daemon idiom
+                 under KeepAlive; only exec-into-a-one-shot is the disease,
+                 and one-shot-ness of the target is statically undecidable.
+                 `--strict` elevates these to findings.
+    warn       = True iff class (c): no smells, short wrapper, no recognized
+                 blocking construct either.
+    """
+    lines = text.splitlines()
+    findings: list[tuple[int, str]] = []
+    exec_warns: list[tuple[int, str]] = []
+    for line_no, line in enumerate(lines, start=1):
+        m = _EXEC_LINE_RE.match(line)
+        if m and _is_process_exec(m.group(2)):
+            exec_warns.append((line_no, _SMELL_EXEC))
+        if _NOHUP_RE.search(line) and _BG_TRAILING_RE.search(line.rstrip()):
+            findings.append((line_no, _SMELL_NOHUP))
+    warn = (
+        not findings
+        and not exec_warns
+        and len(lines) < _WARN_LINE_LIMIT
+        and not _has_blocking_marker(text)
+    )
+    return findings, exec_warns, warn
+
+
+# ---------------------------------------------------------------- main
+
+
+def _rel(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def run(
+    root_paths: list[Path], repo_root: Path, verbose: bool
+) -> dict[str, Any]:
+    errors: list[str] = []
+    findings: list[str] = []
+    warns: list[str] = []
+    unresolved: list[str] = []
+
+    plist_paths = collect_plists(root_paths, errors)
+    basename_index = build_basename_index(root_paths, errors)
+
+    for plist_path in plist_paths:
+        plist_rel = _rel(plist_path, repo_root)
+        try:
+            payload = plistlib.loads(plist_path.read_bytes())
+        except Exception as exc:  # noqa: BLE001 — fail-visible, never crash
+            errors.append(f"plist unreadable/unparseable ({type(exc).__name__}): {plist_rel}")
+            continue
+        if not isinstance(payload, dict):
+            errors.append(f"plist root is not a dict: {plist_rel}")
+            continue
+        if not is_keepalive_managed(payload.get("KeepAlive")):
+            continue
+
+        argv = extract_argv(payload)
+        wrapper, reason = resolve_wrapper(argv, repo_root, basename_index)
+        if wrapper is None:
+            if verbose:
+                unresolved.append(f"{plist_rel}: KeepAlive=true, payload UNRESOLVED ({reason}): {argv!r}")
+            continue
+
+        try:
+            text = wrapper.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            errors.append(f"wrapper unreadable ({type(exc).__name__}): {_rel(wrapper, repo_root)}")
+            continue
+
+        wrapper_rel = _rel(wrapper, repo_root)
+        smells, exec_warns, warn = classify_wrapper(text)
+        for line_no, smell in smells:
+            findings.append(f"{plist_rel}: KeepAlive=true but {wrapper_rel}:{line_no} {smell}")
+        for line_no, smell in exec_warns:
+            warns.append(
+                f"{plist_rel}: KeepAlive=true and {wrapper_rel}:{line_no} {smell} "
+                f"(WARN: legitimate iff the exec target runs forever — verify, or run --strict)"
+            )
+        if warn:
+            warns.append(
+                f"{plist_rel}: KeepAlive=true but {wrapper_rel} has no exec/nohup smell "
+                f"and no blocking construct detected either — cannot confirm it stays "
+                f"alive under KeepAlive (WARN, W60)"
+            )
+
+    exit_code = (1 if findings else 0) | (4 if errors else 0)
+    return {
+        "schema": 1,
+        "findings": findings,
+        "warns": warns,
+        "unresolved": unresolved,
+        "errors": errors,
+        "exit": exit_code,
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root", action="append", default=None,
+        help="repeatable; default: " + ", ".join(DEFAULT_ROOTS),
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument("--verbose", action="store_true", help="also print UNRESOLVED payloads")
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="elevate WARN-class smells (exec-into-payload, no-blocking-construct) to findings",
+    )
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT, help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    roots = args.root if args.root else list(DEFAULT_ROOTS)
+    root_paths = [
+        (Path(r) if Path(r).is_absolute() else repo_root / r) for r in roots
+    ]
+
+    result = run(root_paths, repo_root, args.verbose)
+    if args.strict and result["warns"]:
+        result["findings"] = result["findings"] + [f"[strict] {w}" for w in result["warns"]]
+        result["warns"] = []
+        result["exit"] = result["exit"] | 1
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return result["exit"]
+
+    print(f"[keepalive-lint] scanned roots: {', '.join(str(_rel(r, repo_root)) for r in root_paths)}")
+    print(f"[findings] {len(result['findings'])}")
+    for f in result["findings"]:
+        print(f"  - {f}")
+    print(f"[warns] {len(result['warns'])}")
+    for w in result["warns"]:
+        print(f"  - {w}")
+    if args.verbose:
+        print(f"[unresolved] {len(result['unresolved'])}")
+        for u in result["unresolved"]:
+            print(f"  - {u}")
+    if result["errors"]:
+        print(f"[errors] {len(result['errors'])} operational error(s) — scan is PARTIAL, not clean:")
+        for e in result["errors"]:
+            print(f"  - {e}")
+    if not result["findings"] and not result["errors"]:
+        print("  clean — no KeepAlive=true wrapper shows a one-shot smell")
+    if result["exit"]:
+        print(
+            f"KEEPALIVE LINT FAIL (exit {result['exit']}: 1=one-shot-smell 4=scan-error) — "
+            f"superscar #7: replace the exec/nohup one-shot with a real blocking loop "
+            f"(while true; do ...; sleep N; done), or switch to StartInterval + no KeepAlive"
+        )
+    return result["exit"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_lint_plist_keepalive.py
+++ b/scripts/tests/test_lint_plist_keepalive.py
@@ -1,0 +1,404 @@
+"""Tests for scripts/lint_plist_keepalive.py (superscar #7 KeepAlive lint).
+
+Every FAIL-class detector gets a GUILT case (the historical disease IS
+caught) and an INNOCENCE case (the adjacent legitimate state is NOT
+flagged) — same discipline lint_home_fork.py's tests apply to superscar #1.
+No live ~/Library dependence — everything runs against tmp_path fixtures.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import plistlib
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "lint_plist_keepalive.py"
+_spec = importlib.util.spec_from_file_location("lint_plist_keepalive", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+lpk = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lpk)
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "infra" / "launchagents").mkdir(parents=True)
+    (repo / "scripts" / "launchd").mkdir(parents=True)
+    (repo / "apps").mkdir(parents=True)
+    return repo
+
+
+def write_plist(path: Path, keepalive, program_args: list[str], start_interval=None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict = {"Label": path.stem, "ProgramArguments": program_args}
+    if keepalive is not None:
+        payload["KeepAlive"] = keepalive
+    if start_interval is not None:
+        payload["StartInterval"] = start_interval
+    path.write_bytes(plistlib.dumps(payload))
+
+
+def default_roots(repo: Path) -> list[Path]:
+    return [repo / r for r in lpk.DEFAULT_ROOTS]
+
+
+# ---------------------------------------------------------------- KeepAlive truthiness
+
+
+def test_is_keepalive_managed() -> None:
+    assert lpk.is_keepalive_managed(True) is True
+    assert lpk.is_keepalive_managed({"SuccessfulExit": False, "Crashed": True}) is True
+    assert lpk.is_keepalive_managed(False) is False
+    assert lpk.is_keepalive_managed(None) is False
+    assert lpk.is_keepalive_managed({}) is False
+
+
+# ---------------------------------------------------------------- classify_wrapper
+
+
+def test_classify_exec_is_warn_class() -> None:
+    # DEMOTED post day-1 calibration (#3 discipline): exec-into-server is the
+    # legitimate daemon idiom; exec smells are WARN, elevated only by --strict.
+    text = "#!/bin/bash\nset -euo pipefail\nexec python3 x.py\n"
+    findings, exec_warns, warn = lpk.classify_wrapper(text)
+    assert findings == []
+    assert len(exec_warns) == 1
+    line_no, smell = exec_warns[0]
+    assert line_no == 3
+    assert "exec" in smell
+    assert warn is False
+
+
+def test_classify_guilt_nohup_background() -> None:
+    text = "#!/bin/bash\nnohup node server.js &\necho started\n"
+    findings, exec_warns, warn = lpk.classify_wrapper(text)
+    assert len(findings) == 1
+    line_no, smell = findings[0]
+    assert line_no == 2
+    assert "nohup" in smell
+    assert warn is False
+
+
+def test_classify_innocence_blocking_loop() -> None:
+    text = (
+        "#!/bin/bash\n"
+        "while true; do\n"
+        "  ./do_thing.sh\n"
+        "  sleep 60\n"
+        "done\n"
+    )
+    findings, exec_warns, warn = lpk.classify_wrapper(text)
+    assert findings == []
+    assert warn is False
+
+
+def test_classify_innocence_exec_fd_redirect() -> None:
+    """The superscar #3 carve-out: `exec 9>lockfile` opens a file
+    descriptor, it does not replace the process — a real line from this
+    repo's own intake-worker-run.sh (a genuinely long-running KeepAlive
+    worker) must NOT be flagged as a one-shot smell."""
+    text = (
+        "#!/bin/bash\n"
+        'exec 9>"${LOCKFILE}"\n'
+        "while true; do\n"
+        "  do_work\n"
+        "  sleep 5\n"
+        "done\n"
+    )
+    findings, exec_warns, warn = lpk.classify_wrapper(text)
+    assert findings == []
+    assert warn is False
+
+
+def test_classify_warn_short_wrapper_no_blocking_marker() -> None:
+    text = "#!/bin/bash\necho hello\n"
+    findings, exec_warns, warn = lpk.classify_wrapper(text)
+    assert findings == []
+    assert warn is True
+
+
+def test_classify_innocence_long_wrapper_no_findings_no_warn() -> None:
+    # 200+ lines, no exec/nohup, no recognized blocking marker: absence of
+    # evidence in a large orchestrator is NOT flagged as WARN (spec: warn
+    # only applies when < 200 lines).
+    body = "\n".join(f"echo line-{i}" for i in range(250))
+    text = f"#!/bin/bash\n{body}\n"
+    findings, exec_warns, warn = lpk.classify_wrapper(text)
+    assert findings == []
+    assert warn is False
+
+
+def test_classify_innocence_nohup_without_background() -> None:
+    text = "#!/bin/bash\nnohup ./foo.sh && echo done\n"
+    findings, exec_warns, warn = lpk.classify_wrapper(text)
+    assert findings == []
+
+
+# ---------------------------------------------------------------- resolve_wrapper
+
+
+def test_resolve_wrapper_repo_relative_direct(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    (repo / "scripts" / "run.sh").write_text("exec foo\n")
+    argv = ["/bin/bash", "scripts/run.sh"]
+    index = lpk.build_basename_index(default_roots(repo), [])
+    wrapper, reason = lpk.resolve_wrapper(argv, repo, index)
+    assert reason is None
+    assert wrapper == repo / "scripts" / "run.sh"
+
+
+def test_resolve_wrapper_basename_bridge_lookup(tmp_path: Path) -> None:
+    """HOME-fork bridge shape (superscar #1 W68/W72): the plist references
+    an absolute ~nuzantara path that doesn't exist here, but a same-named
+    file IS tracked somewhere under the scanned roots."""
+    repo = make_repo(tmp_path)
+    bridge = repo / "infra" / "openclaw" / "wr2"
+    bridge.mkdir(parents=True)
+    (bridge / "wr2-script-wrapper.sh").write_text("exec run-it\n")
+    argv = ["/Users/nuzantara/.openclaw/bin/wr2/wr2-script-wrapper.sh", "scripts/wr2_supervisor.py"]
+    index = lpk.build_basename_index(default_roots(repo), [])
+    wrapper, reason = lpk.resolve_wrapper(argv, repo, index)
+    assert reason is None
+    assert wrapper == bridge / "wr2-script-wrapper.sh"
+
+
+def test_resolve_wrapper_inline_shell_flag_unresolved(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    argv = ["/bin/bash", "-lc", "set -a; source ~/.env; set +a; exec ~/bin/python -m thing"]
+    index = lpk.build_basename_index(default_roots(repo), [])
+    wrapper, reason = lpk.resolve_wrapper(argv, repo, index)
+    assert wrapper is None
+    assert reason == "inline-shell(-c/-lc)"
+
+
+def test_resolve_wrapper_direct_binary_unresolved(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    argv = ["/opt/homebrew/bin/fly", "proxy", "15432:5432"]
+    index = lpk.build_basename_index(default_roots(repo), [])
+    wrapper, reason = lpk.resolve_wrapper(argv, repo, index)
+    assert wrapper is None
+    assert reason == "not-resolvable-in-repo"
+
+
+# ---------------------------------------------------------------- end-to-end run()
+
+
+def test_run_guilt_exec_one_shot(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    wrapper = repo / "apps" / "worker" / "run.sh"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\nexec python3 -m worker\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.worker.plist",
+        keepalive=True,
+        program_args=["/bin/bash", str(wrapper)],
+    )
+    result = lpk.run(default_roots(repo), repo, verbose=False)
+    # exec smell is WARN-class by default (exit 0)…
+    assert result["exit"] == 0
+    assert result["findings"] == []
+    assert len(result["warns"]) == 1
+    assert "com.test.worker.plist" in result["warns"][0]
+    assert "run.sh:2" in result["warns"][0]
+    assert result["errors"] == []
+    # …and --strict elevates it to a finding with exit 1.
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = lpk.main([
+            "--repo-root", str(repo), "--strict",
+            "--root", "infra/launchagents", "--root", "scripts/launchd",
+            "--root", "infra", "--root", "apps",
+        ])
+    assert rc & 1 == 1
+    assert "[strict]" in buf.getvalue()
+
+
+def test_run_guilt_nohup(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    wrapper = repo / "apps" / "worker" / "run.sh"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\nnohup node server.js &\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.nohup.plist",
+        keepalive=True,
+        program_args=["/bin/zsh", str(wrapper)],
+    )
+    result = lpk.run(default_roots(repo), repo, verbose=False)
+    assert result["exit"] == 1
+    assert len(result["findings"]) == 1
+    assert "nohup" in result["findings"][0]
+
+
+def test_run_innocence_blocking_loop_wrapper(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    wrapper = repo / "apps" / "worker" / "run.sh"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\nwhile true; do\n  ./do.sh\n  sleep 30\ndone\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.clean.plist",
+        keepalive=True,
+        program_args=["/bin/bash", str(wrapper)],
+    )
+    result = lpk.run(default_roots(repo), repo, verbose=False)
+    assert result["exit"] == 0
+    assert result["findings"] == []
+    assert result["warns"] == []
+
+
+def test_run_innocence_keepalive_absent_exec_wrapper(tmp_path: Path) -> None:
+    """A one-shot wrapper is only a problem UNDER KeepAlive — no KeepAlive
+    key at all means launchd runs it once (StartInterval-style cron) and a
+    plain `exec` inside is completely normal."""
+    repo = make_repo(tmp_path)
+    wrapper = repo / "apps" / "worker" / "run.sh"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\nexec python3 -m worker\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.nokeepalive.plist",
+        keepalive=None,
+        program_args=["/bin/bash", str(wrapper)],
+    )
+    result = lpk.run(default_roots(repo), repo, verbose=False)
+    assert result == {
+        "schema": 1, "findings": [], "warns": [], "unresolved": [], "errors": [], "exit": 0,
+    }
+
+
+def test_run_innocence_start_interval_cron_no_keepalive(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    wrapper = repo / "apps" / "worker" / "run.sh"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\nexec python3 -m worker\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.cron.plist",
+        keepalive=False,
+        program_args=["/bin/bash", str(wrapper)],
+        start_interval=900,
+    )
+    result = lpk.run(default_roots(repo), repo, verbose=False)
+    assert result["exit"] == 0
+    assert result["findings"] == []
+
+
+def test_run_warn_c_short_wrapper(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    wrapper = repo / "apps" / "worker" / "run.sh"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\necho hello\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.warn.plist",
+        keepalive=True,
+        program_args=["/bin/bash", str(wrapper)],
+    )
+    result = lpk.run(default_roots(repo), repo, verbose=False)
+    assert result["exit"] == 0  # WARN never fails the build
+    assert result["findings"] == []
+    assert len(result["warns"]) == 1
+    assert "com.test.warn.plist" in result["warns"][0]
+
+
+def test_run_unresolved_only_when_verbose(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.proxy.plist",
+        keepalive=True,
+        program_args=["/opt/homebrew/bin/fly", "proxy", "15432:5432"],
+    )
+    quiet = lpk.run(default_roots(repo), repo, verbose=False)
+    assert quiet["unresolved"] == []
+    assert quiet["exit"] == 0
+    verbose = lpk.run(default_roots(repo), repo, verbose=True)
+    assert len(verbose["unresolved"]) == 1
+    assert verbose["exit"] == 0  # unresolved is informational, never a failure
+
+
+def test_run_unparseable_plist_is_error_not_finding(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    (repo / "infra" / "launchagents" / "broken.plist").write_bytes(b"not a plist at all")
+    result = lpk.run(default_roots(repo), repo, verbose=False)
+    assert result["findings"] == []
+    assert len(result["errors"]) == 1
+    assert "broken.plist" in result["errors"][0]
+    assert result["exit"] == 4
+
+
+def test_run_bitmask_findings_plus_errors(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    wrapper = repo / "apps" / "worker" / "run.sh"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\nnohup python3 -m worker &\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.worker.plist",
+        keepalive=True,
+        program_args=["/bin/bash", str(wrapper)],
+    )
+    (repo / "infra" / "launchagents" / "broken.plist").write_bytes(b"garbage")
+    result = lpk.run(default_roots(repo), repo, verbose=False)
+    assert result["exit"] == 5  # 1 (finding) | 4 (error)
+
+
+# ---------------------------------------------------------------- main() / --json
+
+
+def _write_config_free_env(tmp_path: Path) -> Path:
+    return make_repo(tmp_path)
+
+
+def test_main_json_shape_clean(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    repo = make_repo(tmp_path)
+    rc = lpk.main(["--repo-root", str(repo), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "schema": 1, "findings": [], "warns": [], "unresolved": [], "errors": [], "exit": 0,
+    }
+
+
+def test_main_json_shape_with_finding(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    repo = make_repo(tmp_path)
+    wrapper = repo / "apps" / "worker" / "run.sh"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/bin/bash\nnohup python3 -m worker &\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.worker.plist",
+        keepalive=True,
+        program_args=["/bin/bash", str(wrapper)],
+    )
+    rc = lpk.main(["--repo-root", str(repo), "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == 1
+    assert len(payload["findings"]) == 1
+    assert payload["exit"] == 1
+    for key in ("schema", "findings", "warns", "unresolved", "errors", "exit"):
+        assert key in payload
+
+
+def test_main_custom_root_widens_coverage(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """--root lets a caller widen scope to bare scripts/ (documented scope
+    limitation of the defaults)."""
+    repo = make_repo(tmp_path)
+    (repo / "scripts").mkdir(exist_ok=True)
+    wrapper = repo / "scripts" / "job_run.sh"
+    wrapper.write_text("#!/bin/bash\nnohup python3 -m job &\n")
+    write_plist(
+        repo / "infra" / "launchagents" / "com.test.job.plist",
+        keepalive=True,
+        program_args=["/bin/bash", str(wrapper)],
+    )
+    # Default roots: NOT resolvable (scripts/ bare is out of scope).
+    rc_default = lpk.main(["--repo-root", str(repo), "--json"])
+    assert rc_default == 0
+    default_payload = json.loads(capsys.readouterr().out)
+    assert default_payload["findings"] == []
+
+    # Widened roots: resolvable, finding surfaces.
+    rc_widened = lpk.main(["--repo-root", str(repo), "--root", "infra", "--root", "scripts", "--json"])
+    assert rc_widened == 1
+    widened_payload = json.loads(capsys.readouterr().out)
+    assert len(widened_payload["findings"]) == 1


### PR DESCRIPTION
scripts/lint_plist_keepalive.py: static repo-side lint for the W67/W60
restart-storm family — for every TRACKED plist with KeepAlive truthy it
resolves the wrapper payload and classifies one-shot smells:
  FAIL  `nohup ... &` (children SIGTERM'd every KeepAlive cycle — the
        unambiguous W67 disease), exit 1;
  WARN  `exec ...` — DEMOTED after day-1 calibration on the real repo
        (superscar #3 discipline applied to the linter itself: sampled exec
        targets — livekit server, wa-mirror node bridge — are long-running
        servers, the CORRECT daemon idiom; one-shot-ness of the target is
        statically undecidable). `--strict` elevates warns to findings;
  WARN  keepalive-managed wrapper with no blocking construct at all;
  exit 4 on unparseable plists (fail-visible, W84).

Day-1 real run: 0 findings, 8 exec-warns (triage list in the immune-forge
report), 0 errors. 24 unit tests (guilt/innocence incl. fd-redirect exec
carve-out, nohup-without-& innocence, bitmask, --strict elevation).

Also fixes infra/launchagents/com.nuzantara.branch-cleanup.weekly.plist:
its XML comment contained `--apply` — `--` inside an XML comment is
illegal XML; Apple's plutil tolerates it, Python expat (and this linter)
rejects it. Reworded. Found by the linter's own first run.

immune-enforcement.yml: runs the new test file, path-triggers extended.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
