### PR TITLE
fix(kbli): lot runner — retro-demote certified verdicts on failed D2 self-confirmation

### DIFF
--- a/infra/workflows/kbli-batch-a-lot.js
+++ b/infra/workflows/kbli-batch-a-lot.js
@@ -677,11 +677,10 @@ async function adjudicateCode(code) {
     Boolean(d5 && d5.abstain && d5.abstain.needed);
   // an out-of-scope-facet claim from EITHER seat overrides the diff outright — "the visible facts
   // agree" is a weaker claim than "this needs evidence we don't have this pass" (plan §8 A-1).
-  const verdict = abstainNeeded ? "abstained" : diff.verdict;
-  const quarantined = verdict === "quarantined";
+  const preD2Verdict = abstainNeeded ? "abstained" : diff.verdict;
 
   let d2 = null;
-  if (verdict === "certified" && d1 && d1.licensing_inherits === true) {
+  if (preD2Verdict === "certified" && d1 && d1.licensing_inherits === true) {
     d2 = await agent(d2Prompt(code), {
       label: `D2:${code}`,
       phase: "Adjudicate",
@@ -689,6 +688,33 @@ async function adjudicateCode(code) {
       model: "sonnet",
     });
   }
+
+  // D2 SELF-CONFIRM RETRO-DEMOTE (post-Lot-A-L1 close-out fix, 2026-07-18): a certified verdict
+  // whose D2 extraction FAILED its own self-confirming guard (self_confirmed.code_appears_in_row
+  // !== true, red-team F8 locator-poisoning check) or came back with EMPTY per_skala_rows must be
+  // impossible by construction — "certified" cannot mean "D1/D5 agreed AND we never actually
+  // confirmed the row". This is exactly what happened to code 38222 in Lot A-L1: D1 and D5
+  // independently agreed clean (preD2Verdict="certified"), but the D2 evidence page only carried
+  // the PARENT code 38220, not 38222 itself — self_confirmed.code_appears_in_row=false — and the
+  // runner still emitted "certified" because nothing downstream of D2 ever looked at its own
+  // self-confirmation result. The conductor caught it at D6 review; this closes the runner gap so
+  // the same class of miss can't reach "certified" again. Category=phantom_source_pointer (closed
+  // registry, plan §5 m3): "the cited row/source doesn't actually confirm the code" is precisely
+  // what a failed self-confirmation means.
+  const d2SelfConfirmFailed =
+    d2 !== null &&
+    (!d2.self_confirmed ||
+      d2.self_confirmed.code_appears_in_row !== true ||
+      !Array.isArray(d2.per_skala_rows) ||
+      d2.per_skala_rows.length === 0);
+
+  const verdict = d2SelfConfirmFailed ? "quarantined" : preD2Verdict;
+  const quarantined = verdict === "quarantined";
+  const category = quarantined
+    ? d2SelfConfirmFailed
+      ? "phantom_source_pointer"
+      : diff.category
+    : null;
 
   return {
     code,
@@ -700,9 +726,10 @@ async function adjudicateCode(code) {
     quarantined,
     concordant: diff.concordant,
     verdict,
-    category: verdict === "quarantined" ? diff.category : null,
+    category,
     divergent: diff.divergent,
     category_mismatch: diff.category_mismatch,
+    d2_self_confirm_failed: d2SelfConfirmFailed,
     seatInvocations: d2 ? 3 : 2,
   };
 }

--- a/scripts/kbli_filiera/tests/test_lot_runner_contract.py
+++ b/scripts/kbli_filiera/tests/test_lot_runner_contract.py
@@ -24,6 +24,10 @@ pilot-report criterion-#6 fix:
    2026-07-18 over-match (requiring innocence controls to also be in-scope) blocked a real lot
    dispatch (run wf_3477eb84-e75, "REFUSED: 2 code(s) not in-scope: 65121, 85202" — both
    legitimate controls) — this is the regression guard for that exact class of bug.
+6. A certified verdict whose D2 extraction FAILED self-confirmation (code_appears_in_row !== true)
+   or came back with an empty per_skala_rows list MUST retro-demote to quarantined — the Lot A-L1
+   close-out regression guard for code 38222 (D1/D5 agreed clean, but D2's evidence page only
+   carried the parent code 38220; the runner still emitted certified).
 
 The calibration artifact (data/kbli-filiera/batch-reports/batchA-calibration.json) ships on a
 separate PR (agent/air-m5/kbli/batcha-calibration) — test 1 SKIPS (not fails) if that file is not
@@ -252,3 +256,43 @@ def test_innocence_misused_as_innocence_refusal_branch_exists(js_source: str) ->
         "misusedAsInnocence is computed but never gates the lot — the guard is dead code"
     )
     assert "cannot double as an innocence control" in js_source
+
+
+# ---------------------------------------------------------------------------
+# 6. D2 self-confirm failure retro-demotes a certified verdict (Lot A-L1 close-out, code 38222)
+# ---------------------------------------------------------------------------
+
+def test_guilt_d2_self_confirm_failure_retro_demotes_certified(js_source: str) -> None:
+    """GUILT: a certified verdict whose D2 extraction failed self-confirmation
+    (code_appears_in_row !== true) or came back with empty per_skala_rows MUST retro-demote to
+    quarantined — the regression guard for code 38222 in Lot A-L1 (D1/D5 agreed clean, D2's
+    evidence page only had the parent code 38220, but the runner still emitted certified)."""
+    assert re.search(r"d2SelfConfirmFailed", js_source), (
+        "no d2SelfConfirmFailed guard found — a failed D2 self-confirmation could still reach certified"
+    )
+    assert re.search(r"code_appears_in_row\s*!==\s*true", js_source), (
+        "d2SelfConfirmFailed does not check self_confirmed.code_appears_in_row !== true"
+    )
+    assert re.search(r"per_skala_rows\.length\s*===\s*0", js_source), (
+        "d2SelfConfirmFailed does not check for an empty per_skala_rows extraction"
+    )
+    assert re.search(
+        r'verdict\s*=\s*d2SelfConfirmFailed\s*\?\s*"quarantined"\s*:\s*preD2Verdict',
+        js_source,
+    ), "the final verdict is not gated on d2SelfConfirmFailed — retro-demote is not wired"
+    assert '"phantom_source_pointer"' in js_source
+
+
+def test_innocence_successful_d2_keeps_certified_verdict(js_source: str) -> None:
+    """INNOCENCE: a SUCCESSFUL D2 extraction (self-confirmed, non-empty rows) must NOT be
+    downgraded, and a code that never triggers D2 at all must be unaffected — proves the
+    retro-demote fires only on a genuine D2 failure, never on every D2 call or on codes where D2
+    never ran (d2 stays null)."""
+    assert re.search(
+        r'const verdict = d2SelfConfirmFailed \? "quarantined" : preD2Verdict;',
+        js_source,
+    ), "verdict computation does not fall back to preD2Verdict when D2 self-confirms successfully"
+    assert re.search(r"d2SelfConfirmFailed\s*=\s*\n?\s*d2\s*!==\s*null\s*&&", js_source), (
+        "d2SelfConfirmFailed is not gated on d2 !== null — a code that never ran D2 could be "
+        "wrongly demoted"
+    )


### PR DESCRIPTION
## Summary
- A certified verdict in `infra/workflows/kbli-batch-a-lot.js` whose D2 self-confirming extraction FAILED (`self_confirmed.code_appears_in_row !== true`) or returned an empty `per_skala_rows` list now retro-demotes to `quarantined`/`phantom_source_pointer` before the result is ever returned.
- Found live on code **38222** during the Lot-1 gate: D1 and D5 independently agreed clean, but D2's evidence page only carried the **parent code 38220**, not 38222 itself. The conductor caught it at D6 review; nothing downstream of D2 had checked its own self-confirmation result until now — this makes that class of miss impossible by construction.
- Guilt + innocence tests added to `scripts/kbli_filiera/tests/test_lot_runner_contract.py` (renumbered to section 6 — main had grown a section 5 for the membership-gate guard in the interim).

## Provenance
Salvaged from closed PR #2723 (branch `agent/air-m5/kbli/lot1-postfix`, commit `a715f20e9e`), which was superseded by the deeper twin conductor gate in #2721. This is the one piece of that branch that is orthogonal, still-valid hardening — everything else on that branch (calibration literal changes, the plan-doc §8 A-3 report, PENDING-ARMS entry) is deliberately NOT carried over. The live `CALIBRATION` block (floors `0.75`/`0.20`/`0.85`) is byte-identical to current main.

## Test plan
- [x] `git diff --stat` shows exactly 2 files changed (`infra/workflows/kbli-batch-a-lot.js`, `scripts/kbli_filiera/tests/test_lot_runner_contract.py`)
- [x] `grep d2SelfConfirmFailed infra/workflows/kbli-batch-a-lot.js` — present
- [x] `grep "m1_blind_concordance_floor: 0.75" infra/workflows/kbli-batch-a-lot.js` — unchanged
- [x] `python3 -m pytest scripts/kbli_filiera/tests/ -q` — 175 passed
- [x] New guilt/innocence tests pass individually (`test_guilt_d2_self_confirm_failure_retro_demotes_certified`, `test_innocence_successful_d2_keeps_certified_verdict`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)