### PR TITLE
fix(healer): headless spawn hardening — two overlapping silent hangs cured

### DIFF
--- a/infra/healer/healer-run.sh
+++ b/infra/healer/healer-run.sh
@@ -140,11 +140,26 @@ fi
 
 SESSION_LOG="$LOG_DIR/session-$(date +%Y%m%d-%H%M%S).log"
 export HEALER_RUN=1
+# Headless hardening (first-tick autopsy 2026-07-06, two OVERLAPPING silent
+# hangs — 0 bytes out, 0 CPU): (a) --dangerously-skip-permissions has a
+# ONE-TIME interactive acceptance; in -p/no-TTY it hangs invisibly — the
+# machine needs `bypassPermissionsModeAccepted: true` in ~/.claude.json
+# (armed on Mini 2026-07-06); (b) untrusted cwd triggers the folder-trust
+# dialog, same invisible hang (tests from $HOME hung; from the repo they
+# PONG) — the cd "$REPO" above is load-bearing, keep it before this spawn.
+# Belt-and-suspenders: MAX env token when available (Keychain reads can
+# block under launchd/sshd, W84 family), closed stdin, and a zeroed MCP set
+# (the healer's perimeter is git/bash/file work; every configured MCP server
+# is a synchronous-init hang risk in -p mode).
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -n "${CLAUDE_CODE_OAUTH_TOKEN_1:-}" ]; then
+    export CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN_1"
+fi
 "$CLAUDE_BIN" -p "$(cat "$MANDATE")
 
 CONTESTO DI QUESTO TICK — receptor scattati: ${REASONS}" \
     --model "$MODEL" --dangerously-skip-permissions \
-    > "$SESSION_LOG" 2>&1 &
+    --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
+    </dev/null > "$SESSION_LOG" 2>&1 &
 CPID=$!
 
 # wall-clock watchdog (macOS has no timeout(1))


### PR DESCRIPTION
First induced healer tick hung silently (0 CPU, 0 output, 10+ min). Autopsy found **two overlapping invisible hangs** in claude -p/no-TTY mode:

1. **`--dangerously-skip-permissions` one-time acceptance** — renders nothing headless, hangs forever. Cured machine-side (`bypassPermissionsModeAccepted: true` on Mini) + documented at the spawn site.
2. **Folder-trust dialog on untrusted cwd** — probes from `$HOME` hung; from the repo: PONG in seconds. `cd "$REPO"` is now marked load-bearing.

Belt-and-suspenders added to the spawn: MAX env token fallback (W84 Keychain family — same cure as the regulatory wrapper, PR #1999), closed stdin (codex stdin lesson), zeroed MCP set (`--strict-mcp-config --mcp-config '{"mcpServers":{}}'` — the healer's perimeter is git/bash/file work and every configured MCP server is a synchronous-init hang risk).

**Proof**: PONG in <35s on Mini with the exact healer flag combination. Installer session re-arms the pair and re-kickstarts immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)