### PR TITLE
fix(analytics): cast EXTRACT(EPOCH) ROUND to ::numeric — live 500 on /response-times

### DIFF
--- a/apps/backend-rag/backend/services/analytics/historical_analytics.py
+++ b/apps/backend-rag/backend/services/analytics/historical_analytics.py
@@ -169,21 +169,23 @@ async def calculate_response_times(
                 COUNT(*) as total_practices,
 
                 -- Inquiry to Start
-                ROUND(AVG(EXTRACT(EPOCH FROM (p.start_date - p.inquiry_date)) / 86400), 2)
+                -- NOTE: EXTRACT(EPOCH ...) returns double precision; ROUND(double, int)
+                -- does not exist in Postgres, so cast the numeric arg to ::numeric.
+                ROUND((AVG(EXTRACT(EPOCH FROM (p.start_date - p.inquiry_date)) / 86400))::numeric, 2)
                     as avg_days_inquiry_to_start,
-                ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (p.start_date - p.inquiry_date)) / 86400), 2)
+                ROUND((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (p.start_date - p.inquiry_date)) / 86400))::numeric, 2)
                     as median_days_inquiry_to_start,
 
                 -- Start to Completion
-                ROUND(AVG(EXTRACT(EPOCH FROM (p.completion_date - p.start_date)) / 86400), 2)
+                ROUND((AVG(EXTRACT(EPOCH FROM (p.completion_date - p.start_date)) / 86400))::numeric, 2)
                     as avg_days_start_to_completion,
-                ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (p.completion_date - p.start_date)) / 86400), 2)
+                ROUND((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (p.completion_date - p.start_date)) / 86400))::numeric, 2)
                     as median_days_start_to_completion,
 
                 -- Total Cycle Time
-                ROUND(AVG(EXTRACT(EPOCH FROM (p.completion_date - p.inquiry_date)) / 86400), 2)
+                ROUND((AVG(EXTRACT(EPOCH FROM (p.completion_date - p.inquiry_date)) / 86400))::numeric, 2)
                     as avg_days_total_cycle,
-                ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (p.completion_date - p.inquiry_date)) / 86400), 2)
+                ROUND((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (p.completion_date - p.inquiry_date)) / 86400))::numeric, 2)
                     as median_days_total_cycle
 
             FROM practices p

--- a/apps/backend-rag/backend/tests/services/analytics/test_historical_analytics_round_numeric.py
+++ b/apps/backend-rag/backend/tests/services/analytics/test_historical_analytics_round_numeric.py
@@ -1,0 +1,87 @@
+"""Regression guard: SQL ROUND() in historical_analytics must never receive a
+bare double-precision first arg.
+
+Postgres has ROUND(numeric, int) but NOT ROUND(double precision, int). The
+`get_response_times` query used `ROUND(AVG(EXTRACT(EPOCH ...) / 86400), 2)`,
+where EXTRACT(EPOCH ...) is double precision -> live HTTP 500:
+
+    function round(double precision, integer) does not exist
+
+The fix casts the numeric arg to ::numeric before ROUND. This test is a static
+guard over the module's SQL: every ROUND(...) whose first argument contains an
+EXTRACT(EPOCH ...) expression must route that expression through an explicit
+::numeric cast. It fails on the pre-fix source and passes on the fixed source,
+independently of a live DB (so it runs in CI without Postgres).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# __file__ = .../backend/tests/services/analytics/test_...py
+#   parents[0]=analytics parents[1]=services parents[2]=tests parents[3]=backend
+_MODULE = (
+    Path(__file__).resolve().parents[3]
+    / "services"
+    / "analytics"
+    / "historical_analytics.py"
+)
+
+
+def _source() -> str:
+    return _MODULE.read_text(encoding="utf-8")
+
+
+def _round_call_bodies(sql: str) -> list[str]:
+    """Return the substring inside each top-level ROUND( ... ) call.
+
+    Uses paren-depth counting so nested AVG()/EXTRACT()/PERCENTILE_CONT() are
+    kept whole rather than split on the first inner comma.
+    """
+    bodies: list[str] = []
+    for m in re.finditer(r"ROUND\s*\(", sql, flags=re.IGNORECASE):
+        i = m.end()
+        depth = 1
+        start = i
+        while i < len(sql) and depth > 0:
+            c = sql[i]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+            i += 1
+        bodies.append(sql[start : i - 1])
+    return bodies
+
+
+def test_module_exists() -> None:
+    assert _MODULE.is_file(), f"analytics module not found at {_MODULE}"
+
+
+def test_every_extract_epoch_round_is_numeric_cast() -> None:
+    """Any ROUND() whose body references EXTRACT(EPOCH ...) must cast to ::numeric.
+
+    This is the exact class that caused the live 500 on /api/analytics/response-times.
+    """
+    sql = _source()
+    offenders: list[str] = []
+    for body in _round_call_bodies(sql):
+        if re.search(r"EXTRACT\s*\(\s*EPOCH", body, flags=re.IGNORECASE):
+            if "::numeric" not in body.lower():
+                offenders.append(body.strip()[:120])
+    assert not offenders, (
+        "ROUND() over EXTRACT(EPOCH ...) without ::numeric cast — "
+        "Postgres has no ROUND(double precision, int):\n" + "\n".join(offenders)
+    )
+
+
+def test_response_times_query_casts_all_epoch_rounds() -> None:
+    """Belt-and-suspenders: the specific six duration metrics are cast."""
+    sql = _source()
+    # The six response-time ROUNDs all divide by 86400 (seconds/day).
+    for body in _round_call_bodies(sql):
+        if "86400" in body:
+            assert "::numeric" in body.lower(), (
+                f"day-duration ROUND missing ::numeric cast: {body.strip()[:120]}"
+            )

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`331 routers · 636 services · 1116 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`331 routers · 636 services · 1117 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
Live prod E2E as Founder found HTTP 500 on `GET /api/analytics/response-times`: `function round(double precision, integer) does not exist`. `calculate_response_times` wrapped `ROUND(AVG(EXTRACT(EPOCH ...)/86400), 2)` — EXTRACT(EPOCH) is double precision, Postgres has no `ROUND(double, int)`. Cast each of the 6 duration metrics to `::numeric`.

**W89 class-audit**: `sla_compliance`/`revenue_metrics` ROUNDs already cast to `::numeric`; `response_times` was the lone offender. Same class as #2157, distinct endpoint.

Added a static regression guard (paren-depth parse of every ROUND body → require `::numeric` on any EXTRACT(EPOCH) arg); proven to fail on pre-fix source, pass on fix, no live DB needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)