### PR TITLE
fix(wa-outbox): burst coalescing, per-thread lock, claim fencing, lease heartbeat + K workers

### DIFF
--- a/apps/backend-rag/backend/app/main_api.py
+++ b/apps/backend-rag/backend/app/main_api.py
@@ -31,6 +31,26 @@ def _wa_outbox_scheduler_enabled() -> bool:
     }
 
 
+def _wa_outbox_worker_count() -> int:
+    """How many concurrent scheduler loops to spawn (P9, spec zantara-wa-spec-v2
+    D2.5). K parallelism only ships AFTER the P2-P6 correctness fixes — the
+    per-thread advisory lock in wa_outbox_worker.py is what makes >1 worker
+    safe (two workers can now claim different rows without ever concurrently
+    processing the same thread). Default 2. Any non-integer or non-positive
+    value falls back to the default rather than crashing startup.
+    """
+    raw = os.getenv("WA_OUTBOX_WORKERS", "2")
+    try:
+        count = int(raw)
+    except ValueError:
+        logger.warning("WA_OUTBOX_WORKERS=%r is not an int — defaulting to 2", raw)
+        return 2
+    if count < 1:
+        logger.warning("WA_OUTBOX_WORKERS=%d is not positive — defaulting to 2", count)
+        return 2
+    return count
+
+
 def _make_wa_bot_generate(app: FastAPI):
     """Build the bot_generate_fn for the wa_outbox scheduler.
 
@@ -50,11 +70,16 @@ def _make_wa_bot_generate(app: FastAPI):
     return _bot_generate
 
 
-async def _run_wa_outbox_scheduler(app: FastAPI) -> None:
+async def _run_wa_outbox_scheduler(app: FastAPI, worker_id: int = 0) -> None:
     """Drain the wa_outbox send-queue by calling process_outbox_once in a loop.
 
-    Hosted on the 'api' process group (always-on, single-worker) so exactly one
-    scheduler runs. Tight-loops while draining (status == 'sent'), backs off to
+    P9 (spec zantara-wa-spec-v2 D2.5): as of the F1a concurrency pass, up to
+    WA_OUTBOX_WORKERS (default 2) instances of this loop run concurrently on
+    the 'api' process group — safe because wa_outbox_worker.process_outbox_once
+    now holds a per-thread advisory lock across the whole claim→send lifetime
+    (P3), so two workers can never process the same thread simultaneously even
+    when they claim different rows. `worker_id` is purely for log correlation.
+    Tight-loops while draining (status == 'sent'), backs off to
     WA_OUTBOX_POLL_SECONDS when idle. Never crashes the app: per-tick exceptions
     are logged and the loop continues after a backoff.
     """
@@ -64,7 +89,7 @@ async def _run_wa_outbox_scheduler(app: FastAPI) -> None:
     interval = float(os.getenv("WA_OUTBOX_POLL_SECONDS", "3"))
     pool = app.state.db_pool
     bot_generate_fn = _make_wa_bot_generate(app)
-    logger.info("✅ WA outbox scheduler started (poll=%ss)", interval)
+    logger.info("✅ WA outbox scheduler started (worker=%d poll=%ss)", worker_id, interval)
     while True:
         try:
             status = await process_outbox_once(
@@ -75,10 +100,10 @@ async def _run_wa_outbox_scheduler(app: FastAPI) -> None:
             # full queue per panel 2026-06-04). Back off fully when idle.
             await asyncio.sleep(0.1 if status == "sent" else interval)
         except asyncio.CancelledError:
-            logger.info("🛑 WA outbox scheduler cancelled")
+            logger.info("🛑 WA outbox scheduler cancelled (worker=%d)", worker_id)
             raise
         except Exception:
-            logger.exception("WA outbox scheduler tick failed; backing off")
+            logger.exception("WA outbox scheduler tick failed (worker=%d); backing off", worker_id)
             await asyncio.sleep(interval)
 
 
@@ -108,7 +133,7 @@ async def lifespan_light(app: FastAPI):
                 "+ WA outbox scheduler",
             )
             app.state.notification_scheduler = None
-            app.state._wa_outbox_scheduler_task = None
+            app.state._wa_outbox_scheduler_tasks = []
         else:
             try:
                 from backend.app.modules.notifications.scheduler import init_scheduler
@@ -122,17 +147,26 @@ async def lifespan_light(app: FastAPI):
             # lifespan) because app.state.db_pool is only set above, inside this
             # background init task; an outer-lifespan task could start with
             # db_pool=None (panel race-fix 2026-06-04). Guard on a real pool.
+            #
+            # P9: WA_OUTBOX_WORKERS (default 2) independent scheduler loops are
+            # spawned, all sharing the same pool + bot_generate_fn closure
+            # style (each builds its own closure — cheap, avoids any shared
+            # mutable state across workers). Stored as a LIST on app.state
+            # (was a single task pre-F1a) so shutdown can cancel every one.
             if not _wa_outbox_scheduler_enabled():
-                app.state._wa_outbox_scheduler_task = None
+                app.state._wa_outbox_scheduler_tasks = []
                 logger.warning(
                     "⚠️ WA outbox scheduler disabled by WA_OUTBOX_SCHEDULER_ENABLED",
                 )
             elif getattr(app.state, "db_pool", None) is not None:
-                app.state._wa_outbox_scheduler_task = asyncio.create_task(
-                    _run_wa_outbox_scheduler(app)
-                )
+                worker_count = _wa_outbox_worker_count()
+                app.state._wa_outbox_scheduler_tasks = [
+                    asyncio.create_task(_run_wa_outbox_scheduler(app, worker_id=i))
+                    for i in range(worker_count)
+                ]
+                logger.info("✅ WA outbox scheduler: %d worker(s) spawned", worker_count)
             else:
-                app.state._wa_outbox_scheduler_task = None
+                app.state._wa_outbox_scheduler_tasks = []
                 logger.warning(
                     "⚠️ WA outbox scheduler NOT started — db_pool unavailable",
                 )
@@ -142,11 +176,14 @@ async def lifespan_light(app: FastAPI):
 
     yield
 
-    # Shutdown: cancel the WA outbox scheduler BEFORE closing the pool it uses.
+    # Shutdown: cancel every WA outbox scheduler worker BEFORE closing the
+    # pool they use (P9 — up to WA_OUTBOX_WORKERS tasks now, was a single task
+    # pre-F1a).
     logger.info("🛑 [API PROCESS] Shutting down...")
-    wa_task = getattr(app.state, "_wa_outbox_scheduler_task", None)
-    if wa_task is not None:
+    wa_tasks = getattr(app.state, "_wa_outbox_scheduler_tasks", None) or []
+    for wa_task in wa_tasks:
         wa_task.cancel()
+    for wa_task in wa_tasks:
         try:
             await wa_task
         except (asyncio.CancelledError, Exception):

--- a/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
+++ b/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
@@ -54,6 +54,19 @@ _HISTORY_TURNS = 12
 _rag_client: httpx.AsyncClient | None = None
 _rag_client_lock = asyncio.Lock()
 
+# P9 admission gate (spec zantara-wa-spec-v2 D2.5): bounds how many in-flight
+# agentic-RAG calls THIS api process will ever have open against the separate
+# 'rag' Fly process group (shared-2x, 2 vCPU) at once. Placed here rather than
+# in wa_outbox_worker.py because this module owns the ONE call site that
+# actually reaches the RAG process for this feature (main_api.py's K
+# scheduler workers all funnel bot generation through generate_bot_reply) —
+# K workers stampeding the rag process with more simultaneous calls than it
+# can serve would just turn concurrency into RAG-side queueing/timeouts
+# instead of outbox-side throughput. Module-level singleton, lazily built (no
+# `await` between the None-check and the assignment, so this is safe without
+# a lock on a single-threaded event loop — see _get_bot_generation_semaphore).
+_bot_generation_semaphore: asyncio.Semaphore | None = None
+
 
 def is_bot_autoreply_enabled() -> bool:
     """True only when the Fly secret WA_INBOX_BOT_AUTOREPLY is truthy.
@@ -68,6 +81,26 @@ def is_bot_autoreply_enabled() -> bool:
         "yes",
         "on",
     )
+
+
+def _get_bot_generation_semaphore() -> asyncio.Semaphore:
+    """Lazily build (once) the admission-gate semaphore for RAG calls.
+
+    Max concurrent = int(env WA_BOT_MAX_CONCURRENT_GENERATIONS, default 3).
+    Read once, on first use — not re-read per call — matching the existing
+    lazy-singleton pattern for ``_rag_client`` in this module. There is no
+    `await` between the None-check and the assignment below, so on a
+    single-threaded asyncio event loop this cannot race even without a lock
+    (two concurrent callers can't interleave between those two lines).
+    """
+    global _bot_generation_semaphore
+    if _bot_generation_semaphore is None:
+        try:
+            max_concurrent = int(os.getenv("WA_BOT_MAX_CONCURRENT_GENERATIONS", "3"))
+        except ValueError:
+            max_concurrent = 3
+        _bot_generation_semaphore = asyncio.Semaphore(max(1, max_concurrent))
+    return _bot_generation_semaphore
 
 
 def _rag_client_headers() -> dict[str, str]:
@@ -192,10 +225,14 @@ async def generate_bot_reply(pool: asyncpg.Pool, thread: Any) -> str:
         "channel": "whatsapp",
     }
 
-    client = await _get_rag_client()
-    resp = await client.post("/api/agentic-rag/query", json=payload)
-    resp.raise_for_status()
-    data = resp.json()
+    # P9 admission gate — bound in-flight RAG calls from this api process
+    # (see _get_bot_generation_semaphore docstring). Scoped tightly around
+    # the actual HTTP round-trip, not the cheap DB context-load above it.
+    async with _get_bot_generation_semaphore():
+        client = await _get_rag_client()
+        resp = await client.post("/api/agentic-rag/query", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
 
     if data.get("abstain"):
         # RAG refused — do not guess. Let the worker park it; operator can take over.

--- a/apps/backend-rag/backend/services/integrations/wa_outbox_worker.py
+++ b/apps/backend-rag/backend/services/integrations/wa_outbox_worker.py
@@ -3,32 +3,77 @@
 Drains the ``wa_outbox`` send-intent queue for the Meta WhatsApp Business
 number +62 821-3465-159 (``phone_number_id`` = ``META_INBOX_PHONE_NUMBER_ID``).
 
-Design (panel-approved spec 2026-06-03, sezione 3 "Worker"):
+Design (panel-approved spec 2026-06-03, sezione 3 "Worker"; hardened by the
+2026-07-17 F1a adversarial pass — see docs/superpowers/specs (zantara-wa-spec-v2)
+sections P2-P6/D2):
 
-1. Reclaim stale claims (``claim_expires_at < now()`` → ``pending``) so a
-   crashed worker does not park sends forever.
-2. Claim one due ``pending`` row with ``FOR UPDATE SKIP LOCKED`` (single-flight,
-   crash-safe lease).
-3. If the row needs bot generation, re-check ``human_handling`` (the operator
-   may have taken over since the webhook enqueued it) → if true, ABORT and drop
-   the outbox row (bot must stay silent on a human-handled thread).
-4. Enforce the Meta 24h customer-care window — if the last inbound customer
-   message is older than 24h, fail the ledger row (free-text send not allowed).
-5. Send via the existing ``whatsapp_service`` (hardcodes the target
+1. Reclaim stale claims (``claim_expires_at < now()``) for BOTH ``claimed`` and
+   ``generating`` rows → back to ``pending``. A crashed worker (mid-send OR
+   mid-generation) must not park a send forever (P5).
+2. Claim one due ``pending`` row. Candidates are scanned with
+   ``FOR UPDATE SKIP LOCKED`` (row-level single-flight), but a candidate is
+   only actually claimed after this worker wins a **per-thread advisory lock**
+   (P3) — this is what stops two workers from concurrently processing two
+   *different* pending rows of the *same* thread (SKIP LOCKED alone only
+   dedupes the same row).
+3. Coalescing (P2): once a bot-reply row is claimed, every OTHER pending
+   bot-reply row for the same thread is superseded (marked failed,
+   ``error='superseded_by_coalescing'``) — the generator always answers the
+   *latest* thread message, so one send covers a whole burst.
+4. If the row needs bot generation, re-check ``human_handling`` (the operator
+   may have taken over since the webhook enqueued it) → if true, ABORT and
+   drop the outbox row (bot must stay silent on a human-handled thread). A
+   lease-heartbeat renews ``claim_expires_at`` every ~60s while generation is
+   in flight (P6 — CLAIM_LEASE_SECONDS=300 must outlive a slow RAG call), and
+   an immediately-pre-send fenced re-check of ``human_handling`` catches a
+   takeover that happened *during* generation (P4) — a late/lost race aborts
+   silently ("fenced") rather than sending.
+5. Enforce the Meta 24h customer-care window — if the last inbound customer
+   message is older than 24h, fail the ledger row (free-text send not
+   allowed).
+6. Send via the existing ``whatsapp_service`` (hardcodes the target
    ``phone_number_id`` from settings — already the correct number), record the
    Meta ``wamid`` on the ledger row, apply any orphan ``wa_status_pending``
    receipt for that wamid, and mark the outbox row done. On HTTP failure,
    backoff with ``next_retry_at``; after ``MAX_ATTEMPTS`` mark ``failed``.
 
+Concurrency-control fencing (P4, applies to every state-changing UPDATE on
+``wa_outbox`` after the initial claim): each UPDATE is scoped
+``WHERE id = $1 AND claim_token = $2 AND status = $3`` and uses
+``RETURNING id`` to detect whether it actually matched. Zero rows means this
+worker's lease was reclaimed (or the row was superseded) since the last
+checkpoint — abort processing silently and return ``"fenced"``. The one
+exception is the *final* success commit: by the time we reach it the Graph
+send has *already happened* (an irreversible external side-effect), so losing
+the fence there cannot un-send the message — we log loudly (residual
+double-send window, see the comment at the bottom of ``_process_claimed_row``)
+and still report ``"sent"``, we do not swallow the fact that a message went
+out.
+
+Per-thread advisory lock (P3, design deviation from the literal spec text —
+documented inline at the call site): the spec text says
+``pg_try_advisory_xact_lock`` taken "inside the claim transaction". This
+worker's claim transaction is intentionally short (it commits immediately
+after marking the row 'claimed'); an *xact*-scoped lock would therefore
+release the instant that transaction commits — i.e. before generation even
+starts, defeating the purpose. This implementation uses the **session**-scoped
+``pg_try_advisory_lock`` / ``pg_advisory_unlock`` pair instead, held for the
+entire lifetime of ``_process_claimed_row`` (claim → generate → send →
+commit) on the same pooled connection, and *always* released in a
+``finally`` before the connection returns to the pool (a leaked session-scoped
+lock would otherwise permanently wedge that thread on every future connection
+reuse — see the docstring on ``process_outbox_once``).
+
 This module exposes a single callable, :func:`process_outbox_once`, which
-processes at most one outbox row per call. A scheduler/loop that calls it every
-~3s is intentionally left as a TODO hook (see module bottom) — wiring a new
-LaunchAgent/background loop is out of scope for the backend feature and would
-be decided with the operator.
+processes at most one outbox row per call. ``main_api.py`` spawns
+``WA_OUTBOX_WORKERS`` (default 2) concurrent scheduler loops calling this in
+a tight cycle (P9) — safe because of the per-thread advisory lock above.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 import uuid
 from collections.abc import Awaitable, Callable
@@ -43,9 +88,23 @@ logger = logging.getLogger(__name__)
 # existing whatsapp_service sends from the correct number without parametrising.
 META_INBOX_PHONE_NUMBER_ID = "1104946272705747"
 
-# Lease window for a claimed outbox row. Must be safely larger than the
-# Graph + LLM send timeout (spec: < 30s) to avoid a second worker double-sending.
-CLAIM_LEASE_SECONDS = 120
+# Lease window for a claimed outbox row. P6 (spec 2026-07-17): the previous
+# 120s == the RAG read-timeout (120s in wa_inbox_bot._get_rag_client), so a
+# slow-but-legitimate generation could outlive its own lease and get reclaimed
+# out from under it. 300s gives headroom; the heartbeat below (renewed every
+# ~60s during generation) keeps it fresh well before it would ever expire.
+CLAIM_LEASE_SECONDS = 300
+
+# How often the lease is renewed while bot_generate_fn is in flight. Module
+# level (not a local constant) so tests can monkeypatch it to a tiny value
+# instead of waiting out a real 60s interval.
+LEASE_HEARTBEAT_INTERVAL_SECONDS = 60
+
+# How many due-pending candidates to consider per claim attempt before giving
+# up as idle. Only relevant when multiple candidates' threads are already
+# locked by other in-flight workers (P3) — this is a background poller, not a
+# hot path, so a modest scan window is fine.
+CLAIM_CANDIDATE_LIMIT = 20
 
 # Send retry policy.
 MAX_ATTEMPTS = 5
@@ -58,6 +117,10 @@ CUSTOMER_WINDOW_HOURS = 24
 # returns the reply text to send (or raises). Kept injectable so the worker has
 # no hard dependency on the RAG orchestrator (and is trivially testable).
 BotGenerateFn = Callable[[asyncpg.Record], Awaitable[str]]
+
+# Reused by both the advisory-lock TRY and its matching UNLOCK — must stay
+# identical so the two calls hash to the same lock key for a given thread_id.
+_THREAD_LOCK_KEY_SQL = "hashtext('wa_outbox_thread_' || $1::text)"
 
 
 def _extract_wamid(send_result: dict[str, Any] | None) -> str | None:
@@ -106,6 +169,78 @@ async def _apply_pending_status(conn: asyncpg.Connection, wamid: str) -> None:
     logger.info("wa_outbox: applied staged status %s for wamid=%s", pending["status"], wamid)
 
 
+async def _coalesce_thread_bursts(
+    conn: asyncpg.Connection, thread_id: int, outbox_id: int
+) -> int:
+    """Supersede other pending bot-reply rows of the same thread (P2).
+
+    The generator always answers the *latest* thread message (see
+    ``wa_inbox_bot._load_thread_context``), so whichever row of a same-thread
+    burst gets claimed first, its generated reply already covers the whole
+    burst — the other pending bot-reply rows would just be redundant sends.
+    Only ``needs_generation`` rows are touched: a pending HUMAN send must
+    never be silently dropped.
+    """
+    async with conn.transaction():
+        superseded = await conn.fetch(
+            """
+            UPDATE wa_outbox
+            SET status = 'failed'
+            WHERE thread_id = $1
+              AND status = 'pending'
+              AND needs_generation = true
+              AND id <> $2
+            RETURNING id, message_id
+            """,
+            thread_id,
+            outbox_id,
+        )
+        for row in superseded:
+            await conn.execute(
+                """
+                UPDATE meta_inbox_messages
+                SET status = 'failed', error = 'superseded_by_coalescing'
+                WHERE id = $1
+                """,
+                row["message_id"],
+            )
+    if superseded:
+        logger.info(
+            "wa_outbox: coalesced %d pending bot reply(ies) for thread %s into outbox %s",
+            len(superseded),
+            thread_id,
+            outbox_id,
+        )
+    return len(superseded)
+
+
+async def _lease_heartbeat_loop(
+    conn: asyncpg.Connection, outbox_id: int, claim_token: uuid.UUID
+) -> None:
+    """Renew the claim lease every ~60s while bot_generate_fn is in flight.
+
+    Fenced by claim_token + status='generating' — a best-effort renewal, not
+    a correctness gate (the pre-send fence after generation is the actual
+    gate). If this worker's row was already reclaimed, the UPDATE simply
+    matches zero rows and the next tick tries again harmlessly.
+    """
+    try:
+        while True:
+            await asyncio.sleep(LEASE_HEARTBEAT_INTERVAL_SECONDS)
+            await conn.execute(
+                """
+                UPDATE wa_outbox
+                SET claim_expires_at = NOW() + ($3 * INTERVAL '1 second')
+                WHERE id = $1 AND claim_token = $2 AND status = 'generating'
+                """,
+                outbox_id,
+                claim_token,
+                CLAIM_LEASE_SECONDS,
+            )
+    except asyncio.CancelledError:
+        raise
+
+
 async def process_outbox_once(
     pool: asyncpg.Pool,
     whatsapp_service: Any,
@@ -122,231 +257,268 @@ async def process_outbox_once(
 
     Returns:
         A short status string describing what happened (for logging/metrics):
-        ``"idle"`` (no due row), ``"sent"``, ``"aborted_human"``,
-        ``"window_closed"``, ``"retry"``, ``"failed"``.
+        ``"idle"`` (no due row, or every due row's thread is locked by
+        another worker), ``"sent"``, ``"aborted_human"``, ``"window_closed"``,
+        ``"retry"``, ``"failed"``, ``"fenced"`` (lease lost mid-flight —
+        aborted before any externally-visible action).
     """
-    # 1. Reclaim stale claims (best-effort, outside the claim TX).
+    # 1. Reclaim stale claims (best-effort, outside the claim TX). Covers both
+    #    'claimed' (crash before/at send) and 'generating' (crash mid bot
+    #    generation, P5) — a live worker's row never hits this because the
+    #    heartbeat keeps claim_expires_at fresh during generation.
     await pool.execute(
         """
         UPDATE wa_outbox
         SET status = 'pending', claim_token = NULL, claimed_at = NULL,
             claim_expires_at = NULL
-        WHERE status = 'claimed' AND claim_expires_at < NOW()
+        WHERE status IN ('claimed', 'generating') AND claim_expires_at < NOW()
         """,
     )
 
     claim_token = uuid.uuid4()
 
     async with pool.acquire() as conn:
-        # 2. Claim one due pending row. The SELECT ... FOR UPDATE SKIP LOCKED
-        #    + same-TX UPDATE is the single-flight guarantee across workers.
+        # 2. Claim one due pending row whose thread is not already owned by
+        #    another worker. FOR UPDATE SKIP LOCKED gives row-level
+        #    single-flight over the candidate scan; the per-thread advisory
+        #    lock (P3) gives single-flight over the *thread* across different
+        #    rows — see module docstring for why this is session-scoped
+        #    (pg_try_advisory_lock), not xact-scoped.
+        claimed_row: asyncpg.Record | None = None
+        thread_id_for_lock: int | None = None
         async with conn.transaction():
-            row = await conn.fetchrow(
+            candidates = await conn.fetch(
                 """
                 SELECT id, thread_id, message_id, needs_generation, attempts
                 FROM wa_outbox
                 WHERE status = 'pending' AND next_retry_at <= NOW()
                 ORDER BY next_retry_at, id
                 FOR UPDATE SKIP LOCKED
-                LIMIT 1
+                LIMIT $1
                 """,
+                CLAIM_CANDIDATE_LIMIT,
             )
-            if row is None:
-                return "idle"
-
-            await conn.execute(
-                """
-                UPDATE wa_outbox
-                SET status = 'claimed', claim_token = $2, claimed_at = NOW(),
-                    claim_expires_at = NOW() + ($3 * INTERVAL '1 second')
-                WHERE id = $1
-                """,
-                row["id"],
-                claim_token,
-                CLAIM_LEASE_SECONDS,
-            )
-
-        outbox_id = row["id"]
-        thread_id = row["thread_id"]
-        message_id = row["message_id"]
-        needs_generation = row["needs_generation"]
-        attempts = row["attempts"]
-
-        # Load the thread (human_handling gate + 24h window source).
-        thread = await conn.fetchrow(
-            """
-            SELECT thread_id, counterpart_phone, human_handling,
-                   last_customer_at
-            FROM meta_inbox_threads
-            WHERE thread_id = $1
-            """,
-            thread_id,
-        )
-        if thread is None:
-            # Should not happen (FK), but never park the row.
-            await conn.execute(
-                "UPDATE wa_outbox SET status = 'failed' WHERE id = $1", outbox_id
-            )
-            await conn.execute(
-                """
-                UPDATE meta_inbox_messages
-                SET status = 'failed', error = 'thread_missing'
-                WHERE id = $1
-                """,
-                message_id,
-            )
-            logger.error("wa_outbox: thread %s missing for outbox %s", thread_id, outbox_id)
-            return "failed"
-
-        # 3. Bot replies: re-check human_handling (takeover may have flipped it).
-        body_text: str
-        if needs_generation:
-            if thread["human_handling"]:
-                # Operator took over — bot must stay silent. Drop the intent.
-                await conn.execute(
-                    "UPDATE wa_outbox SET status = 'failed' WHERE id = $1", outbox_id
+            for candidate in candidates:
+                acquired = await conn.fetchval(
+                    f"SELECT pg_try_advisory_lock({_THREAD_LOCK_KEY_SQL})",
+                    candidate["thread_id"],
                 )
-                await conn.execute(
-                    """
-                    UPDATE meta_inbox_messages
-                    SET status = 'failed', error = 'aborted_human_takeover'
-                    WHERE id = $1
-                    """,
-                    message_id,
-                )
-                logger.info(
-                    "wa_outbox: aborted bot send for thread %s (human_handling=true)",
-                    thread_id,
-                )
-                return "aborted_human"
-
-            await conn.execute(
-                "UPDATE meta_inbox_messages SET status = 'generating' WHERE id = $1",
-                message_id,
-            )
-            await conn.execute(
-                "UPDATE wa_outbox SET status = 'generating' WHERE id = $1", outbox_id
-            )
-            # bot_generate_fn may raise (transient RAG error, or — in the
-            # human-send-only v1 — a NotImplementedError sentinel). Without this
-            # guard the exception bubbles to the scheduler and the row is left
-            # ORPHANED in 'generating' (reclaim only resets 'claimed' rows), so
-            # it is never retried nor surfaced. Mirror the send retry/backoff
-            # policy: retry with backoff up to MAX_ATTEMPTS, then mark failed.
-            try:
-                body_text = await bot_generate_fn(thread)
-            except Exception as gen_exc:
-                attempts += 1
-                if attempts >= MAX_ATTEMPTS:
-                    await conn.execute(
-                        "UPDATE wa_outbox SET status = 'failed', attempts = $2 WHERE id = $1",
-                        outbox_id,
-                        attempts,
-                    )
-                    await conn.execute(
-                        """
-                        UPDATE meta_inbox_messages
-                        SET status = 'failed', error = $2
-                        WHERE id = $1
-                        """,
-                        message_id,
-                        f"bot_generate_failed_after_{attempts}_attempts: {gen_exc}",
-                    )
-                    logger.error(
-                        "wa_outbox: bot generation failed permanently "
-                        "(outbox=%s thread=%s): %s",
-                        outbox_id,
-                        thread_id,
-                        gen_exc,
-                    )
-                    return "failed"
-
-                backoff = RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempts - 1))
+                if not acquired:
+                    # Another worker already owns this thread — leave the row
+                    # pending (SKIP LOCKED already released it at TX end) and
+                    # try the next candidate.
+                    continue
                 await conn.execute(
                     """
                     UPDATE wa_outbox
-                    SET status = 'pending', attempts = $2,
-                        next_retry_at = NOW() + ($3 * INTERVAL '1 second'),
-                        claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL
+                    SET status = 'claimed', claim_token = $2, claimed_at = NOW(),
+                        claim_expires_at = NOW() + ($3 * INTERVAL '1 second')
                     WHERE id = $1
                     """,
-                    outbox_id,
-                    attempts,
-                    backoff,
+                    candidate["id"],
+                    claim_token,
+                    CLAIM_LEASE_SECONDS,
                 )
+                claimed_row = candidate
+                thread_id_for_lock = candidate["thread_id"]
+                break
+
+        if claimed_row is None:
+            return "idle"
+
+        try:
+            return await _process_claimed_row(
+                conn, claimed_row, claim_token, whatsapp_service, bot_generate_fn
+            )
+        finally:
+            # MUST always run: this is a session-scoped advisory lock on a
+            # POOLED connection. If we don't release it here, the lock stays
+            # held by that Postgres backend session for as long as the
+            # connection lives in the pool — silently wedging every future
+            # claim attempt on this thread from ANY worker that happens to
+            # reuse this connection. (family #2 "esiste ≠ armato" shape: a
+            # missing finally here would be invisible until threads mysteriously
+            # stop getting replies.)
+            try:
                 await conn.execute(
-                    "UPDATE meta_inbox_messages SET status = 'queued' WHERE id = $1",
-                    message_id,
+                    f"SELECT pg_advisory_unlock({_THREAD_LOCK_KEY_SQL})",
+                    thread_id_for_lock,
                 )
-                logger.warning(
-                    "wa_outbox: bot generation failed (attempt %d/%d), retry in %ds "
-                    "(outbox=%s): %s",
-                    attempts,
-                    MAX_ATTEMPTS,
-                    backoff,
-                    outbox_id,
-                    gen_exc,
+            except Exception:
+                logger.exception(
+                    "wa_outbox: failed to release advisory lock for thread %s "
+                    "(connection likely unusable; will not be reused)",
+                    thread_id_for_lock,
                 )
-                return "retry"
 
-            await conn.execute(
-                "UPDATE meta_inbox_messages SET body = $2 WHERE id = $1",
-                message_id,
-                body_text,
-            )
-        else:
-            # Human send: the body is already on the ledger row.
-            ledger = await conn.fetchrow(
-                "SELECT body FROM meta_inbox_messages WHERE id = $1",
-                message_id,
-            )
-            body_text = (ledger["body"] if ledger else None) or ""
 
-        # 4. Enforce the Meta 24h customer-care window.
-        window_open = await conn.fetchval(
+async def _process_claimed_row(
+    conn: asyncpg.Connection,
+    row: asyncpg.Record,
+    claim_token: uuid.UUID,
+    whatsapp_service: Any,
+    bot_generate_fn: BotGenerateFn,
+) -> str:
+    """Everything after a row is claimed and its thread lock is held."""
+    outbox_id = row["id"]
+    thread_id = row["thread_id"]
+    message_id = row["message_id"]
+    needs_generation = row["needs_generation"]
+    attempts = row["attempts"]
+
+    # ``expected_status`` tracks wa_outbox.status as WE believe it to be after
+    # our own last successful fenced transition — every subsequent fenced
+    # UPDATE checks against it, and is updated only after that UPDATE itself
+    # confirms (via RETURNING) that it actually matched.
+    expected_status = "claimed"
+
+    # 3. Coalescing (P2) — before doing anything else, drop redundant pending
+    #    bot-reply rows of this thread. Safe from races: we hold the
+    #    per-thread advisory lock, so no other worker can claim a same-thread
+    #    row out from under this sweep.
+    if needs_generation:
+        await _coalesce_thread_bursts(conn, thread_id, outbox_id)
+
+    # Load the thread (human_handling gate + 24h window source).
+    thread = await conn.fetchrow(
+        """
+        SELECT thread_id, counterpart_phone, human_handling,
+               last_customer_at
+        FROM meta_inbox_threads
+        WHERE thread_id = $1
+        """,
+        thread_id,
+    )
+    if thread is None:
+        # Should not happen (FK), but never park the row.
+        fenced = await conn.fetchrow(
             """
-            SELECT last_customer_at IS NOT NULL
-               AND NOW() - last_customer_at < ($2 * INTERVAL '1 hour')
-            FROM meta_inbox_threads
-            WHERE thread_id = $1
+            UPDATE wa_outbox SET status = 'failed'
+            WHERE id = $1 AND claim_token = $2 AND status = $3
+            RETURNING id
             """,
-            thread_id,
-            CUSTOMER_WINDOW_HOURS,
+            outbox_id,
+            claim_token,
+            expected_status,
         )
-        if not window_open:
-            await conn.execute(
-                "UPDATE wa_outbox SET status = 'failed' WHERE id = $1", outbox_id
+        if fenced is None:
+            logger.warning("wa_outbox: fence lost before thread-missing failure (outbox=%s)", outbox_id)
+            return "fenced"
+        await conn.execute(
+            """
+            UPDATE meta_inbox_messages
+            SET status = 'failed', error = 'thread_missing'
+            WHERE id = $1
+            """,
+            message_id,
+        )
+        logger.error("wa_outbox: thread %s missing for outbox %s", thread_id, outbox_id)
+        return "failed"
+
+    # 4. Bot replies: re-check human_handling (takeover may have flipped it
+    #    since the webhook enqueued this row).
+    body_text: str
+    if needs_generation:
+        if thread["human_handling"]:
+            fenced = await conn.fetchrow(
+                """
+                UPDATE wa_outbox SET status = 'failed'
+                WHERE id = $1 AND claim_token = $2 AND status = $3
+                RETURNING id
+                """,
+                outbox_id,
+                claim_token,
+                expected_status,
             )
+            if fenced is None:
+                logger.warning(
+                    "wa_outbox: fence lost before pre-generation takeover abort (outbox=%s)",
+                    outbox_id,
+                )
+                return "fenced"
             await conn.execute(
                 """
                 UPDATE meta_inbox_messages
-                SET status = 'failed', error = '24h_window_closed'
+                SET status = 'failed', error = 'aborted_human_takeover'
                 WHERE id = $1
                 """,
                 message_id,
             )
-            logger.info("wa_outbox: 24h window closed for thread %s", thread_id)
-            return "window_closed"
+            logger.info(
+                "wa_outbox: aborted bot send for thread %s (human_handling=true)",
+                thread_id,
+            )
+            return "aborted_human"
 
-        # 5. Send via Graph (whatsapp_service hardcodes the target number).
+        fenced = await conn.fetchrow(
+            """
+            UPDATE wa_outbox SET status = 'generating'
+            WHERE id = $1 AND claim_token = $2 AND status = $3
+            RETURNING id
+            """,
+            outbox_id,
+            claim_token,
+            expected_status,
+        )
+        if fenced is None:
+            logger.warning("wa_outbox: fence lost before generating transition (outbox=%s)", outbox_id)
+            return "fenced"
+        expected_status = "generating"
         await conn.execute(
-            "UPDATE meta_inbox_messages SET status = 'sending' WHERE id = $1",
+            "UPDATE meta_inbox_messages SET status = 'generating' WHERE id = $1",
             message_id,
         )
+
+        # bot_generate_fn may raise (transient RAG error, or — in the
+        # human-send-only v1 — a NotImplementedError sentinel). Without this
+        # guard the exception bubbles to the scheduler and the row is left
+        # ORPHANED in 'generating' (reclaim only resets 'claimed' rows), so
+        # it is never retried nor surfaced. Mirror the send retry/backoff
+        # policy: retry with backoff up to MAX_ATTEMPTS, then mark failed.
+        #
+        # P5/P6: the heartbeat below renews claim_expires_at every ~60s for
+        # the duration of this await so a slow (but alive) generation is
+        # never reclaimed out from under this worker. It runs on the SAME
+        # connection as the rest of this function; that is only safe because
+        # bot_generate_fn (wa_inbox_bot.generate_bot_reply) never touches
+        # this connection — it acquires its own from the pool internally and
+        # talks to the RAG process over HTTP. The heartbeat is always
+        # cancelled and awaited-to-completion in `finally`, BEFORE the
+        # exception/success handling below touches `conn` again, so there is
+        # never a concurrent query in flight on this connection.
+        heartbeat_task = asyncio.create_task(
+            _lease_heartbeat_loop(conn, outbox_id, claim_token)
+        )
+        gen_exc: Exception | None = None
         try:
-            send_result = await whatsapp_service.send_message(
-                phone=thread["counterpart_phone"],
-                text=body_text,
-                reply_to_message_id=None,
-            )
-        except Exception as exc:
+            body_text = await bot_generate_fn(thread)
+        except Exception as exc:  # deliberately broad — see the retry/failed handling below
+            gen_exc = exc
+            body_text = ""
+        finally:
+            heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat_task
+
+        if gen_exc is not None:
             attempts += 1
             if attempts >= MAX_ATTEMPTS:
-                await conn.execute(
-                    "UPDATE wa_outbox SET status = 'failed', attempts = $2 WHERE id = $1",
+                fenced = await conn.fetchrow(
+                    """
+                    UPDATE wa_outbox SET status = 'failed', attempts = $2
+                    WHERE id = $1 AND claim_token = $3 AND status = $4
+                    RETURNING id
+                    """,
                     outbox_id,
                     attempts,
+                    claim_token,
+                    expected_status,
                 )
+                if fenced is None:
+                    logger.warning(
+                        "wa_outbox: fence lost before terminal gen-failure (outbox=%s)", outbox_id
+                    )
+                    return "fenced"
                 await conn.execute(
                     """
                     UPDATE meta_inbox_messages
@@ -354,69 +526,285 @@ async def process_outbox_once(
                     WHERE id = $1
                     """,
                     message_id,
-                    f"send_failed_after_{attempts}_attempts: {exc}",
+                    f"bot_generate_failed_after_{attempts}_attempts: {gen_exc}",
                 )
                 logger.error(
-                    "wa_outbox: send failed permanently (outbox=%s thread=%s): %s",
+                    "wa_outbox: bot generation failed permanently "
+                    "(outbox=%s thread=%s): %s",
                     outbox_id,
                     thread_id,
-                    exc,
+                    gen_exc,
                 )
                 return "failed"
 
             backoff = RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempts - 1))
-            await conn.execute(
+            fenced = await conn.fetchrow(
                 """
                 UPDATE wa_outbox
                 SET status = 'pending', attempts = $2,
                     next_retry_at = NOW() + ($3 * INTERVAL '1 second'),
                     claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL
-                WHERE id = $1
+                WHERE id = $1 AND claim_token = $4 AND status = $5
+                RETURNING id
                 """,
                 outbox_id,
                 attempts,
                 backoff,
+                claim_token,
+                expected_status,
+            )
+            if fenced is None:
+                logger.warning(
+                    "wa_outbox: fence lost before gen-failure retry requeue (outbox=%s)", outbox_id
+                )
+                return "fenced"
+            await conn.execute(
+                "UPDATE meta_inbox_messages SET status = 'queued' WHERE id = $1",
+                message_id,
             )
             logger.warning(
-                "wa_outbox: send failed (attempt %d/%d), retry in %ds (outbox=%s): %s",
+                "wa_outbox: bot generation failed (attempt %d/%d), retry in %ds "
+                "(outbox=%s): %s",
                 attempts,
                 MAX_ATTEMPTS,
                 backoff,
                 outbox_id,
-                exc,
+                gen_exc,
             )
             return "retry"
 
-        wamid = _extract_wamid(send_result)
-        async with conn.transaction():
+        await conn.execute(
+            "UPDATE meta_inbox_messages SET body = $2 WHERE id = $1",
+            message_id,
+            body_text,
+        )
+    else:
+        # Human send: the body is already on the ledger row.
+        ledger = await conn.fetchrow(
+            "SELECT body FROM meta_inbox_messages WHERE id = $1",
+            message_id,
+        )
+        body_text = (ledger["body"] if ledger else None) or ""
+
+    # 5. Pre-send fence (P4): re-confirm this worker still owns the lease
+    #    RIGHT before the irreversible Graph send, in the same transaction as
+    #    a fresh read of human_handling. This is what actually closes the
+    #    takeover-during-generation race — the earlier pre-generation check
+    #    (step 4 above) only catches a takeover that happened BEFORE
+    #    generation started.
+    async with conn.transaction():
+        fence_row = await conn.fetchrow(
+            """
+            UPDATE wa_outbox
+            SET claim_expires_at = NOW() + ($4 * INTERVAL '1 second')
+            WHERE id = $1 AND claim_token = $2 AND status = $3
+            RETURNING id
+            """,
+            outbox_id,
+            claim_token,
+            expected_status,
+            CLAIM_LEASE_SECONDS,
+        )
+        human_handling_now = False
+        if fence_row is not None and needs_generation:
+            human_handling_now = bool(
+                await conn.fetchval(
+                    "SELECT human_handling FROM meta_inbox_threads WHERE thread_id = $1",
+                    thread_id,
+                )
+            )
+
+    if fence_row is None:
+        logger.warning("wa_outbox: pre-send fence lost (outbox=%s status=%s)", outbox_id, expected_status)
+        return "fenced"
+
+    if needs_generation and human_handling_now:
+        # Operator took over WHILE we were generating — the reply we just
+        # produced must NEVER be sent.
+        await conn.execute(
+            """
+            UPDATE wa_outbox SET status = 'failed'
+            WHERE id = $1 AND claim_token = $2 AND status = $3
+            """,
+            outbox_id,
+            claim_token,
+            expected_status,
+        )
+        await conn.execute(
+            """
+            UPDATE meta_inbox_messages
+            SET status = 'failed', error = 'aborted_human_takeover_pre_send'
+            WHERE id = $1
+            """,
+            message_id,
+        )
+        logger.info(
+            "wa_outbox: aborted pre-send for thread %s (human_handling flipped true during generation)",
+            thread_id,
+        )
+        return "aborted_human"
+
+    # 6. Enforce the Meta 24h customer-care window.
+    window_open = await conn.fetchval(
+        """
+        SELECT last_customer_at IS NOT NULL
+           AND NOW() - last_customer_at < ($2 * INTERVAL '1 hour')
+        FROM meta_inbox_threads
+        WHERE thread_id = $1
+        """,
+        thread_id,
+        CUSTOMER_WINDOW_HOURS,
+    )
+    if not window_open:
+        fenced = await conn.fetchrow(
+            """
+            UPDATE wa_outbox SET status = 'failed'
+            WHERE id = $1 AND claim_token = $2 AND status = $3
+            RETURNING id
+            """,
+            outbox_id,
+            claim_token,
+            expected_status,
+        )
+        if fenced is None:
+            logger.warning("wa_outbox: fence lost before window-closed failure (outbox=%s)", outbox_id)
+            return "fenced"
+        await conn.execute(
+            """
+            UPDATE meta_inbox_messages
+            SET status = 'failed', error = '24h_window_closed'
+            WHERE id = $1
+            """,
+            message_id,
+        )
+        logger.info("wa_outbox: 24h window closed for thread %s", thread_id)
+        return "window_closed"
+
+    # 7. Send via Graph (whatsapp_service hardcodes the target number).
+    await conn.execute(
+        "UPDATE meta_inbox_messages SET status = 'sending' WHERE id = $1",
+        message_id,
+    )
+    try:
+        send_result = await whatsapp_service.send_message(
+            phone=thread["counterpart_phone"],
+            text=body_text,
+            reply_to_message_id=None,
+        )
+    except Exception as exc:
+        attempts += 1
+        if attempts >= MAX_ATTEMPTS:
+            fenced = await conn.fetchrow(
+                """
+                UPDATE wa_outbox SET status = 'failed', attempts = $2
+                WHERE id = $1 AND claim_token = $3 AND status = $4
+                RETURNING id
+                """,
+                outbox_id,
+                attempts,
+                claim_token,
+                expected_status,
+            )
+            if fenced is None:
+                logger.warning("wa_outbox: fence lost before terminal send-failure (outbox=%s)", outbox_id)
+                return "fenced"
             await conn.execute(
                 """
                 UPDATE meta_inbox_messages
-                SET status = 'sent', meta_message_id = $2, sent_at = NOW()
+                SET status = 'failed', error = $2
                 WHERE id = $1
                 """,
                 message_id,
-                wamid,
+                f"send_failed_after_{attempts}_attempts: {exc}",
             )
-            await conn.execute(
-                "UPDATE wa_outbox SET status = 'done' WHERE id = $1", outbox_id
+            logger.error(
+                "wa_outbox: send failed permanently (outbox=%s thread=%s): %s",
+                outbox_id,
+                thread_id,
+                exc,
             )
-            # Fold any status receipt that raced ahead of the send commit.
-            if wamid:
-                await _apply_pending_status(conn, wamid)
+            return "failed"
 
-        logger.info(
-            "wa_outbox: sent (outbox=%s thread=%s wamid=%s)",
+        backoff = RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempts - 1))
+        fenced = await conn.fetchrow(
+            """
+            UPDATE wa_outbox
+            SET status = 'pending', attempts = $2,
+                next_retry_at = NOW() + ($3 * INTERVAL '1 second'),
+                claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL
+            WHERE id = $1 AND claim_token = $4 AND status = $5
+            RETURNING id
+            """,
             outbox_id,
-            thread_id,
+            attempts,
+            backoff,
+            claim_token,
+            expected_status,
+        )
+        if fenced is None:
+            logger.warning("wa_outbox: fence lost before send-failure retry requeue (outbox=%s)", outbox_id)
+            return "fenced"
+        logger.warning(
+            "wa_outbox: send failed (attempt %d/%d), retry in %ds (outbox=%s): %s",
+            attempts,
+            MAX_ATTEMPTS,
+            backoff,
+            outbox_id,
+            exc,
+        )
+        return "retry"
+
+    # 8. The Graph send has now IRREVERSIBLY happened. Everything below is
+    #    best-effort bookkeeping — if the fenced commit below loses the race
+    #    (lease reclaimed in the tiny window between the pre-send fence and
+    #    here), we do NOT report "fenced" (that would imply nothing happened
+    #    externally, which is false: a message was sent). This is the
+    #    documented residual double-send window (spec P5): a crash or a lost
+    #    fence exactly here can leave the ledger unable to record 'sent',
+    #    and a reclaimer could hand the row to a second worker that sends
+    #    again. We do not implement reconciliation for this — the idea
+    #    (spec P5) is a periodic job that folds a matching wamid status
+    #    receipt into any 'sending'-stuck row older than N minutes; that is
+    #    out of scope for F1a.
+    wamid = _extract_wamid(send_result)
+    async with conn.transaction():
+        commit_fenced = await conn.fetchrow(
+            """
+            UPDATE wa_outbox SET status = 'done'
+            WHERE id = $1 AND claim_token = $2 AND status = $3
+            RETURNING id
+            """,
+            outbox_id,
+            claim_token,
+            expected_status,
+        )
+        await conn.execute(
+            """
+            UPDATE meta_inbox_messages
+            SET status = 'sent', meta_message_id = $2, sent_at = NOW()
+            WHERE id = $1
+            """,
+            message_id,
             wamid,
         )
-        return "sent"
+        # Fold any status receipt that raced ahead of the send commit.
+        if wamid:
+            await _apply_pending_status(conn, wamid)
 
+    if commit_fenced is None:
+        logger.error(
+            "wa_outbox: RESIDUAL DOUBLE-SEND WINDOW hit — message was sent (wamid=%s) "
+            "but the lease for outbox=%s was already lost by commit time; the ledger "
+            "row was still updated to 'sent' above. thread=%s",
+            wamid,
+            outbox_id,
+            thread_id,
+        )
 
-# TODO(scheduler): a background loop calling process_outbox_once(pool,
-# whatsapp_service, bot_generate_fn) every ~3s is required to drain the queue
-# in production. It is intentionally NOT wired here — the choice of host
-# (FastAPI lifespan asyncio task vs LaunchAgent vs WebhookProcessor sibling)
-# is an operator/deploy decision. process_outbox_once is the unit of work; the
-# loop just needs to call it, catch exceptions, and sleep ~3s between ticks.
+    logger.info(
+        "wa_outbox: sent (outbox=%s thread=%s wamid=%s)",
+        outbox_id,
+        thread_id,
+        wamid,
+    )
+    return "sent"

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
@@ -12,6 +12,7 @@ Covers the Option-B safety contract:
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -181,3 +182,85 @@ async def test_get_rag_client_applies_internal_key_header(monkeypatch):
     finally:
         await client.aclose()
         wa_inbox_bot._rag_client = None
+
+
+# ── P9: admission semaphore bounding concurrent RAG calls ──────────────────
+
+
+def test_bot_generation_semaphore_defaults_to_3(monkeypatch):
+    monkeypatch.delenv("WA_BOT_MAX_CONCURRENT_GENERATIONS", raising=False)
+    monkeypatch.setattr(wa_inbox_bot, "_bot_generation_semaphore", None)
+    sem = wa_inbox_bot._get_bot_generation_semaphore()
+    assert sem._value == 3
+
+
+def test_bot_generation_semaphore_env_override(monkeypatch):
+    monkeypatch.setattr(wa_inbox_bot, "_bot_generation_semaphore", None)
+    monkeypatch.setenv("WA_BOT_MAX_CONCURRENT_GENERATIONS", "7")
+    sem = wa_inbox_bot._get_bot_generation_semaphore()
+    assert sem._value == 7
+
+
+def test_bot_generation_semaphore_invalid_env_falls_back_to_3(monkeypatch):
+    monkeypatch.setattr(wa_inbox_bot, "_bot_generation_semaphore", None)
+    monkeypatch.setenv("WA_BOT_MAX_CONCURRENT_GENERATIONS", "not-a-number")
+    sem = wa_inbox_bot._get_bot_generation_semaphore()
+    assert sem._value == 3
+
+
+def test_bot_generation_semaphore_is_a_singleton(monkeypatch):
+    monkeypatch.setattr(wa_inbox_bot, "_bot_generation_semaphore", None)
+    monkeypatch.setenv("WA_BOT_MAX_CONCURRENT_GENERATIONS", "2")
+    first = wa_inbox_bot._get_bot_generation_semaphore()
+    # a second env value must NOT retroactively resize an already-built semaphore
+    monkeypatch.setenv("WA_BOT_MAX_CONCURRENT_GENERATIONS", "9")
+    second = wa_inbox_bot._get_bot_generation_semaphore()
+    assert first is second
+    assert second._value == 2
+
+
+@pytest.mark.asyncio
+async def test_bot_generation_semaphore_bounds_concurrent_rag_calls(monkeypatch):
+    """5 concurrent generate_bot_reply calls with max_concurrent=2 must never
+    have more than 2 RAG POSTs in flight at once."""
+    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
+    monkeypatch.setattr(wa_inbox_bot, "_bot_generation_semaphore", None)
+    monkeypatch.setenv("WA_BOT_MAX_CONCURRENT_GENERATIONS", "2")
+
+    in_flight = 0
+    max_in_flight = 0
+    lock = asyncio.Lock()
+
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock(return_value=None)
+    resp.json = MagicMock(return_value={"abstain": False, "answer": "ok"})
+
+    async def _post(url: str, json: dict[str, Any]) -> Any:
+        nonlocal in_flight, max_in_flight
+        async with lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.05)
+        async with lock:
+            in_flight -= 1
+        return resp
+
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=_post)
+
+    async def _get_client() -> Any:
+        return client
+
+    monkeypatch.setattr(wa_inbox_bot, "_get_rag_client", _get_client)
+
+    pool = _Pool(_ROWS_NEWEST_FIRST)
+    results = await asyncio.gather(
+        *[
+            wa_inbox_bot.generate_bot_reply(pool, _thread(thread_id=i))
+            for i in range(5)
+        ]
+    )
+
+    assert results == ["ok"] * 5
+    assert max_in_flight <= 2
+    assert client.post.await_count == 5

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_scheduler.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_scheduler.py
@@ -111,7 +111,78 @@ async def test_lifespan_light_disables_only_wa_outbox_scheduler(
     async with main_api.lifespan_light(app):
         await app.state._init_task
         assert app.state.notification_scheduler == "notification-scheduler"
-        assert app.state._wa_outbox_scheduler_task is None
+        assert app.state._wa_outbox_scheduler_tasks == []
+
+
+def test_wa_outbox_worker_count_defaults_to_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WA_OUTBOX_WORKERS", raising=False)
+    assert main_api._wa_outbox_worker_count() == 2
+
+
+@pytest.mark.parametrize("value,expected", [("1", 1), ("5", 5), ("0", 2), ("-3", 2), ("bogus", 2)])
+def test_wa_outbox_worker_count_env_override_and_fallback(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: int
+) -> None:
+    monkeypatch.setenv("WA_OUTBOX_WORKERS", value)
+    assert main_api._wa_outbox_worker_count() == expected
+
+
+@pytest.mark.asyncio
+async def test_lifespan_light_spawns_k_workers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """P9: WA_OUTBOX_WORKERS controls how many concurrent scheduler loops get
+    spawned, stored as a list on app.state._wa_outbox_scheduler_tasks (was a
+    single task pre-F1a)."""
+
+    class FakePool:
+        async def close(self) -> None:
+            pass
+
+    async def fake_initialize_services_light(app: Any) -> None:
+        app.state.db_pool = FakePool()
+
+    async def fake_init_scheduler(pool: Any) -> str:
+        return "notification-scheduler"
+
+    async def fake_close() -> None:
+        pass
+
+    calls: list[int] = []
+
+    async def fake_run_wa_outbox_scheduler(app: Any, worker_id: int = 0) -> None:
+        # Real loop is infinite; here it's a no-op that just records which
+        # worker_id it was spawned with and returns (shutdown/cancellation
+        # path is exercised separately by test_scheduler_cancels_cleanly).
+        calls.append(worker_id)
+
+    initializer_mod = ModuleType("backend.app.setup.service_initializer")
+    scheduler_mod = ModuleType("backend.app.modules.notifications.scheduler")
+    rag_proxy_mod = ModuleType("backend.app.rag_proxy")
+    wa_inbox_bot_mod = ModuleType("backend.services.integrations.wa_inbox_bot")
+    initializer_mod.initialize_services_light = fake_initialize_services_light
+    scheduler_mod.init_scheduler = fake_init_scheduler
+    rag_proxy_mod.close_proxy_client = fake_close
+    wa_inbox_bot_mod.close_rag_client = fake_close
+
+    monkeypatch.delenv("DISABLE_BACKGROUND_WORKERS", raising=False)
+    monkeypatch.setenv("WA_OUTBOX_SCHEDULER_ENABLED", "1")
+    monkeypatch.setenv("WA_OUTBOX_WORKERS", "2")
+    monkeypatch.setitem(sys.modules, "backend.app.setup.service_initializer", initializer_mod)
+    monkeypatch.setitem(sys.modules, "backend.app.modules.notifications.scheduler", scheduler_mod)
+    monkeypatch.setitem(sys.modules, "backend.app.rag_proxy", rag_proxy_mod)
+    monkeypatch.setitem(
+        sys.modules, "backend.services.integrations.wa_inbox_bot", wa_inbox_bot_mod
+    )
+    monkeypatch.setattr(main_api, "_run_wa_outbox_scheduler", fake_run_wa_outbox_scheduler)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with main_api.lifespan_light(app):
+        await app.state._init_task
+        assert len(app.state._wa_outbox_scheduler_tasks) == 2
+        # let the (no-op) spawned tasks run to completion
+        await asyncio.gather(*app.state._wa_outbox_scheduler_tasks)
+
+    assert sorted(calls) == [0, 1]
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_worker.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_worker.py
@@ -1,16 +1,29 @@
 """Tests for the WA Meta Inbox outbox worker (process_outbox_once).
 
-Covers (spec sezione 3 "Worker"):
+Covers (spec sezione 3 "Worker" + 2026-07-17 F1a hardening — zantara-wa-spec-v2
+sections P2-P6/D2):
   - happy path: claim a pending human send → Graph send → ledger sent + wamid +
     apply staged status receipt → outbox done.
-  - human_handling re-check abort for a bot reply (takeover after enqueue).
+  - human_handling re-check abort for a bot reply, BOTH before generation
+    (takeover already flagged when claimed) and AFTER generation (takeover
+    flips mid-generation — P4 pre-send fence).
   - 24h window closed → ledger failed + outbox failed (no send).
   - send HTTP failure → backoff retry (attempts++, status back to pending).
-  - idle when no due row.
+  - bot-generation failure → backoff retry / terminal failure.
+  - idle when no due row / when every due row's thread is already locked.
+  - per-thread coalescing at claim (P2): a burst of pending bot-reply rows for
+    the same thread is collapsed to one send, the rest marked superseded.
+  - per-thread advisory lock (P3): a claim attempt skips a candidate whose
+    thread is already locked and tries the next one.
+  - lease reclaimer now also covers 'generating' rows (P5/P6).
 
-The mock connection is scripted: fetchrow/fetchval return queued values in
-call order, execute records SQL. transaction() is a no-op async CM. The pool
-exposes execute() (reclaim) + acquire() (the claim/work conn).
+The mock connection is scripted: fetch/fetchrow/fetchval return queued values
+in call order (one independent queue per method — matches the worker calling
+each method for a different SQL shape), execute records SQL. ALL FOUR methods
+record into `executed` (uniform SQL/args audit trail) so fenced UPDATEs done
+via `fetchrow(...RETURNING id)` are just as assertable as plain `execute()`
+calls. transaction() is a no-op async CM. The pool exposes execute() (reclaim)
++ acquire() (the claim/work conn).
 """
 
 from __future__ import annotations
@@ -28,22 +41,30 @@ from backend.services.integrations.wa_outbox_worker import process_outbox_once
 class ScriptedConn:
     def __init__(
         self,
-        fetchrow_results: list[Any],
+        fetchrow_results: list[Any] | None = None,
         fetchval_results: list[Any] | None = None,
+        fetch_results: list[Any] | None = None,
     ) -> None:
         self.executed: list[tuple[str, tuple[Any, ...]]] = []
-        self._fetchrow = list(fetchrow_results)
+        self._fetchrow = list(fetchrow_results or [])
         self._fetchval = list(fetchval_results or [])
+        self._fetch = list(fetch_results or [])
 
     async def execute(self, sql: str, *args: Any) -> str:
         self.executed.append((sql, args))
         return "UPDATE 1"
 
     async def fetchrow(self, sql: str, *args: Any) -> Any:
+        self.executed.append((sql, args))
         return self._fetchrow.pop(0) if self._fetchrow else None
 
     async def fetchval(self, sql: str, *args: Any) -> Any:
+        self.executed.append((sql, args))
         return self._fetchval.pop(0) if self._fetchval else None
+
+    async def fetch(self, sql: str, *args: Any) -> list[Any]:
+        self.executed.append((sql, args))
+        return self._fetch.pop(0) if self._fetch else []
 
     def transaction(self) -> Any:
         @asynccontextmanager
@@ -82,9 +103,37 @@ async def _bot_gen(_thread: Any) -> str:
     return "generated bot reply"
 
 
+def _candidate(
+    id_: int,
+    thread_id: int = 7,
+    message_id: int = 100,
+    needs_generation: bool = False,
+    attempts: int = 0,
+) -> dict[str, Any]:
+    return {
+        "id": id_,
+        "thread_id": thread_id,
+        "message_id": message_id,
+        "needs_generation": needs_generation,
+        "attempts": attempts,
+    }
+
+
+def _thread_row(thread_id: int = 7, human_handling: bool = False) -> dict[str, Any]:
+    return {
+        "thread_id": thread_id,
+        "counterpart_phone": "628111",
+        "human_handling": human_handling,
+        "last_customer_at": "x",
+    }
+
+
+# ── idle / reclaim scope ──────────────────────────────────────────────────
+
+
 @pytest.mark.asyncio
 async def test_idle_when_no_due_row() -> None:
-    conn = ScriptedConn(fetchrow_results=[None])  # claim → nothing
+    conn = ScriptedConn(fetch_results=[[]])  # candidate scan → nothing
     pool = _make_pool(conn)
     result = await process_outbox_once(pool, _wa_service(), _bot_gen)
     assert result == "idle"
@@ -93,30 +142,40 @@ async def test_idle_when_no_due_row() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reclaim_covers_generating_rows_too() -> None:
+    """P5/P6: a crash mid bot-generation must not orphan the row forever —
+    the reclaimer's WHERE clause must cover 'generating', not just 'claimed'."""
+    conn = ScriptedConn(fetch_results=[[]])
+    pool = _make_pool(conn)
+
+    await process_outbox_once(pool, _wa_service(), _bot_gen)
+
+    pool.execute.assert_awaited_once()
+    reclaim_sql = pool.execute.call_args[0][0]
+    assert "'claimed'" in reclaim_sql
+    assert "'generating'" in reclaim_sql
+    assert "claim_expires_at < NOW()" in reclaim_sql
+
+
+# ── human send happy path ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
 async def test_human_send_happy_path_applies_staged_status() -> None:
+    candidate = _candidate(1, thread_id=7, message_id=100, needs_generation=False)
     conn = ScriptedConn(
         fetchrow_results=[
-            # claim
-            {
-                "id": 1,
-                "thread_id": 7,
-                "message_id": 100,
-                "needs_generation": False,
-                "attempts": 0,
-            },
-            # thread load (human_handling gate + window source)
-            {
-                "thread_id": 7,
-                "counterpart_phone": "628111",
-                "human_handling": True,
-                "last_customer_at": "x",
-            },
-            # ledger body load (human send)
-            {"body": "ciao dal team"},
-            # _apply_pending_status: staged receipt exists for the wamid
-            {"status": "delivered", "error": None},
+            _thread_row(human_handling=True),  # thread load (human_handling irrelevant to human send)
+            {"body": "ciao dal team"},  # ledger body load
+            {"id": 1},  # pre-send fence RETURNING
+            {"id": 1},  # final commit RETURNING
+            {"status": "delivered", "error": None},  # staged receipt exists
         ],
-        fetchval_results=[True],  # window_open
+        fetchval_results=[
+            True,  # advisory lock acquired for thread 7
+            True,  # window_open
+        ],
+        fetch_results=[[candidate]],  # candidate scan
     )
     pool = _make_pool(conn)
     svc = _wa_service(send_result={"messages": [{"id": "wamid.SENT.1"}]})
@@ -125,39 +184,32 @@ async def test_human_send_happy_path_applies_staged_status() -> None:
 
     assert result == "sent"
     svc.send_message.assert_awaited_once()
-    # ledger marked sent with the wamid
     assert any(
         "status = 'sent'" in s and "wamid.SENT.1" in str(a) for s, a in conn.executed
     )
-    # outbox marked done
     assert conn.sql_contains("UPDATE wa_outbox SET status = 'done'")
-    # staged receipt folded in + deleted
     assert any(
         "UPDATE meta_inbox_messages" in s and "delivered" in str(a) for s, a in conn.executed
     )
     assert conn.sql_contains("DELETE FROM wa_status_pending")
+    # advisory lock taken + released for the winning thread
+    assert conn.sql_contains("pg_try_advisory_lock")
+    assert any(7 in a for _, a in conn.sql_with_args("pg_advisory_unlock"))
 
 
 @pytest.mark.asyncio
-async def test_bot_reply_aborts_on_human_takeover() -> None:
+async def test_bot_reply_aborts_on_human_takeover_before_generation() -> None:
+    candidate = _candidate(2, thread_id=7, message_id=200, needs_generation=True)
     conn = ScriptedConn(
         fetchrow_results=[
-            # claim (bot reply, needs generation)
-            {
-                "id": 2,
-                "thread_id": 7,
-                "message_id": 200,
-                "needs_generation": True,
-                "attempts": 0,
-            },
-            # thread load → human took over
-            {
-                "thread_id": 7,
-                "counterpart_phone": "628111",
-                "human_handling": True,
-                "last_customer_at": "x",
-            },
-        ]
+            _thread_row(human_handling=True),  # already taken over at claim time
+            {"id": 2},  # fenced pre-generation abort RETURNING
+        ],
+        fetchval_results=[True],  # advisory lock
+        fetch_results=[
+            [candidate],  # candidate scan
+            [],  # coalesce sweep — nothing else pending for this thread
+        ],
     )
     pool = _make_pool(conn)
     svc = _wa_service()
@@ -172,24 +224,19 @@ async def test_bot_reply_aborts_on_human_takeover() -> None:
 
 @pytest.mark.asyncio
 async def test_window_closed_fails_without_send() -> None:
+    candidate = _candidate(3, thread_id=7, message_id=300, needs_generation=False)
     conn = ScriptedConn(
         fetchrow_results=[
-            {
-                "id": 3,
-                "thread_id": 7,
-                "message_id": 300,
-                "needs_generation": False,
-                "attempts": 0,
-            },
-            {
-                "thread_id": 7,
-                "counterpart_phone": "628111",
-                "human_handling": True,
-                "last_customer_at": "x",
-            },
+            _thread_row(human_handling=True),
             {"body": "late reply"},
+            {"id": 3},  # pre-send fence RETURNING
+            {"id": 3},  # window-closed fenced fail RETURNING
         ],
-        fetchval_results=[False],  # window_open = False (>24h)
+        fetchval_results=[
+            True,  # advisory lock
+            False,  # window_open = False (>24h)
+        ],
+        fetch_results=[[candidate]],
     )
     pool = _make_pool(conn)
     svc = _wa_service()
@@ -203,24 +250,16 @@ async def test_window_closed_fails_without_send() -> None:
 
 @pytest.mark.asyncio
 async def test_send_failure_retries_with_backoff() -> None:
+    candidate = _candidate(4, thread_id=7, message_id=400, needs_generation=False)
     conn = ScriptedConn(
         fetchrow_results=[
-            {
-                "id": 4,
-                "thread_id": 7,
-                "message_id": 400,
-                "needs_generation": False,
-                "attempts": 0,
-            },
-            {
-                "thread_id": 7,
-                "counterpart_phone": "628111",
-                "human_handling": True,
-                "last_customer_at": "x",
-            },
+            _thread_row(human_handling=True),
             {"body": "retry me"},
+            {"id": 4},  # pre-send fence RETURNING
+            {"id": 4},  # retry-requeue fenced RETURNING
         ],
-        fetchval_results=[True],  # window open
+        fetchval_results=[True, True],  # advisory lock, window_open
+        fetch_results=[[candidate]],
     )
     pool = _make_pool(conn)
     svc = _wa_service(raise_exc=RuntimeError("graph 500"))
@@ -228,7 +267,6 @@ async def test_send_failure_retries_with_backoff() -> None:
     result = await process_outbox_once(pool, svc, _bot_gen)
 
     assert result == "retry"
-    # back to pending with attempts incremented + next_retry_at backoff
     retry_updates = conn.sql_with_args("status = 'pending'")
     assert retry_updates, "expected an UPDATE back to pending for retry"
     assert any("next_retry_at" in s for s, _ in retry_updates)
@@ -240,23 +278,18 @@ async def test_bot_generate_failure_retries_not_orphaned() -> None:
     # Panel 2026-06-04 (Codex): a raising bot_generate_fn must NOT leave the row
     # orphaned in 'generating' — it must retry with backoff (the v1 sentinel
     # raises NotImplementedError, and a transient RAG error in B must retry too).
+    candidate = _candidate(6, thread_id=7, message_id=600, needs_generation=True)
     conn = ScriptedConn(
         fetchrow_results=[
-            {
-                "id": 6,
-                "thread_id": 7,
-                "message_id": 600,
-                "needs_generation": True,
-                "attempts": 0,
-            },
-            # thread load → human NOT handling, so the bot path proceeds
-            {
-                "thread_id": 7,
-                "counterpart_phone": "628111",
-                "human_handling": False,
-                "last_customer_at": "x",
-            },
-        ]
+            _thread_row(human_handling=False),
+            {"id": 6},  # generating-transition fenced RETURNING
+            {"id": 6},  # gen-failure retry-requeue fenced RETURNING
+        ],
+        fetchval_results=[True],  # advisory lock
+        fetch_results=[
+            [candidate],
+            [],  # coalesce sweep — nothing else pending
+        ],
     )
     pool = _make_pool(conn)
     svc = _wa_service()
@@ -268,7 +301,6 @@ async def test_bot_generate_failure_retries_not_orphaned() -> None:
 
     assert result == "retry"
     svc.send_message.assert_not_awaited()
-    # row went back to pending (NOT left in 'generating') + attempts incremented
     retry_updates = conn.sql_with_args("status = 'pending'")
     assert retry_updates, "bot-gen failure must re-queue, never orphan in generating"
     assert any("next_retry_at" in s for s, _ in retry_updates)
@@ -277,22 +309,18 @@ async def test_bot_generate_failure_retries_not_orphaned() -> None:
 
 @pytest.mark.asyncio
 async def test_bot_generate_failure_terminal_after_max_attempts() -> None:
+    candidate = _candidate(
+        7, thread_id=7, message_id=700, needs_generation=True,
+        attempts=wa_outbox_worker.MAX_ATTEMPTS - 1,
+    )
     conn = ScriptedConn(
         fetchrow_results=[
-            {
-                "id": 7,
-                "thread_id": 7,
-                "message_id": 700,
-                "needs_generation": True,
-                "attempts": wa_outbox_worker.MAX_ATTEMPTS - 1,
-            },
-            {
-                "thread_id": 7,
-                "counterpart_phone": "628111",
-                "human_handling": False,
-                "last_customer_at": "x",
-            },
-        ]
+            _thread_row(human_handling=False),
+            {"id": 7},  # generating-transition fenced RETURNING
+            {"id": 7},  # terminal-failure fenced RETURNING
+        ],
+        fetchval_results=[True],
+        fetch_results=[[candidate], []],
     )
     pool = _make_pool(conn)
     svc = _wa_service()
@@ -310,24 +338,19 @@ async def test_bot_generate_failure_terminal_after_max_attempts() -> None:
 
 @pytest.mark.asyncio
 async def test_send_failure_terminal_after_max_attempts() -> None:
+    candidate = _candidate(
+        5, thread_id=7, message_id=500, needs_generation=False,
+        attempts=wa_outbox_worker.MAX_ATTEMPTS - 1,
+    )
     conn = ScriptedConn(
         fetchrow_results=[
-            {
-                "id": 5,
-                "thread_id": 7,
-                "message_id": 500,
-                "needs_generation": False,
-                "attempts": wa_outbox_worker.MAX_ATTEMPTS - 1,
-            },
-            {
-                "thread_id": 7,
-                "counterpart_phone": "628111",
-                "human_handling": True,
-                "last_customer_at": "x",
-            },
+            _thread_row(human_handling=True),
             {"body": "last try"},
+            {"id": 5},  # pre-send fence RETURNING
+            {"id": 5},  # terminal send-failure fenced RETURNING
         ],
-        fetchval_results=[True],
+        fetchval_results=[True, True],
+        fetch_results=[[candidate]],
     )
     pool = _make_pool(conn)
     svc = _wa_service(raise_exc=RuntimeError("graph 500"))
@@ -337,3 +360,224 @@ async def test_send_failure_terminal_after_max_attempts() -> None:
     assert result == "failed"
     assert conn.sql_contains("UPDATE wa_outbox SET status = 'failed', attempts")
     assert any("send_failed_after_" in str(a) for _, a in conn.executed)
+
+
+# ── P2: per-thread coalescing at claim ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_coalescing_supersedes_other_pending_bot_replies_same_thread() -> None:
+    """2 pending bot-reply rows for the same thread → claim one, supersede the
+    other, send exactly one reply."""
+    winner = _candidate(10, thread_id=7, message_id=1000, needs_generation=True)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            _thread_row(human_handling=False),
+            {"id": 10},  # generating-transition fenced RETURNING
+            {"id": 10},  # pre-send fence RETURNING
+            {"id": 10},  # final commit RETURNING
+            None,  # no staged status receipt
+        ],
+        fetchval_results=[
+            True,  # advisory lock
+            False,  # human_handling re-read at pre-send (no takeover)
+            True,  # window_open
+        ],
+        fetch_results=[
+            [winner],  # candidate scan claims outbox id=10
+            [{"id": 11, "message_id": 1001}],  # coalesce sweep supersedes id=11
+        ],
+    )
+    pool = _make_pool(conn)
+    svc = _wa_service(send_result={"messages": [{"id": "wamid.BURST.1"}]})
+
+    result = await process_outbox_once(pool, svc, _bot_gen)
+
+    assert result == "sent"
+    svc.send_message.assert_awaited_once()  # exactly ONE reply for the burst
+    # the superseded row (id=11 / message 1001) was marked failed with the
+    # coalescing marker, never touched by a send
+    assert any(
+        "needs_generation = true" in s and (7, 10) == a for s, a in conn.executed
+    )
+    assert any(
+        "superseded_by_coalescing" in s and 1001 in a for s, a in conn.executed
+    )
+
+
+@pytest.mark.asyncio
+async def test_coalescing_does_not_touch_pending_human_sends() -> None:
+    """Coalescing must only ever supersede needs_generation=true rows — a
+    pending HUMAN send for the same thread must survive untouched (the SQL
+    filter itself enforces this; assert the coalesce query carries the
+    needs_generation=true predicate)."""
+    winner = _candidate(12, thread_id=7, message_id=1200, needs_generation=True)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            _thread_row(human_handling=False),
+            {"id": 12},
+            {"id": 12},
+            {"id": 12},
+            None,
+        ],
+        fetchval_results=[True, False, True],
+        fetch_results=[
+            [winner],
+            [],  # nothing superseded (the only other pending row is human-send, filtered out)
+        ],
+    )
+    pool = _make_pool(conn)
+    svc = _wa_service(send_result={"messages": [{"id": "wamid.X"}]})
+
+    result = await process_outbox_once(pool, svc, _bot_gen)
+
+    assert result == "sent"
+    coalesce_calls = conn.sql_with_args("needs_generation = true")
+    assert coalesce_calls, "coalesce query must filter on needs_generation = true"
+
+
+# ── P3: per-thread advisory lock excludes concurrent claim of a locked thread ──
+
+
+@pytest.mark.asyncio
+async def test_advisory_lock_skips_candidate_whose_thread_is_locked() -> None:
+    """Two candidates come back from the FOR UPDATE SKIP LOCKED scan: the
+    first belongs to a thread another worker already owns (lock try fails),
+    the second's thread is free. The worker must skip the first and claim the
+    second — never process two rows of a thread another worker holds."""
+    locked = _candidate(30, thread_id=99, message_id=3000, needs_generation=False)
+    free = _candidate(31, thread_id=7, message_id=3001, needs_generation=False)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            _thread_row(thread_id=7, human_handling=False),
+            {"body": "hi"},
+            {"id": 31},  # pre-send fence RETURNING
+            {"id": 31},  # final commit RETURNING
+            None,  # no staged receipt
+        ],
+        fetchval_results=[
+            False,  # advisory lock TRY for thread 99 → fails, already owned
+            True,  # advisory lock TRY for thread 7 → succeeds
+            True,  # window_open
+        ],
+        fetch_results=[[locked, free]],
+    )
+    pool = _make_pool(conn)
+    svc = _wa_service(send_result={"messages": [{"id": "wamid.FREE.1"}]})
+
+    result = await process_outbox_once(pool, svc, _bot_gen)
+
+    assert result == "sent"
+    # exactly two lock-try attempts, for both candidate threads in order
+    lock_tries = conn.sql_with_args("pg_try_advisory_lock")
+    assert len(lock_tries) == 2
+    assert lock_tries[0][1] == (99,)
+    assert lock_tries[1][1] == (7,)
+    # the row that actually got claimed is id=31 (thread 7), never id=30
+    claim_updates = conn.sql_with_args("SET status = 'claimed'")
+    assert len(claim_updates) == 1
+    assert claim_updates[0][1][0] == 31
+    # released the WON thread's lock (7), not the skipped one (99)
+    unlock_calls = conn.sql_with_args("pg_advisory_unlock")
+    assert len(unlock_calls) == 1
+    assert unlock_calls[0][1] == (7,)
+
+
+@pytest.mark.asyncio
+async def test_idle_when_every_candidate_thread_is_locked() -> None:
+    locked_a = _candidate(40, thread_id=101, needs_generation=False)
+    locked_b = _candidate(41, thread_id=102, needs_generation=False)
+    conn = ScriptedConn(
+        fetchval_results=[False, False],  # both candidates' threads owned elsewhere
+        fetch_results=[[locked_a, locked_b]],
+    )
+    pool = _make_pool(conn)
+
+    result = await process_outbox_once(pool, _wa_service(), _bot_gen)
+
+    assert result == "idle"
+    # no claim UPDATE happened, and (since claimed_row stayed None) no unlock
+    # call was made either — the lock was never acquired for anything.
+    assert not conn.sql_with_args("SET status = 'claimed'")
+    assert not conn.sql_with_args("pg_advisory_unlock")
+
+
+# ── P4: fencing abort — takeover mid-generation must result in NO send ─────
+
+
+@pytest.mark.asyncio
+async def test_fencing_aborts_send_when_takeover_happens_during_generation() -> None:
+    """human_handling is FALSE when the row is claimed (generation proceeds)
+    but flips to TRUE by the time we re-read it in the pre-send fence — the
+    reply that was just generated must never be sent, and the row must not
+    end up 'done'."""
+    candidate = _candidate(20, thread_id=7, message_id=2000, needs_generation=True)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            _thread_row(human_handling=False),  # NOT taken over yet at claim time
+            {"id": 20},  # generating-transition fenced RETURNING
+            {"id": 20},  # pre-send fence RETURNING (lease still ours)
+        ],
+        fetchval_results=[
+            True,  # advisory lock
+            True,  # human_handling re-read at pre-send → TRUE (takeover mid-gen)
+        ],
+        fetch_results=[[candidate], []],
+    )
+    pool = _make_pool(conn)
+    svc = _wa_service()
+
+    result = await process_outbox_once(pool, svc, _bot_gen)
+
+    assert result == "aborted_human"
+    svc.send_message.assert_not_awaited()
+    assert not conn.sql_contains("UPDATE wa_outbox SET status = 'done'")
+    assert conn.sql_contains("aborted_human_takeover_pre_send")
+    assert conn.sql_contains("UPDATE wa_outbox SET status = 'failed'")
+
+
+@pytest.mark.asyncio
+async def test_fencing_returns_fenced_when_lease_lost_before_generating_transition() -> None:
+    """The generating-transition UPDATE is fenced by claim_token+status; if it
+    matches zero rows (lease already reclaimed) the worker aborts silently
+    with 'fenced' rather than plowing ahead with generation on a row it no
+    longer owns."""
+    candidate = _candidate(21, thread_id=7, message_id=2100, needs_generation=True)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            _thread_row(human_handling=False),
+            None,  # generating-transition fence RETURNING → 0 rows matched
+        ],
+        fetchval_results=[True],
+        fetch_results=[[candidate], []],
+    )
+    pool = _make_pool(conn)
+    svc = _wa_service()
+
+    result = await process_outbox_once(pool, svc, _bot_gen)
+
+    assert result == "fenced"
+    svc.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fencing_returns_fenced_at_pre_send_when_lease_lost() -> None:
+    """Lease lost between the generating-transition and the pre-send fence
+    (e.g. a reclaimer beat the heartbeat) — abort before the Graph send."""
+    candidate = _candidate(22, thread_id=7, message_id=2200, needs_generation=True)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            _thread_row(human_handling=False),
+            {"id": 22},  # generating-transition fenced RETURNING → ok
+            None,  # pre-send fence RETURNING → 0 rows, lease lost
+        ],
+        fetchval_results=[True],
+        fetch_results=[[candidate], []],
+    )
+    pool = _make_pool(conn)
+    svc = _wa_service()
+
+    result = await process_outbox_once(pool, svc, _bot_gen)
+
+    assert result == "fenced"
+    svc.send_message.assert_not_awaited()

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_worker.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_outbox_worker.py
@@ -28,6 +28,8 @@ calls. transaction() is a no-op async CM. The pool exposes execute() (reclaim)
 
 from __future__ import annotations
 
+import asyncio
+import uuid
 from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -581,3 +583,94 @@ async def test_fencing_returns_fenced_at_pre_send_when_lease_lost() -> None:
 
     assert result == "fenced"
     svc.send_message.assert_not_awaited()
+
+
+# ── P5/P6: lease heartbeat during generation ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lease_heartbeat_loop_renews_and_stops_on_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct, timing-independent test of the heartbeat loop itself: each
+    sleep tick renews claim_expires_at fenced by claim_token+status, and a
+    CancelledError (task.cancel()) propagates rather than being swallowed."""
+    conn = ScriptedConn()
+    real_sleep = asyncio.sleep
+    tick_count = 0
+
+    async def _fast_sleep(_seconds: float) -> None:
+        nonlocal tick_count
+        tick_count += 1
+        if tick_count > 2:
+            raise asyncio.CancelledError
+        await real_sleep(0)
+
+    monkeypatch.setattr(wa_outbox_worker.asyncio, "sleep", _fast_sleep)
+
+    claim_token = uuid.uuid4()
+    with pytest.raises(asyncio.CancelledError):
+        await wa_outbox_worker._lease_heartbeat_loop(conn, 99, claim_token)
+
+    renewals = [
+        (s, a)
+        for s, a in conn.executed
+        if "claim_expires_at" in s and "status = 'generating'" in s
+    ]
+    assert len(renewals) == 2  # ticks 1 and 2 renewed; tick 3 raised before renewing
+    assert all(a[0] == 99 and a[1] == claim_token for _, a in renewals)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_started_during_generation_and_cancelled_after() -> None:
+    """The heartbeat task must be created before bot_generate_fn is awaited
+    and reliably cancelled+awaited-to-completion once it returns, regardless
+    of how long generation actually took."""
+    events: list[str] = []
+
+    async def _fake_heartbeat_loop(
+        _conn: Any, _outbox_id: int, _claim_token: uuid.UUID
+    ) -> None:
+        events.append("started")
+        try:
+            await asyncio.sleep(1000)  # would hang the test if never cancelled
+        except asyncio.CancelledError:
+            events.append("cancelled")
+            raise
+
+    # bot_generate_fn must actually yield to the event loop at least once for
+    # the concurrently-created heartbeat task to ever get a scheduling slice
+    # before we cancel it — a non-yielding stub (module-level `_bot_gen`, used
+    # everywhere else in this file) runs to completion in the same tick with
+    # zero awaits inside it, so `heartbeat_task.cancel()` would fire before
+    # asyncio ever ran the task even once. In production this is a non-issue:
+    # the real bot_generate_fn (wa_inbox_bot.generate_bot_reply) always awaits
+    # a real httpx call.
+    async def _yielding_bot_gen(_thread: Any) -> str:
+        await asyncio.sleep(0)
+        return "generated bot reply"
+
+    original = wa_outbox_worker._lease_heartbeat_loop
+    wa_outbox_worker._lease_heartbeat_loop = _fake_heartbeat_loop
+    try:
+        candidate = _candidate(60, thread_id=7, message_id=6000, needs_generation=True)
+        conn = ScriptedConn(
+            fetchrow_results=[
+                _thread_row(human_handling=False),
+                {"id": 60},  # generating-transition fenced RETURNING
+                {"id": 60},  # pre-send fence RETURNING
+                {"id": 60},  # final commit RETURNING
+                None,  # no staged receipt
+            ],
+            fetchval_results=[True, False, True],
+            fetch_results=[[candidate], []],
+        )
+        pool = _make_pool(conn)
+        svc = _wa_service(send_result={"messages": [{"id": "wamid.HB2"}]})
+
+        result = await process_outbox_once(pool, svc, _yielding_bot_gen)
+    finally:
+        wa_outbox_worker._lease_heartbeat_loop = original
+
+    assert result == "sent"
+    assert events == ["started", "cancelled"]


### PR DESCRIPTION
## Summary

Implements BUILD F1a of `zantara-wa-spec-v2.md` §D2 (items 1-5): outbox
correctness fixes land BEFORE concurrency, per the adversarial-panel-approved
design. Fixes 4 bugs that exist TODAY in production at K=1 (feature-independent
of any of the concurrency work), then ships K=2 workers on top once the
correctness fixes make that safe.

### Prod bugs fixed (existed today, K=1)

1. **Burst duplicate replies (P2)** — every inbound WA message enqueued its
   own `wa_outbox` row while the bot generator always answers the *latest*
   thread message, so a burst of 2-3 quick customer messages produced 2-3
   near-identical bot replies. Fix: **per-thread coalescing at claim** — once
   a bot-reply row is claimed, every OTHER pending bot-reply row of the same
   thread is superseded (`status='failed'`, ledger `error='superseded_by_coalescing'`).
   Pending HUMAN sends are never touched.

2. **Takeover-during-generation send (P4)** — `human_handling` was only
   checked once, before generation started; if the operator took over the
   thread WHILE the bot was mid-generation, the stale reply still got sent.
   Fix: a **fenced pre-send check** re-reads `human_handling` in the same
   transaction immediately before the Graph send — a takeover mid-generation
   now aborts with **no send**, row does not reach `'done'`.

3. **Generating-crash orphan (P5)** — the stale-claim reclaimer only reset
   rows stuck in `'claimed'`; a crash mid bot-generation left a row parked in
   `'generating'` forever. Fix: reclaimer now also covers `'generating'` rows
   whose lease expired.

4. **Lease == RAG timeout (P6)** — `CLAIM_LEASE_SECONDS` was 120s, identical
   to the RAG read-timeout, so a legitimately slow-but-alive generation could
   get reclaimed out from under itself. Fix: lease raised to 300s **plus a
   heartbeat** that renews `claim_expires_at` every ~60s while
   `bot_generate_fn` is in flight.

### Concurrency (P3, P9) — shipped only after the correctness fixes above

- **Per-thread advisory lock**: candidates are still scanned with
  `FOR UPDATE SKIP LOCKED`, but a candidate is only actually claimed after
  this worker wins `pg_try_advisory_lock(hashtext('wa_outbox_thread_'||thread_id))`.
  This is what stops two workers from concurrently processing two *different*
  rows of the *same* thread — SKIP LOCKED alone only dedupes the same row.
- **claim_token fencing**: every `wa_outbox` state-changing UPDATE after the
  claim is `WHERE id=$1 AND claim_token=$2 AND status=$3 RETURNING id`; zero
  rows matched means the lease was reclaimed/superseded since the last
  checkpoint, so the worker aborts silently (`"fenced"`) instead of acting on
  a row it no longer owns.
- **K=2 scheduler workers**: `main_api.py` spawns `WA_OUTBOX_WORKERS`
  (default 2, env-tunable) concurrent scheduler loops — safe now because of
  the advisory lock above.
- **Admission semaphore**: `wa_inbox_bot.py` bounds concurrent in-flight RAG
  calls from this api process to `WA_BOT_MAX_CONCURRENT_GENERATIONS` (default
  3), so K workers can't stampede the separate 2-vCPU `rag` Fly process group
  with more simultaneous agentic-RAG calls than it can serve.

### Design deviation (documented inline, justified here too)

Spec P3 literally says `pg_try_advisory_xact_lock` "inside the claim
transaction." This worker's claim transaction is intentionally short — it
commits immediately after marking the row `'claimed'`, before generation even
starts. An **xact-scoped** lock would therefore release the instant that
short transaction commits, i.e. before the window it's meant to protect
(claim → generate → send) even begins — defeating the purpose entirely.

Used the **session-scoped** `pg_try_advisory_lock` / `pg_advisory_unlock`
pair instead, held for the whole `claim → generate → send → commit`
lifetime on the same pooled connection, and *always* released in a `finally`
around the row-processing call. This last part matters: a leaked
session-scoped lock on a *pooled* connection would silently wedge every
future claim attempt on that thread by any worker that happens to reuse that
connection — the `finally` (with its own defensive try/except so a dead
connection can't mask the primary error) is what prevents that failure mode.

No schema change: reuses the existing `wa_outbox` CHECK-constrained states
(`pending|generating|claimed|done|failed`) throughout.

## Test plan

- [x] 55/55 unit tests green: `test_wa_outbox_worker.py` (18 — coalescing,
      advisory-lock candidate-skip, fencing-abort on takeover-during-generation
      and at each lease-loss checkpoint, lease-heartbeat renew+cancel),
      `test_wa_outbox_scheduler.py` (23 — K-worker spawn/shutdown,
      `WA_OUTBOX_WORKERS` parsing/fallback), `test_wa_inbox_bot.py` (14 —
      admission-semaphore default/override/fallback/singleton + a real
      concurrency test bounding max in-flight RAG POSTs).
- [x] `python -c "from backend.app.dependencies import get_current_user; print('OK')"` → `OK`
- [x] Pre-existing RAG regression suite unaffected: `test_kg_langgraph.py` +
      `test_kg_subgraphs.py` + `test_confidence.py` → 91/91 passed
- [x] `ruff check` clean on all 6 changed files
- [ ] Post-deploy: live same-thread burst → ONE reply; takeover during
      generation → NO bot send; K=2 with concurrent synthetic queries → zero
      duplicates, zero orphans (F1a acceptance criteria, spec §Phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
