### PR TITLE
feat(wr2-renderer): executable gates for Art 7/6.1/4.3 + palette signal (Art 2.3)

### DIFF
--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -1140,7 +1140,16 @@ def _check_body_font_size_floor(skeleton_css: str, family: str) -> None:
 # audit). This block gives them teeth.
 # ---------------------------------------------------------------------------
 
-_CONSTITUTION_PATH = _BRAND / "constitution.md"
+# Deliberately NOT _BRAND (Path.home()/.claude/skills/bali-zero-brand — a
+# machine-local symlink into this same repo, HOME-fork family #1): a CI
+# runner has no ~/.claude/skills, so a path built off Path.home() 404s on
+# every PR, unlike the layouts/tokens code above which either mocks this
+# directory in tests or never got a fail-closed reader wired to it. Article 7
+# is fail-closed, so it needs a path that resolves the same way in CI as it
+# does on a dev machine: straight off the repo checkout (parents[2] from
+# scripts/wr2_html_renderer/composer.py is the repo root).
+_REPO_ROOT_FOR_CONSTITUTION = Path(__file__).resolve().parents[2]
+_CONSTITUTION_PATH = _REPO_ROOT_FOR_CONSTITUTION / "skills" / "bali-zero-brand" / "constitution.md"
 
 
 def _load_forbidden_phrases(path: Path | None = None) -> list[str]:

--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -1132,6 +1132,184 @@ def _check_body_font_size_floor(skeleton_css: str, family: str) -> None:
             )
 
 
+# ---------------------------------------------------------------------------
+# Article 7 (forbidden phrases) + Article 6.1 (body word count) hard gates
+# (2026-07-14, cure item 13 / research/operations/2026-07-14-wr2-deep-audit.md
+# §5): both articles say "hard fail" in the constitution but had ZERO
+# executable enforcement anywhere in the render engine (grep-verified by the
+# audit). This block gives them teeth.
+# ---------------------------------------------------------------------------
+
+_CONSTITUTION_PATH = _BRAND / "constitution.md"
+
+
+def _load_forbidden_phrases(path: Path | None = None) -> list[str]:
+    """Parse the Article 7 closed list straight out of the canonical
+    constitution.md — NEVER hardcode the phrase list in code, so an amendment
+    to Article 7 (Article 11 process) takes effect the next render with no
+    code change.
+
+    Fail-closed idiom (mirrors `tokens_to_css.load_tokens` /
+    `_brand_base_css_body` in this module): constitution.md is a repo-tracked
+    file that must always exist for THIS renderer to be brand-compliant at
+    all — unlike the WR2_VISION_REQUIRED toggle (claude_vision.py), which
+    guards an OPTIONAL external subprocess (Claude CLI vision) that can
+    legitimately be transiently unavailable. A missing canonical brand file is
+    not "transient infra flake", it's "the renderer's ground truth is gone" —
+    so this raises unconditionally rather than soft-passing, same as the two
+    precedents above.
+    """
+    p = path or _CONSTITUTION_PATH
+    if not p.is_file():
+        raise FileNotFoundError(
+            f"Article 7 enforcement requires the brand constitution, not "
+            f"found at {p} — refusing to render without the phrase list "
+            f"(fail-closed, not fail-open: see _load_forbidden_phrases docstring)"
+        )
+    text = p.read_text(encoding="utf-8")
+    m = re.search(
+        r"## Article 7 — Forbidden phrases \(closed list\)(.*?)(?=\n## )",
+        text,
+        re.DOTALL,
+    )
+    if not m:
+        raise ValueError(
+            f"Article 7 section not found in {p} — constitution.md shape "
+            f"changed; the closed list heading must stay "
+            f"'## Article 7 — Forbidden phrases (closed list)'"
+        )
+    phrases = re.findall(r"`([^`]+)`", m.group(1))
+    if not phrases:
+        raise ValueError(f"Article 7 section in {p} parsed but yielded zero phrases (blind-scan guard)")
+    return phrases
+
+
+_PHRASE_PATTERN_CACHE: dict[str, "re.Pattern[str]"] = {}
+
+
+def _forbidden_phrase_pattern(phrase: str) -> "re.Pattern[str]":
+    """Word/phrase-boundary regex for one forbidden phrase (scar family #3
+    discipline: match on ENTITY, never bare substring — a banned single word
+    like `unlock` must not fire inside `unlockable`, and `landscape` must not
+    fire inside `landscaper`). Non-alphanumeric lookaround (not bare `\\b`) so
+    apostrophes/hyphens inside a phrase (`let's dive in`) don't confuse the
+    boundary. Internal whitespace is tolerated as `\\s+` so a phrase that
+    happens to wrap across a rendered line still matches. Cached — the
+    Article 7 list is short and re-compiled at most once per phrase per
+    process.
+    """
+    cached = _PHRASE_PATTERN_CACHE.get(phrase)
+    if cached is not None:
+        return cached
+    escaped = re.escape(phrase.strip())
+    escaped = re.sub(r"(?:\\ )+", r"\\s+", escaped)
+    pattern = re.compile(rf"(?<![A-Za-z0-9]){escaped}(?![A-Za-z0-9])", re.IGNORECASE)
+    _PHRASE_PATTERN_CACHE[phrase] = pattern
+    return pattern
+
+
+def _slide_copy_texts(slide: dict[str, Any]) -> dict[str, str]:
+    """The reader-facing copy fields Article 6.1 (word count) and Article 7
+    (forbidden phrases) check: heading, subheading, body, the statement-bomb
+    punch line, and the evidence-carved take/caption line. Mirrors the same
+    field-name fallbacks `_fill_placeholders` uses (headline/heading,
+    subhead/subheading, body/body_text) so the gate sees exactly the text
+    that will render, not a stale/alternate schema key.
+    """
+    return {
+        "heading": str(slide.get("headline") or slide.get("heading") or "").strip(),
+        "subhead": str(slide.get("subhead") or slide.get("subheading") or "").strip(),
+        "body": str(slide.get("body") or slide.get("body_text") or "").strip(),
+        "statement": str(slide.get("statement") or "").strip(),
+        "caption": str(slide.get("take_line") or slide.get("take_label") or "").strip(),
+    }
+
+
+def _check_forbidden_phrases(slide: dict[str, Any], *, index: int) -> None:
+    """Article 7 hard gate: heading/subhead/body/statement/caption text must
+    not contain any phrase from the constitution's closed forbidden-phrase
+    list. Raises ValueError naming the slide + every (field, phrase) hit, so
+    a single retry fixes every violation instead of whack-a-mole one at a
+    time.
+
+    Known scope limit (not a silent assumption — documented per the audit's
+    "give it teeth or honesty" mandate): 3 entries carry a sense-qualifier in
+    the constitution's own prose — `landscape` ("in metaphorical sense"),
+    `journey` ("in the boilerplate sense"), `ecosystem` ("in marketing
+    sense"). This scanner has no semantic disambiguation; it hard-fails on
+    the LITERAL phrase regardless of sense (e.g. a genuinely geographic "the
+    landscape of Kerobokan" would also trip it). That is a stricter reading
+    than the constitution's stated intent, not a looser one — false positives
+    route back to the storyboarder for a rephrase, which is the same failure
+    mode the constitution already accepts for its OTHER 20 sense-independent
+    entries. Fixing this needs an LLM judge (the vision critic already covers
+    this class of nuance on the interactive path per the audit); a
+    deterministic composer-time gate cannot do better without one.
+    """
+    phrases = _load_forbidden_phrases()
+    hits: list[str] = []
+    for field, text in _slide_copy_texts(slide).items():
+        if not text:
+            continue
+        for phrase in phrases:
+            if _forbidden_phrase_pattern(phrase).search(text):
+                hits.append(f"{field}={phrase!r}")
+    if hits:
+        raise ValueError(
+            f"Article 7 hard fail: slide {index} contains forbidden phrase(s): "
+            f"{', '.join(hits)}"
+        )
+
+
+# Article 6.1: "Body length: 25-50 words per slide. Hard fail if outside
+# range. Cover slide exempt (title only)."
+_ART_6_1_BODY_WORD_MIN = 25
+_ART_6_1_BODY_WORD_MAX = 50
+
+
+def _check_body_word_count(skeleton: str, slide: dict[str, Any], *, index: int, family: str) -> None:
+    """Article 6.1 hard gate: prose body text must be 25-50 words.
+
+    Scope, derived from the skeleton itself (not a hardcoded family
+    allow-list): the gate applies only when this family's skeleton actually
+    renders a prose `{{body}}` placeholder (editorial-text,
+    photo-headline-yellow-sub, photo-fullbleed / -top / -split,
+    source-citation, stat-card-hero — verified via `grep -l "{{body}}"
+    layouts/*.md`). Families that render STRUCTURED copy instead have no
+    `{{body}}` token and are correctly untouched:
+      - cover-photo: constitution explicitly exempts it ("title only") —
+        and structurally it has no {{body}} either, belt-and-suspenders.
+      - statement-bomb: Article 6.6 mandates the closing be a SHORT
+        single-line statement, which would directly contradict a blanket
+        25-50-word floor; it renders via {{statement}}, not {{body}}.
+      - dark-status-list / evidence-carved / timeline-pinboard /
+        numbered-forces-list / qa-dialogue / elegant-close: structured
+        item/fact/QA arrays, not a prose body — Article 6.1 doesn't cleanly
+        apply to a bullet list or a QA exchange.
+    A new layout family automatically gets this gate the moment its skeleton
+    adopts {{body}} — no code change required.
+    """
+    if "{{body}}" not in skeleton:
+        return
+    body = str(slide.get("body") or slide.get("body_text") or "").strip()
+    n = len(body.split()) if body else 0
+    if not (_ART_6_1_BODY_WORD_MIN <= n <= _ART_6_1_BODY_WORD_MAX):
+        raise ValueError(
+            f"Article 6.1 hard fail: slide {index} ({family}) body has {n} "
+            f"words — constitution requires "
+            f"{_ART_6_1_BODY_WORD_MIN}-{_ART_6_1_BODY_WORD_MAX}. "
+            f"body={body[:120]!r}"
+        )
+
+
+def _check_slide_constitution_gates(skeleton: str, slide: dict[str, Any], *, index: int, family: str) -> None:
+    """Run both Article 7 + Article 6.1 gates for one slide. Single call site
+    so compose_carousel and materialize_slide_html stay in lockstep (both
+    build one HTML file per slide from the same skeleton + slide dict)."""
+    _check_forbidden_phrases(slide, index=index)
+    _check_body_word_count(skeleton, slide, index=index, family=family)
+
+
 def _default_heading_subhead_colors(slide: dict[str, Any]) -> tuple[str, str]:
     """Odd/even alternation default for heading_color / subhead_color.
 
@@ -1526,6 +1704,7 @@ async def compose_carousel(
 
             skeleton = _extract_skeleton(plan.family)
             _check_body_font_size_floor(skeleton, plan.family)
+            _check_slide_constitution_gates(skeleton, plan.slide, index=plan.index, family=plan.family)
             html = _normalize_skeleton(skeleton)
             if plan.expect_hero and hero_filename:
                 html = _hero_bg_to_img(html, hero_filename)
@@ -1545,6 +1724,38 @@ async def compose_carousel(
 
     result = await render_html_files(html_specs, output_dir, timeout_ms=timeout_ms, make_pdf=True)
 
+    # Article 2.3 palette-adherence SIGNAL (recorded, NOT a hard gate — see
+    # critic_signals.palette_adherence_ratio module comment for why v1 ships
+    # as a measured value to calibrate a future threshold, not a fabricated
+    # one). Never allowed to break the render pipeline — a signal failing to
+    # compute is a warning, not a carousel failure.
+    from .critic_signals import palette_adherence_ratio  # local import, optional numpy/PIL dep
+
+    plans_by_index = {p.index: p for p in plans}
+    palette_signal: list[dict[str, Any]] = []
+    for png_path in result.png_paths:
+        try:
+            idx = int(png_path.stem)
+        except ValueError:
+            continue
+        plan = plans_by_index.get(idx)
+        if plan is None:
+            continue
+        try:
+            ratio = palette_adherence_ratio(png_path, family=plan.family, has_hero=plan.expect_hero)
+        except Exception as exc:
+            logger.warning("Art 2.3 palette signal failed for slide %d: %s", idx, exc)
+            continue
+        palette_signal.append({"slide": idx, "family": plan.family, "ratio": round(ratio, 4)})
+        if ratio < 0.95:
+            logger.warning(
+                "Art 2.3 palette signal: slide %d (%s) ratio=%.3f below the "
+                "constitution's 95%% target — SIGNAL ONLY (v1, uncalibrated "
+                "threshold), recorded in manifest.json palette_adherence",
+                idx, plan.family, ratio,
+            )
+    palette_signal.sort(key=lambda e: e["slide"])
+
     # write a manifest
     manifest = {
         "topic": topic,
@@ -1557,6 +1768,7 @@ async def compose_carousel(
         "failures": result.failures,
         "png_paths": [str(p) for p in result.png_paths],
         "pdf_path": str(result.pdf_path) if result.pdf_path else None,
+        "palette_adherence": palette_signal,
     }
     (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     return result
@@ -1586,6 +1798,7 @@ async def materialize_slide_html(
 
     skeleton = _extract_skeleton(family)
     _check_body_font_size_floor(skeleton, family)
+    _check_slide_constitution_gates(skeleton, slide, index=index, family=family)
     html = _normalize_skeleton(skeleton)
     if expect_hero and hero_filename:
         html = _hero_bg_to_img(html, hero_filename)

--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -1301,6 +1301,20 @@ def _check_body_word_count(skeleton: str, slide: dict[str, Any], *, index: int, 
     if "{{body}}" not in skeleton:
         return
     body = str(slide.get("body") or slide.get("body_text") or "").strip()
+    # FACTS-STACK exemption: a body the composer itself parses as LABEL: value
+    # fact pairs renders as a discrete row stack (see the facts_block branch in
+    # _fill_placeholders), not as running prose. Article 6.1's 25-50 band is a
+    # PROSE-legibility rule — its stated rationale is UPPERCASE reading-speed +
+    # text-zone overflow of continuous copy — and a terse 4-row facts stack
+    # ("NEW FEE: IDR 3,500,000. OLD FEE: ...") is legitimate editorial well
+    # under 25 words. The exemption predicate is EXACTLY the composer's own
+    # facts-branch condition (same _split_source_line + _parse_fact_pairs
+    # call chain), so the gate and the renderer can never disagree about
+    # which bodies are prose.
+    if body:
+        body_wo_source, _ = _split_source_line(body)
+        if _parse_fact_pairs(body_wo_source):
+            return
     n = len(body.split()) if body else 0
     if not (_ART_6_1_BODY_WORD_MIN <= n <= _ART_6_1_BODY_WORD_MAX):
         raise ValueError(

--- a/scripts/wr2_html_renderer/critic_signals.py
+++ b/scripts/wr2_html_renderer/critic_signals.py
@@ -161,6 +161,109 @@ def calmest_band(image_path: Path, n_bands: int = 3) -> tuple[int, list[float]]:
     return best, busyness
 
 
+# ---------------------------------------------------------------------------
+# Article 2.3 palette-adherence SIGNAL (2026-07-14, cure item 13 /
+# research/operations/2026-07-14-wr2-deep-audit.md §5): the constitution says
+# "TEXT zones... >=95% of pixels in palette tokens. Hard fail" but no
+# measurement of this existed anywhere in the engine (grep-verified). This
+# adds the actual pixel measurement — but ships it as a recorded SIGNAL
+# (logged + written to manifest.json), NOT a hard gate, because:
+#   1. We don't have per-element zone bounding boxes at this post-render
+#      stage (no structured layout JSON survives PNG rasterization) — the
+#      hero-band exclusion below is a coarse family-aware approximation
+#      (reusing renderer._hero_visible_in_png's band geometry), not a real
+#      per-element text/hero/overlay mask. It over-excludes (the gradient
+#      overlay + any text inside the excluded band is skipped too, not just
+#      the photo) and under-excludes (a stray hero corner outside the band
+#      still counts against the ratio).
+#   2. No calibration run exists yet against real published carousels to
+#      pick a defensible tolerance/threshold; fabricating a hard-fail
+#      threshold without that data would over-block on the approximation's
+#      noise, not the actual brand violation.
+# Recording the ratio on every render is what MAKES that calibration
+# possible later — see PR body for the v1-signal-not-gate rationale.
+# ---------------------------------------------------------------------------
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[float, float, float]:
+    h = hex_color.lstrip("#")
+    return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def _brand_palette_rgb() -> np.ndarray:
+    """The exact 6 tokens Article 2.3 names: color.bg.* + color.text.* +
+    color.accent.* + color.status.* (NOT color.overlay.* — that's a photo
+    legibility scrim, not a palette color per Article 2.1's token table)."""
+    from .tokens_to_css import load_tokens  # local import, mirrors renderer.py
+
+    tokens = load_tokens()
+    color = tokens["color"]
+    hexes = [
+        color["bg"]["antracite"]["value"],
+        color["bg"]["black"]["value"],
+        color["text"]["white"]["value"],
+        color["text"]["muted"]["value"],
+        color["accent"]["yellow"]["value"],
+        color["status"]["red"]["value"],
+    ]
+    return np.array([_hex_to_rgb(h) for h in hexes], dtype=np.float64)
+
+
+def _hero_exclusion_band(family: str | None, h: int) -> tuple[int, int] | None:
+    """Row range (y0, y1) to exclude as the HERO PHOTO zone, mirroring
+    renderer._hero_visible_in_png's family-aware sampling bands exactly (same
+    families, same fractions) so the two never drift apart. None = no
+    exclusion (measure the whole canvas)."""
+    if family == "photo-fullbleed-top":
+        return (11 * h // 20, 17 * h // 20)  # ~55%-85%
+    if family == "photo-fullbleed-split":
+        return (2 * h // 5, 3 * h // 5)  # ~40%-60%
+    return (h // 12, h // 3)  # ~8%-33% (cover-photo / photo-headline-yellow-sub / photo-fullbleed / unknown)
+
+
+def palette_adherence_ratio(
+    png_path: Path,
+    *,
+    family: str | None = None,
+    has_hero: bool = False,
+    tolerance: float = 40.0,
+    sample_stride: int = 4,
+) -> float:
+    """Fraction of sampled canvas pixels within `tolerance` Euclidean RGB
+    distance of the nearest brand-palette token color (Article 2.3 signal).
+
+    `has_hero=False` (text-only families — editorial-text, dark-status-list,
+    evidence-carved, statement-bomb, elegant-close, qa-dialogue,
+    timeline-pinboard, numbered-forces-list, stat-card-hero) measures the
+    FULL canvas — there is no photo zone to exclude, so the whole slide IS
+    the constitution's TEXT zone. `has_hero=True` excludes the family-aware
+    hero band (see `_hero_exclusion_band`) before measuring — approximating
+    Article 2.3's "HERO PHOTO zones: NO palette pixel constraint" exemption.
+
+    `tolerance` (Euclidean RGB distance, 0-441) accounts for anti-aliased
+    text edges and JPEG-ish gradient banding blending a palette color into
+    its neighbor — a bare exact-hex match would undercount even a perfectly
+    compliant slide. 40.0 is a starting value (~14% of the 0-255 per-channel
+    range), NOT calibrated against real renders — see module comment.
+    """
+    palette_rgb = _brand_palette_rgb()
+    arr = _load_rgb(png_path).astype(np.float64)
+    h, w, _ = arr.shape
+    if has_hero:
+        y0, y1 = _hero_exclusion_band(family, h)
+        keep = np.ones(h, dtype=bool)
+        keep[y0:y1] = False
+        arr = arr[keep]
+    if arr.size == 0:
+        return 1.0  # degenerate (nothing left to measure) — no false alarm
+    sampled = arr[::sample_stride, ::sample_stride, :].reshape(-1, 3)
+    if sampled.size == 0:
+        return 1.0
+    dists = np.sqrt(((sampled[:, None, :] - palette_rgb[None, :, :]) ** 2).sum(axis=2))
+    nearest = dists.min(axis=1)
+    return float((nearest <= tolerance).mean())
+
+
 @dataclass
 class GeometryLint:
     near_empty: bool  # slide is almost all one flat color (render likely broke)

--- a/scripts/wr2_html_renderer/renderer.py
+++ b/scripts/wr2_html_renderer/renderer.py
@@ -127,7 +127,24 @@ def _stage_assets(output_dir: Path) -> None:
     if _BRAND_LOGO.is_file():
         shutil.copy2(_BRAND_LOGO, slides_dir / "logo.png")
     else:
-        logger.warning("brand logo not found at %s — slides will miss the logo", _BRAND_LOGO)
+        # HARD GATE (2026-07-14, cure item 13 / Article 4.3 "present on every
+        # slide without exception. Hard fail if missing"). Was a
+        # logger.warning since the renderer's original PR (#1228) — staging
+        # would silently continue with no logo.png at all, and EVERY layout
+        # skeleton in the library (12/12, verified via `grep -l
+        # data-zone-type="logo" layouts/*.md`) bakes the mark via CSS
+        # `background-image:url('logo.png')` against this ONE staged file,
+        # so a missing master asset means every slide in the carousel would
+        # render logo-less. No layout family is exempt (no full-bleed-hero
+        # skeleton omits the logo div either), so this is a blanket gate —
+        # mirrors the W99 BRAND FONT NOT LOADED hard gate in _render_one
+        # below: green ≠ working (superscar #2), a carousel without the
+        # brand mark is a render FAILURE, not a nuance worth a log line.
+        raise FileNotFoundError(
+            f"Article 4.3 hard fail: brand logo asset not found at "
+            f"{_BRAND_LOGO} — every slide in this carousel would render "
+            f"without the logo"
+        )
 
     # _base.css with token :root injected from tokens.json (no drift)
     from .tokens_to_css import load_tokens, render_root_block  # local import
@@ -191,9 +208,35 @@ async () => {
   //    reflects post-load() truth rather than the lazy status field).
   const montserrat = document.fonts.check('800 16px Montserrat')
                   || document.fonts.check('700 16px Montserrat');
-  return { total_images: imgs.length, decoded_images: decoded, montserrat };
+  // 4. Logo (Article 4.3 — present on every slide, hard fail if missing).
+  //    Every layout skeleton bakes the mark as `<div class="logo">` with the
+  //    CSS background-image set in _base.css; check the element exists AND
+  //    its resolved background-image actually loaded (not 'none' — the
+  //    value it falls back to if logo.png 404s under this file:// origin).
+  const logoEl = document.querySelector('.logo');
+  const logoPresent = !!logoEl;
+  let logoBgOk = false;
+  if (logoEl) {
+    const bg = getComputedStyle(logoEl).backgroundImage;
+    logoBgOk = !!bg && bg !== 'none';
+  }
+  return {
+    total_images: imgs.length, decoded_images: decoded, montserrat,
+    logo_present: logoPresent, logo_bg_ok: logoBgOk,
+  };
 }
 """
+
+
+def _readiness_logo_ok(readiness: dict[str, Any]) -> bool:
+    """Article 4.3 gate predicate: True only if the rendered page has a
+    `.logo` element AND its CSS background-image actually resolved.
+
+    Pulled out of `_render_one` as a pure function so the gate logic is
+    unit-testable without a live Chromium page (mirrors the readiness dict
+    shape `_READINESS_JS` returns).
+    """
+    return bool(readiness.get("logo_present")) and bool(readiness.get("logo_bg_ok"))
 
 
 async def _render_one(
@@ -235,6 +278,22 @@ async def _render_one(
             f"{html_path.name}: BRAND FONT NOT LOADED — Montserrat @font-face "
             f"unavailable (missing _fonts.css link?); slide would paint in the "
             f"system font",
+        )
+
+    if not _readiness_logo_ok(readiness):
+        # HARD GATE (2026-07-14, cure item 13 / Article 4.3): the staging-time
+        # check above (_stage_assets) only proves the master asset EXISTS on
+        # disk; this proves the mark actually resolved on THIS rendered page
+        # (mirrors the montserrat check's mechanism — a boolean read off the
+        # in-page readiness probe, gated per-slide, not a log line). No layout
+        # family is exempt, so a missing/unresolved logo is a hard fail here
+        # too, same as the font gate above.
+        return (
+            False,
+            False,
+            f"{html_path.name}: LOGO MISSING — Article 4.3 requires the brand "
+            f"mark on every slide without exception; .logo element "
+            f"{'not found' if not readiness.get('logo_present') else 'has no background-image loaded'}",
         )
 
     if expect_hero:

--- a/scripts/wr2_html_renderer/tests/test_article2_3_palette_signal.py
+++ b/scripts/wr2_html_renderer/tests/test_article2_3_palette_signal.py
@@ -1,0 +1,135 @@
+"""Article 2.3 (palette >=95% pixel adherence) SIGNAL tests (cure item 13,
+2026-07-14 — research/operations/2026-07-14-wr2-deep-audit.md §5: "Art 2.3
+'>=95% palette pixels' (the measurement does not exist in code)").
+
+This ships as a recorded SIGNAL (manifest.json `palette_adherence`), not a
+hard gate — see critic_signals.py module comment for why (no per-element
+zone bounding boxes survive to the PNG, no calibration data yet). These
+tests pin the measurement itself: guilt (off-palette fill scores low),
+innocence (on-palette fill scores ~1.0), and the hero-band exclusion
+(an off-palette hero region must not drag down a compliant text canvas).
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from wr2_html_renderer import critic_signals as CS  # noqa: E402
+
+pytest.importorskip("PIL")
+pytest.importorskip("numpy")
+
+from PIL import Image  # noqa: E402
+
+
+def _solid_png(path, rgb, size=(200, 250)):
+    Image.new("RGB", size, rgb).save(path)
+
+
+def _split_png(path, top_rgb, bottom_rgb, size=(200, 250), split_frac=0.33):
+    img = Image.new("RGB", size)
+    w, h = size
+    split_y = int(h * split_frac)
+    for y in range(h):
+        color = top_rgb if y < split_y else bottom_rgb
+        for x in range(w):
+            img.putpixel((x, y), color)
+    img.save(path)
+
+
+# --- INNOCENCE: a slide painted entirely in a brand palette color ----------
+
+def test_innocence_pure_antracite_scores_full_adherence(tmp_path):
+    p = tmp_path / "slide.png"
+    _solid_png(p, (0x37, 0x3D, 0x42))  # color.bg.antracite
+    ratio = CS.palette_adherence_ratio(p, has_hero=False)
+    assert ratio > 0.99
+
+
+def test_innocence_pure_yellow_accent_scores_full_adherence(tmp_path):
+    p = tmp_path / "slide.png"
+    _solid_png(p, (0xF4, 0xC4, 0x30))  # color.accent.yellow
+    ratio = CS.palette_adherence_ratio(p, has_hero=False)
+    assert ratio > 0.99
+
+
+# --- GUILT: a slide painted in a banned color -------------------------------
+
+@pytest.mark.parametrize(
+    "rgb",
+    [
+        (0, 200, 0),  # banned green
+        (0, 0, 220),  # banned blue
+        (150, 50, 200),  # banned purple
+    ],
+)
+def test_guilt_banned_color_scores_low_adherence(tmp_path, rgb):
+    p = tmp_path / "slide.png"
+    _solid_png(p, rgb)
+    ratio = CS.palette_adherence_ratio(p, has_hero=False)
+    assert ratio < 0.05
+
+
+# --- Hero-band exclusion: has_hero=True must exclude the photo zone --------
+
+def test_hero_band_exclusion_ignores_offpalette_top_third(tmp_path):
+    """A cover-photo slide: the family's exposed photo band (~8%-33%, the
+    same fractions renderer._hero_visible_in_png samples) is a (simulated)
+    cinematic photo full of banned-palette colors; everywhere else is
+    compliant antracite bg + white text. Article 2.3 exempts the hero zone
+    entirely — has_hero=True with family='cover-photo' should score
+    near-1.0 despite the noisy band, while measuring the FULL canvas (no
+    exclusion) must score visibly lower."""
+    p = tmp_path / "slide.png"
+    w, h = 200, 250
+    img = Image.new("RGB", (w, h), (0x37, 0x3D, 0x42))
+    y0, y1 = h // 12, h // 3  # exact band CS._hero_exclusion_band computes
+    for y in range(y0, y1):
+        for x in range(w):
+            img.putpixel((x, y), (0, 180, 0))
+    img.save(p)
+    ratio_excluding_hero = CS.palette_adherence_ratio(p, family="cover-photo", has_hero=True)
+    ratio_full_canvas = CS.palette_adherence_ratio(p, has_hero=False)
+    assert ratio_excluding_hero > 0.99
+    assert ratio_full_canvas < ratio_excluding_hero  # exclusion demonstrably matters
+
+
+def test_hero_band_exclusion_family_aware_lower_band(tmp_path):
+    """photo-fullbleed-top exposes its photo LOWER (~55%-85%), not top-third
+    — verifies the band mirrors renderer._hero_visible_in_png's per-family
+    geometry rather than always assuming top-third."""
+    p = tmp_path / "slide.png"
+    w, h = 200, 250
+    img = Image.new("RGB", (w, h), (0x37, 0x3D, 0x42))
+    # paint the family's actual exposed band (55%-85%) with a banned color
+    y0, y1 = int(h * 0.55), int(h * 0.85)
+    for y in range(y0, y1):
+        for x in range(w):
+            img.putpixel((x, y), (0, 0, 220))
+    img.save(p)
+    ratio = CS.palette_adherence_ratio(p, family="photo-fullbleed-top", has_hero=True)
+    assert ratio > 0.9
+
+
+def test_signal_returns_plain_float_not_a_verdict_object(tmp_path):
+    """Contract check: the function returns a plain float ratio (a SIGNAL),
+    never a pass/fail verdict object — callers decide what to do with it."""
+    p = tmp_path / "slide.png"
+    _solid_png(p, (0x37, 0x3D, 0x42))
+    ratio = CS.palette_adherence_ratio(p, has_hero=False)
+    assert isinstance(ratio, float)
+    assert 0.0 <= ratio <= 1.0
+
+
+def test_degenerate_full_exclusion_returns_neutral_one(tmp_path, monkeypatch):
+    """Defensive edge case: if the hero-band exclusion were ever to consume
+    the ENTIRE canvas (not reachable via the real per-family bands, which
+    are always a proper subset — verified by the other hero-band tests —
+    but the code must not crash or manufacture a false alarm if it were),
+    fall back to a neutral 1.0 rather than dividing by zero samples."""
+    p = tmp_path / "slide.png"
+    _solid_png(p, (0, 200, 0), size=(10, 10))
+    monkeypatch.setattr(CS, "_hero_exclusion_band", lambda family, h: (0, h))
+    ratio = CS.palette_adherence_ratio(p, family="cover-photo", has_hero=True)
+    assert ratio == 1.0

--- a/scripts/wr2_html_renderer/tests/test_article4_3_logo_gate.py
+++ b/scripts/wr2_html_renderer/tests/test_article4_3_logo_gate.py
@@ -1,0 +1,95 @@
+"""Article 4.3 (logo on every slide) hard-gate tests (cure item 13,
+2026-07-14 — research/operations/2026-07-14-wr2-deep-audit.md §5: "Art 4.3
+logo-on-every-slide (warning only, renderer.py:130)").
+
+Two mechanisms, two test groups:
+  1. _stage_assets: promoted from logger.warning to a hard FileNotFoundError
+     when the master logo.png asset is missing (staging-time, fail-fast).
+  2. _readiness_logo_ok: per-slide render-time gate predicate (mirrors the
+     W99 BRAND FONT NOT LOADED mechanism — a boolean read off the in-page
+     readiness probe), pulled out as a pure function so it's testable
+     without a live Chromium page.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from wr2_html_renderer import renderer as R  # noqa: E402
+
+
+# --- _stage_assets: staging-time hard gate ----------------------------------
+
+def test_guilt_missing_master_logo_asset_hard_fails(tmp_path, monkeypatch):
+    monkeypatch.setattr(R, "_BRAND_LOGO", tmp_path / "does-not-exist.png")
+    out_dir = tmp_path / "out"
+    with pytest.raises(FileNotFoundError, match=r"Article 4\.3"):
+        R._stage_assets(out_dir)
+
+
+def test_innocence_present_master_logo_asset_stages_cleanly(tmp_path, monkeypatch):
+    fake_logo = tmp_path / "logo.png"
+    # minimal valid PNG bytes (1x1 transparent) — _stage_assets only copies
+    # the file, it doesn't decode it, so any real file proves the branch.
+    fake_logo.write_bytes(
+        bytes.fromhex(
+            "89504e470d0a1a0a0000000d494844520000000100000001080600000"
+            "01f15c4890000000a49444154789c6360000002000155001e0e5a9a00"
+            "0000004945454e44ae426082"
+        )
+    )
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(R, "_BRAND_LOGO", fake_logo)
+    # _stage_assets also reads the brand _base.css and tokens.json — those
+    # ARE expected to exist in this repo checkout (brand skill is checked
+    # in), so we exercise the real path rather than mocking them away.
+    if not (R.Path.home() / ".claude" / "skills" / "bali-zero-brand" / "layouts" / "_base.css").is_file():
+        pytest.skip("brand skill _base.css not present on this machine")
+    R._stage_assets(out_dir)
+    assert (out_dir / "logo.png").is_file()
+    assert (out_dir / "logo.png").read_bytes() == fake_logo.read_bytes()
+
+
+# --- _readiness_logo_ok: per-slide render-time gate predicate ---------------
+
+def test_guilt_no_logo_element_fails():
+    assert not R._readiness_logo_ok({"logo_present": False, "logo_bg_ok": False})
+
+
+def test_guilt_logo_element_present_but_background_unresolved_fails():
+    """The element exists (a stray `.logo` div in markup) but its CSS
+    background-image never loaded (e.g. logo.png 404 under file://) — must
+    still fail, matching the montserrat gate's boolean-truth mechanism."""
+    assert not R._readiness_logo_ok({"logo_present": True, "logo_bg_ok": False})
+
+
+def test_innocence_logo_present_and_loaded_passes():
+    assert R._readiness_logo_ok({"logo_present": True, "logo_bg_ok": True})
+
+
+def test_innocence_missing_keys_default_to_fail_not_crash():
+    """Defensive: a readiness dict from an older/odd page (missing the new
+    keys entirely) must fail closed, not raise a KeyError."""
+    assert not R._readiness_logo_ok({})
+
+
+def test_sweep_real_layout_library_every_family_declares_a_logo_div():
+    """Ground-truth precondition for the blanket (no-exception) gate: every
+    layout family's skeleton bakes a `.logo` div. If a future family adds a
+    legitimate no-logo variant (e.g. a full-bleed hero with no mark), this
+    sweep must be updated to encode that exception explicitly — the gate
+    must never silently blanket-fail a slide type that's allowed to skip it."""
+    from pathlib import Path
+
+    layouts_dir = Path.home() / ".claude" / "skills" / "bali-zero-brand" / "layouts"
+    if not layouts_dir.is_dir():
+        pytest.skip("brand layouts dir not present on this machine")
+    checked = 0
+    for md in sorted(layouts_dir.glob("*.md")):
+        text = md.read_text(encoding="utf-8")
+        if "```html" not in text:
+            continue  # _base.css and other non-skeleton .md files
+        assert 'data-zone-type="logo"' in text, md.name
+        checked += 1
+    assert checked > 0, "no skeletons checked — blind sweep (W84 guard)"

--- a/scripts/wr2_html_renderer/tests/test_article6_1_word_count.py
+++ b/scripts/wr2_html_renderer/tests/test_article6_1_word_count.py
@@ -68,6 +68,39 @@ def test_innocence_body_text_fallback_key_also_checked():
     assert result is None  # did not raise
 
 
+def test_innocence_facts_stack_body_exempt_even_when_short():
+    """A body the composer parses as LABEL: value fact pairs renders as a
+    discrete facts STACK, not prose — Article 6.1's prose word band does not
+    apply (exemption predicate = the composer's own facts-branch condition).
+    This exact 20-word shape is the real _FACTS_BODY fixture that the
+    backend-side consumer test (test_wr2_html_render_apply.py) pushes
+    through materialize_slide_html."""
+    facts_body = (
+        "NEW FEE: IDR 3,500,000. OLD FEE: IDR 2,000,000. REGULATION: PMK 47/2026. "
+        "EFFECTIVE: 1 JUNE 2026. [SOURCE: KEMENKEU, 24 APR 2026]"
+    )
+    assert len(facts_body.split()) < C._ART_6_1_BODY_WORD_MIN  # would fail as prose
+    result = C._check_body_word_count(
+        _SKELETON_WITH_BODY, {"body": facts_body}, index=2, family="editorial-text"
+    )
+    assert result is None  # did not raise
+
+
+def test_guilt_short_prose_body_still_fails_next_to_facts_exemption():
+    """Boundary guard for the exemption itself: a 20-word body that does NOT
+    parse as fact pairs (plain prose) must still hard-fail — the facts
+    exemption must not become an under-match hole for any short body."""
+    prose_20 = (
+        "The new regulation changes everything about how foreign companies "
+        "register their business activities in Indonesia starting from June"
+    )
+    assert len(prose_20.split()) < C._ART_6_1_BODY_WORD_MIN  # genuinely short prose
+    with pytest.raises(ValueError, match=r"Article 6\.1"):
+        C._check_body_word_count(
+            _SKELETON_WITH_BODY, {"body": prose_20}, index=3, family="editorial-text"
+        )
+
+
 def test_innocence_family_without_body_placeholder_is_untouched():
     """statement-bomb: Article 6.6 wants a SHORT closing line — a 3-word
     statement must not trip the 25-50-word body gate. Its skeleton has no

--- a/scripts/wr2_html_renderer/tests/test_article6_1_word_count.py
+++ b/scripts/wr2_html_renderer/tests/test_article6_1_word_count.py
@@ -1,0 +1,115 @@
+"""Article 6.1 (body word count) hard-gate tests (cure item 13, 2026-07-14 —
+research/operations/2026-07-14-wr2-deep-audit.md §5: "Art 6.1 body
+word-count... [NONE — hard fail on paper, nothing executable]").
+
+Guilt (too short / too long fails) AND innocence (in-range passes, AND
+families that legitimately render no {{body}} prose are untouched — cover
+per the constitution's explicit exemption, statement-bomb per Article 6.6's
+short-closing mandate).
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from wr2_html_renderer import composer as C  # noqa: E402
+
+_SKELETON_WITH_BODY = "<html><head></head><body>{{heading}}{{body}}</body></html>"
+_SKELETON_WITHOUT_BODY = "<html><head></head><body>{{statement}}</body></html>"
+
+
+def _words(n: int) -> str:
+    return " ".join(f"word{i}" for i in range(n))
+
+
+# --- GUILT ------------------------------------------------------------------
+
+def test_guilt_body_too_short_hard_fails():
+    slide = {"body": _words(10)}
+    with pytest.raises(ValueError, match=r"Article 6\.1"):
+        C._check_body_word_count(_SKELETON_WITH_BODY, slide, index=2, family="editorial-text")
+
+
+def test_guilt_body_too_long_hard_fails():
+    slide = {"body": _words(75)}
+    with pytest.raises(ValueError, match=r"Article 6\.1"):
+        C._check_body_word_count(_SKELETON_WITH_BODY, slide, index=2, family="editorial-text")
+
+
+def test_guilt_empty_body_on_a_body_family_hard_fails():
+    slide = {"body": ""}
+    with pytest.raises(ValueError):
+        C._check_body_word_count(_SKELETON_WITH_BODY, slide, index=2, family="editorial-text")
+
+
+def test_guilt_error_names_slide_family_and_count():
+    slide = {"body": _words(10)}
+    with pytest.raises(ValueError) as exc_info:
+        C._check_body_word_count(_SKELETON_WITH_BODY, slide, index=4, family="stat-card-hero")
+    msg = str(exc_info.value)
+    assert "slide 4" in msg
+    assert "stat-card-hero" in msg
+    assert "10" in msg
+
+
+# --- INNOCENCE ----------------------------------------------------------------
+
+@pytest.mark.parametrize("n", [25, 37, 50])
+def test_innocence_in_range_passes(n):
+    slide = {"body": _words(n)}
+    result = C._check_body_word_count(_SKELETON_WITH_BODY, slide, index=2, family="editorial-text")
+    assert result is None  # did not raise
+
+
+def test_innocence_body_text_fallback_key_also_checked():
+    slide = {"body_text": _words(30)}
+    result = C._check_body_word_count(_SKELETON_WITH_BODY, slide, index=2, family="photo-fullbleed")
+    assert result is None  # did not raise
+
+
+def test_innocence_family_without_body_placeholder_is_untouched():
+    """statement-bomb: Article 6.6 wants a SHORT closing line — a 3-word
+    statement must not trip the 25-50-word body gate. Its skeleton has no
+    {{body}} token, so the gate is a structural no-op for it."""
+    slide = {"statement": "ZERO PENALTY", "body": ""}  # body irrelevant/absent
+    result = C._check_body_word_count(_SKELETON_WITHOUT_BODY, slide, index=9, family="statement-bomb")
+    assert result is None  # did not raise
+
+
+def test_innocence_cover_family_has_no_body_placeholder():
+    """Constitution: 'Cover slide exempt (title only)' — verified structurally:
+    the real cover-photo skeleton has no {{body}} token."""
+    skeleton = C._extract_skeleton("cover-photo")
+    assert "{{body}}" not in skeleton
+    slide = {"headline": "SHORT COVER TITLE", "body": ""}
+    C._check_body_word_count(skeleton, slide, index=1, family="cover-photo")  # no raise
+
+
+def test_sweep_real_layout_library_body_placeholder_families_match_expectation():
+    """Ground-truth sweep (guard-conformance doctrine): the families this
+    module's docstring claims render {{body}} must match what's actually in
+    the layout library on disk, so the gate scope never silently drifts."""
+    from pathlib import Path
+
+    expected_with_body = {
+        "editorial-text",
+        "photo-fullbleed-split",
+        "photo-fullbleed-top",
+        "photo-headline-yellow-sub",
+        "photo-fullbleed",
+        "source-citation",
+        "stat-card-hero",
+    }
+    layouts_dir = Path(C._LAYOUTS)
+    if not layouts_dir.is_dir():
+        pytest.skip("brand layouts dir not present on this machine")
+    found_with_body = set()
+    for md in sorted(layouts_dir.glob("*.md")):
+        try:
+            skeleton = C._extract_skeleton(md.stem)
+        except (FileNotFoundError, ValueError):
+            continue
+        if "{{body}}" in skeleton:
+            found_with_body.add(md.stem)
+    assert found_with_body == expected_with_body

--- a/scripts/wr2_html_renderer/tests/test_article7_forbidden_phrases.py
+++ b/scripts/wr2_html_renderer/tests/test_article7_forbidden_phrases.py
@@ -1,0 +1,134 @@
+"""Article 7 (forbidden phrases) hard-gate tests (cure item 13, 2026-07-14 —
+research/operations/2026-07-14-wr2-deep-audit.md §5: "Art 7 forbidden-phrase
+list (no scanner anywhere in the engine — grep verified)").
+
+Guilt AND innocence per the guard-conformance doctrine (scar family #3 —
+substring trapping): every guard needs a test that PROVES it fires on a real
+violation and a test that PROVES it does NOT fire on a legitimate neighbor
+(a banned single word appearing as a substring INSIDE a longer, innocent
+word must not trigger — the exact W-shape that has bitten this repo before).
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from wr2_html_renderer import composer as C  # noqa: E402
+
+
+def test_loads_the_real_constitution_closed_list():
+    """Ground truth: parses straight from constitution.md, not a hardcoded
+    copy — 22 bullets, one ('swipe to`/`swipe for') carries 2 phrases = 23."""
+    phrases = C._load_forbidden_phrases()
+    assert len(phrases) == 23
+    assert "delve into" in phrases
+    assert "synergy" in phrases
+    assert "swipe to" in phrases
+    assert "swipe for" in phrases
+
+
+def test_missing_constitution_file_fails_closed(tmp_path):
+    """Fail-closed idiom (mirrors tokens_to_css.load_tokens /
+    _brand_base_css_body): no phrase list, no render — never soft-pass."""
+    with pytest.raises(FileNotFoundError):
+        C._load_forbidden_phrases(tmp_path / "nope.md")
+
+
+def test_missing_article_7_section_is_fail_visible(tmp_path):
+    bad = tmp_path / "constitution.md"
+    bad.write_text("# Bali Zero Brand Constitution\n\n## Article 1 — Format\n...\n")
+    with pytest.raises(ValueError):
+        C._load_forbidden_phrases(bad)
+
+
+# --- GUILT: single-word phrase fires on the whole word --------------------
+
+@pytest.mark.parametrize(
+    "phrase,text",
+    [
+        ("unlock", "please unlock your KITAS today"),
+        ("landscape", "the regulatory landscape shifted overnight"),
+        ("paradise", "this is not paradise, it is paperwork"),
+        ("synergy", "we found real synergy between the two filings"),
+        ("game-changer", "PP 20/2026 is a real game-changer for PT PMA"),
+        ("delve into", "let us delve into the new tax rules"),
+        ("let's dive in", "let's dive in now"),
+        ("DM us", "just DM us for a quote"),
+    ],
+)
+def test_guilt_phrase_fires(phrase, text):
+    assert C._forbidden_phrase_pattern(phrase).search(text), (phrase, text)
+
+
+# --- INNOCENCE: banned word as a substring of a longer legitimate word ----
+
+@pytest.mark.parametrize(
+    "phrase,text",
+    [
+        ("unlock", "the unlockable feature is not available"),
+        ("landscape", "the landscaper redesigned the villa garden"),
+        ("realm", "the realmost setting was unrelated"),  # contrived but proves boundary
+        ("journey", "journeyman electricians are in short supply"),
+        ("ecosystem", "the ecosystemic study looked at soil health"),
+    ],
+)
+def test_innocence_substring_inside_longer_word_does_not_fire(phrase, text):
+    assert not C._forbidden_phrase_pattern(phrase).search(text), (phrase, text)
+
+
+def test_innocence_clean_copy_no_match():
+    slide = {
+        "headline": "KITAS RENEWAL RULES CHANGED",
+        "body": "New KITAS renewals now require the sponsor's NPWP on file "
+        "before OSS will process the extension, effective this quarter for "
+        "every foreign worker permit renewal filed after May.",
+    }
+    result = C._check_forbidden_phrases(slide, index=1)
+    assert result is None  # did not raise
+
+
+def test_guilt_raises_with_slide_and_phrase_named():
+    slide = {"headline": "PLEASE UNLOCK YOUR KITAS TODAY"}
+    with pytest.raises(ValueError) as exc_info:
+        C._check_forbidden_phrases(slide, index=3)
+    msg = str(exc_info.value)
+    assert "slide 3" in msg
+    assert "unlock" in msg
+
+
+def test_guilt_collects_multiple_hits_across_fields():
+    slide = {
+        "headline": "LET'S DIVE IN TO PARADISE",
+        "body": "our seamless synergy makes it a real game-changer for you",
+    }
+    with pytest.raises(ValueError) as exc_info:
+        C._check_forbidden_phrases(slide, index=5)
+    msg = str(exc_info.value)
+    # at least the heading AND body violations are both reported, not just
+    # the first hit found (single retry should fix everything at once)
+    assert "heading=" in msg
+    assert "body=" in msg
+
+
+def test_sweep_real_manual_asset_carousels_stay_clean():
+    """Regression guard: the two shipped example carousels in
+    docs/wr2/manual-assets/ must not spuriously trip Article 7 (they predate
+    this gate but were hand-authored to brand voice already)."""
+    import glob
+    import json
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[3]
+    pattern = str(root / "docs" / "wr2" / "manual-assets" / "*" / "slides.json")
+    files = glob.glob(pattern)
+    if not files:
+        pytest.skip("manual-assets fixtures not present on this machine")
+    checked = 0
+    for f in files:
+        data = json.loads(Path(f).read_text())
+        slides = data.get("slides", data) if isinstance(data, dict) else data
+        for i, slide in enumerate(slides, 1):
+            C._check_forbidden_phrases(slide, index=i)  # must not raise
+            checked += 1
+    assert checked > 0, "no slides checked — blind sweep (W84 guard)"


### PR DESCRIPTION
## Summary
- Cure-plan item 13: gives the previously "[NONE]" (docs-only, unenforced) brand-constitution articles teeth as executable gates in the WR2 HTML renderer — Art 7 (forbidden phrases), Art 6.1 (word count), Art 4.3 (logo gate), plus a new Art 2.3 palette signal in `critic_signals.py` for the critic to consume.
- Verified this branch's diff does not touch `scripts/wr2_image_generator.py` or `scripts/wr2_html_render_apply.py`, so it does not need to wait on the image-gen PR train.

## Test plan
- [x] `pytest scripts/wr2_html_renderer/tests/test_article2_3_palette_signal.py test_article4_3_logo_gate.py test_article6_1_word_count.py test_article7_forbidden_phrases.py -q` — 47 passed
- [x] Full `scripts/wr2_html_renderer/tests/` suite — 75 passed (no regressions from the shared composer/renderer/critic_signals edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)