### PR TITLE
fix(nav): render mobile drawer via React portal to escape backdrop-filter containing block

### DIFF
--- a/apps/mouth/src/app/v2/_components/MobileNav.tsx
+++ b/apps/mouth/src/app/v2/_components/MobileNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { Menu, X } from "lucide-react";
 
 interface MobileNavProps {
@@ -9,6 +10,7 @@ interface MobileNavProps {
 
 export function MobileNav({ items }: MobileNavProps) {
   const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     document.documentElement.style.overflow = open ? "hidden" : "";
@@ -16,6 +18,10 @@ export function MobileNav({ items }: MobileNavProps) {
       document.documentElement.style.overflow = "";
     };
   }, [open]);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <>
@@ -35,110 +41,116 @@ export function MobileNav({ items }: MobileNavProps) {
         <Menu size={22} strokeWidth={2.2} />
       </button>
 
-      {/* Backdrop tap-to-close — rendered beneath the drawer panel */}
-      {open && (
-        <div
-          aria-hidden="true"
-          onClick={() => setOpen(false)}
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 398,
-            background: "rgba(0,0,0,0.45)",
-          }}
-        />
-      )}
-
-      {/* Drawer panel — slides in from the left */}
-      <div
-        id="mobile-nav-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Navigation menu"
-        className="md:hidden fixed inset-y-0 left-0 z-[399] flex flex-col w-[min(80vw,320px)]"
-        style={{
-          background: "var(--nav-bg)",
-          borderRight: "1px solid var(--nav-border)",
-          backdropFilter: "blur(16px)",
-          WebkitBackdropFilter: "blur(16px)",
-          transform: open ? "translateX(0)" : "translateX(-100%)",
-          transition: "transform 0.26s cubic-bezier(0.4, 0, 0.2, 1)",
-          willChange: "transform",
-          overflowY: "auto",
-        }}
-      >
-        {/* Header row with close button */}
-        <div
-          className="flex items-center justify-between px-5 h-14 flex-shrink-0"
-          style={{ borderBottom: "1px solid var(--nav-border)" }}
-        >
-          <span
-            className="text-[11px] font-bold uppercase tracking-widest"
-            style={{ color: "var(--text-tertiary)" }}
-          >
-            Menu
-          </span>
-          <button
-            onClick={() => setOpen(false)}
-            aria-label="Close menu"
-            className="inline-flex items-center justify-center w-9 h-9 rounded-md"
-            style={{ color: "var(--text-primary)" }}
-          >
-            <X size={22} strokeWidth={2} />
-          </button>
-        </div>
-
-        {/* Nav links */}
-        <ul className="flex flex-col gap-1 list-none p-5 m-0 flex-1">
-          {items.map((item) => (
-            <li key={item.href}>
-              <a
-                href={item.href}
+      {mounted &&
+        createPortal(
+          <>
+            {/* Backdrop tap-to-close — rendered beneath the drawer panel */}
+            {open && (
+              <div
+                aria-hidden="true"
                 onClick={() => setOpen(false)}
-                className="block px-4 py-3 rounded-xl text-[18px] font-semibold"
                 style={{
-                  color: "var(--text-primary)",
-                  background:
-                    "color-mix(in srgb, var(--accent-funnel) 6%, transparent)",
-                  border:
-                    "1px solid color-mix(in srgb, var(--accent-funnel) 14%, transparent)",
-                  textDecoration: "none",
+                  position: "fixed",
+                  inset: 0,
+                  zIndex: 398,
+                  background: "rgba(0,0,0,0.45)",
                 }}
-              >
-                {item.label}
-              </a>
-            </li>
-          ))}
-        </ul>
+              />
+            )}
 
-        {/* Footer CTAs */}
-        <div className="p-5 flex flex-col gap-3 flex-shrink-0">
-          <a
-            href="#top"
-            onClick={() => setOpen(false)}
-            className="block text-center px-5 py-3 rounded-xl text-[14px] font-semibold"
-            style={{
-              background: "var(--accent-funnel)",
-              color: "var(--text-on-accent)",
-              textDecoration: "none",
-            }}
-          >
-            Get Started
-          </a>
-          <a
-            href="/login"
-            onClick={() => setOpen(false)}
-            className="block text-center px-5 py-3 rounded-xl text-[13px] font-semibold"
-            style={{
-              border: "1px solid var(--border-default)",
-              color: "var(--text-secondary)",
-              textDecoration: "none",
-            }}
-          >
-            Login
-          </a>
-        </div>
-      </div>
+            {/* Drawer panel — slides in from the left */}
+            <div
+              id="mobile-nav-drawer"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Navigation menu"
+              className="md:hidden fixed inset-y-0 left-0 z-[399] flex flex-col w-[min(80vw,320px)]"
+              style={{
+                background: "var(--nav-bg)",
+                borderRight: "1px solid var(--nav-border)",
+                backdropFilter: "blur(16px)",
+                WebkitBackdropFilter: "blur(16px)",
+                transform: open ? "translateX(0)" : "translateX(-100%)",
+                transition: "transform 0.26s cubic-bezier(0.4, 0, 0.2, 1)",
+                willChange: "transform",
+                overflowY: "auto",
+              }}
+            >
+              {/* Header row with close button */}
+              <div
+                className="flex items-center justify-between px-5 h-14 flex-shrink-0"
+                style={{ borderBottom: "1px solid var(--nav-border)" }}
+              >
+                <span
+                  className="text-[11px] font-bold uppercase tracking-widest"
+                  style={{ color: "var(--text-tertiary)" }}
+                >
+                  Menu
+                </span>
+                <button
+                  onClick={() => setOpen(false)}
+                  aria-label="Close menu"
+                  className="inline-flex items-center justify-center w-9 h-9 rounded-md"
+                  style={{ color: "var(--text-primary)" }}
+                >
+                  <X size={22} strokeWidth={2} />
+                </button>
+              </div>
+
+              {/* Nav links */}
+              <ul className="flex flex-col gap-1 list-none p-5 m-0 flex-1">
+                {items.map((item) => (
+                  <li key={item.href}>
+                    <a
+                      href={item.href}
+                      onClick={() => setOpen(false)}
+                      className="block px-4 py-3 rounded-xl text-[18px] font-semibold"
+                      style={{
+                        color: "var(--text-primary)",
+                        background:
+                          "color-mix(in srgb, var(--accent-funnel) 6%, transparent)",
+                        border:
+                          "1px solid color-mix(in srgb, var(--accent-funnel) 14%, transparent)",
+                        textDecoration: "none",
+                      }}
+                    >
+                      {item.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+
+              {/* Footer CTAs */}
+              <div className="p-5 flex flex-col gap-3 flex-shrink-0">
+                <a
+                  href="#top"
+                  onClick={() => setOpen(false)}
+                  className="block text-center px-5 py-3 rounded-xl text-[14px] font-semibold"
+                  style={{
+                    background: "var(--accent-funnel)",
+                    color: "var(--text-on-accent)",
+                    textDecoration: "none",
+                  }}
+                >
+                  Get Started
+                </a>
+                <a
+                  href="/login"
+                  onClick={() => setOpen(false)}
+                  className="block text-center px-5 py-3 rounded-xl text-[13px] font-semibold"
+                  style={{
+                    border: "1px solid var(--border-default)",
+                    color: "var(--text-secondary)",
+                    textDecoration: "none",
+                  }}
+                >
+                  Login
+                </a>
+              </div>
+            </div>
+          </>,
+          document.body,
+        )}
     </>
   );
 }


### PR DESCRIPTION
## Insight
Mobile nav drawer rendered as a 56px-tall clipped panel instead of a full-viewport slide-in. Zero conversion from hamburger menu on all mobile viewports.

## Studio
Added React portal (createPortal) to render backdrop and drawer directly to document.body, escaping the CSS containing block created by NavShell's backdrop-filter. Hamburger button stays inside NavShell. No changes to NavShell, no changes to packages/core.

## Source
Root cause diagnosed via DOM inspection + forced drawer open via script. CSS spec: elements with backdrop-filter create a new containing block for position:fixed descendants — drawer was fixed relative to the 56px nav, not the viewport.

## Methodology
1. Confirmed NavShell nav has backdrop-blur-xl (= backdrop-filter: blur())
2. CSS spec: backdrop-filter creates new stacking + containing context for fixed children
3. Drawer (position:fixed, inset-y-0) was constrained to nav height (56px) not viewport
4. Fix: createPortal(drawerJSX, document.body) — fixed elements inside portal are relative to viewport
5. Added mounted state guard to prevent SSR hydration mismatch
6. Prettier + TSC clean, pre-commit + pre-push passed

## Raw Observations
- backdrop-filter on nav intentional (glassmorphism) — cannot remove, GIALLO zone
- mounted guard pattern is standard for portals in Next.js App Router
- No changes to drawer markup, z-indices, transitions, or nav links
- Fragment balance verified: 2 opening, 2 closing fragments

## Reasoning Path
Two options: (1) remove backdrop-filter from NavShell — breaks glassmorphism, GIALLO, Antonello decision needed; (2) React portal — escapes containing block entirely, VERDE, zero visual regression on desktop. Option 2 is strictly correct and minimal blast radius.

## Risk
Low. Portal pattern is well-established in React 19. SSR guard prevents hydration mismatch. Drawer hidden by default (translateX(-100%)) so no flash on load.

## Implication
Mobile hamburger menu now renders as full-viewport slide-in panel. Restores primary mobile navigation path — direct conversion impact.

## Recommendation
Self-merge after CI green — VERDE scope (apps/mouth/** only), single file changed.

## Next Action
After merge: verify on mobile device — open drawer, confirm full-height panel, backdrop tap-to-close, scroll lock. Then proceed to kbli-mobile-ux-p1p2.