### PR TITLE
fix(infra): sync 7 Mini wrapper canons off ~/Desktop path

### DIFF
--- a/infra/launchagents/wrappers/mini-fleet-watch.sh
+++ b/infra/launchagents/wrappers/mini-fleet-watch.sh
@@ -49,7 +49,7 @@ trap 'rm -f "$PIDFILE"' EXIT
 
 # ---- payload (cron one-shot; G8_keepalive_sane: plist uses StartInterval, no KeepAlive)
 log "run start"
-/usr/bin/python3 "$HOME/Desktop/nuzantara/scripts/fleet_watch.py" >> "$LOG" 2>&1
+/usr/bin/python3 "$HOME/nuzantara/scripts/fleet_watch.py" >> "$LOG" 2>&1
 RC=$?
 
 if [ $RC -eq 0 ]; then

--- a/infra/launchagents/wrappers/mini-tg-digest-flush.sh
+++ b/infra/launchagents/wrappers/mini-tg-digest-flush.sh
@@ -51,7 +51,7 @@ trap 'rm -f "$PIDFILE"' EXIT
 log "run start"
 # Flush the tg_notify spool into ONE grouped Telegram digest. Exit 3 =
 # send-failed-spool-preserved (fail-visible → heartbeat error → healer).
-/usr/bin/python3 "$HOME/Desktop/nuzantara/scripts/tg_digest_flush.py" >> "$LOG" 2>&1
+/usr/bin/python3 "$HOME/nuzantara/scripts/tg_digest_flush.py" >> "$LOG" 2>&1
 RC=$?
 
 if [ $RC -eq 0 ]; then

--- a/infra/launchagents/wrappers/ollama-warm-pin.sh
+++ b/infra/launchagents/wrappers/ollama-warm-pin.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 OLLAMA_URL="http://127.0.0.1:11434"
-TOPOLOGY="/Users/nuzantara/Desktop/nuzantara/MODEL_TOPOLOGY.json"
+TOPOLOGY="/Users/nuzantara/nuzantara/MODEL_TOPOLOGY.json"
 LOG="$HOME/logs/ollama-warm-pin.log"
 PYTHON_BIN="${PYTHON_BIN:-/Users/nuzantara/.pyenv/versions/3.11.11/bin/python3}"
 

--- a/infra/launchagents/wrappers/wa-mirror-runner.sh
+++ b/infra/launchagents/wrappers/wa-mirror-runner.sh
@@ -14,5 +14,5 @@ fi
 
 mkdir -p "${HOME}/logs"
 
-cd "${WA_MIRROR_APP_DIR:-${HOME}/Desktop/nuzantara/apps/wa-mirror}"
+cd "${WA_MIRROR_APP_DIR:-${HOME}/nuzantara/apps/wa-mirror}"
 exec /opt/homebrew/bin/node --enable-source-maps dist/bridge/index.js

--- a/infra/launchagents/wrappers/wr2-warroom-sync.sh
+++ b/infra/launchagents/wrappers/wr2-warroom-sync.sh
@@ -11,7 +11,7 @@
 # read the OUTCOME, not the exit code — we record file counts).
 set -uo pipefail
 
-SRC="pro:/Users/nuzantara/Desktop/nuzantara/apps/war-room/output/"
+SRC="pro:/Users/nuzantara/nuzantara/apps/war-room/output/"
 DST="$HOME/.wr2-warroom-sync/output/"
 LOG="$HOME/Library/Logs/wr2-warroom-sync.log"
 STAMP="$(date '+%Y-%m-%d %H:%M:%S')"
@@ -19,7 +19,7 @@ STAMP="$(date '+%Y-%m-%d %H:%M:%S')"
 mkdir -p "$DST" "$(dirname "$LOG")"
 
 # 1) reachability probe — if the Pro is unreachable, log and exit 0 (no destructive op)
-if ! ssh -o ConnectTimeout=10 -o BatchMode=yes pro 'test -f /Users/nuzantara/Desktop/nuzantara/apps/war-room/output/queue/human-review-queue.json' 2>/dev/null; then
+if ! ssh -o ConnectTimeout=10 -o BatchMode=yes pro 'test -f /Users/nuzantara/nuzantara/apps/war-room/output/queue/human-review-queue.json' 2>/dev/null; then
   echo "$STAMP  SKIP — Pro unreachable or queue missing (no sync, local copy untouched)" >> "$LOG"
   exit 0
 fi

--- a/infra/mini-scripts/kg-query-api-wrapper.sh
+++ b/infra/mini-scripts/kg-query-api-wrapper.sh
@@ -23,5 +23,5 @@ if [ $WAITED -ge $MAX_WAIT_SEC ]; then
   exit 1
 fi
 
-cd ~/Desktop/nuzantara/apps/mata-garuda
+cd ~/nuzantara/apps/mata-garuda
 exec ./.venv/bin/python -m mata_garuda.api.kg_query --bind "$TAILSCALE_IP" --port 8990

--- a/scripts/mini-migration/heartbeat-watchdog.sh
+++ b/scripts/mini-migration/heartbeat-watchdog.sh
@@ -20,7 +20,7 @@
 
 set -u
 
-REPO="${REPO:-/Users/nuzantara/Desktop/nuzantara}"
+REPO="${REPO:-/Users/nuzantara/nuzantara}"
 YAML="${YAML:-$HOME/agent-config/job-ownership.yaml}"
 HB_DIR="$HOME/heartbeat"
 LOG_FILE="$HOME/logs/heartbeat-watchdog.log"


### PR DESCRIPTION
## Summary
- Mini's repo checkout moved from `~/Desktop/nuzantara` to `~/nuzantara` today (`~/Desktop/nuzantara` is now a symlink to it); a live sweep already fixed 8 wrapper scripts' hardcoded `~/Desktop/nuzantara` paths, but only on the HOME side.
- Ports the fix into repo canon for 7 of the 8 (byte-identical to live, sha256-verified): `kg-query-api-wrapper.sh`, `heartbeat-watchdog.sh`, `wa-mirror-runner.sh`, `wr2-warroom-sync.sh`, `ollama-warm-pin.sh`, `mini-tg-digest-flush.sh`, `mini-fleet-watch.sh`.
- `healer-run.sh` has the same divergence but is intentionally excluded — it's the healer's own wrapper, self-modification is out of the healer's constitutional perimeter. Flagged separately.

## Test plan
- [x] `sha256_file(live) == sha256_file(repo)` verified per-file before commit
- [x] `python3 scripts/lint_home_fork.py --check` from main (post-merge) should drop these 7 from the DIVERGED list (only `healer-run.sh` remains, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)