### PR TITLE
fix(db): grant backend_rag_v2 runtime access to compliance_alerts (m114) — migration 244

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/244_compliance_alerts_runtime_grants.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/244_compliance_alerts_runtime_grants.sql
@@ -1,0 +1,204 @@
+-- 244_compliance_alerts_runtime_grants.sql
+-- Runtime grants for compliance_alerts (m114) — closes a gap left by the
+-- 207-211 runtime-grants campaign, which never covered this table.
+--
+-- Live symptom fixed by this migration:
+-- - backend/services/intake/gate_evaluator.py::_count_deadlines() runs
+--   `SELECT count(*) FROM compliance_alerts a JOIN clients c ON ...` as part
+--   of evaluate_gate_status()'s single try-block (documents + late_note +
+--   deadlines all computed inside ONE `pool.acquire()`). Without SELECT on
+--   compliance_alerts, that query raises InsufficientPrivilegeError, the
+--   surrounding try/except (F4 fail-OPEN contract) swallows it and returns
+--   `_degraded(...)` — which zeroes ALL THREE sections, not just deadlines.
+--   Symptom observed: backend/tests/app/routers/test_intake_gate_mirror.py
+--   ::test_evaluator_mirror_mode_blocks_and_respects_staleness asserts
+--   `result["sections"]["documents"]["count"] == 2` and gets 0, even though
+--   the documents-section query itself never touched compliance_alerts.
+-- - backend/services/compliance/alert_repository.py (AlertRepository) does
+--   INSERT (persist generated alerts), SELECT (find_active_by_dedup_key /
+--   get / list_by_client), and UPDATE (promote severity/days_until,
+--   update_status + timestamp columns) against compliance_alerts. No
+--   runtime code path DELETEs rows — only test-fixture teardown
+--   (backend/tests/app/routers/test_compliance_alerts_router.py) does, under
+--   the local `test` role, never under backend_rag_v2 in production. DELETE
+--   is deliberately NOT granted here (least privilege — do not over-grant).
+--
+-- The object is historical/prod-owned in some environments, so the grant is
+-- guarded with to_regclass(). The runtime role is absent in CI test
+-- databases, so the whole migration is guarded on pg_roles (same pattern as
+-- 207-211).
+--
+-- In production this migration is executed by the runtime role. That role
+-- can verify its existing privileges, but cannot grant privileges on objects
+-- owned by other roles. If owner-level grants are still missing, fail with a
+-- precise manual-remediation message instead of a raw PostgreSQL permission
+-- error.
+
+DO $grant_block$
+DECLARE
+    runtime_role constant text := 'backend_rag_v2';
+    object_name text;
+    object_reg regclass;
+    sequence_name text;
+    sequence_reg regclass;
+    write_objects text[] := ARRAY[
+        'public.compliance_alerts'
+    ];
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = runtime_role) THEN
+        RETURN;
+    END IF;
+
+    IF NOT has_schema_privilege(runtime_role, 'public', 'USAGE') THEN
+        BEGIN
+            GRANT USAGE ON SCHEMA public TO backend_rag_v2;
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE WARNING
+                    'manual grant required: GRANT USAGE ON SCHEMA public TO %',
+                    runtime_role;
+        END;
+    END IF;
+
+    IF NOT has_schema_privilege(runtime_role, 'public', 'USAGE') THEN
+        RAISE EXCEPTION
+            'backend_rag_v2 is missing USAGE on schema public; apply manual grant with an owner/admin role';
+    END IF;
+
+    FOREACH object_name IN ARRAY write_objects LOOP
+        object_reg := to_regclass(object_name);
+
+        IF object_reg IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        IF NOT (
+            has_table_privilege(runtime_role, object_reg, 'SELECT')
+            AND has_table_privilege(runtime_role, object_reg, 'INSERT')
+            AND has_table_privilege(runtime_role, object_reg, 'UPDATE')
+        ) THEN
+            BEGIN
+                EXECUTE format(
+                    'GRANT SELECT, INSERT, UPDATE ON TABLE %s TO %I',
+                    object_reg,
+                    runtime_role
+                );
+            EXCEPTION
+                WHEN insufficient_privilege THEN
+                    RAISE WARNING
+                        'manual grant required: GRANT SELECT, INSERT, UPDATE ON TABLE % TO %',
+                        object_name,
+                        runtime_role;
+            END;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'SELECT') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing SELECT on %; apply manual grant with an owner/admin role',
+                object_name;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'INSERT') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing INSERT on %; apply manual grant with an owner/admin role',
+                object_name;
+        END IF;
+
+        IF NOT has_table_privilege(runtime_role, object_reg, 'UPDATE') THEN
+            RAISE EXCEPTION
+                'backend_rag_v2 is missing UPDATE on %; apply manual grant with an owner/admin role',
+                object_name;
+        END IF;
+
+        -- Defensive/future-proofing only: compliance_alerts.alert_id is
+        -- TEXT PRIMARY KEY (db/migrations_v2/114_compliance_alerts.sql), not
+        -- a serial/identity column, so pg_get_serial_sequence(..., 'id')
+        -- always returns NULL today and this block never executes. Kept for
+        -- parity with the 209/211 write_objects pattern in case the PK
+        -- shape ever changes.
+        sequence_name := pg_get_serial_sequence(object_name, 'id');
+
+        IF sequence_name IS NOT NULL THEN
+            sequence_reg := to_regclass(sequence_name);
+
+            IF sequence_reg IS NOT NULL
+                AND NOT (
+                    has_sequence_privilege(runtime_role, sequence_reg, 'USAGE')
+                    AND has_sequence_privilege(runtime_role, sequence_reg, 'SELECT')
+                ) THEN
+                BEGIN
+                    EXECUTE format(
+                        'GRANT USAGE, SELECT ON SEQUENCE %s TO %I',
+                        sequence_reg,
+                        runtime_role
+                    );
+                EXCEPTION
+                    WHEN insufficient_privilege THEN
+                        RAISE WARNING
+                            'manual grant required: GRANT USAGE, SELECT ON SEQUENCE % TO %',
+                            sequence_name,
+                            runtime_role;
+                END;
+            END IF;
+
+            IF sequence_reg IS NOT NULL
+                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'USAGE') THEN
+                RAISE EXCEPTION
+                    'backend_rag_v2 is missing USAGE on sequence %; apply manual grant with an owner/admin role',
+                    sequence_name;
+            END IF;
+
+            IF sequence_reg IS NOT NULL
+                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'SELECT') THEN
+                RAISE EXCEPTION
+                    'backend_rag_v2 is missing SELECT on sequence %; apply manual grant with an owner/admin role',
+                    sequence_name;
+            END IF;
+        END IF;
+    END LOOP;
+END
+$grant_block$;
+
+-- === ROLLBACK ===
+DO $revoke_block$
+DECLARE
+    runtime_role text := 'backend_rag_v2';
+    object_name text;
+    object_reg regclass;
+    sequence_name text;
+    sequence_reg regclass;
+    write_objects text[] := ARRAY[
+        'public.compliance_alerts'
+    ];
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = runtime_role) THEN
+        RETURN;
+    END IF;
+
+    FOREACH object_name IN ARRAY write_objects LOOP
+        object_reg := to_regclass(object_name);
+
+        IF object_reg IS NOT NULL THEN
+            EXECUTE format(
+                'REVOKE SELECT, INSERT, UPDATE ON TABLE %s FROM %I',
+                object_reg,
+                runtime_role
+            );
+        END IF;
+
+        sequence_name := pg_get_serial_sequence(object_name, 'id');
+
+        IF sequence_name IS NOT NULL THEN
+            sequence_reg := to_regclass(sequence_name);
+
+            IF sequence_reg IS NOT NULL THEN
+                EXECUTE format(
+                    'REVOKE USAGE, SELECT ON SEQUENCE %s FROM %I',
+                    sequence_reg,
+                    runtime_role
+                );
+            END IF;
+        END IF;
+    END LOOP;
+END
+$revoke_block$;

--- a/apps/backend-rag/backend/tests/db/test_migration_244_compliance_alerts_runtime_grants.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_244_compliance_alerts_runtime_grants.py
@@ -1,0 +1,99 @@
+"""Contract tests for migration 244 compliance_alerts runtime grants."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.db.migration_manager import _extract_rollback_sql
+
+MIGRATION_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "db"
+    / "migrations_v2"
+    / "244_compliance_alerts_runtime_grants.sql"
+)
+
+WRITE_OBJECTS = ("public.compliance_alerts",)
+
+
+def _forward(sql: str) -> str:
+    """Return the forward section applied by the migration runner."""
+    return sql.split("-- === ROLLBACK ===", maxsplit=1)[0]
+
+
+def test_migration_244_file_exists() -> None:
+    assert MIGRATION_FILE.exists()
+
+
+def test_migration_244_has_rollback_marker() -> None:
+    sql = MIGRATION_FILE.read_text()
+
+    assert "-- === ROLLBACK ===" in sql
+    assert _extract_rollback_sql(sql) is not None
+
+
+def test_migration_244_targets_runtime_role_conditionally() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "runtime_role constant text := 'backend_rag_v2'" in forward
+    assert "pg_roles WHERE rolname = runtime_role" in forward
+    assert "GRANT USAGE ON SCHEMA public TO backend_rag_v2" in forward
+
+
+def test_migration_244_is_safe_when_object_is_missing() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "to_regclass(object_name)" in forward
+    assert "IF object_reg IS NULL THEN" in forward
+    assert "CONTINUE;" in forward
+
+
+def test_migration_244_checks_existing_privileges_before_granting() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "has_schema_privilege(runtime_role, 'public', 'USAGE')" in forward
+    assert "has_table_privilege(runtime_role, object_reg, 'SELECT')" in forward
+    assert "has_table_privilege(runtime_role, object_reg, 'INSERT')" in forward
+    assert "has_table_privilege(runtime_role, object_reg, 'UPDATE')" in forward
+    assert "WHEN insufficient_privilege THEN" in forward
+    assert "manual grant required: GRANT SELECT, INSERT, UPDATE ON TABLE" in forward
+    assert "apply manual grant with an owner/admin role" in forward
+
+
+def test_migration_244_grants_live_error_object() -> None:
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "GRANT SELECT, INSERT, UPDATE ON TABLE" in forward
+    for object_name in WRITE_OBJECTS:
+        assert object_name in forward
+
+
+def test_migration_244_does_not_over_grant_delete() -> None:
+    """Least-privilege guard: no runtime code path DELETEs compliance_alerts
+    rows (backend/services/compliance/alert_repository.py is INSERT/SELECT/
+    UPDATE only) — only test-fixture teardown does, under the local `test`
+    role. This migration must never grant DELETE to backend_rag_v2; a future
+    edit that copy-pastes the 207/209/211 four-privilege bundle onto this
+    table would silently regress that guarantee.
+
+    Checks the actual SQL verbs/privilege-check calls, not a bare substring
+    scan of the whole file — the header comment legitimately discusses
+    DELETE in prose (why it's excluded), and a blind "DELETE not in forward"
+    assertion would false-positive on that prose (guard over-match, cicatrix
+    family #3) instead of checking the grant itself.
+    """
+    forward = _forward(MIGRATION_FILE.read_text())
+
+    assert "GRANT SELECT, INSERT, UPDATE, DELETE" not in forward
+    assert "has_table_privilege(runtime_role, object_reg, 'DELETE')" not in forward
+    assert "REVOKE SELECT, INSERT, UPDATE, DELETE" not in forward
+
+
+def test_migration_244_rollback_revokes_same_grants() -> None:
+    rollback = _extract_rollback_sql(MIGRATION_FILE.read_text())
+
+    assert rollback is not None
+    assert "REVOKE SELECT, INSERT, UPDATE ON TABLE" in rollback
+    assert "DELETE" not in rollback
+    for object_name in WRITE_OBJECTS:
+        assert object_name in rollback

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 638 services · 1148 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 638 services · 1149 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

Closes the gap the **207–211 `*_runtime_grants.sql`** campaign left open: migration **114** created `compliance_alerts` but never granted the prod runtime role (`backend_rag_v2`) access to it, while every other runtime-read/write table got covered.

Adds migration **`244_compliance_alerts_runtime_grants.sql`** (numbered 244 — the orchestrator brief said "212", but 212–243 are already taken; 244 is the next free prefix, W41 uniqueness lint green).

## Why it surfaced

`backend/services/intake/gate_evaluator.py::evaluate_gate_status()` runs all three login-gate queries (documents / late_note / **deadlines**) inside **one** `pool.acquire()` try-block. The deadlines query `JOIN`s `compliance_alerts`. A `permission denied` there raises → the F4 **fail-OPEN** contract swallows it → `_degraded(...)` zeroes **all three** sections, not just deadlines. Symptom: `test_intake_gate_mirror.py::test_evaluator_mirror_mode_blocks_and_respects_staleness` asserts `documents.count == 2`, gets `0` — even though the documents query never touched `compliance_alerts`.

## (a) The migration — additive / idempotent, mirrors 207–211

- Targets the same runtime role `backend_rag_v2`, guarded identically: `pg_roles` existence check (no-op in CI/local where the role is absent), `to_regclass()` object guard, `has_table_privilege()` probes before each `GRANT`, `RAISE WARNING` then `RAISE EXCEPTION` on owner-grant failure, plus a `-- === ROLLBACK ===` revoke section.
- Grants **SELECT, INSERT, UPDATE — deliberately NOT DELETE**. `backend/services/compliance/alert_repository.py` (the only runtime writer) does insert / select / promote(UPDATE) / update_status(UPDATE) / list — **never** deletes. The only `DELETE FROM compliance_alerts` in the tree is test-fixture teardown, under the local `test` role. Least-privilege, not the 207/209/211 four-verb bundle.

## (b) test_migration_244 over-broad DELETE assertion fix

The first draft of the least-privilege guard asserted `"DELETE" not in forward` — which false-matched the **prose header comment** (which explains *why* DELETE is excluded) rather than the SQL. Tightened to assert on the actual verb bundles: `"GRANT SELECT, INSERT, UPDATE, DELETE" not in forward`, `"REVOKE SELECT, INSERT, UPDATE, DELETE" not in ...`, and the `has_table_privilege(..., 'DELETE')` probe absent. Guard-over-match class (cicatrix #3). Caught by running the test before commit; all 8 contract tests green.

## (c) Local `nuzantara_test` — honest note on the unblock

- I applied migration 244 to the local `nuzantara_test` template via the real migration runner (registered `_schema_versions` #15458). It is a **local no-op on grants**: `backend_rag_v2` does not exist in the local/CI role set, so the guarded `DO` block `RETURN`s immediately — exactly how 207–211 already behave locally.
- The pre-push gate passes because the local template grants/owns `compliance_alerts` to the **`test`** role (the CI/local DB role, distinct from prod's `backend_rag_v2`). I observed the template's `compliance_alerts` ownership get re-provisioned to `test` mid-session (a sibling push's fresh bootstrap runs migration 114 under `test`). So the **local** unblock is environmental; **this migration's real value is the PROD gap** below.
- Empirical proof the gate passes: this branch's own pre-push ran the identical gate (clone `nuzantara_test` → full suite incl. the exact target test) → **17269 passed, 115 skipped**.

## ⚠️ PROD verification REQUIRED (operator, DB channel — headless-walled here)

If the prod runtime role `backend_rag_v2` does **not** have `SELECT` on `compliance_alerts` in the production DB, the intake **compliance login gate fails OPEN in production** (the F4 path above zeroes all sections), i.e. reviewers are silently un-gated. This migration cures it on next apply, **but prod state must be confirmed by the operator**:

```
-- run against prod DB as owner/admin:
SELECT has_table_privilege('backend_rag_v2', 'public.compliance_alerts', 'SELECT');
```

Expected after apply: `t`. If `f` today → the gate is currently fail-OPEN in prod.

## Do NOT auto-merge

Migration PR = the auto-merge-OFF exception (config-critical, W38 GRANT-campaign family). Orchestrator reviews the migration diff and merges manually. No `gh pr merge` armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
