### PR TITLE
fix(infra): launchagent_reconcile.py consults home-fork allow-list before flagging

### DIFF
--- a/scripts/launchagent_reconcile.py
+++ b/scripts/launchagent_reconcile.py
@@ -22,6 +22,10 @@ Categories (multi-tag — one file can appear in several):
                       env-specific keys (EnvironmentVariables, *Path, WorkingDirectory).
   home-fork-target    live plist whose payload lives under $HOME outside the repo /
                       deploy clone and is not a symlink into them (superscar #1).
+                      Targets declared or allow-listed in
+                      infra/home-fork/declared-pairs.json are excluded — that file
+                      is the SSOT for "known, not a fork" (lint_home_fork.py already
+                      enforces it; this tool must not re-report what it resolved).
 
 What this tool does NOT do:
   - runtime health (exit codes × log content) → scripts/launchd_liveness_detector.py (W84)
@@ -53,6 +57,7 @@ from __future__ import annotations
 
 import argparse
 import filecmp
+import fnmatch
 import json
 import os
 import plistlib
@@ -131,6 +136,54 @@ def _is_runtime(path: Path) -> bool:
     return path.parent.name == "bin" and any(
         path.name.startswith(i) for i in (*INTERPRETERS, "uvicorn", "gunicorn")
     )
+
+
+def _load_home_fork_config(repo_dir: Path) -> tuple[set[str], list[str]]:
+    """Best-effort load of infra/home-fork/declared-pairs.json's declared live
+    paths + allow patterns. Read-only import; any failure degrades to empty —
+    that JSON stays the SSOT enforced by lint_home_fork.py, this is only a
+    courtesy de-dupe so this tool does not re-flag what that tool already
+    resolved (superscar #3 lesson: a guard that ignores ground-truth cries
+    wolf on known-benign targets)."""
+    config_path = repo_dir / "infra" / "home-fork" / "declared-pairs.json"
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set(), []
+    declared_lives = {p["live"] for p in data.get("pairs", []) if "live" in p}
+    allow = [str(a) for a in data.get("allow", [])]
+    return declared_lives, allow
+
+
+def _normalize_home_path(path: Path, home: Path) -> Optional[str]:
+    try:
+        return "~/" + str(path.relative_to(home))
+    except ValueError:
+        return None
+
+
+def _expand_home_token(token: str, home: Path) -> Path:
+    if token == "~":
+        return home
+    if token.startswith("~/"):
+        return home / token[2:]
+    return Path(token)
+
+
+def _is_declared_or_allowed(
+    path: Path, home: Path, declared_lives: set[str], allow: list[str]
+) -> bool:
+    norm = _normalize_home_path(path, home)
+    if norm is None:
+        return False
+    if norm in declared_lives:
+        return True
+    expanded = str(path)
+    for pattern in allow:
+        pat_expanded = str(_expand_home_token(pattern, home))
+        if fnmatch.fnmatch(norm, pattern) or fnmatch.fnmatch(expanded, pat_expanded):
+            return True
+    return False
 
 _NAME_STAMP_RE = re.compile(r"(20\d{6})")
 
@@ -300,6 +353,7 @@ def reconcile(
     # because launchd can lose its TCC grant there). The disease is DRIFT,
     # not location.
     canon_index = _build_canon_index(repo_dir)
+    declared_lives, home_fork_allow = _load_home_fork_config(repo_dir)
 
     def _repo_canon_for(target: Path) -> Optional[Path]:
         candidates = canon_index.get(target.name)
@@ -381,6 +435,15 @@ def reconcile(
             if canon is not None and filecmp.cmp(str(canon), str(rp), shallow=False):
                 canon_paired.append({"label": label, "file": f.name, "target": t,
                                      "canon": str(canon.relative_to(repo_root))})
+            elif canon is None and _is_declared_or_allowed(
+                rp, home, declared_lives, home_fork_allow
+            ):
+                # No repo canon AND declared/allow-listed in declared-pairs.json:
+                # a known-benign HOME-only target (TCC bridge, vendor binary,
+                # separate-repo tool) — not a fork to (re-)report. A DIVERGED
+                # canon (drift) is never suppressed by this branch — that is
+                # the disease this whole tool exists to catch (superscar #1).
+                pass
             else:
                 detail = (
                     f"DIVERGED from canon {canon.relative_to(repo_root)}" if canon is not None

--- a/scripts/tests/test_launchagent_reconcile.py
+++ b/scripts/tests/test_launchagent_reconcile.py
@@ -9,6 +9,7 @@ No launchctl, no Telegram, no real LaunchAgents dir — everything injected.
 from __future__ import annotations
 
 import importlib.util
+import json
 import plistlib
 import sys
 from datetime import datetime, timedelta, timezone
@@ -137,6 +138,110 @@ def test_home_fork_target_flagged(world):
     )
     r = run_reconcile(world, loaded=None)
     assert [h["label"] for h in r["home_fork_target"]] == ["com.balizero.fork"]
+
+
+def test_home_fork_target_allow_listed_not_a_fork(world):
+    """A target matching infra/home-fork/declared-pairs.json's 'allow' patterns
+    is a known-benign non-fork (e.g. a TCC bridge with no repo canon by
+    design, live 2026-07-08: ~/scripts/mini-git-pull-bridge.sh) — must NOT
+    re-appear in home_fork_target. Superscar #3 lesson: a guard that ignores
+    the ground-truth allow-list cries wolf on a case another tool resolved."""
+    payload = world["home"] / "scripts" / "mini-git-pull-bridge.sh"
+    payload.parent.mkdir(parents=True)
+    payload.write_text("#!/bin/sh\n")
+    hf_dir = world["repo"] / "infra" / "home-fork"
+    hf_dir.mkdir(parents=True)
+    (hf_dir / "declared-pairs.json").write_text(
+        json.dumps({"pairs": [], "allow": ["~/scripts/mini-git-pull-bridge.sh"]})
+    )
+    write_plist(
+        world["agents"] / "com.nuzantara.bridge.plist",
+        "com.nuzantara.bridge",
+        program_args=[str(payload)],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert r["home_fork_target"] == []
+    assert r["canon_paired"] == []
+
+
+def test_home_fork_target_declared_pair_live_not_a_fork(world):
+    """A target whose ~-path exactly matches a declared pair's 'live' field
+    is tracked by lint_home_fork.py's --check sha256 flow already — not a
+    second fork finding here."""
+    payload = world["home"] / "scripts" / "mini-git-pull.sh"
+    payload.parent.mkdir(parents=True)
+    payload.write_text("#!/bin/sh\n")
+    hf_dir = world["repo"] / "infra" / "home-fork"
+    hf_dir.mkdir(parents=True)
+    (hf_dir / "declared-pairs.json").write_text(json.dumps({
+        "pairs": [{
+            "live": "~/scripts/mini-git-pull.sh",
+            "repo": "scripts/mini/mini-git-pull.sh",
+            "machines": ["mini"],
+        }],
+        "allow": [],
+    }))
+    write_plist(
+        world["agents"] / "com.nuzantara.gitpull.plist",
+        "com.nuzantara.gitpull",
+        program_args=[str(payload)],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert r["home_fork_target"] == []
+
+
+def test_declared_pair_with_matching_canon_still_reaches_canon_paired(world):
+    """Regression guard: a live path declared in 'pairs' that ALSO has a
+    byte-identical repo canon (the common case — most declared pairs are
+    exactly this) must land in canon_paired, not be silently dropped before
+    the canon check ever runs. A first draft of this fix suppressed on
+    declared_lives membership alone and ate 12 of 13 real canon_paired
+    findings on the live Mini report — this is that bug, pinned."""
+    canon = world["repo"] / "infra" / "launchagents" / "wrappers" / "mlx-server-run.sh"
+    canon.parent.mkdir(parents=True, exist_ok=True)
+    canon.write_text("#!/bin/sh\necho same\n")
+    live = world["home"] / "scripts" / "mlx-server-run.sh"
+    live.parent.mkdir(parents=True, exist_ok=True)
+    live.write_text("#!/bin/sh\necho same\n")
+    hf_dir = world["repo"] / "infra" / "home-fork"
+    hf_dir.mkdir(parents=True)
+    (hf_dir / "declared-pairs.json").write_text(json.dumps({
+        "pairs": [{
+            "live": "~/scripts/mlx-server-run.sh",
+            "repo": "infra/launchagents/wrappers/mlx-server-run.sh",
+            "machines": ["all"],
+        }],
+        "allow": [],
+    }))
+    write_plist(
+        world["agents"] / "com.balizero.mlx-server.plist",
+        "com.balizero.mlx-server",
+        program_args=[str(live)],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert r["home_fork_target"] == []
+    assert [c["label"] for c in r["canon_paired"]] == ["com.balizero.mlx-server"]
+
+
+def test_home_fork_target_not_allow_listed_still_flagged(world):
+    """Guilt case: an allow-list existing elsewhere in the repo must not
+    blanket-suppress everything — only entries that actually match stay
+    unflagged; a genuinely undeclared payload is still caught."""
+    payload = world["home"] / "scripts" / "genuinely-undeclared.sh"
+    payload.parent.mkdir(parents=True)
+    payload.write_text("#!/bin/sh\n")
+    hf_dir = world["repo"] / "infra" / "home-fork"
+    hf_dir.mkdir(parents=True)
+    (hf_dir / "declared-pairs.json").write_text(
+        json.dumps({"pairs": [], "allow": ["~/scripts/mini-git-pull-bridge.sh"]})
+    )
+    write_plist(
+        world["agents"] / "com.nuzantara.undeclared.plist",
+        "com.nuzantara.undeclared",
+        program_args=[str(payload)],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert [h["label"] for h in r["home_fork_target"]] == ["com.nuzantara.undeclared"]
 
 
 def test_interpreter_payload_under_home_flagged(world):


### PR DESCRIPTION
## Summary
- `scripts/launchagent_reconcile.py`'s HOME-fork detector never consulted `infra/home-fork/declared-pairs.json`'s allow-list, the SSOT `lint_home_fork.py --discover` already enforces — it re-flagged 4 already-resolved targets (WR2Control.app, zero-design/run.sh, GoogleUpdater.wake, `mini-git-pull-bridge.sh`) as HOME-forks, inflating the proprioception `launchagent_canon` P2 divergence from 2 real findings to 5.
- Fix: suppress a HOME-fork finding only when no repo canon is found at all AND the target is declared/allow-listed. A byte-identical or diverged canon is never suppressed — that's the tool's actual job (superscar #1).
- Self-caught regression in the same session: a first draft suppressed purely on `declared_lives` membership (the `pairs` list), which ate 12 of 13 real `canon_paired` findings (most declared pairs ARE byte-identical canon matches). Pinned with a dedicated regression test.

## Verification
- `apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_launchagent_reconcile.py -q` → 34 passed (30 pre-existing + 4 new: allow-list innocence, declared-pair innocence, guilt case, canon_paired regression pin).
- Live re-run on Mini (`python3 scripts/launchagent_reconcile.py --all --json`): `home_fork_target` 6→2 (only the 2 genuine, already-ledgered `fly-pg-tunnel` findings remain), `canon_paired` unaffected (still contains all previously-known entries).

## Test plan
- [x] Existing test suite passes (30/30 before, unaffected)
- [x] New innocence/guilt tests for allow-list + declared-pairs suppression
- [x] Regression test pins the declared-pair-with-matching-canon case
- [x] Live comparison against `lint_home_fork.py --discover` (the authoritative tool) confirms parity: 2 genuine findings in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)