### PR TITLE
docs: repair stale AI_ONBOARDING sync counts on main (W86)

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`331 routers · 636 services · 1108 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`331 routers · 636 services · 1110 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
main's derived doc contract went stale — a recently auto-merged backend PR landed without its `docs_sync.py` bump, so `check-docs-sync` now bounces every innocent backend PR (verified on pure origin/main e2b6517c79: regen changes `docs/AI_ONBOARDING.md` e423df11d0a6 → 19154ae6c02b). One-file repair per the W86 pattern (#1672 precedent). Unblocks #2163/#2164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)