### PR TITLE
fix(newsletter): 3 daily-digest quality bugs found on real prod data

### DIFF
--- a/apps/backend-rag/backend/services/newsletter/builder.py
+++ b/apps/backend-rag/backend/services/newsletter/builder.py
@@ -14,6 +14,7 @@ dossiers (intelligence blindata) never reach the newsletter.
 
 from __future__ import annotations
 
+import html
 import logging
 import re
 from dataclasses import dataclass, field
@@ -142,50 +143,40 @@ DEFAULT_DAILY_THESES_MAX = 2
 DEFAULT_DAILY_TOTAL_MAX = 3
 DEFAULT_DAILY_SCARCE_FLOOR = 2  # fewer than this total items → "scarce day"
 
-# Word-boundary keyword filter for intel_items relevance. topic_tags on the
-# raw lake rows are noisy (an unrelated cooperative-politics story was seen
-# tagged "visa"/"immigration" in production data 2026-07-14) — filtering on
-# the title/summary text itself is more reliable than trusting the tag.
-_RELEVANCE_KEYWORDS = (
-    "visa",
-    "kitas",
-    "kitap",
-    "imigrasi",
-    "immigration",
-    "overstay",
-    "pajak",
-    "tax",
-    "pph",
-    "ppn",
-    "djp",
-    "npwp",
-    "spt",
-    "lkpm",
-    "kbli",
-    "pma",
-    "pmdn",
-    "oss",
-    "nib",
-    "izin",
-    "property",
-    "villa",
-    "hak pakai",
-    "sertifikat",
-    "tanah",
-    "kemenkumham",
-    "permenkumham",
-    "permenaker",
-    "kemenaker",
-    "compliance",
-    "regulasi",
-    "regulation",
-    "akta",
-    "notaris",
-)
+# Word-boundary keyword filter for intel_items relevance, grouped by
+# editorial category. topic_tags on the raw lake rows are noisy (an
+# unrelated cooperative-politics story was seen tagged "visa"/"immigration"
+# in production data 2026-07-14, and a Bali property-market-trust article
+# was tagged "visa" too) — filtering AND labeling off the title/summary
+# text itself is more reliable than trusting the tag. Order matters: the
+# first category whose keyword matches becomes the item's domain_tag.
+_RELEVANCE_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "VISA": ("visa", "kitas", "kitap", "imigrasi", "immigration", "overstay"),
+    "TAX": ("pajak", "tax", "pph", "ppn", "djp", "npwp", "spt", "lkpm"),
+    "KBLI": ("kbli", "pma", "pmdn", "oss", "nib", "izin"),
+    "PROPERTY": ("property", "villa", "hak pakai", "sertifikat", "tanah"),
+    "COMPLIANCE": (
+        "kemenkumham",
+        "permenkumham",
+        "permenaker",
+        "kemenaker",
+        "compliance",
+        "regulasi",
+        "regulation",
+        "akta",
+        "notaris",
+    ),
+}
 _RELEVANCE_RE = re.compile(
-    r"\b(" + "|".join(re.escape(k) for k in _RELEVANCE_KEYWORDS) + r")\b",
+    r"\b("
+    + "|".join(re.escape(k) for keywords in _RELEVANCE_CATEGORIES.values() for k in keywords)
+    + r")\b",
     re.IGNORECASE,
 )
+_CATEGORY_RES: dict[str, re.Pattern[str]] = {
+    tag: re.compile(r"\b(" + "|".join(re.escape(k) for k in keywords) + r")\b", re.IGNORECASE)
+    for tag, keywords in _RELEVANCE_CATEGORIES.items()
+}
 
 
 @dataclass
@@ -224,22 +215,72 @@ def _thesis_to_item(t: CrossDossierThesis) -> DailyDigestItem:
     )
 
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WP_APPEARED_FIRST_RE = re.compile(
+    r"\s*The post .*? appeared first on .*?\.?\s*$", re.IGNORECASE | re.DOTALL
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _clean_summary(raw: str, *, max_len: int = 320) -> str:
+    """Strip HTML markup, entities, and WordPress-RSS boilerplate.
+
+    Found live 2026-07-14: some scraped intel_items.summary values are the
+    raw RSS <description> — full HTML tags, `&#8217;`-style entities, and a
+    trailing "The post X appeared first on Y." syndication footer. None of
+    that is editorial content; the digest must show clean prose, not a raw
+    feed dump.
+    """
+    text = _HTML_TAG_RE.sub(" ", raw)
+    text = html.unescape(text)
+    text = _WP_APPEARED_FIRST_RE.sub("", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    if len(text) > max_len:
+        text = text[: max_len - 1].rstrip() + "…"
+    return text
+
+
 def _intel_item_to_item(i: IntelItemSummary) -> DailyDigestItem:
-    domain_tag = (i.topic_tags[0].upper() if i.topic_tags else "INTEL")[:14]
     return DailyDigestItem(
         kind="intel_item",
         title=i.title,
-        body=i.summary or "",
+        body=_clean_summary(i.summary) if i.summary else "",
         source_label=i.source_domain or "source",
         source_url=i.canonical_url,
         source_date=i.published_at or i.first_seen_at,
-        domain_tag=domain_tag,
+        domain_tag=_domain_tag_for(i),
     )
 
 
+def _domain_tag_for(i: IntelItemSummary) -> str:
+    """Kicker badge derived from the matched relevance category, NOT the
+    raw ``topic_tags`` (found noisy live 2026-07-14 — a Bali property-market
+    article was tagged "visa"). Falls back to "INTEL" if, somehow, nothing
+    in _RELEVANCE_CATEGORIES matches (should not happen post-_is_relevant)."""
+    haystack = f"{i.title} {_clean_summary(i.summary) if i.summary else ''}"
+    for tag, pattern in _CATEGORY_RES.items():
+        if pattern.search(haystack):
+            return tag
+    return "INTEL"
+
+
 def _is_relevant(i: IntelItemSummary) -> bool:
-    haystack = f"{i.title} {i.summary or ''}"
+    haystack = f"{i.title} {_clean_summary(i.summary) if i.summary else ''}"
     return bool(_RELEVANCE_RE.search(haystack))
+
+
+def _has_editorial_content(i: IntelItemSummary) -> bool:
+    """Reject rows with no (or whitespace-only, post-cleaning) summary.
+
+    Found live 2026-07-14: some scraped intel_items have title but empty
+    summary — selecting them renders a blank body line in the card. Others
+    have a summary that's ONLY WordPress-RSS boilerplate ("The post X
+    appeared first on Y.") which _clean_summary strips to empty. Either
+    way: an empty body is honest (no fabrication) but reads as broken;
+    better to skip and let another fresh, relevant item (or the scarce-day
+    note) take the slot.
+    """
+    return bool(_clean_summary(i.summary).strip()) if i.summary else False
 
 
 class DailyDigestBuilder:
@@ -301,7 +342,7 @@ class DailyDigestBuilder:
                     lookback_hours=self.lookback_hours,
                     limit=max(remaining * 5, 10),  # over-fetch, then relevance-filter
                 )
-                relevant = [i for i in candidates if _is_relevant(i)]
+                relevant = [i for i in candidates if _is_relevant(i) and _has_editorial_content(i)]
                 items.extend(_intel_item_to_item(i) for i in relevant[:remaining])
             except Exception as exc:
                 logger.debug("daily digest intel_items fetch failed: %s", exc)

--- a/apps/backend-rag/backend/tests/services/newsletter/test_daily_digest_builder.py
+++ b/apps/backend-rag/backend/tests/services/newsletter/test_daily_digest_builder.py
@@ -15,6 +15,8 @@ from backend.services.newsletter.builder import (
     DEFAULT_DAILY_THESES_MAX,
     DEFAULT_DAILY_TOTAL_MAX,
     DailyDigestBuilder,
+    _clean_summary,
+    _domain_tag_for,
 )
 
 
@@ -173,6 +175,35 @@ async def test_relevant_intel_item_included(repos):
     assert content.items[0].kind == "intel_item"
 
 
+@pytest.mark.asyncio
+async def test_relevant_intel_item_with_empty_summary_excluded(repos):
+    """Regression 2026-07-14 (found on real prod data): a relevant item
+    with no summary would render a blank body line in the card — skip it
+    rather than ship a broken-looking card."""
+    intel, cognitive = repos
+    blank_summary = _intel_item(
+        title="Ekstensifikasi Pajak Melesat, DJP Catat 143.449 WP Baru",
+        summary="",
+    )
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[blank_summary])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert content.is_empty
+
+
+@pytest.mark.asyncio
+async def test_relevant_intel_item_with_whitespace_only_summary_excluded(repos):
+    intel, cognitive = repos
+    ws_summary = _intel_item(
+        title="Aturan Pajak UMKM Disempurnakan",
+        summary="   ",
+    )
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[ws_summary])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert content.is_empty
+
+
 # ── Scarce day flag ─────────────────────────────────────────
 
 
@@ -243,3 +274,124 @@ async def test_intel_item_carries_source_url_and_domain(repos):
     content = await builder.build_daily(now=_now())
     assert content.items[0].source_url == item.canonical_url
     assert content.items[0].source_label == item.source_domain
+
+
+# ── domain_tag derived from matched content, not raw noisy tags ─────────
+# Regression 2026-07-14: a real prod row about Bali's property market was
+# tagged topic_tags=["visa"] — the old (raw-tag) logic would have badged
+# it "VISA". The fix derives the badge from which _RELEVANCE_CATEGORIES
+# keyword actually matched the title/summary.
+
+
+def test_domain_tag_for_visa_keyword():
+    item = _intel_item(title="Indonesia tightens visa rules", summary="overstay crackdown")
+    assert _domain_tag_for(item) == "VISA"
+
+
+def test_domain_tag_for_tax_keyword():
+    item = _intel_item(title="DJP catat wajib pajak baru", summary="ekstensifikasi pajak")
+    assert _domain_tag_for(item) == "TAX"
+
+
+def test_domain_tag_for_property_keyword_not_misled_by_noisy_topic_tag():
+    item = _intel_item(
+        title="Can You Measure Trust in Bali's Property Market?",
+        summary="A look at property transactions and buyer trust in Bali.",
+        topic_tags=["visa"],  # noisy/wrong tag on the raw row — must be ignored
+    )
+    assert _domain_tag_for(item) == "PROPERTY"
+
+
+@pytest.mark.asyncio
+async def test_selected_intel_item_domain_tag_matches_content_not_raw_tag(repos):
+    intel, cognitive = repos
+    property_item = _intel_item(
+        title="Can You Measure Trust in Bali's Property Market?",
+        summary="A look at property transactions and buyer trust in Bali.",
+        topic_tags=["visa", "immigration"],  # noisy — must not win over content match
+    )
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[property_item])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert len(content.items) == 1
+    assert content.items[0].domain_tag == "PROPERTY"
+
+
+# ── _clean_summary — strip raw RSS/WordPress markup ─────────────────────
+# Regression 2026-07-14: a real prod row's summary was the raw RSS
+# <description> — HTML tags, HTML entities, and a "The post X appeared
+# first on Y." syndication footer appended by WordPress.
+
+
+def test_clean_summary_strips_html_tags():
+    raw = "<p>Trust is one of the most discussed qualities.</p>"
+    assert _clean_summary(raw) == "Trust is one of the most discussed qualities."
+
+
+def test_clean_summary_unescapes_html_entities():
+    raw = "Bali&#8217;s property market is opaque."
+    assert _clean_summary(raw) == "Bali’s property market is opaque."
+
+
+def test_clean_summary_strips_wordpress_appeared_first_on_footer():
+    raw = (
+        "<p>Trust is hard to measure in property.</p>\n"
+        '<p>The post <a href="https://x.com/y">Can You Measure Trust</a> appeared first on '
+        '<a href="https://indonesiaexpat.id">Indonesia Expat</a>.</p>'
+    )
+    cleaned = _clean_summary(raw)
+    assert "appeared first on" not in cleaned
+    assert cleaned == "Trust is hard to measure in property."
+
+
+def test_clean_summary_truncates_long_text_with_ellipsis():
+    raw = "word " * 200
+    cleaned = _clean_summary(raw, max_len=50)
+    assert len(cleaned) <= 50
+    assert cleaned.endswith("…")
+
+
+def test_clean_summary_plain_text_passthrough_unchanged():
+    assert _clean_summary("Indonesia cut visa-free entry by 87 percent.") == (
+        "Indonesia cut visa-free entry by 87 percent."
+    )
+
+
+@pytest.mark.asyncio
+async def test_raw_wordpress_summary_rendered_as_clean_body(repos):
+    intel, cognitive = repos
+    wp_item = _intel_item(
+        title="Can You Measure Trust in Bali's Property Market?",
+        summary=(
+            "<p>Trust is hard to measure in Bali&#8217;s property market.</p>\n"
+            '<p>The post <a href="https://x.com">Can You Measure Trust</a> appeared first on '
+            '<a href="https://indonesiaexpat.id">Indonesia Expat</a>.</p>'
+        ),
+    )
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[wp_item])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert len(content.items) == 1
+    body = content.items[0].body
+    assert "<p>" not in body
+    assert "appeared first on" not in body
+    assert "&#8217;" not in body
+    assert body == "Trust is hard to measure in Bali’s property market."
+
+
+@pytest.mark.asyncio
+async def test_summary_that_is_only_wordpress_boilerplate_excluded(repos):
+    """A summary that, after cleaning, is empty must be treated the same
+    as a genuinely empty summary — skip, don't ship a blank card."""
+    intel, cognitive = repos
+    boilerplate_only = _intel_item(
+        title="Some Bali property story",
+        summary=(
+            'The post <a href="https://x.com">title</a> appeared first on '
+            '<a href="https://indonesiaexpat.id">Indonesia Expat</a>.'
+        ),
+    )
+    intel.fetch_recent_intel_items = AsyncMock(return_value=[boilerplate_only])
+    builder = DailyDigestBuilder(intel_repo=intel, cognitive_repo=cognitive)
+    content = await builder.build_daily(now=_now())
+    assert content.is_empty


### PR DESCRIPTION
## Summary
- PR #2434 squash-merged the daily digest feature to `main`, but this quality-fix branch (`agent/air-m5/wr2/newsletter-daily`) had drifted onto a stale ancestor with a large unrelated diff — this PR carries a FRESH branch off `origin/main` with only the live 2-file delta (`builder.py` + its test), content-verified identical to the corresponding diff on the old stale branch.
- Found by rendering today's actual digest against prod Postgres (read-only) before the live test send — all three would have shipped a visibly broken card:
  - Empty/whitespace-only `intel_items.summary` rendered a blank body line. `_has_editorial_content()` now skips such rows instead of padding with a blank card.
  - A row's summary was the raw RSS/WordPress `<description>` — HTML tags, entities (`&#8217;`), and a trailing syndication footer. `_clean_summary()` strips all three; a summary that cleans to empty is treated as genuinely empty.
  - `domain_tag` was read off the raw (noisy) `topic_tags[0]` — a Bali property-market article was tagged "visa" in production data. `_domain_tag_for()` now derives the badge from which `_RELEVANCE_CATEGORIES` keyword actually matched the title/summary.
- 7 new regression tests.

## Test plan
- [x] `pytest apps/backend-rag/backend/tests/services/newsletter/test_daily_digest_builder.py -q` — 26 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)