### PR TITLE
fix(crm-process): semantic bz-tokens for status colors (theme-correct)

### DIFF
--- a/apps/mouth/src/app/(workspace)/process/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/page.tsx
@@ -1805,9 +1805,9 @@ export default function PratichePage() {
                                         : "transparent",
                                   color:
                                     ageDays > 14
-                                      ? "#f87171"
+                                      ? "var(--bz-error)"
                                       : ageDays > 7
-                                        ? "#fbbf24"
+                                        ? "var(--bz-warning)"
                                         : "var(--bz-text-2)",
                                 }}
                                 title={`Last updated: ${new Date(practice.updated_at).toLocaleDateString("en-US")}`}
@@ -2019,10 +2019,10 @@ export default function PratichePage() {
                     color:
                       selectedPractice.payment_status === ps
                         ? ps === "paid"
-                          ? "#4ade80"
+                          ? "var(--bz-success)"
                           : ps === "partial"
-                            ? "#fbbf24"
-                            : "#f87171"
+                            ? "var(--bz-warning)"
+                            : "var(--bz-error)"
                         : "var(--bz-text-2)",
                     border:
                       selectedPractice.payment_status === ps
@@ -2050,21 +2050,21 @@ export default function PratichePage() {
                   {
                     value: "normal",
                     label: "Normal",
-                    color: "#9ca3af",
+                    color: "var(--bz-text-secondary)",
                     active: "rgba(156,163,175,0.25)",
                     border: "rgba(156,163,175,0.4)",
                   },
                   {
                     value: "high",
                     label: "High",
-                    color: "#fb923c",
+                    color: "var(--bz-warning)",
                     active: "rgba(249,115,22,0.25)",
                     border: "rgba(249,115,22,0.4)",
                   },
                   {
                     value: "urgent",
                     label: "Urgent",
-                    color: "#f87171",
+                    color: "var(--bz-error)",
                     active: "rgba(239,68,68,0.25)",
                     border: "rgba(239,68,68,0.4)",
                   },


### PR DESCRIPTION
Same token-drift class as #2180 (Clients). The Process page hardcoded 8 raw hex status colors (age badges, payment-status chips, priority chips). Mapped each to `bz-tokens.css` semantic tokens (`--bz-error`/`--bz-warning`/`--bz-success`/`--bz-text-secondary`) so they adapt to light theme. Zero raw hex remain. Values-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)