### PR TITLE
feat(wr2): external-post registration + gallery recency + IG metrics repair (red-teamed 2 rounds)

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
@@ -322,3 +322,110 @@ def test_ingest_external_explicit_date(queue_file):
     items = json.loads(queue_file.read_text())
     new = next(i for i in items if qw.item_id_of(i) == "ig-Cabc123_-")
     assert new["instagram_published_at"] == "2026-05-01T12:00:00+00:00"
+
+
+# ── add_external / validate_external_payload — M5->Pro propagation (§B) ────
+
+
+def _external_payload(**overrides):
+    payload = {
+        "item_id": "external_2026-07-17T090000_my-manual-post",
+        "state": "published",
+        "instagram_post_url": VALID_URL,
+        "source": "external_manual",
+        "published_at": "2026-07-17T09:00:00+00:00",
+        "instagram_published_at": "2026-07-17T09:00:00+00:00",
+        "topic": "My manual post",
+        "topic_slug": "my-manual-post",
+        "slide_count": 0,
+        "created_at": "2026-07-17T09:00:00+00:00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.parametrize("field", list(qw.REQUIRED_EXTERNAL_PAYLOAD_FIELDS))
+def test_validate_external_payload_rejects_missing_required_field(field):
+    payload = _external_payload()
+    del payload[field]
+    err = qw.validate_external_payload(payload)
+    assert err is not None and field in err
+
+
+def test_validate_external_payload_rejects_wrong_state():
+    err = qw.validate_external_payload(_external_payload(state="drafted"))
+    assert err is not None and "state" in err
+
+
+def test_validate_external_payload_rejects_wrong_source():
+    err = qw.validate_external_payload(_external_payload(source="manual_external"))
+    assert err is not None and "source" in err
+
+
+def test_validate_external_payload_rejects_bad_url():
+    err = qw.validate_external_payload(_external_payload(instagram_post_url="https://example.com/not-ig"))
+    assert err is not None and "instagram_post_url" in err
+
+
+def test_validate_external_payload_accepts_well_formed_payload():
+    assert qw.validate_external_payload(_external_payload()) is None
+
+
+def test_add_external_happy_path_appends_verbatim(queue_file):
+    before = len(json.loads(queue_file.read_text()))
+    payload = _external_payload()
+    res = qw.add_external(queue_file, payload)
+    assert res.status == "added" and res.ok is True
+    items = json.loads(queue_file.read_text())
+    assert len(items) == before + 1
+    new = next(i for i in items if qw.item_id_of(i) == payload["item_id"])
+    assert new["state"] == "published"
+    assert new["instagram_post_url"] == VALID_URL
+    assert new["source"] == "external_manual"
+    assert new["topic_slug"] == "my-manual-post"
+    assert new["slide_count"] == 0
+    # OTHER items untouched
+    alpha = next(i for i in items if qw.item_id_of(i) == "alpha-FIRSTPROD")
+    assert alpha["state"] == "applied_ready_for_damar"
+
+
+def test_add_external_invalid_payload_no_write(queue_file):
+    before = queue_file.read_text()
+    res = qw.add_external(queue_file, _external_payload(state="drafted"))
+    assert res.status == "invalid_payload" and res.ok is False
+    assert queue_file.read_text() == before
+
+
+def test_add_external_duplicate_item_id_refused(queue_file):
+    payload = _external_payload()
+    qw.add_external(queue_file, payload)
+    n_after_first = len(json.loads(queue_file.read_text()))
+    # same item_id, different URL — must still be refused as a duplicate
+    dup = _external_payload(instagram_post_url="https://www.instagram.com/p/DIFFERENT99/")
+    res = qw.add_external(queue_file, dup)
+    assert res.status == "already_present" and res.ok is True
+    items = json.loads(queue_file.read_text())
+    assert len(items) == n_after_first  # no duplicate appended
+    kept = next(i for i in items if qw.item_id_of(i) == payload["item_id"])
+    assert kept["instagram_post_url"] == VALID_URL  # original untouched
+
+
+def test_add_external_duplicate_url_different_item_id_refused(queue_file):
+    payload = _external_payload()
+    qw.add_external(queue_file, payload)
+    n_after_first = len(json.loads(queue_file.read_text()))
+    # different item_id, SAME url — must still be refused as a duplicate
+    dup = _external_payload(item_id="external_2026-07-17T091500_retry-post", topic_slug="retry-post")
+    res = qw.add_external(queue_file, dup)
+    assert res.status == "already_present" and res.ok is True
+    assert len(json.loads(queue_file.read_text())) == n_after_first
+
+
+def test_add_external_idempotent_replay_safe(queue_file):
+    """The M5->Pro push-back loop may retry the SAME payload after a flaky ssh —
+    replaying the identical payload twice must be a no-op, not an error."""
+    payload = _external_payload()
+    res1 = qw.add_external(queue_file, payload)
+    assert res1.status == "added"
+    res2 = qw.add_external(queue_file, payload)
+    assert res2.status == "already_present" and res2.ok is True

--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
@@ -324,6 +324,122 @@ def test_ingest_external_explicit_date(queue_file):
     assert new["instagram_published_at"] == "2026-05-01T12:00:00+00:00"
 
 
+# ── build_external_item / ingest_external_post — ig_media_id (§C, 2026-07-17) ─
+#
+# The scraper diagnosis (team-lead, live Pro-side) found `build_external_item`
+# derives its pseudo-id from the URL SHORTCODE and DISCARDS the real numeric
+# Graph media id even when the caller (wr2_ig_discovery.py) already fetched it.
+# This threads an OPTIONAL `ig_media_id` through, stored as its own field —
+# never folded into item_id's ig-<shortcode> derivation.
+
+
+def test_build_external_item_omits_ig_media_id_when_not_passed():
+    # GUILT/regression guard: no Graph fetch happened -> no fabricated field.
+    it = qw.build_external_item(VALID_URL, "2026-06-10T00:00:00+00:00", topic="My post")
+    assert "ig_media_id" not in it
+
+
+def test_build_external_item_stores_ig_media_id_when_passed():
+    # INNOCENCE: caller already has the real numeric Graph id -> persisted verbatim,
+    # as a STRING, and separate from item_id (which stays shortcode-derived).
+    it = qw.build_external_item(
+        VALID_URL, "2026-06-10T00:00:00+00:00", topic="My post", ig_media_id=17895695668004550,
+    )
+    assert it["ig_media_id"] == "17895695668004550"
+    assert it["item_id"] == "ig-Cabc123_-"  # unchanged — never derived from ig_media_id
+
+
+def test_build_external_item_omits_ig_media_id_when_falsy():
+    # empty string / 0 must not produce a bogus ig_media_id="" or "0" field.
+    it = qw.build_external_item(VALID_URL, "2026-06-10T00:00:00+00:00", ig_media_id="")
+    assert "ig_media_id" not in it
+
+
+def test_ingest_external_without_ig_media_id_omits_field(queue_file):
+    # Regression: the WR2 Control app's manual §A entry point never has a Graph
+    # fetch — the minted item must degrade gracefully (no field), not crash.
+    res = qw.ingest_external_post(queue_file, VALID_URL)
+    assert res.ok
+    items = json.loads(queue_file.read_text())
+    new = next(i for i in items if qw.item_id_of(i) == "ig-Cabc123_-")
+    assert "ig_media_id" not in new
+
+
+def test_ingest_external_with_ig_media_id_persists_it(queue_file):
+    res = qw.ingest_external_post(
+        queue_file, VALID_URL, ig_media_id="17895695668004550",
+    )
+    assert res.ok
+    items = json.loads(queue_file.read_text())
+    new = next(i for i in items if qw.item_id_of(i) == "ig-Cabc123_-")
+    assert new["ig_media_id"] == "17895695668004550"
+
+
+# ── backfill_media_id — reconciliation for already-known posts (§C point 3) ──
+#
+# WR2-native carousels are published via the app's own publish gate, which
+# records the permalink but NEVER a Graph media id. wr2_ig_discovery.py's
+# reconciliation pass (find_media_id_backfills) calls this to attach the real
+# id back onto a native entry once discovery matches it by shortcode.
+
+
+def _native_published_item(item_id="bali-pma-rental-crackdown", ig_url=VALID_URL):
+    """A WR2-native carousel entry: published via the app's own gate — has a
+    permalink but no ig_media_id (the exact shape backfill_media_id targets)."""
+    return {
+        "id": item_id,
+        "topic_slug": item_id,
+        "state": "published",
+        "instagram_post_url": ig_url,
+        "instagram_published_at": "2026-07-10T00:00:00+00:00",
+        "engagement_metrics": None,
+    }
+
+
+@pytest.fixture
+def native_queue_file(tmp_path):
+    items = [_native_published_item()]
+    p = tmp_path / "native-queue.json"
+    p.write_text(json.dumps(items))
+    return p
+
+
+def test_backfill_media_id_not_found_no_write(native_queue_file):
+    before = native_queue_file.read_text()
+    res = qw.backfill_media_id(native_queue_file, "does-not-exist", "17895695668004550")
+    assert res.status == "not_found" and res.ok is False
+    assert native_queue_file.read_text() == before
+
+
+def test_backfill_media_id_backfills_native_entry(native_queue_file):
+    res = qw.backfill_media_id(
+        native_queue_file, "bali-pma-rental-crackdown", "17895695668004550",
+    )
+    assert res.status == "backfilled" and res.ok is True
+    items = json.loads(native_queue_file.read_text())
+    updated = next(i for i in items if qw.item_id_of(i) == "bali-pma-rental-crackdown")
+    assert updated["ig_media_id"] == "17895695668004550"
+    # everything else on the item survives untouched
+    assert updated["instagram_post_url"] == VALID_URL
+    assert updated["state"] == "published"
+
+
+def test_backfill_media_id_idempotent_replay_is_noop(native_queue_file):
+    qw.backfill_media_id(native_queue_file, "bali-pma-rental-crackdown", "17895695668004550")
+    after_first = native_queue_file.read_text()
+    res = qw.backfill_media_id(native_queue_file, "bali-pma-rental-crackdown", "17895695668004550")
+    assert res.status == "already_backfilled" and res.ok is True
+    assert native_queue_file.read_text() == after_first  # no duplicate write
+
+
+def test_backfill_media_id_conflict_refuses_overwrite(native_queue_file):
+    qw.backfill_media_id(native_queue_file, "bali-pma-rental-crackdown", "17895695668004550")
+    after_first = native_queue_file.read_text()
+    res = qw.backfill_media_id(native_queue_file, "bali-pma-rental-crackdown", "99999999999999999")
+    assert res.status == "conflict" and res.ok is False
+    assert native_queue_file.read_text() == after_first  # refused — no overwrite
+
+
 # ── add_external / validate_external_payload — M5->Pro propagation (§B) ────
 
 

--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_queue_writer.py
@@ -512,16 +512,22 @@ def test_add_external_invalid_payload_no_write(queue_file):
     assert queue_file.read_text() == before
 
 
-def test_add_external_duplicate_item_id_refused(queue_file):
+def test_add_external_same_item_id_different_post_is_conflict(queue_file):
+    """GUILT (Codex red-team, 2026-07-17, finding E): the SAME item_id but a
+    DIFFERENT post (different URL/shortcode) must be a distinct `conflict`
+    status with ok=False — NOT `already_present`/ok=True, which the wrapper
+    reads as "safe to mark synced" and would silently lose the genuinely
+    distinct post with no record it was ever dropped. Was previously
+    asserting the pre-finding-E (buggy) already_present/ok=True behavior."""
     payload = _external_payload()
     qw.add_external(queue_file, payload)
     n_after_first = len(json.loads(queue_file.read_text()))
-    # same item_id, different URL — must still be refused as a duplicate
+    # same item_id, DIFFERENT URL — a genuinely different post, must conflict
     dup = _external_payload(instagram_post_url="https://www.instagram.com/p/DIFFERENT99/")
     res = qw.add_external(queue_file, dup)
-    assert res.status == "already_present" and res.ok is True
+    assert res.status == "conflict" and res.ok is False
     items = json.loads(queue_file.read_text())
-    assert len(items) == n_after_first  # no duplicate appended
+    assert len(items) == n_after_first  # no duplicate appended, no write at all
     kept = next(i for i in items if qw.item_id_of(i) == payload["item_id"])
     assert kept["instagram_post_url"] == VALID_URL  # original untouched
 

--- a/apps/wr2-control-app/Sources/AppState.swift
+++ b/apps/wr2-control-app/Sources/AppState.swift
@@ -715,6 +715,71 @@ final class AppState: ObservableObject {
         }
     }
 
+    // MARK: - External post registration (§A, 2026-07-17 — "aggiungi upload e URL di
+    // un post che abbiamo fatto e non obbligatoriamente passato per la app")
+
+    /// Register a manually-published Instagram post that bypassed the WR2 pipeline
+    /// entirely — no drafted carousel ever existed for it. Validates the URL/topic
+    /// (ExternalPostRegistration, pure), optionally copies+converts picked images to
+    /// PNG under `<root>/carousel/external-<date>-<slug>/slides/` (numeric naming so
+    /// WarRoom's existing cover/scan logic just works — that logic only recognizes
+    /// `.png`, so a JPG pick is re-encoded, not just renamed), then appends the queue
+    /// entry via `QueueWriter.addExternalPost` (throws on validation failure or
+    /// duplicate URL/id — refused, not silently ignored) and refreshes the gallery so
+    /// the new card appears immediately, matching `importCarousel`'s idiom.
+    func addExternalPost(igURLRaw: String, topicRaw: String, publishDate: Date,
+                         images: [URL], lang: LanguageManager) throws {
+        let url = try ExternalPostRegistration.canonicalizeInstagramURL(igURLRaw)
+        let topic = try ExternalPostRegistration.validateTopic(topicRaw)
+        let slug = CarouselIO.safeSlug(topic)
+        guard slug.isEmpty == false else { throw ExternalPostRegistration.ValidationError.emptyTopic }
+
+        var carouselPath: String?
+        var slideCount = 0
+        if images.isEmpty == false {
+            let dirName = ExternalPostRegistration.carouselDirName(publishDate: publishDate, slug: slug)
+            let dir = WarRoom.carouselRoot().appendingPathComponent(dirName, isDirectory: true)
+            let slidesDir = dir.appendingPathComponent("slides", isDirectory: true)
+            try FileManager.default.createDirectory(at: slidesDir, withIntermediateDirectories: true)
+            for (i, src) in images.enumerated() {
+                let dest = slidesDir.appendingPathComponent(String(format: "%02d.png", i + 1))
+                try Self.writeImageAsPNG(from: src, to: dest)
+            }
+            slideCount = images.count
+            carouselPath = "~/nuzantara/apps/war-room/output/carousel/\(dirName)/"
+        }
+
+        let entry = ExternalPostRegistration.buildQueueEntry(
+            instagramURL: url, topic: topic, slug: slug, publishDate: publishDate,
+            slideCount: slideCount, carouselPath: carouselPath)
+        try QueueWriter.addExternalPost(queueFile: WarRoom.queueFile(), entry: entry)
+        refreshFromDisk()
+        notice("✓ " + lang.t("externalPost.saved"))
+    }
+
+    /// Copy `src` to `dest` as PNG. A `.png` source is a plain file copy; any other
+    /// image type (JPG etc., per §A's "PNG/JPG" acceptance) is decoded and re-encoded
+    /// via NSImage/NSBitmapImageRep — `WarRoom.slidePNGs` filters strictly on `.png`
+    /// extension, so a bytes-only rename would silently vanish from the slide count.
+    private static func writeImageAsPNG(from src: URL, to dest: URL) throws {
+        if FileManager.default.fileExists(atPath: dest.path) {
+            try FileManager.default.removeItem(at: dest)
+        }
+        if src.pathExtension.lowercased() == "png" {
+            try FileManager.default.copyItem(at: src, to: dest)
+            return
+        }
+        guard let image = NSImage(contentsOf: src),
+              let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else {
+            throw NSError(domain: "AppState", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Non riesco a leggere l'immagine: \(src.lastPathComponent)"
+            ])
+        }
+        try png.write(to: dest)
+    }
+
     // MARK: - Disk refresh (gallery + queue)
 
     func refreshFromDisk() {

--- a/apps/wr2-control-app/Sources/ExternalPostRegistration.swift
+++ b/apps/wr2-control-app/Sources/ExternalPostRegistration.swift
@@ -69,9 +69,16 @@ enum ExternalPostRegistration {
     }
 
     /// The on-disk carousel dir name for an external post WITH images:
-    /// `external-<yyyy-MM-dd>-<slug>` (spec §A).
+    /// `external-<yyyy-MM-dd>T<HHmmss>-<slug>`.
+    ///
+    /// Includes TIME, not just date (Codex red-team, 2026-07-17, finding H):
+    /// `makeItemID` is unique on date+time+slug, but this dir name was date+slug
+    /// only — two same-day, same-slug external registrations (e.g. the operator
+    /// re-registers a correction, or two posts on the same topic in one day)
+    /// would collide into ONE directory, silently clobbering the first post's
+    /// images with the second's.
     static func carouselDirName(publishDate: Date, slug: String) -> String {
-        "external-\(utcDateFormatter("yyyy-MM-dd").string(from: publishDate))-\(slug)"
+        "external-\(utcDateFormatter("yyyy-MM-dd'T'HHmmss").string(from: publishDate))-\(slug)"
     }
 
     /// Build the queue entry — every field from §A. `carousel_path` is present only

--- a/apps/wr2-control-app/Sources/ExternalPostRegistration.swift
+++ b/apps/wr2-control-app/Sources/ExternalPostRegistration.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// "Aggiungi post esterno" — register an Instagram post Zero/Damar published OUTSIDE
+/// the WR2 app (a post that never went through the pipeline, so no drafted carousel
+/// ever existed for it locally). Pure-Foundation core: URL validation/canonicalization,
+/// item_id/slug/dir-name derivation, and queue-entry construction — unit-testable
+/// without SwiftUI, same split as ExternalImport.swift. The actual file copy (optional
+/// images, needs AppKit for JPG→PNG conversion) and the QueueWriter append happen in
+/// AppState, matching the reRenderCarousel/publishToInstagram/importExternalCarousel idiom.
+enum ExternalPostRegistration {
+
+    enum ValidationError: Error, Equatable, LocalizedError {
+        case emptyURL
+        case notAnInstagramPostURL
+        case emptyTopic
+
+        var errorDescription: String? {
+            switch self {
+            case .emptyURL:               return "L'URL Instagram è obbligatorio."
+            case .notAnInstagramPostURL:  return "Non sembra un link a un post/reel Instagram valido."
+            case .emptyTopic:             return "Il titolo/argomento è obbligatorio."
+            }
+        }
+    }
+
+    /// `instagram.com/(p|reel)/<shortcode>[/][?...]` — optional `www`, optional trailing
+    /// slash/query string. Mirrors QueueWriter.extractMediaID's shape (Swift side) and
+    /// scripts/wr2_queue_writer.py's `_IG_URL_RE` (Python side) — hand-kept in sync,
+    /// there being no shared source between the two languages.
+    private static let igURLPattern = #"^https?://(www\.)?instagram\.com/(p|reel)/([A-Za-z0-9_-]+)/?(\?.*)?$"#
+
+    /// Validate + canonicalize a pasted Instagram URL to `https://www.instagram.com/(p|reel)/<code>/`.
+    /// Rejects empty/garbage (acceptance criteria §A: "reject empty/garbage").
+    static func canonicalizeInstagramURL(_ raw: String) throws -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { throw ValidationError.emptyURL }
+        guard let re = try? NSRegularExpression(pattern: igURLPattern, options: [.caseInsensitive]) else {
+            throw ValidationError.notAnInstagramPostURL
+        }
+        let range = NSRange(trimmed.startIndex..., in: trimmed)
+        guard let m = re.firstMatch(in: trimmed, range: range),
+              let kindRange = Range(m.range(at: 2), in: trimmed),
+              let codeRange = Range(m.range(at: 3), in: trimmed) else {
+            throw ValidationError.notAnInstagramPostURL
+        }
+        let kind = trimmed[kindRange].lowercased()
+        let code = String(trimmed[codeRange])
+        return "https://www.instagram.com/\(kind)/\(code)/"
+    }
+
+    /// Validate a required title/topic field: trimmed, non-empty. Returns the trimmed value.
+    static func validateTopic(_ raw: String) throws -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { throw ValidationError.emptyTopic }
+        return trimmed
+    }
+
+    private static func utcDateFormatter(_ format: String) -> DateFormatter {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(identifier: "UTC")
+        df.dateFormat = format
+        return df
+    }
+
+    /// `item_id` per spec §A: `external_<yyyy-MM-dd>T<HHmmss>_<slug>`.
+    static func makeItemID(publishDate: Date, slug: String) -> String {
+        "external_\(utcDateFormatter("yyyy-MM-dd'T'HHmmss").string(from: publishDate))_\(slug)"
+    }
+
+    /// The on-disk carousel dir name for an external post WITH images:
+    /// `external-<yyyy-MM-dd>-<slug>` (spec §A).
+    static func carouselDirName(publishDate: Date, slug: String) -> String {
+        "external-\(utcDateFormatter("yyyy-MM-dd").string(from: publishDate))-\(slug)"
+    }
+
+    /// Build the queue entry — every field from §A. `carousel_path` is present only
+    /// when at least one image was copied in (0-image entries render as a cover-less
+    /// virtual card, the SAME convention the ig-* Graph-API backfill entries use —
+    /// WarRoom.swift:361-397). Both `published_at` (spec's literal field name) and
+    /// `instagram_published_at` (the field every existing consumer — WarRoom's
+    /// `pubAtBySlug`/`parsePublishedAt`, the Python scraper's staleness check — actually
+    /// reads) carry the SAME ISO timestamp; writing only the former would make this
+    /// entry invisible to the §D recency fix and the publish-date display.
+    static func buildQueueEntry(
+        instagramURL: String, topic: String, slug: String, publishDate: Date,
+        slideCount: Int, carouselPath: String?
+    ) -> [String: Any] {
+        let iso = ISO8601DateFormatter().string(from: publishDate)
+        var entry: [String: Any] = [
+            "item_id": makeItemID(publishDate: publishDate, slug: slug),
+            "state": "published",
+            "instagram_post_url": instagramURL,
+            "source": "external_manual",
+            "published_at": iso,
+            "instagram_published_at": iso,
+            "topic": topic,
+            "topic_slug": slug,
+            "slide_count": slideCount,
+            "created_at": iso,
+        ]
+        if let carouselPath { entry["carousel_path"] = carouselPath }
+        return entry
+    }
+}

--- a/apps/wr2-control-app/Sources/Localization.swift
+++ b/apps/wr2-control-app/Sources/Localization.swift
@@ -205,6 +205,17 @@ enum L10n {
         "detail.openIG":       [.it: "Apri su Instagram",                              .id: "Buka di Instagram"],
         "detail.critic":       [.it: "Controllo qualità",                              .id: "Pemeriksaan kualitas"],
         "detail.close":        [.it: "Chiudi",                                          .id: "Tutup"],
+        // external post registration (§A, 2026-07-17) — a post published OUTSIDE the app
+        "externalPost.button":    [.it: "Aggiungi post esterno",                            .id: "Tambah post eksternal"],
+        "externalPost.title":     [.it: "Registra un post pubblicato fuori dall'app",        .id: "Daftarkan post yang diterbitkan di luar app"],
+        "externalPost.urlLabel":  [.it: "URL Instagram",                                     .id: "URL Instagram"],
+        "externalPost.topicLabel":[.it: "Titolo / argomento",                                .id: "Judul / topik"],
+        "externalPost.dateLabel": [.it: "Data di pubblicazione",                             .id: "Tanggal publikasi"],
+        "externalPost.imagesLabel":[.it: "Immagini (opzionale)",                             .id: "Gambar (opsional)"],
+        "externalPost.pickImages":[.it: "Scegli immagini",                                   .id: "Pilih gambar"],
+        "externalPost.imagesCount":[.it: "%d immagine/i selezionate",                        .id: "%d gambar dipilih"],
+        "externalPost.save":      [.it: "Salva",                                             .id: "Simpan"],
+        "externalPost.saved":     [.it: "Post registrato ✓",                                 .id: "Post terdaftar ✓"],
         // gallery sort + result badges (Task 6)
         "gallery.sort.viral":        [.it: "Più condivisi",   .id: "Paling dibagikan"],
         "gallery.sort.recent":       [.it: "Più recenti",     .id: "Terbaru"],

--- a/apps/wr2-control-app/Sources/QueueWriter.swift
+++ b/apps/wr2-control-app/Sources/QueueWriter.swift
@@ -119,6 +119,61 @@ enum QueueWriter {
         }
     }
 
+    /// Duplicate error code for `addExternalPost` — mirrors `ineligibleStateErrorCode`.
+    static let duplicateExternalPostErrorCode = 4
+
+    /// Append a manually-registered external Instagram post (§A external-post feature,
+    /// 2026-07-17) — a post Zero/Damar published OUTSIDE the WR2 pipeline, so there is
+    /// no drafted carousel for it to advance. Unlike `enqueueDrafted` (state="drafted",
+    /// awaiting review) this writes directly in the ALREADY-published shape so it shows
+    /// up in the gallery immediately via `isQueueItemPublished`'s exemption from the A2
+    /// completeness gate — mirroring the existing ig-* virtual-entry convention
+    /// (WarRoom.swift:361-397) this feature is modeled on.
+    ///
+    /// Refuses a duplicate — same `instagram_post_url` (trimmed) OR same `item_id`
+    /// already present in the LOCAL queue — BEFORE any write (mirrors `markPublished`'s
+    /// guard-first discipline), so a double-tap of Save (or a retried M5→Pro replay)
+    /// never double-enqueues (acceptance criteria §A #2). This is the LOCAL/M5 half of
+    /// the duplicate check; `scripts/wr2_queue_writer.py add_external` re-checks
+    /// independently on the Pro side once the entry propagates (§B).
+    @discardableResult
+    static func addExternalPost(queueFile: URL, entry: [String: Any]) throws -> Bool {
+        let newID = entry["item_id"] as? String
+        let newURL = (entry["instagram_post_url"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let data = (try? Data(contentsOf: queueFile)) ?? Data("[]".utf8)
+        var arr = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] ?? []
+
+        let isDuplicate = arr.contains { existing in
+            if let nid = newID, (existing["item_id"] as? String) == nid { return true }
+            if let nurl = newURL, nurl.isEmpty == false {
+                let existingURL = (existing["instagram_post_url"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if existingURL == nurl { return true }
+            }
+            return false
+        }
+        guard isDuplicate == false else {
+            throw NSError(domain: "QueueWriter", code: duplicateExternalPostErrorCode, userInfo: [
+                NSLocalizedDescriptionKey:
+                    "un post con questo URL o id è già registrato"
+            ])
+        }
+
+        arr.append(entry)
+        let out = try JSONSerialization.data(withJSONObject: arr, options: [.prettyPrinted, .sortedKeys])
+        let tmp = queueFile.deletingLastPathComponent()
+            .appendingPathComponent(".\(queueFile.lastPathComponent).tmp-\(UUID().uuidString)")
+        do {
+            try out.write(to: tmp)
+            _ = try FileManager.default.replaceItemAt(queueFile, withItemAt: tmp)
+        } catch {
+            try? FileManager.default.removeItem(at: tmp)
+            throw error
+        }
+        return true
+    }
+
     /// Append a fresh `drafted` review entry for a just-rendered carousel, so it surfaces
     /// in Revisione. Closes the Step-7 enqueue gap: the orchestrator renders to
     /// output/carousel/<slug>/ but does not always write the queue row itself.

--- a/apps/wr2-control-app/Sources/QueueWriter.swift
+++ b/apps/wr2-control-app/Sources/QueueWriter.swift
@@ -88,7 +88,6 @@ enum QueueWriter {
     /// classification the gallery band and `Carousel.isPublishEligible` use — so this
     /// is not a second, independently-maintained rule (scar #3).
     static func markPublished(queueFile: URL, slug: String, igURL: String, publishedAt: String) throws {
-        let mediaID = extractMediaID(from: igURL)
         try mutate(queueFile: queueFile, slug: slug) { item in
             let state = item["state"] as? String
             let verdict = item["critic_overall_verdict"] as? String
@@ -103,7 +102,14 @@ enum QueueWriter {
             }
             item["state"] = "published"
             item["instagram_post_url"] = igURL
-            if let m = mediaID { item["ig_media_id"] = m }
+            // NEVER write ig_media_id here (Codex red-team, 2026-07-17, finding B):
+            // extractMediaID(from:) returns the URL SHORTCODE, not the real numeric
+            // Graph media id — the scraper's media_id_of() (wr2_ig_metrics_scraper.py)
+            // now treats a present ig_media_id as AUTHORITATIVE and feeds it straight
+            // to the Graph API, so writing the shortcode here would poison metrics for
+            // every app-published post (Graph 400 / wrong media). The real numeric id
+            // is only ever known by wr2_ig_discovery.py's Graph fetch and is backfilled
+            // later via backfill_media_id — this writer must leave the field untouched.
             item["instagram_published_at"] = publishedAt
         }
     }
@@ -141,15 +147,45 @@ enum QueueWriter {
         let newID = entry["item_id"] as? String
         let newURL = (entry["instagram_post_url"] as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let data = (try? Data(contentsOf: queueFile)) ?? Data("[]".utf8)
-        var arr = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] ?? []
+        // Only a genuine "no queue file yet" starts from an empty array (Codex
+        // red-team, 2026-07-17, finding A). The previous `(try? ...) ?? []` on
+        // BOTH the read and the parse meant ANY transient read error (a sandbox
+        // hiccup, a concurrent writer mid-replace) OR a decode failure (corrupt/
+        // truncated JSON) silently degraded to [], and the append below would
+        // then WRITE OVER THE WHOLE QUEUE with just this one entry. A real file
+        // that exists but fails to read or parse must THROW — visible in the UI,
+        // zero write — never be treated as "empty".
+        var arr: [[String: Any]]
+        if FileManager.default.fileExists(atPath: queueFile.path) {
+            let data = try Data(contentsOf: queueFile)
+            guard let parsed = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+                throw NSError(domain: "QueueWriter", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "queue is not a JSON array — refusing to overwrite it"
+                ])
+            }
+            arr = parsed
+        } else {
+            arr = []
+        }
 
+        // Shortcode-first (Codex red-team, 2026-07-17, finding D, mirrored from the
+        // Python-side add_external fix): an existing entry's URL may carry a
+        // different query string/scheme/www variant (e.g. a stray ?utm_...) of
+        // the SAME post — comparing by shortcode first (WarRoom.igShortcode)
+        // catches that; exact-string is only the fallback when either URL
+        // doesn't parse a shortcode at all.
+        let newShortcode = newURL.flatMap { WarRoom.igShortcode(from: $0) }
         let isDuplicate = arr.contains { existing in
             if let nid = newID, (existing["item_id"] as? String) == nid { return true }
             if let nurl = newURL, nurl.isEmpty == false {
                 let existingURL = (existing["instagram_post_url"] as? String)?
                     .trimmingCharacters(in: .whitespacesAndNewlines)
-                if existingURL == nurl { return true }
+                if let newCode = newShortcode, let existingURL,
+                   let existingCode = WarRoom.igShortcode(from: existingURL) {
+                    if existingCode == newCode { return true }
+                } else if existingURL == nurl {
+                    return true
+                }
             }
             return false
         }

--- a/apps/wr2-control-app/Sources/Views/GalleryView.swift
+++ b/apps/wr2-control-app/Sources/Views/GalleryView.swift
@@ -24,6 +24,7 @@ struct GalleryView: View {
     var onSelect: ((Carousel) -> Void)? = nil
     @State private var selected: Carousel?   // used only when onSelect is nil (legacy sheet)
     @State private var sort: GallerySort = .recent
+    @State private var showingAddExternalPost = false
 
     private let columns = [GridItem(.adaptive(minimum: 200, maximum: 240), spacing: 18)]
 
@@ -53,6 +54,10 @@ struct GalleryView: View {
                     .pickerStyle(.segmented)
                     .frame(width: 260)
 
+                    Button { showingAddExternalPost = true } label: {
+                        Label(lang.t("externalPost.button"), systemImage: "plus.square.on.square").font(.system(size: 12))
+                    }.buttonStyle(.bordered).tint(Theme.muted)
+
                     Button { state.refreshFromDisk() } label: {
                         Label(lang.t("gallery.refresh"), systemImage: "arrow.clockwise").font(.system(size: 12))
                     }.buttonStyle(.bordered).tint(Theme.muted)
@@ -74,6 +79,7 @@ struct GalleryView: View {
         }
         // legacy sheet — only shown when onSelect is nil (e.g. GalleryView used standalone)
         .sheet(item: $selected) { c in CarouselDetail(carousel: c, lang: lang) }
+        .sheet(isPresented: $showingAddExternalPost) { AddExternalPostView(lang: lang) }
     }
 
     private var emptyState: some View {
@@ -285,6 +291,96 @@ struct CarouselDetail: View {
                     Text(nums.prefix(6).joined(separator: "  ·  ")).font(Theme.numberFont).foregroundStyle(Theme.yellow)
                 }
             }
+        }
+    }
+}
+
+// MARK: - Add external post (§A, 2026-07-17)
+
+/// "Aggiungi post esterno" sheet — register an Instagram post that was published
+/// OUTSIDE the app (never went through the pipeline), optionally attaching images
+/// picked from disk. Validation + entry construction is pure (ExternalPostRegistration);
+/// this view only collects input and delegates the write to AppState.addExternalPost.
+struct AddExternalPostView: View {
+    @EnvironmentObject var state: AppState
+    let lang: LanguageManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var urlText: String = ""
+    @State private var topicText: String = ""
+    @State private var publishDate: Date = Date()
+    @State private var images: [URL] = []
+    @State private var errorText: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text(lang.t("externalPost.title"))
+                    .font(.system(size: 16, weight: .bold)).foregroundStyle(Theme.white)
+                Spacer()
+                Button { dismiss() } label: { Image(systemName: "xmark") }
+                    .buttonStyle(.plain).foregroundStyle(Theme.muted)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(lang.t("externalPost.urlLabel")).font(.system(size: 11, weight: .semibold)).foregroundStyle(Theme.muted)
+                TextField("https://instagram.com/p/…", text: $urlText).textFieldStyle(.roundedBorder)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(lang.t("externalPost.topicLabel")).font(.system(size: 11, weight: .semibold)).foregroundStyle(Theme.muted)
+                TextField("", text: $topicText).textFieldStyle(.roundedBorder)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(lang.t("externalPost.dateLabel")).font(.system(size: 11, weight: .semibold)).foregroundStyle(Theme.muted)
+                DatePicker("", selection: $publishDate, displayedComponents: [.date]).labelsHidden()
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(lang.t("externalPost.imagesLabel")).font(.system(size: 11, weight: .semibold)).foregroundStyle(Theme.muted)
+                HStack(spacing: 10) {
+                    Button(lang.t("externalPost.pickImages")) { pickImages() }.buttonStyle(.bordered).tint(Theme.muted)
+                    if images.isEmpty == false {
+                        Text(String(format: lang.t("externalPost.imagesCount"), images.count))
+                            .font(.system(size: 11)).foregroundStyle(Theme.muted)
+                    }
+                }
+            }
+
+            if let errorText {
+                Text(errorText).font(.system(size: 11)).foregroundStyle(.red)
+            }
+
+            HStack {
+                Spacer()
+                Button(lang.t("studio.cancel")) { dismiss() }.buttonStyle(.bordered).tint(Theme.muted)
+                Button(lang.t("externalPost.save")) { save() }.buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+        .background(Theme.ink)
+    }
+
+    private func pickImages() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = true
+        panel.allowedContentTypes = [.png, .jpeg]
+        guard panel.runModal() == .OK else { return }
+        images = panel.urls
+    }
+
+    private func save() {
+        errorText = nil
+        do {
+            try state.addExternalPost(igURLRaw: urlText, topicRaw: topicText,
+                                       publishDate: publishDate, images: images, lang: lang)
+            dismiss()
+        } catch {
+            errorText = error.localizedDescription
         }
     }
 }

--- a/apps/wr2-control-app/Sources/Views/ReviewView.swift
+++ b/apps/wr2-control-app/Sources/Views/ReviewView.swift
@@ -8,7 +8,19 @@ struct ReviewView: View {
     @State private var selectedCarousel: Carousel? = nil
     @State private var showExternalImport = false
 
+    // Codex red-team finding J, 2026-07-17: `state.queue` is the RAW, unfiltered
+    // parse of human-review-queue.json — every state, including already-published
+    // entries (WR2-native AND the §A external-post feature's own state="published"
+    // rows). This surface is titled "Review" / "items in queue" — a published entry
+    // isn't waiting for anything, so it must not pollute the pending-review list.
+    // Reuses the SAME canonical predicate the gallery/completeness-gate use
+    // (`isQueueItemPublished`, Models.swift) rather than a second ad-hoc rule.
+    private var pendingReviewQueue: [ReviewItem] {
+        state.queue.filter { !isQueueItemPublished($0) }
+    }
+
     var body: some View {
+        let pending = pendingReviewQueue
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 HStack {
@@ -16,7 +28,7 @@ struct ReviewView: View {
                         Text(lang.t("review.title")).font(Theme.titleFont).foregroundStyle(Theme.white)
                         HStack(spacing: 8) {
                             FactRule(width: 28)
-                            Text("\(state.queue.count) \(lang.t("review.count"))")
+                            Text("\(pending.count) \(lang.t("review.count"))")
                                 .font(Theme.bodyFont).foregroundStyle(Theme.muted)
                         }
                     }
@@ -35,11 +47,11 @@ struct ReviewView: View {
                     Text(n).font(.system(size: 11, weight: .semibold)).foregroundStyle(Theme.green)
                 }
 
-                if state.queue.isEmpty {
+                if pending.isEmpty {
                     empty
                 } else {
                     VStack(spacing: 10) {
-                        ForEach(state.queue) { item in
+                        ForEach(pending) { item in
                             // Open the carousel detail (Migliora / Zero Design / mark-published)
                             // by joining the queue item to its on-disk carousel.
                             // WarRoom.matchCarousel handles both slug vocabularies (legacy

--- a/apps/wr2-control-app/Sources/WarRoom.swift
+++ b/apps/wr2-control-app/Sources/WarRoom.swift
@@ -230,6 +230,71 @@ enum WarRoom {
             || physicalSlugs.contains(where: { queueItemMatchesByFSMRegex(item, candidateSlug: $0) })
     }
 
+    // MARK: - Gallery recency sort key (§D, 2026-07-17 — "re-rendered cards must not
+    // stay buried under their original date")
+
+    /// Newest on-disk modification date among the given slide PNGs, or `nil` if empty.
+    static func newestSlideModificationDate(_ slidePNGs: [URL]) -> Date? {
+        slidePNGs
+            .compactMap { (try? $0.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate }
+            .max()
+    }
+
+    /// The gallery "recent" sort key for an on-disk carousel. A directory's own mtime
+    /// bumps only on add/remove/rename of entries WITHIN it — on APFS/HFS+, overwriting
+    /// an EXISTING file's bytes in place (a re-render replacing slides/1.png with fresh
+    /// content, same filename) does NOT bump the directory's mtime, so a carousel
+    /// re-rendered today kept sorting under its original creation date (ground
+    /// 2026-07-17: a carousel re-rendered 16/7 stayed buried under its 2026-07-14 dir).
+    /// Fix: take the max of the directory mtime and the newest slide PNG's OWN mtime —
+    /// the slide FILE's mtime DOES bump on an in-place overwrite.
+    ///
+    /// Published carousels are the one exception: they sort by `publishedAt` (when
+    /// parseable), never by file-touch recency — an unrelated LATER touch of a
+    /// published carousel's files (e.g. a metrics backfill writing into the same dir)
+    /// must never bump its position; publication date is what matters for a live post.
+    static func recencySortKey(
+        dirModified: Date, newestSlideModified: Date?, isPublished: Bool, publishedAt: String?
+    ) -> Date {
+        if isPublished, let pubAt = publishedAt, let parsed = parsePublishedAt(pubAt) {
+            return parsed
+        }
+        return max(dirModified, newestSlideModified ?? Date.distantPast)
+    }
+
+    // MARK: - Duplicate virtual-entry detection (§E, 2026-07-17)
+
+    /// Extract the IG shortcode (the `/p/<code>/` or `/reel/<code>/` segment) from a
+    /// post/reel URL, or `nil` if the string doesn't look like one. Mirrors
+    /// `QueueWriter.extractMediaID`'s shape (Swift) and Python's
+    /// `extract_ig_shortcode`/`ExternalPostRegistration`'s pattern — used here so a
+    /// cosmetic difference (trailing slash, query string) between two URLs referring to
+    /// the SAME post doesn't defeat a real duplicate match (entity-based match, not
+    /// bare substring — scar #3 discipline).
+    static func igShortcode(from url: String) -> String? {
+        let s = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let r = s.range(of: #"/(p|reel|tv)/([^/?#]+)"#, options: .regularExpression) else { return nil }
+        let seg = String(s[r])
+        return seg.components(separatedBy: "/").filter { !$0.isEmpty }.last
+    }
+
+    /// True if `igURL` refers to the SAME Instagram post as any URL in `knownURLs`
+    /// (compared by shortcode when both parse as IG post/reel URLs, else by trimmed
+    /// exact string). Used to hide a virtual `ig-*`-style queue entry when a REAL
+    /// on-disk carousel already carries the same `instagram_post_url` (live case:
+    /// `ig-DaxDJuYFPi6` duplicating `bali-pma-rental-crackdown`'s own queue-joined URL).
+    static func matchesAnyPhysicalInstagramURL(_ igURL: String, knownURLs: [String]) -> Bool {
+        let target = igURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard target.isEmpty == false else { return false }
+        let targetCode = igShortcode(from: target)
+        return knownURLs.contains { raw in
+            let known = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard known.isEmpty == false else { return false }
+            if let tc = targetCode, let kc = igShortcode(from: known) { return tc == kc }
+            return known == target
+        }
+    }
+
     // MARK: - Carousel gallery scan
 
     static func scanCarousels(carouselRoot root: URL? = nil,
@@ -335,8 +400,15 @@ enum WarRoom {
                 }
             }
 
-            let mod = (try? dir.resourceValues(forKeys: [.contentModificationDateKey]))?
+            // §D recency fix (2026-07-17): dir mtime alone misses in-place re-renders
+            // (same filenames, fresh bytes) — see recencySortKey's doc comment.
+            let dirModified = (try? dir.resourceValues(forKeys: [.contentModificationDateKey]))?
                 .contentModificationDate ?? Date.distantPast
+            let mod = recencySortKey(
+                dirModified: dirModified,
+                newestSlideModified: newestSlideModificationDate(pngs),
+                isPublished: published,
+                publishedAt: pubAtBySlug[slug])
             let brief = readBrief(in: dir)
 
             carousels.append(Carousel(
@@ -367,10 +439,21 @@ enum WarRoom {
         // (not a raw topic_slug/basename guess) — otherwise a physical dir the gate excluded, or
         // one whose queue row's topic_slug is a truncated FSM form, gets a duplicate phantom
         // entry here that shadows its real cover/slides (Codex red-team finding #4, 2026-07-16).
+        //
+        // §E dedup (2026-07-17): the slug/topic_slug-based resolver above only catches a
+        // duplicate when THIS item's OWN slug fields happen to match a physical dir. A
+        // SEPARATE queue row (e.g. an independent Graph-API backfill entry, `ig-<mediaid>`)
+        // whose slug fields point nowhere but whose `instagram_post_url` is the SAME post
+        // a real carousel already displays is missed by that check — live case:
+        // `ig-DaxDJuYFPi6` duplicating `bali-pma-rental-crackdown`'s own queue-joined URL.
+        // `igUrlBySlug` already holds, for every physical dir, the URL its OWN resolved
+        // queue item carries — comparing against those values (not just slugs) catches it.
+        let physicalInstagramURLs = Array(igUrlBySlug.values)
         for item in queue {
             guard let igURL = item.instagram_post_url,
                   igURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else { continue }
             guard resolvesToPhysicalDir(item, physicalSlugs: physicalSlugs) == false else { continue }
+            guard matchesAnyPhysicalInstagramURL(igURL, knownURLs: physicalInstagramURLs) == false else { continue }
             let slug = item.topic_slug
                 ?? item.carousel_path.map { ($0 as NSString).lastPathComponent }
                 ?? item.id

--- a/apps/wr2-control-app/Tests/main.swift
+++ b/apps/wr2-control-app/Tests/main.swift
@@ -829,6 +829,260 @@ func test_externalImportOutcomeParsing() {
     }
 }
 
+// MARK: - External post registration (§A, 2026-07-17)
+
+func test_externalPostRegistrationURLValidation() {
+    T.suite("ExternalPostRegistration — Instagram URL validation/canonicalization")
+
+    // INNOCENZA — well-formed URLs in several shapes all canonicalize correctly.
+    do {
+        let canon = try ExternalPostRegistration.canonicalizeInstagramURL("https://instagram.com/p/Cabc123_-")
+        T.eq(canon, "https://www.instagram.com/p/Cabc123_-/", "bare p/ URL (no www, no trailing slash) canonicalizes")
+    } catch { T.check(false, "well-formed p/ URL should not throw: \(error)") }
+
+    do {
+        let canon = try ExternalPostRegistration.canonicalizeInstagramURL("  https://www.instagram.com/reel/Xyz789/?igshid=foo  ")
+        T.eq(canon, "https://www.instagram.com/reel/Xyz789/", "reel URL with query string + surrounding whitespace canonicalizes, drops query")
+    } catch { T.check(false, "well-formed reel URL should not throw: \(error)") }
+
+    // COLPEVOLEZZA — reject empty/garbage (acceptance criteria §A).
+    func expectThrows(_ url: String, _ expected: ExternalPostRegistration.ValidationError, _ msg: String) {
+        do {
+            _ = try ExternalPostRegistration.canonicalizeInstagramURL(url)
+            T.check(false, "\(msg): should have thrown")
+        } catch let e as ExternalPostRegistration.ValidationError {
+            T.eq(e, expected, msg)
+        } catch {
+            T.check(false, "\(msg): wrong error type \(error)")
+        }
+    }
+    expectThrows("", .emptyURL, "empty string rejected")
+    expectThrows("   ", .emptyURL, "whitespace-only rejected")
+    expectThrows("not a url", .notAnInstagramPostURL, "garbage string rejected")
+    expectThrows("https://instagram.com/balizero0", .notAnInstagramPostURL, "profile URL (not a post) rejected")
+    expectThrows("https://example.com/p/abc/", .notAnInstagramPostURL, "wrong host rejected")
+}
+
+func test_externalPostRegistrationTopicAndIdentity() {
+    T.suite("ExternalPostRegistration — topic validation + item_id/dir-name/entry construction")
+
+    do {
+        let t = try ExternalPostRegistration.validateTopic("  My manual post  ")
+        T.eq(t, "My manual post", "topic is trimmed")
+    } catch { T.check(false, "well-formed topic should not throw") }
+
+    do {
+        _ = try ExternalPostRegistration.validateTopic("   ")
+        T.check(false, "blank topic should throw emptyTopic")
+    } catch ExternalPostRegistration.ValidationError.emptyTopic {
+        T.check(true, "blank topic throws emptyTopic")
+    } catch { T.check(false, "wrong error type") }
+
+    var comps = DateComponents()
+    comps.year = 2026; comps.month = 7; comps.day = 17; comps.hour = 9; comps.minute = 0; comps.second = 0
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = TimeZone(identifier: "UTC")!
+    let date = cal.date(from: comps)!
+
+    T.eq(ExternalPostRegistration.makeItemID(publishDate: date, slug: "my-manual-post"),
+         "external_2026-07-17T090000_my-manual-post", "item_id format: external_<date>T<time>_<slug>")
+    T.eq(ExternalPostRegistration.carouselDirName(publishDate: date, slug: "my-manual-post"),
+         "external-2026-07-17-my-manual-post", "carousel dir name: external-<date>-<slug>")
+
+    let entryNoImages = ExternalPostRegistration.buildQueueEntry(
+        instagramURL: "https://www.instagram.com/p/Abc123/", topic: "My manual post",
+        slug: "my-manual-post", publishDate: date, slideCount: 0, carouselPath: nil)
+    T.eq(entryNoImages["item_id"] as? String, "external_2026-07-17T090000_my-manual-post", "0-image entry item_id")
+    T.eq(entryNoImages["state"] as? String, "published", "0-image entry state=published")
+    T.eq(entryNoImages["source"] as? String, "external_manual", "0-image entry source=external_manual")
+    T.eq(entryNoImages["slide_count"] as? Int, 0, "0-image entry slide_count=0")
+    T.check(entryNoImages["carousel_path"] == nil, "0-image entry has NO carousel_path (renders as virtual card)")
+    T.check(entryNoImages["instagram_published_at"] != nil, "instagram_published_at set (existing consumers read this key)")
+    T.check(entryNoImages["published_at"] != nil, "published_at also set (spec's literal field name)")
+
+    let entryWithImages = ExternalPostRegistration.buildQueueEntry(
+        instagramURL: "https://www.instagram.com/p/Abc123/", topic: "My manual post",
+        slug: "my-manual-post", publishDate: date, slideCount: 3,
+        carouselPath: "~/nuzantara/apps/war-room/output/carousel/external-2026-07-17-my-manual-post/")
+    T.eq(entryWithImages["slide_count"] as? Int, 3, "image entry slide_count reflects the copied-image count")
+    T.check(entryWithImages["carousel_path"] != nil, "image entry HAS carousel_path")
+}
+
+// MARK: - Gallery recency sort key (§D, 2026-07-17 — re-rendered cards must not stay buried)
+
+func test_recencySortKeyPure() {
+    T.suite("WarRoom.recencySortKey — max(dir, slide-mtime) for drafts, publishedAt for published")
+
+    let dirOld = Date(timeIntervalSince1970: 1_752_000_000)
+    let slideNew = Date(timeIntervalSince1970: 1_752_800_000)   // later than dirOld
+
+    // COLPEVOLEZZA (the pre-fix bug: dir mtime alone) — a fresher slide mtime must win.
+    let key1 = WarRoom.recencySortKey(dirModified: dirOld, newestSlideModified: slideNew,
+                                        isPublished: false, publishedAt: nil)
+    T.eq(key1, slideNew, "unpublished: newer slide mtime wins over older dir mtime")
+
+    // INNOCENZA — max, not "always prefer slide": dir mtime wins when it IS the newer one.
+    let key2 = WarRoom.recencySortKey(dirModified: slideNew, newestSlideModified: dirOld,
+                                        isPublished: false, publishedAt: nil)
+    T.eq(key2, slideNew, "unpublished: dir mtime wins when it's the newer one")
+
+    let key3 = WarRoom.recencySortKey(dirModified: dirOld, newestSlideModified: nil,
+                                        isPublished: false, publishedAt: nil)
+    T.eq(key3, dirOld, "unpublished, no slide mtime available: falls back to dir mtime alone")
+
+    // PUBLISHED — publishedAt wins even when file mtimes are much newer (an unrelated
+    // later touch, e.g. a metrics backfill, must never bump a live post's position).
+    let pubDate = "2026-06-01T00:00:00Z"
+    let key4 = WarRoom.recencySortKey(dirModified: slideNew, newestSlideModified: slideNew,
+                                        isPublished: true, publishedAt: pubDate)
+    T.eq(key4, WarRoom.parsePublishedAt(pubDate), "published: publishedAt wins over much-newer file mtimes")
+
+    // published but no/unparseable publishedAt → falls back to max(dir, slide).
+    let key5 = WarRoom.recencySortKey(dirModified: dirOld, newestSlideModified: slideNew,
+                                        isPublished: true, publishedAt: nil)
+    T.eq(key5, slideNew, "published with no publishedAt: falls back to max(dir, slide)")
+}
+
+func test_scanCarouselsRerenderSortsToTop() {
+    T.suite("WarRoom.scanCarousels — re-rendered carousel sorts to top of drafted (§D acceptance #3)")
+
+    let root = makeFixtureRoot()
+    defer { try? fm.removeItem(at: root) }
+    let croot = root.appendingPathComponent("carousel", isDirectory: true)
+
+    let oldDir = makeCarousel(in: root, slug: "old-draft", slides: ["1.png", "2.png"])
+    // "re-rendered" dir: same shape — a re-render overwrites the PNG bytes in place,
+    // same filenames, so its directory's OWN mtime does not bump (see doc comment).
+    let rerenderedDir = makeCarousel(in: root, slug: "rerendered-draft", slides: ["1.png", "2.png"])
+
+    let farPast = Date(timeIntervalSinceNow: -86_400 * 30)
+    let justNow = Date()
+    try? fm.setAttributes([.modificationDate: farPast], ofItemAtPath: oldDir.path)
+    try? fm.setAttributes([.modificationDate: farPast], ofItemAtPath: rerenderedDir.path)
+    let rerenderedSlide = rerenderedDir.appendingPathComponent("slides/1.png")
+    try? fm.setAttributes([.modificationDate: justNow], ofItemAtPath: rerenderedSlide.path)
+
+    let queueJSON = """
+    [
+      {"id":"od","topic_slug":"old-draft","slide_count":2,"state":"drafted"},
+      {"id":"rd","topic_slug":"rerendered-draft","slide_count":2,"state":"drafted"}
+    ]
+    """
+    let qurl = fm.temporaryDirectory.appendingPathComponent("q-\(UUID()).json")
+    try? queueJSON.data(using: .utf8)!.write(to: qurl)
+    defer { try? fm.removeItem(at: qurl) }
+    let queue = WarRoom.readQueue(queueFile: qurl)
+
+    let carousels = WarRoom.scanCarousels(carouselRoot: croot, queue: queue)
+        .sorted { $0.modified > $1.modified }
+    T.eq(carousels.first?.slug, "rerendered-draft",
+         "the re-rendered carousel (fresh slide mtime) sorts FIRST despite both dirs sharing an old dir-mtime")
+}
+
+// MARK: - Duplicate virtual-entry detection (§E, 2026-07-17)
+
+func test_igShortcodeExtraction() {
+    T.suite("WarRoom.igShortcode — entity extraction for URL-equality dedup")
+    T.eq(WarRoom.igShortcode(from: "https://www.instagram.com/p/DaxDJuYFPi6/"), "DaxDJuYFPi6", "p/ URL")
+    T.eq(WarRoom.igShortcode(from: "https://instagram.com/reel/Xyz789/?igshid=x"), "Xyz789", "reel/ URL with query string")
+    T.check(WarRoom.igShortcode(from: "https://instagram.com/balizero0") == nil, "profile URL has no shortcode")
+}
+
+func test_matchesAnyPhysicalInstagramURL() {
+    T.suite("WarRoom.matchesAnyPhysicalInstagramURL — cosmetic-difference-tolerant URL dedup")
+
+    let known = ["https://www.instagram.com/p/DaxDJuYFPi6/", "https://www.instagram.com/p/Other111/"]
+    T.check(WarRoom.matchesAnyPhysicalInstagramURL("https://instagram.com/p/DaxDJuYFPi6/?igshid=x", knownURLs: known),
+            "same shortcode, different cosmetic form (no www, query string) still matches")
+    T.check(WarRoom.matchesAnyPhysicalInstagramURL("https://www.instagram.com/p/Unrelated999/", knownURLs: known) == false,
+            "a genuinely different shortcode does not match")
+    T.check(WarRoom.matchesAnyPhysicalInstagramURL("", knownURLs: known) == false, "empty string never matches")
+    T.check(WarRoom.matchesAnyPhysicalInstagramURL("https://instagram.com/p/DaxDJuYFPi6/", knownURLs: []) == false,
+            "no known URLs at all -> no match")
+}
+
+func test_scanCarouselsDedupesVirtualEntrySharingURL() {
+    T.suite("WarRoom.scanCarousels — virtual ig-* entry hidden when a physical sibling shares its URL (§E)")
+
+    let root = makeFixtureRoot()
+    defer { try? fm.removeItem(at: root) }
+    let croot = root.appendingPathComponent("carousel", isDirectory: true)
+
+    // the REAL carousel, published, with its own queue-joined instagram_post_url.
+    _ = makeCarousel(in: root, slug: "bali-pma-rental-crackdown", slides: ["1.png"], declareSlides: .absent)
+
+    let queueJSON = """
+    [
+      {"id":"real-1","topic_slug":"bali-pma-rental-crackdown","state":"published",
+       "instagram_post_url":"https://www.instagram.com/p/DaxDJuYFPi6/",
+       "instagram_published_at":"2026-06-01T00:00:00Z"},
+      {"item_id":"ig-DaxDJuYFPi6","topic":"(backfill duplicate)","state":"published",
+       "instagram_post_url":"https://www.instagram.com/p/DaxDJuYFPi6/?igshid=x",
+       "instagram_published_at":"2026-06-01T00:00:00Z"},
+      {"item_id":"ig-GenuinelyUnrelated1","topic":"(a real other IG-only post)","state":"published",
+       "instagram_post_url":"https://www.instagram.com/p/GenuinelyUnrelated1/",
+       "instagram_published_at":"2026-06-02T00:00:00Z"}
+    ]
+    """
+    let qurl = fm.temporaryDirectory.appendingPathComponent("q-\(UUID()).json")
+    try? queueJSON.data(using: .utf8)!.write(to: qurl)
+    defer { try? fm.removeItem(at: qurl) }
+    let queue = WarRoom.readQueue(queueFile: qurl)
+
+    let carousels = WarRoom.scanCarousels(carouselRoot: croot, queue: queue)
+
+    // GUILT — without the fix this would show TWO cards for the same post.
+    let dupMatches = carousels.filter { $0.instagramURL?.contains("DaxDJuYFPi6") == true }
+    T.eq(dupMatches.count, 1, "only ONE card total for the DaxDJuYFPi6 post (the real on-disk one, virtual hidden)")
+    T.check(dupMatches.first?.slug == "bali-pma-rental-crackdown",
+            "the surviving card is the REAL on-disk carousel, not the virtual phantom")
+
+    // INNOCENCE — a genuinely unrelated IG-only post (no physical sibling) still shows.
+    T.check(carousels.contains { $0.slug == "ig-GenuinelyUnrelated1" },
+            "a genuinely different IG-only post with no physical sibling still renders as a virtual card")
+}
+
+// MARK: - External-manual entries: completeness gate exemption (§A guilt+innocence pair)
+
+func test_externalManualCompletenessGateGuiltInnocence() {
+    T.suite("A2 completeness gate — external_manual entries stay exempt (§A guilt+innocence regression)")
+
+    let root = makeFixtureRoot()
+    defer { try? fm.removeItem(at: root) }
+    let croot = root.appendingPathComponent("carousel", isDirectory: true)
+
+    // GUILT — an ordinary DRAFTED (unpublished) dir whose real PNG count (1) doesn't
+    // match its declared count (3) must STILL be excluded — the pre-existing A2 gate,
+    // unchanged by the external-post feature.
+    _ = makeCarousel(in: root, slug: "mismatched-draft", slides: ["1.png"], declareSlides: .objectSlides(3))
+
+    let queueJSON = """
+    [
+      {"id":"md","topic_slug":"mismatched-draft","state":"drafted"},
+      {"item_id":"external_2026-07-17T090000_no-image-test","state":"published",
+       "instagram_post_url":"https://www.instagram.com/p/ExternalNoImage1/",
+       "instagram_published_at":"2026-07-17T09:00:00Z","source":"external_manual",
+       "topic":"No-image external post","topic_slug":"no-image-test","slide_count":0}
+    ]
+    """
+    let qurl = fm.temporaryDirectory.appendingPathComponent("q-\(UUID()).json")
+    try? queueJSON.data(using: .utf8)!.write(to: qurl)
+    defer { try? fm.removeItem(at: qurl) }
+    let queue = WarRoom.readQueue(queueFile: qurl)
+
+    let carousels = WarRoom.scanCarousels(carouselRoot: croot, queue: queue)
+
+    T.check(carousels.contains { $0.slug == "mismatched-draft" } == false,
+            "GUILT: mismatched-disk drafted entry is still excluded from the gallery")
+    T.eq(WarRoom.excludedIncompleteCount, 1,
+         "GUILT: the exclusion is observable via excludedIncompleteCount (scar #2)")
+
+    let external = carousels.first { $0.instagramURL == "https://www.instagram.com/p/ExternalNoImage1/" }
+    T.check(external != nil, "INNOCENCE: the 0-image external_manual entry IS present in the gallery")
+    T.check(external?.isPublished == true, "INNOCENCE: it renders as published")
+    T.eq(external?.slideCount, 0, "INNOCENCE: slideCount reflects the declared 0")
+}
+
 // MARK: - main
 
 let suites: [() -> Void] = [
@@ -853,6 +1107,14 @@ let suites: [() -> Void] = [
     test_externalImportClassification,
     test_externalImportArguments,
     test_externalImportOutcomeParsing,
+    test_externalPostRegistrationURLValidation,
+    test_externalPostRegistrationTopicAndIdentity,
+    test_recencySortKeyPure,
+    test_scanCarouselsRerenderSortsToTop,
+    test_igShortcodeExtraction,
+    test_matchesAnyPhysicalInstagramURL,
+    test_scanCarouselsDedupesVirtualEntrySharingURL,
+    test_externalManualCompletenessGateGuiltInnocence,
 ]
 for s in suites { s() }
 exit(T.report())

--- a/apps/wr2-control-app/Tests/main.swift
+++ b/apps/wr2-control-app/Tests/main.swift
@@ -886,8 +886,22 @@ func test_externalPostRegistrationTopicAndIdentity() {
 
     T.eq(ExternalPostRegistration.makeItemID(publishDate: date, slug: "my-manual-post"),
          "external_2026-07-17T090000_my-manual-post", "item_id format: external_<date>T<time>_<slug>")
+    // Codex red-team finding H, 2026-07-17: dir name now carries TIME too (matches
+    // makeItemID's date+time uniqueness) — was date+slug only, which let two
+    // same-day same-slug registrations collide into one directory.
     T.eq(ExternalPostRegistration.carouselDirName(publishDate: date, slug: "my-manual-post"),
-         "external-2026-07-17-my-manual-post", "carousel dir name: external-<date>-<slug>")
+         "external-2026-07-17T090000-my-manual-post", "carousel dir name: external-<date>T<time>-<slug>")
+
+    // GUILT (finding H): two same-day, same-slug registrations at DIFFERENT times
+    // must now produce DISTINCT dir names — the exact collision the date-only
+    // format allowed.
+    var comps2 = comps
+    comps2.hour = 14; comps2.minute = 30
+    let laterSameDay = cal.date(from: comps2)!
+    T.check(
+        ExternalPostRegistration.carouselDirName(publishDate: date, slug: "my-manual-post") !=
+        ExternalPostRegistration.carouselDirName(publishDate: laterSameDay, slug: "my-manual-post"),
+        "two same-day same-slug registrations at different times get DISTINCT dir names (finding H)")
 
     let entryNoImages = ExternalPostRegistration.buildQueueEntry(
         instagramURL: "https://www.instagram.com/p/Abc123/", topic: "My manual post",
@@ -903,7 +917,7 @@ func test_externalPostRegistrationTopicAndIdentity() {
     let entryWithImages = ExternalPostRegistration.buildQueueEntry(
         instagramURL: "https://www.instagram.com/p/Abc123/", topic: "My manual post",
         slug: "my-manual-post", publishDate: date, slideCount: 3,
-        carouselPath: "~/nuzantara/apps/war-room/output/carousel/external-2026-07-17-my-manual-post/")
+        carouselPath: "~/nuzantara/apps/war-room/output/carousel/external-2026-07-17T090000-my-manual-post/")
     T.eq(entryWithImages["slide_count"] as? Int, 3, "image entry slide_count reflects the copied-image count")
     T.check(entryWithImages["carousel_path"] != nil, "image entry HAS carousel_path")
 }

--- a/apps/wr2-control-app/Tests/main.swift
+++ b/apps/wr2-control-app/Tests/main.swift
@@ -1004,6 +1004,12 @@ func test_matchesAnyPhysicalInstagramURL() {
 func test_scanCarouselsDedupesVirtualEntrySharingURL() {
     T.suite("WarRoom.scanCarousels — virtual ig-* entry hidden when a physical sibling shares its URL (§E)")
 
+    // Live shape (team-lead diagnosis, 2026-07-17): the real queue had TWO
+    // entries for this post — idx 61 (native, this fixture's "real-1") only
+    // got its instagram_post_url once flipped to published, and idx 71
+    // (ig-DaxDJuYFPi6) was discovery-ingested 07-14 while idx 61's URL was
+    // still null, with its topic mislabeled "150 LICENSED." — kept verbatim
+    // here for direct traceability to the incident, not a placeholder.
     let root = makeFixtureRoot()
     defer { try? fm.removeItem(at: root) }
     let croot = root.appendingPathComponent("carousel", isDirectory: true)
@@ -1016,7 +1022,7 @@ func test_scanCarouselsDedupesVirtualEntrySharingURL() {
       {"id":"real-1","topic_slug":"bali-pma-rental-crackdown","state":"published",
        "instagram_post_url":"https://www.instagram.com/p/DaxDJuYFPi6/",
        "instagram_published_at":"2026-06-01T00:00:00Z"},
-      {"item_id":"ig-DaxDJuYFPi6","topic":"(backfill duplicate)","state":"published",
+      {"item_id":"ig-DaxDJuYFPi6","topic":"150 LICENSED.","state":"published",
        "instagram_post_url":"https://www.instagram.com/p/DaxDJuYFPi6/?igshid=x",
        "instagram_published_at":"2026-06-01T00:00:00Z"},
       {"item_id":"ig-GenuinelyUnrelated1","topic":"(a real other IG-only post)","state":"published",

--- a/apps/wr2-control-app/Tests/queuewritertest/main.swift
+++ b/apps/wr2-control-app/Tests/queuewritertest/main.swift
@@ -22,7 +22,11 @@ import Foundation
         let after = try! JSONSerialization.jsonObject(with: Data(contentsOf: qf)) as! [[String: Any]]
         expect((after[0]["state"] as? String) == "published", "state advanced to published")
         expect((after[0]["instagram_post_url"] as? String) == "https://instagram.com/p/ABC123/", "ig url written")
-        expect((after[0]["ig_media_id"] as? String) == "ABC123", "media id written")
+        // Codex red-team finding B, 2026-07-17: markPublished must NEVER write
+        // ig_media_id — extractMediaID's output is a URL SHORTCODE, not the real
+        // numeric Graph media id, and the scraper now trusts a present ig_media_id
+        // as authoritative (would poison metrics for every app-published post).
+        expect(after[0]["ig_media_id"] == nil, "markPublished writes no ig_media_id (finding B)")
         expect((after[0]["instagram_published_at"] as? String) == "2026-06-22", "published_at written")
         expect((after[0]["UNKNOWN_FUTURE"] as? String) == "keepme", "unknown field preserved (scar #9)")
 
@@ -193,6 +197,56 @@ import Foundation
         expect(afterSecond.count == 2, "queue now has 2 entries")
         let firstStillThere = afterSecond.contains { ($0["item_id"] as? String) == "external_2026-07-17T090000_a-manual-post" }
         expect(firstStillThere, "the first entry is untouched by the second append")
+
+        // --- Codex red-team finding D (Swift mirror), 2026-07-17: shortcode-first ----
+        // dedup compare. A "?utm_..." query-string variant of the SAME post
+        // (ManualOne, already in qf3) must still be caught as a duplicate — exact
+        // string compare alone would have missed it and double-enqueued.
+        let dupSameShortcodeDifferentQuery = makeExternalEntry(
+            itemID: "external_2026-07-17T094000_utm-retry",
+            url: "https://www.instagram.com/p/ManualOne/?utm_source=ig")
+        var threwDupShortcode = false
+        do { try QueueWriter.addExternalPost(queueFile: qf3, entry: dupSameShortcodeDifferentQuery) }
+        catch { threwDupShortcode = true }
+        expect(threwDupShortcode, "addExternalPost throws on a same-shortcode-different-query duplicate (finding D)")
+        let afterShortcodeDup = try! JSONSerialization.jsonObject(with: Data(contentsOf: qf3)) as! [[String: Any]]
+        expect(afterShortcodeDup.count == 2, "same-shortcode duplicate attempt does not append (queue still has 2 entries)")
+
+        // INNOCENCE: a genuinely different shortcode must still append fine even
+        // though it shares the same URL prefix/domain as an existing entry.
+        let entry3 = makeExternalEntry(itemID: "external_2026-07-17T094500_third-post",
+                                        url: "https://www.instagram.com/p/ManualThree/")
+        let added3 = try! QueueWriter.addExternalPost(queueFile: qf3, entry: entry3)
+        expect(added3, "addExternalPost still appends a genuinely different shortcode (innocence, finding D)")
+
+        // --- Codex red-team finding A, 2026-07-17: corrupt/unparseable queue file ----
+        // must THROW, never silently degrade to []. `(try? ...) ?? []` on both the
+        // read AND the parse meant a transient read error or corrupt/truncated JSON
+        // was indistinguishable from "no queue file yet" — the subsequent append
+        // would then WRITE OVER THE WHOLE QUEUE with just the new entry. Only a
+        // genuine missing file may start from an empty array.
+        let dirCorrupt = FileManager.default.temporaryDirectory.appendingPathComponent("wr2q-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(at: dirCorrupt, withIntermediateDirectories: true)
+        let qfCorrupt = dirCorrupt.appendingPathComponent("q.json")
+        let corruptBytes = "{not valid json at all".data(using: .utf8)!
+        try! corruptBytes.write(to: qfCorrupt)
+        let entryForCorrupt = makeExternalEntry(itemID: "external_2026-07-17T094500_corrupt-test",
+                                                 url: "https://www.instagram.com/p/CorruptTest/")
+        var threwOnCorrupt = false
+        do { try QueueWriter.addExternalPost(queueFile: qfCorrupt, entry: entryForCorrupt) }
+        catch { threwOnCorrupt = true }
+        expect(threwOnCorrupt, "addExternalPost throws on a corrupt/unparseable queue file (finding A)")
+        let corruptAfter = try! Data(contentsOf: qfCorrupt)
+        expect(corruptAfter == corruptBytes, "corrupt queue file is left byte-for-byte untouched, not overwritten")
+
+        // INNOCENCE: a genuinely missing queue file still starts from [] and appends fine.
+        let dirMissing = FileManager.default.temporaryDirectory.appendingPathComponent("wr2q-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(at: dirMissing, withIntermediateDirectories: true)
+        let qfMissing = dirMissing.appendingPathComponent("q.json")  // never created
+        let entryForMissing = makeExternalEntry(itemID: "external_2026-07-17T095000_missing-file-test",
+                                                 url: "https://www.instagram.com/p/MissingFileTest/")
+        let addedToMissing = try! QueueWriter.addExternalPost(queueFile: qfMissing, entry: entryForMissing)
+        expect(addedToMissing, "addExternalPost still succeeds against a genuinely missing queue file (innocence)")
 
         print("RESULT: \(fails == 0 ? "GREEN" : "RED")")
         exit(fails == 0 ? 0 : 1)

--- a/apps/wr2-control-app/Tests/queuewritertest/main.swift
+++ b/apps/wr2-control-app/Tests/queuewritertest/main.swift
@@ -134,6 +134,66 @@ import Foundation
             expect(false, "legacy verdict-only \"pass\" row should NOT be refused: \(error)")
         }
 
+        // --- addExternalPost — external-post feature (§A, 2026-07-17) ----------------
+        func makeExternalEntry(itemID: String, url: String) -> [String: Any] {
+            [
+                "item_id": itemID,
+                "state": "published",
+                "instagram_post_url": url,
+                "source": "external_manual",
+                "published_at": "2026-07-17T09:00:00+00:00",
+                "instagram_published_at": "2026-07-17T09:00:00+00:00",
+                "topic": "A manual post",
+                "topic_slug": "a-manual-post",
+                "slide_count": 0,
+            ]
+        }
+
+        let dir3 = FileManager.default.temporaryDirectory.appendingPathComponent("wr2q-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(at: dir3, withIntermediateDirectories: true)
+        let qf3 = dir3.appendingPathComponent("q.json")
+        try! Data("[]".utf8).write(to: qf3)
+
+        let entry1 = makeExternalEntry(itemID: "external_2026-07-17T090000_a-manual-post",
+                                        url: "https://www.instagram.com/p/ManualOne/")
+        let added1 = try! QueueWriter.addExternalPost(queueFile: qf3, entry: entry1)
+        expect(added1, "addExternalPost returns true on a fresh append")
+        let afterAdd = try! JSONSerialization.jsonObject(with: Data(contentsOf: qf3)) as! [[String: Any]]
+        expect(afterAdd.count == 1, "queue now has exactly 1 entry")
+        expect((afterAdd[0]["state"] as? String) == "published", "external entry written with state=published")
+        expect((afterAdd[0]["source"] as? String) == "external_manual", "external entry written with source=external_manual")
+
+        // duplicate by SAME item_id (different URL) must be refused, no write.
+        let dupSameID = makeExternalEntry(itemID: "external_2026-07-17T090000_a-manual-post",
+                                           url: "https://www.instagram.com/p/DifferentURL/")
+        var threwDupID = false
+        do { try QueueWriter.addExternalPost(queueFile: qf3, entry: dupSameID) }
+        catch { threwDupID = true }
+        expect(threwDupID, "addExternalPost throws on duplicate item_id")
+        let afterDupID = try! JSONSerialization.jsonObject(with: Data(contentsOf: qf3)) as! [[String: Any]]
+        expect(afterDupID.count == 1, "duplicate item_id attempt does not append (queue still has 1 entry)")
+
+        // duplicate by SAME url (different item_id) must ALSO be refused, no write.
+        let dupSameURL = makeExternalEntry(itemID: "external_2026-07-17T091500_retry-post",
+                                            url: "https://www.instagram.com/p/ManualOne/")
+        var threwDupURL = false
+        do { try QueueWriter.addExternalPost(queueFile: qf3, entry: dupSameURL) }
+        catch { threwDupURL = true }
+        expect(threwDupURL, "addExternalPost throws on duplicate instagram_post_url (different item_id)")
+        let afterDupURL = try! JSONSerialization.jsonObject(with: Data(contentsOf: qf3)) as! [[String: Any]]
+        expect(afterDupURL.count == 1, "duplicate URL attempt does not append (queue still has 1 entry)")
+
+        // a genuinely different post (different id AND url) must append fine, alongside
+        // — and must NEVER disturb the existing entry (scar #9 discipline).
+        let entry2 = makeExternalEntry(itemID: "external_2026-07-17T093000_second-post",
+                                        url: "https://www.instagram.com/p/ManualTwo/")
+        let added2 = try! QueueWriter.addExternalPost(queueFile: qf3, entry: entry2)
+        expect(added2, "addExternalPost returns true for a genuinely new entry")
+        let afterSecond = try! JSONSerialization.jsonObject(with: Data(contentsOf: qf3)) as! [[String: Any]]
+        expect(afterSecond.count == 2, "queue now has 2 entries")
+        let firstStillThere = afterSecond.contains { ($0["item_id"] as? String) == "external_2026-07-17T090000_a-manual-post" }
+        expect(firstStillThere, "the first entry is untouched by the second append")
+
         print("RESULT: \(fails == 0 ? "GREEN" : "RED")")
         exit(fails == 0 ? 0 : 1)
     }

--- a/apps/wr2-control-app/test.sh
+++ b/apps/wr2-control-app/test.sh
@@ -42,8 +42,12 @@ echo "▸ compiling QueueWriter tests…"
 # isQueuePublishEligible/CarouselPhase (the fail-closed publish-state gate, cross-
 # finding with the Python A3 daily-reconciler) — a genuine new compile dependency, not
 # a workaround.
+# WarRoom.swift joined in 2026-07-17 (Codex red-team finding D mirror):
+# QueueWriter.addExternalPost's duplicate guard now calls WarRoom.igShortcode for
+# shortcode-first URL-equality — WarRoom.swift is Foundation-only (no SwiftUI/AppKit),
+# same constraint class as Models.swift/QueueWriter.swift, so it's a safe compile add.
 swiftc -parse-as-library -sdk "$SDK" -target "$TARGET" \
-  -o "$QW_BIN" "$ROOT/Sources/Models.swift" "$ROOT/Sources/QueueWriter.swift" "$ROOT/Tests/queuewritertest/main.swift"
+  -o "$QW_BIN" "$ROOT/Sources/Models.swift" "$ROOT/Sources/WarRoom.swift" "$ROOT/Sources/QueueWriter.swift" "$ROOT/Tests/queuewritertest/main.swift"
 echo "▸ running QueueWriter tests…"
 "$QW_BIN"
 

--- a/apps/wr2-control-app/test.sh
+++ b/apps/wr2-control-app/test.sh
@@ -20,6 +20,7 @@ SRC=(
   "$ROOT/Sources/PromptBuilder.swift"
   "$ROOT/Sources/InstagramCaption.swift"
   "$ROOT/Sources/ExternalImport.swift"
+  "$ROOT/Sources/ExternalPostRegistration.swift"
   "$ROOT/Tests/main.swift"
 )
 

--- a/infra/launchagents/wrappers/wr2-queue-pull.sh
+++ b/infra/launchagents/wrappers/wr2-queue-pull.sh
@@ -156,6 +156,40 @@ for e in rep.get("push_back", []): print(e["ref_code"], e["ig_url"])' | \
               echo "[$(ts)] WARN push-back $ref failed (state not publishable on Pro yet?)" >> "$LOG"
             fi
           done
+          # push external-manual entries back to Pro (§A/§B external-post feature,
+          # 2026-07-17): each is a FULL JSON payload with operator-typed free-text
+          # fields (topic/slug) — unlike ref/url above these are NOT regex-constrained,
+          # so they must NEVER be shell-interpolated into the ssh command string (an
+          # apostrophe in "Zero's post" would break a naive '$payload' embedding —
+          # scar-family #3, substring-safety mistaken for shell-safety). Instead each
+          # compact JSON line is piped over ssh's OWN stdin channel and the remote
+          # reads it back with `"$(cat)"` — the payload never appears literally in any
+          # shell command text on either side.
+          echo "$report" | python3 -c 'import json,sys
+try: rep=json.load(sys.stdin)
+except Exception: rep={}
+for e in rep.get("push_back_external", []):
+    print(json.dumps(e, ensure_ascii=False))' | \
+          while IFS= read -r payload_json; do
+            item_id=$(printf '%s' "$payload_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("item_id","") or "")' 2>/dev/null)
+            if [ -z "$item_id" ]; then
+              echo "[$(ts)] WARN push-back-external: entry with no item_id, skipping" >> "$LOG"
+              continue
+            fi
+            if printf '%s' "$payload_json" | ssh -o ConnectTimeout=10 -o BatchMode=yes pro \
+                 "cd ~/nuzantara && python3 scripts/wr2_queue_writer.py add-external \"\$(cat)\"" >>"$LOG" 2>&1; then
+              # Pro confirmed the entry exists (added now OR already_present from a
+              # prior retry — both are terminal success) — mark the LOCAL copy so
+              # external_push_candidates never re-offers it (idempotent replay-safety).
+              if python3 "$MERGE_PY" --mark-synced-item-id "$item_id" --mark-synced-file "$DEST_DIR/$f" >>"$LOG" 2>&1; then
+                echo "[$(ts)] pushed back external $item_id -> Pro, marked synced_to_pro" >> "$LOG"
+              else
+                echo "[$(ts)] WARN pushed back external $item_id but failed to mark synced_to_pro locally (will retry next cycle)" >> "$LOG"
+              fi
+            else
+              echo "[$(ts)] WARN push-back-external $item_id failed (ssh/add-external error, will retry next cycle)" >> "$LOG"
+            fi
+          done
         else
           # merge failed (rc) or produced empty/invalid output → keep old
           # local file, log, wipe both tmps.

--- a/scripts/test_wr2_ig_discovery.py
+++ b/scripts/test_wr2_ig_discovery.py
@@ -92,10 +92,15 @@ def test_find_media_id_backfills_matches_native_entry_by_shortcode() -> None:
     # GUILT-adjacent live case: a WR2-native carousel published via the app's
     # own gate (permalink, no ig_media_id) — this run's Graph fetch happens to
     # carry the same shortcode with its real numeric id.
+    #
+    # 3rd tuple element (Codex red-team, 2026-07-17, finding F): the matched
+    # shortcode itself, so the caller can pass it to backfill_media_id as
+    # expected_shortcode (a compare-and-set guard taken under that call's own
+    # lock, re-verifying the entry hasn't moved to a different URL since).
     media = [{"id": "17895695668004550", "permalink": "https://www.instagram.com/p/ABC123/"}]
     queue = [{"id": "bali-pma-rental-crackdown", "instagram_post_url": "https://www.instagram.com/p/ABC123/"}]
     assert discovery.find_media_id_backfills(media, queue) == [
-        ("bali-pma-rental-crackdown", "17895695668004550")
+        ("bali-pma-rental-crackdown", "17895695668004550", "ABC123")
     ]
 
 

--- a/scripts/test_wr2_ig_discovery.py
+++ b/scripts/test_wr2_ig_discovery.py
@@ -85,6 +85,56 @@ def test_build_known_shortcodes_ignores_malformed_url() -> None:
     assert discovery.build_known_shortcodes(items) == set()
 
 
+# ── find_media_id_backfills — §C point 3 reconciliation ─────────────────
+
+
+def test_find_media_id_backfills_matches_native_entry_by_shortcode() -> None:
+    # GUILT-adjacent live case: a WR2-native carousel published via the app's
+    # own gate (permalink, no ig_media_id) — this run's Graph fetch happens to
+    # carry the same shortcode with its real numeric id.
+    media = [{"id": "17895695668004550", "permalink": "https://www.instagram.com/p/ABC123/"}]
+    queue = [{"id": "bali-pma-rental-crackdown", "instagram_post_url": "https://www.instagram.com/p/ABC123/"}]
+    assert discovery.find_media_id_backfills(media, queue) == [
+        ("bali-pma-rental-crackdown", "17895695668004550")
+    ]
+
+
+def test_find_media_id_backfills_skips_item_already_backfilled() -> None:
+    # INNOCENCE: an item that already has ig_media_id is never re-paired, even
+    # if this run's fetch would otherwise match it (idempotency at the source).
+    media = [{"id": "17895695668004550", "permalink": "https://www.instagram.com/p/ABC123/"}]
+    queue = [{
+        "id": "bali-pma-rental-crackdown",
+        "instagram_post_url": "https://www.instagram.com/p/ABC123/",
+        "ig_media_id": "17895695668004550",
+    }]
+    assert discovery.find_media_id_backfills(media, queue) == []
+
+
+def test_find_media_id_backfills_skips_item_without_url() -> None:
+    media = [{"id": "17895695668004550", "permalink": "https://www.instagram.com/p/ABC123/"}]
+    queue = [{"id": "drafted-item", "state": "drafted"}]  # no instagram_post_url yet
+    assert discovery.find_media_id_backfills(media, queue) == []
+
+
+def test_find_media_id_backfills_no_pair_when_fetch_lacks_the_shortcode() -> None:
+    # A queue item is missing ig_media_id but THIS run's fetch (limited by
+    # --limit/paging) doesn't happen to include that post — no false pair.
+    media = [{"id": "999", "permalink": "https://www.instagram.com/p/OTHER/"}]
+    queue = [{"id": "bali-pma-rental-crackdown", "instagram_post_url": "https://www.instagram.com/p/ABC123/"}]
+    assert discovery.find_media_id_backfills(media, queue) == []
+
+
+def test_find_media_id_backfills_skips_media_entry_missing_numeric_id() -> None:
+    media = [{"permalink": "https://www.instagram.com/p/ABC123/"}]  # no "id" field
+    queue = [{"id": "bali-pma-rental-crackdown", "instagram_post_url": "https://www.instagram.com/p/ABC123/"}]
+    assert discovery.find_media_id_backfills(media, queue) == []
+
+
+def test_find_media_id_backfills_empty_inputs() -> None:
+    assert discovery.find_media_id_backfills([], []) == []
+
+
 # ── parse_ig_timestamp / is_recent ───────────────────────────────────────
 
 

--- a/scripts/tests/test_wr2_ig_metrics_scraper.py
+++ b/scripts/tests/test_wr2_ig_metrics_scraper.py
@@ -1,0 +1,89 @@
+"""Unit tests for scripts/wr2_ig_metrics_scraper.py — media_id_of / is_stale.
+
+Loaded via importlib (the module lives in repo-root scripts/, same convention
+as test_wr2_queue_pull_merge.py). Covers the §C verification finding
+(2026-07-17, external-post feature spec): the scraper's candidate SELECTION
+already works for any queue entry with instagram_post_url + state=="published"
+regardless of pipeline origin, but the actual Graph FETCH needs a resolvable
+media id, and that id must now be found on EITHER historical id key ("id" or
+"item_id") — the fix under test here.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load(name: str) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec and spec.loader, f"cannot load {name}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+scraper = _load("wr2_ig_metrics_scraper")
+
+
+# ── media_id_of — dual-schema id key (§C fix) ──────────────────────────────
+
+
+def test_media_id_of_legacy_id_key():
+    assert scraper.media_id_of({"id": "ig-1234567890"}) == "1234567890"
+
+
+def test_media_id_of_item_id_key_now_resolves():
+    # GUILT (pre-fix behavior): an entry carrying ONLY "item_id" (the newer FSM/
+    # app schema) used to be silently invisible to the scraper because
+    # media_id_of checked "id" alone. Now it resolves too.
+    assert scraper.media_id_of({"item_id": "ig-9876543210"}) == "9876543210"
+
+
+def test_media_id_of_prefers_id_over_item_id_when_both_present():
+    assert scraper.media_id_of({"id": "ig-AAA", "item_id": "ig-BBB"}) == "AAA"
+
+
+def test_media_id_of_none_without_ig_prefix_on_either_key():
+    # INNOCENCE: this feature's own external_manual ids ("external_<date>_<slug>")
+    # and ingest_external_post's "ig-<shortcode>" ids that happen to collide with
+    # a non-numeric shape are NOT silently treated as Graph media ids — the
+    # documented limitation (see media_id_of docstring) is a real "cannot fetch",
+    # never a wrong fetch.
+    assert scraper.media_id_of({"item_id": "external_2026-07-17T090000_my-post"}) is None
+    assert scraper.media_id_of({}) is None
+
+
+def test_media_id_of_empty_string_ids_return_none():
+    assert scraper.media_id_of({"id": "", "item_id": ""}) is None
+
+
+# ── is_stale ────────────────────────────────────────────────────────────────
+
+
+def test_is_stale_missing_metrics():
+    assert scraper.is_stale(None, 7) is True
+    assert scraper.is_stale({}, 7) is True
+
+
+def test_is_stale_no_timestamp():
+    assert scraper.is_stale({"likes": 10}, 7) is True
+
+
+def test_is_stale_fresh_metrics_not_stale():
+    now_iso = datetime.now(timezone.utc).isoformat()
+    assert scraper.is_stale({"scraped_at": now_iso}, 7) is False
+
+
+def test_is_stale_old_metrics_are_stale():
+    old_iso = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    assert scraper.is_stale({"scraped_at": old_iso}, 7) is True

--- a/scripts/tests/test_wr2_ig_metrics_scraper.py
+++ b/scripts/tests/test_wr2_ig_metrics_scraper.py
@@ -45,7 +45,7 @@ scraper = _load("wr2_ig_metrics_scraper")
 def test_media_id_of_prefers_authoritative_ig_media_id_field():
     # the discovery/backfill-wired field wins even when a legacy id is ALSO present.
     assert scraper.media_id_of({"ig_media_id": "17895695668004550",
-                                 "id": "ig-1111111111"}) == "17895695668004550"
+                                 "id": "ig-11111111111111111"}) == "17895695668004550"
 
 
 def test_media_id_of_ig_media_id_alone():
@@ -54,18 +54,20 @@ def test_media_id_of_ig_media_id_alone():
 
 
 def test_media_id_of_legacy_id_key_numeric_suffix():
-    assert scraper.media_id_of({"id": "ig-1234567890"}) == "1234567890"
+    # all 45 real legacy ids on record are 17-digit Graph media ids (finding I floor).
+    assert scraper.media_id_of({"id": "ig-12345678901234567"}) == "12345678901234567"
 
 
 def test_media_id_of_item_id_key_numeric_suffix_now_resolves():
     # the dual-schema-key half of the fix: an entry carrying ONLY "item_id" (the
     # newer FSM/app schema) used to be silently invisible because media_id_of
-    # checked "id" alone. Now it resolves too, when the suffix is numeric.
-    assert scraper.media_id_of({"item_id": "ig-9876543210"}) == "9876543210"
+    # checked "id" alone. Now it resolves too, when the suffix is numeric and long enough.
+    assert scraper.media_id_of({"item_id": "ig-98765432109876543"}) == "98765432109876543"
 
 
 def test_media_id_of_prefers_id_over_item_id_when_both_present():
-    assert scraper.media_id_of({"id": "ig-1111111111", "item_id": "ig-2222222222"}) == "1111111111"
+    assert scraper.media_id_of({"id": "ig-11111111111111111",
+                                 "item_id": "ig-22222222222222222"}) == "11111111111111111"
 
 
 def test_media_id_of_rejects_alphanumeric_shortcode_suffix():
@@ -88,6 +90,19 @@ def test_media_id_of_none_without_ig_prefix_or_media_id_field():
 
 def test_media_id_of_empty_string_ids_return_none():
     assert scraper.media_id_of({"id": "", "item_id": "", "ig_media_id": ""}) is None
+
+
+def test_media_id_of_rejects_short_all_digit_suffix():
+    # GUILT (Codex red-team, 2026-07-17, finding I): a short all-digit suffix is
+    # exactly the theoretical shortcode-that-happens-to-render-as-digits case
+    # `isdigit()` alone would wrongly trust. All 45 real legacy ids are 17
+    # digits — the <15-digit floor keeps this fallback scoped to that shape,
+    # including the 10-digit shape used (pre-finding-I) as "the legacy example".
+    assert scraper.media_id_of({"id": "ig-123"}) is None
+    assert scraper.media_id_of({"id": "ig-1234567890"}) is None
+    assert scraper.media_id_of({"item_id": "ig-9876543210"}) is None
+    # INNOCENCE: a real 17-digit legacy id still resolves.
+    assert scraper.media_id_of({"id": "ig-12345678901234567"}) == "12345678901234567"
 
 
 # ── is_stale ────────────────────────────────────────────────────────────────

--- a/scripts/tests/test_wr2_ig_metrics_scraper.py
+++ b/scripts/tests/test_wr2_ig_metrics_scraper.py
@@ -1,12 +1,16 @@
 """Unit tests for scripts/wr2_ig_metrics_scraper.py — media_id_of / is_stale.
 
 Loaded via importlib (the module lives in repo-root scripts/, same convention
-as test_wr2_queue_pull_merge.py). Covers the §C verification finding
-(2026-07-17, external-post feature spec): the scraper's candidate SELECTION
-already works for any queue entry with instagram_post_url + state=="published"
-regardless of pipeline origin, but the actual Graph FETCH needs a resolvable
-media id, and that id must now be found on EITHER historical id key ("id" or
-"item_id") — the fix under test here.
+as test_wr2_queue_pull_merge.py). Covers the §C fix, CORRECTED per a live
+Pro-side diagnosis (2026-07-17) that superseded the first-pass fix: the
+scraper's candidate SELECTION already works for any queue entry with
+instagram_post_url + state=="published" regardless of pipeline origin, but the
+Graph FETCH needs a media id it can TRUST — `ig_media_id` (authoritative,
+wired from wr2_ig_discovery.py's real Graph fetch) when present, else a legacy
+`"ig-<digits>"` id/item_id whose suffix is ALL-NUMERIC (a real Graph media id
+is numeric-only; an IG shortcode is alphanumeric — conflating the two was the
+bug the first-pass fix (checking "id" OR "item_id") did not catch, because it
+widened which KEY was searched, not which VALUE was trusted).
 """
 from __future__ import annotations
 
@@ -35,36 +39,55 @@ def _load(name: str) -> ModuleType:
 scraper = _load("wr2_ig_metrics_scraper")
 
 
-# ── media_id_of — dual-schema id key (§C fix) ──────────────────────────────
+# ── media_id_of — ig_media_id preference + numeric-suffix discrimination ────
 
 
-def test_media_id_of_legacy_id_key():
+def test_media_id_of_prefers_authoritative_ig_media_id_field():
+    # the discovery/backfill-wired field wins even when a legacy id is ALSO present.
+    assert scraper.media_id_of({"ig_media_id": "17895695668004550",
+                                 "id": "ig-1111111111"}) == "17895695668004550"
+
+
+def test_media_id_of_ig_media_id_alone():
+    assert scraper.media_id_of({"item_id": "external_2026-07-17T090000_my-post",
+                                 "ig_media_id": "17895695668004550"}) == "17895695668004550"
+
+
+def test_media_id_of_legacy_id_key_numeric_suffix():
     assert scraper.media_id_of({"id": "ig-1234567890"}) == "1234567890"
 
 
-def test_media_id_of_item_id_key_now_resolves():
-    # GUILT (pre-fix behavior): an entry carrying ONLY "item_id" (the newer FSM/
-    # app schema) used to be silently invisible to the scraper because
-    # media_id_of checked "id" alone. Now it resolves too.
+def test_media_id_of_item_id_key_numeric_suffix_now_resolves():
+    # the dual-schema-key half of the fix: an entry carrying ONLY "item_id" (the
+    # newer FSM/app schema) used to be silently invisible because media_id_of
+    # checked "id" alone. Now it resolves too, when the suffix is numeric.
     assert scraper.media_id_of({"item_id": "ig-9876543210"}) == "9876543210"
 
 
 def test_media_id_of_prefers_id_over_item_id_when_both_present():
-    assert scraper.media_id_of({"id": "ig-AAA", "item_id": "ig-BBB"}) == "AAA"
+    assert scraper.media_id_of({"id": "ig-1111111111", "item_id": "ig-2222222222"}) == "1111111111"
 
 
-def test_media_id_of_none_without_ig_prefix_on_either_key():
+def test_media_id_of_rejects_alphanumeric_shortcode_suffix():
+    # GUILT (the corrected bug, 2026-07-17): "ig-DaxDJuYFPi6" is an IG shortcode
+    # (ingest_external_post's pre-ig_media_id convention), NOT a Graph media id —
+    # feeding it to the Graph endpoint would 400 with a confusing error rather
+    # than failing cleanly. The suffix must be ALL-NUMERIC to be trusted.
+    assert scraper.media_id_of({"id": "ig-DaxDJuYFPi6"}) is None
+    assert scraper.media_id_of({"item_id": "ig-Cabc123_-"}) is None
+
+
+def test_media_id_of_none_without_ig_prefix_or_media_id_field():
     # INNOCENCE: this feature's own external_manual ids ("external_<date>_<slug>")
-    # and ingest_external_post's "ig-<shortcode>" ids that happen to collide with
-    # a non-numeric shape are NOT silently treated as Graph media ids — the
-    # documented limitation (see media_id_of docstring) is a real "cannot fetch",
-    # never a wrong fetch.
+    # never even reach the "ig-" branch and never carry ig_media_id (the operator
+    # only pasted a URL, no Graph fetch happened) — a real "cannot fetch", never
+    # a wrong fetch (documented limitation, see media_id_of docstring).
     assert scraper.media_id_of({"item_id": "external_2026-07-17T090000_my-post"}) is None
     assert scraper.media_id_of({}) is None
 
 
 def test_media_id_of_empty_string_ids_return_none():
-    assert scraper.media_id_of({"id": "", "item_id": ""}) is None
+    assert scraper.media_id_of({"id": "", "item_id": "", "ig_media_id": ""}) is None
 
 
 # ── is_stale ────────────────────────────────────────────────────────────────

--- a/scripts/tests/test_wr2_queue_pull_merge.py
+++ b/scripts/tests/test_wr2_queue_pull_merge.py
@@ -278,7 +278,16 @@ def test_external_manual_entry_archived_on_pro_still_kept_locally():
     SAME published-survives-despite-archive path as any other local publish
     transition (test_published_local_only_entry_survives_archive_on_pro
     above), never get silently classified as archived_dropped just because
-    the id happens to also appear in Pro's freshly-pulled archive."""
+    the id happens to also appear in Pro's freshly-pulled archive.
+
+    UPDATED (Codex red-team, 2026-07-17, finding C): the queue-merge outcome
+    (kept locally, published, local_only) is unchanged and still asserted
+    below — but `push_back_external` must NOT re-offer this id anymore. Pro
+    archiving it is a DELIBERATE SSOT decision; re-offering it here would let
+    the wrapper replay `add-external` and RE-CREATE it on Pro, overriding
+    that decision. This is the exact bug finding C describes — the assertion
+    below is the corrected expectation (was, pre-fix, asserting the entry
+    WAS still offered, which was the bug)."""
     entry = _external_manual_entry()
     merged, report = merge.merge_queues(
         [_remote_drafted("carousel_1")],
@@ -293,9 +302,10 @@ def test_external_manual_entry_archived_on_pro_still_kept_locally():
     assert report["local_only"] == [entry["item_id"]]
     assert report["archived_dropped"] == []
     assert report["published_local_kept_despite_archive"] == [entry["item_id"]]
-    # AND the orthogonal push_back_external pass still offers it independently —
-    # surviving the archive check must not accidentally suppress the sync channel.
-    assert [c["item_id"] for c in report["push_back_external"]] == [entry["item_id"]]
+    # the orthogonal push_back_external pass must NOT re-offer an id Pro
+    # already archived — re-offering would re-create it on Pro via
+    # add-external, overriding the SSOT archive decision (finding C).
+    assert report["push_back_external"] == []
 
 
 def test_external_push_candidates_picks_up_unsynced_external_manual_entry():
@@ -334,6 +344,77 @@ def test_external_push_candidates_excludes_invalid_payload():
 def test_merge_queues_report_includes_push_back_external():
     _, report = merge.merge_queues([_remote_drafted()], [_external_manual_entry()])
     assert [c["item_id"] for c in report["push_back_external"]] == ["external_2026-07-17T090000_my-manual-post"]
+
+
+# ── finding C — replay-churn + archive-override guard (Codex red-team, 2026-07-17) ──
+
+
+def test_external_push_candidates_excludes_id_present_in_known_remote_ids():
+    """GUILT (finding C, part ii): an external_manual entry whose id is
+    already present in Pro's live remote queue must never be re-offered —
+    it's already there, offering it again would replay add-external for no
+    reason (the `known_remote_ids` arg is `merge_queues`'s already-populated
+    `seen` set at the call site)."""
+    entry = _external_manual_entry()
+    candidates = merge.external_push_candidates(
+        [entry], known_remote_ids={entry["item_id"]},
+    )
+    assert candidates == []
+
+
+def test_external_push_candidates_excludes_id_present_in_archived_ids():
+    """GUILT (finding C, part ii): an external_manual entry whose id is
+    already present in Pro's freshly-pulled archive must never be
+    re-offered — Pro deliberately archived it; re-offering would let the
+    wrapper replay add-external and RE-CREATE it on Pro, overriding that
+    SSOT decision."""
+    entry = _external_manual_entry()
+    candidates = merge.external_push_candidates(
+        [entry], archived_ids={entry["item_id"]},
+    )
+    assert candidates == []
+
+
+def test_external_push_candidates_innocence_new_unsynced_entry_still_offered():
+    """INNOCENCE: a genuinely new, unsynced external_manual entry whose id is
+    in NEITHER the remote queue NOR the remote archive must still be
+    offered — the new known_remote_ids/archived_ids exclusion must not
+    become a way to silently swallow real, never-yet-synced entries."""
+    entry = _external_manual_entry()
+    candidates = merge.external_push_candidates(
+        [entry], known_remote_ids={"some_other_id"}, archived_ids={"yet_another_id"},
+    )
+    assert [c["item_id"] for c in candidates] == [entry["item_id"]]
+
+
+def test_merge_queues_never_offers_id_already_live_on_remote():
+    """GUILT via merge_queues end-to-end: an external_manual entry that is
+    ALSO already present (by id) in the remote queue itself (e.g. Pro
+    already has its own copy, perhaps from an earlier successful sync whose
+    synced_to_pro flag then got lost — see the replay-churn test below) must
+    not be re-offered by the orthogonal push_back_external pass."""
+    entry = _external_manual_entry()
+    remote_twin = dict(entry)  # Pro's own copy — same id, no synced_to_pro (Pro never writes that flag)
+    _, report = merge.merge_queues([remote_twin], [entry])
+    assert report["push_back_external"] == []
+
+
+def test_synced_flag_survives_remote_wins_no_replay_on_tick_two():
+    """GUILT (finding C, part i — the replay-churn bug): tick 1 already
+    confirmed sync (local copy carries synced_to_pro=True). Pro's OWN copy
+    of the entry (now present in the remote queue) does NOT carry that
+    LOCAL-only bookkeeping flag. Without carrying it forward through the
+    remote-wins branch, external_push_candidates would see an "unsynced"
+    entry again on this very tick and replay add-external forever. The
+    merged/report entry must both show synced_to_pro carried onto the
+    remote-wins copy, AND push_back_external must be empty."""
+    entry = _external_manual_entry(synced_to_pro=True)
+    remote_twin = _external_manual_entry()  # Pro's copy: same id, no synced_to_pro key at all
+    assert "synced_to_pro" not in remote_twin
+    merged, report = merge.merge_queues([remote_twin], [entry])
+    kept = next(e for e in merged if merge.item_id_of(e) == entry["item_id"])
+    assert kept["synced_to_pro"] is True
+    assert report["push_back_external"] == []
 
 
 def test_mark_synced_to_pro_marks_matching_entry_only():

--- a/scripts/tests/test_wr2_queue_pull_merge.py
+++ b/scripts/tests/test_wr2_queue_pull_merge.py
@@ -269,6 +269,35 @@ def _external_manual_entry(**overrides) -> dict:
     return entry
 
 
+# ── archive-awareness x external_manual interaction (team-lead diagnosis, 2026-07-17) ─
+
+
+def test_external_manual_entry_archived_on_pro_still_kept_locally():
+    """GUILT: external_manual entries (§A/§B) are ALWAYS state="published" by
+    construction (validate_external_payload requires it) — they must ride the
+    SAME published-survives-despite-archive path as any other local publish
+    transition (test_published_local_only_entry_survives_archive_on_pro
+    above), never get silently classified as archived_dropped just because
+    the id happens to also appear in Pro's freshly-pulled archive."""
+    entry = _external_manual_entry()
+    merged, report = merge.merge_queues(
+        [_remote_drafted("carousel_1")],
+        [_remote_drafted("carousel_1"), entry],
+        remote_archive=[{"item_id": entry["item_id"], "state": "drafted"}],
+    )
+    ids = [merge.item_id_of(e) for e in merged]
+    assert entry["item_id"] in ids
+    kept = next(e for e in merged if merge.item_id_of(e) == entry["item_id"])
+    assert kept["state"] == "published"
+    assert kept["instagram_post_url"] == entry["instagram_post_url"]
+    assert report["local_only"] == [entry["item_id"]]
+    assert report["archived_dropped"] == []
+    assert report["published_local_kept_despite_archive"] == [entry["item_id"]]
+    # AND the orthogonal push_back_external pass still offers it independently —
+    # surviving the archive check must not accidentally suppress the sync channel.
+    assert [c["item_id"] for c in report["push_back_external"]] == [entry["item_id"]]
+
+
 def test_external_push_candidates_picks_up_unsynced_external_manual_entry():
     local = [_remote_drafted(), _external_manual_entry()]
     candidates = merge.external_push_candidates(local)

--- a/scripts/tests/test_wr2_queue_pull_merge.py
+++ b/scripts/tests/test_wr2_queue_pull_merge.py
@@ -247,3 +247,108 @@ def test_cli_missing_remote_archive_file_degrades_gracefully(tmp_path):
                           "--remote-archive", str(tmp_path / "does-not-exist.json")])
     assert rc == 0
     assert json.loads(out.read_text())[0]["state"] == "published"
+
+
+# ── external_push_candidates / mark_synced_to_pro — M5->Pro propagation (§B) ─
+
+
+def _external_manual_entry(**overrides) -> dict:
+    entry = {
+        "item_id": "external_2026-07-17T090000_my-manual-post",
+        "state": "published",
+        "instagram_post_url": "https://www.instagram.com/p/ManualPost1/",
+        "source": "external_manual",
+        "published_at": "2026-07-17T09:00:00+00:00",
+        "instagram_published_at": "2026-07-17T09:00:00+00:00",
+        "topic": "My manual post",
+        "topic_slug": "my-manual-post",
+        "slide_count": 0,
+        "created_at": "2026-07-17T09:00:00+00:00",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_external_push_candidates_picks_up_unsynced_external_manual_entry():
+    local = [_remote_drafted(), _external_manual_entry()]
+    candidates = merge.external_push_candidates(local)
+    assert [c["item_id"] for c in candidates] == ["external_2026-07-17T090000_my-manual-post"]
+
+
+def test_external_push_candidates_excludes_already_synced():
+    local = [_external_manual_entry(synced_to_pro=True)]
+    assert merge.external_push_candidates(local) == []
+
+
+def test_external_push_candidates_excludes_pipeline_entries():
+    # a normal published WR2-pipeline entry (no source=="external_manual") must NEVER
+    # be offered for push-back on this channel — that's the OTHER push_back list.
+    local = [_local_published()]
+    assert merge.external_push_candidates(local) == []
+
+
+def test_external_push_candidates_excludes_manual_external_source_confusion():
+    # "manual_external" (ingest_external_post's convention) is a DIFFERENT origin —
+    # must not be conflated with "external_manual" (this feature's exact marker).
+    local = [_external_manual_entry(source="manual_external")]
+    assert merge.external_push_candidates(local) == []
+
+
+def test_external_push_candidates_excludes_invalid_payload():
+    # a malformed local entry (missing topic_slug here) must never be shipped over
+    # ssh as a broken CLI argument.
+    entry = _external_manual_entry()
+    del entry["topic_slug"]
+    assert merge.external_push_candidates([entry]) == []
+
+
+def test_merge_queues_report_includes_push_back_external():
+    _, report = merge.merge_queues([_remote_drafted()], [_external_manual_entry()])
+    assert [c["item_id"] for c in report["push_back_external"]] == ["external_2026-07-17T090000_my-manual-post"]
+
+
+def test_mark_synced_to_pro_marks_matching_entry_only():
+    items = [_external_manual_entry(item_id="a"), _external_manual_entry(item_id="b")]
+    updated = merge.mark_synced_to_pro(items, "a")
+    a = next(i for i in updated if i["item_id"] == "a")
+    b = next(i for i in updated if i["item_id"] == "b")
+    assert a["synced_to_pro"] is True
+    assert "synced_to_pro" not in b
+    # pure — input list's dicts not mutated
+    assert "synced_to_pro" not in items[0]
+
+
+def test_mark_synced_to_pro_noop_on_unknown_id():
+    items = [_external_manual_entry(item_id="a")]
+    updated = merge.mark_synced_to_pro(items, "does-not-exist")
+    assert updated == items
+
+
+def test_mark_synced_then_excluded_from_next_push_candidates():
+    entry = _external_manual_entry()
+    synced = merge.mark_synced_to_pro([entry], entry["item_id"])
+    assert merge.external_push_candidates(synced) == []
+
+
+def test_cli_mark_synced_item_id_writes_atomically(tmp_path):
+    f = tmp_path / "local.json"
+    f.write_text(json.dumps([_external_manual_entry(item_id="x")]))
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = merge.main(["--mark-synced-item-id", "x", "--mark-synced-file", str(f)])
+    assert rc == 0
+    resp = json.loads(buf.getvalue())
+    assert resp == {"ok": True, "marked": "x"}
+    updated = json.loads(f.read_text())
+    assert updated[0]["synced_to_pro"] is True
+
+
+def test_cli_mark_synced_requires_file_arg():
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = merge.main(["--mark-synced-item-id", "x"])
+    assert rc == 2

--- a/scripts/tests/test_wr2_queue_writer_external.py
+++ b/scripts/tests/test_wr2_queue_writer_external.py
@@ -1,0 +1,261 @@
+"""Unit tests for the external-post write-path in scripts/wr2_queue_writer.py:
+`add_external` (§B propagation landing point) and `backfill_media_id` (§C
+reconciliation). Loaded via importlib, same convention as the other wr2 test
+modules in this directory.
+
+Covers Codex red-team findings D, E, F, G (2026-07-17):
+  D — add_external dedup must compare by shortcode FIRST, exact-string only
+      as a fallback (a `?utm_...` variant of the same post must not double-enqueue).
+  E — same item_id but a genuinely DIFFERENT post (different URL/shortcode)
+      must return status="conflict", ok=False — never "already_present"/ok=True,
+      which the wrapper reads as "safe to mark synced" and would silently lose
+      the distinct post.
+  F — backfill_media_id must compare-and-set under its OWN lock: an
+      `expected_shortcode` mismatch (the entry's URL moved between discovery's
+      snapshot and this write) must refuse (conflict), never attach a possibly
+      stale media id.
+  G — validate_external_payload must type-check optional `slide_count` (int
+      >= 0) and `published_at` (ISO-parseable) when present.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load(name: str) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec and spec.loader, f"cannot load {name}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+qw = _load("wr2_queue_writer")
+
+
+def _external_payload(**overrides) -> dict:
+    payload = {
+        "item_id": "external_2026-07-17T090000_my-manual-post",
+        "state": "published",
+        "instagram_post_url": "https://www.instagram.com/p/ManualPost1/",
+        "source": qw.EXTERNAL_MANUAL_SOURCE,
+        "topic_slug": "my-manual-post",
+        "published_at": "2026-07-17T09:00:00+00:00",
+        "slide_count": 6,
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ── finding D — shortcode-first dedup compare ────────────────────────────────
+
+
+def test_add_external_dedup_by_shortcode_ignores_query_string_variant(tmp_path):
+    """GUILT: an existing entry's URL carries a stray ?utm_... query string but
+    is the SAME post (same shortcode) as the incoming payload — must be
+    refused as already_present, not double-enqueued as a byte-for-byte
+    different string."""
+    qpath = tmp_path / "q.json"
+    existing = _external_payload(
+        item_id="external_2026-07-17T080000_earlier-write",
+        instagram_post_url="https://www.instagram.com/p/ManualPost1/?utm_source=ig",
+    )
+    qw.write_queue_atomic(qpath, [existing])
+
+    incoming = _external_payload(
+        item_id="external_2026-07-17T090000_my-manual-post",
+        instagram_post_url="https://www.instagram.com/p/ManualPost1/",
+    )
+    res = qw.add_external(qpath, incoming)
+    assert res.status == "already_present"
+    assert res.ok is True
+    assert len(qw.load_queue(qpath)) == 1
+
+
+def test_add_external_innocence_different_shortcode_is_added(tmp_path):
+    """INNOCENCE: a genuinely different post (different shortcode) must still
+    be added normally, even though the URLs share the same domain/prefix."""
+    qpath = tmp_path / "q.json"
+    existing = _external_payload(
+        item_id="external_2026-07-17T080000_earlier-write",
+        instagram_post_url="https://www.instagram.com/p/DifferentPost/",
+    )
+    qw.write_queue_atomic(qpath, [existing])
+
+    incoming = _external_payload()
+    res = qw.add_external(qpath, incoming)
+    assert res.status == "added"
+    assert res.ok is True
+    assert len(qw.load_queue(qpath)) == 2
+
+
+# ── finding E — same item_id, different post -> conflict, not already_present ─
+
+
+def test_add_external_same_item_id_different_url_is_conflict_not_already_present(tmp_path):
+    """GUILT (finding E): the SAME item_id already exists but with a
+    DIFFERENT URL/shortcode — this must be a distinct `conflict` status with
+    ok=False, never collapsed into `already_present`/ok=True (which the
+    wrapper reads as "safe to mark synced", silently losing the genuinely
+    distinct post with no record it was ever dropped)."""
+    qpath = tmp_path / "q.json"
+    existing = _external_payload(instagram_post_url="https://www.instagram.com/p/OriginalPost/")
+    qw.write_queue_atomic(qpath, [existing])
+
+    incoming = _external_payload(instagram_post_url="https://www.instagram.com/p/ADifferentPostEntirely/")
+    res = qw.add_external(qpath, incoming)
+    assert res.status == "conflict"
+    assert res.ok is False
+    # no write — queue untouched
+    assert qw.load_queue(qpath) == [existing]
+
+
+def test_add_external_same_item_id_same_url_is_already_present_ok_true(tmp_path):
+    """INNOCENCE: a genuine retry (same item_id, same post) is the normal
+    idempotent no-op path — already_present, ok=True, safe to mark synced."""
+    qpath = tmp_path / "q.json"
+    existing = _external_payload()
+    qw.write_queue_atomic(qpath, [existing])
+
+    res = qw.add_external(qpath, _external_payload())
+    assert res.status == "already_present"
+    assert res.ok is True
+
+
+def test_cmd_add_external_exit_code_reflects_conflict(tmp_path, capsys):
+    """Verifies finding E needs no wrapper-side change: _cmd_add_external's
+    exit code already propagates ok=False as a nonzero return, which is what
+    the wrapper's existing `if ssh ...; then mark-synced; else WARN; fi` gate
+    keys off of."""
+    qpath = tmp_path / "q.json"
+    existing = _external_payload(instagram_post_url="https://www.instagram.com/p/OriginalPost/")
+    qw.write_queue_atomic(qpath, [existing])
+
+    import argparse
+    args = argparse.Namespace(
+        queue=str(qpath),
+        payload=json.dumps(_external_payload(instagram_post_url="https://www.instagram.com/p/ADifferentPostEntirely/")),
+    )
+    rc = qw._cmd_add_external(args)
+    assert rc == 1
+
+
+# ── finding F — backfill_media_id compare-and-set under lock ────────────────
+
+
+def test_backfill_media_id_expected_shortcode_mismatch_is_conflict(tmp_path):
+    """GUILT (finding F): the entry's URL changed since discovery's snapshot
+    matched it on shortcode ABC123 — backfill must recompute the CURRENT
+    shortcode under its own lock and refuse (conflict, no write) rather than
+    attach media_id for the OLD post onto whatever now sits at this item_id."""
+    qpath = tmp_path / "q.json"
+    item = {"item_id": "carousel_1", "instagram_post_url": "https://www.instagram.com/p/NEWCODE/"}
+    qw.write_queue_atomic(qpath, [item])
+
+    res = qw.backfill_media_id(qpath, "carousel_1", "17895695668004550", expected_shortcode="ABC123")
+    assert res.status == "conflict"
+    assert res.ok is False
+    after = qw.load_queue(qpath)
+    assert "ig_media_id" not in after[0]
+
+
+def test_backfill_media_id_expected_shortcode_matches_writes_normally(tmp_path):
+    """INNOCENCE: the entry's current shortcode matches what discovery
+    snapshotted -> the write proceeds exactly as before finding F."""
+    qpath = tmp_path / "q.json"
+    item = {"item_id": "carousel_1", "instagram_post_url": "https://www.instagram.com/p/ABC123/"}
+    qw.write_queue_atomic(qpath, [item])
+
+    res = qw.backfill_media_id(qpath, "carousel_1", "17895695668004550", expected_shortcode="ABC123")
+    assert res.status == "backfilled"
+    assert res.ok is True
+    after = qw.load_queue(qpath)
+    assert after[0]["ig_media_id"] == "17895695668004550"
+
+
+def test_backfill_media_id_no_expected_shortcode_skips_the_check(tmp_path):
+    """Backward compatibility: callers that never snapshotted a shortcode
+    (expected_shortcode=None, the default) get the pre-finding-F behavior —
+    no compare-and-set, write proceeds."""
+    qpath = tmp_path / "q.json"
+    item = {"item_id": "carousel_1", "instagram_post_url": "https://www.instagram.com/p/Whatever/"}
+    qw.write_queue_atomic(qpath, [item])
+
+    res = qw.backfill_media_id(qpath, "carousel_1", "17895695668004550")
+    assert res.status == "backfilled"
+
+
+def test_backfill_media_id_still_conflicts_on_different_existing_media_id(tmp_path):
+    """Regression guard: the pre-existing "different ig_media_id already
+    present" conflict path must still work when expected_shortcode matches
+    (or is omitted) — finding F's new check is additive, not a replacement."""
+    qpath = tmp_path / "q.json"
+    item = {"item_id": "carousel_1", "instagram_post_url": "https://www.instagram.com/p/ABC123/",
+            "ig_media_id": "11111111111111111"}
+    qw.write_queue_atomic(qpath, [item])
+
+    res = qw.backfill_media_id(qpath, "carousel_1", "22222222222222222", expected_shortcode="ABC123")
+    assert res.status == "conflict"
+    after = qw.load_queue(qpath)
+    assert after[0]["ig_media_id"] == "11111111111111111"
+
+
+# ── finding G — validate_external_payload type-checks optional fields ──────
+
+
+def test_validate_external_payload_rejects_negative_slide_count():
+    err = qw.validate_external_payload(_external_payload(slide_count=-1))
+    assert err is not None and "slide_count" in err
+
+
+def test_validate_external_payload_rejects_non_int_slide_count():
+    err = qw.validate_external_payload(_external_payload(slide_count="six"))
+    assert err is not None and "slide_count" in err
+
+
+def test_validate_external_payload_rejects_bool_slide_count():
+    # bool is a subclass of int in Python — must be explicitly excluded.
+    err = qw.validate_external_payload(_external_payload(slide_count=True))
+    assert err is not None and "slide_count" in err
+
+
+def test_validate_external_payload_accepts_zero_slide_count():
+    # INNOCENCE: 0 is a valid slide_count (>= 0), must not be rejected.
+    err = qw.validate_external_payload(_external_payload(slide_count=0))
+    assert err is None
+
+
+def test_validate_external_payload_accepts_missing_slide_count():
+    # INNOCENCE: slide_count is optional — absence is fine.
+    payload = _external_payload()
+    del payload["slide_count"]
+    assert qw.validate_external_payload(payload) is None
+
+
+def test_validate_external_payload_rejects_unparseable_published_at():
+    err = qw.validate_external_payload(_external_payload(published_at="not-a-date"))
+    assert err is not None and "published_at" in err
+
+
+def test_validate_external_payload_accepts_iso_published_at_with_z_suffix():
+    # INNOCENCE: a trailing "Z" (not directly fromisoformat-parseable pre-3.11)
+    # must still be accepted via the Z->+00:00 normalization.
+    err = qw.validate_external_payload(_external_payload(published_at="2026-07-17T09:00:00Z"))
+    assert err is None
+
+
+def test_validate_external_payload_accepts_missing_published_at():
+    payload = _external_payload()
+    del payload["published_at"]
+    assert qw.validate_external_payload(payload) is None

--- a/scripts/wr2_ig_discovery.py
+++ b/scripts/wr2_ig_discovery.py
@@ -149,7 +149,23 @@ def caption_first_line(caption: Optional[str]) -> str:
 
 
 def build_known_shortcodes(queue_items: list[dict[str, Any]]) -> set[str]:
-    """Every IG shortcode already present in the queue (via instagram_post_url)."""
+    """Every IG shortcode already present in the queue (via instagram_post_url).
+
+    TOCTOU note (§E, team-lead diagnosis 2026-07-17): this is a ONE-TIME
+    snapshot taken at the top of `main()` before the ingest loop below writes
+    anything. A post that becomes known between this snapshot and this run's
+    own `ingest_external_post` calls (e.g. a native WR2 entry published
+    mid-run, or a second discovery run racing this one) can still produce a
+    virtual `ig-<shortcode>` entry sharing a URL/shortcode with a native
+    entry — exactly the live case that triggered this diagnosis (idx 61
+    `bali-pma-rental-crackdown`, native + published, vs idx 71
+    `ig-DaxDJuYFPi6`, discovery-ingested 07-14 while idx 61's URL was still
+    null). This function does NOT close that race, and isn't meant to: the
+    backstop is the WR2 Control app's own §E dedup
+    (`WarRoom.swift::matchesAnyPhysicalInstagramURL`), which hides a virtual
+    entry at GALLERY READ TIME whenever a non-virtual sibling shares its URL,
+    independent of ingestion order or timing.
+    """
     known: set[str] = set()
     for item in queue_items:
         url = item.get("instagram_post_url")
@@ -159,6 +175,49 @@ def build_known_shortcodes(queue_items: list[dict[str, Any]]) -> set[str]:
         if code:
             known.add(code)
     return known
+
+
+def find_media_id_backfills(
+    media_list: list[dict[str, Any]],
+    queue_items: list[dict[str, Any]],
+) -> list[tuple[str, str]]:
+    """Pair up (item_id, ig_media_id) for queue items ALREADY known by
+    shortcode but missing `ig_media_id` — the RECONCILIATION half of §C
+    (`ingest_external_post`'s `ig_media_id` pass-through is the fresh-mint
+    half; this closes the gap for posts that predate that field, notably
+    WR2-NATIVE carousels published via the app's own gate, which records the
+    permalink but never a Graph media id — e.g. `bali-pma-rental-crackdown`).
+
+    Matches by SHORTCODE (not URL string equality — queue URLs may differ in
+    query string/scheme/www; shortcode is the same load-bearing key
+    `build_known_shortcodes()` already uses). Pure and read-only: callers
+    (`main()`) drive the actual `backfill_media_id()` write + dry-run gating.
+    """
+    media_by_shortcode: dict[str, str] = {}
+    for m in media_list:
+        code = _qw.extract_ig_shortcode(m.get("permalink") or "")
+        media_id = m.get("id")
+        if code and media_id:
+            media_by_shortcode[code] = str(media_id)
+
+    pairs: list[tuple[str, str]] = []
+    for item in queue_items:
+        if item.get("ig_media_id"):
+            continue  # already reconciled — nothing to do
+        url = item.get("instagram_post_url")
+        if not url:
+            continue
+        code = _qw.extract_ig_shortcode(url)
+        if not code:
+            continue
+        media_id = media_by_shortcode.get(code)
+        if not media_id:
+            continue  # this run's fetch didn't happen to include that post
+        item_id = _qw.item_id_of(item)
+        if not item_id:
+            continue
+        pairs.append((item_id, media_id))
+    return pairs
 
 
 def parse_ig_timestamp(ts: Optional[str]) -> Optional[datetime]:
@@ -349,12 +408,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         topic = cap_line[:60] if cap_line else f"(external IG post {shortcode})"
         dt = parse_ig_timestamp(m.get("timestamp"))
         published_at = dt.isoformat() if dt else None
+        media_id = m.get("id")  # real numeric Graph id — always carried through when we have it
 
         if args.dry_run:
-            print(f"[dry-run] would ingest url={permalink} topic={topic!r} published_at={published_at}")
+            print(f"[dry-run] would ingest url={permalink} topic={topic!r} published_at={published_at} "
+                  f"ig_media_id={media_id}")
             continue
 
-        res = _qw.ingest_external_post(queue_path, permalink, topic=topic, published_at=published_at)
+        res = _qw.ingest_external_post(
+            queue_path, permalink, topic=topic, published_at=published_at, ig_media_id=media_id,
+        )
         if res.status == "ingested":
             ingested += 1
             print(f"INGESTED url={permalink} topic={topic!r}")
@@ -363,7 +426,31 @@ def main(argv: Optional[list[str]] = None) -> int:
         else:
             print(f"WARN ingest failed url={permalink} status={res.status} detail={res.detail}", file=sys.stderr)
 
-    print(f"DISCOVERY: fetched={fetched} known={len(known)} ingested={ingested} match_pending={match_pending}")
+    # ── §C point 3 reconciliation: WR2-native carousels (published via the
+    # app's own gate) never get an ig_media_id at publish time. Anything this
+    # run's fetch can match by shortcode gets backfilled here, closing the
+    # metrics gap for entries that predate `ig_media_id` (see
+    # find_media_id_backfills docstring). Computed from the pre-ingest
+    # `queue_items` snapshot — safe because backfill_media_id() re-reads the
+    # live file under lock at write time; only already-known entries (which
+    # exist in that snapshot) are ever candidates. ──────────────────────────
+    backfill_pairs = find_media_id_backfills(media_list, queue_items)
+    backfilled = 0
+    for item_id, media_id in backfill_pairs:
+        if args.dry_run:
+            print(f"[dry-run] would backfill ig_media_id={media_id} onto item_id={item_id}")
+            continue
+        res = _qw.backfill_media_id(queue_path, item_id, media_id)
+        if res.status == "backfilled":
+            backfilled += 1
+            print(f"BACKFILLED item_id={item_id} ig_media_id={media_id}")
+        elif res.status == "already_backfilled":
+            pass  # no-op, nothing new to report
+        else:
+            print(f"WARN backfill failed item_id={item_id} status={res.status} detail={res.detail}", file=sys.stderr)
+
+    print(f"DISCOVERY: fetched={fetched} known={len(known)} ingested={ingested} "
+          f"match_pending={match_pending} backfilled={backfilled}")
 
     if match_pending > 0:
         return 1

--- a/scripts/wr2_ig_discovery.py
+++ b/scripts/wr2_ig_discovery.py
@@ -180,9 +180,9 @@ def build_known_shortcodes(queue_items: list[dict[str, Any]]) -> set[str]:
 def find_media_id_backfills(
     media_list: list[dict[str, Any]],
     queue_items: list[dict[str, Any]],
-) -> list[tuple[str, str]]:
-    """Pair up (item_id, ig_media_id) for queue items ALREADY known by
-    shortcode but missing `ig_media_id` — the RECONCILIATION half of §C
+) -> list[tuple[str, str, str]]:
+    """Pair up (item_id, ig_media_id, shortcode) for queue items ALREADY known
+    by shortcode but missing `ig_media_id` — the RECONCILIATION half of §C
     (`ingest_external_post`'s `ig_media_id` pass-through is the fresh-mint
     half; this closes the gap for posts that predate that field, notably
     WR2-NATIVE carousels published via the app's own gate, which records the
@@ -192,6 +192,12 @@ def find_media_id_backfills(
     query string/scheme/www; shortcode is the same load-bearing key
     `build_known_shortcodes()` already uses). Pure and read-only: callers
     (`main()`) drive the actual `backfill_media_id()` write + dry-run gating.
+
+    The shortcode is returned alongside the pair (Codex red-team, 2026-07-17,
+    finding F) so the caller can pass it to `backfill_media_id` as
+    `expected_shortcode` — a compare-and-set guard taken under that call's OWN
+    lock, re-verifying the entry hasn't moved to a different URL between THIS
+    snapshot and the write acquiring the lock (TOCTOU race).
     """
     media_by_shortcode: dict[str, str] = {}
     for m in media_list:
@@ -200,7 +206,7 @@ def find_media_id_backfills(
         if code and media_id:
             media_by_shortcode[code] = str(media_id)
 
-    pairs: list[tuple[str, str]] = []
+    pairs: list[tuple[str, str, str]] = []
     for item in queue_items:
         if item.get("ig_media_id"):
             continue  # already reconciled — nothing to do
@@ -216,7 +222,7 @@ def find_media_id_backfills(
         item_id = _qw.item_id_of(item)
         if not item_id:
             continue
-        pairs.append((item_id, media_id))
+        pairs.append((item_id, media_id, code))
     return pairs
 
 
@@ -436,11 +442,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     # exist in that snapshot) are ever candidates. ──────────────────────────
     backfill_pairs = find_media_id_backfills(media_list, queue_items)
     backfilled = 0
-    for item_id, media_id in backfill_pairs:
+    for item_id, media_id, matched_shortcode in backfill_pairs:
         if args.dry_run:
             print(f"[dry-run] would backfill ig_media_id={media_id} onto item_id={item_id}")
             continue
-        res = _qw.backfill_media_id(queue_path, item_id, media_id)
+        res = _qw.backfill_media_id(queue_path, item_id, media_id, expected_shortcode=matched_shortcode)
         if res.status == "backfilled":
             backfilled += 1
             print(f"BACKFILLED item_id={item_id} ig_media_id={media_id}")

--- a/scripts/wr2_ig_metrics_scraper.py
+++ b/scripts/wr2_ig_metrics_scraper.py
@@ -116,11 +116,34 @@ def is_stale(metrics: Optional[dict], max_age_days: int) -> bool:
 
 
 def media_id_of(item: dict) -> Optional[str]:
-    # backfill ids are "ig-<mediaid>"; otherwise derive from the permalink shortcode is not
-    # enough (Graph needs the numeric media id) — rely on the ig-<id> convention.
-    iid = item.get("id") or ""
-    if iid.startswith("ig-"):
-        return iid[3:]
+    """Extract the Graph API numeric media id from a queue item's own id, if it
+    carries one. Checked on BOTH historical id keys — legacy `"id"` (the
+    Graph-API backfill's own convention) AND `"item_id"` (the newer FSM/app
+    schema — same dual-schema precedent as `wr2_queue_writer.item_id_of`) — so an
+    entry minted under either schema is considered rather than silently skipped.
+
+    §C verification note (external-post feature spec, 2026-07-17): the "keys by
+    instagram_post_url" assumption in that spec is only PARTIALLY true. Selection
+    in `main()` below already filters on `instagram_post_url` + `state=="published"`
+    for ANY queue entry regardless of pipeline origin — but the actual Graph
+    FETCH requires a resolvable id here, and the "ig-" prefix convention assumes
+    the suffix IS a Graph-resolvable NUMERIC media id. That holds for the
+    historical Graph-API backfill (which used the real numeric id), but does
+    NOT hold for `ig-<shortcode>` ids minted by `ingest_external_post`
+    (scripts/wr2_queue_writer.py) or for this feature's own `external_<date>_...`
+    ids — a post/reel permalink's shortcode is a DIFFERENT identifier than the
+    Graph media id, and there is no local mapping between them (resolving one
+    from the other needs an authenticated Business Discovery/oEmbed call this
+    scraper does not make). Entries that fail this id-derivation are now logged
+    explicitly in `main()` (`skipped_no_media_id=`) instead of vanishing into
+    the same silent gap as "not stale yet" — this is a DOCUMENTED LIMITATION,
+    not a bug fixed here: externally-registered posts without a known Graph
+    media id cannot get automated metrics until that resolution is built.
+    """
+    for key in ("id", "item_id"):
+        iid = item.get(key) or ""
+        if iid.startswith("ig-"):
+            return iid[3:]
     return None
 
 
@@ -140,20 +163,29 @@ def main() -> int:
     qpath = Path(args.queue)
     queue = json.loads(qpath.read_text())
 
-    # smart selection: published items whose metrics are missing/stale + have a media id
+    # smart selection: published items whose metrics are missing/stale + have a media id.
+    # Selection on instagram_post_url + state=="published" already applies to ANY queue
+    # entry regardless of pipeline origin (§C: this half of the spec's assumption holds).
+    # `no_media_id` makes the OTHER half — entries that qualify here but can never be
+    # fetched because no Graph-resolvable id can be derived (see media_id_of docstring,
+    # e.g. externally-registered posts) — an OBSERVABLE count instead of a silent drop
+    # indistinguishable from "not stale yet" (scar #2, esiste≠armato).
     todo = []
+    no_media_id = 0
     for item in queue:
         if not (item.get("instagram_post_url") and item.get("state") == "published"):
             continue
         if not media_id_of(item):
+            no_media_id += 1
             continue
         if is_stale(item.get("engagement_metrics"), args.max_age_days):
             todo.append(item)
     if args.limit > 0:
         todo = todo[: args.limit]
 
+    skip_note = f" skipped_no_media_id={no_media_id}" if no_media_id else ""
     print(f"published={sum(1 for i in queue if i.get('state')=='published')} "
-          f"to_refresh={len(todo)} (max_age={args.max_age_days}d)")
+          f"to_refresh={len(todo)} (max_age={args.max_age_days}d){skip_note}")
 
     updated = 0
     for item in todo:

--- a/scripts/wr2_ig_metrics_scraper.py
+++ b/scripts/wr2_ig_metrics_scraper.py
@@ -145,6 +145,12 @@ def media_id_of(item: dict) -> Optional[str]:
        for a post whose real numeric id truly isn't known anywhere yet, this
        stays a DOCUMENTED LIMITATION (needs `wr2_ig_discovery.py`'s
        reconciliation pass to run and find/backfill it), not a bug fixed here.
+
+    Length floor (Codex red-team, 2026-07-17, finding I): all 45 real legacy
+    `ig-<digits>` ids on record are 17-digit Graph media ids. `isdigit()`
+    alone would also accept a THEORETICAL all-digit shortcode — requiring
+    `len(suffix) >= 15` keeps the legacy fallback scoped to what it was
+    actually built for.
     """
     authoritative = item.get("ig_media_id")
     if authoritative:
@@ -153,7 +159,7 @@ def media_id_of(item: dict) -> Optional[str]:
         iid = item.get(key) or ""
         if iid.startswith("ig-"):
             suffix = iid[3:]
-            if suffix.isdigit():
+            if suffix.isdigit() and len(suffix) >= 15:
                 return suffix
     return None
 

--- a/scripts/wr2_ig_metrics_scraper.py
+++ b/scripts/wr2_ig_metrics_scraper.py
@@ -116,34 +116,45 @@ def is_stale(metrics: Optional[dict], max_age_days: int) -> bool:
 
 
 def media_id_of(item: dict) -> Optional[str]:
-    """Extract the Graph API numeric media id from a queue item's own id, if it
-    carries one. Checked on BOTH historical id keys — legacy `"id"` (the
-    Graph-API backfill's own convention) AND `"item_id"` (the newer FSM/app
-    schema — same dual-schema precedent as `wr2_queue_writer.item_id_of`) — so an
-    entry minted under either schema is considered rather than silently skipped.
+    """Extract the Graph API numeric media id for a queue item, or None if it
+    doesn't have one it can be trusted to fetch with.
 
-    §C verification note (external-post feature spec, 2026-07-17): the "keys by
-    instagram_post_url" assumption in that spec is only PARTIALLY true. Selection
-    in `main()` below already filters on `instagram_post_url` + `state=="published"`
-    for ANY queue entry regardless of pipeline origin — but the actual Graph
-    FETCH requires a resolvable id here, and the "ig-" prefix convention assumes
-    the suffix IS a Graph-resolvable NUMERIC media id. That holds for the
-    historical Graph-API backfill (which used the real numeric id), but does
-    NOT hold for `ig-<shortcode>` ids minted by `ingest_external_post`
-    (scripts/wr2_queue_writer.py) or for this feature's own `external_<date>_...`
-    ids — a post/reel permalink's shortcode is a DIFFERENT identifier than the
-    Graph media id, and there is no local mapping between them (resolving one
-    from the other needs an authenticated Business Discovery/oEmbed call this
-    scraper does not make). Entries that fail this id-derivation are now logged
-    explicitly in `main()` (`skipped_no_media_id=`) instead of vanishing into
-    the same silent gap as "not stale yet" — this is a DOCUMENTED LIMITATION,
-    not a bug fixed here: externally-registered posts without a known Graph
-    media id cannot get automated metrics until that resolution is built.
+    §C — CORRECTED per live Pro-side diagnosis, 2026-07-17 (supersedes the
+    2026-07-16 fix below, which only widened the KEY searched, not the VALUE
+    trusted):
+
+    1. `ig_media_id` — the AUTHORITATIVE field (`wr2_queue_writer.build_external_item`
+       / `backfill_media_id`, wired from `wr2_ig_discovery.py`'s own Graph media
+       fetch, which carries the real numeric `id` alongside `permalink`). Always
+       preferred when present — it is never derived/guessed.
+    2. Legacy fallback — `id` or `item_id` (dual-schema precedent, same as
+       `wr2_queue_writer.item_id_of`) with an `"ig-"` prefix, but ONLY when the
+       SUFFIX IS ALL DIGITS. This is the load-bearing correction: a Graph media
+       id is a large all-numeric string, while an IG post/reel SHORTCODE (the
+       `/p/<code>/` URL segment) is alphanumeric with `-`/`_` — the two were
+       being conflated. The historical Graph-API backfill wrote `id: "ig-<real
+       numeric id>"` directly (digits-only suffix, still resolves here); but
+       `ingest_external_post`'s OWN `ig-<shortcode>` convention (used before
+       `ig_media_id` existed, and by any caller that never had a Graph fetch —
+       e.g. the WR2 Control app's manual "add external post" §A feature, whose
+       id looks like `external_<date>T<time>_<slug>` and never even reaches
+       this branch) does NOT resolve — a shortcode fed to the Graph endpoint
+       would 400 with a confusing error instead of failing cleanly.
+    3. Neither present -> None. `main()` counts this (`skipped_no_media_id=`)
+       instead of it vanishing into the same silent gap as "not stale yet" —
+       for a post whose real numeric id truly isn't known anywhere yet, this
+       stays a DOCUMENTED LIMITATION (needs `wr2_ig_discovery.py`'s
+       reconciliation pass to run and find/backfill it), not a bug fixed here.
     """
+    authoritative = item.get("ig_media_id")
+    if authoritative:
+        return str(authoritative)
     for key in ("id", "item_id"):
         iid = item.get(key) or ""
         if iid.startswith("ig-"):
-            return iid[3:]
+            suffix = iid[3:]
+            if suffix.isdigit():
+                return suffix
     return None
 
 

--- a/scripts/wr2_queue_pull_merge.py
+++ b/scripts/wr2_queue_pull_merge.py
@@ -39,6 +39,13 @@ Merge semantics (monotone state lattice — remote wins EXCEPT):
     dropped), with a warning in `queue_and_archive_conflict`.
   - everything else: remote wins verbatim.
 
+`push_back_external` (§A/§B, 2026-07-17): a SEPARATE, read-only pass over
+`local` (see `external_push_candidates`) — entries the WR2 Control app
+registered via the external-post feature that are not yet confirmed synced
+to Pro. Orthogonal to the merge loop above: it never changes what lands in
+`merged`/`local_only`, it only surfaces what the wrapper should replay onto
+Pro via `wr2_queue_writer.py add-external`.
+
 CLI (used by infra/launchagents/wrappers/wr2-queue-pull.sh):
     python3 scripts/wr2_queue_pull_merge.py --remote R.json --local L.json \
         --out M.json [--remote-archive A.json]
@@ -46,7 +53,15 @@ prints a JSON report to stdout:
     {"protected": [ids], "local_only": [ids],
      "push_back": [{"id":..., "ref_code": "WR2-XXXXXX", "ig_url": ...}],
      "archived_dropped": [ids], "queue_and_archive_conflict": [ids],
-     "published_local_kept_despite_archive": [ids]}
+     "published_local_kept_despite_archive": [ids],
+     "push_back_external": [{"item_id":..., ...full payload}]}
+
+Secondary CLI mode (§B, standalone — does not need --remote/--local/--out):
+    python3 scripts/wr2_queue_pull_merge.py --mark-synced-item-id ID \
+        --mark-synced-file L.json
+marks the matching entry `synced_to_pro: true` on L.json after the wrapper
+confirms a `push_back_external` entry landed on Pro, and prints
+`{"ok": true, "marked": ID}`.
 """
 
 from __future__ import annotations
@@ -61,10 +76,13 @@ from typing import Any, Optional
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from wr2_queue_writer import (  # noqa: E402 — same scripts/ dir
+    EXTERNAL_MANUAL_SOURCE,
     PUBLISHED_STATES,
     compute_ref_code,
     item_id_of,
+    validate_external_payload,
     validate_ig_url,
+    write_queue_atomic,
 )
 
 _REF_CODE_SAFE_RE = re.compile(r"^WR2-[0-9A-F]{6}$")
@@ -83,6 +101,52 @@ _PUBLISH_FIELDS = (
 
 def _is_published(entry: dict[str, Any]) -> bool:
     return entry.get("state") in PUBLISHED_STATES
+
+
+def external_push_candidates(local: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Local entries the WR2 Control app registered via the external-post feature
+    (§A, 2026-07-17) that have NOT yet been confirmed synced to Pro. Pure — no I/O,
+    no ssh; the wrapper (wr2-queue-pull.sh) replays each one via
+    `scripts/wr2_queue_writer.py add-external` and then calls `mark_synced_to_pro`
+    below on confirmed success.
+
+    An entry qualifies when ALL of:
+      - `source == EXTERNAL_MANUAL_SOURCE` — only the app's own external-post writes
+        carry this exact marker, never a WR2-pipeline entry (never confuse this with
+        `ingest_external_post`'s `"manual_external"`, a DIFFERENT origin/convention);
+      - `synced_to_pro` is not already truthy — idempotent: a confirmed push must
+        never be replayed forever (the local entry gets marked after success);
+      - the payload passes `validate_external_payload` — a malformed/partial local
+        entry (e.g. a write that raced a crash) must never be shipped over ssh as a
+        broken CLI argument; it stays local-only, unsynced, until it's fixed.
+    """
+    out: list[dict[str, Any]] = []
+    for e in local:
+        if not isinstance(e, dict):
+            continue
+        if e.get("source") != EXTERNAL_MANUAL_SOURCE:
+            continue
+        if e.get("synced_to_pro"):
+            continue
+        if validate_external_payload(e) is not None:
+            continue
+        out.append(e)
+    return out
+
+
+def mark_synced_to_pro(items: list[dict[str, Any]], item_id: str) -> list[dict[str, Any]]:
+    """Pure: return a COPY of `items` with the entry matching `item_id` marked
+    `synced_to_pro: true`, so `external_push_candidates` never re-offers a
+    confirmed push. No-op (items returned unchanged, by value) if no entry matches
+    — the wrapper calling this after a successful ssh push always has a real id,
+    but a stale/raced call must never crash or silently invent an entry."""
+    out: list[dict[str, Any]] = []
+    for it in items:
+        if isinstance(it, dict) and item_id_of(it) == item_id:
+            it = dict(it)
+            it["synced_to_pro"] = True
+        out.append(it)
+    return out
 
 
 def merge_queues(
@@ -187,20 +251,48 @@ def merge_queues(
         "archived_dropped": archived_dropped,
         "queue_and_archive_conflict": queue_and_archive_conflict,
         "published_local_kept_despite_archive": published_local_kept_despite_archive,
+        "push_back_external": external_push_candidates(local),
     }
 
 
 def main(argv: Optional[list[str]] = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--remote", type=Path, required=True, help="freshly pulled Pro queue")
-    ap.add_argument("--local", type=Path, required=True, help="current local queue")
-    ap.add_argument("--out", type=Path, required=True, help="merged output path")
+    # --remote/--local/--out are NOT required at the argparse level (only
+    # enforced below, ap.error) because the secondary --mark-synced-item-id
+    # mode (§B) is a standalone invocation that needs none of them.
+    ap.add_argument("--remote", type=Path, help="freshly pulled Pro queue")
+    ap.add_argument("--local", type=Path, help="current local queue")
+    ap.add_argument("--out", type=Path, help="merged output path")
     ap.add_argument(
         "--remote-archive", type=Path, default=None,
         help="freshly pulled Pro queue-archive.json — cross-checked so an "
              "entry Pro archived is dropped instead of resurrected as local_only",
     )
+    # Secondary mode (§B): after the wrapper successfully replays a push_back_external
+    # entry into Pro via `wr2_queue_writer.py add-external`, it calls back into THIS
+    # script to mark that entry `synced_to_pro: true` on the LOCAL file — so the next
+    # merge's `external_push_candidates` never re-offers it. Kept in this module
+    # (not a new script) because it operates on the same local-queue shape and reuses
+    # `mark_synced_to_pro` directly.
+    ap.add_argument("--mark-synced-item-id", help="mark this item_id synced_to_pro=true on --mark-synced-file")
+    ap.add_argument("--mark-synced-file", type=Path, help="local queue file to mutate (used with --mark-synced-item-id)")
     args = ap.parse_args(argv)
+
+    if args.mark_synced_item_id:
+        if not args.mark_synced_file:
+            print(json.dumps({"ok": False, "error": "--mark-synced-file is required with --mark-synced-item-id"}))
+            return 2
+        items = json.loads(args.mark_synced_file.read_text(encoding="utf-8"))
+        if not isinstance(items, list):
+            print(json.dumps({"ok": False, "error": "--mark-synced-file is not a list"}))
+            return 2
+        updated = mark_synced_to_pro(items, args.mark_synced_item_id)
+        write_queue_atomic(args.mark_synced_file, updated)
+        print(json.dumps({"ok": True, "marked": args.mark_synced_item_id}))
+        return 0
+
+    if not (args.remote and args.local and args.out):
+        ap.error("--remote, --local and --out are all required unless --mark-synced-item-id is given")
 
     remote = json.loads(args.remote.read_text(encoding="utf-8"))
     if not isinstance(remote, list):

--- a/scripts/wr2_queue_pull_merge.py
+++ b/scripts/wr2_queue_pull_merge.py
@@ -103,7 +103,11 @@ def _is_published(entry: dict[str, Any]) -> bool:
     return entry.get("state") in PUBLISHED_STATES
 
 
-def external_push_candidates(local: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def external_push_candidates(
+    local: list[dict[str, Any]],
+    known_remote_ids: Optional[set[str]] = None,
+    archived_ids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]:
     """Local entries the WR2 Control app registered via the external-post feature
     (§A, 2026-07-17) that have NOT yet been confirmed synced to Pro. Pure — no I/O,
     no ssh; the wrapper (wr2-queue-pull.sh) replays each one via
@@ -118,8 +122,18 @@ def external_push_candidates(local: list[dict[str, Any]]) -> list[dict[str, Any]
         never be replayed forever (the local entry gets marked after success);
       - the payload passes `validate_external_payload` — a malformed/partial local
         entry (e.g. a write that raced a crash) must never be shipped over ssh as a
-        broken CLI argument; it stays local-only, unsynced, until it's fixed.
+        broken CLI argument; it stays local-only, unsynced, until it's fixed;
+      - `item_id` is NOT already present in Pro's remote queue OR remote archive
+        (Codex red-team, 2026-07-17, finding C): without this, Pro's own copy of
+        the entry (which never carries the LOCAL-only `synced_to_pro` bookkeeping
+        flag) looks "unsynced" again on the very next tick and gets replayed
+        forever (`already_present` loop) — or worse, if Pro deliberately
+        ARCHIVED it, add-external would RE-CREATE it on Pro, overriding that
+        SSOT decision. `merge_queues` passes the already-populated `seen` set
+        (every valid remote item_id) and `archived_ids` at the call site.
     """
+    known_remote_ids = known_remote_ids or set()
+    archived_ids = archived_ids or set()
     out: list[dict[str, Any]] = []
     for e in local:
         if not isinstance(e, dict):
@@ -127,6 +141,9 @@ def external_push_candidates(local: list[dict[str, Any]]) -> list[dict[str, Any]
         if e.get("source") != EXTERNAL_MANUAL_SOURCE:
             continue
         if e.get("synced_to_pro"):
+            continue
+        eid = item_id_of(e)
+        if eid and (eid in known_remote_ids or eid in archived_ids):
             continue
         if validate_external_payload(e) is not None:
             continue
@@ -213,6 +230,16 @@ def merge_queues(
             # the wrapper interpolates these into an ssh command line.
             if _REF_CODE_SAFE_RE.match(ref) and validate_ig_url(url):
                 push_back.append({"id": str(rid), "ref_code": ref, "ig_url": url.strip()})
+        elif loc is not None and loc.get("synced_to_pro"):
+            # CARRY synced_to_pro (Codex red-team, 2026-07-17, finding C-i):
+            # remote wins verbatim here, but Pro's own copy of an
+            # external_manual entry never carries this LOCAL-only bookkeeping
+            # flag — without carrying it forward, external_push_candidates
+            # would see an "unsynced" entry again next tick and replay
+            # add-external forever (already_present loop).
+            out = dict(r)
+            out["synced_to_pro"] = True
+            merged.append(out)
         else:
             merged.append(r)
 
@@ -251,7 +278,7 @@ def merge_queues(
         "archived_dropped": archived_dropped,
         "queue_and_archive_conflict": queue_and_archive_conflict,
         "published_local_kept_despite_archive": published_local_kept_despite_archive,
-        "push_back_external": external_push_candidates(local),
+        "push_back_external": external_push_candidates(local, known_remote_ids=seen, archived_ids=archived_ids),
     }
 
 

--- a/scripts/wr2_queue_writer.py
+++ b/scripts/wr2_queue_writer.py
@@ -37,10 +37,23 @@ CLI:
     python scripts/wr2_queue_writer.py list-ready
     python scripts/wr2_queue_writer.py ref-code <item_id>
     python scripts/wr2_queue_writer.py mark-published <ref_code> <ig_url> [--at ISO]
+    python scripts/wr2_queue_writer.py ingest-external <ig_url> [--topic T] [--at ISO]
+    python scripts/wr2_queue_writer.py add-external '<json payload>'
 
 Side-effect free functions (pure, unit-tested) are separated from the two I/O
 functions (`load_queue`, `write_queue_atomic`) so the matching/normalization
 logic is testable without touching disk.
+
+DOCUMENTED LIMITATION (external-post feature, §B, 2026-07-17): `add-external`
+lands the QUEUE ENTRY only — it never receives or writes the entry's images.
+When the WR2 Control app (M5) registers an external post WITH images, those
+PNGs stay local to M5's `carousel/external-<date>-<slug>/slides/` directory;
+this writer's Pro-side counterpart has no rsync/copy step for them, and Pro
+(the queue's SSOT) renders nothing for that carousel_path. Acceptable for v1
+because Pro's queue-consuming surfaces (scraper, analyst, mark-published) only
+need instagram_post_url/state/metrics, never the local slide PNGs — but a
+future viewer that expects Pro to render the carousel for an image-bearing
+external post will find the directory missing there.
 """
 
 from __future__ import annotations
@@ -159,6 +172,41 @@ def build_external_item(
         "source": "manual_external",
         "created_at": published_at_iso,
     }
+
+
+REQUIRED_EXTERNAL_PAYLOAD_FIELDS = (
+    "item_id",
+    "state",
+    "instagram_post_url",
+    "source",
+    "topic_slug",
+)
+EXTERNAL_MANUAL_SOURCE = "external_manual"
+
+
+def validate_external_payload(payload: dict[str, Any]) -> Optional[str]:
+    """Return an error string if `payload` is not a valid add-external entry, else None.
+
+    Distinct from `validate_ig_url` (URL shape only): this checks the FULL contract
+    the WR2 Control app (M5) is expected to build (`ExternalPostRegistration.swift`,
+    §A) before pushing it here for propagation to Pro (§B) — required fields present,
+    `state` must already be "published" (this writer never transitions state, only
+    lands an already-published entry), `source` must be the exact literal
+    `"external_manual"` (not the older `ingest_external_post`/`build_external_item`
+    convention `"manual_external"` — the two call sites mint entries for different
+    origins: that one is Zero pasting a bare URL on Pro directly, this one is the app
+    replaying a fully-formed entry it already built on M5).
+    """
+    for field in REQUIRED_EXTERNAL_PAYLOAD_FIELDS:
+        if not payload.get(field):
+            return f"missing required field: {field!r}"
+    if payload.get("state") != "published":
+        return f"state must be 'published', got {payload.get('state')!r}"
+    if payload.get("source") != EXTERNAL_MANUAL_SOURCE:
+        return f"source must be {EXTERNAL_MANUAL_SOURCE!r}, got {payload.get('source')!r}"
+    if not validate_ig_url(str(payload["instagram_post_url"])):
+        return f"instagram_post_url is not a valid IG permalink: {payload['instagram_post_url']!r}"
+    return None
 
 
 def find_by_ref_code(
@@ -374,6 +422,48 @@ def ingest_external_post(
         return PublishResult("ingested", True, compute_ref_code(iid), iid, f"registered external post {iid}")
 
 
+def add_external(path: Path, payload: dict[str, Any]) -> PublishResult:
+    """Append a FULLY-FORMED external-manual queue entry (M5->Pro propagation, §B).
+
+    Distinct from `ingest_external_post` above (which MINTS a minimal item from a
+    bare URL for Zero's manual CLI use, id `ig-<shortcode>`, source
+    `"manual_external"`): this accepts a payload the WR2 Control app already built
+    end-to-end (item_id `external_<date>T<time>_<slug>`, topic_slug, slide_count,
+    carousel_path, source `"external_manual"`, ...) and appends it VERBATIM after
+    validation — the app is the author, this call is only the sync landing point.
+
+    Refuses a duplicate on EITHER the same `instagram_post_url` OR the same
+    `item_id` already present (idempotency requirement, §B acceptance #2): the
+    M5->Pro push-back loop may retry after a flaky ssh, and a real duplicate post
+    submitted twice by the operator must be refused, not double-enqueued.
+
+      * invalid_payload  — missing/wrong-shaped field -> NO write
+      * already_present  — same item_id or instagram_post_url already in queue -> NO write (no-op)
+      * added            — appended + written atomically -> WRITE
+    """
+    err = validate_external_payload(payload)
+    if err:
+        return PublishResult("invalid_payload", False, "", detail=err)
+
+    new_id = str(payload["item_id"])
+    new_url = str(payload["instagram_post_url"]).strip()
+
+    with queue_lock(path):
+        items = load_queue(path)
+        for existing in items:
+            eid = item_id_of(existing)
+            existing_url = (existing.get("instagram_post_url") or "").strip()
+            if eid == new_id or (existing_url and existing_url == new_url):
+                return PublishResult(
+                    "already_present", True, compute_ref_code(new_id), eid,
+                    "no-op: an entry with this item_id or instagram_post_url already exists",
+                )
+        items.append(dict(payload))
+        write_queue_atomic(path, items)
+        return PublishResult("added", True, compute_ref_code(new_id), new_id,
+                              f"registered external post {new_id}")
+
+
 # ── CLI ────────────────────────────────────────────────────────────────────
 
 
@@ -429,6 +519,21 @@ def _cmd_ingest_external(args: argparse.Namespace) -> int:
     return 0 if result.ok else 1
 
 
+def _cmd_add_external(args: argparse.Namespace) -> int:
+    path = _resolve_queue_path(args.queue)
+    try:
+        payload = json.loads(args.payload)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"status": "invalid_json", "ok": False, "detail": str(e)}, ensure_ascii=False))
+        return 1
+    if not isinstance(payload, dict):
+        print(json.dumps({"status": "invalid_json", "ok": False, "detail": "payload is not a JSON object"}))
+        return 1
+    result = add_external(path, payload)
+    print(json.dumps(result.as_dict(), ensure_ascii=False))
+    return 0 if result.ok else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="WR2 publish-feedback queue writer")
     p.add_argument("--queue", help="path to human-review-queue.json (default: env WR2_QUEUE_PATH or standard)")
@@ -456,6 +561,13 @@ def build_parser() -> argparse.ArgumentParser:
     ie.add_argument("--topic", help="human label for the post (default: auto from shortcode)")
     ie.add_argument("--at", help="ISO publication date (default: 25h ago, so it's immediately scraper-eligible)")
     ie.set_defaults(func=_cmd_ingest_external)
+
+    ae = sub.add_parser(
+        "add-external",
+        help="append a fully-formed external_manual entry built by the WR2 Control app (M5->Pro sync, §B)",
+    )
+    ae.add_argument("payload", help="JSON object: item_id/state/instagram_post_url/source/topic_slug/...")
+    ae.set_defaults(func=_cmd_add_external)
     return p
 
 

--- a/scripts/wr2_queue_writer.py
+++ b/scripts/wr2_queue_writer.py
@@ -146,7 +146,8 @@ def extract_ig_shortcode(url: str) -> Optional[str]:
 
 
 def build_external_item(
-    ig_url: str, published_at_iso: str, topic: Optional[str] = None
+    ig_url: str, published_at_iso: str, topic: Optional[str] = None,
+    ig_media_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """Build a fresh, published queue item for an EXTERNALLY-published IG post.
 
@@ -156,10 +157,21 @@ def build_external_item(
     `ig-<shortcode>` (deterministic from the URL → idempotent). `external=True`
     and `source="manual_external"` flag it so the IG analyst knows it lacks the
     full WR2 attributes (archetype/domain/audience).
+
+    `ig_media_id` (§C reconciliation, 2026-07-17 live Pro-side diagnosis): the
+    REAL numeric Graph API media id, when the caller already fetched it (e.g.
+    `wr2_ig_discovery.py`'s own Graph media listing carries `m["id"]`, the
+    numeric id, alongside `permalink`). Stored as its OWN field — NEVER folded
+    into `item_id`'s `ig-<shortcode>` derivation, because the shortcode (the
+    URL's `/p/<code>/` segment) and the Graph media id are DIFFERENT
+    identifiers; a caller that only has the permalink (no Graph fetch, e.g. the
+    WR2 Control app's manual "add external post" §A feature) legitimately omits
+    this, and the metrics scraper degrades gracefully (skips with a logged
+    reason) rather than mistaking the shortcode for a fetchable media id.
     """
     url = ig_url.strip()
     shortcode = extract_ig_shortcode(url) or hashlib.sha1(url.encode()).hexdigest()[:8]
-    return {
+    item: dict[str, Any] = {
         "item_id": f"ig-{shortcode}",
         "topic": topic or f"(external IG post {shortcode})",
         "state": "published",
@@ -172,6 +184,9 @@ def build_external_item(
         "source": "manual_external",
         "created_at": published_at_iso,
     }
+    if ig_media_id:
+        item["ig_media_id"] = str(ig_media_id)
+    return item
 
 
 REQUIRED_EXTERNAL_PAYLOAD_FIELDS = (
@@ -381,6 +396,7 @@ def ingest_external_post(
     topic: Optional[str] = None,
     published_at: Optional[str] = None,
     now: Optional[datetime] = None,
+    ig_media_id: Optional[str] = None,
 ) -> PublishResult:
     """Register an externally-published IG post (no pre-existing queue item).
 
@@ -392,6 +408,11 @@ def ingest_external_post(
     for the scraper (which skips items <24h old) — these posts are already live,
     we are not waiting for a fresh-publish window. Pass `--at` with the real
     publication date when known.
+
+    `ig_media_id`: pass-through to `build_external_item` (§C, 2026-07-17) — the
+    caller's real numeric Graph media id when it already has one (e.g.
+    `wr2_ig_discovery.py`'s Graph fetch). Omitted by callers with only a
+    permalink (no Graph fetch, e.g. the WR2 Control app's manual entry point).
 
     Returns PublishResult with ref_code = compute_ref_code of the minted id.
       * invalid_url     — not an IG permalink -> NO write
@@ -415,11 +436,69 @@ def ingest_external_post(
         published_iso = published_at or (
             (now or datetime.now(timezone.utc)) - timedelta(hours=25)
         ).isoformat()
-        new_item = build_external_item(url, published_iso, topic=topic)
+        new_item = build_external_item(url, published_iso, topic=topic, ig_media_id=ig_media_id)
         items.append(new_item)
         write_queue_atomic(path, items)
         iid = new_item["item_id"]
         return PublishResult("ingested", True, compute_ref_code(iid), iid, f"registered external post {iid}")
+
+
+def backfill_media_id(path: Path, item_id: str, ig_media_id: str) -> PublishResult:
+    """Attach the real numeric Graph media id onto an EXISTING queue item that
+    lacks one (§C reconciliation, 2026-07-17 live Pro-side diagnosis).
+
+    WR2-native carousels are published via the app's own publish gate
+    (`QueueWriter.markPublished`/`mark_published` above), which records the
+    permalink and NEVER a Graph media id — so a native entry (e.g. the
+    `bali-pma-rental-crackdown` case) had no way to get automated metrics even
+    though the same post is trivially fetchable by `wr2_ig_discovery.py`'s own
+    Graph media listing, which carries the real numeric id (Graph's own `id`
+    field) alongside the permalink. `wr2_ig_discovery.py` calls this for every
+    fetched media item whose SHORTCODE already matches a known queue item
+    lacking `ig_media_id` (see `find_media_id_backfills`) — this is the
+    reconciliation half; `ingest_external_post` above is the fresh-mint half.
+
+    Idempotent + conflict-safe, same discipline as `mark_published`:
+      * not_found          — no item matches item_id -> NO write
+      * conflict           — item already has a DIFFERENT ig_media_id -> NO write (needs human)
+      * already_backfilled — same ig_media_id already present -> NO write (no-op)
+      * backfilled         — field written atomically -> WRITE
+    """
+    with queue_lock(path):
+        items = load_queue(path)
+        idx: Optional[int] = None
+        item: Optional[dict[str, Any]] = None
+        for i, it in enumerate(items):
+            if item_id_of(it) == item_id:
+                idx, item = i, it
+                break
+        if item is None:
+            return PublishResult(
+                "not_found", False, compute_ref_code(item_id), item_id,
+                "no queue item matches this item_id",
+            )
+
+        existing = item.get("ig_media_id")
+        if existing:
+            if str(existing) == str(ig_media_id):
+                return PublishResult(
+                    "already_backfilled", True, compute_ref_code(item_id), item_id,
+                    "no-op: ig_media_id already recorded",
+                )
+            return PublishResult(
+                "conflict", False, compute_ref_code(item_id), item_id,
+                f"item already has a DIFFERENT ig_media_id ({existing!r}); refusing to overwrite",
+            )
+
+        updated = dict(item)
+        updated["ig_media_id"] = str(ig_media_id)
+        assert idx is not None
+        items[idx] = updated
+        write_queue_atomic(path, items)
+        return PublishResult(
+            "backfilled", True, compute_ref_code(item_id), item_id,
+            f"backfilled ig_media_id={ig_media_id}",
+        )
 
 
 def add_external(path: Path, payload: dict[str, Any]) -> PublishResult:

--- a/scripts/wr2_queue_writer.py
+++ b/scripts/wr2_queue_writer.py
@@ -211,6 +211,12 @@ def validate_external_payload(payload: dict[str, Any]) -> Optional[str]:
     convention `"manual_external"` — the two call sites mint entries for different
     origins: that one is Zero pasting a bare URL on Pro directly, this one is the app
     replaying a fully-formed entry it already built on M5).
+
+    Type-checks OPTIONAL fields too, when present (Codex red-team, 2026-07-17,
+    finding G): `slide_count` must be an int >= 0, `published_at` must be
+    ISO-parseable. A malformed value here would otherwise ride to Pro verbatim
+    and can break the Swift decode of the WHOLE queue array on the app's next
+    pull — these fields are optional (may be absent), never wrong-shaped.
     """
     for field in REQUIRED_EXTERNAL_PAYLOAD_FIELDS:
         if not payload.get(field):
@@ -221,6 +227,18 @@ def validate_external_payload(payload: dict[str, Any]) -> Optional[str]:
         return f"source must be {EXTERNAL_MANUAL_SOURCE!r}, got {payload.get('source')!r}"
     if not validate_ig_url(str(payload["instagram_post_url"])):
         return f"instagram_post_url is not a valid IG permalink: {payload['instagram_post_url']!r}"
+    if "slide_count" in payload and payload["slide_count"] is not None:
+        sc = payload["slide_count"]
+        if isinstance(sc, bool) or not isinstance(sc, int) or sc < 0:
+            return f"slide_count must be an int >= 0, got {sc!r}"
+    if "published_at" in payload and payload["published_at"] is not None:
+        pa = payload["published_at"]
+        if not isinstance(pa, str):
+            return f"published_at must be an ISO-8601 string, got {pa!r}"
+        try:
+            datetime.fromisoformat(pa.replace("Z", "+00:00"))
+        except ValueError:
+            return f"published_at is not ISO-parseable: {pa!r}"
     return None
 
 
@@ -443,7 +461,9 @@ def ingest_external_post(
         return PublishResult("ingested", True, compute_ref_code(iid), iid, f"registered external post {iid}")
 
 
-def backfill_media_id(path: Path, item_id: str, ig_media_id: str) -> PublishResult:
+def backfill_media_id(
+    path: Path, item_id: str, ig_media_id: str, expected_shortcode: Optional[str] = None,
+) -> PublishResult:
     """Attach the real numeric Graph media id onto an EXISTING queue item that
     lacks one (§C reconciliation, 2026-07-17 live Pro-side diagnosis).
 
@@ -458,9 +478,20 @@ def backfill_media_id(path: Path, item_id: str, ig_media_id: str) -> PublishResu
     lacking `ig_media_id` (see `find_media_id_backfills`) — this is the
     reconciliation half; `ingest_external_post` above is the fresh-mint half.
 
+    `expected_shortcode` (Codex red-team, 2026-07-17, finding F): the shortcode
+    `find_media_id_backfills` actually matched on, at SNAPSHOT time. Without a
+    compare-and-set under THIS call's own lock, a TOCTOU race is possible: if
+    the entry's `instagram_post_url` changes between that snapshot and this
+    write acquiring the lock, the OLD post's media id would get attached to
+    whatever URL now sits at that item_id. Re-derives the entry's CURRENT
+    shortcode under the lock and refuses (conflict) on any mismatch — `None`
+    skips the check (fresh-mint callers that never snapshotted a shortcode).
+
     Idempotent + conflict-safe, same discipline as `mark_published`:
       * not_found          — no item matches item_id -> NO write
-      * conflict           — item already has a DIFFERENT ig_media_id -> NO write (needs human)
+      * conflict           — item already has a DIFFERENT ig_media_id, OR its
+                              current shortcode no longer matches
+                              `expected_shortcode` (race) -> NO write (needs human/retry)
       * already_backfilled — same ig_media_id already present -> NO write (no-op)
       * backfilled         — field written atomically -> WRITE
     """
@@ -477,6 +508,17 @@ def backfill_media_id(path: Path, item_id: str, ig_media_id: str) -> PublishResu
                 "not_found", False, compute_ref_code(item_id), item_id,
                 "no queue item matches this item_id",
             )
+
+        if expected_shortcode:
+            current_url = str(item.get("instagram_post_url") or "")
+            current_shortcode = extract_ig_shortcode(current_url) if current_url else None
+            if current_shortcode != expected_shortcode:
+                return PublishResult(
+                    "conflict", False, compute_ref_code(item_id), item_id,
+                    f"item's current shortcode ({current_shortcode!r}) no longer matches "
+                    f"the snapshot this backfill was matched on ({expected_shortcode!r}); "
+                    "the entry's URL changed under us — refusing to attach a possibly-stale media id",
+                )
 
         existing = item.get("ig_media_id")
         if existing:
@@ -516,8 +558,22 @@ def add_external(path: Path, payload: dict[str, Any]) -> PublishResult:
     M5->Pro push-back loop may retry after a flaky ssh, and a real duplicate post
     submitted twice by the operator must be refused, not double-enqueued.
 
+    URL comparison is SHORTCODE-FIRST (Codex red-team, 2026-07-17, finding D):
+    an existing entry's `instagram_post_url` carrying a different query string or
+    scheme/www variant (e.g. a stray `?utm_...`) than the app's canonicalized URL
+    is still the SAME post — exact-string comparison alone would double-enqueue
+    it. Falls back to exact-string only when either URL doesn't parse a shortcode
+    at all (never silently treats two unparseable strings as equal-by-default).
+
       * invalid_payload  — missing/wrong-shaped field -> NO write
-      * already_present  — same item_id or instagram_post_url already in queue -> NO write (no-op)
+      * already_present  — same post (item_id+URL match, or URL/shortcode match
+                            alone) already in queue -> NO write (no-op)
+      * conflict         — SAME item_id but a DIFFERENT post (URL/shortcode
+                            mismatch, finding E) -> NO write, ok=False. Must never
+                            collapse into already_present: the wrapper's caller
+                            treats ok=True as "safe to mark synced_to_pro", and
+                            marking synced here would silently lose the genuinely
+                            distinct post with no record it was ever dropped.
       * added            — appended + written atomically -> WRITE
     """
     err = validate_external_payload(payload)
@@ -526,16 +582,34 @@ def add_external(path: Path, payload: dict[str, Any]) -> PublishResult:
 
     new_id = str(payload["item_id"])
     new_url = str(payload["instagram_post_url"]).strip()
+    new_shortcode = extract_ig_shortcode(new_url)
 
     with queue_lock(path):
         items = load_queue(path)
         for existing in items:
             eid = item_id_of(existing)
             existing_url = (existing.get("instagram_post_url") or "").strip()
-            if eid == new_id or (existing_url and existing_url == new_url):
+            existing_shortcode = extract_ig_shortcode(existing_url) if existing_url else None
+            if new_shortcode and existing_shortcode:
+                same_post = new_shortcode == existing_shortcode
+            else:
+                same_post = bool(existing_url) and existing_url == new_url
+
+            if eid == new_id:
+                if same_post:
+                    return PublishResult(
+                        "already_present", True, compute_ref_code(new_id), eid,
+                        "no-op: an entry with this item_id and URL already exists",
+                    )
+                return PublishResult(
+                    "conflict", False, compute_ref_code(new_id), eid,
+                    f"item_id {new_id!r} already exists with a DIFFERENT URL "
+                    f"({existing_url!r} vs {new_url!r}); refusing to overwrite",
+                )
+            if same_post:
                 return PublishResult(
                     "already_present", True, compute_ref_code(new_id), eid,
-                    "no-op: an entry with this item_id or instagram_post_url already exists",
+                    "no-op: an entry with this instagram_post_url already exists (different item_id)",
                 )
         items.append(dict(payload))
         write_queue_atomic(path, items)


### PR DESCRIPTION
## What

WR2 Control gains **external-post registration** (Zero's ask 2026-07-17: "inserisci la possibilità di fare upload e inserire url di un post che abbiamo fatto e non obbligatoriamente passato per la app") plus the gallery recency fix and the IG-metrics schema repair:

- **§A Register external post (Swift)**: new gallery sheet — IG URL (validated + canonicalized to `https://www.instagram.com/(p|reel)/<code>/`), title/topic, publish date, optional PNG/JPG images copied to `carousel/external-<date>T<time>-<slug>/slides/NN.png`. Queue entry `item_id: external_<date>T<time>_<slug>`, `state: "published"`, `source: "external_manual"`. Duplicate add refused by shortcode-first compare.
- **§B M5→Pro propagation**: merge script emits `push_back_external` candidates (source-gated, `synced_to_pro`-gated, payload-validated); the wrapper replays each payload over **ssh stdin** (never shell-interpolated — operator free-text can carry apostrophes) to the new `wr2_queue_writer.py add-external` (flock, duplicate/conflict-safe), then marks the local entry `synced_to_pro`.
- **§C Metrics repair**: `media_id_of` now prefers the authoritative `ig_media_id` field; legacy `ig-<digits>` fallback requires ≥15 digits; `wr2_ig_discovery.py` persists the real numeric Graph id at fetch time and **backfills** it (compare-and-set on shortcode under lock) onto known entries — external + native entries become metrics-fetchable. Skips are counted (`skipped_no_media_id`), never silent.
- **§D Gallery recency**: sort key = max(dir mtime, newest slide PNG mtime) — APFS in-place overwrite doesn't bump dir mtime, so re-rendered carousels stayed buried. Published entries keep sorting by `published_at`.
- **§E Dedup**: virtual `ig-*` cards hidden when a real entry references the same post (shortcode compare).

## Adversarial review (generator≠grader, 2 rounds)

Codex 5.6-sol xhigh + session gate; all confirmed in code before fixing:
- R1 (rebase round): `external_manual`-archived-but-published fixture; §C media-id scoping (shortcode ≠ Graph id, separate field, graceful degradation).
- R2 (10 findings, commit `440c7e5288`): fail-open queue read in `addExternalPost` could replace the whole queue with 1 entry (now throws); `markPublished` poisoned `ig_media_id` with the URL shortcode (now never writes it); `synced_to_pro` lost on remote-wins → replay churn + Pro archive decision overridden by re-add (flag carried, candidates exclude remote+archived ids); shortcode-first dedup both sides; same-item_id-different-post now `conflict` (was silent `already_present`); backfill compare-and-set; payload type-checks; per-post dir uniqueness (time in dir name); review-surface filter.

Pre-existing, ledgered separately: M5 shared-lock protocol (app/pull-daemon/scraper), Swift tolerant per-entry decode, `test.sh` plist validator red on main.

## Tests

Python: 196 targeted (merge/scraper/writer/discovery/reconciler) + 59 writer-unit — green. Swift: 172 unit + full `build.sh` app build green (`bash -n` wrapper clean, bash-3.2, no arrays). Red-team fixes each carry guilt+innocence fixtures. Rebased on main post-#2563 with its invariants verified surviving.

## Post-merge

M5: rebuild + relaunch WR2 Control from main; re-sync `~/bin/wr2-queue-pull.sh` (declared HOME pair) + kickstart. Pro: auto-sync organ pulls scripts; verify scraper/discovery next scheduled run. Prove-live: register a real external post end-to-end (M5 card → Pro queue ≤2 ticks → no duplicate on retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
