### PR TITLE
fix(data): retire stale WA number from pricing Qdrant contact blocks

### DIFF
--- a/apps/backend-rag/backend/tests/test_data_invariant_tripwires.py
+++ b/apps/backend-rag/backend/tests/test_data_invariant_tripwires.py
@@ -15,6 +15,7 @@ Born 2026-07-16 from two real gaps found the same day:
 from __future__ import annotations
 
 import inspect
+import json
 import re
 from pathlib import Path
 
@@ -123,3 +124,50 @@ def test_openai_embedding_model_is_frozen() -> None:
         "Mismatched dims corrupt every similarity search against the existing "
         "index."
     )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 — authoritative pricing JSON never regresses to the retired
+# WhatsApp/location contact block (2026-07-18)
+# ---------------------------------------------------------------------------
+
+_RETIRED_WHATSAPP = "+62 813 3805 1876"
+_RETIRED_LOCATION = "Canggu, Bali, Indonesia"
+
+
+def test_authoritative_pricing_json_never_reintroduces_retired_contact() -> None:
+    """``bali_zero_official_prices_2026.json`` — the file `PricingService`
+    loads and ``scripts/prepare_payloads.py`` embeds into
+    ``bali_zero_pricing_hybrid`` — must never regress to the retired
+    WhatsApp/location.
+
+    That retired string lived for months as stale text inside
+    ALREADY-UPSERTED Qdrant vectors (payload-only patched 2026-07-18 by
+    ``scripts/patch_pricing_contact_block.py``) even though this JSON's
+    generator had already moved on to the correct contact info — the JSON
+    was never the bug. A regression here would silently re-poison the
+    collection on the next `prepare_payloads.py` regeneration.
+
+    Deliberately does NOT check ``bali_zero_official_prices_2025.json`` —
+    that file is an intentionally-frozen rollback artefact (see
+    ``apps/backend-rag/backend/data/PRICING_DEPRECATED_2025.md``) and is
+    excluded from every production code path by contract, not by accident.
+    """
+    from backend.app.core.config import settings
+
+    data_path = (
+        _repo_root() / "apps/backend-rag/backend/data/bali_zero_official_prices_2026.json"
+    )
+    assert data_path.exists(), f"authoritative pricing JSON missing at {data_path}"
+
+    contact = json.loads(data_path.read_text(encoding="utf-8"))["metadata"]["contact"]
+
+    assert contact["whatsapp"] == settings.SUPPORT_WHATSAPP, (
+        f"{data_path.name} contact.whatsapp={contact['whatsapp']!r} does not "
+        f"match settings.SUPPORT_WHATSAPP={settings.SUPPORT_WHATSAPP!r} (the "
+        "Meta-verified Bali Zero number) — PricingService answers and the "
+        "RAG-embedded text would drift from the number the bot itself "
+        "advertises."
+    )
+    assert contact["whatsapp"] != _RETIRED_WHATSAPP
+    assert contact.get("location") != _RETIRED_LOCATION

--- a/scripts/patch_pricing_contact_block.py
+++ b/scripts/patch_pricing_contact_block.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Patch the retired WhatsApp/Location contact block baked into the LIVE
+``bali_zero_pricing_hybrid`` Qdrant collection's payload ``text`` field.
+
+WHY payload-only (no re-embed): the collection's generator
+(``scripts/prepare_payloads.py``) already reads the CURRENT, correct contact
+info from ``apps/backend-rag/backend/data/bali_zero_official_prices_2026.json``
+(``metadata.contact.whatsapp`` = the Meta-verified number, ``+62 821 3465
+159``) — the JSON source-of-truth was never stale. What IS stale is the
+collection itself: ``bali_zero_pricing_hybrid`` was built once via
+``migration_031b_hybrid_collections.py`` by copying/re-embedding whatever
+points existed in the OLD ``bali_zero_pricing`` collection at the time, and
+those points still carry the retired contact block verbatim (matches
+``bali_zero_official_prices_2025.json``'s ``text`` fields byte-for-byte:
+``info@balizero.com`` / ``+62 813 3805 1876`` / ``Canggu, Bali, Indonesia``).
+The collection was never refreshed since. A full re-embed (rerunning
+``prepare_payloads.py`` + ``force_upload.sh``) would cost OpenAI calls, target
+a differently-named collection (``bali_zero_pricing`` — not the
+``_hybrid`` name actually registered/queried, see
+``backend/core/collection_registry.py``), and risk reshaping the payload for
+no semantic gain: only two trailer lines change, not the item name/category/
+price the embedding is actually keyed on.
+
+This script instead rewrites ONLY the ``**WhatsApp**:`` and ``**Location**:``
+trailer lines inside each point's ``payload["text"]``, via Qdrant's
+"set payload" endpoint (``POST .../points/payload``), which sets/overwrites
+just the listed top-level payload keys — vectors and every other payload key
+(``name``, ``category``, ``price``, ``duration``, ``validity``, ``notes``,
+``source_type``, ``last_updated``, ``currency``) are left untouched. Prices
+are NEVER touched (CLAUDE.md Golden Rule #11 — PricingTool only).
+
+Idempotent: running twice is a no-op the second time (``rewrite_contact_block``
+returns the input unchanged once the stale markers are gone).
+
+Usage:
+    QDRANT_URL=... QDRANT_API_KEY=... python scripts/patch_pricing_contact_block.py           # dry-run (default)
+    QDRANT_URL=... QDRANT_API_KEY=... python scripts/patch_pricing_contact_block.py --apply    # write
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+COLLECTION_NAME = "bali_zero_pricing_hybrid"
+
+STALE_WHATSAPP = "+62 813 3805 1876"
+CANONICAL_WHATSAPP = "+62 821 3465 159"  # Meta-verified BALI ZERO number
+STALE_LOCATION = "Canggu, Bali, Indonesia"
+CANONICAL_LOCATION = "Kerobokan, Bali, Indonesia"
+
+SCROLL_BATCH_SIZE = 100
+_SAMPLE_TAIL_CHARS = 200
+
+
+def rewrite_contact_block(text: str) -> str:
+    """Rewrite ONLY the WhatsApp/Location trailer lines of a pricing chunk's
+    embedded text. Never touches the name/category/price/duration/validity/
+    notes lines above the ``---`` separator.
+
+    Guilt: a text carrying the stale WhatsApp and/or Location line gets that
+    line rewritten to the canonical value.
+    Innocence: a text without either stale marker is returned byte-identical
+    (including a text that already has the canonical values — idempotent).
+    """
+    if STALE_WHATSAPP not in text and STALE_LOCATION not in text:
+        return text
+    new_text = text.replace(
+        f"**WhatsApp**: {STALE_WHATSAPP}", f"**WhatsApp**: {CANONICAL_WHATSAPP}"
+    )
+    new_text = new_text.replace(
+        f"**Location**: {STALE_LOCATION}", f"**Location**: {CANONICAL_LOCATION}"
+    )
+    return new_text
+
+
+async def _scroll_all_points(
+    client: httpx.AsyncClient, base_url: str, headers: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Scroll every point's id + payload (never vectors) from the collection."""
+    points: list[dict[str, Any]] = []
+    offset: Any = None
+    while True:
+        body: dict[str, Any] = {
+            "limit": SCROLL_BATCH_SIZE,
+            "with_payload": True,
+            "with_vectors": False,
+        }
+        if offset is not None:
+            body["offset"] = offset
+        resp = await client.post(
+            f"{base_url}/collections/{COLLECTION_NAME}/points/scroll",
+            headers=headers,
+            json=body,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        result = resp.json()["result"]
+        points.extend(result["points"])
+        offset = result.get("next_page_offset")
+        if offset is None:
+            break
+    return points
+
+
+async def _set_payload_text(
+    client: httpx.AsyncClient,
+    base_url: str,
+    headers: dict[str, str],
+    point_id: Any,
+    new_text: str,
+) -> None:
+    """Payload-only set — overwrites ONLY the ``text`` key for this one point
+    id. Vectors and every other payload key are untouched by construction
+    (Qdrant's set-payload endpoint merges at the top-level key)."""
+    body = {"payload": {"text": new_text}, "points": [point_id]}
+    resp = await client.post(
+        f"{base_url}/collections/{COLLECTION_NAME}/points/payload",
+        headers=headers,
+        json=body,
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+async def _run(apply: bool) -> int:
+    qdrant_url = os.environ.get("QDRANT_URL")
+    qdrant_api_key = os.environ.get("QDRANT_API_KEY")
+    if not qdrant_url or not qdrant_api_key:
+        logger.error("QDRANT_URL and QDRANT_API_KEY must be set in the environment")
+        return 1
+
+    headers = {"api-key": qdrant_api_key, "Content-Type": "application/json"}
+
+    async with httpx.AsyncClient() as client:
+        points = await _scroll_all_points(client, qdrant_url, headers)
+        logger.info("Scrolled %d point(s) from %s", len(points), COLLECTION_NAME)
+
+        stale: list[tuple[Any, str, str]] = []
+        for point in points:
+            text = (point.get("payload") or {}).get("text", "")
+            if not isinstance(text, str):
+                continue
+            new_text = rewrite_contact_block(text)
+            if new_text != text:
+                stale.append((point["id"], text, new_text))
+
+        logger.info("Found %d point(s) with the retired contact block", len(stale))
+
+        if stale:
+            sample_id, sample_before, sample_after = stale[0]
+            logger.info(
+                "Sample point %s BEFORE (tail): ...%s",
+                sample_id,
+                sample_before[-_SAMPLE_TAIL_CHARS:],
+            )
+            logger.info(
+                "Sample point %s AFTER  (tail): ...%s",
+                sample_id,
+                sample_after[-_SAMPLE_TAIL_CHARS:],
+            )
+
+        if not apply:
+            logger.info("Dry-run only (default) — pass --apply to write changes")
+            return 0
+
+        for point_id, _before, after in stale:
+            await _set_payload_text(client, qdrant_url, headers, point_id, after)
+
+        logger.info("Patched %d point(s) in %s", len(stale), COLLECTION_NAME)
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="Write the patched payloads (default: dry-run)"
+    )
+    args = parser.parse_args()
+    return asyncio.run(_run(apply=args.apply))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_patch_pricing_contact_block.py
+++ b/scripts/test_patch_pricing_contact_block.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Falsifiable tests for scripts/patch_pricing_contact_block.py.
+
+Run:
+    apps/backend-rag/.venv/bin/python -m pytest scripts/test_patch_pricing_contact_block.py -q
+
+Guilt tests (the rewrite MUST fire):
+  - A full pricing chunk carrying the retired WhatsApp + Location trailer
+    gets BOTH rewritten to the canonical values, price/name/category lines
+    untouched.
+  - A chunk with only the stale WhatsApp line (no Location line at all)
+    still gets that one line rewritten.
+Innocence tests (the rewrite MUST NOT fire / MUST NOT clobber):
+  - A chunk that already carries the canonical contact block is returned
+    byte-identical (idempotent — running the patch twice is a no-op).
+  - A chunk from an unrelated collection (no stale marker at all) is
+    returned byte-identical.
+  - The price line is never touched even when it contains digits that look
+    similar to phone-number digits.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import patch_pricing_contact_block as ppcb  # noqa: E402
+
+
+def _chunk(whatsapp: str, location: str, price: str = "5.800.000 IDR") -> str:
+    return (
+        "# C22A&B Internship (180 Days)\n"
+        "**Category**: Single Entry Visas\n"
+        f"**Price**: {price}\n"
+        "**Duration**: 180 days\n"
+        "\n---\n\n"
+        "**Contact**: info@balizero.com\n"
+        f"**WhatsApp**: {whatsapp}\n"
+        f"**Location**: {location}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guilt
+# ---------------------------------------------------------------------------
+
+
+def test_stale_contact_block_rewritten_both_lines():
+    before = _chunk(ppcb.STALE_WHATSAPP, ppcb.STALE_LOCATION)
+    after = ppcb.rewrite_contact_block(before)
+
+    assert ppcb.STALE_WHATSAPP not in after
+    assert ppcb.STALE_LOCATION not in after
+    assert f"**WhatsApp**: {ppcb.CANONICAL_WHATSAPP}" in after
+    assert f"**Location**: {ppcb.CANONICAL_LOCATION}" in after
+
+    # Everything above the `---` separator is untouched, verbatim.
+    before_header = before.split("\n---\n")[0]
+    after_header = after.split("\n---\n")[0]
+    assert before_header == after_header
+
+
+def test_stale_whatsapp_only_rewritten_when_location_already_canonical():
+    before = _chunk(ppcb.STALE_WHATSAPP, ppcb.CANONICAL_LOCATION)
+    after = ppcb.rewrite_contact_block(before)
+
+    assert f"**WhatsApp**: {ppcb.CANONICAL_WHATSAPP}" in after
+    assert f"**Location**: {ppcb.CANONICAL_LOCATION}" in after
+    assert ppcb.STALE_WHATSAPP not in after
+
+
+# ---------------------------------------------------------------------------
+# Innocence
+# ---------------------------------------------------------------------------
+
+
+def test_already_canonical_chunk_is_byte_identical():
+    text = _chunk(ppcb.CANONICAL_WHATSAPP, ppcb.CANONICAL_LOCATION)
+    assert ppcb.rewrite_contact_block(text) == text
+
+
+def test_unrelated_chunk_without_any_stale_marker_is_byte_identical():
+    text = "# Some other KBLI chunk\n**Category**: Not pricing at all\nNo contact block here."
+    assert ppcb.rewrite_contact_block(text) == text
+
+
+def test_price_line_never_touched_even_with_lookalike_digits():
+    # A price that happens to contain a digit run resembling a phone number
+    # must survive untouched — only the labeled WhatsApp/Location lines move.
+    before = _chunk(ppcb.STALE_WHATSAPP, ppcb.STALE_LOCATION, price="8.133.805 IDR")
+    after = ppcb.rewrite_contact_block(before)
+    assert "**Price**: 8.133.805 IDR" in after
+
+
+def test_patch_is_idempotent():
+    once = ppcb.rewrite_contact_block(_chunk(ppcb.STALE_WHATSAPP, ppcb.STALE_LOCATION))
+    twice = ppcb.rewrite_contact_block(once)
+    assert once == twice
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What

The prod Qdrant collection `bali_zero_pricing_hybrid` served pricing docs whose text carried a **retired contact block**: WhatsApp `+62 813 3805 1876` + `Canggu` — surfaced verbatim to clients in source snippets. The Meta-verified number is `+62 821 3465 159`, location Kerobokan.

**Root cause (archaeology):** the JSON source of truth (`bali_zero_official_prices_2026.json`) was never stale — the `_hybrid` collection was built ONCE by `migration_031b_hybrid_collections.py` from the OLD `bali_zero_pricing` collection (2025-era text blocks) and never refreshed.

## Fix

- `scripts/patch_pricing_contact_block.py` — idempotent, payload-only patch (Qdrant set-payload: **vectors untouched**, prices byte-identical; only the `**WhatsApp**:` / `**Location**:` trailer lines rewritten). `--dry-run` default, `--apply` to write.
- **Already applied to prod by the orchestrator session**: dry-run found 70 points → `--apply` patched 70/70 → re-verify finds **0** remaining.
- New data-invariant tripwire: no pricing source may reintroduce the retired number.

## Why payload-only, no re-embed

Embedding model is FROZEN (`text-embedding-3-small`); the two trailer lines are semantically irrelevant to the vector (name/category/price is what's embedded against). A full regen would cost OpenAI calls and target the wrong collection name.

## Tests

Patch-fn guilt (stale block rewritten exactly, prices byte-identical) + innocence (clean doc untouched): 9 green; tripwires 2→3 (additive). Verified independently by the orchestrator session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
