### PR TITLE
fix(infra): decode raw wait-status in launchd_liveness_detector last_exit

### DIFF
--- a/scripts/launchd_liveness_detector.py
+++ b/scripts/launchd_liveness_detector.py
@@ -113,6 +113,27 @@ MARKER_FRESH_SEC = int(os.environ.get("W84_MARKER_FRESH_SEC", str(48 * 3600)))
 UPTIME_STABLE_SEC = int(os.environ.get("W84_UPTIME_STABLE_SEC", str(STALE_GREEN_SEC)))
 
 
+def _decode_wait_status(raw: int) -> int:
+    """Decode the raw POSIX wait() status word `launchctl list <label>` reports
+    for LastExitStatus into the human-legible exit code `launchctl print` and
+    `subprocess` use (positive = normal exit code, negative = killed by that
+    signal number).
+
+    `launchctl list` emits the UNSHIFTED wait-status (a plain `exit 1` shows up
+    as 256, since normal-exit codes are packed into the high byte), while a
+    signal death (e.g. SIGKILL) shows up unshifted in the low bits (9, not
+    2304). Left raw, two jobs both "failing" can show wildly different
+    `last_exit` numbers for no operator-visible reason — confusing in the
+    ledger/Telegram output even though `_classify()`'s zero/non-zero checks
+    are unaffected either way (verified live 2026-07-12: overlap-detector.sh's
+    designed `exit 1` on a real finding showed as `last_exit: 256`).
+    """
+    try:
+        return os.waitstatus_to_exitcode(raw)
+    except ValueError:
+        return raw
+
+
 def _launchctl_status(label: str) -> dict | None:
     """Return the parsed `launchctl list <label>` dict, or None if not loaded."""
     try:
@@ -129,6 +150,8 @@ def _launchctl_status(label: str) -> dict | None:
         m = re.search(r'"(\w+)"\s*=\s*(-?\d+)', line)
         if m:
             d[m.group(1)] = int(m.group(2))
+    if "LastExitStatus" in d:
+        d["LastExitStatus"] = _decode_wait_status(d["LastExitStatus"])
     return d
 
 

--- a/scripts/tests/test_launchd_liveness_exit_status_decode.py
+++ b/scripts/tests/test_launchd_liveness_exit_status_decode.py
@@ -1,0 +1,91 @@
+"""Healer tick 2026-07-12: LastExitStatus from `launchctl list <label>` is the
+raw POSIX wait() status word, not a decoded exit code — a plain `exit 1` shows
+up as 256 (exit codes are packed into the wait-status high byte) while a
+SIGKILL death shows up as 9 (signal deaths aren't shifted). Live proof:
+`launchctl list com.nuzantara.overlap-detector.daily` returned
+`LastExitStatus = 256` for a script whose entire body is `exit 1` on a real
+detection — confusing in the ledger/Telegram output, though `_classify()`'s
+zero/non-zero checks were never actually wrong (both 256 and 1 are non-zero).
+
+Contract under test (_decode_wait_status / _launchctl_status):
+  - a normal-exit raw status (256 = exit 1 shifted into the high byte)
+    decodes to the plain exit code (1)
+  - a signal-death raw status (9 = SIGKILL, unshifted) decodes to the negative
+    signal convention `subprocess`/`launchctl print` use (-9)
+  - a clean exit (0) stays 0
+  - an unparseable value never crashes the detector — falls back to the raw
+    value
+  - `_launchctl_status()` applies the decode to the LastExitStatus key it
+    parses out of live `launchctl list` output, leaving other keys untouched
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "launchd_liveness_detector.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("launchd_liveness_detector", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_normal_exit_is_unshifted():
+    mod = _load_module()
+    assert mod._decode_wait_status(256) == 1
+
+
+def test_signal_death_becomes_negative_signal():
+    mod = _load_module()
+    assert mod._decode_wait_status(9) == -9
+
+
+def test_clean_exit_stays_zero():
+    mod = _load_module()
+    assert mod._decode_wait_status(0) == 0
+
+
+def test_unparseable_status_falls_back_to_raw(monkeypatch):
+    mod = _load_module()
+
+    def _raise(_status):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(mod.os, "waitstatus_to_exitcode", _raise)
+    assert mod._decode_wait_status(999) == 999
+
+
+def test_launchctl_status_decodes_last_exit_status(monkeypatch):
+    """Innocence: other keys parsed from `launchctl list` output pass through
+    untouched — only LastExitStatus is decoded."""
+    mod = _load_module()
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = (
+            '{\n'
+            '\t"Label" = "com.nuzantara.overlap-detector.daily";\n'
+            '\t"LastExitStatus" = 256;\n'
+            '\t"PID" = 12345;\n'
+            '};\n'
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _FakeCompleted())
+    status = mod._launchctl_status("com.nuzantara.overlap-detector.daily")
+    assert status["LastExitStatus"] == 1
+    assert status["PID"] == 12345
+
+
+def test_launchctl_status_not_loaded_returns_none(monkeypatch):
+    mod = _load_module()
+
+    class _FakeCompleted:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _FakeCompleted())
+    assert mod._launchctl_status("com.nonexistent") is None


### PR DESCRIPTION
## Summary
- `launchctl list <label>` reports `LastExitStatus` as the raw POSIX wait() status word, not a decoded exit code — a plain `exit 1` shows up as `256` (exit codes packed into the high byte) while a SIGKILL death shows up as `9` unshifted.
- Live-verified on Mini: `overlap-detector.daily`'s by-design `exit 1` (real dual-node overlap detected today, wr2control on Pro+Mini — already tracked separately in the PENDING-ARMS ledger) surfaced in proprioception as `last_exit: 256`, confusing in the ledger/Telegram output even though `_classify()`'s zero/non-zero checks were never actually wrong.
- Decode via `os.waitstatus_to_exitcode()` inside `_launchctl_status()`, so every consumer (CLI table, `--json`, Telegram alert, `proprioception.py`'s `launchd_liveness` probe) reports the same convention `launchctl print`/`subprocess` use: positive exit code, or negative signal number.
- `com.balizero.wr2control`'s known TCC/SIGKILL finding now reads `last_exit: -9` (was `9`) — same honest signal-9 fact, correctly signed.

## Test plan
- [x] `apps/backend-rag/.venv/bin/pytest scripts/tests/test_launchd_liveness_exit_status_decode.py scripts/tests/test_launchd_liveness_stale_exit_recovery.py scripts/tests/test_launchd_liveness_marker_freshness.py -q` → 26 passed (5 new guilt+innocence tests, 0 regressions in the 2 pre-existing suites)
- [x] Live run `python3 scripts/launchd_liveness_detector.py --json` on Mini before/after: `overlap-detector.daily` `last_exit` 256→1, `wr2control` `last_exit` 9→-9, verdicts unchanged (both stay `FAILING-HONESTLY`)

Healer tick 2026-07-12 (Mini) — proprioception `launchd_liveness` P1 DIVERGED finding, re-verified live before curing (W65/W90 discipline: never build on an unverified receptor citation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)