### PR TITLE
feat(intake): --reroute-drive-folder — route-only resume of the Drive 0-candidate backlog

### DIFF
--- a/.claude/skills/intake/SKILL.md
+++ b/.claude/skills/intake/SKILL.md
@@ -31,12 +31,13 @@ SELECT-only for inspection). The MCP `postgres-nuzantara` points at PROD and is 
 intake — always use the local dev DB for intake work.
 
 Core tables:
-| Table | Key columns |
-|---|---|
+
+| Table                             | Key columns                                                                                                                                                                                                                      |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `document_routing_proposal` (`p`) | `id`, `queue_id`, `status` (**review_pending** / review_claimed / routed / **auto_routed**), `entity_resolution` (JSON: `candidates[]{table,id}`, `doc_type`, `decision`), `routing` (JSON: `fields`, `decision`), `commit_gate` |
-| `intake_queue` (`q`) | `id`, `stage_output` (JSON: `classify.ocr_text_per_page[]`, `extract.fields`, `ocr.pages[]`), `source`, `source_ref`, `blob_hash`, `pipeline_version` |
-| `intake_commit_audit` | `proposal_id`, `client_id`, `outcome` (dry_run/blocked/committed/failed/rolled_back), `committed_by`, `dry_run` (bool) — every decision recorded, reversible |
-| `clients` | `id`, `full_name`, `phone_normalized`, `passport_number`, `kitas_number`, `nationality`, `deleted_at` (soft-delete) |
+| `intake_queue` (`q`)              | `id`, `stage_output` (JSON: `classify.ocr_text_per_page[]`, `extract.fields`, `ocr.pages[]`), `source`, `source_ref`, `blob_hash`, `pipeline_version`                                                                            |
+| `intake_commit_audit`             | `proposal_id`, `client_id`, `outcome` (dry_run/blocked/committed/failed/rolled_back), `committed_by`, `dry_run` (bool) — every decision recorded, reversible                                                                     |
+| `clients`                         | `id`, `full_name`, `phone_normalized`, `passport_number`, `kitas_number`, `nationality`, `deleted_at` (soft-delete)                                                                                                              |
 
 **Extracted fields shape:** `routing.fields` (fallback `stage_output.extract.fields`); each value is
 `{value, confidence, source_page}` or a scalar. Strong-id keys: `passport_no`, `kitas_no`.
@@ -133,6 +134,18 @@ scans, report `research/operations/2026-07-18-intake-station1-2-rescue-recall.md
 ---
 
 ## 5. LIVE STATE (update on every material change)
+
+- **2026-07-18 evening — BACKLOG REROUTED through the m227 fix (EXECUTED, measured):**
+  `scripts/intake_reprocess_backlog.py --reroute-drive-folder --apply` resumed **24,256** Drive
+  0-candidate rows at route-only (stage_output PRESERVED — the blobs are retention-evicted, the saved
+  fields are the only copy; the generic `--reprocess` would have WIPED them, locked by test). Worker
+  restarted first (launchagent `com.nuzantara.intake-worker` runs from `~/nuzantara-deploy`, had
+  pre-merge code in memory). Drained in ~5 min. **Outcome: 1,588 docs (6.5%) gained ≥1 candidate —
+  1,285 LINK_CANDIDATE + 300 AMBIGUOUS** (676 LINK + 172 AMBIG live in review_pending; 588+128 in
+  quarantine via the LEVA-1 noise filter, consultable). Methods: folder_name 1,665, fuzzy_full_name
+  195, strong-id 3 (2 passport + 1 kitas — enricher backfill from prior attaches already compounding).
+  **never-auto held: 0 auto_routed.** Side-win: 14,859 noise NO_MATCH moved review_pending→quarantine
+  (review feed −~15k). Pipeline tag: `pipeline_version='v2.2-m227-folder'`.
 
 - **2026-07-18 (m227 FOLDER FIX — the structural lever for the 24k drive backlog):** `routing.py::
 _match_folder_name` was **root-segment-only** (`source_path.split('/')[0]`) — correct for Dropbox

--- a/apps/backend-rag/backend/tests/scripts/test_intake_reprocess_backlog.py
+++ b/apps/backend-rag/backend/tests/scripts/test_intake_reprocess_backlog.py
@@ -1050,3 +1050,41 @@ def test_review_backlog_report_sql_is_latest_aggregate_and_pii_safe() -> None:
     assert "ocr_chars >= $1" in sql
     assert "sender phone%" in sql
     assert "SELECT 'automation_bucket'" in sql
+
+
+def test_reroute_drive_folder_sql_targets_drive_zero_candidate_bucket() -> None:
+    irb = _load()
+    sql = irb.REROUTE_DRIVE_FOLDER_SELECT_SQL
+    assert "SELECT DISTINCT ON (q.id)" in sql
+    assert "q.source = 'drive'" in sql
+    assert "q.source_path IS NOT NULL" in sql
+    assert "p.status = 'review_pending'" in sql
+    assert "'NO_MATCH'" in sql
+    assert "jsonb_array_length" in sql
+    assert "LIMIT $1" in sql
+
+
+def test_reroute_drive_folder_reset_resumes_route_and_preserves_stage_output() -> None:
+    # The load-bearing invariant: 97.7% of these rows' blobs are retention-
+    # evicted, so the saved stage_output (OCR/extract fields) is the ONLY copy.
+    # A reset that wiped it (like REPROCESS_RESET_SQL does) would be
+    # irreversible data loss + a guaranteed pipeline failure at preprocess.
+    irb = _load()
+    sql = irb.REROUTE_DRIVE_FOLDER_RESET_SQL
+    assert "stage_output" not in sql  # NEVER wiped — route-only resume
+    assert "status           = 'validated'" in sql
+    assert "stage            = 'validate'" in sql
+    assert "pipeline_version = $2" in sql
+    assert "lease_owner      = NULL" in sql
+    assert "lease_expires_at = NULL" in sql
+    assert "attempts         = 0" in sql
+    # guilt check: the FULL-rerun reset (for contrast) DOES wipe stage_output.
+    assert "stage_output" in irb.REPROCESS_RESET_SQL
+
+
+def test_reroute_drive_folder_supersede_only_review_pending() -> None:
+    irb = _load()
+    sql = irb.REROUTE_DRIVE_FOLDER_SUPERSEDE_SQL
+    assert "SET status = 'superseded'" in sql
+    assert "status = 'review_pending'" in sql
+    assert "queue_id = ANY($1::bigint[])" in sql

--- a/scripts/intake_reprocess_backlog.py
+++ b/scripts/intake_reprocess_backlog.py
@@ -242,6 +242,54 @@ UPDATE intake_queue
  WHERE id = ANY($1::bigint[])
 """
 
+# --reroute-drive-folder: Drive 0-candidate rows re-routed through the fixed
+# m227 multi-segment folder matcher (PR #2664). ROUTE-ONLY resume: unlike
+# REPROCESS_RESET_SQL this MUST NOT wipe stage_output — 97.7% of these rows'
+# blobs are retention-evicted, so the saved OCR/extract fields are the ONLY
+# copy; a full re-run would fail at preprocess AND destroy them. Resuming at
+# status='validated' makes the worker run exactly one stage (route → fase4
+# resolve_entity with source_path) against the preserved fields.
+REROUTE_DRIVE_FOLDER_SELECT_SQL = """
+WITH latest AS (
+    SELECT DISTINCT ON (q.id)
+           p.id AS proposal_id, q.id AS queue_id
+      FROM intake_queue q
+      JOIN document_routing_proposal p ON p.queue_id = q.id
+     WHERE q.source = 'drive'
+       AND q.source_path IS NOT NULL
+       AND p.status = 'review_pending'
+       AND (p.entity_resolution->>'decision') = 'NO_MATCH'
+       AND jsonb_array_length(
+             COALESCE(p.entity_resolution->'candidates', '[]'::jsonb)) = 0
+     ORDER BY q.id, p.id DESC
+)
+SELECT proposal_id, queue_id
+  FROM latest
+ ORDER BY queue_id
+ LIMIT $1
+"""
+
+REROUTE_DRIVE_FOLDER_SUPERSEDE_SQL = """
+UPDATE document_routing_proposal
+   SET status = 'superseded'
+ WHERE queue_id = ANY($1::bigint[])
+   AND status = 'review_pending'
+"""
+
+REROUTE_DRIVE_FOLDER_RESET_SQL = """
+UPDATE intake_queue
+   SET status           = 'validated',
+       stage            = 'validate',
+       lease_owner      = NULL,
+       lease_expires_at = NULL,
+       attempts         = 0,
+       next_visible_at  = now(),
+       last_error       = NULL,
+       pipeline_version = $2,
+       updated_at       = now()
+ WHERE id = ANY($1::bigint[])
+"""
+
 # Same v2 reset contract, but for targeted retry lanes that must be observable
 # immediately in production tests. The worker orders pending WhatsApp jobs by
 # next_visible_at, so resetting historical rows to now() parks them behind newer
@@ -1896,6 +1944,51 @@ async def run_reprocess(pool: asyncpg.Pool, pipeline_version: str, apply: bool) 
     return counts
 
 
+async def run_reroute_drive_folder(
+    pool: asyncpg.Pool, pipeline_version: str, limit: int, apply: bool
+) -> dict[str, int]:
+    """Re-route Drive 0-candidate proposals through the fixed m227 folder matcher.
+
+    Route-only resume (status='validated', stage_output PRESERVED — the saved
+    OCR/extract fields are the only copy left after blob retention). Supersedes
+    the stale NO_MATCH proposals and lets the live worker re-run fase-4
+    resolve_entity with source_path, so client folders at any depth (PR #2664)
+    produce LINK_CANDIDATE/AMBIGUOUS proposals. Never attaches — candidates
+    feed the normal review/panel tier.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(REROUTE_DRIVE_FOLDER_SELECT_SQL, limit)
+        queue_ids = sorted({r["queue_id"] for r in rows})
+
+        counts = {"proposals": len(rows), "queue_rows": len(queue_ids)}
+        if not apply:
+            logger.info(
+                "[reroute-drive-folder][DRY-RUN] would supersede %d proposals and "
+                "resume %d queue rows at route (pipeline_version=%s, limit=%d) "
+                "(pass --apply to execute)",
+                counts["proposals"], counts["queue_rows"], pipeline_version, limit,
+            )
+            return counts
+
+        async with conn.transaction():
+            superseded = await conn.execute(
+                REROUTE_DRIVE_FOLDER_SUPERSEDE_SQL, queue_ids
+            )
+            reset = await conn.execute(
+                REROUTE_DRIVE_FOLDER_RESET_SQL, queue_ids, pipeline_version
+            )
+        counts["superseded"] = int(superseded.split()[-1]) if superseded else 0
+        counts["reset"] = int(reset.split()[-1]) if reset else 0
+
+    logger.info(
+        "[reroute-drive-folder] superseded=%d proposals, resumed=%d queue rows at "
+        "route (pipeline_version=%s) — the intake worker re-routes them with the "
+        "m227 multi-segment folder matcher",
+        counts.get("superseded", 0), counts.get("reset", 0), pipeline_version,
+    )
+    return counts
+
+
 async def run_revive_stub(
     pool: asyncpg.Pool, pipeline_version: str, include_groups: bool, apply: bool
 ) -> dict[str, int]:
@@ -3013,6 +3106,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="supersede unknown/NO_MATCH review_pending proposals + reset queue rows",
     )
     p.add_argument(
+        "--reroute-drive-folder",
+        action="store_true",
+        help=(
+            "route-only resume of Drive 0-candidate review_pending rows through "
+            "the fixed m227 folder matcher (stage_output preserved, never wiped)"
+        ),
+    )
+    p.add_argument(
+        "--reroute-limit",
+        type=int,
+        default=30000,
+        help="max Drive 0-candidate rows selected per --reroute-drive-folder run",
+    )
+    p.add_argument(
+        "--reroute-pipeline-version",
+        default="v2.2-m227-folder",
+        help="pipeline_version stamped on rerouted rows (fresh routing_key)",
+    )
+    p.add_argument(
         "--backfill",
         action="store_true",
         help="enqueue historical wa-mirror media skipped by the watermark seed",
@@ -3279,6 +3391,7 @@ async def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     needs_db = (
         args.reprocess
+        or args.reroute_drive_folder
         or args.backfill
         or args.scrub_group_phone
         or args.backfill_source_context
@@ -3297,7 +3410,8 @@ async def main(argv: list[str] | None = None) -> int:
     )
     if not (needs_db or args.delivery_readiness_report):
         logger.error(
-            "nothing to do: pass --backfill, --reprocess, --scrub-group-phone, "
+            "nothing to do: pass --backfill, --reprocess, --reroute-drive-folder, "
+            "--scrub-group-phone, "
             "--backfill-source-context, --revive-stub, "
             "--retry-empty-pdf-ocr, --retry-unschematised-supported, "
             "--retry-typed-missing-fields, --quality-sample, and/or "
@@ -3331,6 +3445,13 @@ async def main(argv: list[str] | None = None) -> int:
             await run_backfill_source_context(pool, args.apply)
         if args.reprocess:
             await run_reprocess(pool, args.pipeline_version, args.apply)
+        if args.reroute_drive_folder:
+            await run_reroute_drive_folder(
+                pool,
+                args.reroute_pipeline_version,
+                max(args.reroute_limit, 1),
+                args.apply,
+            )
         if args.autocatalog_direct_unknown_text:
             await run_autocatalog_direct_unknown_text(
                 pool,


### PR DESCRIPTION
## What
New mode in `scripts/intake_reprocess_backlog.py` that materialises the m227 multi-segment folder fix (#2664) on the existing backlog: supersedes stale NO_MATCH `review_pending` proposals for Drive queue rows (source_path present, 0 candidates) and resumes the rows at `status='validated'`, so the live worker re-runs **only the route stage** (fase-4 `resolve_entity` with `source_path`) against the **preserved** `stage_output`.

**Why not `--reprocess`:** its reset wipes `stage_output` (`'{}'::jsonb`) and restarts from preprocess — but 97.7% of these rows' blobs are retention-evicted (TTL=7d), so the saved OCR/extract fields are the ONLY copy: a full re-run would destroy them and fail at preprocess. The new reset never touches `stage_output` (locked by test, with the guilt-check that `REPROCESS_RESET_SQL` does wipe it).

## Already executed on local nuzantara_dev (measured)
Full run 2026-07-18 evening, `pipeline_version='v2.2-m227-folder'`, worker restarted first (had pre-merge code in memory):
- **24,256 rows resumed at route-only, drained in ~5 min**
- **1,588 docs (6.5%) gained ≥1 candidate — 1,285 LINK_CANDIDATE + 300 AMBIGUOUS** (from 0)
- Methods: `folder_name` 1,665 · `fuzzy_full_name` 195 · strong-id 3 (enricher backfill compounding)
- **never-auto held: 0 `auto_routed`**
- Side-win: 14,859 noise NO_MATCH moved `review_pending` → `quarantine` (review feed −15k)

## Tests
+3 SQL-contract tests (drive/0-candidate scoping; `stage_output` NEVER in the reset SQL; supersede scoped to `review_pending`). File suite 71 passed; full backend suite at pre-push: **17,689 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)