### PR TITLE
fix(modus): collapse queue by-job (no re-process) + nightly cron

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -100,3 +100,8 @@ docs/design/components-catalog.md
 # (gate: check-docs-sync; prettier fighting the generator = format deadlock, 2026-07-02)
 INDEX.md
 docs/runbooks/README.md
+
+# organs_registry.yaml — validate_organs_registry.py --update-checksum owns its
+# canonical format (internal sha256 checksum); prettier's list-indent fights the
+# generator = format deadlock, same class as INDEX.md above (2026-07-13).
+apps/organism/organism/organs_registry.yaml

--- a/INDEX.md
+++ b/INDEX.md
@@ -156,7 +156,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 ### LaunchAgents — copertura documentale
 
 <!-- DOCSYNC:AUTOMATION_COVERAGE_START -->
-`124 plist tracked in infra/launchagents/ · 64 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (52% coverage)`
+`125 plist tracked in infra/launchagents/ · 64 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (51% coverage)`
 <!-- DOCSYNC:AUTOMATION_COVERAGE_END -->
 
 Runbook operativi: indice auto-generato in [docs/runbooks/README.md](docs/runbooks/README.md).

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -165,6 +165,23 @@ organs:
       path: ~/.organism/last_seen/auth-sentinel.json
       timestamp_field: ts
       status_field: status
+  - id: pro.modus_autoloop_nightly
+    runtime: pro_launchd
+    type: cron
+    expected_hb_seconds: 108000
+    owner_module: infra/launchagents/modus_autoloop_cron.sh
+    dependencies: []
+    recovery_action: launchctl_kickstart
+    recovery_params:
+      label: com.balizero.modus.autoloop.nightly
+    severity_on_silence: warning
+    cicatrix_refs:
+      - 2026-07-12-modus-autoloop-append-only-reprocess
+    bridge_source:
+      type: state_file
+      path: ~/.organism/last_seen/modus-autoloop.json
+      timestamp_field: ts
+      status_field: status
   - id: pro.fly_restart_loop_detector
     runtime: pro_launchd
     type: cron

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,1877 +1,1865 @@
 version: 1
 checksum_algo: sha256
-checksum: d993fe3072ae088c7e895d42f4a5e1cffcd17d359cae31b82d744a5dc740ee99
+checksum: 3991225d82ed05d2f72f1f4862fd90dcb74d5e16d40b2451a8725fdd971874dd
 organs:
-  - id: infra.postgres
-    runtime: fly_machine
-    type: daemon
-    expected_hb_seconds: 0
-    owner_module: infra/fly/nuzantara-postgres
-    dependencies: []
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-postgres
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: infra.redis
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 0
-    owner_module: brew/redis
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: homebrew.mxcl.redis
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: infra.qdrant
-    runtime: fly_machine
-    type: daemon
-    expected_hb_seconds: 0
-    owner_module: infra/fly/nuzantara-qdrant
-    dependencies: []
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-qdrant
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: backend.api
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 60
-    owner_module: apps/backend-rag/backend/app/main.py
-    dependencies:
-      - infra.postgres
-      - infra.redis
-      - infra.qdrant
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs:
-      - 2026-04-29-startup-failed-mask
-      - 2026-04-29-drive-poll-attribute-error
-  - id: backend.surface_router
-    runtime: fly_machine
-    type: daemon
-    expected_hb_seconds: 60
-    owner_module: apps/backend-rag/backend/services/routing/surface_router.py
-    dependencies:
-      - backend.api
-      - infra.postgres
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: warning
-    notes:
-      R5 Phase 3 — in-process routing organ. Routes queries to KG vs vector vs
-      NLM. Always-on since Phase 3 deploy.
-    cicatrix_refs: []
-  - id: backend.kg_langgraph_orchestrator
-    runtime: fly_machine
-    type: daemon
-    enabled: false
-    disabled_reason:
-      "R5 Phase 5: feature-flagged via ENABLE_KG_LANGGRAPH=false (default).
-      Enable via fly secrets set ENABLE_KG_LANGGRAPH=1 on nuzantara-rag. Fast-path wired
-      in OrchestratorCore._try_kg_fast_path() — safe to enable per domain."
-    expected_hb_seconds: 60
-    owner_module: apps/backend-rag/backend/services/rag/kg_langgraph_orchestrator.py
-    dependencies:
-      - backend.api
-      - infra.postgres
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: warning
-    notes:
-      R5 Phase 5 — KG LangGraph fast-path organ. Bypasses vector search for entity-heavy
-      queries when subgraph available.
-    cicatrix_refs: []
-  - id: backend.crm.drive_poll
-    runtime: pro_launchd
-    type: cron
-    enabled: false
-    disabled_reason:
-      DISABLED 2026-04-29 in crontab after drive_poll saturated PG; keep
-      registered as disabled until explicitly restored.
-    expected_hb_seconds: 360
-    owner_module: scripts/openclaw-cron/drive-poll.sh
-    dependencies:
-      - infra.postgres
-      - backend.api
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.drive-poll
-    severity_on_silence: warning
-    cicatrix_refs:
-      - 2026-04-29-drive-poll-attribute-error
-    bridge_source:
-      type: state_file
-      path: ~/.agent/decisions/state/drive_poll.last.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.claude_max_watcher
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 3600
-    owner_module: scripts/claude-max-usage-watcher.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.claude-max-usage-watcher
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.claude/usage-watcher/last_run.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.login_healthcheck
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 900
-    owner_module: scripts/login-healthcheck.sh
-    dependencies:
-      - backend.api
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.login-healthcheck
-    severity_on_silence: critical
-    cicatrix_refs:
-      - 2026-04-29-startup-failed-mask
-    bridge_source:
-      type: state_file
-      path: ~/.agent/decisions/state/login_healthcheck.last.json
-      timestamp_field: ts
-      status_field: status
-  - id: m5.auth_sentinel
-    runtime: air_launchd
-    type: cron
-    expected_hb_seconds: 25200
-    owner_module: scripts/auth_sentinel_cron.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.auth-sentinel.daily
-    severity_on_silence: warning
-    cicatrix_refs:
-      - 2026-06-16-W84-tcc-green-dead
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/auth-sentinel.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.modus_autoloop_nightly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 108000
-    owner_module: infra/launchagents/modus_autoloop_cron.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.modus.autoloop.nightly
-    severity_on_silence: warning
-    cicatrix_refs:
-      - 2026-07-12-modus-autoloop-append-only-reprocess
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/modus-autoloop.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.fly_restart_loop_detector
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1350
-    owner_module: scripts/fly-restart-loop-detector.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.fly-restart-loop-detector
-    severity_on_silence: critical
-    cicatrix_refs:
-      - 2026-04-29-drive-poll-attribute-error
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.fly_restart_loop_detector.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.cpu_monitor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1350
-    owner_module: scripts/cpu-monitor.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.cpu-monitor
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.cpu_monitor.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.disk_monitor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1350
-    owner_module: scripts/disk-monitor.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.disk-monitor
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.disk_monitor.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.zombie_hunter
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90
-    owner_module: .claude/scripts/zombie-hunter.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.zombie-hunter
-    severity_on_silence: warning
-    cicatrix_refs:
-      - 2026-04-29-untracked-files-lost
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.zombie_hunter.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.dlq_autopilot
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 2700
-    owner_module: scripts/dlq_autopilot.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.dlq-autopilot
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.dlq_autopilot.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.sentinel
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/nuzantara-sentinel.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.sentinel
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.sentinel.json
-      timestamp_field: ts
-      status_field: status
-  - id: cell.organism
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 90
-    owner_module: apps/cell/cell/main.py
-    dependencies:
-      - infra.postgres
-      - infra.redis
-    recovery_action: human_only
-    recovery_params:
-      label: com.cell.organism
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/cell.organism.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.metabolic_rollup
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/metabolic_rollup_pro.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.cell.metabolic-rollup
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.metabolic_rollup.json
-      timestamp_field: ts
-      status_field: status
-  - id: channel.whatsapp
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 120
-    owner_module: apps/backend-rag/backend/channels/whatsapp
-    dependencies:
-      - backend.api
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: https://kita.balizero.com/api/channels/health-public
-      timestamp_field: ts
-      json_path: channels.whatsapp.status
-  - id: channel.telegram
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 120
-    owner_module: apps/backend-rag/backend/channels/telegram
-    dependencies:
-      - backend.api
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: https://kita.balizero.com/api/channels/health-public
-      timestamp_field: ts
-      json_path: channels.telegram.status
-  - id: channel.instagram
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 120
-    owner_module: apps/backend-rag/backend/channels/instagram
-    dependencies:
-      - backend.api
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: https://kita.balizero.com/api/channels/health-public
-      timestamp_field: ts
-      json_path: channels.instagram.status
-  - id: channel.web
-    runtime: fly_machine
-    type: webhook
-    expected_hb_seconds: 120
-    owner_module: apps/backend-rag/backend/channels/web
-    dependencies:
-      - backend.api
-    recovery_action: fly_machines_start
-    recovery_params:
-      app: nuzantara-rag
-      process_group: api
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: https://kita.balizero.com/api/channels/health-public
-      timestamp_field: ts
-      json_path: channels.web.status
-  - id: pro.intel_nightly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/bali-intel-scraper/scripts/run_intel_pipeline.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.intel.nightly
-    severity_on_silence: warning
-    cicatrix_refs: []
-    starved_after_periods: 2
-    output_artifact: ~/Desktop/nuzantara/apps/bali-intel-scraper/data/published_articles.json
-    bridge_source:
-      type: state_file
-      path: ~/.agent/decisions/state/intel_scraper.last.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.translate_hourly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 5400
-    owner_module: scripts/translate-articles.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.translate.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.translate_hourly.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.renewal_alerts
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/openclaw-cron/renewal-alerts.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.renewal-alerts
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.agent/decisions/state/expiry_alerter.last.json
-      timestamp_field: ts
-      status_field: status
-  - id: wr2.supervisor
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: scripts/wr2_supervisor.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.wr2.supervisor
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/wr2.supervisor.json
-      timestamp_field: ts
-      status_field: status
-  - id: wr2.oracle
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1209600
-    owner_module: backend.services.cognitive.oracle_cli
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.wr2.oracle
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/wr2.oracle.json
-      timestamp_field: ts
-      status_field: status
-  - id: wr2.newsletter
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1209600
-    owner_module: backend.services.newsletter.newsletter_cli
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.wr2.newsletter
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/wr2.newsletter.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.organism_control_panel
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 120
-    owner_module: apps/organism/organism/control_panel.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.nuzantara.organism.control-panel
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: http
-      path: http://127.0.0.1:1819/health
-      timestamp_field: ts
-      json_path: status
-  - id: mata_garuda.watcher_daily.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_watcher.sh
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.watcher.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.reg_alert_30min.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 5400
-    owner_module: apps/mata-garuda/scripts/run_regulation_alert.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.reg-alert.30min
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.kg_linker.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/kg_linker.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.kg-linker
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.wr_topic.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/mata-garuda/scripts/run_wr_topic.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.wr-topic
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.wr2_bridge_hourly.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/scripts/run_wr2_bridge.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.wr2-bridge
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.bridge_adaptive.pro
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 180
-    owner_module: apps/mata-garuda/scripts/run_bridge_adaptive.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.bridge.adaptive
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: mata_garuda.sentinel_daily.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_sentinel.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.sentinel.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.intel_bridge_daily.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_intel_bridge.py
-    dependencies:
-      - infra.redis
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.intel-bridge.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.daily_briefing.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_daily_briefing.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.daily-briefing
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.kita_feed_daily.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_kita_feed.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.kita-feed
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.public_channel.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_public_channel.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.public-channel
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.weekly_digest.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/mata-garuda/scripts/run_weekly_digest.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.weekly-digest
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.gap_consumer.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 4200
-    owner_module: apps/mata-garuda/mata_garuda/workers/gap_consumer.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.gap.consumer
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.invalidation_sweep.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/scripts/run_invalidation_sweep.py
-    dependencies:
-      - infra.redis
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.invalidation-sweep
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.nlm_feeder_stream_hourly.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.nlm-feeder-stream.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.nlm_expander_weekly.pro
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/mata-garuda/scripts/run_nlm_expander.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.matagaruda.nlm-expander.weekly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.ner_worker_hourly.mini
-    runtime: mini_launchd
-    type: cron
-    enabled: false
-    disabled_reason:
-      Retired 2026-07-12 (Zero GO). NER runs on Pro as com.matagaruda.ner.adaptive
-      (300s interval, same run_ner_worker.py entrypoint, log fresh) with kg-linker consuming
-      on Pro hourly. The Mini instance had Disabled:true baked in its plist since Jun
-      29 and was never reloaded; single-owner rule (superscar family 10). Plist archived
-      on Mini to ~/Library/LaunchAgents/.retired-20260712/.
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/ner_worker.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.ner-worker.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: mata_garuda.normalizer_hourly.mini
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: apps/mata-garuda/mata_garuda/workers/normalizer.py
-    dependencies:
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.matagaruda.normalizer.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.canva_apply
-    runtime: pro_launchd
-    type: daemon
-    enabled: false
-    disabled_reason: Superseded by S12; LaunchAgent archived as .disabled-2026-05-09-superseded-by-S12.
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_canva_apply.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.canva-apply
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.connector
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/war-room/scripts/wr2_connector.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.connector
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.dossier_compiler
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/war-room/scripts/wr2_dossier_compiler.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.dossier-compiler
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.draft_generator
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: scripts/wr2_draft_generator.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.draft-generator
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: wr2.hardening
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_hardening.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.hardening
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.image_generator
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: scripts/wr2_image_generator.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.image-generator
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: wr2.learner_nightly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/war-room/scripts/wr2_learner_nightly.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.learner-nightly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.measurer
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_measurer.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.measurer
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.pg_proxy
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 60
-    owner_module: apps/war-room/scripts/wr2_pg_proxy.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.pg-proxy
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: wr2.sla_worker
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_sla_worker.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.sla-worker
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.strategos
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/war-room/scripts/wr2_strategos.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.strategos
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.topic_selector
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/wr2_topic_selector.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.topic-selector
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.trend_hunter
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 600
-    owner_module: apps/war-room/scripts/wr2_trend_hunter.py
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.trend-hunter
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.codex_autofix_ci
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: scripts/codex/codex_autofix_ci.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-autofix-ci
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.codex_overnight_runner
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex/codex_overnight_runner.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-overnight-runner
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.cost_advisor_daily_cap
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/cost-advisor/daily_cap.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cost-advisor-daily-cap
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.openclaw_children_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 3900
-    owner_module: scripts/openclaw-children-watchdog.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.openclaw-children-watchdog
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.nb_intel_delta_watcher
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 7200
-    owner_module: scripts/nb-intel-delta-watcher.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.nb-intel-delta-watcher.hourly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.sentinel_meta_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 4200
-    owner_module: scripts/sentinel-meta-watchdog.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.sentinel-meta-watchdog
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.federation_alert_dispatcher
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 180
-    owner_module: apps/backend-rag/backend/scripts/federation_alert_daemon.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.federation-alert-dispatcher
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: pro.secrets_sync_mini
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/mini-setup/secrets-sync-mini.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.secrets-sync-mini
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: nlm.bridge
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 180
-    owner_module: apps/nlm-bridge/main.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.nlm-bridge
-    severity_on_silence: critical
-    notes:
-      "R5 Phase 6 (2026-05-17): RAG pipeline no longer routes through NLM. Bridge
-      kept for NAGA agent (non-RAG NLM queries) and human-facing NLM UI. Severity critical
-      unchanged — NAGA depends on it."
-    cicatrix_refs: []
-  - id: cell.observatory
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 90
-    owner_module: apps/cell-observatory-collector/cell_observatory/__main__.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cell-observatory
-    severity_on_silence: critical
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/cell.observatory.json
-      timestamp_field: ts
-      status_field: status
-  - id: cell.observatory_prune
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/cell-observatory-collector/cell_observatory/prune.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cell-observatory-prune
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: cell.observatory_selfcheck
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 3900
-    owner_module: apps/cell-observatory-collector/scripts/healthcheck.sh
-    dependencies:
-      - cell.observatory
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cell-observatory-selfcheck
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.post_publish_poller
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/bali-intel-scraper/scripts/post_publish_poller.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.post-publish-poller
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: sota.m13_checkpoint
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/backend-rag/backend/services/sota_loop/m13_checkpoint.py
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.sota.m13-checkpoint
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: sota.m13_collect
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/backend-rag/backend/services/sota_loop/m13_collect.py
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.sota.m13-collect
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: sota.m13_monthly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 2678400
-    owner_module: apps/backend-rag/backend/services/sota_loop/m13_monthly.py
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.sota.m13-monthly
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: sota.m13_weekly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/backend-rag/backend/services/sota_loop/m13_weekly.py
-    dependencies:
-      - infra.postgres
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.sota.m13-weekly
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.canva_oauth_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 3600
-    owner_module: scripts/wr2-canva-oauth-watchdog.sh
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.canva-oauth-watchdog
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.deploy_puller
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: scripts/wr2-deploy-pull.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.deploy-puller
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.fact_checker
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1800
-    owner_module: scripts/wr2_fact_checker.py
-    starved_after_periods: 2
-    output_artifact: ~/logs/wr2_fact_checker_telemetry.jsonl
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.fact-checker
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.fact_extractor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 1800
-    owner_module: scripts/wr2_fact_extractor.py
-    starved_after_periods: 2
-    output_artifact: ~/logs/wr2_fact_extractor_telemetry.jsonl
-    dependencies:
-      - wr2.supervisor
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.fact-extractor
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: wr2.ig_scraper_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: skills/bali-zero-brand/_ig-metrics-scraper.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.ig-scraper.daily
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: wr2.queue_server
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: skills/bali-zero-brand/_damar-queue-server.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.queue-server
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: wr2.reflexion_weekly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: .claude/skills/bali-zero-brand/_reflexion-synthesis.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.reflexion.weekly
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: wr2.supervisor_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: scripts/wr2_supervisor_watchdog.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.supervisor-watchdog
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: wr2.voyager_weekly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: skills/bali-zero-brand/_voyager-curriculum.py
-    dependencies:
-      - wr2.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.wr2.voyager.weekly
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: codex.spalla_calibrate
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex-spalla-calibrate.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.codex-spalla-calibrate
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: codex.coverage_improver
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex/codex-nightly-coverage-improver.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-coverage-improver
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: codex.overnight_feeder
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex/codex-overnight-queue-feeder.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-overnight-feeder
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: codex.research_actor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/codex/codex-daily-research-actor.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.codex-research-actor
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.cost_advisor_weekly
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 691200
-    owner_module: apps/backend-rag/backend/scripts/cost_advisor_cli.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.cost-advisor-weekly
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.automap_server
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: scripts/automap/automap_server.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.automap-server
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.automap_telegram
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: scripts/automap/automap_telegram.py
-    dependencies:
-      - pro.automap_server
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.automap-telegram
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.automap_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90
-    owner_module: scripts/automap/automap_watchdog.py
-    dependencies:
-      - pro.automap_server
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.automap-watchdog
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: organism.supervisor
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 120
-    owner_module: apps/organism/organism/supervisor/daemon.py
-    dependencies:
-      - infra.postgres
-    recovery_action: human_only
-    recovery_params:
-      host: pro
-      label: com.nuzantara.organism.supervisor
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: organism.scheduled_tick
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: apps/organism/organism/scheduled_tick.py
-    dependencies:
-      - organism.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.organism.scheduled-tick
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.heartbeat_bridge
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 120
-    owner_module: apps/cell/scripts/launch_heartbeat_bridge.sh
-    dependencies:
-      - infra.postgres
-      - cell.organism
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.heartbeat-bridge
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: pro.launchagent_state_bridge
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: scripts/launchagent-state-bridge.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.launchagent-state-bridge
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.supervisor_liveness_watchdog
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 900
-    owner_module: scripts/supervisor_liveness_watchdog.sh
-    dependencies:
-      - organism.supervisor
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.supervisor-liveness-watchdog
-    severity_on_silence: critical
-    cicatrix_refs: []
-  - id: pro.memory_sync_bidirectional
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: infra/sync-daemons/memory-sync-bidirectional.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.memory-sync-bidirectional
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.claude_config_sync
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/mini-setup/claude-config-sync.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.claude-config-sync
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.indexing_sweep_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/daily_indexing_cron_wrapper.sh
-    dependencies:
-      - infra.postgres
-      - infra.qdrant
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.indexing-sweep.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.intel_radar_daily_digest
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/cron-agent-python/intel_radar_daily_digest.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.intel-radar-daily-digest
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.post_publish_webhook
-    runtime: pro_launchd
-    type: webhook
-    expected_hb_seconds: 300
-    owner_module: apps/bali-intel-scraper/scripts/post_publish_webhook.py
-    dependencies:
-      - backend.api
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.post-publish-webhook
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: pro.setup_team_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: infra/scripts/setup-team-cron.sh
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.setup-team.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.seo_cell_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/openclaw-cron/seo-cell-daily.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.seo-cell.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.seo_cell_28d_check
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 2419200
-    owner_module: scripts/openclaw-cron/seo-cell-28d-check.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.seo-cell.28d-check
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.bz_daily_visual_pipeline
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/bz-daily-visual-pipeline.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.bz-daily-visual-pipeline
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.domain_mesh_foundations_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: infra/scripts/domain-mesh-foundations-cron.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.domain-mesh.foundations.daily
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.client_value_predictor
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/openclaw-cron/client-value-predictor.sh
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.client-value-predictor
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.automations_reference
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/generate-automations-all.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.automations-reference
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.prime_tunnel
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 300
-    owner_module: cloudflared/config-prime.yml
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.prime-tunnel
-    severity_on_silence: error
-    cicatrix_refs: []
-  - id: pro.ollama_warm_pin
-    runtime: pro_launchd
-    type: cron
-    enabled: false
-    disabled_reason:
-      LaunchAgent archived from Pro on 2026-05-09; warm pin now runs
-      from crontab weekly after Ollama restart.
-    expected_hb_seconds: 900
-    owner_module: scripts/ollama-warm-pin.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.ollama-warm-pin
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.vector_reindex_check
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/vector-reindex-check.py
-    dependencies:
-      - infra.qdrant
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.vector-reindex-check
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.launchd_env_loader
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/launchd_env_loader.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.launchd-env-loader
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.openclaw_logrotate
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/openclaw-logrotate.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.openclaw-logrotate
-    severity_on_silence: info
-    cicatrix_refs: []
-  - id: pro.nb_mitochondrial_monitor_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: apps/mata-garuda/mata_garuda/scripts/nb_monitor/run.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.nb-mitochondrial-monitor.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.regulatory_watcher_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: infra/launchagents/wrappers/regulatory-watcher-run.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.balizero.regulatory-watcher.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-  - id: pro.pg_organism_bridge
-    runtime: pro_launchd
-    type: daemon
-    expected_hb_seconds: 120
-    owner_module: scripts/pg-to-organism-bridge.py
-    dependencies:
-      - infra.postgres
-      - infra.redis
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.pg-organism-bridge
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.pg_organism_bridge.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.sentinel_aggregate
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 600
-    owner_module: scripts/sentinel-aggregate.py
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.sentinel-aggregate
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.sentinel_aggregate.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.outbox_prune_daily
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 90000
-    owner_module: scripts/outbox-prune.sh
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.outbox-prune.daily
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.outbox_prune_daily.json
-      timestamp_field: ts
-      status_field: status
-  - id: mini.healer
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 14400
-    owner_module: infra/healer/healer-run.sh
-    dependencies: []
-    recovery_action: human_only
-    recovery_params:
-      host: mini
-      label: com.nuzantara.healer.4h
-    severity_on_silence: error
-    notes:
-      "The HEALER organ (born 2026-07-06, Zero GO): autonomous 4h cure loop on
-      Mini. Receptors: PENDING-ARMS ledger, proprioception, escalations board, and registry-driven
-      dead-organ scan (scripts/healer_receptor_registry.py). Writes a heartbeat EVERY
-      tick. recovery_action is human_only BY CONSTITUTION: the healer never touches
-      itself and nothing may auto-restart the restarter — healer silence is an operator
-      page, not a recovery target."
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/mini.healer.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.healer
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 21600
-    owner_module: infra/launchagents/wrappers/pro-healer.sh
-    dependencies: []
-    recovery_action: human_only
-    recovery_params:
-      host: pro
-      label: com.nuzantara.healer-pro.6h
-    severity_on_silence: error
-    notes:
-      "Node-scoped healer for Pro: cures Pro LOCAL runtime (kickstart dead organs,
-      HOME-pair refresh from canon), NEVER writes the repo (single-writer stays mini.healer)
-      (born via organ_birth.py, genes imprinted 2026+)"
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.healer.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.tg_digest_flush
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 43200
-    owner_module: infra/launchagents/wrappers/pro-tg-digest-flush.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: pro
-      label: com.nuzantara.tg-digest-flush
-    severity_on_silence: warning
-    notes:
-      "Telegram digest flusher — ONE grouped message per slot for everything tg_notify
-      spooled (notification economy, PR #2067) (born via organ_birth.py, genes imprinted
-      2026+)"
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.tg_digest_flush.json
-      timestamp_field: ts
-      status_field: status
-  - id: mini.tg_digest_flush
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 43200
-    owner_module: infra/launchagents/wrappers/mini-tg-digest-flush.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.nuzantara.mini.tg-digest-flush
-    severity_on_silence: warning
-    notes:
-      "Telegram digest flusher (Mini) — ONE grouped message per slot for everything
-      tg_notify spooled on this node (notification economy, PR #2067) (born via organ_birth.py,
-      genes imprinted 2026+)"
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/mini.tg_digest_flush.json
-      timestamp_field: ts
-      status_field: status
-  - id: pro.wr2_daily_carousel
-    runtime: pro_launchd
-    type: cron
-    expected_hb_seconds: 64800
-    owner_module: scripts/wr2_daily_reconciler.py
-    dependencies:
-      - infra.postgres
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      label: com.balizero.wr2.daily-reconciler
-    severity_on_silence: warning
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/pro.wr2_daily_carousel.json
-      timestamp_field: ts
-      status_field: status
-  - id: mini.fleet_watch
-    runtime: mini_launchd
-    type: cron
-    expected_hb_seconds: 900
-    owner_module: infra/launchagents/wrappers/mini-fleet-watch.sh
-    dependencies: []
-    recovery_action: launchctl_kickstart
-    recovery_params:
-      host: mini
-      label: com.nuzantara.fleet-watch
-    severity_on_silence: warning
-    notes:
-      "Cross-node liveness sentinel: the H24 Mini watches the Pro (tailscale+ssh
-      2-signal verdict) and raises p0 via tg gateway when a peer goes dark >30min. Genesis
-      2026-07-07: Pro dark 5h, zero alarms (its watchdogs died with it). (born via organ_birth.py,
-      genes imprinted 2026+)"
-    cicatrix_refs: []
-    bridge_source:
-      type: state_file
-      path: ~/.organism/last_seen/mini.fleet_watch.json
-      timestamp_field: ts
-      status_field: status
+- id: infra.postgres
+  runtime: fly_machine
+  type: daemon
+  expected_hb_seconds: 0
+  owner_module: infra/fly/nuzantara-postgres
+  dependencies: []
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-postgres
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: infra.redis
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 0
+  owner_module: brew/redis
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: homebrew.mxcl.redis
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: infra.qdrant
+  runtime: fly_machine
+  type: daemon
+  expected_hb_seconds: 0
+  owner_module: infra/fly/nuzantara-qdrant
+  dependencies: []
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-qdrant
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: backend.api
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 60
+  owner_module: apps/backend-rag/backend/app/main.py
+  dependencies:
+  - infra.postgres
+  - infra.redis
+  - infra.qdrant
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs:
+  - 2026-04-29-startup-failed-mask
+  - 2026-04-29-drive-poll-attribute-error
+- id: backend.surface_router
+  runtime: fly_machine
+  type: daemon
+  expected_hb_seconds: 60
+  owner_module: apps/backend-rag/backend/services/routing/surface_router.py
+  dependencies:
+  - backend.api
+  - infra.postgres
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: warning
+  notes: R5 Phase 3 — in-process routing organ. Routes queries to KG vs vector vs
+    NLM. Always-on since Phase 3 deploy.
+  cicatrix_refs: []
+- id: backend.kg_langgraph_orchestrator
+  runtime: fly_machine
+  type: daemon
+  enabled: false
+  disabled_reason: 'R5 Phase 5: feature-flagged via ENABLE_KG_LANGGRAPH=false (default).
+    Enable via fly secrets set ENABLE_KG_LANGGRAPH=1 on nuzantara-rag. Fast-path wired
+    in OrchestratorCore._try_kg_fast_path() — safe to enable per domain.'
+  expected_hb_seconds: 60
+  owner_module: apps/backend-rag/backend/services/rag/kg_langgraph_orchestrator.py
+  dependencies:
+  - backend.api
+  - infra.postgres
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: warning
+  notes: R5 Phase 5 — KG LangGraph fast-path organ. Bypasses vector search for entity-heavy
+    queries when subgraph available.
+  cicatrix_refs: []
+- id: backend.crm.drive_poll
+  runtime: pro_launchd
+  type: cron
+  enabled: false
+  disabled_reason: DISABLED 2026-04-29 in crontab after drive_poll saturated PG; keep
+    registered as disabled until explicitly restored.
+  expected_hb_seconds: 360
+  owner_module: scripts/openclaw-cron/drive-poll.sh
+  dependencies:
+  - infra.postgres
+  - backend.api
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.drive-poll
+  severity_on_silence: warning
+  cicatrix_refs:
+  - 2026-04-29-drive-poll-attribute-error
+  bridge_source:
+    type: state_file
+    path: ~/.agent/decisions/state/drive_poll.last.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.claude_max_watcher
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 3600
+  owner_module: scripts/claude-max-usage-watcher.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.claude-max-usage-watcher
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.claude/usage-watcher/last_run.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.login_healthcheck
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 900
+  owner_module: scripts/login-healthcheck.sh
+  dependencies:
+  - backend.api
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.login-healthcheck
+  severity_on_silence: critical
+  cicatrix_refs:
+  - 2026-04-29-startup-failed-mask
+  bridge_source:
+    type: state_file
+    path: ~/.agent/decisions/state/login_healthcheck.last.json
+    timestamp_field: ts
+    status_field: status
+- id: m5.auth_sentinel
+  runtime: air_launchd
+  type: cron
+  expected_hb_seconds: 25200
+  owner_module: scripts/auth_sentinel_cron.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.auth-sentinel.daily
+  severity_on_silence: warning
+  cicatrix_refs:
+  - 2026-06-16-W84-tcc-green-dead
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/auth-sentinel.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.modus_autoloop_nightly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 108000
+  owner_module: infra/launchagents/modus_autoloop_cron.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.modus.autoloop.nightly
+  severity_on_silence: warning
+  cicatrix_refs:
+  - 2026-07-12-modus-autoloop-append-only-reprocess
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/modus-autoloop.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.fly_restart_loop_detector
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/fly-restart-loop-detector.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.fly-restart-loop-detector
+  severity_on_silence: critical
+  cicatrix_refs:
+  - 2026-04-29-drive-poll-attribute-error
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.fly_restart_loop_detector.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.cpu_monitor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/cpu-monitor.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.cpu-monitor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.cpu_monitor.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.disk_monitor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/disk-monitor.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.disk-monitor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.disk_monitor.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.zombie_hunter
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90
+  owner_module: .claude/scripts/zombie-hunter.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.zombie-hunter
+  severity_on_silence: warning
+  cicatrix_refs:
+  - 2026-04-29-untracked-files-lost
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.zombie_hunter.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.dlq_autopilot
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 2700
+  owner_module: scripts/dlq_autopilot.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.dlq-autopilot
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.dlq_autopilot.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.sentinel
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/nuzantara-sentinel.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.sentinel
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.sentinel.json
+    timestamp_field: ts
+    status_field: status
+- id: cell.organism
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 90
+  owner_module: apps/cell/cell/main.py
+  dependencies:
+  - infra.postgres
+  - infra.redis
+  recovery_action: human_only
+  recovery_params:
+    label: com.cell.organism
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/cell.organism.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.metabolic_rollup
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/metabolic_rollup_pro.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.cell.metabolic-rollup
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.metabolic_rollup.json
+    timestamp_field: ts
+    status_field: status
+- id: channel.whatsapp
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 120
+  owner_module: apps/backend-rag/backend/channels/whatsapp
+  dependencies:
+  - backend.api
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: https://kita.balizero.com/api/channels/health-public
+    timestamp_field: ts
+    json_path: channels.whatsapp.status
+- id: channel.telegram
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 120
+  owner_module: apps/backend-rag/backend/channels/telegram
+  dependencies:
+  - backend.api
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: https://kita.balizero.com/api/channels/health-public
+    timestamp_field: ts
+    json_path: channels.telegram.status
+- id: channel.instagram
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 120
+  owner_module: apps/backend-rag/backend/channels/instagram
+  dependencies:
+  - backend.api
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: https://kita.balizero.com/api/channels/health-public
+    timestamp_field: ts
+    json_path: channels.instagram.status
+- id: channel.web
+  runtime: fly_machine
+  type: webhook
+  expected_hb_seconds: 120
+  owner_module: apps/backend-rag/backend/channels/web
+  dependencies:
+  - backend.api
+  recovery_action: fly_machines_start
+  recovery_params:
+    app: nuzantara-rag
+    process_group: api
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: https://kita.balizero.com/api/channels/health-public
+    timestamp_field: ts
+    json_path: channels.web.status
+- id: pro.intel_nightly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.intel.nightly
+  severity_on_silence: warning
+  cicatrix_refs: []
+  starved_after_periods: 2
+  output_artifact: ~/Desktop/nuzantara/apps/bali-intel-scraper/data/published_articles.json
+  bridge_source:
+    type: state_file
+    path: ~/.agent/decisions/state/intel_scraper.last.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.translate_hourly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 5400
+  owner_module: scripts/translate-articles.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.translate.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.translate_hourly.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.renewal_alerts
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/openclaw-cron/renewal-alerts.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.renewal-alerts
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.agent/decisions/state/expiry_alerter.last.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.supervisor
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: scripts/wr2_supervisor.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.supervisor
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.supervisor.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.oracle
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1209600
+  owner_module: backend.services.cognitive.oracle_cli
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.oracle
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.oracle.json
+    timestamp_field: ts
+    status_field: status
+- id: wr2.newsletter
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1209600
+  owner_module: backend.services.newsletter.newsletter_cli
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.newsletter
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/wr2.newsletter.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.organism_control_panel
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: apps/organism/organism/control_panel.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.nuzantara.organism.control-panel
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: http
+    path: http://127.0.0.1:1819/health
+    timestamp_field: ts
+    json_path: status
+- id: mata_garuda.watcher_daily.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_watcher.sh
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.watcher.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.reg_alert_30min.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 5400
+  owner_module: apps/mata-garuda/scripts/run_regulation_alert.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.reg-alert.30min
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.kg_linker.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/mata_garuda/workers/kg_linker.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.kg-linker
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.wr_topic.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/mata-garuda/scripts/run_wr_topic.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.wr-topic
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.wr2_bridge_hourly.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/scripts/run_wr2_bridge.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.wr2-bridge
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.bridge_adaptive.pro
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 180
+  owner_module: apps/mata-garuda/scripts/run_bridge_adaptive.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.bridge.adaptive
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: mata_garuda.sentinel_daily.mini
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_sentinel.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.matagaruda.sentinel.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.intel_bridge_daily.mini
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_intel_bridge.py
+  dependencies:
+  - infra.redis
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.matagaruda.intel-bridge.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.daily_briefing.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_daily_briefing.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.daily-briefing
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.kita_feed_daily.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_kita_feed.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.kita-feed
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.public_channel.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_public_channel.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.public-channel
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.weekly_digest.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/mata-garuda/scripts/run_weekly_digest.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.weekly-digest
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.gap_consumer.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 4200
+  owner_module: apps/mata-garuda/mata_garuda/workers/gap_consumer.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.gap.consumer
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.invalidation_sweep.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/scripts/run_invalidation_sweep.py
+  dependencies:
+  - infra.redis
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.invalidation-sweep
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.nlm_feeder_stream_hourly.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/mata_garuda/workers/nlm_feeder.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.nlm-feeder-stream.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.nlm_expander_weekly.pro
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/mata-garuda/scripts/run_nlm_expander.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.matagaruda.nlm-expander.weekly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.ner_worker_hourly.mini
+  runtime: mini_launchd
+  type: cron
+  enabled: false
+  disabled_reason: Retired 2026-07-12 (Zero GO). NER runs on Pro as com.matagaruda.ner.adaptive
+    (300s interval, same run_ner_worker.py entrypoint, log fresh) with kg-linker consuming
+    on Pro hourly. The Mini instance had Disabled:true baked in its plist since Jun
+    29 and was never reloaded; single-owner rule (superscar family 10). Plist archived
+    on Mini to ~/Library/LaunchAgents/.retired-20260712/.
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/mata_garuda/workers/ner_worker.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.matagaruda.ner-worker.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: mata_garuda.normalizer_hourly.mini
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: apps/mata-garuda/mata_garuda/workers/normalizer.py
+  dependencies:
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.matagaruda.normalizer.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.canva_apply
+  runtime: pro_launchd
+  type: daemon
+  enabled: false
+  disabled_reason: Superseded by S12; LaunchAgent archived as .disabled-2026-05-09-superseded-by-S12.
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_canva_apply.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.canva-apply
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.connector
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/war-room/scripts/wr2_connector.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.connector
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.dossier_compiler
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/war-room/scripts/wr2_dossier_compiler.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.dossier-compiler
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.draft_generator
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: scripts/wr2_draft_generator.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.draft-generator
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: wr2.hardening
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_hardening.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.hardening
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.image_generator
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: scripts/wr2_image_generator.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.image-generator
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: wr2.learner_nightly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/war-room/scripts/wr2_learner_nightly.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.learner-nightly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.measurer
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_measurer.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.measurer
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.pg_proxy
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 60
+  owner_module: apps/war-room/scripts/wr2_pg_proxy.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.pg-proxy
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: wr2.sla_worker
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_sla_worker.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.sla-worker
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.strategos
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/war-room/scripts/wr2_strategos.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.strategos
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.topic_selector
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/wr2_topic_selector.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.topic-selector
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.trend_hunter
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 600
+  owner_module: apps/war-room/scripts/wr2_trend_hunter.py
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.trend-hunter
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.codex_autofix_ci
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: scripts/codex/codex_autofix_ci.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-autofix-ci
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.codex_overnight_runner
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex/codex_overnight_runner.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-overnight-runner
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.cost_advisor_daily_cap
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/cost-advisor/daily_cap.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cost-advisor-daily-cap
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.openclaw_children_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 3900
+  owner_module: scripts/openclaw-children-watchdog.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.openclaw-children-watchdog
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.nb_intel_delta_watcher
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: scripts/nb-intel-delta-watcher.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.nb-intel-delta-watcher.hourly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.sentinel_meta_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 4200
+  owner_module: scripts/sentinel-meta-watchdog.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.sentinel-meta-watchdog
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.federation_alert_dispatcher
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 180
+  owner_module: apps/backend-rag/backend/scripts/federation_alert_daemon.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.federation-alert-dispatcher
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: pro.secrets_sync_mini
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/mini-setup/secrets-sync-mini.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.secrets-sync-mini
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: nlm.bridge
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 180
+  owner_module: apps/nlm-bridge/main.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.nlm-bridge
+  severity_on_silence: critical
+  notes: 'R5 Phase 6 (2026-05-17): RAG pipeline no longer routes through NLM. Bridge
+    kept for NAGA agent (non-RAG NLM queries) and human-facing NLM UI. Severity critical
+    unchanged — NAGA depends on it.'
+  cicatrix_refs: []
+- id: cell.observatory
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 90
+  owner_module: apps/cell-observatory-collector/cell_observatory/__main__.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cell-observatory
+  severity_on_silence: critical
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/cell.observatory.json
+    timestamp_field: ts
+    status_field: status
+- id: cell.observatory_prune
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/cell-observatory-collector/cell_observatory/prune.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cell-observatory-prune
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: cell.observatory_selfcheck
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 3900
+  owner_module: apps/cell-observatory-collector/scripts/healthcheck.sh
+  dependencies:
+  - cell.observatory
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cell-observatory-selfcheck
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.post_publish_poller
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/bali-intel-scraper/scripts/post_publish_poller.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.post-publish-poller
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: sota.m13_checkpoint
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/backend-rag/backend/services/sota_loop/m13_checkpoint.py
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.sota.m13-checkpoint
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: sota.m13_collect
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/backend-rag/backend/services/sota_loop/m13_collect.py
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.sota.m13-collect
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: sota.m13_monthly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 2678400
+  owner_module: apps/backend-rag/backend/services/sota_loop/m13_monthly.py
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.sota.m13-monthly
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: sota.m13_weekly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/backend-rag/backend/services/sota_loop/m13_weekly.py
+  dependencies:
+  - infra.postgres
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.sota.m13-weekly
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.canva_oauth_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 3600
+  owner_module: scripts/wr2-canva-oauth-watchdog.sh
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.canva-oauth-watchdog
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.deploy_puller
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: scripts/wr2-deploy-pull.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.deploy-puller
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.fact_checker
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1800
+  owner_module: scripts/wr2_fact_checker.py
+  starved_after_periods: 2
+  output_artifact: ~/logs/wr2_fact_checker_telemetry.jsonl
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.fact-checker
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.fact_extractor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1800
+  owner_module: scripts/wr2_fact_extractor.py
+  starved_after_periods: 2
+  output_artifact: ~/logs/wr2_fact_extractor_telemetry.jsonl
+  dependencies:
+  - wr2.supervisor
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.fact-extractor
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: wr2.ig_scraper_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: skills/bali-zero-brand/_ig-metrics-scraper.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.ig-scraper.daily
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: wr2.queue_server
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: skills/bali-zero-brand/_damar-queue-server.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.queue-server
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: wr2.reflexion_weekly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: .claude/skills/bali-zero-brand/_reflexion-synthesis.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.reflexion.weekly
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: wr2.supervisor_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: scripts/wr2_supervisor_watchdog.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.supervisor-watchdog
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: wr2.voyager_weekly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: skills/bali-zero-brand/_voyager-curriculum.py
+  dependencies:
+  - wr2.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wr2.voyager.weekly
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: codex.spalla_calibrate
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex-spalla-calibrate.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.codex-spalla-calibrate
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: codex.coverage_improver
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex/codex-nightly-coverage-improver.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-coverage-improver
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: codex.overnight_feeder
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex/codex-overnight-queue-feeder.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-overnight-feeder
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: codex.research_actor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/codex/codex-daily-research-actor.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.codex-research-actor
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.cost_advisor_weekly
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 691200
+  owner_module: apps/backend-rag/backend/scripts/cost_advisor_cli.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.cost-advisor-weekly
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.automap_server
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: scripts/automap/automap_server.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.automap-server
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.automap_telegram
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: scripts/automap/automap_telegram.py
+  dependencies:
+  - pro.automap_server
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.automap-telegram
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.automap_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90
+  owner_module: scripts/automap/automap_watchdog.py
+  dependencies:
+  - pro.automap_server
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.automap-watchdog
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: organism.supervisor
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: apps/organism/organism/supervisor/daemon.py
+  dependencies:
+  - infra.postgres
+  recovery_action: human_only
+  recovery_params:
+    host: pro
+    label: com.nuzantara.organism.supervisor
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: organism.scheduled_tick
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: apps/organism/organism/scheduled_tick.py
+  dependencies:
+  - organism.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.organism.scheduled-tick
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.heartbeat_bridge
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: apps/cell/scripts/launch_heartbeat_bridge.sh
+  dependencies:
+  - infra.postgres
+  - cell.organism
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.heartbeat-bridge
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: pro.launchagent_state_bridge
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: scripts/launchagent-state-bridge.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.launchagent-state-bridge
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.supervisor_liveness_watchdog
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 900
+  owner_module: scripts/supervisor_liveness_watchdog.sh
+  dependencies:
+  - organism.supervisor
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.supervisor-liveness-watchdog
+  severity_on_silence: critical
+  cicatrix_refs: []
+- id: pro.memory_sync_bidirectional
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: infra/sync-daemons/memory-sync-bidirectional.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.memory-sync-bidirectional
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.claude_config_sync
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/mini-setup/claude-config-sync.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.claude-config-sync
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.indexing_sweep_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/daily_indexing_cron_wrapper.sh
+  dependencies:
+  - infra.postgres
+  - infra.qdrant
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.indexing-sweep.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.intel_radar_daily_digest
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/cron-agent-python/intel_radar_daily_digest.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.intel-radar-daily-digest
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.post_publish_webhook
+  runtime: pro_launchd
+  type: webhook
+  expected_hb_seconds: 300
+  owner_module: apps/bali-intel-scraper/scripts/post_publish_webhook.py
+  dependencies:
+  - backend.api
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.post-publish-webhook
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: pro.setup_team_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: infra/scripts/setup-team-cron.sh
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.setup-team.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.seo_cell_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/openclaw-cron/seo-cell-daily.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.seo-cell.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.seo_cell_28d_check
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 2419200
+  owner_module: scripts/openclaw-cron/seo-cell-28d-check.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.seo-cell.28d-check
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.bz_daily_visual_pipeline
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/bz-daily-visual-pipeline.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.bz-daily-visual-pipeline
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.domain_mesh_foundations_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: infra/scripts/domain-mesh-foundations-cron.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.domain-mesh.foundations.daily
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.client_value_predictor
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/openclaw-cron/client-value-predictor.sh
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.client-value-predictor
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.automations_reference
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/generate-automations-all.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.automations-reference
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.prime_tunnel
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 300
+  owner_module: cloudflared/config-prime.yml
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.prime-tunnel
+  severity_on_silence: error
+  cicatrix_refs: []
+- id: pro.ollama_warm_pin
+  runtime: pro_launchd
+  type: cron
+  enabled: false
+  disabled_reason: LaunchAgent archived from Pro on 2026-05-09; warm pin now runs
+    from crontab weekly after Ollama restart.
+  expected_hb_seconds: 900
+  owner_module: scripts/ollama-warm-pin.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.ollama-warm-pin
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.vector_reindex_check
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/vector-reindex-check.py
+  dependencies:
+  - infra.qdrant
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.vector-reindex-check
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.launchd_env_loader
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/launchd_env_loader.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.launchd-env-loader
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.openclaw_logrotate
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/openclaw-logrotate.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.openclaw-logrotate
+  severity_on_silence: info
+  cicatrix_refs: []
+- id: pro.nb_mitochondrial_monitor_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: apps/mata-garuda/mata_garuda/scripts/nb_monitor/run.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.nb-mitochondrial-monitor.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.regulatory_watcher_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: infra/launchagents/wrappers/regulatory-watcher-run.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.regulatory-watcher.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+- id: pro.pg_organism_bridge
+  runtime: pro_launchd
+  type: daemon
+  expected_hb_seconds: 120
+  owner_module: scripts/pg-to-organism-bridge.py
+  dependencies:
+  - infra.postgres
+  - infra.redis
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.pg-organism-bridge
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.pg_organism_bridge.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.sentinel_aggregate
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 600
+  owner_module: scripts/sentinel-aggregate.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.sentinel-aggregate
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.sentinel_aggregate.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.outbox_prune_daily
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/outbox-prune.sh
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.outbox-prune.daily
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.outbox_prune_daily.json
+    timestamp_field: ts
+    status_field: status
+- id: mini.healer
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 14400
+  owner_module: infra/healer/healer-run.sh
+  dependencies: []
+  recovery_action: human_only
+  recovery_params:
+    host: mini
+    label: com.nuzantara.healer.4h
+  severity_on_silence: error
+  notes: 'The HEALER organ (born 2026-07-06, Zero GO): autonomous 4h cure loop on
+    Mini. Receptors: PENDING-ARMS ledger, proprioception, escalations board, and registry-driven
+    dead-organ scan (scripts/healer_receptor_registry.py). Writes a heartbeat EVERY
+    tick. recovery_action is human_only BY CONSTITUTION: the healer never touches
+    itself and nothing may auto-restart the restarter — healer silence is an operator
+    page, not a recovery target.'
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/mini.healer.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.healer
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 21600
+  owner_module: infra/launchagents/wrappers/pro-healer.sh
+  dependencies: []
+  recovery_action: human_only
+  recovery_params:
+    host: pro
+    label: com.nuzantara.healer-pro.6h
+  severity_on_silence: error
+  notes: 'Node-scoped healer for Pro: cures Pro LOCAL runtime (kickstart dead organs,
+    HOME-pair refresh from canon), NEVER writes the repo (single-writer stays mini.healer)
+    (born via organ_birth.py, genes imprinted 2026+)'
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.healer.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.tg_digest_flush
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 43200
+  owner_module: infra/launchagents/wrappers/pro-tg-digest-flush.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.tg-digest-flush
+  severity_on_silence: warning
+  notes: 'Telegram digest flusher — ONE grouped message per slot for everything tg_notify
+    spooled (notification economy, PR #2067) (born via organ_birth.py, genes imprinted
+    2026+)'
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.tg_digest_flush.json
+    timestamp_field: ts
+    status_field: status
+- id: mini.tg_digest_flush
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 43200
+  owner_module: infra/launchagents/wrappers/mini-tg-digest-flush.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.nuzantara.mini.tg-digest-flush
+  severity_on_silence: warning
+  notes: 'Telegram digest flusher (Mini) — ONE grouped message per slot for everything
+    tg_notify spooled on this node (notification economy, PR #2067) (born via organ_birth.py,
+    genes imprinted 2026+)'
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/mini.tg_digest_flush.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.wr2_daily_carousel
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 64800
+  owner_module: scripts/wr2_daily_reconciler.py
+  dependencies:
+  - infra.postgres
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    label: com.balizero.wr2.daily-reconciler
+  severity_on_silence: warning
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.wr2_daily_carousel.json
+    timestamp_field: ts
+    status_field: status
+- id: mini.fleet_watch
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 900
+  owner_module: infra/launchagents/wrappers/mini-fleet-watch.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.nuzantara.fleet-watch
+  severity_on_silence: warning
+  notes: 'Cross-node liveness sentinel: the H24 Mini watches the Pro (tailscale+ssh
+    2-signal verdict) and raises p0 via tg gateway when a peer goes dark >30min. Genesis
+    2026-07-07: Pro dark 5h, zero alarms (its watchdogs died with it). (born via organ_birth.py,
+    genes imprinted 2026+)'
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/mini.fleet_watch.json
+    timestamp_field: ts
+    status_field: status

--- a/infra/launchagents/com.balizero.modus.autoloop.nightly.plist
+++ b/infra/launchagents/com.balizero.modus.autoloop.nightly.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.balizero.modus.autoloop.nightly</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>/Users/nuzantara/.nuzantara-cron/modus_autoloop_cron.sh</string>
+    </array>
+    <!-- Cron puro: StartCalendarInterval 03:00 WITA, NO KeepAlive (scar #7). -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Log FUORI da ~/Desktop (W84: launchd perde TCC su Desktop). -->
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/.local/state/modus-autoloop/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/.local/state/modus-autoloop/launchd.err.log</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <!-- Kill switch DEFAULT OFF: the installer/operator flips this true.
+             The wrapper also reads launchctl-setenv, so this is the fallback. -->
+        <key>MODUS_AUTOLOOP_ENABLED</key>
+        <string>false</string>
+        <key>MODUS_AUTOLOOP_MAX</key>
+        <string>5</string>
+    </dict>
+</dict>
+</plist>

--- a/infra/launchagents/modus_autoloop_cron.sh
+++ b/infra/launchagents/modus_autoloop_cron.sh
@@ -17,14 +17,29 @@ LOGDIR="$HOME/.local/state/modus-autoloop"
 mkdir -p "$LOGDIR"
 LOG="$LOGDIR/run.log"
 
+# G10 single-instance: a nightly tick must never overlap itself.
+LOCK="$LOGDIR/modus-autoloop.lock"
+if ! mkdir "$LOCK" 2>/dev/null; then
+    echo "[$(date)] another tick holds the lock — exiting" >> "$LOG"; exit 0
+fi
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+
+# G2 heartbeat: prove-of-life the organism guardian reads (scar #2 esiste≠armato).
+HB_DIR="$HOME/.organism/last_seen"; mkdir -p "$HB_DIR"
+_hb() {  # _hb <status> <note>
+    printf '{"ts": %s, "status": "%s", "note": "%s"}\n' \
+        "$(date +%s)" "$1" "${2:-}" > "$HB_DIR/modus-autoloop.json" 2>/dev/null || true
+}
+
 # Defense-in-depth: never pay-per-token Anthropic (a spawned session uses the
 # CLI OAuth path, not the SDK).
 unset ANTHROPIC_API_KEY
 
-cd "$REPO" 2>/dev/null || { echo "[$(date)] FATAL: no repo at $REPO" >> "$LOG"; exit 78; }
+cd "$REPO" 2>/dev/null || { echo "[$(date)] FATAL: no repo at $REPO" >> "$LOG"; _hb error "no repo"; exit 78; }
 
 echo "[$(date)] modus-autoloop tick (enabled=${MODUS_AUTOLOOP_ENABLED:-unset} dryrun=${MODUS_AUTOLOOP_DRYRUN:-unset-default-true})" >> "$LOG"
 "$PY" scripts/modus_autoloop.py >> "$LOG" 2>&1
 rc=$?
 echo "[$(date)] modus-autoloop tick done rc=$rc" >> "$LOG"
+[ "$rc" -eq 0 ] && _hb ok "tick rc=0" || _hb error "tick rc=$rc"
 exit "$rc"

--- a/infra/launchagents/modus_autoloop_cron.sh
+++ b/infra/launchagents/modus_autoloop_cron.sh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+# modus_autoloop_cron.sh — nightly wrapper for the modus autonomous loop consumer.
+# Installed to ~/.nuzantara-cron/ (outside ~/Desktop, W84 TCC-safe) but is a
+# byte-identical copy of THIS repo file (scar #1 HOME-fork: the installer must
+# refuse to run if the live copy diverges from the tracked one).
+#
+# Runs scripts/modus_autoloop.py from the repo. The consumer itself enforces:
+#   - MODUS_AUTOLOOP_ENABLED default OFF (does nothing unless explicitly true)
+#   - MODUS_AUTOLOOP_DRYRUN default TRUE (logs 'would launch', never spawns)
+#   - single-machine guard, K-cap, deferred-on-dead-gate.
+set -uo pipefail
+
+REPO="$HOME/Desktop/nuzantara"
+PY="/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3"
+[ -x "$PY" ] || PY="python3"
+LOGDIR="$HOME/.local/state/modus-autoloop"
+mkdir -p "$LOGDIR"
+LOG="$LOGDIR/run.log"
+
+# Defense-in-depth: never pay-per-token Anthropic (a spawned session uses the
+# CLI OAuth path, not the SDK).
+unset ANTHROPIC_API_KEY
+
+cd "$REPO" 2>/dev/null || { echo "[$(date)] FATAL: no repo at $REPO" >> "$LOG"; exit 78; }
+
+echo "[$(date)] modus-autoloop tick (enabled=${MODUS_AUTOLOOP_ENABLED:-unset} dryrun=${MODUS_AUTOLOOP_DRYRUN:-unset-default-true})" >> "$LOG"
+"$PY" scripts/modus_autoloop.py >> "$LOG" 2>&1
+rc=$?
+echo "[$(date)] modus-autoloop tick done rc=$rc" >> "$LOG"
+exit "$rc"

--- a/scripts/modus_autoloop.py
+++ b/scripts/modus_autoloop.py
@@ -145,18 +145,47 @@ def _is_green(task: dict[str, Any]) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _collapse_by_job(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse an append-only queue to the LAST record per job.
+
+    The D2.3 queue is append-only: mark_resolved()/defer append a new
+    'resolved'/'deferred' row without mutating the original 'pending' row.
+    Reading raw would therefore still see the stale 'pending' row and
+    re-process a job forever (scar family #2 — blind heal-loop, cf. W81b DLQ
+    corpse-sweep). We must decide a job's live status by its NEWEST record.
+
+    `records` is newest-first (read_all_escalations sorts by ts desc), so the
+    first record seen for a given job IS its latest. A record without a `job`
+    key is kept as-is (can't be collapsed — treat as its own singleton).
+    """
+    latest: dict[str, dict[str, Any]] = {}
+    out: list[dict[str, Any]] = []
+    for rec in records:
+        job = rec.get("job")
+        if job is None:
+            out.append(rec)
+            continue
+        if job not in latest:  # newest-first → first seen is the latest
+            latest[job] = rec
+            out.append(rec)
+    return out
+
+
 def _read_pending_green_tasks() -> list[dict[str, Any]]:
-    """Read the queue, filter to pending + green. Fail-open on read errors."""
+    """Read the queue, collapse per-job to latest status, filter to
+    pending + green. Fail-open on read errors."""
     from sentinel_lib import escalations
 
     try:
-        pending = escalations.read_all_escalations(include_resolved=False)
+        # include_resolved=True so a job's resolution/defer record is visible
+        # and can override its earlier pending row during collapse.
+        all_records = escalations.read_all_escalations(include_resolved=True)
     except Exception as exc:  # noqa: BLE001 — never crash the launchd job on a read error
         logger.error("read_all_escalations() failed: %s (treating as empty queue)", exc)
         return []
 
     green: list[dict[str, Any]] = []
-    for task in pending:
+    for task in _collapse_by_job(all_records):
         if task.get("status") != "pending":
             continue
         if task.get("class") != "green":

--- a/scripts/tests/test_modus_autoloop.py
+++ b/scripts/tests/test_modus_autoloop.py
@@ -311,3 +311,51 @@ def test_read_error_fails_open_to_empty_list(monkeypatch: pytest.MonkeyPatch) ->
 
     result = modus_autoloop._read_pending_green_tasks()
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# collapse-by-job: an append-only pending+resolved pair must NOT re-process
+# (scar family #2 — blind heal-loop; the smoke-test that exposed it live 2026-07-12)
+# ---------------------------------------------------------------------------
+
+def test_collapse_by_job_excludes_resolved_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    # newest-first: the resolved record is newer than the pending one for job "done".
+    records = [
+        {"job": "done", "status": "resolved", "ts": 200.0},
+        {"job": "done", "status": "pending", "class": "green", "ts": 100.0, "mandate": "x"},
+        {"job": "live", "status": "pending", "class": "green", "ts": 150.0, "mandate": "y"},
+    ]
+    escalations_mod = _make_fake_escalations_module(pending=records)
+    _install_fake_sentinel_lib(monkeypatch, escalations_mod)
+    _install_fake_green_gate(monkeypatch, verdict=True)
+
+    result = modus_autoloop._read_pending_green_tasks()
+    jobs = [t["job"] for t in result]
+    assert jobs == ["live"], f"resolved job leaked back as pending: {jobs}"
+
+
+def test_collapse_by_job_keeps_deferred_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    records = [
+        {"job": "waiting", "status": "deferred", "ts": 300.0},
+        {"job": "waiting", "status": "pending", "class": "green", "ts": 100.0, "mandate": "z"},
+    ]
+    escalations_mod = _make_fake_escalations_module(pending=records)
+    _install_fake_sentinel_lib(monkeypatch, escalations_mod)
+    _install_fake_green_gate(monkeypatch, verdict=True)
+
+    assert modus_autoloop._read_pending_green_tasks() == []
+
+
+def test_collapse_by_job_unit() -> None:
+    recs = [
+        {"job": "a", "status": "resolved", "ts": 2},
+        {"job": "a", "status": "pending", "ts": 1},
+        {"job": "b", "status": "pending", "ts": 3},
+        {"status": "pending", "ts": 4},  # no job — kept as singleton
+    ]
+    out = modus_autoloop._collapse_by_job(recs)
+    # 'a' collapses to its newest (resolved); 'b' pending; the job-less row kept.
+    a = [r for r in out if r.get("job") == "a"]
+    assert len(a) == 1 and a[0]["status"] == "resolved"
+    assert any(r.get("job") == "b" for r in out)
+    assert any("job" not in r for r in out)


### PR DESCRIPTION
## Real bug caught by a live smoke-test

Arming the modus autonomous loop on Pro (2026-07-12) surfaced a genuine bug in the U3 consumer. The D2.3 escalation queue is **append-only**: `mark_resolved()`/defer append a new `resolved`/`deferred` row without mutating the original `pending` row. The consumer read raw and filtered `status=='pending'`, so it still saw the stale pending row and **would re-process every task forever** — scar family #2 (blind heal-loop, same shape as W81b DLQ corpse-sweep).

Proven live: a resolved smoke-test task still showed as `green pending: 1`.

## Fix

`_collapse_by_job()` reduces the queue to the **newest record per job** before filtering (via `read_all_escalations(include_resolved=True)` so the resolution row is visible to override the earlier pending one). A job whose latest status is `resolved`/`deferred` is no longer pending.

Regression tests (18/18 consumer tests pass):
- pending+resolved pair for a job → excluded
- pending+deferred pair → excluded
- direct `_collapse_by_job` unit test (newest wins, job-less rows kept)

## Also ships the missing nightly cron

U3 shipped the `.py` but not the LaunchAgent that wakes it:
- `com.balizero.modus.autoloop.nightly.plist` — StartCalendarInterval **03:00 WITA**, NO KeepAlive (scar #7), logs outside `~/Desktop` (scar #84), env kill-switch `MODUS_AUTOLOOP_ENABLED` **default false**.
- `modus_autoloop_cron.sh` — repo-tracked wrapper, installed byte-identical to `~/.nuzantara-cron/` (scar #1 HOME-fork discipline).

Follow-up to #2307. Loop stays in explicit dry-run on Pro until this merges + installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)