### PR TITLE
chore(security): ignore PYSEC-2026-1325 (ecdsa Minerva timing attack) — HS256-only JWT

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,8 @@ jobs:
             --ignore-vuln PYSEC-2025-217 \
             --ignore-vuln GHSA-8jfx-5878-hv4v \
             --ignore-vuln CVE-2025-3000 \
-            --ignore-vuln CVE-2026-4372
+            --ignore-vuln CVE-2026-4372 \
+            --ignore-vuln PYSEC-2026-1325
 
       - name: Mypy type check (core + models)
         run: |

--- a/apps/backend-rag/.pip-audit-ignore.md
+++ b/apps/backend-rag/.pip-audit-ignore.md
@@ -268,3 +268,44 @@ Python code, bypassing `trust_remote_code`.
 weekly dependency process — it is a major bump (4.57 → 5.3) requiring compat
 testing with `sentence-transformers` and `spacy`. Remove this entry when the
 bump lands.
+
+---
+
+## PYSEC-2026-1325 (CVE-2024-23342 / GHSA-wj6h-64fc-37mp) — python-ecdsa 0.19.2
+
+**Package:** `ecdsa` (transitive via `python-jose[cryptography]>=3.4.0`)
+**Fix version:** none — upstream `python-ecdsa` project considers side-channel
+attacks out of scope and has stated there is no planned fix.
+**Ignored:** 2026-07-07
+
+**Summary:** Minerva timing attack on the P-256 curve in `python-ecdsa`.
+`ecdsa.SigningKey.sign_digest()` leaks the internal nonce via signature
+timing, potentially allowing private-key discovery for ECDSA signing, key
+generation, and ECDH operations. Signature *verification* is unaffected.
+
+**Why not applicable to this codepath:**
+
+1. **JWT signing in this repo uses HS256 (HMAC), never ES256/ECDSA.**
+   Verified 2026-07-07:
+   ```bash
+   grep -n "jwt_algorithm" apps/backend-rag/backend/app/core/config.py
+   # jwt_algorithm: str = "HS256"
+   ```
+   `apps/backend-rag/backend/app/routers/auth.py` encodes/decodes exclusively
+   with `JWT_ALGORITHM` (= the HS256 default above) — the ECDSA signing path
+   inside `python-jose[cryptography]` (which is what pulls in `ecdsa`) is
+   never invoked by this codebase's token issuance or validation.
+2. **No other code path calls `ecdsa` directly.** `ecdsa` is a transitive
+   dependency of `python-jose[cryptography]` only, per
+   `requirements.lock.txt` (`# via ... python-jose`); grep confirms no
+   first-party import of the `ecdsa` package anywhere under
+   `apps/backend-rag/backend/`.
+3. **Residual risk = if the JWT algorithm were ever switched to ES256**, this
+   entry must be re-evaluated first — re-check this file whenever
+   `jwt_algorithm` changes away from `HS256`.
+
+**Follow-up:** none actionable — upstream has no fix planned for this class
+of attack (accepted risk class, same posture as timing-attack findings in
+other side-channel-out-of-scope libraries). Re-evaluate if `python-jose` is
+ever replaced with a library that surfaces the vulnerable code path, or if
+`jwt_algorithm` changes to an ECDSA-based algorithm.


### PR DESCRIPTION
## Summary

- New security advisory `PYSEC-2026-1325` (CVE-2024-23342, GHSA-wj6h-64fc-37mp) was published today (2026-07-07): a Minerva timing attack on P-256 in `python-ecdsa`. Upstream has stated there is no planned fix (side-channel attacks are out of scope for that project).
- This started blocking the `pip-audit` gate on every backend PR — including unrelated docs-only PRs — because `ecdsa` is a transitive dependency via `python-jose[cryptography]`.
- Verified not exploitable on this codepath: `apps/backend-rag/backend/app/core/config.py` pins `jwt_algorithm: str = "HS256"` (HMAC, not ECDSA), and `auth.py` only ever encodes/decodes with that algorithm. The vulnerable `ecdsa.SigningKey.sign_digest()` path inside `python-jose[cryptography]` is never invoked.
- Added a documented entry to `apps/backend-rag/.pip-audit-ignore.md` (same format as the existing `transformers` entry) and the corresponding `--ignore-vuln PYSEC-2026-1325` flag to `.github/workflows/tests.yml`.

## Test plan

- [x] `pip-audit --strict --requirement <audit-file> <all ignore flags including PYSEC-2026-1325>` → `No known vulnerabilities found, 4 ignored`
- [x] Confirmed `jwt_algorithm` default is `HS256` and no ES256/ECDSA usage in `apps/backend-rag/backend/app/routers/auth.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)