### PR TITLE
feat(ux): add MobileNav to visa, property/eligibility, tax-calendar layouts

### DIFF
--- a/apps/mouth/src/app/(tax-calendar)/tax-calendar/layout.tsx
+++ b/apps/mouth/src/app/(tax-calendar)/tax-calendar/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { NavShell, BZLogo } from "@balizero/core";
 import { SessionInit } from "@/components/funnel/SessionInit";
 import { HeaderWhatsAppCTA } from "@/components/funnel/HeaderWhatsAppCTA";
+import { MobileNav } from "@/app/v2/_components/MobileNav";
 import { getFunnelNavItems } from "@/components/funnel/funnel-nav";
 
 export const metadata: Metadata = {
@@ -14,11 +15,14 @@ export default function TaxCalendarLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const navItems = getFunnelNavItems("tax");
+
   return (
     <div className="min-h-screen flex flex-col">
       <NavShell
         logo={<BZLogo variant="full" />}
-        items={getFunnelNavItems("tax")}
+        items={navItems}
+        slotAfter={<MobileNav items={navItems} />}
         actions={<HeaderWhatsAppCTA funnel="tax" />}
       />
       <SessionInit funnel="tax" />

--- a/apps/mouth/src/app/property/eligibility/layout.tsx
+++ b/apps/mouth/src/app/property/eligibility/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { NavShell, BZLogo } from "@balizero/core";
 import { SessionInit } from "@/components/funnel/SessionInit";
 import { HeaderWhatsAppCTA } from "@/components/funnel/HeaderWhatsAppCTA";
+import { MobileNav } from "@/app/v2/_components/MobileNav";
 import { getFunnelNavItems } from "@/components/funnel/funnel-nav";
 
 export const metadata: Metadata = {
@@ -15,11 +16,14 @@ export default function PropertyLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const navItems = getFunnelNavItems("property");
+
   return (
     <div className="min-h-screen flex flex-col">
       <NavShell
         logo={<BZLogo variant="full" />}
-        items={getFunnelNavItems("property")}
+        items={navItems}
+        slotAfter={<MobileNav items={navItems} />}
         actions={<HeaderWhatsAppCTA funnel="property" />}
       />
       <SessionInit funnel="property" />

--- a/apps/mouth/src/app/visa/layout.tsx
+++ b/apps/mouth/src/app/visa/layout.tsx
@@ -2,6 +2,7 @@ import { Montserrat } from "next/font/google";
 import { NavShell, BZLogo } from "@balizero/core";
 import { SessionInit } from "@/components/funnel/SessionInit";
 import { HeaderWhatsAppCTA } from "@/components/funnel/HeaderWhatsAppCTA";
+import { MobileNav } from "@/app/v2/_components/MobileNav";
 import { getFunnelNavItems } from "@/components/funnel/funnel-nav";
 
 const montserrat = Montserrat({
@@ -16,6 +17,8 @@ export default function VisaLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const navItems = getFunnelNavItems("visa");
+
   return (
     <div
       className={`${montserrat.variable} relative z-1`}
@@ -25,7 +28,8 @@ export default function VisaLayout({
     >
       <NavShell
         logo={<BZLogo variant="full" />}
-        items={getFunnelNavItems("visa")}
+        items={navItems}
+        slotAfter={<MobileNav items={navItems} />}
         actions={<HeaderWhatsAppCTA funnel="visa" />}
       />
       <SessionInit funnel="visa" />


### PR DESCRIPTION
## Insight
3 funnel layouts missing MobileNav in slotAfter NavShell — mobile hamburger menu not rendering on /visa, /property/eligibility, and /tax-calendar pages.

## Studio
- apps/mouth/src/app/visa/layout.tsx
- apps/mouth/src/app/property/eligibility/layout.tsx
- apps/mouth/src/app/(tax-calendar)/tax-calendar/layout.tsx

## Source
Flagged via email 9 Jul 2026. GO confirmed by Antonello email 10 Jul 2026.

## Methodology
Phase 1 read-only audit — confirmed all 3 layouts use identical NavShell + getFunnelNavItems pattern as kbli/layout.tsx (PR #2184). Applied same fix: extract navItems const, add slotAfter={<MobileNav items={navItems} />}, add MobileNav import.

## Raw Observations
- 3 files changed, same 3-line delta each
- Pre-commit hooks passed clean
- (blog)/layout.tsx excluded — different structure, handled in separate PR

## Reasoning Path
Pattern identical to PR #2184 (kbli). No structural deviation across the 3 targets.

## Risk
Low. Import + prop addition only. No logic change. VERDE zone. Self-merge eligible.

## Implication
Mobile hamburger nav now available on /visa, /property/eligibility, /tax-calendar. Consistent UX across all funnel pages.

## Recommendation
Self-merge after CI green. No Antonello review required.

## Next Action
Separate PR for (blog)/layout.tsx after audit of its nav structure.