### PR TITLE
fix(security): resolve detect-secrets false positive in route_risk_registry

### DIFF
--- a/apps/backend-rag/backend/app/auth/route_risk_registry.py
+++ b/apps/backend-rag/backend/app/auth/route_risk_registry.py
@@ -190,7 +190,7 @@ ROUTE_RISKS: tuple[RouteRisk, ...] = (
     RouteRisk("/api/voice/elevenlabs/kbli-audit", ('POST',), RiskLevel.R1_TEAM, gating_safe=True, owner="session",
               note="CONFIRMED. Read backend/app/routers/voice.py:785-799 in full: the entire handler body unconditionally raises HTTPException(410, ...) — no service call, no state touch, no branch th"),
     RouteRisk("/media/generate-image", ('POST',), RiskLevel.R1_TEAM, gating_safe=True, owner="session",
-              note="CONFIRMED. Read backend/app/routers/media.py:20-70 in full: zero Depends, calls ImageGenerationService(api_key='dummy') which is a stateless pollinations.ai proxy — no DB write, no"),
+              note="CONFIRMED. Read backend/app/routers/media.py:20-70 in full: zero Depends, calls ImageGenerationService with a placeholder credential which is a stateless pollinations.ai proxy — no DB write, no"),
     RouteRisk("/media/upload", ('POST',), RiskLevel.R2_ELEVATED, gating_safe=True, owner="session",
               note="CONFIRMED with one correction to the rationale text: read backend/app/routers/media.py:73-109 in full — it does write an arbitrary unvalidated file (no content-type/size check) to "),
 )


### PR DESCRIPTION
Stacked on #2304. Unblocks the **Detect Secrets** required check that was failing #2304.

## Root cause
`route_risk_registry.py:193` — the audit note for `/media/generate-image` contained the literal string `api_key='dummy'` (prose describing the router's code, NOT a real credential). detect-secrets' "Secret Keyword" heuristic tripped on `api_key=`, and `detect_secrets_check_unaudited.py` failed because the line isn't in `.secrets.baseline`.

## Fix
Reworded to "a placeholder credential" — kills the keyword at the root, no `.secrets.baseline` edit needed. Note meaning preserved (the route uses a placeholder credential → stateless proxy → R1/gating_safe rationale intact).

## Verification
`detect-secrets scan route_risk_registry.py` → **zero findings**. ruff clean. Golden-Rule-6 pre-commit secret-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)