### PR TITLE
fix(pricelist): codex sandbox flags + closed stdin — first fully-autonomous Jules loop

### DIFF
--- a/scripts/pricelist_2026/generate_assets.py
+++ b/scripts/pricelist_2026/generate_assets.py
@@ -51,10 +51,10 @@ def _generate_one(brief: str, out_path: Path, size: str, *, dry_run: bool) -> bo
         print(f"           prompt: {prompt[:120]}...")
         return True
     print(f"  ⏳ generating: {out_path.name} ({size})")
-    cmd = ["codex", "exec", "--full-auto", prompt]
+    cmd = ["codex", "exec", "--sandbox", "workspace-write", "--skip-git-repo-check", prompt]
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=300
+            cmd, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL
         )
     except subprocess.TimeoutExpired:
         print(f"  ✗ TIMEOUT: {out_path.name}", file=sys.stderr)


### PR DESCRIPTION
The W89 sibling from the ledger (pricelist `generate_assets.py:54`): `--full-auto` → `--sandbox workspace-write --skip-git-repo-check`, plus `stdin=subprocess.DEVNULL` (W89 hang vector).

**Milestone**: first fully-autonomous Jules loop — session `5555115025998095815` dispatched via `scripts/jules_dispatch.py` (no operator paste), patch retrieved from the API (`outputs.changeSet.gitPatch`), independently verified (exact 2-change diff, py_compile clean, zero residual `full-auto` in the dir), landed via this PR. Jules generates, Fable grades.

Live imagegen behavior gets its natural proof at the next pricelist asset run (network semantics not probeable headless — noted in the ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)