### PR TITLE
fix(ci): arm launchd_liveness_detector test suite in CI (W81 self-cure)

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -77,6 +77,10 @@ jobs:
               scripts/tests/test_tcc_migrate_desktop_paths.py|\
               scripts/tests/test_lint_tcc_desktop_paths.py|\
               infra/tcc-desktop-paths/allowlist.txt|\
+              scripts/launchd_liveness_detector.py|\
+              scripts/tests/test_launchd_liveness_exit_status_decode.py|\
+              scripts/tests/test_launchd_liveness_marker_freshness.py|\
+              scripts/tests/test_launchd_liveness_stale_exit_recovery.py|\
               .claude/skills/modus/PENDING-ARMS.md|\
               .github/workflows/immune-enforcement.yml)
                 RELEVANT=true
@@ -108,6 +112,9 @@ jobs:
             scripts/tests/test_lint_doc_executable_refs.py \
             scripts/tests/test_tcc_migrate_desktop_paths.py \
             scripts/tests/test_lint_tcc_desktop_paths.py \
+            scripts/tests/test_launchd_liveness_exit_status_decode.py \
+            scripts/tests/test_launchd_liveness_marker_freshness.py \
+            scripts/tests/test_launchd_liveness_stale_exit_recovery.py \
             scripts/test_lint_test_reward_hacking.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"


### PR DESCRIPTION
## Summary

Due-diligence today found that `scripts/launchd_liveness_detector.py` — the W84
"green-but-TCC-dead launchd job" detector (PR #1518) — has 26 guilt+innocence
unit tests across 3 files under `scripts/tests/`, all passing locally, but
**referenced by zero workflows in `.github/workflows/`**. This is the exact
"esiste != armato" disease (scar family #2) the detector itself exists to
cure for launchd jobs — here it's the tool's own test suite that was never
armed.

- `scripts/tests/test_launchd_liveness_exit_status_decode.py` (6 tests)
- `scripts/tests/test_launchd_liveness_marker_freshness.py` (4 tests)
- `scripts/tests/test_launchd_liveness_stale_exit_recovery.py` (16 tests)

## Where it's wired in

`immune-enforcement.yml` is the existing home for exactly this class of tool
(lint_home_fork, secrets_permissions_audit, pending_arms_report,
lint_plist_keepalive, arsenal_probe, etc — the "superscar antidotes" battery).
Added:

1. The source script + all 3 test files to the sentinel path-detection
   case-statement (so a PR touching this tool trips the heavier unit-test
   step — verified guilt: a change to any of these 4 paths flips
   `relevant=true`; innocence: an unrelated file does not).
2. The 3 test files to the guilt+innocence unit-test loop, alongside the
   other superscar-antidote tools.

No new workflow created — this is the natural, minimal-diff home, consistent
with the sentinel-pattern convention documented in that file's own header
comments.

## Scope note: guard-conformance.yml / registry.json — NOT touched, on purpose

Checked whether `launchd_liveness_detector.py` should also be censused in
`infra/guard-conformance/registry.json`. That registry's own docstring scopes
it to **superscar #3 (textual over/under-match guards)** — it maps `_guard_*`
reply guards, command hooks, and similar text-matching decision functions to
their guilt+innocence proofs. `launchd_liveness_detector.py` is not a textual
guard: it correlates launchd exit-code + log content + process uptime
(superscar #2, "esiste != armato"), a different family, and its own docstring
says as much ("opus-mythos TAC of superscar #2"). `check_guard_conformance.py`'s
census surfaces (`openclaw_whatsapp_bridge.py`, `infra/claude-hooks` +
`scripts/hooks`, `guardrails_static_core.py`, `lint_tg_direct_senders.py`)
confirm it was never in scope — the checker still reports 0 violations after
this change. No entry invented; this PR only arms the CI execution gap.

## Related but distinct sibling work

PR #2571 (open, unmerged as of this PR) also touches
`scripts/launchd_liveness_detector.py` — arming it as an actual daily
LaunchAgent cron + fixing the `OURS_RE` scope regex + adding a 4th test file
(`test_launchd_liveness_ours_scope.py`). That PR does not touch
`.github/workflows/` at all, so it does not overlap with this fix. Once it
merges, its new 4th test file will need the same CI-arming treatment this PR
gives the existing 3 — flagged here as a natural, small follow-up, not
addressed in this diff (it doesn't exist on `main` yet).

## Test plan

- [x] `python3 -m pytest scripts/tests/test_launchd_liveness_exit_status_decode.py scripts/tests/test_launchd_liveness_marker_freshness.py scripts/tests/test_launchd_liveness_stale_exit_recovery.py -v` — 26/26 pass locally
- [x] Simulated the exact CI loop (all 15 tools in the battery, including the 3 new ones) locally — 0 failures
- [x] `actionlint .github/workflows/immune-enforcement.yml` — clean
- [x] Guilt/innocence-tested the sentinel case-statement addition itself (a change to the 4 new paths flips `relevant=true`; an unrelated file does not)
- [x] `python3 infra/guard-conformance/check_guard_conformance.py` — still 0 violations (confirms no interaction with the #3 registry)