### PR TITLE
fix(kbli): bound notebook inputs and close vector clients

### DIFF
--- a/apps/backend-rag/backend/app/routers/kbli_notebook.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook.py
@@ -12,11 +12,11 @@ import json
 import logging
 import time
 from inspect import isawaitable
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from backend.app.core.config import settings
 from backend.app.dependencies import (
@@ -24,6 +24,14 @@ from backend.app.dependencies import (
     get_search_service,
 )
 from backend.core.collection_registry import resolve_collection_name
+
+logger = logging.getLogger(__name__)
+
+KBLI_QUERY_MAX_LENGTH = 1024
+KBLI_SESSION_ID_MAX_LENGTH = 128
+KBLI_PUBLIC_LIMIT_MAX = 25
+KBLISearchQuery = Annotated[str, Query(min_length=1, max_length=KBLI_QUERY_MAX_LENGTH)]
+KBLIPublicLimit = Annotated[int, Query(ge=1, le=KBLI_PUBLIC_LIMIT_MAX)]
 
 # Persistent KBLI HTTP client (Golden Rule 10: never create AsyncClient per-request)
 _kbli_http_client: httpx.AsyncClient | None = None
@@ -40,7 +48,13 @@ def _get_kbli_client() -> httpx.AsyncClient:
     return _kbli_http_client
 
 
-logger = logging.getLogger(__name__)
+async def close_kbli_http_client() -> None:
+    """Close persistent KBLI Qdrant HTTP client during app shutdown."""
+    global _kbli_http_client
+    if _kbli_http_client is None:
+        return
+    await _kbli_http_client.aclose()
+    _kbli_http_client = None
 
 router = APIRouter(prefix="/kbli-notebook", tags=["KBLI Notebook"])
 
@@ -81,8 +95,8 @@ class KBLISearchResult(BaseModel):
 
 
 class KBLINotebookChatRequest(BaseModel):
-    query: str
-    session_id: str | None = None
+    query: str = Field(..., min_length=1, max_length=KBLI_QUERY_MAX_LENGTH)
+    session_id: str | None = Field(default=None, max_length=KBLI_SESSION_ID_MAX_LENGTH)
 
 
 class KBLINotebookChatResponse(BaseModel):
@@ -237,8 +251,8 @@ def get_kbli_ttl(code: str) -> int:
 
 @router.get("/search", response_model=list[KBLISearchResult])
 async def search_kbli(
-    query: str,
-    limit: int = 10,
+    query: KBLISearchQuery,
+    limit: KBLIPublicLimit = 10,
     search_service=Depends(get_search_service),
 ) -> Any:
     """Search for KBLI codes using semantic search (Qdrant)."""

--- a/apps/backend-rag/backend/app/setup/app_factory.py
+++ b/apps/backend-rag/backend/app/setup/app_factory.py
@@ -456,6 +456,8 @@ async def lifespan(app: FastAPI):
     services_to_close = [
         "alert_service",
         "search_service",
+        # SearchService shares this manager but does not own its shutdown hook.
+        "collection_manager",
         "ai_client",
         "intelligent_router",
         "tool_executor",
@@ -521,6 +523,17 @@ async def lifespan(app: FastAPI):
         logger.info("✅ Qdrant health check client closed")
     except Exception as e:
         logger.debug("Qdrant health client close: %s", e)
+
+    # Close persistent KBLI Notebook Qdrant client
+    try:
+        from backend.app.routers.kbli_notebook import close_kbli_http_client
+
+        await close_kbli_http_client()
+        logger.info("✅ KBLI Notebook Qdrant client closed")
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.warning("⚠️ Error closing KBLI Notebook Qdrant client: %s", e)
 
     # Close asyncpg database pool (not in services_to_close because it uses .close() differently)
     db_pool = getattr(app.state, "db_pool", None)

--- a/apps/backend-rag/backend/services/ingestion/collection_manager.py
+++ b/apps/backend-rag/backend/services/ingestion/collection_manager.py
@@ -8,6 +8,7 @@ Extracted from SearchService to follow Single Responsibility Principle.
 import asyncio
 import logging
 import time
+from inspect import isawaitable
 from typing import Any
 
 from backend.app.core.config import settings
@@ -165,6 +166,22 @@ class CollectionManager:
             collection_name,
             asyncio.Semaphore(self._max_concurrent_searches),
         )
+
+    async def close(self) -> None:
+        """Close cached Qdrant clients and clear the lazy collection cache."""
+        for name, client in list(self._collections_cache.items()):
+            close_fn = getattr(client, "close", None)
+            if close_fn is None:
+                continue
+            try:
+                close_result = close_fn()
+                if isawaitable(close_result):
+                    await close_result
+                logger.debug("✅ Closed collection client: %s", name)
+            except Exception as e:
+                logger.warning("⚠️ Error closing collection client '%s': %s", name, e)
+
+        self._collections_cache.clear()
 
     def get_collection(self, name: str) -> QdrantClient | None:
         """

--- a/apps/backend-rag/backend/tests/routers/test_kbli_notebook.py
+++ b/apps/backend-rag/backend/tests/routers/test_kbli_notebook.py
@@ -85,6 +85,33 @@ class TestSearchEndpoint:
 
         assert response.status_code == 503
 
+    @pytest.mark.integration
+    def test_search_kbli_rejects_oversized_query(self, client: TestClient) -> None:
+        response = client.get(
+            "/kbli-notebook/search",
+            params={"query": "x" * 1025, "limit": 10},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.integration
+    def test_search_kbli_rejects_unbounded_limit(self, client: TestClient) -> None:
+        response = client.get(
+            "/kbli-notebook/search",
+            params={"query": "restaurant", "limit": 100000},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.integration
+    def test_search_kbli_rejects_zero_limit(self, client: TestClient) -> None:
+        response = client.get(
+            "/kbli-notebook/search",
+            params={"query": "restaurant", "limit": 0},
+        )
+
+        assert response.status_code == 422
+
 
 class TestChatEndpoint:
     @pytest.mark.integration
@@ -166,3 +193,21 @@ class TestChatEndpoint:
             )
 
         assert response.status_code == 500
+
+    @pytest.mark.integration
+    def test_chat_kbli_rejects_oversized_query(self, client: TestClient) -> None:
+        response = client.post(
+            "/kbli-notebook/chat",
+            json={"query": "x" * 1025, "session_id": "bounds-test"},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.integration
+    def test_chat_kbli_rejects_oversized_session_id(self, client: TestClient) -> None:
+        response = client.post(
+            "/kbli-notebook/chat",
+            json={"query": "restaurant", "session_id": "x" * 129},
+        )
+
+        assert response.status_code == 422

--- a/apps/backend-rag/backend/tests/services/ingestion/test_collection_manager.py
+++ b/apps/backend-rag/backend/tests/services/ingestion/test_collection_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -194,3 +195,22 @@ async def test_ingest_with_lock_times_out_when_write_lock_is_held() -> None:
             await manager.ingest_with_lock("logical", documents=["doc"], embeddings=[[0.1]])
     finally:
         lock.release()
+
+
+@pytest.mark.asyncio
+async def test_close_closes_cached_collection_clients() -> None:
+    manager = CollectionManager(qdrant_url="http://qdrant.test")
+    first_client = MagicMock()
+    first_client.close = AsyncMock()
+    second_client = MagicMock()
+    second_client.close = AsyncMock()
+    manager._collections_cache = {
+        "kbli_2025_final": first_client,
+        "legal_unified": second_client,
+    }
+
+    await manager.close()
+
+    first_client.close.assert_awaited_once()
+    second_client.close.assert_awaited_once()
+    assert manager._collections_cache == {}

--- a/apps/backend-rag/backend/tests/unit/app/setup/test_app_factory.py
+++ b/apps/backend-rag/backend/tests/unit/app/setup/test_app_factory.py
@@ -171,3 +171,34 @@ class TestLifespan:
 
         # The lifespan cancels the init task if not done
         assert real_future.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_closes_kbli_notebook_client(self):
+        """Shutdown should close the KBLI notebook module-level HTTP client."""
+        from types import SimpleNamespace
+
+        from backend.app.setup.app_factory import lifespan
+
+        app_state = SimpleNamespace()
+        mock_app = MagicMock()
+        mock_app.state = app_state
+        close_kbli_http_client = AsyncMock()
+
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "backend.app.routers.kbli_notebook": MagicMock(
+                        close_kbli_http_client=close_kbli_http_client,
+                    )
+                },
+            ),
+            patch(
+                "backend.app.setup.app_factory.asyncio.create_task",
+                side_effect=_close_created_coro,
+            ),
+        ):
+            async with lifespan(mock_app):
+                pass
+
+        close_kbli_http_client.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Adds Pydantic/FastAPI input bounds on the public KBLI-notebook `/search` and `/chat` endpoints: query capped at 1024 chars, `session_id` capped at 128 chars, `limit` clamped to 1-25. Prevents unbounded-input abuse on public endpoints.
- Closes the module-level persistent `httpx.AsyncClient` in `kbli_notebook.py` and the cached Qdrant clients inside `CollectionManager` (new `.close()` method) on FastAPI shutdown, wired into `app_factory.py`'s lifespan teardown. Satisfies Golden Rule #10 (persistent async clients must be closed in lifespan), previously violated for these two clients.

## Test plan
- [x] Rebased onto current `origin/main` to resolve a real textual conflict in `collection_manager.py`/`test_collection_manager.py` against main's PR #1996 (concurrency-lock/semaphore hardening) — kept both additions (`_ensure_collection_lock_state()` + semaphore init from main, `close()` from this branch); test file rebuilt on top of main's fully-rewritten `FakeQdrantClient`-based suite plus the new `close()` test.
- [x] `PYTHONPATH=. pytest backend/tests/routers/test_kbli_notebook.py backend/tests/services/ingestion/test_collection_manager.py backend/tests/unit/app/setup/test_app_factory.py -q` → 28 passed
- [x] `PYTHONPATH=. pytest backend/tests/services/ingestion/ -q` (full ingestion suite) → 78 passed
- [x] `PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q` (CLAUDE.md §11 pre-deploy set) → 91 passed
- [x] `python -c "from backend.app.dependencies import get_current_user; print('OK')"` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)