### PR TITLE
fix(organism): arsenal_probe heartbeat carries probe liveness, not arsenal health

### DIFF
--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -541,9 +541,17 @@ def write_report(report: dict) -> None:
 
 
 def write_heartbeat(machine: str, degraded: bool, summary_line: str) -> None:
+    # Sidecar carries the PROBE's own health (did it run and produce a report),
+    # never the arsenal's observed health — same fix as pro.fly_restart_loop_detector
+    # (research/operations/2026-07-03-heartbeat-organs-tac.md, PR #1924): a dead AI
+    # seat is a finding, not a monitor failure, so it must not flip organs_heartbeat's
+    # UNHEALTHY_STATUSES gate. Dead seats stay visible via the dedicated arsenal_seats
+    # proprioception probe (--read-last, per-seat status) and healer Telegram on
+    # transitions — this field only ever reflects "the probe ran to completion".
     heartbeat = {
         "organ": f"{machine}.arsenal_probe",
-        "status": "degraded" if degraded else "ok",
+        "status": "ok",
+        "degraded": degraded,
         "note": summary_line,
         "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -673,14 +673,22 @@ def test_write_heartbeat_ok_status_when_not_degraded(tmp_path, monkeypatch):
     hb = json.loads((tmp_path / "m5.arsenal_probe.json").read_text())
     assert hb["organ"] == "m5.arsenal_probe"
     assert hb["status"] == "ok"
+    assert hb["degraded"] is False
     assert hb["note"] == "all fine"
 
 
-def test_write_heartbeat_degraded_status(tmp_path, monkeypatch):
+def test_write_heartbeat_status_stays_ok_when_arsenal_degraded(tmp_path, monkeypatch):
+    """The sidecar's status is the PROBE's own liveness, never the observed
+    arsenal's health (TAC 2026-07-03, same fix as pro.fly_restart_loop_detector
+    PR #1924) — a dead AI seat must not flip organs_heartbeat's UNHEALTHY_STATUSES
+    gate. The finding still travels via the `degraded` field + note, and via the
+    dedicated arsenal_seats proprioception probe."""
     monkeypatch.setattr(ap, "HEARTBEAT_DIR", tmp_path)
     ap.write_heartbeat("mini", degraded=True, summary_line="codex auth dead")
     hb = json.loads((tmp_path / "mini.arsenal_probe.json").read_text())
-    assert hb["status"] == "degraded"
+    assert hb["status"] == "ok"
+    assert hb["degraded"] is True
+    assert hb["note"] == "codex auth dead"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `write_heartbeat()` set the sidecar `status` field to `"degraded"` whenever any AI seat probe failed, which flips the generic `organs_heartbeat` proprioception gate's `HEALTHY_STATUSES` check and reports the probe organ itself as unhealthy — even though the probe ran to completion and did its job correctly.
- A dead AI seat (auth/balance/quota) is a *finding*, not a monitor failure. It's already surfaced via the dedicated `arsenal_seats` proprioception probe and `--read-last --json`.
- Fix: sidecar `status` is now always `"ok"` when the probe itself completed; the arsenal-degraded signal moves to a separate `degraded: bool` field + `note`. Same pattern as the `pro.fly_restart_loop_detector` fix in #1924.

## Context
Found live during a healer tick (Mini-Pro2, 2026-07-17): `proprioception.py` flagged `organs_heartbeat` DIVERGED with `mini.arsenal_probe: breathing but status=degraded`. This branch was already committed + pushed by a prior session but no PR was ever opened — completing that stranded work rather than redoing it.

## Test plan
- [x] `pytest scripts/tests/test_arsenal_probe.py -q` — 108 passed (includes updated `test_write_heartbeat_status_stays_ok_when_arsenal_degraded`)
- [ ] Post-merge: re-run `proprioception.py --json --no-fetch` and confirm `organs_heartbeat` no longer flags `mini.arsenal_probe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)