### PR TITLE
feat(kbli): add onboarding persona doors above trust bar

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -5,6 +5,7 @@ import { getSections } from "@/lib/kbli-data";
 import { KBLISearch } from "@/components/kbli/KBLISearch";
 import { KBLISectorGrid } from "@/components/kbli/KBLISectorGrid";
 import { ZantaraChat } from "@/components/kbli/ZantaraChat";
+import { KBLIPersonaDoors } from "@/components/kbli/KBLIPersonaDoors";
 import { FunnelFrame } from "@balizero/core";
 
 export const metadata: Metadata = {
@@ -177,6 +178,8 @@ export default async function KBLIHomePage({
             </div>
           </div>
         </div>
+
+        <KBLIPersonaDoors />
 
         {/* ── TRUST BAR ── */}
         <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-6 -mt-4">

--- a/apps/mouth/src/components/kbli/KBLIPersonaDoors.tsx
+++ b/apps/mouth/src/components/kbli/KBLIPersonaDoors.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Building2, Globe, Search } from "lucide-react";
+import { trackFunnelEvent } from "@balizero/core/analytics";
+import { getOrCreateSessionId } from "@balizero/core/auth";
+
+type KBLIDoor = "start-business" | "pma-investor" | "find-code";
+
+const DOORS = [
+  {
+    id: "start-business" as KBLIDoor,
+    icon: Building2,
+    label: "Starting a Business",
+    subtext:
+      "Find your KBLI code, check license requirements, understand risk class.",
+  },
+  {
+    id: "pma-investor" as KBLIDoor,
+    icon: Globe,
+    label: "Foreign Investor (PMA)",
+    subtext:
+      "See which sectors allow 100% foreign ownership and which are restricted.",
+  },
+  {
+    id: "find-code" as KBLIDoor,
+    icon: Search,
+    label: "I Have a Specific Code",
+    subtext: "Know what you need — go straight to the search.",
+  },
+] as const;
+
+function handleDoorClick(door: KBLIDoor): void {
+  void trackFunnelEvent("persona_door_click", {
+    sessionId: getOrCreateSessionId(),
+    payload: { door, source: "kbli_hero" },
+  });
+}
+
+export function KBLIPersonaDoors() {
+  return (
+    <div className="mt-8 mb-0">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500 mb-4">
+        Where do you want to begin?
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {DOORS.map(({ id, icon: Icon, label, subtext }) => (
+          <a
+            key={id}
+            href="#kbli-search"
+            onClick={() => handleDoorClick(id)}
+            className="block p-4 rounded-xl transition-all duration-200 cursor-pointer no-underline bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.07)] hover:bg-[rgba(255,255,255,0.06)] hover:border-[rgba(255,255,255,0.12)]"
+          >
+            <Icon size={18} strokeWidth={1.8} className="text-zinc-400 mb-2" />
+            <div className="text-[14px] font-semibold text-zinc-100 mb-1">
+              {label}
+            </div>
+            <div className="text-[12px] leading-relaxed text-zinc-500">
+              {subtext}
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 1. Insight
/kbli had no onboarding layer. Users arriving cold had no signal about
where to begin — the page opened directly into a visual hero and search
with zero intent disambiguation. 82% bounce rate (GSC/GA4 baseline,
pre-July) is consistent with this UX gap.

## 2. Studio
Added a thin "Where do you want to begin?" section between the hero and
trust bar. Three persona doors as ghost anchor links: Starting a Business,
Foreign Investor (PMA), I Have a Specific Code. Each anchors to
#kbli-search and fires persona_door_click analytics on click.

## 3. Source
- GSC keyword mining 2026-07-14: 15 KBLI pages pos <6, CTR 0%
- KBLI bounce rate pattern (GA4, post 21 May 2026 baseline)
- MYTHOS Stage A §B: KBLI channel approved for bounded UX additions

## 4. Methodology
- Verified persona_door_click in FUNNEL_EVENTS (funnel-view.ts:50) before writing any code
- Chose trackFunnelEvent() directly over trackPersonaDoor() to avoid extending PersonaDoor union type — zero ripple on homepage analytics
- Client boundary isolated to KBLIPersonaDoors.tsx only; page.tsx remains Server Component
- CSS hover via Tailwind classes only — works on touch devices, zero JS event listeners, better INP

## 5. Raw Observations
- page.tsx: +2 lines (import + JSX). No other modifications.
- KBLIPersonaDoors.tsx: +68 lines, new file.
- TSC --noEmit: clean (full workspace)
- No package-lock.json staged
- KBLI scope boundary respected: no DB, API, or searchParams changes

## 6. Reasoning Path
PersonaDoor type extension was considered and rejected. Extending the
existing union type would create downstream mismatches with homepage
FunnelFeature. Calling trackFunnelEvent("persona_door_click", {door, source})
directly is type-safe (payload is Record<string, unknown>) and leaves the
existing type contract untouched.

## 7. Risk
Low. VERDE zone, no backend surface touched. persona_door_click already in
backend allowlist (Antonello merged PR #1280) — parity test will not fail.
If #kbli-search anchor ID is missing, clicks scroll to top harmlessly.

## 8. Implication
Gives Google a stronger content signal on /kbli (additional semantic
structure). Gives first-time users a decision scaffold before reaching
search — expected to reduce bounce for cold-intent traffic.

## 9. Recommendation
Merge after CI green. Monitor persona_door_click in GA4 breakdown by door
param for 7 days post-deploy.

## 10. Next Action
- [ ] Verify #kbli-search anchor ID exists in KBLISearch component
- [ ] Monitor persona_door_click breakdown by door (GA4, 7-day window)
- [ ] KBLI title/meta rewrite batch (separate PR, ref: gsc-keyword-mining-2026-07-14.md)
