### PR TITLE
fix(mouth): serve llms-full from generated asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -704,6 +704,7 @@ apps/evaluator/handoff/
 .windsurf/
 apps/mouth/public/kbli-navigator/images/base64_data.txt
 apps/mouth/public/llms-full.txt
+apps/mouth/public/static/ai/llms-full.txt
 apps/evaluator/indexing_state.json
 tmp_notebooklm/
 

--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -121,6 +121,17 @@ const nextConfig: NextConfig = {
     ],
   },
   // ⚡ Performance: Add cache headers for static assets
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: "/llms-full.txt",
+          destination: "/static/ai/llms-full.txt",
+        },
+      ],
+    };
+  },
+
   async headers() {
     return [
       {

--- a/apps/mouth/scripts/generate-llms-full.ts
+++ b/apps/mouth/scripts/generate-llms-full.ts
@@ -15,7 +15,10 @@ const KBLI_DATA_PATH = path.join(
   process.cwd(),
   "data/KBLI_2025_FINAL_CLEAN.json",
 );
-const OUTPUT_EN = path.join(process.cwd(), "public/llms-full.txt");
+const OUTPUT_EN = path.join(
+  process.cwd(),
+  "public/static/ai/llms-full.txt",
+);
 const OUTPUT_ID = path.join(process.cwd(), "public/llms-id.txt");
 const OUTPUT_KBLI = path.join(process.cwd(), "public/llms-kbli.txt");
 const LLMS_TXT_PATH = path.join(process.cwd(), "public/llms.txt");
@@ -88,6 +91,7 @@ async function generate() {
   enArticles.forEach((a) => {
     enContent += `\n---\nTITLE: ${a.title}\nCATEGORY: ${a.category}\nURL: ${a.url}\nPUBLISHED: ${a.publishedAt}\n\n### ZANTARA AI SUMMARY\n${a.excerpt}\n\nCONTENT:\n${a.content}\n`;
   });
+  fs.mkdirSync(path.dirname(OUTPUT_EN), { recursive: true });
   fs.writeFileSync(OUTPUT_EN, enContent);
 
   if (FULL_ONLY) {


### PR DESCRIPTION
## Summary
- generate `llms-full.txt` into an ignored static asset path during `apps/mouth` build
- rewrite `/llms-full.txt` before dynamic blog category routing so the public AI ingestion URL serves text, not an HTML category page
- keep the 22MB generated export out of git

## Verification
- `cd apps/mouth && npm run test -- src/lib/kbli-faq.test.ts --run`
- `cd apps/mouth && npm run typecheck`
- `cd apps/mouth && npm run lint` (0 errors, existing warnings only)
- `cd apps/mouth && npm run build`
- local `next start` smoke: `/llms-full.txt` returned `200`, `Content-Type: text/plain; charset=UTF-8`, 23.5MB, and AI text header
- local stale sweep: no `June 18, 2026` deadline copy in `apps/mouth/src`, `apps/mouth/public`, or `apps/mouth/data/kbli-gold-all.json`
