### PR TITLE
feat(kbli-filiera): batch-0 vault compilers — pp28/oss fetchers, manifest, tigris mirror, bps registrar

### DIFF
--- a/.github/workflows/kbli-filiera-vault-compilers.yml
+++ b/.github/workflows/kbli-filiera-vault-compilers.yml
@@ -1,0 +1,45 @@
+name: kbli-filiera-vault-compilers
+
+# Batch-0 vault-bootstrap compilers for GARUDA-FILIERA
+# (research/operations/2026-07-16-kbli-garuda-filiera-workflow.md §4):
+# scripts/kbli_filiera/{vault_fetch_pp28,vault_fetch_oss,vault_fetch_bps,
+# vault_manifest}.py + vault_mirror_tigris.sh. Pure-stdlib compilers, zero
+# network in the test battery (unittest.mock/monkeypatch fixtures only —
+# these are the sole sanctioned writers of the raw-evidence vault per
+# infra/claude-hooks/data-plane-registry.json, id "kbli-filiera").
+on:
+  pull_request:
+    paths:
+      - "scripts/kbli_filiera/**"
+      - ".github/workflows/kbli-filiera-vault-compilers.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/kbli_filiera/**"
+      - ".github/workflows/kbli-filiera-vault-compilers.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kbli-filiera-vault-compilers-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kbli-filiera-vault-compilers:
+    name: kbli-filiera-vault-compilers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Run vault compiler test battery
+        run: |
+          set -uo pipefail
+          python -m pip install --quiet pytest
+          python -m pytest scripts/kbli_filiera/tests/ -v

--- a/scripts/kbli_filiera/__init__.py
+++ b/scripts/kbli_filiera/__init__.py
@@ -1,0 +1,17 @@
+"""kbli_filiera — GARUDA-FILIERA Batch 0 vault-bootstrap compilers.
+
+Deterministic, no-LLM Python compilers per the three-layer division of
+labor in research/operations/2026-07-16-kbli-garuda-filiera-workflow.md §1:
+an LLM never manufactures a deterministic fact — these scripts are the
+ONLY sanctioned writers of the raw-evidence vault (L0,
+research/operations/2026-07-16-kbli-filiera-methodology.md P4) and,
+downstream, of data/kbli-filiera/** (guard-enforced:
+infra/claude-hooks/data-plane-registry.json, id "kbli-filiera").
+
+Modules:
+  vault_common       — shared HTTP/hash/JSONL/logging utilities.
+  vault_fetch_pp28    — PP 28/2025 lampiran corpus (peraturan.bpk.go.id).
+  vault_fetch_oss     — full OSS RBA re-snapshot (gw.oss.go.id).
+  vault_fetch_bps     — BPS Tabel Konversi registrar (browser-manual, Turnstile-blocked).
+  vault_manifest      — deterministic sha256 manifest walker over the vault.
+"""

--- a/scripts/kbli_filiera/tests/test_vault_common.py
+++ b/scripts/kbli_filiera/tests/test_vault_common.py
@@ -1,0 +1,179 @@
+"""Unit tests for scripts/kbli_filiera/vault_common.py — pure logic only,
+no network (mirrors the repo convention in scripts/wr2_html_renderer/tests/:
+sys.path insert of scripts/ + package import)."""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from kbli_filiera import vault_common as common  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Content-Disposition filename parsing
+# ---------------------------------------------------------------------------
+
+class TestParseContentDispositionFilename:
+    def test_quoted_filename(self):
+        header = 'attachment; filename="2.6g Lampiran I.F Sektor (I.F.4501-5248).pdf"'
+        assert common.parse_content_disposition_filename(header) == (
+            "2.6g Lampiran I.F Sektor (I.F.4501-5248).pdf"
+        )
+
+    def test_rfc5987_star_filename(self):
+        header = "attachment; filename*=UTF-8''2.6g%20Lampiran%20I.F.pdf"
+        assert common.parse_content_disposition_filename(header) == "2.6g Lampiran I.F.pdf"
+
+    def test_star_takes_priority_over_plain(self):
+        header = 'attachment; filename="fallback.pdf"; filename*=UTF-8\'\'real%20name.pdf'
+        assert common.parse_content_disposition_filename(header) == "real name.pdf"
+
+    def test_bare_unquoted_filename(self):
+        header = "attachment; filename=plain.pdf"
+        assert common.parse_content_disposition_filename(header) == "plain.pdf"
+
+    def test_missing_header_returns_none(self):
+        assert common.parse_content_disposition_filename(None) is None
+        assert common.parse_content_disposition_filename("") is None
+
+    def test_header_without_filename_returns_none(self):
+        assert common.parse_content_disposition_filename("attachment") is None
+
+
+# ---------------------------------------------------------------------------
+# PP28 lampiran filename structural parse
+# ---------------------------------------------------------------------------
+
+class TestParsePp28LampiranFilename:
+    def test_fragment_letter_range(self):
+        # The grounded fact from the live probe (2026-07-16): a single
+        # lampiran LETTER spans multiple sequential BPK ids.
+        filename = "2.6g Lampiran I.F Sektor Pariwisata (I.F.4501-5248).pdf"
+        result = common.parse_pp28_lampiran_filename(filename)
+        assert result == {"fragment": "2.6g", "letter": "I.F", "range": "4501-5248"}
+
+    def test_letter_without_sub_letter(self):
+        filename = "2.1 Lampiran I Sektor ESDM (I.1-4500).pdf"
+        result = common.parse_pp28_lampiran_filename(filename)
+        assert result["fragment"] == "2.1"
+        assert result["letter"] == "I"
+        assert result["range"] == "1-4500"
+
+    def test_no_range_present(self):
+        filename = "2.19 Lampiran IV Ketentuan Umum.pdf"
+        result = common.parse_pp28_lampiran_filename(filename)
+        assert result["fragment"] == "2.19"
+        assert result["letter"] == "IV"
+        assert result["range"] is None
+
+    def test_unparseable_filename_returns_all_none(self):
+        result = common.parse_pp28_lampiran_filename("random-file-name.pdf")
+        assert result == {"fragment": None, "letter": None, "range": None}
+
+    def test_never_raises_on_empty_string(self):
+        result = common.parse_pp28_lampiran_filename("")
+        assert result == {"fragment": None, "letter": None, "range": None}
+
+
+# ---------------------------------------------------------------------------
+# Idempotent resume decision
+# ---------------------------------------------------------------------------
+
+class TestDecideResume:
+    def test_no_prior_record_refetches(self, tmp_path):
+        target = tmp_path / "some.pdf"
+        assert common.decide_resume(None, target) == "refetch"
+
+    def test_prior_not_200_refetches(self, tmp_path):
+        target = tmp_path / "some.pdf"
+        target.write_bytes(b"data")
+        prior = {"http_status": 404, "bytes": 4, "sha256": common.sha256_bytes(b"data")}
+        assert common.decide_resume(prior, target) == "refetch"
+
+    def test_missing_file_refetches(self, tmp_path):
+        target = tmp_path / "missing.pdf"
+        prior = {"http_status": 200, "bytes": 4, "sha256": "deadbeef"}
+        assert common.decide_resume(prior, target) == "refetch"
+
+    def test_matching_size_and_sha256_skips(self, tmp_path):
+        data = b"hello vault"
+        target = tmp_path / "match.pdf"
+        target.write_bytes(data)
+        prior = {"http_status": 200, "bytes": len(data), "sha256": common.sha256_bytes(data)}
+        assert common.decide_resume(prior, target) == "skip"
+
+    def test_size_mismatch_refetches(self, tmp_path):
+        data = b"hello vault"
+        target = tmp_path / "sizemismatch.pdf"
+        target.write_bytes(data)
+        prior = {"http_status": 200, "bytes": len(data) + 1, "sha256": common.sha256_bytes(data)}
+        assert common.decide_resume(prior, target) == "refetch"
+
+    def test_sha256_mismatch_refetches_even_with_matching_size(self, tmp_path):
+        # Corrupted-on-disk case: byte count happens to match, content doesn't.
+        data = b"hello vault"
+        corrupted = b"HELLO VAULT"  # same length, different bytes
+        assert len(data) == len(corrupted)
+        target = tmp_path / "corrupted.pdf"
+        target.write_bytes(corrupted)
+        prior = {"http_status": 200, "bytes": len(data), "sha256": common.sha256_bytes(data)}
+        assert common.decide_resume(prior, target) == "refetch"
+
+    def test_sha256_is_reverified_from_disk_not_trusted_blindly(self, tmp_path):
+        # The prior record CLAIMS a sha256 that matches the (wrong) on-disk
+        # bytes would only pass if we trusted the log; decide_resume must
+        # actually re-hash the file.
+        target = tmp_path / "trust.pdf"
+        target.write_bytes(b"real content")
+        wrong_hash_prior = {
+            "http_status": 200,
+            "bytes": len(b"real content"),
+            "sha256": common.sha256_bytes(b"different content entirely!!"),
+        }
+        assert common.decide_resume(wrong_hash_prior, target) == "refetch"
+
+
+# ---------------------------------------------------------------------------
+# Hashing + jsonl + filename sanitizing
+# ---------------------------------------------------------------------------
+
+class TestHashingAndJsonl:
+    def test_sha256_file_matches_sha256_bytes(self, tmp_path):
+        data = b"the quick brown fox"
+        f = tmp_path / "x.bin"
+        f.write_bytes(data)
+        assert common.sha256_file(f) == common.sha256_bytes(data)
+
+    def test_append_and_read_jsonl_roundtrip(self, tmp_path):
+        log = tmp_path / "sub" / "log.jsonl"
+        common.append_jsonl(log, {"a": 1})
+        common.append_jsonl(log, {"a": 2})
+        records = common.read_jsonl(log)
+        assert records == [{"a": 1}, {"a": 2}]
+
+    def test_read_jsonl_missing_file_returns_empty(self, tmp_path):
+        assert common.read_jsonl(tmp_path / "nope.jsonl") == []
+
+    def test_read_jsonl_skips_corrupt_lines(self, tmp_path):
+        log = tmp_path / "log.jsonl"
+        log.write_text('{"a": 1}\nNOT JSON\n{"a": 2}\n', encoding="utf-8")
+        assert common.read_jsonl(log) == [{"a": 1}, {"a": 2}]
+
+
+class TestSanitizeFilename:
+    def test_keeps_readable_characters(self):
+        name = "2.6g Lampiran I.F (I.F.4501-5248).pdf"
+        assert common.sanitize_filename(name) == name
+
+    def test_strips_path_separators(self):
+        assert "/" not in common.sanitize_filename("a/b\\c.pdf")
+
+    def test_collapses_whitespace(self):
+        assert common.sanitize_filename("a    b.pdf") == "a b.pdf"
+
+    def test_caps_length_preserving_extension(self):
+        long_stem = "x" * 300
+        result = common.sanitize_filename(f"{long_stem}.pdf", max_len=50)
+        assert len(result) <= 50
+        assert result.endswith(".pdf")

--- a/scripts/kbli_filiera/tests/test_vault_fetch_bps.py
+++ b/scripts/kbli_filiera/tests/test_vault_fetch_bps.py
@@ -1,0 +1,86 @@
+"""Unit tests for scripts/kbli_filiera/vault_fetch_bps.py — pure logic +
+local-file I/O only, no network (this compiler never fetches over HTTP)."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from kbli_filiera import vault_common as common  # noqa: E402
+from kbli_filiera import vault_fetch_bps as bps  # noqa: E402
+
+
+class TestValidateSourceUrl:
+    def test_official_id_url_accepted(self):
+        assert bps.validate_source_url(bps.OFFICIAL_URLS[0]) is True
+
+    def test_official_en_url_accepted(self):
+        assert bps.validate_source_url(bps.OFFICIAL_URLS[1]) is True
+
+    def test_third_party_mirror_rejected(self):
+        assert bps.validate_source_url("https://some-mirror.example.com/tabel-konversi.pdf") is False
+
+    def test_lookalike_url_rejected(self):
+        # A near-identical URL (trailing slash, different scheme) is still
+        # NOT one of the two exact official strings — no fuzzy matching.
+        assert bps.validate_source_url(bps.OFFICIAL_URLS[0] + "/") is False
+        assert bps.validate_source_url(bps.OFFICIAL_URLS[0].replace("https", "http")) is False
+
+    def test_empty_string_rejected(self):
+        assert bps.validate_source_url("") is False
+
+
+class TestRegister:
+    def test_register_copies_file_and_appends_log(self, tmp_path):
+        src = tmp_path / "downloads" / "tabel-konversi.pdf"
+        src.parent.mkdir(parents=True)
+        src.write_bytes(b"%PDF fake bps table")
+        vault_root = tmp_path / "vault"
+
+        rec = bps.register(vault_root, src, bps.OFFICIAL_URLS[0], fetched_at="2026-07-16T00:00:00Z")
+
+        dest = vault_root / "bps" / "tabel-konversi.pdf"
+        assert dest.exists()
+        assert dest.read_bytes() == src.read_bytes()
+        assert rec["sha256"] == common.sha256_bytes(src.read_bytes())
+        assert rec["fetched_via"] == "browser-manual"
+        assert rec["source_url"] == bps.OFFICIAL_URLS[0]
+        assert rec["rel_path"] == "bps/tabel-konversi.pdf"
+
+        logged = common.read_jsonl(vault_root / "bps" / "fetch-log.jsonl")
+        assert logged == [rec]
+
+    def test_register_refuses_third_party_mirror(self, tmp_path):
+        src = tmp_path / "x.pdf"
+        src.write_bytes(b"data")
+        with pytest.raises(ValueError, match="no silent mirrors"):
+            bps.register(tmp_path / "vault", src, "https://mirror.example.com/x.pdf")
+
+    def test_register_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            bps.register(tmp_path / "vault", tmp_path / "does-not-exist.pdf", bps.OFFICIAL_URLS[0])
+
+
+class TestInstructions:
+    def test_mentions_both_official_urls(self):
+        text = bps.instructions()
+        assert bps.OFFICIAL_URLS[0] in text
+        assert bps.OFFICIAL_URLS[1] in text
+
+    def test_mentions_register_flag(self):
+        assert "--register" in bps.instructions()
+
+
+class TestBuildBpsRecord:
+    def test_shape(self, tmp_path):
+        vault_root = tmp_path / "vault"
+        dest = vault_root / "bps" / "x.pdf"
+        dest.parent.mkdir(parents=True)
+        dest.write_bytes(b"data")
+        rec = bps.build_bps_record(dest, vault_root, bps.OFFICIAL_URLS[0], b"data", "2026-07-16T00:00:00Z")
+        assert rec["http_status"] == 200
+        assert rec["fetched_via"] == "browser-manual"
+        assert rec["bytes"] == 4
+        assert rec["rel_path"] == "bps/x.pdf"

--- a/scripts/kbli_filiera/tests/test_vault_fetch_bps.py
+++ b/scripts/kbli_filiera/tests/test_vault_fetch_bps.py
@@ -19,6 +19,24 @@ class TestValidateSourceUrl:
     def test_official_en_url_accepted(self):
         assert bps.validate_source_url(bps.OFFICIAL_URLS[1]) is True
 
+    def test_en_url_has_the_live_probed_triple_dash_slug(self):
+        # Pin the exact live-probed (2026-07-16, vault-scout) EN slug:
+        # "2020---kbli" is a TRIPLE dash, not a typo — a gate review caught
+        # an earlier single-dash version of this constant that would have
+        # refused the real page (guard-over-match, cicatrix superscar #3).
+        assert "tabel-konversi-kbli-2020---kbli-2025.html" in bps.OFFICIAL_URLS[1]
+
+    def test_single_dash_en_lookalike_is_correctly_refused(self):
+        # Plausible fetch typo AND a plausible phishing-style lookalike of
+        # the real (triple-dash) EN URL — refusing it is correct behavior,
+        # pinned so it can never silently start being accepted.
+        single_dash_lookalike = (
+            "https://www.bps.go.id/en/publication/2026/04/22/909d503355d2b7664e43dea8/"
+            "tabel-konversi-kbli-2020-kbli-2025.html"
+        )
+        assert single_dash_lookalike != bps.OFFICIAL_URLS[1]
+        assert bps.validate_source_url(single_dash_lookalike) is False
+
     def test_third_party_mirror_rejected(self):
         assert bps.validate_source_url("https://some-mirror.example.com/tabel-konversi.pdf") is False
 

--- a/scripts/kbli_filiera/tests/test_vault_fetch_oss.py
+++ b/scripts/kbli_filiera/tests/test_vault_fetch_oss.py
@@ -1,0 +1,148 @@
+"""Unit tests for scripts/kbli_filiera/vault_fetch_oss.py — no network:
+common.http_get is monkeypatched wherever a fetch would otherwise fire."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from kbli_filiera import vault_common as common  # noqa: E402
+from kbli_filiera import vault_fetch_oss as oss  # noqa: E402
+
+
+def _fake_result(status=200, headers=None, body=b"", error=None):
+    return common.FetchResult(status=status, headers=headers or {}, body=body, error=error)
+
+
+class TestEndpointUrl:
+    def test_detail_has_no_prefix(self):
+        assert oss.endpoint_url("detail", "abc-uuid") == "https://gw.oss.go.id/v2/portal/kbli/abc-uuid"
+
+    def test_ruang_lingkup_prefix(self):
+        assert oss.endpoint_url("ruang_lingkup", "abc-uuid") == (
+            "https://gw.oss.go.id/v2/portal/kbli/ruang-lingkup/abc-uuid"
+        )
+
+    def test_relasi_and_umku_prefixes(self):
+        assert oss.endpoint_url("relasi", "u") == "https://gw.oss.go.id/v2/portal/kbli/relasi/u"
+        assert oss.endpoint_url("umku", "u") == "https://gw.oss.go.id/v2/portal/kbli/umku/u"
+
+
+class TestLoadCodeUuidMap:
+    def test_filters_to_5_digit_codes_only(self, tmp_path):
+        gt = tmp_path / "gt.json"
+        gt.write_text(json.dumps({
+            "_meta": {},
+            "data": [
+                {"kode": "47111", "uuid": "u1", "digits": 5},
+                {"kode": "471", "uuid": "u2", "digits": 3},
+                {"kode": "68112", "uuid": "u3", "digits": 5},
+            ],
+        }), encoding="utf-8")
+        codes = oss.load_code_uuid_map(gt)
+        assert codes == [("47111", "u1"), ("68112", "u3")]
+
+
+class TestBuildAbsenceRecord:
+    def test_shape_matches_spec(self):
+        rec = oss.build_absence_record("47111", "ruang_lingkup", "http://x", "uuid-1", 404, "2026-07-16T00:00:00Z")
+        assert rec == {
+            "code": "47111",
+            "endpoint": "ruang_lingkup",
+            "url": "http://x",
+            "uuid": "uuid-1",
+            "status": 404,
+            "recorded_as": "absent",
+            "fetched_at": "2026-07-16T00:00:00Z",
+        }
+
+
+class TestFetchEndpoint:
+    def test_200_writes_data_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(common, "http_get", lambda *a, **k: _fake_result(200, {}, b'{"ok": true}'))
+        rec = oss.fetch_endpoint(tmp_path, "47111", "uuid-1", "detail", None)
+        assert rec["_kind"] == "data"
+        assert rec["http_status"] == 200
+        target = tmp_path / rec["rel_path"]
+        assert target.read_bytes() == b'{"ok": true}'
+
+    def test_404_returns_absence_kind_never_writes_a_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(common, "http_get", lambda *a, **k: _fake_result(404, {}, b""))
+        rec = oss.fetch_endpoint(tmp_path, "47111", "uuid-1", "ruang_lingkup", None)
+        assert rec["_kind"] == "absence"
+        assert rec["status"] == 404
+        assert rec["recorded_as"] == "absent"
+        data_file = oss.data_path(tmp_path, "47111", "ruang_lingkup")
+        assert not data_file.exists()
+
+    def test_non_200_non_404_records_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(common, "http_get", lambda *a, **k: _fake_result(503, {}, b"", "HTTP 503"))
+        rec = oss.fetch_endpoint(tmp_path, "47111", "uuid-1", "umku", None)
+        assert rec["_kind"] == "data"
+        assert rec["http_status"] == 503
+        assert rec["error"]
+        assert rec["rel_path"] is None
+
+    def test_verified_prior_skips_without_network(self, tmp_path, monkeypatch):
+        data = b'{"cached": true}'
+        target = oss.data_path(tmp_path, "47111", "detail")
+        target.parent.mkdir(parents=True)
+        target.write_bytes(data)
+        prior = {
+            "code": "47111", "endpoint": "detail", "url": "x", "uuid": "uuid-1",
+            "bytes": len(data), "sha256": common.sha256_bytes(data),
+            "fetched_at": "2026-07-16T00:00:00Z", "http_status": 200,
+            "rel_path": target.relative_to(tmp_path).as_posix(),
+        }
+
+        def _boom(*a, **k):
+            raise AssertionError("http_get must not be called on a verified skip")
+
+        monkeypatch.setattr(common, "http_get", _boom)
+        result = oss.fetch_endpoint(tmp_path, "47111", "uuid-1", "detail", prior)
+        assert result is None
+
+
+class TestRun:
+    def test_only_filters_to_requested_codes(self, tmp_path, monkeypatch):
+        gt = tmp_path / "gt.json"
+        gt.write_text(json.dumps({
+            "_meta": {},
+            "data": [
+                {"kode": "47111", "uuid": "u1", "digits": 5},
+                {"kode": "68112", "uuid": "u2", "digits": 5},
+                {"kode": "99999", "uuid": "u3", "digits": 5},
+            ],
+        }), encoding="utf-8")
+        seen_codes = set()
+
+        def _fake_http(url, **k):
+            seen_codes.add(url.rsplit("/", 1)[-1])
+            return _fake_result(200, {}, b"{}")
+
+        monkeypatch.setattr(common, "http_get", _fake_http)
+        rc = oss.run(tmp_path, gt, only={"47111"}, rate_s=0)
+        assert rc == 0
+        assert seen_codes == {"u1"}  # only the requested code's uuid was fetched
+
+    def test_404_endpoints_do_not_cause_a_nonzero_exit(self, tmp_path, monkeypatch):
+        gt = tmp_path / "gt.json"
+        gt.write_text(json.dumps({
+            "_meta": {}, "data": [{"kode": "47111", "uuid": "u1", "digits": 5}],
+        }), encoding="utf-8")
+        monkeypatch.setattr(common, "http_get", lambda *a, **k: _fake_result(404, {}, b""))
+        rc = oss.run(tmp_path, gt, rate_s=0)
+        assert rc == 0
+        absences = common.read_jsonl(oss.absences_path(tmp_path))
+        assert len(absences) == 4  # detail + ruang_lingkup + relasi + umku, all absent
+        assert all(a["recorded_as"] == "absent" for a in absences)
+
+    def test_real_failure_causes_nonzero_exit(self, tmp_path, monkeypatch):
+        gt = tmp_path / "gt.json"
+        gt.write_text(json.dumps({
+            "_meta": {}, "data": [{"kode": "47111", "uuid": "u1", "digits": 5}],
+        }), encoding="utf-8")
+        monkeypatch.setattr(common, "http_get", lambda *a, **k: _fake_result(500, {}, b"", "HTTP 500"))
+        rc = oss.run(tmp_path, gt, rate_s=0)
+        assert rc == 1

--- a/scripts/kbli_filiera/tests/test_vault_fetch_pp28.py
+++ b/scripts/kbli_filiera/tests/test_vault_fetch_pp28.py
@@ -1,0 +1,146 @@
+"""Unit tests for scripts/kbli_filiera/vault_fetch_pp28.py — no network:
+common.http_get is monkeypatched wherever a fetch would otherwise fire."""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from kbli_filiera import vault_common as common  # noqa: E402
+from kbli_filiera import vault_fetch_pp28 as pp28  # noqa: E402
+
+
+def _fake_result(status=200, headers=None, body=b"", error=None):
+    return common.FetchResult(status=status, headers=headers or {}, body=body, error=error)
+
+
+class TestTargetPath:
+    def test_builds_id_dunder_filename(self, tmp_path):
+        target = pp28.target_path(tmp_path, 394930, "2.1 Lampiran I.A (I.A.1-500).pdf")
+        assert target.parent == tmp_path / "pp28"
+        assert target.name == "394930__2.1 Lampiran I.A (I.A.1-500).pdf"
+
+
+class TestFetchOneResume:
+    def test_verified_prior_skips_without_network(self, tmp_path, monkeypatch):
+        data = b"pdf bytes"
+        filename = "2.1 Lampiran I.A (I.A.1-500).pdf"
+        target = pp28.target_path(tmp_path, 394930, filename)
+        target.parent.mkdir(parents=True)
+        target.write_bytes(data)
+        prior = {
+            "id": 394930, "url": "x", "filename": filename,
+            "bytes": len(data), "sha256": common.sha256_bytes(data),
+            "fetched_at": "2026-07-16T00:00:00Z", "http_status": 200,
+            "rel_path": target.relative_to(tmp_path).as_posix(),
+        }
+
+        called = {"n": 0}
+
+        def _boom(*a, **k):
+            called["n"] += 1
+            raise AssertionError("http_get must not be called on a verified skip")
+
+        monkeypatch.setattr(common, "http_get", _boom)
+        rec = pp28.fetch_one(tmp_path, 394930, prior, sleep_s=0)
+        assert rec is prior
+        assert called["n"] == 0
+
+    def test_corrupted_prior_triggers_refetch(self, tmp_path, monkeypatch):
+        filename = "2.1 Lampiran I.A (I.A.1-500).pdf"
+        target = pp28.target_path(tmp_path, 394930, filename)
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"CORRUPTED")
+        prior = {
+            "id": 394930, "url": "x", "filename": filename,
+            "bytes": 9, "sha256": common.sha256_bytes(b"original bytes"),
+            "fetched_at": "2026-07-16T00:00:00Z", "http_status": 200,
+            "rel_path": target.relative_to(tmp_path).as_posix(),
+        }
+        new_body = b"fresh download"
+        monkeypatch.setattr(
+            common, "http_get",
+            lambda *a, **k: _fake_result(
+                200,
+                {"Content-Disposition": f'attachment; filename="{filename}"',
+                 "Content-Length": str(len(new_body))},
+                new_body,
+            ),
+        )
+        rec = pp28.fetch_one(tmp_path, 394930, prior, sleep_s=0)
+        assert rec["sha256"] == common.sha256_bytes(new_body)
+        assert target.read_bytes() == new_body
+
+
+class TestFetchOneFreshFetch:
+    def test_ok_fetch_writes_file_and_parses_structure(self, tmp_path, monkeypatch):
+        filename = "2.6g Lampiran I.F (I.F.4501-5248).pdf"
+        body = b"%PDF-1.4 fake content"
+        monkeypatch.setattr(
+            common, "http_get",
+            lambda *a, **k: _fake_result(
+                200,
+                {"Content-Disposition": f'attachment; filename="{filename}"',
+                 "Content-Length": str(len(body))},
+                body,
+            ),
+        )
+        rec = pp28.fetch_one(tmp_path, 394941, None, sleep_s=0)
+        assert rec["http_status"] == 200
+        assert rec["sha256"] == common.sha256_bytes(body)
+        assert rec["fragment"] == "2.6g"
+        assert rec["letter"] == "I.F"
+        assert rec["range"] == "4501-5248"
+        written = tmp_path / rec["rel_path"]
+        assert written.read_bytes() == body
+
+    def test_non_200_status_records_error_and_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(common, "http_get", lambda *a, **k: _fake_result(500, {}, b"", "HTTP 500"))
+        rec = pp28.fetch_one(tmp_path, 394930, None, sleep_s=0)
+        assert rec["http_status"] == 500
+        assert rec["error"]
+        assert not (tmp_path / "pp28").exists() or not any((tmp_path / "pp28").iterdir())
+
+    def test_content_length_mismatch_is_fail_visible(self, tmp_path, monkeypatch):
+        body = b"short"
+        monkeypatch.setattr(
+            common, "http_get",
+            lambda *a, **k: _fake_result(
+                200,
+                {"Content-Disposition": 'attachment; filename="x.pdf"', "Content-Length": "99999"},
+                body,
+            ),
+        )
+        rec = pp28.fetch_one(tmp_path, 394930, None, sleep_s=0)
+        assert rec["rel_path"] is None
+        assert "mismatch" in rec["error"]
+
+
+class TestRun:
+    def test_run_returns_zero_when_all_ok(self, tmp_path, monkeypatch):
+        body = b"ok"
+        monkeypatch.setattr(
+            common, "http_get",
+            lambda *a, **k: _fake_result(
+                200, {"Content-Disposition": 'attachment; filename="x.pdf"'}, body,
+            ),
+        )
+        rc = pp28.run(tmp_path, ids=(1, 2, 3), sleep_s=0)
+        assert rc == 0
+        records = common.read_jsonl(pp28.fetch_log_path(tmp_path))
+        assert len(records) == 3
+
+    def test_run_finishes_full_sweep_and_returns_one_on_any_failure(self, tmp_path, monkeypatch):
+        calls = []
+
+        def _fake_http(url, **k):
+            calls.append(url)
+            if url.endswith("2"):
+                return _fake_result(500, {}, b"", "HTTP 500")
+            return _fake_result(200, {"Content-Disposition": 'attachment; filename="x.pdf"'}, b"ok")
+
+        monkeypatch.setattr(common, "http_get", _fake_http)
+        rc = pp28.run(tmp_path, ids=(1, 2, 3), sleep_s=0)
+        assert rc == 1
+        # the sweep must not stop early at the failing id — all 3 attempted
+        assert len(calls) == 3

--- a/scripts/kbli_filiera/tests/test_vault_manifest.py
+++ b/scripts/kbli_filiera/tests/test_vault_manifest.py
@@ -1,0 +1,96 @@
+"""Unit tests for scripts/kbli_filiera/vault_manifest.py — pure filesystem
+walk + hashing, no network."""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from kbli_filiera import vault_common as common  # noqa: E402
+from kbli_filiera import vault_manifest as manifest  # noqa: E402
+
+
+def _make_tree(root):
+    (root / "pp28").mkdir(parents=True)
+    (root / "pp28" / "394930__a.pdf").write_bytes(b"pdf-a")
+    (root / "pp28" / "394931__b.pdf").write_bytes(b"pdf-b")
+    common.append_jsonl(root / "pp28" / "fetch-log.jsonl", {
+        "id": 394930, "url": "https://example/394930", "rel_path": "pp28/394930__a.pdf",
+        "http_status": 200, "fetched_at": "2026-07-16T00:00:00Z",
+    })
+    common.append_jsonl(root / "pp28" / "fetch-log.jsonl", {
+        "id": 394931, "url": "https://example/394931", "rel_path": "pp28/394931__b.pdf",
+        "http_status": 200, "fetched_at": "2026-07-16T00:01:00Z",
+    })
+    (root / "oss" / "47111").mkdir(parents=True)
+    (root / "oss" / "47111" / "detail.json").write_bytes(b'{"detail": true}')
+    common.append_jsonl(root / "oss" / "fetch-log.jsonl", {
+        "code": "47111", "endpoint": "detail", "url": "https://oss/47111",
+        "rel_path": "oss/47111/detail.json", "http_status": 200,
+        "fetched_at": "2026-07-16T02:00:00Z",
+    })
+    common.append_jsonl(root / "oss" / "absences.jsonl", {
+        "code": "47111", "endpoint": "ruang_lingkup", "status": 404, "recorded_as": "absent",
+    })
+
+
+class TestBuildManifest:
+    def test_entries_sorted_by_rel_path(self, tmp_path):
+        _make_tree(tmp_path)
+        entries = manifest.build_manifest(tmp_path)
+        rel_paths = [e["rel_path"] for e in entries]
+        assert rel_paths == sorted(rel_paths)
+
+    def test_log_files_excluded_from_manifest(self, tmp_path):
+        _make_tree(tmp_path)
+        entries = manifest.build_manifest(tmp_path)
+        names = {e["rel_path"] for e in entries}
+        assert "pp28/fetch-log.jsonl" not in names
+        assert "oss/fetch-log.jsonl" not in names
+        assert "oss/absences.jsonl" not in names
+
+    def test_absences_never_produce_manifest_entries(self, tmp_path):
+        _make_tree(tmp_path)
+        entries = manifest.build_manifest(tmp_path)
+        # ruang_lingkup was recorded absent (404) -> no file, no entry
+        assert not any("ruang_lingkup" in e["rel_path"] for e in entries)
+
+    def test_provenance_merged_by_exact_rel_path(self, tmp_path):
+        _make_tree(tmp_path)
+        entries = {e["rel_path"]: e for e in manifest.build_manifest(tmp_path)}
+        pp28_a = entries["pp28/394930__a.pdf"]
+        assert pp28_a["source_url"] == "https://example/394930"
+        assert pp28_a["fetched_at"] == "2026-07-16T00:00:00Z"
+        assert pp28_a["sha256"] == common.sha256_bytes(b"pdf-a")
+        assert pp28_a["bytes"] == len(b"pdf-a")
+
+    def test_file_with_no_provenance_still_included(self, tmp_path):
+        tmp_path.joinpath("orphan.txt").write_bytes(b"no log entry for this")
+        entries = manifest.build_manifest(tmp_path)
+        orphan = next(e for e in entries if e["rel_path"] == "orphan.txt")
+        assert "source_url" not in orphan
+        assert "fetched_at" not in orphan
+        assert orphan["sha256"] == common.sha256_bytes(b"no log entry for this")
+
+
+class TestDeterminism:
+    def test_same_tree_produces_byte_identical_output(self, tmp_path):
+        _make_tree(tmp_path)
+        first = manifest.render_manifest(manifest.build_manifest(tmp_path))
+        second = manifest.render_manifest(manifest.build_manifest(tmp_path))
+        assert first == second
+
+    def test_rebuild_after_touching_provenance_order_is_still_deterministic(self, tmp_path):
+        # Re-append the SAME log lines in a different insertion order for a
+        # third file — output must not depend on jsonl iteration order.
+        _make_tree(tmp_path)
+        (tmp_path / "oss" / "68112").mkdir(parents=True)
+        (tmp_path / "oss" / "68112" / "detail.json").write_bytes(b'{"x": 1}')
+        common.append_jsonl(tmp_path / "oss" / "fetch-log.jsonl", {
+            "code": "68112", "endpoint": "detail", "url": "https://oss/68112",
+            "rel_path": "oss/68112/detail.json", "http_status": 200,
+            "fetched_at": "2026-07-16T03:00:00Z",
+        })
+        run_a = manifest.render_manifest(manifest.build_manifest(tmp_path))
+        run_b = manifest.render_manifest(manifest.build_manifest(tmp_path))
+        assert run_a == run_b

--- a/scripts/kbli_filiera/vault_common.py
+++ b/scripts/kbli_filiera/vault_common.py
@@ -1,0 +1,252 @@
+"""vault_common — shared utilities for the GARUDA-FILIERA Batch-0 vault compilers.
+
+Pure-stdlib on purpose (Mini runs these; avoid exotic deps per the batch-0
+mandate). Everything network-facing goes through `http_get`, which bypasses
+the system proxy explicitly (memory trap: urllib honors it silently —
+scripts/fetch_oss_risk.py hit this first) and never retries a 404 (a 404 is
+a signal, not a transient failure — P3 corroborated-absence discipline,
+research/operations/2026-07-16-kbli-filiera-methodology.md).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import unquote
+
+DEFAULT_VAULT_ROOT = Path("~/nuzantara-vault").expanduser()
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+def setup_logger(name: str) -> logging.Logger:
+    """logger, never print() (CLAUDE.md golden rule #8) — idempotent, safe
+    to call more than once for the same name (won't double-attach handlers)."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# Time
+# ---------------------------------------------------------------------------
+
+def now_iso() -> str:
+    """UTC, second precision, explicit Z suffix — matches the fetched_at
+    shape used across every fetch-log/absence record in this package."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path, chunk_size: int = 1 << 20) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# JSONL append/read log
+# ---------------------------------------------------------------------------
+
+def append_jsonl(path: Path, record: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        f.flush()
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    """Never raises on a missing file or a corrupt line (a torn last line
+    from a killed process is recoverable — the log is append-only evidence,
+    not a transaction log; a bad line is just skipped, not fatal)."""
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Idempotent resume (shared decision logic — pp28 and oss fetchers both use
+# this so "existing-file-with-matching-sha skipped, mismatched-sha
+# refetched" is ONE tested code path, not two copies that can drift apart)
+# ---------------------------------------------------------------------------
+
+def decide_resume(prior: dict | None, file_path: Path) -> str:
+    """Returns "skip" (file verified on disk, matches the prior record's
+    recorded bytes+sha256) or "refetch" (no prior, prior wasn't a clean
+    200, file missing, size drifted, or sha256 drifted — re-verified on
+    every call, never trusted blindly per the batch-0 spec)."""
+    if prior is None:
+        return "refetch"
+    if prior.get("http_status") != 200:
+        return "refetch"
+    if not file_path.exists():
+        return "refetch"
+    try:
+        if file_path.stat().st_size != prior.get("bytes"):
+            return "refetch"
+    except OSError:
+        return "refetch"
+    if sha256_file(file_path) != prior.get("sha256"):
+        return "refetch"
+    return "skip"
+
+
+# ---------------------------------------------------------------------------
+# HTTP (stdlib urllib — proxy-bypassed, 404-is-terminal, polite retry)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FetchResult:
+    status: int
+    headers: dict[str, str] = field(default_factory=dict)
+    body: bytes = b""
+    error: str | None = None
+
+
+def http_get(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: float = 25.0,
+    retries: int = 3,
+    backoff: float = 1.5,
+) -> FetchResult:
+    """GET with an explicit proxy bypass (ProxyHandler({})) and a 404 that
+    returns IMMEDIATELY without entering the retry loop — a 404 is a
+    LEGIT no-scope/absence signal, never a transient failure to hammer
+    (P3; "never retry-storm it"). Any other non-2xx or network exception
+    retries up to `retries` times with linear backoff, then returns a
+    FetchResult with `error` set (never raises — callers decide fail-visible
+    handling, e.g. exit-1-after-full-sweep)."""
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    last_status = 0
+    last_error = "exhausted"
+    for attempt in range(retries):
+        req = urllib.request.Request(url, headers=headers or {})
+        try:
+            with opener.open(req, timeout=timeout) as resp:
+                return FetchResult(status=resp.status, headers=dict(resp.headers), body=resp.read())
+        except urllib.error.HTTPError as exc:
+            body = exc.read() if exc.fp else b""
+            if exc.code == 404:
+                return FetchResult(status=404, headers=dict(exc.headers or {}), body=body)
+            last_status = exc.code
+            last_error = f"HTTP {exc.code}"
+        except Exception as exc:  # noqa: BLE001 — network layer, deliberately broad
+            last_error = str(exc)
+        if attempt < retries - 1:
+            time.sleep(backoff * (attempt + 1))
+    return FetchResult(status=last_status, headers={}, body=b"", error=last_error)
+
+
+# ---------------------------------------------------------------------------
+# Content-Disposition filename parsing
+# ---------------------------------------------------------------------------
+
+_CD_STAR_RE = re.compile(r"filename\*\s*=\s*[^']*''([^;]+)", re.IGNORECASE)
+_CD_QUOTED_RE = re.compile(r'filename\s*=\s*"([^"]+)"', re.IGNORECASE)
+_CD_BARE_RE = re.compile(r"filename\s*=\s*([^;]+)", re.IGNORECASE)
+
+
+def parse_content_disposition_filename(header_value: str | None) -> str | None:
+    """RFC 6266/5987-tolerant filename extraction: filename*=UTF-8''...
+    (percent-encoded) takes priority over plain quoted/bare filename=...
+    Returns None if the header is absent or carries no filename param."""
+    if not header_value:
+        return None
+    m = _CD_STAR_RE.search(header_value)
+    if m:
+        return unquote(m.group(1)).strip()
+    m = _CD_QUOTED_RE.search(header_value)
+    if m:
+        return m.group(1).strip()
+    m = _CD_BARE_RE.search(header_value)
+    if m:
+        return m.group(1).strip().strip('"')
+    return None
+
+
+# ---------------------------------------------------------------------------
+# PP28 lampiran filename structure (a lampiran LETTER can span multiple
+# sequential BPK download ids — this parser is what lets the fetch-log
+# double as the id->lampiran map, no separate file needed: grounded fact
+# 2026-07-16, e.g. id 394941 = "2.6g Lampiran I.F ... (I.F.4501-5248).pdf")
+# ---------------------------------------------------------------------------
+
+_LAMPIRAN_HEAD_RE = re.compile(
+    r"^(?P<fragment>\d+\.\d+[a-zA-Z]?)\s+Lampiran\s+(?P<letter>[IVXLCDM]+(?:\.[A-Z])?)\b"
+)
+_LAMPIRAN_RANGE_RE = re.compile(
+    r"\((?:[IVXLCDM]+(?:\.[A-Z])?\.)?(?P<range>\d+-\d+)[^)]*\)"
+)
+
+
+def parse_pp28_lampiran_filename(filename: str) -> dict:
+    """Best-effort structural parse of a PP28 lampiran Content-Disposition
+    filename into {fragment, letter, range}. Any field is None when not
+    present — never raises, an unparseable filename still gets recorded
+    verbatim in the fetch-log (`filename` field), just without the
+    structural breakdown."""
+    head = _LAMPIRAN_HEAD_RE.match(filename)
+    range_m = _LAMPIRAN_RANGE_RE.search(filename)
+    return {
+        "fragment": head.group("fragment") if head else None,
+        "letter": head.group("letter") if head else None,
+        "range": range_m.group("range") if range_m else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filename sanitizing (vault blob names must be safe on POSIX + S3 keys)
+# ---------------------------------------------------------------------------
+
+_UNSAFE_RE = re.compile(r"[\x00-\x1f/\\]")
+
+
+def sanitize_filename(name: str, *, max_len: int = 180) -> str:
+    """Replaces control chars and path separators, collapses whitespace,
+    and caps length (preserving the extension where recognizable) — keeps
+    the human-readable source filename (parentheses/dots survive) while
+    making it a safe single path component on any filesystem the vault
+    might live on."""
+    name = _UNSAFE_RE.sub("_", name)
+    name = re.sub(r"\s+", " ", name).strip()
+    if len(name) > max_len:
+        stem, dot, ext = name.rpartition(".")
+        if dot and stem and len(ext) <= 8:
+            keep = max_len - len(ext) - 1
+            name = f"{stem[:keep]}.{ext}"
+        else:
+            name = name[:max_len]
+    return name

--- a/scripts/kbli_filiera/vault_fetch_bps.py
+++ b/scripts/kbli_filiera/vault_fetch_bps.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""vault_fetch_bps.py — Batch-0 vault compiler: BPS Tabel Konversi registrar (stub).
+
+BPS's tabel-konversi page (bps.go.id) sits behind Cloudflare Turnstile —
+NO headless HTTP fetcher is built for it here, on purpose: an automated
+fetch would either be blocked (useless) or, worse, silently succeed against
+a challenge page and store garbage as if it were the real PDF — a false
+"fetched" signal is worse than no fetch. This script never attempts one.
+
+Two official URLs ONLY (id + en publication pages). No third-party mirror
+is ever accepted as a vault source (P4, "no silent mirrors" —
+research/operations/2026-07-16-kbli-filiera-methodology.md) — enforced by
+`validate_source_url`, not just documented.
+
+Workflow:
+  1. `python vault_fetch_bps.py` (no args) prints the two official URLs and
+     the registration instructions.
+  2. A browser-assisted step (operator, or a browser-driving agent)
+     downloads the PDF by hand to any local path.
+  3. `python vault_fetch_bps.py --register <downloaded.pdf> --source-url <one of the two URLs>`
+     ingests it into <vault-root>/bps/ with full provenance (url, fetch
+     date, sha256, fetched_via: "browser-manual").
+
+Usage:
+    python scripts/kbli_filiera/vault_fetch_bps.py
+    python scripts/kbli_filiera/vault_fetch_bps.py --register ~/Downloads/tabel-konversi.pdf \\
+        --source-url https://www.bps.go.id/id/publication/2026/04/22/909d503355d2b7664e43dea8/tabel-konversi-kbli-2020-kbli-2025.html
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+try:
+    from kbli_filiera import vault_common as common
+except ImportError:  # pragma: no cover
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from kbli_filiera import vault_common as common
+
+OFFICIAL_URLS: tuple[str, ...] = (
+    "https://www.bps.go.id/id/publication/2026/04/22/909d503355d2b7664e43dea8/tabel-konversi-kbli-2020-kbli-2025.html",
+    "https://www.bps.go.id/en/publication/2026/04/22/909d503355d2b7664e43dea8/tabel-konversi-kbli-2020-kbli-2025.html",
+)
+
+LOG = common.setup_logger("vault_fetch_bps")
+
+
+def instructions() -> str:
+    lines = [
+        "BPS Tabel Konversi KBLI 2020-2025 is behind Cloudflare Turnstile —",
+        "no headless fetcher is built or supported for it here (a silent",
+        "failure there would itself become a false ABSENT/fetched signal).",
+        "Fetch by hand (browser-assisted or operator download):",
+        "",
+    ]
+    lines += [f"  - {u}" for u in OFFICIAL_URLS]
+    lines += [
+        "",
+        "Then register the downloaded file into the vault:",
+        "  python vault_fetch_bps.py --register <downloaded.pdf> --source-url <one of the URLs above>",
+    ]
+    return "\n".join(lines)
+
+
+def validate_source_url(url: str) -> bool:
+    """No silent mirrors (P4): only the two official BPS URLs are accepted
+    as vault provenance — a third-party mirror, even a byte-faithful copy,
+    is refused. Enforced here, not just documented in the docstring."""
+    return url in OFFICIAL_URLS
+
+
+def build_bps_record(dest: Path, vault_root: Path, source_url: str, data: bytes, fetched_at: str) -> dict:
+    """Pure record-shape builder — no I/O — so the provenance shape is
+    directly unit-testable without touching the filesystem."""
+    return {
+        "filename": dest.name,
+        "url": source_url,
+        "source_url": source_url,
+        "bytes": len(data),
+        "sha256": common.sha256_bytes(data),
+        "fetched_at": fetched_at,
+        "fetched_via": "browser-manual",
+        "http_status": 200,
+        "rel_path": dest.relative_to(vault_root).as_posix(),
+    }
+
+
+def register(vault_root: Path, src: Path, source_url: str, *, fetched_at: str | None = None) -> dict:
+    if not validate_source_url(source_url):
+        raise ValueError(
+            f"refusing to register: {source_url!r} is not one of the two official BPS URLs "
+            f"(no silent mirrors) -- allowed: {OFFICIAL_URLS}"
+        )
+    if not src.exists() or not src.is_file():
+        raise FileNotFoundError(f"--register target not found: {src}")
+
+    data = src.read_bytes()
+    dest = vault_root / "bps" / common.sanitize_filename(src.name)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dest)
+
+    rec = build_bps_record(dest, vault_root, source_url, data, fetched_at or common.now_iso())
+    common.append_jsonl(vault_root / "bps" / "fetch-log.jsonl", rec)
+    LOG.info("registered %s -> %s (sha256=%s)", src, dest, rec["sha256"][:12])
+    return rec
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--vault-root", type=Path, default=common.DEFAULT_VAULT_ROOT)
+    ap.add_argument("--register", type=Path, default=None, help="path to a manually-downloaded BPS PDF")
+    ap.add_argument("--source-url", type=str, default=None, help="which of the two official URLs it came from")
+    args = ap.parse_args(argv)
+
+    if args.register is None:
+        print(instructions())
+        return 0
+
+    if not args.source_url:
+        LOG.error("--register requires --source-url (one of the two official BPS URLs)")
+        return 2
+
+    try:
+        register(args.vault_root.expanduser(), args.register, args.source_url)
+    except (ValueError, FileNotFoundError) as exc:
+        LOG.error(str(exc))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kbli_filiera/vault_fetch_bps.py
+++ b/scripts/kbli_filiera/vault_fetch_bps.py
@@ -41,7 +41,11 @@ except ImportError:  # pragma: no cover
 
 OFFICIAL_URLS: tuple[str, ...] = (
     "https://www.bps.go.id/id/publication/2026/04/22/909d503355d2b7664e43dea8/tabel-konversi-kbli-2020-kbli-2025.html",
-    "https://www.bps.go.id/en/publication/2026/04/22/909d503355d2b7664e43dea8/tabel-konversi-kbli-2020-kbli-2025.html",
+    # NOTE: the EN slug has a TRIPLE dash ("2020---kbli"), not a typo — live-probed
+    # 2026-07-16 (vault-scout). A single-dash lookalike is a plausible fetch typo
+    # AND a plausible phishing-style lookalike; validate_source_url refuses it
+    # (pinned in tests/test_vault_fetch_bps.py).
+    "https://www.bps.go.id/en/publication/2026/04/22/909d503355d2b7664e43dea8/tabel-konversi-kbli-2020---kbli-2025.html",
 )
 
 LOG = common.setup_logger("vault_fetch_bps")

--- a/scripts/kbli_filiera/vault_fetch_oss.py
+++ b/scripts/kbli_filiera/vault_fetch_oss.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""vault_fetch_oss.py — Batch-0 vault compiler: full OSS RBA re-snapshot.
+
+For every 5-digit KBLI-2025 code in the code->uuid ground-truth map
+(data/source_documents/KBLI_2025_OSS_GROUND_TRUTH.json, 1,559 codes),
+fetches detail + ruang-lingkup + relasi + umku from gw.oss.go.id and writes
+each into <vault-root>/oss/<code>/{detail,ruang_lingkup,relasi,umku}.json
+(raw response bytes — this IS the L0 raw-evidence vault, never reformatted).
+
+A 404 on ruang-lingkup/relasi/umku is a LEGIT no-scope signal (P3,
+research/operations/2026-07-16-kbli-filiera-methodology.md) — recorded in
+<vault-root>/oss/absences.jsonl as {"status": 404, "recorded_as": "absent",
+...}, NEVER as an empty file pretending to be data. `vault_common.http_get`
+already refuses to retry a 404 (no retry-storm on a single probe); this
+compiler does not itself cache/skip a previously-recorded absence across
+runs — corroboration-over-time (>=3 attempts over >=72h, the methodology's
+D0 discipline) is a later compiler's job, not batch-0's "full re-snapshot".
+
+Auth: OSS_RBA_USER_KEY env var (static public app credential — never
+hardcoded, fail-visible if unset). TRAP: urllib honors the system proxy by
+default; vault_common.http_get already bypasses it (ProxyHandler({})).
+
+Idempotent resume (data records only — see docstring above re: absences):
+an already-recorded 200 is verified on disk before being skipped.
+
+Usage:
+    OSS_RBA_USER_KEY=... python scripts/kbli_filiera/vault_fetch_oss.py \\
+        [--vault-root PATH] [--ground-truth PATH] [--only 47111,68112]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+try:
+    from kbli_filiera import vault_common as common
+except ImportError:  # pragma: no cover
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from kbli_filiera import vault_common as common
+
+BASE = "https://gw.oss.go.id/v2/portal/kbli/"
+# Path segments appended to BASE before the uuid, per kbli-navigator SKILL.md §3.
+ENDPOINT_PREFIX = {
+    "detail": "",
+    "ruang_lingkup": "ruang-lingkup/",
+    "relasi": "relasi/",
+    "umku": "umku/",
+}
+RATE_S = 1.0 / 3.0  # ~3 req/s max
+PROGRESS_EVERY = 50
+
+USER_KEY = os.environ.get("OSS_RBA_USER_KEY", "")
+LOG = common.setup_logger("vault_fetch_oss")
+
+
+def endpoint_url(endpoint: str, uuid: str) -> str:
+    return f"{BASE}{ENDPOINT_PREFIX[endpoint]}{uuid}"
+
+
+def load_code_uuid_map(ground_truth_path: Path) -> list[tuple[str, str]]:
+    data = json.loads(ground_truth_path.read_text(encoding="utf-8"))
+    return [(str(x["kode"]), x["uuid"]) for x in data["data"] if x.get("digits") == 5]
+
+
+def build_absence_record(code: str, endpoint: str, url: str, uuid: str, status: int, fetched_at: str) -> dict:
+    """The exact recorded shape for a corroborated-by-a-single-probe
+    absence — {"status": 404, "recorded_as": "absent", ...} — pure, no I/O,
+    directly unit-testable."""
+    return {
+        "code": code,
+        "endpoint": endpoint,
+        "url": url,
+        "uuid": uuid,
+        "status": status,
+        "recorded_as": "absent",
+        "fetched_at": fetched_at,
+    }
+
+
+def data_path(vault_root: Path, code: str, endpoint: str) -> Path:
+    return vault_root / "oss" / code / f"{endpoint}.json"
+
+
+def fetch_log_path(vault_root: Path) -> Path:
+    return vault_root / "oss" / "fetch-log.jsonl"
+
+
+def absences_path(vault_root: Path) -> Path:
+    return vault_root / "oss" / "absences.jsonl"
+
+
+def load_latest(vault_root: Path) -> dict[tuple[str, str], dict]:
+    latest: dict[tuple[str, str], dict] = {}
+    for rec in common.read_jsonl(fetch_log_path(vault_root)):
+        key = (rec.get("code"), rec.get("endpoint"))
+        latest[key] = rec
+    return latest
+
+
+def fetch_endpoint(vault_root: Path, code: str, uuid: str, endpoint: str, prior: dict | None) -> dict | None:
+    """Returns {"_kind": "data"|"absence", ...record} to be appended to the
+    matching log, or None on a verified-on-disk skip (no log growth)."""
+    target = data_path(vault_root, code, endpoint)
+
+    if prior is not None and common.decide_resume(prior, target) == "skip":
+        return None
+
+    url = endpoint_url(endpoint, uuid)
+    result = common.http_get(url, headers={"user_key": USER_KEY, "accept": "application/json"})
+    fetched_at = common.now_iso()
+
+    if result.status == 404:
+        LOG.info("code=%s endpoint=%s ABSENT (404)", code, endpoint)
+        return {"_kind": "absence", **build_absence_record(code, endpoint, url, uuid, 404, fetched_at)}
+
+    if result.status != 200:
+        LOG.error("code=%s endpoint=%s FETCH FAILED status=%s error=%s", code, endpoint, result.status, result.error)
+        return {
+            "_kind": "data",
+            "code": code,
+            "endpoint": endpoint,
+            "url": url,
+            "uuid": uuid,
+            "bytes": 0,
+            "sha256": None,
+            "fetched_at": fetched_at,
+            "http_status": result.status,
+            "rel_path": None,
+            "error": result.error or f"HTTP {result.status}",
+        }
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(result.body)
+    return {
+        "_kind": "data",
+        "code": code,
+        "endpoint": endpoint,
+        "url": url,
+        "uuid": uuid,
+        "bytes": len(result.body),
+        "sha256": common.sha256_bytes(result.body),
+        "fetched_at": fetched_at,
+        "http_status": 200,
+        "rel_path": target.relative_to(vault_root).as_posix(),
+    }
+
+
+def run(vault_root: Path, ground_truth_path: Path, *, only: set[str] | None = None, rate_s: float = RATE_S) -> int:
+    codes = load_code_uuid_map(ground_truth_path)
+    if only:
+        codes = [(c, u) for c, u in codes if c in only]
+    latest = load_latest(vault_root)
+    log_path = fetch_log_path(vault_root)
+    abs_path = absences_path(vault_root)
+
+    total = len(codes)
+    failures = 0
+    for i, (code, uuid) in enumerate(codes, start=1):
+        for endpoint in ENDPOINT_PREFIX:
+            prior = latest.get((code, endpoint))
+            rec = fetch_endpoint(vault_root, code, uuid, endpoint, prior)
+            if rec is None:
+                continue
+            kind = rec.pop("_kind")
+            if kind == "absence":
+                common.append_jsonl(abs_path, rec)
+            else:
+                common.append_jsonl(log_path, rec)
+                if rec.get("http_status") == 200:
+                    latest[(code, endpoint)] = rec
+                else:
+                    failures += 1
+            time.sleep(rate_s)
+        if i % PROGRESS_EVERY == 0 or i == total:
+            LOG.info("%s of %s codes processed (failures=%s)", i, total, failures)
+
+    if failures:
+        LOG.error("SWEEP COMPLETE with %s endpoint failures across %s codes", failures, total)
+        return 1
+    LOG.info("SWEEP COMPLETE %s codes ok", total)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--vault-root", type=Path, default=common.DEFAULT_VAULT_ROOT)
+    ap.add_argument(
+        "--ground-truth", type=Path,
+        default=Path("data/source_documents/KBLI_2025_OSS_GROUND_TRUTH.json"),
+    )
+    ap.add_argument("--only", type=str, default="", help="comma-separated 5-digit codes for a partial run")
+    args = ap.parse_args(argv)
+
+    if not USER_KEY:
+        LOG.error("OSS_RBA_USER_KEY not set — see kbli-navigator SKILL.md §3 (public app credential)")
+        return 2
+    if not args.ground_truth.exists():
+        LOG.error("ground-truth map not found: %s (pass --ground-truth explicitly)", args.ground_truth)
+        return 2
+
+    only = {c.strip() for c in args.only.split(",") if c.strip()} or None
+    return run(args.vault_root.expanduser(), args.ground_truth, only=only)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kbli_filiera/vault_fetch_pp28.py
+++ b/scripts/kbli_filiera/vault_fetch_pp28.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""vault_fetch_pp28.py — Batch-0 vault compiler: PP 28/2025 lampiran corpus.
+
+Downloads all 21 BPK-hosted lampiran PDFs (peraturan.bpk.go.id/Download/<id>,
+ids 394930..394950 — all HTTP 200, content-type application/octet-stream,
+real filename in Content-Disposition; live-probed 2026-07-16) into
+<vault-root>/pp28/<id>__<filename>.
+
+GROUNDED FACT (2026-07-16): one lampiran LETTER can span MULTIPLE
+sequential ids — e.g. id 394941 is
+"2.6g Lampiran I.F ... (I.F.4501-5248).pdf". This script never assumes
+1 id = 1 letter: it structurally parses each downloaded Content-Disposition
+filename (vault_common.parse_pp28_lampiran_filename) and records
+{fragment, letter, range} alongside every fetch-log entry, so the
+id->lampiran map is the fetch-log itself — no separate map file to drift.
+
+Idempotent resume: an id already recorded with http_status==200 is
+verified on disk (size + re-hashed sha256, vault_common.decide_resume)
+before being skipped — a stale/corrupted local copy is always refetched,
+never trusted from the log alone.
+
+Fail-visible (superscar #2, "esiste != armato"): the full 21-id sweep
+always runs to completion; only at the end does a non-empty failure list
+cause a non-zero exit, so one bad id never hides the rest of the report.
+
+Usage:
+    python scripts/kbli_filiera/vault_fetch_pp28.py [--vault-root PATH] [--sleep-s N]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+try:
+    from kbli_filiera import vault_common as common
+except ImportError:  # pragma: no cover — allow `python vault_fetch_pp28.py` from this dir
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from kbli_filiera import vault_common as common
+
+BASE_URL = "https://peraturan.bpk.go.id/Download/"
+# Verified live 2026-07-16 (kbli-navigator SKILL.md §3): 21 files, all HTTP 200.
+LAMPIRAN_IDS: tuple[int, ...] = tuple(range(394930, 394951))
+
+LOG = common.setup_logger("vault_fetch_pp28")
+
+
+def fetch_log_path(vault_root: Path) -> Path:
+    return vault_root / "pp28" / "fetch-log.jsonl"
+
+
+def load_latest_by_id(vault_root: Path) -> dict[int, dict]:
+    latest: dict[int, dict] = {}
+    for rec in common.read_jsonl(fetch_log_path(vault_root)):
+        rid = rec.get("id")
+        if rid is not None:
+            latest[rid] = rec
+    return latest
+
+
+def target_path(vault_root: Path, lampiran_id: int, filename: str) -> Path:
+    safe = common.sanitize_filename(filename)
+    return vault_root / "pp28" / f"{lampiran_id}__{safe}"
+
+
+def fetch_one(vault_root: Path, lampiran_id: int, prior: dict | None, *, sleep_s: float = 2.0) -> dict:
+    """Fetch (or verify-and-skip) one lampiran id. Returns the record that
+    should be appended to the fetch-log, or the untouched `prior` record
+    itself on a verified skip (callers use `is` identity to decide whether
+    the log actually needs a new line — see run())."""
+    if prior is not None:
+        candidate_target = target_path(vault_root, lampiran_id, prior.get("filename") or "")
+        if common.decide_resume(prior, candidate_target) == "skip":
+            LOG.info("id=%s SKIP (verified on disk) -> %s", lampiran_id, candidate_target.name)
+            return prior
+
+    url = BASE_URL + str(lampiran_id)
+    result = common.http_get(url, headers={"Accept": "application/octet-stream"})
+    fetched_at = common.now_iso()
+
+    if result.status != 200:
+        LOG.error("id=%s FETCH FAILED status=%s error=%s", lampiran_id, result.status, result.error)
+        return {
+            "id": lampiran_id,
+            "url": url,
+            "filename": None,
+            "bytes": 0,
+            "sha256": None,
+            "fetched_at": fetched_at,
+            "http_status": result.status,
+            "rel_path": None,
+            "error": result.error or f"HTTP {result.status}",
+        }
+
+    filename = common.parse_content_disposition_filename(
+        result.headers.get("Content-Disposition")
+    ) or f"{lampiran_id}.pdf"
+    target = target_path(vault_root, lampiran_id, filename)
+
+    content_length = result.headers.get("Content-Length")
+    if content_length is not None and str(content_length).isdigit() and int(content_length) != len(result.body):
+        LOG.error(
+            "id=%s SIZE MISMATCH content-length=%s downloaded=%s",
+            lampiran_id, content_length, len(result.body),
+        )
+        return {
+            "id": lampiran_id,
+            "url": url,
+            "filename": filename,
+            "bytes": len(result.body),
+            "sha256": common.sha256_bytes(result.body),
+            "fetched_at": fetched_at,
+            "http_status": result.status,
+            "rel_path": None,
+            "error": f"size mismatch: content-length={content_length} downloaded={len(result.body)}",
+        }
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(result.body)
+    rec = {
+        "id": lampiran_id,
+        "url": url,
+        "filename": filename,
+        "bytes": len(result.body),
+        "sha256": common.sha256_bytes(result.body),
+        "fetched_at": fetched_at,
+        "http_status": result.status,
+        "rel_path": target.relative_to(vault_root).as_posix(),
+        **common.parse_pp28_lampiran_filename(filename),
+    }
+    LOG.info("id=%s OK bytes=%s sha256=%s -> %s", lampiran_id, rec["bytes"], rec["sha256"][:12], rec["rel_path"])
+    time.sleep(sleep_s)  # polite: 1 request at a time
+    return rec
+
+
+def run(vault_root: Path, ids: tuple[int, ...] = LAMPIRAN_IDS, *, sleep_s: float = 2.0) -> int:
+    latest = load_latest_by_id(vault_root)
+    log_path = fetch_log_path(vault_root)
+    failures: list[int] = []
+
+    for lampiran_id in ids:
+        prior = latest.get(lampiran_id)
+        rec = fetch_one(vault_root, lampiran_id, prior, sleep_s=sleep_s)
+        if rec is not prior:
+            common.append_jsonl(log_path, rec)
+        if rec.get("error") or rec.get("http_status") != 200:
+            failures.append(lampiran_id)
+
+    if failures:
+        LOG.error("SWEEP COMPLETE with %s of %s failures: %s", len(failures), len(ids), failures)
+        return 1
+    LOG.info("SWEEP COMPLETE %s of %s ok", len(ids), len(ids))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--vault-root", type=Path, default=common.DEFAULT_VAULT_ROOT)
+    ap.add_argument("--sleep-s", type=float, default=2.0, help="polite delay between requests")
+    args = ap.parse_args(argv)
+    return run(args.vault_root.expanduser(), sleep_s=args.sleep_s)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kbli_filiera/vault_manifest.py
+++ b/scripts/kbli_filiera/vault_manifest.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""vault_manifest.py — Batch-0 vault compiler: deterministic sha256 manifest.
+
+Walks <vault-root> and emits a sorted, deterministic JSON manifest —
+[{rel_path, sha256, bytes, source_url?, fetched_at?}, ...] — merging
+per-file provenance from every `fetch-log.jsonl` found under the vault
+(each fetcher writes its own `rel_path` field, so the merge is an exact
+key match, no path reconstruction/guessing).
+
+This is THE compiler that will eventually write data/kbli-filiera/manifest/
+in the repo (guard-protected, infra/claude-hooks/data-plane-registry.json)
+— for now it only supports `--out <any path>`; this PR does not commit a
+generated manifest (per the batch-0 mandate).
+
+Determinism (G16-adjacent, "reproducibility gate"): entries are sorted by
+rel_path and every dict is built with a fixed key order, so the SAME vault
+tree always produces byte-identical output regardless of filesystem walk
+order.
+
+Absences never enter the manifest — they don't produce a file (P3/no
+"empty file pretending to be data"), so there is nothing on disk to hash.
+
+Usage:
+    python scripts/kbli_filiera/vault_manifest.py --vault-root PATH [--out PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from kbli_filiera import vault_common as common
+except ImportError:  # pragma: no cover
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from kbli_filiera import vault_common as common
+
+LOG_FILE_NAMES = {"fetch-log.jsonl", "absences.jsonl"}
+LOG = common.setup_logger("vault_manifest")
+
+
+def collect_provenance(vault_root: Path) -> dict[str, dict]:
+    """rel_path -> {source_url, fetched_at}, built from every
+    fetch-log.jsonl under the vault. Only clean 200 records with a
+    `rel_path` contribute — an error record has no file on disk to merge
+    onto."""
+    provenance: dict[str, dict] = {}
+    for log_path in sorted(vault_root.rglob("fetch-log.jsonl")):
+        for rec in common.read_jsonl(log_path):
+            rel_path = rec.get("rel_path")
+            if not rel_path or rec.get("http_status") != 200:
+                continue
+            provenance[rel_path] = {
+                "source_url": rec.get("url"),
+                "fetched_at": rec.get("fetched_at"),
+            }
+    return provenance
+
+
+def build_manifest(vault_root: Path) -> list[dict]:
+    provenance = collect_provenance(vault_root)
+    entries: list[dict] = []
+    for path in vault_root.rglob("*"):
+        if not path.is_file() or path.name in LOG_FILE_NAMES:
+            continue
+        rel_path = path.relative_to(vault_root).as_posix()
+        entry: dict = {
+            "rel_path": rel_path,
+            "sha256": common.sha256_file(path),
+            "bytes": path.stat().st_size,
+        }
+        prov = provenance.get(rel_path)
+        if prov:
+            entry["source_url"] = prov.get("source_url")
+            entry["fetched_at"] = prov.get("fetched_at")
+        entries.append(entry)
+    entries.sort(key=lambda e: e["rel_path"])
+    return entries
+
+
+def render_manifest(entries: list[dict]) -> str:
+    return json.dumps(entries, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--vault-root", type=Path, default=common.DEFAULT_VAULT_ROOT)
+    ap.add_argument("--out", type=Path, default=None, help="write manifest here instead of stdout")
+    args = ap.parse_args(argv)
+
+    vault_root = args.vault_root.expanduser()
+    if not vault_root.exists():
+        LOG.error("vault root does not exist: %s", vault_root)
+        return 2
+
+    entries = build_manifest(vault_root)
+    payload = render_manifest(entries)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(payload, encoding="utf-8")
+        LOG.info("wrote %s entries to %s", len(entries), args.out)
+    else:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kbli_filiera/vault_mirror_tigris.sh
+++ b/scripts/kbli_filiera/vault_mirror_tigris.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# vault_mirror_tigris.sh — durability mirror for the GARUDA-FILIERA
+# raw-evidence vault onto Tigris (S3-compatible), per
+# research/operations/2026-07-16-kbli-garuda-filiera-workflow.md §7:
+#   "Vault: Mini is primary, Tigris versioned mirror is the durability
+#    layer, the git manifest is the integrity layer."
+#
+# Credential pattern follows scripts/fly-pg-backup.sh: source
+# ~/.nuzantara-secrets.env for AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+# (Tigris creds) — never cat/echo/embed the secret itself (cicatrix
+# superscar #4, "secret in the clear").
+#
+# Usage:
+#   scripts/kbli_filiera/vault_mirror_tigris.sh [<vault-root>]
+#   VAULT_ROOT=/custom/path scripts/kbli_filiera/vault_mirror_tigris.sh
+set -euo pipefail
+
+VAULT_ROOT="${1:-${VAULT_ROOT:-$HOME/nuzantara-vault}}"
+TIGRIS_ENDPOINT="https://fly.storage.tigris.dev"
+TIGRIS_BUCKET="nuzantara-backups"
+TIGRIS_PREFIX="kbli-vault"
+
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] && [ -f "$HOME/.nuzantara-secrets.env" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$HOME/.nuzantara-secrets.env"
+  set +a
+fi
+
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+  echo "vault_mirror_tigris.sh: no Tigris credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)." >&2
+  echo "  Expected in ~/.nuzantara-secrets.env (never printed/committed — scar #4)." >&2
+  exit 2
+fi
+
+if [ ! -d "$VAULT_ROOT" ]; then
+  echo "vault_mirror_tigris.sh: vault root not found: $VAULT_ROOT" >&2
+  exit 2
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "vault_mirror_tigris.sh: aws CLI not found on PATH." >&2
+  exit 2
+fi
+
+echo "vault_mirror_tigris.sh: syncing $VAULT_ROOT -> s3://$TIGRIS_BUCKET/$TIGRIS_PREFIX/ ..."
+aws s3 sync "$VAULT_ROOT" "s3://$TIGRIS_BUCKET/$TIGRIS_PREFIX/" \
+  --endpoint-url "$TIGRIS_ENDPOINT" \
+  --only-show-errors
+
+echo "vault_mirror_tigris.sh: sync complete."


### PR DESCRIPTION
GARUDA-FILIERA Batch 0 (L0 raw-evidence vault) compilers under `scripts/kbli_filiera/` — the ONLY sanctioned writers of the guard-protected data plane (#2550):

- `vault_fetch_pp28.py` — 21 BPK lampiran PDFs (ids 394930-394950), idempotent resume (size+sha re-verified on skip), fail-visible full sweep, id→lampiran map built from Content-Disposition parsing (grounded fact: one lampiran letter spans multiple ids, e.g. "2.6g Lampiran I.F (I.F.4501-5248)")
- `vault_fetch_oss.py` — full OSS RBA re-snapshot (1,559 codes × detail/ruang-lingkup/relasi/umku), 404 recorded as explicit absence (P3), ~3 req/s, resume, `--only` partial runs, key from env only
- `vault_manifest.py` — deterministic sorted sha256 manifest merging fetch-log provenance (same tree → byte-identical output)
- `vault_mirror_tigris.sh` — `aws s3 sync` to `s3://nuzantara-backups/kbli-vault/` (fly-pg-backup.sh credential pattern, scar #4 clean)
- `vault_fetch_bps.py` — registrar stub for the Turnstile-blocked BPS conversion table: browser/manual download + `--register` with sha256 provenance; ONLY the two live-probed official BPS URLs accepted (no silent mirrors, enforced not documented)
- 66 unit tests, no network (fixtures/mocks): CD parsing incl. fragment case, resume decisions, absence shape, manifest determinism, official-URL pinning (incl. refusing the single-dash EN lookalike)

Grounding: live probes 2026-07-16 (vault-scout) — PP28 ids all 200; OSS count 2422 unchanged; ground-truth schema verified against the real file (1,559 five-digit codes); BPS behind Cloudflare Turnstile (no headless fetcher by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)