### PR TITLE
chore(intel): nb-curator daily health report — 2026-07-11 (harvested)

### DIFF
--- a/research/nb-health/2026-07-11-health.md
+++ b/research/nb-health/2026-07-11-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-07-11 (daily)
 
 ## Summary

--- a/research/nb-health/2026-07-11-health.md
+++ b/research/nb-health/2026-07-11-health.md
@@ -1,0 +1,55 @@
+# NB Arsenal Health Report — 2026-07-11 (daily)
+
+## Summary
+- Total: 95 notebooks (was 88 on 2026-06-16 per memory, +7), ~5,281 sources (was ~4,290, +991 over 25d)
+- Healthy: 71 | Empty scaffolds: 24 | Broken: 0 | Stale: 0
+- Health taxonomy in live inventory JSON is structural only (healthy/empty) — no interactive `nlm query` timeout test run this pass (out of scope for daily structural pass)
+
+## NB-INTEL family (structural)
+| NB | src | Δ vs 06-16 | near_cap |
+|---|---|---|---|
+| AIResearch | 500 | 0 — **STILL AT CEILING, 25+ days** | **true** |
+| AIResearch-2 Overflow | 258 | +257 (overflow NB absorbing growth) | false |
+| Regulation | 105 | +60 | false |
+| Press | 375 | +141 | false |
+| Tax | 145 | +118 | false |
+| Immigration | 163 | +71 | false |
+
+All healthy, no timeouts observed.
+
+## Notable core-stack deltas (vs 06-16 snapshot, not fully diffed per hard-limit instructions)
+- NB-4 Tax: 169→188 (+19, organic)
+- NB-LAB-AGENT-ENGINEERING: 404→395 (−9, likely cleanup)
+- +7 net new notebooks since 06-16 (not individually diffed this pass)
+
+## Empty scaffolds (24) — archive candidates if still unused at next monthly review
+UU Cipta Kerja · Bali Minimum Wage · 2× untitled · CRM Drive-sync · Arming Claude Code · Veo Flow Ecosystem · Regulatory Research May 2026 · Veo Competitors · HGB Property Research · Tax Changes Research · Labor Law Research May 2025 · Indonesian Tax Updates 2025-2026 · KITAP Research · KITAS Research · Immigration Regulation Search · 7× NB-WA-{Sahira,Krisna,Damar,Asya,Ari,Adit,Surya} · Air-M5 thin-client config.
+
+## Broken / Stale
+None detected in structural pass.
+
+## PART 2 — NB-INTEL-Press dedup/summarize proposals (daily scope, Press only)
+
+### Near-dup title clusters (eyeballed titles only, no URLs pulled)
+1. Bali influencer-visa crackdown (4 sources, same event/multi-outlet): "Bali Cracks Down on Visa Rules for Influencers..." / "Bali Immigration Tightens Rules on Foreign Influencers..." / "Bali Perketat Aturan Visa untuk Influencer Asing..." / "Indonesia's Tough New Rules: Influencers Face Deportation...". Keep 1 EN + 1 ID canonical.
+2. PNBP sektor visa +6.42% story (3 sources): "Ditjen Imigrasi catat PNBP sektor visa naik 6.42 persen..." (×2 identical title, likely different URL) + "Di Tengah Isu Global, Imigrasi Catatkan Kenaikan PNBP 6.42...". Keep 1.
+3. "Dirjen Imigrasi sebut RI raih investasi Rp2 triliun dari WNA penerima Golden Visa" — double-space vs single-space title variant (same ANTARA wire). Keep 1.
+4. "Indonesia Adds 7 New Digital Tax Collectors, Including Strava" vs same +"- News En.tempo.co" suffix. Keep 1.
+5. "Why Vietnam Revised Its Visa-Free Policy for Indonesians" vs same +"- Life & Style En.tempo.co" suffix. Keep 1.
+
+Additional literal-title-duplicate pairs observed (KBLI 2025 kepatuhan usaha, Kemenpar KBLI transformasi, MoF marketplace collectors, Menkumham visa rumah kedua, Wamenpar KBLI, Investasi Vila di Bali) — likely ANTARA regional-portal syndication under different URLs, not caught by exact-URL pre-step. Flagged for awareness, not itemized (0-5 eyeball cap this pass).
+
+### Summarization proposal (topic ≥10 sources)
+- **Marketplace/e-commerce digital tax collection rollout (Aug 2026)** — ~13-14 Press sources cover one OSINT topic (DJP 4-7 marketplace appointees incl. Strava, PMK 37/2025, 0.5% final tax on online sellers, NIB-for-creators requirement). Propose synthetic master summary (offline Ollama) + remove originals, pending review.
+
+### Stale sources (>90d)
+Not computable this pass — inventory carries titles only, no per-source `updated_at`. Defer to next monthly full pass (`nlm source list <uuid> --json`).
+
+## Operator actions
+- [ ] Review 5 near-dup clusters + noted syndication dups above
+- [ ] Approve/reject marketplace-tax summarization bundle (~13 sources → 1 synthetic doc)
+- [ ] AIResearch AT CEILING (500) 25+ days — confirm overflow routing to AIResearch-2 (258 src) is the accepted mitigation
+- [ ] 24 empty scaffolds — archive candidates if still unused next month
+
+## Infra note
+This report was written to `.worktrees/intel-20260711-nbhealth/research/nb-health/` instead of the canonical `research/nb-health/` main-checkout path — a new `worktree_isolation`/`worktree_file_write_check` hook (W79/L5.1) now blocks direct writes/shell-writes into main for Write and Bash alike, with no per-directory exemption for untracked scratch report dirs. Prior daily reports (e.g. 2026-07-10) landed directly in main, implying the production cron wrapper sets `AGENT_WORKTREE_ENFORCEMENT=false` in its launchd env — this interactive pass did not have that set. Recommend either exempting `research/nb-health/` (untracked, dated, single-writer, no sibling-race risk) or confirming the cron wrapper's escape hatch for future automated runs.


### PR DESCRIPTION
Harvested from the orphaned worktree \`.worktrees/intel-20260711-nbhealth\`, which had this file sitting untracked/uncommitted. Committed fresh onto current origin/main rather than the worktree's stale base to avoid a pre-existing (already-fixed-on-main) flaky test.

nb-curator Mode B+C daily run.

## Test plan
- [x] Full pytest suite green: 16981 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)