### PR TITLE
fix(infra): reverse-promote modus autoloop enqueue block to regulatory wrapper canon

### DIFF
--- a/infra/launchagents/wrappers/regulatory-watcher-run.sh
+++ b/infra/launchagents/wrappers/regulatory-watcher-run.sh
@@ -381,5 +381,27 @@ else
     organism_hb_set error "all tiers failed"
 fi
 
+
+# --- modus autoloop enqueue (PR #2307) ---
+# When regulatory-watcher confirmed a real delta on disk this run, deposit ONE
+# green-class task into the modus escalation queue so the autonomous loop can
+# capture it into research/regulatory/** (a low-risk, in-perimeter mandate — NOT
+# "apply the regulation", which would be a business/legal decision and NOT green).
+# One task per RUN (not per delta). Idempotent (modus_enqueue skips same pending
+# job). Fail-open: never break the watcher.
+if [ -f "$DELTA_JSON" ]; then
+    _mod_n=$(/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3 -c "import json;print(len(json.load(open('$DELTA_JSON')).get('deltas',[])))" 2>/dev/null || echo 0)
+    if [ "${_mod_n:-0}" -gt 0 ]; then
+        ( cd "$HOME/Desktop/nuzantara" && \
+          /Users/nuzantara/.pyenv/versions/3.11.11/bin/python3 scripts/modus_enqueue.py \
+            --job "regulatory-delta-capture-$DATE" \
+            --source "regulatory-watcher" \
+            --mandate "Capture today's $_mod_n regulatory delta(s) from $DELTA_JSON into a research/regulatory note; only record, do NOT apply or advise." \
+            --class green \
+            --perimeter "research/regulatory/**" \
+        ) >> "$LOG" 2>&1 || echo "[$(date)] modus_enqueue failed (non-fatal)" >> "$LOG"
+    fi
+fi
+
 rm -f "$TMPOUT"
 exit 0


### PR DESCRIPTION
## What

The live HOME copy on Pro (`~/scripts/regulatory-watcher-run.sh`) gained a 22-line **modus autoloop enqueue** block (PR #2307 design: on a real regulatory delta, deposit ONE green-class capture task via `scripts/modus_enqueue.py` — one per run, idempotent, fail-open) that was never ported back to the repo canon. Found by `lint_home_fork.py --check` exit 1 on Pro immediately after tonight's fleet-align (scar family #1, reverse-debt direction: live evolved past canon).

## Verify
- Canon is now **byte-identical** to the live copy: `sha256 = ea01a168…` on both sides (live probed read-only via ssh)
- `zsh -n` clean (the wrapper is zsh — `bash -n` false-alarms on the pre-existing `(N.om)` glob qualifier at :168)
- `scripts/modus_enqueue.py` confirmed on main (landed with #2307)
- No live-side touch needed: the declared-pair check goes green by canon catching up

🤖 Generated with [Claude Code](https://claude.com/claude-code)