### PR TITLE
chore(regulatory-watcher): 2026-07-16 daily delta — zero new citations

### DIFF
--- a/research/regulatory/2026-07-16-delta.json
+++ b/research/regulatory/2026-07-16-delta.json
@@ -1,0 +1,42 @@
+{
+  "run_at": "2026-07-16T07:06:57+08:00",
+  "today": "2026-07-16",
+  "yesterday_seen_count": 21,
+  "new_today_count": 0,
+  "partial": false,
+  "unreachable_sources": [
+    "https://www.hukumonline.com/berita/ (HTTP 403)",
+    "https://muc.co.id/article (HTTP 403)",
+    "https://ikpi.or.id/news/ (HTTP 404)",
+    "https://ortax.org/news (HTTP 200 but client-side SPA shell, title 'Artikel tidak ditemukan')",
+    "https://peraturan.bpk.go.id/Search?type=PerundangUndangan&jenis=PMK&tahun=2026 (HTTP 200 but Angular SPA shell, no static results)",
+    "https://www.pajak.go.id/peraturan (HTTP 200 but no extractable static entries, likely JS-rendered table)",
+    "https://jdih.kemnaker.go.id/peraturan (HTTP 200 but no extractable static entries, JS filter shell)",
+    "https://jdih.kemenkeu.go.id/peraturan (curl timeout, HTTP 000)"
+  ],
+  "deltas": [],
+  "seen_citations": [
+    "UU Nomor 4 Tahun 2026",
+    "UU Nomor 5 Tahun 2026",
+    "PP Nomor 20 Tahun 2026",
+    "PP Nomor 24 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026",
+    "Perpres Nomor 26 Tahun 2026",
+    "Perpres Nomor 27 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026",
+    "PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 41 Tahun 2026",
+    "PMK Nomor 40 Tahun 2026",
+    "PMK Nomor 28 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026",
+    "Permenaker Nomor 7 Tahun 2026",
+    "Permenaker Nomor 8 Tahun 2026",
+    "Permenaker Nomor 9 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026",
+    "PMK 37/2025",
+    "Permendagri 6/2026",
+    "KMK 29/MK/EF.2/2026",
+    "PMK Nomor 44 Tahun 2026"
+  ],
+  "note": "NB-INTEL family (Regulation/Press/Immigration/Tax) all returned 'nessuna novita' for the 24-48h window. NB-INTEL-Tax offered an unrelated follow-up about a proposed amendment to PP Nomor 8 Tahun 2006 (Laporan Kinerja Bendahara Umum Negara) reported 2026-07-14 by Minister Purbaya - a proposal-stage mention, not a published act, dropped per hard rule 2 (no speculation). Primary web sources: Hukumonline 403, MUC 403, IKPI 404 (all unchanged vs prior runs), Ortax /news still a client-side SPA shell (200 but 'Artikel tidak ditemukan', unchanged since 2026-07-15 fix). DDTC loaded full content (669KB) - newest dated article is 'Ketentuan Pencabutan Pemberian Kuasa oleh Wajib Pajak' (2026-07-14, citing PMK 44/2026) - that citation is already in seen_citations from 2026-07-14's run, dropped via dedup. No DDTC article newer than 2026-07-14 found; nothing within the 48h window (2026-07-14 07:00 to 2026-07-16 07:00 WITA). Backup gov portals: peraturan.go.id (200, real static content, 75KB) surfaced two entries worth flagging for Antonello's manual review even though both fail the strict 48h freshness gate: (1) Peraturan Menteri Imigrasi dan Pemasyarakatan Nomor 10 Tahun 2026 'PENAMBAHAN DAFTAR NEGARA, PEMERINTAH WILAYAH ADMINISTRATIF KHUSUS SUATU NEGARA, DAN ENTITAS TERTENTU YANG DIBERIKAN BEBAS VISA KUNJUNGAN' (Tanggal Penetapan 07 Juli 2026, Tanggal Pengundangan 09 Juli 2026 - visa-free country list addition, directly relevant to Bali Zero's visa/immigration service line, but 7-9 days old at time of this run and never appeared in any prior delta file per historical grep - possibly a late site-indexing lag rather than a same-day publication); (2) Peraturan Presiden Nomor 32 Tahun 2026 on ratification of an Indonesia-Japan economic partnership protocol amendment (Perpres explicitly outside Bali Zero service lines - trade agreement, not visa/tax/property/company/HR). Neither added to deltas/seen_citations per the hard 48h-window + service-line filters, but both are new discoveries not seen in any prior run - recommend Antonello manually check Permenimipas 10/2026 for client-facing visa-free-country updates. peraturan.bpk.go.id now returns HTTP 200 (recovered from 403 on 2026-07-15) but is confirmed a pure Angular SPA shell (app-root marker, zero static PMK entries) - source remains functionally unreachable for our fetch method. pajak.go.id (200) and jdih.kemnaker.go.id (200) both loaded but yielded zero extractable static regulation entries, consistent with JS-rendered tables. jdih.kemenkeu.go.id timed out (000) this run. imigrasi.go.id newest press item now dated 2026-07-03 (KPK integrity collaboration follow-up), still outside the 48h window, no regulatory content. No source contradicted the NB-reported null result for citable, in-window, service-line-relevant deltas. Zero new deltas today."
+}


### PR DESCRIPTION
## Summary
- Daily regulatory-watcher run for 2026-07-16 (all 6 workflow steps executed inline, no background tasks per incident 2026-07-05 guard)
- NB-INTEL family (Regulation/Press/Immigration/Tax): all 4 returned "nessuna novità" for the 24-48h window
- Web cross-check (5 primary legal-tech + 6 backup gov portals): no in-window, service-line-relevant new deltas
- `new_today_count: 0` → no Telegram alert sent, per spec
- Note field flags 2 out-of-window discoveries for manual follow-up: Permenimipas 10/2026 (visa-free country list addition — relevant to visa line) and Perpres 32/2026 (Indonesia-Japan trade protocol — out of scope)

## Test plan
- [x] JSON validated with `python3 -m json.load` — valid, `new_today_count: 0`
- [x] File verified on disk post-write (`ls -la`)
- [x] `seen_citations` correctly carries forward yesterday's 21 entries (no new ones to union)

🤖 Generated with [Claude Code](https://claude.com/claude-code)