### PR TITLE
fix(mouth): route ghost-route redirect through the RSC guard (WAVE 0 follow-up)

### DIFF
--- a/apps/mouth/src/__tests__/middleware.test.ts
+++ b/apps/mouth/src/__tests__/middleware.test.ts
@@ -526,6 +526,29 @@ describe("Middleware - Multi-domain Routing", () => {
       expect(response.status).not.toBe(302);
       expect(response.headers.get("x-pathname")).toBe("/dashboard");
     });
+
+    // The ghost-route redirect is cross-origin (kita → mail/calendar/...), so
+    // an RSC prefetch of <Link href="/email"> must get 204, not a 302 that
+    // trips a console CORS error. The original ghost-route block redirected
+    // manually and skipped the RSC guard — this pins that it no longer does.
+    it("[guilt] returns 204 for an RSC prefetch of a ghost route (/email)", () => {
+      const request = createRequest("https://kita.balizero.com/email", {
+        accept: "text/x-component",
+      });
+      const response = proxy(request);
+
+      expect(response.status).toBe(204);
+    });
+
+    it("[innocence] still 302-redirects a real navigation to /email", () => {
+      const request = createRequest("https://kita.balizero.com/email", {
+        accept: "text/html,application/xhtml+xml",
+      });
+      const response = proxy(request);
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("https://mail.balizero.com/");
+    });
   });
 
   // =======================================================================

--- a/apps/mouth/src/proxy.ts
+++ b/apps/mouth/src/proxy.ts
@@ -445,9 +445,10 @@ export function proxy(request: NextRequest) {
         const deepPath = pathname.slice(routePrefix.length) || "/";
         const targetUrl = new URL(deepPath, `https://${targetHost}`);
         targetUrl.search = request.nextUrl.search;
-        const redirectResponse = NextResponse.redirect(targetUrl, 302);
-        redirectResponse.headers.set("x-pathname", pathname);
-        return redirectResponse;
+        // Cross-origin (kita → mail/calendar/drive/knowledge): route through
+        // crossOriginRedirect so an RSC prefetch of <Link href="/email"> gets
+        // 204 instead of a cross-origin 302 that trips a console CORS error.
+        return crossOriginRedirect(request, targetUrl, 302);
       }
     }
 


### PR DESCRIPTION
## Follow-up to WAVE 0 (#2120): ghost-route redirect skipped the RSC guard

Found during PROVE-LIVE of WAVE 0 on prod.

### The bug
The WAVE 0 ghost-route block redirects `kita/{email,calendar,knowledge,documents}` to their standalone app subdomains (mail/calendar/drive/knowledge.balizero.com). It built the 302 **by hand** (`NextResponse.redirect` + manual `x-pathname`) instead of calling `crossOriginRedirect()` — the helper the other four cross-origin redirects in `proxy.ts` already use, which returns **204** for an RSC prefetch instead of a cross-origin 302.

**Effect:** an RSC prefetch of `<Link href="/email">` gets a cross-origin 302 → a console CORS error. That's the exact class `crossOriginRedirect()` exists to prevent, and the whole point of the WAVE 0 RSC fix.

**Proven live:** `curl -H 'Accept: text/x-component' https://kita.balizero.com/email` returned **302**, not 204.

### The fix
Replaced the 3 manual redirect lines with `return crossOriginRedirect(request, targetUrl, 302)`.

### Tests (guilt + innocence, #3 scar discipline)
- `[guilt]` RSC prefetch of `/email` → 204.
- `[innocence]` real navigation to `/email` → 302 → `https://mail.balizero.com/`.
- 64 middleware tests green (full file).

Auto-merge armed (bug fix, no brand/guardrail/migration change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
