### PR TITLE
fix(intake): bound Ollama model residency

### DIFF
--- a/apps/backend-rag/backend/services/intake/inference_runtime.py
+++ b/apps/backend-rag/backend/services/intake/inference_runtime.py
@@ -23,7 +23,12 @@ from dataclasses import dataclass
 logger = logging.getLogger("zantara.intake.inference_runtime")
 
 DEFAULT_OLLAMA_MAX_INFLIGHT = 1
-DEFAULT_OLLAMA_KEEP_ALIVE = "15m"
+# Intake alternates qwen2.5vl OCR with qwen3.5 text extraction. Pro currently
+# admits one loaded Ollama model at a time; a long residency hint therefore
+# makes the next model wait behind an idle predecessor until that hint expires.
+# A short grace keeps adjacent same-model page calls warm without converting a
+# model switch into repeated HTTP timeouts.
+DEFAULT_OLLAMA_KEEP_ALIVE = "5s"
 _MAX_CONFIGURED_INFLIGHT = 8
 
 

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_inference_runtime.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_inference_runtime.py
@@ -58,6 +58,6 @@ def test_invalid_gate_configuration_fails_safe(monkeypatch) -> None:
 
 def test_keep_alive_has_safe_default_and_override(monkeypatch) -> None:
     monkeypatch.delenv("INTAKE_OLLAMA_KEEP_ALIVE", raising=False)
-    assert inference_runtime.ollama_keep_alive() == "15m"
+    assert inference_runtime.ollama_keep_alive() == "5s"
     monkeypatch.setenv("INTAKE_OLLAMA_KEEP_ALIVE", "30m")
     assert inference_runtime.ollama_keep_alive() == "30m"

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 638 services · 1145 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 638 services · 1146 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/infra/launchagents/com.nuzantara.intake-worker.plist
+++ b/infra/launchagents/com.nuzantara.intake-worker.plist
@@ -31,7 +31,7 @@
 		<key>INTAKE_LOG_LEVEL</key>
 		<string>INFO</string>
 		<key>INTAKE_OLLAMA_KEEP_ALIVE</key>
-		<string>15m</string>
+		<string>5s</string>
 		<key>INTAKE_OLLAMA_MAX_INFLIGHT</key>
 		<string>1</string>
 		<key>INTAKE_NAMEID_AUTO_ATTACH_ENABLED</key>


### PR DESCRIPTION
## Outcome

Prevents the single-model Ollama scheduler from holding idle qwen3.5 residency for 15 minutes while Intake OCR requests for qwen2.5vl expire serially. The 5-second grace still keeps adjacent same-model page calls warm.

## Production evidence

- before: qwen2.5vl OCR calls repeatedly hit the 120s page timeout, with admission waits accumulating to roughly 240s
- canary after installed config change: qwen2.5vl loaded immediately and completed real-page OCR generations in about 13s
- no raw OCR text, source references, or client identifiers were logged or copied

## Verification

- `ruff format --check` and `ruff check`: pass
- focused inference-runtime tests: 4 passed
- complete Intake and direct-parser suite: 471 passed, 1 skipped
- `plutil -lint`: pass