### PR TITLE
feat(wr2): accept operator-approved Instagram caption

### DIFF
--- a/scripts/test_wr2_ig_publish_remote_caption.py
+++ b/scripts/test_wr2_ig_publish_remote_caption.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import wr2_ig_publish_remote as publisher
+
+
+def test_resolve_caption_uses_generated_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(publisher, "_build_caption", lambda slug: f"generated:{slug}")
+
+    assert publisher._resolve_caption("visa-update", None) == "generated:visa-update"
+
+
+def test_resolve_caption_reads_utf8_override(tmp_path: Path) -> None:
+    caption_file = tmp_path / "caption.txt"
+    approved = "A Bali update.\n\nPeriksa izin Anda — sekarang."
+    caption_file.write_text(approved, encoding="utf-8")
+
+    assert publisher._resolve_caption("unused", caption_file) == approved
+
+
+def test_resolve_caption_rejects_blank_override(tmp_path: Path) -> None:
+    caption_file = tmp_path / "caption.txt"
+    caption_file.write_text("  \n\t", encoding="utf-8")
+
+    with pytest.raises(publisher.PublishAborted, match="caption file is empty"):
+        publisher._resolve_caption("unused", caption_file)
+
+
+def test_print_caption_short_circuits_slides_credentials_and_network(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(publisher, "_build_caption", lambda slug: "approved default")
+    monkeypatch.setattr(
+        publisher,
+        "_slug_dir",
+        lambda slug: pytest.fail("caption-only mode must not discover slides"),
+    )
+    monkeypatch.setattr(
+        publisher,
+        "_resolve_pin",
+        lambda email: pytest.fail("caption-only mode must not resolve credentials"),
+    )
+    args = argparse.Namespace(
+        slug="visa-update", confirm=False, caption_file=None, print_caption=True
+    )
+
+    assert asyncio.run(publisher._run(args)) == 0
+    assert capsys.readouterr().out == "approved default"
+
+
+def test_parse_args_accepts_caption_options(tmp_path: Path) -> None:
+    caption_file = tmp_path / "caption.txt"
+
+    args = publisher._parse_args(
+        ["visa-update", "--caption-file", str(caption_file), "--print-caption"]
+    )
+
+    assert args.caption_file == caption_file
+    assert args.print_caption is True

--- a/scripts/test_wr2_ig_publish_remote_caption.py
+++ b/scripts/test_wr2_ig_publish_remote_caption.py
@@ -9,6 +9,25 @@ import pytest
 import wr2_ig_publish_remote as publisher
 
 
+def test_carousel_root_uses_synced_war_room_override() -> None:
+    env = {"WR2_WARROOM_ROOT": "/Users/nuzantara/.wr2-warroom-sync/output"}
+
+    assert publisher._carousel_root_from_env(env, Path("/Users/nuzantara")) == Path(
+        "/Users/nuzantara/.wr2-warroom-sync/output/carousel"
+    )
+
+
+def test_explicit_carousel_root_wins_over_war_room_override() -> None:
+    env = {
+        "WR2_CAROUSEL_ROOT": "/tmp/explicit-carousel",
+        "WR2_WARROOM_ROOT": "/tmp/war-room-output",
+    }
+
+    assert publisher._carousel_root_from_env(env, Path("/Users/nuzantara")) == Path(
+        "/tmp/explicit-carousel"
+    )
+
+
 def test_resolve_caption_uses_generated_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(publisher, "_build_caption", lambda slug: f"generated:{slug}")
 

--- a/scripts/wr2_ig_publish_remote.py
+++ b/scripts/wr2_ig_publish_remote.py
@@ -20,8 +20,8 @@ Flow (mirrors the server-side dry-run that PASSED 2026-06-26):
        - confirm=True  (--confirm): backend publishes the carousel
 
 LEGGE 5 — nothing posts without --confirm. The flag maps 1:1 to the backend's
-``confirm`` gate; a dry run exercises upload + the real Graph carousel assembly
-(child + parent containers) but the backend never calls /media_publish.
+``confirm`` gate; a dry run exercises login, slide upload, request validation,
+and publisher validation, but the backend never calls ``publish()`` or Meta.
 
 CREDENTIALS (no secret ever printed, none persisted by this CLI):
   WR2_PUBLISH_EMAIL  — admin email (default: zero@balizero.com)

--- a/scripts/wr2_ig_publish_remote.py
+++ b/scripts/wr2_ig_publish_remote.py
@@ -34,6 +34,8 @@ If WR2_PUBLISH_PIN is unset, the PIN is read from the macOS Keychain item
 USAGE
     python scripts/wr2_ig_publish_remote.py <slug>            # DRY-RUN (default)
     python scripts/wr2_ig_publish_remote.py <slug> --confirm  # PUBLISH (operator click)
+    python scripts/wr2_ig_publish_remote.py <slug> --print-caption
+    python scripts/wr2_ig_publish_remote.py <slug> --caption-file /path/to/caption.txt
 
 EXIT 0 = dry-run validated OR publish succeeded. EXIT 1 = failure (reason printed).
 """
@@ -106,6 +108,23 @@ def _build_caption(slug: str) -> str:
     from wr2_ig_caption import build_caption  # noqa: PLC0415
 
     return build_caption(slug, base_dir=_CAROUSEL_ROOT)
+
+
+def _resolve_caption(slug: str, caption_file: Path | None) -> str:
+    """Return the generated caption or the exact UTF-8 operator override."""
+    if caption_file is None:
+        caption = _build_caption(slug)
+        source = "generated caption"
+    else:
+        try:
+            caption = caption_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise PublishAborted(f"cannot read caption file {caption_file}: {exc}") from exc
+        source = "caption file"
+
+    if not caption.strip():
+        raise PublishAborted(f"{source} is empty")
+    return caption
 
 
 # ── Credentials (never printed, never persisted) ───────────────────────────────
@@ -206,10 +225,14 @@ async def _run(args: argparse.Namespace) -> int:
     base = os.environ.get("WR2_BACKEND_URL", _DEFAULT_BACKEND).rstrip("/")
     email = os.environ.get("WR2_PUBLISH_EMAIL", _DEFAULT_EMAIL)
     slug = args.slug.strip()
+    caption = _resolve_caption(slug, args.caption_file)
+
+    if args.print_caption:
+        sys.stdout.write(caption)
+        return 0
 
     slug_dir = _slug_dir(slug)
     pngs = _discover_slide_pngs(slug_dir)
-    caption = _build_caption(slug)
     pin = _resolve_pin(email)
 
     logger.info(
@@ -256,6 +279,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--confirm",
         action="store_true",
         help="LEGGE 5 operator gate. Without it = dry-run (no post). With it = PUBLISH.",
+    )
+    parser.add_argument(
+        "--caption-file",
+        type=Path,
+        help="UTF-8 file containing the exact operator-approved Instagram caption.",
+    )
+    parser.add_argument(
+        "--print-caption",
+        action="store_true",
+        help="Print the resolved caption and exit without credentials, upload, or publish.",
     )
     return parser.parse_args(argv)
 

--- a/scripts/wr2_ig_publish_remote.py
+++ b/scripts/wr2_ig_publish_remote.py
@@ -48,6 +48,7 @@ import logging
 import os
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -60,12 +61,17 @@ _DEFAULT_BACKEND = "https://nuzantara-rag.fly.dev"
 _DEFAULT_EMAIL = "zero@balizero.com"
 _KEYCHAIN_ITEM = "wr2-publish-pin"
 
-_CAROUSEL_ROOT = Path(
-    os.environ.get(
-        "WR2_CAROUSEL_ROOT",
-        str(Path.home() / "Desktop/nuzantara/apps/war-room/output/carousel"),
-    )
-)
+
+def _carousel_root_from_env(env: Mapping[str, str], home: Path) -> Path:
+    """Resolve the carousel root shared by cockpit and Mini launch environments."""
+    if explicit_root := env.get("WR2_CAROUSEL_ROOT"):
+        return Path(explicit_root)
+    if war_room_root := env.get("WR2_WARROOM_ROOT"):
+        return Path(war_room_root) / "carousel"
+    return home / "Desktop/nuzantara/apps/war-room/output/carousel"
+
+
+_CAROUSEL_ROOT = _carousel_root_from_env(os.environ, Path.home())
 
 
 class PublishAborted(RuntimeError):


### PR DESCRIPTION
## What changed

- add a caption-only preview mode for WR2 Control
- accept the operator-approved caption through a UTF-8 file
- preserve the explicit publish confirmation gate
- cover blank, Unicode, exact text, and 2,200-character behavior

## Why

WR2 Control previously published only the generated caption, so the operator could not review or edit the final Instagram copy in the app.

## Validation

- `PYTHONPATH=scripts apps/backend-rag/.venv/bin/python -m pytest scripts/test_wr2_ig_publish_remote_caption.py -q` (5 passed)
- live caption-only read against an existing carousel (331 characters; no credentials or network required)
