### PR TITLE
fix(blog): add MobileNav to BlogLayout slotAfter

### DIFF
--- a/apps/mouth/src/app/(blog)/layout.tsx
+++ b/apps/mouth/src/app/(blog)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { NavShell, BZLogo } from "@balizero/core";
+import { MobileNav } from "@/app/v2/_components/MobileNav";
 import { ZantaraFAB } from "@/app/v2/_components/ZantaraFAB";
 import { Footer } from "@/app/v2/_components/Footer";
 import { I18nProvider } from "@/i18n";
@@ -36,6 +37,7 @@ export default function BlogLayout({ children }: { children: ReactNode }) {
             </Link>
           }
           items={BLOG_NAV_ITEMS}
+          slotAfter={<MobileNav items={BLOG_NAV_ITEMS} />}
           actions={
             <Link
               href="/contact"


### PR DESCRIPTION
## Insight
All (blog)/* routes — /business/[slug], /taxes/[slug], /visa/[slug], /news, /team, /services — were missing mobile navigation entirely. Users on mobile had no hamburger menu across the entire blog route group.

## Studio
Single layout file edit: apps/mouth/src/app/(blog)/layout.tsx. Added MobileNav import and slotAfter prop to NavShell. No logic change, no state, no analytics impact. 2-line diff.

## Source
Phase 1 read-only audit of (blog)/layout.tsx — compared against working pattern in /v2/news/page.tsx and /v2/page.tsx which both pass slotAfter={<MobileNav items={NAV_ITEMS} />} correctly.

## Methodology
Grepped MobileNav usage across all NavShell instances in apps/mouth/src/app/. Confirmed (blog)/layout.tsx was the only NavShell consumer missing slotAfter. Verified WhatsApp CTAs in ArticleClient.tsx already use WhatsAppLeadButton correctly — no Golden Rule violation found.

## Raw Observations
- apps/mouth/src/app/(blog)/layout.tsx: NavShell had logo + items + actions, slotAfter absent
- apps/mouth/src/app/v2/page.tsx: slotAfter present and correct
- apps/mouth/src/app/v2/news/page.tsx: slotAfter present and correct
- pt-14 on main wrapper: correct, matches NavShell h-14

## Reasoning Path
MobileNav renders as null on md+ via md:hidden on the trigger button. Zero visual impact on desktop. On mobile it renders the hamburger trigger opening the full-screen nav overlay. Self-contained client component — no shared state, no analytics events.

## Risk
Low. Worst case: MobileNav does not render if NavShell ignores unknown props — but slotAfter is confirmed in NavShell prop interface and used identically in two other layouts.

## Implication
Mobile users on all blog article pages now have working navigation. Reduces dead-end bounce on mobile across /business/*, /taxes/*, /visa/*, /news, /team, /services.

## Recommendation
Self-merge after all Required CI checks green. VERDE zone — apps/mouth only.

## Next Action
Monitor mobile bounce rate on /business/* and /taxes/* in GA4 post-deploy (filter: hostname = balizero.com, device category = mobile).