### PR TITLE
fix(wr2-app): delta-log gate exclusions — stop ~30MB/day wr2control.err growth

### DIFF
--- a/apps/wr2-control-app/Sources/WarRoom.swift
+++ b/apps/wr2-control-app/Sources/WarRoom.swift
@@ -125,9 +125,32 @@ enum WarRoom {
     /// GalleryView can show "N nascosti" next to the existing carousel count.
     private(set) static var excludedIncompleteCount: Int = 0
 
+    /// Delta-logging state for `logGateExclusion` (scar #2, esiste≠armato — noise that
+    /// drowns real signal). The pipeline re-scans every ~10s; re-emitting the ~29 identical
+    /// "excluded '<slug>'" stderr lines every cycle grew `wr2control.err` ~30MB/day. These
+    /// two maps let the gate emit a line ONLY when a slug's exclusion is NEW or its reason
+    /// CHANGED vs the immediately-previous scan — un-exclude→re-exclude re-emits (a slug
+    /// absent from `thisScanExclusions` this cycle is gone from `lastScanExclusions` next
+    /// cycle), so a carousel that breaks AGAIN is never silently swallowed.
+    private static var lastScanExclusions: [String: String] = [:]
+    private static var thisScanExclusions: [String: String] = [:]
+    /// Count of exclusion lines ACTUALLY written to stderr on the most recent scan (delta
+    /// survivors), reset per scan alongside excludedIncompleteCount. Test-only surface that
+    /// makes the throttle observable without capturing stderr: on a steady-state re-scan
+    /// this is 0 while excludedIncompleteCount stays exact.
+    private(set) static var gateExclusionLogEmits: Int = 0
+
     private static func logGateExclusion(slug: String, reason: String) {
-        FileHandle.standardError.write("wr2-gate: excluded '\(slug)' — \(reason)\n".data(using: .utf8)!)
+        // Counter ALWAYS advances — the "N nascosti" gallery badge must stay exact; only the
+        // stderr WRITE is throttled (scar #2), never the count.
         excludedIncompleteCount += 1
+        thisScanExclusions[slug] = reason
+        // Suppress only an exclusion identical to the previous scan's; a NEW slug or a
+        // CHANGED reason still emits, so exclusion stays observable (first occurrence +
+        // every change is logged).
+        if lastScanExclusions[slug] == reason { return }
+        gateExclusionLogEmits += 1
+        FileHandle.standardError.write("wr2-gate: excluded '\(slug)' — \(reason)\n".data(using: .utf8)!)
     }
 
     /// Resolve the DECLARED slide count for an on-disk carousel directory — the number the
@@ -302,8 +325,10 @@ enum WarRoom {
         // Reset BEFORE any I/O, on every exit path including an early return below — a
         // stale nonzero count surviving a failed/empty scan would show "N nascosti" over
         // a gallery that simply failed to read, its own silent-lie (Codex red-team
-        // finding #5, 2026-07-16).
+        // finding #5, 2026-07-16). `gateExclusionLogEmits` (stderr lines written this scan)
+        // shares that discipline — 0 on a failed scan.
         excludedIncompleteCount = 0
+        gateExclusionLogEmits = 0
 
         let fm = FileManager.default
         let croot = root ?? carouselRoot()
@@ -311,6 +336,16 @@ enum WarRoom {
             at: croot,
             includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
             options: [.skipsHiddenFiles]) else { return [] }
+
+        // Delta-logging baseline rotation (scar #2 noise reduction) — done ONLY here, AFTER
+        // the unreadable-root guard, NEVER before it (Codex red-team CADE 2026-07-18). A
+        // transient root-read failure must not overwrite `lastScanExclusions`: if it did,
+        // the next successful scan would see an empty baseline and re-emit EVERY unchanged
+        // exclusion, so one I/O flap recreates the ~30MB/day log storm (cross-family #8
+        // network-flap). On early return the maps are left untouched, so the last
+        // SUCCESSFUL scan's snapshot survives the flap and becomes the baseline here.
+        lastScanExclusions = thisScanExclusions
+        thisScanExclusions = [:]
 
         // Every physical (non-archived) directory slug on disk, gathered BEFORE gating
         // or queue-joining — two downstream steps need the FULL set, not just

--- a/apps/wr2-control-app/Tests/main.swift
+++ b/apps/wr2-control-app/Tests/main.swift
@@ -434,6 +434,87 @@ func test_completeOrNothingGate() {
          "excludedIncompleteCount counts exactly the 2 unpublished exclusions (mismatch + undeclarable)")
 }
 
+func test_gateExclusionDeltaLogging() {
+    T.suite("gate exclusion delta-logging (scar #2 — throttle stderr, keep count exact)")
+
+    let root = makeFixtureRoot()
+    defer { try? fm.removeItem(at: root) }
+    let croot = root.appendingPathComponent("carousel", isDirectory: true)
+
+    // Two unpublished exclusions: a count mismatch and an undeclarable dir.
+    let mismatchDir = makeCarousel(in: root, slug: "delta-mismatch", slides: (1...8).map { "\($0).png" },
+                                    declareSlides: .objectSlides(9))
+    _ = makeCarousel(in: root, slug: "delta-undeclarable", slides: ["1.png", "2.png"], declareSlides: .absent)
+
+    // Scan 1 — first observation: both exclusions are NEW, so both emit to stderr.
+    _ = WarRoom.scanCarousels(carouselRoot: croot, queue: [])
+    T.eq(WarRoom.excludedIncompleteCount, 2, "scan 1: both exclusions counted")
+    T.eq(WarRoom.gateExclusionLogEmits, 2, "scan 1: first observation emits both (new exclusions)")
+
+    // Scan 2 — identical fixture: INNOCENCE. Count stays exact (badge still right) but
+    // NOTHING is re-emitted — this is the ~30MB/day fix.
+    _ = WarRoom.scanCarousels(carouselRoot: croot, queue: [])
+    T.eq(WarRoom.excludedIncompleteCount, 2, "scan 2: count stays exact across an unchanged re-scan")
+    T.eq(WarRoom.gateExclusionLogEmits, 0, "innocence: an unchanged exclusion does NOT re-emit next cycle")
+
+    // Scan 3 — mutate one exclusion's REASON (declared 9 → 10 ⇒ 'disk=8 declared=10'):
+    // GUILT. A changed reason must break the throttle; the unchanged one stays quiet.
+    let tenSlides: [String: Any] = ["slides": (0..<10).map { ["index": $0 + 1] }]
+    try? JSONSerialization.data(withJSONObject: tenSlides)
+        .write(to: mismatchDir.appendingPathComponent("slides.json"))
+    _ = WarRoom.scanCarousels(carouselRoot: croot, queue: [])
+    T.eq(WarRoom.excludedIncompleteCount, 2, "scan 3: still 2 exclusions")
+    T.eq(WarRoom.gateExclusionLogEmits, 1, "guilt: a CHANGED exclusion reason re-emits (only the changed one)")
+
+    // Scan 4 — TRANSIENT root-read failure (nonexistent root): returns [] and must NOT
+    // touch the dedup baseline (Codex red-team CADE 2026-07-18). Counters still reset to 0.
+    let deadRoot = root.appendingPathComponent("carousel-nonexistent", isDirectory: true)
+    let survivors = WarRoom.scanCarousels(carouselRoot: deadRoot, queue: [])
+    T.eq(survivors.count, 0, "scan 4: unreadable root returns empty")
+    T.eq(WarRoom.excludedIncompleteCount, 0, "scan 4: failed scan resets the badge count to 0")
+    T.eq(WarRoom.gateExclusionLogEmits, 0, "scan 4: failed scan emits nothing")
+
+    // Scan 5 — good root again, fixture UNCHANGED since scan 3: the baseline survived the
+    // flap, so nothing re-emits. Pre-fix this printed a full duplicate burst (2 emits).
+    _ = WarRoom.scanCarousels(carouselRoot: croot, queue: [])
+    T.eq(WarRoom.excludedIncompleteCount, 2, "scan 5: count exact again after recovery")
+    T.eq(WarRoom.gateExclusionLogEmits, 0,
+         "guilt (Codex CADE): after a transient root-read failure, unchanged exclusions must NOT re-emit — the dedup baseline survives the flap")
+}
+
+func test_gateExclusionDeltaFixedThenBrokenAgain() {
+    T.suite("gate exclusion delta-logging — a carousel FIXED then BROKEN AGAIN re-emits (Codex #1 coverage)")
+
+    let root = makeFixtureRoot()
+    defer { try? fm.removeItem(at: root) }
+    let croot = root.appendingPathComponent("carousel", isDirectory: true)
+    let slidesDir = root.appendingPathComponent("carousel/flapper/slides", isDirectory: true)
+
+    // declared=3, start incomplete (disk=2) → excluded.
+    _ = makeCarousel(in: root, slug: "flapper", slides: ["1.png", "2.png"], declareSlides: .objectSlides(3))
+
+    // Scan 1 — incomplete: NEW exclusion → emits.
+    _ = WarRoom.scanCarousels(carouselRoot: croot, queue: [])
+    T.eq(WarRoom.excludedIncompleteCount, 1, "scan 1: incomplete flapper excluded")
+    T.eq(WarRoom.gateExclusionLogEmits, 1, "scan 1: new exclusion emits")
+
+    // Scan 2 — FIX (add 3rd png ⇒ disk=3=declared): now complete, drops out of the baseline.
+    try? fm.copyItem(at: slidesDir.appendingPathComponent("1.png"),
+                     to: slidesDir.appendingPathComponent("3.png"))
+    let survivors2 = WarRoom.scanCarousels(carouselRoot: croot, queue: [])
+    T.check(survivors2.contains(where: { $0.slug == "flapper" }), "scan 2: fixed flapper is now listed")
+    T.eq(WarRoom.excludedIncompleteCount, 0, "scan 2: no exclusions after fix")
+    T.eq(WarRoom.gateExclusionLogEmits, 0, "scan 2: nothing to emit after fix")
+
+    // Scan 3 — BREAK AGAIN (remove the 3rd png ⇒ disk=2): excluded again. Because scan 2
+    // dropped it from the baseline, this must RE-EMIT — a regressed carousel is never
+    // silently swallowed (scar #2, esiste≠armato).
+    try? fm.removeItem(at: slidesDir.appendingPathComponent("3.png"))
+    _ = WarRoom.scanCarousels(carouselRoot: croot, queue: [])
+    T.eq(WarRoom.excludedIncompleteCount, 1, "scan 3: broken-again flapper excluded")
+    T.eq(WarRoom.gateExclusionLogEmits, 1, "guilt: fixed→broken-again re-emits (regression stays observable)")
+}
+
 // MARK: - Codex red-team hardening (2026-07-16, findings #1/#2/#3/#6 on the A2 gate)
 
 func test_matchCarouselPrecedenceOrder() {
@@ -1118,6 +1199,8 @@ let suites: [() -> Void] = [
     test_completeOrNothingGate,
     test_matchCarouselPrecedenceOrder,
     test_completeOrNothingGateHardening,
+    test_gateExclusionDeltaLogging,
+    test_gateExclusionDeltaFixedThenBrokenAgain,
     test_publishEligibilityCrossFinding,
     test_isPublishedIndependentFieldCheck,
     test_stateWiredThroughScanCarousels,


### PR DESCRIPTION
## What

The WR2 control app's completeness gate (`WarRoom.logGateExclusion`) wrote a stderr line for **every** excluded carousel on **every ~10s scan cycle**, re-emitting ~29 identical lines each cycle → `~/Library/Logs/wr2control.err` grew ~30MB/day (open wound in `/wr2` §1 LIVE STATE; scar #2 — noise drowns real signal).

## Fix

Delta-logging: emit a stderr line only when a slug's exclusion is **new** or its **reason changed** vs the immediately-previous scan. `excludedIncompleteCount` (the "N nascosti" gallery badge) still increments on every call, so the count stays byte-identical to pre-diff — only the stderr *write* is throttled, and a first occurrence or any change is always logged (exclusion stays observable).

Baseline rotation (`lastScanExclusions = thisScanExclusions`) happens **after** the unreadable-root guard, never before it: a transient I/O flap must not reset the dedup baseline, or the next successful scan would re-emit everything and recreate the storm on recovery (found by Codex red-team — cross-family #8 network-flap).

## Tests (guilt/innocence, +12 assertions)

- first observation emits; unchanged re-scan suppresses (**the ~30MB/day fix**)
- changed reason re-emits (only the changed one)
- transient root-read failure preserves the baseline → no duplicate burst on recovery (**Codex CADE regression**)
- fixed→broken-again re-emits (a regressed carousel is never silently swallowed)

`zsh apps/wr2-control-app/test.sh` → `RESULT: 191 passed, 0 failed` (up from 179 baseline). QueueWriter harness GREEN, launch-agent config PASS. No regressions.

## Prove-live

The app runs on **M5** (not a Fly deploy). Relaunch (rebuild via `apps/wr2-control-app/build.sh`) picks up the throttle; verified by watching `wr2control.err` stop re-emitting unchanged exclusions each cycle.

## Generator≠grader

Implementer: Sonnet. Adversarial gate: Codex `sol` high red-team (1 CADE on the reset-placement → fixed + regression-tested). Final on-disk gate + independent test re-run by the orchestrator session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
