### PR TITLE
fix(kbli): 68112 code-collision — detach PP28 MICE-venue licensing from residential leasing code

### DIFF
--- a/.github/workflows/kbli-68112-collision-regression.yml
+++ b/.github/workflows/kbli-68112-collision-regression.yml
@@ -1,0 +1,65 @@
+name: kbli-68112-collision-regression
+
+# Regression tripwire for the KBLI 68112 code-number collision (fixed 2026-07-16).
+#
+# BPS Peraturan 7/2025 (KBLI 2025, current) codes 68112 as residential leasing;
+# PP 28/2025 (numbered on the OLD KBLI 2020) codes the SAME 5-digit number 68112
+# as MICE-venue rental (Lampiran I.L, Sektor Pariwisata, p.I.L.44) — a pure
+# code-number collision across two 2025 regulations. The served datasets had the
+# correct residential title but the WRONG (PP28-MICE) per_skala licensing block.
+# Fix: per_skala -> [] (honest — no OSS NSPK published yet for the new code,
+# ruang-lingkup 404), original block preserved under
+# per_skala_disputed_pp28_mice for audit, advisory _data_note added.
+#
+# This job is the tripwire: it fails if the MICE-venue licensing ever leaks back
+# into 68112's own per_skala on any served dataset copy. Scoped to this ONE known
+# collision — see scripts/tests/test_kbli_68112_pp28_mice_collision.py docstring
+# for why a dataset-wide "no MICE/Venue" rule would false-positive on 68124/82300
+# (legitimate MICE/convention-venue codes).
+#
+# Path-scoped (no pending-forever, W69 BUCO #1): a PR that doesn't touch the KBLI
+# dataset or this test has nothing for it to check. NON-REQUIRED by design: a new
+# signal observes for a review cycle before it can block; flip to required only
+# after it proves stable + zero false-positive.
+on:
+  pull_request:
+    paths:
+      - "source_documents/KBLI_2025_FINAL_CLEAN.json"
+      - "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+      - "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+      - "scripts/tests/test_kbli_68112_pp28_mice_collision.py"
+      - ".github/workflows/kbli-68112-collision-regression.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "source_documents/KBLI_2025_FINAL_CLEAN.json"
+      - "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+      - "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+      - "scripts/tests/test_kbli_68112_pp28_mice_collision.py"
+      - ".github/workflows/kbli-68112-collision-regression.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kbli-68112-collision-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kbli-68112-collision-regression:
+    name: kbli-68112-collision-regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Run 68112 collision regression test
+        run: |
+          set -uo pipefail
+          python -m pip install --quiet pytest
+          python -m pytest scripts/tests/test_kbli_68112_pp28_mice_collision.py -v

--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
   "lastModified": "2026-07-16",
-  "datasetSha256": "sha256:2336d47e07af13d786981493c4137ea9f5407cf7f6f14c9c1617ed2a476b9aa5",
+  "datasetSha256": "sha256:cf3deb265ac6c4778ad7c2125af44e79967c1f568d773450a58ea93e2ab3b8ee",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
-  "lastModified": "2026-07-13",
-  "datasetSha256": "sha256:27a18d4821dcf22f71b2184a3f5a68f5851cfaa3090c9f7cc0c0b8aa4ca2b37c",
+  "lastModified": "2026-07-16",
+  "datasetSha256": "sha256:2336d47e07af13d786981493c4137ea9f5407cf7f6f14c9c1617ed2a476b9aa5",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/scripts/tests/test_kbli_68112_pp28_mice_collision.py
+++ b/scripts/tests/test_kbli_68112_pp28_mice_collision.py
@@ -1,0 +1,122 @@
+"""Regression pin — KBLI 68112 PP28-MICE code-number collision (2026-07-16).
+
+Verified facts (image-verified 3x against the official PP 28/2025 + BPS Peraturan
+7/2025 PDFs; see PR description for the full chain):
+  - 68112 under BPS Peraturan 7/2025 (KBLI 2025, current — what OSS uses today) =
+    residential leasing ("Aktivitas Penyewaan Bangunan dan Lahan Hunian Milik
+    Sendiri atau Sewa"). The dataset's judul/uraian for this code are correct.
+  - 68112 under PP 28/2025 (numbered on the OLD KBLI 2020) = a DIFFERENT activity,
+    "Penyewaan Venue Penyelenggaraan Aktifitas MICE dan Event Khusus" (Lampiran
+    I.L, Sektor Pariwisata, p.I.L.44 row 25) — a pure code-NUMBER collision across
+    the two regulations, not the same business activity.
+  - The served dataset had (until 2026-07-16) the CORRECT residential title but the
+    WRONG per_skala licensing block — the PP28-MICE block, whose kewajiban text
+    literally names "Penyewaan Venue Penyelenggra aan Aktifitas MICE" / mentions
+    "LSPr (khusus PMA)".
+  - OSS RBA ruang-lingkup for the new residential 68112 returns 404 (no published
+    risk-based NSPK yet) — hence `_l2_status: "no_oss_risk"` on the record. There is
+    no ground truth to fabricate a residential per_skala from, so the honest fix is
+    an EMPTY per_skala (the frontend already guards `licensing.length > 0`), not a
+    guess.
+
+The fix (see scripts/sync_kbli_dataset.sh consumers): per_skala -> [], the original
+MICE block preserved verbatim under `per_skala_disputed_pp28_mice` for audit (never
+silently deleted), and an advisory `_data_note` added.
+
+This test is the tripwire: it FAILS if 68112's per_skala EVER again contains the
+MICE-venue licensing text, on every dataset copy that ships to a client-facing
+surface. It is scoped to this ONE known historical collision — a dataset-wide
+"no MICE/Venue anywhere" rule would false-positive on 68124 ("Penyewaan Tempat
+Penyelenggaraan ... MICE ...") and 82300 ("Penyelenggaraan Konvensi dan Pameran
+Bisnis"), which legitimately are MICE/venue/convention codes (verified 2026-07-16 —
+do not generalize this guard to those records).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CODE = "68112"
+CONTAMINATION_MARKERS = ("MICE", "Venue")
+
+# Every SERVED/canonical copy that must stay clean. Gitignored RAG runtime copies
+# are materialized by scripts/sync_kbli_dataset.sh at build time and may be absent
+# on a fresh checkout/CI runner — skipped if missing, same convention as that script.
+DATASET_PATHS = [
+    REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json",  # production, balizero.com/kbli
+    REPO_ROOT / "data/source_documents/KBLI_2025_FINAL_CLEAN.json",  # tracked fallback / canonical (via source_documents/ symlink)
+    REPO_ROOT / "apps/backend-rag/backend/data/KBLI_2025_FINAL_CLEAN.json",  # gitignored, RAG runtime
+]
+
+
+def _load_record(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    for rec in data["data"]:
+        if rec.get("kode_kbli_2025") == CODE:
+            return rec
+    raise AssertionError(f"{path}: record {CODE} not found in dataset")
+
+
+def _existing_paths():
+    return [p for p in DATASET_PATHS if p.exists()]
+
+
+@pytest.mark.parametrize(
+    "path", _existing_paths(), ids=[str(p.relative_to(REPO_ROOT)) for p in _existing_paths()]
+)
+def test_68112_per_skala_has_no_mice_venue_contamination(path: Path):
+    rec = _load_record(path)
+    per_skala_blob = json.dumps(rec.get("per_skala") or [], ensure_ascii=False)
+    for marker in CONTAMINATION_MARKERS:
+        assert marker not in per_skala_blob, (
+            f"{path}: 68112 per_skala still contains {marker!r} — the PP28 "
+            "MICE-venue licensing (Lampiran I.L, p.I.L.44) has leaked back into "
+            "the residential-leasing code (BPS Peraturan 7/2025). Move it to "
+            "per_skala_disputed_pp28_mice instead of shipping it as this code's "
+            "own licensing."
+        )
+
+
+def test_68112_disputed_mice_block_preserved_for_audit():
+    """The removed block must be KEPT (not silently deleted) for audit."""
+    rec = _load_record(REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json")
+    disputed = rec.get("per_skala_disputed_pp28_mice")
+    assert disputed, (
+        "68112 must retain the original PP28-MICE per_skala under "
+        "per_skala_disputed_pp28_mice for audit — it should never be silently deleted."
+    )
+    blob = json.dumps(disputed, ensure_ascii=False)
+    assert any(marker in blob for marker in CONTAMINATION_MARKERS), (
+        "per_skala_disputed_pp28_mice should still contain the MICE/Venue text it "
+        "was moved to preserve — if this trips, the audit trail itself was edited."
+    )
+
+
+def test_68112_has_advisory_data_note():
+    rec = _load_record(REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json")
+    note = rec.get("_data_note", "")
+    assert "68111" in note, "advisory note should point to the nearest residential NSPK reference (68111)"
+    assert "no_oss_risk" not in note  # note is prose, not a field-name echo
+    assert "OSS" in note and "404" in note, "advisory note should explain the OSS 404 (no published NSPK yet)"
+
+
+def test_68112_other_mice_codes_untouched():
+    """Sanity/innocence guard: 68124 and 82300 legitimately mention MICE/Venue in
+    their own per_skala (verified 2026-07-16) — this fix must not have touched them."""
+    data = json.loads(
+        (REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json").read_text(encoding="utf-8")
+    )
+    by_code = {r["kode_kbli_2025"]: r for r in data["data"]}
+    for code in ("68124", "82300"):
+        rec = by_code.get(code)
+        if rec is None:
+            continue
+        blob = json.dumps(rec.get("per_skala") or [], ensure_ascii=False)
+        assert any(m in blob for m in CONTAMINATION_MARKERS), (
+            f"{code} unexpectedly lost its legitimate MICE/Venue per_skala text — "
+            "this guard is scoped to 68112 only, do not touch this record."
+        )

--- a/scripts/tests/test_kbli_68112_pp28_mice_collision.py
+++ b/scripts/tests/test_kbli_68112_pp28_mice_collision.py
@@ -30,6 +30,15 @@ surface. It is scoped to this ONE known historical collision — a dataset-wide
 Penyelenggaraan ... MICE ...") and 82300 ("Penyelenggaraan Konvensi dan Pameran
 Bisnis"), which legitimately are MICE/venue/convention codes (verified 2026-07-16 —
 do not generalize this guard to those records).
+
+Follow-up (2026-07-16, same PR): the contamination had ALSO leaked into
+`intel_2026.whatYouNeed` ("Self-Assessment document covering MICE venue
+standards..."), a field the first pass of this fix did not touch. That field
+has now been replaced verbatim. `test_68112_record_has_no_mice_venue_outside_audit_key`
+is the whole-record guard added for this: it scans the ENTIRE 68112 record
+(every field) for "MICE"/"Venue", excluding only the intentional audit key
+`per_skala_disputed_pp28_mice` — so no other field (present or future) can
+carry the collision back in unnoticed.
 """
 
 from __future__ import annotations
@@ -102,6 +111,64 @@ def test_68112_has_advisory_data_note():
     assert "68111" in note, "advisory note should point to the nearest residential NSPK reference (68111)"
     assert "no_oss_risk" not in note  # note is prose, not a field-name echo
     assert "OSS" in note and "404" in note, "advisory note should explain the OSS 404 (no published NSPK yet)"
+
+
+AUDIT_KEY = "per_skala_disputed_pp28_mice"
+
+# A leaf string OUTSIDE the audit key is allowed to name "MICE"/"Venue" ONLY when
+# it is DISCLAIMING the collision (explaining that this MICE-venue text belonged
+# to a different activity and does not apply to 68112's residential leasing) —
+# never when it ASSERTS the MICE licensing as this code's own requirement (that
+# was the original bug: the old intel_2026.whatYouNeed named "MICE venue
+# standards" as part of 68112's OWN obligations, with no disclaiming language
+# anywhere in the field). "code-number collision" is the phrase both legitimate
+# disclaimers (_data_note and the corrected whatYouNeed) share verbatim, and is
+# absent from the original contaminated text — entity/intent match, not a bare
+# substring, per this repo's scar-family #3 guard discipline (guilt+innocence,
+# never over-match on the mere presence of "MICE").
+DISCLAIMER_MARKER = "code-number collision"
+
+
+def _iter_leaf_strings(obj, path=""):
+    """Yield (path, value) for every string leaf in a nested dict/list structure."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            yield from _iter_leaf_strings(v, f"{path}.{k}" if path else k)
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            yield from _iter_leaf_strings(v, f"{path}[{i}]")
+    elif isinstance(obj, str):
+        yield path, obj
+
+
+@pytest.mark.parametrize(
+    "path", _existing_paths(), ids=[str(p.relative_to(REPO_ROOT)) for p in _existing_paths()]
+)
+def test_68112_record_has_no_mice_venue_outside_audit_key(path: Path):
+    """Whole-record guard: no field of 68112 — intel_2026, l4_bali, pma_*, etc. —
+    may ASSERT the MICE-venue licensing as applicable, anywhere in the record,
+    EXCEPT the intentional audit key `per_skala_disputed_pp28_mice` (excluded
+    entirely — it exists precisely to preserve the original PP28 block verbatim).
+
+    A field outside the audit key MAY still name "MICE"/"Venue" if — and only
+    if — it is disclaiming the collision (contains DISCLAIMER_MARKER): this is
+    legitimate explanatory prose (`_data_note`, `intel_2026.whatYouNeed`), not
+    a resurgence of the bug. Any occurrence WITHOUT the disclaimer marker in the
+    same field fails — this is what catches contamination anywhere in the
+    record, not just per_skala (the shape of the intel_2026.whatYouNeed leak
+    the first pass of this fix missed).
+    """
+    rec = _load_record(path)
+    rec_without_audit_key = {k: v for k, v in rec.items() if k != AUDIT_KEY}
+    for field_path, value in _iter_leaf_strings(rec_without_audit_key):
+        if any(marker in value for marker in CONTAMINATION_MARKERS):
+            assert DISCLAIMER_MARKER in value.lower(), (
+                f"{path}: 68112.{field_path} contains MICE/Venue text with no "
+                f"{DISCLAIMER_MARKER!r} disclaimer in the same field — looks "
+                "like the PP28 MICE-venue licensing is being ASSERTED as this "
+                "code's own requirement again, not disclaimed as the collision "
+                "it is. Field value: " + value[:200]
+            )
 
 
 def test_68112_other_mice_codes_untouched():


### PR DESCRIPTION
## The collision (verified facts — image-verified 3x against official PDFs, not re-derived here)

KBLI code **68112** is a code-NUMBER collision between two 2025 regulations:

- **BPS Peraturan 7/2025 (KBLI 2025, current — what OSS uses today)**: 68112 = *"Aktivitas Penyewaan Bangunan dan Lahan Hunian Milik Sendiri atau Sewa"* (residential leasing). The dataset's `judul`/`uraian` for this code are already correct.
- **PP 28/2025 (June 2025, numbered on the OLD KBLI 2020)**: 68112 = *"Penyewaan Venue Penyelenggaraan Aktifitas MICE dan Event Khusus"* (Lampiran I.L, Sektor Pariwisata, p.I.L.44 row 25) — a completely different business activity that happens to share the same 5-digit number under the old numbering.
- OSS RBA `ruang-lingkup` for the new residential 68112 returns **404** — no risk-based NSPK has been published yet for this new code (`_l2_status: "no_oss_risk"` on the record, which is exactly why the old fallback pulled in the wrong PP28-MICE licensing).
- There is **no** residential-leasing 68112 anywhere in PP 28/2025. The residential activity in PP28 is coded **68111** (Lampiran I.H, Sektor PUPR; authority Bupati/Walikota; NIB + Sertifikat Standar).

The served datasets therefore had the *correct* residential title but the *wrong* licensing: `per_skala.kewajiban` literally named "Penyewaan Venue Penyelenggra aan Aktifitas MICE" and "LSPr (khusus PMA)" — the MICE-venue obligations, not residential ones.

## The fix

For the 68112 record:
- `per_skala` → `[]` (honest — we have no OSS ground truth for the new code; the frontend already guards `licensing.length > 0` so this renders no license table instead of a wrong one).
- The original PP28-MICE block is **preserved, not deleted**, under a new key `per_skala_disputed_pp28_mice` (audit trail).
- Added `_data_note` (verbatim, per the pre-verified fact-brief) explaining the collision and pointing to the nearest residential reference (68111).
- `judul`/`uraian`/`pma_*`/`l4_bali`/`_l2_status` etc. are **untouched** — only `per_skala` was replaced and the two new keys added.

## Files changed

- `source_documents/KBLI_2025_FINAL_CLEAN.json` — canonical (this is a tracked **symlink** to `data/source_documents/KBLI_2025_FINAL_CLEAN.json`, the physical file that git actually diffs)
- `data/source_documents/KBLI_2025_FINAL_CLEAN.json` — same physical file as above
- `apps/mouth/data/KBLI_2025_FINAL_CLEAN.json` — production copy (balizero.com/kbli), propagated via `scripts/sync_kbli_dataset.sh` and verified byte-identical to canonical (`--check` passes)
- `apps/mouth/data/kbli-dataset-version.json` — sha256 sidecar bumped (`27a18d48…` → `2336d47e…`, `lastModified` → 2026-07-16) so the existing vitest guard (`kbli-dataset-version.test.ts`) doesn't fail
- `scripts/tests/test_kbli_68112_pp28_mice_collision.py` (new) — regression tripwire
- `.github/workflows/kbli-68112-collision-regression.yml` (new) — path-scoped, non-required CI job running that test

**Deliberately NOT touched**: `apps/kbli-navigator` — per its own README ("NOT the production app... Do not fix production bugs here"), it's a design sandbox whose data file (`data/kbli-2025.json`) is gitignored and not present in a fresh checkout; it falls back to a path that doesn't resolve in this repo layout. Production is `apps/mouth`.

## Verification performed

- `python -m json.tool` on the edited canonical file — valid JSON.
- **Zero collateral change**: 1559/1559 records total; sha256(sort_keys) of all 1558 non-68112 records combined, and of `metadata`, are byte-identical before/after.
- `bash scripts/sync_kbli_dataset.sh --check` — all 4 tracked+gitignored consumers in sync with canonical.
- `python3 scripts/kbli_dataset_lint.py` — 0 blocking findings (68112 now shows only the informational, non-blocking `L7 per-skala-empty`, expected for a special-regime/no-ground-truth code).
- `python3 -m pytest scripts/tests/test_kbli_dataset_lint_guards.py -q` — 30 passed (no regression to the existing guard suite).
- New regression test: 6/6 passed **after** the fix; independently confirmed the same assertion (`"MICE"/"Venue" not in per_skala`) would have **failed** against the pre-fix dataset (checked via `git show HEAD:...` of the previous commit).

## intel_2026 contamination found but NOT edited (flagging for review, per task scope)

`intel_2026.whatYouNeed` for 68112 also transcribes the MICE licensing prose: *"PMA businesses need an LSPr-certified standard. Self-Assessment document covering MICE venue standards (facilities, organization, HR) is referenced in the obligations."* This is downstream of the same root contamination but is investor-facing editorial prose, not a data field — out of scope for this data-correctness fix. Recommend a follow-up prose-patch (via `scripts/kbli_apply_wave_patches.py`, which already allow-lists `intel_2026.whatYouNeed` as a patchable field) once a residential replacement paragraph is drafted. `l4_bali` and `intel_2026.editorial.*` for 68112 were checked and are clean (no MICE/Venue mentions).

Sanity-checked: two OTHER codes legitimately mention MICE/Venue in their own `per_skala` — **68124** ("Penyewaan Tempat Penyelenggaraan Aktivitas Pertemuan, Perjalanan Insentif, Konvensi, dan Pameran, serta Acara Khusus") and **82300** ("Penyelenggaraan Konvensi dan Pameran Bisnis"). These are correctly MICE-related codes under the 2025 numbering and were intentionally left untouched — the regression test includes an explicit innocence check (`test_68112_other_mice_codes_untouched`) so a future overly-broad "no MICE anywhere" guard doesn't false-positive on them.

## Durability against rebuild (checked, no override registry added — none needed)

Reviewed the 3 named rebuild/patch scripts:
- `scripts/kbli_apply_wave_patches.py` — `ALLOWED_FIELDS` only covers `l4_bali.reason` + `intel_2026.*` prose fields; it structurally cannot touch `per_skala`.
- `scripts/kbli_audit_patcher.py` — explicitly documented "Never touch KBLI_2025_FINAL_CLEAN.json or per_skala data."
- `scripts/build_kbli_l2_oss_risk.py` — a manual, `--apply`-gated audit tool that operates on a `/tmp` staging copy, not the live repo files directly. For `_l2_status: "no_oss_risk"` codes it "keeps the old per_skala" — but since canonical's `per_skala` for 68112 is now honestly `[]` (the MICE data lives only under the new `per_skala_disputed_pp28_mice` key, which this script doesn't read), any future re-run naturally preserves the honest empty state rather than resurrecting the MICE block. No separate override/exception registry exists in this codebase for KBLI per_skala, and none was needed here — the fix's own data shape is self-durable against all three scripts.

## Follow-ups (not done in this PR — flagging per instructions)

1. `intel_2026.whatYouNeed` prose patch for 68112 (see above).
2. Native macOS KBLI Navigator app (`~/Desktop/kbli-navigator-app`, outside this repo) is now out of sync with canonical — running `scripts/sync_kbli_dataset.sh` printed the standard fleet-notice pointing to its own `deploy/install-3mac.sh` / `make-team-installer.sh` / `check-fleet.sh`. Operator action, outside this repo's git history.

## Not armed for auto-merge

This is a client-facing data-correctness fix — leaving for manual review per instructions, not arming `--auto`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>