### PR TITLE
chore(secrets-audit): prune tmp/jiti cache dirs from family #4 scan

### DIFF
--- a/scripts/secrets_permissions_audit.py
+++ b/scripts/secrets_permissions_audit.py
@@ -60,6 +60,8 @@ PRUNE_DIR_NAMES = frozenset(
         "Cache",
         "Caches",
         "CachedData",
+        "tmp",
+        "jiti",
     }
 )
 

--- a/scripts/tests/test_secrets_permissions_audit.py
+++ b/scripts/tests/test_secrets_permissions_audit.py
@@ -108,6 +108,30 @@ def test_innocence_public_key_and_readme_excluded(tmp_path: Path) -> None:
 
 
 # --------------------------------------------------------------------------
+# 4b. INNOCENCE — tmp/jiti cache dirs are pruned (2026-07-05 Pro false-positive
+# cluster: ~34 jiti *.cjs cache files under ~/.openclaw/tmp/jiti/), while a
+# sibling secret-like file OUTSIDE those dirs is still caught (guilt preserved)
+# --------------------------------------------------------------------------
+
+
+def test_innocence_tmp_and_jiti_cache_dirs_are_pruned(tmp_path: Path) -> None:
+    jiti_dir = tmp_path / "tmp" / "jiti"
+    jiti_dir.mkdir(parents=True)
+    cached_token_file = jiti_dir / "some-token-cache.cjs"
+    cached_token_file.write_text("// jiti transpile cache\n")
+    cached_token_file.chmod(0o644)
+
+    real_secret = tmp_path / ".env.master"
+    real_secret.write_text("SECRET=deadbeef\n")
+    real_secret.chmod(0o644)
+
+    findings = audit.scan([tmp_path], max_depth=4)
+
+    assert cached_token_file not in _paths(findings)
+    assert real_secret in _paths(findings)
+
+
+# --------------------------------------------------------------------------
 # 5. Symlink to a 0644 secret is skipped (never followed)
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `tmp` and `jiti` to `PRUNE_DIR_NAMES` in `scripts/secrets_permissions_audit.py`, closing the follow-up from the 2026-07-05 Pro secrets-audit enrichment ledger line (57 findings, ~34 false positives under `~/.openclaw/tmp/jiti/*.cjs` — jiti transpile cache files, not durable secret exposure).
- Adds a guilt+innocence test: a secret-like filename inside `tmp/jiti/` is pruned, a sibling real secret outside it is still caught.

## Test plan
- [x] `apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_secrets_permissions_audit.py -q` → 20 passed (incl. new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)