### PR TITLE
chore(intel): nb-curator daily health report — 2026-07-12 (harvested)

### DIFF
--- a/research/nb-health/2026-07-12-health.md
+++ b/research/nb-health/2026-07-12-health.md
@@ -1,0 +1,54 @@
+# NB Arsenal Health Report — 2026-07-12 (daily, Mode B+C)
+
+## Summary
+- Total: 95 notebooks live, 5314 sources (structural snapshot from `nb-inventory-live.json`, generated 2026-07-11T20:01 UTC)
+- Healthy: 71 | Empty (0 sources): 24 | Broken: 0
+- near_cap (NLM ~500-src ceiling): 1 → **NB-INTEL-AIResearch** (dc5d01cd, 500/500). Overflow NB **NB-INTEL-AIResearch-2** (069f009c, 265 src, healthy) is absorbing growth — mitigation confirmed still in place.
+- NB-INTEL family: Immigration=163, Tax=145, Regulation=105, Press=393, AIResearch=500(+265 overflow=765 total). All 5 healthy, updated_at 2026-07-11T20:00 (feeder active same-day).
+
+## Stale (updated_at >30d, source_count>0 — heuristic proxy, not content-freshness)
+7 notebooks: 361fcb85 "BZ Analisi Business Gen-Giu 2026" (2 src, 35d) · f4dcb203 "WA-CORPUS-GATE-TEST" (1 src, 37d) · 9c82e1db "WA-CORPUS-SCALE-SURYA" (10 src, 37d) · a10ea479 "WA-CORPUS-RECONCILE-TEST" (2 src, 38d) · 7e4665c3 "WA-CORPUS-PILOT-CLEAN" (1 src, 38d) · 84216491 "The World Ahead 2026" (70 src, 110d) · 5881d15d "The World Ahead 2025" (70 src, 227d). All low-priority test/archival scaffolds — no action needed.
+
+## Empty scaffolds (24, 0 sources — mostly NB-WA-* team scaffolds + placeholder research NBs)
+No change in kind vs prior passes; candidates for archive after 90d unused per Mode B doctrine. Not re-enumerated here (see prior reports for full list).
+
+## Inventory hygiene note (not broken, flagged for awareness)
+6 NBs still carry `[MERGED-INTO-...]` / `[ARCHIVED-DELETE-...]` title prefixes but remain live+healthy with 445 combined sources (d97ff70b 44, 4a8f3162 67, 917a1300 49, 201b4b94 150, 50396b3e 129, 46b4dfe0 6). Read-only agent — no deletion proposed; flagging for operator review per prior passes.
+
+## PART 2 — NB-INTEL-Press dedup/summarize proposals (daily scope)
+Press = 393 sources. Exact-URL dups and challenge pages already auto-removed pre-pass (0 today). Eyeballed titles for fuzzy/near-dup + event-cluster candidates:
+
+```
+CLUSTER Press dup-1
+  keep: "1.274 Golden Visa diterbitkan, Indonesia raup investasi Rp52 triliun - ANTARA News Kalteng"
+  remove: duplicate-title instance (same string appears twice in source list)
+  reason: exact-title dup (not exact-URL — likely re-scraped, different URL/timestamp)
+
+CLUSTER Press dup-2
+  keep: "Ditjen Imigrasi catat PNBP sektor visa naik 6.42 persen pada semester I 2026 - ANTARA News Makassar"
+  remove: duplicate-title instance
+  reason: exact-title dup
+
+CLUSTER Press dup-3
+  keep: "Indonesia Adds 7 New Digital Tax Collectors, Including Strava"
+  remove: "Indonesia Adds 7 New Digital Tax Collectors, Including Strava - News En.tempo.co"
+  reason: near-dup title (same story, syndication suffix)
+
+CLUSTER Press bundle-influencer-crackdown (event, 4 src — below 10-src summarization threshold)
+  members: "Bali Cracks Down on Visa Rules for Influencers and Content Creators", "Bali Immigration Tightens Rules on Foreign Influencers and Content Creators", "Bali Perketat Aturan Visa untuk Influencer Asing, Ini Ketentuannya - Jakarta365", "Indonesia's Tough New Rules: Influencers Face Deportation for Posting on Tourist Visas in Bali!"
+  reason: same event (influencer visa crackdown), reworded/multi-language — bundle candidate, not yet summarization-eligible
+
+CLUSTER Press bundle-kpk-pemerasan (event, 3 src — below threshold)
+  members: "KPK dalami dugaan pemerasan izin tinggal WNA di Bali", "KPK periksa delapan pegawai Imigrasi Jakbar untuk dalami pemerasan", "KPK: Tarif pemerasan Imigrasi di Bali capai Rp100 ribu-Rp2,5 juta"
+  reason: same event (KPK immigration extortion probe), reworded
+```
+
+No Press topic cluster reached ≥10 sources this pass → **0 summarization bundles proposed** (threshold not met).
+
+## Operator actions
+- [ ] Review 5 Press dedup/bundle candidates above (3 dup-pairs + 2 event-bundles, none yet summarization-eligible)
+- [ ] Optional: review 6 MERGED/ARCHIVED-titled NBs (445 src) for actual archival/deletion
+- [ ] No broken NBs — no urgent action required
+- [ ] **File currently sits in worktree `.worktrees/intel-2026-07-12-health-daily/research/nb-health/` — main checkout write blocked by `worktree_isolation.py` hook (W79). Needs manual copy/merge to `research/nb-health/2026-07-12-health.md` on main.**
+
+No Telegram sent (0 broken, <3 threshold not crossed).

--- a/research/nb-health/2026-07-12-health.md
+++ b/research/nb-health/2026-07-12-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-07-12 (daily, Mode B+C)
 
 ## Summary


### PR DESCRIPTION
Harvested from the orphaned worktree \`.worktrees/intel-2026-07-12-health-daily\`, which had this file sitting untracked/uncommitted. Committed fresh onto current origin/main rather than the worktree's stale base to avoid a pre-existing (already-fixed-on-main) flaky test.

nb-curator Mode B+C daily run — 95 notebooks total.

## Test plan
- [x] Full pytest suite green: 16981 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)