### PR TITLE
fix(mouth): ship llms-full asset outside static exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -704,7 +704,7 @@ apps/evaluator/handoff/
 .windsurf/
 apps/mouth/public/kbli-navigator/images/base64_data.txt
 apps/mouth/public/llms-full.txt
-apps/mouth/public/static/ai/llms-full.txt
+apps/mouth/public/ai/llms-full.txt
 apps/evaluator/indexing_state.json
 tmp_notebooklm/
 

--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -126,7 +126,7 @@ const nextConfig: NextConfig = {
       beforeFiles: [
         {
           source: "/llms-full.txt",
-          destination: "/static/ai/llms-full.txt",
+          destination: "/ai/llms-full.txt",
         },
       ],
     };

--- a/apps/mouth/scripts/generate-llms-full.ts
+++ b/apps/mouth/scripts/generate-llms-full.ts
@@ -17,7 +17,7 @@ const KBLI_DATA_PATH = path.join(
 );
 const OUTPUT_EN = path.join(
   process.cwd(),
-  "public/static/ai/llms-full.txt",
+  "public/ai/llms-full.txt",
 );
 const OUTPUT_ID = path.join(process.cwd(), "public/llms-id.txt");
 const OUTPUT_KBLI = path.join(process.cwd(), "public/llms-kbli.txt");


### PR DESCRIPTION
## Summary
- Move the generated `llms-full.txt` public artifact from `public/static/ai` to `public/ai` because `public/static/**` is excluded from Vercel output tracing.
- Keep `/llms-full.txt` as the public URL via an exact `beforeFiles` rewrite to `/ai/llms-full.txt`.
- Keep the generated 22MB artifact ignored so builds produce it without committing it.

## Production context
Latest production after #2005 rewrote `/llms-full.txt` to `/static/ai/llms-full.txt`, but Vercel returned `x-matched-path: /404`. This patch ships the generated file outside the excluded `public/static/**` path.

## Verification
- `npm run test -- src/lib/kbli-faq.test.ts --run` (3 passed)
- `npm run typecheck`
- `npm run lint` (0 errors, existing warnings)
- `npm run build`
- Local `next start` smoke: `/llms-full.txt` returned `200 OK`, `Content-Type: text/plain; charset=UTF-8`, `Content-Length: 23526621`, and no stale `June 18, 2026` copy.
