### PR TITLE
fix(codex): recursion brake in autofix generator — never fix your own fixes

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -19,6 +19,7 @@ on:
       - "scripts/arsenal_probe.py"
       - "scripts/check_adversarial_review.py"
       - "scripts/jules_dispatch.py"
+      - "scripts/codex/codex-nightly-autofix-ci.sh"
       - "scripts/tests/test_lint_home_fork.py"
       - "scripts/tests/test_secrets_permissions_audit.py"
       - "scripts/tests/test_pending_arms_report.py"
@@ -26,6 +27,7 @@ on:
       - "scripts/tests/test_arsenal_probe.py"
       - "scripts/tests/test_adversarial_review_gate.py"
       - "scripts/tests/test_jules_dispatch.py"
+      - "scripts/tests/test_codex_autofix_selector.py"
       - "infra/home-fork/declared-pairs.json"
       - ".claude/skills/modus/PENDING-ARMS.md"
       - ".github/workflows/immune-enforcement.yml"
@@ -56,7 +58,8 @@ jobs:
             scripts/tests/test_lint_plist_keepalive.py \
             scripts/tests/test_arsenal_probe.py \
             scripts/tests/test_adversarial_review_gate.py \
-            scripts/tests/test_jules_dispatch.py ; do
+            scripts/tests/test_jules_dispatch.py \
+            scripts/tests/test_codex_autofix_selector.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"
               python -m pytest "$t" -q || fail=1

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -39,6 +39,14 @@
       ]
     },
     {
+      "live": "~/scripts/codex/nightly-autofix-ci.sh",
+      "repo": "scripts/codex/codex-nightly-autofix-ci.sh",
+      "_note": "Hourly codex auto-fix generator (plist com.nuzantara.codex-autofix-ci, StartCalendarInterval Minute=15, via cron-runner.sh). Declared 2026-07-06 together with the recursion-brake fix — was an UNDECLARED live payload (family #1); basenames differ by history.",
+      "machines": [
+        "pro"
+      ]
+    },
+    {
       "live": "~/scripts/wr2-ig-metrics-analyst-run.sh",
       "repo": "infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh",
       "_note": "Promoted to repo canon 2026-07-06 (healer tick) to close the sonnet-5 runtime-proof gap (PENDING-ARMS 2026-07-03): live copy called `claude` directly with no 'used: <tier>' log line. Repo canon adds explicit provenance logging only — same invocation, same model. Live HOME copy on Pro still needs manual sync (healer is read-only on Pro).",

--- a/scripts/codex/codex-nightly-autofix-ci.sh
+++ b/scripts/codex/codex-nightly-autofix-ci.sh
@@ -172,10 +172,19 @@ while IFS= read -r run_json; do
 
     ELIGIBLE_RUN_JSON="$run_json"
     break
+# RECURSION BRAKE (2026-07-06): never select a failure on one of our OWN
+# codex/auto-fix-ci-* branches — each failed fix PR became the next cycle's
+# target (#2063→#2064→#2065, hourly daisy-chain capped only by DAILY_CAP).
+# Also skip dependabot/* branches: dependabot force-pushes/recreates them, so
+# a fix PR based on one has a mutable base and gets orphaned (today's chain
+# root was a 98-package bump). Revert the dependabot line if we ever WANT
+# codex attempting dependabot repairs — the recursion line must stay.
 done < <(printf '%s\n' "$FAILED_RUNS" | jq -c --arg now "$NOW_EPOCH" --arg cooldown "$COOLDOWN_PER_RUN" --arg statefile "$STATE_FILE" '
     .[] | select(
         .headBranch != "main" and
         .headBranch != "master" and
+        (.headBranch | startswith("codex/auto-fix-ci-") | not) and
+        (.headBranch | startswith("dependabot/") | not) and
         .name != "Codex auto-fix on CI failure"
     ) | {
         run_id: (.databaseId | tostring),

--- a/scripts/tests/test_codex_autofix_selector.py
+++ b/scripts/tests/test_codex_autofix_selector.py
@@ -1,0 +1,107 @@
+"""Guilt+innocence for the codex-nightly-autofix-ci.sh eligibility filter.
+
+Recursion bite 2026-07-06: the generator chased its own codex/auto-fix-ci-*
+branches — each failed fix PR became the next cycle's target (#2063 -> #2064
+-> #2065, hourly, bounded only by the daily cap). Root of the chain was a
+failing dependabot mega-bump, whose branch is force-push mutable and thus a
+fragile base for a fix PR.
+
+The filter must never select:
+  - its own output branches (codex/auto-fix-ci-*)  [recursion brake]
+  - dependabot/* branches (mutable base)           [fragile-base guard]
+and must still select a genuine feature-branch failure (innocence).
+
+Runs the REAL script in CODEX_AUTOFIX_DRY_RUN=1 with injected failed-runs
+JSON — no gh, no codex, no network, no git mutations (dry-run exits before
+any checkout).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent / "codex" / "codex-nightly-autofix-ci.sh"
+)
+
+
+def _mkrun(run_id: int, branch: str, name: str = "Tests & Coverage") -> dict:
+    return {
+        "databaseId": run_id,
+        "name": name,
+        "headBranch": branch,
+        "headSha": "a" * 40,
+        "displayTitle": f"run on {branch}",
+        "createdAt": "2026-07-06T17:00:00Z",
+    }
+
+
+def _run(tmp_path: Path, runs: list[dict]) -> subprocess.CompletedProcess:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "CODEX_AUTOFIX_DRY_RUN": "1",
+            "CODEX_AUTOFIX_FAILED_RUNS_JSON": json.dumps(runs),
+            "CODEX_AUTOFIX_STATE_DIR": str(tmp_path / "state"),
+            "CODEX_AUTOFIX_LOG_DIR": str(tmp_path / "logs"),
+            "CODEX_AUTOFIX_REPO_ROOT": str(repo_root),
+            # Point at a nonexistent lib so the HOME automation lib is never sourced.
+            "CODEX_AUTOMATION_LIB": str(tmp_path / "no-such-lib.sh"),
+        }
+    )
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_guilt_own_autofix_branch_never_selected(tmp_path):
+    """A failure on codex/auto-fix-ci-* must be invisible (recursion brake)."""
+    proc = _run(tmp_path, [_mkrun(111, "codex/auto-fix-ci-99999")])
+    assert proc.returncode == 0, proc.stderr
+    assert "No eligible failures" in proc.stdout
+    assert "selected run_id" not in proc.stdout
+
+
+def test_guilt_dependabot_branch_never_selected(tmp_path):
+    """A failure on dependabot/* must be invisible (mutable fix base)."""
+    proc = _run(
+        tmp_path, [_mkrun(222, "dependabot/pip/apps/backend-rag/minor-and-patch-x")]
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "No eligible failures" in proc.stdout
+
+
+def test_guilt_main_branch_never_selected(tmp_path):
+    """Pre-existing guard pinned: main failures are not auto-fix targets."""
+    proc = _run(tmp_path, [_mkrun(233, "main")])
+    assert proc.returncode == 0, proc.stderr
+    assert "No eligible failures" in proc.stdout
+
+
+def test_innocence_feature_branch_selected(tmp_path):
+    """A genuine feature-branch failure must still be selected."""
+    proc = _run(tmp_path, [_mkrun(333, "agent/air-m5/feature/x")])
+    assert proc.returncode == 0, proc.stderr
+    assert "[dry-run] selected run_id=333" in proc.stdout
+
+
+def test_innocence_real_failure_behind_own_branch_selected(tmp_path):
+    """Own-branch noise ahead in the list must not shadow a real failure."""
+    proc = _run(
+        tmp_path,
+        [
+            _mkrun(444, "codex/auto-fix-ci-123"),
+            _mkrun(555, "feature/real-work"),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "[dry-run] selected run_id=555" in proc.stdout


### PR DESCRIPTION
## The loop

The hourly codex auto-fix generator (Pro plist `com.nuzantara.codex-autofix-ci`, Minute=15) selects the first eligible failed run. The eligibility filter excluded `main`/`master` and its own workflow name — **but not its own output branches**. So:

1. Dependabot 98-package bump PR fails Tests & Coverage →
2. generator opens #2063 based on the dependabot branch → #2063's CI fails →
3. generator picks THAT run → #2064 → fails → #2065 → …

Hourly daisy-chain, bounded only by `DAILY_CAP=3`, restarting every day. Verified by tracing run headBranches: #2065's target ran on #2064's branch, #2064's on #2063's, root = `dependabot/pip/apps/backend-rag/minor-and-patch-6327ff60af`.

## Fix

Two lines in the jq filter:
- `codex/auto-fix-ci-*` excluded — **recursion brake** (must stay, ever)
- `dependabot/*` excluded — fragile base: dependabot force-pushes/recreates branches, orphaning any fix PR built on one. Reversible design choice — drop this line if we ever want codex attempting dependabot repairs.

## Proofs

- 5 guilt/innocence tests run the **real script** in `CODEX_AUTOFIX_DRY_RUN=1` with injected failed-runs JSON (no gh/codex/network): own-branch invisible, dependabot invisible, main invisible, feature branch selected, real failure not shadowed by own-branch noise. 5/5 local.
- `bash -n` + `jq empty` clean.

## Arming plan (post-merge)

- Pro HOME copy `~/scripts/codex/nightly-autofix-ci.sh` is blob-identical to pre-fix canon (verified `d25e7639`) → plain `cp` canon→HOME after merge, blob-proof after. Pair now DECLARED in `declared-pairs.json` (was an undeclared live payload, family #1).
- The 3 tail PRs (#2063/#2064/#2065) are reaper territory (`codex-autofix-reaper`): Tests & Coverage is green on main, so they're close-eligible at its next cycle; a dry-run dispatch will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)