### PR TITLE
chore(home-fork): declare 6 more Mini payloads, allow-list 2 (family #1)

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -154,11 +154,61 @@
       "machines": [
         "pro"
       ]
+    },
+    {
+      "live": "~/bin/wa-mirror-runner.sh",
+      "repo": "infra/launchagents/wrappers/wa-mirror-runner.sh",
+      "_note": "Part of the 2026-07-05 13-payload finding. Promoted to canon 2026-07-07 (healer tick), byte-identical.",
+      "machines": [
+        "mini"
+      ]
+    },
+    {
+      "live": "~/bin/wr2-warroom-sync.sh",
+      "repo": "infra/launchagents/wrappers/wr2-warroom-sync.sh",
+      "_note": "Part of the 2026-07-05 13-payload finding. Promoted to canon 2026-07-07 (healer tick), byte-identical.",
+      "machines": [
+        "mini"
+      ]
+    },
+    {
+      "live": "~/scripts/ollama-warm-pin.sh",
+      "repo": "infra/launchagents/wrappers/ollama-warm-pin.sh",
+      "_note": "Part of the 2026-07-05 13-payload finding. Promoted to canon 2026-07-07 (healer tick), byte-identical.",
+      "machines": [
+        "mini"
+      ]
+    },
+    {
+      "live": "~/scripts/openclaw-cron/drive-poll.sh",
+      "repo": "infra/launchagents/wrappers/openclaw-cron/drive-poll.sh",
+      "_note": "Part of the 2026-07-05 13-payload finding (openclaw-cron x3, crontab-executed not plist). Promoted to canon 2026-07-07 (healer tick), byte-identical.",
+      "machines": [
+        "mini"
+      ]
+    },
+    {
+      "live": "~/scripts/openclaw-cron/crm-kg-build-mediated.sh",
+      "repo": "infra/launchagents/wrappers/openclaw-cron/crm-kg-build-mediated.sh",
+      "_note": "Part of the 2026-07-05 13-payload finding (openclaw-cron x3, crontab-executed not plist). Promoted to canon 2026-07-07 (healer tick), byte-identical.",
+      "machines": [
+        "mini"
+      ]
+    },
+    {
+      "live": "~/scripts/openclaw-cron/crm-kg-garbage-collect.sh",
+      "repo": "infra/launchagents/wrappers/openclaw-cron/crm-kg-garbage-collect.sh",
+      "_note": "Part of the 2026-07-05 13-payload finding (openclaw-cron x3, crontab-executed not plist). Promoted to canon 2026-07-07 (healer tick), byte-identical.",
+      "machines": [
+        "mini"
+      ]
     }
   ],
   "allow": [
     "~/Library/Application Support/Google/GoogleUpdater/*",
     "~/Library/Google/GoogleSoftwareUpdate/*",
-    "~/scripts/mini-git-pull-bridge.sh"
+    "~/scripts/mini-git-pull-bridge.sh",
+    "~/Applications/WR2 Control.app/*",
+    "~/.local/bin/zero-design/*"
   ]
 }

--- a/infra/launchagents/wrappers/ollama-warm-pin.sh
+++ b/infra/launchagents/wrappers/ollama-warm-pin.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Pin the designated warm model after Ollama starts.
+# Reads MODEL_TOPOLOGY.json for the correct model per hostname.
+# Called by LaunchAgent com.nuzantara.ollama-warm-pin at boot.
+set -euo pipefail
+
+OLLAMA_URL="http://127.0.0.1:11434"
+TOPOLOGY="/Users/nuzantara/Desktop/nuzantara/MODEL_TOPOLOGY.json"
+LOG="$HOME/logs/ollama-warm-pin.log"
+PYTHON_BIN="${PYTHON_BIN:-/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3}"
+
+if [ ! -x "$PYTHON_BIN" ]; then
+    PYTHON_BIN="/opt/homebrew/bin/python3.11"
+fi
+
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] $*" >> "$LOG"; }
+
+# Wait for Ollama ready (max 60s)
+for i in $(seq 1 60); do
+    curl -sf "$OLLAMA_URL/api/tags" > /dev/null 2>&1 && break
+    sleep 1
+done
+
+if ! curl -sf "$OLLAMA_URL/api/tags" > /dev/null 2>&1; then
+    log "ERROR: Ollama not responding after 60s"
+    exit 1
+fi
+
+# Read warm model from topology
+MODEL=$("$PYTHON_BIN" -c "
+import json, socket
+t = json.load(open('$TOPOLOGY'))
+h = socket.gethostname()
+for v in t['nodes'].values():
+    if v['hostname'] == h:
+        print(v['warm_model'])
+        break
+")
+
+CTX=$("$PYTHON_BIN" -c "
+import json, socket
+t = json.load(open('$TOPOLOGY'))
+h = socket.gethostname()
+for v in t['nodes'].values():
+    if v['hostname'] == h:
+        print(v.get('warm_ctx', 4096))
+        break
+")
+
+if [ -z "$MODEL" ]; then
+    log "ERROR: No warm model found for hostname $(hostname)"
+    exit 1
+fi
+
+# Read additional warm models (optional — empty if not configured)
+EXTRA_MODELS=$("$PYTHON_BIN" -c "
+import json, socket
+t = json.load(open('$TOPOLOGY'))
+h = socket.gethostname()
+for v in t['nodes'].values():
+    if v['hostname'] == h:
+        for m in v.get('warm_models_extra', []) or []:
+            print(m)
+        break
+")
+
+# Pin a single model with keep_alive=-1 and think:false
+_pin_model() {
+    local model="$1"
+    local ctx="$2"
+    curl -s "$OLLAMA_URL/api/chat" \
+        -d "{\"model\": \"$model\", \"keep_alive\": -1, \"messages\": [{\"role\": \"user\", \"content\": \"ping\"}], \"stream\": false, \"think\": false, \"options\": {\"num_ctx\": $ctx, \"num_predict\": 1}}" \
+        > /dev/null 2>&1
+    log "Pinned $model warm (ctx=$ctx, keep_alive=-1)"
+}
+
+# Pin primary
+_pin_model "$MODEL" "$CTX"
+
+# Pin extras (use smaller ctx to keep memory footprint reasonable)
+if [ -n "$EXTRA_MODELS" ]; then
+    while IFS= read -r extra; do
+        [ -z "$extra" ] && continue
+        _pin_model "$extra" "8192"
+    done <<< "$EXTRA_MODELS"
+fi
+
+log "Warm-pin complete on $(hostname)"

--- a/infra/launchagents/wrappers/openclaw-cron/crm-kg-build-mediated.sh
+++ b/infra/launchagents/wrappers/openclaw-cron/crm-kg-build-mediated.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# CRM KG Tier-B mediated edges builder — every 6h
+# Calls Fly.io endpoint, returns immediately (background task on api side).
+source "$HOME/.openclaw-cron-env" 2>/dev/null || true
+
+LOG="$HOME/logs/cron-tmp/crm-kg-build-mediated.log"
+API_URL="${API_URL:-https://nuzantara-rag.fly.dev}"
+API_KEY="${NUZANTARA_API_KEY:-}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG"; }
+
+log "=== build-mediated trigger ==="
+
+if [ -z "$API_KEY" ]; then
+    log "❌ NUZANTARA_API_KEY non impostata"
+    exit 1
+fi
+
+HTTP_CODE=$(curl -s -o /tmp/crm_kg_mediated.tmp -w "%{http_code}" --max-time 30 \
+    -X POST -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+    "${API_URL}/api/admin/crm-kg/build-mediated" 2>/dev/null) || HTTP_CODE="000"
+
+BODY=$(cat /tmp/crm_kg_mediated.tmp 2>/dev/null || echo "")
+
+if [ "$HTTP_CODE" = "200" ]; then
+    log "✅ build-mediated OK: $BODY"
+else
+    log "⚠️ build-mediated HTTP $HTTP_CODE: $BODY"
+fi
+
+log "=== End ==="

--- a/infra/launchagents/wrappers/openclaw-cron/crm-kg-garbage-collect.sh
+++ b/infra/launchagents/wrappers/openclaw-cron/crm-kg-garbage-collect.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# CRM KG garbage collector — daily 03:00 WITA
+# Soft-deletes orphan nodes + hard-deletes old edges.
+source "$HOME/.openclaw-cron-env" 2>/dev/null || true
+
+LOG="$HOME/logs/cron-tmp/crm-kg-garbage-collect.log"
+API_URL="${API_URL:-https://nuzantara-rag.fly.dev}"
+API_KEY="${NUZANTARA_API_KEY:-}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG"; }
+
+log "=== garbage-collect trigger ==="
+
+if [ -z "$API_KEY" ]; then
+    log "❌ NUZANTARA_API_KEY non impostata"
+    exit 1
+fi
+
+HTTP_CODE=$(curl -s -o /tmp/crm_kg_gc.tmp -w "%{http_code}" --max-time 30 \
+    -X POST -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+    "${API_URL}/api/admin/crm-kg/garbage-collect" 2>/dev/null) || HTTP_CODE="000"
+
+BODY=$(cat /tmp/crm_kg_gc.tmp 2>/dev/null || echo "")
+
+if [ "$HTTP_CODE" = "200" ]; then
+    log "✅ garbage-collect OK: $BODY"
+else
+    log "⚠️ garbage-collect HTTP $HTTP_CODE: $BODY"
+fi
+
+log "=== End ==="

--- a/infra/launchagents/wrappers/openclaw-cron/drive-poll.sh
+++ b/infra/launchagents/wrappers/openclaw-cron/drive-poll.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Drive Changes Poll - Ogni 5 minuti
+# Triggera il polling di Google Drive per nuovi file via API endpoint dedicato
+
+source "$HOME/.openclaw-cron-env" 2>/dev/null || true
+
+LOG="/tmp/openclaw-drive-poll.log"
+API_URL="${API_URL:-https://nuzantara-rag.fly.dev}"
+API_KEY="${NUZANTARA_API_KEY:-}"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG"
+}
+
+log "=== Drive Poll Start ==="
+
+if [ -z "$API_KEY" ]; then
+    log "❌ NUZANTARA_API_KEY non impostata"
+    exit 1
+fi
+
+# Chiama direttamente il poll endpoint (sveglia il backend + esegue il poll)
+HTTP_CODE=$(curl -s -o /tmp/drive_poll_body.tmp -w "%{http_code}" --max-time 120 \
+    -X POST \
+    -H "X-API-Key: $API_KEY" \
+    -H "Content-Type: application/json" \
+    "${API_URL}/api/admin/drive/poll" 2>/dev/null) || HTTP_CODE="000"
+BODY=$(cat /tmp/drive_poll_body.tmp 2>/dev/null || echo "")
+
+if [ "$HTTP_CODE" = "200" ]; then
+    PROCESSED=$(echo "$BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('processed',0))" 2>/dev/null || echo "?")
+    log "✅ Drive poll OK: $PROCESSED new files processed"
+elif [ "$HTTP_CODE" = "000" ]; then
+    log "⚠️ Backend not responding (timeout/unreachable) — Fly may be sleeping"
+else
+    log "⚠️ Drive poll failed (HTTP $HTTP_CODE): $BODY"
+fi
+
+# Trunca log
+if [ -f "$LOG" ] && [ $(stat -f%z "$LOG" 2>/dev/null || echo 0) -gt 1048576 ]; then
+    tail -500 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+fi
+
+log "=== Drive Poll End ==="

--- a/infra/launchagents/wrappers/wa-mirror-runner.sh
+++ b/infra/launchagents/wrappers/wa-mirror-runner.sh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+set -euo pipefail
+
+export HOME="${HOME:-/Users/nuzantara}"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export NODE_ENV="${NODE_ENV:-production}"
+
+ENV_FILE="${WA_MIRROR_ENV_FILE:-${HOME}/.wa-mirror.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+mkdir -p "${HOME}/logs"
+
+cd "${WA_MIRROR_APP_DIR:-${HOME}/Desktop/nuzantara/apps/wa-mirror}"
+exec /opt/homebrew/bin/node --enable-source-maps dist/bridge/index.js

--- a/infra/launchagents/wrappers/wr2-warroom-sync.sh
+++ b/infra/launchagents/wrappers/wr2-warroom-sync.sh
@@ -1,0 +1,36 @@
+#!/bin/zsh
+# wr2-warroom-sync.sh — keep the Mini's WR2 Control data fresh from the Pro.
+#
+# The WR2 Control app on the Mini reads from $HOME/.wr2-warroom-sync/output
+# (set as WR2_WARROOM_ROOT in its LaunchAgent). The authoritative war-room data
+# lives on the Pro. This pulls Pro→Mini so Damar's operator view stays current.
+#
+# Fail-soft: a network flap (proxy/WireGuard/ssh) must NOT wipe or corrupt the
+# local copy. rsync to a same-filesystem staging dir then swap only on success,
+# and never run --delete against a half-synced tree. Logs every run (scar #2:
+# read the OUTCOME, not the exit code — we record file counts).
+set -uo pipefail
+
+SRC="pro:/Users/nuzantara/Desktop/nuzantara/apps/war-room/output/"
+DST="$HOME/.wr2-warroom-sync/output/"
+LOG="$HOME/Library/Logs/wr2-warroom-sync.log"
+STAMP="$(date '+%Y-%m-%d %H:%M:%S')"
+
+mkdir -p "$DST" "$(dirname "$LOG")"
+
+# 1) reachability probe — if the Pro is unreachable, log and exit 0 (no destructive op)
+if ! ssh -o ConnectTimeout=10 -o BatchMode=yes pro 'test -f /Users/nuzantara/Desktop/nuzantara/apps/war-room/output/queue/human-review-queue.json' 2>/dev/null; then
+  echo "$STAMP  SKIP — Pro unreachable or queue missing (no sync, local copy untouched)" >> "$LOG"
+  exit 0
+fi
+
+# 2) sync. --delete keeps the mirror honest, but only after the probe above proved
+#    the source is real (so we never mirror an empty/half source onto a good copy).
+if rsync -a --delete --timeout=120 "$SRC" "$DST" >/dev/null 2>>"$LOG"; then
+  COUNT=$(find "$DST/carousel" -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+  test -f "$DST/queue/human-review-queue.json" && Q="queue-ok" || Q="queue-MISSING"
+  echo "$STAMP  OK — synced ($COUNT carousel dirs, $Q)" >> "$LOG"
+else
+  echo "$STAMP  WARN — rsync failed (exit $?), local copy preserved" >> "$LOG"
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Reduces the 2026-07-05 13-undeclared-HOME-payload finding on Mini from 10 remaining to 2.
- Promotes `wa-mirror-runner.sh`, `wr2-warroom-sync.sh`, `ollama-warm-pin.sh`, and 3 openclaw-cron crontab scripts (`drive-poll.sh`, `crm-kg-build-mediated.sh`, `crm-kg-garbage-collect.sh`) to repo canon under `infra/launchagents/wrappers/`, declared in `infra/home-fork/declared-pairs.json`. All verified byte-identical to the live HOME copies via `diff` this session.
- Allow-lists `WR2Control.app` (compiled Mach-O GUI bundle, no portable script source) and `zero-design/run.sh` (lives under `~/zero-design-studio`, its own separate git repo — out of this monorepo's scope) rather than porting them.
- Deliberately leaves 2 undeclared: both `com.nuzantara.fly-pg-tunnel{,.local}.plist` point at `~/.local/bin/fly-pg-tunnel-from-config`, a legacy pre-supervisor tunnel script currently failing with Fly org-auth errors on Mini. This overlaps the already-tracked W87 DB-access-from-Mini ledger item and needs an architecture decision (retire vs. give Mini its own supervisor-based tunnel), not a mechanical port — tracked as a follow-up ledger line.

## Verification
- `python3 scripts/lint_home_fork.py --discover --config <worktree>/infra/home-fork/declared-pairs.json` (repo-root left at canonical main for correct repo-resident detection): undeclared count 10 → 2, and the 2 remaining are exactly the deferred fly-pg-tunnel entries.
- `diff` confirmed byte-identical for all 6 promoted scripts before copy.
- `--check` currently reports NO-REPO-TWIN against the unmodified main checkout (expected — the tool is worktree-hardened per W81 and reads canon from main, which doesn't have these files until this PR merges).

## Test plan
- [ ] Post-merge: `python3 scripts/lint_home_fork.py --discover` on Mini shows 2 remaining (fly-pg-tunnel only)
- [ ] Post-merge: `python3 scripts/lint_home_fork.py --check` shows no NO-REPO-TWIN for the 6 new pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)