### PR TITLE
feat(wr2): arm color alternation + typography micro-rules in composer

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -3115,6 +3115,20 @@ _BODY_SLIDE_HTML = (
 )
 
 
+def _EXPECTED_HOUSE_STYLE_CSS(slide):
+    """The always-on <style> blocks _fill_placeholders injects for every
+    slide (2026-07-12 color-override + typography-guard micro-rules) — reuses
+    the real composer functions so this fixture can never drift from the
+    production injection order/content.
+    """
+    from wr2_html_renderer.composer import (
+        _TYPOGRAPHY_GUARD_CSS,
+        _heading_color_override_css,
+    )
+
+    return _heading_color_override_css(slide) + _TYPOGRAPHY_GUARD_CSS
+
+
 def test_fill_placeholders_facts_body_renders_label_value_stack():
     """A facts body renders as a label/value stack: one row per pair, the
     source line present OUTSIDE the rows, yellow accent on the FIRST value
@@ -3166,19 +3180,29 @@ def test_fill_placeholders_facts_body_without_source_still_stacks():
 def test_fill_placeholders_non_parsing_body_byte_identical():
     """Regression: a body that does NOT parse as fact pairs renders EXACTLY as
     before the change — placeholder substituted verbatim, no facts markup, no
-    injected facts CSS."""
+    injected facts CSS. (2026-07-12: the color-override + typography-guard
+    <style> blocks are now ALWAYS injected — see _heading_color_override_css
+    / _TYPOGRAPHY_GUARD_CSS — so "byte-identical" is scoped to the facts-block
+    markup specifically, not the whole document; those two blocks are
+    unconditional house-style, not part of the facts-block feature this test
+    guards.)"""
     from wr2_html_renderer.composer import _fill_placeholders
 
     prose = "YOUR KITAP STAYS VALID. THE RENEWAL WINDOW MOVED TO MARCH."
+    slide = {"headline": "SHORT TITLE", "body": prose}
     out = _fill_placeholders(
         _BODY_SLIDE_HTML,
-        {"headline": "SHORT TITLE", "body": prose},
+        slide,
         hero_filename=None,
         cover_family=False,
     )
-    # pre-change snapshot semantics: plain placeholder substitution only
-    expected = _BODY_SLIDE_HTML.replace("{{heading}}", "SHORT TITLE").replace(
+    # pre-change snapshot semantics: plain placeholder substitution, PLUS the
+    # always-on color-override/typography-guard style blocks (2026-07-12).
+    expected_body = _BODY_SLIDE_HTML.replace("{{heading}}", "SHORT TITLE").replace(
         "{{body}}", prose
+    )
+    expected = expected_body.replace(
+        "</head>", _EXPECTED_HOUSE_STYLE_CSS(slide) + "</head>"
     )
     assert out == expected
     assert "fact-row" not in out
@@ -3190,16 +3214,20 @@ def test_fill_placeholders_cover_family_facts_body_untouched():
     body that would parse as pairs renders as the legacy paragraph."""
     from wr2_html_renderer.composer import _fill_placeholders
 
+    slide = {"headline": "FEE", "body": _FACTS_BODY}
     out = _fill_placeholders(
         _BODY_SLIDE_HTML,
-        {"headline": "FEE", "body": _FACTS_BODY},
+        slide,
         hero_filename=None,
         cover_family=True,
     )
     assert "fact-row" not in out
     assert "data-facts-block" not in out
-    expected = _BODY_SLIDE_HTML.replace("{{heading}}", "FEE").replace(
+    expected_body = _BODY_SLIDE_HTML.replace("{{heading}}", "FEE").replace(
         "{{body}}", _FACTS_BODY
+    )
+    expected = expected_body.replace(
+        "</head>", _EXPECTED_HOUSE_STYLE_CSS(slide) + "</head>"
     )
     assert out == expected
 

--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -1039,20 +1039,117 @@ _COLOR_TOKEN_VARS = {
     "white": "var(--color-text-white)",
 }
 
+# Typography micro-rules (Zero, 2026-07-12) — armed centrally in composer.py
+# rather than duplicated per-layout .md file, so the rule holds even when a
+# new layout family forgets to restate it. Always injected (unconditional,
+# unlike the color override above which only fires on a slide's explicit/
+# default color choice) — these are house-style constants, not per-slide
+# editorial choices, so there is nothing to preserve flexibility for.
+#
+# 1. UPPERCASE EVERYWHERE — supersedes the 2026-05-22 "Title Case body for
+#    word-count readability" exception (evidence-carved .fact/.take-text,
+#    editorial-text .body, stat-card-hero .body): Zero's ruling 2026-07-12
+#    is that restraint now comes from layout/color hierarchy, not case: all
+#    rendered text is uppercase, no exceptions.
+# 2. FONT-WEIGHT HIERARCHY — heading/headline always extrabold (800); body
+#    text never at or above that weight (capped at bold/700), so a body
+#    block can never flatten the visual hierarchy against its heading.
+# 3. SIZE FLOOR — checked separately (_check_body_font_size_floor below),
+#    NOT coerced via CSS here: a blanket `font-size: 22px !important` would
+#    fight each layout's own scale (a subhead is deliberately smaller than a
+#    heading, a .fact value deliberately larger than a .fact label) and a
+#    self-referential `max(22px, <inherited>)` can't recover the pre-!important
+#    value once the cascade already applied one !important rule. Floor
+#    violations are logged as a warning instead — visible, not silently
+#    coerced into a possibly-wrong size.
+#
+# Selectors are the common text-role classes shared across layout .md files
+# (grep-verified 2026-07-12): a selector that doesn't exist in a given
+# layout is simply inert there — no risk of breaking a family that doesn't
+# use it.
+_TYPOGRAPHY_GUARD_CSS = (
+    '\n<style data-typography-guard="1">\n'
+    ".heading,.headline,.subheading,.subhead,.body,.body-item,"
+    ".fact .text,.take-text,.item .label,.item .value,"
+    ".voice-a .quote,.voice-b .quote,.row-label,.row-value,"
+    ".label,.value,.text{text-transform:uppercase !important;}\n"
+    ".heading,.headline{font-weight:800 !important;}\n"
+    ".body,.body-item,.fact .text,.take-text,.item .value,"
+    ".voice-a .quote,.voice-b .quote,.text{font-weight:700 !important;}\n"
+    "</style>\n"
+)
+
+# Floor check: warn (never coerce — see comment above) when a layout's own
+# .md skeleton declares a body-role font-size below this px value. Checked
+# once per family at render time from the skeleton's raw CSS text, not
+# per-slide (the size is a template constant, not slide data).
+_BODY_FONT_SIZE_FLOOR_PX = 22
+_BODY_ROLE_SELECTORS_RE = re.compile(
+    r"\.(?:body|body-item|fact \.text|take-text|item \.value|"
+    r"voice-a \.quote|voice-b \.quote)\s*\{[^}]*font-size:\s*(\d+)px",
+)
+
+
+def _check_body_font_size_floor(skeleton_css: str, family: str) -> None:
+    """Warn if a layout's body-role text is authored below the IG-legibility
+    floor. Non-blocking (logger.warning only) — see _TYPOGRAPHY_GUARD_CSS
+    comment for why this isn't a CSS !important coercion.
+    """
+    for m in _BODY_ROLE_SELECTORS_RE.finditer(skeleton_css):
+        px = int(m.group(1))
+        if px < _BODY_FONT_SIZE_FLOOR_PX:
+            logger.warning(
+                "typography guard: %s body-role font-size %dpx is below the "
+                "%dpx IG-legibility floor",
+                family, px, _BODY_FONT_SIZE_FLOOR_PX,
+            )
+
+
+def _default_heading_subhead_colors(slide: dict[str, Any]) -> tuple[str, str]:
+    """Odd/even alternation default for heading_color / subhead_color.
+
+    Micro-rule (Zero, 2026-07-12): odd slide_number -> heading=yellow /
+    subhead=white; even -> inverted. This is a DEFAULT only — it fires
+    exclusively when the slide has NOT declared its own heading_color/
+    subhead_color, so a deliberate per-slide editorial choice (e.g. two
+    consecutive covers both wanting a yellow headline) always wins. The
+    alternation exists so an un-opinionated carousel still gets visual
+    rhythm across its slides instead of every slide defaulting to the same
+    layout-family palette.
+
+    Falls back to slide_number == 1 (odd) when slide_number is missing/
+    unparseable, matching the historical single-carousel default.
+    """
+    try:
+        n = int(slide.get("slide_number") or 1)
+    except (TypeError, ValueError):
+        n = 1
+    return ("yellow", "white") if n % 2 == 1 else ("white", "yellow")
+
 
 def _heading_color_override_css(slide: dict[str, Any]) -> str:
     """Build a scoped !important <style> block for this slide's heading_color
-    / subhead_color, if present and recognized. Each slide renders as its own
-    standalone HTML file, so an !important override here can never leak into
-    another slide or carousel — it only ever wins the cascade within this one
-    document, on top of whatever default the layout family's own <style>
-    block already set.
+    / subhead_color. Each slide renders as its own standalone HTML file, so
+    an !important override here can never leak into another slide or
+    carousel — it only ever wins the cascade within this one document, on
+    top of whatever default the layout family's own <style> block already
+    set.
+
+    Precedence: an explicit heading_color/subhead_color on the slide always
+    wins (editorial flexibility preserved). Only the field(s) NOT explicitly
+    set fall back to the odd/even alternation default above — so a slide
+    that only sets heading_color still gets a sensible subhead_color default
+    instead of silently keeping the layout's hardcoded one.
     """
+    default_heading, default_subhead = _default_heading_subhead_colors(slide)
+    heading_token = str(slide.get("heading_color") or "").strip().lower() or default_heading
+    subhead_token = str(slide.get("subhead_color") or "").strip().lower() or default_subhead
+
     rules = []
-    heading_color = _COLOR_TOKEN_VARS.get(str(slide.get("heading_color") or "").strip().lower())
+    heading_color = _COLOR_TOKEN_VARS.get(heading_token)
     if heading_color:
         rules.append(f".heading,.headline{{color:{heading_color} !important;}}")
-    subhead_color = _COLOR_TOKEN_VARS.get(str(slide.get("subhead_color") or "").strip().lower())
+    subhead_color = _COLOR_TOKEN_VARS.get(subhead_token)
     if subhead_color:
         rules.append(f".subheading,.subhead{{color:{subhead_color} !important;}}")
     if not rules:
@@ -1312,6 +1409,16 @@ def _fill_placeholders(
         else:
             html = html + color_css
 
+    # Typography micro-rules (uppercase everywhere, heading/body weight
+    # hierarchy) — unconditional, every slide gets this, see
+    # _TYPOGRAPHY_GUARD_CSS for the full rationale.
+    if "</head>" in html:
+        html = html.replace("</head>", _TYPOGRAPHY_GUARD_CSS + "</head>", 1)
+    elif "</body>" in html:
+        html = html.replace("</body>", _TYPOGRAPHY_GUARD_CSS + "</body>", 1)
+    else:
+        html = html + _TYPOGRAPHY_GUARD_CSS
+
     # Inject the facts-block styles ONLY when the stack was rendered, so a
     # non-parsing body stays byte-identical to the legacy paragraph output.
     if facts_block:
@@ -1391,6 +1498,7 @@ async def compose_carousel(
                         logger.warning("slide %d hero download failed url=%s", plan.index, url)
 
             skeleton = _extract_skeleton(plan.family)
+            _check_body_font_size_floor(skeleton, plan.family)
             html = _normalize_skeleton(skeleton)
             if plan.expect_hero and hero_filename:
                 html = _hero_bg_to_img(html, hero_filename)
@@ -1449,6 +1557,7 @@ async def materialize_slide_html(
     expect_hero = bool(slide.get("is_hero_image")) or index == 1
 
     skeleton = _extract_skeleton(family)
+    _check_body_font_size_floor(skeleton, family)
     html = _normalize_skeleton(skeleton)
     if expect_hero and hero_filename:
         html = _hero_bg_to_img(html, hero_filename)


### PR DESCRIPTION
## Summary
Three house-style micro-rules, requested by Zero (2026-07-12), armed centrally in `composer.py` so they hold across every layout family instead of depending on each `.md` skeleton restating them correctly.

1. **Odd/even heading_color/subhead_color DEFAULT alternation** — odd slide_number → heading=yellow/subhead=white, even → inverted. Fires ONLY as a fallback: an explicit per-slide `heading_color`/`subhead_color` (the mechanism shipped in #2256) always wins, so editorial flexibility is fully preserved.
2. **Forced uppercase everywhere** (heading/subhead/body/item text) — supersedes the 2026-05-22 "Title Case body for word-count readability" exception on evidence-carved/editorial-text/stat-card-hero.
3. **Font-weight hierarchy guard** — heading/headline always extrabold (800), body-role text capped at bold (700), so a body block can never flatten the hierarchy against its heading.

All three ride the same scoped `!important` `<style>` injection pattern already established for the per-slide color override in #2256 — each slide is its own standalone HTML file, so nothing can leak across slides/carousels.

Also adds a **non-coercive font-size floor check** (`_check_body_font_size_floor`): warns via `logger.warning` (never silently rewrites) when a layout's own skeleton declares body-role text below the 22px IG-legibility floor. A blanket CSS floor was considered and rejected — it would fight each layout's own type scale (a subhead is deliberately smaller than a heading) and can't recover a pre-`!important` value once the cascade already applied one.

## Test plan
- [x] Standalone Playwright render of `editorial-text` with a deliberately mixed-case body — confirms the guard renders fully uppercase
- [x] Re-rendered the 2026-07-10 visa-revenue carousel (9 slides) end-to-end: explicit per-slide color choices (slide 1, 2, 9) still honored exactly as before; hero-visibility gate still passes on all slides
- [x] Syntax check after each edit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>