### PR TITLE
fix(mata-garuda): retry-with-backoff on redis-cli timeout in base_worker.redis_cmd

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/base_worker.py
+++ b/apps/mata-garuda/mata_garuda/workers/base_worker.py
@@ -29,6 +29,7 @@ import logging
 import os
 import shutil
 import subprocess
+import time
 
 logger = logging.getLogger("mata_garuda.workers")
 
@@ -102,20 +103,37 @@ def _redis_env() -> dict[str, str] | None:
     return env
 
 
-def redis_cmd(*args: str, timeout: int = 10) -> str:
-    """Execute a redis-cli command and return output."""
+def redis_cmd(*args: str, timeout: int = 10, retries: int = 2) -> str:
+    """Execute a redis-cli command and return output.
+
+    Retries on TimeoutExpired only (transient host-load scheduling delay,
+    not a real network/redis fault — 2026-07-08 intel-bridge investigation
+    found 100% publish failures correlating with Mini load average 25-38,
+    all timing out at the default 10s with zero retry). A short fixed
+    backoff between attempts lets a scheduling spike clear rather than
+    hammering an already-loaded host immediately. retries=2 means up to
+    3 total attempts; set retries=0 to preserve the old single-shot
+    behavior for any caller that wants a strict fail-fast.
+    """
     cmd = [REDIS_CLI] + _redis_host_args() + list(args)
-    try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout, env=_redis_env()
-        )
-        if result.returncode != 0:
-            return f"[ERROR] redis-cli: {result.stderr.strip()}"
-        return result.stdout.strip()
-    except FileNotFoundError:
-        return "[ERROR] redis-cli not found"
-    except subprocess.TimeoutExpired:
-        return f"[ERROR] redis-cli timeout after {timeout}s"
+    attempts = retries + 1
+    last_timeout = timeout
+    for attempt in range(attempts):
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, env=_redis_env()
+            )
+            if result.returncode != 0:
+                return f"[ERROR] redis-cli: {result.stderr.strip()}"
+            return result.stdout.strip()
+        except FileNotFoundError:
+            return "[ERROR] redis-cli not found"
+        except subprocess.TimeoutExpired:
+            last_timeout = timeout
+            if attempt < attempts - 1:
+                time.sleep(1.5 * (attempt + 1))
+                continue
+    return f"[ERROR] redis-cli timeout after {last_timeout}s ({attempts} attempts)"
 
 
 def stream_read_new(

--- a/apps/mata-garuda/tests/test_base_worker_redis_cmd_retry.py
+++ b/apps/mata-garuda/tests/test_base_worker_redis_cmd_retry.py
@@ -1,0 +1,88 @@
+"""
+Tests for base_worker.redis_cmd retry-on-timeout behavior (2026-07-08).
+
+Context: intel-bridge was observed at 292/292 (100%) publish failures on
+Mini, all failing with "redis-cli timeout after 10s" while Mini's load
+average was 25-38 (vs a 1.3-1.7 baseline) — a single-shot 10s timeout with
+zero retry turns a transient host-scheduling spike into a hard failure.
+redis_cmd() now retries TimeoutExpired (not other errors) with a short
+fixed backoff between attempts, controlled by a new `retries` kwarg that
+defaults to 2 (3 total attempts) and is fully backward compatible (every
+existing caller passes only positional *args + `timeout=` keyword).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from mata_garuda.workers import base_worker
+
+
+def _completed(stdout: str = "OK", returncode: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+@patch("mata_garuda.workers.base_worker.time.sleep", return_value=None)
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_redis_cmd_succeeds_first_try_no_retry_needed(mock_run, mock_sleep):
+    mock_run.return_value = _completed("PONG")
+    out = base_worker.redis_cmd("PING")
+    assert out == "PONG"
+    assert mock_run.call_count == 1
+    assert mock_sleep.call_count == 0
+
+
+@patch("mata_garuda.workers.base_worker.time.sleep", return_value=None)
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_redis_cmd_retries_on_timeout_then_succeeds(mock_run, mock_sleep):
+    mock_run.side_effect = [
+        subprocess.TimeoutExpired(cmd="redis-cli", timeout=10),
+        _completed("OK"),
+    ]
+    out = base_worker.redis_cmd("XADD", "stream", "*", "field", "value")
+    assert out == "OK"
+    assert mock_run.call_count == 2
+    assert mock_sleep.call_count == 1
+
+
+@patch("mata_garuda.workers.base_worker.time.sleep", return_value=None)
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_redis_cmd_exhausts_retries_and_reports_attempts(mock_run, mock_sleep):
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="redis-cli", timeout=10)
+    out = base_worker.redis_cmd("XADD", "stream", "*", "field", "value")
+    assert out == "[ERROR] redis-cli timeout after 10s (3 attempts)"
+    assert mock_run.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+@patch("mata_garuda.workers.base_worker.time.sleep", return_value=None)
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_redis_cmd_retries_zero_preserves_single_shot_behavior(mock_run, mock_sleep):
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="redis-cli", timeout=5)
+    out = base_worker.redis_cmd("PING", timeout=5, retries=0)
+    assert out == "[ERROR] redis-cli timeout after 5s (1 attempts)"
+    assert mock_run.call_count == 1
+    assert mock_sleep.call_count == 0
+
+
+@patch("mata_garuda.workers.base_worker.time.sleep", return_value=None)
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_redis_cmd_does_not_retry_non_timeout_errors(mock_run, mock_sleep):
+    mock_run.return_value = _completed(returncode=1)
+    mock_run.return_value.stderr = "WRONGTYPE Operation against a key"
+    out = base_worker.redis_cmd("XADD", "stream", "*")
+    assert out == "[ERROR] redis-cli: WRONGTYPE Operation against a key"
+    assert mock_run.call_count == 1
+    assert mock_sleep.call_count == 0
+
+
+@patch("mata_garuda.workers.base_worker.subprocess.run", side_effect=FileNotFoundError())
+def test_redis_cmd_file_not_found_no_retry(mock_run):
+    out = base_worker.redis_cmd("PING")
+    assert out == "[ERROR] redis-cli not found"
+    assert mock_run.call_count == 1


### PR DESCRIPTION
## Summary
- intel-bridge was observed at 292/292 (100%) publish failures on Mini, all failing with `redis-cli timeout after 10s`, correlating with an extreme Mini load average (25-38 vs a 1.3-1.7 baseline).
- `base_worker.redis_cmd` was single-shot with no retry — a transient host-scheduling spike (not a real network/redis fault) turns into a hard failure for every caller (publish, XADD, XACK, task queue ops, health checks — 8+ modules).
- `redis_cmd()` now retries only on `subprocess.TimeoutExpired` with a short fixed backoff (1.5s × attempt) between tries. New `retries` kwarg defaults to 2 (3 total attempts), fully backward compatible — verified every existing caller passes only positional `*args` + a `timeout=` keyword.

## Test plan
- [x] 6 new tests in `test_base_worker_redis_cmd_retry.py`: first-try success, retry-then-succeed, retries exhausted, `retries=0` preserves old single-shot behavior, non-timeout errors never retried, `FileNotFoundError` never retried.
- [x] Full suite: 1023 passed, 26 skipped, 15 failed — confirmed all 15 pre-exist on main (`cell_core` missing module + one live-network test), zero regressions from this change.
- [ ] Operator/next-tick: watch intel-bridge's next scheduled run on Mini for improved success rate as a live confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)