### PR TITLE
chore(claude): vendor process toolkit as repo SSOT + harden commands gitignore (PII)

### DIFF
--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -1,0 +1,62 @@
+---
+name: resume
+description: Re-inject Mnemos handoff JSON post-compact. Reads precompact-handoff state files.
+---
+
+> **CANON**: repo `.claude/` (vendored 2026-07-17, PR process-toolkit SSOT) — shadows the `~/.claude/` HOME copy. Edit HERE, never in `$HOME`. Pro/Mini shadow it on `git pull`.
+
+# /resume
+
+Per-command contract (T3.4 panel amendment):
+
+- **Side effects**: ZERO. Read-only — display only.
+- **Input schema**: no args.
+- **Failure mode**: if no handoff file found → state "no recent Mnemos handoff", do not fabricate.
+- **Audit**: none.
+
+## Steps
+
+1. ALWAYS print the recent-sessions list first (operator preference 2026-05-30 — lista sessioni on every /resume):
+
+```bash
+python3 ~/.claude/scripts/resume-session-list.py 12
+```
+
+Display the output verbatim. If the operator replies with a `#`, resume THAT session's handoff; otherwise default to the most recent (continue with Step 2).
+
+2. Find most recent handoff (or the one chosen above):
+
+```bash
+ls -t ~/.claude/state/precompact-handoff-*.json 2>/dev/null | head -1
+```
+
+3. If no file → output:
+
+```
+=== NO MNEMOS HANDOFF ===
+No file found at ~/.claude/state/precompact-handoff-*.json.
+Either: (a) session not yet compacted, (b) PreCompact hook (T2.5) not active, (c) handoff cleaned post-resume.
+=== END ===
+```
+
+4. If file found → Read + display:
+
+```
+=== RESUME FROM COMPACT ===
+Session ID: <id>
+Timestamp: <ts>
+Objective: <text>
+Changed files: <list>
+Verified commands: <list>
+Risks: <list>
+Next action: <text>
+=== END RESUME ===
+```
+
+5. Confirm with user: "Continua su next action? (y/n)" — wait for explicit response before any action.
+
+## Anti-pattern
+
+- Read multiple handoff files and merge — ambiguous source of truth
+- Auto-execute "next action" without explicit confirmation
+- Delete handoff file (leave for next /resume)

--- a/.claude/commands/scar.md
+++ b/.claude/commands/scar.md
@@ -1,0 +1,61 @@
+---
+name: scar
+description: Append cicatrix-scars.md entry strutturato (TRAUMA/ANTIBODY/GOTCHA). APPEND ONLY — no auto-commit.
+---
+
+> **CANON**: repo `.claude/` (vendored 2026-07-17, PR process-toolkit SSOT) — shadows the `~/.claude/` HOME copy. Edit HERE, never in `$HOME`. Pro/Mini shadow it on `git pull`.
+
+# /scar $ARGUMENTS
+
+Per-command contract (T3.4 panel amendment):
+
+- **Side effects**: APPEND to `~/nuzantara/.claude/rules/cicatrix-scars.md` ONLY. NO git commit, NO push.
+- **Input schema**: `<severity> <one-line description>`. Severity ∈ {P0, P1, P2, P3, RESOLVED, INFO}.
+- **Failure mode**: if severity unrecognized or `$ARGUMENTS` empty → ABORT with format reminder.
+- **Audit**: log timestamp + severity + description to `~/.claude/state/scar-audit.log`.
+
+## Steps
+
+1. Parse `$ARGUMENTS`: first token = severity, rest = description. Validate severity in allowed set.
+2. Optionally ask user for: TRAUMA (one paragraph), ANTIBODY (proposed fix), GOTCHA (edge case), Reference (commit SHA / spec path / line). If `$ARGUMENTS` already contains structured content, skip.
+3. Build entry:
+
+```
+### <icon> <severity>: <description> (YYYY-MM-DD)
+
+_Discovered: YYYY-MM-DD HH:MM WITA · Severity: <severity> · Status: <derive from severity>_
+
+**TRAUMA**: <user-supplied>
+
+**ANTIBODY**: <user-supplied>
+
+**GOTCHA**: <user-supplied>
+
+**Reference**: <user-supplied>
+```
+
+Icon mapping: P0=🚨, P1=⚠️, P2=⚠️, P3=ℹ️, RESOLVED=✅, INFO=ℹ️.
+
+4. Append via Bash heredoc (bypass Write hook for cicatrix path — appends are allowed, not destructive):
+
+```bash
+cat >> ~/nuzantara/.claude/rules/cicatrix-scars.md <<'SCAREOF'
+<entry>
+SCAREOF
+```
+
+5. Propagate to worktrees: `cp ~/nuzantara/.claude/rules/cicatrix-scars.md <worktree>/.claude/rules/cicatrix-scars.md` (inode-independent).
+
+6. Append audit log:
+
+```bash
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ')|<severity>|<description>" >> ~/.claude/state/scar-audit.log
+```
+
+7. **NO git commit** — operator commits manually.
+
+## Anti-pattern
+
+- Inventare scar senza evidenza empirica (anti-hallucination)
+- Auto-commit (rischio commit accidentale + cross-branch pollution)
+- Skipping audit log (rende impossibile reconciliation post-fact)

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,40 @@
+---
+name: verify
+description: Empirical verification — file exists / command exit / value present / process / URL. Anti-hallucination enforcement (2026-05-13).
+---
+
+> **CANON**: repo `.claude/` (vendored 2026-07-17, PR process-toolkit SSOT) — shadows the `~/.claude/` HOME copy. Edit HERE, never in `$HOME`. Pro/Mini shadow it on `git pull`.
+
+# /verify $ARGUMENTS
+
+Per-command contract (T3.4 panel amendment):
+
+- **Side effects**: ZERO. Read-only. NO writes, NO state mutation.
+- **Input schema**: free-form target. Infer type from shape (path / cmd / "X exists" / URL).
+- **Failure mode**: report PARTIAL with reason, never fabricate.
+- **Audit**: none required (no mutation).
+
+## Steps
+
+Esegui ADESSO la verifica empirica del target `$ARGUMENTS`. NOT da memoria/context.
+
+Infer target type:
+
+- File path (starts with `/` or `~`) → `ls -la <path>` + report size, perms, mtime
+- Command verbatim (contains spaces + verbs) → execute + report exit code + first/last 10 lines stdout
+- String/value lookup ("X in file Y") → grep
+- Process name ("process X running") → `ps aux | grep -v grep | grep <name>` + count
+- URL (starts with http) → `curl -sI -m 5 <url>` + HTTP status
+
+## Output format
+
+```
+VERIFY <target>:
+- Status: PASS | FAIL | PARTIAL
+- Evidence: <command output verbatim, single line if possible>
+- Anomalie: <list, empty if none>
+```
+
+## Anti-pattern (anti-hallucination 2026-05-13 rule 1)
+
+NEVER cite output da context buffer. SOLO da tool call eseguito IN QUESTO turn. Se dubbio "ho letto o sto inventando" → re-eseguire tool.

--- a/.claude/skills/agent-session-discipline/SKILL.md
+++ b/.claude/skills/agent-session-discipline/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: agent-session-discipline
+description: Use at session start when working on a feature/fix that involves code changes. Creates an isolated worktree via L1 broker (scripts/agent_start.py) to prevent sibling-orphan stash and cross-agent collisions. Prerequisite for any commit/push workflow.
+---
+
+> **CANON**: repo `.claude/` (vendored 2026-07-17, PR process-toolkit SSOT) — shadows the `~/.claude/` HOME copy. Edit HERE, never in `$HOME`. Pro/Mini shadow it on `git pull`.
+
+# Agent Session Discipline (L5.1)
+
+## When to invoke
+
+- User asks "implement X" / "fix Y" / "add feature Z"
+- About to write code that will be committed
+- After session start in main checkout (`cwd = ~/nuzantara`)
+- When SessionStart hook surfaces "Strongly recommended before any git mutation OR file write"
+- After observing high alive-AI-process count + sibling-orphan stash count
+
+## What to do
+
+### Step 1 — Pick a lane
+
+From L1 allowlist (defined in `scripts/agent_start.py` KNOWN_LANES):
+
+`wr2 wr3 infra docs db cicatrix-fix mouth intel cell organism mata-garuda backend-rag frontend ops`
+
+If your task doesn't fit, use `ops` as fallback or `--allow-unknown-lane` flag.
+
+### Step 2 — Generate task-id
+
+Short kebab-case, ~3 words max. Examples:
+
+- `kg-bridge-s16`
+- `drive-metadata`
+- `workflow-l5-1`
+- `wa-copilot-fix-x`
+
+Pattern: `^[a-z0-9][a-z0-9\-]{0,63}$` (lowercase, digits, dash).
+
+### Step 3 — Create worktree
+
+```bash
+python scripts/agent_start.py --lane <lane> --task-id <task-id> --ttl-min 120
+```
+
+Output: `WORKTREE_READY ~/nuzantara/.worktrees/<lane>-<task-id>`
+
+Effects:
+
+- Branch `agent/<host>/<lane>/<task-id>` created from `--base-branch` (default `main`)
+- Worktree mounted at the path
+- Symlinks: `apps/backend-rag/.venv`, `apps/backend-rag/.env`, `node_modules/` (env-safe)
+- `.agent-task.json` metadata file (task_id, lane, branch, host, created_at, ttl_minutes, pid)
+
+### Step 4 — Use the worktree path
+
+Bash tool resets cwd between calls. To work in worktree:
+
+- **git commands**: use `git -C /path/to/worktree ...`
+- **file paths**: use absolute paths starting with `~/nuzantara/.worktrees/<lane>-<task-id>/`
+- **Don't** try to `cd` and persist — won't work
+
+Verify periodically:
+
+```bash
+git -C ~/nuzantara/.worktrees/<lane>-<task-id> status --short
+```
+
+### Step 5 — Implementation workflow
+
+In the worktree:
+
+1. Read existing code, memory (`mem recent`), cicatrix (`grep` `.claude/rules/cicatrix-scars.md`)
+2. Plan changes (use Plan tool if architectural, dispatch 4-LLM panel if cross-cutting)
+3. Write/Edit files (all absolute paths starting with worktree path)
+4. Test (pytest scope-relative)
+5. Commit (`git -C <worktree> commit -m "feat(scope): subject"` with `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`)
+6. Push (`git -C <worktree> push -u origin <branch>`)
+
+### Step 6 — Session end
+
+When task complete:
+
+```bash
+# Open PR
+gh pr create --draft --base main --head agent/<host>/<lane>/<task-id> --title "..." --body "..."
+
+# Release worktree (after merge)
+python scripts/agent_start.py --release <task-id>
+```
+
+If WIP not yet committed:
+
+```bash
+git -C /path/to/worktree stash push -u -m "session-end-<task-id>-wip"
+# (worktree stays alive until --release or --cleanup TTL expiry)
+```
+
+## Common pitfalls
+
+| Pitfall                                         | Avoidance                                                                                               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Forgetting to use `git -C`                      | Always prefix every git command with `-C /path/to/worktree`                                             |
+| Writing to main checkout accidentally           | Use absolute paths starting with worktree path; PreToolUse hook will block otherwise                    |
+| `cd /worktree && git ...` doesn't persist       | Bash tool resets cwd; use `git -C` instead                                                              |
+| Husky pre-commit fails for missing node_modules | Symlink from main: `ln -sfn ~/nuzantara/node_modules ~/nuzantara/.worktrees/<wt>/node_modules`          |
+| Husky pre-commit fails for typecheck            | Same: `ln -sfn ~/nuzantara/apps/mouth/node_modules ~/nuzantara/.worktrees/<wt>/apps/mouth/node_modules` |
+| Prettier auto-formats .md commits               | Run `npx prettier --write <file>` BEFORE `git add` to avoid retry                                       |
+
+## Emergency escape
+
+When hooks block legitimate work:
+
+```bash
+export AGENT_WORKTREE_ENFORCEMENT=false  # disable for whole session
+```
+
+Use sparingly. The escape is logged in `/tmp/nuz_l5_1_blocks`.
+
+## Reference
+
+- L1 broker spec: `docs/runbooks/agent-worktree-broker.md`
+- L2 lease spec: `docs/runbooks/redis-lease-registry.md`
+- L5.1 spec: `research/operations/specs/L5.1-agent-worktree-enforcement-2026-05-25.md`
+- Panel synthesis: `research/operations/specs/L5.1-panel-synthesis-2026-05-25.md`
+- Hook code: `~/.claude/hooks/worktree_isolation.py` + `worktree_file_write_check.py`
+- Cicatrix family: 2026-04-29 #1+#2, W50/W51/W52, sibling-orphan-2026-05-25-\*

--- a/.claude/skills/karpathy-discipline/SKILL.md
+++ b/.claude/skills/karpathy-discipline/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: karpathy-discipline
+description: Use BEFORE any feature implementation, refactor, bug fix, or non-trivial code change. Applies 4 Karpathy principles to reduce common LLM coding mistakes (silent assumptions, hypertrophy, collateral changes, vague success criteria).
+allowed-tools: Read, Edit, Write, Bash(git diff:*), Bash(git status:*), Bash(grep:*), Bash(rg:*)
+---
+
+> **CANON**: repo `.claude/` (vendored 2026-07-17, PR process-toolkit SSOT) — shadows the `~/.claude/` HOME copy. Edit HERE, never in `$HOME`. Pro/Mini shadow it on `git pull`.
+
+# Karpathy Discipline
+
+Source: `forrestchang/andrej-karpathy-skills` (109K+ ⭐). Verbatim from canonical CLAUDE.md.
+
+**Tradeoff dichiarato**: _"These guidelines bias toward caution over speed. For trivial tasks, use judgment."_
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+**The test**: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if**: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+---
+
+## Nuzantara-specific applications
+
+(Per CLAUDE.md project context)
+
+- **Think Before Coding** → si combina con regola 2026-05-13 "4-LLM panel review BEFORE user approval" per spec ad alto stakes
+- **Simplicity First** → applicato in fix MEMORY.md 60.6KB→13.8KB (2026-05-19)
+- **Surgical Changes** → riflette cicatrix-scars rule "atomic commits, no `--no-verify`, no `--amend` on pushed"
+- **Goal-Driven Execution** → richiede TaskCreate/TaskUpdate + acceptance criteria in spec

--- a/.claude/skills/reuse-first/SKILL.md
+++ b/.claude/skills/reuse-first/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: reuse-first
+description: Use BEFORE implementing/building/writing-from-scratch any non-trivial component (queue, OCR, adapter, entity-resolution, review-UI, scraper, parser, etc.). Codifies "search for working code others already wrote before writing your own — adapt, don't reinvent". TRIGGER on every "implementa / costruisci / scrivi da zero / build / let's add X" where X is a buildable component, not a one-liner. Born from a real session where searching GitHub revealed ~70% of a document-intake system was already written by others (text-extract-api, paperless-gpt, pgqueuer, splink, instructor).
+allowed-tools: Read, Edit, Write, Bash, WebSearch, WebFetch
+---
+
+> **CANON**: repo `.claude/` (vendored 2026-07-17, PR process-toolkit SSOT) — shadows the `~/.claude/` HOME copy. Edit HERE, never in `$HOME`. Pro/Mini shadow it on `git pull`.
+
+# Reuse-First — codice prima di scrivere
+
+**Principio**: prima di implementare X, cerca chi ha già fatto X. Adatta, non reinventare.
+
+La domanda d'apertura non è _"come lo scrivo?"_ ma _"chi l'ha già scritto, e quanto ne posso prendere?"_.
+Quasi sempre la risposta è: più di quanto pensi. Settimane di lavoro evaporano quando scopri che il
+70% del sistema esiste già, testato, in repo di altri.
+
+**Tradeoff dichiarato**: questa skill costa 10-30 min di ricerca up-front. Per task triviali (un
+helper di 10 righe, un rename, un fix con causa nota) → salta, usa giudizio. È per i componenti
+_buildabili_: roba che altrimenti ti porteresti via giorni.
+
+---
+
+## La procedura (7 passi)
+
+### 1. Scomponi in mattoni
+
+Prima di cercare, decomponi la cosa da costruire nei suoi componenti atomici. Non cerchi
+"document-intake system" (troppo vago) — cerchi i mattoni: `queue`, `OCR adapter`, `entity
+resolution`, `review UI`, `structured extraction`. Ogni mattone è una query di ricerca distinta.
+
+### 2. Doppia ricerca per ogni mattone
+
+Per OGNI mattone, due ricerche indipendenti:
+
+- **(a) Dentro il repo nostro** — riuso interno. `grep`/`rg` per funzioni/classi/pattern che già
+  risolvono il mattone. Spesso un collega-sessione l'ha già scritto. Costo zero, licenza nostra.
+- **(b) Repo di ALTRI su GitHub** — riuso esterno. Due sotto-categorie:
+  - _repo-applicazione_ che risolvono lo stesso problema end-to-end (es. `paperless-gpt`, `text-extract-api`)
+  - _librerie_ per il singolo mattone (es. `pgqueuer` per la coda, `splink` per entity-resolution, `instructor` per structured output)
+  - Strumenti: `WebSearch "<mattone> site:github.com"`, poi `WebFetch` su README / struttura repo / file chiave per capire cosa fa davvero e come.
+
+### 3. Classifica ogni trovato
+
+Per ogni candidato, assegna UNA etichetta:
+
+| Etichetta                     | Quando                                           | Azione                                              |
+| ----------------------------- | ------------------------------------------------ | --------------------------------------------------- |
+| **[COPIA-DIRETTO]**           | file/funzione self-contained, licenza permissiva | vendora con attribuzione                            |
+| **[FORKA-E-ADATTA]**          | repo-app vicino al bisogno, licenza permissiva   | forka, taglia il superfluo, adatta ai vincoli       |
+| **[STUDIA-PATTERN-RISCRIVI]** | il codice è GPL/AGPL ma il _pattern_ è buono     | leggi, capisci, **ri-scrivi da zero** — MAI copiare |
+| **[INSTALLA-LIB]**            | libreria matura risolve il mattone               | aggiungi a dependencies, non scrivere niente        |
+| **[SCRIVI-NUOVO]**            | nient'altro regge — ultima scelta, non la prima  | scrivi, ma documenta _perché_ niente andava bene    |
+
+### 4. GATE LICENZE (load-bearing — non saltabile)
+
+Prima di copiare **una sola riga** nel repo, verifica la licenza:
+
+- **MIT / Apache-2.0 / BSD** → vendorabile nel repo CON attribuzione (header + NOTICE).
+- **GPL / AGPL / LGPL-strong** → **SOLO leggere il pattern e ri-scrivere**. Copiarne anche un frammento
+  nel nostro repo lo **contamina** (copyleft = obbligo di rilasciare tutto con quella licenza). → `[STUDIA-PATTERN-RISCRIVI]`.
+- **Nessuna LICENSE** (repo senza file licenza) → default = "all rights reserved" → **non copiabile**.
+  Si può solo leggere per ispirazione, non importare.
+- In dubbio → tratta come non-copiabile finché non hai verificato. Verifica SEMPRE, mai presumere "tanto è open".
+
+### 5. Valuta maturità
+
+Un repo trovato ≠ un repo da usare. Controlla:
+
+- **Stelle** + **ultima commit** (abbandonato >12-18 mesi = diffida) + **issue/PR aperte** (segnale di bug noti irrisolti).
+- **Demo vs produzione**: tanti repo sono prove-di-concetto belle in README e rotte in pratica.
+- **Cloud-only quando serve locale**: se il repo presume un servizio cloud/paid e a te serve local/PII
+  → non scartare a priori (vedi passo 6), ma sappi che dovrai sostituire quel layer.
+
+### 6. Adatta ai vincoli nostri
+
+Il repo di altri non conosce i nostri vincoli. Adatta:
+
+- **PII locale (Symbiosis Law 2)** — i dati intelligence/cliente non escono dal Pro. Un repo che manda
+  testo a un'API cloud va riscritto per girare local (Ollama, asyncpg locale).
+- **No paid API** — niente chiavi a pagamento (vedi CLAUDE.md). Sostituisci OpenAI→Ollama/embeddings local dove serve.
+- **Stack nostro** — `asyncpg` non `psycopg2`, `httpx` async non `requests`, Ollama per LLM/vision, Mac/arm64.
+- **Regola chiave**: un repo cloud-only **non si scarta**, si riscrive il layer-cloud in locale — _se il
+  PATTERN sottostante è buono_. Il valore è il pattern, non l'implementazione del trasporto.
+
+### 7. Documenta la provenienza
+
+Per ogni pezzo riusato, traccia: **da quale repo, quale licenza, quale file/commit**. In un header,
+un commento, o un `PROVENANCE.md`. Serve per: audit licenze, aggiornamenti upstream, e onestà
+intellettuale. Tracciabilità non opzionale.
+
+---
+
+## Mini-esempio reale (la sessione che ha generato questa skill, 2026-06-04)
+
+Task: costruire un sistema di **document-intake** (akta/visa docs → estrazione → CRM). Reazione
+istintiva: "scrivo coda + OCR + parser + dedup + UI". Reazione corretta: scomponi e cerca.
+
+| Mattone                   | Trovato (altri)    | Esito                                         |
+| ------------------------- | ------------------ | --------------------------------------------- |
+| OCR/extract               | `text-extract-api` | [FORKA-E-ADATTA] — local, no cloud            |
+| pipeline doc→LLM          | `paperless-gpt`    | [STUDIA-PATTERN-RISCRIVI] — pattern di intake |
+| coda su Postgres          | `pgqueuer`         | [INSTALLA-LIB] — già asyncpg-native           |
+| entity resolution / dedup | `splink`           | [INSTALLA-LIB]                                |
+| structured LLM output     | `instructor`       | [INSTALLA-LIB]                                |
+
+Risultato: **~70% già scritto da altri**. Settimane → giorni. Il codice nuovo si è ridotto al collante
+e all'adattamento ai vincoli (PII local, asyncpg, Ollama).
+
+---
+
+## Anti-pattern (riconoscili e fermati)
+
+- **Reinventare per orgoglio** — "lo scrivo meglio io". Quasi mai vero per mattoni standard (code,
+  OCR, dedup). Il tempo speso a riscrivere è tempo rubato al problema vero (i _nostri_ vincoli).
+- **Copiare GPL/AGPL nel repo** — contamina la licenza dell'intero progetto. SEMPRE [STUDIA-PATTERN-RISCRIVI]
+  per copyleft, mai copia-incolla.
+- **Adottare una lib cloud per dati PII** — viola Law 2. Un default OpenAI/cloud non si accetta solo
+  perché "è il README ufficiale". Riscrivi il layer in local o scarta.
+- **Clonare repo morti** — demo abbandonate (ultima commit 2 anni fa, 30 issue aperte) costano più del
+  green-field. Maturità prima dell'entusiasmo.
+- **Saltare il gate licenze** — "tanto è su GitHub, è open" è falso: no-LICENSE = all-rights-reserved.
+  Verifica sempre prima di importare.
+- **Cercare il sistema intero invece dei mattoni** — query troppo larghe non trovano niente. Scomponi (passo 1).
+
+---
+
+## Integrazione con le altre skill
+
+- Gira **dentro lo STEP 1 GROUND** di `sota-architecture-loop`: "lo stato esterno ai tuoi priors"
+  include _anche il codice che altri hanno già scritto_, non solo NB/web.
+- Complementare a `karpathy-discipline` §2 (Simplicity First): il codice più semplice è spesso quello
+  che non scrivi affatto perché esiste già.

--- a/.claude/skills/skill-catalog/SKILL.md
+++ b/.claude/skills/skill-catalog/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: skill-catalog
+description: Use when a user request does NOT match any currently-loaded skill — BEFORE answering "I don't have a skill for that". The full Claude Code skill ecosystem (Tier 2/3 + hundreds of community skills) is NOT all installed; their descriptions are catalogued in the MOS, not in context. This skill tells you to query the MOS catalog and install the right skill on-demand.
+---
+
+> **CANON**: repo `.claude/` (vendored 2026-07-17, PR process-toolkit SSOT) — shadows the `~/.claude/` HOME copy. Edit HERE, never in `$HOME`. Pro/Mini shadow it on `git pull`.
+
+# Skill Catalog — on-demand skill discovery
+
+**The problem this solves**: Claude Code loads ALL installed skill descriptions into context at session start. To avoid context bloat (the orchestration-decay 8→0 regression), only Tier-1 skills + a curated few are installed. Everything else lives in the **MOS catalog** — searchable, zero context cost until queried.
+
+## When to use
+
+- A request doesn't match any loaded skill in your list.
+- Before saying "no skill for that" or improvising.
+- When the user asks about a domain you suspect has a dedicated skill (deploy checklist, incident response, RAG tuning, document generation, marketing, etc.).
+
+## How (the on-demand cascade)
+
+1. **Query the MOS catalog** (two verified paths — the prefix string `SKILL-CATALOG` itself breaks FTS5 because of the hyphen, so query by DOMAIN not by prefix):
+
+   ```bash
+   # a) by domain/intent — FTS5 keyword (e.g. "sandbox", "python", "video", "security", "trailofbits")
+   ~/.claude/scripts/mem query "<domain keyword>"
+
+   # b) full catalog dump — deterministic LIKE (use when "show me everything available")
+   sqlite3 -header -column ~/.claude/memory.db \
+     "SELECT id, importance, content FROM memories WHERE content LIKE 'SKILL-CATALOG%' ORDER BY importance DESC;"
+   ```
+
+   Catalog entries are `pattern`-type, prefixed `SKILL-CATALOG:` (or `SKILL-CATALOG-WARN:` for ones that should NOT be installed) with name + 1-line + install command.
+
+2. **If a match is found** → install it at the moment of need:
+
+   ```
+   /plugin install <plugin>@<marketplace>      # for plugin-hosted skills
+   # or for repo-hosted: git clone <repo> /tmp/x && audit SKILL.md && cp to ~/.claude/skills/
+   ```
+
+   Then `/reload-plugins`. The skill is now loaded and triggers.
+
+3. **If no catalog match** → it's genuinely uncatalogued. Say so honestly, and optionally propose researching + cataloguing it.
+
+## Discipline (anti-sprawl, the whole point)
+
+- **NEVER pre-install Tier 2/3 in bulk** — that re-creates the context bloat this skill exists to prevent.
+- **Install on-demand, use, then consider disabling** if it was a one-off (`/plugin` disable keeps it catalogued but out of context).
+- The MOS catalog is the source of truth for "what skills EXIST but aren't loaded". Keep it current: when you research a new skill worth knowing, `mem save pattern "SKILL-CATALOG: <name> — <1-line> — install: <cmd>" <importance>`.
+
+## Tiering (loaded vs catalogued)
+
+- **Tier 1 (installed, always loaded)**: security (trailofbits static-analysis/differential-review/second-opinion, security-guidance), qdrant, claude-md-management, + the Nuzantara custom DIR skills.
+- **Tier 2 (installed selectively)**: engineering@knowledge-work-plugins (incident-response, deploy-checklist, etc.).
+- **Tier 3+ (catalogued in MOS, NOT installed)**: everything else — query the catalog to find + install on-demand.
+
+Reference: `research/operations/2026-05-31-global-claude-skills-study.md`, lesson `feedback_orchestration_first.md` (the decay this prevents).

--- a/.claude/skills/sota-architecture-loop/SKILL.md
+++ b/.claude/skills/sota-architecture-loop/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: sota-architecture-loop
+description: Use BEFORE architecting code, designing a feature, or making a structural/architectural decision. Evidence-backed 8-step loop (frame → ground → reason → council → decision-gate → execute → verify → capture) that improves on a naive 'reason → council → research → brainstorm' loop. Decides WHEN to invoke the multi-LLM council vs single-orchestrator, and runs review as asymmetric-adversarial (never consensus). Orchestrator-agnostic: works whether Claude, Codex, or Gemini drives.
+allowed-tools: Read, Write, Edit, Bash, Skill, Agent, WebFetch
+---
+
+> **CANON**: repo `.claude/` (vendored 2026-07-17, PR process-toolkit SSOT) — shadows the `~/.claude/` HOME copy. Edit HERE, never in `$HOME`. Pro/Mini shadow it on `git pull`.
+
+# SOTA Architecture Loop
+
+Procedura per architettura codice + feature design con orchestrazione multi-LLM.
+Evidence-backed (paper 2024-2026), non opinione. Fonti + verifica in
+`research/operations/2026-05-30-sota-ai-architecture-methodology.md`.
+
+**Tre regole da cui tutto deriva** (verificate, vedi research file):
+
+> Eterogeneità batte numerosità · Adversarialità calibrata batte consenso · Verifica esterna batte autodichiarazione.
+
+---
+
+## Il loop (8 step)
+
+```
+0. FRAME      Orchestratore solo. Decomponi: deciso / da-decidere / vincoli. 1 spec scheletro.
+1. GROUND     Verità ESTERNA ai priors, PRIMA di ragionare. La fonte dipende dal dominio:
+              · normativo/fattuale → NotebookLM (NB) + deep research
+              · INTERNO al repo (infra, codice, cron, debt) → disk-state: ls/Read/grep/git/launchctl/log
+2. REASON     Orchestratore reasoning sui fatti del passo 1 (mai sul training).
+3. COUNCIL    SOLO se il gate sotto dice sì. Eterogeneo + asimmetrico. Mai consenso, mai cloni.
+4. DECISION   Kill gate: go / no-go / defer + 1 metrica falsificabile.
+5. EXECUTE    TDD, worktree isolato (agent_start.py), commit atomici.
+6. VERIFY     Adversariale + EMPIRICO esterno (Codex sandbox / pytest / verify skill).
+7. CAPTURE    Scar/lesson (cicatrix-scars.md / mem save).
+```
+
+**Perché ground PRIMA di reason/council**: se ragioni sui priors di training, allucini (KBLI, normativa, API)
+— o ragioni su una premessa STALE (una cicatrix che dice "non esiste X" quando X è stato shippato ieri).
+Il ground non è solo RAG: è qualunque verità esterna ai tuoi priors. Per un dominio normativo = NB+web;
+per un debt interno = lo STATO DEL DISCO (lo script esiste già? il cron passa davvero `--apply`? cosa dice
+il log?). RAG è il grounding #1 per fatti esterni; `ls`/`Read`/`git`/`launchctl` lo è per fatti interni.
+**Test empirico W62 (2026-05-30)**: questo step ha ucciso una feature fantasma in 3 tool call — la cicatrix
+diceva "fix NOT shipped", il disco diceva "shippato ma disarmato da un flag mancante". Mai fidarsi del
+ricordo (proprio o di una cicatrix): verifica lo stato reale prima di progettare.
+
+---
+
+## STEP 3 — Quando convocare il council (e quando NO)
+
+Il council multi-LLM costa **~15× i token** di un singolo agente (dato Anthropic). Non è gratis e
+spesso NON migliora. Convocalo **solo se TUTTE e tre vere**:
+
+1. **Priors diversi possono cambiare la risposta.** La domanda dipende da conoscenza dove
+   modelli con training diverso divergono (normativa, regolamenti, fatti recenti, API esterne).
+   Se la decisione è meccanica/deducibile dai fatti groundati → 3 LLM convergono → paghi 15× per conferma.
+2. **L'errore costa più di 15× token.** Pre-deploy critical path, migration, quote cliente,
+   decisione architetturale irreversibile, spesa reale. Se rollback è gratis → non serve.
+3. **Il lavoro è davvero parallelo / breadth.** Più angoli indipendenti da coprire insieme.
+   (Anthropic: il multi-agente vince su _research_, MA "coding ha meno task parallelizzabili".)
+
+### Tabella decisione
+
+| Situazione                                                        | Council? | Cosa fare invece                                       |
+| ----------------------------------------------------------------- | -------- | ------------------------------------------------------ |
+| Decisione architetturale irreversibile (DB schema, auth, billing) | ✅ SÌ    | council eterogeneo asimmetrico                         |
+| Quote cliente / spec con numeri normativi                         | ✅ SÌ    | + NB-1/4/5 come 4° panelist ground-truth               |
+| Pre-deploy critical path                                          | ✅ SÌ    | red team obbligatorio (cf. federation triggers)        |
+| Feature isolata, fatti già groundati, rollback facile             | ❌ NO    | orchestratore-solo + più budget reasoning + 1 red-team |
+| Refactor lineare 1-2 file                                         | ❌ NO    | orchestratore-solo + 1 spalla (un LLM ≠) sul diff      |
+| Bug fix con causa nota                                            | ❌ NO    | systematic-debugging skill, no council                 |
+| Task meccanico (format, lint, rename)                             | ❌ NO    | esegui e basta                                         |
+
+### Anti-pattern del council (evidence-backed)
+
+- **N-cloni dello stesso modello** = groupthink. Su 7-8B il debate omogeneo collassa: sycophancy
+  fino 85.5%, abbandona risposte corrette fino 70%, e un _singolo_ agente con 10× budget lo batte
+  a 1/3 del costo. → Council **solo eterogeneo** (modelli con training diverso: Claude / Gemini / DeepSeek / Codex), mai N-cloni dello stesso modello (es. Claude×3 o Codex×3).
+- **Panel grande + tanti round** = più conformity. Shrink maggioranza 6→3 dimezza il conformity;
+  1→5 round lo alza. → 3 panelisti, round cappati (adaptive stop), non "discutete finché concordate".
+- **Council prima dei fatti** = ragiona su allucinazioni. → sempre dopo STEP 1.
+
+---
+
+## STEP 3/6 — Review adversariale asimmetrica (cos'è davvero)
+
+**Il consenso è la cosa SBAGLIATA.** Davanti a una maggioranza errata gli LLM non solo cedono —
+**fabbricano reasoning** per giustificare il cambio (conformity → hallucination, verificato).
+"Siete tutti d'accordo?" non nasconde solo l'errore: ne _genera di nuovi_. Mai chiudere per consenso.
+
+"Asimmetrica" = due assi distinti (è qui che si sbaglia):
+
+### Asse 1 — asimmetria di RUOLO (chi fa cosa)
+
+Nessuno valuta sé stesso. Tre ruoli separati, **ognuno su un LLM DIVERSO** (è il _diverso_ che conta,
+non quale — l'orchestratore può essere Claude o Codex a seconda di chi guida la sessione):
+
+| Ruolo           | Compito                                                                                                                      | Vincolo                                           |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| **Proponente**  | produce la tesi / il diff / la spec                                                                                          | è l'agente/LLM che sta lavorando — chiunque guidi |
+| **Red-team**    | prova a DISTRUGGERE: buco legale, numero sbagliato, regolazione mancante, contraddizione frase-A vs frase-B, KBLI allucinato | LLM ≠ proponente                                  |
+| **Costruttivo** | NON distrugge: prova a SALVARE migliorando — edge case, naming, semplificazione                                              | LLM ≠ proponente, idealmente ≠ red-team           |
+
+**Regola vincolante: i tre ruoli su tre modelli diversi** (priors di training diversi = il valore).
+Quali modelli è secondario e fungibile. Se Codex orchestra, allora proponente=Codex, e
+red-team/costruttivo vanno su Claude + Gemini + DeepSeek (qualsiasi due ≠ Codex). Se Claude orchestra,
+red-team/costruttivo su Gemini/DeepSeek/Codex. **Anti-pattern: proponente e critico sullo stesso modello**
+(auto-approvazione mascherata).
+
+Il giudizio finale è di **chi orchestra** (l'LLM lead, chiunque sia) o un gate empirico (STEP 6),
+**mai** del proponente quando proponente = orchestratore: in quel caso il verdetto lo dà il gate empirico.
+
+### Asse 2 — asimmetria di INCENTIVO (come sono premiati)
+
+Il prompt deve invertire l'incentivo, altrimenti collassano sul "sì, ottimo":
+
+- **Red-team premiato se TROVA un difetto**, non se conferma. Prompt: _"Default a 'difettoso' se
+  hai dubbi. Il tuo lavoro è trovare il flaw, non approvare. Se non trovi nulla, cerca più a fondo."_
+- **Costruttivo premiato se SALVA l'idea** migliorandola, non se la elogia. Prompt: _"Assumi che
+  l'idea vada fatta; il tuo compito è renderla difendibile, non giudicarla."_
+- **Mai** un prompt simmetrico "valuta questa proposta" → produce sycophancy.
+
+### Calibrazione (non puro-adversariale, non puro-consenso)
+
+Il debate batte la self-reflection perché evita la "Degeneration-of-Thought" (un modello sicuro
+di sé non genera pensieri nuovi). MA troppa adversarialità degrada quanto il consenso. Mix ottimale =
+**1 troublemaker forte (red-team) + 1 peacemaker (costruttivo)**, non 4 che si massacrano né 4 che annuiscono.
+
+### Chiusura: gate empirico, non autodichiarazione
+
+Il segnale "fatto/solved" dell'agente è inaffidabile (gli agent marcano risolte cose che non lo sono).
+→ STEP 6 chiude con **prova esterna**: `pytest`, Codex sandbox, `verify` skill, curl 200.
+Mai "è finito" detto dall'agente che l'ha fatto. (cf. cicatrix premature-completion.)
+
+---
+
+## Mapping rapido sullo stack
+
+> "L'orchestratore" = l'LLM che guida la sessione (Claude **o** Codex **o** Gemini). I nomi qui sotto
+> sono i candidati abituali per ruolo, non assegnazioni fisse. La sola regola dura: nel COUNCIL e nella
+> review, i ruoli stanno su modelli **diversi tra loro**.
+
+| Step       | Strumento / chi                                                                                                                                                                                                                        |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0 FRAME    | orchestratore + `karpathy-discipline` skill                                                                                                                                                                                            |
+| 1 GROUND   | normativo/fattuale: `notebook_query` (NB) + `deep-research` / `federation_orchestrator search`. INTERNO: `ls`/`Read`/`grep`/`git worktree list`/`launchctl print`/tail log — lo stato del disco È il ground                            |
+| 2 REASON   | orchestratore                                                                                                                                                                                                                          |
+| 3 COUNCIL  | fan-out su ≥3 modelli diversi (pool: Claude, Gemini/agy, DeepSeek, Codex). 1 red-team (`devils-advocate`) + 1 costruttivo (`spalla`/`codex-second-opinion`); NB-dominio come ground-truth panelist se UUID noto. Ruoli ≠ orchestratore |
+| 4 DECISION | orchestratore — go/no-go/defer + metrica (Symbiosis L7)                                                                                                                                                                                |
+| 5 EXECUTE  | `agent_start.py` worktree + `test-driven-development` skill                                                                                                                                                                            |
+| 6 VERIFY   | gate empirico esterno: `pytest` / Codex sandbox / `verify` skill / curl 200 — indipendente da chi ha scritto                                                                                                                           |
+| 7 CAPTURE  | `scar` skill / `mem save`                                                                                                                                                                                                              |
+
+## Scorciatoie (NON è dogma)
+
+- Task triviale → salta al solo STEP 5-6. Il loop completo è per decisioni che pesano.
+- Già groundato in sessione → non rifare STEP 1.
+- Dominio puramente creativo (non fattuale) → STEP 1 conta meno; lì reason-prima può andare.
+- **Debt interno / "sistemiamo X"** → STEP 1 = disk-state, NON RAG. Prima domanda sempre: "X esiste già?
+  funziona davvero?". NB/web qui sono rumore. (W62: la feature esisteva ma girava disarmata.)

--- a/.gitignore
+++ b/.gitignore
@@ -537,7 +537,19 @@ openclaw
 !.claude/agents/frontend-browser.md
 !.claude/agents/mcp-health.md
 !.claude/agents/spalla-review.md
+# 2026-07-17: slash commands hold PER-PERSON team corners (subhi/ari/... with
+# probation dates, RBAC perimeters) that live ONLY in ~/.claude/commands and must
+# NEVER reach this PUBLIC repo (UU PDP / SYMBIOSIS Law 2). !.claude/commands/ nudo
+# would track any corner dropped into the repo dir — same red-team finding #8 as
+# agents. Narrow to an explicit per-file allowlist: only vetted process/utility
+# commands. Update this list ONLY when deliberately vendoring a non-PII command.
 !.claude/commands/
+.claude/commands/*
+!.claude/commands/codex-second-opinion.md
+!.claude/commands/stadio-zero.md
+!.claude/commands/scar.md
+!.claude/commands/verify.md
+!.claude/commands/resume.md
 !.claude/scripts/
 !.claude/hooks/
 !.claude/rules/

--- a/INDEX.md
+++ b/INDEX.md
@@ -151,8 +151,13 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 <!-- DOCSYNC:SKILLS_INDEX_START -->
 | Skill | Description (truncated) |
 | ----- | ----------------------- |
+| `.claude/skills/agent-session-discipline/` | Use at session start when working on a feature/fix that involves code changes. Creates an isolated worktree via L1 broker (scripts/agent_start.py) to prevent... |
+| `.claude/skills/karpathy-discipline/` | Use BEFORE any feature implementation, refactor, bug fix, or non-trivial code change. Applies 4 Karpathy principles to reduce common LLM coding mistakes (sil... |
 | `.claude/skills/kbli-navigator/` | "KBLI Navigator corner — the live shared context for ALL KBLI corpus/product work (dataset, gold, KG, editorial, kbli pages on balizero.com). Load BEFORE tou... |
 | `.claude/skills/modus/` | USE FOR EVERY non-trivial mandate — feature, fix, refactor, research, audit, ops, content — coding or not. The master operating loop of the organism: TRIAGE ... |
+| `.claude/skills/reuse-first/` | Use BEFORE implementing/building/writing-from-scratch any non-trivial component (queue, OCR, adapter, entity-resolution, review-UI, scraper, parser, etc.). C... |
+| `.claude/skills/skill-catalog/` | Use when a user request does NOT match any currently-loaded skill — BEFORE answering "I don't have a skill for that". The full Claude Code skill ecosystem (T... |
+| `.claude/skills/sota-architecture-loop/` | Use BEFORE architecting code, designing a feature, or making a structural/architectural decision. Evidence-backed 8-step loop (frame → ground → reason → coun... |
 <!-- DOCSYNC:SKILLS_INDEX_END -->
 
 ### LaunchAgents — copertura documentale


### PR DESCRIPTION
## What

Vendor the **non-PII process toolkit** into the repo as single-source-of-truth, and **harden the `.claude/commands/` gitignore allowlist** so per-person team corners can never leak to this PUBLIC repo.

### Vendored (were HOME-only forks in `~/.claude`, drifting silently per machine)
- Commands: `scar`, `verify`, `resume`
- Skills: `sota-architecture-loop`, `reuse-first`, `karpathy-discipline`, `skill-catalog`, `agent-session-discipline`

Repo `.claude/` shadows the `~/.claude` HOME copy (proven for agents in #2544) → Pro/Mini pick these up on `git pull`; future edits propagate via git instead of being hand-copied.

### Security hardening (the load-bearing change)
`.claude/commands/` was blanket-allowlisted (`!.claude/commands/`). Any per-person corner (`subhi.md`, `ari.md` — carrying probation dates + RBAC perimeters) dropped into the repo dir would be tracked and pushed to this **public** repo (UU PDP / SYMBIOSIS Law 2). Narrowed to an explicit **per-file allowlist** — the same red-team finding #8 pattern already applied to `.claude/agents/`.

**Verified empirically** (`git check-ignore`): `subhi.md`/`ari.md`/nested `team/subhi.md`/any unlisted `*.md` in `.claude/commands/` → IGNORED; the 5 vetted process commands → tracked. Fail-safe direction: nothing tracks unless explicitly allowlisted.

## Notes
- Re-rooted stale `~/Desktop/nuzantara` → `~/nuzantara` (canonical post-#2499) in `scar.md` + `agent-session-discipline`.
- CANON marker on every vendored file (bans HOME edit + is the precedence probe for post-merge PROVE-LIVE).
- **Excluded** `dispatch-stat.md` (hardcodes a machine-specific memory project-id) and all `.bak-drift` files.
- `INDEX.md` docsync regen folded into the same commit (W86).
- **Person/dept corners stay OUT of this public repo by design** (PII) — separate private-sync decision, deferred.

## Post-merge (session-owned)
- PROVE-LIVE: launch a session from `~/nuzantara` on M5 + Pro, invoke a vendored command/skill, confirm the CANON marker loads = repo shadows HOME (skill-shadow is proven for agents, re-verified here since "mai presumere la precedenza").
- ALIGN-FLEET: HOME copies become shadowed-stale; optional cleanup.
