### PR TITLE
fix(wr2-imagegen): steal stale image lease — dead holder starved a9e4e5d8 for 31h

### DIFF
--- a/scripts/tests/test_wr2_image_generator_lease.py
+++ b/scripts/tests/test_wr2_image_generator_lease.py
@@ -1,5 +1,6 @@
 """Tests for the per-draft lease CAS added to wr2_image_generator.py (B5,
-2026-07-14 — overlap-prevention, audit cure-plan §10 item 5).
+2026-07-14 — overlap-prevention, audit cure-plan §10 item 5), PLUS the
+stale-lease steal sweep added 2026-07-16 (`_reset_stale_image_leases`).
 
 `wr2_image_generator.py` was the one WR2 lane with NO CAS/lease at all —
 unlike the HTML-render and Canva-render lanes (`_pg.py`
@@ -9,6 +10,14 @@ guard their fetch on `lease_owner IS NULL`. Two overlapping invocations
 the same plist) could double-process the same draft and — sharper for the
 detection fix in the same PR — race writes into the SAME shared
 `~/.codex/generated_images/` tree that `_select_fresh_codex_png` scans.
+
+The CAS lease itself had no stale-lease steal: a holder that crashed/was
+SIGTERM'd before releasing left `lease_owner` set forever, starving the
+draft on every subsequent run (live: draft a9e4e5d8-5afa-41ff-8c8a-
+dad947701037 held by a dead PID for ~31h). `_reset_stale_image_leases`
+mirrors the sibling lanes' watchdog-sweep convention (`_pg.py`
+`reset_stale_leases` / `reset_stale_html_leases`): a separate sweep called
+once at the top of `run()`, not baked into the CAS's WHERE clause.
 
 DB-free: `asyncpg.Connection` is an AsyncMock, matching the style already
 used in apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/
@@ -105,6 +114,82 @@ async def test_persist_imaged_lease_owner_none_is_a_noop_guard(wig):
     await wig._persist_imaged(conn, "abc", [], {}, lease_owner=None)
     args = conn.execute.call_args[0]
     assert args[-1] is None
+
+
+@pytest.mark.asyncio
+async def test_reset_stale_image_leases_default_ttl_is_40min(wig):
+    assert wig.IMAGE_LEASE_STALE_MINUTES == 40
+
+
+@pytest.mark.asyncio
+async def test_reset_stale_image_leases_sql_scopes_by_staleness_and_status(wig):
+    """GUILT: the sweep's WHERE clause is staleness-scoped (owner set AND
+    lease_acquired_at older than the TTL), not a blanket clear-all — matching
+    the sibling lanes' `reset_stale_leases`/`reset_stale_html_leases` shape."""
+    conn = AsyncMock()
+    conn.fetch.return_value = [{"id": "abc"}]
+    ids = await wig._reset_stale_image_leases(conn, stale_after_minutes=40)
+    assert ids == ["abc"]
+    sql, ttl_arg = conn.fetch.call_args[0]
+    assert "lease_owner IS NOT NULL" in sql
+    assert "lease_acquired_at < NOW()" in sql
+    assert "status IN ('drafts_checked', 'drafts')" in sql
+    assert ttl_arg == "40"
+
+
+@pytest.mark.asyncio
+async def test_reset_stale_image_leases_no_op_when_nothing_stale(wig):
+    """INNOCENCE: a fresh lease (or no lease at all) is never swept — the SQL
+    predicate does the filtering; an empty result from the (mocked) DB round
+    trip must propagate as an empty list, not synthesize a false reclaim."""
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+    ids = await wig._reset_stale_image_leases(conn)
+    assert ids == []
+
+
+@pytest.mark.asyncio
+async def test_run_sweeps_stale_leases_before_fetch_unless_dry_run(wig, monkeypatch):
+    """The sweep runs once at the top of `run()`, before any fetch — mirrors
+    `orchestrator.py::run()` (Canva) and `wr2_html_render_apply.py::run()`
+    (HTML), and must NOT fire during --dry-run (no DB mutation on a dry pass)."""
+    calls: list[bool] = []
+
+    async def _fake_reset(conn, stale_after_minutes=wig.IMAGE_LEASE_STALE_MINUTES):
+        calls.append(True)
+        return []
+
+    monkeypatch.setattr(wig, "_reset_stale_image_leases", _fake_reset)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://fake/fake")
+
+    class _FakeConn:
+        async def fetch(self, *a, **kw):
+            return []
+
+    class _FakeAcquireCtx:
+        async def __aenter__(self):
+            return _FakeConn()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakePool:
+        def acquire(self):
+            return _FakeAcquireCtx()
+
+        async def close(self):
+            return None
+
+    async def _fake_create_pool(*a, **kw):
+        return _FakePool()
+
+    monkeypatch.setattr(wig.asyncpg, "create_pool", _fake_create_pool)
+
+    await wig.run(dry_run=True)
+    assert calls == []  # dry-run: sweep skipped
+
+    await wig.run(dry_run=False)
+    assert calls == [True]  # live run: sweep fired exactly once
 
 
 @pytest.mark.asyncio

--- a/scripts/wr2_image_generator.py
+++ b/scripts/wr2_image_generator.py
@@ -1321,6 +1321,11 @@ async def _acquire_image_lease(
     Status is re-checked in the same CAS (not just at `_fetch_pending`
     time) so a draft that moved on between fetch and lease attempt is
     never claimed. Release happens in `_persist_imaged` / `_mark_image_failed`.
+
+    No steal-on-acquire: a lease abandoned by a dead holder (crash/SIGTERM
+    before release) is reclaimed by the separate `_reset_stale_image_leases`
+    sweep at the top of `run()`, not by this CAS's WHERE clause — mirrors the
+    sibling lanes (see that function's docstring).
     """
     row = await conn.fetchrow(
         """
@@ -1335,6 +1340,53 @@ async def _acquire_image_lease(
         lease_owner,
     )
     return row is not None
+
+
+IMAGE_LEASE_STALE_MINUTES = 40
+"""TTL for reclaiming an abandoned image-gen lease (steal-on-sweep, 2026-07-16).
+
+`_acquire_image_lease` above had NO stale-lease steal: a holder that
+crashed/was SIGTERM'd before releasing (`_persist_imaged`/`_mark_image_failed`
+never ran) left `lease_owner` set forever, starving the draft on every
+subsequent run — live proof: draft a9e4e5d8-5afa-41ff-8c8a-dad947701037 held
+by a dead PID for ~31h, skipped hourly the whole time.
+
+40min gives a 2x safety margin over the observed per-draft ceiling (~8 hero
+slides x ~150s Codex/FlowKit round-trip each ≈ 20min) so a lease is never
+stolen out from under a genuinely still-running worker. Scaled up from the
+Canva lane's `stale_after_minutes=15` (`_pg.py::reset_stale_leases`) because
+image-gen's per-draft work is heavier than a single Canva apply.
+"""
+
+
+async def _reset_stale_image_leases(
+    conn: asyncpg.Connection, stale_after_minutes: int = IMAGE_LEASE_STALE_MINUTES,
+) -> list[uuid.UUID]:
+    """Watchdog sweep — reclaim leases abandoned by a dead holder.
+
+    Mirrors the sibling lanes' convention (`_pg.py::reset_stale_leases` for
+    Canva, `reset_stale_html_leases` for HTML): the steal lives in a separate
+    sweep called once at the top of `run()` BEFORE the fetch, not baked into
+    `_acquire_image_lease`'s CAS WHERE clause — a dead holder's lease is freed
+    here so the draft re-enters the normal CAS-acquire path on this same tick.
+    Scoped to `status IN ('drafts_checked', 'drafts')` because that's the only
+    range `_acquire_image_lease` ever claims (this lane, unlike Canva/HTML,
+    does not transition status while leased — see its docstring).
+    """
+    rows = await conn.fetch(
+        """
+        UPDATE war_room_drafts
+           SET lease_owner       = NULL,
+               lease_acquired_at = NULL,
+               updated_at        = NOW()
+         WHERE lease_owner IS NOT NULL
+           AND lease_acquired_at < NOW() - ($1 || ' minutes')::interval
+           AND status IN ('drafts_checked', 'drafts')
+        RETURNING id
+        """,
+        str(stale_after_minutes),
+    )
+    return [r["id"] for r in rows]
 
 
 async def _persist_imaged(
@@ -1671,6 +1723,16 @@ async def run(*, dry_run: bool = False, draft_id: str | None = None) -> int:
     pool = await asyncpg.create_pool(dsn=dsn, min_size=1, max_size=2, command_timeout=600)
     try:
         async with pool.acquire() as conn:
+            if not dry_run:
+                reclaimed = await _reset_stale_image_leases(conn)
+                if reclaimed:
+                    logger.warning(
+                        "Reclaimed %d stale image-gen lease(s) (dead holder, TTL=%dmin): %s",
+                        len(reclaimed),
+                        IMAGE_LEASE_STALE_MINUTES,
+                        [str(x)[:8] for x in reclaimed[:5]],
+                    )
+
             if draft_id:
                 rows = await conn.fetch(
                     """


### PR DESCRIPTION
## Summary
- `_acquire_image_lease` (B5, 2026-07-14) was a CAS lease with no stale-lease steal — a holder that crashed/was SIGTERM'd before releasing left `lease_owner` set forever, permanently starving the draft.
- **Live proof**: draft `a9e4e5d8-5afa-41ff-8c8a-dad947701037` held by dead PID `wr2-image-generator:Nuzantara:47214` for ~31h (`lease_acquired_at` 2026-07-14 13:51 UTC), status stuck at `drafts`, skipped hourly the whole time.
- Adds `_reset_stale_image_leases` (TTL=40min — 2x margin over the observed ~20min per-draft ceiling: up to ~8 hero slides × ~150s Codex/FlowKit round-trip each), called once at the top of `run()` before the fetch.
- The steal lives in a **separate sweep**, not baked into `_acquire_image_lease`'s CAS WHERE clause — mirrors the sibling lanes' existing convention (`_pg.py::reset_stale_leases` for the Canva lane, `reset_stale_html_leases` for the HTML lane, both called once at the top of their respective `run()`s before the fetch).
- Sweep is skipped during `--dry-run` (no DB mutation on a dry pass).

## HTML-apply lease — does NOT share this bug
Checked `wr2_html_render_apply.py`: it already calls `heartbeat_html_lease` during render (line 823) and `reset_stale_html_leases` at the top of its drain loop (line 1249, `stale_after_minutes=10`). The HTML lane already has TTL/heartbeat-based stale-reset — this PR brings the image-gen lane up to the same standard, not a new pattern.

## Immediate remediation (done directly, outside this PR)
Cleared the stuck lease on Pro's local DB (matched the exact stale owner `wr2-image-generator:Nuzantara:47214` so no live lease could be clobbered) — confirmed 0 leased rows remain afterward. Draft `a9e4e5d8` re-enters the pipeline on the next hourly run without waiting for deploy.

## Test plan
- [x] GUILT: `_reset_stale_image_leases`'s SQL is staleness-scoped (`lease_owner IS NOT NULL AND lease_acquired_at < NOW() - interval AND status IN (...)`), not a blanket clear-all
- [x] INNOCENCE: empty DB result propagates as empty list — no synthesized reclaim
- [x] Wiring: sweep fires exactly once per live `run()`, zero times during `--dry-run`
- [x] `PYTHONPATH=. pytest scripts/tests/ -k image_generator -v` → 44 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)