### PR TITLE
feat(intake): v2 entry — auto-create contact on unknown WA phone + client_id_hint stamping (PR-1)

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -153,6 +153,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 | ----- | ----------------------- |
 | `.claude/skills/agent-session-discipline/` | Use at session start when working on a feature/fix that involves code changes. Creates an isolated worktree via L1 broker (scripts/agent_start.py) to prevent... |
 | `.claude/skills/bot/` | "Zantara WA bot corner — the live shared context for ALL work on the Zantara WhatsApp Meta bot (+62 821-3465-159): outbox/inbox pipeline, agentic RAG brain, ... |
+| `.claude/skills/intake/` | "Intake corner — the live shared context for the document-intake organism (WhatsApp/Drive docs → OCR → classify → extract → route → attach-to-client). Load B... |
 | `.claude/skills/karpathy-discipline/` | Use BEFORE any feature implementation, refactor, bug fix, or non-trivial code change. Applies 4 Karpathy principles to reduce common LLM coding mistakes (sil... |
 | `.claude/skills/kbli-navigator/` | "KBLI Navigator corner — the live shared context AND the full plan-to-the-end for ALL KBLI corpus/product work (dataset, gold, KG, editorial, kbli pages on b... |
 | `.claude/skills/modus/` | USE FOR EVERY non-trivial mandate — feature, fix, refactor, research, audit, ops, content — coding or not. The master operating loop of the organism: TRIAGE ... |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 327 routers · 639 services
+- Backend: FastAPI · 327 routers · 640 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 31 · Packages: 6

--- a/apps/backend-rag/backend/db/migrations_v2/246_clients_wa_intake_autocreate.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/246_clients_wa_intake_autocreate.sql
@@ -18,9 +18,22 @@
 -- INSERT ... ON CONFLICT this PR relies on, without touching the legacy
 -- dup mountain (a separate CRM-dedup workstream, out of scope here).
 --
+-- `phone_normalized` itself is NOT created by any prior migration — verified
+-- 2026-07-18 by grepping the full migrations_v2 chain (173/175 create OTHER
+-- tables' OWN phone_normalized column; 225 only MENTIONS clients.phone_normalized
+-- in a comment). The SQLModel `Client` class (backend/app/modules/crm/models.py)
+-- that CI bootstraps via `SQLModel.metadata.create_all()` only declares `phone`,
+-- not `phone_normalized` — so a from-scratch CI database lacks the column
+-- entirely, and CI failed with `column "phone_normalized" does not exist` before
+-- this line was added. On local dev / prod the column pre-exists out-of-band
+-- (added by hand at some point, outside the tracked migration chain — a latent
+-- schema-drift debt, out of scope to reconcile here); IF NOT EXISTS makes this
+-- a no-op there and the creating statement everywhere else.
+--
 -- Idempotent (IF NOT EXISTS / IF EXISTS everywhere) — safe to re-run.
 
 ALTER TABLE clients ADD COLUMN IF NOT EXISTS origin VARCHAR(50);
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS phone_normalized TEXT;
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_clients_phone_normalized_wa_intake
     ON clients (phone_normalized)
@@ -29,5 +42,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_clients_phone_normalized_wa_intake
       AND origin = 'wa-intake';
 
 -- === ROLLBACK ===
+-- `phone_normalized` is intentionally NOT dropped here: on local dev / prod it
+-- pre-exists out-of-band with real data this migration does not own, and on a
+-- from-scratch CI database other code (routing.py / auto_attach.py /
+-- contact_autocreate.py) reads/writes it independently of migration 246 —
+-- dropping it would break those unrelated paths. This migration owns (and
+-- therefore only rolls back) the index and the `origin` column.
 DROP INDEX IF EXISTS ux_clients_phone_normalized_wa_intake;
 ALTER TABLE clients DROP COLUMN IF EXISTS origin;

--- a/apps/backend-rag/backend/db/migrations_v2/246_clients_wa_intake_autocreate.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/246_clients_wa_intake_autocreate.sql
@@ -1,0 +1,33 @@
+-- 246_clients_wa_intake_autocreate.sql
+--
+-- intake-v2 PR-1: identity capture at the entry door.
+--
+-- Adds `origin` to `clients` so contacts auto-created by the WhatsApp intake
+-- entry-door (unknown sender phone -> minimal contact, status='unlabeled') are
+-- distinguishable from manually-created / lead-imported / CRM-created rows.
+--
+-- The partial UNIQUE index on phone_normalized is SCOPED to
+-- (deleted_at IS NULL AND origin = 'wa-intake') rather than the full column.
+-- Live measurement (2026-07-18, nuzantara_dev, GROUP BY phone_normalized HAVING
+-- count(*) > 1 among deleted_at IS NULL clients) found 622 duplicate groups /
+-- 664 extra rows in the existing legacy population (shared numbers, spouses,
+-- reused numbers, historical dedup debt) — a full-column unique index would
+-- fail to build. The auto-create path (backend/services/intake/
+-- contact_autocreate.py) ONLY ever inserts rows with origin='wa-intake', so
+-- scoping the index to that origin is sufficient for the idempotent
+-- INSERT ... ON CONFLICT this PR relies on, without touching the legacy
+-- dup mountain (a separate CRM-dedup workstream, out of scope here).
+--
+-- Idempotent (IF NOT EXISTS / IF EXISTS everywhere) — safe to re-run.
+
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS origin VARCHAR(50);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_clients_phone_normalized_wa_intake
+    ON clients (phone_normalized)
+    WHERE phone_normalized IS NOT NULL
+      AND deleted_at IS NULL
+      AND origin = 'wa-intake';
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS ux_clients_phone_normalized_wa_intake;
+ALTER TABLE clients DROP COLUMN IF EXISTS origin;

--- a/apps/backend-rag/backend/services/intake/contact_autocreate.py
+++ b/apps/backend-rag/backend/services/intake/contact_autocreate.py
@@ -1,0 +1,252 @@
+"""intake-v2 PR-1 — identity capture at the entry door.
+
+WhatsApp always carries a sender phone. This module resolves that phone at
+ENQUEUE time to a client_id_hint, so a document never lands 0-candidate for
+the trivial reason that "nobody ever created a contact for this number":
+
+  a. **team roster / internal number** -> the doc is a FORWARD, never a new
+     contact (reuses ``auto_attach._is_internal_sender_phone`` — the same
+     roster/env-configured internal-number gate LEVA-2's direct-phone path
+     already relies on, so there is exactly ONE roster definition in the
+     codebase, not two that can drift).
+  b. **existing client** (``clients.phone_normalized`` match) -> return its id.
+     Read-only, always attempted regardless of the create killswitch (there is
+     no PII-creation risk in *finding* an existing row).
+  c. **unknown phone** -> auto-create a MINIMAL contact
+     (``status='unlabeled'``, ``origin='wa-intake'``) and return its id. Gated
+     behind ``INTAKE_AUTOCREATE_CONTACT_ENABLED`` (default OFF, read at call
+     time — same pattern as the other intake flags in ``auto_attach.py``).
+
+Idempotent under concurrency: the INSERT targets the partial UNIQUE index
+``ux_clients_phone_normalized_wa_intake`` (migration 246, scoped to
+``origin='wa-intake' AND deleted_at IS NULL`` — NOT a full-column unique
+index, because live legacy data has 622 duplicate ``phone_normalized`` groups
+outside this origin). Two concurrent callers racing to auto-create the same
+unknown phone: exactly one INSERT wins, the loser's ``ON CONFLICT DO NOTHING``
+returns no row and this module re-selects the winner's id — nobody ever
+observes a phantom conflict, nobody double-creates.
+
+PII / Symbiosis Law 2: this module only ever writes ``phone_normalized`` (a
+number, not a name) and an optional caller-supplied display name onto a new
+row; it never fabricates identity data. Everything runs against whatever
+Postgres the caller's ``conn`` is connected to (local dev for backlog tooling,
+Fly prod for the live app process) — same contract as the rest of the intake
+writer stack (``client_enricher.py``, ``auto_attach.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+import asyncpg
+
+from backend.services.intake.auto_attach import _is_internal_sender_phone
+from backend.services.intake.routing import normalize_sender_phone
+
+logger = logging.getLogger("zantara.intake.contact_autocreate")
+
+AUTOCREATE_ENABLED_ENV = "INTAKE_AUTOCREATE_CONTACT_ENABLED"
+
+# Values written onto an auto-created contact (migration 246 / this module).
+WA_INTAKE_ORIGIN = "wa-intake"
+UNLABELED_STATUS = "unlabeled"
+AUTOCREATE_CREATED_BY = "system:wa-intake-autocreate"
+
+# Resolution kinds — every branch of the entry-door decision, so callers can
+# log/route without re-deriving the reason from a free-text string.
+KIND_INTERNAL_FORWARD = "internal_forward"
+KIND_EXISTING = "existing"
+KIND_CREATED = "created"
+KIND_AMBIGUOUS = "ambiguous"
+KIND_NO_PHONE = "no_phone"
+KIND_DISABLED = "disabled"
+
+
+def autocreate_contact_enabled() -> bool:
+    """True only if INTAKE_AUTOCREATE_CONTACT_ENABLED is explicitly truthy (default OFF).
+
+    Read at call time (ops/tests can flip it per-process). Gates ONLY the
+    CREATE branch — resolving an EXISTING client by phone is always attempted,
+    flag or no flag, because it performs no write and carries no mis-creation
+    risk.
+    """
+    return os.environ.get(AUTOCREATE_ENABLED_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+@dataclass(frozen=True)
+class ContactResolution:
+    """Outcome of :func:`resolve_or_create_contact` — one call, one verdict.
+
+    ``client_id`` is set for ``existing`` and ``created`` only; every other
+    kind means "do not stamp client_id_hint from this signal".
+    """
+
+    kind: str
+    client_id: int | None
+    phone_normalized: str | None
+    reason: str
+
+
+async def _match_existing_by_phone(
+    conn: asyncpg.Connection, normalized: str
+) -> list[int]:
+    """Exact match against ``clients.phone_normalized``, both storage variants.
+
+    Mirrors ``routing._match_sender_phone`` (dual ``+``/bare lookup) but returns
+    bare ids — this module never needs the full_name payload.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT id
+        FROM clients
+        WHERE deleted_at IS NULL
+          AND phone_normalized IN ($1, $2)
+        ORDER BY id
+        LIMIT 3
+        """,
+        normalized,
+        "+" + normalized,
+    )
+    return [r["id"] for r in rows]
+
+
+async def resolve_or_create_contact(
+    conn: asyncpg.Connection,
+    *,
+    sender_phone: str | None,
+    full_name_hint: str | None = None,
+) -> ContactResolution:
+    """Resolve a WA sender phone to a client_id at intake-entry time.
+
+    Call inside the caller's own transaction (or a fresh one) — the CREATE
+    branch performs a real INSERT. Never raises on a benign no-op; only a
+    genuine DB fault propagates.
+    """
+    normalized = normalize_sender_phone(sender_phone)
+    if not normalized:
+        return ContactResolution(
+            kind=KIND_NO_PHONE,
+            client_id=None,
+            phone_normalized=None,
+            reason="sender phone missing or unnormalizable",
+        )
+
+    if _is_internal_sender_phone(sender_phone):
+        return ContactResolution(
+            kind=KIND_INTERNAL_FORWARD,
+            client_id=None,
+            phone_normalized=normalized,
+            reason=(
+                "sender phone is team roster / internal number — never "
+                "auto-create a contact for a forwarder"
+            ),
+        )
+
+    matches = await _match_existing_by_phone(conn, normalized)
+    if len(matches) == 1:
+        return ContactResolution(
+            kind=KIND_EXISTING,
+            client_id=matches[0],
+            phone_normalized=normalized,
+            reason="single existing client matches sender phone",
+        )
+    if len(matches) > 1:
+        return ContactResolution(
+            kind=KIND_AMBIGUOUS,
+            client_id=None,
+            phone_normalized=normalized,
+            reason=f"sender phone shared by {len(matches)} clients — needs human",
+        )
+
+    if not autocreate_contact_enabled():
+        return ContactResolution(
+            kind=KIND_DISABLED,
+            client_id=None,
+            phone_normalized=normalized,
+            reason="autocreate killswitch off — no existing match either",
+        )
+
+    # clients.full_name is NOT NULL. Reuse the codebase's existing placeholder
+    # convention for phone-keyed leads with no known name (`Lead +<digits>` —
+    # see crm_clients.py's `unnamed` filter / client_enricher._name_is_junk),
+    # so this auto-created row is picked up by the SAME "still needs a name"
+    # tooling that already exists for WA-mirror leads, rather than inventing a
+    # second placeholder convention.
+    full_name = (full_name_hint or "").strip() or f"Lead +{normalized}"
+    # `phone` is set to the SAME normalized digits as `phone_normalized`, not
+    # left NULL. `clients` carries a live trigger
+    # (trg_normalize_phone -> update_phone_normalized()) that unconditionally
+    # recomputes `NEW.phone_normalized := normalize_phone_number(NEW.phone)` on
+    # every INSERT — verified empirically against nuzantara_dev 2026-07-18. If
+    # `phone` were left NULL, the trigger would silently overwrite our
+    # `phone_normalized` value back to NULL, and the partial unique index
+    # (scoped to `phone_normalized IS NOT NULL`) would never apply — the
+    # idempotency this whole module depends on would silently vanish.
+    # `normalize_phone_number` only strips non-digits (no 0/8->62 rewriting),
+    # so feeding it the ALREADY-normalized digits is a safe no-op.
+    row = await conn.fetchrow(
+        """
+        INSERT INTO clients
+            (full_name, phone, phone_normalized, status, origin, created_by,
+             created_at, updated_at)
+        VALUES ($1, $2, $2, $3, $4, $5, NOW(), NOW())
+        ON CONFLICT (phone_normalized)
+        WHERE (phone_normalized IS NOT NULL
+               AND deleted_at IS NULL
+               AND origin = 'wa-intake')
+        DO NOTHING
+        RETURNING id
+        """,
+        full_name,
+        normalized,
+        UNLABELED_STATUS,
+        WA_INTAKE_ORIGIN,
+        AUTOCREATE_CREATED_BY,
+    )
+    if row is not None:
+        logger.info(
+            "contact_autocreate: created client=%s from unknown WA sender phone",
+            row["id"],
+        )
+        return ContactResolution(
+            kind=KIND_CREATED,
+            client_id=row["id"],
+            phone_normalized=normalized,
+            reason="auto-created minimal contact for unknown WA sender phone",
+        )
+
+    # Lost the race to a concurrent caller creating the SAME phone — the
+    # partial unique index is the arbiter; re-select the winner.
+    winner = await conn.fetchrow(
+        """
+        SELECT id FROM clients
+        WHERE deleted_at IS NULL AND origin = $1 AND phone_normalized = $2
+        """,
+        WA_INTAKE_ORIGIN,
+        normalized,
+    )
+    if winner is not None:
+        return ContactResolution(
+            kind=KIND_EXISTING,
+            client_id=winner["id"],
+            phone_normalized=normalized,
+            reason="concurrent auto-create race — reused winning row",
+        )
+
+    logger.warning(
+        "contact_autocreate: INSERT conflict but re-select found no row "
+        "(unexpected race outcome) — abstaining"
+    )
+    return ContactResolution(
+        kind=KIND_AMBIGUOUS,
+        client_id=None,
+        phone_normalized=normalized,
+        reason="insert conflict but re-select found nothing — abstain, never guess",
+    )

--- a/apps/backend-rag/backend/services/intake/whatsapp_live_adapter.py
+++ b/apps/backend-rag/backend/services/intake/whatsapp_live_adapter.py
@@ -46,6 +46,7 @@ from backend.channels.whatsapp.media_webhook_parse import (
     InboundMedia,
     parse_media_webhook,
 )
+from backend.services.intake.contact_autocreate import resolve_or_create_contact
 from backend.services.intake.enqueue import EnqueueResult, enqueue
 
 logger = logging.getLogger(__name__)
@@ -127,6 +128,37 @@ async def ingest_live_media(
             logger.exception("received_by resolver failed media_id=%s", media.media_id)
             received_by = None
 
+        # 2b. Identity capture at the door (intake-v2 PR-1). The sender phone
+        #     is ALWAYS present on WhatsApp — resolve it to a client_id_hint so
+        #     the document never lands 0-candidate for the trivial reason that
+        #     nobody ever created a contact for this number. Team-roster
+        #     numbers never get a contact (they're forwarders); unknown
+        #     numbers auto-create a minimal contact when
+        #     INTAKE_AUTOCREATE_CONTACT_ENABLED is armed (default OFF — until
+        #     then this degrades to "existing match only", never worse than
+        #     today). A resolver fault must NOT drop the document — it just
+        #     falls back to no hint, same as before this feature existed.
+        client_id_hint: int | None = None
+        try:
+            async with pool.acquire() as identity_conn:
+                async with identity_conn.transaction():
+                    resolution = await resolve_or_create_contact(
+                        identity_conn, sender_phone=media.from_phone
+                    )
+            client_id_hint = resolution.client_id
+            logger.info(
+                "contact_autocreate: media_id=%s kind=%s client_id=%s",
+                media.media_id,
+                resolution.kind,
+                resolution.client_id,
+            )
+        except Exception:
+            logger.exception(
+                "contact_autocreate resolver failed media_id=%s — falling back "
+                "to no client_id_hint",
+                media.media_id,
+            )
+
         # 3. Enqueue (DB) — source_ref ties the queue row back to the WA message
         #    so the live flow is distinguishable from the export flow and the
         #    intake_key is stable across Meta retries.
@@ -142,6 +174,7 @@ async def ingest_live_media(
                 byte_size=downloaded.byte_size,
                 received_by=received_by,
                 sender_phone=media.from_phone,
+                client_id_hint=client_id_hint,
             )
         except Exception:
             logger.exception("live WA enqueue failed media_id=%s", media.media_id)

--- a/apps/backend-rag/backend/tests/services/intake/test_contact_autocreate.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_contact_autocreate.py
@@ -1,0 +1,209 @@
+"""intake-v2 PR-1 — identity capture at the entry door: gate + idempotency tests.
+
+Per W96 (test-writes-prod), this suite NEVER touches a real database — a
+``FakeConn`` stands in for ``asyncpg.Connection`` and dispatches on query text,
+same convention as ``test_intake_routing_phone.py``. The concurrency test
+models the ON CONFLICT DO NOTHING + re-select race explicitly (a second
+``resolve_or_create_contact`` call observing the first call's committed row)
+rather than touching Postgres — the real SQL (partial unique index arbiter +
+the ``phone``/``phone_normalized`` trigger interaction) was verified manually
+against nuzantara_dev in a rolled-back transaction while building this module;
+this suite locks in the CALLER-VISIBLE contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.services.intake import contact_autocreate as ca
+
+
+class FakeConn:
+    """Minimal asyncpg.Connection stand-in: dispatches on query text.
+
+    ``existing_matches``: rows returned for the phone-lookup SELECT.
+    ``insert_returns_id``: id returned by the INSERT ... RETURNING id (None
+        means the INSERT lost the ON CONFLICT race, mirroring a concurrent
+        winner already occupying the partial-unique slot).
+    ``winner_id``: id returned by the post-conflict re-select SELECT.
+    """
+
+    def __init__(
+        self,
+        *,
+        existing_matches: list[dict[str, Any]] | None = None,
+        insert_returns_id: int | None = None,
+        winner_id: int | None = None,
+    ) -> None:
+        self.existing_matches = existing_matches or []
+        self.insert_returns_id = insert_returns_id
+        self.winner_id = winner_id
+        self.fetch_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.fetchrow_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls.append((query, args))
+        if "phone_normalized IN" in query:
+            return self.existing_matches
+        return []
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
+        self.fetchrow_calls.append((query, args))
+        if "INSERT INTO clients" in query:
+            if self.insert_returns_id is not None:
+                return {"id": self.insert_returns_id}
+            return None
+        if "SELECT id FROM clients" in query and "origin = $1" in query:
+            return {"id": self.winner_id} if self.winner_id is not None else None
+        return None
+
+
+def _never_internal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ca, "_is_internal_sender_phone", lambda _phone: False)
+
+
+def _always_internal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ca, "_is_internal_sender_phone", lambda _phone: True)
+
+
+# --------------------------------------------------------------------------- #
+# (a) roster / internal phone -> NEVER a contact
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_roster_phone_never_creates_a_contact(monkeypatch: pytest.MonkeyPatch) -> None:
+    _always_internal(monkeypatch)
+    monkeypatch.setenv(ca.AUTOCREATE_ENABLED_ENV, "1")
+    conn = FakeConn(insert_returns_id=999)  # would "succeed" if ever attempted
+
+    out = await ca.resolve_or_create_contact(conn, sender_phone="0811234567")
+
+    assert out.kind == ca.KIND_INTERNAL_FORWARD
+    assert out.client_id is None
+    assert not conn.fetchrow_calls, "internal/roster phone must never reach the INSERT"
+    assert not conn.fetch_calls, "internal/roster phone must never even probe existing clients"
+
+
+# --------------------------------------------------------------------------- #
+# (b) known phone -> existing id, no create attempted
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_known_phone_returns_existing_client_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    _never_internal(monkeypatch)
+    monkeypatch.setenv(ca.AUTOCREATE_ENABLED_ENV, "1")
+    conn = FakeConn(existing_matches=[{"id": 123}])
+
+    out = await ca.resolve_or_create_contact(conn, sender_phone="081234567890")
+
+    assert out.kind == ca.KIND_EXISTING
+    assert out.client_id == 123
+    assert not conn.fetchrow_calls, "an existing match must never trigger an INSERT"
+
+
+@pytest.mark.asyncio
+async def test_shared_phone_multiple_matches_is_ambiguous_not_a_guess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _never_internal(monkeypatch)
+    monkeypatch.setenv(ca.AUTOCREATE_ENABLED_ENV, "1")
+    conn = FakeConn(existing_matches=[{"id": 1}, {"id": 2}])
+
+    out = await ca.resolve_or_create_contact(conn, sender_phone="081234567890")
+
+    assert out.kind == ca.KIND_AMBIGUOUS
+    assert out.client_id is None
+    assert not conn.fetchrow_calls
+
+
+# --------------------------------------------------------------------------- #
+# (c) unknown phone -> auto-create, gated by the killswitch
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_unknown_phone_creates_when_flag_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    _never_internal(monkeypatch)
+    monkeypatch.setenv(ca.AUTOCREATE_ENABLED_ENV, "1")
+    conn = FakeConn(existing_matches=[], insert_returns_id=555)
+
+    out = await ca.resolve_or_create_contact(conn, sender_phone="081234567890")
+
+    assert out.kind == ca.KIND_CREATED
+    assert out.client_id == 555
+    # The SQL binds the SAME $2 placeholder to both `phone` and
+    # `phone_normalized` columns (the DB-side trigger overwrites
+    # phone_normalized FROM phone otherwise) — asyncpg sees one bound param.
+    insert_query, insert_args = conn.fetchrow_calls[0]
+    assert "INSERT INTO clients" in insert_query
+    assert "VALUES ($1, $2, $2, $3, $4, $5" in insert_query
+    assert insert_args[1] == out.phone_normalized
+
+
+@pytest.mark.asyncio
+async def test_unknown_phone_flag_off_is_noop_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _never_internal(monkeypatch)
+    monkeypatch.delenv(ca.AUTOCREATE_ENABLED_ENV, raising=False)
+    conn = FakeConn(existing_matches=[])
+
+    out = await ca.resolve_or_create_contact(conn, sender_phone="081234567890")
+
+    assert out.kind == ca.KIND_DISABLED
+    assert out.client_id is None
+    assert not conn.fetchrow_calls, "killswitch off must never reach the INSERT"
+
+
+@pytest.mark.asyncio
+async def test_no_phone_abstains(monkeypatch: pytest.MonkeyPatch) -> None:
+    _never_internal(monkeypatch)
+    monkeypatch.setenv(ca.AUTOCREATE_ENABLED_ENV, "1")
+    conn = FakeConn(insert_returns_id=999)
+
+    out = await ca.resolve_or_create_contact(conn, sender_phone=None)
+
+    assert out.kind == ca.KIND_NO_PHONE
+    assert out.client_id is None
+    assert not conn.fetch_calls
+    assert not conn.fetchrow_calls
+
+
+# --------------------------------------------------------------------------- #
+# Concurrent double-call -> created exactly once (idempotent under the race)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_concurrent_double_call_creates_exactly_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _never_internal(monkeypatch)
+    monkeypatch.setenv(ca.AUTOCREATE_ENABLED_ENV, "1")
+
+    # Caller A: nobody exists yet, wins the INSERT race.
+    conn_a = FakeConn(existing_matches=[], insert_returns_id=777)
+    out_a = await ca.resolve_or_create_contact(conn_a, sender_phone="081234567890")
+    assert out_a.kind == ca.KIND_CREATED
+    assert out_a.client_id == 777
+
+    # Caller B: races in at the SAME moment (still sees 0 existing matches —
+    # A's row hasn't committed from B's snapshot yet), loses the ON CONFLICT
+    # (insert_returns_id=None) and re-selects A's committed winner.
+    conn_b = FakeConn(existing_matches=[], insert_returns_id=None, winner_id=777)
+    out_b = await ca.resolve_or_create_contact(conn_b, sender_phone="081234567890")
+
+    assert out_b.kind == ca.KIND_EXISTING
+    assert out_b.client_id == 777
+    assert out_a.client_id == out_b.client_id, "both callers must converge on ONE client id"
+
+
+@pytest.mark.asyncio
+async def test_conflict_with_no_reselect_hit_abstains_never_guesses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pathological race outcome (should not happen) — must abstain, not fabricate an id."""
+    _never_internal(monkeypatch)
+    monkeypatch.setenv(ca.AUTOCREATE_ENABLED_ENV, "1")
+    conn = FakeConn(existing_matches=[], insert_returns_id=None, winner_id=None)
+
+    out = await ca.resolve_or_create_contact(conn, sender_phone="081234567890")
+
+    assert out.kind == ca.KIND_AMBIGUOUS
+    assert out.client_id is None

--- a/apps/backend-rag/backend/tests/services/intake/test_whatsapp_live_adapter.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_whatsapp_live_adapter.py
@@ -165,6 +165,110 @@ async def test_dup_counts_as_already_present(monkeypatch, http_client):
     assert counters.enqueued_new == 0
 
 
+class _FakeTxnCtx:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeIdentityConn:
+    def transaction(self):
+        return _FakeTxnCtx()
+
+
+class _FakeAcquireCtx:
+    async def __aenter__(self):
+        return _FakeIdentityConn()
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePoolWithAcquire:
+    """A pool stub that supports `.acquire()` (unlike the bare object() used
+    elsewhere in this file) so the identity-capture leg's `pool.acquire()` /
+    `conn.transaction()` calls succeed instead of raising — needed to prove
+    client_id_hint really flows end to end, not just "gracefully degrades"."""
+
+    def acquire(self):
+        return _FakeAcquireCtx()
+
+
+@pytest.mark.asyncio
+async def test_contact_autocreate_client_id_hint_flows_into_enqueue(monkeypatch, http_client):
+    """intake-v2 PR-1 wiring: resolve_or_create_contact's client_id must reach
+    enqueue()'s client_id_hint — this is the whole point of the entry-door
+    identity-capture feature (never leave a document 0-candidate for the
+    trivial reason nobody made a contact for this WA number yet)."""
+
+    async def fake_download(client, *, media_id, **kw):
+        return DownloadedMedia(blob_path="/tmp/x", mime_type="application/pdf",
+                                sha256="h", byte_size=1, media_id=media_id)
+
+    captured = {}
+
+    async def fake_enqueue(pool, **kw):
+        captured.update(kw)
+        return EnqueueResult(instance_id=1, queue_id=2, was_new=True)
+
+    class _StubResolution:
+        kind = "created"
+        client_id = 555
+
+    async def fake_resolve(_conn, *, sender_phone, full_name_hint=None):
+        assert sender_phone == "62811"
+        return _StubResolution()
+
+    monkeypatch.setattr(mod, "download_media", fake_download)
+    monkeypatch.setattr(mod, "enqueue", fake_enqueue)
+    monkeypatch.setattr(mod, "resolve_or_create_contact", fake_resolve)
+
+    async with http_client:
+        counters = await mod.ingest_live_media(
+            _doc_envelope(), pool=_FakePoolWithAcquire(), http_client=http_client,
+            access_token="t", dest_dir="/tmp",
+            resolve_received_by=(await _resolver_const("ari@balizero.com")),
+        )
+
+    assert counters.enqueued_new == 1
+    assert captured["client_id_hint"] == 555
+
+
+@pytest.mark.asyncio
+async def test_contact_autocreate_resolver_exception_falls_back_to_no_hint(monkeypatch, http_client):
+    """A resolver fault (DB blip, whatever) must never drop the document — it
+    degrades to client_id_hint=None, the same as before this feature existed."""
+
+    async def fake_download(client, *, media_id, **kw):
+        return DownloadedMedia(blob_path="/tmp/x", mime_type="application/pdf",
+                                sha256="h", byte_size=1, media_id=media_id)
+
+    captured = {}
+
+    async def fake_enqueue(pool, **kw):
+        captured.update(kw)
+        return EnqueueResult(instance_id=1, queue_id=2, was_new=True)
+
+    async def fake_resolve(_conn, *, sender_phone, full_name_hint=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(mod, "download_media", fake_download)
+    monkeypatch.setattr(mod, "enqueue", fake_enqueue)
+    monkeypatch.setattr(mod, "resolve_or_create_contact", fake_resolve)
+
+    async with http_client:
+        counters = await mod.ingest_live_media(
+            _doc_envelope(), pool=_FakePoolWithAcquire(), http_client=http_client,
+            access_token="t", dest_dir="/tmp",
+            resolve_received_by=(await _resolver_const("ari@balizero.com")),
+        )
+
+    assert counters.enqueued_new == 1, "a resolver fault must not drop the document"
+    assert captured["client_id_hint"] is None
+
+
 @pytest.mark.asyncio
 async def test_no_media_is_noop(monkeypatch, http_client):
     async def fake_download(*a, **k):  # should never be called

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 639 services · 1166 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 640 services · 1167 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

PR-1 of intake-v2 ("perfect /intake from today", design spec `intake-v2-design.md`): identity capture at the WhatsApp entry door, so a document never lands 0-candidate for the trivial reason that nobody ever created a contact for the sender's number.

- **`backend/services/intake/contact_autocreate.py`** (new) — `resolve_or_create_contact(conn, sender_phone=...)` resolves a WA sender phone at enqueue time:
  - team-roster / internal number → never creates a contact (reuses `auto_attach._is_internal_sender_phone`, one roster definition, not two that can drift)
  - existing client match → returns its id (read-only, always attempted regardless of the killswitch)
  - unknown phone → auto-creates a minimal contact (`status='unlabeled'`, `origin='wa-intake'`, placeholder name `Lead +<digits>` reusing the codebase's existing WA-mirror-lead naming convention), gated by `INTAKE_AUTOCREATE_CONTACT_ENABLED` (**default OFF**)
  - idempotent under concurrency via `INSERT ... ON CONFLICT DO NOTHING` + re-select against a partial unique index
- **Migration 246** — adds `clients.origin` + a partial UNIQUE index on `phone_normalized` scoped to `(deleted_at IS NULL AND origin='wa-intake')`.
- **Wired into `whatsapp_live_adapter.ingest_live_media`** — resolves the contact before `enqueue()` and stamps `client_id_hint`; a resolver fault degrades to no hint rather than dropping the document.

## Measured (decided the migration scope)

`GROUP BY phone_normalized HAVING count(*) > 1` among live (`deleted_at IS NULL`) clients on `nuzantara_dev`: **622 duplicate groups / 664 extra rows**. Non-zero, so the unique index is scoped to `origin='wa-intake'` rather than the full column (a full-column unique index would fail to build against the existing legacy population — shared numbers, spouses, reused numbers, historical dedup debt, out of scope here).

## Divergence from the design-spec prompt / important findings

1. **`ingest_live_media` has zero production callers today** (grep confirmed — only its own tests reference it). The live WA webhook → intake wiring is a separate, already-tracked gap (intake skill LIVE STATE: "entry leak"). This PR wires identity-capture into the architecturally-correct seam so it activates the moment that wiring lands; it does not itself arm the live webhook path.
2. **The create-contact API 409-on-duplicate-phone guard (task item #4) was already shipped on `main`** (`crm_clients.py::create_client`, commit `6354304`, PR #2496/#2208 lineage) — existing tests (`test_crm_clients.py`, `test_crm_clients_coverage.py`) already cover it. No new work was needed there.
3. **DB trigger discovery (empirically verified against `nuzantara_dev` in rolled-back transactions):** `clients` carries `trg_normalize_phone → update_phone_normalized()`, which unconditionally recomputes `phone_normalized` FROM the `phone` column on every INSERT. The INSERT in `contact_autocreate.py` binds the SAME normalized value to both `phone` and `phone_normalized` — leaving `phone` NULL would have silently defeated the whole idempotency mechanism (verified this failure mode directly before fixing it).
4. **`clients.full_name` is NOT NULL** (schema-verified) — the design spec's "full_name NULL" is infeasible; used the existing `Lead +<digits>` placeholder convention (already used by `crm_clients.py`'s `unnamed` filter and `client_enricher._name_is_junk`) instead of inventing a second one.

## Flags

- `INTAKE_AUTOCREATE_CONTACT_ENABLED` (new, default OFF) — gates the CREATE branch only; existing-client resolution always runs.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/services/intake/test_contact_autocreate.py -v` — 8/8 passed (roster-phone never creates, existing-phone match, ambiguous shared-phone abstains, flag-off no-op, flag-on creates, concurrent double-call creates exactly once, conflict-with-no-reselect abstains, no-phone abstains)
- [x] `PYTHONPATH=. pytest backend/tests/services/intake/test_whatsapp_live_adapter.py -v` — 7/7 passed (2 new: client_id_hint flows into enqueue, resolver exception falls back to no hint without dropping the doc)
- [x] `PYTHONPATH=. pytest backend/tests/services/intake/ -q` — 466 passed, 1 skipped (pre-existing, unrelated)
- [x] `python -c "from backend.app.dependencies import get_current_user"` — import chain OK
- [x] `squawk-cli` (repo's exact CI exclusion set) — 0 issues on migration 246
- [x] Migration DDL + `ON CONFLICT` semantics verified live against `nuzantara_dev` in rolled-back transactions (fresh insert wins, concurrent duplicate hits `DO NOTHING`, different-origin same-phone unaffected)
- [x] Pre-push hook: full suite (17709 tests) — 17594 passed, 115 skipped, 0 failed

## Migration — auto-merge intentionally NOT armed

Per repo rule (migration-class PRs are auto-merge OFF), this PR is NOT armed for auto-merge. Please review + merge manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)