### PR TITLE
fix(intel): step-done 500 + hero-rotation staged PR write

### DIFF
--- a/apps/backend-rag/backend/app/routers/intel.py
+++ b/apps/backend-rag/backend/app/routers/intel.py
@@ -726,7 +726,7 @@ async def mark_step_done(
         await conn.execute(
             """
             UPDATE post_publish_queue
-            SET completed_steps = COALESCE(completed_steps, '{}'::jsonb) || jsonb_build_object($2, true)
+            SET completed_steps = COALESCE(completed_steps, '{}'::jsonb) || jsonb_build_object($2::text, true)
             WHERE slug = $1
             """,
             slug,

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_router.py
@@ -398,3 +398,47 @@ class TestGetPendingQueueSelfHealing:
         test_client, _conn = _client_with_auth(mock_services)
         response = test_client.get("/api/intel/post-publish-queue/pending")
         assert response.status_code == 401
+
+
+# ── mark_step_done ──────────────────────────────────────────────────────────
+#
+# Regression coverage for the "could not determine data type of parameter $2"
+# 500 (Fly prod log, reproduced live): `jsonb_build_object($2, true)` gives
+# asyncpg/Postgres nothing to infer $2's type from in that position. Fix casts
+# it explicitly: `jsonb_build_object($2::text, true)`. These tests pin the
+# cast in the executed SQL text (mocked connection, no real DB — see
+# `_client_with_auth` above) and confirm the endpoint returns 200/401 as
+# expected.
+
+
+class TestMarkStepDone:
+    def test_step_done_casts_param_and_returns_200(self, mock_services):
+        from backend.app.routers import intel as intel_router_module
+
+        intel_router_module.settings.intel_scraper_api_key = "test-key"
+        test_client, conn = _client_with_auth(mock_services)
+
+        response = test_client.post(
+            "/api/intel/post-publish-queue/step-done",
+            headers={"X-API-Key": "test-key"},
+            json={"slug": "test-article", "step": "hero_image"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True, "slug": "test-article", "step": "hero_image"}
+
+        conn.execute.assert_awaited_once()
+        executed_sql = conn.execute.await_args_list[0].args[0]
+        assert "jsonb_build_object($2::text, true)" in executed_sql
+
+    def test_unauthorized_without_api_key(self, mock_services):
+        from backend.app.routers import intel as intel_router_module
+
+        intel_router_module.settings.intel_scraper_api_key = "test-key"
+        test_client, _conn = _client_with_auth(mock_services)
+
+        response = test_client.post(
+            "/api/intel/post-publish-queue/step-done",
+            json={"slug": "test-article", "step": "hero_image"},
+        )
+        assert response.status_code == 401

--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -330,6 +330,10 @@ def flush_seo_batch() -> bool:
     return _flush_batch("seo", "bot/seo-metadata", "fix(seo): GEO/AEO metadata {date} ({n} files)")
 
 
+def flush_layout_batch() -> bool:
+    return _flush_batch("layout", "bot/homepage-layout", "chore(homepage): hero rotation {date}")
+
+
 def _image_exists_on_github(gh_path: str) -> bool:
     try:
         check = subprocess.run(
@@ -708,7 +712,10 @@ LATEST_KEYS = ["latest_1", "latest_2", "latest_3", "latest_4", "latest_5"]
 def rotate_hero(new_slug: str) -> bool:
     """Rotate homepage-layout.json: push new_slug to hero_main, cascade others down.
     Old hero_5 moves to latest_1, shifting latest_* down (latest_5 dropped).
-    Commits and pushes to GitHub.
+
+    Stages the write for the end-of-tick batch flush (`flush_layout_batch`) instead
+    of PUT-ing straight to main — direct PUTs are rejected by branch protection
+    (see the "GitHub batch-branch/PR commit mechanism" note above `_stage_commit`).
     """
     import base64 as _b64
 
@@ -725,7 +732,6 @@ def rotate_hero(new_slug: str) -> bool:
             return False
         data = json.loads(result.stdout)
         layout = json.loads(_b64.b64decode(data["content"]).decode("utf-8"))
-        sha = data["sha"]
     except Exception as e:
         log(f"  ⚠ Hero: read error: {e}")
         return False
@@ -758,26 +764,14 @@ def rotate_hero(new_slug: str) -> bool:
         if i < len(new_latests):
             layout[key] = new_latests[i]
 
-    # Write back to GitHub
+    # Stage the write for the end-of-tick layout batch flush (see flush_layout_batch)
     new_content = json.dumps(layout, indent=2, ensure_ascii=False) + "\n"
-    encoded = _b64.b64encode(new_content.encode("utf-8")).decode("utf-8")
-    payload = {
-        "message": f"feat(homepage): rotate hero → {new_slug[:50]}",
-        "content": encoded,
-        "sha": sha,
-    }
-    try:
-        result = subprocess.run(
-            ["gh", "api", f"repos/{GITHUB_OWNER}/{GITHUB_REPO}/contents/{HOMEPAGE_LAYOUT_PATH}",
-             "--method", "PUT", "--input", "-"],
-            input=json.dumps(payload), capture_output=True, text=True, timeout=30,
-        )
-        ok = result.returncode == 0
-        log(f"  {'✅' if ok else '❌'} Hero rotation pushed (hero_main={new_slug[:40]})")
-        return ok
-    except Exception as e:
-        log(f"  ⚠ Hero rotation push error: {e}")
-        return False
+    _stage_commit(
+        "layout", HOMEPAGE_LAYOUT_PATH, new_content.encode("utf-8"),
+        f"feat(homepage): rotate hero → {new_slug[:50]}",
+    )
+    log(f"  ✅ Hero rotation staged (hero_main={new_slug[:40]})")
+    return True
 
 
 # ─── GIT OPERATIONS ───────────────────────────────────────────────────────────
@@ -928,15 +922,17 @@ def main():
             if "translate" not in failed_steps and item.get("source") == "intel":
                 translated_slugs.append(slug)
 
-    # Flush this tick's staged GitHub writes (images + SEO) — ONE bot branch +
-    # auto-merged PR per kind, replacing the direct-to-main PUTs branch
-    # protection has been rejecting since ~2026-05-22.
+    # Flush this tick's staged GitHub writes (images + SEO + homepage layout) —
+    # ONE bot branch + auto-merged PR per kind, replacing the direct-to-main
+    # PUTs branch protection has been rejecting since ~2026-05-22.
     img_flush_ok = flush_image_batch()
     seo_flush_ok = flush_seo_batch()
-    if not img_flush_ok or not seo_flush_ok:
+    layout_flush_ok = flush_layout_batch()
+    if not img_flush_ok or not seo_flush_ok or not layout_flush_ok:
         send_telegram_alert(
             "⚠️ *Post-publish poller*\n"
-            f"GitHub batch flush failed (image={img_flush_ok}, seo={seo_flush_ok}) — see log"
+            f"GitHub batch flush failed (image={img_flush_ok}, seo={seo_flush_ok}, "
+            f"layout={layout_flush_ok}) — see log"
         )
 
     # Commit translations

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -235,3 +235,100 @@ class TestStageCommit:
         import base64
 
         assert base64.b64decode(item["content_b64"]) == b"raw-bytes"
+
+
+class TestFlushLayoutBatch:
+    def test_uses_distinct_branch_prefix_and_title(self):
+        ppp._stage_commit(
+            "layout", ppp.HOMEPAGE_LAYOUT_PATH, b'{"hero_main": "foo"}',
+            "feat(homepage): rotate hero → foo",
+        )
+        calls = []
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=_happy_path_fake_run(calls)):
+            ok = ppp.flush_layout_batch()
+
+        assert ok is True
+        assert ppp._PENDING_COMMITS == []  # drained
+
+        create_ref_calls = [
+            c for c in calls
+            if c["cmd"][:2] == ["gh", "api"] and c["cmd"][2].endswith("/git/refs") and "POST" in c["cmd"]
+        ]
+        import json as _json
+
+        ref_payload = _json.loads(create_ref_calls[0]["kwargs"]["input"])
+        assert ref_payload["ref"].startswith("refs/heads/bot/homepage-layout-")
+
+        pr_create_calls = [c for c in calls if c["cmd"][:3] == ["gh", "pr", "create"]]
+        title = pr_create_calls[0]["cmd"][pr_create_calls[0]["cmd"].index("--title") + 1]
+        assert title.startswith("chore(homepage): hero rotation ")
+
+
+# ── rotate_hero (homepage-layout.json write path) ──────────────────────────
+#
+# Regression coverage: rotate_hero() used to PUT apps/mouth/src/content/
+# homepage-layout.json straight to main via the Contents API — rejected by
+# branch protection (live prod log: "❌ Hero rotation pushed"). It must now
+# stage the write for flush_layout_batch (kind="layout") instead, same as the
+# image/SEO paths above.
+
+
+def _layout_read_result(layout: dict, sha: str = "layoutsha123") -> "subprocess.CompletedProcess[str]":
+    import base64 as _b64
+    import json as _json
+
+    content_b64 = _b64.b64encode(_json.dumps(layout).encode("utf-8")).decode("utf-8")
+    return _res(stdout=_json.dumps({"content": content_b64, "sha": sha}))
+
+
+class TestRotateHero:
+    def _fake_read(self, layout, calls):
+        read_cmd = ["gh", "api", f"repos/{ppp.GITHUB_OWNER}/{ppp.GITHUB_REPO}/contents/{ppp.HOMEPAGE_LAYOUT_PATH}"]
+
+        def fake_run(cmd, **kwargs):
+            calls.append({"cmd": list(cmd), "kwargs": kwargs})
+            if list(cmd) == read_cmd:
+                return _layout_read_result(layout)
+            return _res(returncode=0)
+
+        return fake_run
+
+    def test_stages_layout_write_instead_of_direct_put(self):
+        """rotate_hero must NOT PUT directly to main — it stages into
+        _PENDING_COMMITS (kind='layout') for flush_layout_batch to commit via a
+        bot branch + auto-merged PR."""
+        layout = {
+            "hero_main": "old-hero", "hero_2": "h2", "hero_3": "h3", "hero_4": "h4", "hero_5": "h5",
+            "latest_1": "l1", "latest_2": "l2", "latest_3": "l3", "latest_4": "l4", "latest_5": "l5",
+        }
+        calls = []
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=self._fake_read(layout, calls)):
+            ok = ppp.rotate_hero("new-hero")
+
+        assert ok is True
+
+        # No direct PUT to the Contents API happened
+        put_calls = [c for c in calls if "PUT" in c["cmd"]]
+        assert put_calls == []
+
+        # Staged exactly one "layout" commit with the rotated content
+        layout_commits = [c for c in ppp._PENDING_COMMITS if c["kind"] == "layout"]
+        assert len(layout_commits) == 1
+        assert layout_commits[0]["gh_path"] == ppp.HOMEPAGE_LAYOUT_PATH
+
+        import base64 as _b64
+        import json as _json
+
+        staged_layout = _json.loads(_b64.b64decode(layout_commits[0]["content_b64"]).decode("utf-8"))
+        assert staged_layout["hero_main"] == "new-hero"
+        assert staged_layout["hero_2"] == "old-hero"
+        assert staged_layout["latest_1"] == "h5"  # evicted old hero_5, cascaded to latest_1
+
+    def test_already_hero_main_is_noop_no_stage(self):
+        layout = {"hero_main": "same-slug"}
+        calls = []
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=self._fake_read(layout, calls)):
+            ok = ppp.rotate_hero("same-slug")
+
+        assert ok is True
+        assert ppp._PENDING_COMMITS == []

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 638 services · 1151 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 638 services · 1154 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- `POST /api/intel/post-publish-queue/step-done` has been returning HTTP 500 on **every** call since inception. Fly prod log: `could not determine data type of parameter $2` — asyncpg/Postgres can't infer `$2`'s type inside `jsonb_build_object($2, true)`. Fixed by casting explicitly: `jsonb_build_object($2::text, true)`.
- `rotate_hero()` in `post_publish_poller.py` was still PUT-ing `apps/mouth/src/content/homepage-layout.json` straight to `main` via the Contents API — rejected by branch protection (live prod log today: "❌ Hero rotation pushed"), same class of bug already fixed for cover images/SEO in #2595. Now routes through the existing `_stage_commit`/`_flush_batch` mechanism via a new `layout` kind + `flush_layout_batch()` (branch prefix `bot/homepage-layout`), wired into `main()` alongside `flush_image_batch()`/`flush_seo_batch()`.

## Test plan
- [x] `TestMarkStepDone` (backend router unit tests) — 200 path pins the `$2::text` cast in the executed SQL; 401 path for missing API key.
- [x] `TestFlushLayoutBatch` + `TestRotateHero` (poller unit tests) — confirms `rotate_hero()` no longer issues a direct PUT and stages a `layout`-kind commit instead; confirms `flush_layout_batch()` uses the `bot/homepage-layout` branch prefix and `chore(homepage): hero rotation` title.
- [x] Full backend pytest suite green pre-push: `17396 passed, 165 skipped` (303s).
- [x] Poller unit suite (`--confcutdir=tests/unit`, pre-existing broken root `conftest.py` per repo convention): `12 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)