### PR TITLE
fix(infra): exclude Claude Desktop ShipIt updater from overlap-detector

### DIFF
--- a/scripts/mini-migration/overlap-detector.sh
+++ b/scripts/mini-migration/overlap-detector.sh
@@ -50,9 +50,13 @@ telegram_alert() {
 log "=== overlap-detector run ==="
 
 # Pull active labels (with PID, not the dash-prefixed inactive ones)
-# from both machines. We exclude "system" prefixes (com.apple, com.google,
-# homebrew.mxcl) — they're allowed to coexist.
-SYSTEM_FILTER='com\.apple|com\.google|com\.openai|com\.openssh|homebrew\.mxcl|com\.adobe|com\.microsoft'
+# from both machines. We exclude "system"/third-party prefixes (com.apple,
+# com.google, homebrew.mxcl) — they're allowed to coexist. Healer tick
+# 2026-07-10: com.anthropic.claudefordesktop.ShipIt (Claude Desktop's Sparkle
+# auto-update helper) recurred as a false-positive overlap 7x since 2026-05-28
+# — it's a one-shot updater helper checking independently on each machine,
+# not a Nuzantara/mata-garuda organ, and shares no state (#10 does not apply).
+SYSTEM_FILTER='com\.apple|com\.google|com\.openai|com\.openssh|homebrew\.mxcl|com\.adobe|com\.microsoft|com\.anthropic\.claudefordesktop'
 
 # NODE-LOCAL dual-run allowlist (2026-07-06, grounded live — NOT split-brain):
 # these bind LOOPBACK (mlx :8080, livekit API :7880) and serve only their own


### PR DESCRIPTION
## Summary
- `com.anthropic.claudefordesktop.ShipIt` (Claude Desktop's Sparkle auto-update helper) has recurred as a false-positive Pro/Mini overlap 7x since 2026-05-28 (most recently 2026-07-10 09:30 WITA, found live this tick).
- It's a one-shot updater helper each machine checks independently — not a Nuzantara/mata-garuda organ, shares no state, so family #10 (active-active split-brain) doesn't apply. Same bucket as the existing `com.apple`/`com.google`/`homebrew.mxcl` exclusions.
- Added `com\.anthropic\.claudefordesktop` to `SYSTEM_FILTER` in `scripts/mini-migration/overlap-detector.sh`.

## Test plan
- [x] `bash -n scripts/mini-migration/overlap-detector.sh` — syntax OK
- [x] Simulated the new filter against a sample label set (guilt+innocence): `ShipIt` is excluded, `com.balizero.mlx-server` / `com.nuzantara.local-livekit-server` / `com.nuzantara.healer.4h` still pass through untouched.
- [ ] Live proof at next daily 09:30 WITA run once merged AND the HOME copy (`~/scripts/overlap-detector.sh`, declared pair in `infra/home-fork/declared-pairs.json`) is refreshed from repo canon post-merge — will do as a follow-up in the same tick.

🤖 Generated with a Mini-Pro2 healer tick.