### PR TITLE
feat(article): Add article 'Indonesia Visa Revenue Breaks Rp2.8 Trillion Despi...'

### DIFF
--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.mdx
@@ -1,0 +1,93 @@
+---
+title: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
+slug: "indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty"
+excerpt: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
+coverImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.jpg"
+cardImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty_card.jpg"
+coverImageAlt: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
+category: "immigration"
+tags: ["immigration", "indonesia", "visa", "revenue", "breaks"]
+publishedAt: "2026-07-11"
+author:
+  name: "Exa: nusadaily.com"
+  avatar: /static/zantara-avatar.png
+trending: false
+featured: false
+readingTime: 3
+difficulty: "intermediate"
+seoTitle: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global..."
+seoDescription: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
+aiGenerated: true
+aiConfidenceScore: 0.85
+aiOptimization:
+  answerSnippet: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
+  primaryQuestion: "What does Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty mean for expats in Bali?"
+
+---
+
+## TL;DR
+
+<InfoCard
+  title="Quick Summary"
+  items={[
+    { label: "Should I Worry?", value: "Depends" },
+    { label: "Risk Level", value: "Medium" },
+    { label: "Who's Affected", value: "Expats and investors in Indonesia" },
+    { label: "When", value: "Check article for specific dates" },
+  ]}
+/>
+
+**Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion,**
+
+---
+
+## The Facts
+
+Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued demand for Indonesian entry and stay permits even as international trade flows and capital markets face external shocks.
+
+PNBP — Penerimaan Negara Bukan Pajak, or Non-Tax State Revenue — constitutes a critical income stream for Indonesia's immigration apparatus. It encompasses fees charged for visa issuance, extensions, temporary stay permits (KITAS), permanent stay permits (KITAP), sponsored work permits, and related administrative services. The tariff schedule underpinning these collections is set by Government Regulation (Peraturan Pemerintah) and revised periodically in line with state budget priorities.
+
+At Rp2.8 trillion, the figure represents a substantial fiscal intake from the immigration sector alone. Indonesia's immigration revenues have trended upward in recent years, driven by the resumption of international travel following the pandemic, the launch of new visa products including the Second Home Visa (E33G) and the Remote Worker Visa (E33H), and sustained structural demand from the investor and digital nomad communities concentrated in Bali, Lombok, and Jakarta.
+
+The framing of this announcement — positioned explicitly against global economic uncertainty — appears deliberate. Officials have in recent statements highlighted immigration revenue as a resilient income source even when trade volumes contract, pointing to the structural demand for Indonesian residency and entry from retirees, entrepreneurs, and location-independent workers as an insulating factor.
+
+The precise reporting period, the breakdown by visa category, and whether Rp2.8 trillion represents a year-to-date, full-year, or cumulative multi-year total were not available in the source material examined. Verification of these specifics against official Direktorat Jenderal Imigrasi data or Ministry of Law and Human Rights budget publications is strongly advised before citing the headline number in a legal or financial context.
+
+---
+
+## Bali Zero Take
+
+### The Hidden Insight
+
+A Rp2.8 trillion PNBP milestone matters to clients for one reason above all: governments protect and grow revenue streams that perform. When immigration fees demonstrate this resilience — posting reco
+
+### Our Analysis
+
+rd-level figures while global markets wobble — the political incentive shifts firmly toward sustaining the tariff structure, not reducing it. The next Government Regulation revision on immigration PNB
+
+### Our Advice
+
+P is more likely to hold or edge rates upward than to cut them.
+
+For Bali-based foreigners, the more important signal is structural. This revenue performance validates Indonesia's strategy of broadening its immigration product line — Second Home Visa, multiple-entry business visa, investor KITAS — and makes further product launches politically viable. New visa products tend to arrive with new PNBP categories attached.
+
+The near-term risk for clients mid-permit is minimal. PNBP tariff changes require a new Government Regulation and are not applied retroactively. The exposure window is at renewal or fresh application — which is precisely when a current fee audit should be standard practice before any commitment is made.
+
+---
+
+## Next Steps
+
+<Checklist
+  title="Action Items"
+  items={[
+    { text: "For Expats", subItems: ["riate KITAS should model immigration costs over the next 24 months, treating a 10\u201320% PNBP increase as a conservative planning scenario. Monitor official publications from Direktorat Jenderal Imigrasi at imigrasi.go.id and the Ministry of Law and Human Rights for any new Government Regulation on PNBP tariffs. If you are evaluating a first visa application or a permit upgrade, schedule a consultation before the next expected revision window."] },
+    { text: "For Investors", subItems: ["Review the article for specific actions"] },
+  ]}
+/>
+
+---
+
+<AskZantara
+  question="Have questions about this topic?"
+  placeholder="Ask Zantara AI for personalized advice..."
+/>


### PR DESCRIPTION
feat(article): Add article 'Indonesia Visa Revenue Breaks Rp2.8 Trillion Despi...'

Category: immigration
Position: hero_main

🤖 Published via Article Composer

Auto-opened by Article Composer (News Room publish). Auto-merge enabled — merges once required checks pass.