### PR TITLE
feat(flowkit): add MCP video bridge

### DIFF
--- a/apps/nuzantara-mcp/nuzantara_mcp/server.py
+++ b/apps/nuzantara-mcp/nuzantara_mcp/server.py
@@ -154,6 +154,7 @@ from nuzantara_mcp.tools.workflows import register as register_workflows
 from nuzantara_mcp.tools.admin import register as register_admin
 from nuzantara_mcp.tools.health import register as register_health
 from nuzantara_mcp.tools.google_bridge import register as register_google_bridge
+from nuzantara_mcp.tools.flowkit import register as register_flowkit
 
 # --- Tier 1 expansion: Journey, Pricing, Invoicing, Compliance ---
 from nuzantara_mcp.tools.journey import register as register_journey
@@ -204,6 +205,7 @@ register_workflows(mcp, _call, _call_safe)
 register_admin(mcp, _call, _call_safe)
 register_health(mcp, _call, _call_safe)
 register_google_bridge(mcp, _call, _call_safe)
+register_flowkit(mcp, _call, _call_safe)
 
 # Tier 1 expansion
 register_journey(mcp, _call, _call_safe)

--- a/apps/nuzantara-mcp/nuzantara_mcp/tools/flowkit.py
+++ b/apps/nuzantara-mcp/nuzantara_mcp/tools/flowkit.py
@@ -1,0 +1,424 @@
+"""FlowKit tools for WR2/WR3 image and video generation.
+
+The FlowKit runtime lives on Pro. When this MCP server runs from Air-M5 or
+Mini, these tools execute the repo CLI over SSH and stage local assets/output
+without installing FlowKit on the thin-client machine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shlex
+import socket
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+LOCAL_PYTHON = REPO_ROOT / "apps/backend-rag/.venv/bin/python"
+LOCAL_CLI = REPO_ROOT / "scripts/flowkit_cli.py"
+PRO_ALIAS = "pro"
+PRO_REPO = "~/Desktop/nuzantara"
+PRO_PYTHON = "apps/backend-rag/.venv/bin/python"
+PRO_REMOTE_CLI = "/tmp/nuz-flowkit-bridge/flowkit_cli.py"
+
+RASTER_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
+DEFAULT_ASSET_CANDIDATES = [
+    "/Users/balizero/Desktop/logo/zer.jpg",
+    "/Users/balizero/Desktop/logo/zer.jpeg",
+    "/Users/balizero/Desktop/logo/selfie_converted.jpg",
+    "/Users/nuzantara/Desktop/logo/zer.jpg",
+    "/Users/nuzantara/Desktop/logo/zer.jpeg",
+    str(REPO_ROOT / "apps/mouth/public/avatars/default-active.svg"),
+    str(REPO_ROOT / "apps/mouth/public/avatars/default-lead.svg"),
+]
+
+
+def _is_pro() -> bool:
+    return socket.gethostname() == "Nuzantara"
+
+
+def _local_python() -> str:
+    if LOCAL_PYTHON.exists():
+        return str(LOCAL_PYTHON)
+    return sys.executable
+
+
+async def _run_process(
+    argv: list[str], *, timeout_s: int = 600
+) -> tuple[int, str, str]:
+    process = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(), timeout=timeout_s
+        )
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.communicate()
+        return 124, "", f"timeout after {timeout_s}s"
+    return (
+        int(process.returncode or 0),
+        stdout.decode(errors="replace"),
+        stderr.decode(errors="replace"),
+    )
+
+
+def _parse_cli_stdout(returncode: int, stdout: str, stderr: str) -> dict[str, Any]:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        return {
+            "ok": False,
+            "error_kind": "flowkit_error",
+            "error": "FlowKit CLI returned no JSON",
+            "returncode": returncode,
+            "stderr": stderr.strip(),
+        }
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError:
+        return {
+            "ok": False,
+            "error_kind": "flowkit_error",
+            "error": "FlowKit CLI returned malformed JSON",
+            "returncode": returncode,
+            "stdout": stdout[-1200:],
+            "stderr": stderr.strip(),
+        }
+    if isinstance(payload, dict):
+        payload.setdefault("returncode", returncode)
+        if stderr.strip():
+            payload.setdefault("stderr", stderr.strip()[-1200:])
+        return payload
+    return {
+        "ok": False,
+        "error_kind": "flowkit_error",
+        "error": "FlowKit CLI JSON was not an object",
+        "returncode": returncode,
+        "payload": payload,
+    }
+
+
+def _cli_argv(args: list[str]) -> list[str]:
+    if _is_pro():
+        return [_local_python(), str(LOCAL_CLI), *args]
+    remote_cmd = f"cd {PRO_REPO} && {PRO_PYTHON} {shlex.quote(PRO_REMOTE_CLI)} {shlex.join(args)}"
+    return ["ssh", "-o", "ConnectTimeout=5", PRO_ALIAS, remote_cmd]
+
+
+async def _run_flowkit_cli(args: list[str], *, timeout_s: int = 600) -> dict[str, Any]:
+    if not _is_pro():
+        stage_error = await _stage_cli_for_pro()
+        if stage_error:
+            return stage_error
+    returncode, stdout, stderr = await _run_process(
+        _cli_argv(args), timeout_s=timeout_s
+    )
+    return _parse_cli_stdout(returncode, stdout, stderr)
+
+
+async def _ssh_mkdir(path: str) -> dict[str, Any] | None:
+    returncode, _, stderr = await _run_process(
+        ["ssh", "-o", "ConnectTimeout=5", PRO_ALIAS, "mkdir", "-p", path],
+        timeout_s=30,
+    )
+    if returncode != 0:
+        return {
+            "ok": False,
+            "error_kind": "flowkit_error",
+            "error": f"Failed to create Pro staging directory: {stderr.strip()}",
+            "returncode": returncode,
+        }
+    return None
+
+
+async def _stage_cli_for_pro() -> dict[str, Any] | None:
+    if not LOCAL_CLI.exists():
+        return {
+            "ok": False,
+            "error_kind": "flowkit_error",
+            "error": f"FlowKit CLI is missing locally: {LOCAL_CLI}",
+        }
+
+    mkdir_error = await _ssh_mkdir(str(Path(PRO_REMOTE_CLI).parent))
+    if mkdir_error:
+        return mkdir_error
+
+    returncode, _, stderr = await _run_process(
+        ["scp", str(LOCAL_CLI), f"{PRO_ALIAS}:{PRO_REMOTE_CLI}"],
+        timeout_s=30,
+    )
+    if returncode != 0:
+        return {
+            "ok": False,
+            "error_kind": "flowkit_error",
+            "error": f"Failed to stage FlowKit CLI on Pro: {stderr.strip()}",
+            "returncode": returncode,
+        }
+    return None
+
+
+async def _stage_local_file_for_pro(path: str) -> tuple[str, dict[str, Any] | None]:
+    if _is_pro():
+        return path, None
+
+    local_path = Path(path).expanduser()
+    if not local_path.exists():
+        return path, None
+
+    remote_dir = f"/tmp/nuz-flowkit-assets/{uuid.uuid4().hex}"
+    mkdir_error = await _ssh_mkdir(remote_dir)
+    if mkdir_error:
+        return path, mkdir_error
+
+    remote_path = f"{remote_dir}/{local_path.name}"
+    returncode, _, stderr = await _run_process(
+        ["scp", str(local_path), f"{PRO_ALIAS}:{remote_path}"],
+        timeout_s=60,
+    )
+    if returncode != 0:
+        return path, {
+            "ok": False,
+            "error_kind": "flowkit_error",
+            "error": f"Failed to stage asset on Pro: {stderr.strip()}",
+            "returncode": returncode,
+        }
+    return remote_path, None
+
+
+async def _prepare_remote_dest(path: str) -> tuple[str, dict[str, Any] | None]:
+    if _is_pro() or not path:
+        return path, None
+    local_path = Path(path).expanduser()
+    remote_dir = f"/tmp/nuz-flowkit-output/{uuid.uuid4().hex}"
+    mkdir_error = await _ssh_mkdir(remote_dir)
+    if mkdir_error:
+        return path, mkdir_error
+    return f"{remote_dir}/{local_path.name}", None
+
+
+async def _copy_output_from_pro(
+    remote_path: str, local_path: str
+) -> dict[str, Any] | None:
+    if _is_pro() or not remote_path or not local_path or remote_path == local_path:
+        return None
+    dest = Path(local_path).expanduser()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    returncode, _, stderr = await _run_process(
+        ["scp", f"{PRO_ALIAS}:{remote_path}", str(dest)],
+        timeout_s=120,
+    )
+    if returncode != 0:
+        return {
+            "ok": False,
+            "error_kind": "flowkit_error",
+            "error": f"FlowKit output generated on Pro but copy-back failed: {stderr.strip()}",
+            "returncode": returncode,
+            "remote_path": remote_path,
+        }
+    return None
+
+
+async def _path_exists_on_pro(path: str) -> bool:
+    returncode, _, _ = await _run_process(
+        ["ssh", "-o", "ConnectTimeout=5", PRO_ALIAS, "test", "-f", path],
+        timeout_s=10,
+    )
+    return returncode == 0
+
+
+def _is_uploadable(path: str) -> bool:
+    return Path(path).suffix.lower() in RASTER_SUFFIXES
+
+
+async def _resolve_asset_candidates(asset_path: str = "") -> dict[str, Any]:
+    candidates = [asset_path] if asset_path else DEFAULT_ASSET_CANDIDATES
+    seen: set[str] = set()
+    local_matches: list[dict[str, Any]] = []
+    pro_matches: list[dict[str, Any]] = []
+    for raw_candidate in candidates:
+        if not raw_candidate or raw_candidate in seen:
+            continue
+        seen.add(raw_candidate)
+        local_path = Path(raw_candidate).expanduser()
+        if local_path.exists():
+            local_matches.append(
+                {
+                    "path": str(local_path),
+                    "uploadable": _is_uploadable(str(local_path)),
+                    "machine": socket.gethostname(),
+                }
+            )
+        if not _is_pro() and raw_candidate.startswith("/Users/nuzantara/"):
+            if await _path_exists_on_pro(raw_candidate):
+                pro_matches.append(
+                    {
+                        "path": raw_candidate,
+                        "uploadable": _is_uploadable(raw_candidate),
+                        "machine": "Nuzantara",
+                    }
+                )
+
+    recommended = ""
+    for match in [*local_matches, *pro_matches]:
+        if match["uploadable"]:
+            recommended = str(match["path"])
+            break
+
+    return {
+        "ok": bool(recommended),
+        "local_matches": local_matches,
+        "pro_matches": pro_matches,
+        "recommended_start_image_path": recommended,
+        "note": (
+            "Use an explicit start_image_path or start_image_media_id. "
+            "The bridge does not assume an AVATAR record exists."
+        ),
+    }
+
+
+def register(mcp, _call=None, _call_safe=None) -> None:
+    """Register FlowKit tools."""
+
+    @mcp.tool()
+    async def flowkit_health() -> dict[str, Any]:
+        """Check FlowKit readiness on Pro, usable from Air-M5 via SSH."""
+        payload = await _run_flowkit_cli(["health"], timeout_s=60)
+        payload["executed_on"] = "Pro" if not _is_pro() else "local-Pro"
+        return payload
+
+    @mcp.tool()
+    async def flowkit_resolve_asset(asset_path: str = "") -> dict[str, Any]:
+        """Find a usable raster start-image asset before video generation."""
+        return await _resolve_asset_candidates(asset_path)
+
+    @mcp.tool()
+    async def flowkit_upload_image(
+        image_path: str,
+        project_name: str = "mcp-flowkit",
+        project_id: str = "",
+    ) -> dict[str, Any]:
+        """Upload a local image to FlowKit and return the media_id."""
+        staged_path, stage_error = await _stage_local_file_for_pro(image_path)
+        if stage_error:
+            return stage_error
+        args = [
+            "upload-image",
+            "--image-path",
+            staged_path,
+            "--project",
+            project_name,
+        ]
+        if project_id:
+            args.extend(["--project-id", project_id])
+        payload = await _run_flowkit_cli(args, timeout_s=180)
+        if staged_path != image_path:
+            payload["local_source_path"] = image_path
+            payload["pro_staged_path"] = staged_path
+        return payload
+
+    @mcp.tool()
+    async def flowkit_generate_image(
+        prompt: str,
+        orientation: str = "PORTRAIT",
+        project_name: str = "mcp-flowkit",
+        dest_path: str = "",
+        paygate_tier: str = "PAYGATE_TIER_TIER1P5",
+    ) -> dict[str, Any]:
+        """Generate a Nano Banana Pro image through FlowKit on Pro."""
+        remote_dest, dest_error = await _prepare_remote_dest(dest_path)
+        if dest_error:
+            return dest_error
+        args = [
+            "generate-image",
+            "--prompt",
+            prompt,
+            "--orientation",
+            orientation,
+            "--project",
+            project_name,
+            "--paygate-tier",
+            paygate_tier,
+        ]
+        if remote_dest:
+            args.extend(["--dest", remote_dest])
+        payload = await _run_flowkit_cli(args, timeout_s=240)
+        if payload.get("ok") and remote_dest and dest_path and remote_dest != dest_path:
+            copy_error = await _copy_output_from_pro(remote_dest, dest_path)
+            if copy_error:
+                return copy_error
+            payload["remote_path"] = payload.get("local_path", remote_dest)
+            payload["local_path"] = str(Path(dest_path).expanduser())
+        return payload
+
+    @mcp.tool()
+    async def flowkit_generate_video(
+        prompt: str,
+        project_name: str = "mcp-flowkit",
+        start_image_media_id: str = "",
+        start_image_path: str = "",
+        scene_id: str = "",
+        orientation: str = "PORTRAIT",
+        dest_path: str = "",
+        paygate_tier: str = "PAYGATE_TIER_TIER1P5",
+    ) -> dict[str, Any]:
+        """Generate an 8s Veo video from a real start image."""
+        if not start_image_media_id and not start_image_path:
+            asset_probe = await _resolve_asset_candidates()
+            return {
+                "ok": False,
+                "error_kind": "missing_asset",
+                "error": (
+                    "Missing start image. Pass start_image_media_id or "
+                    "start_image_path; no AVATAR row is assumed."
+                ),
+                "asset_probe": asset_probe,
+            }
+
+        staged_path = start_image_path
+        if start_image_path:
+            staged_path, stage_error = await _stage_local_file_for_pro(start_image_path)
+            if stage_error:
+                return stage_error
+
+        remote_dest, dest_error = await _prepare_remote_dest(dest_path)
+        if dest_error:
+            return dest_error
+
+        args = [
+            "generate-video",
+            "--prompt",
+            prompt,
+            "--orientation",
+            orientation,
+            "--project",
+            project_name,
+            "--paygate-tier",
+            paygate_tier,
+        ]
+        if start_image_media_id:
+            args.extend(["--start-image-media-id", start_image_media_id])
+        if staged_path:
+            args.extend(["--start-image-path", staged_path])
+        if scene_id:
+            args.extend(["--scene-id", scene_id])
+        if remote_dest:
+            args.extend(["--dest", remote_dest])
+
+        payload = await _run_flowkit_cli(args, timeout_s=720)
+        if staged_path != start_image_path:
+            payload["local_source_path"] = start_image_path
+            payload["pro_staged_path"] = staged_path
+        if payload.get("ok") and remote_dest and dest_path and remote_dest != dest_path:
+            copy_error = await _copy_output_from_pro(remote_dest, dest_path)
+            if copy_error:
+                return copy_error
+            payload["remote_path"] = payload.get("local_path", remote_dest)
+            payload["local_path"] = str(Path(dest_path).expanduser())
+        return payload

--- a/apps/nuzantara-mcp/tests/test_tools_flowkit.py
+++ b/apps/nuzantara-mcp/tests/test_tools_flowkit.py
@@ -1,0 +1,175 @@
+"""Unit tests for FlowKit MCP tools."""
+
+from __future__ import annotations
+
+import pytest
+
+from nuzantara_mcp.tools import flowkit
+from nuzantara_mcp.tools.flowkit import register
+
+
+def _register_tools(mock_mcp, mock_call, mock_call_safe):
+    tools: dict = {}
+
+    def capture_tool():
+        def decorator(fn):
+            tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    mock_mcp.tool = capture_tool
+    register(mock_mcp, mock_call, mock_call_safe)
+    return tools
+
+
+@pytest.mark.asyncio
+async def test_flowkit_health_routes_to_cli(
+    mock_mcp, mock_call, mock_call_safe, monkeypatch
+) -> None:
+    tools = _register_tools(mock_mcp, mock_call, mock_call_safe)
+    captured: dict = {}
+
+    async def fake_run(args, *, timeout_s=600):
+        captured["args"] = args
+        captured["timeout_s"] = timeout_s
+        return {"ok": True}
+
+    monkeypatch.setattr(flowkit, "_is_pro", lambda: False)
+    monkeypatch.setattr(flowkit, "_run_flowkit_cli", fake_run)
+
+    result = await tools["flowkit_health"]()
+
+    assert result["ok"] is True
+    assert result["executed_on"] == "Pro"
+    assert captured["args"] == ["health"]
+
+
+@pytest.mark.asyncio
+async def test_run_flowkit_cli_stages_cli_on_m5(monkeypatch) -> None:
+    calls: dict = {"staged": False}
+
+    async def fake_stage_cli():
+        calls["staged"] = True
+        return None
+
+    async def fake_process(argv, *, timeout_s=600):
+        calls["argv"] = argv
+        calls["timeout_s"] = timeout_s
+        return 0, '{"ok": true}\n', ""
+
+    monkeypatch.setattr(flowkit, "_is_pro", lambda: False)
+    monkeypatch.setattr(flowkit, "_stage_cli_for_pro", fake_stage_cli)
+    monkeypatch.setattr(flowkit, "_run_process", fake_process)
+
+    result = await flowkit._run_flowkit_cli(["health"], timeout_s=11)
+
+    assert result["ok"] is True
+    assert calls["staged"] is True
+    assert calls["timeout_s"] == 11
+    assert calls["argv"][0] == "ssh"
+    assert "/tmp/nuz-flowkit-bridge/flowkit_cli.py" in calls["argv"][-1]
+
+
+@pytest.mark.asyncio
+async def test_generate_video_requires_start_image(
+    mock_mcp, mock_call, mock_call_safe, monkeypatch
+) -> None:
+    tools = _register_tools(mock_mcp, mock_call, mock_call_safe)
+
+    async def fake_resolve(asset_path: str = ""):
+        return {
+            "ok": True,
+            "recommended_start_image_path": "/Users/balizero/Desktop/logo/zer.jpg",
+        }
+
+    monkeypatch.setattr(flowkit, "_resolve_asset_candidates", fake_resolve)
+
+    result = await tools["flowkit_generate_video"](prompt="0-8s: slow push-in.")
+
+    assert result["ok"] is False
+    assert result["error_kind"] == "missing_asset"
+    assert "AVATAR" in result["error"]
+    assert result["asset_probe"]["recommended_start_image_path"].endswith("zer.jpg")
+
+
+@pytest.mark.asyncio
+async def test_generate_video_stages_m5_asset_for_pro(
+    mock_mcp,
+    mock_call,
+    mock_call_safe,
+    monkeypatch,
+) -> None:
+    tools = _register_tools(mock_mcp, mock_call, mock_call_safe)
+    captured: dict = {}
+
+    async def fake_stage(path: str):
+        return "/tmp/nuz-flowkit-assets/abc/zer.jpg", None
+
+    async def fake_dest(path: str):
+        return "", None
+
+    async def fake_run(args, *, timeout_s=600):
+        captured["args"] = args
+        captured["timeout_s"] = timeout_s
+        return {"ok": True, "video_media_id": "media-1"}
+
+    monkeypatch.setattr(flowkit, "_stage_local_file_for_pro", fake_stage)
+    monkeypatch.setattr(flowkit, "_prepare_remote_dest", fake_dest)
+    monkeypatch.setattr(flowkit, "_run_flowkit_cli", fake_run)
+
+    result = await tools["flowkit_generate_video"](
+        prompt="0-8s: editorial dolly move.",
+        start_image_path="/Users/balizero/Desktop/logo/zer.jpg",
+        paygate_tier="PAYGATE_TIER_TIER1P5",
+    )
+
+    assert result["ok"] is True
+    assert result["local_source_path"] == "/Users/balizero/Desktop/logo/zer.jpg"
+    assert result["pro_staged_path"] == "/tmp/nuz-flowkit-assets/abc/zer.jpg"
+    assert captured["args"][0] == "generate-video"
+    assert captured["args"][captured["args"].index("--start-image-path") + 1] == (
+        "/tmp/nuz-flowkit-assets/abc/zer.jpg"
+    )
+    assert captured["args"][captured["args"].index("--paygate-tier") + 1] == (
+        "PAYGATE_TIER_TIER1P5"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_image_copies_remote_output_back_to_m5(
+    mock_mcp,
+    mock_call,
+    mock_call_safe,
+    monkeypatch,
+) -> None:
+    tools = _register_tools(mock_mcp, mock_call, mock_call_safe)
+
+    async def fake_prepare(path: str):
+        return "/tmp/nuz-flowkit-output/abc/hero.png", None
+
+    async def fake_copy(remote_path: str, local_path: str):
+        assert remote_path == "/tmp/nuz-flowkit-output/abc/hero.png"
+        assert local_path == "/Users/balizero/Desktop/hero.png"
+        return None
+
+    async def fake_run(args, *, timeout_s=600):
+        assert args[0] == "generate-image"
+        return {
+            "ok": True,
+            "media_id": "image-1",
+            "local_path": "/tmp/nuz-flowkit-output/abc/hero.png",
+        }
+
+    monkeypatch.setattr(flowkit, "_prepare_remote_dest", fake_prepare)
+    monkeypatch.setattr(flowkit, "_copy_output_from_pro", fake_copy)
+    monkeypatch.setattr(flowkit, "_run_flowkit_cli", fake_run)
+
+    result = await tools["flowkit_generate_image"](
+        prompt="Bali Zero editorial hero",
+        dest_path="/Users/balizero/Desktop/hero.png",
+    )
+
+    assert result["ok"] is True
+    assert result["remote_path"] == "/tmp/nuz-flowkit-output/abc/hero.png"
+    assert result["local_path"] == "/Users/balizero/Desktop/hero.png"

--- a/docs/wr2/flowkit-integration.md
+++ b/docs/wr2/flowkit-integration.md
@@ -1,9 +1,10 @@
 # WR2 Image Generator — FlowKit Integration
 
-> **Status**: Shipped Sprint 1.6 W3, 2026-05-03. FlowKit is the **secondary
-> backend**, opt-in via `WR2_IMAGE_BACKEND=auto` (the new default). The
-> existing Playwright path is preserved as fallback and remains the
-> production behavior whenever FlowKit is unreachable.
+> **Status**: Shipped Sprint 1.6 W3, 2026-05-03; MCP bridge extended
+> 2026-07-05 for image, upload-image, and `/api/flow/generate-video`.
+> FlowKit remains the **secondary backend** for WR2 images, opt-in via
+> `WR2_IMAGE_BACKEND=auto`. The MCP/CLI bridge is the local operator path for
+> hero stills and Veo i2v video, including Air-M5 usage through Pro over SSH.
 
 ## Why FlowKit
 
@@ -15,7 +16,8 @@ Playwright path drives via the Gemini web UI. Concrete numbers:
 | Path | Latency / image | Credit cost | Setup overhead |
 |---|---|---|---|
 | Playwright (existing) | 30-90 s | 0 (web UI quota) | persistent Chrome profile, hover-reveal selectors |
-| FlowKit (new) | 5-15 s | **0** (FREE for `PAYGATE_TIER_TWO`) | local agent on `:8100` + Chrome extension |
+| FlowKit image | 5-15 s | **0** (FREE for `PAYGATE_TIER_TWO`) | local agent on Pro `:8100` + Chrome extension |
+| FlowKit video | async, usually minutes | Veo/Flow credits | explicit start image + `PAYGATE_TIER_TIER1P5` |
 
 Same model, same image quality, **5-10× faster**, same $0 marginal cost.
 The slow path is preserved because FlowKit's bearer token expires every
@@ -26,6 +28,9 @@ sits idle the next call returns `NO_FLOW_KEY` until refresh).
 
 ```mermaid
 flowchart LR
+    M5[Air-M5 MCP client] -->|ssh pro + scp asset/output| MCP[flowkit MCP tools]
+    MCP --> CLI[scripts/flowkit_cli.py]
+    CLI --> FK
     DB[(Postgres<br/>war_room_drafts)] --> WR2[wr2_image_generator.py]
     WR2 -->|probe once per draft| Probe{FlowKit<br/>is_available?}
     Probe -->|yes| FK[FlowKit<br/>:8100]
@@ -50,6 +55,9 @@ draft** — we don't re-probe between slides because (a) it's wasteful and
 | `WR2_FLOWKIT_TIMEOUT_S` | `60` | HTTP timeout for individual FlowKit calls. |
 | `WR2_FLOWKIT_MATERIAL` | `realistic` | FlowKit project material/style preset. `realistic` matches the WR2 brand bar (editorial photo aesthetic). |
 | `WR2_FLOWKIT_LANGUAGE` | `en` | Project language hint. |
+| `FLOWKIT_BASE_URL` | `http://127.0.0.1:8100` | CLI/MCP bridge endpoint, evaluated on Pro. |
+| `FLOWKIT_PAYGATE_TIER` | `PAYGATE_TIER_TIER1P5` | Default CLI/MCP tier for Ultra video models. |
+| `FLOWKIT_VIDEO_TIMEOUT_S` | `240` | CLI/MCP video polling timeout when `--dest` is requested. |
 
 The existing Playwright vars (`WR2_GEMINI_PROFILE_DIR`, `WR2_IMAGE_TIMEOUT_PER_SLIDE`,
 `WR2_IMAGE_MAX_RETRIES`, `WR2_IMAGE_VLM_VALIDATION` etc.) are unchanged
@@ -73,6 +81,8 @@ The `auto` backend falls back to Playwright on ANY of:
 6. Local read of the downloaded PNG produces zero bytes.
 7. VLM alignment validation rejects the FlowKit output (off-prompt
    stock-style content) — same threshold as Playwright (`WR2_IMAGE_MIN_ALIGN_SCORE=0.5`).
+8. Video generation is requested without `start_image_media_id` or
+   `start_image_path`. The bridge must not assume an `AVATAR`/photo DB row.
 
 In `flowkit`-only mode the same conditions instead surface as an error in
 the per-slide tuple (`(slide_number, None, error_msg)`) — there is no
@@ -85,7 +95,7 @@ errors.
 
 ```bash
 # 1. Boot the local agent (assumes setup per the skill doc)
-cd /tmp/flowkit-poc/flowkit
+cd ~/flowkit
 source venv/bin/activate
 python -m agent.main &  # listens on :8100 (HTTP) + :9222 (extension WS)
 
@@ -99,11 +109,45 @@ curl -s http://127.0.0.1:8100/health \
 # connected: True
 
 curl -s http://127.0.0.1:8100/api/flow/credits | python3 -m json.tool | head -10
-# Should NOT be {"detail":"NO_FLOW_KEY"}
+# Should NOT be NO_FLOW_KEY or UNAUTHENTICATED.
 ```
 
-If `connected: false` after 30 s, refresh the Flow tab and click the
-extension icon again — the WebSocket bridge re-establishes within ~5 s.
+If `extension_connected: true` but `/api/flow/credits` returns 401
+`UNAUTHENTICATED`, the extension websocket is alive but the Flow bearer token
+is stale. Refresh `https://labs.google/fx/tools/flow` on Pro and click the
+FlowKit extension icon again.
+
+### Operator bridge from Pro or Air-M5
+
+Use the repo CLI for direct checks on Pro:
+
+```bash
+ssh pro 'cd ~/Desktop/nuzantara && apps/backend-rag/.venv/bin/python scripts/flowkit_cli.py health'
+```
+
+For Air-M5, use the MCP tools. They copy the current CLI bridge to
+`/tmp/nuz-flowkit-bridge/flowkit_cli.py` on Pro, execute it there, stage local
+raster assets with `scp`, and copy generated output back to the M5 destination:
+
+```python
+await flowkit_health()
+await flowkit_resolve_asset("/Users/balizero/Desktop/logo/zer.jpg")
+await flowkit_generate_image(
+    prompt="Bali Zero editorial immigration hero, photo-realistic, no text",
+    dest_path="/Users/balizero/Desktop/wr2-hero.png",
+)
+await flowkit_generate_video(
+    prompt="0-8s: slow editorial push-in, warm Bali office light, natural movement, no text",
+    start_image_path="/Users/balizero/Desktop/logo/zer.jpg",
+    dest_path="/Users/balizero/Desktop/wr2-hero.mp4",
+    paygate_tier="PAYGATE_TIER_TIER1P5",
+)
+```
+
+For video, one of `start_image_media_id` or `start_image_path` is mandatory.
+If the operator already uploaded an image, reuse the returned `media_id`; if
+the source is a local M5 photo, pass its M5 path and let the MCP bridge stage it
+to Pro. SVG avatar placeholders are not valid start images for Flow video.
 
 ### Verify the WR2 cron picks up FlowKit
 
@@ -134,8 +178,9 @@ FlowKit unavailable — using Playwright backend
 | Symptom | What's happening | Action |
 |---|---|---|
 | `FlowKit /health unreachable` (DEBUG-level log) | Local agent not running. | None — auto path falls back to Playwright. Restart agent next time you boot Chrome. |
-| `FlowKit token not captured (NO_FLOW_KEY)` | Bearer expired (>45 min idle on Flow tab). | None — auto fallback. To restore primary: refresh `labs.google/fx/tools/flow` and click extension icon. |
-| `FlowKit generate-image status=403 ... MODEL_ACCESS_DENIED` | Region block on the requested model (Veo 3 from Bali, etc.). | None — auto fallback. Image gen via `GEM_PIX_2` is NOT region-blocked, so this should not fire for hero images. |
+| `FlowKit token not captured (NO_FLOW_KEY)` or `UNAUTHENTICATED` | Bearer expired or not captured. `extension_connected: true` is not enough. | Refresh `labs.google/fx/tools/flow` on Pro and click the FlowKit extension icon. |
+| `missing_asset` from MCP/CLI video | No start frame was passed, or the expected photo path does not exist on Pro/M5. | Pass `start_image_path` or upload first and pass `start_image_media_id`; do not rely on `AVATAR`. |
+| `FlowKit generate-image/video ... MODEL_ACCESS_DENIED` | Account/tier/model mismatch or region block. | Check `/api/flow/credits` and `~/flowkit/agent/models.json`; Ultra video needs `PAYGATE_TIER_TIER1P5` mapping to `veo_3_1_i2v_s_fast_portrait_ultra`. |
 | `flowkit VLM rejected (score=0.4 < 0.5)` | FlowKit output didn't match prompt (off-brand) | None — auto path falls back to Playwright; flowkit-only path returns error and slide is marked failed. |
 
 ## What does NOT change

--- a/scripts/flowkit_cli.py
+++ b/scripts/flowkit_cli.py
@@ -1,0 +1,847 @@
+#!/usr/bin/env python3
+"""FlowKit command bridge for WR2/WR3 and MCP tools.
+
+The FlowKit agent is intentionally local to the Pro machine. This CLI speaks to
+that local HTTP API and emits one JSON object to stdout so MCP wrappers and
+operators can distinguish token, asset, and model-access failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+
+
+JsonDict = dict[str, Any]
+Orientation = Literal["PORTRAIT", "LANDSCAPE"]
+
+DEFAULT_BASE_URL = os.environ.get("FLOWKIT_BASE_URL", "http://127.0.0.1:8100")
+DEFAULT_TIMEOUT_S = float(os.environ.get("FLOWKIT_TIMEOUT_S", "30"))
+DEFAULT_VIDEO_TIMEOUT_S = float(os.environ.get("FLOWKIT_VIDEO_TIMEOUT_S", "240"))
+DEFAULT_PAYGATE_TIER = os.environ.get(
+    "FLOWKIT_PAYGATE_TIER",
+    "PAYGATE_TIER_TIER1P5",
+)
+
+IMAGE_ASPECT_RATIOS = {
+    "PORTRAIT": "IMAGE_ASPECT_RATIO_PORTRAIT",
+    "LANDSCAPE": "IMAGE_ASPECT_RATIO_LANDSCAPE",
+}
+VIDEO_ASPECT_RATIOS = {
+    "PORTRAIT": "VIDEO_ASPECT_RATIO_PORTRAIT",
+    "LANDSCAPE": "VIDEO_ASPECT_RATIO_LANDSCAPE",
+}
+
+
+class FlowKitBridgeError(Exception):
+    """Structured FlowKit bridge failure."""
+
+    def __init__(
+        self,
+        *,
+        kind: str,
+        message: str,
+        status: int | None = None,
+        detail: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.status = status
+        self.detail = detail
+
+    def to_payload(self) -> JsonDict:
+        payload: JsonDict = {
+            "ok": False,
+            "error_kind": self.kind,
+            "error": str(self),
+        }
+        if self.status is not None:
+            payload["status"] = self.status
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        payload["next_action"] = _next_action_for_kind(self.kind)
+        return payload
+
+
+def _classify_error_text(text: str, *, status: int | None = None) -> str:
+    """Map FlowKit/Google error text to operator-actionable buckets."""
+    lowered = text.lower()
+    if (
+        status == 401
+        or "unauthenticated" in lowered
+        or "invalid authentication" in lowered
+    ):
+        return "flow_auth"
+    if "no_flow_key" in lowered:
+        return "flow_token_missing"
+    if "extension not connected" in lowered or "connection refused" in lowered:
+        return "flowkit_unavailable"
+    if (
+        "model_access_denied" in lowered
+        or "public_error_model_access_denied" in lowered
+        or "no model for tier=" in lowered
+    ):
+        return "model_access"
+    if "file not found" in lowered or "missing start image" in lowered:
+        return "missing_asset"
+    if "unsafe_generation" in lowered:
+        return "unsafe_generation"
+    if (
+        "quota_exceeded" in lowered
+        or "resource_exhausted" in lowered
+        or "insufficient credit" in lowered
+    ):
+        return "quota"
+    if "timeout" in lowered:
+        return "timeout"
+    return "flowkit_error"
+
+
+def _next_action_for_kind(kind: str) -> str:
+    actions = {
+        "flow_auth": (
+            "Refresh https://labs.google/fx/tools/flow on Pro, click the FlowKit "
+            "extension icon, then rerun health; extension_connected alone is not enough."
+        ),
+        "flow_token_missing": (
+            "Refresh the Flow tab on Pro so the extension captures a fresh Bearer token."
+        ),
+        "flowkit_unavailable": (
+            "Start FlowKit on Pro: cd ~/flowkit && source venv/bin/activate && "
+            "python -m agent.main."
+        ),
+        "model_access": (
+            "Check /api/flow/credits and ~/flowkit/agent/models.json. For Ultra video, "
+            "PAYGATE_TIER_TIER1P5 must map to veo_3_1_i2v_s_fast_portrait_ultra."
+        ),
+        "missing_asset": (
+            "Pass --start-image-media-id or --start-image-path. Do not assume an AVATAR "
+            "database row exists."
+        ),
+        "unsafe_generation": "Rewrite the prompt to remove restricted/named-public-figure triggers.",
+        "quota": "Wait for credit reset or choose a lower-cost path before retrying.",
+        "timeout": "Check FlowKit worker status and rerun with a longer timeout if the job is pending.",
+    }
+    return actions.get(
+        kind, "Inspect the returned FlowKit detail and retry after fixing the blocker."
+    )
+
+
+def _json_text(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=True, sort_keys=True)
+
+
+def _emit(payload: JsonDict, *, exit_code: int = 0) -> int:
+    sys.stdout.write(_json_text(payload) + "\n")
+    return exit_code
+
+
+def _compact_detail(data: Any, *, limit: int = 1200) -> Any:
+    if isinstance(data, (str, int, float, bool)) or data is None:
+        return data
+    text = _json_text(data)
+    if len(text) <= limit:
+        return data
+    return text[:limit]
+
+
+async def _request_json(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    *,
+    json_body: JsonDict | None = None,
+    timeout_s: float | None = None,
+) -> JsonDict:
+    try:
+        resp = await client.request(method, path, json=json_body, timeout=timeout_s)
+    except (httpx.HTTPError, OSError) as exc:
+        text = str(exc)
+        raise FlowKitBridgeError(
+            kind=_classify_error_text(text),
+            message=f"FlowKit {method} {path} unreachable: {text}",
+        ) from exc
+
+    try:
+        data = resp.json()
+    except ValueError:
+        data = {"raw_body": resp.text[:1200]}
+
+    if resp.status_code >= 400:
+        detail = data.get("detail") if isinstance(data, dict) else data
+        text = _json_text(detail)
+        raise FlowKitBridgeError(
+            kind=_classify_error_text(text, status=resp.status_code),
+            message=f"FlowKit {method} {path} status={resp.status_code}",
+            status=resp.status_code,
+            detail=_compact_detail(detail),
+        )
+
+    if isinstance(data, dict):
+        detail = data.get("detail")
+        error = data.get("error")
+        if detail or error:
+            err_detail = detail or error
+            text = _json_text(err_detail)
+            raise FlowKitBridgeError(
+                kind=_classify_error_text(text, status=resp.status_code),
+                message=f"FlowKit {method} {path} returned an error envelope",
+                status=resp.status_code,
+                detail=_compact_detail(err_detail),
+            )
+        return data
+
+    raise FlowKitBridgeError(
+        kind="flowkit_error",
+        message=f"FlowKit {method} {path} returned non-object JSON",
+        status=resp.status_code,
+        detail=_compact_detail(data),
+    )
+
+
+async def _safe_request_json(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    *,
+    json_body: JsonDict | None = None,
+    timeout_s: float | None = None,
+) -> JsonDict:
+    try:
+        data = await _request_json(
+            client,
+            method,
+            path,
+            json_body=json_body,
+            timeout_s=timeout_s,
+        )
+        return {"ok": True, "data": data}
+    except FlowKitBridgeError as exc:
+        payload = exc.to_payload()
+        payload["ok"] = False
+        return payload
+
+
+async def _ensure_project(
+    client: httpx.AsyncClient,
+    *,
+    name: str,
+    material: str,
+    language: str,
+    timeout_s: float,
+) -> str:
+    body = {"name": name, "material": material, "language": language}
+    data = await _request_json(
+        client,
+        "POST",
+        "/api/projects",
+        json_body=body,
+        timeout_s=timeout_s,
+    )
+    project_id = (
+        data.get("id")
+        or data.get("project_id")
+        or (data.get("project") or {}).get("id")
+    )
+    if not isinstance(project_id, str) or not project_id:
+        raise FlowKitBridgeError(
+            kind="flowkit_error",
+            message="FlowKit project create returned no project id",
+            detail=_compact_detail(data),
+        )
+    return project_id
+
+
+async def _create_video(
+    client: httpx.AsyncClient,
+    *,
+    project_id: str,
+    title: str,
+    orientation: Orientation,
+    timeout_s: float,
+) -> str:
+    body = {
+        "project_id": project_id,
+        "title": title,
+        "orientation": "VERTICAL" if orientation == "PORTRAIT" else "HORIZONTAL",
+    }
+    data = await _request_json(
+        client,
+        "POST",
+        "/api/videos",
+        json_body=body,
+        timeout_s=timeout_s,
+    )
+    video_id = (
+        data.get("id") or data.get("video_id") or (data.get("video") or {}).get("id")
+    )
+    if not isinstance(video_id, str) or not video_id:
+        raise FlowKitBridgeError(
+            kind="flowkit_error",
+            message="FlowKit video create returned no video id",
+            detail=_compact_detail(data),
+        )
+    return video_id
+
+
+async def _create_scene(
+    client: httpx.AsyncClient,
+    *,
+    video_id: str,
+    scene_id: str | None,
+    prompt: str,
+    timeout_s: float,
+) -> str:
+    if scene_id:
+        return scene_id
+    body = {
+        "video_id": video_id,
+        "display_order": 1,
+        "prompt": prompt,
+        "chain_type": "ROOT",
+    }
+    data = await _request_json(
+        client,
+        "POST",
+        "/api/scenes",
+        json_body=body,
+        timeout_s=timeout_s,
+    )
+    created_scene_id = (
+        data.get("id") or data.get("scene_id") or (data.get("scene") or {}).get("id")
+    )
+    if not isinstance(created_scene_id, str) or not created_scene_id:
+        raise FlowKitBridgeError(
+            kind="flowkit_error",
+            message="FlowKit scene create returned no scene id",
+            detail=_compact_detail(data),
+        )
+    return created_scene_id
+
+
+def _parse_image_response(data: JsonDict) -> JsonDict:
+    media = data.get("media")
+    if not isinstance(media, list) or not media:
+        raise FlowKitBridgeError(
+            kind="flowkit_error",
+            message="FlowKit generate-image response has no media array",
+            detail=_compact_detail(data),
+        )
+    first = media[0] if isinstance(media[0], dict) else {}
+    generated = (first.get("image") or {}).get("generatedImage") or {}
+    media_id = generated.get("mediaId") or first.get("name")
+    fife_url = generated.get("fifeUrl")
+    dimensions = first.get("dimensions") or {}
+    if not isinstance(media_id, str) or not media_id:
+        raise FlowKitBridgeError(
+            kind="flowkit_error",
+            message="FlowKit generate-image response missing mediaId",
+            detail=_compact_detail(data),
+        )
+    result: JsonDict = {
+        "media_id": media_id,
+        "model": generated.get("modelNameType") or "",
+        "seed": generated.get("seed") or 0,
+        "width": dimensions.get("width") or 0,
+        "height": dimensions.get("height") or 0,
+    }
+    if isinstance(fife_url, str) and fife_url:
+        result["fife_url"] = fife_url
+    return result
+
+
+def _parse_video_response(data: JsonDict) -> JsonDict:
+    workflows = data.get("workflows") or data.get("operations") or []
+    media = data.get("media") or []
+    first_workflow = workflows[0] if isinstance(workflows, list) and workflows else {}
+    first_media = media[0] if isinstance(media, list) and media else {}
+    workflow_id = (
+        first_workflow.get("name")
+        or first_workflow.get("id")
+        or first_workflow.get("operation")
+        or ""
+    )
+    video_media_id = (
+        first_media.get("name")
+        or first_media.get("mediaId")
+        or first_workflow.get("_primary_media_id")
+        or ""
+    )
+    status = first_workflow.get("status") or first_media.get("status") or ""
+    if not isinstance(video_media_id, str) or not video_media_id:
+        raise FlowKitBridgeError(
+            kind="flowkit_error",
+            message="FlowKit generate-video response missing video media id",
+            detail=_compact_detail(data),
+        )
+    return {
+        "workflow_id": workflow_id,
+        "video_media_id": video_media_id,
+        "status": status,
+        "raw": data,
+    }
+
+
+async def _download_url(
+    client: httpx.AsyncClient,
+    url: str,
+    dest_path: Path,
+    *,
+    timeout_s: float,
+) -> Path:
+    try:
+        resp = await client.get(url, follow_redirects=True, timeout=timeout_s)
+    except httpx.HTTPError as exc:
+        raise FlowKitBridgeError(
+            kind=_classify_error_text(str(exc)),
+            message=f"FlowKit media download failed: {exc}",
+        ) from exc
+    if resp.status_code != 200:
+        raise FlowKitBridgeError(
+            kind=_classify_error_text(resp.text, status=resp.status_code),
+            message=f"FlowKit media download status={resp.status_code}",
+            status=resp.status_code,
+            detail=resp.text[:1200],
+        )
+    if not resp.content:
+        raise FlowKitBridgeError(
+            kind="flowkit_error",
+            message="FlowKit media download returned zero bytes",
+        )
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    dest_path.write_bytes(resp.content)
+    return dest_path
+
+
+async def _download_video_media(
+    client: httpx.AsyncClient,
+    *,
+    media_id: str,
+    dest_path: Path,
+    timeout_s: float,
+    poll_interval_s: float,
+) -> Path:
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    last_payload: JsonDict = {}
+    while asyncio.get_running_loop().time() < deadline:
+        payload = await _safe_request_json(
+            client,
+            "GET",
+            f"/api/flow/media/{media_id}",
+            timeout_s=min(30.0, timeout_s),
+        )
+        if payload.get("ok"):
+            data = payload.get("data") or {}
+            last_payload = data if isinstance(data, dict) else {}
+            video = last_payload.get("video") or {}
+            encoded = video.get("encodedVideo") or last_payload.get("encodedVideo")
+            if isinstance(encoded, str) and encoded:
+                mp4_bytes = base64.b64decode(encoded)
+                if len(mp4_bytes) < 32 or b"ftyp" not in mp4_bytes[:32]:
+                    raise FlowKitBridgeError(
+                        kind="flowkit_error",
+                        message="FlowKit media bytes do not look like MP4",
+                        detail={"bytes": len(mp4_bytes)},
+                    )
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                dest_path.write_bytes(mp4_bytes)
+                return dest_path
+            fife_url = video.get("fifeUrl") or video.get("url")
+            if isinstance(fife_url, str) and fife_url:
+                return await _download_url(
+                    client,
+                    fife_url,
+                    dest_path,
+                    timeout_s=min(60.0, timeout_s),
+                )
+        else:
+            kind = payload.get("error_kind")
+            status = payload.get("status")
+            transient = (
+                kind in {"timeout"}
+                or status in {404, 500, 503}
+                or _is_transient_media_error(payload)
+            )
+            if not transient:
+                raise FlowKitBridgeError(
+                    kind=str(kind or "flowkit_error"),
+                    message="FlowKit media endpoint returned terminal error",
+                    status=status if isinstance(status, int) else None,
+                    detail=_compact_detail(payload),
+                )
+            last_payload = payload
+        await asyncio.sleep(poll_interval_s)
+
+    raise FlowKitBridgeError(
+        kind="timeout",
+        message=f"FlowKit media {media_id[:8]} not ready after {timeout_s:.0f}s",
+        detail=_compact_detail(last_payload),
+    )
+
+
+def _is_transient_media_error(payload: JsonDict) -> bool:
+    detail = payload.get("detail")
+    if not isinstance(detail, dict):
+        return False
+    error = detail.get("error")
+    if not isinstance(error, dict):
+        return False
+    code = error.get("code")
+    status = str(error.get("status", "")).upper()
+    return code in (404, "404", 500, "500", 503, "503") or status in {
+        "NOT_FOUND",
+        "INTERNAL",
+        "UNAVAILABLE",
+    }
+
+
+async def action_health(args: argparse.Namespace) -> JsonDict:
+    async with httpx.AsyncClient(
+        base_url=args.base_url.rstrip("/"),
+        timeout=args.timeout,
+    ) as client:
+        health = await _safe_request_json(
+            client, "GET", "/health", timeout_s=args.timeout
+        )
+        flow_status = await _safe_request_json(
+            client,
+            "GET",
+            "/api/flow/status",
+            timeout_s=args.timeout,
+        )
+        credits = await _safe_request_json(
+            client,
+            "GET",
+            "/api/flow/credits",
+            timeout_s=args.timeout,
+        )
+
+    extension_connected = bool((health.get("data") or {}).get("extension_connected"))
+    token_ok = bool(credits.get("ok"))
+    ready = bool(health.get("ok") and extension_connected and token_ok)
+
+    blocker = ""
+    if not health.get("ok"):
+        blocker = str(health.get("error_kind") or "flowkit_unavailable")
+    elif not extension_connected:
+        blocker = "flowkit_unavailable"
+    elif not token_ok:
+        blocker = str(credits.get("error_kind") or "flow_auth")
+
+    return {
+        "ok": ready,
+        "base_url": args.base_url,
+        "extension_connected": extension_connected,
+        "health": health,
+        "flow_status": flow_status,
+        "credits": credits,
+        "blocker": blocker,
+        "next_action": _next_action_for_kind(blocker) if blocker else "",
+    }
+
+
+async def action_upload_image(args: argparse.Namespace) -> JsonDict:
+    image_path = Path(args.image_path).expanduser()
+    if not image_path.exists():
+        raise FlowKitBridgeError(
+            kind="missing_asset",
+            message=f"Image asset not found: {image_path}",
+            detail={"image_path": str(image_path)},
+        )
+
+    async with httpx.AsyncClient(
+        base_url=args.base_url.rstrip("/"),
+        timeout=args.timeout,
+    ) as client:
+        project_id = args.project_id or await _ensure_project(
+            client,
+            name=args.project,
+            material=args.material,
+            language=args.language,
+            timeout_s=args.timeout,
+        )
+        data = await _request_json(
+            client,
+            "POST",
+            "/api/flow/upload-image",
+            json_body={
+                "file_path": str(image_path),
+                "project_id": project_id,
+                "file_name": args.file_name or image_path.name,
+            },
+            timeout_s=args.timeout,
+        )
+
+    media_id = data.get("media_id") or data.get("_mediaId")
+    if not isinstance(media_id, str) or not media_id:
+        raise FlowKitBridgeError(
+            kind="flowkit_error",
+            message="FlowKit upload-image returned no media_id",
+            detail=_compact_detail(data),
+        )
+    return {
+        "ok": True,
+        "action": "upload-image",
+        "project_id": project_id,
+        "media_id": media_id,
+        "image_path": str(image_path),
+        "raw": data.get("raw", data),
+    }
+
+
+async def action_generate_image(args: argparse.Namespace) -> JsonDict:
+    async with httpx.AsyncClient(
+        base_url=args.base_url.rstrip("/"),
+        timeout=args.timeout,
+    ) as client:
+        project_id = args.project_id or await _ensure_project(
+            client,
+            name=args.project,
+            material=args.material,
+            language=args.language,
+            timeout_s=args.timeout,
+        )
+        data = await _request_json(
+            client,
+            "POST",
+            "/api/flow/generate-image",
+            json_body={
+                "prompt": args.prompt,
+                "project_id": project_id,
+                "aspect_ratio": IMAGE_ASPECT_RATIOS[args.orientation],
+                "user_paygate_tier": args.paygate_tier,
+            },
+            timeout_s=args.timeout,
+        )
+        result = _parse_image_response(data)
+        if args.dest:
+            fife_url = result.get("fife_url")
+            if not isinstance(fife_url, str) or not fife_url:
+                raise FlowKitBridgeError(
+                    kind="flowkit_error",
+                    message="FlowKit image response has no fife_url to download",
+                    detail=_compact_detail(result),
+                )
+            local_path = await _download_url(
+                client,
+                fife_url,
+                Path(args.dest).expanduser(),
+                timeout_s=args.timeout,
+            )
+            result["local_path"] = str(local_path)
+
+    result.update(
+        {
+            "ok": True,
+            "action": "generate-image",
+            "project_id": project_id,
+            "orientation": args.orientation,
+            "paygate_tier": args.paygate_tier,
+        }
+    )
+    return result
+
+
+async def action_generate_video(args: argparse.Namespace) -> JsonDict:
+    if not args.start_image_media_id and not args.start_image_path:
+        raise FlowKitBridgeError(
+            kind="missing_asset",
+            message=(
+                "Missing start image. Provide --start-image-media-id or "
+                "--start-image-path; the bridge will not assume an AVATAR row exists."
+            ),
+            detail={
+                "candidate_m5_path": "/Users/balizero/Desktop/logo/zer.jpg",
+                "candidate_pro_path": "/Users/nuzantara/Desktop/logo/zer.jpg",
+            },
+        )
+
+    async with httpx.AsyncClient(
+        base_url=args.base_url.rstrip("/"),
+        timeout=max(args.timeout, args.video_timeout),
+    ) as client:
+        project_id = args.project_id or await _ensure_project(
+            client,
+            name=args.project,
+            material=args.material,
+            language=args.language,
+            timeout_s=args.timeout,
+        )
+        video_id = args.video_id or await _create_video(
+            client,
+            project_id=project_id,
+            title=args.project,
+            orientation=args.orientation,
+            timeout_s=args.timeout,
+        )
+        scene_id = await _create_scene(
+            client,
+            video_id=video_id,
+            scene_id=args.scene_id,
+            prompt=args.prompt,
+            timeout_s=args.timeout,
+        )
+
+        start_image_media_id = args.start_image_media_id
+        if not start_image_media_id:
+            upload_args = argparse.Namespace(
+                image_path=args.start_image_path,
+                project_id=project_id,
+                project=args.project,
+                material=args.material,
+                language=args.language,
+                file_name=Path(args.start_image_path).name,
+                base_url=args.base_url,
+                timeout=args.timeout,
+            )
+            upload = await action_upload_image(upload_args)
+            start_image_media_id = upload["media_id"]
+
+        data = await _request_json(
+            client,
+            "POST",
+            "/api/flow/generate-video",
+            json_body={
+                "start_image_media_id": start_image_media_id,
+                "prompt": args.prompt,
+                "project_id": project_id,
+                "scene_id": scene_id,
+                "aspect_ratio": VIDEO_ASPECT_RATIOS[args.orientation],
+                "user_paygate_tier": args.paygate_tier,
+            },
+            timeout_s=args.video_timeout,
+        )
+        result = _parse_video_response(data)
+
+        if args.dest:
+            downloaded = await _download_video_media(
+                client,
+                media_id=result["video_media_id"],
+                dest_path=Path(args.dest).expanduser(),
+                timeout_s=args.video_timeout,
+                poll_interval_s=args.poll_interval,
+            )
+            result["local_path"] = str(downloaded)
+
+    result.update(
+        {
+            "ok": True,
+            "action": "generate-video",
+            "project_id": project_id,
+            "video_id": video_id,
+            "scene_id": scene_id,
+            "start_image_media_id": start_image_media_id,
+            "orientation": args.orientation,
+            "paygate_tier": args.paygate_tier,
+        }
+    )
+    return result
+
+
+def _add_common_http(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_S)
+
+
+def _add_common_project(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--project", default="mcp-flowkit")
+    parser.add_argument("--project-id", default="")
+    parser.add_argument("--material", default="realistic")
+    parser.add_argument("--language", default="en")
+    parser.add_argument("--paygate-tier", default=DEFAULT_PAYGATE_TIER)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="FlowKit JSON bridge")
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    health = subparsers.add_parser("health", help="Check FlowKit readiness")
+    _add_common_http(health)
+
+    upload = subparsers.add_parser("upload-image", help="Upload a local image asset")
+    _add_common_http(upload)
+    _add_common_project(upload)
+    upload.add_argument("--image-path", required=True)
+    upload.add_argument("--file-name", default="")
+
+    image = subparsers.add_parser("generate-image", help="Generate a Flow image")
+    _add_common_http(image)
+    _add_common_project(image)
+    image.add_argument("--prompt", required=True)
+    image.add_argument(
+        "--orientation", choices=["PORTRAIT", "LANDSCAPE"], default="PORTRAIT"
+    )
+    image.add_argument("--dest", default="")
+
+    video = subparsers.add_parser(
+        "generate-video", help="Generate a Flow video from a start image"
+    )
+    _add_common_http(video)
+    _add_common_project(video)
+    video.add_argument("--prompt", required=True)
+    video.add_argument(
+        "--orientation", choices=["PORTRAIT", "LANDSCAPE"], default="PORTRAIT"
+    )
+    video.add_argument("--video-id", default="")
+    video.add_argument("--scene-id", default="")
+    video.add_argument("--start-image-media-id", default="")
+    video.add_argument("--start-image-path", default="")
+    video.add_argument("--dest", default="")
+    video.add_argument("--video-timeout", type=float, default=DEFAULT_VIDEO_TIMEOUT_S)
+    video.add_argument("--poll-interval", type=float, default=10.0)
+
+    return parser
+
+
+async def run(args: argparse.Namespace) -> JsonDict:
+    if args.action == "health":
+        return await action_health(args)
+    if args.action == "upload-image":
+        return await action_upload_image(args)
+    if args.action == "generate-image":
+        return await action_generate_image(args)
+    if args.action == "generate-video":
+        return await action_generate_video(args)
+    raise FlowKitBridgeError(
+        kind="flowkit_error", message=f"Unknown action: {args.action}"
+    )
+
+
+def _legacy_argv(argv: list[str]) -> list[str]:
+    """Keep compatibility with the early WIP form: --prompt ... --dest ..."""
+    if argv and argv[0].startswith("-"):
+        return ["generate-image", *argv]
+    return argv
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(_legacy_argv(list(argv or sys.argv[1:])))
+    try:
+        payload = asyncio.run(run(args))
+    except FlowKitBridgeError as exc:
+        return _emit(exc.to_payload(), exit_code=2)
+    except Exception as exc:  # pragma: no cover - last-resort CLI guard
+        kind = _classify_error_text(str(exc))
+        return _emit(
+            {
+                "ok": False,
+                "error_kind": kind,
+                "error": str(exc),
+                "next_action": _next_action_for_kind(kind),
+            },
+            exit_code=2,
+        )
+    return _emit(payload, exit_code=0 if payload.get("ok", True) else 2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_flowkit_cli.py
+++ b/scripts/tests/test_flowkit_cli.py
@@ -1,0 +1,167 @@
+"""Unit tests for the FlowKit JSON CLI bridge."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+import sys
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import flowkit_cli  # noqa: E402
+
+
+def test_classifies_auth_and_model_access_failures() -> None:
+    assert flowkit_cli._classify_error_text(
+        "invalid authentication credentials", status=401
+    ) == ("flow_auth")
+    assert flowkit_cli._classify_error_text("PUBLIC_ERROR_MODEL_ACCESS_DENIED") == (
+        "model_access"
+    )
+    assert flowkit_cli._classify_error_text("No model for tier=PAYGATE_TIER_ONE") == (
+        "model_access"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_video_requires_explicit_start_image() -> None:
+    parser = flowkit_cli.build_parser()
+    args = parser.parse_args(
+        [
+            "generate-video",
+            "--prompt",
+            "0-8s: editorial dolly toward the Bali Zero anchor.",
+        ]
+    )
+
+    with pytest.raises(flowkit_cli.FlowKitBridgeError) as exc_info:
+        await flowkit_cli.run(args)
+
+    assert exc_info.value.kind == "missing_asset"
+    assert "AVATAR" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_health_surfaces_credit_auth_blocker(monkeypatch) -> None:
+    async def fake_safe_request_json(client, method, path, **kwargs):
+        if path == "/health":
+            return {"ok": True, "data": {"extension_connected": True}}
+        if path == "/api/flow/status":
+            return {"ok": True, "data": {"flow_key_present": False}}
+        if path == "/api/flow/credits":
+            return {
+                "ok": False,
+                "error_kind": "flow_auth",
+                "status": 401,
+                "detail": {"status": "UNAUTHENTICATED"},
+            }
+        raise AssertionError(path)
+
+    monkeypatch.setattr(flowkit_cli, "_safe_request_json", fake_safe_request_json)
+
+    result = await flowkit_cli.action_health(
+        Namespace(base_url="http://127.0.0.1:8100", timeout=1.0)
+    )
+
+    assert result["ok"] is False
+    assert result["extension_connected"] is True
+    assert result["blocker"] == "flow_auth"
+    assert "extension_connected alone is not enough" in result["next_action"]
+
+
+def test_parse_video_response_accepts_flow_workflows_media_shape() -> None:
+    parsed = flowkit_cli._parse_video_response(
+        {
+            "workflows": [{"name": "operations/video-123", "status": "RUNNING"}],
+            "media": [{"name": "media/video-456"}],
+        }
+    )
+
+    assert parsed["workflow_id"] == "operations/video-123"
+    assert parsed["video_media_id"] == "media/video-456"
+    assert parsed["status"] == "RUNNING"
+
+
+def test_transient_media_error_matches_flow_pending_envelope() -> None:
+    assert flowkit_cli._is_transient_media_error(
+        {
+            "ok": False,
+            "detail": {"error": {"code": 404, "status": "NOT_FOUND"}},
+        }
+    )
+    assert flowkit_cli._is_transient_media_error(
+        {
+            "ok": False,
+            "detail": {"error": {"code": 500, "status": "INTERNAL"}},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_video_uploads_start_image_before_submit(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_ensure_project(client, **kwargs):
+        return "project-1"
+
+    async def fake_create_video(client, **kwargs):
+        return "video-1"
+
+    async def fake_create_scene(client, **kwargs):
+        return "scene-1"
+
+    async def fake_upload_image(args):
+        captured["upload_path"] = args.image_path
+        captured["upload_project_id"] = args.project_id
+        return {"ok": True, "media_id": "media/start-image-1"}
+
+    async def fake_request_json(
+        client, method, path, *, json_body=None, timeout_s=None
+    ):
+        captured["method"] = method
+        captured["path"] = path
+        captured["body"] = json_body
+        return {
+            "workflows": [{"name": "operations/video-1"}],
+            "media": [{"name": "media/video-1"}],
+        }
+
+    monkeypatch.setattr(flowkit_cli, "_ensure_project", fake_ensure_project)
+    monkeypatch.setattr(flowkit_cli, "_create_video", fake_create_video)
+    monkeypatch.setattr(flowkit_cli, "_create_scene", fake_create_scene)
+    monkeypatch.setattr(flowkit_cli, "action_upload_image", fake_upload_image)
+    monkeypatch.setattr(flowkit_cli, "_request_json", fake_request_json)
+
+    result = await flowkit_cli.action_generate_video(
+        Namespace(
+            base_url="http://127.0.0.1:8100",
+            timeout=1.0,
+            video_timeout=1.0,
+            project_id="",
+            project="wr2-test",
+            material="realistic",
+            language="en",
+            video_id="",
+            scene_id="",
+            prompt="0-8s: editorial dolly.",
+            orientation="PORTRAIT",
+            start_image_media_id="",
+            start_image_path="/tmp/zer.jpg",
+            paygate_tier="PAYGATE_TIER_TIER1P5",
+            dest="",
+            poll_interval=0.01,
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["start_image_media_id"] == "media/start-image-1"
+    assert captured["upload_path"] == "/tmp/zer.jpg"
+    assert captured["upload_project_id"] == "project-1"
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/api/flow/generate-video"
+    assert captured["body"]["start_image_media_id"] == "media/start-image-1"
+    assert captured["body"]["user_paygate_tier"] == "PAYGATE_TIER_TIER1P5"


### PR DESCRIPTION
## Summary
- add a FlowKit JSON CLI for health, image upload, image generation, and video generation
- expose MCP FlowKit tools that route Air-M5/Mini calls through Pro, stage local assets, and copy outputs back
- fail closed on missing start images and classify Flow auth/model-access blockers explicitly
- document the WR2 FlowKit runbook for the next hero/video generation run

## Verification
- apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_flowkit_cli.py -q
- PYTHONPATH=apps/nuzantara-mcp apps/backend-rag/.venv/bin/python -m pytest apps/nuzantara-mcp/tests/test_tools_flowkit.py -q
- apps/backend-rag/.venv/bin/python -m ruff check scripts/flowkit_cli.py apps/nuzantara-mcp/nuzantara_mcp/tools/flowkit.py apps/nuzantara-mcp/tests/test_tools_flowkit.py scripts/tests/test_flowkit_cli.py
- apps/backend-rag/.venv/bin/python -m ruff format --check scripts/flowkit_cli.py apps/nuzantara-mcp/nuzantara_mcp/tools/flowkit.py apps/nuzantara-mcp/tests/test_tools_flowkit.py scripts/tests/test_flowkit_cli.py
- git diff --check

## Live FlowKit note
The bridge is code-ready, and M5-to-Pro asset staging was verified with /Users/balizero/Desktop/logo/zer.jpg. The current runtime blocker is Flow auth on Pro: /api/flow/credits returns an UNAUTHENTICATED error envelope even though the extension websocket is connected. Refresh the Flow tab and FlowKit extension token on Pro, then rerun flowkit_health before spending generation credits.