### PR TITLE
fix(deps): drop imports orphaned by #2205 (unblocks fly-deploy)

### DIFF
--- a/apps/backend-rag/backend/app/deps/auth.py
+++ b/apps/backend-rag/backend/app/deps/auth.py
@@ -8,12 +8,9 @@ No heavy service imports at module level — only jose, fastapi.security.
 import logging
 from typing import Annotated, Any
 
-import asyncpg
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
-
-from backend.app.deps.database import get_database_pool
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Post-#2205 the fly-deploy failed at the pre-deploy Ruff F401 gate: `get_current_portal_client` was the only user of `asyncpg` + `get_database_pool` in deps/auth.py. Deploy was SKIPPED (prod stayed on prior release, no outage). Removes the 2 dead imports. Deploy-critical ruff + deps-critical tests (18) green.