### PR TITLE
fix(mouth): clear remaining post-deadline KBLI copy

### DIFF
--- a/apps/mouth/src/content/articles/business/kbli-2025-gold-rush-migration.mdx
+++ b/apps/mouth/src/content/articles/business/kbli-2025-gold-rush-migration.mdx
@@ -195,7 +195,7 @@ Ensure your quarterly investment activity reports match the new codes. Discrepan
 
 ### 4. OSS System Readiness
 
-As of January 2026, the OSS system hasn't fully integrated KBLI 2025 due to pending sectoral regulations. Don't force a premature update — prepare your notarial deeds and execute the change when BKPM announces readiness.
+OSS/NIB handling must be verified live. The June 2026 transition window has closed, so unresolved mappings should be treated as remediation: confirm whether OSS accepts the target KBLI 2025 code, keep notarial evidence ready, and document any portal blockage before filing.
 
 ## The Bottom Line
 

--- a/apps/mouth/src/content/articles/business/kbli-2025-retail-ecommerce.it.mdx
+++ b/apps/mouth/src/content/articles/business/kbli-2025-retail-ecommerce.it.mdx
@@ -213,7 +213,7 @@ Per la strategia di migrazione completa e cosa preparare mentre l'integrazione d
 
 5. **La vendita al dettaglio e all'ingrosso sono classificazioni diverse.** Vendere ai consumatori (47xxx) e vendere alle aziende (46xxx) richiedono codici diversi. Se fai entrambe le cose, registra entrambi.
 
-6. **La scadenza è reale.** Il la finestra di transizione di giugno 2026 è ormai chiusa è la data di conformità KBLI 2025. La finestra di transizione di giugno 2026 è chiusa; verifica il trattamento OSS/NIB corrente.
+6. **La finestra è chiusa.** La transizione di giugno 2026 è ormai una questione di remediation: verifica il trattamento OSS/NIB corrente e correggi eventuali codici legacy prima di nuove pratiche o modifiche.
 
 ---
 

--- a/apps/mouth/src/content/articles/business/oss-registration-guide.fr.mdx
+++ b/apps/mouth/src/content/articles/business/oss-registration-guide.fr.mdx
@@ -54,7 +54,7 @@ faq:
   - question: "Can I register on OSS without a notary?"
     answer: "No. You need an AHU-approved company deed (Akta Pendirian) created by a notary before registering on OSS. The AHU approval number is required during OSS registration. For PT PMA, the notary also handles BKPM investment approval."
   - question: "What if OSS shows my KBLI code as not available?"
-    answer: "OSS hasn't fully integrated KBLI 2025 yet. If your new KBLI 2025 code isn't available, use the closest KBLI 2020 equivalent. Update when OSS supports the new codes. Document your intended KBLI 2025 code for future migration."
+    answer: "If OSS does not show the expected KBLI 2025 code, do not fall back blindly to a legacy code. Verify the live OSS/NIB workflow, document the intended code, and escalate it as post-deadline remediation before filing or amending."
 contentStructure:
   hasHowTo: true
   hasFAQ: true

--- a/apps/mouth/src/content/articles/business/oss-registration-guide.id.mdx
+++ b/apps/mouth/src/content/articles/business/oss-registration-guide.id.mdx
@@ -54,7 +54,7 @@ faq:
   - question: "Can I register on OSS without a notary?"
     answer: "No. You need an AHU-approved company deed (Akta Pendirian) created by a notary before registering on OSS. The AHU approval number is required during OSS registration. For PT PMA, the notary also handles BKPM investment approval."
   - question: "What if OSS shows my KBLI code as not available?"
-    answer: "OSS hasn't fully integrated KBLI 2025 yet. If your new KBLI 2025 code isn't available, use the closest KBLI 2020 equivalent. Update when OSS supports the new codes. Document your intended KBLI 2025 code for future migration."
+    answer: "If OSS does not show the expected KBLI 2025 code, do not fall back blindly to a legacy code. Verify the live OSS/NIB workflow, document the intended code, and escalate it as post-deadline remediation before filing or amending."
 contentStructure:
   hasHowTo: true
   hasFAQ: true

--- a/apps/mouth/src/content/articles/business/oss-registration-guide.it.mdx
+++ b/apps/mouth/src/content/articles/business/oss-registration-guide.it.mdx
@@ -54,7 +54,7 @@ faq:
   - question: "Can I register on OSS without a notary?"
     answer: "No. You need an AHU-approved company deed (Akta Pendirian) created by a notary before registering on OSS. The AHU approval number is required during OSS registration. For PT PMA, the notary also handles BKPM investment approval."
   - question: "What if OSS shows my KBLI code as not available?"
-    answer: "OSS hasn't fully integrated KBLI 2025 yet. If your new KBLI 2025 code isn't available, use the closest KBLI 2020 equivalent. Update when OSS supports the new codes. Document your intended KBLI 2025 code for future migration."
+    answer: "If OSS does not show the expected KBLI 2025 code, do not fall back blindly to a legacy code. Verify the live OSS/NIB workflow, document the intended code, and escalate it as post-deadline remediation before filing or amending."
 contentStructure:
   hasHowTo: true
   hasFAQ: true

--- a/apps/mouth/src/content/articles/business/oss-registration-guide.mdx
+++ b/apps/mouth/src/content/articles/business/oss-registration-guide.mdx
@@ -54,7 +54,7 @@ faq:
   - question: "Can I register on OSS without a notary?"
     answer: "No. You need an AHU-approved company deed (Akta Pendirian) created by a notary before registering on OSS. The AHU approval number is required during OSS registration. For PT PMA, the notary also handles BKPM investment approval."
   - question: "What if OSS shows my KBLI code as not available?"
-    answer: "OSS hasn't fully integrated KBLI 2025 yet. If your new KBLI 2025 code isn't available, use the closest KBLI 2020 equivalent. Update when OSS supports the new codes. Document your intended KBLI 2025 code for future migration."
+    answer: "If OSS does not show the expected KBLI 2025 code, do not fall back blindly to a legacy code. Verify the live OSS/NIB workflow, document the intended code, and escalate it as post-deadline remediation before filing or amending."
 contentStructure:
   hasHowTo: true
   hasFAQ: true

--- a/apps/mouth/src/content/articles/business/oss-registration-guide.ru.mdx
+++ b/apps/mouth/src/content/articles/business/oss-registration-guide.ru.mdx
@@ -54,7 +54,7 @@ faq:
   - question: "Can I register on OSS without a notary?"
     answer: "No. You need an AHU-approved company deed (Akta Pendirian) created by a notary before registering on OSS. The AHU approval number is required during OSS registration. For PT PMA, the notary also handles BKPM investment approval."
   - question: "What if OSS shows my KBLI code as not available?"
-    answer: "OSS hasn't fully integrated KBLI 2025 yet. If your new KBLI 2025 code isn't available, use the closest KBLI 2020 equivalent. Update when OSS supports the new codes. Document your intended KBLI 2025 code for future migration."
+    answer: "If OSS does not show the expected KBLI 2025 code, do not fall back blindly to a legacy code. Verify the live OSS/NIB workflow, document the intended code, and escalate it as post-deadline remediation before filing or amending."
 contentStructure:
   hasHowTo: true
   hasFAQ: true

--- a/apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.fr.mdx
+++ b/apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.fr.mdx
@@ -46,7 +46,7 @@ faq:
   - question: "What is the Category J/K split in KBLI 2025?"
     answer: "KBLI 2025 splits the old Information & Communication category into Category J (content, media, creator economy with foreign ownership restrictions) and Category K (telecommunications, programming, infrastructure open to 100% foreign ownership). This allows Indonesia to protect media sovereignty while attracting tech investment."
   - question: "Has the OSS system been updated for KBLI 2025?"
-    answer: "As of early 2026, the OSS system has not fully integrated KBLI 2025 codes. Businesses should prepare all documentation and notarial deeds but wait for official BKPM announcements before executing changes, as premature updates can lock your NIB and block customs clearance."
+    answer: "KBLI 2025 is now the current classification basis. If OSS does not show the expected code or blocks an amendment, verify the live OSS/NIB workflow, document the intended KBLI 2025 code, and treat the case as post-deadline remediation rather than a future migration."
 contentStructure:
   hasHowTo: true
   hasFAQ: true

--- a/apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.id.mdx
+++ b/apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.id.mdx
@@ -55,10 +55,10 @@ faq:
       This allows Indonesia to protect media sovereignty while attracting tech investment.
     question: What is the Category J/K split in KBLI 2025?
   - answer:
-      As of early 2026, the OSS system has not fully integrated KBLI 2025 codes.
-      Businesses should prepare all documentation and notarial deeds but wait for official
-      BKPM announcements before executing changes, as premature updates can lock your
-      NIB and block customs clearance.
+      KBLI 2025 is now the current classification basis. If OSS does not show
+      the expected code or blocks an amendment, verify the live OSS/NIB workflow,
+      document the intended KBLI 2025 code, and treat the case as post-deadline
+      remediation rather than a future migration.
     question: Has the OSS system been updated for KBLI 2025?
 featured: true
 lang: id

--- a/apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.mdx
+++ b/apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.mdx
@@ -46,7 +46,7 @@ faq:
   - question: "What is the Category J/K split in KBLI 2025?"
     answer: "KBLI 2025 splits the old Information & Communication category into Category J (content, media, creator economy with foreign ownership restrictions) and Category K (telecommunications, programming, infrastructure open to 100% foreign ownership). This allows Indonesia to protect media sovereignty while attracting tech investment."
   - question: "Has the OSS system been updated for KBLI 2025?"
-    answer: "As of early 2026, the OSS system has not fully integrated KBLI 2025 codes. Businesses should prepare all documentation and notarial deeds but wait for official BKPM announcements before executing changes, as premature updates can lock your NIB and block customs clearance."
+    answer: "KBLI 2025 is now the current classification basis. If OSS does not show the expected code or blocks an amendment, verify the live OSS/NIB workflow, document the intended KBLI 2025 code, and treat the case as post-deadline remediation rather than a future migration."
 contentStructure:
   hasHowTo: true
   hasFAQ: true
@@ -161,15 +161,15 @@ The era of choosing a KBLI code for "convenience" is over. The code you select i
 
 ## The OSS Gap: An Honest Assessment
 
-The ambition of KBLI 2025 is tempered by an implementation reality: as of January 2026, the OSS system **hasn't fully integrated** the new codes. Sectoral implementing regulations from technical ministries are still pending. The system's "brain" doesn't yet know how to process applications for many new activities.
+The ambition of KBLI 2025 is tempered by an implementation reality: live OSS/NIB handling and sectoral ministry follow-through still need to be verified case by case. As of July 2026, the transition window is closed, so the question is no longer whether to prepare for future integration; it is whether your current NIB record, ministry license path, and tax profile accept the correct KBLI 2025 code today.
 
-This creates a dangerous transition period where:
+This creates a post-deadline remediation period where:
 
-- The law requires KBLI 2025 compliance
-- The system can't yet process KBLI 2025 applications
-- The Fiktif Positif mechanism (deemed approval through bureaucratic silence) serves as an imperfect safety valve
+- The law now expects KBLI 2025 alignment
+- Some filings may still require live OSS/NIB verification before submission
+- The Fiktif Positif mechanism (deemed approval through bureaucratic silence) remains an imperfect safety valve
 
-Businesses should prepare all documentation and notarial deeds for the migration but **wait for official BKPM announcements** before executing changes in OSS. Premature updates can lock your NIB and block customs clearance.
+Businesses should keep documentation and notarial deeds ready, verify the live workflow before each filing, and remediate records that still show KBLI 2020 codes. Do not rely on January 2026 portal behavior for a July 2026 filing decision.
 
 ## What This Means for Indonesia
 

--- a/apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.ru.mdx
+++ b/apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.ru.mdx
@@ -46,7 +46,7 @@ faq:
   - question: "What is the Category J/K split in KBLI 2025?"
     answer: "KBLI 2025 splits the old Information & Communication category into Category J (content, media, creator economy with foreign ownership restrictions) and Category K (telecommunications, programming, infrastructure open to 100% foreign ownership). This allows Indonesia to protect media sovereignty while attracting tech investment."
   - question: "Has the OSS system been updated for KBLI 2025?"
-    answer: "As of early 2026, the OSS system has not fully integrated KBLI 2025 codes. Businesses should prepare all documentation and notarial deeds but wait for official BKPM announcements before executing changes, as premature updates can lock your NIB and block customs clearance."
+    answer: "KBLI 2025 is now the current classification basis. If OSS does not show the expected code or blocks an amendment, verify the live OSS/NIB workflow, document the intended KBLI 2025 code, and treat the case as post-deadline remediation rather than a future migration."
 contentStructure:
   hasHowTo: true
   hasFAQ: true


### PR DESCRIPTION
## Summary
- Removes the remaining future-tense KBLI/OSS deadline copy from public article surfaces.
- Updates localized OSS registration and KBLI upgrade FAQs to post-deadline remediation language.
- Regenerates apps/mouth/public/llms-full.txt from the corrected article corpus.

## Public surfaces changed
- apps/mouth/src/content/articles/business/kbli-2025-gold-rush-migration.mdx
- apps/mouth/src/content/articles/business/kbli-2025-retail-ecommerce.it.mdx
- apps/mouth/src/content/articles/business/oss-registration-guide.{mdx,it,id,fr,ru}.mdx
- apps/mouth/src/content/articles/business/upgrading-indonesia-kbli-2025.{mdx,id,fr,ru}.mdx
- apps/mouth/public/llms-full.txt

## Verification
- git diff --check
- KBLI/post-deadline stale-copy rg sweep across apps/mouth/src, apps/mouth/data, apps/mouth/public/llms-full.txt, and canonical dataset
- npm run lint
- npm run typecheck
- npm run test -- --run src/content/content-freshness-sentinel.test.ts src/lib/kbli-faq.test.ts src/lib/kbli-dataset-version.test.ts
- npm run build

## Remaining editorial decision
- The only broad-scan match left is an OTA/tax article about a March 31, 2026 deadline, outside KBLI scope.
