### PR TITLE
chore(home-fork): declare wr2-ig-metrics-scrape.sh pair (Pro LaunchAgent payload)

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Declared HOME-executed script copies and their git-tracked twins (superscar #1 HOME-fork drift). Consumed by scripts/lint_home_fork.py --check (sha256 live vs repo) and --discover (a HOME-executed payload NOT listed here and NOT allow-matched is an UNDECLARED finding). Overlapping SSOT note: scripts/proprioception.py DEFAULT_REGISTRY 'home_fork_scripts' declares its own pairs \u2014 lint_home_fork.py merges them at runtime (best-effort import) so the two lists cannot silently drift; add NEW pairs HERE. Paths use ~ (expanded per-machine: balizero on M5, nuzantara on Pro/Mini). 'machines': m5|pro|mini|all.",
+  "_doc": "Declared HOME-executed script copies and their git-tracked twins (superscar #1 HOME-fork drift). Consumed by scripts/lint_home_fork.py --check (sha256 live vs repo) and --discover (a HOME-executed payload NOT listed here and NOT allow-matched is an UNDECLARED finding). Overlapping SSOT note: scripts/proprioception.py DEFAULT_REGISTRY 'home_fork_scripts' declares its own pairs — lint_home_fork.py merges them at runtime (best-effort import) so the two lists cannot silently drift; add NEW pairs HERE. Paths use ~ (expanded per-machine: balizero on M5, nuzantara on Pro/Mini). 'machines': m5|pro|mini|all.",
   "pairs": [
     {
       "live": "~/.fly/bin/fly_pg_tunnel_supervisor.sh",
@@ -19,7 +19,7 @@
     {
       "live": "~/scripts/regulatory-watcher-run.sh",
       "repo": "infra/launchagents/wrappers/regulatory-watcher-run.sh",
-      "_note": "Pro=active cron (heartbeat pro.regulatory_watcher_daily); M5=dormant aligned copy (workstation, no cron). NOT Mini \u2014 a Mini cron would be active-active split-brain (superscar #10) on the same delta the #2009 lock guards. Was 'all', which made lint --check chase a nonexistent Mini pair (false drift). Verified by content 2026-07-06.",
+      "_note": "Pro=active cron (heartbeat pro.regulatory_watcher_daily); M5=dormant aligned copy (workstation, no cron). NOT Mini — a Mini cron would be active-active split-brain (superscar #10) on the same delta the #2009 lock guards. Was 'all', which made lint --check chase a nonexistent Mini pair (false drift). Verified by content 2026-07-06.",
       "machines": ["pro", "m5"]
     },
     {
@@ -30,13 +30,13 @@
     {
       "live": "~/scripts/codex/nightly-autofix-ci.sh",
       "repo": "scripts/codex/codex-nightly-autofix-ci.sh",
-      "_note": "Hourly codex auto-fix generator (plist com.nuzantara.codex-autofix-ci, StartCalendarInterval Minute=15, via cron-runner.sh). Declared 2026-07-06 together with the recursion-brake fix \u2014 was an UNDECLARED live payload (family #1); basenames differ by history.",
+      "_note": "Hourly codex auto-fix generator (plist com.nuzantara.codex-autofix-ci, StartCalendarInterval Minute=15, via cron-runner.sh). Declared 2026-07-06 together with the recursion-brake fix — was an UNDECLARED live payload (family #1); basenames differ by history.",
       "machines": ["pro"]
     },
     {
       "live": "~/scripts/wr2-ig-metrics-analyst-run.sh",
       "repo": "infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh",
-      "_note": "Promoted to repo canon 2026-07-06 (healer tick) to close the sonnet-5 runtime-proof gap (PENDING-ARMS 2026-07-03): live copy called `claude` directly with no 'used: <tier>' log line. Repo canon adds explicit provenance logging only \u2014 same invocation, same model. Live HOME copy on Pro still needs manual sync (healer is read-only on Pro).",
+      "_note": "Promoted to repo canon 2026-07-06 (healer tick) to close the sonnet-5 runtime-proof gap (PENDING-ARMS 2026-07-03): live copy called `claude` directly with no 'used: <tier>' log line. Repo canon adds explicit provenance logging only — same invocation, same model. Live HOME copy on Pro still needs manual sync (healer is read-only on Pro).",
       "machines": ["pro"]
     },
     {
@@ -229,7 +229,7 @@
     {
       "live": "~/scripts/wr2-contract-test.sh",
       "repo": "infra/launchagents/wrappers/wr2-contract-test.sh",
-      "_note": "W89 class-audit (2026-07-11, PENDING-ARMS ledger ~68): BG-ceiling env + anti-background prompt sentence + provenance log line added. Manual forensic harness, no scheduler \u2014 dormant but was undeclared HOME-only.",
+      "_note": "W89 class-audit (2026-07-11, PENDING-ARMS ledger ~68): BG-ceiling env + anti-background prompt sentence + provenance log line added. Manual forensic harness, no scheduler — dormant but was undeclared HOME-only.",
       "machines": ["pro"]
     },
     {
@@ -241,12 +241,17 @@
     {
       "live": "~/bin/wr2-queue-pull.sh",
       "repo": "infra/launchagents/wrappers/wr2-queue-pull.sh",
-      "_note": "M5 queue/carousel mirror puller (plist com.balizero.wr2.queue-pull; lives in ~/bin per W84 TCC-on-Desktop). Declared 2026-07-13 with the re-render verb PR (WR2_PULL_CHECKSUM one-shot mode) \u2014 was an UNDECLARED live payload (family #1).",
+      "_note": "M5 queue/carousel mirror puller (plist com.balizero.wr2.queue-pull; lives in ~/bin per W84 TCC-on-Desktop). Declared 2026-07-13 with the re-render verb PR (WR2_PULL_CHECKSUM one-shot mode) — was an UNDECLARED live payload (family #1).",
       "machines": ["m5"]
     },
     {
       "live": "~/Library/LaunchAgents/com.nuzantara.intake-worker.plist",
       "repo": "infra/launchagents/com.nuzantara.intake-worker.plist",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/.openclaw/bin/wr2/wr2-ig-metrics-scrape.sh",
+      "repo": "scripts/wr2-ig-metrics-scrape.sh",
       "machines": ["pro"]
     }
   ],


### PR DESCRIPTION
The nightly IG metrics LaunchAgent on Pro executes ~/.openclaw/bin/wr2/
wr2-ig-metrics-scrape.sh, a HOME copy of scripts/wr2-ig-metrics-scrape.sh
(re-aligned byte-identical after #2416 added the discovery step). Undeclared
pairs are invisible to lint_home_fork.py --check (superscar #1).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
