### PR TITLE
fix(reconcile): scripts/lib among canon dirs (heartbeat.sh canon-pair)

### DIFF
--- a/scripts/launchagent_reconcile.py
+++ b/scripts/launchagent_reconcile.py
@@ -267,7 +267,7 @@ def reconcile(
     # canon is byte-identical is NOT a fork — it is the W84-safe placement
     # (launchd payloads deliberately live OUTSIDE ~/Desktop because launchd can
     # lose its TCC grant there). The disease is DRIFT, not location.
-    canon_dirs = (repo_infra / "wrappers", repo_dir / "scripts", repo_dir / "infra" / "scripts")
+    canon_dirs = (repo_infra / "wrappers", repo_dir / "scripts", repo_dir / "scripts" / "lib", repo_dir / "infra" / "scripts")
 
     def _repo_canon_for(target: Path) -> Optional[Path]:
         for d in canon_dirs:


### PR DESCRIPTION
Companion to #1969's W84-safe heartbeat placement: HOME copies of `heartbeat.sh` pair with `scripts/lib/heartbeat.sh`, so the canon lookup needs `scripts/lib` or every such copy gets flagged as a no-canon HOME-fork. 25/25 reconcile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)