### PR TITLE
test(security): fix 9 tests broken by R3 admin-gate enforcement

### DIFF
--- a/apps/backend-rag/backend/tests/unit/app/routers/test_legal_ingest.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_legal_ingest.py
@@ -15,6 +15,7 @@ backend_path = Path(__file__).parent.parent.parent.parent.parent / "backend"
 if str(backend_path) not in sys.path:
     sys.path.insert(0, str(backend_path))
 
+from backend.app.dependencies import get_current_user
 from backend.app.routers.legal_ingest import router
 from backend.services.ingestion.legal_ingestion_service import LegalIngestionService
 
@@ -38,9 +39,16 @@ def mock_legal_service():
 
 @pytest.fixture
 def app():
-    """Create FastAPI app with router"""
+    """Create FastAPI app with router.
+
+    Legal ingest endpoints are admin-gated (Case OS R3): override
+    get_current_user with an admin identity so the router's
+    _require_ingest_admin gate passes and these tests exercise the
+    ingest logic rather than the auth layer.
+    """
     app = FastAPI()
     app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: {"role": "admin"}
     return app
 
 

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_oracle_ingest.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_oracle_ingest.py
@@ -152,7 +152,9 @@ async def test_ingest_known_collection_uses_collection_manager_get_collection(mo
         documents=[DocumentChunk(content="some legal text here", metadata={"law_id": "X"})],
     )
 
-    response = await ingest_documents(request=request, service=service)  # type: ignore[arg-type]
+    response = await ingest_documents(
+        request=request, service=service, user={"role": "admin"}
+    )  # type: ignore[arg-type]
 
     assert response.success is True
     assert response.documents_ingested == 1
@@ -169,7 +171,9 @@ async def test_ingest_unknown_collection_reports_not_found_without_attributeerro
         documents=[DocumentChunk(content="some legal text here", metadata={"law_id": "X"})],
     )
 
-    response = await ingest_documents(request=request, service=service)  # type: ignore[arg-type]
+    response = await ingest_documents(
+        request=request, service=service, user={"role": "admin"}
+    )  # type: ignore[arg-type]
 
     assert response.success is False
     assert response.message == "Collection not found"

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_performance.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_performance.py
@@ -15,14 +15,21 @@ backend_path = Path(__file__).parent.parent.parent.parent.parent / "backend"
 if str(backend_path) not in sys.path:
     sys.path.insert(0, str(backend_path))
 
+from backend.app.dependencies import get_current_user
 from backend.app.routers.performance import router
 
 
 @pytest.fixture
 def app():
-    """Create FastAPI app with router"""
+    """Create FastAPI app with router.
+
+    The clear-cache endpoints are admin-gated (Case OS R3): override
+    get_current_user with an admin identity so the router's admin gate
+    passes and these tests exercise the cache logic rather than auth.
+    """
     app = FastAPI()
     app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: {"role": "admin"}
     return app
 
 

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_analytics.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_analytics.py
@@ -326,7 +326,7 @@ class TestStoreIntel:
                 metadata={"title": "test"},
                 full_data={"key": "value"},
             )
-            result = await store_intel(request)
+            result = await store_intel(request, current_user={"role": "admin"})
 
         assert result["success"] is True
         assert result["collection"] == "bali_intel_visa"
@@ -344,7 +344,7 @@ class TestStoreIntel:
             full_data={},
         )
         with pytest.raises(HTTPException) as exc_info:
-            await store_intel(request)
+            await store_intel(request, current_user={"role": "admin"})
         # The inner HTTPException(400) is caught by the outer try/except
         # and re-raised as HTTPException(500), so we check for 500.
         assert exc_info.value.status_code == 500

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_router.py
@@ -21,12 +21,17 @@ def mock_services():
         patch("backend.app.routers.intel.intel_bulk_operation_items") as mock_bulk_items,
         patch("backend.app.routers.intel.intel_items_approved") as mock_approved,
         patch("backend.app.routers.intel.intel_items_rejected") as mock_rejected,
+        patch("backend.app.routers.intel.settings") as mock_settings,
     ):
         mock_actions.labels.return_value = MagicMock()
         mock_bulk_ops.labels.return_value = MagicMock()
         mock_bulk_items.labels.return_value = MagicMock()
         mock_approved.labels.return_value = MagicMock()
         mock_rejected.labels.return_value = MagicMock()
+        # bulk-approve/reject are admin-gated (Case OS R3). intel._require_intel_admin
+        # checks the caller email against settings.admin_emails_set; the test env
+        # leaves that set empty, so seed it with the admin identity used below.
+        mock_settings.admin_emails_set = frozenset({"zero@balizero.com"})
 
         yield {
             "staging": mock_staging,
@@ -47,6 +52,13 @@ def client(mock_services):
     from backend.app.utils.internal_api_auth import verify_internal_api_key
 
     app.dependency_overrides[verify_internal_api_key] = lambda: True
+
+    # bulk-approve is admin-gated (Case OS R3). intel._require_intel_admin
+    # checks the caller email against settings.admin_emails_set (NOT role),
+    # so supply an allow-listed admin email.
+    from backend.app.dependencies import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: {"email": "zero@balizero.com"}
 
     # Override DB pool with proper async context manager
     from backend.app.dependencies import get_database_pool


### PR DESCRIPTION
Stacked on #2304 (the authz gate + R3 enforcement branch).

## What
Adding `Depends(get_current_user)` + `_require_*_admin` to the 17 R3 gating-safe routes (PR #2317) broke **9 pre-existing tests** that called those handlers without an admin principal. CI (testmon) surfaced only 1 (`test_legal_ingest`); the other 8 were latent — a full `-p no:testmon` sweep exposed them.

## Fixes (3 shapes, matched to call style + gate type)
| Test file | Broke | Fix |
|---|---|---|
| `test_legal_ingest.py` | 401 | `dependency_overrides[get_current_user]={"role":"admin"}` |
| `test_performance.py` (×3) | 401 | same override |
| `test_oracle_ingest.py` (×2) | `Depends` object has no `.get` | pass `user={"role":"admin"}` to the direct call |
| `test_intel_analytics.py` (×2) | same | pass `current_user={"role":"admin"}` to the direct call |
| `test_intel_router.py` (×2) | 403 "admin only" | patch `intel.settings.admin_emails_set` (email-only gate, not `is_crm_admin`) + admin email |

## Verification
- All **68 tests** across the 5 touched files pass (`-p no:testmon`).
- Remaining router-test failures (`test_voice_legacy`, `test_auth` DB, `test_bridge_wa` role, `test_hr_leave_rbac`) are **pre-existing env noise** — those files are untouched by this branch and fail identically on `origin/main` (empty `admin_emails_set` / missing local test DB role).
- ruff clean; anti-reward-hacking test-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)