### PR TITLE
docs(infra): promote kg-query-api's live plist to repo canon

### DIFF
--- a/infra/launchagents/com.matagaruda.kg-query-api.plist
+++ b/infra/launchagents/com.matagaruda.kg-query-api.plist
@@ -2,43 +2,36 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Label</key>
-    <string>com.matagaruda.kg-query-api</string>
-    <!--
-        TCC bypass: launchd-spawned /bin/{zsh,bash} cannot open files in
-        ~/Desktop, but the mata-garuda venv python (adhoc-signed) can read
-        and exec from there. We exec it directly with no shell wrapper.
-    -->
-    <key>ProgramArguments</key>
-    <array>
-        <string>/Users/nuzantara/Desktop/nuzantara/apps/mata-garuda/.venv/bin/python</string>
-        <string>-m</string>
-        <string>mata_garuda.api.kg_query</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <true/>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>HOME</key>
-        <string>/Users/nuzantara</string>
-        <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-        <key>PYTHONPATH</key>
-        <string>/Users/nuzantara/Desktop/nuzantara/apps/mata-garuda</string>
-        <key>KG_API_BIND</key>
-        <string>100.93.236.6</string>
-        <key>KG_API_PORT</key>
-        <string>8990</string>
-    </dict>
-    <key>StandardOutPath</key>
-    <string>/Users/nuzantara/logs/mata-garuda-kg-api.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/nuzantara/logs/mata-garuda-kg-api.err</string>
-    <key>ThrottleInterval</key>
-    <integer>15</integer>
-    <key>WorkingDirectory</key>
-    <string>/Users/nuzantara/Desktop/nuzantara/apps/mata-garuda</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/nuzantara</string>
+		<key>KG_API_BIND</key>
+		<string>100.93.236.6</string>
+		<key>KG_API_PORT</key>
+		<string>8990</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<key>PYTHONPATH</key>
+		<string>/Users/nuzantara/Desktop/nuzantara/apps/mata-garuda</string>
+	</dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>com.matagaruda.kg-query-api</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/scripts/mini-infra/kg-query-api-wrapper.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/mata-garuda-kg-api.err</string>
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/mata-garuda-kg-api.log</string>
+	<key>ThrottleInterval</key>
+	<integer>15</integer>
+	<key>WorkingDirectory</key>
+	<string>/Users/nuzantara/Desktop/nuzantara/apps/mata-garuda</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- `infra/launchagents/com.matagaruda.kg-query-api.plist` still had the pre-F3.2 direct-venv-exec `ProgramArguments`; the live Mini plist was upgraded to exec `kg-query-api-wrapper.sh` (already canonized at `infra/mini-scripts/`), which waits for tailscaled to bind `100.93.236.6` before starting the API. Flagged by `launchagent_reconcile.py` as "Repo-divergent (1)".
- Promoted the live, empirically-proven plist to repo canon (verified byte-identical via `diff` + `plutil -lint` OK). No live change — this only corrects the repo copy.

## Test plan
- [x] `diff` live plist vs updated repo canon — identical
- [x] `plutil -lint` — OK
- [x] `python3 scripts/launchagent_reconcile.py` — "Repo-divergent" count 1 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)