### PR TITLE
fix(wr2): archive-aware queue merge + dirless false-positive repair (red-teamed)

### DIFF
--- a/infra/launchagents/wrappers/wr2-queue-pull.sh
+++ b/infra/launchagents/wrappers/wr2-queue-pull.sh
@@ -66,59 +66,92 @@ esac
 MERGE_PY="$HOME/nuzantara/scripts/wr2_queue_pull_merge.py"
 
 while true; do
-  for f in human-review-queue.json queue-archive.json; do
-    # PID-suffixed tmp: a WR2_PULL_CHECKSUM one-shot may run while the daemon
-    # loop is live — a shared deterministic tmp path would interleave writes.
-    tmp="$DEST_DIR/.$f.pull.tmp.$$"
-    if ssh -o ConnectTimeout=10 -o BatchMode=yes pro "cat '$SRC_DIR/$f'" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
-      # valida JSON prima di sostituire (mai clobberare con spazzatura)
-      if python3 -c "import json,sys; json.load(open('$tmp'))" 2>/dev/null; then
-        if [ "$f" = "human-review-queue.json" ] && [ -f "$MERGE_PY" ] && [ -f "$DEST_DIR/$f" ]; then
-          # merge instead of clobber: local publish transitions survive the pull
+  # queue-archive.json pulled FIRST (2026-07-17, archive-blind resurrect fix):
+  # the human-review-queue.json merge below needs THIS SAME iteration's fresh
+  # archive to tell "archived on Pro" apart from "genuinely new local entry" —
+  # a stale on-disk archive from last tick would resurrect an archived entry
+  # for up to one more interval every time. archive_tmp is kept alive (not
+  # rm'd) until the queue merge below has consumed it.
+  archive_tmp=""
+  archive_f="queue-archive.json"
+  tmp="$DEST_DIR/.$archive_f.pull.tmp.$$"
+  if ssh -o ConnectTimeout=10 -o BatchMode=yes pro "cat '$SRC_DIR/$archive_f'" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+    if python3 -c "import json,sys; json.load(open('$tmp'))" 2>/dev/null; then
+      archive_tmp="$tmp"
+      if ! cmp -s "$tmp" "$DEST_DIR/$archive_f" 2>/dev/null; then
+        cp "$tmp" "$DEST_DIR/$archive_f"
+        echo "[$(ts)] updated $archive_f" >> "$LOG"
+      fi
+    else
+      echo "[$(ts)] WARN $archive_f pulled but invalid JSON, kept old" >> "$LOG"
+      rm -f "$tmp"
+    fi
+  else
+    echo "[$(ts)] WARN pull $archive_f failed (Pro unreachable?)" >> "$LOG"
+    rm -f "$tmp"
+  fi
+
+  f="human-review-queue.json"
+  # PID-suffixed tmp: a WR2_PULL_CHECKSUM one-shot may run while the daemon
+  # loop is live — a shared deterministic tmp path would interleave writes.
+  tmp="$DEST_DIR/.$f.pull.tmp.$$"
+  if ssh -o ConnectTimeout=10 -o BatchMode=yes pro "cat '$SRC_DIR/$f'" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+    # valida JSON prima di sostituire (mai clobberare con spazzatura)
+    if python3 -c "import json,sys; json.load(open('$tmp'))" 2>/dev/null; then
+      if [ -f "$MERGE_PY" ] && [ -f "$DEST_DIR/$f" ]; then
+        # merge instead of clobber: local publish transitions survive the pull.
+        # NOTE: no bash arrays here — macOS ships bash 3.2, where an empty
+        # array expanded as "${arr[@]}" under `set -u` throws "unbound
+        # variable" (verified live), which would crash this loop every tick
+        # the archive pull fails/is skipped.
+        if [ -n "$archive_tmp" ]; then
+          report=$(python3 "$MERGE_PY" --remote "$tmp" --local "$DEST_DIR/$f" --out "$tmp.merged" --remote-archive "$archive_tmp" 2>>"$LOG")
+        else
           report=$(python3 "$MERGE_PY" --remote "$tmp" --local "$DEST_DIR/$f" --out "$tmp.merged" 2>>"$LOG")
-          if [ -s "$tmp.merged" ]; then
-            if ! cmp -s "$tmp.merged" "$DEST_DIR/$f" 2>/dev/null; then
-              mv "$tmp.merged" "$DEST_DIR/$f"
-              echo "[$(ts)] merged $f ($report)" >> "$LOG"
-            else
-              rm -f "$tmp.merged"
-            fi
-            rm -f "$tmp"
-            # push protected publish transitions back to Pro (SSOT) via the
-            # canonical writer. ref/url are shell-safe by construction (strict
-            # regexes in the merge script); the writer re-validates on Pro.
-            echo "$report" | python3 -c 'import json,sys
+        fi
+        if [ -s "$tmp.merged" ]; then
+          if ! cmp -s "$tmp.merged" "$DEST_DIR/$f" 2>/dev/null; then
+            mv "$tmp.merged" "$DEST_DIR/$f"
+            echo "[$(ts)] merged $f ($report)" >> "$LOG"
+          else
+            rm -f "$tmp.merged"
+          fi
+          rm -f "$tmp"
+          # push protected publish transitions back to Pro (SSOT) via the
+          # canonical writer. ref/url are shell-safe by construction (strict
+          # regexes in the merge script); the writer re-validates on Pro.
+          echo "$report" | python3 -c 'import json,sys
 try: rep=json.load(sys.stdin)
 except Exception: rep={}
 for e in rep.get("push_back", []): print(e["ref_code"], e["ig_url"])' | \
-            while read -r ref url; do
-              if ssh -o ConnectTimeout=10 -o BatchMode=yes pro \
-                   "cd ~/nuzantara && python3 scripts/wr2_queue_writer.py mark-published '$ref' '$url'" >>"$LOG" 2>&1; then
-                echo "[$(ts)] pushed back $ref -> published on Pro" >> "$LOG"
-              else
-                echo "[$(ts)] WARN push-back $ref failed (state not publishable on Pro yet?)" >> "$LOG"
-              fi
-            done
-          else
-            # merge failed → keep old local file, log, fall back to nothing
-            echo "[$(ts)] WARN merge of $f produced no output, kept old" >> "$LOG"
-            rm -f "$tmp" "$tmp.merged"
-          fi
-        elif ! cmp -s "$tmp" "$DEST_DIR/$f" 2>/dev/null; then
-          mv "$tmp" "$DEST_DIR/$f"
-          echo "[$(ts)] updated $f" >> "$LOG"
+          while read -r ref url; do
+            if ssh -o ConnectTimeout=10 -o BatchMode=yes pro \
+                 "cd ~/nuzantara && python3 scripts/wr2_queue_writer.py mark-published '$ref' '$url'" >>"$LOG" 2>&1; then
+              echo "[$(ts)] pushed back $ref -> published on Pro" >> "$LOG"
+            else
+              echo "[$(ts)] WARN push-back $ref failed (state not publishable on Pro yet?)" >> "$LOG"
+            fi
+          done
         else
-          rm -f "$tmp"   # no change
+          # merge failed → keep old local file, log, fall back to nothing
+          echo "[$(ts)] WARN merge of $f produced no output, kept old" >> "$LOG"
+          rm -f "$tmp" "$tmp.merged"
         fi
+      elif ! cmp -s "$tmp" "$DEST_DIR/$f" 2>/dev/null; then
+        mv "$tmp" "$DEST_DIR/$f"
+        echo "[$(ts)] updated $f" >> "$LOG"
       else
-        echo "[$(ts)] WARN $f pulled but invalid JSON, kept old" >> "$LOG"
-        rm -f "$tmp"
+        rm -f "$tmp"   # no change
       fi
     else
-      echo "[$(ts)] WARN pull $f failed (Pro unreachable?)" >> "$LOG"
+      echo "[$(ts)] WARN $f pulled but invalid JSON, kept old" >> "$LOG"
       rm -f "$tmp"
     fi
-  done
+  else
+    echo "[$(ts)] WARN pull $f failed (Pro unreachable?)" >> "$LOG"
+    rm -f "$tmp"
+  fi
+  rm -f "$archive_tmp"
 
   # Pull the latest REAL ig-insights amendment (the Insights view reads it). Exclude the
   # "insufficient-data" stubs. Take the newest by filename date.

--- a/infra/launchagents/wrappers/wr2-queue-pull.sh
+++ b/infra/launchagents/wrappers/wr2-queue-pull.sh
@@ -79,8 +79,16 @@ while true; do
     if python3 -c "import json,sys; json.load(open('$tmp'))" 2>/dev/null; then
       archive_tmp="$tmp"
       if ! cmp -s "$tmp" "$DEST_DIR/$archive_f" 2>/dev/null; then
-        cp "$tmp" "$DEST_DIR/$archive_f"
-        echo "[$(ts)] updated $archive_f" >> "$LOG"
+        # atomic swap (Codex red-team, 2026-07-17): a plain `cp` truncated by
+        # a concurrent read or interrupted mid-write would still log
+        # "updated" here and lose the good temp at end of tick — cp into a
+        # sibling tmp then rename so the mirror is never observed partial.
+        if cp "$tmp" "$DEST_DIR/$archive_f.tmp.$$" && mv "$DEST_DIR/$archive_f.tmp.$$" "$DEST_DIR/$archive_f"; then
+          echo "[$(ts)] updated $archive_f" >> "$LOG"
+        else
+          echo "[$(ts)] WARN failed to atomically update $archive_f mirror, kept old" >> "$LOG"
+          rm -f "$DEST_DIR/$archive_f.tmp.$$"
+        fi
       fi
     else
       echo "[$(ts)] WARN $archive_f pulled but invalid JSON, kept old" >> "$LOG"
@@ -104,12 +112,28 @@ while true; do
         # array expanded as "${arr[@]}" under `set -u` throws "unbound
         # variable" (verified live), which would crash this loop every tick
         # the archive pull fails/is skipped.
+        #
+        # rm -f "$tmp.merged" FIRST (Codex red-team, 2026-07-17): the daemon
+        # keeps the same PID (and thus the same $tmp path) across every tick
+        # of this loop — a merge that failed mid-write on a PRIOR tick can
+        # leave a stale non-empty .merged file that a LATER failed merge
+        # (one that crashes before writing --out at all) would otherwise
+        # re-install via the `[ -s "$tmp.merged" ]` check below, believing
+        # it to be this tick's fresh output.
+        rm -f "$tmp.merged"
         if [ -n "$archive_tmp" ]; then
           report=$(python3 "$MERGE_PY" --remote "$tmp" --local "$DEST_DIR/$f" --out "$tmp.merged" --remote-archive "$archive_tmp" 2>>"$LOG")
         else
           report=$(python3 "$MERGE_PY" --remote "$tmp" --local "$DEST_DIR/$f" --out "$tmp.merged" 2>>"$LOG")
         fi
-        if [ -s "$tmp.merged" ]; then
+        merge_rc=$?
+        # gate on BOTH exit code 0 AND re-parseable JSON (Codex red-team,
+        # 2026-07-17): ENOSPC mid-write can leave a partial-but-non-empty
+        # JSON file that `[ -s ... ]` alone would accept — the next tick
+        # would then treat the corrupt local queue as [] and wipe every
+        # local-only entry.
+        if [ "$merge_rc" -eq 0 ] && [ -s "$tmp.merged" ] \
+             && python3 -c "import json,sys; json.load(open('$tmp.merged'))" 2>/dev/null; then
           if ! cmp -s "$tmp.merged" "$DEST_DIR/$f" 2>/dev/null; then
             mv "$tmp.merged" "$DEST_DIR/$f"
             echo "[$(ts)] merged $f ($report)" >> "$LOG"
@@ -133,8 +157,9 @@ for e in rep.get("push_back", []): print(e["ref_code"], e["ig_url"])' | \
             fi
           done
         else
-          # merge failed → keep old local file, log, fall back to nothing
-          echo "[$(ts)] WARN merge of $f produced no output, kept old" >> "$LOG"
+          # merge failed (rc) or produced empty/invalid output → keep old
+          # local file, log, wipe both tmps.
+          echo "[$(ts)] WARN merge of $f failed or produced invalid output (rc=$merge_rc), kept old" >> "$LOG"
           rm -f "$tmp" "$tmp.merged"
         fi
       elif ! cmp -s "$tmp" "$DEST_DIR/$f" 2>/dev/null; then

--- a/scripts/tests/test_wr2_completeness_gate.py
+++ b/scripts/tests/test_wr2_completeness_gate.py
@@ -617,6 +617,36 @@ def test_resolve_slides_dir_suffix_match_prefers_newest_dir():
         assert resolved != old_dir / "slides"
 
 
+def test_resolve_slides_dir_suffix_match_rejects_cross_topic_over_match():
+    """GUILT (Codex red-team HIGH #2, 2026-07-17): a bare `*{needle}*` glob
+    over-matches ACROSS topics — needle `visa-myth` also matches dir
+    `2026-07-17-evisa-mythology-bbbb` ("e"+"visa-myth"+"ology", no hyphen
+    boundary), and being newer would make the OLD newest-first sort PREFER
+    the foreign dir. The segment-anchored match must reject it and resolve
+    to the genuine `2026-07-14-visa-myth-aaaa` dir instead, even though the
+    foreign dir is lexicographically later."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        carousel_root = root / "carousel"
+        genuine_dir = carousel_root / "2026-07-14-visa-myth-aaaa"
+        foreign_dir = carousel_root / "2026-07-17-evisa-mythology-bbbb"
+        (genuine_dir / "slides").mkdir(parents=True)
+        (genuine_dir / "slides" / "01.png").write_bytes(b"\x89PNG-genuine")
+        (foreign_dir / "slides").mkdir(parents=True)
+        (foreign_dir / "slides" / "01.png").write_bytes(b"\x89PNG-foreign")
+
+        entry = {
+            "slides_dir": str(root / "gone" / "slides"),
+            "carousel_path": str(root / "gone"),
+            "topic_slug": "visa-myth",
+        }
+        resolved = reconciler._resolve_slides_dir(entry, carousel_root)
+        assert resolved == genuine_dir / "slides"
+        assert resolved != foreign_dir / "slides"
+
+
 def test_backfill_apply_preserves_other_queue_entries(tmp_path):
     """INNOCENCE: entries with no mismatch (including published history) must
     be byte-for-byte preserved by the backfill write."""
@@ -648,15 +678,16 @@ def test_backfill_apply_preserves_other_queue_entries(tmp_path):
 
 def test_repair_guilt_false_incomplete_restored_to_drafted_under_apply(tmp_path):
     """GUILT: a render_incomplete entry whose resolved slides dir (using the
-    FIXED resolution) has real PNGs is restored to drafted, with the correct
-    disk-derived slide_count, under --apply."""
+    FIXED resolution) has real PNGs, AND independent ground truth agrees
+    with disk (expected == disk == 8 via intended_slide_count), is restored
+    to drafted with the correct disk-derived slide_count, under --apply."""
     car_dir = tmp_path / "carousel" / "indonesia-visafree-myth-reality"
     slides_dir = car_dir / "slides"
     _make_pngs(slides_dir, 8)
     qp = tmp_path / "queue" / "human-review-queue.json"
     _write_queue(qp, [{
         "id": "carousel_old", "draft_id": "d-old", "state": reconciler.RENDER_INCOMPLETE_STATE,
-        "slide_count": 8, "carousel_path": str(car_dir),
+        "slide_count": 8, "intended_slide_count": 8, "carousel_path": str(car_dir),
         "state_history": [{"state": reconciler.RENDER_INCOMPLETE_STATE, "at": "t0",
                             "reason": "dirless: slides_dir missing/not a directory"}],
     }])
@@ -664,6 +695,8 @@ def test_repair_guilt_false_incomplete_restored_to_drafted_under_apply(tmp_path)
     assert len(reports) == 1
     assert reports[0]["action"] == "restore_to_drafted"
     assert reports[0]["disk"] == 8
+    assert reports[0]["expected"] == 8
+    assert reports[0]["expected_source"] == "intended_slide_count"
 
     entry = json.loads(qp.read_text())[0]
     assert entry["state"] == "drafted"
@@ -679,11 +712,52 @@ def test_repair_dry_run_never_mutates(tmp_path):
     qp = tmp_path / "queue" / "human-review-queue.json"
     before = [{
         "id": "carousel_old", "draft_id": "d-old", "state": reconciler.RENDER_INCOMPLETE_STATE,
-        "slide_count": 8, "carousel_path": str(car_dir),
+        "slide_count": 8, "intended_slide_count": 8, "carousel_path": str(car_dir),
     }]
     _write_queue(qp, before)
     reports = reconciler.repair_false_incomplete(queue_path=qp, dry_run=True)
     assert len(reports) == 1 and reports[0]["action"] == "restore_to_drafted"
+    assert json.loads(qp.read_text()) == before
+
+
+def test_repair_guilt_genuinely_incomplete_not_restored(tmp_path):
+    """GUILT (Codex red-team HIGH #3, 2026-07-17): a GENUINELY incomplete
+    carousel (disk=8, but slides.json — independent ground truth — says 9)
+    sitting in render_incomplete must NOT be restored to drafted. Restoring
+    it would make a real partial render publish-eligible, defeating the
+    complete-or-nothing gate."""
+    car_dir = tmp_path / "carousel" / "genuinely-incomplete-topic"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    (car_dir / "slides.json").write_text(json.dumps({"slides": [{}] * 9}))
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    before = [{
+        "id": "carousel_incomplete", "draft_id": "d-inc", "state": reconciler.RENDER_INCOMPLETE_STATE,
+        "slide_count": 8, "carousel_path": str(car_dir),
+    }]
+    _write_queue(qp, before)
+    reports = reconciler.repair_false_incomplete(queue_path=qp, dry_run=False)
+    assert reports == []
+    assert json.loads(qp.read_text()) == before
+
+
+def test_repair_guilt_no_ground_truth_not_restored(tmp_path):
+    """GUILT (Codex red-team HIGH #3, 2026-07-17): an entry with real PNGs on
+    disk but NO independent ground truth at all (no intended_slide_count
+    field, no meta.json, no slides.json) must NOT be restored — refusing to
+    guess is the same doctrine as apply_completeness_backfill's
+    unknown_intent."""
+    car_dir = tmp_path / "carousel" / "no-ground-truth-topic"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    before = [{
+        "id": "carousel_noground", "draft_id": "d-noground", "state": reconciler.RENDER_INCOMPLETE_STATE,
+        "slide_count": 8, "carousel_path": str(car_dir),
+    }]
+    _write_queue(qp, before)
+    reports = reconciler.repair_false_incomplete(queue_path=qp, dry_run=False)
+    assert reports == []
     assert json.loads(qp.read_text()) == before
 
 
@@ -733,7 +807,7 @@ def test_repair_exclude_id_hard_excludes_entry(tmp_path):
     qp = tmp_path / "queue" / "human-review-queue.json"
     before = [{
         "id": "carousel_excluded", "draft_id": "d-excl", "state": reconciler.RENDER_INCOMPLETE_STATE,
-        "slide_count": 8, "carousel_path": str(car_dir),
+        "slide_count": 8, "intended_slide_count": 8, "carousel_path": str(car_dir),
     }]
     _write_queue(qp, before)
     reports = reconciler.repair_false_incomplete(
@@ -752,7 +826,7 @@ def test_repair_preserves_other_queue_entries_byte_for_byte(tmp_path):
     _write_queue(qp, [
         published,
         {"id": "carousel_old", "draft_id": "d-old", "state": reconciler.RENDER_INCOMPLETE_STATE,
-         "slide_count": 8, "carousel_path": str(car_dir)},
+         "slide_count": 8, "intended_slide_count": 8, "carousel_path": str(car_dir)},
     ])
     reconciler.repair_false_incomplete(queue_path=qp, dry_run=False)
     queue = json.loads(qp.read_text())

--- a/scripts/tests/test_wr2_completeness_gate.py
+++ b/scripts/tests/test_wr2_completeness_gate.py
@@ -587,6 +587,36 @@ def test_resolve_slides_dir_pure_unit_all_three_paths():
         assert reconciler._resolve_slides_dir(entry4, carousel_root) is None
 
 
+def test_resolve_slides_dir_suffix_match_prefers_newest_dir():
+    """GUILT (gate finding, 2026-07-17): when step 3's suffix-match has MULTIPLE
+    candidates (a topic re-rendered into a second dir), the resolver must
+    return the NEWEST (later-dated) one, never the oldest. Carousel dirs are
+    date-prefixed (2026-07-08-..., 2026-07-14-...); a naive ascending sort
+    picks the OLDEST match — reproduced live before this fix: two dirs
+    2026-07-08-visa-myth-aaa and 2026-07-14-visa-myth-bbb, both with valid
+    slides, resolved to 2026-07-08 (stale)."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        carousel_root = root / "carousel"
+        old_dir = carousel_root / "2026-07-08-visa-myth-aaa"
+        new_dir = carousel_root / "2026-07-14-visa-myth-bbb"
+        (old_dir / "slides").mkdir(parents=True)
+        (old_dir / "slides" / "01.png").write_bytes(b"\x89PNG-old")
+        (new_dir / "slides").mkdir(parents=True)
+        (new_dir / "slides" / "01.png").write_bytes(b"\x89PNG-new")
+
+        entry = {
+            "slides_dir": str(root / "gone" / "slides"),
+            "carousel_path": str(root / "gone"),
+            "topic_slug": "visa-myth",
+        }
+        resolved = reconciler._resolve_slides_dir(entry, carousel_root)
+        assert resolved == new_dir / "slides"
+        assert resolved != old_dir / "slides"
+
+
 def test_backfill_apply_preserves_other_queue_entries(tmp_path):
     """INNOCENCE: entries with no mismatch (including published history) must
     be byte-for-byte preserved by the backfill write."""

--- a/scripts/tests/test_wr2_completeness_gate.py
+++ b/scripts/tests/test_wr2_completeness_gate.py
@@ -461,6 +461,132 @@ def test_backfill_apply_marks_dirless_render_incomplete(tmp_path):
     assert entry["state"] == reconciler.RENDER_INCOMPLETE_STATE
 
 
+# ── old-schema carousel_path-only resolution fix (2026-07-17) ──────────────
+# WHY: OLD-style queue entries (pre-`slides_dir` field, still live in the
+# queue) carry only `carousel_path` and NO `slides_dir` key at all. The old
+# code treated the missing key as "no dir" and misclassified a real,
+# fully-rendered carousel as dirless (live case: indonesia-visafree-myth-
+# reality, 8 real PNGs, mis-marked tonight).
+
+
+def test_guilt_old_schema_carousel_path_only_entry_is_not_dirless(tmp_path):
+    """GUILT: an entry with ONLY carousel_path (no slides_dir key at all) and
+    real PNGs under carousel_path/slides must resolve correctly — not dirless,
+    and (with a correct declared count) not flagged as any mismatch at all."""
+    car_dir = tmp_path / "carousel" / "indonesia-visafree-myth-reality"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    _write_queue(qp, [{
+        "id": "carousel_old", "draft_id": "d-old", "state": "drafted",
+        "slide_count": 8, "carousel_path": str(car_dir),
+        # deliberately NO "slides_dir" key — old-schema shape
+    }])
+    mismatches = reconciler.check_completeness(queue_path=qp)
+    assert mismatches == []
+
+
+def test_innocence_genuinely_dirless_entry_without_slides_dir_key_stays_dirless(tmp_path):
+    """INNOCENCE: an entry with only carousel_path, where NEITHER
+    carousel_path/slides NOR any carousel_root suffix-match exists, must
+    still classify as dirless — the fix must not make everything resolve."""
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    _write_queue(qp, [{
+        "id": "carousel_gone", "draft_id": "d-gone", "state": "drafted",
+        "slide_count": 8, "carousel_path": str(tmp_path / "carousel" / "gone-topic"),
+    }])
+    mismatches = reconciler.check_completeness(queue_path=qp)
+    assert len(mismatches) == 1 and mismatches[0].classification == "dirless"
+
+
+def test_backfill_apply_never_mutates_old_schema_entry_with_real_pngs(tmp_path):
+    """GUILT (backfill path): the same old-schema entry must not be mutated to
+    render_incomplete by apply_completeness_backfill either."""
+    car_dir = tmp_path / "carousel" / "indonesia-visafree-myth-reality"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    before = [{
+        "id": "carousel_old", "draft_id": "d-old", "state": "drafted",
+        "slide_count": 8, "carousel_path": str(car_dir),
+    }]
+    _write_queue(qp, before)
+    reports = reconciler.apply_completeness_backfill(queue_path=qp, dry_run=False)
+    assert reports == []
+    assert json.loads(qp.read_text()) == before
+
+
+def test_suffix_match_resolves_when_both_recorded_paths_are_stale(tmp_path, monkeypatch):
+    """Resolution step 3: neither slides_dir nor carousel_path point at a real
+    directory anymore (the carousel dir was renamed/re-persisted), but a
+    directory under carousel_root (check_completeness resolves this from
+    WR2_OUTPUT_ROOT, same as _verify_visibility_or_backfill) matches by
+    topic_slug — the entry must still resolve, not be classified dirless."""
+    monkeypatch.setenv("WR2_OUTPUT_ROOT", str(tmp_path / "wr2-output"))
+    carousel_root = tmp_path / "wr2-output" / "carousel"
+    real_dir = carousel_root / "2026-07-01-indonesia-visafree-myth-reality-abcd1234"
+    slides_dir = real_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    stale = tmp_path / "carousel" / "stale-dir-no-longer-exists"
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    _write_queue(qp, [{
+        "id": "carousel_drifted", "draft_id": "d-drift", "state": "drafted",
+        "slide_count": 8,
+        "carousel_path": str(stale),
+        "slides_dir": str(stale / "slides"),
+        "topic_slug": "indonesia-visafree-myth-reality",
+    }])
+    mismatches = reconciler.check_completeness(queue_path=qp)
+    assert mismatches == []
+
+
+def test_resolve_slides_dir_pure_unit_all_three_paths():
+    """Direct unit coverage of _resolve_slides_dir()'s 3-step priority,
+    independent of check_completeness()'s queue/env plumbing."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        carousel_root = root / "carousel"
+
+        # step 1: slides_dir present and real
+        sd = root / "direct-slides"
+        sd.mkdir()
+        assert reconciler._resolve_slides_dir({"slides_dir": str(sd)}, carousel_root) == sd
+
+        # step 1 fallback -> step 2: slides_dir stale, carousel_path resolves
+        cp = root / "carousel-dir"
+        (cp / "slides").mkdir(parents=True)
+        entry = {"slides_dir": str(root / "nope"), "carousel_path": str(cp)}
+        assert reconciler._resolve_slides_dir(entry, carousel_root) == cp / "slides"
+
+        # step 2b: carousel_path itself IS the slides dir already
+        direct_slides_as_cp = root / "already-slides"
+        direct_slides_as_cp.mkdir()
+        entry2 = {"carousel_path": str(direct_slides_as_cp / "slides")}
+        (direct_slides_as_cp / "slides").mkdir()
+        assert reconciler._resolve_slides_dir(entry2, carousel_root) == direct_slides_as_cp / "slides"
+
+        # step 3: both stale, suffix-match under carousel_root by topic_slug
+        carousel_root.mkdir()
+        matched = carousel_root / "2026-01-01-my-topic-slug-deadbeef"
+        (matched / "slides").mkdir(parents=True)
+        entry3 = {
+            "slides_dir": str(root / "gone" / "slides"),
+            "carousel_path": str(root / "gone"),
+            "topic_slug": "my-topic-slug",
+        }
+        assert reconciler._resolve_slides_dir(entry3, carousel_root) == matched / "slides"
+
+        # all three fail -> None
+        entry4 = {
+            "slides_dir": str(root / "gone2" / "slides"),
+            "carousel_path": str(root / "gone2"),
+            "topic_slug": "no-such-topic-anywhere",
+        }
+        assert reconciler._resolve_slides_dir(entry4, carousel_root) is None
+
+
 def test_backfill_apply_preserves_other_queue_entries(tmp_path):
     """INNOCENCE: entries with no mismatch (including published history) must
     be byte-for-byte preserved by the backfill write."""
@@ -481,6 +607,127 @@ def test_backfill_apply_preserves_other_queue_entries(tmp_path):
     queue = json.loads(qp.read_text())
     assert queue[0] == published
     assert queue[1]["slide_count"] == 8
+
+
+# ── repair_false_incomplete() one-shot repair (2026-07-17) ─────────────────
+# WHY: the pre-fix dirless bug (see _resolve_slides_dir section above) had
+# already mutated some render_incomplete entries in the live queue before the
+# fix merged. This one-shot CLI restores the false positives it produced,
+# without touching genuinely dirless entries or any other state.
+
+
+def test_repair_guilt_false_incomplete_restored_to_drafted_under_apply(tmp_path):
+    """GUILT: a render_incomplete entry whose resolved slides dir (using the
+    FIXED resolution) has real PNGs is restored to drafted, with the correct
+    disk-derived slide_count, under --apply."""
+    car_dir = tmp_path / "carousel" / "indonesia-visafree-myth-reality"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    _write_queue(qp, [{
+        "id": "carousel_old", "draft_id": "d-old", "state": reconciler.RENDER_INCOMPLETE_STATE,
+        "slide_count": 8, "carousel_path": str(car_dir),
+        "state_history": [{"state": reconciler.RENDER_INCOMPLETE_STATE, "at": "t0",
+                            "reason": "dirless: slides_dir missing/not a directory"}],
+    }])
+    reports = reconciler.repair_false_incomplete(queue_path=qp, dry_run=False)
+    assert len(reports) == 1
+    assert reports[0]["action"] == "restore_to_drafted"
+    assert reports[0]["disk"] == 8
+
+    entry = json.loads(qp.read_text())[0]
+    assert entry["state"] == "drafted"
+    assert entry["slide_count"] == 8
+    assert entry["slides_dir"] == str(slides_dir)
+    assert entry["state_history"][-1]["by"] == "wr2-daily-reconciler-repair-false-incomplete"
+
+
+def test_repair_dry_run_never_mutates(tmp_path):
+    car_dir = tmp_path / "carousel" / "indonesia-visafree-myth-reality"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    before = [{
+        "id": "carousel_old", "draft_id": "d-old", "state": reconciler.RENDER_INCOMPLETE_STATE,
+        "slide_count": 8, "carousel_path": str(car_dir),
+    }]
+    _write_queue(qp, before)
+    reports = reconciler.repair_false_incomplete(queue_path=qp, dry_run=True)
+    assert len(reports) == 1 and reports[0]["action"] == "restore_to_drafted"
+    assert json.loads(qp.read_text()) == before
+
+
+def test_repair_innocence_genuinely_dirless_entry_untouched(tmp_path):
+    """INNOCENCE: an entry genuinely dirless even under the fixed resolution
+    (no slides_dir/carousel_path/suffix-match resolves) must stay
+    render_incomplete — the repair must not resurrect a real false negative."""
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    before = [{
+        "id": "carousel_gone", "draft_id": "d-gone", "state": reconciler.RENDER_INCOMPLETE_STATE,
+        "slide_count": 8, "carousel_path": str(tmp_path / "carousel" / "truly-gone"),
+    }]
+    _write_queue(qp, before)
+    reports = reconciler.repair_false_incomplete(queue_path=qp, dry_run=False)
+    assert reports == []
+    assert json.loads(qp.read_text()) == before
+
+
+def test_repair_innocence_published_and_other_states_never_touched(tmp_path):
+    """INNOCENCE: entries in ANY state other than render_incomplete —
+    including a published entry whose disk mismatches its declared count —
+    must never be considered by the repair, even if their resolved dir would
+    have real PNGs."""
+    car_dir = tmp_path / "carousel" / "some-published-topic"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 5)
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    before = [
+        {"id": "carousel_pub", "draft_id": "d-pub", "state": "published",
+         "slide_count": 9999, "carousel_path": str(car_dir)},
+        {"id": "carousel_drafted", "draft_id": "d-draft", "state": "drafted",
+         "slide_count": 5, "carousel_path": str(car_dir)},
+    ]
+    _write_queue(qp, before)
+    reports = reconciler.repair_false_incomplete(queue_path=qp, dry_run=False)
+    assert reports == []
+    assert json.loads(qp.read_text()) == before
+
+
+def test_repair_exclude_id_hard_excludes_entry(tmp_path):
+    """--exclude-id: an operator override that skips a specific entry even
+    though it would otherwise resolve cleanly (e.g. a genuinely-bad carousel
+    that happens to share the render_incomplete state)."""
+    car_dir = tmp_path / "carousel" / "excluded-topic"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    before = [{
+        "id": "carousel_excluded", "draft_id": "d-excl", "state": reconciler.RENDER_INCOMPLETE_STATE,
+        "slide_count": 8, "carousel_path": str(car_dir),
+    }]
+    _write_queue(qp, before)
+    reports = reconciler.repair_false_incomplete(
+        queue_path=qp, dry_run=False, exclude_ids={"carousel_excluded"},
+    )
+    assert reports == []
+    assert json.loads(qp.read_text()) == before
+
+
+def test_repair_preserves_other_queue_entries_byte_for_byte(tmp_path):
+    car_dir = tmp_path / "carousel" / "indonesia-visafree-myth-reality"
+    slides_dir = car_dir / "slides"
+    _make_pngs(slides_dir, 8)
+    qp = tmp_path / "queue" / "human-review-queue.json"
+    published = {"id": "carousel_pub", "draft_id": "d0", "state": "published", "slide_count": 9999}
+    _write_queue(qp, [
+        published,
+        {"id": "carousel_old", "draft_id": "d-old", "state": reconciler.RENDER_INCOMPLETE_STATE,
+         "slide_count": 8, "carousel_path": str(car_dir)},
+    ])
+    reconciler.repair_false_incomplete(queue_path=qp, dry_run=False)
+    queue = json.loads(qp.read_text())
+    assert queue[0] == published
+    assert queue[1]["state"] == "drafted"
 
 
 # ── HIGH #5: staging + atomic swap in _persist_local_artifacts ─────────────

--- a/scripts/tests/test_wr2_queue_pull_merge.py
+++ b/scripts/tests/test_wr2_queue_pull_merge.py
@@ -148,6 +148,30 @@ def test_archived_local_only_entry_is_dropped_not_resurrected():
     assert [e["id"] for e in merged] == ["carousel_1"]
     assert report["local_only"] == []
     assert report["archived_dropped"] == ["golden_visa_1"]
+    assert report["published_local_kept_despite_archive"] == []
+
+
+def test_published_local_only_entry_survives_archive_on_pro():
+    """CRITICAL GUILT (Codex red-team, 2026-07-17): a local entry that is
+    ITSELF published* must survive even when its id is in the remote
+    archive and absent from the remote queue — push_back only fires from
+    the remote loop (for entries still present in the remote queue), so an
+    id Pro has already archived can never push_back; dropping it here would
+    permanently lose the published state + instagram_post_url with no
+    recovery path (live race: M5 publishes A, Pro archives A before the
+    next tick's push_back lands)."""
+    archived_and_published = _local_published("golden_visa_1")
+    merged, report = merge.merge_queues(
+        [_remote_drafted("carousel_1")],
+        [_remote_drafted("carousel_1"), archived_and_published],
+        remote_archive=[_remote_drafted("golden_visa_1")],
+    )
+    assert [e["id"] for e in merged] == ["carousel_1", "golden_visa_1"]
+    assert merged[1]["state"] == "published"
+    assert merged[1]["instagram_post_url"] == "https://www.instagram.com/p/AbC123/"
+    assert report["local_only"] == ["golden_visa_1"]
+    assert report["archived_dropped"] == []
+    assert report["published_local_kept_despite_archive"] == ["golden_visa_1"]
 
 
 def test_genuinely_local_entry_not_in_archive_still_protected():

--- a/scripts/tests/test_wr2_queue_pull_merge.py
+++ b/scripts/tests/test_wr2_queue_pull_merge.py
@@ -125,3 +125,101 @@ def test_cli_corrupt_local_falls_back_to_remote(tmp_path):
         rc = merge.main(["--remote", str(r), "--local", str(l), "--out", str(out)])
     assert rc == 0
     assert json.loads(out.read_text())[0]["state"] == "drafted"
+
+
+# ── archive-blind resurrect fix (2026-07-17) ─────────────────────────────────
+# WHY: Pro moves an entry from its live queue to queue-archive.json (archiving
+# it). The next pull's remote queue no longer contains that id, so — without
+# an archive cross-check — the OLD code classified it as local_only ("new
+# local entry") and kept re-adding it to the merged output forever. Live case:
+# a golden-visa entry archived on Pro at 17:4x kept reappearing on M5 every
+# tick.
+
+def test_archived_local_only_entry_is_dropped_not_resurrected():
+    """GUILT: a local entry whose id is present in the freshly-pulled remote
+    archive must disappear from the merge output — Pro's archive decision
+    wins, it is not resurrected as a "new" local-only entry."""
+    archived = _remote_drafted("golden_visa_1")
+    merged, report = merge.merge_queues(
+        [_remote_drafted("carousel_1")],
+        [_remote_drafted("carousel_1"), archived],
+        remote_archive=[archived],
+    )
+    assert [e["id"] for e in merged] == ["carousel_1"]
+    assert report["local_only"] == []
+    assert report["archived_dropped"] == ["golden_visa_1"]
+
+
+def test_genuinely_local_entry_not_in_archive_still_protected():
+    """INNOCENCE: a local-only entry whose id is NOT in the remote archive
+    must still be kept and reported as local_only — the archive cross-check
+    must not become a new way to lose real local-only entries."""
+    extra = _local_published("app_upload_1")
+    other_archived = _remote_drafted("some_other_archived_id")
+    merged, report = merge.merge_queues(
+        [_remote_drafted()],
+        [_local_published(), extra],
+        remote_archive=[other_archived],
+    )
+    assert [e["id"] for e in merged] == ["carousel_1", "app_upload_1"]
+    assert report["local_only"] == ["app_upload_1"]
+    assert report["archived_dropped"] == []
+
+
+def test_entry_in_both_remote_queue_and_archive_queue_wins():
+    """INNOCENCE (pathological case): an id present in BOTH the live remote
+    queue AND the remote archive is NOT dropped and NOT local_only — the
+    live queue wins (kept as a normal remote entry), with a warning flag."""
+    rem = _remote_drafted("carousel_1")
+    merged, report = merge.merge_queues(
+        [rem],
+        [],
+        remote_archive=[_remote_drafted("carousel_1")],
+    )
+    assert [e["id"] for e in merged] == ["carousel_1"]
+    assert merged[0]["state"] == "drafted"
+    assert report["local_only"] == []
+    assert report["archived_dropped"] == []
+    assert report["queue_and_archive_conflict"] == ["carousel_1"]
+
+
+def test_no_remote_archive_arg_behaves_as_before():
+    """Backward compatibility: remote_archive=None (or omitted) must not
+    change any existing behavior — callers that never pass it are unaffected."""
+    merged, report = merge.merge_queues([_remote_drafted()], [_local_published()])
+    assert merged[0]["state"] == "published"
+    assert report["archived_dropped"] == []
+    assert report["queue_and_archive_conflict"] == []
+
+
+def test_cli_remote_archive_flag_drops_archived_entry(tmp_path):
+    r = tmp_path / "r.json"; r.write_text(json.dumps([_remote_drafted("carousel_1")]))
+    archived = _remote_drafted("golden_visa_1")
+    l = tmp_path / "l.json"; l.write_text(json.dumps([_remote_drafted("carousel_1"), archived]))
+    a = tmp_path / "a.json"; a.write_text(json.dumps([archived]))
+    out = tmp_path / "m.json"
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = merge.main(["--remote", str(r), "--local", str(l), "--out", str(out),
+                          "--remote-archive", str(a)])
+    assert rc == 0
+    assert [e["id"] for e in json.loads(out.read_text())] == ["carousel_1"]
+    rep = json.loads(buf.getvalue())
+    assert rep["archived_dropped"] == ["golden_visa_1"]
+
+
+def test_cli_missing_remote_archive_file_degrades_gracefully(tmp_path):
+    """A --remote-archive path that doesn't exist (e.g. Pro's archive pull
+    failed this tick) must never crash the CLI — degrade to no cross-check."""
+    r = tmp_path / "r.json"; r.write_text(json.dumps([_remote_drafted()]))
+    l = tmp_path / "l.json"; l.write_text(json.dumps([_local_published()]))
+    out = tmp_path / "m.json"
+    import io
+    from contextlib import redirect_stdout
+    with redirect_stdout(io.StringIO()):
+        rc = merge.main(["--remote", str(r), "--local", str(l), "--out", str(out),
+                          "--remote-archive", str(tmp_path / "does-not-exist.json")])
+    assert rc == 0
+    assert json.loads(out.read_text())[0]["state"] == "published"

--- a/scripts/wr2_daily_reconciler.py
+++ b/scripts/wr2_daily_reconciler.py
@@ -398,6 +398,23 @@ def _resolve_expected_count(
     return None, "none"
 
 
+def _needle_on_segment_boundary(name: str, needle: str) -> bool:
+    """True iff `needle` sits on hyphen-segment boundaries inside `name`
+    (Codex red-team HIGH #2, 2026-07-17): a bare `*{needle}*` glob
+    over-matches ACROSS topics — needle `visa-myth` matches dir
+    `2026-07-17-evisa-mythology-b` (the substring is "e"+"visa-myth"+"ology",
+    with no hyphen boundary on either side), and newest-first would then
+    PREFER that foreign dir over the genuine match. Anchor on the FULL
+    needle as one unit (not its internal hyphens) — exact name, or bounded
+    by a hyphen on the side(s) that aren't the string's own start/end."""
+    return (
+        name == needle
+        or name.endswith("-" + needle)
+        or ("-" + needle + "-") in name
+        or name.startswith(needle + "-")
+    )
+
+
 def _resolve_slides_dir(entry: dict[str, Any], carousel_root: Path) -> Path | None:
     """Resolve an entry's slides directory across schema/path drift
     (2026-07-17 fix — live case: `indonesia-visafree-myth-reality`, 8 real
@@ -414,11 +431,13 @@ def _resolve_slides_dir(entry: dict[str, Any], carousel_root: Path) -> Path | No
       1. entry["slides_dir"], expanduser()'d, if it is a real directory.
       2. entry["carousel_path"], expanduser()'d — either already IS the
          slides dir, or is the carousel dir one level up (try + "slides").
-      3. Suffix-match under `carousel_root` by the entry's own dir basename
-         (from carousel_path) or topic_slug — mirrors the app's own
-         `*-{draft_id[:8]}`-style matching convention (see
+      3. Segment-anchored suffix-match under `carousel_root` by the entry's
+         own dir basename (from carousel_path) or topic_slug — mirrors the
+         app's own `*-{draft_id[:8]}`-style matching convention (see
          `_verify_visibility_or_backfill`) for entries whose recorded path
          has since drifted (re-persisted/renamed carousel dir).
+         `_needle_on_segment_boundary` rejects a bare substring hit that
+         crosses topic boundaries (see its docstring).
     """
     sd = entry.get("slides_dir")
     if sd:
@@ -440,12 +459,20 @@ def _resolve_slides_dir(entry: dict[str, Any], carousel_root: Path) -> Path | No
                            entry.get("topic_slug")) if n]
     if needles and carousel_root.is_dir():
         for needle in needles:
-            # newest-first: carousel dirs are date-prefixed (2026-07-08-...,
-            # 2026-07-14-...), so lexicographic descending == newest-first.
-            # A topic re-rendered into a second dir must resolve to that
-            # newer render, never the stale one from a prior attempt.
-            # Deliberately sort-by-name (deterministic), not by mtime.
-            for m in sorted(carousel_root.glob(f"*{needle}*"), reverse=True):
+            # glob is a cheap prefilter (substring); _needle_on_segment_
+            # boundary is the real gate — rejects cross-topic over-matches
+            # like needle "visa-myth" hitting dir "...-evisa-mythology-...".
+            accepted = [
+                m for m in carousel_root.glob(f"*{needle}*")
+                if _needle_on_segment_boundary(m.name, needle)
+            ]
+            # newest-first AMONG ACCEPTED matches: carousel dirs are
+            # date-prefixed (2026-07-08-..., 2026-07-14-...), so
+            # lexicographic descending == newest-first. A topic re-rendered
+            # into a second dir must resolve to that newer render, never
+            # the stale one from a prior attempt. Deliberately sort-by-name
+            # (deterministic), not by mtime.
+            for m in sorted(accepted, reverse=True):
                 candidate = m / "slides"
                 if candidate.is_dir():
                     return candidate
@@ -886,9 +913,20 @@ def repair_false_incomplete(
     """One-shot repair (2026-07-17): the pre-fix dirless bug (missing/stale
     `slides_dir` misread as "no dir" for old-schema `carousel_path`-only
     entries — see `_resolve_slides_dir`) marked genuinely-complete carousels
-    render_incomplete. This scans every CURRENT `render_incomplete` entry and,
-    using the FIXED resolution, restores it to `drafted` when the resolved
-    slides dir actually has >=1 real slide PNG on disk.
+    render_incomplete. This scans every CURRENT `render_incomplete` entry
+    and, using the FIXED resolution, restores it to `drafted` when the
+    resolved slides dir has >=1 real slide PNG on disk AND disk matches
+    independently-resolved ground truth (`_resolve_expected_count` — the
+    same source `apply_completeness_backfill` trusts).
+
+    HIGH #3 (Codex red-team, 2026-07-17): `disk >= 1` alone is NOT enough —
+    a GENUINELY incomplete carousel (disk=8, but an independent source says
+    9) sitting in render_incomplete would otherwise be restored to drafted
+    with slide_count=8, becoming publish-eligible and defeating the
+    complete-or-nothing gate. Restore ONLY when `expected is not None and
+    disk == expected`; when expected is None (no independent ground truth
+    at all), refuse to guess — same doctrine as apply_completeness_
+    backfill's unknown_intent.
 
     Report-only by default; `--apply` mutates under the queue's fcntl lock +
     tmp+rename protocol (same as `apply_completeness_backfill`) so a
@@ -937,9 +975,16 @@ def repair_false_incomplete(
                 disk = viz.derive_slide_count(slides_dir)
                 if disk < 1:
                     continue  # resolved a dir, but it's empty — not a false positive
+                expected, expected_source = _resolve_expected_count(slides_dir.parent, entry)
+                if expected is None or disk != expected:
+                    # HIGH #3: no independent ground truth, or disk disagrees
+                    # with it — refuse to guess. Restoring here would make a
+                    # genuinely-incomplete carousel publish-eligible.
+                    continue
                 report = {
                     "entry_id": entry_id, "resolved_slides_dir": str(slides_dir),
-                    "disk": disk, "action": "restore_to_drafted",
+                    "disk": disk, "expected": expected, "expected_source": expected_source,
+                    "action": "restore_to_drafted",
                 }
                 if not dry_run:
                     entry["state"] = "drafted"

--- a/scripts/wr2_daily_reconciler.py
+++ b/scripts/wr2_daily_reconciler.py
@@ -440,7 +440,12 @@ def _resolve_slides_dir(entry: dict[str, Any], carousel_root: Path) -> Path | No
                            entry.get("topic_slug")) if n]
     if needles and carousel_root.is_dir():
         for needle in needles:
-            for m in sorted(carousel_root.glob(f"*{needle}*")):
+            # newest-first: carousel dirs are date-prefixed (2026-07-08-...,
+            # 2026-07-14-...), so lexicographic descending == newest-first.
+            # A topic re-rendered into a second dir must resolve to that
+            # newer render, never the stale one from a prior attempt.
+            # Deliberately sort-by-name (deterministic), not by mtime.
+            for m in sorted(carousel_root.glob(f"*{needle}*"), reverse=True):
                 candidate = m / "slides"
                 if candidate.is_dir():
                     return candidate

--- a/scripts/wr2_daily_reconciler.py
+++ b/scripts/wr2_daily_reconciler.py
@@ -398,6 +398,55 @@ def _resolve_expected_count(
     return None, "none"
 
 
+def _resolve_slides_dir(entry: dict[str, Any], carousel_root: Path) -> Path | None:
+    """Resolve an entry's slides directory across schema/path drift
+    (2026-07-17 fix — live case: `indonesia-visafree-myth-reality`, 8 real
+    PNGs on disk, mis-marked dirless/render_incomplete).
+
+    OLD-style queue entries (pre-`slides_dir` field, still live in the
+    queue) carry only `carousel_path` (often `~`-prefixed) and NO
+    `slides_dir` key at all. Trusting a missing `slides_dir` as "no dir" —
+    the pre-fix behavior — misclassified a real, fully-rendered carousel as
+    dirless.
+
+    Resolution order — only when ALL three fail is the entry genuinely
+    dirless:
+      1. entry["slides_dir"], expanduser()'d, if it is a real directory.
+      2. entry["carousel_path"], expanduser()'d — either already IS the
+         slides dir, or is the carousel dir one level up (try + "slides").
+      3. Suffix-match under `carousel_root` by the entry's own dir basename
+         (from carousel_path) or topic_slug — mirrors the app's own
+         `*-{draft_id[:8]}`-style matching convention (see
+         `_verify_visibility_or_backfill`) for entries whose recorded path
+         has since drifted (re-persisted/renamed carousel dir).
+    """
+    sd = entry.get("slides_dir")
+    if sd:
+        p = Path(sd).expanduser()
+        if p.is_dir():
+            return p
+
+    cp = entry.get("carousel_path")
+    cp_path: Path | None = None
+    if cp:
+        cp_path = Path(cp).expanduser()
+        if cp_path.name == "slides" and cp_path.is_dir():
+            return cp_path
+        candidate = cp_path / "slides"
+        if candidate.is_dir():
+            return candidate
+
+    needles = [n for n in (cp_path.name if cp_path is not None else None,
+                           entry.get("topic_slug")) if n]
+    if needles and carousel_root.is_dir():
+        for needle in needles:
+            for m in sorted(carousel_root.glob(f"*{needle}*")):
+                candidate = m / "slides"
+                if candidate.is_dir():
+                    return candidate
+    return None
+
+
 def _classify_completeness(*, disk: int, expected: int | None) -> str:
     """4-way classification (design spec A3; extended HIGH #3/#4, 2026-07-16):
 
@@ -447,6 +496,7 @@ def check_completeness(
     if not isinstance(queue, list):
         return []
 
+    carousel_root = viz._default_output_root() / "carousel"
     mismatches: list[CompletenessMismatch] = []
     for entry in queue:
         if not isinstance(entry, dict):
@@ -458,17 +508,16 @@ def check_completeness(
         if not isinstance(declared, int):
             continue
         entry_id = str(entry.get("id") or entry.get("item_id") or "?")
-        sd = entry.get("slides_dir")
-        if not sd or not Path(sd).is_dir():
+        slides_dir = _resolve_slides_dir(entry, carousel_root)
+        if slides_dir is None:
             mismatches.append(CompletenessMismatch(
                 entry_id=entry_id, draft_id=entry.get("draft_id"), state=state,
                 declared=declared, disk=0, expected=None, expected_source="none",
                 classification="dirless",
             ))
             continue
-        slides_dir = Path(sd)
         disk = viz.derive_slide_count(slides_dir)
-        car_dir = Path(entry.get("carousel_path")) if entry.get("carousel_path") else slides_dir.parent
+        car_dir = slides_dir.parent
         # HIGH #3 (2026-07-16): resolve expected BEFORE any disk==declared
         # shortcut — a queue whose declared count happens to match disk can
         # still be WRONG against a trusted independent source (e.g.
@@ -509,6 +558,7 @@ def apply_completeness_backfill(
     qp = queue_path or (viz._default_output_root() / "queue" / "human-review-queue.json")
     if not qp.exists():
         return []
+    carousel_root = viz._default_output_root() / "carousel"
     lock_path = qp.with_suffix(".lock")
     reports: list[dict[str, Any]] = []
     with open(lock_path, "w", encoding="utf-8") as lock_fh:
@@ -534,8 +584,8 @@ def apply_completeness_backfill(
                 if not isinstance(declared, int):
                     continue
                 entry_id = str(entry.get("id") or entry.get("item_id") or "?")
-                sd = entry.get("slides_dir")
-                if not sd or not Path(sd).is_dir():
+                slides_dir = _resolve_slides_dir(entry, carousel_root)
+                if slides_dir is None:
                     report = {
                         "entry_id": entry_id, "classification": "dirless",
                         "declared": declared, "disk": 0, "action": "mark_render_incomplete",
@@ -545,14 +595,13 @@ def apply_completeness_backfill(
                         entry.setdefault("state_history", []).append({
                             "state": RENDER_INCOMPLETE_STATE, "at": now_iso,
                             "by": "wr2-daily-reconciler-backfill",
-                            "reason": "dirless: slides_dir missing/not a directory",
+                            "reason": "dirless: slides_dir/carousel_path/suffix-match all missing",
                         })
                         changed = True
                     reports.append(report)
                     continue
-                slides_dir = Path(sd)
                 disk = viz.derive_slide_count(slides_dir)
-                car_dir = Path(entry.get("carousel_path")) if entry.get("carousel_path") else slides_dir.parent
+                car_dir = slides_dir.parent
                 # HIGH #3: resolve expected BEFORE any disk==declared
                 # shortcut — see the matching comment in check_completeness.
                 expected, expected_source = _resolve_expected_count(car_dir, entry)
@@ -823,6 +872,107 @@ async def _tick(
     return 0
 
 
+def repair_false_incomplete(
+    queue_path: Path | None = None,
+    *,
+    dry_run: bool = True,
+    exclude_ids: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """One-shot repair (2026-07-17): the pre-fix dirless bug (missing/stale
+    `slides_dir` misread as "no dir" for old-schema `carousel_path`-only
+    entries — see `_resolve_slides_dir`) marked genuinely-complete carousels
+    render_incomplete. This scans every CURRENT `render_incomplete` entry and,
+    using the FIXED resolution, restores it to `drafted` when the resolved
+    slides dir actually has >=1 real slide PNG on disk.
+
+    Report-only by default; `--apply` mutates under the queue's fcntl lock +
+    tmp+rename protocol (same as `apply_completeness_backfill`) so a
+    concurrent render/repoint cannot be clobbered by a stale decision.
+    `exclude_ids` (operator override, e.g. `--exclude-id` repeatable on the
+    CLI) hard-excludes specific entry ids — for a genuinely-bad carousel that
+    happens to also be in render_incomplete. Never touches any other state
+    (published/terminal or otherwise) — this repair is scoped exclusively to
+    undoing the false positives this specific bug produced."""
+    import fcntl
+    import json as _json
+
+    import wr2_html_render_apply as viz  # same scripts/ dir, same venv
+
+    qp = queue_path or (viz._default_output_root() / "queue" / "human-review-queue.json")
+    if not qp.exists():
+        return []
+    excludes = exclude_ids or set()
+    carousel_root = viz._default_output_root() / "carousel"
+    lock_path = qp.with_suffix(".lock")
+    reports: list[dict[str, Any]] = []
+    with open(lock_path, "w", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            try:
+                queue = _json.loads(qp.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001 — corrupt queue: never guess, never write
+                logger.warning("repair-false-incomplete: queue unreadable at %s", qp, exc_info=True)
+                return []
+            if not isinstance(queue, list):
+                return []
+
+            changed = False
+            now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            for entry in queue:
+                if not isinstance(entry, dict):
+                    continue
+                if entry.get("state") != RENDER_INCOMPLETE_STATE:
+                    continue  # scoped strictly to this state — never touches anything else
+                entry_id = str(entry.get("id") or entry.get("item_id") or "?")
+                if entry_id in excludes:
+                    continue
+                slides_dir = _resolve_slides_dir(entry, carousel_root)
+                if slides_dir is None:
+                    continue  # genuinely dirless even under the fixed resolution — leave it
+                disk = viz.derive_slide_count(slides_dir)
+                if disk < 1:
+                    continue  # resolved a dir, but it's empty — not a false positive
+                report = {
+                    "entry_id": entry_id, "resolved_slides_dir": str(slides_dir),
+                    "disk": disk, "action": "restore_to_drafted",
+                }
+                if not dry_run:
+                    entry["state"] = "drafted"
+                    entry["slide_count"] = disk
+                    entry["slides_dir"] = str(slides_dir)
+                    entry.setdefault("state_history", []).append({
+                        "state": "drafted", "at": now_iso,
+                        "by": "wr2-daily-reconciler-repair-false-incomplete",
+                        "reason": (
+                            f"restored: fixed slides_dir resolution finds {disk} "
+                            f"real PNG(s) on disk — pre-fix dirless bug had missed "
+                            f"the carousel_path-only/suffix-match resolution"
+                        ),
+                    })
+                    changed = True
+                reports.append(report)
+
+            if not dry_run and changed:
+                tmp = qp.with_suffix(f".tmp.{os.getpid()}")
+                tmp.write_text(_json.dumps(queue, indent=2, ensure_ascii=False), encoding="utf-8")
+                os.replace(tmp, qp)
+                logger.info("repair-false-incomplete applied: %d entries restored", len(reports))
+            return reports
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+
+def _cmd_repair_false_incomplete(apply: bool, exclude_ids: list[str]) -> int:
+    """One-shot CLI mode: restore render_incomplete entries wrongly marked
+    dirless by the pre-fix bug back to drafted, when the FIXED resolution
+    finds real PNGs. Report-only by default; --apply mutates."""
+    import json as _json
+
+    reports = repair_false_incomplete(dry_run=not apply, exclude_ids=set(exclude_ids))
+    print(_json.dumps({"apply": apply, "count": len(reports), "reports": reports}, indent=2))
+    return 0
+
+
 def _cmd_backfill_completeness(apply: bool) -> int:
     """One-shot mode (A3): apply the 3-way completeness classification to
     every non-terminal queue entry. Default dry-run (report only); --apply
@@ -847,10 +997,27 @@ def main() -> int:
              "no DB, no decide()/kickstart. Combine with --apply to mutate.",
     )
     parser.add_argument(
+        "--repair-false-incomplete", action="store_true",
+        help="one-shot: restore render_incomplete entries wrongly marked dirless "
+             "by the pre-2026-07-17 slides_dir resolution bug (old-schema "
+             "carousel_path-only entries) back to drafted, when the FIXED "
+             "resolution finds real PNGs on disk. Report-only by default; "
+             "combine with --apply to mutate. Combine with --exclude-id to "
+             "hard-exclude specific entries.",
+    )
+    parser.add_argument(
+        "--exclude-id", action="append", default=[], metavar="ENTRY_ID",
+        help="with --repair-false-incomplete: hard-exclude this entry id from "
+             "restoration (repeatable)",
+    )
+    parser.add_argument(
         "--apply", action="store_true",
-        help="with --backfill-completeness: actually mutate the queue (default: report only)",
+        help="with --backfill-completeness or --repair-false-incomplete: "
+             "actually mutate the queue (default: report only)",
     )
     args = parser.parse_args()
+    if args.repair_false_incomplete:
+        return _cmd_repair_false_incomplete(apply=args.apply, exclude_ids=args.exclude_id)
     if args.backfill_completeness:
         return _cmd_backfill_completeness(apply=args.apply)
     dry = args.dry_run or os.environ.get("WR2_RECONCILER_DRY_RUN") == "1"

--- a/scripts/wr2_queue_pull_merge.py
+++ b/scripts/wr2_queue_pull_merge.py
@@ -19,13 +19,24 @@ Merge semantics (monotone state lattice — remote wins EXCEPT):
     when its ref-code/IG-URL are shell-safe by construction (strict regex).
   - entry only in LOCAL (app-created: upload/auto-enqueue): kept, appended
     after remote entries, reported as local_only. Never pushed back.
+    EXCEPTION (2026-07-17, archive-blind resurrect fix): if the entry's id
+    is present in `remote_archive` (Pro's freshly-pulled queue-archive.json),
+    Pro deliberately ARCHIVED it — it is dropped instead of resurrected, and
+    reported under `archived_dropped`. Live case: a golden-visa entry
+    archived on Pro kept reappearing on M5 every tick because the old code
+    treated "gone from remote queue" as always meaning "new local entry".
+    Pathological case (present in BOTH remote queue and remote archive):
+    the live queue wins — kept as a normal remote entry (not local_only, not
+    dropped), with a warning in `queue_and_archive_conflict`.
   - everything else: remote wins verbatim.
 
 CLI (used by infra/launchagents/wrappers/wr2-queue-pull.sh):
-    python3 scripts/wr2_queue_pull_merge.py --remote R.json --local L.json --out M.json
+    python3 scripts/wr2_queue_pull_merge.py --remote R.json --local L.json \
+        --out M.json [--remote-archive A.json]
 prints a JSON report to stdout:
     {"protected": [ids], "local_only": [ids],
-     "push_back": [{"id":..., "ref_code": "WR2-XXXXXX", "ig_url": ...}]}
+     "push_back": [{"id":..., "ref_code": "WR2-XXXXXX", "ig_url": ...}],
+     "archived_dropped": [ids], "queue_and_archive_conflict": [ids]}
 """
 
 from __future__ import annotations
@@ -65,9 +76,19 @@ def _is_published(entry: dict[str, Any]) -> bool:
 
 
 def merge_queues(
-    remote: list[dict[str, Any]], local: list[dict[str, Any]]
+    remote: list[dict[str, Any]],
+    local: list[dict[str, Any]],
+    remote_archive: Optional[list[dict[str, Any]]] = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Merge Pro's queue (remote, SSOT) with the M5 local copy.
+
+    `remote_archive` (2026-07-17): Pro's freshly-pulled queue-archive.json —
+    entries Pro deliberately archived. Without this, an entry archived on Pro
+    (removed from its live queue) looks identical, to this function, to a
+    genuinely-new local-only entry — and gets resurrected into the merged
+    output forever (live case: a golden-visa entry archived on Pro kept
+    reappearing on M5 every pull). `None`/empty = old behavior (no archive
+    cross-check), so callers that don't have an archive yet degrade safely.
 
     Returns (merged, report). Pure — no I/O.
     """
@@ -78,9 +99,18 @@ def merge_queues(
             if eid:
                 local_by_id[eid] = e
 
+    archived_ids: set[str] = set()
+    for a in remote_archive or []:
+        if isinstance(a, dict):
+            aid = item_id_of(a)
+            if aid:
+                archived_ids.add(aid)
+
     merged: list[dict[str, Any]] = []
     protected: list[str] = []
     push_back: list[dict[str, str]] = []
+    archived_dropped: list[str] = []
+    queue_and_archive_conflict: list[str] = []
     seen: set[str] = set()
 
     for r in remote:
@@ -90,6 +120,11 @@ def merge_queues(
         rid = item_id_of(r)
         if rid:
             seen.add(rid)
+            if rid in archived_ids:
+                # pathological: Pro's live queue AND its archive both carry
+                # this id — the live queue wins (it's the more current SSOT
+                # signal); just flag it, never drop a still-queued entry.
+                queue_and_archive_conflict.append(str(rid))
         loc = local_by_id.get(rid) if rid else None
         if loc is not None and _is_published(loc) and not _is_published(r):
             out = dict(r)
@@ -112,14 +147,22 @@ def merge_queues(
         if not isinstance(e, dict):
             continue
         eid = item_id_of(e)
-        if eid and eid not in seen:
-            merged.append(e)
-            local_only.append(str(eid))
+        if not eid or eid in seen:
+            continue
+        if eid in archived_ids:
+            # archived on Pro, absent from Pro's live queue: Pro's decision,
+            # not a new local entry — drop instead of resurrecting.
+            archived_dropped.append(str(eid))
+            continue
+        merged.append(e)
+        local_only.append(str(eid))
 
     return merged, {
         "protected": protected,
         "local_only": local_only,
         "push_back": push_back,
+        "archived_dropped": archived_dropped,
+        "queue_and_archive_conflict": queue_and_archive_conflict,
     }
 
 
@@ -128,6 +171,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     ap.add_argument("--remote", type=Path, required=True, help="freshly pulled Pro queue")
     ap.add_argument("--local", type=Path, required=True, help="current local queue")
     ap.add_argument("--out", type=Path, required=True, help="merged output path")
+    ap.add_argument(
+        "--remote-archive", type=Path, default=None,
+        help="freshly pulled Pro queue-archive.json — cross-checked so an "
+             "entry Pro archived is dropped instead of resurrected as local_only",
+    )
     args = ap.parse_args(argv)
 
     remote = json.loads(args.remote.read_text(encoding="utf-8"))
@@ -143,7 +191,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         except Exception:  # noqa: BLE001 — corrupt local: remote wins wholesale
             local = []
 
-    merged, report = merge_queues(remote, local)
+    remote_archive: Optional[list] = None
+    if args.remote_archive is not None and args.remote_archive.exists():
+        try:
+            parsed_archive = json.loads(args.remote_archive.read_text(encoding="utf-8"))
+            if isinstance(parsed_archive, list):
+                remote_archive = parsed_archive
+        except Exception:  # noqa: BLE001 — corrupt archive: skip the cross-check, don't fail the pull
+            remote_archive = None
+
+    merged, report = merge_queues(remote, local, remote_archive)
     args.out.write_text(
         json.dumps(merged, indent=2, ensure_ascii=False), encoding="utf-8"
     )

--- a/scripts/wr2_queue_pull_merge.py
+++ b/scripts/wr2_queue_pull_merge.py
@@ -25,6 +25,15 @@ Merge semantics (monotone state lattice — remote wins EXCEPT):
     reported under `archived_dropped`. Live case: a golden-visa entry
     archived on Pro kept reappearing on M5 every tick because the old code
     treated "gone from remote queue" as always meaning "new local entry".
+    CRITICAL COUNTER-EXCEPTION (Codex red-team, 2026-07-17): a LOCAL entry
+    that is itself published* is ALWAYS kept even when archived on Pro —
+    kept in the merged output AND reported as local_only, plus flagged
+    under `published_local_kept_despite_archive`. Rationale: push_back only
+    fires from the REMOTE loop above, and once Pro archives the id it is no
+    longer in the remote queue at all — if this loop dropped it too, a
+    local publish transition that hadn't push-backed yet (race: M5
+    publishes, Pro archives before the next tick's push-back lands) would
+    lose its published state + instagram_post_url PERMANENTLY.
     Pathological case (present in BOTH remote queue and remote archive):
     the live queue wins — kept as a normal remote entry (not local_only, not
     dropped), with a warning in `queue_and_archive_conflict`.
@@ -36,7 +45,8 @@ CLI (used by infra/launchagents/wrappers/wr2-queue-pull.sh):
 prints a JSON report to stdout:
     {"protected": [ids], "local_only": [ids],
      "push_back": [{"id":..., "ref_code": "WR2-XXXXXX", "ig_url": ...}],
-     "archived_dropped": [ids], "queue_and_archive_conflict": [ids]}
+     "archived_dropped": [ids], "queue_and_archive_conflict": [ids],
+     "published_local_kept_despite_archive": [ids]}
 """
 
 from __future__ import annotations
@@ -143,6 +153,7 @@ def merge_queues(
             merged.append(r)
 
     local_only: list[str] = []
+    published_local_kept_despite_archive: list[str] = []
     for e in local:
         if not isinstance(e, dict):
             continue
@@ -150,8 +161,20 @@ def merge_queues(
         if not eid or eid in seen:
             continue
         if eid in archived_ids:
-            # archived on Pro, absent from Pro's live queue: Pro's decision,
-            # not a new local entry — drop instead of resurrecting.
+            if _is_published(e):
+                # CRITICAL (Codex red-team, 2026-07-17): a local publish
+                # transition survives an archive on Pro — dropping it here
+                # (as a plain archived_dropped) would permanently lose the
+                # published state + instagram_post_url with no recovery
+                # path, since push_back only fires from the remote loop
+                # above and this id is no longer in the remote queue at all.
+                merged.append(e)
+                local_only.append(str(eid))
+                published_local_kept_despite_archive.append(str(eid))
+                continue
+            # archived on Pro, absent from Pro's live queue, NOT published
+            # locally: Pro's decision, not a new local entry — drop instead
+            # of resurrecting.
             archived_dropped.append(str(eid))
             continue
         merged.append(e)
@@ -163,6 +186,7 @@ def merge_queues(
         "push_back": push_back,
         "archived_dropped": archived_dropped,
         "queue_and_archive_conflict": queue_and_archive_conflict,
+        "published_local_kept_despite_archive": published_local_kept_despite_archive,
     }
 
 


### PR DESCRIPTION
## What

Two production bugs found during the 2026-07-17 WR2 backfill night, plus a repair CLI and Codex red-team hardening:

**Bug 1 — Pro-archived entries resurrected forever on M5.** `wr2_queue_pull_merge.py` treated "gone from remote queue" as always meaning "new local entry", so an entry Pro deliberately archived (e.g. the golden-visa dead entry) reappeared on M5 every 300s tick. The merge now cross-checks Pro's freshly-pulled `queue-archive.json` (pulled FIRST in the same wrapper iteration): archived → dropped (`archived_dropped`); in both live queue and archive → live queue wins (flagged); archive missing/corrupt → safe degrade to old behavior.

**Bug 2 — old-schema entries mis-marked dirless.** The reconciler trusted a missing `slides_dir` key as "no dir": old entries carrying only `carousel_path` (often `~`-prefixed) with 8–9 real PNGs on disk were mis-marked `render_incomplete` (live cases: `indonesia-visafree-myth-reality`, `bali-pma-rental-crackdown`). New `_resolve_slides_dir` resolves via slides_dir → carousel_path(/slides) → segment-anchored suffix-match under the carousel root (newest-first among accepted).

**Repair CLI** — `wr2_daily_reconciler.py --repair-false-incomplete [--apply] [--exclude-id ID]`: restores `render_incomplete` false positives to `drafted` ONLY when the fixed resolution finds a dir whose disk count equals the independently-resolved expected count (slides.json etc.). No ground truth → refuses to guess. Scoped strictly to `render_incomplete`; mutations under fcntl lock + tmp+os.replace.

## Adversarial review (generator≠grader)

Session gate (Fable) + Codex 5.6-sol xhigh red-team. 6 findings fixed in `b954a83548`:
- CRITICAL: local published entry dropped by archive check before `_is_published` → published local transitions now always survive (`published_local_kept_despite_archive`).
- HIGH: substring suffix-match crossed topics (`visa-myth` ⊂ `evisa-mythology`) → segment-boundary gate.
- HIGH: repair required only ≥1 PNG → an 8/9 genuinely-incomplete carousel would return publish-eligible → now `disk == expected` required.
- Wrapper: stale `.merged` cleanup, merge-RC + JSON re-parse gate before `mv` (ENOSPC partial-write), atomic archive mirror update.

Accepted/documented: merge without archive on archive-pull failure (deliberate fail-open, WARN-logged); archive→queue pull TOCTOU (self-heals next tick). Pre-existing, ledgered separately: lockless wrapper vs queue writers; MERGE_PY-absent clobber fallback.

## Tests

74 passed (`test_wr2_queue_pull_merge.py`, `test_wr2_completeness_gate.py`, `test_wr2_daily_reconciler.py`) — guilt+innocence fixtures for every fix. `bash -n` clean on the wrapper (macOS bash 3.2, no arrays).

## Post-merge

Deploy both Pro checkouts + M5, then run `--repair-false-incomplete` (dry-run → `--apply`) on Pro to restore the two false-positive entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
