### PR TITLE
perf(crm): slim clients list 10MB->200KB — lazy-load base64 avatars

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -5,6 +5,8 @@ Endpoints for managing client data (anagrafica clienti)
 Refactored: Migrated to asyncpg with connection pooling (2025-12-07)
 """
 
+import base64
+import binascii
 import json
 import re
 import time
@@ -13,6 +15,7 @@ from typing import Any
 
 import asyncpg
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Path, Query, Request
+from fastapi.responses import RedirectResponse, Response
 from pydantic import BaseModel, EmailStr, field_validator
 
 from backend.app.dependencies import get_current_user, get_database_pool
@@ -405,6 +408,10 @@ class ClientResponse(BaseModel):
     assigned_to: str | None = None
     tax_consultant: str | None = None
     avatar_url: str | None = None
+    # has_avatar: list views omit the (potentially base64 data-URI) avatar_url
+    # to keep the page lean; the card lazy-loads the image from
+    # GET /api/crm/clients/{id}/avatar when this is true.
+    has_avatar: bool = False
     address: str | None = None
     notes: str | None = None
     strategic_recap: str | None = None
@@ -752,7 +759,13 @@ async def list_clients(
                 """
                 SELECT
                     c.id, c.uuid, c.full_name, c.email, c.phone, c.whatsapp, c.nationality, c.status,
-                    c.client_type, c.assigned_to, c.avatar_url, c.first_contact_date, c.last_interaction_date,
+                    c.client_type, c.assigned_to,
+                    -- Base64 data-URI avatars (avg 20KB, max 518KB) bloat the list
+                    -- page to ~10MB. Inline only http(s) URLs; the card lazy-loads
+                    -- data-URI images from /{id}/avatar via the has_avatar flag.
+                    CASE WHEN c.avatar_url LIKE 'data:%' THEN NULL ELSE c.avatar_url END AS avatar_url,
+                    (c.avatar_url IS NOT NULL AND length(c.avatar_url) > 0) AS has_avatar,
+                    c.first_contact_date, c.last_interaction_date,
                     c.passport_number, c.passport_expiry, c.date_of_birth, c.gender, c.birthplace, c.company_name,
                     c.custom_fields, c.address, c.notes, c.npwp, c.nib,
                     c.tags, c.created_at, c.updated_at,
@@ -936,6 +949,63 @@ async def get_client(
                 raise HTTPException(status_code=404, detail="Client not found")
 
             return ClientResponse(**dict(row))
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise handle_database_error(e) from e
+
+
+@router.get("/{client_id}/avatar")
+async def get_client_avatar(
+    client_id: int = Path(..., gt=0),
+    db_pool: asyncpg.Pool = Depends(get_database_pool),
+    current_user: dict = Depends(get_current_user),
+) -> Response:
+    """Serve a client's avatar image.
+
+    The list endpoint (`GET /`) omits base64 data-URI avatars to keep the page
+    lean (they average ~20KB, up to 518KB, and would bloat a 200-row page to
+    ~10MB). Cards lazy-load the image here when `has_avatar` is true.
+
+    - Stored as a `data:` URI  -> decoded and streamed as image bytes.
+    - Stored as an http(s) URL  -> 302 redirect to that URL.
+
+    Access Control: admin sees any client; a team member only their assigned
+    ones (same rule as `GET /{client_id}`).
+    """
+    try:
+        async with db_pool.acquire() as conn:
+            await verify_client_access(client_id, current_user, conn, allow_assigned=True)
+            avatar_url = await conn.fetchval(
+                "SELECT avatar_url FROM clients WHERE id = $1 AND deleted_at IS NULL",
+                client_id,
+            )
+
+        if not avatar_url:
+            raise HTTPException(status_code=404, detail="No avatar for this client")
+
+        if avatar_url.startswith("http://") or avatar_url.startswith("https://"):
+            return RedirectResponse(url=avatar_url, status_code=302)
+
+        if avatar_url.startswith("data:"):
+            # data:[<mediatype>][;base64],<data>
+            try:
+                header, b64 = avatar_url.split(",", 1)
+                media_type = "image/jpeg"
+                if header.startswith("data:") and ";" in header:
+                    media_type = header[len("data:"):].split(";", 1)[0] or media_type
+                image_bytes = base64.b64decode(b64)
+            except (ValueError, binascii.Error) as e:
+                raise HTTPException(status_code=422, detail="Malformed avatar data") from e
+            return Response(
+                content=image_bytes,
+                media_type=media_type,
+                headers={"Cache-Control": "private, max-age=86400"},
+            )
+
+        # Unknown scheme -> treat as not found rather than leaking the raw value.
+        raise HTTPException(status_code=404, detail="No servable avatar for this client")
 
     except HTTPException:
         raise

--- a/apps/backend-rag/backend/tests/unit/routers/test_client_avatar_slimming.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_client_avatar_slimming.py
@@ -1,0 +1,109 @@
+"""Regression: the clients LIST must not inline base64 data-URI avatars.
+
+Live 2026-07-10: GET /api/crm/clients?limit=200 returned ~7.5MB because
+`avatar_url` holds base64 data:image blobs (avg ~20KB, max 518KB, 383 clients).
+The list now returns `avatar_url=None` + `has_avatar=True` for data-URI avatars
+(http URLs pass through), and the image is served lazily by
+GET /api/crm/clients/{id}/avatar.
+"""
+
+import base64
+
+import pytest
+from fastapi import HTTPException
+
+
+class TestClientResponseHasAvatar:
+    def test_field_present_default_false(self):
+        from backend.app.routers.crm_clients import ClientResponse
+
+        assert "has_avatar" in ClientResponse.model_fields
+        assert ClientResponse.model_fields["has_avatar"].default is False
+
+
+class TestAvatarRouteRegistered:
+    def test_route_registered(self):
+        from backend.app.routers import crm_clients
+
+        paths = [r.path for r in crm_clients.router.routes]
+        assert "/api/crm/clients/{client_id}/avatar" in paths
+
+
+class TestAvatarEndpoint:
+    """Exercise the decode/redirect/404 branches directly."""
+
+    @staticmethod
+    def _pool(avatar_value):
+        from unittest.mock import AsyncMock, MagicMock
+
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value=avatar_value)
+
+        class _Ctx:
+            async def __aenter__(self):
+                return conn
+
+            async def __aexit__(self, *a):
+                return None
+
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=_Ctx())
+        return pool
+
+    @pytest.fixture(autouse=True)
+    def _patch_access(self, monkeypatch):
+        # verify_client_access is imported into the router module namespace.
+        from unittest.mock import AsyncMock
+
+        import backend.app.routers.crm_clients as mod
+
+        monkeypatch.setattr(mod, "verify_client_access", AsyncMock(return_value=None))
+
+    @pytest.mark.asyncio
+    async def test_data_uri_returns_image_bytes(self):
+        from backend.app.routers.crm_clients import get_client_avatar
+
+        payload = b"\xff\xd8\xff\xe0hello-jpeg"
+        b64 = base64.b64encode(payload).decode()
+        data_uri = f"data:image/png;base64,{b64}"
+
+        resp = await get_client_avatar(
+            client_id=1, db_pool=self._pool(data_uri), current_user={"email": "z@balizero.com"}
+        )
+        assert resp.body == payload
+        assert resp.media_type == "image/png"
+        assert "max-age" in resp.headers.get("cache-control", "")
+
+    @pytest.mark.asyncio
+    async def test_http_url_redirects(self):
+        from backend.app.routers.crm_clients import get_client_avatar
+
+        resp = await get_client_avatar(
+            client_id=1,
+            db_pool=self._pool("https://cdn.example.com/a.jpg"),
+            current_user={"email": "z@balizero.com"},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://cdn.example.com/a.jpg"
+
+    @pytest.mark.asyncio
+    async def test_no_avatar_is_404(self):
+        from backend.app.routers.crm_clients import get_client_avatar
+
+        with pytest.raises(HTTPException) as exc:
+            await get_client_avatar(
+                client_id=1, db_pool=self._pool(None), current_user={"email": "z@balizero.com"}
+            )
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_malformed_data_uri_is_422(self):
+        from backend.app.routers.crm_clients import get_client_avatar
+
+        with pytest.raises(HTTPException) as exc:
+            await get_client_avatar(
+                client_id=1,
+                db_pool=self._pool("data:image/png;base64,!!!not-base64!!!"),
+                current_user={"email": "z@balizero.com"},
+            )
+        assert exc.value.status_code == 422

--- a/apps/mouth/src/components/crm/ClientCard.tsx
+++ b/apps/mouth/src/components/crm/ClientCard.tsx
@@ -61,6 +61,15 @@ export const ClientCard = React.memo(
     // Get country flag for fallback
     const countryFlag = getCountryFlag(client.nationality);
 
+    // Avatar source: inline URL when present (http), else lazy-load the
+    // (base64 data-URI) image the list endpoint omitted for payload size.
+    // Served same-origin via the /api proxy -> cookie-authenticated backend.
+    const avatarSrc = client.avatar_url
+      ? client.avatar_url
+      : client.has_avatar
+        ? `/api/crm/clients/${client.id}/avatar`
+        : null;
+
     // Passport expiry alert
     const passportDaysLeft = client.passport_expiry
       ? Math.ceil(
@@ -127,17 +136,18 @@ export const ClientCard = React.memo(
             <div
               className={`relative w-10 h-10 rounded-full ${ringColor} ring-2 ring-offset-2 ring-offset-[var(--background-secondary)] shrink-0`}
             >
-              {client.avatar_url ? (
+              {avatarSrc ? (
                 <img
-                  src={client.avatar_url}
+                  src={avatarSrc}
                   alt={client.full_name}
+                  loading="lazy"
                   className="w-full h-full rounded-full object-cover"
                   onError={(e) => {
                     (e.target as HTMLImageElement).style.display = "none";
                   }}
                 />
               ) : null}
-              {!client.avatar_url && (
+              {!avatarSrc && (
                 <div className="w-full h-full rounded-full bg-[rgba(255,255,255,0.05)] flex items-center justify-center text-[var(--tx-pure)]">
                   {countryFlag ? (
                     <span className="text-lg leading-none">{countryFlag}</span>

--- a/apps/mouth/src/lib/api/crm/crm.types.ts
+++ b/apps/mouth/src/lib/api/crm/crm.types.ts
@@ -310,6 +310,9 @@ export interface Client {
   assigned_to?: string;
   tax_consultant?: string | null;
   avatar_url?: string;
+  /** True when the client has an avatar the list omitted for size;
+   *  fetch the image from GET /api/crm/clients/{id}/avatar. */
+  has_avatar?: boolean;
   company_name?: string;
   first_contact_date?: string;
   last_interaction_date?: string;

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 634 services · 1122 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 634 services · 1123 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Problem

`GET /api/crm/clients?limit=200` returned **~7.5 MB**. Root cause: `avatar_url` stores **base64 `data:image` blobs** (avg ~20KB, **max 518KB**; 383 clients), inlined once per row → ~10MB of avatar bytes on a 200-row page. Measured live 2026-07-10 (the response truncated even a 60s curl).

## Fix

- **List** (`GET /`) now returns `avatar_url=NULL` for data-URI avatars (http(s) URLs pass through) + a `has_avatar` boolean.
- **New** `GET /api/crm/clients/{id}/avatar` serves the image lazily: decodes the data-URI to bytes (`Cache-Control: private, max-age=86400`) or 302-redirects an http URL. RBAC = same as `GET /{id}`.
- **Frontend** `ClientCard` builds `avatarSrc = avatar_url ?? (has_avatar ? '/api/crm/clients/{id}/avatar' : null)` and lazy-loads it. Works same-origin through the `/api [...path]` proxy, which forwards the `nz_access_token` cookie → a plain `<img>` authenticates via `HybridAuthMiddleware`'s cookie path (no Bearer header needed). Kanban + list page both render through `ClientCard`. Detail view unchanged (still full `avatar_url`).

## Measured (prod DB)

Slimmed list projection: **~10.4 MB → ~208 KB** for 200 rows (**50×**), **zero** data-URI leakage into the list.

## Tests

`test_client_avatar_slimming.py` (6): `has_avatar` field default, route registered, data-URI→bytes, http→302, none→404, malformed→422. Full `crm_client` suite green (**162**). Frontend `tsc` clean (0 errors). `docs_sync` regenerated in this commit (W86).

## Follow-up (not in scope)

The real data-model fix is migrating the 383 inline avatars to blob storage so `avatar_url` is always a URL — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
