### PR TITLE
fix(infra): exempt broker's node_modules symlink from the WIP guard

### DIFF
--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -59,7 +59,14 @@ WORKTREES_DIR = REPO_ROOT / ".worktrees"
 TASK_METADATA_FILENAME = ".agent-task.json"
 # Broker-generated files that must NOT count as user WIP (otherwise every
 # freshly created worktree reads as dirty and is never cleanup-eligible).
-BROKER_GENERATED_FILES = frozenset({".agent-task.json", ".env.worktree"})
+# `node_modules` is a SYMLINK_TARGETS entry: .gitignore has `node_modules/`
+# (directory-only pattern) but no bare `node_modules` rule, and git's ignore
+# matching does not treat a symlink-to-a-directory as a directory — so the
+# broker's own symlink shows up as `?? node_modules` in every worktree,
+# permanently tripping the WIP guard and making `--cleanup` a no-op forever
+# (found live: 3 worktrees sat 5-14h past a 60min TTL, silently "WARN"-skipped
+# by the daily cron every run). Reproduced empirically before this fix.
+BROKER_GENERATED_FILES = frozenset({".agent-task.json", ".env.worktree", "node_modules"})
 LSOF_FALLBACK_PATHS: tuple[Path, ...] = (Path("/usr/sbin/lsof"),)
 
 # Lanes documented in CLAUDE.md + research synthesis.

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -153,6 +153,60 @@ def test_create_symlinks_only_when_targets_exist(fake_repo):
     assert not (out / "node_modules").exists()
 
 
+def test_node_modules_symlink_not_counted_as_wip(fake_repo):
+    """node_modules is a SYMLINK_TARGETS entry; .gitignore's `node_modules/`
+    (directory-only pattern) does not match a symlink-to-a-directory, so the
+    broker's own symlink read as `?? node_modules` (untracked) in every
+    worktree — permanently tripping the WIP guard. Regression for a bug found
+    live: 3 worktrees sat 5-14h past a 60min TTL because `--cleanup` always
+    saw "WIP" and WARN-skipped (exit 0, never loud) every single run.
+    """
+    mod, repo = fake_repo
+    (repo / "node_modules").mkdir()
+    (repo / "node_modules" / "placeholder.txt").write_text("x\n")
+    (repo / ".gitignore").write_text("node_modules/\n")
+    _commit_in_worktree(repo, mod, ".gitignore", "add gitignore")
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True, capture_output=True)
+
+    wt = mod.cmd_create("wr2", "nm-innocent", ttl_minutes=5)
+    assert (wt / "node_modules").is_symlink()
+    assert mod._worktree_has_wip(wt) is False
+
+
+def test_node_modules_symlink_does_not_mask_real_wip(fake_repo):
+    """Guilt case: the node_modules exemption must not swallow genuine WIP."""
+    mod, repo = fake_repo
+    (repo / "node_modules").mkdir()
+    (repo / "node_modules" / "placeholder.txt").write_text("x\n")
+    (repo / ".gitignore").write_text("node_modules/\n")
+    _commit_in_worktree(repo, mod, ".gitignore", "add gitignore")
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True, capture_output=True)
+
+    wt = mod.cmd_create("wr2", "nm-guilty", ttl_minutes=5)
+    (wt / "real_work.py").write_text("# uncommitted\n")
+    assert mod._worktree_has_wip(wt) is True
+
+
+def test_cleanup_reaps_expired_worktree_with_only_node_modules_symlink(fake_repo, capsys):
+    """Integration-level: --cleanup must actually reap a TTL-expired worktree
+    whose only 'dirty' porcelain entry is the broker's own node_modules
+    symlink — this is the exact class that silently accumulated orphans."""
+    mod, repo = fake_repo
+    (repo / "node_modules").mkdir()
+    (repo / ".gitignore").write_text("node_modules/\n")
+    _commit_in_worktree(repo, mod, ".gitignore", "add gitignore")
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True, capture_output=True)
+
+    wt = mod.cmd_create("wr2", "nm-cleanup", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    _backdate_worktree_mtime(wt, minutes=120)
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert not wt.exists()
+    out = capsys.readouterr().out
+    assert "nm-cleanup" in out
+
+
 def test_create_rejects_unknown_lane_by_default(fake_repo):
     mod, _ = fake_repo
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary
- `scripts/agent_start.py`'s worktree broker symlinks `node_modules` into every worktree (`SYMLINK_TARGETS`), but `.gitignore` only has the directory-only pattern `node_modules/` — git's ignore matching does not treat a symlink-to-a-directory as a directory, so the symlink always reads as `?? node_modules` (untracked) in `git status --porcelain`.
- `_worktree_has_wip()` counted this as WIP, permanently tripping the WIP-safe guard on **every** worktree the broker ever creates — `--cleanup` (the daily TTL reaper cron) has effectively been a no-op since the symlink target was introduced, silently WARN-skipping and exiting 0.
- Found live on Mini this healer tick: 3 orphan worktrees sat 5-14h past their 60min TTL. Root-caused, reproduced empirically on a fresh worktree (`?? node_modules` vs the correctly-ignored `!! .env.worktree`), reaped the 3 live orphans by hand (`--release --force`, each independently content-on-main verified per W88 discipline before reaping), then fixed the classifier so it self-heals going forward.
- Fix: add `node_modules` to the existing `BROKER_GENERATED_FILES` exemption set (same treatment already given to `.agent-task.json` / `.env.worktree`).

## Test plan
- [x] `python -m pytest scripts/tests/test_agent_start.py -q` — 43 passed (was 40; 3 new)
- [x] New test (innocence): node_modules symlink alone → `_worktree_has_wip()` is `False`
- [x] New test (guilt): node_modules symlink + a genuine untracked file → still `True` (exemption doesn't mask real WIP)
- [x] New test (integration): `--cleanup` actually reaps a TTL-expired worktree whose only porcelain entry is the symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)