### PR TITLE
fix(wr2): deploy-pull self-heals read-only-runtime dirt instead of freezing (W81/#2)

### DIFF
--- a/scripts/tests/test_wr2_deploy_pull_selfheal.py
+++ b/scripts/tests/test_wr2_deploy_pull_selfheal.py
@@ -1,0 +1,177 @@
+"""Guilt+innocence tests for the dirty-worktree self-heal in wr2-deploy-pull.sh
+(W81/#2, incident 2026-07-05->07).
+
+A sibling session left a tracked-deleted plist (unstaged) in the deploy clone
+~/Desktop/nuzantara-deploy. The OLD single DIRTY block treated every porcelain
+line the same: log first entry, alert once (6h cooldown), exit 1 -- forever,
+because the clone stays dirty until a human intervenes. Code propagation to
+the WR2 runtime froze for 2+ days while the alert rotted behind cooldown.
+
+The deploy clone is BY CONTRACT read-only runtime: any local modification is
+drift, never valuable work. This suite proves the classifier:
+  (a) untracked (`?? `)                 -> not blocking, proceeds+advances
+  (b) unstaged tracked mod/del (` M`/` D`) -> self-healed via `git checkout --`,
+      proceeds+advances, status ok:self-healed
+  (c) staged / index-mutated entries    -> still refuses, exit 1, no self-heal
+  (d) WR2_DEPLOY_PULL_SELFHEAL=0        -> old freeze behavior preserved
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+DEPLOY_PULL = SCRIPTS_DIR / "wr2-deploy-pull.sh"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True
+    )
+    return out.stdout.strip()
+
+
+def _setup_deploy_world(tmp_path: Path):
+    """origin bare repo + deploy clone under a fake HOME (same pattern as
+    test_wr2_runtime_stamp.py's _setup_deploy_world -- kept independent here
+    so this file runs standalone)."""
+    home = tmp_path / "home"
+    (home / "Desktop").mkdir(parents=True)
+    src = tmp_path / "src"
+    src.mkdir()
+    _git(src, "init", "-q", "-b", "main")
+    _git(src, "config", "user.email", "t@t")
+    _git(src, "config", "user.name", "t")
+    (src / "f.txt").write_text("v1\n")
+    (src / "tracked.plist").write_text("<plist>v1</plist>\n")
+    _git(src, "add", ".")
+    _git(src, "commit", "-qm", "v1")
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(src), str(origin)], check=True)
+    deploy = home / "Desktop" / "nuzantara-deploy"
+    subprocess.run(["git", "clone", "-q", str(origin), str(deploy)], check=True)
+    return home, src, origin, deploy
+
+
+def _run_pull(home: Path, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env.pop("TELEGRAM_BOT_TOKEN", None)
+    # Hermetic: never let the real tg_notify.py touch a live spool/secrets.
+    env["TG_DRY_RUN"] = "1"
+    env["TG_SPOOL_DIR"] = str(home / ".organism" / "tg_spool")
+    env["TG_SECRETS_FILE"] = "/dev/null"
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(DEPLOY_PULL)], capture_output=True, text=True, env=env, timeout=60
+    )
+
+
+def _outcome(home: Path) -> dict:
+    p = home / ".organism" / "last_seen" / "wr2.deploy_pull.json"
+    assert p.is_file(), "outcome heartbeat missing -- the trap did not fire"
+    return json.loads(p.read_text())
+
+
+def _advance_remote(src: Path, origin: Path, marker: str = "v2") -> None:
+    (src / "f.txt").write_text(f"{marker}\n")
+    _git(src, "add", ".")
+    _git(src, "commit", "-qm", marker)
+    _git(src, "push", "-q", str(origin), "main")
+
+
+def _log_text(home: Path) -> str:
+    return (home / "logs" / "wr2-deploy-pull.log").read_text()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# (a) untracked junk -> not blocking, proceeds and advances
+# ─────────────────────────────────────────────────────────────────────────
+def test_untracked_junk_proceeds_and_advances(tmp_path):
+    home, src, origin, deploy = _setup_deploy_world(tmp_path)
+    (deploy / "venv-leftover.tmp").write_text("junk\n")  # untracked, not ours
+    _advance_remote(src, origin)
+
+    res = _run_pull(home)
+    assert res.returncode == 0, res.stderr
+    out = _outcome(home)
+    assert out["status"] == "ok:advanced"
+    log = _log_text(home)
+    assert "not blocking" in log
+    assert "venv-leftover.tmp" in log
+    # untracked junk must survive the run untouched (never git-checkout'd)
+    assert (deploy / "venv-leftover.tmp").is_file()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# (b) tracked file deleted locally (unstaged) -> self-healed, advances
+# ─────────────────────────────────────────────────────────────────────────
+def test_tracked_deleted_file_self_heals_and_advances(tmp_path):
+    home, src, origin, deploy = _setup_deploy_world(tmp_path)
+    (deploy / "tracked.plist").unlink()  # exactly the real incident's shape
+    _advance_remote(src, origin)
+
+    res = _run_pull(home)
+    assert res.returncode == 0, res.stderr
+    out = _outcome(home)
+    assert out["status"] == "ok:self-healed"
+    assert out["old_head"] != out["new_head"]
+    log = _log_text(home)
+    assert "self-healed dirty" in log
+    assert "tracked.plist" in log
+    # healed: the file is back, worktree clean
+    assert (deploy / "tracked.plist").is_file()
+    assert _git(deploy, "status", "--porcelain") == ""
+
+
+def test_tracked_modified_file_self_heals_when_up_to_date(tmp_path):
+    """No remote advance available -> still heals, terminal status reflects
+    the heal even though there was nothing to fast-forward."""
+    home, src, origin, deploy = _setup_deploy_world(tmp_path)
+    (deploy / "tracked.plist").write_text("<plist>LOCAL MUTATION</plist>\n")
+
+    res = _run_pull(home)
+    assert res.returncode == 0, res.stderr
+    out = _outcome(home)
+    assert out["status"] == "ok:self-healed"
+    assert out["old_head"] == out["new_head"]
+    assert _git(deploy, "status", "--porcelain") == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# (c) staged local change -> refuses, exit 1, no self-heal, P0 notified
+# ─────────────────────────────────────────────────────────────────────────
+def test_staged_change_refuses_no_selfheal(tmp_path):
+    home, src, origin, deploy = _setup_deploy_world(tmp_path)
+    (deploy / "new-staged.txt").write_text("staged content\n")
+    _git(deploy, "add", "new-staged.txt")
+
+    res = _run_pull(home)
+    assert res.returncode == 1, res.stderr
+    out = _outcome(home)
+    assert out["status"] == "error:dirty"
+    log = _log_text(home)
+    assert "non-healable" in log
+    # never touched: still staged, nothing checked out
+    status = _git(deploy, "status", "--porcelain")
+    assert "new-staged.txt" in status
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# (d) WR2_DEPLOY_PULL_SELFHEAL=0 -> old freeze behavior preserved
+# ─────────────────────────────────────────────────────────────────────────
+def test_selfheal_opt_out_preserves_old_freeze_behavior(tmp_path):
+    home, src, origin, deploy = _setup_deploy_world(tmp_path)
+    (deploy / "tracked.plist").unlink()
+
+    res = _run_pull(home, extra_env={"WR2_DEPLOY_PULL_SELFHEAL": "0"})
+    assert res.returncode == 1, res.stderr
+    out = _outcome(home)
+    assert out["status"] == "error:dirty"
+    # untouched: the deletion persists, no checkout happened
+    assert not (deploy / "tracked.plist").exists()

--- a/scripts/tests/test_wr2_runtime_stamp.py
+++ b/scripts/tests/test_wr2_runtime_stamp.py
@@ -167,6 +167,11 @@ def _run_pull(home, extra_env=None, path_prefix=None):
     env = dict(os.environ)
     env["HOME"] = str(home)
     env.pop("TELEGRAM_BOT_TOKEN", None)
+    # Hermetic tg_notify.py: never let a self-heal/dirty alert touch a live
+    # spool or secrets file even though HOME is already faked above.
+    env["TG_DRY_RUN"] = "1"
+    env["TG_SPOOL_DIR"] = str(home / ".organism" / "tg_spool")
+    env["TG_SECRETS_FILE"] = "/dev/null"
     if path_prefix:
         env["WR2_DEPLOY_PULL_TEST_PATH_PREFIX"] = str(path_prefix)
     if extra_env:
@@ -227,9 +232,15 @@ def test_deploy_pull_advanced_kickstarts_when_armed(tmp_path):
     assert "com.balizero.wr2.supervisor-watchdog" in recorded
 
 
-def test_deploy_pull_dirty_clone_is_honest_error(tmp_path):
+def test_deploy_pull_dirty_clone_self_heals(tmp_path):
+    """A tracked-file unstaged mutation (` M`) is exactly the W81/#2 incident
+    shape (2026-07-05->07: a sibling's tracked-deleted plist froze the puller
+    for 2+ days) -- it now self-heals instead of freezing. See
+    test_wr2_deploy_pull_selfheal.py for the full guilt+innocence matrix
+    (untracked / self-heal / staged-refuses / opt-out)."""
     home, _src, _origin, deploy = _setup_deploy_world(tmp_path)
     (deploy / "f.txt").write_text("local mutation\n")
     res = _run_pull(home)
-    assert res.returncode == 1
-    assert _outcome(home)["status"] == "error:dirty"
+    assert res.returncode == 0, res.stderr
+    assert _outcome(home)["status"] == "ok:self-healed"
+    assert (deploy / "f.txt").read_text() == "v1\n"

--- a/scripts/wr2-deploy-pull.sh
+++ b/scripts/wr2-deploy-pull.sh
@@ -37,6 +37,10 @@ OUTCOME_STATUS="error:unclassified"
 OUTCOME_OLD_HEAD=""
 OUTCOME_NEW_HEAD=""
 OUTCOME_ADVANCE=0
+# set (not appended to OUTCOME_STATUS directly) if the dirty-classifier below
+# self-heals class-b entries; folded into the terminal ok:* status so the
+# heartbeat distinguishes a healed run from a routinely-clean one (§1 spec).
+SELF_HEALED=0
 
 write_outcome() {
   local rc="${1:-0}"
@@ -126,6 +130,26 @@ is_git_worktree() {
   [[ -d "$dir/.git" || -f "$dir/.git" ]]
 }
 
+# ── tg_notify gateway (#2067): prefer the one true gate over raw send_telegram
+# so alerts/heals show up in the P0/digest tiers instead of rotting behind the
+# old per-key 6h cooldown (the incident this self-heal fixes sat silent for
+# 2+ days because "dirty_worktree" was already in cooldown). Falls through to
+# send_telegram if the gateway script is missing (e.g. a bootstrap clone with
+# no scripts/ yet) or errors — never let notification wiring change exit codes.
+TG_NOTIFY_PY="${WR2_TG_NOTIFY_PY:-${SOURCE_REPO}/scripts/tg_notify.py}"
+
+tg_notify_or_fallback() {
+  local tier="$1" key="$2" fallback_key="$3" text="$4"
+  if [[ -f "$TG_NOTIFY_PY" ]]; then
+    if python3 "$TG_NOTIFY_PY" --tier "$tier" --source wr2-deploy-pull \
+        --dedup-key "$key" -- "$text" >>"$LOG" 2>&1; then
+      return 0
+    fi
+    log "WARN: tg_notify.py failed (tier=${tier} key=${key}), falling back to send_telegram"
+  fi
+  send_telegram "$fallback_key" "$text"
+}
+
 # 2026-06-27: -deploy is now a full CLONE (not a worktree) — council Q1, isolated object
 # store immune to the main's sibling-race (W63/#5). The clone is cheap: HEAD tree ~0.9GB
 # (the 45G "repo" was venv+node_modules+.worktrees, which a clone never materializes).
@@ -200,13 +224,86 @@ if [[ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]]; then
   exit 1
 fi
 
-DIRTY="$(git status --porcelain 2>/dev/null | head -1)"
-if [[ -n "$DIRTY" ]]; then
-  log "ERROR: deploy worktree has local changes - first dirty entry: ${DIRTY}"
-  send_telegram "dirty_worktree" \
-    "WR2 deploy worktree DIRTY. First dirty entry: \`${DIRTY}\`. Inspect: \`cd ${DEPLOY_DIR} && git status\`."
-  OUTCOME_STATUS="error:dirty"
-  exit 1
+# ── Dirty-worktree classification + self-heal (W81/#2, incident 2026-07-05→07) ──
+# The deploy clone is BY CONTRACT read-only runtime — any local modification is
+# drift, never valuable work. A sibling session leaving one tracked-deleted
+# plist (unstaged) froze code propagation for 2+ days because the OLD single
+# DIRTY-block treated every porcelain line the same (alert once, cooldown-
+# suppress, exit 1 forever). Classify instead of blanket-blocking:
+#   (a) untracked (`?? `)              -> NOT blocking, just log+continue
+#       (runtime junk: venvs/output dirs legitimately live in the clone)
+#   (b) unstaged tracked mod/del       -> SELF-HEAL: git checkout -- <path>
+#       (worktree col M/D, index col space or M — never touches staged/index)
+#   (c) anything else (staged, renamed,
+#       conflicts) or failed self-heal -> block as before (now via tg_notify P0)
+DIRTY_RAW="$(git status --porcelain 2>/dev/null)"
+if [[ -n "$DIRTY_RAW" ]]; then
+  UNTRACKED_PATHS=()
+  HEALABLE_PATHS=()
+  BLOCKING_LINES=()
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    idx_col="${line:0:1}"
+    wt_col="${line:1:1}"
+    path="${line:3}"
+    if [[ "$idx_col" == "?" && "$wt_col" == "?" ]]; then
+      UNTRACKED_PATHS+=("$path")
+    elif [[ ( "$idx_col" == " " || "$idx_col" == "M" ) && ( "$wt_col" == "M" || "$wt_col" == "D" ) ]]; then
+      HEALABLE_PATHS+=("$path")
+    else
+      BLOCKING_LINES+=("$line")
+    fi
+  done <<< "$DIRTY_RAW"
+
+  if (( ${#UNTRACKED_PATHS[@]} > 0 )); then
+    preview="$(printf '%s, ' "${UNTRACKED_PATHS[@]:0:3}")"
+    preview="${preview%, }"
+    log "untracked entries present (${#UNTRACKED_PATHS[@]}) - not blocking: ${preview}$( (( ${#UNTRACKED_PATHS[@]} > 3 )) && echo " ...")"
+  fi
+
+  if (( ${#BLOCKING_LINES[@]} > 0 )); then
+    first_blocking="${BLOCKING_LINES[0]}"
+    log "ERROR: deploy worktree has non-healable local changes - first blocking entry: ${first_blocking}"
+    tg_notify_or_fallback p0 "wr2-deploy-pull-dirty" "dirty_worktree" \
+      "WR2 deploy worktree DIRTY (non-healable). First blocking entry: \`${first_blocking}\`. Inspect: \`cd ${DEPLOY_DIR} && git status\`."
+    OUTCOME_STATUS="error:dirty"
+    exit 1
+  fi
+
+  if (( ${#HEALABLE_PATHS[@]} > 0 )); then
+    if [[ "${WR2_DEPLOY_PULL_SELFHEAL:-1}" == "1" ]]; then
+      if git checkout -- "${HEALABLE_PATHS[@]}" 2>>"$LOG"; then
+        STILL_DIRTY="$(git status --porcelain -- "${HEALABLE_PATHS[@]}" 2>/dev/null)"
+        if [[ -z "$STILL_DIRTY" ]]; then
+          healed_preview="$(printf '%s, ' "${HEALABLE_PATHS[@]:0:3}")"
+          healed_preview="${healed_preview%, }"
+          log "self-healed dirty: ${healed_preview}$( (( ${#HEALABLE_PATHS[@]} > 3 )) && echo " ...")"
+          tg_notify_or_fallback digest "wr2-deploy-pull-selfheal" "selfheal_worktree" \
+            "WR2 deploy worktree self-healed ${#HEALABLE_PATHS[@]} dirty tracked path(s): \`${healed_preview}\`."
+          SELF_HEALED=1
+        else
+          log "ERROR: self-heal ran but worktree still dirty for healable paths: ${STILL_DIRTY}"
+          tg_notify_or_fallback p0 "wr2-deploy-pull-dirty" "dirty_worktree" \
+            "WR2 deploy worktree self-heal FAILED to converge. Remaining: \`${STILL_DIRTY}\`. Inspect: \`cd ${DEPLOY_DIR} && git status\`."
+          OUTCOME_STATUS="error:dirty"
+          exit 1
+        fi
+      else
+        log "ERROR: git checkout -- self-heal failed"
+        tg_notify_or_fallback p0 "wr2-deploy-pull-dirty" "dirty_worktree" \
+          "WR2 deploy worktree self-heal FAILED (git checkout error). Inspect: \`cd ${DEPLOY_DIR} && git status\`."
+        OUTCOME_STATUS="error:dirty"
+        exit 1
+      fi
+    else
+      first_healable="${HEALABLE_PATHS[0]}"
+      log "ERROR: deploy worktree has local changes - first dirty entry:  M ${first_healable} (self-heal disabled: WR2_DEPLOY_PULL_SELFHEAL=0)"
+      tg_notify_or_fallback p0 "wr2-deploy-pull-dirty" "dirty_worktree" \
+        "WR2 deploy worktree DIRTY. First dirty entry: \` M ${first_healable}\`. Self-heal disabled. Inspect: \`cd ${DEPLOY_DIR} && git status\`."
+      OUTCOME_STATUS="error:dirty"
+      exit 1
+    fi
+  fi
 fi
 
 if ! git fetch --quiet origin "$EXPECTED_BRANCH" 2>>"$LOG"; then
@@ -241,6 +338,7 @@ if [[ "$LOCAL_HEAD" == "$REMOTE_HEAD" ]]; then
   state_set "last_run_ts" "$(now_epoch)"
   state_set "last_head" "$LOCAL_HEAD"
   OUTCOME_STATUS="ok:up-to-date"
+  (( SELF_HEALED == 1 )) && OUTCOME_STATUS="ok:self-healed"
   OUTCOME_NEW_HEAD="$LOCAL_HEAD"
   exit 0
 fi
@@ -278,6 +376,7 @@ state_set "last_run_ts" "$(now_epoch)"
 state_set "last_head" "$NEW_HEAD"
 state_set "last_advance_count" "$COMMIT_COUNT"
 OUTCOME_STATUS="ok:advanced"
+(( SELF_HEALED == 1 )) && OUTCOME_STATUS="ok:self-healed"
 OUTCOME_NEW_HEAD="$NEW_HEAD"
 [[ "$COMMIT_COUNT" =~ ^[0-9]+$ ]] && OUTCOME_ADVANCE="$COMMIT_COUNT"
 


### PR DESCRIPTION
## Why

Incident 2026-07-05→07: a sibling session left ONE tracked-deleted plist (unstaged) in the deploy clone `~/Desktop/nuzantara-deploy`. The old single DIRTY block (first porcelain line → telegram once → 6h cooldown → exit 1) froze WR2 code propagation for 2+ days while the alert rotted in cooldown silence. The deploy clone is by contract a read-only runtime checkout: local modification = drift, never valuable work.

## What

Classify `git status --porcelain` instead of blanket-blocking:
- **untracked (`??`)** → never blocks (runtime junk like venvs legitimately lives in the clone), logged with count+preview
- **unstaged tracked mod/del** → **self-heal** via `git checkout --` + re-verify; digest-tier tg note; terminal heartbeat `ok:self-healed`; opt-out `WR2_DEPLOY_PULL_SELFHEAL=0`
- **anything else** (staged, renames, conflicts) or failed heal → refuse as before, but now escalated via **tg_notify P0** (fallback `send_telegram`) so it can't rot in per-key cooldown again

## Verification

- `scripts/tests/test_wr2_deploy_pull_selfheal.py`: full guilt+innocence matrix (untracked proceeds+advances / tracked-deleted self-heals `ok:self-healed` / staged refuses exit 1 / opt-out restores freeze behavior) against real fixture git repos
- existing `test_wr2_runtime_stamp.py` updated where it asserted the replaced behavior (+hermetic tg env: `TG_DRY_RUN`, verified real knobs in tg_notify.py)
- independently re-run by the orchestrating session: **21 passed** + `bash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)