### PR TITLE
feat(infra): reverse-promote 5 HOME-only claude wrappers on Pro (W89 class-audit)

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -4,281 +4,239 @@
     {
       "live": "~/.fly/bin/fly_pg_tunnel_supervisor.sh",
       "repo": "scripts/fly_pg_tunnel_supervisor.sh",
-      "machines": [
-        "all"
-      ]
+      "machines": ["all"]
     },
     {
       "live": "~/.nuzantara-cron/agent_worktree_cleanup_cron.sh",
       "repo": "scripts/agent_worktree_cleanup_cron.sh",
-      "machines": [
-        "all"
-      ]
+      "machines": ["all"]
     },
     {
       "live": "~/.nuzantara-cron/verify_connectome_run.sh",
       "repo": "scripts/verify_connectome_run.sh",
-      "machines": [
-        "all"
-      ]
+      "machines": ["all"]
     },
     {
       "live": "~/scripts/regulatory-watcher-run.sh",
       "repo": "infra/launchagents/wrappers/regulatory-watcher-run.sh",
       "_note": "Pro=active cron (heartbeat pro.regulatory_watcher_daily); M5=dormant aligned copy (workstation, no cron). NOT Mini — a Mini cron would be active-active split-brain (superscar #10) on the same delta the #2009 lock guards. Was 'all', which made lint --check chase a nonexistent Mini pair (false drift). Verified by content 2026-07-06.",
-      "machines": [
-        "pro",
-        "m5"
-      ]
+      "machines": ["pro", "m5"]
     },
     {
       "live": "~/scripts/wr2-deploy-pull.sh",
       "repo": "scripts/wr2-deploy-pull.sh",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/codex/nightly-autofix-ci.sh",
       "repo": "scripts/codex/codex-nightly-autofix-ci.sh",
       "_note": "Hourly codex auto-fix generator (plist com.nuzantara.codex-autofix-ci, StartCalendarInterval Minute=15, via cron-runner.sh). Declared 2026-07-06 together with the recursion-brake fix — was an UNDECLARED live payload (family #1); basenames differ by history.",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/wr2-ig-metrics-analyst-run.sh",
       "repo": "infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh",
       "_note": "Promoted to repo canon 2026-07-06 (healer tick) to close the sonnet-5 runtime-proof gap (PENDING-ARMS 2026-07-03): live copy called `claude` directly with no 'used: <tier>' log line. Repo canon adds explicit provenance logging only — same invocation, same model. Live HOME copy on Pro still needs manual sync (healer is read-only on Pro).",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/mlx-server-run.sh",
       "repo": "infra/launchagents/wrappers/mlx-server-run.sh",
-      "machines": [
-        "pro",
-        "mini"
-      ]
+      "machines": ["pro", "mini"]
     },
     {
       "live": "~/scripts/mini-infra/kg-query-api-wrapper.sh",
       "repo": "infra/mini-scripts/kg-query-api-wrapper.sh",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/heartbeat-watchdog.sh",
       "repo": "scripts/mini-migration/heartbeat-watchdog.sh",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/log-prune.sh",
       "repo": "scripts/mini-migration/log-prune.sh",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/overlap-detector.sh",
       "repo": "scripts/mini-migration/overlap-detector.sh",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/mini-git-pull.sh",
       "repo": "scripts/mini/mini-git-pull.sh",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/Library/Application Support/Nuzantara/local-livekit/scripts/run_local_livekit_server.sh",
       "repo": "apps/backend-rag/scripts/run_local_livekit_server.sh",
       "_note": "Was UNDECLARED (part of the 2026-07-05 13-payload finding). Confirmed byte-identical 2026-07-07 (healer tick).",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/Library/Application Support/Nuzantara/local-livekit/scripts/run_local_livekit_worker.sh",
       "repo": "apps/backend-rag/scripts/run_local_livekit_worker.sh",
       "_note": "Was UNDECLARED (part of the 2026-07-05 13-payload finding). Confirmed byte-identical 2026-07-07 (healer tick).",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/healer-run.sh",
       "repo": "infra/healer/healer-run.sh",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/HEALER-MANDATE.md",
       "repo": "infra/healer/HEALER-MANDATE.md",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/Library/LaunchAgents/com.nuzantara.healer.4h.plist",
       "repo": "infra/launchagents/com.nuzantara.healer.4h.plist",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/pro-healer.sh",
       "repo": "infra/launchagents/wrappers/pro-healer.sh",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/Library/LaunchAgents/com.nuzantara.healer-pro.6h.plist",
       "repo": "infra/launchagents/com.nuzantara.healer-pro.6h.plist",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/HEALER-PRO-MANDATE.md",
       "repo": "infra/healer/HEALER-PRO-MANDATE.md",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/bin/wa-mirror-runner.sh",
       "repo": "infra/launchagents/wrappers/wa-mirror-runner.sh",
       "_note": "Part of the 2026-07-05 13-payload finding. Promoted to canon 2026-07-07 (healer tick), byte-identical.",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/bin/wr2-warroom-sync.sh",
       "repo": "infra/launchagents/wrappers/wr2-warroom-sync.sh",
       "_note": "Part of the 2026-07-05 13-payload finding. Promoted to canon 2026-07-07 (healer tick), byte-identical.",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/ollama-warm-pin.sh",
       "repo": "infra/launchagents/wrappers/ollama-warm-pin.sh",
       "_note": "Part of the 2026-07-05 13-payload finding. Promoted to canon 2026-07-07 (healer tick), byte-identical.",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/openclaw-cron/drive-poll.sh",
       "repo": "infra/launchagents/wrappers/openclaw-cron/drive-poll.sh",
       "_note": "Part of the 2026-07-05 13-payload finding (openclaw-cron x3, crontab-executed not plist). Promoted to canon 2026-07-07 (healer tick), byte-identical.",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/openclaw-cron/crm-kg-build-mediated.sh",
       "repo": "infra/launchagents/wrappers/openclaw-cron/crm-kg-build-mediated.sh",
       "_note": "Part of the 2026-07-05 13-payload finding (openclaw-cron x3, crontab-executed not plist). Promoted to canon 2026-07-07 (healer tick), byte-identical.",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/openclaw-cron/crm-kg-garbage-collect.sh",
       "repo": "infra/launchagents/wrappers/openclaw-cron/crm-kg-garbage-collect.sh",
       "_note": "Part of the 2026-07-05 13-payload finding (openclaw-cron x3, crontab-executed not plist). Promoted to canon 2026-07-07 (healer tick), byte-identical.",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/pro-tg-digest-flush.sh",
       "repo": "infra/launchagents/wrappers/pro-tg-digest-flush.sh",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/Library/LaunchAgents/com.nuzantara.tg-digest-flush.plist",
       "repo": "infra/launchagents/com.nuzantara.tg-digest-flush.plist",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/mini-tg-digest-flush.sh",
       "repo": "infra/launchagents/wrappers/mini-tg-digest-flush.sh",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/Library/LaunchAgents/com.nuzantara.mini.tg-digest-flush.plist",
       "repo": "infra/launchagents/com.nuzantara.mini.tg-digest-flush.plist",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/scripts/sentinel_lib/alerter.py",
       "repo": "scripts/sentinel_lib/alerter.py",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/wa-mirror-attention-telegram.py",
       "repo": "scripts/wa-mirror-attention-telegram.py",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/fly-restart-loop-detector.sh",
       "repo": "scripts/fly-restart-loop-detector.sh",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/fly-qdrant-backup.sh",
       "repo": "scripts/fly-qdrant-backup.sh",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/Library/LaunchAgents/com.balizero.wr2.daily-reconciler.plist",
       "repo": "infra/launchagents/com.balizero.wr2.daily-reconciler.plist",
-      "machines": [
-        "pro"
-      ]
+      "machines": ["pro"]
     },
     {
       "live": "~/scripts/mini-fleet-watch.sh",
       "repo": "infra/launchagents/wrappers/mini-fleet-watch.sh",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
     },
     {
       "live": "~/Library/LaunchAgents/com.nuzantara.fleet-watch.plist",
       "repo": "infra/launchagents/com.nuzantara.fleet-watch.plist",
-      "machines": [
-        "mini"
-      ]
+      "machines": ["mini"]
+    },
+    {
+      "live": "~/scripts/claude-cascade.sh",
+      "repo": "infra/launchagents/wrappers/claude-cascade.sh",
+      "_note": "W89 class-audit (2026-07-11, PENDING-ARMS ledger ~68): shared choke-point for competitor-monitor + yield-optimizer's Claude-tier attempts. Reverse-promoted with a BG-ceiling env fix applied once here instead of duplicated per-caller.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/competitor-monitor-run.sh",
+      "repo": "infra/launchagents/wrappers/competitor-monitor-run.sh",
+      "_note": "W89 class-audit (2026-07-11, PENDING-ARMS ledger ~68): anti-background prompt sentence + provenance log line added.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/yield-optimizer-run.sh",
+      "repo": "infra/launchagents/wrappers/yield-optimizer-run.sh",
+      "_note": "W89 class-audit (2026-07-11, PENDING-ARMS ledger ~68): anti-background prompt sentence + provenance log line added.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/run-nb-curator-mode-c.sh",
+      "repo": "infra/launchagents/wrappers/run-nb-curator-mode-c.sh",
+      "_note": "W89 class-audit (2026-07-11, PENDING-ARMS ledger ~68): BG-ceiling env + anti-background prompt sentence + provenance log line added; model bumped claude-sonnet-4-6->claude-sonnet-5 to match the already-armed HOME copy's sibling migration (2026-07-03 doc).",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/wr2-contract-test.sh",
+      "repo": "infra/launchagents/wrappers/wr2-contract-test.sh",
+      "_note": "W89 class-audit (2026-07-11, PENDING-ARMS ledger ~68): BG-ceiling env + anti-background prompt sentence + provenance log line added. Manual forensic harness, no scheduler — dormant but was undeclared HOME-only.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent.sh",
+      "repo": "infra/launchagents/wrappers/cron-agent.sh",
+      "_note": "W89 class-audit (2026-07-11, PENDING-ARMS ledger ~68): run_agent() gets BG-ceiling env + anti-background prompt sentence + provenance log line. Live crontab consumer of the 'agent' tier: weekly-dep-audit, seo-guardian-weekly, conversation-cleanup, indexing-daily, learning-pipeline (verified via `crontab -l` on Pro 2026-07-11).",
+      "machines": ["pro"]
     }
   ],
   "allow": [

--- a/infra/launchagents/install_fly_pg_tunnel.sh
+++ b/infra/launchagents/install_fly_pg_tunnel.sh
@@ -12,6 +12,22 @@
 # M5-ONLY: the proxy + Keychain RO secret live on M5 (Law 6 / PII boundary). The Pro has its
 # own stable Fly net and does not need this. Refuses to install on any other host.
 #
+# WHY NOT MINI (decided 2026-07-11, PENDING-ARMS ledger ~56): Mini had 2 legacy
+# pre-supervisor plists (com.nuzantara.fly-pg-tunnel{,.local}) chasing this same tunnel
+# via ~/.local/bin/fly-pg-tunnel-from-config — retired (archived, not deleted) after
+# confirming a THREE-layer blocker, not a "just wire it up" gap: (1) Mini's `fly` CLI has
+# NO access token at all (`fly auth whoami` → "no access token available", interactive
+# `fly auth login` required — operator[secret], can't be scripted); (2) even once
+# authed, Mini's Keychain has no `nuzantara-postgres-readonly` entry this supervisor's
+# heartbeat_ok() requires; (3) even once seeded, a headless SSH session cannot read a
+# GUI-session Keychain item on macOS (the same wall that blocks direct Postgres access
+# from Mini, W87 family) — so the supervisor's `security find-generic-password` call
+# would still fail non-interactively. Extending the `whoami=balizero` guard to include
+# Mini would arm a supervisor that heartbeats FALSE FOREVER, which is worse than the
+# retired plists' honest churn. If Mini access is ever wanted: operator runs
+# `fly auth login` interactively on Mini + seeds the Keychain entry via a GUI-unlocked
+# session, THEN this guard can be relaxed — not before.
+#
 # TCC NOTE: launchd cannot exec scripts under ~/Desktop on M5 (macOS TCC → status 126
 # "Operation not permitted"). The installer therefore STAGES the supervisor into ~/.fly/bin/
 # (outside the protected tree) and points the LaunchAgent there. Verified 2026-06-15.

--- a/infra/launchagents/wrappers/claude-cascade.sh
+++ b/infra/launchagents/wrappers/claude-cascade.sh
@@ -1,0 +1,204 @@
+#!/bin/zsh
+# claude-cascade.sh — single entry point for autonomous Claude invocations with full fallback cascade.
+#
+# Tries CLI binaries in this order, falling back on quota exhaustion:
+#   1. claude          (default OAuth slot, MAX plan #1)
+#   2. claude-acct2    (MAX plan #2, if setup-acct-slot.sh 2 + /login completed)
+#   3. agy -p (Antigravity CLI Gemini 3.1 Pro, Google AI Ultra sub)
+#   4. codex exec --sandbox read-only    (ChatGPT Plus / Pro)
+#   5. ollama run qwen3.5:9b             (local, always available)
+# Note: slot 3 was removed 2026-05-09 — only 2 MAX plans active (kaiser + #2).
+#
+# Usage:
+#   claude-cascade.sh "<prompt text>" [--model MODEL] [--agent AGENT_NAME]
+#   echo "prompt" | claude-cascade.sh --stdin [--agent AGENT_NAME]
+#
+# Output: stdout = LLM response. Stderr = which tier was used + which tiers were skipped.
+# Exit codes: 0 = success on any tier. 1 = ALL tiers failed. 2 = bad usage.
+#
+# Quota-exhaust detection patterns (case-insensitive grep):
+#   "out of extra usage", "usage limit", "quota exceeded", "rate.limit", "429", "exhausted"
+#
+# W89 class-audit fix (2026-07-11, PENDING-ARMS ledger ~68): sonnet-5 in --print mode can
+# silently spawn its work as a BACKGROUND task; the CLI kills it at the print-mode ceiling
+# and exits 0 with no output on stdout — the caller sees "success" with nothing to show for
+# it (incident: regulatory-watcher-run.sh 2026-07-05). Every Claude-tier attempt through
+# this cascade shares the same fix: raise the background ceiling so legitimate long work
+# survives, and callers must additionally tell the model inline never to background (this
+# script cannot inject that into an arbitrary caller-supplied $PROMPT — see each wrapper
+# that calls this cascade for its own anti-background sentence).
+
+set -uo pipefail
+
+unset ANTHROPIC_API_KEY  # defense-in-depth: never pay-per-token Anthropic
+
+# Source secrets so spawned agents have DEEPSEEK_API_KEY, TELEGRAM_*, etc.
+# This is the canonical location of all autonomous-runtime secrets.
+if [ -f "$HOME/.nuzantara-secrets.env" ]; then
+    set -a
+    source "$HOME/.nuzantara-secrets.env" 2>/dev/null
+    set +a
+fi
+# Re-strip ANTHROPIC_API_KEY in case secrets file accidentally contained it
+unset ANTHROPIC_API_KEY
+
+# W89 class-audit (2026-07-11): 30min ceiling — same value as regulatory-watcher-run.sh's
+# own fix, applied here once so every caller of this cascade (competitor-monitor,
+# yield-optimizer, and any future claude-cascade.sh consumer) inherits it uniformly.
+export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS="${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:-1800000}"
+
+PROMPT=""
+MODEL=""
+AGENT=""
+USE_STDIN=0
+EXTRA_ARGS=()
+
+# parse args
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model) MODEL="$2"; shift 2 ;;
+        --agent) AGENT="$2"; shift 2 ;;
+        --stdin) USE_STDIN=1; shift ;;
+        --) shift; EXTRA_ARGS+=("$@"); break ;;
+        -*) EXTRA_ARGS+=("$1"); shift ;;
+        *) PROMPT="$1"; shift ;;
+    esac
+done
+
+if [ "$USE_STDIN" -eq 1 ]; then
+    PROMPT="$(cat)"
+fi
+
+if [ -z "$PROMPT" ]; then
+    echo "usage: $0 \"<prompt>\" [--model M] [--agent A]" >&2
+    exit 2
+fi
+
+QUOTA_PATTERN="out of extra usage|usage limit|quota exceeded|rate.limit|429|exhausted|please try again later"
+
+# build claude args (model + agent + extras)
+build_claude_args() {
+    local args=("--print")
+    [ -n "$MODEL" ] && args+=("--model" "$MODEL")
+    [ -n "$AGENT" ] && args+=("--agent" "$AGENT")
+    args+=("${EXTRA_ARGS[@]}")
+    echo "${args[@]}"
+}
+
+try_claude() {
+    local bin="$1"
+    local label="$2"
+    [ ! -x "$bin" ] && [ ! -L "$bin" ] && { echo "  [skip] $label not installed at $bin" >&2; return 99; }
+
+    local tmpout=$(mktemp)
+    local args=$(build_claude_args)
+
+    echo "  [try] $label ($bin)" >&2
+    echo "$PROMPT" | $bin ${=args} >"$tmpout" 2>&1
+    local exit=$?
+
+    if grep -qiE "$QUOTA_PATTERN" "$tmpout"; then
+        echo "  [exhausted] $label quota" >&2
+        rm -f "$tmpout"
+        return 98
+    fi
+    if [ $exit -ne 0 ]; then
+        echo "  [error] $label exit=$exit" >&2
+        cat "$tmpout" >&2
+        rm -f "$tmpout"
+        return $exit
+    fi
+
+    cat "$tmpout"
+    rm -f "$tmpout"
+    echo "[claude-cascade] used: $label" >&2
+    return 0
+}
+
+try_gemini() {
+    local agy="$HOME/.local/bin/agy"
+    [ ! -x "$agy" ] && { echo "  [skip] tier3 agy not installed" >&2; return 99; }
+    local tmpout=$(mktemp)
+    echo "  [try] tier3 agy (Gemini 3.1 Pro)" >&2
+    echo "$PROMPT" | "$agy" -p --print-timeout 5m >"$tmpout" 2>&1
+    local exit=$?
+    if [ $exit -ne 0 ]; then
+        echo "  [error] agy exit=$exit" >&2
+        cat "$tmpout" >&2
+        rm -f "$tmpout"
+        return $exit
+    fi
+    cat "$tmpout"
+    rm -f "$tmpout"
+    echo "[claude-cascade] used: tier3 agy-gemini3.1pro" >&2
+    return 0
+}
+
+try_codex() {
+    [ ! -x /opt/homebrew/bin/codex ] && { echo "  [skip] tier4 codex not installed" >&2; return 99; }
+    local tmpout=$(mktemp)
+    echo "  [try] tier4 codex" >&2
+    /opt/homebrew/bin/codex exec --sandbox read-only --skip-git-repo-check "$PROMPT" >"$tmpout" 2>&1
+    local exit=$?
+    if [ $exit -ne 0 ]; then
+        echo "  [error] codex exit=$exit" >&2
+        cat "$tmpout" >&2
+        rm -f "$tmpout"
+        return $exit
+    fi
+    cat "$tmpout"
+    rm -f "$tmpout"
+    echo "[claude-cascade] used: tier4 codex" >&2
+    return 0
+}
+
+try_ollama() {
+    [ ! -x /opt/homebrew/bin/ollama ] && { echo "  [skip] ollama not installed" >&2; return 99; }
+    if [ -n "$AGENT" ]; then
+        echo "  [skip] tier5 ollama — --agent=$AGENT requires Claude tier" >&2
+        return 99
+    fi
+    local tmpout=$(mktemp)
+    echo "  [try] tier5 ollama qwen3.5:9b local" >&2
+    /opt/homebrew/bin/ollama run qwen3.5:9b "$PROMPT" >"$tmpout" 2>&1
+    local exit=$?
+    if [ $exit -ne 0 ]; then
+        echo "  [error] ollama exit=$exit" >&2
+        cat "$tmpout" >&2
+        rm -f "$tmpout"
+        return $exit
+    fi
+    cat "$tmpout"
+    rm -f "$tmpout"
+    echo "[claude-cascade] used: tier5 ollama-qwen3.5:9b-local" >&2
+    return 0
+}
+
+# ============= CASCADE =============
+echo "[claude-cascade] starting (prompt ${#PROMPT} chars, agent='$AGENT', model='$MODEL')" >&2
+
+# Tier 1-2: Claude OAuth slots (if configured)
+for slot in "$HOME/.local/bin/claude:tier1-claude-default" \
+            "$HOME/.local/bin/claude-acct2:tier2-claude-acct2" \
+            "$HOME/.local/bin/claude-acct3:tier2b-claude-acct3"; do
+    bin="${slot%:*}"
+    label="${slot#*:}"
+    try_claude "$bin" "$label"
+    rc=$?
+    [ $rc -eq 0 ] && exit 0
+    [ $rc -eq 99 ] && continue  # not installed
+    [ $rc -eq 98 ] && continue  # quota exhausted, try next
+    # other errors: try next tier (could be transient; cascade is permissive)
+done
+
+# Tier 3: Gemini
+try_gemini && exit 0
+
+# Tier 4: Codex
+try_codex && exit 0
+
+# Tier 5: Ollama local (always-on safety net)
+try_ollama && exit 0
+
+echo "[claude-cascade] ALL TIERS FAILED" >&2
+exit 1

--- a/infra/launchagents/wrappers/competitor-monitor-run.sh
+++ b/infra/launchagents/wrappers/competitor-monitor-run.sh
@@ -1,0 +1,60 @@
+#!/bin/zsh
+# competitor-monitor cron wrapper. Monthly day 1 09:00 WITA.
+# Spawns claude --print --agent competitor-monitor.
+#
+# W89 class-audit fix (2026-07-11, PENDING-ARMS ledger ~68): sonnet-5 in --print mode can
+# silently spawn its work as a background task; the CLI kills it at the print-mode ceiling
+# and exits 0 with no output — "success" with nothing produced (incident: regulatory-watcher
+# 2026-07-05). Fix here is the same shape: claude-cascade.sh (this wrapper's Claude-tier
+# entry point) raises CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS, and the prompt below tells the
+# model inline never to background this run.
+
+set -uo pipefail
+unset ANTHROPIC_API_KEY
+
+[ -f "$HOME/.nuzantara-secrets.env" ] && set -a && source "$HOME/.nuzantara-secrets.env" && set +a
+
+mkdir -p "$HOME/Desktop/nuzantara/research/competitive" "$HOME/.claude/projects/-Users-nuzantara/competitive-snapshots" "$HOME/logs"
+LOG="$HOME/logs/competitor-monitor.log"
+MONTH=$(TZ=Asia/Makassar date +%Y-%m)
+
+echo "[$(date)] competitor-monitor run starting for $MONTH" >> "$LOG"
+
+PROMPT="Run competitor-monitor agent for month $MONTH.
+Read ~/.claude/agents/competitor-monitor.md for full spec.
+- Web fetch 3 competitors: Lets Move Indonesia, Emerhub, Flado
+- Compare vs last month's snapshot in ~/.claude/projects/-Users-nuzantara/competitive-snapshots/
+- IG screenshot triage via Ollama qwen2.5vl:7b LOCAL pre-filter
+- Sonnet analysis on filtered posts
+- Output digest to ~/Desktop/nuzantara/research/competitive/${MONTH}-digest.md
+- Save snapshot for next month
+- Telegram digest if material changes detected
+- Cold-start logic: if no prior snapshot, mark cold_start: true in digest
+Do ALL the work inline in this session — never spawn a background task or background agent
+for this; this is a one-shot print-mode run and backgrounded work is terminated at exit,
+leaving no digest on disk (W89 class-audit, regulatory-watcher incident 2026-07-05)."
+
+TMPOUT=$(mktemp)
+# Multi-tier cascade: claude → claude-acct2 → claude-acct3 → gemini → codex → ollama
+"$HOME/scripts/claude-cascade.sh" "$PROMPT" --model claude-sonnet-5 --agent competitor-monitor \
+    >"$TMPOUT" 2>>"$LOG"
+EXIT=$?
+cat "$TMPOUT" >> "$LOG"
+
+if [ $EXIT -ne 0 ]; then
+    echo "[$(date)] competitor-monitor ALL TIERS FAILED ($EXIT)" >> "$LOG"
+fi
+
+# Explicit tier-provenance line (W89 class-audit, 2026-07-11): grep the cascade's own
+# "[claude-cascade] used: <tier>" line so a run's actual answering tier is always on record
+# in this wrapper's own log, not just buried in the cascade's stderr interleave.
+USED_TIER=$(grep -o '\[claude-cascade\] used: [^"]*' "$TMPOUT" | tail -1 || true)
+if [ -n "$USED_TIER" ]; then
+    echo "[$(date)] [competitor-monitor] ${USED_TIER}" >> "$LOG"
+else
+    echo "[$(date)] [competitor-monitor] used: none (all tiers failed or no tier line found)" >> "$LOG"
+fi
+
+rm -f "$TMPOUT"
+echo "[$(date)] competitor-monitor run complete" >> "$LOG"
+exit 0

--- a/infra/launchagents/wrappers/cron-agent.sh
+++ b/infra/launchagents/wrappers/cron-agent.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# cron-agent.sh — Universal cron wrapper for all automation tiers
+#
+# Usage:
+#   cron-agent.sh exec  <job-name> <script> [args...]   # Tier 0: run script, alert on failure
+#   cron-agent.sh agent <job-name> <prompt-file>         # Tier 2: claude -p with 3-token fallback
+#
+# Features:
+#   - Telegram alert on failure (with cooldown)
+#   - 3-account Claude OAuth fallback (TOKEN_1 → TOKEN_2 → TOKEN_3)
+#   - Structured logging to ~/logs/cron-agent/
+#   - Timeout enforcement
+#   - Lock file (prevents concurrent runs of same job)
+#   - Exit code tracking for health report
+#
+# Environment:
+#   TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID — alerts (loaded from ~/.nuzantara-secrets.env)
+#   CLAUDE_CODE_OAUTH_TOKEN_{1,2,3} — 3 Claude Max accounts for agent tier
+#   CRON_AGENT_TIMEOUT — override default timeout (default: 300s exec, 600s agent)
+#   CRON_AGENT_DRY_RUN — set to "1" to print commands without executing
+#
+# W89 class-audit fix (2026-07-11, PENDING-ARMS ledger ~68): sonnet-5 in --print mode can
+# silently spawn its work as a background task; the CLI kills it at the print-mode ceiling
+# and exits 0 with no output (incident: regulatory-watcher 2026-07-05). run_agent() below
+# raises the background ceiling and the prompt appends an inline anti-background sentence,
+# plus an explicit "used: tier1-<label>" provenance log line per successful attempt.
+
+set -uo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+TIER="${1:-}"
+JOB_NAME="${2:-}"
+SCRIPT_OR_PROMPT="${3:-}"
+shift 3 2>/dev/null || true
+
+if [[ -z "$TIER" || -z "$JOB_NAME" || -z "$SCRIPT_OR_PROMPT" ]]; then
+    echo "Usage: cron-agent.sh {exec|agent} <job-name> <script-or-prompt-file> [args...]"
+    exit 1
+fi
+
+# Paths
+LOG_DIR="$HOME/logs/cron-agent"
+LOG_FILE="$LOG_DIR/${JOB_NAME}.log"
+STATE_DIR="$HOME/.cron-agent"
+LOCK_FILE="$STATE_DIR/${JOB_NAME}.lock"
+STATE_FILE="$STATE_DIR/${JOB_NAME}.state.json"
+COOLDOWN_FILE="$STATE_DIR/${JOB_NAME}.cooldown"
+SECRETS_FILE="$HOME/.nuzantara-secrets.env"
+
+mkdir -p "$LOG_DIR" "$STATE_DIR"
+
+# Load secrets
+[[ -f "$SECRETS_FILE" ]] && { set -a; source "$SECRETS_FILE"; set +a; }
+
+TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-${TELEGRAM_OWNER_CHAT_ID:-1125336968}}"
+
+# Timeouts
+case "$TIER" in
+    exec)  DEFAULT_TIMEOUT=300 ;;
+    agent) DEFAULT_TIMEOUT=600 ;;
+    *)     echo "Unknown tier: $TIER"; exit 1 ;;
+esac
+TIMEOUT="${CRON_AGENT_TIMEOUT:-$DEFAULT_TIMEOUT}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] [$JOB_NAME] $*" >> "$LOG_FILE"; }
+
+send_telegram() {
+    local msg="$1"
+    [[ -z "$TELEGRAM_BOT_TOKEN" ]] && return
+    # Cooldown: max 1 alert per 30 min per job
+    if [[ -f "$COOLDOWN_FILE" ]]; then
+        local age=$(( $(date +%s) - $(stat -f%m "$COOLDOWN_FILE" 2>/dev/null || echo 0) ))
+        [[ $age -lt 1800 ]] && { log "Telegram cooldown active (${age}s < 1800s)"; return; }
+    fi
+    curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_CHAT_ID}" \
+        -d "text=${msg}" \
+        -d "parse_mode=HTML" \
+        --max-time 10 >/dev/null 2>&1 || true
+    touch "$COOLDOWN_FILE"
+}
+
+save_state() {
+    local status="$1" exit_code="$2" duration="$3" error="${4:-}"
+    cat > "$STATE_FILE" << STATEEOF
+{"job":"$JOB_NAME","tier":"$TIER","ts":$(date +%s),"status":"$status","exit_code":$exit_code,"duration_s":$duration,"error":"$(echo "$error" | head -c 200 | tr '"' "'" | tr '\n' ' ')","host":"$(hostname)"}
+STATEEOF
+}
+
+acquire_lock() {
+    # macOS: use shlock (PID-based lockfile). Stale detection via PID check.
+    if [[ -f "$LOCK_FILE" ]]; then
+        local old_pid
+        old_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+        if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
+            log "SKIP: lock held by PID $old_pid"
+            exit 0
+        fi
+        # Stale lock — previous process died
+        log "Removing stale lock (PID $old_pid dead)"
+        rm -f "$LOCK_FILE"
+    fi
+    echo $$ > "$LOCK_FILE"
+}
+
+release_lock() {
+    rm -f "$LOCK_FILE"
+}
+
+# ── PATH setup ────────────────────────────────────────────────────────────────
+export PATH="/opt/homebrew/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/Users/nuzantara/.local/bin:/usr/local/bin:/usr/bin:/bin"
+export HOME="/Users/nuzantara"
+
+# sonnet-5 --print + background tasks (W89 class-audit, 2026-07-11): the CLI kills
+# backgrounded work after the print-mode ceiling; 30min keeps a legitimate long agent
+# run alive across every job that dispatches through the agent tier below.
+export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS="${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:-1800000}"
+
+# ── Lock ──────────────────────────────────────────────────────────────────────
+acquire_lock
+trap 'release_lock' EXIT
+
+# ── Tier: exec ────────────────────────────────────────────────────────────────
+
+run_exec() {
+    local script="$SCRIPT_OR_PROMPT"
+    if [[ ! -f "$script" ]]; then
+        # Try expanding ~
+        script="${script/#\~/$HOME}"
+    fi
+    if [[ ! -f "$script" ]]; then
+        log "ERROR: script not found: $SCRIPT_OR_PROMPT"
+        save_state "error" 127 0 "script not found: $SCRIPT_OR_PROMPT"
+        send_telegram "❌ <b>$JOB_NAME</b>: script not found: $SCRIPT_OR_PROMPT"
+        exit 127
+    fi
+
+    log "START tier=exec script=$script"
+    local start_ts=$(date +%s)
+
+    if [[ "${CRON_AGENT_DRY_RUN:-}" == "1" ]]; then
+        echo "[DRY RUN] Would execute: bash $script $*"
+        log "DRY RUN: bash $script $*"
+        save_state "dry_run" 0 0
+        return 0
+    fi
+
+    local output exit_code
+    output=$(timeout "$TIMEOUT" bash "$script" "$@" 2>&1) || exit_code=$?
+    exit_code=${exit_code:-0}
+    local duration=$(( $(date +%s) - start_ts ))
+
+    # Log output (last 50 lines)
+    echo "$output" | tail -50 >> "$LOG_FILE"
+
+    if [[ $exit_code -eq 0 ]]; then
+        log "OK duration=${duration}s"
+        save_state "ok" 0 "$duration"
+    elif [[ $exit_code -eq 124 ]]; then
+        log "TIMEOUT after ${TIMEOUT}s"
+        save_state "timeout" 124 "$duration" "timeout after ${TIMEOUT}s"
+        send_telegram "⏰ <b>$JOB_NAME</b> timeout after ${TIMEOUT}s"
+    else
+        local err_tail
+        err_tail=$(echo "$output" | tail -3 | tr '\n' ' ' | head -c 200)
+        log "FAILED exit=$exit_code err=$err_tail"
+        save_state "error" "$exit_code" "$duration" "$err_tail"
+        send_telegram "❌ <b>$JOB_NAME</b> failed (exit $exit_code)
+${err_tail}"
+    fi
+    return $exit_code
+}
+
+# ── Tier: agent ───────────────────────────────────────────────────────────────
+
+run_agent() {
+    local prompt_file="$SCRIPT_OR_PROMPT"
+    if [[ ! -f "$prompt_file" ]]; then
+        prompt_file="${prompt_file/#\~/$HOME}"
+    fi
+    if [[ ! -f "$prompt_file" ]]; then
+        log "ERROR: prompt file not found: $SCRIPT_OR_PROMPT"
+        save_state "error" 127 0 "prompt file not found: $SCRIPT_OR_PROMPT"
+        send_telegram "❌ <b>$JOB_NAME</b>: prompt file not found: $SCRIPT_OR_PROMPT"
+        exit 127
+    fi
+
+    local prompt
+    prompt=$(cat "$prompt_file")
+    # W89 class-audit (2026-07-11): tell the model inline never to background this run —
+    # a backgrounded task is killed at the print-mode ceiling, leaving no output at all.
+    prompt="${prompt}
+
+Do ALL the work inline in this turn — never spawn a background task or background agent
+for this; this is a one-shot print-mode run and backgrounded work is terminated at exit,
+leaving no output (W89 class-audit, regulatory-watcher incident 2026-07-05)."
+
+    log "START tier=agent prompt_file=$prompt_file prompt_len=${#prompt}"
+    local start_ts=$(date +%s)
+
+    if [[ "${CRON_AGENT_DRY_RUN:-}" == "1" ]]; then
+        echo "[DRY RUN] Would run claude -p with prompt from $prompt_file (${#prompt} chars)"
+        log "DRY RUN: claude -p (${#prompt} chars)"
+        save_state "dry_run" 0 0
+        return 0
+    fi
+
+    # 3-token OAuth fallback chain
+    local tokens=()
+    local labels=()
+    for i in 1 2 3; do
+        local var_name="CLAUDE_CODE_OAUTH_TOKEN_${i}"
+        local tok="${!var_name:-}"
+        if [[ -n "$tok" ]]; then
+            tokens+=("$tok")
+            labels+=("token_$i")
+        fi
+    done
+    # Legacy fallback
+    if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+        local is_dup=0
+        for t in "${tokens[@]:-}"; do
+            [[ "$t" == "$CLAUDE_CODE_OAUTH_TOKEN" ]] && is_dup=1
+        done
+        if [[ $is_dup -eq 0 ]]; then
+            tokens+=("$CLAUDE_CODE_OAUTH_TOKEN")
+            labels+=("token_legacy")
+        fi
+    fi
+    # Keychain fallback (no token = use system keychain)
+    tokens+=("")
+    labels+=("keychain")
+
+    local RATE_LIMIT_PATTERN="rate.limit\|too many requests\|429\|exhausted\|quota\|hit your limit\|capacity\|overloaded"
+    local output="" exit_code=1
+
+    for idx in "${!tokens[@]}"; do
+        local token="${tokens[$idx]}"
+        local label="${labels[$idx]}"
+        log "Trying $label..."
+
+        local env_args=()
+        if [[ -n "$token" ]]; then
+            env_args=(env "CLAUDE_CODE_OAUTH_TOKEN=$token")
+        else
+            env_args=(env -u CLAUDE_CODE_OAUTH_TOKEN)
+        fi
+
+        # --permission-mode bypassPermissions: no approval waits.
+        # Note: --bare is incompatible with OAuth tokens (requires ANTHROPIC_API_KEY).
+        # --model haiku: Routing A (2026-04-22) — cron automatici usano Haiku,
+        # libera quota Opus per sessioni interattive. Override via CLAUDE_CRON_MODEL env var.
+        # Data-driven decision: cron = 82% sessions but 0.6% output value (empirical analysis 2026-04-22).
+        local cron_model="${CLAUDE_CRON_MODEL:-claude-haiku-4-5-20251001}"
+        output=$("${env_args[@]}" timeout "$TIMEOUT" claude -p --model "$cron_model" --permission-mode bypassPermissions "$prompt" 2>&1) && exit_code=0 || exit_code=$?
+
+        # Check if rate limited (explicit error message)
+        if [[ $exit_code -ne 0 ]] && echo "$output" | grep -qi "$RATE_LIMIT_PATTERN"; then
+            log "$label: rate limited (explicit), trying next"
+            continue
+        fi
+
+        # Check if token is silently exhausted (empty output, any exit code).
+        # Claude CLI with exhausted Max-plan token returns empty output with exit 0 or 143.
+        # Real errors have messages; real success has non-empty output.
+        local output_trimmed="${output//[[:space:]]/}"
+        if [[ -z "$output_trimmed" ]] && [[ $exit_code -ne 124 ]]; then
+            log "$label: empty output (likely quota/rate issue), trying next"
+            continue
+        fi
+
+        # Success or non-empty error output — stop trying
+        break
+    done
+
+    local duration=$(( $(date +%s) - start_ts ))
+
+    # Log output (last 80 lines)
+    echo "$output" | tail -80 >> "$LOG_FILE"
+
+    if [[ $exit_code -eq 0 ]]; then
+        log "OK duration=${duration}s label=${labels[$idx]}"
+        # Explicit tier-provenance line (W89 class-audit, 2026-07-11): which of the
+        # 4 fallback slots (token_1/2/3/legacy/keychain) actually answered.
+        log "[cron-agent] used: tier2-claude-${labels[$idx]} (exit=0)"
+        save_state "ok" 0 "$duration"
+    elif [[ $exit_code -eq 124 ]]; then
+        log "TIMEOUT all tokens exhausted after ${TIMEOUT}s"
+        save_state "timeout" 124 "$duration" "all tokens exhausted, timeout"
+        send_telegram "⏰ <b>$JOB_NAME</b> agent timeout (all 3 tokens tried)"
+    else
+        local err_tail
+        err_tail=$(echo "$output" | tail -3 | tr '\n' ' ' | head -c 200)
+        log "FAILED exit=$exit_code label=${labels[$idx]:-?} err=$err_tail"
+        save_state "error" "$exit_code" "$duration" "$err_tail"
+        send_telegram "❌ <b>$JOB_NAME</b> agent failed (exit $exit_code, last token: ${labels[$idx]:-?})
+${err_tail}"
+    fi
+    return $exit_code
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+
+case "$TIER" in
+    exec)  run_exec "$@" ;;
+    agent) run_agent ;;
+    *)     echo "Unknown tier: $TIER"; exit 1 ;;
+esac

--- a/infra/launchagents/wrappers/run-nb-curator-mode-c.sh
+++ b/infra/launchagents/wrappers/run-nb-curator-mode-c.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# run-nb-curator-mode-c.sh — invoke nb-curator agent in Mode C
+#
+# Schedule (set in com.balizero.nb-curator.mode-c.weekly.plist):
+#   every Monday 05:00 WITA
+#
+# Scope decision happens inside the agent based on today's date:
+#   day-of-month <= 7 AND Monday → full pass (5 NB + stale-all)
+#   any other Monday             → Press + stale-all only
+#
+# Stale >90 days runs every Monday for all 5 NB.
+#
+# Output:
+#   - Markdown report at ~/Desktop/nuzantara/research/nb-health/YYYY-MM-nb-intel-curation.md
+#   - Telegram digest to chat_id 1125336968 (from agent)
+# Failure handling:
+#   - Wrapper redirects stdout+stderr to ~/logs/nb-curator-mode-c.log
+#   - Telegram alert if exit != 0
+#
+# W89 class-audit fix (2026-07-11, PENDING-ARMS ledger ~68): sonnet-5 in --print mode can
+# silently spawn its work as a background task; the CLI kills it at the print-mode ceiling
+# and exits 0 with no report on disk (incident: regulatory-watcher 2026-07-05). Fix here:
+# raise the background ceiling, tell the model inline never to background, and log an
+# explicit "used: tier1-<model>" provenance line (single-tier by design — this agent's
+# NotebookLM MCP tool access needs Claude, not agy/codex/ollama).
+
+set -uo pipefail
+
+LOG_FILE="${HOME}/logs/nb-curator-mode-c.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Load secrets for Telegram alerting on wrapper-level failure
+SECRETS_FILE="${HOME}/.nuzantara-secrets.env"
+if [[ -f "$SECRETS_FILE" ]]; then
+    # shellcheck disable=SC1090
+    set -a; source "$SECRETS_FILE"; set +a
+fi
+
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.pyenv/versions/3.11.11/bin:${PATH:-}"
+export PATH HOME
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG_FILE"
+}
+
+log "=== nb-curator Mode C run starting ==="
+
+# sonnet-5 --print + background tasks (W89 class-audit, 2026-07-11): the CLI kills
+# backgrounded work after the print-mode ceiling; 30min keeps a legitimate full-pass run
+# (5 NB + dedup clustering) alive.
+export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS="${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:-1800000}"
+
+# Invoke claude CLI to run the nb-curator agent in Mode C.
+# The agent reads the date itself and decides scope (full vs Press-only).
+PROMPT="Run nb-curator agent in Mode C (Dedupe/Summarize). Read today's date, decide scope per the schedule in your spec (day-of-month <=7 AND Monday = full pass; else Press + stale-all). Emit markdown report under ~/Desktop/nuzantara/research/nb-health/ and Telegram digest. Do NOT call any nlm rm or any mutating command — propose-only per Article 1. Do ALL the work inline in this turn — never spawn a background task or background agent for this; this is a one-shot print-mode run and backgrounded work is terminated at exit, leaving no report on disk (W89 class-audit, regulatory-watcher incident 2026-07-05)."
+
+if ! command -v claude >/dev/null 2>&1; then
+    log "FAIL: claude CLI not in PATH"
+    exit 127
+fi
+
+# Use subagent invocation via stdin so we don't depend on a specific CLI flag.
+# The agent file at ~/.claude/agents/nb-curator.md is autoloaded.
+START_EPOCH=$(date +%s)
+
+# Allow up to 30 min for the full pass (5 NB × ~3min each + dedup clustering)
+timeout 1800 claude -p "$PROMPT" --model claude-sonnet-5 \
+    >> "$LOG_FILE" 2>&1
+EXIT=$?
+
+END_EPOCH=$(date +%s)
+DURATION=$((END_EPOCH - START_EPOCH))
+
+log "=== nb-curator Mode C done (exit=${EXIT}, duration=${DURATION}s) ==="
+
+# Explicit tier-provenance line (W89 class-audit, 2026-07-11): single-tier by design (no
+# claude-cascade.sh fallback — NotebookLM MCP access needs Claude specifically).
+if [[ "$EXIT" -eq 0 ]]; then
+    log "[nb-curator-mode-c] used: tier1-claude-sonnet-5 (exit=0)"
+else
+    log "[nb-curator-mode-c] agent run FAILED (exit=${EXIT}) model=claude-sonnet-5"
+fi
+
+if [[ "$EXIT" -ne 0 ]] && [[ -n "${TELEGRAM_BOT_TOKEN:-}" ]] && [[ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]]; then
+    msg="⚠️ nb-curator Mode C failed (exit=${EXIT}, ${DURATION}s). Log: ${LOG_FILE}"
+    curl -sS --max-time 10 -X POST \
+        "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_OWNER_CHAT_ID}" \
+        -d "text=${msg}" >/dev/null 2>&1 || true
+fi
+
+exit "$EXIT"

--- a/infra/launchagents/wrappers/wr2-contract-test.sh
+++ b/infra/launchagents/wrappers/wr2-contract-test.sh
@@ -1,0 +1,141 @@
+#!/bin/zsh
+# wr2-contract-test.sh — invoke wr2-design-architect + verify contracts ABC forensicamente
+#
+# Usage:
+#   ./wr2-contract-test.sh                      # use default test topic
+#   ./wr2-contract-test.sh "topic text" "domain" "audience"
+#
+# Returns 0 if all 3 contracts PASS, non-zero otherwise.
+#
+# W89 class-audit fix (2026-07-11, PENDING-ARMS ledger ~68): sonnet-5/opus in --print mode
+# can silently spawn its work as a background task; the CLI kills it at the print-mode
+# ceiling and exits 0 with no orchestrator-output.txt on disk (incident: regulatory-watcher
+# 2026-07-05). Fix here: raise the background ceiling, tell the model inline never to
+# background, and log an explicit "used: tier1-<model>" provenance line (single-tier by
+# design — this is a manual forensic harness for the Claude-only wr2-design-architect agent).
+
+set -uo pipefail
+
+TOPIC="${1:-BPJS Ketenagakerjaan tarif update Q3 2026}"
+DOMAIN="${2:-regulatory}"
+AUDIENCE="${3:-founder}"
+OUT="${WR2_TEST_OUT:-/tmp/wr2-contract-test}"
+LOG="${HOME}/logs/wr2-contract-test.log"
+mkdir -p "$(dirname "$LOG")"
+
+echo "[$(date)] WR2 contract test starting" >&2
+echo "  topic: $TOPIC" >&2
+echo "  domain: $DOMAIN" >&2
+echo "  audience: $AUDIENCE" >&2
+echo "  output: $OUT" >&2
+
+mkdir -p "$OUT"
+rm -rf "$OUT"/* 2>/dev/null || true
+
+# sonnet-5/opus --print + background tasks (W89 class-audit, 2026-07-11): the CLI kills
+# backgrounded work after the print-mode ceiling; 30min keeps a legitimate 4-subagent
+# fan-out run alive.
+export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS="${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:-1800000}"
+
+# Spawn orchestrator via claude --print --agent
+PROMPT="Standalone manual contract verification run.
+Topic: $TOPIC
+Domain: $DOMAIN. Audience: $AUDIENCE.
+Output dir: $OUT/
+Per Step 0 ENFORCEMENT PROLOGUE: invoke 4 sub-agents (Contract A), brief MUST have nb_sources_consulted+nb_query_log (B), declare image_strategy explicitly (C), no silent placeholder reuse.
+Run final Self-audit. Output STATUS line at end. NO Playwright render. NO canva_pending.json write.
+Do ALL the work inline in this session — never spawn a background task or background agent
+for this; this is a one-shot print-mode run and backgrounded work is terminated at exit,
+leaving no orchestrator-output.txt on disk (W89 class-audit, regulatory-watcher incident 2026-07-05)."
+
+unset ANTHROPIC_API_KEY
+$HOME/.local/bin/claude --print --model claude-opus-4-7 \
+    --agent wr2-design-architect "$PROMPT" \
+    > "$OUT/orchestrator-output.txt" 2>&1
+EXIT=$?
+
+echo "[$(date)] orchestrator exit=$EXIT" >&2
+
+# Explicit tier-provenance line (W89 class-audit, 2026-07-11): single-tier by design (no
+# claude-cascade.sh fallback — this harness exercises the Claude-only wr2-design-architect
+# agent and its 4 subagent fan-out).
+if [ "$EXIT" -eq 0 ]; then
+    echo "[$(date)] [wr2-contract-test] used: tier1-claude-opus-4-7 (exit=0)" | tee -a "$LOG" >&2
+else
+    echo "[$(date)] [wr2-contract-test] agent run FAILED (exit=$EXIT) model=claude-opus-4-7" | tee -a "$LOG" >&2
+fi
+
+# ============== FORENSIC VERIFICATION ==============
+echo ""
+echo "===== CONTRACT VERIFICATION ====="
+
+PASS_A=0; PASS_B=0; PASS_C=0
+
+# Contract A — fan-out: 4 sub-agent transcripts present?
+A_COUNT=$(ls "$OUT"/{brief,storyboard,layout,critic}-raw.txt 2>/dev/null | wc -l | tr -d ' ')
+if [ "$A_COUNT" -ge 4 ]; then
+    echo "Contract A (fan-out): PASS — $A_COUNT subagent transcripts found"
+    PASS_A=1
+else
+    echo "Contract A (fan-out): FAIL — only $A_COUNT/4 transcripts"
+fi
+
+# Contract B — NB query: brief.json has nb_sources_consulted ≥1 + nb_query_log ≥1
+if [ -f "$OUT/brief.json" ]; then
+    B_RESULT=$(/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3 -c "
+import json, sys
+try:
+    d = json.load(open('$OUT/brief.json'))
+    src = len(d.get('nb_sources_consulted', []))
+    logs = len(d.get('nb_query_log', []))
+    if src >= 1 and logs >= 1:
+        print(f'PASS sources={src} queries={logs}')
+    else:
+        print(f'FAIL sources={src} queries={logs}')
+except Exception as e:
+    print(f'FAIL parse-error: {e}')
+")
+    if [[ "$B_RESULT" == PASS* ]]; then
+        echo "Contract B (NB query): $B_RESULT"
+        PASS_B=1
+    else
+        echo "Contract B (NB query): $B_RESULT"
+    fi
+else
+    echo "Contract B (NB query): FAIL — brief.json missing"
+fi
+
+# Contract C — image strategy declared per hero, no silent placeholder reuse
+if [ -f "$OUT/slides.json" ]; then
+    C_RESULT=$(/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3 -c "
+import json
+d = json.load(open('$OUT/slides.json'))
+slides = d.get('slides', d) if isinstance(d, dict) else d
+heroes = [s for s in slides if s.get('is_hero_image')]
+if not heroes:
+    print('FAIL no-hero-slides')
+else:
+    missing = [s for s in heroes if not s.get('image_strategy') or not s.get('image_source')]
+    if missing:
+        print(f'FAIL {len(missing)}/{len(heroes)} heroes missing image_strategy/source')
+    else:
+        print(f'PASS all {len(heroes)} heroes declare image_strategy + image_source')
+")
+    if [[ "$C_RESULT" == PASS* ]]; then
+        echo "Contract C (image strategy): $C_RESULT"
+        PASS_C=1
+    else
+        echo "Contract C (image strategy): $C_RESULT"
+    fi
+else
+    echo "Contract C (image strategy): FAIL — slides.json missing"
+fi
+
+echo ""
+TOTAL=$((PASS_A + PASS_B + PASS_C))
+echo "===== TOTAL: $TOTAL/3 contracts PASS ====="
+
+if [ "$TOTAL" -eq 3 ]; then
+    exit 0
+fi
+exit 1

--- a/infra/launchagents/wrappers/yield-optimizer-run.sh
+++ b/infra/launchagents/wrappers/yield-optimizer-run.sh
@@ -1,0 +1,60 @@
+#!/bin/zsh
+# yield-optimizer cron wrapper. Sun 04:00 WITA.
+# Spawns claude --print --agent yield-optimizer (Sonnet 4.6 OAuth, Ollama qwen3.5:9b LOCAL for CRM PII).
+# Cost: 0$ (OAuth + local Ollama).
+#
+# W89 class-audit fix (2026-07-11, PENDING-ARMS ledger ~68): sonnet-5 in --print mode can
+# silently spawn its work as a background task; the CLI kills it at the print-mode ceiling
+# and exits 0 with no output — "success" with nothing produced (incident: regulatory-watcher
+# 2026-07-05). Fix here is the same shape: claude-cascade.sh (this wrapper's Claude-tier
+# entry point) raises CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS, and the prompt below tells the
+# model inline never to background this run.
+
+set -uo pipefail
+unset ANTHROPIC_API_KEY
+
+[ -f "$HOME/.nuzantara-secrets.env" ] && set -a && source "$HOME/.nuzantara-secrets.env" && set +a
+
+mkdir -p "$HOME/Desktop/nuzantara/research/commercial" "$HOME/logs"
+LOG="$HOME/logs/yield-optimizer.log"
+DATE=$(TZ=Asia/Makassar date +%Y-%m-%d)
+WEEK=$(TZ=Asia/Makassar date +%Y-W%V)
+
+echo "[$(date)] yield-optimizer run starting for $WEEK" >> "$LOG"
+
+PROMPT="Run yield-optimizer agent for week $WEEK ($DATE).
+Read ~/.claude/agents/yield-optimizer.md for full spec.
+- Pull CRM via Postgres (apply 6 opportunity rules R1-R6, cap 20)
+- Generate WhatsApp pitches via Ollama qwen3.5:9b LOCAL (NEVER cloud LLM for CRM PII)
+- Output to ~/Desktop/nuzantara/research/commercial/${WEEK}-yield-opportunities.md
+- Telegram digest to TELEGRAM_OWNER_CHAT_ID
+- Emit eventbus learning.updated event
+NO autonomous outreach. Drafts ONLY for ops team.
+Do ALL the work inline in this session — never spawn a background task or background agent
+for this; this is a one-shot print-mode run and backgrounded work is terminated at exit,
+leaving no opportunities file on disk (W89 class-audit, regulatory-watcher incident 2026-07-05)."
+
+TMPOUT=$(mktemp)
+# Multi-tier cascade: claude → claude-acct2 → claude-acct3 → gemini → codex → ollama
+"$HOME/scripts/claude-cascade.sh" "$PROMPT" --model claude-sonnet-5 --agent yield-optimizer \
+    >"$TMPOUT" 2>>"$LOG"
+EXIT=$?
+cat "$TMPOUT" >> "$LOG"
+
+if [ $EXIT -ne 0 ]; then
+    echo "[$(date)] yield-optimizer ALL TIERS FAILED ($EXIT)" >> "$LOG"
+fi
+
+# Explicit tier-provenance line (W89 class-audit, 2026-07-11): grep the cascade's own
+# "[claude-cascade] used: <tier>" line so a run's actual answering tier is always on record
+# in this wrapper's own log, not just buried in the cascade's stderr interleave.
+USED_TIER=$(grep -o '\[claude-cascade\] used: [^"]*' "$TMPOUT" | tail -1 || true)
+if [ -n "$USED_TIER" ]; then
+    echo "[$(date)] [yield-optimizer] ${USED_TIER}" >> "$LOG"
+else
+    echo "[$(date)] [yield-optimizer] used: none (all tiers failed or no tier line found)" >> "$LOG"
+fi
+
+rm -f "$TMPOUT"
+echo "[$(date)] yield-optimizer run complete" >> "$LOG"
+exit 0


### PR DESCRIPTION
## Summary

PENDING-ARMS ledger line ~68 (W89 class-audit): the sonnet-5 `--print` backgrounding vulnerability (CLI silently spawns work as a background task, kills it at the print-mode ceiling, exits 0 with no artifact — incident: regulatory-watcher 2026-07-05) lived undetected in 7 more HOME-only wrappers on Pro. nb-curator/regulatory-watcher/ig-metrics were already closed in prior PRs; this closes the remaining 5:

- `competitor-monitor-run.sh` + `yield-optimizer-run.sh`: route through `claude-cascade.sh` (reverse-promoted here too — was never in repo canon), fix applied once at the cascade's single Claude-tier choke point + anti-background prompt sentence + provenance grep in each wrapper's own log.
- `run-nb-curator-mode-c.sh` + `wr2-contract-test.sh`: direct `claude -p`/`--print` callers, following the `wr2-ig-metrics-analyst-run.sh` precedent (BG-ceiling env + inline anti-background directive + explicit `used: tier1-<model>` log line).
- `cron-agent.sh`: universal cron wrapper, live crontab consumer for 5+ jobs (weekly-dep-audit, seo-guardian-weekly, conversation-cleanup, indexing-daily, learning-pipeline) via its `agent` tier — same fix at the single `run_agent()` claude invocation.

All 6 declared in `infra/home-fork/declared-pairs.json` (machines=[pro]).

## Test plan

- [x] `bash -n` syntax-clean on all 6 files (verified this session)
- [x] `python3 -c "import json; json.load(...)"` valid on declared-pairs.json
- [x] Pre-commit hooks green (lease-check, secrets scan, prettier, typecheck, python lint, off-limits check)
- [ ] Live HOME sync + blob-proof on Pro (PENDING-ALIGN, tracked in ledger delta — read-only from this M5 worktree session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)