### PR TITLE
fix(notifications): admin gate uses canonical is_crm_admin, not phantom is_admin (W89)

### DIFF
--- a/apps/backend-rag/backend/app/modules/notifications/admin_router.py
+++ b/apps/backend-rag/backend/app/modules/notifications/admin_router.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.utils.crm_utils import is_crm_admin
 
 logger = logging.getLogger(__name__)
 
@@ -76,8 +77,16 @@ class RetryResponse(BaseModel):
 
 
 def require_admin(current_user: dict) -> None:
-    """Verify user is admin."""
-    if not current_user.get("is_admin"):
+    """Verify user is a CRM admin.
+
+    Uses the canonical `is_crm_admin` check (email in admin allowlist OR role
+    in {admin, board member, ceo, founder}) — the SAME gate the rest of the
+    CRM uses. The previous `current_user.get("is_admin")` gated on a boolean
+    the auth layer never populates (`get_current_user` emits only
+    {email, user_id, role, permissions}), so it 403'd every caller including
+    genuine Founders. Bug #6, found via live prod E2E 2026-07-08.
+    """
+    if not is_crm_admin(current_user):
         raise HTTPException(status_code=403, detail="Admin access required")
 
 

--- a/apps/backend-rag/backend/app/modules/notifications/router.py
+++ b/apps/backend-rag/backend/app/modules/notifications/router.py
@@ -20,6 +20,7 @@ from backend.app.dependencies import get_current_user, get_database_pool
 from backend.app.modules.notifications.checker import ExpiryChecker
 from backend.app.modules.notifications.models import ClientInfo
 from backend.app.modules.notifications.service import NotificationService
+from backend.app.utils.crm_utils import is_crm_admin
 from backend.app.utils.internal_api_auth import verify_internal_api_key
 
 logger = logging.getLogger(__name__)
@@ -261,8 +262,10 @@ async def send_pending_alerts(
     Send all pending alerts.
     Admin only endpoint.
     """
-    # Check admin role
-    if not current_user.get("is_admin"):
+    # Check admin role (canonical is_crm_admin — same gate as the rest of the
+    # CRM; the old `.get("is_admin")` gated on a flag the auth layer never
+    # populates, 403'ing genuine admins. Bug #6 class-fix, W89).
+    if not is_crm_admin(current_user):
         raise HTTPException(status_code=403, detail="Admin access required")
 
     try:

--- a/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_admin_router_role_check.py
+++ b/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_admin_router_role_check.py
@@ -1,0 +1,182 @@
+"""
+Tests for notifications admin_router.require_admin using the canonical
+role/email-based admin check (Bug #6, found via live prod E2E 2026-07-08).
+
+SCAR CONTEXT:
+`admin_router.require_admin` gated on `current_user.get("is_admin")` — a
+boolean field the auth layer NEVER populates. `get_current_user`
+(backend/app/deps/auth.py) returns only {email, user_id, role, permissions};
+`is_admin` is absent, so `.get("is_admin")` is always None → EVERY caller
+gets 403, including genuine Founders (zero@balizero.com). The notifications
+admin tab reached the backend (double-prefix fix #2143 mounted the route)
+but 403'd for the owner.
+
+FIX: delegate to the canonical `is_crm_admin(current_user)` used across
+crm_clients.py — email-in-admin-list OR role in {admin, board member, ceo,
+founder}. This is the SAME check the working CRM tabs use, so a real admin's
+role-based JWT reaches the notifications endpoints.
+
+This test drives require_admin directly with representative user dicts (the
+exact shape get_current_user emits), so it proves the gate by CONTENT, not by
+the phantom flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+
+def _require_admin():
+    from backend.app.modules.notifications.admin_router import require_admin
+
+    return require_admin
+
+
+def test_founder_role_admin_passes() -> None:
+    """GUILT: a genuine admin (role=founder) — the exact dict shape
+    get_current_user emits — must NOT be rejected. This is the regression:
+    the old `is_admin` flag was absent → 403 for the owner."""
+    require_admin = _require_admin()
+    founder = {
+        "email": "someone@balizero.com",
+        "user_id": "someone@balizero.com",
+        "role": "founder",
+        "permissions": [],
+    }
+    # Must not raise.
+    require_admin(founder)
+
+
+def test_admin_email_passes() -> None:
+    """GUILT: an email in the admin allowlist (zero@balizero.com) passes even
+    if its role were a plain 'user' — mirrors is_crm_admin's email branch."""
+    require_admin = _require_admin()
+    admin_by_email = {
+        "email": "zero@balizero.com",
+        "user_id": "zero@balizero.com",
+        "role": "user",
+        "permissions": [],
+    }
+    require_admin(admin_by_email)
+
+
+def test_regular_user_still_403() -> None:
+    """INNOCENCE: a non-admin team member (role=user, non-admin email) must
+    still be rejected 403 — the fix must not open the endpoint to everyone."""
+    require_admin = _require_admin()
+    regular = {
+        "email": "staffer@balizero.com",
+        "user_id": "staffer@balizero.com",
+        "role": "user",
+        "permissions": [],
+    }
+    with pytest.raises(HTTPException) as exc:
+        require_admin(regular)
+    assert exc.value.status_code == 403
+
+
+def test_client_role_403() -> None:
+    """INNOCENCE: a portal client must never reach notifications admin."""
+    require_admin = _require_admin()
+    client = {
+        "email": "client@example.com",
+        "user_id": "client@example.com",
+        "role": "client",
+        "permissions": [],
+    }
+    with pytest.raises(HTTPException) as exc:
+        require_admin(client)
+    assert exc.value.status_code == 403
+
+
+def test_does_not_gate_on_phantom_is_admin_flag() -> None:
+    """INNOCENCE (source-level): require_admin must no longer GATE on the
+    phantom `.get("is_admin")` key that the auth layer never sets — it must
+    delegate to the canonical is_crm_admin helper instead.
+
+    The check inspects the executable CODE (docstring stripped) so an
+    explanatory docstring that names the old flag doesn't false-positive.
+    """
+    import ast
+    import inspect
+
+    from backend.app.modules.notifications import admin_router
+
+    fn = ast.parse(inspect.getsource(admin_router.require_admin)).body[0]
+    # Drop the docstring so we scan only real statements.
+    body = fn.body
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(getattr(body[0], "value", None), ast.Constant)
+    ):
+        body = body[1:]
+    code = "\n".join(ast.dump(stmt) for stmt in body)
+
+    assert "is_admin" not in code, (
+        "require_admin CODE still gates on the phantom `is_admin` flag — "
+        "get_current_user never populates it, so this 403s real admins. "
+        "Delegate to is_crm_admin(current_user) instead."
+    )
+    assert "is_crm_admin" in code, (
+        "require_admin should delegate to the canonical is_crm_admin helper "
+        "(email allowlist OR role in {admin, board member, ceo, founder})."
+    )
+
+
+def test_no_notifications_route_gates_on_phantom_is_admin_flag() -> None:
+    """GUILT+class (W89): NO route in the notifications module may gate on the
+    phantom `current_user.get("is_admin")` flag — the auth layer never sets it,
+    so it 403s genuine admins. This scans the whole module (admin_router.py AND
+    router.py) so the sibling that had the same bug can't creep back in, and a
+    newly-added admin endpoint can't reintroduce it.
+    """
+    import ast
+    from pathlib import Path
+
+    module_dir = (
+        Path(__file__).resolve().parents[6]
+        / "backend"
+        / "app"
+        / "modules"
+        / "notifications"
+    )
+    assert module_dir.is_dir(), f"notifications module not found at {module_dir}"
+
+    def _phantom_gate_nodes(tree: ast.AST) -> list[ast.AST]:
+        """Find real accesses of the 'is_admin' key on a mapping — either
+        `x.get("is_admin")` or `x["is_admin"]`. AST-based, so string literals
+        (docstrings, comments, explanatory prose) are structurally excluded."""
+        hits: list[ast.AST] = []
+        for node in ast.walk(tree):
+            # x.get("is_admin")
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value == "is_admin"
+            ):
+                hits.append(node)
+            # x["is_admin"]
+            if (
+                isinstance(node, ast.Subscript)
+                and isinstance(node.slice, ast.Constant)
+                and node.slice.value == "is_admin"
+            ):
+                hits.append(node)
+        return hits
+
+    offenders: list[str] = []
+    for py in sorted(module_dir.glob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in _phantom_gate_nodes(tree):
+            offenders.append(f"{py.name}:{getattr(node, 'lineno', '?')}")
+
+    assert not offenders, (
+        "These notifications routes still access the phantom `is_admin` flag "
+        "that get_current_user never populates (403s real admins). Use "
+        "is_crm_admin(current_user) instead:\n  " + "\n  ".join(offenders)
+    )

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`331 routers · 636 services · 1107 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`331 routers · 636 services · 1108 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Bug #6 — notifications admin tab 403s genuine admins (found via live prod E2E 2026-07-08)

After #2143 mounted the notifications admin route (double-prefix fix, 404→403), live testing with the Founder token (zero@) showed **403 "Admin access required"** on `/api/admin/notifications/{dashboard,alerts,stats,retry}` and `/api/notifications/send-pending`.

### Root cause (verified by content)
Both admin gates checked `current_user.get("is_admin")` — a boolean the auth layer **never populates**. `get_current_user` (`backend/app/deps/auth.py`) emits only `{email, user_id, role, permissions}`, so `.get("is_admin")` is always `None` → **403 for every caller, including genuine Founders**. The notifications tab reached the backend but was dead for the owner.

### Fix
Both call-sites (`admin_router.require_admin` + `router.send_pending_alerts`) now delegate to the canonical **`is_crm_admin(current_user)`** used across `crm_clients.py` — email in admin allowlist OR role ∈ {admin, board member, ceo, founder}. Same gate the working CRM tabs use.

### W89 class-fix
`grep` found **both** sibling gates in the notifications module; both fixed in one commit. New test file:
- **GUILT**: founder-role + admin-email users pass `require_admin`.
- **INNOCENCE**: regular user + portal client still 403; `require_admin` code no longer gates on the phantom flag.
- **Class-guard (AST-based)**: fails if ANY notifications route reintroduces a `.get("is_admin")` / `["is_admin"]` gate — docstring/comment mentions are structurally excluded.

`docs/AI_ONBOARDING.md` test count regenerated in the same commit (W86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)