### PR TITLE
fix(hooks): deploy runtime-state allowlist via installer + declare 3 hook pairs (superscar #1)

### DIFF
--- a/infra/claude-hooks/install_worktree_hooks.sh
+++ b/infra/claude-hooks/install_worktree_hooks.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# install_worktree_hooks.sh — install the two worktree-isolation hooks into
-# ~/.claude/hooks/ from this repo dir, then SELF-VERIFY with the innocence vaccine.
+# install_worktree_hooks.sh — install the two worktree-isolation hooks + the
+# runtime-state allowlist data into ~/.claude/hooks/ from this repo dir, then
+# SELF-VERIFY with the innocence vaccine.
 #
 # Why this exists: install_phase_aware.sh deliberately skips worktree_isolation.py
 # ("managed by W79"), so these two hooks had NO installer — which is exactly how
@@ -24,29 +25,43 @@ HOOKS=(worktree_isolation.py worktree_file_write_check.py)
 mkdir -p "$DST"
 
 declare -a BACKUPS=()
+declare -a NEW_FILES=()
 
 install_file() {
     local name="$1"
+    local mode="${2:-700}"   # .py hooks are executable (700); data files pass 644
     local src="$SRC/$name"
     local dst="$DST/$name"
     if [ ! -f "$src" ]; then
         echo "  SKIP $name (not in repo dir $SRC)"
         return 1
     fi
-    if [ -f "$dst" ] && ! diff -q "$src" "$dst" >/dev/null 2>&1; then
-        cp "$dst" "$dst.bak-pre-worktree-$TS"
-        BACKUPS+=("$dst.bak-pre-worktree-$TS:$dst")
-        echo "  backed up existing $name -> $name.bak-pre-worktree-$TS"
+    if [ -f "$dst" ]; then
+        if ! diff -q "$src" "$dst" >/dev/null 2>&1; then
+            cp -p "$dst" "$dst.bak-pre-worktree-$TS"   # -p: backup keeps original mode
+            BACKUPS+=("$dst.bak-pre-worktree-$TS:$dst")
+            echo "  backed up existing $name -> $name.bak-pre-worktree-$TS"
+        fi
+    else
+        # no prior version to back up → track so rollback removes it (not orphan it)
+        NEW_FILES+=("$dst")
     fi
     cp "$src" "$dst"
-    chmod 700 "$dst"
-    echo "  installed $name"
+    chmod "$mode" "$dst"
+    echo "  installed $name (mode $mode)"
 }
 
 echo "== installing worktree-isolation hooks into $DST =="
 for h in "${HOOKS[@]}"; do
     install_file "$h"
 done
+
+# runtime_state_allowlist.json is DATA read by worktree_isolation.py (the ff-only
+# exception's per-machine allowlist), NOT an executable hook — install it too, as
+# 644. Without this the JSON stays absent/stale live while the repo source moves:
+# the exact gap that shut the Pro ff-only exception and stranded W91's path fix
+# (superscar #1 applied to the guard's own data). Rolled back with the hooks.
+install_file runtime_state_allowlist.json 644
 
 echo "== self-verify: running the innocence vaccine against installed hooks =="
 # The vaccine copies the REPO hooks into a synthetic tempdir, so it validates the
@@ -61,10 +76,21 @@ if python3 "$SRC/test_hook_innocence.py" && python3 "$SRC/test_arm_keep_hook.py"
 fi
 
 echo "== VACCINE RED — rolling back to avoid leaving a broken hook live =="
-for pair in "${BACKUPS[@]}"; do
-    bak="${pair%%:*}"; orig="${pair##*:}"
-    cp "$bak" "$orig"
-    echo "  restored $orig from backup"
-done
+# NOTE: guard every array value-expansion with a count test — macOS /bin/bash is
+# 3.2, where `"${arr[@]}"` on an empty array aborts under `set -u` (would strand
+# the rollback half-done). `${#arr[@]}` is safe on an empty declared array.
+if [ ${#BACKUPS[@]} -gt 0 ]; then
+    for pair in "${BACKUPS[@]}"; do
+        bak="${pair%%:*}"; orig="${pair##*:}"
+        cp -p "$bak" "$orig"   # -p: restore original content AND mode
+        echo "  restored $orig from backup"
+    done
+fi
+if [ ${#NEW_FILES[@]} -gt 0 ]; then
+    for nf in "${NEW_FILES[@]}"; do
+        rm -f "$nf"
+        echo "  removed newly-installed $nf (had no prior version to restore)"
+    done
+fi
 echo "== rollback complete. Investigate test_hook_innocence.py failures before retrying. =="
 exit 1

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -335,6 +335,23 @@
       "repo": "infra/launchagents/wrappers/launchd-liveness-detector.sh",
       "_note": "liveness-detector-arm-0717 (PENDING-ARMS, not yet installed): declared pre-emptively so lint_home_fork.py --discover does not flag the future HOME-fork copy as undeclared once operator[control-plane] installs it. Pro-only by design (per-host launchd/log state — a Mini copy would need its own instance, not a shared one, cf. superscar #10 active-active).",
       "machines": ["pro"]
+    },
+    {
+      "live": "~/.claude/hooks/worktree_isolation.py",
+      "repo": "infra/claude-hooks/worktree_isolation.py",
+      "_note": "worktree-isolation guard (superscar #3, most-scarred guard in the organism). install via infra/claude-hooks/install_worktree_hooks.sh (self-verifying vaccine + rollback), NOT install_phase_aware.sh which skips it. Declared 2026-07-17 after an 11-day fleet-wide drift went unnoticed (no pair existed) — superscar #1 antidote applied to the guard itself.",
+      "machines": ["all"]
+    },
+    {
+      "live": "~/.claude/hooks/worktree_file_write_check.py",
+      "repo": "infra/claude-hooks/worktree_file_write_check.py",
+      "machines": ["all"]
+    },
+    {
+      "live": "~/.claude/hooks/runtime_state_allowlist.json",
+      "repo": "infra/claude-hooks/runtime_state_allowlist.json",
+      "_note": "DATA read by worktree_isolation.py (the ff-only exception's per-machine allowlist). install_worktree_hooks.sh deploys it as 644 alongside the two .py hooks.",
+      "machines": ["all"]
     }
   ],
   "allow": [


### PR DESCRIPTION
## What

Close the deploy gap behind #2576's Fix C: the `worktree_isolation` hook's runtime-state allowlist was never actually deployed to `~/.claude/hooks/`, so the repo fix (correct `published_articles.json` path) never reached the **hook** consumer live.

## Why (consumer-map, "merged ≠ live")

`worktree_isolation.py` reads the allowlist from `Path(__file__).parent / "runtime_state_allowlist.json"` — a HOME copy next to the hook. But `install_worktree_hooks.sh` copied only the two `.py` hooks, **never the JSON**. Result, fleet-wide, discovered live:

- **M5**: allowlist present but **dead** (stale bare-basename `published_articles.json`).
- **Pro / Mini**: allowlist **absent** → hook fail-closes the ff-only exception entirely.
- The hook `.py` itself was HOME-forked into **3 distinct stale versions** (M5 `#2266`, Pro/Mini `#2026`) — all clean historical snapshots, zero bespoke edits (proven by blob match to git history), 11 days stale, and **none declared** in `declared-pairs.json` so `lint_home_fork` never saw the drift.

## How

- `install_worktree_hooks.sh`: `install_file` gains a mode arg (`.py`=700, data=644) and now installs `runtime_state_allowlist.json` too. Rollback (on vaccine-red) also removes newly-created files.
- `declared-pairs.json`: declare all 3 (`worktree_isolation.py`, `worktree_file_write_check.py`, `runtime_state_allowlist.json`, machines `all`) — superscar #1 antidote applied to the guard itself, so future drift is caught.
- Installing origin/main is a pure **forward upgrade** everywhere (adds the allowlist feature #2266 + W92 cure + the ~/Desktop→~/nuzantara repoint #2499; loses nothing).

## Adversarial review (Codex gpt-5.6-sol, high)

Found 3 real issues; 2 fixed, 1 scoped-out:
1. **Fixed** — rollback aborted on empty array under `set -u` in **macOS bash 3.2** (pre-existing in the BACKUPS loop too). Guarded both loops with `${#arr[@]}`. Reproduced crash→survival under `/bin/bash 3.2`.
2. **Fixed** — rollback restored content but not file mode → `cp -p` on backup + restore. Verified 600 restored after a 644 install.
3. **Noted, out of scope** — `lint_home_fork.check_pairs()` treats an *absent* live file as not-a-breach (line ~187), so Pro/Mini's absent allowlist won't gate until first deploy. Pre-existing semantic affecting all pairs; the declaration still enforces content-parity fleet-wide post-deploy.

## Tests

- shellcheck clean; `declared-pairs.json` valid (64 pairs).
- Sandbox install (fake `$HOME`): all 3 deployed (700/700/644), fixed path present, **innocence + arm-keep vaccine GREEN**.
- Rollback harness under `/bin/bash` 3.2: empty-array survived + new file removed; mode 600 restored.

## Deploy (post-merge, by the session)

Run `bash infra/claude-hooks/install_worktree_hooks.sh` on M5/Pro/Mini (self-verifying vaccine + rollback), then PROVE-LIVE: all 3 live == repo, allowlist present with fixed path, `lint_home_fork` clean for the new pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
