### PR TITLE
fix(rag): curated_qa injection was dead in prod — native filter 400s search_collection

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
@@ -355,13 +355,15 @@ class OrchestratorCore:
         method never returns an answer directly and never short-circuits the
         query pipeline.
 
-        Injection is DOMAIN-FILTERED: with the calibrated within-domain
-        threshold (0.58) alone, cosine similarity still overlaps enough
-        across domains that a query in one domain (e.g. "register a PT PMA
-        company") can score above threshold against a curated_qa entry from
-        an unrelated domain (e.g. a visa Q&A) — polluting the answer with
-        irrelevant evidence. Only inject when the query has a concrete,
-        classified domain, and restrict the search itself to that domain.
+        Injection is DOMAIN-GATED: with the score threshold alone, cosine
+        similarity overlaps enough across domains that a query in one domain
+        (e.g. "register a PT PMA company") can score above threshold against a
+        curated_qa entry from an unrelated domain (e.g. a visa Q&A) — polluting
+        the answer with irrelevant evidence. So we only inject when the query
+        has a concrete, classified domain AND each retrieved hit's own `domain`
+        tag matches it (the per-hit recheck below). The gate is applied on the
+        retrieved hits rather than as a Qdrant `filter` argument on purpose —
+        see the search_collection call for why passing a filter there is a trap.
 
         Defensive by design: any failure (Qdrant down, malformed payload,
         missing retriever) is logged and degrades to "" (no injection) —
@@ -389,11 +391,25 @@ class OrchestratorCore:
             return ""
 
         try:
+            # NO Qdrant-level domain filter here (root-caused 2026-07-18):
+            # search_collection() feeds `filter` through SearchService ->
+            # _convert_filter_to_qdrant_format, which expects the SIMPLIFIED
+            # {field: value} shape and re-wraps anything else. A Qdrant-native
+            # {"must": [{"key": "domain", ...}]} filter got mangled into a
+            # condition on a field literally named "must" -> Qdrant HTTP 400
+            # ("Expected some form of condition"); even the simplified
+            # {"domain": domain} form emits an unindexed `metadata.domain` term
+            # -> HTTP 400. Either way the whole search died, so curated_qa
+            # injection NEVER fired in prod (dead since F1b/#2588; #2684's
+            # "domain filter" only reinforced the trap). The per-hit
+            # `hit_domain != domain` recheck below is the real, sufficient
+            # domain gate: every curated_qa point carries a top-level `domain`,
+            # so an off-domain query retrieves only same-store hits and discards
+            # any whose tag doesn't match -> "" (no cross-domain pollution).
             search_result = await self.retriever.search_collection(
                 query=query,
                 collection_name=_CURATED_QA_COLLECTION_NAME,
                 limit=_CURATED_QA_TOP_K,
-                filter={"must": [{"key": "domain", "match": {"value": domain}}]},
             )
             if not isinstance(search_result, dict):
                 # Defensive: search_collection's real contract returns a plain
@@ -410,12 +426,14 @@ class OrchestratorCore:
                 if hit.get("score", 0.0) < _CURATED_QA_SCORE_THRESHOLD:
                     continue
                 metadata = hit.get("metadata") or {}
-                # Belt-and-suspenders: the Qdrant `filter` above is the primary
-                # domain gate, but never trust a single signal (scar family #3
-                # guard-over/under-match) — re-check the hit's own domain tag
-                # and skip on mismatch rather than assume the filter held.
+                # PRIMARY domain gate (there is no Qdrant-level filter — see the
+                # search_collection call above): inject a hit ONLY when its own
+                # `domain` tag equals the query's classified domain. This is what
+                # prevents cross-domain pollution (scar family #3). A hit with a
+                # missing/blank/mismatched domain tag is skipped conservatively —
+                # every real curated_qa point carries an explicit domain.
                 hit_domain = metadata.get("domain")
-                if hit_domain and hit_domain != domain:
+                if hit_domain != domain:
                     continue
                 answer = metadata.get("answer")
                 if not answer:

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_curated_qa_grounding_injection.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_curated_qa_grounding_injection.py
@@ -5,19 +5,22 @@ context as high-priority evidence; the LLM still answers the real question
 and the abstain gate still runs downstream (the injection never short-
 circuits the query, unlike the FAQ cache exact-match path).
 
-Domain filter (2026-07-18): the 0.90 raw-cosine gate almost never fired for
+Domain gate (2026-07-18): the 0.90 raw-cosine gate almost never fired for
 real paraphrased queries (0.46-0.74 cosine vs stored questions). Lowering the
 threshold alone pollutes cross-domain answers (a "register PT PMA" query can
-score >0.58 against a visa Q&A). The fix is DOMAIN-FILTERED injection: only
-inject when the query has a concrete, classified domain, and restrict the
-Qdrant search itself (+ a defensive per-hit re-check) to that domain.
+score high against a visa Q&A). The fix injects ONLY when the query has a
+concrete, classified domain AND each retrieved hit's own `domain` tag matches
+it. Note: NO Qdrant `filter` is passed — search_collection re-wraps a native
+filter into a malformed query that Qdrant 400s (the reason injection was dead
+in prod even after #2684's "domain filter"); the per-hit recheck is the real,
+sufficient domain gate.
 
 Three layers of coverage:
 1. `_inject_curated_qa_grounding()` in isolation — retrieval/formatting/
    threshold/domain-gate/exception-handling logic.
-2. Domain-gate guilt + innocence — proves a matching domain injects (with the
-   domain filter sent to search_collection) and a mismatched/general domain
-   never does, even when a same-score foreign-domain hit is present.
+2. Domain-gate guilt + innocence — proves a matching domain injects (calling
+   search WITHOUT a Qdrant filter) and a mismatched/general domain never does,
+   even when a same-score foreign-domain hit is present.
 3. One process_query_core() wiring test — proves the call site actually
    flows the injected string into the system prompt's additional_context,
    and that the ReAct loop (and therefore the abstain gate) still executes
@@ -137,7 +140,12 @@ async def test_hit_above_threshold_is_prepended_with_source_tag() -> None:
     _, kwargs = core.retriever.search_collection.call_args
     assert kwargs["collection_name"] == "curated_qa"
     assert kwargs["limit"] == 2
-    assert kwargs["filter"] == {"must": [{"key": "domain", "match": {"value": "visa"}}]}
+    # REGRESSION (2026-07-18): the injection must NOT pass a Qdrant-native
+    # `filter` — search_collection re-wraps it through the simplified-format
+    # converter, producing a malformed filter that Qdrant 400s and kills the
+    # whole search (curated_qa injection was dead in prod for exactly this).
+    # Domain scoping is enforced by the per-hit recheck, not a Qdrant filter.
+    assert kwargs.get("filter") is None
 
 
 @pytest.mark.asyncio
@@ -301,9 +309,11 @@ async def test_general_domain_returns_empty_string_and_never_calls_search() -> N
 
 
 @pytest.mark.asyncio
-async def test_concrete_domain_query_sends_matching_qdrant_filter() -> None:
-    """GUILT — a concrete non-general domain (e.g. company) DOES call search,
-    with a Qdrant filter scoped to that exact domain."""
+async def test_concrete_domain_query_searches_without_a_qdrant_filter() -> None:
+    """GUILT + REGRESSION — a concrete non-general domain (e.g. company) DOES
+    call search, but WITHOUT any Qdrant `filter` kwarg. Passing a native
+    {"must": [...]} filter here is the bug that made curated_qa injection 400
+    and go dark in prod; domain scoping is done by the per-hit recheck below."""
     core = make_core()
     search_mock = AsyncMock(return_value=_search_result([]))
     core.retriever = SimpleNamespace(search_collection=search_mock)
@@ -316,17 +326,18 @@ async def test_concrete_domain_query_sends_matching_qdrant_filter() -> None:
     assert result == ""  # no company-domain curated_qa content exists yet
     search_mock.assert_awaited_once()
     _, kwargs = search_mock.call_args
-    assert kwargs["filter"] == {"must": [{"key": "domain", "match": {"value": "company"}}]}
+    assert kwargs.get("filter") is None
 
 
 @pytest.mark.asyncio
 async def test_company_domain_query_never_injects_a_leaked_visa_hit() -> None:
     """INNOCENCE — the core anti-pollution guarantee: a company-domain query
-    must return "" even if the search layer (Qdrant misconfig, or — as
-    simulated here — a permissive test double) leaks back a high-scoring
-    VISA-tagged hit despite the domain=company filter that was requested.
-    The orchestrator's own per-hit domain re-check is the second line of
-    defense (never trust a single signal — scar family #3)."""
+    must return "" even though the search layer returns a high-scoring
+    VISA-tagged hit (all curated_qa content is visa-domain today, and retrieval
+    is unfiltered by design — there is no Qdrant-level domain filter). The
+    orchestrator's per-hit `hit_domain != domain` recheck is the ONLY and
+    sufficient domain gate (match on the entity, not a single upstream signal —
+    scar family #3)."""
     core = make_core()
     core.retriever = SimpleNamespace(
         search_collection=AsyncMock(


### PR DESCRIPTION
## What

The `curated_qa` grounding injection was **completely dead in prod** — the 412 vetted visa Q&A never reached the bot. This fixes the actual root cause.

## Root cause (found by a live `ask_legal` battery, then proven against prod Qdrant)

`_inject_curated_qa_grounding` passed a **Qdrant-native** filter to `search_collection()`:

```python
filter={"must": [{"key": "domain", "match": {"value": domain}}]}
```

But `search_collection` → `SearchService._convert_filter_to_qdrant_format` expects the **simplified** `{field: value}` shape and re-wraps anything else. Iterating the native dict, it took `key="must"`, `value=[…list…]` and emitted a condition on a field literally named `must` matching a list → **Qdrant HTTP 400 "Expected some form of condition"** → the whole search died → caught → `{"results": []}` → **injection never fired**.

Empirically proven this turn against prod `curated_qa`:

| variant | result |
|---|---|
| no filter | ✅ 4 visa hits, top **cos=0.728** (overstay Q&A) |
| **prod's actual filter** (native, double-wrapped) | ❌ **HTTP 400** |
| correct native bare-`domain` | ✅ 4 hits |
| simplified `{domain:visa}`→converter | ❌ **HTTP 400** (unindexed `metadata.domain`) |

So `#2684`'s "domain filter" was **dead on arrival** — every path through the converter 400s. The `ask_legal` battery confirmed: **zero `✅ [CuratedQA] Injected` log lines**, answers sourced from legacy collections, overstay answer missed the 10-year ban.

## Fix

Drop the `filter=` kwarg. Domain scoping is enforced by the **existing per-hit recheck** (tightened to `hit_domain != domain` so untagged hits are also skipped). Every `curated_qa` point carries a top-level `domain`, so an off-domain query retrieves same-store hits and discards any whose tag ≠ the query's classified domain → `""` (no cross-domain pollution — scar family #3, belt-and-suspenders the author already built).

## Tests

- Fixed **3 assertions** that codified the broken native filter as the contract (scar #6 — the tests validated the bug) + a **regression** asserting the injection calls search **without** a filter.
- 19/19 injection tests · 278 orchestrator tests · 91 §11 core-RAG tests · import-chain — all green.

## Follow-ups (separate, pre-existing — NOT in this PR)

- **Multi-agent / specialized routing branches** don't consume `system_context_for_prompt`, so curated grounding (and KG context) is dropped for multi-agent-routed queries (e.g. cost+timeline questions). This is why the overstay query — routed multi-agent — returned evidence 0.
- **Threshold scale**: `0.58` is compared against the formatted `1/(2-cos)` score, not raw cosine (effective floor ≈0.28 cosine). Lenient but domain-gated → not a safety bug.
- 60s MCP timeout on 2/4 multi-agent battery queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
