### PR TITLE
fix(mouth): downgrade proxy auth denials to warnings

### DIFF
--- a/apps/mouth/src/app/api/[...path]/route.test.ts
+++ b/apps/mouth/src/app/api/[...path]/route.test.ts
@@ -239,7 +239,7 @@ describe("proxy catch-all route — auth failure logging", () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 
-  it("keeps error logging for credentialed auth failures", async () => {
+  it("logs credentialed auth failures as warnings, not runtime errors", async () => {
     const req = new MockNextRequest("http://localhost/api/auth/profile", {
       method: "GET",
       cookies: { nz_access_token: "stale-jwt" },
@@ -248,13 +248,13 @@ describe("proxy catch-all route — auth failure logging", () => {
     const response = await GET(req as never);
 
     expect(response.status).toBe(401);
-    expect(logger.error).toHaveBeenCalledWith(
-      "[Proxy] Auth error 401 for GET /api/auth/profile",
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Proxy] Auth rejected 401 for GET /api/auth/profile with credentials",
       expect.objectContaining({
-        action: "error",
+        action: "auth_rejected",
       }),
-      expect.any(Error),
     );
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/mouth/src/app/api/[...path]/route.ts
+++ b/apps/mouth/src/app/api/[...path]/route.ts
@@ -251,15 +251,12 @@ async function proxy(req: NextRequest): Promise<Response> {
         };
 
         if (hasAuthCookie || hasAuthHeader) {
-          logger.error(
-            `[Proxy] Auth error ${upstream.status} for ${req.method} ${url.pathname}`,
+          logger.warn(
+            `[Proxy] Auth rejected ${upstream.status} for ${req.method} ${url.pathname} with credentials`,
             {
               ...authLogContext,
-              action: "error",
+              action: "auth_rejected",
             },
-            toError(
-              `[Proxy] Auth error ${upstream.status} for ${req.method} ${url.pathname}`,
-            ),
           );
         } else {
           logger.warn(


### PR DESCRIPTION
## Summary
- log credentialed proxy 401/403 responses as auth_rejected warnings instead of errors
- keep auth-denial observability without creating Vercel runtime error groups for expected stale-session cases
- update proxy route tests

## Tests
- npm test -- 'src/app/api/[...path]/route.test.ts' --run
- npm run typecheck -- --pretty false