### PR TITLE
fix(husky): pre-push CI-parity — OLLAMA_URL dead-port + e2e ignore (unblocks machine-wide pushes)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -27,6 +27,15 @@ echo "✅ Skipping full test suite (covered by pre-commit hooks)"
 # so must this hook, else every push fails with `role "nuzantara" does not exist`.
 # PYTHONPATH=.:../crm-cell also matches CI (crm-cell is a sibling package).
 #
+# CI-parity also means CI's ABSENCES: the CI service containers run Postgres+Redis
+# but NO Ollama, so live-LLM tests self-skip there via is_ollama_available()
+# (e.g. test_live_sealion_golden_rule_null_on_illegible). A dev machine may reach
+# a fleet Ollama, which flips those same tests to RUN — making the gate both
+# stricter than CI and flaky (2026-07-11: the freshly-armed gate stranded two
+# sibling report pushes on that exact live SEA-LION test). OLLAMA_BASE_URL points
+# at a dead port so the hook gates exactly the test set CI gates. Same rationale
+# for --ignore=backend/tests/e2e, which mirrors tests.yml:190.
+#
 # F5: keg-only postgresql@17 `pg_isready`/`psql` are NOT on the PATH of this hook's
 # non-interactive shell; resolve by absolute path with a `command -v` fallback.
 # F8: with PG provisioned, a genuine test failure must BLOCK (exit 1), not "Continuing".
@@ -53,12 +62,14 @@ else
            TEST_DATABASE_URL="postgresql://test:test@localhost:5432/$PRE_PUSH_DB" \
            JWT_SECRET_KEY="${JWT_SECRET_KEY:-test_jwt_secret_key_for_testing_only_min_32_chars_long}" \
            API_KEYS="${API_KEYS:-test_api_key_1,test_api_key_2}" \
-           PYTHONPATH=.:../crm-cell python -m pytest backend/tests/ --tb=short -q ); then
+           OLLAMA_BASE_URL="http://127.0.0.1:9" \
+           PYTHONPATH=.:../crm-cell python -m pytest backend/tests/ --ignore=backend/tests/e2e --tb=short -q ); then
         echo "❌ Python tests FAILED — push blocked."
         echo "   Reproduce: cd apps/backend-rag && source .venv/bin/activate && \\"
         echo "     DATABASE_URL=postgresql://test:test@localhost:5432/$PRE_PUSH_DB \\"
         echo "     TEST_DATABASE_URL=postgresql://test:test@localhost:5432/$PRE_PUSH_DB \\"
-        echo "     PYTHONPATH=.:../crm-cell pytest backend/tests/"
+        echo "     OLLAMA_BASE_URL=http://127.0.0.1:9 \\"
+        echo "     PYTHONPATH=.:../crm-cell pytest backend/tests/ --ignore=backend/tests/e2e"
         exit 1
     fi
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -32,9 +32,14 @@ echo "✅ Skipping full test suite (covered by pre-commit hooks)"
 # (e.g. test_live_sealion_golden_rule_null_on_illegible). A dev machine may reach
 # a fleet Ollama, which flips those same tests to RUN — making the gate both
 # stricter than CI and flaky (2026-07-11: the freshly-armed gate stranded two
-# sibling report pushes on that exact live SEA-LION test). OLLAMA_BASE_URL points
-# at a dead port so the hook gates exactly the test set CI gates. Same rationale
-# for --ignore=backend/tests/e2e, which mirrors tests.yml:190.
+# sibling report pushes on that exact live SEA-LION test). OLLAMA_URL points at a
+# dead port so the hook gates exactly the test set CI gates — the env name is the
+# pydantic mapping of settings.ollama_url (backend/app/core/config.py:127), NOT the
+# module-global's name OLLAMA_BASE_URL (probed empirically 2026-07-11: only
+# OLLAMA_URL overrides). Same rationale for --ignore=backend/tests/e2e (tests.yml:190).
+# NOTE: git resolves the relative hooksPath against the MAIN checkout — worktree
+# copies of this file do NOT govern pushes; this fix bites machine-wide only once
+# merged to main and pulled there.
 #
 # F5: keg-only postgresql@17 `pg_isready`/`psql` are NOT on the PATH of this hook's
 # non-interactive shell; resolve by absolute path with a `command -v` fallback.
@@ -62,13 +67,13 @@ else
            TEST_DATABASE_URL="postgresql://test:test@localhost:5432/$PRE_PUSH_DB" \
            JWT_SECRET_KEY="${JWT_SECRET_KEY:-test_jwt_secret_key_for_testing_only_min_32_chars_long}" \
            API_KEYS="${API_KEYS:-test_api_key_1,test_api_key_2}" \
-           OLLAMA_BASE_URL="http://127.0.0.1:9" \
+           OLLAMA_URL="http://127.0.0.1:9" \
            PYTHONPATH=.:../crm-cell python -m pytest backend/tests/ --ignore=backend/tests/e2e --tb=short -q ); then
         echo "❌ Python tests FAILED — push blocked."
         echo "   Reproduce: cd apps/backend-rag && source .venv/bin/activate && \\"
         echo "     DATABASE_URL=postgresql://test:test@localhost:5432/$PRE_PUSH_DB \\"
         echo "     TEST_DATABASE_URL=postgresql://test:test@localhost:5432/$PRE_PUSH_DB \\"
-        echo "     OLLAMA_BASE_URL=http://127.0.0.1:9 \\"
+        echo "     OLLAMA_URL=http://127.0.0.1:9 \\"
         echo "     PYTHONPATH=.:../crm-cell pytest backend/tests/ --ignore=backend/tests/e2e"
         exit 1
     fi


### PR DESCRIPTION
## Problem

The freshly-armed pre-push Python gate (state 3: local PG provisioned → full suite runs) is **stricter than CI**: CI's service containers have Postgres+Redis but NO Ollama, so live-LLM tests self-skip there via `is_ollama_available()`. A dev machine that can reach a fleet Ollama flips those same tests to RUN — `test_live_sealion_golden_rule_null_on_illegible` failed locally and stranded every push on this machine on 2026-07-11 (three sessions hit it independently).

## Fix (2 commits)

1. Add `OLLAMA_URL=http://127.0.0.1:9` (dead port) to the hook's CI-parity env block, so the hook gates **exactly the test set CI gates** — live tests self-skip, same as CI. Also `--ignore=backend/tests/e2e` to match `tests.yml:190`.
2. Correct the env var name: the first commit used `OLLAMA_BASE_URL`, which is only the NAME of the module global in `ollama_client.py`. Pydantic sources `settings.ollama_url` from env **`OLLAMA_URL`** (`backend/app/core/config.py:127`). **Probed empirically**: `OLLAMA_BASE_URL=dead-port` → URL stays `localhost:11434` (no-op); `OLLAMA_URL=dead-port` → overrides.

## Load-bearing discovery (documented in the hook comments)

Git resolves the relative `core.hooksPath` against the **MAIN checkout** — worktree copies of `.husky/pre-push` never govern a push. This fix bites machine-wide only once merged to main and pulled there. Until then, pushes use the env-inheritance technique (`OLLAMA_URL=http://127.0.0.1:9 git push …`), which is CI-parity by the same argument.

## Verification

- Full suite green under the new env on this machine (sealion among SKIPPED, zero failed).
- Hook diff vs CI (`.github/workflows/tests.yml`) reviewed line-by-line: env pairs match (DATABASE_URL/TEST_DATABASE_URL → `test:test@localhost:5432/nuzantara_test`), `--ignore=backend/tests/e2e` matches, no `-m` filter in either.
- CI itself is unaffected (hook does not run in CI; CI never had Ollama).

## Known limitation surfaced during rollout (2026-07-11 night)

Two sessions pushing concurrently run two full suites against the SAME `nuzantara_test` DB → mutual corruption (DDL race: `relation "partners" does not exist`, deadlocks, duplicate keys — observed live, 9F+2E, zero of them real). The hook already parameterizes `PRE_PUSH_TEST_DB`; interim protocol on multi-session machines is one private DB per session (`createdb` + bootstrap + `PRE_PUSH_TEST_DB=<name> git push`). Durable cure (follow-up, not this PR): default to a per-push ephemeral DB cloned from a template.

Adversarial review requested from the merge-train lane (S2) before arming — reviewer instruction: collect-only diff of hook env vs `tests.yml` env, hunt for any pair where the hook is now WEAKER than CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
