### PR TITLE
feat(mouth): tokenize dashboard chart palette (--bz-chart-*) + kebab a11y

### DIFF
--- a/apps/mouth/src/app/(workspace)/dashboard/page.tsx
+++ b/apps/mouth/src/app/(workspace)/dashboard/page.tsx
@@ -37,15 +37,15 @@ import { RefreshCw } from "lucide-react";
 
 // ── Category colors ────────────────────────────────────────
 const CATEGORY_COLOR: Record<string, string> = {
-  visas: "#4a8ec4",
-  business: "#5cb88a",
-  taxes: "#b89a40",
-  property: "#9880d8",
-  living: "#d4845a",
-  emerging_trends: "#4ab8c4",
+  visas: "var(--bz-chart-1)",
+  business: "var(--bz-chart-2)",
+  taxes: "var(--bz-chart-3)",
+  property: "var(--bz-chart-4)",
+  living: "var(--bz-chart-5)",
+  emerging_trends: "var(--bz-chart-6)",
 };
 function getCategoryColor(cat: string): string {
-  return CATEGORY_COLOR[cat] ?? "#9880d8";
+  return CATEGORY_COLOR[cat] ?? "var(--bz-chart-4)";
 }
 
 interface IntelArticle {
@@ -101,7 +101,7 @@ function IntakeReviewBanner() {
         border: "1px solid rgba(212,132,90,0.25)",
       }}
     >
-      <FileText size={14} style={{ color: "#d4845a" }} />
+      <FileText size={14} style={{ color: "var(--bz-chart-5)" }} />
       <div className="flex-1 min-w-0">
         <p className="text-[11px] font-semibold text-white/80">
           {count} document{count === 1 ? "" : "s"} waiting for your review
@@ -112,7 +112,10 @@ function IntakeReviewBanner() {
       </div>
       <span
         className="text-[10px] font-bold tabular-nums px-2 py-0.5 rounded-full"
-        style={{ background: "rgba(212,132,90,0.18)", color: "#d4845a" }}
+        style={{
+          background: "rgba(212,132,90,0.18)",
+          color: "var(--bz-chart-5)",
+        }}
       >
         {count}
       </span>
@@ -191,11 +194,11 @@ function useTeamStats(enabled: boolean) {
 
 // ── Status config for practices ───────────────────────────
 const STATUS_CONFIG = {
-  inquiry: { label: "Inquiry", dot: "#9ca3af" },
-  quotation: { label: "Quotation", dot: "#b89a40" },
-  in_progress: { label: "In Progress", dot: "#4a8ec4" },
-  documents: { label: "Documents", dot: "#b89a40" },
-  completed: { label: "Completed", dot: "#5cb88a" },
+  inquiry: { label: "Inquiry", dot: "var(--bz-chart-8)" },
+  quotation: { label: "Quotation", dot: "var(--bz-chart-3)" },
+  in_progress: { label: "In Progress", dot: "var(--bz-chart-1)" },
+  documents: { label: "Documents", dot: "var(--bz-chart-3)" },
+  completed: { label: "Completed", dot: "var(--bz-chart-2)" },
 } as const;
 
 // ── Metric Bar item ────────────────────────────────────────
@@ -280,9 +283,9 @@ function PipelineRow({ p }: { p: CasePreview }) {
         className="text-[9px] font-semibold tabular-nums whitespace-nowrap flex items-center gap-1"
         style={{
           color: isExpired
-            ? "#c45c78"
+            ? "var(--bz-chart-7)"
             : isUrgent
-              ? "#b89a40"
+              ? "var(--bz-chart-3)"
               : "rgba(255,255,255,0.25)",
         }}
       >
@@ -518,7 +521,7 @@ export default function DashboardPage() {
                 formatIDRCompact(revenue.paid_revenue),
               )
             : "—",
-          accent: "#9880d8",
+          accent: "var(--bz-chart-4)",
         },
         {
           label: "Outstanding",
@@ -526,14 +529,14 @@ export default function DashboardPage() {
             ? formatIDRCompact(revenue.outstanding_revenue)
             : "—",
           sub: STRINGS.dashboard.outstandingSub,
-          accent: "#d4845a",
+          accent: "var(--bz-chart-5)",
         },
         {
           label: STRINGS.dashboard.clientsLabel,
           value:
             totalClients != null ? totalClients.toLocaleString("en-US") : "—",
           sub: STRINGS.dashboard.clientsSub,
-          accent: "#4a8ec4",
+          accent: "var(--bz-chart-1)",
           href: "/clients",
         },
         {
@@ -543,7 +546,7 @@ export default function DashboardPage() {
             stats.activeCases,
             stats.criticalDeadlines,
           ),
-          accent: "#5cb88a",
+          accent: "var(--bz-chart-2)",
           href: "/process",
         },
         {
@@ -553,7 +556,7 @@ export default function DashboardPage() {
             stats.pendingInvoices > 0
               ? STRINGS.dashboard.invoicesPendingSub
               : STRINGS.dashboard.invoicesPaidSub,
-          accent: "#b89a40",
+          accent: "var(--bz-chart-3)",
         },
       ]
     : [
@@ -561,26 +564,26 @@ export default function DashboardPage() {
           label: "My Cases",
           value: stats.activeCases,
           sub: "assigned",
-          accent: "#5cb88a",
+          accent: "var(--bz-chart-2)",
           href: "/process",
         },
         {
           label: "Stalled",
           value: stats.criticalDeadlines,
           sub: ">14 days",
-          accent: "#c45c78",
+          accent: "var(--bz-chart-7)",
         },
         {
           label: "Invoices",
           value: stats.pendingInvoices > 0 ? stats.pendingInvoices : "—",
           sub: "pending",
-          accent: "#b89a40",
+          accent: "var(--bz-chart-3)",
         },
         {
           label: "Unread",
           value: stats.whatsappUnread + stats.emailUnread,
           sub: "messages",
-          accent: "#4a8ec4",
+          accent: "var(--bz-chart-1)",
         },
       ];
 

--- a/apps/mouth/src/app/(workspace)/process/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/page.tsx
@@ -1360,6 +1360,8 @@ export default function PratichePage() {
                                     onClick={(e) =>
                                       handleMenuClick(e, practice)
                                     }
+                                    title="More options"
+                                    aria-label="More options"
                                   >
                                     <MoreVertical className="w-4 h-4" />
                                   </button>

--- a/packages/design-system/tokens/bz-tokens.css
+++ b/packages/design-system/tokens/bz-tokens.css
@@ -12,7 +12,7 @@
 
   /* Navy scale */
   --bz-navy-950: #040a10;
-  --bz-navy-900: #060D14;
+  --bz-navy-900: #060d14;
   --bz-navy-800: #0c1f3a;
   --bz-navy-700: #1d273b;
 
@@ -26,12 +26,12 @@
   --bz-copper: #d4845a;
   --bz-copper-hover: #c07348;
   --bz-copper-deep: #b5633a;
-  --bz-gold: #D4A853;
+  --bz-gold: #d4a853;
   --bz-amber: #e8a849;
   --bz-warm: #c9a96e;
 
   /* Cool accents */
-  --bz-blue: #2E6FD4;
+  --bz-blue: #2e6fd4;
   --bz-blue-light: #4a87e8;
   --bz-periwinkle: #8b9cf7;
   --bz-cool: #5e7fb5;
@@ -49,8 +49,24 @@
   --bz-warning: #d4923a;
   --bz-error: #d95f5a;
 
+  /* Chart / categorical series (numbered, NOT status semantics —
+     used for dashboard category dots, stat accents, chart series.
+     Dark defaults = exact hex already in use on the dashboard;
+     do not recolor, only tokenize. All ≥3:1 vs navy card bg
+     (WCAG AA graphical-object threshold). */
+  --bz-chart-1: #4a8ec4; /* blue — visas / in_progress / clients stat */
+  --bz-chart-2: #5cb88a; /* green — business / completed / cases stat */
+  --bz-chart-3: #b89a40; /* gold — taxes / quotation-documents / invoices stat */
+  --bz-chart-4: #9880d8; /* purple — property / revenue stat / category fallback */
+  --bz-chart-5: var(
+    --bz-copper
+  ); /* copper — living (same hue as brand accent) */
+  --bz-chart-6: #4ab8c4; /* teal — emerging_trends */
+  --bz-chart-7: #c45c78; /* rose — expired / stalled */
+  --bz-chart-8: #9ca3af; /* gray — inquiry (neutral status dot) */
+
   /* Cream (marketing) */
-  --bz-cream: #F2EDE6;
+  --bz-cream: #f2ede6;
 
   /* Layout constants */
   --bz-sidebar-width: 216px;
@@ -105,17 +121,13 @@
 
   /* Shadows */
   --bz-shadow-card:
-    0 1px 2px rgba(0, 0, 0, 0.2),
-    0 4px 16px rgba(0, 0, 0, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.2), 0 4px 16px rgba(0, 0, 0, 0.12),
     0 0 0 1px var(--bz-border);
   --bz-shadow-card-hover:
-    0 4px 12px rgba(0, 0, 0, 0.2),
-    0 16px 40px rgba(0, 0, 0, 0.15),
-    0 0 0 1px var(--bz-border-hover),
-    0 0 30px rgba(212, 132, 90, 0.04);
+    0 4px 12px rgba(0, 0, 0, 0.2), 0 16px 40px rgba(0, 0, 0, 0.15),
+    0 0 0 1px var(--bz-border-hover), 0 0 30px rgba(212, 132, 90, 0.04);
   --bz-shadow-glow:
-    0 0 20px rgba(212, 132, 90, 0.15),
-    0 0 60px rgba(212, 132, 90, 0.05);
+    0 0 20px rgba(212, 132, 90, 0.15), 0 0 60px rgba(212, 132, 90, 0.05);
 
   /* Color scheme */
   color-scheme: dark;
@@ -135,9 +147,9 @@
 
   /* Text — WCAG AA verified: all >=4.5:1 on #f5f6f8 */
   --bz-text-pure: #000000;
-  --bz-text-primary: #1a1a2e;        /* 13.9:1 on #f5f6f8 */
-  --bz-text-secondary: #4a4a6a;      /* 5.8:1 on #f5f6f8 */
-  --bz-text-muted: #6b6b85;          /* 4.5:1 on #f5f6f8 */
+  --bz-text-primary: #1a1a2e; /* 13.9:1 on #f5f6f8 */
+  --bz-text-secondary: #4a4a6a; /* 5.8:1 on #f5f6f8 */
+  --bz-text-muted: #6b6b85; /* 4.5:1 on #f5f6f8 */
   --bz-text-1: #2a2520;
   --bz-text-2: #6b6560;
   --bz-text-3: #9a9590;
@@ -163,19 +175,30 @@
   --bz-sidebar-active-bg: rgba(181, 99, 58, 0.08);
   --bz-sidebar-active-border: rgba(181, 99, 58, 0.3);
 
+  /* Chart / categorical series — darkened for AA graphical-object
+     contrast (>=3:1) on white card bg (#fff / rgba(255,255,255,.9)).
+     Computed via WCAG relative-luminance darken-by-value + slight
+     saturation boost; verified empirically (contrast ratios below). */
+  --bz-chart-1: #4a8ec4; /* 3.52:1 — already passes, unchanged */
+  --bz-chart-2: #4ba478; /* darkened from #5cb88a, 3.05:1 */
+  --bz-chart-3: #af9034; /* darkened from #b89a40, 3.06:1 */
+  --bz-chart-4: #9880d8; /* 3.27:1 — already passes, unchanged */
+  --bz-chart-5: var(
+    --bz-copper-deep
+  ); /* 4.37:1 — reuses existing light-accent token */
+  --bz-chart-6: #39a1ac; /* darkened from #4ab8c4, 3.06:1 */
+  --bz-chart-7: #c45c78; /* 4.08:1 — already passes, unchanged */
+  --bz-chart-8: #8e95a1; /* darkened from #9ca3af, 3.02:1 */
+
   /* Shadows */
   --bz-shadow-card:
-    0 1px 2px rgba(0, 0, 0, 0.06),
-    0 4px 16px rgba(0, 0, 0, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.06), 0 4px 16px rgba(0, 0, 0, 0.04),
     0 0 0 1px var(--bz-border);
   --bz-shadow-card-hover:
-    0 4px 12px rgba(0, 0, 0, 0.08),
-    0 16px 40px rgba(0, 0, 0, 0.06),
-    0 0 0 1px var(--bz-border-hover),
-    0 0 30px rgba(181, 99, 58, 0.04);
+    0 4px 12px rgba(0, 0, 0, 0.08), 0 16px 40px rgba(0, 0, 0, 0.06),
+    0 0 0 1px var(--bz-border-hover), 0 0 30px rgba(181, 99, 58, 0.04);
   --bz-shadow-glow:
-    0 0 20px rgba(181, 99, 58, 0.1),
-    0 0 60px rgba(181, 99, 58, 0.03);
+    0 0 20px rgba(181, 99, 58, 0.1), 0 0 60px rgba(181, 99, 58, 0.03);
 
   /* Color scheme */
   color-scheme: light;


### PR DESCRIPTION
## What
CRM frontend UI/UX hardening (GEAR-3 mandate, "UI/UX da fare invidia" prong).

**Prong A — chart-palette tokenization.** `dashboard/page.tsx` had 8 distinct hardcoded hex forming a bespoke chart/category palette (NOT status semantics — mapping them to error/success/warning would be wrong). Introduced a `--bz-chart-1..8` semantic token family in `packages/design-system/tokens/bz-tokens.css`, defined in BOTH `:root` (dark) and `[data-theme="light"]`:
- Dark defaults are byte-identical to the original hex → **zero visual change on dark theme**.
- Light-theme values darkened where needed to clear the WCAG 3:1 graphical-object AA threshold on white card bg (ratios documented inline).
- `dashboard/page.tsx` now has zero raw hex; 25 `var(--bz-chart-*)` references.

**Scope**: analytics/intelligence pages use different palette mechanisms (Tailwind arbitrary classes / per-card branding accents), not the same categorical class → left untouched, per class-audit discipline.

**Prong B — a11y.** The kanban-card kebab menu (`MoreVertical` icon) in `process/page.tsx` had no accessible label → added `aria-label`/`title="More options"` matching the identical list-view button. Clients page audited: already fully instrumented, zero changes needed.

## Verify
- `cd apps/mouth && npm run typecheck` (tsc --noEmit) → 0 errors
- eslint (root-hoisted v9 binary) → 0 errors, 3 pre-existing warnings (none on touched lines)
- Pre-commit hook passed; zero raw hex remain in touched files.

The CRM design system (copper+navy) stays deliberately distinct from the marketing brand (antracite/yellow/red) — not unified.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>