### PR TITLE
refactor(newsletter): reuse email_branding.LOGO_URL SSOT for daily logo

### DIFF
--- a/apps/backend-rag/backend/services/newsletter/publisher.py
+++ b/apps/backend-rag/backend/services/newsletter/publisher.py
@@ -34,6 +34,7 @@ from backend.services.layout.templates import (
     NEWSLETTER_HTML,
 )
 from backend.services.newsletter.builder import DailyDigestContent, RoundupContent
+from backend.services.notifications.email_branding import LOGO_URL as _BRAND_LOGO_URL
 
 logger = logging.getLogger(__name__)
 
@@ -41,10 +42,12 @@ logger = logging.getLogger(__name__)
 LOCKED_SENDER_EMAIL = "zantara@balizero.com"
 LOCKED_SENDER_NAME = "Zantara"
 
-# Purpose-built email logo asset (apps/mouth/public/static/email/), served
-# publicly by the Vercel-hosted mouth frontend — no new infra, no inline
-# CID (unproven across the 3-provider Zoho/Brevo/Resend send chain).
-DEFAULT_DAILY_LOGO_URL = "https://www.balizero.com/static/email/balizero-logo-email.png"
+# Same asset (apps/mouth/public/static/email/), same host, as every other
+# Bali Zero client email (welcome_email_service.py etc.) — SSOT in
+# email_branding.py. Previously this module hardcoded a second, unproven
+# www.balizero.com URL to the same file; consolidated 2026-07-15 (no
+# functional change — both hosts serve the identical asset).
+DEFAULT_DAILY_LOGO_URL = _BRAND_LOGO_URL
 
 DEFAULT_NOTIFICATIONS_URL = (
     os.environ.get("NOTIFICATIONS_EMAIL_URL")


### PR DESCRIPTION
## Summary
- The daily digest hardcoded its own `DEFAULT_DAILY_LOGO_URL` pointing at `www.balizero.com/static/email/balizero-logo-email.png` — a second, unproven URL to the exact same asset every other Bali Zero client email already serves via `kita.balizero.com` (`email_branding.LOGO_URL`).
- Consolidated to reuse the SSOT constant. No functional change: both hosts serve the identical 46190-byte PNG (verified via curl, 200/image-png, multiple UAs including a Zoho-labeled one).

## Important framing (read before merging)
This is **not** a fix for the "broken logo icon" Zero saw in Zoho. Investigated before touching code:
- The `www.balizero.com` URL was never technically broken — reachable, valid PNG, no 404/redirect/auth-wall.
- `email_branding.py`'s own doc comment documents that a public HTTPS URL (not a base64 data-URI) is the pattern proven to render across Gmail webview/Apple Mail/iOS/Outlook — the original mandate for this task assumed a data-URI embed was the fix, which would have directly contradicted that tested prior art.
- The broken-icon symptom is most likely Zoho's own remote-image-blocking default, or a cached failure from the very first send (before/as the asset went live) — neither of which a URL change resolves. A fresh test send should render correctly since the asset is confirmed live now.

This PR is a cleanliness/SSOT consolidation (one hardcoded logo URL instead of two), using the already-proven cross-client pattern.

## Test plan
- [x] `PYTHONPATH=. pytest backend/tests/ -k "newsletter" -q` — 92 passed
- [x] Import chain smoke test (`NewsletterPublisher` instantiates, no circular import with `email_branding`)
- [x] Generated `render_daily_html()` locally and confirmed the `<img>` line: `<img src="https://kita.balizero.com/static/email/balizero-logo-email.png" width="40" height="40" alt="Bali Zero" style="display:block;border:0;border-radius:4px;">`
- [x] Pre-commit + pre-push hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)