### PR TITLE
feat(ops): codex-autofix reaper — autonomous reap every 48h

### DIFF
--- a/.github/workflows/codex-autofix-reaper.yml
+++ b/.github/workflows/codex-autofix-reaper.yml
@@ -1,24 +1,28 @@
-name: cron - codex autofix reaper (weekly report; manual reap)
+name: cron - codex autofix reaper (autonomous reap every 48h)
 
 # Garbage-collects the Codex auto-fix backlog (superscar #2: the nightly autofix generator
 # opens a PR + branch per failing CI run and never reaps them — they accrete for weeks).
 #
-# SCHEDULED runs are REPORT-ONLY: they print what is reapable and exit non-fatally. They NEVER
-# close a PR or delete a branch on their own — reaping is an explicit, human-triggered action
-# (workflow_dispatch with reap=true), because closing/deleting is outward-facing.
+# AUTONOMOUS: the scheduled run (every 48h) EXECUTES the reap directly (--reap --yes) — it
+# closes eligible PRs and deletes orphan branches on its own, no human in the loop. Every
+# action is reported to Telegram (audit trail), so a wrong reap is visible and reversible
+# (closed PRs reopen; deleted branches survive ~90d in GitHub's reflog + the closed PR).
 #
-# The reaper is conservative by construction (scripts/codex_autofix_reaper.py): it only touches
-# codex/auto-fix-ci-* branches, only closes a PR whose target workflow is green on main AND which
-# has no OTHER failing checks, and only deletes an orphan branch that is already on main by content
-# (blob-per-file, W88) or is a genuinely abandoned no-PR branch past --stale-days.
+# Safe-by-construction (scripts/codex_autofix_reaper.py), which is why autonomy is acceptable:
+#   - only ever touches codex/auto-fix-ci-* branches (anchored regex, never a human branch);
+#   - closes a PR ONLY if its target workflow is green on main AND it has NO other failing
+#     checks (the #1820 innocence guard — real unfinished work is never closed);
+#   - deletes an orphan branch ONLY if it has no open PR AND is already on main by content
+#     (blob-per-file, W88) or is a genuinely abandoned no-PR branch past --stale-days.
+# Kill switch: disable this workflow in the Actions tab, or delete the schedule block.
 
 on:
   schedule:
-    - cron: "0 22 * * 1" # 22:00 UTC Mon = 06:00 WITA Tue — after the weekly branch-cleanup window
+    - cron: "0 22 */2 * *" # every 48h at 22:00 UTC (06:00 WITA)
   workflow_dispatch:
     inputs:
-      reap:
-        description: "Actually close eligible PRs + delete orphan branches (default: report only)"
+      dry_run:
+        description: "Report only, do not reap (default: false — dispatch also reaps)"
         type: boolean
         default: false
       stale_days:
@@ -51,36 +55,53 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Report reapable backlog
-        id: report
+      - name: Reap (autonomous on schedule; --dry_run to preview via dispatch)
+        id: reap
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           STALE_DAYS: ${{ github.event.inputs.stale_days || '14' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           set -uo pipefail
-          # Validate stale_days is a bare integer before it reaches the CLI (defence-in-depth
-          # against workflow_dispatch input injection, even though only write-access users trigger it).
+          # Validate stale_days is a bare integer (defence-in-depth against dispatch input
+          # injection, even though only write-access users can trigger it).
           case "$STALE_DAYS" in
             ''|*[!0-9]*) echo "invalid stale_days: $STALE_DAYS" >&2; exit 2 ;;
           esac
+          REAP_FLAGS="--reap --yes"
+          if [ "$DRY_RUN" = "true" ]; then REAP_FLAGS=""; fi
+          # Capture output for both the step summary and the Telegram body.
           python3 scripts/codex_autofix_reaper.py \
             --repo "$REPO" \
             --stale-days "$STALE_DAYS" \
-            | tee "$GITHUB_STEP_SUMMARY"
+            $REAP_FLAGS 2>&1 | tee reaper-output.txt | tee "$GITHUB_STEP_SUMMARY"
+          # Persist a compact summary line + whether anything was reaped, for the notify step.
+          {
+            echo "reaped<<EOF"
+            grep -E "^(closed #|deleted branch)" reaper-output.txt || echo "(nothing reaped this cycle)"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Reap (manual dispatch only, reap=true)
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reap == 'true' }}
+      - name: Notify Telegram (only when something was actually reaped)
+        if: ${{ !cancelled() }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          STALE_DAYS: ${{ github.event.inputs.stale_days || '14' }}
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          REAPED: ${{ steps.reap.outputs.reaped }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -uo pipefail
-          case "$STALE_DAYS" in
-            ''|*[!0-9]*) echo "invalid stale_days: $STALE_DAYS" >&2; exit 2 ;;
+          [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing — skip"; exit 0; }
+          # Stay silent on quiet cycles: no message when nothing was reaped.
+          case "$REAPED" in
+            *"(nothing reaped this cycle)"*|"") echo "quiet cycle — no Telegram"; exit 0 ;;
           esac
-          python3 scripts/codex_autofix_reaper.py \
-            --repo "$REPO" \
-            --stale-days "$STALE_DAYS" \
-            --reap --yes
+          TEXT="🧹 <b>Codex auto-fix reaper</b> — autonomous cycle
+          ${REAPED}
+          Run: ${RUN_URL}"
+          curl -sS -m 10 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" \
+            -d "parse_mode=HTML" >/dev/null || true


### PR DESCRIPTION
## What changed (operator directive)

The reap is now **the system's own action**. Previously the scheduled run was report-only and reaping required a manual `workflow_dispatch`. Now the scheduled run **every 48h executes `--reap --yes` directly** — it closes eligible PRs and deletes orphan branches autonomously, no human in the loop.

## Why autonomy is safe here

The eligibility logic (unchanged `scripts/codex_autofix_reaper.py`, tests 5/5) is safe-by-construction:
- Only ever touches `codex/auto-fix-ci-*` branches (anchored regex — never a human branch).
- Closes a PR **only if** its target workflow is green on main **AND** it has no other failing checks (the #1820 innocence guard — real unfinished work is never closed).
- Deletes an orphan branch **only if** no open PR **AND** already-on-main-by-content (blob-per-file, W88) or a genuinely abandoned no-PR branch past `--stale-days`.

## The mitigation for a now-blind action

Every reap posts a **Telegram summary** (`closed #N` / `deleted branch X`) so a wrong reap is visible and reversible — closed PRs reopen, deleted branches survive ~90d in the reflog + the closed PR references them. Quiet cycles stay silent (no spam). `workflow_dispatch` keeps a `dry_run` input to preview without acting. Kill switch: disable the workflow in the Actions tab.

## Security
Telegram body + all dispatch inputs pass via `env:` (`stale_days` integer-validated); no untrusted value is interpolated into a `run:` block (security-hook honored).

## Test plan
- `pytest scripts/tests/test_codex_autofix_reaper.py -q` → 5 passed.
- Live dry-run: correctly flags #1909 (obsolete `codex/auto-fix-ci-*`, target green on main, CONFLICTING → serves no one) as the one close-eligible PR — exactly what the autonomous cycle will reap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)