### PR TITLE
fix(portal): exclude soft-deleted clients from impersonation search (500 + data leak)

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal_admin.py
+++ b/apps/backend-rag/backend/app/routers/portal_admin.py
@@ -50,8 +50,9 @@ async def search_clients(
                 """
                 SELECT id, email, full_name
                 FROM clients
-                WHERE LOWER(full_name) LIKE '%' || LOWER($1) || '%'
-                   OR LOWER(email) LIKE '%' || LOWER($1) || '%'
+                WHERE deleted_at IS NULL
+                  AND (LOWER(full_name) LIKE '%' || LOWER($1) || '%'
+                       OR LOWER(email) LIKE '%' || LOWER($1) || '%')
                 ORDER BY
                     CASE WHEN LOWER(full_name) LIKE LOWER($1) || '%' THEN 0 ELSE 1 END,
                     full_name
@@ -65,7 +66,8 @@ async def search_clients(
                 """
                 SELECT id, email, full_name
                 FROM clients
-                WHERE full_name IS NOT NULL
+                WHERE deleted_at IS NULL
+                  AND full_name IS NOT NULL
                 ORDER BY updated_at DESC NULLS LAST
                 LIMIT $1
                 """,

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_portal_admin_search_deleted.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_portal_admin_search_deleted.py
@@ -1,0 +1,78 @@
+"""
+Tests for portal_admin.search_clients — soft-deleted client exclusion.
+
+SCAR CONTEXT (found via live prod E2E sweep, 2026-07-08):
+The superuser impersonation picker (/api/portal/admin/clients/search) did NOT
+filter `deleted_at IS NULL`. The DB holds 10,221 soft-deleted clients vs 1,683
+live; with `ORDER BY updated_at DESC` the recently-deleted ones sorted to the
+TOP of the picker. An admin selecting a soft-deleted client then hit:
+  - 500 on /portal/visa and /portal/company — the dashboard mixin filters
+    `deleted_at IS NULL`, raises "Client N not found", and the router swallows
+    the ValueError into a generic 500.
+  - a DATA LEAK on /portal/dashboard/summary, /matters, /taxes — those do NOT
+    filter deleted_at, so they return the soft-deleted client's data.
+
+Fixing the SOURCE (the search query) removes both symptoms: the admin never
+sees a deleted client to impersonate.
+
+Static source-analysis test (no DB fixture needed): both SQL branches of
+search_clients MUST constrain `deleted_at IS NULL`.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROUTER_PATH = (
+    Path(__file__).resolve().parents[5]
+    / "backend"
+    / "app"
+    / "routers"
+    / "portal_admin.py"
+)
+
+
+def _search_func_source() -> str:
+    tree = ast.parse(ROUTER_PATH.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "search_clients":
+            src = ast.get_source_segment(
+                ROUTER_PATH.read_text(encoding="utf-8"), node
+            )
+            assert src, "could not extract search_clients source"
+            return src
+    raise AssertionError("search_clients handler not found")
+
+
+def test_both_sql_branches_exclude_soft_deleted() -> None:
+    """GUILT: every `FROM clients` SELECT in the picker filters deleted_at.
+
+    The handler has two query branches (with query_text / without). BOTH must
+    exclude soft-deleted clients, else the picker leaks 10k+ deleted clients.
+    """
+    src = _search_func_source()
+    # Count the SELECT ... FROM clients occurrences (the two branches).
+    from_clients = src.count("FROM\n                clients") + src.count(
+        "FROM clients"
+    )
+    assert from_clients >= 2, (
+        f"Expected 2 `FROM clients` query branches, found {from_clients} — "
+        "test anchor drifted; re-check search_clients."
+    )
+    # Every branch must constrain deleted_at IS NULL.
+    deleted_guards = src.count("deleted_at IS NULL")
+    assert deleted_guards >= 2, (
+        f"search_clients has {deleted_guards} `deleted_at IS NULL` guards but "
+        f"{from_clients} `FROM clients` branches — a branch leaks soft-deleted "
+        "clients into the impersonation picker (live prod: 10,221 deleted)."
+    )
+
+
+def test_still_returns_live_clients_shape() -> None:
+    """INNOCENCE: the fix doesn't gut the query — it still SELECTs the three
+    picker fields and orders results (i.e. we constrained, not replaced)."""
+    src = _search_func_source()
+    assert "id, email, full_name" in src, "picker must still return id/email/full_name"
+    assert "ORDER BY" in src, "picker must still order results"
+    assert "LIMIT" in src, "picker must still limit results"

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`329 routers · 636 services · 1104 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`329 routers · 636 services · 1105 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What
Adds `deleted_at IS NULL` to both query branches of `portal_admin.search_clients` — the superuser impersonation picker.

## Why (found via live prod E2E)
The picker did **not** filter soft-deleted clients. Live DB: **10,221 soft-deleted vs 1,683 live**; `ORDER BY updated_at DESC` sorted recently-deleted clients to the **top**, so an admin's first results were deleted clients.

Selecting a soft-deleted client produced two downstream symptoms:
- **500** on `/api/portal/visa` and `/api/portal/company` — the dashboard mixin *does* filter `deleted_at IS NULL`, raises `Client N not found`, and the router swallows it into a generic 500 (Fly traceback confirmed).
- **Data leak** on `/portal/dashboard/summary`, `/matters`, `/taxes` — those do *not* filter deleted_at, returning the soft-deleted client's data.

Fixing the **source** removes both at once — the admin never sees a deleted client to impersonate.

## Test
- guilt: both `FROM clients` branches carry a `deleted_at IS NULL` guard — verified to **FAIL on origin/main** (0 guards).
- innocence: still selects `id/email/full_name`, still `ORDER BY` + `LIMIT`.
- Endpoint was previously untested.

DOCSYNC 1104→1105 folded in (W86). Bug fix, no migration → auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)