### PR TITLE
fix(healer): self-heal ModuleNotFoundError(yaml) in registry receptor

### DIFF
--- a/scripts/healer_receptor_registry.py
+++ b/scripts/healer_receptor_registry.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,6 +41,46 @@ from pathlib import Path
 HEALTHY_STATUSES = {"ok", "success", "healthy", "starting", "running"}
 EXEMPT_STATUSES = {"disabled"}
 DEAD_MULTIPLIER = 3
+_REEXEC_GUARD_ENV = "_HEALER_REGISTRY_REEXEC_DONE"
+# Project venvs known to carry PyYAML (see apps/backend-rag/requirements*.txt) —
+# checked in order, first match wins. Kept short and repo-relative on purpose:
+# this is a same-machine self-heal, not a general interpreter search.
+_YAML_VENV_CANDIDATES = (
+    "apps/backend-rag/.venv/bin/python3",
+    ".venv/bin/python3",
+)
+
+
+def _yaml_importable() -> bool:
+    try:
+        import yaml  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _find_yaml_venv(repo_root: Path) -> Path | None:
+    for rel in _YAML_VENV_CANDIDATES:
+        candidate = repo_root / rel
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _reexec_with_yaml_if_needed() -> None:
+    """Whatever invoked us as bare `python3` may resolve to a system
+    interpreter without PyYAML (Homebrew python3, W-mini 2026-07-17:
+    ModuleNotFoundError crashed this receptor with exit 2 on every tick).
+    Re-exec once under a project venv that has it before giving up."""
+    if _yaml_importable():
+        return
+    if os.environ.get(_REEXEC_GUARD_ENV):
+        return  # already retried — let the real ImportError surface as exit 2
+    candidate = _find_yaml_venv(Path(__file__).resolve().parent.parent)
+    if candidate is None:
+        return
+    env = dict(os.environ, **{_REEXEC_GUARD_ENV: "1"})
+    os.execve(str(candidate), [str(candidate), str(Path(__file__).resolve()), *sys.argv[1:]], env)
 
 
 def parse_ts(value) -> datetime | None:
@@ -137,6 +178,7 @@ def run(node: str, registry_path: Path, sidecar_dir: Path) -> dict:
 
 
 def main(argv: list[str] | None = None) -> int:
+    _reexec_with_yaml_if_needed()
     ap = argparse.ArgumentParser(description="Registry-driven dead-organ receptor")
     ap.add_argument("--node", required=True, choices=["mini", "pro"])
     ap.add_argument("--registry", default=None)

--- a/scripts/tests/test_healer_receptor_yaml_fallback.py
+++ b/scripts/tests/test_healer_receptor_yaml_fallback.py
@@ -1,0 +1,96 @@
+"""yaml-import self-heal guilt+innocence (superscar #2 Esiste≠Armato).
+
+Born 2026-07-17 (Mini healer tick): the receptor's `python3 scripts/healer_
+receptor_registry.py --node mini --json` invocation resolved to Homebrew's
+system python3 (3.14), which lacks PyYAML — every tick returned exit 2
+"RECEPTOR BROKEN: ModuleNotFoundError: No module named 'yaml'", a broken
+receptor silently reads as coverage loss. Fix: try importing yaml first;
+if unavailable, re-exec once under a project venv that has it.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+_MOD_PATH = Path(__file__).resolve().parents[1] / "healer_receptor_registry.py"
+_spec = importlib.util.spec_from_file_location("healer_receptor_registry", _MOD_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["healer_receptor_registry"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+def test_find_yaml_venv_returns_first_existing_candidate(tmp_path):
+    # innocence would be "no candidate exists" (next test) — this is guilt:
+    # a real candidate must be found and returned, not just any truthy path.
+    second = tmp_path / ".venv" / "bin" / "python3"
+    second.parent.mkdir(parents=True)
+    second.write_text("#!/bin/sh\n")
+    first = tmp_path / "apps" / "backend-rag" / ".venv" / "bin" / "python3"
+    first.parent.mkdir(parents=True)
+    first.write_text("#!/bin/sh\n")
+
+    found = _mod._find_yaml_venv(tmp_path)
+
+    assert found == first  # first candidate in the tuple wins when both exist
+
+
+def test_find_yaml_venv_returns_none_when_no_candidate(tmp_path):
+    assert _mod._find_yaml_venv(tmp_path) is None
+
+
+def test_reexec_noop_when_yaml_importable(monkeypatch):
+    calls = []
+    monkeypatch.setattr(_mod, "_yaml_importable", lambda: True)
+    monkeypatch.setattr(os, "execve", lambda *a, **k: calls.append((a, k)))
+
+    _mod._reexec_with_yaml_if_needed()
+
+    assert calls == []  # yaml already importable — must not touch execve at all
+
+
+def test_reexec_noop_when_guard_env_already_set(monkeypatch):
+    calls = []
+    monkeypatch.setattr(_mod, "_yaml_importable", lambda: False)
+    monkeypatch.setenv(_mod._REEXEC_GUARD_ENV, "1")
+    monkeypatch.setattr(os, "execve", lambda *a, **k: calls.append((a, k)))
+
+    _mod._reexec_with_yaml_if_needed()
+
+    assert calls == []  # already retried once — a second broken import must surface as exit 2, not loop
+
+
+def test_reexec_noop_when_no_venv_candidate_found(monkeypatch):
+    calls = []
+    monkeypatch.setattr(_mod, "_yaml_importable", lambda: False)
+    monkeypatch.delenv(_mod._REEXEC_GUARD_ENV, raising=False)
+    monkeypatch.setattr(_mod, "_find_yaml_venv", lambda repo_root: None)
+    monkeypatch.setattr(os, "execve", lambda *a, **k: calls.append((a, k)))
+
+    _mod._reexec_with_yaml_if_needed()
+
+    assert calls == []  # no candidate venv — falls through to the real ImportError at call site
+
+
+def test_reexec_execs_found_candidate_with_guard_flag_set(monkeypatch, tmp_path):
+    monkeypatch.setattr(_mod, "_yaml_importable", lambda: False)
+    monkeypatch.delenv(_mod._REEXEC_GUARD_ENV, raising=False)
+    candidate = tmp_path / "python3"
+    monkeypatch.setattr(_mod, "_find_yaml_venv", lambda repo_root: candidate)
+    captured = {}
+
+    def fake_execve(path, argv, env):
+        captured["path"] = path
+        captured["argv"] = argv
+        captured["env"] = env
+
+    monkeypatch.setattr(os, "execve", fake_execve)
+
+    monkeypatch.setattr(sys, "argv", ["healer_receptor_registry.py", "--node", "mini", "--json"])
+    _mod._reexec_with_yaml_if_needed()
+
+    assert captured["path"] == str(candidate)
+    assert captured["argv"][0] == str(candidate)
+    assert captured["argv"][1] == str(_MOD_PATH.resolve())
+    assert captured["argv"][2:] == ["--node", "mini", "--json"]
+    assert captured["env"][_mod._REEXEC_GUARD_ENV] == "1"


### PR DESCRIPTION
## Summary
- `scripts/healer_receptor_registry.py --node mini --json` (healer receptor 4) hit exit 2 every tick: `RECEPTOR BROKEN: ModuleNotFoundError: No module named 'yaml'`. `python3` on Mini resolves to Homebrew's system interpreter (3.14), which doesn't have PyYAML — the healer's own diagnostic receptor was silently broken (superscar #2 Esiste≠Armato: a broken receptor is coverage loss).
- The wrapper that invokes it (`infra/healer/healer-run.sh`) is out of the healer's self-edit perimeter, so the fix lives in the receptor: try `import yaml` first; if unavailable, re-exec once under a project venv known to carry it (`apps/backend-rag/.venv`, repo-root `.venv` — both confirmed to have PyYAML 6.0.3), guarded by an env sentinel against re-exec loops.

## Context
Found live during a healer tick (Mini-Pro2, 2026-07-17): `healer_receptor_registry.py --node mini --json` returned `{"exit": 2}` instead of an organ report.

## Test plan
- [x] New `scripts/tests/test_healer_receptor_yaml_fallback.py` (6 tests): venv-candidate lookup + no-op/guard/exec branches of `_reexec_with_yaml_if_needed`
- [x] Manual repro: `/opt/homebrew/bin/python3 scripts/healer_receptor_registry.py --node mini --json` now returns `exit=0` with a full organ report (was exit 2 before this fix)
- [x] `pytest scripts/tests/test_healer_receptor_yaml_fallback.py scripts/tests/test_healer_receptor_parse_ts.py scripts/tests/test_healer_receptor_running_status.py -q` — 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)