### PR TITLE
fix(infra): migrate 2 reverse-promoted wrappers to tg_notify gateway (unblocks fleet PR train)

### DIFF
--- a/infra/launchagents/wrappers/cron-agent.sh
+++ b/infra/launchagents/wrappers/cron-agent.sh
@@ -69,17 +69,17 @@ log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] [$JOB_NAME] $*" >> "$LOG_FILE"; }
 
 send_telegram() {
     local msg="$1"
-    [[ -z "$TELEGRAM_BOT_TOKEN" ]] && return
-    # Cooldown: max 1 alert per 30 min per job
+    # Notification gateway (post-#2263 canon promotion): tg_notify.py owns token
+    # resolution + tiering + 6h dedup; this wrapper keeps its own 30-min cooldown.
+    # No env-token gate: an alert must not vanish silently when env lacks the token.
     if [[ -f "$COOLDOWN_FILE" ]]; then
         local age=$(( $(date +%s) - $(stat -f%m "$COOLDOWN_FILE" 2>/dev/null || echo 0) ))
         [[ $age -lt 1800 ]] && { log "Telegram cooldown active (${age}s < 1800s)"; return; }
     fi
-    curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-        -d "chat_id=${TELEGRAM_CHAT_ID}" \
-        -d "text=${msg}" \
-        -d "parse_mode=HTML" \
-        --max-time 10 >/dev/null 2>&1 || true
+    local gateway="$(dirname "$0")/tg_notify.py"
+    [ -f "$gateway" ] || gateway="$HOME/Desktop/nuzantara/scripts/tg_notify.py"
+    python3 "$gateway" --tier p0 --source cron-agent \
+        --dedup-key "cron-agent:${JOB_NAME}:$(hostname -s)" -- "$msg" >/dev/null 2>&1 || true
     touch "$COOLDOWN_FILE"
 }
 

--- a/infra/launchagents/wrappers/run-nb-curator-mode-c.sh
+++ b/infra/launchagents/wrappers/run-nb-curator-mode-c.sh
@@ -81,12 +81,14 @@ else
     log "[nb-curator-mode-c] agent run FAILED (exit=${EXIT}) model=claude-sonnet-5"
 fi
 
-if [[ "$EXIT" -ne 0 ]] && [[ -n "${TELEGRAM_BOT_TOKEN:-}" ]] && [[ -n "${TELEGRAM_OWNER_CHAT_ID:-}" ]]; then
+if [[ "$EXIT" -ne 0 ]]; then
+    # Notification gateway (post-#2263 canon promotion): tg_notify.py owns token
+    # resolution + dedup — no env-token gate, the alert must not vanish silently.
     msg="⚠️ nb-curator Mode C failed (exit=${EXIT}, ${DURATION}s). Log: ${LOG_FILE}"
-    curl -sS --max-time 10 -X POST \
-        "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-        -d "chat_id=${TELEGRAM_OWNER_CHAT_ID}" \
-        -d "text=${msg}" >/dev/null 2>&1 || true
+    gateway="$(dirname "$0")/tg_notify.py"
+    [ -f "$gateway" ] || gateway="$HOME/Desktop/nuzantara/scripts/tg_notify.py"
+    python3 "$gateway" --tier p0 --source nb-curator-mode-c \
+        --dedup-key "nb-curator-mode-c:$(hostname -s)" -- "$msg" >/dev/null 2>&1 || true
 fi
 
 exit "$EXIT"


### PR DESCRIPTION
## Problem

PR #2263 promoted `cron-agent.sh` + `run-nb-curator-mode-c.sh` from HOME to canon still carrying their legacy direct `api.telegram.org` curls. `lint_tg_direct_senders` scans **tree-wide** (`git ls-files`) and `grandfathered.json` is **monotone-shrink by design** — so every PR whose merge ref includes post-#2263 main fails the required `gateway` check (observed live on #2266; the whole PR train is blocked).

## Fix (canonical, not an allowlist)

Both send paths now call `scripts/tg_notify.py --tier p0` with `--source` + host-scoped `--dedup-key` (cohort-3 pattern from `disk_watchdog.sh`). `cron-agent` keeps its local 30-min cooldown on top of the gateway's dedup. Both drop the env-token gate — the gateway owns token resolution; a missing env token must not silently swallow an alert.

## Verification
- `bash -n` clean on both files.
- `python3 scripts/lint_tg_direct_senders.py` in this tree: **clean (7362 files scanned, 0 new senders)**.
- Full pre-push suite green (private-DB CI-parity env).

## Fleet note
Live HOME copies on Pro now diverge from canon until the standing PENDING-ALIGN:Pro ledger line (cp + `cmp -s` proof) is executed post-merge — same line already covers the other 4 wrappers from #2263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)