### PR TITLE
chore: gitignore .playwright-cli/ browser logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,6 +270,7 @@ docs/generated/
 coverage.json
 # Auto-generated Playwright extensions
 .playwright-mcp/
+.playwright-cli/
 apps/mouth/coverage/
 lint_*.txt
 


### PR DESCRIPTION
The browser skill writes transient console/page logs to `.playwright-cli/` (mirrors the already-ignored `.playwright-mcp/`). Debug artifacts, not source. 1-line ignore.