### PR TITLE
fix(intel): periodic flush + never-skip image + force reconciliation (news cover pipeline necrosis, 3/3)

### DIFF
--- a/apps/backend-rag/backend/app/routers/intel.py
+++ b/apps/backend-rag/backend/app/routers/intel.py
@@ -559,35 +559,63 @@ async def enqueue_post_publish(
     request: Request,
     pool: Any = Depends(get_database_pool),
 ) -> dict:
-    """Internal: add a slug to the post-processing queue (translate + image + SEO)."""
+    """Internal: add a slug to the post-processing queue (translate + image + SEO).
+
+    `force: true` is the reconciliation path (2026-07-17): a batch flush lost
+    mid-run leaves `completed_steps.image=true` recorded even though the cover
+    never landed on GitHub — the default ON CONFLICT below only resets 'failed'
+    rows, so a 'done' item with a missing cover would never be re-run. `force`
+    unconditionally resets status/attempts/completed_steps regardless of the
+    row's current status.
+    """
     body = await request.json()
     slug = body.get("slug", "")
     category = body.get("category", "business")
     source = body.get("source", "intel")
     article_id = body.get("article_id")
     title = body.get("title")
+    force = bool(body.get("force", False))
     if not slug:
         raise HTTPException(status_code=400, detail="slug required")
     async with pool.acquire() as conn:
-        await conn.execute(
-            """
-            INSERT INTO post_publish_queue (slug, title, category, source, article_id)
-            VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (slug) DO UPDATE SET
-                status = CASE WHEN post_publish_queue.status = 'failed'
-                              THEN 'pending' ELSE post_publish_queue.status END,
-                attempts = CASE WHEN post_publish_queue.status = 'failed'
-                                THEN 0 ELSE post_publish_queue.attempts END,
-                error_message = NULL
-            """,
-            slug,
-            title,
-            category,
-            source,
-            article_id,
-        )
+        if force:
+            await conn.execute(
+                """
+                INSERT INTO post_publish_queue (slug, title, category, source, article_id)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (slug) DO UPDATE SET
+                    status = 'pending',
+                    attempts = 0,
+                    completed_steps = '{}'::jsonb,
+                    error_message = NULL
+                """,
+                slug,
+                title,
+                category,
+                source,
+                article_id,
+            )
+        else:
+            await conn.execute(
+                """
+                INSERT INTO post_publish_queue (slug, title, category, source, article_id)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (slug) DO UPDATE SET
+                    status = CASE WHEN post_publish_queue.status = 'failed'
+                                  THEN 'pending' ELSE post_publish_queue.status END,
+                    attempts = CASE WHEN post_publish_queue.status = 'failed'
+                                    THEN 0 ELSE post_publish_queue.attempts END,
+                    error_message = NULL
+                """,
+                slug,
+                title,
+                category,
+                source,
+                article_id,
+            )
     logger.info(
-        "📥 Post-publish queue: added", extra={"slug": slug, "category": category, "source": source}
+        "📥 Post-publish queue: added",
+        extra={"slug": slug, "category": category, "source": source, "force": force},
     )
     return {"ok": True, "slug": slug}
 

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_router.py
@@ -309,6 +309,78 @@ class TestPostPublishQueue:
         assert response.status_code == 400
 
 
+# ── enqueue_post_publish force reconciliation (2026-07-17) ─────────────────
+#
+# Regression coverage for the poller-necrosis reconciliation path: a batch
+# flush lost mid-run leaves completed_steps.image=true recorded even though
+# the cover never landed on GitHub — the default ON CONFLICT only resets
+# 'failed' rows, so a 'done' item with a missing cover would never re-run.
+# `force: true` must unconditionally reset status/attempts/completed_steps;
+# the default (force absent/false) must stay byte-identical to before.
+
+
+class TestEnqueuePostPublishForce:
+    def test_force_true_resets_unconditionally(self, mock_services):
+        from backend.app.routers import intel as intel_router_module
+
+        intel_router_module.settings.intel_scraper_api_key = "test-key"
+        test_client, conn = _client_with_auth(mock_services)
+
+        response = test_client.post(
+            "/api/intel/post-publish-queue",
+            json={"slug": "test-article", "category": "business", "force": True},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+        conn.execute.assert_awaited_once()
+        executed_sql = conn.execute.await_args_list[0].args[0]
+        assert "status = 'pending'" in executed_sql
+        assert "attempts = 0" in executed_sql
+        assert "completed_steps = '{}'::jsonb" in executed_sql
+        assert "error_message = NULL" in executed_sql
+        # Unconditional — no CASE WHEN status='failed' guard like the default path
+        assert "CASE WHEN" not in executed_sql
+
+    def test_force_absent_keeps_existing_conditional_sql(self, mock_services):
+        """Non-regression pin: default behavior (no `force`) is untouched."""
+        from backend.app.routers import intel as intel_router_module
+
+        intel_router_module.settings.intel_scraper_api_key = "test-key"
+        test_client, conn = _client_with_auth(mock_services)
+
+        response = test_client.post(
+            "/api/intel/post-publish-queue",
+            json={"slug": "test-article", "category": "business"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+        conn.execute.assert_awaited_once()
+        executed_sql = conn.execute.await_args_list[0].args[0]
+        assert "CASE WHEN post_publish_queue.status = 'failed'" in executed_sql
+        assert "THEN 'pending' ELSE post_publish_queue.status END" in executed_sql
+        assert "THEN 0 ELSE post_publish_queue.attempts END" in executed_sql
+        assert "completed_steps = '{}'::jsonb" not in executed_sql
+
+    def test_force_false_explicit_same_as_absent(self, mock_services):
+        from backend.app.routers import intel as intel_router_module
+
+        intel_router_module.settings.intel_scraper_api_key = "test-key"
+        test_client, conn = _client_with_auth(mock_services)
+
+        response = test_client.post(
+            "/api/intel/post-publish-queue",
+            json={"slug": "test-article", "force": False},
+        )
+
+        assert response.status_code == 200
+        executed_sql = conn.execute.await_args_list[0].args[0]
+        assert "CASE WHEN post_publish_queue.status = 'failed'" in executed_sql
+
+
 # ── get_pending_queue self-healing (stale-claim reaper + failed re-pick) ───
 #
 # Regression coverage for the queue-necrosis fix: `get_pending_queue` now runs

--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -884,21 +884,26 @@ def process_item(item: dict) -> tuple[bool, list[str]]:
                 rotate_hero(slug)
             else:
                 failed_steps.append("translate")
-        # Image
-        if not done.get("image"):
-            if run_image(slug, category, title=title):
-                mark_step_done(slug, "image")
-            else:
-                failed_steps.append("image")
+        # Image — NEVER skip based on completed_steps alone (2026-07-17 fix): the
+        # flag can lie if a prior run died mid-tick before flushing (see
+        # maybe_flush_all_batches). run_image()'s own idempotency check
+        # (_image_exists_on_github against main) makes calling it unconditionally
+        # a cheap no-op (~2 `gh api` calls) when the covers genuinely exist, and
+        # regenerates them when the flag lied.
+        if run_image(slug, category, title=title):
+            mark_step_done(slug, "image")
+        else:
+            failed_steps.append("image")
 
         return (len(failed_steps) == 0, failed_steps)
 
     elif source == "news":
-        if not done.get("image"):
-            if run_image(slug, category, title=title, article_id=article_id):
-                mark_step_done(slug, "image")
-            else:
-                failed_steps.append("image")
+        # Image — same "never skip on completed_steps alone" rule as the intel
+        # branch above (see comment there).
+        if run_image(slug, category, title=title, article_id=article_id):
+            mark_step_done(slug, "image")
+        else:
+            failed_steps.append("image")
         return (len(failed_steps) == 0, failed_steps)
 
     else:

--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -334,6 +334,38 @@ def flush_layout_batch() -> bool:
     return _flush_batch("layout", "bot/homepage-layout", "chore(homepage): hero rotation {date}")
 
 
+_FLUSH_THRESHOLD = 8
+
+
+def maybe_flush_all_batches(threshold: int = _FLUSH_THRESHOLD) -> bool:
+    """Mid-run flush: once staged GitHub writes reach `threshold`, flush image+seo+
+    layout batches immediately instead of waiting for the end-of-run sweep in main().
+
+    Crash-exposure fix (2026-07-17): a run that dies mid-tick (translate hang,
+    killer unknown, no traceback — live incident: the 16:56 run died ~22:20 with
+    ~2 dozen covers staged and lost) previously kept every staged write in RAM
+    for the FULL run — 5-10h with the current backlog. This shrinks the exposure
+    window to ~`threshold` items (~30-40min). Same flush functions + same
+    Telegram-alert-on-failure condition as the final sweep in main() — more
+    flushes per run (more bot PRs) is intentional, not a bug.
+
+    Returns True iff a flush was actually triggered this call.
+    """
+    if len(_PENDING_COMMITS) < threshold:
+        return False
+    log(f"🔁 Mid-run flush triggered ({len(_PENDING_COMMITS)} staged ≥ {threshold})")
+    img_ok = flush_image_batch()
+    seo_ok = flush_seo_batch()
+    layout_ok = flush_layout_batch()
+    if not img_ok or not seo_ok or not layout_ok:
+        send_telegram_alert(
+            "⚠️ *Post-publish poller*\n"
+            f"GitHub batch flush failed (image={img_ok}, seo={seo_ok}, "
+            f"layout={layout_ok}) — see log"
+        )
+    return True
+
+
 def _image_exists_on_github(gh_path: str) -> bool:
     try:
         check = subprocess.run(
@@ -918,7 +950,10 @@ def main():
             if "translate" not in failed_steps and item.get("source") == "intel":
                 translated_slugs.append(slug)
 
-    # Flush this tick's staged GitHub writes (images + SEO + homepage layout) —
+        # Periodic mid-run flush (crash exposure fix) — see maybe_flush_all_batches.
+        maybe_flush_all_batches()
+
+    # Final sweep: flush this tick's staged GitHub writes (images + SEO + homepage layout) —
     # ONE bot branch + auto-merged PR per kind, replacing the direct-to-main
     # PUTs branch protection has been rejecting since ~2026-05-22.
     img_flush_ok = flush_image_batch()

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -409,3 +409,90 @@ class TestMaybeFlushAllBatches:
 
         assert triggered is True
         mock_img.assert_called_once()
+
+
+# ── process_item: image step must never be skipped on completed_steps alone ─
+#
+# Regression coverage for the queue-necrosis bug: `completed_steps.image=true`
+# used to gate a hard skip of run_image() — if a run died before flushing, the
+# flag was already true in the DB (mark_step_done fires before the flush), so
+# the cover was lost FOREVER (next run trusts the lying flag). run_image()'s
+# own idempotency (_image_exists_on_github check against main) makes calling
+# it unconditionally safe: cheap no-op when covers are really there, regen
+# when the flag lied.
+
+
+class TestProcessItemNeverSkipsImageStep:
+    def test_intel_source_calls_run_image_even_when_completed_steps_true(self):
+        item = {
+            "slug": "test-slug",
+            "category": "business",
+            "source": "intel",
+            "title": "Test Title",
+            "completed_steps": {"seo": True, "translate": True, "image": True},
+        }
+        with (
+            patch.object(ppp, "run_seo", return_value=True) as mock_seo,
+            patch.object(ppp, "run_translate", return_value=True) as mock_translate,
+            patch.object(ppp, "run_image", return_value=True) as mock_image,
+            patch.object(ppp, "mark_step_done") as mock_mark,
+            patch.object(ppp, "rotate_hero") as mock_rotate,
+        ):
+            all_ok, failed_steps = ppp.process_item(item)
+
+        assert all_ok is True
+        assert failed_steps == []
+        mock_image.assert_called_once_with("test-slug", "business", title="Test Title")
+        mock_mark.assert_called_once_with("test-slug", "image")
+        # seo/translate are genuinely done — only the image gate is bypassed
+        mock_seo.assert_not_called()
+        mock_translate.assert_not_called()
+        mock_rotate.assert_not_called()
+
+    def test_news_source_calls_run_image_even_when_completed_steps_true(self):
+        item = {
+            "slug": "news-slug",
+            "category": "regulation",
+            "source": "news",
+            "article_id": "art-1",
+            "title": "News Title",
+            "completed_steps": {"image": True},
+        }
+        with (
+            patch.object(ppp, "run_image", return_value=True) as mock_image,
+            patch.object(ppp, "mark_step_done") as mock_mark,
+        ):
+            all_ok, failed_steps = ppp.process_item(item)
+
+        assert all_ok is True
+        assert failed_steps == []
+        mock_image.assert_called_once_with(
+            "news-slug", "regulation", title="News Title", article_id="art-1"
+        )
+        mock_mark.assert_called_once_with("news-slug", "image")
+
+    def test_regenerates_and_reports_failure_when_flag_lied_and_regen_fails(self):
+        """completed_steps.image=true but run_image() itself returns False
+        (cover genuinely missing + Codex unreachable) — must be reported as a
+        failed step (retried next tick), never silently trusted as done."""
+        item = {
+            "slug": "lost-slug",
+            "category": "business",
+            "source": "intel",
+            "title": "Lost",
+            "completed_steps": {"seo": True, "translate": True, "image": True},
+        }
+        with (
+            patch.object(ppp, "run_seo", return_value=True),
+            patch.object(ppp, "run_translate", return_value=True),
+            patch.object(ppp, "run_image", return_value=False) as mock_image,
+            patch.object(ppp, "mark_step_done") as mock_mark,
+            patch.object(ppp, "rotate_hero"),
+        ):
+            all_ok, failed_steps = ppp.process_item(item)
+
+        assert all_ok is False
+        assert failed_steps == ["image"]
+        mock_image.assert_called_once()
+        # mark_step_done must NOT be called for "image" when run_image fails
+        assert ("lost-slug", "image") not in [c.args for c in mock_mark.call_args_list]

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -332,3 +332,80 @@ class TestRotateHero:
 
         assert ok is True
         assert ppp._PENDING_COMMITS == []
+
+
+# ── maybe_flush_all_batches (periodic mid-run flush, crash-exposure fix) ───
+#
+# Regression coverage: the poller used to stage every GitHub write in RAM for
+# the FULL run (5-10h with the current backlog) and only flush once at the
+# very end — a run that dies mid-tick (no traceback, killer unknown) lost
+# every staged cover. maybe_flush_all_batches() shrinks that exposure window
+# by flushing image+seo+layout batches once staged writes reach a threshold.
+
+
+class TestMaybeFlushAllBatches:
+    def test_below_threshold_is_noop(self):
+        for i in range(ppp._FLUSH_THRESHOLD - 1):
+            ppp._stage_commit("image", f"apps/mouth/public/static/news/{i}.jpg", b"x", "m")
+
+        with (
+            patch.object(ppp, "flush_image_batch") as mock_img,
+            patch.object(ppp, "flush_seo_batch") as mock_seo,
+            patch.object(ppp, "flush_layout_batch") as mock_layout,
+            patch.object(ppp, "send_telegram_alert") as mock_alert,
+        ):
+            triggered = ppp.maybe_flush_all_batches()
+
+        assert triggered is False
+        mock_img.assert_not_called()
+        mock_seo.assert_not_called()
+        mock_layout.assert_not_called()
+        mock_alert.assert_not_called()
+
+    def test_at_threshold_flushes_all_three_batches(self):
+        for i in range(ppp._FLUSH_THRESHOLD):
+            ppp._stage_commit("image", f"apps/mouth/public/static/news/{i}.jpg", b"x", "m")
+
+        with (
+            patch.object(ppp, "flush_image_batch", return_value=True) as mock_img,
+            patch.object(ppp, "flush_seo_batch", return_value=True) as mock_seo,
+            patch.object(ppp, "flush_layout_batch", return_value=True) as mock_layout,
+            patch.object(ppp, "send_telegram_alert") as mock_alert,
+        ):
+            triggered = ppp.maybe_flush_all_batches()
+
+        assert triggered is True
+        mock_img.assert_called_once()
+        mock_seo.assert_called_once()
+        mock_layout.assert_called_once()
+        mock_alert.assert_not_called()
+
+    def test_flush_failure_sends_telegram_alert_same_condition_as_final_sweep(self):
+        for i in range(ppp._FLUSH_THRESHOLD):
+            ppp._stage_commit("image", f"apps/mouth/public/static/news/{i}.jpg", b"x", "m")
+
+        with (
+            patch.object(ppp, "flush_image_batch", return_value=False),
+            patch.object(ppp, "flush_seo_batch", return_value=True),
+            patch.object(ppp, "flush_layout_batch", return_value=True),
+            patch.object(ppp, "send_telegram_alert") as mock_alert,
+        ):
+            triggered = ppp.maybe_flush_all_batches()
+
+        assert triggered is True
+        mock_alert.assert_called_once()
+        assert "image=False" in mock_alert.call_args.args[0]
+
+    def test_custom_threshold_respected(self):
+        ppp._stage_commit("image", "apps/mouth/public/static/news/a.jpg", b"x", "m")
+        ppp._stage_commit("image", "apps/mouth/public/static/news/b.jpg", b"x", "m")
+
+        with (
+            patch.object(ppp, "flush_image_batch", return_value=True) as mock_img,
+            patch.object(ppp, "flush_seo_batch", return_value=True),
+            patch.object(ppp, "flush_layout_batch", return_value=True),
+        ):
+            triggered = ppp.maybe_flush_all_batches(threshold=2)
+
+        assert triggered is True
+        mock_img.assert_called_once()


### PR DESCRIPTION
## Summary

Third micro-PR of the "news cover pipeline necrosis" campaign (#2595 and #2599 already merged). Fixes the crash-exposure gap found live last night: the poller's run at 16:56 died ~22:20 (during a translate, no traceback, killer unknown) with ~2 dozen Codex-generated cover images staged in RAM and never flushed — and because `completed_steps.image=true` was already recorded in the DB for those items, the next run permanently skipped regenerating their covers.

- **fix(intel): flush staged github writes every 8 items (crash exposure)** — `apps/bali-intel-scraper/scripts/post_publish_poller.py`: new `maybe_flush_all_batches()` flushes image+seo+layout batches mid-run once `_PENDING_COMMITS` reaches 8, called after every processed item in `main()`'s loop. Same flush functions + same Telegram-alert-on-failure condition as the existing end-of-run sweep, which is left untouched as the final safety net. Shrinks RAM exposure from a full 5-10h run down to ~30-40min. More flushes per run (more bot PRs) is intentional.
- **fix(intel): never skip image step on completed_steps alone** — `process_item()` now always calls `run_image()` regardless of `completed_steps.image`. `run_image()`'s own idempotency check (`_image_exists_on_github` against `main`) makes this a cheap no-op (~2 `gh api` calls) when covers genuinely exist, and regenerates them when the flag lied (lost mid-run flush).
- **feat(intel): force re-enqueue resets completed_steps for reconciliation** — `apps/backend-rag/backend/app/routers/intel.py`, `enqueue_post_publish`: optional `"force": true` body field makes the `ON CONFLICT` unconditionally reset `status='pending', attempts=0, completed_steps='{}'::jsonb, error_message=NULL`, regardless of the row's current status. Default behavior (force absent/false) is unchanged — needed to reconcile the ~2 dozen items already `done` with missing covers from last night's incident.

## Test plan
- [x] `apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py` — 19 passed (12 baseline + 7 new: `TestMaybeFlushAllBatches` ×4, `TestProcessItemNeverSkipsImageStep` ×3)
- [x] `apps/backend-rag/backend/tests/unit/routers/test_intel_router.py` — 28 passed (25 baseline + 3 new: `TestEnqueuePostPublishForce`)
- [x] Pre-deploy smoke: `python -c "from backend.app.dependencies import get_current_user; print('OK')"` → OK
- [x] Targeted RAG pytest (`test_kg_langgraph.py` + `test_kg_subgraphs.py` + `test_confidence.py`) — 91 passed
- [x] `scripts/docs_sync.py --check` — DOCSYNC OK (no drift) at every commit
- [x] Full pre-push suite (pre-push hook, 17662 collected) — 17497 passed, 165 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)