### PR TITLE
fix(wr2): treat missed drafts as terminal

### DIFF
--- a/scripts/tests/test_wr2_supervisor_watchdog.py
+++ b/scripts/tests/test_wr2_supervisor_watchdog.py
@@ -309,7 +309,8 @@ def _make_outcome_conn(stale_rows=(), age_rows=(), rendered_rows=(), renderer_en
         if "lease_heartbeat_at" in q and "'rendering'" in q:
             return list(stale_rows)
         if "GROUP BY status" in q:
-            return list(age_rows)
+            excluded = set(args[0])
+            return [row for row in age_rows if row["status"] not in excluded]
         if "drive_url IS NOT NULL" in q:
             return list(rendered_rows)
         raise AssertionError(f"unmocked fetch: {q[:120]}")
@@ -373,6 +374,14 @@ def test_state_age_unknown_state_always_flagged(wd):
     ])
     sent = _run_outcome(wd, conn)
     assert any("UNKNOWN states" in m for m in sent)
+
+
+def test_state_age_missed_is_terminal_not_unknown(wd):
+    """Missed drafts are intentionally skipped pipeline runs, not state drift."""
+    conn = _make_outcome_conn(age_rows=[
+        {"status": "missed", "n": 17, "oldest_hours": 300.0},
+    ])
+    assert _run_outcome(wd, conn) == []
 
 
 def test_state_age_checked_backlog_expected_when_renderer_off(wd):

--- a/scripts/wr2_supervisor_watchdog.py
+++ b/scripts/wr2_supervisor_watchdog.py
@@ -163,6 +163,7 @@ TERMINAL_STATUSES = (
     "render_failed",
     "fact_check_failed",
     "image_failed",
+    "missed",
     "rejected",
 )
 


### PR DESCRIPTION
## Summary
- Treat WR2 `missed` drafts as terminal in the supervisor watchdog state-age probe
- Make the watchdog outcome test helper respect terminal statuses excluded by the SQL query
- Add regression coverage so `missed` does not page as state-machine drift

## Tests
- `PYTHONPATH=. pytest scripts/tests/test_wr2_supervisor_watchdog.py -q`
- Live Pro SQL check: `state_age_unknown_after_missed_terminal=[]`, `state_age_over_after_missed_terminal=[]`