### PR TITLE
fix(seo): FAQ markup parity — one builder feeds JSON-LD and visible Common Questions

### DIFF
--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -32,6 +32,7 @@ import Link from "next/link";
 import { MarkdownClient } from "@/components/kbli/MarkdownClient";
 import { KBLIPageTracker } from "@/components/kbli/KBLIPageTracker";
 import { KBLIConsultationCTA } from "@/components/kbli/KBLIConsultationCTA";
+import { KBLICommonQuestions } from "@/components/kbli/KBLICommonQuestions";
 import { FunnelFrame } from "@balizero/core";
 
 const ZantaraChat = lazy(() =>
@@ -855,99 +856,6 @@ export default async function KBLICodePage({
                 </div>
               )}
 
-              {/* Q&A Section — visible text for AI extractability */}
-              <section className="mt-8">
-                <div className="flex items-center gap-4 py-2 mb-6">
-                  <div
-                    className="h-px flex-1"
-                    style={{ background: "var(--kbli-border)" }}
-                  />
-                  <span className="text-xs font-medium uppercase tracking-[0.15em] text-[var(--foreground-muted)]">
-                    Common Questions
-                  </span>
-                  <div
-                    className="h-px flex-1"
-                    style={{ background: "var(--kbli-border)" }}
-                  />
-                </div>
-                <div className="space-y-4">
-                  <details
-                    className="rounded-xl border border-[var(--border)] overflow-hidden"
-                    open
-                  >
-                    <summary
-                      className="cursor-pointer px-5 py-3.5 text-sm font-semibold text-[var(--foreground)] transition-colors hover:text-[var(--kbli-accent)]"
-                      style={{ background: "var(--kbli-bg-elevated)" }}
-                    >
-                      Can foreigners operate a {kbli.titleEn.toLowerCase()}{" "}
-                      business in Indonesia?
-                    </summary>
-                    <div
-                      className="px-5 py-4 text-sm leading-relaxed text-[var(--foreground-secondary)]"
-                      style={{ background: "var(--kbli-bg-surface)" }}
-                    >
-                      {kbli.pma.status === "open"
-                        ? `Yes. KBLI ${kbli.code} (${kbli.titleId}) is classified as TERBUKA — open to 100% foreign ownership through a PT PMA company. You do not need a local Indonesian partner.`
-                        : kbli.pma.status === "restricted"
-                          ? kbli.pma.capSpecial
-                            ? `Conditionally. KBLI ${kbli.code} (${kbli.titleId}) is TERBATAS with special distribution conditions (open to foreign ownership but subject to a special distribution-network/location requirement — verify the exact terms in OSS).${kbli.pma.condition ? ` Condition: ${kbli.pma.condition}` : ""}`
-                            : `Partially. KBLI ${kbli.code} (${kbli.titleId}) is classified as TERBATAS — foreign ownership is ${kbli.pma.capVerified ? "capped" : "indicatively capped (unverified)"} at ${kbli.pma.maxForeign}%. You will need an Indonesian partner for the remaining shares.${kbli.pma.condition ? ` Condition: ${kbli.pma.condition}` : ""}`
-                          : `No. KBLI ${kbli.code} (${kbli.titleId}) is classified as TERTUTUP — closed to foreign investment. This business activity is reserved for Indonesian nationals.`}
-                    </div>
-                  </details>
-                  <details className="rounded-xl border border-[var(--border)] overflow-hidden">
-                    <summary
-                      className="cursor-pointer px-5 py-3.5 text-sm font-semibold text-[var(--foreground)] transition-colors hover:text-[var(--kbli-accent)]"
-                      style={{ background: "var(--kbli-bg-elevated)" }}
-                    >
-                      What license do I need for KBLI {kbli.code}?
-                    </summary>
-                    <div
-                      className="px-5 py-4 text-sm leading-relaxed text-[var(--foreground-secondary)]"
-                      style={{ background: "var(--kbli-bg-surface)" }}
-                    >
-                      {kbli.licensing.length > 0
-                        ? `KBLI ${kbli.code} has a ${kbli.licensing[0].riskCategory} risk classification. You need: ${kbli.licensing[0].licenseType || "NIB (Nomor Induk Berusaha)"}. ${kbli.licensing[0].timeframe ? `Processing time: ${kbli.licensing[0].timeframe}.` : "Processing is typically handled through the OSS (Online Single Submission) system."}`
-                        : `KBLI ${kbli.code} requires a NIB (Nomor Induk Berusaha) obtained through the OSS (Online Single Submission) system. Contact a licensed consultant for specific requirements.`}
-                    </div>
-                  </details>
-                  {kbli.transition.previousCodes.length > 0 && (
-                    <details className="rounded-xl border border-[var(--border)] overflow-hidden">
-                      <summary
-                        className="cursor-pointer px-5 py-3.5 text-sm font-semibold text-[var(--foreground)] transition-colors hover:text-[var(--kbli-accent)]"
-                        style={{ background: "var(--kbli-bg-elevated)" }}
-                      >
-                        How did KBLI {kbli.code} change from 2020 to 2025?
-                      </summary>
-                      <div
-                        className="px-5 py-4 text-sm leading-relaxed text-[var(--foreground-secondary)]"
-                        style={{ background: "var(--kbli-bg-surface)" }}
-                      >
-                        KBLI {kbli.code} was mapped from previous code
-                        {kbli.transition.previousCodes.length > 1
-                          ? "s"
-                          : ""}: {kbli.transition.previousCodes.join(", ")}{" "}
-                        (KBLI 2020).
-                        {kbli.transition.mappingNote
-                          ? ` ${kbli.transition.mappingNote}`
-                          : ""}
-                        {kbli.transition.mappingStatus === "MATCH_LANGSUNG"
-                          ? " This is a direct match — the code number and scope remained the same."
-                          : kbli.transition.mappingStatus ===
-                              "CODICE_RINUMERATO"
-                            ? " The code was renumbered but the business activity scope is essentially unchanged."
-                            : kbli.transition.mappingStatus ===
-                                "MATCH_CON_AGGREGAZIONE"
-                              ? " Multiple 2020 codes were merged into this single 2025 code."
-                              : ""}{" "}
-                        All businesses must migrate to KBLI 2025 by June 18,
-                        2026 (BPS Regulation 7/2025).
-                      </div>
-                    </details>
-                  )}
-                </div>
-              </section>
-
               {/* Article card for non-Gold pages */}
               {article && (
                 <a
@@ -996,6 +904,10 @@ export default async function KBLICodePage({
               )}
             </div>
           )}
+
+          {/* COMMON QUESTIONS — visible counterpart of the FAQPage JSON-LD,
+              rendered on gold AND non-gold layouts (markup honesty) */}
+          <KBLICommonQuestions code={kbli} />
 
           {/* RELATED CODES */}
           {related.length > 0 && (

--- a/apps/mouth/src/components/kbli/KBLICommonQuestions.tsx
+++ b/apps/mouth/src/components/kbli/KBLICommonQuestions.tsx
@@ -1,0 +1,51 @@
+import { buildKbliFaq } from "@/lib/kbli-faq";
+import type { KBLICode } from "@/lib/kbli-types";
+
+/**
+ * Visible counterpart of KBLIFaqJsonLd — both render from buildKbliFaq(),
+ * so the FAQPage markup always has matching on-page content (Google
+ * requires FAQ markup content to be visible on the page).
+ */
+export function KBLICommonQuestions({ code }: { code: KBLICode }) {
+  const faq = buildKbliFaq(code);
+
+  return (
+    <section className="mt-8">
+      <div className="flex items-center gap-4 py-2 mb-6">
+        <div
+          className="h-px flex-1"
+          style={{ background: "var(--kbli-border)" }}
+        />
+        <span className="text-xs font-medium uppercase tracking-[0.15em] text-[var(--foreground-muted)]">
+          Common Questions
+        </span>
+        <div
+          className="h-px flex-1"
+          style={{ background: "var(--kbli-border)" }}
+        />
+      </div>
+      <div className="space-y-4">
+        {faq.map((entry, i) => (
+          <details
+            key={entry.question}
+            className="rounded-xl border border-[var(--border)] overflow-hidden"
+            open={i === 0}
+          >
+            <summary
+              className="cursor-pointer px-5 py-3.5 text-sm font-semibold text-[var(--foreground)] transition-colors hover:text-[var(--kbli-accent)]"
+              style={{ background: "var(--kbli-bg-elevated)" }}
+            >
+              {entry.question}
+            </summary>
+            <div
+              className="px-5 py-4 text-sm leading-relaxed text-[var(--foreground-secondary)]"
+              style={{ background: "var(--kbli-bg-surface)" }}
+            >
+              {entry.answer}
+            </div>
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/mouth/src/components/kbli/KBLIStructuredData.tsx
+++ b/apps/mouth/src/components/kbli/KBLIStructuredData.tsx
@@ -1,4 +1,5 @@
 import type { KBLICode } from "@/lib/kbli-types";
+import { buildKbliFaq } from "@/lib/kbli-faq";
 
 export function KBLICodeJsonLd({
   code,
@@ -105,50 +106,13 @@ export function KBLICodeJsonLd({
 }
 
 export function KBLIFaqJsonLd({ code }: { code: KBLICode }) {
-  // National openness != Bali registrability — a Bali-blocked code must NOT answer
-  // Google's "can foreigners operate this" with an unqualified "Yes, 100%, no local
-  // partner". Qualify the open answer with the Bali block.
-  const baliBlocked = !!code.baliL4?.blocked;
-  const pmaAnswer =
-    code.pma.status === "open"
-      ? baliBlocked
-        ? `Nationally yes — but NOT in Bali. KBLI ${code.code} (${code.titleId}) is TERBUKA (100% foreign ownership) at the national level, but a PT PMA currently cannot register it in Bali (reserved for UMKM / 2026 moratorium). ${code.baliL4?.reason ?? "See the Bali status above."} Outside Bali it is open to a PT PMA with no local partner required.`
-        : `Yes. KBLI ${code.code} (${code.titleId}) is TERBUKA — open to 100% foreign ownership via PT PMA. No local Indonesian partner required.`
-      : code.pma.status === "restricted"
-        ? `Partially. KBLI ${code.code} is TERBATAS — foreign ownership capped at ${code.pma.maxForeign}%.${code.pma.condition ? ` Condition: ${code.pma.condition}` : ""} An Indonesian partner holds the remaining shares.`
-        : `No. KBLI ${code.code} (${code.titleId}) is TERTUTUP — closed to foreign investment. Reserved for Indonesian nationals only.`;
-
-  const licenseAnswer =
-    code.licensing.length > 0
-      ? `KBLI ${code.code} has a ${code.licensing[0].riskCategory} risk classification. Required license: ${code.licensing[0].licenseType ?? "NIB (Nomor Induk Berusaha)"}. ${code.licensing[0].timeframe ? `Processing time: ${code.licensing[0].timeframe}.` : "Processed through OSS (Online Single Submission)."}`
-      : `KBLI ${code.code} requires a NIB (Nomor Induk Berusaha) via OSS (Online Single Submission). Contact a licensed consultant for specific requirements.`;
-
-  const questions: { question: string; answer: string }[] = [
-    {
-      question: `Can foreigners operate a ${code.titleEn.toLowerCase()} business in Indonesia?`,
-      answer: pmaAnswer,
-    },
-    {
-      question: `What license is required for KBLI ${code.code}?`,
-      answer: licenseAnswer,
-    },
-    {
-      question: `What is KBLI ${code.code}?`,
-      answer: `KBLI ${code.code} is the Indonesian business classification code for "${code.titleId}" (${code.titleEn}). It falls under Section ${code.section ?? "N/A"} of KBLI 2025, the Indonesian Standard Industrial Classification updated by BPS (Regulation 7/2025), effective June 18, 2026.`,
-    },
-  ];
-
-  if (code.transition.previousCodes.length > 0) {
-    questions.push({
-      question: `How did KBLI ${code.code} change from KBLI 2020 to 2025?`,
-      answer: `KBLI ${code.code} was mapped from previous code${code.transition.previousCodes.length > 1 ? "s" : ""} ${code.transition.previousCodes.join(", ")} (KBLI 2020).${code.transition.mappingNote ? ` ${code.transition.mappingNote}` : ""} All businesses must migrate to KBLI 2025 by June 18, 2026 per BPS Regulation 7/2025.`,
-    });
-  }
-
+  // Questions and answers come from buildKbliFaq — the SAME source that
+  // renders the visible Common Questions section, so the FAQPage markup
+  // always has matching on-page content (Google requires it).
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    mainEntity: questions.map((q) => ({
+    mainEntity: buildKbliFaq(code).map((q) => ({
       "@type": "Question",
       name: q.question,
       acceptedAnswer: {

--- a/apps/mouth/src/lib/kbli-faq.test.ts
+++ b/apps/mouth/src/lib/kbli-faq.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildKbliFaq } from "./kbli-faq";
+import { getCode } from "./kbli-data";
+import type { KBLICode } from "./kbli-types";
+
+describe("buildKbliFaq", () => {
+  it("qualifies the open answer on a Bali-blocked code — never an unqualified yes", () => {
+    const blocked = getCode("56101");
+    expect(blocked).toBeDefined();
+    const base = blocked as KBLICode;
+    const synthetic: KBLICode = {
+      ...base,
+      pma: { ...base.pma, status: "open" },
+      baliL4: { ...(base.baliL4 ?? {}), blocked: true, reason: "test reason" },
+    } as KBLICode;
+
+    const pmaAnswer = buildKbliFaq(synthetic)[0].answer;
+    expect(pmaAnswer).toContain("NOT in Bali");
+    expect(pmaAnswer).not.toMatch(/^Yes\./);
+  });
+
+  it("handles capSpecial restricted codes without stating a numeric cap as fact", () => {
+    const base = getCode("56101") as KBLICode;
+    const synthetic: KBLICode = {
+      ...base,
+      baliL4: undefined,
+      pma: {
+        ...base.pma,
+        status: "restricted",
+        capSpecial: true,
+        maxForeign: 0,
+      },
+    } as KBLICode;
+
+    const pmaAnswer = buildKbliFaq(synthetic)[0].answer;
+    expect(pmaAnswer).toContain("special distribution conditions");
+    expect(pmaAnswer).not.toContain("capped at 0%");
+  });
+
+  it("returns 3-4 entries and every answer names the code", () => {
+    const code = getCode("56101") as KBLICode;
+    const faq = buildKbliFaq(code);
+    expect(faq.length).toBeGreaterThanOrEqual(3);
+    expect(faq.length).toBeLessThanOrEqual(4);
+    for (const entry of faq) {
+      expect(entry.answer).toContain(code.code);
+    }
+  });
+});

--- a/apps/mouth/src/lib/kbli-faq.ts
+++ b/apps/mouth/src/lib/kbli-faq.ts
@@ -1,0 +1,74 @@
+import type { KBLICode } from "@/lib/kbli-types";
+
+export interface KbliFaqEntry {
+  question: string;
+  answer: string;
+}
+
+/**
+ * Single source of truth for the per-code FAQ.
+ *
+ * Feeds BOTH the FAQPage JSON-LD (KBLIFaqJsonLd) and the visible
+ * "Common Questions" section (KBLICommonQuestions). Google requires
+ * FAQPage markup content to be visible on the page — before this module
+ * the JSON-LD was emitted on every page while the visible Q&A only
+ * existed on non-Gold layouts, and the two texts had drifted apart
+ * (the JSON-LD carried the Bali-block qualification, the visible answer
+ * did not; the visible answer handled capSpecial, the JSON-LD did not).
+ * One builder = the markup is honest by construction.
+ *
+ * Every fact below comes from dataset fields already rendered elsewhere
+ * on the same page (PMA verdict banner, licensing table, transition
+ * note) — no new regulatory claims.
+ */
+export function buildKbliFaq(code: KBLICode): KbliFaqEntry[] {
+  const baliBlocked = !!code.baliL4?.blocked;
+
+  const pmaAnswer =
+    code.pma.status === "open"
+      ? baliBlocked
+        ? `Nationally yes — but NOT in Bali. KBLI ${code.code} (${code.titleId}) is TERBUKA (100% foreign ownership) at the national level, but a PT PMA currently cannot register it in Bali (reserved for UMKM / 2026 moratorium). ${code.baliL4?.reason ?? "See the Bali status above."} Outside Bali it is open to a PT PMA with no local partner required.`
+        : `Yes. KBLI ${code.code} (${code.titleId}) is TERBUKA — open to 100% foreign ownership via PT PMA. No local Indonesian partner required.`
+      : code.pma.status === "restricted"
+        ? code.pma.capSpecial
+          ? `Conditionally. KBLI ${code.code} (${code.titleId}) is TERBATAS with special distribution conditions (open to foreign ownership but subject to a special distribution-network/location requirement — verify the exact terms in OSS).${code.pma.condition ? ` Condition: ${code.pma.condition}` : ""}`
+          : `Partially. KBLI ${code.code} (${code.titleId}) is TERBATAS — foreign ownership is ${code.pma.capVerified ? "capped" : "indicatively capped (unverified)"} at ${code.pma.maxForeign}%.${code.pma.condition ? ` Condition: ${code.pma.condition}` : ""} An Indonesian partner holds the remaining shares.`
+        : `No. KBLI ${code.code} (${code.titleId}) is TERTUTUP — closed to foreign investment. Reserved for Indonesian nationals only.`;
+
+  const licenseAnswer =
+    code.licensing.length > 0
+      ? `KBLI ${code.code} has a ${code.licensing[0].riskCategory} risk classification. Required license: ${code.licensing[0].licenseType ?? "NIB (Nomor Induk Berusaha)"}. ${code.licensing[0].timeframe ? `Processing time: ${code.licensing[0].timeframe}.` : "Processed through OSS (Online Single Submission)."}`
+      : `KBLI ${code.code} requires a NIB (Nomor Induk Berusaha) via OSS (Online Single Submission). Contact a licensed consultant for specific requirements.`;
+
+  const entries: KbliFaqEntry[] = [
+    {
+      question: `Can foreigners operate a ${code.titleEn.toLowerCase()} business in Indonesia?`,
+      answer: pmaAnswer,
+    },
+    {
+      question: `What license is required for KBLI ${code.code}?`,
+      answer: licenseAnswer,
+    },
+    {
+      question: `What is KBLI ${code.code}?`,
+      answer: `KBLI ${code.code} is the Indonesian business classification code for "${code.titleId}" (${code.titleEn}). It falls under Section ${code.section ?? "N/A"} of KBLI 2025, the Indonesian Standard Industrial Classification updated by BPS (Regulation 7/2025), effective June 18, 2026.`,
+    },
+  ];
+
+  if (code.transition.previousCodes.length > 0) {
+    const mappingStatusNote =
+      code.transition.mappingStatus === "MATCH_LANGSUNG"
+        ? " This is a direct match — the code number and scope remained the same."
+        : code.transition.mappingStatus === "CODICE_RINUMERATO"
+          ? " The code was renumbered but the business activity scope is essentially unchanged."
+          : code.transition.mappingStatus === "MATCH_CON_AGGREGAZIONE"
+            ? " Multiple 2020 codes were merged into this single 2025 code."
+            : "";
+    entries.push({
+      question: `How did KBLI ${code.code} change from KBLI 2020 to 2025?`,
+      answer: `KBLI ${code.code} was mapped from previous code${code.transition.previousCodes.length > 1 ? "s" : ""} ${code.transition.previousCodes.join(", ")} (KBLI 2020).${code.transition.mappingNote ? ` ${code.transition.mappingNote}` : ""}${mappingStatusNote} All businesses must migrate to KBLI 2025 by June 18, 2026 per BPS Regulation 7/2025.`,
+    });
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## Why

FAQPage JSON-LD was emitted on **every** KBLI page while the visible Q&A existed only on non-Gold layouts — 436 gold pages carried FAQ markup with no matching on-page content (Google requires FAQ markup content to be visible). The two texts had also drifted in opposite directions: the JSON-LD had the Bali-block qualification but no capSpecial branch; the visible answer handled capSpecial but greeted Bali-blocked codes with an unqualified "Yes, 100% foreign ownership", contradicting the PMA verdict banner on the same page.

## What

- New `buildKbliFaq()` — single source of truth; answers are the **union** of the two previous texts (Bali-block qualification + capSpecial + capVerified wording + mappingStatus sentences). Every fact comes from dataset fields already rendered on the same page — zero new regulatory claims.
- `KBLIFaqJsonLd` renders from the builder.
- New `KBLICommonQuestions` renders the same entries visibly on gold AND non-gold layouts (replaces the inline non-gold section).
- Also adds visible unique text to 436 gold pages (content differentiation, per the programmatic-SEO 30-40% rule).

## Verification

- Tests 3/3: Bali-blocked never yields an unqualified yes; capSpecial never states a numeric cap as fact; every answer names the code.
- `npm run typecheck` ✓ · full `next build` ✓ (1,560 HTML in .next; "Common Questions" present in a gold page artifact).

Part of the SEO/KBLI offensive (#1963, #1965, #1966, #1974; report in `research/seo/2026-07-05-kbli-seo-offensive.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>