### PR TITLE
fix(genome): portable claude-binary resolver in G6 spawn (template + both healers)

### DIFF
--- a/infra/healer/healer-run.sh
+++ b/infra/healer/healer-run.sh
@@ -34,7 +34,15 @@ SIDECAR="$SIDECAR_DIR/mini.healer.json"
 PIDFILE="/tmp/nuzantara-healer.pid"
 MANDATE="$HOME/scripts/HEALER-MANDATE.md"
 MAX_WALL_S="${HEALER_MAX_WALL_S:-3300}"   # 55 min hard cap for the LLM session
-CLAUDE_BIN="${HEALER_CLAUDE_BIN:-/opt/homebrew/bin/claude}"
+# claude binary is NOT at the same path fleet-wide (Mini: /opt/homebrew symlink;
+# Pro: ~/.local/bin only). Env override wins; otherwise probe, then PATH.
+CLAUDE_BIN="${HEALER_CLAUDE_BIN:-}"
+if [ -z "$CLAUDE_BIN" ]; then
+    for _c in /opt/homebrew/bin/claude "$HOME/.local/bin/claude" /usr/local/bin/claude; do
+        if [ -x "$_c" ]; then CLAUDE_BIN="$_c"; break; fi
+    done
+fi
+[ -n "$CLAUDE_BIN" ] || CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
 MODEL="${HEALER_MODEL:-claude-sonnet-5}"
 
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
@@ -248,6 +256,11 @@ export HEALER_RUN=1
 # is a synchronous-init hang risk in -p mode).
 if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -n "${CLAUDE_CODE_OAUTH_TOKEN_1:-}" ]; then
     export CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN_1"
+fi
+if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
+    log "FATAL: no claude binary (env HEALER_CLAUDE_BIN, /opt/homebrew, ~/.local, /usr/local, PATH all empty)"
+    heartbeat "error" "no claude binary"
+    exit 1
 fi
 "$CLAUDE_BIN" -p "$(cat "$MANDATE")
 

--- a/infra/launchagents/wrappers/pro-healer.sh
+++ b/infra/launchagents/wrappers/pro-healer.sh
@@ -70,7 +70,16 @@ telegram() { # $1 text — best-effort, never blocks the run
 #     hang risk in -p mode); OAuth token from env, Keychain can be LOCKED here.
 REPO="$HOME/Desktop/nuzantara"
 MAX_WALL_S="${PRO_HEALER_MAX_WALL_S:-3300}"
-CLAUDE_BIN="${PRO_HEALER_CLAUDE_BIN:-/opt/homebrew/bin/claude}"
+# claude binary is NOT at the same path fleet-wide (Mini: /opt/homebrew symlink;
+# Pro: ~/.local/bin only — first live tick died exit=127 on the homebrew default).
+# Env override wins; otherwise probe known locations, then PATH.
+CLAUDE_BIN="${PRO_HEALER_CLAUDE_BIN:-}"
+if [ -z "$CLAUDE_BIN" ]; then
+    for _c in /opt/homebrew/bin/claude "$HOME/.local/bin/claude" /usr/local/bin/claude; do
+        if [ -x "$_c" ]; then CLAUDE_BIN="$_c"; break; fi
+    done
+fi
+[ -n "$CLAUDE_BIN" ] || CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
 MODEL="${PRO_HEALER_MODEL:-claude-sonnet-5}"
 
 if [ -z "${PRO_HEALER_TRAMPOLINED:-}" ] && [ -z "${SSH_CONNECTION:-}" ]; then
@@ -147,6 +156,11 @@ MANDATE="$HOME/scripts/HEALER-PRO-MANDATE.md"
 if [ ! -f "$MANDATE" ]; then
     log "FATAL: mandate file missing"
     heartbeat "error" "mandate missing"
+    exit 1
+fi
+if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
+    log "FATAL: no claude binary (env PRO_HEALER_CLAUDE_BIN, /opt/homebrew, ~/.local, /usr/local, PATH all empty)"
+    heartbeat "error" "no claude binary"
     exit 1
 fi
 

--- a/scripts/organ_birth.py
+++ b/scripts/organ_birth.py
@@ -134,7 +134,16 @@ trap 'rm -f "$PIDFILE"' EXIT
 #     hang risk in -p mode); OAuth token from env, Keychain can be LOCKED here.
 REPO="$HOME/Desktop/nuzantara"
 MAX_WALL_S="${{{var}_MAX_WALL_S:-3300}}"
-CLAUDE_BIN="${{{var}_CLAUDE_BIN:-/opt/homebrew/bin/claude}}"
+# claude binary is NOT at the same path fleet-wide (Mini: /opt/homebrew symlink;
+# Pro: ~/.local/bin only — healer-pro first tick died exit=127 on a hardcoded
+# homebrew default). Env override wins; otherwise probe, then PATH.
+CLAUDE_BIN="${{{var}_CLAUDE_BIN:-}}"
+if [ -z "$CLAUDE_BIN" ]; then
+    for _c in /opt/homebrew/bin/claude "$HOME/.local/bin/claude" /usr/local/bin/claude; do
+        if [ -x "$_c" ]; then CLAUDE_BIN="$_c"; break; fi
+    done
+fi
+[ -n "$CLAUDE_BIN" ] || CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
 MODEL="${{{var}_MODEL:-claude-sonnet-5}}"
 
 if [ -z "${{{var}_TRAMPOLINED:-}}" ] && [ -z "${{SSH_CONNECTION:-}}" ]; then
@@ -157,6 +166,11 @@ if [ -z "${{CLAUDE_CODE_OAUTH_TOKEN:-}}" ] && [ -n "${{CLAUDE_CODE_OAUTH_TOKEN_1
 fi
 
 SESSION_LOG="$LOG_DIR/session-$(date +%Y%m%d-%H%M%S).log"
+if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
+    log "FATAL: no claude binary (env {var}_CLAUDE_BIN, /opt/homebrew, ~/.local, /usr/local, PATH all empty)"
+    heartbeat "error" "no claude binary"
+    exit 1
+fi
 "$CLAUDE_BIN" -p "TODO: your standing mandate here" \\
     --model "$MODEL" --dangerously-skip-permissions \\
     --strict-mcp-config --mcp-config '{{"mcpServers":{{}}}}' \\


### PR DESCRIPTION
## What

healer-pro's FIRST live tick on Pro proved the whole G2/G9 chain (trampoline fired, receptors found real work: `registry:14-dead-organs home-fork-drift`, sidecar honestly wrote `status=degraded`) — and then died at spawn with exit=127: the G6 block hardcodes `/opt/homebrew/bin/claude`, but on Pro claude lives ONLY at `~/.local/bin/claude` (Mini has the homebrew symlink, which is why the Mini healer never hit this).

## Cure — at the genome level, not the instance

Same resolver shape in all three places (env override → probe `/opt/homebrew` → `~/.local` → `/usr/local` → `command -v`), plus a pre-spawn fail-visible guard (`log FATAL` + `heartbeat error`) so a missing binary is a diagnosed condition, not a bare shell 127:

- `scripts/organ_birth.py` — the G6 template every future organ inherits
- `infra/launchagents/wrappers/pro-healer.sh`
- `infra/healer/healer-run.sh`

## Proof

- gate: 142 plists, 0 regressions, 0 non-conformant births
- 23/23 conformance tests green (e2e birth→gate exercises the NEW template)
- `bash -n` clean on both wrappers

Post-merge arming: refresh Pro pair (`~/scripts/pro-healer.sh`) + Mini pair (`~/scripts/healer-run.sh`), re-kickstart healer-pro first tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)