### PR TITLE
feat(llm): promote Gemini 3.5 Flash to primary/channel model (WA bot lane)

### DIFF
--- a/apps/backend-rag/backend/llm/config.py
+++ b/apps/backend-rag/backend/llm/config.py
@@ -12,12 +12,12 @@ Updated: S04 LLM Solidification
 class ModelName:
     """Gemini model names — the ONLY place to change model versions."""
 
-    # Primary (Gemini 3 Flash Preview)
-    PRIMARY = "gemini-3-flash-preview"
+    # Primary (Gemini 3.5 Flash — GA)
+    PRIMARY = "gemini-3.5-flash"
     # Fallback (Gemini 2.5 Flash — stable GA)
     FALLBACK = "gemini-2.5-flash"
     # Channel-facing (same as primary for cost parity)
-    CHANNEL = "gemini-3-flash-preview"
+    CHANNEL = "gemini-3.5-flash"
 
 
 class OpenRouterModel:

--- a/apps/backend-rag/backend/llm/providers/gemini.py
+++ b/apps/backend-rag/backend/llm/providers/gemini.py
@@ -17,16 +17,16 @@ class GeminiProvider(LLMProvider):
     LLMProvider adapter for Google Gemini (via GeminiJakselService).
 
     Supports:
-    - gemini-3-flash-preview (default)
+    - gemini-3.5-flash (default)
     - gemini-2.5-flash (fallback)
     """
 
-    def __init__(self, model_name: str = "gemini-3-flash-preview") -> None:
+    def __init__(self, model_name: str = "gemini-3.5-flash") -> None:
         """
         Initialize Gemini provider.
 
         Args:
-            model_name: Model to use (default: gemini-3-flash-preview)
+            model_name: Model to use (default: gemini-3.5-flash)
         """
         self._model_name = model_name
         self._service = None

--- a/apps/backend-rag/backend/llm/token_estimator.py
+++ b/apps/backend-rag/backend/llm/token_estimator.py
@@ -18,7 +18,7 @@ _TOKEN_WORD_RATIO = 1.3
 class TokenEstimator:
     """Lightweight token estimator using word-count approximation."""
 
-    def __init__(self, model: str = "gemini-3-flash-preview") -> None:
+    def __init__(self, model: str = "gemini-3.5-flash") -> None:
         self.model = model
 
     def estimate_tokens(self, text: str) -> int:

--- a/apps/backend-rag/backend/services/llm_clients/gemini_service.py
+++ b/apps/backend-rag/backend/services/llm_clients/gemini_service.py
@@ -23,15 +23,15 @@ logger = logging.getLogger(__name__)
 
 
 class GeminiJakselService:
-    def __init__(self, model_name: str = "gemini-3-flash-preview") -> None:
+    def __init__(self, model_name: str = "gemini-3.5-flash") -> None:
         """
         Initialize Gemini Service with Jaksel Persona and OpenRouter fallback.
 
         Args:
-            model_name: "gemini-3-flash-preview" (primary) or fallback model
+            model_name: "gemini-3.5-flash" (primary) or fallback model
 
         Note:
-            - Primary: 3 Flash Preview (fast, cost-effective)
+            - Primary: 3.5 Flash (fast, cost-effective)
             - Fallback: 2.0 Flash (stable, reliable)
             - Automatic fallback to OpenRouter free models on 429
         """

--- a/apps/backend-rag/backend/services/llm_clients/pricing.py
+++ b/apps/backend-rag/backend/services/llm_clients/pricing.py
@@ -58,15 +58,19 @@ class TokenUsage:
 # Source: https://ai.google.dev/pricing, https://openai.com/pricing, https://openrouter.ai/models
 LLM_PRICING: dict[str, dict[str, float]] = {
     # ── Active Gemini Models (primary + fallback) ──
-    "gemini-3-flash-preview": {
-        "input": 0.10,
-        "output": 0.40,
+    "gemini-3.5-flash": {
+        "input": 1.50,
+        "output": 9.00,
     },
     "gemini-2.5-flash": {
         "input": 0.075,
         "output": 0.30,
     },
     # ── Legacy Gemini (kept for cost tracking of old logs) ──
+    "gemini-3-flash-preview": {
+        "input": 0.10,
+        "output": 0.40,
+    },
     "gemini-2.0-flash": {
         "input": 0.075,
         "output": 0.30,

--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator.py
@@ -96,7 +96,7 @@ class AgenticRAGOrchestrator:
         self,
         tools: list[BaseTool],
         db_pool: Any = None,
-        model_name: str = "gemini-3-flash-preview",  # Zantara AI - Gemini 3 Flash Preview
+        model_name: str = "gemini-3.5-flash",  # Zantara AI - Gemini 3.5 Flash
         semantic_cache: SemanticCache = None,
         faq_cache: Any = None,  # NotebookLMCacheService
         retriever: Any = None,

--- a/apps/backend-rag/backend/services/rag/verification_service.py
+++ b/apps/backend-rag/backend/services/rag/verification_service.py
@@ -65,7 +65,7 @@ class VerificationService:
 
     def __init__(self) -> None:
         self._genai_client: GenAIClient | None = None
-        self.model_name = "gemini-3-flash-preview"
+        self.model_name = "gemini-3.5-flash"
 
     def _get_genai_client(self) -> GenAIClient | None:
         """Lazy load GenAI client."""

--- a/apps/backend-rag/backend/tests/services/llm_clients/test_gemini_service.py
+++ b/apps/backend-rag/backend/tests/services/llm_clients/test_gemini_service.py
@@ -78,7 +78,7 @@ class TestInitialization:
 
     def test_default_model_name(self, _patch_persona: Any) -> None:
         svc = GeminiJakselService()
-        assert svc.model_name == "gemini-3-flash-preview"
+        assert svc.model_name == "gemini-3.5-flash"
 
     def test_few_shot_history_populated(self, _patch_persona: Any) -> None:
         svc = GeminiJakselService()

--- a/apps/backend-rag/backend/tests/unit/llm/adapters/test_registry.py
+++ b/apps/backend-rag/backend/tests/unit/llm/adapters/test_registry.py
@@ -22,7 +22,7 @@ class TestModelType:
 
     def test_model_type_values(self):
         """Test ModelType enum values"""
-        assert ModelType.GEMINI_FLASH.value == "gemini-3-flash-preview"
+        assert ModelType.GEMINI_FLASH.value == "gemini-3.5-flash"
         assert ModelType.GEMINI_FLASH_FALLBACK.value == "gemini-2.5-flash"
 
     def test_model_type_enum(self):

--- a/apps/backend-rag/backend/tests/unit/llm/providers/test_gemini_provider.py
+++ b/apps/backend-rag/backend/tests/unit/llm/providers/test_gemini_provider.py
@@ -22,7 +22,7 @@ class TestGeminiProvider:
 
         provider = GeminiProvider()
 
-        assert provider._model_name == "gemini-3-flash-preview"
+        assert provider._model_name == "gemini-3.5-flash"
         assert provider._service == mock_service
         assert provider._available is True
 
@@ -104,7 +104,7 @@ class TestGeminiProvider:
         response = await provider.generate(messages)
 
         assert response.content == "Test response"
-        assert response.model == "gemini-3-flash-preview"
+        assert response.model == "gemini-3.5-flash"
         assert response.provider == "gemini"
         assert response.finish_reason == "stop"
 

--- a/apps/backend-rag/backend/tests/unit/llm/test_token_estimator.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_token_estimator.py
@@ -23,7 +23,7 @@ class TestTokenEstimator:
     def test_init_default_model(self):
         """Test initialization with default model"""
         estimator = TokenEstimator()
-        assert estimator.model == "gemini-3-flash-preview"
+        assert estimator.model == "gemini-3.5-flash"
 
     def test_init_custom_model(self):
         """Test initialization with custom model"""

--- a/apps/backend-rag/backend/tests/unit/llm/test_zantara_ai_client.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_zantara_ai_client.py
@@ -91,7 +91,7 @@ def test_init_genai_client_fail_production(mock_genai_available, mock_genai_clie
 def test_get_model_info(mock_genai_available, mock_genai_client):
     client = ZantaraAIClient(api_key="test")
     info = client.get_model_info()
-    assert info["model"] == "gemini-3-flash-preview"
+    assert info["model"] == "gemini-3.5-flash"
     assert info["provider"] == "google_native"
 
     client.mock_mode = True


### PR DESCRIPTION
## Summary

- Zero's GO recorded: `gemini-3.5-flash` is GA on ai.google.dev with function-calling support. Swaps `ModelName.PRIMARY`/`ModelName.CHANNEL` from `gemini-3-flash-preview` to `gemini-3.5-flash` across all 7 consumer sites: `backend/llm/config.py` (SSOT), `backend/services/rag/verification_service.py` (hardcoded slug), `backend/llm/token_estimator.py` (default param), `backend/llm/providers/gemini.py` (default + docstring), `backend/services/llm_clients/gemini_service.py` (default + docstring), `backend/services/rag/agentic/orchestrator.py` (default). `ModelName.FALLBACK` stays `gemini-2.5-flash`, unchanged.
- `pricing.py`: added a `gemini-3.5-flash` entry ($1.50 input / $9.00 output per 1M tokens, official ai.google.dev rates) as the new active-model price key; kept the `gemini-3-flash-preview` entry for legacy cost-log accounting.
- `llm/adapters/registry.py` needed **no edit**: `get_adapter()` resolves via exact `ModelType` enum match first (`GEMINI_FLASH = ModelName.PRIMARY`, so it tracks the new slug automatically), and its string-fallback only checks the generic substring `"gemini"` — not the literal `"gemini-3-flash"` — so it was never at risk of the new slug falling through.
- Updated 6 test assertions across 5 files that pinned the old default/primary-model slug (`test_zantara_ai_client.py`, `test_gemini_provider.py` x2, `test_token_estimator.py`, `test_registry.py`, `test_gemini_service.py::test_default_model_name`). Left `test_gemini_service.py::test_model_name_strips_prefix` untouched — it passes an explicit `model_name` param to exercise `"models/"` prefix-stripping, unrelated to the default slug.
- Swept `apps/backend-rag/tests/` (sibling dir, separate from `backend/tests/`) for remaining old-slug references — confirmed out of scope: `pytest.ini`/`pyproject.toml` both set `testpaths = backend/tests`, so that tree isn't collected by CI.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/unit/llm/ backend/tests/services/llm_clients/ backend/tests/unit/services/rag/agentic/test_orchestrator_coverage.py -q` → **341 passed, 8 skipped, 0 failed**
- [x] Import chain smoke check: `python -c "from backend.app.dependencies import get_current_user; print('OK')"` → `OK`
- [x] Pre-commit hooks (anti-reward-hacking lint, secrets audit, linting, import-chain check) all green on commit `045c37925`

## Rollback

Revert this commit. No schema/registry changes to unwind — pure slug swap + one new pricing dict entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)