### PR TITLE
chore(codeowners): map the RAG data-invariant paths (documentation, not armed)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,6 +80,25 @@
 /apps/backend-rag/backend/services/billing/          @Balizero1987
 
 # ---------------------------------------------------------------------------
+# RAG data-invariants — TIER 1 (silent-corruption class)
+# Added 2026-07-16. These are the paths where a plausible-but-wrong change
+# passes every test and CI-green while silently corrupting: the exact class
+# an independent review is WEAKEST at catching, so it gets an owner gate.
+# Rationale = CLAUDE.md §9 Data Invariants:
+#   - embeddings.py: model text-embedding-3-small is FROZEN (1536 dims) —
+#     changing it invalidates 93,283 vectors with no test failure.
+#   - agentic/: the 5 named abstain gates (reasoning.py generation gate,
+#     _abstain_policy.py SSOT, orchestrator_response.py label gate). A tweak
+#     here = tax advice at 0.11 evidence, a safety regression that's green.
+#   - kb/: curated knowledge base — "NEVER auto-promote" (CLAUDE.md §15).
+#   - lead_capture/: the LeadSource enum contract that 422'd the homepage CTA
+#     for 10 days (2026-07-16) when it drifted from the frontend.
+/apps/backend-rag/backend/core/embeddings.py         @Balizero1987
+/apps/backend-rag/backend/services/rag/agentic/      @Balizero1987
+/apps/backend-rag/backend/kb/                         @Balizero1987
+/apps/backend-rag/backend/services/lead_capture/     @Balizero1987
+
+# ---------------------------------------------------------------------------
 # Subhi lane (write access, owner co-review per SYMBIOSIS protocol)
 # Perimeter ref: CLAUDE.md §13 + memory reference_bali_zero_team.md
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds the RAG data-invariant paths (embedding model FROZEN, abstain gates, curated kb/, lead_capture enum) to CODEOWNERS → @Balizero1987.

**This is a map, not a gate.** main has no required review block (`require_code_owner_reviews: false`), so the whole 108-line CODEOWNERS governs nothing today — this addition included. It marks which backend paths are silent-corruption-class so the ownership is documented if review is ever armed.

Per 2026-07-16 decision: the owner does not do code review, so this file will NOT be armed as a human-review gate (that would be a gate no one can open). The real protection for these paths is CI tripwire tests (separate PR), not human review. Kept as documentation of sensitivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)