### PR TITLE
fix(reaper): W88 content check — Jules pilot output, verified

### DIFF
--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -623,7 +623,13 @@ def _branch_in_origin_main(worktree: Path) -> bool:
 
     Implementation: ``git -C <wt> merge-base --is-ancestor HEAD origin/main``
     (exit 0 ⇒ HEAD is an ancestor of origin/main ⇒ every commit is already in
-    main upstream; exit 1 ⇒ HEAD has commits NOT in origin/main).
+    main upstream; exit 1 ⇒ HEAD has commits NOT in origin/main — but the
+    ancestor test is a PROXY that lies on squash-merged/reworked branches
+    (W88), so exit 1 falls through to a blob-per-file CONTENT check: the
+    branch is merged iff every file it authored since its merge-base has the
+    same blob on origin/main. Never the three-dot diff — post-squash the
+    merge-base regresses and three-dot counts main's own progress as
+    branch-only changes, the W88 second-degree trap).
 
     Why ``origin/main`` and not local ``main`` or ``@{upstream}`` (the refuter
     killed both earlier designs):
@@ -654,8 +660,43 @@ def _branch_in_origin_main(worktree: Path) -> bool:
     if proc.returncode == 0:
         return True
     if proc.returncode == 1:
-        # HEAD has commits not in origin/main → unmerged work present.
-        return False
+        # Ancestor check failed (unmerged commits present) — BUT squash merges
+        # and reworks break the ancestor proxy (W88). We must verify by CONTENT
+        # before refusing to reap. A branch is safe to reap if every file it
+        # authored (changed since its merge-base) has the SAME blob on origin/main.
+        mb_proc = _run_git(
+            ["merge-base", "origin/main", "HEAD"], cwd=worktree, check=False
+        )
+        if mb_proc.returncode != 0:
+            return False
+        mb = mb_proc.stdout.strip()
+
+        diff_proc = _run_git(
+            ["diff", "--name-only", mb, "HEAD"], cwd=worktree, check=False
+        )
+        if diff_proc.returncode != 0:
+            return False
+
+        for f in diff_proc.stdout.splitlines():
+            f = f.strip()
+            if not f:
+                continue
+            bh_proc = _run_git(
+                ["rev-parse", f"HEAD:{f}"], cwd=worktree, check=False
+            )
+            bh = bh_proc.stdout.strip() if bh_proc.returncode == 0 else "__ABSENT__"
+
+            mh_proc = _run_git(
+                ["rev-parse", f"origin/main:{f}"], cwd=worktree, check=False
+            )
+            mh = mh_proc.stdout.strip() if mh_proc.returncode == 0 else "__ABSENT__"
+
+            if bh != mh:
+                return False
+
+        # If all changed files match origin/main by blob, the content is merged.
+        return True
+
     # rc >= 128 (bad ref, not a git dir, unknown HEAD): fail-safe to protect.
     logger.warning(
         "merge-base probe inconclusive for %s (rc=%s) — treating as unmerged "

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -605,6 +605,69 @@ def test_branch_in_origin_main_real_resolver(fake_repo):
     assert mod._branch_in_origin_main(missing) is True
 
 
+def test_branch_in_origin_main_squash_merged_is_reapable(fake_repo):
+    """W88: A branch that was squash-merged into origin/main is NOT an ancestor,
+    but its blob content matches origin/main. It must be recognized as merged
+    and reap-eligible."""
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "squash", ttl_minutes=5)
+
+    # Create work on branch
+    (wt / "squash.txt").write_text("squash content\n")
+    _commit_in_worktree(wt, mod, "squash.txt", "wip")
+
+    # Assert not merged yet
+    assert mod._branch_in_origin_main(wt) is False
+
+    # Simulate squash merge: add the same exact file/content to main
+    # directly, bypassing the regular merge commit, then push to origin.
+    (repo / "squash.txt").write_text("squash content\n")
+    subprocess.run(["git", "add", "squash.txt"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "squash merge"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+
+    # Fetch in worktree to update its known origin/main
+    subprocess.run(["git", "fetch", "origin"], cwd=wt, check=True)
+
+    # W88: it is not an ancestor, but content matches, so it IS merged.
+    assert mod._branch_in_origin_main(wt) is True
+
+
+def test_branch_in_origin_main_unmerged_content_refuses_reap(fake_repo):
+    """W88: A branch where blob content differs from origin/main must NOT be
+    reapable, even if some files match."""
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "unmerged", ttl_minutes=5)
+
+    (wt / "file1.txt").write_text("content 1\n")
+    _commit_in_worktree(wt, mod, "file1.txt", "commit 1")
+
+    (wt / "file2.txt").write_text("content 2 branch\n")
+    _commit_in_worktree(wt, mod, "file2.txt", "commit 2")
+
+    # Simulate partial or conflicting changes on main
+    # Ensure it happens in the main repo tree, not an uninitialized main_repo subdir
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True)
+    (repo / "file1.txt").write_text("content 1\n")  # matches
+    (repo / "file2.txt").write_text("content 2 main\n")  # differs
+    subprocess.run(["git", "add", "file1.txt", "file2.txt"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "diff content"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+
+    subprocess.run(["git", "fetch", "origin"], cwd=wt, check=True)
+
+    # Differing content must block reap
+    assert mod._branch_in_origin_main(wt) is False
+
+
 # ---------------------------------------------------------------------------
 # list — orphan detection (W62 ANTIBODY #2)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Squash-merged branches never pass the ancestor test, so `_branch_in_origin_main()` protected their worktrees forever (zombie accumulation — the exact W88 disease). On ancestor exit 1 the guard now falls through to blob-per-file content verification (branch-authored files since merge-base, `rev-parse HEAD:f` vs `origin/main:f`), never the three-dot diff (W88 second-degree trap). Git failures keep the fail-safe False.

**Jules pilot**: code + guilt/innocence tests produced by Google Jules from the pilot task spec (session 11202335505505569504; its publish never reached GitHub — app permissions). Independent verification done per the Antigravity-style contract: diff reviewed line-by-line against the W88 scar antidote, full suite re-run (38/38), scope check clean (one function + two tests, 2-AND reap rule untouched — process-liveness guard intact in the caller). Polish added: docstring updated to describe the fallback, trailing whitespace stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)