### PR TITLE
feat(mouth): codex door self-alerts on foreign entry via WhatsApp

### DIFF
--- a/apps/mouth/src/app/codex/route.test.ts
+++ b/apps/mouth/src/app/codex/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GET, POST } from './route';
 
@@ -9,10 +9,11 @@ const DOOR_MARKER = 'Da mihi signum';
 
 const URL_ = 'https://balizero.com/codex';
 
-function postRequest(pin: string): Request {
+function postRequest(pin: string, headers: Record<string, string> = {}): Request {
   return new Request(URL_, {
     method: 'POST',
     body: new URLSearchParams({ pin }),
+    headers,
   });
 }
 
@@ -65,3 +66,58 @@ describe('/codex PIN gate', () => {
     expect(body).not.toContain(CONTENT_MARKER);
   });
 });
+
+describe('/codex door alert (guilt + innocence)', () => {
+  const fetchMock = vi.fn(async () => new Response('{"messages":[{"id":"x"}]}', { status: 200 }));
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('CODEX_WA_TOKEN', 'test-token');
+    vi.stubEnv('CODEX_WA_PHONE_ID', '12345');
+    fetchMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('guilt: correct pin from Italy sends the ENTERED WhatsApp', async () => {
+    const res = await POST(postRequest('666', { 'x-vercel-ip-country': 'IT', 'x-vercel-ip-city': 'Roma' }));
+    expect(res.status).toBe(303);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('graph.facebook.com');
+    const body = JSON.parse(String(init.body));
+    expect(body.text.body).toContain('ENTRATO');
+    expect(body.text.body).toContain('IT (Roma)');
+  });
+
+  it('guilt: wrong pin from Italy sends the door WhatsApp', async () => {
+    const res = await POST(postRequest('123', { 'x-vercel-ip-country': 'IT' }));
+    expect(res.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body));
+    expect(body.text.body).toContain('sbagliato');
+  });
+
+  it('innocence: correct pin from a skip-listed country stays silent', async () => {
+    const res = await POST(postRequest('666', { 'x-vercel-ip-country': 'US' }));
+    expect(res.status).toBe(303);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('innocence: alert not configured — door still works, nothing sent', async () => {
+    vi.stubEnv('CODEX_WA_TOKEN', '');
+    const res = await POST(postRequest('666', { 'x-vercel-ip-country': 'IT' }));
+    expect(res.status).toBe(303);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('innocence: WhatsApp API failure never blocks the reader', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    const res = await POST(postRequest('666', { 'x-vercel-ip-country': 'IT' }));
+    expect(res.status).toBe(303);
+  });
+});
+

--- a/apps/mouth/src/app/codex/route.ts
+++ b/apps/mouth/src/app/codex/route.ts
@@ -87,6 +87,59 @@ function doorHtml(error = false): string {
 </html>`;
 }
 
+
+// ---- door alert -------------------------------------------------------------
+// The door itself reports who knocked: Vercel stamps the client's geo on every
+// request (x-vercel-ip-country/-city), so no log polling and no third-party
+// token is needed. Countries in CODEX_ALERT_SKIP_COUNTRIES (default US — the
+// owner's current location and the fleet's probes) stay silent; everyone else
+// (the intended reader connects from Italy) triggers a WhatsApp to the owner.
+// The alert is auxiliary: any failure is logged and NEVER blocks the reader.
+const ALERT_TIMEOUT_MS = 3000;
+
+function skipCountries(): Set<string> {
+  return new Set(
+    (process.env.CODEX_ALERT_SKIP_COUNTRIES ?? 'US')
+      .split(',')
+      .map((c) => c.trim().toUpperCase())
+      .filter(Boolean),
+  );
+}
+
+async function notifyDoor(req: Request, entered: boolean): Promise<void> {
+  try {
+    const token = process.env.CODEX_WA_TOKEN;
+    const phoneId = process.env.CODEX_WA_PHONE_ID;
+    if (!token || !phoneId) return; // alert not configured — door still works
+    const country = (req.headers.get('x-vercel-ip-country') ?? '??').toUpperCase();
+    if (skipCountries().has(country)) return;
+    const city = decodeURIComponent(req.headers.get('x-vercel-ip-city') ?? '');
+    const when = new Intl.DateTimeFormat('it-IT', {
+      timeZone: 'Europe/Rome',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date());
+    const where = city ? `${country} (${city})` : country;
+    const text = entered
+      ? `📜 CODEX — qualcuno è ENTRATO col segno giusto · ${where} · ${when} IT`
+      : `📜 CODEX — segno sbagliato alla porta · ${where} · ${when} IT`;
+    const res = await fetch(`https://graph.facebook.com/v22.0/${phoneId}/messages`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        to: process.env.CODEX_ALERT_TO ?? '6282210302328',
+        type: 'text',
+        text: { body: text },
+      }),
+      signal: AbortSignal.timeout(ALERT_TIMEOUT_MS),
+    });
+    if (!res.ok) console.error('codex door alert failed:', res.status, await res.text());
+  } catch (err) {
+    console.error('codex door alert error:', err);
+  }
+}
+
 export async function GET(req: Request): Promise<Response> {
   const sig = getCookie(req, COOKIE_NAME);
   if (sig && sig === (await expectedSig())) {
@@ -100,6 +153,7 @@ export async function POST(req: Request): Promise<Response> {
   const pin = form?.get('pin');
   if (typeof pin === 'string' && pin.trim() === PIN) {
     const sig = await expectedSig();
+    await notifyDoor(req, true);
     return new Response(null, {
       status: 303,
       headers: {
@@ -110,5 +164,6 @@ export async function POST(req: Request): Promise<Response> {
       },
     });
   }
+  await notifyDoor(req, false);
   return new Response(doorHtml(true), { status: 401, headers: BASE_HEADERS });
 }


### PR DESCRIPTION
## Why

The Mini polling receptor (#2048) went blind ~6h after birth: Vercel **geo-blocks** its internal `request-logs` endpoint from non-US IPs — same bearer token returns 200 from California and 403 from Indonesia. Before dying it did its job: two real alerts fired (4 + 3 foreign events, 18:57 and 20:27 UTC).

## What

The door now reports who knocked, by itself: `/codex` POST reads `x-vercel-ip-country`/`-city` (stamped by Vercel on every request — real client geo, better than edge region) and sends the WhatsApp directly. Correct pin = "è ENTRATO", wrong pin = "segno sbagliato alla porta". No polling, no Vercel API token, no geo fragility.

- Skip-list `CODEX_ALERT_SKIP_COUNTRIES` (default `US` — owner's current location + fleet probes egress).
- Alert awaited with 3s timeout, fail-open: WA outage or missing config can never block the reader.
- Env added to Vercel production pre-merge (`CODEX_WA_TOKEN`, `CODEX_WA_PHONE_ID`, `CODEX_ALERT_SKIP_COUNTRIES=ZZ` temporarily for the post-merge live proof, then reverted to default).

## Verify

- 10/10 route tests (5 existing gate + 5 new guilt/innocence: IT entry alerts with `IT (Roma)`, IT wrong-pin alerts as door, US silent, unconfigured silent-but-working, WA network failure still 303).
- Post-merge live proof plan: probe from M5 with skip=ZZ → real WA arrives; revert skip to default US → probe silent; then retire the blind Mini organ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)