### PR TITLE
fix(whatsapp): arm the guardian on the LIVE init path (scheduler is disabled in prod)

### DIFF
--- a/apps/backend-rag/backend/app/setup/service_initializer.py
+++ b/apps/backend-rag/backend/app/setup/service_initializer.py
@@ -1395,6 +1395,33 @@ async def initialize_services(app: FastAPI) -> None:
         )
         logger.error("❌ Failed to initialize Health Monitor: %s", e)
 
+    # 10d. WhatsApp WABA subscription guardian (live path — the Autonomous
+    # Scheduler above is disabled, so the guardian runs its own loop with the
+    # scheduler's Redis leader lock; idempotent re-arm POST every 6h + inbound
+    # silence receptor. Kill switch: WA_SUBSCRIPTION_GUARDIAN_ENABLED=false.
+    try:
+        from backend.services.misc.whatsapp_subscription_guardian import (
+            start_whatsapp_subscription_guardian_task,
+        )
+
+        wa_guardian_task = start_whatsapp_subscription_guardian_task(
+            db_pool=db_pool,
+            alert_service=alert_service,
+        )
+        app.state.wa_subscription_guardian_task = wa_guardian_task
+        if wa_guardian_task is not None:
+            service_registry.register(
+                "wa_subscription_guardian", ServiceStatus.HEALTHY, critical=False
+            )
+    except Exception as e:
+        service_registry.register(
+            "wa_subscription_guardian",
+            ServiceStatus.DEGRADED,
+            error=str(e),
+            critical=False,
+        )
+        logger.error("❌ Failed to start WhatsApp subscription guardian: %s", e)
+
     # 10c. Olympus DB Guardian
     # Background workers kill switch (2026-04-12 incident): skip Olympus when
     # DISABLE_BACKGROUND_WORKERS=1 — Olympus heartbeat/pulse loops corrupt the

--- a/apps/backend-rag/backend/services/misc/whatsapp_subscription_guardian.py
+++ b/apps/backend-rag/backend/services/misc/whatsapp_subscription_guardian.py
@@ -216,7 +216,29 @@ class WhatsAppSubscriptionGuardian:
 
         result = {"rearm": rearm, "deafness": deafness, "ran_at": now.isoformat()}
         logger.info("[wa-sub-guardian] cycle done: %s", json.dumps(result))
+        await self._persist_state(result)
         return result
+
+    async def _persist_state(self, result: dict[str, Any]) -> None:
+        """Durable receptor (economia-notifiche): Telegram is a best-effort VIEW
+        nobody may be reading — the verdict must also live as disk-state. One
+        row in ``system_settings`` keyed ``wa_subscription_guardian_last``, so
+        any session/monitor can read the last cycle with one SELECT.
+        """
+        if self.db_pool is None:
+            return
+        try:
+            await self.db_pool.execute(
+                """
+                INSERT INTO system_settings (key, value, updated_at)
+                VALUES ('wa_subscription_guardian_last', $1, now())
+                ON CONFLICT (key) DO UPDATE
+                    SET value = EXCLUDED.value, updated_at = now()
+                """,
+                json.dumps(result),
+            )
+        except Exception as e:  # persistence must never kill the cycle
+            logger.warning("[wa-sub-guardian] state persist failed: %s", e)
 
 
 async def _guardian_loop(

--- a/apps/backend-rag/backend/services/misc/whatsapp_subscription_guardian.py
+++ b/apps/backend-rag/backend/services/misc/whatsapp_subscription_guardian.py
@@ -219,6 +219,56 @@ class WhatsAppSubscriptionGuardian:
         return result
 
 
+async def _guardian_loop(
+    guardian: WhatsAppSubscriptionGuardian, interval_seconds: int
+) -> None:
+    """Standalone loop for the LIVE init path (the AutonomousScheduler is
+    disabled in prod — service_initializer §10, "omnichannel stabilization" —
+    so registering there alone would be an unarmed arm, scar W81).
+
+    Leader election reuses the scheduler's own Redis lock key, so if the
+    scheduler is ever re-enabled the two paths dedupe instead of double-running.
+    """
+    from backend.services.misc.autonomous_scheduler import _acquire_task_lock
+
+    await asyncio.sleep(30)  # let the app finish booting
+    while True:
+        try:
+            if await _acquire_task_lock("wa_subscription_guardian", interval_seconds):
+                await guardian.run_cycle()
+            else:
+                logger.debug("[wa-sub-guardian] another worker holds the lock")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # the loop must survive anything
+            logger.error("[wa-sub-guardian] cycle crashed: %s", e)
+        await asyncio.sleep(interval_seconds)
+
+
+def start_whatsapp_subscription_guardian_task(
+    db_pool: Any = None,
+    alert_service: Any = None,
+    interval_seconds: int = 21600,
+) -> asyncio.Task | None:
+    """Spawn the guardian loop on the running event loop (kill-switch aware)."""
+    if os.environ.get("WA_SUBSCRIPTION_GUARDIAN_ENABLED", "true").lower() in {
+        "false",
+        "0",
+        "no",
+    }:
+        logger.info("[wa-sub-guardian] disabled via WA_SUBSCRIPTION_GUARDIAN_ENABLED")
+        return None
+    guardian = WhatsAppSubscriptionGuardian(db_pool=db_pool, alert_service=alert_service)
+    task = asyncio.get_event_loop().create_task(
+        _guardian_loop(guardian, interval_seconds), name="wa_subscription_guardian"
+    )
+    logger.info(
+        "✅ WhatsApp subscription guardian loop started (%dh interval)",
+        interval_seconds // 3600,
+    )
+    return task
+
+
 def register_whatsapp_subscription_guardian(
     scheduler: Any,
     db_pool: Any = None,

--- a/apps/backend-rag/backend/tests/services/misc/test_whatsapp_subscription_guardian.py
+++ b/apps/backend-rag/backend/tests/services/misc/test_whatsapp_subscription_guardian.py
@@ -354,3 +354,52 @@ class TestLiveLoopStarter:
             await mod._guardian_loop(FakeGuardian(), 21600)
 
         assert cycles == []
+
+
+class TestStatePersistence:
+    """Telegram is a view nobody may read (economia-notifiche) — the cycle
+    verdict must land in system_settings as durable disk-state."""
+
+    @pytest.mark.asyncio
+    async def test_cycle_persists_verdict_to_system_settings(self):
+        recent = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        pool = MagicMock()
+        pool.fetchrow = AsyncMock(return_value={"last_inbound": recent})
+        pool.execute = AsyncMock()
+        g = _guardian(db_pool=pool)
+        g._client = MagicMock(is_closed=False)
+        g._client.post = AsyncMock(return_value=_mock_response())
+
+        await g.run_cycle()
+
+        sql, payload = pool.execute.await_args.args
+        assert "wa_subscription_guardian_last" in sql
+        import json as _json
+
+        stored = _json.loads(payload)
+        assert stored["rearm"]["ok"] is True
+        assert stored["deafness"]["deaf"] is False
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_never_kills_cycle(self):
+        recent = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        pool = MagicMock()
+        pool.fetchrow = AsyncMock(return_value={"last_inbound": recent})
+        pool.execute = AsyncMock(side_effect=RuntimeError("db down"))
+        g = _guardian(db_pool=pool)
+        g._client = MagicMock(is_closed=False)
+        g._client.post = AsyncMock(return_value=_mock_response())
+
+        result = await g.run_cycle()
+
+        assert result["rearm"]["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_pool_skips_persistence(self):
+        g = _guardian(db_pool=None)
+        g._client = MagicMock(is_closed=False)
+        g._client.post = AsyncMock(return_value=_mock_response())
+
+        result = await g.run_cycle()
+
+        assert result["rearm"]["ok"] is True

--- a/apps/backend-rag/backend/tests/services/misc/test_whatsapp_subscription_guardian.py
+++ b/apps/backend-rag/backend/tests/services/misc/test_whatsapp_subscription_guardian.py
@@ -8,6 +8,7 @@ alert-dedup latch that keeps a long silence from spamming every 6h cycle.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -272,3 +273,84 @@ class TestRegistration:
 
         assert guardian is None
         scheduler.register_task.assert_not_called()
+
+
+class TestLiveLoopStarter:
+    """The scheduler registration alone is an unarmed arm (W81: the
+    AutonomousScheduler is disabled in prod) — the live path is the loop."""
+
+    @pytest.mark.asyncio
+    async def test_starts_named_task(self):
+        from backend.services.misc.whatsapp_subscription_guardian import (
+            start_whatsapp_subscription_guardian_task,
+        )
+
+        task = start_whatsapp_subscription_guardian_task(interval_seconds=21600)
+
+        assert task is not None
+        assert task.get_name() == "wa_subscription_guardian"
+        task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_kill_switch_returns_none(self, monkeypatch):
+        from backend.services.misc.whatsapp_subscription_guardian import (
+            start_whatsapp_subscription_guardian_task,
+        )
+
+        monkeypatch.setenv("WA_SUBSCRIPTION_GUARDIAN_ENABLED", "false")
+
+        assert start_whatsapp_subscription_guardian_task() is None
+
+    @pytest.mark.asyncio
+    async def test_loop_respects_leader_lock(self, monkeypatch):
+        from backend.services.misc import whatsapp_subscription_guardian as mod
+
+        cycles = []
+
+        class FakeGuardian:
+            async def run_cycle(self):
+                cycles.append(1)
+
+        async def no_sleep(_):
+            if len(cycles) >= 1 or no_sleep.calls >= 3:
+                raise asyncio.CancelledError
+            no_sleep.calls += 1
+
+        no_sleep.calls = 0
+        monkeypatch.setattr(mod.asyncio, "sleep", no_sleep)
+        monkeypatch.setattr(
+            "backend.services.misc.autonomous_scheduler._acquire_task_lock",
+            AsyncMock(return_value=True),
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await mod._guardian_loop(FakeGuardian(), 21600)
+
+        assert cycles == [1]
+
+    @pytest.mark.asyncio
+    async def test_loop_skips_cycle_when_lock_denied(self, monkeypatch):
+        from backend.services.misc import whatsapp_subscription_guardian as mod
+
+        cycles = []
+
+        class FakeGuardian:
+            async def run_cycle(self):
+                cycles.append(1)
+
+        async def no_sleep(_):
+            if no_sleep.calls >= 2:
+                raise asyncio.CancelledError
+            no_sleep.calls += 1
+
+        no_sleep.calls = 0
+        monkeypatch.setattr(mod.asyncio, "sleep", no_sleep)
+        monkeypatch.setattr(
+            "backend.services.misc.autonomous_scheduler._acquire_task_lock",
+            AsyncMock(return_value=False),
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await mod._guardian_loop(FakeGuardian(), 21600)
+
+        assert cycles == []


### PR DESCRIPTION
## Summary
- Post-deploy live probe of #2415 caught a W81 (esiste≠armato): the guardian was registered on the `AutonomousScheduler`, but `create_and_start_scheduler` is only reachable from `_init_background_services`, which is **commented out in prod** ("omnichannel stabilization") — the engine never starts.
- Fix: standalone asyncio loop started from the LIVE init section (§10d, next to Health Monitor / Olympus). It reuses the scheduler's own Redis leader-lock key (`nuzantara:scheduler:lock:wa_subscription_guardian`), so if the scheduler is ever re-enabled the two paths dedupe instead of double-running.
- Kill switch unchanged (`WA_SUBSCRIPTION_GUARDIAN_ENABLED=false`).

## Test plan
- [x] 20/20 tests green (+4: named task spawn, kill switch, leader-lock honored, lock-denied skips cycle)
- [x] import-chain smoke
- [ ] post-merge live proof: Redis lock key exists with ~6h TTL + `cycle done` in fly logs + startup line `guardian loop started`

🤖 Generated with [Claude Code](https://claude.com/claude-code)