### PR TITLE
fix(kbli): kg_kbli_license_fix writes licensing_status=PENDING_REGULATION on cure

### DIFF
--- a/apps/backend-rag/backend/scripts/kg_kbli_license_fix.py
+++ b/apps/backend-rag/backend/scripts/kg_kbli_license_fix.py
@@ -2,8 +2,10 @@
 kg_kbli_license_fix.py — remove collision/contaminated licensing (REQUIRES
 edges) from the Postgres knowledge graph for KBLI codes whose CANONICAL
 dataset record says there is no per-code licensing to show
-(`per_skala == []`), and re-sync the node's description/uraian off the same
-canonical record.
+(`per_skala == []`), re-sync the node's description/uraian off the same
+canonical record, AND mark `properties.licensing_status =
+"PENDING_REGULATION"` so the router stops defaulting a freshly-declared
+honest gap to "REGULATED".
 
 WHY (2026-07-16/17, PENDING-ARMS follow-up to #2508, extended for
 GARUDA-FILIERA Fase 1): `inspect_kbli 68112` returned REQUIRES-linked
@@ -45,6 +47,23 @@ trail that can go stale or get lost. Idempotent: a re-run that finds the
 edges already gone (current REQUIRES targets = []) does not touch — and
 does not blank — a `_disputed_requires` archive written by an earlier run.
 
+CLASS DEFECT FIXED THIS VERSION (2026-07-18, Lot 1 discovery): this script
+detached/archived the disputed REQUIRES edges and re-synced
+description/uraian, but never wrote `properties.licensing_status` — so a
+cured node has NO explicit key, and the router (`kbli_notebook.py`
+`props.get("licensing_status", "REGULATED")`) falls back to the default
+"REGULATED", presenting a freshly-declared honest gap as if it were still
+regulated. For the pilot's 8 codes and Lot 1's 13 codes this was patched
+with a one-shot ad-hoc write directly in prod, never versioned. This
+version closes that class of bug: every `per_skala_empty` cure ALSO sets
+`properties.licensing_status = "PENDING_REGULATION"` in the SAME UPDATE —
+idempotent, a re-run that finds it already `"PENDING_REGULATION"` is a
+declared no-op, same discipline as the `_disputed_requires` archive above.
+A code that is NOT a cure (`per_skala` non-empty/absent, `delete_all_requires
+= False`) never has this field touched — whatever `licensing_status` it
+already carries (or lacks) survives untouched, same as every other field
+outside the licensing-cure decision.
+
 WHAT IT DOES per `--only` code:
   1. Load the canonical record — see `--dataset` below for local-file vs
      URL.
@@ -65,7 +84,11 @@ WHAT IT DOES per `--only` code:
         where `properties.uraian` — which the router prefers over
         `description`, see `kbli_notebook.py` `props.get("uraian",
         node["description"])` — was never re-synced).
-     d. If the canonical record carries a `_data_note`, mirror it into
+     d. Set `properties.licensing_status = "PENDING_REGULATION"` in the
+        SAME UPDATE (idempotent: a value already `"PENDING_REGULATION"` is
+        a declared no-op) — the class-cure this version adds, see the
+        "CLASS DEFECT FIXED THIS VERSION" paragraph above.
+     e. If the canonical record carries a `_data_note`, mirror it into
         `properties._data_note` (never fabricated — only copied verbatim).
   Orphaned target nodes (0 remaining edges after the delete) are left in
   place, not deleted — conservative default, they are inert once nothing
@@ -129,6 +152,7 @@ class LicenseFixPlan:
     new_properties: dict | None = None
     update_node: bool = False
     skip_reason: str | None = None
+    licensing_status_note: str | None = None  # human-readable transition, set only for cures
 
 
 def plan_fix(
@@ -200,6 +224,24 @@ def plan_fix(
         # own per_skala_disputed_pp28_collision pattern (never silent-delete).
         new_props["_disputed_requires"] = disputed
 
+    licensing_status_note: str | None = None
+    if delete_all_requires:
+        # Class-cure (2026-07-18, Lot 1 discovery): a per_skala_empty gap is
+        # an honest "no licensing defined" verdict, but the router
+        # (`kbli_notebook.py` `props.get("licensing_status", "REGULATED")`)
+        # falls back to "REGULATED" whenever the key is absent — so every
+        # cured code needs its own explicit marker, not just detached edges.
+        # Idempotent: writing the same value again is a declared no-op (the
+        # note says so; the actual props dict ends up unchanged either way).
+        old_licensing_status = old_props.get("licensing_status")
+        if old_licensing_status == "PENDING_REGULATION":
+            licensing_status_note = "licensing_status already PENDING_REGULATION (no-op)"
+        else:
+            licensing_status_note = (
+                f"licensing_status: {old_licensing_status or 'missing'} -> PENDING_REGULATION"
+            )
+        new_props["licensing_status"] = "PENDING_REGULATION"
+
     old_description = kg_row["description"]
     description_stale = bool(uraian) and old_description != uraian
     props_stale = new_props != old_props
@@ -221,6 +263,7 @@ def plan_fix(
         new_properties=new_props if update_node else None,
         update_node=update_node,
         skip_reason=None if per_skala_empty else "per_skala non-empty (or absent) — no generic derivation path",
+        licensing_status_note=licensing_status_note,
     )
 
 
@@ -325,11 +368,12 @@ async def main() -> None:
 
             if plan.update_node:
                 logger.info(
-                    "  %s: would update description/properties.uraian (%d chars)%s%s",
+                    "  %s: would update description/properties.uraian (%d chars)%s%s%s",
                     code,
                     len(plan.new_description or ""),
                     " + _data_note" if plan.new_properties and plan.new_properties.get("_data_note") else "",
                     f" + _disputed_requires({len(plan.disputed_requires)})" if plan.disputed_requires else "",
+                    f" + {plan.licensing_status_note}" if plan.licensing_status_note else "",
                 )
                 if args.apply:
                     # W89 jsonb double-encoding class-guard: bind the pre-serialized
@@ -344,6 +388,12 @@ async def main() -> None:
                         plan.new_description,
                         json.dumps(plan.new_properties, ensure_ascii=False),
                     )
+            elif plan.licensing_status_note:
+                # delete_all_requires True but nothing at all changed this
+                # run (edges already gone, uraian/data_note already synced,
+                # licensing_status already PENDING_REGULATION) — declare the
+                # no-op explicitly rather than staying silent about it.
+                logger.info("  %s: %s (no other changes)", code, plan.licensing_status_note)
     finally:
         await conn.close()
 

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kg_kbli_license_fix.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kg_kbli_license_fix.py
@@ -62,6 +62,11 @@ def test_guilty_per_skala_empty_deletes_all_requires_and_archives_every_target()
     # untouched fields survive the merge
     assert plan.new_properties["pma_status"] == "TERBUKA"
     assert plan.skip_reason is None
+    # class-cure (2026-07-18): the node has no licensing_status key at all —
+    # the cure writes PENDING_REGULATION so the router stops defaulting to
+    # "REGULATED" on a freshly-declared honest gap.
+    assert plan.new_properties["licensing_status"] == "PENDING_REGULATION"
+    assert plan.licensing_status_note == "licensing_status: missing -> PENDING_REGULATION"
 
 
 def test_guilty_with_no_current_edges_still_marks_delete_all_requires_but_no_archive():
@@ -76,13 +81,19 @@ def test_guilty_with_no_current_edges_still_marks_delete_all_requires_but_no_arc
     # _disputed_requires key (nothing to archive this run).
     assert plan.update_node is True
     assert "_disputed_requires" not in plan.new_properties
+    # licensing_status is still written even with zero edges to archive —
+    # it is gated on delete_all_requires (the per_skala verdict), not on
+    # whether this particular run found edges to delete.
+    assert plan.new_properties["licensing_status"] == "PENDING_REGULATION"
 
 
 def test_idempotent_rerun_after_edges_already_deleted_does_not_touch_prior_archive():
     """Second run: edges are already gone (current_requires_targets=[]) and
     the node was already fully synced by a prior run, including a
-    _disputed_requires archive from that run. Must be a total no-op —
-    critically, must NOT overwrite/blank the existing archive."""
+    _disputed_requires archive AND a licensing_status=PENDING_REGULATION
+    write from that run. Must be a total no-op — critically, must NOT
+    overwrite/blank the existing archive, and the licensing_status
+    re-write must be declared a no-op, not silently skipped."""
     already_synced_row = {
         "description": CANONICAL_CURED["uraian"],
         "properties": {
@@ -90,6 +101,7 @@ def test_idempotent_rerun_after_edges_already_deleted_does_not_touch_prior_archi
             "pma_status": "TERBUKA",
             "_data_note": CANONICAL_CURED["_data_note"],
             "_disputed_requires": MIXED_TARGETS,  # archived by the first run
+            "licensing_status": "PENDING_REGULATION",  # written by the first run
         },
     }
 
@@ -100,6 +112,7 @@ def test_idempotent_rerun_after_edges_already_deleted_does_not_touch_prior_archi
     assert plan.update_node is False
     assert plan.new_properties is None
     assert plan.new_description is None
+    assert plan.licensing_status_note == "licensing_status already PENDING_REGULATION (no-op)"
 
 
 def test_innocent_per_skala_non_empty_refuses_edge_deletion():
@@ -115,6 +128,29 @@ def test_innocent_per_skala_non_empty_refuses_edge_deletion():
     assert plan.update_node is True
     assert plan.new_properties is not None
     assert "_disputed_requires" not in plan.new_properties
+    # NOT a cure (per_skala non-empty) — licensing_status is never touched,
+    # even though the text sync happens.
+    assert plan.licensing_status_note is None
+    assert "licensing_status" not in plan.new_properties
+
+
+def test_innocent_per_skala_non_empty_leaves_existing_licensing_status_untouched():
+    """A code that is NOT a detached/cured gap (per_skala non-empty) may
+    already carry its OWN licensing_status (e.g. a legacy "REGULATED" value
+    unrelated to this cure) — the class-cure only ever writes
+    PENDING_REGULATION for per_skala==[] codes; a non-detached code's
+    existing value must survive the merge byte-for-byte."""
+    record = dict(CANONICAL_CURED, per_skala=[{"skala_usaha": ["Menengah"]}])
+    row = {
+        "description": KG_ROW_STALE["description"],
+        "properties": dict(KG_ROW_STALE["properties"], licensing_status="REGULATED"),
+    }
+
+    plan = plan_fix("51103", record, row, MIXED_TARGETS)
+
+    assert plan.delete_all_requires is False
+    assert plan.licensing_status_note is None
+    assert plan.new_properties["licensing_status"] == "REGULATED"
 
 
 def test_innocent_per_skala_key_entirely_absent_treated_as_non_empty():
@@ -124,12 +160,17 @@ def test_innocent_per_skala_key_entirely_absent_treated_as_non_empty():
 
     assert plan.delete_all_requires is False
     assert plan.skip_reason is not None and "non-empty" in plan.skip_reason
+    assert plan.licensing_status_note is None
 
 
 def test_innocent_already_clean_node_is_full_noop_except_edge_flag():
     clean_row = {
         "description": CANONICAL_CURED["uraian"],
-        "properties": {"uraian": CANONICAL_CURED["uraian"], "_data_note": CANONICAL_CURED["_data_note"]},
+        "properties": {
+            "uraian": CANONICAL_CURED["uraian"],
+            "_data_note": CANONICAL_CURED["_data_note"],
+            "licensing_status": "PENDING_REGULATION",
+        },
     }
 
     plan = plan_fix("51103", CANONICAL_CURED, clean_row, [])
@@ -138,6 +179,7 @@ def test_innocent_already_clean_node_is_full_noop_except_edge_flag():
     assert plan.new_properties is None
     assert plan.new_description is None
     assert plan.delete_all_requires is True  # still checked/attempted, idempotent — no edges exist
+    assert plan.licensing_status_note == "licensing_status already PENDING_REGULATION (no-op)"
 
 
 def test_skip_code_missing_from_canonical_dataset():


### PR DESCRIPTION
## Summary

- `kg_kbli_license_fix.py` detaches contaminated REQUIRES edges and archives them into `properties._disputed_requires`, but never wrote `properties.licensing_status` — so a cured node has no explicit key, and the router (`kbli_notebook.py:474`, `props.get("licensing_status", "REGULATED")`) falls back to `"REGULATED"`, presenting a freshly-declared honest gap as if it were still regulated.
- For the pilot's 8 codes and Lot 1's 13 codes this was patched with a one-shot ad-hoc write directly in prod, never versioned. This PR closes the class defect: every `per_skala_empty` cure now sets `properties.licensing_status = "PENDING_REGULATION"` in the SAME `UPDATE` as the existing `_disputed_requires` archive / uraian / description resync — no second roundtrip.
- Idempotent by construction: a re-run against a node already carrying `licensing_status == "PENDING_REGULATION"` is a declared no-op (dry-run reports `licensing_status already PENDING_REGULATION (no-op)`; no DB write if nothing else changed either).
- Non-cure codes (`per_skala` non-empty or absent — `delete_all_requires = False`) never have the field touched, whatever value (or absence) they already carry.
- Docstring updated (module header, new "CLASS DEFECT FIXED THIS VERSION" paragraph, and the `WHAT IT DOES` step list) — it previously enumerated exactly the fields the script touches and licensing_status wasn't among them.

## Test plan

- [x] Extended `backend/tests/unit/scripts/test_kg_kbli_license_fix.py` (pure `plan_fix` unit tests, no DB/network):
  - guilt: node missing `licensing_status` → written to `PENDING_REGULATION` (both with and without current edges to archive)
  - innocence: node already `PENDING_REGULATION` + nothing else drifted → full no-op, declared via `licensing_status_note`
  - innocence: non-cure code (`per_skala` non-empty) with a pre-existing DIFFERENT `licensing_status` (e.g. `"REGULATED"`) → survives untouched
  - innocence: non-cure code with no `licensing_status` at all → field never added
- [x] `PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/scripts/test_kg_kbli_license_fix.py -v` → 12/12 passed
- [x] `ruff check` on both changed files → clean
- [x] No DB/prod calls made — all verification is against the pure `plan_fix` decision function with mocked dicts

## Adversarial review

Seat: **codex** — mechanical class-cure of an already-adjudicated honesty gap; guilt+innocence tests pin the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)