### PR TITLE
chore(cron): disarm birthday-notifier autonomous schedule (Case OS Fase 0)

### DIFF
--- a/.github/workflows/cron-notifiers-birthday.yml
+++ b/.github/workflows/cron-notifiers-birthday.yml
@@ -1,7 +1,14 @@
-name: cron - notifiers birthday (daily 00:05 WITA)
+name: cron - notifiers birthday (DISARMED 2026-07-12 — manual only)
+# Zero's decision 2026-07-12 (Case OS Fase 0): the birthday notifier was the
+# only LIVE case of a machine emailing a client with no human in the loop.
+# The daily schedule is REMOVED so nothing sends autonomously. The endpoint and
+# workflow_dispatch remain, so the list can still be generated on demand and
+# handed to whoever owns the client — a human presses send.
+# To fully retire: delete this file + the endpoint. To re-arm: restore the
+# `schedule:` block below (an explicit, ratified decision — not a default).
 on:
-  schedule:
-    - cron: "5 16 * * *" # 16:05 UTC = 00:05 WITA next day
+  # schedule:  # DISARMED — do not re-add without an explicit R3 ratification
+  #   - cron: "5 16 * * *"  # 16:05 UTC = 00:05 WITA next day
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## Zero's decision (2026-07-12, Case OS Fase 0)

The birthday notifier was the **only live case of a machine emailing a client with no human in the loop** — a daily GitHub cron (`00:05 WITA`) hitting `POST /api/cron/notifiers/birthday`, which sends an autonomous birthday email to the client.

Decision: **switch it off**, rather than ratify an "autonomous outbound to the client" precedent for the lowest-value gesture in the system. Once that category exists, the next question stops being *whether* a machine may message a client and becomes only *which* message — and that road ends at automated dunning on a ledger that doesn't yet know who paid.

## What changes

- Removes the `schedule:` trigger.
- **Keeps** `workflow_dispatch` and the endpoint — the birthday list can still be generated on demand and handed to whoever owns the client, who presses send.
- Reversible: restoring the `schedule:` block is an explicit, ratified R3 decision, not a default. The old cron line is preserved commented-out with that note.

Verified on disk: the parsed `on` block is now `{workflow_dispatch: {}}` — no active schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)