### PR TITLE
feat(intake): review-refinery pilot + /intake skill

### DIFF
--- a/.claude/skills/intake/SKILL.md
+++ b/.claude/skills/intake/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: intake
+description: "Intake corner — the live shared context for the document-intake organism (WhatsApp/Drive docs → OCR → classify → extract → route → attach-to-client). Load BEFORE touching the intake pipeline, the review_pending queue, the refinery pilot, the auto-attach gates, or the CRM writer — or when Zero says /intake, 'coda intake', 'review queue', 'auto-attach', 'refinery'. Holds: the north star (drain the queue with ZERO mis-attribution), the anatomy map (every table/file/gate/flag), the tier logic, LIVE STATE, and the blood-bought rules (2026-05-17 identity-hallucination scar)."
+---
+
+# INTAKE — the document-intake organism
+
+> **North star:** every document that arrives (passport, KITAS, visa, KTP, akta, NIB, NPWP,
+> bank statement…) lands attached to the RIGHT client, or is honestly quarantined — **never
+> attached to the wrong person.** The backlog is finite (~35.8k `review_pending`); drain it by
+> corroboration, not by guessing. **A wrong attach is worse than an unattached doc** (2026-05-17
+> scar: name-frequency auto-attach → 12 mis-attributed summaries purged by hand).
+
+---
+
+## 0. The one rule that governs everything
+
+**Auto-commit ONLY on strong-identifier corroboration** (passport / KITAS / NPWP / NIK **number equal**
+between the document and the client record). **Name-only is NEVER an auto-commit** — it is the exact
+failure mode of the 2026-05-17 identity-hallucination scar. Name-only, at most, pre-fills a decision;
+it never writes autonomously without a second concordant signal. The refinery may **quarantine** (say
+"not attachable") — that is a correct terminal state, not a failure. Forcing an attach on the ~25k
+no-match mountain is forbidden.
+
+---
+
+## 1. Anatomy — where the organism lives
+
+**DB (LOCAL, not Fly — scar W87):** `nuzantara_dev` on `127.0.0.1:5432`, user `nuzantara` (trust auth,
+SELECT-only for inspection). The MCP `postgres-nuzantara` points at PROD and is the WRONG store for
+intake — always use the local dev DB for intake work.
+
+Core tables:
+| Table | Key columns |
+|---|---|
+| `document_routing_proposal` (`p`) | `id`, `queue_id`, `status` (**review_pending** / review_claimed / routed / **auto_routed**), `entity_resolution` (JSON: `candidates[]{table,id}`, `doc_type`, `decision`), `routing` (JSON: `fields`, `decision`), `commit_gate` |
+| `intake_queue` (`q`) | `id`, `stage_output` (JSON: `classify.ocr_text_per_page[]`, `extract.fields`, `ocr.pages[]`), `source`, `source_ref`, `blob_hash`, `pipeline_version` |
+| `intake_commit_audit` | `proposal_id`, `client_id`, `outcome` (dry_run/blocked/committed/failed/rolled_back), `committed_by`, `dry_run` (bool) — every decision recorded, reversible |
+| `clients` | `id`, `full_name`, `phone_normalized`, `passport_number`, `kitas_number`, `nationality`, `deleted_at` (soft-delete) |
+
+**Extracted fields shape:** `routing.fields` (fallback `stage_output.extract.fields`); each value is
+`{value, confidence, source_page}` or a scalar. Strong-id keys: `passport_no`, `kitas_no`.
+**Strong-id normalization (canonical):** `re.sub(r"[^A-Za-z0-9]","",str(v)).upper()`, keep only `len>=6`.
+
+**Pipeline (code, in `apps/backend-rag/backend/services/intake/`):**
+
+- `routing.py:1290` → `_try_auto_attach_after_route()` runs the auto-attach gates right after a proposal is routed.
+- `auto_attach.py` — the 3 **already-built, tested** gates (all default OFF):
+  - `try_auto_attach` (LEVA-2): strong-id ⟂ **phone** concordance.
+  - `try_direct_phone_auto_attach`: direct-chat phone-only.
+  - `try_nameid_auto_attach` (LEVA-3): strong-id + document-subject-**name** concordance (no-phone sources).
+- `writer.py` — the SINGLE safe commit path (reuse it, never raw SQL):
+  - `plan_commit(proposal, conn, *, committed_by, override_client_id=None, …) -> CommitPlan` (`.blocked`, `.block_reasons`, `.ops`). READ-ONLY; validates against current DB (P0#3: e.g. **soft-deleted client → blocked**).
+  - `execute_commit(plan, conn, *, dry_run=True, advance_from="review_claimed", advance_to="routed") -> CommitResult` (`.outcome`, `.audit_id`). System auto-attach uses `advance_from="review_pending", advance_to="auto_routed"`. `dry_run=False` **requires** `INTAKE_WRITER_ENABLED` truthy, else raises before any write.
+  - `rollback_commit(conn, client_id=…, idempotency_key=…, committed_by=…)` — detaches + reopens the proposal.
+- `extract.py` — field extraction; `client_enricher.py` — writes doc strong-id onto the client (backfill primitive), same TX as the doc write.
+
+**Feature flags (env, read at call time, ALL default OFF; both the specific flag AND `INTAKE_WRITER_ENABLED` must be on for any autonomous write):**
+`INTAKE_WRITER_ENABLED` · `INTAKE_AUTO_ATTACH_ENABLED` · `INTAKE_DIRECT_PHONE_AUTO_ATTACH_ENABLED` · `INTAKE_NAMEID_AUTO_ATTACH_ENABLED`.
+**Arming pattern:** for a surgical batch, set the flags **in the batch process env only** (never flip the live routing daemon / never a Fly secret) → blast radius = exactly the proposals the batch iterates.
+
+---
+
+## 2. The tier logic (what may write, and how)
+
+| Tier                                                           | Signal                                             | Precision (135 ground-truth)                                   | Headless?                                   |
+| -------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------- |
+| **Deterministic strong-id**                                    | doc passport/kitas == candidate's, exactly 1 match | **61/61 = 100%**                                               | ✅ safe — arm it                            |
+| Panel-unanimous name-only + 2nd signal (phone/nationality/DOB) | both LLMs MATCH same client + a corroborator       | ~100% in-sample (survivor bias)                                | ⚠️ only with the raised bar, measured first |
+| Single-model name-only                                         | one LLM MATCH, dissent                             | **owns the only error** (prop 12923: picked 4037 vs truth 659) | ❌ quarantine, never auto                   |
+| No match / 0-candidate                                         | —                                                  | —                                                              | quarantine (correct terminal state)         |
+
+**Ambiguity even at strong-id level:** if a doc strong-id matches **>1** client → exclude (data-quality
+lead, usually duplicate client records — see the 62130 case, 7 clients one passport).
+
+---
+
+## 3. The refinery pilot (the measuring instrument)
+
+`scripts/intake_refinery_pilot.py` (worktree `backend-rag-intake-refinery`). Panel = `qwen3.5:9b` +
+`aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m` (local Ollama, `think:false`, `format:json`) + DeepSeek
+(dead, 402). Modes: `--mode groundtruth` (precision vs `intake_commit_audit` committed truth) /
+`--mode sample-review` (dry triage of `review_pending`). Run: `cd apps/backend-rag && source .venv/bin/activate`
+then `PYTHONPATH=. python scripts/intake_refinery_pilot.py --mode groundtruth --limit 135`.
+
+**Proven findings (2026-07-18):**
+
+- **Panel width / model strength is SECOND-ORDER.** SEA-LION-32B over qwen-9B added **0** auto-commits
+  (rescued 1 NONE→triage-candidate). The auto-commit bottleneck is **structural** (CRM has ~2.6% passport,
+  0% kitas) — no model can corroborate against absent data. A cloud seat (GLM etc.) is not the lever.
+- Deterministic tier: **100% precision**. Name-only single-model owns the only observed error.
+
+---
+
+## 4. Sizing of the 35,796 `review_pending` (read-only scan, 2026-07-18)
+
+- `HAS_DOC_STRONGID` = **5,147** (passport 3,783 / kitas 920 / visa 444).
+- `DET_MATCH_NOW` ≈ **20-21** — doc strong-id already equals a candidate → auto-committable today.
+- `N1_BACKFILL_FUEL` = **1,338** — single-candidate + doc strong-id the client LACKS → each confirmed
+  attach writes that id onto the client (`client_enricher.py`), compounding future auto-corroboration.
+- **~25,402 (71%) zero-candidate** — strong-id CORROBORATES, it does not FIND → needs Station 1+2
+  (re-OCR + all-clients strong-id/name re-search). This is the volume; the panel does not touch it.
+
+**The levers, in order of volume:** identity-backfill (1,338) + re-OCR/re-search (25k) ≫ deterministic
+tier (20) ≫ panel width (0). Reviewers/LLMs drain the human tail; they do not replace the missing
+structural signal.
+
+---
+
+## 5. LIVE STATE (update on every material change)
+
+- **2026-07-18:** deterministic tier proven (61/61) + **18 documents auto-attached** via `plan_commit`/
+  `execute_commit` (tag `committed_by='system:refinery-deterministic'`, `review_pending`→`auto_routed`,
+  reversible). Pilot v2 committed (`a4914660b`, adds SEA-LION panel + N-model gate).
+- **OPEN — 3 soft-deleted-client proposals** (82041/82021/82034 → client 10236, `deleted_at` set):
+  correctly refused by the writer, still `review_pending`. Decision: restore client vs re-route vs human.
+- **OPEN — dedup anomaly 62130:** 7 clients share one normalized passport → likely duplicate client
+  records; a direct lead into the CRM dedup problem.
+- **NOT DONE — entry leak** (~3,084 wa-mirror rows never enqueued, ~80/day) + **1,345 rows frozen
+  mid-pipeline since 2026-06-20** — separate upstream levers; the refinery drains, the leak bleeds.
+
+---
+
+## 6. Blood-bought rules (scars)
+
+- **2026-05-17 identity-hallucination:** name-frequency auto-attach mis-attributed 12 → **never
+  name-only auto**. Strong-id corroboration or quarantine.
+- **W65 generator≠grader:** the model that proposes a match never grades it. The refinery uses a
+  separate panel; any "confirmed" verdict is re-checked, not trusted.
+- **W87 postgres access-wall:** intake lives on LOCAL `nuzantara_dev`, NOT the Fly-prod MCP. `✔ Connected`
+  ≠ auth+query.
+- **W96 test-writes-prod:** intake tests must redirect output/DB to fixtures, never touch the real queue.
+- **Law 2 (UU PDP):** the refinery's _output_ is an attach decision (doc_id→client_id) INSIDE the system.
+  Reports / memories / logs / skills **never** transcribe client PII (names, passport/kitas VALUES,
+  phones) in clear — integers, `client_id`, field-name-matched only. Processing may use context; output may not.
+- **Reversibility:** dry_run → measured precision → real write in batches, with `intake_commit_audit`
+  - `rollback_commit` + a kill-switch (the flags). Never a blind mass write.
+
+---
+
+## 7. Design spec + references
+
+- Full station design (Station 0 dedup/junk → 1 re-extract → 2 candidate-regen → 3 panel → 4 gate →
+  5 commit): scratchpad `intake-refinery-design.md`.
+- Memory: `discovery_refinery_panel_width_is_second_order_2026_07_18` (findings + sizing + precision).
+- Writer/gate code is the ground truth — re-read `writer.py` / `auto_attach.py` in-turn before any mutation
+  (anti-hallucination: never build on a remembered signature).

--- a/scripts/intake_refinery_pilot.py
+++ b/scripts/intake_refinery_pilot.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Intake Review Refinery — PILOT (measurement only, ZERO writes).
+
+Reads review-proposal evidence from local nuzantara_dev (read-only role), runs a
+single-LLM adjudication pass (local Ollama qwen3.5:9b), and compares the verdict to
+ground truth. Emits ONLY redacted output (client_id ints, match booleans, scores) —
+never client names / passport numbers / OCR text (SYMBIOSIS Law-2 output boundary held
+even though processing is Law-2-waived for this mission).
+
+Usage:
+  PYTHONPATH=. .venv/bin/python scripts/intake_refinery_pilot.py --mode groundtruth --limit 8
+  PYTHONPATH=. .venv/bin/python scripts/intake_refinery_pilot.py --mode sample-review --limit 5
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import subprocess
+from typing import Any
+
+import asyncpg
+import httpx
+
+OLLAMA = "http://127.0.0.1:11434/api/generate"
+MODEL = "qwen3.5:9b"
+
+# Ground-truth: auto_routed proposals whose committed client_id we trust as the label.
+GROUNDTRUTH: list[tuple[int, int]] = [
+    (111537, 10226), (108983, 6927), (100334, 7315), (99685, 10214),
+    (99678, 6299), (87241, 10487), (86817, 10587), (86534, 10522),
+    (80767, 10339), (80338, 10382), (73465, 10273), (73307, 10280),
+]
+
+
+async def _connect() -> asyncpg.Connection:
+    # Local nuzantara_dev via trust auth (user=nuzantara). Script is SELECT-only by construction.
+    return await asyncpg.connect(
+        host="127.0.0.1", port=5432, user="nuzantara", database="nuzantara_dev",
+    )
+
+
+def _ocr_text(stage_output: dict[str, Any], max_chars: int = 4000) -> str:
+    """Assemble OCR text from stage_output (classify holds it per the reader map)."""
+    classify = stage_output.get("classify") or {}
+    pages = classify.get("ocr_text_per_page")
+    if isinstance(pages, list):
+        text = "\n".join(p.get("text", "") if isinstance(p, dict) else str(p) for p in pages)
+    else:
+        ocr = stage_output.get("ocr") or {}
+        pgs = ocr.get("pages") or []
+        text = "\n".join(p.get("text", "") for p in pgs if isinstance(p, dict))
+    return text[:max_chars]
+
+
+def _extract_fields(stage_output: dict[str, Any], routing: dict[str, Any]) -> dict[str, Any]:
+    fields = (routing or {}).get("fields") or (stage_output.get("extract") or {}).get("fields") or {}
+    out = {}
+    for k, v in fields.items():
+        if isinstance(v, dict):
+            out[k] = v.get("value")
+        else:
+            out[k] = v
+    return {k: v for k, v in out.items() if v}
+
+
+async def _candidate_clients(conn: asyncpg.Connection, candidates: list[dict]) -> list[dict]:
+    """Fetch match-fields for each candidate client (name/phone/passport/kitas/nationality)."""
+    ids = [c["id"] for c in candidates if c.get("table") == "clients" and c.get("id")]
+    if not ids:
+        return []
+    rows = await conn.fetch(
+        "SELECT id, full_name, phone_normalized, passport_number, kitas_number, nationality "
+        "FROM clients WHERE id = ANY($1::int[]) AND deleted_at IS NULL", ids,
+    )
+    return [dict(r) for r in rows]
+
+
+ADJUDICATE_PROMPT = """You are a strict document-to-client matcher for an Indonesian immigration agency.
+Given a document's OCR text + extracted fields, and a list of candidate clients, decide which candidate
+client is the SUBJECT of this document (the person the document is ABOUT — not who forwarded it).
+
+Rules:
+- Match on strong identifiers first: passport number, KITAS number. If the document's passport/KITAS
+  number equals a candidate's, that candidate is the subject with high confidence.
+- Then match on full name (the name printed ON the document vs the candidate's full_name).
+- A phone match alone is WEAK: the sender may be a staff member forwarding a client's document.
+- If NO candidate is the subject, answer NONE. If two candidates are equally plausible, answer AMBIGUOUS.
+- Never guess from frequency or folder names.
+
+Return ONLY compact JSON: {"client_id": <int|null>, "verdict": "MATCH"|"NONE"|"AMBIGUOUS",
+"confidence": <0..1>, "matched_on": "passport"|"kitas"|"name"|"phone"|"none"}
+
+DOCUMENT:
+doc_type: {doc_type}
+extracted_fields: {fields}
+ocr_text (truncated):
+{ocr}
+
+CANDIDATE CLIENTS:
+{candidates}
+"""
+
+
+async def _adjudicate(client: httpx.AsyncClient, bundle: dict) -> dict:
+    prompt = (ADJUDICATE_PROMPT
+              .replace("{doc_type}", str(bundle["doc_type"]))
+              .replace("{fields}", json.dumps(bundle["fields"], ensure_ascii=False))
+              .replace("{ocr}", bundle["ocr"])
+              .replace("{candidates}", json.dumps(bundle["candidates"], ensure_ascii=False)))
+    r = await client.post(OLLAMA, json={
+        "model": MODEL, "prompt": prompt, "stream": False,
+        "think": False, "format": "json", "keep_alive": "5m",
+        "options": {"temperature": 0.0, "num_predict": 200},
+    }, timeout=120)
+    r.raise_for_status()
+    resp = r.json().get("response", "{}")
+    try:
+        return json.loads(resp)
+    except json.JSONDecodeError:
+        return {"client_id": None, "verdict": "PARSE_ERROR", "confidence": 0.0, "matched_on": "none"}
+
+
+async def _evidence_bundle(conn: asyncpg.Connection, proposal_id: int) -> dict | None:
+    row = await conn.fetchrow(
+        "SELECT p.entity_resolution, p.routing, p.commit_gate, q.stage_output "
+        "FROM document_routing_proposal p JOIN intake_queue q ON q.id=p.queue_id WHERE p.id=$1",
+        proposal_id,
+    )
+    if not row:
+        return None
+    er = json.loads(row["entity_resolution"]) if isinstance(row["entity_resolution"], str) else (row["entity_resolution"] or {})
+    routing = json.loads(row["routing"]) if isinstance(row["routing"], str) else (row["routing"] or {})
+    so = json.loads(row["stage_output"]) if isinstance(row["stage_output"], str) else (row["stage_output"] or {})
+    candidates = er.get("candidates") or []
+    cand_clients = await _candidate_clients(conn, candidates)
+    # Redact candidate presentation for the LLM: keep name+identifiers (processing allowed, Law2 waived).
+    cand_view = [{
+        "client_id": c["id"], "full_name": c.get("full_name"),
+        "passport_number": c.get("passport_number"), "kitas_number": c.get("kitas_number"),
+        "phone": c.get("phone_normalized"), "nationality": c.get("nationality"),
+    } for c in cand_clients]
+    return {
+        "proposal_id": proposal_id,
+        "doc_type": er.get("doc_type") or routing.get("doc_type") or "unknown",
+        "fields": _extract_fields(so, routing),
+        "ocr": _ocr_text(so),
+        "candidates": cand_view,
+        "n_candidates": len(candidates),
+    }
+
+
+async def run(mode: str, limit: int) -> None:
+    conn = await _connect()
+    try:
+        if mode == "groundtruth":
+            targets = GROUNDTRUTH[:limit]
+        else:
+            rows = await conn.fetch(
+                "SELECT p.id FROM document_routing_proposal p "
+                "WHERE p.status='review_pending' AND p.entity_resolution->>'decision'='AMBIGUOUS' "
+                "ORDER BY p.created_at DESC LIMIT $1", limit,
+            )
+            targets = [(r["id"], None) for r in rows]
+
+        agree = 0
+        total = 0
+        async with httpx.AsyncClient() as http:
+            for proposal_id, truth in targets:
+                bundle = await _evidence_bundle(conn, proposal_id)
+                if bundle is None:
+                    print(f"proposal={proposal_id} MISSING")
+                    continue
+                verdict = await _adjudicate(http, bundle)
+                total += 1
+                picked = verdict.get("client_id")
+                match_truth = (truth is not None and picked == truth)
+                if match_truth:
+                    agree += 1
+                # REDACTED output only: ids, verdict, confidence, matched_on, ocr length.
+                print(json.dumps({
+                    "proposal": proposal_id, "truth_client": truth,
+                    "picked_client": picked, "verdict": verdict.get("verdict"),
+                    "matched_on": verdict.get("matched_on"), "conf": verdict.get("confidence"),
+                    "n_cand": bundle["n_candidates"], "ocr_chars": len(bundle["ocr"]),
+                    "agrees_with_truth": match_truth if truth is not None else None,
+                }, ensure_ascii=False))
+        if mode == "groundtruth" and total:
+            print(f"\nGROUNDTRUTH AGREEMENT: {agree}/{total} = {agree/total:.0%}")
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["groundtruth", "sample-review"], default="groundtruth")
+    ap.add_argument("--limit", type=int, default=8)
+    args = ap.parse_args()
+    asyncio.run(run(args.mode, args.limit))

--- a/scripts/intake_refinery_pilot.py
+++ b/scripts/intake_refinery_pilot.py
@@ -26,6 +26,7 @@ import httpx
 
 OLLAMA = "http://127.0.0.1:11434/api/generate"
 MODEL = "qwen3.5:9b"
+SECOND_MODEL = "aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m"
 DEEPSEEK_URL = "https://api.deepseek.com/chat/completions"
 DEEPSEEK_MODEL = "deepseek-v4-pro"
 
@@ -137,12 +138,12 @@ def _safe_json(s: str) -> dict:
     return {"client_id": None, "verdict": "PARSE_ERROR", "confidence": 0.0, "matched_on": "none"}
 
 
-async def _ollama_adjudicate(client: httpx.AsyncClient, bundle: dict) -> dict:
+async def _ollama_adjudicate(client: httpx.AsyncClient, bundle: dict, model: str = MODEL) -> dict:
     r = await client.post(OLLAMA, json={
-        "model": MODEL, "prompt": _build_prompt(bundle), "stream": False,
-        "think": False, "format": "json", "keep_alive": "5m",
+        "model": model, "prompt": _build_prompt(bundle), "stream": False,
+        "think": False, "format": "json", "keep_alive": "10m",
         "options": {"temperature": 0.0, "num_predict": 200},
-    }, timeout=120)
+    }, timeout=300)
     r.raise_for_status()
     return _safe_json(r.json().get("response", "{}"))
 
@@ -205,22 +206,25 @@ def _to_int(v: Any) -> int | None:
         return None
 
 
-def _gate(bundle: dict, oll: dict, ds: dict) -> tuple[str, int | None, str]:
-    """Return (tier, client_id, reason). tier in AUTO_COMMIT / HUMAN_CONFIRM / NONE."""
+def _gate(bundle: dict, verdicts: list[dict]) -> tuple[str, int | None, str]:
+    """Gate on deterministic strong-id + agreement among the ALIVE panel models.
+    tier in AUTO_COMMIT / HUMAN_CONFIRM / NONE."""
     if bundle["det_client"] is not None:
         return "AUTO_COMMIT", bundle["det_client"], f"deterministic strong-id ({bundle['det_on']})"
-    o_id, d_id = _to_int(oll.get("client_id")), _to_int(ds.get("client_id"))
-    o_ok = oll.get("verdict") == "MATCH" and o_id is not None
-    d_ok = ds.get("verdict") == "MATCH" and d_id is not None
-    if o_ok and d_ok and o_id == d_id:
-        strong = oll.get("matched_on") in ("passport", "kitas") or ds.get("matched_on") in ("passport", "kitas")
-        return ("AUTO_COMMIT" if strong else "HUMAN_CONFIRM", o_id,
-                "panel agree + strong-id" if strong else "panel agree, name-only")
-    if o_ok and d_ok and o_id != d_id:
-        return "HUMAN_CONFIRM", None, "panel split on client"
-    if o_ok or d_ok:
-        return "HUMAN_CONFIRM", (o_id if o_ok else d_id), "single-model match"
-    return "NONE", None, "no model match"
+    picks = [(_to_int(v.get("client_id")), v.get("matched_on"))
+             for v in verdicts if v.get("verdict") == "MATCH" and _to_int(v.get("client_id"))]
+    if not picks:
+        return "NONE", None, "no model match"
+    ids = [p[0] for p in picks]
+    top = max(set(ids), key=ids.count)
+    agree = ids.count(top)
+    strong = any(mo in ("passport", "kitas") for pid, mo in picks if pid == top)
+    if agree >= 2 and len(set(ids)) == 1:  # unanimous among the alive models
+        return ("AUTO_COMMIT" if strong else "HUMAN_CONFIRM", top,
+                "panel unanimous + strong-id" if strong else "panel unanimous, name-only")
+    if agree >= 2:
+        return "HUMAN_CONFIRM", top, "panel majority (some dissent)"
+    return "HUMAN_CONFIRM", top, "single-model match"
 
 
 async def run(mode: str, limit: int) -> None:
@@ -248,7 +252,8 @@ async def run(mode: str, limit: int) -> None:
                 bundle = await _evidence_bundle(conn, proposal_id)
                 if bundle is None:
                     continue
-                oll = await _ollama_adjudicate(http, bundle)
+                oll = await _ollama_adjudicate(http, bundle, MODEL)
+                sea = await _ollama_adjudicate(http, bundle, SECOND_MODEL)
                 ds = {"verdict": "SKIP"}
                 if ds_key:
                     try:
@@ -256,7 +261,7 @@ async def run(mode: str, limit: int) -> None:
                     except (httpx.HTTPError, KeyError) as exc:
                         nonlocal_ds_err.append(str(exc)[:80])
                         ds = {"verdict": "ERR"}
-                tier, cid, reason = _gate(bundle, oll, ds)
+                tier, cid, reason = _gate(bundle, [oll, sea, ds])
                 tiers[tier] += 1
                 if truth is not None:
                     gt_total += 1
@@ -267,7 +272,7 @@ async def run(mode: str, limit: int) -> None:
                 print(json.dumps({
                     "proposal": proposal_id, "truth": truth, "tier": tier, "picked": cid,
                     "reason": reason, "n_cand": bundle["n_candidates"], "det": bundle["det_on"],
-                    "oll": oll.get("verdict"), "ds": ds.get("verdict"),
+                    "qwen": oll.get("verdict"), "sealion": sea.get("verdict"), "ds": ds.get("verdict"),
                     "auto_ok": (cid == truth) if (truth is not None and tier == "AUTO_COMMIT") else None,
                 }, ensure_ascii=False))
         n = sum(tiers.values())

--- a/scripts/intake_refinery_pilot.py
+++ b/scripts/intake_refinery_pilot.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import subprocess
+import os
+import re
+from pathlib import Path
 from typing import Any
 
 import asyncpg
@@ -24,13 +26,25 @@ import httpx
 
 OLLAMA = "http://127.0.0.1:11434/api/generate"
 MODEL = "qwen3.5:9b"
+DEEPSEEK_URL = "https://api.deepseek.com/chat/completions"
+DEEPSEEK_MODEL = "deepseek-v4-pro"
 
-# Ground-truth: auto_routed proposals whose committed client_id we trust as the label.
-GROUNDTRUTH: list[tuple[int, int]] = [
-    (111537, 10226), (108983, 6927), (100334, 7315), (99685, 10214),
-    (99678, 6299), (87241, 10487), (86817, 10587), (86534, 10522),
-    (80767, 10339), (80338, 10382), (73465, 10273), (73307, 10280),
-]
+
+def _deepseek_key() -> str | None:
+    env = Path.home() / ".openclaw/workspace/.env.master"
+    if not env.exists():
+        return None
+    for line in env.read_text().splitlines():
+        if line.startswith("DEEPSEEK_API_KEY="):
+            return line.split("=", 1)[1].strip().strip('"')
+    return None
+
+
+def _norm_id(v: str | None) -> str | None:
+    if not v:
+        return None
+    s = re.sub(r"[^A-Za-z0-9]", "", str(v)).upper()
+    return s if len(s) >= 6 else None
 
 
 async def _connect() -> asyncpg.Connection:
@@ -102,23 +116,45 @@ CANDIDATE CLIENTS:
 """
 
 
-async def _adjudicate(client: httpx.AsyncClient, bundle: dict) -> dict:
-    prompt = (ADJUDICATE_PROMPT
-              .replace("{doc_type}", str(bundle["doc_type"]))
-              .replace("{fields}", json.dumps(bundle["fields"], ensure_ascii=False))
-              .replace("{ocr}", bundle["ocr"])
-              .replace("{candidates}", json.dumps(bundle["candidates"], ensure_ascii=False)))
+def _build_prompt(bundle: dict) -> str:
+    return (ADJUDICATE_PROMPT
+            .replace("{doc_type}", str(bundle["doc_type"]))
+            .replace("{fields}", json.dumps(bundle["fields"], ensure_ascii=False))
+            .replace("{ocr}", bundle["ocr"])
+            .replace("{candidates}", json.dumps(bundle["candidates"], ensure_ascii=False)))
+
+
+def _safe_json(s: str) -> dict:
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, TypeError):
+        m = re.search(r"\{.*\}", s or "", re.DOTALL)
+        if m:
+            try:
+                return json.loads(m.group(0))
+            except json.JSONDecodeError:
+                pass
+    return {"client_id": None, "verdict": "PARSE_ERROR", "confidence": 0.0, "matched_on": "none"}
+
+
+async def _ollama_adjudicate(client: httpx.AsyncClient, bundle: dict) -> dict:
     r = await client.post(OLLAMA, json={
-        "model": MODEL, "prompt": prompt, "stream": False,
+        "model": MODEL, "prompt": _build_prompt(bundle), "stream": False,
         "think": False, "format": "json", "keep_alive": "5m",
         "options": {"temperature": 0.0, "num_predict": 200},
     }, timeout=120)
     r.raise_for_status()
-    resp = r.json().get("response", "{}")
-    try:
-        return json.loads(resp)
-    except json.JSONDecodeError:
-        return {"client_id": None, "verdict": "PARSE_ERROR", "confidence": 0.0, "matched_on": "none"}
+    return _safe_json(r.json().get("response", "{}"))
+
+
+async def _deepseek_adjudicate(client: httpx.AsyncClient, bundle: dict, key: str) -> dict:
+    r = await client.post(DEEPSEEK_URL, headers={"Authorization": f"Bearer {key}"}, json={
+        "model": DEEPSEEK_MODEL, "temperature": 0.0,
+        "response_format": {"type": "json_object"},
+        "messages": [{"role": "user", "content": _build_prompt(bundle)}],
+    }, timeout=120)
+    r.raise_for_status()
+    return _safe_json(r.json()["choices"][0]["message"]["content"])
 
 
 async def _evidence_bundle(conn: asyncpg.Connection, proposal_id: int) -> dict | None:
@@ -140,53 +176,110 @@ async def _evidence_bundle(conn: asyncpg.Connection, proposal_id: int) -> dict |
         "passport_number": c.get("passport_number"), "kitas_number": c.get("kitas_number"),
         "phone": c.get("phone_normalized"), "nationality": c.get("nationality"),
     } for c in cand_clients]
+    fields = _extract_fields(so, routing)
+    # STATION 4-pre: deterministic strong-id tiebreak (zero-risk) — doc's passport/kitas vs candidates'.
+    doc_pp, doc_kt = _norm_id(fields.get("passport_no")), _norm_id(fields.get("kitas_no"))
+    det_hits = []
+    for c in cand_clients:
+        if doc_pp and _norm_id(c.get("passport_number")) == doc_pp:
+            det_hits.append((c["id"], "passport"))
+        elif doc_kt and _norm_id(c.get("kitas_number")) == doc_kt:
+            det_hits.append((c["id"], "kitas"))
+    det_client = det_hits[0][0] if len(det_hits) == 1 else None
+    det_on = det_hits[0][1] if len(det_hits) == 1 else None
     return {
         "proposal_id": proposal_id,
         "doc_type": er.get("doc_type") or routing.get("doc_type") or "unknown",
-        "fields": _extract_fields(so, routing),
+        "fields": fields,
         "ocr": _ocr_text(so),
         "candidates": cand_view,
         "n_candidates": len(candidates),
+        "det_client": det_client, "det_on": det_on,
     }
+
+
+def _to_int(v: Any) -> int | None:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _gate(bundle: dict, oll: dict, ds: dict) -> tuple[str, int | None, str]:
+    """Return (tier, client_id, reason). tier in AUTO_COMMIT / HUMAN_CONFIRM / NONE."""
+    if bundle["det_client"] is not None:
+        return "AUTO_COMMIT", bundle["det_client"], f"deterministic strong-id ({bundle['det_on']})"
+    o_id, d_id = _to_int(oll.get("client_id")), _to_int(ds.get("client_id"))
+    o_ok = oll.get("verdict") == "MATCH" and o_id is not None
+    d_ok = ds.get("verdict") == "MATCH" and d_id is not None
+    if o_ok and d_ok and o_id == d_id:
+        strong = oll.get("matched_on") in ("passport", "kitas") or ds.get("matched_on") in ("passport", "kitas")
+        return ("AUTO_COMMIT" if strong else "HUMAN_CONFIRM", o_id,
+                "panel agree + strong-id" if strong else "panel agree, name-only")
+    if o_ok and d_ok and o_id != d_id:
+        return "HUMAN_CONFIRM", None, "panel split on client"
+    if o_ok or d_ok:
+        return "HUMAN_CONFIRM", (o_id if o_ok else d_id), "single-model match"
+    return "NONE", None, "no model match"
 
 
 async def run(mode: str, limit: int) -> None:
     conn = await _connect()
+    ds_key = _deepseek_key()
     try:
         if mode == "groundtruth":
-            targets = GROUNDTRUTH[:limit]
+            rows = await conn.fetch(
+                "SELECT p.id, a.client_id FROM document_routing_proposal p "
+                "JOIN intake_commit_audit a ON a.proposal_id=p.id "
+                "WHERE p.status IN ('routed','auto_routed') AND a.outcome='committed' "
+                "AND a.client_id IS NOT NULL ORDER BY a.committed_at DESC LIMIT $1", limit)
+            targets = [(r["id"], r["client_id"]) for r in rows]
         else:
             rows = await conn.fetch(
                 "SELECT p.id FROM document_routing_proposal p "
-                "WHERE p.status='review_pending' AND p.entity_resolution->>'decision'='AMBIGUOUS' "
-                "ORDER BY p.created_at DESC LIMIT $1", limit,
-            )
+                "WHERE p.status='review_pending' ORDER BY p.created_at DESC LIMIT $1", limit)
             targets = [(r["id"], None) for r in rows]
 
-        agree = 0
-        total = 0
+        tiers = {"AUTO_COMMIT": 0, "HUMAN_CONFIRM": 0, "NONE": 0}
+        auto_correct = auto_total = gt_total = 0
+        nonlocal_ds_err: list[str] = []
         async with httpx.AsyncClient() as http:
             for proposal_id, truth in targets:
                 bundle = await _evidence_bundle(conn, proposal_id)
                 if bundle is None:
-                    print(f"proposal={proposal_id} MISSING")
                     continue
-                verdict = await _adjudicate(http, bundle)
-                total += 1
-                picked = verdict.get("client_id")
-                match_truth = (truth is not None and picked == truth)
-                if match_truth:
-                    agree += 1
-                # REDACTED output only: ids, verdict, confidence, matched_on, ocr length.
+                oll = await _ollama_adjudicate(http, bundle)
+                ds = {"verdict": "SKIP"}
+                if ds_key:
+                    try:
+                        ds = await _deepseek_adjudicate(http, bundle, ds_key)
+                    except (httpx.HTTPError, KeyError) as exc:
+                        nonlocal_ds_err.append(str(exc)[:80])
+                        ds = {"verdict": "ERR"}
+                tier, cid, reason = _gate(bundle, oll, ds)
+                tiers[tier] += 1
+                if truth is not None:
+                    gt_total += 1
+                    if tier == "AUTO_COMMIT":
+                        auto_total += 1
+                        if cid == truth:
+                            auto_correct += 1
                 print(json.dumps({
-                    "proposal": proposal_id, "truth_client": truth,
-                    "picked_client": picked, "verdict": verdict.get("verdict"),
-                    "matched_on": verdict.get("matched_on"), "conf": verdict.get("confidence"),
-                    "n_cand": bundle["n_candidates"], "ocr_chars": len(bundle["ocr"]),
-                    "agrees_with_truth": match_truth if truth is not None else None,
+                    "proposal": proposal_id, "truth": truth, "tier": tier, "picked": cid,
+                    "reason": reason, "n_cand": bundle["n_candidates"], "det": bundle["det_on"],
+                    "oll": oll.get("verdict"), "ds": ds.get("verdict"),
+                    "auto_ok": (cid == truth) if (truth is not None and tier == "AUTO_COMMIT") else None,
                 }, ensure_ascii=False))
-        if mode == "groundtruth" and total:
-            print(f"\nGROUNDTRUTH AGREEMENT: {agree}/{total} = {agree/total:.0%}")
+        n = sum(tiers.values())
+        print(f"\nTIERS: {tiers}  (n={n})")
+        if n:
+            print(f"COVERAGE auto-commit: {tiers['AUTO_COMMIT']}/{n} = {tiers['AUTO_COMMIT']/n:.0%}")
+        if auto_total:
+            print(f"AUTO-COMMIT PRECISION vs ground truth: {auto_correct}/{auto_total} = {auto_correct/auto_total:.0%}")
+        if gt_total:
+            print(f"(ground-truth rows evaluated: {gt_total})")
+        if nonlocal_ds_err:
+            print(f"DEEPSEEK DEGRADED: {len(nonlocal_ds_err)} errors, e.g. {nonlocal_ds_err[0]}")
     finally:
         await conn.close()
 


### PR DESCRIPTION
## What

- **`scripts/intake_refinery_pilot.py`** — read-only multi-LLM adjudication harness for the intake `review_pending` backlog. Panel = qwen3.5:9b + SEA-LION-v4-32B (local Ollama), deterministic strong-id tiebreak, tier gate (AUTO_COMMIT / HUMAN_CONFIRM / NONE). Modes `groundtruth` / `sample-review`. No writes.
- **`.claude/skills/intake/SKILL.md`** — durable `/intake` corner: pipeline anatomy (local `nuzantara_dev`/W87, tables, the 3 tested auto-attach gates, writer path), tier logic, refinery findings, LIVE STATE, blood-bought rules (2026-05-17 identity-hallucination, W65, Law 2).

## Measured (2026-07-18)

- Deterministic strong-id tier: **61/61 = 100% precision** on ground-truth → **18 documents auto-attached** live (reversible, audited).
- Panel width is **second-order** (SEA-LION-32B over qwen-9B added 0 auto-commits): the bottleneck is structural (sparse strong-ids in CRM), not model capability.
- Backlog sizing: 20 deterministic-now · 1,338 backfill-fuel (headless-safe ceiling ~34 on name+phone) · ~25k zero-candidate → re-OCR/re-search.

## Safety

Pilot is SELECT-only. No production code paths touched. Skill is docs. The 18 live attaches used the EXISTING `plan_commit`/`execute_commit` writer with `INTAKE_WRITER_ENABLED` scoped to a batch process; live routing flags untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)