### PR TITLE
fix(crm): add missing /practices/stats/revenue-growth route (dashboard 404)

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_practices.py
+++ b/apps/backend-rag/backend/app/routers/crm_practices.py
@@ -1776,6 +1776,165 @@ async def get_practices_stats(
         raise handle_database_error(e)
 
 
+@router.get("/stats/revenue-growth")
+@cached(ttl=CACHE_TTL_STATS_SECONDS, prefix="crm_practices_revenue_growth")
+async def get_practices_revenue_growth(
+    request: Any = None,
+    db_pool: asyncpg.Pool = Depends(get_database_pool),
+    current_user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    """
+    Month-over-month revenue growth for the practices book.
+
+    Contract consumed by the frontend (crm.api.ts::getRevenueGrowth →
+    useDashboardStats). The FE runs this inside a Promise.all with practice
+    stats + expiry alerts and has NO catch, so a 404 here previously rejected
+    the whole dashboard stats block on every workspace page. The route MUST
+    exist and return the shape below.
+
+    Response shape:
+        {
+          "current_month":  {total_revenue, paid_revenue, outstanding_revenue},
+          "previous_month": {total_revenue, paid_revenue, outstanding_revenue},
+          "growth_percentage": float,   # (curr - prev) / prev * 100, 0 if prev==0
+          "monthly_breakdown": [ {month, total_revenue}, ... ]  # last 6 months
+        }
+
+    Access Control:
+    - Admin (full view): revenue across all practices.
+    - Team member: revenue only for practices assigned to them.
+
+    Performance: cached for 5 minutes (CACHE_TTL_STATS_SECONDS).
+    """
+    try:
+        # RBAC: None for admins (full view), else the user's email.
+        user_filter = get_practices_user_filter(current_user)
+
+        # Build the optional RBAC clause; placeholder indices are DERIVED from
+        # params length (PR #2142 class) so the admin path (empty params) and
+        # the team-member path (one leading param) both bind without an
+        # IndeterminateDatatypeError.
+        params: list[Any] = []
+        rbac_where = ""
+        if user_filter:
+            params.append(user_filter)
+            rbac_where = f" AND assigned_to = ${len(params)}"
+
+        # Month boundaries (UTC), computed in Python so the SQL only binds dates.
+        now = datetime.now(timezone.utc)
+        current_start = now.replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+        # First day of previous month.
+        prev_start = (current_start - timedelta(days=1)).replace(day=1)
+        next_start = (current_start + timedelta(days=32)).replace(day=1)
+        # Six-month window start (for the breakdown).
+        breakdown_start = current_start
+        for _ in range(5):
+            breakdown_start = (breakdown_start - timedelta(days=1)).replace(day=1)
+
+        revenue_select = (
+            "SUM(actual_price) AS total_revenue, "
+            "SUM(CASE WHEN payment_status = 'paid' THEN actual_price ELSE 0 END) "
+            "AS paid_revenue, "
+            "SUM(CASE WHEN payment_status IN ('unpaid', 'partial') "
+            "THEN actual_price - COALESCE(paid_amount, 0) ELSE 0 END) "
+            "AS outstanding_revenue"
+        )
+
+        async with db_pool.acquire() as conn:
+            # Current month.
+            cur_start_idx = len(params) + 1
+            cur_end_idx = len(params) + 2
+            current_row = await conn.fetchrow(
+                f"""
+                SELECT {revenue_select}
+                FROM practices
+                WHERE actual_price IS NOT NULL{rbac_where}
+                  AND created_at >= ${cur_start_idx}
+                  AND created_at < ${cur_end_idx}
+                """,
+                *params,
+                current_start,
+                next_start,
+            )
+
+            # Previous month.
+            prev_start_idx = len(params) + 1
+            prev_end_idx = len(params) + 2
+            previous_row = await conn.fetchrow(
+                f"""
+                SELECT {revenue_select}
+                FROM practices
+                WHERE actual_price IS NOT NULL{rbac_where}
+                  AND created_at >= ${prev_start_idx}
+                  AND created_at < ${prev_end_idx}
+                """,
+                *params,
+                prev_start,
+                current_start,
+            )
+
+            # Last-6-months breakdown (total revenue per month).
+            bd_start_idx = len(params) + 1
+            breakdown_rows = await conn.fetch(
+                f"""
+                SELECT
+                    date_trunc('month', created_at) AS month,
+                    SUM(actual_price) AS total_revenue
+                FROM practices
+                WHERE actual_price IS NOT NULL{rbac_where}
+                  AND created_at >= ${bd_start_idx}
+                GROUP BY date_trunc('month', created_at)
+                ORDER BY month ASC
+                """,
+                *params,
+                breakdown_start,
+            )
+
+        def _money(row: Any, key: str) -> float:
+            value = row[key] if row and row[key] is not None else 0
+            return float(value)
+
+        current_month = {
+            "total_revenue": _money(current_row, "total_revenue"),
+            "paid_revenue": _money(current_row, "paid_revenue"),
+            "outstanding_revenue": _money(current_row, "outstanding_revenue"),
+        }
+        previous_month = {
+            "total_revenue": _money(previous_row, "total_revenue"),
+            "paid_revenue": _money(previous_row, "paid_revenue"),
+            "outstanding_revenue": _money(previous_row, "outstanding_revenue"),
+        }
+
+        prev_total = previous_month["total_revenue"]
+        if prev_total > 0:
+            growth_percentage = round(
+                (current_month["total_revenue"] - prev_total) / prev_total * 100,
+                2,
+            )
+        else:
+            growth_percentage = 0.0
+
+        monthly_breakdown = [
+            {
+                "month": row["month"].date().isoformat(),
+                "total_revenue": float(row["total_revenue"] or 0),
+            }
+            for row in breakdown_rows
+        ]
+
+        return {
+            "current_month": current_month,
+            "previous_month": previous_month,
+            "growth_percentage": growth_percentage,
+            "monthly_breakdown": monthly_breakdown,
+        }
+
+    except Exception as e:
+        raise handle_database_error(e)
+
+
 @router.post("/{practice_id}/regenerate-invoice")
 async def regenerate_invoice(
     request: Request,

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_practices_revenue_growth.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_practices_revenue_growth.py
@@ -1,0 +1,99 @@
+"""
+Tests for GET /api/crm/practices/stats/revenue-growth.
+
+SCAR CONTEXT: The frontend (crm.api.ts::getRevenueGrowth, useDashboardStats)
+calls /api/crm/practices/stats/revenue-growth inside a Promise.all with NO
+catch. The backend had no such route → 404 → the whole Promise.all rejected →
+the entire dashboard stats block (Header.tsx, NotificationBell.tsx, every
+workspace page) died. This test locks the contract the FE + crm.api.test.ts
+already assert.
+
+Two axes:
+  - guilt:    the route exists and returns the FE-expected shape
+  - innocence: the SQL derives month placeholders from params length, so admin
+              (no RBAC filter) and team-member (RBAC filter) both bind cleanly
+              (no IndeterminateDatatypeError — same class as PR #2142).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROUTER_PATH = (
+    Path(__file__).resolve().parents[5]
+    / "backend"
+    / "app"
+    / "routers"
+    / "crm_practices.py"
+)
+
+
+def _route_source() -> str:
+    """The source of the revenue-growth handler, isolated."""
+    src = ROUTER_PATH.read_text(encoding="utf-8")
+    assert '"/stats/revenue-growth"' in src, (
+        "Route /stats/revenue-growth is MISSING — the FE getRevenueGrowth() "
+        "call 404s and rejects the dashboard Promise.all."
+    )
+    return src
+
+
+def _revenue_growth_func() -> ast.FunctionDef:
+    tree = ast.parse(ROUTER_PATH.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and any(
+            isinstance(d, ast.Call)
+            and any(
+                isinstance(a, ast.Constant) and a.value == "/stats/revenue-growth"
+                for a in d.args
+            )
+            for d in node.decorator_list
+        ):
+            return node
+    raise AssertionError("revenue-growth async handler not found")
+
+
+def test_route_exists() -> None:
+    """GUILT: the route is registered on the practices router."""
+    _route_source()
+
+
+def test_returns_fe_contract_keys() -> None:
+    """GUILT: the handler returns the exact keys crm.api.test.ts asserts."""
+    func = _revenue_growth_func()
+    src = ast.get_source_segment(ROUTER_PATH.read_text(encoding="utf-8"), func) or ""
+    for key in (
+        "current_month",
+        "previous_month",
+        "growth_percentage",
+        "monthly_breakdown",
+    ):
+        assert key in src, f"revenue-growth response missing FE-contract key: {key}"
+
+
+def test_no_hardcoded_date_placeholder_after_optional_filter() -> None:
+    """INNOCENCE (PR #2142 class): no `>= $2`/`< $3` hardcoded after an
+    optional RBAC filter — placeholders must be derived from params length so
+    the admin path (empty params) binds without IndeterminateDatatypeError."""
+    import re
+
+    func = _revenue_growth_func()
+    src = ast.get_source_segment(ROUTER_PATH.read_text(encoding="utf-8"), func) or ""
+    hardcoded = re.findall(r"created_at\s*[<>]=?\s*\$[23]\b", src)
+    assert not hardcoded, (
+        f"Hardcoded $2/$3 date placeholder after optional RBAC filter "
+        f"(PR #2142 regression class): {hardcoded}"
+    )
+
+
+def test_date_placeholder_index_is_derived_from_params_length() -> None:
+    """INNOCENCE: placeholder indices come from len(params), not literals."""
+    import re
+
+    func = _revenue_growth_func()
+    src = ast.get_source_segment(ROUTER_PATH.read_text(encoding="utf-8"), func) or ""
+    assert re.search(r"len\(\w*params\)\s*\+\s*1", src), (
+        "Expected a params-derived placeholder index (len(params) + 1) so the "
+        "admin (no-filter) and team-member (filter) paths both bind cleanly."
+    )

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`329 routers · 636 services · 1104 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`329 routers · 636 services · 1105 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

Adds the missing backend route `GET /api/crm/practices/stats/revenue-growth`.

## Why (found via live prod E2E)

The frontend `crm.api.ts::getRevenueGrowth()` (consumed by `useDashboardStats`) calls this endpoint inside a `Promise.all` **with no `.catch`**, alongside practice stats + expiry alerts. The backend had no such route → **404 → the whole `Promise.all` rejected → the entire dashboard stats block died** on every workspace page (`Header.tsx`, `NotificationBell.tsx`).

Discovered with real Founder credentials sweeping the live CRM tabs; `crm.api.test.ts` and `schema` already assumed the endpoint exists.

## The fix

New route on the existing `crm_practices` router returning the exact shape the FE test asserts:
```
{ current_month:{total,paid,outstanding}, previous_month:{...}, growth_percentage, monthly_breakdown[] }
```
- **RBAC-aware**: admin = full view; team member = own assigned practices only.
- **Params-derived placeholder indices** (`len(params)+1`), not hardcoded `$2/$3` — same discipline as #2142, so both the admin (empty-params) and team-member paths bind without `IndeterminateDatatypeError`.
- Verified by compiled regex that the 2-segment path is **not** shadowed by `/{practice_id}`.
- DOCSYNC test count 1104→1105 folded into the same commit (W86).

## Tests
- `test_practices_revenue_growth.py`: guilt (route exists + FE-contract keys) + innocence (no hardcoded `$2/$3`).
- 109 practices tests green locally.

Bug fix, no migration, no new router registration → auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)