### PR TITLE
feat(rag+wr2): KB blood for carousels — chunk snippets + oracle-grounding fallback

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/tools.py
+++ b/apps/backend-rag/backend/services/rag/agentic/tools.py
@@ -276,6 +276,7 @@ class VectorSearchTool(BaseTool):
                         "score": chunk.get("score", 0.0) if isinstance(chunk, dict) else 0.0,
                         "collection": source_col,
                         "doc_id": doc_id,
+                        "snippet": text[:500],
                     },
                 )
 

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_agentic_tools.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_agentic_tools.py
@@ -91,6 +91,7 @@ async def test_vector_search_uses_selected_collection_and_deduplicates_results()
             "score": 0.92,
             "collection": "legal_unified",
             "doc_id": "doc-1",
+            "snippet": "PT PMA requires shareholder identity documents.",
         },
     ]
     assert "Source: legal_unified" in result["content"]

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_pipeline.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_pipeline.py
@@ -67,6 +67,36 @@ class TestPipelineStages:
         assert isinstance(result, dict)
 
     @pytest.mark.asyncio
+    async def test_citation_stage_preserves_snippet_from_tool_source(self):
+        """A chunk's text (as the tool's 'snippet' field) must survive normalization."""
+        stage = CitationStage()
+        data = {
+            "response": "Test response",
+            "sources": [
+                {
+                    "id": 1,
+                    "title": "PP 28/2025",
+                    "url": "https://example.test/pp28",
+                    "score": 0.88,
+                    "collection": "legal_unified",
+                    "doc_id": "doc-9",
+                    "snippet": "PP 28/2025 mengatur konversi KBLI 2020 ke KBLI 2025.",
+                },
+            ],
+        }
+        result = await stage.process(data)
+        assert result["citations"] == [
+            {
+                "title": "PP 28/2025",
+                "url": "https://example.test/pp28",
+                "collection": "legal_unified",
+                "score": 0.88,
+                "snippet": "PP 28/2025 mengatur konversi KBLI 2020 ke KBLI 2025.",
+                "metadata": {},
+            },
+        ]
+
+    @pytest.mark.asyncio
     async def test_format_stage(self):
         """Test FormatStage"""
         stage = FormatStage()

--- a/scripts/tests/test_wr2_grounding.py
+++ b/scripts/tests/test_wr2_grounding.py
@@ -35,13 +35,98 @@ def test_enabled_injects(monkeypatch=None):
 def test_no_citation_degrades():
     g.ENABLED = True
     async def empty(_): return "prose without any law number"
+    async def oracle_empty(_): return ""
     g._query_rag = empty
+    g._query_oracle = oracle_empty
     out = asyncio.run(g.ground_enrichment({"enrichment": {}, "article_summary": "y"}, "t"))
+    assert out["enrichment"] == {}
+
+
+def test_oracle_fallback_used_when_chat_stream_has_no_citations():
+    """Chat-stream yields no citations -> falls back to /api/oracle/query snippets."""
+    g.ENABLED = True
+
+    async def chat_stream_empty(_):
+        return "prose without any law number"
+
+    async def oracle_with_snippets(_):
+        # Simulates _query_oracle's scan-corpus assembly from citations[].snippet.
+        return "Snippet A: per PP 28/2025.\nSnippet B: see PMK 37/2025 for details."
+
+    g._query_rag = chat_stream_empty
+    g._query_oracle = oracle_with_snippets
+    out = asyncio.run(g.ground_enrichment({"enrichment": {}, "article_summary": "y"}, "t"))
+    citations = g._find_law_citations(out["enrichment"]["the_facts"])
+    assert "PP 28/2025" in citations
+    assert "PMK 37/2025" in citations
+    assert out["enrichment"]["grounding_source"] == "fly-oracle-http"
+
+
+def test_oracle_query_extracts_snippets_from_response_shape(monkeypatch=None):
+    """_query_oracle must scan answer + citations[].snippet + sources[].snippet."""
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "answer": "General overview, no citation here.",
+                "citations": [
+                    {"title": "PP 28/2025 art. 3", "snippet": "Ref PP 28/2025 applies to KBLI conversion."},
+                ],
+                "sources": [
+                    {"title": "PMK circular", "snippet": "See PMK 37/2025 for the fee schedule."},
+                ],
+            }
+
+    class _FakeAsyncClient:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            assert headers.get("X-API-Key") == g.API_KEY
+            assert url.endswith("/api/oracle/query")
+            return _FakeResponse()
+
+    import httpx as real_httpx
+    orig_client = real_httpx.AsyncClient
+    real_httpx.AsyncClient = _FakeAsyncClient
+    try:
+        corpus = asyncio.run(g._query_oracle("KBLI conversion"))
+    finally:
+        real_httpx.AsyncClient = orig_client
+
+    citations = g._find_law_citations(corpus)
+    assert "PP 28/2025" in citations
+    assert "PMK 37/2025" in citations
+
+
+def test_oracle_failure_leaves_brief_unchanged():
+    g.ENABLED = True
+
+    async def chat_stream_empty(_):
+        return "prose without any law number"
+
+    async def oracle_raises(_):
+        raise RuntimeError("boom")
+
+    g._query_rag = chat_stream_empty
+    g._query_oracle = oracle_raises
+    brief = {"enrichment": {}, "article_summary": "y"}
+    out = asyncio.run(g.ground_enrichment(brief, "t"))
     assert out["enrichment"] == {}
 
 
 if __name__ == "__main__":
     for fn in [test_law_extraction_matches_factchecker, test_inject_roundtrips,
-               test_disabled_passthrough, test_enabled_injects, test_no_citation_degrades]:
+               test_disabled_passthrough, test_enabled_injects, test_no_citation_degrades,
+               test_oracle_fallback_used_when_chat_stream_has_no_citations,
+               test_oracle_query_extracts_snippets_from_response_shape,
+               test_oracle_failure_leaves_brief_unchanged]:
         fn(); print("PASS", fn.__name__)
     print("ALL PASS")

--- a/scripts/wr2_grounding.py
+++ b/scripts/wr2_grounding.py
@@ -26,12 +26,17 @@ validation). The cron-safe source is the Fly backend RAG the topic-selector ALRE
 talks to (`NUZANTARA_BACKEND_URL` + `X-API-Key`). We query it over HTTP, read the
 answer text, and extract the law citations the same way the fact-checker matches them.
 
-KNOWN GAP (verified live 2026-06-24, 3 domains): the only cron-safe RAG endpoint
-(/api/v1/visa-oracle/chat) returns prose + title-only sources, NOT extractable
-PP/PMK/UU N/YYYY citations. So this module currently degrades to enrichment={} on
-real queries and the hook is INERT until a real citation source is wired (NB-brief
-materialization, KB reg-number payload, or a raw-chunk endpoint). It ships flag-off
-so it activates the day a source exists, with no further code change.
+KNOWN GAP — UPDATED 2026-07-07 (was: verified live 2026-06-24, 3 domains): the
+chat-stream RAG endpoint (/api/v2/bali-zero/chat-stream) still returns prose +
+title-only sources, NOT extractable PP/PMK/UU N/YYYY citations on its own. As of
+2026-07-07 the search tool backing `/api/oracle/query` now fills a `snippet`
+field (first 500 chars of the retrieved chunk) on every source/citation entry
+(`backend/services/rag/agentic/tools.py`), so `_query_oracle()` below queries
+that endpoint directly and scans `answer` + every `citations[].snippet` +
+`sources[].snippet` for law citations. `ground_enrichment` tries the chat-stream
+path FIRST (cheaper, already warm) and falls back to `_query_oracle` only if
+that path yields zero citations — so the day the chat-stream path itself starts
+returning citations, the fallback simply never triggers, no code change needed.
 
 CONTRACTS
 ---------
@@ -54,6 +59,7 @@ logger = logging.getLogger("wr2.grounding")
 
 ENABLED = os.environ.get("WR2_RESEARCH_STEP_ENABLED", "false").lower() == "true"
 RAG_TIMEOUT_S = float(os.environ.get("WR2_GROUNDING_TIMEOUT_S", "8"))
+ORACLE_TIMEOUT_S = float(os.environ.get("WR2_GROUNDING_ORACLE_TIMEOUT_S", "90"))
 BACKEND_URL = os.environ.get("NUZANTARA_BACKEND_URL", "https://nuzantara-rag.fly.dev")
 API_KEY = os.environ.get("NUZANTARA_API_KEY", "zantara-secret-2024")
 
@@ -158,6 +164,58 @@ async def _query_rag(topic: str) -> str:
     return "\n".join(chunks)
 
 
+async def _query_oracle(topic: str) -> str:
+    """Ask /api/oracle/query about `topic`; return a scan corpus for law citations.
+
+    Unlike `_query_rag` (chat-stream prose), the oracle endpoint's search tool
+    fills a `snippet` field (raw chunk text) on every source/citation entry
+    (backend/services/rag/agentic/tools.py). The scan corpus is `answer` plus
+    every `citations[].snippet` and `sources[].snippet` — "" on any failure.
+    """
+    import json
+
+    import httpx
+
+    query = (
+        f"What Indonesian regulations, laws, or articles govern: {topic}? "
+        "Cite the specific regulation numbers (e.g. PP, PMK, UU, Perpres, Pasal)."
+    )
+    url = f"{BACKEND_URL.rstrip('/')}/api/oracle/query"
+    try:
+        async with httpx.AsyncClient(timeout=ORACLE_TIMEOUT_S) as client:
+            resp = await client.post(
+                url,
+                json={"query": query},
+                headers={"X-API-Key": API_KEY},
+            )
+            if resp.status_code != 200:
+                logger.warning("Oracle grounding: backend returned %s", resp.status_code)
+                return ""
+            data = resp.json()
+    except Exception as exc:  # noqa: BLE001 — graceful-degrade on ANY error
+        logger.warning("Oracle grounding query failed (degrading): %s", exc)
+        return ""
+
+    if not isinstance(data, dict):
+        return ""
+
+    parts: list[str] = []
+    answer = data.get("answer")
+    if isinstance(answer, str):
+        parts.append(answer)
+
+    for key in ("citations", "sources"):
+        entries = data.get(key)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict):
+                snippet = entry.get("snippet")
+                if isinstance(snippet, str) and snippet:
+                    parts.append(snippet)
+    return "\n".join(parts)
+
+
 async def ground_enrichment(brief_json: dict[str, Any], topic: str) -> dict[str, Any]:
     """Populate brief_json['enrichment'] with regulatory rails for `topic`.
 
@@ -173,10 +231,21 @@ async def ground_enrichment(brief_json: dict[str, Any], topic: str) -> dict[str,
         return brief_json
 
     answer = await _query_rag(topic)
-    if not answer:
-        return brief_json
+    citations = _find_law_citations(answer) if answer else []
+    grounding_source = "fly-rag-http"
 
-    citations = _find_law_citations(answer)
+    if not citations:
+        # Chat-stream path yielded nothing extractable — fall back to the
+        # oracle endpoint, whose sources/citations carry a `snippet` field.
+        try:
+            oracle_corpus = await _query_oracle(topic)
+        except Exception as exc:  # noqa: BLE001 — graceful-degrade on ANY error
+            logger.warning("Oracle grounding fallback failed (degrading): %s", exc)
+            oracle_corpus = ""
+        if oracle_corpus:
+            citations = _find_law_citations(oracle_corpus)
+            grounding_source = "fly-oracle-http"
+
     if not citations:
         logger.info("RAG grounding: no law citations for topic=%r — degrading", topic[:60])
         return brief_json
@@ -184,12 +253,12 @@ async def ground_enrichment(brief_json: dict[str, Any], topic: str) -> dict[str,
     nb_brief = {"regulatory_citations_verbatim": citations}
     base_facts = existing_facts or str(brief_json.get("article_summary") or "")[:600]
     enrichment["the_facts"] = _inject_rails_into_facts(base_facts, nb_brief)
-    enrichment.setdefault("grounding_source", "fly-rag-http")
+    enrichment.setdefault("grounding_source", grounding_source)
 
     out = dict(brief_json)
     out["enrichment"] = enrichment
     logger.info(
-        "RAG grounding: injected %d citation(s) for topic=%r: %s",
-        len(citations), topic[:60], ", ".join(citations[:8]),
+        "RAG grounding: injected %d citation(s) for topic=%r via %s: %s",
+        len(citations), topic[:60], grounding_source, ", ".join(citations[:8]),
     )
     return out


### PR DESCRIPTION
## Why

WR2 carousels were not "permeated by the KB": `wr2_grounding.py` (the module injecting verbatim regulatory rails into the draft brief) found zero extractable citations because (a) the chat-stream endpoint returns prose without PP/PMK/UU forms and (b) the oracle endpoint returned sources with **empty snippets** (probed live 2026-07-07: rich answer, `"snippet": ""` on all sources) → `enrichment={}` → `fact_check_status='degraded'` on most rendered drafts.

## What

1. **backend**: `VectorSearchTool` now includes `"snippet": text[:500]` per source (`services/rag/agentic/tools.py`). Propagation verified line-by-line: tools.py → `kg_orchestrator.py:385` (`all_sources.extend(json.loads(result)["sources"])`) → `pipeline.py CitationStage._normalize_citations` (already read `snippet`, never received it) → API `citations`.
2. **wr2_grounding**: new `_query_oracle()` fallback — POST `/api/oracle/query`, scan corpus = `answer` + all `citations[].snippet` + `sources[].snippet`; timeout env `WR2_GROUNDING_ORACLE_TIMEOUT_S` (default 90s, live endpoint takes ~45s). Chat-stream path stays primary; all module contracts preserved (graceful-degrade, flag `WR2_RESEARCH_STEP_ENABLED` default OFF, PII boundary).

Arming the flag on the Pro topic-selector happens AFTER this deploys and a live probe shows non-empty enrichment (tracked in modus PENDING-ARMS).

## Verification

- backend: 13 passed (`test_pipeline.py`, `test_agentic_tools.py`) — snippet in tool output AND in normalized citations
- grounding: 8 passed (oracle fallback with fake snippets containing PP 28/2025 + PMK 37/2025 → enrichment populated verbatim; oracle failure → brief unchanged)
- independently re-run by the orchestrating session; import-chain smoke OK; `docs_sync.py` → no changes (W86 checked)
- NOTE: merge auto-triggers fly deploy (main→backend-rag) — wanted here; post-deploy live probe follows in the arc

🤖 Generated with [Claude Code](https://claude.com/claude-code)