### PR TITLE
fix(db): remove dead sequence-grant sub-block from migration 244

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/244_compliance_alerts_runtime_grants.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/244_compliance_alerts_runtime_grants.sql
@@ -39,8 +39,6 @@ DECLARE
     runtime_role constant text := 'backend_rag_v2';
     object_name text;
     object_reg regclass;
-    sequence_name text;
-    sequence_reg regclass;
     write_objects text[] := ARRAY[
         'public.compliance_alerts'
     ];
@@ -110,51 +108,19 @@ BEGIN
                 object_name;
         END IF;
 
-        -- Defensive/future-proofing only: compliance_alerts.alert_id is
-        -- TEXT PRIMARY KEY (db/migrations_v2/114_compliance_alerts.sql), not
-        -- a serial/identity column, so pg_get_serial_sequence(..., 'id')
-        -- always returns NULL today and this block never executes. Kept for
-        -- parity with the 209/211 write_objects pattern in case the PK
-        -- shape ever changes.
-        sequence_name := pg_get_serial_sequence(object_name, 'id');
-
-        IF sequence_name IS NOT NULL THEN
-            sequence_reg := to_regclass(sequence_name);
-
-            IF sequence_reg IS NOT NULL
-                AND NOT (
-                    has_sequence_privilege(runtime_role, sequence_reg, 'USAGE')
-                    AND has_sequence_privilege(runtime_role, sequence_reg, 'SELECT')
-                ) THEN
-                BEGIN
-                    EXECUTE format(
-                        'GRANT USAGE, SELECT ON SEQUENCE %s TO %I',
-                        sequence_reg,
-                        runtime_role
-                    );
-                EXCEPTION
-                    WHEN insufficient_privilege THEN
-                        RAISE WARNING
-                            'manual grant required: GRANT USAGE, SELECT ON SEQUENCE % TO %',
-                            sequence_name,
-                            runtime_role;
-                END;
-            END IF;
-
-            IF sequence_reg IS NOT NULL
-                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'USAGE') THEN
-                RAISE EXCEPTION
-                    'backend_rag_v2 is missing USAGE on sequence %; apply manual grant with an owner/admin role',
-                    sequence_name;
-            END IF;
-
-            IF sequence_reg IS NOT NULL
-                AND NOT has_sequence_privilege(runtime_role, sequence_reg, 'SELECT') THEN
-                RAISE EXCEPTION
-                    'backend_rag_v2 is missing SELECT on sequence %; apply manual grant with an owner/admin role',
-                    sequence_name;
-            END IF;
-        END IF;
+        -- NOTE (fix244-seqbug): a sequence-grant sub-block used to live here,
+        -- guarded on `pg_get_serial_sequence(object_name, 'id')`. It assumed
+        -- that call returns NULL when the table has no `id` column — it does
+        -- not; Postgres RAISEs "column ... does not exist" instead, which is
+        -- not caught by any exception handler in this DO-block. Because
+        -- compliance_alerts.alert_id is TEXT PRIMARY KEY (no `id` column,
+        -- no serial/identity — see 114_compliance_alerts.sql) and
+        -- write_objects here is only ever `public.compliance_alerts`, that
+        -- call ALWAYS raised in any environment where `backend_rag_v2`
+        -- exists (i.e. prod), aborting this DO-block on every apply attempt
+        -- and failing the Fly release_command (`apply_all_pending`). The
+        -- sub-block was genuinely dead code (table has no sequence to grant
+        -- on), so it is removed rather than guarded — least-surface fix.
     END LOOP;
 END
 $grant_block$;
@@ -165,8 +131,6 @@ DECLARE
     runtime_role text := 'backend_rag_v2';
     object_name text;
     object_reg regclass;
-    sequence_name text;
-    sequence_reg regclass;
     write_objects text[] := ARRAY[
         'public.compliance_alerts'
     ];
@@ -184,20 +148,6 @@ BEGIN
                 object_reg,
                 runtime_role
             );
-        END IF;
-
-        sequence_name := pg_get_serial_sequence(object_name, 'id');
-
-        IF sequence_name IS NOT NULL THEN
-            sequence_reg := to_regclass(sequence_name);
-
-            IF sequence_reg IS NOT NULL THEN
-                EXECUTE format(
-                    'REVOKE USAGE, SELECT ON SEQUENCE %s FROM %I',
-                    sequence_reg,
-                    runtime_role
-                );
-            END IF;
         END IF;
     END LOOP;
 END

--- a/apps/backend-rag/backend/tests/db/test_migration_244_compliance_alerts_runtime_grants.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_244_compliance_alerts_runtime_grants.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import asyncpg
+import pytest
+
+from backend.db.migration_base import split_migration_sql
 from backend.db.migration_manager import _extract_rollback_sql
 
 MIGRATION_FILE = (
@@ -13,7 +17,16 @@ MIGRATION_FILE = (
     / "244_compliance_alerts_runtime_grants.sql"
 )
 
+COMPLIANCE_ALERTS_MIGRATION_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "db"
+    / "migrations_v2"
+    / "114_compliance_alerts.sql"
+)
+
 WRITE_OBJECTS = ("public.compliance_alerts",)
+
+RUNTIME_ROLE = "backend_rag_v2"
 
 
 def _forward(sql: str) -> str:
@@ -97,3 +110,170 @@ def test_migration_244_rollback_revokes_same_grants() -> None:
     assert "DELETE" not in rollback
     for object_name in WRITE_OBJECTS:
         assert object_name in rollback
+
+
+def _strip_sql_line_comments(sql: str) -> str:
+    """Drop lines that are pure `--` comments.
+
+    Guard-over-match note (cicatrix family #3): a bare
+    `"needle" not in forward` substring check is exactly the trap this
+    repo's own guardrail doctrine warns about — this migration file's own
+    explanatory prose is allowed to *discuss* a removed function call
+    (as it does, in the NOTE comment above the FOREACH loop's tail) without
+    that meaning the call is still executable. Every comment line in this
+    file's style starts with `--` on its own line (no trailing inline
+    comments), so filtering by line-prefix is precise here — this checks
+    the entity (executable code), not the substring (any occurrence at
+    all, including prose).
+    """
+    return "\n".join(
+        line for line in sql.splitlines() if not line.strip().startswith("--")
+    )
+
+
+def test_migration_244_forward_sql_has_no_serial_sequence_lookup() -> None:
+    """Structural guard against regressing the 2026-07-17 fix.
+
+    compliance_alerts.alert_id is TEXT PRIMARY KEY (no `id` column — see
+    114_compliance_alerts.sql), so any future edit that reintroduces
+    `pg_get_serial_sequence(object_name, 'id')` (or an equivalent
+    per-column-name sequence lookup) inside the FOREACH loop would
+    reintroduce the exact bug: that call RAISES "column ... does not
+    exist" when the table has no `id` column, uncaught by any exception
+    handler in this DO-block, aborting the whole migration on every real
+    apply attempt (i.e. whenever `backend_rag_v2` exists — prod). This is
+    a cheap static tripwire alongside the dynamic proof below, not a
+    replacement for it — see
+    test_migration_244_applies_cleanly_with_runtime_role_present for the
+    bug this guards against (which this line-only check cannot itself
+    catch: the text-contract tests in this file existed BEFORE the fix and
+    never ran the SQL, which is why the bug reached prod in the first
+    place).
+
+    Checks executable code only (comment lines stripped) — the migration's
+    own NOTE comment legitimately mentions `pg_get_serial_sequence` in
+    prose explaining why it's gone; a bare substring scan of the whole
+    file would false-positive on that prose instead of checking for the
+    live call (same over-match class the existing
+    test_migration_244_does_not_over_grant_delete docstring already
+    warns about).
+    """
+    forward_code = _strip_sql_line_comments(_forward(MIGRATION_FILE.read_text()))
+    assert "pg_get_serial_sequence" not in forward_code
+
+
+# ---------------------------------------------------------------------------
+# Real-DB regression tests for the 2026-07-17 prod outage.
+#
+# Root cause: `pg_get_serial_sequence(object_name, 'id')` (previously at
+# line ~119) does not return NULL for a table with no `id` column — it
+# RAISEs `UndefinedColumnError: column "id" of relation "compliance_alerts"
+# does not exist`, uncaught by any exception handler in this DO-block. Every
+# text-contract test above reads the file and asserts on substrings; none of
+# them ever EXECUTE the SQL, so none could catch a runtime-only failure mode.
+#
+# The bug was invisible locally/CI because the whole DO-block is guarded by
+# `IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = runtime_role) THEN
+# RETURN; END IF;` — `backend_rag_v2` is never created locally or in CI, so
+# the guard RETURNs before the FOREACH loop ever reaches the crashing line.
+# In prod, the role exists, the guard passes through, and the migration
+# aborted on every `apply_all_pending()` call (i.e. every `flyctl deploy`
+# release_command) from 2026-07-16 19:47Z onward.
+#
+# These tests create `backend_rag_v2` for real (inside the transaction-
+# scoped `db_tx` fixture, which is always rolled back at teardown — nothing
+# persists, no manual cleanup needed) so the FOREACH loop's grant logic
+# actually executes, exercising the exact code path that broke prod.
+# ---------------------------------------------------------------------------
+
+
+async def _ensure_role(conn: asyncpg.Connection, role: str) -> None:
+    """Create `role` if it doesn't already exist (e.g. a CI/staging DB where
+    the runtime role is provisioned out-of-band). Runs inside the caller's
+    transaction — `db_tx` rolls it back at teardown either way, so this
+    never leaves cluster-wide state behind when it's this function that
+    created the role."""
+    exists = await conn.fetchval(
+        "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)",
+        role,
+    )
+    if not exists:
+        await conn.execute(f'CREATE ROLE "{role}"')
+
+
+async def _ensure_compliance_alerts_table(conn: asyncpg.Connection) -> None:
+    """Idempotently ensure compliance_alerts exists (114's forward SQL is
+    itself `CREATE TABLE IF NOT EXISTS`). In both local dev and CI this
+    table is already present by the time this test file runs, but building
+    it defensively keeps this test self-sufficient rather than relying on
+    ambient ordering."""
+    exists = await conn.fetchval(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+        "WHERE table_schema = 'public' AND table_name = 'compliance_alerts')"
+    )
+    if not exists:
+        sql = COMPLIANCE_ALERTS_MIGRATION_FILE.read_text(encoding="utf-8")
+        forward, _ = split_migration_sql(sql)
+        await conn.execute(forward)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_migration_244_applies_cleanly_with_runtime_role_present(
+    db_tx: asyncpg.Connection,
+) -> None:
+    """The forward SQL must complete without raising, and must grant exactly
+    SELECT/INSERT/UPDATE (never DELETE) to backend_rag_v2 on
+    compliance_alerts, when the runtime role actually exists — the prod
+    code path. Pre-fix, `db_tx.execute(forward)` below raised
+    `asyncpg.exceptions.UndefinedColumnError`.
+    """
+    await _ensure_role(db_tx, RUNTIME_ROLE)
+    await _ensure_compliance_alerts_table(db_tx)
+
+    sql = MIGRATION_FILE.read_text(encoding="utf-8")
+    forward, _ = split_migration_sql(sql)
+
+    # Must not raise. This is the exact statement the Fly release_command
+    # (`python -m backend.db.migrate apply-all` -> apply_all_pending() ->
+    # BaseMigration.apply() -> conn.execute(sql_forward)) executes in prod.
+    await db_tx.execute(forward)
+
+    for priv in ("SELECT", "INSERT", "UPDATE"):
+        granted = await db_tx.fetchval(
+            "SELECT has_table_privilege($1, 'public.compliance_alerts', $2)",
+            RUNTIME_ROLE,
+            priv,
+        )
+        assert granted, f"{RUNTIME_ROLE} missing {priv} after migration 244 applied"
+
+    delete_granted = await db_tx.fetchval(
+        "SELECT has_table_privilege($1, 'public.compliance_alerts', 'DELETE')",
+        RUNTIME_ROLE,
+    )
+    assert not delete_granted, "migration 244 must never grant DELETE (least privilege)"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_migration_244_idempotent_when_reapplied(
+    db_tx: asyncpg.Connection,
+) -> None:
+    """The forward SQL must be safe to execute twice in a row. Matters for
+    manual remediation / a re-run after a stuck deploy, and mirrors the
+    file's own `has_table_privilege(...)` re-check-before-grant contract.
+    """
+    await _ensure_role(db_tx, RUNTIME_ROLE)
+    await _ensure_compliance_alerts_table(db_tx)
+
+    sql = MIGRATION_FILE.read_text(encoding="utf-8")
+    forward, _ = split_migration_sql(sql)
+
+    await db_tx.execute(forward)
+    await db_tx.execute(forward)  # must not raise the second time either
+
+    granted = await db_tx.fetchval(
+        "SELECT has_table_privilege($1, 'public.compliance_alerts', 'SELECT')",
+        RUNTIME_ROLE,
+    )
+    assert granted


### PR DESCRIPTION
## Root cause

`pg_get_serial_sequence(object_name, 'id')` does not return `NULL` for a table with no `id` column — it **RAISEs** `column "id" of relation "compliance_alerts" does not exist`, uncaught by any exception handler in the migration's DO-block. `compliance_alerts` has no `id` column (`alert_id` is `TEXT PRIMARY KEY` — see `114_compliance_alerts.sql`), so the sub-block aborted the whole migration on every real apply attempt, i.e. whenever the `backend_rag_v2` role exists (prod). Locally/CI this stayed a silent no-op, because the DO-block's own role guard `RETURN`s before the FOREACH loop ever reaches the crashing line (the role is never created there).

**Impact**: every `flyctl deploy` of `nuzantara-rag` since 2026-07-16 19:47Z has failed its `release_command` (`apply_all_pending`). Prod kept serving the last good release only because Fly aborts the release before swap — but the deploy backlog has been stuck ~13h.

## Why in-place edit is safe

Migration 244 has **zero successful applies anywhere** (no `_schema_versions` row in prod or local), so editing it in place causes no drift. A new migration 245 cannot route around this — `apply_all_pending`'s failed-migration list still fails the `release_command`'s exit code regardless of any later migration succeeding, so the fix has to land inside 244 itself.

## What the commit adds

- Removes the dead sequence-grant sub-block from both the grant and revoke DO-blocks (the sub-block only ever applied to `compliance_alerts`, which has no sequence to grant on — dead code by the migration's own comment, "kept for parity ... in case the PK shape ever changes"). Table-grant logic (the migration's actual intent) is untouched.
- A real DB-integration test (`test_migration_244_applies_cleanly_with_runtime_role_present`, `test_migration_244_idempotent_when_reapplied`) that creates the `backend_rag_v2` role for real inside a rolled-back transaction and executes the forward SQL — the exact prod code path the previous text-contract-only tests never exercised (pre-fix, this raised `UndefinedColumnError`).
- A comment-aware static tripwire (`test_migration_244_forward_sql_has_no_serial_sequence_lookup`) against reintroducing `pg_get_serial_sequence` into the executable SQL, without false-positiving on the file's own explanatory prose (guard-over-match discipline, cicatrix family #3).

Verified locally on M5: all 11 tests in `test_migration_244_compliance_alerts_runtime_grants.py` pass (including the two real-DB integration tests against a real `backend_rag_v2` role), `ruff check` clean, full pre-push suite green (17381 passed / 165 skipped / 0 failed).

## Credit

Commit authored by a sibling session (Pro worktree `infra-fix244-seqbug`, transferred verbatim via `git am` — Pro's pre-push env blocked the original push). Content unmodified in transfer; verified byte-for-byte via `git show --stat`/`git log` before pushing from M5.

## Merge policy

Migration-class change — **no auto-merge**. The orchestrator (this session) merges manually after required checks (incl. Squawk migration lint) go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)