### PR TITLE
fix(wr2): scraper dual-schema KeyError on old-schema queue entries

### DIFF
--- a/scripts/tests/test_wr2_ig_metrics_scraper.py
+++ b/scripts/tests/test_wr2_ig_metrics_scraper.py
@@ -15,6 +15,7 @@ widened which KEY was searched, not which VALUE was trusted).
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -125,3 +126,125 @@ def test_is_stale_fresh_metrics_not_stale():
 def test_is_stale_old_metrics_are_stale():
     old_iso = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
     assert scraper.is_stale({"scraped_at": old_iso}, 7) is True
+
+
+# ── _display_id — schema-agnostic log label (hotfix, 2026-07-17) ───────────
+#
+# Live Pro prove-live crash: the success/skip/dry-run print lines in main()'s
+# fetch loop did `item.get('topic_slug') or item['id']` — a bare subscript
+# that KeyErrors on an old-schema entry carrying ONLY `item_id` (never `id`).
+# media_id_of already handles this exact dual-schema split correctly (checks
+# BOTH `id` and `item_id`); these print lines never got the same treatment.
+
+
+def test_display_id_old_schema_item_id_only_no_keyerror():
+    # GUILT (the exact live-crash shape): no "id" key, no "topic_slug" key at all.
+    assert scraper._display_id({"item_id": "bali-pma-rental-crackdown"}) == "bali-pma-rental-crackdown"
+
+
+def test_display_id_prefers_topic_slug_when_present():
+    # INNOCENCE: existing precedence (topic_slug first) is unchanged.
+    assert scraper._display_id({"topic_slug": "my-topic", "id": "x", "item_id": "y"}) == "my-topic"
+
+
+def test_display_id_falls_back_to_id_when_no_topic_slug():
+    assert scraper._display_id({"id": "carousel-1"}) == "carousel-1"
+
+
+def test_display_id_none_topic_slug_falls_through_to_item_id():
+    # a present-but-falsy topic_slug (None) must still fall through, not short-circuit.
+    assert scraper._display_id({"topic_slug": None, "item_id": "fallback-id"}) == "fallback-id"
+
+
+def test_display_id_no_identifying_field_at_all_returns_placeholder():
+    assert scraper._display_id({}) == "?"
+
+
+# ── main() end-to-end — dual-schema KeyError regression (hotfix, 2026-07-17) ─
+#
+# Drives main() itself (not just the unit-level _display_id above) so a
+# regression reintroduced at any of the three print call-sites shows up as a
+# real crash on an old-schema item, matching the live Pro failure mode: the
+# scraper died mid-loop with KeyError BEFORE ever reaching the atomic-write
+# step, so discovery's freshly-backfilled ig_media_id never got its metrics
+# attached.
+
+
+def test_main_completes_for_old_schema_item_id_only_entry(tmp_path, monkeypatch, capsys):
+    queue_path = tmp_path / "queue.json"
+    entry = {
+        "item_id": "bali-pma-rental-crackdown",  # OLD SCHEMA: no "id", no "topic_slug"
+        "state": "published",
+        "instagram_post_url": "https://www.instagram.com/p/ABC123/",
+        "ig_media_id": "17895695668004550",  # already backfilled -> media_id_of resolves it
+        "engagement_metrics": None,  # missing -> selected for refresh
+    }
+    queue_path.write_text(json.dumps([entry]))
+
+    monkeypatch.setenv("INSTAGRAM_ACCESS_TOKEN", "test-token")
+    monkeypatch.setattr(sys, "argv", ["wr2_ig_metrics_scraper.py", "--queue", str(queue_path)])
+    monkeypatch.setattr(
+        scraper, "fetch_metrics",
+        lambda media_id, token: {
+            "likes": 10, "reach": 100, "saved": 2, "shares": 1,
+            "source": "ig_metrics_scraper", "scraped_at": "2026-07-17T09:00:00+00:00",
+        },
+    )
+
+    rc = scraper.main()  # must NOT raise KeyError — this is the regression guard
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ok   bali-pma-rental-crackdown" in out  # falls back to item_id, never crashes
+    updated = json.loads(queue_path.read_text())
+    assert updated[0]["engagement_metrics"]["likes"] == 10  # the write it used to never reach
+
+
+def test_main_dry_run_also_completes_for_old_schema_entry(tmp_path, monkeypatch, capsys):
+    # the [dry] print site is the SAME bug class — cover it independently.
+    queue_path = tmp_path / "queue.json"
+    entry = {
+        "item_id": "bali-pma-rental-crackdown",
+        "state": "published",
+        "instagram_post_url": "https://www.instagram.com/p/ABC123/",
+        "ig_media_id": "17895695668004550",
+        "engagement_metrics": None,
+    }
+    queue_path.write_text(json.dumps([entry]))
+
+    monkeypatch.setenv("INSTAGRAM_ACCESS_TOKEN", "test-token")
+    monkeypatch.setattr(sys, "argv", ["wr2_ig_metrics_scraper.py", "--queue", str(queue_path), "--dry-run"])
+    monkeypatch.setattr(
+        scraper, "fetch_metrics",
+        lambda media_id, token: {"likes": 5, "source": "ig_metrics_scraper",
+                                  "scraped_at": "2026-07-17T09:00:00+00:00"},
+    )
+
+    rc = scraper.main()
+
+    assert rc == 0
+    assert "[dry] bali-pma-rental-crackdown" in capsys.readouterr().out
+    # dry-run never writes
+    assert json.loads(queue_path.read_text())[0]["engagement_metrics"] is None
+
+
+def test_main_skip_path_also_completes_for_old_schema_entry(tmp_path, monkeypatch, capsys):
+    # the "skip ... no metrics returned" print site is the SAME bug class too.
+    queue_path = tmp_path / "queue.json"
+    entry = {
+        "item_id": "bali-pma-rental-crackdown",
+        "state": "published",
+        "instagram_post_url": "https://www.instagram.com/p/ABC123/",
+        "ig_media_id": "17895695668004550",
+        "engagement_metrics": None,
+    }
+    queue_path.write_text(json.dumps([entry]))
+
+    monkeypatch.setenv("INSTAGRAM_ACCESS_TOKEN", "test-token")
+    monkeypatch.setattr(sys, "argv", ["wr2_ig_metrics_scraper.py", "--queue", str(queue_path)])
+    monkeypatch.setattr(scraper, "fetch_metrics", lambda media_id, token: None)
+
+    rc = scraper.main()
+
+    assert rc == 0
+    assert "skip bali-pma-rental-crackdown" in capsys.readouterr().out

--- a/scripts/wr2_ig_metrics_scraper.py
+++ b/scripts/wr2_ig_metrics_scraper.py
@@ -164,6 +164,19 @@ def media_id_of(item: dict) -> Optional[str]:
     return None
 
 
+def _display_id(item: dict) -> str:
+    """Schema-agnostic label for a queue item's log lines (Codex red-team hotfix,
+    2026-07-17, live Pro prove-live): the success/skip/dry-run prints in main()'s
+    fetch loop used a bare `item['id']` fallback after `topic_slug` — old-schema
+    entries (§C reconciliation candidates like bali-pma-rental-crackdown) only
+    carry `item_id`, never `id`, so the scraper KeyError'd mid-loop BEFORE the
+    write at the end of the run. `media_id_of` already handles this dual-schema
+    split correctly (checks BOTH `id` and `item_id`); these print lines never got
+    the same treatment. Never raises — `'?'` is the last resort for a genuinely
+    unlabeled item, never a crash."""
+    return item.get("topic_slug") or item.get("id") or item.get("item_id") or "?"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--queue", default=str(DEFAULT_QUEUE))
@@ -209,14 +222,14 @@ def main() -> int:
         mid = media_id_of(item)
         m = fetch_metrics(mid, token)
         if m is None:
-            print(f"  skip {item.get('topic_slug') or item['id']}: no metrics returned")
+            print(f"  skip {_display_id(item)}: no metrics returned")
             continue
         if args.dry_run:
-            print(f"  [dry] {item.get('topic_slug') or item['id']}: {m}")
+            print(f"  [dry] {_display_id(item)}: {m}")
         else:
             item["engagement_metrics"] = m
             updated += 1
-            print(f"  ok   {item.get('topic_slug') or item['id']}: "
+            print(f"  ok   {_display_id(item)}: "
                   f"likes={m.get('likes')} reach={m.get('reach')} "
                   f"saved={m.get('saved')} shares={m.get('shares')}")
         time.sleep(0.3)  # be gentle on the API


### PR DESCRIPTION
## What

One-line class fix found by #2578's live prove on Pro: the metrics scraper's success/skip/dry-run print lines used `item.get('topic_slug') or item['id']` — old-schema queue entries (the §C reconciliation candidates, e.g. `bali-pma-rental-crackdown`) carry only `item_id`, so the run KeyError'd mid-loop before the final snapshot write. `media_id_of` already handled the dual schema; these log lines never got the same treatment.

Fix: schema-agnostic `_display_id()` helper (never raises), swept across all 3 print sites (W89 class-audit — no other bare `item['id']` subscripts remain in the file). Regression fixtures: old-schema entry through the success/skip paths of `main()` without KeyError (21 tests green).

Unblocks: the first complete scraper run over the 49 freshly-backfilled `ig_media_id` entries — metrics finally attach to native + external posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
