### PR TITLE
fix(hooks): tilde/env blind-spot in worktree_isolation target resolver

### DIFF
--- a/.github/workflows/guard-conformance.yml
+++ b/.github/workflows/guard-conformance.yml
@@ -83,6 +83,12 @@ jobs:
           set -euo pipefail
           python3 infra/claude-hooks/test_w85_stash_readonly.py
 
+      - name: Tilde/env target-resolver suite (blind-spot fixed 2026-07-06)
+        if: steps.relevant.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          python3 infra/claude-hooks/test_tilde_target_resolver.py
+
       # These two regression suites existed since W83/W84 but NO workflow
       # executed them (found by the red-team pass on this very PR: they only
       # satisfied substring arming via path-filter text — W81 theater).

--- a/infra/claude-hooks/test_tilde_target_resolver.py
+++ b/infra/claude-hooks/test_tilde_target_resolver.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tilde/env blind-spot in `_effective_git_target` — guilt+innocence suite.
+
+Found 2026-07-06 by the W85 live guilt-probe: `git -C ~/Desktop/nuzantara
+stash push` PASSED the live hook while the absolute-path form was correctly
+BLOCKED. Root cause: `_effective_git_target` returned the raw extracted token,
+and downstream `pathlib.Path('~/x').resolve()` is CWD-RELATIVE — the target
+never compared equal to REPO_ROOT, so the op fell into the conservative
+"allow_external" branch. Same class for `$HOME/...` / `${HOME}/...` forms.
+
+Fix under test: the extracted `-C` / `cd` token is passed through
+`os.path.expandvars(os.path.expanduser(...))` at the single choke point, so
+both consumers (allowed-worktree check and repo-root comparison) see what the
+shell will actually touch.
+
+  GUILT     — tilde/env forms of a main-checkout target must resolve to the
+              same absolute path the shell would use (the downstream block
+              then fires exactly like the absolute form).
+  INNOCENCE — absolute and relative externals are untouched; unknown `$VARS`
+              stay literal (expandvars semantics); no `-C`/`cd` → default cwd.
+
+    python3 infra/claude-hooks/test_tilde_target_resolver.py
+Exit 0 = resolver mirrors shell expansion. Exit 1 = regression.
+
+Reference: PENDING-ARMS tilde blind-spot line · superscar #3 (the resolver
+sits UPSTREAM of BLOCKED_SUBCMD_RE: a target the resolver cannot see makes
+the best regex irrelevant).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("wi_tilde", str(HERE / "worktree_isolation.py"))
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    mod = _load_module()
+    fx = mod._effective_git_target
+    home = os.path.expanduser("~")
+    failures: list[str] = []
+
+    def check(label: str, cmd: str, cwd: str, expected: str) -> None:
+        got = fx(cmd, cwd)
+        if got != expected:
+            failures.append(f"{label}: {cmd!r} → {got!r}, expected {expected!r}")
+
+    # GUILT — shell-expandable forms of a main-checkout target must expand.
+    check("guilt tilde -C", "git -C ~/Desktop/nuzantara stash push -m x", "/tmp",
+          f"{home}/Desktop/nuzantara")
+    check("guilt $HOME -C", "git -C $HOME/Desktop/nuzantara stash pop", "/tmp",
+          f"{home}/Desktop/nuzantara")
+    check("guilt ${HOME} -C", "git -C ${HOME}/Desktop/nuzantara reset --hard", "/tmp",
+          f"{home}/Desktop/nuzantara")
+    check("guilt tilde cd", "cd ~/Desktop/nuzantara && git pull", "/tmp",
+          f"{home}/Desktop/nuzantara")
+    check("guilt $HOME cd", "cd $HOME/Desktop/nuzantara ; git merge x", "/tmp",
+          f"{home}/Desktop/nuzantara")
+
+    # GUILT end-to-end shape: expanded tilde target now resolves EQUAL to the
+    # absolute form — the exact comparison the block decision uses.
+    tilde_resolved = pathlib.Path(fx("git -C ~/Desktop/nuzantara stash push", "/tmp")).resolve()
+    abs_resolved = pathlib.Path(f"{home}/Desktop/nuzantara").resolve()
+    if tilde_resolved != abs_resolved:
+        failures.append(
+            f"guilt e2e: tilde target resolves to {tilde_resolved}, absolute form to "
+            f"{abs_resolved} — the downstream repo-root comparison would still diverge"
+        )
+
+    # INNOCENCE — untouched cases.
+    check("innocence absolute", "git -C /tmp/elsewhere pull", "/x", "/tmp/elsewhere")
+    check("innocence relative", "git -C sub/dir pull", "/x", "sub/dir")
+    check("innocence no -C/cd", "git pull", "/some/cwd", "/some/cwd")
+    unknown = fx("git -C $__NUZ_NO_SUCH_VAR__/repo pull", "/x")
+    if unknown != "$__NUZ_NO_SUCH_VAR__/repo":
+        failures.append(
+            f"innocence unknown-var: expected literal passthrough, got {unknown!r}"
+        )
+    # mid-token tilde is NOT a home reference in shell — expanduser leaves it.
+    check("innocence mid-token tilde", "git -C /data/ver~2/repo pull", "/x", "/data/ver~2/repo")
+
+    if failures:
+        print("TILDE RESOLVER FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print(f"=== ALL {5 + 1 + 5} OK — resolver mirrors shell expansion; externals untouched ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -530,13 +530,22 @@ def _effective_git_target(cmd: str, default_cwd: str) -> str:
     """Determine the effective working dir for git command.
 
     Priority: `git -C <path>` > `cd <path> && git` > default cwd.
+
+    Tilde/env blind-spot fix (2026-07-06, found by the W85 live guilt-probe):
+    the extracted token is expanded the way the shell will (`~`, `$HOME`,
+    `${HOME}`) BEFORE downstream resolution — an unexpanded `~/Desktop/...`
+    used to defeat the realpath comparison (Path('~/x').resolve() is
+    cwd-relative), letting a mutating git op against main pass when written
+    with a tilde while the absolute form was correctly blocked. Expansion
+    mirrors shell semantics, so it can only move the verdict TOWARD the
+    truth of what the command will actually touch.
     """
     m = GIT_C_RE.search(cmd)
     if m:
-        return m.group(1)
+        return os.path.expandvars(os.path.expanduser(m.group(1)))
     m = CD_GIT_RE.search(cmd)
     if m:
-        return m.group(1)
+        return os.path.expandvars(os.path.expanduser(m.group(1)))
     return default_cwd
 
 

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -173,6 +173,12 @@
               "tests": [
                 "infra/claude-hooks/test_w79_shell_write.py"
               ]
+            },
+            "_effective_git_target": {
+              "tests": [
+                "infra/claude-hooks/test_tilde_target_resolver.py"
+              ],
+              "note": "tilde/env blind-spot fixed 2026-07-06 (expanduser+expandvars at the single choke point; found by the W85 live guilt-probe \u2014 the resolver sits UPSTREAM of BLOCKED_SUBCMD_RE)"
             }
           },
           "also_covered_by": [


### PR DESCRIPTION
Found by the W85 live guilt-probe (2026-07-06): `git -C ~/Desktop/nuzantara
stash push` PASSED the live hook while the absolute-path form was correctly
BLOCKED. `_effective_git_target` returned the raw extracted token and
downstream `Path('~/x').resolve()` is cwd-relative, so the target never
compared equal to REPO_ROOT and the op fell into the conservative
"allow_external" branch. Same class for `$HOME` / `${HOME}` forms.

Fix at the single choke point: the extracted `-C`/`cd` token goes through
`os.path.expandvars(os.path.expanduser(...))` — expansion mirrors shell
semantics, so it can only move the verdict toward what the command will
actually touch. Both consumers (allowed-worktree check and repo-root
comparison) now see the expanded form.

New guilt+innocence suite test_tilde_target_resolver.py (11 cases: tilde /
$HOME / ${HOME} on -C and cd forms; absolute/relative externals untouched;
unknown vars stay literal; mid-token tilde not expanded). Registered under
`_effective_git_target` in the conformance registry and executed directly
by guard-conformance.yml (armed, not theater).

Full regression green: block_regex 20/20, W83 21/21, W84 22/22, W85 suite,
vaccine 34/34, conformance checker 0 violations.

Live ~/.claude/hooks fold follows the merge via the sanctioned
install_worktree_hooks.sh; the PENDING-ARMS line closes only after the
live tilde probe. Operator GO recorded ("approvato tutto, mergiate armate").

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
