### PR TITLE
fix(ops): clean up WR2 and cron heartbeats

### DIFF
--- a/apps/cell/cell/sensors/cron_sensor.py
+++ b/apps/cell/cell/sensors/cron_sensor.py
@@ -16,6 +16,17 @@ from typing import Any
 logger = logging.getLogger("cell.sensors.cron")
 
 _STATE_DIR = os.path.expanduser("~/.agent/decisions/state")
+_CRON_AGENT_DIR = os.path.expanduser("~/.cron-agent")
+_CRON_AGENT_PYTHON_DIR = os.path.expanduser("~/.cron-agent-python")
+
+_JOB_STATE_ALIASES: dict[str, list[str]] = {
+    "nlm_deep_research": [
+        os.path.join(_CRON_AGENT_DIR, "nlm-deep-research.state.json"),
+    ],
+    "system_doctor": [
+        os.path.join(_CRON_AGENT_PYTHON_DIR, "system-doctor.state.json"),
+    ],
+}
 
 # Expected max period in hours for each watched job.
 # (yellow = 1.5× period, red = 3× period)
@@ -23,7 +34,7 @@ _JOB_PERIODS: dict[str, float] = {
     "fly_pg_backup":       24.0,   # daily
     "intel_scraper":       24.0,   # daily 03:00
     "nlm_deep_research":   24.0,   # daily 04:30
-    "t4_monitor_daily":     6.0,   # every 6h
+    "t4_monitor":           6.0,   # every 6h; cron-wrapper writes t4_monitor.last.json
     # "war_room" removed 2026-04-27: WR1 was decommissioned by PR #171
     # (apps/war-room/pipeline.sh deleted). The intel-nightly LaunchAgent
     # already logs "skip" for it, but the watcher kept marking it failed
@@ -45,6 +56,16 @@ _JOB_PERIODS: dict[str, float] = {
     "knowledge_graph_builder": 168.0,
     "metabolic_rollup":        24.0,   # daily 23:30
 }
+
+
+def _state_candidates(state_dir: str, job_name: str) -> list[str]:
+    """Return current and legacy heartbeat paths for a watched job."""
+    candidates = [
+        os.path.join(state_dir, f"{job_name}.last.json"),
+        os.path.join(state_dir, f"{job_name.replace('_', '-')}.last.json"),
+        *_JOB_STATE_ALIASES.get(job_name, []),
+    ]
+    return list(dict.fromkeys(candidates))
 
 
 @dataclass
@@ -88,13 +109,8 @@ class CronSensor:
         jobs: list[CronJobStatus] = []
 
         for job_name, period_hours in self._periods.items():
-            # State file may use hyphens or underscores interchangeably
-            candidates = [
-                os.path.join(self._dir, f"{job_name}.last.json"),
-                os.path.join(self._dir, f"{job_name.replace('_', '-')}.last.json"),
-            ]
             state: dict[str, Any] | None = None
-            for path in candidates:
+            for path in _state_candidates(self._dir, job_name):
                 if os.path.isfile(path):
                     try:
                         with open(path) as f:
@@ -108,7 +124,8 @@ class CronSensor:
                 continue
 
             ts = state.get("ts")
-            job_ok = state.get("status", "ok") == "ok"
+            reported_status = str(state.get("status", "ok")).lower()
+            job_ok = reported_status == "ok"
 
             if not ts:
                 jobs.append(CronJobStatus(name=job_name, status="unknown"))
@@ -132,7 +149,7 @@ class CronSensor:
                 status=cron_status,
                 age_hours=round(age_hours, 2),
                 last_run=last_run_iso,
-                last_job_status=state.get("status", "?"),
+                last_job_status=reported_status,
             ))
 
         worst = max(
@@ -141,7 +158,11 @@ class CronSensor:
             default="unknown",
         )
         stale = [j.name for j in jobs if j.status in ("yellow", "red")]
-        failed = [j.name for j in jobs if j.last_job_status == "failed"]
+        failed = [
+            j.name
+            for j in jobs
+            if j.last_job_status in ("failed", "error", "timeout")
+        ]
 
         return CronReading(
             status=worst,

--- a/apps/cell/tests/test_new_sensors.py
+++ b/apps/cell/tests/test_new_sensors.py
@@ -167,6 +167,81 @@ def test_cron_sensor_unknown_no_file():
         assert reading.jobs[0].status == "unknown"
 
 
+def test_cron_sensor_reads_job_alias_path(monkeypatch):
+    import time
+
+    from cell.sensors import cron_sensor as cron_sensor_module
+    from cell.sensors.cron_sensor import CronSensor
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        alias_dir = os.path.join(tmpdir, "cron-agent-python")
+        os.makedirs(alias_dir)
+        alias_file = os.path.join(alias_dir, "system-doctor.state.json")
+        with open(alias_file, "w") as f:
+            json.dump({"job": "system-doctor", "ts": int(time.time()), "status": "ok"}, f)
+
+        monkeypatch.setattr(
+            cron_sensor_module,
+            "_JOB_STATE_ALIASES",
+            {"system_doctor": [alias_file]},
+        )
+
+        sensor = CronSensor(state_dir=tmpdir, job_periods={"system_doctor": 24.0})
+        reading = sensor.read()
+        job = next(j for j in reading.jobs if j.name == "system_doctor")
+
+    assert job.status == "green"
+    assert reading.status == "green"
+
+
+def test_cron_sensor_reads_t4_monitor_current_job_name():
+    import time
+
+    from cell.sensors.cron_sensor import CronSensor
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_file = os.path.join(tmpdir, "t4_monitor.last.json")
+        with open(state_file, "w") as f:
+            json.dump({"job": "t4_monitor", "ts": int(time.time()), "status": "ok"}, f)
+
+        sensor = CronSensor(state_dir=tmpdir, job_periods={"t4_monitor": 6.0})
+        reading = sensor.read()
+        job = next(j for j in reading.jobs if j.name == "t4_monitor")
+
+    assert job.status == "green"
+    assert reading.status == "green"
+
+
+def test_cron_sensor_default_uses_t4_monitor_current_job_name():
+    from cell.sensors.cron_sensor import CronSensor
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sensor = CronSensor(state_dir=tmpdir)
+        reading = sensor.read()
+
+    names = [job.name for job in reading.jobs]
+    assert "t4_monitor" in names
+    assert "t4_monitor_daily" not in names
+
+
+def test_cron_sensor_marks_error_status_as_failed_metadata():
+    import time
+
+    from cell.sensors.cron_sensor import CronSensor
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_file = os.path.join(tmpdir, "system_doctor.last.json")
+        with open(state_file, "w") as f:
+            json.dump({"job": "system-doctor", "ts": int(time.time()), "status": "error"}, f)
+
+        sensor = CronSensor(state_dir=tmpdir, job_periods={"system_doctor": 24.0})
+        reading = sensor.read()
+        job = next(j for j in reading.jobs if j.name == "system_doctor")
+
+    assert job.status == "yellow"
+    assert reading.metadata["failed_jobs"] == ["system_doctor"]
+
+
 # ── TrendDetector ─────────────────────────────────────────────────────────────
 
 def test_trend_detector_monotonic_drift():

--- a/scripts/tests/test_wr2_supervisor.py
+++ b/scripts/tests/test_wr2_supervisor.py
@@ -270,6 +270,46 @@ async def test_malformed_payload_skipped(sup):
     assert mock_ks.call_count == 0
 
 
+@pytest.mark.asyncio
+async def test_ack_outbox_updates_wr2_row(sup):
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    acked = await sup._ack_outbox_if_present({"_outbox_id": "123"}, conn)
+
+    assert acked is True
+    conn.execute.assert_awaited_once()
+    query, outbox_id = conn.execute.await_args.args
+    assert "UPDATE events_outbox" in query
+    assert "channel = 'wr2_status_change'" in query
+    assert outbox_id == 123
+
+
+@pytest.mark.asyncio
+async def test_ack_outbox_ignores_missing_or_invalid_id(sup, caplog):
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    assert await sup._ack_outbox_if_present({}, conn) is False
+    with caplog.at_level("WARNING"):
+        assert await sup._ack_outbox_if_present({"_outbox_id": "bad"}, conn) is False
+
+    assert conn.execute.await_count == 0
+    assert any("invalid _outbox_id" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_and_ack_acks_after_success(sup):
+    conn = MagicMock()
+
+    with patch.object(sup, "_handle_payload", new=AsyncMock()) as mock_handle:
+        with patch.object(sup, "_ack_outbox_if_present", new=AsyncMock(return_value=True)) as mock_ack:
+            await sup._handle_payload_and_ack({"_outbox_id": 456}, conn)
+
+    mock_handle.assert_awaited_once_with({"_outbox_id": 456}, conn)
+    mock_ack.assert_awaited_once_with({"_outbox_id": 456}, conn)
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Reconciliation
 # ─────────────────────────────────────────────────────────────────────────

--- a/scripts/wr2_supervisor.py
+++ b/scripts/wr2_supervisor.py
@@ -263,6 +263,31 @@ async def _current_status(conn: asyncpg.Connection, draft_id: str) -> str | None
         )
 
 
+async def _ack_outbox_if_present(payload: dict[str, Any], conn: asyncpg.Connection) -> bool:
+    """Ack durable wr2_status_change rows carried by live NOTIFY payloads."""
+    raw_outbox_id = payload.get("_outbox_id")
+    if raw_outbox_id is None:
+        return False
+    try:
+        outbox_id = int(raw_outbox_id)
+    except (TypeError, ValueError):
+        logger.warning("invalid _outbox_id in wr2 payload: %r", raw_outbox_id)
+        return False
+
+    async with _get_conn_lock():
+        result = await conn.execute(
+            """
+            UPDATE events_outbox
+               SET consumed_at = NOW()
+             WHERE id = $1
+               AND channel = 'wr2_status_change'
+               AND consumed_at IS NULL
+            """,
+            outbox_id,
+        )
+    return result == "UPDATE 1"
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Notification handler
 # ─────────────────────────────────────────────────────────────────────────
@@ -335,6 +360,14 @@ async def _handle_payload(payload: dict[str, Any], conn: asyncpg.Connection) -> 
         await loop.run_in_executor(None, _kickstart, target)
 
 
+async def _handle_payload_and_ack(payload: dict[str, Any], conn: asyncpg.Connection) -> None:
+    """Handle a live notification, then ack its outbox row on success."""
+    await _handle_payload(payload, conn)
+    acked = await _ack_outbox_if_present(payload, conn)
+    if acked:
+        logger.debug("acked wr2_status_change outbox id=%s", payload.get("_outbox_id"))
+
+
 def _trim_dedup() -> None:
     """Bound the dedup set size to avoid unbounded growth."""
     if len(_recently_dispatched) > _RECENTLY_DISPATCHED_MAX:
@@ -361,7 +394,7 @@ def _on_notification(connection, pid, channel, payload_str):  # noqa: ARG001 —
     except json.JSONDecodeError as e:
         logger.warning("non-JSON notification on %s: %r (%s)", channel, payload_str, e)
         return
-    task = asyncio.create_task(_handle_payload(payload, connection))
+    task = asyncio.create_task(_handle_payload_and_ack(payload, connection))
     _handler_tasks.add(task)
     task.add_done_callback(_handler_tasks.discard)
     task.add_done_callback(_log_task_exception)


### PR DESCRIPTION
## Summary
- Ack durable wr2_status_change outbox rows after live NOTIFY handlers complete successfully
- Keep replay path unchanged for stored payloads without _outbox_id
- Teach CronSensor to read current cron-agent / cron-agent-python heartbeat paths
- Stop watching the retired t4_monitor_daily heartbeat name and cover error statuses in failed_jobs metadata

## Tests
- PYTHONPATH=apps/cell apps/backend-rag/.venv/bin/python -m pytest apps/cell/tests/test_new_sensors.py -q
- apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_wr2_supervisor.py -q
- apps/backend-rag/.venv/bin/python -m py_compile apps/cell/cell/sensors/cron_sensor.py scripts/wr2_supervisor.py
- Pro: PYTHONPATH=apps/cell /Users/nuzantara/Desktop/nuzantara/.venv/bin/python -m pytest apps/cell/tests/test_new_sensors.py -q
- Pro: /Users/nuzantara/Desktop/nuzantara/.venv/bin/python -m pytest scripts/tests/test_wr2_supervisor.py -q
- Pro: /Users/nuzantara/Desktop/nuzantara/.venv/bin/python -m py_compile apps/cell/cell/sensors/cron_sensor.py scripts/wr2_supervisor.py

## Live verification
- Pro worktree CronSensor read: green, no stale_jobs, no failed_jobs