### PR TITLE
chore(home-fork): declare local-livekit pair, allow-list mini-git-pull bridge

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -98,6 +98,22 @@
       ]
     },
     {
+      "live": "~/Library/Application Support/Nuzantara/local-livekit/scripts/run_local_livekit_server.sh",
+      "repo": "apps/backend-rag/scripts/run_local_livekit_server.sh",
+      "_note": "Was UNDECLARED (part of the 2026-07-05 13-payload finding). Confirmed byte-identical 2026-07-07 (healer tick).",
+      "machines": [
+        "mini"
+      ]
+    },
+    {
+      "live": "~/Library/Application Support/Nuzantara/local-livekit/scripts/run_local_livekit_worker.sh",
+      "repo": "apps/backend-rag/scripts/run_local_livekit_worker.sh",
+      "_note": "Was UNDECLARED (part of the 2026-07-05 13-payload finding). Confirmed byte-identical 2026-07-07 (healer tick).",
+      "machines": [
+        "mini"
+      ]
+    },
+    {
       "live": "~/scripts/healer-run.sh",
       "repo": "infra/healer/healer-run.sh",
       "machines": [
@@ -142,6 +158,7 @@
   ],
   "allow": [
     "~/Library/Application Support/Google/GoogleUpdater/*",
-    "~/Library/Google/GoogleSoftwareUpdate/*"
+    "~/Library/Google/GoogleSoftwareUpdate/*",
+    "~/scripts/mini-git-pull-bridge.sh"
   ]
 }


### PR DESCRIPTION
## Summary
- 2 of the 13 undeclared HOME-executed payloads from the 2026-07-05 ledger finding have a byte-identical repo twin: `run_local_livekit_server.sh` / `run_local_livekit_worker.sh` (both at `apps/backend-rag/scripts/`). Re-verified byte-identical this session via `diff` before declaring.
- `~/scripts/mini-git-pull-bridge.sh` is a genuine one-off TCC bridge (launchd cannot exec under `~/Desktop`) whose own header already documents it as intentional, pointing at the already-declared `mini-git-pull.sh`. Allow-listed rather than promoted to canon.
- Reduces the ledger's "13 undeclared HOME-executed payloads" tech-debt item to 10 remaining (wa-mirror-runner, wr2-warroom-sync, WR2Control.app, zero-design/run.sh, fly-pg-tunnel-from-config x2, ollama-warm-pin, openclaw-cron x3 — still need real triage: promote-to-canon or allow-list-with-rationale, not yet done here).

## Test plan
- [x] `infra/home-fork/declared-pairs.json` valid JSON
- [x] `pytest scripts/tests/test_lint_home_fork.py` 23/23 pass
- [ ] Post-merge: `python3 scripts/lint_home_fork.py --discover` on Mini shows count drop 13 -> 10 (the tool is worktree-hardened — reads only the main checkout — so this can't be exercised pre-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)