### PR TITLE
docs(research): correct Codex seat labels to GPT-5.6-sol; pin xhigh for red-team runs

### DIFF
--- a/research/operations/2026-07-16-kbli-filiera-methodology.md
+++ b/research/operations/2026-07-16-kbli-filiera-methodology.md
@@ -8,7 +8,7 @@ sources:
   - "BPS Tabel Konversi KBLI 2020–KBLI 2025 (publication 2026-04-22, https://www.bps.go.id/id/publication/2026/04/22/909d503355d2b7664e43dea8/tabel-konversi-kbli-2020-kbli-2025.html)"
   - "Permen Investasi dan Hilirisasi/BKPM No. 5/2025 (in force 2025-10-02, revokes BKPM 3/2021, 4/2021, 5/2021 — https://peraturan.bpk.go.id/Details/332573/permeninvesbkpm-no-5-tahun-2025)"
   - "memory: discovery_kbli_68112_code_collision_pp28_vs_bps_2026_07_16, discovery_kbli_noscope_codes_per_skala_not_from_oss_2026_07_16, discovery_kg_perizinan_name_dedup_disease_2026_07_16, lesson_kbli_remap_gate_context_beats_title_2026_07_16"
-  - "adversarial panel 2026-07-16: Codex GPT-5.5 red-team (15 findings, 5 FATAL) + Gemini 3.1 Pro costruttivo (12 suggestions)"
+  - "adversarial panel 2026-07-16: Codex GPT-5.6-sol red-team (15 findings, 5 FATAL; CLI default gpt-5.6-sol, effort medium) + Gemini 3.1 Pro costruttivo (12 suggestions)"
 adversarial_review: codex
 ---
 
@@ -208,7 +208,7 @@ previous), and a permitted-use note (public portal data, no PII, snapshot-for-ve
    with liveness receptors, not just KeepAlive).
 
 ## Adversarial review (generator≠grader panel record)
-- Codex GPT-5.5 red-team: 15 findings (5 FATAL, 10 MAJOR) — all incorporated above; the two
+- Codex GPT-5.6-sol red-team (CLI default, effort medium): 15 findings (5 FATAL, 10 MAJOR) — all incorporated above; the two
   factual FATALs (Perpres annexes are 2020-vintage; BKPM 4/2021 revoked by 5/2025) independently
   verified this session (web, primary-source links in frontmatter).
 - Gemini 3.1 Pro costruttivo: 12 suggestions — incorporated: L2b sectoral layer, PB-UMKU, capital

--- a/research/operations/2026-07-16-kbli-garuda-filiera-workflow.md
+++ b/research/operations/2026-07-16-kbli-garuda-filiera-workflow.md
@@ -7,7 +7,7 @@ sources:
   - "companion: research/operations/2026-07-16-kbli-filiera-methodology.md (P1-P9, L0-L6, G13-G17)"
   - "mandate: Zero 2026-07-16 — 'ideare il workflow di agenti e LLM, scegliere l'orchestratore-mente-immobile, programma di ricostruzione dei singoli KBLI in maniera scientifica'"
   - "live enumeration 2026-07-16 on KBLI_2025_FINAL_CLEAN.json (119 / 478 / 1,263 / ~175 risk classes)"
-  - "adversarial panel 2026-07-16: Codex GPT-5.5 red-team (12 findings, 4 FATAL) + Gemini 3.1 Pro costruttivo (10 suggestions)"
+  - "adversarial panel 2026-07-16: Codex GPT-5.6-sol red-team (12 findings, 4 FATAL; CLI default gpt-5.6-sol, effort medium) + Gemini 3.1 Pro costruttivo (10 suggestions)"
 ---
 
 # GARUDA-FILIERA — the per-code KBLI reconstruction program (agents, seats, orchestrator)
@@ -51,7 +51,7 @@ sources:
 | Extractor | **Sonnet 5** (`model:"sonnet"`) | Workflow `agent()` | structured extraction from lampiran IMAGE renders; crosswalk mapping proposals with uraian-level rationale |
 | Vision locator | **qwen2.5vl:7b** (Ollama, Mini) | local batch | page/row triage on 300-dpi renders — LOCATOR ONLY, never the reader |
 | Width / regulatory search | **Gemini via `agy`** | CLI background | normativa search; long-context volume reads; BPS-table ingestion checks |
-| Red-team | **Codex GPT-5.5** | `codex exec --sandbox read-only < /dev/null` | attack mapping proposals + batch reports; sandbox checks on compiler outputs |
+| Red-team | **Codex GPT-5.6-sol** | `codex exec -m gpt-5.6-sol -c model_reasoning_effort="xhigh" --sandbox read-only < /dev/null` | attack mapping proposals + batch reports; sandbox checks on compiler outputs. `gpt-5.6-luna` available for mechanical Codex-side lanes |
 | Refuter (3rd family) | **GLM 5.2 → DeepSeek v4-pro → (swap rule §6)** | probe-then-cascade | blind re-extraction + falsification of non-deterministic facts |
 | Ground truth | **NotebookLM** (bipolar) | MCP | regulatory-claim verification ONLY with W90 freshness check |
 | Operator | **Zero** | Legge 5 | batch GO, publish decisions, consents |
@@ -179,7 +179,7 @@ order within a class (division/group) to maximize prompt-cache reuse (Gemini).
 
 ## Adversarial review (generator≠grader panel record)
 
-- **Codex GPT-5.5 red-team, 12 findings (4 FATAL, 8 MAJOR)** — all incorporated: F1 SPOF →
+- **Codex GPT-5.6-sol red-team (CLI default, effort medium), 12 findings (4 FATAL, 8 MAJOR)** — all incorporated: F1 SPOF →
   accepted-by-design with durable-state mitigation (§1); F2 resume → op_id idempotency + hash
   chain (§3); F3 races → leases + pinned manifests + fencing (§3); F4 crosswalk overreach → no
   deterministic 1-to-1 acceptance, uraian-equivalence check (§3 D1); F5 correlated verification →


### PR DESCRIPTION
## Summary
- The 2026-07-16 adversarial panels actually ran on gpt-5.6-sol (codex-cli 0.144.4 default, effort medium) — the "GPT-5.5" labels in the two Filiera research docs were inherited from the stale global arsenal doc (v0.133 era). Panel records now state what actually ran; the GARUDA-FILIERA seat table pins `-m gpt-5.6-sol -c model_reasoning_effort="xhigh"` for future red-team runs per the verified family routing (sol=critical, terra=standard, luna=grunt).

## Test plan
- [x] Docs-only; `grep -c GPT-5.5` on both files = 0; backend suite green via pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)