### PR TITLE
feat(organism): codex access receptor — WhatsApp alert on foreign entry

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -156,7 +156,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 ### LaunchAgents — copertura documentale
 
 <!-- DOCSYNC:AUTOMATION_COVERAGE_START -->
-`119 plist tracked in infra/launchagents/ · 64 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (54% coverage)`
+`120 plist tracked in infra/launchagents/ · 64 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (53% coverage)`
 <!-- DOCSYNC:AUTOMATION_COVERAGE_END -->
 
 Runbook operativi: indice auto-generato in [docs/runbooks/README.md](docs/runbooks/README.md).

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: 2693b53b89a1df260bf1a26f8ec15bdb221da8552119b7b061b5b5f4bec79f4f
+checksum: b663d795fbbb554911265ac9192c99252d678c0c94a7f46550ec7e687156e41b
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -1743,5 +1743,25 @@ organs:
   bridge_source:
     type: state_file
     path: ~/.organism/last_seen/pro.healer.json
+    timestamp_field: ts
+    status_field: status
+- id: mini.codex_access_watch
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 300
+  owner_module: infra/launchagents/wrappers/mini-codex-access-watch.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.nuzantara.codex-access-watch
+  severity_on_silence: warning
+  notes: Watch balizero.com/codex access logs (Vercel) and WhatsApp-alert Zero when
+    someone enters from outside the US (Leopoldo from Italy) (born via organ_birth.py,
+    genes imprinted 2026+)
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/mini.codex_access_watch.json
     timestamp_field: ts
     status_field: status

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -130,6 +130,20 @@
       "machines": [
         "pro"
       ]
+    },
+    {
+      "live": "~/scripts/mini-codex-access-watch.sh",
+      "repo": "infra/launchagents/wrappers/mini-codex-access-watch.sh",
+      "machines": [
+        "mini"
+      ]
+    },
+    {
+      "live": "~/Library/LaunchAgents/com.nuzantara.codex-access-watch.plist",
+      "repo": "infra/launchagents/com.nuzantara.codex-access-watch.plist",
+      "machines": [
+        "mini"
+      ]
     }
   ],
   "allow": [

--- a/infra/launchagents/com.nuzantara.codex-access-watch.plist
+++ b/infra/launchagents/com.nuzantara.codex-access-watch.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.nuzantara.codex-access-watch</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/scripts/mini-codex-access-watch.sh</string>
+    </array>
+    <key>StartInterval</key><integer>300</integer>
+    <key>RunAtLoad</key><false/>
+    <key>StandardOutPath</key><string>/tmp/com.nuzantara.codex-access-watch.out</string>
+    <key>StandardErrorPath</key><string>/tmp/com.nuzantara.codex-access-watch.err</string>
+</dict>
+</plist>

--- a/infra/launchagents/wrappers/mini-codex-access-watch.sh
+++ b/infra/launchagents/wrappers/mini-codex-access-watch.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# mini.codex_access_watch — Watch balizero.com/codex access logs (Vercel) and WhatsApp-alert Zero when someone enters from outside the US (Leopoldo from Italy)
+# Born via scripts/organ_birth.py (DNA/GENOME 2026-07-06): genes imprinted at birth.
+# Canon: infra/launchagents/wrappers/mini-codex_access_watch.sh
+# Live:  ~/scripts/mini-codex_access_watch.sh (declared pair, node=mini)
+
+set -u   # G9_fail_visible: unset vars crash, they do not expand empty
+
+ORGAN_ID="mini.codex_access_watch"
+LOG_DIR="$HOME/logs/mini-codex_access_watch"
+LOG="$LOG_DIR/run.log"
+mkdir -p "$LOG_DIR"
+SIDECAR_DIR="$HOME/.organism/last_seen"
+PIDFILE="/tmp/nuzantara-mini-codex_access_watch.pid"
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+# G2_heartbeat — sidecar EVERY exit path (Esiste≠Armato: prove life, every run)
+heartbeat() { # $1 status, $2 note
+    mkdir -p "$SIDECAR_DIR"
+    printf '{"ts":"%s","status":"%s","note":"%s"}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2" > "$SIDECAR_DIR/$ORGAN_ID.json"
+}
+
+# G4_node_guard — wrong node exits VISIBLY (heartbeat), never silently (#10)
+if [ "$(hostname -s)" != "Mini-Pro2" ]; then
+    log "node guard: $(hostname -s) != Mini-Pro2 — not my node, exiting"
+    heartbeat "disabled" "wrong-node $(hostname -s)"
+    exit 0
+fi
+
+# G5_kill_switch — operator stop without uninstall; disabled heartbeat keeps
+# the healer from resurrecting an intentionally-stopped organ
+if [ "${MINI_CODEX_ACCESS_WATCH_ENABLED:-true}" = "false" ]; then
+    log "kill switch MINI_CODEX_ACCESS_WATCH_ENABLED=false — exiting"
+    heartbeat "disabled" "kill switch"
+    exit 0
+fi
+
+# G10_single_instance — pidfile + liveness probe + trap cleanup
+if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+    log "previous run still alive (pid $(cat "$PIDFILE")) — skipping"
+    heartbeat "ok" "skipped: previous run alive"
+    exit 0
+fi
+echo $$ > "$PIDFILE"
+trap 'rm -f "$PIDFILE"' EXIT
+
+# ---- payload (cron one-shot; G8_keepalive_sane: plist uses StartInterval, no KeepAlive)
+log "run start"
+
+REPO="$HOME/Desktop/nuzantara"
+WATCHER="$REPO/scripts/codex_access_watch.py"
+ENV_FILE="$HOME/.config/nuzantara/codex-watch.env"   # 0600: vercel token + WA line id
+MASTER_ENV="$HOME/.openclaw/workspace/.env.master"   # WHATSAPP_TOKEN lives here
+
+if [ ! -f "$WATCHER" ]; then
+    log "FATAL: watcher missing at $WATCHER (repo not pulled?)"
+    heartbeat "error" "watcher missing"
+    exit 1
+fi
+if [ ! -f "$ENV_FILE" ]; then
+    log "FATAL: env file missing at $ENV_FILE"
+    heartbeat "error" "env file missing"
+    exit 1
+fi
+set -a
+source "$ENV_FILE"
+[ -z "${WHATSAPP_TOKEN:-}" ] && [ -f "$MASTER_ENV" ] && \
+    eval "$(grep -E '^WHATSAPP_TOKEN=' "$MASTER_ENV")"
+set +a
+
+/usr/bin/python3 "$WATCHER" >> "$LOG" 2>&1
+RC=$?
+
+if [ $RC -eq 0 ]; then
+    heartbeat "ok" "run done"
+else
+    heartbeat "error" "rc=$RC"   # G9: failure is VISIBLE in the sidecar too
+fi
+log "run done rc=$RC"
+exit 0

--- a/scripts/codex_access_watch.py
+++ b/scripts/codex_access_watch.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""codex_access_watch.py — WhatsApp receptor for balizero.com/codex access.
+
+Polls Vercel request logs for the `mouth` project, filters /codex requests,
+and sends Zero a WhatsApp when someone enters from OUTSIDE the US edge set —
+the reader this exists for is Leopoldo, who connects from Italy (fra1/cdg1/...).
+Zero and this fleet's own probes currently egress from California (sfo1), so
+US-edge traffic is self-noise and stays silent.
+
+Reading a request:
+  POST 303 = correct PIN, entered · POST 401 = wrong sign at the door ·
+  GET 200  = page load (door or codex, cookie-dependent).
+
+Blind-guard (scar family #2, Esiste≠Armato): after N consecutive Vercel API
+failures the receptor tells Zero it has gone blind — a watcher that cannot
+see must not stay silently green. State (seen request ids, failure counter)
+persists in ~/.organism/state/codex_access_watch.state.json.
+
+Env (wrapper sources these; no secrets on the CLI):
+  CODEX_WATCH_VERCEL_TOKEN     Vercel CLI bearer token (required)
+  WHATSAPP_TOKEN               Meta Cloud API token (required)
+  WHATSAPP_PHONE_NUMBER_ID     Bali Zero WA line id (required)
+  CODEX_WATCH_ALERT_TO         recipient, default Zero 6282210302328
+  CODEX_WATCH_TEST_PING=1      send a liveness test message and exit
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+PROJECT_ID = "prj_LcXb9ZgeUvWpxaIM9K47tQYPeuee"  # mouth on Vercel
+OWNER_ID = "team_jX3mEbUemBs0Zy4i8aFYZsjS"  # nuzantara-2026
+DEFAULT_ALERT_TO = "6282210302328"  # Zero — already public in wa.me fallback
+
+# Vercel edges that are "us": Zero in California + this fleet's probes.
+# Anything else (fra1/cdg1/lhr1/dub1/arn1 = Europe, sin1/hkg1 = Asia, ...)
+# is a stranger at the door — for now that means Leopoldo.
+SELF_EDGES = {"sfo1", "iad1", "pdx1", "cle1"}
+
+EU_EDGES = {"fra1", "cdg1", "lhr1", "dub1", "arn1", "mad1"}
+
+STATE_PATH = Path.home() / ".organism/state/codex_access_watch.state.json"
+WINDOW_HOURS = 24  # catch-up horizon after downtime; dedup absorbs overlap
+SEEN_TTL_HOURS = 48
+BLIND_AFTER_FAILURES = 12  # ~1h at 300s cadence
+BLIND_ALERT_COOLDOWN_H = 24
+
+
+def _load_state() -> dict[str, Any]:
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except (OSError, ValueError):
+        return {"seen": {}, "failures": 0, "last_blind_alert": 0}
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state))
+    tmp.replace(STATE_PATH)
+
+
+def fetch_codex_rows(token: str) -> list[dict[str, Any]]:
+    now_ms = int(time.time() * 1000)
+    params = urllib.parse.urlencode(
+        {
+            "projectId": PROJECT_ID,
+            "ownerId": OWNER_ID,
+            "page": 0,
+            "startDate": now_ms - WINDOW_HOURS * 3600 * 1000,
+            "endDate": now_ms,
+            "environment": "production",
+            "search": "codex",
+            "teamId": OWNER_ID,
+        }
+    )
+    req = urllib.request.Request(
+        f"https://vercel.com/api/logs/request-logs?{params}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+    rows = data if isinstance(data, list) else (data.get("logs") or data.get("rows") or [])
+    return [r for r in rows if isinstance(r, dict) and r.get("requestPath", "").startswith("/codex")]
+
+
+def edge_regions(row: dict[str, Any]) -> set[str]:
+    return {e.get("region", "") for e in (row.get("proxyEvents") or [])} - {""}
+
+
+def classify_new_foreign(
+    rows: list[dict[str, Any]], seen: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Return NEW events whose edge is outside SELF_EDGES (guilt),
+    skipping self-noise and already-seen ids (innocence)."""
+    out = []
+    for r in rows:
+        rid = r.get("requestId") or r.get("id") or ""
+        if not rid or rid in seen:
+            continue
+        regions = edge_regions(r)
+        foreign = regions - SELF_EDGES
+        if not foreign:
+            continue
+        out.append(
+            {
+                "id": rid,
+                "ts": r.get("timestamp", ""),
+                "method": r.get("requestMethod", "?"),
+                "status": r.get("statusCode", 0),
+                "regions": sorted(foreign),
+            }
+        )
+    return out
+
+
+def _fmt_time(ts: str) -> str:
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        it = dt.astimezone(timezone(timedelta(hours=2)))
+        return f"{it:%H:%M} IT"
+    except ValueError:
+        return ts
+
+
+def _describe(ev: dict[str, Any]) -> str:
+    where = ",".join(ev["regions"])
+    zone = " (Europa)" if set(ev["regions"]) & EU_EDGES else ""
+    m, s = ev["method"], ev["status"]
+    if m == "POST" and s == 303:
+        what = "PIN GIUSTO — è entrato"
+    elif m == "POST":
+        what = f"segno sbagliato alla porta ({s})"
+    else:
+        what = f"pagina caricata ({s})"
+    return f"• {_fmt_time(ev['ts'])} da {where}{zone}: {what}"
+
+
+def build_message(events: list[dict[str, Any]]) -> str:
+    entered = any(e["method"] == "POST" and e["status"] == 303 for e in events)
+    head = "📜 CODEX — qualcuno è ENTRATO" if entered else "📜 CODEX — movimento alla porta"
+    lines = [_describe(e) for e in events[:10]]
+    if len(events) > 10:
+        lines.append(f"… e altri {len(events) - 10} eventi")
+    return head + " (balizero.com/codex)\n" + "\n".join(lines)
+
+
+def send_whatsapp(text: str) -> None:
+    token = os.environ["WHATSAPP_TOKEN"]
+    phone_id = os.environ["WHATSAPP_PHONE_NUMBER_ID"]
+    to = os.environ.get("CODEX_WATCH_ALERT_TO", DEFAULT_ALERT_TO)
+    body = json.dumps(
+        {
+            "messaging_product": "whatsapp",
+            "to": to,
+            "type": "text",
+            "text": {"body": text[:4000]},
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"https://graph.facebook.com/v22.0/{phone_id}/messages",
+        data=body,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        out = json.loads(resp.read())
+    if not out.get("messages"):
+        raise RuntimeError(f"WA send got no message id: {out}")
+
+
+def main() -> int:
+    if os.environ.get("CODEX_WATCH_TEST_PING") == "1":
+        send_whatsapp("📜 Il ricettore del Codex è vivo: ti avviserò qui quando Leopoldo entra.")
+        print("test ping sent")
+        return 0
+
+    state = _load_state()
+    try:
+        rows = fetch_codex_rows(os.environ["CODEX_WATCH_VERCEL_TOKEN"])
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError, KeyError) as e:
+        state["failures"] = int(state.get("failures", 0)) + 1
+        print(f"fetch failed ({state['failures']} consecutive): {e}", file=sys.stderr)
+        if state["failures"] >= BLIND_AFTER_FAILURES and (
+            time.time() - state.get("last_blind_alert", 0) > BLIND_ALERT_COOLDOWN_H * 3600
+        ):
+            try:
+                send_whatsapp(
+                    "⚠️ Il ricettore del Codex è CIECO da ~1h (Vercel API failure). "
+                    "Gli accessi di Leopoldo non sono osservati."
+                )
+                state["last_blind_alert"] = time.time()
+            except OSError as we:
+                print(f"blind-alert send failed too: {we}", file=sys.stderr)
+        _save_state(state)
+        return 1
+
+    state["failures"] = 0
+    events = classify_new_foreign(rows, state["seen"])
+    now = time.time()
+    for ev in events:
+        state["seen"][ev["id"]] = now
+    # prune old ids so the state file cannot grow unbounded
+    cutoff = now - SEEN_TTL_HOURS * 3600
+    state["seen"] = {k: v for k, v in state["seen"].items() if v > cutoff}
+
+    if events:
+        send_whatsapp(build_message(events))
+        print(f"alerted: {len(events)} foreign events")
+    else:
+        print(f"quiet: {len(rows)} rows, all self")
+    _save_state(state)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_codex_access_watch.py
+++ b/scripts/tests/test_codex_access_watch.py
@@ -1,0 +1,60 @@
+"""Guilt + innocence tests for the codex access receptor (scar #3 discipline).
+
+Guilt: a POST 303 from a European edge MUST alert.
+Innocence: self-noise (sfo1/iad1 probes) and already-seen ids MUST stay silent.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "codex_access_watch", Path(__file__).resolve().parents[1] / "codex_access_watch.py"
+)
+watch = importlib.util.module_from_spec(spec)
+sys.modules["codex_access_watch"] = watch
+spec.loader.exec_module(watch)
+
+
+def _row(rid: str, method: str, status: int, regions: list[str]) -> dict:
+    return {
+        "requestId": rid,
+        "timestamp": "2026-07-06T12:18:59.000Z",
+        "requestPath": "/codex",
+        "requestMethod": method,
+        "statusCode": status,
+        "proxyEvents": [{"region": r} for r in regions],
+    }
+
+
+def test_guilt_eu_entry_alerts():
+    events = watch.classify_new_foreign([_row("a1", "POST", 303, ["fra1"])], seen={})
+    assert len(events) == 1
+    assert events[0]["regions"] == ["fra1"]
+    msg = watch.build_message(events)
+    assert "ENTRATO" in msg and "fra1" in msg and "Europa" in msg
+
+
+def test_guilt_eu_wrong_pin_alerts_as_door():
+    events = watch.classify_new_foreign([_row("a2", "POST", 401, ["cdg1"])], seen={})
+    assert len(events) == 1
+    msg = watch.build_message(events)
+    assert "ENTRATO" not in msg and "sbagliato" in msg
+
+
+def test_innocence_self_edges_stay_silent():
+    rows = [
+        _row("b1", "POST", 303, ["sfo1"]),
+        _row("b2", "GET", 200, ["iad1", "sfo1"]),
+    ]
+    assert watch.classify_new_foreign(rows, seen={}) == []
+
+
+def test_innocence_seen_ids_not_realerted():
+    row = _row("c1", "POST", 303, ["fra1"])
+    assert watch.classify_new_foreign([row], seen={"c1": 1.0}) == []
+
+
+def test_mixed_edge_still_foreign():
+    # a request seen by both a US and an EU edge is not self-noise
+    events = watch.classify_new_foreign([_row("d1", "GET", 200, ["iad1", "fra1"])], seen={})
+    assert len(events) == 1 and events[0]["regions"] == ["fra1"]


### PR DESCRIPTION
## What

New organ **mini.codex_access_watch** (born via `organ_birth.py`, all 10 genes imprinted): polls Vercel request logs for `balizero.com/codex` every 5 minutes on Mini and sends Zero a **WhatsApp** when someone reaches the codex from a **non-US edge region** (the intended reader, Leopoldo, connects from Italy → fra1/cdg1/...). Zero + fleet probes currently egress from California (sfo1) and stay silent.

## How

- `scripts/codex_access_watch.py` — stdlib-only; internal Vercel `request-logs` API with CLI bearer token; per-requestId dedup (48h TTL); 24h catch-up window (Mini downtime safe); POST 303 = entered, POST 401 = wrong sign, GET = page load; **blind-guard** (scar family #2): after ~1h of consecutive API failures it WhatsApps that it has gone blind (24h cooldown).
- Wrapper payload: sources `~/.config/nuzantara/codex-watch.env` (0600, Vercel token + WA line id) and `WHATSAPP_TOKEN` from the master env; fail-visible heartbeats on every path.
- Registry entry + declared home-fork pair via `--apply`.

## Verify

- Guilt+innocence tests (scar #3): 5/5 pass — EU POST 303 alerts, EU 401 reads as "door", sfo1/iad1 self-noise silent, seen ids not re-alerted, mixed-edge counts as foreign.
- `check_organ_conformance.py`: 143 plists scanned, 0 regressions, 0 non-conformant births.
- `lint_plist_keepalive.py`: clean (cron uses StartInterval, no KeepAlive).
- Post-merge arming on Mini (plist bootstrap + env file + live pair) tracked in PENDING-ARMS until first heartbeat + live WA test ping verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)