### PR TITLE
fix(portal): resolve client from team_members, not user_profiles (real-client 500 on taxes/visa)

### DIFF
--- a/apps/backend-rag/backend/app/deps/auth.py
+++ b/apps/backend-rag/backend/app/deps/auth.py
@@ -276,24 +276,47 @@ async def get_current_portal_client(
             detail="This endpoint is only accessible to clients",
         )
 
+    # Client accounts live in team_members (role='client', linked_client_id ->
+    # clients.id), NOT user_profiles. The old JOIN targeted user_profiles.role /
+    # .linked_client_id — columns that do not exist there — so every real client
+    # (role=client) hitting /api/portal/taxes or /visa got HTTP 500
+    # (UndefinedColumnError). Mirror the working resolver in
+    # portal.get_current_client (team_members lookup). Observed live 2026-07-10.
+    user_id = user.get("id") or user.get("user_id")
     async with db_pool.acquire() as conn:
-        client_row = await conn.fetchrow(
+        row = await conn.fetchrow(
             """
-            SELECT c.id, c.email, c.full_name
-            FROM clients c
-            JOIN user_profiles up ON up.linked_client_id = c.id
-            WHERE up.id = $1 AND up.role = 'client'
+            SELECT id, email, full_name, linked_client_id, portal_access
+            FROM team_members
+            WHERE id = $1 AND role = 'client' AND active = true
             """,
-            user.get("user_id"),
+            str(user_id),
         )
 
-        if not client_row:
+        if not row:
             logger.warning(
-                f"Portal client lookup failed for user_id={user.get('user_id')} email={user.get('email')}",
+                "Portal client lookup failed for user_id=%s email=%s",
+                user_id,
+                user.get("email"),
             )
             raise HTTPException(
-                status_code=404,
-                detail="Client profile not found. Please contact support.",
+                status_code=403,
+                detail="Client account not found or inactive",
+            )
+        if not row["portal_access"]:
+            raise HTTPException(
+                status_code=403,
+                detail="Portal access not enabled for this account",
+            )
+        if not row["linked_client_id"]:
+            raise HTTPException(
+                status_code=403,
+                detail="Client profile not linked to account",
             )
 
-        return {**dict(client_row), "impersonating": False}
+        return {
+            "id": row["linked_client_id"],
+            "email": row["email"],
+            "full_name": row["full_name"],
+            "impersonating": False,
+        }

--- a/apps/backend-rag/backend/tests/unit/app/test_portal_client_auth_schema.py
+++ b/apps/backend-rag/backend/tests/unit/app/test_portal_client_auth_schema.py
@@ -1,0 +1,129 @@
+"""Regression: get_current_portal_client must resolve clients from team_members,
+NOT user_profiles.
+
+Live incident 2026-07-10: real clients (role='client') hitting /api/portal/taxes
+and /api/portal/visa got HTTP 500 because the resolver did
+`JOIN user_profiles up ON up.linked_client_id = c.id WHERE up.role = 'client'`
+but user_profiles has NEITHER `role` NOR `linked_client_id` columns
+(asyncpg UndefinedColumnError). Client accounts actually live in team_members
+(role='client', linked_client_id -> clients.id). Superuser impersonation
+(?as_client=<id>) masked the bug because it never hit this branch.
+
+These tests pin the team_members lookup, the client_id mapping
+(linked_client_id -> returned id), and that failures are 403 (auth), never 500.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_request(user: dict | None, query_params: dict | None = None):
+    """Mock Request whose .state.user is `user`."""
+    request = MagicMock()
+    request.state.user = user
+    request.query_params = query_params or {}
+    return request
+
+
+@pytest.mark.asyncio
+async def test_client_resolved_from_team_members(mock_db_pool):
+    """Happy path: a real client (role='client') is resolved via team_members and
+    the returned id is the linked_client_id (the clients.id), not the account id."""
+    from backend.app.deps.auth import get_current_portal_client
+
+    pool, conn = mock_db_pool
+    conn.fetchrow.return_value = {
+        "id": "acct-uuid-abc",
+        "email": "e2e-portal-client@test.balizero.com",
+        "full_name": "E2E Portal Client",
+        "linked_client_id": 12087,
+        "portal_access": True,
+    }
+    request = _make_request(
+        {"user_id": "acct-uuid-abc", "email": "e2e-portal-client@test.balizero.com", "role": "client"}
+    )
+
+    result = await get_current_portal_client(request, db_pool=pool)
+
+    assert result["id"] == 12087, "must return linked_client_id (clients.id), not the account id"
+    assert result["email"] == "e2e-portal-client@test.balizero.com"
+    assert result["impersonating"] is False
+
+    # GUILT: the query must target team_members, never user_profiles.
+    sql = conn.fetchrow.await_args.args[0]
+    assert "team_members" in sql
+    assert "user_profiles" not in sql
+    assert "role = 'client'" in sql
+
+
+@pytest.mark.asyncio
+async def test_no_row_is_403_not_500(mock_db_pool):
+    """No matching team_members row -> 403 (auth failure), NEVER a 500."""
+    from backend.app.deps.auth import get_current_portal_client
+
+    pool, conn = mock_db_pool
+    conn.fetchrow.return_value = None
+    request = _make_request({"user_id": "ghost", "email": "ghost@test.balizero.com", "role": "client"})
+
+    with pytest.raises(HTTPException) as exc:
+        await get_current_portal_client(request, db_pool=pool)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_portal_access_disabled_is_403(mock_db_pool):
+    from backend.app.deps.auth import get_current_portal_client
+
+    pool, conn = mock_db_pool
+    conn.fetchrow.return_value = {
+        "id": "acct", "email": "c@test.balizero.com", "full_name": "C",
+        "linked_client_id": 999, "portal_access": False,
+    }
+    request = _make_request({"user_id": "acct", "email": "c@test.balizero.com", "role": "client"})
+
+    with pytest.raises(HTTPException) as exc:
+        await get_current_portal_client(request, db_pool=pool)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unlinked_account_is_403(mock_db_pool):
+    from backend.app.deps.auth import get_current_portal_client
+
+    pool, conn = mock_db_pool
+    conn.fetchrow.return_value = {
+        "id": "acct", "email": "c@test.balizero.com", "full_name": "C",
+        "linked_client_id": None, "portal_access": True,
+    }
+    request = _make_request({"user_id": "acct", "email": "c@test.balizero.com", "role": "client"})
+
+    with pytest.raises(HTTPException) as exc:
+        await get_current_portal_client(request, db_pool=pool)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_client_role_is_403(mock_db_pool):
+    """A team member without role='client' must not reach the client data path."""
+    from backend.app.deps.auth import get_current_portal_client
+
+    pool, conn = mock_db_pool
+    request = _make_request({"user_id": "staff", "email": "staff@balizero.com", "role": "staff"})
+
+    with pytest.raises(HTTPException) as exc:
+        await get_current_portal_client(request, db_pool=pool)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_missing_user_is_401(mock_db_pool):
+    from backend.app.deps.auth import get_current_portal_client
+
+    pool, _ = mock_db_pool
+    request = _make_request(None)
+
+    with pytest.raises(HTTPException) as exc:
+        await get_current_portal_client(request, db_pool=pool)
+    assert exc.value.status_code == 401

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`331 routers · 636 services · 1124 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`331 routers · 636 services · 1125 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

`get_current_portal_client` (the auth dep used by `portal_taxes` + `portal_visa`) resolved the client with:

```sql
JOIN user_profiles up ON up.linked_client_id = c.id WHERE up.role = 'client'
```

`user_profiles` has **neither** a `role` **nor** a `linked_client_id` column. Every real client (`role=client`) hitting `/api/portal/taxes/`, `/api/portal/taxes/summary`, `/api/portal/visa/`, `/api/portal/visa/summary` got **HTTP 500** (asyncpg `UndefinedColumnError`).

Superuser **impersonation** (`?as_client=<id>`) masked the bug in every prior QA pass — that branch returns before the broken query runs. Only a login as a genuine `role=client` account surfaces it.

## Fix

Client accounts live in `team_members` (`role='client'`, `linked_client_id -> clients.id`), exactly like the **working** resolver `portal.get_current_client`. This mirrors that lookup: fetch `team_members` by account id, gate on `portal_access` + `linked_client_id`, return the linked client id. Every failure is now **403 (auth)**, never 500.

## Proven live (prod DB, 2026-07-10)

- OLD query → `UndefinedColumnError: column up.linked_client_id does not exist`
- NEW query → resolves account `d5690f20…` → client `12087`, `portal_access=True`

## Tests (R1 — adversarial guilt + innocence)

`test_portal_client_auth_schema.py` (6 tests):
- **guilt**: asserts the SQL targets `team_members` and does **NOT** contain `user_profiles`
- **innocence**: valid client row → returns `linked_client_id` as `id`
- 403-not-500 on: no row · `portal_access=False` · unlinked account · non-client role · 401 on missing user

Full portal+deps regression: **58 passed**. `docs_sync` regenerated in the same commit (W86).

## Scars

Scar #9 (schema drift — read STATE by the real column, not a dead schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
