### PR TITLE
fix(kbli): TransitionBadge dark-theme tokens instead of light-mode Tailwind

### DIFF
--- a/apps/mouth/src/components/kbli/TransitionBadge.test.tsx
+++ b/apps/mouth/src/components/kbli/TransitionBadge.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { TransitionBadge } from "./TransitionBadge";
+
+describe("TransitionBadge — dark-theme tokens", () => {
+  it("renders a labeled pill styled from a --kbli-* token, never a light-mode class", () => {
+    const { container } = render(<TransitionBadge status="MATCH_LANGSUNG" />);
+    expect(screen.getByText("Direct Match")).toBeDefined();
+    const span = container.querySelector("span")!;
+    // color comes from the theme token, not a hardcoded light-mode class
+    expect(span.style.color).toContain("--kbli-pma-open");
+    expect(span.getAttribute("class") ?? "").not.toMatch(
+      /bg-(green|blue|amber|purple)-\d/,
+    );
+  });
+
+  it("innocence: empty status renders nothing", () => {
+    const { container } = render(<TransitionBadge status="" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/mouth/src/components/kbli/TransitionBadge.tsx
+++ b/apps/mouth/src/components/kbli/TransitionBadge.tsx
@@ -8,11 +8,16 @@ const LABELS: Record<KBLIMappingStatus, string> = {
   "": "",
 };
 
+// Dark-theme tokens (src/styles/kbli-theme.css), NOT hardcoded light-mode
+// Tailwind classes (bg-green-50 …) — those rendered as pale chips on the dark
+// hero, out of step with every sibling KBLI badge (Risk/PMA/Bali/Provenance).
+// bg + border are alpha-composited from the same token via color-mix, mirroring
+// KBLIProvenancePanel. Four distinct hues, one per mapping status.
 const COLORS: Record<KBLIMappingStatus, string> = {
-  MATCH_LANGSUNG: "bg-green-50 text-green-700 border-green-200",
-  CODICE_RINUMERATO: "bg-blue-50 text-blue-700 border-blue-200",
-  MATCH_CON_AGGREGAZIONE: "bg-amber-50 text-amber-700 border-amber-200",
-  BPS_ONLY: "bg-purple-50 text-purple-700 border-purple-200",
+  MATCH_LANGSUNG: "var(--kbli-pma-open)", // #5ec490 green — clean 1:1 match
+  CODICE_RINUMERATO: "var(--kbli-accent2)", // #8b9cf7 blue — renumbered
+  MATCH_CON_AGGREGAZIONE: "var(--kbli-amber)", // #e8a849 amber — merged
+  BPS_ONLY: "var(--kbli-accent)", // #d4845a terracotta — brand-new code
   "": "",
 };
 
@@ -22,9 +27,15 @@ interface TransitionBadgeProps {
 
 export function TransitionBadge({ status }: TransitionBadgeProps) {
   if (!status) return null;
+  const color = COLORS[status];
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${COLORS[status]}`}
+      className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium"
+      style={{
+        color,
+        borderColor: `color-mix(in srgb, ${color} 30%, transparent)`,
+        backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+      }}
     >
       {LABELS[status]}
     </span>


### PR DESCRIPTION
Swaps the 2020->2025 mapping badge from hardcoded light-mode Tailwind classes (bg-green-50 …) to four distinct --kbli-* dark-theme tokens (pma-open/accent2/amber/accent) with color-mix alpha, matching every sibling KBLI badge. Found in TRACK-P post-deploy visual QA; pre-existing outlier, not a TRACK-P regression. Verified: tsc clean, TransitionBadge.test.tsx guilt+innocence green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)