### PR TITLE
fix(kbli): search snippet leak, exact-code lookup, chat abstain recalibration

### DIFF
--- a/apps/backend-rag/backend/app/routers/kbli_notebook.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook.py
@@ -10,6 +10,7 @@ Date: 2026-02-05
 
 import json
 import logging
+import re
 import time
 from inspect import isawaitable
 from typing import Annotated, Any
@@ -124,6 +125,35 @@ def _payload_value(payload: dict[str, Any], *keys: str, default: Any = None) -> 
         if metadata.get(key) not in (None, ""):
             return metadata[key]
     return default
+
+
+# The ingestion script (reindex_kbli_2025_final.py) stores the embedding text —
+# which opens with an internal "[CONTEXT: ...]" grounding header — as the payload
+# `content` field. That header exists for the embedding model, not for humans:
+# strip it before content is used as a user-facing snippet.
+_CONTEXT_HEADER_RE = re.compile(r"^\s*\[CONTEXT:[^\]]*\]\s*")
+
+_KBLI_CODE_RE = re.compile(r"^\d{4,5}$")
+
+
+def _clean_snippet(text: str | None) -> str:
+    """Strip the internal [CONTEXT: ...] embedding header from payload content."""
+    return _CONTEXT_HEADER_RE.sub("", text or "").lstrip()
+
+
+def _result_from_payload(payload: dict[str, Any], score: float) -> "KBLISearchResult":
+    """Build a KBLISearchResult from a flat/legacy Qdrant KBLI payload."""
+    return KBLISearchResult(
+        code=_payload_value(payload, "kode_kbli", "kode", "kode_kbli_2025", default="N/A"),
+        title=_payload_value(payload, "judul", "title_id", default="N/A"),
+        description=_clean_snippet(
+            _payload_value(payload, "content", "text", "description", default="") or "",
+        )[:200]
+        + "...",
+        score=round(score, 4),
+        pma_status=_payload_value(payload, "pma_status", default="UNKNOWN"),
+        risk_category=_payload_value(payload, "kategori_risiko", default="Unknown"),
+    )
 
 
 async def _resolve_embedding(search_service: Any, query: str) -> list[float]:
@@ -260,25 +290,29 @@ async def search_kbli(
     logger.info("🔍 KBLI Search Request: '%s' (limit: %s)", query, limit)
 
     try:
+        # Exact-code fast-path: a bare 4/5-digit query is a code lookup, not a
+        # semantic search — embedding a bare number ranks by noise (observed live
+        # 2026-07-08: "68111" did not surface 68111 in the top 5). Unknown codes
+        # fall through to semantic search so non-canonical forms (e.g. 68100)
+        # still get neighborly suggestions.
+        exact_result: KBLISearchResult | None = None
+        code_query = query.strip()
+        if _KBLI_CODE_RE.fullmatch(code_query):
+            exact_payload = await _get_kbli_payload_from_qdrant(code_query)
+            if exact_payload:
+                exact_result = _result_from_payload(exact_payload, score=1.0)
+
         embedding = await _resolve_embedding(search_service, query)
         results = await _search_kbli_qdrant(embedding, limit)
 
-        search_results = []
+        search_results: list[KBLISearchResult] = [exact_result] if exact_result else []
         for r in results:
-            p = r.get("payload", {})
-            search_results.append(
-                KBLISearchResult(
-                    code=_payload_value(p, "kode_kbli", "kode", "kode_kbli_2025", default="N/A"),
-                    title=_payload_value(p, "judul", "title_id", default="N/A"),
-                    description=(
-                        _payload_value(p, "content", "text", "description", default="") or ""
-                    )[:200]
-                    + "...",
-                    score=round(r.get("score", 0.0), 4),
-                    pma_status=_payload_value(p, "pma_status", default="UNKNOWN"),
-                    risk_category=_payload_value(p, "kategori_risiko", default="Unknown"),
-                ),
-            )
+            if len(search_results) >= limit:
+                break
+            candidate = _result_from_payload(r.get("payload", {}), score=r.get("score", 0.0))
+            if exact_result and candidate.code == exact_result.code:
+                continue
+            search_results.append(candidate)
 
         duration = (time.time() - start_time) * 1000
         logger.info(

--- a/apps/backend-rag/backend/app/routers/kbli_notebook_chat.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook_chat.py
@@ -21,6 +21,7 @@ from backend.app.routers.kbli_notebook import (
     KBLINotebookChatRequest,
     KBLINotebookChatResponse,
     KBLISearchResult,
+    _clean_snippet,
     _get_kbli_payload_from_qdrant,
     _payload_value,
     _resolve_embedding,
@@ -442,10 +443,15 @@ async def _generate_kbli_explanation(
         return fallback_answer
 
 
-# Minimum score threshold for ABSTAIN logic
-MIN_RELEVANCE_SCORE = (
-    0.40  # Results below this score trigger ABSTAIN (lowered from 0.60 to reduce false negatives)
-)
+# Minimum score threshold for ABSTAIN logic.
+# Calibrated 2026-07-08 against the LIVE prod score distribution (query embedder
+# text-embedding-3-small vs the enriched ~6k-char kbli_2025_final docs): legit
+# natural-language questions score 0.28-0.52, legit single keywords 0.18-0.32,
+# off-domain noise 0.11-0.16. The previous 0.40 (tuned on the older, shorter
+# pre-enrichment collection) sat ABOVE the entire legit band and abstained on
+# every natural question in prod — including the site's own suggested examples.
+# Tripwire test: TestChatAbstainThreshold (test_kbli_notebook.py).
+MIN_RELEVANCE_SCORE = 0.18
 
 # Hardcoded known KBLI codes not present in Qdrant collection
 # Used as synthetic fallback when code lookup fails via both PostgreSQL and Qdrant
@@ -757,9 +763,9 @@ async def chat_kbli(
                         "title_id",
                         default=f"KBLI {code}",
                     ),
-                    description=(
+                    description=_clean_snippet(
                         _payload_value(qdrant_payload, "content", "text", "description", default="")
-                        or ""
+                        or "",
                     )[:200]
                     + "...",
                     score=1.0,
@@ -975,8 +981,8 @@ async def chat_kbli(
                     KBLISearchResult(
                         code=code,
                         title=_payload_value(p, "judul", "title_id", default="N/A"),
-                        description=(
-                            _payload_value(p, "content", "text", "description", default="") or ""
+                        description=_clean_snippet(
+                            _payload_value(p, "content", "text", "description", default="") or "",
                         )[:200]
                         + "...",
                         score=round(r.get("score", 0.0), 4),

--- a/apps/backend-rag/backend/tests/routers/test_kbli_notebook.py
+++ b/apps/backend-rag/backend/tests/routers/test_kbli_notebook.py
@@ -211,3 +211,190 @@ class TestChatEndpoint:
         )
 
         assert response.status_code == 422
+
+
+class TestSnippetCleaning:
+    @pytest.mark.unit
+    def test_clean_snippet_strips_context_header(self) -> None:
+        raw = (
+            "[CONTEXT: KBLI 2025 - BPS 7/2025 + PP28/2025 - Kode 56101 - "
+            "Aktivitas Penyediaan Makanan di Bangunan Tetap]\n\n"
+            "# KBLI 56101: Aktivitas Penyediaan Makanan di Bangunan Tetap"
+        )
+        cleaned = kbli_notebook_module._clean_snippet(raw)
+        assert cleaned.startswith("# KBLI 56101")
+        assert "[CONTEXT:" not in cleaned
+
+    @pytest.mark.unit
+    def test_clean_snippet_passthrough_without_header(self) -> None:
+        assert kbli_notebook_module._clean_snippet("Plain description") == "Plain description"
+
+    @pytest.mark.unit
+    def test_clean_snippet_handles_empty_and_none(self) -> None:
+        assert kbli_notebook_module._clean_snippet("") == ""
+        assert kbli_notebook_module._clean_snippet(None) == ""
+
+    @pytest.mark.integration
+    def test_search_strips_context_header_from_description(self, client: TestClient) -> None:
+        results = [
+            {
+                "payload": {
+                    "kode_kbli": "56101",
+                    "judul": "Aktivitas Penyediaan Makanan di Bangunan Tetap",
+                    "content": (
+                        "[CONTEXT: KBLI 2025 - BPS 7/2025 + PP28/2025 - Kode 56101 - "
+                        "Aktivitas Penyediaan Makanan di Bangunan Tetap]\n\n"
+                        "Real BPS description of the restaurant activity"
+                    ),
+                    "pma_status": "TERBUKA",
+                    "kategori_risiko": "Menengah Rendah",
+                },
+                "score": 0.5,
+            }
+        ]
+
+        with (
+            patch(
+                "backend.app.routers.kbli_notebook._resolve_embedding",
+                AsyncMock(return_value=[0.1, 0.2]),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._search_kbli_qdrant",
+                AsyncMock(return_value=results),
+            ),
+        ):
+            response = client.get("/kbli-notebook/search?query=restaurant")
+
+        assert response.status_code == 200
+        description = response.json()[0]["description"]
+        assert not description.startswith("[CONTEXT:")
+        assert description.startswith("Real BPS description")
+
+
+class TestExactCodeFastPath:
+    _EXACT_PAYLOAD = {
+        "kode_kbli": "68111",
+        "judul": "Real Estat Yang Dimiliki Sendiri Atau Disewa",
+        "content": "[CONTEXT: KBLI 2025 - Kode 68111 - Real Estat]\n\nReal estate activities",
+        "pma_status": "TERBUKA",
+        "kategori_risiko": "Menengah Rendah",
+    }
+    _SEMANTIC = [
+        {
+            "payload": {
+                "kode_kbli": "41019",
+                "judul": "Konstruksi Konvensional Gedung Lainnya",
+                "content": "Construction of other buildings",
+                "pma_status": "TERBUKA",
+                "kategori_risiko": "Menengah Rendah",
+            },
+            "score": 0.2,
+        }
+    ]
+
+    @pytest.mark.integration
+    def test_search_exact_code_returns_code_first(self, client: TestClient) -> None:
+        with (
+            patch(
+                "backend.app.routers.kbli_notebook._resolve_embedding",
+                AsyncMock(return_value=[0.1, 0.2]),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._search_kbli_qdrant",
+                AsyncMock(return_value=list(self._SEMANTIC)),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._get_kbli_payload_from_qdrant",
+                AsyncMock(return_value=dict(self._EXACT_PAYLOAD)),
+            ),
+        ):
+            response = client.get("/kbli-notebook/search?query=68111")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload[0]["code"] == "68111"
+        assert payload[0]["score"] == 1.0
+        assert not payload[0]["description"].startswith("[CONTEXT:")
+        assert payload[1]["code"] == "41019"
+
+    @pytest.mark.integration
+    def test_search_exact_code_dedupes_semantic_duplicate(self, client: TestClient) -> None:
+        semantic_with_dup = list(self._SEMANTIC) + [
+            {"payload": dict(self._EXACT_PAYLOAD), "score": 0.3}
+        ]
+        with (
+            patch(
+                "backend.app.routers.kbli_notebook._resolve_embedding",
+                AsyncMock(return_value=[0.1, 0.2]),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._search_kbli_qdrant",
+                AsyncMock(return_value=semantic_with_dup),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._get_kbli_payload_from_qdrant",
+                AsyncMock(return_value=dict(self._EXACT_PAYLOAD)),
+            ),
+        ):
+            response = client.get("/kbli-notebook/search?query=68111")
+
+        codes = [r["code"] for r in response.json()]
+        assert codes.count("68111") == 1
+        assert codes[0] == "68111"
+
+    @pytest.mark.integration
+    def test_search_exact_code_not_found_falls_back_to_semantic(
+        self, client: TestClient
+    ) -> None:
+        with (
+            patch(
+                "backend.app.routers.kbli_notebook._resolve_embedding",
+                AsyncMock(return_value=[0.1, 0.2]),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._search_kbli_qdrant",
+                AsyncMock(return_value=list(self._SEMANTIC)),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._get_kbli_payload_from_qdrant",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            response = client.get("/kbli-notebook/search?query=68100")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload[0]["code"] == "41019"
+
+    @pytest.mark.integration
+    def test_search_non_numeric_query_skips_exact_lookup(self, client: TestClient) -> None:
+        exact_mock = AsyncMock(return_value=dict(self._EXACT_PAYLOAD))
+        with (
+            patch(
+                "backend.app.routers.kbli_notebook._resolve_embedding",
+                AsyncMock(return_value=[0.1, 0.2]),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._search_kbli_qdrant",
+                AsyncMock(return_value=list(self._SEMANTIC)),
+            ),
+            patch(
+                "backend.app.routers.kbli_notebook._get_kbli_payload_from_qdrant",
+                exact_mock,
+            ),
+        ):
+            response = client.get("/kbli-notebook/search?query=restaurant")
+
+        assert response.status_code == 200
+        exact_mock.assert_not_awaited()
+
+
+class TestChatAbstainThreshold:
+    @pytest.mark.unit
+    def test_min_relevance_score_calibrated_range(self) -> None:
+        # Calibrated 2026-07-08 against the live prod score battery (embedding
+        # text-embedding-3-small, enriched 6k-char docs): legit sentences 0.28-0.52,
+        # legit single keywords 0.18-0.32, off-domain noise 0.11-0.16. The previous
+        # 0.40 (tuned on the pre-enrichment collection) abstained on EVERY natural
+        # question. Guard the calibrated band against silent re-raising.
+        assert 0.15 <= kbli_chat_module.MIN_RELEVANCE_SCORE <= 0.25

--- a/apps/backend-rag/backend/tests/unit/routers/test_kbli_notebook_chat.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_kbli_notebook_chat.py
@@ -159,13 +159,15 @@ def test_get_llm_gateway_creates_new():
         "backend.app.routers.kbli_notebook_chat._llm_gateway_instance",
         None,
     ):
+        fresh_gateway = MagicMock()
         with patch(
             "backend.services.rag.agentic.llm_gateway.LLMGateway",
-            return_value=MagicMock(),
+            return_value=fresh_gateway,
         ):
             from backend.app.routers.kbli_notebook_chat import _get_llm_gateway
 
-            _get_llm_gateway()
+            # With the cached instance cleared, a new gateway is constructed
+            assert _get_llm_gateway() is fresh_gateway
             # Restores instance after test via autouse fixture
 
 
@@ -512,7 +514,10 @@ def test_non_business_keywords_list():
 def test_min_relevance_score():
     from backend.app.routers.kbli_notebook_chat import MIN_RELEVANCE_SCORE
 
-    assert MIN_RELEVANCE_SCORE == 0.40
+    # Recalibrated 2026-07-08 against the live prod score distribution (legit
+    # keywords bottom out at 0.18; off-domain noise tops out at ~0.16). The old
+    # 0.40 sat above the entire legit band and abstained on every natural query.
+    assert MIN_RELEVANCE_SCORE == 0.18
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
Production audit 2026-07-08 (trigger: Subhi's KBLI Navigator production re-audit) confirmed three live defects on the KBLI search/chat surface. All three were verified against prod BEFORE fixing, and each fix has tests.

1. **`[CONTEXT:...]` snippet leak** — the ingestion script stores the embedding text (which opens with an internal grounding header) as payload `content`; `/search` and chat returned it raw in every result, eating ~70 of the 200 snippet chars. New `_clean_snippet()` applied at all 3 consumers (class-audited).
2. **Exact-code fast-path** — live probe: query "68111" did not return 68111 in its own top-5 (pure semantic ranking on a bare number). `/search` now resolves `^\d{4,5}$` queries via the existing payload-filter lookup, score 1.0, deduped; unknown codes fall through to semantic.
3. **Chat abstain recalibration** — `MIN_RELEVANCE_SCORE` 0.40 sat above the ENTIRE legit score band of the current enriched collection (live battery: legit sentences 0.28–0.52, legit keywords 0.18–0.32, off-domain noise 0.11–0.16) → prod chat abstained on every natural question, including the site's own suggested examples. Recalibrated to 0.18 + tripwire test.

## Test plan
- `pytest backend/tests/routers/test_kbli_notebook.py backend/tests/unit/routers/test_kbli_notebook_chat*.py` → 77 passed locally (M5).
- Post-deploy live probes (will run after merge): `/search?query=restaurant` description has no `[CONTEXT:`; `/search?query=68111` top-1 == 68111; chat answers "Can foreigners own a villa rental business?" instead of the canned abstain.

Companion data PR: mis-assigned gold/intel editorial content (56303 etc.). Full audit report lands there (`research/operations/2026-07-08-kbli-editorial-content-audit.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)