### PR TITLE
feat(wr2): per-slide color override + stat-card-hero + numbered-forces-list layouts

### DIFF
--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -61,14 +61,21 @@ RENDERABLE_FAMILIES = {
     "statement-bomb",
     "elegant-close",
     "source-citation",
+    "stat-card-hero",
+    "numbered-forces-list",
 }
 
 # Families named in tokens.json layout_defaults but with NO skeleton yet
 # (GROUND gap #1). The composer must NEVER silently emit one of these — it would
 # produce a blank/broken slide. If a mapping would pick one, fall back + warn.
+# "stat-card-hero" REMOVED 2026-07-11: it now has a real skeleton
+# (layouts/stat-card-hero.md, bar-comparison chart support) and belongs in
+# RENDERABLE_FAMILIES only — it was previously listed in BOTH sets, which
+# meant an explicit pin was silently downgraded to photo-headline-yellow-sub
+# even though the RENDERABLE_FAMILIES check ran first (dead code path, never
+# actually exercised because no slides.json pinned it before this fix).
 UNDEFINED_FAMILIES = {
     "swiss-grid-asymmetry",
-    "stat-card-hero",
     "thin-red-rule-divider",
     "monospace-evidence-block",
     "three-verdicts",
@@ -841,6 +848,14 @@ _FACT_LABEL_MAX_WORDS = 4
 # skeleton's .text-panel is already a flex column, so this is positioning-inert
 # for every other element. Selectors are defensive descendants of the
 # skeleton's .body slot; unused selectors are inert (same approach as levers).
+_BAR_ITEMS_BLOCK_CSS = (
+    "\n<style data-bar-items-block=\"1\">\n"
+    ".body{display:flex;flex-direction:column;gap:20px;}\n"
+    ".body-item{border-left:4px solid var(--color-accent-yellow);"
+    "padding-left:16px;}\n"
+    "</style>\n"
+)
+
 _FACTS_BLOCK_CSS = (
     "\n<style data-facts-block=\"1\">\n"
     ".text-panel{justify-content:center;}\n"
@@ -1015,12 +1030,43 @@ def _qa_dialogue_fields(slide: dict[str, Any]) -> dict[str, str]:
     return out
 
 
+# Token names storyboarder/critic use for heading_color/subhead_color →
+# the brand CSS custom property they resolve to. "yellow-accent" is an
+# alias seen on statement-bomb slides for the same accent token.
+_COLOR_TOKEN_VARS = {
+    "yellow": "var(--color-accent-yellow)",
+    "yellow-accent": "var(--color-accent-yellow)",
+    "white": "var(--color-text-white)",
+}
+
+
+def _heading_color_override_css(slide: dict[str, Any]) -> str:
+    """Build a scoped !important <style> block for this slide's heading_color
+    / subhead_color, if present and recognized. Each slide renders as its own
+    standalone HTML file, so an !important override here can never leak into
+    another slide or carousel — it only ever wins the cascade within this one
+    document, on top of whatever default the layout family's own <style>
+    block already set.
+    """
+    rules = []
+    heading_color = _COLOR_TOKEN_VARS.get(str(slide.get("heading_color") or "").strip().lower())
+    if heading_color:
+        rules.append(f".heading,.headline{{color:{heading_color} !important;}}")
+    subhead_color = _COLOR_TOKEN_VARS.get(str(slide.get("subhead_color") or "").strip().lower())
+    if subhead_color:
+        rules.append(f".subheading,.subhead{{color:{subhead_color} !important;}}")
+    if not rules:
+        return ""
+    return '\n<style data-heading-color-override="1">\n' + "\n".join(rules) + "\n</style>\n"
+
+
 def _fill_placeholders(
     html: str,
     slide: dict[str, Any],
     *,
     hero_filename: str | None,
     cover_family: bool = False,
+    family: str = "",
 ) -> str:
     """Fill {{placeholders}} + simple {{#if}} blocks from a slide dict.
 
@@ -1032,6 +1078,40 @@ def _fill_placeholders(
     # (Canva) drafts use heading/subheading. Read BOTH so an old-schema draft does
     # not render a blank cover (vision: "no editorial text").
     headline = (slide.get("headline") or slide.get("heading") or "").strip()
+    # An author-supplied " / " is an explicit line-break marker (the
+    # storyboarder's way of forcing a 2-line split at a specific word
+    # boundary, e.g. cover-photo's "IDR 2.815 TRILLION / FROM VISAS ALONE")
+    # — never meant to render as a literal slash. Convert to <br> FIRST,
+    # before any wrap/font-fit/de-orphan pass runs, so those passes see an
+    # already-<br>-wrapped headline (a case they already no-op on) instead
+    # of a raw " / " they don't know about. stat-card-hero overrides this
+    # below with its own richer split (adds a <span class="lead">).
+    # statement-bomb is EXCLUDED: its {{statement}} falls back to this same
+    # `headline` (below), and statement_emphasis_html HTML-escapes the whole
+    # string — a raw <br> would come back as literal "&lt;br&gt;" text. That
+    # family already wraps naturally in the browser (no explicit breaks
+    # needed, verified against the target), so leave " / " as a plain space
+    # there instead of injecting a tag its own downstream escaping can't carry.
+    if family not in ("stat-card-hero", "statement-bomb") and " / " in headline:
+        headline = "<br>".join(part.strip() for part in headline.split(" / "))
+    elif family == "statement-bomb" and " / " in headline:
+        headline = " ".join(part.strip() for part in headline.split(" / "))
+    # numbered-forces-list only: pull the leading integer off the headline
+    # ("3 FORCES BEHIND THE RISE" -> numeral "3", heading "FORCES\nBEHIND
+    # THE RISE") for the giant-numeral graphic, BEFORE the de-orphan pass
+    # below glues the numeral to its noun with &nbsp; (which would break
+    # this regex's plain-space match). The remainder wraps to two lines at
+    # the midpoint word boundary so it balances against the numeral the way
+    # the target design does; a headline with no leading integer renders
+    # with no numeral (empty {{numeral}}, heading unchanged).
+    numeral = ""
+    if family == "numbered-forces-list":
+        m = re.match(r"^(\d+)\s+(.*)$", headline)
+        if m:
+            numeral = m.group(1)
+            rest_words = m.group(2).split()
+            mid = (len(rest_words) + 1) // 2
+            headline = " ".join(rest_words[:mid]) + "\n" + " ".join(rest_words[mid:])
     # rebalance_wrap lever (designer loop): re-wrap the headline into balanced
     # lines via a <br>. Text-only — applied here BEFORE placeholder substitution
     # so the skeleton's {{heading}}/{{statement}} carry the <br> verbatim (the
@@ -1056,6 +1136,14 @@ def _fill_placeholders(
     # Deterministic number de-orphan (belt-and-suspenders): glue any remaining
     # bare numeral to its noun so the browser can never strand it.
     headline = _deorphan_numbers_in_headline(headline)
+    # stat-card-hero only: a headline authored as "UNIT / VALUE VS VALUE"
+    # (e.g. "IDR / 2.815T VS 2.645T") splits on the slash into a small white
+    # unit line + the big yellow comparison line, matching the target design
+    # where the currency unit reads as a caption above the accent numbers.
+    # No-op for every other family and for a headline with no " / ".
+    if family == "stat-card-hero" and " / " in headline:
+        lead, _, rest = headline.partition(" / ")
+        headline = f'<span class="lead">{_html_escape(lead)}</span><br>{_html_escape(rest)}'
     subhead = (slide.get("subhead") or slide.get("subheading") or "").strip()
     body = (slide.get("body") or slide.get("body_text") or "").strip()
     reg = (slide.get("regulation_code") or slide.get("primary_regulation_code") or "").strip()
@@ -1067,12 +1155,28 @@ def _fill_placeholders(
     # and NO facts CSS is injected → byte-identical to the legacy rendering.
     body_html = body
     facts_block = False
+    bar_items_block = False
     if body and not cover_family:
         body_wo_source, source_text = _split_source_line(body)
         pairs = _parse_fact_pairs(body_wo_source)
         if pairs:
             body_html = _facts_block_html(pairs, source_text)
             facts_block = True
+        elif family == "photo-headline-yellow-sub" and "\n\n" in body_wo_source:
+            # photo-headline-yellow-sub, 2-4 \n\n-separated statements: render
+            # as a yellow-bar-divided item stack (matches target design) instead
+            # of one run-on paragraph. Conservative — only when the body is
+            # ALREADY authored as blank-line-separated blocks (2-4 of them); a
+            # single-paragraph body for this family renders unchanged.
+            blocks = [b.strip() for b in body_wo_source.split("\n\n") if b.strip()]
+            if 2 <= len(blocks) <= 4:
+                body_html = "\n".join(
+                    f'<div class="body-item">{_emphasize_key_numbers(b)}</div>'
+                    for b in blocks
+                )
+                bar_items_block = True
+            else:
+                body_html = _emphasize_key_numbers(body_html)
         else:
             # Plain-paragraph body: yellow the crux regulatory number(s) so the
             # key fact pops (Art 6.9 anchor-highlight; option C 2026-06-24). The
@@ -1104,6 +1208,35 @@ def _fill_placeholders(
         else:
             statement_emphasis_html = f'<span class="emphasis">{words[0]}</span>'
 
+    # stat-card-hero's bar-comparison chart: flatten slide["chart"]["rows"] to a
+    # top-level "chart_rows" array (the {{#each}} expander only reads top-level
+    # slide keys, no dotted paths) and compute each row's bar width as a % of
+    # the max value in the set, so the two/three bars are proportionally
+    # comparable at a glance (mirrors the target design's grey-vs-yellow
+    # bar-comparison). Numeric value is parsed out of the row's display string
+    # (e.g. "IDR 2.645T" -> 2.645) — first float found, unit-agnostic since all
+    # rows in one chart share the same unit.
+    chart = slide.get("chart")
+    if isinstance(chart, dict) and isinstance(chart.get("rows"), list) and chart["rows"]:
+        rows = chart["rows"]
+        parsed = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            m = re.search(r"[\d.]+", str(row.get("value") or ""))
+            parsed.append(float(m.group()) if m else 0.0)
+        max_val = max(parsed) if parsed else 0.0
+        chart_rows = []
+        for row, val in zip(rows, parsed):
+            pct = round((val / max_val) * 100) if max_val > 0 else 0
+            chart_rows.append({
+                "label": row.get("label") or "",
+                "value": row.get("value") or "",
+                "bar_pct": max(pct, 4),  # floor so a near-zero row still shows a sliver
+                "is_max": val >= max_val and max_val > 0,
+            })
+        slide = {**slide, "chart_rows": chart_rows}
+
     # Expand {{#each <var>}} list blocks FIRST (dark-status-list / evidence-carved /
     # source-citation / timeline-pinboard) so the loop rows are materialized before
     # the scalar placeholder pass. Previously unhandled → raw mustache shipped.
@@ -1124,6 +1257,9 @@ def _fill_placeholders(
         # to empty so a slide with no take never leaks a placeholder either.
         "{{take_label}}": _html_escape((slide.get("take_label") or "").strip()),
         "{{take_line}}": _html_escape((slide.get("take_line") or "").strip()),
+        # numbered-forces-list giant numeral (extracted above from the
+        # headline's leading integer). Empty for every other family.
+        "{{numeral}}": numeral,
     }
     # qa-dialogue: map qa_pairs → the template's flat voice_a/voice_b fields.
     for fk, fv in _qa_dialogue_fields(slide).items():
@@ -1156,6 +1292,26 @@ def _fill_placeholders(
         else:
             html = html + font_css
 
+    # Per-slide heading/subhead color override. storyboarder emits
+    # heading_color/subhead_color (e.g. "yellow", "white", "yellow-accent")
+    # on every slide, but every layout family hardcodes its own default
+    # palette in the .md skeleton's <style> block (verified correct as the
+    # established GLOBAL default across other carousels — must not be
+    # edited). When a slide's value DIFFERS from that family's baked-in
+    # default, scope an !important override to this slide only, appended
+    # after the skeleton's own <style> so cascade order wins without
+    # touching the shared template. No-op (empty override) when the field
+    # is absent or already matches the default, so unrelated carousels are
+    # byte-identical.
+    color_css = _heading_color_override_css(slide)
+    if color_css:
+        if "</head>" in html:
+            html = html.replace("</head>", color_css + "</head>", 1)
+        elif "</body>" in html:
+            html = html.replace("</body>", color_css + "</body>", 1)
+        else:
+            html = html + color_css
+
     # Inject the facts-block styles ONLY when the stack was rendered, so a
     # non-parsing body stays byte-identical to the legacy paragraph output.
     if facts_block:
@@ -1165,6 +1321,15 @@ def _fill_placeholders(
             html = html.replace("</body>", _FACTS_BLOCK_CSS + "</body>", 1)
         else:
             html = html + _FACTS_BLOCK_CSS
+
+    # Same pattern for the photo-headline-yellow-sub bar-items body split.
+    if bar_items_block:
+        if "</head>" in html:
+            html = html.replace("</head>", _BAR_ITEMS_BLOCK_CSS + "</head>", 1)
+        elif "</body>" in html:
+            html = html.replace("</body>", _BAR_ITEMS_BLOCK_CSS + "</body>", 1)
+        else:
+            html = html + _BAR_ITEMS_BLOCK_CSS
 
     return html
 
@@ -1232,6 +1397,7 @@ async def compose_carousel(
             html = _fill_placeholders(
                 html, plan.slide, hero_filename=hero_filename,
                 cover_family=(plan.family == "cover-photo"),
+                family=plan.family,
             )
             html = _apply_levers_to_html(html, plan.slide)  # designer-loop levers
 
@@ -1299,7 +1465,8 @@ async def materialize_slide_html(
             flags=re.DOTALL,
         )
     html = _fill_placeholders(
-        html, slide, hero_filename=hero_filename, cover_family=(family == "cover-photo")
+        html, slide, hero_filename=hero_filename, cover_family=(family == "cover-photo"),
+        family=family,
     )
     html = _apply_levers_to_html(html, slide)
 

--- a/skills/bali-zero-brand/layouts/numbered-forces-list.md
+++ b/skills/bali-zero-brand/layouts/numbered-forces-list.md
@@ -1,0 +1,145 @@
+# Layout family: numbered-forces-list
+
+> A giant numeral (matching the count named in the headline, e.g. "3
+> FORCES...") sits left of a two-line headline, followed by a stack of
+> yellow-label / white-caption items separated by a thin yellow rule. Used
+> for "N things driving X" enumerations where the count itself is the hook.
+> Distinct from `dark-status-list`: that family renders label=small-muted /
+> value=large (status enumeration); this one renders label=large-yellow /
+> value=small-white (numbered driver list) — inverting the hierarchy would
+> break every existing dark-status-list carousel, hence the separate family.
+
+## When to use
+
+- Headline names a count ("3 FORCES BEHIND THE RISE", "4 REASONS WHY...").
+- 2-4 items, each a short driver/force/reason + one-line elaboration.
+- Pin explicitly via `layout_family: "numbered-forces-list"` — never
+  auto-routed (needs the leading numeral parsed out of the headline AND a
+  structured `items` array, neither of which the generic non-hero routing
+  guarantees).
+
+## Parameters
+
+```yaml
+heading:
+  string # "N FORCES BEHIND THE RISE" — leading integer is extracted
+  # into the giant numeral graphic; the remainder is the
+  # two-line headline text next to it.
+items: # 2-4 items
+  - label: string # short driver name, rendered large + yellow
+    value: string # one-line elaboration, rendered small + white
+```
+
+## HTML/CSS skeleton
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="../_base.css" />
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap");
+      body {
+        padding: 110px var(--spacing-edge-margin) 180px
+          var(--spacing-edge-margin);
+        display: flex;
+        flex-direction: column;
+      }
+      .numeral-row {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: var(--spacing-edge-margin);
+      }
+      .numeral {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 160px;
+        line-height: 1;
+        color: var(--color-accent-yellow);
+      }
+      .heading {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 52px;
+        line-height: var(--line-height-tight);
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-accent-yellow);
+        text-transform: uppercase;
+        white-space: pre-line;
+      }
+      .items {
+        display: flex;
+        flex-direction: column;
+        gap: 28px;
+      }
+      .item {
+        border-left: 4px solid var(--color-accent-yellow);
+        padding-left: 20px;
+      }
+      .item .label {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 32px;
+        line-height: 1.15;
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-accent-yellow);
+        text-transform: uppercase;
+        margin-bottom: 6px;
+      }
+      .item .value {
+        font-weight: var(--font-weight-bold);
+        font-size: 24px;
+        line-height: 1.3;
+        letter-spacing: var(--letter-spacing-body);
+        color: var(--color-text-white);
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="numeral-row" data-zone-type="text">
+      <div class="numeral">{{numeral}}</div>
+      <div class="heading">{{heading}}</div>
+    </div>
+    <div class="items" data-zone-type="text">
+      {{#each items}}
+      <div class="item">
+        <div class="label">{{label}}</div>
+        <div class="value">{{value}}</div>
+      </div>
+      {{/each}}
+    </div>
+    <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
+  </body>
+</html>
+```
+
+## Example data (visa revenue drivers)
+
+```json
+{
+  "heading": "3 FORCES BEHIND THE RISE",
+  "items": [
+    {
+      "label": "SECOND HOME VISA",
+      "value": "E33 — THE PRODUCT DRIVING INVESTOR UPTAKE."
+    },
+    {
+      "label": "REMOTE WORKER VISA",
+      "value": "E33G — CAPTURES DIGITAL-NOMAD DEMAND."
+    },
+    {
+      "label": "DIGITAL TRANSFORMATION",
+      "value": "DIRECTOR GENERAL MARANTOKO CITES IT ALONGSIDE SELECTIVE POLICY."
+    }
+  ]
+}
+```
+
+## Common failures
+
+- Headline has no leading integer → composer falls back to no numeral
+  graphic (empty `{{numeral}}`), heading still renders full-width. Verify
+  the headline is authored "N ..." before pinning this family.
+- More than 4 items → numeral+heading proportions get crowded out, items
+  stack too tall for the canvas.
+- `value` longer than ~12 words → wraps to 3 lines, breaks the item's
+  visual rhythm against its siblings.

--- a/skills/bali-zero-brand/layouts/stat-card-hero.md
+++ b/skills/bali-zero-brand/layouts/stat-card-hero.md
@@ -1,0 +1,182 @@
+# Layout family: stat-card-hero
+
+> Text-only comparison slide: a big "A vs B" headline stat, followed by a
+> horizontal bar-comparison chart (grey vs yellow) that makes the delta
+> between two (or three) values legible at a glance, then a closing
+> takeaway line. Used for "same metric, two periods" reveals — e.g. H1
+> revenue year-over-year — where the number alone doesn't convey the size
+> of the gap as well as a bar does.
+
+## When to use
+
+- A slide whose core content is a numeric comparison between 2-3 rows
+  (periods, categories) AND the storyboarder supplied a `chart` object.
+- Do NOT auto-route here (see composer.py `map_slide_to_family`) — this
+  family needs a `chart.rows` array with parseable numeric `value` strings,
+  which the generic non-hero routing does not guarantee. Pin explicitly via
+  `layout_family: "stat-card-hero"` in slides.json.
+
+## Parameters
+
+```yaml
+heading: string # big stat line, e.g. "IDR / 2.815T VS 2.645T"
+subheading: string # kicker above the heading, yellow
+body: string # closing takeaway line below the chart
+chart:
+  type: "bar-comparison"
+  rows: # 2-3 rows
+    - label: string # e.g. "H1 2025"
+      value: string # display string, e.g. "IDR 2.645T"
+```
+
+## HTML/CSS skeleton
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="../_base.css" />
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap");
+      body {
+        padding: 100px var(--spacing-edge-margin) 180px
+          var(--spacing-edge-margin);
+        display: flex;
+        flex-direction: column;
+      }
+      .top-rule {
+        width: 90px;
+        height: 8px;
+        background: var(--color-accent-yellow);
+        margin-bottom: 36px;
+      }
+      .subheading {
+        font-weight: var(--font-weight-bold);
+        font-size: var(--font-size-subheadline);
+        line-height: var(--line-height-snug);
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-accent-yellow);
+        text-transform: uppercase;
+        margin-bottom: 16px;
+      }
+      .heading {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 64px;
+        line-height: var(--line-height-tight);
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-accent-yellow);
+        text-transform: uppercase;
+        text-wrap: balance;
+        margin-bottom: 48px;
+      }
+      .heading .lead {
+        color: var(--color-text-white);
+      }
+      .chart {
+        display: flex;
+        flex-direction: column;
+        gap: 28px;
+        margin-bottom: 40px;
+      }
+      .chart-row .row-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 10px;
+      }
+      .chart-row .row-label {
+        font-weight: var(--font-weight-bold);
+        font-size: 22px;
+        letter-spacing: 0.04em;
+        color: rgba(255, 255, 255, 0.6);
+        text-transform: uppercase;
+      }
+      .chart-row .row-value {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 28px;
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-text-white);
+      }
+      .chart-row.is-max .row-value {
+        color: var(--color-accent-yellow);
+      }
+      .chart-row .bar-track {
+        width: 100%;
+        height: 32px;
+        background: rgba(255, 255, 255, 0.06);
+      }
+      .chart-row .bar-fill {
+        height: 100%;
+        background: rgba(255, 255, 255, 0.45);
+      }
+      .chart-row.is-max .bar-fill {
+        background: var(--color-accent-yellow);
+      }
+      .baseline-rule {
+        height: 2px;
+        background: rgba(255, 255, 255, 0.14);
+        margin-bottom: 28px;
+      }
+      .body {
+        font-weight: var(--font-weight-bold);
+        font-size: 32px;
+        line-height: 1.4;
+        letter-spacing: var(--letter-spacing-body);
+        color: var(--color-text-white);
+        text-transform: none;
+      }
+      .body .emphasis {
+        color: var(--color-accent-yellow);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="top-rule" data-zone-type="text"></div>
+    <div class="subheading" data-zone-type="text">{{subheading}}</div>
+    <div class="heading" data-zone-type="text">{{heading}}</div>
+    <div class="chart" data-zone-type="text">
+      {{#each chart_rows}}
+      <div class="chart-row{{#if is_max}} is-max{{/if}}">
+        <div class="row-head">
+          <div class="row-label">{{label}}</div>
+          <div class="row-value">{{value}}</div>
+        </div>
+        <div class="bar-track">
+          <div class="bar-fill" style="width:{{bar_pct}}%"></div>
+        </div>
+      </div>
+      {{/each}}
+    </div>
+    <div class="baseline-rule"></div>
+    <div class="body" data-zone-type="text">{{body}}</div>
+    <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
+  </body>
+</html>
+```
+
+## Example data (H1 revenue YoY)
+
+```json
+{
+  "subheading": "H1 REVENUE, YEAR OVER YEAR · +6.42%",
+  "heading": "IDR / 2.815T VS 2.645T",
+  "chart": {
+    "type": "bar-comparison",
+    "rows": [
+      { "label": "H1 2025", "value": "IDR 2.645T" },
+      { "label": "H1 2026", "value": "IDR 2.815T" }
+    ]
+  },
+  "body": "SAME METRIC, SAME SOURCE, SIX MONTHS EACH. VISA VOLUME FELL 6.77% — YET REVENUE ROSE 6.42%."
+}
+```
+
+## Common failures
+
+- `chart.rows` missing/empty → composer drops the `{{#each}}` block entirely,
+  slide renders with an empty gap between heading and body. Always verify
+  `chart.rows` has ≥2 parseable numeric `value` strings before pinning this
+  family.
+- More than 3 rows → bars get visually thin, comparison reads as clutter.
+- Values in mixed units (e.g. one row "IDR 2.6T", another "38%") → the
+  proportional bar width is meaningless across units. One chart = one unit.


### PR DESCRIPTION
## Summary
- Adds a per-slide `heading_color`/`subhead_color` override mechanism in `composer.py` — these fields were already emitted by the storyboarder into `slides.json` but never read, so every layout family's color scheme was hardcoded to its global default with no way to express a deliberate per-carousel exception.
- Fills a real gap: `stat-card-hero` was listed as renderable but had no `.md` skeleton (silently fell back to `editorial-text`, dropping the bar-comparison chart entirely). Added the skeleton + a `chart_rows` normalizer.
- Adds `numbered-forces-list`, a new family for "N things driving X" headlines (giant numeral + label/value item stack), kept separate from `dark-status-list` since that family's label/value hierarchy is inverted and used elsewhere.
- Two smaller fixes: a headline's `" / "` is a line-break marker, not literal text (was rendering as a slash on cover-photo); `photo-headline-yellow-sub` now renders `\n\n`-separated body statements as a yellow-bar item stack instead of one run-on paragraph.

Verified locally against a target design (9-slide visa-revenue carousel) via `wr2_rerender_local.py` with the worktree's composer.py + new layouts symlinked in — all 9 slides now match the target's colors/structure while keeping the previously-applied content corrections (E33/E33G, PP 28/2019, DG typo).

## Test plan
- [x] `python3 -m ast` syntax check on composer.py after each edit
- [x] Local re-render of the 9-slide carousel, visual diff against target PNGs for all 9 slides
- [x] Confirmed no regression on slide 9 (statement-bomb) after the headline `" / "` fix — excluded that family since its `{{statement}}` fallback HTML-escapes the whole string
- [ ] CI (pre-commit/pre-push already green locally)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>