### PR TITLE
feat(wr2-imagegen): route VLM quality-scorer to dedicated Mini Ollama

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -313,6 +313,12 @@
       "repo": "scripts/wr2-cron-wrapper.sh",
       "_note": "WR2 deep audit 2026-07-14 (§4): the HOME copy (f17092b3) had DIVERGED from the repo copy (3cd52391) on the same machine — oracle/connector/newsletter were running the stale fork. Declared so --check catches this class of drift going forward. RESOLVED same day: the live copy self-realigned via a routine pull (mtime 14:05 WITA), re-verified read-only on Pro 2026-07-14 ~15:30 WITA — sha 3cd52391 both sides, byte-identical. No manual sync pending. Consumers verified via ProgramArguments grep: com.balizero.wr2.{oracle,connector,newsletter,dossier-compiler,learner-nightly,measurer,sla-worker,strategos,trend-hunter} + com.balizero.sota.m13-* all exec ~/.openclaw/bin/wr2/wr2-cron-wrapper.sh (NOT ~/scripts/, which does not exist on Pro).",
       "machines": ["pro"]
+    },
+    {
+      "live": "~/Library/LaunchAgents/com.balizero.wr2.image-generator.plist",
+      "repo": "infra/launchagents/com.balizero.wr2.image-generator.plist",
+      "_note": "2026-07-16: added WR2_IMAGE_VLM_URL=http://100.93.236.6:11434 (Mini tailscale IP) so the VLM quality-scorer routes off Pro's contended Ollama (176 daemons, ~60s+ under load) onto Mini's dedicated Ollama. Was undeclared before this pair was created.",
+      "machines": ["pro"]
     }
   ],
   "allow": [

--- a/infra/launchagents/com.balizero.wr2.image-generator.plist
+++ b/infra/launchagents/com.balizero.wr2.image-generator.plist
@@ -8,6 +8,8 @@
 		<string>/Users/nuzantara</string>
 		<key>PATH</key>
 		<string>/Users/nuzantara/.local/bin:/Users/nuzantara/.npm-global/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<key>WR2_IMAGE_VLM_URL</key>
+		<string>http://100.93.236.6:11434</string>
 	</dict>
 	<key>Label</key>
 	<string>com.balizero.wr2.image-generator</string>


### PR DESCRIPTION
## Summary
- Pro's Ollama runs ~176 daemons; under contention the VLM alignment scorer (`qwen2.5vl:7b`) exceeded its 60s timeout on every call, so the quality gate (`scripts/wr2_image_generator.py`) was effectively disabled (fail-open).
- Points the generator at Mini's dedicated, idle Ollama instead: `WR2_IMAGE_VLM_URL=http://100.93.236.6:11434` (Mini tailscale IP) added to the LaunchAgent's `EnvironmentVariables`.
- Declares `com.balizero.wr2.image-generator.plist` as a HOME-fork pair in `infra/home-fork/declared-pairs.json` (was undeclared).

## Infra changes made outside this diff (Mini + Pro live state)
- **Mini Ollama exposed on network**: flipped `expose=1` in the app's own settings DB (`~/Library/Application Support/Ollama/db.sqlite`, `settings` table) — this is the persistent mechanism (survives reboot), NOT `launchctl setenv OLLAMA_HOST` which I confirmed does **not** survive a restart for this GUI-spawned Electron process (tested: set it, restarted via `launchctl kickstart`, server still bound to 127.0.0.1). Ollama.app cleanly quit + relaunched to pick up the new setting; now listens on `*:11434`.
- **Address chosen**: Mini's tailscale IP `100.93.236.6:11434`, not the LAN IP. The LAN IP recorded in memory (`192.168.110.44`) has drifted to `192.168.110.184` and is **unreachable from Pro** (ping + curl both time out — subnet/firewall mismatch). Tailscale was rock-solid: 5/5 calls, ~20-28ms.
- **Live plist deployed to Pro**: `~/Library/LaunchAgents/com.balizero.wr2.image-generator.plist` updated to match this PR's canon (all 90 plists in that dir are `0444`; chmod'd, scp'd, re-locked, verified byte-identical).
- **Warm-pin left unchanged**: Mini is at 23G/24G RAM used (348MB free) — `MODEL_TOPOLOGY.json`'s existing `mini_ram_policy` note ("keep only qwen2.5:7b warm by default... load qwen2.5vl:7b cold only for explicit jobs") is correct and was NOT overridden. Measured cold-load VLM latency is 14.5s, 4x margin under the 60s timeout, so warm-pinning isn't needed for correctness and would risk OOM.

## PROVE-LIVE
- Real VLM inference Pro→Mini over tailscale, 1536x1024 test image: **14.5s total** (4.4s cold model-load + 9.5s prompt-eval + 0.5s eval), HTTP 200, coherent response. Well under the 60s timeout.
- Did NOT force-restart Pro's live `com.balizero.wr2.image-generator` LaunchAgent — it was mid-run on real production drafts (`a9e4e5d8`, then `feeb7d83`) when I made the change; interrupting would risk a stale CAS lease (the exact class of bug PR #2485 just fixed — confirmed Pro's `nuzantara-deploy` worktree is still behind that PR, `c94fe4de7` is an ancestor of `c8c704b58d`/#2485, so the lease-steal fix is NOT yet live there). Waited for the run to reach a natural per-item boundary before touching the live plist.
- Because launchd caches the job definition at load time, the live process's NEXT invocation needs an explicit `launchctl bootout`/`bootstrap` (or reboot) to pick up the new env — noting this so whoever verifies the first live Mini-scored slide knows to check for a `VLM score` line (not `timed out — accepting image`) post-reload.

## Test plan
- [x] plutil -lint on both canon and live plist
- [x] JSON validity on declared-pairs.json
- [x] Live plist byte-identical to canon after deploy (diff verified)
- [x] Real Pro→Mini VLM inference timed and successful (200 OK, 14.5s)
- [ ] Operator/next session: `launchctl bootout gui/501/com.balizero.wr2.image-generator && launchctl bootstrap gui/501 ~/Library/LaunchAgents/com.balizero.wr2.image-generator.plist` on Pro once no run is in flight, then confirm a live `VLM score` log line against Mini's IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)