### PR TITLE
fix(lead-capture): add homepage_hero to LeadSource — primary CTA leads were 422'd for 10 days

### DIFF
--- a/apps/backend-rag/backend/services/lead_capture/source.py
+++ b/apps/backend-rag/backend/services/lead_capture/source.py
@@ -28,6 +28,12 @@ class LeadSource(str, Enum):
     # selection modal, /services/[slug] pages. No fixed hash route — the
     # service slug + package name are carried in context, not result_hash.
     PRICING_MODAL = "pricing_modal"
+    # Homepage hero primary CTA (2026-07-06 frontend, enum landed 2026-07-16):
+    # HeroCTA.tsx, the single red primary action of balizero.com. Shipped
+    # against this enum before the value existed, so every hero click 422'd
+    # and fell back to the bare wa.me link — clicks tracked, leads unlogged.
+    # No result page: the visitor has not run a tool, they came off the hero.
+    HOMEPAGE_HERO = "homepage_hero"
 
     @property
     def human_name(self) -> str:
@@ -44,6 +50,7 @@ class LeadSource(str, Enum):
             LeadSource.ZANTARA_WIDGET_HANDOFF: "the Zantara chat",
             LeadSource.CTA_HANDOFF: "Bali Zero",
             LeadSource.PRICING_MODAL: "the pricing page",
+            LeadSource.HOMEPAGE_HERO: "the homepage",
         }[self]
 
     @property
@@ -67,4 +74,6 @@ class LeadSource(str, Enum):
             LeadSource.CTA_HANDOFF: "/",
             # No fixed hash route — service slug varies; carried in context.
             LeadSource.PRICING_MODAL: "/",
+            # The hero IS the homepage; no tool result to link back to.
+            LeadSource.HOMEPAGE_HERO: "/",
         }[self]

--- a/apps/backend-rag/backend/tests/services/lead_capture/test_whatsapp_deeplink.py
+++ b/apps/backend-rag/backend/tests/services/lead_capture/test_whatsapp_deeplink.py
@@ -146,3 +146,9 @@ class TestSourceEnum:
         # Wire-format values: the mouth frontend sends these literal strings.
         assert LeadSource.ARTICLE.value == "article"
         assert LeadSource.KBLI_NAVIGATOR.value == "kbli_navigator"
+        # HeroCTA.tsx posts source="homepage_hero". It shipped 2026-07-06
+        # against an enum that did not carry the value: the router's
+        # `source: LeadSource` rejected every homepage hero click with 422
+        # until 2026-07-16, so the site's single primary CTA wrote no
+        # lead_intents row for 10 days. Pinning the wire value here.
+        assert LeadSource("homepage_hero") is LeadSource.HOMEPAGE_HERO


### PR DESCRIPTION
## What

Adds `HOMEPAGE_HERO = "homepage_hero"` to the `LeadSource` enum, plus its two required `@property` entries and a wire-value pin in the tests.

## Why

`HeroCTA.tsx:51` has posted `source="homepage_hero"` to `/api/lead/capture` since **2026-07-06**. The value was never added to the enum. The router types the field as `source: LeadSource` (`routers/lead_capture.py:43`), so FastAPI rejected **every homepage hero click with 422**.

Nothing looked broken, which is why it survived 10 days:

- `WhatsAppLeadButton.tsx:79-83` catches the failure, fires `trackLeadWhatsAppCTA(source, {captured:false})` and falls back to the bare `wa.me` link → the visitor still reaches WhatsApp, and the GA4 event still fires.
- The only casualty is silent: **zero `lead_intents` rows** from balizero.com's single red primary CTA for 10 days.

The frontend shipped deliberately in this state — `HeroCTA.tsx:27-33` documents the gap and the safe fallback, and says the enum value is the missing half. This lands it.

## Surfaced by

Subhi's GA4 audit EOD 15/7 ("Home hero CTA: zero GA4 events fire on click"). His framing was a server-vs-client wrapper gap in `HeroBlueprint.tsx` — that part is a red herring (`HeroCTA.tsx:1` is already `"use client"`, and the event is beacon-transported at `analytics.ts:267`, fired before navigation). Verifying that claim is what exposed this, which is the real defect underneath.

## Verification

- **RED** on pre-fix enum: `ValueError: 'homepage_hero' is not a valid LeadSource`
- **GREEN** after: 32 `lead_capture` + 35 lead-related tests pass
- Deeplink renders `Hi Bali Zero — I just used the homepage on your site.` with no `Reference:` line (no result page — matches `article` / `cta_handoff` / `pricing_modal`)

Both `@property` dicts are keyed exhaustively with `[self]`, so a missing entry would raise `KeyError`; `test_all_sources_have_names` already guards that.

## Note for review

`human_name = "the homepage"` is client-visible — it renders into the WhatsApp message body. Consistent with `"the pricing page"` / `"the Insights blog"`. Easy to reword if you want different copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)