### PR TITLE
feat(wa-tester): standalone WhatsApp phone-test CLI against the Zantara bot

### DIFF
--- a/apps/wa-mirror/docs/wa-tester.md
+++ b/apps/wa-mirror/docs/wa-tester.md
@@ -1,0 +1,200 @@
+# wa-tester — WhatsApp phone-test CLI for the Zantara bot
+
+## What it is
+
+`wa-tester` is a standalone, on-demand CLI that runs end-to-end test
+batteries against the Zantara WhatsApp bot (**+62 821 3465 159**) by sending
+real WhatsApp messages **from Zero's own number (+62 822 3010 2328)** and
+recording the bot's replies. It lets the team run a battery of real
+questions through the real WhatsApp channel — the same path a client uses —
+instead of only hitting the backend RAG API directly.
+
+It lives at:
+
+- `apps/wa-mirror/scripts/wa-tester-core.ts` — pure logic (allowlist guard,
+  battery validation, quiet-period reply collection, transcript assembly).
+  Fully unit-tested, no network/socket code.
+- `apps/wa-mirror/scripts/wa-tester.ts` — the CLI entrypoint. Owns the live
+  Baileys socket (connect, pair, send, listen).
+- `apps/wa-mirror/scripts/wa-tester.sh` — thin wrapper (`PATH` fixup +
+  `npx tsx`).
+
+## It is NOT a mirror session — read this before touching anything
+
+`apps/wa-mirror` is architected as a **read-only** mirror (`bridge/session.ts`
+header: _"we never call sock.sendMessage"_) that connects each Bali Zero team
+member's WhatsApp account and logs their conversations into the CRM. It is
+managed by `scripts/start-one.sh` / `start-all.sh`, tracked in
+`~/.wa-mirror.accounts.json`, supervised by `scripts/supervise-launcher.sh`,
+and kept alive by a LaunchAgent plist.
+
+`wa-tester` is architecturally the opposite of that on purpose:
+
+|                         | wa-mirror (bridge)                | wa-tester                                                             |
+| ----------------------- | --------------------------------- | --------------------------------------------------------------------- |
+| Sends messages?         | Never (read-only)                 | Yes — that's the whole point                                          |
+| Who's account?          | Every team member (9 sessions)    | ONLY Zero's own number, ad-hoc                                        |
+| Roster?                 | `~/.wa-mirror.accounts.json`      | none — not an account, not a session                                  |
+| Daemon/cron/plist?      | Yes (supervised, always-on)       | **No — CLI only, exits when done**                                    |
+| Writes to Postgres/CRM? | Yes (every message)               | **No — zero DB dependency**                                           |
+| Auth state path         | `apps/wa-mirror/sessions/<e164>/` | `~/.wa-tester/state/<e164>/` (separate tree, never under `sessions/`) |
+
+**wa-tester must never be added to the accounts roster, never get a plist,
+never run on a schedule, and its auth-state directory must never live under
+`apps/wa-mirror/sessions/`.** If it did, the supervisor / `start-all.sh`
+would try to manage it as a 10th read-only mirror session, which would be
+both wrong (it sends messages) and a privacy violation (mirroring captures
+_all_ of Zero's personal chats, not just the test conversation with the
+bot).
+
+`bridge/` itself is never modified by wa-tester — the two pure helpers it
+imports (`isTerminalCloseCode`, `mapCloseReason` from `bridge/session.ts`)
+are read-only, DB-agnostic close-code classifiers reused as-is.
+
+## THE one rule: hardcoded recipient allowlist
+
+wa-tester runs from Zero's **real** WhatsApp number. The one thing that
+makes that safe is that it can never message anyone except the Zantara bot.
+
+- The recipient JID is a compile-time constant in
+  `wa-tester-core.ts` (`BOT_JID` / `BOT_PHONE_E164`, +62 821 3465 159).
+  **No CLI flag, environment variable, or config file can change it.**
+- Every battery file is validated **before any socket connects and before
+  any message is sent** (`validateBattery` in `wa-tester-core.ts`). The
+  validator scans both the battery root and every question for any
+  recipient-lookalike field (`to`, `recipient`, `jid`, `phone`, `number`,
+  `target`, `send_to`); if present and it does not resolve to the bot
+  number, the whole run is refused with a hard error.
+- The guard is covered by guilt + innocence tests in
+  `tests/wa-tester-core.test.ts` (per the repo's guard-conformance
+  discipline — `.claude/rules/cicatrix-superscar.md` family #3): a battery
+  naming another number is refused, a normal battery (or one whose
+  recipient field happens to already match the bot) passes.
+
+## Pairing runbook
+
+Auth state is a separate Baileys identity from any wa-mirror session —
+pairing has to happen once, interactively, from Zero's phone.
+
+```bash
+cd apps/wa-mirror
+bash scripts/wa-tester.sh --pair
+```
+
+1. A QR code is written to `/tmp/qr-tester-6282230102328.png` and also
+   printed to the terminal as ASCII.
+2. On Zero's phone: **WhatsApp → Settings → Linked Devices → Link a
+   Device**, scan it.
+3. WhatsApp always bounces the connection once right after pairing
+   (Baileys close code 515, `restartRequired`) — wa-tester reconnects
+   automatically exactly once and confirms the session is stable before
+   exiting `0`. If it does not stabilize, re-run `--pair`.
+4. Auth state is now persisted under `WA_TESTER_STATE_DIR` (default
+   `~/.wa-tester/state/+6282230102328/`, `chmod 0700`). Nothing else needs
+   to run — there is no daemon to start.
+
+**Re-pairing** (device unlinked, or moving to a fresh state dir): delete the
+state directory and run `--pair` again:
+
+```bash
+rm -rf ~/.wa-tester/state/+6282230102328
+bash scripts/wa-tester.sh --pair
+```
+
+**Check pairing/connectivity without sending anything:**
+
+```bash
+bash scripts/wa-tester.sh --status
+```
+
+Prints one line — `NOT_PAIRED`, `PAIRED_AND_CONNECTED — <jid>`, or
+`PAIRED_BUT_CONNECT_FAILED — <reason>` — with exit codes `1`/`0`/`2`
+respectively. Sends no messages.
+
+## Battery format
+
+A battery is a JSON file with a list of questions to fire at the bot in
+order, one at a time:
+
+```json
+{
+  "questions": [
+    { "id": "b211a-basics", "text": "Ciao, come funziona il B211A?" },
+    { "id": "kitas-cost", "text": "Quanto costa il KITAS investor?" }
+  ],
+  "reply_timeout_s": 90,
+  "inter_question_delay_s": 20
+}
+```
+
+- `questions[].id` — unique string, used to key the transcript.
+- `questions[].text` — the exact message sent to the bot.
+- `reply_timeout_s` (default `90`) — hard cap: if zero replies arrive within
+  this window, the question is recorded with 0 replies and the run moves on.
+  Also a safety cap that stops collection even mid-conversation.
+- `inter_question_delay_s` (default `20`) — pause between questions.
+- Any field named `to`/`recipient`/`jid`/`phone`/`number`/`target`/`send_to`
+  at the battery root or on a question is checked against the hardcoded bot
+  number — see "THE one rule" above.
+
+Run it:
+
+```bash
+bash scripts/wa-tester.sh --send-battery battery.json --out transcript.json
+```
+
+For each question, wa-tester sends the text to the bot, then collects
+**every** reply message until either the `reply_timeout_s` cap is hit or a
+**10-second quiet period** elapses after at least one reply has arrived
+(handles multi-message bot answers that arrive as several bubbles).
+
+Output transcript (`--out`, default `/tmp/wa-tester-transcript-<ts>.json`):
+
+```json
+{
+  "battery_file": "/abs/path/battery.json",
+  "bot_jid": "628213465159@s.whatsapp.net",
+  "started_at": "2026-...",
+  "finished_at": "2026-...",
+  "questions": [
+    {
+      "id": "b211a-basics",
+      "text": "Ciao, come funziona il B211A?",
+      "sent_at": "2026-...",
+      "replies": [
+        { "text": "...", "timestamp": "2026-...", "latency_ms": 1832 }
+      ],
+      "reply_count": 1,
+      "first_reply_latency_ms": 1832
+    }
+  ],
+  "summary": { "total_questions": 2, "questions_with_zero_replies": 0 }
+}
+```
+
+wa-tester exits non-zero if **any** question got zero replies —
+`summary.questions_with_zero_replies > 0` — so it can gate a CI-style check
+or a Telegram alert on a real end-to-end silence.
+
+## Privacy rails
+
+- The live socket subscribes to `messages.upsert` and processes **only**
+  events whose `remoteJid` equals the hardcoded bot JID; every other chat
+  (including group chats, status updates, and any of Zero's real personal
+  conversations) is ignored in the handler and never logged, printed, or
+  written to the transcript.
+- Auth state directory is `chmod 0700` on creation (repo scar family #4 —
+  secret-in-the-clear; Baileys auth state includes Signal session keys).
+- No Postgres/CRM writes, no Telegram alerts, no EventBus emission — the
+  tester has zero footprint outside its own state dir and the transcript
+  file it's told to write.
+
+## Runtime notes
+
+- Runtime is the Pro machine. Non-interactive `ssh` sessions don't source
+  the shell rc that puts Homebrew `node`/`npm` on `PATH` — `wa-tester.sh`
+  prepends `/opt/homebrew/bin` explicitly so it works over `ssh pro
+'bash apps/wa-mirror/scripts/wa-tester.sh --status'` without a login
+  shell.
+- Same Baileys version as the mirror (`@whiskeysockets/baileys@7.0.0-rc13`,
+  reused from `package.json` — no second Baileys dependency).

--- a/apps/wa-mirror/package.json
+++ b/apps/wa-mirror/package.json
@@ -11,6 +11,7 @@
     "dev": "tsx watch bridge/index.ts",
     "onboard": "tsx scripts/onboard.ts",
     "status": "tsx scripts/status.ts",
+    "wa-tester": "tsx scripts/wa-tester.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/apps/wa-mirror/scripts/wa-tester-core.ts
+++ b/apps/wa-mirror/scripts/wa-tester-core.ts
@@ -1,0 +1,380 @@
+// wa-tester-core.ts — pure, unit-testable logic for wa-tester.
+//
+// Deliberately kept OUTSIDE bridge/ (the read-only mirror organ). wa-tester
+// is a separate, single-purpose tool: it sends test messages from Zero's own
+// WhatsApp number to the Zantara bot and records the replies. Nothing in
+// here touches Postgres, the CRM, Telegram, or the wa-mirror sessions/
+// roster — see docs/wa-tester.md for the full boundary.
+//
+// Everything in this file is a pure function or a pure state machine (no
+// I/O, no Baileys socket, no clock reads except via injected `nowMs`
+// parameters) so it can be unit-tested without a live WhatsApp connection.
+// The live-socket glue lives in scripts/wa-tester.ts and imports from here.
+
+import { normalizePhone, phoneDigits } from "../bridge/phone.js";
+
+// ---------------------------------------------------------------------------
+// THE ONE RULE — hardcoded recipient allowlist.
+//
+// wa-tester runs from Zero's REAL WhatsApp number. The one thing that makes
+// that safe is that it can NEVER send to anyone but the Zantara bot. This
+// constant is not read from a flag, env var, or config file anywhere in this
+// tool — grep the repo for BOT_PHONE_E164 if you doubt it.
+// ---------------------------------------------------------------------------
+export const BOT_PHONE_E164 = "+628213465159"; // Zantara WA bot (+62 821 3465 159)
+export const BOT_PHONE_DIGITS = "628213465159";
+export const BOT_JID = `${BOT_PHONE_DIGITS}@s.whatsapp.net`;
+
+// Zero's own number — used ONLY to derive the default auth-state path and
+// the QR filename. NEVER used as a send target.
+export const TESTER_PHONE_E164 = "+6282230102328"; // +62 822 3010 2328
+export const TESTER_PHONE_DIGITS = "6282230102328";
+
+export const DEFAULT_REPLY_TIMEOUT_S = 90;
+export const DEFAULT_INTER_QUESTION_DELAY_S = 20;
+export const QUIET_PERIOD_S = 10;
+
+// ---------------------------------------------------------------------------
+// Recipient allowlist guard
+// ---------------------------------------------------------------------------
+
+/** Keys a battery author might (mistakenly or maliciously) use to try to
+ * redirect a send to a different number. Checked at the battery root AND on
+ * every question object. Any OTHER key is ignored — this guard only fires
+ * on fields that are plausibly "who do we send this to". */
+const RECIPIENT_LOOKALIKE_KEYS = [
+  "to",
+  "recipient",
+  "jid",
+  "phone",
+  "number",
+  "target",
+  "send_to",
+] as const;
+
+/**
+ * True if `value` (E.164, bare digits, local 0-prefixed, or a JID string
+ * like "628213465159@s.whatsapp.net") resolves to the hardcoded bot number.
+ * Fails CLOSED: anything that cannot be confidently matched is NOT the bot.
+ */
+export function matchesBotRecipient(value: string): boolean {
+  const jidPart = value.includes("@")
+    ? value.split("@")[0].split(":")[0]
+    : value;
+  const normalized = normalizePhone(jidPart);
+  if (normalized && phoneDigits(normalized) === BOT_PHONE_DIGITS) return true;
+  const rawDigits = jidPart.replace(/\D/g, "");
+  return rawDigits.length > 0 && rawDigits === BOT_PHONE_DIGITS;
+}
+
+export type AllowlistViolation = { ok: false; error: string };
+export type AllowlistOk = { ok: true };
+
+/**
+ * Scans one object (battery root or a single question) for any
+ * recipient-lookalike field and refuses if it does not resolve to the bot.
+ * Called BEFORE any send — see validateBattery below.
+ */
+export function checkRecipientAllowlist(
+  obj: Record<string, unknown>,
+  ctx: string,
+): AllowlistOk | AllowlistViolation {
+  for (const key of RECIPIENT_LOOKALIKE_KEYS) {
+    if (!(key in obj)) continue;
+    const val = obj[key];
+    if (typeof val !== "string" || val.trim() === "") continue;
+    if (!matchesBotRecipient(val)) {
+      return {
+        ok: false,
+        error:
+          `${ctx}: field '${key}'=${JSON.stringify(val)} does not resolve to the ` +
+          `hardcoded bot recipient (${BOT_PHONE_E164}) — refusing to send. ` +
+          "wa-tester allows ONLY the Zantara bot number, no exceptions, no override.",
+      };
+    }
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Battery parsing / validation
+// ---------------------------------------------------------------------------
+
+export type BatteryQuestion = { id: string; text: string };
+
+export type Battery = {
+  questions: BatteryQuestion[];
+  reply_timeout_s: number;
+  inter_question_delay_s: number;
+};
+
+export type ValidateBatteryResult =
+  | { ok: true; battery: Battery }
+  | { ok: false; error: string };
+
+function coercePositiveNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0)
+    return value;
+  return fallback;
+}
+
+export function validateBattery(raw: unknown): ValidateBatteryResult {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { ok: false, error: "battery: root must be a JSON object" };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  const rootGuard = checkRecipientAllowlist(obj, "battery");
+  if (!rootGuard.ok) return rootGuard;
+
+  if (!Array.isArray(obj.questions) || obj.questions.length === 0) {
+    return {
+      ok: false,
+      error: "battery: 'questions' must be a non-empty array",
+    };
+  }
+
+  const questions: BatteryQuestion[] = [];
+  const seenIds = new Set<string>();
+  for (let i = 0; i < obj.questions.length; i++) {
+    const q = obj.questions[i];
+    if (typeof q !== "object" || q === null || Array.isArray(q)) {
+      return { ok: false, error: `battery.questions[${i}]: must be an object` };
+    }
+    const qObj = q as Record<string, unknown>;
+
+    const qGuard = checkRecipientAllowlist(qObj, `battery.questions[${i}]`);
+    if (!qGuard.ok) return qGuard;
+
+    if (typeof qObj.id !== "string" || qObj.id.trim() === "") {
+      return {
+        ok: false,
+        error: `battery.questions[${i}]: 'id' must be a non-empty string`,
+      };
+    }
+    if (typeof qObj.text !== "string" || qObj.text.trim() === "") {
+      return {
+        ok: false,
+        error: `battery.questions[${i}]: 'text' must be a non-empty string`,
+      };
+    }
+    if (seenIds.has(qObj.id)) {
+      return {
+        ok: false,
+        error: `battery.questions[${i}]: duplicate id '${qObj.id}'`,
+      };
+    }
+    seenIds.add(qObj.id);
+    questions.push({ id: qObj.id, text: qObj.text });
+  }
+
+  return {
+    ok: true,
+    battery: {
+      questions,
+      reply_timeout_s: coercePositiveNumber(
+        obj.reply_timeout_s,
+        DEFAULT_REPLY_TIMEOUT_S,
+      ),
+      inter_question_delay_s: coercePositiveNumber(
+        obj.inter_question_delay_s,
+        DEFAULT_INTER_QUESTION_DELAY_S,
+      ),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reply collection — quiet-period state machine
+// ---------------------------------------------------------------------------
+
+export type CollectedReply = { text: string; timestampMs: number };
+
+export type CollectorVerdict = "collecting" | "stop_quiet" | "stop_timeout";
+
+/**
+ * Pure decision engine for "have we collected enough replies to this
+ * question yet?". No clock reads, no timers — the caller (live socket code
+ * or a test) supplies `nowMs` and reply events explicitly.
+ *
+ * Rule: keep collecting until EITHER
+ *   (a) reply_timeout_s has elapsed since sent_at with ZERO replies (hard
+ *       timeout, question is answered with 0 replies), or
+ *   (b) at least one reply has arrived AND quiet_period_s has elapsed since
+ *       the LAST reply (quiet-period complete), or
+ *   (c) reply_timeout_s has elapsed since sent_at regardless of reply count
+ *       (safety cap — never wait past the hard timeout even mid-quiet-window).
+ */
+export class ReplyCollector {
+  private readonly replies: CollectedReply[] = [];
+  private readonly sentAtMs: number;
+  private readonly hardTimeoutMs: number;
+  private readonly quietPeriodMs: number;
+
+  constructor(opts: {
+    sentAtMs: number;
+    replyTimeoutS: number;
+    quietPeriodS?: number;
+  }) {
+    this.sentAtMs = opts.sentAtMs;
+    this.hardTimeoutMs = opts.replyTimeoutS * 1000;
+    this.quietPeriodMs = (opts.quietPeriodS ?? QUIET_PERIOD_S) * 1000;
+  }
+
+  addReply(text: string, timestampMs: number): void {
+    this.replies.push({ text, timestampMs });
+  }
+
+  get count(): number {
+    return this.replies.length;
+  }
+
+  get all(): CollectedReply[] {
+    return [...this.replies];
+  }
+
+  verdict(nowMs: number): CollectorVerdict {
+    const elapsedSinceSent = nowMs - this.sentAtMs;
+    if (this.replies.length === 0) {
+      return elapsedSinceSent >= this.hardTimeoutMs
+        ? "stop_timeout"
+        : "collecting";
+    }
+    if (elapsedSinceSent >= this.hardTimeoutMs) return "stop_timeout";
+    const lastReplyAt = this.replies[this.replies.length - 1].timestampMs;
+    const quietElapsed = nowMs - lastReplyAt;
+    return quietElapsed >= this.quietPeriodMs ? "stop_quiet" : "collecting";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reconnect bookkeeping (pure) — used by --pair's bounded 515 reconnect
+// ---------------------------------------------------------------------------
+
+/** Should the live socket reconnect after a `connection: "close"` event?
+ * `terminal` must come from bridge/session.js's isTerminalCloseCode — this
+ * function only owns the bounded-attempt-count decision, not the Baileys
+ * close-code classification (never duplicate that logic; import it). */
+export function shouldReconnect(params: {
+  terminal: boolean;
+  attempt: number;
+  maxAttempts: number;
+}): boolean {
+  if (params.terminal) return false;
+  return params.attempt < params.maxAttempts;
+}
+
+// ---------------------------------------------------------------------------
+// Message text extraction (loose Baileys duck-typing, mirrors the local
+// convention in bridge/message_capture.ts's private extractBody — kept as a
+// SEPARATE small copy here rather than exporting from bridge/, since bridge/
+// stays byte-identical/untouched per the read-only-mirror invariant).
+// ---------------------------------------------------------------------------
+
+type LooseMessageShape = {
+  conversation?: string | null;
+  extendedTextMessage?: { text?: string | null } | null;
+};
+
+export function extractMessageText(message: unknown): string {
+  const m = (message ?? {}) as LooseMessageShape;
+  if (typeof m.conversation === "string" && m.conversation.length > 0) {
+    return m.conversation;
+  }
+  if (
+    typeof m.extendedTextMessage?.text === "string" &&
+    m.extendedTextMessage.text.length > 0
+  ) {
+    return m.extendedTextMessage.text;
+  }
+  return "";
+}
+
+/** Mirrors bridge/message_capture.ts's private parseTimestamp — same
+ * Baileys messageTimestamp shape (number | numeric-string | Long-like). */
+export function parseMessageTimestampMs(
+  value: number | string | { toNumber?: () => number } | null | undefined,
+): number {
+  if (typeof value === "number") return value * 1000;
+  if (typeof value === "string") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n * 1000 : Date.now();
+  }
+  if (value && typeof value.toNumber === "function") {
+    return value.toNumber() * 1000;
+  }
+  return Date.now();
+}
+
+// ---------------------------------------------------------------------------
+// Transcript assembly
+// ---------------------------------------------------------------------------
+
+export type QuestionResult = {
+  id: string;
+  text: string;
+  sent_at: string; // ISO 8601
+  replies: { text: string; timestamp: string; latency_ms: number }[];
+  reply_count: number;
+  first_reply_latency_ms: number | null;
+};
+
+export function buildQuestionResult(
+  question: BatteryQuestion,
+  sentAtMs: number,
+  replies: CollectedReply[],
+): QuestionResult {
+  const repliesOut = replies.map((r) => ({
+    text: r.text,
+    timestamp: new Date(r.timestampMs).toISOString(),
+    latency_ms: r.timestampMs - sentAtMs,
+  }));
+  return {
+    id: question.id,
+    text: question.text,
+    sent_at: new Date(sentAtMs).toISOString(),
+    replies: repliesOut,
+    reply_count: repliesOut.length,
+    first_reply_latency_ms:
+      repliesOut.length > 0 ? repliesOut[0].latency_ms : null,
+  };
+}
+
+export type Transcript = {
+  battery_file: string;
+  bot_jid: string;
+  started_at: string;
+  finished_at: string;
+  questions: QuestionResult[];
+  summary: {
+    total_questions: number;
+    questions_with_zero_replies: number;
+  };
+};
+
+export function buildTranscript(opts: {
+  batteryFile: string;
+  botJid: string;
+  startedAtMs: number;
+  finishedAtMs: number;
+  results: QuestionResult[];
+}): Transcript {
+  const zeroReplyCount = opts.results.filter((r) => r.reply_count === 0).length;
+  return {
+    battery_file: opts.batteryFile,
+    bot_jid: opts.botJid,
+    started_at: new Date(opts.startedAtMs).toISOString(),
+    finished_at: new Date(opts.finishedAtMs).toISOString(),
+    questions: opts.results,
+    summary: {
+      total_questions: opts.results.length,
+      questions_with_zero_replies: zeroReplyCount,
+    },
+  };
+}
+
+export function transcriptHasZeroReplyQuestion(
+  transcript: Transcript,
+): boolean {
+  return transcript.summary.questions_with_zero_replies > 0;
+}

--- a/apps/wa-mirror/scripts/wa-tester.sh
+++ b/apps/wa-mirror/scripts/wa-tester.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# wa-tester.sh — thin wrapper around scripts/wa-tester.ts.
+#
+# On-demand CLI only — NOT a daemon, NOT in any plist/cron, NOT in the
+# wa-mirror accounts roster. See docs/wa-tester.md.
+#
+# Usage:
+#   bash wa-tester.sh --pair
+#   bash wa-tester.sh --send-battery battery.json [--out transcript.json]
+#   bash wa-tester.sh --status
+
+set -eo pipefail
+
+# Runtime is Pro — non-interactive ssh sessions don't source the shell rc
+# files that put Homebrew node/npm on PATH (the well-known ssh-non-interactive
+# PATH gotcha; see org runbook). Prepend it explicitly rather than assuming.
+export PATH="/opt/homebrew/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$APP_ROOT"
+exec npx tsx scripts/wa-tester.ts "$@"

--- a/apps/wa-mirror/scripts/wa-tester.ts
+++ b/apps/wa-mirror/scripts/wa-tester.ts
@@ -1,0 +1,516 @@
+// wa-tester.ts — standalone WhatsApp phone-test CLI.
+//
+// Runs end-to-end batteries against the Zantara WA bot (+62 821 3465 159)
+// FROM Zero's own WhatsApp number (+62 822 3010 2328). This is a SEPARATE,
+// single-purpose organ — it does NOT touch apps/wa-mirror's read-only-mirror
+// invariant (bridge/session.ts: "we never call sock.sendMessage"), does NOT
+// write to Postgres/CRM, does NOT enter the mirror's accounts roster, plist,
+// or supervisor, and is on-demand only (no cron, no daemon). See
+// docs/wa-tester.md for the full picture.
+//
+// Usage:
+//   tsx scripts/wa-tester.ts --pair
+//   tsx scripts/wa-tester.ts --send-battery battery.json [--out transcript.json]
+//   tsx scripts/wa-tester.ts --status
+//
+// Auth state lives under WA_TESTER_STATE_DIR (default
+// ~/.wa-tester/state/+6282230102328/) — NEVER under apps/wa-mirror/sessions/.
+
+import "dotenv/config";
+
+import { Boom } from "@hapi/boom";
+import makeWASocket, {
+  fetchLatestBaileysVersion,
+  makeCacheableSignalKeyStore,
+  useMultiFileAuthState,
+} from "@whiskeysockets/baileys";
+import type { BaileysEventMap, WASocket } from "@whiskeysockets/baileys";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import qrcodeTerminal from "qrcode-terminal";
+import QRCode from "qrcode";
+
+import { isTerminalCloseCode, mapCloseReason } from "../bridge/session.js";
+import {
+  BOT_JID,
+  BOT_PHONE_E164,
+  QUIET_PERIOD_S,
+  ReplyCollector,
+  TESTER_PHONE_DIGITS,
+  TESTER_PHONE_E164,
+  buildQuestionResult,
+  buildTranscript,
+  extractMessageText,
+  parseMessageTimestampMs,
+  shouldReconnect,
+  transcriptHasZeroReplyQuestion,
+  validateBattery,
+  type QuestionResult,
+} from "./wa-tester-core.js";
+
+const logger = pino({
+  level: process.env.WA_MIRROR_LOG_LEVEL ?? "info",
+  base: undefined,
+});
+
+const STATE_DIR =
+  process.env.WA_TESTER_STATE_DIR ??
+  path.join(homedir(), ".wa-tester", "state", TESTER_PHONE_E164);
+
+const QR_PATH = `/tmp/qr-tester-${TESTER_PHONE_DIGITS}.png`;
+
+const PAIR_MAX_ATTEMPTS = 2; // initial connect + ONE reconnect for the post-pairing 515 bounce
+const PAIR_STABLE_WINDOW_MS = 12_000; // time to wait after `open` to see if a 515 bounce follows
+const STATUS_CONNECT_TIMEOUT_MS = 20_000;
+
+async function ensureStateDir(): Promise<void> {
+  await mkdir(STATE_DIR, { recursive: true });
+  // Scar #4 (secret-in-the-clear): Baileys auth state includes the Signal
+  // identity/session keys — treat it exactly like any other credential dir.
+  await chmod(STATE_DIR, 0o700);
+}
+
+async function isPaired(): Promise<boolean> {
+  try {
+    const raw = await readFile(path.join(STATE_DIR, "creds.json"), "utf8");
+    const creds = JSON.parse(raw) as { registered?: boolean };
+    return creds.registered === true;
+  } catch {
+    return false;
+  }
+}
+
+function makeSocket(
+  version: [number, number, number],
+  authState: Awaited<ReturnType<typeof useMultiFileAuthState>>["state"],
+): WASocket {
+  return makeWASocket({
+    version,
+    auth: {
+      creds: authState.creds,
+      keys: makeCacheableSignalKeyStore(authState.keys, logger),
+    },
+    printQRInTerminal: false,
+    browser: ["Bali Zero WA-Tester", "Chrome", "1.0.0"],
+    logger: logger.child({ component: "baileys" }),
+    markOnlineOnConnect: true,
+    // Mirror bridge/session.ts's proven-safe socket options (CICATRIX
+    // 2026-05-25): full history sync avoids the LID-mapping instability bug
+    // Baileys' own DANGER log warns about when sync is disabled.
+    syncFullHistory: true,
+    generateHighQualityLinkPreview: false,
+    defaultQueryTimeoutMs: 60_000,
+    keepAliveIntervalMs: 25_000,
+  });
+}
+
+type CloseInfo = { code: number; terminal: boolean; reason: string };
+
+function readCloseInfo(
+  lastDisconnect: { error?: unknown } | null | undefined,
+): CloseInfo {
+  const code =
+    (lastDisconnect as { error?: Boom } | undefined)?.error?.output
+      ?.statusCode ?? 0;
+  return {
+    code,
+    terminal: isTerminalCloseCode(code),
+    reason: mapCloseReason(code),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// --pair
+// ---------------------------------------------------------------------------
+
+async function runPair(): Promise<void> {
+  await ensureStateDir();
+  const { version } = await fetchLatestBaileysVersion();
+
+  let attempt = 0;
+  let openedOnce = false;
+
+  while (true) {
+    attempt += 1;
+    const { state, saveCreds } = await useMultiFileAuthState(STATE_DIR);
+    const sock = makeSocket(version, state);
+    sock.ev.on("creds.update", saveCreds);
+
+    const outcome = await new Promise<"open" | "close">((resolve, reject) => {
+      sock.ev.on("connection.update", (update) => {
+        void (async () => {
+          if (update.qr) {
+            await QRCode.toFile(QR_PATH, update.qr, { width: 400 });
+            process.stderr.write(
+              `\n[wa-tester] QR saved to ${QR_PATH} — open it with: open ${QR_PATH}\n`,
+            );
+            qrcodeTerminal.generate(update.qr, { small: true }, (ascii) => {
+              process.stdout.write(ascii + "\n");
+            });
+          }
+          if (update.connection === "open") {
+            resolve("open");
+          } else if (update.connection === "close") {
+            const info = readCloseInfo(update.lastDisconnect);
+            logger.warn(
+              { attempt, ...info },
+              "wa-tester pair: connection closed",
+            );
+            if (info.terminal) {
+              reject(
+                new Error(
+                  `wa-tester: pairing failed — terminal close (${info.reason})`,
+                ),
+              );
+              return;
+            }
+            resolve("close");
+          }
+        })();
+      });
+    });
+
+    if (outcome === "open") {
+      openedOnce = true;
+      logger.info(
+        { attempt, jid: sock.user?.id },
+        "wa-tester pair: connection open",
+      );
+      // Wait a bit to see whether the expected post-pairing 515 bounce
+      // follows. If the socket stays open for the stable window, we're done.
+      const bounced = await waitForBounceOrStable(sock);
+      if (!bounced) {
+        sock.end(undefined);
+        process.stdout.write(`PAIRED — auth state saved to ${STATE_DIR}\n`);
+        return;
+      }
+      // A close fired during the stable window — fall through to the
+      // reconnect-attempt gate below using the close info already logged.
+    }
+
+    const terminalSoFar = false; // non-terminal closes only reach here (terminal rejects above)
+    if (
+      !shouldReconnect({
+        terminal: terminalSoFar,
+        attempt,
+        maxAttempts: PAIR_MAX_ATTEMPTS,
+      })
+    ) {
+      throw new Error(
+        `wa-tester: pairing did not stabilize after ${attempt} attempt(s) — ` +
+          (openedOnce
+            ? "connection opened but kept bouncing; try again"
+            : "connection never opened; QR likely expired unscanned — try again"),
+      );
+    }
+    logger.info(
+      { attempt },
+      "wa-tester pair: reconnecting once (515 bounce contract)",
+    );
+  }
+}
+
+/** Resolves `true` if the socket closes within PAIR_STABLE_WINDOW_MS
+ * (the expected post-pairing 515 bounce), `false` if it stays open. */
+function waitForBounceOrStable(sock: WASocket): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      sock.ev.off("connection.update", onUpdate);
+      resolve(false);
+    }, PAIR_STABLE_WINDOW_MS);
+    const onUpdate = (update: BaileysEventMap["connection.update"]) => {
+      if (settled) return;
+      if (update.connection === "close") {
+        settled = true;
+        clearTimeout(timer);
+        sock.ev.off("connection.update", onUpdate);
+        resolve(true);
+      }
+    };
+    sock.ev.on("connection.update", onUpdate);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// --status
+// ---------------------------------------------------------------------------
+
+async function runStatus(): Promise<void> {
+  if (!(await isPaired())) {
+    process.stdout.write(`NOT_PAIRED — run: tsx scripts/wa-tester.ts --pair\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { version } = await fetchLatestBaileysVersion();
+  const { state, saveCreds } = await useMultiFileAuthState(STATE_DIR);
+  const sock = makeSocket(version, state);
+  sock.ev.on("creds.update", saveCreds);
+
+  const result = await new Promise<{ ok: boolean; detail: string }>(
+    (resolve) => {
+      const timer = setTimeout(() => {
+        resolve({ ok: false, detail: "connect timed out" });
+      }, STATUS_CONNECT_TIMEOUT_MS);
+      sock.ev.on("connection.update", (update) => {
+        if (update.connection === "open") {
+          clearTimeout(timer);
+          resolve({ ok: true, detail: sock.user?.id ?? "connected" });
+        } else if (update.connection === "close") {
+          const info = readCloseInfo(update.lastDisconnect);
+          if (info.terminal) {
+            clearTimeout(timer);
+            resolve({
+              ok: false,
+              detail: `logged out (${info.reason}) — re-pair required`,
+            });
+          }
+          // non-terminal: keep waiting until the timeout above fires
+        }
+      });
+    },
+  );
+
+  try {
+    sock.end(undefined);
+  } catch {
+    // socket already tearing down — non-fatal
+  }
+
+  if (result.ok) {
+    process.stdout.write(`PAIRED_AND_CONNECTED — ${result.detail}\n`);
+  } else {
+    process.stdout.write(`PAIRED_BUT_CONNECT_FAILED — ${result.detail}\n`);
+    process.exitCode = 2;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// --send-battery
+// ---------------------------------------------------------------------------
+
+async function connectPairedSocket(): Promise<WASocket> {
+  const { version } = await fetchLatestBaileysVersion();
+  const { state, saveCreds } = await useMultiFileAuthState(STATE_DIR);
+  const sock = makeSocket(version, state);
+  sock.ev.on("creds.update", saveCreds);
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          "wa-tester: connect timed out before questions could be sent",
+        ),
+      );
+    }, STATUS_CONNECT_TIMEOUT_MS);
+    sock.ev.on("connection.update", (update) => {
+      if (update.connection === "open") {
+        clearTimeout(timer);
+        resolve();
+      } else if (update.connection === "close") {
+        const info = readCloseInfo(update.lastDisconnect);
+        if (info.terminal) {
+          clearTimeout(timer);
+          reject(
+            new Error(
+              `wa-tester: logged out (${info.reason}) — re-pair required`,
+            ),
+          );
+        }
+        // non-terminal pre-open bounce: keep waiting for the retry inside
+        // Baileys' own queueing, bounded by the timer above.
+      }
+    });
+  });
+  return sock;
+}
+
+/** Subscribes to messages.upsert scoped ONLY to the bot's JID conversation.
+ * Privacy rail: every other chat/event is ignored and never logged. */
+function collectReplies(
+  sock: WASocket,
+  sentAtMs: number,
+  replyTimeoutS: number,
+): Promise<{ text: string; timestampMs: number }[]> {
+  const collector = new ReplyCollector({
+    sentAtMs,
+    replyTimeoutS,
+    quietPeriodS: QUIET_PERIOD_S,
+  });
+
+  const onUpsert = (event: BaileysEventMap["messages.upsert"]) => {
+    if (event.type !== "notify") return;
+    for (const m of event.messages) {
+      if (m.key?.remoteJid !== BOT_JID) continue; // ignore every other chat, no exceptions
+      if (m.key?.fromMe) continue; // our own outbound echo, not a bot reply
+      const text = extractMessageText(m.message);
+      if (!text) continue;
+      const ts = parseMessageTimestampMs(m.messageTimestamp as never);
+      collector.addReply(text, ts);
+    }
+  };
+
+  sock.ev.on("messages.upsert", onUpsert);
+  return new Promise((resolve) => {
+    const POLL_MS = 250;
+    const timer = setInterval(() => {
+      if (collector.verdict(Date.now()) !== "collecting") {
+        clearInterval(timer);
+        sock.ev.off("messages.upsert", onUpsert);
+        resolve(collector.all);
+      }
+    }, POLL_MS);
+  });
+}
+
+async function runSendBattery(
+  batteryPath: string,
+  outPath: string,
+): Promise<void> {
+  const raw = JSON.parse(await readFile(batteryPath, "utf8"));
+  const validation = validateBattery(raw);
+  if (!validation.ok) {
+    // The allowlist guard (and every other validation) runs BEFORE any
+    // socket connects and BEFORE any send — a bad battery never gets a
+    // chance to touch the network.
+    throw new Error(`wa-tester: invalid battery — ${validation.error}`);
+  }
+  const battery = validation.battery;
+
+  if (!(await isPaired())) {
+    throw new Error(
+      "wa-tester: not paired — run: tsx scripts/wa-tester.ts --pair",
+    );
+  }
+
+  const sock = await connectPairedSocket();
+  logger.info(
+    { jid: sock.user?.id, questions: battery.questions.length },
+    "wa-tester: connected — starting battery",
+  );
+
+  const startedAtMs = Date.now();
+  const results: QuestionResult[] = [];
+
+  try {
+    for (let i = 0; i < battery.questions.length; i++) {
+      const question = battery.questions[i];
+      const sentAtMs = Date.now();
+      await sock.sendMessage(BOT_JID, { text: question.text });
+      logger.info({ id: question.id }, "wa-tester: question sent");
+
+      const replies = await collectReplies(
+        sock,
+        sentAtMs,
+        battery.reply_timeout_s,
+      );
+      const result = buildQuestionResult(question, sentAtMs, replies);
+      results.push(result);
+      logger.info(
+        { id: question.id, reply_count: result.reply_count },
+        "wa-tester: question done",
+      );
+
+      const isLast = i === battery.questions.length - 1;
+      if (!isLast) {
+        await new Promise((r) =>
+          setTimeout(r, battery.inter_question_delay_s * 1000),
+        );
+      }
+    }
+  } finally {
+    try {
+      sock.end(undefined);
+    } catch {
+      // socket already tearing down — non-fatal
+    }
+  }
+
+  const finishedAtMs = Date.now();
+  const transcript = buildTranscript({
+    batteryFile: path.resolve(batteryPath),
+    botJid: BOT_JID,
+    startedAtMs,
+    finishedAtMs,
+    results,
+  });
+
+  await writeFile(outPath, JSON.stringify(transcript, null, 2) + "\n", "utf8");
+  process.stdout.write(
+    `wa-tester: ${transcript.summary.total_questions - transcript.summary.questions_with_zero_replies}/` +
+      `${transcript.summary.total_questions} questions replied — transcript written to ${outPath}\n`,
+  );
+
+  if (transcriptHasZeroReplyQuestion(transcript)) {
+    process.exitCode = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): {
+  mode: "pair" | "status" | "send-battery" | null;
+  batteryPath?: string;
+  outPath?: string;
+} {
+  if (argv.includes("--pair")) return { mode: "pair" };
+  if (argv.includes("--status")) return { mode: "status" };
+  const batteryIdx = argv.indexOf("--send-battery");
+  if (batteryIdx !== -1) {
+    const batteryPath = argv[batteryIdx + 1];
+    const outIdx = argv.indexOf("--out");
+    const outPath =
+      outIdx !== -1
+        ? argv[outIdx + 1]
+        : `/tmp/wa-tester-transcript-${Date.now()}.json`;
+    return { mode: "send-battery", batteryPath, outPath };
+  }
+  return { mode: null };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.mode === "pair") {
+    await runPair();
+    return;
+  }
+  if (args.mode === "status") {
+    await runStatus();
+    return;
+  }
+  if (args.mode === "send-battery") {
+    if (!args.batteryPath) {
+      process.stderr.write(
+        "Usage: tsx scripts/wa-tester.ts --send-battery <file.json> [--out <path>]\n",
+      );
+      process.exitCode = 2;
+      return;
+    }
+    await runSendBattery(args.batteryPath, args.outPath!);
+    return;
+  }
+
+  process.stderr.write(
+    "Usage:\n" +
+      "  tsx scripts/wa-tester.ts --pair\n" +
+      "  tsx scripts/wa-tester.ts --send-battery <file.json> [--out <path>]\n" +
+      "  tsx scripts/wa-tester.ts --status\n" +
+      `\nSole allowed recipient: Zantara bot ${BOT_PHONE_E164}. No flag/env/config can change it.\n`,
+  );
+  process.exitCode = 2;
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  logger.error({ msg }, "wa-tester failed");
+  process.stderr.write(`wa-tester: ${msg}\n`);
+  process.exitCode = 1;
+});

--- a/apps/wa-mirror/tests/wa-tester-core.test.ts
+++ b/apps/wa-mirror/tests/wa-tester-core.test.ts
@@ -1,0 +1,424 @@
+// wa-tester-core.test.ts — unit tests for the pure logic behind wa-tester.
+//
+// No live WhatsApp calls here — everything under test is a pure function or
+// a pure state machine driven by injected timestamps. Live-socket glue
+// (scripts/wa-tester.ts) is exercised manually against the real bot, not in
+// CI.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BOT_JID,
+  BOT_PHONE_E164,
+  ReplyCollector,
+  buildQuestionResult,
+  buildTranscript,
+  checkRecipientAllowlist,
+  extractMessageText,
+  matchesBotRecipient,
+  parseMessageTimestampMs,
+  shouldReconnect,
+  transcriptHasZeroReplyQuestion,
+  validateBattery,
+} from "../scripts/wa-tester-core.js";
+
+describe("matchesBotRecipient — allowlist entity matching", () => {
+  it("matches the bot's E.164 form", () => {
+    expect(matchesBotRecipient("+628213465159")).toBe(true);
+  });
+
+  it("matches bare digits (no +)", () => {
+    expect(matchesBotRecipient("628213465159")).toBe(true);
+  });
+
+  it("matches the local 0-prefixed Indonesian form", () => {
+    expect(matchesBotRecipient("08213465159")).toBe(true);
+  });
+
+  it("matches a full Baileys JID string", () => {
+    expect(matchesBotRecipient("628213465159@s.whatsapp.net")).toBe(true);
+  });
+
+  it("does NOT match a different Indonesian number (fails closed)", () => {
+    expect(matchesBotRecipient("+6281234567890")).toBe(false);
+  });
+
+  it("does NOT match garbage input", () => {
+    expect(matchesBotRecipient("not-a-phone")).toBe(false);
+    expect(matchesBotRecipient("")).toBe(false);
+  });
+});
+
+describe("checkRecipientAllowlist — guilt + innocence", () => {
+  it("[innocence] passes an object with no recipient-lookalike fields", () => {
+    const result = checkRecipientAllowlist({ id: "q1", text: "hello" }, "ctx");
+    expect(result.ok).toBe(true);
+  });
+
+  it("[innocence] passes when the recipient field matches the bot, any format", () => {
+    for (const val of [
+      "+628213465159",
+      "628213465159",
+      "628213465159@s.whatsapp.net",
+    ]) {
+      const result = checkRecipientAllowlist({ to: val }, "ctx");
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it("[guilt] refuses when 'to' points at a different number", () => {
+    const result = checkRecipientAllowlist(
+      { to: "+6281234567890" },
+      "battery.questions[0]",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("battery.questions[0]");
+      expect(result.error).toContain(BOT_PHONE_E164);
+    }
+  });
+
+  it("[guilt] refuses on ANY of the recipient-lookalike keys, not just 'to'", () => {
+    for (const key of [
+      "recipient",
+      "jid",
+      "phone",
+      "number",
+      "target",
+      "send_to",
+    ]) {
+      const result = checkRecipientAllowlist({ [key]: "+15551234567" }, "ctx");
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  it("[innocence] ignores unrelated keys entirely", () => {
+    const result = checkRecipientAllowlist(
+      { id: "q1", text: "what about my KITAS", note: "+6281234567890" },
+      "ctx",
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("validateBattery", () => {
+  const validRaw = {
+    questions: [
+      { id: "q1", text: "Ciao, come funziona il B211A?" },
+      { id: "q2", text: "Quanto costa il KITAS investor?" },
+    ],
+    reply_timeout_s: 90,
+    inter_question_delay_s: 20,
+  };
+
+  it("[innocence] accepts a well-formed battery", () => {
+    const result = validateBattery(validRaw);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.battery.questions).toHaveLength(2);
+      expect(result.battery.reply_timeout_s).toBe(90);
+      expect(result.battery.inter_question_delay_s).toBe(20);
+    }
+  });
+
+  it("[innocence] defaults reply_timeout_s / inter_question_delay_s when omitted", () => {
+    const result = validateBattery({ questions: [{ id: "q1", text: "hi" }] });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.battery.reply_timeout_s).toBe(90);
+      expect(result.battery.inter_question_delay_s).toBe(20);
+    }
+  });
+
+  it("[guilt] the ALLOWLIST GUARD refuses a battery whose question targets another number", () => {
+    const evil = {
+      questions: [
+        { id: "q1", text: "hi", to: "+6281234567890" },
+        { id: "q2", text: "hi again" },
+      ],
+    };
+    const result = validateBattery(evil);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("battery.questions[0]");
+    }
+  });
+
+  it("[guilt] the ALLOWLIST GUARD also checks the battery root, not just questions", () => {
+    const evil = {
+      recipient: "+6281234567890",
+      questions: [{ id: "q1", text: "hi" }],
+    };
+    const result = validateBattery(evil);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("battery:");
+    }
+  });
+
+  it("rejects a non-object root", () => {
+    expect(validateBattery("not an object").ok).toBe(false);
+    expect(validateBattery(null).ok).toBe(false);
+    expect(validateBattery([1, 2, 3]).ok).toBe(false);
+  });
+
+  it("rejects an empty or missing questions array", () => {
+    expect(validateBattery({ questions: [] }).ok).toBe(false);
+    expect(validateBattery({}).ok).toBe(false);
+  });
+
+  it("rejects a question missing id or text", () => {
+    expect(validateBattery({ questions: [{ text: "hi" }] }).ok).toBe(false);
+    expect(validateBattery({ questions: [{ id: "q1" }] }).ok).toBe(false);
+  });
+
+  it("rejects duplicate question ids", () => {
+    const result = validateBattery({
+      questions: [
+        { id: "q1", text: "hi" },
+        { id: "q1", text: "hi again" },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("duplicate id");
+  });
+
+  it("falls back to defaults for non-positive/garbage timeout values", () => {
+    const result = validateBattery({
+      questions: [{ id: "q1", text: "hi" }],
+      reply_timeout_s: -5,
+      inter_question_delay_s: "not a number",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.battery.reply_timeout_s).toBe(90);
+      expect(result.battery.inter_question_delay_s).toBe(20);
+    }
+  });
+});
+
+describe("ReplyCollector — quiet-period state machine", () => {
+  const SENT_AT = 1_000_000;
+
+  it("keeps collecting before any reply and before the hard timeout", () => {
+    const c = new ReplyCollector({
+      sentAtMs: SENT_AT,
+      replyTimeoutS: 90,
+      quietPeriodS: 10,
+    });
+    expect(c.verdict(SENT_AT + 5_000)).toBe("collecting");
+  });
+
+  it("stops on hard timeout with ZERO replies", () => {
+    const c = new ReplyCollector({
+      sentAtMs: SENT_AT,
+      replyTimeoutS: 90,
+      quietPeriodS: 10,
+    });
+    expect(c.verdict(SENT_AT + 90_000)).toBe("stop_timeout");
+    expect(c.count).toBe(0);
+  });
+
+  it("keeps collecting immediately after one reply (quiet window not yet elapsed)", () => {
+    const c = new ReplyCollector({
+      sentAtMs: SENT_AT,
+      replyTimeoutS: 90,
+      quietPeriodS: 10,
+    });
+    c.addReply("hello", SENT_AT + 3_000);
+    expect(c.verdict(SENT_AT + 5_000)).toBe("collecting");
+  });
+
+  it("stops on quiet-period completion (10s no new messages after >=1 reply)", () => {
+    const c = new ReplyCollector({
+      sentAtMs: SENT_AT,
+      replyTimeoutS: 90,
+      quietPeriodS: 10,
+    });
+    c.addReply("hello", SENT_AT + 3_000);
+    expect(c.verdict(SENT_AT + 3_000 + 10_000)).toBe("stop_quiet");
+  });
+
+  it("resets the quiet window on each new reply", () => {
+    const c = new ReplyCollector({
+      sentAtMs: SENT_AT,
+      replyTimeoutS: 90,
+      quietPeriodS: 10,
+    });
+    c.addReply("part 1", SENT_AT + 3_000);
+    // 9s after first reply — still inside quiet window, would NOT have
+    // stopped yet.
+    expect(c.verdict(SENT_AT + 12_000)).toBe("collecting");
+    c.addReply("part 2", SENT_AT + 12_000);
+    // Another 9s after the SECOND reply — still collecting because the
+    // window reset.
+    expect(c.verdict(SENT_AT + 21_000)).toBe("collecting");
+    // 10s after the second reply — quiet period complete.
+    expect(c.verdict(SENT_AT + 22_000)).toBe("stop_quiet");
+  });
+
+  it("the hard timeout is a safety cap even mid-conversation (never waits past it)", () => {
+    const c = new ReplyCollector({
+      sentAtMs: SENT_AT,
+      replyTimeoutS: 30,
+      quietPeriodS: 10,
+    });
+    c.addReply("hello", SENT_AT + 25_000); // reply arrives late, quiet window would extend past 30s
+    expect(c.verdict(SENT_AT + 30_000)).toBe("stop_timeout");
+  });
+
+  it("all() returns a defensive copy", () => {
+    const c = new ReplyCollector({ sentAtMs: SENT_AT, replyTimeoutS: 90 });
+    c.addReply("hello", SENT_AT + 1_000);
+    const snapshot = c.all;
+    snapshot.push({ text: "injected", timestampMs: 0 });
+    expect(c.count).toBe(1);
+  });
+});
+
+describe("shouldReconnect — bounded reconnect gate", () => {
+  it("never reconnects on a terminal close", () => {
+    expect(
+      shouldReconnect({ terminal: true, attempt: 1, maxAttempts: 2 }),
+    ).toBe(false);
+  });
+
+  it("reconnects when attempts remain and the close is non-terminal", () => {
+    expect(
+      shouldReconnect({ terminal: false, attempt: 1, maxAttempts: 2 }),
+    ).toBe(true);
+  });
+
+  it("stops once the attempt budget is exhausted (the '515: reconnect once' contract)", () => {
+    expect(
+      shouldReconnect({ terminal: false, attempt: 2, maxAttempts: 2 }),
+    ).toBe(false);
+  });
+});
+
+describe("extractMessageText", () => {
+  it("extracts plain conversation text", () => {
+    expect(extractMessageText({ conversation: "hello world" })).toBe(
+      "hello world",
+    );
+  });
+
+  it("extracts extendedTextMessage text (quoted/linked replies)", () => {
+    expect(
+      extractMessageText({ extendedTextMessage: { text: "quoted reply" } }),
+    ).toBe("quoted reply");
+  });
+
+  it("prefers conversation over extendedTextMessage when both present", () => {
+    expect(
+      extractMessageText({
+        conversation: "plain",
+        extendedTextMessage: { text: "extended" },
+      }),
+    ).toBe("plain");
+  });
+
+  it("returns empty string for media-only / unsupported message shapes", () => {
+    expect(extractMessageText({})).toBe("");
+    expect(extractMessageText(null)).toBe("");
+    expect(extractMessageText(undefined)).toBe("");
+    expect(extractMessageText({ imageMessage: { caption: "a photo" } })).toBe(
+      "",
+    );
+  });
+});
+
+describe("parseMessageTimestampMs", () => {
+  it("converts a numeric Baileys timestamp (seconds) to epoch ms", () => {
+    expect(parseMessageTimestampMs(1_700_000_000)).toBe(1_700_000_000_000);
+  });
+
+  it("converts a numeric string", () => {
+    expect(parseMessageTimestampMs("1700000000")).toBe(1_700_000_000_000);
+  });
+
+  it("converts a Long-like object via toNumber()", () => {
+    expect(parseMessageTimestampMs({ toNumber: () => 1_700_000_000 })).toBe(
+      1_700_000_000_000,
+    );
+  });
+
+  it("falls back to now() for null/undefined/non-numeric string (never throws/NaN)", () => {
+    const before = Date.now();
+    expect(Number.isFinite(parseMessageTimestampMs(null))).toBe(true);
+    expect(Number.isFinite(parseMessageTimestampMs(undefined))).toBe(true);
+    expect(Number.isFinite(parseMessageTimestampMs("not-a-number"))).toBe(true);
+    const after = Date.now();
+    const val = parseMessageTimestampMs(null);
+    expect(val).toBeGreaterThanOrEqual(before);
+    expect(val).toBeLessThanOrEqual(after + 1);
+  });
+});
+
+describe("buildQuestionResult / buildTranscript — transcript assembly", () => {
+  const SENT_AT = 1_700_000_000_000;
+
+  it("computes per-reply latency_ms and first_reply_latency_ms", () => {
+    const result = buildQuestionResult({ id: "q1", text: "hello" }, SENT_AT, [
+      { text: "part 1", timestampMs: SENT_AT + 1_200 },
+      { text: "part 2", timestampMs: SENT_AT + 3_400 },
+    ]);
+    expect(result.reply_count).toBe(2);
+    expect(result.replies[0].latency_ms).toBe(1_200);
+    expect(result.replies[1].latency_ms).toBe(3_400);
+    expect(result.first_reply_latency_ms).toBe(1_200);
+    expect(result.sent_at).toBe(new Date(SENT_AT).toISOString());
+  });
+
+  it("reports null first_reply_latency_ms and 0 reply_count for a silent question", () => {
+    const result = buildQuestionResult(
+      { id: "q1", text: "hello" },
+      SENT_AT,
+      [],
+    );
+    expect(result.reply_count).toBe(0);
+    expect(result.first_reply_latency_ms).toBeNull();
+    expect(result.replies).toEqual([]);
+  });
+
+  it("buildTranscript aggregates questions_with_zero_replies in the summary", () => {
+    const answered = buildQuestionResult({ id: "q1", text: "a" }, SENT_AT, [
+      { text: "reply", timestampMs: SENT_AT + 500 },
+    ]);
+    const silent = buildQuestionResult({ id: "q2", text: "b" }, SENT_AT, []);
+    const transcript = buildTranscript({
+      batteryFile: "/tmp/battery.json",
+      botJid: BOT_JID,
+      startedAtMs: SENT_AT,
+      finishedAtMs: SENT_AT + 60_000,
+      results: [answered, silent],
+    });
+    expect(transcript.summary.total_questions).toBe(2);
+    expect(transcript.summary.questions_with_zero_replies).toBe(1);
+    expect(transcript.bot_jid).toBe(BOT_JID);
+  });
+
+  it("transcriptHasZeroReplyQuestion flags a battery with any silent question", () => {
+    const answered = buildQuestionResult({ id: "q1", text: "a" }, SENT_AT, [
+      { text: "reply", timestampMs: SENT_AT + 500 },
+    ]);
+    const allAnswered = buildTranscript({
+      batteryFile: "/tmp/b.json",
+      botJid: BOT_JID,
+      startedAtMs: SENT_AT,
+      finishedAtMs: SENT_AT + 1_000,
+      results: [answered],
+    });
+    expect(transcriptHasZeroReplyQuestion(allAnswered)).toBe(false);
+
+    const silent = buildQuestionResult({ id: "q2", text: "b" }, SENT_AT, []);
+    const oneSilent = buildTranscript({
+      batteryFile: "/tmp/b.json",
+      botJid: BOT_JID,
+      startedAtMs: SENT_AT,
+      finishedAtMs: SENT_AT + 1_000,
+      results: [answered, silent],
+    });
+    expect(transcriptHasZeroReplyQuestion(oneSilent)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `apps/wa-mirror/scripts/wa-tester.ts` — an on-demand CLI to run end-to-end test batteries against the Zantara WA bot (+62 821 3465 159) from Zero's own WhatsApp number (+62 822 3010 2328), so the team can exercise the real WhatsApp channel instead of only hitting the backend RAG API directly.

This is a **separate, single-purpose organ**:
- Does NOT touch `bridge/`'s read-only-mirror invariant (`bridge/session.ts`: "we never call sock.sendMessage") — zero modifications to `bridge/`, only two pure read-only imports (`isTerminalCloseCode`, `mapCloseReason`).
- Does NOT write to Postgres/CRM, does NOT send Telegram alerts, does NOT emit to the EventBus.
- Does NOT enter the wa-mirror accounts roster, plist, or supervisor — CLI-only, on-demand, no daemon/cron.
- Auth state lives under `WA_TESTER_STATE_DIR` (default `~/.wa-tester/state/+6282230102328/`), never under `apps/wa-mirror/sessions/`.

### The one rule: hardcoded recipient allowlist
The bot JID is a compile-time constant in `wa-tester-core.ts` — no flag/env/config can change it. Every battery file is validated (allowlist scan on root + every question, for `to`/`recipient`/`jid`/`phone`/`number`/`target`/`send_to` fields) **before** any socket connects and **before** any send. Guilt + innocence tests cover the guard per the repo's guard-conformance discipline.

### What it does
- `--pair`: fresh QR pairing (PNG to `/tmp/qr-tester-6282230102328.png` + terminal ASCII), handles the expected post-pairing Baileys 515 `restartRequired` bounce (bounded reconnect-once), confirms stable connection, exits 0.
- `--send-battery <file.json> [--out <path>]`: sends each question to the bot, collects replies until a 10s quiet-period or `reply_timeout_s` cap, writes a transcript JSON (sent_at, replies with per-reply latency_ms, first_reply_latency_ms). Exits non-zero if any question got zero replies.
- `--status`: one-line pairing/connectivity probe, sends nothing.

### Files
- `apps/wa-mirror/scripts/wa-tester-core.ts` — pure logic (allowlist guard, battery validation, quiet-period reply collector state machine, transcript assembly). Fully unit-tested, zero network/socket code.
- `apps/wa-mirror/scripts/wa-tester.ts` — CLI entrypoint, owns the live Baileys socket. Reuses the app's existing `@whiskeysockets/baileys@7.0.0-rc13` dependency (no second Baileys).
- `apps/wa-mirror/scripts/wa-tester.sh` — thin wrapper (Homebrew PATH fixup for non-interactive ssh + `npx tsx`).
- `apps/wa-mirror/docs/wa-tester.md` — boundary vs wa-mirror, pairing runbook, battery format, privacy rails.
- `apps/wa-mirror/tests/wa-tester-core.test.ts` — 42 new unit tests (allowlist guilt/innocence, battery validation, quiet-period state machine, reconnect gate, message text extraction, transcript assembly).
- `apps/wa-mirror/package.json` — adds `"wa-tester": "tsx scripts/wa-tester.ts"` script, no dependency changes.

### Deviation from mandate (documented, not hidden)
While pushing, the full pre-push Python suite (forced because no changed file is on the innocent-path allowlist) failed on 9 **pre-existing, unrelated** errors in `backend/tests/services/intake/test_intake_routing_npwp.py` — `asyncpg.exceptions.UndefinedColumnError: column "npwp" of relation "clients"`. Root cause: the local persistent test DB (`nuzantara_test`) was missing migration `248_clients_npwp_strongid.sql` (`ALTER TABLE clients ADD COLUMN IF NOT EXISTS npwp TEXT` — explicitly idempotent/safe per its own header comment, "no-op on prod and on the refreshed local dev"). Applied that one migration directly to the local test DB (not production) to unblock; re-ran the full suite clean (18,208 passed, 0 failed) before re-pushing. Zero relation to this PR's diff (100% `apps/wa-mirror/**`).

## Test plan
- [x] `npm run build` (tsc) green from `apps/wa-mirror/`
- [x] `npm test` (vitest) green: 7 test files, 95 tests passed (53 pre-existing + 42 new)
- [x] Manual CLI smoke tests: no-args usage/exit 2; evil battery (mismatched recipient) refused before any connect/send; unpaired `--send-battery` refused before any connect; unpaired `--status` reports `NOT_PAIRED`
- [x] `python3 scripts/docs_sync.py --check` — DOCSYNC OK, no changes needed
- [x] Pre-push full suite: 18,208 passed / 0 failed (after fixing the unrelated pre-existing test-DB drift)
- [ ] Live `--pair` + `--send-battery` run against the real Zantara bot — requires Zero's physical QR scan (operator/GUI action), not executable from this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)