### PR TITLE
fix(rag): thread curated/KG grounding into the multi-agent branch

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
@@ -1031,6 +1031,7 @@ class OrchestratorCore:
                 ma_result = await self._multi_agent_coordinator.process(
                     query=query,
                     user_context={"extracted_entities": extracted_entities},
+                    grounding_context=system_context_for_prompt,
                 )
                 if ma_result.get("final_answer"):
                     return CoreResult(

--- a/apps/backend-rag/backend/services/rag/multi_agent_coordinator.py
+++ b/apps/backend-rag/backend/services/rag/multi_agent_coordinator.py
@@ -75,6 +75,10 @@ class MultiAgentState(TypedDict):
     Attributes:
         query: Original user query
         user_context: User metadata (citizenship, intent, etc.)
+        grounding_context: Pre-vetted evidence from the orchestrator (curated_qa
+            blocks + KG context + workflow summary); empty string when none.
+            (consumed by LegalAgent + Synthesizer only; FinancialAgent is
+            PricingService-SSOT, TimelineAgent inherits via legal_analysis)
         legal_analysis: Output from LegalAgent
         financial_breakdown: Output from FinancialAgent
         timeline_estimate: Output from TimelineAgent
@@ -85,6 +89,7 @@ class MultiAgentState(TypedDict):
 
     query: str
     user_context: dict[str, Any]
+    grounding_context: str
     legal_analysis: str
     financial_breakdown: str
     timeline_estimate: str
@@ -184,10 +189,20 @@ class LegalAgent:
                     + "\n- ".join(entity_names)
                 )
 
+            grounding = state.get("grounding_context", "")
+            grounding_block = ""
+            if grounding:
+                grounding_block = (
+                    "\n\nPre-vetted evidence from Bali Zero's knowledge base "
+                    "(HIGH PRIORITY — prefer these facts over your own recall when they conflict):\n"
+                    f"{grounding}"
+                )
+
             prompt = (
                 f"You are a legal requirements analyst for Indonesian business and immigration.\n\n"
                 f'Query: "{query}"\n'
-                f"{entity_summary}\n\n"
+                f"{entity_summary}"
+                f"{grounding_block}\n\n"
                 f"List the required documents and compliance steps in order.\n"
                 f"Focus on: required documents (NPWP, Akta, passport, etc.), "
                 f"legal entities involved (PT PMA, Perorangan, etc.), "
@@ -211,6 +226,7 @@ class LegalAgent:
                         "agent": "legal",
                         "output": analysis,
                         "entities_used": len(legal_entities),
+                        "had_grounding": bool(grounding),
                         "duration_s": round(duration, 2),
                     },
                 ],
@@ -530,13 +546,22 @@ class MultiAgentCoordinator:
         start_time = time.time()
 
         try:
+            grounding = state.get("grounding_context", "")
+            grounding_block = ""
+            if grounding:
+                grounding_block = (
+                    "\n\nPre-vetted evidence (HIGH PRIORITY — the final answer must not "
+                    f"contradict these facts):\n{grounding}\n"
+                )
+
             prompt = (
                 f"You are a senior business consultant for Bali Zero, "
                 f"helping clients with Indonesian business and immigration.\n\n"
                 f'User query: "{state["query"]}"\n\n'
                 f"**Legal Analysis:**\n{state.get('legal_analysis', 'Not available')}\n\n"
                 f"**Financial Breakdown:**\n{state.get('financial_breakdown', 'Not available')}\n\n"
-                f"**Timeline Estimate:**\n{state.get('timeline_estimate', 'Not available')}\n\n"
+                f"**Timeline Estimate:**\n{state.get('timeline_estimate', 'Not available')}\n"
+                f"{grounding_block}\n"
                 f"Synthesize these into a coherent, actionable answer for the client.\n"
                 f"Format:\n"
                 f"**Legal Requirements:** ...\n"
@@ -580,6 +605,7 @@ class MultiAgentCoordinator:
         self,
         query: str,
         user_context: dict[str, Any] | None = None,
+        grounding_context: str = "",
     ) -> dict[str, Any]:
         """
         Run multi-agent workflow for a complex query.
@@ -587,6 +613,10 @@ class MultiAgentCoordinator:
         Args:
             query: User query requiring multi-domain expertise
             user_context: Optional user metadata
+            grounding_context: Optional pre-vetted evidence from the caller
+                (orchestrator's curated_qa + KG + workflow context) — passed
+                through to LegalAgent and the Synthesizer as HIGH PRIORITY
+                evidence. Empty string means no grounding available.
 
         Returns:
             Dict with keys: query, legal_analysis, financial_breakdown,
@@ -599,6 +629,7 @@ class MultiAgentCoordinator:
         initial_state: MultiAgentState = {
             "query": query,
             "user_context": user_context or {},
+            "grounding_context": grounding_context,
             "legal_analysis": "",
             "financial_breakdown": "",
             "timeline_estimate": "",

--- a/apps/backend-rag/backend/tests/services/rag/test_multi_agent.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_multi_agent.py
@@ -69,6 +69,7 @@ def base_state() -> MultiAgentState:
     return {
         "query": "How much will PT PMA cost and when can I start operations?",
         "user_context": {},
+        "grounding_context": "",
         "legal_analysis": "",
         "financial_breakdown": "",
         "timeline_estimate": "",

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_curated_qa_grounding_injection.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_curated_qa_grounding_injection.py
@@ -511,3 +511,43 @@ async def test_process_query_core_survives_injection_exception_and_still_builds_
         )
 
     core.prompt_builder.build_system_prompt.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_query_core_threads_curated_grounding_into_multi_agent_process(
+    wired_core: OrchestratorCore,
+) -> None:
+    """WIRING (multi-agent grounding fix, 2026-07-18): a curated_qa hit
+    injected into system_context_for_prompt must reach
+    MultiAgentCoordinator.process(grounding_context=...) when
+    requires_multi_agent() routes the query to the multi-agent branch —
+    proving the fix for the branch that previously called process() with
+    only the extracted entities, dropping the curated/KG grounding entirely.
+    """
+    core = wired_core
+    core.retriever = SimpleNamespace(
+        search_collection=AsyncMock(
+            return_value=_search_result(
+                [_hit(0.95, answer="Curated grounding answer.")],
+            ),
+        ),
+    )
+    mock_coordinator = MagicMock()
+    mock_coordinator.process = AsyncMock(return_value={"final_answer": "x"})
+    core._multi_agent_coordinator = mock_coordinator
+
+    with patch(
+        "backend.services.rag.agentic.orchestrator_core.requires_multi_agent",
+        return_value=True,
+    ):
+        result = await core.process_query_core(
+            query="What is the E33 deposit amount?",
+            user_id="u1",
+            conversation_history=None,
+            start_time=0.0,
+        )
+
+    assert result.answer == "x"
+    mock_coordinator.process.assert_awaited_once()
+    _, kwargs = mock_coordinator.process.call_args
+    assert "Curated grounding answer." in kwargs["grounding_context"]

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_multi_agent_coordinator.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_multi_agent_coordinator.py
@@ -117,6 +117,7 @@ class TestLegalAgentAnalyze:
         state: MultiAgentState = {
             "query": "What documents for KITAS?",
             "user_context": {},
+            "grounding_context": "",
             "legal_analysis": "",
             "financial_breakdown": "",
             "timeline_estimate": "",
@@ -138,6 +139,7 @@ class TestLegalAgentAnalyze:
         state: MultiAgentState = {
             "query": "test",
             "user_context": {},
+            "grounding_context": "",
             "legal_analysis": "",
             "financial_breakdown": "",
             "timeline_estimate": "",
@@ -169,6 +171,7 @@ class TestFinancialAgentAnalyze:
         state: MultiAgentState = {
             "query": "How much does PT PMA cost?",
             "user_context": {},
+            "grounding_context": "",
             "legal_analysis": "",
             "financial_breakdown": "",
             "timeline_estimate": "",
@@ -193,6 +196,7 @@ class TestFinancialAgentAnalyze:
         state: MultiAgentState = {
             "query": "cost?",
             "user_context": {},
+            "grounding_context": "",
             "legal_analysis": "",
             "financial_breakdown": "",
             "timeline_estimate": "",
@@ -218,6 +222,7 @@ class TestTimelineAgentAnalyze:
         state: MultiAgentState = {
             "query": "When can I start?",
             "user_context": {},
+            "grounding_context": "",
             "legal_analysis": "Step 1: Get NPWP\nStep 2: Register OSS",
             "financial_breakdown": "",
             "timeline_estimate": "",
@@ -239,6 +244,7 @@ class TestTimelineAgentAnalyze:
         state: MultiAgentState = {
             "query": "timeline?",
             "user_context": {},
+            "grounding_context": "",
             "legal_analysis": "",
             "financial_breakdown": "",
             "timeline_estimate": "",
@@ -295,6 +301,7 @@ class TestMultiAgentCoordinator:
             state: MultiAgentState = {
                 "query": "test",
                 "user_context": {},
+                "grounding_context": "",
                 "legal_analysis": "Legal stuff",
                 "financial_breakdown": "Cost stuff",
                 "timeline_estimate": "Timeline stuff",
@@ -321,6 +328,7 @@ class TestMultiAgentCoordinator:
             state: MultiAgentState = {
                 "query": "test",
                 "user_context": {},
+                "grounding_context": "",
                 "legal_analysis": "Legal",
                 "financial_breakdown": "Financial",
                 "timeline_estimate": "Timeline",

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_multi_agent_grounding.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_multi_agent_grounding.py
@@ -1,0 +1,209 @@
+"""Multi-agent grounding injection (2026-07-18).
+
+Fix: requires_multi_agent()-routed queries (cost+timeline, multi-domain,
+>5 entities) called coordinator.process() with only the extracted entities —
+the orchestrator's system_context_for_prompt (curated_qa blocks + KG context
++ workflow) was dropped, so multi-agent answers were built ungrounded.
+
+Consumers: LegalAgent.analyze() and MultiAgentCoordinator._synthesize_outputs()
+get a HIGH PRIORITY evidence block appended to their prompt when
+grounding_context is non-empty. FinancialAgent stays PricingService-SSOT
+(deliberately untouched — mixing extra context would weaken its "use ONLY
+the official prices above" instruction). TimelineAgent inherits grounded
+facts transitively via legal_analysis (also untouched).
+
+Guilt + innocence per consumer (scar family #3 discipline), plus one
+orchestrator wiring test proving the injected curated block reaches
+coordinator.process(grounding_context=...).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.rag.multi_agent_coordinator import (
+    FinancialAgent,
+    LegalAgent,
+    MultiAgentCoordinator,
+    MultiAgentState,
+)
+
+VETTED_FACT = "[CURATED ref 2026-07-18]\nVetted fact."
+
+
+def _base_state(**overrides) -> MultiAgentState:
+    state: MultiAgentState = {
+        "query": "How much will PT PMA cost and when can I start?",
+        "user_context": {},
+        "grounding_context": "",
+        "legal_analysis": "",
+        "financial_breakdown": "",
+        "timeline_estimate": "",
+        "agent_outputs": [],
+        "final_answer": "",
+        "errors": [],
+    }
+    state.update(overrides)  # type: ignore[typeddict-item]
+    return state
+
+
+# ── LegalAgent — guilt + innocence ──────────────────────────────────────────
+
+
+class TestLegalAgentGrounding:
+    @pytest.mark.asyncio
+    async def test_grounding_present_is_injected_as_high_priority(self):
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="Legal analysis"))
+
+        agent = LegalAgent(llm=mock_llm, kg_retrieval=None)
+        state = _base_state(grounding_context=VETTED_FACT)
+
+        result = await agent.analyze(state)
+
+        prompt_sent = mock_llm.ainvoke.call_args[0][0]
+        assert VETTED_FACT in prompt_sent
+        assert "HIGH PRIORITY" in prompt_sent
+        assert result["agent_outputs"][0]["had_grounding"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_grounding_omits_header_and_marks_false(self):
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="Legal analysis"))
+
+        agent = LegalAgent(llm=mock_llm, kg_retrieval=None)
+        state = _base_state(grounding_context="")
+
+        result = await agent.analyze(state)
+
+        prompt_sent = mock_llm.ainvoke.call_args[0][0]
+        assert "Pre-vetted evidence" not in prompt_sent
+        assert result["agent_outputs"][0]["had_grounding"] is False
+
+
+# ── Synthesizer — guilt + innocence ─────────────────────────────────────────
+
+
+class TestSynthesizerGrounding:
+    @pytest.mark.asyncio
+    async def test_grounding_present_is_injected_as_high_priority(self):
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="Synthesized answer"))
+
+        with patch(
+            "backend.services.rag.multi_agent_coordinator.get_pricing_service",
+            return_value=MagicMock(),
+        ):
+            coordinator = MultiAgentCoordinator()
+            coordinator._llm = mock_llm
+
+            state = _base_state(
+                grounding_context=VETTED_FACT,
+                legal_analysis="Legal stuff",
+                financial_breakdown="Cost stuff",
+                timeline_estimate="Timeline stuff",
+            )
+
+            await coordinator._synthesize_outputs(state)
+
+        prompt_sent = mock_llm.ainvoke.call_args[0][0]
+        assert VETTED_FACT in prompt_sent
+        assert "HIGH PRIORITY" in prompt_sent
+
+    @pytest.mark.asyncio
+    async def test_no_grounding_omits_header(self):
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="Synthesized answer"))
+
+        with patch(
+            "backend.services.rag.multi_agent_coordinator.get_pricing_service",
+            return_value=MagicMock(),
+        ):
+            coordinator = MultiAgentCoordinator()
+            coordinator._llm = mock_llm
+
+            state = _base_state(
+                grounding_context="",
+                legal_analysis="Legal stuff",
+                financial_breakdown="Cost stuff",
+                timeline_estimate="Timeline stuff",
+            )
+
+            await coordinator._synthesize_outputs(state)
+
+        prompt_sent = mock_llm.ainvoke.call_args[0][0]
+        assert "Pre-vetted evidence" not in prompt_sent
+
+
+# ── FinancialAgent — innocence (SSOT-pure, never touched) ──────────────────
+
+
+class TestFinancialAgentStaysUngrounded:
+    @pytest.mark.asyncio
+    async def test_grounding_context_never_reaches_financial_prompt(self):
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="Cost breakdown"))
+
+        mock_pricing = MagicMock()
+        mock_pricing.get_pricing = MagicMock(return_value={})
+        mock_pricing.format_for_llm_context = MagicMock(return_value="Pricing data")
+        mock_pricing.loaded = True
+
+        agent = FinancialAgent(llm=mock_llm, pricing_service=mock_pricing)
+        state = _base_state(grounding_context=VETTED_FACT)
+
+        await agent.analyze(state)
+
+        prompt_sent = mock_llm.ainvoke.call_args[0][0]
+        assert "Pre-vetted evidence" not in prompt_sent
+        assert VETTED_FACT not in prompt_sent
+
+
+# ── process() kwarg wiring ──────────────────────────────────────────────────
+
+
+class TestProcessGroundingKwarg:
+    @pytest.mark.asyncio
+    async def test_process_threads_grounding_context_into_initial_state(self):
+        with patch(
+            "backend.services.rag.multi_agent_coordinator.get_pricing_service",
+            return_value=MagicMock(),
+        ):
+            coordinator = MultiAgentCoordinator()
+            captured_state: dict = {}
+
+            async def _fake_ainvoke(state: MultiAgentState) -> MultiAgentState:
+                captured_state.update(state)
+                return {**state, "final_answer": "done"}
+
+            with patch.object(coordinator, "_ensure_initialized"):
+                coordinator._graph = MagicMock()
+                coordinator._graph.ainvoke = AsyncMock(side_effect=_fake_ainvoke)
+
+                await coordinator.process(
+                    query="test query",
+                    grounding_context=VETTED_FACT,
+                )
+
+        assert captured_state["grounding_context"] == VETTED_FACT
+
+    @pytest.mark.asyncio
+    async def test_process_defaults_grounding_context_to_empty_string(self):
+        with patch(
+            "backend.services.rag.multi_agent_coordinator.get_pricing_service",
+            return_value=MagicMock(),
+        ):
+            coordinator = MultiAgentCoordinator()
+            captured_state: dict = {}
+
+            async def _fake_ainvoke(state: MultiAgentState) -> MultiAgentState:
+                captured_state.update(state)
+                return {**state, "final_answer": "done"}
+
+            with patch.object(coordinator, "_ensure_initialized"):
+                coordinator._graph = MagicMock()
+                coordinator._graph.ainvoke = AsyncMock(side_effect=_fake_ainvoke)
+
+                await coordinator.process(query="test query")
+
+        assert captured_state["grounding_context"] == ""

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 640 services · 1167 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 640 services · 1168 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

Queries routed to the **multi-agent branch** (`requires_multi_agent()`: cost+timeline, multi-domain, >5 entities) called `coordinator.process()` with only the extracted entities — **`system_context_for_prompt` (curated_qa blocks + KG context + workflow) was dropped**, so multi-agent answers were built ungrounded.

Proven live during the #2689 battery: an overstay query routed multi-agent returned `evidence 0`, no sources, and missed the vetted UU 63/2024 facts — while the same facts are answered correctly on the ReAct path post-#2689.

This is the second consumption gate of the curated cache (consumer-map: the injection writes into `system_context_for_prompt`, but not every routing branch read it — scar #9).

## Fix

- `MultiAgentState.grounding_context` (new field) + optional `process(grounding_context="")` kwarg — backwards-compatible.
- Consumed by **LegalAgent** and the **Synthesizer** as HIGH-PRIORITY evidence blocks in their prompts.
- **FinancialAgent deliberately untouched** — PricingService is the pricing SSOT; extra context would weaken its "use ONLY the official prices above" instruction.
- **TimelineAgent** inherits grounded facts transitively via `legal_analysis`.
- Orchestrator call site now passes `grounding_context=system_context_for_prompt` (curated injection at step 3c runs immediately before this branch).
- `had_grounding` observability flag in the legal agent output.

With empty grounding the prompts are byte-identical to before (innocence preserved).

## Tests

- New `test_multi_agent_grounding.py` (209 lines): guilt+innocence per consumer — legal/synthesize receive the block, **financial never does**, `process()` kwarg default + explicit.
- New wiring test in `test_curated_qa_grounding_injection.py`: a curated_qa hit injected into the system context **reaches `process(grounding_context=...)`** when the query routes multi-agent (content assertion, not mock-theater).
- 9 existing `MultiAgentState` literals updated for the new key.
- Verified by the orchestrator session (final gate, generator≠grader): 58 + 27 + 91 tests green, import chain OK, full pre-push suite 17605 passed.
- `docs/AI_ONBOARDING.md` regen in the same commit (W86).

## Prove-live plan (post-merge)

Fire a cost+timeline visa query (multi-agent route) → Fly logs must show `✅ [CuratedQA] Injected` **followed by** `🔀 [Phase 6] Multi-agent` on the same query, and the answer must carry the vetted facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
