### PR TITLE
fix(nuzantara-mcp): secrets-file fallback for API key + boot-triage ledger

### DIFF
--- a/apps/nuzantara-mcp/nuzantara_mcp/server.py
+++ b/apps/nuzantara-mcp/nuzantara_mcp/server.py
@@ -9,6 +9,7 @@ Transport: stdio (for Claude Code / Cowork / OpenClaw local integration)
 
 import logging
 import os
+from pathlib import Path
 from typing import Any, Optional
 
 import httpx
@@ -19,9 +20,35 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
 logger = logging.getLogger("nuzantara-mcp")
 
 # --- Configuration ---
+def _secret_from_env_file(name: str, path: Optional[Path] = None) -> str:
+    """Fallback for secrets the invoker's environment does not carry.
+
+    launchd/mcporter/interactive-session contexts often spawn this server
+    without NUZANTARA_API_KEY exported — after the default-deny authz gate
+    (#2304) every authed tool then 401s. The fleet keeps secrets in
+    ~/.nuzantara-secrets.env (0600); read the var by NAME, never log values.
+    Missing file or var -> "" (identical to pre-fallback behavior, fail-safe).
+    """
+    env_file = path if path is not None else Path.home() / ".nuzantara-secrets.env"
+    try:
+        for raw in env_file.read_text().splitlines():
+            line = raw.strip()
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            if line.startswith(f"{name}="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return ""
+
+
 BACKEND_URL = os.getenv("NUZANTARA_BACKEND_URL", "https://nuzantara-rag.fly.dev")
-API_KEY = os.getenv("NUZANTARA_API_KEY", "")
-ADMIN_API_KEY = os.getenv("NUZANTARA_ADMIN_API_KEY") or os.getenv("ADMIN_API_KEY", "")
+API_KEY = os.getenv("NUZANTARA_API_KEY", "") or _secret_from_env_file("NUZANTARA_API_KEY")
+ADMIN_API_KEY = (
+    os.getenv("NUZANTARA_ADMIN_API_KEY")
+    or os.getenv("ADMIN_API_KEY", "")
+    or _secret_from_env_file("NUZANTARA_ADMIN_API_KEY")
+)
 TIMEOUT = int(os.getenv("NUZANTARA_TIMEOUT", "30"))
 LONG_TIMEOUT = int(os.getenv("NUZANTARA_LONG_TIMEOUT", "120"))
 

--- a/apps/nuzantara-mcp/tests/test_http_helpers.py
+++ b/apps/nuzantara-mcp/tests/test_http_helpers.py
@@ -108,3 +108,34 @@ async def test_call_safe_returns_error_on_connection_error() -> None:
     assert result["error"] is True
     assert result["status"] == 0
     assert "Connection error" in result["detail"]
+
+
+def test_secret_from_env_file_reads_named_var(tmp_path) -> None:
+    """Fallback reads the exact var from a secrets env file (export-prefixed too)."""
+    from nuzantara_mcp.server import _secret_from_env_file
+
+    env_file = tmp_path / "secrets.env"
+    env_file.write_text(
+        "# comment\n"
+        "export OTHER_KEY=zzz\n"
+        'NUZANTARA_API_KEY="file-key"\n'
+    )
+
+    assert _secret_from_env_file("NUZANTARA_API_KEY", env_file) == "file-key"
+
+
+def test_secret_from_env_file_name_is_anchored(tmp_path) -> None:
+    """A var whose name merely prefixes the requested one must not match (family #3)."""
+    from nuzantara_mcp.server import _secret_from_env_file
+
+    env_file = tmp_path / "secrets.env"
+    env_file.write_text("NUZANTARA_API_KEY_OLD=stale\n")
+
+    assert _secret_from_env_file("NUZANTARA_API_KEY", env_file) == ""
+
+
+def test_secret_from_env_file_missing_file_is_empty(tmp_path) -> None:
+    """Absent/unreadable file -> '' (fail-safe: identical to no fallback)."""
+    from nuzantara_mcp.server import _secret_from_env_file
+
+    assert _secret_from_env_file("NUZANTARA_API_KEY", tmp_path / "absent.env") == ""


### PR DESCRIPTION
Boot-triage 2026-07-14, lane 2.

**Fix.** Post-#2304 (default-deny authz), every authed nuzantara-mcp tool returns 401 when the invoker environment lacks `NUZANTARA_API_KEY` — live evidence: the openclaw guardian-board runs degraded since 07-12 with all 5 `crm_guardian_*` tools failing, and this session's own MCP seat got instant 401s. `server.py` now falls back to reading the key by NAME from `~/.nuzantara-secrets.env` (0600): missing file/var keeps pre-fallback behavior exactly (fail-safe). 3 new guilt/innocence tests (named-var read incl. `export` prefix, name anchoring against prefix vars, absent file). 25/25 suite green; stripped-env import probe on Pro shows API_KEY non-empty without printing it.

**Ledger.** 7 PENDING-ARMS lines from today's boot triage: W84 TCC-dead launchd class on Pro (4 jobs, trampoline sweep pending), launchagent-state-bridge KeepAlive red-lie (2 false-sick daemons), garuda streams Mini/Pro split-brain + scorer lag 1048, nextdns tamper watcher starved on missing secrets (operator[secret]), 04:02 regulatory-delta toucher watch, the MCP 401 line itself (cured here, natural proof at next 08:30 board fire), PENDING-ALIGN:M5 (sshd TCC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)