### PR TITLE
fix(infra): stop hiding RECOVERED on chatty-but-healthy launchd jobs

### DIFF
--- a/scripts/launchd_liveness_detector.py
+++ b/scripts/launchd_liveness_detector.py
@@ -92,11 +92,24 @@ MARKER_FRESH_SEC = int(os.environ.get("W84_MARKER_FRESH_SEC", str(48 * 3600)))
 # A job that died once and has been alive+quiet ever since was reported
 # FAILING-HONESTLY forever, off evidence that predates its current run. Live
 # proof: mlx-server (4d11h uptime, serving /v1/models), fly-pg-tunnel.local
-# (16d uptime, port 15432 accepting connections), local-livekit-server (16d
-# uptime, port 7880 answering 200) — all three FAILING-HONESTLY, all three
-# demonstrably alive and serving. RECOVERED requires the SAME window on BOTH
-# signals (see _classify) so a genuinely still-broken job — log actively
-# re-writing fresh errors, stale_green stays False — is never masked.
+# (16d uptime, port 15432 accepting connections) — both FAILING-HONESTLY,
+# both demonstrably alive and serving. RECOVERED requires a stable uptime
+# (see _classify) so a job that JUST restarted (could still be crash-looping)
+# is never masked.
+#
+# Healer tick 2026-07-10 (same day, second pass): the FIRST version of this
+# fix additionally required `stale_green` (log quiet for STALE_GREEN_SEC) on
+# the theory that "log actively re-writing" meant "actively re-writing fresh
+# ERRORS". False: stale_green only measures ANY log write, not a failure one.
+# local-livekit-server (16d uptime, port 7880 answering 200) logs benign
+# periodic "high cpu load" INFO lines every few hours — its log is NEVER
+# stale, so it stayed FAILING-HONESTLY forever despite being provably healthy.
+# The real "no active failure" signal already exists: `marker is None`, which
+# _log_has_failure_marker gates on its OWN freshness window (MARKER_FRESH_SEC,
+# 48h) and only matches known launch-failure signatures. By the time
+# `_classify` reaches the RECOVERED branch, marker is already guaranteed None
+# (the marker-present branches return earlier) — stale_green added no real
+# protection beyond that, only false negatives for chatty-but-healthy jobs.
 UPTIME_STABLE_SEC = int(os.environ.get("W84_UPTIME_STABLE_SEC", str(STALE_GREEN_SEC)))
 
 
@@ -278,16 +291,18 @@ def _classify(
     status: dict | None,
     marker: str | None,
     prog_exists: bool,
-    stale_green: bool,
     uptime_sec: float | None,
 ) -> str:
     """Pure classification — exit-code x log-content x process-uptime.
 
-    RECOVERED only fires when BOTH the process has been alive longer than
-    UPTIME_STABLE_SEC AND the log has been quiet that same window (stale_green).
-    Either signal alone is not enough: a job that just restarted (short uptime)
-    might still be crash-looping, and a job with a fresh log full of new errors
-    (stale_green False) is a live finding no matter how long its PID has run.
+    RECOVERED fires when the process has been alive longer than
+    UPTIME_STABLE_SEC with NO failure marker. Marker is already guaranteed
+    None by the time we reach this branch (the marker-present branches above
+    return first), and `_log_has_failure_marker` has its own freshness gate
+    (MARKER_FRESH_SEC) — so "no marker" already means "no known launch-failure
+    signature in the recent log", independent of how chatty the log is.
+    Short uptime alone still blocks RECOVERED: a job that just restarted
+    could still be crash-looping regardless of log content.
     """
     if status is None:
         return "NOT-LOADED"
@@ -300,11 +315,10 @@ def _classify(
     if exit_code not in (0, None):
         if (
             pid is not None
-            and stale_green
             and uptime_sec is not None
             and uptime_sec > UPTIME_STABLE_SEC
         ):
-            return "RECOVERED"       # sticky exit code, provably alive+quiet since
+            return "RECOVERED"       # sticky exit code, provably alive since
         return "FAILING-HONESTLY"    # non-zero, no marker, no recovery proof
     if not prog_exists:
         return "ARMED-TO-NOTHING"    # plist points at a missing script
@@ -335,7 +349,7 @@ def audit() -> list[dict]:
         # doesn't outlive the incarnation that produced it. See _classify.
         verdict = _classify(
             status=status, marker=marker, prog_exists=prog_exists,
-            stale_green=stale_green, uptime_sec=uptime_sec,
+            uptime_sec=uptime_sec,
         )
 
         findings.append({

--- a/scripts/tests/test_launchd_liveness_stale_exit_recovery.py
+++ b/scripts/tests/test_launchd_liveness_stale_exit_recovery.py
@@ -2,16 +2,27 @@
 job's PREVIOUS incarnation's exit code for as long as the CURRENT incarnation
 keeps running. Live proof the same tick: mlx-server (4d11h uptime, serving
 /v1/models), fly-pg-tunnel.local (16d uptime, port 15432 accepting
-connections), local-livekit-server (16d uptime, port 7880 answering 200) were
-ALL reported FAILING-HONESTLY off an exit code that predates their current run.
+connections) were reported FAILING-HONESTLY off an exit code that predates
+their current run.
+
+Healer tick 2026-07-10 (second pass, same day): the first version of this fix
+also required `stale_green` (log quiet for STALE_GREEN_SEC) on the theory that
+"log actively re-writing" meant "actively re-writing fresh ERRORS". False:
+stale_green only measures ANY log write. local-livekit-server (16d uptime,
+port 7880 answering 200) logs benign periodic "high cpu load" INFO lines every
+few hours — never stale — so it stayed FAILING-HONESTLY despite being
+provably healthy. Dropped stale_green from `_classify`: by the time the
+RECOVERED branch is reached, `marker` is already guaranteed None (the
+marker-present branches return earlier), and `_log_has_failure_marker` has its
+own freshness gate — so "no marker" already means "no known failure signature
+in the recent log", independent of how chatty the log is.
 
 Contract under test (_classify / _parse_etime / _process_uptime_seconds):
-  - a non-zero exit with a currently-running PID, long uptime, AND a quiet
-    (stale) log -> RECOVERED (both signals required)
+  - a non-zero exit with a currently-running PID and long uptime -> RECOVERED,
+    regardless of how chatty (non-stale) its log is, as long as no failure
+    marker was found
   - short uptime (just restarted, could still be crash-looping) -> stays
-    FAILING-HONESTLY
-  - fresh log (actively re-writing errors) -> stays FAILING-HONESTLY even with
-    long uptime — a genuinely still-broken long-lived job is never masked
+    FAILING-HONESTLY even with a long-quiet log
   - no PID (not currently running) -> stays FAILING-HONESTLY, can't claim
     "alive since"
   - a launch-failure marker still wins DEAD-GREEN/DEAD-NONZERO regardless of
@@ -81,52 +92,54 @@ def test_process_uptime_seconds_unknown_pid_is_none():
 
 # --------------------------------------------------------------------- _classify
 
-def test_recovers_when_uptime_and_log_both_stable(monkeypatch):
+def test_recovers_when_uptime_stable_and_log_quiet(monkeypatch):
     mod = _load_module()
     monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
     verdict = mod._classify(
         status={"LastExitStatus": 15, "PID": 12345},
         marker=None, prog_exists=True,
-        stale_green=True, uptime_sec=7200,
+        uptime_sec=7200,
+    )
+    assert verdict == "RECOVERED"
+
+
+def test_recovers_even_when_log_is_chatty_but_marker_free(monkeypatch):
+    """The real bug this tick: local-livekit-server logs benign periodic INFO
+    lines (never stale) while being provably healthy (16d uptime, port 7880
+    answering 200). No failure marker in the log + long uptime is proof
+    enough — chattiness alone must not block RECOVERED."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
+    verdict = mod._classify(
+        status={"LastExitStatus": 15, "PID": 12345},
+        marker=None, prog_exists=True,
+        uptime_sec=999999,
     )
     assert verdict == "RECOVERED"
 
 
 def test_stays_failing_honestly_when_uptime_too_short(monkeypatch):
     """A job that JUST restarted could still be crash-looping — short uptime
-    is not proof of recovery even with a quiet log."""
+    is not proof of recovery."""
     mod = _load_module()
     monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
     verdict = mod._classify(
         status={"LastExitStatus": 15, "PID": 12345},
         marker=None, prog_exists=True,
-        stale_green=True, uptime_sec=60,
-    )
-    assert verdict == "FAILING-HONESTLY"
-
-
-def test_stays_failing_honestly_when_log_not_stale(monkeypatch):
-    """A genuinely still-broken long-lived job (actively re-writing fresh
-    errors) must never be masked, no matter how long its PID has run."""
-    mod = _load_module()
-    monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
-    verdict = mod._classify(
-        status={"LastExitStatus": 15, "PID": 12345},
-        marker=None, prog_exists=True,
-        stale_green=False, uptime_sec=999999,
+        uptime_sec=60,
     )
     assert verdict == "FAILING-HONESTLY"
 
 
 def test_stays_failing_honestly_when_no_pid(monkeypatch):
     """Not currently running (no PID in launchctl list) — can't claim
-    'provably alive since', even with a stale log."""
+    'provably alive since'."""
     mod = _load_module()
     monkeypatch.setattr(mod, "UPTIME_STABLE_SEC", 3600)
     verdict = mod._classify(
         status={"LastExitStatus": 15},
         marker=None, prog_exists=True,
-        stale_green=True, uptime_sec=None,
+        uptime_sec=None,
     )
     assert verdict == "FAILING-HONESTLY"
 
@@ -139,7 +152,7 @@ def test_marker_still_wins_dead_nonzero_regardless_of_uptime(monkeypatch):
     verdict = mod._classify(
         status={"LastExitStatus": 1, "PID": 12345},
         marker="bash: /x/y: Operation not permitted", prog_exists=True,
-        stale_green=True, uptime_sec=999999,
+        uptime_sec=999999,
     )
     assert verdict == "DEAD-NONZERO"
 
@@ -150,7 +163,7 @@ def test_marker_still_wins_dead_green_regardless_of_uptime(monkeypatch):
     verdict = mod._classify(
         status={"LastExitStatus": 0, "PID": 12345},
         marker="bash: /x/y: Operation not permitted", prog_exists=True,
-        stale_green=True, uptime_sec=999999,
+        uptime_sec=999999,
     )
     assert verdict == "DEAD-GREEN"
 
@@ -159,7 +172,7 @@ def test_not_loaded_when_status_none():
     mod = _load_module()
     assert mod._classify(
         status=None, marker=None, prog_exists=True,
-        stale_green=True, uptime_sec=None,
+        uptime_sec=None,
     ) == "NOT-LOADED"
 
 
@@ -168,7 +181,7 @@ def test_ok_unaffected_by_zero_exit():
     assert mod._classify(
         status={"LastExitStatus": 0, "PID": 12345},
         marker=None, prog_exists=True,
-        stale_green=False, uptime_sec=10,
+        uptime_sec=10,
     ) == "OK"
 
 
@@ -177,5 +190,5 @@ def test_armed_to_nothing_unaffected():
     assert mod._classify(
         status={"LastExitStatus": 0, "PID": 12345},
         marker=None, prog_exists=False,
-        stale_green=False, uptime_sec=10,
+        uptime_sec=10,
     ) == "ARMED-TO-NOTHING"


### PR DESCRIPTION
## Summary
- Yesterday's #2195 fix required a quiet log (`stale_green`) before classifying a stuck-exit-code job as `RECOVERED` — but a chatty-and-healthy server (periodic benign INFO logging) never satisfies "quiet", so it stayed `FAILING-HONESTLY` forever.
- Live proof this tick: `com.nuzantara.local-livekit-server` (16d continuous uptime, port 7880 answering) logs benign "high cpu load" INFO lines every few hours and was still flagged `FAILING-HONESTLY` by `proprioception.py` after #2195 merged.
- Root cause: `marker is None` (no known launch-failure signature within `_log_has_failure_marker`'s own 48h freshness window) is already sufficient proof of "no active failure" — `stale_green` added no real protection on top of that, only false negatives for healthy chatty jobs. Dropped it from `_classify`'s `RECOVERED` gate.

## Test plan
- [x] `pytest scripts/tests/test_launchd_liveness_stale_exit_recovery.py scripts/tests/test_launchd_liveness_marker_freshness.py -v` — 20/20 passed, including new `test_recovers_even_when_log_is_chatty_but_marker_free` covering the exact bug.
- [x] Live re-run of `scripts/launchd_liveness_detector.py --json` on Mini-Pro2 post-fix: `com.nuzantara.local-livekit-server` now reports `RECOVERED` (was `FAILING-HONESTLY`).
- [x] `pytest scripts/tests/ -k liveness` — 74 passed, no regressions in adjacent liveness-tier tests.

🤖 Generated with a Mini-Pro2 healer tick — content-verified per SYMBIOSIS W88/W90.