### PR TITLE
fix(mouth): harden prod runtime article and login paths

### DIFF
--- a/apps/mouth/src/app/api/auth/login/route.test.ts
+++ b/apps/mouth/src/app/api/auth/login/route.test.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const originalNuzantaraApiUrl = process.env.NUZANTARA_API_URL;
+const originalNextPublicApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+function makeLoginRequest(): NextRequest {
+  return new NextRequest("https://balizero.com/api/auth/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "ops@balizero.com", pin: "123456" }),
+  });
+}
+
+describe("POST /api/auth/login", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          message: "Login successful",
+          data: {
+            token: " token-with-newline\n",
+            csrfToken: " csrf-with-newline\n",
+            expiresIn: 3600,
+            user: { email: "ops@balizero.com" },
+          },
+        }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    if (originalNuzantaraApiUrl === undefined) {
+      delete process.env.NUZANTARA_API_URL;
+    } else {
+      process.env.NUZANTARA_API_URL = originalNuzantaraApiUrl;
+    }
+
+    if (originalNextPublicApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalNextPublicApiUrl;
+    }
+
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("trims whitespace from backend URL env values before proxying", async () => {
+    process.env.NUZANTARA_API_URL = "https://backend.example.com/api\n";
+    delete process.env.NEXT_PUBLIC_API_URL;
+
+    const { POST } = await import("./route");
+    const response = await POST(makeLoginRequest());
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://backend.example.com/api/auth/login",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/mouth/src/app/api/auth/login/route.ts
+++ b/apps/mouth/src/app/api/auth/login/route.ts
@@ -7,7 +7,7 @@ function getBackendUrl(): string {
     process.env.NEXT_PUBLIC_API_URL ||
     "https://nuzantara-rag.fly.dev";
   // Normalize: strip trailing slash and /api suffix to get base URL
-  return raw.replace(/\/+$/, "").replace(/\/api$/, "");
+  return raw.trim().replace(/\/+$/, "").replace(/\/api$/, "");
 }
 const BACKEND_URL = getBackendUrl();
 

--- a/apps/mouth/src/components/blog/MDXContentRSC.test.tsx
+++ b/apps/mouth/src/components/blog/MDXContentRSC.test.tsx
@@ -74,4 +74,22 @@ describe("renderMDXBody", () => {
     expect(html).not.toContain("calculateResult");
     expect(html).not.toContain("Functions cannot be passed");
   });
+
+  it("server-renders tax takeaway MDX that uses KeyTakeaway children", async () => {
+    const articlePath = path.join(
+      process.cwd(),
+      "src/content/articles/tax/ppn-12-percent-increase-2026.mdx",
+    );
+    const articleFile = fs.readFileSync(articlePath, "utf8");
+    const { content } = matter(articleFile);
+
+    const mdxBody = await renderMDXBody(stripImports(content));
+
+    const html = renderToString(<>{mdxBody}</>);
+
+    expect(html).toContain("Indonesia PPN/VAT Rate 2026");
+    expect(html).toContain("Key Takeaways");
+    expect(html).toContain("PPN raised to 12%");
+    expect(html).not.toContain("Cannot read properties of undefined");
+  });
 });

--- a/apps/mouth/src/components/seo/AnswerBox.test.tsx
+++ b/apps/mouth/src/components/seo/AnswerBox.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { KeyTakeaway } from "./AnswerBox";
+
+describe("KeyTakeaway", () => {
+  it("renders explicit points", () => {
+    render(<KeyTakeaway points={["First point", "Second point"]} />);
+
+    expect(screen.getByText("First point")).toBeTruthy();
+    expect(screen.getByText("Second point")).toBeTruthy();
+  });
+
+  it("renders MDX children when points are omitted", () => {
+    render(
+      <KeyTakeaway>
+        <strong>TL;DR:</strong> MDX-authored takeaway text.
+      </KeyTakeaway>,
+    );
+
+    expect(screen.getByText("TL;DR:")).toBeTruthy();
+    expect(screen.getByText(/MDX-authored takeaway text/)).toBeTruthy();
+  });
+});

--- a/apps/mouth/src/components/seo/AnswerBox.tsx
+++ b/apps/mouth/src/components/seo/AnswerBox.tsx
@@ -44,11 +44,18 @@ export function AnswerBox({ children, className = "" }: AnswerBoxProps) {
  * Use for complex topics that need structured summarization.
  */
 interface KeyTakeawayProps {
-  points: string[];
+  points?: string[];
+  children?: React.ReactNode;
   className?: string;
 }
 
-export function KeyTakeaway({ points, className = "" }: KeyTakeawayProps) {
+export function KeyTakeaway({
+  points,
+  children,
+  className = "",
+}: KeyTakeawayProps) {
+  const hasPoints = Array.isArray(points) && points.length > 0;
+
   return (
     <div
       className={`
@@ -60,14 +67,18 @@ export function KeyTakeaway({ points, className = "" }: KeyTakeawayProps) {
       <h3 className="text-sm uppercase tracking-wider text-accent-sand mb-3 font-semibold">
         Key Takeaways
       </h3>
-      <ul className="space-y-2">
-        {points.map((point, index) => (
-          <li key={index} className="flex items-start gap-3 text-silver">
-            <span className="text-accent-sand mt-1">•</span>
-            <span>{point}</span>
-          </li>
-        ))}
-      </ul>
+      {hasPoints ? (
+        <ul className="space-y-2">
+          {points.map((point, index) => (
+            <li key={index} className="flex items-start gap-3 text-silver">
+              <span className="text-accent-sand mt-1">•</span>
+              <span>{point}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="text-silver">{children}</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow  to render MDX children as well as explicit , fixing tax articles that currently throw on 
- trim auth backend URL env values before proxying login requests, preventing newline-tainted env values from generating bad upstream calls
- add focused regression coverage for the live PPN article and login proxy normalization

## Tests
- 
> nuzantara@5.2.0 test
> npm run test:ci -w apps/mouth src/components/seo/AnswerBox.test.tsx src/app/api/auth/login/route.test.ts src/components/blog/MDXContentRSC.test.tsx --run


> mouth@5.2.0 test:ci
> vitest --run --coverage src/components/seo/AnswerBox.test.tsx src/app/api/auth/login/route.test.ts src/components/blog/MDXContentRSC.test.tsx
- 
> nuzantara@5.2.0 typecheck
> npm run typecheck -w apps/mouth --pretty false


> mouth@5.2.0 typecheck
> tsc --noEmit