### PR TITLE
fix(organism): case-insensitive G4 node guard — hostname case varies by node

### DIFF
--- a/infra/launchagents/wrappers/mini-codex-access-watch.sh
+++ b/infra/launchagents/wrappers/mini-codex-access-watch.sh
@@ -24,8 +24,8 @@ heartbeat() { # $1 status, $2 note
 }
 
 # G4_node_guard — wrong node exits VISIBLY (heartbeat), never silently (#10)
-if [ "$(hostname -s)" != "Mini-Pro2" ]; then
-    log "node guard: $(hostname -s) != Mini-Pro2 — not my node, exiting"
+if [ "$(hostname -s | tr '[:upper:]' '[:lower:]')" != "mini-pro2" ]; then
+    log "node guard: $(hostname -s) != mini-pro2 — not my node, exiting"
     heartbeat "disabled" "wrong-node $(hostname -s)"
     exit 0
 fi

--- a/infra/launchagents/wrappers/pro-healer.sh
+++ b/infra/launchagents/wrappers/pro-healer.sh
@@ -24,8 +24,8 @@ heartbeat() { # $1 status, $2 note
 }
 
 # G4_node_guard — wrong node exits VISIBLY (heartbeat), never silently (#10)
-if [ "$(hostname -s)" != "Nuzantara" ]; then
-    log "node guard: $(hostname -s) != Nuzantara — not my node, exiting"
+if [ "$(hostname -s | tr '[:upper:]' '[:lower:]')" != "nuzantara" ]; then
+    log "node guard: $(hostname -s) != nuzantara — not my node, exiting"
     heartbeat "disabled" "wrong-node $(hostname -s)"
     exit 0
 fi

--- a/scripts/organ_birth.py
+++ b/scripts/organ_birth.py
@@ -57,7 +57,10 @@ PAIRS_PATH = REPO / "infra/home-fork/declared-pairs.json"
 WRAPPER_DIR = REPO / "infra/launchagents/wrappers"
 PLIST_DIR = REPO / "infra/launchagents"
 
-NODE_HOSTNAMES = {"mini": "Mini-Pro2", "pro": "Nuzantara"}
+# Lowercase canon: `hostname -s` case differs by macOS name source (Mini
+# reports "mini-pro2" while its ComputerName is "Mini-Pro2") — the guard
+# lowercases both sides before comparing, so the map must be lowercase too.
+NODE_HOSTNAMES = {"mini": "mini-pro2", "pro": "nuzantara"}
 # M5 is EXCLUDED by design: interactive laptop, no daemon fleet (CLAUDE.md §1).
 
 
@@ -97,7 +100,7 @@ heartbeat() {{ # $1 status, $2 note
 }}
 
 # G4_node_guard — wrong node exits VISIBLY (heartbeat), never silently (#10)
-if [ "$(hostname -s)" != "{hostname}" ]; then
+if [ "$(hostname -s | tr '[:upper:]' '[:lower:]')" != "{hostname}" ]; then
     log "node guard: $(hostname -s) != {hostname} — not my node, exiting"
     heartbeat "disabled" "wrong-node $(hostname -s)"
     exit 0


### PR DESCRIPTION
## What

The G4 node guard born by `organ_birth.py` compares `hostname -s` case-sensitively against a mixed-case map (`Mini-Pro2`/`Nuzantara`). On Mini, `hostname -s` reports **lowercase** `mini-pro2`, so the freshly-born `mini.codex_access_watch` exited wrong-node on every tick — a blind organ with a green exit code (scar family #2). Pro matches only because its hostname happens to be exactly `Nuzantara`.

## Fix (class cure, W89)

- Guard lowercases both sides: `hostname -s | tr '[:upper:]' '[:lower:]'` vs lowercase canon.
- Applied in the generator template AND both born wrappers (`mini-codex-access-watch.sh`, `pro-healer.sh` — the only two in-repo users of the guard, grep-verified).

## Verify

- `test_organ_conformance.py` 11/11 pass; `check_organ_conformance.py` clean (G4 is advisory in the gate).
- Live proof on Mini: patched live pair, kickstarted — heartbeat `status=ok`, log `quiet: 50 rows, all self`.
- Post-merge: align Pro's live `pro-healer.sh` pair (sha256 pair-lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)