### PR TITLE
fix(matagaruda): wire heartbeat-sidecar instrumentation for 3 running organs

### DIFF
--- a/apps/mata-garuda/scripts/run_intel_bridge.py
+++ b/apps/mata-garuda/scripts/run_intel_bridge.py
@@ -13,15 +13,39 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from mata_garuda.agents.intel_scraper_bridge import bridge_intel_scraper
+from mata_garuda.workers.heartbeat import emit_heartbeat
+
+# Organ id matches organs_registry.yaml `mata_garuda.intel_bridge_daily.mini`
+# (com.matagaruda.intel-bridge.daily on Mini). Wired 2026-07-07 (healer receptor
+# 4, PENDING-ARMS): this cron was running fine but had never written the
+# heartbeat sidecar the registry-driven receptor expects, so it was flagged
+# never_armed instead of ok. See mata_garuda.workers.heartbeat for the shared
+# emitter (same ~/.organism/last_seen/<organ_id>.json schema as other organs).
+ORGAN_ID = "mata_garuda.intel_bridge_daily.mini"
 
 
 def main() -> int:
     result = bridge_intel_scraper()
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    return 0 if result.get("case_resolved", False) else 0
+    # Heartbeat at real completion (after the bridge call returns), carrying
+    # its published/skipped counts — not just a process-start ping.
+    emit_heartbeat(
+        ORGAN_ID,
+        "ok",
+        metadata={
+            "published": result.get("published", 0),
+            "skipped": result.get("skipped", 0),
+            "case_resolved": result.get("case_resolved", False),
+        },
+    )
+    return 0
     # NOTE: we return 0 even on "no_recent_items" because the Lamarckian
     # case_not_resolved is informational, not an error, per GENOME.md.
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except BaseException as exc:  # noqa: BLE001 — heartbeat then re-raise
+        emit_heartbeat(ORGAN_ID, "fail", metadata={"error": f"{type(exc).__name__}: {exc}"})
+        raise

--- a/apps/mata-garuda/scripts/run_normalizer.py
+++ b/apps/mata-garuda/scripts/run_normalizer.py
@@ -13,25 +13,49 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from mata_garuda.runtime.knowledge import KnowledgeBase
+from mata_garuda.workers.heartbeat import emit_heartbeat
 from mata_garuda.workers.normalizer import run_normalizer
+
+# Organ id matches organs_registry.yaml `mata_garuda.normalizer_hourly.mini`
+# (com.matagaruda.normalizer.hourly on Mini). Wired 2026-07-07 (healer receptor
+# 4, PENDING-ARMS): this cron was running fine but had never written the
+# heartbeat sidecar the registry-driven receptor expects, so it was flagged
+# never_armed instead of ok. See mata_garuda.workers.heartbeat for the shared
+# emitter (same ~/.organism/last_seen/<organ_id>.json schema as other organs).
+ORGAN_ID = "mata_garuda.normalizer_hourly.mini"
 
 
 def main() -> int:
     kb = KnowledgeBase()
     total = {"processed": 0, "duplicates": 0, "published": 0, "errors": 0}
 
-    # Drain in batches of 50; cap 1000 items/run
-    for _ in range(20):
-        r = run_normalizer(kb, max_items=50)
-        if r.get("processed", 0) == 0:
-            break
-        for k in total:
-            total[k] += r.get(k, 0)
+    try:
+        # Drain in batches of 50; cap 1000 items/run
+        for _ in range(20):
+            r = run_normalizer(kb, max_items=50)
+            if r.get("processed", 0) == 0:
+                break
+            for k in total:
+                total[k] += r.get(k, 0)
+    finally:
+        kb.close()
 
-    kb.close()
     print(json.dumps({"run": total}, indent=2))
+
+    # Heartbeat at real completion (after the drain loop finishes), status
+    # derived from run stats via the shared convention (green-but-dead: read
+    # a backlog but nothing progressed -> degraded, not silently ok).
+    status = "fail" if total["errors"] and total["errors"] >= max(1, total["processed"]) else (
+        "degraded" if total["processed"] > 0 and total["published"] == 0 and total["duplicates"] == 0
+        else "ok"
+    )
+    emit_heartbeat(ORGAN_ID, status, metadata=total)
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except BaseException as exc:  # noqa: BLE001 — heartbeat then re-raise
+        emit_heartbeat(ORGAN_ID, "fail", metadata={"error": f"{type(exc).__name__}: {exc}"})
+        raise

--- a/apps/mata-garuda/scripts/run_sentinel_cell.py
+++ b/apps/mata-garuda/scripts/run_sentinel_cell.py
@@ -136,6 +136,14 @@ if __name__ == "__main__":
     # Stage 2 (2026-06-30): emit an organism heartbeat at end of every run so a
     # green-but-dead pulse surfaces in ~/.organism/last_seen instead of being
     # masked by an exit-0. Wraps main(), preserves its exit code, re-raises crashes.
+    #
+    # 2026-07-07 (healer receptor 4, PENDING-ARMS): organ_id fixed to match the
+    # id `mata_garuda.sentinel_daily.mini` declared in organs_registry.yaml (this
+    # script is the Mini `com.matagaruda.sentinel.daily` cron target — same code
+    # also runs hourly on Pro under a separate label, but only the Mini registry
+    # entry exists today). Previous id `mata_garuda.sentinel_cell` never matched
+    # any registry entry, so healer_receptor_registry.py always saw a missing
+    # sidecar and classified this organ `never_armed` despite it running fine.
     from mata_garuda.workers.heartbeat import run_with_heartbeat
 
-    sys.exit(run_with_heartbeat("mata_garuda.sentinel_cell", main))
+    sys.exit(run_with_heartbeat("mata_garuda.sentinel_daily.mini", main))


### PR DESCRIPTION
## Summary
- `healer_receptor_registry.py --node mini` flags `mata_garuda.sentinel_daily.mini` / `intel_bridge_daily.mini` / `normalizer_hourly.mini` as `never_armed`. On-disk verification (this PR's prep) confirmed the reality is mixed, not death: all 3 crons are loaded in launchd with fresh logs — they simply never wrote the `~/.organism/last_seen/<organ_id>.json` sidecar the registry-driven receptor expects.
- `run_sentinel_cell.py` already called `run_with_heartbeat()`, but under organ_id `mata_garuda.sentinel_cell` — which matches no registry entry. Fixed to the registry's `mata_garuda.sentinel_daily.mini`.
- `run_intel_bridge.py` and `run_normalizer.py` had zero heartbeat instrumentation. Added `emit_heartbeat()` calls at real completion (after the actual work returns), reusing `apps/mata-garuda/mata_garuda/workers/heartbeat.py` — the established in-repo emitter (same sidecar schema other mata_garuda organs already use), not a new format.
- `com.matagaruda.ner-worker.hourly` is untouched — it's genuinely unloaded in launchd (not just unwired) and needs an operator ARM/RETIRE decision, out of scope for this mechanical instrumentation PR.

## Test plan
- [x] `python3 -m py_compile` on all 3 edited files — all pass
- [x] `git diff --stat` confirms only the 3 intended files changed, `run_ner_worker.py` / `mata_garuda/workers/ner_worker.py` untouched
- [x] No existing test imports `run_intel_bridge.py` or `run_normalizer.py` directly; `tests/test_run_sentinel_cell.py` only exercises `_run_one_pulse()` (unaffected by the organ_id string change in the `__main__` block)
- [ ] Post-merge on Mini: `healer_receptor_registry.py --node mini` should show these 3 organs move from `never_armed` to `ok` after their next scheduled run

Ref: `.claude/skills/modus/PENDING-ARMS.md` (2026-07-07, "healer receptor 4")

🤖 Generated with [Claude Code](https://claude.com/claude-code)