### PR TITLE
feat(kbli): native-app fleet drift notice in sync_kbli_dataset.sh

### DIFF
--- a/scripts/sync_kbli_dataset.sh
+++ b/scripts/sync_kbli_dataset.sh
@@ -106,3 +106,23 @@ if [[ "$MODE" == "--check" ]]; then
   fi
   echo "All KBLI dataset consumers are in sync with canonical."
 fi
+
+# ── native-app fleet notice (local only — never CI, never --check) ─────────────────
+# The macOS KBLI Navigator (~/Desktop/kbli-navigator-app, OUTSIDE this repo) ships its
+# own copy of the dataset; its build refreshes from canonical, but only a deploy pushes
+# it to the 3-Mac fleet + the team zip. This block makes the drift VISIBLE at exactly
+# the moment canonical changes (this script is the mandatory step after any change),
+# instead of relying on someone remembering (superscar #2: costruito ≠ armato).
+APP_REPO="$HOME/Desktop/kbli-navigator-app"
+if [[ "$MODE" == "sync" && -z "${CI:-}" && -d "$APP_REPO" ]]; then
+  APP_COPY="$APP_REPO/Resources/KBLI_2025_FINAL_CLEAN.json"
+  if ! cmp -s "$CANONICAL" "$APP_COPY" 2>/dev/null; then
+    echo ""
+    echo "⚠︎ native app fleet NOT aligned with the new canonical. To align everything:"
+    echo "   $APP_REPO/deploy/install-3mac.sh        # build + deploy M5/Pro/Mini + content probe"
+    echo "   $APP_REPO/deploy/make-team-installer.sh # refresh the team zip"
+    echo "   $APP_REPO/deploy/check-fleet.sh         # verify (read-only)"
+  else
+    echo "native app Resources/ already matches canonical (deploy still needed if bundles are older — check-fleet.sh)"
+  fi
+fi


### PR DESCRIPTION
## What

After any canonical KBLI dataset change, the mandatory `scripts/sync_kbli_dataset.sh` run now also compares canonical against the native macOS app's dataset copy (`~/Desktop/kbli-navigator-app/Resources/`, outside this repo) and prints the three alignment commands (`install-3mac.sh` / `make-team-installer.sh` / `check-fleet.sh`) when they drift.

## Why

The Navigator fleet (3 Macs + team zip) ships its own dataset copy that only a deploy refreshes. Superscar #2 (built ≠ armed): the refresh relied on someone remembering. This makes the drift visible at the exact moment it is born, with zero new daemons.

## Safety

- Gated on sync mode (CI runs `--check`), `-z $CI`, and the app dir existing → CI behavior byte-identical.
- Read-only toward the app repo: prints, never mutates.
- Tested both modes live in the worktree: `--check` output unchanged; sync mode prints the aligned-state line.

Companion (app repo, committed separately): `install-3mac.sh` post-deploy content probe per machine + `check-fleet.sh` receptor + `make-team-installer.sh` for office team Macs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)