### PR TITLE
fix(self-healing): IPv6 loopback for in-container self-calls (api check + naga)

### DIFF
--- a/apps/backend-rag/backend/self_healing/backend_agent.py
+++ b/apps/backend-rag/backend/self_healing/backend_agent.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 import time
 import traceback
@@ -127,7 +128,14 @@ class BackendSelfHealingAgent:
                 CPUCheck(),
                 MemoryCheck(),
                 DiskCheck(),
-                HTTPAPICheck("http://localhost:8080/health", client=self.http_client),
+                # Default to the IPv6 loopback: in prod uvicorn binds `::` only
+                # and the container's /etc/hosts maps localhost to 127.0.0.1
+                # alone, so "localhost" could never connect (check was red on
+                # every cycle once the agent went live, 2026-07-14).
+                HTTPAPICheck(
+                    os.environ.get("SELF_HEAL_API_URL", "http://[::1]:8080/health"),
+                    client=self.http_client,
+                ),
                 DBCheck(),
                 self._cache_check,
             ],

--- a/apps/backend-rag/backend/services/naga/deps.py
+++ b/apps/backend-rag/backend/services/naga/deps.py
@@ -28,7 +28,10 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _BACKEND_URL_LOCAL = os.getenv("BACKEND_URL", "https://nuzantara-rag.fly.dev")
-_BACKEND_URL_SERVER = "http://localhost:8080"  # Self-call on Fly.io
+# Self-call on Fly.io. IPv6 loopback by default: naga mounts only on the rag
+# process, whose uvicorn binds `::` while the container's /etc/hosts maps
+# localhost to 127.0.0.1 alone — "localhost" could never connect there.
+_BACKEND_URL_SERVER = os.getenv("NAGA_SELF_URL", "http://[::1]:8080")
 _API_KEY = os.getenv("SCRAPER_API_KEY", "internal-scraper-key")
 _GEMINI_MODEL = os.getenv("NAGA_GEMINI_MODEL", "gemini-3.1-pro-preview")
 

--- a/apps/backend-rag/backend/tests/unit/self_healing/test_backend_agent_facade.py
+++ b/apps/backend-rag/backend/tests/unit/self_healing/test_backend_agent_facade.py
@@ -132,3 +132,18 @@ class TestReducedAgent:
         agent = BackendSelfHealingAgent(service_name="t")
         names = [type(a).__name__ for a in agent.orchestrator.actions]
         assert names == ["GCAction", "ReconnectCacheAction", "RestartServiceAction"]
+
+    def test_api_check_defaults_to_ipv6_loopback(self):
+        # Prod uvicorn binds `::` only and /etc/hosts maps localhost to
+        # 127.0.0.1 alone — a "localhost" URL can never connect (red on
+        # every cycle, proven live 2026-07-14).
+        agent = BackendSelfHealingAgent(service_name="t")
+        api_checks = [c for c in agent.orchestrator.checks if type(c).__name__ == "HTTPAPICheck"]
+        assert len(api_checks) == 1
+        assert api_checks[0].url == "http://[::1]:8080/health"
+
+    def test_api_check_url_env_override(self, monkeypatch):
+        monkeypatch.setenv("SELF_HEAL_API_URL", "http://127.0.0.1:9999/health")
+        agent = BackendSelfHealingAgent(service_name="t")
+        api_checks = [c for c in agent.orchestrator.checks if type(c).__name__ == "HTTPAPICheck"]
+        assert api_checks[0].url == "http://127.0.0.1:9999/health"


### PR DESCRIPTION
Follow-up to #2429 (scheduler necropsy), found by the post-deploy PROVE-LIVE probe.

## The bug (one class, two victims)

On the **rag** process uvicorn binds `::` only, and the container's `/etc/hosts` maps `localhost` to `127.0.0.1` alone. Proven live on machine `1781e5eda03438`: connection **refused** via localhost, **200** via `[::1]`.

- `self_healing` `HTTPAPICheck("http://localhost:8080/health")` — red on every cycle since the reduced agent went live (prod stats: `api: runs=3 ok=0 fail=3, ConnectError`). Harmless to the cure surface (GC-only) but a permanently-red check is exactly the theater #2429 was killing.
- `naga/deps.py` `_BACKEND_URL_SERVER = "http://localhost:8080"` — naga mounts **only** on the rag process (heavy routers), so server-mode `ask_legal`/`search_intel` self-calls dialed the same wall.

## Fix

Both default to `http://[::1]:8080` with env overrides (`SELF_HEAL_API_URL`, `NAGA_SELF_URL`) for dev runs bound to v4. Tests pin the default and the override.

Note: the **api** process binds `0.0.0.0` (v4) but runs `initialize_services_light` — no self-healing agent, no naga — so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)