### PR TITLE
feat(hooks): worktree_isolation allows ff-only pull on tracked-clean main

### DIFF
--- a/infra/claude-hooks/test_ffonly_pull_exception.py
+++ b/infra/claude-hooks/test_ffonly_pull_exception.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""ff-only pull exception — guilt+innocence (2026-07-06, Zero directive).
+
+The worktree_isolation hook blocks every mutating git op in the MAIN checkout
+(superscar #5 sibling-race antidote). Zero's directive 2026-07-06: sessions must
+be able to self-align the fleet's main checkouts without waiting for the
+operator. The narrow exception: `git pull --ff-only` targeting main is allowed
+IFF the main tree is clean of TRACKED modifications — the one mutating git op
+that cannot race a sibling (HEAD moves forward only; git aborts the ff itself
+if a tracked file would collide).
+
+  GUILT     (the guard still bites): bare `git pull`, `pull --rebase`,
+            compound `pull --ff-only && git checkout`, --ff-only hidden in a
+            quoted literal, checkout/merge/stash — none open the exception;
+            a tracked-dirty main keeps it shut; a failed probe keeps it shut
+            (fail-closed: loosening on uncertainty would invert the guard).
+  INNOCENCE (the exception opens): `git pull --ff-only [origin main]` and
+            `git -C <main> pull --ff-only` on a tracked-clean tree pass;
+            untracked files (scratch/) do not gate it.
+
+    python3 infra/claude-hooks/test_ffonly_pull_exception.py
+Exit 0 = exception opens only for the sibling-race-free op. Exit 1 = regression.
+
+Reference: cicatrix-superscar.md #3/#5 · registry: infra/guard-conformance/registry.json
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("wi_ffonly", str(HERE / "worktree_isolation.py"))
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _git(repo: pathlib.Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True,
+        env={"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+             "HOME": str(repo), "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"},
+    )
+
+
+def main() -> int:
+    mod = _load_module()
+    strip = mod._strip_noise
+    only_pull = mod._only_ffonly_pull
+    failures: list[str] = []
+
+    # ---- GUILT: commands that must NOT open the exception -------------------
+    guilty = [
+        "git pull",                                            # no --ff-only
+        "git pull origin main",                                # no --ff-only
+        "git pull --rebase",                                   # rebase
+        "git pull --rebase --ff-only",                         # rebase wins
+        "git pull --ff-only && git checkout main",             # compound: checkout
+        "git checkout feature && git pull --ff-only",          # compound: checkout
+        "git merge origin/main",                               # not a pull at all
+        "git stash && git pull --ff-only",                     # compound: stash push
+        'echo "--ff-only" && git pull',                        # flag only in a quoted literal
+        "git checkout x",                                      # no pull
+    ]
+    for cmd in guilty:
+        if only_pull(strip(cmd)):
+            failures.append(f"GUILT: exception wrongly opens for: {cmd!r}")
+
+    # ---- INNOCENCE: commands that must open the (command-side) exception ----
+    innocent = [
+        "git pull --ff-only",
+        "git pull --ff-only origin main",
+        "git pull origin main --ff-only",
+        "git -C /Users/x/Desktop/nuzantara pull --ff-only origin main",
+        "cd /Users/x/Desktop/nuzantara && git pull --ff-only",
+    ]
+    for cmd in innocent:
+        if not only_pull(strip(cmd)):
+            failures.append(f"INNOCENCE: exception fails to open for: {cmd!r}")
+
+    # ---- tree-clean probe on a fixture repo ---------------------------------
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td) / "fixture"
+        repo.mkdir()
+        _git(repo, "init", "-q")
+        (repo / "a.txt").write_text("one\n")
+        _git(repo, "add", "a.txt")
+        _git(repo, "commit", "-qm", "init")
+
+        mod.REPO_ROOT = str(repo)  # point the probe at the fixture
+
+        # clean tree → probe True (innocence)
+        if not mod._main_tree_tracked_clean():
+            failures.append("INNOCENCE: clean fixture tree reported dirty")
+
+        # untracked file must NOT gate the exception (innocence)
+        (repo / "scratch.txt").write_text("untracked\n")
+        if not mod._main_tree_tracked_clean():
+            failures.append("INNOCENCE: untracked file wrongly gates the probe")
+
+        # tracked modification MUST gate it (guilt)
+        (repo / "a.txt").write_text("two\n")
+        if mod._main_tree_tracked_clean():
+            failures.append("GUILT: tracked-dirty tree reported clean")
+
+        # probe failure → shut (guilt / fail-closed): nonexistent repo root
+        mod.REPO_ROOT = str(pathlib.Path(td) / "does-not-exist")
+        if mod._main_tree_tracked_clean():
+            failures.append("GUILT: probe failure wrongly opens the exception")
+
+    if failures:
+        print("FAIL — ff-only pull exception regressions:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("OK — exception opens only for ff-only pull on a tracked-clean main "
+          f"({len(guilty)} guilt + {len(innocent)} innocence + 4 probe cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -549,6 +549,47 @@ def _effective_git_target(cmd: str, default_cwd: str) -> str:
     return default_cwd
 
 
+# --- ff-only pull exception (2026-07-06, Zero directive: sessions self-align) -----
+# `git pull --ff-only` on a tracked-clean main checkout is the ONE mutating git op
+# that cannot cause a sibling-race: it only moves HEAD forward along origin (no
+# history rewrite, no working-tree merge; git itself aborts the ff if a tracked
+# file would collide). Blocking it forced every fleet main-checkout alignment to
+# wait for the operator (PENDING-ALIGN ledger lines). The exception is deliberately
+# narrow (anti-#3, both signs):
+#   - EVERY blocked-verb match in the command must be `pull` (a compound like
+#     `git pull --ff-only && git checkout x` still blocks on the checkout);
+#   - `--ff-only` must appear in the noise-stripped command (a flag hiding inside
+#     a quoted literal does not count) and `--rebase` must not;
+#   - the main checkout must be clean of TRACKED modifications (untracked files
+#     like scratch/ don't gate an ff pull). Probe failure → exception does NOT
+#     open (fail-closed toward the historical block, unlike the hook's usual
+#     negative-gating: loosening a guard on uncertainty would invert its point).
+
+def _only_ffonly_pull(cmd_scan: str) -> bool:
+    """True iff the command's only blocked git verb(s) are `pull`, with --ff-only
+    and without --rebase — evaluated on the noise-stripped command."""
+    verbs = [m.group(1) for m in BLOCKED_SUBCMD_RE.finditer(cmd_scan)]
+    # group(1) is None for the commit -a / add -A alternation branches → not a pull.
+    if not verbs or any(v != "pull" for v in verbs):
+        return False
+    if "--ff-only" not in cmd_scan or "--rebase" in cmd_scan:
+        return False
+    return True
+
+
+def _main_tree_tracked_clean() -> bool:
+    """Tracked-files-clean probe of the MAIN checkout (untracked ignored).
+    Any probe failure returns False → the ff-only exception stays shut."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", REPO_ROOT, "status", "--porcelain", "--untracked-files=no"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return False
+    return r.returncode == 0 and r.stdout.strip() == ""
+
+
 def _n_alive_cached() -> int:
     try:
         return int(pathlib.Path(ALIVE_COUNT_CACHE).read_text().strip())
@@ -675,6 +716,12 @@ def main():
     repo_real = pathlib.Path(REPO_ROOT).resolve()
     if target_real != repo_real:
         _probe_log(payload, "allow_external")
+        sys.exit(0)
+
+    # ff-only pull on a tracked-clean main is sibling-race-free → allow (see the
+    # exception block above for the full rationale and its fail-closed posture).
+    if _only_ffonly_pull(cmd_scan) and _main_tree_tracked_clean():
+        _probe_log(payload, "allow_ffonly_pull_clean_main")
         sys.exit(0)
 
     # Block.

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Guard Conformance Registry (superscar #3 \u2014 over/under-match). Maps EVERY live textual guard to its GUILT proof (the guard fires on the historical bad case) and INNOCENCE proof (the guard does NOT fire on the adjacent legitimate case). Enforced by infra/guard-conformance/check_guard_conformance.py: a censused guard missing from here, a phantom test reference, or a test no CI workflow runs = FAIL. The mandate rule this executes: 'nessuna guardia mergiata senza un test di innocenza E di colpevolezza' (cicatrix-superscar.md #3). To add a guard: write both tests first, then register it here.",
+  "_doc": "Guard Conformance Registry (superscar #3 — over/under-match). Maps EVERY live textual guard to its GUILT proof (the guard fires on the historical bad case) and INNOCENCE proof (the guard does NOT fire on the adjacent legitimate case). Enforced by infra/guard-conformance/check_guard_conformance.py: a censused guard missing from here, a phantom test reference, or a test no CI workflow runs = FAIL. The mandate rule this executes: 'nessuna guardia mergiata senza un test di innocenza E di colpevolezza' (cicatrix-superscar.md #3). To add a guard: write both tests first, then register it here.",
   "version": 1,
   "surfaces": {
     "bridge_reply_guards": {
@@ -156,7 +156,7 @@
                 "infra/claude-hooks/test_block_regex.py",
                 "infra/claude-hooks/test_w85_stash_readonly.py"
               ],
-              "note": "W85 stash over-match FIXED 2026-07-06 (negative lookahead: read-only `stash list|show` pass, bare/mutating stash still blocked) \u2014 test_w85_stash_readonly.py converted from tripwire-pin to plain guilt+innocence per the pin's own instructions"
+              "note": "W85 stash over-match FIXED 2026-07-06 (negative lookahead: read-only `stash list|show` pass, bare/mutating stash still blocked) — test_w85_stash_readonly.py converted from tripwire-pin to plain guilt+innocence per the pin's own instructions"
             },
             "_is_remote_dispatch": {
               "tests": [
@@ -178,7 +178,13 @@
               "tests": [
                 "infra/claude-hooks/test_tilde_target_resolver.py"
               ],
-              "note": "tilde/env blind-spot fixed 2026-07-06 (expanduser+expandvars at the single choke point; found by the W85 live guilt-probe \u2014 the resolver sits UPSTREAM of BLOCKED_SUBCMD_RE)"
+              "note": "tilde/env blind-spot fixed 2026-07-06 (expanduser+expandvars at the single choke point; found by the W85 live guilt-probe — the resolver sits UPSTREAM of BLOCKED_SUBCMD_RE)"
+            },
+            "_only_ffonly_pull": {
+              "tests": [
+                "infra/claude-hooks/test_ffonly_pull_exception.py"
+              ],
+              "note": "ff-only pull exception (2026-07-06, Zero directive: sessions self-align fleet main checkouts): pull --ff-only on a tracked-clean main is allowed — the one mutating git op that cannot sibling-race. Fail-closed on probe failure. 10 guilt + 5 innocence + 4 probe cases."
             }
           },
           "also_covered_by": [
@@ -238,7 +244,7 @@
         }
       },
       "exempt": {
-        "infra/claude-hooks/dispatch_nudge.py": "advisory transcript reminder (CLAUDE.md \u00a77 T1.1) \u2014 emits a nudge, never blocks a command; no block/allow contract to test",
+        "infra/claude-hooks/dispatch_nudge.py": "advisory transcript reminder (CLAUDE.md §7 T1.1) — emits a nudge, never blocks a command; no block/allow contract to test",
         "scripts/hooks/check_import_chain.sh": "shell preflight, not a command-matching guard on model output",
         "scripts/hooks/check_protected_files.sh": "static path blocklist, exercised by hot-zone-pr-gate CI",
         "scripts/hooks/escalations_alert_sessionstart.sh": "SessionStart injector, never blocks",


### PR DESCRIPTION
## Cosa
Direttiva Zero 2026-07-06: le sessioni devono poter **auto-allineare i main checkout della flotta** senza aspettare l'operatore. Il hook `worktree_isolation` ora consente `git pull --ff-only` sul main SOLO se il tree è pulito di modifiche tracked — l'unica git-op mutante che non può causare sibling-race (#5): HEAD avanza soltanto, niente rewrite, e git stesso abortisce l'ff su collisione tracked.

## Perimetro (anti-#3, entrambi i segni)
- ogni verbo bloccato nel comando deve essere `pull` → compound con `checkout`/`stash` bloccano ancora;
- `--ff-only` deve sopravvivere al noise-strip (un flag dentro una stringa quotata non conta); `--rebase` squalifica;
- probe tree-clean **fail-closed**: su probe fallito l'eccezione resta CHIUSA (inverso del negative-gating abituale del hook — allentare una guardia sull'incertezza ne invertirebbe il senso).

## Prove
- `test_ffonly_pull_exception.py`: **10 guilt + 5 innocence + 4 probe cases**, tutti verdi.
- Regressione: `test_w85_stash_readonly.py`, `test_block_regex.py`, `test_w83_remote_dispatch.py` PASS.
- `check_guard_conformance.py`: 0 violazioni, nuovo symbol censito con proof guilt+innocence.

## Post-merge (ALIGN-FLEET, tracked)
Propagazione canon → `~/.claude/hooks/worktree_isolation.py` su M5+Pro+Mini con blob-proof (il live M5 è già stantio: manca W85+tilde — questa propagazione lo cura). Poi prova live: pull ff-only sul main M5 (10 commit dietro) attraversa il hook da solo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)