### PR TITLE
fix(deps): resync root npm lock + make the desync impossible to merge silently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,8 +93,17 @@ updates:
           - "patch"
 
   # Node.js frontend
+  #
+  # directory MUST stay "/" — this is an npm-workspaces monorepo whose single
+  # hoisted package-lock.json lives at the root. Pointed at "/apps/mouth" (as it
+  # was until 2026-07-16) Dependabot can see that workspace's package.json but
+  # NOT the root lock, so every PR it opened bumped the manifest and left the
+  # lock behind. Four majors landed that way (#2384/#2385/#2386/#2387) and broke
+  # `npm ci` on main for days; the only jobs that run `npm ci` are non-required,
+  # so nothing went red that anyone had to look at. From "/" Dependabot resolves
+  # the workspace tree and updates the manifest AND the root lock in one PR.
   - package-ecosystem: "npm"
-    directory: "/apps/mouth"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -103,15 +112,18 @@ updates:
       - "dependencies"
       - "security"
     ignore:
-      # lucide-react majors are not safely auto-mergeable here. This is an
-      # npm-workspaces monorepo with a single hoisted root package-lock.json,
-      # but Dependabot bumps only apps/mouth/package.json, leaving the lock
-      # (and the hashFiles-keyed node_modules cache) at the old version. The
-      # mouth vitest runner inlines packages/core, so vite's import-analysis
-      # resolver fails on the bare `lucide-react` import when declared != lock,
-      # breaking the required Frontend (mouth) check (see closed PR #956). Bump
-      # majors deliberately with a synced root lockfile. Mirrors the
-      # torch / sentence-transformers semver-major ignore in the pip block.
+      # lucide-react majors are not safely auto-mergeable here: the mouth vitest
+      # runner inlines packages/core, so vite's import-analysis resolver fails on
+      # the bare `lucide-react` import when declared != lock (closed PR #956).
+      #
+      # NOTE 2026-07-16: the *desync* half of that old rationale is now fixed at
+      # the root (directory "/" above + the required `npm lock honors manifest`
+      # gate), so this ignore no longer carries the structural cure — it is now
+      # just an ordinary "icon-library majors get a human" hold, mirroring the
+      # torch / sentence-transformers semver-major ignore in the pip block. It
+      # was ALSO the scar: scoping the fix to one dependency instead of the class
+      # is exactly why the disease came back through four other packages. Do not
+      # add per-package ignores here to paper over a lock desync — fix the lock.
       - dependency-name: "lucide-react"
         update-types: ["version-update:semver-major"]
     groups:

--- a/.github/workflows/npm-lock-sync.yml
+++ b/.github/workflows/npm-lock-sync.yml
@@ -1,0 +1,79 @@
+name: npm lock sync
+
+# The gate that would have caught the 2026-07-16 desync on day one.
+#
+# WHAT HAPPENED: this is an npm-workspaces monorepo with ONE hoisted root
+# package-lock.json, but Dependabot was configured on `directory: /apps/mouth`,
+# so it bumped apps/mouth/package.json and never touched the root lock. Four
+# MAJOR bumps landed that way (#2384 @vitejs/plugin-react, #2385 ai 6->7,
+# #2386 @ai-sdk/react 3->4, #2387 @types/node) and `npm ci` on main started
+# failing with EUSAGE.
+#
+# WHY NOBODY NOTICED: the only jobs that run `npm ci` — SonarQube, Snyk
+# Node.js, Cross-import integrity, Lighthouse — are all NON-REQUIRED, so they
+# went red and blocked nothing. Everything that gates a merge (tests.yml) and
+# everything that ships (vercel.json) uses `npm install`, which silently
+# re-resolves from package.json and ignores the stale lock. Result: four
+# scanners dead for days, and prod builds resolving `^`-ranges fresh on every
+# deploy instead of installing a pinned tree.
+#
+# The dependabot.yml npm block already DOCUMENTED this exact failure mode (see
+# the lucide-react ignore, PR #956) — but the cure was scoped to one dependency
+# instead of the class, so the disease came back through four other packages.
+#
+# THIS gate is the class-level cure: it runs on EVERY pull request and fails if
+# the lock cannot satisfy the manifests. It is the npm sibling of
+# test_lock_honors_requirements.py (scar W98, the pip side of the same family).
+#
+# NO `paths:` FILTER — DELIBERATE. This job is a REQUIRED check, and a required
+# check that is path-skipped stays "pending" forever on non-matching PRs,
+# blocking every merge. The whole file must keep running everywhere. If you add
+# a paths filter here, you must first remove it from the required contexts.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-lock-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lock-honors-manifest:
+    name: npm lock honors manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      # `npm ci` is the contract: it refuses to install when package.json and
+      # package-lock.json disagree. --dry-run keeps it read-only — we want the
+      # verdict, not the node_modules tree.
+      - name: npm ci --dry-run (fails on lock/manifest desync)
+        id: locksync
+        run: npm ci --dry-run --no-audit --no-fund
+
+      - name: Explain the failure
+        if: failure() && steps.locksync.conclusion == 'failure'
+        run: |
+          echo "::error title=npm lock is out of sync with package.json::The root package-lock.json cannot satisfy the workspace manifests."
+          echo ""
+          echo "This usually means a package.json was bumped without regenerating the root lock."
+          echo "Dependabot bumping a workspace manifest alone is the classic cause."
+          echo ""
+          echo "Fix, from the repo root:"
+          echo "    npm install --package-lock-only"
+          echo "    git add package-lock.json && git commit"
+          echo ""
+          echo "Do NOT work around this by switching a workflow to 'npm install' —"
+          echo "that is what hid this class of bug for days (see the header of"
+          echo "this file). The lock is meant to be the pinned truth."
+          exit 1

--- a/.github/workflows/npm-lock-sync.yml
+++ b/.github/workflows/npm-lock-sync.yml
@@ -57,9 +57,20 @@ jobs:
       # `npm ci` is the contract: it refuses to install when package.json and
       # package-lock.json disagree. --dry-run keeps it read-only — we want the
       # verdict, not the node_modules tree.
+      #
+      # --ignore-scripts is LOAD-BEARING, not tidiness. Without it the root
+      # `prepare` script runs `husky`, which is not on PATH under --dry-run, and
+      # the job dies `code 127 / command sh -c husky` — a red gate that says
+      # NOTHING about lock sync. That false-positive is this gate's own version
+      # of the guard-over-match family (cicatrix #3): firing on the wrong
+      # entity. Caught by this very job on its first run (PR #2505). It also
+      # means CI never executes package lifecycle scripts just to read a lock
+      # verdict. The EUSAGE reconciliation we care about happens before any
+      # script would run, so the guard keeps its teeth — see the guilt/innocence
+      # pair asserted below.
       - name: npm ci --dry-run (fails on lock/manifest desync)
         id: locksync
-        run: npm ci --dry-run --no-audit --no-fund
+        run: npm ci --dry-run --ignore-scripts --no-audit --no-fund
 
       - name: Explain the failure
         if: failure() && steps.locksync.conclusion == 'failure'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,7 +1600,7 @@
     "apps/mouth": {
       "version": "5.2.0",
       "dependencies": {
-        "@ai-sdk/react": "^3.0.118",
+        "@ai-sdk/react": "^4.0.32",
         "@formkit/auto-animate": "^0.9.0",
         "@next/third-parties": "^16.1.6",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -1614,7 +1614,7 @@
         "@tanstack/react-query-devtools": "^5.91.3",
         "@tanstack/react-virtual": "^3.13.13",
         "@types/dompurify": "^3.0.5",
-        "ai": "^6.0.3",
+        "ai": "^7.0.29",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -1648,11 +1648,11 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "25.9.1",
+        "@types/node": "26.1.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/uuid": "^10.0.0",
-        "@vitejs/plugin-react": "^5.1.2",
+        "@vitejs/plugin-react": "^6.0.3",
         "@vitest/coverage-istanbul": "^4.0.15",
         "chrome-launcher": "^1.2.1",
         "eslint": "^9.39.2",
@@ -1666,6 +1666,73 @@
         "tailwindcss": "^4",
         "typescript": "^5.9.3",
         "vitest": "^4.0.15"
+      }
+    },
+    "apps/mouth/node_modules/@ai-sdk/gateway": {
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.21.tgz",
+      "integrity": "sha512-GafyeyHFDKJjdtbyhCQ0aC2FORdyE56IxK45EZ1JLO1iVdg8XqEU3bwnRzI0+5S1XHV7W2qQsxkZnGYPbsFiXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "apps/mouth/node_modules/@ai-sdk/provider": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "apps/mouth/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.10.tgz",
+      "integrity": "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "apps/mouth/node_modules/@ai-sdk/react": {
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.32.tgz",
+      "integrity": "sha512-H1tu1C5XoY1fh14Q4ABS1ljPx+H/y20MqJrUhATW5jjdAqOyyAy0rFl2qj5BC9uhFMtM+NkxEUOEPB5qeQLDQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "2.0.14",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
+        "ai": "7.0.29",
+        "swr": "^2.4.1",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "apps/mouth/node_modules/@bcoe/v8-coverage": {
@@ -1735,12 +1802,47 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "apps/mouth/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "apps/mouth/node_modules/@types/node": {
-      "version": "25.9.1",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
+      }
+    },
+    "apps/mouth/node_modules/@vitejs/plugin-react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "apps/mouth/node_modules/@vitest/coverage-istanbul": {
@@ -1885,6 +1987,23 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/mouth/node_modules/ai": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.29.tgz",
+      "integrity": "sha512-q+A+skhl6SyjWliU6W7zNYgDUrEk5SbNrCc5vt4S9n6+n6e7jSorDmu51hlhjDOsS7VwzWGCgbWFvvT3iomtvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.21",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "apps/mouth/node_modules/ajv": {
@@ -2137,7 +2256,9 @@
       }
     },
     "apps/mouth/node_modules/undici-types": {
-      "version": "7.24.6",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2332,68 +2453,51 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.130",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.130.tgz",
-      "integrity": "sha512-qenRdpoYM+2y8Ibj3Y7XngvfcG4NIpejaM+YqAKWXi3/N1qZYeIelrm19jxhIwQW0W/g7WUz0L2Agl7+FnwrQA==",
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.14.tgz",
+      "integrity": "sha512-Vf2THTWylnOiPUZgPEzTcbin+6pIBKMdJnDNAMHD0u+upNoO5747HMMFUJJnNNjk8eroAPomaVmF0w8gadA4WA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.29",
-        "@vercel/oidc": "3.2.0"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
+        "pkce-challenge": "^5.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
-    "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.29",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.29.tgz",
-      "integrity": "sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==",
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.10.tgz",
+      "integrity": "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider": "4.0.3",
         "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/react": {
-      "version": "3.0.206",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.206.tgz",
-      "integrity": "sha512-26gbPT876BZVXJlSNjqkCDOFiqfxAAhYn+a/ryV6ce5TWo6EfWQZeEiLrZOS6bxaOi7xxkB5uPZaZKFaIJndjQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "4.0.29",
-        "ai": "6.0.204",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -13844,6 +13948,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -13954,24 +14064,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ai": {
-      "version": "6.0.204",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.204.tgz",
-      "integrity": "sha512-SudB8rUwaVhpWF8+qTJcxUptXPIdN9rWMknzTT3WbKa2QwiGRshyepFKNkDILWm882LgqlEyRZgKhNT14j0jpQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "3.0.130",
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.29",
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {


### PR DESCRIPTION
## What broke

`npm ci` fails on `origin/main` with `EUSAGE`. Four Dependabot PRs bumped `apps/mouth/package.json` and never touched the root `package-lock.json`:

| package | package.json | root lock | |
|---|---|---|---|
| `ai` | `^7.0.29` | `6.0.204` | major |
| `@ai-sdk/react` | `^4.0.32` | `3.0.206` | major |
| `@vitejs/plugin-react` | `^6.0.3` | `5.2.0` | major |
| `@types/node` | `26.1.1` | `25.9.1` | major |

This is an npm-workspaces monorepo with **one hoisted root lock**, but the npm block in `dependabot.yml` pointed at `directory: /apps/mouth` — from there Dependabot cannot see the root lock.

## Why it went unnoticed for days

The only jobs that run `npm ci` — **SonarQube, Snyk Node.js Security, Cross-import integrity, Lighthouse** — are all **non-required**. They went red and blocked nothing. #2385 itself merged with Snyk Node and Cross-import already failing. Two of the four are our only Node-side security scanners.

Nothing else noticed because **nothing else uses the lock**: `tests.yml` installs with `npm install --no-fund`, and `vercel.json` ships with `installCommand: npm install`. Both silently re-resolve from `package.json` and ignore a stale lock. So prod already runs the new majors (and is green on them), while the lock — the thing meant to pin the tree — describes an install nobody performs.

`dependabot.yml` **already documented this exact failure mode** (the lucide-react ignore, PR #956). The cure was scoped to one dependency instead of the class, so it came back through four other packages.

## Three parts — the first alone peels off within a week

1. **Regenerate the root lock** (`npm install --package-lock-only`). Safe: it aligns the lock to what prod and the required tests already resolve and run green on. npm de-hoists the four into `apps/mouth/node_modules/*` because their versions diverge from the other workspaces — correct workspace behavior, and why this is a 154-line diff rather than a full churn.
2. **`dependabot` npm `directory: /apps/mouth` → `/`** so it owns the root lock and stops generating desyncs.
3. **New required gate `npm lock honors manifest`** running `npm ci --dry-run` on every PR — the npm sibling of `test_lock_honors_requirements.py` (scar W98, pip side of the same family). **Deliberately no `paths:` filter**: a path-skipped required check stays pending forever and blocks every merge.

## Verification

- **RED before**: `npm ci --dry-run` → `RC=1`, `EUSAGE`, `Missing: ai@7.0.29 / @ai-sdk/react@4.0.32 / @vitejs/plugin-react@6.0.3`, `Invalid: @types/node`
- **GREEN after**: `RC=0`
- Full backend suite on pre-push: **17174 passed, 165 skipped**
- Both YAML files parse; job name matches the context to be registered

## Follow-up (needs this on main first)

Add `npm lock honors manifest` to the required contexts. Open PRs will need a branch update to pick it up — that's the one-time cost of arming it.

**CORRECTION (2026-07-16, before anyone builds on it):** an earlier draft of this section claimed prod could be pinned by switching the root `vercel.json` to `npm ci`. That is **wrong, and the change would have been a no-op**.

Verified against the live project (`vercel project inspect mouth --scope nuzantara-2026`): **Root Directory = `apps/mouth`**. Vercel therefore reads `apps/mouth/vercel.json` (`installCommand: npm install --include=dev`), and the repo-root `vercel.json` is **dead config** — its installCommand, buildCommand, outputDirectory and that elaborate ignoreCommand never run. (`.claude/rules/frontend-nextjs.md:16` — "Deploy mouth/kita from monorepo root, NOT from apps/mouth" — contradicts the live setting and is stale.)

The real picture is worse than "stale lock": `apps/mouth` has **no package-lock.json at all**, so prod resolves fresh from `apps/mouth/package.json` on every build — the root lock never governs prod. Pinning it needs either a Root Directory change or an install command that can reach the root lock, which depends on the "include files outside root directory" setting. That's an experiment against a preview deploy, not a one-liner, so it stays out of this PR.

This PR's value is unchanged and stands on its own: it unbreaks the four `npm ci` jobs and stops Dependabot generating desyncs.
