### PR TITLE
fix(eventbus): devils-advocate budget guard resolves scripts/ on HOME-fork deployments

### DIFF
--- a/infra/eventbus/devils_advocate_runner.py
+++ b/infra/eventbus/devils_advocate_runner.py
@@ -502,13 +502,25 @@ def call_deepseek(target_text: str, target_path: str, brand_ctx: str,
         raise RuntimeError("DEEPSEEK_API_KEY missing")
 
     # Smart-spend 2026-07-14: consult the cost breaker before spending, ledger
-    # after. Best-effort import (the HOME-fork copy on Pro may not sit next to
-    # a scripts/ dir) — a missing guard logs a warning and proceeds; a firing
-    # guard raises, which is the runner's normal fail-visible path.
+    # after. Best-effort import (the HOME-fork copy on Pro lives at
+    # ~/scripts/eventbus/ with no repo scripts/ two levels up, so we also try
+    # NUZANTARA_REPO_ROOT and the known checkout locations) — a missing guard
+    # logs a warning and proceeds; a firing guard raises, which is the
+    # runner's normal fail-visible path.
     _dsc = None
     try:
         import sys as _sys
-        _scripts_dir = str(Path(__file__).resolve().parents[2] / "scripts")
+        _env_root = os.environ.get("NUZANTARA_REPO_ROOT")
+        _candidates = [
+            Path(__file__).resolve().parents[2] / "scripts",
+            *([Path(_env_root) / "scripts"] if _env_root else []),
+            Path.home() / "Desktop" / "nuzantara-deploy" / "scripts",
+            Path.home() / "Desktop" / "nuzantara" / "scripts",
+        ]
+        _scripts_dir = next(
+            (str(c) for c in _candidates if (c / "deepseek_client.py").is_file()),
+            str(_candidates[0]),
+        )
         if _scripts_dir not in _sys.path:
             _sys.path.insert(0, _scripts_dir)
         import deepseek_client as _dsc  # noqa: PLC0415


### PR DESCRIPTION
## Why

Follow-up to #2413. The live eventbus on Pro runs from `~/scripts/eventbus/` (HOME deployment): there `Path(__file__).parents[2]/scripts` resolves to `~/scripts`, which has no `deepseek_client.py` — so the freshly-shipped budget guard would silently degrade to unguarded on the exact machine that runs devils-advocate.

## What

The guard import now tries, in order: repo-relative → `$NUZANTARA_REPO_ROOT/scripts` → the Pro deploy worktree (`~/Desktop/nuzantara-deploy/scripts`) → the checkout (`~/Desktop/nuzantara/scripts`), picking the first that actually contains `deepseek_client.py`. Behavior unchanged on repo-resident copies; still best-effort (missing guard = warning + proceed, firing guard = raise).

## Proof

- Simulated the HOME layout (file under `<home>/scripts/eventbus/`): resolver picks the checkout and `import deepseek_client` succeeds.
- Pre-push gate: full suite passed.
- Post-merge plan: cp repo→`~/scripts/eventbus/` on Pro (currently byte-identical pre-patch, no unpromoted work) + live import probe from the HOME location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)