### PR TITLE
security: strip rotated public key from hardcoded defaults + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Twitter (CRC broken), Google Chat (scaffold), Slack (scaffold) quarantined `.dis
 
 ## 13. Critical Operational Rules
 
-- **Email sending** (REGOLA FISSA): always `from=zantara@balizero.com` via Brevo `/api/notifications/send-email` + `X-API-Key: zantara-secret-2024`. Never `notifications@`/`subhi@`/personal addresses.
+- **Email sending** (REGOLA FISSA): always `from=zantara@balizero.com` via Brevo `/api/notifications/send-email` + `X-API-Key: <NOTIFICATIONS_API_KEY>` (the literal `zantara-secret-2024` was a public-repo admin key — rotated + revoked 2026-07-12; read the key from the env, never hardcode it). Never `notifications@`/`subhi@`/personal addresses.
 - **CRM RBAC**: Admin (`zero@`, `antonellosiano@`, `asya@balizero.com`) = all access. Team = only `assigned_to` matches.
 - **Team perimeter rule**: full roster in memory `reference_bali_zero_team.md`. Subhi probation 90gg (2026-04-30 → 2026-07-29), perimeter `apps/mouth/(blog|marketing|kbli|visa|property|tax-calendar)/**` + GA4/GSC only. NO backend RAG, NO secrets, NO organs_registry.yaml.
 - **OCR multi-page**: ALWAYS all pages — directors typically page 2-3 of akta. Timeout 120s for >3 pages. Vision: `qwen2.5vl:7b` ONLY.

--- a/apps/backend-rag/backend/app/routers/admin_practice_auto_create.py
+++ b/apps/backend-rag/backend/app/routers/admin_practice_auto_create.py
@@ -4,7 +4,7 @@ Admin Auto-Practice Creation Router
 POST /api/admin/practice/auto-create
 
 Triggers auto-creation of visa renewal practices for visas expiring in ~60 days.
-Access: Requires X-API-Key (zantara-secret-2024) or ADMIN_API_KEY.
+Access: Requires X-API-Key (== NUZANTARA_API_KEY) or X-Debug-Key (== ADMIN_API_KEY).
 """
 
 import hmac

--- a/apps/backend-rag/backend/services/newsletter/newsletter_cli.py
+++ b/apps/backend-rag/backend/services/newsletter/newsletter_cli.py
@@ -10,7 +10,7 @@ Environment
 NEWSLETTER_RECIPIENTS   comma-separated email list (fallback if no recipients_fn
                         wire-up is available; primarily for bootstrap / dev).
 NOTIFICATIONS_EMAIL_URL override internal endpoint (default localhost:8000).
-NOTIFICATIONS_API_KEY   override internal X-API-Key (default zantara-secret-2024).
+NOTIFICATIONS_API_KEY   internal X-API-Key (required; no default — rotated key).
 
 Exit codes:
     0  sent (even if 0 recipients — log-only)

--- a/apps/backend-rag/backend/services/newsletter/publisher.py
+++ b/apps/backend-rag/backend/services/newsletter/publisher.py
@@ -4,7 +4,7 @@ Auth + sender policy (from ``memory/feedback_email_sender``):
     - Sender is ALWAYS ``zantara@balizero.com`` with name "Zantara".
     - Never use zero@, nuzantara@, notifications@ as sender.
     - Transport is the internal FastAPI route ``/api/notifications/send-email``
-      with header ``X-API-Key: zantara-secret-2024``.
+      with header ``X-API-Key: <NOTIFICATIONS_API_KEY>``.
     - The route auto-detects Brevo vs SendGrid based on key prefix; we don't
       care here, we just POST.
 
@@ -42,7 +42,11 @@ DEFAULT_NOTIFICATIONS_URL = (
     os.environ.get("NOTIFICATIONS_EMAIL_URL")
     or "http://127.0.0.1:8000/api/notifications/send-email"
 )
-DEFAULT_API_KEY = os.environ.get("NOTIFICATIONS_API_KEY", "zantara-secret-2024")
+# No hardcoded default: the previous fallback (`zantara-secret-2024`) was a
+# real admin key committed to a public repo. It has been rotated + revoked.
+# In prod NOTIFICATIONS_API_KEY is set; anywhere it is not, fail loudly rather
+# than ship a credential-shaped string.
+DEFAULT_API_KEY = os.environ.get("NOTIFICATIONS_API_KEY", "")
 DEFAULT_TIMEOUT = 15.0
 
 

--- a/apps/backend-rag/backend/tests/services/newsletter/test_publisher.py
+++ b/apps/backend-rag/backend/tests/services/newsletter/test_publisher.py
@@ -159,7 +159,9 @@ async def test_recipients_trimmed_and_empty_filtered():
 async def test_single_recipient_happy_path():
     client = AsyncMock(spec=httpx.AsyncClient)
     client.post = AsyncMock(return_value=_ok_response())
-    pub = NewsletterPublisher(http_client=client)
+    # Pass the key explicitly — the old hardcoded default (`zantara-secret-2024`)
+    # was a real admin key on a public repo and has been rotated + revoked.
+    pub = NewsletterPublisher(http_client=client, api_key="test-notifications-key")
 
     result = await pub.send_roundup(_content(), ["zero@balizero.com"])
     assert result.recipients_attempted == 1
@@ -172,7 +174,7 @@ async def test_single_recipient_happy_path():
     payload = call.kwargs["json"]
 
     assert url.endswith("/api/notifications/send-email")
-    assert headers.get("X-API-Key") == "zantara-secret-2024"
+    assert headers.get("X-API-Key") == "test-notifications-key"
     assert payload["from"] == LOCKED_SENDER_EMAIL
     assert payload["from_name"] == LOCKED_SENDER_NAME
     assert payload["to"] == "zero@balizero.com"

--- a/apps/backend-rag/scripts/reactivation_email_campaign.py
+++ b/apps/backend-rag/scripts/reactivation_email_campaign.py
@@ -37,7 +37,9 @@ DATABASE_URL = os.environ.get(
     "postgresql://backend_rag_v2:<<ROTATED_2026_05_22_see_DATABASE_URL_env>>@localhost:15432/nuzantara_rag",
 )
 BACKEND_URL = os.environ.get("BACKEND_URL", "https://nuzantara-rag.fly.dev")
-EMAIL_API_KEY = os.environ.get("INTERNAL_API_KEY", "zantara-secret-2024")
+# No hardcoded default: the previous fallback (`zantara-secret-2024`) was a
+# real admin key committed to a public repo. It has been rotated + revoked.
+EMAIL_API_KEY = os.environ.get("INTERNAL_API_KEY", "")
 
 LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
 LOG_DIR.mkdir(exist_ok=True)


### PR DESCRIPTION
Follow-up to the P0 (#2290) and the **live key rotation** performed this session.

`zantara-secret-2024` was a real production admin key, hardcoded as a fallback default in this **public** repo (`newsletter/publisher.py`, `reactivation_email_campaign.py`) and cited as a literal in three docstrings + `CLAUDE.md §13`.

It has been **rotated and revoked** in prod — verified live: the old key now returns `401` from the internet (was `200`). This removes it from source:

- `publisher.py` / `reactivation_email_campaign.py`: default is now `""`. In prod the env is set; anywhere it isn't, fail loudly rather than ship a credential-shaped string.
- docstrings + `CLAUDE.md`: reference the env var name, not a literal key.
- `test_publisher.py`: passes the key explicitly instead of relying on the (removed) default.

**Nothing functional changes in prod** — `NOTIFICATIONS_API_KEY` / `INTERNAL_API_KEY` / `NUZANTARA_API_KEY` are all set to the rotated key on Fly.

Tests: newsletter suite 25 passed · import chain OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)