### PR TITLE
fix(channels): hide internal RAG source names from client-facing Fonti footer

### DIFF
--- a/apps/backend-rag/backend/channels/instagram/formatter.py
+++ b/apps/backend-rag/backend/channels/instagram/formatter.py
@@ -3,6 +3,7 @@
 import logging
 
 from backend.channels.base import ChannelResponse
+from backend.channels.source_filter import public_sources
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +17,10 @@ class InstagramMessageFormatter:
         parts = []
         if response.text:
             parts.append(response.text)
-        if response.sources:
+        safe_sources = public_sources(response.sources)
+        if safe_sources:
             parts.append("\n\n📚 Fonti:")
-            for idx, src in enumerate(response.sources[:3], 1):
+            for idx, src in enumerate(safe_sources[:3], 1):
                 parts.append(f"{idx}. {src.get('title', 'Link')}")
                 if src.get("url"):
                     parts.append(f"   {src['url']}")

--- a/apps/backend-rag/backend/channels/source_filter.py
+++ b/apps/backend-rag/backend/channels/source_filter.py
@@ -1,0 +1,88 @@
+"""
+Source Filter — hide internal RAG source names from client-facing footers.
+
+The agentic RAG pipeline already cites the actual regulation/law inline in
+the answer text (e.g. "Source: Permenkumham 11/2024") — that stays as-is.
+This module governs a SEPARATE, narrower surface: the "Fonti"/"Sources"
+footer appended after the answer, which historically echoed raw internal
+chunk metadata (KB doc titles, NotebookLM training-data labels, generic
+"Document" placeholders) straight to clients.
+
+Only a source with a genuine PUBLIC url AND a non-internal title is
+eligible to appear in that client-facing footer.
+
+Author: Claude Sonnet 5
+Date: 2026-07-18
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Case-insensitive substring markers. Matched against "title url" combined,
+# so a marker present in either field drops the source.
+_INTERNAL_TITLE_MARKERS = (
+    "notebooklm",
+    "training data",
+    "generated training",
+    "session",
+    "traineddata",
+    "internal",
+    "chunk",
+    "curated_qa",
+)
+
+# Titles that carry no real information to a client — always dropped.
+_GENERIC_TITLES = {"", "document", "documento"}
+
+
+def _is_internal(title: str, url: str) -> bool:
+    """Return True if title/url looks like an internal RAG artifact."""
+    title_lower = title.strip().lower()
+    url_lower = url.strip().lower()
+
+    if title_lower in _GENERIC_TITLES:
+        return True
+
+    haystack = f"{title_lower} {url_lower}"
+    return any(marker in haystack for marker in _INTERNAL_TITLE_MARKERS)
+
+
+def public_sources(sources: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """
+    Filter a raw RAG sources list down to genuinely public, client-safe entries.
+
+    A source is KEPT only if:
+      - it has a "url" value starting with "http://" or "https://" (a real
+        public link — sources without one are internal KB chunks/doc refs
+        and are dropped), AND
+      - neither its title nor its url matches the internal blocklist
+        (notebooklm, training data, generated training, session, traineddata,
+        internal, chunk, curated_qa), case-insensitive substring match, AND
+      - its title is not empty / "document" / "documento".
+
+    Args:
+        sources: Raw sources list from the RAG response (may be None).
+
+    Returns:
+        Filtered list safe to show in a client-facing "Fonti"/"Sources"
+        footer. Empty list if nothing qualifies — callers should then
+        suppress the footer entirely rather than render an empty section.
+    """
+    if not sources:
+        return []
+
+    filtered: list[dict[str, Any]] = []
+    for source in sources:
+        title = str(source.get("title") or "")
+        url = str(source.get("url") or "")
+
+        if not url.startswith(("http://", "https://")):
+            continue
+        if _is_internal(title, url):
+            continue
+
+        filtered.append(source)
+
+    return filtered

--- a/apps/backend-rag/backend/channels/telegram/formatter.py
+++ b/apps/backend-rag/backend/channels/telegram/formatter.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any
 
 from backend.channels.base import ChannelResponse
+from backend.channels.source_filter import public_sources
 
 logger = logging.getLogger(__name__)
 
@@ -60,9 +61,10 @@ class TelegramMessageFormatter:
         Returns:
             Formatted sources string
         """
+        safe_sources = public_sources(sources)
         formatted_sources = []
 
-        for idx, source in enumerate(sources[:5], 1):  # Max 5 sources
+        for idx, source in enumerate(safe_sources[:5], 1):  # Max 5 sources
             title = source.get("title", "Documento")
             url = source.get("url")
 

--- a/apps/backend-rag/backend/channels/web/formatter.py
+++ b/apps/backend-rag/backend/channels/web/formatter.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any
 
 from backend.channels.base import ChannelResponse
+from backend.channels.source_filter import public_sources
 
 logger = logging.getLogger(__name__)
 
@@ -60,9 +61,10 @@ class WebMessageFormatter:
         Returns:
             Formatted sources string
         """
+        safe_sources = public_sources(sources)
         formatted_sources = []
 
-        for idx, source in enumerate(sources, 1):
+        for idx, source in enumerate(safe_sources, 1):
             title = source.get("title", "Documento")
             url = source.get("url")
             collection = source.get("collection", "")

--- a/apps/backend-rag/backend/channels/whatsapp/formatter.py
+++ b/apps/backend-rag/backend/channels/whatsapp/formatter.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any
 
 from backend.channels.base import ChannelResponse
+from backend.channels.source_filter import public_sources
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +54,11 @@ class WhatsAppMessageFormatter:
 
     @staticmethod
     def _format_sources(sources: list[dict[str, Any]]) -> str:
-        """Format sources list for WhatsApp."""
+        """Format sources list for WhatsApp (internal RAG sources filtered out)."""
+        safe_sources = public_sources(sources)
         formatted_sources = []
 
-        for idx, source in enumerate(sources[:5], 1):  # Max 5 sources
+        for idx, source in enumerate(safe_sources[:5], 1):  # Max 5 sources
             title = source.get("title", "Documento")
             url = source.get("url")
 

--- a/apps/backend-rag/backend/tests/channels/test_source_filter.py
+++ b/apps/backend-rag/backend/tests/channels/test_source_filter.py
@@ -1,0 +1,105 @@
+"""
+Tests for backend.channels.source_filter.public_sources.
+
+Guards against the client-facing "📚 Fonti:" footer leaking internal RAG
+source names (NotebookLM training-data labels, raw KB doc titles, generic
+"Document" placeholders) to clients on any channel.
+
+Author: Claude Sonnet 5
+Date: 2026-07-18
+"""
+
+from backend.channels.source_filter import public_sources
+
+
+class TestPublicSourcesDropsInternal:
+    """Internal-looking sources must never survive the filter."""
+
+    def test_drops_generic_document_title(self) -> None:
+        sources = [{"title": "Document", "url": "https://example.com/doc"}]
+        assert public_sources(sources) == []
+
+    def test_drops_generic_documento_title_case_insensitive(self) -> None:
+        sources = [{"title": "DOCUMENTO", "url": "https://example.com/doc"}]
+        assert public_sources(sources) == []
+
+    def test_drops_notebooklm_training_data_label(self) -> None:
+        sources = [
+            {
+                "title": "NotebookLM Generated Training Data - Session 2",
+                "url": "https://notebooklm.google.com/whatever",
+            }
+        ]
+        assert public_sources(sources) == []
+
+    def test_drops_raw_kb_doc_title_without_public_url(self) -> None:
+        sources = [{"title": "B1 VISA SAAT KEDATANGAN (WISATA)"}]
+        assert public_sources(sources) == []
+
+    def test_drops_source_with_no_url_key_at_all(self) -> None:
+        sources = [{"title": "Overstay, Deportation, Blacklist (Penangkalan)"}]
+        assert public_sources(sources) == []
+
+    def test_drops_source_with_empty_url(self) -> None:
+        sources = [{"title": "Some internal chunk", "url": ""}]
+        assert public_sources(sources) == []
+
+    def test_drops_source_with_non_http_url(self) -> None:
+        # Internal file:// or relative paths are not public links.
+        sources = [{"title": "Local KB file", "url": "file:///data/kb/doc.md"}]
+        assert public_sources(sources) == []
+
+    def test_drops_title_containing_chunk_marker(self) -> None:
+        sources = [{"title": "kb_chunk_0042", "url": "https://example.com/x"}]
+        assert public_sources(sources) == []
+
+    def test_drops_title_containing_curated_qa_marker(self) -> None:
+        sources = [{"title": "curated_qa entry", "url": "https://example.com/x"}]
+        assert public_sources(sources) == []
+
+    def test_all_four_leak_examples_dropped_together(self) -> None:
+        sources = [
+            {"title": "Document", "url": "https://example.com/doc"},
+            {
+                "title": "NotebookLM Generated Training Data - Session 2",
+                "url": "https://notebooklm.google.com/whatever",
+            },
+            {"title": "B1 VISA SAAT KEDATANGAN (WISATA)"},
+            {"title": "Overstay, Deportation, Blacklist (Penangkalan)"},
+        ]
+        assert public_sources(sources) == []
+
+
+class TestPublicSourcesKeepsLegitimate:
+    """A genuinely public, well-formed source must pass through untouched."""
+
+    def test_keeps_legitimate_public_source(self) -> None:
+        source = {
+            "title": "Imigrasi B1 page",
+            "url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/B1",
+        }
+        assert public_sources([source]) == [source]
+
+    def test_keeps_http_scheme_too(self) -> None:
+        source = {"title": "Official gazette", "url": "http://peraturan.go.id/x"}
+        assert public_sources([source]) == [source]
+
+    def test_mixed_list_keeps_only_legitimate_entry(self) -> None:
+        legit = {
+            "title": "Imigrasi B1 page",
+            "url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/B1",
+        }
+        sources = [
+            {"title": "Document", "url": "https://example.com/doc"},
+            legit,
+            {"title": "B1 VISA SAAT KEDATANGAN (WISATA)"},
+        ]
+        assert public_sources(sources) == [legit]
+
+
+class TestPublicSourcesEdgeCases:
+    def test_none_input_returns_empty_list(self) -> None:
+        assert public_sources(None) == []
+
+    def test_empty_list_returns_empty_list(self) -> None:
+        assert public_sources([]) == []

--- a/apps/backend-rag/backend/tests/unit/channels/conftest.py
+++ b/apps/backend-rag/backend/tests/unit/channels/conftest.py
@@ -23,13 +23,13 @@ def simple_response() -> ChannelResponse:
 
 @pytest.fixture
 def response_with_sources() -> ChannelResponse:
-    """ChannelResponse with sources attached."""
+    """ChannelResponse with sources attached (all client-safe: public url + non-internal title)."""
     return ChannelResponse(
         text="Here is the answer.",
         sources=[
             {"title": "Visa Guide", "url": "https://example.com/visa", "collection": "visa_oracle"},
             {"title": "Tax Info", "url": "https://example.com/tax", "collection": "tax_genius"},
-            {"title": "Local Doc", "collection": "legal_unified"},
+            {"title": "Local Doc", "url": "https://example.com/local-doc", "collection": "legal_unified"},
         ],
         metadata={},
     )

--- a/apps/backend-rag/backend/tests/unit/channels/test_instagram_adapter.py
+++ b/apps/backend-rag/backend/tests/unit/channels/test_instagram_adapter.py
@@ -140,13 +140,16 @@ class TestInstagramFormatter:
         assert result == "❌ Errore: something broke"
 
     def test_format_source_without_url(self) -> None:
+        """Sources without a public url look internal and are dropped entirely."""
         response = ChannelResponse(
             text="Answer",
             sources=[{"title": "No URL Doc"}],
             metadata={},
         )
         result = InstagramMessageFormatter.format_response(response)
-        assert "1. No URL Doc" in result
+        assert result == "Answer"
+        assert "No URL Doc" not in result
+        assert "Fonti" not in result
 
 
 # ============================================================================

--- a/apps/backend-rag/backend/tests/unit/channels/test_telegram_adapter.py
+++ b/apps/backend-rag/backend/tests/unit/channels/test_telegram_adapter.py
@@ -205,9 +205,19 @@ class TestTelegramFormatter:
         assert "Here is the answer." in result
         assert "*Fonti:*" in result
         assert "[Visa Guide](https://example.com/visa)" in result
-        assert "3. Local Doc" in result
-        # Sources without URL should not have link syntax
-        assert "[Local Doc]" not in result
+        assert "3. [Local Doc](https://example.com/local-doc)" in result
+
+    def test_format_source_without_url(self) -> None:
+        """Sources without a public url look internal and are dropped entirely."""
+        response = ChannelResponse(
+            text="Answer",
+            sources=[{"title": "No URL Doc"}],
+            metadata={},
+        )
+        result = TelegramMessageFormatter.format_response(response)
+        assert result == "Answer"
+        assert "No URL Doc" not in result
+        assert "Fonti" not in result
 
     def test_format_sources_max_five(self) -> None:
         response = ChannelResponse(

--- a/apps/backend-rag/backend/tests/unit/channels/test_web_adapter.py
+++ b/apps/backend-rag/backend/tests/unit/channels/test_web_adapter.py
@@ -104,7 +104,7 @@ class TestWebFormatter:
         assert "## 📚 Fonti" in result
         assert "[Visa Guide](https://example.com/visa)" in result
         assert "_(visa_oracle)_" in result
-        assert "3. Local Doc _(legal_unified)_" in result
+        assert "3. [Local Doc](https://example.com/local-doc) _(legal_unified)_" in result
 
     def test_format_with_workflow(self, response_with_workflow: ChannelResponse) -> None:
         result = WebMessageFormatter.format_response(response_with_workflow)
@@ -120,9 +120,10 @@ class TestWebFormatter:
         assert result == "1. [Doc A](https://a.com) _(col_a)_"
 
     def test_format_sources_without_url(self) -> None:
+        """Sources without a public url look internal and are dropped entirely."""
         sources = [{"title": "Doc B", "collection": "col_b"}]
         result = WebMessageFormatter._format_sources(sources)
-        assert result == "1. Doc B _(col_b)_"
+        assert result == ""
 
     def test_format_workflow_no_steps(self) -> None:
         result = WebMessageFormatter._format_workflow({"name": "Simple Plan", "steps": []})

--- a/apps/backend-rag/backend/tests/unit/channels/test_whatsapp_adapter.py
+++ b/apps/backend-rag/backend/tests/unit/channels/test_whatsapp_adapter.py
@@ -184,13 +184,16 @@ class TestWhatsAppFormatter:
         assert "S5" not in result
 
     def test_format_source_without_url(self) -> None:
+        """Sources without a public url look internal and are dropped entirely."""
         response = ChannelResponse(
             text="A",
             sources=[{"title": "Offline Doc"}],
             metadata={},
         )
         result = WhatsAppMessageFormatter.format_response(response)
-        assert "1. Offline Doc" in result
+        assert result == "A"
+        assert "Offline Doc" not in result
+        assert "Fonti" not in result
 
     def test_format_with_workflow(self, response_with_workflow: ChannelResponse) -> None:
         result = WhatsAppMessageFormatter.format_response(response_with_workflow)
@@ -307,7 +310,7 @@ class TestWhatsAppAdapter:
         self,
         adapter: WhatsAppChannelAdapter,
     ) -> None:
-        with pytest.raises(Exception):
+        with pytest.raises(AttributeError):
             await adapter.receive_message({"entry": "bad"})
 
     async def test_send_response_success(

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 639 services · 1165 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 639 services · 1166 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- The `📚 Fonti:` footer on all 4 client-facing channels (WhatsApp, Telegram, Web, Instagram) was echoing raw internal RAG source metadata to clients — NotebookLM training-data labels, generic "Document" placeholders, and raw KB doc titles. The LLM's inline citation of the actual regulation (e.g. "Source: Permenkumham 11/2024") is untouched — this only affects the trailing sources footer.
- Adds `backend/channels/source_filter.py::public_sources()`, a shared DRY filter: a source is kept only if it has a genuine `http(s)` url AND its title/url doesn't match an internal blocklist (`notebooklm`, `training data`, `generated training`, `session`, `traineddata`, `internal`, `chunk`, `curated_qa`, or empty/"document"/"documento"). Sources without a public url are treated as internal and dropped.
- Wired into all 4 formatters (`whatsapp/formatter.py`, `telegram/formatter.py`, `web/formatter.py`, `instagram/formatter.py`); if nothing qualifies, the footer is suppressed entirely (callers already gate on non-empty `sources_text`).
- Updated the shared `response_with_sources` test fixture + 4 per-channel "source without url" unit tests, which previously encoded the leaky behavior this PR removes.
- Includes the DOCSYNC test-count bump (1165 -> 1166) for the new test file.

## Test plan
- [x] `PYTHONPATH=. pytest backend/tests/channels/test_source_filter.py -q` — 15/15 passed
- [x] `PYTHONPATH=. pytest backend/tests/unit/channels/ backend/tests/channels/ -q` — 304 formatter/channel tests passed (7 pre-existing unrelated errors confirmed to be test-collection-order pollution independent of this diff, reproduced on unmodified code)
- [x] `python -c "from backend.app.dependencies import get_current_user; print('OK')"` — import chain OK
- [x] Full pre-push suite: 17550 passed, 165 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)