### PR TITLE
fix(wr2-renderer): quality wave — Art 14.1 swipe indicator, dark-status WCAG, vertical centering

### DIFF
--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -217,6 +217,25 @@ def _normalize_skeleton(html: str) -> str:
     return html
 
 
+def _inject_swipe_indicator(html: str, index: int, total: int) -> str:
+    """Article 14.1 (APPROVED 2026-05-12): slides 2..N-1 MUST carry a
+    `.swipe-indicator` (yellow dot, bottom-right; CSS lives in _base.css).
+    No layout skeleton ships the element, so every carousel rendered without
+    this injection violated 14.1 — the critic soft-flagged it on EVERY run
+    (systemic composer gap, closed 2026-07-14). Cover and closer excluded.
+    Idempotent: skeletons that grow their own indicator are left alone.
+    """
+    if index <= 1 or index >= total:
+        return html
+    if "swipe-indicator" in html:
+        return html
+    return html.replace(
+        "</body>",
+        '<div class="swipe-indicator" data-zone-type="ui"></div>\n</body>',
+        1,
+    )
+
+
 def _hero_bg_to_img(html: str, hero_filename: str) -> str:
     """Rewrite a CSS background-image hero into a real <img> for decode-gating.
 
@@ -1516,6 +1535,7 @@ async def compose_carousel(
                 family=plan.family,
             )
             html = _apply_levers_to_html(html, plan.slide)  # designer-loop levers
+            html = _inject_swipe_indicator(html, plan.index, total)
 
             html_path = slides_dir / f"{plan.index:02d}.html"
             html_path.write_text(html, encoding="utf-8")
@@ -1586,6 +1606,7 @@ async def materialize_slide_html(
         family=family,
     )
     html = _apply_levers_to_html(html, slide)
+    html = _inject_swipe_indicator(html, index, total)
 
     html_path = slides_dir / f"{index:02d}.html"
     html_path.write_text(html, encoding="utf-8")

--- a/scripts/wr2_html_renderer/tests/test_swipe_indicator.py
+++ b/scripts/wr2_html_renderer/tests/test_swipe_indicator.py
@@ -1,0 +1,38 @@
+"""Article 14.1 swipe-indicator injection (systemic composer gap, closed 2026-07-14).
+
+The constitution (14.1, APPROVED 2026-05-12) requires a `.swipe-indicator` on
+slides 2..N-1; the CSS has lived in layouts/_base.css since then, but no layout
+skeleton ships the element and the composer never injected it — the critic
+soft-flagged the absence on every single carousel run.
+"""
+
+from wr2_html_renderer.composer import _inject_swipe_indicator
+
+HTML = "<html><head></head><body><div>content</div></body></html>"
+
+
+class TestSwipeIndicator:
+    def test_inner_slides_get_the_dot(self):
+        for idx in (2, 5, 8):
+            out = _inject_swipe_indicator(HTML, idx, 9)
+            assert out.count('class="swipe-indicator"') == 1, idx
+
+    def test_cover_excluded(self):
+        assert "swipe-indicator" not in _inject_swipe_indicator(HTML, 1, 9)
+
+    def test_closer_excluded(self):
+        assert "swipe-indicator" not in _inject_swipe_indicator(HTML, 9, 9)
+
+    def test_two_slide_carousel_has_none(self):
+        assert "swipe-indicator" not in _inject_swipe_indicator(HTML, 1, 2)
+        assert "swipe-indicator" not in _inject_swipe_indicator(HTML, 2, 2)
+
+    def test_idempotent_on_skeleton_owned_indicator(self):
+        """Innocence: a skeleton that already carries its own indicator is left alone."""
+        own = HTML.replace("<div>content</div>", '<div class="swipe-indicator"></div>')
+        out = _inject_swipe_indicator(own, 3, 9)
+        assert out.count("swipe-indicator") == 1
+
+    def test_injected_before_body_close(self):
+        out = _inject_swipe_indicator(HTML, 4, 9)
+        assert out.index("swipe-indicator") < out.index("</body>")

--- a/skills/bali-zero-brand/layouts/dark-status-list.md
+++ b/skills/bali-zero-brand/layouts/dark-status-list.md
@@ -11,67 +11,93 @@
 ## Parameters
 
 ```yaml
-heading: string  # e.g. "FACTS (SOURCED) VS OUR TAKE"
-items:  # 3-6 items
+heading: string # e.g. "FACTS (SOURCED) VS OUR TAKE"
+items: # 3-6 items
   - label: string
     value: string
-    status: enum [neutral, critical, positive]  # neutral=white, critical=red, positive=yellow
+    status: enum [neutral, critical, positive] # neutral=white, critical=white value + red left-bar, positive=yellow
 ```
 
 ## HTML/CSS skeleton
 
 ```html
 <!doctype html>
-<html><head>
-<link rel="stylesheet" href="../_base.css">
-<style>
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap');
-body {
-  padding: 80px var(--spacing-edge-margin) 180px var(--spacing-edge-margin);
-  display: flex; flex-direction: column;
-}
-.heading {
-  font-weight: var(--font-weight-extrabold);
-  font-size: 56px; line-height: var(--line-height-tight);
-  letter-spacing: var(--letter-spacing-title);
-  color: var(--color-text-white);
-  text-transform: uppercase; margin-bottom: var(--spacing-edge-margin);
-}
-.items {
-  display: flex; flex-direction: column; gap: 32px;
-}
-.item {
-  display: flex; flex-direction: column; gap: 8px;
-  border-left: 4px solid rgba(255,255,255,0.2); padding-left: 20px;
-}
-.label {
-  font-weight: var(--font-weight-bold);
-  font-size: 24px; letter-spacing: 0.04em;
-  color: rgba(255,255,255,0.6); text-transform: uppercase;
-}
-.value {
-  font-weight: var(--font-weight-extrabold);
-  font-size: 40px; line-height: 1.15;
-  letter-spacing: var(--letter-spacing-title); text-transform: uppercase;
-}
-.status-neutral .value { color: var(--color-text-white); }
-.status-critical .value { color: var(--color-status-red); }
-.status-critical .item { border-left-color: var(--color-status-red); }
-.status-positive .value { color: var(--color-accent-yellow); }
-.status-positive .item { border-left-color: var(--color-accent-yellow); }
-</style></head>
-<body>
-  <div class="heading" data-zone-type="text">{{heading}}</div>
-  <div class="items" data-zone-type="text">
-    {{#each items}}
-    <div class="item status-{{status}}">
-      <div class="label">{{label}}</div>
-      <div class="value">{{value}}</div>
+<html>
+  <head>
+    <link rel="stylesheet" href="../_base.css" />
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&display=swap");
+      body {
+        padding: 80px var(--spacing-edge-margin) 180px
+          var(--spacing-edge-margin);
+        display: flex;
+        flex-direction: column;
+      }
+      .heading {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 56px;
+        line-height: var(--line-height-tight);
+        letter-spacing: var(--letter-spacing-title);
+        color: var(--color-text-white);
+        text-transform: uppercase;
+        margin-bottom: var(--spacing-edge-margin);
+      }
+      .items {
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
+      .item {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        border-left: 4px solid rgba(255, 255, 255, 0.2);
+        padding-left: 20px;
+      }
+      .label {
+        font-weight: var(--font-weight-bold);
+        font-size: 24px;
+        letter-spacing: 0.04em;
+        color: rgba(255, 255, 255, 0.6);
+        text-transform: uppercase;
+      }
+      .value {
+        font-weight: var(--font-weight-extrabold);
+        font-size: 40px;
+        line-height: 1.15;
+        letter-spacing: var(--letter-spacing-title);
+        text-transform: uppercase;
+      }
+      .status-neutral .value {
+        color: var(--color-text-white);
+      }
+      .status-critical .value {
+        color: var(--color-text-white);
+      } /* WCAG fix 2026-07-14: red text on antracite = 1.87:1 (fail) — the red ALARM lives on the border line, per Art 14.4 */
+      .status-critical .item {
+        border-left-color: var(--color-status-red);
+      }
+      .status-positive .value {
+        color: var(--color-accent-yellow);
+      }
+      .status-positive .item {
+        border-left-color: var(--color-accent-yellow);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="heading" data-zone-type="text">{{heading}}</div>
+    <div class="items" data-zone-type="text">
+      {{#each items}}
+      <div class="item status-{{status}}">
+        <div class="label">{{label}}</div>
+        <div class="value">{{value}}</div>
+      </div>
+      {{/each}}
     </div>
-    {{/each}}
-  </div>
-  <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
-</body></html>
+    <div class="logo" data-zone-type="logo">3 ALI ZERO</div>
+  </body>
+</html>
 ```
 
 ## Example data

--- a/skills/bali-zero-brand/layouts/numbered-forces-list.md
+++ b/skills/bali-zero-brand/layouts/numbered-forces-list.md
@@ -44,6 +44,10 @@ items: # 2-4 items
           var(--spacing-edge-margin);
         display: flex;
         flex-direction: column;
+        /* 2026-07-14: center the block vertically — with 3 forces the content
+           filled ~45% of the canvas top-anchored (top-heavy void, critic soft
+           flag on every render). Padding still reserves logo/indicator zones. */
+        justify-content: center;
       }
       .numeral-row {
         display: flex;

--- a/skills/bali-zero-brand/layouts/stat-card-hero.md
+++ b/skills/bali-zero-brand/layouts/stat-card-hero.md
@@ -43,6 +43,9 @@ chart:
           var(--spacing-edge-margin);
         display: flex;
         flex-direction: column;
+        /* 2026-07-14: center the stack vertically — heading+chart+body filled
+           ~50% of the canvas top-anchored (top-heavy void, critic soft flag). */
+        justify-content: center;
       }
       .top-rule {
         width: 90px;


### PR DESCRIPTION
Closes three systemic gaps the critic soft-flagged on every carousel run:

1. Swipe indicator (Art 14.1, APPROVED 2026-05-12): the CSS has lived in
   layouts/_base.css since May but no skeleton ships the element and the
   composer never injected it — every carousel violated 14.1. New
   _inject_swipe_indicator() wired in BOTH composition paths
   (compose_carousel + materialize_slide_html): slides 2..N-1 get the yellow
   dot, cover and closer excluded, idempotent on skeleton-owned indicators.

2. dark-status-list WCAG (spec: _proposed-amendment-dark-status-list-wcag.md,
   endorsed by the critic 2026-07-13): .status-critical .value red #C8102E on
   antracite = 1.87:1 (fail) on load-bearing regulatory data. Now white text
   (11:1 AAA) with the red ALARM kept on the left border line (Art 14.4:
   sanctions red for rule-divider lines, not text).

3. Vertical centering for numbered-forces-list and stat-card-hero: content
   filled ~50% of the canvas top-anchored (top-heavy void). justify-content:
   center on the body column.

Cover .regulation-badge NOT added: its absence is by-design (composer strips
it — the yellow kicker already shows the regulation; the tiny badge is
illegible at thumbnail size). The critic's check 5.7 flag is stale vs that
documented decision.

Tests: tests/test_swipe_indicator.py (6 cases: inner/cover/closer/2-slide/
idempotence/placement); full renderer suite 28/28. Live proof: bike carousel
re-rendered with the worktree composer — dot present on 02-08, absent on
01/09, fonts still 100% Montserrat. Centering pixel-proof lands post-merge
(the renderer resolves layouts via the HOME symlink to the MAIN checkout, so
worktree layout edits are not visible to renders until merged).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
