### PR TITLE
feat(measurer): arm the IG token chain — watchdog in cron wrapper + sampler host by token family

### DIFF
--- a/apps/backend-rag/backend/services/measurer/scheduler_cli.py
+++ b/apps/backend-rag/backend/services/measurer/scheduler_cli.py
@@ -45,6 +45,24 @@ def _configure_logging() -> None:
     )
 
 
+def _resolve_graph_base() -> str | None:
+    """Pick the Graph API host matching the token family.
+
+    The only known-valid production token is INSTAGRAM-Login family
+    (wr2_ig_publish probe 2026-06-25): valid on graph.instagram.com ONLY —
+    MetaGraphSampler's facebook default answers 190 OAuthException for it.
+    IG_GRAPH_BASE wins when set; otherwise IG_TOKEN_FAMILY selects the host
+    (default instagram, mirroring ig_token_watchdog's default).
+    """
+    explicit = os.environ.get("IG_GRAPH_BASE")
+    if explicit:
+        return explicit
+    family = (os.environ.get("IG_TOKEN_FAMILY") or "instagram").strip().lower()
+    if family == "facebook":
+        return None  # keep MetaGraphSampler's facebook default
+    return "https://graph.instagram.com/v21.0"
+
+
 def _build_samplers() -> list:
     """Build the sampler list from what's reachable in this environment.
 
@@ -59,7 +77,7 @@ def _build_samplers() -> list:
         )
 
         try:
-            samplers.append(MetaGraphSampler())
+            samplers.append(MetaGraphSampler(graph_base=_resolve_graph_base()))
         except Exception as exc:
             logger.warning("MetaGraphSampler init failed: %s", exc)
     return samplers

--- a/apps/backend-rag/backend/tests/services/measurer/test_scheduler_cli_graph_base.py
+++ b/apps/backend-rag/backend/tests/services/measurer/test_scheduler_cli_graph_base.py
@@ -1,0 +1,69 @@
+"""Sampler graph host must match the token family (measurer arming, 2026-07-13).
+
+GUILT context: the only known-valid production token is INSTAGRAM-Login
+family — probed live: it answers 190 OAuthException on graph.facebook.com.
+MetaGraphSampler's default graph_base is the facebook host, so building it
+bare (the pre-fix scheduler_cli did) starves the measurer even WITH a valid
+token in env. Mini's dead token failing 190 on BOTH hosts is a separate
+problem (operator[secret]); this guards the code half.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.measurer import scheduler_cli
+from backend.services.measurer.meta_graph_sampler import DEFAULT_GRAPH_BASE
+
+INSTAGRAM_BASE = "https://graph.instagram.com/v21.0"
+
+
+def _clear_ig_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "IG_LONG_LIVED_TOKEN",
+        "INSTAGRAM_ACCESS_TOKEN",
+        "IG_GRAPH_BASE",
+        "IG_TOKEN_FAMILY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_default_family_builds_instagram_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GUILT: bare build used the facebook default → 190 for the live token."""
+    _clear_ig_env(monkeypatch)
+    monkeypatch.setenv("IG_LONG_LIVED_TOKEN", "token-under-test")
+
+    samplers = scheduler_cli._build_samplers()
+
+    assert len(samplers) == 1
+    assert samplers[0].graph_base == INSTAGRAM_BASE
+
+
+def test_facebook_family_keeps_sampler_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """INNOCENCE: an explicit facebook-family token keeps the historic host."""
+    _clear_ig_env(monkeypatch)
+    monkeypatch.setenv("IG_LONG_LIVED_TOKEN", "token-under-test")
+    monkeypatch.setenv("IG_TOKEN_FAMILY", "facebook")
+
+    samplers = scheduler_cli._build_samplers()
+
+    assert len(samplers) == 1
+    assert samplers[0].graph_base == DEFAULT_GRAPH_BASE.rstrip("/")
+
+
+def test_explicit_graph_base_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_ig_env(monkeypatch)
+    monkeypatch.setenv("IG_LONG_LIVED_TOKEN", "token-under-test")
+    monkeypatch.setenv("IG_TOKEN_FAMILY", "facebook")
+    monkeypatch.setenv("IG_GRAPH_BASE", "https://graph.example.test/v99.0")
+
+    samplers = scheduler_cli._build_samplers()
+
+    assert samplers[0].graph_base == "https://graph.example.test/v99.0"
+
+
+def test_no_token_builds_no_samplers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """INNOCENCE: token-tolerant — starving stays a warning, not a crash."""
+    _clear_ig_env(monkeypatch)
+
+    assert scheduler_cli._build_samplers() == []

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 636 services · 1133 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 636 services · 1134 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/scripts/wr2-cron-wrapper.sh
+++ b/scripts/wr2-cron-wrapper.sh
@@ -67,4 +67,30 @@ if [[ ! -x "$VENV_PY" ]]; then
     VENV_PY="python"
 fi
 
+# 3.5 Measurer only: keep the IG long-lived token alive before the sweep
+# (Task-30 watchdog, runbook docs/runbooks/ig-token-watchdog.md §Arming).
+# Token-tolerant: with no token configured the watchdog exits 2 and the
+# scheduler still runs (it degrades to "no samplers" on its own); the exit-2
+# line below is the standing NEEDS-OPERATOR alarm until a token lands.
+if [[ "$MODULE" == "backend.services.measurer.scheduler_cli" ]]; then
+    set +e
+    IG_TOKEN_ENV_FILE="$SECRETS_FILE" \
+    IG_TOKEN_STATE_FILE="$HOME/.nuzantara-ig-token-state.json" \
+    PYTHONPATH=. "$VENV_PY" -m backend.services.measurer.ig_token_watchdog
+    wd_rc=$?
+    set -e
+    if [[ $wd_rc -eq 2 ]]; then
+        echo "[measurer] ig-token-watchdog NEEDS OPERATOR (exit 2 — token missing or unrefreshable)" >&2
+    elif [[ $wd_rc -ne 0 ]]; then
+        echo "[measurer] ig-token-watchdog unexpected exit $wd_rc" >&2
+    fi
+    # Re-source so a just-refreshed token reaches scheduler_cli.
+    if [[ -f "$SECRETS_FILE" ]]; then
+        # shellcheck disable=SC1090
+        set -a
+        source "$SECRETS_FILE"
+        set +a
+    fi
+fi
+
 exec env PYTHONPATH=. "$VENV_PY" -m "$MODULE" "$@"


### PR DESCRIPTION
Completes the two code legs Task-30 (#2342) left unarmed, token-tolerant: the ONLY remaining gesture is the token itself.

**Live probe first** (this session): Mini's `INSTAGRAM_ACCESS_TOKEN` answers **190 OAuthException on BOTH** `graph.instagram.com` and `graph.facebook.com` — the ledger's re-probe-on-instagram-host hypothesis is REFUTED; that token is dead, full stop. First valid token remains operator[secret].

- `scripts/wr2-cron-wrapper.sh` (repo-tracked, the measurer plist on Pro executes it from the checkout — no HOME-fork): measurer-only pre-step runs `ig_token_watchdog` each 6h tick per runbook §Arming; exit 2 → standing `NEEDS OPERATOR` log line, sweep never blocked; secrets re-sourced so a refreshed token reaches `scheduler_cli` same-tick
- `scheduler_cli`: `MetaGraphSampler` built with the Graph host matching the token family (default **instagram** — the live Fly token's family; the facebook default answers 190 for it). `IG_GRAPH_BASE` override wins.
- Tests: guilt + innocence, measurer battery 80 green. docs_sync folded in-commit.

Arming proof once merged + Pro pulls: a `[measurer] ig-token-watchdog NEEDS OPERATOR` line in the measurer log each tick (the standing alarm until the token lands), flipping to a watchdog provenance line the day it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)