### PR TITLE
feat(wr2): record IG publishes — war_room_posts + queue state (A4)

### DIFF
--- a/scripts/tests/test_wr2_ig_publish_records.py
+++ b/scripts/tests/test_wr2_ig_publish_records.py
@@ -1,0 +1,102 @@
+"""Tests for the A4 publish-record helpers in wr2_ig_publish (file-based pieces).
+
+Spec: docs/specs/wr2-definitiva-v1.md R4 — war_room_posts and the review-queue
+entry are the learning loops' food; both were empty forever. DB writes are
+covered by their simple SQL + best-effort contract; these tests pin the local
+file logic (meta.json draft-id read, queue publish-mark with lock + matching).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load(name: str) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec and spec.loader, f"cannot load {name}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pub = _load("wr2_ig_publish")
+
+
+def _with_root(monkeypatch, tmp_path: Path) -> Path:
+    """Point the CLI's carousel root at a tmp output tree."""
+    out = tmp_path / "output"
+    (out / "carousel").mkdir(parents=True)
+    monkeypatch.setattr(pub, "_carousel_root", lambda: out / "carousel")
+    return out
+
+
+def test_read_meta_draft_id(tmp_path, monkeypatch):
+    out = _with_root(monkeypatch, tmp_path)
+    slug_dir = out / "carousel" / "2026-07-07-topic-abcd1234"
+    slug_dir.mkdir()
+    (slug_dir / "meta.json").write_text(json.dumps({"draft_id": "d-real-uuid"}))
+    assert pub._read_meta_draft_id("2026-07-07-topic-abcd1234") == "d-real-uuid"
+
+
+def test_read_meta_draft_id_legacy_dir_returns_none(tmp_path, monkeypatch):
+    out = _with_root(monkeypatch, tmp_path)
+    (out / "carousel" / "legacy-slug").mkdir()
+    assert pub._read_meta_draft_id("legacy-slug") is None
+
+
+def test_mark_queue_published_by_draft_id(tmp_path, monkeypatch):
+    out = _with_root(monkeypatch, tmp_path)
+    qdir = out / "queue"
+    qdir.mkdir()
+    qp = qdir / "human-review-queue.json"
+    qp.write_text(json.dumps([
+        {"id": "a", "draft_id": "d1", "state": "drafted", "state_history": []},
+        {"id": "b", "draft_id": "d2", "state": "drafted"},
+    ]))
+    pub._mark_queue_published(slug="whatever", draft_id="d2", permalink="https://ig/p/1")
+    queue = json.loads(qp.read_text())
+    assert queue[1]["state"] == "published"
+    assert queue[1]["instagram_post_url"] == "https://ig/p/1"
+    assert queue[1]["state_history"][-1]["by"] == "wr2_ig_publish"
+    # the other entry untouched
+    assert queue[0]["state"] == "drafted"
+
+
+def test_mark_queue_published_by_slug_fallback(tmp_path, monkeypatch):
+    out = _with_root(monkeypatch, tmp_path)
+    qdir = out / "queue"
+    qdir.mkdir()
+    qp = qdir / "human-review-queue.json"
+    qp.write_text(json.dumps([
+        {"id": "x", "topic_slug": "my-carousel", "state": "drafted"},
+    ]))
+    pub._mark_queue_published(slug="my-carousel", draft_id=None, permalink="https://ig/p/2")
+    queue = json.loads(qp.read_text())
+    assert queue[0]["state"] == "published"
+
+
+def test_mark_queue_published_no_match_is_noop(tmp_path, monkeypatch):
+    out = _with_root(monkeypatch, tmp_path)
+    qdir = out / "queue"
+    qdir.mkdir()
+    qp = qdir / "human-review-queue.json"
+    original = [{"id": "y", "topic_slug": "other", "state": "drafted"}]
+    qp.write_text(json.dumps(original))
+    pub._mark_queue_published(slug="nope", draft_id="dz", permalink="u")
+    assert json.loads(qp.read_text()) == original
+
+
+def test_mark_queue_missing_file_is_noop(tmp_path, monkeypatch):
+    _with_root(monkeypatch, tmp_path)
+    # no queue file at all — must not raise
+    pub._mark_queue_published(slug="s", draft_id=None, permalink="u")

--- a/scripts/wr2_ig_publish.py
+++ b/scripts/wr2_ig_publish.py
@@ -537,9 +537,139 @@ async def _run(args: argparse.Namespace) -> int:
 
     permalink = result.post_url or ""
     logger.info("PUBLISHED ok: media_id=%s permalink=%s", result.post_external_id, permalink)
+
+    # ── A4 publish records (spec docs/specs/wr2-definitiva-v1.md R4) ──────────
+    # war_room_posts + the review-queue entry are what the learning loops eat
+    # (measurer / ig-metrics-analyst / learner-nightly) — both were empty forever.
+    # BEST-EFFORT: the publish already happened; record-keeping failures are
+    # logged loudly but never turn a successful publish into exit 1.
+    real_draft_id = _read_meta_draft_id(slug)
+    try:
+        await _record_war_room_post(
+            draft_id=real_draft_id,
+            permalink=permalink,
+            post_external_id=result.post_external_id,
+            caption=caption,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("war_room_posts record failed (publish OK): %s", exc)
+    try:
+        _mark_queue_published(slug=slug, draft_id=real_draft_id, permalink=permalink)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("queue publish-mark failed (publish OK): %s", exc)
+
     # The app parses this exact stdout line.
     print(f"IG_URL={permalink}")  # noqa: T201 - stdout contract line
     return 0
+
+
+def _read_meta_draft_id(slug: str) -> str | None:
+    """The war_room_drafts UUID travels in meta.json (written by the html-apply
+    visibility chain since 2026-07-07). Legacy carousel dirs lack it -> None."""
+    meta_path = _carousel_root() / slug / "meta.json"
+    try:
+        if meta_path.is_file():
+            data = json.loads(meta_path.read_text(encoding="utf-8"))
+            did = str(data.get("draft_id") or "").strip()
+            return did or None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("meta.json unreadable for %s: %s", slug, exc)
+    return None
+
+
+async def _record_war_room_post(
+    *,
+    draft_id: str | None,
+    permalink: str,
+    post_external_id: str | None,
+    caption: str,
+) -> None:
+    """INSERT the publish into war_room_posts (FK -> war_room_drafts) and promote
+    the draft to status='published'. Requires the REAL draft id from meta.json —
+    the CLI's uuid5(slug) would violate the FK, so legacy dirs are skipped."""
+    if not draft_id:
+        logger.warning(
+            "no real draft_id (legacy carousel dir without meta.json) — "
+            "war_room_posts NOT recorded; learning loops stay blind for this one"
+        )
+        return
+    import asyncpg
+
+    from backend.app.core.config import settings
+
+    dsn = settings.database_url or os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("no DSN for war_room_posts record")
+        return
+    conn = await asyncpg.connect(dsn)
+    try:
+        await conn.execute(
+            """
+            INSERT INTO war_room_posts (draft_id, platform, post_external_id, post_url, final_text)
+            VALUES ($1::uuid, 'instagram', $2, $3, $4)
+            ON CONFLICT (draft_id, platform) DO UPDATE
+               SET post_external_id = EXCLUDED.post_external_id,
+                   post_url = EXCLUDED.post_url
+            """,
+            draft_id, post_external_id, permalink, caption[:4000],
+        )
+        await conn.execute(
+            """
+            UPDATE war_room_drafts SET status='published', updated_at=NOW()
+             WHERE id=$1::uuid AND status IN ('rendered','pending_review','approved')
+            """,
+            draft_id,
+        )
+        logger.info("war_room_posts recorded for draft %s", draft_id)
+    finally:
+        await conn.close()
+
+
+def _mark_queue_published(*, slug: str, draft_id: str | None, permalink: str) -> None:
+    """Flip the review-queue entry to state='published' (same fcntl-lock protocol
+    as the html-apply appender). Match by draft_id first, then by slug."""
+    import fcntl
+    from datetime import datetime, timezone
+
+    qp = _carousel_root().parent / "queue" / "human-review-queue.json"
+    if not qp.exists():
+        logger.warning("review queue missing at %s — publish not queue-marked", qp)
+        return
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    lock_path = qp.with_suffix(".lock")
+    with open(lock_path, "w", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            queue = json.loads(qp.read_text(encoding="utf-8"))
+            if not isinstance(queue, list):
+                logger.error("review queue is not a JSON array: %s", qp)
+                return
+            hit = None
+            for item in queue:
+                if not isinstance(item, dict):
+                    continue
+                if draft_id and item.get("draft_id") == draft_id:
+                    hit = item
+                    break
+                cp = str(item.get("carousel_path") or "")
+                if item.get("topic_slug") == slug or cp.rstrip("/").endswith(slug):
+                    hit = item
+                    break
+            if hit is None:
+                logger.warning("no queue entry matched slug=%s draft_id=%s", slug, draft_id)
+                return
+            hit["state"] = "published"
+            hit["instagram_post_url"] = permalink
+            hit["instagram_published_at"] = now
+            hit.setdefault("state_history", []).append(
+                {"state": "published", "at": now, "by": "wr2_ig_publish"}
+            )
+            tmp = qp.with_suffix(f".tmp.{os.getpid()}")
+            tmp.write_text(json.dumps(queue, indent=2, ensure_ascii=False), encoding="utf-8")
+            os.replace(tmp, qp)
+            logger.info("queue entry marked published (slug=%s)", slug)
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:


### PR DESCRIPTION
## Why
`war_room_posts` = 0 rows and `wr2_publish_attempts` = 0 rows since forever — IG publishes lived only in the queue JSON, so the learning loops (measurer, ig-metrics-analyst, learner-nightly) had nothing to eat (spec `docs/specs/wr2-definitiva-v1.md` R4, "loops alive but starved").

## What
On successful `--confirm` publish: INSERT `war_room_posts` using the REAL `draft_id` from `meta.json` (visibility-chain artifact; legacy dirs without it are skipped loudly — the CLI's `uuid5(slug)` would violate the FK) + promote draft to `published`; flip the review-queue entry to `state='published'` with permalink (same fcntl protocol as the appender). All best-effort: a done publish never exits 1 over record-keeping.

## Verification
6 tests green (meta read, queue mark by draft_id and slug-fallback, no-match no-op, missing-file no-op); py_compile clean. Natural end-proof at Zero's next Publish click (Legge 5 — no autonomous IG publish to test with).

🤖 Generated with [Claude Code](https://claude.com/claude-code)