### PR TITLE
fix(rag): stop unsolicited price dumps — intent-gate pricing boost + narrow PricingTool triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 327 routers · 640 services
+- Backend: FastAPI · 327 routers · 641 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 31 · Packages: 6

--- a/apps/backend-rag/backend/services/misc/pricing_intent.py
+++ b/apps/backend-rag/backend/services/misc/pricing_intent.py
@@ -1,0 +1,64 @@
+"""
+Pricing-intent classifier for the RAG search boost gate.
+
+Pure, dependency-free helper: no class instantiation, no I/O. Decides whether
+a raw user query is actually ASKING about price, so the unconditional
+`PRICING_SCORE_BOOST` in result_formatter.py doesn't fire on every
+visa/company/tax question that merely happens to touch a domain the
+`bali_zero_pricing_hybrid` collection also covers.
+
+Scar family #3 (guard-over-match, .claude/rules/cicatrix-superscar.md)
+discipline: matching must be on ENTITY/INTENT, never bare substring.
+"fee" is a substring of "coffee", "rate" is a substring of "corporate",
+"cost" is a substring of "Costa Rica" — single-word keywords are matched
+on \\b word boundaries. Multi-word phrases ("how much", "quanto costa")
+are naturally self-delimiting and may match as substrings.
+"""
+
+from __future__ import annotations
+
+import re
+
+# EN + IT + ID price-intent terms. Alternation order does not affect
+# re.search() correctness (boolean any-match) — longest-phrase-first
+# only for readability.
+_PRICE_INTENT_TERMS = (
+    "how much",
+    "quanto costa",
+    "quanto viene",
+    "pricing",
+    "price",
+    "costs",
+    "cost",
+    "fees",
+    "fee",
+    "charge",
+    "rates",
+    "rate",
+    "prezzi",
+    "prezzo",
+    "costi",
+    "costo",
+    "tariffa",
+    "berapa",
+    "harga",
+    "biaya",
+    "tarif",
+)
+
+_PRICE_INTENT_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(term) for term in _PRICE_INTENT_TERMS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+def has_pricing_intent(query: str) -> bool:
+    """Return True if `query` is actually asking about a price/cost/fee.
+
+    Pure function — no side effects, no service dependency. Word-boundary
+    matched (scar #3): "coffee"/"corporate"/"Costa Rica" do NOT trigger a
+    false positive just because they contain "fee"/"rate"/"cost".
+    """
+    if not query:
+        return False
+    return bool(_PRICE_INTENT_RE.search(query))

--- a/apps/backend-rag/backend/services/misc/result_formatter.py
+++ b/apps/backend-rag/backend/services/misc/result_formatter.py
@@ -11,6 +11,8 @@ def format_search_results(
     raw_results: dict[str, Any],
     collection_name: str,
     primary_collection: str | None = None,
+    *,
+    query: str | None = None,
 ) -> list[dict[str, Any]]:
     """Format raw vector database results with score boosting and metadata enrichment.
 
@@ -35,6 +37,10 @@ def format_search_results(
             - ids (list[str]): Document IDs
         collection_name: Source collection name for this batch
         primary_collection: If set, boost results from this collection
+        query: Original user query text. Gates the pricing boost (see
+            "Pricing boost" below) — omit only for callers that don't have
+            the raw query in scope, which keeps the pre-gate behavior
+            (boost always applied) for backwards compatibility.
 
     Returns:
         List of formatted result dicts:
@@ -62,6 +68,12 @@ def format_search_results(
         >>> print(results[0]["score"])  # 0.9185 (base + pricing boost)
     """
     from backend.app.core.constants import SearchConstants
+    from backend.services.misc.pricing_intent import has_pricing_intent
+
+    # Gate the pricing boost on actual price-intent (scar #3, guard-over-match
+    # discipline): query=None means the caller can't tell us the raw query —
+    # keep the old unconditional-boost behavior rather than silently starving it.
+    apply_pricing_boost = query is None or has_pricing_intent(query)
 
     formatted_results = []
 
@@ -78,7 +90,7 @@ def format_search_results(
         if primary_collection and collection_name == primary_collection:
             score = min(SearchConstants.MAX_SCORE, score * SearchConstants.PRIMARY_COLLECTION_BOOST)
 
-        if collection_name == "bali_zero_pricing_hybrid":
+        if collection_name == "bali_zero_pricing_hybrid" and apply_pricing_boost:
             score = min(SearchConstants.MAX_SCORE, score + SearchConstants.PRICING_SCORE_BOOST)
 
         if collection_name == "bali_zero_team":

--- a/apps/backend-rag/backend/services/rag/agentic/tools.py
+++ b/apps/backend-rag/backend/services/rag/agentic/tools.py
@@ -419,7 +419,7 @@ class PricingTool(BaseTool):
         return (
             "🚨 MANDATORY for ALL Bali Zero service price questions. "
             "Get OFFICIAL pricing from Bali Zero database (NO AI generation, NO memory). "
-            "USE THIS when user asks: 'quanto costa', 'price', 'prezzo', 'costo', 'harga', 'berapa', 'cost', 'pricing', 'PT PMA', 'KITAS', 'visa'. "
+            "USE THIS when user asks: 'quanto costa', 'price', 'prezzo', 'costo', 'harga', 'berapa', 'cost', 'pricing'. "
             "Returns EXACT current prices from official pricing database. "
             "NEVER guess prices - ALWAYS call this tool first for price questions."
         )

--- a/apps/backend-rag/backend/services/search/search_service.py
+++ b/apps/backend-rag/backend/services/search/search_service.py
@@ -684,6 +684,7 @@ class SearchService:
                 raw_results,
                 collection_name,
                 primary_collection=None,
+                query=query,
             )
 
             # Record query for health monitoring
@@ -864,6 +865,7 @@ class SearchService:
             raw_results,
             collection_name,
             primary_collection=None,
+            query=query,
         )
         return {
             "query": query,
@@ -1116,6 +1118,7 @@ class SearchService:
                 raw_results,
                 collection_name,
                 primary_collection=None,
+                query=query,
             )
 
             # Record query for health monitoring
@@ -1374,6 +1377,7 @@ class SearchService:
                     raw_results,
                     collection_name,
                     primary_collection=primary_collection,
+                    query=query,
                 )
 
                 return collection_name, formatted_results
@@ -1559,6 +1563,7 @@ class SearchService:
                 raw_results,
                 collection_name,
                 primary_collection=None,
+                query=query,
             )
 
             return {"query": query, "results": formatted_results, "collection": collection_name}

--- a/apps/backend-rag/backend/tests/services/misc/test_pricing_intent.py
+++ b/apps/backend-rag/backend/tests/services/misc/test_pricing_intent.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.services.misc.pricing_intent import has_pricing_intent
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "is remote work permitted on a D12 visa?",
+        # Scar #3 word-boundary trap: "fee" is a substring of "coffee", "rate"
+        # is a substring of "corporate" — neither is a real price-intent word
+        # here, so this must NOT match.
+        "what a nice coffee shop and corporate strategy discussion",
+        "what documents do I need for a KITAS?",
+        "",
+    ],
+)
+def test_has_pricing_intent_guilt_false_on_non_price_questions(query: str) -> None:
+    assert has_pricing_intent(query) is False
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "quanto costa un D12?",
+        "how much is the E33G",
+        "berapa harga KITAS",
+        "what's the price for a PT PMA setup?",
+        "quanto viene una KITAP?",
+        "biaya tarif untuk NPWP",
+    ],
+)
+def test_has_pricing_intent_innocence_true_on_price_questions(query: str) -> None:
+    assert has_pricing_intent(query) is True
+
+
+def test_has_pricing_intent_is_case_insensitive() -> None:
+    assert has_pricing_intent("HOW MUCH does a D12 cost?") is True
+
+
+def test_has_pricing_intent_none_query_is_false() -> None:
+    assert has_pricing_intent(None) is False  # type: ignore[arg-type]

--- a/apps/backend-rag/backend/tests/services/misc/test_result_formatter.py
+++ b/apps/backend-rag/backend/tests/services/misc/test_result_formatter.py
@@ -63,3 +63,51 @@ def test_format_search_results_handles_missing_optional_arrays_and_negative_dist
 
 def test_format_search_results_returns_empty_for_no_documents() -> None:
     assert format_search_results({}, "general") == []
+
+
+def _pricing_raw_results() -> dict:
+    return {
+        "ids": ["doc-1"],
+        "documents": ["D12 remote work rules"],
+        "distances": [1.0],
+        "metadatas": [{}],
+    }
+
+
+def test_format_search_results_pricing_boost_skipped_without_price_intent() -> None:
+    # Guilt: a non-price question hitting the pricing collection must NOT
+    # get the +0.15 boost — this is the unsolicited-price-dump bug.
+    formatted = format_search_results(
+        _pricing_raw_results(),
+        "bali_zero_pricing_hybrid",
+        query="is remote work permitted on a D12 visa?",
+    )
+    assert formatted[0]["score"] == 0.5  # base score only, no boost
+
+
+def test_format_search_results_pricing_boost_applied_with_price_intent() -> None:
+    # Innocence: a genuine price question still gets the boost.
+    formatted = format_search_results(
+        _pricing_raw_results(),
+        "bali_zero_pricing_hybrid",
+        query="quanto costa un D12?",
+    )
+    assert formatted[0]["score"] == 0.65  # base 0.5 + PRICING_SCORE_BOOST 0.15
+
+
+def test_format_search_results_pricing_boost_applied_when_query_omitted() -> None:
+    # Backwards compat: query=None (caller can't tell us) keeps old
+    # unconditional-boost behavior.
+    formatted = format_search_results(_pricing_raw_results(), "bali_zero_pricing_hybrid")
+    assert formatted[0]["score"] == 0.65
+
+
+def test_format_search_results_team_boost_unaffected_by_query() -> None:
+    # bali_zero_team boost is out of scope for the pricing-intent gate —
+    # must stay unconditional regardless of query.
+    formatted = format_search_results(
+        _pricing_raw_results(),
+        "bali_zero_team",
+        query="is remote work permitted on a D12 visa?",
+    )
+    assert formatted[0]["score"] == 0.65

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_tools_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_tools_coverage.py
@@ -350,6 +350,22 @@ class TestPricingTool:
     def test_description(self):
         assert "MANDATORY" in self._make_tool().description
 
+    def test_description_no_longer_advertises_bare_domain_words(self):
+        # Guilt: 'PT PMA'/'KITAS'/'visa' are domain words, not price-intent
+        # words — any visa/company question satisfied them and double-
+        # triggered get_pricing on non-price questions (unsolicited price
+        # dumps). They must not appear as call triggers anymore.
+        description = self._make_tool().description
+        assert "'PT PMA'" not in description
+        assert "'KITAS'" not in description
+        assert "'visa'" not in description
+
+    def test_description_still_advertises_genuine_price_intent_words(self):
+        # Innocence: real price-intent triggers stay intact.
+        description = self._make_tool().description
+        assert "'quanto costa'" in description
+        assert "'price'" in description
+
     def test_parameters_schema(self):
         schema = self._make_tool().parameters_schema
         assert "service_type" in schema["properties"]
@@ -448,9 +464,9 @@ class TestTeamKnowledgeTool:
 
         tool = TeamKnowledgeTool(db_pool=None)
         with patch("pathlib.Path.exists", return_value=False):
-            tool._get_data_file_path()
-        # May return None or a path depending on which paths exist
-        # The important thing is it doesn't raise
+            result = tool._get_data_file_path()
+        # Path.exists patched False for every candidate path -> deterministic None
+        assert result is None
 
     def test_load_team_data_with_no_file(self):
         from backend.services.rag.agentic.tools import TeamKnowledgeTool

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 640 services · 1168 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 641 services · 1169 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

Non-price questions were answered with full price lists (live: "is remote work permitted on a D12?" → D12 + E33G price lists). Two in-perimeter mechanisms, both fixed:

- **(A) Tool self-advertisement** — `PricingTool.description` listed bare domain words `'PT PMA', 'KITAS', 'visa'` as call triggers, so any visa/company question invited a `get_pricing` call. Narrowed to genuine price-intent words only; the MANDATORY-for-price-questions framing (anti-price-hallucination) is untouched.
- **(B) Unconditional retrieval boost** — `format_search_results` applied the +0.15 `bali_zero_pricing_hybrid` boost on EVERY federated search, so pricing docs structurally outranked legal docs regardless of intent. New pure `has_pricing_intent()` helper (EN/IT/ID; **word-boundary matched** — scar family #3: "fee"⊂"coffee", "rate"⊂"corporate", "cost"⊂"Costa Rica" do not trigger) gates the boost. Threaded `query=` at all 5 `format_search_results` call sites in search_service (class-audit W89); `query=None` preserves legacy behavior for unseen callers. `bali_zero_team` boost deliberately untouched.

## Not in this PR (operator-gated)

The strongest trigger for the D12 case lives in `zantara_core.py` (OFF-LIMITS): bare `"D1"` substring (matches inside "D12") + "which visa to choose → get_pricing MANDATORY" fold-in. That fold-in is a deliberate anti-stale-visa-code measure — flagged to Zero separately, not edited here.

## Tests

Guilt+innocence: non-price D12 query → no boost, word-boundary traps → False; "quanto costa un D12?" / "berapa harga KITAS" → True + boost applied; `query=None` → legacy boost. 76 new/touched + 65 collateral green; import chain OK; verified independently by the orchestrator session (generator≠grader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
