### PR TITLE
feat(cache): review-pack generator — simple per-reviewer team files for dossier review

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_curated_qa_review_pack.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_curated_qa_review_pack.py
@@ -1,0 +1,494 @@
+"""Curated-cache cantiere: scripts/curated_qa_review_pack.py
+
+The review-pack generator splits a CHATKB dossier (same E33 markdown shape
+the GARUDA visa corpus ships in) into simple per-reviewer .md/.html files
+for non-technical Bali Zero staff to vet before promotion to the bot's
+verbatim FAQ cache.
+
+Coverage:
+1. Parsing fidelity — the module reuses (never reimplements)
+   scripts.curated_qa_convert_e33.parse_e33_markdown_file.
+2. Batch-slug derivation from filename.
+3. Round-robin assignment balance (overlap=1 and overlap>1).
+4. INTERNAL-stripping guilt (never leaks) + innocence (FINAL text passes
+   through byte-faithful).
+5. Bahasa Indonesia (default lang=id) template rendering.
+6. Manifest correctness.
+7. PII/provenance rail (--source override gate).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import curated_qa_convert_e33 as converter
+from scripts import curated_qa_review_pack as review_pack
+
+# ── Synthetic E33-format fixture (NOT copied real content) ─────────────────
+# Deliberately includes INTERNAL / banned-phrasing / confirm-in-writing
+# content so the guilt test has something real to catch, and one question
+# with an empty LAW REFS block so the "no refs" fallback text is exercised.
+
+SYNTHETIC_E33_MARKDOWN = """# E33 Second Home Visa — Chat-LLM Knowledge Base
+
+> **E33 Second Home Visa** · Bali Zero · generated 2026-07-15
+> Full record for the chat-handling LLM.
+
+---
+
+## Section A. Eligibility & Suitability
+
+### Q1. Why choose the E33 visa over an investor KITAS?
+
+**FINAL (client-facing):**
+E33 is the simplest route for a long stay without a company sponsoring you.
+It requires a qualifying deposit and grants a long, renewable stay.
+
+**CONFIDENCE:** BERSYARAT
+
+**INTERNAL:**
+Confidence: BERSYARAT — the core comparison is confirmed against the
+primary regulator source, but some execution details remain open.
+
+**Banned phrasing for this topic:** "approval guaranteed."
+**Safe phrasing:** "eligible, subject to Imigrasi discretion."
+
+**CONFIRM IN WRITING:**
+- Whether splitting the deposit across two banks is permitted.
+- The exact reporting procedure after arrival.
+
+**LAW REFS (source-cited, unverified):**
+- imigrasi.go.id — E33 Visa Rumah Kedua (https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E33)
+- imigrasi.go.id — E28A Visa Investor (https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E28A)
+
+### Q2. Is there a minimum age requirement?
+
+**FINAL (client-facing):**
+No specific minimum age is codified for the standard E33 visa. In practice
+the applicant needs to be a legal adult to hold the qualifying deposit.
+
+**CONFIDENCE:** BELUM_DIATUR_PUBLIK
+
+**INTERNAL:**
+No numeric min/max age is codified for the generic E33 in the regulation.
+
+**CONFIRM IN WRITING:**
+- Whether Imigrasi permits a minor as the principal applicant.
+
+**LAW REFS (source-cited, unverified):**
+
+### Q3. Will you provide written reminders for deadlines?
+
+**FINAL (client-facing):**
+Yes — Bali Zero sends milestone-based written reminders ahead of the
+90-day deadline and extension windows, as a value-added service.
+
+**CONFIDENCE:** KEBIJAKAN_PENYEDIA
+
+**INTERNAL:**
+Confidence: KEBIJAKAN_PENYEDIA — this is a service commitment, not a
+government-mandated system.
+
+**CONFIRM IN WRITING:**
+- Exact reminder cadence and channels per the written engagement agreement.
+
+**LAW REFS (source-cited, unverified):**
+- UU No. 6/2011 tentang Keimigrasian, Pasal 71 (reporting obligations)
+"""
+
+
+@pytest.fixture
+def synthetic_e33_file(tmp_path: Path) -> Path:
+    path = tmp_path / "E33-DEFINITIVE-CHATKB-2026-07-15.md"
+    path.write_text(SYNTHETIC_E33_MARKDOWN, encoding="utf-8")
+    return path
+
+
+def _make_rows(n: int) -> list[dict]:
+    """Minimal synthetic curated_qa-shaped rows for pure assignment tests
+    (no need to go through the markdown parser for these)."""
+    return [
+        {
+            "question": f"Question {i}?",
+            "answer": f"Answer {i}.",
+            "domain": "visa",
+            "lang": "id",
+            "source_ref": f"fixture.md#Q{i}",
+            "source_date": "2026-07-15",
+            "confidence_class": "JELAS",
+            "law_refs": [],
+            "source_priority": 0,
+        }
+        for i in range(1, n + 1)
+    ]
+
+
+# ── 1. Parsing fidelity vs the converter's contract ─────────────────────────
+
+
+def test_load_batches_delegates_to_converter_parser(synthetic_e33_file: Path) -> None:
+    """The review-pack generator must not reimplement a second parser
+    dialect — its rows must be identical to calling the converter directly
+    (same domain/lang/source_priority)."""
+    expected_rows, expected_counts = converter.parse_e33_markdown_file(
+        synthetic_e33_file, domain="e33-2026-07-15", lang="id", source_priority=0,
+    )
+
+    [batch] = review_pack.load_batches(
+        [synthetic_e33_file], lang="id", source_override=True, allowed_dir=synthetic_e33_file.parent,
+    )
+
+    assert batch.rows == expected_rows
+    assert batch.confidence_counts == expected_counts
+
+
+def test_load_batches_raises_on_empty_dossier(tmp_path: Path) -> None:
+    empty = tmp_path / "EMPTY-DEFINITIVE-CHATKB-2026-07-15.md"
+    empty.write_text("> generated 2026-07-15\n\nNo questions here.\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="zero questions"):
+        review_pack.load_batches([empty], lang="id", source_override=True, allowed_dir=tmp_path)
+
+
+# ── 2. Batch-slug derivation ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_slug", "expected_title"),
+    [
+        ("E33-DEFINITIVE-CHATKB-2026-07-15.md", "e33-2026-07-15", "E33"),
+        ("GARUDA-VOA-DEFINITIVE-CHATKB-2026-07-18.md", "garuda-voa-2026-07-18", "GARUDA VOA"),
+        ("some_other_file.md", "some-other-file", "some other file"),
+    ],
+)
+def test_derive_batch(filename: str, expected_slug: str, expected_title: str) -> None:
+    slug, title = review_pack.derive_batch(Path(f"/x/{filename}"))
+    assert slug == expected_slug
+    assert title == expected_title
+
+
+# ── 3+4. Round-robin assignment: balance + overlap ──────────────────────────
+
+
+def test_round_robin_overlap_1_is_a_partition() -> None:
+    rows = _make_rows(13)
+    reviewers = [f"Reviewer {i}" for i in range(1, 7)]
+
+    assignment = review_pack.assign_round_robin(rows, reviewers, overlap=1)
+
+    all_assigned = [row["source_ref"] for rows_ in assignment.values() for row in rows_]
+    assert sorted(all_assigned) == sorted(row["source_ref"] for row in rows)
+    assert len(all_assigned) == len(rows)  # each row appears exactly once
+
+
+def test_round_robin_overlap_1_is_balanced() -> None:
+    rows = _make_rows(13)
+    reviewers = [f"Reviewer {i}" for i in range(1, 7)]
+
+    assignment = review_pack.assign_round_robin(rows, reviewers, overlap=1)
+
+    counts = [len(v) for v in assignment.values()]
+    assert max(counts) - min(counts) <= 1
+    assert sum(counts) == 13
+
+
+@pytest.mark.parametrize(("n", "reviewer_count", "overlap"), [(13, 6, 2), (20, 5, 3), (7, 4, 4), (1, 3, 1)])
+def test_round_robin_overlap_n_balanced_and_distinct(n: int, reviewer_count: int, overlap: int) -> None:
+    rows = _make_rows(n)
+    reviewers = [f"Reviewer {i}" for i in range(1, reviewer_count + 1)]
+
+    assignment = review_pack.assign_round_robin(rows, reviewers, overlap=overlap)
+
+    counts = [len(v) for v in assignment.values()]
+    assert max(counts) - min(counts) <= 1
+    assert sum(counts) == n * overlap
+
+    # Every row assigned to `overlap` DISTINCT reviewers.
+    reviewer_sets_per_row: dict[str, set[str]] = {row["source_ref"]: set() for row in rows}
+    for reviewer_name, assigned_rows in assignment.items():
+        for row in assigned_rows:
+            reviewer_sets_per_row[row["source_ref"]].add(reviewer_name)
+    assert all(len(s) == overlap for s in reviewer_sets_per_row.values())
+
+
+def test_round_robin_overlap_exceeding_reviewer_count_raises() -> None:
+    rows = _make_rows(5)
+    reviewers = ["A", "B", "C"]
+    with pytest.raises(ValueError, match="overlap"):
+        review_pack.assign_round_robin(rows, reviewers, overlap=4)
+
+
+def test_round_robin_zero_overlap_raises() -> None:
+    with pytest.raises(ValueError, match="overlap"):
+        review_pack.assign_round_robin(_make_rows(3), ["A"], overlap=0)
+
+
+def test_round_robin_zero_reviewers_raises() -> None:
+    with pytest.raises(ValueError, match="reviewer"):
+        review_pack.assign_round_robin(_make_rows(3), [], overlap=1)
+
+
+# ── 5. INTERNAL-stripping: guilt + innocence ────────────────────────────────
+
+
+def _build_single_pack(synthetic_e33_file: Path, *, lang: str = "id") -> tuple[str, str, list]:
+    """Helper: parse the fixture, build one reviewer's md+html pack
+    containing ALL rows, return (markdown, html, items)."""
+    [batch] = review_pack.load_batches(
+        [synthetic_e33_file], lang=lang, source_override=True, allowed_dir=synthetic_e33_file.parent,
+    )
+    items = [review_pack.row_to_item(row) for row in batch.rows]
+    md = review_pack.render_markdown_pack(
+        batch_title=batch.title,
+        reviewer_name="Reviewer 1",
+        items=items,
+        lang=lang,
+        generated_date="2026-07-19",
+        deadline_date="2026-07-22",
+    )
+    html = review_pack.render_html_pack(
+        batch_title=batch.title,
+        reviewer_name="Reviewer 1",
+        items=items,
+        lang=lang,
+        generated_date="2026-07-19",
+        deadline_date="2026-07-22",
+    )
+    return md, html, items
+
+
+def test_guilt_internal_reasoning_never_leaks_into_markdown(synthetic_e33_file: Path) -> None:
+    md, _html, _items = _build_single_pack(synthetic_e33_file)
+
+    assert "INTERNAL" not in md
+    assert "Banned phrasing" not in md
+    assert "primary regulator source" not in md
+    assert "CONFIRM IN WRITING" not in md
+    assert "splitting the deposit across two banks" not in md  # confirm-in-writing bullet
+
+
+def test_guilt_internal_reasoning_never_leaks_into_html(synthetic_e33_file: Path) -> None:
+    _md, html, _items = _build_single_pack(synthetic_e33_file)
+
+    assert "INTERNAL" not in html
+    assert "Banned phrasing" not in html
+    assert "primary regulator source" not in html
+    assert "CONFIRM IN WRITING" not in html
+    assert "splitting the deposit across two banks" not in html
+
+
+def test_innocence_final_answer_passes_through_byte_faithful_in_markdown(synthetic_e33_file: Path) -> None:
+    md, _html, items = _build_single_pack(synthetic_e33_file)
+
+    q1 = next(item for item in items if item.number == "1")
+    assert q1.answer in md  # verbatim substring, no mangling
+
+
+def test_innocence_final_answer_passes_through_byte_faithful_in_html(synthetic_e33_file: Path) -> None:
+    _md, html, items = _build_single_pack(synthetic_e33_file)
+
+    q1 = next(item for item in items if item.number == "1")
+    # HTML-escapes for safety and turns newlines into <br> (matching the
+    # renderer's own transform) but must not otherwise alter the text.
+    import html as html_lib
+
+    expected = html_lib.escape(q1.answer, quote=False).replace("\n", "<br>")
+    assert expected in html
+
+
+def test_law_refs_empty_falls_back_to_placeholder_text(synthetic_e33_file: Path) -> None:
+    md, html, items = _build_single_pack(synthetic_e33_file)
+
+    q2 = next(item for item in items if item.number == "2")
+    assert q2.law_refs == []
+    assert "Tidak ada referensi hukum tercatat" in md
+    assert "Tidak ada referensi hukum tercatat" in html
+
+
+# ── 6. Bahasa Indonesia template rendering ──────────────────────────────────
+
+
+def test_bahasa_indonesia_is_the_default_lang() -> None:
+    args = review_pack.parse_args(
+        ["--input", "x.md", "--reviewers", "1", "--out-dir", "/tmp/out"],
+    )
+    assert args.lang == "id"
+
+
+def test_bahasa_markdown_contains_expected_instructions_and_checkboxes(synthetic_e33_file: Path) -> None:
+    md, _html, _items = _build_single_pack(synthetic_e33_file, lang="id")
+
+    assert "Paket Review" in md
+    assert "✅ BENAR" in md
+    assert "❌ SALAH" in md
+    assert "⚠️ RAGU" in md
+    assert "harga TIDAK boleh muncul" in md
+    assert "- [ ] ✅ BENAR" in md
+    assert "Ringkasan" in md
+    assert "Jumlah pertanyaan: 3" in md
+    assert "Target kembali: 2026-07-22" in md
+
+
+def test_bahasa_html_contains_checkbox_inputs_and_big_font_css(synthetic_e33_file: Path) -> None:
+    _md, html, _items = _build_single_pack(synthetic_e33_file, lang="id")
+
+    assert html.count('<input type="checkbox">') == 3 * 3  # 3 questions x 3 verdict options
+    assert "font-size: 18px" in html or "font-size:18px" in html
+    assert "<!doctype html>" in html.lower()
+    assert "Paket Review" in html
+
+
+def test_confidence_badge_translated_for_known_class_and_passthrough_for_unknown() -> None:
+    assert review_pack._confidence_label("id", "JELAS") == "Pasti"
+    assert review_pack._confidence_label("id", "BERSYARAT") == "Bersyarat"
+    assert review_pack._confidence_label("id", "SOME_NEW_CLASS") == "SOME_NEW_CLASS"
+
+
+# ── 7. Manifest correctness ──────────────────────────────────────────────
+
+
+def test_manifest_structure_and_files_written(synthetic_e33_file: Path, tmp_path: Path) -> None:
+    batches = review_pack.load_batches(
+        [synthetic_e33_file], lang="id", source_override=True, allowed_dir=synthetic_e33_file.parent,
+    )
+    out_dir = tmp_path / "packs"
+
+    manifest = review_pack.build_review_packs(
+        batches=batches,
+        reviewer_names=["Reviewer 1", "Reviewer 2"],
+        overlap=1,
+        lang="id",
+        out_dir=out_dir,
+        generated_date="2026-07-19",
+        deadline_date="2026-07-22",
+    )
+
+    assert manifest["lang"] == "id"
+    assert manifest["overlap"] == 1
+    assert manifest["reviewers"] == ["Reviewer 1", "Reviewer 2"]
+    assert len(manifest["batches"]) == 1
+
+    entry = manifest["batches"][0]
+    assert entry["batch_id"] == "e33-2026-07-15"
+    assert entry["source_file"] == "E33-DEFINITIVE-CHATKB-2026-07-15.md"
+    assert entry["total_questions"] == 3
+
+    # every row assigned exactly once across the two reviewers (overlap=1)
+    all_assigned = [ref for refs in entry["assignments"].values() for ref in refs]
+    assert sorted(all_assigned) == [
+        "E33-DEFINITIVE-CHATKB-2026-07-15.md#Q1",
+        "E33-DEFINITIVE-CHATKB-2026-07-15.md#Q2",
+        "E33-DEFINITIVE-CHATKB-2026-07-15.md#Q3",
+    ]
+
+    # files listed in the manifest actually exist on disk
+    for reviewer_name, file_map in entry["files"].items():
+        assert (out_dir / file_map["md"]).exists()
+        assert (out_dir / file_map["html"]).exists()
+        assert reviewer_name in entry["assignments"]
+
+    # manifest itself must be JSON-serializable (no stray Path/dataclass objects)
+    json.dumps(manifest)
+
+
+def test_manifest_overlap_2_each_question_in_exactly_two_reviewer_lists(
+    synthetic_e33_file: Path, tmp_path: Path,
+) -> None:
+    batches = review_pack.load_batches(
+        [synthetic_e33_file], lang="id", source_override=True, allowed_dir=synthetic_e33_file.parent,
+    )
+    out_dir = tmp_path / "packs"
+
+    manifest = review_pack.build_review_packs(
+        batches=batches,
+        reviewer_names=["Reviewer 1", "Reviewer 2", "Reviewer 3"],
+        overlap=2,
+        lang="id",
+        out_dir=out_dir,
+        generated_date="2026-07-19",
+        deadline_date="2026-07-22",
+    )
+
+    entry = manifest["batches"][0]
+    all_assigned = [ref for refs in entry["assignments"].values() for ref in refs]
+    assert len(all_assigned) == 3 * 2
+    from collections import Counter
+
+    counts = Counter(all_assigned)
+    assert all(count == 2 for count in counts.values())
+
+
+# ── PII / provenance rail ────────────────────────────────────────────────
+
+
+def test_validate_input_path_allows_inside_allowed_dir(tmp_path: Path) -> None:
+    allowed = tmp_path / "data" / "curated_qa"
+    allowed.mkdir(parents=True)
+    f = allowed / "some-dossier.md"
+    f.write_text("x", encoding="utf-8")
+
+    result = review_pack.validate_input_path(f, source_override=False, allowed_dir=allowed)
+    assert result is None  # does not raise; explicit assert for the anti-reward-hacking lint
+
+
+def test_validate_input_path_refuses_outside_without_source(tmp_path: Path) -> None:
+    allowed = tmp_path / "data" / "curated_qa"
+    allowed.mkdir(parents=True)
+    outside = tmp_path / "Desktop" / "dossier.md"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("x", encoding="utf-8")
+
+    with pytest.raises(review_pack.ReviewPackSourceError):
+        review_pack.validate_input_path(outside, source_override=False, allowed_dir=allowed)
+
+
+def test_validate_input_path_allows_outside_with_source_override(tmp_path: Path) -> None:
+    allowed = tmp_path / "data" / "curated_qa"
+    allowed.mkdir(parents=True)
+    outside = tmp_path / "Desktop" / "dossier.md"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("x", encoding="utf-8")
+
+    result = review_pack.validate_input_path(outside, source_override=True, allowed_dir=allowed)
+    assert result is None  # does not raise; explicit assert for the anti-reward-hacking lint
+
+
+def test_validate_input_path_missing_file_raises_regardless_of_override(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.md"
+    with pytest.raises(FileNotFoundError):
+        review_pack.validate_input_path(missing, source_override=True, allowed_dir=tmp_path)
+
+
+# ── Reviewer-name resolution ─────────────────────────────────────────────
+
+
+def test_resolve_reviewer_names_from_count() -> None:
+    names = review_pack.resolve_reviewer_names(reviewers=3, reviewers_file=None)
+    assert names == ["Reviewer 1", "Reviewer 2", "Reviewer 3"]
+
+
+def test_resolve_reviewer_names_from_file(tmp_path: Path) -> None:
+    f = tmp_path / "names.txt"
+    f.write_text("Surya\nAri\n\nAsya\n", encoding="utf-8")
+    names = review_pack.resolve_reviewer_names(reviewers=None, reviewers_file=f)
+    assert names == ["Surya", "Ari", "Asya"]
+
+
+def test_resolve_reviewer_names_empty_file_raises(tmp_path: Path) -> None:
+    f = tmp_path / "names.txt"
+    f.write_text("\n\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="no reviewer names"):
+        review_pack.resolve_reviewer_names(reviewers=None, reviewers_file=f)
+
+
+def test_resolve_reviewer_names_neither_given_raises() -> None:
+    with pytest.raises(ValueError, match="reviewers"):
+        review_pack.resolve_reviewer_names(reviewers=None, reviewers_file=None)
+
+
+def test_resolve_reviewer_names_zero_raises() -> None:
+    with pytest.raises(ValueError, match=">= 1"):
+        review_pack.resolve_reviewer_names(reviewers=0, reviewers_file=None)

--- a/apps/backend-rag/scripts/curated_qa_review_pack.py
+++ b/apps/backend-rag/scripts/curated_qa_review_pack.py
@@ -1,0 +1,700 @@
+"""Curated Q&A review-pack generator (curated-cache cantiere, Phase 1/2 support).
+
+Zero's mandate: "prepara dei file semplici che distribuisco al team di tante
+persone" — split a CHATKB dossier (E33-format markdown, same shape the
+GARUDA visa corpus ships in) into simple per-reviewer files so non-technical
+Bali Zero staff can vet each Q&A row before it is promoted to the bot's
+verbatim FAQ cache.
+
+Reuses `scripts.curated_qa_convert_e33.parse_e33_markdown_file` for the
+actual CHATKB parsing contract (### Q<N>. / **FINAL (client-facing):** /
+**CONFIDENCE:** / **LAW REFS (source-cited, unverified):**) — this module
+does NOT re-implement a second parser dialect. In particular, the FINAL
+block is the ONLY text that ever reaches a reviewer: **INTERNAL** reasoning,
+banned-phrasing notes, and "confirm in writing" lists are parsed away by
+the converter before this module ever sees the row.
+
+Pure stdlib, no LLM calls, no network I/O.
+
+Usage:
+    cd apps/backend-rag && source .venv/bin/activate
+    PYTHONPATH=. python scripts/curated_qa_review_pack.py \\
+        --input ~/Desktop/E33-SecondHome/E33-DEFINITIVE-CHATKB-2026-07-15.md \\
+        --source \\
+        --reviewers 6 --lang id \\
+        --out-dir ~/Desktop/REVIEW-PACKS-2026-07-19/
+"""
+
+from __future__ import annotations
+
+import argparse
+import html as html_lib
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+from scripts.curated_qa_convert_e33 import parse_e33_markdown_file
+
+logger = logging.getLogger("curated_qa_review_pack")
+
+# ── PII / provenance rail ────────────────────────────────────────────────────
+# Only CHATKB files inside the repo's data/curated_qa/ tree may be read by
+# default. Anything else (a Desktop dossier, a scratch export, ...) requires
+# the operator to explicitly pass --source, acknowledging this is a
+# non-repo path. This module never reads logs or DB dumps — it only ever
+# opens the exact file paths given on the CLI.
+REPO_CURATED_QA_DIR = Path(__file__).resolve().parents[1] / "data" / "curated_qa"
+
+
+class ReviewPackSourceError(ValueError):
+    """Raised when an input path fails the PII/provenance rail."""
+
+
+def validate_input_path(
+    path: Path, *, source_override: bool, allowed_dir: Path = REPO_CURATED_QA_DIR
+) -> None:
+    """Refuse to read `path` unless it is inside `allowed_dir` or the
+    caller explicitly passed --source (source_override=True).
+
+    Raises:
+        ReviewPackSourceError: path is outside allowed_dir and no override.
+        FileNotFoundError: path does not exist.
+    """
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"{path}: input file does not exist")
+    try:
+        resolved.relative_to(allowed_dir.resolve())
+        return
+    except ValueError:
+        pass
+    if not source_override:
+        raise ReviewPackSourceError(
+            f"{path}: refusing to read — outside repo {allowed_dir} and --source not given. "
+            "Pass --source to explicitly allow a non-repo dossier path (e.g. a Desktop CHATKB file).",
+        )
+
+
+# ── Batch derivation from filename ──────────────────────────────────────────
+
+_BATCH_SLUG_RE = re.compile(
+    r"^(?P<prefix>.+?)-DEFINITIVE-CHATKB-(?P<date>\d{4}-\d{2}-\d{2})$",
+    re.IGNORECASE,
+)
+
+
+def slugify(text: str) -> str:
+    """Lowercase, ASCII-safe, hyphen-separated slug. Never empty for
+    non-empty input (falls back to 'x' if everything gets stripped)."""
+    slug = re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+    return slug or "x"
+
+
+def derive_batch(path: Path) -> tuple[str, str]:
+    """Derive (batch_slug, batch_title) from a CHATKB filename.
+
+    Recognizes the "<PREFIX>-DEFINITIVE-CHATKB-<YYYY-MM-DD>" convention used
+    by both real dossiers this build targets (E33-DEFINITIVE-CHATKB-... and
+    GARUDA-VOA-DEFINITIVE-CHATKB-...); falls back to a plain slug of the
+    filename stem for anything else so no input is ever rejected on naming.
+    """
+    stem = path.stem
+    match = _BATCH_SLUG_RE.match(stem)
+    if match:
+        prefix = match.group("prefix")
+        batch_date = match.group("date")
+        return f"{slugify(prefix)}-{batch_date}", prefix.replace("-", " ")
+    return slugify(stem), stem.replace("-", " ").replace("_", " ")
+
+
+# ── Batch / review-item data model ──────────────────────────────────────────
+
+
+@dataclass
+class Batch:
+    slug: str
+    title: str
+    source_path: Path
+    rows: list[dict[str, Any]]
+    confidence_counts: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class ReviewItem:
+    number: str
+    question: str
+    answer: str
+    confidence_class: str
+    law_refs: list[str]
+    source_ref: str
+
+
+_SOURCE_REF_NUMBER_RE = re.compile(r"#Q(\d+)$")
+
+
+def row_to_item(row: dict[str, Any]) -> ReviewItem:
+    match = _SOURCE_REF_NUMBER_RE.search(row["source_ref"])
+    number = match.group(1) if match else "?"
+    return ReviewItem(
+        number=number,
+        question=row["question"],
+        answer=row["answer"],
+        confidence_class=row["confidence_class"],
+        law_refs=list(row["law_refs"]),
+        source_ref=row["source_ref"],
+    )
+
+
+def load_batches(
+    input_paths: list[Path],
+    *,
+    lang: str,
+    source_override: bool,
+    allowed_dir: Path = REPO_CURATED_QA_DIR,
+) -> list[Batch]:
+    batches: list[Batch] = []
+    for raw_path in input_paths:
+        path = raw_path.expanduser()
+        validate_input_path(path, source_override=source_override, allowed_dir=allowed_dir)
+        batch_slug, batch_title = derive_batch(path)
+        rows, counts = parse_e33_markdown_file(
+            path.resolve(),
+            domain=batch_slug,
+            lang=lang,
+            source_priority=0,
+        )
+        if not rows:
+            raise ValueError(
+                f"{path}: parsed zero questions — refusing to build an empty review pack"
+            )
+        batches.append(
+            Batch(
+                slug=batch_slug,
+                title=batch_title,
+                source_path=path,
+                rows=rows,
+                confidence_counts=counts,
+            ),
+        )
+    return batches
+
+
+# ── Round-robin assignment (with optional overlap) ──────────────────────────
+
+
+def resolve_reviewer_names(*, reviewers: int | None, reviewers_file: Path | None) -> list[str]:
+    if reviewers_file is not None:
+        names = [
+            line.strip()
+            for line in reviewers_file.expanduser().read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        if not names:
+            raise ValueError(f"{reviewers_file}: no reviewer names found")
+        return names
+    if reviewers is not None:
+        if reviewers < 1:
+            raise ValueError("--reviewers must be >= 1")
+        return [f"Reviewer {i}" for i in range(1, reviewers + 1)]
+    raise ValueError("either reviewers or reviewers_file is required")
+
+
+def assign_round_robin(
+    rows: list[dict[str, Any]],
+    reviewer_names: list[str],
+    *,
+    overlap: int = 1,
+) -> dict[str, list[dict[str, Any]]]:
+    """Split `rows` round-robin across `reviewer_names`.
+
+    With overlap=1 (default) every row goes to exactly one reviewer. With
+    overlap=k>1, every row goes to k DISTINCT reviewers (independent
+    double-review) — implemented as a sliding window over the reviewer
+    cycle, which keeps per-reviewer load balanced to within 1 regardless of
+    N or the overlap factor.
+    """
+    reviewer_count = len(reviewer_names)
+    if reviewer_count == 0:
+        raise ValueError("need at least one reviewer")
+    if overlap < 1:
+        raise ValueError("overlap must be >= 1")
+    if overlap > reviewer_count:
+        raise ValueError(f"overlap ({overlap}) cannot exceed reviewer count ({reviewer_count})")
+
+    assignment: dict[str, list[dict[str, Any]]] = {name: [] for name in reviewer_names}
+    for i, row in enumerate(rows):
+        for k in range(overlap):
+            reviewer = reviewer_names[(i + k) % reviewer_count]
+            assignment[reviewer].append(row)
+    return assignment
+
+
+# ── Bahasa/IT/EN templates ───────────────────────────────────────────────────
+
+_STRINGS: dict[str, dict[str, Any]] = {
+    "id": {
+        "title": "Paket Review",
+        "reviewer_label": "Reviewer",
+        "date_label": "Tanggal",
+        "instructions_title": "Petunjuk",
+        "instructions": [
+            "Baca jawaban FINAL di bawah ini seolah-olah kamu adalah klien yang bertanya.",
+            "Tandai setiap pertanyaan: ✅ BENAR, atau ❌ SALAH (tulis koreksinya), "
+            "atau ⚠️ RAGU (tulis catatan).",
+            "Cek juga: harga TIDAK boleh muncul di jawaban ini.",
+            "Cek nomor WhatsApp / alamat kalau disebut — harus benar.",
+        ],
+        "send_back": "Kirim kembali file ini (atau foto halaman yang sudah ditandai) ke Zero.",
+        "law_refs_label": "Dasar hukum",
+        "law_refs_none": "Tidak ada referensi hukum tercatat",
+        "confidence_label": "Tingkat kepastian",
+        "answer_options": {
+            "correct": "✅ BENAR",
+            "wrong": "❌ SALAH — koreksi:",
+            "unsure": "⚠️ RAGU — catatan:",
+        },
+        "summary_title": "Ringkasan",
+        "summary_total": "Jumlah pertanyaan",
+        "summary_deadline": "Target kembali",
+    },
+    "it": {
+        "title": "Pacchetto di revisione",
+        "reviewer_label": "Revisore",
+        "date_label": "Data",
+        "instructions_title": "Istruzioni",
+        "instructions": [
+            "Leggi la risposta FINALE qui sotto come se fossi il cliente che fa la domanda.",
+            "Segna ogni domanda: ✅ CORRETTA, oppure ❌ SBAGLIATA (scrivi la correzione), "
+            "oppure ⚠️ DUBBIO (scrivi una nota).",
+            "Controlla anche: NON deve comparire nessun prezzo nella risposta.",
+            "Controlla il numero WhatsApp / l'indirizzo se citati — devono essere corretti.",
+        ],
+        "send_back": "Rimanda questo file (o le foto delle pagine segnate) a Zero.",
+        "law_refs_label": "Riferimenti normativi",
+        "law_refs_none": "Nessun riferimento normativo registrato",
+        "confidence_label": "Livello di certezza",
+        "answer_options": {
+            "correct": "✅ CORRETTA",
+            "wrong": "❌ SBAGLIATA — correzione:",
+            "unsure": "⚠️ DUBBIO — nota:",
+        },
+        "summary_title": "Riepilogo",
+        "summary_total": "Numero di domande",
+        "summary_deadline": "Scadenza per la restituzione",
+    },
+    "en": {
+        "title": "Review Pack",
+        "reviewer_label": "Reviewer",
+        "date_label": "Date",
+        "instructions_title": "Instructions",
+        "instructions": [
+            "Read the FINAL answer below as if you were the client asking the question.",
+            "Mark each question: ✅ CORRECT, or ❌ WRONG (write the correction), "
+            "or ⚠️ UNSURE (write a note).",
+            "Also check: NO price should appear in this answer.",
+            "Check the WhatsApp number / address if mentioned — it must be correct.",
+        ],
+        "send_back": "Send this file back (or photos of the marked-up pages) to Zero.",
+        "law_refs_label": "Law references",
+        "law_refs_none": "No law references recorded",
+        "confidence_label": "Confidence",
+        "answer_options": {
+            "correct": "✅ CORRECT",
+            "wrong": "❌ WRONG — correction:",
+            "unsure": "⚠️ UNSURE — note:",
+        },
+        "summary_title": "Summary",
+        "summary_total": "Total questions",
+        "summary_deadline": "Target return date",
+    },
+}
+
+_CONFIDENCE_LABELS: dict[str, dict[str, str]] = {
+    "id": {
+        "JELAS": "Pasti",
+        "BERSYARAT": "Bersyarat",
+        "DINAMIS": "Bisa berubah",
+        "KEBIJAKAN_PENYEDIA": "Kebijakan kami",
+        "BELUM_DIATUR_PUBLIK": "Belum ada aturan resmi",
+    },
+    "it": {
+        "JELAS": "Certo",
+        "BERSYARAT": "Condizionato",
+        "DINAMIS": "Può cambiare",
+        "KEBIJAKAN_PENYEDIA": "Nostra policy",
+        "BELUM_DIATUR_PUBLIK": "Non ancora regolato pubblicamente",
+    },
+    "en": {
+        "JELAS": "Settled",
+        "BERSYARAT": "Conditional",
+        "DINAMIS": "Can change",
+        "KEBIJAKAN_PENYEDIA": "Our policy",
+        "BELUM_DIATUR_PUBLIK": "Not yet publicly regulated",
+    },
+}
+
+
+def _confidence_label(lang: str, confidence_class: str) -> str:
+    return _CONFIDENCE_LABELS.get(lang, {}).get(confidence_class, confidence_class)
+
+
+# ── Markdown pack ─────────────────────────────────────────────────────────
+
+
+def render_markdown_pack(
+    *,
+    batch_title: str,
+    reviewer_name: str,
+    items: list[ReviewItem],
+    lang: str,
+    generated_date: str,
+    deadline_date: str,
+) -> str:
+    s = _STRINGS[lang]
+    lines: list[str] = []
+    lines.append(f"# {s['title']} — {batch_title}")
+    lines.append("")
+    lines.append(f"**{s['reviewer_label']}:** {reviewer_name}  ")
+    lines.append(f"**{s['date_label']}:** {generated_date}")
+    lines.append("")
+    lines.append(f"## {s['instructions_title']}")
+    for i, instr in enumerate(s["instructions"], start=1):
+        lines.append(f"{i}. {instr}")
+    lines.append("")
+    lines.append(s["send_back"])
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    opts = s["answer_options"]
+    for item in items:
+        lines.append(f"### Q{item.number}. {item.question}")
+        lines.append("")
+        lines.append(item.answer)
+        lines.append("")
+        law_refs_text = "; ".join(item.law_refs) if item.law_refs else s["law_refs_none"]
+        lines.append(f"**{s['law_refs_label']}:** {law_refs_text}")
+        conf_label = _confidence_label(lang, item.confidence_class)
+        lines.append(f"**{s['confidence_label']}:** {conf_label} ({item.confidence_class})")
+        lines.append("")
+        lines.append(f"- [ ] {opts['correct']}")
+        lines.append(f"- [ ] {opts['wrong']} ________________________________")
+        lines.append(f"- [ ] {opts['unsure']} ________________________________")
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+    lines.append(f"## {s['summary_title']}")
+    lines.append(f"{s['summary_total']}: {len(items)}")
+    lines.append(f"{s['summary_deadline']}: {deadline_date}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ── HTML pack (print-ready, single self-contained file) ────────────────────
+
+
+def _esc(text: str) -> str:
+    return html_lib.escape(text, quote=False)
+
+
+def render_html_pack(
+    *,
+    batch_title: str,
+    reviewer_name: str,
+    items: list[ReviewItem],
+    lang: str,
+    generated_date: str,
+    deadline_date: str,
+) -> str:
+    s = _STRINGS[lang]
+    opts = s["answer_options"]
+
+    instructions_html = "".join(f"<li>{_esc(text)}</li>" for text in s["instructions"])
+
+    item_blocks: list[str] = []
+    for item in items:
+        law_refs_text = "; ".join(item.law_refs) if item.law_refs else s["law_refs_none"]
+        conf_label = _confidence_label(lang, item.confidence_class)
+        answer_html = _esc(item.answer).replace("\n", "<br>")
+        item_blocks.append(
+            f"""<section class="qa-card">
+  <h2>Q{_esc(item.number)}. {_esc(item.question)}</h2>
+  <p class="answer">{answer_html}</p>
+  <p class="meta"><strong>{_esc(s["law_refs_label"])}:</strong> {_esc(law_refs_text)}</p>
+  <p class="meta badge"><strong>{_esc(s["confidence_label"])}:</strong> {_esc(conf_label)} ({_esc(item.confidence_class)})</p>
+  <div class="verdict">
+    <label><input type="checkbox"> {_esc(opts["correct"])}</label>
+    <label><input type="checkbox"> {_esc(opts["wrong"])} <span class="blank"></span></label>
+    <label><input type="checkbox"> {_esc(opts["unsure"])} <span class="blank"></span></label>
+  </div>
+</section>""",
+        )
+
+    page_title = f"{s['title']} — {batch_title} — {reviewer_name}"
+
+    return f"""<!doctype html>
+<html lang="{_esc(lang)}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{_esc(page_title)}</title>
+<style>
+  body {{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+    font-size: 18px;
+    line-height: 1.55;
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 24px;
+    color: #111;
+    background: #fff;
+  }}
+  h1 {{ font-size: 28px; margin-bottom: 4px; }}
+  h2 {{ font-size: 22px; margin: 0 0 8px; }}
+  .meta-block {{ font-size: 17px; margin-bottom: 16px; }}
+  .qa-card {{
+    border: 2px solid #333;
+    border-radius: 10px;
+    padding: 18px 20px;
+    margin-bottom: 26px;
+    page-break-inside: avoid;
+  }}
+  .answer {{ font-size: 19px; margin: 8px 0 14px; }}
+  .meta {{ font-size: 15px; color: #444; margin: 4px 0; }}
+  .verdict {{ margin-top: 14px; }}
+  .verdict label {{ display: block; font-size: 18px; margin: 10px 0; }}
+  .verdict input[type=checkbox] {{
+    width: 24px;
+    height: 24px;
+    margin-right: 10px;
+    vertical-align: middle;
+  }}
+  .blank {{
+    display: inline-block;
+    border-bottom: 1px solid #333;
+    width: 320px;
+    height: 1.3em;
+    vertical-align: middle;
+  }}
+  ol {{ font-size: 17px; }}
+  hr {{ margin: 24px 0; border: none; border-top: 1px solid #ccc; }}
+  @media print {{
+    body {{ padding: 0; }}
+    .qa-card {{ break-inside: avoid; }}
+  }}
+</style>
+</head>
+<body>
+<h1>{_esc(s["title"])} — {_esc(batch_title)}</h1>
+<p class="meta-block">
+  <strong>{_esc(s["reviewer_label"])}:</strong> {_esc(reviewer_name)}<br>
+  <strong>{_esc(s["date_label"])}:</strong> {_esc(generated_date)}
+</p>
+<h2>{_esc(s["instructions_title"])}</h2>
+<ol>{instructions_html}</ol>
+<p>{_esc(s["send_back"])}</p>
+<hr>
+{"".join(item_blocks)}
+<h2>{_esc(s["summary_title"])}</h2>
+<p>
+  {_esc(s["summary_total"])}: {len(items)}<br>
+  {_esc(s["summary_deadline"])}: {_esc(deadline_date)}
+</p>
+</body>
+</html>
+"""
+
+
+# ── Orchestration ────────────────────────────────────────────────────────
+
+
+def build_review_packs(
+    *,
+    batches: list[Batch],
+    reviewer_names: list[str],
+    overlap: int,
+    lang: str,
+    out_dir: Path,
+    generated_date: str,
+    deadline_date: str,
+) -> dict[str, Any]:
+    """Write per-reviewer .md/.html packs for every batch and return the
+    manifest dict (also written to disk by the caller)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, Any] = {
+        "generated_at": generated_date,
+        "lang": lang,
+        "overlap": overlap,
+        "reviewers": reviewer_names,
+        "batches": [],
+    }
+
+    for batch in batches:
+        assignment = assign_round_robin(batch.rows, reviewer_names, overlap=overlap)
+        batch_entry: dict[str, Any] = {
+            "batch_id": batch.slug,
+            "batch_title": batch.title,
+            "source_file": batch.source_path.name,
+            "total_questions": len(batch.rows),
+            "confidence_class_counts": batch.confidence_counts,
+            "files": {},
+            "assignments": {},
+        }
+
+        for reviewer_name in reviewer_names:
+            rows_for_reviewer = assignment[reviewer_name]
+            if not rows_for_reviewer:
+                continue
+            items = [row_to_item(row) for row in rows_for_reviewer]
+            reviewer_slug = slugify(reviewer_name)
+            md_name = f"review-pack-{batch.slug}-{reviewer_slug}.md"
+            html_name = f"review-pack-{batch.slug}-{reviewer_slug}.html"
+
+            md_text = render_markdown_pack(
+                batch_title=batch.title,
+                reviewer_name=reviewer_name,
+                items=items,
+                lang=lang,
+                generated_date=generated_date,
+                deadline_date=deadline_date,
+            )
+            html_text = render_html_pack(
+                batch_title=batch.title,
+                reviewer_name=reviewer_name,
+                items=items,
+                lang=lang,
+                generated_date=generated_date,
+                deadline_date=deadline_date,
+            )
+
+            (out_dir / md_name).write_text(md_text, encoding="utf-8")
+            (out_dir / html_name).write_text(html_text, encoding="utf-8")
+
+            batch_entry["files"][reviewer_name] = {"md": md_name, "html": html_name}
+            batch_entry["assignments"][reviewer_name] = [
+                row["source_ref"] for row in rows_for_reviewer
+            ]
+
+        manifest["batches"].append(batch_entry)
+
+    return manifest
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Split CHATKB Q&A dossiers into simple per-reviewer packs (.md + .html) "
+            "for team review before curated-cache promotion."
+        ),
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        nargs="+",
+        required=True,
+        help="One or more CHATKB markdown source files (E33 format).",
+    )
+    reviewer_group = parser.add_mutually_exclusive_group(required=True)
+    reviewer_group.add_argument(
+        "--reviewers", type=int, default=None, help="Number of anonymous reviewers."
+    )
+    reviewer_group.add_argument(
+        "--reviewers-file",
+        type=Path,
+        default=None,
+        help="Path to a text file with one reviewer name per line.",
+    )
+    parser.add_argument(
+        "--lang",
+        choices=sorted(_STRINGS),
+        default="id",
+        help="Pack language (default: id — Bahasa Indonesia, the team language).",
+    )
+    parser.add_argument(
+        "--out-dir", type=Path, required=True, help="Directory to write packs + manifest into."
+    )
+    parser.add_argument(
+        "--overlap",
+        type=int,
+        default=1,
+        help="Number of independent reviewers per question (default: 1, no overlap).",
+    )
+    parser.add_argument(
+        "--source",
+        action="store_true",
+        help=(
+            "Explicitly allow reading --input files outside repo data/curated_qa/ "
+            "(e.g. a Desktop dossier). PII/provenance rail — refused without this flag."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Override manifest output path (default: <out-dir>/review-packs-manifest.json).",
+    )
+    return parser.parse_args(argv)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    args = parse_args()
+
+    reviewer_names = resolve_reviewer_names(
+        reviewers=args.reviewers, reviewers_file=args.reviewers_file
+    )
+    if args.overlap > len(reviewer_names):
+        raise SystemExit(
+            f"--overlap ({args.overlap}) cannot exceed reviewer count ({len(reviewer_names)})"
+        )
+
+    batches = load_batches(args.input, lang=args.lang, source_override=args.source)
+    logger.info(
+        "Loaded %d batch(es), %d total questions",
+        len(batches),
+        sum(len(b.rows) for b in batches),
+    )
+
+    generated_date = date.today().isoformat()
+    deadline_date = (date.today() + timedelta(days=3)).isoformat()
+    out_dir = args.out_dir.expanduser()
+
+    manifest = build_review_packs(
+        batches=batches,
+        reviewer_names=reviewer_names,
+        overlap=args.overlap,
+        lang=args.lang,
+        out_dir=out_dir,
+        generated_date=generated_date,
+        deadline_date=deadline_date,
+    )
+
+    manifest_path = (
+        args.manifest.expanduser() if args.manifest else out_dir / "review-packs-manifest.json"
+    )
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    files_written = sum(len(entry["files"]) * 2 for entry in manifest["batches"])
+    logger.info(
+        "Wrote %d files (.md+.html) across %d batch(es); manifest at %s",
+        files_written,
+        len(batches),
+        manifest_path,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 649 services · 1186 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 649 services · 1187 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

Zero's mandate (2026-07-19): "prepara dei file semplici che distribuisco al team di tante persone" — the expert-review bottleneck of the curated-cache cantiere (plan `docs/plans/2026-07-19-curated-cache-cantiere.md`) becomes distributed team review.

`apps/backend-rag/scripts/curated_qa_review_pack.py` (stdlib-only, no LLM): takes E33/GARUDA-format CHATKB dossiers (reuses the `curated_qa_convert_e33.py` parsing contract — no second dialect), splits Q&A round-robin across N reviewers (optional `--overlap`), and emits one SIMPLE file per reviewer in `.md` + print-ready `.html`: Bahasa instructions (read as the client, mark ✅ BENAR / ❌ SALAH+koreksi / ⚠️ RAGU, check no prices + correct WA/contacts), per-Q FINAL answer + LAW REFS + confidence badge + checkbox block. **INTERNAL sections are stripped** (guilt+innocence tested). A `review-packs-manifest.json` maps reviewer→question-ids for return ingestion.

First real packs already generated and verified on the orchestrator's machine (E33 ×6 reviewers + GARUDA-VOA ×6, zero INTERNAL leakage) — `~/Desktop/REVIEW-PACKS-2026-07-19/`.

## Tests

Parsing fidelity vs converter contract, round-robin balance, overlap assignment, INTERNAL-strip guilt+innocence, Bahasa rendering, manifest correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)