### PR TITLE
fix(hooks): W85 — stash over-match cured with negative lookahead

### DIFF
--- a/infra/claude-hooks/test_w85_stash_readonly.py
+++ b/infra/claude-hooks/test_w85_stash_readonly.py
@@ -1,29 +1,27 @@
 #!/usr/bin/env python3
-"""W85 pin — BLOCKED_SUBCMD_RE `stash` over-match, documented-broken contract.
+"""W85 — BLOCKED_SUBCMD_RE stash guilt+innocence (over-match FIXED 2026-07-06).
 
-W85 (cicatrix-scars.md, superscar #3): `BLOCKED_SUBCMD_RE` carries a bare
-`stash`, so read-only `git stash list` / `git stash show` are blocked exactly
-like the mutating `stash push` / `stash pop`. Third consecutive over-match of
-the SAME guard in two days (after W83, W84) — the scar itself says the family
-"non si chiude con un fix puntuale". The fix (enumerate mutating stash verbs,
-or allow-list `stash (list|show)`) is tracked as a PENDING-ARMS line; it is
-NOT applied here because patching the repo copy alone would fork it from the
-live ~/.claude/hooks copy (superscar #1, W83 GOTCHA-d: patch BOTH or neither),
-and the live copy governs the very session that would edit it.
+W85 (cicatrix-scars.md, superscar #3): `BLOCKED_SUBCMD_RE` carried a bare
+`stash`, so read-only `git stash list` / `git stash show` were blocked exactly
+like the mutating `stash push` / `stash pop` — the third consecutive over-match
+of the SAME guard in two days (after W83, W84).
 
-W82-TRIPWIRE SEMANTICS (same as infra/scar-gates/test_W82_*): this test is
-GREEN while the documented contract HOLDS — bug present and captured:
-  GUILT  (guard still catches real danger): `git stash push` IS blocked.
-  PINNED OVER-MATCH (the W85 hole, asserted PRESENT): `git stash list` and
-         `git stash show` are ALSO blocked today.
-The moment someone fixes the regex, the pinned assertions FAIL loudly →
-update this pin to a plain innocence test + flip the registry note + close
-the PENDING-ARMS line. A silent fix would otherwise leave the conformance
-registry lying about the guard's contract.
+HISTORY OF THIS FILE: it was born as a W82-style TRIPWIRE that PINNED the
+documented-broken contract (green while the bug was present and captured,
+failing loudly when the fix landed). The fix landed 2026-07-06 with operator
+GO, folded into the repo copy AND the live ~/.claude/hooks copy in the same
+operation (superscar #1, W83 GOTCHA-d: patch BOTH or neither). Per the pin's
+own instructions it is now a plain guilt+innocence test:
+
+  GUILT     (guard catches real danger): bare `git stash` (= stash push),
+            `stash push/pop/apply/drop/clear/create/store/branch` ARE blocked.
+  INNOCENCE (adjacent-legit passes): `git stash list` / `git stash show`
+            (incl. flags/args) are NOT blocked; `stashes` as a word is not
+            a token match.
 
     python3 infra/claude-hooks/test_w85_stash_readonly.py
-Exit 0 = contract holds (guilt caught, over-match still present & documented).
-Exit 1 = contract changed (either the guard went blind, or the W85 fix landed).
+Exit 0 = guard matches on intent (mutating) and spares read-only queries.
+Exit 1 = regression on either side (went blind on guilt, or re-over-matches).
 
 Reference: cicatrix-superscar.md #3 · registry: infra/guard-conformance/registry.json
 """
@@ -48,31 +46,44 @@ def main() -> int:
     regex = _load_regex()
     failures: list[str] = []
 
-    # GUILT — the guard must still catch genuinely mutating stash commands.
-    for cmd in ("git stash", "git stash push", "git stash pop"):
+    # GUILT — every mutating stash form must still be blocked.
+    for cmd in (
+        "git stash",
+        "git stash push",
+        "git stash push -m wip",
+        "git stash pop",
+        "git stash apply",
+        "git stash drop",
+        "git stash clear",
+        "git stash create",
+        "git stash store abc123",
+        "git stash branch fix/x",
+        "git -C /tmp/repo stash pop",
+    ):
         if not regex.search(cmd):
             failures.append(f"GUILT MISS: `{cmd}` no longer blocked — guard went blind")
 
-    # PINNED W85 OVER-MATCH — read-only stash queries are blocked TODAY.
-    # These assertions document the bug; their failure means the fix landed.
-    for cmd in ("git stash list", "git stash show"):
-        if not regex.search(cmd):
-            failures.append(
-                f"W85 CONTRACT CHANGED: `{cmd}` is no longer blocked — the over-match "
-                f"fix landed. Update this pin to a plain innocence test, flip the "
-                f"registry.json note, close the W85 PENDING-ARMS line."
-            )
+    # INNOCENCE — read-only stash queries (the W85 hole, now fixed) must pass.
+    for cmd in (
+        "git stash list",
+        "git stash list --stat",
+        "git stash show",
+        "git stash show -p stash@{0}",
+    ):
+        if regex.search(cmd):
+            failures.append(f"INNOCENT BITTEN: `{cmd}` blocked — W85 over-match regressed")
+
+    # INNOCENCE — token adjacency: 'stashes' is not the stash subcommand.
+    if regex.search("echo git stashes are neat"):
+        failures.append("INNOCENT BITTEN: substring `stashes` matched — word-boundary broken")
 
     if failures:
-        print("W85 PIN FAILED — the documented contract changed:")
+        print("W85 FAILED:")
         for f in failures:
             print(f"  - {f}")
         return 1
 
-    print(
-        "OK (W85 pin) — guard catches mutating stash; read-only stash over-match "
-        "still present and DOCUMENTED (fix tracked in PENDING-ARMS, not silent)."
-    )
+    print("OK (W85) — mutating stash blocked, read-only stash list/show pass.")
     return 0
 
 

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -99,10 +99,13 @@ def _derive_repo_root() -> str:
 REPO_ROOT = _derive_repo_root()
 
 # Blocked git subcommands.
+# W85 fix (2026-07-06): `stash` carries a negative lookahead so read-only
+# `stash list` / `stash show` pass; bare `git stash` (= stash push) and every
+# mutating stash verb still match — the guard matches intent, not bare token.
 BLOCKED_SUBCMD_RE = re.compile(
     r"\bgit\s+(?:-c\s+\S+\s+)*"  # optional -c key=val flags
     r"(?:-C\s+\S+\s+)?"  # optional -C path
-    r"(checkout|switch|stash|reset|merge|rebase|pull)\b"
+    r"(checkout|switch|stash(?!\s+(?:list|show)\b)|reset|merge|rebase|pull)\b"
     r"|\bgit\s+commit\s+(?:[^\s]+\s+)*(?:-[A-Za-z]*a|--all\b)"  # commit -a / -am / -a -m / --all
     r"|\bgit\s+add\s+(?:-A|-a|--all|\.)"  # add -A / add -a / add --all / add .
 )

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -1,32 +1,53 @@
 {
-  "_doc": "Guard Conformance Registry (superscar #3 — over/under-match). Maps EVERY live textual guard to its GUILT proof (the guard fires on the historical bad case) and INNOCENCE proof (the guard does NOT fire on the adjacent legitimate case). Enforced by infra/guard-conformance/check_guard_conformance.py: a censused guard missing from here, a phantom test reference, or a test no CI workflow runs = FAIL. The mandate rule this executes: 'nessuna guardia mergiata senza un test di innocenza E di colpevolezza' (cicatrix-superscar.md #3). To add a guard: write both tests first, then register it here.",
+  "_doc": "Guard Conformance Registry (superscar #3 \u2014 over/under-match). Maps EVERY live textual guard to its GUILT proof (the guard fires on the historical bad case) and INNOCENCE proof (the guard does NOT fire on the adjacent legitimate case). Enforced by infra/guard-conformance/check_guard_conformance.py: a censused guard missing from here, a phantom test reference, or a test no CI workflow runs = FAIL. The mandate rule this executes: 'nessuna guardia mergiata senza un test di innocenza E di colpevolezza' (cicatrix-superscar.md #3). To add a guard: write both tests first, then register it here.",
   "version": 1,
   "surfaces": {
     "bridge_reply_guards": {
       "source": "scripts/openclaw_whatsapp_bridge.py",
-      "census": { "method": "ast-def-prefix", "prefix": "_guard_" },
+      "census": {
+        "method": "ast-def-prefix",
+        "prefix": "_guard_"
+      },
       "test_file": "apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script.py",
       "guards": {
         "_guard_document_status_reply": {
-          "scar": ["F37"],
-          "guilt": ["test_document_status_guard_f37_affirmative_approved_clobbers"],
-          "innocence": ["test_document_status_guard_f37_conditional_approved_passes"]
+          "scar": [
+            "F37"
+          ],
+          "guilt": [
+            "test_document_status_guard_f37_affirmative_approved_clobbers"
+          ],
+          "innocence": [
+            "test_document_status_guard_f37_conditional_approved_passes"
+          ]
         },
         "_guard_legacy_b211_reply": {
-          "scar": ["W72"],
-          "guilt": ["test_b211_guard_still_clobbers_unsafe_current_claim"],
-          "innocence": ["test_b211_guard_allows_correct_definitional_answer"]
+          "scar": [
+            "W72"
+          ],
+          "guilt": [
+            "test_b211_guard_still_clobbers_unsafe_current_claim"
+          ],
+          "innocence": [
+            "test_b211_guard_allows_correct_definitional_answer"
+          ]
         },
         "_guard_hak_milik_reply": {
-          "scar": ["W73-family"],
-          "guilt": ["test_hak_milik_guard_clobbers_short_wrong_claim"],
+          "scar": [
+            "W73-family"
+          ],
+          "guilt": [
+            "test_hak_milik_guard_clobbers_short_wrong_claim"
+          ],
           "innocence": [
             "test_hak_milik_guard_passes_correct_short_answer",
             "test_hak_milik_guard_passes_correct_indonesian_answer"
           ]
         },
         "_guard_lkpm_reply": {
-          "scar": ["W73#2"],
+          "scar": [
+            "W73#2"
+          ],
           "guilt": [
             "test_lkpm_guard_still_clobbers_stale_deadline",
             "test_lkpm_guard_clobbers_wrong_window_while_valid"
@@ -37,8 +58,13 @@
           ]
         },
         "_guard_property_zoning_reply": {
-          "scar": ["W68", "W68b"],
-          "guilt": ["test_property_zoning_guard_still_fires_on_airbnb_operation"],
+          "scar": [
+            "W68",
+            "W68b"
+          ],
+          "guilt": [
+            "test_property_zoning_guard_still_fires_on_airbnb_operation"
+          ],
           "innocence": [
             "test_property_zoning_guard_allows_villa_leasehold_duration",
             "test_property_zoning_guard_allows_villa_lease_duration_reworded",
@@ -47,30 +73,55 @@
           ]
         },
         "_guard_tax_compliance_reply": {
-          "scar": ["W73#3"],
-          "guilt": ["test_tax_guard_still_appends_on_penalty_intent"],
-          "innocence": ["test_tax_guard_does_not_append_on_stable_rate_fact"]
+          "scar": [
+            "W73#3"
+          ],
+          "guilt": [
+            "test_tax_guard_still_appends_on_penalty_intent"
+          ],
+          "innocence": [
+            "test_tax_guard_does_not_append_on_stable_rate_fact"
+          ]
         },
         "_guard_villa_kbli_reply": {
-          "scar": ["W68", "W73#1"],
-          "guilt": ["test_bridge_guard_corrects_bad_villa_55193_reply"],
+          "scar": [
+            "W68",
+            "W73#1"
+          ],
+          "guilt": [
+            "test_bridge_guard_corrects_bad_villa_55193_reply"
+          ],
           "innocence": [
             "test_bridge_guard_keeps_grounded_villa_mapping_reply",
             "test_villa_terms_no_longer_carry_substring_traps"
           ]
         },
         "_guard_kbli_label_reply": {
-          "scar": ["F38"],
-          "guilt": ["test_kbli_label_guard_f38_kbli_context_still_fires"],
-          "innocence": ["test_kbli_label_guard_f38_postcode_does_not_fire"]
+          "scar": [
+            "F38"
+          ],
+          "guilt": [
+            "test_kbli_label_guard_f38_kbli_context_still_fires"
+          ],
+          "innocence": [
+            "test_kbli_label_guard_f38_postcode_does_not_fire"
+          ]
         },
         "_guard_cafe_pma_reply": {
-          "scar": ["W73#4"],
-          "guilt": ["test_cafe_guard_still_fires_on_real_cafe_question"],
-          "innocence": ["test_cafe_guard_does_not_clobber_definitional_pt_pma_answer"]
+          "scar": [
+            "W73#4"
+          ],
+          "guilt": [
+            "test_cafe_guard_still_fires_on_real_cafe_question"
+          ],
+          "innocence": [
+            "test_cafe_guard_does_not_clobber_definitional_pt_pma_answer"
+          ]
         },
         "_guard_nominee_reply": {
-          "scar": ["W73#5"],
+          "scar": [
+            "W73#5"
+          ],
           "guilt": [
             "test_nominee_guard_fires_on_natural_phrasing",
             "test_nominee_guard_clobbers_short_risky_only_answer",
@@ -86,66 +137,102 @@
       }
     },
     "command_hooks": {
-      "hooks_dirs": ["infra/claude-hooks", "scripts/hooks"],
+      "hooks_dirs": [
+        "infra/claude-hooks",
+        "scripts/hooks"
+      ],
       "vaccine": "infra/claude-hooks/test_hook_innocence.py",
       "entries": {
         "infra/claude-hooks/worktree_isolation.py": {
-          "scar": ["W79", "W83", "W84", "W85"],
+          "scar": [
+            "W79",
+            "W83",
+            "W84",
+            "W85"
+          ],
           "symbols": {
             "BLOCKED_SUBCMD_RE": {
               "tests": [
                 "infra/claude-hooks/test_block_regex.py",
                 "infra/claude-hooks/test_w85_stash_readonly.py"
               ],
-              "note": "W85 stash over-match still OPEN in code — test_w85_stash_readonly.py PINS the documented-broken contract (W82-tripwire style); fix is a PENDING-ARMS line, not silent"
+              "note": "W85 stash over-match FIXED 2026-07-06 (negative lookahead: read-only `stash list|show` pass, bare/mutating stash still blocked) \u2014 test_w85_stash_readonly.py converted from tripwire-pin to plain guilt+innocence per the pin's own instructions"
             },
-            "_is_remote_dispatch": { "tests": ["infra/claude-hooks/test_w83_remote_dispatch.py"] },
+            "_is_remote_dispatch": {
+              "tests": [
+                "infra/claude-hooks/test_w83_remote_dispatch.py"
+              ]
+            },
             "_strip_noise": {
               "tests": [
                 "infra/claude-hooks/test_w84_strip_noise_cross_line.py",
                 "infra/claude-hooks/test_w83_remote_dispatch.py"
               ]
             },
-            "_write_hits_main": { "tests": ["infra/claude-hooks/test_w79_shell_write.py"] }
+            "_write_hits_main": {
+              "tests": [
+                "infra/claude-hooks/test_w79_shell_write.py"
+              ]
+            }
           },
-          "also_covered_by": ["vaccine"]
+          "also_covered_by": [
+            "vaccine"
+          ]
         },
         "infra/claude-hooks/worktree_file_write_check.py": {
-          "scar": ["W80"],
+          "scar": [
+            "W80"
+          ],
           "symbols": {},
-          "tests": ["infra/claude-hooks/test_arm_keep_hook.py"],
-          "also_covered_by": ["vaccine"]
+          "tests": [
+            "infra/claude-hooks/test_arm_keep_hook.py"
+          ],
+          "also_covered_by": [
+            "vaccine"
+          ]
         },
         "infra/claude-hooks/host_boundary.py": {
           "symbols": {},
-          "tests": ["infra/claude-hooks/test_host_boundary.py"]
+          "tests": [
+            "infra/claude-hooks/test_host_boundary.py"
+          ]
         },
         "infra/claude-hooks/_phase.py": {
           "symbols": {},
-          "tests": ["infra/claude-hooks/test_phase.py"]
+          "tests": [
+            "infra/claude-hooks/test_phase.py"
+          ]
         },
         "infra/claude-hooks/premise_gate.py": {
           "symbols": {},
-          "tests": ["infra/claude-hooks/test_premise_gate.py"]
+          "tests": [
+            "infra/claude-hooks/test_premise_gate.py"
+          ]
         },
         "infra/claude-hooks/orchestrate_gate.py": {
           "symbols": {},
           "tests": [],
-          "also_covered_by": ["vaccine"]
+          "also_covered_by": [
+            "vaccine"
+          ]
         },
         "infra/claude-hooks/stadio_zero_nudge.py": {
           "symbols": {},
           "tests": [],
-          "also_covered_by": ["vaccine"]
+          "also_covered_by": [
+            "vaccine"
+          ]
         },
         "scripts/hooks/seam_verify.py": {
           "symbols": {},
           "tests": [],
-          "also_covered_by": ["vaccine"]
+          "also_covered_by": [
+            "vaccine"
+          ]
         }
       },
       "exempt": {
-        "infra/claude-hooks/dispatch_nudge.py": "advisory transcript reminder (CLAUDE.md §7 T1.1) — emits a nudge, never blocks a command; no block/allow contract to test",
+        "infra/claude-hooks/dispatch_nudge.py": "advisory transcript reminder (CLAUDE.md \u00a77 T1.1) \u2014 emits a nudge, never blocks a command; no block/allow contract to test",
         "scripts/hooks/check_import_chain.sh": "shell preflight, not a command-matching guard on model output",
         "scripts/hooks/check_protected_files.sh": "static path blocklist, exercised by hot-zone-pr-gate CI",
         "scripts/hooks/escalations_alert_sessionstart.sh": "SessionStart injector, never blocks",
@@ -163,7 +250,9 @@
     },
     "under_match_sentinels": {
       "content-freshness-sentinel": {
-        "scar": ["W82"],
+        "scar": [
+          "W82"
+        ],
         "delegated_to": "infra/scar-gates/test_W82_content_freshness_undermatch.py",
         "note": "guilt+innocence live in the scar gate; the fact-based cure is a declared operator firebreak (2026-06-16)"
       }


### PR DESCRIPTION
BLOCKED_SUBCMD_RE carried a bare `stash`, blocking read-only `git stash
list` / `git stash show` exactly like the mutating verbs — third
consecutive over-match of this guard in the #3 family (after W83, W84).

Fix: `stash(?!\s+(?:list|show)\b)` — bare `git stash` (= stash push) and
every mutating stash verb (push/pop/apply/drop/clear/create/store/branch)
still match; only the two read-only queries pass. Word-boundary keeps
`stashes` a non-match.

test_w85_stash_readonly.py converted from W82-tripwire pin (which pinned
the documented-broken contract and was designed to fail loudly on this
very fix) to a plain guilt+innocence suite, per the pin's own
instructions. registry.json note flipped to the fixed state.

Verified: W85 suite OK, test_block_regex 20/20, W83 21/21, W84 22/22,
hook-innocence vaccine 34/34, guard-conformance checker 0 violations.
Live ~/.claude/hooks copy: fold is operator-executed (host_boundary
correctly blocks agent writes to the control plane); the PENDING-ARMS
line closes only after the live cmp+probe proof.

Applied with operator GO 2026-07-06 ("applica il fix W85 repo+live").

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
