### PR TITLE
fix(crm): 503 on 3 analytics endpoints for admins (dynamic $N placeholder indices)

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_analytics.py
+++ b/apps/backend-rag/backend/app/routers/crm_analytics.py
@@ -146,12 +146,15 @@ async def get_client_overview(
             month_start = datetime.now(tz=timezone.utc).replace(
                 day=1, hour=0, minute=0, second=0, microsecond=0
             )
+            # Index follows the optional assigned-filter param ($1). Hardcoding
+            # $2 here 503s for admins (no filter → param is $1, not $2).
+            date_idx = len(params) + 1
             new_month_query = f"""
                 SELECT COUNT(*) FROM clients
                 {where_clause}
-                {"AND" if where_clause else "WHERE"} created_at >= $2
+                {"AND" if where_clause else "WHERE"} created_at >= ${date_idx}
             """
-            month_params = [*params, month_start] if params else [month_start]
+            month_params = [*params, month_start]
             new_this_month = await conn.fetchval(new_month_query, *month_params) or 0
 
             # New this week
@@ -162,9 +165,9 @@ async def get_client_overview(
             new_week_query = f"""
                 SELECT COUNT(*) FROM clients
                 {where_clause}
-                {"AND" if where_clause else "WHERE"} created_at >= $2
+                {"AND" if where_clause else "WHERE"} created_at >= ${date_idx}
             """
-            week_params = [*params, week_start] if params else [week_start]
+            week_params = [*params, week_start]
             new_this_week = await conn.fetchval(new_week_query, *week_params) or 0
 
             # By status
@@ -324,6 +327,14 @@ async def get_revenue_summary(
                 month_end = _next_month_start(month_start)
                 month_label = month_start.strftime("%Y-%m")
 
+                # Placeholder indices must follow the (optional) assigned-filter
+                # param, not be hardcoded to $2/$3 — otherwise an admin with no
+                # filter (params == []) makes the date params $1/$2 while the SQL
+                # still references $2/$3, and $3 is never bound → asyncpg raises
+                # IndeterminateDatatypeError ("could not determine data type of
+                # parameter $1") and the whole endpoint 503s for every admin.
+                start_idx = len(params) + 1
+                end_idx = len(params) + 2
                 month_query = f"""
                     SELECT
                         COALESCE(SUM(p.actual_price), 0) as revenue,
@@ -331,11 +342,9 @@ async def get_revenue_summary(
                     FROM practices p
                     JOIN clients c ON p.client_id = c.id
                     {where_clause}
-                    {"AND" if where_clause else "WHERE"} p.created_at >= $2 AND p.created_at < $3
+                    {"AND" if where_clause else "WHERE"} p.created_at >= ${start_idx} AND p.created_at < ${end_idx}
                 """
-                month_params = (
-                    [*params, month_start, month_end] if params else [month_start, month_end]
-                )
+                month_params = [*params, month_start, month_end]
                 month_row = await conn.fetchrow(month_query, *month_params)
 
                 months.append(
@@ -460,32 +469,31 @@ async def get_client_trend(
                 month_end = _next_month_start(month_start)
                 month_label = month_start.strftime("%b %Y")
 
+                # Placeholder indices follow the optional assigned-filter param;
+                # hardcoded $2/$3 503s for admins (no filter → date params start
+                # at $1). See revenue/summary for the same class of bug.
+                c_start = len(client_params) + 1
+                c_end = len(client_params) + 2
                 # New clients
                 new_clients_query = f"""
                     SELECT COUNT(*) FROM clients
                     {where_clause}
-                    {"AND" if where_clause else "WHERE"} created_at >= $2 AND created_at < $3
+                    {"AND" if where_clause else "WHERE"} created_at >= ${c_start} AND created_at < ${c_end}
                 """
-                new_params = (
-                    [*client_params, month_start, month_end]
-                    if client_params
-                    else [month_start, month_end]
-                )
+                new_params = [*client_params, month_start, month_end]
                 new_clients = await conn.fetchval(new_clients_query, *new_params) or 0
 
                 # Revenue
+                p_start = len(practice_params) + 1
+                p_end = len(practice_params) + 2
                 revenue_query = f"""
                     SELECT COALESCE(SUM(p.actual_price), 0)
                     FROM practices p
                     JOIN clients c ON p.client_id = c.id
                     {where_clause.replace("WHERE", "WHERE c.") if where_clause else ""}
-                    {"AND" if where_clause else "WHERE"} p.created_at >= $2 AND p.created_at < $3
+                    {"AND" if where_clause else "WHERE"} p.created_at >= ${p_start} AND p.created_at < ${p_end}
                 """
-                rev_params = (
-                    [*practice_params, month_start, month_end]
-                    if practice_params
-                    else [month_start, month_end]
-                )
+                rev_params = [*practice_params, month_start, month_end]
                 revenue = await conn.fetchval(revenue_query, *rev_params) or 0
 
                 results.append(

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_crm_analytics_param_index.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_crm_analytics_param_index.py
@@ -1,0 +1,95 @@
+"""
+Test: analytics endpoints with an OPTIONAL assigned-filter must derive their
+date-param placeholder indices from len(params), never hardcode $2/$3.
+
+The bug (found live in prod 2026-07-08): get_revenue_summary / get_client_overview
+/ get_clients_trend built a WHERE clause with an optional `assigned_to = $1`
+filter, then referenced the date params as $2/$3. For an ADMIN (no assigned
+filter → params == []), the date params are actually $1/$2, so $3 is never
+bound and asyncpg raises IndeterminateDatatypeError ("could not determine data
+type of parameter $1") → the endpoint 503s for every admin, while a filtered
+team member (params == [email]) works. All three CRM analytics tabs were dead
+for admins.
+
+These tests are static source-analysis (same style as the sibling
+test_crm_analytics_no_n_plus_one.py): they assert the fixed functions no longer
+contain the hardcoded-index pattern (guilt) and DO derive indices from
+len(params) (innocence of the fix).
+"""
+
+import ast
+import re
+from pathlib import Path
+
+ROUTER_PATH = Path(__file__).parents[5] / "backend" / "app" / "routers" / "crm_analytics.py"
+
+# The three endpoints that had the optional-filter + hardcoded-date-index bug.
+AFFECTED_FUNCS = [
+    "get_revenue_summary",
+    "get_client_overview",
+    "get_client_trend",
+]
+
+
+def _get_function_source(func_name: str) -> str:
+    source = ROUTER_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == func_name:
+            return "\n".join(lines[node.lineno - 1 : node.end_lineno])  # type: ignore[attr-defined]
+    return ""
+
+
+def test_affected_functions_exist() -> None:
+    for fn in AFFECTED_FUNCS:
+        assert _get_function_source(fn), f"{fn} not found in crm_analytics.py"
+
+
+def test_no_hardcoded_date_placeholder_after_optional_filter() -> None:
+    """[guilt] No date comparison may hardcode $2/$3 in these functions.
+
+    The buggy shape was: `created_at >= $2 AND created_at < $3` (or `>= $2`),
+    where $2/$3 are wrong whenever the optional $1 filter is absent. After the
+    fix, date placeholders are interpolated from len(params), so no literal
+    `>= $2` / `< $3` should survive in the date-range comparisons.
+    """
+    for fn in AFFECTED_FUNCS:
+        src = _get_function_source(fn)
+        # Any created_at comparison against a *literal* $2 or $3 is the bug.
+        offenders = re.findall(r"created_at\s*[<>]=?\s*\$[23]\b", src)
+        assert not offenders, (
+            f"{fn} still hardcodes a date placeholder ({offenders}) after an "
+            "optional assigned-filter — this 503s for admins (params empty → "
+            "date param is $1, not $2). Derive the index from len(params)."
+        )
+
+
+def test_date_placeholder_index_is_derived_from_params_length() -> None:
+    """[innocence] The fix derives the index from len(params)/len(*_params).
+
+    Each affected function must compute at least one `len(...) + 1` index used
+    to build the date-range placeholder, proving the index tracks the actual
+    parameter count rather than a hardcoded position.
+    """
+    for fn in AFFECTED_FUNCS:
+        src = _get_function_source(fn)
+        assert re.search(r"len\(\w*params\)\s*\+\s*1", src), (
+            f"{fn} does not derive a date placeholder index from len(params) — "
+            "the fix must compute `${len(params)+1}` so admins (no filter) bind "
+            "$1 correctly."
+        )
+
+
+def test_month_params_no_longer_branch_on_params_truthiness() -> None:
+    """[innocence] month_params must not use the `if params else` fallback.
+
+    The old code did `[*params, start, end] if params else [start, end]`, which
+    is exactly what mismatched the SQL indices. After the fix the params list is
+    unconditional `[*params, start, end]` and the SQL index adapts instead.
+    """
+    src = _get_function_source("get_revenue_summary")
+    assert "if params else" not in src, (
+        "get_revenue_summary still branches month_params on `if params else` — "
+        "unify to `[*params, start, end]` and adapt the SQL index."
+    )

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`329 routers · 636 services · 1104 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`329 routers · 636 services · 1105 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## 503 on 3 CRM analytics tabs for every admin — found by live prod E2E

Discovered during a **live production E2E sweep** (headless Playwright, real Founder login as `zero@balizero.com`). The revenue/analytics tab rendered near-empty with a 503; two sibling analytics tabs shared the same fault.

### Root cause (from the real Fly traceback, not a guess)
```
asyncpg.exceptions.IndeterminateDatatypeError: could not determine data type of parameter $1
  at crm_analytics.py:339 get_revenue_summary → month_row = await conn.fetchrow(month_query, *month_params)
```
`get_revenue_summary`, `get_client_overview`, `get_client_trend` build a WHERE clause with an **optional** `assigned_to = $1` filter, then **hardcode** the date params as `$2`/`$3`.
- Team member (filter present): params `[email, start, end]` → `$1/$2/$3` line up → works.
- **Admin (no filter → `params == []`)**: date params are `$1/$2`, but the SQL still says `$2/$3` → `$3` never bound, `$1`'s type unknowable → **503**.

So every admin (Founder/board/owner) saw 3 dead analytics tabs, while team members did not — which is why it slipped through.

### Fix
Derive the placeholder index from `len(params)` (`${len(params)+1}`) in all **5** date-range comparisons across the 3 endpoints, and drop the `[*params, …] if params else […]` branch that caused the mismatch.

### W89 class-audit
Grepped every router for the same shape. The only other hardcoded-`$2` date queries (`admin_conversation_cleanup`, `lkpm`) have **no** optional leading filter, so they bind correctly. Class is contained to this file. The 2 analytics endpoints that already worked (`team/performance`, `processes/by-type`) have no optional-filter+extra-date-param combo.

### Verification
- All 3 corrected queries run clean against the **prod DB** (admin case, `$1/$2`).
- New static guilt/innocence test `test_crm_analytics_param_index.py`: the guilt assertion catches the **5** hardcoded `$2/$3` comparisons still on `origin/main`; passes on the fix.
- 15 crm_analytics unit tests green; import chain + AST OK.

Auto-merge armed (bug fix, no migration/guardrail). Deploys via fly-deploy.yml on merge; will re-prove live (revenue/summary → 200) post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
