### PR TITLE
fix(tests): voice_legacy env-isolation — pin legacy audio alias + silero module

### DIFF
--- a/apps/backend-rag/backend/tests/unit/app/routers/test_voice_legacy.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_voice_legacy.py
@@ -171,6 +171,7 @@ def test_local_audio_status_requires_api_key() -> None:
 
 def test_local_audio_status_disabled_is_sanitized(monkeypatch) -> None:
     monkeypatch.setattr(settings, "voice_concierge_local_audio_enabled", False)
+    monkeypatch.setattr(settings, "voice_concierge_local_audio", False)
     app = FastAPI()
     app.include_router(router)
     client = TestClient(app)
@@ -197,6 +198,13 @@ def test_local_audio_status_disabled_is_sanitized(monkeypatch) -> None:
 
 def test_local_audio_status_redacts_whisper_paths(monkeypatch) -> None:
     monkeypatch.setattr(settings, "voice_concierge_local_audio_enabled", True)
+    # Pin VAD to an unimportable module: on hosts with silero-vad installed
+    # (voice runtime machines) the real module would flip turn_detection_ready.
+    monkeypatch.setattr(
+        settings,
+        "voice_concierge_silero_module",
+        "nonexistent_silero_module_for_test",
+    )
     monkeypatch.setattr(
         settings,
         "voice_concierge_whisper_binary",


### PR DESCRIPTION
## Problem

Two `test_voice_legacy.py` tests fail on any host with a runtime `.env` / voice stack installed (the Pro), while passing in CI. This makes the husky pre-push pytest gate red on the Pro for every push, regardless of branch content (standing blocker since 2026-07-08).

- `test_local_audio_status_disabled_is_sanitized` patched only `voice_concierge_local_audio_enabled`, but the router ORs the **legacy `voice_concierge_local_audio` alias** (`voice.py::_local_audio_enabled`), which the Pro's `.env` sets. Sibling tests already pin both — this was the one missed call-site (W89 class-audit).
- `test_local_audio_status_redacts_whisper_paths` asserted `turn_detection_ready is False`, but VAD readiness = **importability of the `silero_vad` module** — installed on voice runtime machines. Pinned to an unimportable module name, matching the file's existing `FakeUnavailableVAD` pattern.

## Proof

- 35/35 green on the Pro (hostile env: `.env` legacy alias set + silero-vad installed), original file restored after the probe.
- CI semantics unchanged (both settings already default to the pinned values there).

## Class-audit (W89)

All 4 `voice_concierge_local_audio_enabled=False` patch-sites checked: 3 already pin the legacy alias; only line 173 missed it. All 3 `turn_detection_ready is False` asserts checked: one fakes the provider, one is the disabled path, only the whisper-paths test needed the module pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)