### PR TITLE
fix(infra): classify healer quota failures

### DIFF
--- a/infra/healer/healer-run.sh
+++ b/infra/healer/healer-run.sh
@@ -28,7 +28,7 @@ set -u
 LOG_DIR="$HOME/logs/healer"
 LOG="$LOG_DIR/healer.log"
 mkdir -p "$LOG_DIR"
-REPO="$HOME/Desktop/nuzantara"
+REPO="${HEALER_REPO:-$HOME/Desktop/nuzantara}"
 SIDECAR_DIR="$HOME/.organism/last_seen"
 SIDECAR="$SIDECAR_DIR/mini.healer.json"
 PIDFILE="/tmp/nuzantara-healer.pid"
@@ -122,14 +122,7 @@ fi
 
 # Receptor 2: proprioception — boundary divergences on THIS machine
 PROP_JSON=$(python3 scripts/proprioception.py --json --no-fetch 2>/dev/null)
-DIVERGED=$(printf '%s' "$PROP_JSON" | python3 -c "
-import json,sys
-try:
-    d=json.load(sys.stdin)
-    print(sum(1 for p in d.get('probes',[]) if str(p.get('verdict','')).upper()=='DIVERGED'))
-except Exception:
-    print(0)
-" 2>/dev/null)
+DIVERGED=$(printf '%s' "$PROP_JSON" | python3 scripts/healer_run_checks.py count-diverged 2>/dev/null || echo 0)
 if [ "${DIVERGED:-0}" -gt 0 ] 2>/dev/null; then
     ACTIONABLE=1; REASONS="${REASONS}proprioception:${DIVERGED}-diverged "
 fi
@@ -290,7 +283,16 @@ if [ $CEXIT -eq 0 ]; then
     heartbeat "ok" "session done: ${REASONS}"
     telegram "🩹 HEALER (Mini): run completato su ${REASONS}. Esito: ${TAIL:0:400}"
 else
-    heartbeat "degraded" "session exit=$CEXIT"
-    telegram "⚠️ HEALER (Mini): sessione uscita $CEXIT su ${REASONS}. Log: $SESSION_LOG"
+    FAILURE_CLASS=$(printf '%s' "$TAIL" | python3 scripts/healer_run_checks.py classify-session-tail 2>/dev/null || echo session_error)
+    if [ "$FAILURE_CLASS" = "rate_or_quota_limit" ]; then
+        heartbeat "degraded" "claude quota/rate limit: ${REASONS}"
+        telegram "⚠️ HEALER (Mini): Claude quota/rate limit su ${REASONS}. Nessuna cascade debole per policy; log: $SESSION_LOG"
+    elif [ "$FAILURE_CLASS" = "auth_required" ]; then
+        heartbeat "degraded" "claude auth required: ${REASONS}"
+        telegram "⚠️ HEALER (Mini): Claude auth richiesta su ${REASONS}. Nessuna cascade debole per policy; log: $SESSION_LOG"
+    else
+        heartbeat "degraded" "session exit=$CEXIT"
+        telegram "⚠️ HEALER (Mini): sessione uscita $CEXIT su ${REASONS}. Log: $SESSION_LOG"
+    fi
 fi
 exit 0

--- a/scripts/healer_run_checks.py
+++ b/scripts/healer_run_checks.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Small testable checks used by infra/healer/healer-run.sh."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+RATE_OR_QUOTA_MARKERS: tuple[str, ...] = (
+    "hit your weekly limit",
+    "hit your usage limit",
+    "usage limit",
+    "weekly limit",
+    "rate limit",
+    "rate.limit",
+    "out of extra usage",
+    "quota exceeded",
+    "quota_exceeded",
+    "resource_exhausted",
+    "429",
+    "exhausted",
+)
+
+AUTH_REQUIRED_MARKERS: tuple[str, ...] = (
+    "auth required",
+    "authentication required",
+    "login required",
+    "not logged in",
+    "oauth",
+    "token_revoked",
+    "refresh_token",
+    "unauthorized",
+    "401",
+)
+
+
+def count_diverged_probes(raw_json: str) -> int:
+    """Count DIVERGED proprioception probes across current and legacy schemas."""
+    try:
+        data = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return 0
+
+    probes = data.get("probes")
+    if not isinstance(probes, list):
+        return 0
+
+    count = 0
+    for probe in probes:
+        if not isinstance(probe, dict):
+            continue
+        status = str(probe.get("status") or probe.get("verdict") or "").upper()
+        if status == "DIVERGED":
+            count += 1
+    return count
+
+
+def classify_session_tail(text: str) -> str:
+    """Classify known operator-gated CLI failures; generic errors stay generic."""
+    lowered = text.lower()
+    if any(marker in lowered for marker in RATE_OR_QUOTA_MARKERS):
+        return "rate_or_quota_limit"
+    if any(marker in lowered for marker in AUTH_REQUIRED_MARKERS):
+        return "auth_required"
+    return "session_error"
+
+
+def _read_stdin() -> str:
+    return sys.stdin.read()
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.stderr.write("usage: healer_run_checks.py <count-diverged|classify-session-tail>\n")
+        return 2
+
+    command = argv[1]
+    payload = _read_stdin()
+    if command == "count-diverged":
+        sys.stdout.write(f"{count_diverged_probes(payload)}\n")
+        return 0
+    if command == "classify-session-tail":
+        sys.stdout.write(f"{classify_session_tail(payload)}\n")
+        return 0
+
+    sys.stderr.write(f"unknown command: {command}\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/tests/test_healer_run_checks.py
+++ b/scripts/tests/test_healer_run_checks.py
@@ -1,0 +1,43 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+_MOD_PATH = Path(__file__).resolve().parents[1] / "healer_run_checks.py"
+_spec = importlib.util.spec_from_file_location("healer_run_checks", _MOD_PATH)
+checks = importlib.util.module_from_spec(_spec)
+sys.modules["healer_run_checks"] = checks
+_spec.loader.exec_module(checks)
+
+
+def test_count_diverged_uses_current_status_schema() -> None:
+    raw = '{"probes":[{"id":"a","status":"DIVERGED"},{"id":"b","status":"OK"}]}'
+
+    assert checks.count_diverged_probes(raw) == 1
+
+
+def test_count_diverged_keeps_legacy_verdict_schema() -> None:
+    raw = '{"probes":[{"id":"a","verdict":"DIVERGED"},{"id":"b","verdict":"OK"}]}'
+
+    assert checks.count_diverged_probes(raw) == 1
+
+
+def test_count_diverged_malformed_json_is_zero() -> None:
+    assert checks.count_diverged_probes("not-json") == 0
+
+
+def test_classify_session_tail_detects_weekly_limit() -> None:
+    tail = "You've hit your weekly limit - resets Jul 12 at 9am (Asia/Makassar)"
+
+    assert checks.classify_session_tail(tail) == "rate_or_quota_limit"
+
+
+def test_classify_session_tail_detects_auth_required() -> None:
+    tail = "401 token_revoked refresh_token_reused"
+
+    assert checks.classify_session_tail(tail) == "auth_required"
+
+
+def test_classify_session_tail_leaves_unknown_failures_generic() -> None:
+    tail = "unexpected process crash"
+
+    assert checks.classify_session_tail(tail) == "session_error"


### PR DESCRIPTION
## Summary
- count Mini proprioception divergences from the current `status` field while preserving legacy `verdict`
- add a small testable helper for healer-run parsing/classification
- classify Claude quota/auth failures in the healer heartbeat instead of reporting a generic `session exit=1`

## Verification
- `bash -n infra/healer/healer-run.sh`
- `python -m pytest scripts/tests/test_healer_run_checks.py scripts/tests/test_healer_receptor_running_status.py -q`
- Mini: `python -m pytest scripts/tests/test_healer_run_checks.py scripts/tests/test_healer_receptor_running_status.py apps/backend-rag/backend/tests/unit/self_healing -q` (45 passed)
- Mini controlled tick: sidecar now reports `claude quota/rate limit` with `proprioception:5-diverged`
- Public smoke: `balizero.com`, `/kg/routes`, `/kg/stats`, `kita.balizero.com/chat`, and `nuzantara-rag.fly.dev/health` all HTTP 200

## Notes
- Pro is still offline over Tailscale/SSH, so Pro-local organism and pg-proxy cleanup cannot be completed from this branch.