### PR TITLE
fix(intel): poller translations through bot-branch/PR flow — kill the orphan-committer

### DIFF
--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -334,6 +334,11 @@ def flush_layout_batch() -> bool:
     return _flush_batch("layout", "bot/homepage-layout", "chore(homepage): hero rotation {date}")
 
 
+def flush_translation_batch() -> bool:
+    return _flush_batch("translation", "bot/articles-translations",
+                         "feat(articles): add translations {date} ({n} files)")
+
+
 _FLUSH_THRESHOLD = 8
 
 
@@ -824,37 +829,54 @@ def git_pull_monorepo():
         log(f"⚠ git pull error: {e}")
 
 
-def git_commit_and_push_translations(slugs: list[str]):
+def git_commit_and_push_translations(slugs: list[str]) -> bool:
+    """Stage translation .mdx files and flush via the same batch-branch/PR
+    mechanism as flush_image_batch/flush_seo_batch/flush_layout_batch (see the
+    "GitHub batch-branch/PR commit mechanism" module note above `_stage_commit`).
+
+    Direct `git push origin main` (the old mechanism) is rejected by branch
+    protection EVERY time — and it doesn't fail loudly: the commit lands on the
+    main checkout regardless (git commit succeeds locally), then the push is
+    bounced, leaving an orphan local commit that blocks the next `git pull
+    --ff-only` for every subsequent tick until someone rescues it by hand
+    (live incident 2026-07-18: commits e2c3951c/be43e312d, both rescued
+    manually twice in one day). This function NEVER runs `git add`/`git
+    commit`/`git push` on the main checkout — files are read straight off disk
+    (translate_articles.py already wrote them there) and committed via the
+    GitHub Contents API on a bot branch, exactly like every other write path
+    in this module.
+
+    On any failure (branch create, PUT, PR create) `_flush_batch` logs the gh
+    failure and this returns False. Nothing was ever `git add`-ed, so the
+    local .mdx files are simply left untracked on disk — the next tick's
+    rglob picks them straight back up and re-stages them. No local git state
+    to unwind, no orphan commit possible.
+    """
     repo_root = SCRIPT_DIR.parent.parent.parent
     articles_dir = repo_root / "apps" / "mouth" / "src" / "content" / "articles"
 
-    translation_files = []
+    translation_files: list[Path] = []
     for slug in slugs:
         for f in articles_dir.rglob(f"{slug}.*.mdx"):
-            translation_files.append(str(f.relative_to(repo_root)))
+            translation_files.append(f)
 
     if not translation_files:
         log("⚠ No translation files to commit")
-        return
+        return True
 
-    log(f"▶ git commit+push {len(translation_files)} translation files")
-    try:
-        subprocess.run(["git", "add"] + translation_files, cwd=str(repo_root), capture_output=True, check=True, timeout=30)
-        status = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=str(repo_root), capture_output=True, timeout=10)
-        if status.returncode == 0:
-            log("⏭ Nothing staged — already committed")
-            return
-        msg = f"feat(articles): add translations for {', '.join(slugs[:3])}{'...' if len(slugs) > 3 else ''}"
-        subprocess.run(["git", "commit", "--no-verify", "-m", msg], cwd=str(repo_root), capture_output=True, check=True, timeout=30)
-        push = subprocess.run(["git", "push", "--no-verify", "origin", "main"], cwd=str(repo_root), capture_output=True, text=True, timeout=60)
-        if push.returncode == 0:
-            log("✅ Translations pushed")
-        else:
-            subprocess.run(["git", "pull", "--rebase", "origin", "main"], cwd=str(repo_root), capture_output=True, timeout=60)
-            push2 = subprocess.run(["git", "push", "--no-verify", "origin", "main"], cwd=str(repo_root), capture_output=True, text=True, timeout=60)
-            log(f"{'✅' if push2.returncode == 0 else '❌'} Push after rebase: exit={push2.returncode}")
-    except Exception as e:
-        log(f"⚠ git push translations failed: {e}")
+    message = f"feat(articles): add translations for {', '.join(slugs[:3])}{'...' if len(slugs) > 3 else ''}"
+    log(f"▶ Staging {len(translation_files)} translation file(s) for batch commit")
+    for f in translation_files:
+        gh_path = str(f.relative_to(repo_root))
+        try:
+            content = f.read_bytes()
+        except OSError as e:
+            log(f"  ⚠ Could not read {gh_path}: {e}")
+            continue
+        _stage_commit("translation", gh_path, content, message)
+        log(f"  📦 staged → {gh_path}")
+
+    return flush_translation_batch()
 
 
 # ─── MAIN ──────────────────────────────────────────────────────────────────────
@@ -971,9 +993,14 @@ def main():
             f"layout={layout_flush_ok}) — see log"
         )
 
-    # Commit translations
+    # Commit translations — staged + flushed via the same batch-branch/PR
+    # mechanism as image/seo/layout (see git_commit_and_push_translations).
     if translated_slugs:
-        git_commit_and_push_translations(translated_slugs)
+        if not git_commit_and_push_translations(translated_slugs):
+            send_telegram_alert(
+                "⚠️ *Post-publish poller*\n"
+                f"Translation batch flush failed for: {', '.join(translated_slugs[:5])}"
+            )
 
     # Mark done
     if done_slugs:

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -264,6 +264,155 @@ class TestFlushLayoutBatch:
         assert title.startswith("chore(homepage): hero rotation ")
 
 
+# ── git_commit_and_push_translations (translations batch-branch/PR flow) ───
+#
+# Regression coverage: the poller used to `git add` + `git commit --no-verify`
+# + `git push --no-verify origin main` directly on the main checkout. Branch
+# protection rejects that push every time, but the commit had already landed
+# locally — leaving an orphan commit that blocks every subsequent tick's
+# `git pull --ff-only` until rescued by hand (live incident 2026-07-18:
+# commits e2c3951c/be43e312d, both rescued manually the same day). The fix
+# routes translations through the same batch-branch/PR mechanism as
+# image/seo/layout — never touching local git state at all.
+
+
+def _write_translation_file(tmp_path, slug, lang, category="business", content="---\nfoo\n---\nbody"):
+    articles_dir = tmp_path / "apps" / "mouth" / "src" / "content" / "articles" / category
+    articles_dir.mkdir(parents=True, exist_ok=True)
+    f = articles_dir / f"{slug}.{lang}.mdx"
+    f.write_text(content, encoding="utf-8")
+    return f
+
+
+def _fake_repo_root(tmp_path, monkeypatch):
+    """Point ppp.SCRIPT_DIR at tmp_path/apps/bali-intel-scraper/scripts so
+    SCRIPT_DIR.parent.parent.parent (repo_root inside the function) resolves
+    to tmp_path — lets us stage real files without touching the real repo."""
+    fake_script_dir = tmp_path / "apps" / "bali-intel-scraper" / "scripts"
+    fake_script_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(ppp, "SCRIPT_DIR", fake_script_dir)
+
+
+class TestGitCommitAndPushTranslations:
+    def test_never_invokes_git_push_or_commit_to_main(self, tmp_path, monkeypatch):
+        """GUILT: the translations flow must never shell out to git at all —
+        no `git add`, no `git commit`, no `git push ... main`. Everything goes
+        through the gh-api batch-branch/PR mechanism instead."""
+        _fake_repo_root(tmp_path, monkeypatch)
+        _write_translation_file(tmp_path, "test-slug", "fr")
+
+        calls = []
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=_happy_path_fake_run(calls)):
+            ok = ppp.git_commit_and_push_translations(["test-slug"])
+
+        assert ok is True
+        git_calls = [c for c in calls if c["cmd"] and c["cmd"][0] == "git"]
+        assert git_calls == []  # zero direct git subprocess invocations
+        push_main_calls = [c for c in calls if "push" in c["cmd"] and "main" in c["cmd"]]
+        assert push_main_calls == []
+
+    def test_uses_translations_branch_prefix_and_gh_pr_create(self, tmp_path, monkeypatch):
+        """INNOCENCE: expected behavior is the same batch-branch/PR mechanism
+        as image/seo/layout — branch prefix bot/articles-translations, one
+        gh api PUT per staged file, gh pr create + --auto --squash arm."""
+        _fake_repo_root(tmp_path, monkeypatch)
+        _write_translation_file(tmp_path, "test-slug", "fr")
+        _write_translation_file(tmp_path, "test-slug", "ru")
+
+        calls = []
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=_happy_path_fake_run(calls)):
+            ok = ppp.git_commit_and_push_translations(["test-slug"])
+
+        assert ok is True
+        assert ppp._PENDING_COMMITS == []  # drained by the flush
+
+        import json as _json
+
+        create_ref_calls = [
+            c for c in calls
+            if c["cmd"][:2] == ["gh", "api"] and c["cmd"][2].endswith("/git/refs") and "POST" in c["cmd"]
+        ]
+        assert len(create_ref_calls) == 1
+        ref_payload = _json.loads(create_ref_calls[0]["kwargs"]["input"])
+        assert ref_payload["ref"].startswith("refs/heads/bot/articles-translations-")
+
+        pr_create_calls = [c for c in calls if c["cmd"][:3] == ["gh", "pr", "create"]]
+        pr_merge_calls = [c for c in calls if c["cmd"][:3] == ["gh", "pr", "merge"]]
+        assert len(pr_create_calls) == 1
+        assert len(pr_merge_calls) == 1
+        assert "--auto" in pr_merge_calls[0]["cmd"]
+        assert "--squash" in pr_merge_calls[0]["cmd"]
+
+        title = pr_create_calls[0]["cmd"][pr_create_calls[0]["cmd"].index("--title") + 1]
+        assert title.startswith("feat(articles): add translations ")
+
+        put_calls = [c for c in calls if "/contents/" in c["cmd"][2] and "PUT" in c["cmd"]]
+        assert len(put_calls) == 2  # both translation files staged+committed
+        for pc in put_calls:
+            payload = _json.loads(pc["kwargs"]["input"])
+            assert payload["message"].startswith("feat(articles): add translations for test-slug")
+            assert payload["branch"].startswith("bot/articles-translations-")
+
+    def test_no_files_found_is_noop_returns_true(self, tmp_path, monkeypatch, _silence_log):
+        _fake_repo_root(tmp_path, monkeypatch)
+
+        calls = []
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=_happy_path_fake_run(calls)):
+            ok = ppp.git_commit_and_push_translations(["nonexistent-slug"])
+
+        assert ok is True
+        assert calls == []
+        assert any("No translation files to commit" in m for m in _silence_log)
+
+    def test_flush_failure_returns_false_and_never_touches_local_git_state(self, tmp_path, monkeypatch, _silence_log):
+        """On a flush failure the function must return False and the .mdx file
+        must remain untouched on disk — no git add/commit ever ran, so the
+        next tick's rglob picks it right back up and re-stages it."""
+        _fake_repo_root(tmp_path, monkeypatch)
+        f = _write_translation_file(tmp_path, "test-slug", "fr")
+
+        def fake_run(cmd, **kwargs):
+            s = " ".join(cmd)
+            if "git/refs/heads/main" in s:
+                return _res(stdout="deadbeef\n")
+            if s.endswith("git/refs --method POST --input -"):
+                return _res(returncode=1, stderr="422 Reference already exists")
+            return _res(returncode=0)
+
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=fake_run):
+            ok = ppp.git_commit_and_push_translations(["test-slug"])
+
+        assert ok is False
+        assert f.exists()
+        assert f.read_text(encoding="utf-8") == "---\nfoo\n---\nbody"  # untouched
+        assert any("Reference already exists" in m for m in _silence_log)
+
+
+class TestFlushTranslationBatch:
+    def test_uses_distinct_branch_prefix_and_title(self):
+        ppp._stage_commit(
+            "translation", "apps/mouth/src/content/articles/business/foo.fr.mdx", b"---\n---\nbody",
+            "feat(articles): add translations for foo",
+        )
+        calls = []
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=_happy_path_fake_run(calls)):
+            ok = ppp.flush_translation_batch()
+
+        assert ok is True
+        create_ref_calls = [
+            c for c in calls
+            if c["cmd"][:2] == ["gh", "api"] and c["cmd"][2].endswith("/git/refs") and "POST" in c["cmd"]
+        ]
+        import json as _json
+
+        ref_payload = _json.loads(create_ref_calls[0]["kwargs"]["input"])
+        assert ref_payload["ref"].startswith("refs/heads/bot/articles-translations-")
+
+        pr_create_calls = [c for c in calls if c["cmd"][:3] == ["gh", "pr", "create"]]
+        title = pr_create_calls[0]["cmd"][pr_create_calls[0]["cmd"].index("--title") + 1]
+        assert title.startswith("feat(articles): add translations ")
+
+
 # ── rotate_hero (homepage-layout.json write path) ──────────────────────────
 #
 # Regression coverage: rotate_hero() used to PUT apps/mouth/src/content/


### PR DESCRIPTION
## Summary

`git_commit_and_push_translations()` used to `git add` + `commit --no-verify` + `push --no-verify origin main` directly on the Desktop main checkout. Branch protection rejects that push EVERY time — but only after the commit already landed locally, leaving an orphan commit that blocks every subsequent `git pull --ff-only` on Pro AND Mini (which mirrors pro/main). Live incident 2026-07-18: TWO orphans in one day (e2c3951c 17:12, be43e312d 19:15), both rescued by hand via #2730/#2748.

## Cure

Reroute translations through the exact mechanism the module already uses for image/seo/layout writes: `_stage_commit`/`_flush_batch` with branch prefix `bot/articles-translations` — files read straight off disk, committed via the GitHub Contents API on a bot branch, PR auto-merge armed. Zero `git add/commit/push` subprocess calls remain in the translations path (the only residual git calls in the module are the read-side ff-only pull in `git_pull_monorepo`). On flush failure nothing was ever git-added, so the `.mdx` files stay untracked and the next tick's rglob re-stages them — no local state to unwind, no orphan possible. Flush failure now also fires a Telegram alert (same pattern as the other batches).

## Verification

- 5 new guilt+innocence tests (`test_never_invokes_git_push_or_commit_to_main`, branch-prefix + `gh pr create` + `--auto --squash` assertions, no-files noop, flush-failure-leaves-git-untouched) — 24/24 green, independently re-run by the orchestrating session (generator≠grader).
- Generator diagnosis + both rescue PRs documented in the S1 TAC report (#2715) and ledgered (#2749).

🤖 Generated with [Claude Code](https://claude.com/claude-code)