### PR TITLE
chore(deps): ignore fsspec >2026.2.0 until datasets raises its ceiling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "sentence-transformers"
         update-types: ["version-update:semver-major"]
+      # datasets==4.8.5 caps fsspec at <=2026.2.0; a group bump that raises
+      # fsspec past the cap makes the WHOLE minor-and-patch group unsatisfiable
+      # (uv resolver error -> one failed install cascades into 4 red required
+      # checks; see closed group PR #2062). Drop this ignore when datasets
+      # raises its fsspec ceiling - dependabot will then move the pair together.
+      - dependency-name: "fsspec"
+        versions: [">2026.2.0"]
     groups:
       # OpenAI-stack packages isolated into their own group so a breaking bump
       # (openai/langchain-openai sit near the frozen embedding path:


### PR DESCRIPTION
## Why

Group PR #2062 (98-package minor-and-patch bump) is unsatisfiable by construction: it bumps `fsspec` to 2026.6.0 while `datasets==4.8.5` requires `fsspec<=2026.2.0`. The failed install cascaded into 4 red required checks — and that red run seeded the codex auto-fix recursion chain (#2063→#2065) cured by #2069.

## Fix

Narrow `ignore` rule in `dependabot.yml`, same documented pattern as the existing torch / sentence-transformers / lucide-react entries:

```yaml
- dependency-name: "fsspec"
  versions: [">2026.2.0"]
```

Reversible: drop it when `datasets` raises its fsspec ceiling — dependabot then moves the pair together.

## After merge

`@dependabot recreate` on #2062 regenerates the group without the impossible pin (config is read from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)