### PR TITLE
fix(mata-garuda): plist_watchdog host-pins — stop resurrecting Mini-only services on Pro

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/plist_watchdog.py
+++ b/apps/mata-garuda/mata_garuda/workers/plist_watchdog.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import socket
 import subprocess
 import sys
 import time
@@ -53,6 +54,14 @@ WINDOW_SECONDS = 24 * 3600
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 SNAPSHOT_DIR = _REPO_ROOT / "infra" / "launchagents"
 
+# host-pins.json — declarative label→host(s) pinning (cicatrix family #10,
+# active-active split-brain). A label listed here is only healed by THIS
+# watchdog on a host whose normalized hostname is in the list. Fail-open:
+# missing/malformed file ⇒ no pinning at all, identical to pre-pin behavior.
+# Filename only (not a fixed Path) so it's resolved against SNAPSHOT_DIR at
+# call-time — this keeps it test-patchable the same way SNAPSHOT_DIR is.
+HOST_PINS_FILENAME = "host-pins.json"
+
 
 def _uid() -> int:
     return os.getuid()
@@ -60,6 +69,47 @@ def _uid() -> int:
 
 def _domain() -> str:
     return f"gui/{_uid()}"
+
+
+def _normalize_host(name: str) -> str:
+    """lowercase, strip a trailing '.local' mDNS suffix."""
+    n = (name or "").strip().lower()
+    if n.endswith(".local"):
+        n = n[: -len(".local")]
+    return n
+
+
+def _current_host() -> str:
+    """This machine's normalized hostname (Pro=nuzantara, Mini=mini-pro2)."""
+    try:
+        name = socket.gethostname()
+    except OSError:
+        name = ""
+    return _normalize_host(name)
+
+
+def _load_host_pins() -> tuple[dict[str, list[str]], str]:
+    """Load SNAPSHOT_DIR/host-pins.json. Fail-open: file absent/malformed ⇒
+    no pinning at all — identical to the pre-pin behavior. Resolved against
+    SNAPSHOT_DIR at call-time (not a module-load-time constant) so it stays
+    test-patchable. Returns (pins, status_line)."""
+    path = SNAPSHOT_DIR / HOST_PINS_FILENAME
+    try:
+        raw = path.read_text()
+    except OSError:
+        return {}, "host-pins: unreadable — no pinning"
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return {}, "host-pins: unreadable — no pinning"
+    if not isinstance(data, dict):
+        return {}, "host-pins: unreadable — no pinning"
+    pins: dict[str, list[str]] = {}
+    for label, hosts in data.items():
+        if not isinstance(hosts, list):
+            continue  # e.g. skips "_comment"
+        pins[label] = [_normalize_host(str(h)) for h in hosts]
+    return pins, f"host-pins: loaded ({len(pins)} label(s) pinned)"
 
 
 def _launchctl_knows(label: str) -> bool:
@@ -159,7 +209,9 @@ def _emit_heartbeat(status: str, meta: dict) -> None:
 def main() -> int:
     now = time.time()
     led = _load_ledger()
-    healed, diverged, breaker_tripped, ok = [], [], [], 0
+    current_host = _current_host()
+    host_pins, pins_status = _load_host_pins()
+    healed, diverged, breaker_tripped, skipped_pinned, ok = [], [], [], [], 0
 
     snapshots = sorted(glob.glob(str(SNAPSHOT_DIR / f"{LABEL_PREFIX}*.plist")))
     for snap_path in snapshots:
@@ -181,7 +233,17 @@ def main() -> int:
             ok += 1
             continue
 
-        # VANISHED (absent from disk OR unknown to launchctl) → heal candidate
+        # VANISHED (absent from disk OR unknown to launchctl) → heal candidate,
+        # UNLESS the label is host-pinned to hosts that don't include this one
+        # (cicatrix #10 active-active split-brain: don't resurrect a Mini-only
+        # service on Pro just because Pro doesn't know it).
+        pinned_hosts = host_pins.get(label)
+        if pinned_hosts and current_host not in pinned_hosts:
+            skipped_pinned.append(
+                f"{label}: host-pinned to {pinned_hosts!r}, this host is {current_host!r}"
+            )
+            continue
+
         if not _breaker_ok(led, label, now):
             breaker_tripped.append(label)
             continue
@@ -194,14 +256,18 @@ def main() -> int:
 
     _save_ledger(led)
 
+    print(pins_status)
     print(f"[matagaruda-plist-watchdog] snapshots={len(snapshots)} ok={ok} "
-          f"healed={len(healed)} diverged={len(diverged)} breaker_tripped={len(breaker_tripped)}")
+          f"healed={len(healed)} diverged={len(diverged)} breaker_tripped={len(breaker_tripped)} "
+          f"skipped_pinned={len(skipped_pinned)}")
     for h in healed:
         print(f"  HEALED: {h}")
     for d in diverged:
         print(f"  DIVERGED (report-only, not touched): {d}")
     for b in breaker_tripped:
         print(f"  BREAKER-TRIPPED (>{MAX_HEALS_PER_WINDOW}/{WINDOW_SECONDS}s): {b}")
+    for s in skipped_pinned:
+        print(f"  SKIP {s}")
 
     status = "ok"
     if any("FAILED" in h for h in healed) or breaker_tripped:

--- a/apps/mata-garuda/tests/test_plist_watchdog.py
+++ b/apps/mata-garuda/tests/test_plist_watchdog.py
@@ -107,3 +107,76 @@ def test_ledger_persisted(env):
     led = json.loads((pw.LEDGER).read_text())
     assert "com.matagaruda.zeta" in led
     assert len(led["com.matagaruda.zeta"]) == 1
+
+
+# ── host-pins (cicatrix family #10 — active-active split-brain) ────────────
+
+
+def _write_pins(pw, snap_dir: Path, pins: dict) -> None:
+    (snap_dir / "host-pins.json").write_text(json.dumps(pins))
+
+
+def test_pinned_label_wrong_host_is_skipped_not_healed(env, monkeypatch):
+    """Label pinned to mini-pro2, this host is 'Nuzantara' → NOT healed,
+    report contains SKIP with the pin + this-host detail."""
+    _write_pins(pw, env.snap, {"com.matagaruda.kg-query-api": ["mini-pro2"]})
+    monkeypatch.setattr(pw.socket, "gethostname", lambda: "Nuzantara")
+    env.add_snapshot("kg-query-api")   # vanished (no live file) → would-be heal
+    assert pw.main() == 0
+    assert env.bootstrapped == []
+    assert "com.matagaruda.kg-query-api" not in [
+        h.split(":")[0] for h in env.bootstrapped
+    ]
+
+
+def test_pinned_label_wrong_host_report_contains_skip(env, monkeypatch, capsys):
+    _write_pins(pw, env.snap, {"com.matagaruda.kg-query-api": ["mini-pro2"]})
+    monkeypatch.setattr(pw.socket, "gethostname", lambda: "Nuzantara")
+    env.add_snapshot("kg-query-api")
+    pw.main()
+    out = capsys.readouterr().out
+    assert "SKIP com.matagaruda.kg-query-api" in out
+    assert "mini-pro2" in out
+    assert "nuzantara" in out  # normalized current host
+
+
+def test_pinned_label_matching_host_heals_normally(env, monkeypatch):
+    """Label pinned to mini-pro2, this host normalizes to 'mini-pro2'
+    (from 'Mini-Pro2.local') → heals normally."""
+    _write_pins(pw, env.snap, {"com.matagaruda.kg-query-api": ["mini-pro2"]})
+    monkeypatch.setattr(pw.socket, "gethostname", lambda: "Mini-Pro2.local")
+    env.add_snapshot("kg-query-api")
+    assert pw.main() == 0
+    assert "com.matagaruda.kg-query-api" in env.bootstrapped
+
+
+def test_unpinned_label_heals_as_today(env, monkeypatch):
+    """A label absent from host-pins.json heals exactly like before pinning."""
+    _write_pins(pw, env.snap, {"com.matagaruda.kg-query-api": ["mini-pro2"]})
+    monkeypatch.setattr(pw.socket, "gethostname", lambda: "Nuzantara")
+    env.add_snapshot("some-other-job")   # NOT in the pins file
+    assert pw.main() == 0
+    assert "com.matagaruda.some-other-job" in env.bootstrapped
+
+
+def test_missing_host_pins_file_heals_as_today(env, monkeypatch, capsys):
+    """No host-pins.json at all (SNAPSHOT_DIR/host-pins.json absent) → fail-open,
+    behavior identical to pre-pin (heals), plus a report line."""
+    assert not (env.snap / "host-pins.json").exists()
+    monkeypatch.setattr(pw.socket, "gethostname", lambda: "Nuzantara")
+    env.add_snapshot("kg-query-api")
+    assert pw.main() == 0
+    assert "com.matagaruda.kg-query-api" in env.bootstrapped
+    out = capsys.readouterr().out
+    assert "host-pins: unreadable" in out
+
+
+def test_malformed_host_pins_file_fails_open(env, monkeypatch, capsys):
+    """host-pins.json exists but is not valid JSON → fail-open, same as missing."""
+    (env.snap / "host-pins.json").write_text("{not valid json,,,")
+    monkeypatch.setattr(pw.socket, "gethostname", lambda: "Nuzantara")
+    env.add_snapshot("kg-query-api")
+    assert pw.main() == 0
+    assert "com.matagaruda.kg-query-api" in env.bootstrapped
+    out = capsys.readouterr().out
+    assert "host-pins: unreadable" in out

--- a/infra/launchagents/host-pins.json
+++ b/infra/launchagents/host-pins.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "labels pinned to specific hosts — plist_watchdog only heals a pinned label on its declared host(s). Hostname normalized: lowercase, strip .local. Pro=nuzantara, Mini=mini-pro2.",
+  "com.matagaruda.kg-query-api": ["mini-pro2"]
+}


### PR DESCRIPTION
## Summary

The plist_watchdog heals any `com.matagaruda.*` label that launchctl doesn't know by reinstalling it from the repo snapshot — with **zero machine-awareness**. Today that resurrected `com.matagaruda.kg-query-api` on Pro: a Mini-only service (its wrapper lives in `~/scripts/mini-infra/`, present only on Mini; the live service answers 200 on `100.93.236.6:8990`). It had already been deliberately disarmed on Pro (`.disabled-pre-split-brain-fix`) — the healer was recreating the disease (cicatrix family #10, active-active split-brain).

## Cure

Declarative `infra/launchagents/host-pins.json`: a pinned label is only healed on a host whose normalized hostname (`lowercase`, strip `.local`) is in its list. **Fail-open**: file absent/malformed ⇒ behavior byte-identical to pre-pin (everything heals as today), with an explicit `host-pins: unreadable` report line so the degradation is visible, never silent.

First pin: `com.matagaruda.kg-query-api → ["mini-pro2"]`.

## Verification

- 6 new guilt+innocence tests (wrong host skipped + SKIP report line · matching host heals · unpinned label heals · missing file fail-open · malformed file fail-open) — 12/12 passing, re-run independently by the orchestrating session (generator≠grader).
- Live counterpart already applied on Pro: `launchctl disable` + bootout of the phantom instance (evidence in the S1 TAC report, `research/operations/2026-07-18-medico-s1-tac-organismo.md` in PR from the medico branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)