### PR TITLE
fix(wr2): unify review-queue locking across all three writers

### DIFF
--- a/scripts/tests/test_wr2_queue_locking.py
+++ b/scripts/tests/test_wr2_queue_locking.py
@@ -1,0 +1,151 @@
+"""Torture + conformance tests for the unified review-queue locking.
+
+Ledger line (PENDING-ARMS 2026-07-07, Codex red-team HIGH): three writers share
+`human-review-queue.json` — the renderer's `_append_review_queue` (locked), the
+Damar queue-server UI handlers and `wr2_queue_writer` (both lock-free until this
+change). A UI action racing the renderer's append lost one of the two writes.
+
+Proof-of-armed required by the ledger: "all three writers take
+`human-review-queue.lock`; torture test with concurrent append+publish keeps
+both writes". The torture test here runs the two REAL writer code paths in
+separate PROCESSES (fcntl.flock is a cross-process lock) hammering one queue
+file; every write from both sides must survive.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = SCRIPTS_DIR.parent
+SERVER_PATH = REPO_ROOT / "skills" / "bali-zero-brand" / "_damar-queue-server.py"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, f"cannot load {name} from {path}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+qw = _load("wr2_queue_writer", SCRIPTS_DIR / "wr2_queue_writer.py")
+server = _load("damar_queue_server", SERVER_PATH)
+
+
+# ── The torture test (cross-process, both REAL writer paths) ────────────────
+
+_APPEND_WORKER = r"""
+import importlib.util, sys, types
+from pathlib import Path
+scripts_dir, qpath, n = Path(sys.argv[1]), Path(sys.argv[2]), int(sys.argv[3])
+sys.modules.setdefault("asyncpg", types.ModuleType("asyncpg"))  # hermetic: html module imports it at top level
+spec = importlib.util.spec_from_file_location("html", scripts_dir / "wr2_html_render_apply.py")
+html = importlib.util.module_from_spec(spec); sys.modules["html"] = html; spec.loader.exec_module(html)
+for i in range(n):
+    html._append_review_queue(
+        {"id": f"append-{i}", "draft_id": f"draft-{i:04d}", "state": "drafted"},
+        queue_path=qpath,
+    )
+"""
+
+_INGEST_WORKER = r"""
+import importlib.util, sys
+from pathlib import Path
+scripts_dir, qpath, n = Path(sys.argv[1]), Path(sys.argv[2]), int(sys.argv[3])
+spec = importlib.util.spec_from_file_location("qw", scripts_dir / "wr2_queue_writer.py")
+qw = importlib.util.module_from_spec(spec); sys.modules["qw"] = qw; spec.loader.exec_module(qw)
+for i in range(n):
+    r = qw.ingest_external_post(qpath, f"https://www.instagram.com/p/TORT{i:04d}x/")
+    assert r.status == "ingested", r.status
+"""
+
+
+def test_torture_concurrent_append_and_ingest_lose_nothing(tmp_path):
+    """Two processes hammer the same queue via the two real writer modules.
+
+    Renderer-append (html_render_apply) races queue_writer ingest, N rounds
+    each. Without the shared flock this loses entries (both load the same
+    baseline, second os.replace erases the first's write); with it, the final
+    queue must hold ALL 2N entries and stay valid JSON.
+    """
+    qpath = tmp_path / "human-review-queue.json"
+    qpath.write_text("[]")
+    n = 25
+    procs = [
+        subprocess.Popen([sys.executable, "-c", w, str(SCRIPTS_DIR), str(qpath), str(n)],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        for w in (_APPEND_WORKER, _INGEST_WORKER)
+    ]
+    for p in procs:
+        _, err = p.communicate(timeout=120)
+        assert p.returncode == 0, err.decode()
+
+    queue = json.loads(qpath.read_text())  # valid JSON = no partial write seen
+    appended = {e["id"] for e in queue if str(e.get("id", "")).startswith("append-")}
+    ingested = {e.get("item_id") for e in queue if str(e.get("item_id", "")).startswith("ig-TORT")}
+    assert len(appended) == n, f"lost renderer appends: {n - len(appended)}"
+    assert len(ingested) == n, f"lost queue_writer ingests: {n - len(ingested)}"
+    assert (tmp_path / "human-review-queue.lock").exists()
+
+
+# ── queue-server handlers: locked + atomic ───────────────────────────────────
+
+
+def _seed_server_queue(tmp_path, monkeypatch, items):
+    qpath = tmp_path / "human-review-queue.json"
+    qpath.write_text(json.dumps(items))
+    monkeypatch.setattr(server, "QUEUE_PATH", qpath)
+    return qpath
+
+
+def test_server_mark_published_takes_lock_and_writes(tmp_path, monkeypatch):
+    qpath = _seed_server_queue(tmp_path, monkeypatch, [
+        {"id": "it-1", "state": "drafted"},
+    ])
+    body, code = server.mark_published("it-1", "https://www.instagram.com/p/ABC/")
+    assert code == 200 and body["ok"]
+    assert json.loads(qpath.read_text())[0]["state"] == "published"
+    assert qpath.with_suffix(".lock").exists()
+
+
+def test_server_mark_rejected_no_write_on_bad_tag(tmp_path, monkeypatch):
+    """Innocence: a refused transition must not touch the file."""
+    qpath = _seed_server_queue(tmp_path, monkeypatch, [
+        {"id": "it-2", "state": "drafted"},
+    ])
+    before = qpath.read_text()
+    body, code = server.mark_rejected("it-2", "not-a-valid-tag", "")
+    assert code == 400 and not body["ok"]
+    assert qpath.read_text() == before
+
+
+def test_server_save_queue_is_atomic_no_partial_tmp_left(tmp_path, monkeypatch):
+    qpath = _seed_server_queue(tmp_path, monkeypatch, [])
+    server.save_queue([{"id": "x"}])
+    assert json.loads(qpath.read_text()) == [{"id": "x"}]
+    leftovers = [p for p in qpath.parent.iterdir() if p.name.startswith(".queue-")]
+    assert leftovers == []
+
+
+def test_queue_writer_mark_published_locks_and_publishes(tmp_path):
+    qpath = tmp_path / "human-review-queue.json"
+    item_id = "carousel_x"
+    qpath.write_text(json.dumps([
+        {"id": item_id, "state": "approved", "topic_slug": "x"},
+    ]))
+    ref = qw.compute_ref_code(item_id)
+    res = qw.mark_published(qpath, ref, "https://www.instagram.com/p/XYZ/")
+    assert res.status == "published", res.detail
+    assert json.loads(qpath.read_text())[0]["state"] == "published"
+    assert qpath.with_suffix(".lock").exists()

--- a/scripts/wr2_queue_writer.py
+++ b/scripts/wr2_queue_writer.py
@@ -46,12 +46,14 @@ logic is testable without touching disk.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import hashlib
 import json
 import os
 import re
 import sys
 import tempfile
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -250,6 +252,25 @@ def write_queue_atomic(path: Path, items: list[dict[str, Any]]) -> None:
         raise
 
 
+@contextmanager
+def queue_lock(path: Path):
+    """Serialize read-modify-write against the other queue writers.
+
+    Same lock file and protocol as wr2_html_render_apply._append_review_queue
+    and _damar-queue-server (fcntl EX on human-review-queue.lock) — an atomic
+    replace alone does not prevent two writers from both loading the same
+    baseline and the second replace erasing the first one's mutation."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(".lock")
+    with open(lock_path, "w", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+
 # ── Orchestration ──────────────────────────────────────────────────────────
 
 
@@ -275,34 +296,35 @@ def mark_published(
     if not validate_ig_url(ig_url):
         return PublishResult("invalid_url", False, ref, detail=f"not an IG permalink: {ig_url!r}")
 
-    items = load_queue(path)
-    idx, item = find_by_ref_code(items, ref)
-    if item is None:
-        return PublishResult("not_found", False, ref, detail="no queue item matches this ref-code")
+    with queue_lock(path):
+        items = load_queue(path)
+        idx, item = find_by_ref_code(items, ref)
+        if item is None:
+            return PublishResult("not_found", False, ref, detail="no queue item matches this ref-code")
 
-    iid = item_id_of(item)
-    state = item.get("state")
-    existing_url = (item.get("instagram_post_url") or "").strip()
-    new_url = ig_url.strip()
+        iid = item_id_of(item)
+        state = item.get("state")
+        existing_url = (item.get("instagram_post_url") or "").strip()
+        new_url = ig_url.strip()
 
-    if state in PUBLISHED_STATES:
-        if existing_url == new_url:
-            return PublishResult("already_published", True, ref, iid, "no-op: same URL already recorded")
-        return PublishResult(
-            "conflict", False, ref, iid,
-            f"already published with a different URL ({existing_url!r}); refusing to overwrite",
-        )
+        if state in PUBLISHED_STATES:
+            if existing_url == new_url:
+                return PublishResult("already_published", True, ref, iid, "no-op: same URL already recorded")
+            return PublishResult(
+                "conflict", False, ref, iid,
+                f"already published with a different URL ({existing_url!r}); refusing to overwrite",
+            )
 
-    if state not in PUBLISHABLE_STATES:
-        return PublishResult(
-            "wrong_state", False, ref, iid,
-            f"state {state!r} is not publishable (expected one of {PUBLISHABLE_STATES})",
-        )
+        if state not in PUBLISHABLE_STATES:
+            return PublishResult(
+                "wrong_state", False, ref, iid,
+                f"state {state!r} is not publishable (expected one of {PUBLISHABLE_STATES})",
+            )
 
-    published_iso = published_at or (now or datetime.now(timezone.utc)).isoformat()
-    items[idx] = apply_publish(item, new_url, published_iso)
-    write_queue_atomic(path, items)
-    return PublishResult("published", True, ref, iid, f"published at {published_iso}")
+        published_iso = published_at or (now or datetime.now(timezone.utc)).isoformat()
+        items[idx] = apply_publish(item, new_url, published_iso)
+        write_queue_atomic(path, items)
+        return PublishResult("published", True, ref, iid, f"published at {published_iso}")
 
 
 def ingest_external_post(
@@ -332,23 +354,24 @@ def ingest_external_post(
     if not validate_ig_url(url):
         return PublishResult("invalid_url", False, "", detail=f"not an IG permalink: {ig_url!r}")
 
-    items = load_queue(path)
-    for existing in items:
-        if (existing.get("instagram_post_url") or "").strip() == url:
-            iid = item_id_of(existing)
-            return PublishResult(
-                "already_present", True, compute_ref_code(iid or url), iid,
-                "no-op: this IG URL is already registered",
-            )
+    with queue_lock(path):
+        items = load_queue(path)
+        for existing in items:
+            if (existing.get("instagram_post_url") or "").strip() == url:
+                iid = item_id_of(existing)
+                return PublishResult(
+                    "already_present", True, compute_ref_code(iid or url), iid,
+                    "no-op: this IG URL is already registered",
+                )
 
-    published_iso = published_at or (
-        (now or datetime.now(timezone.utc)) - timedelta(hours=25)
-    ).isoformat()
-    new_item = build_external_item(url, published_iso, topic=topic)
-    items.append(new_item)
-    write_queue_atomic(path, items)
-    iid = new_item["item_id"]
-    return PublishResult("ingested", True, compute_ref_code(iid), iid, f"registered external post {iid}")
+        published_iso = published_at or (
+            (now or datetime.now(timezone.utc)) - timedelta(hours=25)
+        ).isoformat()
+        new_item = build_external_item(url, published_iso, topic=topic)
+        items.append(new_item)
+        write_queue_atomic(path, items)
+        iid = new_item["item_id"]
+        return PublishResult("ingested", True, compute_ref_code(iid), iid, f"registered external post {iid}")
 
 
 # ── CLI ────────────────────────────────────────────────────────────────────

--- a/skills/bali-zero-brand/_damar-queue-server.py
+++ b/skills/bali-zero-brand/_damar-queue-server.py
@@ -22,9 +22,13 @@ Endpoints:
 Local-only: binds to 127.0.0.1 explicitly. No external exposure.
 """
 
+import fcntl
+import functools
 import json
+import os
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -57,8 +61,37 @@ def load_queue():
 
 
 def save_queue(queue):
+    """Atomic write (tmp + os.replace) — a reader must never see a partial file."""
     QUEUE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    QUEUE_PATH.write_text(json.dumps(queue, indent=2))
+    fd, tmp = tempfile.mkstemp(dir=str(QUEUE_PATH.parent), prefix=".queue-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(queue, f, indent=2)
+        os.replace(tmp, QUEUE_PATH)
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def with_queue_lock(fn):
+    """Serialize read-modify-write against the other queue writers.
+
+    Same lock file and protocol as wr2_html_render_apply._append_review_queue and
+    wr2_queue_writer (fcntl EX on human-review-queue.lock) — without it, a UI
+    action racing the renderer's append loses one of the two writes (Codex
+    red-team HIGH, PENDING-ARMS 2026-07-07)."""
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        QUEUE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = QUEUE_PATH.with_suffix(".lock")
+        with open(lock_path, "w", encoding="utf-8") as lock_fh:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX)
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                fcntl.flock(lock_fh, fcntl.LOCK_UN)
+    return wrapper
 
 
 def find_item(queue, item_id):
@@ -68,6 +101,7 @@ def find_item(queue, item_id):
     return None
 
 
+@with_queue_lock
 def mark_published(item_id, ig_url):
     queue = load_queue()
     item = find_item(queue, item_id)
@@ -92,6 +126,7 @@ def mark_published(item_id, ig_url):
     return {"ok": True, "new_state": new_state, "item_id": item_id}, 200
 
 
+@with_queue_lock
 def mark_rejected(item_id, reason_tag, notes):
     queue = load_queue()
     item = find_item(queue, item_id)
@@ -114,6 +149,7 @@ def mark_rejected(item_id, reason_tag, notes):
     return {"ok": True, "item_id": item_id, "reason_tag": reason_tag}, 200
 
 
+@with_queue_lock
 def capture_delta(item_id):
     """Stub: full Canva-MCP-driven diff requires orchestrator runtime.
 
@@ -141,6 +177,7 @@ def capture_delta(item_id):
     return {"ok": True, "item_id": item_id, "state": "reviewed"}, 200
 
 
+@with_queue_lock
 def flag_needs_human_edit(item_id, reason, retry_count, critic_report_path):
     """Transition a drafted carousel to drafted_needs_human_edit after orchestrator
     exhausts retry budget. Used by wr2-design-architect Failure mode."""


### PR DESCRIPTION
Closes the PENDING-ARMS line "review-queue multi-writer locking NOT unified" (Codex red-team HIGH from #2101 review).

- `_damar-queue-server.py`: the 4 mutating handlers now run under `with_queue_lock` (fcntl EX on `human-review-queue.lock`, same protocol as the renderer); `save_queue` becomes atomic (tmp + `os.replace`).
- `wr2_queue_writer.py`: `mark_published` and `ingest_external_post` wrap their load→write critical sections in the same lock.
- Torture test (cross-process, real writer modules): renderer-append vs queue-writer ingest, 25 rounds each — 50/50 writes survive. **Guilt run against pre-lock main: 0/25 renderer appends survived.** Plus innocence tests (refused transition = no write) and atomicity smoke.

Arming note: the live queue-server copy on Pro (`~/.claude/skills/bali-zero-brand/`) gets synced + the server restarted after merge — tracked in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)