### PR TITLE
fix(nav): extract BlogNav client component to hide Home on homepage

### DIFF
--- a/apps/mouth/src/app/(blog)/_components/BlogNav.tsx
+++ b/apps/mouth/src/app/(blog)/_components/BlogNav.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { NavShell, BZLogo } from "@balizero/core";
+import { MobileNav } from "@/app/v2/_components/MobileNav";
+import type { NavItem } from "@balizero/core";
+
+const ALL_NAV_ITEMS: NavItem[] = [
+  { label: "Home", href: "/" },
+  { label: "Visa", href: "/services/visa" },
+  { label: "Business", href: "/services/company" },
+  { label: "Tax", href: "/services/tax" },
+  { label: "Property", href: "/services/property" },
+  { label: "News", href: "/news" },
+  { label: "Team", href: "/team" },
+];
+
+export function BlogNav() {
+  const pathname = usePathname();
+  const items =
+    pathname === "/"
+      ? ALL_NAV_ITEMS.filter((item) => item.href !== "/")
+      : ALL_NAV_ITEMS;
+
+  return (
+    <NavShell
+      logo={
+        <Link
+          href="/"
+          aria-label="Bali Zero"
+          className="inline-flex items-center"
+        >
+          <BZLogo variant="full" />
+        </Link>
+      }
+      items={items}
+      slotAfter={<MobileNav items={items} />}
+      actions={
+        <Link
+          href="/contact"
+          className="inline-flex items-center gap-2 text-[12px] font-semibold uppercase tracking-[0.18em] px-4 py-2 rounded-full transition-all"
+          style={{
+            background: "var(--accent-funnel, #3a6dff)",
+            color: "#fff",
+          }}
+        >
+          Talk to us
+        </Link>
+      }
+    />
+  );
+}

--- a/apps/mouth/src/app/(blog)/layout.tsx
+++ b/apps/mouth/src/app/(blog)/layout.tsx
@@ -1,20 +1,8 @@
 import type { ReactNode } from "react";
-import Link from "next/link";
-import { NavShell, BZLogo } from "@balizero/core";
-import { MobileNav } from "@/app/v2/_components/MobileNav";
+import { BlogNav } from "@/app/(blog)/_components/BlogNav";
 import { ZantaraFAB } from "@/app/v2/_components/ZantaraFAB";
 import { Footer } from "@/app/v2/_components/Footer";
 import { I18nProvider } from "@/i18n";
-
-const BLOG_NAV_ITEMS = [
-  { label: "Home", href: "/" },
-  { label: "Visa", href: "/services/visa" },
-  { label: "Business", href: "/services/company" },
-  { label: "Tax", href: "/services/tax" },
-  { label: "Property", href: "/services/property" },
-  { label: "News", href: "/news" },
-  { label: "Team", href: "/team" },
-];
 
 export default function BlogLayout({ children }: { children: ReactNode }) {
   return (
@@ -26,31 +14,7 @@ export default function BlogLayout({ children }: { children: ReactNode }) {
           color: "var(--text-primary)",
         }}
       >
-        <NavShell
-          logo={
-            <Link
-              href="/"
-              aria-label="Bali Zero"
-              className="inline-flex items-center"
-            >
-              <BZLogo variant="full" />
-            </Link>
-          }
-          items={BLOG_NAV_ITEMS}
-          slotAfter={<MobileNav items={BLOG_NAV_ITEMS} />}
-          actions={
-            <Link
-              href="/contact"
-              className="inline-flex items-center gap-2 text-[12px] font-semibold uppercase tracking-[0.18em] px-4 py-2 rounded-full transition-all"
-              style={{
-                background: "var(--accent-funnel, #3a6dff)",
-                color: "#fff",
-              }}
-            >
-              Talk to us
-            </Link>
-          }
-        />
+        <BlogNav />
         <main className="flex-1 pt-14">{children}</main>
         <Footer />
         <ZantaraFAB />


### PR DESCRIPTION
## Insight
The `Home` nav link is redundant when the user is already on the homepage — it adds visual noise without conversion value and clutters the nav on a page where every pixel of attention matters.

## Studio
Thin client wrapper (`BlogNav.tsx`) extracts pathname-aware nav filtering from the Server Component layout. `NavShell` receives a pre-filtered `items` array — no changes to the primitive itself. `MobileNav` inherits the same filtered list automatically.

## Source
Todoist task `6h5X5QX63FF3mqh6` — scheduled 15 Jul 2026. NavShell interface confirmed: no built-in hide prop, filter-before-pass is the correct pattern per component comments.

## Methodology
1. Confirmed `NavShell` accepts `items: NavItem[]` with no built-in conditional rendering
2. Created `BlogNav.tsx` as `'use client'` component — only layer that can call `usePathname()`
3. Filter: `pathname === '/'` removes the `href: '/'` item before passing to NavShell
4. `(blog)/layout.tsx` reduced to pure Server Component — imports only `BlogNav`
5. `MobileNav` receives same filtered array via BlogNav — no separate fix needed
6. TSC clean, pre-commit + pre-push hooks passed

## Raw Observations
- `BLOG_NAV_ITEMS` array moved from layout into BlogNav — single source of truth
- 3 imports removed from layout: `Link`, `NavShell`, `BZLogo`, `MobileNav`
- No changes to `packages/core` — VERDE zone only
- Untracked research files confirmed not staged

## Reasoning Path
Server Component cannot call `usePathname()`. Options: (a) convert layout to client — bad, loses RSC benefits; (b) pass `hideHome` prop down — leaks routing concern into layout; (c) thin client wrapper — correct, minimal blast radius, zero primitive changes. Chose (c).

## Risk
Low. Filter is additive — all other routes receive the full nav unchanged. Only `pathname === '/'` path is affected. `NavShell` primitive untouched.

## Implication
Homepage nav is now cleaner. Sets the pattern for future conditional nav items without touching `NavShell` or `packages/core`.

## Recommendation
Self-merge after CI green — VERDE scope (`apps/mouth/**` only).

## Next Action
Monitor CI. After merge: complete Todoist task `6h5X5QX63FF3mqh6` with audit trail comment.