### PR TITLE
fix(mouth): preserve interactive MDX props

### DIFF
--- a/apps/mouth/src/components/blog/MDXContentRSC.test.tsx
+++ b/apps/mouth/src/components/blog/MDXContentRSC.test.tsx
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import { renderToString } from "react-dom/server";
+import matter from "gray-matter";
+import { describe, expect, it } from "vitest";
+
+import { renderMDXBody } from "./MDXContentRSC";
+
+function stripImports(content: string): string {
+  return content
+    .replace(/^import\s+[\s\S]*?from\s+['"][^'"]+['"];?\s*$/gm, "")
+    .replace(/^import\s*{[\s\S]*?}\s*from\s*['"][^'"]+['"];?\s*$/gm, "")
+    .trim();
+}
+
+describe("renderMDXBody", () => {
+  it("server-renders the driving license article interactive MDX body", async () => {
+    const articlePath = path.join(
+      process.cwd(),
+      "src/content/articles/lifestyle/driving-license-foreigners.mdx",
+    );
+    const articleFile = fs.readFileSync(articlePath, "utf8");
+    const { content } = matter(articleFile);
+
+    const mdxBody = await renderMDXBody(stripImports(content));
+
+    const html = renderToString(<>{mdxBody}</>);
+
+    expect(html).toContain("Driving License for Foreigners in Indonesia 2026");
+    expect(html).toContain("How long are you staying in Indonesia?");
+    expect(html).toContain("Prepare Documents");
+    expect(html).not.toContain("Decision tree unavailable");
+    expect(html).not.toContain("Journey map unavailable");
+  });
+});

--- a/apps/mouth/src/components/blog/MDXContentRSC.tsx
+++ b/apps/mouth/src/components/blog/MDXContentRSC.tsx
@@ -40,6 +40,11 @@ export async function renderMDXBody(source: string): Promise<ReactNode> {
     source,
     components: mdxComponents,
     options: {
+      // These MDX files are local, versioned article sources. The interactive
+      // article components rely on array/object props such as nodes={[...]} and
+      // steps={[...]}; next-mdx-remote removes those by default as "remote" JS.
+      blockJS: false,
+      blockDangerousJS: true,
       mdxOptions: {
         remarkPlugins: [remarkGfm],
         development: false,

--- a/apps/mouth/src/components/blog/interactive/DecisionTree.tsx
+++ b/apps/mouth/src/components/blog/interactive/DecisionTree.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   ChevronRight,
@@ -19,9 +19,9 @@ import { cn } from "@/lib/utils";
 
 export interface DecisionNode {
   id: string;
-  question: string;
+  question?: string;
   description?: string;
-  options: DecisionOption[];
+  options?: DecisionOption[];
   /** If true, this is a final result node */
   isResult?: boolean;
   /** Result details (only for result nodes) */
@@ -42,7 +42,9 @@ export interface DecisionOption {
   description?: string;
   icon?: string;
   /** ID of the next node */
-  nextNodeId: string;
+  nextNodeId?: string;
+  /** Legacy MDX field used by older articles */
+  next?: string;
 }
 
 export interface DecisionTreeProps {
@@ -54,7 +56,7 @@ export interface DecisionTreeProps {
   subtitle?: string;
   description?: string;
   /** All nodes in the tree */
-  nodes: DecisionNode[];
+  nodes?: DecisionNode[];
   /** ID of the starting node (defaults to "start" or first node) */
   startNodeId?: string;
   /** Show progress indicator */
@@ -117,12 +119,14 @@ export function DecisionTree({
   onComplete,
   className,
 }: DecisionTreeProps) {
+  const safeNodes = useMemo(() => normalizeDecisionNodes(nodes), [nodes]);
+
   // Compute defaults
   const effectiveId = id || title.toLowerCase().replace(/\s+/g, "-");
   const effectiveStartNodeId =
     startNodeId ||
-    nodes.find((n) => n.id === "start")?.id ||
-    nodes[0]?.id ||
+    safeNodes.find((n) => n.id === "start")?.id ||
+    safeNodes[0]?.id ||
     "";
   const effectiveSubtitle = subtitle || description;
 
@@ -132,10 +136,13 @@ export function DecisionTree({
 
   // Get current node
   const currentNodeId = path[path.length - 1];
-  const currentNode = nodes.find((n) => n.id === currentNodeId);
+  const currentNode = safeNodes.find((n) => n.id === currentNodeId);
 
   // Calculate progress
-  const nodesMap = new Map(nodes.map((n) => [n.id, n]));
+  const nodesMap = useMemo(
+    () => new Map(safeNodes.map((n) => [n.id, n])),
+    [safeNodes],
+  );
   const maxDepth = calculateMaxDepth(nodesMap, effectiveStartNodeId);
   const progress =
     maxDepth > 0 ? Math.min(((path.length - 1) / maxDepth) * 100, 100) : 0;
@@ -170,6 +177,19 @@ export function DecisionTree({
   const handleRestart = useCallback(() => {
     setPath([effectiveStartNodeId]);
   }, [effectiveStartNodeId]);
+
+  if (safeNodes.length === 0) {
+    return (
+      <div
+        className={cn(
+          "bg-black/40 rounded-2xl border border-white/10 p-6",
+          className,
+        )}
+      >
+        <p className="text-white/60">Decision tree unavailable</p>
+      </div>
+    );
+  }
 
   if (!currentNode) {
     return (
@@ -271,18 +291,14 @@ export function DecisionTree({
                       onClick={() => setPath(path.slice(0, index + 1))}
                       className="hover:text-white/60 transition-colors truncate max-w-[150px]"
                     >
-                      {node.question.length > 30
-                        ? node.question.slice(0, 30) + "..."
-                        : node.question}
+                      {formatNodeLabel(node)}
                     </button>
                     <ChevronRight className="w-3 h-3 flex-shrink-0" />
                   </React.Fragment>
                 );
               })}
               <span className="text-white/60 truncate max-w-[150px]">
-                {currentNode.question.length > 30
-                  ? currentNode.question.slice(0, 30) + "..."
-                  : currentNode.question}
+                {formatNodeLabel(currentNode)}
               </span>
             </div>
           </div>
@@ -303,6 +319,8 @@ function QuestionView({
   node: DecisionNode;
   onSelect: (nextNodeId: string) => void;
 }) {
+  const options = node.options || [];
+
   return (
     <div>
       {/* Question */}
@@ -311,7 +329,9 @@ function QuestionView({
           <HelpCircle className="w-5 h-5" />
         </div>
         <div>
-          <h4 className="text-lg font-medium text-white">{node.question}</h4>
+          <h4 className="text-lg font-medium text-white">
+            {node.question || "Choose an option"}
+          </h4>
           {node.description && (
             <p className="text-white/60 text-sm mt-1">{node.description}</p>
           )}
@@ -320,13 +340,18 @@ function QuestionView({
 
       {/* Options */}
       <div className="space-y-3">
-        {node.options.map((option, index) => (
+        {options.length === 0 && (
+          <div className="p-4 rounded-xl bg-white/5 border border-white/10 text-white/60">
+            No decision options available.
+          </div>
+        )}
+        {options.map((option, index) => (
           <motion.button
-            key={option.nextNodeId}
+            key={option.nextNodeId || option.label}
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: index * 0.05 }}
-            onClick={() => onSelect(option.nextNodeId)}
+            onClick={() => option.nextNodeId && onSelect(option.nextNodeId)}
             className={cn(
               "w-full p-4 rounded-xl text-left",
               "bg-white/5 hover:bg-white/10 border border-white/10 hover:border-accent-blue-editorial/50",
@@ -476,20 +501,53 @@ function ResultView({
 
 function calculateMaxDepth(
   nodesMap: Map<string, DecisionNode>,
-  nodeId: string,
+  nodeId: string | undefined,
   visited = new Set<string>(),
 ): number {
+  if (!nodeId) return 0;
   if (visited.has(nodeId)) return 0;
   visited.add(nodeId);
 
   const node = nodesMap.get(nodeId);
-  if (!node || node.isResult || !node.options.length) return 0;
+  const options = node?.options || [];
+  if (!node || node.isResult || options.length === 0) return 0;
 
   let maxChildDepth = 0;
-  for (const option of node.options) {
+  for (const option of options) {
     const childDepth = calculateMaxDepth(nodesMap, option.nextNodeId, visited);
     maxChildDepth = Math.max(maxChildDepth, childDepth);
   }
 
   return 1 + maxChildDepth;
+}
+
+function normalizeDecisionNodes(
+  nodes: DecisionNode[] | undefined,
+): DecisionNode[] {
+  if (!Array.isArray(nodes)) return [];
+
+  return nodes
+    .filter((node) => node && typeof node.id === "string")
+    .map((node) => ({
+      ...node,
+      question: node.question || node.result?.title || "",
+      isResult: Boolean(node.isResult || node.result),
+      options: Array.isArray(node.options)
+        ? node.options
+            .map((option) => ({
+              ...option,
+              nextNodeId: option.nextNodeId || option.next,
+            }))
+            .filter(
+              (option): option is DecisionOption & { nextNodeId: string } =>
+                typeof option.nextNodeId === "string" &&
+                option.nextNodeId.length > 0,
+            )
+        : [],
+    }));
+}
+
+function formatNodeLabel(node: DecisionNode): string {
+  const label = node.question || node.result?.title || node.id;
+  return label.length > 30 ? `${label.slice(0, 30)}...` : label;
 }

--- a/apps/mouth/src/components/blog/interactive/JourneyMap.tsx
+++ b/apps/mouth/src/components/blog/interactive/JourneyMap.tsx
@@ -45,10 +45,14 @@ export interface JourneyMapProps {
   title: string;
   /** Subtitle */
   subtitle?: string;
+  /** Legacy MDX alias for subtitle */
+  description?: string;
   /** Steps */
-  steps: JourneyStep[];
+  steps?: JourneyStep[];
   /** Total estimated duration */
   totalDuration?: string;
+  /** Legacy MDX alias for totalDuration */
+  estimatedTotal?: string;
   /** Total estimated cost */
   totalCost?: string | number;
   /** Show fast track option */
@@ -68,8 +72,10 @@ export interface JourneyMapProps {
 export function JourneyMap({
   title,
   subtitle,
+  description,
   steps,
   totalDuration,
+  estimatedTotal,
   totalCost,
   showFastTrack = false,
   fastTrackSteps,
@@ -79,8 +85,15 @@ export function JourneyMap({
   const [selectedStep, setSelectedStep] = useState<string | null>(null);
   const [isFastTrack, setIsFastTrack] = useState(false);
 
-  const activeSteps = isFastTrack && fastTrackSteps ? fastTrackSteps : steps;
+  const baseSteps = Array.isArray(steps) ? steps : [];
+  const alternativeSteps = Array.isArray(fastTrackSteps)
+    ? fastTrackSteps
+    : undefined;
+  const activeSteps =
+    isFastTrack && alternativeSteps ? alternativeSteps : baseSteps;
   const selectedStepData = activeSteps.find((s) => s.id === selectedStep);
+  const effectiveSubtitle = subtitle || description;
+  const effectiveTotalDuration = totalDuration || estimatedTotal;
 
   // Calculate totals
   const calculatedDuration = activeSteps.reduce((acc, step) => {
@@ -92,6 +105,19 @@ export function JourneyMap({
     if (typeof step.cost === "number") return acc + step.cost;
     return acc;
   }, 0);
+
+  if (activeSteps.length === 0) {
+    return (
+      <div
+        className={cn(
+          "bg-black/40 rounded-2xl border border-white/10 p-6",
+          className,
+        )}
+      >
+        <p className="text-white/60">Journey map unavailable</p>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -107,13 +133,13 @@ export function JourneyMap({
             <h3 className="font-serif text-xl font-semibold text-white">
               {title}
             </h3>
-            {subtitle && (
-              <p className="text-white/60 text-sm mt-1">{subtitle}</p>
+            {effectiveSubtitle && (
+              <p className="text-white/60 text-sm mt-1">{effectiveSubtitle}</p>
             )}
           </div>
 
           {/* Fast track toggle */}
-          {showFastTrack && fastTrackSteps && (
+          {showFastTrack && alternativeSteps && (
             <button
               onClick={() => setIsFastTrack(!isFastTrack)}
               className={cn(
@@ -137,7 +163,7 @@ export function JourneyMap({
           <div className="flex items-center gap-2 text-white/60">
             <Clock className="w-4 h-4" />
             <span className="text-sm">
-              {totalDuration || `~${calculatedDuration} days`}
+              {effectiveTotalDuration || `~${calculatedDuration} days`}
             </span>
           </div>
           <div className="flex items-center gap-2 text-white/60">


### PR DESCRIPTION
## Summary
- preserve local MDX array/object JSX props during server-side article rendering
- harden DecisionTree and JourneyMap against missing legacy props
- add a regression test for /living/driving-license-foreigners interactive MDX rendering

## Verification
- npm test -- --run src/components/blog/MDXContentRSC.test.tsx
- npm run typecheck
- npm run build