### PR TITLE
fix(infra): keep expiry alerter heartbeat fresh

### DIFF
--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -72,14 +72,16 @@ if [[ -n "${DATABASE_URL_LOCAL:-}" ]]; then
     export DATABASE_URL
 fi
 
-# macOS uses gtimeout from coreutils
-if command -v gtimeout &>/dev/null; then
+# macOS usually needs gtimeout from coreutils, but production Pro may not have
+# it installed. Keep the wrapper functional with a small bash-native fallback.
+if [[ "${CRON_WRAPPER_DISABLE_EXTERNAL_TIMEOUT:-}" == "1" ]]; then
+    TIMEOUT_CMD=""
+elif command -v gtimeout &>/dev/null; then
     TIMEOUT_CMD="gtimeout"
 elif command -v timeout &>/dev/null; then
     TIMEOUT_CMD="timeout"
 else
-    echo "ERROR: neither timeout nor gtimeout found. Install coreutils." >&2
-    exit 1
+    TIMEOUT_CMD=""
 fi
 
 mkdir -p "$LOG_DIR" "$LOCK_DIR" "$SENTINEL_STATE_DIR"
@@ -122,6 +124,42 @@ send_telegram() {
         -- "$msg" >> "$LOG_FILE" 2>&1 || true
 }
 
+run_command_with_timeout() {
+    if [ -n "$TIMEOUT_CMD" ]; then
+        OUTPUT=$("$TIMEOUT_CMD" "$TIMEOUT" "${COMMAND[@]}" 2>&1) && return 0 || return $?
+    fi
+
+    local output_file timeout_file pid watcher exit_code
+    output_file="$(mktemp "${TMPDIR:-/tmp}/cron-wrapper.${SENTINEL_JOB_KEY}.XXXXXX")"
+    timeout_file="${output_file}.timeout"
+
+    "${COMMAND[@]}" > "$output_file" 2>&1 &
+    pid=$!
+
+    (
+        sleep "$TIMEOUT"
+        if kill -0 "$pid" 2>/dev/null; then
+            : > "$timeout_file"
+            kill "$pid" 2>/dev/null || true
+            sleep 2
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    ) &
+    watcher=$!
+
+    wait "$pid" && exit_code=0 || exit_code=$?
+    kill "$watcher" 2>/dev/null || true
+    wait "$watcher" 2>/dev/null || true
+
+    OUTPUT="$(cat "$output_file" 2>/dev/null || true)"
+    if [ -f "$timeout_file" ]; then
+        exit_code=124
+    fi
+    rm -f "$output_file" "$timeout_file"
+
+    return "$exit_code"
+}
+
 # ── Execute with retry ───────────────────────────────────────────────────────
 ATTEMPT=0
 EXIT_CODE=1
@@ -130,7 +168,7 @@ OUTPUT=""
 while [ $ATTEMPT -le $MAX_RETRIES ]; do
     ATTEMPT=$((ATTEMPT + 1))
 
-    OUTPUT=$($TIMEOUT_CMD "$TIMEOUT" "${COMMAND[@]}" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+    run_command_with_timeout && EXIT_CODE=0 || EXIT_CODE=$?
 
     if [ $EXIT_CODE -eq 0 ]; then
         break

--- a/scripts/expiry_alerter.py
+++ b/scripts/expiry_alerter.py
@@ -384,6 +384,24 @@ asyncio.run(m())
         log(f"CRM write-back failed: {result.stderr[:100]}")
 
 
+def _write_heartbeat(status: str = "ok") -> None:
+    import pathlib
+
+    state_dir = pathlib.Path.home() / ".agent" / "decisions" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "expiry_alerter.last.json").write_text(
+        json.dumps(
+            {
+                "job": "expiry_alerter",
+                "ts": int(__import__("time").time()),
+                "status": status,
+                "host": __import__("socket").gethostname(),
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
 def main() -> None:
     global VERBOSE
 
@@ -402,6 +420,7 @@ def main() -> None:
     if not raw_items:
         log("No expiries found in next 30 days")
         print("No expiries found.")
+        _write_heartbeat()
         return
 
     # Classify urgency
@@ -420,6 +439,7 @@ def main() -> None:
     if not items:
         log("No critical/warning expiries")
         print("No urgent expiries.")
+        _write_heartbeat()
         return
 
     log(f"Found {len(items)} expiries needing attention")
@@ -452,13 +472,7 @@ def main() -> None:
         print("\n--- TELEGRAM PREVIEW ---")
         print(tg_text)
 
-    # Sentinel heartbeat
-    import pathlib
-    state_dir = pathlib.Path.home() / ".agent" / "decisions" / "state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    (state_dir / "expiry_alerter.last.json").write_text(
-        f'{{"job":"expiry_alerter","ts":{int(__import__("time").time())},"status":"ok","host":"{__import__("socket").gethostname()}"}}'
-    )
+    _write_heartbeat()
 
 
 if __name__ == "__main__":

--- a/scripts/expiry_alerter.py
+++ b/scripts/expiry_alerter.py
@@ -86,8 +86,35 @@ def _is_local_fly_host() -> bool:
     )
 
 
-def _run_fly_console_python(encoded: str, timeout_s: int = 30) -> subprocess.CompletedProcess[str]:
+def _local_database_url() -> str:
+    for key in ("EXPIRY_ALERTER_DATABASE_URL", "DATABASE_URL_LOCAL"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    if "localhost" in database_url or "127.0.0.1" in database_url:
+        return database_url
+    return ""
+
+
+def _run_prod_python(encoded: str, timeout_s: int = 30) -> subprocess.CompletedProcess[str]:
     python_command = f"import base64;exec(base64.b64decode(b'{encoded}'))"
+    local_db_url = _local_database_url()
+    if local_db_url:
+        env = os.environ.copy()
+        env["DATABASE_URL"] = local_db_url
+        try:
+            return subprocess.run(
+                [sys.executable, "-c", python_command],
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                env=env,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            raise ExpiryAlerterError(f"Local query runner failed: {exc}") from exc
+
     fly_args = [
         "fly",
         "ssh",
@@ -97,20 +124,23 @@ def _run_fly_console_python(encoded: str, timeout_s: int = 30) -> subprocess.Com
         "-C",
         f"python3 -c {shlex.quote(python_command)}",
     ]
-    if _is_local_fly_host():
+    try:
+        if _is_local_fly_host():
+            return subprocess.run(
+                fly_args,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+        remote_command = " ".join(shlex.quote(arg) for arg in fly_args)
         return subprocess.run(
-            fly_args,
+            ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", SSH_HOST, remote_command],
             capture_output=True,
             text=True,
             timeout=timeout_s,
         )
-    remote_command = " ".join(shlex.quote(arg) for arg in fly_args)
-    return subprocess.run(
-        ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", SSH_HOST, remote_command],
-        capture_output=True,
-        text=True,
-        timeout=timeout_s,
-    )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        raise ExpiryAlerterError(f"Remote query runner failed: {exc}") from exc
 
 
 def _query_expiries() -> list[dict]:
@@ -190,7 +220,7 @@ asyncio.run(m())
 '''
     encoded = __import__("base64").b64encode(code.encode()).decode()
 
-    result = _run_fly_console_python(encoded, timeout_s=30)
+    result = _run_prod_python(encoded, timeout_s=30)
 
     if result.returncode != 0:
         raise ExpiryAlerterError(f"Query failed: {result.stderr[:200]}")
@@ -416,7 +446,11 @@ asyncio.run(m())
         print(f"[DRY RUN] Would mark renewal_required for {len(client_ids)} clients: {ids_csv}")
         return
 
-    result = _run_fly_console_python(encoded, timeout_s=30)
+    try:
+        result = _run_prod_python(encoded, timeout_s=30)
+    except ExpiryAlerterError as exc:
+        log(f"CRM write-back failed: {exc}")
+        return
     if result.returncode == 0:
         log(f"CRM write-back: marked {len(client_ids)} clients renewal_required")
     else:
@@ -451,6 +485,9 @@ def main() -> None:
     VERBOSE = args.verbose
 
     env = _load_env()
+    for key in ("EXPIRY_ALERTER_DATABASE_URL", "DATABASE_URL_LOCAL", "DATABASE_URL"):
+        if key in env and key not in os.environ:
+            os.environ[key] = env[key]
     bot_token = env.get("TELEGRAM_BOT_TOKEN") or os.environ.get("TELEGRAM_BOT_TOKEN", "")
 
     log("Querying CRM for expiries...")

--- a/scripts/expiry_alerter.py
+++ b/scripts/expiry_alerter.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
+import socket
 import smtplib
 import subprocess
 import sys
@@ -49,6 +51,10 @@ OVERDUE_DAYS = 0     # Already expired
 VERBOSE = False
 
 
+class ExpiryAlerterError(RuntimeError):
+    """Raised when the alerter cannot trust its CRM query result."""
+
+
 def log(msg: str) -> None:
     if VERBOSE:
         print(f"[alerter] {msg}", file=sys.stderr)
@@ -63,6 +69,48 @@ def _load_env() -> dict[str, str]:
                 key, _, value = line.partition("=")
                 env[key.strip()] = value.strip()
     return env
+
+
+def _is_local_fly_host() -> bool:
+    host = SSH_HOST.strip().lower()
+    local_hosts = {
+        "",
+        "local",
+        "localhost",
+        "127.0.0.1",
+        socket.gethostname().lower(),
+        socket.getfqdn().lower(),
+    }
+    return host in local_hosts or (
+        host == "pro" and socket.gethostname().lower().startswith("nuzantara")
+    )
+
+
+def _run_fly_console_python(encoded: str, timeout_s: int = 30) -> subprocess.CompletedProcess[str]:
+    python_command = f"import base64;exec(base64.b64decode(b'{encoded}'))"
+    fly_args = [
+        "fly",
+        "ssh",
+        "console",
+        "--app",
+        "nuzantara-rag",
+        "-C",
+        f"python3 -c {shlex.quote(python_command)}",
+    ]
+    if _is_local_fly_host():
+        return subprocess.run(
+            fly_args,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    remote_command = " ".join(shlex.quote(arg) for arg in fly_args)
+    return subprocess.run(
+        ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", SSH_HOST, remote_command],
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+    )
 
 
 def _query_expiries() -> list[dict]:
@@ -142,15 +190,10 @@ asyncio.run(m())
 '''
     encoded = __import__("base64").b64encode(code.encode()).decode()
 
-    result = subprocess.run(
-        ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", SSH_HOST,
-         f'fly ssh console --app nuzantara-rag -C "python3 -c \\"import base64;exec(base64.b64decode(b\'{encoded}\'))\\"" 2>/dev/null'],
-        capture_output=True, text=True, timeout=30,
-    )
+    result = _run_fly_console_python(encoded, timeout_s=30)
 
     if result.returncode != 0:
-        log(f"Query failed: {result.stderr[:200]}")
-        return []
+        raise ExpiryAlerterError(f"Query failed: {result.stderr[:200]}")
 
     output = result.stdout.strip()
     # Find the JSON line (last line starting with [)
@@ -158,7 +201,7 @@ asyncio.run(m())
         line = line.strip()
         if line.startswith("["):
             return json.loads(line)
-    return []
+    raise ExpiryAlerterError("Query returned no JSON payload")
 
 
 def _classify_urgency(expiry_str: str) -> tuple[str, int, str]:
@@ -373,11 +416,7 @@ asyncio.run(m())
         print(f"[DRY RUN] Would mark renewal_required for {len(client_ids)} clients: {ids_csv}")
         return
 
-    result = subprocess.run(
-        ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", SSH_HOST,
-         f'fly ssh console --app nuzantara-rag -C "python3 -c \\"import base64;exec(base64.b64decode(b\'{encoded}\'))\\"" 2>/dev/null'],
-        capture_output=True, text=True, timeout=30,
-    )
+    result = _run_fly_console_python(encoded, timeout_s=30)
     if result.returncode == 0:
         log(f"CRM write-back: marked {len(client_ids)} clients renewal_required")
     else:
@@ -415,7 +454,13 @@ def main() -> None:
     bot_token = env.get("TELEGRAM_BOT_TOKEN") or os.environ.get("TELEGRAM_BOT_TOKEN", "")
 
     log("Querying CRM for expiries...")
-    raw_items = _query_expiries()
+    try:
+        raw_items = _query_expiries()
+    except ExpiryAlerterError as exc:
+        log(str(exc))
+        print(f"Expiry alerter failed: {exc}", file=sys.stderr)
+        _write_heartbeat(status="failed")
+        raise SystemExit(1) from exc
 
     if not raw_items:
         log("No expiries found in next 30 days")

--- a/scripts/tests/test_cron_wrapper.py
+++ b/scripts/tests/test_cron_wrapper.py
@@ -1,0 +1,73 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WRAPPER = _REPO_ROOT / "scripts" / "cron-wrapper.sh"
+
+
+def _wrapper_env(tmp_path: Path, timeout_s: int = 5) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "CRON_LOG_DIR": str(tmp_path / "logs"),
+            "CRON_MAX_RETRIES": "0",
+            "CRON_TIMEOUT": str(timeout_s),
+            "CRON_WRAPPER_DISABLE_EXTERNAL_TIMEOUT": "1",
+        }
+    )
+    return env
+
+
+def _state(home: Path, job_name: str) -> dict:
+    path = home / ".agent" / "decisions" / "state" / f"{job_name}.last.json"
+    return json.loads(path.read_text())
+
+
+def test_cron_wrapper_runs_with_native_timeout_fallback(tmp_path) -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            str(_WRAPPER),
+            "unit-success",
+            "bash",
+            "-c",
+            "printf fallback-ok",
+        ],
+        cwd=_REPO_ROOT,
+        env=_wrapper_env(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0
+    heartbeat = _state(tmp_path, "unit_success")
+    assert heartbeat["status"] == "ok"
+    assert heartbeat["source"] == "cron-wrapper"
+    assert "fallback-ok" in (tmp_path / "logs" / "unit-success.log").read_text()
+
+
+def test_cron_wrapper_native_timeout_fallback_returns_124(tmp_path) -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            str(_WRAPPER),
+            "unit-timeout",
+            "bash",
+            "-c",
+            "printf started; sleep 5",
+        ],
+        cwd=_REPO_ROOT,
+        env=_wrapper_env(tmp_path, timeout_s=1),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 124
+    heartbeat = _state(tmp_path, "unit_timeout")
+    assert heartbeat["status"] == "failed"
+    assert "timeout after 1s" in heartbeat["last_error"]

--- a/scripts/tests/test_expiry_alerter.py
+++ b/scripts/tests/test_expiry_alerter.py
@@ -1,0 +1,61 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_MOD_PATH = Path(__file__).resolve().parents[1] / "expiry_alerter.py"
+_spec = importlib.util.spec_from_file_location("expiry_alerter", _MOD_PATH)
+expiry = importlib.util.module_from_spec(_spec)
+sys.modules["expiry_alerter"] = expiry
+_spec.loader.exec_module(expiry)
+
+
+def _heartbeat_path(home: Path) -> Path:
+    return home / ".agent" / "decisions" / "state" / "expiry_alerter.last.json"
+
+
+def _read_heartbeat(home: Path) -> dict:
+    return json.loads(_heartbeat_path(home).read_text())
+
+
+def test_main_writes_heartbeat_when_no_expiries(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["expiry_alerter.py"])
+    monkeypatch.setattr(expiry, "_load_env", lambda: {})
+    monkeypatch.setattr(expiry, "_query_expiries", lambda: [])
+
+    expiry.main()
+
+    assert "No expiries found." in capsys.readouterr().out
+    heartbeat = _read_heartbeat(tmp_path)
+    assert heartbeat["job"] == "expiry_alerter"
+    assert heartbeat["status"] == "ok"
+    assert heartbeat["host"]
+    assert isinstance(heartbeat["ts"], int)
+
+
+def test_main_writes_heartbeat_when_no_items_are_urgent(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["expiry_alerter.py"])
+    monkeypatch.setattr(expiry, "_load_env", lambda: {})
+    monkeypatch.setattr(
+        expiry,
+        "_query_expiries",
+        lambda: [
+            {
+                "client_id": 1,
+                "full_name": "Test Client",
+                "assigned_to": "ops@example.com",
+                "exp_type": "practice",
+                "expiry_date": "2030-01-01",
+                "passport_expiry": None,
+            }
+        ],
+    )
+
+    expiry.main()
+
+    assert "No urgent expiries." in capsys.readouterr().out
+    heartbeat = _read_heartbeat(tmp_path)
+    assert heartbeat["job"] == "expiry_alerter"
+    assert heartbeat["status"] == "ok"

--- a/scripts/tests/test_expiry_alerter.py
+++ b/scripts/tests/test_expiry_alerter.py
@@ -84,8 +84,30 @@ def test_main_fails_closed_when_query_fails(monkeypatch, tmp_path, capsys) -> No
     assert heartbeat["status"] == "failed"
 
 
-def test_run_fly_console_python_uses_local_shell_on_pro(monkeypatch) -> None:
+def test_run_prod_python_prefers_local_database_url(monkeypatch) -> None:
     calls = []
+    monkeypatch.setenv("DATABASE_URL_LOCAL", "postgresql://local/test")
+    monkeypatch.delenv("EXPIRY_ALERTER_DATABASE_URL", raising=False)
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return CompletedProcess(cmd, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(expiry.subprocess, "run", fake_run)
+
+    result = expiry._run_prod_python("abc", timeout_s=7)
+
+    assert result.returncode == 0
+    assert calls[0][0][:2] == [sys.executable, "-c"]
+    assert calls[0][1]["env"]["DATABASE_URL"] == "postgresql://local/test"
+    assert calls[0][1]["timeout"] == 7
+
+
+def test_run_prod_python_uses_local_fly_fallback_on_pro(monkeypatch) -> None:
+    calls = []
+    monkeypatch.delenv("DATABASE_URL_LOCAL", raising=False)
+    monkeypatch.delenv("EXPIRY_ALERTER_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.setattr(expiry, "SSH_HOST", "pro")
     monkeypatch.setattr(expiry.socket, "gethostname", lambda: "Nuzantara")
     monkeypatch.setattr(expiry.socket, "getfqdn", lambda: "Nuzantara.local")
@@ -96,7 +118,7 @@ def test_run_fly_console_python_uses_local_shell_on_pro(monkeypatch) -> None:
 
     monkeypatch.setattr(expiry.subprocess, "run", fake_run)
 
-    result = expiry._run_fly_console_python("abc", timeout_s=7)
+    result = expiry._run_prod_python("abc", timeout_s=7)
 
     assert result.returncode == 0
     assert calls[0][0][0] == "fly"

--- a/scripts/tests/test_expiry_alerter.py
+++ b/scripts/tests/test_expiry_alerter.py
@@ -2,6 +2,9 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
 
 _MOD_PATH = Path(__file__).resolve().parents[1] / "expiry_alerter.py"
 _spec = importlib.util.spec_from_file_location("expiry_alerter", _MOD_PATH)
@@ -59,3 +62,43 @@ def test_main_writes_heartbeat_when_no_items_are_urgent(monkeypatch, tmp_path, c
     heartbeat = _read_heartbeat(tmp_path)
     assert heartbeat["job"] == "expiry_alerter"
     assert heartbeat["status"] == "ok"
+
+
+def test_main_fails_closed_when_query_fails(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["expiry_alerter.py"])
+    monkeypatch.setattr(expiry, "_load_env", lambda: {})
+
+    def fail_query() -> list[dict]:
+        raise expiry.ExpiryAlerterError("Query failed: auth denied")
+
+    monkeypatch.setattr(expiry, "_query_expiries", fail_query)
+
+    with pytest.raises(SystemExit) as exc_info:
+        expiry.main()
+
+    assert exc_info.value.code == 1
+    assert "Expiry alerter failed: Query failed: auth denied" in capsys.readouterr().err
+    heartbeat = _read_heartbeat(tmp_path)
+    assert heartbeat["job"] == "expiry_alerter"
+    assert heartbeat["status"] == "failed"
+
+
+def test_run_fly_console_python_uses_local_shell_on_pro(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(expiry, "SSH_HOST", "pro")
+    monkeypatch.setattr(expiry.socket, "gethostname", lambda: "Nuzantara")
+    monkeypatch.setattr(expiry.socket, "getfqdn", lambda: "Nuzantara.local")
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return CompletedProcess(cmd, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(expiry.subprocess, "run", fake_run)
+
+    result = expiry._run_fly_console_python("abc", timeout_s=7)
+
+    assert result.returncode == 0
+    assert calls[0][0][0] == "fly"
+    assert "ssh" in calls[0][0]
+    assert calls[0][1]["timeout"] == 7


### PR DESCRIPTION
## Summary
- write the expiry alerter heartbeat on no-expiry and no-urgent early exits
- fail closed on CRM query errors instead of reporting false no-expiry success
- query expiries through the local database proxy when DATABASE_URL_LOCAL is available
- add a bash-native fallback when cron-wrapper runs without timeout/gtimeout
- add regression tests for stale-state, query failure, DB-local runner, and wrapper fallback branches

## Tests
- /Users/balizero/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_cron_wrapper.py scripts/tests/test_expiry_alerter.py scripts/tests/test_healer_run_checks.py scripts/tests/test_healer_receptor_running_status.py -q
- /Users/balizero/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m py_compile scripts/expiry_alerter.py scripts/tests/test_expiry_alerter.py scripts/tests/test_cron_wrapper.py
- bash -n scripts/cron-wrapper.sh
- /Users/balizero/Desktop/nuzantara/apps/backend-rag/.venv/bin/python scripts/docs_sync.py --check --quiet
- Mini: /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_cron_wrapper.py scripts/tests/test_expiry_alerter.py scripts/tests/test_healer_run_checks.py scripts/tests/test_healer_receptor_running_status.py -q
- Mini: /Users/nuzantara/Desktop/nuzantara/apps/backend-rag/.venv/bin/python scripts/docs_sync.py --check --quiet
- Pro live dry-run: /Users/nuzantara/scripts/openclaw-cron/renewal-alerts.sh --dry-run --verbose