### PR TITLE
fix(wr2-app): complete-or-nothing gallery gate + fail-closed publish guard

### DIFF
--- a/apps/wr2-control-app/Sources/AppState.swift
+++ b/apps/wr2-control-app/Sources/AppState.swift
@@ -17,6 +17,10 @@ final class AppState: ObservableObject {
     @Published var carousels: [Carousel] = []
     @Published var queue: [ReviewItem] = []
     @Published var lastRefresh: Date?
+    /// Dirs the A2 complete-or-nothing gate excluded on the last refresh (drafted/
+    /// unpublished carousels whose disk PNG count didn't match their declared count).
+    /// Surfaced in GalleryView so the exclusion stays observable, not silent (scar #2).
+    @Published var excludedIncompleteCount: Int = 0
 
     /// slug → live/just-finished run, rebuilt every refresh from TWO signals:
     /// the on-disk `.run.json` marker AND a `ps` scan (catches orphan/legacy runs
@@ -720,6 +724,7 @@ final class AppState: ObservableObject {
         let c = WarRoom.scanCarousels(queue: q)
         self.queue = q
         self.carousels = c
+        self.excludedIncompleteCount = WarRoom.excludedIncompleteCount
         self.liveRuns = Self.detectLiveRuns(carousels: c)
         self.lastRefresh = Date()
     }

--- a/apps/wr2-control-app/Sources/Localization.swift
+++ b/apps/wr2-control-app/Sources/Localization.swift
@@ -120,6 +120,7 @@ enum L10n {
         // gallery
         "gallery.title":    [.it: "Caroselli",             .id: "Karosel"],
         "gallery.count":    [.it: "caroselli generati",    .id: "karosel dibuat"],
+        "gallery.incompleteHidden": [.it: "nascosti (slide incomplete)", .id: "disembunyikan (slide belum lengkap)"],
         "gallery.refresh":  [.it: "Aggiorna",              .id: "Segarkan"],
         "gallery.empty":    [.it: "Nessun carosello ancora", .id: "Belum ada karosel"],
         "gallery.empty.sub":[.it: "Creane uno dallo Studio", .id: "Buat satu dari Studio"],

--- a/apps/wr2-control-app/Sources/Localization.swift
+++ b/apps/wr2-control-app/Sources/Localization.swift
@@ -155,6 +155,7 @@ enum L10n {
         "detail.notPublished": [.it: "Non ancora pubblicato",                           .id: "Belum diterbitkan"],
         "detail.awaiting":     [.it: "Pubblicato — in attesa di misurazione (~24h)",    .id: "Terbit — menunggu pengukuran (~24 jam)"],
         "detail.markPublished":[.it: "Segna come pubblicato",                           .id: "Tandai sudah terbit"],
+        "detail.notPublishEligible":[.it: "Non pubblicabile — stato non pronto",        .id: "Belum bisa diterbitkan — status belum siap"],
         "detail.openDesign":   [.it: "Apri in Zero Design",                             .id: "Buka di Zero Design"],
         "detail.revise":       [.it: "Migliora",                                        .id: "Perbaiki"],
         "detail.rerender":     [.it: "Ri-renderizza",                                   .id: "Render ulang"],

--- a/apps/wr2-control-app/Sources/Models.swift
+++ b/apps/wr2-control-app/Sources/Models.swift
@@ -155,6 +155,19 @@ struct Carousel: Identifiable, Equatable {
     var instagramURL: String?         // Instagram post URL
     var publishedAt: String?          // ISO date of publication
     var canvaURL: String?             // Zero Design / Canva edit url (for waitlist work)
+    /// The queue item's RAW, current `state` field — deliberately kept SEPARATE from
+    /// `criticVerdict` (which is `critic_overall_verdict ?? state`, verdict-first).
+    /// Cross-finding with the Python A3 daily-reconciler (2026-07-16): that reconciler
+    /// can flip a queue entry's `state` to `render_incomplete` independently of any
+    /// earlier critic verdict, when a post-render disk-level drift makes a previously
+    /// "pass"-verdicted carousel no longer match its declared slide count. If phase/
+    /// publish-eligibility were computed from `criticVerdict` (verdict-first), a stale
+    /// `critic_overall_verdict: "pass"` would mask the fresh `render_incomplete` state
+    /// and both the gallery band and the publish button would keep showing "ready" for
+    /// a carousel that no longer is. `state` here is `nil` only for legacy-schema queue
+    /// rows that never carried a `state` field at all (`effectiveStatus` falls back to
+    /// `criticVerdict` in that case only).
+    var state: String?
 
     /// Mirrors `isQueueItemPublished(_:)` below, applied to this struct's already-
     /// flattened fields (a Carousel doesn't retain the raw ReviewItem it was joined
@@ -180,9 +193,30 @@ struct Carousel: Identifiable, Equatable {
         }
     }
 
-    /// Lifecycle phase, derived from publication + the queue state/verdict.
+    /// The effective lifecycle status for phase/publish-eligibility decisions: raw
+    /// `state` when present (the freshest signal — see the doc comment on `state`
+    /// above), falling back to `criticVerdict` only for legacy-schema rows that never
+    /// carried a `state` field. Deliberately NOT the same precedence as `criticVerdict`
+    /// itself, which stays verdict-first because it feeds a DIFFERENT feature (the
+    /// pass/soft_fail critic-verdict badge in the detail view) that must keep showing
+    /// the critic's judgement, not the lifecycle state.
+    private var effectiveStatus: String? { state ?? criticVerdict }
+
+    /// Lifecycle phase, derived from publication + the queue's effective status.
     /// Drives the gallery band colour: published=green, waitlist=blue, review=yellow, rejected=red.
-    var phase: CarouselPhase { CarouselPhase.of(state: criticVerdict, isPublished: isPublished) }
+    var phase: CarouselPhase { CarouselPhase.of(state: effectiveStatus, isPublished: isPublished) }
+
+    /// Safe to offer a FRESH publish action (Mark-published or a real Instagram
+    /// publish) right now. Reuses `CarouselPhase` — the SAME classification the
+    /// gallery band already uses — rather than a second, independently-maintained
+    /// state allow-list (scar #3: two guards judging the same fact drift apart). Only
+    /// `.waitlist` ("finished, awaiting publish" — e.g. `drafted`/`rendered`/`approved`)
+    /// is eligible; `.review` (in-flight, stalled, `render_incomplete`, or any
+    /// unrecognized future status — the existing fail-closed default) and `.rejected`
+    /// are not. Already-published entries use the separate, reversible undo-publish
+    /// flow, never this gate — `phase` already resolves to `.published` (never
+    /// `.waitlist`) whenever `isPublished` is true, so that case is covered for free.
+    var isPublishEligible: Bool { phase == .waitlist }
 }
 
 /// The visual lifecycle phase of a carousel, collapsing the full pipeline FSM
@@ -302,4 +336,17 @@ func isQueueItemPublished(_ item: ReviewItem) -> Bool {
     let state = (item.critic_overall_verdict ?? item.state ?? "")
         .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     return state == "published"
+}
+
+/// Raw-dict variant of `Carousel.isPublishEligible`, for `QueueWriter` — which mutates
+/// the queue JSON as a plain `[String: Any]` graph and deliberately never decodes
+/// through `ReviewItem` (the writer's whole design is to leave unknown fields
+/// untouched, scar #9 schema-drift). NOT a second, independently-maintained rule: it
+/// calls the exact same `CarouselPhase.of` classification `Carousel.isPublishEligible`
+/// does, with the same `state ?? criticVerdict` precedence (state wins when present —
+/// see the doc comment on `Carousel.state`). Cross-finding, 2026-07-16: without this,
+/// `QueueWriter.markPublished` would let ANY entry be published regardless of state —
+/// including one the Python A3 daily-reconciler just flagged `render_incomplete`.
+func isQueuePublishEligible(state: String?, criticVerdict: String?) -> Bool {
+    CarouselPhase.of(state: state ?? criticVerdict, isPublished: false) == .waitlist
 }

--- a/apps/wr2-control-app/Sources/Models.swift
+++ b/apps/wr2-control-app/Sources/Models.swift
@@ -155,7 +155,18 @@ struct Carousel: Identifiable, Equatable {
     var instagramURL: String?         // Instagram post URL
     var publishedAt: String?          // ISO date of publication
     var canvaURL: String?             // Zero Design / Canva edit url (for waitlist work)
-    var isPublished: Bool { instagramURL?.isEmpty == false }
+
+    /// Mirrors `isQueueItemPublished(_:)` below, applied to this struct's already-
+    /// flattened fields (a Carousel doesn't retain the raw ReviewItem it was joined
+    /// from). A trimmed non-empty `instagramURL` OR a trusted `criticVerdict=="published"`
+    /// (fed from `item.critic_overall_verdict ?? item.state` at join time) — never bare
+    /// presence of the URL key, which an empty string could satisfy (Codex red-team
+    /// finding #3, 2026-07-16).
+    var isPublished: Bool {
+        let urlNonEmpty = instagramURL?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        let trustedPublishedState = criticVerdict?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "published"
+        return urlNonEmpty || trustedPublishedState
+    }
 
     /// L10n key for the critic verdict (or the raw value if unknown). Kept Foundation-pure;
     /// the localized string lives in an extension in Localization.swift (SwiftUI side).
@@ -270,4 +281,25 @@ struct ReviewItem: Identifiable, Equatable, Decodable {
         return (s?.isEmpty == false) ? s : nil
     }
     var hasCanva: Bool { canvaLink != nil }
+}
+
+/// Canonical "is this genuinely published" predicate — the ONE rule shared by the A2
+/// completeness gate's exemption (WarRoom.scanCarousels), `Carousel.isPublished` above,
+/// and the queue's second-pass virtual-carousel materialization. Two conditions, either
+/// sufficient:
+///  - a trimmed non-empty `instagram_post_url` — an empty string (present but blank,
+///    not absent) must NEVER count, or an incomplete render could bypass the
+///    completeness gate just by carrying a stray blank field (Codex red-team finding
+///    #3, 2026-07-16, guilt direction);
+///  - a trusted `state`/`critic_overall_verdict` of exactly `"published"` — a legacy row
+///    that reached this state before its URL/timestamp were backfilled must still count,
+///    or it silently vanishes from the gallery (same finding, innocence direction).
+func isQueueItemPublished(_ item: ReviewItem) -> Bool {
+    if let url = item.instagram_post_url,
+       url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+        return true
+    }
+    let state = (item.critic_overall_verdict ?? item.state ?? "")
+        .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return state == "published"
 }

--- a/apps/wr2-control-app/Sources/Models.swift
+++ b/apps/wr2-control-app/Sources/Models.swift
@@ -171,14 +171,23 @@ struct Carousel: Identifiable, Equatable {
 
     /// Mirrors `isQueueItemPublished(_:)` below, applied to this struct's already-
     /// flattened fields (a Carousel doesn't retain the raw ReviewItem it was joined
-    /// from). A trimmed non-empty `instagramURL` OR a trusted `criticVerdict=="published"`
-    /// (fed from `item.critic_overall_verdict ?? item.state` at join time) — never bare
+    /// from). Published if EITHER: a trimmed non-empty `instagramURL`, OR `state`
+    /// trimmed+lowercased == "published", OR `criticVerdict` trimmed+lowercased ==
+    /// "published" — `state` and `criticVerdict` are checked INDEPENDENTLY, never
+    /// coalesced (`??`). Coalescing was the bug (2026-07-16 finding-3 corner, caught in
+    /// final-gate review): `criticVerdict` is ITSELF `critic_overall_verdict ?? state`
+    /// at join time, so a row with a non-nil verdict (e.g. an app-enqueued legacy
+    /// "pass", pre-#2442 fabricated) permanently hides `state` even after that row is
+    /// later marked `state: "published"` without a URL backfill — an independent
+    /// per-field OR check is required to catch it, matching the "state must not be
+    /// masked" spirit already applied to `phase`/`effectiveStatus` above. Never bare
     /// presence of the URL key, which an empty string could satisfy (Codex red-team
     /// finding #3, 2026-07-16).
     var isPublished: Bool {
         let urlNonEmpty = instagramURL?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-        let trustedPublishedState = criticVerdict?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "published"
-        return urlNonEmpty || trustedPublishedState
+        let normalizedState = (state ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedVerdict = (criticVerdict ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return urlNonEmpty || normalizedState == "published" || normalizedVerdict == "published"
     }
 
     /// L10n key for the critic verdict (or the raw value if unknown). Kept Foundation-pure;
@@ -319,23 +328,32 @@ struct ReviewItem: Identifiable, Equatable, Decodable {
 
 /// Canonical "is this genuinely published" predicate — the ONE rule shared by the A2
 /// completeness gate's exemption (WarRoom.scanCarousels), `Carousel.isPublished` above,
-/// and the queue's second-pass virtual-carousel materialization. Two conditions, either
-/// sufficient:
+/// and the queue's second-pass virtual-carousel materialization. Published if ANY of:
 ///  - a trimmed non-empty `instagram_post_url` — an empty string (present but blank,
 ///    not absent) must NEVER count, or an incomplete render could bypass the
 ///    completeness gate just by carrying a stray blank field (Codex red-team finding
 ///    #3, 2026-07-16, guilt direction);
-///  - a trusted `state`/`critic_overall_verdict` of exactly `"published"` — a legacy row
-///    that reached this state before its URL/timestamp were backfilled must still count,
+///  - `state` trimmed+lowercased == `"published"`;
+///  - `critic_overall_verdict` trimmed+lowercased == `"published"` — a legacy row that
+///    reached this verdict before its URL/timestamp were backfilled must still count,
 ///    or it silently vanishes from the gallery (same finding, innocence direction).
+/// `state` and `critic_overall_verdict` are checked INDEPENDENTLY, never coalesced
+/// (`?? `) — final-gate finding, 2026-07-16: the original coalesced form
+/// `(critic_overall_verdict ?? state)` let a non-nil verdict (e.g. an app-enqueued
+/// legacy "pass", pre-#2442 fabricated verdict) permanently hide `state` even after
+/// that row was later marked `state: "published"` — an app-side markPublished with no
+/// URL backfill would then read as UNPUBLISHED, and if the carousel were also
+/// disk-incomplete it would wrongly vanish from the gallery instead of being exempted.
 func isQueueItemPublished(_ item: ReviewItem) -> Bool {
     if let url = item.instagram_post_url,
        url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
         return true
     }
-    let state = (item.critic_overall_verdict ?? item.state ?? "")
+    let normalizedState = (item.state ?? "")
         .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    return state == "published"
+    let normalizedVerdict = (item.critic_overall_verdict ?? "")
+        .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return normalizedState == "published" || normalizedVerdict == "published"
 }
 
 /// Raw-dict variant of `Carousel.isPublishEligible`, for `QueueWriter` — which mutates

--- a/apps/wr2-control-app/Sources/QueueWriter.swift
+++ b/apps/wr2-control-app/Sources/QueueWriter.swift
@@ -43,7 +43,7 @@ enum QueueWriter {
     }
 
     private static func mutate(queueFile: URL, slug: String,
-                              _ change: (inout [String: Any]) -> Void) throws {
+                              _ change: (inout [String: Any]) throws -> Void) throws {
         let data = try Data(contentsOf: queueFile)
         guard var arr = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
             throw NSError(domain: "QueueWriter", code: 1,
@@ -51,7 +51,7 @@ enum QueueWriter {
         }
         var touched = false
         for i in arr.indices where matches(arr[i], slug: slug) {
-            change(&arr[i]); touched = true
+            try change(&arr[i]); touched = true
         }
         guard touched else {
             throw NSError(domain: "QueueWriter", code: 2,
@@ -70,9 +70,34 @@ enum QueueWriter {
         }
     }
 
+    /// Publish-eligibility error domain code — thrown BEFORE any field is touched
+    /// (guard-first inside the `mutate` closure), so a refused publish never leaves a
+    /// partial mutation on disk: `mutate` only writes after its closure returns
+    /// without throwing.
+    static let ineligibleStateErrorCode = 3
+
+    /// Marks a queue entry published. FAIL-CLOSED on the entry's CURRENT state
+    /// (cross-finding with the Python A3 daily-reconciler, 2026-07-16): this writer
+    /// mutates the queue JSON directly and never goes through
+    /// `scripts/wr2_queue_writer.py`'s `mark_published`, so without this check an
+    /// entry the reconciler just flagged `render_incomplete` (declared/disk mismatch
+    /// it could not explain as stale metadata) — or any other not-ready state — could
+    /// still be published from this app even though every OTHER consumer already
+    /// refuses it by construction (that script's own `PUBLISHABLE_STATES` allow-list).
+    /// Uses `isQueuePublishEligible` (Models.swift) — the SAME `CarouselPhase`
+    /// classification the gallery band and `Carousel.isPublishEligible` use — so this
+    /// is not a second, independently-maintained rule (scar #3).
     static func markPublished(queueFile: URL, slug: String, igURL: String, publishedAt: String) throws {
         let mediaID = extractMediaID(from: igURL)
         try mutate(queueFile: queueFile, slug: slug) { item in
+            let state = item["state"] as? String
+            let verdict = item["critic_overall_verdict"] as? String
+            guard isQueuePublishEligible(state: state, criticVerdict: verdict) else {
+                throw NSError(domain: "QueueWriter", code: ineligibleStateErrorCode, userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "refusing to mark published — state \(state.map { "\"\($0)\"" } ?? "(none)") is not publish-eligible (the carousel needs to reach a finished/ready state first, e.g. a render_incomplete or in-review entry cannot be published)"
+                ])
+            }
             if item["state_before_publish"] == nil {
                 item["state_before_publish"] = item["state"] ?? "drafted"
             }

--- a/apps/wr2-control-app/Sources/Views/CarouselDetailView.swift
+++ b/apps/wr2-control-app/Sources/Views/CarouselDetailView.swift
@@ -429,7 +429,28 @@ struct CarouselDetailView: View {
         } else if showPublishForm {
             publishForm
         } else {
-            markPublishedButton
+            VStack(alignment: .leading, spacing: 8) {
+                if carousel.isPublishEligible == false {
+                    notPublishEligibleBanner
+                }
+                markPublishedButton
+            }
+        }
+    }
+
+    // Visible reason (never a silently-disabled button, per the 2026-07-16 cross-finding
+    // with the Python A3 daily-reconciler): shown whenever the carousel's current state
+    // — `render_incomplete`, a stalled/in-flight render, or any status the app doesn't
+    // recognize as "ready" — makes both publish buttons below ineligible.
+    private var notPublishEligibleBanner: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11))
+                .foregroundStyle(Theme.red)
+            Text(lang.t("detail.notPublishEligible") + " (\(carousel.state ?? carousel.criticVerdict ?? "—"))")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Theme.red)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -499,7 +520,10 @@ struct CarouselDetailView: View {
                 .padding(.vertical, 8)
                 .background(Capsule().fill(igLink.trimmingCharacters(in: .whitespaces).isEmpty
                                            ? Theme.yellow.opacity(0.4) : Theme.yellow))
-                .disabled(igLink.trimmingCharacters(in: .whitespaces).isEmpty)
+                // Defense-in-depth: QueueWriter.markPublished itself now refuses an
+                // ineligible state too, but the UI should never invite the click at all.
+                .disabled(igLink.trimmingCharacters(in: .whitespaces).isEmpty
+                          || carousel.isPublishEligible == false)
 
                 Button(lang.t("studio.cancel")) {
                     showPublishForm = false
@@ -601,7 +625,9 @@ struct CarouselDetailView: View {
                 .background(Capsule().fill(Theme.blue))
             }
             .buttonStyle(.plain)
-            .disabled(state.isRunning || state.isPublishingSlug != nil)
+            // Fail-closed (2026-07-16 cross-finding): a render_incomplete or otherwise
+            // not-ready carousel must never even OPEN the publish popover.
+            .disabled(state.isRunning || state.isPublishingSlug != nil || carousel.isPublishEligible == false)
             .popover(isPresented: $showPublishIGConfirm, arrowEdge: .bottom) { publishIGConfirm }
 
             Button {
@@ -615,6 +641,7 @@ struct CarouselDetailView: View {
                     .background(Capsule().fill(Theme.green))
             }
             .buttonStyle(.plain)
+            .disabled(carousel.isPublishEligible == false)
         }
     }
 
@@ -696,6 +723,7 @@ struct CarouselDetailView: View {
                     captionIsLoading || captionLoadError != nil
                         || InstagramCaption.isPublishable(publishCaption) == false
                         || state.isPublishingSlug != nil
+                        || carousel.isPublishEligible == false
                 )
 
                 // The explicit operator publish click (confirm=true).
@@ -716,6 +744,7 @@ struct CarouselDetailView: View {
                     captionIsLoading || captionLoadError != nil
                         || InstagramCaption.isPublishable(publishCaption) == false
                         || state.isPublishingSlug != nil
+                        || carousel.isPublishEligible == false
                 )
 
                 Button(lang.t("detail.publishIGCancel")) { showPublishIGConfirm = false }

--- a/apps/wr2-control-app/Sources/Views/GalleryView.swift
+++ b/apps/wr2-control-app/Sources/Views/GalleryView.swift
@@ -38,6 +38,10 @@ struct GalleryView: View {
                             Text("\(visible(state.carousels).count) \(lang.t("gallery.count"))")
                                 .font(Theme.bodyFont).foregroundStyle(Theme.muted)
                         }
+                        if state.excludedIncompleteCount > 0 {
+                            Text("\(state.excludedIncompleteCount) \(lang.t("gallery.incompleteHidden"))")
+                                .font(.system(size: 10)).foregroundStyle(Theme.muted)
+                        }
                     }
                     Spacer()
                     // Sort picker

--- a/apps/wr2-control-app/Sources/WarRoom.swift
+++ b/apps/wr2-control-app/Sources/WarRoom.swift
@@ -271,6 +271,7 @@ enum WarRoom {
         // predicate, not bare field presence (Codex finding #3: an empty-string
         // `instagram_post_url` used to count as "published" and bypass the gate).
         var verdictBySlug: [String: String] = [:]
+        var stateBySlug: [String: String] = [:]
         var metricsBySlug: [String: EngagementMetrics] = [:]
         var igUrlBySlug: [String: String] = [:]
         var pubAtBySlug: [String: String] = [:]
@@ -279,6 +280,10 @@ enum WarRoom {
         for slug in physicalSlugs {
             guard let item = resolveQueueItem(forSlug: slug, in: queue) else { continue }
             if let v = item.critic_overall_verdict ?? item.state { verdictBySlug[slug] = v }
+            // Raw `state`, kept SEPARATE from verdictBySlug above (which is verdict-first
+            // and feeds the critic-verdict badge only) — see Carousel.state doc comment
+            // for why a stale verdict must never mask a fresh render_incomplete state.
+            if let s = item.state { stateBySlug[slug] = s }
             if let m = item.engagement_metrics { metricsBySlug[slug] = m }
             if let u = item.instagram_post_url { igUrlBySlug[slug] = u }
             if let a = item.instagram_published_at { pubAtBySlug[slug] = a }
@@ -349,7 +354,8 @@ enum WarRoom {
                 metrics: metricsBySlug[slug],
                 instagramURL: igUrlBySlug[slug],
                 publishedAt: pubAtBySlug[slug],
-                canvaURL: canvaBySlug[slug]))
+                canvaURL: canvaBySlug[slug],
+                state: stateBySlug[slug]))
         }
 
         // Second pass — published carousels that live ONLY in the queue (no on-disk render).
@@ -386,7 +392,8 @@ enum WarRoom {
                 metrics: item.engagement_metrics,
                 instagramURL: igURL,
                 publishedAt: item.instagram_published_at,
-                canvaURL: item.canvaLink))
+                canvaURL: item.canvaLink,
+                state: item.state))
         }
 
         return carousels.sorted { $0.modified > $1.modified }

--- a/apps/wr2-control-app/Sources/WarRoom.swift
+++ b/apps/wr2-control-app/Sources/WarRoom.swift
@@ -63,22 +63,100 @@ enum WarRoom {
     ///  1. basename of `carousel_path` (authoritative — same join scanCarousels uses)
     ///  2. `topic_slug` exact (legacy schema)
     ///  3. anchored FSM pattern `^\d{4}-\d{2}-\d{2}-<topic_slug>-[0-9a-f]{6,}$`
+    ///
+    /// Steps extracted into `queueItemMatchesByPath`/`queueItemMatchesByTopicSlug` so the
+    /// A2 completeness gate below (which only has a candidate SLUG, not a built Carousel
+    /// array, while it's still deciding whether the dir belongs in the gallery at all) can
+    /// reuse the exact same resolution rule instead of growing a second, driftable copy
+    /// (scar #3: a guard and its untested twin are how over/under-match pairs are born).
     static func matchCarousel(for item: ReviewItem, in carousels: [Carousel]) -> Carousel? {
-        if let p = item.carousel_path {
-            let trimmed = p.hasSuffix("/") ? String(p.dropLast()) : p
-            let slug = (trimmed as NSString).lastPathComponent
-            if slug.isEmpty == false,
-               let c = carousels.first(where: { $0.slug == slug }) { return c }
+        if let c = carousels.first(where: { queueItemMatchesByPath(item, candidateSlug: $0.slug) }) {
+            return c
         }
-        guard let ts = item.topic_slug, ts.isEmpty == false else { return nil }
-        if let c = carousels.first(where: { $0.slug == ts }) { return c }
+        guard item.topic_slug?.isEmpty == false else { return nil }
+        return carousels.first(where: { queueItemMatchesByTopicSlug(item, candidateSlug: $0.slug) })
+    }
+
+    /// Step 1: does `item.carousel_path`'s basename equal `slug`?
+    static func queueItemMatchesByPath(_ item: ReviewItem, candidateSlug slug: String) -> Bool {
+        guard let p = item.carousel_path else { return false }
+        let trimmed = p.hasSuffix("/") ? String(p.dropLast()) : p
+        let pathSlug = (trimmed as NSString).lastPathComponent
+        return pathSlug.isEmpty == false && pathSlug == slug
+    }
+
+    /// Steps 2+3: does `item.topic_slug` match `slug` exactly (legacy schema) or via the
+    /// anchored FSM `date-topic_slug-id8` pattern?
+    static func queueItemMatchesByTopicSlug(_ item: ReviewItem, candidateSlug slug: String) -> Bool {
+        guard let ts = item.topic_slug, ts.isEmpty == false else { return false }
+        if ts == slug { return true }
         let escaped = NSRegularExpression.escapedPattern(for: ts)
         let pattern = "^\\d{4}-\\d{2}-\\d{2}-\(escaped)-[0-9a-f]{6,}$"
-        guard let re = try? NSRegularExpression(pattern: pattern) else { return nil }
-        return carousels.first(where: { c in
-            let r = NSRange(c.slug.startIndex..., in: c.slug)
-            return re.firstMatch(in: c.slug, range: r) != nil
-        })
+        guard let re = try? NSRegularExpression(pattern: pattern) else { return false }
+        let r = NSRange(slug.startIndex..., in: slug)
+        return re.firstMatch(in: slug, range: r) != nil
+    }
+
+    // MARK: - A2 complete-or-nothing gate (2026-07-16, Zero mandate: "the app must NEVER
+    // receive drafted carousels with a single/partial slide — complete or nothing")
+
+    /// Count of on-disk dirs the gate excluded on the MOST RECENT `scanCarousels` call
+    /// (reset at the top of each scan). Exclusion must be observable, not silent (scar
+    /// #2, esiste≠armato) — this is the cheapest surface that doesn't require threading a
+    /// new return type through every call site (AppState, galleryproof, and the test
+    /// harness all call `scanCarousels() -> [Carousel]` today). AppState republishes it so
+    /// GalleryView can show "N nascosti" next to the existing carousel count.
+    private(set) static var excludedIncompleteCount: Int = 0
+
+    private static func logGateExclusion(slug: String, reason: String) {
+        FileHandle.standardError.write("wr2-gate: excluded '\(slug)' — \(reason)\n".data(using: .utf8)!)
+        excludedIncompleteCount += 1
+    }
+
+    /// Resolve the DECLARED slide count for an on-disk carousel directory — the number the
+    /// gate compares against the REAL PNG count. Three sources, first hit wins:
+    ///  (a) `slides.json` in the dir — count of entries in the `slides` array (or the bare
+    ///      top-level array in older files). NEVER the top-level `slide_count` int field:
+    ///      that metadata can go stale after an in-place revise (scar #9 — ground fact
+    ///      2026-07-16: 13 live queue entries found off-by-one after post-draft edits that
+    ///      never re-derived it; trusting the array length itself is what the render
+    ///      pipeline's own A1 gate does, so the app agrees with the producer).
+    ///  (b) `manifest.json` `total_slides` — the external-import path
+    ///      (`wr2_carousel_import.py`, MIN_SLIDES=1) writes this shape with no slides.json.
+    ///  (c) the review queue's `slide_count`, joined via the SAME path/topic_slug
+    ///      resolution `matchCarousel` uses.
+    /// `nil` = undeclarable — no source exists, so the dir is not eligible for the gallery
+    /// at all (see scanCarousels): silently trusting raw disk PNGs is the disease, not the cure.
+    static func declaredSlideCount(in dir: URL, slug: String, queue: [ReviewItem]) -> Int? {
+        if let n = slideCountFromSlidesJSON(in: dir) { return n }
+        if let n = slideCountFromManifest(in: dir) { return n }
+        return queueDeclaredSlideCount(forSlug: slug, in: queue)
+    }
+
+    private static func slideCountFromSlidesJSON(in dir: URL) -> Int? {
+        let url = dir.appendingPathComponent("slides.json")
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) else { return nil }
+        if let arr = obj as? [[String: Any]] { return arr.count }
+        if let d = obj as? [String: Any], let arr = d["slides"] as? [[String: Any]] { return arr.count }
+        return nil
+    }
+
+    private static func slideCountFromManifest(in dir: URL) -> Int? {
+        let url = dir.appendingPathComponent("manifest.json")
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return obj["total_slides"] as? Int
+    }
+
+    private static func queueDeclaredSlideCount(forSlug slug: String, in queue: [ReviewItem]) -> Int? {
+        if let item = queue.first(where: { queueItemMatchesByPath($0, candidateSlug: slug) }) {
+            return item.slide_count
+        }
+        if let item = queue.first(where: { queueItemMatchesByTopicSlug($0, candidateSlug: slug) }) {
+            return item.slide_count
+        }
+        return nil
     }
 
     // MARK: - Carousel gallery scan
@@ -91,6 +169,8 @@ enum WarRoom {
             at: croot,
             includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
             options: [.skipsHiddenFiles]) else { return [] }
+
+        excludedIncompleteCount = 0
 
         // build slug -> verdict/metrics/url/published maps from the queue (defensive across schemas)
         var verdictBySlug: [String: String] = [:]
@@ -135,6 +215,25 @@ enum WarRoom {
             let pngs = slidePNGs(in: slidesDir)
             guard pngs.isEmpty == false else { continue }   // only real carousels
 
+            // A2 complete-or-nothing gate (mandate 2026-07-16): a drafted/unpublished
+            // carousel is listed ONLY when the real PNG count matches its DECLARED count.
+            // Published/history entries are exempt — immutable, REPOINT-guarded, and
+            // already passed the render pipeline's own completeness gate before going
+            // live, so a later local drift here must never hide them retroactively.
+            let published = pubAtBySlug[slug] != nil || igUrlBySlug[slug] != nil
+            let declared = declaredSlideCount(in: dir, slug: slug, queue: queue)
+            if published == false {
+                guard let d = declared else {
+                    logGateExclusion(slug: slug,
+                                      reason: "undeclarable — no slides.json/manifest.json/queue slide_count")
+                    continue
+                }
+                guard pngs.count == d else {
+                    logGateExclusion(slug: slug, reason: "incomplete — disk=\(pngs.count) declared=\(d)")
+                    continue
+                }
+            }
+
             let mod = (try? dir.resourceValues(forKeys: [.contentModificationDateKey]))?
                 .contentModificationDate ?? Date.distantPast
             let brief = readBrief(in: dir)
@@ -148,7 +247,7 @@ enum WarRoom {
                 topic: brief?.topic,
                 domain: brief?.domain,
                 criticVerdict: verdictBySlug[slug],
-                slideCount: pngs.count,
+                slideCount: declared ?? pngs.count,   // displayed count = declared, never raw disk
                 imagegenFallback: detectImagegenFallback(in: dir),
                 coverURL: coverURL(slidesDir: slidesDir, slidePNGs: pngs),
                 metrics: metricsBySlug[slug],

--- a/apps/wr2-control-app/Sources/WarRoom.swift
+++ b/apps/wr2-control-app/Sources/WarRoom.swift
@@ -59,22 +59,33 @@ enum WarRoom {
     ///    silently loses its click target ("non riesco ad aprire i drafted").
     ///
     /// Resolution order — every step is an exact/anchored match, never bare
-    /// substring (scar #3, guard-over-match):
+    /// substring (scar #3, guard-over-match), and each step is a GENUINELY SEPARATE
+    /// pass over the full candidate set before falling to the next — never combined
+    /// into one predicate. A combined pass lets ARRAY ORDER decide between two steps
+    /// of different precedence whenever both would match different candidates
+    /// (Codex red-team finding #1, 2026-07-16: an item with topic_slug=="golden-visa"
+    /// must always resolve to the exact dir `golden-visa`, never to a same-topic dated
+    /// FSM dir like `2026-07-08-golden-visa-deadbeef` just because that happened to
+    /// come first in a modified-descending sort):
     ///  1. basename of `carousel_path` (authoritative — same join scanCarousels uses)
     ///  2. `topic_slug` exact (legacy schema)
     ///  3. anchored FSM pattern `^\d{4}-\d{2}-\d{2}-<topic_slug>-[0-9a-f]{6,}$`
     ///
-    /// Steps extracted into `queueItemMatchesByPath`/`queueItemMatchesByTopicSlug` so the
-    /// A2 completeness gate below (which only has a candidate SLUG, not a built Carousel
-    /// array, while it's still deciding whether the dir belongs in the gallery at all) can
-    /// reuse the exact same resolution rule instead of growing a second, driftable copy
-    /// (scar #3: a guard and its untested twin are how over/under-match pairs are born).
+    /// Steps extracted into `queueItemMatchesByPath`/`queueItemMatchesByExactTopicSlug`/
+    /// `queueItemMatchesByFSMRegex` so the A2 completeness gate below (which only has a
+    /// candidate SLUG, not a built Carousel array, while it's still deciding whether the
+    /// dir belongs in the gallery at all) can reuse the exact same resolution rule instead
+    /// of growing a second, driftable copy (scar #3: a guard and its untested twin are how
+    /// over/under-match pairs are born).
     static func matchCarousel(for item: ReviewItem, in carousels: [Carousel]) -> Carousel? {
         if let c = carousels.first(where: { queueItemMatchesByPath(item, candidateSlug: $0.slug) }) {
             return c
         }
         guard item.topic_slug?.isEmpty == false else { return nil }
-        return carousels.first(where: { queueItemMatchesByTopicSlug(item, candidateSlug: $0.slug) })
+        if let c = carousels.first(where: { queueItemMatchesByExactTopicSlug(item, candidateSlug: $0.slug) }) {
+            return c
+        }
+        return carousels.first(where: { queueItemMatchesByFSMRegex(item, candidateSlug: $0.slug) })
     }
 
     /// Step 1: does `item.carousel_path`'s basename equal `slug`?
@@ -85,11 +96,17 @@ enum WarRoom {
         return pathSlug.isEmpty == false && pathSlug == slug
     }
 
-    /// Steps 2+3: does `item.topic_slug` match `slug` exactly (legacy schema) or via the
-    /// anchored FSM `date-topic_slug-id8` pattern?
-    static func queueItemMatchesByTopicSlug(_ item: ReviewItem, candidateSlug slug: String) -> Bool {
+    /// Step 2: does `item.topic_slug` match `slug` EXACTLY (legacy schema)? Kept as its
+    /// own pass, never combined with step 3 — see `matchCarousel` doc above.
+    static func queueItemMatchesByExactTopicSlug(_ item: ReviewItem, candidateSlug slug: String) -> Bool {
         guard let ts = item.topic_slug, ts.isEmpty == false else { return false }
-        if ts == slug { return true }
+        return ts == slug
+    }
+
+    /// Step 3: does `item.topic_slug` match `slug` via the anchored FSM
+    /// `date-topic_slug-id8` pattern? Only tried after steps 1+2 both miss.
+    static func queueItemMatchesByFSMRegex(_ item: ReviewItem, candidateSlug slug: String) -> Bool {
+        guard let ts = item.topic_slug, ts.isEmpty == false else { return false }
         let escaped = NSRegularExpression.escapedPattern(for: ts)
         let pattern = "^\\d{4}-\\d{2}-\\d{2}-\(escaped)-[0-9a-f]{6,}$"
         guard let re = try? NSRegularExpression(pattern: pattern) else { return false }
@@ -149,20 +166,80 @@ enum WarRoom {
         return obj["total_slides"] as? Int
     }
 
+    /// Queue-based fallback (source c): resolve `slug`'s declared count from the review
+    /// queue, at the SAME path → exact-topic_slug → FSM-regex precedence `matchCarousel`
+    /// uses — each tier tried in full before falling to the next, and each tier
+    /// considers ONLY items that actually carry a `slide_count` (Codex red-team finding
+    /// #2, 2026-07-16: the previous version returned `nil` the instant the FIRST
+    /// path-matching item lacked a count, even when a later item at the SAME tier had
+    /// one — and combined exact+regex into one pass, letting queue array order silently
+    /// pick between two items that disagree). If MULTIPLE items at the SAME tier declare
+    /// DIFFERENT counts, that's genuine ambiguity — fail closed (nil, i.e. undeclarable)
+    /// rather than silently picking the first; the gate logs the specific reason via
+    /// `queueAmbiguityDescription` below (kept pure/side-effect-free here so this
+    /// function is safe to call from both `declaredSlideCount` and the diagnostic path
+    /// without double-incrementing `excludedIncompleteCount`).
     private static func queueDeclaredSlideCount(forSlug slug: String, in queue: [ReviewItem]) -> Int? {
-        if let item = queue.first(where: { queueItemMatchesByPath($0, candidateSlug: slug) }) {
-            return item.slide_count
-        }
-        if let item = queue.first(where: { queueItemMatchesByTopicSlug($0, candidateSlug: slug) }) {
-            return item.slide_count
+        for matcher in [queueItemMatchesByPath, queueItemMatchesByExactTopicSlug, queueItemMatchesByFSMRegex] {
+            let counts = queue.filter { matcher($0, slug) }.compactMap(\.slide_count)
+            guard counts.isEmpty == false else { continue }   // no count-bearing hit at this tier — try next
+            let distinct = Set(counts)
+            return distinct.count == 1 ? distinct.first : nil   // >1 distinct value → ambiguous → nil, stop here
         }
         return nil
+    }
+
+    /// Diagnostic-only companion to `queueDeclaredSlideCount`: if a dir's declared count
+    /// came back nil specifically because of a same-tier queue disagreement (not a true
+    /// absence of any source), describe the conflicting values for the gate's exclusion
+    /// log. Pure — never mutates state — so calling it purely to build a log message
+    /// never double-counts `excludedIncompleteCount` (Codex red-team finding #2).
+    private static func queueAmbiguityDescription(forSlug slug: String, in queue: [ReviewItem]) -> String? {
+        for matcher in [queueItemMatchesByPath, queueItemMatchesByExactTopicSlug, queueItemMatchesByFSMRegex] {
+            let counts = queue.filter { matcher($0, slug) }.compactMap(\.slide_count)
+            guard counts.isEmpty == false else { continue }
+            let distinct = Set(counts)
+            return distinct.count > 1 ? "ambiguous queue slide_count at this precedence tier: \(distinct.sorted())" : nil
+        }
+        return nil
+    }
+
+    /// Resolve the ONE queue item that authoritatively describes a physical directory
+    /// `slug`, via the same path → exact-topic_slug → FSM-regex precedence
+    /// `matchCarousel` uses. Used to build the per-slug verdict/metrics/published maps
+    /// below so a physical dir never misses its own queue row just because a map was
+    /// indexed by the queue's raw fields instead of resolved against the actual
+    /// directory name (Codex red-team finding #4, 2026-07-16).
+    private static func resolveQueueItem(forSlug slug: String, in queue: [ReviewItem]) -> ReviewItem? {
+        if let item = queue.first(where: { queueItemMatchesByPath($0, candidateSlug: slug) }) { return item }
+        if let item = queue.first(where: { queueItemMatchesByExactTopicSlug($0, candidateSlug: slug) }) { return item }
+        return queue.first(where: { queueItemMatchesByFSMRegex($0, candidateSlug: slug) })
+    }
+
+    /// True if `item` resolves (via the canonical path/exact/regex precedence) to ANY
+    /// of the given physical directory slugs. Used by the second pass to avoid
+    /// spawning a duplicate "virtual" carousel for a queue row that already has a real
+    /// on-disk dir — even one the completeness gate excluded (Codex red-team finding
+    /// #4: previously the dedup set held only gate-SURVIVING slugs, checked via a raw
+    /// topic_slug/basename guess, so a physical dir named differently from the queue's
+    /// truncated topic_slug got excluded by the gate AND re-created here as a phantom
+    /// virtual entry with no local cover/slides).
+    private static func resolvesToPhysicalDir(_ item: ReviewItem, physicalSlugs: [String]) -> Bool {
+        physicalSlugs.contains(where: { queueItemMatchesByPath(item, candidateSlug: $0) })
+            || physicalSlugs.contains(where: { queueItemMatchesByExactTopicSlug(item, candidateSlug: $0) })
+            || physicalSlugs.contains(where: { queueItemMatchesByFSMRegex(item, candidateSlug: $0) })
     }
 
     // MARK: - Carousel gallery scan
 
     static func scanCarousels(carouselRoot root: URL? = nil,
                               queue: [ReviewItem] = []) -> [Carousel] {
+        // Reset BEFORE any I/O, on every exit path including an early return below — a
+        // stale nonzero count surviving a failed/empty scan would show "N nascosti" over
+        // a gallery that simply failed to read, its own silent-lie (Codex red-team
+        // finding #5, 2026-07-16).
+        excludedIncompleteCount = 0
+
         let fm = FileManager.default
         let croot = root ?? carouselRoot()
         guard let entries = try? fm.contentsOfDirectory(
@@ -170,38 +247,43 @@ enum WarRoom {
             includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
             options: [.skipsHiddenFiles]) else { return [] }
 
-        excludedIncompleteCount = 0
+        // Every physical (non-archived) directory slug on disk, gathered BEFORE gating
+        // or queue-joining — two downstream steps need the FULL set, not just
+        // gate-survivors: (1) the per-slug queue join below must resolve against every
+        // real dir so one that ALSO gets excluded by the completeness gate still gets
+        // correct published/verdict/metrics data; (2) the second pass's dedup must
+        // never spawn a duplicate for a dir that exists physically but didn't survive
+        // the gate (Codex red-team finding #4, 2026-07-16).
+        var physicalSlugs: [String] = []
+        for dir in entries {
+            let isDir = (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+            guard isDir else { continue }
+            let slug = dir.lastPathComponent
+            if slug.hasPrefix("_") { continue }
+            physicalSlugs.append(slug)
+        }
 
-        // build slug -> verdict/metrics/url/published maps from the queue (defensive across schemas)
+        // Resolve each physical slug to ITS ONE queue item via the canonical
+        // precedence — never by indexing the queue on its own raw fields (Codex
+        // finding #4: that let a dir silently miss its own publication/verdict data
+        // whenever the FSM directory name diverges from the queue's truncated
+        // topic_slug). `publishedBySlug` uses the canonical `isQueueItemPublished`
+        // predicate, not bare field presence (Codex finding #3: an empty-string
+        // `instagram_post_url` used to count as "published" and bypass the gate).
         var verdictBySlug: [String: String] = [:]
         var metricsBySlug: [String: EngagementMetrics] = [:]
         var igUrlBySlug: [String: String] = [:]
         var pubAtBySlug: [String: String] = [:]
         var canvaBySlug: [String: String] = [:]
-        for item in queue {
-            let slug: String?
-            if let p = item.carousel_path {
-                let trimmed = p.hasSuffix("/") ? String(p.dropLast()) : p
-                slug = trimmed.components(separatedBy: "/").last
-            } else {
-                slug = item.topic_slug
-            }
-            guard let s = slug else { continue }
-            if let v = item.critic_overall_verdict ?? item.state {
-                verdictBySlug[s] = v
-            }
-            if let m = item.engagement_metrics {
-                metricsBySlug[s] = m
-            }
-            if let u = item.instagram_post_url {
-                igUrlBySlug[s] = u
-            }
-            if let a = item.instagram_published_at {
-                pubAtBySlug[s] = a
-            }
-            if let c = item.canvaLink {
-                canvaBySlug[s] = c
-            }
+        var publishedBySlug: [String: Bool] = [:]
+        for slug in physicalSlugs {
+            guard let item = resolveQueueItem(forSlug: slug, in: queue) else { continue }
+            if let v = item.critic_overall_verdict ?? item.state { verdictBySlug[slug] = v }
+            if let m = item.engagement_metrics { metricsBySlug[slug] = m }
+            if let u = item.instagram_post_url { igUrlBySlug[slug] = u }
+            if let a = item.instagram_published_at { pubAtBySlug[slug] = a }
+            if let c = item.canvaLink { canvaBySlug[slug] = c }
+            publishedBySlug[slug] = isQueueItemPublished(item)
         }
 
         var carousels: [Carousel] = []
@@ -212,20 +294,34 @@ enum WarRoom {
             if slug.hasPrefix("_") { continue }   // skip _archived-*, etc.
 
             let slidesDir = dir.appendingPathComponent("slides", isDirectory: true)
+            // Distinguish a genuinely-empty/not-yet-rendered slides/ dir from one that
+            // exists but is momentarily unreadable (permission/I/O flap): the lenient
+            // `slidePNGs` collapses both to `[]` via `try?`, so an I/O error was
+            // previously silently dropped with no log/counter — indistinguishable from
+            // a real empty dir (Codex red-team finding #5, 2026-07-16).
+            let slidesDirReadable = (try? fm.contentsOfDirectory(
+                at: slidesDir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) != nil
             let pngs = slidePNGs(in: slidesDir)
-            guard pngs.isEmpty == false else { continue }   // only real carousels
+            guard pngs.isEmpty == false else {
+                if slidesDirReadable == false {
+                    logGateExclusion(slug: slug, reason: "slides/ unreadable (I/O error) — not a genuine empty carousel")
+                }
+                continue
+            }
 
             // A2 complete-or-nothing gate (mandate 2026-07-16): a drafted/unpublished
-            // carousel is listed ONLY when the real PNG count matches its DECLARED count.
-            // Published/history entries are exempt — immutable, REPOINT-guarded, and
-            // already passed the render pipeline's own completeness gate before going
-            // live, so a later local drift here must never hide them retroactively.
-            let published = pubAtBySlug[slug] != nil || igUrlBySlug[slug] != nil
+            // carousel is listed ONLY when the real PNG count matches its DECLARED
+            // count. Published/history entries are exempt — immutable, REPOINT-guarded,
+            // and already passed the render pipeline's own completeness gate before
+            // going live, so a later local drift here must never hide them
+            // retroactively.
+            let published = publishedBySlug[slug] ?? false
             let declared = declaredSlideCount(in: dir, slug: slug, queue: queue)
             if published == false {
                 guard let d = declared else {
-                    logGateExclusion(slug: slug,
-                                      reason: "undeclarable — no slides.json/manifest.json/queue slide_count")
+                    let reason = queueAmbiguityDescription(forSlug: slug, in: queue)
+                        ?? "undeclarable — no slides.json/manifest.json/queue slide_count"
+                    logGateExclusion(slug: slug, reason: reason)
                     continue
                 }
                 guard pngs.count == d else {
@@ -261,13 +357,17 @@ enum WarRoom {
         // engagement metrics but no slides/ folder. The folder scan above can never surface them,
         // so the gallery would show 0 of them ("apro la app e non è aggiornata"). We add them here
         // as IG-only carousels: no local PNG (cover placeholder), metrics/URL/topic/date from queue.
-        let physicalSlugs = Set(carousels.map { $0.slug })
+        // Dedup checks EVERY physical dir (not just gate-survivors) via the canonical resolver
+        // (not a raw topic_slug/basename guess) — otherwise a physical dir the gate excluded, or
+        // one whose queue row's topic_slug is a truncated FSM form, gets a duplicate phantom
+        // entry here that shadows its real cover/slides (Codex red-team finding #4, 2026-07-16).
         for item in queue {
-            guard let igURL = item.instagram_post_url, igURL.isEmpty == false else { continue }
+            guard let igURL = item.instagram_post_url,
+                  igURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else { continue }
+            guard resolvesToPhysicalDir(item, physicalSlugs: physicalSlugs) == false else { continue }
             let slug = item.topic_slug
                 ?? item.carousel_path.map { ($0 as NSString).lastPathComponent }
                 ?? item.id
-            guard physicalSlugs.contains(slug) == false else { continue }
 
             let mod = item.instagram_published_at.flatMap(parsePublishedAt) ?? Date.distantPast
             carousels.append(Carousel(

--- a/apps/wr2-control-app/Tests/census/main.swift
+++ b/apps/wr2-control-app/Tests/census/main.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+// A2 GATE — REAL-DATA CENSUS (mandatory innocence proof, 2026-07-16 Codex red-team round)
+//
+// Runs the FIXED, production WarRoom.scanCarousels() read-only against the REAL local
+// war-room output (no root/queue override — same defaults AppState uses) and independently
+// recomputes, for every physical directory the gate did NOT list, WHY it was excluded — by
+// calling the same public WarRoom resolvers (declaredSlideCount/slidePNGs), never by parsing
+// stderr log lines. This never mutates anything: FileManager reads only, no writes.
+//
+// Categories reported, each with the hidden dirs BY NAME:
+//   listed              — carousels the gallery would actually show
+//   hidden-incomplete    — real PNGs exist but declared != disk (or slides/ empty/unreadable)
+//   hidden-undeclarable  — no declaration source at all (or ambiguous same-tier queue rows)
+//   published-exempt     — listed carousels kept ONLY because they're genuinely published
+//                          (both on-disk exempted dirs and queue-only virtual entries)
+
+let fm = FileManager.default
+let queue = WarRoom.readQueue()
+let croot = WarRoom.carouselRoot()
+
+let listed = WarRoom.scanCarousels(queue: queue)
+let listedSlugs = Set(listed.map { $0.slug })
+
+// Every physical (non-archived) directory on disk — the SAME filter scanCarousels applies
+// (skip dot-hidden entries and any `_`-prefixed archive dir).
+let physical: [String] = (try? fm.contentsOfDirectory(
+    at: croot, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]))?
+    .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false }
+    .map { $0.lastPathComponent }
+    .filter { $0.hasPrefix("_") == false } ?? []
+
+print("═══════════════════════════════════════════════════════════════")
+print("A2 GATE — REAL-DATA CENSUS")
+print("carousel root: \(croot.path)")
+print("queue file:    \(WarRoom.queueFile().path)")
+print("run at:        \(Date())")
+print("═══════════════════════════════════════════════════════════════")
+print("physical directories (non-archived): \(physical.count)")
+print("queue items:                          \(queue.count)")
+print("")
+
+var hiddenIncomplete: [(slug: String, reason: String)] = []
+var hiddenUndeclarable: [(slug: String, reason: String)] = []
+var publishedExemptPhysical: [String] = []
+
+for slug in physical {
+    let dir = croot.appendingPathComponent(slug, isDirectory: true)
+    let slidesDir = dir.appendingPathComponent("slides", isDirectory: true)
+    let pngs = WarRoom.slidePNGs(in: slidesDir)
+
+    if listedSlugs.contains(slug) {
+        if let c = listed.first(where: { $0.slug == slug }), c.isPublished {
+            publishedExemptPhysical.append(slug)
+        }
+        continue
+    }
+
+    // Not listed — independently recompute WHY, via the exact same public resolvers
+    // the gate itself calls (never trusting a remembered/logged reason).
+    if pngs.isEmpty {
+        hiddenIncomplete.append((slug, "empty or unreadable slides/ dir"))
+        continue
+    }
+    let declared = WarRoom.declaredSlideCount(in: dir, slug: slug, queue: queue)
+    if let d = declared {
+        hiddenIncomplete.append((slug, "disk=\(pngs.count) declared=\(d)"))
+    } else {
+        hiddenUndeclarable.append((slug, "no slides.json/manifest.json/queue slide_count (or ambiguous same-tier queue rows)"))
+    }
+}
+
+// Queue-only "virtual" published carousels the second pass materializes (no physical dir
+// at all) — verified by an independent, direct disk-existence check on the Carousel's own
+// `directory` field, not by any internal bookkeeping flag (scar #9 discipline: verify by
+// content/reality, never by a proxy that could itself be wrong).
+let virtualPublished = listed.filter { fm.fileExists(atPath: $0.directory.path) == false }
+
+let listedPhysicalCount = listed.count - virtualPublished.count
+
+print("LISTED (total the gallery shows): \(listed.count)")
+print("  of which physical on-disk:       \(listedPhysicalCount)")
+print("  of which queue-only virtual:      \(virtualPublished.count)")
+print("")
+
+print("HIDDEN — incomplete (\(hiddenIncomplete.count)):")
+for (s, r) in hiddenIncomplete.sorted(by: { $0.slug < $1.slug }) { print("   - \(s)   [\(r)]") }
+print("")
+
+print("HIDDEN — undeclarable (\(hiddenUndeclarable.count)):")
+for (s, r) in hiddenUndeclarable.sorted(by: { $0.slug < $1.slug }) { print("   - \(s)   [\(r)]") }
+print("")
+
+print("PUBLISHED-EXEMPT — physical dir kept despite incompleteness (\(publishedExemptPhysical.count)):")
+for s in publishedExemptPhysical.sorted() { print("   - \(s)") }
+print("")
+
+print("PUBLISHED-EXEMPT — virtual, queue-only, no physical dir at all (\(virtualPublished.count)):")
+for c in virtualPublished.sorted(by: { $0.slug < $1.slug }) { print("   - \(c.slug)") }
+print("")
+
+// Sanity identity: every physical dir is in EXACTLY one bucket — listed (physical) XOR
+// hidden-incomplete XOR hidden-undeclarable. If this doesn't add up, the census itself
+// has a bug (double-counted or dropped a dir) and its other numbers can't be trusted.
+let accounted = listedPhysicalCount + hiddenIncomplete.count + hiddenUndeclarable.count
+print("═══════════════════════════════════════════════════════════════")
+print("SANITY: physical(\(physical.count)) == listed-physical + hidden-incomplete + hidden-undeclarable (\(accounted))? \(accounted == physical.count ? "OK" : "MISMATCH — census bug, do not trust the above")")
+print("═══════════════════════════════════════════════════════════════")
+
+exit(accounted == physical.count ? 0 : 1)

--- a/apps/wr2-control-app/Tests/main.swift
+++ b/apps/wr2-control-app/Tests/main.swift
@@ -51,20 +51,32 @@ func makeFixtureRoot() -> URL {
 
 /// - Parameter declareSlides: the A2 complete-or-nothing gate (WarRoom.declaredSlideCount)
 ///   needs a declaration source (slides.json/manifest.json/queue slide_count) or the dir is
-///   undeclarable and excluded outright. Default `.matching` writes a `slides.json` whose
-///   `slides` array has exactly `slides.count` entries, so every PRE-EXISTING call site
-///   (written before the gate existed) stays "complete" and green without touching each one.
-///   `.none` omits slides.json entirely (for the undeclarable-dir test). `.count(n)` writes n
-///   entries regardless of `slides.count` (for the incomplete/mismatch guilt tests).
-enum DeclaredSlides {
-    case matching
-    case none
-    case count(Int)
+///   undeclarable and excluded outright. `.auto` (the default) resolves to
+///   `.objectSlides(slides.count)` — the OBJECT schema `{"slides":[...]}` is the dominant
+///   real-world shape (a 2026-07-16 census of the live local carousel root found 100% of
+///   existing slides.json files use it, none use a bare top-level array — Codex red-team
+///   finding #6). `.bareArray` exercises the legacy/rare shape explicitly. `.absent` omits
+///   slides.json entirely (majority real-world shape — most local dirs have none at all,
+///   falling through to manifest.json/queue). `.malformed` writes invalid JSON.
+///   NOTE: this case is named `.absent`, NOT `.none` — a case literally named `none` on an
+///   enum used through an `Optional`-typed parameter is a documented Swift trap: `.none` at
+///   the call site resolves to `Optional<DeclaredSlides>.none` (plain nil) instead of
+///   `Optional.some(.none)`, silently discarding the intended declaration mode. Caught live
+///   2026-07-16: with a `DeclaredSlides?` parameter and a `case none`, EVERY `.none` call
+///   site below silently reverted to the `.auto` default instead of "no slides.json at all",
+///   which made the "undeclarable" and "ambiguous same-tier queue count" guilt tests pass
+///   for the wrong reason (source (a) short-circuited before source (c) was ever reached).
+enum DeclaredSlides: Equatable {
+    case objectSlides(Int)
+    case bareArray(Int)
+    case absent
+    case malformed
+    case auto
 }
 
 @discardableResult
 func makeCarousel(in root: URL, slug: String, slides: [String], brief: [String: Any]? = nil,
-                   declareSlides: DeclaredSlides = .matching) -> URL {
+                   declareSlides: DeclaredSlides = .auto) -> URL {
     let dir = root.appendingPathComponent("carousel/\(slug)", isDirectory: true)
     let slidesDir = dir.appendingPathComponent("slides", isDirectory: true)
     try? fm.createDirectory(at: slidesDir, withIntermediateDirectories: true)
@@ -86,17 +98,23 @@ func makeCarousel(in root: URL, slug: String, slides: [String], brief: [String: 
        let data = try? JSONSerialization.data(withJSONObject: brief) {
         try? data.write(to: dir.appendingPathComponent("brief.json"))
     }
-    let declaredCount: Int?
-    switch declareSlides {
-    case .matching: declaredCount = slides.count
-    case .none: declaredCount = nil
-    case .count(let n): declaredCount = n
-    }
-    if let n = declaredCount {
-        let slideEntries = (0..<n).map { ["index": $0 + 1] }
-        if let data = try? JSONSerialization.data(withJSONObject: slideEntries) {
+    let mode: DeclaredSlides = (declareSlides == .auto) ? .objectSlides(slides.count) : declareSlides
+    switch mode {
+    case .objectSlides(let n):
+        let entries = (0..<n).map { ["index": $0 + 1] }
+        let obj: [String: Any] = ["slides": entries]
+        if let data = try? JSONSerialization.data(withJSONObject: obj) {
             try? data.write(to: dir.appendingPathComponent("slides.json"))
         }
+    case .bareArray(let n):
+        let entries = (0..<n).map { ["index": $0 + 1] }
+        if let data = try? JSONSerialization.data(withJSONObject: entries) {
+            try? data.write(to: dir.appendingPathComponent("slides.json"))
+        }
+    case .absent, .auto:
+        break
+    case .malformed:
+        try? Data("{ not valid json ,,,".utf8).write(to: dir.appendingPathComponent("slides.json"))
     }
     return dir
 }
@@ -359,26 +377,26 @@ func test_completeOrNothingGate() {
 
     // COLPEVOLEZZA — declared (9) != disk (8): must be excluded entirely, not just flagged.
     _ = makeCarousel(in: root, slug: "mismatch-9-vs-8", slides: (1...8).map { "\($0).png" },
-                      declareSlides: .count(9))
+                      declareSlides: .objectSlides(9))
 
     // COLPEVOLEZZA — no slides.json/manifest.json/queue entry at all: undeclarable, excluded
     // even though real PNGs exist on disk (never silently trust raw disk count).
-    _ = makeCarousel(in: root, slug: "undeclarable", slides: ["1.png", "2.png"], declareSlides: .none)
+    _ = makeCarousel(in: root, slug: "undeclarable", slides: ["1.png", "2.png"], declareSlides: .absent)
 
     // fallback (b) — manifest.json total_slides, no slides.json (external-import shape).
     let manifestDir = makeCarousel(in: root, slug: "manifest-fallback", slides: ["1.png", "2.png"],
-                                    declareSlides: .none)
+                                    declareSlides: .absent)
     let manifestJSON: [String: Any] = ["total_slides": 2, "imported": true]
     try? JSONSerialization.data(withJSONObject: manifestJSON)
         .write(to: manifestDir.appendingPathComponent("manifest.json"))
 
     // fallback (c) — queue slide_count, no slides.json/manifest.json at all.
     _ = makeCarousel(in: root, slug: "queue-fallback", slides: ["1.png", "2.png", "3.png"],
-                      declareSlides: .none)
+                      declareSlides: .absent)
 
     // published exemption — undeclarable AND the only 1 disk PNG, but published: must stay
     // visible regardless (immutable, REPOINT-guarded — never hidden retroactively).
-    _ = makeCarousel(in: root, slug: "published-partial", slides: ["1.png"], declareSlides: .none)
+    _ = makeCarousel(in: root, slug: "published-partial", slides: ["1.png"], declareSlides: .absent)
 
     let queueJSON = """
     [
@@ -414,6 +432,109 @@ func test_completeOrNothingGate() {
 
     T.eq(WarRoom.excludedIncompleteCount, 2,
          "excludedIncompleteCount counts exactly the 2 unpublished exclusions (mismatch + undeclarable)")
+}
+
+// MARK: - Codex red-team hardening (2026-07-16, findings #1/#2/#3/#6 on the A2 gate)
+
+func test_matchCarouselPrecedenceOrder() {
+    T.suite("matchCarousel precedence — exact wins over regex regardless of array order (Codex finding #1)")
+
+    func fakeCarousel(_ slug: String) -> Carousel {
+        Carousel(slug: slug, directory: URL(fileURLWithPath: "/tmp/\(slug)"),
+                  slidesDir: URL(fileURLWithPath: "/tmp/\(slug)/slides"),
+                  slidePNGs: [], modified: Date(), topic: nil, domain: nil,
+                  criticVerdict: nil, slideCount: 1, imagegenFallback: false,
+                  coverURL: nil, metrics: nil, instagramURL: nil, publishedAt: nil, canvaURL: nil)
+    }
+    let exactDir = fakeCarousel("golden-visa-order")
+    let regexDir = fakeCarousel("2026-07-08-golden-visa-order-deadbeef")
+
+    let json = #"[{"id":"x","topic_slug":"golden-visa-order","state":"drafted"}]"#
+    let url = fm.temporaryDirectory.appendingPathComponent("q-\(UUID()).json")
+    try? json.data(using: .utf8)!.write(to: url)
+    defer { try? fm.removeItem(at: url) }
+    let item = WarRoom.readQueue(queueFile: url)[0]
+
+    // COLPEVOLEZZA (the pre-fix bug): a combined exact+regex pass lets array order pick
+    // the regex dir here. Putting it FIRST is exactly the scenario that broke.
+    T.eq(WarRoom.matchCarousel(for: item, in: [regexDir, exactDir])?.slug, "golden-visa-order",
+         "exact match wins even when the regex-matching dir sorts FIRST in the array")
+    // INNOCENZA — same result with the array in the other order (sanity, not the bug itself).
+    T.eq(WarRoom.matchCarousel(for: item, in: [exactDir, regexDir])?.slug, "golden-visa-order",
+         "exact match wins when it already sorts first too")
+}
+
+func test_completeOrNothingGateHardening() {
+    T.suite("A2 gate hardening — Codex red-team findings #2/#3/#6 (2026-07-16)")
+
+    let root = makeFixtureRoot()
+    defer { try? fm.removeItem(at: root) }
+    let croot = root.appendingPathComponent("carousel", isDirectory: true)
+
+    // Finding #2 — two queue rows at the SAME precedence tier (both exact topic_slug,
+    // neither has carousel_path) declare DIFFERENT slide_count. Must be excluded with a
+    // logged ambiguity reason, never silently resolved by picking the first row.
+    _ = makeCarousel(in: root, slug: "ambiguous-count", slides: (1...7).map { "\($0).png" },
+                      declareSlides: .absent)
+
+    // Finding #3 (guilt) — an empty-string instagram_post_url must NOT count as published
+    // and must NOT let an incomplete render bypass the gate.
+    _ = makeCarousel(in: root, slug: "empty-url-guilt", slides: (1...3).map { "\($0).png" },
+                      declareSlides: .objectSlides(5))
+
+    // Finding #3 (innocence) — a legacy row with state=="published" but no URL/timestamp
+    // at all must still count as published and must NOT be hidden.
+    _ = makeCarousel(in: root, slug: "state-only-published", slides: ["1.png"], declareSlides: .absent)
+
+    // Finding #6 — a malformed slides.json must not crash and must fall through cleanly
+    // to the next declaration source (queue slide_count here), same as if it were absent.
+    _ = makeCarousel(in: root, slug: "malformed-json", slides: (1...4).map { "\($0).png" },
+                      declareSlides: .malformed)
+
+    // Finding #6 — multi-source conflict mirroring the real `bali-pma-rental-crackdown`
+    // case: slides.json (a) says 9, manifest.json (b) says 999, queue (c) says 8 — (a)
+    // must win over both, precedence a > b > c.
+    let conflictDir = makeCarousel(in: root, slug: "multi-source-conflict",
+                                    slides: (1...9).map { "\($0).png" }, declareSlides: .objectSlides(9))
+    let manifestConflict: [String: Any] = ["total_slides": 999]
+    try? JSONSerialization.data(withJSONObject: manifestConflict)
+        .write(to: conflictDir.appendingPathComponent("manifest.json"))
+
+    let queueJSON = """
+    [
+      {"id":"amb1","topic_slug":"ambiguous-count","slide_count":7,"state":"drafted"},
+      {"id":"amb2","topic_slug":"ambiguous-count","slide_count":8,"state":"drafted"},
+      {"id":"eu","topic_slug":"empty-url-guilt","instagram_post_url":"","state":"drafted"},
+      {"id":"sp","topic_slug":"state-only-published","state":"published"},
+      {"id":"mj","topic_slug":"malformed-json","slide_count":4,"state":"drafted"},
+      {"id":"msc","topic_slug":"multi-source-conflict","slide_count":8,"state":"drafted"}
+    ]
+    """
+    let qurl = fm.temporaryDirectory.appendingPathComponent("q-\(UUID()).json")
+    try? queueJSON.data(using: .utf8)!.write(to: qurl)
+    defer { try? fm.removeItem(at: qurl) }
+    let queue = WarRoom.readQueue(queueFile: qurl)
+    T.eq(queue.count, 6, "hardening-test queue fixture decoded")
+
+    let carousels = WarRoom.scanCarousels(carouselRoot: croot, queue: queue)
+    func find(_ slug: String) -> Carousel? { carousels.first(where: { $0.slug == slug }) }
+
+    T.check(find("ambiguous-count") == nil,
+            "finding #2 guilt: same-tier queue rows disagreeing on slide_count → excluded, not first-picked")
+
+    T.check(find("empty-url-guilt") == nil,
+            "finding #3 guilt: empty-string instagram_post_url does NOT bypass the gate")
+
+    T.check(find("state-only-published") != nil,
+            "finding #3 innocence: state==\"published\" with no URL/timestamp still exempts the gate")
+
+    T.check(find("malformed-json") != nil,
+            "finding #6: malformed slides.json falls through to queue fallback, no crash")
+    T.eq(find("malformed-json")?.slideCount, 4, "finding #6: fallback count taken from queue after malformed (a)")
+
+    T.check(find("multi-source-conflict") != nil, "finding #6: a>b>c conflict — carousel listed")
+    T.eq(find("multi-source-conflict")?.slideCount, 9,
+         "finding #6: slides.json (a)=9 wins over manifest (b)=999 and queue (c)=8")
 }
 
 // MARK: - carousel phase mapping (pipeline↔app coherence, 2026-06-25)
@@ -606,6 +727,8 @@ let suites: [() -> Void] = [
     test_adversarialFixes,
     test_reviewQueueJoin,
     test_completeOrNothingGate,
+    test_matchCarouselPrecedenceOrder,
+    test_completeOrNothingGateHardening,
     test_carouselPhaseMapping,
     test_instagramCaptionValidation,
     test_instagramCaptionProcessContract,

--- a/apps/wr2-control-app/Tests/main.swift
+++ b/apps/wr2-control-app/Tests/main.swift
@@ -537,6 +537,78 @@ func test_completeOrNothingGateHardening() {
          "finding #6: slides.json (a)=9 wins over manifest (b)=999 and queue (c)=8")
 }
 
+// MARK: - Publish-eligibility gate (2026-07-16 cross-finding w/ Python A3 reconciler)
+
+func test_publishEligibilityCrossFinding() {
+    T.suite("publish-eligibility — fresh state must not be masked by a stale verdict")
+
+    func fakeCarousel(state: String?, criticVerdict: String?, isPublished: Bool = false) -> Carousel {
+        Carousel(slug: "x", directory: URL(fileURLWithPath: "/tmp/x"),
+                 slidesDir: URL(fileURLWithPath: "/tmp/x/slides"), slidePNGs: [],
+                 modified: Date(), topic: nil, domain: nil, criticVerdict: criticVerdict,
+                 slideCount: 8, imagegenFallback: false, coverURL: nil, metrics: nil,
+                 instagramURL: isPublished ? "https://instagram.com/p/x/" : nil,
+                 publishedAt: nil, canvaURL: nil, state: state)
+    }
+
+    // COLPEVOLEZZA — the exact cross-finding bug: a stale GOOD verdict from an earlier
+    // successful critic run must NOT mask a FRESH render_incomplete state the Python A3
+    // daily-reconciler set later (a post-render disk-level drift the render-time gate
+    // couldn't see). If phase/eligibility were still computed verdict-first
+    // (critic_overall_verdict ?? state, the OLD precedence), this carousel would wrongly
+    // read as waitlist/publishable.
+    let maskedByStaleVerdict = fakeCarousel(state: "render_incomplete", criticVerdict: "pass")
+    T.eq(maskedByStaleVerdict.phase, .review,
+         "fresh render_incomplete state wins over a stale \"pass\" verdict -> review, not waitlist")
+    T.check(maskedByStaleVerdict.isPublishEligible == false,
+            "guilt: not publish-eligible despite the stale good verdict")
+
+    // INNOCENZA — a legacy-schema row with NO `state` field at all, only the verdict,
+    // must still fall back correctly (the fix must not regress rows that never carried
+    // a state field in the first place).
+    let legacyVerdictOnly = fakeCarousel(state: nil, criticVerdict: "pass")
+    T.eq(legacyVerdictOnly.phase, .waitlist, "no state field -> falls back to criticVerdict -> waitlist")
+    T.check(legacyVerdictOnly.isPublishEligible, "innocence: legacy verdict-only carousel stays eligible")
+
+    // INNOCENZA — the ordinary, current-day case: state="drafted", no verdict yet.
+    let ordinaryDraft = fakeCarousel(state: "drafted", criticVerdict: nil)
+    T.eq(ordinaryDraft.phase, .waitlist, "drafted -> waitlist")
+    T.check(ordinaryDraft.isPublishEligible, "innocence: an ordinary drafted carousel is eligible")
+
+    // COLPEVOLEZZA — an already-published carousel is never "eligible for a FRESH
+    // publish" (that's the separate, reversible undo-publish flow).
+    let alreadyPublished = fakeCarousel(state: "published", criticVerdict: "pass", isPublished: true)
+    T.check(alreadyPublished.isPublishEligible == false,
+            "guilt: already-published carousel is not eligible for a fresh publish")
+}
+
+func test_stateWiredThroughScanCarousels() {
+    T.suite("WarRoom.scanCarousels wires raw state through the queue join (not just verdict)")
+
+    let root = makeFixtureRoot()
+    defer { try? fm.removeItem(at: root) }
+    let croot = root.appendingPathComponent("carousel", isDirectory: true)
+    _ = makeCarousel(in: root, slug: "cross-finding-slug", slides: (1...8).map { "\($0).png" })
+
+    let json = """
+    [{"id":"cf","topic_slug":"cross-finding-slug","state":"render_incomplete","critic_overall_verdict":"pass","slide_count":8}]
+    """
+    let url = fm.temporaryDirectory.appendingPathComponent("q-\(UUID()).json")
+    try? json.data(using: .utf8)!.write(to: url)
+    defer { try? fm.removeItem(at: url) }
+    let queue = WarRoom.readQueue(queueFile: url)
+
+    let carousels = WarRoom.scanCarousels(carouselRoot: croot, queue: queue)
+    guard let c = carousels.first(where: { $0.slug == "cross-finding-slug" }) else {
+        T.check(false, "cross-finding-slug carousel should be listed (complete render, gate unaffected by publish state)")
+        return
+    }
+    T.eq(c.state, "render_incomplete", "raw state wired through from the queue join")
+    T.eq(c.criticVerdict, "pass", "criticVerdict stays verdict-first — unchanged field, different purpose (critic badge)")
+    T.eq(c.phase, .review, "phase uses raw state, not verdict -> review despite the \"pass\" verdict")
+    T.check(c.isPublishEligible == false, "publish gate correctly refuses despite the gallery listing it as complete")
+}
+
 // MARK: - carousel phase mapping (pipeline↔app coherence, 2026-06-25)
 
 func test_carouselPhaseMapping() {
@@ -729,6 +801,8 @@ let suites: [() -> Void] = [
     test_completeOrNothingGate,
     test_matchCarouselPrecedenceOrder,
     test_completeOrNothingGateHardening,
+    test_publishEligibilityCrossFinding,
+    test_stateWiredThroughScanCarousels,
     test_carouselPhaseMapping,
     test_instagramCaptionValidation,
     test_instagramCaptionProcessContract,

--- a/apps/wr2-control-app/Tests/main.swift
+++ b/apps/wr2-control-app/Tests/main.swift
@@ -582,6 +582,49 @@ func test_publishEligibilityCrossFinding() {
             "guilt: already-published carousel is not eligible for a fresh publish")
 }
 
+func test_isPublishedIndependentFieldCheck() {
+    T.suite("isQueueItemPublished / Carousel.isPublished — state & verdict checked independently (2026-07-16 final-gate finding)")
+
+    func item(state: String?, verdict: String?, url: String? = nil) -> ReviewItem {
+        var obj: [String: Any] = ["id": "x", "topic_slug": "x"]
+        if let s = state { obj["state"] = s }
+        if let v = verdict { obj["critic_overall_verdict"] = v }
+        if let u = url { obj["instagram_post_url"] = u }
+        let data = try! JSONSerialization.data(withJSONObject: obj)
+        return try! JSONDecoder().decode(ReviewItem.self, from: data)
+    }
+
+    func fakeCarousel(state: String?, criticVerdict: String?, instagramURL: String? = nil) -> Carousel {
+        Carousel(slug: "x", directory: URL(fileURLWithPath: "/tmp/x"),
+                 slidesDir: URL(fileURLWithPath: "/tmp/x/slides"), slidePNGs: [],
+                 modified: Date(), topic: nil, domain: nil, criticVerdict: criticVerdict,
+                 slideCount: 8, imagegenFallback: false, coverURL: nil, metrics: nil,
+                 instagramURL: instagramURL, publishedAt: nil, canvaURL: nil, state: state)
+    }
+
+    // COLPEVOLEZZA — the exact corner caught in final-gate review: verdict="pass" is
+    // non-nil, so the OLD coalesced `critic_overall_verdict ?? state` NEVER even looked
+    // at `state`. An app-enqueued legacy row (pre-#2442 fabricated "pass" verdict)
+    // later marked `state: "published"` with no URL backfill must still read as
+    // published — each field is now checked independently, not coalesced.
+    T.check(isQueueItemPublished(item(state: "published", verdict: "pass")),
+            "guilt: verdict=\"pass\" no longer masks state=\"published\" (isQueueItemPublished)")
+    T.check(fakeCarousel(state: "published", criticVerdict: "pass").isPublished,
+            "guilt: same corner case on Carousel.isPublished")
+
+    // INNOCENZA — every previously-working path must still work.
+    T.check(isQueueItemPublished(item(state: nil, verdict: nil, url: "https://instagram.com/p/x/")),
+            "innocence: URL alone still marks published")
+    T.check(isQueueItemPublished(item(state: "published", verdict: nil)),
+            "innocence: state alone (no verdict) still marks published")
+    T.check(isQueueItemPublished(item(state: nil, verdict: "published")),
+            "innocence: verdict alone (no state) still marks published")
+    T.check(isQueueItemPublished(item(state: "drafted", verdict: "pass")) == false,
+            "innocence: neither field says \"published\" -> not published (independent OR doesn't over-trigger)")
+    T.check(fakeCarousel(state: "drafted", criticVerdict: "pass").isPublished == false,
+            "innocence: same non-trigger case on Carousel.isPublished")
+}
+
 func test_stateWiredThroughScanCarousels() {
     T.suite("WarRoom.scanCarousels wires raw state through the queue join (not just verdict)")
 
@@ -802,6 +845,7 @@ let suites: [() -> Void] = [
     test_matchCarouselPrecedenceOrder,
     test_completeOrNothingGateHardening,
     test_publishEligibilityCrossFinding,
+    test_isPublishedIndependentFieldCheck,
     test_stateWiredThroughScanCarousels,
     test_carouselPhaseMapping,
     test_instagramCaptionValidation,

--- a/apps/wr2-control-app/Tests/main.swift
+++ b/apps/wr2-control-app/Tests/main.swift
@@ -49,7 +49,22 @@ func makeFixtureRoot() -> URL {
     return base
 }
 
-func makeCarousel(in root: URL, slug: String, slides: [String], brief: [String: Any]? = nil) -> URL {
+/// - Parameter declareSlides: the A2 complete-or-nothing gate (WarRoom.declaredSlideCount)
+///   needs a declaration source (slides.json/manifest.json/queue slide_count) or the dir is
+///   undeclarable and excluded outright. Default `.matching` writes a `slides.json` whose
+///   `slides` array has exactly `slides.count` entries, so every PRE-EXISTING call site
+///   (written before the gate existed) stays "complete" and green without touching each one.
+///   `.none` omits slides.json entirely (for the undeclarable-dir test). `.count(n)` writes n
+///   entries regardless of `slides.count` (for the incomplete/mismatch guilt tests).
+enum DeclaredSlides {
+    case matching
+    case none
+    case count(Int)
+}
+
+@discardableResult
+func makeCarousel(in root: URL, slug: String, slides: [String], brief: [String: Any]? = nil,
+                   declareSlides: DeclaredSlides = .matching) -> URL {
     let dir = root.appendingPathComponent("carousel/\(slug)", isDirectory: true)
     let slidesDir = dir.appendingPathComponent("slides", isDirectory: true)
     try? fm.createDirectory(at: slidesDir, withIntermediateDirectories: true)
@@ -70,6 +85,18 @@ func makeCarousel(in root: URL, slug: String, slides: [String], brief: [String: 
     if let brief = brief,
        let data = try? JSONSerialization.data(withJSONObject: brief) {
         try? data.write(to: dir.appendingPathComponent("brief.json"))
+    }
+    let declaredCount: Int?
+    switch declareSlides {
+    case .matching: declaredCount = slides.count
+    case .none: declaredCount = nil
+    case .count(let n): declaredCount = n
+    }
+    if let n = declaredCount {
+        let slideEntries = (0..<n).map { ["index": $0 + 1] }
+        if let data = try? JSONSerialization.data(withJSONObject: slideEntries) {
+            try? data.write(to: dir.appendingPathComponent("slides.json"))
+        }
     }
     return dir
 }
@@ -318,6 +345,77 @@ func test_reviewQueueJoin() {
     T.check(match(5) == nil, "'other' does not join 2026-07-08-other-topic-deadbeef (suffix not hex id)")
 }
 
+// MARK: - A2 complete-or-nothing gate (2026-07-16 mandate)
+
+func test_completeOrNothingGate() {
+    T.suite("A2 complete-or-nothing gate (2026-07-16 mandate)")
+
+    let root = makeFixtureRoot()
+    defer { try? fm.removeItem(at: root) }
+    let croot = root.appendingPathComponent("carousel", isDirectory: true)
+
+    // INNOCENZA — N-of-N via slides.json (source a): a full render passes through unaffected.
+    _ = makeCarousel(in: root, slug: "complete-5", slides: (1...5).map { "\($0).png" })
+
+    // COLPEVOLEZZA — declared (9) != disk (8): must be excluded entirely, not just flagged.
+    _ = makeCarousel(in: root, slug: "mismatch-9-vs-8", slides: (1...8).map { "\($0).png" },
+                      declareSlides: .count(9))
+
+    // COLPEVOLEZZA — no slides.json/manifest.json/queue entry at all: undeclarable, excluded
+    // even though real PNGs exist on disk (never silently trust raw disk count).
+    _ = makeCarousel(in: root, slug: "undeclarable", slides: ["1.png", "2.png"], declareSlides: .none)
+
+    // fallback (b) — manifest.json total_slides, no slides.json (external-import shape).
+    let manifestDir = makeCarousel(in: root, slug: "manifest-fallback", slides: ["1.png", "2.png"],
+                                    declareSlides: .none)
+    let manifestJSON: [String: Any] = ["total_slides": 2, "imported": true]
+    try? JSONSerialization.data(withJSONObject: manifestJSON)
+        .write(to: manifestDir.appendingPathComponent("manifest.json"))
+
+    // fallback (c) — queue slide_count, no slides.json/manifest.json at all.
+    _ = makeCarousel(in: root, slug: "queue-fallback", slides: ["1.png", "2.png", "3.png"],
+                      declareSlides: .none)
+
+    // published exemption — undeclarable AND the only 1 disk PNG, but published: must stay
+    // visible regardless (immutable, REPOINT-guarded — never hidden retroactively).
+    _ = makeCarousel(in: root, slug: "published-partial", slides: ["1.png"], declareSlides: .none)
+
+    let queueJSON = """
+    [
+      {"id":"qf","topic_slug":"queue-fallback","slide_count":3,"state":"drafted"},
+      {"id":"pp","topic_slug":"published-partial","state":"pass",
+       "instagram_post_url":"https://instagram.com/p/xyz",
+       "instagram_published_at":"2026-06-01T00:00:00Z"}
+    ]
+    """
+    let qurl = fm.temporaryDirectory.appendingPathComponent("q-\(UUID()).json")
+    try? queueJSON.data(using: .utf8)!.write(to: qurl)
+    defer { try? fm.removeItem(at: qurl) }
+    let queue = WarRoom.readQueue(queueFile: qurl)
+    T.eq(queue.count, 2, "gate-test queue fixture decoded")
+
+    let carousels = WarRoom.scanCarousels(carouselRoot: croot, queue: queue)
+    func find(_ slug: String) -> Carousel? { carousels.first(where: { $0.slug == slug }) }
+
+    T.check(find("complete-5") != nil, "innocence: N-of-N (slides.json) is listed")
+    T.eq(find("complete-5")?.slideCount, 5, "innocence: displayed count == declared == disk")
+
+    T.check(find("mismatch-9-vs-8") == nil, "guilt: declared=9 vs disk=8 is excluded entirely")
+    T.check(find("undeclarable") == nil, "guilt: no declaration source at all is excluded")
+
+    T.check(find("manifest-fallback") != nil, "fallback (b): manifest.json total_slides accepted")
+    T.eq(find("manifest-fallback")?.slideCount, 2, "fallback (b): displayed count from manifest.json")
+
+    T.check(find("queue-fallback") != nil, "fallback (c): queue slide_count accepted")
+    T.eq(find("queue-fallback")?.slideCount, 3, "fallback (c): displayed count from queue join")
+
+    T.check(find("published-partial") != nil,
+            "published exemption: undeclarable+mismatched but published stays visible")
+
+    T.eq(WarRoom.excludedIncompleteCount, 2,
+         "excludedIncompleteCount counts exactly the 2 unpublished exclusions (mismatch + undeclarable)")
+}
+
 // MARK: - carousel phase mapping (pipeline↔app coherence, 2026-06-25)
 
 func test_carouselPhaseMapping() {
@@ -507,6 +605,7 @@ let suites: [() -> Void] = [
     test_topicPrompt,
     test_adversarialFixes,
     test_reviewQueueJoin,
+    test_completeOrNothingGate,
     test_carouselPhaseMapping,
     test_instagramCaptionValidation,
     test_instagramCaptionProcessContract,

--- a/apps/wr2-control-app/Tests/queuewritertest/main.swift
+++ b/apps/wr2-control-app/Tests/queuewritertest/main.swift
@@ -61,6 +61,79 @@ import Foundation
         expect(enqueued.contains("\"critic_overall_verdict\":\"not_run\""),
                "enqueueDrafted honestly records \"not_run\" (no critic ever ran on this path)")
 
+        // --- Publish-eligibility fail-closed gate (2026-07-16 cross-finding with the -
+        // Python A3 daily-reconciler): markPublished must refuse a not-ready state, and
+        // must leave the queue entry byte-for-byte unchanged when it does (no partial
+        // mutation snuck in before the guard fires).
+        func makeQueue(state: String, extra: String = "") -> URL {
+            let d = FileManager.default.temporaryDirectory.appendingPathComponent("wr2q-\(UUID().uuidString)")
+            try! FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+            let f = d.appendingPathComponent("q.json")
+            try! Data("""
+            [{"id":"a","topic_slug":"gate-test","state":"\(state)"\(extra)}]
+            """.utf8).write(to: f)
+            return f
+        }
+
+        // COLPEVOLEZZA — render_incomplete (the A3 reconciler's queue-level state for a
+        // declared/disk mismatch it could not explain as stale metadata) must refuse.
+        let qfIncomplete = makeQueue(state: "render_incomplete")
+        var threwIncomplete = false
+        do { try QueueWriter.markPublished(queueFile: qfIncomplete, slug: "gate-test", igURL: "https://instagram.com/p/X/", publishedAt: "2026-07-16") }
+        catch { threwIncomplete = true }
+        expect(threwIncomplete, "markPublished refuses a render_incomplete entry")
+        let afterIncomplete = try! JSONSerialization.jsonObject(with: Data(contentsOf: qfIncomplete)) as! [[String: Any]]
+        expect((afterIncomplete[0]["state"] as? String) == "render_incomplete",
+               "refused publish leaves state untouched (no partial mutation)")
+        expect(afterIncomplete[0]["instagram_post_url"] == nil,
+               "refused publish never writes instagram_post_url")
+
+        // COLPEVOLEZZA (generalization — not a hardcoded string check on just one
+        // literal) — any other not-ready state (in-flight render, quality bounce,
+        // rejection) must ALSO refuse, since the gate classifies via CarouselPhase, not
+        // a narrow allow-list of one string.
+        for badState in ["rendering", "soft_fail", "render_failed", "rejected", "missed"] {
+            let qf3 = makeQueue(state: badState)
+            var threw3 = false
+            do { try QueueWriter.markPublished(queueFile: qf3, slug: "gate-test", igURL: "https://instagram.com/p/X/", publishedAt: "2026-07-16") }
+            catch { threw3 = true }
+            expect(threw3, "markPublished refuses state \"\(badState)\"")
+        }
+
+        // INNOCENZA — genuinely ready states must still publish. "drafted" is already
+        // exercised as the baseline case at the top of this file; here we additionally
+        // prove the fix doesn't over-restrict the OTHER waitlist-band states.
+        for goodState in ["drafted", "rendered", "approved", "applied_ready_for_damar"] {
+            let qf4 = makeQueue(state: goodState)
+            do {
+                try QueueWriter.markPublished(queueFile: qf4, slug: "gate-test", igURL: "https://instagram.com/p/X/", publishedAt: "2026-07-16")
+                let after4 = try! JSONSerialization.jsonObject(with: Data(contentsOf: qf4)) as! [[String: Any]]
+                expect((after4[0]["state"] as? String) == "published",
+                       "markPublished still succeeds from state \"\(goodState)\" (innocence)")
+            } catch {
+                expect(false, "markPublished should NOT refuse state \"\(goodState)\": \(error)")
+            }
+        }
+
+        // INNOCENZA — a legacy-schema row with NO `state` field at all, only a
+        // critic_overall_verdict of "pass" (CarouselPhase.of treats bare "pass" as
+        // waitlist-equivalent), must still be publishable — the state-first fallback
+        // to criticVerdict must not regress legacy rows that never had a state field.
+        let dirLegacy = FileManager.default.temporaryDirectory.appendingPathComponent("wr2q-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(at: dirLegacy, withIntermediateDirectories: true)
+        let qfLegacy = dirLegacy.appendingPathComponent("q.json")
+        try! Data("""
+        [{"id":"a","topic_slug":"gate-test","critic_overall_verdict":"pass"}]
+        """.utf8).write(to: qfLegacy)
+        do {
+            try QueueWriter.markPublished(queueFile: qfLegacy, slug: "gate-test", igURL: "https://instagram.com/p/X/", publishedAt: "2026-07-16")
+            let afterLegacy = try! JSONSerialization.jsonObject(with: Data(contentsOf: qfLegacy)) as! [[String: Any]]
+            expect((afterLegacy[0]["state"] as? String) == "published",
+                   "legacy row with no state field, verdict \"pass\", still publishes (innocence)")
+        } catch {
+            expect(false, "legacy verdict-only \"pass\" row should NOT be refused: \(error)")
+        }
+
         print("RESULT: \(fails == 0 ? "GREEN" : "RED")")
         exit(fails == 0 ? 0 : 1)
     }

--- a/apps/wr2-control-app/test.sh
+++ b/apps/wr2-control-app/test.sh
@@ -37,8 +37,12 @@ echo "▸ running…"
 # -parse-as-library — swiftc's own suggested fix). This is the D2 innocence-test home.
 QW_BIN="$ROOT/build/queuewritertest"
 echo "▸ compiling QueueWriter tests…"
+# Models.swift joined in 2026-07-16: QueueWriter.markPublished now calls
+# isQueuePublishEligible/CarouselPhase (the fail-closed publish-state gate, cross-
+# finding with the Python A3 daily-reconciler) — a genuine new compile dependency, not
+# a workaround.
 swiftc -parse-as-library -sdk "$SDK" -target "$TARGET" \
-  -o "$QW_BIN" "$ROOT/Sources/QueueWriter.swift" "$ROOT/Tests/queuewritertest/main.swift"
+  -o "$QW_BIN" "$ROOT/Sources/Models.swift" "$ROOT/Sources/QueueWriter.swift" "$ROOT/Tests/queuewritertest/main.swift"
 echo "▸ running QueueWriter tests…"
 "$QW_BIN"
 


### PR DESCRIPTION
## Summary
Owner mandate (Zero, 2026-07-16): the WR2 Control app must never show drafted carousels with missing slides — "o completi o nulla".

- **Gallery gate** (`WarRoom.scanCarousels`): a carousel is listed ONLY when disk PNG count == declared slide count, resolved slides.json → manifest.json `total_slides` → review-queue `slide_count` via canonical 3-pass matching (path → exact topic_slug → anchored FSM regex). Undeclarable or mismatched + unpublished → excluded, logged, surfaced as a "N nascosti (slide incomplete)" caption (IT+ID). Published entries always visible (REPOINT-guarded immutable history).
- **Fail-closed publish guard**: new `Carousel.state` field (a stale `critic_overall_verdict:"pass"` can no longer mask a fresher `render_incomplete`); `isPublishEligible` reuses the existing `CarouselPhase` classification (fail-closed default); `QueueWriter.markPublished` refuses ineligible states with a visible error and zero partial mutation; publish buttons disabled with a visible reason banner.
- **Canonical published predicate** (`isQueueItemPublished`): trimmed non-empty IG URL OR state/verdict == "published", each field checked independently (never coalesced).

## Adversarial verification
- Codex gpt-5.6-sol (xhigh) red-team: 6 findings — all verified on disk and fixed (matching precedence, count ambiguity fail-closed, published-exemption reality check, canonical resolver for publication maps, counter reset on I/O error, realistic fixtures incl. object-schema slides.json).
- **Real-data census** (129 physical dirs, 76 queue items, read-only): 90 listed / 28 hidden-incomplete / 13 hidden smoke-test residue; regression diff vs pre-gate baseline byte-identical on every real carousel, zero legitimate losses, and one LIVE phantom-duplicate card bug fixed (Rp2.8T carousel).
- Tests: 131 passed / 0 failed (+38 new assertions incl. guilt+innocence for gate, publish guard, published predicate). `./build.sh` 0 errors. Pre-push backend suite 17185 passed.

App bundle replacement on M5 happens at app-quit (operator; source-of-truth rebuilt from this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)