### PR TITLE
feat(crm): store client avatars in Tigris + reject inline base64 (write-path fix)

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -14,7 +14,18 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import asyncpg
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Path, Query, Request
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Body,
+    Depends,
+    File,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    UploadFile,
+)
 from fastapi.responses import RedirectResponse, Response
 from pydantic import BaseModel, EmailStr, field_validator
 
@@ -308,6 +319,24 @@ class ClientUpdate(BaseModel):
     nib: str | None = None
     current_visa_type: str | None = None
     current_visa_sponsor: str | None = None
+
+    @field_validator("avatar_url")
+    @classmethod
+    def reject_data_uri_avatar(cls, v: str | None) -> str | None:
+        """Avatars must be storage URLs, never inline base64.
+
+        Base64 data: URIs stored in avatar_url bloated the clients list to
+        ~10MB (avg 20KB, max 518KB per row). New avatars go through
+        POST /api/crm/clients/{id}/avatar which uploads to Tigris and stores a
+        public URL. Reject data: URIs here so the bloat can never return via a
+        plain client update.
+        """
+        if v and v.startswith("data:"):
+            raise ValueError(
+                "avatar_url must be a storage URL; upload the image via "
+                "POST /api/crm/clients/{id}/avatar instead of an inline data: URI"
+            )
+        return v
 
     @field_validator("status")
     @classmethod
@@ -1011,6 +1040,84 @@ async def get_client_avatar(
         raise
     except Exception as e:
         raise handle_database_error(e) from e
+
+
+_AVATAR_MAX_BYTES = 5 * 1024 * 1024  # 5MB — generous for a 400px crop, rejects abuse
+_AVATAR_CONTENT_TYPES = {
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+}
+
+
+@router.post("/{client_id}/avatar", response_model=dict)
+async def upload_client_avatar(
+    client_id: int = Path(..., gt=0),
+    file: UploadFile = File(...),
+    db_pool: asyncpg.Pool = Depends(get_database_pool),
+    current_user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Upload a client avatar to Tigris S3 and store the public URL.
+
+    Replaces the legacy path where the frontend inlined a base64 data: URI into
+    avatar_url (which bloated the clients list to ~10MB). The image bytes are
+    stored object-side and avatar_url becomes a plain public https URL.
+
+    Access Control: admin any client; team member only their assigned ones.
+    """
+    import hashlib as _hl
+
+    from backend.services.canva_renderer_v2 import _tigris
+
+    content_type = (file.content_type or "").lower()
+    ext = _AVATAR_CONTENT_TYPES.get(content_type)
+    if ext is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported avatar type '{content_type}'. Use JPEG, PNG or WebP.",
+        )
+
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty file")
+    if len(data) > _AVATAR_MAX_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Avatar too large ({len(data)} bytes); max {_AVATAR_MAX_BYTES}.",
+        )
+
+    async with db_pool.acquire() as conn:
+        await verify_client_access(client_id, current_user, conn, allow_assigned=True)
+
+    # Content-addressed key so re-uploads get a fresh URL (no stale CDN bytes).
+    sha8 = _hl.sha256(data).hexdigest()[:8]
+    key = f"client-avatar/{client_id}/{sha8}.{ext}"
+    try:
+        s3 = _tigris.get_s3_client()
+        s3.put_object(
+            Bucket=_tigris.BUCKET,
+            Key=key,
+            Body=data,
+            ContentType=content_type,
+            ACL="public-read",
+        )
+    except Exception as e:
+        logger.error("Avatar upload to Tigris failed for client %s: %s", client_id, e)
+        raise HTTPException(status_code=502, detail="Avatar storage failed") from e
+
+    public_url = f"https://{_tigris.PUBLIC_HOST}/{key}"
+
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE clients SET avatar_url = $1, updated_at = NOW() WHERE id = $2",
+            public_url,
+            client_id,
+        )
+    await invalidate_cache("zantara:crm_clients_stats:*")
+
+    logger.info("Avatar uploaded for client %s -> %s", client_id, key)
+    return {"success": True, "avatar_url": public_url}
 
 
 @router.get("/by-email/{email}", response_model=ClientResponse)

--- a/apps/backend-rag/backend/tests/unit/routers/test_client_avatar_upload.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_client_avatar_upload.py
@@ -1,0 +1,140 @@
+"""Regression: client avatars go to Tigris storage, never inline base64.
+
+Follows #2206 (which stopped SERVING base64 in the list). This closes the
+WRITE path: ClientUpdate rejects data: URIs, and POST /clients/{id}/avatar
+uploads bytes to Tigris and stores a public URL.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+
+class TestClientUpdateRejectsDataUri:
+    def test_data_uri_rejected(self):
+        from backend.app.routers.crm_clients import ClientUpdate
+
+        with pytest.raises(ValueError):
+            ClientUpdate(avatar_url="data:image/png;base64,AAAABBBB")
+
+    def test_storage_url_accepted(self):
+        from backend.app.routers.crm_clients import ClientUpdate
+
+        u = ClientUpdate(
+            avatar_url="https://nuzantara-warroom-images.fly.storage.tigris.dev/client-avatar/1/ab12cd34.jpg"
+        )
+        assert u.avatar_url.startswith("https://")
+
+    def test_none_accepted(self):
+        from backend.app.routers.crm_clients import ClientUpdate
+
+        assert ClientUpdate(avatar_url=None).avatar_url is None
+
+
+class TestUploadRouteRegistered:
+    def test_post_avatar_registered(self):
+        from backend.app.routers import crm_clients
+
+        found = False
+        for r in crm_clients.router.routes:
+            if getattr(r, "path", None) == "/api/crm/clients/{client_id}/avatar" and "POST" in (
+                getattr(r, "methods", set()) or set()
+            ):
+                found = True
+        assert found
+
+
+class TestUploadEndpoint:
+    @staticmethod
+    def _pool():
+        conn = MagicMock()
+        conn.execute = AsyncMock(return_value=None)
+
+        class _Ctx:
+            async def __aenter__(self):
+                return conn
+
+            async def __aexit__(self, *a):
+                return None
+
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=_Ctx())
+        return pool, conn
+
+    @pytest.fixture(autouse=True)
+    def _patch(self, monkeypatch):
+        import backend.app.routers.crm_clients as mod
+
+        monkeypatch.setattr(mod, "verify_client_access", AsyncMock(return_value=None))
+
+        async def _noop_invalidate(*a, **k):
+            return None
+
+        monkeypatch.setattr(mod, "invalidate_cache", _noop_invalidate)
+
+        # Patch the tigris client used inside the handler.
+        import backend.services.canva_renderer_v2._tigris as tg
+
+        fake_s3 = MagicMock()
+        fake_s3.put_object = MagicMock(return_value={})
+        monkeypatch.setattr(tg, "get_s3_client", lambda: fake_s3)
+        monkeypatch.setattr(tg, "BUCKET", "test-bucket")
+        monkeypatch.setattr(tg, "PUBLIC_HOST", "test-bucket.fly.storage.tigris.dev")
+        self._fake_s3 = fake_s3
+
+    @staticmethod
+    def _upload(content: bytes, content_type: str) -> UploadFile:
+        import io
+
+        uf = UploadFile(filename="a.jpg", file=io.BytesIO(content))
+        # UploadFile.content_type is derived from headers; set directly for the test.
+        uf.__dict__["_content_type"] = content_type
+        # Starlette exposes content_type via headers; patch the property source.
+        object.__setattr__(uf, "headers", {"content-type": content_type})
+        return uf
+
+    @pytest.mark.asyncio
+    async def test_jpeg_upload_stores_public_url(self):
+        from backend.app.routers.crm_clients import upload_client_avatar
+
+        pool, conn = self._pool()
+        uf = self._upload(b"\xff\xd8\xff\xe0jpegbytes", "image/jpeg")
+
+        result = await upload_client_avatar(
+            client_id=7, file=uf, db_pool=pool, current_user={"email": "z@balizero.com"}
+        )
+        assert result["success"] is True
+        assert result["avatar_url"].startswith("https://test-bucket.fly.storage.tigris.dev/client-avatar/7/")
+        assert result["avatar_url"].endswith(".jpg")
+        # DB updated with the URL, not bytes
+        args = conn.execute.await_args.args
+        assert args[1].startswith("https://")
+        assert args[2] == 7
+        # object stored public-read
+        kwargs = self._fake_s3.put_object.call_args.kwargs
+        assert kwargs["ACL"] == "public-read"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_type_rejected(self):
+        from backend.app.routers.crm_clients import upload_client_avatar
+
+        pool, _ = self._pool()
+        uf = self._upload(b"GIF89a", "image/gif")
+        with pytest.raises(HTTPException) as exc:
+            await upload_client_avatar(
+                client_id=7, file=uf, db_pool=pool, current_user={"email": "z@balizero.com"}
+            )
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_empty_file_rejected(self):
+        from backend.app.routers.crm_clients import upload_client_avatar
+
+        pool, _ = self._pool()
+        uf = self._upload(b"", "image/png")
+        with pytest.raises(HTTPException) as exc:
+            await upload_client_avatar(
+                client_id=7, file=uf, db_pool=pool, current_user={"email": "z@balizero.com"}
+            )
+        assert exc.value.status_code == 400

--- a/apps/backend-rag/scripts/backfill_client_avatars_to_tigris.py
+++ b/apps/backend-rag/scripts/backfill_client_avatars_to_tigris.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""One-shot backfill: migrate inline base64 data:URI avatars to Tigris storage.
+
+For every client whose avatar_url is a `data:` URI, decode the image, upload it
+to the Tigris bucket (content-addressed key), and replace avatar_url with the
+public https URL. Idempotent: rows already on https are skipped; re-running only
+processes remaining data: rows.
+
+Usage (on Pro, from apps/backend-rag with venv active):
+    PYTHONPATH=. python3 backfill_avatars.py --dry-run   # report only
+    PYTHONPATH=. python3 backfill_avatars.py --apply     # perform migration
+"""
+import argparse
+import asyncio
+import base64
+import binascii
+import hashlib
+import os
+import pathlib
+import sys
+
+import asyncpg
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+_EXT = {"image/jpeg": "jpg", "image/jpg": "jpg", "image/png": "png", "image/webp": "webp"}
+
+
+def dburl():
+    for cand in [pathlib.Path.home() / ".nuzantara-secrets.env"]:
+        if cand.exists():
+            for line in cand.read_text().splitlines():
+                if line.startswith("DATABASE_URL_LOCAL="):
+                    return line.split("=", 1)[1].strip().strip("'").strip('"')
+    return os.environ.get("DATABASE_URL_LOCAL")
+
+
+def parse_data_uri(uri: str):
+    """Return (content_type, ext, raw_bytes) or None if not a valid image data URI."""
+    if not uri.startswith("data:"):
+        return None
+    try:
+        header, b64 = uri.split(",", 1)
+    except ValueError:
+        return None
+    meta = header[len("data:"):]
+    content_type = meta.split(";", 1)[0].lower() if meta else "image/jpeg"
+    ext = _EXT.get(content_type)
+    if ext is None:
+        return None
+    try:
+        raw = base64.b64decode(b64)
+    except (binascii.Error, ValueError):
+        return None
+    if not raw:
+        return None
+    return content_type, ext, raw
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="perform the migration (default: dry-run)")
+    ap.add_argument("--dry-run", action="store_true", help="report only (default)")
+    ap.add_argument("--limit", type=int, default=100000)
+    args = ap.parse_args()
+    apply = args.apply and not args.dry_run
+
+    from backend.services.canva_renderer_v2 import _tigris
+
+    con = await asyncpg.connect(dburl(), timeout=30)
+    rows = await con.fetch(
+        "SELECT id, avatar_url FROM clients "
+        "WHERE deleted_at IS NULL AND avatar_url LIKE 'data:%' "
+        "ORDER BY id LIMIT $1",
+        args.limit,
+    )
+    print(f"data:URI avatars to migrate: {len(rows)}  (mode={'APPLY' if apply else 'DRY-RUN'})")
+
+    s3 = _tigris.get_s3_client() if apply else None
+    migrated = skipped = failed = 0
+    for r in rows:
+        cid, uri = r["id"], r["avatar_url"]
+        parsed = parse_data_uri(uri)
+        if parsed is None:
+            print(f"  client {cid}: UNPARSEABLE data URI (len={len(uri)}) — skip")
+            skipped += 1
+            continue
+        content_type, ext, raw = parsed
+        sha8 = hashlib.sha256(raw).hexdigest()[:8]
+        key = f"client-avatar/{cid}/{sha8}.{ext}"
+        public_url = f"https://{_tigris.PUBLIC_HOST}/{key}"
+        if not apply:
+            print(f"  client {cid}: {len(raw)} B {content_type} -> {public_url}")
+            migrated += 1
+            continue
+        try:
+            s3.put_object(Bucket=_tigris.BUCKET, Key=key, Body=raw,
+                          ContentType=content_type, ACL="public-read")
+            await con.execute(
+                "UPDATE clients SET avatar_url=$1, updated_at=NOW() WHERE id=$2",
+                public_url, cid,
+            )
+            migrated += 1
+            if migrated % 25 == 0:
+                print(f"  ... {migrated} migrated")
+        except Exception as e:
+            print(f"  client {cid}: FAILED {type(e).__name__}: {e}")
+            failed += 1
+
+    print(f"\nDONE: migrated={migrated} skipped={skipped} failed={failed}")
+    # verify: how many data: avatars remain
+    remain = await con.fetchval(
+        "SELECT count(*) FROM clients WHERE deleted_at IS NULL AND avatar_url LIKE 'data:%'"
+    )
+    print(f"data:URI avatars remaining in DB: {remain}")
+    await con.close()
+
+
+asyncio.run(main())

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/modals/EditClientModal.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/modals/EditClientModal.tsx
@@ -5,7 +5,7 @@ import { User, Upload, X } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
-import { cropToSquare } from "@/lib/utils/imageResize";
+import { cropToSquareBlob } from "@/lib/utils/imageResize";
 import type { Client } from "@/lib/api/crm/crm.types";
 import { COMMON_NATIONALITIES, CLIENT_STATUSES } from "@/lib/api/crm/crm.types";
 import { Modal } from "../Modal";
@@ -23,6 +23,7 @@ export function EditClientModal({
 }) {
   const { options: teamMemberOptions } = useTeamMemberOptions();
   const [isSaving, setIsSaving] = useState(false);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
   const [formData, setFormData] = useState({
     full_name: client.full_name || "",
     email: client.email || "",
@@ -61,16 +62,26 @@ export function EditClientModal({
     }
 
     try {
-      // Crop to square and resize to 400x400px
-      const resizedImage = await cropToSquare(file, 400, 0.85);
-      setFormData((prev) => ({ ...prev, avatar_url: resizedImage }));
+      // Crop to square and resize to 400x400px, then upload to storage so the
+      // avatar_url is a URL — never an inline base64 blob (the backend rejects
+      // data: URIs on update).
+      const resizedBlob = await cropToSquareBlob(file, 400, 0.85);
+      const uploadFile = new File([resizedBlob], "avatar.jpg", {
+        type: resizedBlob.type || "image/jpeg",
+      });
+      setIsUploadingAvatar(true);
+      const res = await api.crm.uploadClientAvatar(client.id, uploadFile);
+      setFormData((prev) => ({ ...prev, avatar_url: res.avatar_url }));
+      toast.success("Avatar uploaded");
     } catch (error) {
       logger.error(
-        "Failed to process image",
+        "Failed to process/upload image",
         { component: "ClientDetail", action: "processImage" },
         error instanceof Error ? error : new Error(String(error)),
       );
-      toast.error("Failed to process image. Please try again.");
+      toast.error("Failed to upload image. Please try again.");
+    } finally {
+      setIsUploadingAvatar(false);
     }
   };
 
@@ -185,13 +196,24 @@ export function EditClientModal({
           <p className="text-xs text-[var(--bz-text-2)] mb-2">
             Upload a profile picture (max 2MB)
           </p>
-          <label className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--bz-accent)] text-white hover:bg-[var(--bz-accent)]/90 transition-colors cursor-pointer">
+          <label
+            className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--bz-accent)] text-white transition-colors ${
+              isUploadingAvatar
+                ? "opacity-60 cursor-not-allowed"
+                : "hover:bg-[var(--bz-accent)]/90 cursor-pointer"
+            }`}
+          >
             <Upload className="w-4 h-4" />
-            {formData.avatar_url ? "Change Photo" : "Upload Photo"}
+            {isUploadingAvatar
+              ? "Uploading…"
+              : formData.avatar_url
+                ? "Change Photo"
+                : "Upload Photo"}
             <input
               type="file"
               accept="image/*"
               onChange={handleAvatarUpload}
+              disabled={isUploadingAvatar}
               className="hidden"
             />
           </label>

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -1043,6 +1043,23 @@ export class CrmApi {
   /**
    * Upload file to a subfolder
    */
+  /**
+   * Upload a client avatar image to storage (Tigris) and set avatar_url to the
+   * returned public URL. Replaces the legacy base64-into-avatar_url path that
+   * bloated the clients list. Backend: POST /api/crm/clients/{id}/avatar.
+   */
+  async uploadClientAvatar(
+    clientId: number,
+    file: File,
+  ): Promise<{ success: boolean; avatar_url: string }> {
+    const formData = new FormData();
+    formData.append("file", file);
+    return this.client.request(`/api/crm/clients/${clientId}/avatar`, {
+      method: "POST",
+      body: formData,
+    });
+  }
+
   async uploadFileToFolder(
     clientId: number,
     folderName: string,

--- a/apps/mouth/src/lib/utils/imageResize.ts
+++ b/apps/mouth/src/lib/utils/imageResize.ts
@@ -148,3 +148,51 @@ export async function cropToSquare(
     reader.readAsDataURL(file);
   });
 }
+
+
+/**
+ * Same center-crop + resize as cropToSquare, but returns a Blob (for multipart
+ * upload) instead of a base64 data URL. Avatars are uploaded to storage, so the
+ * bytes must travel as a Blob, not an inline data: URI.
+ */
+export async function cropToSquareBlob(
+  file: File,
+  size: number = 400,
+  quality: number = 0.85,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new Error("Failed to get canvas context"));
+          return;
+        }
+        ctx.imageSmoothingEnabled = true;
+        ctx.imageSmoothingQuality = "high";
+        const minDim = Math.min(img.width, img.height);
+        const sx = (img.width - minDim) / 2;
+        const sy = (img.height - minDim) / 2;
+        ctx.drawImage(img, sx, sy, minDim, minDim, 0, 0, size, size);
+        const mimeType = file.type === "image/png" ? "image/png" : "image/jpeg";
+        canvas.toBlob(
+          (blob) => {
+            if (blob) resolve(blob);
+            else reject(new Error("Failed to encode image"));
+          },
+          mimeType,
+          quality,
+        );
+      };
+      img.onerror = () => reject(new Error("Failed to load image"));
+      img.src = e.target?.result as string;
+    };
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 634 services · 1123 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 634 services · 1124 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

Follow-up to #2206 (which stopped **serving** base64 avatars in the list). This closes the **write path** so the 10MB-list bloat can never return, and ships the backfill for existing data.

## Backend

- **`POST /api/crm/clients/{id}/avatar`** (multipart) → uploads the image to Tigris S3 (content-addressed key `client-avatar/{id}/{sha8}.{ext}`, `public-read`) and sets `avatar_url` to the public https URL. RBAC = same as `GET /{id}`. Validates type (JPEG/PNG/WebP) + size (5MB).
- **`ClientUpdate` now rejects `avatar_url` starting with `data:`** — a client update can no longer re-insert a base64 blob.

## Frontend

- `EditClientModal` crops the photo to a **Blob** (new `cropToSquareBlob`) and uploads it via `api.crm.uploadClientAvatar`, storing the returned **URL** in `avatar_url` (not base64). Button shows an "Uploading…" state.

## Migration

- `scripts/backfill_client_avatars_to_tigris.py` migrates the ~383 existing `data:` URI avatars → Tigris → https URL. **Idempotent, dry-run by default.** Run manually on Pro after deploy (has DB + Tigris creds).

## Infra

Tigris creds (`AWS_*`) are already Fly secrets on `nuzantara-rag`. Bucket `nuzantara-warroom-images`, reusing the existing `_tigris` client.

## Tests

`test_client_avatar_upload.py` (7): guard rejects `data:`/accepts URL/None, POST route registered, JPEG→public URL (public-read ACL, DB stores URL not bytes), unsupported-type→400, empty→400. `crm_client` suite green (**173**). Frontend `tsc` clean (**0**). `docs_sync` regenerated (W86).

## Post-merge steps (manual)

1. After deploy: `ssh pro`, `cd ~/Desktop/nuzantara/apps/backend-rag`, venv, `PYTHONPATH=. python3 scripts/backfill_client_avatars_to_tigris.py --dry-run` → review → `--apply`.
2. Verify: `SELECT count(*) FROM clients WHERE avatar_url LIKE 'data:%'` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
