### PR TITLE
fix(a11y): add article title to alt text in news card

### DIFF
--- a/apps/mouth/src/app/v2/news/page.tsx
+++ b/apps/mouth/src/app/v2/news/page.tsx
@@ -167,7 +167,7 @@ function ArticleCard({ article: a }: { article: ArticleListItem }) {
         {a.coverImage ? (
           <Image
             src={a.coverImage}
-            alt=""
+            alt={a.title}
             fill
             sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 380px"
             quality={75}


### PR DESCRIPTION
## Insight
Article card cover image used empty alt text (alt=''), making the image inaccessible to screen readers. Article context is available in the component.

## Studio
Single alt text value swap: alt='' → alt={a.title}. No layout or rendering changes.

## Source
Mobile UX audit — alt text gap on homepage news cards. ArticleCard component receives article object with title property.

## Methodology
Confirmed a.title available at line 217 (card render displays it). Python replace: matched 'src={a.coverImage}\n            alt=""' → alt={a.title}. TSC clean, pre-commit + pre-push passed.

## Raw Observations
- Article object (a) has title, category, slug, publishedAt, excerpt, readingTime, featured, coverImage
- alt="" is intentional empty only if image is purely decorative; article cover provides context

## Reasoning Path
Article cover image is content-bearing (supports article discovery), not decorative. Screen reader users benefit from article title in alt text to understand the card's subject before clicking.

## Risk
None. Alt text change only affects accessibility tree, zero visual impact.

## Implication
News card cover images now accessible to assistive technology. Improves WCAG 2.1 AA compliance.

## Recommendation
Self-merge after CI green — VERDE scope (apps/mouth/** only), single line changed.

## Next Action
After merge: verify in accessibility tree via DevTools → Elements → check alt attribute.