### PR TITLE
fix(rag): verifier empty-verdict must not trigger self-correction + LLM latency telemetry + honest reranker

### DIFF
--- a/apps/backend-rag/backend/app/routers/agentic_rag.py
+++ b/apps/backend-rag/backend/app/routers/agentic_rag.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from backend.app.core.config import settings
 from backend.app.dependencies import (
     get_current_user,
     get_current_user_optional,
@@ -454,7 +455,21 @@ async def query_agentic_rag(
                 "cache_hit": result.cache_hit,
                 "ab_config": {
                     "hybrid": hybrid_config,
-                    "rerank": rerank_config,
+                    # HONESTY FIX (2026-07-18): `rerank_config` is the A/B
+                    # experiment's INTENDED variant (e.g. "with_rerank" ->
+                    # {"use_reranking": True}) from a random per-user split —
+                    # it is never actually wired into orchestrator.process_query
+                    # and does NOT reflect whether reranking really ran.
+                    # search_service._init_reranker() used to hardcode
+                    # enabled=True regardless of settings.enable_reranker,
+                    # so a query could show "with_rerank" here while the
+                    # cross-encoder silently failed to import and returned
+                    # zero scores. `reranker_actually_enabled` is the real,
+                    # global on/off switch (see settings.enable_reranker).
+                    "rerank": {
+                        **rerank_config,
+                        "reranker_actually_enabled": settings.enable_reranker,
+                    },
                     "expansion": expansion_config,
                 },
             },

--- a/apps/backend-rag/backend/services/rag/agentic/llm_gateway.py
+++ b/apps/backend-rag/backend/services/rag/agentic/llm_gateway.py
@@ -37,6 +37,7 @@ UPDATED 2025-12-23:
 
 import asyncio
 import logging
+import time
 from typing import Any
 
 import httpx
@@ -60,6 +61,7 @@ from backend.app.metrics import (
 )
 from backend.app.utils.tracing import set_span_attribute, set_span_status, trace_span
 from backend.llm.genai_client import GENAI_AVAILABLE, GenAIClient, get_genai_client, types
+from backend.llm.metrics_emitter import emit_llm_metric
 from backend.services.llm_clients.openrouter_client import ModelTier, OpenRouterClient
 from backend.services.llm_clients.pricing import TokenUsage, create_token_usage
 from backend.services.rag.agentic.chat_session import ChatSession, MockChatSession
@@ -331,8 +333,16 @@ class LLMGateway:
             >>> logger.info(f"[{model}] {response} (cost: ${usage.cost_usd:.6f})")
         """
         query_cost_tracker = {"cost": 0.0, "depth": 0}
+        # Latency telemetry (2026-07-18): this call and the rephrase/
+        # self-correction retry are the two biggest single LLM calls in the
+        # ReAct loop (~15-17s each in the live timeout repro), yet had ZERO
+        # latency logging — unlike genai_client.generate_content's "LLM
+        # call" logger. Mirror that pattern here at the gateway level so the
+        # duration is visible regardless of which tier/model actually served
+        # the request.
+        t0 = time.perf_counter()
         try:
-            return await self._send_with_fallback(
+            text_content, model_used, response_obj, token_usage = await self._send_with_fallback(
                 chat=chat,
                 message=message,
                 system_prompt=system_prompt,
@@ -342,13 +352,36 @@ class LLMGateway:
                 query_cost_tracker=query_cost_tracker,
                 images=images,
             )
+            latency_ms = round((time.perf_counter() - t0) * 1000)
+            provider = "openrouter" if model_used == "openrouter" else "gemini"
+            logger.info(
+                "LLM gateway call",
+                extra={
+                    "provider": provider,
+                    "model": model_used,
+                    "tier": tier,
+                    "latency_ms": latency_ms,
+                    "prompt_tokens": token_usage.prompt_tokens,
+                    "completion_tokens": token_usage.completion_tokens,
+                },
+            )
+            await emit_llm_metric(
+                provider=provider,
+                model=model_used,
+                latency_ms=latency_ms,
+                prompt_tokens=token_usage.prompt_tokens,
+                completion_tokens=token_usage.completion_tokens,
+            )
+            return (text_content, model_used, response_obj, token_usage)
         except Exception as e:
+            latency_ms = round((time.perf_counter() - t0) * 1000)
             logger.exception(
                 "All LLM models failed",
                 extra={
                     "tier": tier,
                     "fallback_depth": query_cost_tracker["depth"],
                     "total_cost": query_cost_tracker["cost"],
+                    "latency_ms": latency_ms,
                 },
             )
             llm_all_models_failed_total.inc()

--- a/apps/backend-rag/backend/services/rag/agentic/pipeline.py
+++ b/apps/backend-rag/backend/services/rag/agentic/pipeline.py
@@ -94,6 +94,7 @@ class VerificationStage(PipelineStage):
             logger.debug(f"[{self.name}] Skipping verification (response too short or no context)")
             data["verification_score"] = 1.0
             data["verification_status"] = "skipped"
+            data["verdict_available"] = True
             return data
 
         try:
@@ -109,19 +110,27 @@ class VerificationStage(PipelineStage):
                 "score": verification.score,
                 "reasoning": verification.reasoning,
                 "missing_citations": verification.missing_citations,
+                "verdict_available": verification.verdict_available,
             }
             data["verification_score"] = verification.score
             data["verification_status"] = verification.status.value
+            data["verdict_available"] = verification.verdict_available
 
             logger.info(
                 f"[{self.name}] Verification complete: "
-                f"status={verification.status.value}, score={verification.score:.2f}",
+                f"status={verification.status.value}, score={verification.score:.2f}, "
+                f"verdict_available={verification.verdict_available}",
             )
 
         except (ValueError, RuntimeError, KeyError) as e:
+            # verification_service.verify_response() is designed to never
+            # raise (it fails-open internally); this is a defense-in-depth
+            # net. Same rule applies: no real verdict here → never gate
+            # self-correction on the placeholder score.
             logger.warning(f"[{self.name}] Verification failed: {e}", exc_info=True)
             data["verification_score"] = 0.5
             data["verification_status"] = "error"
+            data["verdict_available"] = False
 
         return data
 

--- a/apps/backend-rag/backend/services/rag/agentic/reasoning.py
+++ b/apps/backend-rag/backend/services/rag/agentic/reasoning.py
@@ -907,9 +907,28 @@ Make it feel natural and helpful, not forced.
                     # Run through pipeline
                     processed = await self.response_pipeline.process(pipeline_data)
                     set_span_attribute("verification_score", processed.get("verification_score", 0))
+                    verdict_available = processed.get("verdict_available", True)
+                    verification_score = processed.get("verification_score", 1.0)
+                    set_span_attribute("verdict_available", verdict_available)
 
-                    # Handle verification failure (self-correction)
-                    if processed.get("verification_score", 1.0) < 0.7 and state.context_gathered:
+                    # Handle verification failure (self-correction) — ONLY when
+                    # the verifier actually produced a verdict. An empty/
+                    # unparseable verifier response (verdict_available=False)
+                    # must never trigger self-correction: the placeholder
+                    # score=0.5 is not a real judgment, and rephrasing on top
+                    # of it wastes a full rephrase+re-verify round-trip
+                    # (~23s — the verifier hits the same empty-response bug on
+                    # retry, so the loop "corrects" an answer that was never
+                    # actually rejected). See verification_service.py.
+                    if not verdict_available:
+                        if verification_score < 0.7 and state.context_gathered:
+                            logger.info(
+                                "🛡️ [Pipeline] Verifier unavailable — skipping "
+                                "self-correction (placeholder score=%.2f is not a "
+                                "real verdict).",
+                                verification_score,
+                            )
+                    elif verification_score < 0.7 and state.context_gathered:
                         verification = processed.get("verification", {})
                         logger.warning(
                             f"🛡️ [Pipeline] REJECTED draft (Score: {verification.get('score', 0)}). "

--- a/apps/backend-rag/backend/services/rag/verification_service.py
+++ b/apps/backend-rag/backend/services/rag/verification_service.py
@@ -47,6 +47,10 @@ class VerificationResult(BaseModel):
         reasoning: Explanation of the verification decision.
         corrected_answer: Suggested correction if verification failed.
         missing_citations: List of claims that lack source citations.
+        verdict_available: False when the LLM judge never produced a real
+            verdict (empty response, unparseable JSON, or an unexpected
+            error) — `score`/`status` in that case are a placeholder, not
+            a real judgment, and MUST NOT gate self-correction downstream.
     """
 
     is_valid: bool
@@ -55,6 +59,7 @@ class VerificationResult(BaseModel):
     reasoning: str
     corrected_answer: str | None = None
     missing_citations: list[str] = []
+    verdict_available: bool = True
 
 
 class VerificationService:
@@ -160,7 +165,32 @@ Return a JSON object with this exact structure:
                 max_output_tokens=8192,
             )
 
-            result_json = json.loads(result.get("text", "{}"))
+            # Gemini can return an EMPTY string for `text` (safety block or
+            # content filter). The `"{}"` default on .get() only applies when
+            # the key is MISSING, not when its value is "" — json.loads("")
+            # raises, which used to fall through to the blanket except below
+            # and mint a fake score=0.5. Downstream (reasoning.py) treated
+            # that fake 0.5 as a real "half-supported" verdict and triggered
+            # a wasted self-correction round-trip (rephrase LLM call, then
+            # re-verify — same empty-response bug, ~23s wasted on a query
+            # that was correct the first time). Guard explicitly so callers
+            # can tell "no verdict" from "verdict genuinely says 0.5".
+            text = (result.get("text") or "").strip()
+            if not text:
+                logger.warning(
+                    "🛡️ [Verifier] LLM returned empty response "
+                    "(possible safety block or content filter) — "
+                    "verdict unavailable, passing through",
+                )
+                return VerificationResult(
+                    is_valid=True,
+                    status=VerificationStatus.PARTIALLY_VERIFIED,
+                    score=0.5,
+                    reasoning="Verifier LLM returned an empty response. Verdict unavailable.",
+                    verdict_available=False,
+                )
+
+            result_json = json.loads(text)
 
             status = VerificationStatus(result_json.get("status", "unverified"))
             score = float(result_json.get("score", 0.0))
@@ -179,15 +209,30 @@ Return a JSON object with this exact structure:
                 missing_citations=result_json.get("missing_citations", []),
             )
 
+        except (json.JSONDecodeError, ValueError, KeyError) as e:
+            # Verdict could not be parsed (malformed JSON / invalid status
+            # enum / missing key). Never a real verdict — never let it gate
+            # self-correction downstream.
+            logger.warning("🛡️ [Verifier] Could not parse verifier verdict: %s", e)
+            return VerificationResult(
+                is_valid=True,
+                status=VerificationStatus.PARTIALLY_VERIFIED,
+                score=0.5,
+                reasoning=f"Verifier verdict could not be parsed: {e}",
+                verdict_available=False,
+            )
+
         except Exception as e:
+            # Unexpected error (network, API, etc.). Fail safe: allow it but
+            # log error — and, same as above, never let the placeholder
+            # score gate self-correction.
             logger.error("❌ [Verifier] Error during verification: %s", e)
-            # Fail safe: allow it but log error, or block?
-            # Better to block high-stakes, but for now we'll allow with warning.
             return VerificationResult(
                 is_valid=True,
                 status=VerificationStatus.PARTIALLY_VERIFIED,
                 score=0.5,
                 reasoning=f"Verification failed processing: {e}",
+                verdict_available=False,
             )
 
 

--- a/apps/backend-rag/backend/services/search/search_service.py
+++ b/apps/backend-rag/backend/services/search/search_service.py
@@ -915,10 +915,22 @@ class SearchService:
         """
         if not hasattr(self, "_reranker"):
             backend: str = getattr(settings, "reranker_backend", "cross-encoder")
+            # HONESTY FIX (2026-07-18): this used to hardcode enabled=True
+            # regardless of settings.enable_reranker (default False — the
+            # cross-encoder model is intentionally NOT bundled in the prod
+            # image, saves ~5GB). That forced CrossEncoderReranker to try
+            # loading sentence_transformers on every call, fail with
+            # "No module named 'sentence_transformers'", and silently
+            # return zero scores — while callers still believed reranking
+            # ran. Respecting the setting here makes `.enabled` honest, so
+            # search_with_reranking()'s `if reranker.enabled:` check
+            # actually short-circuits instead of eating the failed-import
+            # cost on every query.
+            reranker_enabled = getattr(settings, "enable_reranker", False)
             if backend == "cross-encoder":
                 from backend.services.rag.reranker import CrossEncoderReranker
 
-                self._reranker = CrossEncoderReranker(enabled=True)
+                self._reranker = CrossEncoderReranker(enabled=reranker_enabled)
                 logger.info(
                     f"🔧 CrossEncoderReranker initialized: enabled={self._reranker.enabled}, "
                     f"model={self._reranker.model_name}",
@@ -937,7 +949,7 @@ class SearchService:
                 )
                 from backend.services.rag.reranker import CrossEncoderReranker
 
-                self._reranker = CrossEncoderReranker(enabled=True)
+                self._reranker = CrossEncoderReranker(enabled=reranker_enabled)
         return self._reranker
 
     async def search_with_reranking(

--- a/apps/backend-rag/backend/tests/services/rag/test_verification_service.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_verification_service.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from backend.services.rag.verification_service import (
     VerificationResult,
@@ -38,7 +39,7 @@ class TestVerificationResult:
         assert result.score == 0.95
 
     def test_score_bounds_enforced(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError, match="score"):
             VerificationResult(
                 is_valid=True,
                 status=VerificationStatus.VERIFIED,
@@ -55,6 +56,7 @@ class TestVerificationResult:
         )
         assert result.corrected_answer is None
         assert result.missing_citations == []
+        assert result.verdict_available is True
 
 
 class TestVerificationServiceFallbacks:
@@ -108,6 +110,54 @@ class TestVerificationServiceFallbacks:
         assert result.is_valid is True
         assert result.status == VerificationStatus.PARTIALLY_VERIFIED
         assert "failed" in result.reasoning.lower()
+        # Placeholder score — never a real verdict, must never gate
+        # self-correction downstream (reasoning.py).
+        assert result.verdict_available is False
+
+    @pytest.mark.asyncio
+    async def test_empty_llm_response_marks_verdict_unavailable(self):
+        """2026-07-18 fix: Gemini can return text="" (safety block / content
+        filter). json.loads("") used to raise and fall into the blanket
+        except, minting a score=0.5 that reasoning.py's self-correction gate
+        treated as a real verdict — wasting a rephrase+re-verify round-trip
+        (~23s, live timeout repro). Guard must catch this BEFORE json.loads
+        and mark verdict_available=False, never raise.
+        """
+        service = VerificationService()
+        mock_client = MagicMock()
+        mock_client.is_available = True
+        mock_client.generate_content = AsyncMock(return_value={"text": ""})
+        service._genai_client = mock_client
+
+        result = await service.verify_response(
+            query="test",
+            draft_answer="test answer",
+            context_chunks=["context"],
+        )
+        assert result.is_valid is True
+        assert result.status == VerificationStatus.PARTIALLY_VERIFIED
+        assert result.score == 0.5
+        assert result.verdict_available is False
+
+    @pytest.mark.asyncio
+    async def test_unparseable_json_marks_verdict_unavailable(self):
+        """Malformed JSON from the verifier LLM must also be treated as
+        'no verdict available', not a real score=0.5."""
+        service = VerificationService()
+        mock_client = MagicMock()
+        mock_client.is_available = True
+        mock_client.generate_content = AsyncMock(return_value={"text": "{not valid json"})
+        service._genai_client = mock_client
+
+        result = await service.verify_response(
+            query="test",
+            draft_answer="test answer",
+            context_chunks=["context"],
+        )
+        assert result.is_valid is True
+        assert result.status == VerificationStatus.PARTIALLY_VERIFIED
+        assert result.score == 0.5
+        assert result.verdict_available is False
 
 
 class TestVerificationServiceWithLLM:
@@ -141,6 +191,8 @@ class TestVerificationServiceWithLLM:
         assert result.is_valid is True
         assert result.status == VerificationStatus.VERIFIED
         assert result.score == 0.95
+        # Innocence: a normal, successfully-parsed verdict is a REAL verdict.
+        assert result.verdict_available is True
 
     @pytest.mark.asyncio
     async def test_hallucination_detected(self):

--- a/apps/backend-rag/backend/tests/unit/routers/test_agentic_rag_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_agentic_rag_coverage.py
@@ -310,3 +310,102 @@ class TestGetConversationHistory:
             db_pool=pool,
         )
         assert result == []
+
+
+# ============================================================================
+# query_agentic_rag — ab_config.rerank honesty (2026-07-18)
+#
+# `rerank_config` is the A/B experiment's randomly-assigned INTENDED variant
+# (e.g. "with_rerank" -> {"use_reranking": True}) — it is never actually
+# wired into orchestrator.process_query and does not reflect whether
+# reranking really ran. search_service._init_reranker() used to hardcode
+# enabled=True regardless of settings.enable_reranker, so a query could
+# report "with_rerank" here while the cross-encoder silently failed to
+# import sentence_transformers and returned zero scores. debug_info must
+# also carry the REAL global on/off switch.
+# ============================================================================
+
+
+class TestQueryAgenticRagRerankHonesty:
+    def _mock_result(self) -> MagicMock:
+        result = MagicMock()
+        result.answer = "answer"
+        result.sources = []
+        result.document_count = 0
+        result.timings = {"total": 0.1}
+        result.route_used = "flash"
+        result.tools_called = []
+        result.model_used = "gemini-3-flash"
+        result.cache_hit = False
+        result.abstain = False
+        result.abstain_reason = None
+        result.evidence_score = 0.9
+        result.workflow = None
+        result.reasoning = None
+        result.entities = {}
+        result.confidence_score = 0.9
+        return result
+
+    def _mock_ab_manager(self) -> MagicMock:
+        manager = MagicMock()
+        manager.assign_variant.return_value = "with_rerank"
+        manager.get_variant_config.side_effect = lambda exp, variant: (
+            {"use_reranking": True, "top_k": 5} if exp == "reranking_on_off" else {}
+        )
+        manager.metrics_tracker.record_query_metrics = AsyncMock()
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_reports_actual_state_false_even_when_ab_says_with_rerank(
+        self, monkeypatch
+    ):
+        """Guilt: A/B bucket says 'with_rerank' but the real global switch
+        is off — debug_info must surface the real state, not just the A/B
+        intent."""
+        from backend.app.routers import agentic_rag as router_module
+
+        orchestrator = AsyncMock()
+        orchestrator.process_query = AsyncMock(return_value=self._mock_result())
+
+        monkeypatch.setattr(
+            router_module, "get_ab_test_manager", lambda: self._mock_ab_manager()
+        )
+        monkeypatch.setattr(router_module, "_lf_enabled", lambda: False)
+        monkeypatch.setattr(router_module.settings, "enable_reranker", False)
+
+        request = router_module.AgenticQueryRequest(query="what is KITAS?")
+        response = await router_module.query_agentic_rag(
+            request=request,
+            current_user=None,
+            orchestrator=orchestrator,
+            db_pool=None,
+        )
+
+        rerank_debug = response.debug_info["ab_config"]["rerank"]
+        assert rerank_debug["use_reranking"] is True  # A/B intent preserved
+        assert rerank_debug["reranker_actually_enabled"] is False  # real state
+
+    @pytest.mark.asyncio
+    async def test_reports_actual_state_true_when_setting_enabled(self, monkeypatch):
+        """Innocence: when settings.enable_reranker=True, the honesty field
+        reflects that too — behavior for the True case is unchanged."""
+        from backend.app.routers import agentic_rag as router_module
+
+        orchestrator = AsyncMock()
+        orchestrator.process_query = AsyncMock(return_value=self._mock_result())
+
+        monkeypatch.setattr(
+            router_module, "get_ab_test_manager", lambda: self._mock_ab_manager()
+        )
+        monkeypatch.setattr(router_module, "_lf_enabled", lambda: False)
+        monkeypatch.setattr(router_module.settings, "enable_reranker", True)
+
+        request = router_module.AgenticQueryRequest(query="what is KITAS?")
+        response = await router_module.query_agentic_rag(
+            request=request,
+            current_user=None,
+            orchestrator=orchestrator,
+            db_pool=None,
+        )
+
+        assert response.debug_info["ab_config"]["rerank"]["reranker_actually_enabled"] is True

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_llm_gateway.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_llm_gateway.py
@@ -185,15 +185,25 @@ class TestCircuitBreaker:
         assert gateway._is_circuit_open("test_model") is False
 
     def test_record_success(self, gateway):
+        circuit = gateway._get_circuit_breaker("test_model")
+        circuit.record_failure()  # seed a failure to prove the reset below
+        assert circuit.failure_count == 1
+
         gateway._record_success("test_model")
-        # Should not raise
+
+        assert circuit.failure_count == 0
 
     @patch("backend.services.rag.agentic.llm_gateway.ErrorClassifier")
     @patch("backend.services.rag.agentic.llm_gateway.get_error_context")
     def test_record_failure(self, mock_ctx, mock_classifier, gateway):
         mock_classifier.classify_error.return_value = ("transient", "low")
         mock_ctx.return_value = {}
+
         gateway._record_failure("test_model", Exception("test error"))
+
+        circuit = gateway._get_circuit_breaker("test_model")
+        assert circuit.failure_count == 1
+        mock_classifier.classify_error.assert_called_once()
 
 
 # ============================================================================
@@ -334,6 +344,75 @@ class TestSendMessage:
         )
         call_kwargs = gateway._send_with_fallback.call_args[1]
         assert call_kwargs["images"] is not None
+
+
+# ============================================================================
+# send_message latency telemetry (2026-07-18)
+#
+# The two biggest single LLM calls in the ReAct loop (final-answer synthesis
+# + self-correction rephrase) go through send_message, which previously had
+# ZERO latency logging — unlike genai_client.generate_content's "LLM call"
+# logger. Mirror that pattern: one INFO line with model/tier/latency_ms on
+# success, and latency_ms in the "All LLM models failed" log on total
+# failure.
+# ============================================================================
+
+
+class TestSendMessageTelemetry:
+    @pytest.mark.asyncio
+    async def test_send_message_logs_latency_on_success(self, gateway, caplog):
+        mock_usage = MagicMock()
+        mock_usage.cost_usd = 0.001
+        mock_usage.prompt_tokens = 42
+        mock_usage.completion_tokens = 7
+        gateway._send_with_fallback = AsyncMock(
+            return_value=("response text", "gemini-3-flash", MagicMock(), mock_usage),
+        )
+
+        with caplog.at_level("INFO"):
+            await gateway.send_message(chat=None, message="Hello", tier=TIER_FLASH)
+
+        records = [r for r in caplog.records if r.message == "LLM gateway call"]
+        assert len(records) == 1
+        assert records[0].latency_ms >= 0
+        assert records[0].model == "gemini-3-flash"
+        assert records[0].provider == "gemini"
+        assert records[0].prompt_tokens == 42
+        assert records[0].completion_tokens == 7
+
+    @pytest.mark.asyncio
+    async def test_send_message_emits_metric_on_success(self, gateway):
+        mock_usage = MagicMock()
+        mock_usage.cost_usd = 0.0
+        mock_usage.prompt_tokens = 10
+        mock_usage.completion_tokens = 5
+        gateway._send_with_fallback = AsyncMock(
+            return_value=("response text", "openrouter", None, mock_usage),
+        )
+
+        with patch(
+            "backend.services.rag.agentic.llm_gateway.emit_llm_metric",
+            new_callable=AsyncMock,
+        ) as mock_emit:
+            await gateway.send_message(chat=None, message="Hello", tier=TIER_FLASH)
+
+        mock_emit.assert_awaited_once()
+        assert mock_emit.call_args.kwargs["provider"] == "openrouter"
+        assert mock_emit.call_args.kwargs["model"] == "openrouter"
+        assert mock_emit.call_args.kwargs["prompt_tokens"] == 10
+        assert mock_emit.call_args.kwargs["completion_tokens"] == 5
+        assert mock_emit.call_args.kwargs["latency_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_send_message_logs_latency_on_total_failure(self, gateway, caplog):
+        gateway._send_with_fallback = AsyncMock(side_effect=RuntimeError("All failed"))
+
+        with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="All LLM models failed"):
+            await gateway.send_message(chat=None, message="Hello")
+
+        records = [r for r in caplog.records if r.message == "All LLM models failed"]
+        assert len(records) == 1
+        assert records[0].latency_ms >= 0
 
 
 # ============================================================================

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave1.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave1.py
@@ -920,6 +920,65 @@ class TestPipelineProcessing:
         assert result_state.final_answer == "corrected answer"
 
     @pytest.mark.asyncio
+    async def test_pipeline_verdict_unavailable_skips_self_correction(self, engine):
+        """2026-07-18 verifier-timeout fix: verification_score < 0.7 but
+        verdict_available=False (empty/unparseable verifier response) must
+        NOT trigger self-correction — only 1 pipeline pass, only 1
+        send_message call (no wasted rephrase round-trip)."""
+        pipeline = MagicMock()
+        pipeline.process = AsyncMock(
+            return_value={
+                "response": "original answer",
+                "verification_score": 0.5,
+                "verdict_available": False,
+                "verification": {
+                    "reasoning": "Verifier LLM returned an empty response. Verdict unavailable.",
+                },
+            },
+        )
+        from backend.services.rag.agentic.reasoning import ReasoningEngine
+
+        local_engine = ReasoningEngine(tool_map={}, response_pipeline=pipeline)
+
+        state = AgentState(query="q", max_steps=1, current_step=0, intent_type="simple")
+        # Populate context so the (skipped) self-correction branch would be reachable
+        state.context_gathered = ["some context"]
+
+        call = {"i": 0}
+
+        async def send(*a, **k):
+            call["i"] += 1
+            return _llm_response("Final Answer: original answer")
+
+        gateway = _mk_gateway(send_message_side_effect=send, has_tools=True)
+
+        with (
+            patch(
+                "backend.services.rag.agentic.reasoning.detect_query_language",
+                return_value="ENGLISH",
+            ),
+            patch(
+                "backend.services.rag.agentic.reasoning.calculate_evidence_score", return_value=0.8
+            ),
+            patch("backend.services.rag.agentic.reasoning.is_critical_domain", return_value=False),
+            patch("backend.services.rag.agentic.reasoning.parse_tool_call", return_value=None),
+            patch("backend.services.rag.agentic.reasoning.is_valid_tool_call", return_value=False),
+            patch(
+                "backend.services.rag.agentic.reasoning.post_process_response",
+                new_callable=AsyncMock,
+                return_value="processed",
+            ),
+        ):
+            result_state, _, _, _ = await _run_loop(local_engine, gateway, state)
+
+        # Pipeline ran only once — NO re-run after a (skipped) self-correction
+        assert pipeline.process.await_count == 1
+        # send_message called only once (the original answer) — no rephrase call
+        assert call["i"] == 1
+        # Original (never "corrected") answer stands
+        assert result_state.final_answer == "original answer"
+
+    @pytest.mark.asyncio
     async def test_pipeline_error_falls_back_to_post_process(self, engine):
         """R30: response_pipeline.process raises ValueError → post_process_response applied, no raise escapes."""
         pipeline = MagicMock()

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_response_pipeline_stages.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_response_pipeline_stages.py
@@ -66,11 +66,15 @@ class TestVerificationStage:
 
         assert result["verification_score"] == 1.0
         assert result["verification_status"] == "skipped"
+        assert result["verdict_available"] is True
         mock_svc.verify_response.assert_not_called()
 
     async def test_verification_service_raise_yields_error_status_and_half_score(self):
         """VerificationStage error path: verify_response raises ValueError →
-        score=0.5, status='error'. No unhandled raise escapes.
+        score=0.5, status='error', verdict_available=False (defense-in-depth
+        net — verification_service itself never raises, but if it did, the
+        placeholder score must never be mistaken for a real verdict).
+        No unhandled raise escapes.
         """
         stage = VerificationStage(min_response_length=50)
         data = {
@@ -88,8 +92,78 @@ class TestVerificationStage:
         # Error path
         assert result["verification_score"] == 0.5
         assert result["verification_status"] == "error"
+        assert result["verdict_available"] is False
         # No `verification` dict populated (the happy-path-only field)
         assert "verification" not in result
+
+    async def test_verification_propagates_verdict_unavailable_from_service(self):
+        """2026-07-18 fix: when verification_service returns a real
+        VerificationResult with verdict_available=False (e.g. the verifier
+        LLM returned an empty response), the pipeline must propagate that
+        flag verbatim into `data["verdict_available"]` — this is what
+        reasoning.py reads to skip self-correction.
+        """
+        from backend.services.rag.verification_service import (
+            VerificationResult,
+            VerificationStatus,
+        )
+
+        stage = VerificationStage(min_response_length=50)
+        data = {
+            "response": "a" * 100,
+            "query": "q",
+            "context_chunks": ["some context chunk"],
+        }
+
+        fake_result = VerificationResult(
+            is_valid=True,
+            status=VerificationStatus.PARTIALLY_VERIFIED,
+            score=0.5,
+            reasoning="Verifier LLM returned an empty response. Verdict unavailable.",
+            verdict_available=False,
+        )
+        with patch(
+            "backend.services.rag.agentic.pipeline.verification_service",
+        ) as mock_svc:
+            mock_svc.verify_response = AsyncMock(return_value=fake_result)
+            result = await stage.process(data)
+
+        assert result["verification_score"] == 0.5
+        assert result["verdict_available"] is False
+        assert result["verification"]["verdict_available"] is False
+
+    async def test_verification_propagates_verdict_available_on_normal_response(self):
+        """Innocence: a normal, successfully-parsed verdict propagates
+        verdict_available=True (byte-identical score/status/is_valid
+        behavior, plus the new flag)."""
+        from backend.services.rag.verification_service import (
+            VerificationResult,
+            VerificationStatus,
+        )
+
+        stage = VerificationStage(min_response_length=50)
+        data = {
+            "response": "a" * 100,
+            "query": "q",
+            "context_chunks": ["some context chunk"],
+        }
+
+        fake_result = VerificationResult(
+            is_valid=True,
+            status=VerificationStatus.VERIFIED,
+            score=0.95,
+            reasoning="All claims supported",
+        )
+        with patch(
+            "backend.services.rag.agentic.pipeline.verification_service",
+        ) as mock_svc:
+            mock_svc.verify_response = AsyncMock(return_value=fake_result)
+            result = await stage.process(data)
+
+        assert result["verification_score"] == 0.95
+        assert result["verification_status"] == "verified"
+        assert result["verdict_available"] is True
+        assert result["verification"]["verdict_available"] is True
 
 
 # ============================================================================

--- a/apps/backend-rag/backend/tests/unit/services/search/test_search_service_comprehensive.py
+++ b/apps/backend-rag/backend/tests/unit/services/search/test_search_service_comprehensive.py
@@ -820,6 +820,41 @@ class TestSearchService:
         result = search_service._init_reranker()
         assert result is mock_reranker
 
+    def test_init_reranker_respects_enable_reranker_false(self, search_service):
+        """2026-07-18 honesty fix (reranker illusion, scar family #2): before
+        the fix, _init_reranker() hardcoded enabled=True regardless of
+        settings.enable_reranker, so the prod default (False — model not
+        bundled, saves ~5GB) was silently ignored: CrossEncoderReranker
+        tried to import sentence_transformers on every call, failed, and
+        returned zero scores while claiming to be "initialized". Uses the
+        REAL CrossEncoderReranker (not mocked) — with enabled=False it
+        never touches sentence_transformers, so this stays fast/offline.
+        """
+        if hasattr(search_service, "_reranker"):
+            delattr(search_service, "_reranker")
+
+        with patch("backend.services.search.search_service.settings") as mock_settings:
+            mock_settings.reranker_backend = "cross-encoder"
+            mock_settings.enable_reranker = False
+
+            result = search_service._init_reranker()
+
+        assert result.enabled is False
+
+    def test_init_reranker_respects_enable_reranker_true(self, search_service):
+        """Innocence: settings.enable_reranker=True — behavior unchanged
+        from before the fix (reranker constructed enabled)."""
+        if hasattr(search_service, "_reranker"):
+            delattr(search_service, "_reranker")
+
+        with patch("backend.services.search.search_service.settings") as mock_settings:
+            mock_settings.reranker_backend = "cross-encoder"
+            mock_settings.enable_reranker = True
+
+            result = search_service._init_reranker()
+
+        assert result.enabled is True
+
     @pytest.mark.asyncio
     async def test_search_with_reranking_reranker_enabled(self, search_service):
         """Test search_with_reranking when reranker is enabled"""


### PR DESCRIPTION
## What

Live 60s-timeout repro (server finished at 59996ms) showed the pipeline burning **~23s (38% of wall) on a self-correction round-trip structurally destined to fail**, plus two observability holes. Three atomic commits:

### 1. `fix(rag)`: verifier unavailable-verdict must not trigger self-correction

Gemini can return an EMPTY `text` for the verifier call ("possible safety block or content filter" — observed 3× in ONE request). `json.loads("")` raised (the `"{}"` default only covers a MISSING key, not `""`), fell into the blanket `except` → fake `score=0.5` → `reasoning.py` gates on `verification_score < 0.7` (ignoring `is_valid`!) → REJECT → rephrase LLM call (~16.6s) + re-verify (~6.5s) → **same empty-response bug again** → 0.5 accepted. Net: ~23s wasted, answer unchanged.

Fix: new `VerificationResult.verdict_available` flag — False on empty-response, parse-error (narrowed except), and unexpected-error paths; propagated through `pipeline.py`; `reasoning.py` fires self-correction **only on a real verdict** below threshold. No score faking — the placeholder stays 0.5 for observability; the FLAG gates. Class-audit (W89): the only other `verification_score` consumer with a threshold is a cosmetic label in `orchestrator_response.py:130` ("passed"/"unchecked" — correctly says "unchecked" for unavailable verdicts).

### 2. `feat(observability)`: latency telemetry on `llm_gateway.send_message`

The two biggest single LLM calls (final-answer synthesis 15.8s, rephrase 16.6s in the repro) had ZERO latency logging. Now logs `latency_ms` + provider/model/tier per call (mirrors `genai_client`'s "LLM call" pattern, uses existing `emit_llm_metric`).

### 3. `fix(search)`: honest reranker state — respect `enable_reranker=False`

`_init_reranker()` hardcoded `CrossEncoderReranker(enabled=True)` while the config says False (model intentionally not bundled, ~5GB): every call tried importing `sentence_transformers`, failed, returned zero scores — a scar-family-#2 silent no-op claiming to rerank. Now respects the setting so `search_with_reranking` short-circuits. (The A/B framework's `with_rerank` label is a separate cosmetic surface — noted, not touched.)

## Also shipped ops-side by the orchestrator session (already live)

Missing Qdrant keyword indexes on `status_vigensi` created for `legal_unified`, `kbli_2025_final`, `immigration_circulars`, `balizero_news` (+nested) — kills the per-search 400+fallback round-trip on every federated query.

## Tests

171 passed across the 6 touched suites (verifier guilt/innocence: empty→no rephrase call, real-0.5→rephrase preserved; telemetry caplog; reranker both settings) + 65 collateral + import chain — re-run independently by the orchestrator session (generator≠grader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
