### PR TITLE
fix(intel): SEO step — migrate off deprecated gemini CLI to agy + codex fallback

### DIFF
--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -4,7 +4,9 @@ Post-publish poller v3 — Resilient unified pipeline with step tracking.
 
 Runs every 5 minutes via LaunchAgent (com.balizero.post-publish-poller).
 Reads from PostgreSQL-backed queue on backend, processes each article:
-  - SEO/GEO metadata optimization (Gemini CLI)
+  - SEO/GEO metadata optimization (agy — Antigravity CLI, Gemini 3.1 Pro;
+    falls back to Codex when agy is unreachable. `gemini` CLI is DEPRECATED —
+    Google discontinued the free-tier CLI, confirmed 2026-07-18)
   - Translation to 4 languages (Ollama local)
   - Cover image generation (bz_image_style + Codex $imagegen / gpt-image-2,
     two formats: 21:9 hero + 16:10 homepage card)
@@ -14,7 +16,8 @@ Resilience features:
   - Step tracking: completed_steps JSONB — only re-runs failed steps on retry
   - Max 5 attempts: after that, item moves to 'dead' status
   - Telegram alert on failure (after 2+ attempts)
-  - SEO prompt via stdin (not CLI arg) to avoid timeout on long articles
+  - SEO/image steps are pre-flight health-checked (agy_healthy, codex_healthy)
+    — a dead CLI leaves the step queued, never a corrupted/fabricated result
 
 Sources:
   - 'intel': MDX articles from intel scraper (full pipeline: SEO + translate + image)
@@ -23,6 +26,7 @@ Sources:
 import base64
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -56,6 +60,186 @@ IMAGE_GH_DIR = "apps/mouth/public/static/news"
 CODEX_BIN_DIR = "/opt/homebrew/bin"
 CODEX_TIMEOUT = 480  # seconds per image (smoke test ~3min, headroom for retries)
 CODEX_HEALTH_TIMEOUT = 60
+
+# ── agy (Antigravity CLI) — SEO/GEO text generation ──────────────────────────
+# Replaces the deprecated `gemini` CLI. Confirmed live 2026-07-18:
+# `gemini -m gemini-2.5-pro` returns `IneligibleTierError: This client is no
+# longer supported for Gemini Code Assist for individuals ... migrate to the
+# Antigravity suite` — Google discontinued the free-tier CLI outright. This is
+# a PERMANENT break (auth-tier removed, not a PATH/model mismatch) — every
+# SEO tick was silently eating this error as "no JSON in Gemini response".
+# agy runs on the Google AI Ultra OAuth seat; the model string matches what
+# scripts/agy_swarm_commander.py resolves its "pro-high" alias to.
+AGY_BIN_DIR = str(Path.home() / ".local" / "bin")
+AGY_MODEL = "Gemini 3.1 Pro (High)"
+AGY_HEALTH_TIMEOUT = 60
+SEO_LLM_TIMEOUT = 120  # per-call budget for the SEO JSON completion (agy or codex)
+
+
+def _agy_env() -> dict:
+    """Env for agy subprocess: ensure ~/.local/bin (where agy lives — not
+    guaranteed on the cron PATH) is present, strip paid-API keys (defense-in-
+    depth — agy runs on Google AI Ultra OAuth quota, never a billed key).
+    Mirrors _codex_env() below.
+    """
+    env = dict(os.environ)
+    path = env.get("PATH", "")
+    if AGY_BIN_DIR not in path.split(":"):
+        env["PATH"] = f"{AGY_BIN_DIR}:{path}" if path else AGY_BIN_DIR
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "FIREWORKS_API_KEY",
+    ):
+        env.pop(key, None)
+    return env
+
+
+_AGY_AUTH_DEAD_RE = re.compile(
+    r"authentication required|authentication failed|please sign in|"
+    r"not authenticated|log ?in to|token_revoked|401|unauthor",
+    re.I,
+)
+
+
+def agy_healthy() -> bool:
+    """Pre-flight: is the Antigravity CLI (agy) reachable and authed?
+
+    agy needs an interactive Google/Antigravity re-auth on its own schedule
+    (auth_sentinel.py family B — a human-only gesture per CLAUDE.md's
+    credential boundary, NOT something this poller can fix headlessly).
+    Confirmed live 2026-07-18 via `auth_sentinel.py --json`: agy status=
+    "action", "sessione Antigravity/Google scaduta o non risponde". If
+    unreachable, the caller leaves the SEO step queued for a later tick
+    instead of silently giving up (or corrupting frontmatter).
+    """
+    try:
+        proc = subprocess.run(
+            ["agy", "--print-timeout", "45s", "--print", "reply with exactly: pong"],
+            capture_output=True, text=True,
+            timeout=AGY_HEALTH_TIMEOUT, env=_agy_env(), cwd="/tmp",
+        )
+        out = (proc.stdout or "") + (proc.stderr or "")
+        if proc.returncode == 0 and "pong" in out.lower():
+            return True
+        if _AGY_AUTH_DEAD_RE.search(out):
+            log(f"  ⚠ agy auth FAIL: {out.strip()[-160:]}")
+        else:
+            log(f"  ⚠ agy health unclear rc={proc.returncode}: {out.strip()[-160:]}")
+        return False
+    except FileNotFoundError:
+        log("  ⚠ agy CLI not found on PATH")
+        return False
+    except subprocess.TimeoutExpired:
+        log("  ⚠ agy health-check timed out")
+        return False
+    except Exception as e:
+        log(f"  ⚠ agy health-check error: {e}")
+        return False
+
+
+def agy_generate_text(prompt: str, timeout: int = SEO_LLM_TIMEOUT) -> str | None:
+    """Run one non-interactive agy turn, return raw stdout (None on
+    timeout/error). `--sandbox` disables tool/shell actions — this call wants
+    a plain text/JSON completion, not an agentic session."""
+    try:
+        proc = subprocess.run(
+            ["agy", "--model", AGY_MODEL, "--sandbox",
+             "--print-timeout", f"{timeout}s", "--print", prompt],
+            capture_output=True, text=True,
+            timeout=timeout + 15, env=_agy_env(), cwd="/tmp",
+        )
+    except subprocess.TimeoutExpired:
+        log("    ❌ agy generation timed out")
+        return None
+    except Exception as e:
+        log(f"    ❌ agy generation error: {e}")
+        return None
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "")[-200:]
+        log(f"    ❌ agy generation rc={proc.returncode}: {tail}")
+        return None
+    return proc.stdout or ""
+
+
+def codex_generate_text(prompt: str, timeout: int = SEO_LLM_TIMEOUT) -> str | None:
+    """Run `codex exec` for a plain-text/JSON completion (read-only sandbox —
+    no file writes needed). Fallback path for SEO generation when agy is
+    unreachable; reuses the same ChatGPT Pro OAuth quota already spent on
+    cover images in this file."""
+    try:
+        proc = subprocess.run(
+            ["codex", "exec", "--skip-git-repo-check", "--sandbox", "read-only", "-"],
+            input=prompt, capture_output=True, text=True,
+            timeout=timeout, env=_codex_env(), cwd="/tmp",
+        )
+    except subprocess.TimeoutExpired:
+        log("    ❌ codex text generation timed out")
+        return None
+    except Exception as e:
+        log(f"    ❌ codex text generation error: {e}")
+        return None
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "")[-200:]
+        log(f"    ❌ codex text generation rc={proc.returncode}: {tail}")
+        return None
+    return proc.stdout or ""
+
+
+def _seo_llm_complete(prompt: str) -> tuple[str | None, str]:
+    """Get a raw completion for the SEO prompt from the first healthy CLI:
+    agy (primary — CLAUDE.md-mandated replacement for the deprecated `gemini`
+    CLI) then codex (fallback — already wired into this file for cover
+    images). Returns (None, "") if neither is reachable; the caller MUST
+    leave the item queued rather than fabricate metadata.
+    """
+    if agy_healthy():
+        out = agy_generate_text(prompt)
+        if out is not None:
+            return out, "agy"
+        log("  ⚠ SEO: agy healthy but generation failed — trying codex")
+    if codex_healthy():
+        out = codex_generate_text(prompt)
+        if out is not None:
+            return out, "codex"
+    return None, ""
+
+
+def _iter_json_objects(text: str):
+    """Yield every syntactically-balanced {...} substring in `text`, in
+    appearance order. More robust than a single greedy regex span (which
+    would swallow from the first '{' anywhere — e.g. an echoed prompt —
+    straight through to the very last '}' and then fail to parse)."""
+    depth = 0
+    start = None
+    for i, ch in enumerate(text):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            if depth > 0:
+                depth -= 1
+                if depth == 0 and start is not None:
+                    yield text[start:i + 1]
+                    start = None
+
+
+def _extract_seo_json(raw: str) -> dict | None:
+    """Tolerant JSON extraction for the SEO completion: scan every balanced
+    {...} candidate, last-first (the model's real answer is usually the LAST
+    object printed, after any reasoning/prompt-echo prose), and accept the
+    first one that both parses AND carries an expected key."""
+    for blob in reversed(list(_iter_json_objects(raw))):
+        try:
+            obj = json.loads(blob)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and ("seoTitle" in obj or "seoDescription" in obj):
+            return obj
+    return None
 
 
 def _codex_env() -> dict:
@@ -449,9 +633,12 @@ def wait_for_ollama_free(max_wait: int = 60 * 15) -> bool:
 # ─── SEO/GEO ──────────────────────────────────────────────────────────────────
 
 def run_seo(slug: str, category: str) -> bool:
-    """Optimize SEO/GEO metadata of published MDX via Gemini. Uses stdin for prompt."""
-    import re
+    """Optimize SEO/GEO metadata of published MDX via agy (fallback: codex).
 
+    Pre-flight health-checked (see _seo_llm_complete): if neither CLI is
+    reachable, the step is left queued for a later tick rather than silently
+    giving up — or worse, corrupting frontmatter with a garbage response.
+    """
     ARTICLES_PATH = "apps/mouth/src/content/articles"
     mdx_path = f"{ARTICLES_PATH}/{category}/{slug}.mdx"
 
@@ -507,35 +694,14 @@ Return this exact JSON structure:
   }}
 }}"""
 
-    # Use stdin instead of -p arg to avoid shell/timeout issues on long prompts
-    try:
-        result = subprocess.run(
-            ["gemini", "-m", "gemini-2.5-pro"],
-            input=prompt, capture_output=True, text=True, timeout=90,
-        )
-        if result.returncode != 0 or not result.stdout.strip():
-            # Fallback to default model
-            result = subprocess.run(
-                ["gemini"],
-                input=prompt, capture_output=True, text=True, timeout=90,
-            )
-    except subprocess.TimeoutExpired:
-        log("  ⚠ SEO: Gemini timeout (90s)")
-        return False
-    except Exception as e:
-        log(f"  ⚠ SEO: Gemini error: {e}")
+    raw, tool_used = _seo_llm_complete(prompt)
+    if raw is None:
+        log("  ⏸ SEO: no LLM reachable (agy + codex both down) — leaving queued")
         return False
 
-    raw = result.stdout.strip()
-    json_match = re.search(r'\{.*\}', raw, re.DOTALL)
-    if not json_match:
-        log("  ⚠ SEO: no JSON in Gemini response")
-        return False
-
-    try:
-        seo = json.loads(json_match.group(0))
-    except json.JSONDecodeError:
-        log("  ⚠ SEO: invalid JSON from Gemini")
+    seo = _extract_seo_json(raw)
+    if seo is None:
+        log(f"  ⚠ SEO: no JSON in {tool_used} response")
         return False
 
     def set_fm_field(fm: str, key: str, value: str) -> str:
@@ -564,7 +730,7 @@ Return this exact JSON structure:
     # _PENDING_COMMITS) — stage for the end-of-tick batch-branch/PR flush instead.
     _stage_commit("seo", mdx_path, new_content.encode("utf-8"),
                   f"feat(seo): optimize GEO/AEO metadata for '{title[:50]}'")
-    log("  📦 SEO/GEO metadata staged for batch commit")
+    log(f"  📦 SEO/GEO metadata staged for batch commit (via {tool_used})")
     return True
 
 

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -7,6 +7,8 @@ replacement: writes are staged in-memory during a poller tick and flushed
 once, per kind, into ONE bot branch + auto-merged PR.
 """
 
+import base64
+import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -645,3 +647,191 @@ class TestProcessItemNeverSkipsImageStep:
         mock_image.assert_called_once()
         # mark_step_done must NOT be called for "image" when run_image fails
         assert ("lost-slug", "image") not in [c.args for c in mock_mark.call_args_list]
+
+
+# ── SEO step: migrated off the deprecated `gemini` CLI ──────────────────────
+#
+# `gemini -m gemini-2.5-pro` started returning `IneligibleTierError: ... migrate
+# to the Antigravity suite` — Google discontinued the free-tier CLI outright
+# (confirmed live 2026-07-18), a PERMANENT break, not a PATH/model mismatch.
+# run_seo() now delegates to _seo_llm_complete(), which tries agy first
+# (CLAUDE.md's mandated replacement) then falls back to codex (already wired
+# into this file for cover images) — each pre-flight health-checked so a dead
+# tool leaves the item queued instead of corrupting frontmatter.
+
+
+class TestExtractSeoJson:
+    def test_valid_json_only(self):
+        raw = '{"seoTitle": "Foo", "seoDescription": "Bar"}'
+        assert ppp._extract_seo_json(raw) == {"seoTitle": "Foo", "seoDescription": "Bar"}
+
+    def test_json_with_surrounding_prose(self):
+        raw = 'Here is the metadata:\n{"seoTitle": "Foo", "seoDescription": "Bar"}\nHope that helps!'
+        assert ppp._extract_seo_json(raw) == {"seoTitle": "Foo", "seoDescription": "Bar"}
+
+    def test_prompt_echo_then_real_answer_picks_the_last_valid_object(self):
+        # Simulates an agentic CLI echoing an unrelated JSON blob (e.g. its
+        # own input record) before the real answer — must pick the LAST
+        # candidate that parses AND carries an expected key, not the first.
+        raw = '{"unrelated": "echo"}\n\n{"seoTitle": "Real", "seoDescription": "Answer"}'
+        assert ppp._extract_seo_json(raw) == {"seoTitle": "Real", "seoDescription": "Answer"}
+
+    def test_no_braces_returns_none(self):
+        assert ppp._extract_seo_json("Error: authentication required. Run 'agy' to log in.") is None
+
+    def test_empty_string_returns_none(self):
+        assert ppp._extract_seo_json("") is None
+
+    def test_malformed_json_returns_none(self):
+        assert ppp._extract_seo_json("{seoTitle: not valid json}") is None
+
+
+class TestSeoLlmCascade:
+    def test_agy_healthy_and_generates_uses_agy_only(self):
+        with (
+            patch.object(ppp, "agy_healthy", return_value=True),
+            patch.object(ppp, "agy_generate_text", return_value='{"seoTitle": "x"}') as mock_agy,
+            patch.object(ppp, "codex_healthy") as mock_codex_healthy,
+        ):
+            raw, tool = ppp._seo_llm_complete("prompt")
+
+        assert (raw, tool) == ('{"seoTitle": "x"}', "agy")
+        mock_agy.assert_called_once_with("prompt")
+        mock_codex_healthy.assert_not_called()
+
+    def test_agy_unreachable_falls_back_to_codex(self):
+        with (
+            patch.object(ppp, "agy_healthy", return_value=False),
+            patch.object(ppp, "codex_healthy", return_value=True),
+            patch.object(ppp, "codex_generate_text", return_value='{"seoDescription": "y"}') as mock_codex,
+        ):
+            raw, tool = ppp._seo_llm_complete("prompt")
+
+        assert (raw, tool) == ('{"seoDescription": "y"}', "codex")
+        mock_codex.assert_called_once_with("prompt")
+
+    def test_agy_healthy_but_generation_fails_falls_back_to_codex(self):
+        with (
+            patch.object(ppp, "agy_healthy", return_value=True),
+            patch.object(ppp, "agy_generate_text", return_value=None),
+            patch.object(ppp, "codex_healthy", return_value=True),
+            patch.object(ppp, "codex_generate_text", return_value='{"seoTitle": "z"}'),
+        ):
+            raw, tool = ppp._seo_llm_complete("prompt")
+
+        assert (raw, tool) == ('{"seoTitle": "z"}', "codex")
+
+    def test_both_unreachable_returns_none_never_fabricates(self):
+        with (
+            patch.object(ppp, "agy_healthy", return_value=False),
+            patch.object(ppp, "codex_healthy", return_value=False),
+        ):
+            raw, tool = ppp._seo_llm_complete("prompt")
+
+        assert raw is None
+        assert tool == ""
+
+
+def _mdx_frontmatter_payload(body_extra: str = "") -> str:
+    """A `gh api contents/...` response body for a not-yet-optimized MDX file
+    (no answerSnippet in frontmatter, so run_seo won't short-circuit as
+    already-optimized)."""
+    content = (
+        "---\n"
+        'title: "Test Article"\n'
+        'seoTitle: ""\n'
+        "---\n"
+        f"Body text here.{body_extra}\n"
+    )
+    return json.dumps({"content": base64.b64encode(content.encode()).decode("ascii")})
+
+
+class TestRunSeo:
+    def test_valid_json_response_stages_seo_commit(self):
+        gh_payload = _mdx_frontmatter_payload()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["gh", "api"]:
+                return _res(stdout=gh_payload)
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        seo_json = (
+            '{"seoTitle": "Great SEO Title", "seoDescription": "Great SEO description.", '
+            '"aiOptimization": {"answerSnippet": "The answer.", "primaryQuestion": "What is it?"}}'
+        )
+        with (
+            patch("scripts.post_publish_poller.subprocess.run", side_effect=fake_run),
+            patch.object(ppp, "_seo_llm_complete", return_value=(seo_json, "agy")),
+        ):
+            ok = ppp.run_seo("test-slug", "business")
+
+        assert ok is True
+        staged = [c for c in ppp._PENDING_COMMITS if c["kind"] == "seo"]
+        assert len(staged) == 1
+        decoded = base64.b64decode(staged[0]["content_b64"]).decode()
+        assert "Great SEO Title" in decoded
+        assert "Great SEO description." in decoded
+        assert staged[0]["gh_path"] == "apps/mouth/src/content/articles/business/test-slug.mdx"
+
+    def test_empty_or_non_json_response_does_not_stage_and_returns_false(self):
+        """The CLI ran (agy/codex both reported healthy) but its answer had no
+        parseable JSON (e.g. a stray auth-error string past the health-check,
+        or a truncated response) — must NOT stage a commit and must return
+        False so the item is honestly retried, never a silent no-op success."""
+        gh_payload = _mdx_frontmatter_payload()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["gh", "api"]:
+                return _res(stdout=gh_payload)
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        with (
+            patch("scripts.post_publish_poller.subprocess.run", side_effect=fake_run),
+            patch.object(ppp, "_seo_llm_complete", return_value=("not json at all", "agy")),
+        ):
+            ok = ppp.run_seo("test-slug", "business")
+
+        assert ok is False
+        assert [c for c in ppp._PENDING_COMMITS if c["kind"] == "seo"] == []
+
+    def test_neither_agy_nor_codex_reachable_leaves_item_queued(self):
+        """Both CLIs unreachable (e.g. agy needs interactive re-auth AND codex
+        token revoked) — must leave the step queued (return False, no staged
+        commit), never fabricate metadata to force a "done" state."""
+        gh_payload = _mdx_frontmatter_payload()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["gh", "api"]:
+                return _res(stdout=gh_payload)
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        with (
+            patch("scripts.post_publish_poller.subprocess.run", side_effect=fake_run),
+            patch.object(ppp, "_seo_llm_complete", return_value=(None, "")),
+        ):
+            ok = ppp.run_seo("test-slug", "business")
+
+        assert ok is False
+        assert [c for c in ppp._PENDING_COMMITS if c["kind"] == "seo"] == []
+
+    def test_agy_invocation_uses_configured_model_and_sandbox(self):
+        """Regression pin for the actual CLI invocation shape (agy_swarm_
+        commander.py convention: --model "Gemini 3.1 Pro (High)" --sandbox)."""
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            return _res(stdout='{"seoTitle": "x"}')
+
+        with patch("scripts.post_publish_poller.subprocess.run", side_effect=fake_run):
+            out = ppp.agy_generate_text("some prompt")
+
+        assert out == '{"seoTitle": "x"}'
+        cmd = captured["cmd"]
+        assert cmd[0] == "agy"
+        assert "--model" in cmd and ppp.AGY_MODEL in cmd
+        assert "--sandbox" in cmd
+        assert "--print" in cmd and "some prompt" in cmd
+        # PATH must include agy's install dir even if the cron PATH lacks it
+        assert ppp.AGY_BIN_DIR in captured["env"]["PATH"].split(":")


### PR DESCRIPTION
## Summary

- `run_seo()` in `apps/bali-intel-scraper/scripts/post_publish_poller.py` called the `gemini` CLI (`gemini -m gemini-2.5-pro`, fallback bare `gemini`), which now returns `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals ... migrate to the Antigravity suite` on every call — Google discontinued the free-tier CLI outright (confirmed live 2026-07-18 by direct invocation on Pro with the exact production env/PATH). This is a **permanent** break, not a PATH/model mismatch — every SEO tick silently ate the error as "no JSON in Gemini response", producing ~54 stuck articles in the post-publish queue (currently 115 `failed` rows, ~54 of them SEO).
- `run_seo()` now calls `_seo_llm_complete()`, which tries **agy** (Antigravity CLI, Gemini 3.1 Pro — CLAUDE.md's mandated replacement for the deprecated `gemini` CLI) first, falling back to **codex** (already wired into this file for cover images via `codex_healthy()`/`_codex_env()`) when agy is unreachable. Both paths are pre-flight health-checked (`agy_healthy()`/`codex_healthy()`) — a dead tool leaves the item queued for a later tick instead of corrupting frontmatter or silently no-oping.
- JSON extraction is now a tolerant balanced-brace scan (`_extract_seo_json` / `_iter_json_objects`) instead of a single greedy regex, so prompt-echo prose from an agentic CLI doesn't defeat parsing.
- **Live finding**: agy itself is currently NOT authenticated on Pro (`auth_sentinel.py --json` → `agy: status=action, "sessione Antigravity/Google scaduta o non risponde"`) — a human-only re-auth gesture (Antigravity IDE) per CLAUDE.md's credential boundary, already tracked separately by `auth_sentinel.py`. `codex` is healthy right now, so the fallback path can start draining the backlog immediately; once agy is re-authed the primary path takes over with zero further deploy.
- **Scope note**: `run_translate()` / `git_commit_and_push_translations()` are intentionally untouched — #2752 (merged earlier the same day) already fixed the orphan-committer bug in the translation git-push path. This PR is SEO-only to avoid overlapping with that change.

## Test plan

- [x] `python3 -m pytest apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py --confcutdir=apps/bali-intel-scraper/tests/unit -q` → 38 passed (24 pre-existing + 14 new)
- [x] Adversarial check: reverted just the source-file fix (`git stash`) and reran the new test file against the OLD code — all 14 new SEO tests failed as expected (proves they're not vacuous), then restored the fix and re-confirmed green
- [x] `ruff check` clean on both changed files
- [x] `scripts/docs_sync.py --check` → no drift
- [x] Guilt/innocence coverage: (a) valid JSON from agy → stages the SEO commit; (b) empty/non-JSON response → does NOT stage, returns `False`, logs the tool that produced the bad response; (c) both agy and codex unreachable → leaves item queued, never fabricates metadata
- [x] Regression pin on the exact agy CLI invocation shape (`--model "Gemini 3.1 Pro (High)" --sandbox --print-timeout … --print …`, matching `scripts/agy_swarm_commander.py`'s `pro-high` alias) + PATH hardening (`~/.local/bin` prepended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)