### PR TITLE
docs(sync): refresh docsync-generated counts

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -156,7 +156,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 ### LaunchAgents — copertura documentale
 
 <!-- DOCSYNC:AUTOMATION_COVERAGE_START -->
-`121 plist tracked in infra/launchagents/ · 93 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (77% coverage)`
+`120 plist tracked in infra/launchagents/ · 93 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (78% coverage)`
 <!-- DOCSYNC:AUTOMATION_COVERAGE_END -->
 
 Runbook operativi: indice auto-generato in [docs/runbooks/README.md](docs/runbooks/README.md).

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 637 services · 1137 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 637 services · 1140 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- proprioception `docs_sync` probe flagged drift (P3, class code<->docs)
- `python3 scripts/docs_sync.py` regen: INDEX.md automation-coverage 121→120 plist tracked / 77%→78%, AI_ONBOARDING.md test count 1137→1140
- mechanical regen only, no manual edits

## Test plan
- [x] `python3 scripts/docs_sync.py --check` clean after regen (verified locally in worktree)
- [x] diff reviewed — only the two DOCSYNC-marked blocks changed

🤖 Healer tick (Mini-Pro2)