### PR TITLE
docs(sync): bump test count 1140→1141 — W86 repair for #2456

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 636 services · 1140 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 636 services · 1141 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

PR #2456 added `test_kg_extraction_model.py` but its `check-docs-sync` (advisory, non-required) **failed** and auto-merge landed anyway — leaving `docs/AI_ONBOARDING.md` stale on main (`1140 tests` vs the real `1141`).

That stale derived-count is a landmine: the next innocent backend PR's `check-docs-sync` would fail on a file it never touched (textbook **W86**).

## Fix

1-line regen of the DOCSYNC block via `python scripts/docs_sync.py`, exactly like the #1670→#1672 repair.

## Note

Root cause is W86 (derived contract must travel IN the feature commit; with `--auto` there is no "later"). The KG model fix itself (#2456) is **live and proven** — this only reconciles the docs count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)