### PR TITLE
fix(intake): drain model timeouts safely

### DIFF
--- a/apps/backend-rag/backend/services/intake/extract.py
+++ b/apps/backend-rag/backend/services/intake/extract.py
@@ -64,7 +64,10 @@ OLLAMA_BASE_URL: str = os.getenv("OLLAMA_URL", "http://localhost:11434")
 # SEA-LION 32B q4 is a heavy local model: ~25-45s warm, cold-load slower.
 _GENERATE_TIMEOUT_SECONDS: float = float(os.getenv("INTAKE_EXTRACT_TIMEOUT", "300"))
 _CONNECT_TIMEOUT_SECONDS: float = 5.0
-_DEFAULT_NUM_PREDICT = 1024
+# The schema payload is compact. Bounding generation to 512 tokens leaves the
+# model enough room for every supported field while keeping extraction inside
+# the worker SLA on the shared local Ollama runtime.
+_DEFAULT_NUM_PREDICT = 512
 
 # Confidence assigned to a value the model returned WITH evidence. The extractor
 # is deterministic (temperature 0) and does not emit calibrated probabilities;
@@ -2082,11 +2085,7 @@ async def extract_fields(
     pages = [p if isinstance(p, str) else str(p) for p in (ocr_text_per_page or [])]
     if not pages or not any(p.strip() for p in pages):
         # No legible OCR at all -> every field null (golden rule), no model call.
-        specs = DOC_TYPE_FIELDS[canonical]
-        fields = {
-            name: {"value": None, "confidence": 0.0, "source_page": None}
-            for name, _is_list, _desc in specs
-        }
+        fields = _blank_fields(canonical)
         logger.warning("extract: empty OCR for doc_type=%s -> all fields null", canonical)
         return {
             "doc_type": canonical,
@@ -2102,10 +2101,7 @@ async def extract_fields(
         if deterministic_fields:
             deterministic_extractors.append("passport_mrz")
             if _passport_mrz_complete(deterministic_fields):
-                fields = {
-                    name: {"value": None, "confidence": 0.0, "source_page": None}
-                    for name, _is_list, _desc in DOC_TYPE_FIELDS[canonical]
-                }
+                fields = _blank_fields(canonical)
                 _merge_deterministic_fields(fields, deterministic_fields)
                 return {
                     "doc_type": canonical,
@@ -2134,7 +2130,34 @@ async def extract_fields(
     prompt = _build_prompt(canonical, model_pages)
     gen = generate_fn or _ollama_generate
     resolved_model = _resolve_extraction_model()
-    raw_response = await gen(resolved_model, prompt)
+    try:
+        raw_response = await gen(resolved_model, prompt)
+    except httpx.ReadTimeout:
+        # A model that exceeded the extraction SLA supplied no trustworthy
+        # evidence. Advance the document with an explicit null envelope so
+        # validate/route can create a human-review proposal instead of retrying
+        # the same poison document forever. Deterministic evidence (for example
+        # a checksum-valid partial MRZ) remains safe to preserve.
+        fields = _blank_fields(canonical)
+        if deterministic_fields:
+            _merge_deterministic_fields(fields, deterministic_fields)
+        model_label = f"{_model_metric_label(resolved_model)}-timeout-fallback"
+        logger.warning(
+            "extract: model SLA timeout for doc_type=%s model=%s -> "
+            "null evidence envelope for human review",
+            canonical,
+            _model_metric_label(resolved_model),
+        )
+        result: dict[str, Any] = {
+            "doc_type": canonical,
+            "fields": fields,
+            "extraction_model": model_label,
+            "any_low_confidence": True,
+            "skipped": "model_timeout",
+        }
+        if deterministic_extractors:
+            result["deterministic_extractors"] = deterministic_extractors
+        return result
     parsed = _parse_response(raw_response)
 
     specs = DOC_TYPE_FIELDS[canonical]

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_extract.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_extract.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 
+import httpx
 import pytest
 
 from backend.llm.ollama_client import is_ollama_available
@@ -81,6 +82,29 @@ async def test_ollama_generate_applies_capacity_controls(monkeypatch):
     assert payload["model"] == "qwen3.5:9b"
     assert payload["keep_alive"] == "19m"
     assert payload["options"]["num_predict"] == 768
+
+
+async def test_ollama_generate_defaults_to_bounded_output(monkeypatch):
+    calls = []
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": '{"ok": true}'}
+
+    class _FakeClient:
+        async def post(self, path, json):
+            calls.append((path, json))
+            return _FakeResponse()
+
+    monkeypatch.delenv("INTAKE_EXTRACT_NUM_PREDICT", raising=False)
+    monkeypatch.setattr(extract, "_get_client", lambda: _FakeClient())
+
+    await extract._ollama_generate("qwen3.5:9b", "extract JSON")
+
+    assert calls[0][1]["options"]["num_predict"] == 512
 
 
 def test_canonical_doc_type_aliases():
@@ -320,6 +344,52 @@ async def test_passport_partial_mrz_merges_with_model_output():
     assert out["extraction_model"] == "sea-lion"
     assert out["deterministic_extractors"] == ["passport_mrz"]
     assert out["fields"]["passport_no"]["value"] == "MODEL123"
+    assert out["fields"]["name"]["value"] == "Eriksson Anna Maria"
+    assert out["fields"]["nationality"]["value"] == "Italian"
+    assert out["fields"]["dob"]["value"] == "1974-08-12"
+    assert out["fields"]["expiry"]["value"] == "2030-04-15"
+
+
+async def test_model_read_timeout_advances_with_explicit_null_fields(monkeypatch):
+    async def _timeout(model, prompt):  # noqa: ARG001
+        raise httpx.ReadTimeout("model exceeded extraction SLA")
+
+    monkeypatch.setenv("INTAKE_EXTRACTION_MODEL", "qwen3.5:9b")
+    out = await extract.extract_fields(
+        "nib",
+        ["unstructured scan with no reliable labels"],
+        generate_fn=_timeout,
+    )
+
+    assert out["skipped"] == "model_timeout"
+    assert out["extraction_model"] == "qwen3.5:9b-timeout-fallback"
+    assert out["any_low_confidence"] is True
+    assert set(out["fields"]) == {
+        "nib_number",
+        "company_name",
+        "kbli_codes",
+        "address",
+        "issue_date",
+    }
+    assert all(
+        field == {"value": None, "confidence": 0.0, "source_page": None}
+        for field in out["fields"].values()
+    )
+
+
+async def test_model_read_timeout_preserves_checksum_valid_partial_mrz(monkeypatch):
+    async def _timeout(model, prompt):  # noqa: ARG001
+        raise httpx.ReadTimeout("model exceeded extraction SLA")
+
+    monkeypatch.setenv("INTAKE_EXTRACTION_MODEL", "qwen3.5:9b")
+    ocr = (
+        "P<ITAERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\nL898902C35ITA7408122F3004157ZE184226B<<<<<10"
+    )
+    out = await extract.extract_fields("passport", [ocr], generate_fn=_timeout)
+
+    assert out["skipped"] == "model_timeout"
+    assert out["deterministic_extractors"] == ["passport_mrz"]
+    assert out["fields"]["passport_no"]["value"] is None
     assert out["fields"]["name"]["value"] == "Eriksson Anna Maria"
     assert out["fields"]["nationality"]["value"] == "Italian"
     assert out["fields"]["dob"]["value"] == "1974-08-12"

--- a/infra/launchagents/com.nuzantara.intake-worker.plist
+++ b/infra/launchagents/com.nuzantara.intake-worker.plist
@@ -13,7 +13,7 @@
 		<key>INTAKE_EXTRACTION_MODEL</key>
 		<string>qwen3.5:9b</string>
 		<key>INTAKE_EXTRACT_NUM_PREDICT</key>
-		<string>1024</string>
+		<string>512</string>
 		<key>INTAKE_EXTRACT_PAGE_LOCAL_MAX_CHARS</key>
 		<string>12000</string>
 		<key>INTAKE_EXTRACT_PAGE_LOCAL_RADIUS</key>


### PR DESCRIPTION
## Outcome
- convert local extraction read timeouts into explicit null-field results routed to human review
- preserve deterministic evidence while preventing poison documents from blocking queue drain
- reduce extraction output budget from 1024 to 512 tokens for lower latency
- keep connection failures retryable

## Verification
- 455 Intake tests passed, 1 skipped
- full backend gate: 17,183 passed, 115 skipped, 0 failed
- Ruff and launchd plist validation passed

## Safety
No extracted values are fabricated on timeout; the proposal remains human-review-only.