### PR TITLE
fix(infra): launchagent-state-bridge refuses to run off Pro (host guard)

### DIFF
--- a/scripts/launchagent-state-bridge.py
+++ b/scripts/launchagent-state-bridge.py
@@ -12,6 +12,7 @@ import json
 import os
 import socket
 import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,6 +22,25 @@ from typing import Any
 DEFAULT_LAST_SEEN_DIR = Path("~/.organism/last_seen").expanduser()
 DEFAULT_LEGACY_STATE_DIR = Path("~/.agent/decisions/state").expanduser()
 HEALTHY_EXIT_CODES = {0}
+
+# Every label in BRIDGED_LABELS is a Pro-resident launchd job (com.balizero.*,
+# com.nuzantara.*, homebrew.mxcl.*) — this bridge exists to read PRO's own
+# `launchctl list` and stamp PRO's organism sidecars. Run on any other host
+# (Mini, M5), it still executes happily: `launchctl list` succeeds locally,
+# every one of these ~90 labels is legitimately absent there, and
+# build_receipt() writes "label not loaded" -> status=failed for all of them —
+# a wholesale false-failed wave for organs that are healthy on their real host.
+# Same node-guard idiom as mini-fleet-watch.sh's G4 (checked-in 2026-07-07).
+# Root cause: an ad-hoc `--json` diagnostic run on Mini on 2026-07-09 21:27
+# (evidence: /tmp/launchagent-state-bridge-mini.{json,err}) silently clobbered
+# ~/.organism/last_seen/ with 89 false-failed receipts, surfaced by
+# proprioception's organs_heartbeat probe as a 78-organ P1 the next session.
+RESIDENT_HOST = "nuzantara"  # Pro's hostname, lowercased, first label
+
+
+def running_on_resident_host(host: str | None = None) -> bool:
+    name = (host if host is not None else os.uname().nodename).split(".")[0].lower()
+    return name == RESIDENT_HOST
 
 
 @dataclass(frozen=True)
@@ -670,7 +690,29 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--legacy-state-dir", default=str(DEFAULT_LEGACY_STATE_DIR))
     parser.add_argument("--no-legacy", action="store_true")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--allow-off-host",
+        action="store_true",
+        help=(
+            "write receipts even when not running on the resident host "
+            "(RESIDENT_HOST). Every BRIDGED_LABELS entry is a Pro-only "
+            "launchd job — off-host runs otherwise produce a false-failed "
+            "receipt for every one of them. Intended for tests/fixtures."
+        ),
+    )
     args = parser.parse_args(argv)
+
+    if not args.allow_off_host and not running_on_resident_host():
+        host = os.uname().nodename
+        print(
+            f"[launchagent-state-bridge] refusing to write receipts: host "
+            f"'{host}' is not the resident host '{RESIDENT_HOST}'. Every "
+            "BRIDGED_LABELS entry is a Pro-only launchd job — running here "
+            "would stamp ~/.organism/last_seen/ with a false-failed receipt "
+            "for each of them. Pass --allow-off-host to override (tests only).",
+            file=sys.stderr,
+        )
+        return 0
 
     if args.launchctl_file:
         agents = parse_launchctl(Path(args.launchctl_file).read_text(encoding="utf-8"))

--- a/scripts/tests/test_launchagent_state_bridge_host_guard.py
+++ b/scripts/tests/test_launchagent_state_bridge_host_guard.py
@@ -1,0 +1,120 @@
+"""Tests for launchagent-state-bridge's host-residency guard (2026-07-10).
+
+Root cause this pins shut: BRIDGED_LABELS is a fixed list of ~90 Pro-only
+launchd job labels (com.balizero.*, com.nuzantara.*, homebrew.mxcl.*). An
+ad-hoc `--json` diagnostic run on Mini (2026-07-09 21:27, evidence
+/tmp/launchagent-state-bridge-mini.{json,err}) executed happily off-host:
+`launchctl list` succeeded locally, every Pro-only label was legitimately
+absent there, and build_receipt() wrote "label not loaded" -> status=failed
+for all ~90 of them into ~/.organism/last_seen/ — surfaced the next session
+by proprioception's organs_heartbeat probe as a 78-organ P1 false alarm.
+
+Contract (guilt + innocence, per cicatrix-superscar #2/#10 antidote):
+  - GUILT: running off the resident host writes NO receipts (main() no-ops,
+    exit 0 — a diagnostic mistake must not corrupt state, but also must not
+    look like a hard failure to a caller).
+  - INNOCENCE: running ON the resident host, or with --allow-off-host,
+    writes receipts exactly as before the guard existed.
+  - running_on_resident_host() is case-insensitive and considers only the
+    first dot-separated label (handles "Nuzantara.local" style nodenames),
+    mirroring organism_stale_detector.py's _core_organs_expected_here().
+
+The module name is loaded via importlib (hyphenated filename), mirroring
+test_dlq_corpse_sweep_organism.py.
+"""
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture()
+def bridge():
+    if _SCRIPTS_DIR not in sys.path:
+        sys.path.insert(0, _SCRIPTS_DIR)
+    spec = importlib.util.spec_from_file_location(
+        "launchagent_state_bridge_host_guard",
+        os.path.join(_SCRIPTS_DIR, "launchagent-state-bridge.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # dataclasses + `from __future__ import annotations` resolves string
+    # annotations via sys.modules[cls.__module__] — the module must be
+    # registered there before exec_module() runs the class bodies.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestRunningOnResidentHost:
+    def test_exact_match(self, bridge):
+        assert bridge.running_on_resident_host("nuzantara") is True
+
+    def test_case_insensitive(self, bridge):
+        assert bridge.running_on_resident_host("Nuzantara") is True
+
+    def test_first_label_only(self, bridge):
+        """A hostname with a domain suffix still matches on the first label."""
+        assert bridge.running_on_resident_host("Nuzantara.local") is True
+
+    def test_mini_is_not_resident(self, bridge):
+        assert bridge.running_on_resident_host("mini-pro2") is False
+
+    def test_air_m5_is_not_resident(self, bridge):
+        assert bridge.running_on_resident_host("Air-M5") is False
+
+
+class TestMainHostGuard:
+    """main() must not touch launchctl or ~/.organism/last_seen/ off-host."""
+
+    def test_off_host_writes_no_receipts(self, bridge, tmp_path, monkeypatch):
+        monkeypatch.setattr(bridge, "running_on_resident_host", lambda *_: False)
+        launchctl_file = tmp_path / "launchctl.txt"
+        launchctl_file.write_text("1234\t0\tcom.balizero.qdrant.daemon\n")
+        last_seen = tmp_path / "last_seen"
+
+        rc = bridge.main([
+            "--launchctl-file", str(launchctl_file),
+            "--last-seen-dir", str(last_seen),
+            "--no-legacy",
+        ])
+
+        assert rc == 0
+        assert not last_seen.exists() or list(last_seen.iterdir()) == []
+
+    def test_on_host_writes_receipts(self, bridge, tmp_path, monkeypatch):
+        monkeypatch.setattr(bridge, "running_on_resident_host", lambda *_: True)
+        monkeypatch.setattr(bridge, "BRIDGED_TCP_PROBES", ())  # no real network I/O
+        launchctl_file = tmp_path / "launchctl.txt"
+        launchctl_file.write_text("1234\t0\tcom.balizero.qdrant.daemon\n")
+        last_seen = tmp_path / "last_seen"
+
+        rc = bridge.main([
+            "--launchctl-file", str(launchctl_file),
+            "--last-seen-dir", str(last_seen),
+            "--no-legacy",
+        ])
+
+        assert rc == 0
+        written = {p.name for p in last_seen.iterdir()}
+        assert "infra.qdrant_pro.json" in written
+
+    def test_allow_off_host_overrides_guard(self, bridge, tmp_path, monkeypatch):
+        monkeypatch.setattr(bridge, "running_on_resident_host", lambda *_: False)
+        monkeypatch.setattr(bridge, "BRIDGED_TCP_PROBES", ())  # no real network I/O
+        launchctl_file = tmp_path / "launchctl.txt"
+        launchctl_file.write_text("1234\t0\tcom.balizero.qdrant.daemon\n")
+        last_seen = tmp_path / "last_seen"
+
+        rc = bridge.main([
+            "--launchctl-file", str(launchctl_file),
+            "--last-seen-dir", str(last_seen),
+            "--no-legacy",
+            "--allow-off-host",
+        ])
+
+        assert rc == 0
+        written = {p.name for p in last_seen.iterdir()}
+        assert "infra.qdrant_pro.json" in written


### PR DESCRIPTION
## Summary
- `scripts/launchagent-state-bridge.py`'s `BRIDGED_LABELS` is a fixed list of ~90 Pro-only launchd job labels. Running the script on any other host still "succeeds" (`launchctl list` works locally) but every label is legitimately absent there, so every receipt gets written as `status=failed / "label not loaded"`.
- Root cause of a real incident: an ad-hoc `--json` diagnostic run on Mini on 2026-07-09 21:27 (evidence `/tmp/launchagent-state-bridge-mini.{json,err}`, still on disk) silently clobbered `~/.organism/last_seen/` with 87 false-failed receipts for Pro-only organs. `proprioception.py`'s `organs_heartbeat` probe surfaced this the next session as a 78-organ P1 ("breathing but status=failed").
- `main()` now checks `running_on_resident_host()` (same idiom as `mini-fleet-watch.sh`'s `G4_node_guard`) before touching `launchctl` or writing any receipt. Off-host it refuses gracefully (stderr explanation, exit 0) unless `--allow-off-host` is passed (tests only).
- The 87 garbage receipts already on Mini's local `~/.organism/last_seen/` were identified precisely (`source=launchagent-state-bridge` + `host=mini-pro2` + has a `label` key, i.e. not the legitimate TCP probe) and deleted this tick — `organism_stale_detector.py --json` now returns `[]` on Mini.

## Test plan
- [x] `apps/backend-rag/.venv/bin/python3 -m pytest scripts/tests/test_launchagent_state_bridge_host_guard.py -v` — 8/8 passed (host-match logic + main() guard on/off-host/override).
- [x] `apps/backend-rag/.venv/bin/python3 -m pytest scripts/tests/test_organism_stale_detector.py scripts/tests/test_dlq_corpse_sweep_organism.py -q` — 21/21 passed, no regression.
- [x] `python3 -m py_compile scripts/launchagent-state-bridge.py scripts/tests/test_launchagent_state_bridge_host_guard.py` — clean.
- [x] Live functional check on Mini: `python3 scripts/launchagent-state-bridge.py --json --last-seen-dir /tmp/state-bridge-guard-test` refuses with exit 0, directory never created.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>