### PR TITLE
fix(ops): auth-sentinel PATH missing mise shims

### DIFF
--- a/scripts/auth_sentinel_cron.sh
+++ b/scripts/auth_sentinel_cron.sh
@@ -36,9 +36,12 @@ heartbeat() {
 # unset ANTHROPIC_API_KEY: il probe claude usa il CLI OAuth, mai la key a pagamento
 unset ANTHROPIC_API_KEY 2>/dev/null || true
 
-# PATH esteso: i CLI (agy/codex/nlm/fly) vivono in ~/.local/bin e homebrew — in
-# env launchd il PATH è minimale, senza questo i probe darebbero SKIP/NOT_FOUND.
-export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+# PATH esteso: i CLI (agy/codex/nlm/fly/claude/node) vivono in ~/.local/bin,
+# ~/.local/share/mise/shims (mise = version-manager Node/Python, i binari REALI
+# come `claude`/`node`/`npm` sono link lì dentro) e homebrew — in env launchd il
+# PATH è minimale, senza questo i probe darebbero SKIP/NOT_FOUND (verificato in
+# prod 2026-07-12: claude-oauth→NOT_FOUND, codex→"node: No such file").
+export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 echo "[$(ts)] auth-sentinel tick start" >> "$LOG"
 if [ ! -f "$REPO/scripts/auth_sentinel.py" ]; then


### PR DESCRIPTION
## Perché
Primo tick reale sul cron M5 (2026-07-12T11:24Z, post-install PR #2261) ha mostrato `claude-oauth` e `codex` come UNKNOWN/NOT_FOUND — il wrapper aveva un PATH che copriva `~/.local/bin` + homebrew ma non `~/.local/share/mise/shims`, dove `mise` (version-manager Node/Python di questa macchina) linka i binari reali `claude`/`node`/`npm`. La shell interattiva ce l'ha nel PATH (per questo i test manuali di ieri erano passati); l'ambiente minimale di launchd no.

## Fix
Una riga: aggiunto `$HOME/.local/share/mise/shims` in testa al PATH del wrapper.

## Verifica
`env -i` (ambiente pulito stile-launchd) prima/dopo:
- **Prima**: 6🟢 + 1🟠 + 2🟡 (claude-oauth NOT_FOUND, codex "node: No such file")
- **Dopo**: 7🟢 + 1🟠 + 0🟡

🤖 Generated with [Claude Code](https://claude.com/claude-code)