### PR TITLE
feat(intel): liveness forced-choice tier — replace additive rubric (growth-loop B2)

### DIFF
--- a/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
+++ b/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
@@ -57,7 +57,6 @@ OUTPUT FORMAT (strict JSON only, no markdown):
     {{"question": "...", "answer": "..."}},
     {{"question": "...", "answer": "..."}}
   ],
-  "live_news_score": 0,
   "liveness_tier": "evergreen",
   "live_news_reasons": [],
   "metadata": {{
@@ -68,62 +67,82 @@ OUTPUT FORMAT (strict JSON only, no markdown):
   }}
 }}
 
-LIVE NEWS SCORING (0-100):
-Compute live_news_score by summing these signals (max 100):
-- +40: A specific decree, regulation, or peraturan with an explicit publication date in the last 48h is cited (e.g. "Peraturan BKPM 5/2026 published 2026-04-23"). Only fire if BOTH the document name AND its date are present.
-- +30: A concrete event with a date is referenced (arrest, deportation, tax audit, BKPM raid, MoU signing). Specific named event, not generic "recent".
-- +30: An official figure or threshold was just released (PNBP fee change, BKPM threshold, BPS statistic, OJK rate). Must include the actual number.
+LIVENESS TIER (forced choice):
+You MUST choose exactly one of: "breaking", "developing", "evergreen". Do not compute a
+score — pick the tier directly from the signal definitions below.
 
-If none of the three apply: live_news_score = 0.
+- breaking — a concrete dated event/decision in the last ~48h that changes what readers
+  must do NOW (new decree published with date, enforcement action, fee change effective
+  immediately).
+- developing — a dated, concrete story that is actively unfolding or has a near-term
+  deadline/effect (announced-but-not-yet-effective rule, dated arrests/raids with policy
+  implications, official figures just released, imminent deadlines).
+- evergreen — routine guides, how-tos, explainer content, undated or old news, recurring
+  seasonal content.
 
-Then derive liveness_tier from the score:
-- "breaking" if live_news_score >= 80
-- "developing" if 40 <= live_news_score < 80
-- "evergreen" if live_news_score < 40
+CALIBRATED ANCHORS (real examples from our corpus):
+- developing:
+  * "15 WNA China dan Vietnam Ditangkap Usai Buka Lowongan Kerja" (dated arrests, policy
+    implication)
+  * "Immigration Cuts Visa-Free Entry by 87.91%" (official figure just released)
+  * "Empat Marketplace Besar Jadi Pemungut Pajak Mulai Agustus" (dated upcoming policy)
+- breaking (illustrative shape — "effective now, published <48h"):
+  * "Permenkumham 12/2026 diundangkan 2026-07-17: syarat KITAS investor berubah efektif
+    hari ini"
+  * "Deportasi 8 WNA di Bandara Ngurah Rai hari ini usai razia overstay"
+  * "PNBP visa D2 naik jadi IDR 6 juta, berlaku efektif hari ini"
+- evergreen:
+  * "How to apply for KITAS"
+  * "The Complete Guide to PT PMA"
+  * Undated lifestyle / cost-of-living explainer
 
-live_news_reasons: list of max 3 short strings (≤80 chars each) that explain WHY you assigned the score. Format examples:
+live_news_reasons: list of max 3 short strings (≤80 chars each) that explain WHY you
+assigned the tier. Format examples:
 - "BKPM Reg 5/2026 published 2026-04-23"
 - "Deportation of 12 nationals at Ngurah Rai 2026-04-25"
 - "PNBP fee for D2 visa raised to IDR 5.5M (effective 2026-04-20)"
-If live_news_score is 0, return an empty list.
+If liveness_tier is "evergreen", return an empty list.
 
 RULES:
 - headline: never include the source name, make it punchy and specific
 - the_facts: journalism only, no Bali Zero branding, no "our clients"
 - bali_zero_take: this is where we add our expert spin
-- live_news_score: be conservative. If unsure, score lower. Routine guides ("How to apply for KITAS") are evergreen by definition.
+- liveness_tier: if unsure between two tiers, pick the LOWER one. But note: routine guides
+  are evergreen BY SHAPE — a dated, concrete story is NOT routine just because it's about a
+  familiar topic (visa, tax, KITAS).
 - live_news_reasons: only cite signals you can quote from the source content. Do not invent.
 - Output ONLY valid JSON, no explanations or markdown code blocks
 """
 
 
-def _normalize_live_news_fields(enriched: dict[str, Any]) -> dict[str, Any]:
-    """Clamp live_news_score, recompute liveness_tier from score, sanitize reasons.
+_TIER_TO_SCORE = {'breaking': 90, 'developing': 60, 'evergreen': 0}
 
-    Defensive normalization — the prompt instructs Claude to derive the tier
-    from the score, but model output occasionally drifts (e.g. score=85 but
-    tier="developing", or score returned as a string "high"). We trust the
-    score (with clamping) and recompute the tier deterministically; this also
-    means downstream WR2 selector code can rely on a strict invariant:
-    `tier == bucket(score)` always holds after enrichment.
+
+def _normalize_live_news_fields(enriched: dict[str, Any]) -> dict[str, Any]:
+    """Trust the validated TIER, derive live_news_score deterministically.
+
+    Growth-loop sprint B2 (2026-07-18): trust direction is INVERTED from the
+    pre-B2 module. The old additive 0-100 rubric structurally amplified
+    central-tendency bias (real distribution: 124/135 items scored exactly 0,
+    the rest capped at 30, nothing above — the live pool was permanently
+    empty). The prompt now forces the model to pick one of
+    breaking/developing/evergreen directly; `live_news_score` is a DERIVED
+    compatibility value for the selector's `>=40` filter and #2631's
+    persistence contract, NOT a measurement — never trust a model-provided
+    score, even if present (stray field / prompt drift tolerated but ignored).
+
+    liveness_tier missing or not one of the three valid values -> evergreen
+    (score 0, reasons []). This also means downstream WR2 selector code can
+    still rely on the strict invariant `tier == bucket(score)` under the
+    existing 80/40 buckets (90->breaking, 60->developing, 0->evergreen).
 
     Mutates and returns the same dict. Missing fields are filled with
-    safe defaults (score=0, tier="evergreen", reasons=[]) so downstream
+    safe defaults (tier="evergreen", score=0, reasons=[]) so downstream
     code never has to handle KeyError.
     """
-    raw_score = enriched.get('live_news_score', 0)
-    try:
-        score = int(round(float(raw_score)))
-    except (TypeError, ValueError):
-        score = 0
-    score = max(0, min(100, score))
-
-    if score >= 80:
-        tier = 'breaking'
-    elif score >= 40:
-        tier = 'developing'
-    else:
-        tier = 'evergreen'
+    raw_tier = enriched.get('liveness_tier')
+    tier = raw_tier if raw_tier in _TIER_TO_SCORE else 'evergreen'
+    score = _TIER_TO_SCORE[tier]
 
     raw_reasons = enriched.get('live_news_reasons', [])
     if not isinstance(raw_reasons, list):
@@ -132,7 +151,7 @@ def _normalize_live_news_fields(enriched: dict[str, Any]) -> dict[str, Any]:
     for r in raw_reasons[:3]:
         if isinstance(r, str) and r.strip():
             reasons.append(r.strip()[:200])
-    if score == 0:
+    if tier == 'evergreen':
         reasons = []
 
     enriched['live_news_score'] = score

--- a/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
+++ b/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timezone
 from typing import Any
 import logging
 
@@ -26,6 +27,10 @@ Category: {category}
 Published: {published_date}
 Content: {content}
 </notizia_scraped>
+
+AS OF: {as_of} — this is the current date/time; use it (together with
+Published, and any dates mentioned in Content) to judge whether events are
+"in the last ~48h" for the LIVENESS TIER section below.
 
 <base_legale_certificata>
 {nlm_legal_basis}
@@ -57,7 +62,7 @@ OUTPUT FORMAT (strict JSON only, no markdown):
     {{"question": "...", "answer": "..."}},
     {{"question": "...", "answer": "..."}}
   ],
-  "liveness_tier": "evergreen",
+  "liveness_tier": "<breaking|developing|evergreen>",
   "live_news_reasons": [],
   "metadata": {{
     "suggested_slug": "url-friendly-slug-max-60-chars",
@@ -69,27 +74,32 @@ OUTPUT FORMAT (strict JSON only, no markdown):
 
 LIVENESS TIER (forced choice):
 You MUST choose exactly one of: "breaking", "developing", "evergreen". Do not compute a
-score — pick the tier directly from the signal definitions below.
+score — pick the tier directly from the signal definitions below. Judge "last ~48h" and
+"near-term" relative to AS OF above (not to the calibrated anchors below, which are shape
+references only, not date references).
 
-- breaking — a concrete dated event/decision in the last ~48h that changes what readers
-  must do NOW (new decree published with date, enforcement action, fee change effective
-  immediately).
+- breaking — a concrete dated event/decision within the last ~48h of AS OF that changes
+  what readers must do NOW: a new decree published with a date, a single enforcement
+  action (arrest/deportation/raid) that concluded within that ~48h window with immediate
+  effect, or a fee change effective immediately.
 - developing — a dated, concrete story that is actively unfolding or has a near-term
-  deadline/effect (announced-but-not-yet-effective rule, dated arrests/raids with policy
-  implications, official figures just released, imminent deadlines).
+  deadline/effect: an announced-but-not-yet-effective rule, dated arrests/raids reported as
+  part of a broader enforcement pattern or policy story (not the initial <48h enforcement
+  moment itself), official figures just released, imminent deadlines.
 - evergreen — routine guides, how-tos, explainer content, undated or old news, recurring
   seasonal content.
 
-CALIBRATED ANCHORS (real examples from our corpus):
+CALIBRATED ANCHORS (real examples from our corpus; shape references, not date references):
 - developing:
-  * "15 WNA China dan Vietnam Ditangkap Usai Buka Lowongan Kerja" (dated arrests, policy
-    implication)
+  * "15 WNA China dan Vietnam Ditangkap Usai Buka Lowongan Kerja" (dated arrests, part of
+    an enforcement pattern, policy implication)
   * "Immigration Cuts Visa-Free Entry by 87.91%" (official figure just released)
   * "Empat Marketplace Besar Jadi Pemungut Pajak Mulai Agustus" (dated upcoming policy)
-- breaking (illustrative shape — "effective now, published <48h"):
-  * "Permenkumham 12/2026 diundangkan 2026-07-17: syarat KITAS investor berubah efektif
-    hari ini"
-  * "Deportasi 8 WNA di Bandara Ngurah Rai hari ini usai razia overstay"
+- breaking (illustrative shape — "effective now, published within 48h of AS OF"):
+  * "Permenkumham 12/2026 diundangkan kemarin: syarat KITAS investor berubah efektif hari
+    ini"
+  * "Deportasi 8 WNA di Bandara Ngurah Rai hari ini usai razia overstay" (single enforcement
+    action, immediate effect — not a pattern reported after the fact)
   * "PNBP visa D2 naik jadi IDR 6 juta, berlaku efektif hari ini"
 - evergreen:
   * "How to apply for KITAS"
@@ -117,6 +127,36 @@ RULES:
 
 _TIER_TO_SCORE = {'breaking': 90, 'developing': 60, 'evergreen': 0}
 
+# F5 (Codex red-team, 2026-07-18): buffer above the prompt's ≤80-char
+# instruction for live_news_reasons, so minor model overshoot doesn't get
+# truncated mid-thought — but bounded well below the old 200, which let a
+# reason balloon into a near-paragraph.
+_REASON_MAX_CHARS = 120
+
+
+def _derive_tier_from_score(raw_score: Any) -> str:
+    """F2 (Codex red-team, 2026-07-18): legacy/truncated-output fallback.
+
+    #2631's persistence contract still tolerates a `live_news_score`-only
+    payload with no `liveness_tier` (e.g. a truncated JSON parse, or an
+    older enrichment run). Rather than silently discarding that signal and
+    collapsing to evergreen, best-effort derive a tier from the score using
+    the pre-B2 80/40 buckets — with the same defensive float coercion and
+    clamping the old additive-rubric normalizer used. Garbage,
+    out-of-range, or absent scores fall back to evergreen (no signal),
+    never raise.
+    """
+    try:
+        score = int(round(float(raw_score)))
+    except (TypeError, ValueError):
+        return 'evergreen'
+    score = max(0, min(100, score))
+    if score >= 80:
+        return 'breaking'
+    elif score >= 40:
+        return 'developing'
+    return 'evergreen'
+
 
 def _normalize_live_news_fields(enriched: dict[str, Any]) -> dict[str, Any]:
     """Trust the validated TIER, derive live_news_score deterministically.
@@ -129,19 +169,36 @@ def _normalize_live_news_fields(enriched: dict[str, Any]) -> dict[str, Any]:
     breaking/developing/evergreen directly; `live_news_score` is a DERIVED
     compatibility value for the selector's `>=40` filter and #2631's
     persistence contract, NOT a measurement — never trust a model-provided
-    score, even if present (stray field / prompt drift tolerated but ignored).
+    score over a VALID tier, even if present (stray field / prompt drift
+    tolerated but ignored — see test_score_only_fallback_never_fires_when_
+    tier_is_valid).
 
-    liveness_tier missing or not one of the three valid values -> evergreen
-    (score 0, reasons []). This also means downstream WR2 selector code can
-    still rely on the strict invariant `tier == bucket(score)` under the
-    existing 80/40 buckets (90->breaking, 60->developing, 0->evergreen).
+    F1 (Codex red-team, 2026-07-18): raw_tier is normalized (str + strip +
+    lower) BEFORE the membership check — the pre-fix code did
+    `raw_tier in _TIER_TO_SCORE` directly, which raises TypeError for a
+    non-str, unhashable value (list/dict) and silently mis-evergreens a
+    differently-cased/whitespace-padded valid tier ("Developing").
+
+    F2 (Codex red-team, 2026-07-18): if the (normalized) tier is not one of
+    the three valid values — missing, garbage, or a non-str type — fall
+    back to deriving it from a legacy/truncated `live_news_score` if one was
+    still sent (see `_derive_tier_from_score`), instead of discarding the
+    signal outright.
+
+    Either way the strict invariant downstream WR2 selector code relies on
+    still holds: `tier == bucket(score)` under the existing 80/40 buckets
+    (90->breaking, 60->developing, 0->evergreen).
 
     Mutates and returns the same dict. Missing fields are filled with
     safe defaults (tier="evergreen", score=0, reasons=[]) so downstream
     code never has to handle KeyError.
     """
     raw_tier = enriched.get('liveness_tier')
-    tier = raw_tier if raw_tier in _TIER_TO_SCORE else 'evergreen'
+    tier_candidate = raw_tier.strip().lower() if isinstance(raw_tier, str) else ''
+    if tier_candidate in _TIER_TO_SCORE:
+        tier = tier_candidate
+    else:
+        tier = _derive_tier_from_score(enriched.get('live_news_score'))
     score = _TIER_TO_SCORE[tier]
 
     raw_reasons = enriched.get('live_news_reasons', [])
@@ -150,7 +207,7 @@ def _normalize_live_news_fields(enriched: dict[str, Any]) -> dict[str, Any]:
     reasons: list[str] = []
     for r in raw_reasons[:3]:
         if isinstance(r, str) and r.strip():
-            reasons.append(r.strip()[:200])
+            reasons.append(r.strip()[:_REASON_MAX_CHARS])
     if tier == 'evergreen':
         reasons = []
 
@@ -187,6 +244,11 @@ def enrich_article_claude_cli(article: dict[str, Any]) -> dict[str, Any]:
     nlm_legal = _escape_for_prompt(str(nlm_legal or '')[:3000])
     nlm_web = _escape_for_prompt(str(nlm_web or '')[:2000])
 
+    # F4 (Codex red-team, 2026-07-18): AS OF anchors the LIVENESS TIER "last
+    # ~48h" judgment to the real current date instead of nothing — system
+    # generated, not user/article input, so no _escape_for_prompt needed.
+    as_of = datetime.now(timezone.utc).isoformat()
+
     # Build prompt — ALL article fields escaped to prevent XML tag spoofing
     prompt = ENRICHMENT_PROMPT_TEMPLATE.format(
         title=_escape_for_prompt(str(article.get('title') or 'Unknown')[:300]),
@@ -196,6 +258,7 @@ def enrich_article_claude_cli(article: dict[str, Any]) -> dict[str, Any]:
         content=_escape_for_prompt(str(article.get('content') or '')[:4000]),
         nlm_legal_basis=nlm_legal,
         nlm_web_findings=nlm_web,
+        as_of=as_of,
     )
 
     try:

--- a/apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_live_news.py
+++ b/apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_live_news.py
@@ -15,6 +15,17 @@ persistence contract — not a measurement. Downstream code still relies on
 the invariant `tier == bucket(score)` (90->breaking, 60->developing,
 0->evergreen under the existing 80/40 buckets), so score derivation must
 keep hitting those exact buckets.
+
+B2 red-team round (Codex, 2026-07-18) added 5 hardening fixes (F1-F5):
+F1 — normalize raw_tier defensively BEFORE membership check (case/whitespace,
+never crash on a non-str type like list/dict). F2 — legacy/truncated
+score-only output (`{"live_news_score": 85}`, no tier) still derives a tier
+via the pre-B2 80/40 buckets instead of collapsing to evergreen. F3 — the
+prompt's OUTPUT FORMAT no longer shows a literal `"evergreen"` default
+(anchoring risk now that tier is authoritative) — a bracket placeholder
+instead. F4 — prompt-only: AS OF context + relative dates in the breaking
+anchors + enforcement-vs-pattern disambiguation for arrests. F5 — reasons
+truncation buffer lowered from 200 to 120 chars.
 """
 from __future__ import annotations
 
@@ -89,6 +100,143 @@ def test_stray_model_score_overridden_for_breaking_too() -> None:
 
 
 # ---------------------------------------------------------------------------
+# F1 (HIGH, Codex red-team): raw_tier must be normalized (case/whitespace)
+# BEFORE the membership check, and must never crash on a non-str type — the
+# pre-fix code did `raw_tier in _TIER_TO_SCORE` directly, which raises
+# TypeError: unhashable type for a list/dict value.
+# ---------------------------------------------------------------------------
+
+def test_tier_case_insensitive() -> None:
+    out = _normalize_live_news_fields({"liveness_tier": "Developing"})
+    assert out["liveness_tier"] == "developing"
+    assert out["live_news_score"] == 60
+
+
+def test_tier_whitespace_stripped() -> None:
+    out = _normalize_live_news_fields({"liveness_tier": " developing "})
+    assert out["liveness_tier"] == "developing"
+    assert out["live_news_score"] == 60
+
+
+def test_tier_list_value_no_crash() -> None:
+    """Pre-fix: `["breaking"] in _TIER_TO_SCORE` raises TypeError (unhashable
+    type: 'list'). Post-fix: non-str tier values are never used as a dict
+    membership key — they fall through to evergreen (no score to derive
+    from) without an exception."""
+    out = _normalize_live_news_fields({"liveness_tier": ["breaking"]})
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_score"] == 0
+
+
+def test_tier_dict_value_no_crash() -> None:
+    """Same TypeError class as the list case, dict is unhashable too."""
+    out = _normalize_live_news_fields({"liveness_tier": {"tier": "x"}})
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_score"] == 0
+
+
+# ---------------------------------------------------------------------------
+# F2 (HIGH, Codex red-team): legacy/truncated score-only output — a model
+# response that dropped `liveness_tier` but still carries `live_news_score`
+# (e.g. a truncated JSON parse, or a #2631-era output) must not collapse to
+# evergreen/0 and silently discard the signal. Fall back to deriving the
+# tier from the score via the pre-B2 80/40 buckets, then re-derive the
+# canonical score from THAT tier so the tier==bucket(score) invariant holds.
+# ---------------------------------------------------------------------------
+
+def test_score_only_legacy_output_85_derives_breaking() -> None:
+    out = _normalize_live_news_fields({"live_news_score": 85})
+    assert out["liveness_tier"] == "breaking"
+    assert out["live_news_score"] == 90
+
+
+def test_score_only_legacy_output_55_derives_developing() -> None:
+    out = _normalize_live_news_fields({"live_news_score": 55})
+    assert out["liveness_tier"] == "developing"
+    assert out["live_news_score"] == 60
+
+
+def test_score_only_legacy_output_garbage_falls_back_to_evergreen() -> None:
+    out = _normalize_live_news_fields({"live_news_score": "high"})
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_score"] == 0
+
+
+def test_score_only_fallback_never_fires_when_tier_is_valid() -> None:
+    """Regression guard: the F2 fallback must only trigger when the tier is
+    ABSENT/invalid — a valid tier (even 'evergreen') always wins over any
+    score, matching test_stray_model_score_is_overridden_tier_wins above."""
+    out = _normalize_live_news_fields({"liveness_tier": "evergreen", "live_news_score": 85})
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_score"] == 0
+
+
+# ---------------------------------------------------------------------------
+# F3 (HIGH, Codex red-team): the OUTPUT FORMAT template used to show a
+# literal `"liveness_tier": "evergreen"` default — an anchoring risk now
+# that the tier is authoritative (same central-tendency-bias shape as the
+# additive rubric this sprint replaced). Must be a bracket placeholder.
+# ---------------------------------------------------------------------------
+
+def test_prompt_template_does_not_default_to_evergreen_literal() -> None:
+    assert '"liveness_tier": "evergreen"' not in ENRICHMENT_PROMPT_TEMPLATE
+
+
+def test_prompt_template_has_tier_placeholder() -> None:
+    assert '"liveness_tier": "<breaking|developing|evergreen>"' in ENRICHMENT_PROMPT_TEMPLATE
+
+
+def test_normalizer_handles_literal_placeholder_copy() -> None:
+    """If Claude echoes the template placeholder literally instead of
+    picking a real tier, the normalizer must not crash and must fall back
+    to evergreen (passes through the F1 str-normalize + F2 score-fallback
+    path — no live_news_score present here, so lands on evergreen)."""
+    out = _normalize_live_news_fields({"liveness_tier": "<breaking|developing|evergreen>"})
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_score"] == 0
+
+
+# ---------------------------------------------------------------------------
+# F4 (MEDIUM/partial, Codex red-team): prompt-only. AS OF context anchors
+# "last ~48h" to the actual current date instead of nothing; breaking
+# anchors use relative dates (a frozen absolute date goes stale as the
+# calendar moves and mis-anchors the corpus); arrests are disambiguated —
+# breaking only for <48h enforcement with immediate effect, dated arrests
+# as part of a broader pattern are developing. (Selector-side change is
+# NOT needed — MAX_ARTICLE_AGE_HOURS=72 hard cutoff on fresh_items already
+# covers the downstream staleness concern Codex raised.)
+# ---------------------------------------------------------------------------
+
+def test_prompt_has_as_of_context() -> None:
+    assert "AS OF" in ENRICHMENT_PROMPT_TEMPLATE
+    assert "{as_of}" in ENRICHMENT_PROMPT_TEMPLATE
+
+
+def test_prompt_formats_with_as_of_parameter() -> None:
+    """enrich_article_claude_cli must pass as_of (UTC ISO date) into the
+    template — this is what anchors the breaking/developing 48h window to
+    today instead of to whatever date happened to be baked into the
+    calibrated anchors at prompt-authoring time."""
+    formatted = ENRICHMENT_PROMPT_TEMPLATE.format(
+        title="t", source="s", category="c", published_date="p", content="x",
+        nlm_legal_basis="", nlm_web_findings="",
+        as_of="2026-07-18T00:00:00+00:00",
+    )
+    assert "2026-07-18T00:00:00+00:00" in formatted
+
+
+def test_prompt_breaking_anchor_has_no_frozen_absolute_date() -> None:
+    """The original B2 breaking anchor baked in a literal 2026-07-17 date —
+    exactly the staleness trap AS OF exists to avoid. Anchors must use
+    relative time language instead."""
+    assert "2026-07-17" not in ENRICHMENT_PROMPT_TEMPLATE
+
+
+def test_prompt_disambiguates_dated_arrests_as_pattern() -> None:
+    assert "pattern" in ENRICHMENT_PROMPT_TEMPLATE.lower()
+
+
+# ---------------------------------------------------------------------------
 # Innocence: reasons pass through intact for non-evergreen tiers, sanitation
 # rules from the pre-B2 module are unchanged.
 # ---------------------------------------------------------------------------
@@ -118,10 +266,13 @@ def test_reasons_capped_at_three() -> None:
     assert out["live_news_reasons"] == ["one", "two", "three"]
 
 
-def test_reasons_truncated_at_200_chars() -> None:
+def test_reasons_truncated_at_120_chars() -> None:
+    """F5: buffer lowered from 200 to 120 — still well above the prompt's
+    ≤80-char instruction (tolerates minor model overshoot) but bounded
+    tighter than the old 200 to keep the reasons list actually short."""
     long = "x" * 500
     out = _normalize_live_news_fields({"liveness_tier": "breaking", "live_news_reasons": [long]})
-    assert len(out["live_news_reasons"][0]) == 200
+    assert len(out["live_news_reasons"][0]) == 120
 
 
 def test_reasons_filter_non_strings() -> None:

--- a/apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_live_news.py
+++ b/apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_live_news.py
@@ -1,11 +1,20 @@
 """
-Tests for the live_news_score normalization in claude_cli_enricher.
+Tests for the liveness-tier normalization in claude_cli_enricher.
 
-Locks down the post-Claude defensive normalization: clamping the score,
-deriving the tier deterministically from the score, and sanitizing the
-reasons list. This is the boundary downstream WR2 selector relies on:
-after enrichment, `tier == bucket(score)` always holds and reasons is
-always a list of clean strings (or empty).
+Growth-loop sprint B2 (2026-07-18): the additive 0-100 rubric was replaced
+with a forced-choice tier (breaking/developing/evergreen) — the additive
+rubric structurally amplified central-tendency bias (124/135 real items
+scored exactly 0, the rest capped at 30, nothing above; live pool stayed
+permanently empty). Research capture:
+research/operations/2026-07-18-wr2-liveness-scoring-redesign.md.
+
+Trust direction is now INVERTED from the pre-B2 module: the model's
+`liveness_tier` is the validated signal; `live_news_score` is a DERIVED
+compatibility value for the selector's `>=40` filter and #2631's
+persistence contract — not a measurement. Downstream code still relies on
+the invariant `tier == bucket(score)` (90->breaking, 60->developing,
+0->evergreen under the existing 80/40 buckets), so score derivation must
+keep hitting those exact buckets.
 """
 from __future__ import annotations
 
@@ -18,90 +27,91 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from claude_cli_enricher import _normalize_live_news_fields  # type: ignore  # noqa: E402
+from claude_cli_enricher import (  # type: ignore  # noqa: E402
+    ENRICHMENT_PROMPT_TEMPLATE,
+    _normalize_live_news_fields,
+)
 
 
-def test_score_below_40_is_evergreen() -> None:
-    out = _normalize_live_news_fields({"live_news_score": 30, "liveness_tier": "ignored"})
-    assert out["live_news_score"] == 30
+# ---------------------------------------------------------------------------
+# Guilt: tier drives the derived score deterministically.
+# ---------------------------------------------------------------------------
+
+def test_tier_breaking_derives_score_90() -> None:
+    out = _normalize_live_news_fields({"liveness_tier": "breaking"})
+    assert out["liveness_tier"] == "breaking"
+    assert out["live_news_score"] == 90
+
+
+def test_tier_developing_derives_score_60() -> None:
+    out = _normalize_live_news_fields({"liveness_tier": "developing"})
+    assert out["liveness_tier"] == "developing"
+    assert out["live_news_score"] == 60
+
+
+def test_tier_evergreen_derives_score_0() -> None:
+    out = _normalize_live_news_fields({"liveness_tier": "evergreen"})
     assert out["liveness_tier"] == "evergreen"
-
-
-def test_score_40_is_developing() -> None:
-    """40 is the breaking-down threshold; must round into developing not evergreen."""
-    out = _normalize_live_news_fields({"live_news_score": 40})
-    assert out["liveness_tier"] == "developing"
-
-
-def test_score_79_is_developing() -> None:
-    out = _normalize_live_news_fields({"live_news_score": 79})
-    assert out["liveness_tier"] == "developing"
-
-
-def test_score_80_is_breaking() -> None:
-    out = _normalize_live_news_fields({"live_news_score": 80})
-    assert out["liveness_tier"] == "breaking"
-
-
-def test_score_100_is_breaking() -> None:
-    out = _normalize_live_news_fields({"live_news_score": 100})
-    assert out["liveness_tier"] == "breaking"
-
-
-def test_score_clamped_above_100() -> None:
-    """Claude occasionally returns 250 when prompted to sum signals."""
-    out = _normalize_live_news_fields({"live_news_score": 250})
-    assert out["live_news_score"] == 100
-    assert out["liveness_tier"] == "breaking"
-
-
-def test_score_clamped_below_0() -> None:
-    out = _normalize_live_news_fields({"live_news_score": -10})
     assert out["live_news_score"] == 0
-    assert out["liveness_tier"] == "evergreen"
-
-
-def test_score_string_coerced() -> None:
-    """Some model outputs return numbers as strings."""
-    out = _normalize_live_news_fields({"live_news_score": "55"})
-    assert out["live_news_score"] == 55
-    assert out["liveness_tier"] == "developing"
-
-
-def test_score_garbage_falls_back_to_zero() -> None:
-    out = _normalize_live_news_fields({"live_news_score": "high"})
-    assert out["live_news_score"] == 0
-    assert out["liveness_tier"] == "evergreen"
     assert out["live_news_reasons"] == []
 
 
-def test_score_float_rounded() -> None:
-    """Bayesian-leaning models sometimes return 78.4."""
-    out = _normalize_live_news_fields({"live_news_score": 78.6})
-    assert out["live_news_score"] == 79
-
-
-def test_missing_score_defaults_to_zero() -> None:
+def test_tier_missing_defaults_to_evergreen() -> None:
     out = _normalize_live_news_fields({})
-    assert out["live_news_score"] == 0
     assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_score"] == 0
     assert out["live_news_reasons"] == []
 
 
-def test_tier_recomputed_even_when_model_disagrees() -> None:
-    """Don't trust Claude's tier — recompute from score deterministically.
+def test_tier_garbage_falls_back_to_evergreen() -> None:
+    out = _normalize_live_news_fields({"liveness_tier": "hot"})
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_score"] == 0
+    assert out["live_news_reasons"] == []
 
-    The downstream WR2 selector reads tier and assumes it's bucket(score).
-    If Claude returned score=85 but tier='evergreen' (we've seen this), the
-    selector would silently route a breaking story to the routine queue.
+
+def test_stray_model_score_is_overridden_tier_wins() -> None:
+    """The model MUST NOT output live_news_score anymore, but if it does
+    (prompt drift / stray field), the validated tier wins — never the
+    number. This is the trust-direction inversion this sprint exists for.
     """
-    out = _normalize_live_news_fields({"live_news_score": 85, "liveness_tier": "evergreen"})
+    out = _normalize_live_news_fields({"liveness_tier": "evergreen", "live_news_score": 85})
+    assert out["liveness_tier"] == "evergreen"
+    assert out["live_news_score"] == 0
+
+
+def test_stray_model_score_overridden_for_breaking_too() -> None:
+    """Symmetric case: a stray low score must not downgrade a validated
+    breaking tier either."""
+    out = _normalize_live_news_fields({"liveness_tier": "breaking", "live_news_score": 5})
     assert out["liveness_tier"] == "breaking"
+    assert out["live_news_score"] == 90
+
+
+# ---------------------------------------------------------------------------
+# Innocence: reasons pass through intact for non-evergreen tiers, sanitation
+# rules from the pre-B2 module are unchanged.
+# ---------------------------------------------------------------------------
+
+def test_developing_reasons_preserved() -> None:
+    out = _normalize_live_news_fields({
+        "liveness_tier": "developing",
+        "live_news_reasons": ["dated arrests at Ngurah Rai", "policy implication cited"],
+    })
+    assert out["live_news_reasons"] == ["dated arrests at Ngurah Rai", "policy implication cited"]
+
+
+def test_evergreen_reasons_emptied_even_if_model_invented_some() -> None:
+    out = _normalize_live_news_fields({
+        "liveness_tier": "evergreen",
+        "live_news_reasons": ["some hallucinated signal"],
+    })
+    assert out["live_news_reasons"] == []
 
 
 def test_reasons_capped_at_three() -> None:
     out = _normalize_live_news_fields({
-        "live_news_score": 80,
+        "liveness_tier": "breaking",
         "live_news_reasons": ["one", "two", "three", "four", "five"],
     })
     assert len(out["live_news_reasons"]) == 3
@@ -110,13 +120,13 @@ def test_reasons_capped_at_three() -> None:
 
 def test_reasons_truncated_at_200_chars() -> None:
     long = "x" * 500
-    out = _normalize_live_news_fields({"live_news_score": 80, "live_news_reasons": [long]})
+    out = _normalize_live_news_fields({"liveness_tier": "breaking", "live_news_reasons": [long]})
     assert len(out["live_news_reasons"][0]) == 200
 
 
 def test_reasons_filter_non_strings() -> None:
     out = _normalize_live_news_fields({
-        "live_news_score": 50,
+        "liveness_tier": "developing",
         "live_news_reasons": ["valid", None, 42, {"nested": "garbage"}, "also valid"],
     })
     assert out["live_news_reasons"] == ["valid"]
@@ -128,7 +138,7 @@ def test_reasons_filter_non_strings() -> None:
 
 def test_reasons_filter_empty_strings() -> None:
     out = _normalize_live_news_fields({
-        "live_news_score": 50,
+        "liveness_tier": "developing",
         "live_news_reasons": ["", "  ", "real reason"],
     })
     # First 3 raw slots: "", "  ", "real reason". After strip-filter only
@@ -136,31 +146,58 @@ def test_reasons_filter_empty_strings() -> None:
     assert out["live_news_reasons"] == ["real reason"]
 
 
-def test_reasons_zeroed_when_score_is_zero() -> None:
-    """If we couldn't find any signals, reasons must be empty even if model invented some."""
-    out = _normalize_live_news_fields({
-        "live_news_score": 0,
-        "live_news_reasons": ["some hallucinated signal"],
-    })
-    assert out["live_news_reasons"] == []
-
-
 def test_reasons_non_list_falls_back_to_empty() -> None:
-    out = _normalize_live_news_fields({"live_news_score": 50, "live_news_reasons": "not a list"})
+    out = _normalize_live_news_fields({"liveness_tier": "developing", "live_news_reasons": "not a list"})
     assert out["live_news_reasons"] == []
 
 
 def test_normalization_preserves_other_fields() -> None:
-    """Mutates only live_news_* keys; everything else passes through untouched."""
+    """Mutates only live_news_*/liveness_tier keys; everything else passes
+    through untouched."""
     enriched = {
         "headline": "Big News",
         "the_facts": "facts",
-        "live_news_score": 50,
+        "liveness_tier": "developing",
         "metadata": {"tags": ["foo"]},
     }
     out = _normalize_live_news_fields(enriched)
     assert out["headline"] == "Big News"
     assert out["the_facts"] == "facts"
     assert out["metadata"] == {"tags": ["foo"]}
-    assert out["live_news_score"] == 50
     assert out["liveness_tier"] == "developing"
+    assert out["live_news_score"] == 60
+
+
+def test_invariant_tier_equals_bucket_of_derived_score() -> None:
+    """Downstream WR2 selector code relies on tier == bucket(score) always
+    holding after enrichment, under the existing 80/40 buckets."""
+    for tier, expected_score in (("breaking", 90), ("developing", 60), ("evergreen", 0)):
+        out = _normalize_live_news_fields({"liveness_tier": tier})
+        score = out["live_news_score"]
+        if score >= 80:
+            bucket = "breaking"
+        elif score >= 40:
+            bucket = "developing"
+        else:
+            bucket = "evergreen"
+        assert out["liveness_tier"] == bucket == tier
+        assert score == expected_score
+
+
+# ---------------------------------------------------------------------------
+# Prompt-content assertions: forced-choice section present, calibrated
+# anchors present, old additive section gone.
+# ---------------------------------------------------------------------------
+
+def test_prompt_has_forced_choice_section() -> None:
+    assert "LIVENESS TIER (forced choice)" in ENRICHMENT_PROMPT_TEMPLATE
+
+
+def test_prompt_has_the_three_real_developing_anchors() -> None:
+    assert "15 WNA China dan Vietnam Ditangkap Usai Buka Lowongan Kerja" in ENRICHMENT_PROMPT_TEMPLATE
+    assert "Immigration Cuts Visa-Free Entry by 87.91%" in ENRICHMENT_PROMPT_TEMPLATE
+    assert "Empat Marketplace Besar Jadi Pemungut Pajak Mulai Agustus" in ENRICHMENT_PROMPT_TEMPLATE
+
+
+def test_prompt_no_longer_has_additive_scoring_section() -> None:
+    assert "LIVE NEWS SCORING" not in ENRICHMENT_PROMPT_TEMPLATE

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 638 services · 1162 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 638 services · 1163 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Wound

The enricher's additive liveness rubric (+40 decree-with-date / +30 dated-event / +30 official-figure, buckets 80/40) classifies EVERYTHING evergreen on real data: over the last 10 enriched runs on Pro, 124/135 articles scored exactly 0 and 11 scored exactly 30 — nothing crossed the developing threshold (40). The 11 at 30 include objectively-live stories (dated arrests, the 87.91% visa-free cut, the August marketplace tax change). A real story fires exactly ONE signal, and one signal can never clear a threshold calibrated for a sum. Even after #2631's transport fix, the live pool stays permanently empty — the plumbing is fixed, the water is still all "evergreen".

Research grounding: `research/marketing/2026-07-18-wr2-liveness-scoring-redesign.md` (growth-loop sprint R2, 15 sources) — additive LLM rubrics structurally amplify central-tendency bias; the best cost/benefit mitigation in the literature is forced-choice classification with few-shot calibrated anchors.

## Change (one module + its tests)

- **Prompt**: the additive "LIVE NEWS SCORING (0-100)" section is replaced by "LIVENESS TIER (forced choice)" — the model picks breaking/developing/evergreen directly, guided by 3 calibrated anchors per tier (the real mis-scored stories become developing anchors). `AS OF: {as_of}` (UTC) is injected so "last ~48h" is anchored; breaking anchors use relative dates (no frozen dates to go stale); arrests disambiguated (single <48h enforcement = breaking; dated pattern = developing). The JSON template shows a `<breaking|developing|evergreen>` placeholder, not a copyable "evergreen" default.
- **`_normalize_live_news_fields`**: trust direction INVERTED — trust the validated tier, derive `live_news_score` deterministically (breaking→90, developing→60, evergreen→0; the score is a compatibility value for the selector's `>=40` filter and #2631's persistence contract, not a measurement). Tier normalized (case/whitespace, non-str safe) before validation; invalid/missing tier falls back to deriving from a legacy numeric score via the pre-B2 80/40 buckets (keeps #2631's defensive net effective). Invariant `tier == bucket(score)` still holds downstream.

## Verification

- TDD both rounds: 14 guilt tests failed on pre-change code (round 1), 13 on the red-team round (incl. two real `TypeError: unhashable` crashes) → 34/34 green post-fix.
- Codex GPT-5.6-sol red-team (generator≠grader): 5 findings (3 HIGH), all fixed in the follow-up commit and re-verified empirically (10/10 normalizer probe cases by the orchestrating session).
- W89 class-audit of every `live_news_score` reader repo-wide: selector bonus/filter compatible ({90,60,0} → bonus {45,30,0}, filter ≥40 admits developing+); draft-generator usage is log-only; warroom_step2_briefer is a naming collision on a different pipeline.
- W86: docs_sync regen (`docs/AI_ONBOARDING.md` test count) folded into the PR.

## Expected in production

First non-empty live pool on a real news day (topic-selector log: "using live pool (N items)"), tier-based tone/length steering activates. Prove-live: manual replay of known mis-scored stories post-deploy + tonight's 01:00 WITA run distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)