### PR TITLE
feat(kbli): honest "Not classified" risk over false "Low" fallback

### DIFF
--- a/apps/backend-rag/backend/app/routers/kbli_notebook.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook.py
@@ -279,6 +279,20 @@ def get_kbli_ttl(code: str) -> int:
     return 2592000  # 30 Days
 
 
+def _resolve_risk_profile(qdrant_risk: str | None, licenses: list["KBLILicense"]) -> str:
+    """Risk label surfaced to the client for a KBLI code.
+
+    Honest gap over false reassurance (Zero decision 2026-07-17): when no risk is
+    defined anywhere — no Qdrant ``kategori_risiko`` and no license risk row — return
+    ``"Not classified"`` instead of a made-up ``"Low"``. A cured false-friend code
+    (``per_skala`` detached from a cross-vintage collision) has NO risk basis, and
+    ``"Low"`` would be a false-reassuring assertion. The mouth explorer's
+    ``getRiskLevel``/``getRiskBadge`` + ``RiskGauge`` render this as a neutral,
+    needle-less state; WA/webchat pass the string verbatim to the LLM.
+    """
+    return qdrant_risk or (licenses[0].risk_level if licenses else None) or "Not classified"
+
+
 @router.get("/search", response_model=list[KBLISearchResult])
 async def search_kbli(
     query: KBLISearchQuery,
@@ -440,7 +454,7 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
                 or "UNKNOWN"
             )
 
-            risk_profile = qdrant_risk or (licenses[0].risk_level if licenses else None) or "Low"
+            risk_profile = _resolve_risk_profile(qdrant_risk, licenses)
 
             # Patch licenses with "Unknown" risk using Qdrant value
             if qdrant_risk:

--- a/apps/backend-rag/backend/tests/routers/test_kbli_risk_profile.py
+++ b/apps/backend-rag/backend/tests/routers/test_kbli_risk_profile.py
@@ -1,0 +1,40 @@
+"""Risk-profile resolution for inspect_kbli (Zero decision 2026-07-17).
+
+An undefined risk must surface as an honest "Not classified" gap, never the old
+false-reassuring "Low" default. A cured false-friend code (per_skala detached from
+a cross-vintage collision) has NO risk basis, so "Low" would lie to the client.
+"""
+
+from backend.app.routers.kbli_notebook import KBLILicense, _resolve_risk_profile
+
+
+def _lic(risk_level: str) -> KBLILicense:
+    return KBLILicense(
+        type="NIB dan Sertifikat Standar",
+        scale=["Menengah"],
+        risk_level=risk_level,
+        sla="Otomatis",
+        requirements=[],
+    )
+
+
+def test_qdrant_risk_takes_precedence() -> None:
+    # Qdrant kategori_risiko is the primary source when present.
+    assert _resolve_risk_profile("Menengah Tinggi", [_lic("Rendah")]) == "Menengah Tinggi"
+
+
+def test_falls_back_to_first_license_risk_when_no_qdrant() -> None:
+    assert _resolve_risk_profile(None, [_lic("Tinggi")]) == "Tinggi"
+
+
+def test_not_classified_when_no_risk_anywhere() -> None:
+    # Cured false-friend: Qdrant risk cleared AND no license rows → honest gap.
+    assert _resolve_risk_profile(None, []) == "Not classified"
+
+
+def test_regression_never_the_old_low_default() -> None:
+    # The old fallback "Low" was a false reassurance — it must be gone.
+    assert _resolve_risk_profile(None, []) != "Low"
+    assert _resolve_risk_profile("", []) == "Not classified"
+    # An empty license risk string is not a low reading either.
+    assert _resolve_risk_profile(None, [_lic("")]) == "Not classified"

--- a/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.test.tsx
+++ b/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+
+import { getRiskBadge, getRiskLevel } from "./KBLIInspector";
+
+// Zero decision 2026-07-17: an undefined/unclassified KBLI risk must surface as
+// an honest "Not Classified" gap, NEVER the old false-reassuring "low"/"Low Risk"
+// default. A cured false-friend code (per_skala detached) has no risk basis.
+// Guilt + innocence corpus per scar #3 (a guard must not fire on legit neighbours).
+
+describe("getRiskLevel", () => {
+  it("INNOCENCE: real Indonesian risk tiers still map correctly", () => {
+    expect(getRiskLevel("Tinggi")).toBe("high");
+    expect(getRiskLevel("Menengah Tinggi")).toBe("medium-high");
+    expect(getRiskLevel("Menengah")).toBe("medium");
+    expect(getRiskLevel("Menengah Rendah")).toBe("medium-low");
+    expect(getRiskLevel("Rendah")).toBe("low");
+    // English aliases the router/licenses can emit.
+    expect(getRiskLevel("High")).toBe("high");
+    expect(getRiskLevel("Low")).toBe("low");
+  });
+
+  it("GUILT: undefined risk returns 'not-classified', never 'low'", () => {
+    expect(getRiskLevel("Not classified")).toBe("not-classified");
+    expect(getRiskLevel("")).toBe("not-classified");
+    expect(getRiskLevel("Unknown")).toBe("not-classified");
+    // A value matching no known tier is a gap, not a low reading.
+    expect(getRiskLevel("¯\\_(ツ)_/¯")).toBe("not-classified");
+  });
+});
+
+describe("getRiskBadge", () => {
+  it("INNOCENCE: real risk tiers keep their labels", () => {
+    expect(getRiskBadge("Rendah").label).toBe("Low Risk");
+    expect(getRiskBadge("Tinggi").label).toBe("High Risk");
+    expect(getRiskBadge("Menengah Tinggi").label).toBe("Medium-High Risk");
+    expect(getRiskBadge("Menengah Rendah").label).toBe("Medium-Low Risk");
+  });
+
+  it("GUILT: undefined risk is neutral 'Not Classified', not 'Low Risk'", () => {
+    const badge = getRiskBadge("Not classified");
+    expect(badge.label).toBe("Not Classified");
+    expect(badge.className).toContain("badge-neutral");
+    expect(badge.label).not.toMatch(/low/i);
+    expect(getRiskBadge("").label).toBe("Not Classified");
+    expect(getRiskBadge("Unknown").label).toBe("Not Classified");
+  });
+});

--- a/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.tsx
+++ b/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.tsx
@@ -37,6 +37,11 @@ export function getRiskBadge(risk: string): {
   className: string;
 } {
   const r = (risk || "").toLowerCase();
+  // Honest gap over false reassurance: an undefined/unclassified risk must NOT
+  // fall through to "Low Risk" (Zero decision 2026-07-17). A cured false-friend
+  // code has no risk basis — say so, neutrally.
+  if (!r || r === "not classified" || r === "unknown")
+    return { label: "Not Classified", className: "badge badge-neutral" };
   if (r.includes("tinggi") && r.includes("menengah"))
     return { label: "Medium-High Risk", className: "badge badge-warning" };
   if (r.includes("tinggi") || r === "high")
@@ -52,13 +57,17 @@ export function getRiskBadge(risk: string): {
 
 export function getRiskLevel(
   risk: string,
-): "low" | "medium-low" | "medium" | "medium-high" | "high" {
+): "low" | "medium-low" | "medium" | "medium-high" | "high" | "not-classified" {
   const r = (risk || "").toLowerCase();
+  // Undefined/unclassified → "not-classified" (neutral gauge, no misleading
+  // needle), NEVER the old default "low" which falsely reassured (Zero 2026-07-17).
+  if (!r || r === "not classified" || r === "unknown") return "not-classified";
   if (r.includes("tinggi") && r.includes("menengah")) return "medium-high";
   if (r.includes("tinggi") || r === "high") return "high";
   if (r.includes("menengah") && r.includes("rendah")) return "medium-low";
   if (r.includes("menengah") || r === "medium") return "medium";
-  return "low";
+  if (r.includes("rendah") || r === "low") return "low";
+  return "not-classified";
 }
 
 // =============================================================================

--- a/apps/mouth/src/app/kbli-explorer/components/RiskGauge.tsx
+++ b/apps/mouth/src/app/kbli-explorer/components/RiskGauge.tsx
@@ -3,7 +3,13 @@
 import React from "react";
 import { motion } from "framer-motion";
 
-type RiskLevel = "low" | "medium-low" | "medium" | "medium-high" | "high";
+type RiskLevel =
+  | "low"
+  | "medium-low"
+  | "medium"
+  | "medium-high"
+  | "high"
+  | "not-classified";
 
 const NEEDLE_ANGLES: Record<RiskLevel, number> = {
   low: 25,
@@ -11,6 +17,8 @@ const NEEDLE_ANGLES: Record<RiskLevel, number> = {
   medium: 90,
   "medium-high": 125,
   high: 155,
+  // Needle is hidden for "not-classified"; angle unused but keeps the map total.
+  "not-classified": 90,
 };
 
 const RISK_LABELS: Record<RiskLevel, string> = {
@@ -19,6 +27,7 @@ const RISK_LABELS: Record<RiskLevel, string> = {
   medium: "Medium Risk",
   "medium-high": "Medium-High",
   high: "High Risk",
+  "not-classified": "Not Classified",
 };
 
 const RISK_COLORS: Record<RiskLevel, string> = {
@@ -27,6 +36,7 @@ const RISK_COLORS: Record<RiskLevel, string> = {
   medium: "#fbbf24",
   "medium-high": "#f97316",
   high: "#ef4444",
+  "not-classified": "#9ca3af",
 };
 
 const WIDTH = 160;
@@ -57,6 +67,7 @@ export default function RiskGauge({ level }: { level: RiskLevel }) {
   const angle = NEEDLE_ANGLES[level];
   const color = RISK_COLORS[level];
   const label = RISK_LABELS[level];
+  const isUnclassified = level === "not-classified";
 
   // Needle endpoint (from center, pointing outward)
   const needleLength = RADIUS - 12;
@@ -93,24 +104,27 @@ export default function RiskGauge({ level }: { level: RiskLevel }) {
           strokeLinecap="round"
         />
 
-        {/* Needle */}
-        <motion.line
-          x1={CX}
-          y1={CY}
-          x2={nx}
-          y2={ny}
-          stroke={color}
-          strokeWidth={2}
-          strokeLinecap="round"
-          initial={{ x2: CX, y2: CY - needleLength }}
-          animate={{ x2: nx, y2: ny }}
-          transition={{
-            type: "spring",
-            stiffness: 80,
-            damping: 12,
-            delay: 0.3,
-          }}
-        />
+        {/* Needle — hidden for "not-classified": any position would imply a
+            risk reading the data doesn't support (Zero 2026-07-17). */}
+        {!isUnclassified && (
+          <motion.line
+            x1={CX}
+            y1={CY}
+            x2={nx}
+            y2={ny}
+            stroke={color}
+            strokeWidth={2}
+            strokeLinecap="round"
+            initial={{ x2: CX, y2: CY - needleLength }}
+            animate={{ x2: nx, y2: ny }}
+            transition={{
+              type: "spring",
+              stiffness: 80,
+              damping: 12,
+              delay: 0.3,
+            }}
+          />
+        )}
 
         {/* Center dot */}
         <circle cx={CX} cy={CY} r={4} fill={color} />

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 638 services · 1151 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 638 services · 1154 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Why

`inspect_kbli` defaulted an **undefined** risk to `"Low"` — a false reassurance. A cured false-friend KBLI code (its `per_skala` detached from a cross-vintage PP28 collision) has **no risk basis**, and telling a client "Low Risk" is a plausible-but-wrong assertion (Zero decision 2026-07-17: honest gap > false reassurance).

The false "Low" lived on **three independent surfaces** — fixing the router alone was not enough:
1. Backend `kbli_notebook.py` — `risk_profile = ... or "Low"`.
2. Frontend `getRiskLevel()` — returned `"low"` for any unrecognized value.
3. Frontend `getRiskBadge()` — fell through to the `"Low Risk"` info badge.

## What

- **Backend**: extract pure `_resolve_risk_profile(qdrant_risk, licenses)` → `qdrant_risk or first-license-risk or "Not classified"`. 4 unit tests (`test_kbli_risk_profile.py`).
- **Frontend (mouth `/kbli-explorer`)**: `getRiskLevel` returns `"not-classified"` for undefined/unknown (never `"low"`); `getRiskBadge` shows a neutral **"Not Classified"** badge; `RiskGauge` renders a **needle-less neutral** state (a needle at any position would imply a reading). 4 unit tests, guilt+innocence corpus (real Indonesian tiers unchanged) — `KBLIInspector.test.tsx`.
- **WA/webchat**: no mapping — the string flows verbatim to the LLM.
- `docs_sync` regen folded in (W86); `tsc --noEmit` clean.

## Consumer-map (rule #6)

`risk_profile` consumers: mouth `/kbli-explorer` (KG-backed, distinct from `/kbli/[code]` SSR-canonical) + WhatsApp/webchat via MCP `inspect_kbli`. Both handle "Not classified" gracefully after this change.

## Follow-up (NOT this PR)

After this deploys: clear Qdrant `kategori_risiko` for the 6 `no_oss_risk` cured codes (49213/20111 keep their OSS risk) so they surface "Not classified" instead of the stale collision value; then bust the inspect cache. Canonical `whatYouNeed` prose cure tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)