### PR TITLE
ci(gate): actionlint schema+expression gate + fix pull_request_target injection

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,61 @@
+name: actionlint
+
+# Schema + expression gate for GitHub Actions workflow files.
+#
+# Born 2026-07-16: the ai-pr-review.yml advisory Action (#2533) merged green but
+# NEVER RAN — a literal empty `${EXPR}` inside a run: comment startup-failed it on
+# every push (GitHub scans run: bodies for expressions before the shell ever sees
+# the '#'). Nothing in CI caught it: a startup-failing workflow is non-required, so
+# it stays green-because-invisible (scar #2, exists != armed). This gate turns that
+# whole class into a hard, REQUIRED failure — actionlint validates workflow schema +
+# every `${{ }}` expression, and flags untrusted-input interpolation (the
+# pull_request_target + head.ref injection class fixed in the same PR).
+#
+# NO `paths:` filter — this is meant to be a REQUIRED check. A path-filtered required
+# check never reports on PRs outside its paths and leaves them stuck at
+# "Expected — waiting for status" forever (same reasoning as adversarial-review-gate.yml).
+# actionlint on a clean corpus is ~2s, so running on every PR blocks nothing innocent.
+#
+# actionlint is pinned by VERSION AND SHA256 — a compromised release cannot inject.
+# `-shellcheck=` keeps the gate to schema + expressions (the class that caused real
+# incidents); shell-style is out of scope (the corpus is not shellcheck-clean, and
+# that is a separate, noisier tightening for later).
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: actionlint — workflow schema + expression gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      ACTIONLINT_VERSION: "1.7.12"
+      ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download actionlint (pinned version + sha256)
+        run: |
+          set -euo pipefail
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL "$url" -o actionlint.tgz
+          echo "${ACTIONLINT_SHA256}  actionlint.tgz" | sha256sum -c -
+          tar xzf actionlint.tgz actionlint
+          chmod +x actionlint
+
+      - name: Lint all workflow files
+        run: |
+          set -euo pipefail
+          # No file args → actionlint auto-discovers .github/workflows/*.yml.
+          # -shellcheck= disables the shellcheck pass (pre-installed on the runner,
+          # would flood on shell style); we gate schema + expression syntax +
+          # untrusted-input use, which is the class that startup-fails or injects.
+          ./actionlint -color -shellcheck=

--- a/.github/workflows/auto-merge-whitelist.yml
+++ b/.github/workflows/auto-merge-whitelist.yml
@@ -45,22 +45,32 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Untrusted webhook fields go via env, NEVER interpolated into the script.
+          # head.ref / user.login are attacker-controlled and this job runs as
+          # pull_request_target with a write token — a branch named `";evil;"` would
+          # otherwise inject shell (GHSA workflow-injection class; actionlint [expression]).
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          CHECK_SUITE_ID: ${{ github.event.check_suite.id }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            echo "number=${{ github.event.pull_request.number }}"   >> "$GITHUB_OUTPUT"
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
-            echo "author=${{ github.event.pull_request.user.login }}" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+            echo "number=$PR_NUMBER"  >> "$GITHUB_OUTPUT"
+            echo "branch=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
+            echo "author=$PR_AUTHOR"   >> "$GITHUB_OUTPUT"
           else
             # check_suite: pick the PR(s) associated with the suite
-            PR_NUM="$(gh api repos/${{ github.repository }}/check-suites/${{ github.event.check_suite.id }}/pulls --jq '.[0].number' 2>/dev/null || echo '')"
+            PR_NUM="$(gh api "repos/$REPO/check-suites/$CHECK_SUITE_ID/pulls" --jq '.[0].number' 2>/dev/null || echo '')"
             if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
-              echo "No PR linked to check_suite ${{ github.event.check_suite.id }} — skipping."
+              echo "No PR linked to check_suite $CHECK_SUITE_ID — skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            BRANCH="$(gh pr view "$PR_NUM" --repo ${{ github.repository }} --json headRefName --jq '.headRefName')"
-            AUTHOR="$(gh pr view "$PR_NUM" --repo ${{ github.repository }} --json author --jq '.author.login')"
+            BRANCH="$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefName --jq '.headRefName')"
+            AUTHOR="$(gh pr view "$PR_NUM" --repo "$REPO" --json author --jq '.author.login')"
             echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
             echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
             echo "author=$AUTHOR" >> "$GITHUB_OUTPUT"
@@ -69,8 +79,9 @@ jobs:
       - name: Check branch whitelist
         id: branch_check
         if: steps.pr.outputs.skip != 'true'
+        env:
+          BRANCH: ${{ steps.pr.outputs.branch }} # carries the attacker-controlled ref → env, not inline
         run: |
-          BRANCH='${{ steps.pr.outputs.branch }}'
           if [[ "$BRANCH" =~ ^docs/auto-sync- ]]              || \
              [[ "$BRANCH" =~ ^dependabot/(pip|npm_and_yarn)/ ]] || \
              [[ "$BRANCH" =~ ^chore/fmt- ]]; then
@@ -84,8 +95,9 @@ jobs:
       - name: Check author allowlist
         id: author_check
         if: steps.branch_check.outputs.match == 'true'
+        env:
+          AUTHOR: ${{ steps.pr.outputs.author }} # attacker-controlled login → env, not inline
         run: |
-          AUTHOR='${{ steps.pr.outputs.author }}'
           case "$AUTHOR" in
             dependabot|dependabot[bot]|github-actions|github-actions[bot]|Balizero1987)
               echo "Author '$AUTHOR' is allowlisted."


### PR DESCRIPTION
## Context

Surfaced while proving the Layer-2 advisory AI-review Action (#2533) live. It had **merged green but never actually run**: an empty `${EXPR}` in a `run:` comment startup-failed it on every push (GitHub scans `run:` bodies for expressions *before* the shell sees the `#`). Nothing in CI caught it — a startup-failing workflow is non-required, so it is **green-because-invisible** (scar #2, exists≠armed). The empty-expr itself was fixed in #2537; this PR closes the whole class.

## What

**1. `fix(security)` — auto-merge-whitelist injection.** `actionlint` flagged a second, unrelated finding: `auto-merge-whitelist.yml` runs as `pull_request_target` with a **write token** and interpolated `github.event.pull_request.head.ref` (attacker-controlled branch name) directly into a `run:` script. A branch named `` `";evil;"` `` would inject shell in a privileged context (GHSA workflow-injection class). Fix: every `github.event.*` and attacker-controlled step-output now goes through `env:` and is referenced as a quoted `$VAR`. No behaviour change.

**2. `ci(gate)` — actionlint.** New required-intent gate that validates workflow **schema + every `${{ }}` expression + untrusted-input use** on every PR.
- Pinned by **version AND sha256** (`1.7.12` / `8aca8db9…`) — a compromised release can't inject.
- **No `paths:` filter** so it can be a REQUIRED check without the path-skip trap (a path-filtered required check stalls PRs outside its paths forever — same reasoning as `adversarial-review-gate.yml`).
- `-shellcheck=` scopes it to schema+expressions (the class that caused the incidents); shell-style is a separate, noisier tightening.

Corpus is **actionlint-clean** as of this PR (local self-lint `RC=0`, including the gate linting itself).

## After merge

Add `actionlint — workflow schema + expression gate` to branch protection as a **required** check (done at green-on-main, so no PR is blocked by a required check that doesn't exist yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)