### PR TITLE
fix(organism): interval_job receipt class — poller false-failed cured on both edges

### DIFF
--- a/scripts/launchagent-state-bridge.py
+++ b/scripts/launchagent-state-bridge.py
@@ -49,6 +49,12 @@ class BridgedLaunchAgent:
     organ_id: str
     daemon: bool
     legacy_job_id: str = ""
+    # StartInterval jobs legitimately sit pid=None ("exited") between ticks, and
+    # launchctl's exit column is sticky across restarts. Neither daemon=True
+    # (pid-required → false-failed between ticks) nor daemon=False (sticky
+    # exit-required → false-failed while a run is live) fits them: an interval
+    # job is healthy when it is running NOW or its last run exited clean.
+    interval_job: bool = False
 
 
 @dataclass(frozen=True)
@@ -80,12 +86,15 @@ BRIDGED_LABELS: tuple[BridgedLaunchAgent, ...] = (
     BridgedLaunchAgent(
         label="com.balizero.post-publish-poller",
         organ_id="pro.post_publish_poller",
-        # daemon=True: this is a long-running KeepAlive poller with a live pid,
-        # not a scheduled one-shot. With daemon=False the receipt was derived
-        # from launchctl's sticky "last exit code" column (=1 after any past
-        # crash/restart), reporting status=failed while ps proved the process
-        # alive and actively opening PRs (observed live 2026-07-18).
-        daemon=True,
+        # interval_job: the plist is StartInterval=300 (verified via plutil
+        # 2026-07-19), NOT KeepAlive. This spec has now produced BOTH false
+        # verdicts: daemon=False false-failed on the sticky exit=1 while a run
+        # was live (observed 2026-07-18, flipped to daemon=True by #2715), then
+        # daemon=True false-failed "daemon not running" between ticks while the
+        # log showed clean 5-min runs (observed 2026-07-19). interval_job
+        # covers both: alive-now OR last-run-clean = ok.
+        daemon=False,
+        interval_job=True,
         legacy_job_id="post_publish_poller",
     ),
     BridgedLaunchAgent(
@@ -592,7 +601,14 @@ def build_receipt(
     pid = agent.get("pid")
     exit_code = agent.get("exit_code", 0)
 
-    if spec.daemon:
+    if spec.interval_job:
+        # Alive-now OR last-run-clean = ok. Only idle-AND-crashed-last-run is a
+        # real failure for a StartInterval job (see the dataclass field note).
+        if pid is not None or exit_code in HEALTHY_EXIT_CODES:
+            status, last_error = "ok", ""
+        else:
+            status, last_error = "failed", f"exit code {exit_code}"
+    elif spec.daemon:
         status = "ok" if pid is not None else "failed"
         last_error = "" if pid is not None else "daemon not running"
     else:

--- a/scripts/tests/test_launchagent_state_bridge_host_guard.py
+++ b/scripts/tests/test_launchagent_state_bridge_host_guard.py
@@ -120,13 +120,17 @@ class TestMainHostGuard:
         assert "infra.qdrant_pro.json" in written
 
 
-class TestPostPublishPollerDaemonReceipt:
-    """post-publish-poller must be bridged by pid-liveness, not exit code.
+class TestPostPublishPollerIntervalReceipt:
+    """post-publish-poller is a StartInterval=300 job (plutil-verified
+    2026-07-19), and its spec has now produced BOTH false verdicts:
 
-    2026-07-18: with daemon=False the receipt read launchctl's sticky
-    "last exit code" column (=1 after any past restart) and reported
-    status=failed while ps proved the poller alive and opening PRs.
-    Guilt+innocence per cicatrix family #3.
+    - 2026-07-18 (daemon=False): sticky "last exit code"=1 while ps proved
+      the poller alive and opening PRs → false failed.
+    - 2026-07-19 (daemon=True, the #2715 cure): pid=None between ticks
+      while the log showed clean 5-min runs → false "daemon not running".
+
+    interval_job semantics cover both: alive-now OR last-run-clean = ok;
+    only idle-AND-crashed is failed. Guilt+innocence per cicatrix family #3.
     """
 
     def _spec(self, bridge):
@@ -135,8 +139,10 @@ class TestPostPublishPollerDaemonReceipt:
         assert len(specs) == 1
         return specs[0]
 
-    def test_flag_is_daemon(self, bridge):
-        assert self._spec(bridge).daemon is True
+    def test_flag_is_interval_job(self, bridge):
+        spec = self._spec(bridge)
+        assert spec.interval_job is True
+        assert spec.daemon is False
 
     def test_alive_with_sticky_exit_is_ok(self, bridge):
         """Innocence: live pid + stale exit 1 → ok (the 2026-07-18 case)."""
@@ -149,8 +155,8 @@ class TestPostPublishPollerDaemonReceipt:
         )
         assert receipt["status"] == "ok"
 
-    def test_dead_daemon_is_failed(self, bridge):
-        """Guilt: no pid → failed, even with exit_code 0."""
+    def test_idle_between_ticks_with_clean_exit_is_ok(self, bridge):
+        """Innocence: pid=None + exit 0 → ok (the 2026-07-19 case)."""
         spec = self._spec(bridge)
         receipt = bridge.build_receipt(
             spec,
@@ -158,4 +164,33 @@ class TestPostPublishPollerDaemonReceipt:
             now=1_700_000_000,
             host="pro",
         )
+        assert receipt["status"] == "ok"
+        assert "last_error" not in receipt
+
+    def test_idle_and_crashed_last_run_is_failed(self, bridge):
+        """Guilt: pid=None + exit 1 → failed (the only honest death shape)."""
+        spec = self._spec(bridge)
+        receipt = bridge.build_receipt(
+            spec,
+            {spec.label: {"pid": None, "exit_code": 1}},
+            now=1_700_000_000,
+            host="pro",
+        )
         assert receipt["status"] == "failed"
+        assert receipt["last_error"] == "exit code 1"
+
+    def test_true_daemons_keep_pid_required_semantics(self, bridge):
+        """Innocence for the daemon class: the webhook (KeepAlive) still
+        reports failed on pid=None even with exit 0 — interval_job must not
+        leak into real daemons."""
+        specs = [s for s in bridge.BRIDGED_LABELS
+                 if s.label == "com.balizero.post-publish-webhook"]
+        assert len(specs) == 1 and specs[0].daemon is True
+        receipt = bridge.build_receipt(
+            specs[0],
+            {specs[0].label: {"pid": None, "exit_code": 0}},
+            now=1_700_000_000,
+            host="pro",
+        )
+        assert receipt["status"] == "failed"
+        assert receipt["last_error"] == "daemon not running"


### PR DESCRIPTION
## Root cause

`com.balizero.post-publish-poller` is a **StartInterval=300** job (plutil-verified), not KeepAlive. Its bridge spec has produced BOTH false verdicts within 48h:

| date | spec | false verdict | reality |
|---|---|---|---|
| 2026-07-18 | `daemon=False` | failed (sticky exit=1) | ps proved run alive, opening PRs |
| 2026-07-19 | `daemon=True` (#2715 cure) | failed "daemon not running" | log shows clean runs every 5 min |

Neither pid-required nor sticky-exit-required fits an interval job.

## Cure

New `BridgedLaunchAgent.interval_job` receipt class: **alive-now OR last-run-clean = ok**; only idle-AND-crashed-last-run reports failed. Real daemons (webhook, KeepAlive) keep strict pid-required semantics, pinned by an innocence test so the new class can't leak.

## Proof

- 13/13 tests (class rewritten guilt+innocence, incl. both historical false-positive shapes as innocence cases)
- Live on Pro from this branch: poller sidecar `status=ok` (was `failed`), 85 receipts written
- Clears today's proprioception P1 `organs_heartbeat` false finding + the pending DLQ escalation `post_publish_poller: daemon not running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)