### PR TITLE
docs(sync): refresh onboarding test count

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`331 routers · 636 services · 1106 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`331 routers · 636 services · 1107 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- regenerate docs/AI_ONBOARDING.md after the admin RBAC E2E receptor increased the backend test count
- keep Docs Sync Check green after the notifications router merge

## Verification
- apps/backend-rag/.venv/bin/python scripts/docs_sync.py --check
- apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_docs_sync_atlas.py -q