### PR TITLE
fix(mouth): restore typecheck and vercel build guard

### DIFF
--- a/.github/workflows/vercel-build-guard.yml
+++ b/.github/workflows/vercel-build-guard.yml
@@ -24,7 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           echo "Frontend files changed — Vercel build proceeding"
           echo "Commit: ${{ github.sha }}"
-          echo "Message: ${{ github.event.head_commit.message }}"
+          printf 'Message:\n%s\n' "$COMMIT_MESSAGE"

--- a/apps/mouth/scripts/generate-llms-full.ts
+++ b/apps/mouth/scripts/generate-llms-full.ts
@@ -45,7 +45,7 @@ async function generate() {
     for (const file of files) {
       const filePath = path.join(categoryPath, file);
       const fileContents = fs.readFileSync(filePath, "utf8");
-      let parsed: matter.GrayMatterFile<string>;
+      let parsed: ReturnType<typeof matter>;
       try {
         parsed = matter(fileContents);
       } catch (error) {

--- a/apps/mouth/src/app/codex/route.test.ts
+++ b/apps/mouth/src/app/codex/route.test.ts
@@ -86,7 +86,10 @@ describe('/codex door alert (guilt + innocence)', () => {
     const res = await POST(postRequest('666', { 'x-vercel-ip-country': 'IT', 'x-vercel-ip-city': 'Roma' }));
     expect(res.status).toBe(303);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
     expect(url).toContain('graph.facebook.com');
     const body = JSON.parse(String(init.body));
     expect(body.text.body).toContain('ENTRATO');
@@ -97,7 +100,11 @@ describe('/codex door alert (guilt + innocence)', () => {
     const res = await POST(postRequest('123', { 'x-vercel-ip-country': 'IT' }));
     expect(res.status).toBe(401);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body));
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    const body = JSON.parse(String(init.body));
     expect(body.text.body).toContain('sbagliato');
   });
 
@@ -120,4 +127,3 @@ describe('/codex door alert (guilt + innocence)', () => {
     expect(res.status).toBe(303);
   });
 });
-

--- a/apps/mouth/src/types/gray-matter.d.ts
+++ b/apps/mouth/src/types/gray-matter.d.ts
@@ -1,0 +1,16 @@
+declare module "gray-matter" {
+  export interface GrayMatterFile<I = string> {
+    data: Record<string, any>;
+    content: string;
+    excerpt?: string;
+    orig: I;
+    language: string;
+    matter: string;
+    stringify(language?: string): string;
+  }
+
+  export default function matter<I = string>(
+    input: I,
+    options?: Record<string, unknown>,
+  ): GrayMatterFile<I>;
+}


### PR DESCRIPTION
## Summary
- Make Vercel Build Guard log multiline commit messages via env + printf, avoiding shell syntax errors on conventional commit bodies.
- Add a local gray-matter declaration so strict TypeScript builds can compile existing MDX readers and generation scripts.
- Make Codex route test fetch tuple casts explicit for current TypeScript strictness.

## Verification
- npm run typecheck
- npm run test -- --run src/lib/kbli-data.test.ts src/lib/kbli-cover-design.test.ts src/lib/kbli-hero-images.test.ts src/app/codex/route.test.ts