### PR TITLE
fix(notifications): un-nest admin_router — /notifications tab was 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 329 routers · 636 services
+- Backend: FastAPI · 331 routers · 636 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 31 · Packages: 6

--- a/apps/backend-rag/backend/app/modules/notifications/router.py
+++ b/apps/backend-rag/backend/app/modules/notifications/router.py
@@ -568,7 +568,9 @@ if os.getenv("ENVIRONMENT", "development").lower() != "production":
 
     router.include_router(test_router)
 
-# Include admin router
-from backend.app.modules.notifications.admin_router import router as admin_router
-
-router.include_router(admin_router)
+# NOTE: admin_router (prefix="/api/admin/notifications") is intentionally NOT
+# nested here. Nesting it under this router (prefix="/api/notifications") gave
+# the double-prefixed path /api/notifications/api/admin/notifications/* — a 404
+# for the frontend, which correctly calls /api/admin/notifications/*. It is
+# mounted at the top level in router_registration.py (its own manifest entry)
+# so its absolute prefix is honored as-is.

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -402,6 +402,12 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
         tags=("module",),
     ),
     RouterEntry(
+        name="notifications_admin",
+        process_groups=_API,
+        import_path="backend.app.modules.notifications.admin_router",
+        tags=("module",),
+    ),
+    RouterEntry(
         name="cron_notifiers",
         process_groups=_API,
         import_path="backend.app.routers.cron_notifiers",

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -250,6 +250,13 @@ def include_routers(api: FastAPI) -> None:
 
     api.include_router(notifications_router)
 
+    # Notifications admin router (prefix="/api/admin/notifications"). Mounted at
+    # the top level, NOT nested under notifications_router — nesting double-
+    # prefixed it to /api/notifications/api/admin/notifications/* (404).
+    from backend.app.modules.notifications.admin_router import router as notifications_admin_router
+
+    api.include_router(notifications_admin_router)
+
     # Cron notifiers (visa expiry, unpaid invoices, stale practices)
     from backend.app.routers.cron_notifiers import router as cron_notifiers_router
 
@@ -672,6 +679,12 @@ def include_light_routers(api: FastAPI) -> None:
     from backend.app.modules.notifications.router import router as notifications_router
 
     api.include_router(notifications_router)
+
+    # Notifications admin router — top-level mount (see include_routers note):
+    # nesting it double-prefixed /api/admin/notifications/* to a 404.
+    from backend.app.modules.notifications.admin_router import router as notifications_admin_router
+
+    api.include_router(notifications_admin_router)
 
     # Cron notifiers (visa expiry, unpaid invoices, stale practices)
     from backend.app.routers.cron_notifiers import router as cron_notifiers_router

--- a/apps/backend-rag/backend/tests/setup/test_router_manifest.py
+++ b/apps/backend-rag/backend/tests/setup/test_router_manifest.py
@@ -52,6 +52,7 @@ MODULE_ROUTER_NAMES: frozenset[str] = frozenset(
         "identity",
         "knowledge",
         "notifications",
+        "notifications_admin",
     }
 )
 

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`329 routers · 636 services · 1105 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`331 routers · 636 services · 1106 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## /notifications CRM tab was 404 — admin_router double-prefixed

Found by the **live production E2E sweep** (headless Playwright, real Founder login). The `/notifications` workspace tab rendered empty; the network trace showed `GET /api/admin/notifications/dashboard → 404`.

### Root cause
`admin_router` (`prefix="/api/admin/notifications"`) was nested inside the notifications parent router (`prefix="/api/notifications"`) via `router.include_router(admin_router)`. FastAPI **concatenates** prefixes, so the routes actually mounted at `/api/notifications/api/admin/notifications/*` — while the frontend (correctly) calls `/api/admin/notifications/*`. The double-prefixed paths are even visible in the generated `schema.d.ts`.

### Fix
Mount `admin_router` at the top level instead of nesting it:
- Remove `router.include_router(admin_router)` from the parent (with an explanatory note so it isn't re-added).
- Add `api.include_router(notifications_admin_router)` in **both** `include_routers()` (monolithic) and `include_light_routers()` (main_api prod) — parity per the router-registration scar (#54/#55/#60 → #424 silent 404s).
- Add its `RouterEntry` to the manifest + register `notifications_admin` in `MODULE_ROUTER_NAMES` (it's a module router under `modules/notifications/`, not `routers/`).

### Verification
- **Both router parity gates pass** (`test_router_manifest.py` + `test_manifest_registration_parity.py`, 360 tests) — these are the exact guards that catch registration-drift 404s.
- Built the app and listed routes: the 5 admin endpoints now mount at `/api/admin/notifications/{dashboard,alerts,stats,retry,pause-client}` with **zero** double-prefixed paths.
- Import chain + AST OK on all 3 touched backend files.

Auto-merge armed (bug fix, no migration). Deploys via fly-deploy.yml on merge; will re-prove live (`/api/admin/notifications/dashboard` → 200/403, not 404) post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
