### PR TITLE
fix(mouth): track llms-full static asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -703,8 +703,6 @@ scripts/canva/output/
 apps/evaluator/handoff/
 .windsurf/
 apps/mouth/public/kbli-navigator/images/base64_data.txt
-apps/mouth/public/llms-full.txt
-apps/mouth/public/ai/llms-full.txt
 apps/evaluator/indexing_state.json
 tmp_notebooklm/
 

--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -120,18 +120,6 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  // ⚡ Performance: Add cache headers for static assets
-  async rewrites() {
-    return {
-      beforeFiles: [
-        {
-          source: "/llms-full.txt",
-          destination: "/ai/llms-full.txt",
-        },
-      ],
-    };
-  },
-
   async headers() {
     return [
       {

--- a/apps/mouth/scripts/generate-llms-full.ts
+++ b/apps/mouth/scripts/generate-llms-full.ts
@@ -15,10 +15,7 @@ const KBLI_DATA_PATH = path.join(
   process.cwd(),
   "data/KBLI_2025_FINAL_CLEAN.json",
 );
-const OUTPUT_EN = path.join(
-  process.cwd(),
-  "public/ai/llms-full.txt",
-);
+const OUTPUT_EN = path.join(process.cwd(), "public/llms-full.txt");
 const OUTPUT_ID = path.join(process.cwd(), "public/llms-id.txt");
 const OUTPUT_KBLI = path.join(process.cwd(), "public/llms-kbli.txt");
 const LLMS_TXT_PATH = path.join(process.cwd(), "public/llms.txt");


### PR DESCRIPTION
## Summary
- Track `apps/mouth/public/llms-full.txt` as a real public static asset so Vercel uploads it with the source bundle.
- Remove the `/llms-full.txt` rewrite; the file is now served directly from `public/llms-full.txt` before dynamic blog routes can match it.
- Keep the generator output path aligned with the tracked public asset.

## Production context
PR #2006 made local serving correct but production still returned HTML for `/llms-full.txt`: `x-nextjs-rewritten-path: /ai/llms-full.txt` and `x-matched-path: /[category]/[slug]`. That means the ignored/generated public asset was not available in the Vercel deployment package. This patch makes the asset explicit and tracked.

## Verification
- `npm run build`
- `npm run test -- src/lib/kbli-faq.test.ts --run` (3 passed)
- `npm run typecheck`
- `npm run lint` (0 errors, existing warnings)
- Local `next start` smoke: `/llms-full.txt` returned `200 OK`, `Content-Type: text/plain; charset=UTF-8`, `Content-Length: 23526621`, no HTML, and no stale `June 18, 2026` copy.
