### PR TITLE
chore(rag): jsonb ::text::jsonb cure + gitignore hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,8 @@ lint_*.txt
 .cursorignore
 
 # Root-local artifacts and session output
+/output/
+/outputs/
 .CLAUDE.md.swp
 .next/
 .vercel/

--- a/apps/backend-rag/backend/app/routers/intake_review.py
+++ b/apps/backend-rag/backend/app/routers/intake_review.py
@@ -1218,7 +1218,7 @@ async def reject_review(
                     INSERT INTO intake_commit_audit (
                         proposal_id, queue_id, committed_by, dry_run,
                         outcome, plan
-                    ) VALUES ($1, $2, $3, false, 'rejected', $4::jsonb)
+                    ) VALUES ($1, $2, $3, false, 'rejected', $4::text::jsonb)
                     """,
                     proposal_id,
                     prop["queue_id"],

--- a/apps/backend-rag/backend/app/routers/visa_oracle.py
+++ b/apps/backend-rag/backend/app/routers/visa_oracle.py
@@ -412,7 +412,7 @@ async def _persist_session_create(
                 """
                 INSERT INTO visa_oracle_sessions
                     (session_id, quiz_answers, recommended_visas, ip_hash)
-                VALUES ($1, $2::jsonb, $3::jsonb, $4)
+                VALUES ($1, $2::text::jsonb, $3::text::jsonb, $4)
                 """,
                 session_id,
                 json.dumps(quiz_answers),
@@ -436,7 +436,7 @@ async def _persist_session_append_message(
             await conn.execute(
                 """
                 UPDATE visa_oracle_sessions
-                SET messages = messages || $2::jsonb
+                SET messages = messages || $2::text::jsonb
                 WHERE session_id = $1
                 """,
                 session_id,

--- a/apps/backend-rag/backend/app/routers/wr2_publish.py
+++ b/apps/backend-rag/backend/app/routers/wr2_publish.py
@@ -313,7 +313,7 @@ async def _ledger_record_result(
             idempotency_key = f"{carousel_id}:{_PLATFORM}:{content_hash[:16]}"
             await conn.execute(
                 "UPDATE wr2_publish_attempts "
-                "SET state = $1, provider_response = $2::jsonb, updated_at = now() "
+                "SET state = $1, provider_response = $2::text::jsonb, updated_at = now() "
                 "WHERE idempotency_key = $3",
                 state,
                 json.dumps(provider_response or {}),
@@ -406,11 +406,11 @@ async def publish_ig(body: PublishIGRequest) -> dict[str, Any]:
     called and ``approval_state`` stays ``"pending"``. ``confirm == True`` =>
     ledger precondition + real publish with ``approval_state == "approved"``.
     """
+    from backend.services.publisher.base import PublisherError
     from backend.services.publisher.ig_publisher import (
         IGPublisher,
         close_ig_publisher_client,
     )
-    from backend.services.publisher.base import PublisherError
 
     slug = body.slug
     image_urls = body.image_urls

--- a/apps/backend-rag/backend/app/utils/json_utils.py
+++ b/apps/backend-rag/backend/app/utils/json_utils.py
@@ -10,18 +10,24 @@ USAGE:
 
     # Method 1: Use to_jsonb helper
     await conn.execute(
-        "INSERT INTO t (data) VALUES ($1::jsonb)",
+        "INSERT INTO t (data) VALUES ($1::text::jsonb)",
         to_jsonb(my_dict)
     )
 
     # Method 2: Use json_serializer with json.dumps
     import json
     await conn.execute(
-        "INSERT INTO t (data) VALUES ($1::jsonb)",
+        "INSERT INTO t (data) VALUES ($1::text::jsonb)",
         json.dumps(my_dict, default=json_serializer)
     )
 
 See: CLAUDE.md "Asyncpg + JSONB Development Guidelines" for full documentation.
+
+NOTE: always bind JSONB values with the ``$N::text::jsonb`` DOUBLE cast, never the
+bare ``$N::jsonb``. The double cast prevents the jsonb string-scalar disease
+(#2525): a serialized JSON string bound as ``$N::jsonb`` can be stored as a jsonb
+*scalar string* instead of a jsonb object/array. ``$N::text::jsonb`` is the
+canonical write pattern across the backend (38 files).
 """
 
 import json
@@ -84,7 +90,7 @@ def to_jsonb(data: dict | list | None) -> str | None:
 
     Example:
         >>> await conn.execute(
-        ...     "INSERT INTO activity_log (changes) VALUES ($1::jsonb)",
+        ...     "INSERT INTO activity_log (changes) VALUES ($1::text::jsonb)",
         ...     to_jsonb({"status": "completed", "amount": Decimal("500")})
         ... )
     """


### PR DESCRIPTION
## Summary
Cleanup PR from a "smart housekeeping" pass on M5. Two atomic commits.

### 1. `fix(rag)`: cure 4 bare `$N::jsonb` single-cast writers -> `::text::jsonb`
Surfaced by grepping for the non-canonical single-cast after the #2525 jsonb string-scalar sweep. Four routers bound `json.dumps()` strings to bare `$N::jsonb` - the uncured pattern. All now use `$N::text::jsonb` (canonical, 38 files): equivalent for valid JSON input, prevents the scalar-string disease.

- `visa_oracle.py:415` quiz_answers/recommended_visas INSERT
- `visa_oracle.py:439` messages `||` append
- `intake_review.py:1221` intake_commit_audit.plan INSERT
- `wr2_publish.py:316` wr2_publish_attempts.provider_response UPDATE
- (+ auto-fixed a pre-existing ruff I001 import-sort in `wr2_publish.py:409`)

### 2. `chore`: gitignore `/output` `/outputs` + canonicalize `json_utils` docstring
- `.gitignore`: root-level `/output/` `/outputs/` permanently dirtied `git status`.
- `json_utils.py`: docstring examples demonstrated the exact `$1::jsonb` disease pattern - updated to `$1::text::jsonb` + NOTE.

## Verification
- [x] pre-push gate M5: **17185 passed, 165 skipped, 0 failed** (15m)
- [x] pre-commit green (ruff, import chain, secrets, off-limits)
- [x] 0 bare `$N::jsonb` single-cast remaining in the 3 routers

🤖 Generated with [Claude Code](https://claude.com/claude-code)