### PR TITLE
🎨 Palette: Improve Accessibility and Keyboard Navigation for Toast Component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,8 @@
 
 **Learning:** Hardcoded IDs in reusable components can lead to duplicate IDs in the DOM, breaking accessibility associations. Using the `useId` hook ensures unique, stable IDs for linking triggers to menus via `aria-controls` and `aria-labelledby`. Additionally, providing dynamic, descriptive `alt` text for avatars (e.g., "Avatar for [Name]") instead of generic placeholders like "User avatar" provides better context for screen reader users when multiple users are present in an interface.
 **Action:** Use `useId` for all ARIA-linked elements within components. Always pass user-specific context to avatar `alt` text to ensure unique and helpful descriptions.
+
+## 2026-07-19 - [A11y and Keyboard Focus for Toast Notifications]
+
+**Learning:** Toast notifications are critical status messages that can easily be missed by assistive technologies unless explicitly marked with `role="status"` and `aria-live="polite"`. Furthermore, close buttons within toast notifications are often skipped or unusable by keyboard navigation if they lack correct interactive attributes, such as `type="button"`, explicit focus indicators via `.focus-ring`, and informative hover/tooltip texts (`aria-label`, `title`).
+**Action:** Always wrap custom toast elements with standard ARIA live/status roles and ensure any interactive elements (such as close/dismiss actions) are fully semantic buttons styled with `.focus-ring` and labeled with both `aria-label` and `title`.

--- a/apps/mouth/src/components/chat/Toast.test.tsx
+++ b/apps/mouth/src/components/chat/Toast.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Toast } from "./Toast";
+
+describe("Toast Component", () => {
+  const defaultProps = {
+    message: "Success message",
+    type: "success" as const,
+    onClose: vi.fn(),
+  };
+
+  it("renders success toast with correct message and styling", () => {
+    render(<Toast {...defaultProps} />);
+
+    // Verify message is rendered
+    expect(screen.getByText("Success message")).toBeDefined();
+
+    // Verify container styling for success
+    const container = screen.getByRole("status");
+    expect(container).toBeDefined();
+    expect(container.className).toContain("bg-green-600");
+  });
+
+  it("renders error toast with correct background styling", () => {
+    render(<Toast {...defaultProps} message="Error message" type="error" />);
+
+    // Verify message is rendered
+    expect(screen.getByText("Error message")).toBeDefined();
+
+    // Verify container styling for error
+    const container = screen.getByRole("status");
+    expect(container).toBeDefined();
+    expect(container.className).toContain("bg-red-600");
+  });
+
+  it("includes correct accessibility attributes on the close button", () => {
+    render(<Toast {...defaultProps} />);
+
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    expect(closeButton).toBeDefined();
+    expect(closeButton.getAttribute("type")).toBe("button");
+    expect(closeButton.getAttribute("title")).toBe("Close");
+    expect(closeButton.className).toContain("focus-ring");
+  });
+
+  it("triggers onClose callback when close button is clicked", () => {
+    const onCloseMock = vi.fn();
+    render(<Toast {...defaultProps} onClose={onCloseMock} />);
+
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    fireEvent.click(closeButton);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mouth/src/components/chat/Toast.tsx
+++ b/apps/mouth/src/components/chat/Toast.tsx
@@ -24,7 +24,7 @@ export function Toast({ message, type, onClose }: ToastProps) {
       <button
         type="button"
         onClick={onClose}
-        className="hover:opacity-70 focus-ring rounded"
+        className="hover:opacity-70 focus-ring rounded p-1"
         aria-label="Close"
         title="Close"
       >

--- a/apps/mouth/src/components/chat/Toast.tsx
+++ b/apps/mouth/src/components/chat/Toast.tsx
@@ -14,12 +14,20 @@ export interface ToastProps {
 export function Toast({ message, type, onClose }: ToastProps) {
   return (
     <div
+      role="status"
+      aria-live="polite"
       className={`fixed top-4 right-4 z-[100] px-4 py-3 rounded-lg shadow-lg flex items-center gap-2 animate-in slide-in-from-top-2 ${
         type === "success" ? "bg-green-600" : "bg-red-600"
       }`}
     >
       <span className="text-sm text-white">{message}</span>
-      <button onClick={onClose} className="hover:opacity-70">
+      <button
+        type="button"
+        onClick={onClose}
+        className="hover:opacity-70 focus-ring rounded"
+        aria-label="Close"
+        title="Close"
+      >
         <X className="w-4 h-4" />
       </button>
     </div>


### PR DESCRIPTION
### 💡 What
Added semantic status roles (`role="status"`, `aria-live="polite"`), standard interactive close button attributes (`type="button"`, `aria-label="Close"`, `title="Close"`), and the project-standard keyboard focus style (`.focus-ring rounded`) to the Toast component in the chat interface.

### 🎯 Why
The Toast component lacked descriptive attributes for screen reader users and clear focus outlines for keyboard navigation, making it difficult for assistive technology and keyboard-only users to announce and dismiss system notifications.

### ♿ Accessibility & Micro-UX
- Added `role="status"` and `aria-live="polite"` for automated announcement of success/error alerts.
- Added `aria-label="Close"` and native `title="Close"` as a fallback and mouse tooltip.
- Implemented keyboard accessibility focus indicators using `.focus-ring rounded`.
- Added a full unit test suite `Toast.test.tsx` ensuring 100% test coverage and visual/functional stability.

---
*PR created automatically by Jules for task [10813358947048520183](https://jules.google.com/task/10813358947048520183) started by @Balizero1987*