### PR TITLE
fix(infra): worktree-GC reaps unpushed-branch dirs (W88 gate) + live-cwd guard + detached-HEAD preservation

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -168,7 +168,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 ### LaunchAgents — copertura documentale
 
 <!-- DOCSYNC:AUTOMATION_COVERAGE_START -->
-`123 plist tracked in infra/launchagents/ · 93 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (76% coverage)`
+`124 plist tracked in infra/launchagents/ · 94 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (76% coverage)`
 <!-- DOCSYNC:AUTOMATION_COVERAGE_END -->
 
 Runbook operativi: indice auto-generato in [docs/runbooks/README.md](docs/runbooks/README.md).

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: 25af0bde5e40fa20e626d78169f64e940301becabd6729e6a7936e2985c8468c
+checksum: cf2a710add0066991f19e42041d7a2186f60a4e0c4288db9ff4979312b3ae763
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -1912,6 +1912,27 @@ organs:
   bridge_source:
     type: state_file
     path: ~/.organism/last_seen/pro.wr2_worktree_gc.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.worktree_gc_universal
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 129600
+  owner_module: scripts/worktree_gc_universal.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.worktree-gc-universal.daily
+  severity_on_silence: warning
+  notes: Reaps stale git worktrees across the whole fleet (not just WR2/broker lanes)
+    to free disk. Unpushed-commit gate no longer blocks removal (W88 cure, dir-only
+    reclaim, branch ref preserved) — registered manually as part of the G1/G2 gene
+    retrofit 2026-07-18, not organ_birth.py-generated.
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/com.nuzantara.worktree-gc-universal.daily.json
     timestamp_field: ts
     status_field: status
 - id: mini.fleet_watch

--- a/infra/launchagents/com.nuzantara.worktree-gc-universal.daily.plist
+++ b/infra/launchagents/com.nuzantara.worktree-gc-universal.daily.plist
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Universal worktree garbage collector — daily 08:30 WITA
+Covers ALL git worktrees (not just WR2/broker lanes). 3-LLM panel 2026-05-29.
+Script: scripts/worktree_gc_universal.py (merged PR #925)
+
+ENFORCING since 2026-05-30: the apply flag was added after ~50h dry-run
+observation (panel recommended 48h). Dry-run logs 2026-05-29→30 showed
+correct decisions (KEEP on unpushed commits, quarantine-before-remove on
+dirty). Per W62 RESOLVED. To revert to report-only: remove the apply
+argument line in ProgramArguments below.
+
+Kill switch (without removing plist):
+    set WORKTREE_GC_ENABLED=false in EnvironmentVariables (already true here)
+
+TRACKED 2026-07-18 (cicatrix #1 HOME-fork cure): this plist previously lived
+ONLY on Pro's live LaunchAgents dir, untracked in the repo — closing the
+"no plist references worktree_gc_universal.py" gap. ProgramArguments,
+schedule, and paths below are byte-identical to Pro's live copy pulled
+2026-07-18 (same day the daily cron's "reaps 0 for days" bug — the
+unpushed-commit hard-KEEP gate, W88-inflated — was cured in the script);
+this comment block only was reworded to drop a literal double-hyphen that
+was silently-invalid XML inside a comment (macOS `plutil -lint` is lenient
+about it, Python's expat parser used by `scripts/lint_plist_keepalive.py`
+is not — same class of bug the "day-1" fix on branch-cleanup.weekly.plist
+already corrected once). This file is HOME-fork-scoped by nature (paths are
+per-machine under /Users/nuzantara/); install/update it on each machine's
+own ~/Library/LaunchAgents/ via `scripts/lint_home_fork.py` declared-pairs
+discipline, do not assume this tracked copy is symlinked live.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.nuzantara.worktree-gc-universal.daily</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>/opt/homebrew/bin/python3</string>
+		<string>/Users/nuzantara/nuzantara/scripts/worktree_gc_universal.py</string>
+		<string>--apply</string>
+	</array>
+
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>0</integer>
+		<key>Minute</key>
+		<integer>30</integer>
+	</dict>
+	<!-- 00:30 UTC = 08:30 WITA (30min after WR2 GC at 08:00) -->
+
+	<key>WorkingDirectory</key>
+	<string>/Users/nuzantara/nuzantara</string>
+
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>WORKTREE_GC_ENABLED</key>
+		<string>true</string>
+		<key>WORKTREE_GC_MAX_AGE_HOURS</key>
+		<string>24</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/bin:/bin</string>
+	</dict>
+
+	<key>StandardOutPath</key>
+	<string>/Users/nuzantara/logs/worktree-gc-universal.log</string>
+
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/worktree-gc-universal.error.log</string>
+
+	<key>RunAtLoad</key>
+	<false/>
+
+	<key>KeepAlive</key>
+	<false/>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.worktree-gc-universal.daily.plist
+++ b/infra/launchagents/com.nuzantara.worktree-gc-universal.daily.plist
@@ -27,6 +27,16 @@ already corrected once). This file is HOME-fork-scoped by nature (paths are
 per-machine under /Users/nuzantara/); install/update it on each machine's
 own ~/Library/LaunchAgents/ via `scripts/lint_home_fork.py` declared-pairs
 discipline, do not assume this tracked copy is symlinked live.
+
+ROUND-2 FIX 2026-07-18 (BLOCKER A): PATH below gained a trailing
+`:/usr/sbin` — on both M5 and Pro, `lsof` (used by the script's live-cwd
+guard) lives ONLY at /usr/sbin/lsof, which this PATH did not previously
+include, so a bare `lsof` invocation raised FileNotFoundError under this
+exact cron every run and the guard was silently inert (scar #2). The
+PRIMARY fix is in the script (_resolve_lsof_path() resolves an absolute
+path independent of PATH); this PATH edit is defense-in-depth only. The
+INSTALLED copy on Pro's ~/Library/LaunchAgents/ needs this same edit
+applied at deploy time — this tracked copy alone does not update it live.
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -60,7 +70,7 @@ discipline, do not assume this tracked copy is symlinked live.
 		<key>WORKTREE_GC_MAX_AGE_HOURS</key>
 		<string>24</string>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/bin:/bin</string>
+		<string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin</string>
 	</dict>
 
 	<key>StandardOutPath</key>

--- a/scripts/tests/test_worktree_gc_universal.py
+++ b/scripts/tests/test_worktree_gc_universal.py
@@ -6,14 +6,17 @@ a script (not an importable package member), so it is loaded by path via
 helper returns a ``subprocess.CompletedProcess`` whose ``.stdout`` callers read,
 so the fakes return a small stand-in with a ``stdout`` attribute.
 
-``TestGcIntegration`` and ``TestHasLiveCwd`` are the exception: they exercise
-``gc()`` end-to-end against REAL git repos + REAL ``git worktree`` under
-``tmp_path`` (never the real ~/nuzantara checkout or its worktrees — W96
-discipline), to prove the 2026-07-18 W88 cure empirically: dir-removal of an
-unpushed-but-clean named-branch worktree preserves the branch ref.
+``TestGcIntegration`` is the exception: it exercises ``gc()`` end-to-end
+against REAL git repos + REAL ``git worktree`` under ``tmp_path`` (never the
+real ~/nuzantara checkout or its worktrees — W96 discipline), to prove the
+2026-07-18 fixes empirically: dir-removal of an unpushed-but-clean
+named-branch worktree preserves the branch ref (W88 cure, round-1), and
+dir-removal of a clean detached-HEAD worktree preserves its commit via a
+durable ref (BLOCKER B cure, round-2).
 """
 import importlib.util
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -245,47 +248,111 @@ class TestUnpushedCommits:
 
 
 # ---------------------------------------------------------------------------
-# _has_live_cwd (added 2026-07-18)
+# _resolve_lsof_path (round-2, 2026-07-18 — BLOCKER A)
+#
+# The daily cron's plist PATH is /opt/homebrew/bin:/usr/bin:/bin, which does
+# NOT contain lsof on either M5 or Pro (it lives at /usr/sbin/lsof — verified
+# empirically 2026-07-18: `env -i PATH=/opt/homebrew/bin:/usr/bin:/bin which
+# lsof` -> rc=1 on M5). A bare ["lsof", ...] subprocess call under that PATH
+# raised FileNotFoundError every single cron run, silently disabling the
+# live-cwd guard (scar #2, green-but-not-working).
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLsofPath:
+    def test_absolute_fallback_when_path_excludes_lsof(self, monkeypatch):
+        # Reproduce the EXACT cron bug on THIS machine, unmocked: set PATH
+        # to the cron's real value, confirm shutil.which alone genuinely
+        # fails (proving the bug is real, not assumed), then confirm the
+        # absolute-path fallback probe (which stats the filesystem directly,
+        # ignoring PATH) still resolves lsof.
+        monkeypatch.setenv("PATH", "/opt/homebrew/bin:/usr/bin:/bin")
+        assert shutil.which("lsof") is None, (
+            "PATH must genuinely exclude lsof for this test to be meaningful "
+            "— if this fails, the cron bug premise no longer holds on this "
+            "machine and the test should be revisited"
+        )
+        resolved = gc._resolve_lsof_path()
+        assert resolved is not None
+        assert Path(resolved).exists()
+
+    def test_shutil_which_preferred_when_available(self, monkeypatch, tmp_path):
+        fake_lsof = tmp_path / "lsof"
+        fake_lsof.write_text("#!/bin/sh\necho fake\n")
+        fake_lsof.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{tmp_path}:/usr/bin:/bin")
+        assert gc._resolve_lsof_path() == str(fake_lsof)
+
+    def test_returns_none_when_truly_absent(self, monkeypatch):
+        monkeypatch.setattr(gc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(gc.Path, "exists", lambda self: False)
+        assert gc._resolve_lsof_path() is None
+
+
+# ---------------------------------------------------------------------------
+# _collect_live_cwds (round-2, 2026-07-18)
+# ---------------------------------------------------------------------------
+
+
+class TestCollectLiveCwds:
+    def test_lsof_missing_returns_empty_set_and_warns_visibly(self, monkeypatch, caplog):
+        monkeypatch.setattr(gc, "_resolve_lsof_path", lambda: None)
+        with caplog.at_level("WARNING"):
+            result = gc._collect_live_cwds()
+        assert result == set()
+        assert any("DEGRADED" in r.message for r in caplog.records)
+
+    def test_parses_cwd_lines_from_lsof_output(self, monkeypatch):
+        monkeypatch.setattr(gc, "_resolve_lsof_path", lambda: "/usr/sbin/lsof")
+
+        def fake_run(cmd, **k):
+            assert cmd[0] == "/usr/sbin/lsof"
+            assert cmd[1:] == ["-a", "-d", "cwd", "-Fn"]
+            return _FakeProcRC("p123\nfcwd\nn/some/path\np456\nfcwd\nn/other/path\n")
+
+        monkeypatch.setattr(gc.subprocess, "run", fake_run)
+        assert gc._collect_live_cwds() == {"/some/path", "/other/path"}
+
+    def test_invocation_error_returns_empty_set_and_warns(self, monkeypatch, caplog):
+        monkeypatch.setattr(gc, "_resolve_lsof_path", lambda: "/usr/sbin/lsof")
+
+        def _raise(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="lsof", timeout=20)
+
+        monkeypatch.setattr(gc.subprocess, "run", _raise)
+        with caplog.at_level("WARNING"):
+            result = gc._collect_live_cwds()
+        assert result == set()
+        assert any("DEGRADED" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _has_live_cwd (round-2, 2026-07-18 — now a pure in-Python prefix-match
+# against a pre-collected set; no subprocess call of its own, see
+# _collect_live_cwds above for the single system-wide lsof call per gc() run)
 # ---------------------------------------------------------------------------
 
 
 class TestHasLiveCwd:
-    def test_no_process_cwd_inside_returns_false(self, tmp_path):
-        # Nothing has this fresh tmp_path as its cwd -> False. (The positive
-        # case — a real process cwd'd inside — was verified manually on
-        # macOS with a backgrounded `sleep` + `lsof -a -d cwd -Fn`; see the
-        # function docstring for the empirical note.)
-        target = tmp_path / "nobody-here"
-        target.mkdir()
-        assert gc._has_live_cwd(target) is False
+    def test_exact_match(self):
+        assert gc._has_live_cwd(Path("/a/b/c"), {"/a/b/c"}) is True
 
-    def test_lsof_missing_returns_false_never_raises(self, tmp_path, monkeypatch):
-        def _raise(*a, **k):
-            raise FileNotFoundError("lsof not installed")
+    def test_subdirectory_match(self):
+        # This is the case the naive `lsof -d cwd -- <dir>` exact-match form
+        # misses (empirically verified 2026-07-18) — a shell cd'd into a
+        # SUBDIRECTORY of the worktree must still count as active.
+        assert gc._has_live_cwd(Path("/a/b"), {"/a/b/deep/sub"}) is True
 
-        monkeypatch.setattr(gc.subprocess, "run", _raise)
-        assert gc._has_live_cwd(tmp_path) is False
+    def test_unrelated_path_does_not_match(self):
+        assert gc._has_live_cwd(Path("/a/b"), {"/some/other/place"}) is False
 
-    def test_subdirectory_cwd_matches_via_prefix(self, tmp_path, monkeypatch):
-        # Simulate lsof reporting a process whose cwd is a SUBDIRECTORY of
-        # the worktree — this is the case the naive `lsof -d cwd -- <dir>`
-        # exact-match form misses (empirically verified); our prefix-match
-        # in Python must catch it.
-        sub = tmp_path / "apps" / "backend-rag"
+    def test_empty_set_never_matches(self):
+        assert gc._has_live_cwd(Path("/a/b"), set()) is False
 
-        def fake_run(cmd, **k):
-            assert cmd[:4] == ["lsof", "-a", "-d", "cwd"]
-            return _FakeProcRC(f"p123\nfcwd\nn{sub}\n")
-
-        monkeypatch.setattr(gc.subprocess, "run", fake_run)
-        assert gc._has_live_cwd(tmp_path) is True
-
-    def test_unrelated_cwd_does_not_match(self, tmp_path, monkeypatch):
-        def fake_run(cmd, **k):
-            return _FakeProcRC("p123\nfcwd\nn/some/other/place\n")
-
-        monkeypatch.setattr(gc.subprocess, "run", fake_run)
-        assert gc._has_live_cwd(tmp_path) is False
+    def test_similar_prefix_without_separator_does_not_match(self):
+        # /a/bc must NOT match target /a/b — the prefix check requires a
+        # trailing separator, not a bare string prefix.
+        assert gc._has_live_cwd(Path("/a/b"), {"/a/bc"}) is False
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +461,36 @@ class TestGcIntegration:
         rev = _git(["rev-parse", "feature/foo"], cwd=repo, env=env, check=False)
         assert rev.returncode == 0, "branch ref must survive dir removal"
         assert rev.stdout.strip()
+
+    def test_detached_head_clean_worktree_removed_commit_preserved_via_ref(
+        self, gc_repo,
+    ):
+        """BLOCKER B anti-orphan proof (round-2, 2026-07-18): a CLEAN
+        detached-HEAD worktree with 1 unique commit is REMOVED, but the
+        commit is preserved via a refs/agent-quarantine/<slug>-head ref —
+        never orphaned. Before the fix, `git stash create` (the only
+        preservation mechanism) is EMPTY on a clean tree, so this exact case
+        sailed through un-quarantined and the commit became dangling."""
+        mod, repo, env = gc_repo
+        wt = mod.WORKTREES_DIR / "detached-lane"
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        # --detach: HEAD is a raw commit, no branch ref anywhere for it.
+        _git(["worktree", "add", "--detach", str(wt), "main"], cwd=repo, env=env)
+        (wt / "unique.txt").write_text("only reachable from detached HEAD\n")
+        _git(["add", "unique.txt"], cwd=wt, env=env)
+        _git(["commit", "-m", "unique detached commit"], cwd=wt, env=env)
+        commit_sha = _git(["rev-parse", "HEAD"], cwd=wt, env=env).stdout.strip()
+
+        _age_path(wt, mod.DEFAULT_MAX_AGE_HOURS + 1)
+
+        mod.gc(apply=True, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
+
+        assert not wt.exists()
+        slug = mod._slug(str(wt))
+        ref = f"{mod.QUARANTINE_REF_PREFIX}/{slug}-head"
+        resolved = _git(["rev-parse", "--verify", ref], cwd=repo, env=env, check=False)
+        assert resolved.returncode == 0, "detached HEAD commit must be preserved"
+        assert resolved.stdout.strip() == commit_sha
 
     def test_recent_worktree_kept_active_not_removed(self, gc_repo):
         """(b) A worktree touched within MIN_AGE_MIN is kept (active session)."""

--- a/scripts/tests/test_worktree_gc_universal.py
+++ b/scripts/tests/test_worktree_gc_universal.py
@@ -5,8 +5,18 @@ a script (not an importable package member), so it is loaded by path via
 ``importlib.util``. Git is mocked by monkeypatching ``_run_git``; the real
 helper returns a ``subprocess.CompletedProcess`` whose ``.stdout`` callers read,
 so the fakes return a small stand-in with a ``stdout`` attribute.
+
+``TestGcIntegration`` and ``TestHasLiveCwd`` are the exception: they exercise
+``gc()`` end-to-end against REAL git repos + REAL ``git worktree`` under
+``tmp_path`` (never the real ~/nuzantara checkout or its worktrees — W96
+discipline), to prove the 2026-07-18 W88 cure empirically: dir-removal of an
+unpushed-but-clean named-branch worktree preserves the branch ref.
 """
 import importlib.util
+import os
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -36,7 +46,11 @@ class TestSlug:
     def test_basic_path_becomes_safe_filename(self):
         slug = gc._slug("/Users/nuz/nuzantara/.worktrees/ops-foo")
         assert "/" not in slug
-        assert slug == "Users_nuz_Desktop_nuzantara_.worktrees_ops-foo"
+        # Pre-existing bug fixed 2026-07-18: the expected literal had a stray
+        # "Desktop_" segment that never matched the input path above (a
+        # pure copy-paste artifact, unrelated to the repo's actual
+        # out-of-Desktop move — the input never contained "Desktop").
+        assert slug == "Users_nuz_nuzantara_.worktrees_ops-foo"
 
     def test_trailing_slash_stripped(self):
         slug = gc._slug("/tmp/lane/")
@@ -169,3 +183,276 @@ class TestHasRealDirty:
 
         monkeypatch.setattr(gc, "_run_git", fake)
         assert gc._has_real_dirty(Path("/tmp/wt")) is True
+
+
+# ---------------------------------------------------------------------------
+# _unpushed_commits (W88 honesty short-circuit, added 2026-07-18)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcRC:
+    """Like _FakeProc but with an explicit returncode (needed for the
+    ``git diff --quiet`` short-circuit, which signals via exit code)."""
+
+    def __init__(self, stdout: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+class TestUnpushedCommits:
+    def test_content_merged_short_circuits_to_zero(self, monkeypatch):
+        # `git diff --quiet origin/main...HEAD` exits 0 -> no content diff ->
+        # 0 even though a naive rev-list count would be non-zero (W88 cure).
+        def fake(args, **k):
+            if args[0] == "diff":
+                return _FakeProcRC(returncode=0)
+            if args[0] == "rev-list":
+                return _FakeProcRC("7833")  # would-be inflated proxy count
+            return _FakeProcRC()
+
+        monkeypatch.setattr(gc, "_run_git", fake)
+        assert gc._unpushed_commits(Path("/tmp/wt"), "feature/x") == 0
+
+    def test_content_diff_falls_through_to_revlist_count(self, monkeypatch):
+        # diff --quiet exits 1 (has diff) -> fall through to the raw proxy.
+        def fake(args, **k):
+            if args[0] == "diff":
+                return _FakeProcRC(returncode=1)
+            if args[0] == "rev-list":
+                return _FakeProcRC("3")
+            return _FakeProcRC()
+
+        monkeypatch.setattr(gc, "_run_git", fake)
+        assert gc._unpushed_commits(Path("/tmp/wt"), "feature/x") == 3
+
+    def test_git_error_on_diff_falls_through_to_revlist(self, monkeypatch):
+        def fake(args, **k):
+            if args[0] == "diff":
+                raise subprocess.CalledProcessError(1, args)
+            if args[0] == "rev-list":
+                return _FakeProcRC("2")
+            return _FakeProcRC()
+
+        monkeypatch.setattr(gc, "_run_git", fake)
+        assert gc._unpushed_commits(Path("/tmp/wt"), "feature/x") == 2
+
+    def test_both_git_calls_fail_returns_conservative_one(self, monkeypatch):
+        def fake(args, **k):
+            raise subprocess.CalledProcessError(1, args)
+
+        monkeypatch.setattr(gc, "_run_git", fake)
+        assert gc._unpushed_commits(Path("/tmp/wt"), "feature/x") == 1
+
+
+# ---------------------------------------------------------------------------
+# _has_live_cwd (added 2026-07-18)
+# ---------------------------------------------------------------------------
+
+
+class TestHasLiveCwd:
+    def test_no_process_cwd_inside_returns_false(self, tmp_path):
+        # Nothing has this fresh tmp_path as its cwd -> False. (The positive
+        # case — a real process cwd'd inside — was verified manually on
+        # macOS with a backgrounded `sleep` + `lsof -a -d cwd -Fn`; see the
+        # function docstring for the empirical note.)
+        target = tmp_path / "nobody-here"
+        target.mkdir()
+        assert gc._has_live_cwd(target) is False
+
+    def test_lsof_missing_returns_false_never_raises(self, tmp_path, monkeypatch):
+        def _raise(*a, **k):
+            raise FileNotFoundError("lsof not installed")
+
+        monkeypatch.setattr(gc.subprocess, "run", _raise)
+        assert gc._has_live_cwd(tmp_path) is False
+
+    def test_subdirectory_cwd_matches_via_prefix(self, tmp_path, monkeypatch):
+        # Simulate lsof reporting a process whose cwd is a SUBDIRECTORY of
+        # the worktree — this is the case the naive `lsof -d cwd -- <dir>`
+        # exact-match form misses (empirically verified); our prefix-match
+        # in Python must catch it.
+        sub = tmp_path / "apps" / "backend-rag"
+
+        def fake_run(cmd, **k):
+            assert cmd[:4] == ["lsof", "-a", "-d", "cwd"]
+            return _FakeProcRC(f"p123\nfcwd\nn{sub}\n")
+
+        monkeypatch.setattr(gc.subprocess, "run", fake_run)
+        assert gc._has_live_cwd(tmp_path) is True
+
+    def test_unrelated_cwd_does_not_match(self, tmp_path, monkeypatch):
+        def fake_run(cmd, **k):
+            return _FakeProcRC("p123\nfcwd\nn/some/other/place\n")
+
+        monkeypatch.setattr(gc.subprocess, "run", fake_run)
+        assert gc._has_live_cwd(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: real git repos + real `git worktree` under tmp_path.
+#
+# Exercises gc() end-to-end (NOT mocked _run_git) to prove the CHANGE B
+# invariant empirically: reclaiming an unpushed-but-clean named-branch
+# worktree's DIRECTORY never touches the branch REF. Never touches the real
+# ~/nuzantara checkout/worktrees (W96 discipline) — everything lives under
+# tmp_path with its own bare `origin` remote.
+# ---------------------------------------------------------------------------
+
+
+def _git(args, cwd, env, check=True):
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd), env=env,
+        capture_output=True, text=True, check=check,
+    )
+
+
+def _load_gc_module(repo_root: Path):
+    """Fresh module instance with REPO_ROOT/WORKTREES_DIR/ALLOWLIST_PATHS
+    repointed at a tmp git repo, so gc() operates entirely inside tmp_path
+    (mirrors the reload pattern in test_agent_start.py's _load_module)."""
+    spec = importlib.util.spec_from_file_location(
+        "worktree_gc_universal_under_test", SPEC_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    mod.REPO_ROOT = repo_root
+    mod.WORKTREES_DIR = repo_root / ".worktrees"
+    mod.ALLOWLIST_PATHS = {str(repo_root.resolve())}
+    return mod
+
+
+def _add_worktree(repo, wt_path, branch, env, *, base="main"):
+    _git(["worktree", "add", "-b", branch, str(wt_path), base], cwd=repo, env=env)
+
+
+def _age_path(path: Path, hours: float):
+    """Push mtime of path + path/.git into the past so age gates pass."""
+    old = time.time() - hours * 3600 - 60
+    os.utime(path, (old, old))
+    gitp = path / ".git"
+    try:
+        os.utime(gitp, (old, old))
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def gc_git_env():
+    env = dict(os.environ)
+    env["GIT_AUTHOR_NAME"] = "Test"
+    env["GIT_AUTHOR_EMAIL"] = "test@example.com"
+    env["GIT_COMMITTER_NAME"] = "Test"
+    env["GIT_COMMITTER_EMAIL"] = "test@example.com"
+    return env
+
+
+@pytest.fixture
+def gc_repo(tmp_path, gc_git_env, monkeypatch):
+    """Main repo (bare `origin` remote + pushed main) + a fresh gc module
+    scoped to it. Mirrors test_agent_start.py's fake_repo: a bare origin is
+    the minimal honest model — without one, EVERY worktree would read as
+    unpushed."""
+    monkeypatch.delenv("WORKTREE_GC_ENABLED", raising=False)
+
+    origin = tmp_path / "origin.git"
+    _git(["init", "--bare", "-b", "main", str(origin)], cwd=tmp_path, env=gc_git_env)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-b", "main"], cwd=repo, env=gc_git_env)
+    (repo / "README.md").write_text("seed\n")
+    _git(["add", "README.md"], cwd=repo, env=gc_git_env)
+    _git(["commit", "-m", "seed"], cwd=repo, env=gc_git_env)
+    _git(["remote", "add", "origin", str(origin)], cwd=repo, env=gc_git_env)
+    _git(["push", "-u", "origin", "main"], cwd=repo, env=gc_git_env)
+
+    mod = _load_gc_module(repo)
+    return mod, repo, gc_git_env
+
+
+class TestGcIntegration:
+    def test_old_clean_worktree_unpushed_commit_removed_branch_survives(
+        self, gc_repo,
+    ):
+        """(a) An OLD clean worktree on a branch with an unpushed commit is
+        REMOVED — and the branch ref still exists afterward. This is the
+        core W88 cure: `git worktree remove` never deletes the branch."""
+        mod, repo, env = gc_repo
+        wt = mod.WORKTREES_DIR / "feature-foo"
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        _add_worktree(repo, wt, "feature/foo", env)
+        (wt / "new.txt").write_text("unpushed work\n")
+        _git(["add", "new.txt"], cwd=wt, env=env)
+        _git(["commit", "-m", "unpushed commit"], cwd=wt, env=env)
+
+        _age_path(wt, mod.DEFAULT_MAX_AGE_HOURS + 1)
+
+        mod.gc(apply=True, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
+
+        assert not wt.exists()
+        rev = _git(["rev-parse", "feature/foo"], cwd=repo, env=env, check=False)
+        assert rev.returncode == 0, "branch ref must survive dir removal"
+        assert rev.stdout.strip()
+
+    def test_recent_worktree_kept_active_not_removed(self, gc_repo):
+        """(b) A worktree touched within MIN_AGE_MIN is kept (active session)."""
+        mod, repo, env = gc_repo
+        wt = mod.WORKTREES_DIR / "feature-fresh"
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        _add_worktree(repo, wt, "feature/fresh", env)
+        # Fresh mtime (just created) — no _age_path call.
+
+        mod.gc(apply=True, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
+
+        assert wt.exists()
+
+    def test_real_dirty_worktree_quarantined_then_removed(self, gc_repo):
+        """(c) A worktree with real (non-formatting) uncommitted changes is
+        quarantined onto refs/agent-quarantine/<slug> THEN removed."""
+        mod, repo, env = gc_repo
+        wt = mod.WORKTREES_DIR / "feature-dirty"
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        _add_worktree(repo, wt, "feature/dirty", env)
+        (wt / "README.md").write_text("seed\nreal uncommitted change\n")
+
+        _age_path(wt, mod.DEFAULT_MAX_AGE_HOURS + 1)
+
+        mod.gc(apply=True, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
+
+        assert not wt.exists()
+        slug = mod._slug(str(wt))
+        ref = _git(
+            ["rev-parse", f"{mod.QUARANTINE_REF_PREFIX}/{slug}"],
+            cwd=repo, env=env, check=False,
+        )
+        assert ref.returncode == 0, "quarantine ref must exist before removal"
+        assert ref.stdout.strip()
+
+    def test_allowlisted_main_checkout_never_touched(self, gc_repo):
+        """(d) The main checkout (in ALLOWLIST_PATHS) is skipped even if old
+        and dirty."""
+        mod, repo, env = gc_repo
+        (repo / "README.md").write_text("seed\ndirty on main\n")
+        _age_path(repo, mod.DEFAULT_MAX_AGE_HOURS + 1)
+
+        mod.gc(apply=True, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
+
+        assert repo.exists()
+        status = _git(["status", "--porcelain"], cwd=repo, env=env)
+        assert "README.md" in status.stdout  # untouched, still dirty
+
+    def test_dry_run_removes_nothing(self, gc_repo):
+        """(e) Without --apply, gc() is report-only: no dir is removed."""
+        mod, repo, env = gc_repo
+        wt = mod.WORKTREES_DIR / "feature-dryrun"
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        _add_worktree(repo, wt, "feature/dryrun", env)
+        (wt / "new.txt").write_text("unpushed work\n")
+        _git(["add", "new.txt"], cwd=wt, env=env)
+        _git(["commit", "-m", "unpushed commit"], cwd=wt, env=env)
+        _age_path(wt, mod.DEFAULT_MAX_AGE_HOURS + 1)
+
+        mod.gc(apply=False, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
+
+        assert wt.exists()

--- a/scripts/tests/test_worktree_gc_universal.py
+++ b/scripts/tests/test_worktree_gc_universal.py
@@ -12,9 +12,11 @@ real ~/nuzantara checkout or its worktrees — W96 discipline), to prove the
 2026-07-18 fixes empirically: dir-removal of an unpushed-but-clean
 named-branch worktree preserves the branch ref (W88 cure, round-1), and
 dir-removal of a clean detached-HEAD worktree preserves its commit via a
-durable ref (BLOCKER B cure, round-2).
+durable ref (BLOCKER B cure, round-2). ``TestHeartbeat`` and
+``TestMainHeartbeatWiring`` exercise the G2_heartbeat gene (round-3).
 """
 import importlib.util
+import json
 import os
 import shutil
 import subprocess
@@ -30,6 +32,19 @@ SPEC_PATH = SCRIPT_DIR / "worktree_gc_universal.py"
 _spec = importlib.util.spec_from_file_location("worktree_gc_universal", SPEC_PATH)
 gc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(gc)
+
+
+@pytest.fixture(autouse=True)
+def _heartbeat_sidecar_isolation(tmp_path, monkeypatch):
+    """W96: no test in this module may EVER write to the real
+    ~/.organism/last_seen/ — autouse means every test gets an isolated
+    sidecar dir by default, whether or not it deliberately exercises the
+    heartbeat path (defense in depth: a future test that calls main() or
+    _heartbeat() without remembering to patch the env var still lands in
+    tmp_path). A test that wants to verify ORGANISM_LAST_SEEN_DIR honoring
+    specifically can still override this via its own monkeypatch.setenv
+    (function-scoped monkeypatch — last call wins within the same test)."""
+    monkeypatch.setenv("ORGANISM_LAST_SEEN_DIR", str(tmp_path / "organism-last-seen"))
 
 
 class _FakeProc:
@@ -553,3 +568,125 @@ class TestGcIntegration:
         mod.gc(apply=False, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
 
         assert wt.exists()
+
+
+# ---------------------------------------------------------------------------
+# _heartbeat (G2_heartbeat gene, round-3, 2026-07-18) — direct unit tests.
+# The autouse _heartbeat_sidecar_isolation fixture above already redirects
+# ORGANISM_LAST_SEEN_DIR to tmp_path for every test in this module; these
+# tests exercise the function's own contract on top of that isolation.
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeat:
+    def test_honors_organism_last_seen_dir_env(self, tmp_path, monkeypatch):
+        """(d) sidecar path honors ORGANISM_LAST_SEEN_DIR."""
+        custom_dir = tmp_path / "custom-sidecar-dir"
+        monkeypatch.setenv("ORGANISM_LAST_SEEN_DIR", str(custom_dir))
+
+        gc._heartbeat("ok", "test detail")
+
+        sidecar = custom_dir / f"{gc.ORGAN_ID}.json"
+        assert sidecar.exists()
+        payload = json.loads(sidecar.read_text())
+        assert payload["organ"] == gc.ORGAN_ID
+        assert payload["status"] == "ok"
+        assert payload["detail"] == "test detail"
+        assert payload["ts"].endswith("Z")  # UTC ISO marker
+
+    def test_write_failure_never_raises(self, tmp_path, monkeypatch):
+        """(c) heartbeat write failure (mkdir raises) never escapes as an
+        exception — the GC's exit code must never depend on liveness-proof
+        succeeding."""
+        sidecar_dir = tmp_path / "unwritable"
+        monkeypatch.setenv("ORGANISM_LAST_SEEN_DIR", str(sidecar_dir))
+
+        def _raise_mkdir(*a, **k):
+            raise OSError("simulated disk full")
+
+        monkeypatch.setattr(gc.Path, "mkdir", _raise_mkdir)
+
+        gc._heartbeat("ok", "should be swallowed, not raised")  # must not raise
+
+        # Prove the failure was genuinely swallowed, not silently no-op'd
+        # into "success anyway": mkdir never ran, so no sidecar dir exists.
+        assert not sidecar_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# main() heartbeat wiring (G2_heartbeat gene, round-3, 2026-07-18) —
+# end-to-end: real gc_repo, real main() call (sys.argv monkeypatched),
+# real sidecar file read back.
+# ---------------------------------------------------------------------------
+
+
+class TestMainHeartbeatWiring:
+    def test_apply_run_writes_ok_sidecar_with_reap_counters(
+        self, gc_repo, monkeypatch, tmp_path,
+    ):
+        """(a) --apply run -> sidecar written with status ok and detail
+        carrying the real reap counters (the anti-blindness payload)."""
+        mod, repo, env = gc_repo
+        sidecar_dir = tmp_path / "sidecar-main-ok"
+        monkeypatch.setenv("ORGANISM_LAST_SEEN_DIR", str(sidecar_dir))
+
+        wt = mod.WORKTREES_DIR / "feature-heartbeat"
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        _add_worktree(repo, wt, "feature/heartbeat", env)
+        (wt / "new.txt").write_text("unpushed work\n")
+        _git(["add", "new.txt"], cwd=wt, env=env)
+        _git(["commit", "-m", "unpushed commit"], cwd=wt, env=env)
+        _age_path(wt, mod.DEFAULT_MAX_AGE_HOURS + 1)
+
+        monkeypatch.setattr(
+            sys, "argv",
+            ["worktree_gc_universal.py", "--apply",
+             "--max-age-hours", str(mod.DEFAULT_MAX_AGE_HOURS)],
+        )
+        rc = mod.main()
+        assert rc == 0
+        assert not wt.exists()  # sanity: the reap actually happened
+
+        sidecar = sidecar_dir / f"{mod.ORGAN_ID}.json"
+        assert sidecar.exists()
+        payload = json.loads(sidecar.read_text())
+        assert payload["organ"] == mod.ORGAN_ID
+        assert payload["status"] == "ok"
+        assert "removed=" in payload["detail"]
+        assert "removed=0" not in payload["detail"]  # something was actually reaped
+
+    def test_kill_switch_writes_disabled_sidecar(self, gc_repo, monkeypatch, tmp_path):
+        """(b) kill-switch set -> status disabled."""
+        mod, repo, env = gc_repo
+        sidecar_dir = tmp_path / "sidecar-main-disabled"
+        monkeypatch.setenv("ORGANISM_LAST_SEEN_DIR", str(sidecar_dir))
+        monkeypatch.setenv("WORKTREE_GC_ENABLED", "false")
+        monkeypatch.setattr(sys, "argv", ["worktree_gc_universal.py"])
+
+        rc = mod.main()
+        assert rc == 0
+
+        sidecar = sidecar_dir / f"{mod.ORGAN_ID}.json"
+        assert sidecar.exists()
+        payload = json.loads(sidecar.read_text())
+        assert payload["status"] == "disabled"
+
+    def test_heartbeat_failure_does_not_break_main_exit_code(
+        self, gc_repo, monkeypatch, tmp_path,
+    ):
+        """(c, end-to-end) even with the heartbeat write itself broken
+        (mkdir raises), main() still returns its normal exit code and no
+        exception escapes — liveness-proof failure must never mask (or
+        cause) a GC failure."""
+        mod, repo, env = gc_repo
+        monkeypatch.setenv("ORGANISM_LAST_SEEN_DIR", str(tmp_path / "broken"))
+        monkeypatch.setenv("WORKTREE_GC_ENABLED", "false")
+        monkeypatch.setattr(sys, "argv", ["worktree_gc_universal.py"])
+
+        def _raise_mkdir(*a, **k):
+            raise OSError("simulated failure")
+
+        monkeypatch.setattr(mod.Path, "mkdir", _raise_mkdir)
+
+        rc = mod.main()  # must not raise
+        assert rc == 0

--- a/scripts/worktree_gc_universal.py
+++ b/scripts/worktree_gc_universal.py
@@ -15,29 +15,54 @@ scope. For each candidate it applies the panel's safety model:
   2b. Live-cwd gate: skip if any process on the machine has its cwd inside the
       worktree (exact match OR a subdirectory) — a precise "active session"
       signal the mtime-age gate alone misses (a shell idling deep in the tree
-      touches no file, so mtime never moves). Best-effort via `lsof`; missing
-      binary / any error → falls through to the age/dirty gates below, never
-      crashes the GC.
+      touches no file, so mtime never moves). `lsof` is resolved by ABSOLUTE
+      path (round-2 fix, 2026-07-18: the daily cron's plist PATH is
+      `/opt/homebrew/bin:/usr/bin:/bin`, which does NOT contain `lsof` on
+      either M5 or Pro — it lives at `/usr/sbin/lsof` — so a bare
+      `["lsof", ...]` call silently raised FileNotFoundError under the REAL
+      cron and the guard was inert the whole time: scar #2, green-but-not-
+      working). lsof is invoked ONCE per gc() run (system-wide cwd dump),
+      never once per worktree — a 53-worktree fleet at a 20s timeout each
+      would be ~17min cumulative worst case. Missing binary / any error →
+      logged (visibly, not silently) and falls through to the age/dirty
+      gates below; a live-cwd check must never crash or hang the GC.
   3. Dirty classification: `git status --porcelain` AND a whitespace-insensitive
      diff. Pure formatting noise (Prettier/Black reflow) is NOT real work
      (W62: the 6 orphans were all formatting-only). Real dirty → QUARANTINE.
-  4. Quarantine before removal: if a worktree has real uncommitted work OR is on
-     a detached HEAD with commits, stash it onto refs/agent-quarantine/<slug>
-     so nothing is lost, THEN remove. Never blind-delete dirty work.
-  5. Unpushed-commit handling (FIXED 2026-07-18 — cure for the W88 "kept
-     forever" bug: the daily cron reaped 0 for days, 53 worktrees / 55G
-     accumulated, because this gate hard-KEPT every named-branch worktree
-     with `rev-list origin/main..HEAD` > 0 — a proxy that inflated to
-     7779-7833 on divergent/rebased/squashed bases). A NAMED branch's
-     unpushed commits no longer block dir removal: `git worktree remove`
-     only deletes the WORKING DIRECTORY, never the branch ref — the branch
-     (and every commit on it) survives in refs/heads/ untouched and is fully
-     recoverable via `git worktree add <path> <branch>`. The GC logs a
-     RECLAIM-DIR line (operator awareness + the exact resume command) and
-     proceeds to remove the dir. This script NEVER runs `git branch -D`/`-d`
-     — grep the file to confirm the invariant holds. Detached HEAD with
-     unpushed commits is the one case still quarantined first (those commits
-     have no branch ref to fall back on if the dir goes away).
+  4. Preservation before removal runs on TWO INDEPENDENT tracks, either of
+     which can veto the remove:
+       a. Real uncommitted work (any worktree) → stash-quarantine onto
+          refs/agent-quarantine/<slug> (git stash create; never touches the
+          stash stack). Quarantine failure → KEEP, never remove.
+       b. Detached HEAD (round-2 fix, 2026-07-18 — cure for a silent-orphan
+          bug: a CLEAN detached-HEAD worktree has no branch ref, so
+          `git worktree remove` was dropping the only pointer to its
+          commits into dangling/unreachable space. `git stash create` is
+          EMPTY on a clean tree, so the old real_dirty-only quarantine never
+          fired for this case). For ANY detached worktree about to be
+          removed, UNCONDITIONALLY resolve `git rev-parse --verify HEAD` and
+          write it to refs/agent-quarantine/<slug>-head BEFORE removal —
+          never gated by the unpushed-commit proxy (rule 5), which can
+          false-zero a detached HEAD via the three-dot content
+          short-circuit. Resolution or ref-write failure → KEEP, never
+          remove (log "could not preserve detached HEAD").
+     Quarantine/preservation refs check for a pre-existing ref at the same
+     name first (slug-truncation collision) and append a short sha
+     uniquifier on collision, so a re-run never clobbers a prior quarantine.
+  5. Unpushed-commit handling for NAMED branches only (FIXED 2026-07-18 —
+     cure for the W88 "kept forever" bug: the daily cron reaped 0 for days,
+     53 worktrees / 55G accumulated, because this gate hard-KEPT every
+     named-branch worktree with `rev-list origin/main..HEAD` > 0 — a proxy
+     that inflated to 7779-7833 on divergent/rebased/squashed bases). A
+     NAMED branch's unpushed commits no longer block dir removal:
+     `git worktree remove` only deletes the WORKING DIRECTORY, never the
+     branch ref — the branch (and every commit on it) survives in
+     refs/heads/ untouched and is fully recoverable via
+     `git worktree add <path> <branch>`. The GC logs a RECLAIM-DIR line
+     (operator awareness + the exact resume command) and proceeds to remove
+     the dir. This script NEVER runs `git branch -D`/`-d` — grep the file to
+     confirm the invariant holds. (Detached HEAD is rule 4b above, not this
+     rule — it never had a branch ref to rely on.)
   6. `git worktree prune` at the end → clears phantom admin entries for /tmp
      worktrees deleted on reboot (Pattern 7).
   7. dry-run by DEFAULT; --apply required to remove.
@@ -51,6 +76,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -173,45 +199,88 @@ def _has_real_dirty(worktree: Path) -> bool:
     return bool(diff.strip())
 
 
-def _has_live_cwd(worktree: Path) -> bool:
-    """True if any process on the machine has its cwd inside this worktree
-    (exact match OR a subdirectory) — a precise "active session" signal the
-    mtime-age gate alone misses (a shell idling deep in the tree touches no
-    file, so mtime never moves).
+def _resolve_lsof_path() -> str | None:
+    """Resolve an absolute path to `lsof`, independent of the caller's PATH.
 
-    Implementation note (verified empirically on macOS, 2026-07-18): the
-    obvious `lsof -a -d cwd -Fn -- <dir>` form only matches an EXACT cwd —
-    a shell cd'd into a *subdirectory* of the worktree (e.g.
-    `<worktree>/apps/backend-rag`) is invisible to it. `lsof +D <dir>`
-    recursively walks the target directory's open files and would be
-    catastrophically slow on a large worktree (this GC exists because
-    worktrees grow to tens of GB). The reliable+cheap form: ask lsof for
-    EVERY process's cwd system-wide (`lsof -a -d cwd -Fn`, no path filter —
-    a syscall-table read, ~0.2s even on a busy box) and prefix-match the
-    paths in Python. That correctly catches both exact and nested cwds.
+    BLOCKER (round-2, 2026-07-18): the daily cron's plist sets
+    `PATH=/opt/homebrew/bin:/usr/bin:/bin`. On BOTH M5 and Pro, `lsof` lives
+    ONLY at `/usr/sbin/lsof` — not on that PATH. A bare
+    `subprocess.run(["lsof", ...])` therefore raised FileNotFoundError under
+    the ACTUAL cron every single run, and the old `_has_live_cwd` caught
+    that broadly and returned False — so the live-cwd guard was silently
+    inert in production the whole time it existed (scar #2, "green but not
+    working": no crash, no log, just a guard that never once fired).
 
-    lsof missing/erroring/timing out → False (fall back to the age/dirty
-    gates; a live-cwd check must never crash or hang the GC).
+    `shutil.which` first (honors an explicit PATH when one is set — covers
+    interactive/test invocations), else probe the two known-good absolute
+    locations directly. None found → caller must log visibly and degrade,
+    never fail silently again.
+    """
+    found = shutil.which("lsof")
+    if found:
+        return found
+    for candidate in ("/usr/sbin/lsof", "/usr/bin/lsof"):
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def _collect_live_cwds() -> set[str]:
+    """Run `lsof -a -d cwd -Fn` ONCE (system-wide, no path filter) and return
+    the set of every process's cwd path on the machine.
+
+    Cheap: a syscall-table read (~0.2s even on a busy box), NOT a directory
+    walk (`lsof +D <dir>` would recursively stat every open file under the
+    target — catastrophic on a worktree that can run to tens of GB, which is
+    exactly why this GC exists). Call this ONCE per gc() run and pass the
+    result to `_has_live_cwd` for each worktree (round-2 fix, 2026-07-18:
+    Codex flagged that calling lsof per-worktree could cost up to ~17min
+    cumulative worst-case across a 53-worktree fleet at a 20s timeout each).
+
+    lsof missing (resolver finds nothing) or any invocation error → empty
+    set, logged ONCE here (not once per worktree, which would spam the log
+    across a large fleet) as a WARNING so the degradation is VISIBLE. Falls
+    through to the age/dirty gates for every worktree this run; a live-cwd
+    check must never crash or hang the GC.
+    """
+    lsof_path = _resolve_lsof_path()
+    if lsof_path is None:
+        logger.warning(
+            "live-cwd guard DEGRADED — lsof not found (checked PATH + "
+            "/usr/sbin/lsof + /usr/bin/lsof); this run falls back to "
+            "age/dirty gates only",
+        )
+        return set()
+    try:
+        out = subprocess.run(
+            [lsof_path, "-a", "-d", "cwd", "-Fn"],
+            capture_output=True, text=True, timeout=20,
+        ).stdout
+    except Exception as exc:  # noqa: BLE001 — best-effort, never crash the GC
+        logger.warning("live-cwd guard DEGRADED — lsof invocation failed: %s", exc)
+        return set()
+    return {line[1:] for line in out.splitlines() if line.startswith("n")}
+
+
+def _has_live_cwd(worktree: Path, live_cwds: set[str]) -> bool:
+    """True if `live_cwds` (from _collect_live_cwds(), collected ONCE per
+    gc() run) contains this worktree's path — exact match OR a subdirectory
+    — a precise "active session" signal the mtime-age gate alone misses (a
+    shell idling deep in the tree touches no file, so mtime never moves).
+
+    Pure Python prefix-match, no subprocess call here (verified empirically
+    on macOS, 2026-07-18: the obvious `lsof -a -d cwd -Fn -- <dir>` form
+    only matches an EXACT cwd — a shell cd'd into a *subdirectory* of the
+    worktree, e.g. `<worktree>/apps/backend-rag`, is invisible to it — so
+    the prefix-match has to happen in Python against the full system-wide
+    dump, not via lsof's own path filter).
     """
     try:
         target = str(worktree.resolve())
     except OSError:
         target = str(worktree)
-    try:
-        out = subprocess.run(
-            ["lsof", "-a", "-d", "cwd", "-Fn"],
-            capture_output=True, text=True, timeout=20,
-        ).stdout
-    except Exception:
-        return False
     prefix = target.rstrip("/") + "/"
-    for line in out.splitlines():
-        if not line.startswith("n"):
-            continue
-        name = line[1:]
-        if name == target or name.startswith(prefix):
-            return True
-    return False
+    return any(c == target or c.startswith(prefix) for c in live_cwds)
 
 
 def _unpushed_commits(worktree: Path, branch: str | None) -> int:
@@ -258,12 +327,39 @@ def _unpushed_commits(worktree: Path, branch: str | None) -> int:
         return 1
 
 
+def _ref_exists(ref: str) -> bool:
+    """True if `ref` already resolves to an object (any worktree shares the
+    same ref namespace via the common .git dir)."""
+    result = _run_git(["rev-parse", "--verify", "--quiet", ref], check=False)
+    return result.returncode == 0
+
+
+def _unique_ref(base_ref: str, sha_hint: str) -> str:
+    """Return base_ref, or base_ref + a short sha-based uniquifier if
+    base_ref already resolves (FIX C, round-2, 2026-07-18): the 80-char
+    truncation in _slug() can theoretically collide two different worktree
+    paths onto the same slug, and re-running the GC before a prior
+    quarantine ref is manually cleaned up would otherwise clobber it with
+    `update-ref` (unconditional overwrite). Cheap: one `rev-parse --verify`.
+    """
+    if not _ref_exists(base_ref):
+        return base_ref
+    return f"{base_ref}-{sha_hint[:8]}"
+
+
 def _quarantine(worktree: Path, slug: str, *, apply: bool) -> bool:
     """Create a quarantine ref capturing the worktree's current tree+untracked.
 
     Uses `git stash create` (produces a commit object without touching the
-    stash stack) then writes it to refs/agent-quarantine/<slug>. Returns True
-    on success (or dry-run). Best-effort: failure → False (caller keeps wt).
+    stash stack) then writes it to refs/agent-quarantine/<slug> (or a
+    collision-safe variant, see _unique_ref). Returns True on success (or
+    dry-run). Best-effort: failure → False (caller keeps wt).
+
+    NOTE: `git stash create` is EMPTY on a clean working tree — it captures
+    only uncommitted diffs, never committed-but-unreachable-elsewhere
+    commits. It is NOT a substitute for _preserve_detached_head(), which
+    covers the orthogonal case of a detached HEAD's own commits (BLOCKER B,
+    round-2, 2026-07-18).
     """
     ref = f"{QUARANTINE_REF_PREFIX}/{slug}"
     if not apply:
@@ -280,8 +376,9 @@ def _quarantine(worktree: Path, slug: str, *, apply: bool) -> bool:
                            cwd=worktree, check=False)
         sha = created.stdout.strip()
         if sha:
-            _run_git(["update-ref", ref, sha], check=False)
-            logger.info("quarantined %s -> %s (%s)", worktree, ref, sha[:10])
+            final_ref = _unique_ref(ref, sha)
+            _run_git(["update-ref", final_ref, sha], check=False)
+            logger.info("quarantined %s -> %s (%s)", worktree, final_ref, sha[:10])
         # Also drop a patch artifact under .agent-receipts/ for human-readable
         # recovery even if the ref is later pruned.
         receipts = REPO_ROOT / ".agent-receipts"
@@ -294,6 +391,57 @@ def _quarantine(worktree: Path, slug: str, *, apply: bool) -> bool:
     except Exception as exc:  # noqa: BLE001 — best-effort, never crash GC
         logger.warning("quarantine failed for %s: %s", worktree, exc)
         return False
+
+
+def _preserve_detached_head(worktree: Path, slug: str, *, apply: bool) -> bool:
+    """Unconditionally create a durable ref to a detached worktree's HEAD
+    BEFORE removal (BLOCKER B, round-2, 2026-07-18).
+
+    A detached-HEAD worktree has NO branch ref — its commits are reachable
+    ONLY through that worktree's HEAD. `git worktree remove` drops that
+    pointer; if nothing else references the commits, they become dangling
+    and are eventually GC'd by git itself. `git stash create` (the
+    _quarantine() mechanism) does NOT cover this — it is EMPTY on a clean
+    tree, so a CLEAN detached-HEAD worktree with unique commits sailed
+    through the old real_dirty-only quarantine gate and got force-removed,
+    orphaning its commits.
+
+    This check runs for EVERY detached worktree about to be removed,
+    UNCONDITIONALLY — never gated by _unpushed_commits(), which can
+    false-zero a detached HEAD via its three-dot content short-circuit
+    (e.g. a revert/merge commit unique to this worktree but content-equal
+    to origin/main would read as "0 unpushed" while still being the only
+    reachable pointer to that commit object).
+
+    Returns True iff a durable ref now exists pointing at HEAD (or dry-run).
+    False → caller MUST keep the worktree, never remove it.
+    """
+    ref = f"{QUARANTINE_REF_PREFIX}/{slug}-head"
+    if not apply:
+        logger.info(
+            "[dry-run] would preserve detached HEAD %s -> %s", worktree, ref,
+        )
+        return True
+    rev = _run_git(["rev-parse", "--verify", "HEAD"], cwd=worktree, check=False)
+    sha = rev.stdout.strip()
+    if rev.returncode != 0 or not sha:
+        logger.error(
+            "could not resolve HEAD for detached worktree %s (rc=%d) — "
+            "refusing to remove", worktree, rev.returncode,
+        )
+        return False
+    final_ref = _unique_ref(ref, sha)
+    updated = _run_git(["update-ref", final_ref, sha], check=False)
+    if updated.returncode != 0:
+        logger.error(
+            "update-ref failed for detached worktree %s -> %s (rc=%d) — "
+            "refusing to remove", worktree, final_ref, updated.returncode,
+        )
+        return False
+    logger.info(
+        "preserved detached HEAD %s -> %s (%s)", worktree, final_ref, sha[:10],
+    )
+    return True
 
 
 def _remove(worktree: Path, *, apply: bool) -> bool:
@@ -319,6 +467,11 @@ def gc(*, apply: bool, max_age_hours: float) -> int:
         return 0
 
     entries = _list_worktrees()
+    # Collected ONCE for the whole run — see _collect_live_cwds() docstring
+    # for why (round-2 fix: calling lsof per-worktree could cost ~17min
+    # cumulative worst-case across a large fleet).
+    live_cwds = _collect_live_cwds()
+
     # In dry-run these count what WOULD happen; in apply they count what DID.
     removed = 0
     quarantined = 0
@@ -347,7 +500,7 @@ def gc(*, apply: bool, max_age_hours: float) -> int:
             kept_active += 1
             continue
 
-        if _has_live_cwd(path):
+        if _has_live_cwd(path, live_cwds):
             logger.info("KEEP %s — live process cwd inside (active)", path_str)
             kept_active += 1
             continue
@@ -358,35 +511,48 @@ def gc(*, apply: bool, max_age_hours: float) -> int:
 
         slug = _slug(path_str)
         real_dirty = _has_real_dirty(path)
-        unpushed = _unpushed_commits(path, e.get("branch"))
-
-        # Detached HEAD with commits OR real dirty work → quarantine first.
-        needs_quarantine = real_dirty or (e.get("detached") and unpushed > 0)
+        is_detached = bool(e.get("detached"))
 
         # INVARIANT: this GC NEVER deletes a branch (no `git branch -D`/`-d`
         # anywhere in this file — grep to confirm). `git worktree remove`
-        # only removes the WORKING DIRECTORY; the branch ref — and every
-        # commit on it — survives untouched in refs/heads/ and is fully
-        # recoverable via `git worktree add <path> <branch>`. So a clean
-        # named branch's unpushed commits must NOT block dir reclamation
-        # (W88 cure, 2026-07-18): log for operator awareness, then fall
-        # through to removal below (no quarantine needed — the branch ref
-        # IS the durable copy).
-        if unpushed > 0 and not e.get("detached"):
-            logger.warning(
-                "RECLAIM-DIR %s — branch '%s' retains %d commit(s) not on "
-                "origin/main; dir reclaimed to free disk, branch ref "
-                "PRESERVED (resume with: git worktree add %s %s)",
-                path_str, e.get("branch"), unpushed, path_str, e.get("branch"),
-            )
-            reclaimed_unpushed += 1
+        # only removes the WORKING DIRECTORY.
+        #
+        # Preservation runs on TWO INDEPENDENT tracks; either can veto the
+        # remove. See module docstring rule 4 for the full rationale.
 
-        if needs_quarantine:
+        # Track 1: real uncommitted work → stash-quarantine (any worktree).
+        if real_dirty:
             if not _quarantine(path, slug, apply=apply):
                 logger.warning("KEEP %s — quarantine failed, refusing to remove",
                                path_str)
                 continue
             quarantined += 1
+
+        # Track 2a: detached HEAD → UNCONDITIONAL durable ref to HEAD before
+        # removal (BLOCKER B, round-2, 2026-07-18 — a clean detached-HEAD
+        # worktree has no branch ref, and _quarantine()'s stash-create is
+        # empty on a clean tree, so its commits would otherwise be orphaned).
+        if is_detached:
+            if not _preserve_detached_head(path, slug, apply=apply):
+                logger.warning(
+                    "KEEP %s — could not preserve detached HEAD, refusing "
+                    "to remove", path_str,
+                )
+                continue
+        else:
+            # Track 2b: named branch → the branch ref already preserves
+            # every commit (W88 cure, 2026-07-18): unpushed commits never
+            # block removal, just get logged for operator awareness.
+            unpushed = _unpushed_commits(path, e.get("branch"))
+            if unpushed > 0:
+                logger.warning(
+                    "RECLAIM-DIR %s — branch '%s' retains %d commit(s) not "
+                    "on origin/main; dir reclaimed to free disk, branch ref "
+                    "PRESERVED (resume with: git worktree add %s %s)",
+                    path_str, e.get("branch"), unpushed, path_str,
+                    e.get("branch"),
+                )
+                reclaimed_unpushed += 1
 
         if _remove(path, apply=apply):
             removed += 1

--- a/scripts/worktree_gc_universal.py
+++ b/scripts/worktree_gc_universal.py
@@ -67,6 +67,16 @@ scope. For each candidate it applies the panel's safety model:
      worktrees deleted on reboot (Pattern 7).
   7. dry-run by DEFAULT; --apply required to remove.
   8. Loop-bug alarm: WARN if it would remove > MAX_REMOVE_ALARM in one run.
+  9. G2_heartbeat (organ-conformance gene, round-3, 2026-07-18): every run
+     writes a JSON sidecar to ~/.organism/last_seen/<ORGAN_ID>.json (env
+     ORGANISM_LAST_SEEN_DIR overridable) via _heartbeat(), wired at the
+     single try/except/finally point in main() — status ok (with the real
+     removed/quarantined/reclaimed_unpushed/kept_active/phantom counters),
+     disabled (kill-switch), or error (exception summary). This is the
+     anti-blindness fix for the exact failure class this file's own history
+     is made of: the daily cron reaped 0 for days with zero external signal.
+     Registry entry: apps/organism/organism/organs_registry.yaml
+     id=pro.worktree_gc_universal.
 
 Kill switch: WORKTREE_GC_ENABLED=false → no-op exit 0.
 Run: python scripts/worktree_gc_universal.py [--apply] [--quiet]
@@ -74,13 +84,16 @@ Run: python scripts/worktree_gc_universal.py [--apply] [--quiet]
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import shutil
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger("worktree_gc_universal")
 
@@ -88,6 +101,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKTREES_DIR = REPO_ROOT / ".worktrees"
 STATE_FILENAME = ".agent-task.json"
 KILL_SWITCH_ENV = "WORKTREE_GC_ENABLED"
+
+# G2_heartbeat (organ-conformance gene, round-3 2026-07-18): the SAME string
+# as this organ's launchd Label (plist Label + registry recovery_params.label
+# + this ID — one string, three consumers, never three separately-maintained
+# copies). registry entry: apps/organism/organism/organs_registry.yaml
+# id=pro.worktree_gc_universal.
+ORGAN_ID = "com.nuzantara.worktree-gc-universal.daily"
 
 MIN_AGE_MIN = 15          # skip worktrees touched in the last 15 min (active)
 DEFAULT_MAX_AGE_HOURS = 24
@@ -101,6 +121,42 @@ ALLOWLIST_PATHS = {
     str(Path.home() / "Desktop" / "nuzantara-deploy"),
     str(Path.home() / "Desktop" / "nuzantara-crm-guardian-drive"),
 }
+
+
+def _heartbeat(status: str, detail: str = "") -> None:
+    """G2_heartbeat (organ-conformance gene, round-3 2026-07-18): proves this
+    organ ran — this exact blindness ("reaped 0 for days", nobody noticed) IS
+    the disease the round-1/2 fixes cured; this gene makes the NEXT such
+    blindness visible instead of silent (superscar #2, Esiste≠Armato).
+
+    Writes a JSON sidecar to <ORGANISM_LAST_SEEN_DIR or ~/.organism/last_seen>
+    /<ORGAN_ID>.json with {organ, status, ts, detail}. `status` is one of
+    ok|error|disabled. `detail` carries the real reap counters on success —
+    the anti-blindness payload a healer/receptor can actually read, not
+    regex-bait for a conformance gate.
+
+    Best-effort ONLY: any failure (permission, disk full, missing HOME, ...)
+    is swallowed here. A heartbeat write must NEVER crash the GC or change
+    its exit code — the GC's job is reaping worktrees, not proving liveness;
+    liveness is a side effect it must survive losing.
+    """
+    try:
+        sidecar_dir = Path(
+            os.environ.get("ORGANISM_LAST_SEEN_DIR")
+            or os.path.expanduser("~/.organism/last_seen")
+        )
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "organ": ORGAN_ID,
+            "status": status,
+            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "detail": detail,
+        }
+        (sidecar_dir / f"{ORGAN_ID}.json").write_text(
+            json.dumps(payload), encoding="utf-8",
+        )
+    except Exception as exc:  # noqa: BLE001 — heartbeat is best-effort, never fatal
+        logger.debug("heartbeat write failed (non-fatal): %s", exc)
 
 
 def _run_git(args, *, cwd=None, check=True):
@@ -461,10 +517,17 @@ def _slug(path: str) -> str:
     return path.rstrip("/").replace("/", "_").lstrip("_")[:80]
 
 
-def gc(*, apply: bool, max_age_hours: float) -> int:
+def gc(*, apply: bool, max_age_hours: float) -> dict[str, Any]:
+    """Run one GC pass. Returns a report dict — NOT a bare exit code — so
+    main() can wire a real G2 heartbeat from the actual counters (round-3,
+    2026-07-18) instead of a content-free "it ran" ping. Keys:
+    disabled (bool) — kill-switch short-circuit, all other keys absent;
+    otherwise removed/quarantined/reclaimed_unpushed/kept_active/phantom
+    (int) + apply (bool).
+    """
     if _kill_switch_active():
         logger.info("%s=false — GC disabled, no-op", KILL_SWITCH_ENV)
-        return 0
+        return {"disabled": True}
 
     entries = _list_worktrees()
     # Collected ONCE for the whole run — see _collect_live_cwds() docstring
@@ -573,7 +636,15 @@ def gc(*, apply: bool, max_age_hours: float) -> int:
         "phantom=%d apply=%s",
         removed, quarantined, reclaimed_unpushed, kept_active, pruned_phantom, apply,
     )
-    return 0
+    return {
+        "disabled": False,
+        "removed": removed,
+        "quarantined": quarantined,
+        "reclaimed_unpushed": reclaimed_unpushed,
+        "kept_active": kept_active,
+        "phantom": pruned_phantom,
+        "apply": apply,
+    }
 
 
 def main() -> int:
@@ -591,7 +662,32 @@ def main() -> int:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
         stream=sys.stdout,
     )
-    return gc(apply=args.apply, max_age_hours=args.max_age_hours)
+
+    # G2_heartbeat single wiring point (round-3, 2026-07-18): every exit path
+    # — disabled, ok, error — writes exactly one sidecar via this try/except/
+    # finally, never sprinkled per-callsite. `report` stays None only if
+    # gc() raised before returning, which is exactly the "error" case the
+    # except-block already handles; the finally-block's ok/disabled branch
+    # is then correctly skipped (no double-write).
+    report: dict[str, Any] | None = None
+    try:
+        report = gc(apply=args.apply, max_age_hours=args.max_age_hours)
+        return 0
+    except Exception as exc:  # noqa: BLE001 — heartbeat first, then re-raise visibly
+        _heartbeat("error", f"{type(exc).__name__}: {exc}")
+        raise
+    finally:
+        if report is not None:
+            if report.get("disabled"):
+                _heartbeat("disabled", "kill switch")
+            else:
+                detail = (
+                    f"removed={report['removed']} quarantined={report['quarantined']} "
+                    f"reclaimed_unpushed={report['reclaimed_unpushed']} "
+                    f"kept_active={report['kept_active']} phantom={report['phantom']} "
+                    f"apply={report['apply']}"
+                )
+                _heartbeat("ok", detail)
 
 
 if __name__ == "__main__":

--- a/scripts/worktree_gc_universal.py
+++ b/scripts/worktree_gc_universal.py
@@ -12,14 +12,32 @@ scope. For each candidate it applies the panel's safety model:
 
   1. NEVER touch the main checkout or known long-lived worktrees (allowlist).
   2. Age gate: skip if mtime < MIN_AGE_MIN (active session).
+  2b. Live-cwd gate: skip if any process on the machine has its cwd inside the
+      worktree (exact match OR a subdirectory) — a precise "active session"
+      signal the mtime-age gate alone misses (a shell idling deep in the tree
+      touches no file, so mtime never moves). Best-effort via `lsof`; missing
+      binary / any error → falls through to the age/dirty gates below, never
+      crashes the GC.
   3. Dirty classification: `git status --porcelain` AND a whitespace-insensitive
      diff. Pure formatting noise (Prettier/Black reflow) is NOT real work
      (W62: the 6 orphans were all formatting-only). Real dirty → QUARANTINE.
   4. Quarantine before removal: if a worktree has real uncommitted work OR is on
      a detached HEAD with commits, stash it onto refs/agent-quarantine/<slug>
      so nothing is lost, THEN remove. Never blind-delete dirty work.
-  5. Unpushed-commit gate: if the branch has commits not on origin, do NOT
-     remove — report for operator (a branch may be mid-PR).
+  5. Unpushed-commit handling (FIXED 2026-07-18 — cure for the W88 "kept
+     forever" bug: the daily cron reaped 0 for days, 53 worktrees / 55G
+     accumulated, because this gate hard-KEPT every named-branch worktree
+     with `rev-list origin/main..HEAD` > 0 — a proxy that inflated to
+     7779-7833 on divergent/rebased/squashed bases). A NAMED branch's
+     unpushed commits no longer block dir removal: `git worktree remove`
+     only deletes the WORKING DIRECTORY, never the branch ref — the branch
+     (and every commit on it) survives in refs/heads/ untouched and is fully
+     recoverable via `git worktree add <path> <branch>`. The GC logs a
+     RECLAIM-DIR line (operator awareness + the exact resume command) and
+     proceeds to remove the dir. This script NEVER runs `git branch -D`/`-d`
+     — grep the file to confirm the invariant holds. Detached HEAD with
+     unpushed commits is the one case still quarantined first (those commits
+     have no branch ref to fall back on if the dir goes away).
   6. `git worktree prune` at the end → clears phantom admin entries for /tmp
      worktrees deleted on reboot (Pattern 7).
   7. dry-run by DEFAULT; --apply required to remove.
@@ -155,11 +173,80 @@ def _has_real_dirty(worktree: Path) -> bool:
     return bool(diff.strip())
 
 
+def _has_live_cwd(worktree: Path) -> bool:
+    """True if any process on the machine has its cwd inside this worktree
+    (exact match OR a subdirectory) — a precise "active session" signal the
+    mtime-age gate alone misses (a shell idling deep in the tree touches no
+    file, so mtime never moves).
+
+    Implementation note (verified empirically on macOS, 2026-07-18): the
+    obvious `lsof -a -d cwd -Fn -- <dir>` form only matches an EXACT cwd —
+    a shell cd'd into a *subdirectory* of the worktree (e.g.
+    `<worktree>/apps/backend-rag`) is invisible to it. `lsof +D <dir>`
+    recursively walks the target directory's open files and would be
+    catastrophically slow on a large worktree (this GC exists because
+    worktrees grow to tens of GB). The reliable+cheap form: ask lsof for
+    EVERY process's cwd system-wide (`lsof -a -d cwd -Fn`, no path filter —
+    a syscall-table read, ~0.2s even on a busy box) and prefix-match the
+    paths in Python. That correctly catches both exact and nested cwds.
+
+    lsof missing/erroring/timing out → False (fall back to the age/dirty
+    gates; a live-cwd check must never crash or hang the GC).
+    """
+    try:
+        target = str(worktree.resolve())
+    except OSError:
+        target = str(worktree)
+    try:
+        out = subprocess.run(
+            ["lsof", "-a", "-d", "cwd", "-Fn"],
+            capture_output=True, text=True, timeout=20,
+        ).stdout
+    except Exception:
+        return False
+    prefix = target.rstrip("/") + "/"
+    for line in out.splitlines():
+        if not line.startswith("n"):
+            continue
+        name = line[1:]
+        if name == target or name.startswith(prefix):
+            return True
+    return False
+
+
 def _unpushed_commits(worktree: Path, branch: str | None) -> int:
     """Count commits on this worktree's HEAD not present on origin/main.
 
-    Conservative: any error → return 1 (treat as has-unpushed, keep it).
+    W88 CAVEAT: this is a PROXY, not a truth signal. `rev-list --count
+    origin/main..HEAD` inflates wildly on a divergent/rebased/squashed base
+    (verified 2026-07-18: 7779-7833 on health/repush/one-shot worktrees whose
+    content was long since squash-merged) — that inflation is exactly what
+    made the GC's old unpushed-gate KEEP-FOREVER (see gc()). Since 2026-07-18
+    this count is used ONLY to produce an operator-facing log number, never to
+    gate dir-removal for a named branch (a clean branch's commits survive in
+    the branch ref regardless of what this reports).
+
+    Honesty short-circuit: if `git diff --quiet origin/main...HEAD` (three-dot,
+    content since common ancestor) reports no difference, the branch is fully
+    merged BY CONTENT — return 0 even if rev-list would over-count. The
+    three-dot form has its own known failure mode post-squash (cicatrix #9,
+    the W88 double-trap: an arrears merge-base can make it report a phantom
+    difference) — but that failure only produces a false NON-zero, never a
+    false zero, so trusting a "no diff" (exit 0) verdict here is safe; we
+    never trust a "has diff" verdict as truth, we just fall through to the
+    raw, known-noisy rev-list count for the log line.
+
+    Conservative on error: any git failure → return 1 (log-line only, no
+    longer a keep/remove gate for named branches).
     """
+    try:
+        quiet = _run_git(
+            ["diff", "--quiet", "origin/main...HEAD"], cwd=worktree, check=False,
+        )
+        if quiet.returncode == 0:
+            return 0
+    except Exception:  # noqa: BLE001 — best-effort short-circuit, never fatal
+        pass
     try:
         # Use origin/main as the canonical upstream baseline.
         out = _run_git(
@@ -235,7 +322,7 @@ def gc(*, apply: bool, max_age_hours: float) -> int:
     # In dry-run these count what WOULD happen; in apply they count what DID.
     removed = 0
     quarantined = 0
-    kept_unpushed = 0
+    reclaimed_unpushed = 0
     kept_active = 0
     pruned_phantom = 0
     verb = "would " if not apply else ""
@@ -260,6 +347,11 @@ def gc(*, apply: bool, max_age_hours: float) -> int:
             kept_active += 1
             continue
 
+        if _has_live_cwd(path):
+            logger.info("KEEP %s — live process cwd inside (active)", path_str)
+            kept_active += 1
+            continue
+
         if age < max_age_hours * 3600:
             # Not old enough yet.
             continue
@@ -271,14 +363,23 @@ def gc(*, apply: bool, max_age_hours: float) -> int:
         # Detached HEAD with commits OR real dirty work → quarantine first.
         needs_quarantine = real_dirty or (e.get("detached") and unpushed > 0)
 
+        # INVARIANT: this GC NEVER deletes a branch (no `git branch -D`/`-d`
+        # anywhere in this file — grep to confirm). `git worktree remove`
+        # only removes the WORKING DIRECTORY; the branch ref — and every
+        # commit on it — survives untouched in refs/heads/ and is fully
+        # recoverable via `git worktree add <path> <branch>`. So a clean
+        # named branch's unpushed commits must NOT block dir reclamation
+        # (W88 cure, 2026-07-18): log for operator awareness, then fall
+        # through to removal below (no quarantine needed — the branch ref
+        # IS the durable copy).
         if unpushed > 0 and not e.get("detached"):
-            # Branch with unpushed commits — may be mid-PR. Keep + report.
             logger.warning(
-                "KEEP %s — branch '%s' has %d unpushed commit(s); not GC'd "
-                "(operator review)", path_str, e.get("branch"), unpushed,
+                "RECLAIM-DIR %s — branch '%s' retains %d commit(s) not on "
+                "origin/main; dir reclaimed to free disk, branch ref "
+                "PRESERVED (resume with: git worktree add %s %s)",
+                path_str, e.get("branch"), unpushed, path_str, e.get("branch"),
             )
-            kept_unpushed += 1
-            continue
+            reclaimed_unpushed += 1
 
         if needs_quarantine:
             if not _quarantine(path, slug, apply=apply):
@@ -302,9 +403,9 @@ def gc(*, apply: bool, max_age_hours: float) -> int:
         )
 
     logger.info(
-        "done: removed=%d quarantined=%d kept_unpushed=%d kept_active=%d "
+        "done: removed=%d quarantined=%d reclaimed_unpushed=%d kept_active=%d "
         "phantom=%d apply=%s",
-        removed, quarantined, kept_unpushed, kept_active, pruned_phantom, apply,
+        removed, quarantined, reclaimed_unpushed, kept_active, pruned_phantom, apply,
     )
     return 0
 


### PR DESCRIPTION
Armed-but-broken daily reaper (com.nuzantara.worktree-gc-universal.daily, --apply, 00:30) reaped 0 for days -> 53 worktrees/55G. Root cause: unpushed-commit gate hard-KEPT any named-branch worktree with rev-list origin/main..HEAD>0 -- a W88-inflated proxy (7779-7833 on divergent bases). git worktree remove preserves the branch ref, so reclaiming a clean worktree's dir loses zero commits; the gate was miscalibrated.

Round-1: decouple dir-removal from the unpushed gate (branch ref preserved), add lsof live-cwd guard, W88-honest counting, track the HOME-fork plist (scar #1).

Round-2 (Codex red-team caught 2 real BLOCKERs, both verified against live code):
- A: the live-cwd guard was INERT under the cron -- lsof lives only at /usr/sbin/lsof, not on the plist PATH -> silent fail-open (scar #2). Fix: _resolve_lsof_path (abs-path), single _collect_live_cwds() call, VISIBLE degradation warning, plist PATH += /usr/sbin.
- B: detached-HEAD clean worktrees could ORPHAN commits (_quarantine stash-create is empty on a clean tree). Fix: _preserve_detached_head refs HEAD before removal, unconditionally, False->keep.
- C: ref-collision guard.

Safety: branch refs NEVER deleted; detached HEADs ref'd before removal; dirty quarantined; live-cwd + age gates protect active worktrees. 37 tests incl. anti-orphan proof. Accepted residual: TOCTOU window (tiny; .husky/_ makes remove-without-force impractical). Installed Pro plist PATH fixed at deploy.