### PR TITLE
docs(kbli): A1-first sequencing ruling + extraction-gate correction

### DIFF
--- a/.agents/skills/kbli-navigator/SKILL.md
+++ b/.agents/skills/kbli-navigator/SKILL.md
@@ -26,7 +26,7 @@ pattern_, NOT the goal. The goal is a navigator where every rendered risk / lice
 fact is either government-sourced (with a citable locator + vintage) or an honest declared gap —
 zero silent cross-vintage fill anywhere in the catalog. §5 is the plan that gets us there.
 
-## 1. LIVE STATE (last update 2026-07-17 — keep current)
+## 1. LIVE STATE (last update 2026-07-18 — keep current)
 
 **Where the 1,559 actually stand (grounded on the Filiera methodology census):**
 
@@ -73,7 +73,7 @@ proven-live 4,959/4,959 at `nuzantara-backups/kbli-vault/` · OSS coverage 6,236
 vs census). **Open quarantines (proposed in PR #2622, NOT resolved):** BPS Vol.1 missing
 (Turnstile → browser lane) · Perpres-annex compiler not built · absence ≥72h window needs one
 probe after 2026-07-19T18:10Z · stray mirror copy in `nuzantara-warroom-images/kbli-vault/`
-(pre-fix run) to delete · PP28 300-dpi renders pending. **EXTRACTION GATE: D0-D6 cannot start until the PP28 300-dpi renders exist + the P1-v2 addendum lands (instrument status snapshots, OSS endpoint inventory — see #2622 conductor comment) + the P0 membership artifact is emitted.**
+(pre-fix run) to delete. **EXTRACTION GATE — collapsed to ONE precondition (updated 2026-07-18):** the gate is now just **P0 membership** (#2640 LANDING; the Detect Secrets git-SHA false-positive on `canonical_revision` was fixed via a durable auto-triage rule for `data/kbli-filiera/membership/`, proven end-to-end; auto-merge armed SQUASH). Two prior "gates" dissolved: (a) **renders are NOT a bulk pre-build** — the PP28 300-dpi renders are produced **on-demand per-code at D2** from the sha256-pinned PP28 PDFs (`pdftoppm -r 300`, deterministic, offline); (b) the **OSS endpoint inventory is DONE** (6,236/6,236 pairs, in the manifest). **P1-v2 addendum HELD until AFTER Pilota A1** — Zero ruling 2026-07-18 (_"aspetti dopo il Pilota A1 così misuriamo prima su vault-core pulito"_): Perpres 10/49 + Bali/Kepmenaker + per-instrument status snapshots come as a SECOND vault wave; `pma_status`/`l4_bali`/TKA facets **abstain fail-safe** (A1/A5/A6) this pass and are lifted later — never published wrong. **⇒ Pilota A1 starts on the OSS+PP28+BPS core the moment P0 is on main.** Genuinely-deferred (NOT gates): BPS Vol.1 (Turnstile → browser lane), absence-window one probe after 2026-07-19T18:10Z, stray warroom mirror copy to delete.
 
 **Governance flags:**
 

--- a/.claude/skills/kbli-navigator/SKILL.md
+++ b/.claude/skills/kbli-navigator/SKILL.md
@@ -26,7 +26,7 @@ pattern_, NOT the goal. The goal is a navigator where every rendered risk / lice
 fact is either government-sourced (with a citable locator + vintage) or an honest declared gap —
 zero silent cross-vintage fill anywhere in the catalog. §5 is the plan that gets us there.
 
-## 1. LIVE STATE (last update 2026-07-17 — keep current)
+## 1. LIVE STATE (last update 2026-07-18 — keep current)
 
 **Where the 1,559 actually stand (grounded on the Filiera methodology census):**
 
@@ -73,7 +73,7 @@ proven-live 4,959/4,959 at `nuzantara-backups/kbli-vault/` · OSS coverage 6,236
 vs census). **Open quarantines (proposed in PR #2622, NOT resolved):** BPS Vol.1 missing
 (Turnstile → browser lane) · Perpres-annex compiler not built · absence ≥72h window needs one
 probe after 2026-07-19T18:10Z · stray mirror copy in `nuzantara-warroom-images/kbli-vault/`
-(pre-fix run) to delete · PP28 300-dpi renders pending. **EXTRACTION GATE: D0-D6 cannot start until the PP28 300-dpi renders exist + the P1-v2 addendum lands (instrument status snapshots, OSS endpoint inventory — see #2622 conductor comment) + the P0 membership artifact is emitted.**
+(pre-fix run) to delete. **EXTRACTION GATE — collapsed to ONE precondition (updated 2026-07-18):** the gate is now just **P0 membership** (#2640 LANDING; the Detect Secrets git-SHA false-positive on `canonical_revision` was fixed via a durable auto-triage rule for `data/kbli-filiera/membership/`, proven end-to-end; auto-merge armed SQUASH). Two prior "gates" dissolved: (a) **renders are NOT a bulk pre-build** — the PP28 300-dpi renders are produced **on-demand per-code at D2** from the sha256-pinned PP28 PDFs (`pdftoppm -r 300`, deterministic, offline); (b) the **OSS endpoint inventory is DONE** (6,236/6,236 pairs, in the manifest). **P1-v2 addendum HELD until AFTER Pilota A1** — Zero ruling 2026-07-18 (_"aspetti dopo il Pilota A1 così misuriamo prima su vault-core pulito"_): Perpres 10/49 + Bali/Kepmenaker + per-instrument status snapshots come as a SECOND vault wave; `pma_status`/`l4_bali`/TKA facets **abstain fail-safe** (A1/A5/A6) this pass and are lifted later — never published wrong. **⇒ Pilota A1 starts on the OSS+PP28+BPS core the moment P0 is on main.** Genuinely-deferred (NOT gates): BPS Vol.1 (Turnstile → browser lane), absence-window one probe after 2026-07-19T18:10Z, stray warroom mirror copy to delete.
 
 **Governance flags:**
 

--- a/research/operations/2026-07-18-kbli-batch-a-plan.md
+++ b/research/operations/2026-07-18-kbli-batch-a-plan.md
@@ -167,7 +167,19 @@ A fact (risk tier, license row, authority, scale, obligation) is **CERTIFIED** o
 
 ## 8. Amendments (append-only)
 
-- (none yet)
+- **A-1 (2026-07-18, Zero) — A1-first sequencing; addendum vault wave deferred.** The P1
+  evidence classes NOT in the Batch-0 core vault (Perpres 10/49-2021 annexes, Bali Gubernur
+  overlay + Kepmenaker 228/2019 rows, per-instrument in-force/dicabut status snapshots) become a
+  **second vault wave (P1-v2) that is HELD until AFTER Pilota A1 runs** — the pilot measures on
+  the clean OSS + PP28 + BPS core first (Zero: *"aspetti dopo il Pilota A1 così misuriamo prima
+  su vault-core pulito"*). This does NOT weaken any acceptance criterion: facts depending on the
+  deferred classes (`pma_status`, `l4_bali`, TKA) come out `abstained(pending-evidence)` per
+  A1/A5, honest-gap per A6 — never certified from the core alone, never published wrong. The
+  PP28 300-dpi renders required by A3 are produced **on-demand per-code at D2** from the
+  sha256-pinned PP28 lampiran PDFs (`pdftoppm -r 300`, deterministic), so they are not a
+  bulk-prebuild precondition. Net effect: the extraction gate collapses to P0 (membership) only;
+  the addendum wave and the abstention-lifting re-run are scoped from the Pilota A1 measured
+  report alongside Batch B cadence.
 
 ## Adversarial review
 


### PR DESCRIPTION
**Zero ruling 2026-07-18** (*"aspetti dopo il Pilota A1 così misuriamo prima su vault-core pulito"*): the P1-v2 vault addendum (Perpres 10/49 + Bali Gubernur overlay + Kepmenaker 228/2019 + per-instrument in-force/dicabut status snapshots) is **HELD until AFTER Pilota A1**. The pilot measures on the clean OSS+PP28+BPS core first; the addendum wave + abstention-lifting re-run are scoped from the pilot's measured report.

## Changes
- **kbli-navigator corner** (`.claude` + `.agents` mirrors, byte-identical): §1 LIVE STATE extraction-gate block rewritten. The gate was **stale** — it claimed D0-D6 is blocked by PP28 300-dpi renders + the addendum + P0. Corrected:
  - renders are produced **on-demand per-code at D2** from the sha256-pinned PP28 PDFs (`pdftoppm -r 300`, deterministic) — not a bulk pre-build;
  - the OSS endpoint inventory is **DONE** (6,236/6,236 pairs, in the manifest);
  - the addendum is **deferred by ruling**, not a gate.
  - Net: the gate collapses to **P0** (membership, #2640 **MERGED** — the Detect Secrets git-SHA false-positive was fixed). A reader-lane would have wrongly held extraction on the stale text.
- **Batch A plan §8** (append-only): amendment **A-1** records the ruling. **No acceptance criterion weakened** — facts needing the deferred classes (`pma_status`/`l4_bali`/TKA) come out `abstained(pending-evidence)` per A1/A5, honest-gap per A6; never certified from the core alone, never published wrong.

Docs-only. Prettier + pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)