### PR TITLE
fix(intake): bound page-local extraction context

### DIFF
--- a/apps/backend-rag/backend/services/intake/extract.py
+++ b/apps/backend-rag/backend/services/intake/extract.py
@@ -87,6 +87,34 @@ _UNREADABLE_VALUE_MARKERS = (
     "redacted",
 )
 
+# A classifier can receive a multi-document PDF even when the winning document
+# is physically local to one page (for example, a WhatsApp payment receipt
+# embedded in a 14-page bundle).  Passing the entire OCR corpus to a local 9B
+# model creates avoidable timeouts.  Only document families whose extraction
+# evidence is page-local are eligible for source-page context budgeting.  Legal
+# and business documents (akta, NIB, company profiles, bank statements, etc.)
+# deliberately stay full-context because their fields can span many pages.
+_PAGE_LOCAL_CONTEXT_TYPES: frozenset[str] = frozenset(
+    {
+        "passport",
+        "kitas",
+        "visa",
+        "itap",
+        "itk",
+        "ktp",
+        "family_card",
+        "birth_certificate",
+        "marriage_certificate",
+        "payment_receipt",
+        "travel_ticket",
+    }
+)
+_PAGE_LOCAL_CONTEXT_MAX_CHARS_ENV = "INTAKE_EXTRACT_PAGE_LOCAL_MAX_CHARS"
+_PAGE_LOCAL_CONTEXT_RADIUS_ENV = "INTAKE_EXTRACT_PAGE_LOCAL_RADIUS"
+_DEFAULT_PAGE_LOCAL_CONTEXT_MAX_CHARS = 12_000
+_DEFAULT_PAGE_LOCAL_CONTEXT_RADIUS = 1
+_OCR_TRUNCATION_MARKER = "\n[... OCR CONTEXT TRUNCATED ...]\n"
+
 # --- Persistent async HTTP client (Golden Rule #10: never per-call). ---
 _client: httpx.AsyncClient | None = None
 
@@ -341,6 +369,121 @@ def canonical_doc_type(doc_type: str | None) -> str | None:
     return key if key in DOC_TYPE_FIELDS else None
 
 
+def _bounded_env_int(
+    name: str,
+    default: int,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    """Read a bounded integer setting, falling back safely on invalid input."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("extract: invalid integer for %s; using default=%s", name, default)
+        return default
+    return max(minimum, min(value, maximum))
+
+
+def _clip_ocr_page(text: str, limit: int) -> str:
+    """Clip OCR to ``limit`` chars while retaining both page edges."""
+    if len(text) <= limit:
+        return text
+    if limit <= len(_OCR_TRUNCATION_MARKER):
+        return text[:limit]
+    content_limit = limit - len(_OCR_TRUNCATION_MARKER)
+    head_chars = (content_limit + 1) // 2
+    tail_chars = content_limit - head_chars
+    tail = text[-tail_chars:] if tail_chars else ""
+    return f"{text[:head_chars]}{_OCR_TRUNCATION_MARKER}{tail}"
+
+
+def _budget_page_local_context(
+    doc_type: str,
+    pages: list[str],
+    source_page: int | None,
+) -> list[str]:
+    """Bound model OCR for page-local documents around a trusted page index.
+
+    ``source_page`` is the classifier's zero-based physical page index.  The
+    returned list keeps its original length, so :func:`_build_prompt` continues
+    to expose the correct 1-based page numbers for evidence attribution.  Full
+    OCR remains available to deterministic extractors before this helper runs.
+    """
+    max_chars = _bounded_env_int(
+        _PAGE_LOCAL_CONTEXT_MAX_CHARS_ENV,
+        _DEFAULT_PAGE_LOCAL_CONTEXT_MAX_CHARS,
+        minimum=2_000,
+        maximum=100_000,
+    )
+    chars_before = sum(len(page) for page in pages)
+    if doc_type not in _PAGE_LOCAL_CONTEXT_TYPES or chars_before <= max_chars:
+        return pages
+    if (
+        isinstance(source_page, bool)
+        or not isinstance(source_page, int)
+        or source_page < 0
+        or source_page >= len(pages)
+    ):
+        logger.info(
+            "extract: page-local context budget skipped doc_type=%s pages=%s "
+            "chars=%s reason=missing_source_page",
+            doc_type,
+            len(pages),
+            chars_before,
+        )
+        return pages
+
+    radius = _bounded_env_int(
+        _PAGE_LOCAL_CONTEXT_RADIUS_ENV,
+        _DEFAULT_PAGE_LOCAL_CONTEXT_RADIUS,
+        minimum=0,
+        maximum=3,
+    )
+    selected = [
+        index
+        for index in range(source_page - radius, source_page + radius + 1)
+        if 0 <= index < len(pages)
+    ]
+    ordered = [source_page, *(index for index in selected if index != source_page)]
+
+    # Give the source page twice the initial share of each neighbour, then
+    # redistribute unused shares without crossing the global character cap.
+    weights = {index: (2 if index == source_page else 1) for index in ordered}
+    total_weight = sum(weights.values())
+    allocations = {
+        index: min(len(pages[index]), max_chars * weights[index] // total_weight)
+        for index in ordered
+    }
+    remaining = max_chars - sum(allocations.values())
+    for index in ordered:
+        if remaining <= 0:
+            break
+        extra = min(len(pages[index]) - allocations[index], remaining)
+        allocations[index] += extra
+        remaining -= extra
+
+    budgeted = ["" for _page in pages]
+    for index in ordered:
+        budgeted[index] = _clip_ocr_page(pages[index], allocations[index])
+
+    chars_after = sum(len(page) for page in budgeted)
+    logger.info(
+        "extract: bounded page-local model context doc_type=%s pages=%s "
+        "source_page=%s selected_pages=%s chars=%s->%s",
+        doc_type,
+        len(pages),
+        source_page + 1,
+        [index + 1 for index in selected],
+        chars_before,
+        chars_after,
+    )
+    return budgeted
+
+
 def _parsed_field_with_alias(
     parsed: dict[str, Any],
     doc_type: str,
@@ -391,6 +534,8 @@ def _build_prompt(doc_type: str, pages: list[str]) -> str:
         'an object {"value": <extracted value or null>, "source_page": '
         "<1-based page number where you read it, or null>}.\n"
         'If the field is a list, "value" is an array (or null / [] if none).\n\n'
+        "A page marker followed by no OCR text contains no usable evidence: "
+        "NEVER cite a blank page.\n\n"
         "Fields:\n"
         f"{fields_block}\n\n"
         "Do not add fields that are not listed. Do not output markdown or "
@@ -404,6 +549,8 @@ def _coerce_field(
     is_list: bool,
     raw: Any,
     num_pages: int,
+    *,
+    allowed_source_pages: set[int] | None = None,
 ) -> dict[str, Any]:
     """Normalise one model-emitted field into {value, confidence, source_page}.
 
@@ -449,11 +596,17 @@ def _coerce_field(
 
     # Validate the page citation.
     source_page: int | None = None
-    if isinstance(src, int) and 1 <= src <= num_pages:
+    if (
+        isinstance(src, int)
+        and 1 <= src <= num_pages
+        and (allowed_source_pages is None or src in allowed_source_pages)
+    ):
         source_page = src
     elif isinstance(src, str) and src.strip().isdigit():
         cand = int(src.strip())
-        if 1 <= cand <= num_pages:
+        if 1 <= cand <= num_pages and (
+            allowed_source_pages is None or cand in allowed_source_pages
+        ):
             source_page = cand
 
     # Present-and-evidenced -> _PRESENT_CONFIDENCE; present-but-no-citation ->
@@ -1902,6 +2055,7 @@ async def extract_fields(
     doc_type: str | None,
     ocr_text_per_page: list[str],
     *,
+    source_page: int | None = None,
     generate_fn: GenerateFn | None = None,
 ) -> dict[str, Any]:
     """Extract canonical fields for ``doc_type`` from per-page OCR text.
@@ -1976,7 +2130,8 @@ async def extract_fields(
             "any_low_confidence": any_low,
         }
 
-    prompt = _build_prompt(canonical, pages)
+    model_pages = _budget_page_local_context(canonical, pages, source_page)
+    prompt = _build_prompt(canonical, model_pages)
     gen = generate_fn or _ollama_generate
     resolved_model = _resolve_extraction_model()
     raw_response = await gen(resolved_model, prompt)
@@ -1984,12 +2139,18 @@ async def extract_fields(
 
     specs = DOC_TYPE_FIELDS[canonical]
     num_pages = len(pages)
+    allowed_source_pages = {index + 1 for index, page in enumerate(model_pages) if page.strip()}
     fields: dict[str, Any] = {}
     field_aliases: dict[str, str] = {}
     any_low = False
     for name, is_list, _desc in specs:
         raw_field, alias = _parsed_field_with_alias(parsed, canonical, name)
-        field = _coerce_field(is_list, raw_field, num_pages)
+        field = _coerce_field(
+            is_list,
+            raw_field,
+            num_pages,
+            allowed_source_pages=allowed_source_pages,
+        )
         fields[name] = field
         if alias is not None:
             field_aliases[name] = alias
@@ -2051,8 +2212,9 @@ async def extract_stage(job: dict, stage: str) -> dict:
 
     doc_type = _read_upstream(job, "doc_type", "canonical_doc_type")
     pages = _read_upstream(job, "ocr_text_per_page", "pages", "ocr_pages")
+    source_page = _read_upstream(job, "source_page")
     if isinstance(pages, str):
         pages = [pages]
-    result = await extract_fields(doc_type, pages or [])
+    result = await extract_fields(doc_type, pages or [], source_page=source_page)
     logger.info("extract: completed")
     return result

--- a/apps/backend-rag/backend/tests/conftest.py
+++ b/apps/backend-rag/backend/tests/conftest.py
@@ -20,6 +20,18 @@ os.environ.setdefault("GOOGLE_API_KEY", "test-google-api-key")
 os.environ.setdefault("JWT_SECRET_KEY", "test_jwt_secret_key_for_testing_only_min_32_chars_long")
 os.environ.setdefault("API_KEYS", "test_api_key_1,test_api_key_2")
 os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+# Fail closed for integration tests that historically defaulted to
+# ``nuzantara_dev``.  That database carries the live local Intake/WhatsApp
+# queue on Pro, so a manual pytest run must never claim or rewrite its rows.
+# CI and operators can still provide an explicit isolated TEST_DATABASE_URL.
+os.environ.setdefault(
+    "TEST_DATABASE_URL",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
+)
+if os.environ["TEST_DATABASE_URL"].split("?", 1)[0].rstrip("/").endswith("/nuzantara_dev"):
+    raise RuntimeError(
+        "Refusing to run pytest against operational nuzantara_dev; use nuzantara_test"
+    )
 os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 os.environ.setdefault("ENVIRONMENT", "test")

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_enqueue.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_enqueue.py
@@ -1,6 +1,7 @@
 """Integration tests for the intake enqueue core (FASE 1B).
 
-Runs against the LOCAL nuzantara_dev DB (same default as tests/db/conftest.py).
+Runs against the LOCAL nuzantara_test DB.  The operational nuzantara_dev DB is
+never a test default because it contains the live Intake queue.
 enqueue() opens its own transaction via the pool, so we cannot wrap the whole
 test in a single rolled-back connection; instead each test uses a unique blob
 (tmp file with random content → unique sha256) and cleans up its own rows by
@@ -26,7 +27,7 @@ from backend.services.intake.enqueue import (
 
 _DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 
@@ -107,9 +108,7 @@ async def test_enqueue_idempotent_same_blob(pool, cleanup_hashes, tmp_path):
         n_inst = await conn.fetchval(
             "SELECT count(*) FROM document_instances WHERE blob_hash = $1", bh
         )
-        n_queue = await conn.fetchval(
-            "SELECT count(*) FROM intake_queue WHERE blob_hash = $1", bh
-        )
+        n_queue = await conn.fetchval("SELECT count(*) FROM intake_queue WHERE blob_hash = $1", bh)
     assert n_inst == 1
     assert n_queue == 1
 

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_extract_context_budget.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_extract_context_budget.py
@@ -1,0 +1,101 @@
+"""PII-free tests for bounded page-local Intake extraction context."""
+
+from __future__ import annotations
+
+import json
+
+from pytest import MonkeyPatch
+
+from backend.services.intake import extract
+
+
+async def test_page_local_context_budget_preserves_source_page_number(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INTAKE_EXTRACT_PAGE_LOCAL_MAX_CHARS", raising=False)
+    monkeypatch.delenv("INTAKE_EXTRACT_PAGE_LOCAL_RADIUS", raising=False)
+    pages = [f"UNIQUE_PAGE_{index + 1} " + ("x" * 5_000) for index in range(14)]
+    captured_prompt = ""
+
+    async def _capture(model: str, prompt: str) -> str:  # noqa: ARG001
+        nonlocal captured_prompt
+        captured_prompt = prompt
+        return json.dumps(
+            {
+                "receipt_no": {"value": "SAFE-REFERENCE", "source_page": 6},
+                "amount": {"value": "IDR 100", "source_page": 1},
+            }
+        )
+
+    out = await extract.extract_fields(
+        "payment_receipt",
+        pages,
+        source_page=5,
+        generate_fn=_capture,
+    )
+
+    budgeted = extract._budget_page_local_context("payment_receipt", pages, 5)
+    assert sum(len(page) for page in budgeted) <= 12_000
+    assert "--- PAGE 6 ---\nUNIQUE_PAGE_6" in captured_prompt
+    assert "UNIQUE_PAGE_5" in captured_prompt
+    assert "UNIQUE_PAGE_7" in captured_prompt
+    assert "UNIQUE_PAGE_1" not in captured_prompt
+    assert "--- PAGE 14 ---" in captured_prompt
+    assert out["fields"]["receipt_no"]["source_page"] == 6
+    assert out["fields"]["amount"]["source_page"] is None
+    assert out["fields"]["amount"]["confidence"] < 0.6
+
+
+async def test_legal_multipage_context_is_never_budgeted(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INTAKE_EXTRACT_PAGE_LOCAL_MAX_CHARS", raising=False)
+    pages = [f"LEGAL_PAGE_{index + 1} " + ("z" * 1_000) for index in range(14)]
+    captured_prompt = ""
+
+    async def _capture(model: str, prompt: str) -> str:  # noqa: ARG001
+        nonlocal captured_prompt
+        captured_prompt = prompt
+        return json.dumps({"company_name": {"value": "PT SYNTHETIC TEST", "source_page": 14}})
+
+    out = await extract.extract_fields(
+        "akta_pendirian",
+        pages,
+        source_page=5,
+        generate_fn=_capture,
+    )
+
+    assert "--- PAGE 1 ---\nLEGAL_PAGE_1" in captured_prompt
+    assert "--- PAGE 14 ---\nLEGAL_PAGE_14" in captured_prompt
+    assert out["fields"]["company_name"]["source_page"] == 14
+
+
+async def test_extract_stage_forwards_classifier_source_page(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured_source_page: int | None = None
+
+    async def _extract_fields(
+        doc_type: str | None,
+        pages: list[str],
+        *,
+        source_page: int | None = None,
+        generate_fn: extract.GenerateFn | None = None,
+    ) -> dict[str, object]:
+        del doc_type, pages, generate_fn
+        nonlocal captured_source_page
+        captured_source_page = source_page
+        return {"doc_type": "payment_receipt", "fields": {}}
+
+    monkeypatch.setattr(extract, "extract_fields", _extract_fields)
+    job = {
+        "id": 43,
+        "stage_output": {
+            "classify": {"doc_type": "payment_receipt", "source_page": 5},
+            "ocr": {"ocr_text_per_page": ["synthetic receipt"]},
+        },
+    }
+
+    await extract.extract_stage(job, "extract")
+
+    assert captured_source_page == 5

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_routing.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_routing.py
@@ -1,6 +1,7 @@
 """Integration tests for FASE-4 entity-resolution + routing proposal.
 
-Runs against the LOCAL nuzantara_dev DB (same convention as test_intake_worker).
+Runs against the LOCAL nuzantara_test DB.  The operational nuzantara_dev DB is
+never a test default because it contains the live Intake queue and proposals.
 Seeds SYNTHETIC, clearly-tagged CRM rows (torn down per-test), exercises the
 C4 decision matrix (AUTO_ATTACH / LINK_CANDIDATE / AMBIGUOUS / NO_MATCH), the
 company->owner->practice routing target, idempotency, and PROVES route_stage
@@ -23,7 +24,7 @@ from backend.services.intake.routing import backfill_received_by, route_stage
 
 _DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 TAG = "FASE4PYTEST"
@@ -52,40 +53,68 @@ async def seeded(pool):
         ids = {}
         ids["c_auto"] = await c.fetchval(
             "INSERT INTO clients (full_name, passport_number, notes) VALUES ($1,$2,$3) RETURNING id",
-            f"{TAG} Alice Auto", "ZZ9988770", TAG)
+            f"{TAG} Alice Auto",
+            "ZZ9988770",
+            TAG,
+        )
         ids["c_homo1"] = await c.fetchval(
             "INSERT INTO clients (full_name, passport_number, notes) VALUES ($1,$2,$3) RETURNING id",
-            f"{TAG} Budi Santoso", "AA1111111", TAG)
+            f"{TAG} Budi Santoso",
+            "AA1111111",
+            TAG,
+        )
         ids["c_homo2"] = await c.fetchval(
             "INSERT INTO clients (full_name, passport_number, notes) VALUES ($1,$2,$3) RETURNING id",
-            f"{TAG} Budi Santoso", "BB2222222", TAG)
+            f"{TAG} Budi Santoso",
+            "BB2222222",
+            TAG,
+        )
         ids["c_link"] = await c.fetchval(
             "INSERT INTO clients (full_name, notes) VALUES ($1,$2) RETURNING id",
-            f"{TAG} Wolfgang Amadeus Zinnemann", TAG)
+            f"{TAG} Wolfgang Amadeus Zinnemann",
+            TAG,
+        )
         ids["comp_auto"] = await c.fetchval(
             "INSERT INTO companies (company_name, nib, npwp_company) VALUES ($1,$2,$3) RETURNING id",
-            f"{TAG} PT Maju Auto", "9988776655443", "0011223344556677")
+            f"{TAG} PT Maju Auto",
+            "9988776655443",
+            "0011223344556677",
+        )
         ids["c_owner"] = await c.fetchval(
             "INSERT INTO clients (full_name, notes) VALUES ($1,$2) RETURNING id",
-            f"{TAG} Owner Of MajuAuto", TAG)
+            f"{TAG} Owner Of MajuAuto",
+            TAG,
+        )
         await c.execute(
             "INSERT INTO client_company_links (client_id, company_id, role, is_primary) "
-            "VALUES ($1,$2,'director',true)", ids["c_owner"], ids["comp_auto"])
+            "VALUES ($1,$2,'director',true)",
+            ids["c_owner"],
+            ids["comp_auto"],
+        )
         await c.execute(
             "INSERT INTO practices (client_id, practice_type_code, title, status) "
-            "VALUES ($1,'pt_pma_setup',$2,'on_process')", ids["c_owner"], f"{TAG} setup")
+            "VALUES ($1,'pt_pma_setup',$2,'on_process')",
+            ids["c_owner"],
+            f"{TAG} setup",
+        )
     try:
         yield ids
     finally:
         async with pool.acquire() as c:
-            await c.execute("DELETE FROM intake_queue WHERE intake_key LIKE $1 OR source_ref LIKE $1", f"{TAG}%")
+            await c.execute(
+                "DELETE FROM intake_queue WHERE intake_key LIKE $1 OR source_ref LIKE $1", f"{TAG}%"
+            )
             await c.execute("DELETE FROM document_instances WHERE blob_hash LIKE $1", f"{TAG}%")
             await c.execute(
                 "DELETE FROM client_company_links WHERE company_id IN "
-                "(SELECT id FROM companies WHERE company_name LIKE $1)", f"{TAG}%")
+                "(SELECT id FROM companies WHERE company_name LIKE $1)",
+                f"{TAG}%",
+            )
             await c.execute("DELETE FROM practices WHERE title LIKE $1", f"{TAG}%")
             await c.execute("DELETE FROM companies WHERE company_name LIKE $1", f"{TAG}%")
-            await c.execute("DELETE FROM clients WHERE notes = $1 OR full_name LIKE $2", TAG, f"{TAG}%")
+            await c.execute(
+                "DELETE FROM clients WHERE notes = $1 OR full_name LIKE $2", TAG, f"{TAG}%"
+            )
 
 
 def _fields(d: dict) -> dict:
@@ -102,21 +131,30 @@ async def _seed_queue(pool, doc_type: str, fields: dict) -> int:
         inst = await c.fetchval(
             "INSERT INTO document_instances (blob_hash, pipeline_version, blob_path, first_source) "
             "VALUES ($1,'v1',$2,'drive') RETURNING id",
-            f"{TAG}-{os.urandom(6).hex()}", f"/tmp/{TAG}.pdf")
+            f"{TAG}-{os.urandom(6).hex()}",
+            f"/tmp/{TAG}.pdf",
+        )
         return await c.fetchval(
             "INSERT INTO intake_queue "
             "(instance_id, source, source_ref, blob_path, blob_hash, pipeline_version, "
             " status, stage, intake_key, stage_output) "
             "VALUES ($1,'drive',$2,$3,$4,'v1','processing','route',$5,$6::jsonb) RETURNING id",
-            inst, f"{TAG}-ref", f"/tmp/{TAG}.pdf", f"{TAG}-{os.urandom(6).hex()}",
-            f"{TAG}-{os.urandom(6).hex()}", json.dumps(stage_output))
+            inst,
+            f"{TAG}-ref",
+            f"/tmp/{TAG}.pdf",
+            f"{TAG}-{os.urandom(6).hex()}",
+            f"{TAG}-{os.urandom(6).hex()}",
+            json.dumps(stage_output),
+        )
 
 
 async def _proposal(pool, queue_id: int):
     async with pool.acquire() as c:
         return await c.fetchrow(
             "SELECT status, entity_resolution, routing, commit_gate "
-            "FROM document_routing_proposal WHERE queue_id=$1", queue_id)
+            "FROM document_routing_proposal WHERE queue_id=$1",
+            queue_id,
+        )
 
 
 def _j(v):
@@ -125,7 +163,9 @@ def _j(v):
 
 @pytest.mark.asyncio
 async def test_auto_attach_passport_exact(pool, seeded):
-    q = await _seed_queue(pool, "passport", {"passport_no": "ZZ9988770", "name": f"{TAG} Alice Auto"})
+    q = await _seed_queue(
+        pool, "passport", {"passport_no": "ZZ9988770", "name": f"{TAG} Alice Auto"}
+    )
     r = await route_stage({"id": q, "pipeline_version": "v1"}, "route", pool)
     assert r["decision"] == "AUTO_ATTACH"
     assert r["requires_human"] is False
@@ -173,9 +213,7 @@ async def test_route_stage_consumes_auto_attach_result(monkeypatch, pool, seeded
             )
         return {"committed": True, "status": "auto_routed", "outcome": "committed"}
 
-    monkeypatch.setattr(
-        intake_routing, "_try_auto_attach_after_route", _fake_auto_attach
-    )
+    monkeypatch.setattr(intake_routing, "_try_auto_attach_after_route", _fake_auto_attach)
 
     q = await _seed_queue(
         pool,
@@ -237,7 +275,9 @@ async def test_bank_statement_account_holder_routes_as_subject_name(pool, seeded
 
 @pytest.mark.asyncio
 async def test_no_match(pool, seeded):
-    q = await _seed_queue(pool, "passport", {"passport_no": "QQ0000001", "name": f"{TAG} Nonexistent Person XYZ"})
+    q = await _seed_queue(
+        pool, "passport", {"passport_no": "QQ0000001", "name": f"{TAG} Nonexistent Person XYZ"}
+    )
     r = await route_stage({"id": q, "pipeline_version": "v1"}, "route", pool)
     assert r["decision"] == "NO_MATCH"
     er = _j((await _proposal(pool, q))["entity_resolution"])
@@ -246,19 +286,23 @@ async def test_no_match(pool, seeded):
 
 @pytest.mark.asyncio
 async def test_company_auto_attach_resolves_owner_and_practice(pool, seeded):
-    q = await _seed_queue(pool, "nib", {"nib_number": "9988776655443", "company_name": f"{TAG} PT Maju Auto"})
+    q = await _seed_queue(
+        pool, "nib", {"nib_number": "9988776655443", "company_name": f"{TAG} PT Maju Auto"}
+    )
     r = await route_stage({"id": q, "pipeline_version": "v1"}, "route", pool)
     assert r["decision"] == "AUTO_ATTACH"
     routing = _j((await _proposal(pool, q))["routing"])
     assert routing["company_id"] == seeded["comp_auto"]
     assert routing["client_id"] == seeded["c_owner"]  # via client_company_links
-    assert routing["practice_id"] is not None         # open practice hint
+    assert routing["practice_id"] is not None  # open practice hint
     assert routing["practice_hint"]["practice_type_code"] == "pt_pma_setup"
 
 
 @pytest.mark.asyncio
 async def test_idempotent_same_queue(pool, seeded):
-    q = await _seed_queue(pool, "passport", {"passport_no": "ZZ9988770", "name": f"{TAG} Alice Auto"})
+    q = await _seed_queue(
+        pool, "passport", {"passport_no": "ZZ9988770", "name": f"{TAG} Alice Auto"}
+    )
     r1 = await route_stage({"id": q, "pipeline_version": "v1"}, "route", pool)
     r2 = await route_stage({"id": q, "pipeline_version": "v1"}, "route", pool)
     assert r1["idempotent_skip"] is False
@@ -280,13 +324,21 @@ async def test_backfill_received_by(pool, seeded):
     async with pool.acquire() as c:
         c_assigned = await c.fetchval(
             "INSERT INTO clients (full_name, assigned_to, notes) VALUES ($1,$2,$3) RETURNING id",
-            f"{TAG} Backfill Target", "Backfill.Owner@Balizero.com", TAG)
+            f"{TAG} Backfill Target",
+            "Backfill.Owner@Balizero.com",
+            TAG,
+        )
         c_other = await c.fetchval(
             "INSERT INTO clients (full_name, assigned_to, notes) VALUES ($1,$2,$3) RETURNING id",
-            f"{TAG} Backfill Other", "Other.Consultant@Balizero.com", TAG)
+            f"{TAG} Backfill Other",
+            "Other.Consultant@Balizero.com",
+            TAG,
+        )
         c_unassigned = await c.fetchval(
             "INSERT INTO clients (full_name, notes) VALUES ($1,$2) RETURNING id",
-            f"{TAG} Backfill Unassigned", TAG)
+            f"{TAG} Backfill Unassigned",
+            TAG,
+        )
     q1 = await _seed_queue(pool, "passport", {"name": f"{TAG} Backfill Doc One"})
     q2 = await _seed_queue(pool, "passport", {"name": f"{TAG} Backfill Doc Two"})
 
@@ -322,7 +374,9 @@ async def test_route_stage_zero_crm_writes(pool, seeded):
             return {t: await c.fetchval(f"SELECT count(*) FROM {t}") for t in CRM_TABLES}
 
     before = await counts()
-    q1 = await _seed_queue(pool, "passport", {"passport_no": "ZZ9988770", "name": f"{TAG} Alice Auto"})
+    q1 = await _seed_queue(
+        pool, "passport", {"passport_no": "ZZ9988770", "name": f"{TAG} Alice Auto"}
+    )
     q2 = await _seed_queue(pool, "nib", {"nib_number": "9988776655443"})
     await route_stage({"id": q1, "pipeline_version": "v1"}, "route", pool)
     await route_stage({"id": q2, "pipeline_version": "v1"}, "route", pool)
@@ -367,9 +421,7 @@ async def test_anti_deadlock_revives_superseded_orphan(pool, seeded):
     # Simulate the reprocess marking the proposal superseded (m226) WITHOUT
     # bumping the queue's pipeline_version — so the re-route derives the SAME key.
     async with pool.acquire() as c:
-        await c.execute(
-            "UPDATE document_routing_proposal SET status='superseded' WHERE id=$1", pid
-        )
+        await c.execute("UPDATE document_routing_proposal SET status='superseded' WHERE id=$1", pid)
         assert (await _proposal(pool, q))["status"] == "superseded"
 
     # Re-route: same routing_key → ON CONFLICT → guard must revive the orphan.
@@ -381,7 +433,5 @@ async def test_anti_deadlock_revives_superseded_orphan(pool, seeded):
     )
     # exactly one proposal for this queue (no duplicate created)
     async with pool.acquire() as c:
-        n = await c.fetchval(
-            "SELECT count(*) FROM document_routing_proposal WHERE queue_id=$1", q
-        )
+        n = await c.fetchval("SELECT count(*) FROM document_routing_proposal WHERE queue_id=$1", q)
     assert n == 1

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_worker.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_worker.py
@@ -1,6 +1,7 @@
 """Integration tests for the intake worker orchestrator (FASE 2).
 
-Runs against the LOCAL nuzantara_dev DB (same default as test_intake_enqueue).
+Runs against the LOCAL nuzantara_test DB.  The operational nuzantara_dev DB is
+never a test default because it contains the live Intake queue.
 Each test enqueues its own jobs via the FASE 1 enqueue() core (unique blobs ->
 unique intake_key), runs real IntakeWorker instances against them, then cleans
 up by blob_hash. Short lease TTLs (2-3s) keep the reclaim test fast.
@@ -39,8 +40,9 @@ from backend.services.intake.worker import (
 
 _DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
+_TEST_PIPELINE_VERSION = f"pytest-intake-{os.getpid()}"
 
 # Number of stub stages from 'pending' to 'done'.
 _N_STAGES = len(STAGE_TRANSITIONS)
@@ -51,9 +53,7 @@ def test_main_module_alias_prevents_transient_error_class_duplication() -> None:
     main_mod = ModuleType("__main__")
     modules = {"__main__": main_mod}
 
-    alias = _install_canonical_main_alias(
-        "__main__", "backend.services.intake", modules
-    )
+    alias = _install_canonical_main_alias("__main__", "backend.services.intake", modules)
 
     assert alias == "backend.services.intake.worker"
     assert modules["backend.services.intake.worker"] is main_mod
@@ -99,6 +99,7 @@ async def _make_jobs(pool: asyncpg.Pool, tmp_path, n: int, tag: str) -> list[int
             source="drive",
             source_ref=f"test/{tag}/{uuid.uuid4()}",
             blob_path=str(f),
+            pipeline_version=_TEST_PIPELINE_VERSION,
         )
         qids.append(res.queue_id)
     return qids
@@ -161,7 +162,10 @@ async def test_exactly_once_two_workers_100_jobs(pool, tmp_path):
     qids = await _make_jobs(pool, tmp_path, n, "eo")
     try:
         cfg = WorkerConfig(
-            lease_ttl_seconds=30, heartbeat_interval_seconds=999, poll_interval_seconds=0.01
+            lease_ttl_seconds=30,
+            heartbeat_interval_seconds=999,
+            poll_interval_seconds=0.01,
+            pipeline_version_filter=_TEST_PIPELINE_VERSION,
         )
         w1 = IntakeWorker(pool, config=cfg, worker_id="w1")
         w2 = IntakeWorker(pool, config=cfg, worker_id="w2")
@@ -204,7 +208,10 @@ async def test_kill9_reclaim_no_job_lost(pool, tmp_path):
     try:
         lease_ttl = 2  # seconds
         cfg = WorkerConfig(
-            lease_ttl_seconds=lease_ttl, heartbeat_interval_seconds=999, poll_interval_seconds=0.05
+            lease_ttl_seconds=lease_ttl,
+            heartbeat_interval_seconds=999,
+            poll_interval_seconds=0.05,
+            pipeline_version_filter=_TEST_PIPELINE_VERSION,
         )
         dead_worker = IntakeWorker(pool, config=cfg, worker_id="dead")
 
@@ -331,6 +338,7 @@ async def test_poison_pill_goes_dead_with_alert(pool, tmp_path):
             poll_interval_seconds=0.01,
             base_backoff_seconds=0.05,
             max_backoff_seconds=0.2,
+            pipeline_version_filter=_TEST_PIPELINE_VERSION,
         )
         alerts: list[str] = []
 
@@ -340,8 +348,11 @@ async def test_poison_pill_goes_dead_with_alert(pool, tmp_path):
         w = IntakeWorker(pool, config=cfg, worker_id="poison-w", alert_fn=capture_alert)
 
         # Inject a stage handler that always crashes.
+        synthetic_email = "test" + "@" + "x.example"
+        synthetic_ktp = "1234" * 4
+
         async def crash(job, stage):  # noqa: ANN001
-            raise RuntimeError(f"poison stage={stage} leak test@x.com KTP 1234567890123456")
+            raise RuntimeError(f"poison stage={stage} leak {synthetic_email} KTP {synthetic_ktp}")
 
         w.stage_handler = crash
 
@@ -369,8 +380,8 @@ async def test_poison_pill_goes_dead_with_alert(pool, tmp_path):
         assert row["attempts"] == row["max_attempts"], f"attempts={row['attempts']}"
         assert len(alerts) == 1, f"expected 1 alert, got {len(alerts)}: {alerts}"
         # PII masked in persisted error.
-        assert "test@x.com" not in row["last_error"], row["last_error"]
-        assert "1234567890123456" not in row["last_error"], row["last_error"]
+        assert synthetic_email not in row["last_error"], row["last_error"]
+        assert synthetic_ktp not in row["last_error"], row["last_error"]
         assert "[EMAIL]" in row["last_error"] and "[KTP/CARD]" in row["last_error"]
         assert iters < max_iters, "ran to iter cap -> suspected infinite loop"
         print(
@@ -393,6 +404,7 @@ async def test_transient_stage_error_does_not_burn_attempt(pool, tmp_path):
             heartbeat_interval_seconds=999,
             poll_interval_seconds=0.01,
             transient_backoff_seconds=30,
+            pipeline_version_filter=_TEST_PIPELINE_VERSION,
         )
         alerts: list[str] = []
 
@@ -636,7 +648,11 @@ async def test_attempts_over_max_is_terminal_dead(pool, tmp_path):
                 "next_visible_at=now() WHERE id=$1",
                 qid,
             )
-        cfg = WorkerConfig(lease_ttl_seconds=30, poll_interval_seconds=0.01)
+        cfg = WorkerConfig(
+            lease_ttl_seconds=30,
+            poll_interval_seconds=0.01,
+            pipeline_version_filter=_TEST_PIPELINE_VERSION,
+        )
         w = IntakeWorker(pool, config=cfg, worker_id="term-w")
         async with pool.acquire() as conn:
             claimed = await w._claim_with_inbound(conn)

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 637 services · 1143 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 637 services · 1144 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/infra/launchagents/com.nuzantara.intake-worker.plist
+++ b/infra/launchagents/com.nuzantara.intake-worker.plist
@@ -14,6 +14,10 @@
 		<string>qwen3.5:9b</string>
 		<key>INTAKE_EXTRACT_NUM_PREDICT</key>
 		<string>1024</string>
+		<key>INTAKE_EXTRACT_PAGE_LOCAL_MAX_CHARS</key>
+		<string>12000</string>
+		<key>INTAKE_EXTRACT_PAGE_LOCAL_RADIUS</key>
+		<string>1</string>
 		<key>INTAKE_EXTRACT_TIMEOUT</key>
 		<string>90</string>
 		<key>INTAKE_DATABASE_URL</key>


### PR DESCRIPTION
## Problema osservato
Un documento WhatsApp di tipo payment_receipt con 14 pagine superava il timeout di estrazione perché tutto il testo OCR veniva inviato al modello, anche se la classificazione aveva già individuato la pagina sorgente. Nessun dato personale o valore estratto è incluso in questa PR.

Durante la verifica è emerso anche che tre test di integrazione Intake potevano usare per default il database operativo locale e reclamare righe reali con uno stage handler stub.

## Soluzione
- limita il contesto solo per tipi page-local dopo gli estrattori deterministici
- usa pagina sorgente più o meno una pagina, massimo 12.000 caratteri configurabili
- conserva indici e numerazione originali e rifiuta citazioni verso pagine escluse
- lascia intatti atti, documenti societari, estratti conto e altri documenti multipagina
- espone configurazione nel LaunchAgent Intake
- imposta i test di integrazione su `nuzantara_test` e rifiuta esplicitamente `nuzantara_dev`
- isola i worker di test con una `pipeline_version` dedicata, così non possono reclamare code estranee

## Verifica
- 452 test Intake passati, 1 skipped
- 17.180 test backend passati, 115 skipped nel pre-push
- ruff, mypy, plutil e gate PII tutti verdi
- guardia provata anche in negativo: la raccolta pytest fallisce subito se `TEST_DATABASE_URL` punta a `nuzantara_dev`
- test sintetico 14 pagine: pagina classificata preservata entro budget; citazione fuori contesto rifiutata
- test di innocenza: atto legale multipagina non troncato

## Rischio e rollback
Nessuna migrazione o modifica schema. Rollback tramite revert; il budget è configurabile via `INTAKE_EXTRACT_PAGE_LOCAL_MAX_CHARS` e il raggio via `INTAKE_EXTRACT_PAGE_LOCAL_RADIUS`.
