### PR TITLE
fix(kbli): lot runner — innocence controls are non-members by design (validation over-match)

### DIFF
--- a/infra/workflows/kbli-batch-a-lot.js
+++ b/infra/workflows/kbli-batch-a-lot.js
@@ -165,13 +165,34 @@ const inScopeCodes = new Set(
     .filter((m) => m && m.in_scope === true)
     .map((m) => String(m.kode_kbli_2025)),
 );
-const outOfScope = CODES.map((c) => c.code).filter(
-  (code) => !inScopeCodes.has(code),
-);
+// In-scope membership is required ONLY for non-innocence codes (plan §1 "Batch A scope = the 114
+// A-serving codes ONLY" governs the codes actually being adjudicated as Batch A members).
+// Innocence controls are BY DESIGN non-members — OSS-native clean codes used as a sanity check on
+// the pipeline itself (see the usage example above: `{ code: "65121", innocenceControl: true }`,
+// same class as the pilot's 65121/85202/85579) — so requiring them to ALSO be in-scope contradicts
+// the script's own contract. FIXED 2026-07-18: this over-match blocked a real lot dispatch (run
+// wf_3477eb84-e75, "REFUSED: 2 code(s) not in-scope: 65121, 85202" — both legitimate controls).
+const outOfScope = CODES.filter((c) => !c.innocenceControl)
+  .map((c) => c.code)
+  .filter((code) => !inScopeCodes.has(code));
 if (outOfScope.length) {
   throw new Error(
     `kbli-batch-a-lot: lot ${lotId} REFUSED — ${outOfScope.length} code(s) not in-scope per the ` +
       `membership artifact (plan §1 "Batch A scope = the 114 A-serving codes ONLY"): ${outOfScope.join(", ")}`,
+  );
+}
+// Guard the OTHER direction: an in-scope Batch A member cannot ALSO be flagged as an innocence
+// control. A real member has real obligations to adjudicate — using it as a "nothing should
+// change here" sanity check would either mask a genuine miss (if it silently passes) or produce a
+// spurious quarantine (if the pipeline correctly finds real work to do on it).
+const misusedAsInnocence = CODES.filter(
+  (c) => c.innocenceControl && inScopeCodes.has(c.code),
+).map((c) => c.code);
+if (misusedAsInnocence.length) {
+  throw new Error(
+    `kbli-batch-a-lot: lot ${lotId} REFUSED — ${misusedAsInnocence.length} code(s) marked ` +
+      `innocenceControl are actually in-scope Batch A members per the membership artifact (a ` +
+      `member cannot double as an innocence control): ${misusedAsInnocence.join(", ")}`,
   );
 }
 

--- a/scripts/kbli_filiera/tests/test_lot_runner_contract.py
+++ b/scripts/kbli_filiera/tests/test_lot_runner_contract.py
@@ -18,6 +18,12 @@ pilot-report criterion-#6 fix:
    draft embedding `JSON.stringify(d1Result)` directly in the refuter's prompt (anchoring theater,
    copied verbatim from kbli-pilot-a1.js, which has the identical unfixed defect). This test is
    the regression guard for that exact class of bug.
+5. The membership in-scope gate exempts innocenceControl codes (they are BY DESIGN non-members —
+   OSS-native clean codes), while still refusing a genuinely out-of-scope non-innocence code AND
+   refusing a code that is BOTH an in-scope member AND flagged as an innocence control. A
+   2026-07-18 over-match (requiring innocence controls to also be in-scope) blocked a real lot
+   dispatch (run wf_3477eb84-e75, "REFUSED: 2 code(s) not in-scope: 65121, 85202" — both
+   legitimate controls) — this is the regression guard for that exact class of bug.
 
 The calibration artifact (data/kbli-filiera/batch-reports/batchA-calibration.json) ships on a
 separate PR (agent/air-m5/kbli/batcha-calibration) — test 1 SKIPS (not fails) if that file is not
@@ -194,3 +200,55 @@ def test_innocence_d1_prompt_may_reference_evidence(js_source: str) -> None:
     _params, body = _function_signature_and_body(js_source, "d1Prompt")
     assert "canonical.json" in body, "d1Prompt should legitimately reference the evidence dir"
     assert "crosswalk" in body and "pp28" in body
+
+
+# ---------------------------------------------------------------------------
+# 5. Membership gate exempts innocence controls from in-scope check (both directions)
+# ---------------------------------------------------------------------------
+
+def test_guilt_innocence_controls_exempt_from_in_scope_check(js_source: str) -> None:
+    """GUILT: the outOfScope computation must filter OUT innocenceControl codes BEFORE checking
+    membership — innocence controls are BY DESIGN non-members (OSS-native clean codes, same class
+    as the pilot's 65121/85202/85579), and the workflow's own usage example (line ~92) shows an
+    `{ code: "65121", innocenceControl: true }` entry. Requiring them to also be in-scope
+    contradicted the script's own contract and blocked a real lot dispatch (run wf_3477eb84-e75,
+    2026-07-18: REFUSED on 65121/85202, both legitimate innocence controls)."""
+    assert re.search(
+        r"outOfScope\s*=\s*CODES\.filter\(\s*\(c\)\s*=>\s*!c\.innocenceControl\s*\)",
+        js_source,
+    ), (
+        "outOfScope computation does not exempt innocenceControl codes from the in-scope check — "
+        "the 2026-07-18 over-match would block any lot containing a legitimate innocence control"
+    )
+
+
+def test_innocence_out_of_scope_non_innocence_code_still_refuses(js_source: str) -> None:
+    """INNOCENCE: the guilt fix above must not be satisfiable by simply deleting the in-scope
+    check outright — a genuinely out-of-scope NON-innocence code must still REFUSE the lot. Proves
+    the exemption discriminates on innocenceControl, not on removing the gate entirely."""
+    assert "not in-scope per the" in js_source
+    assert re.search(r"if\s*\(outOfScope\.length\)\s*{", js_source), (
+        "the out-of-scope refusal branch is missing — the membership gate would be a no-op"
+    )
+
+
+def test_guilt_in_scope_member_cannot_be_used_as_innocence_control(js_source: str) -> None:
+    """GUILT (the OTHER direction): a code that IS an in-scope Batch A member cannot ALSO be
+    flagged as an innocence control — a member has real obligations to adjudicate, so misusing it
+    as a "nothing should change here" control would either mask a genuine miss or produce a
+    spurious quarantine. Both directions of the exemption need their own guard (word-boundary /
+    entity-level check per cicatrix family #3 — an exemption is a guardia a segno invertito)."""
+    assert re.search(
+        r"misusedAsInnocence\s*=\s*CODES\.filter\(\s*\(c\)\s*=>\s*c\.innocenceControl\s*&&\s*"
+        r"inScopeCodes\.has\(c\.code\)",
+        js_source,
+    ), "no misusedAsInnocence guard found — an in-scope member could silently double as an innocence control"
+
+
+def test_innocence_misused_as_innocence_refusal_branch_exists(js_source: str) -> None:
+    """INNOCENCE: the misusedAsInnocence guilt check above must be wired to an actual REFUSE
+    branch, not just a computed-and-ignored variable."""
+    assert re.search(r"if\s*\(misusedAsInnocence\.length\)\s*{", js_source), (
+        "misusedAsInnocence is computed but never gates the lot — the guard is dead code"
+    )
+    assert "cannot double as an innocence control" in js_source


### PR DESCRIPTION
## Summary

The membership in-scope validation in `infra/workflows/kbli-batch-a-lot.js` required EVERY code in `args.codes` — including `{code, innocenceControl:true}` entries — to be `in_scope` in the membership artifact. But innocence controls are BY DESIGN non-members (OSS-native clean codes, same class as the pilot's 65121/85202/85579), and the workflow's own usage comment (line ~92) shows `{ code: "65121", innocenceControl: true }` as the canonical example. The validation contradicted the script's own contract and blocked a real lot dispatch: run `wf_3477eb84-e75` REFUSED with "2 code(s) not in-scope: 65121, 85202" — both legitimate innocence controls, not out-of-scope codes.

## Fix

- `outOfScope` now filters `CODES` to non-innocence entries BEFORE checking membership — in-scope is required only for the codes actually being adjudicated as Batch A members.
- New `misusedAsInnocence` guard covers the OTHER direction: a code that IS an in-scope Batch A member cannot ALSO be flagged as an innocence control (a real member has real obligations to adjudicate; using it as a "nothing should change here" control would either mask a genuine miss or produce a spurious quarantine).

## Test plan

- [x] `python3 -m pytest scripts/kbli_filiera/tests/ -q` → **173 passed, 0 skipped** (calibration artifact is already on main, so the previously-skipped calibration-drift test runs too now).
- [x] `npx prettier --check` clean.
- [x] New guilt+innocence test pairs for both directions in `test_lot_runner_contract.py`: guilt asserts the innocenceControl exemption is present in the `outOfScope` filter / the `misusedAsInnocence` guard exists; innocence asserts a genuinely out-of-scope non-innocence code still REFUSES and the `misusedAsInnocence` guard is wired to an actual refusal branch, not dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)