### PR TITLE
fix(portal): map client-not-found to 404 across all portal endpoints (W89 class-fix)

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -339,6 +339,12 @@ async def get_visa_status(
             "success": True,
             "data": data,
         }
+    except ValueError as e:
+        # Client row is gone / soft-deleted (portal_service filters
+        # `... WHERE id = $1 AND deleted_at IS NULL`) → not-found, not a 500.
+        # Consistent with get_dashboard above (BUG C).
+        logger.warning(f"Visa client not found for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to get visa status for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -371,6 +377,10 @@ async def get_companies(
             "success": True,
             "data": companies,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone → not-found, not a 500 (see get_dashboard).
+        logger.warning(f"Companies client not found for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to get companies for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -489,6 +499,12 @@ async def get_tax_overview(
             "success": True,
             "data": data,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in get_tax_overview for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to get tax overview for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -524,6 +540,12 @@ async def get_documents(
             "success": True,
             "data": documents,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in get_documents for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to get documents for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -591,6 +613,12 @@ async def upload_document(
             "message": "Document uploaded successfully",
             "data": document,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone -> not-found, not a 500 (see get_dashboard).
+        logger.warning(
+            f"Client not found in upload_document for client {client['client_id']}: {e}"
+        )
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to upload document for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -664,6 +692,12 @@ async def delete_document(
         }
     except HTTPException:
         raise
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in delete_document for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(
             f"Failed to delete document {document_id} for client {client['client_id']}: {e}"
@@ -696,6 +730,12 @@ async def restore_document(
         }
     except HTTPException:
         raise
+    except ValueError as e:
+        # Client soft-deleted / gone -> not-found, not a 500 (see get_dashboard).
+        logger.warning(
+            f"Client not found in restore_document for client {client['client_id']}: {e}"
+        )
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(
             f"Failed to restore document {document_id} for client {client['client_id']}: {e}"
@@ -732,6 +772,12 @@ async def get_messages(
             "success": True,
             "data": data,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in get_messages for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to get messages for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -762,6 +808,12 @@ async def send_message(
             "message": "Message sent",
             "data": message,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in send_message for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to send message for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -789,6 +841,12 @@ async def mark_message_read(
             "success": True,
             "message": "Message marked as read",
         }
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in mark_message_read for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error("Failed to mark message %s as read: %s", message_id, e)
         raise HTTPException(
@@ -819,6 +877,12 @@ async def get_preferences(
             "success": True,
             "data": preferences,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in get_preferences for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to get preferences for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -855,6 +919,12 @@ async def update_preferences(
             "message": "Settings updated",
             "data": preferences,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in update_preferences for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to update preferences for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -893,6 +963,12 @@ async def get_timeline(
             "success": True,
             "data": data,
         }
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in get_timeline for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to get timeline for client {client['client_id']}: {e}")
         raise HTTPException(
@@ -1084,6 +1160,12 @@ async def update_profile(
         if fields:
             await invalidate_cache("zantara:crm_clients_stats:*")
         return {"success": True, "data": result}
+    except ValueError as e:
+        # Client soft-deleted / gone (portal_service filters
+        # `deleted_at IS NULL`) -> not-found, not a 500. Consistent
+        # with get_dashboard (BUG C).
+        logger.warning(f"Client not found in update_profile for client {client['client_id']}: {e}")
+        raise HTTPException(status_code=404, detail="Client not found") from e
     except Exception as e:
         logger.error(f"Failed to update profile for client {client['client_id']}: {e}")
         raise HTTPException(

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_portal_notfound_404.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_portal_notfound_404.py
@@ -1,0 +1,106 @@
+"""
+Tests for portal.py not-found → 404 consistency (W89 class-fix).
+
+SCAR CONTEXT (found via live prod E2E, 2026-07-08):
+Portal endpoints resolve a client via portal_service methods that filter
+`... WHERE id = $1 AND deleted_at IS NULL` and raise
+`ValueError("Client N not found")` for a soft-deleted / missing client.
+`get_dashboard` correctly caught that ValueError and returned 404, but the
+sibling endpoints (get_visa_status, get_companies, get_tax_overview, ...)
+only had a bare `except Exception → 500`, so a not-found client surfaced as
+an opaque 500 (confirmed live on /api/portal/visa & /api/portal/company).
+
+W89 class-fix: EVERY portal endpoint that resolves a client and catches
+Exception must FIRST catch ValueError → 404. This test enforces the whole
+class, so the next endpoint added can't silently reintroduce the 500.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+ROUTER_PATH = (
+    Path(__file__).resolve().parents[5]
+    / "backend"
+    / "app"
+    / "routers"
+    / "portal.py"
+)
+
+
+def _source_lines() -> list[str]:
+    return ROUTER_PATH.read_text(encoding="utf-8").split("\n")
+
+
+def _endpoints_resolving_client_with_500() -> list[tuple[str, int, bool]]:
+    """For each `except Exception → 500` that follows a portal_service call on
+    a client, return (fn_name, lineno, has_value_error_404_sibling)."""
+    src = _source_lines()
+    results: list[tuple[str, int, bool]] = []
+    for i, line in enumerate(src):
+        if "except Exception as e:" not in line:
+            continue
+        block = "\n".join(src[i : i + 7])
+        if "status_code=500" not in block:
+            continue
+        # enclosing function
+        fn = "?"
+        for j in range(i, max(0, i - 70), -1):
+            m = re.match(r"\s*async def (\w+)", src[j])
+            if m:
+                fn = m.group(1)
+                break
+        trybody = "\n".join(src[max(0, i - 18) : i])
+        resolves_client = "portal_service." in trybody and "client[" in trybody
+        if not resolves_client:
+            continue
+        back = "\n".join(src[max(0, i - 10) : i])
+        # The invariant is "a ValueError from client resolution is HANDLED as a
+        # 4xx, never a raw 500". Most endpoints map it to 404 (client not
+        # found); a few legitimately map it to 400 (bad-input validation, e.g.
+        # set_primary_company). Either counts as handled.
+        handled = "except ValueError" in back and (
+            "status_code=404" in back or "status_code=400" in back
+        )
+        results.append((fn, i + 1, handled))
+    return results
+
+
+def test_every_client_resolving_endpoint_handles_value_error_not_500() -> None:
+    """GUILT+class: no portal endpoint that resolves a client may fall through
+    to a raw 500 on a ValueError — each must catch ValueError as a 4xx
+    (404 not-found, or 400 bad-input) before `except Exception → 500`.
+    """
+    offenders = [
+        f"{fn} (L{ln})"
+        for fn, ln, handled in _endpoints_resolving_client_with_500()
+        if not handled
+    ]
+    assert not offenders, (
+        "These portal endpoints resolve a client but 500 on a ValueError "
+        "(e.g. a soft-deleted client) instead of a 4xx — add "
+        "`except ValueError → 404` before `except Exception → 500` "
+        "(see get_dashboard):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_module_still_imports_and_parses() -> None:
+    """INNOCENCE: the 11 inserted handlers didn't break the module."""
+    tree = ast.parse(ROUTER_PATH.read_text(encoding="utf-8"))
+    fns = {n.name for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)}
+    # A representative set of the endpoints we hardened must still exist.
+    for fn in ("get_dashboard", "get_visa_status", "get_companies", "get_tax_overview"):
+        assert fn in fns, f"expected endpoint {fn} vanished after the edit"
+
+
+def test_404_handler_reraises_only_value_error_not_generic() -> None:
+    """INNOCENCE: the inserted 404 blocks catch ValueError specifically (not a
+    bare Exception), so genuine internal errors still surface as 500."""
+    src = ROUTER_PATH.read_text(encoding="utf-8")
+    # Every inserted 404 block is guarded by `except ValueError as e:` — there
+    # must be no `except Exception ... status_code=404` (that would 404 real
+    # server errors).
+    bad = re.findall(r"except Exception as e:[^\n]*\n(?:[^\n]*\n){0,4}?[^\n]*status_code=404", src)
+    assert not bad, "A generic Exception handler returns 404 — it would mask real 500s"

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`331 routers · 636 services · 1107 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`331 routers · 636 services · 1108 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What
Every portal endpoint that resolves a client now catches `ValueError("Client not found") → 404` before the generic `except Exception → 500`, matching the already-correct `get_dashboard`.

## Why (found via live prod E2E)
Portal endpoints resolve a client via `portal_service` methods that filter `... WHERE id = $1 AND deleted_at IS NULL` and raise `ValueError` for a soft-deleted / missing client. `get_dashboard` handled it (→404); **11 siblings only had `except Exception → 500`**, so a not-found client surfaced as an opaque 500 — confirmed live: `/api/portal/visa` and `/api/portal/company` both 500'd with `Client 3604 not found` when impersonating a soft-deleted client.

## Scope
Pure additions (**82 insertions, 0 deletions** in portal.py) — no existing logic changed. Endpoints hardened: `get_visa_status`, `get_companies`, `get_tax_overview`, `get_documents`, `delete_document`, `restore_document`, `upload_document`, `get_messages`, `send_message`, `mark_message_read`, `get_preferences`, `update_preferences`, `get_timeline`, `update_profile`. `set_primary_company` intentionally keeps `ValueError → 400` (bad-input validation, not not-found).

## Relationship to #2145
Defense-in-depth: #2145 stops admins impersonating soft-deleted clients (the trigger); this hardens the response regardless of how a not-found client is reached.

## Test
A **class-guard**: scans every `except Exception → 500` following a client-resolving `portal_service` call and fails if it lacks a `ValueError → 4xx` sibling — so a new endpoint can't silently reintroduce the 500. Plus innocence (no generic `Exception → 404` that would mask real 500s). DOCSYNC folded in (W86).

Bug fix, no migration → auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)