### PR TITLE
feat(wr2): IG discovery step — hand-published posts enter the queue

### DIFF
--- a/scripts/test_wr2_ig_discovery.py
+++ b/scripts/test_wr2_ig_discovery.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import wr2_ig_discovery as discovery
+
+# scar W96: tests never touch the real queue path — every fixture below is a
+# plain in-memory list/dict, no disk I/O beyond what pytest's tmp_path gives us
+# (and this module doesn't even need tmp_path since the tested helpers are pure).
+
+
+# ── word_tokens ──────────────────────────────────────────────────────────
+
+
+def test_word_tokens_drops_short_words() -> None:
+    assert discovery.word_tokens("a to KBLI visa update now") == {"kbli", "visa", "update"}
+
+
+def test_word_tokens_empty_string() -> None:
+    assert discovery.word_tokens("") == set()
+    assert discovery.word_tokens(None) == set()  # type: ignore[arg-type]
+
+
+def test_word_tokens_lowercases() -> None:
+    assert discovery.word_tokens("KITAS Rules Update") == {"kitas", "rules", "update"}
+
+
+# ── jaccard_similarity ──────────────────────────────────────────────────
+
+
+def test_jaccard_identical_sets_is_one() -> None:
+    s = {"visa", "kitas", "rules"}
+    assert discovery.jaccard_similarity(s, s) == 1.0
+
+
+def test_jaccard_disjoint_sets_is_zero() -> None:
+    assert discovery.jaccard_similarity({"visa"}, {"tax"}) == 0.0
+
+
+def test_jaccard_both_empty_is_zero_not_matched() -> None:
+    assert discovery.jaccard_similarity(set(), set()) == 0.0
+
+
+def test_jaccard_partial_overlap() -> None:
+    a = {"visa", "kitas", "rules", "update"}
+    b = {"visa", "kitas", "guide", "price"}
+    # intersection = {visa, kitas} = 2, union = 6
+    assert discovery.jaccard_similarity(a, b) == 2 / 6
+
+
+# ── caption_first_line ──────────────────────────────────────────────────
+
+
+def test_caption_first_line_splits_on_blank_line() -> None:
+    caption = "New KITAS rules 2026\n\nRead the full breakdown in our bio link."
+    assert discovery.caption_first_line(caption) == "New KITAS rules 2026"
+
+
+def test_caption_first_line_none_is_empty() -> None:
+    assert discovery.caption_first_line(None) == ""
+
+
+def test_caption_first_line_blank_is_empty() -> None:
+    assert discovery.caption_first_line("   \n\n  ") == ""
+
+
+# ── build_known_shortcodes ───────────────────────────────────────────────
+
+
+def test_build_known_shortcodes_extracts_from_urls() -> None:
+    items = [
+        {"instagram_post_url": "https://www.instagram.com/p/ABC123/"},
+        {"instagram_post_url": "https://www.instagram.com/reel/XYZ789/"},
+        {"topic": "no url here"},
+    ]
+    assert discovery.build_known_shortcodes(items) == {"ABC123", "XYZ789"}
+
+
+def test_build_known_shortcodes_empty_queue() -> None:
+    assert discovery.build_known_shortcodes([]) == set()
+
+
+def test_build_known_shortcodes_ignores_malformed_url() -> None:
+    items = [{"instagram_post_url": "not-a-url"}]
+    assert discovery.build_known_shortcodes(items) == set()
+
+
+# ── parse_ig_timestamp / is_recent ───────────────────────────────────────
+
+
+def test_parse_ig_timestamp_offset_no_colon() -> None:
+    dt = discovery.parse_ig_timestamp("2026-06-01T12:00:00+0000")
+    assert dt is not None
+    assert dt.year == 2026 and dt.month == 6 and dt.day == 1
+
+
+def test_parse_ig_timestamp_none_input() -> None:
+    assert discovery.parse_ig_timestamp(None) is None
+
+
+def test_parse_ig_timestamp_garbage_input() -> None:
+    assert discovery.parse_ig_timestamp("not-a-date") is None
+
+
+def test_is_recent_within_window() -> None:
+    now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    ts = (now - timedelta(days=10)).isoformat()
+    assert discovery.is_recent(ts, max_age_days=90, now=now) is True
+
+
+def test_is_recent_outside_window() -> None:
+    now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    ts = (now - timedelta(days=200)).isoformat()
+    assert discovery.is_recent(ts, max_age_days=90, now=now) is False
+
+
+def test_is_recent_unparseable_is_false() -> None:
+    now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    assert discovery.is_recent("garbage", max_age_days=90, now=now) is False
+
+
+# ── filter_new_media ─────────────────────────────────────────────────────
+
+
+def test_filter_new_media_excludes_known_shortcode() -> None:
+    now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    media = [
+        {
+            "permalink": "https://www.instagram.com/p/KNOWN1/",
+            "timestamp": (now - timedelta(days=1)).isoformat(),
+        }
+    ]
+    out = discovery.filter_new_media(media, known_shortcodes={"KNOWN1"}, max_age_days=90, now=now)
+    assert out == []
+
+
+def test_filter_new_media_excludes_stale_media() -> None:
+    now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    media = [
+        {
+            "permalink": "https://www.instagram.com/p/NEW1/",
+            "timestamp": (now - timedelta(days=365)).isoformat(),
+        }
+    ]
+    out = discovery.filter_new_media(media, known_shortcodes=set(), max_age_days=90, now=now)
+    assert out == []
+
+
+def test_filter_new_media_keeps_fresh_unknown_media() -> None:
+    now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    media = [
+        {
+            "permalink": "https://www.instagram.com/p/NEW2/",
+            "timestamp": (now - timedelta(days=5)).isoformat(),
+        }
+    ]
+    out = discovery.filter_new_media(media, known_shortcodes=set(), max_age_days=90, now=now)
+    assert len(out) == 1
+    assert out[0]["permalink"].endswith("/p/NEW2/")
+
+
+def test_filter_new_media_skips_media_without_permalink() -> None:
+    now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    media = [{"timestamp": now.isoformat()}]
+    out = discovery.filter_new_media(media, known_shortcodes=set(), max_age_days=90, now=now)
+    assert out == []
+
+
+# ── find_fuzzy_match ─────────────────────────────────────────────────────
+
+
+def test_find_fuzzy_match_hits_above_threshold() -> None:
+    queue = [
+        {"item_id": "wr2-1", "topic": "KBLI 2025 conversion rules for PT PMA", "state": "drafted"},
+        {"item_id": "wr2-2", "topic": "Tax deadline reminder Q2", "state": "reviewed"},
+    ]
+    match = discovery.find_fuzzy_match("KBLI 2025 conversion rules explained", queue)
+    assert match is not None
+    assert match["item_id"] == "wr2-1"
+
+
+def test_find_fuzzy_match_no_hit_below_threshold() -> None:
+    queue = [{"item_id": "wr2-1", "topic": "Completely unrelated subject matter", "state": "drafted"}]
+    match = discovery.find_fuzzy_match("KBLI 2025 conversion rules", queue)
+    assert match is None
+
+
+def test_find_fuzzy_match_ignores_out_of_flight_states() -> None:
+    queue = [
+        {"item_id": "wr2-1", "topic": "KBLI 2025 conversion rules for PT PMA", "state": "published"},
+    ]
+    match = discovery.find_fuzzy_match("KBLI 2025 conversion rules explained", queue)
+    assert match is None
+
+
+def test_find_fuzzy_match_empty_caption_line_no_match() -> None:
+    queue = [{"item_id": "wr2-1", "topic": "KBLI 2025 conversion rules", "state": "drafted"}]
+    assert discovery.find_fuzzy_match("", queue) is None
+
+
+def test_find_fuzzy_match_empty_queue_no_match() -> None:
+    assert discovery.find_fuzzy_match("KBLI 2025 conversion rules", []) is None

--- a/scripts/wr2-ig-metrics-scrape.sh
+++ b/scripts/wr2-ig-metrics-scrape.sh
@@ -35,4 +35,17 @@ INSTAGRAM_ACCESS_TOKEN="$TOK" "$PY" "$REPO/scripts/wr2_ig_metrics_scraper.py" \
   --max-age-days 3 >> "$LOG" 2>&1
 rc=$?
 echo "[$(ts)] scrape done rc=$rc" >> "$LOG"
+
+# Discovery step: find posts published BY HAND on @balizero0 that never went
+# through the WR2 pipeline (queue stays blind to them otherwise, scar #2).
+# Non-fatal on failure — the nightly metrics refresh above is the load-bearing
+# job, discovery is a best-effort add-on. MATCH-PENDING lines (fuzzy match to
+# an in-flight queue item) land in the same $LOG for a human to resolve via
+# `wr2_queue_writer.py mark-published`.
+echo "[$(ts)] discovery start" >> "$LOG"
+INSTAGRAM_ACCESS_TOKEN="$TOK" "$PY" "$REPO/scripts/wr2_ig_discovery.py" \
+  --token-env INSTAGRAM_ACCESS_TOKEN --max-age-days 90 >> "$LOG" 2>&1 \
+  || echo "[$(ts)] discovery failed rc=$?" >> "$LOG"
+echo "[$(ts)] discovery done" >> "$LOG"
+
 exit $rc

--- a/scripts/wr2_ig_discovery.py
+++ b/scripts/wr2_ig_discovery.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""WR2 IG discovery — find posts published BY HAND that never entered the queue.
+
+The nightly `wr2_ig_metrics_scraper.py` only refreshes metrics for entries
+already sitting in `human-review-queue.json`. Posts published directly on
+Instagram @balizero0 (bypassing the WR2 pipeline, e.g. by Zero) never get a
+queue entry, so the "published carousels" view goes silently blind for them
+— discovered 2026-07 after ~a month of hand-published posts with zero
+tracking (scar #2 "esiste != armato": the queue LOOKED complete).
+
+The Playwright-based harvester (`wr2_ig_profile_harvester.py`) is login-walled
+against Instagram's web UI and collected 0 URLs in practice. This script uses
+the SAME Instagram Graph API token the metrics scraper already has (it can
+LIST the account's own media deterministically, no browser/login needed).
+
+For each fetched media item not already known to the queue (by IG shortcode)
+and within `--max-age-days`:
+  - if its caption fuzzy-matches (word-token Jaccard) a queue item still in
+    flight (drafted/reviewed/applied_ready_for_damar/approved), this is
+    PROBABLY that item published early/out-of-band — print a
+    `MATCH-PENDING` line. This is a SIGNAL only: this script never marks an
+    item published on a fuzzy match (mark-published is exact-ref-code only,
+    see `wr2_queue_writer.py`). A human/operator session resolves it with
+    `wr2_queue_writer.py mark-published <ref_code> <url>`.
+  - otherwise it is a genuinely-external post: register it via STRATO 3
+    `ingest_external_post` (same path the profile harvester uses), which
+    mints a scraper-consumable `published` item.
+
+Fail-visible (scar #2, W84 blind-scan guard): an account with a real posting
+history returning 0 media from the API is broken auth, not "clean" — exit 2.
+
+Token: read from the env var NAMED by --token-env (default
+INSTAGRAM_ACCESS_TOKEN). The token itself is NEVER printed or logged; any
+exception text is redacted before being written to stdout/stderr.
+
+CLI:
+    wr2_ig_discovery.py --token-env INSTAGRAM_ACCESS_TOKEN [--queue PATH]
+                         [--dry-run] [--max-age-days 90]
+
+Exit codes:
+    0  clean run, nothing pending
+    1  run OK but MATCH-PENDING item(s) need human disambiguation
+    2  API/HTTP error, or 0 media returned (blind-scan guard)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# ── Import STRATO 3 (sibling module in scripts/) — same pattern as
+# wr2_ig_profile_harvester.py: register in sys.modules BEFORE exec_module,
+# python 3.14's dataclass machinery needs the module findable by name. ──────
+_THIS_DIR = Path(__file__).resolve().parent
+_WRITER_PATH = _THIS_DIR / "wr2_queue_writer.py"
+_spec = importlib.util.spec_from_file_location("wr2_queue_writer", _WRITER_PATH)
+_qw = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _qw
+_spec.loader.exec_module(_qw)
+
+GRAPH = "https://graph.instagram.com"
+DEFAULT_MAX_AGE_DAYS = 90
+DEFAULT_LIMIT = 50
+MATCH_STATES = frozenset({"drafted", "reviewed", "applied_ready_for_damar", "approved"})
+JACCARD_THRESHOLD = 0.4
+MIN_WORD_LEN = 4  # "words >3 chars"
+
+_WORD_RE = re.compile(r"[A-Za-z0-9']+")
+
+
+# ── SSL / HTTP (mirrors wr2_ig_metrics_scraper.py) ──────────────────────────
+
+
+def _ssl_ctx() -> ssl.SSLContext:
+    """Robust CA resolution — the macOS framework Python often lacks system CAs
+    (SSL: CERTIFICATE_VERIFY_FAILED, verified on M5). Try, in order: certifi's
+    bundle, the OpenSSL system bundles curl uses, then the plain default."""
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    for ca in ("/etc/ssl/cert.pem",
+               "/opt/homebrew/etc/openssl@3/cert.pem",
+               "/opt/homebrew/etc/ca-certificates/cert.pem"):
+        if os.path.exists(ca):
+            try:
+                return ssl.create_default_context(cafile=ca)
+            except Exception:
+                continue
+    return ssl.create_default_context()
+
+
+_SSL = _ssl_ctx()
+
+
+def _get(url: str, timeout: int = 25) -> dict:
+    with urllib.request.urlopen(url, timeout=timeout, context=_SSL) as r:
+        return json.load(r)
+
+
+def _redact(text: str, token: Optional[str]) -> str:
+    """Strip the raw token out of any string before it is printed/logged."""
+    if token and token in text:
+        return text.replace(token, "***REDACTED***")
+    return text
+
+
+# ── Pure helpers (no I/O, unit-tested) ─────────────────────────────────────
+
+
+def word_tokens(text: str) -> set[str]:
+    """Lowercase word tokens of length > 3 chars — the unit the Jaccard match
+    operates on. Deliberately crude (no stemming/stopwords): this is a
+    signaler, not an auto-actuator, so false negatives are safe (they just
+    fall through to a fresh external ingest, never a wrong auto-publish)."""
+    if not text:
+        return set()
+    return {w.lower() for w in _WORD_RE.findall(text) if len(w) > MIN_WORD_LEN - 1}
+
+
+def jaccard_similarity(a: set[str], b: set[str]) -> float:
+    """|intersection| / |union|. 0.0 if both sets are empty (no signal, not a match)."""
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def caption_first_line(caption: Optional[str]) -> str:
+    """First non-empty visual line of an IG caption (captions are usually
+    hook-line + blank line + body)."""
+    if not caption:
+        return ""
+    stripped = caption.strip()
+    if not stripped:
+        return ""
+    return stripped.splitlines()[0].strip()
+
+
+def build_known_shortcodes(queue_items: list[dict[str, Any]]) -> set[str]:
+    """Every IG shortcode already present in the queue (via instagram_post_url)."""
+    known: set[str] = set()
+    for item in queue_items:
+        url = item.get("instagram_post_url")
+        if not url:
+            continue
+        code = _qw.extract_ig_shortcode(url)
+        if code:
+            known.add(code)
+    return known
+
+
+def parse_ig_timestamp(ts: Optional[str]) -> Optional[datetime]:
+    """Parse a Graph API timestamp (ISO-ish, e.g. '2026-06-01T12:34:56+0000')
+    into an aware datetime, or None if unparseable."""
+    if not ts:
+        return None
+    s = ts.strip()
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except Exception:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def is_recent(ts: Optional[str], max_age_days: int, now: datetime) -> bool:
+    """True if `ts` parses and is no older than max_age_days relative to `now`."""
+    dt = parse_ig_timestamp(ts)
+    if dt is None:
+        return False
+    age_days = (now - dt).total_seconds() / 86400.0
+    return age_days <= max_age_days
+
+
+def filter_new_media(
+    media_list: list[dict[str, Any]],
+    known_shortcodes: set[str],
+    max_age_days: int,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    """Media entries whose shortcode is NOT in `known_shortcodes` and whose
+    timestamp is within `max_age_days` of `now`. Order-preserving."""
+    out: list[dict[str, Any]] = []
+    for m in media_list:
+        permalink = m.get("permalink") or ""
+        code = _qw.extract_ig_shortcode(permalink)
+        if not code or code in known_shortcodes:
+            continue
+        if not is_recent(m.get("timestamp"), max_age_days, now):
+            continue
+        out.append(m)
+    return out
+
+
+def find_fuzzy_match(
+    caption_line: str,
+    queue_items: list[dict[str, Any]],
+    states: frozenset[str] = MATCH_STATES,
+    threshold: float = JACCARD_THRESHOLD,
+) -> Optional[dict[str, Any]]:
+    """Best queue item (in an in-flight state) whose topic fuzzy-matches
+    `caption_line` above `threshold`, else None. Ties keep the first (queue
+    order) at the winning score."""
+    cap_tokens = word_tokens(caption_line)
+    if not cap_tokens:
+        return None
+    best: Optional[dict[str, Any]] = None
+    best_score = 0.0
+    for item in queue_items:
+        if item.get("state") not in states:
+            continue
+        topic_tokens = word_tokens(_qw.topic_of(item))
+        score = jaccard_similarity(cap_tokens, topic_tokens)
+        if score >= threshold and score > best_score:
+            best = item
+            best_score = score
+    return best
+
+
+# ── Network I/O ──────────────────────────────────────────────────────────
+
+
+def fetch_all_media(token: str, limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
+    """Fetch the account's own media via Graph API, following ONE
+    `paging.next` page max (so at most 2 pages / ~2*limit items).
+
+    Raises RuntimeError on a hard failure fetching page 1. A page-2 fetch
+    failure is best-effort (we already have page-1 data) and only warns.
+    """
+    url = (
+        f"{GRAPH}/me/media?fields=id,caption,permalink,timestamp,media_type"
+        f"&limit={limit}&access_token={token}"
+    )
+    try:
+        first = _get(url)
+    except urllib.error.HTTPError as e:
+        body = _redact(e.read().decode("utf-8", "ignore")[:200], token)
+        raise RuntimeError(f"IG API HTTP error {e.code}: {body}") from e
+    except Exception as e:
+        raise RuntimeError(f"IG API error: {_redact(str(e), token)}") from e
+
+    media: list[dict[str, Any]] = list(first.get("data", []))
+    next_url = (first.get("paging") or {}).get("next")
+    if next_url:
+        try:
+            second = _get(next_url)
+            media.extend(second.get("data", []))
+        except Exception as e:
+            print(f"[discovery] WARN: paging.next fetch failed: {_redact(str(e), token)}", file=sys.stderr)
+    return media
+
+
+# ── Orchestration ──────────────────────────────────────────────────────────
+
+
+def _resolve_queue_path(arg: Optional[str]) -> Path:
+    if arg:
+        return Path(arg)
+    env = os.environ.get("WR2_QUEUE_PATH")
+    return Path(env) if env else _qw.DEFAULT_QUEUE_PATH
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="WR2 IG discovery — hand-published posts missing from the queue"
+    )
+    p.add_argument(
+        "--token-env",
+        default="INSTAGRAM_ACCESS_TOKEN",
+        help="name of the env var holding the IG access token (default: INSTAGRAM_ACCESS_TOKEN). "
+        "The token value itself is never printed or logged.",
+    )
+    p.add_argument("--queue", help="path to human-review-queue.json (default: env WR2_QUEUE_PATH or standard)")
+    p.add_argument("--dry-run", action="store_true", help="do not mutate the queue; print what would happen")
+    p.add_argument(
+        "--max-age-days",
+        type=int,
+        default=DEFAULT_MAX_AGE_DAYS,
+        help=f"only consider IG media published within this many days (default {DEFAULT_MAX_AGE_DAYS})",
+    )
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    token = os.environ.get(args.token_env)
+    if not token:
+        print(f"ERROR: env var {args.token_env} not set", file=sys.stderr)
+        return 2
+
+    queue_path = _resolve_queue_path(args.queue)
+
+    try:
+        media_list = fetch_all_media(token)
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    fetched = len(media_list)
+    if fetched == 0:
+        # scar W84 blind-scan guard: an account with real posting history
+        # returning 0 media is broken auth, never "clean".
+        print(
+            "ERROR: IG API returned 0 media — treating as broken auth, not a clean "
+            "account (blind-scan guard, scar W84)",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        queue_items = _qw.load_queue(queue_path)
+    except FileNotFoundError:
+        queue_items = []
+
+    known = build_known_shortcodes(queue_items)
+    now = datetime.now(timezone.utc)
+    new_media = filter_new_media(media_list, known, args.max_age_days, now)
+
+    ingested = 0
+    match_pending = 0
+    for m in new_media:
+        permalink = m.get("permalink") or ""
+        cap_line = caption_first_line(m.get("caption"))
+        match = find_fuzzy_match(cap_line, queue_items)
+
+        if match is not None:
+            match_pending += 1
+            iid = _qw.item_id_of(match)
+            ref = _qw.compute_ref_code(iid) if iid else "UNKNOWN"
+            topic = _qw.topic_of(match)
+            print(f"MATCH-PENDING ref={ref} url={permalink} topic={topic}")
+            continue
+
+        shortcode = _qw.extract_ig_shortcode(permalink)
+        topic = cap_line[:60] if cap_line else f"(external IG post {shortcode})"
+        dt = parse_ig_timestamp(m.get("timestamp"))
+        published_at = dt.isoformat() if dt else None
+
+        if args.dry_run:
+            print(f"[dry-run] would ingest url={permalink} topic={topic!r} published_at={published_at}")
+            continue
+
+        res = _qw.ingest_external_post(queue_path, permalink, topic=topic, published_at=published_at)
+        if res.status == "ingested":
+            ingested += 1
+            print(f"INGESTED url={permalink} topic={topic!r}")
+        elif res.status == "already_present":
+            print(f"SKIP (already present) url={permalink}")
+        else:
+            print(f"WARN ingest failed url={permalink} status={res.status} detail={res.detail}", file=sys.stderr)
+
+    print(f"DISCOVERY: fetched={fetched} known={len(known)} ingested={ingested} match_pending={match_pending}")
+
+    if match_pending > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The WR2 app's "published carousels" list went blind for a month: posts published BY HAND on IG @balizero0 never enter `human-review-queue.json`. The nightly scrape only refreshes metrics for entries already in the queue; the one-off IG backfill ran 2026-06-23 and discovery never happened again. Concrete symptom: the Rp2.8T immigration-revenue carousel (IG 2026-07-11) was invisible in the app until manually reconciled today. The Playwright harvester is login-walled (collected 0 URLs); the Graph API token already used by the metrics scraper lists the account's own media deterministically.

## What

- **`scripts/wr2_ig_discovery.py`** — lists `me/media` via the Instagram Graph API (token from `INSTAGRAM_ACCESS_TOKEN`, never logged), builds the known-shortcode set from the queue, then per new post: fuzzy-match (word-token Jaccard ≥0.4) against in-flight queue items → `MATCH-PENDING` signal (never auto-mutates a drafted carousel entry), or `ingest_external_post` for unmatched posts. Fail-visible: exit 2 on API error or 0-media response (blind-scan guard, scar W84), exit 1 on pending matches.
- **`scripts/test_wr2_ig_discovery.py`** — 28 unit tests on pure helpers, tmp-path only (scar W96: tests never touch prod state).
- **`scripts/wr2-ig-metrics-scrape.sh`** — nightly wrapper now runs discovery after the metrics scrape (non-fatal, same log).

## Verification

- `pytest scripts/test_wr2_ig_discovery.py scripts/test_wr2_ig_publish_remote_caption.py -q` → 35 passed
- `py_compile` both scripts, `bash -n` wrapper → OK
- CLI smoke: missing token exits 2

Post-merge arming (tracked): propagate wrapper to the live HOME fork `~/.openclaw/bin/wr2/wr2-ig-metrics-scrape.sh` on Pro (currently byte-identical to repo copy) and declare the pair in `infra/home-fork/declared-pairs.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)