### PR TITLE
fix(intel): carry structured enrichment through to WR2 drafts — kill enrichment:{} (scar #9)

### DIFF
--- a/apps/backend-rag/backend/app/routers/intel.py
+++ b/apps/backend-rag/backend/app/routers/intel.py
@@ -98,6 +98,25 @@ class ScraperSubmission(BaseModel):
     )
     liveness_tier: Literal["breaking", "developing", "evergreen"] | None = None
     live_news_reasons: list[str] | None = Field(None, max_length=3)
+    # WR2 enrichment passthrough (scar family #9, state-schema mutation
+    # drift): the intel enricher produces a full structured object
+    # (the_facts/bali_zero_take/in_practice/next_steps/faq/
+    # thirty_second_brief/metadata, ~1400-2000 words) but it was lost
+    # before reaching WR2 drafts — wr2_topic_selector wrote enrichment: {}
+    # into every draft's brief_json (verified 2026-06-24: {} on 12/12
+    # drafts). Carried through so the topic selector gets structured
+    # ground truth, not just truncated content. Optional: legacy
+    # callers/scrapers that don't send it keep working unchanged.
+    enrichment: dict | None = Field(
+        None,
+        description=(
+            "Full structured enricher object (the_facts/bali_zero_take/"
+            "in_practice/next_steps/faq/thirty_second_brief/metadata) — "
+            "carried through so wr2_topic_selector gets structured ground "
+            "truth, not just truncated content. Optional: legacy callers "
+            "unaffected (scar #9)."
+        ),
+    )
 
 
 class ApprovalRequest(BaseModel):

--- a/apps/backend-rag/backend/app/routers/intel.py
+++ b/apps/backend-rag/backend/app/routers/intel.py
@@ -205,8 +205,17 @@ async def list_pending_items(
     filter_type: str | None = None,
     sort_type: str | None = None,
     search: str | None = None,
+    include_enrichment: bool = False,
 ) -> Any:
-    """List items pending approval in staging area with filtering and sorting"""
+    """List items pending approval in staging area with filtering and sorting.
+
+    include_enrichment (round-2 red-team MUST-FIX #1, scar family #9):
+    opt-in only. This route has no pagination and the default projection
+    would otherwise ship the full ~1400-2000 word enrichment object on
+    EVERY pending item to EVERY consumer (News Room UI, Visa Oracle UI, MCP
+    tool) — only scripts/wr2_topic_selector.py actually reads it, and only
+    from the single ranked top item. Default False keeps the payload lean.
+    """
     logger.info(
         "Listing pending items",
         extra={
@@ -214,11 +223,18 @@ async def list_pending_items(
             "filter_type": filter_type,
             "sort_type": sort_type,
             "has_search": bool(search),
+            "include_enrichment": include_enrichment,
             "endpoint": "/api/intel/staging/pending",
         },
     )
 
-    return staging_service.list_pending_items(type, filter_type, sort_type, search)
+    return staging_service.list_pending_items(
+        type,
+        filter_type,
+        sort_type,
+        search,
+        include_enrichment=include_enrichment,
+    )
 
 
 @router.get("/api/intel/staging/preview/{type}/{item_id}")

--- a/apps/backend-rag/backend/app/routers/intel_scraper.py
+++ b/apps/backend-rag/backend/app/routers/intel_scraper.py
@@ -457,6 +457,12 @@ async def submit_from_scraper(
             "live_news_reasons": [
                 r.strip()[:200] for r in (submission.live_news_reasons or [])
             ][:3],
+            # WR2 enrichment passthrough (scar family #9): carry the full
+            # structured enricher object into staging so it survives to
+            # wr2_topic_selector via list_pending_items' projection. Default
+            # {} preserves today's behavior for legacy/partial-deploy
+            # scrapers that don't send it yet.
+            "enrichment": submission.enrichment or {},
         }
 
         if submission.cover_image:

--- a/apps/backend-rag/backend/app/routers/intel_scraper.py
+++ b/apps/backend-rag/backend/app/routers/intel_scraper.py
@@ -412,13 +412,54 @@ async def submit_from_scraper(
                 time.time() - start_time,
             )
 
-            return {
+            # Round-2 red-team MUST-FIX #3 (scar family #9): the early
+            # return above happens BEFORE staging_data (with enrichment) is
+            # built below, so a duplicate hit against an item written by an
+            # older/partial-deploy scraper — enrichment absent or `{}` —
+            # would leave that item's future draft stuck at `{}` forever
+            # (7-day dedup window). Heal it in place: merge the new
+            # submission's enrichment into the existing staging file when
+            # the existing item doesn't already have a usable one. Never
+            # let a heal failure turn a successful dedup into a 500 —
+            # log and fall through to the unchanged response shape.
+            enrichment_backfilled = False
+            new_enrichment = submission.enrichment
+            existing_enrichment = duplicate.get("enrichment")
+            dup_item_id = duplicate.get("item_id")
+            if (
+                isinstance(new_enrichment, dict)
+                and new_enrichment
+                and not (isinstance(existing_enrichment, dict) and existing_enrichment)
+                and dup_item_id
+            ):
+                try:
+                    existing_full = staging_service.load_staging_item(intel_type, dup_item_id)
+                    if existing_full is not None:
+                        existing_full["enrichment"] = new_enrichment
+                        staging_service.save_staging_item(intel_type, dup_item_id, existing_full)
+                        enrichment_backfilled = True
+                        logger.info(
+                            "Backfilled enrichment onto duplicate staging item",
+                            extra={"item_id": dup_item_id},
+                        )
+                except Exception:
+                    logger.warning(
+                        "Enrichment backfill failed for duplicate staging item "
+                        "— dedup response unaffected",
+                        extra={"item_id": dup_item_id},
+                        exc_info=True,
+                    )
+
+            response: dict[str, Any] = {
                 "success": True,
                 "message": "Article already exists in staging",
                 "item_id": duplicate.get("item_id"),
                 "intel_type": intel_type,
                 "duplicate": True,
             }
+            if enrichment_backfilled:
+                response["enrichment_backfilled"] = True
+            return response
 
         # WR2 liveness rewire (SPRINT B1, scar family #9 break #2; red-team
         # FIX3 2026-07-18): normalize with uniform defaults so every staging

--- a/apps/backend-rag/backend/app/routers/intel_scraper.py
+++ b/apps/backend-rag/backend/app/routers/intel_scraper.py
@@ -431,6 +431,7 @@ async def submit_from_scraper(
                 and new_enrichment
                 and not (isinstance(existing_enrichment, dict) and existing_enrichment)
                 and dup_item_id
+                and duplicate.get("status") in (None, "pending")
             ):
                 try:
                     existing_full = staging_service.load_staging_item(intel_type, dup_item_id)

--- a/apps/backend-rag/backend/services/intel/intel_staging_service.py
+++ b/apps/backend-rag/backend/services/intel/intel_staging_service.py
@@ -270,6 +270,7 @@ class IntelStagingService:
         filter_type: str | None = None,
         sort_type: str | None = None,
         search: str | None = None,
+        include_enrichment: bool = False,
     ) -> dict[str, Any]:
         """
         List items pending approval in staging area.
@@ -279,6 +280,16 @@ class IntelStagingService:
             filter_type: Optional filter type
             sort_type: Optional sort type
             search: Optional search query
+            include_enrichment: round-2 red-team fix (scar family #9). The
+                full structured enrichment object is ~1400-2000 words; the
+                route has no pagination and most consumers (News Room UI,
+                Visa Oracle UI, MCP tool) never read it — only
+                wr2_topic_selector.py does, and only for the single ranked
+                top item. Default False keeps the default projection lean
+                (no "enrichment" key at all); pass True to opt in. Archived/
+                approved items NEVER carry enrichment regardless of this
+                flag — the topic selector never ranks published items, and
+                UIs that need archived detail already use /preview.
 
         Returns:
             Dictionary with items and count
@@ -320,42 +331,45 @@ class IntelStagingService:
                         # published_url is set ONLY by the publish endpoint, not by scraper
                         if status != "published" and data.get("published_url"):
                             status = "published"
-                        items.append(
-                            {
-                                "id": file_path.stem,
-                                "type": category,
-                                "title": data.get("title", "Untitled"),
-                                "status": status,
-                                "detected_at": data.get("detected_at"),
-                                "source": data.get("source_url", data.get("url", "")),
-                                "detection_type": data.get("detection_type", "NEW"),
-                                "content": data.get("content"),
-                                "cover_image": data.get("cover_image"),
-                                # WR2 liveness rewire (SPRINT B1, scar family
-                                # #9 break #3): these were already persisted
-                                # in staging JSON but never served — legacy
-                                # items (no key) uniformly default to
-                                # 0/"evergreen"/[]. live_news_* trio goes
-                                # through the normalizer (red-team FIX1+FIX2)
-                                # so garbage/null source data can't crash or
-                                # leak downstream.
-                                "tier": data.get("tier"),
-                                "published_at": data.get("published_at"),
-                                "relevance_score": data.get("relevance_score"),
-                                "category": data.get("category"),
-                                # WR2 enrichment passthrough (scar family #9,
-                                # state-schema mutation drift): the full
-                                # structured enricher object was persisted in
-                                # staging JSON (write side, submit_from_scraper)
-                                # but this projection is what wr2_topic_selector
-                                # actually consumes via GET /api/intel/staging/
-                                # pending — omitting it here would silently
-                                # drop it again even after the write-side fix.
-                                # Default {} for legacy items without the key.
-                                "enrichment": data.get("enrichment") or {},
-                                **_normalize_live_news_projection(data),
-                            },
-                        )
+                        projected: dict[str, Any] = {
+                            "id": file_path.stem,
+                            "type": category,
+                            "title": data.get("title", "Untitled"),
+                            "status": status,
+                            "detected_at": data.get("detected_at"),
+                            "source": data.get("source_url", data.get("url", "")),
+                            "detection_type": data.get("detection_type", "NEW"),
+                            "content": data.get("content"),
+                            "cover_image": data.get("cover_image"),
+                            # WR2 liveness rewire (SPRINT B1, scar family
+                            # #9 break #3): these were already persisted
+                            # in staging JSON but never served — legacy
+                            # items (no key) uniformly default to
+                            # 0/"evergreen"/[]. live_news_* trio goes
+                            # through the normalizer (red-team FIX1+FIX2)
+                            # so garbage/null source data can't crash or
+                            # leak downstream.
+                            "tier": data.get("tier"),
+                            "published_at": data.get("published_at"),
+                            "relevance_score": data.get("relevance_score"),
+                            "category": data.get("category"),
+                            **_normalize_live_news_projection(data),
+                        }
+                        # WR2 enrichment passthrough round-2 red-team fix
+                        # (scar family #9, state-schema mutation drift):
+                        # opt-in only (payload fan-out, MUST-FIX #1) — the
+                        # route has no pagination and only the topic
+                        # selector reads this, from the single ranked top
+                        # item. Type-guarded (MUST-FIX #2) — a hand-edited/
+                        # legacy staging JSON can carry a truthy non-dict
+                        # (e.g. a list); `or {}` only normalizes falsy
+                        # values, so a non-dict would otherwise pass through
+                        # and crash wr2_draft_generator.py's unguarded
+                        # `.get("thirty_second_brief")` downstream.
+                        if include_enrichment:
+                            _enr = data.get("enrichment")
+                            projected["enrichment"] = _enr if isinstance(_enr, dict) else {}
+                        items.append(projected)
                 except Exception as e:
                     logger.error(
                         "Error reading staging file %s: %s",
@@ -392,9 +406,12 @@ class IntelStagingService:
                                     "published_at": data.get("published_at"),
                                     "relevance_score": data.get("relevance_score"),
                                     "category": data.get("category"),
-                                    # WR2 enrichment passthrough (scar family
-                                    # #9) — mirror the staging-root branch above.
-                                    "enrichment": data.get("enrichment") or {},
+                                    # Round-2 red-team MUST-FIX #1: archived/
+                                    # approved items NEVER carry enrichment
+                                    # (regardless of include_enrichment) —
+                                    # the topic selector never ranks
+                                    # published items, and detail-view
+                                    # consumers already use /preview.
                                     **_normalize_live_news_projection(data),
                                 },
                             )

--- a/apps/backend-rag/backend/services/intel/intel_staging_service.py
+++ b/apps/backend-rag/backend/services/intel/intel_staging_service.py
@@ -343,6 +343,16 @@ class IntelStagingService:
                                 "published_at": data.get("published_at"),
                                 "relevance_score": data.get("relevance_score"),
                                 "category": data.get("category"),
+                                # WR2 enrichment passthrough (scar family #9,
+                                # state-schema mutation drift): the full
+                                # structured enricher object was persisted in
+                                # staging JSON (write side, submit_from_scraper)
+                                # but this projection is what wr2_topic_selector
+                                # actually consumes via GET /api/intel/staging/
+                                # pending — omitting it here would silently
+                                # drop it again even after the write-side fix.
+                                # Default {} for legacy items without the key.
+                                "enrichment": data.get("enrichment") or {},
                                 **_normalize_live_news_projection(data),
                             },
                         )
@@ -382,6 +392,9 @@ class IntelStagingService:
                                     "published_at": data.get("published_at"),
                                     "relevance_score": data.get("relevance_score"),
                                     "category": data.get("category"),
+                                    # WR2 enrichment passthrough (scar family
+                                    # #9) — mirror the staging-root branch above.
+                                    "enrichment": data.get("enrichment") or {},
                                     **_normalize_live_news_projection(data),
                                 },
                             )

--- a/apps/backend-rag/backend/tests/services/intel/test_intel_staging_service.py
+++ b/apps/backend-rag/backend/tests/services/intel/test_intel_staging_service.py
@@ -191,15 +191,45 @@ def test_list_pending_items_projects_tier_and_live_news_fields(tmp_path: Path) -
     assert archived["live_news_reasons"] == ["price hike confirmed"]
 
 
-def test_list_pending_items_projects_enrichment_object(tmp_path: Path) -> None:
-    """GUILT (WR2 enrichment passthrough, scar family #9): a non-empty
-    `enrichment` persisted in staging JSON must be projected verbatim in
-    BOTH the staging-root branch AND the archived/approved branch —
-    wr2_topic_selector.py reads `top_item.get("enrichment")` straight off
-    the pending item served by this method (via GET
-    /api/intel/staging/pending), not from the raw JSON file directly, so
-    omitting it here would silently drop it even after a correct write-side
-    fix."""
+def test_list_pending_items_omits_enrichment_by_default(tmp_path: Path) -> None:
+    """GUILT (round-2 red-team MUST-FIX #1, payload fan-out regression): the
+    default call (include_enrichment=False, the route's default) must NOT
+    emit the "enrichment" key at all — the route has no pagination and
+    almost every consumer (News Room UI, Visa Oracle UI, MCP tool) never
+    reads it. Only opt-in callers (wr2_topic_selector.py) should pay the
+    ~1400-2000 word payload cost."""
+    service = _service(tmp_path)
+    now = datetime.now(timezone.utc).isoformat()
+    enrichment_obj = {"the_facts": "Facts here.", "bali_zero_take": "Our take."}
+    service.save_staging_item(
+        "visa",
+        "visa-enriched",
+        {
+            "title": "Enriched update",
+            "source_url": "https://example.com/enriched",
+            "detected_at": now,
+            "content": "content",
+            "enrichment": enrichment_obj,
+        },
+    )
+
+    result = service.list_pending_items()  # include_enrichment defaults False
+
+    item = next(i for i in result["items"] if i["id"] == "visa-enriched")
+    assert "enrichment" not in item
+
+
+def test_list_pending_items_projects_enrichment_object_when_opted_in(tmp_path: Path) -> None:
+    """GUILT (WR2 enrichment passthrough, scar family #9; round-2 red-team
+    MUST-FIX #1): with include_enrichment=True, a non-empty `enrichment`
+    persisted in staging JSON must be projected verbatim in the
+    staging-root branch — wr2_topic_selector.py reads
+    `top_item.get("enrichment")` straight off the pending item served by
+    this method (via GET /api/intel/staging/pending?include_enrichment=true),
+    not from the raw JSON file directly, so omitting it here would silently
+    drop it even after a correct write-side fix. The archived/approved
+    branch must NEVER carry it, regardless of the flag — the topic selector
+    never ranks published items and detail-view consumers use /preview."""
     service = _service(tmp_path)
     now = datetime.now(timezone.utc).isoformat()
     enrichment_obj = {
@@ -235,20 +265,20 @@ def test_list_pending_items_projects_enrichment_object(tmp_path: Path) -> None:
         ),
     )
 
-    result = service.list_pending_items()
+    result = service.list_pending_items(include_enrichment=True)
 
     items_by_id = {item["id"]: item for item in result["items"]}
     assert items_by_id["visa-enriched"]["enrichment"] == enrichment_obj
-    assert items_by_id["news-enriched"]["enrichment"] == enrichment_obj
+    assert "enrichment" not in items_by_id["news-enriched"]
 
 
 def test_list_pending_items_defaults_enrichment_to_empty_dict_for_legacy_items(
     tmp_path: Path,
 ) -> None:
     """INNOCENCE: legacy staging JSON written before the enrichment
-    passthrough fix has no `enrichment` key at all — projection must
-    default to {} uniformly, never KeyError or bare None (mirrors the
-    live_news_* trio's legacy-default contract)."""
+    passthrough fix has no `enrichment` key at all — with include_enrichment
+    =True, projection must default to {} uniformly, never KeyError or bare
+    None (mirrors the live_news_* trio's legacy-default contract)."""
     service = _service(tmp_path)
     now = datetime.now(timezone.utc).isoformat()
     service.save_staging_item(
@@ -262,12 +292,42 @@ def test_list_pending_items_defaults_enrichment_to_empty_dict_for_legacy_items(
         },
     )
 
-    result = service.list_pending_items()
+    result = service.list_pending_items(include_enrichment=True)
 
     legacy = next(
         item for item in result["items"] if item["id"] == "news-legacy-enrichment"
     )
     assert legacy["enrichment"] == {}
+
+
+def test_list_pending_items_coerces_non_dict_enrichment_to_empty_dict(
+    tmp_path: Path,
+) -> None:
+    """GUILT (round-2 red-team MUST-FIX #2): a hand-edited/legacy staging
+    JSON can carry a truthy non-dict `enrichment` (e.g. a list) — `or {}`
+    alone only normalizes falsy values, so a non-dict would otherwise pass
+    through the projection and crash wr2_draft_generator.py's unguarded
+    `.get("thirty_second_brief")` downstream. Must project to {}."""
+    service = _service(tmp_path)
+    now = datetime.now(timezone.utc).isoformat()
+    service.save_staging_item(
+        "news",
+        "news-dirty-enrichment",
+        {
+            "title": "Dirty item",
+            "source_url": "https://example.com/dirty",
+            "detected_at": now,
+            "content": "content",
+            "enrichment": ["bad"],
+        },
+    )
+
+    result = service.list_pending_items(include_enrichment=True)
+
+    dirty = next(
+        item for item in result["items"] if item["id"] == "news-dirty-enrichment"
+    )
+    assert dirty["enrichment"] == {}
 
 
 def test_list_pending_items_defaults_legacy_items_without_live_news_fields(

--- a/apps/backend-rag/backend/tests/services/intel/test_intel_staging_service.py
+++ b/apps/backend-rag/backend/tests/services/intel/test_intel_staging_service.py
@@ -191,6 +191,85 @@ def test_list_pending_items_projects_tier_and_live_news_fields(tmp_path: Path) -
     assert archived["live_news_reasons"] == ["price hike confirmed"]
 
 
+def test_list_pending_items_projects_enrichment_object(tmp_path: Path) -> None:
+    """GUILT (WR2 enrichment passthrough, scar family #9): a non-empty
+    `enrichment` persisted in staging JSON must be projected verbatim in
+    BOTH the staging-root branch AND the archived/approved branch —
+    wr2_topic_selector.py reads `top_item.get("enrichment")` straight off
+    the pending item served by this method (via GET
+    /api/intel/staging/pending), not from the raw JSON file directly, so
+    omitting it here would silently drop it even after a correct write-side
+    fix."""
+    service = _service(tmp_path)
+    now = datetime.now(timezone.utc).isoformat()
+    enrichment_obj = {
+        "the_facts": "Facts here.",
+        "bali_zero_take": "Our take.",
+        "thirty_second_brief": "Brief.",
+        "faq": [{"q": "Q1", "a": "A1"}],
+        "metadata": {"suggested_slug": "slug", "tags": ["tag1"]},
+    }
+    service.save_staging_item(
+        "visa",
+        "visa-enriched",
+        {
+            "title": "Enriched update",
+            "source_url": "https://example.com/enriched",
+            "detected_at": now,
+            "content": "content",
+            "enrichment": enrichment_obj,
+        },
+    )
+
+    archived_dir = tmp_path / "news" / "archived" / "approved"
+    archived_dir.mkdir(parents=True)
+    (archived_dir / "news-enriched.json").write_text(
+        json.dumps(
+            {
+                "title": "Archived enriched update",
+                "source_url": "https://example.com/archived-enriched",
+                "detected_at": now,
+                "content": "content",
+                "enrichment": enrichment_obj,
+            },
+        ),
+    )
+
+    result = service.list_pending_items()
+
+    items_by_id = {item["id"]: item for item in result["items"]}
+    assert items_by_id["visa-enriched"]["enrichment"] == enrichment_obj
+    assert items_by_id["news-enriched"]["enrichment"] == enrichment_obj
+
+
+def test_list_pending_items_defaults_enrichment_to_empty_dict_for_legacy_items(
+    tmp_path: Path,
+) -> None:
+    """INNOCENCE: legacy staging JSON written before the enrichment
+    passthrough fix has no `enrichment` key at all — projection must
+    default to {} uniformly, never KeyError or bare None (mirrors the
+    live_news_* trio's legacy-default contract)."""
+    service = _service(tmp_path)
+    now = datetime.now(timezone.utc).isoformat()
+    service.save_staging_item(
+        "news",
+        "news-legacy-enrichment",
+        {
+            "title": "Legacy item",
+            "source_url": "https://example.com/legacy",
+            "detected_at": now,
+            "content": "content",
+        },
+    )
+
+    result = service.list_pending_items()
+
+    legacy = next(
+        item for item in result["items"] if item["id"] == "news-legacy-enrichment"
+    )
+    assert legacy["enrichment"] == {}
+
+
 def test_list_pending_items_defaults_legacy_items_without_live_news_fields(
     tmp_path: Path,
 ) -> None:

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_coverage.py
@@ -471,6 +471,105 @@ async def test_submit_scraper_trusts_explicit_tier_over_score_derivation(
     assert staging_data["liveness_tier"] == "breaking"
 
 
+# ---------------------------------------------------------------------------
+# Tests: submit_from_scraper — enrichment passthrough (scar family #9,
+# state-schema mutation drift). The intel enricher produces a full
+# structured object (the_facts/bali_zero_take/in_practice/next_steps/faq/
+# thirty_second_brief/metadata) but ScraperSubmission had no field to
+# receive it — wr2_topic_selector wrote enrichment: {} into every draft's
+# brief_json (verified 2026-06-24: {} on 12/12 drafts).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_scraper_enrichment_persisted(client_no_auth):
+    """GUILT: a submitted `enrichment` object round-trips verbatim into
+    staging_data over the HTTP contract (not just at the Pydantic-model
+    level)."""
+    mock_classification_svc = MagicMock()
+    mock_classification_svc.classify_intel_type.return_value = "news"
+
+    mock_staging_svc = MagicMock()
+    mock_staging_svc.generate_item_id.return_value = "news-2026-enrich-http"
+    mock_staging_svc.check_duplicate.return_value = None
+    mock_staging_svc.save_staging_item.return_value = (
+        "/tmp/intel_pending/news/news-2026-enrich-http.json"
+    )
+    mock_staging_svc.update_staging_queue_metrics = MagicMock()
+
+    enrichment_obj = {
+        "the_facts": "Facts here.",
+        "bali_zero_take": "Our take.",
+        "thirty_second_brief": "Brief.",
+        "faq": [{"q": "Q1", "a": "A1"}],
+        "metadata": {"suggested_slug": "slug", "tags": ["tag1"]},
+    }
+    payload = {**SCRAPER_PAYLOAD, "enrichment": enrichment_obj}
+
+    with (
+        patch(
+            "backend.app.utils.internal_api_auth.api_key_auth.validate_api_key",
+            return_value={"role": "service"},
+        ),
+        patch("backend.app.routers.intel_scraper.classification_service", mock_classification_svc),
+        patch("backend.app.routers.intel_scraper.staging_service", mock_staging_svc),
+        patch("backend.app.routers.intel_scraper.intel_articles_submitted"),
+        patch("backend.app.routers.intel_scraper.intel_articles_duplicates"),
+        patch("backend.app.routers.intel_scraper.intel_scraper_latency"),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/intel/scraper/submit",
+                json=payload,
+                headers={"X-API-Key": "test-intel-api-key"},
+            )
+
+    assert response.status_code == 200
+    mock_staging_svc.save_staging_item.assert_called_once()
+    staging_data = mock_staging_svc.save_staging_item.call_args[0][2]
+    assert staging_data["enrichment"] == enrichment_obj
+
+
+@pytest.mark.asyncio
+async def test_submit_scraper_enrichment_absent_still_validates(client_no_auth):
+    """INNOCENCE (backward-compat): a legacy payload WITHOUT `enrichment`
+    still validates (200, not 422) and defaults to {} in staging_data —
+    the additive/optional field must never break existing scraper
+    callers."""
+    mock_classification_svc = MagicMock()
+    mock_classification_svc.classify_intel_type.return_value = "news"
+
+    mock_staging_svc = MagicMock()
+    mock_staging_svc.generate_item_id.return_value = "news-2026-no-enrich"
+    mock_staging_svc.check_duplicate.return_value = None
+    mock_staging_svc.save_staging_item.return_value = (
+        "/tmp/intel_pending/news/news-2026-no-enrich.json"
+    )
+    mock_staging_svc.update_staging_queue_metrics = MagicMock()
+
+    with (
+        patch(
+            "backend.app.utils.internal_api_auth.api_key_auth.validate_api_key",
+            return_value={"role": "service"},
+        ),
+        patch("backend.app.routers.intel_scraper.classification_service", mock_classification_svc),
+        patch("backend.app.routers.intel_scraper.staging_service", mock_staging_svc),
+        patch("backend.app.routers.intel_scraper.intel_articles_submitted"),
+        patch("backend.app.routers.intel_scraper.intel_articles_duplicates"),
+        patch("backend.app.routers.intel_scraper.intel_scraper_latency"),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/intel/scraper/submit",
+                json=SCRAPER_PAYLOAD,
+                headers={"X-API-Key": "test-intel-api-key"},
+            )
+
+    assert response.status_code == 200
+    staging_data = mock_staging_svc.save_staging_item.call_args[0][2]
+    assert staging_data["enrichment"] == {}
+
+
 @pytest.mark.asyncio
 async def test_submit_scraper_missing_api_key(client_no_auth):
     """Missing API key → 401."""

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_coverage.py
@@ -232,6 +232,61 @@ async def test_submit_scraper_duplicate_article(client_no_auth):
     assert data["item_id"] == "news-existing"
 
 
+@pytest.mark.asyncio
+async def test_submit_scraper_duplicate_backfills_enrichment(client_no_auth):
+    """GUILT (round-2 red-team MUST-FIX #3, scar family #9): re-submitting
+    a duplicate URL whose existing staging file has no usable enrichment,
+    with a non-empty enrichment in the NEW submission, must heal the
+    existing file in place (HTTP-level round-trip of the same fix covered
+    at the router-unit level)."""
+    mock_classification_svc = MagicMock()
+    mock_classification_svc.classify_intel_type.return_value = "news"
+
+    existing_item = {
+        "item_id": "news-existing-heal",
+        "title": "Existing",
+        "source_url": SCRAPER_PAYLOAD["source_url"],
+        "enrichment": {},
+    }
+    mock_staging_svc = MagicMock()
+    mock_staging_svc.generate_item_id.return_value = "news-new-submission"
+    mock_staging_svc.check_duplicate.return_value = existing_item
+    mock_staging_svc.load_staging_item.return_value = dict(existing_item)
+    mock_staging_svc.update_staging_queue_metrics = MagicMock()
+
+    enrichment_obj = {"the_facts": "Fresh facts.", "bali_zero_take": "Fresh take."}
+    payload = {**SCRAPER_PAYLOAD, "enrichment": enrichment_obj}
+
+    with (
+        patch(
+            "backend.app.utils.internal_api_auth.api_key_auth.validate_api_key",
+            return_value={"role": "service"},
+        ),
+        patch("backend.app.routers.intel_scraper.classification_service", mock_classification_svc),
+        patch("backend.app.routers.intel_scraper.staging_service", mock_staging_svc),
+        patch("backend.app.routers.intel_scraper.intel_articles_submitted"),
+        patch("backend.app.routers.intel_scraper.intel_articles_duplicates"),
+        patch("backend.app.routers.intel_scraper.intel_scraper_latency"),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/intel/scraper/submit",
+                json=payload,
+                headers={"X-API-Key": "test-intel-api-key"},
+            )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["duplicate"] is True
+    assert data["enrichment_backfilled"] is True
+    mock_staging_svc.load_staging_item.assert_called_once_with("news", "news-existing-heal")
+    mock_staging_svc.save_staging_item.assert_called_once()
+    saved_type, saved_id, saved_data = mock_staging_svc.save_staging_item.call_args[0]
+    assert saved_type == "news"
+    assert saved_id == "news-existing-heal"
+    assert saved_data["enrichment"] == enrichment_obj
+
+
 # ---------------------------------------------------------------------------
 # Tests: submit_from_scraper — live_news fields (WR2 liveness rewire, break #2)
 #

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
@@ -412,6 +412,90 @@ class TestSubmitFromScraper:
             assert exc_info.value.status_code == 500
 
     @pytest.mark.asyncio
+    async def test_enrichment_persisted(self) -> None:
+        """GUILT (WR2 enrichment passthrough, scar family #9): a
+        ScraperSubmission carrying a full structured `enrichment` object
+        must round-trip it verbatim into staging_data."""
+        from backend.app.routers.intel import ScraperSubmission
+        from backend.app.routers.intel_scraper import submit_from_scraper
+
+        with (
+            patch("backend.app.routers.intel_scraper.classification_service") as mock_cls,
+            patch("backend.app.routers.intel_scraper.staging_service") as mock_stg,
+            patch("backend.app.routers.intel_scraper.intel_articles_submitted") as mock_metric,
+            patch("backend.app.routers.intel_scraper.intel_scraper_latency") as mock_latency,
+        ):
+            mock_cls.classify_intel_type.return_value = "news"
+            mock_stg.generate_item_id.return_value = "news-2026-enriched"
+            mock_stg.check_duplicate.return_value = None
+            mock_stg.save_staging_item.return_value = "/tmp/staging/news/news-2026-enriched.json"
+            mock_stg.update_staging_queue_metrics = MagicMock()
+            mock_metric.labels.return_value.inc = MagicMock()
+            mock_latency.labels.return_value.observe = MagicMock()
+
+            enrichment_obj = {
+                "the_facts": "Facts here.",
+                "bali_zero_take": "Our take.",
+                "thirty_second_brief": "Brief.",
+                "faq": [{"q": "Q1", "a": "A1"}],
+            }
+            submission = ScraperSubmission(
+                title="Enriched article",
+                content="Content",
+                source_url="https://example.com/enriched",
+                source_name="test-scraper",
+                category="news",
+                relevance_score=70,
+                extraction_method="auto",
+                tier="tier1",
+                enrichment=enrichment_obj,
+            )
+            result = await submit_from_scraper(submission=submission, _api_key_verified=None)
+
+        assert result["success"] is True
+        mock_stg.save_staging_item.assert_called_once()
+        staging_data = mock_stg.save_staging_item.call_args[0][2]
+        assert staging_data["enrichment"] == enrichment_obj
+
+    @pytest.mark.asyncio
+    async def test_enrichment_defaults_to_empty_dict_when_absent(self) -> None:
+        """INNOCENCE: a legacy submission WITHOUT `enrichment` must still
+        validate (backward-compat) and default to {} in staging_data — not
+        crash, not omit the key entirely."""
+        from backend.app.routers.intel import ScraperSubmission
+        from backend.app.routers.intel_scraper import submit_from_scraper
+
+        with (
+            patch("backend.app.routers.intel_scraper.classification_service") as mock_cls,
+            patch("backend.app.routers.intel_scraper.staging_service") as mock_stg,
+            patch("backend.app.routers.intel_scraper.intel_articles_submitted") as mock_metric,
+            patch("backend.app.routers.intel_scraper.intel_scraper_latency") as mock_latency,
+        ):
+            mock_cls.classify_intel_type.return_value = "news"
+            mock_stg.generate_item_id.return_value = "news-2026-legacy"
+            mock_stg.check_duplicate.return_value = None
+            mock_stg.save_staging_item.return_value = "/tmp/staging/news/news-2026-legacy.json"
+            mock_stg.update_staging_queue_metrics = MagicMock()
+            mock_metric.labels.return_value.inc = MagicMock()
+            mock_latency.labels.return_value.observe = MagicMock()
+
+            submission = ScraperSubmission(
+                title="Legacy article",
+                content="Content",
+                source_url="https://example.com/legacy",
+                source_name="test-scraper",
+                category="news",
+                relevance_score=50,
+                extraction_method="auto",
+                tier="tier1",
+            )
+            result = await submit_from_scraper(submission=submission, _api_key_verified=None)
+
+        assert result["success"] is True
+        staging_data = mock_stg.save_staging_item.call_args[0][2]
+        assert staging_data["enrichment"] == {}
+
+    @pytest.mark.asyncio
     async def test_with_cover_image(self) -> None:
         from backend.app.routers.intel import ScraperSubmission
         from backend.app.routers.intel_scraper import submit_from_scraper

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
@@ -388,6 +388,146 @@ class TestSubmitFromScraper:
         assert result["success"] is True
 
     @pytest.mark.asyncio
+    async def test_duplicate_backfills_enrichment_when_existing_item_lacks_it(self) -> None:
+        """GUILT (round-2 red-team MUST-FIX #3, scar family #9): a
+        duplicate hit against an existing staging item with no usable
+        enrichment must be healed in place when the new submission carries
+        one — the early-return dedup response happens BEFORE staging_data
+        is built, so without this fix the existing item's future draft
+        would stay stuck at {} forever (7-day dedup window)."""
+        from backend.app.routers.intel import ScraperSubmission
+        from backend.app.routers.intel_scraper import submit_from_scraper
+
+        with (
+            patch("backend.app.routers.intel_scraper.classification_service") as mock_cls,
+            patch("backend.app.routers.intel_scraper.staging_service") as mock_stg,
+            patch("backend.app.routers.intel_scraper.intel_articles_duplicates") as mock_dup,
+            patch("backend.app.routers.intel_scraper.intel_scraper_latency") as mock_latency,
+        ):
+            mock_cls.classify_intel_type.return_value = "news"
+            mock_stg.generate_item_id.return_value = "news-2026-dup"
+            existing_item = {
+                "item_id": "news-2026-existing",
+                "title": "Existing",
+                "source_url": "https://example.com/dup",
+                "enrichment": {},
+            }
+            mock_stg.check_duplicate.return_value = existing_item
+            mock_stg.load_staging_item.return_value = dict(existing_item)
+            mock_dup.labels.return_value.inc = MagicMock()
+            mock_latency.labels.return_value.observe = MagicMock()
+
+            enrichment_obj = {
+                "the_facts": "Fresh facts.",
+                "bali_zero_take": "Fresh take.",
+            }
+            submission = ScraperSubmission(
+                title="Duplicate with enrichment",
+                content="Content",
+                source_url="https://example.com/dup",
+                source_name="scraper",
+                category="news",
+                relevance_score=50,
+                extraction_method="auto",
+                tier="tier1",
+                enrichment=enrichment_obj,
+            )
+            result = await submit_from_scraper(submission=submission, _api_key_verified=None)
+
+        assert result["duplicate"] is True
+        assert result["success"] is True
+        assert result["enrichment_backfilled"] is True
+        mock_stg.load_staging_item.assert_called_once_with("news", "news-2026-existing")
+        mock_stg.save_staging_item.assert_called_once()
+        saved_type, saved_id, saved_data = mock_stg.save_staging_item.call_args[0]
+        assert saved_type == "news"
+        assert saved_id == "news-2026-existing"
+        assert saved_data["enrichment"] == enrichment_obj
+
+    @pytest.mark.asyncio
+    async def test_duplicate_skips_backfill_when_existing_already_has_enrichment(
+        self,
+    ) -> None:
+        """INNOCENCE: an existing duplicate that ALREADY carries a
+        non-empty enrichment dict must not be touched — no load/save call,
+        no `enrichment_backfilled` key in the response."""
+        from backend.app.routers.intel import ScraperSubmission
+        from backend.app.routers.intel_scraper import submit_from_scraper
+
+        with (
+            patch("backend.app.routers.intel_scraper.classification_service") as mock_cls,
+            patch("backend.app.routers.intel_scraper.staging_service") as mock_stg,
+            patch("backend.app.routers.intel_scraper.intel_articles_duplicates") as mock_dup,
+            patch("backend.app.routers.intel_scraper.intel_scraper_latency") as mock_latency,
+        ):
+            mock_cls.classify_intel_type.return_value = "news"
+            mock_stg.generate_item_id.return_value = "news-2026-dup2"
+            mock_stg.check_duplicate.return_value = {
+                "item_id": "news-2026-existing2",
+                "enrichment": {"the_facts": "Already there."},
+            }
+            mock_dup.labels.return_value.inc = MagicMock()
+            mock_latency.labels.return_value.observe = MagicMock()
+
+            submission = ScraperSubmission(
+                title="Duplicate again",
+                content="Content",
+                source_url="https://example.com/dup2",
+                source_name="scraper",
+                category="news",
+                relevance_score=50,
+                extraction_method="auto",
+                tier="tier1",
+                enrichment={"the_facts": "New but should not overwrite."},
+            )
+            result = await submit_from_scraper(submission=submission, _api_key_verified=None)
+
+        assert result["duplicate"] is True
+        assert "enrichment_backfilled" not in result
+        mock_stg.load_staging_item.assert_not_called()
+        mock_stg.save_staging_item.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_backfill_failure_does_not_break_dedup_response(self) -> None:
+        """Heal-attempt failures must never turn a successful dedup into a
+        500 — log and fall through to the unchanged response shape."""
+        from backend.app.routers.intel import ScraperSubmission
+        from backend.app.routers.intel_scraper import submit_from_scraper
+
+        with (
+            patch("backend.app.routers.intel_scraper.classification_service") as mock_cls,
+            patch("backend.app.routers.intel_scraper.staging_service") as mock_stg,
+            patch("backend.app.routers.intel_scraper.intel_articles_duplicates") as mock_dup,
+            patch("backend.app.routers.intel_scraper.intel_scraper_latency") as mock_latency,
+        ):
+            mock_cls.classify_intel_type.return_value = "news"
+            mock_stg.generate_item_id.return_value = "news-2026-dup3"
+            mock_stg.check_duplicate.return_value = {
+                "item_id": "news-2026-existing3",
+                "enrichment": {},
+            }
+            mock_stg.load_staging_item.side_effect = OSError("disk error")
+            mock_dup.labels.return_value.inc = MagicMock()
+            mock_latency.labels.return_value.observe = MagicMock()
+
+            submission = ScraperSubmission(
+                title="Duplicate heal failure",
+                content="Content",
+                source_url="https://example.com/dup3",
+                source_name="scraper",
+                category="news",
+                relevance_score=50,
+                extraction_method="auto",
+                tier="tier1",
+                enrichment={"the_facts": "New."},
+            )
+            result = await submit_from_scraper(submission=submission, _api_key_verified=None)
+
+        assert result["success"] is True
+        assert result["duplicate"] is True
+        assert "enrichment_backfilled" not in result
+
+    @pytest.mark.asyncio
     async def test_service_error(self) -> None:
         from fastapi import HTTPException
 

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
@@ -488,6 +488,53 @@ class TestSubmitFromScraper:
         mock_stg.save_staging_item.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_duplicate_skips_backfill_when_existing_is_published(self) -> None:
+        """INNOCENCE (round-3 NICE fix, scar family #9): a duplicate hit
+        against an existing staging item that is already `status: published`
+        must NOT be healed even when it lacks enrichment and the new
+        submission carries one. Published items still live in the staging
+        root (the Telegram-quorum publish path never archives them), so an
+        unconditional heal would write to a closed/live record. No
+        downstream reader depends on this today (topic-selector filters
+        status=="pending"), but the write itself must not happen."""
+        from backend.app.routers.intel import ScraperSubmission
+        from backend.app.routers.intel_scraper import submit_from_scraper
+
+        with (
+            patch("backend.app.routers.intel_scraper.classification_service") as mock_cls,
+            patch("backend.app.routers.intel_scraper.staging_service") as mock_stg,
+            patch("backend.app.routers.intel_scraper.intel_articles_duplicates") as mock_dup,
+            patch("backend.app.routers.intel_scraper.intel_scraper_latency") as mock_latency,
+        ):
+            mock_cls.classify_intel_type.return_value = "news"
+            mock_stg.generate_item_id.return_value = "news-2026-dup4"
+            mock_stg.check_duplicate.return_value = {
+                "item_id": "news-2026-existing4",
+                "enrichment": {},
+                "status": "published",
+            }
+            mock_dup.labels.return_value.inc = MagicMock()
+            mock_latency.labels.return_value.observe = MagicMock()
+
+            submission = ScraperSubmission(
+                title="Duplicate against published item",
+                content="Content",
+                source_url="https://example.com/dup4",
+                source_name="scraper",
+                category="news",
+                relevance_score=50,
+                extraction_method="auto",
+                tier="tier1",
+                enrichment={"the_facts": "New but must not land on a published item."},
+            )
+            result = await submit_from_scraper(submission=submission, _api_key_verified=None)
+
+        assert result["duplicate"] is True
+        assert "enrichment_backfilled" not in result
+        mock_stg.load_staging_item.assert_not_called()
+        mock_stg.save_staging_item.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_duplicate_backfill_failure_does_not_break_dedup_response(self) -> None:
         """Heal-attempt failures must never turn a successful dedup into a
         500 — log and fall through to the unchanged response shape."""

--- a/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+++ b/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
@@ -147,6 +147,16 @@ def build_staging_payload(art: dict) -> dict:
         _tier = enr.get("liveness_tier")
         payload["liveness_tier"] = _tier if _tier else _derive_tier_from_score(enr["live_news_score"])
         payload["live_news_reasons"] = (enr.get("live_news_reasons") or [])[:3]
+    # WR2 enrichment passthrough (scar family #9, state-schema mutation
+    # drift): the full structured enricher object above was FLATTENED into
+    # content/brief/faq/slug/tags — never sent as a nested object — so
+    # wr2_topic_selector.py's `top_item.get("enrichment") or {}` always saw
+    # {} (verified 2026-06-24: {} on 12/12 drafts). Additive only: does NOT
+    # remove the flattened fields above (other surfaces may still read
+    # them). Only set when non-empty so a partial deploy degrades
+    # gracefully (today's behavior either direction).
+    if enr:
+        payload["enrichment"] = enr
     return payload
 
 

--- a/apps/bali-intel-scraper/tests/unit/test_run_intel_pipeline_build_staging_payload.py
+++ b/apps/bali-intel-scraper/tests/unit/test_run_intel_pipeline_build_staging_payload.py
@@ -175,6 +175,62 @@ def test_payload_trusts_explicit_tier_over_score_derivation() -> None:
     assert payload["liveness_tier"] == "breaking"
 
 
+# ---------------------------------------------------------------------------
+# enrichment passthrough (scar family #9, state-schema mutation drift): the
+# structured enricher object was flattened into content/brief/faq/slug/tags
+# but never sent as a nested object — wr2_topic_selector.py's
+# `top_item.get("enrichment") or {}` always saw {} (verified 2026-06-24: {}
+# on 12/12 drafts). Additive fix: the full enr dict also rides along as
+# payload["enrichment"] when non-empty.
+# ---------------------------------------------------------------------------
+
+
+def test_payload_includes_full_enrichment_object_when_present() -> None:
+    """GUILT: a non-empty art["enrichment"] must survive verbatim as
+    payload["enrichment"] — the full structured object, not just the
+    flattened content/brief/faq fields."""
+    art = _base_art(
+        thirty_second_brief="Brief text",
+        faq=[{"q": "Q1", "a": "A1"}],
+        bali_zero_take="Our take.",
+        in_practice="Practice.",
+        next_steps="Steps.",
+        metadata={"suggested_slug": "slug-here", "tags": ["tag1"]},
+    )
+
+    payload = build_staging_payload(art)
+
+    assert payload["enrichment"] == art["enrichment"]
+    assert payload["enrichment"]["the_facts"] == "Facts go here."
+    assert payload["enrichment"]["thirty_second_brief"] == "Brief text"
+    # The existing flattening is UNCHANGED — additive, not a replacement.
+    assert payload["brief"] == "Brief text"
+    assert payload["faq"] == [{"q": "Q1", "a": "A1"}]
+    assert "## Facts\n\nFacts go here." in payload["content"]
+
+
+def test_payload_omits_enrichment_when_absent_or_empty() -> None:
+    """INNOCENCE: art without an enrichment dict (or an explicitly empty
+    one) must NOT invent a payload["enrichment"] key — omit it entirely so
+    legacy/partial-deploy consumers see today's behavior unchanged."""
+    art = {
+        "title": "Raw title",
+        "text": "Raw scraped text.",
+        "source": "raw-source",
+        "source_url": "https://example.com/raw",
+    }
+
+    payload = build_staging_payload(art)
+
+    assert "enrichment" not in payload
+
+    art_empty = _base_art()
+    art_empty["enrichment"] = {}
+    payload_empty = build_staging_payload(art_empty)
+
+    assert "enrichment" not in payload_empty
+
+
 def test_payload_falls_back_to_title_when_no_enrichment() -> None:
     """No enrichment dict at all (art["enrichment"] missing) must not
     crash — falls back to art["title"] / empty sections, matching the

--- a/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
+++ b/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
@@ -770,3 +770,63 @@ async def test_process_one_composes_when_facts_citations_only_but_enrichment_ric
     persist_calls = [c for c in conn.execute.call_args_list if "status" in c.args[0]]
     assert any("'drafts'" in c.args[0] for c in persist_calls)
     assert not any("parked" in c.args[0] for c in persist_calls)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Round-3 red-team MUST-FIX: a truthy non-dict enrichment (e.g. a list) must
+# not crash _has_usable_source / _process_one with AttributeError. This is
+# the same bug class as test_enriched_brief_coerces_non_dict_enrichment_
+# instead_of_raising above, at a 4th site the round-2 fix missed:
+# _has_usable_source's `if not enrichment: return False` guard only catches
+# FALSY non-dicts — a truthy one (`["bad"]`) sailed past it straight into
+# the unguarded `enrichment.get("the_facts")`.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_has_usable_source_false_and_no_raise_when_enrichment_is_non_dict_truthy() -> None:
+    """GUILT (round-3 MUST-FIX): `_has_usable_source('', ['bad'])` pre-fix
+    raised `AttributeError: 'list' object has no attribute 'get'` because a
+    truthy non-dict list is not caught by the `if not enrichment` falsy
+    guard. Post-fix (coercion moved to the _process_one boundary) the
+    _process_one caller never hands _has_usable_source a non-dict — but
+    _has_usable_source itself must still degrade gracefully (never raise)
+    for any other caller that isn't as disciplined."""
+    result = _has_usable_source("", ["bad"])
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_process_one_parks_gracefully_when_enrichment_is_non_dict_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Integration GUILT (round-3 MUST-FIX): a news-shaped brief_json whose
+    `enrichment` field is a truthy non-dict (hand-edited/legacy staging
+    record, e.g. a list) must park cleanly instead of raising AttributeError
+    out of `_has_usable_source` before B2's park backstop can act. Confirms
+    the `_process_one` boundary coercion (line ~1384: non-dict -> None)
+    covers this class end-to-end, not just the `_build_enriched_brief`
+    entry guard."""
+    draft_id = uuid.uuid4()
+    row = {
+        "id": draft_id,
+        "topic": "Some News Event",
+        "brief_json": {
+            "article_summary": "",
+            "enrichment": ["bad"],
+            "staging_type": "news",
+            "liveness_tier": None,
+        },
+    }
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    compose_mock = AsyncMock()
+    monkeypatch.setattr(dg, "claude_compose_slides", compose_mock)
+
+    outcome = await dg._process_one(conn, row)
+
+    assert outcome == "parked"
+    compose_mock.assert_not_called()
+    conn.execute.assert_awaited_once()
+    args, _kwargs = conn.execute.call_args
+    assert "parked" in args[0]
+    assert args[1] == draft_id

--- a/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
+++ b/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
@@ -94,6 +94,20 @@ def test_enriched_brief_handles_empty_enrichment() -> None:
     assert _build_enriched_brief({"unknown_field": "noise"}, live_reasons=None) == ""
 
 
+def test_enriched_brief_coerces_non_dict_enrichment_instead_of_raising() -> None:
+    """GUILT (round-2 red-team MUST-FIX #2, scar family #9): a hand-edited/
+    legacy staging JSON can carry a truthy non-dict `enrichment` (e.g. a
+    list) that survives the upstream projection and topic-selector guards.
+    Every field access in this function is an unguarded `enrichment.get(...)`
+    — pre-fix, a list argument raised AttributeError (`'list' object has no
+    attribute 'get'`) which was NOT caught by the local caller handlers and
+    sent the whole draft to REJECTED. Must degrade to the empty-brief
+    fallback instead."""
+    assert _build_enriched_brief(["bad"], live_reasons=None) == ""
+    assert _build_enriched_brief("not a dict either", live_reasons=None) == ""
+    assert _build_enriched_brief(None, live_reasons=None) == ""
+
+
 def test_enriched_brief_skips_missing_sections() -> None:
     """Partial enrichment renders only the sections that exist."""
     brief = _build_enriched_brief(

--- a/scripts/tests/test_wr2_topic_selector_live_news.py
+++ b/scripts/tests/test_wr2_topic_selector_live_news.py
@@ -255,3 +255,43 @@ async def test_fetch_staging_retries_timeout(monkeypatch: pytest.MonkeyPatch) ->
 
     assert calls["count"] == 2
     assert items == [{"id": "keep", "status": "pending"}]
+
+
+@pytest.mark.asyncio
+async def test_fetch_staging_requests_include_enrichment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GUILT (round-2 red-team MUST-FIX #1, scar family #9): the topic
+    selector is the ONE consumer that ranks the full pending queue and then
+    reads enrichment off the single top item — it must opt in explicitly
+    (include_enrichment=true) now that the route defaults the key off."""
+    captured_urls: list[str] = []
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"items": []}
+
+    class _CapturingAsyncClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def __aenter__(self) -> "_CapturingAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def get(self, url: str, *args: object, **kwargs: object) -> _Response:
+            captured_urls.append(url)
+            return _Response()
+
+    monkeypatch.setattr("wr2_topic_selector.httpx.AsyncClient", _CapturingAsyncClient)
+
+    await fetch_staging("https://backend.example", "api-key")
+
+    assert len(captured_urls) == 1
+    assert "include_enrichment=true" in captured_urls[0]
+    assert "type=all" in captured_urls[0]

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -801,7 +801,12 @@ def _has_usable_source(summary: str, enrichment: dict[str, Any] | None) -> bool:
     """
     if summary and summary.strip():
         return True
-    if not enrichment:
+    # Belt-and-suspenders (round-3 red-team MUST-FIX, scar family #9): the
+    # `_process_one` caller now coerces a truthy non-dict enrichment to None
+    # before it reaches here, but `enrichment.get(...)` below is unguarded —
+    # a truthy non-dict (e.g. a list) is not caught by `if not enrichment`
+    # alone, so this function must also be safe for any other caller.
+    if not isinstance(enrichment, dict) or not enrichment:
         return False
 
     the_facts = str(enrichment.get("the_facts") or "")
@@ -1381,7 +1386,11 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> _Proces
     brief = json.loads(brief_raw) if isinstance(brief_raw, str) else (brief_raw or {})
     summary = brief.get("article_summary") or ""
     source_url = brief.get("source_url") or ""
-    enrichment = brief.get("enrichment") or None
+    # A truthy non-dict enrichment (hand-edited/legacy brief_json, e.g. a list)
+    # must coerce to None here so every downstream use (_has_usable_source,
+    # _build_enriched_brief) sees a safe dict-or-None — not just falsy values.
+    _enrichment_raw = brief.get("enrichment")
+    enrichment = _enrichment_raw if isinstance(_enrichment_raw, dict) else None
     live_reasons = brief.get("live_news_reasons") or []
     if not isinstance(live_reasons, list):
         live_reasons = []

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -576,6 +576,16 @@ def _build_enriched_brief(enrichment: dict[str, Any], live_reasons: list[str] | 
     Returns an empty string if enrichment has no usable fields, so the
     caller can fall back to the legacy summary path cleanly.
     """
+    # Round-2 red-team MUST-FIX #2 defense-in-depth (scar family #9): a
+    # hand-edited/legacy staging JSON can carry a truthy non-dict
+    # `enrichment` (e.g. a list) that survives the upstream projection and
+    # topic-selector guards. Every field access below is an unguarded
+    # `enrichment.get(...)`, which raises AttributeError on a non-dict and
+    # was previously uncaught by the local handlers, sending the whole
+    # draft to REJECTED. Coerce here as the last line of defense.
+    if not isinstance(enrichment, dict):
+        enrichment = {}
+
     parts: list[str] = []
 
     brief30 = enrichment.get("thirty_second_brief") or {}

--- a/scripts/wr2_topic_selector.py
+++ b/scripts/wr2_topic_selector.py
@@ -181,7 +181,12 @@ def score_item(item: dict[str, Any]) -> tuple[float, dict[str, Any]]:
 
 
 async def fetch_staging(backend_url: str, api_key: str) -> list[dict[str, Any]]:
-    url = f"{backend_url.rstrip('/')}/api/intel/staging/pending?type=all"
+    # include_enrichment=true (round-2 red-team MUST-FIX #1, scar family #9):
+    # this is the ONE consumer of the full structured enrichment object
+    # (single ranked top item, see fetch_staging callers below) — opts in
+    # explicitly so the default-lean projection stays lean for every other
+    # consumer of this route (News Room UI, Visa Oracle UI, MCP tool).
+    url = f"{backend_url.rstrip('/')}/api/intel/staging/pending?type=all&include_enrichment=true"
     attempts = max(1, STAGING_FETCH_ATTEMPTS)
     for attempt in range(1, attempts + 1):
         try:
@@ -611,7 +616,13 @@ async def run(*, dry_run: bool = False, force: bool = False) -> int:
         # available material. We pass the entire enriched object through
         # brief_json so the draft generator can use the structured ground
         # truth instead of a truncated paragraph.
-        enrichment_obj = top_item.get("enrichment") or {}
+        # Round-2 red-team MUST-FIX #2 defense-in-depth: a hand-edited/
+        # legacy staging JSON can carry a truthy non-dict enrichment value
+        # (e.g. a list) — `or {}` alone only normalizes falsy values, so a
+        # non-dict would pass straight into brief_json and crash
+        # wr2_draft_generator.py's unguarded `.get("thirty_second_brief")`.
+        _raw_enrichment = top_item.get("enrichment")
+        enrichment_obj = _raw_enrichment if isinstance(_raw_enrichment, dict) else {}
         brief_json: dict[str, Any] = {
             "staging_id": staging_id,
             "staging_type": top_item.get("type"),


### PR DESCRIPTION
## What

Carries the intel enricher's structured `enrichment` object (the_facts / bali_zero_take / in_practice / next_steps / faq / thirty_second_brief / metadata) all the way through to WR2 drafts. Before this, `wr2_topic_selector` wrote `brief_json.enrichment = {}` on every draft — the enricher's work was **silently dropped** at the scraper→staging boundary (scar family **#9**, state-schema mutation drift). Hardened through **two Codex adversarial red-team rounds** (generator≠grader).

## Round 1 — the passthrough (4 hops, additive + optional)

1. **`intel.py::ScraperSubmission`** — added `enrichment: dict | None` (Pydantic drops undeclared fields).
2. **`intel_scraper.py::submit_from_scraper`** — persists `enrichment` in the staging JSON.
3. **`intel_staging_service.py::list_pending_items`** — projects enrichment (the hop the implementer's deeper GROUND found; a 3-file spec would have died silently here).
4. **`run_intel_pipeline.py::build_staging_payload`** — additive, non-empty-guarded.

## Round 2 — three MUST-FIX from Codex red-team (all verified on disk before fixing)

1. **Payload fan-out (opt-in projection).** `/api/intel/staging/pending` has no pagination and 3 consumers load `type=all` (News Room UI, Visa Oracle UI, MCP) that never read enrichment — only `wr2_topic_selector` does, and only off the single ranked top item. Added `include_enrichment: bool = False` to the route + service; enrichment is emitted **only** in the staging-root branch **when opted in**, and **removed from the archived/approved branch** unconditionally (the selector discards published; UIs use `/preview`). Topic-selector opts in via `?include_enrichment=true`. → zero regression to default callers.
2. **Legacy dirty JSON (type guard).** `data.get("enrichment") or {}` only normalized falsy values; a hand-edited `enrichment: ["bad"]` passed through and crashed `_build_enriched_brief`'s unguarded `.get()` → rejected draft (the service explicitly documents it must tolerate hand-edited JSON). Guarded at the projection boundary (`isinstance(dict) else {}`) + defense-in-depth at the topic-selector read and at `_build_enriched_brief` entry.
3. **Dedup left the existing queue at `{}` (heal-in-place).** Dedup early-returned success *before* `staging_data` was built, so a URL already pending under the old scraper (`enrichment: {}`) never gained enrichment within the 7-day window. On a dup hit, if the new submission has a non-empty dict enrichment the existing item lacks, it loads the existing staging file (`load_staging_item`) → merges → atomic re-save (`save_staging_item`), wrapped in try/except (never 500), `enrichment_backfilled: true` on success. Verified: `check_duplicate` and `load_staging_item` read the same root dir (consistent); `check_duplicate` returns the full dict so the "already has enrichment" pre-check is accurate (no write-amplification); the write is atomic and round-trips all fields.

## Round 3 — one MUST-FIX + one defensive NICE (fresh-context refuter)

1. **Non-dict enrichment crashed a 4th site (MUST).** A truthy non-dict `brief_json.enrichment` (legacy/other-producer, e.g. `["bad"]`) sailed past `_process_one`'s `or None` (falsy-only) and past `_has_usable_source`'s `if not enrichment` guard into an **unguarded** `enrichment.get("the_facts")` at `wr2_draft_generator.py:807` → AttributeError → rejected draft (the exact class round-2 #2 targeted, at a site it missed; reproduced live). Fixed at the `_process_one` boundary (coerce non-dict→None, so it takes the graceful "no usable source → park" path) **and** hardened `_has_usable_source` itself (`isinstance(dict)` guard) belt-and-suspenders.
2. **Dedup-heal could touch a published record (NICE).** Published items stay in the staging root (not archived), so `check_duplicate` can match one; the heal now gates on `status in (None, "pending")` so it never writes enrichment onto a closed/published record.

## Why it's safe

- Round-1 hops additive + optional; legacy items without the key project `{}` (matches the topic-selector's existing `top_item.get("enrichment") or {}`).
- Round-2 opt-in means News Room / Visa Oracle / MCP keep the pre-fix lean projection; only the WR2 consumer opts in, and never pays for archived items.
- Consumer chain verified end-to-end: `wr2_topic_selector.py` (`GET /pending?type=all&include_enrichment=true`) → `list_pending_items` projection → reads top-item enrichment → `brief_json["enrichment"]`.

## Tests (independently re-run this session)

- backend intel + scraper suites: **71 passed**
- topic-selector + draft-generator suites: **67 passed**
- scraper pipeline build-payload: **11 passed**
Guilt+innocence coverage: default omits enrichment; opt-in projects staging-root only (not archived); legacy `["bad"]` → `{}`; dedup backfills when absent, skips when present, degrades gracefully on failure; `_build_enriched_brief` non-dict → `""` (no raise).

## Verify (generator≠grader — 3 implementer rounds, 2 independent graders + session on-disk)

Sonnet implementer ≠ grader, every round. **Codex `gpt-5.6-sol` round-1** found the 3 round-2 MUST-FIX. The round-2 re-gate cascaded: Codex hung (30-min timeout), Gemini `agy` timed out, DeepSeek returned HTTP 402 (balance-dead) — so the re-gate fell back to a **fresh-context Sonnet refuter** (CLAUDE.md §6 endorsed default), which found the round-3 MUST-FIX + NICE. Plus this session's own independent on-disk verification each round and test re-runs. **Known limitation ledgered** (not shipped): the dedup-heal is a lockless read-modify-write (pre-existing class across all staging file IO) — two simultaneous same-URL submissions could last-write-wins on `enrichment`; no torn JSON (atomic rename), narrow window (fires only while enrichment absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
