### PR TITLE
feat(wr2): arm wr2_orchestrator_metrics — per-step observability writers

### DIFF
--- a/scripts/tests/test_wr2_orchestrator_metrics.py
+++ b/scripts/tests/test_wr2_orchestrator_metrics.py
@@ -1,0 +1,247 @@
+"""Guilt+innocence tests for wr2_orchestrator_metrics (B11).
+
+Migration 203 created `wr2_orchestrator_metrics` with zero production writer
+(research/operations/2026-07-14-wr2-deep-audit.md §1/§8). These tests cover
+the module's two hard contracts:
+
+  1. record_step() / resolve_carousel_id() are FAIL-OPEN-LOUD — a DB error
+     (dead connection, FK violation, whatever) is caught, logged, and never
+     propagates to the caller. A metrics failure must never kill a render.
+  2. A healthy write (fake connection that succeeds) actually reaches
+     conn.execute() with the right SQL shape and values — the innocence
+     case: fail-open must not become "never actually writes".
+
+No real Postgres — a minimal fake asyncpg.Connection stands in.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load(name: str) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec and spec.loader, f"cannot load {name}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+wom = _load("wr2_orchestrator_metrics")
+
+
+class _FakeConn:
+    """Records every execute()/fetchrow() call; can be told to fail."""
+
+    def __init__(self, *, fail: bool = False, fetchrow_result: dict | None = None):
+        self.fail = fail
+        self.fetchrow_result = fetchrow_result
+        self.executed: list[tuple[str, tuple]] = []
+        self.fetchrow_calls: list[tuple[str, tuple]] = []
+        self.closed = False
+
+    async def execute(self, sql: str, *args):
+        if self.fail:
+            raise RuntimeError("simulated DB failure")
+        self.executed.append((sql, args))
+        return "INSERT 0 1"
+
+    async def fetchrow(self, sql: str, *args):
+        if self.fail:
+            raise RuntimeError("simulated DB failure")
+        self.fetchrow_calls.append((sql, args))
+        return self.fetchrow_result
+
+    async def close(self):
+        self.closed = True
+
+
+# ── record_step: guilt (must fail open, never raise) ────────────────────────
+
+
+def test_record_step_db_failure_does_not_raise():
+    import asyncio
+
+    conn = _FakeConn(fail=True)
+
+    async def go():
+        return await wom.record_step(
+            carousel_id="11111111-1111-1111-1111-111111111111",
+            step_name="brief_interpreter",
+            step_index=1,
+            success=True,
+            conn=conn,
+        )
+
+    result = asyncio.run(go())
+    assert result is False  # reported failure, but did NOT raise
+
+
+def test_record_step_none_carousel_id_is_a_noop_not_a_crash():
+    import asyncio
+
+    conn = _FakeConn()
+
+    async def go():
+        return await wom.record_step(
+            carousel_id=None,
+            step_name="brief_interpreter",
+            step_index=1,
+            success=True,
+            conn=conn,
+        )
+
+    result = asyncio.run(go())
+    assert result is False
+    assert conn.executed == []  # never even attempted the FK-doomed insert
+
+
+def test_record_step_unknown_step_name_is_a_noop():
+    import asyncio
+
+    conn = _FakeConn()
+
+    async def go():
+        return await wom.record_step(
+            carousel_id="11111111-1111-1111-1111-111111111111",
+            step_name="not_a_real_step",
+            step_index=1,
+            success=True,
+            conn=conn,
+        )
+
+    result = asyncio.run(go())
+    assert result is False
+    assert conn.executed == []
+
+
+def test_resolve_carousel_id_db_failure_returns_none_not_raise():
+    import asyncio
+
+    conn = _FakeConn(fail=True)
+
+    async def go():
+        return await wom.resolve_carousel_id(
+            conn, topic="some topic", session_id="test-session"
+        )
+
+    result = asyncio.run(go())
+    assert result is None
+
+
+# ── innocence: a healthy write actually reaches conn.execute() ──────────────
+
+
+def test_record_step_healthy_write_reaches_execute_with_right_shape():
+    import asyncio
+
+    conn = _FakeConn()
+
+    async def go():
+        return await wom.record_step(
+            carousel_id="11111111-1111-1111-1111-111111111111",
+            step_name="ig_publisher",
+            step_index=8,
+            model="ig-graph-api",
+            tier=1,
+            latency_ms=1234,
+            retry_count=0,
+            cost_usd_figurative=0.0,
+            success=True,
+            conn=conn,
+        )
+
+    result = asyncio.run(go())
+    assert result is True
+    assert len(conn.executed) == 1
+    sql, args = conn.executed[0]
+    assert "INSERT INTO wr2_orchestrator_metrics" in sql
+    assert args[0] == "11111111-1111-1111-1111-111111111111"  # carousel_id
+    assert args[1] == "ig_publisher"  # step_name
+    assert args[2] == 8  # step_index
+    assert args[10] is True  # success
+
+
+def test_record_step_failure_row_carries_error_class_and_truncated_message():
+    import asyncio
+
+    conn = _FakeConn()
+    long_msg = "x" * 5000
+
+    async def go():
+        return await wom.record_step(
+            carousel_id="11111111-1111-1111-1111-111111111111",
+            step_name="image_prompt_author",
+            step_index=3,
+            success=False,
+            error_class="all_images_failed",
+            error_message=long_msg,
+            conn=conn,
+        )
+
+    result = asyncio.run(go())
+    assert result is True
+    sql, args = conn.executed[0]
+    assert args[10] is False  # success
+    assert args[11] == "all_images_failed"  # error_class
+    assert len(args[12]) <= 2000  # error_message truncated
+
+
+def test_resolve_carousel_id_finds_existing_row_by_topic():
+    import asyncio
+
+    conn = _FakeConn(fetchrow_result={"carousel_id": "22222222-2222-2222-2222-222222222222"})
+
+    async def go():
+        return await wom.resolve_carousel_id(
+            conn, topic="existing topic", session_id="test-session"
+        )
+
+    result = asyncio.run(go())
+    assert result == "22222222-2222-2222-2222-222222222222"
+    assert len(conn.fetchrow_calls) == 1
+    sql, args = conn.fetchrow_calls[0]
+    assert "SELECT carousel_id FROM wr2_carousel_runs" in sql
+    assert args[0] == "existing topic"
+
+
+def test_resolve_carousel_id_rejects_empty_topic_without_touching_db():
+    import asyncio
+
+    conn = _FakeConn()
+
+    async def go():
+        return await wom.resolve_carousel_id(conn, topic="   ", session_id="x")
+
+    result = asyncio.run(go())
+    assert result is None
+    assert conn.fetchrow_calls == []
+
+
+def test_record_step_tier_out_of_range_is_a_noop():
+    import asyncio
+
+    conn = _FakeConn()
+
+    async def go():
+        return await wom.record_step(
+            carousel_id="11111111-1111-1111-1111-111111111111",
+            step_name="critic",
+            step_index=5,
+            tier=99,
+            success=True,
+            conn=conn,
+        )
+
+    result = asyncio.run(go())
+    assert result is False
+    assert conn.executed == []

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -42,6 +42,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import asyncpg  # noqa: E402
 
+import wr2_orchestrator_metrics as wom  # noqa: E402  (B11: per-step observability, fail-open)
 import wr2_topic_type as tt  # noqa: E402  (pure, side-effect-free)
 from backend.llm.claude_oauth_client import (  # noqa: E402
     ClaudeOAuthError,
@@ -1214,6 +1215,14 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
     register = ""
     slides: list[dict[str, Any]] = []
     for attempt in range(max_regen + 1):
+        # B11: per-step observability (wr2_orchestrator_metrics, migration 203 —
+        # had zero writer before this). Wraps the single Claude call that stands
+        # in for the interactive path's brief_interpreter (this script composes
+        # brief+storyboard in one shot, not two — see wr2_orchestrator_metrics.py
+        # module docstring for the mapping rationale). Fail-open: never blocks
+        # a draft on a metrics-recording failure.
+        _wom_t0 = time.perf_counter()
+        _wom_error: Exception | None = None
         try:
             parsed = await claude_compose_slides(
                 topic=topic, summary=summary, source_url=source_url,
@@ -1221,14 +1230,33 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> bool:
                 avoid_steer=avoid_steer, liveness_tier=liveness_tier,
             )
         except (ClaudeOAuthError, ClaudeOAuthNotAvailable) as e:
+            _wom_error = e
             logger.error("Claude OAuth failed: %s", e)
             await _mark_rejected(conn, draft_id, f"claude_failed: {e}")
             _send_telegram(f"WR2 draft_generator Claude failed\ndraft {draft_id}\n{str(e)[:200]}")
             return False
         except (json.JSONDecodeError, ValueError) as e:
+            _wom_error = e
             logger.error("Claude output parse failed: %s", e)
             await _mark_rejected(conn, draft_id, f"parse_error: {e}")
             return False
+        finally:
+            _wom_cid = await wom.resolve_carousel_id(
+                conn, topic=topic, session_id=f"draft_generator:{draft_id}"
+            )
+            await wom.record_step(
+                carousel_id=_wom_cid,
+                step_name="brief_interpreter",
+                step_index=1,
+                model="claude-opus-4-7",
+                tier=1,
+                latency_ms=int((time.perf_counter() - _wom_t0) * 1000),
+                retry_count=attempt,
+                success=_wom_error is None,
+                error_class=type(_wom_error).__name__ if _wom_error else None,
+                error_message=str(_wom_error)[:500] if _wom_error else None,
+                conn=conn,
+            )
 
         try:
             register, slides = _normalise_slides(parsed)

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -44,6 +44,7 @@ import os
 import socket
 import sys
 import threading
+import time
 import uuid
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
@@ -56,6 +57,7 @@ sys.path.insert(0, str(_REPO / "scripts"))
 
 import asyncpg  # noqa: E402
 
+import wr2_orchestrator_metrics as wom  # noqa: E402  (B11: per-step observability, fail-open)
 from backend.services.canva_renderer_v2 import _pg  # noqa: E402
 from wr2_html_renderer.claude_vision import VisionTransient  # noqa: E402
 
@@ -904,10 +906,45 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
         try:
             hero_dir = work / "heroes"
             hero_dir.mkdir(parents=True, exist_ok=True)
-            with _HeroServer(hero_dir) as server:
-                norm_slides = _normalize_heroes(slides, hero_dir, server)
-                slides_dir, weak_slides = await _render_carousel(
-                    str(draft_id), norm_slides, work, vision_required
+            # B11: per-step observability (wr2_orchestrator_metrics, migration
+            # 203 — had zero writer before this). Times the whole per-carousel
+            # render (designer-loop critic + Playwright PNG production happen
+            # INSIDE _render_carousel, not as separate awaits) — recorded once
+            # as 'playwright_render' (the concrete artifact-producing step) to
+            # avoid fabricating a second, duplicate-latency 'critic' row for
+            # work that isn't separately timed; see wr2_orchestrator_metrics.py
+            # module docstring. Fail-open, and re-raises the real error.
+            _wom_t0 = time.perf_counter()
+            _wom_error: Exception | None = None
+            try:
+                with _HeroServer(hero_dir) as server:
+                    norm_slides = _normalize_heroes(slides, hero_dir, server)
+                    slides_dir, weak_slides = await _render_carousel(
+                        str(draft_id), norm_slides, work, vision_required
+                    )
+            except Exception as _render_exc:  # noqa: BLE001 — record then re-raise, never swallow
+                _wom_error = _render_exc
+                raise
+            finally:
+                # NOTE: deliberately NOT reusing main_conn here — a render can
+                # take up to ~15 min and the pg-proxy idle-closes it mid-render
+                # (see the _ensure_live reconnect a few lines below, same
+                # cause). conn=None makes both calls open their own short-lived
+                # connection instead of racing that staleness.
+                _wom_cid = await wom.resolve_carousel_id(
+                    None, topic=str(dict(row).get("topic") or ""),
+                    session_id=f"html_apply:{draft_id}",
+                )
+                await wom.record_step(
+                    carousel_id=_wom_cid,
+                    step_name="playwright_render",
+                    step_index=6,
+                    tier=1,
+                    latency_ms=int((time.perf_counter() - _wom_t0) * 1000),
+                    retry_count=0,
+                    success=_wom_error is None,
+                    error_class=type(_wom_error).__name__ if _wom_error else None,
+                    error_message=str(_wom_error)[:500] if _wom_error else None,
                 )
             # _stage_assets copies logo.png INTO slides_dir in vision mode (per-slide
             # HTML resolves file:// assets there) — a bare *.png glob shipped the

--- a/scripts/wr2_ig_publish.py
+++ b/scripts/wr2_ig_publish.py
@@ -63,6 +63,7 @@ import json
 import logging
 import os
 import sys
+import time
 import uuid
 from pathlib import Path
 from typing import Any
@@ -84,6 +85,11 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _BACKEND_DIR = _REPO_ROOT / "apps" / "backend-rag"
 if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import wr2_orchestrator_metrics as wom  # noqa: E402  (B11: per-step observability, fail-open)
 
 # Carousel output root. Matches wr2_rerender_local.py convention: defaults to the
 # M5 app-machine Desktop path, overridable via WR2_CAROUSEL_ROOT for Pro/Mini.
@@ -509,10 +515,39 @@ async def _run(args: argparse.Namespace) -> int:
         logger.error("IGPublisher init failed: %s", exc)
         return 1
 
+    # B11: per-step observability (wr2_orchestrator_metrics, migration 203 —
+    # had zero writer before this). Clean 1:1 mapping to the 'ig_publisher'
+    # enum value; carousel_id is already resolved above by
+    # _ledger_precondition (SAME find-or-create-by-topic idiom
+    # wr2_orchestrator_metrics.resolve_carousel_id mirrors). Fail-open.
+    _wom_t0 = time.perf_counter()
+    result = None
+    _wom_error: Exception | None = None
     try:
         result = await publisher.publish(draft)
+    except Exception as exc:  # noqa: BLE001 — record then re-raise, never swallow
+        _wom_error = exc
+        raise
     finally:
         await close_ig_publisher_client()
+        _wom_ok = result is not None and result.ok
+        await wom.record_step(
+            carousel_id=carousel_id,
+            step_name="ig_publisher",
+            step_index=8,
+            tier=1,
+            latency_ms=int((time.perf_counter() - _wom_t0) * 1000),
+            retry_count=0,
+            success=_wom_ok,
+            error_class=(
+                type(_wom_error).__name__ if _wom_error
+                else (None if _wom_ok else "publish_failed")
+            ),
+            error_message=(
+                str(_wom_error)[:500] if _wom_error
+                else (None if _wom_ok else (result.error or None))
+            ),
+        )
 
     if not result.ok:
         await _ledger_record_result(

--- a/scripts/wr2_image_generator.py
+++ b/scripts/wr2_image_generator.py
@@ -43,6 +43,9 @@ from typing import Any
 
 import asyncpg  # noqa: E402
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wr2_orchestrator_metrics as wom  # noqa: E402  (B11: per-step observability, fail-open)
+
 logger = logging.getLogger("wr2.image_generator")
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -1261,6 +1264,13 @@ async def _process_one(
             )
         return True
 
+    # B11: per-step observability (wr2_orchestrator_metrics, migration 203 —
+    # had zero writer before this). Times the WHOLE per-draft image generation
+    # section (all heroes, whichever backend); closest available enum value is
+    # image_prompt_author (the table has no distinct "render image" value —
+    # see wr2_orchestrator_metrics.py module docstring). Fail-open.
+    _wom_t0 = time.perf_counter()
+
     # ── Backend selection (Sprint A 2026-05-07: Codex added as primary) ──
     # Probe Codex + FlowKit ONCE per draft (not per slide). Codex is the
     # default primary in `auto` mode because it produces 4:5 1080x1350
@@ -1398,6 +1408,23 @@ async def _process_one(
     successes = len(url_by_slide)
     failures = len(errors_by_slide)
     logger.info("Draft %s: %d/%d images OK", draft_id, successes, successes + failures)
+
+    _wom_cid = await wom.resolve_carousel_id(
+        conn, topic=topic, session_id=f"image_generator:{draft_id}"
+    )
+    await wom.record_step(
+        carousel_id=_wom_cid,
+        step_name="image_prompt_author",
+        step_index=3,
+        model=IMAGE_BACKEND,  # backend mode (auto/codex/flowkit/playwright), not an LLM name
+        tier=1,  # no LLM-cascade tier applies to image backends — see module docstring
+        latency_ms=int((time.perf_counter() - _wom_t0) * 1000),
+        retry_count=failures,  # approximate: 1 failed hero ≈ ≥1 exhausted retry, see wr2_image_generator.py's own retry loop in _gen_image_with_semaphore
+        success=successes > 0,  # mirrors the actual pipeline gate below (successes == 0 -> image_failed)
+        error_class="all_images_failed" if successes == 0 else None,
+        error_message=("; ".join(list(errors_by_slide.values())[:3]) if successes == 0 else None),
+        conn=conn,
+    )
 
     for s in slides:
         if s.get("is_hero_image"):

--- a/scripts/wr2_orchestrator_metrics.py
+++ b/scripts/wr2_orchestrator_metrics.py
@@ -1,0 +1,277 @@
+"""WR2 orchestrator per-step observability — writers for `wr2_orchestrator_metrics`.
+
+Migration 203 (2026-05-27, `apps/backend-rag/backend/db/migrations_v2/203_wr2_orchestrator_metrics.sql`)
+created this table with a full per-step schema (cascade tier, cost, latency,
+retry) and it had ZERO production writer — self-attested pipeline health was
+the only signal (research/operations/2026-07-14-wr2-deep-audit.md §1: "quality
+contracts are self-attested... a self-attested instruction is not an enforced
+contract"). Live DB check 2026-07-14: 46 rows total, all from a manual test
+harness between 2026-05-26 and 2026-06-03 (`session_id LIKE 'manual-%'`) —
+the table has been an invisible fossil for six weeks.
+
+GROUNDING NOTE (2026-07-14, discovered while wiring this): the table's FK
+(`carousel_id REFERENCES wr2_carousel_runs`) points at a table the CURRENT
+production autonomous pipeline does not use for its own identity — pipeline
+scripts (`wr2_draft_generator.py`, `wr2_image_generator.py`,
+`wr2_html_render_apply.py`) key everything off `war_room_drafts.id`
+(draft_id), a DIFFERENT table. `wr2_carousel_runs` is populated today only at
+PUBLISH time via a find-or-create-by-topic idiom that already exists twice in
+this repo (`wr2_ig_publish.py::_resolve_carousel_id`,
+`apps/backend-rag/backend/app/routers/wr2_publish.py::_resolve_carousel_id`).
+`resolve_carousel_id()` below mirrors that SAME idiom (reused, not
+reinvented) so a metrics row recorded early in the pipeline (brief/image/
+render) and the ledger row a later publish-time call resolves both land on
+the SAME carousel_id for the same topic — one identity per topic, not a
+second, disconnected identity model.
+
+Connection pattern: `asyncpg.connect(DATABASE_URL)` per call, matching the
+existing idiom in `wr2_supervisor.py` / `wr2_html_render_apply.py` (short-lived
+CLI/cron script lifetime — CLAUDE.md Golden Rule 10's persistent-client
+mandate targets long-running FastAPI request handlers, not one-shot scripts).
+Call sites that already hold an open `asyncpg.Connection` (e.g.
+`wr2_draft_generator.py::_process_one`) should pass it via `conn=` to avoid
+opening a redundant connection.
+
+FAIL-OPEN-LOUD CONTRACT: every public function here catches its own
+exceptions, logs at WARNING, and returns a sentinel (None / False) — NEVER
+raises to the caller. A metrics-recording failure must never turn a healthy
+render into a failed one. This is the explicit design constraint from the
+task brief and is enforced by the guilt tests in
+`scripts/tests/test_wr2_orchestrator_metrics.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import logging
+import os
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger("wr2.orchestrator_metrics")
+
+# Mirrors the migration 203 CHECK constraint verbatim — keep in sync.
+VALID_STEPS = frozenset(
+    {
+        "brief_interpreter",
+        "storyboarder",
+        "image_prompt_author",
+        "layout_composer",
+        "critic",
+        "playwright_render",
+        "telegram_gate",
+        "ig_publisher",
+    }
+)
+
+# Mirrors the migration 203 CHECK constraint on `tier` verbatim.
+VALID_TIERS = frozenset({1, 2, 3, 4})
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL not set")
+    return dsn
+
+
+async def resolve_carousel_id(
+    conn: asyncpg.Connection | None,
+    *,
+    topic: str,
+    session_id: str,
+    state: str = "drafted",
+) -> str | None:
+    """Find-or-create a `wr2_carousel_runs` row for `topic`.
+
+    Mirrors the SAME find-or-create-by-topic idiom already used at publish
+    time by `wr2_ig_publish.py::_resolve_carousel_id` and
+    `wr2_publish.py::_resolve_carousel_id` — reused here (not reinvented) so
+    metrics recorded early in the pipeline resolve to the same carousel_id a
+    later publish-time call would find for the same topic.
+
+    `conn=None` opens (and closes) a fresh connection — use this at call
+    sites where a long-running step may have left the caller's own
+    connection idle-closed by the pg-proxy (e.g. after a multi-minute
+    Playwright render; `wr2_html_render_apply.py::_apply_one` reconnects
+    `main_conn` for exactly this reason right after the render).
+
+    Fail-open: returns None (never raises) on any DB error. Callers must
+    treat None as "skip this metrics write", never as a render-blocking
+    condition.
+    """
+    if not topic or not topic.strip():
+        logger.warning("resolve_carousel_id SKIPPED: empty topic")
+        return None
+    owns_conn = conn is None
+    try:
+        if owns_conn:
+            conn = await asyncpg.connect(_dsn(), timeout=10)
+        row = await conn.fetchrow(
+            "SELECT carousel_id FROM wr2_carousel_runs WHERE topic = $1 "
+            "ORDER BY created_at DESC LIMIT 1",
+            topic,
+        )
+        if row is not None:
+            return str(row["carousel_id"])
+        topic_hash = hashlib.sha256(topic.encode("utf-8")).hexdigest()
+        new_row = await conn.fetchrow(
+            "INSERT INTO wr2_carousel_runs (topic, topic_hash, state, session_id) "
+            "VALUES ($1, $2, $3, $4) RETURNING carousel_id",
+            topic,
+            topic_hash,
+            state,
+            session_id,
+        )
+        return str(new_row["carousel_id"])
+    except Exception as exc:  # noqa: BLE001 — fail-open-loud, see module docstring
+        logger.warning("resolve_carousel_id FAILED for topic=%r: %s", topic[:80], exc)
+        return None
+    finally:
+        if owns_conn and conn is not None:
+            try:
+                await conn.close()
+            except Exception:  # noqa: BLE001 — closing a dead connection must not raise either
+                pass
+
+
+async def record_step(
+    *,
+    carousel_id: str | None,
+    step_name: str,
+    step_index: int,
+    success: bool,
+    model: str | None = None,
+    tier: int = 1,
+    latency_ms: int | None = None,
+    tokens_in: int | None = None,
+    tokens_out: int | None = None,
+    cost_usd_figurative: float = 0.0,
+    retry_count: int = 0,
+    error_class: str | None = None,
+    error_message: str | None = None,
+    conn: asyncpg.Connection | None = None,
+) -> bool:
+    """Write one `wr2_orchestrator_metrics` row.
+
+    FAIL-OPEN-LOUD: any failure (bad DSN, connection refused, FK violation
+    because `carousel_id` doesn't exist, unknown `step_name`) is caught,
+    logged at WARNING, and swallowed. NEVER raises. Returns True iff the row
+    was actually written — callers in the pipeline should log/ignore the
+    return value, never branch a render's control flow on it.
+
+    `carousel_id=None` (e.g. `resolve_carousel_id` itself failed upstream) is
+    a no-op, logged at WARNING, not an exception — the FK is NOT NULL so a
+    write would fail anyway; skipping avoids a doomed round-trip.
+    """
+    if carousel_id is None:
+        logger.warning(
+            "record_step SKIPPED (no carousel_id) step=%s idx=%s", step_name, step_index
+        )
+        return False
+    if step_name not in VALID_STEPS:
+        logger.warning(
+            "record_step SKIPPED (step_name=%r not in %s)", step_name, sorted(VALID_STEPS)
+        )
+        return False
+    if tier not in VALID_TIERS:
+        logger.warning("record_step SKIPPED (tier=%r not in %s)", tier, sorted(VALID_TIERS))
+        return False
+
+    owns_conn = conn is None
+    try:
+        if owns_conn:
+            conn = await asyncpg.connect(_dsn(), timeout=10)
+        await conn.execute(
+            """
+            INSERT INTO wr2_orchestrator_metrics
+                (carousel_id, step_name, step_index, model, tier, latency_ms,
+                 tokens_in, tokens_out, cost_usd_figurative, retry_count,
+                 success, error_class, error_message)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            """,
+            carousel_id,
+            step_name,
+            step_index,
+            model,
+            tier,
+            latency_ms,
+            tokens_in,
+            tokens_out,
+            cost_usd_figurative,
+            retry_count,
+            success,
+            error_class,
+            (error_message[:2000] if error_message else None),
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-open-loud, see module docstring
+        logger.warning(
+            "record_step FAILED (metrics only, caller's render is UNAFFECTED) "
+            "step=%s idx=%s carousel_id=%s: %s",
+            step_name, step_index, carousel_id, exc,
+        )
+        return False
+    finally:
+        if owns_conn and conn is not None:
+            try:
+                await conn.close()
+            except Exception:  # noqa: BLE001 — closing a dead connection must not raise either
+                pass
+
+
+async def _report(limit: int) -> None:
+    conn = await asyncpg.connect(_dsn(), timeout=10)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT created_at, step_name, tier, model, latency_ms, retry_count,
+                   success, cost_usd_figurative, carousel_id, error_class
+              FROM wr2_orchestrator_metrics
+             ORDER BY created_at DESC
+             LIMIT $1
+            """,
+            limit,
+        )
+    finally:
+        await conn.close()
+    if not rows:
+        print("wr2_orchestrator_metrics: no rows (table is empty)")
+        return
+    for r in rows:
+        status = "OK" if r["success"] else f"FAIL({r['error_class'] or '?'})"
+        print(
+            f"{r['created_at']}  {r['step_name']:<18} tier={r['tier']} "
+            f"model={(r['model'] or '-'):<20} latency={r['latency_ms'] if r['latency_ms'] is not None else '-'}ms "
+            f"retry={r['retry_count']} {status:<20} cost=${r['cost_usd_figurative']} "
+            f"carousel={str(r['carousel_id'])[:8]}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="wr2_orchestrator_metrics reporter — the table was invisible before this "
+        "module existed (see module docstring); --report is the minimum viable window into it."
+    )
+    parser.add_argument(
+        "--report",
+        type=int,
+        nargs="?",
+        const=20,
+        default=None,
+        metavar="N",
+        help="print the latest N rows (default 20) and exit",
+    )
+    args = parser.parse_args(argv)
+    if args.report is not None:
+        asyncio.run(_report(args.report))
+        return 0
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- The `wr2_orchestrator_metrics` table (migration 203, 2026-05-27) has had a full per-step schema (cascade tier, cost, latency, retry) and zero production writer since creation — 46 historical rows were all from a one-off manual test harness (2026-05-26..06-03), then six weeks of silence. Self-attested pipeline health was the only signal, exactly the "Esiste≠Armato" pattern flagged in the 2026-07-14 WR2 deep audit (finding A1 #2).
- This PR arms per-step observability: `scripts/wr2_orchestrator_metrics.py` adds `record_step()` (fail-open-loud writer — never raises to the caller, since a metrics failure must never kill a render) and `resolve_carousel_id()` (find-or-create by topic, mirroring the same idiom already used at publish time by `wr2_ig_publish.py`/`wr2_publish.py`), plus a `--report` CLI to print the latest N rows so the table stops being invisible even before a dashboard consumer exists.
- Wires 4 call sites, one per pipeline stage: `brief_interpreter` (wr2_draft_generator.py), `image_prompt_author` (wr2_image_generator.py), `playwright_render` (wr2_html_render_apply.py), `ig_publisher` (wr2_ig_publish.py).

## Test plan
- [x] Guilt+innocence unit tests (`scripts/tests/test_wr2_orchestrator_metrics.py`): DB failure / FK-doomed None carousel_id / unknown step_name / out-of-range tier all no-op without raising; a healthy write actually reaches `conn.execute()` with the right SQL shape.
- [x] Pre-push pytest suite (full backend/tests/, CI-parity env) passed on push.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>