### PR TITLE
security(docs): redact real client record from CRM_AUTOMATION_GUIDELINE

### DIFF
--- a/apps/backend-rag/scripts/test_company_drive_ollama.py
+++ b/apps/backend-rag/scripts/test_company_drive_ollama.py
@@ -16,7 +16,7 @@ OAUTH_CLIENT_SECRET = "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"
 OAUTH_REFRESH_TOKEN = "1//0gbiun0bBkNVCCgYIARAAGBASNwF-L9IrGvLMkg0QQ7fz0x98C1zyFqsCvzyijl7NjxUXoJ8K_-BAN8t-ZuQyT5uIv2iVJUPSiMA"
 
 # L'ID della cartella "Company_CRM" di un'azienda reale.
-# Esempio: PT Predmet Development Bali
+# Esempio: PT Example Development Bali
 TEST_COMPANY_FOLDER_ID = "1TCJz0gE4YglNHYYHhlooQVd-V9120vPe"
 
 async def get_token(client: httpx.AsyncClient) -> str:

--- a/docs/CRM_AUTOMATION_GUIDELINE.md
+++ b/docs/CRM_AUTOMATION_GUIDELINE.md
@@ -182,26 +182,28 @@ Identify:
 
 ### Target Fields (Columns D through U)
 
-| #   | Column | Field Name                 | Source Document             | Example                                                                 |
-| --- | ------ | -------------------------- | --------------------------- | ----------------------------------------------------------------------- |
-| 1   | D      | Legal Address              | AKTA or Profil Perseroan    | Jl. Raya Tangeb No. 59, Abianbase, Kec. Mengwi, Kab. Badung, Bali 80351 |
-| 2   | E      | NIB                        | NIB.pdf                     | 2308240057585                                                           |
-| 3   | F      | NPWP                       | NPWP.pdf                    | 07.621.242.2-906.000                                                    |
-| 4   | G      | KBLI (comma-separated)     | NIB.pdf or Profil Perseroan | 68111, 70209                                                            |
-| 5   | H      | Director 1                 | AKTA                        | Ivan Shamrai                                                            |
-| 6   | I      | Ownership % (Director)     | AKTA                        | 50%                                                                     |
-| 7   | J      | Commissioner 1             | AKTA                        | Oleksandr Huliaiev                                                      |
-| 8   | K      | Ownership % (Commissioner) | AKTA                        | 30%                                                                     |
-| 9   | L      | Investor (optional)        | AKTA                        | PT Predmet Construction Group                                           |
-| 10  | M      | Ownership % (Investor)     | AKTA                        | 50%                                                                     |
-| 11  | N      | Authorized Capital         | AKTA                        | Rp 10.100.000.000                                                       |
-| 12  | O      | Incorporation Date         | AKTA or SK                  | 20 Agustus 2024                                                         |
-| 13  | P      | Official Email             | Profil Perseroan or AKTA    | backtobackdevelopmentgroup@gmail.com                                    |
-| 14  | Q      | Official Phone             | Profil Perseroan or AKTA    | 082144087549                                                            |
-| 15  | R      | SK Number                  | AKTA                        | AHU-0064467.AH.01.01.TAHUN 2024                                         |
-| 16  | S      | Tax Office (KPP)           | NPWP                        | KPP Pratama Badung Utara                                                |
-| 17  | T      | Company Status             | AKTA                        | TERTUTUP                                                                |
-| 18  | U      | Office Type                | NIB or general knowledge    | PMA                                                                     |
+> All example values below are SYNTHETIC (redacted 2026-07-12). Never paste real client data into this document.
+
+| #   | Column | Field Name                 | Source Document             | Example                                              |
+| --- | ------ | -------------------------- | --------------------------- | ---------------------------------------------------- |
+| 1   | D      | Legal Address              | AKTA or Profil Perseroan    | Jl. Contoh Raya No. 1, Kuta, Kab. Badung, Bali 80361 |
+| 2   | E      | NIB                        | NIB.pdf                     | 1234567890123                                        |
+| 3   | F      | NPWP                       | NPWP.pdf                    | XX.XXX.XXX.X-XXX.XXX                                 |
+| 4   | G      | KBLI (comma-separated)     | NIB.pdf or Profil Perseroan | 68111, 70209                                         |
+| 5   | H      | Director 1                 | AKTA                        | John Doe                                             |
+| 6   | I      | Ownership % (Director)     | AKTA                        | 50%                                                  |
+| 7   | J      | Commissioner 1             | AKTA                        | Jane Doe                                             |
+| 8   | K      | Ownership % (Commissioner) | AKTA                        | 30%                                                  |
+| 9   | L      | Investor (optional)        | AKTA                        | PT Example Construction Group                        |
+| 10  | M      | Ownership % (Investor)     | AKTA                        | 50%                                                  |
+| 11  | N      | Authorized Capital         | AKTA                        | Rp 10.000.000.000                                    |
+| 12  | O      | Incorporation Date         | AKTA or SK                  | 1 Januari 2024                                       |
+| 13  | P      | Official Email             | Profil Perseroan or AKTA    | company@example.com                                  |
+| 14  | Q      | Official Phone             | Profil Perseroan or AKTA    | 081234567890                                         |
+| 15  | R      | SK Number                  | AKTA                        | AHU-0000000.AH.01.01.TAHUN 2024                      |
+| 16  | S      | Tax Office (KPP)           | NPWP                        | KPP Pratama Badung Utara                             |
+| 17  | T      | Company Status             | AKTA                        | TERTUTUP                                             |
+| 18  | U      | Office Type                | NIB or general knowledge    | PMA                                                  |
 
 ### Extraction Priority
 
@@ -238,8 +240,8 @@ pdfinfo "file.pdf"
 1. **If a field is not found in any document, leave it as empty string `""`**. Never guess or invent data.
 2. **KBLI codes** must be comma-separated, codes only (no descriptions). Example: `"68111, 70209"`, NOT `"68111 - Real Estat"`.
 3. **Ownership percentages** must include the `%` symbol. Example: `"50%"`, NOT `"50"`.
-4. **Capital amounts** must include `Rp` prefix. Example: `"Rp 10.100.000.000"`.
-5. **Dates** should be in the format found in the document (Indonesian format preferred). Example: `"20 Agustus 2024"`.
+4. **Capital amounts** must include `Rp` prefix. Example: `"Rp 10.000.000.000"`.
+5. **Dates** should be in the format found in the document (Indonesian format preferred). Example: `"1 Januari 2024"`.
 6. **SK Number** always starts with `AHU-` followed by digits and year.
 7. **Company Status** is either `TERTUTUP` (closed/private) or `TERBUKA` (open/public). Most are `TERTUTUP`.
 8. **Office Type** is either `PMA` (foreign investment) or `PMDN` (domestic). If company has foreign shareholders → `PMA`.
@@ -332,26 +334,26 @@ from reportlab.lib.enums import TA_CENTER
 def generate_profil_perseroan(data: dict, output_path: str):
     """
     data = {
-        "company_name": "PT BACKTOBACK DEVELOPMENT GROUP",
+        "company_name": "PT EXAMPLE DEVELOPMENT GROUP",
         "company_type": "Perseroan Terbatas (PT) - PMA",
         "status": "TERTUTUP",
-        "sk_number": "AHU-0064467.AH.01.01.TAHUN 2024",
-        "incorporation_date": "20 Agustus 2024",
+        "sk_number": "AHU-0000000.AH.01.01.TAHUN 2024",
+        "incorporation_date": "1 Januari 2024",
         "notaris": "Notaris di Kab. Badung",
-        "address": "Jl. Raya Tangeb No. 59, ...",
+        "address": "Jl. Contoh Raya No. 1, ...",
         "email": "company@gmail.com",
-        "phone": "082144087549",
-        "nib": "2308240057585",
-        "npwp": "07.621.242.2-906.000",
+        "phone": "081234567890",
+        "nib": "1234567890123",
+        "npwp": "XX.XXX.XXX.X-XXX.XXX",
         "kpp": "KPP Pratama Badung Utara",
         "kbli": "68111, 70209",
-        "authorized_capital": "Rp 10.100.000.000",
+        "authorized_capital": "Rp 10.000.000.000",
         "shareholders": [
-            {"name": "PT Predmet Construction Group", "pct": "50%", "role": "Pemegang Saham Mayoritas"},
-            {"name": "Oleksandr Huliaiev", "pct": "30%"},
+            {"name": "PT Example Construction Group", "pct": "50%", "role": "Pemegang Saham Mayoritas"},
+            {"name": "Jane Doe", "pct": "30%"},
         ],
-        "director": "Ivan Shamrai",
-        "commissioner": "Oleksandr Huliaiev",
+        "director": "John Doe",
+        "commissioner": "Jane Doe",
     }
     """
     doc = SimpleDocTemplate(output_path, pagesize=A4,
@@ -459,7 +461,7 @@ Body: {
   "spreadsheet_id": "1CcsZmYOiajdWtTlgmoHNeCqBXhbLRZrQVQOBRs422oY",
   "range": "Company!B10:B",
   "search_column": 0,
-  "search_value": "Backtoback Development Group PT"
+  "search_value": "Example Development Group PT"
 }
 ```
 
@@ -507,7 +509,7 @@ Body: {
   "sheet_name": "Company",
   "row_number": 1701,
   "column_start": "D",
-  "values": ["Jl. Raya Tangeb No. 59, ...", "2308240057585", ...]
+  "values": ["Jl. Contoh Raya No. 1, ...", "1234567890123", ...]
 }
 ```
 
@@ -583,7 +585,7 @@ Maintain a JSON log file:
   "errors": 2,
   "companies": [
     {
-      "name": "Backtoback Development Group PT",
+      "name": "Example Development Group PT",
       "status": "success",
       "fields_extracted": 18,
       "fields_empty": 2,
@@ -688,7 +690,7 @@ email = re.search(r'([\w.+-]+@[\w.-]+\.\w+)', text)
 
 ---
 
-## WORKED EXAMPLE: BACKTOBACK DEVELOPMENT GROUP PT
+## WORKED EXAMPLE: EXAMPLE DEVELOPMENT GROUP PT
 
 ### Phase 1: Exploration
 
@@ -697,7 +699,7 @@ Listed folder `1V1BcajeME-mZqhwtT93q9eMsFW6RrJkh`:
 ```
 [DIR] AKTA/                    1YP1XCXc82_l6gJoxEGOxb2NvDmvYUPWE
 [DIR] DOKUMEN/                 1v4c_fkk78zcqRoi4eMEKFR9hhXOZGLFz
-[DIR] KHASAN KHATER/           ...
+[DIR] PERSONAL DOCS/           ...
 [DIR] NIB/                     14xqNMIjgfYmYxfMe_kR5CKlKeQqPlzwY
 [DIR] NPWP/                    1uIqj3O2JdpljJUax-Gff9CBM3Rb9LLwS
 [DIR] WAJIB LAPOR/             ...
@@ -709,31 +711,31 @@ Listed folder `1V1BcajeME-mZqhwtT93q9eMsFW6RrJkh`:
 Read AKTA documents. Extracted:
 
 ```
-company_name: PT BACKTOBACK DEVELOPMENT GROUP
+company_name: PT EXAMPLE DEVELOPMENT GROUP
 company_type: Perseroan Terbatas (PT) - PMA
 status: TERTUTUP
-sk_number: AHU-0064467.AH.01.01.TAHUN 2024
-incorporation_date: 20 Agustus 2024
-address: Jl. Raya Tangeb No. 59, Abianbase, Kec. Mengwi, Kab. Badung, Bali 80351
-email: backtobackdevelopmentgroup@gmail.com
-phone: 082144087549
-nib: 2308240057585
-npwp: 07.621.242.2-906.000
+sk_number: AHU-0000000.AH.01.01.TAHUN 2024
+incorporation_date: 1 Januari 2024
+address: Jl. Contoh Raya No. 1, Kuta, Kab. Badung, Bali 80361
+email: company@example.com
+phone: 081234567890
+nib: 1234567890123
+npwp: XX.XXX.XXX.X-XXX.XXX
 kpp: KPP Pratama Badung Utara
 kbli: 68111, 70209
-authorized_capital: Rp 10.100.000.000
+authorized_capital: Rp 10.000.000.000
 shareholders:
-  - PT Predmet Construction Group: 50% (Pemegang Saham Mayoritas)
-  - Oleksandr Huliaiev: 30%
-  - Roman Beznosiuk: 15%
-  - Taras Levchyk: 5%
-director: Ivan Shamrai
-commissioner: Oleksandr Huliaiev
+  - PT Example Construction Group: 50% (Pemegang Saham Mayoritas)
+  - Jane Doe: 30%
+  - Alex Roe: 15%
+  - Sam Poe: 5%
+director: John Doe
+commissioner: Jane Doe
 ```
 
 ### Phase 3: Organization
 
-Created `Other/` and `Profile Perseroan/` folders. Moved 12 non-standard items (DOKUMEN, KHASAN KHATER, WAJIB LAPOR, loose files) to `Other/`.
+Created `Other/` and `Profile Perseroan/` folders. Moved 12 non-standard items (DOKUMEN, PERSONAL DOCS, WAJIB LAPOR, loose files) to `Other/`.
 
 Root now contains exactly: AKTA, NIB, NPWP, Profile Perseroan, Other.
 
@@ -745,21 +747,21 @@ Found row via append (company wasn't in sheet yet). Wrote 18 values:
 
 ```python
 values = [
-    "Jl. Raya Tangeb No. 59, Abianbase, Kec. Mengwi, Kab. Badung, Bali 80351",  # D
-    "2308240057585",                    # E
-    "07.621.242.2-906.000",             # F
+    "Jl. Contoh Raya No. 1, Kuta, Kab. Badung, Bali 80361",  # D
+    "1234567890123",                    # E
+    "XX.XXX.XXX.X-XXX.XXX",             # F
     "68111, 70209",                     # G
-    "Ivan Shamrai",                     # H
+    "John Doe",                     # H
     "",                                 # I - Director ownership not specified separately
-    "Oleksandr Huliaiev",               # J
+    "Jane Doe",               # J
     "30%",                              # K
-    "PT Predmet Construction Group",    # L - Investor/majority shareholder
+    "PT Example Construction Group",    # L - Investor/majority shareholder
     "50%",                              # M
-    "Rp 10.100.000.000",               # N
-    "20 Agustus 2024",                  # O
-    "backtobackdevelopmentgroup@gmail.com",  # P
-    "082144087549",                     # Q
-    "AHU-0064467.AH.01.01.TAHUN 2024", # R
+    "Rp 10.000.000.000",               # N
+    "1 Januari 2024",                  # O
+    "company@example.com",  # P
+    "081234567890",                     # Q
+    "AHU-0000000.AH.01.01.TAHUN 2024", # R
     "KPP Pratama Badung Utara",         # S
     "TERTUTUP",                         # T
     "PMA",                              # U


### PR DESCRIPTION
## What

The worked example in `docs/CRM_AUTOMATION_GUIDELINE.md` embedded a **real client company record** in 5 separate blocks (field table, JSON generator docstring, sheet-write example, YAML extraction example, worked-example heading): company name, legal address, NIB, NPWP, official phone/email, SK number, authorized capital, incorporation date, and four shareholder/officer personal names. The repo is public — this was live PII exposure (UU PDP / SYMBIOSIS Law 2).

Found by the pre-commit PII gate during the docs archive-move lane (it correctly refused to move the file); redacted here as a dedicated priority PR.

## How

- Every real value replaced with a clearly synthetic placeholder (`PT EXAMPLE DEVELOPMENT GROUP`, `John/Jane Doe`, `company@example.com`, X-form NPWP, etc.), preserving the document's instructional value.
- NPWP placeholders use the X-form so the file is permanently inert to the PII gate's content regex (no future allowlist bypass needed).
- Synthetic-data notice added above the example table.
- One company-name mention in `apps/backend-rag/scripts/test_company_drive_ollama.py` comment redacted too.
- Verified zero residual matches for all 17 identifying literals + gate regexes.

## Residual (operator decision, tracked in PENDING-ARMS)

Git history still contains the original values. Purging history on a public repo (BFG/filter-repo + force-push) is an operator[business]/[secret] decision — flagged to Zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)