### PR TITLE
fix(kbli): replace HeaderWhatsAppCTA with WhatsAppLeadButton in layout

### DIFF
--- a/apps/mouth/src/app/kbli/layout.tsx
+++ b/apps/mouth/src/app/kbli/layout.tsx
@@ -1,7 +1,8 @@
 import { Montserrat } from "next/font/google";
 import { NavShell, BZLogo } from "@balizero/core";
 import { SessionInit } from "@/components/funnel/SessionInit";
-import { HeaderWhatsAppCTA } from "@/components/funnel/HeaderWhatsAppCTA";
+import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
+import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
 import { getFunnelNavItems } from "@/components/funnel/funnel-nav";
 import { MobileNav } from "@/app/v2/_components/MobileNav";
 
@@ -30,7 +31,21 @@ export default function KBLILayout({
         logo={<BZLogo variant="full" />}
         items={navItems}
         slotAfter={<MobileNav items={navItems} />}
-        actions={<HeaderWhatsAppCTA funnel="kbli" />}
+        actions={
+          <WhatsAppLeadButton
+            source="kbli_navigator"
+            whatsappContext={[{ label: "Source", value: "KBLI Navigator" }]}
+            utm={{ page: "/kbli" }}
+            fallbackHref={buildWhatsAppLink("kbli")}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-md text-[11px] font-semibold uppercase tracking-wide"
+            style={{
+              background: "var(--accent-funnel)",
+              color: "var(--text-on-accent)",
+            }}
+          >
+            Get Started
+          </WhatsAppLeadButton>
+        }
       />
       <SessionInit funnel="kbli" />
       <div className="mx-auto max-w-6xl px-4 pt-14 pb-8 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
Replaces hardcoded `wa.me` href in KBLI navbar with `WhatsAppLeadButton` to restore `lead_intents` attribution.

**Violation:** `HeaderWhatsAppCTA` fired only a frontend GA4 event — zero `/api/lead/capture` POST, all KBLI navbar leads invisible to CRM.

**Fix:** Surgical KBLI-only replacement in `kbli/layout.tsx`. Uses `source='kbli_navigator'` (existing LeadSource enum, no backend change needed). Fallback via `buildWhatsAppLink('kbli')` on API failure. Styling preserved.

**Files changed:** 1 (`apps/mouth/src/app/kbli/layout.tsx`)