### PR TITLE
fix(mouth): move chat stop session id into logger metadata

### DIFF
--- a/apps/mouth/src/hooks/useChatPage.ts
+++ b/apps/mouth/src/hooks/useChatPage.ts
@@ -310,7 +310,7 @@ export function useChatPage(): UseChatPageReturn {
     logger.info("Message generation stopped by user", {
       component: "useChatPage",
       action: "handleStop",
-      sessionId,
+      metadata: { sessionId },
     });
   }, [chatSend, sessionId]);
 


### PR DESCRIPTION
## Summary
- Move the chat stop-generation `sessionId` into logger `metadata` so the object conforms to `LogContext`.
- Unblocks the Next/Vercel production typecheck failure introduced on the stop-generation path.

## Verification
- `npm run typecheck -- --pretty false`
- `npm test -- src/components/chat/ChatInputBar.test.tsx --run`
- `npm run build`
