### PR TITLE
fix(organism): drop retired Canva labels from launchagent-state-bridge

### DIFF
--- a/scripts/launchagent-state-bridge.py
+++ b/scripts/launchagent-state-bridge.py
@@ -298,16 +298,10 @@ BRIDGED_LABELS: tuple[BridgedLaunchAgent, ...] = (
         organ_id="pro.wa_mirror_strategic_recap",
         daemon=False,
     ),
-    BridgedLaunchAgent(
-        label="com.balizero.wr2.canva-gc.weekly",
-        organ_id="wr2.canva_gc_weekly",
-        daemon=False,
-    ),
-    BridgedLaunchAgent(
-        label="com.balizero.wr2.canva-lease-watchdog",
-        organ_id="wr2.canva_lease_watchdog_launchd",
-        daemon=False,
-    ),
+    # wr2.canva_gc_weekly + wr2.canva_lease_watchdog_launchd REMOVED 2026-07-14:
+    # Canva render lane retired 2026-07-13 (#2396 — plists deleted from repo,
+    # booted out on Pro). Bridging them wrote a perpetual false "label not
+    # loaded" failed sidecar for organs that are retired by design.
     BridgedLaunchAgent(
         label="com.balizero.wr2.daily-metrics",
         organ_id="wr2.daily_metrics",


### PR DESCRIPTION
Boot-triage 2026-07-14, lane 3.

The Canva render lane was retired 2026-07-13 (#2396: plists deleted from repo + booted out on Pro), but `scripts/launchagent-state-bridge.py` keeps the two labels in its hardcoded list and rewrites a perpetual `label not loaded → status=failed` sidecar every tick — ghost-sidecar class, exactly the `pro.wa_viewer` removal precedent (2026-07-02). Delisted with a retirement comment; host-guard suite 8/8 green.

The third canva sidecar (`wr2.canva_token_watchdog_launchd`) was organ-written, not bridge-written — removed on Pro directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)