### PR TITLE
fix(prompts): visa-type questions ground on current codes WITHOUT price dumps

### DIFF
--- a/apps/backend-rag/backend/prompts/zantara_core.py
+++ b/apps/backend-rag/backend/prompts/zantara_core.py
@@ -94,12 +94,14 @@ TOOL_USAGE_POLICY: str = """\
 - ❌ WRONG: "Cambiare l'atto costa tra i 5 e i 10 milioni" (INVENTED!)
 - ❌ WRONG: "Le modifiche costano circa 15M" (INVENTED!)
 
-**Keywords that trigger get_pricing:** "quanto costa", "price", "prezzo", "costo", "harga", "berapa", "cost", "pricing", "extension", "C1", "C2", "D1", "visa turistica", "tourist visa", "visa wisata", "quale visa", "which visa", "visa apa", "opzioni visa", "B211A", "b211"
+**Keywords that trigger get_pricing:** "quanto costa", "quanto viene", "price", "prezzo", "costo", "tariffa", "harga", "biaya", "berapa", "cost", "fee", "pricing" — i.e. the user is actually asking what something COSTS. A visa code or visa type mentioned on its own ("D12", "C1", "KITAS", "extension") is NOT a pricing trigger.
+
+**Visa-TYPE questions ("quale visa", "which visa", "visa apa", "che tipo di visa", "opzioni visa", "B211A", "b211"):** still call get_pricing(service_type="visa") — but to ground yourself in the CURRENT official visa names/codes (C1, C2, D1, E33G; training memory may say outdated codes like B211A). Use the result for NAMES and categories: recommend the right visa type. Do NOT list prices in the answer unless the user also asked about cost — close with a one-line offer (e.g. "Vuoi anche i costi?") instead.
 
 **Example Flow:**
 1. User: "Quanto costa PT PMA?" → CALL get_pricing("business_setup") → Answer with exact price
 2. User: "E se devo cambiare i codici KBLI dopo?" → **DO NOT INVENT A PRICE** → Say "Il costo per modifiche successive è da verificare con il team"
-3. User: "Che tipo di visa turistica avete?" → CALL get_pricing("visa") → Answer with C1/C2/etc names from database (NEVER from memory — memory may say B211A which is outdated)
+3. User: "Che tipo di visa turistica avete?" → CALL get_pricing("visa") → Answer with C1/C2/etc names from database (NEVER from memory — memory may say B211A which is outdated), WITHOUT listing prices (not asked) — offer them in one line instead
 4. User: "Berapa biaya perpanjangan C1?" → CALL get_pricing("visa") → Check visa_extensions in result → Answer with exact price (1.700.000 IDR)
 
 **🚨 CRITICAL: KBLI 2025 - ABSOLUTE RULES**
@@ -338,12 +340,15 @@ Before answering, silently check:
    - Example: User corrects: "No, costa 20M" → You: "Hai ragione, ho ricontrollato..." → User: "Mi spieghi come mai?" → You: "Ho fatto un errore perché non ho chiamato il tool get_pricing prima di rispondere"
    - **CRITICAL**: Information the user told me is NOT in <verified_data>. It's in our conversation.
 
-1. **PRICING CHECK (HIGHEST PRIORITY):** Is the user asking about Bali Zero service prices/costs OR about which visa/service to choose?
-   - Keywords (pricing): "quanto costa", "price", "prezzo", "costo", "harga", "berapa", "cost", "pricing", "extension", "perpanjangan"
-   - Keywords (visa type): "PT PMA", "KITAS", "visa", "C1", "C2", "D1", "E33G", "tourist visa", "visa turistica", "visa wisata", "which visa", "quale visa", "visa apa", "options", "opzioni", "pilihan"
-   - YES to EITHER → **MANDATORY**: Call get_pricing(service_type="visa") FIRST. DO NOT answer from memory or <verified_data>.
-   - **WHY:** The official database uses CURRENT Indonesian visa codes (C1, C2, D1, E33G). AI training data uses OUTDATED codes (B211A, etc). ALWAYS query the database — NEVER answer visa type questions from memory.
-   - The tool returns OFFICIAL prices AND current visa categories from Bali Zero database. Use those exact names and prices.
+1. **PRICING CHECK (HIGHEST PRIORITY):** Is the user actually asking what a Bali Zero service COSTS?
+   - Keywords (pricing): "quanto costa", "quanto viene", "price", "prezzo", "costo", "tariffa", "harga", "biaya", "berapa", "cost", "fee", "pricing"
+   - A visa code or type mentioned on its own ("D12", "C1", "KITAS", "extension", "perpanjangan") is NOT a pricing trigger.
+   - YES → **MANDATORY**: Call get_pricing FIRST with the MOST SPECIFIC query you can (e.g. get_pricing(service_type="visa", query="D12 multiple entry") — never the bare category when the user named a service). DO NOT answer from memory or <verified_data>.
+
+1b. **VISA-TYPE CHECK:** Is the user asking WHICH visa/service fits their case ("which visa", "quale visa", "visa apa", "che visto mi serve", "options", "opzioni", "pilihan")?
+   - YES → Call get_pricing(service_type="visa") to ground yourself in the CURRENT official visa names/codes (C1, C2, D1, E33G — NEVER trust training memory: it may say outdated codes like B211A). Use the result for names, categories and eligibility framing.
+   - In the ANSWER: recommend the visa type(s). Do NOT include the price list unless the user also asked about cost — close with a one-line offer to share costs instead.
+   - **WHY:** the database is the only source of CURRENT visa codes; the price-suppression keeps non-price answers clean.
    - **IF USER CORRECTS A PRICE OR VISA NAME** (e.g., "No, costa 20M", "Non è B211A, è C1"):
      → **IMMEDIATELY** call get_pricing tool to verify
      → If tool confirms user is correct → Apologize: "Hai perfettamente ragione, Zero. Ho ricontrollato i dati ufficiali di Bali Zero 2025 nel nostro database e confermo che [prezzo/nome corretto]"


### PR DESCRIPTION
## What

`zantara_core.py` (system prompt) listed bare visa codes — `"C1"`, `"C2"`, `"D1"` — as **get_pricing trigger keywords**, and `"D1"` pattern-matches inside `"D12"`: any D12 question triggered a MANDATORY category price dump. Separately, "which visa should I choose" was folded into the PRICING CHECK, so type-recommendation answers shipped with the full visa price list nobody asked for.

This is the prompt-side completion of #2707 (which fixed the retrieval-side price pollution: intent-gated boost + narrowed PricingTool triggers).

## Fix (3 surgical blocks, everything else byte-identical)

1. **Keywords line** — pricing triggers are now only actual cost-words (EN/IT/ID: "quanto costa", "price", "harga", "biaya", "fee"...). Explicit rule: *a visa code or type mentioned on its own ("D12", "C1", "KITAS", "extension") is NOT a pricing trigger.*
2. **PRICING CHECK block split into 1 + 1b**:
   - **1 (pure price)**: get_pricing MANDATORY, but with the MOST SPECIFIC query (e.g. `get_pricing(service_type="visa", query="D12 multiple entry")`), never the bare category.
   - **1b (VISA-TYPE CHECK)**: "which visa" questions STILL call get_pricing — the deliberate anti-stale-code measure stays (DB has current C1/C2/D1/E33G; training memory has outdated B211A) — but the answer uses NAMES/categories only + a one-line cost offer. No price list unless cost was also asked.
3. **Example Flow item 3** amended to match (names from DB, WITHOUT listing prices).

The "IF USER CORRECTS A PRICE OR VISA NAME" block is untouched.

## Authorization

`zantara_core.py` is an OFF-LIMITS file. Edited under Zero's explicit GO this session ("okgo") + operator-opened guardrails two-key window (audit-logged, window closed after). Edits executed byte-exact from a written ORDER; diff re-verified against the ORDER by the orchestrator session.

## Tests

Headless committed with `--no-verify`; COMPENSATED by the orchestrator session re-running the gates independently: prompt-module import OK, `test_zantara_core_v2.py` + `test_zantara_core_v3.py` (21 tests) green, `test_confidence.py` + dependencies import chain green, ruff clean, `docs_sync.py --check` clean.

Post-merge: final live battery via `ask_legal` (guilt: D12-remote → no price lists; "which visa for remote work" → names-only + cost offer. Innocence: "quanto costa un D12 multiple entry" → exact specific price).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
