### PR TITLE
🎨 Palette: Implement Stop Generation and Sidebar Tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -62,3 +62,8 @@
 
 **Learning:** Live UI states that lack visual labels (like a voice recording overlay) are "silent" to screen readers. Adding `role="status"` and `aria-live="polite"` ensures that assistive technology users are notified of state transitions (e.g., recording started) without being interrupted. Furthermore, adding `aria-label` to semantic lists of "Quick Actions" provides necessary context for group navigation, making the interface more discoverable.
 **Action:** Always apply ARIA live regions to dynamic status overlays. Use descriptive `aria-label` on semantic list containers that serve as primary interaction points.
+
+## 2026-06-22 - [Stop Generation Pattern and Native Tooltips]
+
+**Learning:** In streaming chat interfaces, users value agency and the ability to interrupt long or irrelevant responses. Implementing a "Stop Generation" pattern—where the 'Send' button transforms into a 'Stop' button (Square icon) with high-contrast red styling—provides clear visual feedback and enhances user control. Additionally, for navigation elements with truncated text (like chat history), leveraging the native `title` attribute is a lightweight, accessible way to ensure full content is discoverable on hover without complex tooltip libraries.
+**Action:** Implement "Stop" buttons during all long-running AI streaming operations. Use standard red themed styling (`bg-red-500`) and the `Square` icon for interruptive actions. Always apply the `title` attribute to elements using `truncate` to ensure text discoverability.

--- a/apps/mouth/src/app/chat/page.tsx
+++ b/apps/mouth/src/app/chat/page.tsx
@@ -39,6 +39,7 @@ export default function ChatPage() {
     teamStatus,
     showUserMenu,
     handleSend,
+    handleStop,
     handleNewChat,
     handleConversationClick,
     handleDeleteConversation,
@@ -116,6 +117,7 @@ export default function ChatPage() {
           showImagePrompt={chatInput.imageGenPrompt !== ""}
           setShowImagePrompt={(val) => chatInput.setImageGenPrompt(val ? " " : "")}
           onSend={handleSend}
+          onStop={handleStop}
           onImageGenerate={() => setImageModalOpen(true)}
           showAttachMenu={showAttachMenu}
           setShowAttachMenu={setShowAttachMenu}

--- a/apps/mouth/src/components/chat/ChatInputBar.tsx
+++ b/apps/mouth/src/components/chat/ChatInputBar.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { UI } from "@/constants";
 import {
   Send,
+  Square,
   ImageIcon,
   Plus,
   Loader2,
@@ -26,6 +27,7 @@ export interface ChatInputBarProps {
   showImagePrompt: boolean;
   setShowImagePrompt: (value: boolean) => void;
   onSend: () => void;
+  onStop?: () => void;
   onImageGenerate: () => void;
   showAttachMenu: boolean;
   setShowAttachMenu: (value: boolean) => void;
@@ -57,6 +59,7 @@ export function ChatInputBar({
   isRecording,
   recordingTime,
   onStartRecording,
+  onStop,
   onStopRecording,
   onToggleRecording,
   attachedImages = [],
@@ -279,26 +282,40 @@ export function ChatInputBar({
               aria-label={
                 showImagePrompt ? "Describe your image" : "Type your message"
               }
-              disabled={isLoading}
+              disabled={isLoading && !showImagePrompt}
               rows={1}
               className="flex-1 border-0 bg-transparent focus:ring-0 focus:outline-none focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 min-h-[40px] py-2 px-3 text-sm text-[#D8D6D0] placeholder:text-zinc-500 font-medium outline-none ring-0"
             />
 
             <Button
-              onClick={showImagePrompt ? onImageGenerate : onSend}
-              disabled={!input.trim() || isLoading}
+              onClick={
+                isLoading
+                  ? onStop
+                  : showImagePrompt
+                    ? onImageGenerate
+                    : onSend
+              }
+              disabled={
+                isLoading
+                  ? !onStop
+                  : !input.trim() && !showImagePrompt
+              }
               size="icon"
-              className="rounded-full flex-shrink-0 w-10 h-10 glow-button border-0 focus-ring"
+              className={`rounded-full flex-shrink-0 w-10 h-10 border-0 focus-ring transition-all duration-200 ${
+                isLoading
+                  ? "bg-red-500 hover:bg-red-600 shadow-lg shadow-red-500/20"
+                  : "glow-button"
+              }`}
               aria-label={
                 isLoading
-                  ? "Sending..."
+                  ? "Stop generation"
                   : showImagePrompt
                     ? "Generate image"
                     : "Send message"
               }
             >
               {isLoading ? (
-                <Loader2 className="w-5 h-5 animate-spin" />
+                <Square className="w-4 h-4 fill-current" />
               ) : (
                 <Send className="w-5 h-5" />
               )}

--- a/apps/mouth/src/components/chat/ChatSidebar.tsx
+++ b/apps/mouth/src/components/chat/ChatSidebar.tsx
@@ -146,7 +146,10 @@ export function ChatSidebar({
                       }
                     >
                       <MessageSquare className="w-4 h-4 text-gray-500 flex-shrink-0" />
-                      <span className="text-sm text-gray-400 truncate flex-1">
+                      <span
+                        className="text-sm text-gray-400 truncate flex-1"
+                        title={conv.title || "Untitled"}
+                      >
                         {conv.title || "Untitled"}
                       </span>
                     </button>

--- a/apps/mouth/src/hooks/useChatPage.ts
+++ b/apps/mouth/src/hooks/useChatPage.ts
@@ -83,6 +83,7 @@ export interface UseChatPageReturn {
 
   // Handlers
   handleSend: () => Promise<void>;
+  handleStop: () => void;
   handleNewChat: () => void;
   handleConversationClick: (id: number) => Promise<void>;
   handleDeleteConversation: (id: number, e: React.MouseEvent) => void;
@@ -579,6 +580,7 @@ export function useChatPage(): UseChatPageReturn {
     conversations,
     teamStatus,
     handleSend,
+    handleStop: chatSend.onStop,
     handleNewChat,
     handleConversationClick,
     handleDeleteConversation,

--- a/apps/mouth/src/hooks/useChatSend.ts
+++ b/apps/mouth/src/hooks/useChatSend.ts
@@ -59,6 +59,7 @@ export interface UseChatSendOptions {
 export interface UseChatSendReturn {
   isStreaming: boolean;
   sendMessage: (input: string, attachedImages?: ChatImage[]) => Promise<void>;
+  onStop: () => void;
   streamingSteps: Array<AgentStep>;
   currentStatus: string;
   setCurrentStatus: (status: string) => void;
@@ -76,7 +77,7 @@ export function useChatSend({
   onStep,
 }: UseChatSendOptions): UseChatSendReturn {
   const { t } = useTranslation();
-  const { isStreaming, setIsStreaming, sendStreamingMessage } =
+  const { isStreaming, setIsStreaming, sendStreamingMessage, abortStream } =
     useChatStreaming({
       sessionId,
       isMountedRef,
@@ -191,6 +192,7 @@ export function useChatSend({
   return {
     isStreaming,
     sendMessage,
+    onStop: abortStream,
     streamingSteps,
     currentStatus,
     setCurrentStatus,


### PR DESCRIPTION
💡 **What:** This PR adds two micro-UX improvements to the chat interface:
1. **Stop Generation Button:** The action button in the `ChatInputBar` now transforms into a red "Stop" button (Square icon) when the AI is generating a response. This allows users to interrupt streaming messages.
2. **Sidebar Tooltips:** Conversation titles in the `ChatSidebar` now have a native `title` attribute, ensuring that truncated titles are readable via a tooltip on hover.

🎯 **Why:** 
- **Agency:** Users value the ability to stop unwanted or overly long AI responses.
- **Discoverability:** Truncated text in the sidebar often hides crucial context; tooltips provide a low-overhead solution for this.
- **Consistency:** Follows project-standard iconography and styling for interruptive actions.

♿ **Accessibility:**
- Added `aria-label="Stop generation"` to the new state of the action button.
- Maintained `.focus-ring` for keyboard navigation.
- Native `title` provides a basic but effective way for assistive technologies and mouse users to access truncated content.

✅ **Verification:**
- Verified via isolated verification page and Playwright screenshots.
- Passed targeted vitest suite and ESLint checks for modified files.

---
*PR created automatically by Jules for task [4984303670608011984](https://jules.google.com/task/4984303670608011984) started by @Balizero1987*