### PR TITLE
chore(mouth): log codex door alert delivery outcome

### DIFF
--- a/apps/mouth/src/app/codex/route.ts
+++ b/apps/mouth/src/app/codex/route.ts
@@ -135,6 +135,7 @@ async function notifyDoor(req: Request, entered: boolean): Promise<void> {
       signal: AbortSignal.timeout(ALERT_TIMEOUT_MS),
     });
     if (!res.ok) console.error('codex door alert failed:', res.status, await res.text());
+    else console.log(`codex door alert sent: ${entered ? 'entered' : 'wrong-pin'} from ${where}`);
   } catch (err) {
     console.error('codex door alert error:', err);
   }


### PR DESCRIPTION
## What

One `console.log` on successful codex door alert delivery (`entered`/`wrong-pin` + country/city — geo only, no PII), mirroring the existing failure log. Runtime logs now show both outcomes of the alert path added in #2068.

## Why now

Also serves as the redeploy vehicle that drops the temporary `CODEX_ALERT_SKIP_COUNTRIES=ZZ` live-proof value from the running deployment: the env var is already removed from the Vercel store (code default `US` takes over), but the running deployment was created while it was set, and `vercel redeploy` is deterministically canceled by the monorepo ignore-step. Guilt proof passed live (real WhatsApp delivered from a US probe with skip=ZZ); the innocence proof (US probe silent) runs against the deployment from this PR.

## Verify

10/10 route tests pass (5 gate + 5 alert guilt/innocence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)