### PR TITLE
feat(hooks): data-plane guard — registry-based PreToolUse block on curated datasets

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PROJECT_DIR}/infra/claude-hooks/data_plane_guard.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,11 +38,11 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|NotebookEdit|Bash",
+        "matcher": "Edit|Write|NotebookEdit|Bash|Monitor",
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PROJECT_DIR}/infra/claude-hooks/data_plane_guard.py"
+            "command": "python3 \"${CLAUDE_PROJECT_DIR}/infra/claude-hooks/data_plane_guard.py\""
           }
         ]
       }

--- a/.github/workflows/hook-innocence-gate.yml
+++ b/.github/workflows/hook-innocence-gate.yml
@@ -106,6 +106,7 @@ jobs:
             infra/claude-hooks/test_host_boundary.py \
             infra/claude-hooks/test_phase.py \
             infra/claude-hooks/test_w79_shell_write.py \
+            infra/claude-hooks/test_data_plane_guard.py \
             scripts/test_guardrails_overmatch.py \
             scripts/test_guardrails_core_overmatch.py ; do
             if [ -f "$t" ]; then

--- a/.github/workflows/hook-innocence-gate.yml
+++ b/.github/workflows/hook-innocence-gate.yml
@@ -14,6 +14,9 @@ name: Hook innocence gate (vaccine)
 #   - infra/claude-hooks/test_host_boundary.py    (host_boundary carve-out)
 #   - infra/claude-hooks/test_phase.py            (plan-phase detection)
 #   - infra/claude-hooks/test_w79_shell_write.py  (W79 shell-write detection)
+#   - infra/claude-hooks/test_data_plane_guard.py (data-plane guard, incl. a
+#     .claude/settings.json wiring assertion — a settings-only regression
+#     that breaks the matcher/command now fails this gate too)
 #   - scripts/test_guardrails_core_overmatch.py   (guardrails python-c over-match)
 #
 # SENTINEL PATTERN (W69, copied from verify-the-verifiers.yml): NO top-level
@@ -35,6 +38,7 @@ on:
       - "scripts/test_guardrails_overmatch.py"
       - "scripts/test_guardrails_core_overmatch.py"
       - "scripts/guardrails_sync_check.py"
+      - ".claude/settings.json"
       - ".github/workflows/hook-innocence-gate.yml"
 
 concurrency:
@@ -64,7 +68,7 @@ jobs:
           fi
           base="${{ github.event.pull_request.base.sha }}"
           if git diff --name-only "$base"...HEAD | grep -qE \
-            '^(infra/claude-hooks/|scripts/hooks/|scripts/guardrails_static_core\.py|scripts/test_guardrails_overmatch\.py|scripts/test_guardrails_core_overmatch\.py|scripts/guardrails_sync_check\.py|\.github/workflows/hook-innocence-gate\.yml)'; then
+            '^(infra/claude-hooks/|scripts/hooks/|scripts/guardrails_static_core\.py|scripts/test_guardrails_overmatch\.py|scripts/test_guardrails_core_overmatch\.py|scripts/guardrails_sync_check\.py|\.claude/settings\.json|\.github/workflows/hook-innocence-gate\.yml)'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/infra/claude-hooks/data-plane-registry.json
+++ b/infra/claude-hooks/data-plane-registry.json
@@ -1,0 +1,16 @@
+{
+  "_doc": "Data-plane registry (superscar #3 generalization, 2026-07-16). Maps curated datasets that must ONLY be written by their program's deterministic compiler scripts, never hand-edited by an interactive session or a stray Bash write. ANY program registers its own data plane by appending an entry here — this file, not the hook code, is the extension point: a new program never needs to touch infra/claude-hooks/data_plane_guard.py, it just adds {id, owner, compilers, protected} to `entries`. `protected` globs are matched against the path RELATIVE TO THE GIT ROOT (main checkout or a .worktrees/* worktree — the hook resolves whichever git root actually contains the file), so protection follows the dataset into every worktree. Missing/corrupt registry = the hook PASSES THROUGH with a WARN (infra failure must never brick Edit/Write/Bash).",
+  "version": 1,
+  "entries": [
+    {
+      "id": "kbli-filiera",
+      "owner": "GARUDA-FILIERA program (research/operations/2026-07-16-kbli-garuda-filiera-workflow.md)",
+      "compilers": "scripts/kbli_filiera/",
+      "protected": [
+        "data/kbli-filiera/**",
+        "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
+        "data/source_documents/KBLI_2025_OSS_GROUND_TRUTH.json"
+      ]
+    }
+  ]
+}

--- a/infra/claude-hooks/data-plane-registry.json
+++ b/infra/claude-hooks/data-plane-registry.json
@@ -7,6 +7,7 @@
       "owner": "GARUDA-FILIERA program (research/operations/2026-07-16-kbli-garuda-filiera-workflow.md)",
       "compilers": "scripts/kbli_filiera/",
       "protected": [
+        "data/kbli-filiera",
         "data/kbli-filiera/**",
         "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
         "data/source_documents/KBLI_2025_OSS_GROUND_TRUTH.json"

--- a/infra/claude-hooks/data_plane_guard.py
+++ b/infra/claude-hooks/data_plane_guard.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""data_plane_guard — PreToolUse hook 🔴 (data-plane protection, registry-based).
+
+Blocks INTERACTIVE hand-edits of curated datasets that must only be written by
+their program's sanctioned COMPILER scripts (e.g. GARUDA-FILIERA's
+`scripts/kbli_filiera/*.py` writing `data/kbli-filiera/**`). This generalizes
+to every program in the org via `infra/claude-hooks/data-plane-registry.json`
+— a new program registers its data plane by adding one entry there; this file
+never needs to change.
+
+WHY THIS EXISTS: a compiled dataset hand-edited once by a session "just this
+once" silently diverges from the pipeline that is supposed to be its single
+source of truth — the exact state-schema-mutation-drift disease (superscar
+#9) one layer earlier: catching the edit BEFORE it lands, not after a reader
+breaks on it.
+
+CONTRACT (identical stdin/exit-code shape to host_boundary.py /
+worktree_isolation.py in this same dir): JSON payload on stdin with
+`tool_name` (or `name`), `tool_input`, `cwd`. Exit 2 + stderr = BLOCK.
+Exit 0 (no stderr, or a WARN line) = ALLOW.
+
+SURFACES COVERED:
+  - Edit / Write / NotebookEdit: `tool_input.file_path` (or `notebook_path`
+    for NotebookEdit) resolved and matched against every registry glob.
+  - Bash: DIRECT shell-level writes only — redirects (`>`/`>>`), `tee`,
+    `cp`/`mv`/`install`/`rsync` destination, `sed -i`, `truncate`, `rm`.
+    Reads (`cat`, `grep`, `jq`, a compiler invocation like `python3
+    scripts/kbli_filiera/build.py`) are NOT a write operator and pass
+    trivially — no write-hint keyword, no target extracted.
+
+WORKTREE-AWARE MATCHING (superscar #3, W83/W84/W91/W92/W94 studied first —
+guard-over-match on substrings, cross-line quote fusion, relative paths
+resolved against the wrong cwd, whole-command exemptions): a protected glob
+is repo-RELATIVE (`data/kbli-filiera/**`), but a session usually edits inside
+`.worktrees/<lane>-<task-id>/...`, not the main checkout. Resolving the
+absolute file path against a hardcoded main-checkout root would silently
+under-block every worktree edit — exactly where sessions do their work. So
+matching walks UP from the resolved absolute path looking for the nearest
+`.git` entry (a worktree carries its OWN `.git` file; the main checkout
+carries a `.git` directory) and relativizes against THAT — the file's own
+git root, whichever checkout it happens to live in.
+
+Quote/heredoc noise-stripping on the Bash channel reuses the W84-fixed
+recipe (character classes exclude `\n` so a stray apostrophe/quote on one
+line can never fuse with a quote on a LATER line and swallow real commands
+into "quoted text"). Bash target extraction is deliberately simpler than
+worktree_isolation.py's segment-scoped remote-dispatch machinery — that
+machinery exists to decide "did this git op touch OUR checkout", a question
+this guard doesn't ask. Here the write-hint tokens already stop at
+`&`/`;`/`|`/whitespace by construction (the same char classes), so a target
+can never bleed across a `&&`/`;`/`|` boundary into the wrong segment. Per
+the spec: Edit/Write is the primary surface; Bash is deliberately
+conservative and prefers UNDER-blocking over a new over-match member of
+family #3.
+
+Kill switch: DATA_PLANE_GUARD_OFF=1 → always exit 0 (behaviour = before this
+hook). Missing/corrupt registry → PASS-THROUGH with a WARN (an infra-file
+problem must never brick unrelated Edit/Write/Bash calls).
+
+Reference: cicatrix-superscar.md #3 (guard-over-match) + #9 (state-schema
+drift) · registry: infra/claude-hooks/data-plane-registry.json · conformance:
+infra/guard-conformance/registry.json.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import pathlib
+import re
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent  # infra/claude-hooks
+
+
+# --------------------------------------------------------------------------
+# Repo/registry resolution
+# --------------------------------------------------------------------------
+
+def _repo_root() -> pathlib.Path:
+    """CLAUDE_PROJECT_DIR if set (the harness always points this at the
+    active session's project dir — main checkout or worktree), else the
+    hook file's own repo root (two parents up from infra/claude-hooks/)."""
+    env = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env:
+        return pathlib.Path(env)
+    return HERE.parent.parent
+
+
+def _registry_path() -> pathlib.Path:
+    return _repo_root() / "infra" / "claude-hooks" / "data-plane-registry.json"
+
+
+def _load_registry() -> list[dict] | None:
+    """Registry entries, or None (+ WARN on stderr) on any load failure —
+    never block on our own infra breaking."""
+    path = _registry_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        sys.stderr.write(
+            f"data_plane_guard WARN: registry unreadable ({path}): {exc} "
+            "— pass-through\n"
+        )
+        return None
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        sys.stderr.write(
+            f"data_plane_guard WARN: registry malformed (no 'entries' list "
+            f"at {path}) — pass-through\n"
+        )
+        return None
+    return entries
+
+
+# --------------------------------------------------------------------------
+# Path resolution — worktree-aware repo-relative matching
+# --------------------------------------------------------------------------
+
+def _git_root_for(path: pathlib.Path) -> pathlib.Path | None:
+    """Nearest ancestor carrying a `.git` entry (file, in a worktree, or
+    dir, in the main checkout) — the file's OWN repo root, not a hardcoded
+    one. Pure filesystem walk, no subprocess."""
+    cur = path if path.is_dir() else path.parent
+    for ancestor in (cur, *cur.parents):
+        if (ancestor / ".git").exists():
+            return ancestor
+    return None
+
+
+def _repo_relative(resolved: pathlib.Path) -> str:
+    """`resolved` relative to its own git root (worktree-aware); falls back
+    to `_repo_root()`, then to the absolute path (which then simply will
+    not match any repo-relative glob — safe under-block, never a false
+    block)."""
+    git_root = _git_root_for(resolved)
+    if git_root is not None:
+        try:
+            return resolved.relative_to(git_root).as_posix()
+        except ValueError:
+            pass
+    try:
+        return resolved.relative_to(_repo_root()).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _resolve_target(path_str: str, cwd: str) -> pathlib.Path | None:
+    """Resolve a possibly-relative path against cwd. None on any failure —
+    an unresolvable target is never blocked (conservative)."""
+    try:
+        p = pathlib.Path(os.path.expanduser(os.path.expandvars(path_str)))
+        if not p.is_absolute() and cwd:
+            p = pathlib.Path(cwd) / p
+        return p.resolve()
+    except Exception:
+        return None
+
+
+# Residue filter (adapted from worktree_isolation.py's _is_plausible_path):
+# a real write target has a directory separator, a file extension, or is a
+# dotfile. Rejects operator/shell residue that survived noise-stripping
+# (`2`, `''`, `=0.9`) so it can never be mistaken for a protected path.
+_PATH_LIKE_RE = re.compile(r"^[~$]?[\w./@+-]+$")
+_FILE_EXT_RE = re.compile(r"\.[A-Za-z][A-Za-z0-9]{0,7}$")
+
+
+def _is_plausible_path(t: str) -> bool:
+    if not t or len(t) > 256:
+        return False
+    if not _PATH_LIKE_RE.match(t):
+        return False
+    if "=" in t:
+        return False
+    has_sep = "/" in t
+    has_ext = bool(_FILE_EXT_RE.search(t))
+    is_dotfile = t.startswith(".") and len(t) > 1
+    return has_sep or has_ext or is_dotfile
+
+
+def _matched_entry(rel: str, entries: list[dict]) -> tuple[dict, str] | None:
+    """First (entry, matched_glob) whose `protected` list matches `rel`."""
+    for entry in entries:
+        for pattern in entry.get("protected", []):
+            if fnmatch.fnmatchcase(rel, pattern):
+                return entry, pattern
+    return None
+
+
+# --------------------------------------------------------------------------
+# Bash channel — direct shell-level writes only
+# --------------------------------------------------------------------------
+
+WRITE_HINT_RE = re.compile(
+    r"(>>?|\btee\b|\bsed\b[^|;&]*-i|\btruncate\b|\brm\b|\b(?:cp|mv|install|rsync)\b)"
+)
+REDIR_RE = re.compile(r"(?:[0-9]?>|&>)>?\s*([^\s|;&)]+)")
+VERB_RE = re.compile(
+    r"\b(cp|mv|install|rsync|truncate|rm|tee)\b((?:\s+(?:-\S+|[^\s|;&)]+))+)"
+)
+SED_INVOCATION_RE = re.compile(r"\bsed\b((?:\s+(?:-\S+|[^\s|;&)]+))+)")
+
+# rm/tee can write MULTIPLE targets in one invocation (every non-flag arg is
+# a destination); cp/mv/install/rsync/truncate take the LAST non-flag token
+# (source(s)... DEST).
+_ALL_TARGETS_VERBS = {"rm", "tee"}
+
+
+def _strip_noise(cmd: str) -> str:
+    """Neutralize heredoc bodies + quoted strings before scanning for write
+    targets (W79/W84 false-positive killer, cloned from worktree_isolation.py
+    / host_boundary.py). W84: the quote char-classes MUST exclude `\\n` — a
+    class that crosses newlines fuses an apostrophe on one line with a quote
+    several lines later, collapsing multiple commands into one mangled
+    string and producing a phantom write-target."""
+    def _drop_heredocs(s: str) -> str:
+        lines = s.split("\n")
+        out: list[str] = []
+        i = 0
+        hd_re = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+        while i < len(lines):
+            line = lines[i]
+            m = hd_re.search(line)
+            out.append(line)
+            if m:
+                word = m.group(2)
+                i += 1
+                while i < len(lines) and lines[i].strip() != word:
+                    i += 1
+                i += 1
+                continue
+            i += 1
+        return "\n".join(out)
+
+    s = _drop_heredocs(cmd)
+    s = re.sub(r"'[^'\n]*'", "''", s)
+    s = re.sub(r'"[^"\n]*"', '""', s)
+    return s
+
+
+def _extract_bash_write_targets(cmd: str) -> list[str]:
+    """Best-effort candidate write-destination paths. Conservative: a target
+    we cannot confidently extract is simply not returned (→ command is
+    ALLOWED, per the spec's under-block preference on this channel)."""
+    stripped = _strip_noise(cmd)
+    if not WRITE_HINT_RE.search(stripped):
+        return []
+
+    targets: list[str] = []
+
+    for m in REDIR_RE.finditer(stripped):
+        targets.append(m.group(1))
+
+    for m in VERB_RE.finditer(stripped):
+        verb = m.group(1)
+        args = [a for a in m.group(2).split() if not a.startswith("-")]
+        if not args:
+            continue
+        if verb in _ALL_TARGETS_VERBS:
+            targets.extend(args)
+        else:
+            targets.append(args[-1])
+
+    # sed -i: take the LAST non-flag token of the whole invocation, not a
+    # positional "script argument" guess — robust to BOTH GNU
+    # (`sed -i 's/a/b/' file`, one quoted-script arg) and BSD/macOS
+    # (`sed -i '' 's/a/b/' file`, an EXTRA empty-suffix arg before the
+    # script) forms, since after noise-stripping every quoted arg collapses
+    # to `''`/`""` and the real file path is always the tail token either way.
+    for m in SED_INVOCATION_RE.finditer(stripped):
+        args = m.group(1).split()
+        if not any(a == "-i" or a.startswith("-i") for a in args):
+            continue  # sed without -i writes to stdout, not a file write
+        nonflag = [a for a in args if not a.startswith("-")]
+        if nonflag:
+            targets.append(nonflag[-1])
+
+    cleaned: list[str] = []
+    for t in targets:
+        t = t.strip().strip("'\"")
+        if not t or t.startswith("/dev/") or t in {"&1", "&2"} or t.startswith("$("):
+            continue
+        if not _is_plausible_path(t):
+            continue
+        cleaned.append(t)
+    return cleaned
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+def _block(rel: str, entry: dict, pattern: str, surface: str) -> None:
+    sys.stderr.write(
+        "DATA-PLANE GUARD VIOLATION (hand-edit of a curated dataset)\n"
+        f"  surface : {surface}\n"
+        f"  target  : {rel}\n"
+        f"  matched : registry entry `{entry.get('id', '?')}` (owner: "
+        f"{entry.get('owner', '?')}), glob `{pattern}`\n"
+        "  This dataset is compiled, not hand-edited. Route the change\n"
+        f"  through the program's compiler scripts ({entry.get('compilers', '?')}),\n"
+        "  or open an implementer-lane PR that touches the source-of-truth\n"
+        "  inputs instead. Escape hatch (only if this block is itself wrong):\n"
+        "  DATA_PLANE_GUARD_OFF=1\n"
+    )
+    sys.exit(2)
+
+
+def main() -> int:
+    if os.environ.get("DATA_PLANE_GUARD_OFF") == "1":
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # unparseable → never block on our own parse failure
+
+    entries = _load_registry()
+    if entries is None:
+        return 0  # pass-through, WARN already emitted by _load_registry
+
+    tool = payload.get("tool_name") or payload.get("name") or ""
+    cwd = payload.get("cwd", "")
+    tool_input = payload.get("tool_input") or {}
+
+    if tool in ("Edit", "Write", "NotebookEdit"):
+        fp = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+        if fp:
+            resolved = _resolve_target(fp, cwd)
+            if resolved is not None:
+                rel = _repo_relative(resolved)
+                hit = _matched_entry(rel, entries)
+                if hit is not None:
+                    entry, pattern = hit
+                    _block(rel, entry, pattern, f"{tool} file_path")
+        return 0
+
+    if tool == "Bash":
+        cmd = tool_input.get("command", "")
+        for raw in _extract_bash_write_targets(cmd):
+            resolved = _resolve_target(raw, cwd)
+            if resolved is None:
+                continue
+            rel = _repo_relative(resolved)
+            hit = _matched_entry(rel, entries)
+            if hit is not None:
+                entry, pattern = hit
+                _block(rel, entry, pattern, "Bash write")
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/claude-hooks/data_plane_guard.py
+++ b/infra/claude-hooks/data_plane_guard.py
@@ -8,64 +8,80 @@ to every program in the org via `infra/claude-hooks/data-plane-registry.json`
 — a new program registers its data plane by adding one entry there; this file
 never needs to change.
 
-WHY THIS EXISTS: a compiled dataset hand-edited once by a session "just this
-once" silently diverges from the pipeline that is supposed to be its single
-source of truth — the exact state-schema-mutation-drift disease (superscar
-#9) one layer earlier: catching the edit BEFORE it lands, not after a reader
-breaks on it.
-
 CONTRACT (identical stdin/exit-code shape to host_boundary.py /
 worktree_isolation.py in this same dir): JSON payload on stdin with
 `tool_name` (or `name`), `tool_input`, `cwd`. Exit 2 + stderr = BLOCK.
 Exit 0 (no stderr, or a WARN line) = ALLOW.
 
 SURFACES COVERED:
-  - Edit / Write / NotebookEdit: `tool_input.file_path` (or `notebook_path`
-    for NotebookEdit) resolved and matched against every registry glob.
-  - Bash: DIRECT shell-level writes only — redirects (`>`/`>>`), `tee`,
-    `cp`/`install`/`rsync` destination, `mv` source AND destination (mv
-    destroys its source, so a protected source blocks too — cp/install/rsync
-    sources are read-only and stay allowed), `sed -i`, `truncate`, `rm`.
-    Reads (`cat`, `grep`, `jq`, a compiler invocation like `python3
-    scripts/kbli_filiera/build.py`) are NOT a write operator and pass
-    trivially — no write-hint keyword, no target extracted.
+  - Edit / Write / NotebookEdit: `tool_input.file_path` (or `notebook_path`).
+  - Bash AND Monitor (both execute arbitrary shell commands via
+    `tool_input.command` — Monitor is not a lesser surface, it is the SAME
+    shell channel with different scheduling): direct shell-level writes —
+    redirects, `tee`, `cp`/`install`/`rsync` destination, `mv` source AND
+    destination, `sed -i`/`truncate` (ALL non-flag files, not just the
+    last), `dd of=`, `touch`, `perl -i`, `rm`.
 
-WORKTREE-AWARE MATCHING (superscar #3, W83/W84/W91/W92/W94 studied first —
-guard-over-match on substrings, cross-line quote fusion, relative paths
-resolved against the wrong cwd, whole-command exemptions): a protected glob
-is repo-RELATIVE (`data/kbli-filiera/**`), but a session usually edits inside
-`.worktrees/<lane>-<task-id>/...`, not the main checkout. Resolving the
-absolute file path against a hardcoded main-checkout root would silently
-under-block every worktree edit — exactly where sessions do their work. So
-matching walks UP from the resolved absolute path looking for the nearest
-`.git` entry (a worktree carries its OWN `.git` file; the main checkout
-carries a `.git` directory) and relativizes against THAT — the file's own
-git root, whichever checkout it happens to live in.
+MATCHING (case-folded — APFS/macOS is case-insensitive, a lowercase edit of
+the same real file must still block; W96-adjacent lesson) is worktree-aware:
+walks UP from the resolved absolute path to the nearest `.git` entry and
+relativizes against THAT root — but only if that root ALSO carries our own
+`infra/claude-hooks/data-plane-registry.json` (a foreign git repo that merely
+happens to be an ancestor directory, e.g. `/tmp/other/.git`, is never treated
+as a Nuzantara checkout/worktree — it falls through to the safe absolute-path
+comparison, which cannot match a repo-relative glob).
 
-Quote/heredoc noise-stripping on the Bash channel reuses the W84-fixed
-recipe (character classes exclude `\n` so a stray apostrophe/quote on one
-line can never fuse with a quote on a LATER line and swallow real commands
-into "quoted text"). Bash target extraction is deliberately simpler than
-worktree_isolation.py's segment-scoped remote-dispatch machinery — that
-machinery exists to decide "did this git op touch OUR checkout", a question
-this guard doesn't ask. Here the write-hint tokens already stop at
-`&`/`;`/`|`/whitespace by construction (the same char classes), so a target
-can never bleed across a `&&`/`;`/`|` boundary into the wrong segment. Per
-the spec: Edit/Write is the primary surface; Bash is deliberately
-conservative and prefers UNDER-blocking over a new over-match member of
-family #3.
+BASH/MONITOR COMMAND PARSING (superscar #3 studied first: W83/W84/W91/W92/W94
+— over-match on substrings, cross-line quote fusion, whole-command
+exemptions):
+  - The command is noise-stripped (heredoc bodies dropped; quoted strings
+    either unwrapped to their bare content — if that content itself looks
+    like a plain path, so `> "protected/file"` isn't invisible — or blanked
+    otherwise; then unquoted `#`-comments stripped) BEFORE anything else.
+  - It is split into SEGMENTS on `&& || ; & | <newline>` (arg separators
+    within a segment are `[ \t]` only, never `\s` — an arg-loop must not
+    cross a newline and swallow the NEXT, unrelated command).
+  - Within each segment, write-verbs are matched ONLY at command position
+    (segment start, or right after `$(`/backtick) — `grep rm <file>` or
+    `brew install jq` are never mistaken for the verb `rm`/`install` just
+    because the word appears; a verb is a command, not a substring.
+  - A segment whose command position is `ssh`/`scp` is skipped ENTIRELY for
+    THAT segment only (W94: never a whole-command exemption) — the write
+    happens on the far end, not here.
+  - A pure `cd <path>` segment updates a running list of candidate base
+    dirs; every later target is tried against the session cwd AND every
+    accumulated cd-dir.
+  - A candidate containing glob metacharacters (`*?[`) is expanded against
+    the real filesystem (`glob.glob`, capped) so `rm protected/*.jsonl`
+    cannot hide behind "no literal path token".
+  - Only REDIRECT-sourced targets go through the bare-word plausibility
+    filter (needs a separator/extension/dotfile/glob-char to look path-like,
+    filtering shell-residue like `2>&1`'s stray `2`); VERB-sourced args
+    (cp/mv/rm/tee/etc.) skip that filter — the command-position anchor
+    already proves they are real arguments, so a bare `rm manifest` inside
+    a protected cwd is not silently exempted just for lacking a slash.
 
-Kill switch: DATA_PLANE_GUARD_OFF=1 → always exit 0 (behaviour = before this
-hook). Missing/corrupt registry → PASS-THROUGH with a WARN (an infra-file
-problem must never brick unrelated Edit/Write/Bash calls).
+Registry robustness (a malformed registry must degrade to a WARN + pass-
+through, NEVER crash the hook and NEVER accidentally protect/block
+everything): non-object top-level JSON, a non-list `entries`, a non-object
+entry, or a `protected` field that isn't a list of strings (a bare STRING
+iterates as characters — `"*"` alone would then match every file) are all
+rejected per-item with a WARN, never trusted. The whole dispatch body is
+wrapped so ANY unexpected exception degrades to WARN + ALLOW — `sys.exit(2)`
+(a real block) is the one thing that still propagates through that wrapper.
+
+Kill switch: DATA_PLANE_GUARD_OFF=1 → always exit 0.
 
 Reference: cicatrix-superscar.md #3 (guard-over-match) + #9 (state-schema
 drift) · registry: infra/claude-hooks/data-plane-registry.json · conformance:
-infra/guard-conformance/registry.json.
+infra/guard-conformance/registry.json · wave-2 adversarial review (Codex
+gpt-5.6-sol xhigh, 2026-07-16): 2 CRITICAL + 10 MAJOR + 3 MINOR, all fixed
+here.
 """
 from __future__ import annotations
 
 import fnmatch
+import glob as glob_mod
 import json
 import os
 import pathlib
@@ -73,6 +89,33 @@ import re
 import sys
 
 HERE = pathlib.Path(__file__).resolve().parent  # infra/claude-hooks
+
+# --------------------------------------------------------------------------
+# Shared path-plausibility constants (used by both the quote-unwrap step in
+# _strip_noise and the redirect-target filter in _is_plausible_path).
+# --------------------------------------------------------------------------
+_PATH_LIKE_RE = re.compile(r"^[~$]?[\w./@+-]+$")
+_FILE_EXT_RE = re.compile(r"\.[A-Za-z][A-Za-z0-9]{0,7}$")
+_GLOB_CHARS_RE = re.compile(r"[*?\[]")
+_GLOB_MATCH_CAP = 2000
+
+
+def _is_plausible_path(t: str) -> bool:
+    """Real write targets have a directory separator, a file extension, a
+    dotfile prefix, or glob metacharacters. Rejects operator/shell residue
+    that survived noise-stripping (`2`, `''`, `=0.9`). Applied ONLY to
+    redirect-sourced targets (C8) — verb-sourced args are already proven
+    real by the command-position anchor."""
+    if not t or len(t) > 256:
+        return False
+    if not _PATH_LIKE_RE.match(t):
+        return bool(_GLOB_CHARS_RE.search(t))  # glob chars aren't in the path charset
+    if "=" in t:
+        return False
+    has_sep = "/" in t
+    has_ext = bool(_FILE_EXT_RE.search(t))
+    is_dotfile = t.startswith(".") and len(t) > 1
+    return has_sep or has_ext or is_dotfile
 
 
 # --------------------------------------------------------------------------
@@ -94,8 +137,11 @@ def _registry_path() -> pathlib.Path:
 
 
 def _load_registry() -> list[dict] | None:
-    """Registry entries, or None (+ WARN on stderr) on any load failure —
-    never block on our own infra breaking."""
+    """Validated registry entries, or None (+ WARN) on any load failure —
+    never block on our own infra breaking, and never trust a malformed
+    entry (B1: a bare-string `protected` iterates as characters; `"*"`
+    alone would then match every file — that entry is skipped, not the
+    whole registry)."""
     path = _registry_path()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -105,6 +151,12 @@ def _load_registry() -> list[dict] | None:
             "— pass-through\n"
         )
         return None
+    if not isinstance(data, dict):
+        sys.stderr.write(
+            f"data_plane_guard WARN: registry malformed (top-level JSON is "
+            f"not an object at {path}) — pass-through\n"
+        )
+        return None
     entries = data.get("entries")
     if not isinstance(entries, list):
         sys.stderr.write(
@@ -112,11 +164,28 @@ def _load_registry() -> list[dict] | None:
             f"at {path}) — pass-through\n"
         )
         return None
-    return entries
+    valid: list[dict] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            sys.stderr.write(
+                f"data_plane_guard WARN: registry entry is not an object, "
+                f"skipped: {entry!r}\n"
+            )
+            continue
+        protected = entry.get("protected")
+        if not isinstance(protected, list) or not all(isinstance(p, str) for p in protected):
+            sys.stderr.write(
+                f"data_plane_guard WARN: entry `{entry.get('id', '?')}` has "
+                "a malformed 'protected' field (must be a list of strings), "
+                "skipped\n"
+            )
+            continue
+        valid.append(entry)
+    return valid
 
 
 # --------------------------------------------------------------------------
-# Path resolution — worktree-aware repo-relative matching
+# Path resolution — worktree-aware, foreign-repo-aware, case-folded matching
 # --------------------------------------------------------------------------
 
 def _git_root_for(path: pathlib.Path) -> pathlib.Path | None:
@@ -130,17 +199,31 @@ def _git_root_for(path: pathlib.Path) -> pathlib.Path | None:
     return None
 
 
+def _is_nuzantara_checkout(root: pathlib.Path) -> bool:
+    """A5/foreign-repo guard: a `.git` ancestor is only trusted as OUR repo
+    root if it also carries our own registry file — any other git
+    repository (e.g. `/tmp/other/.git`) is foreign, not a Nuzantara
+    checkout/worktree, no matter how it happens to nest."""
+    return (root / "infra" / "claude-hooks" / "data-plane-registry.json").exists()
+
+
 def _repo_relative(resolved: pathlib.Path) -> str:
-    """`resolved` relative to its own git root (worktree-aware); falls back
-    to `_repo_root()`, then to the absolute path (which then simply will
-    not match any repo-relative glob — safe under-block, never a false
-    block)."""
+    """`resolved` relative to its own (trusted) git root; falls back to
+    `_repo_root()` only when NO git root was found at all, else to the
+    absolute path — which then simply cannot match a repo-relative glob
+    (safe under-block, never a false block)."""
     git_root = _git_root_for(resolved)
     if git_root is not None:
-        try:
-            return resolved.relative_to(git_root).as_posix()
-        except ValueError:
-            pass
+        if _is_nuzantara_checkout(git_root):
+            try:
+                return resolved.relative_to(git_root).as_posix()
+            except ValueError:
+                pass
+        else:
+            # Foreign repository — do not fall through to _repo_root() at
+            # all; relativizing a foreign path against OUR root could never
+            # legitimately match, so go straight to the safe absolute form.
+            return resolved.as_posix()
     try:
         return resolved.relative_to(_repo_root()).as_posix()
     except ValueError:
@@ -159,68 +242,89 @@ def _resolve_target(path_str: str, cwd: str) -> pathlib.Path | None:
         return None
 
 
-# Residue filter (adapted from worktree_isolation.py's _is_plausible_path):
-# a real write target has a directory separator, a file extension, or is a
-# dotfile. Rejects operator/shell residue that survived noise-stripping
-# (`2`, `''`, `=0.9`) so it can never be mistaken for a protected path.
-_PATH_LIKE_RE = re.compile(r"^[~$]?[\w./@+-]+$")
-_FILE_EXT_RE = re.compile(r"\.[A-Za-z][A-Za-z0-9]{0,7}$")
-
-
-def _is_plausible_path(t: str) -> bool:
-    if not t or len(t) > 256:
-        return False
-    if not _PATH_LIKE_RE.match(t):
-        return False
-    if "=" in t:
-        return False
-    has_sep = "/" in t
-    has_ext = bool(_FILE_EXT_RE.search(t))
-    is_dotfile = t.startswith(".") and len(t) > 1
-    return has_sep or has_ext or is_dotfile
-
-
 def _matched_entry(rel: str, entries: list[dict]) -> tuple[dict, str] | None:
-    """First (entry, matched_glob) whose `protected` list matches `rel`."""
+    """First (entry, matched_glob) whose `protected` list matches `rel`,
+    case-folded (C1: APFS/macOS is case-insensitive by default — a
+    lowercase edit of the SAME real file must still be caught)."""
+    rel_l = rel.lower()
     for entry in entries:
         for pattern in entry.get("protected", []):
-            if fnmatch.fnmatchcase(rel, pattern):
+            if fnmatch.fnmatchcase(rel_l, pattern.lower()):
                 return entry, pattern
     return None
 
 
 # --------------------------------------------------------------------------
-# Bash channel — direct shell-level writes only
+# Bash/Monitor channel — direct shell-level writes only
 # --------------------------------------------------------------------------
 
 WRITE_HINT_RE = re.compile(
-    r"(>>?|\btee\b|\bsed\b[^|;&]*-i|\btruncate\b|\brm\b|\b(?:cp|mv|install|rsync)\b)"
+    r"(>>?|\btee\b|\bsed\b[^\n]*-i|\btruncate\b|\brm\b|\btouch\b|\bdd\b|\bperl\b|"
+    r"\b(?:cp|mv|install|rsync)\b)"
 )
-REDIR_RE = re.compile(r"(?:[0-9]?>|&>)>?\s*([^\s|;&)]+)")
-VERB_RE = re.compile(
-    r"\b(cp|mv|install|rsync|truncate|rm|tee)\b((?:\s+(?:-\S+|[^\s|;&)]+))+)"
-)
-SED_INVOCATION_RE = re.compile(r"\bsed\b((?:\s+(?:-\S+|[^\s|;&)]+))+)")
 
-# rm/tee/mv: every non-flag arg is a candidate target. rm/tee because every
-# arg is an independent destination. mv is the odd one out among the
-# "SRC... DEST" verbs: unlike cp/install/rsync it DESTROYS its source (the
-# source path stops existing), so a protected SOURCE must block exactly like
-# a protected dest would — moving a curated dataset out from under itself is
-# as much a hand-edit as overwriting it. cp/install/rsync/truncate stay
-# LAST-non-flag-token-only: their sources are read-only, reading FROM a
-# protected path is not a write (spec-confirmed: `cp protected/x /tmp/`
-# must stay ALLOWED).
-_ALL_TARGETS_VERBS = {"rm", "tee", "mv"}
+# Command-position anchor: a write-verb only counts as a COMMAND if it sits
+# at the start of a segment, or right after a nested command-substitution
+# opener. Segments are already split on `&& || ; & | <newline>` (see
+# SEGMENT_SPLIT_RE) so those separators never need to appear in this anchor.
+_CMD_ANCHOR = r"(?:^|\$\(|`)[ \t]*"
+_TOKEN = r"[^\s|;&)]+"  # a single non-flag token (never crosses whitespace)
+
+REDIR_RE = re.compile(r"(?:[0-9]?>|&>)>?[ \t]*(" + _TOKEN + r")")
+VERB_RE = re.compile(
+    _CMD_ANCHOR + r"(cp|mv|install|rsync|truncate|rm|tee|touch)\b"
+    r"((?:[ \t]+(?:-\S+|" + _TOKEN + r"))*)"
+)
+SED_INVOCATION_RE = re.compile(
+    _CMD_ANCHOR + r"sed\b((?:[ \t]+(?:-\S+|" + _TOKEN + r"))*)"
+)
+DD_RE = re.compile(_CMD_ANCHOR + r"dd\b.*?\bof=(" + _TOKEN + r")")
+PERL_INVOCATION_RE = re.compile(
+    _CMD_ANCHOR + r"perl\b((?:[ \t]+(?:-\S+|" + _TOKEN + r"))*)"
+)
+
+SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||;|&|\||\n")
+_SEGMENT_REMOTE_RE = re.compile(r"^[ \t]*(?:ssh|scp)\b")
+_CD_SEGMENT_RE = re.compile(r"^[ \t]*cd\b[ \t]+(" + _TOKEN + r")[ \t]*$")
+
+# rm/tee/mv/truncate/touch: every non-flag arg is a candidate target.
+# rm/tee/touch because every arg IS an independent destination. mv/truncate
+# are the odd ones out among "SRC... DEST"-shaped verbs: mv DESTROYS its
+# source (unlike cp/install/rsync, whose sources are read-only reads); C5
+# multi-file truncate/sed -i truncate/overwrite EVERY file argument, not
+# just the last one. cp/install/rsync stay LAST-non-flag-token-only.
+_ALL_TARGETS_VERBS = {"rm", "tee", "mv", "truncate", "touch"}
+
+
+def _perl_has_inplace(args: list[str]) -> bool:
+    """True if any short-flag cluster in `args` carries `i` (perl combines
+    flags like `-pi`, `-i.bak`, `-i`) — perl only writes files with -i."""
+    for a in args:
+        if a.startswith("--"):
+            continue
+        if a.startswith("-") and "i" in a[1:]:
+            return True
+    return False
 
 
 def _strip_noise(cmd: str) -> str:
-    """Neutralize heredoc bodies + quoted strings before scanning for write
-    targets (W79/W84 false-positive killer, cloned from worktree_isolation.py
-    / host_boundary.py). W84: the quote char-classes MUST exclude `\\n` — a
-    class that crosses newlines fuses an apostrophe on one line with a quote
-    several lines later, collapsing multiple commands into one mangled
-    string and producing a phantom write-target."""
+    """Neutralize heredoc bodies, quoted strings, and unquoted comments
+    before scanning for write targets.
+
+    Order matters: heredocs first (their body text is free-form and must
+    never leak into the scan), then quotes, then comments (a `#` that WAS
+    inside a quoted string is already resolved by the time comment-
+    stripping runs, so it is never mistaken for a comment marker).
+
+    Quoted strings are UNWRAPPED to their bare inner content when that
+    content itself looks like a plain path (C3: `echo x > "protected/file"`
+    must not become invisible just because the target is quoted — quoting a
+    path is normal, not an escape technique); otherwise they are blanked as
+    before (a quoted sed script, a commit message, anything with
+    whitespace/metacharacters stays `''`/`\"\"`). W84: char classes exclude
+    `\\n` so a stray quote on one line can never fuse with a quote several
+    lines later and swallow real commands into "quoted text"."""
+
     def _drop_heredocs(s: str) -> str:
         lines = s.split("\n")
         out: list[str] = []
@@ -240,58 +344,135 @@ def _strip_noise(cmd: str) -> str:
             i += 1
         return "\n".join(out)
 
+    def _quote_sub(quote_char: str):
+        def _sub(m: re.Match) -> str:
+            inner = m.group(1)
+            if _PATH_LIKE_RE.match(inner):
+                return inner
+            return quote_char * 2
+
+        return _sub
+
     s = _drop_heredocs(cmd)
-    s = re.sub(r"'[^'\n]*'", "''", s)
-    s = re.sub(r'"[^"\n]*"', '""', s)
+    s = re.sub(r"'([^'\n]*)'", _quote_sub("'"), s)
+    s = re.sub(r'"([^"\n]*)"', _quote_sub('"'), s)
+    # A2: strip unquoted shell comments (whitespace-or-line-start `#` to
+    # EOL) — `true # rm <protected>` must not leak the comment's content
+    # into the scan as if it were a real command.
+    s = re.sub(r"(?m)(?:^|(?<=\s))#.*$", "", s)
     return s
 
 
-def _extract_bash_write_targets(cmd: str) -> list[str]:
-    """Best-effort candidate write-destination paths. Conservative: a target
-    we cannot confidently extract is simply not returned (→ command is
-    ALLOWED, per the spec's under-block preference on this channel)."""
-    stripped = _strip_noise(cmd)
-    if not WRITE_HINT_RE.search(stripped):
+def _expand_glob_target(raw: str, cwd: str) -> list[pathlib.Path]:
+    """C4: a candidate containing glob metacharacters is expanded against
+    the REAL filesystem (glob.glob), capped, and each real match is
+    returned as its own candidate. A pattern matching nothing (or an
+    unresolvable base) yields an empty list — safe under-block."""
+    try:
+        p = pathlib.Path(os.path.expanduser(os.path.expandvars(raw)))
+        if not p.is_absolute() and cwd:
+            p = pathlib.Path(cwd) / p
+        pattern = str(p)
+    except Exception:
         return []
+    try:
+        matches = glob_mod.glob(pattern, recursive=True)
+    except Exception:
+        return []
+    out: list[pathlib.Path] = []
+    for m in matches[:_GLOB_MATCH_CAP]:
+        try:
+            out.append(pathlib.Path(m).resolve())
+        except Exception:
+            continue
+    return out
 
-    targets: list[str] = []
 
-    for m in REDIR_RE.finditer(stripped):
-        targets.append(m.group(1))
+def _resolve_candidates(raw: str, base_cwd: str) -> list[pathlib.Path]:
+    if _GLOB_CHARS_RE.search(raw):
+        return _expand_glob_target(raw, base_cwd)
+    resolved = _resolve_target(raw, base_cwd)
+    return [resolved] if resolved is not None else []
 
-    for m in VERB_RE.finditer(stripped):
+
+def _extract_from_segment(seg: str) -> list[tuple[str, bool]]:
+    """Candidate (raw_target, is_redirect) pairs from a SINGLE segment
+    (already confirmed local — never remote-dispatched). Verb/sed/dd/perl
+    matches are anchored to command position so a verb-shaped WORD that is
+    really an argument to a different command (grep's pattern, echo's
+    text, brew's subcommand) is never mistaken for a command of its own."""
+    out: list[tuple[str, bool]] = []
+
+    for m in REDIR_RE.finditer(seg):
+        out.append((m.group(1), True))
+
+    for m in VERB_RE.finditer(seg):
         verb = m.group(1)
         args = [a for a in m.group(2).split() if not a.startswith("-")]
         if not args:
             continue
-        if verb in _ALL_TARGETS_VERBS:
-            targets.extend(args)
-        else:
-            targets.append(args[-1])
+        picks = args if verb in _ALL_TARGETS_VERBS else [args[-1]]
+        out.extend((a, False) for a in picks)
 
-    # sed -i: take the LAST non-flag token of the whole invocation, not a
-    # positional "script argument" guess — robust to BOTH GNU
-    # (`sed -i 's/a/b/' file`, one quoted-script arg) and BSD/macOS
-    # (`sed -i '' 's/a/b/' file`, an EXTRA empty-suffix arg before the
-    # script) forms, since after noise-stripping every quoted arg collapses
-    # to `''`/`""` and the real file path is always the tail token either way.
-    for m in SED_INVOCATION_RE.finditer(stripped):
+    # sed -i: ALL non-flag tokens (C5) — robust to both GNU (`sed -i
+    # 's/a/b/' file`) and BSD (`sed -i '' 's/a/b/' file`) forms, and to
+    # multi-file invocations that mutate every file argument, not just the
+    # last one.
+    for m in SED_INVOCATION_RE.finditer(seg):
         args = m.group(1).split()
         if not any(a == "-i" or a.startswith("-i") for a in args):
             continue  # sed without -i writes to stdout, not a file write
         nonflag = [a for a in args if not a.startswith("-")]
-        if nonflag:
-            targets.append(nonflag[-1])
+        out.extend((a, False) for a in nonflag)
 
-    cleaned: list[str] = []
-    for t in targets:
-        t = t.strip().strip("'\"")
+    for m in DD_RE.finditer(seg):
+        out.append((m.group(1), False))
+
+    for m in PERL_INVOCATION_RE.finditer(seg):
+        args = m.group(1).split()
+        if not _perl_has_inplace(args):
+            continue
+        nonflag = [a for a in args if not a.startswith("-")]
+        out.extend((a, False) for a in nonflag)
+
+    return out
+
+
+def _extract_bash_write_targets(cmd: str, cwd: str) -> list[pathlib.Path]:
+    """Resolved absolute candidate paths for a Bash/Monitor command,
+    honoring segment-scoped ssh/scp skip (A3), cd-tracking (C7), and glob
+    expansion (C4). C8: only REDIRECT-sourced candidates go through the
+    bare-word plausibility filter — verb-sourced args are already proven
+    real by the command-position anchor."""
+    stripped = _strip_noise(cmd)
+    if not WRITE_HINT_RE.search(stripped):
+        return []
+
+    segments = SEGMENT_SPLIT_RE.split(stripped)
+    cd_bases: list[str] = [cwd]
+    raw_candidates: list[tuple[str, bool]] = []
+
+    for seg in segments:
+        if _SEGMENT_REMOTE_RE.match(seg):
+            continue  # A3: this segment's write happens on another host
+        cd_m = _CD_SEGMENT_RE.match(seg)
+        if cd_m:
+            new_base = _resolve_target(cd_m.group(1), cd_bases[-1])
+            if new_base is not None:
+                cd_bases.append(str(new_base))
+            continue
+        raw_candidates.extend(_extract_from_segment(seg))
+
+    resolved: list[pathlib.Path] = []
+    for raw, is_redirect in raw_candidates:
+        t = raw.strip().strip("'\"")
         if not t or t.startswith("/dev/") or t in {"&1", "&2"} or t.startswith("$("):
             continue
-        if not _is_plausible_path(t):
+        if is_redirect and not _is_plausible_path(t):
             continue
-        cleaned.append(t)
-    return cleaned
+        for base in cd_bases:
+            resolved.extend(_resolve_candidates(t, base))
+    return resolved
 
 
 # --------------------------------------------------------------------------
@@ -314,10 +495,7 @@ def _block(rel: str, entry: dict, pattern: str, surface: str) -> None:
     sys.exit(2)
 
 
-def main() -> int:
-    if os.environ.get("DATA_PLANE_GUARD_OFF") == "1":
-        return 0
-
+def _dispatch() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -343,20 +521,32 @@ def main() -> int:
                     _block(rel, entry, pattern, f"{tool} file_path")
         return 0
 
-    if tool == "Bash":
+    if tool in ("Bash", "Monitor"):
         cmd = tool_input.get("command", "")
-        for raw in _extract_bash_write_targets(cmd):
-            resolved = _resolve_target(raw, cwd)
-            if resolved is None:
-                continue
+        for resolved in _extract_bash_write_targets(cmd, cwd):
             rel = _repo_relative(resolved)
             hit = _matched_entry(rel, entries)
             if hit is not None:
                 entry, pattern = hit
-                _block(rel, entry, pattern, "Bash write")
+                _block(rel, entry, pattern, f"{tool} write")
         return 0
 
     return 0
+
+
+def main() -> int:
+    if os.environ.get("DATA_PLANE_GUARD_OFF") == "1":
+        return 0
+    try:
+        return _dispatch()
+    except SystemExit:
+        raise  # a real block must never be swallowed by the safety net below
+    except Exception as exc:
+        sys.stderr.write(
+            f"data_plane_guard WARN: unexpected internal error ({exc!r}) "
+            "— pass-through (never crash-block)\n"
+        )
+        return 0
 
 
 if __name__ == "__main__":

--- a/infra/claude-hooks/data_plane_guard.py
+++ b/infra/claude-hooks/data_plane_guard.py
@@ -23,7 +23,9 @@ SURFACES COVERED:
   - Edit / Write / NotebookEdit: `tool_input.file_path` (or `notebook_path`
     for NotebookEdit) resolved and matched against every registry glob.
   - Bash: DIRECT shell-level writes only — redirects (`>`/`>>`), `tee`,
-    `cp`/`mv`/`install`/`rsync` destination, `sed -i`, `truncate`, `rm`.
+    `cp`/`install`/`rsync` destination, `mv` source AND destination (mv
+    destroys its source, so a protected source blocks too — cp/install/rsync
+    sources are read-only and stay allowed), `sed -i`, `truncate`, `rm`.
     Reads (`cat`, `grep`, `jq`, a compiler invocation like `python3
     scripts/kbli_filiera/build.py`) are NOT a write operator and pass
     trivially — no write-hint keyword, no target extracted.
@@ -200,10 +202,16 @@ VERB_RE = re.compile(
 )
 SED_INVOCATION_RE = re.compile(r"\bsed\b((?:\s+(?:-\S+|[^\s|;&)]+))+)")
 
-# rm/tee can write MULTIPLE targets in one invocation (every non-flag arg is
-# a destination); cp/mv/install/rsync/truncate take the LAST non-flag token
-# (source(s)... DEST).
-_ALL_TARGETS_VERBS = {"rm", "tee"}
+# rm/tee/mv: every non-flag arg is a candidate target. rm/tee because every
+# arg is an independent destination. mv is the odd one out among the
+# "SRC... DEST" verbs: unlike cp/install/rsync it DESTROYS its source (the
+# source path stops existing), so a protected SOURCE must block exactly like
+# a protected dest would — moving a curated dataset out from under itself is
+# as much a hand-edit as overwriting it. cp/install/rsync/truncate stay
+# LAST-non-flag-token-only: their sources are read-only, reading FROM a
+# protected path is not a write (spec-confirmed: `cp protected/x /tmp/`
+# must stay ALLOWED).
+_ALL_TARGETS_VERBS = {"rm", "tee", "mv"}
 
 
 def _strip_noise(cmd: str) -> str:

--- a/infra/claude-hooks/test_data_plane_guard.py
+++ b/infra/claude-hooks/test_data_plane_guard.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""data_plane_guard guilt+innocence corpus (superscar #3 antidote).
+
+Runs the REAL on-disk hook (infra/claude-hooks/data_plane_guard.py) as a
+subprocess with a crafted stdin JSON payload — the exact contract Claude Code
+uses (see test_hook_innocence.py / test_w85_stash_readonly.py for the sibling
+pattern this mirrors). GUILT cases must BLOCK (exit 2); INNOCENCE cases must
+ALLOW (exit 0).
+
+Path resolution is proven against a SYNTHETIC git tree (a temp dir carrying
+both a main-checkout `.git` DIR and a nested `.worktrees/lane-x/` dir with
+its own `.git` FILE — exactly how a real worktree looks) so the corpus is
+deterministic and independent of whatever worktree this test happens to run
+inside. The REAL `infra/claude-hooks/data-plane-registry.json` is used
+unmodified (no CLAUDE_PROJECT_DIR override) except for the one case that
+specifically proves missing-registry pass-through.
+
+Run:  python3 infra/claude-hooks/test_data_plane_guard.py
+      (exit 0 = all clean, 1 = a guilt case went blind or an innocent got bit)
+Also a pytest target: pytest infra/claude-hooks/test_data_plane_guard.py -q
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent  # infra/claude-hooks
+HOOK = HERE / "data_plane_guard.py"
+
+# --- synthetic git tree: main checkout + a nested worktree, both carrying a
+# real `.git` marker so _git_root_for() resolves exactly as it would live.
+_TMP = pathlib.Path(tempfile.mkdtemp(prefix="data_plane_guard_test_"))
+MAIN = _TMP / "main-checkout"
+WT = MAIN / ".worktrees" / "infra-data-plane-guard-fake"
+(MAIN / ".git").mkdir(parents=True, exist_ok=True)          # main checkout: .git DIR
+WT.mkdir(parents=True, exist_ok=True)
+(WT / ".git").write_text("gitdir: /fake/common/git/dir\n")  # worktree: .git FILE
+
+# a dir with NO infra/claude-hooks/data-plane-registry.json under it, for the
+# missing-registry pass-through case.
+_NO_REGISTRY_DIR = _TMP / "no-registry-project"
+_NO_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def run_hook(payload: dict, env_extra: dict | None = None) -> tuple[int, str]:
+    """Invoke the real hook file as Claude Code does: JSON on stdin. Returns
+    (exit_code, stderr)."""
+    env = dict(os.environ)
+    env.pop("DATA_PLANE_GUARD_OFF", None)  # ensure kill switch not leaked from caller shell
+    env.pop("CLAUDE_PROJECT_DIR", None)    # default: let the hook use its own repo root (real registry)
+    if env_extra:
+        env.update(env_extra)
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps(payload),
+            capture_output=True, text=True, timeout=15, env=env,
+        )
+        return (proc.returncode, proc.stderr)
+    except subprocess.TimeoutExpired:
+        return (-2, "TIMEOUT")
+
+
+def edit(path: str, cwd: str = str(MAIN)) -> dict:
+    return {"tool_name": "Edit", "tool_input": {"file_path": path,
+            "old_string": "a", "new_string": "b"}, "cwd": cwd}
+
+
+def write(path: str, cwd: str = str(MAIN)) -> dict:
+    return {"tool_name": "Write", "tool_input": {"file_path": path,
+            "content": "x"}, "cwd": cwd}
+
+
+def bash(cmd: str, cwd: str = str(MAIN)) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": cwd}
+
+
+# (payload, expect, desc) — expect in {"BLOCK", "ALLOW"}
+CASES: list[tuple[dict, str, str, dict | None]] = [
+    # ------------------------------------------------------------------ GUILT
+    (edit("data/kbli-filiera/dossiers/68112.jsonl"), "BLOCK",
+     "Edit hand-touches a kbli-filiera dossier (main checkout)", None),
+    (write("data/source_documents/KBLI_2025_FINAL_CLEAN.json"), "BLOCK",
+     "Write hand-touches the KBLI gold file (main checkout)", None),
+    (edit(str(WT / "data/kbli-filiera/dossiers/68112.jsonl"), cwd=str(WT)), "BLOCK",
+     "same dossier path, but resolved inside a .worktrees/<lane> prefix — "
+     "protection must follow the dataset into worktrees", None),
+    (bash("echo x > data/kbli-filiera/quarantine.md"), "BLOCK",
+     "Bash redirect writes into the protected dir", None),
+    (bash("cp /tmp/a data/source_documents/KBLI_2025_FINAL_CLEAN.json"), "BLOCK",
+     "Bash cp overwrites the KBLI gold file", None),
+    (bash("sed -i '' 's/a/b/' data/kbli-filiera/manifest/m.json"), "BLOCK",
+     "Bash sed -i (BSD two-arg form) edits a manifest in place", None),
+
+    # --------------------------------------------------------------- INNOCENCE
+    (edit("data/kbli-filiera-README.md"), "ALLOW",
+     "adjacent prefix (hyphen, not a path separator) must not match "
+     "data/kbli-filiera/** ", None),
+    (edit("research/operations/x.md"), "ALLOW",
+     "unrelated repo path", None),
+    (bash("cat data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
+     "read-only cat, no write operator", None),
+    (bash("python3 scripts/kbli_filiera/build_canonical.py"), "ALLOW",
+     "compiler invocation itself — no shell-level write operator", None),
+    (bash("grep -r foo data/kbli-filiera/"), "ALLOW",
+     "read-only grep over the protected dir", None),
+    (bash("git add data/kbli-filiera/manifest.json && git commit"), "ALLOW",
+     "git object writes are not hand-edits", None),
+    (edit("data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
+     "same GUILTY path, but registry unreachable from this project dir "
+     "→ pass-through with WARN", {"CLAUDE_PROJECT_DIR": str(_NO_REGISTRY_DIR)}),
+    (edit("data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
+     "same GUILTY path, but kill switch DATA_PLANE_GUARD_OFF=1",
+     {"DATA_PLANE_GUARD_OFF": "1"}),
+]
+
+
+def evaluate() -> list[str]:
+    failures: list[str] = []
+    for payload, expect, desc, env_extra in CASES:
+        code, err = run_hook(payload, env_extra)
+        if code < 0:
+            failures.append(f"{desc}: hook error ({err.strip()[:200]})")
+            continue
+        blocked = code == 2
+        if expect == "BLOCK":
+            if not blocked:
+                failures.append(
+                    f"WENT-BLIND on guilt → {desc}: expected BLOCK, got exit {code}\n"
+                    f"        payload={json.dumps(payload)[:200]}"
+                )
+        else:  # ALLOW
+            if blocked:
+                failures.append(
+                    f"BIT-AN-INNOCENT → {desc}: expected ALLOW, got BLOCK\n"
+                    f"        payload={json.dumps(payload)[:200]}\n"
+                    f"        stderr={err.strip()[:300]}"
+                )
+    return failures
+
+
+def test_data_plane_guard():
+    failures = evaluate()
+    assert not failures, "data_plane_guard GUILT/INNOCENCE regressions:\n" + "\n".join(failures)
+
+
+def test_data_plane_guard_block_message_names_file_and_owner():
+    """The block message must name the file, the matched registry entry, and
+    point at the compiler-script resolution — not just a bare 'blocked'."""
+    code, err = run_hook(edit("data/source_documents/KBLI_2025_FINAL_CLEAN.json"))
+    assert code == 2, f"expected BLOCK, got exit {code}: {err}"
+    assert "KBLI_2025_FINAL_CLEAN.json" in err, err
+    assert "kbli-filiera" in err, err
+    assert "scripts/kbli_filiera" in err, err
+
+
+def test_data_plane_guard_missing_registry_warns_on_stderr():
+    code, err = run_hook(
+        edit("data/kbli-filiera/dossiers/68112.jsonl"),
+        {"CLAUDE_PROJECT_DIR": str(_NO_REGISTRY_DIR)},
+    )
+    assert code == 0, f"expected ALLOW (pass-through), got exit {code}: {err}"
+    assert "WARN" in err, f"expected a WARN line on missing-registry pass-through, got: {err!r}"
+
+
+def _cleanup():
+    shutil.rmtree(_TMP, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    try:
+        failures = evaluate()
+    finally:
+        pass
+    if failures:
+        print("data_plane_guard FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        _cleanup()
+        sys.exit(1)
+    print(f"OK (data_plane_guard) — {len(CASES)} guilt+innocence cases clean.")
+    _cleanup()
+    sys.exit(0)

--- a/infra/claude-hooks/test_data_plane_guard.py
+++ b/infra/claude-hooks/test_data_plane_guard.py
@@ -96,6 +96,13 @@ CASES: list[tuple[dict, str, str, dict | None]] = [
      "Bash cp overwrites the KBLI gold file", None),
     (bash("sed -i '' 's/a/b/' data/kbli-filiera/manifest/m.json"), "BLOCK",
      "Bash sed -i (BSD two-arg form) edits a manifest in place", None),
+    (bash("rm -rf data/kbli-filiera"), "BLOCK",
+     "rm -rf on the BARE protected dir (no glob suffix) — the /** glob alone "
+     "does not match the directory itself, needs the exact entry too", None),
+    (bash("rm -rf data/kbli-filiera/"), "BLOCK",
+     "same, with a trailing slash", None),
+    (bash("mv data/source_documents/KBLI_2025_FINAL_CLEAN.json /tmp/x.json"), "BLOCK",
+     "mv of a protected SOURCE — mv destroys its source, unlike cp/install/rsync", None),
 
     # --------------------------------------------------------------- INNOCENCE
     (edit("data/kbli-filiera-README.md"), "ALLOW",
@@ -111,6 +118,13 @@ CASES: list[tuple[dict, str, str, dict | None]] = [
      "read-only grep over the protected dir", None),
     (bash("git add data/kbli-filiera/manifest.json && git commit"), "ALLOW",
      "git object writes are not hand-edits", None),
+    (bash("mv /tmp/a /tmp/b"), "ALLOW",
+     "mv entirely outside the repo — neither source nor dest is protected", None),
+    (bash("mv data/kbli-filiera-README.md /tmp/"), "ALLOW",
+     "mv source has the adjacent (non-matching) prefix, not the protected dir", None),
+    (bash("cp data/kbli-filiera/dossiers/x.json /tmp/"), "ALLOW",
+     "cp FROM a protected path is a read of the source, not a write — must "
+     "stay allowed (only cp's DEST is checked)", None),
     (edit("data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
      "same GUILTY path, but registry unreachable from this project dir "
      "→ pass-through with WARN", {"CLAUDE_PROJECT_DIR": str(_NO_REGISTRY_DIR)}),

--- a/infra/claude-hooks/test_data_plane_guard.py
+++ b/infra/claude-hooks/test_data_plane_guard.py
@@ -9,14 +9,18 @@ ALLOW (exit 0).
 
 Path resolution is proven against a SYNTHETIC git tree (a temp dir carrying
 both a main-checkout `.git` DIR and a nested `.worktrees/lane-x/` dir with
-its own `.git` FILE — exactly how a real worktree looks) so the corpus is
-deterministic and independent of whatever worktree this test happens to run
-inside. The REAL `infra/claude-hooks/data-plane-registry.json` is used
-unmodified (no CLAUDE_PROJECT_DIR override) except for the one case that
-specifically proves missing-registry pass-through.
+its own `.git` FILE, EACH also carrying its own copy of the registry marker
+file so the A4 foreign-repo guard trusts them) so the corpus is deterministic
+and independent of whatever worktree this test happens to run inside. The
+REAL `infra/claude-hooks/data-plane-registry.json` is used unmodified (no
+CLAUDE_PROJECT_DIR override) except for the cases that specifically prove
+missing/malformed-registry pass-through and the foreign-repo case.
 
 Run:  python3 infra/claude-hooks/test_data_plane_guard.py
-      (exit 0 = all clean, 1 = a guilt case went blind or an innocent got bit)
+      (exit 0 = all clean, 1 = a guilt case went blind, an innocent got bit,
+      or a non-corpus test function failed — B3: this standalone runner
+      executes EVERY test_* function in the module, not just the corpus, so
+      CI invoking this file directly sees the same coverage as pytest.)
 Also a pytest target: pytest infra/claude-hooks/test_data_plane_guard.py -q
 """
 from __future__ import annotations
@@ -30,21 +34,66 @@ import sys
 import tempfile
 
 HERE = pathlib.Path(__file__).resolve().parent  # infra/claude-hooks
+REPO_ROOT = HERE.parent.parent
 HOOK = HERE / "data_plane_guard.py"
+SETTINGS_JSON = REPO_ROOT / ".claude" / "settings.json"
 
 # --- synthetic git tree: main checkout + a nested worktree, both carrying a
-# real `.git` marker so _git_root_for() resolves exactly as it would live.
+# real `.git` marker AND our own registry marker file (A4: the foreign-repo
+# guard only trusts a git root that also carries this file) so
+# _git_root_for()/_is_nuzantara_checkout() resolve exactly as they would live.
 _TMP = pathlib.Path(tempfile.mkdtemp(prefix="data_plane_guard_test_"))
 MAIN = _TMP / "main-checkout"
 WT = MAIN / ".worktrees" / "infra-data-plane-guard-fake"
+
+
+def _plant_registry_marker(root: pathlib.Path) -> None:
+    marker = root / "infra" / "claude-hooks" / "data-plane-registry.json"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("{}")  # presence is all A4 checks — content irrelevant here
+
+
 (MAIN / ".git").mkdir(parents=True, exist_ok=True)          # main checkout: .git DIR
+_plant_registry_marker(MAIN)
 WT.mkdir(parents=True, exist_ok=True)
 (WT / ".git").write_text("gitdir: /fake/common/git/dir\n")  # worktree: .git FILE
+_plant_registry_marker(WT)
+
+# a real on-disk file under MAIN for the glob-expansion guilt case (C4) —
+# glob.glob only matches things that actually exist.
+(MAIN / "data" / "kbli-filiera" / "dossiers").mkdir(parents=True, exist_ok=True)
+(MAIN / "data" / "kbli-filiera" / "dossiers" / "68112.jsonl").write_text("{}")
 
 # a dir with NO infra/claude-hooks/data-plane-registry.json under it, for the
 # missing-registry pass-through case.
 _NO_REGISTRY_DIR = _TMP / "no-registry-project"
 _NO_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+
+# a foreign git repository (A4): has its OWN .git, but does NOT carry our
+# registry marker — must never be trusted as a Nuzantara checkout/worktree.
+FOREIGN = _TMP / "foreign-repo"
+(FOREIGN / ".git").mkdir(parents=True, exist_ok=True)
+(FOREIGN / "data" / "kbli-filiera").mkdir(parents=True, exist_ok=True)
+
+# malformed-registry project dirs (B1) — each carries a deliberately broken
+# infra/claude-hooks/data-plane-registry.json to prove the loader degrades
+# gracefully instead of crashing or over-blocking.
+_MALFORMED_STRING_PROTECTED_DIR = _TMP / "malformed-string-protected"
+(_MALFORMED_STRING_PROTECTED_DIR / "infra" / "claude-hooks").mkdir(parents=True, exist_ok=True)
+(_MALFORMED_STRING_PROTECTED_DIR / "infra" / "claude-hooks" / "data-plane-registry.json").write_text(
+    json.dumps({"entries": [{"id": "bad", "owner": "x", "compilers": "x",
+                              "protected": "data/kbli-filiera/**"}]})
+)
+
+_MALFORMED_TOPLEVEL_LIST_DIR = _TMP / "malformed-toplevel-list"
+(_MALFORMED_TOPLEVEL_LIST_DIR / "infra" / "claude-hooks").mkdir(parents=True, exist_ok=True)
+(_MALFORMED_TOPLEVEL_LIST_DIR / "infra" / "claude-hooks" / "data-plane-registry.json").write_text("[]")
+
+_MALFORMED_NULL_ENTRY_DIR = _TMP / "malformed-null-entry"
+(_MALFORMED_NULL_ENTRY_DIR / "infra" / "claude-hooks").mkdir(parents=True, exist_ok=True)
+(_MALFORMED_NULL_ENTRY_DIR / "infra" / "claude-hooks" / "data-plane-registry.json").write_text(
+    json.dumps({"entries": [None]})
+)
 
 
 def run_hook(payload: dict, env_extra: dict | None = None) -> tuple[int, str]:
@@ -80,7 +129,13 @@ def bash(cmd: str, cwd: str = str(MAIN)) -> dict:
     return {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": cwd}
 
 
-# (payload, expect, desc) — expect in {"BLOCK", "ALLOW"}
+def monitor(cmd: str, cwd: str = str(MAIN)) -> dict:
+    return {"tool_name": "Monitor", "tool_input": {
+        "command": cmd, "description": "test", "timeout_ms": 5000,
+        "persistent": False}, "cwd": cwd}
+
+
+# (payload, expect, desc, env_extra) — expect in {"BLOCK", "ALLOW"}
 CASES: list[tuple[dict, str, str, dict | None]] = [
     # ------------------------------------------------------------------ GUILT
     (edit("data/kbli-filiera/dossiers/68112.jsonl"), "BLOCK",
@@ -103,6 +158,59 @@ CASES: list[tuple[dict, str, str, dict | None]] = [
      "same, with a trailing slash", None),
     (bash("mv data/source_documents/KBLI_2025_FINAL_CLEAN.json /tmp/x.json"), "BLOCK",
      "mv of a protected SOURCE — mv destroys its source, unlike cp/install/rsync", None),
+
+    # -------------------------------------------------- GUILT (wave-2, A1/A3)
+    (bash("true && rm data/kbli-filiera/dossiers/68112.jsonl"), "BLOCK",
+     "A1 re-proof: a verb after && is still a real command, must still block", None),
+    (bash("ssh mini hostname && cp /tmp/a data/source_documents/KBLI_2025_FINAL_CLEAN.json"),
+     "BLOCK",
+     "A3: the ssh prelude is remote, but the cp lives in a LATER, LOCAL "
+     "segment — must still block (never a whole-command exemption)", None),
+
+    # -------------------------------------------------------- GUILT (C1 case)
+    (edit("data/source_documents/kbli_2025_final_clean.json"), "BLOCK",
+     "C1: APFS is case-insensitive — a lowercase edit of the SAME real file "
+     "must still block", None),
+    (edit("data/KBLI-FILIERA/dossiers/x.json"), "BLOCK",
+     "C1: uppercase directory variant of the protected dir must still block", None),
+
+    # ------------------------------------------------------- GUILT (C2 Monitor)
+    (monitor("printf x > data/source_documents/KBLI_2025_FINAL_CLEAN.json"), "BLOCK",
+     "C2: Monitor executes the same shell channel as Bash, must be covered", None),
+
+    # ------------------------------------------------------- GUILT (C3 quoted)
+    (bash('echo x > "data/source_documents/KBLI_2025_FINAL_CLEAN.json"'), "BLOCK",
+     "C3: a double-quoted redirect target must not become invisible", None),
+    (bash("cp /tmp/a 'data/source_documents/KBLI_2025_FINAL_CLEAN.json'"), "BLOCK",
+     "C3: a single-quoted cp destination must not become invisible", None),
+
+    # --------------------------------------------------------- GUILT (C4 glob)
+    (bash("rm data/kbli-filiera/dossiers/*.jsonl"), "BLOCK",
+     "C4: glob expansion must resolve against the real file on disk", None),
+
+    # ------------------------------------------------------ GUILT (C5 multi-file)
+    (bash("sed -i '' 's/a/b/' data/source_documents/KBLI_2025_FINAL_CLEAN.json "
+          "/tmp/control.json"), "BLOCK",
+     "C5: sed -i mutates EVERY file argument, not just the last one", None),
+    (bash("truncate -s 0 data/kbli-filiera/a.json /tmp/control.json"), "BLOCK",
+     "C5: truncate mutates every file argument too", None),
+
+    # ---------------------------------------------------- GUILT (C6 new verbs)
+    (bash("dd if=/tmp/bad.json of=data/source_documents/KBLI_2025_FINAL_CLEAN.json"),
+     "BLOCK", "C6: dd of= was entirely unrecognized before", None),
+    (bash("touch data/kbli-filiera/newfile.json"), "BLOCK",
+     "C6: touch was entirely unrecognized before", None),
+    (bash("perl -pi -e 's/a/b/' data/kbli-filiera/manifest.json"), "BLOCK",
+     "C6: perl -i was entirely unrecognized before", None),
+
+    # --------------------------------------------------------- GUILT (C7 cd)
+    (bash("cd data/source_documents && rm KBLI_2025_FINAL_CLEAN.json"), "BLOCK",
+     "C7: a preceding cd changes the effective base for a relative rm target", None),
+
+    # --------------------------------------------------------- GUILT (C8 bare)
+    (bash("rm manifest", cwd=str(MAIN / "data" / "kbli-filiera")), "BLOCK",
+     "C8: a bare filename (no separator/extension) with cwd already inside "
+     "the protected dir must not escape via the plausibility filter", None),
 
     # --------------------------------------------------------------- INNOCENCE
     (edit("data/kbli-filiera-README.md"), "ALLOW",
@@ -131,6 +239,68 @@ CASES: list[tuple[dict, str, str, dict | None]] = [
     (edit("data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
      "same GUILTY path, but kill switch DATA_PLANE_GUARD_OFF=1",
      {"DATA_PLANE_GUARD_OFF": "1"}),
+
+    # ----------------------------------------------------- INNOCENCE (A1/A2)
+    (bash("grep rm data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
+     "A1: 'rm' is grep's PATTERN argument, not a command — must not block", None),
+    (bash("echo rm\ncat data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
+     "A1: 'rm' as echo's argument on line 1 must not bleed into line 2's "
+     "unrelated cat as a phantom arg (arg-separator must not cross \\n)", None),
+    (bash("brew install jq"), "ALLOW",
+     "A1: 'install' is brew's subcommand, not brew itself — anchored to "
+     "command position, brew never matches our verb list either", None),
+    (bash("true # rm data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
+     "A2: an unquoted shell comment must never leak its content as a command", None),
+
+    # --------------------------------------------------------- INNOCENCE (A3)
+    (bash("ssh mini cp /tmp/a data/source_documents/KBLI_2025_FINAL_CLEAN.json"), "ALLOW",
+     "A3: the whole payload is one remote-dispatched segment — the cp runs "
+     "on Mini, never touches this checkout", None),
+
+    # --------------------------------------------------------- INNOCENCE (A4)
+    (write(str(FOREIGN / "data" / "kbli-filiera" / "mock.json")), "ALLOW",
+     "A4: /tmp/foreign-repo has its own .git but is not a Nuzantara "
+     "checkout (no registry marker) — must never be trusted", None),
+
+    # --------------------------------------------------------- INNOCENCE (B1)
+    (edit("README.md"), "ALLOW",
+     "B1: a registry entry with a bare-STRING 'protected' field must be "
+     "skipped, not iterated as characters (a lone '*' would else match "
+     "everything)", {"CLAUDE_PROJECT_DIR": str(_MALFORMED_STRING_PROTECTED_DIR)}),
+    (edit("data/kbli-filiera/dossiers/x.json"), "ALLOW",
+     "B1: a top-level JSON array (not object) must degrade to pass-through, "
+     "not crash on .get()", {"CLAUDE_PROJECT_DIR": str(_MALFORMED_TOPLEVEL_LIST_DIR)}),
+    (edit("data/kbli-filiera/dossiers/x.json"), "ALLOW",
+     "B1: a null entry in 'entries' must be skipped, not crash on .get()",
+     {"CLAUDE_PROJECT_DIR": str(_MALFORMED_NULL_ENTRY_DIR)}),
+
+    # --------------------------------------------------------- INNOCENCE (C1)
+    (edit("data/kbli-filiera-README.MD"), "ALLOW",
+     "C1: case-folding must not OVER-match — an already-unrelated adjacent "
+     "file stays unrelated regardless of extension casing", None),
+
+    # ----------------------------------------------------- INNOCENCE (C2)
+    (monitor("cat data/kbli-filiera/dossiers/68112.jsonl"), "ALLOW",
+     "C2: a read-only Monitor command must stay allowed", None),
+
+    # ----------------------------------------------------- INNOCENCE (C3)
+    (bash("git commit -m 'rm data/kbli-filiera/x.json'"), "ALLOW",
+     "C3: quoted content WITH whitespace (a commit message) stays blanked, "
+     "not unwrapped — only bare-path-shaped quoted content is preserved", None),
+
+    # ----------------------------------------------------- INNOCENCE (C4)
+    (bash("rm /tmp/nowhere-*.json"), "ALLOW",
+     "C4: a glob pattern matching nothing on disk yields no candidates", None),
+
+    # ----------------------------------------------------- INNOCENCE (C6)
+    (bash("touch /tmp/scratch.json"), "ALLOW",
+     "C6: touch of an unrelated file stays allowed", None),
+    (bash("perl -e 'print 1'"), "ALLOW",
+     "C6: perl WITHOUT -i never writes a file", None),
+
+    # ----------------------------------------------------- INNOCENCE (C7)
+    (bash("cd /tmp && rm x.json"), "ALLOW",
+     "C7: cd to an unrelated dir, target resolves outside the repo entirely", None),
 ]
 
 
@@ -146,7 +316,8 @@ def evaluate() -> list[str]:
             if not blocked:
                 failures.append(
                     f"WENT-BLIND on guilt → {desc}: expected BLOCK, got exit {code}\n"
-                    f"        payload={json.dumps(payload)[:200]}"
+                    f"        payload={json.dumps(payload)[:200]}\n"
+                    f"        stderr={err.strip()[:300]}"
                 )
         else:  # ALLOW
             if blocked:
@@ -182,21 +353,73 @@ def test_data_plane_guard_missing_registry_warns_on_stderr():
     assert "WARN" in err, f"expected a WARN line on missing-registry pass-through, got: {err!r}"
 
 
+def test_settings_json_wires_the_hook_correctly():
+    """B2: CI must independently verify the .claude/settings.json wiring, not
+    just the hook's own logic — a settings-only regression (wrong matcher,
+    wrong filename) must fail this test even though it never touches
+    data_plane_guard.py itself."""
+    assert HOOK.exists(), f"hook file missing on disk: {HOOK}"
+    assert SETTINGS_JSON.exists(), f"settings.json missing: {SETTINGS_JSON}"
+    data = json.loads(SETTINGS_JSON.read_text(encoding="utf-8"))
+    pre_blocks = data.get("hooks", {}).get("PreToolUse", [])
+    required_tools = {"Edit", "Write", "NotebookEdit", "Bash", "Monitor"}
+    found = False
+    for block in pre_blocks:
+        matcher_tools = set(block.get("matcher", "").split("|"))
+        if not required_tools <= matcher_tools:
+            continue
+        for h in block.get("hooks", []):
+            if "infra/claude-hooks/data_plane_guard.py" in h.get("command", ""):
+                found = True
+    assert found, (
+        "No PreToolUse block in .claude/settings.json has BOTH a matcher "
+        f"covering {sorted(required_tools)} AND a command referencing "
+        "infra/claude-hooks/data_plane_guard.py"
+    )
+
+
+def _run_all_module_tests() -> list[str]:
+    """B3: execute every top-level test_* function in this module (skipping
+    test_data_plane_guard itself, which __main__ already runs via evaluate()
+    directly — avoids running the whole subprocess corpus twice). Used by
+    BOTH pytest (implicitly, via its own collection) and the standalone
+    __main__ runner below, so CI invoking this file directly (as
+    hook-innocence-gate.yml does) sees the SAME coverage pytest would."""
+    mod = sys.modules[__name__]
+    failures: list[str] = []
+    for name in sorted(dir(mod)):
+        if not name.startswith("test_") or name == "test_data_plane_guard":
+            continue
+        fn = getattr(mod, name)
+        if not callable(fn):
+            continue
+        try:
+            fn()
+        except AssertionError as exc:
+            failures.append(f"{name}: {exc}")
+        except Exception as exc:  # noqa: BLE001 - report, don't hide
+            failures.append(f"{name}: unexpected error: {exc!r}")
+    return failures
+
+
 def _cleanup():
     shutil.rmtree(_TMP, ignore_errors=True)
 
 
 if __name__ == "__main__":
-    try:
-        failures = evaluate()
-    finally:
-        pass
-    if failures:
+    corpus_failures = evaluate()
+    module_failures = _run_all_module_tests()
+    all_failures = corpus_failures + module_failures
+    if all_failures:
         print("data_plane_guard FAILED:")
-        for f in failures:
+        for f in all_failures:
             print(f"  - {f}")
         _cleanup()
         sys.exit(1)
-    print(f"OK (data_plane_guard) — {len(CASES)} guilt+innocence cases clean.")
+    print(
+        f"OK (data_plane_guard) — {len(CASES)} guilt+innocence cases + "
+        f"{len([n for n in dir(sys.modules[__name__]) if n.startswith('test_') and n != 'test_data_plane_guard'])} "
+        "module tests clean."
+    )
     _cleanup()
     sys.exit(0)

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -200,6 +200,12 @@
           "tests": [],
           "also_covered_by": ["vaccine"]
         },
+        "infra/claude-hooks/data_plane_guard.py": {
+          "scar": ["superscar-3-generalization", "superscar-9"],
+          "symbols": {},
+          "tests": ["infra/claude-hooks/test_data_plane_guard.py"],
+          "note": "registry-based PreToolUse guard (2026-07-16): blocks interactive hand-edits of curated datasets outside their program's sanctioned compiler scripts (infra/claude-hooks/data-plane-registry.json). 14 guilt+innocence cases against a synthetic git tree prove worktree-aware path relativization (the .git-walk-up, not a hardcoded main-checkout root), missing-registry pass-through, and the kill switch."
+        },
         "scripts/hooks/seam_verify.py": {
           "symbols": {},
           "tests": [],


### PR DESCRIPTION
## Summary
- New PreToolUse hook `infra/claude-hooks/data_plane_guard.py` blocks interactive hand-edits of curated datasets that must only be written by their program's sanctioned compiler scripts.
- Registry-based extension point: `infra/claude-hooks/data-plane-registry.json` — any program registers its data plane (id/owner/compilers/protected globs) without touching the hook's code. First entry: GARUDA-FILIERA's `data/kbli-filiera/**` + KBLI gold files.
- Worktree-aware path matching: walks up from the resolved file to the nearest `.git` (worktree marker or main-checkout dir) and relativizes against THAT, so protection follows a registered dataset into every `.worktrees/*` worktree.
- Covers Edit/Write/NotebookEdit (`file_path`) and Bash (direct shell-level writes: redirects, `tee`, `cp`/`mv`/`install`/`rsync`, `sed -i`, `truncate`, `rm`) — reads pass trivially.
- `infra/claude-hooks/test_data_plane_guard.py`: guilt+innocence corpus (superscar #3 antidote) run against the real hook as a subprocess.
- Wired into `.claude/settings.json` PreToolUse, censused in `infra/guard-conformance/registry.json`, and explicitly executed in `.github/workflows/hook-innocence-gate.yml` (not just ancestor-dir path-filter luck).

Commit 2 (`8c71ba4b95`) fixes two under-blocks found by live adversarial probing: a bare-dir `rm -rf` on the protected path, and `mv` of a protected source (mv destroys its source, unlike cp/install/rsync).

This is guardrail-class infra — **NOT auto-merge armed**. A Codex `gpt-5.6-sol` xhigh adversarial review is in flight; further findings will land as additional commits on this branch before merge.

## Test plan
- [x] `python3 infra/claude-hooks/test_data_plane_guard.py` — guilt+innocence corpus, standalone
- [x] `pytest infra/claude-hooks/test_data_plane_guard.py -q`
- [x] `python3 infra/guard-conformance/check_guard_conformance.py` — 0 violations
- [x] `python3 infra/claude-hooks/test_hook_innocence.py` — sibling vaccine, no collateral regression (34/34)
- [ ] Codex adversarial review findings (in flight) — additional commits pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)