### PR TITLE
fix(brand): true anthracite #373D42 — the historic #2C2F38 read as blue-grey

### DIFF
--- a/scripts/wr2_canva_pdf_render.py
+++ b/scripts/wr2_canva_pdf_render.py
@@ -75,7 +75,7 @@ TOKENS_PATH = Path.home() / ".claude/skills/bali-zero-brand/tokens.json"
 LOGO_PATH = Path.home() / ".claude/skills/bali-zero-brand/assets/logo.png"
 
 _TOKENS_FALLBACK = {
-    "bg_antracite": "#2C2F38",
+    "bg_antracite": "#373D42",
     "bg_black": "#000000",
     "text_white": "#FFFFFF",
     "text_muted": "#9CA3AF",
@@ -569,7 +569,7 @@ def draw_regulation_badge(c: canvas.Canvas, code: str, font_mono: str) -> None:
     """SOTA Pattern #3 (Article 14.4 revised 2026-05-13) — yellow rounded badge
     top-right with regulation code in IBM Plex Mono / Menlo fallback.
 
-    WCAG: yellow #F4C430 vs antracite #2C2F38 = 8.14:1 AAA;
+    WCAG: yellow #F4C430 vs antracite #373D42 = 6.70:1 (AA; AAA large text);
           black text on yellow = 12.79:1 AAA inside.
     """
     if not code:

--- a/scripts/wr2_html_renderer/renderer.py
+++ b/scripts/wr2_html_renderer/renderer.py
@@ -395,7 +395,7 @@ def _hero_visible_in_png(png_path: Path, family: str | None = None) -> bool:
         bs = [s[2] for s in samples]
         spread = (max(rs) - min(rs)) + (max(gs) - min(gs)) + (max(bs) - min(bs))
         # A photo lights up most samples AND has color spread. Thresholds chosen
-        # so a flat antracite (#2C2F38, spread 0) or flat black fails, while a
+        # so a flat antracite (#373D42, spread 0) or flat black fails, while a
         # real cinematic hero passes.
         return bright_frac > 0.4 and spread > 40
 

--- a/skills/bali-zero-brand/SKILL.md
+++ b/skills/bali-zero-brand/SKILL.md
@@ -55,7 +55,7 @@ Bali Zero is the Indonesian-business-services agency for expat founders, investo
 
 | Role | Token | Hex |
 |---|---|---|
-| Background primary | `color.bg.antracite` | `#2C2F38` |
+| Background primary | `color.bg.antracite` | `#373D42` |
 | Background secondary | `color.bg.black` | `#000000` |
 | Body text | `color.text.white` | `#FFFFFF` |
 | Accent data | `color.accent.yellow` | `#F4C430` |

--- a/skills/bali-zero-brand/_damar-anchor-ui.html
+++ b/skills/bali-zero-brand/_damar-anchor-ui.html
@@ -5,7 +5,7 @@
 <title>WR2 Anchor Picker</title>
 <style>
   :root {
-    --color-bg-antracite: #2C2F38;
+    --color-bg-antracite: #373D42;
     --color-bg-black: #000000;
     --color-text-white: #FFFFFF;
     --color-text-muted: #9CA3AF;

--- a/skills/bali-zero-brand/_damar-inject-ui.html
+++ b/skills/bali-zero-brand/_damar-inject-ui.html
@@ -5,7 +5,7 @@
 <title>WR2 — Manual Topic Injection</title>
 <style>
   :root {
-    --color-bg-antracite: #2C2F38;
+    --color-bg-antracite: #373D42;
     --color-bg-black: #000000;
     --color-text-white: #FFFFFF;
     --color-text-muted: #9CA3AF;

--- a/skills/bali-zero-brand/_damar-queue-ui.html
+++ b/skills/bali-zero-brand/_damar-queue-ui.html
@@ -5,7 +5,7 @@
 <title>WR2 Damar Queue</title>
 <style>
   :root {
-    --color-bg-antracite: #2C2F38;
+    --color-bg-antracite: #373D42;
     --color-bg-black: #000000;
     --color-text-white: #FFFFFF;
     --color-text-muted: #9CA3AF;

--- a/skills/bali-zero-brand/_damar-tag-ui.html
+++ b/skills/bali-zero-brand/_damar-tag-ui.html
@@ -5,7 +5,7 @@
 <title>WR2 Past Carousel Tagging</title>
 <style>
   :root {
-    --color-bg-antracite: #2C2F38;
+    --color-bg-antracite: #373D42;
     --color-bg-black: #000000;
     --color-text-white: #FFFFFF;
     --color-text-muted: #9CA3AF;

--- a/skills/bali-zero-brand/_render_smoke_test.py
+++ b/skills/bali-zero-brand/_render_smoke_test.py
@@ -30,7 +30,7 @@ TEST_SLIDE = {
 
 ALLOWED_HEX_IN_CSS = {
     # Palette tokens — these are OK in _base.css :root only
-    "#2C2F38", "#000000", "#FFFFFF", "#9CA3AF",
+    "#373D42", "#000000", "#FFFFFF", "#9CA3AF",
     "#F4C430", "#C8102E",
 }
 

--- a/skills/bali-zero-brand/constitution.md
+++ b/skills/bali-zero-brand/constitution.md
@@ -19,7 +19,7 @@
 
 | Token | Hex | Role |
 |---|---|---|
-| `color.bg.antracite` | `#2C2F38` | Primary background |
+| `color.bg.antracite` | `#373D42` | Primary background |
 | `color.bg.black` | `#000000` | Secondary background, hero overlay |
 | `color.text.white` | `#FFFFFF` | Body text, headlines |
 | `color.accent.yellow` | `#F4C430` | Data, sub-headlines, key numbers |
@@ -353,7 +353,7 @@ When `brief.primary_regulation_code` is non-empty, the cover slide MUST display 
 
 When `brief.primary_regulation_code` is empty, the cover MUST NOT display this badge (avoid false-authoritative signal).
 
-**Rationale**: FT, Kontan, Tempo signal "we are citing the primary source" before the body is read. Indonesian regulatory audience reads the code first. Yellow chosen 2026-05-13 after WCAG audit (research/wr2-design-sota/2026-05-13-best-bg-color-editorial-publisher.md) found previous red bg `#C8102E` vs antracite `#2C2F38` = 2.27:1 (FAIL); yellow vs antracite = 8.14:1 (AAA), black text on yellow = 12.79:1 (AAA inside).
+**Rationale**: FT, Kontan, Tempo signal "we are citing the primary source" before the body is read. Indonesian regulatory audience reads the code first. Yellow chosen 2026-05-13 after WCAG audit (research/wr2-design-sota/2026-05-13-best-bg-color-editorial-publisher.md) found red-as-text on the dark bg FAILS contrast; yellow passes. Recomputed 2026-07-08 on the corrected antracite `#373D42` (historic value `#373D42` read as blue-grey — palette fix by Zero): yellow `#F4C430` vs bg = 6.70:1 (AA, AAA for the large display text carousels use), white vs bg = 11.0:1 (AAA), muted `#9CA3AF` vs bg = 4.33:1 (large text/captions only), red `#C8102E` vs bg = 1.87:1 (never as text on bg — logo/badge fills only), black text on yellow = 12.79:1 (AAA inside).
 
 **Brand semantics (added 2026-05-13)**: yellow unifies regulation badge with Article 6.9 anchor highlights as the **family color for "verifiable facts"** — numbers, codes, regulations, dates. Red retained for: logo (3 ALI ZERO red glyph on black-circle bg, accessible by construction), red rule dividers (line not text, contrast n/a), and status critical alerts on white background only.
 

--- a/skills/bali-zero-brand/layouts/_base.css
+++ b/skills/bali-zero-brand/layouts/_base.css
@@ -9,7 +9,7 @@
 
 :root {
   /* Colors — derived from tokens.json color.* */
-  --color-bg-antracite: #2C2F38;
+  --color-bg-antracite: #373D42;
   --color-bg-black: #000000;
   --color-text-white: #FFFFFF;
   --color-text-muted: #9CA3AF;
@@ -117,7 +117,7 @@ body {
  *
  * REVISED 2026-05-13: bg red → yellow, text white → black. Reason: WCAG audit
  * (research/wr2-design-sota/2026-05-13-best-bg-color-editorial-publisher.md)
- * found red #C8102E vs antracite #2C2F38 = 2.27:1 (FAIL). Yellow #F4C430 vs
+ * found red #C8102E vs antracite #373D42 = 2.27:1 (FAIL). Yellow #F4C430 vs
  * antracite = 8.14:1 (AAA). Black text on yellow = 12.79:1 (AAA inside).
  * Yellow now unifies regulation badge with Article 6.9 anchor highlights as
  * the family color for "verifiable facts" (numbers, codes, regulations).

--- a/skills/bali-zero-brand/surfaces/email-template.md
+++ b/skills/bali-zero-brand/surfaces/email-template.md
@@ -38,7 +38,7 @@ Per constitution Article 12.2, every email inherits:
 - **Case**: Title Case in headlines (not UPPERCASE — UPPERCASE in email triggers spam filters and reads aggressive in inbox preview).
 
 ### Palette (subset — email rendering varies)
-- Background: `#FFFFFF` body OR `#2C2F38` antracite for "alert/regulatory" emails. NEVER pure black `#000000` (renders harshly on phone OLED).
+- Background: `#FFFFFF` body OR `#373D42` antracite for "alert/regulatory" emails. NEVER pure black `#000000` (renders harshly on phone OLED).
 - Text on white: `#1A1A1A` (slightly off-black for readability).
 - Text on antracite: `#FFFFFF`.
 - Accent yellow: `#F4C430` for key data points and CTA buttons (sparingly).

--- a/skills/bali-zero-brand/surfaces/fb-community-post.md
+++ b/skills/bali-zero-brand/surfaces/fb-community-post.md
@@ -50,7 +50,7 @@ Same as `carousel-ig` surface for any text laid on image:
 ### Palette (image overlay)
 
 Subset of full brand palette — FB feed crops dark images visually:
-- Background overlay: `#2C2F38` antracite at 70-85% opacity over photo OR `#FFFFFF` flat for "explainer" posts.
+- Background overlay: `#373D42` antracite at 70-85% opacity over photo OR `#FFFFFF` flat for "explainer" posts.
 - Text on antracite overlay: `#FFFFFF`.
 - Text on white: `#1A1A1A`.
 - Accent yellow `#F4C430` for the regulation number / concrete data point.

--- a/skills/bali-zero-brand/surfaces/internal-print-a4/_template.css
+++ b/skills/bali-zero-brand/surfaces/internal-print-a4/_template.css
@@ -33,7 +33,7 @@ html, body {
 /* ========== COLOR TOKENS — bali-zero-brand constitution Article 2 ========== */
 :root {
   /* Brand-cortex official tokens */
-  --bz-bg-dark: #2C2F38;          /* color.bg.antracite */
+  --bz-bg-dark: #373D42;          /* color.bg.antracite */
   --bz-bg-darker: #000000;        /* color.bg.black */
   --bz-text-light: #FFFFFF;       /* color.text.white */
   --bz-text-muted: #9CA3AF;       /* color.text.muted (sources, captions) */

--- a/skills/bali-zero-brand/tokens.json
+++ b/skills/bali-zero-brand/tokens.json
@@ -10,7 +10,7 @@
   },
   "color": {
     "bg": {
-      "antracite": { "value": "#2C2F38", "type": "color", "role": "primary background" },
+      "antracite": { "value": "#373D42", "type": "color", "role": "primary background" },
       "black": { "value": "#000000", "type": "color", "role": "secondary background, hero overlay" }
     },
     "text": {


### PR DESCRIPTION
Zero's palette correction (2026-07-08): color.bg.antracite token was
#2C2F38, blue-channel dominant, rendering slides blue-grey. New value
#373D42 applied across the living canon: tokens.json (SSOT the renderer
injects into :root), layouts/_base.css, canva PDF renderer constant,
smoke-test palette, constitution + SKILL tables, 4 Damar UIs, email/FB/
print-A4 surfaces. WCAG recomputed on the new bg: yellow 6.70:1 (AAA
for carousel display text), white 11.0:1 AAA, muted 4.33:1 (large
text only), red stays fill-only. Historical reports and rendered
artifacts untouched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
