### PR TITLE
fix(mouth): repair strata title MDX syntax

### DIFF
--- a/apps/mouth/src/components/blog/MDXContentRSC.test.tsx
+++ b/apps/mouth/src/components/blog/MDXContentRSC.test.tsx
@@ -13,6 +13,14 @@ function stripImports(content: string): string {
     .trim();
 }
 
+const strataTitleArticles = [
+  "src/content/articles/property/strata-title-explained.mdx",
+  "src/content/articles/property/strata-title-explained.fr.mdx",
+  "src/content/articles/property/strata-title-explained.id.mdx",
+  "src/content/articles/property/strata-title-explained.it.mdx",
+  "src/content/articles/property/strata-title-explained.ru.mdx",
+];
+
 describe("renderMDXBody", () => {
   it("server-renders the driving license article interactive MDX body", async () => {
     const articlePath = path.join(
@@ -32,4 +40,19 @@ describe("renderMDXBody", () => {
     expect(html).not.toContain("Decision tree unavailable");
     expect(html).not.toContain("Journey map unavailable");
   });
+
+  it.each(strataTitleArticles)(
+    "server-renders the strata title article interactive MDX body: %s",
+    async (article) => {
+      const articlePath = path.join(process.cwd(), article);
+      const articleFile = fs.readFileSync(articlePath, "utf8");
+      const { content } = matter(articleFile);
+
+      const mdxBody = await renderMDXBody(stripImports(content));
+
+      const html = renderToString(<>{mdxBody}</>);
+
+      expect(html).toContain("PPJB vs SHMSRS");
+    },
+  );
 });

--- a/apps/mouth/src/content/articles/property/strata-title-explained.fr.mdx
+++ b/apps/mouth/src/content/articles/property/strata-title-explained.fr.mdx
@@ -309,7 +309,7 @@ Les charges typiques couvrent :
 
 <ComparisonTable
   title="PPJB vs SHMSRS"
-  description: "Comprendre le pré-titre vs le titre"
+  description="Comprendre le pré-titre vs le titre"
   items={[
     {
       name: "PPJB",

--- a/apps/mouth/src/content/articles/property/strata-title-explained.it.mdx
+++ b/apps/mouth/src/content/articles/property/strata-title-explained.it.mdx
@@ -309,7 +309,7 @@ Le spese tipiche coprono:
 
 <ComparisonTable
   title="PPJB vs SHMSRS"
-  description: "Comprendere il pre-titolo vs il titolo"
+  description="Comprendere il pre-titolo vs il titolo"
   items={[
     {
       name: "PPJB",

--- a/apps/mouth/src/content/articles/property/strata-title-explained.mdx
+++ b/apps/mouth/src/content/articles/property/strata-title-explained.mdx
@@ -307,7 +307,7 @@ Typical charges cover:
 
 <ComparisonTable
   title="PPJB vs SHMSRS"
-  description: "Understanding pre-title vs title"
+  description="Understanding pre-title vs title"
   items={[
     {
       name: "PPJB",


### PR DESCRIPTION
## Summary
- fix invalid JSX prop syntax in the strata title article ComparisonTable block
- apply the same correction to English, French, and Italian article variants
- add MDX server-render regression coverage for all strata title article variants

## Verification
- npm run test -- --run src/components/blog/MDXContentRSC.test.tsx
- npm run build