### PR TITLE
docs(wr2): corner §4 — mandatory ANTI-TWIN pre-flight at start of every SPRINT B

### DIFF
--- a/.claude/skills/wr2/SKILL.md
+++ b/.claude/skills/wr2/SKILL.md
@@ -197,7 +197,15 @@ Multi-fonte (web + external-bench esistenti in ~/.claude/skills/bali-zero-brand/
 corpus + metriche IG reali). Output: research capture in research/marketing/ con ≥3 fonti e UNA
 raccomandazione azionabile ("adotta X per Y, atteso Z"). Niente ricerca senza raccomandazione.
 
-SPRINT B (build, ~70% del tempo): prendi UN item — dalla raccomandazione dell'ultimo sprint R,
+SPRINT B (build, ~70% del tempo). ANTI-TWIN PRE-FLIGHT (obbligatorio, scar #5 — l'intero sprint B6
+del 2026-07-18 fu un duplicato convergente di una sessione parallela M5, #2680/#2685 vs #2676/#2679,
+~1 sprint bruciato): PRIMA di aprire qualunque lavoro su un wound, per l'item che stai per prendere
+esegui i tre check e STAI GIÙ se un twin è già in volo — (1) `git worktree list` (un lane sibling
+sullo stesso wound è già lì: il tell `wr2-log-delta` era nell'inventario dall'inizio); (2)
+`gh pr list --repo Balizero1987/Teman2 --state all --search "<keyword del wound>"` (twin appena
+aperto/mergiato); (3) grep `origin/main` per il fix già atterrato, verifica per CONTENUTO (W88). Se
+il wound è già curato o in-volo → NON aprire un duplicato: aggiorna solo corner/ledger se stantio e
+passa al prossimo item. POI: prendi UN item — dalla raccomandazione dell'ultimo sprint R,
 dalla §1 LIVE STATE del corner /wr2 (open wounds: liveness scorer 0.0, 13 unknown_intent,
 fact-check degraded, log noise, --rebrief verb…), o da un fix emerso live — e portalo fino in
 fondo con modus: GROUND (ri-grep dei file citati) → BUILD (implementer Sonnet in worktree) →


### PR DESCRIPTION
Structural cure for the sibling-race (scar #5) that cost a full growth-loop sprint (2026-07-18): B6 (gate-log delta-emission) was a 100% convergent duplicate of a parallel M5 session — #2680/#2685 vs the already-merged #2676/#2679 (code + corner + M5 install). The tell (`wr2-log-delta` worktree) was in `git worktree list` the whole time; it was only read when a merge conflict forced it.

Adds a mandatory 3-check pre-flight as the first step of SPRINT B:
1. `git worktree list` — a sibling lane on the same wound is visible there.
2. `gh pr list --search "<wound keyword>"` — an in-flight/just-merged twin.
3. grep `origin/main` for the fix already landed (verify by CONTENT, W88).

If the wound is already cured or in-flight → don't open a duplicate; refresh corner/ledger if stale and move to the next item.

Memory: `discovery_wr2_gate_log_delta_twin_race_2026_07_18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)