### PR TITLE
feat(kbli): TRACK-P provenance layer — verification states, per-fact sources, divergence with citations

### DIFF
--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -13,11 +13,15 @@ import {
   getKbliDatasetLastModified,
 } from "@/lib/kbli-data.server";
 import { formatTimeframe } from "@/lib/kbli-derive";
+import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 import { KBLIBreadcrumb } from "@/components/kbli/KBLIBreadcrumb";
 import { PMABadge } from "@/components/kbli/PMABadge";
 import { RiskBadge } from "@/components/kbli/RiskBadge";
 import { TransitionBadge } from "@/components/kbli/TransitionBadge";
 import { BaliStatusBadge } from "@/components/kbli/BaliStatusBadge";
+import { ProvenanceBadge } from "@/components/kbli/ProvenanceBadge";
+import { KBLIDivergence } from "@/components/kbli/KBLIDivergence";
+import { KBLIProvenancePanel } from "@/components/kbli/KBLIProvenancePanel";
 import { cn } from "@/lib/utils";
 import { KBLICard } from "@/components/kbli/KBLICard";
 import {
@@ -336,7 +340,10 @@ export default async function KBLICodePage({
                   baliBlocked={!!kbli.baliL4?.blocked}
                 />
                 {kbli.licensing[0] && (
-                  <RiskBadge category={kbli.licensing[0].riskCategory} />
+                  <RiskBadge
+                    category={kbli.licensing[0].riskCategory}
+                    verificationPending={isLicensingVerificationPending(kbli)}
+                  />
                 )}
                 <TransitionBadge status={kbli.transition.mappingStatus} />
                 {kbli.baliL4 && (
@@ -347,6 +354,9 @@ export default async function KBLICodePage({
                     needsReview={kbli.baliL4.needsReview}
                     pmaStatus={kbli.pma.status}
                   />
+                )}
+                {kbli.provenance && (
+                  <ProvenanceBadge state={kbli.provenance.state} />
                 )}
               </div>
             </div>
@@ -860,6 +870,16 @@ export default async function KBLICodePage({
                         </div>
                       </div>
                     </div>
+                    {/* One grid-level qualifier instead of per-cell noise:
+                        risk, license AND processing above all come from the
+                        same unverified rows (Codex gate round 5). */}
+                    {isLicensingVerificationPending(kbli) && (
+                      <p className="mt-2 text-[11px] text-[var(--foreground-muted)]">
+                        ⏳ The licensing facts above (risk, license, processing)
+                        await KBLI-2025 crosswalk verification — see Sources
+                        &amp; Verification below.
+                      </p>
+                    )}
                   </section>
                 </>
               )}
@@ -961,6 +981,21 @@ export default async function KBLICodePage({
                 </a>
               )}
             </div>
+          )}
+
+          {/* REGULATORY DIVERGENCE — only on collision-cured codes: the
+              documented 2020-vs-2025 divergence, with citations (TRACK-P) */}
+          {kbli.provenance && (
+            <KBLIDivergence code={kbli.code} provenance={kbli.provenance} />
+          )}
+
+          {/* SOURCES & VERIFICATION — per-fact provenance with vintage,
+              rendered on gold AND non-gold layouts (TRACK-P) */}
+          {kbli.provenance && (
+            <KBLIProvenancePanel
+              kbli={kbli}
+              lastModified={getKbliDatasetLastModified()}
+            />
           )}
 
           {/* COMMON QUESTIONS — visible counterpart of the FAQPage JSON-LD,

--- a/apps/mouth/src/components/kbli/KBLICard.tsx
+++ b/apps/mouth/src/components/kbli/KBLICard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { PMABadge } from "./PMABadge";
 import { RiskBadge } from "./RiskBadge";
+import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 import { TransitionBadge } from "./TransitionBadge";
 import { BaliStatusBadge } from "./BaliStatusBadge";
 import type { KBLICode } from "@/lib/kbli-types";
@@ -93,7 +94,11 @@ export function KBLICard({ code, showTransition = false }: KBLICardProps) {
           size="sm"
         />
         {code.licensing[0] && (
-          <RiskBadge riskCategory={code.licensing[0].riskCategory} size="sm" />
+          <RiskBadge
+            riskCategory={code.licensing[0].riskCategory}
+            size="sm"
+            verificationPending={isLicensingVerificationPending(code)}
+          />
         )}
         {showTransition && code.transition.mappingStatus && (
           <TransitionBadge status={code.transition.mappingStatus} />

--- a/apps/mouth/src/components/kbli/KBLIDivergence.tsx
+++ b/apps/mouth/src/components/kbli/KBLIDivergence.tsx
@@ -1,0 +1,173 @@
+import type { KBLIProvenance } from "@/lib/kbli-types";
+import { RiskBadge } from "./RiskBadge";
+
+// =============================================================================
+// TRACK-P — "Regulatory Divergence" section
+// Product form of the internal discrepancy findings (kbli-navigator corner §5:
+// "we show the divergence with citations"). Renders ONLY on codes a collision
+// cure has touched: the honest-gap `_data_note` (which carries the verbatim,
+// image-verified locators) plus the detached PP28 rows preserved under
+// `per_skala_disputed_*`, framed as the KBLI-2020 meaning of the digits — not
+// as licensing for this activity.
+// =============================================================================
+
+interface KBLIDivergenceProps {
+  code: string;
+  provenance: KBLIProvenance;
+}
+
+/** `perizinan` is a string on legacy rows, an array elsewhere. */
+function licenseLabel(perizinan: string | string[] | undefined): string {
+  if (!perizinan) return "—";
+  if (Array.isArray(perizinan))
+    return perizinan.length > 0 ? perizinan.join(", ") : "—";
+  return perizinan;
+}
+
+export function KBLIDivergence({ code, provenance }: KBLIDivergenceProps) {
+  const { dataNote, disputed } = provenance;
+  if (!dataNote && !disputed) return null;
+
+  // Citations are derived from structured markers only — the cure class is
+  // NOT uniform (digit collisions, wrong-pointer transplants, unlocatable
+  // sources), so no chip is asserted unless its marker backs it. The exact
+  // locators (lampiran, page, render id, sha) live verbatim in the note.
+  const citations: string[] = [
+    "BPS Peraturan 7/2025 (KBLI 2025 classification)",
+  ];
+  if (disputed?.key.includes("pp28")) {
+    citations.push("PP 28/2025 (risk-based licensing annexes)");
+  }
+  if (provenance.licensing.noOssScope) {
+    citations.push(
+      "OSS RBA ruang-lingkup — no KBLI-2025 scope retrievable via the OSS API (404)",
+    );
+  }
+
+  return (
+    <section className="mt-12">
+      <div className="mb-5 flex items-center gap-3">
+        <div
+          className="h-8 w-1 rounded-full"
+          style={{
+            background:
+              "linear-gradient(to bottom, var(--kbli-amber), var(--kbli-accent))",
+          }}
+        />
+        <div>
+          <h2 className="text-sm font-bold uppercase tracking-[0.12em] text-[var(--kbli-accent)]">
+            Regulatory Divergence
+          </h2>
+          <p className="text-xs text-[var(--foreground-muted)]">
+            The licensing previously shown for {code} was removed because its
+            source could not be verified as applying to this activity. Here is
+            what the sources actually say — with citations.
+          </p>
+        </div>
+      </div>
+
+      {/* The documented note — written by the cure compiler, citations verbatim */}
+      {dataNote && (
+        <div
+          className="rounded-xl border px-5 py-4"
+          style={{
+            background: "rgba(232, 168, 73, 0.05)",
+            borderColor: "rgba(232, 168, 73, 0.25)",
+          }}
+        >
+          <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--kbli-amber)]">
+            Correction note — verbatim, with source locators
+          </p>
+          <p className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
+            {dataNote}
+          </p>
+        </div>
+      )}
+
+      {/* The detached PP28 rows — audit trail, explicitly NOT this activity */}
+      {disputed && disputed.rows.length > 0 && (
+        <details className="group mt-4 overflow-hidden rounded-xl border border-[var(--border)]">
+          <summary
+            className="flex cursor-pointer items-center gap-3 px-5 py-3.5 text-xs font-bold uppercase tracking-[0.12em] text-[var(--foreground-muted)] transition-colors hover:text-[var(--foreground-secondary)] [&::-webkit-details-marker]:hidden list-none"
+            style={{ background: "var(--kbli-bg-elevated)" }}
+          >
+            <svg
+              className="h-4 w-4 shrink-0 transition-transform duration-200 group-open:rotate-90"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <path d="M6 4l4 4-4 4" />
+            </svg>
+            <span>
+              The detached licensing rows (source unverified for this activity)
+            </span>
+            <span className="ml-auto rounded-full border border-[var(--border)] px-2 py-0.5 text-[10px] font-medium">
+              {disputed.rows.length}{" "}
+              {disputed.rows.length === 1 ? "row" : "rows"}
+            </span>
+          </summary>
+          <div
+            className="space-y-3 p-5"
+            style={{ background: "var(--kbli-bg-surface)" }}
+          >
+            <p className="text-xs leading-relaxed text-[var(--foreground-muted)]">
+              These rows were previously shown on this page and have been
+              detached — the correction note above documents, with source
+              locators, why their source could not be kept for the activity this
+              page describes. They are preserved here as the audit trail of the
+              divergence.
+            </p>
+            {disputed.rows.map((row, i) => (
+              <div
+                key={i}
+                className="rounded-lg border border-[var(--border)] px-4 py-3"
+                style={{ background: "var(--kbli-bg-elevated)" }}
+              >
+                <div className="flex flex-wrap items-center gap-2.5">
+                  {Array.isArray(row.skala_usaha) &&
+                    row.skala_usaha.length > 0 && (
+                      <span className="text-xs font-semibold text-[var(--foreground)]">
+                        {row.skala_usaha.join(", ")}
+                      </span>
+                    )}
+                  {row.kategori_risiko && (
+                    <RiskBadge category={row.kategori_risiko} size="sm" />
+                  )}
+                  <span className="text-xs text-[var(--foreground-muted)]">
+                    {licenseLabel(row.perizinan)}
+                  </span>
+                  {row.kewenangan && (
+                    <span className="ml-auto text-[11px] text-[var(--foreground-muted)]">
+                      Authority: {row.kewenangan}
+                    </span>
+                  )}
+                </div>
+                {row.scope_uraian && (
+                  <p className="mt-1.5 text-[11px] italic text-[var(--foreground-muted)]">
+                    Source-row scope: {row.scope_uraian}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {/* Citations */}
+      <div className="mt-4 flex flex-wrap gap-2">
+        {citations.map((c) => (
+          <span
+            key={c}
+            className="rounded-full border border-[var(--kbli-border)] px-3 py-1 text-[11px] text-[var(--foreground-muted)]"
+            style={{ background: "var(--kbli-bg-elevated)" }}
+          >
+            {c}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/mouth/src/components/kbli/KBLIProvenancePanel.tsx
+++ b/apps/mouth/src/components/kbli/KBLIProvenancePanel.tsx
@@ -1,0 +1,226 @@
+import type { KBLICode, KBLIProvenance } from "@/lib/kbli-types";
+
+// =============================================================================
+// TRACK-P — "Sources & Verification" panel
+// One row per fact layer rendered on the page: what the source is, which KBLI
+// vintage it speaks, and whether it is verified / pending / detached. The
+// honesty contract (kbli-navigator corner §0): a declared gap is acceptable, a
+// plausible-but-wrong assertion is not — so no row ever claims more than its
+// structured marker supports.
+// =============================================================================
+
+interface KBLIProvenancePanelProps {
+  kbli: KBLICode;
+  /** Dataset sidecar date (kbli-dataset-version.json) — NOT file mtime */
+  lastModified: Date;
+}
+
+/** Human-readable labels for the raw assembly markers (fallback: raw value). */
+const ASSEMBLY_LABELS: Record<string, string> = {
+  "BPS_7_2025 + PP28_2025": "BPS Peraturan 7/2025 + PP 28/2025",
+  PP28_2025_ONLY: "PP 28/2025 (not in the BPS 7/2025 index)",
+  BPS_7_2025_ONLY: "BPS Peraturan 7/2025 (no PP 28/2025 rows)",
+};
+
+type Verdict = "verified" | "pending" | "gap";
+
+const VERDICT_STYLE: Record<Verdict, { label: string; color: string }> = {
+  verified: { label: "Verified", color: "var(--kbli-pma-open)" },
+  pending: { label: "Audit pending", color: "var(--kbli-pma-restricted)" },
+  gap: { label: "Declared gap", color: "var(--foreground-muted)" },
+};
+
+interface SourceRow {
+  layer: string;
+  source: string;
+  vintage: string;
+  verdict: Verdict;
+  detail?: string;
+  locator?: string | null;
+}
+
+function buildRows(kbli: KBLICode, prov: KBLIProvenance): SourceRow[] {
+  const rows: SourceRow[] = [];
+
+  rows.push({
+    layer: "Activity definition",
+    source:
+      ASSEMBLY_LABELS[prov.definition.assembly ?? ""] ??
+      prov.definition.assembly ??
+      "—",
+    vintage: "KBLI 2025",
+    verdict: "verified",
+    detail: "Title and scope as defined by the KBLI-2025 classification.",
+    locator: prov.definition.locator,
+  });
+
+  if (prov.licensing.status === "oss_native") {
+    rows.push({
+      layer: "Risk & licensing",
+      source: "OSS RBA risk scope (ruang lingkup)",
+      vintage: "KBLI 2025",
+      verdict: "verified",
+      detail:
+        "Risk category and licensing rows are KBLI-2025-native from the OSS Risk-Based Approach catalog.",
+      locator: prov.licensing.locator,
+    });
+  } else if (prov.licensing.status === "pending_crosswalk") {
+    // Two honest readings of the no-scope set, discriminated by whether rows
+    // are actually served (114 carry PP28-via-2020 rows; 101 have none —
+    // special/sectoral regime). Wording per corner rule F12: a 404 attests
+    // retrievability via the OSS API, never regulatory absence.
+    const hasRows = kbli.licensing.length > 0;
+    rows.push({
+      layer: "Risk & licensing",
+      source: hasRows
+        ? "PP 28/2025 rows via KBLI-2020 numbering"
+        : "No OSS-RBA rows retrievable — special / sectoral regime",
+      vintage: hasRows ? "KBLI 2020" : "—",
+      verdict: hasRows ? "pending" : "gap",
+      detail: hasRows
+        ? "No KBLI-2025 risk scope was retrievable from the OSS API for this code (ruang-lingkup 404). The rows shown were recorded under the KBLI-2020 numbering and await per-code crosswalk adjudication."
+        : "No KBLI-2025 risk scope was retrievable from the OSS API for this code (ruang-lingkup 404), and no licensing rows are served on this page. Activities in this group are typically licensed under a special or sectoral regime — on the crosswalk watchlist: if OSS publishes a scope, the code is re-adjudicated.",
+    });
+  } else if (prov.licensing.status === "unverified_source") {
+    rows.push({
+      layer: "Risk & licensing",
+      source: "No recognised source marker — audit required",
+      vintage: "—",
+      verdict: "pending",
+      detail:
+        "This code's licensing rows carry no recognised provenance marker (absent or unknown), so their source and vintage cannot be stated. Treat them as unaudited until the crosswalk program classifies them.",
+    });
+  } else {
+    // Neutral by design: the causes behind a detach VARY per code (digit
+    // collision, wrong-pointer transplant, unlocatable source) — the
+    // correction note in the Divergence section carries the specifics, this
+    // row never flattens them into one cause (Codex gate F2).
+    rows.push({
+      layer: "Risk & licensing",
+      source: "Detached — source could not be verified",
+      vintage: "—",
+      verdict: "gap",
+      detail:
+        "The previously-served rows were removed because their source could not be verified as applying to this activity. See Regulatory Divergence above for the documented correction note.",
+    });
+  }
+
+  rows.push({
+    layer: "Foreign ownership (PMA)",
+    source: prov.pma.source ?? "Perpres 10/2021, 49/2021",
+    vintage: "KBLI 2020",
+    verdict: "pending",
+    detail:
+      "The investment-list annexes predate KBLI 2025; the per-code crosswalk audit of this layer is in progress. The value shown is the annex text, disclosed with its vintage.",
+  });
+
+  if (kbli.baliL4) {
+    const m = kbli.baliL4.moratorium;
+    const isNonClassifiable = kbli.baliL4.status === "NON_CLASSIFICABILE";
+    rows.push({
+      layer: "Bali status",
+      source: m?.rule
+        ? `${m.rule}${m.effective ? ` (effective ${m.effective})` : ""}`
+        : "Bali moratorium overlay (Gubernur letter B.27.000/642)",
+      vintage: "2026 overlay",
+      verdict: isNonClassifiable ? "gap" : "pending",
+      detail: isNonClassifiable
+        ? "Not classifiable until the true risk tier is re-derived — the tier this verdict depended on was detached."
+        : `Conservative posture derived from the risk tier · confidence ${kbli.baliL4.confidence}.`,
+    });
+  }
+
+  return rows;
+}
+
+export function KBLIProvenancePanel({
+  kbli,
+  lastModified,
+}: KBLIProvenancePanelProps) {
+  const prov = kbli.provenance;
+  if (!prov) return null;
+
+  const rows = buildRows(kbli, prov);
+  const dateStr = lastModified.toISOString().slice(0, 10);
+
+  return (
+    <section className="mt-12">
+      <div className="mb-5 flex items-center gap-3">
+        <div
+          className="h-8 w-1 rounded-full"
+          style={{
+            background:
+              "linear-gradient(to bottom, var(--kbli-accent2), var(--kbli-accent))",
+          }}
+        />
+        <div>
+          <h2 className="text-sm font-bold uppercase tracking-[0.12em] text-[var(--kbli-accent)]">
+            Sources &amp; Verification
+          </h2>
+          <p className="text-xs text-[var(--foreground-muted)]">
+            Each data layer below traces to a government source with its KBLI
+            vintage — or is declared as a gap. Nothing in these layers is
+            silently filled in.
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="overflow-hidden rounded-xl border border-[var(--border)]"
+        style={{ background: "var(--kbli-bg-elevated)" }}
+      >
+        {rows.map((row) => {
+          const v = VERDICT_STYLE[row.verdict];
+          return (
+            <div
+              key={row.layer}
+              className="flex flex-col gap-1.5 border-b border-[var(--border)] px-5 py-4 last:border-b-0 sm:flex-row sm:items-start sm:gap-4"
+            >
+              <div className="sm:w-44 sm:shrink-0">
+                <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--foreground-muted)]">
+                  {row.layer}
+                </span>
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-semibold text-[var(--foreground)]">
+                    {row.source}
+                  </span>
+                  <span
+                    className="rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+                    style={{
+                      color: v.color,
+                      borderColor: `color-mix(in srgb, ${v.color} 30%, transparent)`,
+                      background: `color-mix(in srgb, ${v.color} 8%, transparent)`,
+                    }}
+                  >
+                    {v.label}
+                  </span>
+                  <span className="rounded-full border border-[var(--kbli-border)] px-2 py-0.5 text-[10px] font-medium text-[var(--foreground-muted)]">
+                    {row.vintage}
+                  </span>
+                </div>
+                {row.detail && (
+                  <p className="mt-1 text-xs leading-relaxed text-[var(--foreground-secondary)]">
+                    {row.detail}
+                  </p>
+                )}
+                {row.locator && (
+                  <p className="mt-1 font-mono text-[10px] text-[var(--foreground-muted)]">
+                    locator: {row.locator}
+                  </p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="mt-3 text-[11px] text-[var(--foreground-muted)]">
+        Dataset last updated {dateStr} · KBLI 2020 and KBLI 2025 reuse code
+        numbers for different activities — cross-vintage rows are labeled, never
+        merged silently.
+      </p>
+    </section>
+  );
+}

--- a/apps/mouth/src/components/kbli/KBLIStructuredData.tsx
+++ b/apps/mouth/src/components/kbli/KBLIStructuredData.tsx
@@ -1,5 +1,6 @@
 import type { KBLICode } from "@/lib/kbli-types";
 import { buildKbliFaq } from "@/lib/kbli-faq";
+import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 
 export function KBLICodeJsonLd({
   code,
@@ -26,22 +27,30 @@ export function KBLICodeJsonLd({
     : baliNonClassifiable
       ? " nationally — Bali PMA applicability not yet classifiable, verify with the team"
       : "";
-  const pmaLabel =
+  // PMA source attribution with vintage (FATAL-2 axis): cite the in-force
+  // annexes and their pending KBLI-2025 crosswalk instead of bare fact.
+  const pmaLabel = `${
     code.pma.status === "open"
       ? `100% foreign ownership allowed (TERBUKA)${baliNat}`
       : code.pma.status === "restricted"
         ? `Restricted to max ${code.pma.maxForeign}% foreign ownership (TERBATAS)`
-        : "Closed to foreign investment (TERTUTUP)";
+        : "Closed to foreign investment (TERTUTUP)"
+  } per Perpres 10/2021 as amended (crosswalk to KBLI 2025 pending)`;
 
   const riskLevel: string = code.licensing[0]?.riskCategory ?? "Unknown";
   const licenseType = code.licensing[0]?.licenseType ?? "NIB";
+  // Rows not verified against a KBLI-2025-native OSS source must not reach
+  // Google/AI answers as unqualified fact (Codex gate round 4).
+  const pendingSuffix = isLicensingVerificationPending(code)
+    ? " (verification pending)"
+    : "";
 
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Article",
     name: `KBLI ${code.code} — ${code.titleId}`,
     headline: `KBLI ${code.code}: ${code.titleId} — Indonesian Business Code Guide`,
-    description: `${code.description.slice(0, 160)}. ${pmaLabel}. Risk: ${riskLevel}.`,
+    description: `${code.description.slice(0, 160)}. ${pmaLabel}. Risk: ${riskLevel}${pendingSuffix}.`,
     inLanguage: "en",
     datePublished: "2025-06-18",
     ...(dateModified
@@ -86,7 +95,7 @@ export function KBLICodeJsonLd({
     about: {
       "@type": "GovernmentService",
       name: `KBLI ${code.code} — ${code.titleId}`,
-      description: `${code.titleEn}. ${pmaLabel}. License: ${licenseType}. Risk level: ${riskLevel}.`,
+      description: `${code.titleEn}. ${pmaLabel}. License: ${licenseType}${pendingSuffix}. Risk level: ${riskLevel}${pendingSuffix}.`,
       serviceType: "Business Classification",
       jurisdiction: {
         "@type": "AdministrativeArea",

--- a/apps/mouth/src/components/kbli/LicensingSection.tsx
+++ b/apps/mouth/src/components/kbli/LicensingSection.tsx
@@ -10,6 +10,7 @@ import type {
   KBLIPmaInfo,
 } from "@/lib/kbli-types";
 import { formatTimeframe } from "@/lib/kbli-derive";
+import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 import dynamic from "next/dynamic";
 
 const ReactMarkdown = dynamic(() => import("react-markdown"), { ssr: false });
@@ -178,19 +179,38 @@ function KeyFacts({
   licensing,
   pma,
   baliBlocked = false,
+  notClassifiable = false,
+  verificationPending = false,
 }: {
   licensing: KBLILicenseByScale[];
   pma: KBLIPmaInfo;
   baliBlocked?: boolean;
+  /** provenance.state === "not_classifiable" — collision-cured, rows detached */
+  notClassifiable?: boolean;
+  /** rows served but not verified against a KBLI-2025-native OSS source */
+  verificationPending?: boolean;
 }) {
   const primary = licensing[0];
   if (!primary) {
-    // No OSS-RBA scale rows: special/sectoral licensing regime (government,
-    // finance/OJK-BI, education, health, culture). Show an honest panel instead
-    // of silently rendering nothing (101 codes fall here).
+    // No OSS-RBA scale rows. Two honest readings, discriminated by the
+    // structured provenance state (TRACK-P), never by prose:
+    // - not_classifiable → a collision cure DETACHED the rows; licensing is
+    //   genuinely not yet defined for this KBLI-2025 activity.
+    // - otherwise → special/sectoral licensing regime (government, finance/
+    //   OJK-BI, education, health, culture; 101 codes fall here).
     const specialFacts: { label: string; value: string; accent?: string }[] = [
-      { label: "Licensing Route", value: "Special / sectoral regime" },
-      { label: "OSS-RBA Rows", value: "None published" },
+      {
+        label: "Licensing Route",
+        value: notClassifiable
+          ? "No verified basis — divergence documented"
+          : "Special / sectoral regime",
+      },
+      {
+        label: "OSS-RBA Rows",
+        value: notClassifiable
+          ? "Detached (unverified source)"
+          : "None retrievable (404)",
+      },
       {
         label: "Foreign Ownership",
         value:
@@ -206,7 +226,12 @@ function KeyFacts({
             ? "var(--kbli-pma-open)"
             : "var(--kbli-pma-closed)",
       },
-      { label: "Authority", value: "Sector regulator — verify case-by-case" },
+      {
+        label: "Authority",
+        value: notClassifiable
+          ? "Not verified — see divergence note"
+          : "Sector regulator — verify case-by-case",
+      },
     ];
     return (
       <div
@@ -282,27 +307,39 @@ function KeyFacts({
   ];
 
   return (
-    <div
-      className="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-[var(--border)] sm:grid-cols-3 lg:grid-cols-5"
-      style={{ background: "var(--kbli-border)" }}
-    >
-      {facts.map((f) => (
-        <div
-          key={f.label}
-          className="flex flex-col gap-1.5 px-4 py-3.5"
-          style={{ background: "var(--kbli-bg-elevated)" }}
-        >
-          <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--foreground-muted)]">
-            {f.label}
-          </span>
-          <span
-            className="text-sm font-semibold"
-            style={{ color: f.accent ?? "var(--foreground)" }}
+    <div>
+      <div
+        className="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-[var(--border)] sm:grid-cols-3 lg:grid-cols-5"
+        style={{ background: "var(--kbli-border)" }}
+      >
+        {facts.map((f) => (
+          <div
+            key={f.label}
+            className="flex flex-col gap-1.5 px-4 py-3.5"
+            style={{ background: "var(--kbli-bg-elevated)" }}
           >
-            {f.value}
-          </span>
-        </div>
-      ))}
+            <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--foreground-muted)]">
+              {f.label}
+            </span>
+            <span
+              className="text-sm font-semibold"
+              style={{ color: f.accent ?? "var(--foreground)" }}
+            >
+              {f.value}
+            </span>
+          </div>
+        ))}
+      </div>
+      {/* One grid-level qualifier instead of per-cell noise: risk, license
+          AND processing above all come from the same unverified rows
+          (Codex gate round 5). */}
+      {verificationPending && (
+        <p className="mt-2 text-[11px] text-[var(--foreground-muted)]">
+          ⏳ The licensing facts above (risk, license, processing) await
+          KBLI-2025 crosswalk verification — see Sources &amp; Verification
+          below.
+        </p>
+      )}
     </div>
   );
 }
@@ -937,6 +974,8 @@ export function LicensingSection({ kbli, gold }: LicensingSectionProps) {
         licensing={kbli.licensing}
         pma={kbli.pma}
         baliBlocked={baliBlocked}
+        notClassifiable={kbli.provenance?.state === "not_classifiable"}
+        verificationPending={isLicensingVerificationPending(kbli)}
       />
 
       {/* ── PP28 RAW DATA (collapsible) ── */}
@@ -966,6 +1005,14 @@ export function LicensingSection({ kbli, gold }: LicensingSectionProps) {
             className="space-y-4 p-5"
             style={{ background: "var(--kbli-bg-surface)" }}
           >
+            {/* The section title names the SOURCE; this line states the
+                verification status of everything below it (Codex round 6b). */}
+            {isLicensingVerificationPending(kbli) && (
+              <p className="text-[11px] text-[var(--foreground-muted)]">
+                ⏳ All licensing values below await KBLI-2025 crosswalk
+                verification — see Sources &amp; Verification.
+              </p>
+            )}
             {/* Tier tabs */}
             {kbli.licensing.length > 1 && (
               <div className="flex items-center gap-4">
@@ -985,7 +1032,11 @@ export function LicensingSection({ kbli, gold }: LicensingSectionProps) {
               <span className="text-sm font-semibold text-[var(--foreground)]">
                 {currentTier.scales.join(", ")}
               </span>
-              <RiskBadge category={currentTier.riskCategory} size="sm" />
+              <RiskBadge
+                category={currentTier.riskCategory}
+                size="sm"
+                verificationPending={isLicensingVerificationPending(kbli)}
+              />
               <span className="text-xs text-[var(--foreground-muted)]">
                 {currentTier.licenseType}
               </span>

--- a/apps/mouth/src/components/kbli/ProvenanceBadge.tsx
+++ b/apps/mouth/src/components/kbli/ProvenanceBadge.tsx
@@ -1,0 +1,62 @@
+import { cn } from "@/lib/utils";
+import type { KBLIVerificationState } from "@/lib/kbli-types";
+
+// TRACK-P provenance badge — the code-level verification state of the risk &
+// licensing data. Scoped claim by design: "verified" speaks ONLY for the
+// OSS-RBA risk-row axis (the PMA layer carries its own vintage disclosure in
+// the Sources & Verification panel), so the badge never overstates.
+interface ProvenanceBadgeProps {
+  state: KBLIVerificationState;
+  size?: "sm" | "md";
+}
+
+const config: Record<
+  KBLIVerificationState,
+  { label: string; icon: string; tone: "ok" | "warn" | "gap"; title: string }
+> = {
+  verified: {
+    label: "OSS-verified · KBLI 2025",
+    icon: "✓",
+    tone: "ok",
+    title:
+      "Risk & licensing rows come from the OSS-RBA KBLI-2025 catalog (vintage-native, no cross-vintage fill).",
+  },
+  pending: {
+    label: "Crosswalk audit pending",
+    icon: "⏳",
+    tone: "warn",
+    title:
+      "This code's risk & licensing rows are not verified against a KBLI-2025-native OSS source; per-code crosswalk adjudication is pending. See Sources & Verification below for the specifics.",
+  },
+  not_classifiable: {
+    label: "Not classifiable — divergence documented",
+    icon: "❓",
+    tone: "gap",
+    title:
+      "The licensing previously shown was detached because its source could not be verified as applying to this activity (e.g. a KBLI 2020-vs-2025 code-number collision). See the Regulatory Divergence section for the documented sources.",
+  },
+};
+
+const toneClass = {
+  ok: "bg-[var(--kbli-pma-open-bg)] text-[var(--kbli-pma-open)] border-[var(--kbli-pma-open)]/20",
+  warn: "bg-[var(--kbli-pma-restricted-bg)] text-[var(--kbli-pma-restricted)] border-[var(--kbli-pma-restricted)]/20",
+  gap: "bg-[var(--kbli-bg-elevated)] text-[var(--foreground-secondary)] border-[var(--kbli-border)]",
+};
+
+export function ProvenanceBadge({ state, size = "md" }: ProvenanceBadgeProps) {
+  const c = config[state];
+  if (!c) return null;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border font-medium",
+        size === "sm" ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm",
+        toneClass[c.tone],
+      )}
+      title={c.title}
+    >
+      <span aria-hidden="true">{c.icon}</span>
+      <span>{c.label}</span>
+    </span>
+  );
+}

--- a/apps/mouth/src/components/kbli/RiskBadge.test.tsx
+++ b/apps/mouth/src/components/kbli/RiskBadge.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { RiskBadge } from "./RiskBadge";
+
+describe("RiskBadge — verificationPending qualifier (TRACK-P)", () => {
+  it("marks the badge when the rows behind the tier are unverified", () => {
+    render(<RiskBadge category="Menengah Rendah" verificationPending />);
+    expect(screen.getByText("Medium-Low Risk")).toBeDefined();
+    expect(screen.getByText("· pending verification")).toBeDefined();
+  });
+
+  it("innocence: a verified tier renders the plain badge, no qualifier", () => {
+    render(<RiskBadge category="Rendah" />);
+    expect(screen.getByText("Low Risk")).toBeDefined();
+    expect(screen.queryByText("· pending verification")).toBeNull();
+  });
+});

--- a/apps/mouth/src/components/kbli/RiskBadge.tsx
+++ b/apps/mouth/src/components/kbli/RiskBadge.tsx
@@ -4,6 +4,12 @@ interface RiskBadgeProps {
   category?: string;
   riskCategory?: string;
   size?: "sm" | "md";
+  /**
+   * The rows behind this risk value are not verified against a
+   * KBLI-2025-native OSS source (crosswalk pending / unreadable marker) —
+   * the badge must not state the tier as unqualified fact (TRACK-P).
+   */
+  verificationPending?: boolean;
 }
 
 function parseRisk(category: string): { label: string; color: string } {
@@ -35,6 +41,7 @@ export function RiskBadge({
   category,
   riskCategory,
   size = "md",
+  verificationPending = false,
 }: RiskBadgeProps) {
   const { label, color } = parseRisk(category ?? riskCategory ?? "");
   return (
@@ -48,12 +55,20 @@ export function RiskBadge({
         borderColor: `${color}33`,
         backgroundColor: `${color}15`,
       }}
+      title={
+        verificationPending
+          ? "This risk tier is not verified against a KBLI-2025-native OSS source; crosswalk adjudication is pending."
+          : undefined
+      }
     >
       <span
         className="inline-block w-1.5 h-1.5 rounded-full"
         style={{ backgroundColor: color }}
       />
       {label} Risk
+      {verificationPending && (
+        <span className="opacity-70">· pending verification</span>
+      )}
     </span>
   );
 }

--- a/apps/mouth/src/lib/kbli-data.server.ts
+++ b/apps/mouth/src/lib/kbli-data.server.ts
@@ -7,6 +7,7 @@ import type {
   KBLIGoldContent,
 } from "./kbli-types";
 import { resolveLicenseType } from "./kbli-derive";
+import { deriveProvenance } from "./kbli-provenance";
 
 // Section names mapping
 const SECTION_NAMES_EN: Record<string, string> = {
@@ -320,6 +321,7 @@ function transformCode(
             : undefined,
         }
       : undefined,
+    provenance: deriveProvenance(raw),
     tier: goldEntry ? "gold" : "bronze",
     keywords: [],
   };

--- a/apps/mouth/src/lib/kbli-data.ts
+++ b/apps/mouth/src/lib/kbli-data.ts
@@ -22,6 +22,7 @@ import { ENGLISH_TITLES_GENERATED } from "./kbli-english-generated";
 import { resolveLicenseType } from "./kbli-derive";
 import { GOLD_CODES } from "./kbli-gold-codes";
 import { getSectionVisual } from "./kbli-cover-design";
+import { deriveProvenance } from "./kbli-provenance";
 
 // =============================================================================
 // Constants: Section metadata
@@ -464,6 +465,7 @@ function transformRecord(raw: KBLIRawCode): KBLICode {
             : undefined,
         }
       : undefined,
+    provenance: deriveProvenance(raw),
   };
 }
 

--- a/apps/mouth/src/lib/kbli-faq.test.ts
+++ b/apps/mouth/src/lib/kbli-faq.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildKbliFaq } from "./kbli-faq";
-import { getCode } from "./kbli-data";
+import { getAllCodes, getCode } from "./kbli-data";
 import type { KBLICode } from "./kbli-types";
 
 describe("buildKbliFaq", () => {
@@ -75,6 +75,38 @@ describe("buildKbliFaq", () => {
     expect(pmaAnswer).not.toContain("capped at 0%");
   });
 
+  it("declares the licensing gap on every cure-detached subtype — never 'special regime', never asserting regulatory absence", () => {
+    // Real cured pilot codes across cause subtypes: 49213 (authority
+    // collision), 60312 (unlocatable source), 64310 (wrong-pointer
+    // transplant). The class answer must be the weakest common truthful
+    // claim: about OUR verification, not about the regulation (Codex gate F1).
+    for (const c of ["49213", "60312", "64310"]) {
+      const cured = getCode(c);
+      expect(cured, `code ${c}`).toBeDefined();
+      expect(cured!.provenance?.state, `code ${c}`).toBe("not_classifiable");
+      const licenseAnswer = buildKbliFaq(cured as KBLICode)[1].answer;
+      expect(licenseAnswer).toContain("could not be verified");
+      expect(licenseAnswer).toContain("Regulatory Divergence");
+      expect(licenseAnswer).not.toContain("special or sectoral regime");
+      // Never assert absence of a regulation — only our verification state.
+      expect(licenseAnswer).not.toContain("not yet defined");
+      expect(licenseAnswer).not.toContain("does not apply");
+    }
+  });
+
+  it("innocence: a legit no-OSS-rows code keeps the special-regime answer", () => {
+    // A code with zero licensing rows but NO collision cure (the ~100-code
+    // special/sectoral group) must keep the special-regime answer.
+    const special = getAllCodes().find(
+      (c) =>
+        c.licensing.length === 0 && c.provenance?.state !== "not_classifiable",
+    );
+    expect(special).toBeDefined();
+    const licenseAnswer = buildKbliFaq(special as KBLICode)[1].answer;
+    expect(licenseAnswer).toContain("special or sectoral regime");
+    expect(licenseAnswer).not.toContain("Regulatory Divergence");
+  });
+
   it("returns 3-4 entries and every answer names the code", () => {
     const code = getCode("56101") as KBLICode;
     const faq = buildKbliFaq(code);
@@ -83,5 +115,28 @@ describe("buildKbliFaq", () => {
     for (const entry of faq) {
       expect(entry.answer).toContain(code.code);
     }
+  });
+
+  it("qualifies the license answer on pending-with-rows codes; verified codes stay unqualified", () => {
+    // 114 real codes serve rows whose provenance awaits crosswalk
+    // adjudication — the FAQ (visible + JSON-LD) must qualify them.
+    const pending = getAllCodes().find(
+      (c) =>
+        c.licensing.length > 0 &&
+        c.provenance?.licensing.status === "pending_crosswalk",
+    );
+    expect(pending).toBeDefined();
+    const pendingAnswer = buildKbliFaq(pending as KBLICode)[1].answer;
+    expect(pendingAnswer).toContain("crosswalk adjudication is pending");
+
+    // Innocence: an OSS-verified code keeps the plain factual answer.
+    const verified = getAllCodes().find(
+      (c) =>
+        c.licensing.length > 0 &&
+        c.provenance?.licensing.status === "oss_native",
+    );
+    expect(verified).toBeDefined();
+    const verifiedAnswer = buildKbliFaq(verified as KBLICode)[1].answer;
+    expect(verifiedAnswer).not.toContain("crosswalk adjudication is pending");
   });
 });

--- a/apps/mouth/src/lib/kbli-faq.ts
+++ b/apps/mouth/src/lib/kbli-faq.ts
@@ -1,4 +1,5 @@
 import type { KBLICode } from "@/lib/kbli-types";
+import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 
 export interface KbliFaqEntry {
   question: string;
@@ -48,13 +49,37 @@ export function buildKbliFaq(code: KBLICode): KbliFaqEntry[] {
           : `Partially. KBLI ${code.code} (${code.titleId}) is TERBATAS — foreign ownership is ${code.pma.capVerified ? "capped" : "indicatively capped (unverified)"} at ${code.pma.maxForeign}%.${code.pma.condition ? ` Condition: ${code.pma.condition}` : ""} An Indonesian partner holds the remaining shares.`
         : `No. KBLI ${code.code} (${code.titleId}) is TERTUTUP — closed to foreign investment. Reserved for Indonesian nationals only.`;
 
+  // PMA source attribution with vintage (FATAL-2 axis): the investment-list
+  // annexes are the in-force regulation but predate KBLI 2025 — disclose the
+  // source and the pending per-code crosswalk instead of asserting bare fact.
+  const pmaSourceNote =
+    " (Source: Perpres 10/2021 as amended by Perpres 49/2021 — the investment-list annexes predate KBLI 2025; per-code crosswalk audit in progress.)";
+
+  // Rows whose provenance is not KBLI-2025-native (crosswalk pending /
+  // unreadable marker) must never be stated as unqualified fact — visible FAQ
+  // and FAQPage JSON-LD both come from this builder (Codex gate round 4).
+  const licenseQualifier = isLicensingVerificationPending(code)
+    ? " Note: the source of these rows has not been verified against a KBLI-2025-native OSS scope; per-code crosswalk adjudication is pending — verify before relying on them (see Sources & Verification on this page)."
+    : "";
+
   const licenseAnswer =
     code.licensing.length > 0
-      ? `KBLI ${code.code} has a ${code.licensing[0].riskCategory} risk classification. Required license: ${code.licensing[0].licenseType ?? "NIB (Nomor Induk Berusaha)"}. ${code.licensing[0].timeframe ? `Processing time: ${code.licensing[0].timeframe}.` : "Processed through OSS (Online Single Submission)."}`
-      : // No OSS-RBA scale rows → special/sectoral regime (government, finance/OJK,
-        // education, health, culture …). Claiming "requires a NIB via OSS" here
-        // would be wrong for most of these activities.
-        `KBLI ${code.code} sits outside the ordinary OSS-RBA risk-based licensing flow: OSS publishes no business-scale licensing rows for it. Activities in this group are typically licensed under a special or sectoral regime (e.g. government affairs, financial services under OJK/BI, education or health authorities) — verify the applicable regulator case-by-case before relying on an NIB alone.`;
+      ? `KBLI ${code.code} has a ${code.licensing[0].riskCategory} risk classification. Required license: ${code.licensing[0].licenseType ?? "NIB (Nomor Induk Berusaha)"}. ${code.licensing[0].timeframe ? `Processing time: ${code.licensing[0].timeframe}.` : "Processed through OSS (Online Single Submission)."}${licenseQualifier}`
+      : // No OSS-RBA scale rows. Discriminated by the structured provenance
+        // state (TRACK-P), never by prose:
+        code.provenance?.state === "not_classifiable"
+        ? // Cure-detached. The marker only attests that the old block was
+          // quarantined — the CAUSE varies per code (digit collision,
+          // wrong-pointer transplant, unlocatable source; the correction note
+          // carries the specifics). So this class string is the WEAKEST common
+          // truthful claim: it speaks about our verification, never asserts
+          // regulatory absence (Codex gate F1).
+          `We cannot yet show a verified licensing basis for KBLI ${code.code}: the licensing previously associated with this code was removed because its source could not be verified as applying to this activity. See the Regulatory Divergence section on this page for the documented sources, and verify the current OSS treatment before relying on any licensing assumption.`
+        : // Special/sectoral regime (government, finance/OJK, education, health,
+          // culture …). Claiming "requires a NIB via OSS" here would be wrong
+          // for most of these activities. Wording per F12: a 404 attests
+          // retrievability via the OSS API, never publication or absence.
+          `KBLI ${code.code} sits outside the ordinary OSS-RBA risk-based licensing flow: no business-scale licensing rows for it are retrievable from OSS. Activities in this group are typically licensed under a special or sectoral regime (e.g. government affairs, financial services under OJK/BI, education or health authorities) — verify the applicable regulator case-by-case before relying on an NIB alone.`;
 
   // Only show an English gloss when a real English title exists — otherwise the
   // copy degenerates to `"X" (X)` with the Indonesian title repeated twice.
@@ -66,7 +91,7 @@ export function buildKbliFaq(code: KBLICode): KbliFaqEntry[] {
   const entries: KbliFaqEntry[] = [
     {
       question: `Can foreigners operate a ${code.titleEn.toLowerCase()} business in Indonesia?`,
-      answer: pmaAnswer,
+      answer: `${pmaAnswer}${pmaSourceNote}`,
     },
     {
       question: `What license is required for KBLI ${code.code}?`,

--- a/apps/mouth/src/lib/kbli-provenance.test.ts
+++ b/apps/mouth/src/lib/kbli-provenance.test.ts
@@ -1,0 +1,291 @@
+// =============================================================================
+// TRACK-P — provenance derivation tests
+// Guilt + innocence corpus (cicatrix #3: a guard is never shipped without both)
+// plus a real-dataset partition invariant so the state machine can't silently
+// drift when the canonical is recompiled.
+// =============================================================================
+
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { deriveProvenance, getDisputedLicensing } from "./kbli-provenance";
+import type { KBLIRawCode, KBLIRawDataFile } from "./kbli-types";
+
+function makeRaw(overrides: Partial<KBLIRawCode> = {}): KBLIRawCode {
+  return {
+    kode_kbli_2025: "99999",
+    judul: "Test Activity",
+    uraian: "Test description",
+    per_skala: [],
+    sektor_id: "T",
+    status_mapping: "MATCH_LANGSUNG",
+    pp28_sources: ["99999"],
+    pma_status: "TERBUKA",
+    pma_max_asing: 100,
+    pma_kondisi: null,
+    pma_prioritas: false,
+    pma_nota: null,
+    pma_source: "Perpres 10/2021, 49/2021",
+    _source: "BPS_7_2025 + PP28_2025",
+    ...overrides,
+  } as KBLIRawCode;
+}
+
+describe("deriveProvenance — state machine (guilt corpus)", () => {
+  it("OSS-native L2 source → verified", () => {
+    const prov = deriveProvenance(
+      makeRaw({
+        _l1_source: "OSS_RBA_2025",
+        _l2_source: "OSS_RBA_resiko_2025",
+      }),
+    );
+    expect(prov.state).toBe("verified");
+    expect(prov.licensing.status).toBe("oss_native");
+    expect(prov.licensing.vintage).toBe("2025");
+    expect(prov.licensing.locator).toBe("OSS_RBA_resiko_2025");
+  });
+
+  it("no_oss_risk WITH served rows → pending crosswalk, vintage 2020", () => {
+    const prov = deriveProvenance(
+      makeRaw({
+        _l2_status: "no_oss_risk",
+        _l2_source: null,
+        per_skala: [
+          {
+            skala_usaha: ["Mikro"],
+            kategori_risiko: "Rendah",
+            perizinan: [],
+            persyaratan: [],
+            jangka_waktu: "",
+            kewajiban: [],
+            pb_umku: [],
+            parameter: "",
+            kewenangan: "",
+            sanksi_peringatan: "",
+            sanksi_denda: "",
+            sanksi_penghentian: "",
+            sanksi_pencabutan: "",
+            fiktif_positif: false,
+          },
+        ],
+      }),
+    );
+    expect(prov.state).toBe("pending");
+    expect(prov.licensing.status).toBe("pending_crosswalk");
+    expect(prov.licensing.vintage).toBe("2020");
+  });
+
+  it("no_oss_risk with ZERO rows (special/sectoral regime) → pending, no row vintage", () => {
+    const prov = deriveProvenance(
+      makeRaw({ _l2_status: "no_oss_risk", _l2_source: null, per_skala: [] }),
+    );
+    expect(prov.state).toBe("pending");
+    expect(prov.licensing.status).toBe("pending_crosswalk");
+    // There is no served row to vintage — claiming "2020 rows" here would
+    // assert rows that do not exist (Codex gate finding, 2026-07-17).
+    expect(prov.licensing.vintage).toBeNull();
+  });
+
+  it("stale OSS-native L2 marker on a cured code loses to the disputed key (49213-class)", () => {
+    // 49213/20111 carry _l2_source=OSS_RBA_resiko_2025 from before the cure
+    // while their rows are detached — disputed MUST win the precedence or
+    // they would render as verified with zero rows.
+    const prov = deriveProvenance(
+      makeRaw({
+        _l2_source: "OSS_RBA_resiko_2025",
+        _data_note: "collision",
+        per_skala_disputed_pp28_collision: {
+          per_skala: [{ kategori_risiko: "Menengah Tinggi" }],
+        },
+      }),
+    );
+    expect(prov.state).toBe("not_classifiable");
+    expect(prov.licensing.status).toBe("detached");
+  });
+
+  it("disputed block (bare-array shape) → not_classifiable + rows surfaced", () => {
+    const prov = deriveProvenance(
+      makeRaw({
+        _l2_status: "no_oss_risk",
+        _data_note: "collision documented",
+        per_skala_disputed_pp28_mice: [
+          { skala_usaha: ["Mikro"], kategori_risiko: "Menengah Rendah" },
+        ],
+      }),
+    );
+    expect(prov.state).toBe("not_classifiable");
+    expect(prov.licensing.status).toBe("detached");
+    expect(prov.dataNote).toBe("collision documented");
+    expect(prov.disputed?.key).toBe("per_skala_disputed_pp28_mice");
+    expect(prov.disputed?.rows).toHaveLength(1);
+  });
+
+  it("disputed block ({per_skala: rows} shape) → rows normalized", () => {
+    const disputed = getDisputedLicensing(
+      makeRaw({
+        per_skala_disputed_pp28_collision: {
+          per_skala: [
+            { kategori_risiko: "Tinggi" },
+            { kategori_risiko: "Rendah" },
+          ],
+          per_skala_legacy: [],
+        },
+      }),
+    );
+    expect(disputed?.rows).toHaveLength(2);
+    expect(disputed?.rows[0].kategori_risiko).toBe("Tinggi");
+  });
+
+  it("no markers at all → conservative pending, never verified", () => {
+    const prov = deriveProvenance(makeRaw());
+    expect(prov.state).toBe("pending");
+  });
+
+  it("unknown _l2_source value → pending with unverified_source, never verified, no invented vintage", () => {
+    // Exact-marker discipline (Codex gates F4+F6): a future or mislabeled
+    // source marker must degrade to pending WITHOUT claiming OSS verification,
+    // a PP28-via-2020 provenance, or any vintage for the rows.
+    const prov = deriveProvenance(
+      makeRaw({ _l2_source: "SOME_FUTURE_SOURCE_2027" }),
+    );
+    expect(prov.state).toBe("pending");
+    expect(prov.licensing.status).toBe("unverified_source");
+    expect(prov.licensing.vintage).toBeNull();
+    expect(prov.licensing.noOssScope).toBe(false);
+  });
+
+  it("unknown _l2_source ALONGSIDE no_oss_risk with served rows → still unverified_source, no 2020 vintage", () => {
+    // Contradictory provenance (unknown marker + no_oss_risk + rows): the
+    // unknown marker wins — claiming "PP28 via KBLI-2020" would invent a
+    // vintage for rows whose declared source we cannot read (F6 round-3).
+    const prov = deriveProvenance(
+      makeRaw({
+        _l2_source: "SOME_FUTURE_SOURCE_2027",
+        _l2_status: "no_oss_risk",
+        per_skala: [
+          {
+            skala_usaha: ["Mikro"],
+            kategori_risiko: "Rendah",
+            perizinan: [],
+            persyaratan: [],
+            jangka_waktu: "",
+            kewajiban: [],
+            pb_umku: [],
+            parameter: "",
+            kewenangan: "",
+            sanksi_peringatan: "",
+            sanksi_denda: "",
+            sanksi_penghentian: "",
+            sanksi_pencabutan: "",
+            fiktif_positif: false,
+          },
+        ],
+      }),
+    );
+    expect(prov.state).toBe("pending");
+    expect(prov.licensing.status).toBe("unverified_source");
+    expect(prov.licensing.vintage).toBeNull();
+    // The 404 fact itself is still carried — it is a retrievability fact,
+    // independent of the unreadable source marker.
+    expect(prov.licensing.noOssScope).toBe(true);
+  });
+});
+
+describe("deriveProvenance — innocence corpus", () => {
+  it("collision-flavored PROSE on a verified record does not flip the state", () => {
+    // The derivation must read structured markers only — a record whose text
+    // mentions "collision"/"MICE"/"detached" is still verified when its L2
+    // marker says OSS-native (cicatrix #3: no substring guards on prose).
+    const prov = deriveProvenance(
+      makeRaw({
+        judul: "Penyewaan Venue MICE",
+        uraian:
+          "This activity text mentions code-number collision and detached rows and MICE venues.",
+        _l2_source: "OSS_RBA_resiko_2025",
+      }),
+    );
+    expect(prov.state).toBe("verified");
+    expect(prov.disputed).toBeNull();
+  });
+
+  it("a legitimate no-scope neighbor (no disputed key) stays pending, not not_classifiable", () => {
+    const prov = deriveProvenance(
+      makeRaw({ _l2_status: "no_oss_risk", _data_note: undefined }),
+    );
+    expect(prov.state).toBe("pending");
+  });
+
+  it("PMA layer is a vintage disclosure on every state, source passed through", () => {
+    const prov = deriveProvenance(
+      makeRaw({ _l2_source: "OSS_RBA_resiko_2025" }),
+    );
+    expect(prov.pma.vintage).toBe("2020");
+    expect(prov.pma.source).toBe("Perpres 10/2021, 49/2021");
+  });
+});
+
+describe("deriveProvenance — real dataset partition invariants", () => {
+  const DATA_PATH = path.join(
+    process.cwd(),
+    "data",
+    "KBLI_2025_FINAL_CLEAN.json",
+  );
+  const parsed = JSON.parse(
+    fs.readFileSync(DATA_PATH, "utf-8"),
+  ) as KBLIRawDataFile;
+
+  it("every record lands in exactly one state; disputed ⇒ not_classifiable ∧ note", () => {
+    let verified = 0;
+    let pending = 0;
+    let notClassifiable = 0;
+    for (const raw of parsed.data) {
+      const prov = deriveProvenance(raw);
+      if (prov.state === "verified") verified++;
+      else if (prov.state === "pending") pending++;
+      else notClassifiable++;
+      const hasDisputedKey = Object.keys(raw).some((k) =>
+        k.startsWith("per_skala_disputed_"),
+      );
+      if (hasDisputedKey) {
+        expect(prov.state).toBe("not_classifiable");
+        // A detach without its honest-gap note would be a silent gap — the
+        // cure compiler always writes both.
+        expect(prov.dataNote).toBeTruthy();
+        expect(prov.disputed?.rows.length).toBeGreaterThan(0);
+      }
+    }
+    expect(verified + pending + notClassifiable).toBe(parsed.data.length);
+    // The cured-pilot set can only grow (batch A remainder) — never shrink
+    // below the 8 proven collision cures, and verified codes must dominate.
+    expect(notClassifiable).toBeGreaterThanOrEqual(8);
+    expect(verified).toBeGreaterThan(1000);
+  });
+
+  it("ALL 8 cured pilot codes derive not_classifiable (every cause subtype)", () => {
+    // The full pilot set — digit collisions (68112, 51103, 51203, 50115),
+    // authority-level collision (49213), many-to-one merge (20111),
+    // wrong-pointer transplant (64310), unlocatable source (60312). The
+    // class handling must hold for every subtype, not just collisions.
+    const byCode = new Map(parsed.data.map((r) => [r.kode_kbli_2025, r]));
+    for (const code of [
+      "68112",
+      "49213",
+      "51103",
+      "51203",
+      "20111",
+      "50115",
+      "60312",
+      "64310",
+    ]) {
+      const raw = byCode.get(code);
+      expect(raw, `code ${code} missing from dataset`).toBeTruthy();
+      const prov = deriveProvenance(raw!);
+      expect(prov.state, `code ${code}`).toBe("not_classifiable");
+      expect(prov.dataNote, `code ${code} note`).toBeTruthy();
+      expect(
+        prov.disputed?.rows.length,
+        `code ${code} disputed rows`,
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/mouth/src/lib/kbli-provenance.ts
+++ b/apps/mouth/src/lib/kbli-provenance.ts
@@ -1,0 +1,161 @@
+// =============================================================================
+// KBLI Provenance Derivation (TRACK-P)
+// Derives the per-code verification state + per-fact provenance from the
+// structured GARUDA-FILIERA markers on the raw record.
+//
+// HARD RULES (kbli-navigator corner §4):
+// - Decisions come ONLY from structured fields (`_l2_source`, `_l2_status`,
+//   `per_skala_disputed_*` keys) — NEVER from substring matching on prose
+//   (cicatrix #3: guard-over-match).
+// - This module never authors licensing values: it only restates locators and
+//   vintages the dataset already carries, or declares the gap.
+// =============================================================================
+
+import type {
+  KBLICode,
+  KBLIDisputedLicensing,
+  KBLIDisputedScaleRow,
+  KBLIProvenance,
+  KBLIRawCode,
+} from "./kbli-types";
+
+const DISPUTED_KEY_PREFIX = "per_skala_disputed_";
+
+/** OSS-native L2 marker value (KBLI-2025-vintage risk rows). */
+const OSS_NATIVE_L2 = "OSS_RBA_resiko_2025";
+
+/** `_l2_status` marker for the no-scope set (OSS ruang-lingkup 404). */
+const NO_OSS_RISK = "no_oss_risk";
+
+/**
+ * Normalize a `per_skala_disputed_*` value to a row array. Two live shapes:
+ * a bare row array (single-scope cures), or `{ per_skala: rows, ... }`
+ * (multi-scope collision cures, e.g. 49213/20111).
+ */
+function normalizeDisputedRows(value: unknown): KBLIDisputedScaleRow[] {
+  if (Array.isArray(value)) return value as KBLIDisputedScaleRow[];
+  if (value && typeof value === "object") {
+    const inner = (value as { per_skala?: unknown }).per_skala;
+    if (Array.isArray(inner)) return inner as KBLIDisputedScaleRow[];
+  }
+  return [];
+}
+
+/** Extract the (single) disputed licensing block, if the record carries one. */
+export function getDisputedLicensing(
+  raw: KBLIRawCode,
+): KBLIDisputedLicensing | null {
+  for (const key of Object.keys(raw)) {
+    if (!key.startsWith(DISPUTED_KEY_PREFIX)) continue;
+    const rows = normalizeDisputedRows(
+      raw[key as `per_skala_disputed_${string}`],
+    );
+    return { key, rows };
+  }
+  return null;
+}
+
+/**
+ * True when the code SERVES licensing rows whose provenance is not verified
+ * against a KBLI-2025-native OSS source (pending crosswalk, or unreadable
+ * marker). Every surface that states risk/license/processing as fact for such
+ * a code must qualify the claim (Codex gate round 4) — FAQ, JSON-LD, key-fact
+ * grids all key on this single helper so they can't drift apart.
+ */
+export function isLicensingVerificationPending(code: KBLICode): boolean {
+  const status = code.provenance?.licensing.status;
+  return (
+    code.licensing.length > 0 &&
+    (status === "pending_crosswalk" || status === "unverified_source")
+  );
+}
+
+/**
+ * Derive the full provenance object for a raw KBLI record.
+ *
+ * State partition (exhaustive over the 1,559 catalog):
+ * - `not_classifiable` — a `per_skala_disputed_*` block exists: a collision
+ *   cure detached the rows; the divergence is documented in `_data_note`.
+ * - `pending`  — `_l2_status === "no_oss_risk"`: OSS published no scope; any
+ *   rows served were carried from KBLI-2020-vintage sources (PP 28/2025 via
+ *   the 2020 numbering) and await crosswalk adjudication.
+ * - `verified` — `_l2_source` EXACTLY equals the OSS-native marker
+ *   (`OSS_RBA_resiko_2025`).
+ * - fallback `pending` — a record with none of the markers, or an unknown
+ *   `_l2_source` value, is treated as unaudited, never silently promoted to
+ *   verified.
+ */
+export function deriveProvenance(raw: KBLIRawCode): KBLIProvenance {
+  const disputed = getDisputedLicensing(raw);
+  const noOssRisk = raw._l2_status === NO_OSS_RISK;
+  // EXACT marker match — a future/unknown `_l2_source` value must degrade to
+  // pending, never silently promote to "OSS-verified" (Codex gate F4).
+  const ossNative = raw._l2_source === OSS_NATIVE_L2;
+  // An unknown-but-present marker means the provenance claim itself is
+  // unverifiable — it beats every other licensing reading except a detach
+  // (Codex gate F6: even alongside no_oss_risk, don't claim PP28/2020).
+  const unknownL2 = raw._l2_source != null && !ossNative;
+
+  const state = disputed
+    ? "not_classifiable"
+    : noOssRisk
+      ? "pending"
+      : ossNative
+        ? "verified"
+        : "pending";
+
+  return {
+    state,
+    definition: {
+      locator: raw._l1_source ?? null,
+      assembly: raw._source ?? null,
+    },
+    licensing:
+      state === "not_classifiable"
+        ? {
+            status: "detached",
+            locator: null,
+            vintage: null,
+            noOssScope: noOssRisk,
+          }
+        : state === "pending"
+          ? unknownL2 || !noOssRisk
+            ? {
+                // No recognised L2 marker (absent, or present-but-unknown —
+                // even alongside no_oss_risk): we cannot state the rows'
+                // source or vintage; asserting "PP28 via KBLI-2020" would
+                // invent provenance (Codex gate F6). Declare the audit need.
+                status: "unverified_source",
+                locator: null,
+                vintage: null,
+                noOssScope: noOssRisk,
+              }
+            : {
+                status: "pending_crosswalk",
+                locator: null,
+                // The no-scope set splits in two (live census 2026-07-17:
+                // 114 vs 101): codes WITH rows carry PP28 rows recorded under
+                // the KBLI-2020 numbering (vintage 2020); codes with ZERO rows
+                // are special/sectoral-regime — there is no row to vintage.
+                vintage: (raw.per_skala ?? []).length > 0 ? "2020" : null,
+                noOssScope: true,
+              }
+          : {
+              status: "oss_native",
+              locator: OSS_NATIVE_L2,
+              vintage: "2025",
+              noOssScope: noOssRisk,
+            },
+    pma: {
+      source: raw.pma_source ?? null,
+      // Perpres 10/2021 + 49/2021 annexes are KBLI-2020-vintage across the
+      // whole catalog (FATAL-2) — declared as pending until the per-code
+      // crosswalk audit lands. This is a source-vintage disclosure, not a
+      // claim that the value is wrong.
+      vintage: "2020",
+      status: "pending_crosswalk",
+    },
+    dataNote: raw._data_note ?? null,
+    disputed,
+  };
+}

--- a/apps/mouth/src/lib/kbli-types.ts
+++ b/apps/mouth/src/lib/kbli-types.ts
@@ -48,6 +48,22 @@ export interface KBLIScaleEntry {
   fiktif_positif: boolean;
 }
 
+/**
+ * A licensing row preserved under a `per_skala_disputed_*` key after a
+ * GARUDA-FILIERA detach (code-number collision cure). Shape is a superset of
+ * KBLIScaleEntry: collision blocks carry extra locator fields (scope_uraian,
+ * scope_index) and may omit sanction columns.
+ */
+export interface KBLIDisputedScaleRow {
+  skala_usaha?: KBLIBusinessScale[];
+  kategori_risiko?: string;
+  perizinan?: string | string[];
+  kewenangan?: string;
+  jangka_waktu?: string;
+  scope_uraian?: string;
+  [key: string]: unknown;
+}
+
 /** Raw KBLI code record — exact match to JSON structure */
 export interface KBLIRawCode {
   kode_kbli_2025: string;
@@ -68,6 +84,23 @@ export interface KBLIRawCode {
   pma_cap_verified?: boolean; // false => TERBATAS cap % not source-backed, render "≈N% unverified"
   pma_route_to?: string; // sibling private code when a govt code is closed to PMA
   _source: string;
+  // ── Per-record provenance (GARUDA-FILIERA layer markers) ──────────────────
+  /** L1 (existence/title/uraian) source — OSS RBA KBLI-2025 catalog snapshot */
+  _l1_source?: string;
+  /** L2 (risk rows) source. `OSS_RBA_resiko_2025` = KBLI-2025-native. Absent/null = rows NOT from OSS. */
+  _l2_source?: string | null;
+  /** `no_oss_risk` = OSS ruang-lingkup returned 404 for this code (no-scope set, crosswalk audit pending) */
+  _l2_status?: string;
+  /** Honest-gap note written by the cure compiler — carries verbatim citations/locators */
+  _data_note?: string;
+  /**
+   * per_skala rows detached by a collision cure, preserved for the audit trail.
+   * Two live shapes: a bare row array, or `{ per_skala: rows, ... }`.
+   */
+  [key: `per_skala_disputed_${string}`]:
+    | KBLIDisputedScaleRow[]
+    | { per_skala?: KBLIDisputedScaleRow[]; [key: string]: unknown }
+    | undefined;
   // Optional fields (present on some records)
   aggregation_note?: string;
   mapping_note?: string;
@@ -151,6 +184,69 @@ export interface KBLIPmaInfo {
   routeTo: string | null; // sibling private code when a govt code is closed to PMA (86101→86103)
 }
 
+// -----------------------------------------------------------------------------
+// Provenance (TRACK-P product layer — every rendered fact is either
+// government-sourced with a locator + vintage, or an honest declared gap)
+// -----------------------------------------------------------------------------
+
+/**
+ * Code-level verification state, derived ONLY from structured markers
+ * (never from prose matching — cicatrix #3):
+ * - `verified`         → risk rows are OSS-RBA KBLI-2025 native (`_l2_source`)
+ * - `pending`          → no OSS scope (`_l2_status: no_oss_risk`); rows carried
+ *                        from KBLI-2020-vintage sources, crosswalk audit pending
+ * - `not_classifiable` → collision cured: rows detached (`per_skala_disputed_*`),
+ *                        divergence documented with citations
+ */
+export type KBLIVerificationState = "verified" | "pending" | "not_classifiable";
+
+/** Licensing-axis provenance status */
+export type KBLILicensingProvenanceStatus =
+  | "oss_native"
+  | "pending_crosswalk"
+  /** `_l2_source` present but not the recognized OSS-native marker — audit required */
+  | "unverified_source"
+  | "detached";
+
+/** A licensing block detached by a collision cure, normalized for display */
+export interface KBLIDisputedLicensing {
+  /** raw key it was preserved under (e.g. per_skala_disputed_pp28_collision) */
+  key: string;
+  rows: KBLIDisputedScaleRow[];
+}
+
+/** Per-fact provenance for a KBLI code — the data behind the provenance UI */
+export interface KBLIProvenance {
+  state: KBLIVerificationState;
+  /** Activity definition (title + uraian) — L1 layer */
+  definition: {
+    /** raw locator, e.g. "OSS_RBA_2025_id_version_fff4053d" */
+    locator: string | null;
+    /** dataset assembly source, e.g. "BPS_7_2025 + PP28_2025" */
+    assembly: string | null;
+  };
+  /** Risk & licensing rows — L2 layer */
+  licensing: {
+    status: KBLILicensingProvenanceStatus;
+    /** raw locator when OSS-native (e.g. "OSS_RBA_resiko_2025"), else null */
+    locator: string | null;
+    /** KBLI vintage of the rows as served; null when detached or no rows */
+    vintage: "2025" | "2020" | null;
+    /** true when `_l2_status === "no_oss_risk"` (OSS ruang-lingkup 404) */
+    noOssScope: boolean;
+  };
+  /** Foreign-ownership layer — Perpres 10/2021 + 49/2021 (KBLI-2020 vintage) */
+  pma: {
+    source: string | null;
+    vintage: "2020";
+    status: "pending_crosswalk";
+  };
+  /** Honest-gap note with verbatim citations (only on cured codes) */
+  dataNote: string | null;
+  /** Detached rows preserved for the audit trail (only on cured codes) */
+  disputed: KBLIDisputedLicensing | null;
+}
+
 /** Processed licensing entry for a specific business scale */
 export interface KBLILicenseByScale {
   scales: KBLIBusinessScale[];
@@ -211,6 +307,8 @@ export interface KBLICode {
   };
   /** L4 — Bali sovereign-local status (moratorium 2026-05-13). National PMA openness != Bali registrability. */
   baliL4?: KBLIBaliL4;
+  /** Per-fact provenance + verification state (TRACK-P). Derived from structured markers only. */
+  provenance?: KBLIProvenance;
 }
 
 /**


### PR DESCRIPTION
## TRACK-P — /kbli product redesign (provenance)

Product form of the GARUDA-FILIERA honesty contract on every `/kbli/<code>` page (**apps/mouth only — data-plane untouched**): every rendered licensing fact now carries its source + KBLI vintage, or a declared gap.

### What ships
- **`kbli-provenance.ts`** — pure state derivation from structured markers ONLY (`_l2_source` exact-match, `_l2_status`, `per_skala_disputed_*` keys; never prose matching, cicatrix #3): **verified** (1,336 OSS-native) / **pending** (215: 114 PP28-via-2020 rows + 101 zero-row special-regime + 2 stale-marker) / **not_classifiable** (8 cure-detached). Disputed wins precedence (49213/20111 carry a stale OSS-native marker); unknown/absent markers degrade to `unverified_source` with no invented vintage.
- **`ProvenanceBadge`** in the hero badge strip.
- **`KBLIProvenancePanel`** "Sources & Verification" — per-layer source + vintage + verdict (definition, risk/licensing, PMA Perpres 10/2021·49/2021 vintage disclosure, Bali overlay), dataset sidecar date.
- **`KBLIDivergence`** "Regulatory Divergence" — the product feature "we show the divergence with citations": verbatim correction note (image-verified locators), detached rows as audit trail, citation chips conditional on structured markers.
- **Honesty fixes** across consuming surfaces: FAQ (visible + FAQPage JSON-LD) + Article JSON-LD qualify crosswalk-pending licensing and attribute PMA to source+vintage; grid-level verification footnotes on both key-facts grids; `RiskBadge` "pending verification" qualifier at all call sites; not-classifiable codes no longer claim "special/sectoral regime". Wording per corner rule F12 (404 = "not retrievable via OSS API", never "not published"); detach copy = weakest common truthful claim (speaks about our verification, never asserts regulatory absence).

### Adversarial gate (generator≠grader)
Codex GPT-5.6 (terra, xhigh, read-only sandbox), **7 rounds**: 2 BLOCKER + 6 MAJOR found and cured (regulatory-absence overclaims, flattened cure causes, truthy-marker promotion, unknown-marker vintage invention, unqualified FAQ/JSON-LD/grid surfaces); PMA-surface scope ruling accepted round 7 → **VERDICT: SHIP**.

### Verified
- `tsc --noEmit` clean · targeted vitest 31/31 (guilt+innocence corpora, all 8 cured codes, unknown-marker cases, real-dataset partition invariant) · full mouth suite 2,000 tests green
- `next build` full SSG 1,559 pages OK; all three states proven in prerendered HTML (01111 verified · 01287 pending · 68112/49213 divergence section with detached rows)

### Declared out of scope (follow-ups)
- `_data_note` verbatim texts contain pre-F12 wording — data-plane, to be rewritten by the filiera cure compilers.
- PMABadge / hero PMA verdict re-labeling across 1,559 pages — FATAL-2 batch program, owner decision (Legge 5). The Sources panel discloses the vintage on every page meanwhile.
- kbli-explorer + native desktop app surfaces — ALIGN-FLEET after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)