### PR TITLE
docs(kbli): record Zero ruling — PMA primary verdict stays clean (vintage disclosed in panel only)

### DIFF
--- a/.claude/skills/kbli-navigator/SKILL.md
+++ b/.claude/skills/kbli-navigator/SKILL.md
@@ -84,6 +84,15 @@ probe after 2026-07-19T18:10Z · stray mirror copy in `nuzantara-warroom-images/
   measured pilot report is the basis for the batch-A-remainder GO.
 - **BKPM discrepancy findings stay INTERNAL** (Zero, 2026-07-16): the 68112 surat klarifikasi stays
   drafted in the drawer, not sent, without a fresh Zero GO.
+- **PMA primary-verdict labeling — RULED (Zero, 2026-07-18, Legge 5):** the headline PMA verdict
+  (hero PMABadge + verdict banner + Foreign-Ownership key-facts cells + OG status chip) STAYS a clean
+  OPEN/RESTRICTED/CLOSED. The Perpres-10/49 vintage-2020 + crosswalk-pending status (FATAL-2 axis) is
+  disclosed ONLY in the TRACK-P "Sources & Verification" panel (already live), NOT stamped on the
+  headline verdict. Rationale: the PMA values are the in-force investment-list annexes (not the
+  per_skala silent-fill disease), largely correct; the FATAL-2 per-code crosswalk refines the
+  underlying values later. → the "PMA re-label" follow-up is CLOSED (ruled), not open — do not
+  re-open without a fresh Zero GO.
+
 - **data-plane guard LIVE** (#2550): only `scripts/kbli_filiera/` compilers may write the canonical
   KBLI dataset + `data/kbli-filiera/**`; interactive hand-edits BLOCKED. Registry
   `infra/claude-hooks/data-plane-registry.json` is the extension point. Kill switch


### PR DESCRIPTION
Documentation-only: records a Zero governance ruling (Legge 5, 2026-07-18) as one bullet in the /kbli-navigator corner §1 Governance flags.

**Ruling:** the headline PMA verdict on `/kbli/<code>` (hero PMABadge, verdict banner, Foreign-Ownership key-facts cells, OG status chip) STAYS a clean OPEN/RESTRICTED/CLOSED. The Perpres-10/49 vintage-2020 + crosswalk-pending status (FATAL-2 axis) is disclosed ONLY in the TRACK-P "Sources & Verification" panel (already live), NOT stamped on the headline verdict. Closes the standing "PMA re-label" follow-up as ruled so no KBLI session re-opens it.

No code, no data-plane. Follows the TRACK-P provenance work (PR #2632/#2643) and the corner LIVE-STATE capture (PR #2660).

🤖 Generated with [Claude Code](https://claude.com/claude-code)