### PR TITLE
fix(visa-oracle): PR0 safety freeze — Gate 0 of the v2 program

### DIFF
--- a/apps/backend-rag/backend/app/routers/visa_oracle.py
+++ b/apps/backend-rag/backend/app/routers/visa_oracle.py
@@ -10,7 +10,7 @@ No authentication required (public product).
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
@@ -27,6 +27,17 @@ router = APIRouter(prefix="/visa-oracle", tags=["visa-oracle"])
 # Pydantic models
 # ---------------------------------------------------------------------------
 
+# PR0 safety freeze (2026-07-17, round2 spec §9 row PR0 / §6.2): additive
+# five-state contract for /recommend. `visas` MUST be [] for every state
+# except SUPPORTED_CANDIDATES — see `_determine_recommend_state`.
+RecommendState = Literal[
+    "NEEDS_INPUT",
+    "SUPPORTED_CANDIDATES",
+    "HUMAN_REVIEW_REQUIRED",
+    "NO_SUPPORTED_PATH",
+    "TEMPORARILY_UNAVAILABLE",
+]
+
 
 class RecommendRequest(BaseModel):
     nationality: str
@@ -39,6 +50,10 @@ class RecommendResponse(BaseModel):
     success: bool
     visas: list[dict[str, Any]]
     session_id: str
+    # PR0 safety freeze — additive, back-compat (old fields unchanged above).
+    state: RecommendState
+    missing_facts: list[str] = []
+    review_reasons: list[str] = []
 
 
 class ChatRequest(BaseModel):
@@ -56,6 +71,10 @@ class ChatResponse(BaseModel):
     confidence: str
     sources: list[str]
     session_id: str
+    # PR0 safety freeze — additive, back-compat. Populated when a safety
+    # branch changed the outcome (e.g. an obsolete-code mention on weak
+    # evidence); empty otherwise.
+    review_reasons: list[str] = []
 
 
 class HandoffRequest(BaseModel):
@@ -107,6 +126,17 @@ def _detect_obsolete_code(text: str) -> tuple[str, str] | None:
         if re.search(rf"\b{re.escape(code)}\b", upper):
             return code, hint
     return None
+
+
+def _obsolete_review_reasons(obsolete_hit: tuple[str, str] | None) -> list[str]:
+    """PR0 W2: the review_reasons annotation carried on a (still-safe)
+    ABSTAIN response when the user's message mentioned a retired visa code.
+    Replaces the removed ABSTAIN→CAUTIOUS promotion — the code is still
+    named, but no candidate/answer is ever generated on the strength of it."""
+    if obsolete_hit is None:
+        return []
+    code, _hint = obsolete_hit
+    return [f"obsolete_code_mentioned:{code}"]
 
 
 # Telegram chat ID for Damar / team lead notifications
@@ -264,6 +294,55 @@ TIMEOUT_FALLBACK_BY_LANG: dict[str, str] = {
 def _parse_family(family_str: str) -> bool:
     """Parse family field: 'spouse', 'children', 'spouse_children' → True; 'solo' → False."""
     return family_str.lower() in {"spouse", "children", "spouse_children", "yes", "true", "1"}
+
+
+_REQUIRED_RECOMMEND_FIELDS = ("nationality", "purpose", "duration")
+
+
+def _missing_recommend_facts(nationality: str, purpose: str, duration: str) -> list[str]:
+    """Return the subset of required /recommend facts that are blank.
+
+    Pydantic already enforces the fields are present strings; this catches
+    "" / whitespace-only submissions that would otherwise fall through to
+    the scorer's permissive category defaults and silently produce a
+    low-signal (but non-empty) candidate list.
+    """
+    values = {"nationality": nationality, "purpose": purpose, "duration": duration}
+    return [name for name in _REQUIRED_RECOMMEND_FIELDS if not values[name].strip()]
+
+
+def _determine_recommend_state(
+    visas: list[dict[str, Any]],
+    missing_facts: list[str],
+) -> tuple[RecommendState, list[str]]:
+    """Map VisaOracleService's raw scored output to a safe five-state outcome.
+
+    PR0 safety freeze — a conservative read of the EXISTING scorer's signal,
+    no new matching logic:
+      - required facts missing               -> NEEDS_INPUT
+      - scorer returned zero rows             -> TEMPORARILY_UNAVAILABLE
+                                                  (the relevant catalog
+                                                  categories produced nothing
+                                                  — a data/service gap, not a
+                                                  user-input problem)
+      - every candidate scored 0 (no real
+        keyword/duration/family signal)       -> NEEDS_INPUT
+      - otherwise                             -> SUPPORTED_CANDIDATES
+
+    Returns (state, review_reasons). Callers MUST clear `visas` to [] unless
+    state == "SUPPORTED_CANDIDATES" — this function does not mutate `visas`.
+    """
+    if missing_facts:
+        return "NEEDS_INPUT", []
+
+    if not visas:
+        return "TEMPORARILY_UNAVAILABLE", ["catalog_no_candidates"]
+
+    best_score = max((visa.get("score") or 0) for visa in visas)
+    if best_score <= 0:
+        return "NEEDS_INPUT", ["low_confidence_match"]
+
+    return "SUPPORTED_CANDIDATES", []
 
 
 def _detect_language(text: str) -> str:
@@ -462,6 +541,51 @@ async def _persist_session_handoff(db_pool: Any, session_id: str) -> None:
         logger.warning("visa-oracle session persist (handoff) failed: %s", exc)
 
 
+async def _fetch_session_snapshot(db_pool: Any, session_id: str) -> dict[str, Any] | None:
+    """Return the server-persisted {quiz_answers, recommended_visas} for a
+    session — PR0 W3: the ONLY trusted source for handoff pricing and
+    recommendation. Both columns were written entirely server-side by
+    `/recommend` (`recommended_visas` is PricingService-derived via
+    `VisaOracleService.recommend_visas`), so this is the "server-side
+    PricingTool path from the persisted session's own data".
+
+    Returns None if the session was never persisted, or on any read failure
+    — the caller must then proceed WITHOUT a price rather than fall back to
+    the client-posted handoff body.
+    """
+    try:
+        async with db_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT quiz_answers, recommended_visas
+                FROM visa_oracle_sessions
+                WHERE session_id = $1
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                session_id,
+            )
+    except Exception as exc:
+        logger.warning("visa-oracle handoff: session snapshot fetch failed: %s", exc)
+        return None
+
+    if row is None:
+        return None
+
+    def _decode(value: Any) -> Any:
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except (TypeError, ValueError):
+                return None
+        return value
+
+    return {
+        "quiz_answers": _decode(row["quiz_answers"]) or {},
+        "recommended_visas": _decode(row["recommended_visas"]) or [],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -476,23 +600,44 @@ async def recommend(
     """
     Score and rank visa types for the given quiz answers.
     No LLM — pure scoring logic from VisaOracleService.
+
+    PR0 safety freeze (2026-07-17): the response also carries `state` /
+    `missing_facts` / `review_reasons`. `visas` is [] for every state except
+    SUPPORTED_CANDIDATES — callers must not treat a non-empty legacy `visas`
+    list as implying a confident match without also checking `state`.
     """
     try:
         service = get_visa_oracle_service()
         family_bool = _parse_family(body.family)
-        visas = service.recommend_visas(
-            nationality=body.nationality,
-            purpose=body.purpose,
-            duration=body.duration,
-            family=family_bool,
-        )
+        missing_facts = _missing_recommend_facts(body.nationality, body.purpose, body.duration)
+
+        try:
+            visas = service.recommend_visas(
+                nationality=body.nationality,
+                purpose=body.purpose,
+                duration=body.duration,
+                family=family_bool,
+            )
+            state, review_reasons = _determine_recommend_state(visas, missing_facts)
+        except Exception as scoring_exc:
+            # Catalog/scoring failure is a degraded-but-recoverable outcome,
+            # not a fatal request error — the frontend must be able to
+            # render it (W4). Genuinely unexpected failures below (service
+            # init, session_id generation) still hit the outer 500 handler.
+            logger.error("visa-oracle /recommend scoring error: %s", scoring_exc, exc_info=True)
+            visas, state, review_reasons = [], "TEMPORARILY_UNAVAILABLE", ["scoring_error"]
+
+        if state != "SUPPORTED_CANDIDATES":
+            visas = []
+
         session_id = service.generate_session_id()
 
         logger.info(
-            "visa-oracle /recommend: purpose=%s duration=%s family=%s → %d visas",
+            "visa-oracle /recommend: purpose=%s duration=%s family=%s state=%s → %d visas",
             body.purpose,
             body.duration,
             family_bool,
+            state,
             len(visas),
         )
         # Persist session non-blocking
@@ -507,7 +652,14 @@ async def recommend(
             )
         )
 
-        return RecommendResponse(success=True, visas=visas, session_id=session_id)
+        return RecommendResponse(
+            success=True,
+            visas=visas,
+            session_id=session_id,
+            state=state,
+            missing_facts=missing_facts,
+            review_reasons=review_reasons,
+        )
 
     except Exception as exc:
         logger.error("visa-oracle /recommend error: %s", exc, exc_info=True)
@@ -680,6 +832,7 @@ async def chat(
                 confidence=CONFIDENCE_ABSTAIN,
                 sources=[],
                 session_id=body.session_id,
+                review_reasons=_obsolete_review_reasons(obsolete_hit),
             )
 
         # --- Use vector similarity scores directly (cross-encoder not available on Fly) ---
@@ -696,20 +849,14 @@ async def chat(
         else:
             confidence = CONFIDENCE_NORMAL
 
-        # If the user mentioned an obsolete code, DON'T ABSTAIN even with weak
-        # scores. We have enough pretraining context + SYSTEM_PROMPT rules to
-        # correctly flag the code as obsolete and redirect. Promote to CAUTIOUS
-        # so the hedging prefix is emitted too.
-        if obsolete_hit and confidence == CONFIDENCE_ABSTAIN:
-            confidence = CONFIDENCE_CAUTIOUS
-            logger.info(
-                "visa-oracle /chat: promoted ABSTAIN→CAUTIOUS due to obsolete "
-                "code %s (top_score=%.3f) session=%s",
-                obsolete_hit[0],
-                top_score,
-                body.session_id[:12],
-            )
-
+        # PR0 safety freeze (2026-07-17): a prior branch here promoted
+        # ABSTAIN→CAUTIOUS whenever the user mentioned an obsolete visa code,
+        # "on the strength of pretraining context + SYSTEM_PROMPT rules"
+        # alone — i.e. it let the LLM generate a free-form answer (including
+        # possible visa recommendations) with NO grounded KB evidence.
+        # Removed (round2 spec §6.6 step 2 / product-design.md §2 claim #2).
+        # Weak evidence now ALWAYS abstains, obsolete code or not — the code
+        # is still named, but only as a review_reasons annotation below.
         if confidence == CONFIDENCE_ABSTAIN:
             logger.info(
                 "visa-oracle /chat: ABSTAIN (top_score=%.3f) session=%s",
@@ -722,6 +869,7 @@ async def chat(
                 confidence=CONFIDENCE_ABSTAIN,
                 sources=[],
                 session_id=body.session_id,
+                review_reasons=_obsolete_review_reasons(obsolete_hit),
             )
 
         # --- Build context for LLM ---
@@ -817,20 +965,52 @@ async def handoff(
 ) -> HandoffResponse:
     """
     Build WhatsApp deep-link URL and send Telegram lead notification.
+
+    PR0 safety freeze (2026-07-17, W3): the recommended visa name and price
+    used in the WhatsApp message / Telegram summary come ONLY from the
+    session this backend itself persisted at /recommend time (already
+    PricingService-derived — see `VisaOracleService.recommend_visas`).
+    `HandoffRequest.recommended_visas` (client-posted) is still accepted on
+    the wire for back-compat but is never used for price/recommendation; a
+    divergence is logged (no PII — visa names/prices/session_id are not
+    personal data). If no server-side session snapshot is found, the
+    handoff proceeds WITHOUT a price rather than trusting the client.
     """
     from backend.services.integrations.telegram_bot_service import telegram_bot
 
     try:
         service = get_visa_oracle_service()
 
-        # Build WhatsApp URL
+        snapshot = await _fetch_session_snapshot(db_pool, body.session_id)
+        server_visas = snapshot["recommended_visas"] if snapshot else []
+        server_top = server_visas[0] if server_visas else {}
+        client_top = body.recommended_visas[0] if body.recommended_visas else {}
+
+        if client_top and (
+            client_top.get("visa_name") != server_top.get("visa_name")
+            or str(client_top.get("price")) != str(server_top.get("price"))
+        ):
+            logger.warning(
+                "visa-oracle /handoff: client-supplied recommendation diverges "
+                "from server-persisted session=%s — client={visa=%s price=%s} "
+                "server={visa=%s price=%s}",
+                body.session_id[:12],
+                client_top.get("visa_name"),
+                client_top.get("price"),
+                server_top.get("visa_name"),
+                server_top.get("price"),
+            )
+
+        # Build WhatsApp URL — quiz facts stay client-supplied (informational
+        # text only, not a price/candidate; same-session self-report as what
+        # produced the recommendation). Only visa_name/price are
+        # server-authoritative.
         nationality = body.quiz_answers.get("nationality", "Unknown")
         purpose = body.quiz_answers.get("purpose", "Unknown")
         duration = body.quiz_answers.get("duration", "Unknown")
 
-        top_visa = body.recommended_visas[0] if body.recommended_visas else {}
-        visa_name = top_visa.get("visa_name", "Indonesian Visa")
-        price = top_visa.get("price", "contact for pricing")
+        visa_name = server_top.get("visa_name", "Indonesian Visa")
+        price = server_top.get("price") or "contact for pricing"
 
         whatsapp_url = service.build_whatsapp_message(
             nationality=nationality,
@@ -845,7 +1025,7 @@ async def handoff(
         qa = body.quiz_answers or {}
         has_real_data = any(
             qa.get(k) and qa.get(k) != "Unknown" for k in ("nationality", "purpose", "duration")
-        ) or bool(body.recommended_visas)
+        ) or bool(server_visas)
         try:
             if not has_real_data:
                 logger.info(
@@ -857,7 +1037,7 @@ async def handoff(
                 summary = service.build_telegram_summary(
                     session_id=body.session_id,
                     quiz_answers=body.quiz_answers,
-                    recommended_visas=body.recommended_visas,
+                    recommended_visas=server_visas,
                     messages=body.messages,
                     language=language,
                 )

--- a/apps/backend-rag/backend/app/routers/visa_oracle.py
+++ b/apps/backend-rag/backend/app/routers/visa_oracle.py
@@ -17,7 +17,11 @@ from pydantic import BaseModel
 
 from backend.app.dependencies import get_database_pool
 from backend.services.common.background import spawn
-from backend.services.visa_oracle.visa_oracle_service import get_visa_oracle_service
+from backend.services.visa_oracle.visa_oracle_service import (
+    DURATION_THRESHOLDS,
+    PURPOSE_CATEGORY_MAP,
+    get_visa_oracle_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +118,11 @@ OBSOLETE_VISA_CODES: dict[str, tuple[str, str]] = {
     "B211": ("C1", "C1 Visa Wisata tourism C2 business visit"),
 }
 
+# Regulatory basis already established elsewhere in this file (SYSTEM_PROMPT
+# REGULATORY ACCURACY section above) — reused verbatim in
+# `_obsolete_code_static_answer` rather than inventing a new citation.
+OBSOLETE_CODE_REGULATORY_BASIS = "PERMENKUMHAM 22/2023"
+
 
 def _detect_obsolete_code(text: str) -> tuple[str, str] | None:
     """Return (obsolete_code, expansion_hint) if the message mentions a
@@ -137,6 +146,38 @@ def _obsolete_review_reasons(obsolete_hit: tuple[str, str] | None) -> list[str]:
         return []
     code, _hint = obsolete_hit
     return [f"obsolete_code_mentioned:{code}"]
+
+
+def _obsolete_code_static_answer(obsolete_hit: tuple[str, str] | None) -> str | None:
+    """PR0 hardening (Codex red-team P2 #6): a DETERMINISTIC, zero-LLM
+    explanation for the ABSTAIN + obsolete-code-mentioned path. Restores the
+    informational value the removed ABSTAIN->CAUTIOUS promotion used to
+    provide (via ungrounded LLM generation) WITHOUT ever calling the LLM.
+
+    Built entirely from data already present in `OBSOLETE_VISA_CODES` (the
+    replacement code + hint, both already curated in this file) plus the
+    `OBSOLETE_CODE_REGULATORY_BASIS` citation already used elsewhere in this
+    router's SYSTEM_PROMPT — no new regulatory claim is introduced. English
+    only for now (a deliberate scope decision, not an oversight — accurately
+    localizing regulatory phrasing into 7 languages is real translation
+    work, out of scope for a safety-freeze hardening pass; see PR report).
+
+    Returns None when no obsolete code was mentioned — callers fall back to
+    the existing generic ABSTAIN fallback (innocence path, unchanged).
+    """
+    if obsolete_hit is None:
+        return None
+    code, _hint = obsolete_hit
+    replacement, _ = OBSOLETE_VISA_CODES.get(code, (None, None))
+    if replacement is None:
+        return None
+    return (
+        f"The visa code {code} was retired as part of the "
+        f"{OBSOLETE_CODE_REGULATORY_BASIS} visa reform and is no longer issued. "
+        f"Based on the most common intent, {replacement} is the closest current "
+        "equivalent — a Bali Zero consultant can confirm the exact match for your "
+        "specific case on WhatsApp (+62 821-3107-363)."
+    )
 
 
 # Telegram chat ID for Damar / team lead notifications
@@ -298,6 +339,27 @@ def _parse_family(family_str: str) -> bool:
 
 _REQUIRED_RECOMMEND_FIELDS = ("nationality", "purpose", "duration")
 
+# PR0 hardening — how much of a raw user-supplied value we echo back into a
+# review_reasons entry (e.g. `invalid_purpose:<value>`). Keeps log/response
+# payloads bounded regardless of what the client posts.
+_MAX_ECHOED_VALUE_LEN = 40
+
+# FIX-2 (Codex red-team P1 #1, nationality overclaim): the legacy scorer
+# (`VisaOracleService.recommend_visas`) never looks at `nationality` at all
+# — it is collected but has zero influence on ranking. A SUPPORTED_CANDIDATES
+# response could otherwise read as "we checked your nationality too". This
+# constant is appended to review_reasons on EVERY SUPPORTED_CANDIDATES
+# response as a declared, truthful limitation — not a bug marker. The v2
+# engine (later PRs) is what actually cures nationality-aware matching.
+NATIONALITY_NOT_EVALUATED_REASON = "nationality_not_evaluated"
+
+
+def _sanitize_echoed_value(value: str) -> str:
+    """Collapse whitespace/newlines and truncate before echoing a raw
+    user-supplied value into a review_reasons entry or log line."""
+    collapsed = " ".join(value.split())
+    return collapsed[:_MAX_ECHOED_VALUE_LEN]
+
 
 def _missing_recommend_facts(nationality: str, purpose: str, duration: str) -> list[str]:
     """Return the subset of required /recommend facts that are blank.
@@ -311,29 +373,82 @@ def _missing_recommend_facts(nationality: str, purpose: str, duration: str) -> l
     return [name for name in _REQUIRED_RECOMMEND_FIELDS if not values[name].strip()]
 
 
+def _invalid_recommend_vocabulary(purpose: str, duration: str) -> list[str]:
+    """FIX-1 (Codex red-team P1 #1, "banana -> SUPPORTED_CANDIDATES"):
+    `VisaOracleService._score_visa` awards a +1.5 duration-fit bonus and a
+    +1.0 family bonus INDEPENDENTLY of whether `purpose` is a recognized
+    value — when `purpose` isn't a `PURPOSE_KEYWORDS` key it silently
+    resolves to an empty keyword list instead of rejecting the request. A
+    nonsense purpose (e.g. "banana") can still score >0 purely from the
+    duration/family bonus and reach SUPPORTED_CANDIDATES. Live-verified
+    against the REAL service: `nationality=US purpose=banana duration=long
+    family=false` scores KITAS rows at 1.5; `duration=nonsense family=true`
+    scores at 1.0 from the family bonus alone.
+
+    This closes the gap with a vocabulary gate on the EXISTING dicts
+    (`PURPOSE_CATEGORY_MAP`, `DURATION_THRESHOLDS`) — no new matching logic,
+    just refusing to score an unrecognized purpose/duration at all.
+    """
+    reasons: list[str] = []
+    if purpose.strip().lower() not in PURPOSE_CATEGORY_MAP:
+        reasons.append(f"invalid_purpose:{_sanitize_echoed_value(purpose)}")
+    if duration.strip().lower() not in DURATION_THRESHOLDS:
+        reasons.append(f"invalid_duration:{_sanitize_echoed_value(duration)}")
+    return reasons
+
+
+def _filter_complete_visas(visas: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """FIX-3 (Codex red-team P1 #2, garbage candidates): drop any scored
+    row lacking a non-empty string `visa_name` before it ever reaches state
+    determination or the response body — an upstream pricing-JSON gap
+    should never surface as a nameless "candidate" client-side."""
+    complete: list[dict[str, Any]] = []
+    for visa in visas:
+        name = visa.get("visa_name")
+        if isinstance(name, str) and name.strip():
+            complete.append(visa)
+    return complete
+
+
 def _determine_recommend_state(
     visas: list[dict[str, Any]],
     missing_facts: list[str],
+    invalid_vocabulary_reasons: list[str] = (),  # type: ignore[assignment]
+    catalog_degraded: bool = False,
 ) -> tuple[RecommendState, list[str]]:
     """Map VisaOracleService's raw scored output to a safe five-state outcome.
 
-    PR0 safety freeze — a conservative read of the EXISTING scorer's signal,
-    no new matching logic:
-      - required facts missing               -> NEEDS_INPUT
-      - scorer returned zero rows             -> TEMPORARILY_UNAVAILABLE
-                                                  (the relevant catalog
-                                                  categories produced nothing
-                                                  — a data/service gap, not a
-                                                  user-input problem)
+    PR0 safety freeze + hardening — a conservative read of the EXISTING
+    scorer's signal, no new matching logic. `visas` is expected to already
+    be completeness-filtered (`_filter_complete_visas`) by the caller;
+    `catalog_degraded` signals that the RAW (pre-filter) list was non-empty
+    but every row was dropped as incomplete.
+
+    Precedence:
+      - required facts missing (blank)        -> NEEDS_INPUT
+      - purpose/duration not in the scorer's
+        known vocabulary (FIX-1)               -> NEEDS_INPUT, invalid_* reasons
+      - raw candidates existed but ALL were
+        incomplete (FIX-3)                     -> TEMPORARILY_UNAVAILABLE, catalog_degraded
+      - scorer returned zero rows              -> TEMPORARILY_UNAVAILABLE, catalog_no_candidates
       - every candidate scored 0 (no real
-        keyword/duration/family signal)       -> NEEDS_INPUT
-      - otherwise                             -> SUPPORTED_CANDIDATES
+        keyword/duration/family signal)        -> NEEDS_INPUT, low_confidence_match
+      - otherwise                              -> SUPPORTED_CANDIDATES,
+                                                   nationality_not_evaluated (FIX-2,
+                                                   a declared limitation — the legacy
+                                                   scorer never evaluates nationality)
 
     Returns (state, review_reasons). Callers MUST clear `visas` to [] unless
     state == "SUPPORTED_CANDIDATES" — this function does not mutate `visas`.
     """
     if missing_facts:
         return "NEEDS_INPUT", []
+
+    if invalid_vocabulary_reasons:
+        return "NEEDS_INPUT", list(invalid_vocabulary_reasons)
+
+    if catalog_degraded:
+        return "TEMPORARILY_UNAVAILABLE", ["catalog_degraded"]
 
     if not visas:
         return "TEMPORARILY_UNAVAILABLE", ["catalog_no_candidates"]
@@ -342,7 +457,17 @@ def _determine_recommend_state(
     if best_score <= 0:
         return "NEEDS_INPUT", ["low_confidence_match"]
 
-    return "SUPPORTED_CANDIDATES", []
+    return "SUPPORTED_CANDIDATES", [NATIONALITY_NOT_EVALUATED_REASON]
+
+
+def _has_usable_content(result: dict[str, Any]) -> bool:
+    """FIX-4 (Codex red-team P1 #3, empty-content generation): a hybrid
+    search hit can carry a real similarity `score` while its `content`/
+    `text` field is empty or whitespace-only (e.g. a chunking gap). Scoring
+    such a hit as evidence would let a HIGH top_score push confidence past
+    the ABSTAIN gate with literally nothing for the LLM to ground on."""
+    content = result.get("content") or result.get("text") or ""
+    return bool(str(content).strip())
 
 
 def _detect_language(text: str) -> str:
@@ -525,18 +650,47 @@ async def _persist_session_append_message(
         logger.warning("visa-oracle session persist (message) failed: %s", exc)
 
 
+def _update_row_count(status: str | None) -> int:
+    """Parse asyncpg's `UPDATE N` command-status string. Returns 0 on any
+    unparseable/missing status — a safe default that just triggers the
+    retry path rather than silently assuming success."""
+    try:
+        return int(str(status).split()[-1])
+    except (AttributeError, ValueError, IndexError):
+        return 0
+
+
+_HANDOFF_TRIGGERED_UPDATE_SQL = """
+    UPDATE visa_oracle_sessions
+    SET handoff_triggered = TRUE
+    WHERE session_id = $1
+    """
+
+
 async def _persist_session_handoff(db_pool: Any, session_id: str) -> None:
-    """Mark handoff_triggered = TRUE. Non-fatal."""
+    """Mark handoff_triggered = TRUE. Non-fatal — failures are logged, not
+    raised.
+
+    FIX-6 (Codex red-team P1 #5, async-persist race): /recommend persists
+    the session via a non-blocking `spawn()`'d INSERT — a fast-clicking
+    user (or a client that skips /recommend and calls /handoff directly)
+    can reach this UPDATE before that INSERT lands, matching 0 rows. Retry
+    ONCE after 1s, then log-and-continue either way — this UPDATE has
+    always been best-effort telemetry, never a gate on the handoff response.
+    """
     try:
         async with db_pool.acquire() as conn:
-            await conn.execute(
-                """
-                UPDATE visa_oracle_sessions
-                SET handoff_triggered = TRUE
-                WHERE session_id = $1
-                """,
-                session_id,
-            )
+            status = await conn.execute(_HANDOFF_TRIGGERED_UPDATE_SQL, session_id)
+        if _update_row_count(status) == 0:
+            await asyncio.sleep(1.0)
+            async with db_pool.acquire() as conn:
+                status = await conn.execute(_HANDOFF_TRIGGERED_UPDATE_SQL, session_id)
+            if _update_row_count(status) == 0:
+                logger.info(
+                    "visa-oracle session persist (handoff): no row for session=%s "
+                    "after 1s retry — logging and continuing",
+                    session_id[:12],
+                )
     except Exception as exc:
         logger.warning("visa-oracle session persist (handoff) failed: %s", exc)
 
@@ -586,6 +740,30 @@ async def _fetch_session_snapshot(db_pool: Any, session_id: str) -> dict[str, An
     }
 
 
+async def _fetch_session_snapshot_with_retry(
+    db_pool: Any,
+    session_id: str,
+    *,
+    max_attempts: int = 3,
+    backoff_seconds: float = 0.4,
+) -> dict[str, Any] | None:
+    """FIX-6 (Codex red-team P1 #5, async-persist race): `/recommend`
+    persists the session via a non-blocking `spawn()`'d INSERT. If
+    `/handoff` arrives before that INSERT lands (fast client, or a slow DB
+    connection acquire), a single `_fetch_session_snapshot` read would
+    spuriously miss a session that DOES exist a few hundred ms later —
+    silently downgrading a real session to the "no server session" fallback.
+    Retry with a short backoff before giving up; still None after
+    `max_attempts` falls through to the existing safe no-price path."""
+    for attempt in range(max_attempts):
+        snapshot = await _fetch_session_snapshot(db_pool, session_id)
+        if snapshot is not None:
+            return snapshot
+        if attempt < max_attempts - 1:
+            await asyncio.sleep(backoff_seconds)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -601,31 +779,46 @@ async def recommend(
     Score and rank visa types for the given quiz answers.
     No LLM — pure scoring logic from VisaOracleService.
 
-    PR0 safety freeze (2026-07-17): the response also carries `state` /
-    `missing_facts` / `review_reasons`. `visas` is [] for every state except
-    SUPPORTED_CANDIDATES — callers must not treat a non-empty legacy `visas`
-    list as implying a confident match without also checking `state`.
+    PR0 safety freeze (2026-07-17) + hardening (Codex red-team round): the
+    response also carries `state` / `missing_facts` / `review_reasons`.
+    `visas` is [] for every state except SUPPORTED_CANDIDATES — callers must
+    not treat a non-empty legacy `visas` list as implying a confident match
+    without also checking `state`. `success=False` (still HTTP 200) is
+    reserved for the scoring-exception path ONLY — a genuine service
+    outage — so a legacy client checking only `success` sees failure on an
+    outage exactly as it did pre-PR0 via the old 500.
     """
     try:
         service = get_visa_oracle_service()
         family_bool = _parse_family(body.family)
         missing_facts = _missing_recommend_facts(body.nationality, body.purpose, body.duration)
+        invalid_vocabulary_reasons = _invalid_recommend_vocabulary(body.purpose, body.duration)
 
+        success = True
         try:
-            visas = service.recommend_visas(
+            raw_visas = service.recommend_visas(
                 nationality=body.nationality,
                 purpose=body.purpose,
                 duration=body.duration,
                 family=family_bool,
             )
-            state, review_reasons = _determine_recommend_state(visas, missing_facts)
+            visas = _filter_complete_visas(raw_visas)
+            catalog_degraded = bool(raw_visas) and not visas
+            state, review_reasons = _determine_recommend_state(
+                visas, missing_facts, invalid_vocabulary_reasons, catalog_degraded
+            )
         except Exception as scoring_exc:
-            # Catalog/scoring failure is a degraded-but-recoverable outcome,
-            # not a fatal request error — the frontend must be able to
-            # render it (W4). Genuinely unexpected failures below (service
-            # init, session_id generation) still hit the outer 500 handler.
+            # A genuine scoring/catalog outage — the frontend must still be
+            # able to render this (W4), but `success=False` preserves the
+            # pre-PR0 "this call failed" signal for legacy callers that only
+            # check `success`. Different from catalog_no_candidates/
+            # catalog_degraded, which are a scorer that ran fine and simply
+            # found nothing — those stay success=True. Genuinely unexpected
+            # failures below (service init, session_id generation) still
+            # hit the outer 500 handler.
             logger.error("visa-oracle /recommend scoring error: %s", scoring_exc, exc_info=True)
             visas, state, review_reasons = [], "TEMPORARILY_UNAVAILABLE", ["scoring_error"]
+            success = False
 
         if state != "SUPPORTED_CANDIDATES":
             visas = []
@@ -653,7 +846,7 @@ async def recommend(
         )
 
         return RecommendResponse(
-            success=True,
+            success=success,
             visas=visas,
             session_id=session_id,
             state=state,
@@ -823,12 +1016,20 @@ async def chat(
             alpha=0.5,
         )
         search_results: list[dict[str, Any]] = raw.get("results", [])
+        # FIX-4 (Codex red-team P1 #3, empty-content generation): a hit can
+        # carry a real similarity score with empty/whitespace `content` —
+        # drop those BEFORE computing top_score so an empty-but-high-scoring
+        # hit can never push confidence past the ABSTAIN gate with nothing
+        # for the LLM to ground on.
+        search_results = [r for r in search_results if _has_usable_content(r)]
 
         if not search_results:
             logger.info("visa-oracle /chat: no results for session=%s", body.session_id[:12])
+            obsolete_answer = _obsolete_code_static_answer(obsolete_hit)
             return ChatResponse(
                 success=True,
-                answer=ABSTAIN_FALLBACK_BY_LANG.get(response_lang, ABSTAIN_FALLBACK_BY_LANG["en"]),
+                answer=obsolete_answer
+                or ABSTAIN_FALLBACK_BY_LANG.get(response_lang, ABSTAIN_FALLBACK_BY_LANG["en"]),
                 confidence=CONFIDENCE_ABSTAIN,
                 sources=[],
                 session_id=body.session_id,
@@ -863,9 +1064,16 @@ async def chat(
                 top_score,
                 body.session_id[:12],
             )
+            # FIX-7 (Codex red-team P2 #6): restore a DETERMINISTIC,
+            # zero-LLM explanation on the obsolete-code path — built only
+            # from the existing OBSOLETE_VISA_CODES data (no generation, no
+            # new legal claim). Innocence: no obsolete code -> generic
+            # ABSTAIN fallback, unchanged.
+            obsolete_answer = _obsolete_code_static_answer(obsolete_hit)
             return ChatResponse(
                 success=True,
-                answer=ABSTAIN_FALLBACK_BY_LANG.get(response_lang, ABSTAIN_FALLBACK_BY_LANG["en"]),
+                answer=obsolete_answer
+                or ABSTAIN_FALLBACK_BY_LANG.get(response_lang, ABSTAIN_FALLBACK_BY_LANG["en"]),
                 confidence=CONFIDENCE_ABSTAIN,
                 sources=[],
                 session_id=body.session_id,
@@ -966,25 +1174,43 @@ async def handoff(
     """
     Build WhatsApp deep-link URL and send Telegram lead notification.
 
-    PR0 safety freeze (2026-07-17, W3): the recommended visa name and price
-    used in the WhatsApp message / Telegram summary come ONLY from the
-    session this backend itself persisted at /recommend time (already
-    PricingService-derived — see `VisaOracleService.recommend_visas`).
-    `HandoffRequest.recommended_visas` (client-posted) is still accepted on
-    the wire for back-compat but is never used for price/recommendation; a
-    divergence is logged (no PII — visa names/prices/session_id are not
-    personal data). If no server-side session snapshot is found, the
-    handoff proceeds WITHOUT a price rather than trusting the client.
+    PR0 safety freeze (2026-07-17, W3) + hardening (Codex red-team round):
+    the recommended visa name and price used in the WhatsApp message /
+    Telegram summary come ONLY from the session this backend itself
+    persisted at /recommend time (already PricingService-derived — see
+    `VisaOracleService.recommend_visas`). `HandoffRequest.recommended_visas`
+    (client-posted) is still accepted on the wire for back-compat but is
+    never used for price/recommendation; a divergence is logged (no PII —
+    visa names/prices/session_id are not personal data).
+
+    FIX-5 (Codex red-team P1 #4): quiz facts (nationality/purpose/duration)
+    also prefer the server-persisted snapshot over the client-posted body —
+    same-session data captured by /recommend itself, before any chance for
+    a later handoff POST to alter it — falling back to the client body only
+    when no snapshot (or an empty one) exists. A body-only handoff (no
+    server session backing it at all) still fires the Telegram lead —
+    leads matter commercially — but is tagged `[UNVERIFIED — no server
+    session]` rather than presented as if server-verified.
     """
     from backend.services.integrations.telegram_bot_service import telegram_bot
 
     try:
         service = get_visa_oracle_service()
 
-        snapshot = await _fetch_session_snapshot(db_pool, body.session_id)
+        # FIX-6: retry-wrapped — /recommend's INSERT is non-blocking and can
+        # still be in flight when a fast client calls /handoff.
+        snapshot = await _fetch_session_snapshot_with_retry(db_pool, body.session_id)
         server_visas = snapshot["recommended_visas"] if snapshot else []
+        server_quiz = snapshot["quiz_answers"] if snapshot else {}
         server_top = server_visas[0] if server_visas else {}
         client_top = body.recommended_visas[0] if body.recommended_visas else {}
+
+        # A session is "verified" when we found a server snapshot that
+        # actually carries something (either scored visas or a persisted
+        # quiz) — an empty snapshot (session row exists but both columns
+        # are default-empty) is not meaningfully different from no session.
+        session_verified = bool(snapshot) and (bool(server_visas) or bool(server_quiz))
+        quiz_answers = server_quiz if server_quiz else body.quiz_answers
 
         if client_top and (
             client_top.get("visa_name") != server_top.get("visa_name")
@@ -1001,13 +1227,11 @@ async def handoff(
                 server_top.get("price"),
             )
 
-        # Build WhatsApp URL — quiz facts stay client-supplied (informational
-        # text only, not a price/candidate; same-session self-report as what
-        # produced the recommendation). Only visa_name/price are
-        # server-authoritative.
-        nationality = body.quiz_answers.get("nationality", "Unknown")
-        purpose = body.quiz_answers.get("purpose", "Unknown")
-        duration = body.quiz_answers.get("duration", "Unknown")
+        # Build WhatsApp URL — quiz_answers is server-snapshot-preferred
+        # (FIX-5). Only visa_name/price are server-authoritative for price.
+        nationality = quiz_answers.get("nationality", "Unknown")
+        purpose = quiz_answers.get("purpose", "Unknown")
+        duration = quiz_answers.get("duration", "Unknown")
 
         visa_name = server_top.get("visa_name", "Indonesian Visa")
         price = server_top.get("price") or "contact for pricing"
@@ -1022,7 +1246,7 @@ async def handoff(
 
         # Send Telegram notification — skip empty/unknown leads
         telegram_sent = False
-        qa = body.quiz_answers or {}
+        qa = quiz_answers or {}
         has_real_data = any(
             qa.get(k) and qa.get(k) != "Unknown" for k in ("nationality", "purpose", "duration")
         ) or bool(server_visas)
@@ -1036,11 +1260,16 @@ async def handoff(
                 language = body.language or "en"
                 summary = service.build_telegram_summary(
                     session_id=body.session_id,
-                    quiz_answers=body.quiz_answers,
+                    quiz_answers=quiz_answers,
                     recommended_visas=server_visas,
                     messages=body.messages,
                     language=language,
                 )
+                if not session_verified:
+                    # FIX-5: never present a body-only lead as if
+                    # server-verified — the escaped brackets keep this
+                    # constant marker inert under legacy Telegram Markdown.
+                    summary = f"\\[UNVERIFIED — no server session\\]\n{summary}"
                 await telegram_bot.send_message(
                     chat_id=TELEGRAM_LEAD_CHAT_ID,
                     text=summary,
@@ -1048,8 +1277,9 @@ async def handoff(
                 )
                 telegram_sent = True
                 logger.info(
-                    "visa-oracle /handoff: Telegram notification sent, session=%s",
+                    "visa-oracle /handoff: Telegram notification sent, session=%s verified=%s",
                     body.session_id[:12],
+                    session_verified,
                 )
         except Exception as tg_exc:
             # Non-fatal — still return WhatsApp URL

--- a/apps/backend-rag/backend/app/routers/visa_oracle.py
+++ b/apps/backend-rag/backend/app/routers/visa_oracle.py
@@ -124,35 +124,52 @@ OBSOLETE_VISA_CODES: dict[str, tuple[str, str]] = {
 OBSOLETE_CODE_REGULATORY_BASIS = "PERMENKUMHAM 22/2023"
 
 
-def _detect_obsolete_code(text: str) -> tuple[str, str] | None:
-    """Return (obsolete_code, expansion_hint) if the message mentions a
-    retired visa code that needs query expansion + regulatory flagging.
-    Matches word-boundary (B211 won't match B2115 etc.)."""
+def _detect_obsolete_codes(text: str) -> list[tuple[str, str]]:
+    """R2-C (Codex re-review NEW-BUG, F6): a message can mention MORE THAN
+    ONE retired visa code (e.g. "is B211 or B211A still valid?") — the
+    prior single-match version silently dropped every code after the
+    first, understating both the review_reasons annotation and the static
+    answer. Returns EVERY match, word-boundary (B211 won't match B211A —
+    no boundary between the shared "211" and the trailing "A" — nor
+    B2115 etc.), in `OBSOLETE_VISA_CODES` dict order."""
     import re
 
     upper = text.upper()
+    hits: list[tuple[str, str]] = []
     for code, (_replacement, hint) in OBSOLETE_VISA_CODES.items():
         if re.search(rf"\b{re.escape(code)}\b", upper):
-            return code, hint
-    return None
+            hits.append((code, hint))
+    return hits
 
 
-def _obsolete_review_reasons(obsolete_hit: tuple[str, str] | None) -> list[str]:
-    """PR0 W2: the review_reasons annotation carried on a (still-safe)
-    ABSTAIN response when the user's message mentioned a retired visa code.
-    Replaces the removed ABSTAIN→CAUTIOUS promotion — the code is still
-    named, but no candidate/answer is ever generated on the strength of it."""
-    if obsolete_hit is None:
-        return []
-    code, _hint = obsolete_hit
-    return [f"obsolete_code_mentioned:{code}"]
+def _detect_obsolete_code(text: str) -> tuple[str, str] | None:
+    """Thin single-value wrapper around `_detect_obsolete_codes` — returns
+    the first match, or None. No internal call site needs this shape
+    anymore (all use the plural form); kept for any future caller that
+    only needs "was ANY obsolete code mentioned"."""
+    hits = _detect_obsolete_codes(text)
+    return hits[0] if hits else None
 
 
-def _obsolete_code_static_answer(obsolete_hit: tuple[str, str] | None) -> str | None:
-    """PR0 hardening (Codex red-team P2 #6): a DETERMINISTIC, zero-LLM
-    explanation for the ABSTAIN + obsolete-code-mentioned path. Restores the
-    informational value the removed ABSTAIN->CAUTIOUS promotion used to
-    provide (via ungrounded LLM generation) WITHOUT ever calling the LLM.
+def _obsolete_review_reasons(obsolete_hits: list[tuple[str, str]]) -> list[str]:
+    """PR0 W2 + R2-C: the review_reasons annotation carried on a
+    (still-safe) ABSTAIN response when the user's message mentioned one or
+    more retired visa codes. One `obsolete_code_mentioned:<code>` entry per
+    DISTINCT code — replaces the removed ABSTAIN→CAUTIOUS promotion; the
+    code(s) are still named, but no candidate/answer is ever generated on
+    the strength of any of them."""
+    return [f"obsolete_code_mentioned:{code}" for code, _hint in obsolete_hits]
+
+
+def _obsolete_code_static_answer(obsolete_hits: list[tuple[str, str]]) -> str | None:
+    """PR0 hardening (Codex red-team P2 #6) + R2-C (multi-code): a
+    DETERMINISTIC, zero-LLM explanation for the ABSTAIN + obsolete-code-
+    mentioned path. Restores the informational value the removed
+    ABSTAIN->CAUTIOUS promotion used to provide (via ungrounded LLM
+    generation) WITHOUT ever calling the LLM. Enumerates EVERY distinct
+    retired code mentioned, one line each, from its own hint data — a
+    message mentioning both B211 and B211A must not silently answer for
+    only one of them.
 
     Built entirely from data already present in `OBSOLETE_VISA_CODES` (the
     replacement code + hint, both already curated in this file) plus the
@@ -165,19 +182,24 @@ def _obsolete_code_static_answer(obsolete_hit: tuple[str, str] | None) -> str | 
     Returns None when no obsolete code was mentioned — callers fall back to
     the existing generic ABSTAIN fallback (innocence path, unchanged).
     """
-    if obsolete_hit is None:
+    lines: list[str] = []
+    for code, _hint in obsolete_hits:
+        replacement, _ = OBSOLETE_VISA_CODES.get(code, (None, None))
+        if replacement is None:
+            continue
+        lines.append(
+            f"The visa code {code} was retired as part of the "
+            f"{OBSOLETE_CODE_REGULATORY_BASIS} visa reform and is no longer issued. "
+            f"Based on the most common intent, {replacement} is the closest current "
+            "equivalent."
+        )
+    if not lines:
         return None
-    code, _hint = obsolete_hit
-    replacement, _ = OBSOLETE_VISA_CODES.get(code, (None, None))
-    if replacement is None:
-        return None
-    return (
-        f"The visa code {code} was retired as part of the "
-        f"{OBSOLETE_CODE_REGULATORY_BASIS} visa reform and is no longer issued. "
-        f"Based on the most common intent, {replacement} is the closest current "
-        "equivalent — a Bali Zero consultant can confirm the exact match for your "
-        "specific case on WhatsApp (+62 821-3107-363)."
+    lines.append(
+        "A Bali Zero consultant can confirm the exact match for your specific "
+        "case on WhatsApp (+62 821-3107-363)."
     )
+    return "\n".join(lines)
 
 
 # Telegram chat ID for Damar / team lead notifications
@@ -398,14 +420,21 @@ def _invalid_recommend_vocabulary(purpose: str, duration: str) -> list[str]:
 
 
 def _filter_complete_visas(visas: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """FIX-3 (Codex red-team P1 #2, garbage candidates): drop any scored
-    row lacking a non-empty string `visa_name` before it ever reaches state
-    determination or the response body — an upstream pricing-JSON gap
-    should never surface as a nameless "candidate" client-side."""
+    """FIX-3 (Codex red-team P1 #2, garbage candidates) + R2-A (Codex
+    re-review residue on the same finding): drop any scored row lacking
+    EITHER a non-empty string `visa_name` OR a non-empty `price` before it
+    ever reaches state determination or the response body. `price` is the
+    consequential field — it is what `/handoff` renders into the WhatsApp
+    deep-link and the Telegram lead — so a row with a name but no price is
+    exactly as unusable a "candidate" as a nameless one. An upstream
+    pricing-JSON gap should never surface as a candidate client-side."""
     complete: list[dict[str, Any]] = []
     for visa in visas:
         name = visa.get("visa_name")
-        if isinstance(name, str) and name.strip():
+        price = visa.get("price")
+        has_name = isinstance(name, str) and name.strip()
+        has_price = price is not None and str(price).strip()
+        if has_name and has_price:
             complete.append(visa)
     return complete
 
@@ -667,30 +696,48 @@ _HANDOFF_TRIGGERED_UPDATE_SQL = """
     """
 
 
+_HANDOFF_UPDATE_RETRY_ATTEMPTS = 3
+_HANDOFF_UPDATE_RETRY_BACKOFF_SECONDS = 5.0  # 2 gaps × 5s ≈ 10s total across 3 attempts
+
+
 async def _persist_session_handoff(db_pool: Any, session_id: str) -> None:
     """Mark handoff_triggered = TRUE. Non-fatal — failures are logged, not
-    raised.
+    raised. Called fire-and-forget via `spawn()` at the call site (see
+    `handoff()`), so every attempt/sleep below already runs off the
+    request/response path — nothing here can add HTTP latency.
 
-    FIX-6 (Codex red-team P1 #5, async-persist race): /recommend persists
-    the session via a non-blocking `spawn()`'d INSERT — a fast-clicking
-    user (or a client that skips /recommend and calls /handoff directly)
-    can reach this UPDATE before that INSERT lands, matching 0 rows. Retry
-    ONCE after 1s, then log-and-continue either way — this UPDATE has
-    always been best-effort telemetry, never a gate on the handoff response.
+    FIX-6 (Codex red-team P1 #5, async-persist race) + R2-E (Codex
+    re-review, F5 residue — DECLARED-ACCEPTABLE MITIGATION, not a full
+    cure): /recommend persists the session via a non-blocking `spawn()`'d
+    INSERT — a fast-clicking user (or a client that skips /recommend and
+    calls /handoff directly) can reach this UPDATE before that INSERT
+    lands, matching 0 rows. Retries up to
+    `_HANDOFF_UPDATE_RETRY_ATTEMPTS` times, backing off
+    `_HANDOFF_UPDATE_RETRY_BACKOFF_SECONDS` between attempts (~10s total),
+    then logs and gives up — this UPDATE has always been best-effort
+    telemetry, never a gate on the handoff response.
+
+    RESIDUE (accepted for the freeze, not fixed here): `handoff_triggered`
+    can still be lost if /recommend's INSERT lands MORE than ~10s late — a
+    real cure needs UPSERT/marker-row schema semantics, which is
+    repository-layer work out of scope for a safety-freeze hardening pass
+    (see commit body; tracked for PR4).
     """
     try:
-        async with db_pool.acquire() as conn:
-            status = await conn.execute(_HANDOFF_TRIGGERED_UPDATE_SQL, session_id)
-        if _update_row_count(status) == 0:
-            await asyncio.sleep(1.0)
+        for attempt in range(_HANDOFF_UPDATE_RETRY_ATTEMPTS):
             async with db_pool.acquire() as conn:
                 status = await conn.execute(_HANDOFF_TRIGGERED_UPDATE_SQL, session_id)
-            if _update_row_count(status) == 0:
-                logger.info(
-                    "visa-oracle session persist (handoff): no row for session=%s "
-                    "after 1s retry — logging and continuing",
-                    session_id[:12],
-                )
+            if _update_row_count(status) > 0:
+                return
+            if attempt < _HANDOFF_UPDATE_RETRY_ATTEMPTS - 1:
+                await asyncio.sleep(_HANDOFF_UPDATE_RETRY_BACKOFF_SECONDS)
+        logger.info(
+            "visa-oracle session persist (handoff): no row for session=%s "
+            "after %d attempts (~%.0fs) — logging and continuing",
+            session_id[:12],
+            _HANDOFF_UPDATE_RETRY_ATTEMPTS,
+            _HANDOFF_UPDATE_RETRY_BACKOFF_SECONDS * (_HANDOFF_UPDATE_RETRY_ATTEMPTS - 1),
+        )
     except Exception as exc:
         logger.warning("visa-oracle session persist (handoff) failed: %s", exc)
 
@@ -994,14 +1041,19 @@ async def chat(
         # downstream: we have enough pretraining knowledge + SYSTEM_PROMPT
         # guidance to correct the code mention, even if the KB top_score
         # is weak (KB is thin on ex-codes precisely because they no longer
-        # exist).
-        obsolete_hit = _detect_obsolete_code(body.message)
-        if obsolete_hit:
-            code, hint = obsolete_hit
-            enriched_query = f"{quiz_ctx}{body.message} {hint}"
+        # exist). R2-C: a message can name more than one retired code —
+        # expand with every DISTINCT hint (B211/B211A share an identical
+        # hint today, so dedupe rather than repeat it verbatim).
+        obsolete_hits = _detect_obsolete_codes(body.message)
+        if obsolete_hits:
+            distinct_hints: list[str] = []
+            for _code, hint in obsolete_hits:
+                if hint not in distinct_hints:
+                    distinct_hints.append(hint)
+            enriched_query = f"{quiz_ctx}{body.message} {' '.join(distinct_hints)}"
             logger.info(
-                "visa-oracle /chat: obsolete code %s detected, expanded query session=%s",
-                code,
+                "visa-oracle /chat: obsolete code(s) %s detected, expanded query session=%s",
+                ",".join(code for code, _hint in obsolete_hits),
                 body.session_id[:12],
             )
         else:
@@ -1025,7 +1077,7 @@ async def chat(
 
         if not search_results:
             logger.info("visa-oracle /chat: no results for session=%s", body.session_id[:12])
-            obsolete_answer = _obsolete_code_static_answer(obsolete_hit)
+            obsolete_answer = _obsolete_code_static_answer(obsolete_hits)
             return ChatResponse(
                 success=True,
                 answer=obsolete_answer
@@ -1033,7 +1085,7 @@ async def chat(
                 confidence=CONFIDENCE_ABSTAIN,
                 sources=[],
                 session_id=body.session_id,
-                review_reasons=_obsolete_review_reasons(obsolete_hit),
+                review_reasons=_obsolete_review_reasons(obsolete_hits),
             )
 
         # --- Use vector similarity scores directly (cross-encoder not available on Fly) ---
@@ -1069,7 +1121,7 @@ async def chat(
             # from the existing OBSOLETE_VISA_CODES data (no generation, no
             # new legal claim). Innocence: no obsolete code -> generic
             # ABSTAIN fallback, unchanged.
-            obsolete_answer = _obsolete_code_static_answer(obsolete_hit)
+            obsolete_answer = _obsolete_code_static_answer(obsolete_hits)
             return ChatResponse(
                 success=True,
                 answer=obsolete_answer
@@ -1077,7 +1129,7 @@ async def chat(
                 confidence=CONFIDENCE_ABSTAIN,
                 sources=[],
                 session_id=body.session_id,
-                review_reasons=_obsolete_review_reasons(obsolete_hit),
+                review_reasons=_obsolete_review_reasons(obsolete_hits),
             )
 
         # --- Build context for LLM ---
@@ -1189,8 +1241,8 @@ async def handoff(
     a later handoff POST to alter it — falling back to the client body only
     when no snapshot (or an empty one) exists. A body-only handoff (no
     server session backing it at all) still fires the Telegram lead —
-    leads matter commercially — but is tagged `[UNVERIFIED — no server
-    session]` rather than presented as if server-verified.
+    leads matter commercially — but is tagged `UNVERIFIED (no server
+    session):` rather than presented as if server-verified.
     """
     from backend.services.integrations.telegram_bot_service import telegram_bot
 
@@ -1266,10 +1318,11 @@ async def handoff(
                     language=language,
                 )
                 if not session_verified:
-                    # FIX-5: never present a body-only lead as if
-                    # server-verified — the escaped brackets keep this
-                    # constant marker inert under legacy Telegram Markdown.
-                    summary = f"\\[UNVERIFIED — no server session\\]\n{summary}"
+                    # FIX-5 + R2-B (Codex re-review): never present a
+                    # body-only lead as if server-verified. Bracket-free
+                    # plain text — no escaping needed at all, and nothing
+                    # for legacy Telegram Markdown to (mis)parse as syntax.
+                    summary = f"UNVERIFIED (no server session):\n{summary}"
                 await telegram_bot.send_message(
                     chat_id=TELEGRAM_LEAD_CHAT_ID,
                     text=summary,

--- a/apps/backend-rag/backend/services/visa_oracle/visa_oracle_service.py
+++ b/apps/backend-rag/backend/services/visa_oracle/visa_oracle_service.py
@@ -129,6 +129,27 @@ SCORE_FAMILY_MATCH = 1.0
 WHATSAPP_NUMBER = "+62 821 3465 159"
 WHATSAPP_BASE_URL = "https://wa.me/6282230102328"
 
+# PR0 hardening (Codex red-team P1 #4, Markdown injection): the 4 chars
+# Telegram's LEGACY Markdown parse_mode (`send_message(..., parse_mode=
+# "Markdown")`, as used by the visa-oracle handoff notification) actually
+# treats as formatting syntax. Deliberately NOT the full MarkdownV2 set
+# (`_*[]()~>#+-=|{}.!`) — this message is sent as legacy v1, which does not
+# recognize backslash as an escape prefix outside these 4 characters;
+# escaping e.g. `.`/`-`/`!` under v1 would insert a literal stray backslash
+# into the rendered message instead of hiding one.
+_TELEGRAM_MARKDOWN_V1_SPECIAL_CHARS: tuple[str, ...] = ("_", "*", "`", "[")
+
+
+def _escape_telegram_markdown_v1(value: Any) -> str:
+    """Escape legacy-Telegram-Markdown special chars in a value about to be
+    interpolated into a `parse_mode="Markdown"` message. Applied at the
+    string-composition boundary in `build_telegram_summary` for every
+    quiz-answer / visa field that ultimately traces back to user input."""
+    text = str(value)
+    for ch in _TELEGRAM_MARKDOWN_V1_SPECIAL_CHARS:
+        text = text.replace(ch, f"\\{ch}")
+    return text
+
 
 # ---------------------------------------------------------------------------
 # Service
@@ -299,13 +320,20 @@ class VisaOracleService:
         Returns:
             Formatted Markdown string for Telegram.
         """
-        nationality = quiz_answers.get("nationality", "Unknown")
-        purpose = quiz_answers.get("purpose", "Unknown")
-        duration = quiz_answers.get("duration", "Unknown")
+        # PR0 hardening (Codex red-team P1 #4): escape every user-influenced
+        # string right at this composition boundary — nationality/purpose/
+        # duration originate from client-declared quiz input (even the
+        # server-snapshot-preferred path traces back to the original
+        # /recommend POST); visa_name is defense-in-depth even though the
+        # router now resolves it server-side.
+        nationality = _escape_telegram_markdown_v1(quiz_answers.get("nationality", "Unknown"))
+        purpose = _escape_telegram_markdown_v1(quiz_answers.get("purpose", "Unknown"))
+        duration = _escape_telegram_markdown_v1(quiz_answers.get("duration", "Unknown"))
         family = quiz_answers.get("family", False)
 
         visa_lines = "\n".join(
-            f"  {i + 1}. {v.get('visa_name', '?')} — {v.get('price', '?')} "
+            f"  {i + 1}. {_escape_telegram_markdown_v1(v.get('visa_name', '?'))} — "
+            f"{_escape_telegram_markdown_v1(v.get('price', '?'))} "
             f"(score: {v.get('score', 0):.1f})"
             for i, v in enumerate(recommended_visas[:3])
         )

--- a/apps/backend-rag/backend/services/visa_oracle/visa_oracle_service.py
+++ b/apps/backend-rag/backend/services/visa_oracle/visa_oracle_service.py
@@ -7,6 +7,7 @@ and family situation. Returns top-3 results with full details.
 
 import hashlib
 import logging
+import re
 import secrets
 from typing import Any
 from urllib.parse import quote
@@ -144,11 +145,47 @@ def _escape_telegram_markdown_v1(value: Any) -> str:
     """Escape legacy-Telegram-Markdown special chars in a value about to be
     interpolated into a `parse_mode="Markdown"` message. Applied at the
     string-composition boundary in `build_telegram_summary` for every
-    quiz-answer / visa field that ultimately traces back to user input."""
+    quiz-answer / visa field that ultimately traces back to user input.
+
+    ONLY valid for values interpolated in NORMAL (non-entity) text — see
+    `_sanitize_code_entity_*` below for values interpolated inside a code
+    span (backticks), where escaping is a different, WRONG mitigation."""
     text = str(value)
     for ch in _TELEGRAM_MARKDOWN_V1_SPECIAL_CHARS:
         text = text.replace(ch, f"\\{ch}")
     return text
+
+
+# R2-B (Codex re-review NEW-BUG, F4): `session_id` and `language` are
+# interpolated INSIDE a Telegram legacy-Markdown CODE SPAN (backticks) in
+# `build_telegram_summary` — e.g. `` `{session_id}` ``. Escaping is INVALID
+# inside a code entity: legacy Markdown does not parse backslash-escapes
+# there, it renders the span's content literally up to the NEXT backtick.
+# An attacker-controlled value containing a backtick would close the span
+# early and inject raw (unescaped) formatting into the surrounding text —
+# `_escape_telegram_markdown_v1` above cannot fix this, no matter which
+# chars it escapes. The only safe mitigation for a code-span value is to
+# WHITELIST the charset, not escape it.
+_SESSION_ID_DISALLOWED_RE = re.compile(r"[^A-Za-z0-9_-]")
+_LANGUAGE_DISALLOWED_RE = re.compile(r"[^a-z-]")
+_SESSION_ID_SANITIZED_MAX_LEN = 40
+_LANGUAGE_SANITIZED_MAX_LEN = 8
+
+
+def _sanitize_code_entity_session_id(value: Any) -> str:
+    """Whitelist `session_id` to `[A-Za-z0-9_-]`, max 40 chars, for safe
+    interpolation inside a Telegram code span. Falls back to "unknown" if
+    sanitization empties the value (e.g. an all-symbol input)."""
+    cleaned = _SESSION_ID_DISALLOWED_RE.sub("", str(value))[:_SESSION_ID_SANITIZED_MAX_LEN]
+    return cleaned or "unknown"
+
+
+def _sanitize_code_entity_language(value: Any) -> str:
+    """Whitelist `language` to `[a-z-]`, max 8 chars, for safe
+    interpolation inside a Telegram code span. Falls back to "unknown" if
+    sanitization empties the value."""
+    cleaned = _LANGUAGE_DISALLOWED_RE.sub("", str(value).lower())[:_LANGUAGE_SANITIZED_MAX_LEN]
+    return cleaned or "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -325,11 +362,18 @@ class VisaOracleService:
         # duration originate from client-declared quiz input (even the
         # server-snapshot-preferred path traces back to the original
         # /recommend POST); visa_name is defense-in-depth even though the
-        # router now resolves it server-side.
+        # router now resolves it server-side. Escaping is correct HERE
+        # because these values land in NORMAL text, not a code span.
         nationality = _escape_telegram_markdown_v1(quiz_answers.get("nationality", "Unknown"))
         purpose = _escape_telegram_markdown_v1(quiz_answers.get("purpose", "Unknown"))
         duration = _escape_telegram_markdown_v1(quiz_answers.get("duration", "Unknown"))
         family = quiz_answers.get("family", False)
+
+        # R2-B: session_id/language are interpolated INSIDE backticks below
+        # — a code span, where escaping does not apply (see the
+        # `_sanitize_code_entity_*` docstring). Whitelist instead.
+        session_id_safe = _sanitize_code_entity_session_id(session_id)
+        language_safe = _sanitize_code_entity_language(language)
 
         visa_lines = "\n".join(
             f"  {i + 1}. {_escape_telegram_markdown_v1(v.get('visa_name', '?'))} — "
@@ -343,8 +387,8 @@ class VisaOracleService:
 
         summary = (
             f"*Visa Oracle Lead* 🧭\n"
-            f"Session: `{session_id[:12]}…`\n"
-            f"Language: `{language}`\n\n"
+            f"Session: `{session_id_safe[:12]}…`\n"
+            f"Language: `{language_safe}`\n\n"
             f"*Quiz Answers*\n"
             f"• Nationality: {nationality}\n"
             f"• Purpose: {purpose}\n"

--- a/apps/backend-rag/backend/tests/routers/test_visa_oracle.py
+++ b/apps/backend-rag/backend/tests/routers/test_visa_oracle.py
@@ -383,30 +383,62 @@ class TestInvalidRecommendVocabulary:
 
 
 class TestFilterCompleteVisas:
-    """Unit tests for the FIX-3 candidate-completeness filter."""
+    """Unit tests for the FIX-3 / R2-A candidate-completeness filter.
 
-    def test_keeps_rows_with_nonempty_name(self) -> None:
+    R2-A (Codex re-review, F2 residue): completeness requires BOTH a
+    non-empty `visa_name` AND a non-empty `price` — `price` is the
+    consequential field /handoff renders into the WhatsApp deep-link and
+    the Telegram lead, so a named row with no price is exactly as unusable
+    a "candidate" as a nameless one."""
+
+    def test_keeps_rows_with_name_and_price(self) -> None:
         from backend.app.routers.visa_oracle import _filter_complete_visas
 
-        visas = [{"visa_name": "C1 Tourism", "score": 2.0}]
+        visas = [{"visa_name": "C1 Tourism", "price": "1.500.000 IDR", "score": 2.0}]
         assert _filter_complete_visas(visas) == visas
 
     def test_drops_row_missing_visa_name(self) -> None:
         from backend.app.routers.visa_oracle import _filter_complete_visas
 
-        assert _filter_complete_visas([{"score": 2}]) == []
+        assert _filter_complete_visas([{"price": "1 IDR", "score": 2}]) == []
 
     def test_drops_row_with_blank_visa_name(self) -> None:
         from backend.app.routers.visa_oracle import _filter_complete_visas
 
-        assert _filter_complete_visas([{"visa_name": "   ", "score": 2}]) == []
+        assert _filter_complete_visas([{"visa_name": "   ", "price": "1 IDR", "score": 2}]) == []
+
+    def test_drops_row_missing_price(self) -> None:
+        """R2-A guilt (probe from the task spec): a name with no price at
+        all must NOT be treated as complete."""
+        from backend.app.routers.visa_oracle import _filter_complete_visas
+
+        assert _filter_complete_visas([{"visa_name": "X", "score": 2}]) == []
+
+    def test_drops_row_with_blank_price(self) -> None:
+        from backend.app.routers.visa_oracle import _filter_complete_visas
+
+        assert _filter_complete_visas([{"visa_name": "X", "price": "   ", "score": 2}]) == []
+
+    def test_drops_row_with_none_price(self) -> None:
+        from backend.app.routers.visa_oracle import _filter_complete_visas
+
+        assert _filter_complete_visas([{"visa_name": "X", "price": None, "score": 2}]) == []
+
+    def test_keeps_row_with_numeric_zero_price(self) -> None:
+        """Innocence: `price` may legitimately be a non-string (a numeric
+        0, e.g.) — the spec is "non-empty/non-null", not "truthy/non-zero"."""
+        from backend.app.routers.visa_oracle import _filter_complete_visas
+
+        visas = [{"visa_name": "Free Consultation", "price": 0, "score": 1.0}]
+        assert _filter_complete_visas(visas) == visas
 
     def test_mixed_list_keeps_only_complete_rows(self) -> None:
         from backend.app.routers.visa_oracle import _filter_complete_visas
 
-        good = {"visa_name": "C1 Tourism", "score": 2.0}
-        bad = {"visa_name": "", "score": 1.0}
-        assert _filter_complete_visas([good, bad, {"score": 5}]) == [good]
+        good = {"visa_name": "C1 Tourism", "price": "1 IDR", "score": 2.0}
+        bad_name = {"visa_name": "", "price": "1 IDR", "score": 1.0}
+        bad_price = {"visa_name": "Y", "price": "", "score": 1.0}
+        assert _filter_complete_visas([good, bad_name, bad_price, {"score": 5}]) == [good]
 
 
 class TestRecommendEndpointFiveState:
@@ -484,14 +516,15 @@ class TestRecommendEndpointFiveState:
         self, mock_get_service, mock_persist, client: TestClient
     ) -> None:
         """Isolates the low_confidence_match path: purpose/duration are
-        BOTH valid vocabulary (FIX-1's gate must NOT fire here) — the
-        only reason this drops to NEEDS_INPUT is the zero score."""
+        BOTH valid vocabulary (FIX-1's gate must NOT fire here) and the row
+        has a real `price` (R2-A's completeness gate must NOT fire either)
+        — the only reason this drops to NEEDS_INPUT is the zero score."""
         mock_service = MagicMock()
         mock_service.recommend_visas.return_value = [
             {
                 "visa_name": "Irrelevant Visa",
                 "category": "single_entry_visas",
-                "price": "",
+                "price": "1.000.000 IDR",
                 "duration": "",
                 "validity": "",
                 "notes": "",
@@ -620,6 +653,39 @@ class TestRecommendEndpointFiveState:
         assert data["visas"] == []
         assert data["review_reasons"] == ["catalog_degraded"]
         assert data["success"] is True  # scorer ran fine — this isn't an exception
+
+    @patch("backend.app.routers.visa_oracle._persist_session_create")
+    @patch("backend.app.routers.visa_oracle.get_visa_oracle_service")
+    def test_state_temporarily_unavailable_when_row_has_name_but_no_price(
+        self, mock_get_service, mock_persist, client: TestClient
+    ) -> None:
+        """R2-A (Codex re-review, F2 residue): the exact probe from the
+        finding — a row with `visa_name` + `score` but NO `price` at all
+        must NOT reach SUPPORTED_CANDIDATES. `price` is what /handoff
+        renders; a named-but-priceless row is a catalog gap, same class as
+        a nameless one."""
+        mock_service = MagicMock()
+        mock_service.recommend_visas.return_value = [{"visa_name": "X", "score": 2}]
+        mock_service.generate_session_id.return_value = "abc123"
+        mock_service.hash_ip.return_value = "hashed_ip"
+        mock_get_service.return_value = mock_service
+
+        response = client.post(
+            "/api/v1/visa-oracle/recommend",
+            json={
+                "nationality": "US",
+                "purpose": "work",
+                "duration": "long",
+                "family": "no",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["state"] != "SUPPORTED_CANDIDATES"
+        assert data["state"] == "TEMPORARILY_UNAVAILABLE"
+        assert data["visas"] == []
+        assert data["review_reasons"] == ["catalog_degraded"]
 
 
 class TestRecommendEndpointRealService:

--- a/apps/backend-rag/backend/tests/routers/test_visa_oracle.py
+++ b/apps/backend-rag/backend/tests/routers/test_visa_oracle.py
@@ -241,6 +241,240 @@ class TestRecommendEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# 3b. PR0 safety freeze — five-state /recommend contract (W1)
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendStateHelpers:
+    """Unit tests for the pure PR0 five-state mapping helpers."""
+
+    def test_missing_facts_all_present(self) -> None:
+        from backend.app.routers.visa_oracle import _missing_recommend_facts
+
+        assert _missing_recommend_facts("German", "work", "long") == []
+
+    def test_missing_facts_detects_blank_nationality(self) -> None:
+        from backend.app.routers.visa_oracle import _missing_recommend_facts
+
+        assert _missing_recommend_facts("   ", "work", "long") == ["nationality"]
+
+    def test_missing_facts_detects_multiple_blank_fields(self) -> None:
+        from backend.app.routers.visa_oracle import _missing_recommend_facts
+
+        assert _missing_recommend_facts("", "", "long") == ["nationality", "purpose"]
+
+    def test_state_needs_input_when_missing_facts(self) -> None:
+        from backend.app.routers.visa_oracle import _determine_recommend_state
+
+        state, reasons = _determine_recommend_state(
+            visas=[{"visa_name": "X", "score": 4.0}],
+            missing_facts=["nationality"],
+        )
+        assert state == "NEEDS_INPUT"
+        assert reasons == []
+
+    def test_state_temporarily_unavailable_when_no_candidates(self) -> None:
+        from backend.app.routers.visa_oracle import _determine_recommend_state
+
+        state, reasons = _determine_recommend_state(visas=[], missing_facts=[])
+        assert state == "TEMPORARILY_UNAVAILABLE"
+        assert reasons == ["catalog_no_candidates"]
+
+    def test_state_needs_input_when_all_scores_zero(self) -> None:
+        from backend.app.routers.visa_oracle import _determine_recommend_state
+
+        state, reasons = _determine_recommend_state(
+            visas=[
+                {"visa_name": "A", "score": 0.0},
+                {"visa_name": "B", "score": 0.0},
+            ],
+            missing_facts=[],
+        )
+        assert state == "NEEDS_INPUT"
+        assert reasons == ["low_confidence_match"]
+
+    def test_state_supported_candidates_when_positive_score(self) -> None:
+        from backend.app.routers.visa_oracle import _determine_recommend_state
+
+        state, reasons = _determine_recommend_state(
+            visas=[{"visa_name": "A", "score": 2.0}],
+            missing_facts=[],
+        )
+        assert state == "SUPPORTED_CANDIDATES"
+        assert reasons == []
+
+
+class TestRecommendEndpointFiveState:
+    """Integration-style tests for the additive five-state /recommend contract."""
+
+    @patch("backend.app.routers.visa_oracle._persist_session_create")
+    @patch("backend.app.routers.visa_oracle.get_visa_oracle_service")
+    def test_state_supported_candidates(
+        self, mock_get_service, mock_persist, client: TestClient
+    ) -> None:
+        mock_service = MagicMock()
+        mock_service.recommend_visas.return_value = [
+            {
+                "visa_name": "Digital Nomad Visa E33G",
+                "category": "single_entry_visas",
+                "price": "5.800.000 IDR",
+                "duration": "60 days",
+                "validity": "1 year",
+                "notes": "",
+                "score": 4.0,
+            }
+        ]
+        mock_service.generate_session_id.return_value = "deadbeef" * 8
+        mock_service.hash_ip.return_value = "hashed_ip"
+        mock_get_service.return_value = mock_service
+
+        response = client.post(
+            "/api/v1/visa-oracle/recommend",
+            json={
+                "nationality": "German",
+                "purpose": "digital_nomad",
+                "duration": "short",
+                "family": "no",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["state"] == "SUPPORTED_CANDIDATES"
+        assert data["missing_facts"] == []
+        assert data["review_reasons"] == []
+        assert len(data["visas"]) == 1
+
+    @patch("backend.app.routers.visa_oracle._persist_session_create")
+    @patch("backend.app.routers.visa_oracle.get_visa_oracle_service")
+    def test_state_temporarily_unavailable_when_service_returns_no_candidates(
+        self, mock_get_service, mock_persist, client: TestClient
+    ) -> None:
+        mock_service = MagicMock()
+        mock_service.recommend_visas.return_value = []
+        mock_service.generate_session_id.return_value = "abc123"
+        mock_service.hash_ip.return_value = "hashed_ip"
+        mock_get_service.return_value = mock_service
+
+        response = client.post(
+            "/api/v1/visa-oracle/recommend",
+            json={
+                "nationality": "US",
+                "purpose": "family",
+                "duration": "long",
+                "family": "yes",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["state"] == "TEMPORARILY_UNAVAILABLE"
+        assert data["visas"] == []
+
+    @patch("backend.app.routers.visa_oracle._persist_session_create")
+    @patch("backend.app.routers.visa_oracle.get_visa_oracle_service")
+    def test_state_needs_input_when_all_candidates_score_zero(
+        self, mock_get_service, mock_persist, client: TestClient
+    ) -> None:
+        mock_service = MagicMock()
+        mock_service.recommend_visas.return_value = [
+            {
+                "visa_name": "Irrelevant Visa",
+                "category": "single_entry_visas",
+                "price": "",
+                "duration": "",
+                "validity": "",
+                "notes": "",
+                "score": 0.0,
+            },
+        ]
+        mock_service.generate_session_id.return_value = "abc123"
+        mock_service.hash_ip.return_value = "hashed_ip"
+        mock_get_service.return_value = mock_service
+
+        response = client.post(
+            "/api/v1/visa-oracle/recommend",
+            json={
+                "nationality": "US",
+                "purpose": "xyz_unknown_purpose",
+                "duration": "short",
+                "family": "no",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["state"] == "NEEDS_INPUT"
+        assert data["visas"] == []
+        assert data["review_reasons"] == ["low_confidence_match"]
+
+    @patch("backend.app.routers.visa_oracle._persist_session_create")
+    @patch("backend.app.routers.visa_oracle.get_visa_oracle_service")
+    def test_state_needs_input_when_required_fact_blank(
+        self, mock_get_service, mock_persist, client: TestClient
+    ) -> None:
+        mock_service = MagicMock()
+        mock_service.recommend_visas.return_value = [
+            {
+                "visa_name": "Tourism",
+                "category": "single_entry_visas",
+                "price": "",
+                "duration": "",
+                "validity": "",
+                "notes": "",
+                "score": 3.0,
+            },
+        ]
+        mock_service.generate_session_id.return_value = "abc123"
+        mock_service.hash_ip.return_value = "hashed_ip"
+        mock_get_service.return_value = mock_service
+
+        response = client.post(
+            "/api/v1/visa-oracle/recommend",
+            json={
+                "nationality": "   ",
+                "purpose": "visit",
+                "duration": "short",
+                "family": "no",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["state"] == "NEEDS_INPUT"
+        assert data["missing_facts"] == ["nationality"]
+        assert data["visas"] == []
+
+    @patch("backend.app.routers.visa_oracle._persist_session_create")
+    @patch("backend.app.routers.visa_oracle.get_visa_oracle_service")
+    def test_state_temporarily_unavailable_on_scoring_exception(
+        self, mock_get_service, mock_persist, client: TestClient
+    ) -> None:
+        mock_service = MagicMock()
+        mock_service.recommend_visas.side_effect = RuntimeError("pricing catalog unavailable")
+        mock_service.generate_session_id.return_value = "abc123"
+        mock_service.hash_ip.return_value = "hashed_ip"
+        mock_get_service.return_value = mock_service
+
+        response = client.post(
+            "/api/v1/visa-oracle/recommend",
+            json={
+                "nationality": "US",
+                "purpose": "work",
+                "duration": "long",
+                "family": "no",
+            },
+        )
+
+        # Degraded (200 + honest state), not a fatal 500 — the frontend must
+        # be able to render this without special-casing an HTTP error.
+        assert response.status_code == 200
+        data = response.json()
+        assert data["state"] == "TEMPORARILY_UNAVAILABLE"
+        assert data["visas"] == []
+
+
+# ---------------------------------------------------------------------------
 # 4. Visa types endpoints (mocked service)
 # ---------------------------------------------------------------------------
 

--- a/apps/backend-rag/backend/tests/routers/test_visa_oracle.py
+++ b/apps/backend-rag/backend/tests/routers/test_visa_oracle.py
@@ -7,6 +7,7 @@ Covers:
 - Response model shapes
 """
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -301,7 +302,111 @@ class TestRecommendStateHelpers:
             missing_facts=[],
         )
         assert state == "SUPPORTED_CANDIDATES"
-        assert reasons == []
+        # FIX-2: every SUPPORTED_CANDIDATES response declares this
+        # truthful limitation — the legacy scorer never evaluates
+        # nationality at all.
+        assert reasons == ["nationality_not_evaluated"]
+
+    def test_state_needs_input_when_purpose_not_in_vocabulary(self) -> None:
+        """FIX-1 (Codex red-team P1 #1): even a positive-scoring candidate
+        must not reach SUPPORTED_CANDIDATES when `purpose` itself is
+        nonsense — the vocabulary gate takes precedence over the score."""
+        from backend.app.routers.visa_oracle import _determine_recommend_state
+
+        state, reasons = _determine_recommend_state(
+            visas=[{"visa_name": "A", "score": 2.0}],
+            missing_facts=[],
+            invalid_vocabulary_reasons=["invalid_purpose:banana"],
+        )
+        assert state == "NEEDS_INPUT"
+        assert reasons == ["invalid_purpose:banana"]
+
+    def test_state_temporarily_unavailable_when_catalog_degraded(self) -> None:
+        """FIX-3 (Codex red-team P1 #2): raw candidates existed but every
+        row was incomplete (dropped by `_filter_complete_visas`) — this is
+        a catalog data problem, not a "no match" or "no input" problem."""
+        from backend.app.routers.visa_oracle import _determine_recommend_state
+
+        state, reasons = _determine_recommend_state(
+            visas=[],
+            missing_facts=[],
+            invalid_vocabulary_reasons=[],
+            catalog_degraded=True,
+        )
+        assert state == "TEMPORARILY_UNAVAILABLE"
+        assert reasons == ["catalog_degraded"]
+
+
+class TestInvalidRecommendVocabulary:
+    """Unit tests for the FIX-1 vocabulary gate helper."""
+
+    def test_known_purpose_and_duration_are_valid(self) -> None:
+        from backend.app.routers.visa_oracle import _invalid_recommend_vocabulary
+
+        assert _invalid_recommend_vocabulary("work", "long") == []
+
+    def test_unknown_purpose_flagged(self) -> None:
+        from backend.app.routers.visa_oracle import _invalid_recommend_vocabulary
+
+        assert _invalid_recommend_vocabulary("banana", "long") == ["invalid_purpose:banana"]
+
+    def test_unknown_duration_flagged(self) -> None:
+        from backend.app.routers.visa_oracle import _invalid_recommend_vocabulary
+
+        assert _invalid_recommend_vocabulary("work", "nonsense") == ["invalid_duration:nonsense"]
+
+    def test_both_unknown_flagged(self) -> None:
+        from backend.app.routers.visa_oracle import _invalid_recommend_vocabulary
+
+        assert _invalid_recommend_vocabulary("banana", "nonsense") == [
+            "invalid_purpose:banana",
+            "invalid_duration:nonsense",
+        ]
+
+    def test_case_and_whitespace_insensitive(self) -> None:
+        from backend.app.routers.visa_oracle import _invalid_recommend_vocabulary
+
+        assert _invalid_recommend_vocabulary("  Work  ", " LONG ") == []
+
+    def test_echoed_value_is_sanitized_and_truncated(self) -> None:
+        """Newlines collapse to spaces and the value truncates to 40 chars
+        — this string flows into API responses and logs."""
+        from backend.app.routers.visa_oracle import _invalid_recommend_vocabulary
+
+        raw = "line1\nline2\t" + ("x" * 60)
+        reasons = _invalid_recommend_vocabulary(raw, "long")
+        assert len(reasons) == 1
+        echoed = reasons[0].split(":", 1)[1]
+        assert "\n" not in echoed
+        assert "\t" not in echoed
+        assert len(echoed) <= 40
+
+
+class TestFilterCompleteVisas:
+    """Unit tests for the FIX-3 candidate-completeness filter."""
+
+    def test_keeps_rows_with_nonempty_name(self) -> None:
+        from backend.app.routers.visa_oracle import _filter_complete_visas
+
+        visas = [{"visa_name": "C1 Tourism", "score": 2.0}]
+        assert _filter_complete_visas(visas) == visas
+
+    def test_drops_row_missing_visa_name(self) -> None:
+        from backend.app.routers.visa_oracle import _filter_complete_visas
+
+        assert _filter_complete_visas([{"score": 2}]) == []
+
+    def test_drops_row_with_blank_visa_name(self) -> None:
+        from backend.app.routers.visa_oracle import _filter_complete_visas
+
+        assert _filter_complete_visas([{"visa_name": "   ", "score": 2}]) == []
+
+    def test_mixed_list_keeps_only_complete_rows(self) -> None:
+        from backend.app.routers.visa_oracle import _filter_complete_visas
+
+        good = {"visa_name": "C1 Tourism", "score": 2.0}
+        bad = {"visa_name": "", "score": 1.0}
+        assert _filter_complete_visas([good, bad, {"score": 5}]) == [good]
 
 
 class TestRecommendEndpointFiveState:
@@ -342,7 +447,9 @@ class TestRecommendEndpointFiveState:
         data = response.json()
         assert data["state"] == "SUPPORTED_CANDIDATES"
         assert data["missing_facts"] == []
-        assert data["review_reasons"] == []
+        # FIX-2: every SUPPORTED_CANDIDATES response must truthfully
+        # declare that nationality was never evaluated by the scorer.
+        assert data["review_reasons"] == ["nationality_not_evaluated"]
         assert len(data["visas"]) == 1
 
     @patch("backend.app.routers.visa_oracle._persist_session_create")
@@ -376,6 +483,9 @@ class TestRecommendEndpointFiveState:
     def test_state_needs_input_when_all_candidates_score_zero(
         self, mock_get_service, mock_persist, client: TestClient
     ) -> None:
+        """Isolates the low_confidence_match path: purpose/duration are
+        BOTH valid vocabulary (FIX-1's gate must NOT fire here) — the
+        only reason this drops to NEEDS_INPUT is the zero score."""
         mock_service = MagicMock()
         mock_service.recommend_visas.return_value = [
             {
@@ -396,7 +506,7 @@ class TestRecommendEndpointFiveState:
             "/api/v1/visa-oracle/recommend",
             json={
                 "nationality": "US",
-                "purpose": "xyz_unknown_purpose",
+                "purpose": "work",
                 "duration": "short",
                 "family": "no",
             },
@@ -472,6 +582,150 @@ class TestRecommendEndpointFiveState:
         data = response.json()
         assert data["state"] == "TEMPORARILY_UNAVAILABLE"
         assert data["visas"] == []
+        # FIX-8: a scoring exception is a real failure — success must be
+        # False so the frontend parser never mistakes this for a clean
+        # "here's what fits" outcome.
+        assert data["success"] is False
+
+    @patch("backend.app.routers.visa_oracle._persist_session_create")
+    @patch("backend.app.routers.visa_oracle.get_visa_oracle_service")
+    def test_state_temporarily_unavailable_when_catalog_degraded(
+        self, mock_get_service, mock_persist, client: TestClient
+    ) -> None:
+        """FIX-3 (Codex red-team P1 #2): the scorer ran fine and returned
+        rows, but EVERY row is missing `visa_name` — a catalog data problem,
+        distinct from both 'no match' (empty list) and 'bad input'."""
+        mock_service = MagicMock()
+        mock_service.recommend_visas.return_value = [
+            {"score": 4.0},
+            {"visa_name": "   ", "score": 3.0},
+        ]
+        mock_service.generate_session_id.return_value = "abc123"
+        mock_service.hash_ip.return_value = "hashed_ip"
+        mock_get_service.return_value = mock_service
+
+        response = client.post(
+            "/api/v1/visa-oracle/recommend",
+            json={
+                "nationality": "US",
+                "purpose": "work",
+                "duration": "long",
+                "family": "no",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["state"] == "TEMPORARILY_UNAVAILABLE"
+        assert data["visas"] == []
+        assert data["review_reasons"] == ["catalog_degraded"]
+        assert data["success"] is True  # scorer ran fine — this isn't an exception
+
+
+class TestRecommendEndpointRealService:
+    """FIX-1 guilt/innocence tests exercised through the REAL
+    `VisaOracleService` (only `PricingService` is stubbed — the scorer
+    itself, `_score_visa`/`recommend_visas`, runs unmocked). The earlier
+    coverage mocked `recommend_visas` directly and never exercised the
+    real +1.5 duration-fit / +1.0 family bonuses that let a nonsense
+    purpose like "banana" still reach a positive score and, pre-FIX-1,
+    SUPPORTED_CANDIDATES — confirmed live via direct service invocation
+    during the red-team round (banana/long/false → 3 candidates score 1.5)."""
+
+    _SAMPLE_PRICES: dict[str, Any] = {
+        "services": {
+            "single_entry_visas": {},
+            "multiple_entry_visas": {},
+            "kitas_permits": {
+                "Working KITAS (Altus/Onshore)": {
+                    "price": "40.000.000 IDR",
+                    "duration": "1 year",
+                    "validity": "1 year",
+                    "notes": "Work permit KITAS",
+                },
+                "Investor KITAS 2 Years (Altus/Onshore)": {
+                    "price": "45.000.000 IDR",
+                    "duration": "2 years",
+                    "validity": "2 years",
+                    "notes": "Investor KITAS",
+                },
+                "Spouse 2 Years (Altus/Onshore)": {
+                    "price": "50.000.000 IDR",
+                    "duration": "2 years",
+                    "validity": "2 years",
+                    "notes": "Spouse KITAS",
+                },
+                "Dependent 2 Years (Altus/Onshore)": {
+                    "price": "48.000.000 IDR",
+                    "duration": "2 years",
+                    "validity": "2 years",
+                    "notes": "Dependent KITAS",
+                },
+            },
+            "visa_extensions": {},
+            "kitap_permits": {},
+            "company_services": {},
+            "other_process": {},
+            "urgent_services": {},
+        }
+    }
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        import backend.services.visa_oracle.visa_oracle_service as svc_module
+
+        svc_module._visa_oracle_service = None
+        yield
+        svc_module._visa_oracle_service = None
+
+    def _post(self, client: TestClient, **overrides: Any) -> dict[str, Any]:
+        import backend.services.visa_oracle.visa_oracle_service as svc_module
+
+        mock_pricing = MagicMock()
+        mock_pricing.prices = self._SAMPLE_PRICES
+        body = {
+            "nationality": "US",
+            "purpose": "work",
+            "duration": "long",
+            "family": "no",
+        }
+        body.update(overrides)
+        with (
+            patch.object(svc_module, "get_pricing_service", return_value=mock_pricing),
+            patch("backend.app.routers.visa_oracle._persist_session_create"),
+        ):
+            response = client.post("/api/v1/visa-oracle/recommend", json=body)
+        assert response.status_code == 200
+        return response.json()
+
+    def test_banana_purpose_long_duration_needs_input(self, client: TestClient) -> None:
+        """Guilt: nonsense purpose="banana" paired with a VALID duration —
+        pre-FIX-1 this scored 1.5 (duration-fit bonus alone) and reached
+        SUPPORTED_CANDIDATES despite the purpose being meaningless."""
+        data = self._post(client, purpose="banana", duration="long", family="no")
+        assert data["state"] == "NEEDS_INPUT"
+        assert data["visas"] == []
+        assert any(r.startswith("invalid_purpose:banana") for r in data["review_reasons"])
+
+    def test_banana_purpose_nonsense_duration_needs_input(self, client: TestClient) -> None:
+        """Guilt: BOTH purpose="banana" and duration="nonsense" — pre-FIX-1
+        this scored 1.0 (family bonus alone, matched via family=True) and
+        still reached SUPPORTED_CANDIDATES."""
+        data = self._post(client, purpose="banana", duration="nonsense", family="yes")
+        assert data["state"] == "NEEDS_INPUT"
+        assert data["visas"] == []
+        reasons = data["review_reasons"]
+        assert any(r.startswith("invalid_purpose:banana") for r in reasons)
+        assert any(r.startswith("invalid_duration:nonsense") for r in reasons)
+
+    def test_work_long_valid_vocabulary_still_supported(self, client: TestClient) -> None:
+        """Innocence: a legitimate purpose+duration pair must still reach
+        SUPPORTED_CANDIDATES through the real, unmocked scorer — the
+        vocabulary gate must not collaterally block honest requests."""
+        data = self._post(client, purpose="work", duration="long", family="no")
+        assert data["state"] == "SUPPORTED_CANDIDATES"
+        assert len(data["visas"]) > 0
+        assert data["review_reasons"] == ["nationality_not_evaluated"]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend-rag/backend/tests/routers/test_visa_oracle_handoff.py
+++ b/apps/backend-rag/backend/tests/routers/test_visa_oracle_handoff.py
@@ -1,0 +1,245 @@
+"""PR0 safety freeze (W3) — /handoff must resolve the recommended visa name
+and price ONLY from the server-persisted `visa_oracle_sessions` snapshot
+(itself PricingService-derived, written by /recommend), never from the
+client-posted `recommended_visas`/prices in the HandoffRequest body.
+
+Round2 spec §6.2 handoff row: "Client-supplied recommendations, prices, and
+quiz facts are ignored and eventually removed." product-design.md §2 lists
+the untrusted handoff path among the confirmed P0 claims.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.requests import Request
+
+
+class _AcquireCM:
+    """Minimal async context manager mimicking `pool.acquire()`."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+def _fake_pool(fetchrow_return):
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=fetchrow_return)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+    return pool, conn
+
+
+def _build_request() -> Request:
+    return Request({"type": "http", "headers": []})
+
+
+def _stub_telegram(monkeypatch):
+    fake_telegram = MagicMock()
+    fake_telegram.send_message = AsyncMock()
+    monkeypatch.setattr(
+        "backend.services.integrations.telegram_bot_service.telegram_bot",
+        fake_telegram,
+    )
+    return fake_telegram
+
+
+@pytest.mark.asyncio
+async def test_handoff_uses_server_price_ignores_client_price(monkeypatch):
+    from backend.app.routers import visa_oracle as mod
+
+    server_row = {
+        "quiz_answers": json.dumps({"nationality": "US", "purpose": "work", "duration": "long"}),
+        "recommended_visas": json.dumps(
+            [{"visa_name": "Working KITAS", "price": "18.000.000 IDR", "score": 4.0}]
+        ),
+    }
+    pool, _conn = _fake_pool(server_row)
+    _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="s1",
+        quiz_answers={"nationality": "US", "purpose": "work", "duration": "long"},
+        recommended_visas=[{"visa_name": "FREE VISA SCAM", "price": "1 IDR"}],
+        messages=[],
+    )
+    resp = await mod.handoff(_build_request(), body, db_pool=pool)
+
+    assert resp.success is True
+    assert "Working" in resp.whatsapp_url
+    assert "KITAS" in resp.whatsapp_url
+    assert "18.000.000" in resp.whatsapp_url
+    assert "FREE" not in resp.whatsapp_url
+    assert "SCAM" not in resp.whatsapp_url
+
+
+@pytest.mark.asyncio
+async def test_handoff_no_price_when_session_not_found(monkeypatch):
+    from backend.app.routers import visa_oracle as mod
+
+    pool, _conn = _fake_pool(None)  # no persisted row for this session_id
+    _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="unknown-session",
+        quiz_answers={"nationality": "US", "purpose": "work", "duration": "long"},
+        recommended_visas=[{"visa_name": "Should Be Ignored", "price": "999 IDR"}],
+        messages=[],
+    )
+    resp = await mod.handoff(_build_request(), body, db_pool=pool)
+
+    assert resp.success is True
+    assert "Should Be Ignored" not in resp.whatsapp_url
+    assert "contact" in resp.whatsapp_url
+    assert "pricing" in resp.whatsapp_url
+
+
+@pytest.mark.asyncio
+async def test_handoff_logs_divergence_warning(monkeypatch, caplog):
+    from backend.app.routers import visa_oracle as mod
+
+    server_row = {
+        "quiz_answers": json.dumps({}),
+        "recommended_visas": json.dumps(
+            [{"visa_name": "Working KITAS", "price": "18.000.000 IDR", "score": 4.0}]
+        ),
+    }
+    pool, _conn = _fake_pool(server_row)
+    _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="s1",
+        quiz_answers={"nationality": "US"},
+        recommended_visas=[{"visa_name": "Different Visa", "price": "1 IDR"}],
+        messages=[],
+    )
+    with caplog.at_level("WARNING"):
+        await mod.handoff(_build_request(), body, db_pool=pool)
+
+    assert any("diverges" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handoff_no_divergence_warning_when_client_matches_server(monkeypatch, caplog):
+    """Innocence test: identical client/server top pick logs nothing."""
+    from backend.app.routers import visa_oracle as mod
+
+    server_row = {
+        "quiz_answers": json.dumps({}),
+        "recommended_visas": json.dumps(
+            [{"visa_name": "Working KITAS", "price": "18.000.000 IDR", "score": 4.0}]
+        ),
+    }
+    pool, _conn = _fake_pool(server_row)
+    _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="s1",
+        quiz_answers={"nationality": "US"},
+        recommended_visas=[{"visa_name": "Working KITAS", "price": "18.000.000 IDR"}],
+        messages=[],
+    )
+    with caplog.at_level("WARNING"):
+        await mod.handoff(_build_request(), body, db_pool=pool)
+
+    assert not any("diverges" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handoff_uses_server_visas_for_telegram_summary(monkeypatch):
+    from backend.app.routers import visa_oracle as mod
+
+    server_row = {
+        "quiz_answers": json.dumps({"nationality": "DE", "purpose": "retire", "duration": "long"}),
+        "recommended_visas": json.dumps(
+            [{"visa_name": "Retirement KITAS", "price": "9.000.000 IDR", "score": 3.0}]
+        ),
+    }
+    pool, _conn = _fake_pool(server_row)
+    fake_telegram = _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="s1",
+        quiz_answers={"nationality": "DE", "purpose": "retire", "duration": "long"},
+        recommended_visas=[{"visa_name": "Not The Real One", "price": "0 IDR"}],
+        messages=[],
+    )
+    await mod.handoff(_build_request(), body, db_pool=pool)
+
+    fake_telegram.send_message.assert_awaited_once()
+    sent_text = fake_telegram.send_message.call_args.kwargs.get("text", "")
+    assert "Retirement KITAS" in sent_text
+    assert "Not The Real One" not in sent_text
+
+
+# ---------------------------------------------------------------------------
+# _fetch_session_snapshot — pure helper unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_session_snapshot_returns_none_on_db_error():
+    from backend.app.routers import visa_oracle as mod
+
+    pool = MagicMock()
+
+    def _raise(*_a, **_kw):
+        raise RuntimeError("connection refused")
+
+    pool.acquire = MagicMock(side_effect=_raise)
+
+    result = await mod._fetch_session_snapshot(pool, "s1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_session_snapshot_returns_none_when_no_row():
+    from backend.app.routers import visa_oracle as mod
+
+    pool, _conn = _fake_pool(None)
+    result = await mod._fetch_session_snapshot(pool, "s1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_session_snapshot_decodes_json_strings():
+    from backend.app.routers import visa_oracle as mod
+
+    row = {
+        "quiz_answers": json.dumps({"nationality": "US"}),
+        "recommended_visas": json.dumps([{"visa_name": "X"}]),
+    }
+    pool, _conn = _fake_pool(row)
+
+    result = await mod._fetch_session_snapshot(pool, "s1")
+    assert result == {
+        "quiz_answers": {"nationality": "US"},
+        "recommended_visas": [{"visa_name": "X"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_session_snapshot_handles_already_decoded_values():
+    """asyncpg can return jsonb as already-decoded objects depending on
+    codec configuration — handle both shapes defensively."""
+    from backend.app.routers import visa_oracle as mod
+
+    row = {
+        "quiz_answers": {"nationality": "US"},
+        "recommended_visas": [{"visa_name": "X"}],
+    }
+    pool, _conn = _fake_pool(row)
+
+    result = await mod._fetch_session_snapshot(pool, "s1")
+    assert result == {
+        "quiz_answers": {"nationality": "US"},
+        "recommended_visas": [{"visa_name": "X"}],
+    }

--- a/apps/backend-rag/backend/tests/routers/test_visa_oracle_handoff.py
+++ b/apps/backend-rag/backend/tests/routers/test_visa_oracle_handoff.py
@@ -16,6 +16,32 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from starlette.requests import Request
 
+# ---------------------------------------------------------------------------
+# FIX-5 (Codex red-team P1 #4, client-trusted quiz + Markdown injection) and
+# FIX-6 (Codex red-team P1 #5, async-persist race) additions live in this
+# same file — they extend the existing W3 (server-authoritative price)
+# coverage above with: (a) quiz_answers also preferring the server snapshot,
+# (b) an explicit UNVERIFIED marker instead of silent suppression on a
+# body-only lead, (c) retry behavior for both the snapshot read and the
+# handoff-triggered UPDATE.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch):
+    """FIX-6 added real `asyncio.sleep` backoff to the retry paths this file
+    exercises — default it to a no-op so the module stays fast. The
+    dedicated retry-behavior tests below re-`monkeypatch.setattr` their own
+    sleep stub AFTER this fixture runs (same `monkeypatch` instance per
+    test), which simply overrides this default when they need to observe
+    `sleep_calls`."""
+    from backend.app.routers import visa_oracle as mod
+
+    async def _noop_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _noop_sleep)
+
 
 class _AcquireCM:
     """Minimal async context manager mimicking `pool.acquire()`."""
@@ -243,3 +269,328 @@ async def test_fetch_session_snapshot_handles_already_decoded_values():
         "quiz_answers": {"nationality": "US"},
         "recommended_visas": [{"visa_name": "X"}],
     }
+
+
+# ---------------------------------------------------------------------------
+# FIX-5 — quiz_answers also prefer the server-persisted snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handoff_uses_server_quiz_answers_for_whatsapp_url(monkeypatch):
+    """FIX-5 (Codex red-team P1 #4): quiz facts (nationality/purpose/
+    duration) also come from the server-persisted snapshot when one exists
+    — not the client body. A stale or manipulated client body must not
+    silently swap what's presented in the WhatsApp deep-link."""
+    from backend.app.routers import visa_oracle as mod
+
+    server_row = {
+        "quiz_answers": json.dumps(
+            {"nationality": "Germany", "purpose": "retire", "duration": "long"}
+        ),
+        "recommended_visas": json.dumps(
+            [{"visa_name": "Retirement KITAS", "price": "9.000.000 IDR", "score": 3.0}]
+        ),
+    }
+    pool, _conn = _fake_pool(server_row)
+    _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="s1",
+        quiz_answers={"nationality": "France", "purpose": "visit", "duration": "short"},
+        recommended_visas=[],
+        messages=[],
+    )
+    resp = await mod.handoff(_build_request(), body, db_pool=pool)
+
+    assert "Germany" in resp.whatsapp_url
+    assert "France" not in resp.whatsapp_url
+
+
+@pytest.mark.asyncio
+async def test_handoff_uses_server_quiz_answers_for_telegram_summary(monkeypatch):
+    """Same server-preference for the Telegram lead summary."""
+    from backend.app.routers import visa_oracle as mod
+
+    server_row = {
+        "quiz_answers": json.dumps(
+            {"nationality": "Germany", "purpose": "retire", "duration": "long"}
+        ),
+        "recommended_visas": json.dumps(
+            [{"visa_name": "Retirement KITAS", "price": "9.000.000 IDR", "score": 3.0}]
+        ),
+    }
+    pool, _conn = _fake_pool(server_row)
+    fake_telegram = _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="s1",
+        quiz_answers={"nationality": "France", "purpose": "visit", "duration": "short"},
+        recommended_visas=[],
+        messages=[],
+    )
+    await mod.handoff(_build_request(), body, db_pool=pool)
+
+    sent_text = fake_telegram.send_message.call_args.kwargs.get("text", "")
+    assert "Germany" in sent_text
+    assert "France" not in sent_text
+
+
+@pytest.mark.asyncio
+async def test_handoff_falls_back_to_body_quiz_answers_when_no_snapshot(monkeypatch):
+    """Innocence: when there is genuinely no server snapshot (session never
+    persisted / not found), the body-posted quiz_answers are the only
+    source available — falling back to them is correct, not a regression."""
+    from backend.app.routers import visa_oracle as mod
+
+    pool, _conn = _fake_pool(None)
+    _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="unknown-session",
+        quiz_answers={"nationality": "France", "purpose": "visit", "duration": "short"},
+        recommended_visas=[],
+        messages=[],
+    )
+    resp = await mod.handoff(_build_request(), body, db_pool=pool)
+
+    assert "France" in resp.whatsapp_url
+
+
+@pytest.mark.asyncio
+async def test_handoff_body_only_lead_marked_unverified_not_suppressed(monkeypatch):
+    """FIX-5: a body-only handoff (no server session at all) must still
+    fire the Telegram lead — leads matter commercially — but tagged
+    UNVERIFIED rather than silently suppressed or presented as verified."""
+    from backend.app.routers import visa_oracle as mod
+
+    pool, _conn = _fake_pool(None)  # no persisted row — genuinely no session
+    fake_telegram = _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="unknown-session",
+        quiz_answers={"nationality": "France", "purpose": "visit", "duration": "short"},
+        recommended_visas=[],
+        messages=[],
+    )
+    resp = await mod.handoff(_build_request(), body, db_pool=pool)
+
+    assert resp.telegram_sent is True
+    fake_telegram.send_message.assert_awaited_once()
+    sent_text = fake_telegram.send_message.call_args.kwargs.get("text", "")
+    assert "UNVERIFIED" in sent_text
+
+
+@pytest.mark.asyncio
+async def test_handoff_verified_session_has_no_unverified_marker(monkeypatch):
+    """Innocence: a genuinely server-verified session must NOT carry the
+    UNVERIFIED marker."""
+    from backend.app.routers import visa_oracle as mod
+
+    server_row = {
+        "quiz_answers": json.dumps({"nationality": "US", "purpose": "work", "duration": "long"}),
+        "recommended_visas": json.dumps(
+            [{"visa_name": "Working KITAS", "price": "18.000.000 IDR", "score": 4.0}]
+        ),
+    }
+    pool, _conn = _fake_pool(server_row)
+    fake_telegram = _stub_telegram(monkeypatch)
+
+    body = mod.HandoffRequest(
+        session_id="s1",
+        quiz_answers={"nationality": "US", "purpose": "work", "duration": "long"},
+        recommended_visas=[],
+        messages=[],
+    )
+    await mod.handoff(_build_request(), body, db_pool=pool)
+
+    sent_text = fake_telegram.send_message.call_args.kwargs.get("text", "")
+    assert "UNVERIFIED" not in sent_text
+
+
+# ---------------------------------------------------------------------------
+# FIX-6 — async-persist race: retry helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_with_retry_succeeds_on_second_attempt(monkeypatch):
+    """FIX-6 (Codex red-team P1 #5): the first read misses (INSERT still in
+    flight), the second succeeds — the retry must not give up after one
+    None."""
+    from backend.app.routers import visa_oracle as mod
+
+    calls = {"n": 0}
+
+    async def _fake_fetch(_pool, _sid):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return {"quiz_answers": {"nationality": "US"}, "recommended_visas": [{"visa_name": "X"}]}
+
+    monkeypatch.setattr(mod, "_fetch_session_snapshot", _fake_fetch)
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _fake_sleep)
+
+    result = await mod._fetch_session_snapshot_with_retry(MagicMock(), "s1")
+
+    assert result == {
+        "quiz_answers": {"nationality": "US"},
+        "recommended_visas": [{"visa_name": "X"}],
+    }
+    assert calls["n"] == 2
+    assert sleep_calls == [0.4]
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_with_retry_gives_up_after_max_attempts(monkeypatch):
+    """Still None after every attempt falls through to the existing safe
+    no-price path — never raises, never hangs."""
+    from backend.app.routers import visa_oracle as mod
+
+    calls = {"n": 0}
+
+    async def _fake_fetch(_pool, _sid):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(mod, "_fetch_session_snapshot", _fake_fetch)
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _fake_sleep)
+
+    result = await mod._fetch_session_snapshot_with_retry(MagicMock(), "s1")
+
+    assert result is None
+    assert calls["n"] == 3
+    assert sleep_calls == [0.4, 0.4]
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_with_retry_no_sleep_when_immediately_found(monkeypatch):
+    """Innocence: the common case (session already persisted) must not pay
+    any retry latency."""
+    from backend.app.routers import visa_oracle as mod
+
+    calls = {"n": 0}
+
+    async def _fake_fetch(_pool, _sid):
+        calls["n"] += 1
+        return {"quiz_answers": {}, "recommended_visas": []}
+
+    monkeypatch.setattr(mod, "_fetch_session_snapshot", _fake_fetch)
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _fake_sleep)
+
+    result = await mod._fetch_session_snapshot_with_retry(MagicMock(), "s1")
+
+    assert result == {"quiz_answers": {}, "recommended_visas": []}
+    assert calls["n"] == 1
+    assert sleep_calls == []
+
+
+@pytest.mark.asyncio
+async def test_persist_session_handoff_retries_once_when_row_not_found(monkeypatch):
+    """FIX-6: the UPDATE runs before /recommend's INSERT lands (0 rows
+    affected) — retry once after 1s, then log-and-continue either way."""
+    from backend.app.routers import visa_oracle as mod
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=["UPDATE 0", "UPDATE 1"])
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _fake_sleep)
+
+    await mod._persist_session_handoff(pool, "s1")
+
+    assert conn.execute.await_count == 2
+    assert sleep_calls == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_persist_session_handoff_logs_and_continues_when_row_never_appears(
+    monkeypatch, caplog
+):
+    """Still 0 rows after the retry — must log and return, never raise."""
+    from backend.app.routers import visa_oracle as mod
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="UPDATE 0")
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+
+    async def _fake_sleep(seconds):
+        return None
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _fake_sleep)
+
+    with caplog.at_level("INFO"):
+        await mod._persist_session_handoff(pool, "s1")
+
+    assert conn.execute.await_count == 2
+    assert any("after 1s retry" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_persist_session_handoff_no_retry_when_row_found_immediately(monkeypatch):
+    """Innocence: the common case succeeds on the first UPDATE — no sleep,
+    no second query."""
+    from backend.app.routers import visa_oracle as mod
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _fake_sleep)
+
+    await mod._persist_session_handoff(pool, "s1")
+
+    assert conn.execute.await_count == 1
+    assert sleep_calls == []
+
+
+class TestUpdateRowCount:
+    """Unit tests for the asyncpg command-status parser backing FIX-6."""
+
+    def test_parses_update_n(self) -> None:
+        from backend.app.routers import visa_oracle as mod
+
+        assert mod._update_row_count("UPDATE 1") == 1
+
+    def test_parses_update_zero(self) -> None:
+        from backend.app.routers import visa_oracle as mod
+
+        assert mod._update_row_count("UPDATE 0") == 0
+
+    def test_returns_zero_on_none(self) -> None:
+        from backend.app.routers import visa_oracle as mod
+
+        assert mod._update_row_count(None) == 0
+
+    def test_returns_zero_on_malformed_status(self) -> None:
+        from backend.app.routers import visa_oracle as mod
+
+        assert mod._update_row_count("not-a-status") == 0

--- a/apps/backend-rag/backend/tests/routers/test_visa_oracle_handoff.py
+++ b/apps/backend-rag/backend/tests/routers/test_visa_oracle_handoff.py
@@ -501,13 +501,15 @@ async def test_fetch_snapshot_with_retry_no_sleep_when_immediately_found(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_persist_session_handoff_retries_once_when_row_not_found(monkeypatch):
-    """FIX-6: the UPDATE runs before /recommend's INSERT lands (0 rows
-    affected) — retry once after 1s, then log-and-continue either way."""
+async def test_persist_session_handoff_retries_across_three_attempts_over_10s(monkeypatch):
+    """R2-E (Codex re-review, F5 residue): the UPDATE runs before
+    /recommend's INSERT lands (0 rows affected) on the first TWO attempts,
+    succeeds on the third — total 3 attempts, ~10s of backoff (2 gaps ×
+    5s), all inside the already-`spawn()`'d background task."""
     from backend.app.routers import visa_oracle as mod
 
     conn = AsyncMock()
-    conn.execute = AsyncMock(side_effect=["UPDATE 0", "UPDATE 1"])
+    conn.execute = AsyncMock(side_effect=["UPDATE 0", "UPDATE 0", "UPDATE 1"])
     pool = MagicMock()
     pool.acquire = MagicMock(return_value=_AcquireCM(conn))
 
@@ -520,15 +522,17 @@ async def test_persist_session_handoff_retries_once_when_row_not_found(monkeypat
 
     await mod._persist_session_handoff(pool, "s1")
 
-    assert conn.execute.await_count == 2
-    assert sleep_calls == [1.0]
+    assert conn.execute.await_count == 3
+    assert sleep_calls == [5.0, 5.0]
 
 
 @pytest.mark.asyncio
 async def test_persist_session_handoff_logs_and_continues_when_row_never_appears(
     monkeypatch, caplog
 ):
-    """Still 0 rows after the retry — must log and return, never raise."""
+    """Still 0 rows after all 3 attempts — must log and return, never
+    raise. This is the DECLARED-ACCEPTABLE residue: a row that lands more
+    than ~10s late is lost (analytics-grade telemetry, not a gate)."""
     from backend.app.routers import visa_oracle as mod
 
     conn = AsyncMock()
@@ -544,14 +548,14 @@ async def test_persist_session_handoff_logs_and_continues_when_row_never_appears
     with caplog.at_level("INFO"):
         await mod._persist_session_handoff(pool, "s1")
 
-    assert conn.execute.await_count == 2
-    assert any("after 1s retry" in r.message for r in caplog.records)
+    assert conn.execute.await_count == 3
+    assert any("after 3 attempts" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_persist_session_handoff_no_retry_when_row_found_immediately(monkeypatch):
     """Innocence: the common case succeeds on the first UPDATE — no sleep,
-    no second query."""
+    no second/third query."""
     from backend.app.routers import visa_oracle as mod
 
     conn = AsyncMock()
@@ -570,6 +574,29 @@ async def test_persist_session_handoff_no_retry_when_row_found_immediately(monke
 
     assert conn.execute.await_count == 1
     assert sleep_calls == []
+
+
+@pytest.mark.asyncio
+async def test_persist_session_handoff_succeeds_on_second_attempt(monkeypatch):
+    """Middle case: row appears on the 2nd attempt — 2 queries, 1 sleep."""
+    from backend.app.routers import visa_oracle as mod
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=["UPDATE 0", "UPDATE 1"])
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _fake_sleep)
+
+    await mod._persist_session_handoff(pool, "s1")
+
+    assert conn.execute.await_count == 2
+    assert sleep_calls == [5.0]
 
 
 class TestUpdateRowCount:

--- a/apps/backend-rag/backend/tests/services/test_visa_oracle_service.py
+++ b/apps/backend-rag/backend/tests/services/test_visa_oracle_service.py
@@ -308,6 +308,97 @@ def test_build_telegram_summary_contains_nationality(service: VisaOracleService)
 
 
 # ---------------------------------------------------------------------------
+# build_telegram_summary — FIX-5 (Codex red-team P1 #4) Markdown escaping
+# ---------------------------------------------------------------------------
+#
+# `build_telegram_summary` is sent with `parse_mode="Markdown"` (legacy
+# Telegram v1), which treats `_`, `*`, backtick, and `[` as formatting
+# syntax. A user who types e.g. `nationality: "_pwned_"` into the quiz can
+# otherwise inject formatting/link-like structure into the message Damar's
+# team reads. Deliberately NOT the full MarkdownV2 char set — legacy v1
+# doesn't recognize backslash as an escape prefix outside these 4 chars, so
+# escaping e.g. `.`/`-`/`!` would insert a literal stray backslash instead
+# of hiding one.
+
+
+def test_build_telegram_summary_escapes_underscore_in_nationality(
+    service: VisaOracleService,
+) -> None:
+    """Guilt: an underscore in a user-controlled field must not survive
+    unescaped — Markdown v1 would render `_pwned_` as italic."""
+    summary = service.build_telegram_summary(
+        session_id="x" * 32,
+        quiz_answers={"nationality": "_pwned_", "purpose": "visit", "duration": "short"},
+        recommended_visas=[],
+        messages=[],
+        language="en",
+    )
+    assert "_pwned_" not in summary
+    assert "\\_pwned\\_" in summary
+
+
+def test_build_telegram_summary_escapes_asterisk_and_backtick(
+    service: VisaOracleService,
+) -> None:
+    """Guilt: `*` (bold) and backtick (code span) must also be escaped."""
+    summary = service.build_telegram_summary(
+        session_id="x" * 32,
+        quiz_answers={"nationality": "US", "purpose": "*bold* `code`", "duration": "short"},
+        recommended_visas=[],
+        messages=[],
+        language="en",
+    )
+    assert "*bold*" not in summary
+    assert "`code`" not in summary
+    assert "\\*bold\\*" in summary
+    assert "\\`code\\`" in summary
+
+
+def test_build_telegram_summary_escapes_visa_name_and_price(
+    service: VisaOracleService,
+) -> None:
+    """Guilt: `visa_name`/`price` in `recommended_visas` are also
+    user-influenced (they trace back to a client-declared session in the
+    body-only handoff fallback path) — defense-in-depth even though the
+    router now resolves them server-side for the verified path."""
+    summary = service.build_telegram_summary(
+        session_id="x" * 32,
+        quiz_answers={"nationality": "US", "purpose": "work", "duration": "long"},
+        recommended_visas=[{"visa_name": "[Fake_Visa]", "price": "1_000_000 IDR", "score": 1.0}],
+        messages=[],
+        language="en",
+    )
+    assert "[Fake_Visa]" not in summary
+    assert "\\[Fake\\_Visa]" in summary
+
+
+def test_build_telegram_summary_plain_text_unaffected(service: VisaOracleService) -> None:
+    """Innocence: ordinary text with none of the 4 special chars renders
+    byte-for-byte unchanged — no stray backslashes inserted."""
+    summary = service.build_telegram_summary(
+        session_id="x" * 32,
+        quiz_answers={"nationality": "Brazilian", "purpose": "retire", "duration": "long"},
+        recommended_visas=[],
+        messages=[],
+        language="en",
+    )
+    assert "\\" not in summary
+
+
+def test_escape_telegram_markdown_v1_only_escapes_four_chars() -> None:
+    """Unit test for the escape helper directly: legacy Markdown v1 doesn't
+    treat `.`/`-`/`!`/`(`/`)` as syntax — escaping them would introduce a
+    stray literal backslash into the rendered message rather than hiding
+    one, so they must pass through untouched."""
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _escape_telegram_markdown_v1,
+    )
+
+    result = _escape_telegram_markdown_v1("a_b*c`d[e.f-g!h(i)j")
+    assert result == "a\\_b\\*c\\`d\\[e.f-g!h(i)j"
+
+
+# ---------------------------------------------------------------------------
 # hash_ip and generate_session_id
 # ---------------------------------------------------------------------------
 

--- a/apps/backend-rag/backend/tests/services/test_visa_oracle_service.py
+++ b/apps/backend-rag/backend/tests/services/test_visa_oracle_service.py
@@ -399,6 +399,125 @@ def test_escape_telegram_markdown_v1_only_escapes_four_chars() -> None:
 
 
 # ---------------------------------------------------------------------------
+# R2-B (Codex re-review NEW-BUG, F4) — code-span sanitization for
+# session_id/language, distinct from escaping (which is invalid inside a
+# Telegram Markdown code span).
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_session_id_strips_disallowed_chars() -> None:
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _sanitize_code_entity_session_id,
+    )
+
+    assert _sanitize_code_entity_session_id("abc`*_[123") == "abc_123"
+
+
+def test_sanitize_session_id_truncates_to_40_chars() -> None:
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _sanitize_code_entity_session_id,
+    )
+
+    result = _sanitize_code_entity_session_id("a" * 100)
+    assert result == "a" * 40
+
+
+def test_sanitize_session_id_falls_back_to_unknown_when_emptied() -> None:
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _sanitize_code_entity_session_id,
+    )
+
+    assert _sanitize_code_entity_session_id("`*[]()~>!.,") == "unknown"
+
+
+def test_sanitize_session_id_passes_through_valid_charset_unchanged() -> None:
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _sanitize_code_entity_session_id,
+    )
+
+    assert _sanitize_code_entity_session_id("deadbeef-1234_5678") == "deadbeef-1234_5678"
+
+
+def test_sanitize_language_strips_disallowed_chars() -> None:
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _sanitize_code_entity_language,
+    )
+
+    assert _sanitize_code_entity_language("en`*_[9") == "en"
+
+
+def test_sanitize_language_truncates_to_8_chars() -> None:
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _sanitize_code_entity_language,
+    )
+
+    assert _sanitize_code_entity_language("abcdefghij") == "abcdefgh"
+
+
+def test_sanitize_language_falls_back_to_unknown_when_emptied() -> None:
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _sanitize_code_entity_language,
+    )
+
+    assert _sanitize_code_entity_language("123`*_[") == "unknown"
+
+
+def test_sanitize_language_lowercases_and_passes_through_hyphen() -> None:
+    from backend.services.visa_oracle.visa_oracle_service import (
+        _sanitize_code_entity_language,
+    )
+
+    assert _sanitize_code_entity_language("EN-us") == "en-us"
+
+
+def test_build_telegram_summary_session_id_with_backtick_does_not_break_entity(
+    service: VisaOracleService,
+) -> None:
+    """R2-B adversarial test (Codex re-review): a `session_id` containing a
+    backtick plus `*_[` characters must not break the code-span entity nor
+    inject formatting into the surrounding message. Structural check: every
+    backtick in the summary is part of a properly PAIRED code span (an even
+    total count), and none of the injected symbols survive verbatim."""
+    malicious_session_id = "abc`*_[def`123"
+    summary = service.build_telegram_summary(
+        session_id=malicious_session_id,
+        quiz_answers={"nationality": "US", "purpose": "work", "duration": "long"},
+        recommended_visas=[],
+        messages=[],
+        language="en",
+    )
+
+    # The raw malicious payload must not appear anywhere in the output.
+    assert malicious_session_id not in summary
+    assert "abc`*_[def`123" not in summary
+
+    # Every backtick present belongs to a well-formed code span — an odd
+    # count would mean a span was left open (or one was force-closed
+    # early), corrupting the rest of the message's formatting.
+    assert summary.count("`") % 2 == 0
+
+    # The sanitized session_id keeps only the whitelisted charset — no
+    # backtick/asterisk/underscore/bracket survives into the code span.
+    assert "abc_def123"[:12] in summary or "abc_def" in summary
+
+
+def test_build_telegram_summary_language_with_backtick_does_not_break_entity(
+    service: VisaOracleService,
+) -> None:
+    """Same adversarial property for `language`."""
+    summary = service.build_telegram_summary(
+        session_id="x" * 32,
+        quiz_answers={"nationality": "US", "purpose": "work", "duration": "long"},
+        recommended_visas=[],
+        messages=[],
+        language="en`*_[injected",
+    )
+
+    assert "en`*_[injected" not in summary
+    assert summary.count("`") % 2 == 0
+
+
+# ---------------------------------------------------------------------------
 # hash_ip and generate_session_id
 # ---------------------------------------------------------------------------
 

--- a/apps/backend-rag/backend/tests/services/visa_oracle/test_chat_obsolete_code.py
+++ b/apps/backend-rag/backend/tests/services/visa_oracle/test_chat_obsolete_code.py
@@ -60,8 +60,10 @@ def _weak_search(score: float = 0.10) -> _StubSearch:
 
 @pytest.mark.asyncio
 async def test_obsolete_code_weak_evidence_stays_abstain(monkeypatch):
-    """B211A mentioned + top_score below 0.30 -> confidence stays ABSTAIN and
-    the LLM is never called."""
+    """B211A mentioned + top_score below 0.30 -> confidence stays ABSTAIN,
+    the LLM is never called, and (FIX-7, Codex red-team P2 #6) the answer is
+    the DETERMINISTIC zero-LLM obsolete-code template — not the generic
+    fallback, and not a generated explanation."""
     from backend.app.routers import visa_oracle as mod
 
     monkeypatch.setattr(
@@ -79,7 +81,10 @@ async def test_obsolete_code_weak_evidence_stays_abstain(monkeypatch):
 
     assert resp.confidence == mod.CONFIDENCE_ABSTAIN
     assert resp.sources == []
-    assert resp.answer == mod.ABSTAIN_FALLBACK_BY_LANG["en"]
+    assert resp.answer == mod._obsolete_code_static_answer(("B211A", "irrelevant"))
+    assert resp.answer != mod.ABSTAIN_FALLBACK_BY_LANG["en"]
+    assert "B211A" in resp.answer
+    assert "C1" in resp.answer
 
 
 @pytest.mark.asyncio
@@ -182,3 +187,81 @@ async def test_obsolete_code_strong_evidence_still_answers_normally(monkeypatch)
 
     assert resp.confidence == mod.CONFIDENCE_NORMAL
     assert "C1" in resp.answer
+
+
+@pytest.mark.asyncio
+async def test_high_score_but_empty_content_stays_abstain(monkeypatch):
+    """FIX-4 (Codex red-team P1 #3, empty-content generation): a hit can
+    carry a real similarity score (0.9, well past the 0.55 NORMAL floor)
+    but empty `content` — nothing for the LLM to ground on. Guilt: this
+    must ABSTAIN, not reach generation on an empty context string."""
+    from backend.app.routers import visa_oracle as mod
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _StubSearch([{"content": "", "score": 0.9, "source": "x"}]),
+    )
+    monkeypatch.setattr(
+        "backend.llm.genai_client.get_genai_client",
+        lambda: _NeverCalledGemini(),
+    )
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="What visa do I need for surfing?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.confidence == mod.CONFIDENCE_ABSTAIN
+    assert resp.sources == []
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_content_stays_abstain(monkeypatch):
+    """Guilt (variant): whitespace-only content is not "usable" content
+    either — same ABSTAIN outcome as a fully empty string."""
+    from backend.app.routers import visa_oracle as mod
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _StubSearch([{"content": "   \n\t  ", "score": 0.9, "source": "x"}]),
+    )
+    monkeypatch.setattr(
+        "backend.llm.genai_client.get_genai_client",
+        lambda: _NeverCalledGemini(),
+    )
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="What visa do I need for surfing?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.confidence == mod.CONFIDENCE_ABSTAIN
+
+
+@pytest.mark.asyncio
+async def test_mixed_results_empty_content_row_dropped_real_content_kept(monkeypatch):
+    """Innocence: a high-score EMPTY-content row alongside a genuine
+    lower-score row with real content must not push the empty row's score
+    into `top_score` — the filter runs before top_score is computed, so
+    the surviving real row's score (0.9 here) legitimately drives NORMAL."""
+    from backend.app.routers import visa_oracle as mod
+
+    class _Gemini:
+        async def generate_content(self, *, contents, **_kw):
+            return {"text": "Real grounded answer."}
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _StubSearch(
+            [
+                {"content": "", "score": 0.95, "source": "empty-but-scored"},
+                {"content": "Real visa content here.", "score": 0.9, "source": "real"},
+            ]
+        ),
+    )
+    monkeypatch.setattr("backend.llm.genai_client.get_genai_client", lambda: _Gemini())
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="What visa do I need for surfing?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.confidence == mod.CONFIDENCE_NORMAL
+    assert resp.sources == ["real"]

--- a/apps/backend-rag/backend/tests/services/visa_oracle/test_chat_obsolete_code.py
+++ b/apps/backend-rag/backend/tests/services/visa_oracle/test_chat_obsolete_code.py
@@ -1,0 +1,184 @@
+"""PR0 safety freeze (W2) — tests for the removal of the ABSTAIN->CAUTIOUS
+obsolete-code promotion in `visa_oracle.chat()`.
+
+Prior behavior (round2 spec §6.6 step 2 / product-design.md §2 claim #2):
+when a user mentioned a retired visa code (e.g. B211A) AND the KB evidence
+was too weak to answer (top_score < 0.30, normally ABSTAIN), the endpoint
+promoted the outcome to CAUTIOUS "on the strength of pretraining context +
+SYSTEM_PROMPT rules" and let Gemini generate a free-form answer with no
+grounded evidence. That promotion is removed: weak evidence now ALWAYS
+abstains, obsolete code or not. The obsolete-code signal is preserved only
+as a `review_reasons` annotation on the (still-safe) ABSTAIN response.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Must be set before any backend imports load config/settings.
+os.environ.setdefault("JWT_SECRET_KEY", "test_jwt_secret_key_for_testing_only_min_32_chars_long")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-key-for-testing-only-nuzantara")
+os.environ.setdefault("GOOGLE_API_KEY", "test-google-api-key")
+os.environ.setdefault("API_KEYS", "test_api_key_1,test_api_key_2")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("ENVIRONMENT", "test")
+
+import pytest
+from starlette.requests import Request
+
+
+def _build_request() -> Request:
+    return Request({"type": "http", "headers": []})
+
+
+class _StubSearch:
+    """Hybrid search stub returning a fixed result set."""
+
+    def __init__(self, results: list) -> None:
+        self._results = results
+
+    async def search_hybrid(self, **_kw):
+        return {"results": self._results}
+
+
+class _NeverCalledGemini:
+    """Fails the test loudly if the LLM is invoked — weak evidence must
+    never reach generation, obsolete code or not."""
+
+    async def generate_content(self, *_a, **_kw):
+        raise AssertionError(
+            "Gemini must not be called on weak evidence — ABSTAIN must not "
+            "be promoted to a generated answer (PR0 safety freeze, W2)."
+        )
+
+
+def _weak_search(score: float = 0.10) -> _StubSearch:
+    return _StubSearch([{"content": "barely relevant snippet", "score": score, "source": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_obsolete_code_weak_evidence_stays_abstain(monkeypatch):
+    """B211A mentioned + top_score below 0.30 -> confidence stays ABSTAIN and
+    the LLM is never called."""
+    from backend.app.routers import visa_oracle as mod
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _weak_search(0.10),
+    )
+    monkeypatch.setattr(
+        "backend.llm.genai_client.get_genai_client",
+        lambda: _NeverCalledGemini(),
+    )
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="What about my B211A visa?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.confidence == mod.CONFIDENCE_ABSTAIN
+    assert resp.sources == []
+    assert resp.answer == mod.ABSTAIN_FALLBACK_BY_LANG["en"]
+
+
+@pytest.mark.asyncio
+async def test_obsolete_code_weak_evidence_sets_review_reasons(monkeypatch):
+    """The obsolete-code signal survives as a review_reasons annotation."""
+    from backend.app.routers import visa_oracle as mod
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _weak_search(0.10),
+    )
+    monkeypatch.setattr(
+        "backend.llm.genai_client.get_genai_client",
+        lambda: _NeverCalledGemini(),
+    )
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="What about my B211A visa?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.review_reasons == ["obsolete_code_mentioned:B211A"]
+
+
+@pytest.mark.asyncio
+async def test_obsolete_code_no_search_results_stays_abstain_with_reason(monkeypatch):
+    """Same safety property when hybrid search returns zero rows at all
+    (the other ABSTAIN early-return point in chat())."""
+    from backend.app.routers import visa_oracle as mod
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _StubSearch([]),
+    )
+    monkeypatch.setattr(
+        "backend.llm.genai_client.get_genai_client",
+        lambda: _NeverCalledGemini(),
+    )
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="Is B211 still valid?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.confidence == mod.CONFIDENCE_ABSTAIN
+    assert resp.review_reasons == ["obsolete_code_mentioned:B211"]
+
+
+@pytest.mark.asyncio
+async def test_weak_evidence_without_obsolete_code_stays_abstain_no_reason(monkeypatch):
+    """Innocence test: the plain ABSTAIN path (no obsolete code mentioned)
+    is unaffected — review_reasons stays empty."""
+    from backend.app.routers import visa_oracle as mod
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _weak_search(0.10),
+    )
+    monkeypatch.setattr(
+        "backend.llm.genai_client.get_genai_client",
+        lambda: _NeverCalledGemini(),
+    )
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="What visa do I need for surfing?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.confidence == mod.CONFIDENCE_ABSTAIN
+    assert resp.review_reasons == []
+
+
+@pytest.mark.asyncio
+async def test_obsolete_code_strong_evidence_still_answers_normally(monkeypatch):
+    """Innocence test: a GENUINE strong match (top_score > 0.55) that
+    happens to mention an obsolete code is untouched — only the
+    weak-evidence promotion was unsafe, not obsolete-code mentions
+    in general."""
+    from backend.app.routers import visa_oracle as mod
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _StubSearch(
+            [
+                {
+                    "content": "B211A was retired; the tourism replacement is C1.",
+                    "score": 0.9,
+                    "source": "imigrasi.go.id",
+                }
+            ]
+        ),
+    )
+
+    class _Gemini:
+        async def generate_content(self, *, contents, **_kw):
+            return {"text": "B211A was retired — use C1 Visa Wisata instead."}
+
+    monkeypatch.setattr("backend.llm.genai_client.get_genai_client", lambda: _Gemini())
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="Is B211A still valid?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.confidence == mod.CONFIDENCE_NORMAL
+    assert "C1" in resp.answer

--- a/apps/backend-rag/backend/tests/services/visa_oracle/test_chat_obsolete_code.py
+++ b/apps/backend-rag/backend/tests/services/visa_oracle/test_chat_obsolete_code.py
@@ -81,7 +81,7 @@ async def test_obsolete_code_weak_evidence_stays_abstain(monkeypatch):
 
     assert resp.confidence == mod.CONFIDENCE_ABSTAIN
     assert resp.sources == []
-    assert resp.answer == mod._obsolete_code_static_answer(("B211A", "irrelevant"))
+    assert resp.answer == mod._obsolete_code_static_answer([("B211A", "irrelevant")])
     assert resp.answer != mod.ABSTAIN_FALLBACK_BY_LANG["en"]
     assert "B211A" in resp.answer
     assert "C1" in resp.answer
@@ -129,6 +129,37 @@ async def test_obsolete_code_no_search_results_stays_abstain_with_reason(monkeyp
 
     assert resp.confidence == mod.CONFIDENCE_ABSTAIN
     assert resp.review_reasons == ["obsolete_code_mentioned:B211"]
+
+
+@pytest.mark.asyncio
+async def test_multiple_obsolete_codes_both_named_in_answer_and_reasons(monkeypatch):
+    """R2-C guilt (Codex re-review NEW-BUG, F6): a message mentioning TWO
+    distinct retired codes (B211 and B211A) must not silently answer for
+    only the first match — both must appear in the deterministic answer
+    AND both must get their own review_reasons entry."""
+    from backend.app.routers import visa_oracle as mod
+
+    monkeypatch.setattr(
+        "backend.services.rag.hybrid_search.HybridSearchService",
+        lambda: _StubSearch([]),
+    )
+    monkeypatch.setattr(
+        "backend.llm.genai_client.get_genai_client",
+        lambda: _NeverCalledGemini(),
+    )
+
+    req = _build_request()
+    body = mod.ChatRequest(session_id="s1", message="Is B211 or B211A still valid?")
+    resp = await mod.chat(req, body, db_pool=None)
+
+    assert resp.confidence == mod.CONFIDENCE_ABSTAIN
+    assert "B211" in resp.answer
+    assert "B211A" in resp.answer
+    assert set(resp.review_reasons) == {
+        "obsolete_code_mentioned:B211",
+        "obsolete_code_mentioned:B211A",
+    }
+    assert len(resp.review_reasons) == 2
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/services/visa_oracle/test_chat_obsolete_code.py
+++ b/apps/backend-rag/backend/tests/services/visa_oracle/test_chat_obsolete_code.py
@@ -14,6 +14,7 @@ as a `review_reasons` annotation on the (still-safe) ABSTAIN response.
 from __future__ import annotations
 
 import os
+import re
 
 # Must be set before any backend imports load config/settings.
 os.environ.setdefault("JWT_SECRET_KEY", "test_jwt_secret_key_for_testing_only_min_32_chars_long")
@@ -136,7 +137,18 @@ async def test_multiple_obsolete_codes_both_named_in_answer_and_reasons(monkeypa
     """R2-C guilt (Codex re-review NEW-BUG, F6): a message mentioning TWO
     distinct retired codes (B211 and B211A) must not silently answer for
     only the first match — both must appear in the deterministic answer
-    AND both must get their own review_reasons entry."""
+    AND both must get their own review_reasons entry.
+
+    Round-3 nit (Codex): a bare `"B211" in answer` substring check is
+    itself a scar-family-#3 guard-over-match — INSIDE a test this time —
+    since it would also (trivially, uselessly) pass on "B211A" alone,
+    never actually proving B211 was named as its OWN entry. Assert
+    exact-boundary presence two independent ways instead: (1) each code
+    appears as its own enumerated "The visa code <CODE> ..." line, not
+    merely as a substring inside the other code's line; (2) a
+    word-boundary regex confirms `\bB211\b` can never match by landing
+    inside "B211A" (no boundary between the shared "211" and trailing
+    "A")."""
     from backend.app.routers import visa_oracle as mod
 
     monkeypatch.setattr(
@@ -153,8 +165,17 @@ async def test_multiple_obsolete_codes_both_named_in_answer_and_reasons(monkeypa
     resp = await mod.chat(req, body, db_pool=None)
 
     assert resp.confidence == mod.CONFIDENCE_ABSTAIN
-    assert "B211" in resp.answer
-    assert "B211A" in resp.answer
+
+    # Exact-boundary check #1: each code owns its own enumerated line.
+    code_lines = [line for line in resp.answer.splitlines() if line.startswith("The visa code ")]
+    mentioned_codes = {line.split("The visa code ", 1)[1].split(" ", 1)[0] for line in code_lines}
+    assert mentioned_codes == {"B211", "B211A"}
+    assert len(code_lines) == 2
+
+    # Exact-boundary check #2: word-boundary regex, independent method.
+    assert re.search(r"\bB211\b", resp.answer) is not None
+    assert re.search(r"\bB211A\b", resp.answer) is not None
+
     assert set(resp.review_reasons) == {
         "obsolete_code_mentioned:B211",
         "obsolete_code_mentioned:B211A",

--- a/apps/mouth/src/lib/visa-oracle/api.test.ts
+++ b/apps/mouth/src/lib/visa-oracle/api.test.ts
@@ -250,7 +250,7 @@ describe("parseRecommendResponse", () => {
     expect(parsed.visas).toEqual([]);
   });
 
-  it("FIX-3 innocence: a well-formed row with score 0 IS a valid candidate (0 is not negative)", () => {
+  it("R2-D guilt: a well-formed row with score 0 is NOT a valid candidate (backend maps <=0 to NEEDS_INPUT)", () => {
     const raw = {
       success: true,
       session_id: "s1",
@@ -264,6 +264,28 @@ describe("parseRecommendResponse", () => {
           validity: "",
           notes: "",
           score: 0,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.visas).toEqual([]);
+  });
+
+  it("FIX-3 innocence: a well-formed row with a strictly positive score IS a valid candidate", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      visas: [
+        {
+          visa_name: "Positive Score Visa",
+          category: "x",
+          price: "1 IDR",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: 0.5,
         },
       ],
     };

--- a/apps/mouth/src/lib/visa-oracle/api.test.ts
+++ b/apps/mouth/src/lib/visa-oracle/api.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  describeRecommendOutcome,
+  parseRecommendResponse,
+  recommendVisas,
+} from "./api";
+import type { QuizAnswers, RecommendResponse } from "./types";
+
+const ANSWERS: QuizAnswers = {
+  nationality: "German",
+  purpose: "work",
+  duration: "long",
+  family: "solo",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// parseRecommendResponse — runtime validation (PR0 W4, round2 spec §6.5)
+// ---------------------------------------------------------------------------
+
+describe("parseRecommendResponse", () => {
+  it("passes through a well-formed SUPPORTED_CANDIDATES response", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      missing_facts: [],
+      review_reasons: [],
+      visas: [
+        {
+          visa_name: "Working KITAS",
+          category: "kitas_permits",
+          price: "18.000.000 IDR",
+          duration: "1 year",
+          validity: "KITAS",
+          notes: "",
+          score: 4,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.state).toBe("SUPPORTED_CANDIDATES");
+    expect(parsed.visas).toHaveLength(1);
+    expect(parsed.visas[0].visa_name).toBe("Working KITAS");
+  });
+
+  it("tolerates absence of state/missing_facts/review_reasons (legacy backend)", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      visas: [
+        {
+          visa_name: "Working KITAS",
+          category: "kitas_permits",
+          price: "18.000.000 IDR",
+          duration: "1 year",
+          validity: "KITAS",
+          notes: "",
+          score: 4,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.state).toBeUndefined();
+    // Legacy shape had no safety invariant — trust visas as before PR0.
+    expect(parsed.visas).toHaveLength(1);
+  });
+
+  it("defensively empties visas when state is NOT SUPPORTED_CANDIDATES, even if the raw payload disagrees", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "NEEDS_INPUT",
+      missing_facts: ["nationality"],
+      review_reasons: ["low_confidence_match"],
+      // A buggy/legacy backend that violates its own invariant — the
+      // frontend must not trust this.
+      visas: [
+        {
+          visa_name: "Fabricated Visa",
+          category: "x",
+          price: "0 IDR",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: 0,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.state).toBe("NEEDS_INPUT");
+    expect(parsed.visas).toEqual([]);
+    expect(parsed.missing_facts).toEqual(["nationality"]);
+  });
+
+  it("drops an unrecognized state value rather than trusting it", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SOME_FUTURE_STATE_WE_DONT_KNOW",
+      visas: [
+        {
+          visa_name: "X",
+          category: "x",
+          price: "",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: 1,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.state).toBeUndefined();
+    expect(parsed.visas).toEqual([]);
+  });
+
+  it("filters out malformed visa entries instead of crashing", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      visas: [
+        {
+          visa_name: "Valid Visa",
+          category: "x",
+          price: "1 IDR",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: 1,
+        },
+        { visa_name: 123 }, // malformed
+        null,
+        "not an object",
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.visas).toHaveLength(1);
+    expect(parsed.visas[0].visa_name).toBe("Valid Visa");
+  });
+
+  it("throws on a fundamentally malformed payload rather than silently returning garbage", () => {
+    expect(() => parseRecommendResponse(null)).toThrow();
+    expect(() => parseRecommendResponse({})).toThrow();
+    expect(() => parseRecommendResponse({ success: true })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recommendVisas — end-to-end fetch + parse
+// ---------------------------------------------------------------------------
+
+describe("recommendVisas", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("never crashes and never fabricates a candidate on an empty-candidates response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        session_id: "s1",
+        state: "NEEDS_INPUT",
+        missing_facts: [],
+        review_reasons: ["low_confidence_match"],
+        visas: [],
+      }),
+    );
+
+    const result = await recommendVisas(ANSWERS);
+    expect(result.state).toBe("NEEDS_INPUT");
+    expect(result.visas).toEqual([]);
+  });
+
+  it("handles TEMPORARILY_UNAVAILABLE without throwing", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        session_id: "s1",
+        state: "TEMPORARILY_UNAVAILABLE",
+        missing_facts: [],
+        review_reasons: ["catalog_no_candidates"],
+        visas: [],
+      }),
+    );
+
+    const result = await recommendVisas(ANSWERS);
+    expect(result.state).toBe("TEMPORARILY_UNAVAILABLE");
+    expect(result.visas).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeRecommendOutcome — honest empty-candidates rendering (PR0 W4)
+// ---------------------------------------------------------------------------
+
+describe("describeRecommendOutcome", () => {
+  function response(overrides: Partial<RecommendResponse>): RecommendResponse {
+    return {
+      success: true,
+      session_id: "s1",
+      visas: [],
+      ...overrides,
+    };
+  }
+
+  it("never fabricates a candidate: with visas present, describes a real match", () => {
+    const outcome = describeRecommendOutcome(
+      response({
+        state: "SUPPORTED_CANDIDATES",
+        visas: [
+          {
+            visa_name: "Working KITAS",
+            category: "x",
+            price: "1 IDR",
+            duration: "",
+            validity: "",
+            notes: "",
+            score: 4,
+          },
+        ],
+      }),
+    );
+    expect(outcome.showWhatsAppEscape).toBe(false);
+    expect(outcome.headline).not.toMatch(/error|crash|undefined/i);
+  });
+
+  it("NEEDS_INPUT with empty visas renders an honest 'need more info' outcome with an escape hatch", () => {
+    const outcome = describeRecommendOutcome(
+      response({
+        state: "NEEDS_INPUT",
+        missing_facts: ["nationality"],
+        visas: [],
+      }),
+    );
+    expect(outcome.showWhatsAppEscape).toBe(true);
+    expect(outcome.detail).toContain("nationality");
+  });
+
+  it("HUMAN_REVIEW_REQUIRED renders an honest 'human specialist' outcome", () => {
+    const outcome = describeRecommendOutcome(
+      response({ state: "HUMAN_REVIEW_REQUIRED", visas: [] }),
+    );
+    expect(outcome.showWhatsAppEscape).toBe(true);
+    expect(outcome.headline.toLowerCase()).toContain("human");
+  });
+
+  it("NO_SUPPORTED_PATH renders an honest 'human specialist' outcome", () => {
+    const outcome = describeRecommendOutcome(
+      response({ state: "NO_SUPPORTED_PATH", visas: [] }),
+    );
+    expect(outcome.showWhatsAppEscape).toBe(true);
+  });
+
+  it("TEMPORARILY_UNAVAILABLE renders an honest degraded outcome, never a crash", () => {
+    const outcome = describeRecommendOutcome(
+      response({ state: "TEMPORARILY_UNAVAILABLE", visas: [] }),
+    );
+    expect(outcome.showWhatsAppEscape).toBe(true);
+    expect(outcome.headline).toBeTruthy();
+  });
+
+  it("absent state (legacy) with empty visas still renders honestly, never undefined", () => {
+    const outcome = describeRecommendOutcome(
+      response({ state: undefined, visas: [] }),
+    );
+    expect(outcome.headline).toBeTruthy();
+    expect(outcome.detail).toBeTruthy();
+    expect(outcome.showWhatsAppEscape).toBe(true);
+  });
+});

--- a/apps/mouth/src/lib/visa-oracle/api.test.ts
+++ b/apps/mouth/src/lib/visa-oracle/api.test.ts
@@ -157,6 +157,149 @@ describe("parseRecommendResponse", () => {
     expect(() => parseRecommendResponse({})).toThrow();
     expect(() => parseRecommendResponse({ success: true })).toThrow();
   });
+
+  // ---------------------------------------------------------------------
+  // FIX-3 (Codex red-team P1 #2, garbage candidates): a visa row is only
+  // valid with a non-empty `visa_name` AND a finite, non-negative `score`.
+  // ---------------------------------------------------------------------
+
+  it("FIX-3 guilt: a row missing visa_name entirely is not a valid candidate", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      visas: [{ score: 2 }],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.visas).toEqual([]);
+  });
+
+  it("FIX-3 guilt: a row with an empty-string visa_name is not a valid candidate", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      visas: [
+        {
+          visa_name: "   ",
+          category: "x",
+          price: "1 IDR",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: 2,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.visas).toEqual([]);
+  });
+
+  it("FIX-3 guilt: a row with a negative score is not a valid candidate", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      visas: [
+        {
+          visa_name: "Suspicious Visa",
+          category: "x",
+          price: "1 IDR",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: -1,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.visas).toEqual([]);
+  });
+
+  it("FIX-3 guilt: a row with a non-finite score (NaN/Infinity) is not a valid candidate", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      visas: [
+        {
+          visa_name: "NaN Visa",
+          category: "x",
+          price: "1 IDR",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: NaN,
+        },
+        {
+          visa_name: "Infinity Visa",
+          category: "x",
+          price: "1 IDR",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: Infinity,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.visas).toEqual([]);
+  });
+
+  it("FIX-3 innocence: a well-formed row with score 0 IS a valid candidate (0 is not negative)", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      visas: [
+        {
+          visa_name: "Zero Score Visa",
+          category: "x",
+          price: "1 IDR",
+          duration: "",
+          validity: "",
+          notes: "",
+          score: 0,
+        },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.visas).toHaveLength(1);
+  });
+
+  it("FIX-8 (b): SUPPORTED_CANDIDATES with an all-invalid visas array ends up empty, never trusted", () => {
+    const raw = {
+      success: true,
+      session_id: "s1",
+      state: "SUPPORTED_CANDIDATES",
+      visas: [
+        { score: 2 },
+        { visa_name: "", score: 5 },
+        { visa_name: "X", score: -3 },
+      ],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.state).toBe("SUPPORTED_CANDIDATES");
+    expect(parsed.visas).toEqual([]);
+  });
+
+  it("FIX-8 (c): passes through success=false unchanged (legacy no-state path)", () => {
+    const raw = {
+      success: false,
+      session_id: "s1",
+      visas: [],
+    };
+
+    const parsed = parseRecommendResponse(raw);
+    expect(parsed.success).toBe(false);
+    expect(parsed.state).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -286,6 +429,78 @@ describe("describeRecommendOutcome", () => {
     );
     expect(outcome.headline).toBeTruthy();
     expect(outcome.detail).toBeTruthy();
+    expect(outcome.showWhatsAppEscape).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------
+  // FIX-8 (Codex red-team P2 #7, success semantics + parser contradictions)
+  // ---------------------------------------------------------------------
+
+  it("FIX-8 (a) guilt: success=false always yields an error outcome, never 'here's what fits'", () => {
+    const outcome = describeRecommendOutcome(
+      response({
+        success: false,
+        state: "TEMPORARILY_UNAVAILABLE",
+        visas: [],
+      }),
+    );
+    expect(outcome.headline).not.toMatch(/here's what fits/i);
+    expect(outcome.showWhatsAppEscape).toBe(true);
+  });
+
+  it("FIX-8 (a) guilt: success=false wins even when state/visas look like a clean match", () => {
+    // A contradictory payload (should never happen from a well-behaved
+    // backend, but the frontend must not trust the label alone) — success
+    // is a stronger signal than a non-empty visas array.
+    const outcome = describeRecommendOutcome(
+      response({
+        success: false,
+        state: "SUPPORTED_CANDIDATES",
+        visas: [
+          {
+            visa_name: "Working KITAS",
+            category: "x",
+            price: "1 IDR",
+            duration: "",
+            validity: "",
+            notes: "",
+            score: 4,
+          },
+        ],
+      }),
+    );
+    expect(outcome.headline).not.toMatch(/here's what fits/i);
+    expect(outcome.showWhatsAppEscape).toBe(true);
+  });
+
+  it("FIX-8 (a) innocence: success=true with a real match still renders 'here's what fits'", () => {
+    const outcome = describeRecommendOutcome(
+      response({
+        success: true,
+        state: "SUPPORTED_CANDIDATES",
+        visas: [
+          {
+            visa_name: "Working KITAS",
+            category: "x",
+            price: "1 IDR",
+            duration: "",
+            validity: "",
+            notes: "",
+            score: 4,
+          },
+        ],
+      }),
+    );
+    expect(outcome.headline).toMatch(/here's what fits/i);
+    expect(outcome.showWhatsAppEscape).toBe(false);
+  });
+
+  it("FIX-8 (b) guilt: SUPPORTED_CANDIDATES with empty visas downgrades to a human-review outcome, never a fabricated match", () => {
+    const outcome = describeRecommendOutcome(
+      response({ success: true, state: "SUPPORTED_CANDIDATES", visas: [] }),
+    );
+    expect(outcome.headline).not.toMatch(/here's what fits/i);
+    expect(outcome.headline.toLowerCase()).toContain("human");
     expect(outcome.showWhatsAppEscape).toBe(true);
   });
 });

--- a/apps/mouth/src/lib/visa-oracle/api.ts
+++ b/apps/mouth/src/lib/visa-oracle/api.ts
@@ -60,13 +60,22 @@ function isVisaRecommendation(value: unknown): value is VisaRecommendation {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
   return (
+    // FIX-3 (Codex red-team P1 #2, garbage candidates): a non-empty
+    // `visa_name` string and a finite, non-negative `score` are the two
+    // fields this row is actually rendered/sorted by — an empty name or a
+    // NaN/Infinity/negative score is not a "row missing some polish", it's
+    // not a real candidate at all. Mirrors the backend's
+    // `_filter_complete_visas` completeness gate.
     typeof v.visa_name === "string" &&
+    v.visa_name.trim().length > 0 &&
     typeof v.category === "string" &&
     typeof v.price === "string" &&
     typeof v.duration === "string" &&
     typeof v.validity === "string" &&
     typeof v.notes === "string" &&
-    typeof v.score === "number"
+    typeof v.score === "number" &&
+    Number.isFinite(v.score) &&
+    v.score >= 0
   );
 }
 
@@ -156,6 +165,20 @@ export interface RecommendOutcome {
 export function describeRecommendOutcome(
   response: RecommendResponse,
 ): RecommendOutcome {
+  // FIX-8 (Codex red-team P2 #7, success semantics): `success=false` is a
+  // genuine backend failure (the scoring-exception path) — it must win
+  // over any `state`/`visas` reading, unconditionally. A parser or a
+  // future backend revision could in principle pair `success=false` with a
+  // non-empty `visas` array; never render "here's what fits" on a call
+  // the backend itself flagged as failed.
+  if (response.success === false) {
+    return {
+      headline: "Something went wrong on our end",
+      detail: "Please try again shortly, or talk to our team now.",
+      showWhatsAppEscape: true,
+    };
+  }
+
   if (response.visas.length > 0) {
     const n = response.visas.length;
     return {
@@ -177,6 +200,14 @@ export function describeRecommendOutcome(
       };
     case "HUMAN_REVIEW_REQUIRED":
     case "NO_SUPPORTED_PATH":
+    case "SUPPORTED_CANDIDATES":
+      // FIX-8: the backend labeled this SUPPORTED_CANDIDATES, but the
+      // `visas.length > 0` guard above didn't fire — every row was
+      // missing/non-array/failed runtime validation (parseRecommendResponse
+      // already empties `visas` in this case, but never trust the label
+      // alone here either). This is a confirmed "needs a human" case, not
+      // an ambiguous/unrecognized one — do not let it fall through to the
+      // generic default copy below.
       return {
         headline: "This case needs a human specialist",
         detail:

--- a/apps/mouth/src/lib/visa-oracle/api.ts
+++ b/apps/mouth/src/lib/visa-oracle/api.ts
@@ -60,12 +60,16 @@ function isVisaRecommendation(value: unknown): value is VisaRecommendation {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
   return (
-    // FIX-3 (Codex red-team P1 #2, garbage candidates): a non-empty
-    // `visa_name` string and a finite, non-negative `score` are the two
-    // fields this row is actually rendered/sorted by — an empty name or a
-    // NaN/Infinity/negative score is not a "row missing some polish", it's
-    // not a real candidate at all. Mirrors the backend's
-    // `_filter_complete_visas` completeness gate.
+    // FIX-3 (Codex red-team P1 #2, garbage candidates) + R2-D (Codex
+    // re-review, F7 residue): a non-empty `visa_name` string and a
+    // finite, STRICTLY POSITIVE `score` are the two fields this row is
+    // actually rendered/sorted by — an empty name or a NaN/Infinity/
+    // zero/negative score is not a "row missing some polish", it's not a
+    // real candidate at all. `score > 0` (not `>= 0`) mirrors the
+    // backend's own `_determine_recommend_state`: `best_score <= 0` maps
+    // to NEEDS_INPUT there, so a zero-score row reaching the frontend as
+    // a "valid" VisaRecommendation would contradict the backend's own
+    // low_confidence_match rule.
     typeof v.visa_name === "string" &&
     v.visa_name.trim().length > 0 &&
     typeof v.category === "string" &&
@@ -75,7 +79,7 @@ function isVisaRecommendation(value: unknown): value is VisaRecommendation {
     typeof v.notes === "string" &&
     typeof v.score === "number" &&
     Number.isFinite(v.score) &&
-    v.score >= 0
+    v.score > 0
   );
 }
 

--- a/apps/mouth/src/lib/visa-oracle/api.ts
+++ b/apps/mouth/src/lib/visa-oracle/api.ts
@@ -1,6 +1,7 @@
 import type {
   QuizAnswers,
   RecommendResponse,
+  RecommendState,
   ChatMessage,
   ChatResponse,
   HandoffResponse,
@@ -10,11 +11,11 @@ import type {
 const API_BASE =
   process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://nuzantara-rag.fly.dev";
 
-async function apiFetch<T>(
+async function apiFetchRaw(
   path: string,
   body: Record<string, unknown>,
   extraHeaders: Record<string, string> = {},
-): Promise<T> {
+): Promise<unknown> {
   const res = await fetch(`${API_BASE}${path}`, {
     method: "POST",
     headers: {
@@ -29,15 +30,183 @@ async function apiFetch<T>(
     throw new Error(`API error ${res.status}: ${text}`);
   }
 
-  return res.json() as Promise<T>;
+  return res.json();
+}
+
+async function apiFetch<T>(
+  path: string,
+  body: Record<string, unknown>,
+  extraHeaders: Record<string, string> = {},
+): Promise<T> {
+  return (await apiFetchRaw(path, body, extraHeaders)) as T;
+}
+
+const RECOMMEND_STATES: readonly RecommendState[] = [
+  "NEEDS_INPUT",
+  "SUPPORTED_CANDIDATES",
+  "HUMAN_REVIEW_REQUIRED",
+  "NO_SUPPORTED_PATH",
+  "TEMPORARILY_UNAVAILABLE",
+];
+
+function isRecommendState(value: unknown): value is RecommendState {
+  return (
+    typeof value === "string" &&
+    (RECOMMEND_STATES as readonly string[]).includes(value)
+  );
+}
+
+function isVisaRecommendation(value: unknown): value is VisaRecommendation {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.visa_name === "string" &&
+    typeof v.category === "string" &&
+    typeof v.price === "string" &&
+    typeof v.duration === "string" &&
+    typeof v.validity === "string" &&
+    typeof v.notes === "string" &&
+    typeof v.score === "number"
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+/**
+ * Runtime-validate a raw `/recommend` JSON payload into a RecommendResponse
+ * rather than blind TS-casting `res.json()` (PR0 safety freeze W4; round2
+ * spec §6.5 "Runtime-validate API responses rather than TypeScript-casting
+ * JSON").
+ *
+ * Tolerates the absence of `state`/`missing_facts`/`review_reasons` — a
+ * legacy backend response that predates PR0 — and in that case trusts
+ * `visas` exactly as before PR0 (no safety invariant existed to enforce).
+ *
+ * For any response that DOES carry a (recognized) `state`, this enforces
+ * the safety invariant defensively even if the backend itself violates it:
+ * `visas` is [] unless `state === "SUPPORTED_CANDIDATES"`. An unrecognized
+ * `state` value is treated as absent (untrusted), not as an implicit
+ * SUPPORTED_CANDIDATES.
+ */
+export function parseRecommendResponse(raw: unknown): RecommendResponse {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("recommendVisas: malformed response (not an object)");
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.success !== "boolean" || typeof obj.session_id !== "string") {
+    throw new Error(
+      "recommendVisas: malformed response (missing success/session_id)",
+    );
+  }
+
+  const rawVisas = Array.isArray(obj.visas)
+    ? obj.visas.filter(isVisaRecommendation)
+    : [];
+
+  // Distinguish "no `state` field at all" (true legacy backend, predates
+  // PR0 — no invariant ever existed to enforce, trust `visas` as before)
+  // from "a `state` field is present but not one of the five known values"
+  // (a NEWER/unknown contract we don't understand — strictly less
+  // trustworthy than legacy, so we do NOT fall back to trusting `visas`).
+  const hasStateField =
+    Object.prototype.hasOwnProperty.call(obj, "state") &&
+    obj.state !== undefined;
+  const state = isRecommendState(obj.state) ? obj.state : undefined;
+  const missing_facts = isStringArray(obj.missing_facts)
+    ? obj.missing_facts
+    : undefined;
+  const review_reasons = isStringArray(obj.review_reasons)
+    ? obj.review_reasons
+    : undefined;
+
+  const visas = !hasStateField
+    ? rawVisas
+    : state === "SUPPORTED_CANDIDATES"
+      ? rawVisas
+      : [];
+
+  return {
+    success: obj.success,
+    session_id: obj.session_id,
+    visas,
+    state,
+    missing_facts,
+    review_reasons,
+  };
+}
+
+export interface RecommendOutcome {
+  headline: string;
+  detail: string;
+  showWhatsAppEscape: boolean;
+}
+
+/**
+ * Derive an honest, non-crashing display outcome from a RecommendResponse.
+ * PR0 safety freeze W4: never render a fabricated candidate; when `visas`
+ * is empty, always surface an honest "need more info" / "talk to a human"
+ * message with the existing WhatsApp/contact escape hatch — never a crash,
+ * never an undefined render.
+ */
+export function describeRecommendOutcome(
+  response: RecommendResponse,
+): RecommendOutcome {
+  if (response.visas.length > 0) {
+    const n = response.visas.length;
+    return {
+      headline: "Here's what fits",
+      detail: `${n} visa option${n === 1 ? "" : "s"} matched your answers.`,
+      showWhatsAppEscape: false,
+    };
+  }
+
+  switch (response.state) {
+    case "NEEDS_INPUT":
+      return {
+        headline: "We need a bit more information",
+        detail:
+          response.missing_facts && response.missing_facts.length > 0
+            ? `Please confirm: ${response.missing_facts.join(", ")}.`
+            : "Your answers weren't specific enough for a confident match — try again with a bit more detail.",
+        showWhatsAppEscape: true,
+      };
+    case "HUMAN_REVIEW_REQUIRED":
+    case "NO_SUPPORTED_PATH":
+      return {
+        headline: "This case needs a human specialist",
+        detail:
+          "Your situation doesn't match a standard path — our team can look at it directly.",
+        showWhatsAppEscape: true,
+      };
+    case "TEMPORARILY_UNAVAILABLE":
+      return {
+        headline: "Recommendations are temporarily unavailable",
+        detail: "Please try again shortly, or talk to our team now.",
+        showWhatsAppEscape: true,
+      };
+    default:
+      // Absent/unrecognized state with empty visas — still honest, never a
+      // fabricated candidate.
+      return {
+        headline: "We couldn't find a confident match",
+        detail: "Talk to our team and we'll help you find the right visa.",
+        showWhatsAppEscape: true,
+      };
+  }
 }
 
 export async function recommendVisas(
   answers: QuizAnswers,
 ): Promise<RecommendResponse> {
-  return apiFetch<RecommendResponse>("/api/v1/visa-oracle/recommend", {
+  const raw = await apiFetchRaw("/api/v1/visa-oracle/recommend", {
     ...answers,
   });
+  return parseRecommendResponse(raw);
 }
 
 function detectBrowserLanguage(): string {

--- a/apps/mouth/src/lib/visa-oracle/types.ts
+++ b/apps/mouth/src/lib/visa-oracle/types.ts
@@ -1,8 +1,15 @@
 export interface QuizAnswers {
   nationality: string;
-  purpose: 'visit' | 'work' | 'invest' | 'retire' | 'digital_nomad' | 'family' | 'study';
-  duration: 'short' | 'medium' | 'long' | 'permanent';
-  family: 'solo' | 'spouse' | 'children' | 'spouse_children';
+  purpose:
+    | "visit"
+    | "work"
+    | "invest"
+    | "retire"
+    | "digital_nomad"
+    | "family"
+    | "study";
+  duration: "short" | "medium" | "long" | "permanent";
+  family: "solo" | "spouse" | "children" | "spouse_children";
 }
 
 export interface VisaRecommendation {
@@ -15,25 +22,42 @@ export interface VisaRecommendation {
   score: number;
 }
 
+// PR0 safety freeze (2026-07-17, round2 spec §9 row PR0 / §6.2): additive
+// five-state contract on /recommend. `visas` is guaranteed [] for every
+// state except SUPPORTED_CANDIDATES.
+export type RecommendState =
+  | "NEEDS_INPUT"
+  | "SUPPORTED_CANDIDATES"
+  | "HUMAN_REVIEW_REQUIRED"
+  | "NO_SUPPORTED_PATH"
+  | "TEMPORARILY_UNAVAILABLE";
+
 export interface RecommendResponse {
   success: boolean;
   visas: VisaRecommendation[];
   session_id: string;
+  // Optional: absent on legacy backend responses that predate PR0. Treat
+  // absence as "unknown state" — NOT as an implicit SUPPORTED_CANDIDATES.
+  state?: RecommendState;
+  missing_facts?: string[];
+  review_reasons?: string[];
 }
 
 export interface ChatMessage {
-  role: 'user' | 'assistant' | 'system';
+  role: "user" | "assistant" | "system";
   content: string;
-  confidence?: 'ABSTAIN' | 'CAUTIOUS' | 'NORMAL';
+  confidence?: "ABSTAIN" | "CAUTIOUS" | "NORMAL";
   sources?: string[];
 }
 
 export interface ChatResponse {
   success: boolean;
   answer: string;
-  confidence: 'ABSTAIN' | 'CAUTIOUS' | 'NORMAL';
+  confidence: "ABSTAIN" | "CAUTIOUS" | "NORMAL";
   sources: string[];
   session_id: string;
+  // Optional: absent on legacy backend responses. PR0 safety freeze W2.
+  review_reasons?: string[];
 }
 
 export interface HandoffResponse {

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 638 services · 1149 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 638 services · 1151 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

**PR0 — Visa Oracle safety freeze**, Gate 0 of the v2 program (owner GO given 2026-07-17). Four additive, back-compatible workstreams on the existing `/api/v1/visa-oracle/*` endpoints — no v2 engine, no new legal/matching logic:

- **W1 — Additive five-state `/recommend` contract.** `RecommendResponse` gains `state` (`NEEDS_INPUT` / `SUPPORTED_CANDIDATES` / `HUMAN_REVIEW_REQUIRED` / `NO_SUPPORTED_PATH` / `TEMPORARILY_UNAVAILABLE`), `missing_facts`, and `review_reasons`, all optional/back-compat. `visas` is now guaranteed `[]` for every state except `SUPPORTED_CANDIDATES` — no more silently trusting a legacy `visas` array without checking the invariant.
- **W2 — Removed the ABSTAIN→CAUTIOUS obsolete-code promotion.** `/chat` used to let the LLM generate a free-form answer on weak KB evidence "on the strength of pretraining context" whenever a retired visa code (B211/B211A) was mentioned — zero grounding. Weak evidence now **always** abstains; the obsolete-code signal survives only as a `review_reasons` annotation, and as of the hardening rounds below, a deterministic zero-LLM explanation.
- **W3 — Server-authoritative `/handoff` pricing.** The WhatsApp deep-link and Telegram lead notification now resolve visa name/price ONLY from the session this backend itself persisted at `/recommend` time (PricingService-derived) — never from client-posted `recommended_visas`/prices. A client/server divergence is logged, never trusted.
- **W4 — Frontend honest empty-candidates handling.** `apps/mouth` runtime-validates `/recommend` responses (no blind TS-casting), and `describeRecommendOutcome()` always renders an honest "need more info" / "talk to a human" message with the WhatsApp escape hatch when `visas` is empty — never a crash, never a fabricated candidate.

## Adversarial review history

This PR shipped through 3 rounds of GPT-5.6-sol xhigh adversarial red-team, generator≠grader throughout (the diff's author never gated its own diff):

1. **Round 1 — REJECT (8 findings, commit `02a3f0080c`).** Vocabulary gate missing (nonsense `purpose` could still score >0 and reach `SUPPORTED_CANDIDATES`), nationality overclaim, garbage candidates (missing `visa_name` not filtered), empty-content generation, client-trusted quiz answers + Telegram Markdown injection, async-persist race on handoff, obsolete-code explanation silently dropped, success-semantics/parser contradictions.
2. **Fix round 1 (commit `8235e3f405`).** All 8 findings addressed: vocabulary gate, `nationality_not_evaluated` declared limitation, candidate-completeness filter, empty-content filter before `top_score`, server-snapshot-preferred quiz + legacy-Markdown escaping, retry on the session-snapshot race, deterministic obsolete-code answer, `success=False` on scoring exceptions + frontend parser hardening.
3. **Round 2 — focused re-review REJECT (4 PARTIAL + 2 NEW-BUG, introduced by round 1's own fixes).** F2 residue: completeness filter didn't require `price`. F5 residue: quiz-preference didn't cover the body-only-handoff case honestly (silent suppression vs. tagged UNVERIFIED). F7 residue / F8 residue: minor gaps in the deterministic-answer and success-semantics fixes. **F4 NEW-BUG**: `session_id`/`language` interpolated inside a Telegram Markdown *code span* (backticks) — the round-1 escaping fix doesn't apply inside a code entity, so a backtick in the value could break out and inject formatting. **F6 NEW-BUG**: the round-1 obsolete-code fix only ever returned the *first* matched retired code, silently dropping any additional code mentioned in the same message.
4. **Fix round 2 (commit `b7a2413bcb`).** R2-A: `_filter_complete_visas` now requires non-empty `visa_name` AND non-empty/non-null `price`. R2-B: added charset-whitelist sanitizers (not escaping — escaping is invalid inside a Markdown code span) for `session_id`/`language`, plus a bracket-free `UNVERIFIED (no server session):` prefix. R2-C: `_detect_obsolete_codes()` now returns every matched code, not just the first. R2-D: frontend `isVisaRecommendation` requires `score > 0` (not `>= 0`), matching the backend's own `best_score <= 0 → NEEDS_INPUT` rule. R2-E: `handoff_triggered` UPDATE retry extended to 3 attempts / ~10s (declared-acceptable residue, not a full cure — see below).
5. **Round 3 — APPROVE-WITH-NITS (all R2 items CLOSED, commit `e2691bfb3f`).** One nit: the round-2 multi-code guilt test used a substring assertion (`"B211" in answer`) that would also trivially match inside `"B211A"` — a guard-over-match signature landing inside a *test* rather than production code. Fixed with exact-boundary assertions (per-code enumerated-line parsing + word-boundary regex), no production code changed.

## Declared accepted residues (not bugs — explicitly scoped out of this freeze)

- **`nationality_not_evaluated`** — every `SUPPORTED_CANDIDATES` response carries this `review_reasons` entry because the legacy scorer never reads nationality at all. Truthful declared limitation; cured by the v2 matching engine.
- **CAUTIOUS band (0.30–0.55) redesign** — deliberately untouched. Deferred to the v2 chat-demotion scope.
- **Frontend session plumbing (ChatAccordion/VisaChat disconnect)** — v1 architecture; not refactored here. Deferred to PR7.
- **`handoff_triggered` flag loss if `/recommend`'s INSERT lands >10s late** — the retry (3 attempts, ~10s backoff, already fire-and-forget via the shared `spawn()` background-task helper) is analytics-grade best-effort telemetry, never a gate on the handoff response itself. A real cure needs UPSERT/marker-row schema semantics — repository-layer work, cured by PR4.

## Reference

Part of the Visa Oracle v2 program — see `docs/plans/2026-07-17-visa-oracle-v2/00-product-design.md` §9 row PR0 (PR #2580).

## Test plan

- [x] Backend: **128 passed** (`test_visa_oracle.py`, `test_visa_oracle_handoff.py`, `test_visa_oracle_service.py`, `test_chat_obsolete_code.py`, `test_chat_jwt.py`) — guilt + innocence pair per fix, real (unmocked) `VisaOracleService` path for the vocabulary-gate probe.
- [x] Frontend: **26 passed** (`api.test.ts`).
- [x] `ruff check` / `ruff format --check` clean on every touched Python file.
- [x] `tsc --noEmit` clean on `apps/mouth`.
- [x] Pre-commit hooks green on every commit (anti-reward-hacking lint, secrets scan, prettier, import-chain smoke test, off-limits-file guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
