### PR TITLE
docs: resync AI_ONBOARDING.md quick-numbers (test count drift)

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`331 routers · 636 services · 1106 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`331 routers · 636 services · 1107 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- proprioception's `docs_sync` probe (code<->docs, W86 family) flagged `docs/AI_ONBOARDING.md` as stale: test count in the DOCSYNC block was 1106, current repo count is 1107.
- Mechanical regen via `python3 scripts/docs_sync.py` — single-line change inside the `DOCSYNC:QUICK_NUMBERS` markers, nothing else touched.

## Verification
- `python3 scripts/docs_sync.py --check` → `DOCSYNC OK (no changes)` after the commit.

## Test plan
- [x] `docs_sync.py --check` clean post-fix (mechanical, no code path change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)