### PR TITLE
feat(visa-engine): PR1b — port-list hardening (canonical dates, STAGE_ORDER, StrictBool, CodeQL pattern, parity pin)

### DIFF
--- a/apps/backend-rag/backend/services/visa_engine/compiler.py
+++ b/apps/backend-rag/backend/services/visa_engine/compiler.py
@@ -79,8 +79,10 @@ from __future__ import annotations
 
 import re
 import unicodedata
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
+from datetime import date
+from types import MappingProxyType
 
 from backend.services.visa_engine import ast as ast_module
 from backend.services.visa_engine.enums import FactValueKind, RuleEffectType, RuleStage
@@ -109,6 +111,43 @@ _PRESENCE_ONLY_OPERATORS = frozenset({"known", "unknown"})
 #: `Field` constraint (bypass-proof re-check, see module docstring).
 _MAX_RULES = 4096
 _MAX_PRODUCTS = 256
+
+#: PR1b item 2 (semantic STAGE_ORDER, arbitrated 2026-07-18 comparative
+#: review of the now-closed reference tree PR #2718): matches
+#: ``enums.RuleStage``'s OWN declaration order — spec (research/visa/2026-
+#: 07-17-visa-oracle-v2-round2-codex-engine-concretization.md §1 ``enums.py``
+#: lines 93-97, mirrored by the JSON Schema enum) — which is also §5.3's
+#: evaluation order: HARD_FILTER -> ELIGIBILITY -> HUMAN_REVIEW -> RANKING.
+#: Deliberately NOT the reference tree's own inverted HARD_FILTER ->
+#: HUMAN_REVIEW -> ELIGIBILITY -> RANKING sequence (rejected by the
+#: arbitrated port-list gate as non-spec-grounded). Used to sort rules
+#: before every per-rule check below runs, so ``CompilationReport.errors``
+#: is deterministic and stage-semantic within any single check — independent
+#: of a RulePack author's arbitrary ``rules`` array declaration order.
+#: ``MappingProxyType`` (not a plain ``dict``), matching this module's other
+#: engine-wide invariant tables (``models.STAGE_EFFECT_TYPE``) — a shared
+#: mutable dict would be a runtime footgun for any caller holding a reference.
+STAGE_ORDER: Mapping[RuleStage, int] = MappingProxyType(
+    {
+        RuleStage.HARD_FILTER: 0,
+        RuleStage.ELIGIBILITY: 1,
+        RuleStage.HUMAN_REVIEW: 2,
+        RuleStage.RANKING: 3,
+    }
+)
+
+
+def _stage_sort_key(rule: Rule) -> tuple[int, str]:
+    """``STAGE_ORDER`` first, ``rule_id`` second — full determinism even
+    when two rules share a stage (a RulePack's ``rules`` array declaration
+    order is not a stable tiebreaker to depend on)."""
+    return (STAGE_ORDER[rule.stage], rule.rule_id)
+
+
+def _sorted_rules_by_stage(rules: Iterable[Rule]) -> tuple[Rule, ...]:
+    """Sort ``rules`` by ``_stage_sort_key`` for deterministic, stage-
+    semantic traversal by every per-rule check in ``compile_rule_pack``."""
+    return tuple(sorted(rules, key=_stage_sort_key))
 
 
 @dataclass(frozen=True, slots=True)
@@ -196,19 +235,31 @@ def compile_rule_pack(
     # check can be handed a `model_construct`-smuggled structure.
     pack = revalidated
     payload = pack.payload
+    # PR1b item 2: every check below that emits a rule_id-attributed error
+    # iterates the STAGE_ORDER-sorted `stage_sorted_rules`, not `payload.rules`
+    # directly — see STAGE_ORDER's docstring. This includes product/source
+    # reference integrity and SUPPORT-purpose coverage (Codex xhigh
+    # independent review residual: these three were originally missed —
+    # they read `payload.rules` for their OWN products/source_records
+    # iteration too, but their RULE-side loop needs the same sort as every
+    # other per-rule check). Genuinely rule-order-independent checks (ID
+    # uniqueness, UTC/NFC over the signed payload, size limits) correctly
+    # keep reading `payload` unsorted — those never attribute an error to a
+    # specific `rule_id` position.
+    stage_sorted_rules = _sorted_rules_by_stage(payload.rules)
 
     _check_header_environment(pack, errors)
-    _check_ast_limits(payload.rules, errors)
-    _check_required_facts_match_condition(payload.rules, errors)
-    _check_required_facts_in_registry(payload.rules, fact_registry, errors)
-    _check_no_commercial_facts_in_legal_stages(payload.rules, fact_registry, errors)
-    _check_ranking_facts_commercial_only(payload.rules, fact_registry, errors)
-    _check_eligibility_not_presence_only(payload.rules, errors)
-    _check_stage_effect_compatibility(payload.rules, errors)
-    _check_fact_literal_kind(payload.rules, fact_registry, errors)
-    _check_product_reference_integrity(payload, errors)
-    _check_source_reference_integrity(payload, errors)
-    _check_support_purposes_on_product(payload, errors)
+    _check_ast_limits(stage_sorted_rules, errors)
+    _check_required_facts_match_condition(stage_sorted_rules, errors)
+    _check_required_facts_in_registry(stage_sorted_rules, fact_registry, errors)
+    _check_no_commercial_facts_in_legal_stages(stage_sorted_rules, fact_registry, errors)
+    _check_ranking_facts_commercial_only(stage_sorted_rules, fact_registry, errors)
+    _check_eligibility_not_presence_only(stage_sorted_rules, errors)
+    _check_stage_effect_compatibility(stage_sorted_rules, errors)
+    _check_fact_literal_kind(stage_sorted_rules, fact_registry, errors)
+    _check_product_reference_integrity(payload, stage_sorted_rules, errors)
+    _check_source_reference_integrity(payload, stage_sorted_rules, errors)
+    _check_support_purposes_on_product(payload, stage_sorted_rules, errors)
     _check_unique_ids(payload, errors)
     _check_utc_and_nfc(payload, errors)
     _check_pack_size_limits(payload, errors)
@@ -554,6 +605,23 @@ _ORDERING_OPS = frozenset({"lt", "lte", "gt", "gte"})
 #: shape, never a single literal's shape).
 _SCALAR_FACT_KINDS = frozenset({FactValueKind.BOOLEAN, FactValueKind.INTEGER, FactValueKind.STRING})
 
+#: PR1b item 1 (ported from the reference tree's comparative review, adapted
+#: to this tree's structure — see ``_is_date_typed``'s docstring for why
+#: ``FactSpec.kind`` alone cannot make this distinction): a date-typed
+#: fact's literal must be a canonical ISO-8601 calendar-date string
+#: (``YYYY-MM-DD``). ``date.fromisoformat`` (Python 3.11) ALSO accepts
+#: compact (``YYYYMMDD``) and ISO week-date (``YYYY-Www-D``) forms, which
+#: then compare LEXICOGRAPHICALLY WRONG against the canonical
+#: ``YYYY-MM-DD`` strings a real fact snapshot stores (PR3's evaluator), so
+#: the shape must be checked in addition to calendar validity. Uses
+#: ``[0-9]`` (not ``\d``, which also matches non-ASCII Unicode decimal
+#: digits under Python's default ``re.UNICODE`` mode) checked via
+#: ``fullmatch`` (not ``^...$``, where ``$`` also matches just before a
+#: trailing newline) — Codex xhigh independent review exactness suggestion:
+#: the regex alone should express the full contract rather than relying on
+#: ``date.fromisoformat`` to reject what a looser pattern would let through.
+_CANONICAL_ISO_DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
+
 
 def _literal_kind(value: bool | int | str) -> FactValueKind:
     # `bool` before `int` — `bool` is an `int` subclass in Python.
@@ -562,6 +630,56 @@ def _literal_kind(value: bool | int | str) -> FactValueKind:
     if isinstance(value, int):
         return FactValueKind.INTEGER
     return FactValueKind.STRING
+
+
+def _is_date_typed(spec: FactSpec) -> bool:
+    """PR1b item 1: distinguishes a date-typed fact from a generic STRING
+    fact. ``FactSpec.kind`` alone cannot — both are ``FactValueKind.STRING``
+    by design (``enums.FactValueKind``'s own docstring: "``STRING`` also
+    covers ISO-8601 dates ... no separate ``DATE`` kind is needed for
+    structural (non-evaluating) validation"). ``FactSpec.value_type`` is the
+    free-text label ``fact_registry.py`` seeds with ``"date"`` for every
+    date-shaped path — that label is what this compiler-only invariant
+    hooks into.
+    """
+    return spec.value_type == "date"
+
+
+def _check_date_literal_format(
+    value: str, spec: FactSpec, op: str, rule: Rule, errors: list[CompilationError]
+) -> None:
+    """PR1b item 1: reject a date-typed fact's literal unless it is BOTH
+    shaped like ``YYYY-MM-DD`` (see ``_CANONICAL_ISO_DATE_RE``'s docstring)
+    AND a calendar-valid date."""
+    if _CANONICAL_ISO_DATE_RE.fullmatch(value) is None:
+        errors.append(
+            CompilationError(
+                code="INVALID_DATE_LITERAL_FORMAT",
+                message=(
+                    f"operator {op!r} literal {value!r} against date-typed fact "
+                    f"{spec.path.value!r} must be a canonical ISO-8601 date string "
+                    "(YYYY-MM-DD) — compact (YYYYMMDD) and week-date (YYYY-Www-D) "
+                    "forms are rejected even though `date.fromisoformat` accepts "
+                    "them, because they compare lexicographically wrong against "
+                    "canonical snapshot values"
+                ),
+                rule_id=rule.rule_id,
+            )
+        )
+        return
+    try:
+        date.fromisoformat(value)
+    except ValueError as exc:
+        errors.append(
+            CompilationError(
+                code="INVALID_DATE_LITERAL_FORMAT",
+                message=(
+                    f"operator {op!r} literal {value!r} against date-typed fact "
+                    f"{spec.path.value!r} is not a valid calendar date: {exc}"
+                ),
+                rule_id=rule.rule_id,
+            )
+        )
 
 
 def _check_single_literal_against_kind(
@@ -576,7 +694,18 @@ def _check_single_literal_against_kind(
     Python-level kind must match ``expected_kind`` (catches ``age == "30"``
     — a STRING literal against an INTEGER fact); (2) if the fact declares a
     closed ``allowed_values`` set, the literal must be a member of it
-    (catches ``marital_status == "NOT_A_STATUS"``).
+    (catches ``marital_status == "NOT_A_STATUS"``). PR1b item 1 adds a third:
+    a date-typed fact's STRING literal must additionally be a canonical
+    ISO-8601 date (see ``_check_date_literal_format``) — checked IN ADDITION
+    TO, never instead of, the ``allowed_values`` membership check below.
+    ``FactRegistry`` explicitly supports custom/alternate registries (see
+    that class's own docstring), so a ``value_type="date"`` spec CAN declare
+    ``allowed_values`` even though no entry in this package's default
+    registry currently does (Codex xhigh independent review counterexample:
+    a custom registry allowing only ``"2026-01-01"`` must still reject the
+    canonical-but-not-allowed literal ``"2026-02-01"`` with
+    ``FACT_LITERAL_NOT_ALLOWED`` — a bare ``return`` right after a
+    successful date-format check would silently skip that).
     """
     literal_kind = _literal_kind(value)
     if literal_kind is not expected_kind:
@@ -591,6 +720,17 @@ def _check_single_literal_against_kind(
             )
         )
         return
+    if _is_date_typed(spec) and isinstance(value, str):
+        errors_before = len(errors)
+        _check_date_literal_format(value, spec, op, rule, errors)
+        if len(errors) > errors_before:
+            # Malformed/invalid date already reported — checking
+            # allowed_values membership on a value we just rejected as not
+            # even a valid date would be redundant noise, not a second
+            # legitimate defect.
+            return
+        # Valid canonical date: fall through to the allowed_values check
+        # below, exactly like any other STRING-kind fact.
     if spec.allowed_values is not None and value not in spec.allowed_values:
         errors.append(
             CompilationError(
@@ -640,6 +780,19 @@ def _check_between_bounds(
             )
         )
         return
+    if _is_date_typed(spec) and isinstance(lower, str) and isinstance(upper, str):
+        # PR1b item 1: both bounds must be canonical ISO-8601 dates before
+        # the lexical `lower > upper` ordering check below means anything —
+        # a malformed (e.g. compact) bound can compare lexicographically
+        # "in order" while still being the wrong shape entirely. If either
+        # bound fails the format check, skip the (now-meaningless) ordering
+        # check rather than emit a confusing/misleading BETWEEN_BOUNDS_
+        # INVERTED alongside it.
+        errors_before = len(errors)
+        _check_date_literal_format(lower, spec, "between", rule, errors)
+        _check_date_literal_format(upper, spec, "between", rule, errors)
+        if len(errors) > errors_before:
+            return
     if lower > upper:
         errors.append(
             CompilationError(
@@ -734,14 +887,21 @@ def _known_product_ids(payload: RulePackPayload) -> frozenset:
 
 
 def _check_product_reference_integrity(
-    payload: RulePackPayload, errors: list[CompilationError]
+    payload: RulePackPayload, rules: tuple[Rule, ...], errors: list[CompilationError]
 ) -> None:
     """Spec §2 compiler-only invariant: "Source-reference and product-reference
     integrity" (product half) — a PRODUCTS-scope rule may only reference
     ``product_version_id``s that exist in ``payload.products``.
+
+    PR1b item 2 residual (Codex xhigh independent review): ``rules`` is the
+    STAGE_ORDER-sorted tuple, not ``payload.rules`` — this emits rule_id-
+    attributed ``UNKNOWN_PRODUCT_REFERENCE`` errors, so it must sort the same
+    as every other per-rule check for a deterministic report (proven live:
+    swapping two rules' declaration order previously inverted this
+    function's error order too).
     """
     known_products = _known_product_ids(payload)
-    for rule in payload.rules:
+    for rule in rules:
         if rule.product_version_ids is None:
             continue
         unknown = frozenset(rule.product_version_ids) - known_products
@@ -756,14 +916,21 @@ def _check_product_reference_integrity(
 
 
 def _check_source_reference_integrity(
-    payload: RulePackPayload, errors: list[CompilationError]
+    payload: RulePackPayload, rules: tuple[Rule, ...], errors: list[CompilationError]
 ) -> None:
     """Spec §2 compiler-only invariant: "Source-reference and product-reference
     integrity" (source half) — every rule/product ``source_refs`` entry must
     exist in ``payload.source_records``.
+
+    PR1b item 2 residual: the rule-attributed half below uses the
+    STAGE_ORDER-sorted ``rules`` (same rationale as
+    ``_check_product_reference_integrity``); the product-attributed half
+    stays on ``payload.products`` unchanged — products have no
+    ``RuleStage``, so payload declaration order is the only meaningful
+    order for them.
     """
     known_sources = frozenset(record.source_record_id for record in payload.source_records)
-    for rule in payload.rules:
+    for rule in rules:
         unknown = frozenset(rule.source_refs) - known_sources
         if unknown:
             errors.append(
@@ -791,7 +958,7 @@ def _check_source_reference_integrity(
 
 
 def _check_support_purposes_on_product(
-    payload: RulePackPayload, errors: list[CompilationError]
+    payload: RulePackPayload, rules: tuple[Rule, ...], errors: list[CompilationError]
 ) -> None:
     """Spec §2 compiler-only invariant: "requested_purposes subset-of
     covered_purposes" — this is the STATIC, structural half PR1 can actually
@@ -799,6 +966,11 @@ def _check_support_purposes_on_product(
     ``requested_purposes`` must be a subset of the union of every TRUE
     SUPPORT rule's ``covered_purposes`` for the winning candidate) needs the
     evaluator (PR3) and is *not* claimed here.
+
+    PR1b item 2 residual: ``rules`` is the STAGE_ORDER-sorted tuple (same
+    rationale as ``_check_product_reference_integrity``) — every error this
+    function emits carries a ``rule_id``, so it is a per-rule check for
+    ordering purposes even though its name reads product-centric.
 
     What this function guarantees, structurally, at compile time:
 
@@ -832,7 +1004,7 @@ def _check_support_purposes_on_product(
         else frozenset()
     )
 
-    for rule in payload.rules:
+    for rule in rules:
         if rule.effect.type != "SUPPORT":
             continue
         claimed = frozenset(rule.effect.covered_purposes)

--- a/apps/backend-rag/backend/services/visa_engine/fact_registry.py
+++ b/apps/backend-rag/backend/services/visa_engine/fact_registry.py
@@ -52,9 +52,16 @@ class FactSpec:
     for structural literal-type checking — see module docstring) and
     ``pii_class`` (the task's explicit "PII class" requirement, not itself
     named in the spec text; see ``enums.PiiClass``'s docstring for the
-    resolution). ``value_type`` stays as a free-text human label (e.g.
-    ``"date"``, ``"money_idr"``, ``"country_code"``) purely for
-    documentation/tooling — ``kind`` is what compiler.py actually branches on.
+    resolution). ``value_type`` is a free-text human label (e.g. ``"date"``,
+    ``"money_idr"``, ``"country_code"``) mostly for documentation/tooling —
+    ``kind`` is what ``compiler.py`` branches on for the general fact/literal-
+    kind matrix. **PR1b exception**: ``compiler.py``'s
+    ``_is_date_typed``/``_check_date_literal_format`` DO branch on
+    ``value_type == "date"`` specifically — ``kind`` alone cannot distinguish
+    a date-typed fact from a generic STRING fact (both are
+    ``FactValueKind.STRING`` by design, see ``enums.FactValueKind``'s own
+    docstring), so this one label is load-bearing for canonical-ISO-8601
+    literal validation, not purely decorative.
     """
 
     path: FactPath

--- a/apps/backend-rag/backend/services/visa_engine/models.py
+++ b/apps/backend-rag/backend/services/visa_engine/models.py
@@ -250,7 +250,11 @@ class StayPolicy(BaseModel):
 class ExtensionPolicy(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    allowed: bool
+    # PR1b item 3 (ported from the reference-tree comparative review):
+    # Field(strict=True) — matching this module's own int-field convention
+    # (e.g. `maximum_extensions` below) — rejects `1`/`0`/`1.0` so a
+    # malformed wire payload can never silently coerce into a bool.
+    allowed: Annotated[bool, Field(strict=True)]
     maximum_extensions: Annotated[int, Field(ge=0, le=100, strict=True)]
     days_per_extension: Annotated[int, Field(ge=1, le=3650, strict=True)] | None
 
@@ -267,7 +271,8 @@ class ClockCheckpointSpec(BaseModel):
 class ClockPolicy(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    available: bool
+    # PR1b item 3: see ExtensionPolicy.allowed's comment above.
+    available: Annotated[bool, Field(strict=True)]
     anchor: ClockAnchor
     checkpoints: tuple[ClockCheckpointSpec, ...] = Field(..., max_length=64)
 
@@ -301,7 +306,8 @@ class VisaProductVersion(BaseModel):
     clock_policy: ClockPolicy
     pricing_key: PricingKey | None
     source_refs: tuple[uuid.UUID, ...] = Field(..., min_length=1)
-    public_catalog: bool
+    # PR1b item 3: see ExtensionPolicy.allowed's comment above.
+    public_catalog: Annotated[bool, Field(strict=True)]
 
     @field_validator("legacy_codes", "legacy_slugs", "covered_purposes", "source_refs")
     @classmethod
@@ -415,7 +421,8 @@ class Rule(BaseModel):
     required_facts: tuple[FactPath, ...] = Field(..., max_length=128)
     source_refs: tuple[uuid.UUID, ...] = Field(..., min_length=1, max_length=32)
     explanation_key: Identifier
-    safety_critical: bool
+    # PR1b item 3: see ExtensionPolicy.allowed's comment above.
+    safety_critical: Annotated[bool, Field(strict=True)]
 
     @field_validator("product_version_ids", "source_refs")
     @classmethod
@@ -1036,7 +1043,8 @@ class Outage(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     code: ReasonCode
-    retryable: bool
+    # PR1b item 3: see ExtensionPolicy.allowed's comment above.
+    retryable: Annotated[bool, Field(strict=True)]
 
 
 class Decision(BaseModel):

--- a/apps/backend-rag/backend/services/visa_engine/schema_export.py
+++ b/apps/backend-rag/backend/services/visa_engine/schema_export.py
@@ -230,6 +230,22 @@ _ALLOF_INJECTIONS: dict[str, list[dict[str, Any]]] = {
             "if": {"properties": {"status": {"const": "AVAILABLE"}}},
             "then": {
                 "properties": {
+                    # PR1b item 5 (integer parity, known one-directional
+                    # divergence — NEVER "fix" this by hand-tightening the
+                    # JSON Schema, it cannot be tightened): JSON Schema
+                    # 2020-12's `"type": "integer"` means "a JSON number with
+                    # a zero fractional part" per the spec itself, so `2.0`
+                    # legally satisfies it — there is no JSON Schema keyword
+                    # for "integer, not merely integer-valued". Every
+                    # `Annotated[int, Field(strict=True)]` field in
+                    # models.py (this `amount`, `Rule.priority`, etc.) is
+                    # narrower: Pydantic's strict mode rejects `2.0`
+                    # outright. This gap is inexpressible in pure JSON
+                    # Schema and is intentional, not a bug — Pydantic is the
+                    # authoritative gate on every write path; the exported
+                    # schema is advisory/interop only. Pinned by
+                    # test_schema_contracts.py::TestIntegerParityDivergencePinned
+                    # so it stays visible rather than being rediscovered.
                     "amount": {"type": "integer", "minimum": 0},
                     "catalog_version": {"type": "string"},
                     "catalog_sha256": _SHA256_HEX_INLINE,

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_fact_registry.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_fact_registry.py
@@ -25,7 +25,7 @@ from backend.services.visa_engine.fact_registry import DEFAULT_FACT_REGISTRY, Fa
 
 class TestDefaultCatalogCompleteness:
     def test_every_fact_path_has_a_spec(self) -> None:
-        for path in FactPath:
+        for path in list(FactPath):
             spec = DEFAULT_FACT_REGISTRY.spec(path)
             assert spec.path is path
 
@@ -40,7 +40,7 @@ class TestDefaultCatalogCompleteness:
             assert DEFAULT_FACT_REGISTRY.spec(path).derived is True
 
     def test_applicant_facts_not_flagged_derived(self) -> None:
-        for path in FactPath:
+        for path in list(FactPath):
             if path in DERIVED_FACT_PATHS:
                 continue
             assert DEFAULT_FACT_REGISTRY.spec(path).derived is False
@@ -74,7 +74,7 @@ class TestMissingPaths:
 
 class TestCommercialClassification:
     def test_commercial_paths_match_enums_constant(self) -> None:
-        for path in FactPath:
+        for path in list(FactPath):
             expected = path in COMMERCIAL_FACT_PATHS
             assert DEFAULT_FACT_REGISTRY.is_commercial(path) is expected
 

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_rulepack_compiler.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_rulepack_compiler.py
@@ -23,6 +23,7 @@ import uuid
 from backend.services.visa_engine import ast as A
 from backend.services.visa_engine import compiler as C
 from backend.services.visa_engine import models as M
+from backend.services.visa_engine.enums import RuleStage
 from backend.tests.services.visa_engine.conftest import (
     GOLD_EFFECTIVE_AT,
     make_product,
@@ -1024,7 +1025,9 @@ class TestGlobalSupportPurposeIntersectionSemantics:
             rules=(global_rule,),
         )
         errors: list[C.CompilationError] = []
-        C._check_support_purposes_on_product(empty_products_payload, errors)  # must not raise
+        C._check_support_purposes_on_product(
+            empty_products_payload, empty_products_payload.rules, errors
+        )  # must not raise
         assert any(e.code == "SUPPORT_RULE_PURPOSE_NOT_ON_ANY_PRODUCT" for e in errors)
 
 
@@ -1256,3 +1259,482 @@ class TestUtcDetectionAnchoredFullMatch:
         )
         report = C.compile_rule_pack(make_rule_pack(payload))
         assert any(e.code == "NON_UTC_DATETIME" for e in report.errors)
+
+
+# ---------------------------------------------------------------------------
+# PR1b item 1 — canonical YYYY-MM-DD literal validation for date-typed facts
+# (ported from the reference tree's comparative review, adapted to this
+# tree's structure: FactSpec.kind alone cannot distinguish a date fact from a
+# generic STRING fact — enums.FactValueKind's own docstring says so — so the
+# hook is FactSpec.value_type == "date", the free-text label fact_registry.py
+# already seeds for every date-shaped path.)
+# ---------------------------------------------------------------------------
+
+
+class TestDateTypedFactLiteralCanonicalFormat:
+    def test_compact_date_literal_rejected(self, source_record: M.SourceRecord) -> None:
+        # date.fromisoformat("20260718") parses fine (Python 3.11+) but
+        # compares lexicographically wrong against canonical "YYYY-MM-DD"
+        # snapshot values — must be rejected at compile time regardless.
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.compact",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={"op": "eq", "fact": "person.birth_date", "value": "20260718"},
+            required_facts=("person.birth_date",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_week_date_literal_rejected(self, source_record: M.SourceRecord) -> None:
+        # date.fromisoformat also accepts ISO week-dates ("2026-W29-2") —
+        # same lexicographic-comparison hazard as the compact form.
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.week",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={"op": "eq", "fact": "person.birth_date", "value": "2026-W29-2"},
+            required_facts=("person.birth_date",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_non_iso_garbage_literal_rejected(self, source_record: M.SourceRecord) -> None:
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.garbage",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={"op": "eq", "fact": "person.birth_date", "value": "not-a-date"},
+            required_facts=("person.birth_date",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_canonical_date_literal_is_innocent(self, source_record: M.SourceRecord) -> None:
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.valid",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={"op": "eq", "fact": "person.birth_date", "value": "2026-07-18"},
+            required_facts=("person.birth_date",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert not any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_between_bounds_malformed_date_rejected(self, source_record: M.SourceRecord) -> None:
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.between.malformed",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={
+                "op": "between",
+                "fact": "person.birth_date",
+                "lower": "20260101",
+                "upper": "2026-12-31",
+            },
+            required_facts=("person.birth_date",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_between_bounds_valid_dates_ordering_still_checked(
+        self, source_record: M.SourceRecord
+    ) -> None:
+        # Both bounds are canonical (so no format error), but inverted —
+        # BETWEEN_BOUNDS_INVERTED must still fire; the date-format guard must
+        # not swallow the pre-existing ordering check for well-formed dates.
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.between.inverted",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={
+                "op": "between",
+                "fact": "person.birth_date",
+                "lower": "2026-12-31",
+                "upper": "2026-01-01",
+            },
+            required_facts=("person.birth_date",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert any(e.code == "BETWEEN_BOUNDS_INVERTED" for e in report.errors)
+        assert not any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_generic_string_fact_not_subject_to_date_check(
+        self, source_record: M.SourceRecord
+    ) -> None:
+        # intent.requested_product_code is STRING-kind with value_type=
+        # "product_code" (no "date" hint, no allowed_values) — a
+        # date-shaped-looking literal must NOT trigger date-format
+        # validation, proving the guard is scoped to value_type=="date", not
+        # any string that merely looks date-shaped.
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.not.a.date.fact",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={"op": "eq", "fact": "intent.requested_product_code", "value": "20260718"},
+            required_facts=("intent.requested_product_code",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert not any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_canonical_form_invalid_calendar_date_rejected(
+        self, source_record: M.SourceRecord
+    ) -> None:
+        # 2026 is not a leap year (2026 % 4 != 0) — "2026-02-29" is
+        # canonically SHAPED (matches YYYY-MM-DD) but not a real calendar
+        # date; `date.fromisoformat` raises ValueError on it. Closes the
+        # Codex xhigh independent review test gap: the ValueError branch of
+        # _check_date_literal_format was implemented but never pinned.
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.invalid.calendar",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={"op": "eq", "fact": "person.birth_date", "value": "2026-02-29"},
+            required_facts=("person.birth_date",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_between_bounds_malformed_upper_bound_rejected(
+        self, source_record: M.SourceRecord
+    ) -> None:
+        # Mirror of test_between_bounds_malformed_date_rejected but with the
+        # malformed literal on the UPPER bound instead of the lower one —
+        # closes the Codex xhigh independent review test gap (only the lower
+        # bound was previously exercised).
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = make_support_rule(
+            rule_id="rule.date.between.malformed.upper",
+            product_version_ids=[product_id],
+            source_refs=[source_record.source_record_id],
+            when={
+                "op": "between",
+                "fact": "person.birth_date",
+                "lower": "2026-01-01",
+                "upper": "20261231",
+            },
+            required_facts=("person.birth_date",),
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+        assert any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_valid_date_still_checked_against_custom_registry_allowed_values(
+        self, source_record: M.SourceRecord
+    ) -> None:
+        # Codex xhigh independent review MEDIUM finding, cured: a custom
+        # FactRegistry (FactRegistry.__init__ explicitly supports a caller-
+        # supplied spec list — see that class's docstring) CAN combine
+        # value_type="date" with allowed_values, even though no entry in
+        # this package's own DEFAULT registry currently does. A literal that
+        # is canonical AND calendar-valid but simply not a member of the
+        # declared allowed_values must still be rejected — a bare `return`
+        # right after a successful date-format check silently skipped this
+        # (Codex's exact counterexample: a registry allowing only
+        # "2026-01-01" accepted the canonical, unrelated "2026-02-01" with
+        # zero errors).
+        from backend.services.visa_engine.enums import FactPath, FactValueKind
+        from backend.services.visa_engine.fact_registry import FactRegistry, FactSpec
+
+        narrow_registry = FactRegistry(
+            [
+                FactSpec(
+                    path=FactPath.PERSON_BIRTH_DATE,
+                    kind=FactValueKind.STRING,
+                    value_type="date",
+                    derived=False,
+                    allowed_values=frozenset({"2026-01-01"}),
+                )
+            ]
+        )
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = M.Rule(
+            rule_id="rule.date.allowed.values.custom.registry",
+            stage="HARD_FILTER",
+            scope="GLOBAL",
+            product_version_ids=None,
+            priority=10,
+            valid_period=_OPEN_PERIOD,
+            when={"op": "eq", "fact": "person.birth_date", "value": "2026-02-01"},
+            effect={"type": "EXCLUDE", "reason_code": "X"},
+            on_unknown="NO_EFFECT",
+            required_facts=["person.birth_date"],
+            source_refs=[source_record.source_record_id],
+            explanation_key="explain.date.allowed.custom",
+            safety_critical=True,
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload), fact_registry=narrow_registry)
+        assert any(e.code == "FACT_LITERAL_NOT_ALLOWED" for e in report.errors)
+        assert not any(e.code == "INVALID_DATE_LITERAL_FORMAT" for e in report.errors)
+
+    def test_allowed_date_literal_against_custom_registry_is_innocent(
+        self, source_record: M.SourceRecord
+    ) -> None:
+        # Innocence half of the test above: the literal that IS in
+        # allowed_values must compile clean.
+        from backend.services.visa_engine.enums import FactPath, FactValueKind
+        from backend.services.visa_engine.fact_registry import FactRegistry, FactSpec
+
+        narrow_registry = FactRegistry(
+            [
+                FactSpec(
+                    path=FactPath.PERSON_BIRTH_DATE,
+                    kind=FactValueKind.STRING,
+                    value_type="date",
+                    derived=False,
+                    allowed_values=frozenset({"2026-01-01"}),
+                )
+            ]
+        )
+        product_id = uuid.uuid4()
+        product = make_product(
+            product_version_id=product_id, source_refs=[source_record.source_record_id]
+        )
+        rule = M.Rule(
+            rule_id="rule.date.allowed.values.custom.registry.valid",
+            stage="HARD_FILTER",
+            scope="GLOBAL",
+            product_version_ids=None,
+            priority=10,
+            valid_period=_OPEN_PERIOD,
+            when={"op": "eq", "fact": "person.birth_date", "value": "2026-01-01"},
+            effect={"type": "EXCLUDE", "reason_code": "X"},
+            on_unknown="NO_EFFECT",
+            required_facts=["person.birth_date"],
+            source_refs=[source_record.source_record_id],
+            explanation_key="explain.date.allowed.custom.valid",
+            safety_critical=True,
+        )
+        payload = make_rule_pack_payload(
+            rules=[rule], products=[product], source_records=[source_record]
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload), fact_registry=narrow_registry)
+        assert not any(
+            e.code in ("FACT_LITERAL_NOT_ALLOWED", "INVALID_DATE_LITERAL_FORMAT")
+            for e in report.errors
+        )
+
+
+# ---------------------------------------------------------------------------
+# PR1b item 2 — semantic STAGE_ORDER used to sort rules before every
+# per-rule check runs, so CompilationReport.errors is deterministic and
+# stage-semantic within any single check, independent of a RulePack
+# author's arbitrary `rules` array declaration order.
+#
+# ARBITRATED SEQUENCE (final gate, spec-grounded): HARD_FILTER -> ELIGIBILITY
+# -> HUMAN_REVIEW -> RANKING — the enum's OWN declaration order (research/
+# visa/2026-07-17-visa-oracle-v2-round2-codex-engine-concretization.md §1
+# enums.py lines 93-97, mirrored by the JSON Schema enum), which is also
+# spec §5.3's evaluation order. Deliberately NOT the reference tree's
+# inverted HARD_FILTER -> HUMAN_REVIEW -> ELIGIBILITY -> RANKING sequence.
+# ---------------------------------------------------------------------------
+
+
+class TestStageOrderDeterministicSorting:
+    def test_stage_order_mapping_values(self) -> None:
+        assert C.STAGE_ORDER[RuleStage.HARD_FILTER] == 0
+        assert C.STAGE_ORDER[RuleStage.ELIGIBILITY] == 1
+        assert C.STAGE_ORDER[RuleStage.HUMAN_REVIEW] == 2
+        assert C.STAGE_ORDER[RuleStage.RANKING] == 3
+
+    def test_commercial_fact_errors_ordered_by_stage_not_declaration_order(
+        self, minimal_valid_pack: M.RulePack, source_record: M.SourceRecord
+    ) -> None:
+        def _legal_stage_rule(rule_id: str, stage: str, effect: dict) -> M.Rule:
+            return M.Rule(
+                rule_id=rule_id,
+                stage=stage,
+                scope="GLOBAL",
+                product_version_ids=None,
+                priority=10,
+                valid_period=_OPEN_PERIOD,
+                when={"op": "known", "fact": "commercial.wants_quote"},
+                effect=effect,
+                on_unknown="NO_EFFECT",
+                required_facts=["commercial.wants_quote"],
+                source_refs=[source_record.source_record_id],
+                explanation_key="explain.stage.order",
+                safety_critical=stage == "HARD_FILTER",
+            )
+
+        # Declared out of BOTH stage order and alphabetical rule_id order
+        # ("human_review" < "hard_filter" is false alphabetically), so a
+        # correct assertion below rules out an accidental id-sort as well as
+        # declaration-order passthrough.
+        human_review_rule = _legal_stage_rule(
+            "rule.stage.order.human_review",
+            "HUMAN_REVIEW",
+            {"type": "REQUIRE_REVIEW", "reason_code": "NEEDS_REVIEW"},
+        )
+        hard_filter_rule = _legal_stage_rule(
+            "rule.stage.order.hard_filter",
+            "HARD_FILTER",
+            {"type": "EXCLUDE", "reason_code": "X"},
+        )
+        eligibility_rule = _legal_stage_rule(
+            "rule.stage.order.eligibility",
+            "ELIGIBILITY",
+            {"type": "SUPPORT", "reason_code": "X", "covered_purposes": ["TOURISM"]},
+        )
+        rules = [
+            *minimal_valid_pack.payload.rules,
+            human_review_rule,
+            hard_filter_rule,
+            eligibility_rule,
+        ]
+        payload = make_rule_pack_payload(
+            rules=rules,
+            products=minimal_valid_pack.payload.products,
+            source_records=minimal_valid_pack.payload.source_records,
+        )
+        report = C.compile_rule_pack(make_rule_pack(payload))
+
+        ordered_ids = [
+            e.rule_id for e in report.errors if e.code == "COMMERCIAL_FACT_IN_LEGAL_STAGE"
+        ]
+        assert ordered_ids == [
+            "rule.stage.order.hard_filter",
+            "rule.stage.order.eligibility",
+            "rule.stage.order.human_review",
+        ]
+
+    def _bogus_source_ref_rules(
+        self, product_id: uuid.UUID
+    ) -> tuple[M.Rule, M.Rule]:
+        """Two GLOBAL rules, each with a `source_refs` UUID that exists
+        nowhere in `payload.source_records` — both trigger
+        UNKNOWN_SOURCE_REFERENCE, one per stage, so the test below can pin
+        the order those two errors come out in."""
+        eligibility_rule = M.Rule(
+            rule_id="rule.stage.order.src.eligibility",
+            stage="ELIGIBILITY",
+            scope="GLOBAL",
+            product_version_ids=None,
+            priority=10,
+            valid_period=_OPEN_PERIOD,
+            when={"op": "intersects", "fact": "intent.purposes", "values": ["TOURISM"]},
+            effect={"type": "SUPPORT", "reason_code": "X", "covered_purposes": ["TOURISM"]},
+            on_unknown="NEEDS_INPUT",
+            required_facts=["intent.purposes"],
+            source_refs=[uuid.uuid4()],  # unknown — not in payload.source_records
+            explanation_key="explain.stage.order.src.eligibility",
+            safety_critical=False,
+        )
+        hard_filter_rule = M.Rule(
+            rule_id="rule.stage.order.src.hard_filter",
+            stage="HARD_FILTER",
+            scope="GLOBAL",
+            product_version_ids=None,
+            priority=10,
+            valid_period=_OPEN_PERIOD,
+            when={"op": "gt", "fact": "immigration.overstay_days", "value": 60},
+            effect={"type": "EXCLUDE", "reason_code": "X"},
+            on_unknown="NO_EFFECT",
+            required_facts=["immigration.overstay_days"],
+            source_refs=[uuid.uuid4()],  # unknown — not in payload.source_records
+            explanation_key="explain.stage.order.src.hard_filter",
+            safety_critical=True,
+        )
+        return eligibility_rule, hard_filter_rule
+
+    def test_source_reference_errors_ordered_by_stage_regardless_of_declaration_order(
+        self, minimal_valid_pack: M.RulePack
+    ) -> None:
+        # PR1b item 2 residual (Codex xhigh independent review MEDIUM
+        # finding, cured): _check_source_reference_integrity previously read
+        # `payload.rules` directly, so its UNKNOWN_SOURCE_REFERENCE errors
+        # came out in payload declaration order, not stage order — Codex's
+        # exact counterexample: declaring [ELIGIBILITY, HARD_FILTER] and
+        # [HARD_FILTER, ELIGIBILITY] produced two DIFFERENT error orders.
+        # This test drives both declaration orders and asserts BOTH produce
+        # the SAME stage-sorted result (HARD_FILTER's error before
+        # ELIGIBILITY's) — proving the fix, not just one lucky order.
+        eligibility_rule, hard_filter_rule = self._bogus_source_ref_rules(
+            minimal_valid_pack.payload.products[0].product_version_id
+        )
+        expected_order = [
+            "rule.stage.order.src.hard_filter",
+            "rule.stage.order.src.eligibility",
+        ]
+
+        for declared_rules in (
+            [*minimal_valid_pack.payload.rules, eligibility_rule, hard_filter_rule],
+            [*minimal_valid_pack.payload.rules, hard_filter_rule, eligibility_rule],
+        ):
+            payload = make_rule_pack_payload(
+                rules=declared_rules,
+                products=minimal_valid_pack.payload.products,
+                source_records=minimal_valid_pack.payload.source_records,
+            )
+            report = C.compile_rule_pack(make_rule_pack(payload))
+            ordered_ids = [
+                e.rule_id for e in report.errors if e.code == "UNKNOWN_SOURCE_REFERENCE"
+            ]
+            assert ordered_ids == expected_order

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_schema_contracts.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_schema_contracts.py
@@ -353,7 +353,7 @@ class TestSchemaExportInvariants:
         schemas = SE.build_schemas()
         condition_schema = schemas["condition.schema.json"]
         rendered = str(condition_schema)
-        for op in ConditionOperator:
+        for op in list(ConditionOperator):
             assert op.value in rendered, f"operator {op.value!r} missing from exported schema"
 
     def test_export_schemas_writes_files_to_disk(self, tmp_path: Path) -> None:
@@ -388,13 +388,13 @@ class TestSchemaExportInvariants:
     def test_decision_state_present_in_contract(self) -> None:
         schemas = SE.build_schemas()
         rendered = str(schemas["contract.schema.json"])
-        for state in DecisionState:
+        for state in list(DecisionState):
             assert state.value in rendered
 
     def test_unknown_reason_present_in_contract(self) -> None:
         schemas = SE.build_schemas()
         rendered = str(schemas["contract.schema.json"])
-        for reason in UnknownReason:
+        for reason in list(UnknownReason):
             assert reason.value in rendered
 
 
@@ -1043,6 +1043,105 @@ class TestStrictIntFields:
     def test_effect_add_score_points_rejects_float(self) -> None:
         with pytest.raises(ValidationError):
             M.EffectAddScore(type="ADD_SCORE", reason_code="X", points=1.0)  # type: ignore[arg-type]
+
+
+class TestStrictBoolFields:
+    """PR1b item 3 (ported from the reference-tree comparative review): every
+    wire-level boolean field must reject ``1``/``0``/``1.0`` — Pydantic's
+    non-strict ``bool`` coerces truthy/falsy ints and int-valued floats
+    silently, which would let a malformed RulePack payload (e.g. hand-edited
+    JSON, or a producer that serializes booleans as 0/1) construct a valid
+    model with the wrong semantic type on the wire. One guilt (``1`` ->
+    rejected) + one innocence (``True`` -> accepted) pair per field, matching
+    this module's existing ``Field(strict=True)`` convention for int fields
+    (see e.g. ``Rule.priority``) rather than importing a separate
+    ``StrictBool`` alias.
+    """
+
+    def test_extension_policy_allowed_rejects_int(self) -> None:
+        with pytest.raises(ValidationError):
+            M.ExtensionPolicy(allowed=1, maximum_extensions=1, days_per_extension=30)  # type: ignore[arg-type]
+
+    def test_extension_policy_allowed_accepts_bool(self) -> None:
+        policy = M.ExtensionPolicy(allowed=True, maximum_extensions=1, days_per_extension=30)
+        assert policy.allowed is True
+
+    def test_clock_policy_available_rejects_int(self) -> None:
+        with pytest.raises(ValidationError):
+            M.ClockPolicy(available=0, anchor="ENTRY_DATE", checkpoints=[])  # type: ignore[arg-type]
+
+    def test_clock_policy_available_accepts_bool(self) -> None:
+        policy = M.ClockPolicy(available=True, anchor="ENTRY_DATE", checkpoints=[])
+        assert policy.available is True
+
+    def test_visa_product_version_public_catalog_rejects_int(
+        self, minimal_valid_pack: M.RulePack
+    ) -> None:
+        dumped = minimal_valid_pack.payload.products[0].model_dump(mode="json", by_alias=True)
+        dumped["public_catalog"] = 1
+        with pytest.raises(ValidationError):
+            M.VisaProductVersion.model_validate(dumped)
+
+    def test_visa_product_version_public_catalog_accepts_bool(
+        self, minimal_valid_pack: M.RulePack
+    ) -> None:
+        product = minimal_valid_pack.payload.products[0]
+        assert product.public_catalog is True
+
+    def test_rule_safety_critical_rejects_int(self, minimal_valid_pack: M.RulePack) -> None:
+        dumped = minimal_valid_pack.payload.rules[0].model_dump(mode="json", by_alias=True)
+        dumped["safety_critical"] = 0
+        with pytest.raises(ValidationError):
+            M.Rule.model_validate(dumped)
+
+    def test_rule_safety_critical_accepts_bool(self, minimal_valid_pack: M.RulePack) -> None:
+        rule = minimal_valid_pack.payload.rules[0].model_copy(update={"safety_critical": True})
+        assert rule.safety_critical is True
+
+    def test_outage_retryable_rejects_int(self) -> None:
+        with pytest.raises(ValidationError):
+            M.Outage(code="X", retryable=1)  # type: ignore[arg-type]
+
+    def test_outage_retryable_rejects_float(self) -> None:
+        # 1.0 is the exact "looks like a bool, isn't" case the reference
+        # tree's task brief calls out explicitly.
+        with pytest.raises(ValidationError):
+            M.Outage(code="X", retryable=1.0)  # type: ignore[arg-type]
+
+    def test_outage_retryable_accepts_bool(self) -> None:
+        outage = M.Outage(code="X", retryable=True)
+        assert outage.retryable is True
+
+
+class TestIntegerParityDivergencePinned:
+    """PR1b item 5: JSON Schema 2020-12's ``"type": "integer"`` accepts a
+    JSON number with a zero fractional part (``2.0``) — the spec's own
+    definition of "integer" is "a number without a fraction or exponent
+    part", not "encoded without a decimal point". ``StrictInt``/
+    ``Field(strict=True)`` on the Pydantic side is narrower: it rejects
+    ``2.0`` outright, float-typed or not. This divergence is
+    inexpressible in pure JSON Schema (there is no ``"integer, strictly
+    encoded"`` keyword) and is therefore a KNOWN, one-directional,
+    intentional gap between the exported contract and the model that
+    actually gates writes — see the comment at schema_export.py's
+    integer-emitting site. This test pins the direction so the gap stays
+    visible and intentional rather than being rediscovered as a "bug".
+    """
+
+    def test_exported_schema_accepts_float_valued_integer_for_priority(self) -> None:
+        contract = SE.build_schemas()["contract.schema.json"]
+        priority_schema = contract["$defs"]["Rule"]["properties"]["priority"]
+        assert priority_schema["type"] == "integer"
+        validator = Draft202012Validator(priority_schema)
+        assert validator.is_valid(2.0)
+
+    def test_model_rejects_the_same_float_valued_integer_for_priority(
+        self, minimal_valid_pack: M.RulePack
+    ) -> None:
+        dumped = minimal_valid_pack.payload.rules[0].model_dump(mode="json", by_alias=True)
+        dumped["priority"] = 2.0
+        with pytest.raises(ValidationError):
+            M.Rule.model_validate(dumped)
 
 
 def _snapshot_dir() -> Path:


### PR DESCRIPTION
## Summary

Adjudicated port-list from the comparative review that closed reference-tree PR #2718 (Track A final gate: **ADOPT_A** — #2654 merged to main as `f73cbb4a7b`; this PR ships the 5 protections that comparative review judged portable onto the winning tree, per [#2718's adjudication comment](https://github.com/Balizero1987/Teman2/pull/2718#issuecomment-adjudication)).

Onto `apps/backend-rag/backend/services/visa_engine/`:

1. **Canonical `YYYY-MM-DD` literal validation** for date-typed facts — adapted to this tree's structure (`FactSpec.kind` is always `STRING` for dates by design; the hook is `FactSpec.value_type == "date"`, since `enums.FactValueKind` has no separate `DATE` kind). Rejects compact (`YYYYMMDD`) and week-date (`YYYY-Www-D`) forms `date.fromisoformat` accepts but that compare lexicographically wrong against canonical snapshot values, plus calendar-invalid canonical-shaped literals (e.g. `2026-02-29`). Covers scalar literals and both sides of `between` bounds.
2. **Explicit `STAGE_ORDER` mapping** (`HARD_FILTER=0, ELIGIBILITY=1, HUMAN_REVIEW=2, RANKING=3` — arbitrated per `research/visa/2026-07-17-visa-oracle-v2-round2-codex-engine-concretization.md` §1 lines 93-97 / the JSON Schema enum declaration order, **deliberately NOT** the reference tree's inverted `HARD_FILTER→HUMAN_REVIEW→ELIGIBILITY→RANKING` sequence) used to sort rules before every per-rule compiler check runs, so `CompilationReport.errors` is deterministic and stage-semantic regardless of a RulePack author's arbitrary declaration order.
3. **StrictBool** (`Field(strict=True)` on `bool`, matching this codebase's existing int-field idiom) on the 5 wire-level booleans: `allowed`, `available`, `public_catalog`, `safety_critical`, `retryable` — rejects `1`/`0`/`1.0` coercion. No JSON Schema drift (verified: `strict=True` is Pydantic-runtime-only, invisible to `model_json_schema()`).
4. **CodeQL `py/non-iterable-in-for-loop` cure**: `for x in SomeEnum:` → `for x in list(SomeEnum):` at the 6 direct str-Enum class iterations in the test suite, mirroring reference commit `1a4360dc1b`'s exact pattern.
5. **JSON Schema/Pydantic integer-parity residual**, documented + pinned: JSON Schema 2020-12's `"type": "integer"` legally accepts `2.0` ("a number with a zero fractional part") while `StrictInt` rejects it outright — inexpressible in pure JSON Schema. Comment at the integer-emitting site in `schema_export.py` + a test pinning the direction.

## Verification (generator≠grader, 2 rounds)

Codex `gpt-5.6-sol` xhigh, read-only, independent correctness review:

- **Round 1**: 2 MEDIUM findings — `STAGE_ORDER` missed 3 helpers (`_check_product_reference_integrity`, `_check_source_reference_integrity`, `_check_support_purposes_on_product`) that still iterated `payload.rules` unsorted despite emitting `rule_id`-attributed errors (proven at runtime: declaring two rules in different orders inverted `CompilationReport.errors`' order); the date-validation branch short-circuited past the `allowed_values` membership check even on a valid canonical date, silently dropping custom-registry `FACT_LITERAL_NOT_ALLOWED` coverage (proven: a registry allowing only `"2026-01-01"` accepted the unrelated `"2026-02-01"` with zero errors).
- **Fix round**: both cured — the 3 helpers now take a `stage_sorted_rules` parameter for their rule-side loop (keeping `payload.products`/`payload.source_records` iteration as-is, since products have no `RuleStage`); the date branch only returns early when it actually appended an error, otherwise falls through to `allowed_values`. Regression tests reproduce Codex's exact runtime counterexamples (both declaration orders asserted equal). Also applied the reviewer's regex-exactness suggestion: `fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")` instead of `\d`/`$`-anchored `match`.
- **Round 2**: both findings **CURED**, no new correctness issues. 27/27 new tests green, 215/215 in touched files green, ruff clean, `git diff --check` clean.

Final local state: **262/262** visa_engine tests green (up from 223 pre-PR1b), ruff clean, `docs_sync.py --check` clean (no derived-doc drift), full backend-rag pre-push suite green (17898 passed / 165 skipped).

## Test plan

- [x] `PYTHONPATH=apps/backend-rag apps/backend-rag/.venv/bin/python -m pytest apps/backend-rag/backend/tests/services/visa_engine -q` → 262 passed
- [x] `ruff check backend/services/visa_engine backend/tests/services/visa_engine` → clean
- [x] `python3 scripts/docs_sync.py --check` → no drift
- [x] Full pre-push suite (pre-commit + pre-push hooks) → green, 17898 passed
- [x] Codex xhigh independent review × 2 rounds → both MEDIUM findings cured, zero residual

🤖 Generated with [Claude Code](https://claude.com/claude-code)