### PR TITLE
fix(wr2): evidence-carved text overflow — position-clobber + flex wrap + take_label bind

### DIFF
--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -250,7 +250,18 @@ def _hero_bg_to_img(html: str, hero_filename: str) -> str:
         "object-fit:cover;z-index:0;}\n"
         ".hero-scrim{position:absolute;inset:0;"
         "background:rgba(10,10,10,0.55);z-index:0;}\n"
-        "body > *:not(.hero-img):not(.hero-scrim){position:relative;z-index:1;}\n"
+        # :where(...) wraps the WHOLE selector so it carries 0 specificity and
+        # NEVER overrides a child's own `position` declaration (e.g.
+        # evidence-carved's `.content{position:absolute;left:...;right:...}`,
+        # which sets the slide's text-box width). Before this fix, the blanket
+        # `position:relative` here beat `.content`'s `position:absolute` on
+        # specificity+cascade order, silently dropping the left/right width
+        # constraint and letting long fact/body text overflow off-canvas
+        # (found 2026-07-11, evidence-carved slide overflow). NOTE: :where(*)
+        # alone (zeroing only the `*`) does NOT work — the :not() clauses
+        # outside :where() still count; the fix is to wrap the entire
+        # selector, verified via Playwright computed-style probe.
+        ":where(body > *:not(.hero-img):not(.hero-scrim)){position:relative;z-index:1;}\n"
     )
     html = html.replace("</style>", hero_img_css + "</style>", 1)
     img_tag = (
@@ -1106,6 +1117,13 @@ def _fill_placeholders(
         "{{regulation_code}}": reg,
         "{{statement}}": statement,
         "{{statement_html_with_emphasis_span}}": statement_emphasis_html,
+        # evidence-carved "take" block scalars. Previously UNBOUND → the raw
+        # mustache ({{take_label}}/{{take_line}}) shipped to the renderer and
+        # leaked as literal text at the bottom of every evidence-carved slide
+        # that supplied a take (critic FAIL, 2026-07-11 revise-run S7). Default
+        # to empty so a slide with no take never leaks a placeholder either.
+        "{{take_label}}": _html_escape((slide.get("take_label") or "").strip()),
+        "{{take_line}}": _html_escape((slide.get("take_line") or "").strip()),
     }
     # qa-dialogue: map qa_pairs → the template's flat voice_a/voice_b fields.
     for fk, fv in _qa_dialogue_fields(slide).items():

--- a/skills/bali-zero-brand/layouts/evidence-carved.md
+++ b/skills/bali-zero-brand/layouts/evidence-carved.md
@@ -92,6 +92,8 @@ take_label: string
         min-width: 36px;
       }
       .fact .text {
+        flex: 1;
+        min-width: 0;
         font-weight: var(--font-weight-bold);
         font-size: 26px;
         line-height: 1.3;


### PR DESCRIPTION
## Summary
Follow-up to #2254 (which fixed the heading `\n` collapse). After that fix, slide 7 body facts still overflowed off-canvas and the take block leaked literal `{{TAKE_LABEL}}`/`{{take_line}}`. Root-caused via a live carousel re-render (Indonesia visa revenue Rp2.8T):

1. `composer.py`'s hero-img fallback CSS (`body > *:not(.hero-img):not(.hero-scrim){position:relative}`) had higher specificity + later cascade order than evidence-carved's own `.content{position:absolute;left:...;right:...}` — silently dropping the left/right width constraint that bounds ALL text in the slide. Fix: wrap the whole selector in `:where(...)` for 0 specificity.
2. `.fact .text` (evidence-carved layout spec) had no `flex:1` / `min-width:0`, so as a flex-row child next to the `§` marker it could refuse to shrink below its content's intrinsic width even once the parent width was fixed by (1).
3. `{{take_label}}`/`{{take_line}}` were unbound placeholders in `composer.py`'s `_fill_placeholders` map — shipped as literal mustache text on every evidence-carved slide with a take block (already flagged by the 2026-07-11 critic run, S7 FAIL).

## Test plan
- [x] Re-rendered the affected carousel slide locally via `wr2_rerender_local.py` after each fix, verified via direct Playwright screenshot — headline wraps, body text stays within canvas bounds, take block renders "OUR READ" + line instead of literal placeholders
- [x] Verified specificity fix with an isolated Playwright computed-style probe (`getComputedStyle(el).position` stays `absolute` after the fix, was `relative` before)
- [ ] Spot-check other evidence-carved carousels for the same pre-existing overflow (this layout family predates the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)