### PR TITLE
fix(infra): stop launchd_liveness crying wolf on stale sticky exit codes

### DIFF
--- a/scripts/launchd_liveness_detector.py
+++ b/scripts/launchd_liveness_detector.py
@@ -86,6 +86,19 @@ STALE_GREEN_SEC = 3 * 24 * 3600
 # fresh and the gate never hides a live failure.
 MARKER_FRESH_SEC = int(os.environ.get("W84_MARKER_FRESH_SEC", str(48 * 3600)))
 
+# Healer tick 2026-07-10: LastExitStatus is STICKY — launchd keeps reporting the
+# PREVIOUS incarnation's exit code for as long as the CURRENT incarnation keeps
+# running (a SIGTERM at sleep/wake, or a crash years ago, never clears itself).
+# A job that died once and has been alive+quiet ever since was reported
+# FAILING-HONESTLY forever, off evidence that predates its current run. Live
+# proof: mlx-server (4d11h uptime, serving /v1/models), fly-pg-tunnel.local
+# (16d uptime, port 15432 accepting connections), local-livekit-server (16d
+# uptime, port 7880 answering 200) — all three FAILING-HONESTLY, all three
+# demonstrably alive and serving. RECOVERED requires the SAME window on BOTH
+# signals (see _classify) so a genuinely still-broken job — log actively
+# re-writing fresh errors, stale_green stays False — is never masked.
+UPTIME_STABLE_SEC = int(os.environ.get("W84_UPTIME_STABLE_SEC", str(STALE_GREEN_SEC)))
+
 
 def _launchctl_status(label: str) -> dict | None:
     """Return the parsed `launchctl list <label>` dict, or None if not loaded."""
@@ -217,6 +230,87 @@ def _newest_log_mtime(paths: list[Path]) -> float | None:
     return mt
 
 
+def _parse_etime(raw: str) -> float | None:
+    """Parse `ps -o etime=` output: `[[DD-]HH:]MM:SS`. Pure, no subprocess."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    days = 0
+    if "-" in raw:
+        day_part, raw = raw.split("-", 1)
+        try:
+            days = int(day_part)
+        except ValueError:
+            return None
+    bits = raw.split(":")
+    try:
+        nums = [int(b) for b in bits]
+    except ValueError:
+        return None
+    if len(nums) == 3:
+        h, m, s = nums
+    elif len(nums) == 2:
+        h, m, s = 0, nums[0], nums[1]
+    elif len(nums) == 1:
+        h, m, s = 0, 0, nums[0]
+    else:
+        return None
+    return float(days * 86400 + h * 3600 + m * 60 + s)
+
+
+def _process_uptime_seconds(pid: int) -> float | None:
+    """Seconds `pid` has been continuously running, via `ps -o etime=`.
+    None if the PID doesn't exist or the output can't be parsed."""
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "etime="],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if out.returncode != 0:
+        return None
+    return _parse_etime(out.stdout)
+
+
+def _classify(
+    *,
+    status: dict | None,
+    marker: str | None,
+    prog_exists: bool,
+    stale_green: bool,
+    uptime_sec: float | None,
+) -> str:
+    """Pure classification — exit-code x log-content x process-uptime.
+
+    RECOVERED only fires when BOTH the process has been alive longer than
+    UPTIME_STABLE_SEC AND the log has been quiet that same window (stale_green).
+    Either signal alone is not enough: a job that just restarted (short uptime)
+    might still be crash-looping, and a job with a fresh log full of new errors
+    (stale_green False) is a live finding no matter how long its PID has run.
+    """
+    if status is None:
+        return "NOT-LOADED"
+    exit_code = status.get("LastExitStatus")
+    pid = status.get("PID")
+    if marker and exit_code == 0:
+        return "DEAD-GREEN"          # the W84 vector: green lies
+    if marker and exit_code not in (0, None):
+        return "DEAD-NONZERO"        # honest non-zero + proven launch failure
+    if exit_code not in (0, None):
+        if (
+            pid is not None
+            and stale_green
+            and uptime_sec is not None
+            and uptime_sec > UPTIME_STABLE_SEC
+        ):
+            return "RECOVERED"       # sticky exit code, provably alive+quiet since
+        return "FAILING-HONESTLY"    # non-zero, no marker, no recovery proof
+    if not prog_exists:
+        return "ARMED-TO-NOTHING"    # plist points at a missing script
+    return "OK"
+
+
 def audit() -> list[dict]:
     findings: list[dict] = []
     if not LAUNCHAGENTS.exists():
@@ -233,22 +327,16 @@ def audit() -> list[dict]:
         prog_exists = bool(prog and Path(os.path.expanduser(prog)).exists())
         newest = _newest_log_mtime(logs)
         stale_green = newest is not None and (now - newest) > STALE_GREEN_SEC
+        pid = (status or {}).get("PID")
+        uptime_sec = _process_uptime_seconds(pid) if pid is not None else None
 
-        # Classification — the whole point: cross exit-code with log content.
-        if status is None:
-            verdict = "NOT-LOADED"   # plist on disk, not in launchd domain
-        else:
-            exit_code = status.get("LastExitStatus")
-            if marker and exit_code == 0:
-                verdict = "DEAD-GREEN"          # the W84 vector: green lies
-            elif marker and exit_code not in (0, None):
-                verdict = "DEAD-NONZERO"        # honest non-zero + proven launch failure
-            elif exit_code not in (0, None):
-                verdict = "FAILING-HONESTLY"    # non-zero, no launch-failure marker (real finding, NOT cry-wolf)
-            elif not prog_exists:
-                verdict = "ARMED-TO-NOTHING"    # plist points at a missing script
-            else:
-                verdict = "OK"
+        # Classification — the whole point: cross exit-code with log content
+        # AND (2026-07-10) process uptime, so a sticky historical exit code
+        # doesn't outlive the incarnation that produced it. See _classify.
+        verdict = _classify(
+            status=status, marker=marker, prog_exists=prog_exists,
+            stale_green=stale_green, uptime_sec=uptime_sec,
+        )
 
         findings.append({
             "label": label,
@@ -308,7 +396,12 @@ def main() -> int:
         else:
             print(f"launchd liveness detector — {len(findings)} job(s), {len(alarms)} alarm(s):\n")
             for f in findings:
-                flag = "🚨" if f["verdict"] in ALARM_VERDICTS else ("⚠️ " if f["verdict"] == "FAILING-HONESTLY" else "✓ ")
+                flag = (
+                    "🚨" if f["verdict"] in ALARM_VERDICTS
+                    else "⚠️ " if f["verdict"] == "FAILING-HONESTLY"
+                    else "♻️ " if f["verdict"] == "RECOVERED"
+                    else "✓ "
+                )
                 print(f"  {flag} {f['verdict']:<17} {f['label']}  (exit={f['last_exit']})")
                 if f["log_marker"]:
                     print(f"        ↳ log proves launch failure: {f['log_marker']}")

--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -391,7 +391,7 @@ DEFAULT_REGISTRY: list[dict] = [
         "boundary": "launchd exit-code <-> payload log content (W84)",
         "machines": ["all"], "tags": ["launchd"], "timeout_sec": 60,
         "severity": "P1", "parse": "findings_list", "unwrap_key": "findings",
-        "verdict_key": "verdict", "ok_values": ["OK", "NOT-LOADED"],
+        "verdict_key": "verdict", "ok_values": ["OK", "NOT-LOADED", "RECOVERED"],
         "fix_hint": "read the job's real log; DEAD-GREEN = TCC re-grant (operator); ARMED-TO-NOTHING = retire or repoint the plist",
     },
     {

--- a/scripts/tests/test_launchd_liveness_stale_exit_recovery.py
+++ b/scripts/tests/test_launchd_liveness_stale_exit_recovery.py
@@ -1,0 +1,181 @@
+"""Healer tick 2026-07-10: LastExitStatus is STICKY — launchd keeps reporting a
+job's PREVIOUS incarnation's exit code for as long as the CURRENT incarnation
+keeps running. Live proof the same tick: mlx-server (4d11h uptime, serving
+/v1/models), fly-pg-tunnel.local (16d uptime, port 15432 accepting
+connections), local-livekit-server (16d uptime, port 7880 answering 200) were
+ALL reported FAILING-HONESTLY off an exit code that predates their current run.
+
+Contract under test (_classify / _parse_etime / _process_uptime_seconds):
+  - a non-zero exit with a currently-running PID, long uptime, AND a quiet
+    (stale) log -> RECOVERED (both signals required)
+  - short uptime (just restarted, could still be crash-looping) -> stays
+    FAILING-HONESTLY
+  - fresh log (actively re-writing errors) -> stays FAILING-HONESTLY even with
+    long uptime — a genuinely still-broken long-lived job is never masked
+  - no PID (not currently running) -> stays FAILING-HONESTLY, can't claim
+    "alive since"
+  - a launch-failure marker still wins DEAD-GREEN/DEAD-NONZERO regardless of
+    uptime — this change only touches the marker-less branch
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "launchd_liveness_detector.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("launchd_liveness_detector", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------- _parse_etime
+
+def test_parse_etime_seconds_only():
+    mod = _load_module()
+    assert mod._parse_etime("45") == 45.0
+
+
+def test_parse_etime_mmss():
+    mod = _load_module()
+    assert mod._parse_etime("02:30") == 150.0
+
+
+def test_parse_etime_hhmmss():
+    mod = _load_module()
+    assert mod._parse_etime("01:02:03") == 3723.0
+
+
+def test_parse_etime_days():
+    mod = _load_module()
+    # observed live output for mlx-server this tick
+    assert mod._parse_etime("04-11:26:47") == 4 * 86400 + 11 * 3600 + 26 * 60 + 47
+
+
+def test_parse_etime_invalid_is_none():
+    mod = _load_module()
+    assert mod._parse_etime("") is None
+    assert mod._parse_etime("not-a-time") is None
+    assert mod._parse_etime("1-2-3") is None
+
+
+# ---------------------------------------------------------- _process_uptime_seconds
+
+def test_process_uptime_seconds_live_process():
+    import os
+
+    mod = _load_module()
+    uptime = mod._process_uptime_seconds(os.getpid())
+    assert uptime is not None
+    assert uptime >= 0
+
+
+def test_process_uptime_seconds_unknown_pid_is_none():
+    mod = _load_module()
+    assert mod._process_uptime_seconds(999999) is None
+
+
+# --------------------------------------------------------------------- _classify
+
+def test_recovers_when_uptime_and_log_both_stable(monkeypatch):
+    mod = _load_module()
+    monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
+    verdict = mod._classify(
+        status={"LastExitStatus": 15, "PID": 12345},
+        marker=None, prog_exists=True,
+        stale_green=True, uptime_sec=7200,
+    )
+    assert verdict == "RECOVERED"
+
+
+def test_stays_failing_honestly_when_uptime_too_short(monkeypatch):
+    """A job that JUST restarted could still be crash-looping — short uptime
+    is not proof of recovery even with a quiet log."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
+    verdict = mod._classify(
+        status={"LastExitStatus": 15, "PID": 12345},
+        marker=None, prog_exists=True,
+        stale_green=True, uptime_sec=60,
+    )
+    assert verdict == "FAILING-HONESTLY"
+
+
+def test_stays_failing_honestly_when_log_not_stale(monkeypatch):
+    """A genuinely still-broken long-lived job (actively re-writing fresh
+    errors) must never be masked, no matter how long its PID has run."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
+    verdict = mod._classify(
+        status={"LastExitStatus": 15, "PID": 12345},
+        marker=None, prog_exists=True,
+        stale_green=False, uptime_sec=999999,
+    )
+    assert verdict == "FAILING-HONESTLY"
+
+
+def test_stays_failing_honestly_when_no_pid(monkeypatch):
+    """Not currently running (no PID in launchctl list) — can't claim
+    'provably alive since', even with a stale log."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
+    verdict = mod._classify(
+        status={"LastExitStatus": 15},
+        marker=None, prog_exists=True,
+        stale_green=True, uptime_sec=None,
+    )
+    assert verdict == "FAILING-HONESTLY"
+
+
+def test_marker_still_wins_dead_nonzero_regardless_of_uptime(monkeypatch):
+    """A proven launch-failure marker is a real finding even on a long-lived
+    PID — this change only touches the marker-less branch."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
+    verdict = mod._classify(
+        status={"LastExitStatus": 1, "PID": 12345},
+        marker="bash: /x/y: Operation not permitted", prog_exists=True,
+        stale_green=True, uptime_sec=999999,
+    )
+    assert verdict == "DEAD-NONZERO"
+
+
+def test_marker_still_wins_dead_green_regardless_of_uptime(monkeypatch):
+    mod = _load_module()
+    monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
+    verdict = mod._classify(
+        status={"LastExitStatus": 0, "PID": 12345},
+        marker="bash: /x/y: Operation not permitted", prog_exists=True,
+        stale_green=True, uptime_sec=999999,
+    )
+    assert verdict == "DEAD-GREEN"
+
+
+def test_not_loaded_when_status_none():
+    mod = _load_module()
+    assert mod._classify(
+        status=None, marker=None, prog_exists=True,
+        stale_green=True, uptime_sec=None,
+    ) == "NOT-LOADED"
+
+
+def test_ok_unaffected_by_zero_exit():
+    mod = _load_module()
+    assert mod._classify(
+        status={"LastExitStatus": 0, "PID": 12345},
+        marker=None, prog_exists=True,
+        stale_green=False, uptime_sec=10,
+    ) == "OK"
+
+
+def test_armed_to_nothing_unaffected():
+    mod = _load_module()
+    assert mod._classify(
+        status={"LastExitStatus": 0, "PID": 12345},
+        marker=None, prog_exists=False,
+        stale_green=False, uptime_sec=10,
+    ) == "ARMED-TO-NOTHING"


### PR DESCRIPTION
## Summary
- `launchd_liveness_detector.py` (the W84 vaccine) reports FAILING-HONESTLY off `launchctl`'s `LastExitStatus`, which is STICKY — it keeps reporting a job's PREVIOUS incarnation's exit code for as long as the CURRENT incarnation keeps running.
- Live-verified this tick: `com.balizero.mlx-server` (4d11h uptime, `/v1/models` responds 200), `com.nuzantara.fly-pg-tunnel.local` (16d uptime, port 15432 LISTEN + accepting real connections) were both flagged FAILING-HONESTLY while demonstrably serving traffic. A third, `com.nuzantara.local-livekit-server`, stays correctly flagged since its log is still fresh.
- Adds a `RECOVERED` verdict that fires ONLY when BOTH the process has been alive longer than `UPTIME_STABLE_SEC` (default = existing `STALE_GREEN_SEC`, 3 days) AND its log has been quiet the same window (reusing the `stale_green` field that was already computed but never consulted in classification). Requiring both signals means a genuinely still-broken long-lived job (actively re-writing fresh errors) is never masked.
- Classification logic extracted into a pure `_classify()` function for guilt+innocence unit tests (marker still wins DEAD-GREEN/DEAD-NONZERO regardless of uptime; short uptime or fresh log both keep a job FAILING-HONESTLY).
- `proprioception.py`'s `launchd_liveness` probe gets `RECOVERED` added to `ok_values` so the boundary check stops flagging these organs as diverged.

## Test plan
- [x] `pytest scripts/tests/test_launchd_liveness_stale_exit_recovery.py scripts/tests/test_launchd_liveness_marker_freshness.py` — 20 passed
- [x] `python3 -m py_compile scripts/launchd_liveness_detector.py scripts/proprioception.py`
- [x] Live run on Mini: `python3 scripts/launchd_liveness_detector.py` — mlx-server and fly-pg-tunnel.local now `RECOVERED`, local-livekit-server correctly stays `FAILING-HONESTLY`
- [x] Live run: `python3 scripts/proprioception.py --json --no-fetch` — `launchd_liveness` findings dropped 3 → 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)