### PR TITLE
fix(broker): W88 blob-content fallback in --release (squash-merge aware)

### DIFF
--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -975,6 +975,10 @@ def _remove_worktree(worktree: Path, branch: str, *, delete_branch: bool) -> Non
 def cmd_release(task_id: str, *, force: bool = False) -> int:
     """Tear down a worktree by task-id. Branch deleted only if merged into base.
 
+    Merged-ness is the cheap ancestor count first, then — because that proxy
+    lies on squash-merged branches (W88) — the same blob-per-file content
+    fallback the cleanup reaper uses (`_branch_in_origin_main`, #2038).
+
     With --force, the branch is deleted unconditionally (operator escape).
     """
     if _kill_switch_active():
@@ -1005,6 +1009,13 @@ def cmd_release(task_id: str, *, force: bool = False) -> int:
         )
 
     merged = _branch_is_merged(meta.branch, base=base)
+    if not merged and wt.is_dir() and base == "main":
+        # W88: the ancestor proxy says "unmerged" for every squash-merged
+        # branch. Fall back to the blob-per-file content check the cleanup
+        # reaper uses. Gated on wt.is_dir() — with the checkout gone the
+        # content check degenerates to True and would delete an unproven
+        # branch (keep the fail-safe direction).
+        merged = _branch_in_origin_main(wt)
     if not merged and not force:
         raise SystemExit(
             f"ERROR: branch {meta.branch} not merged into {base}. "

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -755,6 +755,71 @@ def test_release_force_overrides_unmerged(fake_repo):
     assert not wt.exists()
 
 
+def test_release_reaps_squash_merged_branch(fake_repo):
+    """W88 guilt: --release must recognize a squash-merged branch as merged via
+    the blob-per-file content fallback — the ancestor proxy lies post-squash.
+    Live case 2026-07-06: three squash-merged lanes (#2044/#2045/#2047) needed
+    --force because cmd_release only asked rev-list."""
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "rel-squash")
+
+    (wt / "squash.txt").write_text("squash content\n")
+    subprocess.run(["git", "add", "squash.txt"], cwd=wt, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "wip"],
+        cwd=wt,
+        check=True,
+    )
+
+    # Simulate squash merge: same exact content lands on main as a NEW commit
+    # (branch SHA never becomes an ancestor), then push to origin.
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True)
+    (repo / "squash.txt").write_text("squash content\n")
+    subprocess.run(["git", "add", "squash.txt"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "squash merge"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=wt, check=True)
+
+    rc = mod.cmd_release("rel-squash")  # no --force needed anymore
+    assert rc == 0
+    assert not wt.exists()
+
+
+def test_release_refuses_branch_with_unmerged_content(fake_repo):
+    """W88 innocence: a branch whose blob content differs from origin/main must
+    still be refused by --release without --force (fail-safe preserved)."""
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "rel-unmg")
+
+    (wt / "f.txt").write_text("branch content\n")
+    subprocess.run(["git", "add", "f.txt"], cwd=wt, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "wip"],
+        cwd=wt,
+        check=True,
+    )
+
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True)
+    (repo / "f.txt").write_text("different on main\n")
+    subprocess.run(["git", "add", "f.txt"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "other"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=wt, check=True)
+
+    with pytest.raises(SystemExit) as exc:
+        mod.cmd_release("rel-unmg")
+    assert "not merged" in str(exc.value).lower()
+    assert wt.exists()  # untouched
+
+
 def test_release_unknown_task_errors(fake_repo):
     mod, _ = fake_repo
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## What

`agent_start.py --release` still decided merged-ness with the rev-list ancestor proxy — the exact W88 lie #2038 cured in `--cleanup`. Sibling call-site left on the old check (W89 pattern: cure applied to 1-of-N paths).

**Live bite (today):** three squash-merged lanes (#2044 / #2045 / #2047) refused `--release` and needed `--force` after manual blob-per-file verification.

## Fix

After the cheap ancestor count says "unmerged", fall back to `_branch_in_origin_main(wt)` — the same blob-per-file content check the cleanup reaper uses. Gated on `wt.is_dir()` and `base == "main"`: with the checkout gone the content check degenerates to True, so the gate keeps the fail-safe direction (never delete an unproven branch).

Class-audit of the file: only 2 ancestor call-sites exist (`_branch_in_origin_main` internal + this one); both now cured.

## Tests

40/40 locally — adds:
- **guilt**: squash-merged branch releases WITHOUT `--force`
- **innocence**: branch with content differing from origin/main still refused, worktree untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)