### PR TITLE
🎨 Palette: Localize ChatRecordingOverlay

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -62,6 +62,12 @@
 
 **Learning:** Live UI states that lack visual labels (like a voice recording overlay) are "silent" to screen readers. Adding `role="status"` and `aria-live="polite"` ensures that assistive technology users are notified of state transitions (e.g., recording started) without being interrupted. Furthermore, adding `aria-label` to semantic lists of "Quick Actions" provides necessary context for group navigation, making the interface more discoverable.
 **Action:** Always apply ARIA live regions to dynamic status overlays. Use descriptive `aria-label` on semantic list containers that serve as primary interaction points.
+
+## 2026-07-12 - [Centralized Localization for Chat Overlays]
+
+**Learning:** UI overlays that provide instructional feedback (e.g., voice recording status) must be localized to maintain a professional, accessible experience for multi-language users. Utilizing a shared `useChatLocale` hook ensures that ephemeral UI elements remain in sync with the user's selected language across the application.
+**Action:** Always use `useChatLocale` for instructional text in chat-specific overlays and indicators.
+
 ## 2025-05-15 - [Stop Generation Pattern]
 **Learning:** In AI chat interfaces, the primary action button (Send) should transition to a 'Stop' button during streaming to provide users with control and an intuitive way to interrupt long or irrelevant responses. This requires carefully managing the 'disabled' state to ensure the button remains interactive while the background process is active.
 **Action:** Always implement a 'Stop Generation' toggle on the main input action button when dealing with streaming LLM responses. Use a clear visual cue like a 'Square' icon and ensure proper ARIA labels ('Stop generating') for accessibility.

--- a/apps/mouth/src/components/chat/ChatRecordingOverlay.test.tsx
+++ b/apps/mouth/src/components/chat/ChatRecordingOverlay.test.tsx
@@ -1,15 +1,27 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import {
   ChatRecordingOverlay,
   ChatRecordingOverlayProps,
 } from "./ChatRecordingOverlay";
 
+// Mock useChatLocale
+vi.mock("@/hooks/useChatLocale", () => ({
+  useChatLocale: vi.fn(),
+}));
+
+import { useChatLocale } from "@/hooks/useChatLocale";
+
 describe("ChatRecordingOverlay", () => {
   const defaultProps: ChatRecordingOverlayProps = {
     isRecording: false,
     recordingTime: 0,
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useChatLocale).mockReturnValue("en");
+  });
 
   describe("Visibility", () => {
     it("should not render when not recording", () => {
@@ -22,6 +34,26 @@ describe("ChatRecordingOverlay", () => {
     it("should render when recording", () => {
       render(<ChatRecordingOverlay {...defaultProps} isRecording={true} />);
       expect(screen.getByText("Release to send")).toBeInTheDocument();
+    });
+  });
+
+  describe("Localization", () => {
+    it("renders in English", () => {
+      vi.mocked(useChatLocale).mockReturnValue("en");
+      render(<ChatRecordingOverlay isRecording={true} recordingTime={0} />);
+      expect(screen.getByText("Release to send")).toBeInTheDocument();
+    });
+
+    it("renders in Italian", () => {
+      vi.mocked(useChatLocale).mockReturnValue("it");
+      render(<ChatRecordingOverlay isRecording={true} recordingTime={0} />);
+      expect(screen.getByText("Rilascia per inviare")).toBeInTheDocument();
+    });
+
+    it("renders in Indonesian", () => {
+      vi.mocked(useChatLocale).mockReturnValue("id");
+      render(<ChatRecordingOverlay isRecording={true} recordingTime={0} />);
+      expect(screen.getByText("Lepaskan untuk mengirim")).toBeInTheDocument();
     });
   });
 

--- a/apps/mouth/src/components/chat/ChatRecordingOverlay.tsx
+++ b/apps/mouth/src/components/chat/ChatRecordingOverlay.tsx
@@ -1,7 +1,19 @@
+"use client";
+
+import { useChatLocale } from "@/hooks/useChatLocale";
+
 export interface ChatRecordingOverlayProps {
   isRecording: boolean;
   recordingTime: number;
 }
+
+const LABELS = {
+  en: "Release to send",
+  it: "Rilascia per inviare",
+  id: "Lepaskan untuk mengirim",
+  fr: "Relâcher pour envoyer",
+  ru: "Отпустите для отправки",
+} as const;
 
 function formatTime(seconds: number): string {
   const mins = Math.floor(seconds / 60);
@@ -13,6 +25,9 @@ export function ChatRecordingOverlay({
   isRecording,
   recordingTime,
 }: ChatRecordingOverlayProps) {
+  const locale = useChatLocale();
+  const label = LABELS[locale as keyof typeof LABELS] || LABELS.en;
+
   if (!isRecording) {
     return null;
   }
@@ -25,7 +40,7 @@ export function ChatRecordingOverlay({
     >
       <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
       {formatTime(recordingTime)}
-      <span className="ml-2 opacity-50 text-[10px]">Release to send</span>
+      <span className="ml-2 opacity-50 text-[10px]">{label}</span>
     </div>
   );
 }


### PR DESCRIPTION
Localized the "Release to send" instructional text in the `ChatRecordingOverlay` component for EN, IT, ID, FR, and RU. Updated unit tests to verify the localization logic and ensured project-wide consistency by following existing localization patterns in the `apps/mouth` package.

---
*PR created automatically by Jules for task [16189481277320837301](https://jules.google.com/task/16189481277320837301) started by @Balizero1987*