### PR TITLE
docs(cicatrix): capture P1 scar — 2nd commit orphaned by squash-merge

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -367,3 +367,39 @@ _Discovered: 2026-06-23 · Severity: P1 (WR2 pipeline frozen 20→23 Jun) · Sta
 **ANTIBODY (fix in-turn, stessa sessione):** `FFONLY_PULL_SEGMENT_RE = \bgit\s+(?:-c\s+\S+\s+)*(?:-C\s+\S+\s+)?pull\b[^|;&#\n]*--ff-only(?!\S)` — il flag deve essere un ARGOMENTO del segmento pull: ancorato al verbo, si ferma a separatori di comando (| ; & newline) e a `#`. `--rebase` resta disqualifier-ovunque (over-blocking = direzione sicura). Test: il comando ESATTO del probe-log ora dà False; 15 guilt + 7 innocence + 4 probe.
 
 **GOTCHA:** (1) Il guilt-test live che "fallisce" è il test che funziona — ha beccato in 30 minuti quello che 15 test unitari non avevano immaginato (nessuno dei miei guilt-case aveva il flag in un commento; il caso reale l'ha scritto la mia stessa mano nel commento del test). (2) Quando aggiungi un'ECCEZIONE a una guardia, l'eccezione È una guardia a segno invertito: le serve il suo guilt+innocence, e il suo over-match = il blocco che si apre troppo. (3) `_strip_noise` non copre i commenti: chiunque riusi `cmd_scan` per un check di presenza-flag deve ancorare al segmento del comando, MAI substring globale. (4) La prova-finale-verde non basta: prova l'innocenza E la colpevolezza LIVE, nello stesso giro.
+
+### ⚠️ P2: kbli perizinan è string[] non string — type mentitore crasha resolveLicenseType (2026-06-28)
+
+_Discovered: 2026-06-28 · Severity: P2 · Status: FIXED (PR #1807, commit 51d3c368)_
+
+**TRAUMA**: portando i fix Swift sul web (apps/mouth), `resolveLicenseType` faceva `(perizinan || "").trim()` assumendo stringa (come diceva il tipo `KBLIScaleEntry.perizinan: string`). Ma il dato reale ha `perizinan` come **array** sul 99.5% delle scale (3941 list vs 20 str, spesso `[]`). Array è truthy -> `[].trim()` -> "trim is not a function" -> transformCode CRASHA al primo record. `tsc --noEmit` PASSA (il tipo mentiva), il pre-commit passa, ma i Frontend Tests mouth in CI falliscono 5/5 (kbli-data.test.ts). Stesso pattern dell'audit Swift di giugno (perizinanList[] vs scalar perizinan vuoto).
+
+**ANTIBODY**: `if(Array.isArray(perizinan))` -> join distinct non-vuoti con " · ", else derive-from-risk; mantieni il path scalar per i 20 legacy. Corretto il tipo a `string | string[]`. Verificato 0 crash su tutte le 9262 scale reali via node-runtime PRIMA del commit + casi array nel test.
+
+**GOTCHA**: il typecheck NON e' la rete di sicurezza quando il TIPO stesso e' sbagliato — `perizinan: string` su un dato `string[]` passa tsc e crasha a runtime. La rete e' il test che gira sul DATO REALE (vitest mouth) o il node-runtime-su-dataset-vero. Lezione cross: quando porti logica da un'altra app (Swift->TS), porta anche la conoscenza della FORMA reale del dato, non fidarti del tipo dichiarato nella app di destinazione.
+
+**Reference**: PR #1807, kbli-derive.ts resolveLicenseType, commit 51d3c368. Famiglia #9 (state-schema: tipo dichiarato != forma reale).
+
+### ⚠️ P2: KBLI app — 2 display surfaces ignore l4_bali.blocked, contradict the BLOCKED verdict (461 codes) (2026-06-28)
+
+_Discovered: 2026-06-28 18:50 WITA · Severity: P2 · Status: FIXED (commit 783bf32, kbli-navigator-app)_
+
+**TRAUMA**: On the rich KBLI card (Swift app ~/Desktop/kbli-navigator-app), code 55203 (Villa Rental) showed the verdict correctly as BLOCKED ("a PT PMA cannot register this code") — that surface reads l4Bali.blocked. But TWO other surfaces on the SAME card rendered the raw national-PMA fields and contradicted it: (1) the Authority & Legal Basis ledger table printed a green "PMA: Fully open · 100%" (KBLIRegistryView.swift authorityRows, the closed flag tested only pmaStatus=="TERTUTUP" || m==0 — national closure — never l4Bali.blocked); (2) the Ask Zantara opener (openerLine) truncated the curated bilingual verdict via v.split(".").first, and for a Bali-blocked code that verdict reads "Nationally open ... In Bali, however, ... closed to foreign-owned companies" — so .first alone = "fully open to foreign ownership (100% PMA)", which inverts the meaning. A client sees green "100% open" + Zantara "fully open" under a red "blocked" badge. Affects 461 codes nationally TERBUKA but Bali-blocked.
+
+**ANTIBODY**: Same cure as the whole #3 family — every surface that renders a PMA/openness signal must read the SAME l4Bali.blocked gate the verdict reads, or it is a guard-miss. (1) Authority row now has an else-if baliBlocked branch -> "Open nat'l · blocked in Bali" in the restricted colour, before the green "Fully open" fallback. (2) openerLine returns the WHOLE curated verdict when l4Bali.blocked. Data correct and untouched — rendering-honesty fix only. Structural rule: a verdict/badge and any secondary "at a glance" field that restate the same fact must derive from one shared predicate, not re-derive from raw fields independently.
+
+**GOTCHA**: NEW member of superscar #3 at a fresh grade — not an over-match (false block) nor W82 under-match (stale-fact passes), but a partial-truth surface: the guard fires on the primary surface (verdict) and is ABSENT on the secondary surfaces, which re-derive from raw data and disagree. Also: build.sh is zsh-only (${0:A:h}) — bash build.sh dies with "A: unbound variable" under set -u; run zsh build.sh. And build.sh cp's the canonical dataset from sibling monorepo source_documents/ on every build (cure for #1 HOME-fork), so the app's Resources/KBLI_2025_FINAL_CLEAN.json shows git-dirty after a build that is NOT your change — leave-dirty.
+
+**Reference**: kbli-navigator-app commit 783bf32 · KBLIRegistryView.swift (authorityRows ~535, openerLine ~787) · superscar #3 · memory "discovery KBLI Navigator app 2 display surfaces 2026-06-28"
+
+### ⚠️ P1: second commit pushed after auto-merge fired is orphaned by squash (2026-06-29)
+
+_Discovered: 2026-06-29 08:05 WITA · Severity: P1 · Status: fixed (re-landed PR #1826)_
+
+**TRAUMA**: PR #1824 (wa-mirror internal-sender guard) had auto-merge armed right after creation. I then committed a SECOND fix to the same branch (`edbc340da6` — downstream name-concordance + anti-funnel guards) and pushed. Auto-merge had ALREADY squash-merged the FIRST commit (`fc4ac55c`) at that point → PR went `state: MERGED` carrying only commit 1. The second commit sat orphaned on a dead branch. `gh pr view --json commits` showed "1 commit" (correct, not cache) while the remote BRANCH had 2 — I initially mis-read the discrepancy as API cache lag. The truth was the PR was already closed-merged; pushing more commits to a merged PR's branch does nothing. The downstream gate guards (the whole point of "affronta") never reached main.
+
+**ANTIBODY**: (1) After arming `--auto --squash`, treat the PR as CLOSED to further commits — a high-traffic repo merges within minutes. New work = new branch + new PR, never "push one more onto the armed branch". (2) When `gh pr view --json commits` count < local branch commits, check `state` FIRST: `MERGED` means the extra commits are orphaned, NOT cache lag. (3) Re-land via cherry-pick onto FRESH origin/main (W88: verify by CONTENT — `git show origin/main:<file> | grep <new-symbol>` returned 0, proving not landed) — NOT by re-pushing the stale branch, which had drifted behind main and would have reverted unrelated files (.pip-audit-ignore.md, mata-garuda heartbeat) = regression.
+
+**GOTCHA**: the stale-branch `git diff origin/main..branch` was noisy (20 files, -1120 lines) because main moved forward after the branch base — the deletions were main's NEW work the branch lacked, not the branch's contribution. The branch's REAL contribution was just `auto_attach.py +125` and its test `+80`. Re-pushing the stale branch to "fix" the orphan would have carried all those phantom reverts. Cherry-pick of the single clean commit onto fresh main is the only safe path.
+
+**Reference**: PR #1824 (merged, commit 1 only) → PR #1826 (re-land commit 2, `198f44cef0`). Family #9 state-schema/W88 (verify-by-content) + workflow `feedback_arm_automerge_default_not_leave_to_operator`.


### PR DESCRIPTION
## Summary
- Documents the PR #1824/#1826 incident (squash-merge orphaning a second commit pushed after `--auto --squash` armed) as a proper cicatrix scar entry.
- The branch's original code contribution (wa-mirror internal-sender guard + downstream name-concordance/anti-funnel guards in `auto_attach.py`) is **already fully merged into main** via PR #1824 and PR #1826 — verified this session by per-file blob comparison (`git rev-parse HEAD:<file>` vs `origin/main:<file>`): main is a strict superset of every file this branch touched.
- This PR ships only the doc-only remainder that never landed: the scar write-up itself, which was sitting uncommitted in the worktree.

## Context
A prior triage pass flagged this worktree as carrying real unmerged content. Re-verification (git diff + blob compare, W88 content-not-proxy method) confirmed:
- `auto_attach.py` / `test_intake_auto_attach.py`: HEAD's commits are a strict subset of what's already on `origin/main` (main even has additional evolution beyond this branch).
- `wa_mirror_intake_sweeper.py` / its test: blob-identical to main already.
- Only genuinely new content: an uncommitted addition to `.claude/rules/cicatrix-scars.md` documenting the incident — never captured anywhere on main.

Rebuilt the branch on fresh `origin/main` + this one doc commit (force-pushed; old dead commits are preserved in PR #1824/#1826 history already).

## Test plan
- [x] Doc-only change — no code/tests affected.
- [x] Verified no duplicate: grepped current `origin/main` cicatrix-scars.md for the entry heading, confirmed absent before this PR.
- [x] `git diff origin/main...HEAD --stat` shows a clean +36 line addition, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)