### PR TITLE
fix(kbli): lot runner — align m3 closed registry to calibration v2

### DIFF
--- a/infra/workflows/kbli-batch-a-lot.js
+++ b/infra/workflows/kbli-batch-a-lot.js
@@ -221,8 +221,10 @@ const CALIBRATION = {
     "code_collision",
     "illegitimate_inheritance",
     "wrong_authority_level",
-    "phantom_source_pointer",
     "source_absent_in_vault",
+    "payload_cross_contamination",
+    "unresolvable_source_pointer",
+    "mapping_metadata_false",
   ],
   m4_tokens_per_dossier_ceiling: 400000,
 };
@@ -267,8 +269,10 @@ const REFUTATION_CATEGORIES = [
   "code_collision",
   "illegitimate_inheritance",
   "wrong_authority_level",
-  "phantom_source_pointer",
   "source_absent_in_vault",
+  "payload_cross_contamination",
+  "unresolvable_source_pointer",
+  "mapping_metadata_false",
 ];
 
 const D1_SCHEMA = {
@@ -492,7 +496,8 @@ function d1Prompt(code) {
     `of the three out-of-scope facets above blocks your determination, set abstain={needed:true, ` +
     `facet:"<name>"} instead of guessing. If needs_quarantine=true, also set problem_category to the ` +
     `ONE closed-registry label (code_collision / illegitimate_inheritance / wrong_authority_level / ` +
-    `phantom_source_pointer / source_absent_in_vault) that best fits your reason — or the literal ` +
+    `source_absent_in_vault / payload_cross_contamination / unresolvable_source_pointer / ` +
+    `mapping_metadata_false) that best fits your reason — or the literal ` +
     `sentinel OTHER_NEW_CATEGORY if genuinely none fit (never invent a new label).`
   );
 }
@@ -698,9 +703,10 @@ async function adjudicateCode(code) {
   // the PARENT code 38220, not 38222 itself — self_confirmed.code_appears_in_row=false — and the
   // runner still emitted "certified" because nothing downstream of D2 ever looked at its own
   // self-confirmation result. The conductor caught it at D6 review; this closes the runner gap so
-  // the same class of miss can't reach "certified" again. Category=phantom_source_pointer (closed
-  // registry, plan §5 m3): "the cited row/source doesn't actually confirm the code" is precisely
-  // what a failed self-confirmation means.
+  // the same class of miss can't reach "certified" again. Category=unresolvable_source_pointer
+  // (closed registry, plan §5 m3, v2 label — renamed from phantom_source_pointer per plan A-5:
+  // text-hunt evidence cannot establish nonexistence): "the cited row/source doesn't actually
+  // confirm the code" is precisely what a failed self-confirmation means.
   const d2SelfConfirmFailed =
     d2 !== null &&
     (!d2.self_confirmed ||
@@ -712,7 +718,7 @@ async function adjudicateCode(code) {
   const quarantined = verdict === "quarantined";
   const category = quarantined
     ? d2SelfConfirmFailed
-      ? "phantom_source_pointer"
+      ? "unresolvable_source_pointer"
       : diff.category
     : null;
 

--- a/scripts/kbli_filiera/tests/test_lot_runner_contract.py
+++ b/scripts/kbli_filiera/tests/test_lot_runner_contract.py
@@ -45,6 +45,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LOT_RUNNER_JS = REPO_ROOT / "infra/workflows/kbli-batch-a-lot.js"
 CALIBRATION_JSON = REPO_ROOT / "data/kbli-filiera/batch-reports/batchA-calibration.json"
+CALIBRATION_V2_JSON = REPO_ROOT / "data/kbli-filiera/batch-reports/batchA-calibration-v2.json"
 
 
 @pytest.fixture(scope="module")
@@ -87,22 +88,32 @@ def test_m1_m2_m4_literals_match_calibration_artifact(js_source: str) -> None:
 
 
 def test_m3_closed_registry_matches_calibration_categories(js_source: str) -> None:
-    """m3's 5-category closed registry is pinned in the .js as a JS array — assert it appears
-    verbatim, independent of whether the calibration JSON has landed yet (the registry is quoted
-    in the plan doc too, so this half of the guard has no external-file dependency)."""
+    """m3's closed registry (v2, 7 categories — Lot 1 close-out: +payload_cross_contamination,
+    +mapping_metadata_false; phantom_source_pointer renamed unresolvable_source_pointer per plan
+    A-5) is pinned in the .js as a JS array — assert it appears verbatim, and that it matches the
+    v2 calibration artifact when present. The RETIRED v1 label must never reappear as a live
+    emittable literal (only inside comments explaining the rename)."""
     expected = [
         "code_collision",
         "illegitimate_inheritance",
         "wrong_authority_level",
-        "phantom_source_pointer",
         "source_absent_in_vault",
+        "payload_cross_contamination",
+        "unresolvable_source_pointer",
+        "mapping_metadata_false",
     ]
     for category in expected:
         assert f'"{category}"' in js_source, f"m3 category {category!r} missing from lot runner"
 
-    if CALIBRATION_JSON.exists():
-        calibration = json.loads(CALIBRATION_JSON.read_text(encoding="utf-8"))
-        assert calibration["control_limits"]["m3_refutation_categories"]["categories"] == expected
+    assert '"phantom_source_pointer"' not in js_source, (
+        "retired v1 label phantom_source_pointer still emittable in the lot runner — "
+        "v2 renamed it unresolvable_source_pointer (plan A-5)"
+    )
+
+    if CALIBRATION_V2_JSON.exists():
+        calibration = json.loads(CALIBRATION_V2_JSON.read_text(encoding="utf-8"))
+        v2 = calibration["control_limits"]["m3_refutation_categories"]["categories"]
+        assert sorted(v2) == sorted(expected)
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +291,7 @@ def test_guilt_d2_self_confirm_failure_retro_demotes_certified(js_source: str) -
         r'verdict\s*=\s*d2SelfConfirmFailed\s*\?\s*"quarantined"\s*:\s*preD2Verdict',
         js_source,
     ), "the final verdict is not gated on d2SelfConfirmFailed — retro-demote is not wired"
-    assert '"phantom_source_pointer"' in js_source
+    assert '"unresolvable_source_pointer"' in js_source
 
 
 def test_innocence_successful_d2_keeps_certified_verdict(js_source: str) -> None:


### PR DESCRIPTION
## Summary

The Lot 1 close-out extended the refutation-category registry (plan A-5 + conductor gate #2721): +`payload_cross_contamination` (the dominant Lot 1 disease), +`mapping_metadata_false`, and `phantom_source_pointer` renamed to `unresolvable_source_pointer` (text-hunt evidence cannot establish nonexistence). The runner still pinned the 5-category v1 list, so a Lot 2 seat emitting a v2 category would have been flagged out-of-registry, and the #2731 retro-demote emitted the retired v1 label.

- `CALIBRATION.m3_refutation_categories` + `REFUTATION_CATEGORIES` → v2 (7 categories)
- D1 prompt closed-registry enumeration → v2 labels
- D2 self-confirmation retro-demote emits `unresolvable_source_pointer`
- contract test: expected list → v2, retired-label guard (v1 label must never reappear as an emittable literal), drift-guard vs `batchA-calibration-v2.json` when present (skip-safe before #2740 lands)

## Test plan

- [x] `scripts/kbli_filiera/tests/test_lot_runner_contract.py`: 14 passed — both with and without the v2 calibration JSON present

## Adversarial review

Seat: **codex** — the v2 category set itself was adjudicated at the signed conductor gate (#2721, 3 refuter passes + full-report red-team); this PR mechanically aligns the runner's pinned literals to that already-gated registry, with the retired-label guard preventing regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)