### PR TITLE
fix(mouth): stale PT PMA paid-up capital claim (IDR 10bn) in spouse work-rights guide — EN/ID/IT

### DIFF
--- a/apps/mouth/src/content/_regulatory-claim-ledger.json
+++ b/apps/mouth/src/content/_regulatory-claim-ledger.json
@@ -69,6 +69,14 @@
       "severity": "P0"
     },
     {
+      "id": "CAPITAL-PAIDUP-10B-MINIMUM-PHRASE",
+      "domain": "company",
+      "stale_pattern": "Minimum paid-up capital IDR 10 billion",
+      "current_fact": "Minimum paid-up capital for a PT PMA is IDR 2.5 billion (Pasal 26(10) Permen BKPM 5/2025, 12-month lock-in); minimum TOTAL investment is >IDR 10 billion per 5-digit KBLI per location (Pasal 26(2)) — two separate figures. Variant phrasing of CAPITAL-PAIDUP-10B: the colon-form pattern missed this wording (spouse-dependent-work-rights regression, 2026-07-16).",
+      "source": "Permen Investasi/BKPM 5/2025 Pasal 26(10): 'modal ditempatkan/disetor paling sedikit Rp2.500.000.000,00 per perseroan terbatas'; Pasal 26(2): 'total investasi lebih besar dari Rp10.000.000.000,00 ... per bidang usaha KBLI 5 digit per lokasi'",
+      "severity": "P0"
+    },
+    {
       "id": "RETIRE-NO-SPONSOR-SINGLE",
       "domain": "visa",
       "stale_pattern": "Min. USD 1,500/month income evidence",

--- a/apps/mouth/src/content/articles/immigration/spouse-dependent-work-rights.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/spouse-dependent-work-rights.id.mdx
@@ -192,7 +192,7 @@ Sebelum hal lain, identifikasi kode KBLI (Klasifikasi Baku Lapangan Usaha Indone
 Untuk menjalankan bisnis legal apa pun di Indonesia, Anda memerlukan PT PMA (Perseroan Terbatas Penanaman Modal Asing). Persyaratan:
 
 - Minimal 2 pemegang saham (dapat mencakup perusahaan pasangan Anda yang sudah ada)
-- Modal disetor minimal Rp 10 miliar (meskipun penegakannya bervariasi berdasarkan sektor)
+- Rencana investasi total di atas Rp 10 miliar per KBLI/lokasi; modal disetor minimal Rp 2,5 miliar (Peraturan BKPM 5/2025)
 - Direktur yang ditunjuk (ini akan menjadi pasangan)
 - Alamat terdaftar di Indonesia
 - NIB (Nomor Induk Berusaha) melalui OSS

--- a/apps/mouth/src/content/articles/immigration/spouse-dependent-work-rights.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/spouse-dependent-work-rights.it.mdx
@@ -192,7 +192,7 @@ Prima di tutto, identifica i codici KBLI (Classificazione delle Attività Econom
 Per gestire qualsiasi attività legale in Indonesia, hai bisogno di una PT PMA (Perseroan Terbatas Penanaman Modal Asing). Requisiti:
 
 - Almeno 2 azionisti (può includere la società esistente del coniuge)
-- Capitale versato minimo di 10 miliardi di IDR (sebbene l'applicazione vari in base al settore)
+- Piano di investimento totale superiore a 10 miliardi di IDR per KBLI/località; capitale versato minimo di 2,5 miliardi di IDR (Regolamento BKPM 5/2025)
 - Direttore nominato (sarà il coniuge)
 - Indirizzo registrato in Indonesia
 - NIB (numero di identificazione aziendale) tramite OSS

--- a/apps/mouth/src/content/articles/immigration/spouse-dependent-work-rights.mdx
+++ b/apps/mouth/src/content/articles/immigration/spouse-dependent-work-rights.mdx
@@ -191,7 +191,7 @@ Before anything else, identify the right KBLI (Indonesian Business Classificatio
 To run any legal business in Indonesia, you need a PT PMA (Perseroan Terbatas Penanaman Modal Asing). Requirements:
 
 - Minimum 2 shareholders (can include your spouse's existing company)
-- Minimum paid-up capital IDR 10 billion (though enforcement varies by sector)
+- Total investment plan above IDR 10 billion per KBLI/location; minimum paid-up capital IDR 2.5 billion (BKPM Regulation 5/2025)
 - Appointed Director (this will be the spouse)
 - Registered address in Indonesia
 - NIB (business identification number) via OSS


### PR DESCRIPTION
## Summary
- Permen Investasi/BKPM 5/2025 (in force 2025-10-02, revokes BKPM 4/2021) sets the PT PMA minimum paid-up capital at IDR 2.5 billion (Pasal 26(10)); the >IDR 10 billion figure is the TOTAL investment per 5-digit KBLI per location (Pasal 26(2)). Confirmed by Zero 2026-07-16. The spouse-dependent-work-rights guide still asserted "Minimum paid-up capital IDR 10 billion" as current fact in EN, ID and IT (FR/RU variants don't carry the section) — fixed to the dual-figure claim with the 5/2025 citation.
- Adds ledger claim `CAPITAL-PAIDUP-10B-MINIMUM-PHRASE` to `_regulatory-claim-ledger.json`: the existing colon-form stale_pattern ("Paid-up Capital: IDR 10 billion") did not match this phrasing, so the content-freshness sentinel stayed green over a stale claim (W82 phrasing-variant gap). New pattern proven: exactly 1 guilty hit pre-fix, 0 innocent hits across EN canonical content, sentinel suite 16/16 green post-fix.
- Deliberately out of scope (flagged for domain adjudication): investor-KITAS/E28A tables where IDR 10bn is the still-valid immigration shareholding threshold; the "per shareholder" vs "per perseroan terbatas" phrasing divergence in two capital guides; extending the sentinel to translated content (structural W82).

## Test plan
- [x] `npx vitest run src/content/content-freshness-sentinel.test.ts` — 16/16 green (includes the new claim's test)
- [x] Ledger JSON validated (15 claims)
- [x] Full backend pytest suite green via pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)