### PR TITLE
fix(kbli): add MobileNav to NavShell slotAfter for mobile navigation

### DIFF
--- a/apps/mouth/src/app/kbli/layout.tsx
+++ b/apps/mouth/src/app/kbli/layout.tsx
@@ -3,6 +3,7 @@ import { NavShell, BZLogo } from "@balizero/core";
 import { SessionInit } from "@/components/funnel/SessionInit";
 import { HeaderWhatsAppCTA } from "@/components/funnel/HeaderWhatsAppCTA";
 import { getFunnelNavItems } from "@/components/funnel/funnel-nav";
+import { MobileNav } from "@/app/v2/_components/MobileNav";
 
 const montserrat = Montserrat({
   subsets: ["latin"],
@@ -16,6 +17,8 @@ export default function KBLILayout({
 }: {
   children: React.ReactNode;
 }) {
+  const navItems = getFunnelNavItems("kbli");
+
   return (
     <div
       className={`${montserrat.variable} relative z-1`}
@@ -25,7 +28,8 @@ export default function KBLILayout({
     >
       <NavShell
         logo={<BZLogo variant="full" />}
-        items={getFunnelNavItems("kbli")}
+        items={navItems}
+        slotAfter={<MobileNav items={navItems} />}
         actions={<HeaderWhatsAppCTA funnel="kbli" />}
       />
       <SessionInit funnel="kbli" />


### PR DESCRIPTION
<html><head></head><body><h2>Insight</h2>
<p>KBLI pages (<code>/kbli/*</code>) have zero mobile navigation — no hamburger menu, no way to reach other sections (Home, Visa, Tax, Property). Users on mobile viewports (375–767px) are trapped on the KBLI page with only the Bali Zero logo visible in the header bar.</p>
<h2>Studio</h2>

Before | After
-- | --
Mobile header: logo only, no navigation | Hamburger icon appears, opens full MobileNav drawer
Users cannot leave /kbli on mobile | Full site navigation accessible on all viewports
Desktop: unaffected (nav items use hidden md:flex) | Desktop: unchanged


<h2>Implication</h2>
<ul>
<li>Immediate: /kbli mobile users can now navigate the full site</li>
<li>Follow-up opportunity: same fix needed for <code>/visa</code>, <code>/property</code>, <code>/tax-calendar</code>, <code>/(blog)</code> layouts — separate atomic PRs</li>
<li>No backend dependency, no packages/core changes</li>
</ul>
<h2>Recommendation</h2>
<p>Merge as-is. VERDE zone (<code>apps/mouth/</code> only), CI green required. NavShell.tsx (packages/core) was NOT modified — only consumed its existing <code>slotAfter</code> prop.</p>
<h2>Next Action</h2>
<ul>
<li>[ ] CI green → self-merge (squash + delete branch)</li>
<li>[ ] Post-deploy: verify on production at 375px, 390px, 430px — hamburger visible, drawer opens, all nav links functional</li>
<li>[ ] Add Todoist completion comment after merge</li>
<li>[ ] Plan follow-up PR for other affected layouts (visa, property, tax-calendar, blog)</li>
<li>[ ] Proceed to Task 3: WA sticky bar overlap (<code>sancho/kbli-mobile-wa-bar-fix</code>)</li>
</ul></body></html>