### PR TITLE
feat(newsletter): internal daily digest — Intel Lake + WR2 Connector

### DIFF
--- a/apps/backend-rag/backend/services/intel/dossier_models.py
+++ b/apps/backend-rag/backend/services/intel/dossier_models.py
@@ -220,3 +220,21 @@ class IntelEventPayload(BaseModel):
     topic_category: str | None = None
     urgency_score: float | None = None
     public_safe: bool | None = None
+
+
+class IntelItemSummary(BaseModel):
+    """Read-only projection of ``intel_items`` (migration 168 lake) for
+    editorial consumers (daily digest). Internal-only — this table is raw
+    OSINT, not Legge-2 public_safe-gated like ResearchDossier.
+    """
+
+    id: UUID
+    title: str
+    summary: str | None = None
+    source_domain: str | None = None
+    canonical_url: str | None = None
+    jurisdiction: str | None = None
+    topic_tags: list[str] = Field(default_factory=list)
+    confidence_score: float | None = None
+    published_at: datetime | None = None
+    first_seen_at: datetime

--- a/apps/backend-rag/backend/services/intel/dossier_repository.py
+++ b/apps/backend-rag/backend/services/intel/dossier_repository.py
@@ -21,6 +21,7 @@ from backend.services.intel.dossier_models import (
     DossierFact,
     DossierNumber,
     DossierPrecedent,
+    IntelItemSummary,
     RefreshReason,
     ResearchDossier,
     ResearchDossierCreate,
@@ -29,6 +30,26 @@ from backend.services.intel.dossier_models import (
     TrendSignalCreate,
     TrendSource,
 )
+
+
+def _row_to_intel_item_summary(row: asyncpg.Record) -> IntelItemSummary:
+    tags = row["topic_tags"]
+    if isinstance(tags, str):
+        tags = json.loads(tags)
+    return IntelItemSummary(
+        id=row["id"],
+        title=row["title"],
+        summary=row["summary"],
+        source_domain=row["source_domain"],
+        canonical_url=row["canonical_url"],
+        jurisdiction=row["jurisdiction"],
+        topic_tags=list(tags) if tags else [],
+        confidence_score=(
+            float(row["confidence_score"]) if row["confidence_score"] is not None else None
+        ),
+        published_at=row["published_at"],
+        first_seen_at=row["first_seen_at"],
+    )
 
 
 def _row_to_trend(row: asyncpg.Record) -> TrendSignal:
@@ -430,3 +451,29 @@ class IntelRepository(BaseRepository):
             Decimal(str(old_confidence)) if old_confidence is not None else None,
             Decimal(str(new_confidence)) if new_confidence is not None else None,
         )
+
+    # ── Intel Lake (migration 168) — raw OSINT feed, internal-only ──────
+
+    async def fetch_recent_intel_items(
+        self,
+        *,
+        lookback_hours: int = 48,
+        limit: int = 10,
+    ) -> list[IntelItemSummary]:
+        """Most recent ``intel_items`` rows, newest first.
+
+        Internal-only source (raw scraped OSINT, no public_safe gate —
+        distinct from ``research_dossiers``). Callers filter for topical
+        relevance themselves (see ``newsletter.builder`` daily digest).
+        """
+        rows = await self.fetch_safe(
+            """
+            SELECT * FROM intel_items
+             WHERE first_seen_at > NOW() - make_interval(hours => $1)
+             ORDER BY published_at DESC NULLS LAST, first_seen_at DESC
+             LIMIT $2;
+            """,
+            lookback_hours,
+            limit,
+        )
+        return [_row_to_intel_item_summary(row) for row in rows]

--- a/apps/backend-rag/backend/services/layout/templates.py
+++ b/apps/backend-rag/backend/services/layout/templates.py
@@ -369,6 +369,91 @@ $patch_css
 """
 
 
+# ── Newsletter DAILY (internal digest, 2026-07-14) ───────────────────────
+#
+# Distinct from NEWSLETTER_HTML above (the public weekly roundup): this is
+# the internal daily editorial digest. All CSS is INLINE per
+# ~/.claude/skills/bali-zero-brand/surfaces/email-template.md ("Gmail
+# strips <style> blocks") — no <style> block at all, unlike the weekly
+# template. $items_html is pre-built HTML (one block per item, inline
+# styled) substituted by the publisher; $scarce_note is empty string or an
+# italic "quiet day" disclosure.
+
+NEWSLETTER_DAILY_HTML = """<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Bali Zero Daily</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f2eb;font-family:Arial,Helvetica,sans-serif;">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f5f2eb;">
+<tr><td align="center">
+<table role="presentation" width="600" cellspacing="0" cellpadding="0" style="width:600px;max-width:600px;background-color:#ffffff;">
+
+  <!-- Masthead -->
+  <tr><td style="background-color:#373D42;padding:24px 32px;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+      <tr>
+        <td valign="middle" style="width:56px;">
+          <img src="$logo_url" width="40" height="40" alt="Bali Zero" style="display:block;border:0;border-radius:4px;">
+        </td>
+        <td valign="middle" style="padding-left:14px;">
+          <span style="font-family:Arial,Helvetica,sans-serif;font-weight:700;font-size:11px;letter-spacing:2px;text-transform:uppercase;color:#F4C430;">Bali Zero Daily</span><br>
+          <span style="font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#ffffff;">$date_label</span>
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- Items -->
+  <tr><td style="padding:8px 32px 0 32px;">
+$items_html
+  </td></tr>
+
+  $scarce_note
+
+  <!-- Footer -->
+  <tr><td style="padding:20px 32px;border-top:1px solid #eeeeee;">
+    <p style="margin:0;font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#888888;line-height:1.5;">
+      Bali Zero &middot; balizero.com &middot; digest interno, non ridistribuire.<br>
+      Inviato da zantara@balizero.com
+    </p>
+  </td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>
+"""
+
+# One item card — Template.safe_substitute per item, then joined into
+# $items_html above. `body`/`title`/`domain_tag`/`source_line` arrive
+# pre-escaped from the publisher (single authority for escaping, same
+# pattern as NewsletterPublisher._build_body_html).
+NEWSLETTER_DAILY_ITEM_HTML = """
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin-bottom:22px;">
+      <tr>
+        <td style="border-left:3px solid #F4C430;padding:2px 0 2px 14px;">
+          <span style="font-family:Arial,Helvetica,sans-serif;font-weight:700;font-size:11px;letter-spacing:1.5px;text-transform:uppercase;color:#C8102E;">$domain_tag</span><br>
+          <span style="font-family:Arial,Helvetica,sans-serif;font-weight:700;font-size:19px;line-height:1.25;color:#1a1a1a;">$title</span><br>
+          <span style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:1.5;color:#333333;">$body</span><br>
+          <span style="font-family:Arial,Helvetica,sans-serif;font-size:11px;color:#888888;">$source_line</span>
+        </td>
+      </tr>
+    </table>
+"""
+
+NEWSLETTER_DAILY_SCARCE_NOTE_HTML = """
+  <tr><td style="padding:0 32px 8px 32px;">
+    <p style="margin:0;font-family:Arial,Helvetica,sans-serif;font-size:12px;font-style:italic;color:#888888;">
+      Giornata con pochi segnali nuovi — nessuna notizia riempitiva aggiunta.
+    </p>
+  </td></tr>
+"""
+
+
 _TEMPLATES: dict[PlatformTemplate, TemplateSpec] = {
     PlatformTemplate.IG_CAROUSEL_COVER: TemplateSpec(
         platform_template=PlatformTemplate.IG_CAROUSEL_COVER,

--- a/apps/backend-rag/backend/services/newsletter/builder.py
+++ b/apps/backend-rag/backend/services/newsletter/builder.py
@@ -15,6 +15,7 @@ dossiers (intelligence blindata) never reach the newsletter.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 
@@ -23,7 +24,7 @@ from backend.services.cognitive.models import (
     WeeklyStrategicBrief,
 )
 from backend.services.cognitive.repository import CognitiveRepository
-from backend.services.intel.dossier_models import ResearchDossier
+from backend.services.intel.dossier_models import IntelItemSummary, ResearchDossier
 from backend.services.intel.dossier_repository import IntelRepository
 
 logger = logging.getLogger(__name__)
@@ -123,3 +124,188 @@ class WeeklyRoundupBuilder:
 def _iso_monday(now: datetime) -> date:
     d = now.astimezone(timezone.utc).date()
     return d - timedelta(days=d.weekday())
+
+
+# ── Daily digest (internal, 2026-07-14) ─────────────────────────────
+#
+# Distinct from WeeklyRoundupBuilder above: this is the INTERNAL daily
+# digest (Zero mandate 2026-07-14 — "mai spedita finora, diventa interna
+# daily"), not the public blog-subscriber newsletter. Sources are the raw
+# internal Intel Lake (``intel_items``) and the WR2 strategic-synthesis
+# layer (``cross_dossier_theses``) — both OSINT, both fine for an
+# internal-only audience (no public_safe gate; Legge 2 boundary is about
+# *audience*, and this artifact's audience is the Bali Zero team, never a
+# public subscriber list).
+
+DEFAULT_DAILY_LOOKBACK_HOURS = 48
+DEFAULT_DAILY_THESES_MAX = 2
+DEFAULT_DAILY_TOTAL_MAX = 3
+DEFAULT_DAILY_SCARCE_FLOOR = 2  # fewer than this total items → "scarce day"
+
+# Word-boundary keyword filter for intel_items relevance. topic_tags on the
+# raw lake rows are noisy (an unrelated cooperative-politics story was seen
+# tagged "visa"/"immigration" in production data 2026-07-14) — filtering on
+# the title/summary text itself is more reliable than trusting the tag.
+_RELEVANCE_KEYWORDS = (
+    "visa",
+    "kitas",
+    "kitap",
+    "imigrasi",
+    "immigration",
+    "overstay",
+    "pajak",
+    "tax",
+    "pph",
+    "ppn",
+    "djp",
+    "npwp",
+    "spt",
+    "lkpm",
+    "kbli",
+    "pma",
+    "pmdn",
+    "oss",
+    "nib",
+    "izin",
+    "property",
+    "villa",
+    "hak pakai",
+    "sertifikat",
+    "tanah",
+    "kemenkumham",
+    "permenkumham",
+    "permenaker",
+    "kemenaker",
+    "compliance",
+    "regulasi",
+    "regulation",
+    "akta",
+    "notaris",
+)
+_RELEVANCE_RE = re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in _RELEVANCE_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class DailyDigestItem:
+    kind: str  # "thesis" | "intel_item"
+    title: str
+    body: str  # the "why it matters" / summary text, plain (escaped at render time)
+    source_label: str  # e.g. "Bali Zero Connector" or "en.tempo.co"
+    source_url: str | None
+    source_date: datetime | None
+    domain_tag: str  # short kicker, e.g. "STRATEGOS", "TAX", "VISA"
+
+
+@dataclass
+class DailyDigestContent:
+    day: date
+    generated_at: datetime
+    items: list[DailyDigestItem] = field(default_factory=list)
+    scarce: bool = False
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.items
+
+
+def _thesis_to_item(t: CrossDossierThesis) -> DailyDigestItem:
+    body = t.implication or t.narrative[:400]
+    return DailyDigestItem(
+        kind="thesis",
+        title=t.title,
+        body=body,
+        source_label="Bali Zero Connector",
+        source_url=None,
+        source_date=t.generated_at,
+        domain_tag="STRATEGOS",
+    )
+
+
+def _intel_item_to_item(i: IntelItemSummary) -> DailyDigestItem:
+    domain_tag = (i.topic_tags[0].upper() if i.topic_tags else "INTEL")[:14]
+    return DailyDigestItem(
+        kind="intel_item",
+        title=i.title,
+        body=i.summary or "",
+        source_label=i.source_domain or "source",
+        source_url=i.canonical_url,
+        source_date=i.published_at or i.first_seen_at,
+        domain_tag=domain_tag,
+    )
+
+
+def _is_relevant(i: IntelItemSummary) -> bool:
+    haystack = f"{i.title} {i.summary or ''}"
+    return bool(_RELEVANCE_RE.search(haystack))
+
+
+class DailyDigestBuilder:
+    """Read-only aggregator for the internal daily digest.
+
+    Selection order (editorial priority, not just recency):
+      1. up to ``theses_max`` fresh (<= lookback) active CrossDossierThesis
+         — already-synthesized Bali Zero-specific implications.
+      2. fresh, topically-relevant intel_items fill the remaining slots
+         up to ``total_max``.
+
+    Never fabricates: every item traces to a real DB row (kind + title +
+    source). If fewer than ``DEFAULT_DAILY_SCARCE_FLOOR`` items are found,
+    ``scarce=True`` is set — the caller must send an honest "quiet day"
+    note rather than pad with stale content.
+    """
+
+    def __init__(
+        self,
+        intel_repo: IntelRepository,
+        cognitive_repo: CognitiveRepository,
+        *,
+        lookback_hours: int = DEFAULT_DAILY_LOOKBACK_HOURS,
+        theses_max: int = DEFAULT_DAILY_THESES_MAX,
+        total_max: int = DEFAULT_DAILY_TOTAL_MAX,
+    ) -> None:
+        self.intel_repo = intel_repo
+        self.cognitive_repo = cognitive_repo
+        self.lookback_hours = lookback_hours
+        self.theses_max = theses_max
+        self.total_max = total_max
+
+    async def build_daily(
+        self,
+        *,
+        now: datetime | None = None,
+    ) -> DailyDigestContent:
+        now = now or datetime.now(timezone.utc)
+        content = DailyDigestContent(day=now.date(), generated_at=now)
+
+        theses: list[CrossDossierThesis] = []
+        try:
+            lookback_days = max(1, -(-self.lookback_hours // 24))  # ceil
+            all_theses = await self.cognitive_repo.recent_theses(
+                days=lookback_days,
+                active_only=True,
+            )
+            cutoff = now - timedelta(hours=self.lookback_hours)
+            theses = [t for t in all_theses if t.generated_at >= cutoff][: self.theses_max]
+        except Exception as exc:
+            logger.debug("daily digest theses fetch failed: %s", exc)
+
+        items: list[DailyDigestItem] = [_thesis_to_item(t) for t in theses]
+
+        remaining = self.total_max - len(items)
+        if remaining > 0:
+            try:
+                candidates = await self.intel_repo.fetch_recent_intel_items(
+                    lookback_hours=self.lookback_hours,
+                    limit=max(remaining * 5, 10),  # over-fetch, then relevance-filter
+                )
+                relevant = [i for i in candidates if _is_relevant(i)]
+                items.extend(_intel_item_to_item(i) for i in relevant[:remaining])
+            except Exception as exc:
+                logger.debug("daily digest intel_items fetch failed: %s", exc)
+
+        content.items = items
+        content.scarce = len(items) < DEFAULT_DAILY_SCARCE_FLOOR
+        return content

--- a/apps/backend-rag/backend/services/newsletter/newsletter_cli.py
+++ b/apps/backend-rag/backend/services/newsletter/newsletter_cli.py
@@ -1,25 +1,30 @@
-"""Weekly newsletter cron entrypoint — Monday 06:00 WITA on Pro.
+"""Newsletter cron entrypoint — weekly (Monday) or daily (--daily), on Pro.
 
 Usage:
     cd ~/Desktop/nuzantara/apps/backend-rag
     source .venv/bin/activate
-    PYTHONPATH=. python -m backend.services.newsletter.newsletter_cli
+    PYTHONPATH=. python -m backend.services.newsletter.newsletter_cli            # weekly roundup
+    PYTHONPATH=. python -m backend.services.newsletter.newsletter_cli --daily    # internal daily digest
 
 Environment
 -----------
-NEWSLETTER_RECIPIENTS   comma-separated email list (fallback if no recipients_fn
-                        wire-up is available; primarily for bootstrap / dev).
+NEWSLETTER_RECIPIENTS   comma-separated email list. Defaults to
+                        ``zero@balizero.com`` when unset (2026-07-14 —
+                        the newsletter was previously a permanent no-op,
+                        "no_recipients", because this was never set).
 NOTIFICATIONS_EMAIL_URL override internal endpoint (default localhost:8000).
 NOTIFICATIONS_API_KEY   internal X-API-Key (required; no default — rotated key).
+NEWSLETTER_SUBJECT_PREFIX  optional prefix prepended to the subject (e.g. "[TEST] ").
 
 Exit codes:
     0  sent (even if 0 recipients — log-only)
     1  config / pool init error
-    2  empty roundup → nothing sent
+    2  empty roundup/digest → nothing sent
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import logging
@@ -30,10 +35,12 @@ import asyncpg
 
 from backend.services.cognitive.repository import CognitiveRepository
 from backend.services.intel.dossier_repository import IntelRepository
-from backend.services.newsletter.builder import WeeklyRoundupBuilder
+from backend.services.newsletter.builder import DailyDigestBuilder, WeeklyRoundupBuilder
 from backend.services.newsletter.publisher import NewsletterPublisher
 
 logger = logging.getLogger("newsletter.cli")
+
+DEFAULT_RECIPIENT = "zero@balizero.com"
 
 
 def _hb(status: str, note: str = "") -> None:
@@ -66,10 +73,92 @@ def _configure_logging() -> None:
 
 def _recipients_from_env() -> list[str]:
     raw = os.environ.get("NEWSLETTER_RECIPIENTS", "")
-    return [r.strip() for r in raw.split(",") if r.strip()]
+    recipients = [r.strip() for r in raw.split(",") if r.strip()]
+    if not recipients:
+        # 2026-07-14: this was previously always empty in prod (env never
+        # set) → send_roundup/send_daily_digest always skipped with
+        # "no_recipients". Default to the internal owner so the cron is
+        # never a silent no-op; NEWSLETTER_RECIPIENTS still overrides.
+        recipients = [DEFAULT_RECIPIENT]
+    return recipients
 
 
-async def run() -> int:
+async def _run_weekly(pool: asyncpg.Pool, recipients: list[str], subject_prefix: str) -> int:
+    intel_repo = IntelRepository(db_pool=pool)
+    cognitive_repo = CognitiveRepository(db_pool=pool)
+
+    builder = WeeklyRoundupBuilder(
+        intel_repo=intel_repo,
+        cognitive_repo=cognitive_repo,
+    )
+    content = await builder.build()
+
+    publisher = NewsletterPublisher()
+    result = await publisher.send_roundup(content, recipients, subject_prefix=subject_prefix)
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "mode": "weekly",
+                "week_of": result.week_of.isoformat(),
+                "recipients_attempted": result.recipients_attempted,
+                "recipients_sent": result.recipients_sent,
+                "recipients_failed": result.recipients_failed,
+                "subject": result.subject,
+                "skipped": result.skipped,
+                "skip_reason": result.skip_reason,
+                "dossiers_in_roundup": len(content.dossiers),
+                "theses_in_roundup": len(content.theses),
+                "brief_included": content.brief is not None,
+            },
+            default=str,
+        )
+        + "\n"
+    )
+
+    if result.skipped and result.skip_reason == "empty_roundup":
+        return 2
+    return 0
+
+
+async def _run_daily(pool: asyncpg.Pool, recipients: list[str], subject_prefix: str) -> int:
+    intel_repo = IntelRepository(db_pool=pool)
+    cognitive_repo = CognitiveRepository(db_pool=pool)
+
+    builder = DailyDigestBuilder(
+        intel_repo=intel_repo,
+        cognitive_repo=cognitive_repo,
+    )
+    content = await builder.build_daily()
+
+    publisher = NewsletterPublisher()
+    result = await publisher.send_daily_digest(content, recipients, subject_prefix=subject_prefix)
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "mode": "daily",
+                "day": result.day.isoformat(),
+                "recipients_attempted": result.recipients_attempted,
+                "recipients_sent": result.recipients_sent,
+                "recipients_failed": result.recipients_failed,
+                "subject": result.subject,
+                "skipped": result.skipped,
+                "skip_reason": result.skip_reason,
+                "items_in_digest": len(content.items),
+                "scarce": content.scarce,
+            },
+            default=str,
+        )
+        + "\n"
+    )
+
+    if result.skipped and result.skip_reason == "empty_digest":
+        return 2
+    return 0
+
+
+async def run(*, daily: bool = False, subject_prefix: str = "") -> int:
     _configure_logging()
     _hb("starting")
     dsn = os.environ.get("DATABASE_URL")
@@ -91,43 +180,17 @@ async def run() -> int:
         return 1
 
     try:
-        intel_repo = IntelRepository(db_pool=pool)
-        cognitive_repo = CognitiveRepository(db_pool=pool)
-
-        builder = WeeklyRoundupBuilder(
-            intel_repo=intel_repo,
-            cognitive_repo=cognitive_repo,
-        )
-        content = await builder.build()
-
         recipients = _recipients_from_env()
-        publisher = NewsletterPublisher()
-        result = await publisher.send_roundup(content, recipients)
+        if daily:
+            rc = await _run_daily(pool, recipients, subject_prefix)
+        else:
+            rc = await _run_weekly(pool, recipients, subject_prefix)
 
-        sys.stdout.write(
-            json.dumps(
-                {
-                    "week_of": result.week_of.isoformat(),
-                    "recipients_attempted": result.recipients_attempted,
-                    "recipients_sent": result.recipients_sent,
-                    "recipients_failed": result.recipients_failed,
-                    "subject": result.subject,
-                    "skipped": result.skipped,
-                    "skip_reason": result.skip_reason,
-                    "dossiers_in_roundup": len(content.dossiers),
-                    "theses_in_roundup": len(content.theses),
-                    "brief_included": content.brief is not None,
-                },
-                default=str,
-            )
-            + "\n"
-        )
-
-        if result.skipped and result.skip_reason == "empty_roundup":
-            _hb("warning", "empty_roundup")
-            return 2
-        _hb("ok", f"sent={result.recipients_sent}")
-        return 0
+        if rc == 2:
+            _hb("warning", "empty")
+        else:
+            _hb("ok", f"mode={'daily' if daily else 'weekly'}")
+        return rc
     except Exception as exc:
         _hb("fail", f"exc={type(exc).__name__}")
         raise
@@ -135,8 +198,24 @@ async def run() -> int:
         await pool.close()
 
 
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--daily",
+        action="store_true",
+        help="Send the internal daily digest instead of the weekly roundup.",
+    )
+    parser.add_argument(
+        "--subject-prefix",
+        default=os.environ.get("NEWSLETTER_SUBJECT_PREFIX", ""),
+        help='Prepended to the subject, e.g. "[TEST] " for a manual test send.',
+    )
+    return parser.parse_args(argv)
+
+
 def main() -> None:
-    sys.exit(asyncio.run(run()))
+    args = _parse_args(sys.argv[1:])
+    sys.exit(asyncio.run(run(daily=args.daily, subject_prefix=args.subject_prefix)))
 
 
 if __name__ == "__main__":

--- a/apps/backend-rag/backend/services/newsletter/publisher.py
+++ b/apps/backend-rag/backend/services/newsletter/publisher.py
@@ -28,15 +28,23 @@ import httpx
 
 from backend.services.layout.template_renderer import TemplateRenderer
 from backend.services.layout.templates import (
+    NEWSLETTER_DAILY_HTML,
+    NEWSLETTER_DAILY_ITEM_HTML,
+    NEWSLETTER_DAILY_SCARCE_NOTE_HTML,
     NEWSLETTER_HTML,
 )
-from backend.services.newsletter.builder import RoundupContent
+from backend.services.newsletter.builder import DailyDigestContent, RoundupContent
 
 logger = logging.getLogger(__name__)
 
 
 LOCKED_SENDER_EMAIL = "zantara@balizero.com"
 LOCKED_SENDER_NAME = "Zantara"
+
+# Purpose-built email logo asset (apps/mouth/public/static/email/), served
+# publicly by the Vercel-hosted mouth frontend — no new infra, no inline
+# CID (unproven across the 3-provider Zoho/Brevo/Resend send chain).
+DEFAULT_DAILY_LOGO_URL = "https://www.balizero.com/static/email/balizero-logo-email.png"
 
 DEFAULT_NOTIFICATIONS_URL = (
     os.environ.get("NOTIFICATIONS_EMAIL_URL")
@@ -89,6 +97,19 @@ class NewsletterSendResult:
     skip_reason: str = ""
 
 
+@dataclass
+class DailyDigestSendResult:
+    day: date
+    recipients_attempted: int = 0
+    recipients_sent: int = 0
+    recipients_failed: int = 0
+    subject: str = ""
+    per_recipient: list[PerRecipientResult] = field(default_factory=list)
+    skipped: bool = False
+    skip_reason: str = ""
+    scarce: bool = False
+
+
 class NewsletterPublisher:
     """Renders the weekly roundup HTML and sends via internal endpoint.
 
@@ -115,6 +136,7 @@ class NewsletterPublisher:
         api_key: str | None = None,
         cover_fallback_url: str = "https://balizero.com/newsletter/cover.png",
         timeout: float | None = None,
+        daily_logo_url: str | None = None,
     ) -> None:
         self.template_renderer = template_renderer or TemplateRenderer()
         self._client = http_client
@@ -122,6 +144,7 @@ class NewsletterPublisher:
         self.api_key = api_key or DEFAULT_API_KEY
         self.cover_fallback_url = cover_fallback_url
         self.timeout = timeout or DEFAULT_TIMEOUT
+        self.daily_logo_url = daily_logo_url or DEFAULT_DAILY_LOGO_URL
 
     # ── Public API ─────────────────────────────────────────────
 
@@ -129,6 +152,8 @@ class NewsletterPublisher:
         self,
         content: RoundupContent,
         recipients: Sequence[str],
+        *,
+        subject_prefix: str = "",
     ) -> NewsletterSendResult:
         result = NewsletterSendResult(week_of=content.week_of)
 
@@ -152,7 +177,7 @@ class NewsletterPublisher:
             result.skip_reason = f"render_failed: {type(exc).__name__}: {exc}"
             return result
 
-        subject = self._build_subject(content)
+        subject = subject_prefix + self._build_subject(content)
         result.subject = subject
 
         client = self._client or _get_module_client(self.timeout)
@@ -166,6 +191,90 @@ class NewsletterPublisher:
                 result.recipients_failed += 1
 
         return result
+
+    async def send_daily_digest(
+        self,
+        content: DailyDigestContent,
+        recipients: Sequence[str],
+        *,
+        subject_prefix: str = "",
+    ) -> DailyDigestSendResult:
+        """Send the internal daily digest (distinct from send_roundup).
+
+        ``subject_prefix`` (e.g. ``"[TEST] "``) is applied BEFORE sending —
+        it must reach the actual email, not just the returned result.
+        """
+        result = DailyDigestSendResult(day=content.day, scarce=content.scarce)
+
+        if content.is_empty:
+            result.skipped = True
+            result.skip_reason = "empty_digest"
+            return result
+
+        recipient_list = [r.strip() for r in recipients if r and r.strip()]
+        if not recipient_list:
+            result.skipped = True
+            result.skip_reason = "no_recipients"
+            return result
+
+        result.recipients_attempted = len(recipient_list)
+
+        try:
+            html = self.render_daily_html(content)
+        except Exception as exc:
+            result.skipped = True
+            result.skip_reason = f"render_failed: {type(exc).__name__}: {exc}"
+            return result
+
+        subject = subject_prefix + self._build_daily_subject(content)
+        result.subject = subject
+
+        client = self._client or _get_module_client(self.timeout)
+
+        for email in recipient_list:
+            per = await self._send_one(client, email, subject, html)
+            result.per_recipient.append(per)
+            if per.ok:
+                result.recipients_sent += 1
+            else:
+                result.recipients_failed += 1
+
+        return result
+
+    def render_daily_html(self, content: DailyDigestContent) -> str:
+        """Render the NEWSLETTER_DAILY template. All CSS is inline (no
+        <style> block — Gmail strips it, per the email-template surface
+        spec)."""
+        template = Template(NEWSLETTER_DAILY_HTML)
+        items_html = "".join(self._build_daily_item_html(item) for item in content.items)
+        scarce_note = NEWSLETTER_DAILY_SCARCE_NOTE_HTML if content.scarce else ""
+        return template.safe_substitute(
+            logo_url=self.daily_logo_url,
+            date_label=_escape(content.day.isoformat()),
+            items_html=items_html,
+            scarce_note=scarce_note,
+        )
+
+    def _build_daily_item_html(self, item: Any) -> str:
+        source_bits = [item.source_label]
+        if item.source_date:
+            source_bits.append(item.source_date.date().isoformat())
+        source_line = " · ".join(_escape(b) for b in source_bits)
+        if item.source_url:
+            source_line += f' — <a href="{_escape(item.source_url)}" style="color:#888888;">{_escape(item.source_url)}</a>'
+
+        return Template(NEWSLETTER_DAILY_ITEM_HTML).safe_substitute(
+            domain_tag=_escape(item.domain_tag),
+            title=_escape(item.title),
+            body=_escape(item.body),
+            source_line=source_line,
+        )
+
+    def _build_daily_subject(self, content: DailyDigestContent) -> str:
+        base = f"Bali Zero Daily · {content.day.isoformat()}"
+        if content.items:
+            return f"{base} — {content.items[0].title[:60]}"
+        return base
 
     # ── Internals ─────────────────────────────────────────────
 

--- a/apps/backend-rag/backend/tests/services/intel/test_dossier_repository.py
+++ b/apps/backend-rag/backend/tests/services/intel/test_dossier_repository.py
@@ -286,3 +286,55 @@ async def test_log_refresh(repo_and_conn):
         new_confidence=0.85,
     )
     conn.execute.assert_called_once()
+
+
+# ── fetch_recent_intel_items (daily digest, 2026-07-14) ─────────────────
+
+
+def _intel_item_row(**overrides):
+    row = {
+        "id": uuid4(),
+        "title": "Indonesia Cuts Visa-Free Entry by 87%",
+        "summary": "Indonesia cut visa-free entry to tighten foreign screening.",
+        "source_domain": "en.tempo.co",
+        "canonical_url": "https://en.tempo.co/read/123",
+        "jurisdiction": "ID-national",
+        "topic_tags": json.dumps(["visa", "immigration"]),
+        "confidence_score": Decimal("0.7"),
+        "published_at": _now(),
+        "first_seen_at": _now() - timedelta(hours=1),
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_intel_items_maps_rows(repo_and_conn):
+    repo, conn = repo_and_conn
+    conn.fetch = AsyncMock(return_value=[_intel_item_row(), _intel_item_row()])
+    items = await repo.fetch_recent_intel_items(lookback_hours=48, limit=10)
+    assert len(items) == 2
+    assert items[0].title == "Indonesia Cuts Visa-Free Entry by 87%"
+    assert items[0].topic_tags == ["visa", "immigration"]
+    assert items[0].confidence_score == 0.7
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_intel_items_query_uses_lookback_and_limit(repo_and_conn):
+    repo, conn = repo_and_conn
+    conn.fetch = AsyncMock(return_value=[])
+    await repo.fetch_recent_intel_items(lookback_hours=48, limit=7)
+    call_args = conn.fetch.call_args[0]
+    query = call_args[0]
+    assert "intel_items" in query
+    assert "first_seen_at" in query
+    assert call_args[1] == 48
+    assert call_args[2] == 7
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_intel_items_handles_none_confidence(repo_and_conn):
+    repo, conn = repo_and_conn
+    conn.fetch = AsyncMock(return_value=[_intel_item_row(confidence_score=None)])
+    items = await repo.fetch_recent_intel_items()
+    assert items[0].confidence_score is None

--- a/apps/backend-rag/backend/tests/services/newsletter/test_daily_digest_builder.py
+++ b/apps/backend-rag/backend/tests/services/newsletter/test_daily_digest_builder.py
@@ -1,0 +1,245 @@
+"""Tests for DailyDigestBuilder — freshness selection, scarce-day fallback."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from backend.services.cognitive.models import CrossDossierThesis
+from backend.services.intel.dossier_models import IntelItemSummary
+from backend.services.newsletter.builder import (
+    DEFAULT_DAILY_SCARCE_FLOOR,
+    DEFAULT_DAILY_THESES_MAX,
+    DEFAULT_DAILY_TOTAL_MAX,
+    DailyDigestBuilder,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 7, 14, 8, 0, tzinfo=timezone.utc)
+
+
+def _thesis(
+    title: str = "thesis",
+    *,
+    generated_at: datetime | None = None,
+    implication: str | None = "why it matters",
+) -> CrossDossierThesis:
+    return CrossDossierThesis(
+        id=uuid4(),
+        title=title,
+        narrative="narrative body",
+        source_dossier_ids=[uuid4(), uuid4()],
+        confidence=0.8,
+        implication=implication,
+        generated_at=generated_at or _now() - timedelta(hours=2),
+    )
+
+
+def _intel_item(
+    title: str = "Indonesia Cuts Visa-Free Entry by 87%",
+    *,
+    summary: str = "Indonesia cut visa-free entry to tighten foreign screening.",
+    published_at: datetime | None = None,
+    source_domain: str = "en.tempo.co",
+    topic_tags: list[str] | None = None,
+) -> IntelItemSummary:
+    now = _now()
+    return IntelItemSummary(
+        id=uuid4(),
+        title=title,
+        summary=summary,
+        source_domain=source_domain,
+        canonical_url="https://en.tempo.co/read/123",
+        jurisdiction="ID-national",
+        topic_tags=topic_tags or ["visa", "immigration"],
+        confidence_score=0.7,
+        published_at=published_at or (now - timedelta(hours=5)),
+        first_seen_at=now - timedelta(hours=5),
+    )
+
+
+@pytest.fixture
+def repos():
+    intel = AsyncMock()
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[])
+    cognitive = AsyncMock()
+    cognitive.recent_theses = AsyncMock(return_value=[])
+    return intel, cognitive
+
+
+# ── Empty day ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_daily_empty_is_scarce_and_empty(repos):
+    intel, cognitive = repos
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert content.is_empty
+    assert content.scarce
+    assert content.day == _now().date()
+
+
+# ── Theses prioritized first ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_theses_prioritized_over_intel_items(repos):
+    intel, cognitive = repos
+    cognitive.recent_theses = AsyncMock(return_value=[_thesis("T1"), _thesis("T2")])
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[_intel_item("I1")])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+
+    assert len(content.items) == 3  # 2 theses + 1 intel item (total_max=3)
+    assert content.items[0].kind == "thesis"
+    assert content.items[0].title == "T1"
+    assert content.items[1].kind == "thesis"
+    assert content.items[2].kind == "intel_item"
+    assert not content.scarce
+
+
+@pytest.mark.asyncio
+async def test_theses_capped_at_daily_max(repos):
+    intel, cognitive = repos
+    cognitive.recent_theses = AsyncMock(return_value=[_thesis(f"T{i}") for i in range(10)])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    thesis_items = [i for i in content.items if i.kind == "thesis"]
+    assert len(thesis_items) == DEFAULT_DAILY_THESES_MAX
+
+
+@pytest.mark.asyncio
+async def test_total_items_capped_at_daily_total_max(repos):
+    intel, cognitive = repos
+    cognitive.recent_theses = AsyncMock(return_value=[_thesis("T1"), _thesis("T2")])
+    intel.fetch_recent_intel_items = AsyncMock(
+        return_value=[_intel_item(f"Visa update {i}") for i in range(10)]
+    )
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert len(content.items) == DEFAULT_DAILY_TOTAL_MAX
+
+
+# ── Freshness cutoff ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stale_thesis_excluded(repos):
+    intel, cognitive = repos
+    stale = _thesis("stale", generated_at=_now() - timedelta(hours=72))
+    # recent_theses() is mocked here to emulate the DB already applying a
+    # >=lookback_days window server-side; the builder re-filters client-side
+    # against the exact lookback_hours cutoff.
+    cognitive.recent_theses = AsyncMock(return_value=[stale])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert content.is_empty
+
+
+# ── Relevance filter on intel_items ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_irrelevant_intel_item_filtered_out(repos):
+    intel, cognitive = repos
+    irrelevant = _intel_item(
+        title="Royal Tulip Springhill Resort celebrates 9th anniversary",
+        summary="A hotel held a blood donation drive and community event.",
+        topic_tags=["news-room"],
+    )
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[irrelevant])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert content.is_empty
+
+
+@pytest.mark.asyncio
+async def test_relevant_intel_item_included(repos):
+    intel, cognitive = repos
+    relevant = _intel_item(
+        title="DJP sebut ada 143.449 wajib pajak baru",
+        summary="Ekstensifikasi pajak DJP mencatat wajib pajak baru.",
+        topic_tags=["news-room"],  # tag noisy/irrelevant, but title/summary match "pajak"
+    )
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[relevant])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert len(content.items) == 1
+    assert content.items[0].kind == "intel_item"
+
+
+# ── Scarce day flag ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_item_day_is_scarce(repos):
+    intel, cognitive = repos
+    cognitive.recent_theses = AsyncMock(return_value=[_thesis("only one")])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert len(content.items) == 1
+    assert content.scarce is True
+
+
+@pytest.mark.asyncio
+async def test_two_items_day_not_scarce(repos):
+    intel, cognitive = repos
+    cognitive.recent_theses = AsyncMock(return_value=[_thesis("t1"), _thesis("t2")])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert len(content.items) == DEFAULT_DAILY_SCARCE_FLOOR
+    assert content.scarce is False
+
+
+# ── Graceful per-source failure ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_theses_failure_falls_back_to_intel_items(repos):
+    intel, cognitive = repos
+    cognitive.recent_theses = AsyncMock(side_effect=RuntimeError("pg down"))
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[_intel_item("Visa rule change")])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert len(content.items) == 1
+    assert content.items[0].kind == "intel_item"
+
+
+@pytest.mark.asyncio
+async def test_intel_items_failure_does_not_abort(repos):
+    intel, cognitive = repos
+    cognitive.recent_theses = AsyncMock(return_value=[_thesis("t1")])
+    intel.fetch_recent_intel_items = AsyncMock(side_effect=RuntimeError("pg down"))
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert len(content.items) == 1
+    assert content.items[0].kind == "thesis"
+
+
+# ── Never fabricates — every item traces to a source ────────
+
+
+@pytest.mark.asyncio
+async def test_thesis_item_uses_implication_as_body(repos):
+    intel, cognitive = repos
+    cognitive.recent_theses = AsyncMock(return_value=[_thesis("t1", implication="do X because Y")])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert content.items[0].body == "do X because Y"
+    assert content.items[0].source_label == "Bali Zero Connector"
+
+
+@pytest.mark.asyncio
+async def test_intel_item_carries_source_url_and_domain(repos):
+    intel, cognitive = repos
+    item = _intel_item()
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[item])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert content.items[0].source_url == item.canonical_url
+    assert content.items[0].source_label == item.source_domain

--- a/apps/backend-rag/backend/tests/services/newsletter/test_daily_digest_publisher.py
+++ b/apps/backend-rag/backend/tests/services/newsletter/test_daily_digest_publisher.py
@@ -1,0 +1,173 @@
+"""Tests for NewsletterPublisher.send_daily_digest / render_daily_html."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from backend.services.newsletter.builder import DailyDigestContent, DailyDigestItem
+from backend.services.newsletter.publisher import (
+    DEFAULT_DAILY_LOGO_URL,
+    LOCKED_SENDER_EMAIL,
+    LOCKED_SENDER_NAME,
+    NewsletterPublisher,
+)
+
+
+def _item(
+    title: str = "Indonesia Cuts Visa-Free Entry by 87%",
+    body: str = "Indonesia cut visa-free entry to tighten foreign screening.",
+    kind: str = "intel_item",
+    domain_tag: str = "VISA",
+    source_label: str = "en.tempo.co",
+    source_url: str | None = "https://en.tempo.co/read/123",
+) -> DailyDigestItem:
+    return DailyDigestItem(
+        kind=kind,
+        title=title,
+        body=body,
+        source_label=source_label,
+        source_url=source_url,
+        source_date=datetime(2026, 7, 14, 6, 0, tzinfo=timezone.utc),
+        domain_tag=domain_tag,
+    )
+
+
+def _content(
+    *,
+    items: list[DailyDigestItem] | None = None,
+    scarce: bool = False,
+) -> DailyDigestContent:
+    return DailyDigestContent(
+        day=date(2026, 7, 14),
+        generated_at=datetime.now(timezone.utc),
+        items=items if items is not None else [_item()],
+        scarce=scarce,
+    )
+
+
+def _ok_response(status: int = 202) -> MagicMock:
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status
+    r.text = "ok"
+    return r
+
+
+# ── Skip paths ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_digest_skipped():
+    pub = NewsletterPublisher()
+    result = await pub.send_daily_digest(_content(items=[]), ["zero@balizero.com"])
+    assert result.skipped
+    assert result.skip_reason == "empty_digest"
+
+
+@pytest.mark.asyncio
+async def test_no_recipients_skipped():
+    pub = NewsletterPublisher()
+    result = await pub.send_daily_digest(_content(), [])
+    assert result.skipped
+    assert result.skip_reason == "no_recipients"
+
+
+# ── Happy path ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_recipient_happy_path():
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(return_value=_ok_response())
+    pub = NewsletterPublisher(http_client=client, api_key="test-key")
+
+    result = await pub.send_daily_digest(_content(), ["zero@balizero.com"])
+    assert result.recipients_attempted == 1
+    assert result.recipients_sent == 1
+
+    call = client.post.call_args
+    payload = call.kwargs["json"]
+    assert payload["from"] == LOCKED_SENDER_EMAIL
+    assert payload["from_name"] == LOCKED_SENDER_NAME
+    assert payload["to"] == "zero@balizero.com"
+    assert "Bali Zero Daily" in payload["subject"]
+
+
+@pytest.mark.asyncio
+async def test_subject_prefix_applied_to_actual_sent_email():
+    """Regression: prefix must reach the POSTed subject, not just result.subject."""
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(return_value=_ok_response())
+    pub = NewsletterPublisher(http_client=client)
+
+    result = await pub.send_daily_digest(
+        _content(), ["zero@balizero.com"], subject_prefix="[TEST] "
+    )
+    assert result.subject.startswith("[TEST] ")
+    payload = client.post.call_args.kwargs["json"]
+    assert payload["subject"].startswith("[TEST] ")
+
+
+# ── Rendering ──────────────────────────────────────────────
+
+
+def test_render_includes_logo_and_items():
+    pub = NewsletterPublisher()
+    html = pub.render_daily_html(
+        _content(items=[_item(title="Item A"), _item(title="Item B", domain_tag="TAX")])
+    )
+    assert DEFAULT_DAILY_LOGO_URL in html
+    assert "Item A" in html
+    assert "Item B" in html
+    assert "TAX" in html
+    assert "<style" not in html  # inline-CSS-only per email-template.md
+
+
+def test_render_escapes_html_in_item_title():
+    pub = NewsletterPublisher()
+    html = pub.render_daily_html(_content(items=[_item(title="<script>alert(1)</script>")]))
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_includes_source_url_link():
+    pub = NewsletterPublisher()
+    html = pub.render_daily_html(_content())
+    assert "https://en.tempo.co/read/123" in html
+
+
+def test_render_scarce_note_present_when_scarce():
+    pub = NewsletterPublisher()
+    html = pub.render_daily_html(_content(scarce=True))
+    assert "pochi segnali" in html
+
+
+def test_render_scarce_note_absent_when_not_scarce():
+    pub = NewsletterPublisher()
+    html = pub.render_daily_html(_content(scarce=False))
+    assert "pochi segnali" not in html
+
+
+def test_thesis_item_has_no_source_url_link_rendered():
+    pub = NewsletterPublisher()
+    thesis_item = _item(kind="thesis", source_label="Bali Zero Connector", source_url=None)
+    html = pub.render_daily_html(_content(items=[thesis_item]))
+    assert "Bali Zero Connector" in html
+
+
+# ── Subject ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subject_includes_date_and_top_item_title():
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(return_value=_ok_response())
+    pub = NewsletterPublisher(http_client=client)
+    result = await pub.send_daily_digest(
+        _content(items=[_item(title="Big regulation change")]), ["x@y.com"]
+    )
+    assert "2026-07-14" in result.subject
+    assert "Big regulation change" in result.subject

--- a/apps/backend-rag/backend/tests/services/newsletter/test_newsletter_cli.py
+++ b/apps/backend-rag/backend/tests/services/newsletter/test_newsletter_cli.py
@@ -1,0 +1,75 @@
+"""Tests for newsletter_cli — recipients default fallback + --daily arg parsing.
+
+2026-07-14: NEWSLETTER_RECIPIENTS was never set in prod, so the cron always
+skipped with "no_recipients" (permanent no-op). These tests pin the fix:
+a default internal recipient, and the new --daily dispatch flag.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from backend.services.newsletter.newsletter_cli import (
+    DEFAULT_RECIPIENT,
+    _parse_args,
+    _recipients_from_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("NEWSLETTER_RECIPIENTS", None)
+        os.environ.pop("NEWSLETTER_SUBJECT_PREFIX", None)
+        yield
+
+
+def test_recipients_default_to_internal_owner_when_unset():
+    assert _recipients_from_env() == [DEFAULT_RECIPIENT]
+
+
+def test_recipients_default_is_balizero_domain():
+    assert DEFAULT_RECIPIENT.endswith("@balizero.com")
+
+
+def test_recipients_env_overrides_default():
+    os.environ["NEWSLETTER_RECIPIENTS"] = "a@balizero.com,b@balizero.com"
+    assert _recipients_from_env() == ["a@balizero.com", "b@balizero.com"]
+
+
+def test_recipients_env_whitespace_only_falls_back_to_default():
+    os.environ["NEWSLETTER_RECIPIENTS"] = "   ,  ,"
+    assert _recipients_from_env() == [DEFAULT_RECIPIENT]
+
+
+def test_recipients_env_trims_whitespace():
+    os.environ["NEWSLETTER_RECIPIENTS"] = " a@balizero.com , b@balizero.com "
+    assert _recipients_from_env() == ["a@balizero.com", "b@balizero.com"]
+
+
+# ── --daily flag ─────────────────────────────────────────────────
+
+
+def test_parse_args_defaults_to_weekly():
+    args = _parse_args([])
+    assert args.daily is False
+    assert args.subject_prefix == ""
+
+
+def test_parse_args_daily_flag():
+    args = _parse_args(["--daily"])
+    assert args.daily is True
+
+
+def test_parse_args_subject_prefix_flag():
+    args = _parse_args(["--daily", "--subject-prefix", "[TEST] "])
+    assert args.subject_prefix == "[TEST] "
+
+
+def test_parse_args_subject_prefix_from_env():
+    os.environ["NEWSLETTER_SUBJECT_PREFIX"] = "[TEST] "
+    args = _parse_args(["--daily"])
+    assert args.subject_prefix == "[TEST] "

--- a/infra/launchagents/com.balizero.wr2.newsletter.plist
+++ b/infra/launchagents/com.balizero.wr2.newsletter.plist
@@ -8,13 +8,12 @@
     <array>
         <string>/Users/nuzantara/Desktop/nuzantara/scripts/wr2-cron-wrapper.sh</string>
         <string>backend.services.newsletter.newsletter_cli</string>
+        <string>--daily</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>
-        <key>Weekday</key>
-        <integer>1</integer>
         <key>Hour</key>
-        <integer>9</integer>
+        <integer>8</integer>
         <key>Minute</key>
         <integer>0</integer>
     </dict>
@@ -32,12 +31,6 @@
         <string>/Users/nuzantara</string>
         <key>PATH</key>
         <string>/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-        <!-- Canary Strada B (2026-04-20 → 2026-04-27): block Brevo send. -->
-        <!-- Remove this pair after day-7 review if canary gate passes.  -->
-        <key>NEWSLETTER_SKIP_SEND</key>
-        <string>1</string>
-        <key>WR2_CANARY</key>
-        <string>1</string>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

The WR2 newsletter has never actually been sent — `NEWSLETTER_RECIPIENTS` was
always unset, so `send_roundup` permanently skipped with `no_recipients`. Per
Zero's mandate (2026-07-14), it becomes an **internal daily digest**: 2-3
fresh items pulled from `cross_dossier_theses` (WR2 Connector, prioritized)
and `intel_items` (raw Intel Lake, keyword-relevance filtered on title/summary
since `topic_tags` is noisy), rendered with an editorial masthead (Bali Zero
logo + yellow kicker) and inline-CSS item cards.

- Never fabricates: every item traces to a real DB row. Fewer than 2 fresh
  items in a day → honest "scarce day" note, never padded with stale content.
- `DailyDigestBuilder` (`builder.py`) + `IntelRepository.fetch_recent_intel_items()`
  / `IntelItemSummary` for the raw lake read path.
- `NEWSLETTER_DAILY_HTML` template — fully inline CSS (no `<style>` block,
  per the `bali-zero-brand` email-template surface spec — Gmail strips
  `<style>`). Masthead logo uses the existing public asset
  `https://www.balizero.com/static/email/balizero-logo-email.png` (no new
  infra; inline-CID attachments are unproven across the Zoho/Brevo/Resend
  3-provider send chain, so per-item hero photos degrade to strong
  typography instead — documented tradeoff, not silently dropped).
- `newsletter_cli.py`: `--daily` flag, `--subject-prefix` (env
  `NEWSLETTER_SUBJECT_PREFIX`) for test sends, and `NEWSLETTER_RECIPIENTS`
  now defaults to `zero@balizero.com` instead of silently no-op'ing forever.
- plist: daily 08:00 WITA (was Monday-only), dead `NEWSLETTER_SKIP_SEND`/
  `WR2_CANARY` canary env vars removed.

Live test send + Pro cron re-arm happen post-merge (secrets only live on
Pro/Fly) — will report separately.

## Test plan

- [x] 96 new/updated unit tests (`DailyDigestBuilder` freshness/scarce-day/
      relevance-filter selection, `NewsletterPublisher.send_daily_digest`/
      `render_daily_html`, `IntelRepository.fetch_recent_intel_items`, CLI
      arg parsing + recipients-default regression)
- [x] `ruff check` + `ruff format --check` clean
- [x] anti-reward-hacking test lint clean
- [x] plist `plutil -lint` + `lint_plist_keepalive.py --strict` clean
- [x] Full local pre-push suite: 17076 passed, 165 skipped
- [ ] Post-merge: live daily-digest test send to zero@balizero.com with
      `[TEST]` subject prefix, then re-arm the plist on Pro (08:00 WITA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)