### PR TITLE
fix(wr2): Wave-0 truth-before-throughput — verdict fabrication + verifier self-approval + HOME-fork declarations

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -3682,3 +3682,32 @@ async def test_shadow_terminal_update_zero_rows_is_reported_as_race(monkeypatch,
     monkeypatch.setenv("WR2_HTML_SHADOW", "1")
     result = await html._apply_one("postgres://x", _uuid.uuid4(), "owner-1")
     assert result == "shadow_race"
+
+
+# ── generator≠grader (WR2 deep audit 2026-07-14, §5a finding #1) ────────────
+
+
+def test_render_carousel_does_not_self_approve_brand_verifier():
+    """Tripwire: `_render_carousel` wired `brand_verifier=claude_design_critic`
+    — the SAME callable that already served as the vision critic — collapsing
+    the critic-proposes/verifier-vetoes autonomy guardrail into self-approval
+    (Codex objection #14, verified). Source-level check: standing up the full
+    render pipeline (Drive/DB/chromium) to exercise the live call isn't worth
+    it just to pin a wiring string; this fails loudly if the collapse
+    regresses, regardless of which module the callables are imported from."""
+    import inspect
+
+    import scripts.wr2_html_render_apply as html
+
+    src = inspect.getsource(html._render_carousel)
+    assert "brand_verifier=claude_brand_verifier" in src
+    assert "brand_verifier=claude_design_critic" not in src
+
+
+def test_claude_brand_verifier_is_a_distinct_callable_from_the_critic():
+    """Innocence check: the two adapters must actually be different functions
+    with different prompts, not two names bound to the same object."""
+    from wr2_html_renderer import claude_vision
+
+    assert claude_vision.claude_brand_verifier is not claude_vision.claude_design_critic
+    assert claude_vision._CRITIC_PROMPT != claude_vision._VERIFIER_PROMPT

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -295,6 +295,18 @@
       "live": "~/.openclaw/bin/wr2/wr2-ig-metrics-scrape.sh",
       "repo": "scripts/wr2-ig-metrics-scrape.sh",
       "machines": ["pro"]
+    },
+    {
+      "live": "~/.openclaw/bin/wr2/wr2-script-wrapper.sh",
+      "repo": "infra/openclaw/wr2/wr2-script-wrapper.sh",
+      "_note": "WR2 deep audit 2026-07-14 (§4): was byte-identical to the repo twin (e8e22fe1 both) but UNDECLARED, so lint_home_fork.py --check was blind to it and identical-today was luck, not enforcement.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/.openclaw/bin/wr2/wr2-cron-wrapper.sh",
+      "repo": "scripts/wr2-cron-wrapper.sh",
+      "_note": "WR2 deep audit 2026-07-14 (§4): the HOME copy (f17092b3) had DIVERGED from the repo copy (3cd52391) on the same machine — oracle/connector/newsletter were running the stale fork. Declared so --check catches this class of drift going forward; the live copy still needs a manual sync on Pro (operator/session task, not this PR).",
+      "machines": ["pro"]
     }
   ],
   "allow": [

--- a/scripts/tests/test_wr2_rerender_requeue.py
+++ b/scripts/tests/test_wr2_rerender_requeue.py
@@ -38,6 +38,24 @@ def _queue(tmp_path: Path, items: list[dict]) -> Path:
     return qp
 
 
+# ── generator≠grader sibling check (WR2 deep audit 2026-07-14, §5a #1) ──────
+#
+# wr2_rerender_local.py's own docstring claims it "REUSES the production
+# renderer verbatim ... so the output is identical to what the pipeline would
+# produce" — so the self-approval fix in wr2_html_render_apply.py must also
+# land here, or the two paths silently diverge (the file's own invariant would
+# become false).
+
+
+def test_rerender_does_not_self_approve_brand_verifier():
+    import inspect
+
+    rerender_mod = _load("wr2_rerender_local")
+    src = inspect.getsource(rerender_mod.rerender)
+    assert "brand_verifier=claude_brand_verifier" in src
+    assert "brand_verifier=claude_design_critic" not in src
+
+
 def test_published_entry_refused(tmp_path):
     """GUILT: a published queue entry blocks the requeue by default."""
     qp = _queue(tmp_path, [{"draft_id": "d1", "state": "published"}])

--- a/scripts/tests/test_wr2_visibility_chain.py
+++ b/scripts/tests/test_wr2_visibility_chain.py
@@ -76,7 +76,7 @@ def test_queue_append_and_exact_id_dedup(tmp_path):
     )
     assert entry["state"] == "drafted"
     assert entry["state_history"][0]["by"] == "wr2-html-apply"
-    assert entry["critic_overall_verdict"] == "pass"
+    assert entry["critic_overall_verdict"] == "legibility_only_pass"
 
     assert html._append_review_queue(entry, queue_path=qp) is True
     # SAME render batch re-applied (identical id) → pure dup, skip
@@ -114,7 +114,7 @@ def test_queue_rerender_repoints_drafted_entry_in_place(tmp_path):
     assert item["carousel_path"] == str(tmp_path / "car-new")
     assert item["drive_url"] == "https://drive/new"
     assert item["slide_count"] == 6
-    assert item["critic_overall_verdict"] == "pass"
+    assert item["critic_overall_verdict"] == "legibility_only_pass"
     # breadcrumb: the repoint is visible in state_history
     assert item["state_history"][-1]["by"] == "wr2-html-apply-rerender"
     assert item["state_history"][-1]["at"] == "2026-07-08T09:00:00Z"
@@ -180,7 +180,7 @@ def test_queue_appends_preserve_existing_items(tmp_path):
         slide_count=1, weak_count=2, fact_check_status=None,
         drafted_at="2026-07-07T13:00:00Z",
     )
-    assert entry["critic_overall_verdict"] == "soft_fail"
+    assert entry["critic_overall_verdict"] == "legibility_soft_fail"
     assert html._append_review_queue(entry, queue_path=qp) is True
     queue = json.loads(qp.read_text())
     assert [i["id"] for i in queue][0] == "legacy-1" and len(queue) == 2

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -226,7 +226,13 @@ def _make_queue_entry(
 ) -> dict:
     """Review-queue entry per skills/bali-zero-brand/_review-queue-schema.md."""
     slug = _slugify(topic)
-    verdict = "pass" if weak_count == 0 else "soft_fail"
+    # WR2 deep audit 2026-07-14 (§5a finding #2, Codex objection #15): this path
+    # runs ONLY the per-slide designer-loop legibility critic (readable/hierarchy/
+    # balanced) — the 4-rubric constitution critic (wr2-critic subagent) never
+    # touches this draft. A bare "pass" here was indistinguishable from a real
+    # constitution-critic pass to every downstream consumer (the app, the
+    # analyst, reflexion). Name the verdict for what actually ran.
+    verdict = "legibility_only_pass" if weak_count == 0 else "legibility_soft_fail"
     return {
         "id": f"carousel_{drafted_at}_{slug}",
         "draft_id": str(draft_id),

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -713,7 +713,7 @@ async def _render_carousel(
         make_slide_render_fn,
         _download_hero,
     )
-    from wr2_html_renderer.claude_vision import claude_design_critic
+    from wr2_html_renderer.claude_vision import claude_brand_verifier, claude_design_critic
     from wr2_html_renderer.designer_loop import run_designer_loop
     import httpx
 
@@ -753,8 +753,16 @@ async def _render_carousel(
                 out_dir=slides_dir / f"loop-{i:02d}",
                 is_hero=is_hero,
                 hero_path=(slides_dir / hero_filename) if hero_filename else None,
+                # WR2 deep audit 2026-07-14 (§5a finding #1, Codex objection #14):
+                # this used to bind brand_verifier to claude_design_critic — the SAME callable
+                # as the critic, so the "autonomy guardrail" (critic proposes,
+                # verifier vetoes) was self-approval in production. The two-role
+                # split already exists in claude_vision.py (claude_brand_verifier,
+                # a distinct prompt + fail-closed-if-unavailable) and was already
+                # wired correctly in _designer_e2e.py — only this call site had
+                # collapsed it.
                 vision_critic=claude_design_critic,
-                brand_verifier=claude_design_critic,
+                brand_verifier=claude_brand_verifier,
                 use_vision=True,
                 max_iters=3,
             )

--- a/scripts/wr2_rerender_local.py
+++ b/scripts/wr2_rerender_local.py
@@ -165,7 +165,7 @@ async def rerender(slug: str, *, use_vision: bool = False) -> int:
         return 0
 
     # Vision path: per-slide designer loop (render → critic → adjust → re-render).
-    from wr2_html_renderer.claude_vision import claude_design_critic
+    from wr2_html_renderer.claude_vision import claude_brand_verifier, claude_design_critic
     from wr2_html_renderer.designer_loop import run_designer_loop
 
     total = len(slides)
@@ -195,8 +195,13 @@ async def rerender(slug: str, *, use_vision: bool = False) -> int:
             out_dir=slides_dir / f"loop-{i:02d}",
             is_hero=is_hero,
             hero_path=(slides_dir / hero_filename) if hero_filename else None,
+            # Same fix as wr2_html_render_apply.py (WR2 deep audit 2026-07-14
+            # §5a #1): this file's docstring claims it "REUSES the production
+            # renderer verbatim ... so the output is identical to what the
+            # pipeline would produce" — it must track the production wiring,
+            # not a stale copy of the self-approval bug.
             vision_critic=claude_design_critic,
-            brand_verifier=claude_design_critic,
+            brand_verifier=claude_brand_verifier,
             use_vision=True,
             max_iters=3,
         )


### PR DESCRIPTION
## Summary

Wave-0 items 2-4 of the cure plan in `research/operations/2026-07-14-wr2-deep-audit.md` §10 —
session-executable, no operator dependency.

- **Stop the fabricated verdict** (§5a finding #2 / Codex objection #15): `wr2_html_render_apply.py`
  wrote a bare `"pass"`/`"soft_fail"` into `critic_overall_verdict` from a legibility-only
  designer-loop, indistinguishable downstream from a real 4-rubric constitution-critic pass.
  Renamed to `legibility_only_pass`/`legibility_soft_fail` (option chosen over a separate
  provenance field — see rationale below).
- **Un-collapse the verifier** (§5a finding #1 / Codex objection #14): `_render_carousel` passed
  `brand_verifier=claude_design_critic` — the same callable as the critic, i.e. self-approval on
  the production cron path. `claude_brand_verifier` already existed in `claude_vision.py` with a
  distinct prompt and fail-closed semantics (already correctly wired in `_designer_e2e.py`); only
  this call site, plus its sibling `wr2_rerender_local.py`, had collapsed it.
- **Declare 2 undeclared HOME-fork pairs**: `~/.openclaw/bin/wr2/wr2-script-wrapper.sh` and
  `~/.openclaw/bin/wr2/wr2-cron-wrapper.sh` in `infra/home-fork/declared-pairs.json` — the latter
  had already diverged from its repo twin on Pro (oracle/connector/newsletter running the stale fork).

## Design decision (item 1: rename value vs. provenance field)

Chose **renaming the value** over adding a `critic_provenance` field, after a consumer sweep:

- Python consumers already treat the field as an opaque string, not a strict enum:
  `wr2_carousel_import.py` already writes `"external"`; `wr2_reflexion_synthesis.py` just persists
  whatever is there; tests assert plain string equality. No code branches on the *type* of a
  provenance tag — only on the string value itself.
- Swift consumer (`WR2 Control.app.old-2026-07-11/.../Models.swift`) decodes the field as
  `Optional<String>` with graceful unknown-value handling: `criticVerdictKey`'s switch falls
  through to `.some(let v): return v` (shows raw text, no crash), and — more importantly —
  `CarouselPhase.of()`'s switch has NO case for `legibility_only_pass`, so it now falls to
  `default: return .review` (yellow "needs attention") instead of the old `"pass"` case mapping to
  `.waitlist` (blue "finished, ready"). This is a **correctness improvement for the app**, not just
  a rename: a legibility-only pass stops being visually indistinguishable from a real brand-gate pass.
  `CarouselDetailView.swift`'s looser `.contains("pass")` checks still match (pre-existing
  inconsistency in the app, not introduced here).
- A separate provenance field would have required updating every read site to check it — the
  rename gets the same signal for free at zero call-site cost, since every existing reader already
  treats the value as free text.

## Test plan

- [x] `PYTHONPATH=scripts apps/backend-rag/.venv/bin/python -m pytest scripts/wr2_html_renderer/tests/ -q` — 28 passed
- [x] `PYTHONPATH=scripts apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_wr2_visibility_chain.py scripts/tests/test_wr2_rerender_requeue.py scripts/test_wr2_carousel_import.py -q` — 40 passed
- [x] `apps/backend-rag`: `PYTHONPATH=. pytest backend/tests/unit/scripts/test_wr2_html_render_apply.py -q` — 121 passed (includes 2 new tripwire tests: source-level assertion that `brand_verifier` is never bound to `claude_design_critic`, + an innocence check that the two adapters are genuinely distinct callables/prompts)
- [x] `python3 scripts/lint_home_fork.py --check` — clean (M5 has no pro-scoped pairs to verify locally, by design)
- [x] Full pre-push pytest suite (fired by the push hook): **17042 passed, 165 skipped** in 429.97s

## Consumers checked/updated

- `scripts/tests/test_wr2_visibility_chain.py` — 3 assertions on the literal verdict string updated
- `apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py` — 2 new tripwire tests added
- `scripts/tests/test_wr2_rerender_requeue.py` — 1 new tripwire test added for the `wr2_rerender_local.py` sibling
- `scripts/wr2_daily_reconciler.py` — only imports `_make_queue_entry`, no literal-value assertion, unaffected
- `scripts/wr2_reflexion_synthesis.py` — reads a *different* SQLite `critic_overall_verdict` column (interactive-path `carousel_runs` table), unrelated to this JSON field, unaffected
- Swift app (`WR2 Control.app.old-2026-07-11/...`) — read-only per mandate; decode path verified safe (see design decision above), no code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>