### PR TITLE
fix(kbli): Fase 1 cure — detach 7 false-friend collision licensing blocks

### DIFF
--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
-  "lastModified": "2026-07-16",
-  "datasetSha256": "sha256:cf3deb265ac6c4778ad7c2125af44e79967c1f568d773450a58ea93e2ab3b8ee",
+  "lastModified": "2026-07-17",
+  "datasetSha256": "sha256:c61f1b237528d76342f826bc47b5f15ccc0a33daab5f5c1176efd5a7769dfd94",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/scripts/kbli_filiera/cure_canonical_collisions.py
+++ b/scripts/kbli_filiera/cure_canonical_collisions.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""cure_canonical_collisions.py — deterministic false-friend detach compiler.
+
+GARUDA-FILIERA Fase 1 (research/operations/2026-07-17-kbli-pilot-a1-results.md):
+7 KBLI-2025 codes carry a contaminated `per_skala` licensing block (wrong-vintage
+or wrong-source, image-verified by the pilot D6 gate). This script mechanically
+applies the SAME detach pattern already shipped for 68112 (PR #2508/#2527):
+
+  1. per_skala -> []  (frontend guards licensing.length > 0, so this renders an
+     honest "not yet defined" gap instead of wrong data)
+  2. the CURRENT per_skala value is moved verbatim into a new disputed key
+     (never silently deleted). If the record also carries per_skala_legacy,
+     BOTH are folded into the disputed key as {"per_skala": ..., "per_skala_legacy": ...}
+     and the top-level per_skala_legacy key is removed.
+  3. _data_note = the spec's data_note string (provenance, never authored here).
+  4. pp28_sources / intel_2026 / judul / uraian / pma_* / status_mapping / every
+     other field is left untouched.
+
+This script NEVER invents a licensing value — it is pure DETACH+PRESERVE, driven
+entirely by scripts/kbli_filiera/cure_specs/fase1_collisions.json (or whatever
+--spec points to). It is also the ONLY sanctioned writer of the canonical KBLI
+dataset: infra/claude-hooks/data_plane_guard.py blocks direct Edit/Write/sed/tee
+on data/source_documents/KBLI_2025_FINAL_CLEAN.json for every path except this
+program's own compilers/ (infra/claude-hooks/data-plane-registry.json, id
+"kbli-filiera") — opening the file inside this script is what is sanctioned;
+hand-editing it via Edit/Write/Bash text tools is not.
+
+Usage:
+  # dry run (default) — prints a per-code diff summary, writes nothing
+  python scripts/kbli_filiera/cure_canonical_collisions.py
+
+  # apply — mutates canonical, propagates to the 4 consumer copies via
+  # sync_kbli_dataset.sh, recomputes+writes the vitest sha256 sidecar
+  python scripts/kbli_filiera/cure_canonical_collisions.py --apply
+
+  # subset
+  python scripts/kbli_filiera/cure_canonical_collisions.py --only 49213 51103 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import logging
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("kbli_filiera.cure_canonical_collisions")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SPEC = REPO_ROOT / "scripts" / "kbli_filiera" / "cure_specs" / "fase1_collisions.json"
+DEFAULT_CANONICAL = REPO_ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync_kbli_dataset.sh"
+SIDECAR_PATH = REPO_ROOT / "apps" / "mouth" / "data" / "kbli-dataset-version.json"
+SIDECAR_DATASET_PATH = REPO_ROOT / "apps" / "mouth" / "data" / "KBLI_2025_FINAL_CLEAN.json"
+
+CODE_FIELD = "kode_kbli_2025"
+
+
+class CureError(RuntimeError):
+    """A spec/canonical mismatch severe enough to make the run's exit non-zero."""
+
+
+def _detect_indent(raw_text: str) -> int:
+    """Measure the JSON indent width from the file's own formatting rather than
+    assuming 2 — the dataset has always used 2-space indent, but Karpathy
+    discipline says measure, don't presume."""
+    for line in raw_text.splitlines()[1:8]:
+        stripped = line.lstrip(" ")
+        leading = len(line) - len(stripped)
+        if leading > 0:
+            return leading
+    return 2
+
+
+def load_spec(spec_path: Path) -> dict[str, Any]:
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    if "disputed_key" not in spec or "codes" not in spec:
+        raise CureError(f"{spec_path}: spec missing required 'disputed_key' or 'codes' key")
+    if not isinstance(spec["codes"], list) or not spec["codes"]:
+        raise CureError(f"{spec_path}: 'codes' must be a non-empty list")
+    return spec
+
+
+def _index_by_code(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {r[CODE_FIELD]: r for r in records if CODE_FIELD in r}
+
+
+class CurePlan:
+    """Outcome of evaluating one spec entry against the loaded canonical.
+
+    status:
+      "apply"          — record will be mutated (see `preview` for the diff facts)
+      "already-cured"  — per_skala == [] AND disputed_key present: idempotent no-op
+      "ambiguous-skip" — per_skala == [] but NO disputed_key: refuse to guess, skip
+      "missing"        — code not found in canonical at all
+    """
+
+    def __init__(
+        self,
+        code: str,
+        status: str,
+        *,
+        current_row_count: int = 0,
+        folds_legacy: bool = False,
+        disputed_key: str = "",
+        data_note: str = "",
+    ) -> None:
+        self.code = code
+        self.status = status
+        self.current_row_count = current_row_count
+        self.folds_legacy = folds_legacy
+        self.disputed_key = disputed_key
+        self.data_note = data_note
+
+    def describe(self) -> str:
+        note_preview = (self.data_note[:80] + "…") if len(self.data_note) > 80 else self.data_note
+        if self.status == "missing":
+            return f"{self.code}: NOT FOUND IN CANONICAL — cannot cure"
+        if self.status == "already-cured":
+            return f"{self.code}: ALREADY CURED (skip) — per_skala==[] and {self.disputed_key!r} present"
+        if self.status == "ambiguous-skip":
+            return (
+                f"{self.code}: AMBIGUOUS (skip, no clobber) — per_skala==[] but no "
+                f"{self.disputed_key!r} key; could be a different prior cure"
+            )
+        return (
+            f"{self.code}: per_skala {self.current_row_count} row(s) -> 0 | "
+            f"fold per_skala_legacy: {self.folds_legacy} | disputed_key: {self.disputed_key} | "
+            f"_data_note: {note_preview!r}"
+        )
+
+
+def plan_cure(record: dict[str, Any], entry: dict[str, Any], disputed_key: str) -> CurePlan:
+    code = entry["code"]
+    current_per_skala = record.get("per_skala")
+    has_disputed = disputed_key in record
+    is_empty = current_per_skala == []
+
+    if is_empty and has_disputed:
+        return CurePlan(code, "already-cured", disputed_key=disputed_key)
+    if is_empty and not has_disputed:
+        return CurePlan(code, "ambiguous-skip", disputed_key=disputed_key)
+
+    row_count = len(current_per_skala) if isinstance(current_per_skala, list) else 0
+    return CurePlan(
+        code,
+        "apply",
+        current_row_count=row_count,
+        folds_legacy="per_skala_legacy" in record,
+        disputed_key=disputed_key,
+        data_note=entry["data_note"],
+    )
+
+
+def apply_cure(record: dict[str, Any], entry: dict[str, Any], disputed_key: str) -> dict[str, Any]:
+    """Return a NEW record dict with the cure applied, preserving the original
+    field order and inserting the disputed key immediately after `per_skala`
+    (matching the 68112 template) and `_data_note` at the very end (also
+    matching the 68112 template)."""
+    current_per_skala = record.get("per_skala")
+    disputed_value: Any
+    if "per_skala_legacy" in record:
+        disputed_value = {
+            "per_skala": current_per_skala,
+            "per_skala_legacy": record["per_skala_legacy"],
+        }
+    else:
+        disputed_value = current_per_skala
+
+    new_record: dict[str, Any] = {}
+    for key, value in record.items():
+        if key == "per_skala_legacy":
+            continue  # folded into disputed_value above; dropped from top level
+        if key == "per_skala":
+            new_record["per_skala"] = []
+            new_record[disputed_key] = copy.deepcopy(disputed_value)
+            continue
+        new_record[key] = value
+    new_record["_data_note"] = entry["data_note"]
+    return new_record
+
+
+def run_sync_script() -> None:
+    logger.info("running %s sync", SYNC_SCRIPT)
+    result = subprocess.run(
+        ["bash", str(SYNC_SCRIPT), "sync"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        raise CureError(f"sync_kbli_dataset.sh sync failed with exit {result.returncode}")
+
+
+def update_sidecar() -> None:
+    if not SIDECAR_DATASET_PATH.exists():
+        raise CureError(f"sidecar dataset copy missing: {SIDECAR_DATASET_PATH} (sync must run first)")
+    digest = hashlib.sha256(SIDECAR_DATASET_PATH.read_bytes()).hexdigest()
+    sidecar = json.loads(SIDECAR_PATH.read_text(encoding="utf-8"))
+    before = dict(sidecar)
+    sidecar["datasetSha256"] = f"sha256:{digest}"
+    sidecar["lastModified"] = date.today().isoformat()
+    SIDECAR_PATH.write_text(
+        json.dumps(sidecar, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    logger.info("sidecar updated: %s -> %s", before.get("datasetSha256"), sidecar["datasetSha256"])
+    logger.info("sidecar lastModified: %s -> %s", before.get("lastModified"), sidecar["lastModified"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--spec", type=Path, default=DEFAULT_SPEC, help="cure spec JSON (default: fase1_collisions.json)")
+    parser.add_argument("--canonical", type=Path, default=DEFAULT_CANONICAL, help="canonical dataset to mutate")
+    parser.add_argument("--only", nargs="+", default=None, help="restrict to these KBLI codes")
+    parser.add_argument("--apply", action="store_true", help="mutate the canonical (default: dry-run, writes nothing)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+    spec = load_spec(args.spec)
+    disputed_key: str = spec["disputed_key"]
+    entries: list[dict[str, Any]] = spec["codes"]
+    if args.only:
+        wanted = set(args.only)
+        entries = [e for e in entries if e["code"] in wanted]
+        missing_requested = wanted - {e["code"] for e in entries}
+        if missing_requested:
+            raise CureError(f"--only requested codes not present in spec: {sorted(missing_requested)}")
+
+    if not args.canonical.exists():
+        raise CureError(f"canonical dataset not found: {args.canonical}")
+    raw_text = args.canonical.read_text(encoding="utf-8")
+    indent = _detect_indent(raw_text)
+    dataset = json.loads(raw_text)
+    records: list[dict[str, Any]] = dataset["data"]
+    by_code = _index_by_code(records)
+
+    plans: list[CurePlan] = []
+    problems: list[str] = []
+    for entry in entries:
+        code = entry["code"]
+        record = by_code.get(code)
+        if record is None:
+            plan = CurePlan(code, "missing")
+            problems.append(f"spec code {code!r} not found in canonical {args.canonical}")
+        else:
+            plan = plan_cure(record, entry, disputed_key)
+            if plan.status == "ambiguous-skip":
+                problems.append(
+                    f"code {code!r}: per_skala==[] with no {disputed_key!r} key — ambiguous prior "
+                    "state, skipped to avoid clobbering an unrelated cure"
+                )
+        plans.append(plan)
+
+    print(f"cure_canonical_collisions.py — spec={args.spec} canonical={args.canonical} "
+          f"mode={'APPLY' if args.apply else 'DRY-RUN'}")
+    print(f"disputed_key = {disputed_key!r}, indent = {indent}")
+    print("-" * 78)
+    for plan in plans:
+        print(plan.describe())
+    print("-" * 78)
+
+    applied = [p for p in plans if p.status == "apply"]
+    skipped = len(plans) - len(applied)
+    print(f"summary: {len(applied)} to cure, {skipped} skipped/missing, {len(problems)} problem(s)")
+
+    if not args.apply:
+        if problems:
+            for p in problems:
+                logger.error(p)
+            return 1
+        print("DRY RUN — no files written. Re-run with --apply to mutate the canonical.")
+        return 0
+
+    # --apply path
+    for entry, plan in zip(entries, plans):
+        if plan.status != "apply":
+            continue
+        code = entry["code"]
+        record = by_code[code]
+        idx = next(i for i, r in enumerate(records) if r.get(CODE_FIELD) == code)
+        records[idx] = apply_cure(record, entry, disputed_key)
+
+    if applied:
+        tmp_path = args.canonical.with_suffix(args.canonical.suffix + ".tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as f:
+                json.dump(dataset, f, ensure_ascii=False, indent=indent)
+            tmp_path.replace(args.canonical)
+            logger.info("wrote %d cured record(s) to %s", len(applied), args.canonical)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+        run_sync_script()
+        update_sidecar()
+    else:
+        logger.info("nothing to apply — skipping sync + sidecar update")
+
+    if problems:
+        for p in problems:
+            logger.error(p)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kbli_filiera/cure_specs/fase1_collisions.json
+++ b/scripts/kbli_filiera/cure_specs/fase1_collisions.json
@@ -1,0 +1,50 @@
+{
+  "_doc": "GARUDA-FILIERA Fase 1 cure spec — the 7 KBLI-2025 codes quarantined by pilot A1 (research/operations/2026-07-17-kbli-pilot-a1-results.md), each with an image-verified provenance note from the D6 final gate. This file is the deterministic compiler's INPUT (provenance, authored from the pilot's image-verified findings); scripts/kbli_filiera/cure_canonical_collisions.py mechanically applies the false-friend detach pattern from it. It NEVER authors a replacement licensing value (rule #9 no-new-values-without-provenance / rule #4 detach>plausible-remap): the cure is DETACH (per_skala -> []) + PRESERVE the contaminated block under a disputed key (audit, never silent-delete) + a corroborated _data_note + keep pp28_sources for provenance. The frontend already guards licensing.length>0, so a detached code renders 'licensing not yet defined' (honest gap) rather than wrong data. 68112 was cured earlier (#2508/#2527) with this same pattern and is the template.",
+  "_provenance": "Every note below cites a vault artifact re-read at the D6 gate (BPS Tabel Konversi Vol.2 sha 29f17b3b, PP28 BPK renders, OSS ABSENT.json). Pilot pre-registration: research/operations/2026-07-17-kbli-pilot-a1-preregistration.md. Do NOT edit the served dataset by hand — data-plane guard #2550 blocks it; route changes through the compiler.",
+  "version": 1,
+  "disputed_key": "per_skala_disputed_pp28_collision",
+  "codes": [
+    {
+      "code": "49213",
+      "flavor": "digit-collision-authority",
+      "judul": "Angkutan Perkotaan",
+      "data_note": "KBLI 2025 code 49213 = 'Angkutan Perkotaan' (intra-city urban bus transport). Its pp28_sources included OLD KBLI-2020 code 49213 = 'Angkutan Bus Antarkota Dalam Provinsi (AKDP)' (inter-city provincial bus) — a code-NUMBER collision across the 2020->2025 renumbering, image-verified on PP 28/2025 render 394945 p.I.I.36 (Kewenangan=Gubernur, 'lingkup operasionalnya antarkota dalam provinsi'). The served per_skala therefore carried the WRONG licensing authority level (Gubernur/provincial) for an intra-city activity whose correct authority is Wali Kota/Bupati (city), image-verified on render 394945 p.I.I.65 (OLD-49413 'Angkutan Perkotaan Bukan Bus', Kewenangan=Wali Kota). The crosswalk-correct predecessor of NEW-49213 is 49413 (not OLD-49213, which maps forward to NEW-49222). per_skala detached; correct city-level licensing pending a D2 image-extraction of 49413's PP28 rows (not fabricated here). BPS Vol.2 sha 29f17b3b."
+    },
+    {
+      "code": "51103",
+      "flavor": "cross-vintage-aviation-to-space",
+      "judul": "Transportasi Antariksa untuk Penumpang",
+      "data_note": "KBLI 2025 code 51103 = 'Transportasi Antariksa untuk Penumpang' (space passenger transport), a genuinely NEW activity. Per BPS Tabel Konversi Vol.2 lampiran5 p.193 (image-verified), old-51109 SPLITS into new-51101 (scheduled airline) + new-51103 (space). Its pp28_sources [51103,51108,51104] are all KBLI-2020-vintage AVIATION codes (aircraft operator / AOC / cargo-carrier insurance requirements) — a code-number collision, not the same activity. OSS ruang-lingkup returns 404 (no published NSPK for this new code). Aviation licensing detached; no space-transport NSPK exists to substitute. BPS Vol.2 sha 29f17b3b."
+    },
+    {
+      "code": "51203",
+      "flavor": "cross-vintage-aviation-to-space",
+      "judul": "Transportasi Antariksa untuk Barang",
+      "data_note": "KBLI 2025 code 51203 = 'Transportasi Antariksa untuk Barang' (space cargo transport), a NEW activity. Per BPS lampiran5 p.193 (image-verified), old-51204 (unscheduled international air cargo) SPLITS into new-51202 + new-51203 (space); the freed number 51203 also collides with old-51203 (which maps forward to new-51201). Its pp28_source [51203] carried KBLI-2020 scheduled-air-cargo licensing (aircraft type/quantity, AOC/ROC, cargo insurance) — 100% aviation, zero space content — a code-number collision. OSS ruang-lingkup 404. Aviation licensing detached. BPS Vol.2 sha 29f17b3b."
+    },
+    {
+      "code": "20111",
+      "flavor": "merge-aggregation-unverified",
+      "judul": "Industri Asam, Basa, dan Garam Anorganik",
+      "data_note": "KBLI 2025 code 20111 is a MANY-TO-ONE MERGE target, image-verified on BPS lampiran5 p.140-141: three KBLI-2020 codes converge into it — old-20111 (Khlor-Alkali), old-20114 (Anorganik Lainnya), old-20118 (Organik->Bahan Kimia Khusus). The served per_skala reflected a single-source inheritance (aggregation_note 'Dati da 20111'), not the aggregation across all three feeders that a MERGE requires. Detached pending a proper multi-source licensing extraction; a single-feeder block is neither complete nor certifiable for the merged code. BPS Vol.2 sha 29f17b3b."
+    },
+    {
+      "code": "50115",
+      "flavor": "wrong-mode-source-absent",
+      "judul": "Angkutan Laut Luar Negeri untuk Wisata",
+      "data_note": "KBLI 2025 code 50115 = 'Angkutan Laut Luar Negeri untuk Wisata' (international SEA tourism transport). Its declared pp28_source [51107] is an AIR-transport code ('Angkutan Udara untuk Wisata') — a transport-MODE mismatch — and 51107 was NOT found anywhere in the 21-file PP 28/2025 vault (11,208 pages scanned; pp28/ABSENT.json, verdict=absent). The crosswalk-true predecessor is 50122 (sea, image-verified lampiran5 p.191 / lampiran10 p.387). The served per_skala is sourced from the wrong mode and cannot be verified; detached pending 50122's own PP28 licensing. BPS Vol.2 sha 29f17b3b."
+    },
+    {
+      "code": "60312",
+      "flavor": "absent-source",
+      "judul": "Aktivitas Kantor Berita oleh Swasta",
+      "data_note": "KBLI 2025 code 60312 = 'Aktivitas Kantor Berita oleh Swasta' (private news agency). Its declared pp28_source [63912] could NOT be located across the 21-file PP 28/2025 vault (11,208 pages; pp28/ABSENT.json, verdict=absent). The crosswalk itself is clean (old-63912 -> new-60312, coherent Swasta renumbering, image-verified lampiran5 p.216 / lampiran10 p.409), but the licensing block's declared source is unverifiable in the pinned vault. Detached pending source location (may exist in a PP28 volume outside the 21-file corpus — conservative quarantine, not a certified 'source is bogus'). BPS Vol.2 sha 29f17b3b."
+    },
+    {
+      "code": "64310",
+      "flavor": "wrong-pointer",
+      "judul": "Aktivitas Dana Pasar Uang",
+      "data_note": "KBLI 2025 code 64310 = 'Aktivitas Dana Pasar Uang' (money-market fund), image-verified as a SPLIT of old-64300 into 64310/64320/64330 (lampiran5 p.203 / lampiran10 p.412). Its declared pp28_source [96122] points to PP 28/2025 Lampiran I.L.101 row 76 = 'Aktivitas SPA (Sante Par Aqua)' (image-verified render 394946 p.223) — a wholly unrelated activity (spa/wellness, Menengah Tinggi, LSPr). The licensing block was transplanted from a wrong-pointer source. Detached; no money-market-fund PP28 row substituted (not extracted). BPS Vol.2 sha 29f17b3b."
+    }
+  ]
+}

--- a/scripts/tests/test_kbli_false_friend_registry.py
+++ b/scripts/tests/test_kbli_false_friend_registry.py
@@ -1,0 +1,597 @@
+"""Regression registry — KBLI false-friend per_skala collisions (68112 pattern,
+generalized to all 8 known instances, 2026-07-17).
+
+This file folds in (verbatim, unmodified assertions) the original
+test_kbli_68112_pp28_mice_collision.py — 68112 coverage MUST survive — and adds
+a registry-driven suite for the 7 codes cured by GARUDA-FILIERA Fase 1
+(scripts/kbli_filiera/cure_canonical_collisions.py driven by
+scripts/kbli_filiera/cure_specs/fase1_collisions.json): 49213, 51103, 51203,
+20111, 50115, 60312, 64310.
+
+Cure pattern (identical for all 8, see cure_canonical_collisions.py docstring):
+  1. per_skala -> []  (frontend guards licensing.length > 0 -> honest "not yet
+     defined" gap instead of wrong data)
+  2. the ORIGINAL per_skala (+ per_skala_legacy, if present) preserved verbatim
+     under a disputed key — never silently deleted
+  3. _data_note added (verbatim from the cure spec — never invented here)
+  4. pp28_sources / intel_2026 / judul / uraian / pma_* / status_mapping / every
+     other field left untouched
+
+Scar-family #3 (guard-over-match/under-match) discipline applies throughout:
+every guilt assertion below is paired with an innocence assertion on a
+legitimate neighbor code, and every content marker is a multi-word phrase or
+a case-sensitive whole-word Indonesian/technical term verified (via direct
+tool-call inspection of the served dataset, not assumed) to actually appear
+in the disputed content or disclaiming prose it guards — never a bare
+substring like "SPA" that would false-positive on "space"/"aerospace".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FASE1_SPEC_PATH = REPO_ROOT / "scripts/kbli_filiera/cure_specs/fase1_collisions.json"
+
+# Every SERVED/canonical copy that must stay clean. Gitignored RAG runtime
+# copies are materialized by scripts/sync_kbli_dataset.sh at build/apply time
+# and may be absent on a fresh checkout/CI runner — skipped if missing, same
+# convention the original 68112 test used. This list covers all 4 consumer
+# copies scripts/sync_kbli_dataset.sh propagates (the original 68112 test only
+# checked 3 of the 4 — apps/backend-rag/source_documents/ was missing; adding
+# it here is a strict superset, not a narrowing, of 68112's prior coverage).
+ALL_DATASET_COPIES = [
+    REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json",  # production, balizero.com/kbli
+    REPO_ROOT / "data/source_documents/KBLI_2025_FINAL_CLEAN.json",  # canonical (via source_documents/ symlink)
+    REPO_ROOT / "apps/backend-rag/backend/data/KBLI_2025_FINAL_CLEAN.json",  # gitignored, RAG runtime
+    REPO_ROOT / "apps/backend-rag/source_documents/KBLI_2025_FINAL_CLEAN.json",  # gitignored, RAG runtime
+]
+
+
+def _existing_dataset_copies() -> list[Path]:
+    return [p for p in ALL_DATASET_COPIES if p.exists()]
+
+
+def _load_by_code(path: Path) -> dict[str, dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {r["kode_kbli_2025"]: r for r in data["data"] if "kode_kbli_2025" in r}
+
+
+def _load_record(path: Path, code: str) -> dict[str, Any]:
+    rec = _load_by_code(path).get(code)
+    if rec is None:
+        raise AssertionError(f"{path}: record {code} not found in dataset")
+    return rec
+
+
+def _contains_word_or_phrase(haystack: str, marker: str) -> bool:
+    """Word-boundary-safe containment check (scar-family #3 antidote): a
+    single-word marker is matched with regex word boundaries so it cannot
+    false-positive inside a longer word (e.g. bare 'SPA' inside 'aerospace').
+    A multi-word phrase (contains a space) is matched as a plain substring —
+    the multi-word shape itself is already a strong disambiguator."""
+    if " " in marker:
+        return marker in haystack
+    return re.search(rf"\b{re.escape(marker)}\b", haystack) is not None
+
+
+# ---------------------------------------------------------------------------
+# Registry: all 8 known false-friend per_skala collisions.
+#
+# `marker_in_disputed` — whether the content marker is verified (by direct
+# read of the served dataset) to literally appear inside the disputed key's
+# preserved blob. True for 7 of 8: 64310 is the exception — its actual
+# per_skala content, once inspected, turned out to be a generic low-risk NIB
+# template with no code-specific vocabulary (the "Sante Par Aqua" identity of
+# the wrong pp28 pointer target lives only in the disclaiming _data_note
+# prose, not in the licensing rows themselves). Asserting the marker inside
+# the disputed key for 64310 would be a fabricated claim about the data — so
+# that check is skipped for 64310 specifically, and the marker is instead
+# checked for presence in `_data_note` (the disclaiming surface where it
+# genuinely lives) and continued absence from per_skala/intel_2026.
+#
+# `check_intel_clean` — whether "marker not present in intel_2026" is a valid
+# guilt check for this code. True for all 7 Fase-1 codes (verified clean of
+# wrong-licensing markers per the pilot D6 gate). False for 68112: its
+# corrected intel_2026.whatYouNeed LEGITIMATELY mentions "MICE"/"Venue" as
+# disclaiming prose (explaining the collision to the client) — a blind
+# "marker never in intel_2026" rule would false-positive on 68112's own fix.
+# 68112's nuanced disclaimer-aware whole-record scan lives in the folded-in
+# legacy tests below instead.
+FALSE_FRIENDS: list[dict[str, Any]] = [
+    {
+        "code": "68112",
+        "disputed_key": "per_skala_disputed_pp28_mice",
+        "marker": "MICE",
+        "marker_in_disputed": True,
+        "check_intel_clean": False,
+    },
+    {
+        "code": "49213",
+        "disputed_key": "per_skala_disputed_pp28_collision",
+        "marker": "Gubernur",
+        "marker_in_disputed": True,
+        "check_intel_clean": True,
+    },
+    {
+        "code": "51103",
+        "disputed_key": "per_skala_disputed_pp28_collision",
+        "marker": "pesawat udara",
+        "marker_in_disputed": True,
+        "check_intel_clean": True,
+    },
+    {
+        "code": "51203",
+        "disputed_key": "per_skala_disputed_pp28_collision",
+        "marker": "pesawat udara",
+        "marker_in_disputed": True,
+        "check_intel_clean": True,
+    },
+    {
+        "code": "20111",
+        "disputed_key": "per_skala_disputed_pp28_collision",
+        "marker": "Khlor dan Alkali",
+        "marker_in_disputed": True,
+        "check_intel_clean": True,
+    },
+    {
+        "code": "50115",
+        "disputed_key": "per_skala_disputed_pp28_collision",
+        "marker": "Distribusi Ikan",
+        "marker_in_disputed": True,
+        "check_intel_clean": True,
+    },
+    {
+        "code": "60312",
+        "disputed_key": "per_skala_disputed_pp28_collision",
+        "marker": "lembaga penyiaran",
+        "marker_in_disputed": True,
+        "check_intel_clean": True,
+    },
+    {
+        "code": "64310",
+        "disputed_key": "per_skala_disputed_pp28_collision",
+        "marker": "Sante Par Aqua",
+        "marker_in_disputed": False,  # see registry docstring above
+        "check_intel_clean": True,
+    },
+]
+
+FASE1_CODES = [
+    "49213", "51103", "51203", "20111", "50115", "60312", "64310",
+]
+
+# Legitimate neighbor codes that must be UNTOUCHED by this cure (innocence
+# guard, scar-family #3): each is verified (2026-07-17) to legitimately carry
+# non-empty per_skala licensing. If the cure ever over-reaches onto one of
+# these, this must fail.
+#   68124 — real MICE/convention-venue code (68112's true neighbor)
+#   49222 — real AKDP (Angkutan Antarkota Dalam Provinsi) successor
+#   51101 — real scheduled airline code (51103's aviation neighbor)
+#   20112 — real Industri Gas Industri (20111's chemical-industry neighbor)
+#   50122 — real Angkutan Laut Dalam Negeri untuk Barang Khusus (50115's
+#            crosswalk-true sea-transport predecessor, per the cure's own note)
+#   64121 — real conventional bank (64310's financial-sector neighbor)
+INNOCENT_NEIGHBORS = ["68124", "49222", "51101", "20112", "50122", "64121"]
+
+
+# ---------------------------------------------------------------------------
+# Registry-driven GUILT tests — structural core, all 8 codes, all copies.
+# ---------------------------------------------------------------------------
+
+_DATASET_IDS = [str(p.relative_to(REPO_ROOT)) for p in _existing_dataset_copies()]
+
+
+@pytest.mark.parametrize(
+    "path", _existing_dataset_copies(), ids=_DATASET_IDS,
+)
+@pytest.mark.parametrize(
+    "friend", FALSE_FRIENDS, ids=[f["code"] for f in FALSE_FRIENDS],
+)
+def test_false_friend_per_skala_detached_and_audited(path: Path, friend: dict[str, Any]):
+    """Core GUILT check, all 8: per_skala must be [], the disputed key must be
+    present and non-empty (audit trail preserved, never silently deleted),
+    and _data_note must be present (non-empty)."""
+    rec = _load_record(path, friend["code"])
+    assert rec.get("per_skala") == [], (
+        f"{path}: {friend['code']}.per_skala is not [] — the false-friend "
+        "licensing block has leaked back into the served field."
+    )
+    disputed = rec.get(friend["disputed_key"])
+    assert disputed, (
+        f"{path}: {friend['code']} is missing (or has an empty) "
+        f"{friend['disputed_key']!r} — the original block must be preserved "
+        "for audit, never silently deleted."
+    )
+    note = rec.get("_data_note", "")
+    assert note, f"{path}: {friend['code']} is missing _data_note."
+
+
+@pytest.mark.parametrize(
+    "friend", FALSE_FRIENDS, ids=[f["code"] for f in FALSE_FRIENDS],
+)
+def test_false_friend_marker_present_in_disputed_key_where_expected(friend: dict[str, Any]):
+    """Where the content marker is verified to genuinely live in the disputed
+    blob (all but 64310, see registry docstring), assert it is still there —
+    proof the preserved content is the REAL contaminated block, not a stub."""
+    if not friend["marker_in_disputed"]:
+        pytest.skip(f"{friend['code']}: marker lives in _data_note prose, not the disputed blob (see registry docstring)")
+    path = REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+    rec = _load_record(path, friend["code"])
+    blob = json.dumps(rec[friend["disputed_key"]], ensure_ascii=False)
+    assert _contains_word_or_phrase(blob, friend["marker"]), (
+        f"{friend['code']}: expected marker {friend['marker']!r} not found inside "
+        f"{friend['disputed_key']!r} — the audit trail may have been edited."
+    )
+
+
+@pytest.mark.parametrize(
+    "path", _existing_dataset_copies(), ids=_DATASET_IDS,
+)
+@pytest.mark.parametrize(
+    "friend", [f for f in FALSE_FRIENDS if f["check_intel_clean"]],
+    ids=[f["code"] for f in FALSE_FRIENDS if f["check_intel_clean"]],
+)
+def test_false_friend_marker_absent_from_per_skala_and_intel(path: Path, friend: dict[str, Any]):
+    """The contamination marker must never resurface OUTSIDE the disputed key
+    — specifically not in the served per_skala (trivially true once it's [])
+    and not in intel_2026 (the client-facing editorial content), word/phrase
+    matched (scar #3: never a bare substring)."""
+    rec = _load_record(path, friend["code"])
+    per_skala_blob = json.dumps(rec.get("per_skala") or [], ensure_ascii=False)
+    intel_blob = json.dumps(rec.get("intel_2026") or {}, ensure_ascii=False)
+    assert not _contains_word_or_phrase(per_skala_blob, friend["marker"]), (
+        f"{path}: {friend['code']}.per_skala still contains marker {friend['marker']!r}."
+    )
+    assert not _contains_word_or_phrase(intel_blob, friend["marker"]), (
+        f"{path}: {friend['code']}.intel_2026 contains marker {friend['marker']!r} — "
+        "the false-friend licensing appears to have leaked into client-facing content."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fase-1-specific: _data_note verbatim-from-spec + pp28_sources untouched.
+# ---------------------------------------------------------------------------
+
+def _load_fase1_spec_by_code() -> dict[str, dict[str, Any]]:
+    spec = json.loads(FASE1_SPEC_PATH.read_text(encoding="utf-8"))
+    return {e["code"]: e for e in spec["codes"]}
+
+
+@pytest.mark.parametrize("code", FASE1_CODES)
+def test_fase1_data_note_matches_spec_verbatim(code: str):
+    """_data_note must be copied VERBATIM from the cure spec — the compiler
+    never authors a replacement licensing value or paraphrases the provenance
+    note (rule #9 no-new-values-without-provenance)."""
+    spec_by_code = _load_fase1_spec_by_code()
+    path = REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+    rec = _load_record(path, code)
+    assert rec.get("_data_note") == spec_by_code[code]["data_note"], (
+        f"{code}: _data_note drifted from scripts/kbli_filiera/cure_specs/"
+        "fase1_collisions.json — the compiler must copy data_note verbatim."
+    )
+
+
+@pytest.mark.parametrize("code", FASE1_CODES)
+def test_fase1_pp28_sources_untouched(code: str):
+    """pp28_sources is provenance/audit and must survive the cure unchanged
+    (rule: KEEP pp28_sources unchanged)."""
+    path = REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+    rec = _load_record(path, code)
+    assert rec.get("pp28_sources"), f"{code}: pp28_sources missing or emptied — must be preserved untouched."
+
+
+@pytest.mark.parametrize("code", ["49213", "20111"])
+def test_fase1_legacy_block_folded_into_disputed_key(code: str):
+    """49213 and 20111 are the two Fase-1 codes that also carried
+    per_skala_legacy: the cure must fold BOTH per_skala and per_skala_legacy
+    into the disputed key as {"per_skala": ..., "per_skala_legacy": ...} and
+    remove the top-level per_skala_legacy key (never leave a stray copy)."""
+    path = REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+    rec = _load_record(path, code)
+    disputed = rec["per_skala_disputed_pp28_collision"]
+    assert isinstance(disputed, dict), (
+        f"{code}: expected the disputed key to be a dict with 'per_skala'/"
+        f"'per_skala_legacy' sub-keys (this code had a per_skala_legacy to fold), got {type(disputed)}"
+    )
+    assert set(disputed.keys()) == {"per_skala", "per_skala_legacy"}, (
+        f"{code}: disputed key sub-structure is {sorted(disputed.keys())}, expected exactly "
+        "{'per_skala', 'per_skala_legacy'}"
+    )
+    assert disputed["per_skala"], f"{code}: folded per_skala sub-value is empty."
+    assert disputed["per_skala_legacy"], f"{code}: folded per_skala_legacy sub-value is empty."
+    assert "per_skala_legacy" not in rec, (
+        f"{code}: top-level per_skala_legacy key still present — must be removed after folding."
+    )
+
+
+@pytest.mark.parametrize("code", ["51103", "51203", "50115", "60312", "64310"])
+def test_fase1_no_legacy_block_disputed_key_is_plain_list(code: str):
+    """The other 5 Fase-1 codes never had per_skala_legacy: the disputed key
+    must hold the original per_skala list directly (no extra wrapping dict)."""
+    path = REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+    rec = _load_record(path, code)
+    disputed = rec["per_skala_disputed_pp28_collision"]
+    assert isinstance(disputed, list), (
+        f"{code}: expected the disputed key to be the plain original per_skala "
+        f"list (no per_skala_legacy to fold for this code), got {type(disputed)}"
+    )
+    assert disputed, f"{code}: disputed per_skala list is empty."
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: re-running the compiler dry-run over the served dataset must
+# report every one of the 8 as already-cured (no-op). This exercises the
+# compiler's own detection logic against the REAL served data, not a mock.
+# ---------------------------------------------------------------------------
+
+def test_compiler_dry_run_reports_all_fase1_codes_already_cured():
+    import subprocess
+
+    result = subprocess.run(
+        [
+            "python3",
+            str(REPO_ROOT / "scripts/kbli_filiera/cure_canonical_collisions.py"),
+            "--canonical",
+            str(REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"dry-run over the served dataset should exit 0 (all already cured), "
+        f"got {result.returncode}. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    for code in FASE1_CODES:
+        assert f"{code}: ALREADY CURED (skip)" in result.stdout, (
+            f"expected '{code}: ALREADY CURED (skip)' in dry-run output, not found. "
+            f"stdout:\n{result.stdout}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# INNOCENCE — legitimate neighbor codes untouched (scar-family #3 discipline:
+# every guilt assertion above is paired with an innocence case here).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("code", INNOCENT_NEIGHBORS)
+def test_innocent_neighbor_codes_per_skala_untouched(code: str):
+    """These codes legitimately carry non-empty per_skala licensing and are
+    NOT part of this cure — if the cure ever over-reaches onto one of them,
+    this must fail."""
+    path = REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+    rec = _load_record(path, code)
+    assert rec.get("per_skala"), (
+        f"{code}: per_skala unexpectedly empty — this is a legitimate neighbor "
+        "code, not one of the 8 false-friend collisions; the cure must not "
+        "have touched it."
+    )
+    assert "per_skala_disputed_pp28_collision" not in rec and "per_skala_disputed_pp28_mice" not in rec, (
+        f"{code}: unexpectedly carries a disputed key — this code was never "
+        "part of the cure spec."
+    )
+
+
+# ===========================================================================
+# Folded-in legacy coverage — verbatim from test_kbli_68112_pp28_mice_collision.py
+# (2026-07-16). 68112 coverage MUST survive; kept unmodified below.
+# ===========================================================================
+
+CODE = "68112"
+CONTAMINATION_MARKERS = ("MICE", "Venue")
+
+# Kept identical to the original file's local DATASET_PATHS (3 copies) for the
+# legacy functions below, to change nothing about what already passed. New
+# code above uses the 4-copy ALL_DATASET_COPIES instead.
+DATASET_PATHS = [
+    REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json",  # production, balizero.com/kbli
+    REPO_ROOT / "data/source_documents/KBLI_2025_FINAL_CLEAN.json",  # tracked fallback / canonical (via source_documents/ symlink)
+    REPO_ROOT / "apps/backend-rag/backend/data/KBLI_2025_FINAL_CLEAN.json",  # gitignored, RAG runtime
+]
+
+
+def _load_68112_record(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    for rec in data["data"]:
+        if rec.get("kode_kbli_2025") == CODE:
+            return rec
+    raise AssertionError(f"{path}: record {CODE} not found in dataset")
+
+
+def _existing_paths():
+    return [p for p in DATASET_PATHS if p.exists()]
+
+
+@pytest.mark.parametrize(
+    "path", _existing_paths(), ids=[str(p.relative_to(REPO_ROOT)) for p in _existing_paths()]
+)
+def test_68112_per_skala_has_no_mice_venue_contamination(path: Path):
+    rec = _load_68112_record(path)
+    per_skala_blob = json.dumps(rec.get("per_skala") or [], ensure_ascii=False)
+    for marker in CONTAMINATION_MARKERS:
+        assert marker not in per_skala_blob, (
+            f"{path}: 68112 per_skala still contains {marker!r} — the PP28 "
+            "MICE-venue licensing (Lampiran I.L, p.I.L.44) has leaked back into "
+            "the residential-leasing code (BPS Peraturan 7/2025). Move it to "
+            "per_skala_disputed_pp28_mice instead of shipping it as this code's "
+            "own licensing."
+        )
+
+
+def test_68112_disputed_mice_block_preserved_for_audit():
+    """The removed block must be KEPT (not silently deleted) for audit."""
+    rec = _load_68112_record(REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json")
+    disputed = rec.get("per_skala_disputed_pp28_mice")
+    assert disputed, (
+        "68112 must retain the original PP28-MICE per_skala under "
+        "per_skala_disputed_pp28_mice for audit — it should never be silently deleted."
+    )
+    blob = json.dumps(disputed, ensure_ascii=False)
+    assert any(marker in blob for marker in CONTAMINATION_MARKERS), (
+        "per_skala_disputed_pp28_mice should still contain the MICE/Venue text it "
+        "was moved to preserve — if this trips, the audit trail itself was edited."
+    )
+
+
+def test_68112_has_advisory_data_note():
+    rec = _load_68112_record(REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json")
+    note = rec.get("_data_note", "")
+    assert "68111" in note, "advisory note should point to the nearest residential NSPK reference (68111)"
+    assert "no_oss_risk" not in note  # note is prose, not a field-name echo
+    assert "OSS" in note and "404" in note, "advisory note should explain the OSS 404 (no published NSPK yet)"
+
+
+AUDIT_KEY = "per_skala_disputed_pp28_mice"
+
+# A leaf string OUTSIDE the audit key is allowed to name "MICE"/"Venue" ONLY when
+# it is DISCLAIMING the collision (explaining that this MICE-venue text belonged
+# to a different activity and does not apply to 68112's residential leasing) —
+# never when it ASSERTS the MICE licensing as this code's own requirement (that
+# was the original bug: the old intel_2026.whatYouNeed named "MICE venue
+# standards" as part of 68112's OWN obligations, with no disclaiming language
+# anywhere in the field). "code-number collision" is the phrase both legitimate
+# disclaimers (_data_note and the corrected whatYouNeed) share verbatim, and is
+# absent from the original contaminated text — entity/intent match, not a bare
+# substring, per this repo's scar-family #3 guard discipline (guilt+innocence,
+# never over-match on the mere presence of "MICE").
+DISCLAIMER_MARKER = "code-number collision"
+
+
+def _iter_leaf_strings(obj, path=""):
+    """Yield (path, value) for every string leaf in a nested dict/list structure."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            yield from _iter_leaf_strings(v, f"{path}.{k}" if path else k)
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            yield from _iter_leaf_strings(v, f"{path}[{i}]")
+    elif isinstance(obj, str):
+        yield path, obj
+
+
+@pytest.mark.parametrize(
+    "path", _existing_paths(), ids=[str(p.relative_to(REPO_ROOT)) for p in _existing_paths()]
+)
+def test_68112_record_has_no_mice_venue_outside_audit_key(path: Path):
+    """Whole-record guard: no field of 68112 — intel_2026, l4_bali, pma_*, etc. —
+    may ASSERT the MICE-venue licensing as applicable, anywhere in the record,
+    EXCEPT the intentional audit key `per_skala_disputed_pp28_mice` (excluded
+    entirely — it exists precisely to preserve the original PP28 block verbatim).
+
+    A field outside the audit key MAY still name "MICE"/"Venue" if — and only
+    if — it is disclaiming the collision (contains DISCLAIMER_MARKER): this is
+    legitimate explanatory prose (`_data_note`, `intel_2026.whatYouNeed`), not
+    a resurgence of the bug. Any occurrence WITHOUT the disclaimer marker in the
+    same field fails — this is what catches contamination anywhere in the
+    record, not just per_skala (the shape of the intel_2026.whatYouNeed leak
+    the first pass of this fix missed).
+    """
+    rec = _load_68112_record(path)
+    rec_without_audit_key = {k: v for k, v in rec.items() if k != AUDIT_KEY}
+    for field_path, value in _iter_leaf_strings(rec_without_audit_key):
+        if any(marker in value for marker in CONTAMINATION_MARKERS):
+            assert DISCLAIMER_MARKER in value.lower(), (
+                f"{path}: 68112.{field_path} contains MICE/Venue text with no "
+                f"{DISCLAIMER_MARKER!r} disclaimer in the same field — looks "
+                "like the PP28 MICE-venue licensing is being ASSERTED as this "
+                "code's own requirement again, not disclaimed as the collision "
+                "it is. Field value: " + value[:200]
+            )
+
+
+def test_68112_other_mice_codes_untouched():
+    """Sanity/innocence guard: 68124 and 82300 legitimately mention MICE/Venue in
+    their own per_skala (verified 2026-07-16) — this fix must not have touched them."""
+    data = json.loads(
+        (REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json").read_text(encoding="utf-8")
+    )
+    by_code = {r["kode_kbli_2025"]: r for r in data["data"]}
+    for code in ("68124", "82300"):
+        rec = by_code.get(code)
+        if rec is None:
+            continue
+        blob = json.dumps(rec.get("per_skala") or [], ensure_ascii=False)
+        assert any(m in blob for m in CONTAMINATION_MARKERS), (
+            f"{code} unexpectedly lost its legitimate MICE/Venue per_skala text — "
+            "this guard is scoped to 68112 only, do not touch this record."
+        )
+
+
+# --- Third contaminated surface (2026-07-16, follow-up PR): apps/mouth/data/kbli-gold-all.json ---
+#
+# This gold file is a SEPARATE curated dataset (428 records, keyed directly by code — not the
+# `{"data": [...]}` list shape of KBLI_2025_FINAL_CLEAN.json above) consumed by
+# apps/mouth/src/lib/kbli-data.server.ts. It is NOT one of the copies scripts/sync_kbli_dataset.sh
+# propagates, so PR #2508's per_skala fix never reached it: its 68112.whatYouNeed kept asserting
+# "NIB + Standard Certificate (... Medium-Low risk)" and "Standard Certificate (auto-issued)" —
+# the same PP28-MICE collision, served live on balizero.com/kbli/68112, invisible to every test
+# above because none of them touch this file.
+
+GOLD_PATH = REPO_ROOT / "apps/mouth/data/kbli-gold-all.json"
+
+
+def _load_gold_record() -> dict:
+    data = json.loads(GOLD_PATH.read_text(encoding="utf-8"))
+    rec = data.get(CODE)
+    if rec is None:
+        raise AssertionError(f"{GOLD_PATH}: record {CODE} not found")
+    return rec
+
+
+def test_68112_gold_what_you_need_has_no_medium_low_risk():
+    """Regression pin for the gold-specific bug: whatYouNeed (the customer-facing step
+    list) must never again assert the collision-derived "Medium-Low risk" tier as this
+    code's own requirement — not even in disclaimer form. This is a stricter bar than the
+    whole-record guard below: whatYouNeed is what a client reads to know what to file: it
+    should describe "not yet defined" plainly, not repeat the specific wrong risk-tier
+    label even while debunking it."""
+    rec = _load_gold_record()
+    wyn = rec.get("whatYouNeed", "")
+    assert "Medium-Low risk" not in wyn, (
+        f"{GOLD_PATH}: 68112.whatYouNeed still asserts 'Medium-Low risk' — the "
+        "PP28-MICE collision-derived licensing tier has leaked back into the "
+        "customer-facing step list."
+    )
+
+
+@pytest.mark.parametrize("path", [GOLD_PATH], ids=["apps/mouth/data/kbli-gold-all.json"])
+def test_68112_gold_record_has_no_mice_venue_without_disclaimer(path: Path):
+    """Whole-gold-record guard, same discipline as
+    test_68112_record_has_no_mice_venue_outside_audit_key above: the gold record has no
+    `per_skala_disputed_pp28_mice`-style audit key to exclude (gold never carried the raw
+    per_skala block), so every leaf string is in scope. Any field naming "MICE"/"Venue"
+    must carry the DISCLAIMER_MARKER in the same field, or it looks like the collision is
+    being asserted rather than debunked."""
+    rec = _load_gold_record()
+    for field_path, value in _iter_leaf_strings(rec):
+        if any(marker in value for marker in CONTAMINATION_MARKERS):
+            assert DISCLAIMER_MARKER in value.lower(), (
+                f"{path}: 68112.{field_path} contains MICE/Venue text with no "
+                f"{DISCLAIMER_MARKER!r} disclaimer in the same field — looks like the "
+                "PP28 MICE-venue licensing is being asserted as this code's own "
+                "requirement again. Field value: " + value[:200]
+            )
+
+
+def test_68112_gold_bali_context_untouched_and_innocent():
+    """Innocence case (scar-family #3 guilt+innocence discipline): baliContext's mention
+    of "Standard Certificate for Hospitality (SLHS)" is a LEGITIMATE reference (explaining
+    that daily/Airbnb rentals need a different KBLI + SLHS, not this code) — it must
+    survive this fix untouched, and the whole-record guard above must not have needed to
+    touch it, because it never names "MICE"/"Venue" in the first place."""
+    rec = _load_gold_record()
+    bali_context = rec.get("baliContext", "")
+    assert "SLHS" in bali_context and "Standard Certificate for Hospitality" in bali_context, (
+        "baliContext's legitimate SLHS/hospitality explanation must be preserved verbatim."
+    )
+    assert not any(marker in bali_context for marker in CONTAMINATION_MARKERS), (
+        "baliContext should not mention MICE/Venue at all — if it does now, the "
+        "disclaimer-aware guard above, not a bare-substring ban, is what must clear it."
+    )


### PR DESCRIPTION
GARUDA-FILIERA Fase 1 (GO by Zero). Cures the 7 KBLI-2025 codes quarantined + image-verified by pilot A1 (49213/51103/51203/20111/50115/60312/64310). 68112 false-friend pattern via deterministic compiler (data-plane guard #2550 forbids hand-edits). per_skala detached -> [], contaminated block preserved under per_skala_disputed_pp28_collision, corroborated _data_note, pp28_sources kept.

Verification (generator=Sonnet impl != grader=Fable): semantic diff = exactly 7 records changed (metadata + 1552 others byte-identical); 4 consumer copies byte-identical; sidecar sha bumped same commit (W86); editorial confirmed clean; gold has none of 7. New registry test (guilt+innocence, scar #3) + 68112 test green.

NOT propagated here (separate consumer, follow-up): KG/Qdrant on WA/webchat (parked #2528).

Report: research/operations/2026-07-17-kbli-pilot-a1-results.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)