### PR TITLE
fix(observability): langfuse v4 API compat — fail-open tracing on agentic-rag path

### DIFF
--- a/.agents/skills/bot/SKILL.md
+++ b/.agents/skills/bot/SKILL.md
@@ -20,23 +20,32 @@ WhatsApp Business (Meta Cloud API) number **+62 821-3465-159** = Zantara. Two au
 - **Bali Zero team**: work-support assistant. Check-in via WA (opens the free Meta 24h window),
   CRM nudges, PII-light briefings. Persona = "assistente operativo interno", not sales.
 
-## 1. LIVE STATE (last update 2026-07-17 ~20:20 WITA — keep current)
+## 1. LIVE STATE (last update 2026-07-17 ~23:40 WITA — keep current)
 
 - **PR #2586 MERGED**: 4 production bugs of the outbox worker fixed (burst duplicate replies,
   takeover-during-generation send, generating-crash orphan, FAQ prewarm scope mismatch) +
   per-thread advisory lock, claim-token fencing, lease heartbeat, burst coalescing, K workers
   (`WA_OUTBOX_WORKERS=2`), admission semaphore (`WA_BOT_MAX_CONCURRENT_GENERATIONS=3`).
-- **PR #2588 (cache F1b) MERGED** (2026-07-17 ~21:00 WITA): FAQ cache wired into the orchestrator
-  the WA bot uses (was cache-less), provenance-mandatory cache writes, curated_qa Qdrant collection +
-  grounding injection, harvester/converter tooling. On main, NOT yet deployed.
-- **Model swap IN FLIGHT**: Gemini **3.5 Flash** primary (Zero GO 2026-07-17). Slug
-  `gemini-3.5-flash` double-verified (GA, function calling OK). PR opened right after #2588:
-  `backend/llm/config.py` ModelName.PRIMARY + CHANNEL; consumer-map also
-  `verification_service.py:68`, `pricing.py` cost table, `token_estimator.py` + provider defaults.
-  FALLBACK stays `gemini-2.5-flash`. Rollback = revert. Check `gh pr list` for its status.
-- **Then, in order**: fly deploy rolling → run converters+harvester (216 E33 + 28 golden) into
-  prod FAQ cache + curated_qa → PROVE-LIVE (real WA question, metrics `faq_cache_hits_total`,
-  `curated_qa_injections_total`) → tell Zero to test from his phone.
+- **PR #2588 (cache F1b) MERGED + DEPLOYED**: FAQ cache wired into the orchestrator the WA bot
+  uses, provenance-mandatory cache writes, curated_qa Qdrant collection + grounding injection,
+  harvester/converter tooling. **E33 216 loaded and verified live**: Redis 216 keys + Qdrant 216
+  points.
+- **PR #2611 (Gemini 3.5 Flash) MERGED + DEPLOYED**: PRIMARY/CHANNEL = `gemini-3.5-flash`,
+  proven in prod (GA, function calling OK). FALLBACK stays `gemini-2.5-flash`.
+- **PROVE-LIVE done** on the real bot path: 200 responses in 1.6–3.9s.
+- **LANGFUSE INCIDENT (2026-07-05 → 2026-07-17, bot dead 11 days)**: a dependabot bump
+  (langfuse 3.14.6 → 4.x) renamed `Langfuse.start_as_current_span()` to
+  `start_as_current_observation(..., as_type="span")` — the old name doesn't exist in v4 at all.
+  `_process_query_traced` in `agentic_rag.py` called the v3 name unguarded, so every
+  `/api/agentic-rag/query` call raised `AttributeError` before the orchestrator ever ran. Outbox
+  outcome: 61 failed sends vs 1 success. Emergency mitigation (still active): Fly secret
+  `LANGFUSE_ENABLED=false` (kill-switch in `observability.py::is_enabled`). **Durable fix**: this
+  PR — `backend/core/observability.py::start_traced_span()` resolves v4-first/v3-fallback via
+  `hasattr` and fails open (no-op span + WARNING log) on any mismatch, applied at both real call
+  sites (`agentic_rag.py`, `tone_council.py`). Re-enabling tracing in prod (`fly secrets unset
+LANGFUSE_ENABLED` or set back to `true`) is an operator action AFTER this PR merges+deploys —
+  not done yet as of this update.
+- **Corner PR #2612 MERGED** (prior §1 refresh, superseded by this update).
 - **F2 (team check-in) NOT started** — begins after F1 ships. F3 (member profiles) after F2.
 - **Prompt v4 lane OPEN** (audit done, 7 findings — see §5). **Full-domain cache lane OPEN**
   (design pending). Both tracked in the main session's task list.

--- a/.claude/skills/bot/SKILL.md
+++ b/.claude/skills/bot/SKILL.md
@@ -20,23 +20,32 @@ WhatsApp Business (Meta Cloud API) number **+62 821-3465-159** = Zantara. Two au
 - **Bali Zero team**: work-support assistant. Check-in via WA (opens the free Meta 24h window),
   CRM nudges, PII-light briefings. Persona = "assistente operativo interno", not sales.
 
-## 1. LIVE STATE (last update 2026-07-17 ~20:20 WITA — keep current)
+## 1. LIVE STATE (last update 2026-07-17 ~23:40 WITA — keep current)
 
 - **PR #2586 MERGED**: 4 production bugs of the outbox worker fixed (burst duplicate replies,
   takeover-during-generation send, generating-crash orphan, FAQ prewarm scope mismatch) +
   per-thread advisory lock, claim-token fencing, lease heartbeat, burst coalescing, K workers
   (`WA_OUTBOX_WORKERS=2`), admission semaphore (`WA_BOT_MAX_CONCURRENT_GENERATIONS=3`).
-- **PR #2588 (cache F1b) MERGED** (2026-07-17 ~21:00 WITA): FAQ cache wired into the orchestrator
-  the WA bot uses (was cache-less), provenance-mandatory cache writes, curated_qa Qdrant collection +
-  grounding injection, harvester/converter tooling. On main, NOT yet deployed.
-- **Model swap IN FLIGHT**: Gemini **3.5 Flash** primary (Zero GO 2026-07-17). Slug
-  `gemini-3.5-flash` double-verified (GA, function calling OK). PR opened right after #2588:
-  `backend/llm/config.py` ModelName.PRIMARY + CHANNEL; consumer-map also
-  `verification_service.py:68`, `pricing.py` cost table, `token_estimator.py` + provider defaults.
-  FALLBACK stays `gemini-2.5-flash`. Rollback = revert. Check `gh pr list` for its status.
-- **Then, in order**: fly deploy rolling → run converters+harvester (216 E33 + 28 golden) into
-  prod FAQ cache + curated_qa → PROVE-LIVE (real WA question, metrics `faq_cache_hits_total`,
-  `curated_qa_injections_total`) → tell Zero to test from his phone.
+- **PR #2588 (cache F1b) MERGED + DEPLOYED**: FAQ cache wired into the orchestrator the WA bot
+  uses, provenance-mandatory cache writes, curated_qa Qdrant collection + grounding injection,
+  harvester/converter tooling. **E33 216 loaded and verified live**: Redis 216 keys + Qdrant 216
+  points.
+- **PR #2611 (Gemini 3.5 Flash) MERGED + DEPLOYED**: PRIMARY/CHANNEL = `gemini-3.5-flash`,
+  proven in prod (GA, function calling OK). FALLBACK stays `gemini-2.5-flash`.
+- **PROVE-LIVE done** on the real bot path: 200 responses in 1.6–3.9s.
+- **LANGFUSE INCIDENT (2026-07-05 → 2026-07-17, bot dead 11 days)**: a dependabot bump
+  (langfuse 3.14.6 → 4.x) renamed `Langfuse.start_as_current_span()` to
+  `start_as_current_observation(..., as_type="span")` — the old name doesn't exist in v4 at all.
+  `_process_query_traced` in `agentic_rag.py` called the v3 name unguarded, so every
+  `/api/agentic-rag/query` call raised `AttributeError` before the orchestrator ever ran. Outbox
+  outcome: 61 failed sends vs 1 success. Emergency mitigation (still active): Fly secret
+  `LANGFUSE_ENABLED=false` (kill-switch in `observability.py::is_enabled`). **Durable fix**: this
+  PR — `backend/core/observability.py::start_traced_span()` resolves v4-first/v3-fallback via
+  `hasattr` and fails open (no-op span + WARNING log) on any mismatch, applied at both real call
+  sites (`agentic_rag.py`, `tone_council.py`). Re-enabling tracing in prod (`fly secrets unset
+LANGFUSE_ENABLED` or set back to `true`) is an operator action AFTER this PR merges+deploys —
+  not done yet as of this update.
+- **Corner PR #2612 MERGED** (prior §1 refresh, superseded by this update).
 - **F2 (team check-in) NOT started** — begins after F1 ships. F3 (member profiles) after F2.
 - **Prompt v4 lane OPEN** (audit done, 7 findings — see §5). **Full-domain cache lane OPEN**
   (design pending). Both tracked in the main session's task list.

--- a/apps/backend-rag/backend/app/routers/agentic_rag.py
+++ b/apps/backend-rag/backend/app/routers/agentic_rag.py
@@ -28,7 +28,7 @@ from backend.app.dependencies import (
     get_orchestrator,
 )
 from backend.app.utils.tracing import add_span_event, set_span_status, trace_span
-from backend.core.observability import init_observability
+from backend.core.observability import init_observability, start_traced_span
 from backend.core.observability import is_enabled as _lf_enabled
 from backend.db.repositories.conversation_repository import ConversationRepository
 from backend.services.agents.team_agent_config import (
@@ -198,7 +198,8 @@ async def _process_query_traced(
     # "Langfuse POC" for the full UU PDP compliance note.
     query_str = str(query_kwargs.get("query", ""))
     query_hash = hashlib.sha256(query_str.encode("utf-8")).hexdigest()[:16]
-    with lf.start_as_current_span(
+    with start_traced_span(
+        lf,
         name="agentic_rag.query",
         input={"query_hash": query_hash, "query_length": len(query_str)},
         metadata={
@@ -212,20 +213,21 @@ async def _process_query_traced(
         },
     ) as span:
         result = await orchestrator.process_query(**query_kwargs)
-        try:
-            span.update(
-                output={
-                    "route_used": getattr(result, "route_used", None),
-                    "document_count": getattr(result, "document_count", None),
-                    "model_used": getattr(result, "model_used", None),
-                    "abstain": getattr(result, "abstain", False),
-                    "evidence_score": getattr(result, "evidence_score", None),
-                    # No answer text — may contain PII from RAG retrieval.
-                },
-            )
-        except Exception:
-            # Never let observability break the request
-            pass
+        if span is not None:
+            try:
+                span.update(
+                    output={
+                        "route_used": getattr(result, "route_used", None),
+                        "document_count": getattr(result, "document_count", None),
+                        "model_used": getattr(result, "model_used", None),
+                        "abstain": getattr(result, "abstain", False),
+                        "evidence_score": getattr(result, "evidence_score", None),
+                        # No answer text — may contain PII from RAG retrieval.
+                    },
+                )
+            except Exception:
+                # Never let observability break the request
+                pass
         return result
 
 

--- a/apps/backend-rag/backend/core/observability.py
+++ b/apps/backend-rag/backend/core/observability.py
@@ -25,6 +25,7 @@ Usage:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import threading
@@ -244,6 +245,58 @@ def get_langfuse_client() -> Any | None:
     return _CLIENT
 
 
+@contextlib.contextmanager
+def _noop_span_cm() -> Any:
+    yield None
+
+
+def start_traced_span(
+    lf: Any,
+    *,
+    name: str,
+    input: Any = None,  # matches Langfuse SDK kwarg name
+    metadata: Any = None,
+) -> Any:
+    """Start a Langfuse span, tolerant of the v3->v4 SDK rename.
+
+    Incident (2026-07-05 to 2026-07-17): dependabot bumped `langfuse`
+    3.14.6 -> 4.x. v3.x exposed `Langfuse.start_as_current_span(...)`;
+    v4.x renamed it to `Langfuse.start_as_current_observation(...,
+    as_type="span")` and dropped the old name entirely (verified against
+    the pinned `langfuse==4.14.0` in requirements.lock.txt). Every call
+    site that did `with lf.start_as_current_span(...) as span:`
+    unconditionally raised `AttributeError` on the FIRST call, taking down
+    `/api/agentic-rag/query` end to end for 11 days (61 failed WA-bot
+    sends vs 1 success) until the `LANGFUSE_ENABLED=false` kill-switch
+    was flipped as an emergency mitigation.
+
+    This helper resolves the right method by `hasattr` (v4 preferred,
+    v3 as a defense-in-depth fallback for a hypothetical downgrade) and
+    degrades to a no-op span on ANY failure — telemetry must never crash
+    the query path again. Returns a **synchronous** context manager that
+    yields the span object (or None when tracing could not start).
+    """
+    try:
+        if hasattr(lf, "start_as_current_observation"):
+            return lf.start_as_current_observation(
+                name=name,
+                as_type="span",
+                input=input,
+                metadata=metadata,
+            )
+        if hasattr(lf, "start_as_current_span"):
+            return lf.start_as_current_span(name=name, input=input, metadata=metadata)
+        logger.warning(
+            "langfuse.span_api_missing name=%s — client exposes neither "
+            "start_as_current_observation (v4) nor start_as_current_span "
+            "(v3); tracing disabled for this call (fail-open)",
+            name,
+        )
+    except Exception as exc:
+        logger.warning("langfuse.span_start_failed name=%s error=%s", name, exc)
+    return _noop_span_cm()
+
+
 def shutdown_observability() -> None:
     """Flush pending spans. Call on FastAPI shutdown / CLI exit."""
     global _CLIENT, _INITIALIZED
@@ -263,4 +316,5 @@ __all__ = [
     "init_observability",
     "is_enabled",
     "shutdown_observability",
+    "start_traced_span",
 ]

--- a/apps/backend-rag/backend/services/council/tone_council.py
+++ b/apps/backend-rag/backend/services/council/tone_council.py
@@ -609,7 +609,11 @@ class _SyncSpanAsyncCM:
 def _maybe_council_span(*, topic: str, proponents: list[str]) -> Any:
     """Return an async context manager wrapping a Langfuse span (or a no-op)."""
     try:
-        from backend.core.observability import init_observability, is_enabled
+        from backend.core.observability import (
+            init_observability,
+            is_enabled,
+            start_traced_span,
+        )
     except Exception:
         return _NullAsyncCM()
 
@@ -627,7 +631,11 @@ def _maybe_council_span(*, topic: str, proponents: list[str]) -> Any:
         # PII-safe: hash + length only. War-room topics rarely contain
         # client PII but the pattern is uniform with agentic_rag.
         topic_hash = hashlib.sha256(topic.encode("utf-8")).hexdigest()[:16]
-        sync_cm = lf.start_as_current_span(
+        # start_traced_span is itself v3/v4-tolerant + fail-open (see
+        # backend/core/observability.py) — the outer try/except here is
+        # defense-in-depth kept for any future non-span-API failure.
+        sync_cm = start_traced_span(
+            lf,
             name="tone_council.run",
             input={"topic_hash": topic_hash, "topic_length": len(topic)},
             metadata={"proponents": proponents},

--- a/apps/backend-rag/backend/tests/core/test_observability.py
+++ b/apps/backend-rag/backend/tests/core/test_observability.py
@@ -190,10 +190,13 @@ def test_disabled_path_opens_no_socket(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_shutdown_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGFUSE_ENABLED", "false")
 
-    from backend.core.observability import shutdown_observability
+    import backend.core.observability as obs
 
-    # Must not raise, must not flush anything (there's nothing to flush).
-    shutdown_observability()
+    assert obs._CLIENT is None  # nothing to flush before shutdown
+
+    obs.shutdown_observability()  # must not raise
+
+    assert obs._CLIENT is None  # still no client — nothing was ever constructed
 
 
 def test_shutdown_flushes_when_client_present() -> None:
@@ -216,3 +219,108 @@ def test_shutdown_swallows_flush_errors() -> None:
     obs._INITIALIZED = True
 
     obs.shutdown_observability()  # must not raise
+
+    fake.flush.assert_called_once()  # flush WAS attempted; the error was swallowed
+
+
+# ── 5. start_traced_span — v3/v4 SDK-rename tolerance (2026-07-17) ──────
+#
+# Root cause of the 2026-07-05..17 incident: dependabot bumped langfuse
+# 3.14.6 -> 4.x. v3.x exposed `Langfuse.start_as_current_span(...)`; v4.x
+# renamed it to `Langfuse.start_as_current_observation(..., as_type="span")`
+# and dropped the old name (verified against the pinned langfuse==4.14.0).
+# Every real call site used the v3 name unconditionally with NO guard around
+# the `with` statement itself -> AttributeError crashed every
+# /api/agentic-rag/query call. These tests pin the fix: prefer the real v4
+# API, tolerate a v3 client, and never let a broken/missing span API raise
+# out of start_traced_span.
+
+
+def test_start_traced_span_uses_v4_api_when_available() -> None:
+    from backend.core.observability import start_traced_span
+
+    v4_client = mock.MagicMock(spec=["start_as_current_observation"])
+    sentinel_cm = mock.MagicMock(name="span_cm")
+    v4_client.start_as_current_observation.return_value = sentinel_cm
+
+    result = start_traced_span(
+        v4_client,
+        name="agentic_rag.query",
+        input={"query_hash": "abc"},
+        metadata={"session_id": "s1"},
+    )
+
+    assert result is sentinel_cm
+    v4_client.start_as_current_observation.assert_called_once_with(
+        name="agentic_rag.query",
+        as_type="span",
+        input={"query_hash": "abc"},
+        metadata={"session_id": "s1"},
+    )
+
+
+def test_start_traced_span_falls_back_to_v3_api() -> None:
+    """Defense-in-depth: a hypothetical downgrade to v3.x must still trace."""
+    from backend.core.observability import start_traced_span
+
+    v3_client = mock.MagicMock(spec=["start_as_current_span"])
+    sentinel_cm = mock.MagicMock(name="span_cm")
+    v3_client.start_as_current_span.return_value = sentinel_cm
+
+    result = start_traced_span(
+        v3_client,
+        name="agentic_rag.query",
+        input={"query_hash": "abc"},
+        metadata=None,
+    )
+
+    assert result is sentinel_cm
+    v3_client.start_as_current_span.assert_called_once_with(
+        name="agentic_rag.query",
+        input={"query_hash": "abc"},
+        metadata=None,
+    )
+
+
+def test_start_traced_span_prefers_v4_over_v3_when_both_present() -> None:
+    from backend.core.observability import start_traced_span
+
+    both_client = mock.MagicMock(
+        spec=["start_as_current_observation", "start_as_current_span"],
+    )
+
+    start_traced_span(both_client, name="x")
+
+    both_client.start_as_current_observation.assert_called_once()
+    both_client.start_as_current_span.assert_not_called()
+
+
+def test_start_traced_span_fails_open_when_span_api_missing() -> None:
+    """The exact regression: neither v3 nor v4 method present.
+
+    This is what a mismatched SDK looks like from the caller's side —
+    accessing the missing attribute must NOT raise, and the returned
+    context manager must yield None so `with ... as span:` degrades
+    cleanly instead of crashing the query path.
+    """
+    from backend.core.observability import start_traced_span
+
+    broken_client = mock.MagicMock(spec=[])  # no span methods at all
+
+    cm = start_traced_span(broken_client, name="agentic_rag.query")
+    with cm as span:
+        assert span is None  # no-op span, never raises
+
+
+def test_start_traced_span_fails_open_when_call_raises() -> None:
+    """Even if the attribute exists but calling it explodes, don't crash."""
+    from backend.core.observability import start_traced_span
+
+    exploding_client = mock.MagicMock(spec=["start_as_current_observation"])
+    exploding_client.start_as_current_observation.side_effect = AttributeError(
+        "'Langfuse' object has no attribute 'start_as_current_span'",
+    )
+
+    cm = start_traced_span(exploding_client, name="agentic_rag.query")
+    with cm as span:
+        assert span is None

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_agentic_rag_tracing.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_agentic_rag_tracing.py
@@ -1,0 +1,139 @@
+"""Regression tests for `_process_query_traced` Langfuse fail-open behavior.
+
+Incident (2026-07-05 -> 2026-07-17): dependabot bumped `langfuse` 3.14.6 ->
+4.x. langfuse v4 renamed `Langfuse.start_as_current_span(...)` to
+`Langfuse.start_as_current_observation(..., as_type="span")` and dropped the
+old name entirely. `_process_query_traced` called the v3 name unconditionally
+with the `with` statement itself unguarded -> every `/api/agentic-rag/query`
+call raised `AttributeError` before `orchestrator.process_query` ever ran.
+That is exactly what fed the WA bot's outbox: 61 failed sends vs 1 success
+between 2026-07-05 and 2026-07-17, until `LANGFUSE_ENABLED=false` was flipped
+as an emergency kill-switch.
+
+These tests pin: (1) the query path survives when the langfuse client lacks
+BOTH the v3 and v4 span methods (the exact incident shape), and (2) tracing
+still actually works end-to-end against a realistic v4-shaped mock client.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent.parent.parent / "backend"
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))
+
+from backend.app.routers.agentic_rag import _process_query_traced
+
+
+@pytest.fixture
+def mock_orchestrator():
+    result = MagicMock()
+    result.route_used = "flash"
+    result.document_count = 5
+    result.model_used = "gemini-3.5-flash"
+    result.abstain = False
+    result.evidence_score = 0.9
+
+    orchestrator = AsyncMock()
+    orchestrator.process_query = AsyncMock(return_value=result)
+    return orchestrator
+
+
+def _base_kwargs(orchestrator, query_kwargs=None):
+    return {
+        "orchestrator": orchestrator,
+        "query_kwargs": query_kwargs or {"query": "berapa harga KITAS?"},
+        "authenticated_user_id": "user-123",
+        "session_id": "sess-1",
+        "query_id": "q-1",
+        "ab_variants": {"hybrid_vs_dense": "control"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_query_path_survives_broken_v4_client(mock_orchestrator) -> None:
+    """The exact incident: langfuse client with neither v3 nor v4 span method."""
+    broken_lf = MagicMock(spec=[])  # no start_as_current_span, no *_observation
+
+    with (
+        patch(
+            "backend.app.routers.agentic_rag._lf_enabled",
+            return_value=True,
+        ),
+        patch("langfuse.get_client", return_value=broken_lf),
+    ):
+        result = await _process_query_traced(**_base_kwargs(mock_orchestrator))
+
+    mock_orchestrator.process_query.assert_awaited_once()
+    assert result is mock_orchestrator.process_query.return_value
+
+
+@pytest.mark.asyncio
+async def test_query_path_survives_span_start_raising(mock_orchestrator) -> None:
+    """Attribute present but calling it explodes — still must not crash."""
+    exploding_lf = MagicMock(spec=["start_as_current_observation"])
+    exploding_lf.start_as_current_observation.side_effect = AttributeError(
+        "'Langfuse' object has no attribute 'start_as_current_span'",
+    )
+
+    with (
+        patch(
+            "backend.app.routers.agentic_rag._lf_enabled",
+            return_value=True,
+        ),
+        patch("langfuse.get_client", return_value=exploding_lf),
+    ):
+        result = await _process_query_traced(**_base_kwargs(mock_orchestrator))
+
+    mock_orchestrator.process_query.assert_awaited_once()
+    assert result is mock_orchestrator.process_query.return_value
+
+
+@pytest.mark.asyncio
+async def test_query_path_traces_successfully_with_v4_client(mock_orchestrator) -> None:
+    """Positive case: a realistic v4-shaped client actually gets traced."""
+    span = MagicMock(name="span")
+    span_cm = MagicMock()
+    span_cm.__enter__ = MagicMock(return_value=span)
+    span_cm.__exit__ = MagicMock(return_value=False)
+
+    v4_lf = MagicMock(spec=["start_as_current_observation"])
+    v4_lf.start_as_current_observation.return_value = span_cm
+
+    with (
+        patch(
+            "backend.app.routers.agentic_rag._lf_enabled",
+            return_value=True,
+        ),
+        patch("langfuse.get_client", return_value=v4_lf),
+    ):
+        result = await _process_query_traced(**_base_kwargs(mock_orchestrator))
+
+    mock_orchestrator.process_query.assert_awaited_once()
+    assert result is mock_orchestrator.process_query.return_value
+
+    # Span was actually started via the v4 API, named correctly, as a span.
+    _, call_kwargs = v4_lf.start_as_current_observation.call_args
+    assert call_kwargs["name"] == "agentic_rag.query"
+    assert call_kwargs["as_type"] == "span"
+
+    # Output was recorded on the span (PII-safe: route/model/evidence only).
+    span.update.assert_called_once()
+    output = span.update.call_args.kwargs["output"]
+    assert output["route_used"] == "flash"
+    assert output["model_used"] == "gemini-3.5-flash"
+
+
+@pytest.mark.asyncio
+async def test_query_path_noop_when_langfuse_disabled(mock_orchestrator) -> None:
+    with patch(
+        "backend.app.routers.agentic_rag._lf_enabled",
+        return_value=False,
+    ):
+        result = await _process_query_traced(**_base_kwargs(mock_orchestrator))
+
+    mock_orchestrator.process_query.assert_awaited_once()
+    assert result is mock_orchestrator.process_query.return_value


### PR DESCRIPTION
Durable fix for the 11-day WA bot outage (July 5→17): dependabot #2085 bumped langfuse 3→4; v4 renamed start_as_current_span → start_as_current_observation; agentic_rag.py:201 called the v3 name unguarded → every POST /api/agentic-rag/query 500'd (61 failed / 1 done in wa_outbox). Emergency kill-switch LANGFUSE_ENABLED=false is live; this PR makes the code safe under v4 so telemetry can be re-enabled.

- backend/core/observability.py::start_traced_span(): hasattr resolver (v4 preferred → v3 fallback → no-op span + single WARNING). Telemetry can never crash the query path.
- Applied at both call sites: agentic_rag._process_query_traced (the crash) + tone_council._maybe_council_span (same bug, accidentally fail-open before, now actually traces)
- Tests: v4-path/v3-fallback/missing/exploding fail-open + incident-shape regression (broken client → query still returns) — 59/59 green
- Same PR: /bot corner §1 LIVE STATE refreshed (F1 shipped state + incident + FAQ prune note)

Post-merge+deploy: operator may re-enable telemetry by unsetting LANGFUSE_ENABLED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)