### PR TITLE
fix(visa-engine): PR1b residual — CodeQL list(Enum) pattern + integer-parity pin (+ LIVE STATE reconcile)

### DIFF
--- a/.agents/skills/visaoracle/SKILL.md
+++ b/.agents/skills/visaoracle/SKILL.md
@@ -113,6 +113,9 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
 - 2026-07-18: TRACK C increment C3 shipped (Pro, worktree `mouth-visa-experience`, branch `agent/nuzantara/mouth/visa-experience-c3`) — verdict tree→card morph (View Transitions API + FLIP-style shared `view-transition-name`, feature-detected, spring-reveal fallback, reduced-motion instant swap), tree tap-to-edit (completed trunk steps are real buttons dispatching the existing EDIT action, guarded by new `isEditableTreeStep`), a real scannable QR (`qrcode` npm, reuse-first from `apps/wa-mirror`, synchronous SSR-safe SVG render — no canvas/network) beside the still-visible wa.me link, and a checkable + printable document checklist (real checkboxes, `window.print()` + dedicated `@media print` stylesheet, copy-summary with visible confirmation). Mock-only, single all-inclusive price untouched, EN/ID both updated. 58 unit + 9 e2e passing.
 - 2026-07-18: TRACK C SHIPPED — PR #2617 (C2, consolidated living-tree experience) merged 00:21 WITA and proven live: `https://www.balizero.com/visa-oracle` (200, noindex meta present) is now the single Track C foundation; `/visa-v2` 308-redirects there and C1 artifacts were removed in the consolidation. Experience is mock-only (5-state RecommendState, 12-card catalog, EN/ID, WCAG AA); real engine wiring stays gated on PR1 engine contracts landing on main. Worktree `mouth-visa-experience` intentionally kept alive for the sibling session's post-merge follow-up (widening CI e2e coverage back to the 4 interactive tests).
 - 2026-07-18: PR #2602 (bonifica) MERGED 2026-07-17T15:51Z — FASE 2 gate OPEN. PR #2607 had gone DIRTY after the night's LIVE-STATE merges (#2602/#2606/#2627/#2628 touch the same skill files); resolved the legal way (merge of origin/main into the branch, LIVE STATE lines reconciled, no force-push), automerge still armed.
+- 2026-07-18 (S3 engine lane): TWIN-PR COLLISION ADJUDICATED by Zero (Legge 5): **ADOPT_A** — PR #2654 (M5 tree "A") MERGED to main (f73cbb4a); S3's PR #2718 (tree "B") CLOSED, its branch `agent/nuzantara/mouth/visa-engine-pr1-0718` intentionally KEPT as the PR3 seed (strong-Kleene evaluator + truth-table tests). Binding order from Zero: (1) correctness HOTFIX first — Codex gaps confirmed live in A, fix+guilt+innocence same commit; (2) PR1b port-list from B (only proven incremental value); (3) PR2 signed-bundle re-adapted to A's API with REDONE 3-seat verify; (4) PR3 from seed. Comparative A-vs-B report: `research/visa/2026-07-18-visa-oracle-v2-pr1-a-vs-b-portlist.md`. Hotfix branch `agent/nuzantara/mouth/visa-engine-hotfix-0718` in flight: 4 live gaps (canonical-date-literal P0, ordering-ops-on-enum-strings P1, GLOBAL+explicit-null P1, country-code-format P1).
+- 2026-07-18 (S3, STEP 1 SHIPPED): hotfix **PR #2739 MERGED** to main 12:44Z (`8ac3184ce`) — 4 gaps fixed TDD-style (date literals P0 / ordering fail-closed P1 / country-code shape P1 / KnownDate calendar P0, the last found by the GLM refutation pass); **Gap C (Codex #8 GLOBAL+explicit-null) REFUTED at implementation** — deliberate round-4/5 schema design, evidence re-verified on disk, recorded in the report's §Post-implementation correction. Suite 235→258. 4-stage generator≠grader chain held (Sonnet implementer → GLM report pass → Codex sol-xhigh diff SHIP → Fable final gate). STEP 2 (PR1b) in flight on branch `agent/nuzantara/mouth/visa-engine-pr1b-0718`: 7/8 port-list items done (item 1 product_code dedup SKIPPED with evidence — bitemporal multi-version per product_code is the evaluator's intended §4.3 pattern; the B port would have broken it), suite 258→293, GLM diff review pending.
+- 2026-07-18 (S3, STEP 2 + STEP 3): **STEP 2 SHIPPED** — PR1b **#2745 MERGED** to main (`8ac3184ce`→squash) 14:17Z: 9 hardening commits (F6 quote↔candidate, StrictBool×5, alias-only wire, registry (kind,value_format) consistency, +2 GLM-prescribed P2: `_DATETIME_SHAPE` ASCII, duplicate-candidate-id guard); item-1 product_code dedup SKIPPED, skip **independently confirmed** by GLM (SKIP-RATIONALE CONFIRMED) — follow-up for PR3: enforce uniqueness of the effective+ACTIVE slice per product_code. Suite 258→300. **STEP 3 (PR2 signed bundle) in flight** on branch `agent/nuzantara/mouth/visa-engine-pr2b-clean-0718` (the `-pr2b-0718` branch was W88-rebased onto fresh main to drop the now-squashed PR1b commits): `bundle.py` re-adapted to A's API, **fresh 3-seat verify** (GLM SHIP / Codex FIX-FIRST(1,4,5,6) / Gemini FIX-FIRST) → 11 FIX-NOW hardening applied (TOCTOU, env-bound keys, future-skew on signed_at, unsigned-into-PROD refusal, …), **3 findings REFUTED on the real model** (Codex bootstrap-sequence — model already enforces it; Gemini env-defaults-to-PROD and hex-uppercase — both blocked upstream). FIREBREAK intact (no key ceremony, unsigned fail-closed behind flag, never PROD). Suite 300→385. rfc8785+rfc3339-validator declared, lock honors manifest (W98). Round-4 regulatory recheck persisted on the closed B branch (M.IP-08/2025 effective 2025-06-02 per dictum KELIMA; BVK Permenimipas 10/2026 adds Macau — 19-state official list; number-collision trap with Permenkumham 10/2026 Second Home) — to be re-landed with a later PR.
 - 2026-07-18: TRACK A PR1 foundations pushed (M5) — merge commits against origin/main resolved by regenerating docs_sync markers (README/AI_ONBOARDING quick-numbers) rather than picking a side; PR #2654 open, automerge armed.
 - 2026-07-18: TRACK A PR1 MERGED — dual-PR1 collision (M5 #2654 vs sibling S3 #2718, same
   visa_engine foundations scope) adjudicated ADOPT_A via independent cross-family comparative
@@ -129,6 +132,39 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
   anti-rollback). CodeQL note: iterate enums via `list(Enum)` in tests —
   py/non-iterable-in-for-loop is a required-check failure class (S3 cured it on their tree in
   commit 1a4360dc1b; A-tree tests should adopt the same pattern in PR1b).
+
+- 2026-07-19: **TRACK A PR1b ARBITRATION RESOLVED + STAGE_ORDER CORRECTED.** The 2026-07-18 line
+  126-134 WARNING above ("the two trees disagree on ELIGIBILITY vs HUMAN_REVIEW precedence —
+  arbitrate against the round-2 spec") was itself resolved WRONG the first time: the M5 lane's PR1b
+  attempt (worktree `backend-rag-visa-engine-pr1b`) arbitrated to the enum-DECLARATION order
+  (HARD_FILTER→ELIGIBILITY→HUMAN_REVIEW→RANKING, matching enums.py's literal source order + the
+  spec's JSON Schema enum listing) — flagged **P0 by tri-LLM review on its own PR #2781** and
+  independently re-verified by re-reading the spec's §4.2 `evaluate_product` ALGORITHM pseudocode
+  directly: the correct order is **HARD_FILTER→HUMAN_REVIEW→ELIGIBILITY→RANKING**, exactly what
+  sibling PR #2773 already shipped (commit message: "the prior docstring's 'evaluated in this strict
+  order' claim was wrong"). Declaration order ≠ processing order — do not re-litigate this without
+  re-reading §4.2 fresh. Meanwhile a sibling S3 lane had independently re-shipped the whole PR1b
+  port-list as **PR #2745 MERGED 2026-07-18T14:17:49Z** (after hotfix #2739, before PR2b #2757 and
+  PR3 #2773 — all 4 verified MERGED via `gh pr view` against `Balizero1987/Teman2`), making the M5
+  lane's #2781 a twin-race casualty: **CLOSED 2026-07-19T02:33:58Z**, no merge attempted, full
+  investigative writeup on the PR. Items 1 (canonical date literals) and 3 (StrictBool) were also
+  redundant against #2745's more mature equivalents. Only 2 of the original 5 port-list items were
+  genuinely still unclaimed after a fresh `origin/main` content grep (no merged commit, no open
+  PR/branch): CodeQL `list(Enum)` pattern (7 sites) and the JSON-Schema-vs-StrictInt integer-parity
+  documentation+pin (line 130-131's "common residual" above) — both shipped via branch
+  `agent/air-m5/backend-rag/visa-engine-pr1b-residual` (commit `fc24dc7913`, 492/492 suite green,
+  ruff clean, docs_sync clean).
+- 2026-07-19: **LEDGER GAP FLAGGED (not backfilled here — respecting "whoever changes state updates
+  this file")**: lines 116-118 above narrate Track A only through "STEP 3 (PR2 signed bundle) in
+  flight" — PR2b (#2757, merged 2026-07-18T17:45:52Z) and PR3 (#2773, strong-Kleene evaluator +
+  2-seat fixes, merged 2026-07-18T19:34:19Z) both already landed on main since then but have no
+  LIVE STATE entry recording it. Track A's own next-lane session should backfill STEP 4/5 entries.
+  **Verified standing blocker**: Ed25519 key ceremony remains explicitly operator-side and undone —
+  `bundle.py:269`'s own comment ("the key ceremony (generating...") plus the STEP-2/3 entry's
+  "FIREBREAK intact (no key ceremony, unsigned fail-closed behind flag, never PROD)" both confirm
+  signing code ships unarmed pending real production keys. With PR1→PR3 all merged, "Track A next"
+  is genuinely PR4-6 (undefined in this file) gated behind that ceremony — NOT "PR3 evaluator", which
+  is done.
 
 ## TRACKS — parallel work groups (multi-session coordination)
 

--- a/.claude/skills/visaoracle/SKILL.md
+++ b/.claude/skills/visaoracle/SKILL.md
@@ -133,6 +133,39 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
   py/non-iterable-in-for-loop is a required-check failure class (S3 cured it on their tree in
   commit 1a4360dc1b; A-tree tests should adopt the same pattern in PR1b).
 
+- 2026-07-19: **TRACK A PR1b ARBITRATION RESOLVED + STAGE_ORDER CORRECTED.** The 2026-07-18 line
+  126-134 WARNING above ("the two trees disagree on ELIGIBILITY vs HUMAN_REVIEW precedence —
+  arbitrate against the round-2 spec") was itself resolved WRONG the first time: the M5 lane's PR1b
+  attempt (worktree `backend-rag-visa-engine-pr1b`) arbitrated to the enum-DECLARATION order
+  (HARD_FILTER→ELIGIBILITY→HUMAN_REVIEW→RANKING, matching enums.py's literal source order + the
+  spec's JSON Schema enum listing) — flagged **P0 by tri-LLM review on its own PR #2781** and
+  independently re-verified by re-reading the spec's §4.2 `evaluate_product` ALGORITHM pseudocode
+  directly: the correct order is **HARD_FILTER→HUMAN_REVIEW→ELIGIBILITY→RANKING**, exactly what
+  sibling PR #2773 already shipped (commit message: "the prior docstring's 'evaluated in this strict
+  order' claim was wrong"). Declaration order ≠ processing order — do not re-litigate this without
+  re-reading §4.2 fresh. Meanwhile a sibling S3 lane had independently re-shipped the whole PR1b
+  port-list as **PR #2745 MERGED 2026-07-18T14:17:49Z** (after hotfix #2739, before PR2b #2757 and
+  PR3 #2773 — all 4 verified MERGED via `gh pr view` against `Balizero1987/Teman2`), making the M5
+  lane's #2781 a twin-race casualty: **CLOSED 2026-07-19T02:33:58Z**, no merge attempted, full
+  investigative writeup on the PR. Items 1 (canonical date literals) and 3 (StrictBool) were also
+  redundant against #2745's more mature equivalents. Only 2 of the original 5 port-list items were
+  genuinely still unclaimed after a fresh `origin/main` content grep (no merged commit, no open
+  PR/branch): CodeQL `list(Enum)` pattern (7 sites) and the JSON-Schema-vs-StrictInt integer-parity
+  documentation+pin (line 130-131's "common residual" above) — both shipped via branch
+  `agent/air-m5/backend-rag/visa-engine-pr1b-residual` (commit `fc24dc7913`, 492/492 suite green,
+  ruff clean, docs_sync clean).
+- 2026-07-19: **LEDGER GAP FLAGGED (not backfilled here — respecting "whoever changes state updates
+  this file")**: lines 116-118 above narrate Track A only through "STEP 3 (PR2 signed bundle) in
+  flight" — PR2b (#2757, merged 2026-07-18T17:45:52Z) and PR3 (#2773, strong-Kleene evaluator +
+  2-seat fixes, merged 2026-07-18T19:34:19Z) both already landed on main since then but have no
+  LIVE STATE entry recording it. Track A's own next-lane session should backfill STEP 4/5 entries.
+  **Verified standing blocker**: Ed25519 key ceremony remains explicitly operator-side and undone —
+  `bundle.py:269`'s own comment ("the key ceremony (generating...") plus the STEP-2/3 entry's
+  "FIREBREAK intact (no key ceremony, unsigned fail-closed behind flag, never PROD)" both confirm
+  signing code ships unarmed pending real production keys. With PR1→PR3 all merged, "Track A next"
+  is genuinely PR4-6 (undefined in this file) gated behind that ceremony — NOT "PR3 evaluator", which
+  is done.
+
 ## TRACKS — parallel work groups (multi-session coordination)
 
 The v2 program runs as separate tracks, one per surface, coordinated ONLY through this skill. Any

--- a/apps/backend-rag/backend/services/visa_engine/schema_export.py
+++ b/apps/backend-rag/backend/services/visa_engine/schema_export.py
@@ -230,6 +230,24 @@ _ALLOF_INJECTIONS: dict[str, list[dict[str, Any]]] = {
             "if": {"properties": {"status": {"const": "AVAILABLE"}}},
             "then": {
                 "properties": {
+                    # PR1b item 5 (residual, twin-race adjudication 2026-07-19):
+                    # JSON Schema 2020-12 "type": "integer" is defined as "a
+                    # number with a zero fractional part" and therefore
+                    # ACCEPTS a float like 2.0 as a valid integer instance.
+                    # PriceQuote.amount is `Annotated[int, Field(strict=True)]`
+                    # on the Pydantic side, and pydantic-core's strict-int mode
+                    # REJECTS any float, including whole-valued ones. This
+                    # divergence is inexpressible in pure JSON Schema (no
+                    # "reject non-int-typed floats" primitive exists) and is
+                    # therefore intentional, not a defect — pinned in both
+                    # directions by
+                    # TestIntegerParityDivergencePinned in
+                    # test_schema_contracts.py (via Rule.priority, same
+                    # strict-int shape). Every other strict-int field in this
+                    # engine (e.g. Rule.priority) shares the identical gap;
+                    # this comment lives here because this is the one place
+                    # in schema_export.py that hand-writes an integer type
+                    # literal — the rest are Pydantic-auto-generated.
                     "amount": {"type": "integer", "minimum": 0},
                     "catalog_version": {"type": "string"},
                     "catalog_sha256": _SHA256_HEX_INLINE,

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_fact_registry.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_fact_registry.py
@@ -39,7 +39,7 @@ from backend.tests.services.visa_engine.conftest import GOLD_EFFECTIVE_AT
 
 class TestDefaultCatalogCompleteness:
     def test_every_fact_path_has_a_spec(self) -> None:
-        for path in FactPath:
+        for path in list(FactPath):
             spec = DEFAULT_FACT_REGISTRY.spec(path)
             assert spec.path is path
 
@@ -54,7 +54,7 @@ class TestDefaultCatalogCompleteness:
             assert DEFAULT_FACT_REGISTRY.spec(path).derived is True
 
     def test_applicant_facts_not_flagged_derived(self) -> None:
-        for path in FactPath:
+        for path in list(FactPath):
             if path in DERIVED_FACT_PATHS:
                 continue
             assert DEFAULT_FACT_REGISTRY.spec(path).derived is False
@@ -88,7 +88,7 @@ class TestMissingPaths:
 
 class TestCommercialClassification:
     def test_commercial_paths_match_enums_constant(self) -> None:
-        for path in FactPath:
+        for path in list(FactPath):
             expected = path in COMMERCIAL_FACT_PATHS
             assert DEFAULT_FACT_REGISTRY.is_commercial(path) is expected
 
@@ -247,7 +247,7 @@ class TestValueFormatKindConsistency:
         assert spec.value_format == "country_code"
 
     def test_none_format_always_accepted_regardless_of_kind(self) -> None:
-        for kind in FactValueKind:
+        for kind in list(FactValueKind):
             spec = FactSpec(
                 path=FactPath.PERSON_MARITAL_STATUS,
                 kind=kind,

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_schema_contracts.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_schema_contracts.py
@@ -402,7 +402,7 @@ class TestSchemaExportInvariants:
         schemas = SE.build_schemas()
         condition_schema = schemas["condition.schema.json"]
         rendered = str(condition_schema)
-        for op in ConditionOperator:
+        for op in list(ConditionOperator):
             assert op.value in rendered, f"operator {op.value!r} missing from exported schema"
 
     def test_export_schemas_writes_files_to_disk(self, tmp_path: Path) -> None:
@@ -437,13 +437,13 @@ class TestSchemaExportInvariants:
     def test_decision_state_present_in_contract(self) -> None:
         schemas = SE.build_schemas()
         rendered = str(schemas["contract.schema.json"])
-        for state in DecisionState:
+        for state in list(DecisionState):
             assert state.value in rendered
 
     def test_unknown_reason_present_in_contract(self) -> None:
         schemas = SE.build_schemas()
         rendered = str(schemas["contract.schema.json"])
-        for reason in UnknownReason:
+        for reason in list(UnknownReason):
             assert reason.value in rendered
 
 
@@ -1611,3 +1611,39 @@ class TestIsoDatePatternAsciiOnly:
         assert Draft202012Validator({"type": "string", "pattern": pattern}).is_valid(
             "2026-07-17"
         ) is True
+
+
+class TestIntegerParityDivergencePinned:
+    """PR1b item 5 (residual, twin-race adjudication 2026-07-19): JSON Schema
+    2020-12 ``"type": "integer"`` is defined as "a number with a zero
+    fractional part" — it accepts the float ``2.0`` as a valid integer
+    instance. Pydantic's ``strict=True`` int fields (used throughout this
+    engine, see ``Rule.priority`` / ``PriceQuote.amount``) reject ANY float,
+    including whole-valued ones like ``2.0`` — Python's ``bool``-is-``int``
+    strict-mode carve-out aside, there is no way to express "reject
+    whole-valued floats" in pure JSON Schema 2020-12; ``multipleOf``/
+    ``type: integer`` both accept 2.0 as-is.
+
+    This is a genuine, permanent, inexpressible-in-JSON-Schema divergence
+    between the exported contract and the Pydantic model that produced it
+    -- not a bug to fix. These two tests pin BOTH directions so the
+    divergence stays visible and intentional (a regression in either
+    direction — the schema starting to reject 2.0, or the model starting to
+    accept it — would silently erase the documented gap this class exists
+    to guard).
+    """
+
+    def test_exported_schema_accepts_float_valued_integer_for_priority(self) -> None:
+        contract = SE.build_schemas()["contract.schema.json"]
+        priority_schema = contract["$defs"]["Rule"]["properties"]["priority"]
+        assert priority_schema["type"] == "integer"
+        validator = Draft202012Validator(priority_schema)
+        assert validator.is_valid(2.0) is True
+
+    def test_model_rejects_the_same_float_valued_integer_for_priority(
+        self, minimal_valid_pack: M.RulePack
+    ) -> None:
+        dumped = minimal_valid_pack.payload.rules[0].model_dump(mode="json", by_alias=True)
+        dumped["priority"] = 2.0
+        with pytest.raises(ValidationError):
+            M.Rule.model_validate(dumped)


### PR DESCRIPTION
## Summary

This is a **residual** follow-up to the PR1b hardening port-list mandate (adapted from closed PR #2718's reference tree onto the merged visa engine, originally #2654 / `f73cbb4a7b`).

**Twin-race discovered and adjudicated**: while this branch was in flight, a sibling session independently shipped the same PR1b mandate as **#2745** (merged 2026-07-18T14:17:49Z), on top of #2739, followed by #2757 (PR2b) and #2773 (PR3). This was caught via `mergeable: CONFLICTING` on my first PR attempt (#2781, now closed with full writeup) — never trusted the flag alone, verified by real content-diff against `origin/main` per the "verify by content, never by proxy" discipline.

Per-item disposition after auditing fresh `origin/main` content:

| Item | Disposition |
|---|---|
| 1. Canonical `YYYY-MM-DD` date literal validation | **Dropped** — #2745 already ships a more mature equivalent |
| 2. Semantic `STAGE_ORDER` | **Dropped** — my branch's originally-adjudicated sequence (`HARD_FILTER→ELIGIBILITY→HUMAN_REVIEW→RANKING`) was independently re-verified against the spec's own §4.2 `evaluate_product` pseudocode to be **wrong**. The spec's real algorithm order is `HARD_FILTER→HUMAN_REVIEW→ELIGIBILITY→RANKING`, which is exactly what main's `f77eec7c26` already ships. Shipping the original item 2 here would have been a regression. |
| 3. `StrictBool` on wire-level booleans | **Dropped** — #2745 already ships byte-identical strict-bool fields |
| 4. CodeQL `py/non-iterable-in-for-loop` pattern cure | **Shipped here** — still genuinely open on main |
| 5. Integer parity divergence (JSON Schema vs Pydantic StrictInt) | **Shipped here** — still genuinely open on main |

## What this PR does

- **Item 4**: `for x in SomeEnum:` → `for x in list(SomeEnum):` at the 7 remaining occurrences in the engine test suite (`test_fact_registry.py` x4, `test_schema_contracts.py` x3) — mirrors reference commit `1a4360dc1b`'s established fix. Source directory (`backend/services/visa_engine/`) was already clean.
- **Item 5**: JSON Schema 2020-12 `"type": "integer"` accepts a float like `2.0` (spec defines integer as "a number with a zero fractional part"); this engine's Pydantic models use `Annotated[int, Field(strict=True)]` throughout, which rejects any float. Inexpressible in pure JSON Schema. Added a documenting comment at the one hand-written integer-emitting site in `schema_export.py` (`PriceQuote.amount`, inside a conditional `allOf` injection) plus a new `TestIntegerParityDivergencePinned` test class pinning both directions via `Rule.priority` (schema accepts `2.0` / model rejects `2.0`), verified empirically before committing.

## Second commit: LIVE STATE reconcile

`.claude/skills/visaoracle/SKILL.md` + its `.agents/` mirror (kept byte-identical, per the file's own convention): records the PR1b arbitration RESOLVED — the correct `STAGE_ORDER` is `HARD_FILTER→HUMAN_REVIEW→ELIGIBILITY→RANKING` per spec §4.2's `evaluate_product` pseudocode (this branch's own original reading, the enum-declaration order, was wrong — flagged P0 by tri-LLM review on #2781); records the full sibling ship chain (#2739/#2745/#2757/#2773, all independently re-verified MERGED via `gh pr view` against `Balizero1987/Teman2`) and this branch's #2781 closed as the twin-race casualty. Also flags (without backfilling — respecting "whoever changes state updates this file") that the ledger's STEP narrative never recorded PR2b/PR3 merging, and corrects "Track A next" from a stale "PR3 evaluator" framing (PR3 is done, merged as #2773) to the actually-verified standing blocker: the Ed25519 key ceremony, confirmed still operator-side/undone via `bundle.py:269`'s own comment.

## Gate (generator != grader)

- Full engine suite: **492 passed**, 0 failed.
- `ruff check` on `backend/services/visa_engine` + its tests: clean.
- `scripts/docs_sync.py --check`: no drift (both commits).
- Independent review attempted: `codex exec -m gpt-5.6-sol -c model_reasoning_effort=xhigh --sandbox read-only` hit pure network flap (WebSocket/HTTPS reconnect failures, "No route to host") and returned no verdict — not a finding, infra noise. Both changes are mechanical (CodeQL loop-iteration pattern, already established elsewhere in this codebase) or documentation+test-only (integer parity), and both directions of the parity claim (schema accepts `2.0` / model rejects `2.0`) were empirically verified live against the real exported schema and the real Pydantic model before committing — see commit body for the exact commands.

## Out of scope

Strong-Kleene evaluator (PR3, already merged as #2773), signing (PR2b, already merged as #2757; Ed25519 key ceremony itself remains operator-side and undone), any runtime wiring, and items 1-3 of the original port-list (superseded by #2745).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
