### PR TITLE
chore(deps): hold grpc family — protobuf<6 ceiling makes group bumps unsatisfiable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,17 @@ updates:
       # when presidio raises its cryptography ceiling.
       - dependency-name: "cryptography"
         versions: [">=47.0.0"]
+      # requirements.txt:152 deliberately ceilings protobuf <6.0.0 (OTEL /
+      # google-cloud-aiplatform compat, see the comment there). grpcio-status
+      # >=1.82 requires protobuf>=7.35, so any grpc-family bump makes the
+      # whole group ResolutionImpossible again (regenerated PR #2267 failed
+      # exactly there after the cryptography hold fixed the first conflict).
+      # The grpc family only moves TOGETHER with a deliberate protobuf major
+      # bump — drop these ignores in that PR.
+      - dependency-name: "grpcio"
+      - dependency-name: "grpcio-status"
+      - dependency-name: "grpcio-tools"
+      - dependency-name: "grpcio-health-checking"
     groups:
       # OpenAI-stack packages isolated into their own group so a breaking bump
       # (openai/langchain-openai sit near the frozen embedding path:


### PR DESCRIPTION
Second structural conflict in the pip minor-and-patch group, surfaced by the regenerated #2267 right after the cryptography hold fixed the first one:

- `grpcio-status==1.82.1` requires `protobuf>=7.35.1,<8`
- `requirements.txt:152` deliberately ceilings `protobuf>=5.27.0,<6.0.0` (OTEL / google-cloud-aiplatform compat — see the comment there)
- → uv resolve dies during CI install (`No solution found`), 4 required checks red in ~50s each; the failures are load-bearing, not flaky.

The grpc family (grpcio / -status / -tools / -health-checking) can only move TOGETHER with a deliberate protobuf major bump, so it is ignored in the dependabot group until that PR — same pattern and rationale as the cryptography hold (Zero's decision 2026-07-12: hold the incompatible pair, let the rest update).

After merge: `@dependabot recreate` on #2267 regenerates the group without grpc; expected to resolve and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)