### PR TITLE
feat(intake): raise WhatsApp recognition and drain capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 327 routers · 636 services
+- Backend: FastAPI · 327 routers · 637 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 31 · Packages: 6

--- a/apps/backend-rag/backend/services/intake/classify.py
+++ b/apps/backend-rag/backend/services/intake/classify.py
@@ -68,6 +68,10 @@ import asyncpg
 import httpx
 
 from backend.llm.config import ModelName
+from backend.services.intake.inference_runtime import (
+    ollama_inference_slot,
+    ollama_keep_alive,
+)
 from backend.services.intake.model_roles import resolve_model_role
 
 logger = logging.getLogger("zantara.intake.classify")
@@ -288,13 +292,21 @@ async def _ollama_vision(
         "prompt": prompt,
         "images": [png_b64],
         "stream": False,
+        "keep_alive": ollama_keep_alive(),
         "options": {"temperature": 0.0, "num_predict": resolved_num_predict},
         # CLAUDE.md S9: qwen 3.x family needs think:false. qwen3-vl ignores it
         # for vision (empirically still reasons) but qwen2.5vl honours it.
         "think": False,
     }
     client = _get_client()
-    r = await client.post(f"{OLLAMA_URL}/api/generate", json=payload)
+    async with ollama_inference_slot(operation="ocr_vision", model=model):
+        # Admission wait is intentionally outside the request timeout.  A busy
+        # local GPU should queue work, not make a request expire before it has
+        # started running.
+        r = await asyncio.wait_for(
+            client.post(f"{OLLAMA_URL}/api/generate", json=payload),
+            timeout=OCR_PAGE_TIMEOUT_SECONDS,
+        )
     r.raise_for_status()
     data = r.json()
     return (
@@ -472,9 +484,7 @@ async def ocr_pages(pages: list[Any]) -> list[dict[str, Any]]:
         # non-reasoning VLMs like qwen2.5vl).
         if not text:
             try:
-                resp, thinking = await asyncio.wait_for(
-                    _ollama_vision(primary, b64), timeout=OCR_PAGE_TIMEOUT_SECONDS
-                )
+                resp, thinking = await _ollama_vision(primary, b64)
                 resp = _clean_ocr_response(resp)
                 thinking = _clean_ocr_response(thinking or "")
                 if resp:
@@ -497,10 +507,7 @@ async def ocr_pages(pages: list[Any]) -> list[dict[str, Any]]:
             if _OCR_FALLBACK == primary:
                 logger.info("OCR same-model retry (%s) on page %d", _OCR_FALLBACK, idx)
             try:
-                resp, _ = await asyncio.wait_for(
-                    _ollama_vision(_OCR_FALLBACK, b64),
-                    timeout=OCR_PAGE_TIMEOUT_SECONDS,
-                )
+                resp, _ = await _ollama_vision(_OCR_FALLBACK, b64)
                 resp = _clean_ocr_response(resp)
                 if resp:
                     text, via, model_used = resp, "fallback", _OCR_FALLBACK
@@ -914,10 +921,15 @@ async def _ollama_text_classify(model: str, prompt: str) -> tuple[str, str | Non
         "prompt": prompt,
         "stream": False,
         "think": False,
+        "keep_alive": ollama_keep_alive(),
         "options": {"temperature": 0.0, "num_predict": 24},
     }
     client = _get_client()
-    r = await client.post(f"{OLLAMA_URL}/api/generate", json=payload)
+    async with ollama_inference_slot(operation="text_classify", model=model):
+        r = await asyncio.wait_for(
+            client.post(f"{OLLAMA_URL}/api/generate", json=payload),
+            timeout=TEXT_LLM_CLASSIFY_TIMEOUT_SECONDS,
+        )
     r.raise_for_status()
     data = r.json()
     return (data.get("response") or "").strip(), (data.get("thinking") or "").strip()
@@ -936,9 +948,9 @@ async def _text_llm_classify(ocr_text: str | None) -> str | None:
         return None
     model = _resolve_text_llm_model()
     try:
-        response, thinking = await asyncio.wait_for(
-            _ollama_text_classify(model, _text_llm_classify_prompt(text)),
-            timeout=TEXT_LLM_CLASSIFY_TIMEOUT_SECONDS,
+        response, thinking = await _ollama_text_classify(
+            model,
+            _text_llm_classify_prompt(text),
         )
     except Exception as exc:
         logger.warning("text LLM classify fallback failed model=%s error=%r", model, exc)
@@ -958,14 +970,11 @@ async def _vision_classify_page(png_bytes: bytes) -> str | None:
     """
     try:
         b64 = base64.b64encode(_ensure_min_size(png_bytes)).decode("ascii")
-        resp, thinking = await asyncio.wait_for(
-            _ollama_vision(
-                _VISION_CLASSIFY_MODEL,
-                b64,
-                prompt=_VISION_CLASSIFY_PROMPT,
-                num_predict=_VISION_CLASSIFY_NUM_PREDICT,
-            ),
-            timeout=OCR_PAGE_TIMEOUT_SECONDS,
+        resp, thinking = await _ollama_vision(
+            _VISION_CLASSIFY_MODEL,
+            b64,
+            prompt=_VISION_CLASSIFY_PROMPT,
+            num_predict=_VISION_CLASSIFY_NUM_PREDICT,
         )
     except Exception as exc:
         logger.warning("vision classify fallback failed: %s", exc)

--- a/apps/backend-rag/backend/services/intake/extract.py
+++ b/apps/backend-rag/backend/services/intake/extract.py
@@ -1,9 +1,11 @@
 """Document-intake field extraction (FASE 3 β — 'extract' stage).
 
-Runs the SEA-LION extraction model (``aisingapore/Qwen-SEA-LION-v4-32B-IT``)
-LOCALLY via Ollama (``http://localhost:11434``) — PII never leaves the Pro
-(Law 2 / UU-PDP). For each canonical field the model returns either the value
-WITH ``source_page`` evidence, or an explicit ``null`` — the *Maybe pattern*.
+Runs a schema-driven extraction model LOCALLY via Ollama
+(``http://localhost:11434``) — PII never leaves the Pro (Law 2 / UU-PDP). The
+registry default remains SEA-LION 32B; ``INTAKE_EXTRACTION_MODEL`` can select a
+validated low-latency local tier without changing the safety contract. For each
+canonical field the model returns either the value WITH ``source_page``
+evidence, or an explicit ``null`` — the *Maybe pattern*.
 
 GOLDEN RULE (CLAUDE.md anti-hallucination): a field that is not clearly
 legible is ``null`` with ``confidence == 0.0``. NEVER an invented value. A
@@ -30,6 +32,10 @@ from typing import Any
 
 import httpx
 
+from backend.services.intake.inference_runtime import (
+    ollama_inference_slot,
+    ollama_keep_alive,
+)
 from backend.services.intake.model_roles import resolve_model_role
 from backend.utils.passport_normalize import (
     normalize_date,
@@ -58,6 +64,7 @@ OLLAMA_BASE_URL: str = os.getenv("OLLAMA_URL", "http://localhost:11434")
 # SEA-LION 32B q4 is a heavy local model: ~25-45s warm, cold-load slower.
 _GENERATE_TIMEOUT_SECONDS: float = float(os.getenv("INTAKE_EXTRACT_TIMEOUT", "300"))
 _CONNECT_TIMEOUT_SECONDS: float = 5.0
+_DEFAULT_NUM_PREDICT = 1024
 
 # Confidence assigned to a value the model returned WITH evidence. The extractor
 # is deterministic (temperature 0) and does not emit calibrated probabilities;
@@ -68,6 +75,17 @@ _LOW_CONFIDENCE_THRESHOLD: float = 0.60  # mirrors evidence-scoring CAUTIOUS ban
 _MRZ_CONFIDENCE: float = 0.95
 _LABEL_CONFIDENCE: float = 0.90
 _DETERMINISTIC_LABEL_MODEL: str = "deterministic_labels"
+_UNREADABLE_VALUE_MARKERS = (
+    "unreadable",
+    "illegible",
+    "not legible",
+    "tidak terbaca",
+    "tidak jelas",
+    "blurred",
+    "blurry",
+    "smudged",
+    "redacted",
+)
 
 # --- Persistent async HTTP client (Golden Rule #10: never per-call). ---
 _client: httpx.AsyncClient | None = None
@@ -341,6 +359,7 @@ def _parsed_field_with_alias(
 # Prompt construction + parsing.
 # ---------------------------------------------------------------------------
 
+
 def _build_prompt(doc_type: str, pages: list[str]) -> str:
     """Build the Maybe-pattern extraction prompt with per-page numbering."""
     specs = DOC_TYPE_FIELDS[doc_type]
@@ -350,9 +369,7 @@ def _build_prompt(doc_type: str, pages: list[str]) -> str:
         field_lines.append(f'  - "{name}": {shape} — {desc}')
     fields_block = "\n".join(field_lines)
 
-    numbered_pages = "\n".join(
-        f"--- PAGE {i + 1} ---\n{page}" for i, page in enumerate(pages)
-    )
+    numbered_pages = "\n".join(f"--- PAGE {i + 1} ---\n{page}" for i, page in enumerate(pages))
 
     return (
         "You extract structured fields from an Indonesian legal/identity "
@@ -371,9 +388,9 @@ def _build_prompt(doc_type: str, pages: list[str]) -> str:
         "MRZ disambiguates it, return the date verbatim as printed (do not "
         "reorder) rather than guessing.\n\n"
         "Return ONLY a single JSON object. For EACH field below, the value is "
-        "an object {\"value\": <extracted value or null>, \"source_page\": "
+        'an object {"value": <extracted value or null>, "source_page": '
         "<1-based page number where you read it, or null>}.\n"
-        "If the field is a list, \"value\" is an array (or null / [] if none).\n\n"
+        'If the field is a list, "value" is an array (or null / [] if none).\n\n'
         "Fields:\n"
         f"{fields_block}\n\n"
         "Do not add fields that are not listed. Do not output markdown or "
@@ -408,7 +425,7 @@ def _coerce_field(
     # Normalise "empty" sentinels to null.
     if value is None:
         return null_field
-    if isinstance(value, str) and value.strip().lower() in {"", "null", "none", "n/a", "-"}:
+    if isinstance(value, str) and _is_null_or_unreadable_value(value):
         return null_field
 
     if is_list:
@@ -421,7 +438,7 @@ def _coerce_field(
             if item is None:
                 continue
             text = str(item).strip()
-            if text.lower() in {"", "null", "none", "n/a", "-"}:
+            if _is_null_or_unreadable_value(text):
                 continue
             cleaned.append(text)
         if not cleaned:
@@ -446,6 +463,14 @@ def _coerce_field(
     return {"value": value, "confidence": round(confidence, 2), "source_page": source_page}
 
 
+def _is_null_or_unreadable_value(value: str) -> bool:
+    """Reject model placeholders that describe missing visual evidence."""
+    normalized = value.strip().casefold()
+    if normalized in {"", "null", "none", "n/a", "-"}:
+        return True
+    return any(marker in normalized for marker in _UNREADABLE_VALUE_MARKERS)
+
+
 # ---------------------------------------------------------------------------
 # Deterministic passport MRZ extraction.
 # ---------------------------------------------------------------------------
@@ -459,12 +484,7 @@ _MRZ_WEIGHTS = (7, 3, 1)
 
 def _normalise_mrz_candidate(line: str) -> str:
     """Return a compact MRZ-ish line, dropping OCR spaces/punctuation."""
-    cleaned = (
-        line.upper()
-        .replace("«", "<")
-        .replace("‹", "<")
-        .replace(" ", "")
-    )
+    cleaned = line.upper().replace("«", "<").replace("‹", "<").replace(" ", "")
     return "".join(ch for ch in cleaned if ch in _MRZ_CHARS)
 
 
@@ -488,10 +508,7 @@ def _find_td3_mrz_pair(pages: list[str]) -> tuple[str, str, int] | None:
     extraction-stage field contract.
     """
     for page_idx, text in enumerate(pages, start=1):
-        candidates = [
-            _normalise_mrz_candidate(line)
-            for line in str(text or "").splitlines()
-        ]
+        candidates = [_normalise_mrz_candidate(line) for line in str(text or "").splitlines()]
         candidates = [line for line in candidates if len(line) >= 20 and "<" in line]
         for idx, line1 in enumerate(candidates):
             if not line1.startswith("P<"):
@@ -573,8 +590,7 @@ def _extract_passport_mrz_fields(pages: list[str]) -> dict[str, dict[str, Any]]:
 def _passport_mrz_complete(fields: dict[str, dict[str, Any]]) -> bool:
     """True when MRZ supplied the full passport extraction schema."""
     return all(
-        fields.get(name, {}).get("value")
-        for name, _is_list, _desc in DOC_TYPE_FIELDS["passport"]
+        fields.get(name, {}).get("value") for name, _is_list, _desc in DOC_TYPE_FIELDS["passport"]
     )
 
 
@@ -622,7 +638,7 @@ def _clean_label_value(value: str | None) -> str | None:
     if value is None:
         return None
     cleaned = re.sub(r"\s+", " ", value).strip(" \t:-")
-    if not cleaned or cleaned.lower() in {"null", "none", "n/a", "-"}:
+    if _is_null_or_unreadable_value(cleaned):
         return None
     return cleaned
 
@@ -734,7 +750,9 @@ def _set_list_if_present(
         for part in re.split(r"\s*(?:;|,|\||\bdan\b|\band\b)\s*", cleaned, flags=re.IGNORECASE)
         if part
     ]
-    values = [_title_person_name(part) if person_name else _clean_label_value(part) for part in parts]
+    values = [
+        _title_person_name(part) if person_name else _clean_label_value(part) for part in parts
+    ]
     values = [value for value in values if value]
     if values:
         fields[name] = {"value": values, "confidence": _LABEL_CONFIDENCE, "source_page": page}
@@ -1523,7 +1541,11 @@ def _extract_bank_statement_label_fields(pages: list[str]) -> dict[str, dict[str
     combined = "\n".join(pages)
     bank_name = _bank_name_from_text(combined)
     if bank_name:
-        fields["bank_name"] = {"value": bank_name, "confidence": _LABEL_CONFIDENCE, "source_page": 1}
+        fields["bank_name"] = {
+            "value": bank_name,
+            "confidence": _LABEL_CONFIDENCE,
+            "source_page": 1,
+        }
     return fields
 
 
@@ -1816,19 +1838,39 @@ GenerateFn = Callable[[str, str], Awaitable[str]]
 async def _ollama_generate(model: str, prompt: str) -> str:
     """Call local Ollama /api/generate with JSON format + think:false."""
     client = _get_client()
-    resp = await client.post(
-        "/api/generate",
-        json={
-            "model": model,
-            "prompt": prompt,
-            "stream": False,
-            "think": False,  # SEA-LION/Qwen: return content directly, no <think>.
-            "format": "json",
-            "options": {"temperature": 0},
-        },
-    )
+    raw_num_predict = os.getenv("INTAKE_EXTRACT_NUM_PREDICT", str(_DEFAULT_NUM_PREDICT))
+    try:
+        num_predict = max(128, int(raw_num_predict))
+    except ValueError:
+        logger.warning(
+            "invalid INTAKE_EXTRACT_NUM_PREDICT=%r; using %d",
+            raw_num_predict,
+            _DEFAULT_NUM_PREDICT,
+        )
+        num_predict = _DEFAULT_NUM_PREDICT
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        "think": False,  # SEA-LION/Qwen: return content directly, no <think>.
+        "format": "json",
+        "keep_alive": ollama_keep_alive(),
+        "options": {"temperature": 0, "num_predict": num_predict},
+    }
+    async with ollama_inference_slot(operation="field_extract", model=model):
+        resp = await client.post("/api/generate", json=payload)
     resp.raise_for_status()
     return resp.json().get("response", "")
+
+
+def _model_metric_label(model: str) -> str:
+    """Keep the legacy SEA-LION label while exposing every model override exactly."""
+    return "sea-lion" if "sea-lion" in model.casefold() else model
+
+
+def resolved_extraction_model_label() -> str:
+    """Return the metric label for the model selected by current configuration."""
+    return _model_metric_label(_resolve_extraction_model())
 
 
 def _parse_response(text: str) -> dict[str, Any]:
@@ -1854,6 +1896,7 @@ def _parse_response(text: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Public API.
 # ---------------------------------------------------------------------------
+
 
 async def extract_fields(
     doc_type: str | None,
@@ -1924,10 +1967,7 @@ async def extract_fields(
         if deterministic_fields:
             _merge_deterministic_fields(fields, deterministic_fields)
         deterministic_extractors.append(extractor_name)
-        any_low = any(
-            field["confidence"] < _LOW_CONFIDENCE_THRESHOLD
-            for field in fields.values()
-        )
+        any_low = any(field["confidence"] < _LOW_CONFIDENCE_THRESHOLD for field in fields.values())
         return {
             "doc_type": canonical,
             "fields": fields,
@@ -1938,7 +1978,8 @@ async def extract_fields(
 
     prompt = _build_prompt(canonical, pages)
     gen = generate_fn or _ollama_generate
-    raw_response = await gen(_resolve_extraction_model(), prompt)
+    resolved_model = _resolve_extraction_model()
+    raw_response = await gen(resolved_model, prompt)
     parsed = _parse_response(raw_response)
 
     specs = DOC_TYPE_FIELDS[canonical]
@@ -1961,7 +2002,7 @@ async def extract_fields(
     result = {
         "doc_type": canonical,
         "fields": fields,
-        "extraction_model": EXTRACTION_MODEL_LABEL,
+        "extraction_model": _model_metric_label(resolved_model),
         "any_low_confidence": any_low,
     }
     if field_aliases:
@@ -1974,6 +2015,7 @@ async def extract_fields(
 # ---------------------------------------------------------------------------
 # Stage handler (worker.py FASE 2 contract: async def(job, stage) -> dict).
 # ---------------------------------------------------------------------------
+
 
 def _read_upstream(job: dict, *keys: str) -> Any:
     """Read a value from the job's accumulated stage_output by trying keys.

--- a/apps/backend-rag/backend/services/intake/inference_runtime.py
+++ b/apps/backend-rag/backend/services/intake/inference_runtime.py
@@ -1,0 +1,109 @@
+"""Process-local admission control for Intake Ollama inference.
+
+The Intake worker deliberately runs more than one queue slot so cheap database,
+validation, and routing work can overlap.  Ollama on the Pro is a different
+resource: concurrent OCR/extraction generations compete for the same GPU and can
+turn a few-second request into a five-minute timeout.  This module keeps queue
+concurrency while serialising only the local model calls.
+
+The gate is per asyncio event loop.  That makes it safe for the long-lived worker
+and avoids binding a module-level semaphore to the first pytest event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import weakref
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+logger = logging.getLogger("zantara.intake.inference_runtime")
+
+DEFAULT_OLLAMA_MAX_INFLIGHT = 1
+DEFAULT_OLLAMA_KEEP_ALIVE = "15m"
+_MAX_CONFIGURED_INFLIGHT = 8
+
+
+@dataclass(frozen=True)
+class OllamaInferenceLease:
+    """Metadata about one acquired inference slot."""
+
+    capacity: int
+    wait_ms: int
+
+
+_gates: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, tuple[int, asyncio.Semaphore]] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def ollama_max_inflight() -> int:
+    """Return the bounded process-local Ollama concurrency."""
+    raw = os.getenv("INTAKE_OLLAMA_MAX_INFLIGHT", str(DEFAULT_OLLAMA_MAX_INFLIGHT))
+    try:
+        configured = int(raw)
+    except ValueError:
+        logger.warning(
+            "invalid INTAKE_OLLAMA_MAX_INFLIGHT=%r; using %d",
+            raw,
+            DEFAULT_OLLAMA_MAX_INFLIGHT,
+        )
+        configured = DEFAULT_OLLAMA_MAX_INFLIGHT
+    return min(max(configured, 1), _MAX_CONFIGURED_INFLIGHT)
+
+
+def ollama_keep_alive() -> str:
+    """Return the Ollama residency hint shared by OCR/classify/extract."""
+    return os.getenv("INTAKE_OLLAMA_KEEP_ALIVE", DEFAULT_OLLAMA_KEEP_ALIVE).strip() or (
+        DEFAULT_OLLAMA_KEEP_ALIVE
+    )
+
+
+def clear_ollama_inference_gates() -> None:
+    """Clear idle gates after configuration changes in tests.
+
+    Production configuration is immutable for the lifetime of the worker.  This
+    helper exists so tests that use a fresh event loop or a different capacity do
+    not inherit state from another case.
+    """
+    _gates.clear()
+
+
+def _gate_for_running_loop() -> tuple[int, asyncio.Semaphore]:
+    loop = asyncio.get_running_loop()
+    existing = _gates.get(loop)
+    if existing is not None:
+        return existing
+    capacity = ollama_max_inflight()
+    created = (capacity, asyncio.Semaphore(capacity))
+    _gates[loop] = created
+    return created
+
+
+@asynccontextmanager
+async def ollama_inference_slot(
+    *,
+    operation: str,
+    model: str,
+) -> AsyncIterator[OllamaInferenceLease]:
+    """Acquire the shared Ollama slot around exactly one HTTP generation call."""
+    capacity, gate = _gate_for_running_loop()
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    await gate.acquire()
+    wait_ms = int((loop.time() - started) * 1000)
+    if wait_ms >= 100:
+        logger.info(
+            "intake Ollama admission operation=%s model=%s waited_ms=%d capacity=%d",
+            operation,
+            model,
+            wait_ms,
+            capacity,
+        )
+    try:
+        yield OllamaInferenceLease(capacity=capacity, wait_ms=wait_ms)
+    finally:
+        gate.release()

--- a/apps/backend-rag/backend/services/intake/stages.py
+++ b/apps/backend-rag/backend/services/intake/stages.py
@@ -8,7 +8,7 @@ implementations:
     classification happen in this ONE stage; the v1 passthrough ``ocr`` stage
     was dropped by the v2 machine, migration 224).
   * ``extract``  -> :func:`backend.services.intake.extract.extract_stage`
-    (local SEA-LION field extraction, Maybe pattern).
+    (configured local field extraction, Maybe pattern).
   * ``validate`` -> :func:`backend.services.intake.validate_rules.validate_stage`
     (deterministic, no LLM).
   * ``route``    -> :func:`backend.services.intake.routing.route_stage`
@@ -60,9 +60,9 @@ import httpx
 
 from backend.services.intake import classify as _classify
 from backend.services.intake.extract import (
-    EXTRACTION_MODEL_LABEL,
     canonical_doc_type,
     extract_stage,
+    resolved_extraction_model_label,
 )
 from backend.services.intake.routing import route_stage as _route_stage_fase4
 from backend.services.intake.validate_rules import validate_stage
@@ -171,6 +171,7 @@ def build_real_stage_handler(pool: asyncpg.Pool) -> StageHandler:
                 # So we short-circuit to an empty-extraction result and let the
                 # doc flow on to validate -> route-proposal for human triage.
                 if canonical_doc_type(doc_type) is None:
+                    extraction_model = resolved_extraction_model_label()
                     logger.info(
                         "extract: doc_type=%r not auto-extractable (job=%s) -> "
                         "empty fields, route to review (no DLQ)",
@@ -180,10 +181,10 @@ def build_real_stage_handler(pool: asyncpg.Pool) -> StageHandler:
                     return {
                         "doc_type": doc_type or "unknown",
                         "fields": {},
-                        "extraction_model": EXTRACTION_MODEL_LABEL,
+                        "extraction_model": extraction_model,
                         "any_low_confidence": True,
                         "skipped": "unschematised_doc_type",
-                        "_metric": {"model": EXTRACTION_MODEL_LABEL, "confidence": 0.0},
+                        "_metric": {"model": extraction_model, "confidence": 0.0},
                     }
                 if _env_truthy(_PROPOSAL_ONLY_SKIP_EXTRACT_ENV):
                     logger.info(
@@ -205,7 +206,7 @@ def build_real_stage_handler(pool: asyncpg.Pool) -> StageHandler:
                 payload.setdefault(
                     "_metric",
                     {
-                        "model": payload.get("extraction_model", EXTRACTION_MODEL_LABEL),
+                        "model": payload.get("extraction_model", resolved_extraction_model_label()),
                         "confidence": 0.0 if payload.get("any_low_confidence") else 0.85,
                     },
                 )

--- a/apps/backend-rag/backend/services/intake/writer.py
+++ b/apps/backend-rag/backend/services/intake/writer.py
@@ -48,6 +48,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -160,6 +161,18 @@ class CommitPlan:
     # If an identical (client_id, idempotency_key) document already exists, the
     # real path is a no-op returning this id (idempotency). Surfaced in the plan.
     existing_doc_id: int | None = None
+    # Local-only learning evidence.  These values let the real commit write one
+    # structured feedback row per approved/corrected field without re-reading or
+    # reconstructing the AI proposal after it has advanced to a terminal state.
+    source: str = "unknown"
+    blob_hash: str = ""
+    pipeline_version: str = PIPELINE_VERSION
+    original_fields: dict[str, Any] = field(default_factory=dict)
+    human_field_overrides: dict[str, Any] = field(default_factory=dict)
+    original_client_id: int | None = None
+    entity_confidence: float | None = None
+    extraction_model: str | None = None
+    validation_passed: bool | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -320,38 +333,48 @@ async def plan_commit(
     source = (qrow["source"] if qrow else None) or "unknown"
     source_ref = (qrow["source_ref"] if qrow else None) or str(proposal_id)
     blob_hash = (qrow["blob_hash"] if qrow else None) or ""
-    pipeline_version = (qrow["pipeline_version"] if qrow else None) or p.get(
-        "pipeline_version"
-    ) or PIPELINE_VERSION
+    pipeline_version = (
+        (qrow["pipeline_version"] if qrow else None)
+        or p.get("pipeline_version")
+        or PIPELINE_VERSION
+    )
     doc_index = int(p.get("doc_index") or 0)
 
     # Target client: explicit override (human chose) wins, else routing's resolved client.
-    client_id = override_client_id if override_client_id is not None else routing.get(
-        "client_id"
-    )
+    client_id = override_client_id if override_client_id is not None else routing.get("client_id")
     if practice_explicit:
         # The reviewer chose deliberately — honour it even when it is None
         # ("archive only"): no silent fallback to routing's practice hint.
         practice_id = override_practice_id
     else:
         practice_id = (
-            override_practice_id
-            if override_practice_id is not None
-            else routing.get("practice_id")
+            override_practice_id if override_practice_id is not None else routing.get("practice_id")
         )
 
     payload = _document_payload(routing, stage_output, source_ref)
+    original_fields = payload.get("extracted_fields")
+    if not isinstance(original_fields, dict):
+        original_fields = {}
+    else:
+        original_fields = dict(original_fields)
+    human_field_overrides = dict(final_fields or {})
     # Persist the resolved practice on the document row itself (documents.practice_id):
     # _document_payload doesn't know it, but write_client_document writes
     # payload["practice_id"], and rollback_commit reads it back to detach the link.
     # Without this the column is NULL and rollback can't find the practice to clean.
     payload["practice_id"] = practice_id
-    if final_fields:
-        payload["extracted_fields"] = {**payload.get("extracted_fields", {}), **final_fields}
+    if human_field_overrides:
+        payload["extracted_fields"] = {
+            **original_fields,
+            **human_field_overrides,
+        }
 
-    idem_key = compute_idempotency_key(
-        source, source_ref, blob_hash, doc_index, pipeline_version
-    )
+    extract_output = _as_dict(stage_output.get("extract"))
+    validate_output = _as_dict(stage_output.get("validate"))
+    validation_value = validate_output.get("valid")
+    validation_passed = validation_value if isinstance(validation_value, bool) else None
+
+    idem_key = compute_idempotency_key(source, source_ref, blob_hash, doc_index, pipeline_version)
 
     plan = CommitPlan(
         proposal_id=proposal_id,
@@ -363,6 +386,24 @@ async def plan_commit(
         committed_by=committed_by,
         idempotency_key=idem_key,
         payload=payload,
+        source=str(source),
+        blob_hash=str(blob_hash),
+        pipeline_version=str(pipeline_version),
+        original_fields=original_fields,
+        human_field_overrides=human_field_overrides,
+        original_client_id=routing.get("client_id"),
+        entity_confidence=(
+            float(entity_resolution["score"])
+            if isinstance(entity_resolution.get("score"), (int, float))
+            and not isinstance(entity_resolution.get("score"), bool)
+            else None
+        ),
+        extraction_model=(
+            str(extract_output["extraction_model"])
+            if extract_output.get("extraction_model")
+            else None
+        ),
+        validation_passed=validation_passed,
     )
 
     reasons: list[str] = []
@@ -371,9 +412,7 @@ async def plan_commit(
     if client_id is None:
         reasons.append("no_target_client (decision requires human to pick a client)")
     else:
-        crow = await conn.fetchrow(
-            "SELECT id, deleted_at FROM clients WHERE id = $1", client_id
-        )
+        crow = await conn.fetchrow("SELECT id, deleted_at FROM clients WHERE id = $1", client_id)
         if crow is None:
             reasons.append(f"client {client_id} does not exist")
         elif crow["deleted_at"] is not None:
@@ -399,13 +438,9 @@ async def plan_commit(
             "SELECT 1 FROM information_schema.tables WHERE table_name='family_members'"
         )
         if has_fam_tbl:
-            frow = await conn.fetchrow(
-                "SELECT client_id FROM family_members WHERE id = $1", fam_id
-            )
+            frow = await conn.fetchrow("SELECT client_id FROM family_members WHERE id = $1", fam_id)
             if frow is None or frow["client_id"] != client_id:
-                reasons.append(
-                    f"family_member {fam_id} does not belong to client {client_id}"
-                )
+                reasons.append(f"family_member {fam_id} does not belong to client {client_id}")
 
     # Proposal must still be in a claimable/approvable state (not already terminal).
     cur_status = p.get("status")
@@ -486,15 +521,199 @@ async def plan_commit(
                 values={
                     "queue_id": queue_id,
                     "decision": decision,
-                    "outcome": "approved",
+                    "outcome": "approved|corrected|auto_committed",
                     "verified_by": committed_by,
-                    "fields_touched": list((final_fields or {}).keys()),
+                    "fields_observed": sorted(set(original_fields) | set(human_field_overrides)),
                 },
-                note="one row per field touched + decision-level __entity__ if client overridden (design §5)",
+                note=(
+                    "one idempotent row per non-null approved/corrected field + "
+                    "decision-level __entity__ if client overridden (design §5)"
+                ),
             )
         )
 
     return plan
+
+
+# --------------------------------------------------------------------------- #
+# Structured HITL evidence — local-only learning loop (FASE 4.5 / 5C).
+# --------------------------------------------------------------------------- #
+def _field_value_and_confidence(raw: Any) -> tuple[Any, float | None]:
+    """Unwrap the extractor's ``{value, confidence, source_page}`` field shape."""
+    if not isinstance(raw, dict) or "value" not in raw:
+        return raw, None
+    confidence = raw.get("confidence")
+    return raw.get("value"), (
+        float(confidence)
+        if isinstance(confidence, (int, float)) and not isinstance(confidence, bool)
+        else None
+    )
+
+
+def _normalise_feedback_value(value: Any) -> Any:
+    """Normalise harmless formatting before deciding approved vs corrected."""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        return [_normalise_feedback_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): _normalise_feedback_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    return value
+
+
+def _feedback_text(value: Any) -> str | None:
+    """Serialize one local-only feedback value deterministically into TEXT."""
+    value = _normalise_feedback_value(value)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def _correction_evidence_rows(
+    plan: CommitPlan,
+    *,
+    advance_to: str,
+) -> list[dict[str, Any]]:
+    """Build field-level ground truth for a successful human or auto commit.
+
+    Null fields that nobody touched are excluded: counting them as successes
+    would inflate accuracy even when the model simply missed information.  A
+    human override to/from null is still recorded because it is explicit.
+    """
+    is_auto = advance_to == "auto_routed"
+    field_names = sorted(set(plan.original_fields) | set(plan.human_field_overrides))
+    rows: list[dict[str, Any]] = []
+    for field_name in field_names:
+        ai_value, ai_confidence = _field_value_and_confidence(plan.original_fields.get(field_name))
+        explicitly_overridden = field_name in plan.human_field_overrides
+        if explicitly_overridden:
+            human_value, _ = _field_value_and_confidence(plan.human_field_overrides[field_name])
+        else:
+            human_value = ai_value
+
+        if ai_value is None and human_value is None and not explicitly_overridden:
+            continue
+
+        if is_auto:
+            outcome = "auto_committed"
+        elif _normalise_feedback_value(ai_value) == _normalise_feedback_value(human_value):
+            outcome = "approved"
+        else:
+            outcome = "corrected"
+        rows.append(
+            {
+                "field_name": str(field_name),
+                "ai_value": _feedback_text(ai_value),
+                "human_value": _feedback_text(human_value),
+                "ai_confidence": ai_confidence,
+                "outcome": outcome,
+                "model_id": plan.extraction_model,
+                "stage": "extract",
+                "rule_passed": plan.validation_passed,
+            }
+        )
+
+    # Decision-level entity correction is the highest-value routing signal.
+    if not is_auto and plan.original_client_id != plan.client_id:
+        rows.append(
+            {
+                "field_name": "__entity__",
+                "ai_value": _feedback_text(plan.original_client_id),
+                "human_value": _feedback_text(plan.client_id),
+                "ai_confidence": plan.entity_confidence,
+                "outcome": "corrected",
+                "model_id": "entity-resolution",
+                "stage": "route",
+                "rule_passed": None,
+            }
+        )
+
+    # Preserve a document-level denominator even for an intentionally fieldless
+    # proposal (for example an unknown document routed manually).
+    if not rows:
+        rows.append(
+            {
+                "field_name": "__document__",
+                "ai_value": _feedback_text(plan.doc_type),
+                "human_value": _feedback_text(plan.doc_type),
+                "ai_confidence": None,
+                "outcome": "auto_committed" if is_auto else "approved",
+                "model_id": plan.extraction_model,
+                "stage": "route",
+                "rule_passed": plan.validation_passed,
+            }
+        )
+    return rows
+
+
+async def _record_commit_corrections(
+    conn: asyncpg.Connection,
+    plan: CommitPlan,
+    *,
+    advance_to: str,
+) -> int:
+    """Persist idempotent field feedback in the same transaction as the commit."""
+    if plan.queue_id is None or re.fullmatch(r"[0-9a-fA-F]{64}", plan.blob_hash) is None:
+        logger.warning(
+            "intake.corrections.skipped proposal=%s queue=%s invalid_evidence_key",
+            plan.proposal_id,
+            plan.queue_id,
+        )
+        return 0
+
+    inserted = 0
+    for row in _correction_evidence_rows(plan, advance_to=advance_to):
+        correction_id = await conn.fetchval(
+            """
+            INSERT INTO intake_corrections (
+                queue_id, blob_hash, doc_type, field_name, source,
+                ai_value, human_value, ai_confidence, outcome,
+                model_id, model_version, stage, rule_passed, verified_by
+            )
+            SELECT $1, $2::char(64), $3, $4, $5,
+                   $6, $7, $8, $9,
+                   $10, $11, $12, $13, $14
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM intake_corrections
+                WHERE queue_id = $1
+                  AND field_name = $4
+                  AND outcome = $9
+                  AND ai_value IS NOT DISTINCT FROM $6
+                  AND human_value IS NOT DISTINCT FROM $7
+                  AND model_version IS NOT DISTINCT FROM $11
+            )
+            RETURNING id
+            """,
+            plan.queue_id,
+            plan.blob_hash.lower(),
+            plan.doc_type or "unknown",
+            row["field_name"],
+            (plan.source or "unknown")[:8],
+            row["ai_value"],
+            row["human_value"],
+            row["ai_confidence"],
+            row["outcome"],
+            row["model_id"],
+            plan.pipeline_version,
+            row["stage"],
+            row["rule_passed"],
+            plan.committed_by,
+        )
+        inserted += int(correction_id is not None)
+
+    logger.info(
+        "intake.corrections.recorded proposal=%s queue=%s inserted=%d",
+        plan.proposal_id,
+        plan.queue_id,
+        inserted,
+    )
+    return inserted
 
 
 # --------------------------------------------------------------------------- #
@@ -616,7 +835,12 @@ async def execute_commit(
     # Blocked plan (P0#3): record + refuse, regardless of dry/real.
     if plan.blocked:
         audit_id = await _write_audit(
-            conn, plan, dry_run=dry_run, outcome="blocked", doc_id=None, error="; ".join(plan.block_reasons)
+            conn,
+            plan,
+            dry_run=dry_run,
+            outcome="blocked",
+            doc_id=None,
+            error="; ".join(plan.block_reasons),
         )
         logger.warning(
             "intake.writer.blocked proposal=%s reasons=%s",
@@ -633,9 +857,7 @@ async def execute_commit(
         )
 
     if dry_run:
-        audit_id = await _write_audit(
-            conn, plan, dry_run=True, outcome="dry_run", doc_id=None
-        )
+        audit_id = await _write_audit(conn, plan, dry_run=True, outcome="dry_run", doc_id=None)
         logger.info(
             "intake.writer.DRY_RUN proposal=%s client=%s practice=%s doc_type=%s ops=%d "
             "(would write, NOTHING committed)",
@@ -690,6 +912,15 @@ async def execute_commit(
             plan.doc_type,
             plan.payload.get("extracted_fields"),
         )
+        # Learning evidence is part of the same atomic commit: a document cannot
+        # become routed without also contributing its approved/corrected labels.
+        # The INSERT is idempotent, so re-committing the same intake instance does
+        # not inflate the measured acceptance rate.
+        correction_count = await _record_commit_corrections(
+            conn,
+            plan,
+            advance_to=advance_to,
+        )
         # Proposal advancement to the terminal state — in the SAME TX as the
         # writes. P0#9 inverse: the DRY-RUN path never advances; the REAL path advances
         # exactly once, atomically with the document it routed. ``advance_from``/
@@ -698,16 +929,16 @@ async def execute_commit(
         await advance_proposal(
             conn, plan.proposal_id, from_status=advance_from, target_status=advance_to
         )
-        audit_id = await _write_audit(
-            conn, plan, dry_run=False, outcome="committed", doc_id=doc_id
-        )
+        audit_id = await _write_audit(conn, plan, dry_run=False, outcome="committed", doc_id=doc_id)
         logger.info(
-            "intake.writer.COMMITTED proposal=%s client=%s doc=%s practice=%s enriched=%s (real write)",
+            "intake.writer.COMMITTED proposal=%s client=%s doc=%s practice=%s "
+            "enriched=%s corrections=%d (real write)",
             plan.proposal_id,
             plan.client_id,
             doc_id,
             plan.practice_id,
             sorted(enriched.keys()) if enriched else [],
+            correction_count,
         )
         return CommitResult(
             proposal_id=plan.proposal_id,

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_classify.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_classify.py
@@ -13,6 +13,7 @@ exercised separately by the on-Pro E2E run, not here.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import re
@@ -82,8 +83,7 @@ async def test_passport_classified_via_mrz():
 @pytest.mark.asyncio
 async def test_akta_classified():
     r = await cls.classify_document(
-        "AKTA PENDIRIAN PERSEROAN TERBATAS PT MAJU JAYA NOMOR 17 "
-        "DIHADAPAN NOTARIS ANGGARAN DASAR"
+        "AKTA PENDIRIAN PERSEROAN TERBATAS PT MAJU JAYA NOMOR 17 DIHADAPAN NOTARIS ANGGARAN DASAR"
     )
     assert r["type"] == "akta_pendirian"
     assert r["confidence"] >= 0.30
@@ -101,8 +101,7 @@ async def test_sk_kemenkumham_classified():
 @pytest.mark.asyncio
 async def test_evisa_classified():
     r = await cls.classify_document(
-        "REPUBLIC OF INDONESIA E-VISA VISA INDEX B211A "
-        "DIRECTORATE GENERAL OF IMMIGRATION"
+        "REPUBLIC OF INDONESIA E-VISA VISA INDEX B211A DIRECTORATE GENERAL OF IMMIGRATION"
     )
     assert r["type"] == "visa"
     assert r["confidence"] >= 0.30
@@ -117,9 +116,7 @@ async def test_generic_visa_word_alone_stays_unknown():
 
 @pytest.mark.asyncio
 async def test_family_card_classified():
-    r = await cls.classify_document(
-        "KARTU KELUARGA Nomor Kartu Keluarga No. KK Kepala Keluarga"
-    )
+    r = await cls.classify_document("KARTU KELUARGA Nomor Kartu Keluarga No. KK Kepala Keluarga")
     assert r["type"] == "family_card"
     assert r["confidence"] >= 0.30
 
@@ -135,9 +132,7 @@ async def test_birth_certificate_classified():
 
 @pytest.mark.asyncio
 async def test_marriage_certificate_classified():
-    r = await cls.classify_document(
-        "BUKU NIKAH AKTA NIKAH Kantor Urusan Agama tanggal pernikahan"
-    )
+    r = await cls.classify_document("BUKU NIKAH AKTA NIKAH Kantor Urusan Agama tanggal pernikahan")
     assert r["type"] == "marriage_certificate"
     assert r["confidence"] >= 0.30
 
@@ -338,6 +333,7 @@ async def test_ollama_vision_uses_configured_num_predict(monkeypatch):
             return _FakeResponse()
 
     monkeypatch.setenv("INTAKE_OCR_NUM_PREDICT", "512")
+    monkeypatch.setenv("INTAKE_OLLAMA_KEEP_ALIVE", "17m")
     monkeypatch.setattr(cls, "_get_client", lambda: _FakeClient())
 
     response, thinking = await cls._ollama_vision("qwen2.5vl:7b", "Zm9v")
@@ -345,6 +341,37 @@ async def test_ollama_vision_uses_configured_num_predict(monkeypatch):
     assert response == "OCR TEXT"
     assert thinking == ""
     assert calls[0]["options"]["num_predict"] == 512
+    assert calls[0]["keep_alive"] == "17m"
+
+
+@pytest.mark.asyncio
+async def test_ollama_admission_wait_does_not_consume_request_timeout(monkeypatch):
+    """Queued work gets a full inference timeout after it acquires the GPU."""
+    from backend.services.intake import inference_runtime
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": "OCR TEXT", "thinking": ""}
+
+    class _SlowClient:
+        async def post(self, _url, json):
+            await asyncio.sleep(0.04)
+            return _FakeResponse()
+
+    monkeypatch.setenv("INTAKE_OLLAMA_MAX_INFLIGHT", "1")
+    monkeypatch.setattr(cls, "OCR_PAGE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(cls, "_get_client", lambda: _SlowClient())
+    inference_runtime.clear_ollama_inference_gates()
+
+    results = await asyncio.gather(
+        cls._ollama_vision("qwen2.5vl:7b", "Zm9v"),
+        cls._ollama_vision("qwen2.5vl:7b", "YmFy"),
+    )
+
+    assert [result[0] for result in results] == ["OCR TEXT", "OCR TEXT"]
 
 
 @pytest.mark.asyncio
@@ -410,8 +437,7 @@ async def test_ocr_pages_unwraps_json_text_object_response(monkeypatch):
 async def test_ocr_pages_unwraps_json_pages_object_response(monkeypatch):
     async def fake_vision(model, b64):
         return (
-            '{"pages": [{"text": "KITAS No : 2C11AB98765"}, '
-            '{"text": "Name : MARIO LUCA ROSSI"}]}',
+            '{"pages": [{"text": "KITAS No : 2C11AB98765"}, {"text": "Name : MARIO LUCA ROSSI"}]}',
             "",
         )
 

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_extract.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_extract.py
@@ -21,10 +21,13 @@ from backend.services.intake import extract, model_roles
 # Helpers                                                                      #
 # --------------------------------------------------------------------------- #
 
+
 def _fake_gen(payload: dict):
     """Return a generate_fn that always yields ``payload`` as JSON."""
+
     async def _gen(model: str, prompt: str) -> str:  # noqa: ARG001
         return json.dumps(payload)
+
     return _gen
 
 
@@ -48,6 +51,36 @@ def test_resolve_extraction_model_reads_model_topology(tmp_path, monkeypatch):
 def test_extraction_model_env_override_wins(monkeypatch):
     monkeypatch.setenv("INTAKE_EXTRACTION_MODEL", "override-model:q4")
     assert extract._resolve_extraction_model() == "override-model:q4"
+    assert extract.resolved_extraction_model_label() == "override-model:q4"
+
+
+async def test_ollama_generate_applies_capacity_controls(monkeypatch):
+    calls = []
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": '{"ok": true}'}
+
+    class _FakeClient:
+        async def post(self, path, json):
+            calls.append((path, json))
+            return _FakeResponse()
+
+    monkeypatch.setenv("INTAKE_EXTRACT_NUM_PREDICT", "768")
+    monkeypatch.setenv("INTAKE_OLLAMA_KEEP_ALIVE", "19m")
+    monkeypatch.setattr(extract, "_get_client", lambda: _FakeClient())
+
+    response = await extract._ollama_generate("qwen3.5:9b", "extract JSON")
+
+    assert response == '{"ok": true}'
+    path, payload = calls[0]
+    assert path == "/api/generate"
+    assert payload["model"] == "qwen3.5:9b"
+    assert payload["keep_alive"] == "19m"
+    assert payload["options"]["num_predict"] == 768
 
 
 def test_canonical_doc_type_aliases():
@@ -82,6 +115,7 @@ async def test_unsupported_doc_type_raises():
 # --------------------------------------------------------------------------- #
 # Maybe pattern + GOLDEN RULE (fake model, deterministic)                      #
 # --------------------------------------------------------------------------- #
+
 
 async def test_full_nib_extraction_with_evidence():
     payload = {
@@ -126,6 +160,35 @@ async def test_golden_rule_illegible_field_becomes_null():
     assert out["any_low_confidence"] is True
     # legible fields untouched
     assert out["fields"]["nib_number"]["value"] == "9876543210987"
+
+
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        "[unreadable]",
+        "[tidak terbaca / illegible smudge]",
+        "blurred",
+        "REDACTED",
+    ],
+)
+async def test_golden_rule_model_unreadable_placeholders_become_null(placeholder):
+    payload = {
+        "npwp_number": {"value": "1234567890123456", "source_page": 1},
+        "name": {"value": "PT TEST", "source_page": 1},
+        "address": {"value": placeholder, "source_page": 1},
+    }
+
+    out = await extract.extract_fields(
+        "npwp",
+        ["NOMOR POKOK WAJIB PAJAK\nNama: PT TEST\nAlamat: [unreadable]"],
+        generate_fn=_fake_gen(payload),
+    )
+
+    assert out["fields"]["address"] == {
+        "value": None,
+        "confidence": 0.0,
+        "source_page": None,
+    }
 
 
 async def test_list_field_accepts_model_value_objects():
@@ -250,8 +313,7 @@ async def test_passport_partial_mrz_merges_with_model_output():
     # DOB + expiry check digits are valid. The MRZ pair is trusted enough to
     # provide name/dates/nationality, but not passport_no.
     ocr = (
-        "P<ITAERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\n"
-        "L898902C35ITA7408122F3004157ZE184226B<<<<<10"
+        "P<ITAERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\nL898902C35ITA7408122F3004157ZE184226B<<<<<10"
     )
     out = await extract.extract_fields("passport", [ocr], generate_fn=_fake_gen(payload))
 
@@ -651,11 +713,7 @@ async def test_kitas_label_number_drops_ocr_prefix_inside_value():
         called["n"] += 1
         return "{}"
 
-    ocr = (
-        "KARTU IZIN TINGGAL TERBATAS\n"
-        "No. ITAS : ITAS 2C11AB98765\n"
-        "Nama : MARIO LUCA ROSSI"
-    )
+    ocr = "KARTU IZIN TINGGAL TERBATAS\nNo. ITAS : ITAS 2C11AB98765\nNama : MARIO LUCA ROSSI"
     out = await extract.extract_fields("kitas", [ocr], generate_fn=_gen)
 
     assert called["n"] == 0
@@ -1682,6 +1740,7 @@ async def test_new_doc_type_schemas_extract_with_evidence(
 # Worker stage-handler contract                                               #
 # --------------------------------------------------------------------------- #
 
+
 async def test_extract_stage_reads_upstream_stage_output(monkeypatch):
     payload = {"nib_number": {"value": "1234567890123", "source_page": 1}}
 
@@ -1709,6 +1768,7 @@ async def test_extract_stage_rejects_wrong_stage():
 # --------------------------------------------------------------------------- #
 # LIVE: real SEA-LION model (deselect with -m "not slow")                     #
 # --------------------------------------------------------------------------- #
+
 
 @pytest.mark.slow
 @pytest.mark.integration

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_inference_runtime.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_inference_runtime.py
@@ -1,0 +1,63 @@
+"""Admission-control tests for the shared Intake Ollama runtime."""
+
+from __future__ import annotations
+
+import asyncio
+
+from backend.services.intake import inference_runtime
+
+
+async def test_default_gate_serialises_model_calls(monkeypatch) -> None:
+    monkeypatch.delenv("INTAKE_OLLAMA_MAX_INFLIGHT", raising=False)
+    inference_runtime.clear_ollama_inference_gates()
+    active = 0
+    peak = 0
+
+    async def _call() -> None:
+        nonlocal active, peak
+        async with inference_runtime.ollama_inference_slot(
+            operation="test",
+            model="synthetic",
+        ):
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+
+    await asyncio.gather(*(_call() for _ in range(6)))
+
+    assert peak == 1
+
+
+async def test_configured_gate_allows_bounded_parallelism(monkeypatch) -> None:
+    monkeypatch.setenv("INTAKE_OLLAMA_MAX_INFLIGHT", "2")
+    inference_runtime.clear_ollama_inference_gates()
+    active = 0
+    peak = 0
+
+    async def _call() -> None:
+        nonlocal active, peak
+        async with inference_runtime.ollama_inference_slot(
+            operation="test",
+            model="synthetic",
+        ):
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+
+    await asyncio.gather(*(_call() for _ in range(8)))
+
+    assert peak == 2
+
+
+def test_invalid_gate_configuration_fails_safe(monkeypatch) -> None:
+    monkeypatch.setenv("INTAKE_OLLAMA_MAX_INFLIGHT", "not-an-int")
+    assert inference_runtime.ollama_max_inflight() == 1
+
+
+def test_keep_alive_has_safe_default_and_override(monkeypatch) -> None:
+    monkeypatch.delenv("INTAKE_OLLAMA_KEEP_ALIVE", raising=False)
+    assert inference_runtime.ollama_keep_alive() == "15m"
+    monkeypatch.setenv("INTAKE_OLLAMA_KEEP_ALIVE", "30m")
+    assert inference_runtime.ollama_keep_alive() == "30m"

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_writer.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_writer.py
@@ -71,18 +71,24 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
     """Build a synthetic intake chain + 2 clients + an open practice."""
     tag = f"5btest-{uuid.uuid4().hex[:8]}"
     created: dict[str, list[int]] = {
-        "clients": [], "proposals": [], "queues": [], "instances": [], "practices": []
+        "clients": [],
+        "proposals": [],
+        "queues": [],
+        "instances": [],
+        "practices": [],
     }
     bh = (uuid.uuid4().hex + uuid.uuid4().hex)[:64]  # shared blob for both clients
 
     async with pool.acquire() as conn:
         cid_a = await conn.fetchval(
             "INSERT INTO clients (full_name, assigned_to) VALUES ($1,$2) RETURNING id",
-            f"{tag}-A", ADMIN["email"],
+            f"{tag}-A",
+            ADMIN["email"],
         )
         cid_b = await conn.fetchval(
             "INSERT INTO clients (full_name, assigned_to) VALUES ($1,$2) RETURNING id",
-            f"{tag}-B", ADMIN["email"],
+            f"{tag}-B",
+            ADMIN["email"],
         )
         created["clients"] += [cid_a, cid_b]
 
@@ -90,7 +96,8 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
         prac_a = await conn.fetchval(
             """INSERT INTO practices (client_id, practice_type_code, title, status)
                VALUES ($1, 'kitas_application', $2, 'in_progress') RETURNING id""",
-            cid_a, f"{tag}-practice",
+            cid_a,
+            f"{tag}-practice",
         )
         created["practices"].append(prac_a)
 
@@ -99,7 +106,9 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
         inst = await conn.fetchval(
             """INSERT INTO document_instances (blob_hash, pipeline_version, blob_path, first_source)
                VALUES ($1,$2,$3,'drive') RETURNING id""",
-            bh, PIPELINE, f"/tmp/{tag}.pdf",
+            bh,
+            PIPELINE,
+            f"/tmp/{tag}.pdf",
         )
         created["instances"].append(inst)
 
@@ -110,16 +119,29 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
                    (instance_id, source, source_ref, blob_path, blob_hash, pipeline_version,
                     status, stage_output, intake_key)
                    VALUES ($1,'drive',$2,$3,$4,$5,'review_pending',$6::jsonb,$7) RETURNING id""",
-                inst, source_ref, f"/tmp/{tag}.pdf", bh, PIPELINE,
-                json.dumps({"doc_type": "npwp", "file_id": f"drive-{source_ref}",
-                            "ocr": {"pages": [{"page": 1, "text": "NPWP"}]}}),
+                inst,
+                source_ref,
+                f"/tmp/{tag}.pdf",
+                bh,
+                PIPELINE,
+                json.dumps(
+                    {
+                        "doc_type": "npwp",
+                        "file_id": f"drive-{source_ref}",
+                        "ocr": {"pages": [{"page": 1, "text": "NPWP"}]},
+                    }
+                ),
                 ikey,
             )
             created["queues"].append(qid)
             entity = {"decision": decision, "candidates": [{"table": "clients", "id": client_id}]}
-            routing = {"client_id": client_id, "company_id": None,
-                       "practice_id": practice_id, "doc_type": "npwp",
-                       "fields": {"npwp_number": {"value": "01.234.567.8-901.000"}}}
+            routing = {
+                "client_id": client_id,
+                "company_id": None,
+                "practice_id": practice_id,
+                "doc_type": "npwp",
+                "fields": {"npwp_number": {"value": "01.234.567.8-901.000"}},
+            }
             gate = {"requires_human": decision != "AUTO_ATTACH", "decision": decision}
             pid = await conn.fetchval(
                 """INSERT INTO document_routing_proposal
@@ -129,9 +151,14 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
                    VALUES ($1,0,$2,$3,$4::jsonb,$5::jsonb,$6::jsonb,'review_claimed',
                            $7, now() + interval '15 min', $8)
                    RETURNING id""",
-                qid, PIPELINE, f"{tag}-{uuid.uuid4().hex[:8]}",
-                json.dumps(entity), json.dumps(routing), json.dumps(gate),
-                ADMIN["email"], uuid.uuid4(),
+                qid,
+                PIPELINE,
+                f"{tag}-{uuid.uuid4().hex[:8]}",
+                json.dumps(entity),
+                json.dumps(routing),
+                json.dumps(gate),
+                ADMIN["email"],
+                uuid.uuid4(),
             )
             created["proposals"].append(pid)
             return pid
@@ -139,8 +166,16 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
         p_a = await mk(cid_a, "AUTO_ATTACH", "refA", practice_id=prac_a)
         p_b = await mk(cid_b, "AUTO_ATTACH", "refA")  # SAME source_ref+blob, different client
 
-    yield {"tag": tag, "cid_a": cid_a, "cid_b": cid_b, "prac_a": prac_a,
-           "p_a": p_a, "p_b": p_b, "bh": bh, "created": created}
+    yield {
+        "tag": tag,
+        "cid_a": cid_a,
+        "cid_b": cid_b,
+        "prac_a": prac_a,
+        "p_a": p_a,
+        "p_b": p_b,
+        "bh": bh,
+        "created": created,
+    }
 
     async with pool.acquire() as conn:
         # Real-write tests (flag ON) may have INSERTed documents for these clients —
@@ -163,6 +198,7 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
 
 def _make_app(pool: asyncpg.Pool, user: dict) -> FastAPI:
     from backend.app.routers import intake_review
+
     app = FastAPI()
     app.include_router(intake_review.router)
     app.dependency_overrides[get_current_user] = lambda: user
@@ -218,9 +254,11 @@ async def test_p0_1_idempotency_key_cross_client_distinct(pool, seed):
     """P0#1: same blob, two clients → keys are per-client-scoped, no collision."""
     async with pool.acquire() as conn:
         prop_a = await conn.fetchrow(
-            "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"])
+            "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"]
+        )
         prop_b = await conn.fetchrow(
-            "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_b"])
+            "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_b"]
+        )
         plan_a = await intake_writer.plan_commit(prop_a, conn, committed_by=ADMIN["email"])
         plan_b = await intake_writer.plan_commit(prop_b, conn, committed_by=ADMIN["email"])
     # SAME blob + SAME source_ref → the key STRING is identical across the two
@@ -242,7 +280,8 @@ async def test_p0_3_blocked_on_soft_deleted_client(pool, seed):
         await conn.execute("UPDATE clients SET deleted_at = now() WHERE id=$1", seed["cid_a"])
         try:
             prop_a = await conn.fetchrow(
-                "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"])
+                "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"]
+            )
             plan = await intake_writer.plan_commit(prop_a, conn, committed_by=ADMIN["email"])
             result = await intake_writer.execute_commit(plan, conn, dry_run=True)
         finally:
@@ -261,7 +300,8 @@ async def test_flag_off_real_commit_refused(pool, seed, monkeypatch):
     before = await _crm_counts(pool)
     async with pool.acquire() as conn:
         prop_a = await conn.fetchrow(
-            "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"])
+            "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"]
+        )
         plan = await intake_writer.plan_commit(prop_a, conn, committed_by=ADMIN["email"])
         with pytest.raises(intake_writer.WriterDisabledError):
             await intake_writer.execute_commit(plan, conn, dry_run=False)
@@ -273,17 +313,21 @@ async def test_dry_run_writes_only_audit_row(pool, seed):
     """The ONLY write a dry-run performs is one intake_commit_audit row."""
     async with pool.acquire() as conn:
         n_before = await conn.fetchval(
-            "SELECT count(*) FROM intake_commit_audit WHERE proposal_id=$1", seed["p_a"])
+            "SELECT count(*) FROM intake_commit_audit WHERE proposal_id=$1", seed["p_a"]
+        )
     app = _make_app(pool, ADMIN)
     async with _client(app) as cl:
         r = await cl.post(f"/api/intake/review/{seed['p_a']}/approve", json={})
     assert r.status_code == 200
     async with pool.acquire() as conn:
         n_after = await conn.fetchval(
-            "SELECT count(*) FROM intake_commit_audit WHERE proposal_id=$1", seed["p_a"])
+            "SELECT count(*) FROM intake_commit_audit WHERE proposal_id=$1", seed["p_a"]
+        )
         row = await conn.fetchrow(
             "SELECT dry_run, outcome, doc_id FROM intake_commit_audit "
-            "WHERE proposal_id=$1 ORDER BY id DESC LIMIT 1", seed["p_a"])
+            "WHERE proposal_id=$1 ORDER BY id DESC LIMIT 1",
+            seed["p_a"],
+        )
     assert n_after == n_before + 1
     assert row["dry_run"] is True
     assert row["outcome"] == "dry_run"
@@ -365,10 +409,34 @@ async def test_real_commit_writes_document_and_advances(pool, seed, monkeypatch)
     async with pool.acquire() as conn:
         audit = await conn.fetchrow(
             "SELECT dry_run, outcome, doc_id FROM intake_commit_audit "
-            "WHERE proposal_id=$1 ORDER BY id DESC LIMIT 1", seed["p_a"])
+            "WHERE proposal_id=$1 ORDER BY id DESC LIMIT 1",
+            seed["p_a"],
+        )
     assert audit["dry_run"] is False
     assert audit["outcome"] == "committed"
     assert audit["doc_id"] == new_doc["id"]
+
+    # The same atomic commit produces a local field-level ground-truth row.
+    async with pool.acquire() as conn:
+        correction = await conn.fetchrow(
+            """
+            SELECT field_name, ai_value, human_value, ai_confidence, outcome,
+                   source, verified_by
+            FROM intake_corrections
+            WHERE queue_id = (
+                SELECT queue_id FROM document_routing_proposal WHERE id = $1
+            )
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            seed["p_a"],
+        )
+    assert correction["field_name"] == "npwp_number"
+    assert correction["ai_value"] == "01.234.567.8-901.000"
+    assert correction["human_value"] == correction["ai_value"]
+    assert correction["outcome"] == "approved"
+    assert correction["source"] == "drive"
+    assert correction["verified_by"] == ADMIN["email"]
 
 
 async def test_real_commit_idempotent_recommit(pool, seed, monkeypatch):
@@ -386,6 +454,16 @@ async def test_real_commit_idempotent_recommit(pool, seed, monkeypatch):
     doc_id_1 = r1.json()["result"]["doc_id"]
     assert doc_id_1 is not None
     docs_after_first = await _docs_for_client(pool, seed["cid_a"])
+    async with pool.acquire() as conn:
+        corrections_after_first = await conn.fetchval(
+            """
+            SELECT count(*) FROM intake_corrections
+            WHERE queue_id = (
+                SELECT queue_id FROM document_routing_proposal WHERE id = $1
+            )
+            """,
+            seed["p_a"],
+        )
 
     # The proposal is now 'routed' (terminal) — plan_commit would block it as "not
     # approvable". Re-arm it to 'review_claimed' so a SECOND execute_commit reaches
@@ -398,7 +476,8 @@ async def test_real_commit_idempotent_recommit(pool, seed, monkeypatch):
         )
         async with conn.transaction():
             prop = await conn.fetchrow(
-                "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"])
+                "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"]
+            )
             plan = await intake_writer.plan_commit(prop, conn, committed_by=ADMIN["email"])
             # existing doc surfaced by the idempotency probe
             assert plan.existing_doc_id == doc_id_1
@@ -409,6 +488,17 @@ async def test_real_commit_idempotent_recommit(pool, seed, monkeypatch):
 
     docs_after_second = await _docs_for_client(pool, seed["cid_a"])
     assert len(docs_after_second) == len(docs_after_first), "no duplicate document on re-commit"
+    async with pool.acquire() as conn:
+        corrections_after_second = await conn.fetchval(
+            """
+            SELECT count(*) FROM intake_corrections
+            WHERE queue_id = (
+                SELECT queue_id FROM document_routing_proposal WHERE id = $1
+            )
+            """,
+            seed["p_a"],
+        )
+    assert corrections_after_second == corrections_after_first
 
 
 async def test_blocked_plan_no_write_even_with_flag_on(pool, seed, monkeypatch):
@@ -420,7 +510,8 @@ async def test_blocked_plan_no_write_even_with_flag_on(pool, seed, monkeypatch):
         try:
             async with conn.transaction():
                 prop = await conn.fetchrow(
-                    "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"])
+                    "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"]
+                )
                 plan = await intake_writer.plan_commit(prop, conn, committed_by=ADMIN["email"])
                 result = await intake_writer.execute_commit(plan, conn, dry_run=False)
         finally:
@@ -450,13 +541,16 @@ async def test_exception_mid_tx_rolls_back(pool, seed, monkeypatch):
         with pytest.raises(RuntimeError, match="simulated practice append failure"):
             async with conn.transaction():
                 prop = await conn.fetchrow(
-                    "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"])
+                    "SELECT * FROM document_routing_proposal WHERE id=$1", seed["p_a"]
+                )
                 plan = await intake_writer.plan_commit(prop, conn, committed_by=ADMIN["email"])
                 await intake_writer.execute_commit(plan, conn, dry_run=False)
 
     after = await _crm_counts(pool)
     assert after == before, "TX did not roll back — orphan document survived the failure"
-    assert await _proposal_status(pool, seed["p_a"]) == "review_claimed", "proposal advanced despite rollback"
+    assert await _proposal_status(pool, seed["p_a"]) == "review_claimed", (
+        "proposal advanced despite rollback"
+    )
 
 
 async def test_rollback_commit_undoes_document(pool, seed, monkeypatch):
@@ -474,7 +568,9 @@ async def test_rollback_commit_undoes_document(pool, seed, monkeypatch):
     async with pool.acquire() as conn:
         async with conn.transaction():
             res = await intake_writer.rollback_commit(
-                conn, client_id=seed["cid_a"], idempotency_key=idem_key,
+                conn,
+                client_id=seed["cid_a"],
+                idempotency_key=idem_key,
                 committed_by=ADMIN["email"],
             )
     assert res.outcome == "rolled_back"
@@ -493,7 +589,9 @@ async def test_rollback_commit_undoes_document(pool, seed, monkeypatch):
     async with pool.acquire() as conn:
         async with conn.transaction():
             res2 = await intake_writer.rollback_commit(
-                conn, client_id=seed["cid_a"], idempotency_key=idem_key,
+                conn,
+                client_id=seed["cid_a"],
+                idempotency_key=idem_key,
                 committed_by=ADMIN["email"],
             )
     assert res2.outcome == "rolled_back"
@@ -529,9 +627,7 @@ async def test_rollback_commit_undoes_document(pool, seed, monkeypatch):
         ("skt", "tax", "03_Tax"),
     ],
 )
-def test_company_doc_category_maps_to_company_folder(
-    doc_type, expected_category, expected_folder
-):
+def test_company_doc_category_maps_to_company_folder(doc_type, expected_category, expected_folder):
     """Intake-derived category must be the CANONICAL one that resolves to the
     right Drive folder. Before the fix, nib/akta produced category='company',
     which is absent from CATEGORY_TO_FOLDER → fell through to '99_Misc' (Drive
@@ -565,7 +661,9 @@ async def _set_passport_proposal(conn: asyncpg.Pool, proposal_id: int, client_id
     """Rewrite a seeded proposal to a passport doc with nested {value} fields,
     mirroring the real FASE-3 extract shape (extract.py:252)."""
     routing = {
-        "client_id": client_id, "company_id": None, "practice_id": None,
+        "client_id": client_id,
+        "company_id": None,
+        "practice_id": None,
         "doc_type": "passport",
         "fields": {
             "passport_no": {"value": "YC0000001", "confidence": 0.99, "source_page": 1},
@@ -577,7 +675,9 @@ async def _set_passport_proposal(conn: asyncpg.Pool, proposal_id: int, client_id
     entity = {"decision": "AUTO_ATTACH", "candidates": [{"table": "clients", "id": client_id}]}
     await conn.execute(
         "UPDATE document_routing_proposal SET routing=$1::jsonb, entity_resolution=$2::jsonb WHERE id=$3",
-        json.dumps(routing), json.dumps(entity), proposal_id,
+        json.dumps(routing),
+        json.dumps(entity),
+        proposal_id,
     )
     await conn.execute(
         "UPDATE intake_queue SET stage_output=$1::jsonb WHERE id="
@@ -598,7 +698,9 @@ async def test_approve_enriches_client_card_passport(pool, seed, monkeypatch):
         # baseline: card is empty for these identity columns
         before = await conn.fetchrow(
             "SELECT passport_number, passport_expiry, date_of_birth, nationality "
-            "FROM clients WHERE id=$1", seed["cid_a"])
+            "FROM clients WHERE id=$1",
+            seed["cid_a"],
+        )
     assert before["passport_number"] is None
     assert before["passport_expiry"] is None
 
@@ -611,7 +713,9 @@ async def test_approve_enriches_client_card_passport(pool, seed, monkeypatch):
     async with pool.acquire() as conn:
         after = await conn.fetchrow(
             "SELECT passport_number, passport_expiry, date_of_birth, nationality "
-            "FROM clients WHERE id=$1", seed["cid_a"])
+            "FROM clients WHERE id=$1",
+            seed["cid_a"],
+        )
     assert after["passport_number"] == "YC0000001"
     assert after["passport_expiry"] == date(2034, 6, 19)
     assert after["date_of_birth"] == date(1987, 7, 1)
@@ -621,9 +725,12 @@ async def test_approve_enriches_client_card_passport(pool, seed, monkeypatch):
 async def test_enrichment_skips_archive_only_no_client(pool, seed, monkeypatch):
     """Innocence test: archive-only (client_id None) must NOT attempt any client UPDATE."""
     from backend.services.intake.client_enricher import enrich_client_from_extracted_fields
+
     async with pool.acquire() as conn:
         written = await enrich_client_from_extracted_fields(
-            conn, None, "passport",
+            conn,
+            None,
+            "passport",
             {"passport_no": {"value": "X"}, "expiry": {"value": "2030-01-01"}},
         )
     assert written == {}  # no-op, no exception
@@ -633,13 +740,21 @@ async def test_enrichment_skips_unknown_doctype_and_bad_date(pool, seed, monkeyp
     """Innocence test: unknown doc_type → no-op; a garbage date → that field skipped,
     others still written (never raises, never rolls back the document)."""
     from backend.services.intake.client_enricher import enrich_client_from_extracted_fields
+
     async with pool.acquire() as conn:
         # unknown doc_type → nothing
-        assert await enrich_client_from_extracted_fields(
-            conn, seed["cid_a"], "akta_pendirian", {"x": {"value": "y"}}) == {}
+        assert (
+            await enrich_client_from_extracted_fields(
+                conn, seed["cid_a"], "akta_pendirian", {"x": {"value": "y"}}
+            )
+            == {}
+        )
         # passport with a garbage expiry → expiry skipped, passport_number still written
         written = await enrich_client_from_extracted_fields(
-            conn, seed["cid_a"], "passport",
-            {"passport_no": {"value": "YC9999999"}, "expiry": {"value": "not-a-date"}})
+            conn,
+            seed["cid_a"],
+            "passport",
+            {"passport_no": {"value": "YC9999999"}, "expiry": {"value": "not-a-date"}},
+        )
     assert written.get("passport_number") == "YC9999999"
     assert "passport_expiry" not in written

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_writer_corrections.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_writer_corrections.py
@@ -1,0 +1,112 @@
+"""Fast tests for Intake's field-level learning evidence."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.services.intake import writer
+
+
+def _plan(
+    *,
+    original_fields: dict[str, Any],
+    overrides: dict[str, Any] | None = None,
+    original_client_id: int | None = 10,
+    client_id: int | None = 10,
+) -> writer.CommitPlan:
+    return writer.CommitPlan(
+        proposal_id=1,
+        queue_id=2,
+        client_id=client_id,
+        practice_id=None,
+        decision="AUTO_ATTACH",
+        doc_type="passport",
+        committed_by="reviewer@example.test",
+        idempotency_key="ik:test",
+        payload={},
+        source="whatsapp",
+        blob_hash="a" * 64,
+        pipeline_version="test-v1",
+        original_fields=original_fields,
+        human_field_overrides=overrides or {},
+        original_client_id=original_client_id,
+        entity_confidence=0.82,
+        extraction_model="qwen3.5:9b",
+        validation_passed=True,
+    )
+
+
+def test_feedback_distinguishes_approved_corrected_and_untouched_null() -> None:
+    plan = _plan(
+        original_fields={
+            "name": {"value": " Alice ", "confidence": 0.91, "source_page": 1},
+            "passport_no": {
+                "value": "OLD123",
+                "confidence": 0.74,
+                "source_page": 1,
+            },
+            "expiry": {"value": None, "confidence": 0.0, "source_page": None},
+        },
+        overrides={"passport_no": "NEW123"},
+    )
+
+    rows = writer._correction_evidence_rows(plan, advance_to="routed")
+    by_field = {row["field_name"]: row for row in rows}
+
+    assert set(by_field) == {"name", "passport_no"}
+    assert by_field["name"]["outcome"] == "approved"
+    assert by_field["name"]["human_value"] == "Alice"
+    assert by_field["passport_no"]["outcome"] == "corrected"
+    assert by_field["passport_no"]["ai_value"] == "OLD123"
+    assert by_field["passport_no"]["human_value"] == "NEW123"
+    assert by_field["passport_no"]["ai_confidence"] == 0.74
+
+
+def test_feedback_records_entity_override() -> None:
+    plan = _plan(
+        original_fields={},
+        original_client_id=10,
+        client_id=99,
+    )
+
+    rows = writer._correction_evidence_rows(plan, advance_to="routed")
+
+    assert rows == [
+        {
+            "field_name": "__entity__",
+            "ai_value": "10",
+            "human_value": "99",
+            "ai_confidence": 0.82,
+            "outcome": "corrected",
+            "model_id": "entity-resolution",
+            "stage": "route",
+            "rule_passed": None,
+        }
+    ]
+
+
+def test_auto_attach_is_labelled_separately_from_human_approval() -> None:
+    plan = _plan(
+        original_fields={
+            "passport_no": {
+                "value": "AA123456",
+                "confidence": 0.95,
+                "source_page": 1,
+            }
+        }
+    )
+
+    rows = writer._correction_evidence_rows(plan, advance_to="auto_routed")
+
+    assert len(rows) == 1
+    assert rows[0]["outcome"] == "auto_committed"
+    assert rows[0]["field_name"] == "passport_no"
+
+
+def test_fieldless_commit_still_contributes_document_denominator() -> None:
+    plan = _plan(original_fields={})
+
+    rows = writer._correction_evidence_rows(plan, advance_to="routed")
+
+    assert rows[0]["field_name"] == "__document__"
+    assert rows[0]["outcome"] == "approved"

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 636 services · 1141 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 637 services · 1143 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/infra/launchagents/com.nuzantara.intake-worker.plist
+++ b/infra/launchagents/com.nuzantara.intake-worker.plist
@@ -10,6 +10,12 @@
 		<string>true</string>
 		<key>INTAKE_CONCURRENCY</key>
 		<string>3</string>
+		<key>INTAKE_EXTRACTION_MODEL</key>
+		<string>qwen3.5:9b</string>
+		<key>INTAKE_EXTRACT_NUM_PREDICT</key>
+		<string>1024</string>
+		<key>INTAKE_EXTRACT_TIMEOUT</key>
+		<string>90</string>
 		<key>INTAKE_DATABASE_URL</key>
 		<string>postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev</string>
 		<key>INTAKE_DEDUP_WALL_ENABLED</key>
@@ -20,6 +26,10 @@
 		<string>900</string>
 		<key>INTAKE_LOG_LEVEL</key>
 		<string>INFO</string>
+		<key>INTAKE_OLLAMA_KEEP_ALIVE</key>
+		<string>15m</string>
+		<key>INTAKE_OLLAMA_MAX_INFLIGHT</key>
+		<string>1</string>
 		<key>INTAKE_NAMEID_AUTO_ATTACH_ENABLED</key>
 		<string>true</string>
 		<key>INTAKE_POLL_INTERVAL_SECONDS</key>
@@ -28,6 +38,12 @@
 		<string>true</string>
 		<key>INTAKE_REPO_ROOT</key>
 		<string>/Users/nuzantara/Desktop/nuzantara-deploy</string>
+		<key>INTAKE_TEXT_LLM_CLASSIFY_ENABLED</key>
+		<string>true</string>
+		<key>INTAKE_TEXT_LLM_MODEL</key>
+		<string>qwen3.5:9b</string>
+		<key>INTAKE_TEXT_LLM_TIMEOUT_SECONDS</key>
+		<string>45</string>
 		<key>INTAKE_WRITER_ENABLED</key>
 		<string>true</string>
 		<key>PATH</key>

--- a/scripts/intake_capacity_quality_report.py
+++ b/scripts/intake_capacity_quality_report.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Aggregate-only Intake quality and drain-capacity gate.
+
+The report separates three concepts that are easy to conflate:
+
+* recognition coverage: classified documents that did not end as ``unknown``;
+* verified field acceptance: human-approved vs human-corrected field labels;
+* disposal capacity: completed documents per hour compared with arrivals.
+
+No document text, filename, phone, client id, or extracted value is selected or
+printed. Raw HITL values remain in the Pro's local Postgres (Symbiosis Law 2).
+Default mode is read-only reporting; ``--enforce`` only changes the exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import asyncpg
+
+DEFAULT_DSN = "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
+ACTIVE_STATUSES = ("pending", "ocr_done", "extracted", "validated")
+
+OVERVIEW_SQL = """
+SELECT
+    count(*) FILTER (WHERE created_at >= now() - make_interval(hours => $1)) AS arrivals,
+    count(*) FILTER (
+        WHERE status = 'done'
+          AND updated_at >= now() - make_interval(hours => $1)
+    ) AS completions,
+    count(*) FILTER (WHERE status = ANY($3::text[])) AS backlog,
+    count(*) FILTER (
+        WHERE status = 'dead'
+          AND updated_at >= now() - make_interval(hours => $1)
+    ) AS dead,
+    count(*) FILTER (
+        WHERE created_at >= now() - make_interval(hours => $1)
+          AND stage_output->'classify' ? 'doc_type'
+    ) AS classified,
+    count(*) FILTER (
+        WHERE created_at >= now() - make_interval(hours => $1)
+          AND stage_output->'classify' ? 'doc_type'
+          AND COALESCE(stage_output->'classify'->>'doc_type', 'unknown') <> 'unknown'
+    ) AS recognized,
+    percentile_cont(0.50) WITHIN GROUP (
+        ORDER BY extract(epoch FROM (updated_at - created_at))
+    ) FILTER (
+        WHERE status = 'done'
+          AND updated_at >= now() - make_interval(hours => $1)
+    ) AS completion_p50_seconds,
+    percentile_cont(0.95) WITHIN GROUP (
+        ORDER BY extract(epoch FROM (updated_at - created_at))
+    ) FILTER (
+        WHERE status = 'done'
+          AND updated_at >= now() - make_interval(hours => $1)
+    ) AS completion_p95_seconds,
+    percentile_cont(0.95) WITHIN GROUP (
+        ORDER BY extract(epoch FROM (now() - created_at))
+    ) FILTER (WHERE status = ANY($3::text[])) AS backlog_age_p95_seconds
+FROM intake_queue
+WHERE ($2::text IS NULL OR source = $2)
+"""
+
+CORRECTIONS_SQL = """
+SELECT
+    count(*) FILTER (WHERE c.outcome = 'approved') AS approved_fields,
+    count(*) FILTER (WHERE c.outcome = 'corrected') AS corrected_fields,
+    count(*) FILTER (WHERE c.outcome = 'auto_committed') AS auto_fields
+FROM intake_corrections c
+JOIN intake_queue q ON q.id = c.queue_id
+WHERE c.verified_at >= now() - make_interval(hours => $1)
+  AND c.field_name NOT LIKE '\\_\\_%' ESCAPE '\\'
+  AND ($2::text IS NULL OR q.source = $2)
+"""
+
+STAGE_SQL = """
+SELECT m.stage,
+       count(*) AS samples,
+       round(avg(m.latency_ms))::bigint AS avg_ms,
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY m.latency_ms))::bigint AS p95_ms
+FROM intake_stage_metrics m
+JOIN intake_queue q ON q.id = m.queue_id
+WHERE m.ts >= now() - make_interval(hours => $1)
+  AND ($2::text IS NULL OR q.source = $2)
+GROUP BY m.stage
+ORDER BY m.stage
+"""
+
+
+@dataclass(frozen=True)
+class Targets:
+    recognition_pct: float = 95.0
+    verified_field_acceptance_pct: float = 97.0
+    minimum_verified_fields: int = 100
+    backlog_drain_ratio: float = 1.10
+    maximum_dead: int = 0
+
+
+def _pct(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(100.0 * numerator / denominator, 2)
+
+
+def build_metrics(
+    overview: dict[str, Any],
+    corrections: dict[str, Any],
+    *,
+    hours: int,
+) -> dict[str, Any]:
+    """Normalize aggregate SQL rows and derive rate metrics."""
+    arrivals = int(overview.get("arrivals") or 0)
+    completions = int(overview.get("completions") or 0)
+    classified = int(overview.get("classified") or 0)
+    recognized = int(overview.get("recognized") or 0)
+    approved = int(corrections.get("approved_fields") or 0)
+    corrected = int(corrections.get("corrected_fields") or 0)
+    human_labels = approved + corrected
+    arrival_rate = arrivals / hours
+    completion_rate = completions / hours
+    drain_ratio = completion_rate / arrival_rate if arrival_rate > 0 else None
+    return {
+        "window_hours": hours,
+        "arrivals": arrivals,
+        "completions": completions,
+        "arrivals_per_hour": round(arrival_rate, 2),
+        "completions_per_hour": round(completion_rate, 2),
+        "backlog": int(overview.get("backlog") or 0),
+        "dead": int(overview.get("dead") or 0),
+        "classified": classified,
+        "recognized": recognized,
+        "recognition_coverage_pct": _pct(recognized, classified),
+        "approved_fields": approved,
+        "corrected_fields": corrected,
+        "auto_committed_fields": int(corrections.get("auto_fields") or 0),
+        "human_verified_fields": human_labels,
+        "verified_field_acceptance_pct": _pct(approved, human_labels),
+        "backlog_drain_ratio": round(drain_ratio, 3)
+        if drain_ratio is not None
+        else None,
+        "completion_p50_seconds": _optional_float(
+            overview.get("completion_p50_seconds")
+        ),
+        "completion_p95_seconds": _optional_float(
+            overview.get("completion_p95_seconds")
+        ),
+        "backlog_age_p95_seconds": _optional_float(
+            overview.get("backlog_age_p95_seconds")
+        ),
+    }
+
+
+def _optional_float(value: Any) -> float | None:
+    return round(float(value), 2) if value is not None else None
+
+
+def evaluate_targets(metrics: dict[str, Any], targets: Targets) -> dict[str, str]:
+    """Return PASS/FAIL/INSUFFICIENT_SAMPLE for each explicit operating target."""
+    recognition = metrics.get("recognition_coverage_pct")
+    verified = metrics.get("verified_field_acceptance_pct")
+    human_labels = int(metrics.get("human_verified_fields") or 0)
+    drain_ratio = metrics.get("backlog_drain_ratio")
+    backlog = int(metrics.get("backlog") or 0)
+    dead = int(metrics.get("dead") or 0)
+    return {
+        "recognition_coverage": (
+            "INSUFFICIENT_SAMPLE"
+            if recognition is None
+            else "PASS"
+            if float(recognition) >= targets.recognition_pct
+            else "FAIL"
+        ),
+        "verified_field_acceptance": (
+            "INSUFFICIENT_SAMPLE"
+            if human_labels < targets.minimum_verified_fields or verified is None
+            else "PASS"
+            if float(verified) >= targets.verified_field_acceptance_pct
+            else "FAIL"
+        ),
+        "backlog_drain": (
+            "PASS"
+            if backlog == 0
+            else "INSUFFICIENT_SAMPLE"
+            if drain_ratio is None
+            else "PASS"
+            if float(drain_ratio) >= targets.backlog_drain_ratio
+            else "FAIL"
+        ),
+        "dead_letter": "PASS" if dead <= targets.maximum_dead else "FAIL",
+    }
+
+
+async def collect_report(
+    *,
+    dsn: str,
+    source: str | None,
+    hours: int,
+    targets: Targets,
+) -> dict[str, Any]:
+    """Collect aggregate metrics from the local Intake database."""
+    conn = await asyncpg.connect(dsn)
+    try:
+        overview_row = await conn.fetchrow(
+            OVERVIEW_SQL, hours, source, list(ACTIVE_STATUSES)
+        )
+        correction_row = await conn.fetchrow(CORRECTIONS_SQL, hours, source)
+        stage_rows = await conn.fetch(STAGE_SQL, hours, source)
+    finally:
+        await conn.close()
+    metrics = build_metrics(dict(overview_row), dict(correction_row), hours=hours)
+    stages = [
+        {
+            "stage": row["stage"],
+            "samples": int(row["samples"]),
+            "avg_ms": int(row["avg_ms"] or 0),
+            "p95_ms": int(row["p95_ms"] or 0),
+        }
+        for row in stage_rows
+    ]
+    return {
+        "source": source or "all",
+        "metrics": metrics,
+        "targets": asdict(targets),
+        "gate": evaluate_targets(metrics, targets),
+        "stage_latency": stages,
+    }
+
+
+def _render_text(report: dict[str, Any]) -> str:
+    metrics = report["metrics"]
+    gate = report["gate"]
+    lines = [
+        f"Intake capacity/quality — source={report['source']} window={metrics['window_hours']}h",
+        (
+            f"flow: arrivals={metrics['arrivals']} ({metrics['arrivals_per_hour']}/h) "
+            f"completed={metrics['completions']} ({metrics['completions_per_hour']}/h) "
+            f"backlog={metrics['backlog']} drain_ratio={metrics['backlog_drain_ratio']}"
+        ),
+        (
+            f"recognition: {metrics['recognized']}/{metrics['classified']} "
+            f"known={metrics['recognition_coverage_pct']}% gate={gate['recognition_coverage']}"
+        ),
+        (
+            f"verified fields: approved={metrics['approved_fields']} "
+            f"corrected={metrics['corrected_fields']} "
+            f"acceptance={metrics['verified_field_acceptance_pct']}% "
+            f"gate={gate['verified_field_acceptance']}"
+        ),
+        (
+            f"safety: dead={metrics['dead']} gate={gate['dead_letter']} "
+            f"backlog_gate={gate['backlog_drain']}"
+        ),
+    ]
+    for stage in report["stage_latency"]:
+        lines.append(
+            f"stage {stage['stage']}: n={stage['samples']} avg={stage['avg_ms']}ms "
+            f"p95={stage['p95_ms']}ms"
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hours", type=int, default=24)
+    parser.add_argument("--source", default="whatsapp")
+    parser.add_argument("--all-sources", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--enforce", action="store_true")
+    parser.add_argument("--recognition-target", type=float, default=95.0)
+    parser.add_argument("--field-acceptance-target", type=float, default=97.0)
+    parser.add_argument("--minimum-verified-fields", type=int, default=100)
+    parser.add_argument("--drain-ratio-target", type=float, default=1.10)
+    return parser
+
+
+async def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.hours <= 0:
+        raise ValueError("--hours must be positive")
+    targets = Targets(
+        recognition_pct=args.recognition_target,
+        verified_field_acceptance_pct=args.field_acceptance_target,
+        minimum_verified_fields=args.minimum_verified_fields,
+        backlog_drain_ratio=args.drain_ratio_target,
+    )
+    report = await collect_report(
+        dsn=os.getenv("INTAKE_DATABASE_URL", DEFAULT_DSN),
+        source=None if args.all_sources else args.source,
+        hours=args.hours,
+        targets=targets,
+    )
+    rendered = (
+        json.dumps(report, indent=2, sort_keys=True)
+        if args.json
+        else _render_text(report)
+    )
+    sys.stdout.write(rendered + "\n")
+    if args.enforce and "FAIL" in report["gate"].values():
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None

--- a/scripts/tests/test_intake_capacity_quality_report.py
+++ b/scripts/tests/test_intake_capacity_quality_report.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from scripts.intake_capacity_quality_report import (
+    OVERVIEW_SQL,
+    Targets,
+    build_metrics,
+    evaluate_targets,
+)
+
+
+def test_overview_counts_only_completed_classification_outputs() -> None:
+    assert OVERVIEW_SQL.count("stage_output->'classify' ? 'doc_type'") == 2
+    assert "stage_output ? 'classify'" not in OVERVIEW_SQL
+
+
+def test_build_metrics_separates_recognition_accuracy_and_drain() -> None:
+    metrics = build_metrics(
+        {
+            "arrivals": 100,
+            "completions": 120,
+            "backlog": 20,
+            "dead": 0,
+            "classified": 96,
+            "recognized": 95,
+            "completion_p50_seconds": 90,
+            "completion_p95_seconds": 240,
+            "backlog_age_p95_seconds": 500,
+        },
+        {"approved_fields": 198, "corrected_fields": 2, "auto_fields": 50},
+        hours=10,
+    )
+
+    assert metrics["recognition_coverage_pct"] == 98.96
+    assert metrics["verified_field_acceptance_pct"] == 99.0
+    assert metrics["backlog_drain_ratio"] == 1.2
+    assert metrics["arrivals_per_hour"] == 10.0
+    assert metrics["completions_per_hour"] == 12.0
+
+
+def test_targets_require_real_human_sample_before_quality_pass() -> None:
+    metrics = build_metrics(
+        {
+            "arrivals": 10,
+            "completions": 12,
+            "backlog": 5,
+            "dead": 0,
+            "classified": 10,
+            "recognized": 10,
+        },
+        {"approved_fields": 9, "corrected_fields": 0, "auto_fields": 1000},
+        hours=1,
+    )
+
+    gate = evaluate_targets(metrics, Targets(minimum_verified_fields=100))
+
+    assert gate["recognition_coverage"] == "PASS"
+    assert gate["verified_field_acceptance"] == "INSUFFICIENT_SAMPLE"
+    assert gate["backlog_drain"] == "PASS"
+    assert gate["dead_letter"] == "PASS"
+
+
+def test_targets_fail_slow_drain_bad_labels_and_dead_letters() -> None:
+    metrics = build_metrics(
+        {
+            "arrivals": 20,
+            "completions": 5,
+            "backlog": 40,
+            "dead": 1,
+            "classified": 20,
+            "recognized": 16,
+        },
+        {"approved_fields": 80, "corrected_fields": 20, "auto_fields": 0},
+        hours=1,
+    )
+
+    gate = evaluate_targets(metrics, Targets())
+
+    assert set(gate.values()) == {"FAIL"}


### PR DESCRIPTION
## Outcome

Raises the WhatsApp Intake pipeline's recognition and drain capacity while preserving the existing human-review, quarantine, idempotency, and local-write safety gates.

## Root cause

- Heavy Ollama classification and extraction calls could run concurrently across workers, causing model/GPU contention and repeated long timeouts.
- The extraction path was pinned to a much larger model and a 300 second timeout ceiling.
- Text-only uncertain documents had no bounded local-model fallback.
- Human review decisions were not persisted as field-level learning evidence, so recognition quality could not be measured against verified corrections.

## Changes

- Add one process-local shared Ollama inference gate with configurable maximum inflight requests and keep-alive.
- Configure extraction on qwen3.5:9b with shorter bounded timeouts and dynamic model labels.
- Add a conservative text LLM classification fallback capped inside the review band.
- Normalize unreadable placeholders to null.
- Persist approved/corrected field outcomes idempotently in the same writer transaction.
- Add a PII-safe aggregate KPI report for recognition, verified-field acceptance, drain ratio, backlog, and dead-letter count.
- Update the LaunchAgent environment without changing review/quarantine/write thresholds.

## Safety and impact

- No client PII is introduced in code, tests, logs, or reports.
- No thresholds that bypass review or quarantine are relaxed.
- Writes remain local and transactional.
- Feedback persistence is idempotent.
- Expected operational impact: remove Ollama contention, reduce extraction latency, improve recognition coverage, and make quality measurable from verified outcomes.

## Verification

- Targeted Intake/KPI suite: 442 passed, 1 skipped.
- Full backend pre-push suite: 17,177 passed, 115 skipped.
- Ruff: passed.
- DOCSYNC: passed.
- LaunchAgent plist validation: passed.
- FastAPI critical import chain: passed.
- Synthetic warm extraction probe: all 5 expected receipt fields recognized in 6.497 seconds; this is a latency/capability probe, not a production accuracy claim.

## Baseline to beat

- 24h arrivals: 174
- 24h completions: 188
- drain ratio: 1.08 (target 1.10)
- classified recognition sample: 22/31 = 70.97%
- dead letters: 0
