### PR TITLE
fix(intel-scraper): cache.py key_builder annotation — Callable not builtin callable (import bomb)

### DIFF
--- a/apps/bali-intel-scraper/backend/core/cache.py
+++ b/apps/bali-intel-scraper/backend/core/cache.py
@@ -12,6 +12,7 @@ import asyncio
 import hashlib
 import json
 import pickle
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Generic, TypeVar
@@ -280,7 +281,7 @@ class CacheManager(Generic[T]):
     async def get_or_set(
         self,
         key: str,
-        factory: callable,
+        factory: Callable[..., Any],
         ttl: int | None = None,
         strategy: CacheStrategy | None = None,
     ) -> Any:
@@ -393,7 +394,7 @@ async def close_cache() -> None:
 def cached(
     ttl: int | None = None,
     strategy: CacheStrategy | None = None,
-    key_builder: callable | None = None,
+    key_builder: Callable[..., Any] | None = None,
     skip_args: list[int] | None = None,
 ):
     """Decorator for caching function results."""


### PR DESCRIPTION
## Summary

`apps/bali-intel-scraper/backend/core/cache.py` used the builtin function `callable` as a type annotation instead of `typing.Callable` in two places:

- `cached()` decorator: `key_builder: callable | None = None`
- `CacheManager.get_or_set()`: `factory: callable`

Since the file has no `from __future__ import annotations`, `callable | None` is evaluated eagerly at **import time** as `builtin_function_or_method | NoneType`, which raises:

```
TypeError: unsupported operand type(s) for |: 'builtin_function_or_method' and 'NoneType'
```

This makes `backend.core.cache` uncollectable on any CPython, which in turn makes the entire `apps/bali-intel-scraper/tests/` conftest chain uncollectable (`conftest.py` imports `backend.core.cache.CacheManager`).

## Repro (before fix)

```
$ cd apps/bali-intel-scraper && python3 -c "import sys; sys.path.insert(0,'.'); import backend.core.cache"
Traceback (most recent call last):
  ...
  File ".../backend/core/cache.py", line 396, in <module>
    key_builder: callable | None = None,
                 ~~~~~~~~~^~~~~~
TypeError: unsupported operand type(s) for |: 'builtin_function_or_method' and 'NoneType'
```

## Fix

Import `Callable` from `collections.abc` and use `Callable[..., Any]` for both annotations. No runtime `callable(x)` calls exist in this file, so nothing else changes.

## Verification

- `import backend.core.cache` now succeeds (`IMPORT OK`).
- `python3 -m pytest tests/unit/ --co -q` now collects 120 tests. The 4 remaining collection errors (`ModuleNotFoundError: No module named 'cell_core'` in `tests/unit/cell/*`) are pre-existing and unrelated to this fix — out of scope here.

This unblocks the `apps/bali-intel-scraper/tests/` conftest chain, which was previously uncollectable at the root due to this single import bomb.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>