### PR TITLE
fix(mini-git-pull): resolve untracked collisions instead of skipping (close scar-H)

### DIFF
--- a/scripts/mini/mini-git-pull.sh
+++ b/scripts/mini/mini-git-pull.sh
@@ -39,11 +39,16 @@ set -u
 REPO="$HOME/nuzantara"
 LOG_FILE="$HOME/logs/mini-git-pull.log"
 LOCK_FILE="/tmp/mini-git-pull.lock"
+BACKUP_ROOT="${MINI_GIT_PULL_BACKUP_ROOT:-$HOME/.git-pull-collision-backup}"  # recoverable moved-aside untracked collisions
 STASH_RETENTION_THRESHOLD=5  # alert if more stashes than this accumulate
 TELEGRAM_ALERT_COOLDOWN=3600  # 1h cooldown per alert key
 TELEGRAM_STATE_DIR="$HOME/.agent/decisions/state"
 
 mkdir -p "$(dirname "$LOG_FILE")" "$TELEGRAM_STATE_DIR"
+
+# Force literal pathspecs so an exotic incoming filename (`*`, `:(glob)**`, `:/`) fed to
+# `git ls-files -- "$f"` can never be read as pathspec magic and match unrelated files.
+export GIT_LITERAL_PATHSPECS=1
 
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG_FILE"
@@ -149,38 +154,46 @@ check_type_mismatch() {
   return 0
 }
 
-# Detect untracked local files that occupy a path the incoming merge also
-# touches. `git stash push` (without --include-untracked, see below) does
-# NOT cover untracked files, so they survive the stash step unchanged —
-# but `git merge --ff-only` still refuses when one of them collides with
-# a path the target ref introduces or modifies. Without this check the
-# script stashes tracked changes, fails the merge on the untracked
-# collision, restores the stash, and repeats the whole cycle every 5 min
-# forever (observed 2026-07-11: 7+ retries over 40 min, same path each
-# time) — wasted churn plus a generic "pull-failed" alert that doesn't
-# name the actual blocker. Detect it BEFORE stashing so we skip cleanly
-# with one targeted alert naming the colliding path(s); this is most
-# often a sibling session's uncommitted WIP (e.g. a new test file),
-# which resolves itself once that work is committed or removed — never
-# something this script should touch (Law 5 / sibling-race discipline).
+# RESOLVE untracked/ignored local files that occupy a path the incoming merge also touches.
+# `git merge --ff-only` refuses when an UNTRACKED file collides with a path the target ref
+# introduces, AND (verified on Pro, scar H) SILENTLY OVERWRITES an IGNORED one — so both must
+# be handled. The old behavior SKIPPED the whole tick (exit 1), which for genuinely-transient
+# sibling WIP self-resolves in a tick or two, but (a) left Mini blind to the ignored-file
+# silent-clobber, and (b) stalled indefinitely if the collision persisted. Mirroring
+# scripts/pro/pro-git-pull.sh, we now back each colliding path up to a timestamped,
+# PID-unique, no-clobber backup and MOVE IT ASIDE so the ff can land — recoverable (nothing
+# deleted; every move logged + alerted), so a genuine sibling WIP can be restored from backup.
 #
-# Returns 0 if clean, 1 if a collision is found (caller skips this tick).
-check_untracked_collision() {
-  local changed_paths untracked_paths colliding
-  changed_paths=$(git diff --name-only HEAD "$TARGET_REF" 2>/dev/null)
+# Iterate the INCOMING diff (small, clean git names), classifying each path as untracked by
+# "tracked? no ∧ exists on disk" — so a huge ignore tree (.venv) is never enumerated and
+# ignored collisions ARE caught (unlike `git ls-files --others --exclude-standard`, which
+# skips ignored files). Tracked-modified paths are left to the stash step below.
+#
+# Returns 0 on success (incl. nothing to do); 1 on ANY failure (fail-safe: caller skips tick).
+resolve_untracked_collision() {
+  local changed_paths f backup n=0 first="" ts
+  changed_paths=$(git -c core.quotepath=false diff --name-only HEAD "$TARGET_REF" 2>/dev/null)
   [ -z "$changed_paths" ] && return 0
-  untracked_paths=$(git ls-files --others --exclude-standard 2>/dev/null)
-  [ -z "$untracked_paths" ] && return 0
-  colliding=$(comm -12 <(echo "$changed_paths" | sort) <(echo "$untracked_paths" | sort))
-  if [ -n "$colliding" ]; then
-    local colliding_oneline
-    colliding_oneline=$(echo "$colliding" | tr '\n' ' ' | sed 's/ $//')
-    log "WARN: untracked file(s) collide with incoming $TARGET_REF: $colliding_oneline"
-    log "  HINT: likely a sibling session's uncommitted WIP (new file not yet"
-    log "        committed). Leave it alone — will retry once committed/removed."
-    telegram_alert "untracked-collision" \
-      "Mini pull skipped — untracked file(s) collide with incoming ${TARGET_REMOTE}/main: ${colliding_oneline}. Likely sibling WIP; retries once committed/removed."
-    return 1
+  ts="$(date '+%Y%m%d-%H%M%S')-$$"
+  backup="$BACKUP_ROOT/$ts"
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    # tracked paths → handled by the stash step; only UNTRACKED/IGNORED collide here.
+    git ls-files --error-unmatch -- "$f" >/dev/null 2>&1 && continue
+    # collision only if it actually exists on disk (-L: a dangling symlink blocks/loses too)
+    [ -e "$REPO/$f" ] || [ -L "$REPO/$f" ] || continue
+    mkdir -p "$backup/$(dirname "$f")" 2>>"$LOG_FILE" || { log "ERROR: mkdir backup for $f"; return 1; }
+    if mv -n "$REPO/$f" "$backup/$f" 2>>"$LOG_FILE" && [ ! -e "$REPO/$f" ]; then
+      n=$((n + 1)); [ -z "$first" ] && first="$f"
+      log "  moved colliding untracked/ignored → backup: $f -> $backup/$f"
+    else
+      log "ERROR: mv failed / backup dest existed for $f — skip tick (fail-safe)"; return 1
+    fi
+  done < <(printf '%s\n' "$changed_paths")
+  if [ "$n" -gt 0 ]; then
+    log "Resolved $n untracked/ignored collision(s) with incoming $TARGET_REF into $backup (recoverable)."
+    telegram_alert "untracked-resolved" \
+      "Mini pull: backed up + moved aside ${n} untracked file(s) colliding with incoming ${TARGET_REMOTE}/main (e.g. ${first}) into ${backup}. Restore from backup if any was real sibling WIP."
   fi
   return 0
 }
@@ -282,9 +295,13 @@ if ! check_type_mismatch; then
   exit 1
 fi
 
-# 2026-07-11 hardening: detect untracked-file collisions BEFORE attempting
-# stash. See check_untracked_collision() above.
-if ! check_untracked_collision; then
+# 2026-07-11 hardening (2026-07-17 skip→resolve): back up + move aside untracked/ignored
+# collisions BEFORE the stash step so the ff can land (self-heals instead of stalling, and
+# catches the ignored-file silent-clobber the old --exclude-standard check missed — scar H).
+# See resolve_untracked_collision() above.
+if ! resolve_untracked_collision; then
+  log "ERROR: untracked-collision resolve failed; skip tick (fail-safe)"
+  telegram_alert "untracked-resolve-failed" "Mini pull: untracked-collision resolve errored; tick skipped, nothing merged. Check ~/logs/mini-git-pull.log."
   exit 1
 fi
 

--- a/scripts/mini/test-mini-git-pull-ignored-collision.sh
+++ b/scripts/mini/test-mini-git-pull-ignored-collision.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Ignored-file collision test for scripts/mini/mini-git-pull.sh (scar H, Mini analog).
+#
+# The pre-2026-07-17 detection used `git ls-files --others --exclude-standard`, which
+# EXCLUDES ignored files. So a locally-IGNORED untracked file whose path origin/main now
+# TRACKS was never detected — and `git merge --ff-only` SILENTLY OVERWRITES it (verified on
+# Pro, scar H). This proves the resolve path now catches it: the ignored local file is moved
+# aside to a recoverable backup (not silently clobbered), and the ff still lands.
+
+set -e
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/mini-git-pull-ignored.XXXXXX")
+REMOTE="$WORK/remote.git"
+LOCAL="$WORK/local"
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/mini-git-pull.sh"
+
+echo "[test] workdir: $WORK"
+export HOME="$WORK"
+mkdir -p "$WORK/logs" "$WORK/.agent/decisions/state" "$WORK/Desktop"
+ln -sfn "$LOCAL" "$WORK/nuzantara"
+export TELEGRAM_BOT_TOKEN=""
+
+mkdir -p "$REMOTE"
+git -C "$REMOTE" init --quiet --bare
+git -C "$REMOTE" symbolic-ref HEAD refs/heads/main
+ORIGIN_WORK="$WORK/origin-work"
+git clone --quiet "$REMOTE" "$ORIGIN_WORK"
+git -C "$ORIGIN_WORK" config user.email "test@test"
+git -C "$ORIGIN_WORK" config user.name "test"
+# Base: a .gitignore that ignores runtime/ (so runtime/x.json is ignored locally).
+printf 'runtime/\n' > "$ORIGIN_WORK/.gitignore"
+echo "v1 doc" > "$ORIGIN_WORK/docs.md"
+git -C "$ORIGIN_WORK" add -A
+git -C "$ORIGIN_WORK" commit --quiet -m "v1 + gitignore"
+git -C "$ORIGIN_WORK" branch -M main
+git -C "$ORIGIN_WORK" push --quiet origin main
+
+git clone --quiet "$REMOTE" "$LOCAL"
+git -C "$LOCAL" config user.email "test@test"
+git -C "$LOCAL" config user.name "test"
+
+# Local IGNORED untracked file (matches runtime/ in .gitignore).
+mkdir -p "$LOCAL/runtime"
+echo "LOCAL-ONLY runtime output" > "$LOCAL/runtime/x.json"
+
+# Origin force-adds runtime/x.json (now TRACKED upstream) → the collision that silently
+# clobbered the local ignored file pre-fix.
+mkdir -p "$ORIGIN_WORK/runtime"
+echo "committed upstream version" > "$ORIGIN_WORK/runtime/x.json"
+git -C "$ORIGIN_WORK" add -f runtime/x.json
+git -C "$ORIGIN_WORK" commit --quiet -m "force-add runtime/x.json upstream"
+git -C "$ORIGIN_WORK" push --quiet origin main
+
+set +e
+bash "$SCRIPT"
+RC=$?
+set -e
+
+LOG_FILE="$WORK/logs/mini-git-pull.log"
+echo "[test] exit: $RC"
+sed 's/^/  | /' "$LOG_FILE"
+
+if [ "$RC" -ne 0 ]; then
+  echo "[test] FAIL: expected exit 0 (ignored collision resolved, pull applied), got $RC"
+  exit 1
+fi
+# The ignored local file must be RECOVERABLE in the backup — NOT silently clobbered (scar H).
+BK=$(find "$WORK/.git-pull-collision-backup" -name 'x.json' 2>/dev/null | head -1)
+if [ -z "$BK" ] || [ "$(cat "$BK")" != "LOCAL-ONLY runtime output" ]; then
+  echo "[test] FAIL: ignored local file was NOT backed up (scar H silent clobber regressed!)"
+  exit 1
+fi
+# Working tree now holds origin's tracked version.
+if [ "$(cat "$LOCAL/runtime/x.json")" != "committed upstream version" ]; then
+  echo "[test] FAIL: working tree does not have origin's version after ff"
+  exit 1
+fi
+if [ "$(git -C "$LOCAL" rev-parse HEAD)" != "$(git -C "$ORIGIN_WORK" rev-parse HEAD)" ]; then
+  echo "[test] FAIL: local HEAD did NOT advance — pull should have applied after resolve"
+  exit 1
+fi
+
+rm -rf "$WORK"
+echo "[test] PASS — ignored-collision (scar H): moved aside (recoverable, not clobbered), ff applied."

--- a/scripts/mini/test-mini-git-pull-untracked-collision.sh
+++ b/scripts/mini/test-mini-git-pull-untracked-collision.sh
@@ -3,14 +3,13 @@
 #
 # Reproduces the 2026-07-11 incident: a sibling session has an uncommitted
 # new file on Mini's main checkout (e.g. a new test file), and origin/main
-# advances with a commit that ALSO adds a file at that same path. The old
-# script stashed tracked changes, attempted `git merge --ff-only`, failed
-# on the untracked-path collision, restored the stash, and repeated the
-# whole cycle every 5 minutes forever. The fix detects the collision
-# BEFORE stashing and skips cleanly with one targeted alert.
+# advances with a commit that ALSO adds a file at that same path.
 #
-# This test also has an unrelated tracked-dirty file present, to prove the
-# collision check runs — and skips — before the stash step even fires.
+# 2026-07-17 upgrade (skip → RESOLVE): the puller now backs up + moves the
+# colliding untracked file aside (recoverable) and PROCEEDS with the ff, instead
+# of stalling the whole tick. This test asserts the resolve: the pull lands, the
+# sibling's file is preserved in the backup (not lost), the working tree holds
+# origin's version, and an UNRELATED tracked-dirty file survives via stash+pop.
 
 set -e
 
@@ -69,33 +68,40 @@ LOG_FILE="$WORK/logs/mini-git-pull.log"
 echo "[test] exit: $RC"
 sed 's/^/  | /' "$LOG_FILE"
 
-if [ "$RC" -ne 1 ]; then
-  echo "[test] FAIL: expected exit 1 (collision, needs sibling to resolve), got $RC"
+if [ "$RC" -ne 0 ]; then
+  echo "[test] FAIL: expected exit 0 (collision resolved, pull applied), got $RC"
   exit 1
 fi
-if ! grep -q "untracked file(s) collide" "$LOG_FILE"; then
-  echo "[test] FAIL: log should name the untracked-collision detection"
+if ! grep -q "moved colliding untracked" "$LOG_FILE"; then
+  echo "[test] FAIL: log should name the moved-aside untracked collision"
   exit 1
 fi
-if grep -q "Stashed tracked changes" "$LOG_FILE"; then
-  echo "[test] FAIL: script stashed before checking for the collision — should skip pre-stash"
+# The sibling's file must be RECOVERABLE in the backup (moved aside, not deleted).
+BK=$(find "$WORK/.git-pull-collision-backup" -name 'new_test.py' 2>/dev/null | head -1)
+if [ -z "$BK" ] || [ "$(cat "$BK")" != "sibling WIP draft" ]; then
+  echo "[test] FAIL: sibling's untracked file not recoverable in backup (data loss!)"
   exit 1
 fi
-if ! git -C "$LOCAL" stash list | grep -q "^$"; then
-  : # stash list empty is expected — no assertion needed beyond the grep below
+# The working tree must now hold ORIGIN's version at that path (the ff landed).
+if [ "$(cat "$LOCAL/scripts/new_test.py")" != "committed upstream version" ]; then
+  echo "[test] FAIL: working tree does not have origin's version after ff"
+  exit 1
 fi
+# The pull must have applied (HEAD advanced to origin).
+if [ "$(git -C "$LOCAL" rev-parse HEAD)" != "$(git -C "$ORIGIN_WORK" rev-parse HEAD)" ]; then
+  echo "[test] FAIL: local HEAD did NOT advance — pull should have applied after resolve"
+  exit 1
+fi
+# The UNRELATED tracked-dirty file must survive the stash+pop around the ff.
+if ! grep -q "unrelated local edit" "$LOCAL/docs.md"; then
+  echo "[test] FAIL: unrelated tracked-dirty edit was lost across the pull (stash/pop)"
+  exit 1
+fi
+# No stash should linger (pop succeeded).
 if [ -n "$(git -C "$LOCAL" stash list 2>/dev/null)" ]; then
-  echo "[test] FAIL: a stash was created — sibling's tracked-dirty file should not have been touched"
-  exit 1
-fi
-if [ "$(cat "$LOCAL/scripts/new_test.py")" != "sibling WIP draft" ]; then
-  echo "[test] FAIL: sibling's untracked WIP file was modified — must be left alone"
-  exit 1
-fi
-if [ "$(git -C "$LOCAL" rev-parse HEAD)" = "$(git -C "$ORIGIN_WORK" rev-parse HEAD)" ]; then
-  echo "[test] FAIL: local HEAD advanced despite the collision — pull should have been skipped"
+  echo "[test] FAIL: a stash lingered — pop failed"
   exit 1
 fi
 
 rm -rf "$WORK"
-echo "[test] PASS — untracked-collision: skipped pre-stash, sibling WIP untouched, no pull applied."
+echo "[test] PASS — untracked-collision RESOLVED: moved aside (recoverable), ff applied, unrelated dirty edit preserved."


### PR DESCRIPTION
## What

Harden Mini's `git-pull-main.5min` puller: **resolve** untracked/ignored collisions (back up + move aside, recoverable) instead of **skipping** the whole tick. Completes the fleet-convergence started by the Pro puller (#2549) and its runtime-state hardening.

## Why

Two problems with the skip-on-collision behavior:

1. **Latent silent-data-loss (scar H).** Detection used `git ls-files --others --exclude-standard`, which *excludes ignored files* — so an ignored local file whose path origin now tracks was never detected, and `git merge --ff-only` **silently overwrites** it (verified on Pro, scar H). Mini was vulnerable to this.
2. A persistent collision **stalled the sync indefinitely** (5-min ticks) instead of self-healing.

## How

Mirror `scripts/pro/pro-git-pull.sh`'s untracked branch: iterate the **incoming diff** (small, clean git names), and for each path that is untracked/ignored AND on disk, back it up to a timestamped PID-unique no-clobber backup and move it aside so the ff can land. Per-incoming-path classification catches ignored files (unlike `--exclude-standard`) without enumerating a huge ignore tree (`.venv`). `GIT_LITERAL_PATHSPECS=1`. Fail-safe: any error skips the tick, nothing merged. Tracked-modified paths still go through the existing stash step.

**Tradeoff (explicit):** for a genuinely-transient sibling WIP collision the old skip self-resolved in a tick or two; resolve now relocates it — **recoverably**, with a targeted alert — rather than stalling. This matches Pro and closes scar H. If you'd rather keep skip for *non-ignored* untracked collisions (sibling-WIP protection) and resolve only ignored ones, say so and I'll split it.

## Tests

All 5 Mini smoke tests pass (`scripts/mini/test-mini-git-pull-*.sh`):
- happy-path, tracked-dirty, symlink-mismatch (unchanged — prove no regression),
- untracked-collision **rewritten** to assert resolve (moved-aside recoverable, ff applied, unrelated tracked-dirty edit preserved via stash+pop, no lingering stash),
- **new** ignored-collision test proving the scar-H closure (ignored file moved aside recoverably, not silently clobbered).

shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
