### PR TITLE
fix(wr2): evidence-carved heading ignores line-break, text overflows canvas

### DIFF
--- a/skills/bali-zero-brand/layouts/evidence-carved.md
+++ b/skills/bali-zero-brand/layouts/evidence-carved.md
@@ -23,108 +23,131 @@ take_label: string
 
 ```html
 <!doctype html>
-<html><head>
-<link rel="stylesheet" href="./_base.css">
-<style>
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap');
-.hammurabi {
-  position: absolute; inset: 0;
-  background-image: url('hammurabi-stele.jpg');
-  background-size: cover;
-  background-position: center;
-  filter: brightness(0.55) contrast(1.05);
-}
-.darken {
-  position: absolute; inset: 0;
-  background: linear-gradient(180deg, rgba(0,0,0,0.45) 0%, rgba(0,0,0,0.65) 100%);
-}
-.content {
-  position: absolute;
-  left: var(--spacing-edge-margin);
-  right: var(--spacing-edge-margin);
-  top: 80px;
-  bottom: 180px;
-  display: flex; flex-direction: column;
-  color: var(--color-text-white);
-}
-.heading {
-  font-weight: var(--font-weight-extrabold);
-  font-size: 64px;
-  line-height: var(--line-height-tight);
-  letter-spacing: var(--letter-spacing-title);
-  color: var(--color-text-white);
-  text-transform: uppercase;
-  margin-bottom: 24px;
-  text-shadow: 0 2px 8px rgba(0,0,0,0.6);
-}
-.heading-divider {
-  width: 64px; height: 4px;
-  background: var(--color-accent-yellow);
-  margin-bottom: 36px;
-}
-.facts { display: flex; flex-direction: column; gap: 20px; flex: 1; }
-.fact { display: flex; align-items: flex-start; gap: 16px; padding-left: 4px; }
-.fact .marker {
-  font-weight: var(--font-weight-extrabold);
-  font-size: 24px;
-  color: var(--color-accent-yellow);
-  line-height: 1.2; min-width: 36px;
-}
-.fact .text {
-  font-weight: var(--font-weight-bold);
-  font-size: 26px;
-  line-height: 1.3;
-  letter-spacing: var(--letter-spacing-body);
-  color: var(--color-text-white);
-  /* text-transform removed 2026-05-22: respect storyboarder body_case_chosen=Title Case
+<html>
+  <head>
+    <link rel="stylesheet" href="./_base.css" />
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap");
+      .hammurabi {
+        position: absolute;
+        inset: 0;
+        background-image: url("hammurabi-stele.jpg");
+        background-size: cover;
+        background-position: center;
+        filter: brightness(0.55) contrast(1.05);
+      }
+      .darken {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          180deg,
+          rgba(0, 0, 0, 0.45) 0%,
+          rgba(0, 0, 0, 0.65) 100%
+        );
+      }
+      .content {
+        position: absolute;
+        left: var(--spacing-edge-margin);
+        right: var(--spacing-edge-margin);
+        top: 80px;
+        bottom: 180px;
+        display: flex;
+        flex-direction: column;
+        color: var(--color-text-white);
+      }
+      .heading {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 64px;
+        line-height: var(--line-height-tight);
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-text-white);
+        text-transform: uppercase;
+        margin-bottom: 24px;
+        text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+        white-space: pre-line;
+      }
+      .heading-divider {
+        width: 64px;
+        height: 4px;
+        background: var(--color-accent-yellow);
+        margin-bottom: 36px;
+      }
+      .facts {
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        flex: 1;
+      }
+      .fact {
+        display: flex;
+        align-items: flex-start;
+        gap: 16px;
+        padding-left: 4px;
+      }
+      .fact .marker {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 24px;
+        color: var(--color-accent-yellow);
+        line-height: 1.2;
+        min-width: 36px;
+      }
+      .fact .text {
+        font-weight: var(--font-weight-bold);
+        font-size: 26px;
+        line-height: 1.3;
+        letter-spacing: var(--letter-spacing-body);
+        color: var(--color-text-white);
+        /* text-transform removed 2026-05-22: respect storyboarder body_case_chosen=Title Case
      — uppercase on long body caused critic v1 FAIL (47/42/44 words vs ≤35 cap, S2/S4/S7 pilot
      Permenkumham 22-2024-kitap). Title Case body keeps readability + word count discipline. */
-  text-shadow: 0 1px 4px rgba(0,0,0,0.6);
-}
-.take {
-  margin-top: 24px;
-  padding: 16px 0 0 0;
-  border-top: 2px solid rgba(244, 196, 48, 0.4);
-}
-.take-label {
-  font-weight: var(--font-weight-bold);
-  font-size: 13px;
-  letter-spacing: 0.1em;
-  color: var(--color-accent-yellow);
-  text-transform: uppercase;
-  margin-bottom: 8px;
-}
-.take-text {
-  font-weight: var(--font-weight-bold);
-  font-size: 22px;
-  line-height: 1.25;
-  letter-spacing: var(--letter-spacing-body);
-  color: var(--color-text-white);
-  /* text-transform removed 2026-05-22: same fix as .fact .text (word count discipline). */
-  text-shadow: 0 1px 4px rgba(0,0,0,0.6);
-}
-</style></head>
-<body data-slide-index="2" data-layout="evidence-carved">
-  <div class="hammurabi" data-zone-type="background-texture"></div>
-  <div class="darken" data-zone-type="overlay"></div>
-  <div class="content" data-zone-type="text">
-    <div class="heading">{{heading}}</div>
-    <div class="heading-divider"></div>
-    <div class="facts">
-      {{#each facts}}
-      <div class="fact">
-        <div class="marker">§{{idx}}</div>
-        <div class="text">{{this}}</div>
+        text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+      }
+      .take {
+        margin-top: 24px;
+        padding: 16px 0 0 0;
+        border-top: 2px solid rgba(244, 196, 48, 0.4);
+      }
+      .take-label {
+        font-weight: var(--font-weight-bold);
+        font-size: 13px;
+        letter-spacing: 0.1em;
+        color: var(--color-accent-yellow);
+        text-transform: uppercase;
+        margin-bottom: 8px;
+      }
+      .take-text {
+        font-weight: var(--font-weight-bold);
+        font-size: 22px;
+        line-height: 1.25;
+        letter-spacing: var(--letter-spacing-body);
+        color: var(--color-text-white);
+        /* text-transform removed 2026-05-22: same fix as .fact .text (word count discipline). */
+        text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+      }
+    </style>
+  </head>
+  <body data-slide-index="2" data-layout="evidence-carved">
+    <div class="hammurabi" data-zone-type="background-texture"></div>
+    <div class="darken" data-zone-type="overlay"></div>
+    <div class="content" data-zone-type="text">
+      <div class="heading">{{heading}}</div>
+      <div class="heading-divider"></div>
+      <div class="facts">
+        {{#each facts}}
+        <div class="fact">
+          <div class="marker">§{{idx}}</div>
+          <div class="text">{{this}}</div>
+        </div>
+        {{/each}}
       </div>
-      {{/each}}
+      <div class="take">
+        <div class="take-label">{{take_label}}</div>
+        <div class="take-text">{{take_line}}</div>
+      </div>
     </div>
-    <div class="take">
-      <div class="take-label">{{take_label}}</div>
-      <div class="take-text">{{take_line}}</div>
-    </div>
-  </div>
-  <div class="logo" data-zone-type="logo"></div>
-</body></html>
+    <div class="logo" data-zone-type="logo"></div>
+  </body>
+</html>
 ```
 
 ## Example data (KEP-71 SPT extension)


### PR DESCRIPTION
## Summary
- `.heading` in the `evidence-carved` WR2 layout family had no `white-space` directive, so the browser collapsed the composer's explicit `\n` (used for 2-line titles, e.g. `"THE RULEBOOK BEHIND\nTHE REGISTER"`) into a single space.
- At 64px in a fixed-width flex column with no wrap constraint, the collapsed one-line title ran off the right edge of the 1080px canvas — found while fact-checking and re-rendering a live carousel (Indonesia visa revenue Rp2.8T, slide 7).
- Fix: add `white-space: pre-line;` so the composer's `\n` convention (composer.py:1109-1111 comment) is actually honored.

## Test plan
- [x] Re-rendered the affected carousel slide locally via `wr2_rerender_local.py` after the fix — headline now wraps to 2 lines within canvas bounds
- [ ] Spot-check other evidence-carved carousels for the same pre-existing overflow (this layout family predates the fix, so any 2-line heading carousel may be affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)