### PR TITLE
feat(arsenal): Kimi enters, DeepSeek retires — M5 leg (capture, R1 seats, AGENTS.md contract, Kimi onboarding)

### DIFF
--- a/.claude/agents/wr2-design-architect-resources/architecture-patterns.md
+++ b/.claude/agents/wr2-design-architect-resources/architecture-patterns.md
@@ -111,7 +111,7 @@
 **Cross-LLM verification (bipolar verifier already in CLAUDE.md)**:
 
 - Critic panel: Claude main + Gemini cross-check (free) + NotebookLM ground-truth (NB-DESIGN-AGENT just created).
-- DeepSeek as alternate cross-check when Gemini quota exhausted.
+- Kimi K3 (`kimi` CLI, flat sub) as alternate cross-check when Gemini quota exhausted (DeepSeek API retired 2026-07-19).
 - Never include OpenAI in runtime path (would burn Codex Plus quota that's reserved for code review).
 
 **Tools whitelist for orchestrator** (`tools` field in YAML):

--- a/.claude/agents/wr2-design-architect.md
+++ b/.claude/agents/wr2-design-architect.md
@@ -409,7 +409,7 @@ These rules cannot be overridden by user request without explicit Antonello appr
 - **Centralized state**: you are the orchestrator. Subagents (critic, future layout-composer, future brief-interpreter) are stateless workers reading shared files. NEVER let subagents talk to each other peer-to-peer (Google's 17.2× error-amplification finding).
 - **Human-in-loop on publish**: you do NOT publish to Instagram. Damar publishes manually. Your output stops at Canva (via existing wr2-canva-apply skill).
 - **No autonomous skill writes to main**: skill changes go to `_proposed/`. Antonello commits to main weekly.
-- **Cost = zero**: only OAuth Claude (Opus/Sonnet/Haiku via subagents), free Gemini CLI for cross-check, NotebookLM for ground-truth RAG, DeepSeek API ($0.01/query OK). NEVER use ANTHROPIC_API_KEY, OpenAI API, Vertex AI billed runtime.
+- **Cost = zero**: only OAuth Claude (Opus/Sonnet/Haiku via subagents), free Gemini CLI for cross-check, NotebookLM for ground-truth RAG, Kimi CLI (`~/.kimi-code/bin/kimi`, flat subscription — DeepSeek API retired 2026-07-19). NEVER use ANTHROPIC_API_KEY, OpenAI API, Vertex AI billed runtime.
 - **No emoji in user-facing output**: respond in clean text. Antonello has hard rule on this in CLAUDE.md.
 
 ## When to refuse

--- a/.kimi-code/skills/nuzantara-context/SKILL.md
+++ b/.kimi-code/skills/nuzantara-context/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: nuzantara-context
+description: Deep-context map of the Nuzantara/Bali Zero system for Kimi working in this repo — where every truth lives, which rules are blood-bought, and what Kimi's role in the workflow is. Load whenever a task touches this repo beyond a single file.
+---
+
+# Nuzantara deep context (for Kimi)
+
+You are working inside **Nuzantara**, the production AI-organism of **Bali Zero** (Indonesian
+visa/company/tax/property agency). The root `AGENTS.md` gives you the operating contract
+(machine map, external-agent rules, worktree discipline). This skill tells you **where the
+truth lives** so you never guess.
+
+## Your role in this team's workflow (decided 2026-07-19)
+
+- **You build — a Claude session verifies.** Branches/diffs/artifacts only; never merge,
+  never push `main`, never deploy, never publish (Legge 5). Your reviewer is adversarial by
+  design (generator≠grader) — write for review, cite file:line for every claim.
+- Your strong chairs here: **cross-family second opinion / refuter** (via `kimi` CLI),
+  **agentic web research** (BrowseComp-class), **spreadsheet/data batch**, **frontend/UI
+  and artifact drafts** (sites/slides/docs — brand surfaces still pass the WR2 constitution
+  gates before any use).
+- **Scope tightly.** K3's known failure mode is over-proactivity on ambiguous tasks: state
+  your reading in one line, take the narrowest interpretation, never invent adjacent work.
+
+## Where the truth lives (read, don't guess)
+
+| Need                                                     | Authority                                                                                                |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Project rules, invariants, deploy                        | `CLAUDE.md` (repo root — Claude-oriented but authoritative for everyone)                                 |
+| Ecosystem laws (PII, sovereignty, publish gate)          | `SYMBIOSIS.md`                                                                                           |
+| Operative checklist before building anything             | `VADEMECUM.md`                                                                                           |
+| Repo atlas (where every organ lives)                     | `INDEX.md`                                                                                               |
+| Blood-bought failure patterns (10 families)              | `.claude/rules/cicatrix-superscar.md` — check BEFORE repeating a known mistake                           |
+| WR2 editorial pipeline (carousels → Instagram)           | `.claude/skills/wr2/SKILL.md` (the corner: anatomy, live state, hard rules)                              |
+| Master loop the Claude sessions run                      | `.claude/skills/modus/SKILL.md` · suspended-work ledger: `.claude/skills/modus/PENDING-ARMS.md`          |
+| Backend specifics (Sentry PII hook, migrations, routers) | `apps/backend-rag/CLAUDE.md`                                                                             |
+| Prices                                                   | `PricingTool` ONLY (`backend/data/bali_zero_official_prices_2026.json`) — never hardcode, never estimate |
+| Project memory (decisions/discoveries)                   | `~/.claude/projects/*/memory/MEMORY.md` index (M5: `-Users-balizero-nuzantara`) — read-only for you      |
+
+## Hard invariants you must never break
+
+- **Embedding model FROZEN**: `text-embedding-3-small` (1536 dims). Changing it invalidates ~100k vectors.
+- **KBLI payloads are FLAT** (no nesting) — fields per `CLAUDE.md` §9.
+- **Evidence thresholds are 5 NAMED gates** (`backend/services/rag/agentic/_abstain_policy.py`) — never "tidy" them into one number.
+- **Queue JSONs** (`apps/war-room/output/queue/*.json`) — canonical writers only, never hand-edit.
+- **Migrations**: custom SQL in `backend/db/migrations_v2/NNN_*.sql` with `-- === ROLLBACK ===` marker (NOT Alembic).
+- **Anthropic SDK banned** (`ANTHROPIC_API_KEY` never) — Claude is reached only via the `claude` CLI OAuth path.
+- **No paid per-token APIs** without the owner's explicit authorization (your own Kimi access is flat-subscription — fine).
+
+## Test & verify commands (run before handing work back)
+
+```bash
+cd apps/backend-rag && source .venv/bin/activate
+python -c "from backend.app.dependencies import get_current_user; print('OK')"   # import chain
+PYTHONPATH=. pytest backend/tests/<relevant-path> -q                              # scoped tests
+ruff check backend/                                                               # lint
+```
+
+Frontend: `cd apps/mouth && npm run lint && npm run test`.
+
+## Communication
+
+- Owner is **Zero** (Italian; real name private). Commits/PRs/docs in **English**,
+  conventional format `feat|fix|chore|refactor|docs(scope): subject`.
+- Your handoff = a branch + a 5-line summary: what changed, why, what you tested, what you
+  did NOT verify, open risks. Honesty about untested parts is valued over polish.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,31 @@
-# AGENTS.md - Nuzantara Project Context for Codex
+# AGENTS.md - Nuzantara Project Context for AI coding agents (Codex · Kimi · Gemini · …)
+
+> Read by every AGENTS.md-standard agent: Codex CLI, **Kimi (kimi-code CLI + Kimi Desktop
+> work-mode, whose workspace is this repo)**, Antigravity/agy, and others. "Codex" below
+> generalizes to "you, the external agent" unless a rule names a specific tool.
+
+## 0.0. External-agent contract (READ FIRST — Kimi/Codex/agy alike)
+
+1. **You build — a Claude session verifies.** Your work product is a branch/diff/artifact
+   that an interactive Claude session independently reviews, tests and merges
+   (generator≠grader). **Never merge your own work, never push to `main`, never arm
+   auto-merge, never deploy.** Prepare; don't ship.
+2. **Legge 5 (absolute):** never publish anything outward — no Instagram, no email, no
+   WhatsApp, no client-facing sends. Editorial drafts stop at `drafted` in the review
+   queue; the owner publishes.
+3. **PII boundary (UU PDP / SYMBIOSIS Law 2, non-negotiable):** client PII (KTP, passport,
+   NPWP, akta, CRM records, OSINT) must never be transcribed into cloud outputs, logs,
+   artifacts or prompts. DB access is read-only (`nuzantara_readonly`); if a task seems to
+   need client rows, STOP and surface it.
+4. **Worktree discipline applies to YOU** (§0.5): the Claude-side hooks do NOT bind you —
+   the convention does. Mutations happen in `.worktrees/<lane>-<task>/`, never in the main
+   checkout. Kimi Desktop: ask the operator to point the workspace at a worktree lane.
+5. **Off-limits files:** `zantara_core.py` (edit only via its own rules), `fly.toml`,
+   `.env*`, `alembic/env.py`, curated datasets (data-plane guard), the WR2 queue JSONs
+   (canonical writers only).
+6. **Scope tightly, don't improvise.** If the task is ambiguous, state your assumption in
+   one line and take the narrowest reading — do NOT invent adjacent work (this is aimed
+   especially at K3's known over-proactivity).
 
 ## 0. Machine Identification (IMPORTANT)
 
@@ -69,7 +96,7 @@ M5 has **no `ollama`** by design. Never `ollama pull` or `brew install ollama` o
 | OCR / vision (`qwen2.5vl`) | `ssh pro` — Ollama binds `127.0.0.1:11434`, **closed** to M5 |
 | embed batch (`bge-m3`) | `ssh pro` / `ssh mini` |
 
-Lightweight **cloud** LLM clients **are** fine on M5 (they're already set up): `agy` (Gemini), `codex` (you), `nlm` (NotebookLM), DeepSeek API. Use them directly.
+Lightweight **cloud** LLM clients **are** fine on M5 (they're already set up): `agy` (Gemini), `codex`, `kimi` (`~/.kimi-code/bin/kimi`, armed M5+Pro+Mini), `nlm` (NotebookLM). Use them directly. (DeepSeek API RETIRED 2026-07-19 — never route to it; local `deepseek-r1:32b` Ollama weights on Pro/Mini are unrelated and stay.)
 
 ### HARD RULE R3 — DB & vector store: exact access per service
 
@@ -225,7 +252,7 @@ Use only for emergency / hotfix / cicatrix-fix.
 - **Vector Collections:** 11 canonical logical collections (`backend/core/collection_registry.py`), 104,154 documents
 - **Embedding Model:** `text-embedding-3-small` (1536 dims) — **NEVER CHANGE**
 
-## 2. Codex Behavior Rules (IMPORTANT)
+## 2. Agent Behavior Rules (IMPORTANT)
 
 **DO NOT ask the user to write code.** You are authorized to edit, write, and execute code directly.
 
@@ -615,7 +642,7 @@ fly deploy --strategy rolling
 
 ---
 
-**Last Updated:** 2026-03-28
+**Last Updated:** 2026-07-19 (external-agent contract + Kimi onboarding; was 2026-03-28)
 **Maintained by:** Bali Zero AI Team
 
 ---

--- a/research/operations/2026-07-19-kimi-arsenal-integration-deepseek-retirement.md
+++ b/research/operations/2026-07-19-kimi-arsenal-integration-deepseek-retirement.md
@@ -1,0 +1,161 @@
+---
+date: 2026-07-19
+domain: operations
+client_case: none — arsenal revision on Zero's order ("Kimi è entrato nel team… togli DeepSeek, rivedi il nostro arsenale")
+adversarial_review: codex
+sources:
+  - ON-DISK M5 (this session): /Applications/Kimi.app (Kimi Desktop 3.1.2) · ~/Library/Application Support/kimi-desktop/kimi-agent/kimi-work-models-cache.json (model catalog) · daimon-share/config.toml + daimon/ (runtime) · sessions/hosted-logical/conversations.sqlite + wire.jsonl (the real session studied) · ~/.kimi-code/bin/kimi 0.27.0 — 1-token K3 probe PONG re-run by this author
+  - PR #2791 "feat(arsenal): Kimi seat (K3 + kimi-for-coding 2.7, Allegro flat sub)" — the Pro twin session's probe+doctrine wiring (arsenal_probe kimi seat, SKILL.md §Arsenal, runbook), read this turn
+  - https://www.tomshardware.com/tech-industry/artificial-intelligence/moonshot-releases-2-8-trillion-parameter-kimi-k3 + https://venturebeat.com/technology/chinas-moonshot-ai-releases-kimi-k3-the-largest-open-source-model-ever-rivaling-top-u-s-systems (K3 release 2026-07-16, 2.8T MoE open-weight)
+  - https://simonwillison.net/2026/Jul/16/kimi-k3/ + https://aireleasetracker.com/model/moonshot/kimi-k3 (tracker-reported benchmarks: BrowseComp 91.2, MCP Atlas 84.2, GDPval-AA v2 3rd behind Fable 5 Max / GPT-5.6 Sol Max; over-proactivity caveat)
+  - https://www.marktechpost.com/2026/06/12/moonshot-ai-releases-kimi-k2-7-code-a-coding-model-reporting-21-8-on-kimi-code-bench-v2-over-k2-6/ + https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart (K2.7-Code 2026-06-12, Kimi Code CLI default, −30% thinking tokens)
+  - https://decrypt.co/370954/moonshot-ai-kimi-work-300-agents-desktop + https://www.kimi.com/help/membership/membership-pricing (Kimi Work desktop, Agent Swarm; plans Allegretto $39 / Allegro $99 / Vivace $199)
+  - .claude/skills/modus/SKILL.md §Arsenal · CLAUDE.md §5/§6 · scripts/check_adversarial_review.py KNOWN_SEATS (pre-change census)
+---
+
+# Kimi enters the arsenal; DeepSeek retires — the 2026-07-19 workflow revision (M5 leg)
+
+Zero's mandate: Kimi (K2.7, K3) è entrato nel team — study it, study its live session on M5,
+integrate it into the workflow, retire DeepSeek. **Twin-race note (resolved, scar #5):** while
+this study ran, the Pro Fable session opened **PR #2791** (arsenal_probe `kimi` seat + modus
+§Arsenal + CLAUDE.md §5 + runbook, CLI armed on Pro AND M5). This capture **concedes those
+surfaces to #2791** and carries the complementary half: the M5 desktop-session study, the Kimi
+Work surface map, the **DeepSeek removal** (Zero's explicit order — #2791's cascade still names
+DeepSeek; coordinated via PR comment), the R1 seat census change, and the PII boundary flag.
+
+## 1. What Kimi concretely is (on-disk + multi-source web)
+
+**On M5:** Kimi Desktop **3.1.2** (`/Applications/Kimi.app`), an Electron app embedding an
+agentic runtime ("daimon") with a `kimi-code` kernel, an MCP **client**, a 31-skill library
+(ad-creative, campaign-plan, copywriting, kimi-slides, legal-risk-assessment, pricing-strategy,
+seo-audit, webapp-building, docx/xlsx/pdf, widgets), and a Widget/canvas artifact system. Model
+catalog exposed by the app (`kimi-work-models-cache.json`, read this session):
+
+| Cache key | Display | Context | Capabilities | Role |
+|---|---|---|---|---|
+| `k3-agent` | **K3** | **1,000,000** | thinking, image_in, **video_in**, dynamic tools | flagship chat+agent |
+| `k3-agent-ultra` (modelId/alias `k3-agent-swarm`) | **K3 Swarm** | 1,000,000 | same | "massive search, batch processing" — multi-agent swarm |
+| `k2d6-agent` | K2.6 Agent | 262,144 | thinking, image, video | research/slides/websites/docs/sheets artifacts |
+| `k2p6` (daimon `kimi-code` kernel) | coding model | 262,144 | thinking, image, video | the work-function coder |
+
+Zero's live desktop conversation runs `k3-agent` at thinking **max**; account capacity
+`extended` (XL 1M context available — Allegro-tier features on; flat subscription, no per-token
+key). **Headless:** the standalone `kimi` CLI (`~/.kimi-code/bin/kimi` **0.27.0**, OAuth
+device-code, no API key) is **armed on M5** — this author re-ran the 1-token probe this turn:
+`kimi -p … -m kimi-code/k3` → `PONG`. #2791 reports the same on Pro (author-reported there;
+probed by its own session).
+
+**Web (2026-07, tracker-reported figures):** **K3** (2026-07-16) is a 2.8T-param open-weight MoE
+(16/896 experts, Kimi Delta Attention, ~6.3× faster decode at 1M ctx). BrowseComp **91.2%** (best
+published at release), MCP Atlas 84.2, HLE-with-tools 56.0, #1 LMArena Frontend Code Arena (6/7
+domains, ahead of Fable 5 and GPT-5.6 Sol), AA Coding Index 76.24; GDPval-AA v2 **3rd overall**
+behind only Fable 5 Max and GPT-5.6 Sol Max. **K2.7-Code** (2026-06-12, open-weight, Modified
+MIT): +21.8% Kimi Code Bench v2 vs K2.6, −30% thinking tokens; the standalone CLI's default
+coding model. Evaluator-reported deployment caveat: K3 is **excessively proactive on ambiguous
+tasks** — scope tightly, verify independently.
+
+## 2. How it works here (the M5 desktop session, from wire.jsonl — read by this author)
+
+One completed conversation (`8be3425d…`, 2026-07-19, model k3-agent, workspace
+**`/Users/balizero/nuzantara`** — the MAIN checkout). Zero asked "cosa potresti fare per il mio
+sistema con la funzione work?". Kimi, in **yolo permission mode**, autonomously: (1) ran
+fleet-aware Bash (hostname→pro/mini ssh case logic — it absorbed our conventions); (2) called
+**five of our production MCP tools** (`lam_grounding_snapshot`, `get_agents_status`,
+`check_health_detailed`, `get_client_stats`, `get_intel_metrics`); (3) loaded its widget skills
+(11 reference reads) and built+validated+showed a live "Nuzantara · Mission Control" HTML widget
+(16KB). Usage: 111k cache-read tokens, 829 out. Its MCP client is wired to **our stack**:
+`server-github`, `playwright`, `server-postgres` on the **readonly proxy**
+(`nuzantara_readonly@localhost:15432`), plus Kimi-native tools (imagegen, audiogen, webbridge,
+sec_edgar, scholar, yahoo_finance, world_bank, IMF). (These session-anatomy facts are from this
+author's direct reads of the local artifacts; an external reviewer cannot re-verify the volatile
+parts and graded them author-reported — see §Adversarial review.)
+
+**Risk flags (each with an ops/ledger action):**
+- **PII boundary (HARD).** Kimi is a Chinese cloud stack (Moonshot) — same absolute rule DeepSeek
+  had: **no client PII ever** (UU PDP / Law 2). Its MCP surface today includes the prod readonly
+  DB and `nuzantara-mcp` client tools (`get_client`, `list_clients`…): a Kimi query touching
+  client rows would egress PII to Moonshot. The observed session called only aggregate/health
+  tools, but nothing structural prevents worse. **Interim session-side rule (active now): any
+  prompt we hand Kimi (CLI or desktop) must not require `server-postgres`, CRM/client, or
+  raw-record tools — aggregate/health/intel/KBLI surfaces only.** Restricting/unplugging the MCP
+  config itself is the operator's (`operator[consent]`, ledgered) — not silently done for him.
+- **Sibling discipline (#5).** Workspace = main checkout, in yolo mode — the combination our
+  worktree discipline forbids for agents. Recommend the operator point Kimi work-mode at
+  `.worktrees/ops-kimi-<task>` lanes (Antigravity precedent). Ledgered.
+- **Secret hygiene (#4).** `daimon-share/config.toml` carries the app's own coding-gateway key in
+  cleartext; permissions verified 0600 this session (value not reproduced anywhere).
+
+## 3. The arsenal revision (this PR + #2791 together)
+
+**DeepSeek OUT (Zero's order + the record):** HTTP 402 balance-dead at two consecutive councils
+(2026-06-30, 2026-07-02); already demoted behind GLM on 2026-07-03. This PR removes it from the
+R1 seat census (`check_adversarial_review.py`), the §6 panel line, and the wr2 agent-def
+mentions; the modus §Arsenal cascade edit is **coordinated with #2791** (whose draft still names
+DeepSeek — flagged to the twin via PR comment, per Zero's newer order). The **local**
+`deepseek-r1:32b` Ollama weights are NOT the API seat — they stay (offline reasoning, $0).
+
+**Kimi IN — three roles, two surfaces:**
+
+| Role | Model/surface | When |
+|---|---|---|
+| **Cross-family refuter / R1 seat (headless)** | `kimi` CLI (`-m kimi-code/k3`, or `kimi-for-coding` for code) — **armed on M5+Pro** | Councils, R1 adversarial reviews, panel seat. Refuter cascade (post-#2791, DeepSeek stripped): **GLM 5.2 → Kimi K3 → Codex** per #2791's ordering — probe-then-trust per seat, as ever. Mini login = `operator[consent]` (#2791 ledger). |
+| **Agentic web-research / massive sweep / sheets-batch** | K3 / K3 Swarm via desktop (operator-driven) | BrowseComp-class deep research, competitor/IG sweeps, spreadsheet batch — the independent second-sweep organ. NON-PII only. |
+| **Frontend/UI + artifact builder (verified-arm)** | K3 / K2.6-Agent / kimi-code via desktop work-mode | Antigravity-model: Kimi builds (sites/slides/docs/UI), **the session independently verifies, tests, commits** — Kimi never self-merges; brand surfaces still pass the WR2 constitution gates. |
+
+**Unchanged spine:** Fable 5 architect/final-gate (never cascaded) · Sonnet 5 implementer ·
+Haiku grunt · Codex GPT-5.6 red-team+sandbox · Gemini `agy` width/ingestion · GLM 5.2
+second-brain · Ollama local PII/$0 · NotebookLM ground truth. Operational note (timeboxed, not a
+durable conclusion): Codex `sol` at high effort exceeded the 590s harness cap **twice today** on
+multi-file reviews — use `terra` medium as the R1 default for now, log latencies, and on a
+timeout record the failure and escalate along the declared cascade; never silently downgrade.
+
+**Panels (corrected arithmetic):** the pre-approval panel = **three external LLM seats** (Gemini
+`agy` + Codex GPT-5.6 + Kimi K3 — GLM 5.2 substitutes if a seat is dead) **+ the Fable
+orchestrator + optional NB-1 ground-truth verifier** (NB is retrieval, not an LLM seat). The
+historical label "4-LLM panel" stays as the section name; the composition line is now honest.
+
+**Cost posture:** Kimi = Zero's flat subscription (like MAX / ChatGPT Pro / AI Ultra) —
+free-first/OAuth-first preserved. The per-token `platform.kimi.ai` API is NOT enabled; any
+per-token key would need Zero's explicit authorization. The desktop app's bundled gateway key is
+the app's own — never extracted or reused.
+
+## 4. Recommendation (ONE, actionable)
+
+Adopt the split shipped across #2791 (probe + doctrine) and this PR (DeepSeek removal + R1 seats
++ panel line + this capture), then close the two ledgered operator gates: **(a)** Kimi MCP
+PII-surface restriction (`operator[consent]` — until then the session-side refusal rule above is
+the guard); **(b)** Kimi desktop workspace → `.worktrees/ops-kimi-*`. Expected: a 3-family
+headless refuter cascade led by living seats (GLM/Kimi/Codex), panels with true 3-LLM-seat
+diversity plus NB verification, a BrowseComp-91-class research organ, and zero marginal cost —
+with the PII boundary explicit instead of implicit.
+
+## Adversarial review
+
+Reviewed by Codex `gpt-5.6-terra` (medium effort), generator≠grader — the author did not grade
+its own claims; the reviewer was told to ignore the author's placeholder section. Real verdicts,
+all applied:
+
+- **On-disk catalog — STANDS-WITH-CORRECTION:** reviewer independently verified
+  `kimi-work-models-cache.json` exists with `k3-agent` maxContextSize 1,000,000; caught the Swarm
+  row mislabeled (`k3-agent-swarm` is the modelId/alias — the cache **key** is `k3-agent-ultra`).
+  Fixed in §1.
+- **Session anatomy — STANDS-WITH-CORRECTION:** wire.jsonl anatomy, yolo mode, MCP wiring are
+  author-reported reads of local artifacts the reviewer could not independently re-verify —
+  now attributed as such in §2 (not "verified" tout court).
+- **DeepSeek retirement — STANDS-WITH-CORRECTION:** sound, but the draft's present-tense
+  "docs in this PR / as §Arsenal now reads" was false at review time (repo still named DeepSeek).
+  Fixed: §3 states what THIS PR changes vs what is coordinated with #2791; adoption language is
+  tied to the actual diffs + the checker's self-test passing.
+- **Kimi refuter lead — STANDS-WITH-CORRECTION:** the reviewer demanded the seat not be routed
+  on a desktop catalog alone (W81 esiste≠armato) and precise acceptance criteria (CLI installed,
+  login, explicit model selection, 1-token probe, model identity). Superseded-and-satisfied by
+  events: #2791 armed the CLI on Pro+M5 and this author re-ran the M5 K3 probe (PONG) this turn —
+  the criteria are met with live evidence, not catalog inference.
+- **`terra` R1 default — STANDS-WITH-CORRECTION:** two same-day timeouts justify a *timeboxed
+  operational* default, not a durable performance claim; timeout-handling now specified. Fixed in §3.
+- **"4-LLM panel / true 4-seat diversity" — CADE:** the proposed panel is three external LLM
+  seats; NB-1 is not an LLM and modus caps external seats at three. Fixed: composition rewritten
+  as 3 LLM seats + orchestrator + optional NB; the "regain 4-seat diversity" claim deleted.
+- **PII consent — STANDS-WITH-CORRECTION:** do not silently reconfigure the operator's MCP setup,
+  but waiting must not leave the agent free to invoke PII-bearing tools — an interim session-side
+  refusal rule is now explicit in §2, with config restriction staying `operator[consent]`.

--- a/scripts/check_adversarial_review.py
+++ b/scripts/check_adversarial_review.py
@@ -69,8 +69,11 @@ from typing import List, NamedTuple, Optional, Sequence
 KNOWN_SEATS = {
     "glm-5.2",
     "glm",
-    "deepseek-v4-pro",
-    "deepseek",
+    # DeepSeek API retired 2026-07-19 (Zero's order; seat repeatedly 402 balance-dead) —
+    # a capture claiming a deepseek review would name a seat that cannot be probed.
+    "kimi",
+    "kimi-k3",
+    "kimi-k2.7",
     "codex",
     "gpt-5.5",
     "gemini-3.1-pro",
@@ -162,7 +165,7 @@ def evaluate_file(path: Path) -> FileVerdict:
             path,
             False,
             "`adversarial_review:` key present but value is empty"
-            " — fix: name a reviewing seat (e.g. `deepseek-v4-pro`, `codex`, `human-zero`)",
+            " — fix: name a reviewing seat (e.g. `kimi-k3`, `codex`, `human-zero`)",
         )
 
     if EXEMPT_PREFIX_RE.match(value):
@@ -306,6 +309,17 @@ def run_selftest() -> int:
         expect("GUILT unknown_seat -> fails", v.ok is False)
         expect("GUILT unknown_seat -> reason flags unknown seat", "not a known seat" in v.reason)
 
+        # DeepSeek retired 2026-07-19 — a capture naming the dead seat must FAIL
+        # (fail-honest: the seat can no longer be probed; Zero's removal order).
+        retired_seat = _write(
+            tmp,
+            "research/operations/retired-seat.md",
+            "---\ndate: 2026-07-19\nadversarial_review: deepseek-v4-pro\n---\n\n"
+            "# Title\n\n## Adversarial review\n\nnone survived, 0 raised\n",
+        )
+        v = evaluate_file(retired_seat)
+        expect("GUILT retired deepseek seat -> fails", v.ok is False)
+
         no_section = _write(
             tmp,
             "research/operations/no-section.md",
@@ -336,7 +350,7 @@ def run_selftest() -> int:
         valid = _write(
             tmp,
             "research/operations/valid.md",
-            "---\ndate: 2026-07-06\nadversarial_review: deepseek-v4-pro\n---\n\n"
+            "---\ndate: 2026-07-06\nadversarial_review: kimi-k3\n---\n\n"
             "# Title\n\n## Adversarial review\n\nnone survived, 3 raised\n",
         )
         v = evaluate_file(valid)

--- a/scripts/root_guard.py
+++ b/scripts/root_guard.py
@@ -139,6 +139,10 @@ WHITELIST_DOTDIRS: set[str] = {
     # README.md explaining why each block is parked + cicatrix-scars pointer.
     # Outside every active CI matcher (`paths:` filters), see PR #363.
     ".disabled",
+    # kimi-code project scope: skills under .kimi-code/skills/ are auto-
+    # discovered by the Kimi CLI from the git root (Kimi arsenal entry
+    # 2026-07-19, PR #2798). Same class as .claude/ and .agents/.
+    ".kimi-code",
 }
 
 

--- a/scripts/tests/test_adversarial_review_gate.py
+++ b/scripts/tests/test_adversarial_review_gate.py
@@ -44,7 +44,7 @@ def _write(tmp_path: Path, rel: str, content: str) -> Path:
     return p
 
 
-VALID_FRONTMATTER = "---\ndate: 2026-07-06\nadversarial_review: deepseek-v4-pro\n---\n"
+VALID_FRONTMATTER = "---\ndate: 2026-07-06\nadversarial_review: kimi-k3\n---\n"
 VALID_SECTION = "\n# Title\n\n## Adversarial review\n\nnone survived, 2 raised\n"
 
 
@@ -90,6 +90,20 @@ def test_guilt_unknown_seat(tmp_path):
         tmp_path,
         "research/operations/x.md",
         "---\ndate: 2026-07-06\nadversarial_review: my-cousin\n---\n\n"
+        "# Title\n\n## Adversarial review\n\nnone survived.\n",
+    )
+    v = car.evaluate_file(p)
+    assert v.ok is False
+    assert "not a known seat" in v.reason
+
+
+def test_guilt_retired_deepseek_seat(tmp_path):
+    # DeepSeek API retired 2026-07-19 (Zero's order) — the seat was removed from
+    # KNOWN_SEATS and must now fail like any unknown seat.
+    p = _write(
+        tmp_path,
+        "research/operations/x.md",
+        "---\ndate: 2026-07-06\nadversarial_review: deepseek-v4-pro\n---\n\n"
         "# Title\n\n## Adversarial review\n\nnone survived.\n",
     )
     v = car.evaluate_file(p)
@@ -158,7 +172,7 @@ def test_innocence_seat_token_case_insensitive(tmp_path):
     p = _write(
         tmp_path,
         "research/operations/x.md",
-        "---\ndate: 2026-07-06\nadversarial_review: DeepSeek-V4-Pro\n---\n\n"
+        "---\ndate: 2026-07-06\nadversarial_review: Kimi-K3\n---\n\n"
         "# Title\n\n## ADVERSARIAL REVIEW\n\nnone survived.\n",
     )
     v = car.evaluate_file(p)


### PR DESCRIPTION
Complementary to **#2791** (the Pro twin's probe+doctrine wiring — its files deliberately untouched; coordination via PR comments, scar #5). Zero's mandate: "Kimi è entrato nel team… togli DeepSeek, rivedi l'arsenale… rendilo perfettamente impermeato del nostro sistema."

## Commit 1 — capture + seats + agent defs
- **Research capture** (R1-gated, Codex `terra`, 7 real verdicts incl. 1 CADE on my own panel arithmetic): Kimi Desktop 3.1.2 anatomy, the real M5 work-session study (wire.jsonl), K3/K2.7 tracker benchmarks, the arsenal split, the PII flag. Own `kimi -m kimi-code/k3` probe → PONG on M5.
- **`check_adversarial_review.py`**: KNOWN_SEATS +`kimi`/`kimi-k3`/`kimi-k2.7`, −deepseek. Guilt fixture (retired seat FAILS) + innocence (kimi-k3 passes); selftest 18/18.
- wr2 agent defs: DeepSeek cross-check → Kimi CLI.

## Commit 2 — impermeation (Zero: "rendilo perfettamente impermeato")
- **`AGENTS.md`**: generalized to all AGENTS.md-standard agents; new **§0.0 external-agent contract** (build-vs-verify split, Legge 5 never-publish, PII boundary, worktree discipline binds non-Claude agents by convention, off-limits files, anti-over-proactivity scoping for K3); stale DeepSeek line fixed.
- **`.kimi-code/skills/nuzantara-context/SKILL.md`**: project-scope skill auto-discovered by kimi-code (CLI + Desktop, whose workspace is this repo) — truth-map, Kimi's chairs, hard invariants, test commands, handoff format. Tracked → fleet gets it on pull.

Out-of-band (same mandate, non-git): `~/.kimi-code/AGENTS.md` on M5+Pro+Mini · standing `.worktrees/ops-kimi-desk` for the Desktop workspace · `/workflow` skill updated on M5 (DeepSeek stripped — diff flagged to the twin) · M5 HOME CLAUDE.md arsenal revision · memory decision file.

Zero's rulings recorded: MCP desktop stays FREE for now (owner call); Mini `kimi` login done (verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)