### PR TITLE
chore(home-fork): mark wr2-cron-wrapper divergence resolved — live copy self-realigned on Pro

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -305,7 +305,7 @@
     {
       "live": "~/.openclaw/bin/wr2/wr2-cron-wrapper.sh",
       "repo": "scripts/wr2-cron-wrapper.sh",
-      "_note": "WR2 deep audit 2026-07-14 (§4): the HOME copy (f17092b3) had DIVERGED from the repo copy (3cd52391) on the same machine — oracle/connector/newsletter were running the stale fork. Declared so --check catches this class of drift going forward; the live copy still needs a manual sync on Pro (operator/session task, not this PR).",
+      "_note": "WR2 deep audit 2026-07-14 (§4): the HOME copy (f17092b3) had DIVERGED from the repo copy (3cd52391) on the same machine — oracle/connector/newsletter were running the stale fork. Declared so --check catches this class of drift going forward. RESOLVED same day: the live copy self-realigned via a routine pull (mtime 14:05 WITA), re-verified read-only on Pro 2026-07-14 ~15:30 WITA — sha 3cd52391 both sides, byte-identical. No manual sync pending. Consumers verified via ProgramArguments grep: com.balizero.wr2.{oracle,connector,newsletter,dossier-compiler,learner-nightly,measurer,sla-worker,strategos,trend-hunter} + com.balizero.sota.m13-* all exec ~/.openclaw/bin/wr2/wr2-cron-wrapper.sh (NOT ~/scripts/, which does not exist on Pro).",
       "machines": ["pro"]
     }
   ],

--- a/research/operations/2026-07-14-wr2-deep-audit.md
+++ b/research/operations/2026-07-14-wr2-deep-audit.md
@@ -302,6 +302,14 @@ Only genuinely operator-only items (everything else is session-executable):
    instead of `brand_verifier=claude_design_critic` (`wr2_html_render_apply.py:751`).
 4. Declare the two wr2 wrapper pairs in `declared-pairs.json`; realign the diverged
    `wr2-cron-wrapper.sh` fork on Pro.
+   **CLOSED 2026-07-14**: both pairs declared (PR #2432, `machines=["pro"]`). The realign
+   half resolved itself — the live `~/.openclaw/bin/wr2/wr2-cron-wrapper.sh` self-realigned
+   via a routine pull (mtime 14:05 WITA) and was re-verified read-only on Pro the same
+   afternoon: sha `3cd52391…` byte-identical to `scripts/wr2-cron-wrapper.sh`, and
+   `wr2-script-wrapper.sh` still `e8e22fe1…` both sides. Plist consumers confirmed via
+   `ProgramArguments`: the wr2 crons exec the `~/.openclaw/bin/wr2/` copies (a
+   `~/scripts/wr2-cron-wrapper.sh` path does not exist on Pro). No Pro-side action pending;
+   from here the declared pair makes any future drift a lint `--check` failure instead of luck.
 
 **Wave 1 — resuscitate production (after Wave 0 so recovery doesn't scale unsafe output)**
 5. Fix image-gen per the Wave-0 diagnosis (operator login only if confirmed); add bounded retry


### PR DESCRIPTION
## Summary
- Delta on top of #2432 (which declared the two WR2 wrapper HOME-fork pairs): the cron-wrapper's `_note` still said "the live copy still needs a manual sync on Pro", which is stale. Read-only re-verification on Pro shows the live `~/.openclaw/bin/wr2/wr2-cron-wrapper.sh` self-realigned via a routine pull — byte-identical (sha match) to `scripts/wr2-cron-wrapper.sh` on both sides.
- Closes cure-plan item 4 in the deep-audit doc so nobody chases a manual-sync task that no longer exists (family #2: a stale pending-action is the inverse of a stale green).
- No pair paths/machines changed — note-and-doc truth alignment only.

## Test plan
- [x] `declared-pairs.json` shape-check OK (56 pairs)
- [x] `lint_home_fork.py --check` clean on M5
- [x] `test_lint_home_fork` — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)