### PR TITLE
fix(wr2): queue pull merges instead of clobbering app-side publish transitions

### DIFF
--- a/infra/launchagents/wrappers/wr2-queue-pull.sh
+++ b/infra/launchagents/wrappers/wr2-queue-pull.sh
@@ -35,6 +35,13 @@ ONCE=0
 
 ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
+# Merge helper (split-brain cure, 2026-07-13): the WR2 Control app writes
+# publish transitions LOCALLY (QueueWriter.markPublished) and a blind replace
+# reverted them within one poll cycle. The merge keeps Pro as SSOT but protects
+# local published* entries and emits a push-back list replayed into Pro via the
+# canonical wr2_queue_writer.py (exact ref-code, IG-URL validated writer-side).
+MERGE_PY="$HOME/Desktop/nuzantara/scripts/wr2_queue_pull_merge.py"
+
 while true; do
   for f in human-review-queue.json queue-archive.json; do
     # PID-suffixed tmp: a WR2_PULL_CHECKSUM one-shot may run while the daemon
@@ -43,7 +50,38 @@ while true; do
     if ssh -o ConnectTimeout=10 -o BatchMode=yes pro "cat '$SRC_DIR/$f'" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
       # valida JSON prima di sostituire (mai clobberare con spazzatura)
       if python3 -c "import json,sys; json.load(open('$tmp'))" 2>/dev/null; then
-        if ! cmp -s "$tmp" "$DEST_DIR/$f" 2>/dev/null; then
+        if [ "$f" = "human-review-queue.json" ] && [ -f "$MERGE_PY" ] && [ -f "$DEST_DIR/$f" ]; then
+          # merge instead of clobber: local publish transitions survive the pull
+          report=$(python3 "$MERGE_PY" --remote "$tmp" --local "$DEST_DIR/$f" --out "$tmp.merged" 2>>"$LOG")
+          if [ -s "$tmp.merged" ]; then
+            if ! cmp -s "$tmp.merged" "$DEST_DIR/$f" 2>/dev/null; then
+              mv "$tmp.merged" "$DEST_DIR/$f"
+              echo "[$(ts)] merged $f ($report)" >> "$LOG"
+            else
+              rm -f "$tmp.merged"
+            fi
+            rm -f "$tmp"
+            # push protected publish transitions back to Pro (SSOT) via the
+            # canonical writer. ref/url are shell-safe by construction (strict
+            # regexes in the merge script); the writer re-validates on Pro.
+            echo "$report" | python3 -c 'import json,sys
+try: rep=json.load(sys.stdin)
+except Exception: rep={}
+for e in rep.get("push_back", []): print(e["ref_code"], e["ig_url"])' | \
+            while read -r ref url; do
+              if ssh -o ConnectTimeout=10 -o BatchMode=yes pro \
+                   "cd ~/Desktop/nuzantara && python3 scripts/wr2_queue_writer.py mark-published '$ref' '$url'" >>"$LOG" 2>&1; then
+                echo "[$(ts)] pushed back $ref -> published on Pro" >> "$LOG"
+              else
+                echo "[$(ts)] WARN push-back $ref failed (state not publishable on Pro yet?)" >> "$LOG"
+              fi
+            done
+          else
+            # merge failed → keep old local file, log, fall back to nothing
+            echo "[$(ts)] WARN merge of $f produced no output, kept old" >> "$LOG"
+            rm -f "$tmp" "$tmp.merged"
+          fi
+        elif ! cmp -s "$tmp" "$DEST_DIR/$f" 2>/dev/null; then
           mv "$tmp" "$DEST_DIR/$f"
           echo "[$(ts)] updated $f" >> "$LOG"
         else

--- a/scripts/tests/test_wr2_queue_pull_merge.py
+++ b/scripts/tests/test_wr2_queue_pull_merge.py
@@ -1,0 +1,127 @@
+"""Tests for wr2_queue_pull_merge (split-brain cure, 2026-07-13).
+
+Guilt: a local publish transition survives the pull and lands in push_back.
+Innocence: remote (Pro SSOT) wins everywhere else; junk/garbage never rides
+the push-back channel into an ssh command line.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load(name: str) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec and spec.loader, f"cannot load {name}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+merge = _load("wr2_queue_pull_merge")
+
+
+def _remote_drafted(eid: str = "carousel_1") -> dict:
+    return {"id": eid, "topic": "ITAS vs KITAS", "state": "drafted",
+            "slide_count": 9, "instagram_post_url": None}
+
+
+def _local_published(eid: str = "carousel_1", url: str = "https://www.instagram.com/p/AbC123/") -> dict:
+    return {"id": eid, "topic": "ITAS vs KITAS", "state": "published",
+            "slide_count": 9, "instagram_post_url": url,
+            "instagram_published_at": "2026-07-13T02:00:00Z",
+            "state_history": [{"state": "published", "by": "wr2-control-app"}]}
+
+
+# ── guilt: publish transitions survive the pull ──────────────────────────────
+
+def test_local_publish_survives_remote_drafted():
+    merged, report = merge.merge_queues([_remote_drafted()], [_local_published()])
+    assert merged[0]["state"] == "published"
+    assert merged[0]["instagram_post_url"] == "https://www.instagram.com/p/AbC123/"
+    assert report["protected"] == ["carousel_1"]
+    assert report["push_back"][0]["ref_code"].startswith("WR2-")
+    assert report["push_back"][0]["ig_url"] == "https://www.instagram.com/p/AbC123/"
+
+
+def test_local_only_entry_is_kept_but_never_pushed_back():
+    extra = _local_published("app_upload_1")
+    merged, report = merge.merge_queues([_remote_drafted()], [_local_published(), extra])
+    assert [e["id"] for e in merged] == ["carousel_1", "app_upload_1"]
+    assert report["local_only"] == ["app_upload_1"]
+    assert [e["id"] for e in report["push_back"]] == ["carousel_1"]
+
+
+# ── innocence: remote wins everywhere else ───────────────────────────────────
+
+def test_remote_wins_when_local_not_published():
+    loc = _remote_drafted()
+    loc["state"] = "reviewed"
+    rem = _remote_drafted()
+    rem["state"] = "drafted_needs_human_edit"
+    merged, report = merge.merge_queues([rem], [loc])
+    assert merged[0]["state"] == "drafted_needs_human_edit"
+    assert report["protected"] == [] and report["push_back"] == []
+
+
+def test_remote_published_stays_remote_verbatim():
+    rem = _local_published()  # remote already published
+    loc = _local_published(url="https://www.instagram.com/p/OTHER/")
+    merged, report = merge.merge_queues([rem], [loc])
+    assert merged[0]["instagram_post_url"] == "https://www.instagram.com/p/AbC123/"
+    assert report["protected"] == []
+
+
+def test_bogus_ig_url_never_rides_push_back():
+    loc = _local_published(url="https://evil'; rm -rf /'")
+    merged, report = merge.merge_queues([_remote_drafted()], [loc])
+    # entry is still protected locally (merge), but excluded from the ssh channel
+    assert merged[0]["state"] == "published"
+    assert report["protected"] == ["carousel_1"]
+    assert report["push_back"] == []
+
+
+def test_old_schema_item_id_matching():
+    rem = {"item_id": "old_1", "topic": "X", "state": "applied_ready_for_damar"}
+    loc = {"item_id": "old_1", "topic": "X", "state": "published",
+           "instagram_post_url": "https://www.instagram.com/reel/Zz9/"}
+    merged, report = merge.merge_queues([rem], [loc])
+    assert merged[0]["state"] == "published"
+    assert report["push_back"][0]["ig_url"].endswith("/Zz9/")
+
+
+def test_cli_writes_merged_and_prints_report(tmp_path):
+    r = tmp_path / "r.json"; r.write_text(json.dumps([_remote_drafted()]))
+    l = tmp_path / "l.json"; l.write_text(json.dumps([_local_published()]))
+    out = tmp_path / "m.json"
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = merge.main(["--remote", str(r), "--local", str(l), "--out", str(out)])
+    assert rc == 0
+    assert json.loads(out.read_text())[0]["state"] == "published"
+    rep = json.loads(buf.getvalue())
+    assert rep["protected"] == ["carousel_1"]
+
+
+def test_cli_corrupt_local_falls_back_to_remote(tmp_path):
+    r = tmp_path / "r.json"; r.write_text(json.dumps([_remote_drafted()]))
+    l = tmp_path / "l.json"; l.write_text("{not json")
+    out = tmp_path / "m.json"
+    import io
+    from contextlib import redirect_stdout
+    with redirect_stdout(io.StringIO()):
+        rc = merge.main(["--remote", str(r), "--local", str(l), "--out", str(out)])
+    assert rc == 0
+    assert json.loads(out.read_text())[0]["state"] == "drafted"

--- a/scripts/wr2_queue_pull_merge.py
+++ b/scripts/wr2_queue_pull_merge.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""WR2 queue pull-merge — protect app-side publish transitions from the Pro pull.
+
+WHY (Armate recon 2026-07-13, adversarially CONFIRMED): the WR2 Control app on
+M5 writes publish transitions LOCALLY (QueueWriter.markPublished sets
+state="published" in the local human-review-queue.json), while
+wr2-queue-pull.sh blind-replaces that file with Pro's copy every 300s — the
+operator marks a carousel published and minutes later it silently reverts to
+"drafted" (split-brain, scar family #10). Pro stays the SSOT; this module makes
+the pull a MERGE instead of a clobber, and emits the push-back list so the
+wrapper can replay the protected transitions into Pro via the canonical
+scripts/wr2_queue_writer.py mark-published (exact ref-code, validated IG URL).
+
+Merge semantics (monotone state lattice — remote wins EXCEPT):
+  - entry in both, LOCAL state is published* and REMOTE state is not:
+    remote entry is kept as base, local publish fields overlaid
+    (state, instagram_post_url, instagram_published_at, engagement_metrics,
+    damar_action, damar_action_at, state_history) → also listed in push_back
+    when its ref-code/IG-URL are shell-safe by construction (strict regex).
+  - entry only in LOCAL (app-created: upload/auto-enqueue): kept, appended
+    after remote entries, reported as local_only. Never pushed back.
+  - everything else: remote wins verbatim.
+
+CLI (used by infra/launchagents/wrappers/wr2-queue-pull.sh):
+    python3 scripts/wr2_queue_pull_merge.py --remote R.json --local L.json --out M.json
+prints a JSON report to stdout:
+    {"protected": [ids], "local_only": [ids],
+     "push_back": [{"id":..., "ref_code": "WR2-XXXXXX", "ig_url": ...}]}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from wr2_queue_writer import (  # noqa: E402 — same scripts/ dir
+    PUBLISHED_STATES,
+    compute_ref_code,
+    item_id_of,
+    validate_ig_url,
+)
+
+_REF_CODE_SAFE_RE = re.compile(r"^WR2-[0-9A-F]{6}$")
+
+# Local fields overlaid onto the remote entry when protecting a publish.
+_PUBLISH_FIELDS = (
+    "state",
+    "instagram_post_url",
+    "instagram_published_at",
+    "engagement_metrics",
+    "damar_action",
+    "damar_action_at",
+    "state_history",
+)
+
+
+def _is_published(entry: dict[str, Any]) -> bool:
+    return entry.get("state") in PUBLISHED_STATES
+
+
+def merge_queues(
+    remote: list[dict[str, Any]], local: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Merge Pro's queue (remote, SSOT) with the M5 local copy.
+
+    Returns (merged, report). Pure — no I/O.
+    """
+    local_by_id: dict[str, dict[str, Any]] = {}
+    for e in local:
+        if isinstance(e, dict):
+            eid = item_id_of(e)
+            if eid:
+                local_by_id[eid] = e
+
+    merged: list[dict[str, Any]] = []
+    protected: list[str] = []
+    push_back: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for r in remote:
+        if not isinstance(r, dict):
+            merged.append(r)
+            continue
+        rid = item_id_of(r)
+        if rid:
+            seen.add(rid)
+        loc = local_by_id.get(rid) if rid else None
+        if loc is not None and _is_published(loc) and not _is_published(r):
+            out = dict(r)
+            for k in _PUBLISH_FIELDS:
+                if k in loc:
+                    out[k] = loc[k]
+            merged.append(out)
+            protected.append(str(rid))
+            ref = compute_ref_code(str(rid))
+            url = str(loc.get("instagram_post_url") or "")
+            # shell-safe by construction: strict ref shape + strict IG URL —
+            # the wrapper interpolates these into an ssh command line.
+            if _REF_CODE_SAFE_RE.match(ref) and validate_ig_url(url):
+                push_back.append({"id": str(rid), "ref_code": ref, "ig_url": url.strip()})
+        else:
+            merged.append(r)
+
+    local_only: list[str] = []
+    for e in local:
+        if not isinstance(e, dict):
+            continue
+        eid = item_id_of(e)
+        if eid and eid not in seen:
+            merged.append(e)
+            local_only.append(str(eid))
+
+    return merged, {
+        "protected": protected,
+        "local_only": local_only,
+        "push_back": push_back,
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--remote", type=Path, required=True, help="freshly pulled Pro queue")
+    ap.add_argument("--local", type=Path, required=True, help="current local queue")
+    ap.add_argument("--out", type=Path, required=True, help="merged output path")
+    args = ap.parse_args(argv)
+
+    remote = json.loads(args.remote.read_text(encoding="utf-8"))
+    if not isinstance(remote, list):
+        print(json.dumps({"error": "remote queue is not a list"}))
+        return 2
+    local: list = []
+    if args.local.exists():
+        try:
+            parsed = json.loads(args.local.read_text(encoding="utf-8"))
+            if isinstance(parsed, list):
+                local = parsed
+        except Exception:  # noqa: BLE001 — corrupt local: remote wins wholesale
+            local = []
+
+    merged, report = merge_queues(remote, local)
+    args.out.write_text(
+        json.dumps(merged, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> Rebuild of #2364 — closed in the PII-purge queue drain (2026-07-13 00:57Z); branch rebuilt onto the rewritten history.

## What
Split-brain cure (scar family #10) for the WR2 review queue: the Control app writes `markPublished` into the **local** M5 `human-review-queue.json` (`QueueWriter.swift:73`), while `wr2-queue-pull.sh` replaced that file wholesale from Pro every 300s — silently reverting published carousels to drafted in the app.

- **New `scripts/wr2_queue_pull_merge.py`**: `merge_queues(remote, local)` — remote (Pro SSOT) wins everywhere, EXCEPT local `published`/`published_with_edits` transitions overlay their publish fields when remote isn't published yet; local-only entries kept locally, never pushed back.
- **Push-back channel**: protected transitions pushed back to Pro via the existing `wr2_queue_writer.py mark-published <ref> <url>` CLI over ssh — Pro converges instead of re-clobbering forever. Gated by strict ref-code regex + `validate_ig_url`; anything malformed never reaches the ssh command line.
- **`infra/launchagents/wrappers/wr2-queue-pull.sh`**: merge branch for the queue file (falls back to plain replace if merge script absent), push-back loop after a protected pull.

## Tests
`scripts/tests/test_wr2_queue_pull_merge.py` — 8 tests, guilt + innocence (incl. bogus IG URL never rides push-back; corrupt-local fallback).

## Arming note
The live M5 copy `~/bin/wr2-queue-pull.sh` is a declared HOME pair — re-sync after merge (tracked in modus PENDING-ARMS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)