### PR TITLE
fix(wr2): name-agnostic codex image detection — resurrect image pipeline

### DIFF
--- a/scripts/tests/test_wr2_image_generator_codex_detection.py
+++ b/scripts/tests/test_wr2_image_generator_codex_detection.py
@@ -1,0 +1,251 @@
+"""Tests for the name-agnostic Codex output-PNG detector (B5, 2026-07-14).
+
+Root cause of the "0/5 images" WR2 outage (research/operations/2026-07-14-
+wr2-deep-audit.md §4): `wr2_image_generator.py` globbed
+`~/.codex/generated_images/**/ig_*.png` to detect a fresh Codex render.
+Codex's `$imagegen` skill silently changed its output filename convention
+(`ig_*.png` -> `call_*.png`, later `exec-*.png` observed live) — the glob
+then matched nothing NEW ever again, and every run fell through to the
+"latest existing PNG" staleness check against a file frozen days in the
+past. Every "failed" session directory checked during the live diagnosis
+(2026-07-14) actually contained a correctly-generated PNG under the
+drifted name — Codex succeeded on 100% of the sampled attempts; only the
+detector was blind.
+
+`_select_fresh_codex_png` is the extracted, pure, filename-agnostic
+replacement — these tests drive it directly against a tmp_path tree, no
+Codex subprocess, no network, no DB.
+
+Guilt+innocence matrix (mandated by the fix's own doctrine — cicatrix
+scar family #3, guard-over/under-match): a detector that only recognizes
+today's naming is exactly the bug being fixed, so the tests must prove
+the NEXT unannounced rename (a fourth, invented prefix) is caught too.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+GEN_PATH = SCRIPTS_DIR / "wr2_image_generator.py"
+
+
+@pytest.fixture
+def wig(monkeypatch):
+    """Fresh import of wr2_image_generator with isolated module state.
+
+    Same loader pattern as test_wr2_image_generator_backend.py's `wig`
+    fixture — kept independent here (not shared via conftest) so this file
+    stays self-contained and matches the existing per-file fixture style.
+    """
+    sys.modules.pop("wr2_image_generator", None)
+    sys.modules.pop("wr2_flowkit_client", None)
+    monkeypatch.setenv("WR2_IMAGE_BACKEND", "auto")
+    monkeypatch.setenv("WR2_IMAGE_VLM_VALIDATION", "false")  # bypass Ollama
+    spec = importlib.util.spec_from_file_location("wr2_image_generator", GEN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_image_generator"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _touch(path: Path, mtime: float, content: bytes = b"\x89PNG fake") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    import os as _os
+    _os.utime(path, (mtime, mtime))
+    return path
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# GUILT — every naming convention Codex has actually used (or could use
+# next) must be detected when it's genuinely fresh.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "ig_0411bf5ebfe8a01c016a51eb7974bc8191acaad17d51377fff.png",  # legacy (pre-2026-07-11)
+        "call_eJfQUh5tTZdRW0fEdZFM8LJx.png",  # observed 2026-07-12 onward
+        "exec-4e5c122a-9913-401c-a833-b5a920265d11.png",  # observed 2026-07-14 (exec-fallback)
+        "xyz_totally_invented_future_prefix.png",  # naming drift #4 — not yet observed anywhere
+    ],
+)
+def test_detects_fresh_png_regardless_of_filename(wig, tmp_path, filename):
+    session_dir = tmp_path / "019f5d5a-fake-session"
+    start_ts = time.time()
+    fresh = _touch(session_dir / filename, mtime=start_ts + 1)
+
+    chosen, err = wig._select_fresh_codex_png(tmp_path, set(), start_ts, slide_number=1)
+
+    assert err is None, f"expected detection, got error: {err}"
+    assert chosen == fresh
+
+
+def test_detects_fresh_png_when_written_to_new_uuid_subdir_not_seen_before(wig, tmp_path):
+    """Mirrors the real layout: Codex creates a brand-new per-invocation
+    UUID directory, so `pre_existing` (snapshotted before the run) never
+    contains it — the file counts as fresh purely by "not in pre_existing",
+    independent of the mtime check."""
+    old_session = tmp_path / "019f0000-old-session"
+    old_png = _touch(old_session / "ig_old.png", mtime=time.time() - 100000)
+    pre_existing = {old_png}
+
+    new_session = tmp_path / "019f9999-new-session"
+    start_ts = time.time()
+    fresh = _touch(new_session / "call_brandnew.png", mtime=start_ts - 5)  # mtime even PRE-dates start_ts slightly (clock skew tolerance) but path is new
+
+    chosen, err = wig._select_fresh_codex_png(tmp_path, pre_existing, start_ts, slide_number=2)
+
+    assert err is None
+    assert chosen == fresh
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# INNOCENCE — pre-existing files must never be mistaken for a fresh result.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_pre_existing_file_not_selected_when_a_genuinely_new_one_exists(wig, tmp_path):
+    """The exact shape of the real bug in reverse: an old PNG sits in the
+    tree (frozen days ago, per the live 2026-07-11 `ig_*.png` freeze) AND a
+    genuinely new one lands during this call — the new one must win, never
+    the stale one, no matter what either is named."""
+    stale = _touch(
+        tmp_path / "019f0000-old" / "ig_ancient.png",
+        mtime=time.time() - 3 * 24 * 3600,  # 3 days old
+    )
+    pre_existing = {stale}
+
+    start_ts = time.time()
+    fresh = _touch(tmp_path / "019f9999-new" / "call_fresh.png", mtime=start_ts + 2)
+
+    chosen, err = wig._select_fresh_codex_png(tmp_path, pre_existing, start_ts, slide_number=3)
+
+    assert err is None
+    assert chosen == fresh
+    assert chosen != stale
+
+
+def test_only_stale_pre_existing_png_and_none_fresh_reports_error(wig, tmp_path):
+    """INNOCENCE mirror of the outage itself: if Codex genuinely produced
+    nothing new this run, the ONLY png in the tree is the old one, older
+    than the mtime window — this must still fail loudly (the fix does not
+    paper over real Codex failures, only the false ones)."""
+    old_mtime = time.time() - 10000  # well past CODEX_MTIME_WINDOW_SEC (600s)
+    stale = _touch(tmp_path / "019f0000-old" / "ig_ancient.png", mtime=old_mtime)
+    pre_existing = {stale}
+    start_ts = time.time()
+
+    chosen, err = wig._select_fresh_codex_png(
+        tmp_path, pre_existing, start_ts, mtime_window_sec=600, slide_number=4,
+    )
+
+    assert chosen is None
+    assert err is not None
+    assert "older than" in err
+    assert "name-agnostic" in err  # signals which detector generation produced this
+
+
+def test_no_png_anywhere_reports_error(wig, tmp_path):
+    chosen, err = wig._select_fresh_codex_png(tmp_path, set(), time.time(), slide_number=5)
+    assert chosen is None
+    assert err == "no PNG found in codex output dir"
+
+
+def test_missing_output_dir_reports_error(wig, tmp_path):
+    missing = tmp_path / "does-not-exist"
+    chosen, err = wig._select_fresh_codex_png(missing, set(), time.time(), slide_number=6)
+    assert chosen is None
+    assert err == "codex output dir does not exist after run"
+
+
+def test_multiple_fresh_candidates_picks_the_latest(wig, tmp_path):
+    """If more than one PNG looks fresh (e.g. a slow-clock race with another
+    concurrent Codex session sharing the same machine-wide output dir), the
+    most-recently-written one wins — a defensible tiebreak, not a crash."""
+    start_ts = time.time()
+    older_fresh = _touch(tmp_path / "s1" / "call_a.png", mtime=start_ts + 1)
+    newer_fresh = _touch(tmp_path / "s2" / "call_b.png", mtime=start_ts + 5)
+
+    chosen, err = wig._select_fresh_codex_png(tmp_path, set(), start_ts, slide_number=7)
+
+    assert err is None
+    assert chosen == newer_fresh
+    assert chosen != older_fresh
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Bounded retry + backoff — _acquire_bytes_via_codex wraps the single-shot
+# helper with a small, configurable retry loop.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_codex_retries_on_transient_failure_then_succeeds(wig, monkeypatch):
+    monkeypatch.setattr(wig, "CODEX_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(wig, "CODEX_RETRY_BACKOFF_SEC", 0)  # no real sleep in tests
+    sleep_calls = []
+
+    async def _fake_sleep(sec):
+        sleep_calls.append(sec)
+
+    monkeypatch.setattr(wig.asyncio, "sleep", _fake_sleep)
+
+    fake_bytes = b"\x89PNG" + b"\x00" * 50
+    wig._acquire_bytes_via_codex_once = AsyncMock(
+        side_effect=[(None, "transient codex hiccup"), (fake_bytes, None)],
+    )
+
+    img_bytes, err = await wig._acquire_bytes_via_codex(1, "a prompt", "draft-1")
+
+    assert img_bytes == fake_bytes
+    assert err is None
+    assert wig._acquire_bytes_via_codex_once.await_count == 2
+    assert sleep_calls == [0]  # backed off exactly once, between the two attempts
+
+
+@pytest.mark.asyncio
+async def test_codex_gives_up_after_max_attempts(wig, monkeypatch):
+    monkeypatch.setattr(wig, "CODEX_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(wig, "CODEX_RETRY_BACKOFF_SEC", 0)
+    monkeypatch.setattr(wig.asyncio, "sleep", AsyncMock())
+
+    wig._acquire_bytes_via_codex_once = AsyncMock(
+        return_value=(None, "persistent failure"),
+    )
+
+    img_bytes, err = await wig._acquire_bytes_via_codex(1, "a prompt", "draft-1")
+
+    assert img_bytes is None
+    assert err == "persistent failure"
+    assert wig._acquire_bytes_via_codex_once.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_codex_succeeds_first_try_no_retry_no_sleep(wig, monkeypatch):
+    """Regression guard: the common case (Codex works, as it does 100% of
+    the time per the 2026-07-14 diagnosis) must not pay a retry/backoff
+    tax it doesn't need."""
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(wig.asyncio, "sleep", sleep_mock)
+
+    fake_bytes = b"\x89PNG" + b"\x00" * 50
+    wig._acquire_bytes_via_codex_once = AsyncMock(return_value=(fake_bytes, None))
+
+    img_bytes, err = await wig._acquire_bytes_via_codex(1, "a prompt", "draft-1")
+
+    assert img_bytes == fake_bytes
+    assert err is None
+    assert wig._acquire_bytes_via_codex_once.await_count == 1
+    sleep_mock.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/scripts/tests/test_wr2_image_generator_lease.py
+++ b/scripts/tests/test_wr2_image_generator_lease.py
@@ -1,0 +1,123 @@
+"""Tests for the per-draft lease CAS added to wr2_image_generator.py (B5,
+2026-07-14 — overlap-prevention, audit cure-plan §10 item 5).
+
+`wr2_image_generator.py` was the one WR2 lane with NO CAS/lease at all —
+unlike the HTML-render and Canva-render lanes (`_pg.py`
+`acquire_html_lease_and_fetch` / `acquire_lease_and_fetch`), which already
+guard their fetch on `lease_owner IS NULL`. Two overlapping invocations
+(a stuck run still mid-slide when the supervisor's reconcile sweep re-kicks
+the same plist) could double-process the same draft and — sharper for the
+detection fix in the same PR — race writes into the SAME shared
+`~/.codex/generated_images/` tree that `_select_fresh_codex_png` scans.
+
+DB-free: `asyncpg.Connection` is an AsyncMock, matching the style already
+used in apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/
+test_pg.py for the sibling lanes.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+GEN_PATH = SCRIPTS_DIR / "wr2_image_generator.py"
+
+
+@pytest.fixture
+def wig(monkeypatch):
+    sys.modules.pop("wr2_image_generator", None)
+    sys.modules.pop("wr2_flowkit_client", None)
+    monkeypatch.setenv("WR2_IMAGE_BACKEND", "auto")
+    monkeypatch.setenv("WR2_IMAGE_VLM_VALIDATION", "false")
+    spec = importlib.util.spec_from_file_location("wr2_image_generator", GEN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wr2_image_generator"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_lease_owner_id_identifies_host_and_pid(wig):
+    owner = wig._lease_owner_id()
+    assert owner.startswith("wr2-image-generator:")
+    import os
+    assert str(os.getpid()) in owner
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_unchanged_status_filter(wig):
+    """Regression guard: adding the lease CAS must not touch the existing
+    fetch-candidates query (which still just SELECTs, no CAS — the lease
+    is acquired per-row afterward, in `run()`)."""
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+    await wig._fetch_pending(conn, limit=2)
+    sql = conn.fetch.call_args[0][0]
+    assert "status IN ('drafts_checked', 'drafts')" in sql
+    assert "lease_owner" not in sql  # unchanged — CAS lives in _acquire_image_lease
+
+
+@pytest.mark.asyncio
+async def test_acquire_image_lease_success_returns_true(wig):
+    conn = AsyncMock()
+    conn.fetchrow.return_value = {"id": "abc"}
+    ok = await wig._acquire_image_lease(conn, "abc", "wr2-image-generator:host:123")
+    assert ok is True
+    sql, draft_id, owner = conn.fetchrow.call_args[0]
+    assert "lease_owner = $2" in sql
+    assert "lease_owner IS NULL" in sql
+    assert "status IN ('drafts_checked', 'drafts')" in sql
+    assert draft_id == "abc"
+    assert owner == "wr2-image-generator:host:123"
+
+
+@pytest.mark.asyncio
+async def test_acquire_image_lease_loss_returns_false(wig):
+    """INNOCENCE: a draft already leased by a concurrent invocation (the
+    overlap case this fix exists for) is refused, not double-claimed."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    ok = await wig._acquire_image_lease(conn, "abc", "wr2-image-generator:host:123")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_persist_imaged_clears_lease_guarded_by_owner(wig):
+    conn = AsyncMock()
+    await wig._persist_imaged(
+        conn, "abc", [{"slide_number": 1}], {}, lease_owner="wr2-image-generator:host:123",
+    )
+    sql, *args = conn.execute.call_args[0]
+    assert "status              = 'drafts_imaged'" in sql or "status" in sql and "'drafts_imaged'" in sql
+    assert "lease_owner         = NULL" in sql or "lease_owner" in sql and "NULL" in sql
+    assert args[-1] == "wr2-image-generator:host:123"
+
+
+@pytest.mark.asyncio
+async def test_persist_imaged_lease_owner_none_is_a_noop_guard(wig):
+    """dry-run / no-lease callers pass lease_owner=None — the SQL's own
+    `$4::text IS NULL OR lease_owner = $4` clause makes that an unconditional
+    clear (back-compat with any caller that never acquired a lease)."""
+    conn = AsyncMock()
+    await wig._persist_imaged(conn, "abc", [], {}, lease_owner=None)
+    args = conn.execute.call_args[0]
+    assert args[-1] is None
+
+
+@pytest.mark.asyncio
+async def test_mark_image_failed_clears_lease_guarded_by_owner(wig):
+    conn = AsyncMock()
+    await wig._mark_image_failed(
+        conn, "abc", "all_images_failed: [...]", lease_owner="wr2-image-generator:host:123",
+    )
+    sql, *args = conn.execute.call_args[0]
+    assert "status" in sql and "'image_failed'" in sql
+    assert "lease_owner" in sql and "NULL" in sql
+    assert args[-1] == "wr2-image-generator:host:123"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/scripts/wr2_image_generator.py
+++ b/scripts/wr2_image_generator.py
@@ -34,6 +34,7 @@ import asyncio
 import json
 import logging
 import os
+import socket
 import sys
 import time
 import uuid
@@ -757,6 +758,14 @@ CODEX_OUTPUT_DIR = Path.home() / ".codex" / "generated_images"
 CODEX_TIMEOUT_SEC = float(os.environ.get("WR2_CODEX_TIMEOUT_SEC", "600"))
 CODEX_MTIME_WINDOW_SEC = 600
 
+# Bounded retry for the Codex subprocess itself (2026-07-14, B5 resurrection —
+# distinct from the outer backend=auto fallback in _gen_image_with_semaphore,
+# which only tries Codex ONCE before dropping to FlowKit/Playwright). A
+# transient Codex hiccup (rate limit, momentary CLI flake) shouldn't burn the
+# whole slide down to a different, lower-fidelity backend on the first miss.
+CODEX_MAX_ATTEMPTS = int(os.environ.get("WR2_CODEX_MAX_ATTEMPTS", "2"))
+CODEX_RETRY_BACKOFF_SEC = float(os.environ.get("WR2_CODEX_RETRY_BACKOFF_SEC", "10"))
+
 _CODEX_STRIPPED_ENV_KEYS = frozenset({
     "ANTHROPIC_API_KEY",
     "AWS_BEDROCK_ANTHROPIC_KEY",
@@ -779,19 +788,98 @@ async def _probe_codex_available() -> bool:
         return False
 
 
-async def _acquire_bytes_via_codex(
+def _select_fresh_codex_png(
+    output_dir: Path,
+    pre_existing: set[Path],
+    start_ts: float,
+    *,
+    mtime_window_sec: float = CODEX_MTIME_WINDOW_SEC,
+    now: float | None = None,
+    slide_number: int | str | None = None,
+) -> tuple[Path | None, str | None]:
+    """Name-agnostic pick of the PNG Codex just wrote for THIS invocation.
+
+    2026-07-14 (B5 resurrection): the previous detector globbed
+    `ig_*.png` only. Codex's `$imagegen` skill has silently renamed its
+    output at least twice since (`ig_*.png` -> `call_*.png`, and a third
+    `exec-*.png` variant observed live) — the glob then matches nothing
+    NEW, ever again, and every run falls through to the "latest existing
+    PNG" staleness check against a file frozen days in the past. That
+    made every Codex call look like a failure even though Codex was
+    succeeding on 100% of attempts (verified: every "failed" session
+    directory from the 2026-07-14 outage window actually contained a
+    correctly-generated PNG under the drifted name).
+
+    Detection is now filename-agnostic: any `*.png` under `output_dir`
+    counts as "ours" if EITHER it wasn't present in the pre-run snapshot
+    (`pre_existing`) OR its mtime is at/after `start_ts` (covers the edge
+    case of a path being reused). This can't be fooled by a THIRD rename
+    — only by Codex ceasing to write PNG files at all, which correctly
+    surfaces as a real failure.
+
+    Always logs what it found (count + example path) so the next naming
+    drift is visible in the log stream instead of silently degrading back
+    into this same trap.
+
+    Returns (path, None) on a fresh candidate, or (None, error) — the
+    error covers both "no PNG at all" and "only a stale pre-existing PNG,
+    filename-agnostic staleness check included".
+    """
+    if not output_dir.exists():
+        return None, "codex output dir does not exist after run"
+
+    all_pngs = list(output_dir.rglob("*.png"))
+    fresh: list[tuple[Path, float]] = []
+    for p in all_pngs:
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            continue
+        if p not in pre_existing or mtime >= start_ts:
+            fresh.append((p, mtime))
+
+    logger.info(
+        "[slide %s] codex output scan: %d png(s) total under %s, %d fresh candidate(s)%s",
+        slide_number, len(all_pngs), output_dir,
+        len(fresh),
+        f" (e.g. {fresh[0][0].name})" if fresh else "",
+    )
+
+    if fresh:
+        chosen = max(fresh, key=lambda t: t[1])[0]
+        return chosen, None
+
+    if not all_pngs:
+        return None, "no PNG found in codex output dir"
+
+    now = time.time() if now is None else now
+    latest, latest_mtime = max(
+        ((p, p.stat().st_mtime) for p in all_pngs), key=lambda t: t[1]
+    )
+    if (now - latest_mtime) > mtime_window_sec:
+        return None, (
+            f"latest PNG older than {mtime_window_sec:.0f}s window "
+            f"(checked {len(all_pngs)} file(s), name-agnostic — "
+            f"latest was {latest.name})"
+        )
+    return latest, None
+
+
+async def _acquire_bytes_via_codex_once(
     slide_number: int,
     image_prompt: str,
     draft_id: str,
     tonal_palette: str | None = None,
 ) -> tuple[bytes | None, str | None]:
-    """Generate one hero image via Codex CLI `$imagegen` (gpt-image-2).
+    """Single-attempt Codex `$imagegen` (gpt-image-2) generation.
 
     Aspect ratio 4:5 portrait is enforced via prompt suffix. Returns
     (bytes, None) on success or (None, error) on failure.
 
     Mirrors wr2_draft_generator._generate_cover_via_codex but takes the
-    final composed prompt (BRAND + ANTI_CLICHE) as input.
+    final composed prompt (BRAND + ANTI_CLICHE) as input. Callers wanting
+    retry+backoff should use `_acquire_bytes_via_codex` below — this
+    single-shot helper stays separately testable/callable.
     """
     final_prompt = _compose_final_prompt(image_prompt, tonal_palette)
     # Force 4:5 portrait — gpt-image-2 honours aspect hints in prompt body
@@ -804,7 +892,8 @@ async def _acquire_bytes_via_codex(
 
     pre_existing: set[Path] = set()
     if CODEX_OUTPUT_DIR.exists():
-        pre_existing = set(CODEX_OUTPUT_DIR.rglob("ig_*.png"))
+        pre_existing = set(CODEX_OUTPUT_DIR.rglob("*.png"))
+    start_ts = time.time()
 
     t0 = time.perf_counter()
     try:
@@ -833,19 +922,11 @@ async def _acquire_bytes_via_codex(
     except Exception as e:  # noqa: BLE001
         return None, f"codex spawn failed: {e}"
 
-    if not CODEX_OUTPUT_DIR.exists():
-        return None, "codex output dir does not exist after run"
-    candidates = [p for p in CODEX_OUTPUT_DIR.rglob("ig_*.png") if p not in pre_existing]
-    if not candidates:
-        all_pngs = list(CODEX_OUTPUT_DIR.rglob("ig_*.png"))
-        if not all_pngs:
-            return None, "no PNG found in codex output dir"
-        latest = max(all_pngs, key=lambda p: p.stat().st_mtime)
-        if (time.time() - latest.stat().st_mtime) > CODEX_MTIME_WINDOW_SEC:
-            return None, f"latest PNG older than {CODEX_MTIME_WINDOW_SEC}s window"
-        png_path = latest
-    else:
-        png_path = max(candidates, key=lambda p: p.stat().st_mtime)
+    png_path, select_err = _select_fresh_codex_png(
+        CODEX_OUTPUT_DIR, pre_existing, start_ts, slide_number=slide_number,
+    )
+    if png_path is None:
+        return None, select_err
 
     try:
         img_bytes = png_path.read_bytes()
@@ -858,6 +939,38 @@ async def _acquire_bytes_via_codex(
         slide_number, len(img_bytes), png_path.name, elapsed_ms,
     )
     return img_bytes, None
+
+
+async def _acquire_bytes_via_codex(
+    slide_number: int,
+    image_prompt: str,
+    draft_id: str,
+    tonal_palette: str | None = None,
+) -> tuple[bytes | None, str | None]:
+    """Bounded retry+backoff wrapper around `_acquire_bytes_via_codex_once`.
+
+    2026-07-14 (B5, audit cure-plan §10 item 5): the Codex path previously
+    tried exactly once per slide before falling through to FlowKit/
+    Playwright (lower fidelity — 1:1 crop instead of native 4:5). A
+    transient Codex hiccup (rate limit, momentary CLI flake) shouldn't
+    burn the whole slide down a quality tier on the first miss. Default
+    2 attempts / 10s backoff — small and bounded, not a new architecture.
+    """
+    last_err: str | None = None
+    for attempt in range(1, CODEX_MAX_ATTEMPTS + 1):
+        img_bytes, err = await _acquire_bytes_via_codex_once(
+            slide_number, image_prompt, draft_id, tonal_palette,
+        )
+        if img_bytes:
+            return img_bytes, None
+        last_err = err
+        logger.warning(
+            "[slide %d] codex attempt %d/%d failed: %s",
+            slide_number, attempt, CODEX_MAX_ATTEMPTS, err,
+        )
+        if attempt < CODEX_MAX_ATTEMPTS:
+            await asyncio.sleep(CODEX_RETRY_BACKOFF_SEC)
+    return None, last_err
 
 
 async def _acquire_bytes_via_flowkit(
@@ -1182,11 +1295,52 @@ async def _fetch_pending(conn: asyncpg.Connection, limit: int) -> list[asyncpg.R
     )
 
 
+def _lease_owner_id() -> str:
+    return f"wr2-image-generator:{socket.gethostname()}:{os.getpid()}"
+
+
+async def _acquire_image_lease(
+    conn: asyncpg.Connection, draft_id: uuid.UUID, lease_owner: str,
+) -> bool:
+    """CAS lease on a pending draft — overlap-prevention (2026-07-14, B5).
+
+    `wr2_image_generator.py` was the one WR2 lane with NO lease/CAS at all
+    (the HTML-render and Canva-render lanes both already guard their fetch
+    via `lease_owner IS NULL` in `_pg.py`) — two overlapping invocations
+    (e.g. a stuck run still mid-slide when the supervisor's reconcile
+    sweep re-kicks the same plist) could double-process the same draft:
+    duplicate Codex/Tigris calls, and — sharper for THIS bug — two
+    processes racing writes into the SAME shared `~/.codex/generated_images/`
+    tree the fresh-PNG detector above scans. Mirrors the existing
+    `war_room_drafts.lease_owner` CAS convention (`_pg.py`
+    `acquire_html_lease_and_fetch`) rather than inventing a new mechanism.
+
+    Status is re-checked in the same CAS (not just at `_fetch_pending`
+    time) so a draft that moved on between fetch and lease attempt is
+    never claimed. Release happens in `_persist_imaged` / `_mark_image_failed`.
+    """
+    row = await conn.fetchrow(
+        """
+        UPDATE war_room_drafts
+           SET lease_owner = $2, lease_acquired_at = NOW()
+         WHERE id = $1
+           AND lease_owner IS NULL
+           AND status IN ('drafts_checked', 'drafts')
+        RETURNING id
+        """,
+        draft_id,
+        lease_owner,
+    )
+    return row is not None
+
+
 async def _persist_imaged(
     conn: asyncpg.Connection,
     draft_id: uuid.UUID,
     slides: list[dict[str, Any]],
     council_meta: dict[str, Any],
+    *,
+    lease_owner: str | None = None,
 ) -> None:
     await conn.execute(
         """
@@ -1194,26 +1348,40 @@ async def _persist_imaged(
            SET slides_json         = $2::jsonb,
                council_debate_json = $3::jsonb,
                status              = 'drafts_imaged',
+               lease_owner         = NULL,
+               lease_acquired_at   = NULL,
                updated_at          = NOW()
          WHERE id = $1
+           AND ($4::text IS NULL OR lease_owner = $4)
         """,
         draft_id,
         json.dumps({"slides": slides}),
         json.dumps(council_meta),
+        lease_owner,
     )
 
 
-async def _mark_image_failed(conn: asyncpg.Connection, draft_id: uuid.UUID, reason: str) -> None:
+async def _mark_image_failed(
+    conn: asyncpg.Connection,
+    draft_id: uuid.UUID,
+    reason: str,
+    *,
+    lease_owner: str | None = None,
+) -> None:
     await conn.execute(
         """
         UPDATE war_room_drafts
-           SET status           = 'image_failed',
-               rejection_reason = $2,
-               updated_at       = NOW()
+           SET status            = 'image_failed',
+               rejection_reason  = $2,
+               lease_owner       = NULL,
+               lease_acquired_at = NULL,
+               updated_at        = NOW()
          WHERE id = $1
+           AND ($3::text IS NULL OR lease_owner = $3)
         """,
         draft_id,
         reason[:1000],
+        lease_owner,
     )
 
 
@@ -1227,6 +1395,7 @@ async def _process_one(
     row: asyncpg.Record,
     *,
     dry_run: bool,
+    lease_owner: str | None = None,
 ) -> bool:
     draft_id: uuid.UUID = row["id"]
     topic: str = row["topic"]
@@ -1433,6 +1602,7 @@ async def _process_one(
             conn,
             draft_id,
             f"all_images_failed: {list(errors_by_slide.values())[:3]}",
+            lease_owner=lease_owner,
         )
         _send_telegram(
             f"WR2 image_generator FAILED\n"
@@ -1442,7 +1612,7 @@ async def _process_one(
         )
         return False
 
-    await _persist_imaged(conn, draft_id, slides, council)
+    await _persist_imaged(conn, draft_id, slides, council, lease_owner=lease_owner)
     logger.info("Draft %s → status=drafts_imaged", draft_id)
 
     _send_telegram(
@@ -1494,15 +1664,30 @@ async def run(*, dry_run: bool = False, draft_id: str | None = None) -> int:
                 logger.info("[DRY-RUN] would process %d drafts:", len(rows))
 
             successes = 0
+            lease_owner = _lease_owner_id()
             for row in rows:
+                draft_lease: str | None = None
+                if not dry_run:
+                    acquired = await _acquire_image_lease(conn, row["id"], lease_owner)
+                    if not acquired:
+                        logger.info(
+                            "Draft %s: lease held by another process — skipping "
+                            "(overlap-prevention, B5)", row["id"],
+                        )
+                        continue
+                    draft_lease = lease_owner
                 try:
-                    ok = await _process_one(conn, row, dry_run=dry_run)
+                    ok = await _process_one(
+                        conn, row, dry_run=dry_run, lease_owner=draft_lease,
+                    )
                     if ok:
                         successes += 1
                 except Exception as e:
                     logger.exception("Unhandled error on draft %s: %s", row["id"], e)
                     try:
-                        await _mark_image_failed(conn, row["id"], f"unhandled: {e}")
+                        await _mark_image_failed(
+                            conn, row["id"], f"unhandled: {e}", lease_owner=draft_lease,
+                        )
                     except Exception:
                         pass
 

--- a/scripts/wr2_rerender_requeue.py
+++ b/scripts/wr2_rerender_requeue.py
@@ -17,6 +17,12 @@ What happens next (NOT triggered here — the cron picks it up naturally):
   `WR2_PULL_CHECKSUM=1 wr2-queue-pull.sh --once` on M5 reconciles the mirror
   (steady-state `--ignore-existing` skips replaced-in-place PNGs).
 
+Note (2026-07-14, B5): the `image_failed` lane (drafts stuck before this
+stage, from wr2_image_generator.py's Codex output-detection bug) has its
+OWN dedicated requeue verb — `scripts/wr2_image_requeue.py` — not this one.
+This tool's anti-jump doctrine correctly refuses a pre-image `image_failed`
+row (see `_pg.requeue_draft_for_rerender`'s status whitelist below).
+
 Usage (runs where DATABASE_URL reaches prod — Pro, or via scripts/pg.sh env):
   DATABASE_URL=... python3 scripts/wr2_rerender_requeue.py <draft-uuid> [<draft-uuid> ...]
   DATABASE_URL=... python3 scripts/wr2_rerender_requeue.py --dry-run <draft-uuid>


### PR DESCRIPTION
## Summary

Completes cure-plan item 5 (Wave 1) of `research/operations/2026-07-14-wr2-deep-audit.md`.

The 2026-07-14 outage audit found Codex `$imagegen` at 0/5 images per draft. Live root-cause probe showed Codex actually succeeded on 100% of sampled attempts — the detector was blind: `wr2_image_generator.py` globbed `ig_*.png` under `~/.codex/generated_images/`, but Codex's `$imagegen` skill silently renamed its output (`ig_*.png` → `call_*.png` → `exec-*.png`) some time after 2026-07-11. The glob then matched nothing new, ever, and every run fell through to a "latest PNG older than 600s" staleness check against a file frozen days in the past.

Fixes:

1. `_select_fresh_codex_png`: filename-agnostic detection. Any `*.png` counts as fresh if not in the pre-run snapshot OR mtime ≥ call start — immune to a fourth silent rename, not just the three seen so far. Always logs what it found (count + example path) so the next drift is visible.
2. Bounded retry+backoff on the Codex subprocess itself (2 attempts / 10s default) — previously a single transient hiccup dropped straight to FlowKit/Playwright (lower fidelity, 1:1 crop vs native 4:5).
3. Overlap-prevention: `wr2_image_generator.py` was the one WR2 lane with no lease/CAS at all. Added the same CAS discipline (`war_room_drafts.lease_owner`) already used by the HTML- and Canva-render lanes, so two overlapping invocations can't double-process a draft or race writes into the shared Codex output directory the detector scans.

Rebased onto `origin/main` after #2441 merged (FlowKit-fallback-in-auto-mode wiring) — both behaviors coexist cleanly: #2441's `per_slide_backend`/`flowkit_available` cascade at the codex-primary call site, and this PR's detection/retry/lease additions further down in the same file. No conflicts on rebase (disjoint line ranges, verified).

## Test plan

- [x] `scripts/tests/test_wr2_image_generator_codex_detection.py` — guilt+innocence matrix on `_select_fresh_codex_png` (legacy/current/observed/invented-future naming all detected; stale pre-existing files never mistaken for fresh)
- [x] `scripts/tests/test_wr2_image_generator_lease.py` — CAS acquire/release
- [x] `scripts/tests/test_wr2_image_generator_backend.py` — backend selection (post-#2441 fallback logic still intact)
- [x] `scripts/tests/test_wr2_image_requeue.py` — sibling's requeue tool, unaffected
- [x] 47/47 tests pass locally
- [ ] CI full suite (Backend Tests, CodeQL, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)