### PR TITLE
fix(wr2): bind evidence-carved {{take_label}}/{{take_line}} in composer

### DIFF
--- a/scripts/wr2_html_renderer/tests/test_each_block_render.py
+++ b/scripts/wr2_html_renderer/tests/test_each_block_render.py
@@ -93,6 +93,30 @@ def main() -> int:
     )
     passed &= _check("escaping: < and & escaped in row", "&lt;" in out5 and "&amp;" in out5)
 
+    # --- evidence-carved take-block scalar bind (2026-07-11 revise-run S7) -----
+    # GUILT: {{take_label}}/{{take_line}} were UNBOUND in _fill_placeholders →
+    # raw mustache leaked as literal text at slide bottom (critic FAIL).
+    take_tmpl = (
+        '<div class="take-label">{{take_label}}</div>'
+        '<div class="take-text">{{take_line}}</div>'
+    )
+    out_take = C._fill_placeholders(
+        take_tmpl,
+        {"take_label": "OUR READ", "take_line": "PRICED BY DECREE."},
+        hero_filename=None,
+    )
+    passed &= _check("take: label interpolated", "OUR READ" in out_take)
+    passed &= _check("take: line interpolated", "PRICED BY DECREE." in out_take)
+    passed &= _check("take: no raw {{take_label}}", "{{take_label}}" not in out_take)
+    passed &= _check("take: no raw {{take_line}}", "{{take_line}}" not in out_take)
+
+    # INNOCENCE: a slide with no take fields leaves NO placeholder behind.
+    out_no_take = C._fill_placeholders(take_tmpl, {"heading": "X"}, hero_filename=None)
+    passed &= _check(
+        "take innocence: absent fields → no leaked mustache",
+        "{{take_label}}" not in out_no_take and "{{take_line}}" not in out_no_take,
+    )
+
     print()
     print("RESULT:", "ALL PASS" if passed else "FAILURES")
     return 0 if passed else 1


### PR DESCRIPTION
## Problem
`_fill_placeholders` bound heading/subhead/body/statement/qa fields and the `{{#each}}` loop blocks, but never the `evidence-carved` **take** scalars. Any `evidence-carved` slide supplying a take shipped raw `{{take_label}}`/`{{take_line}}` mustache that leaked as literal text at the slide bottom.

Caught by `wr2-critic` on the 2026-07-11 visa-PNBP carousel revise run — slide 7 rendered a literal `{{TAKE_LABEL}}` / `{{take_line}}` at the bottom (single-slide binary FAIL; the rest of the deck was release-ready).

## Fix
Bind both scalars in the `replacements` dict via `_html_escape`, defaulting to empty string so a slide with **no** take never leaks a placeholder either.

## Test
Added guilt + innocence cases to `test_each_block_render.py`:
- guilt: take_label/take_line interpolate, no raw mustache remains
- innocence: absent fields leave no leaked placeholder

All 23 checks in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)