### PR TITLE
ci(cron): wire compliance-forecast notifier (inert until kill-switch)

### DIFF
--- a/.github/workflows/cron-notifiers-compliance-forecast.yml
+++ b/.github/workflows/cron-notifiers-compliance-forecast.yml
@@ -1,0 +1,23 @@
+name: cron - notifiers compliance-forecast (daily 06:30 WITA)
+on:
+  schedule:
+    - cron: "30 22 * * *" # 22:30 UTC = 06:30 WITA next day
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-notifiers-compliance-forecast-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Inert until system_settings.compliance_forecast_enabled = "true"
+      # (the endpoint returns {"status":"disabled"} otherwise — the kill
+      # switch is the deliberate go-live gesture, not this schedule).
+      - name: POST /api/cron/notifiers/compliance-forecast
+        run: |
+          curl -fsS -X POST https://nuzantara-rag.fly.dev/api/cron/notifiers/compliance-forecast \
+            -H "X-API-Key: ${{ secrets.NUZANTARA_API_KEY }}" \
+            -w '\nHTTP %{http_code} in %{time_total}s\n'


### PR DESCRIPTION
## What

Wires the **trigger half** of the compliance-alerts go-live: a GitHub Actions cron that POSTs `/api/cron/notifiers/compliance-forecast` on `nuzantara-rag` daily at 06:30 WITA (+ `workflow_dispatch`), mirroring the existing `cron-notifiers-*` workflows (same `X-API-Key: NUZANTARA_API_KEY` auth).

The AlertsEngine wiring itself landed in **#2603** (already deployed — fly-deploy auto-runs on `apps/backend-rag/**` merges).

## Why it is safe to merge now

**Deliberately inert.** The endpoint is double-gated by `system_settings.compliance_forecast_enabled` — it returns `{"status":"disabled"}` until that key is set to `"true"`. So merging this schedules a daily no-op until the deliberate go-live flip.

Once enabled:
- alerts go to the **internal** Telegram owner + internal Brevo email — **never clients**;
- `AlertsEngine` dedups by `(client, deadline)` (`build_dedup_key` + `find_active_by_dedup_key`), so re-runs don't re-notify.

## Go-live (separate, deliberate — NOT in this PR)

`INSERT INTO system_settings (key, value) VALUES ('compliance_forecast_enabled','true') ON CONFLICT (key) DO UPDATE SET value='true';` on prod, then a `workflow_dispatch` run to watch the first batch. That flip is a prod DB write (outside the read-only `pg.sh` path) + a business decision — owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)