### PR TITLE
fix(multimodal): drop unsupported --no-progress from nlm mind-map download

### DIFF
--- a/apps/evaluator/nlm_deep_research/multimodal_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/multimodal_pipeline.py
@@ -130,6 +130,12 @@ ARTIFACT_META: dict[str, dict[str, str]] = {
     "report":      {"download_cmd": "report",     "ext": "md",   "display": "Report"},
 }
 
+# Artifact types whose `nlm download <cmd>` subcommand supports --no-progress.
+# Verified via `nlm download <cmd> --help`: audio/infographic have it,
+# mind-map/report do not (mind-map download was failing 100% of the time
+# with "No such option: --no-progress" until this was made conditional).
+NO_PROGRESS_SUPPORTED: set[str] = {"audio", "infographic"}
+
 # Re-generation interval per artifact type (hours)
 MIN_REGEN_INTERVAL: dict[str, int] = {
     "audio":       7 * 24,   # weekly
@@ -354,8 +360,9 @@ def _run_nlm_download(
         NLM_CLI, "download", meta["download_cmd"],
         notebook_id,
         "--output", output_path,
-        "--no-progress",
     ]
+    if artifact_type in NO_PROGRESS_SUPPORTED:
+        cmd.append("--no-progress")
 
     if dry_run:
         logger.info("[DRY-RUN] Would download: %s → %s", artifact_type, output_path)


### PR DESCRIPTION
## Summary
- `nlm download mind-map` (and `download report`) don't support `--no-progress` — only `audio`/`infographic` do, verified via `nlm download <cmd> --help` on Pro.
- `_run_nlm_download()` is a single function shared by all 4 artifact types and hardcoded the flag for all of them, so every scheduled mind-map slot (Tue nb3 + Sun nb3) has failed since generation with `No such option: --no-progress` — 18x in `~/logs/cron-tmp/multimodal.log` on Pro over 2+ months, while audio/infographic slots passed.
- Fix: made `--no-progress` conditional per artifact type (`NO_PROGRESS_SUPPORTED = {"audio", "infographic"}`) instead of a blanket removal, so progress-bar suppression is preserved on the types that actually support it.

## Test plan
- [x] `python3 -m py_compile apps/evaluator/nlm_deep_research/multimodal_pipeline.py`
- [x] `python3 -m pytest apps/evaluator/nlm_deep_research/tests/test_multimodal_pipeline.py -q` — 41 passed
- [x] Verified `nlm download mind-map --help` / `report --help` lack `--no-progress`; `audio`/`infographic --help` have it (via `ssh pro`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)