### PR TITLE
fix(kbli): add curated English title for KBLI 47773

### DIFF
--- a/apps/mouth/src/lib/kbli-english.ts
+++ b/apps/mouth/src/lib/kbli-english.ts
@@ -218,6 +218,7 @@ export const ENGLISH_TITLES: Record<string, string> = {
   "47746": "Antique Retail",
   "47751": "Pet Shop",
   "47761": "Florist",
+  "47773": "Chemical Retail",
   "47774": "Essential Oil & Aromatherapy Retail",
   "47781": "Souvenir & Handicraft Retail",
   "47782": "Painting & Art Retail",


### PR DESCRIPTION
1-line curated map addition. KBLI 47773 previously fell back to auto-generated 'Retail Chemicals'. Now shows 'Chemical Retail' consistent with surrounding entries. GSC: 442 impressions pos 4.2 CTR 0% — title fix expected to improve click signal. VERDE, no DB/API changes.