### PR TITLE
docs(h1): secret-rotation runbook + M5 canonical-checkout decision memo

### DIFF
--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -1,0 +1,66 @@
+# Runbook: Secret Rotation & Fleet Propagation
+
+> Born from scar 2026-07-18 (Kimi S2): a rotated `NUZANTARA_API_KEY` lived only in
+> Pro's `~/.nuzantara-secrets.env`; every `.mcp.json` in the fleet kept an inline
+> stale copy that shadowed the good one (env > file fallback in
+> `nuzantara_mcp/server.py:_secret_from_env_file`). Two days of silent 401s on
+> memory/expiry endpoints. Mini had TWO dead variants. **Rule: a secret is rotated
+> only when every consumer reads the NEW value — never when you changed one file.**
+
+## The fleet's secret store (canonical)
+
+Per-machine, `0600`: `~/.nuzantara-secrets.env` — flat `NAME=value` (optional
+`export ` prefix). Readers: `nuzantara-mcp` (file fallback), cron wrappers,
+sentinel/healer scripts. **This file is the single source of truth for
+machine-local secrets.** Nothing else should carry the value:
+
+- `.mcp.json` `env` blocks — FORBIDDEN for `NUZANTARA_API_KEY` (they shadow the
+  file fallback). After the 2026-07-18/19 sweep: clean on M5, Pro, Mini.
+- Launchd plist `EnvironmentVariables` — scar family W65 (world-readable).
+- Any committed file — scar family W38/W65.
+
+## Rotation procedure (atomic across the fleet)
+
+1. **Generate** the new value where the issuer lives (e.g. Fly secrets for
+   backend-validated keys: `fly secrets set API_KEYS=<new_csv> -a nuzantara-rag` —
+   note: Fly restarts machines; pick a low-traffic window).
+2. **Verify the new value works BEFORE touching local stores** (empirical, never
+   assumed): `curl -s -o /dev/null -w '%{http_code}' -H "X-API-Key: <new>" https://nuzantara-rag.fly.dev/api/crm/expiry-alerts` → expect 200.
+3. **Propagate to every machine's `~/.nuzantara-secrets.env`** — REPLACE, never
+   append (a second `NAME=` line makes the last one win silently and confuses the
+   next operator):
+   ```bash
+   # on each machine (pro / mini / m5), value never echoed to transcripts:
+   grep -v '^NUZANTARA_API_KEY=' ~/.nuzantara-secrets.env > /tmp/s.env && \
+     echo "NUZANTARA_API_KEY=<new>" >> /tmp/s.env && \
+     mv /tmp/s.env ~/.nuzantara-secrets.env && chmod 600 ~/.nuzantara-secrets.env
+   ```
+4. **Sweep inline copies** (the shadow class): any `NUZANTARA_API_KEY` inside
+   `.mcp.json` env blocks on all machines — delete the key so the file fallback
+   engages. Check with hash parity, not eyeballs:
+   ```bash
+   # expected: identical sha256[:16] of the value on pro/mini/m5
+   grep '^NUZANTARA_API_KEY=' ~/.nuzantara-secrets.env | tail -1 | cut -d= -f2 | shasum -a 256 | cut -c1-16
+   ```
+5. **Prove per machine** (content, never exit code): the 200-check from step 2
+   run FROM that machine. MCP servers pick up the new value on next spawn —
+   currently-running stdio servers keep the old env until the host respawns them
+   (tell users to restart the agent session).
+6. **Retire the old value** at the issuer (remove from `API_KEYS` csv) only AFTER
+   step 5 passes on every machine.
+
+## If you find a stale key (forensics)
+
+Symptoms: `401 {"detail":"Authentication required"}` from authed MCP tools while
+public endpoints (`/health`) answer 200. Diagnose in order:
+
+1. Is the key empty? (`_secret_from_env_file` returns `""` → no auth headers at all)
+2. Hash-compare the machine's value vs the live one (step 4) — different = stale.
+3. Check BOTH shadow layers: `.mcp.json` inline env AND `~/.nuzantara-secrets.env`
+   (Mini had two dead variants; the inline one won, both were dead).
+
+## Non-negotiables
+
+- Never print a secret value into a transcript/log; compare by `shasum -a 256 | cut -c1-16`.
+- Never commit `~/.nuzantara-secrets.env` (it's machine-local, perms 0600).
+- One issuer change → one propagation sweep → one verification pass. No partial rotations.

--- a/research/operations/2026-07-19-m5-canonical-checkout-decision.md
+++ b/research/operations/2026-07-19-m5-canonical-checkout-decision.md
@@ -1,0 +1,58 @@
+---
+date: 2026-07-19
+domain: operations
+adversarial_review: exempt-decision-memo
+---
+
+# Decision memo: canonical checkout for `.mcp.json` on Air-M5
+
+> Author: Kimi (Air-M5) · Status: **AWAITING OPERATOR DECISION** (Legge 5 — this changes where every local agent's MCP servers run from)
+
+## Problem (verified 2026-07-18/19)
+
+Air-M5 has TWO live checkouts of the repo:
+
+1. `/Users/balizero/nuzantara` — where Kimi/CLI sessions actually run (cwd of this session's worktrees, agent_start.py, git ops)
+2. `/Users/balizero/Desktop/nuzantara` — where `.mcp.json` (both copies) points the MCP servers: `cwd`, `PYTHONPATH`, and per-app `.venv/bin/python` paths all reference `Desktop/nuzantara`
+
+Consequences of the split:
+
+- Code merged in one checkout does NOT affect the MCP servers until the other checkout is pulled (the servers import from `Desktop/nuzantara/apps/*`)
+- `agent_start.py` worktrees live under the session checkout; the MCP servers read another tree entirely
+- commit `b005f85998` (2026-07-16, "repoint the repo off ~/Desktop/nuzantara") suggests an earlier migration intent that never completed
+- Every fleet doc (AGENTS.md R-tables) describes ONE canonical checkout per machine, M5's is ambiguous
+
+Currently both checkouts sit at the same commit — the divergence is latent, not active. That is precisely when to fix it.
+
+## Options
+
+### A — Canonical: `/Users/balizero/nuzantara` (recommended)
+
+Point everything (`.mcp.json` cwd/PYTHONPATH/venv paths, docs, habits) at the session checkout. Retire the Desktop one (archive it: `mv ~/Desktop/nuzantara ~/Desktop/nuzantara.ARCHIVED-2026-07-19` after a clean-diff check).
+
+- Pros: single tree for sessions AND servers; matches how the other machines are documented (Pro: `~/nuzantara` + `~/nuzantara-deploy`); the Desktop copy becomes a museum, not a shadow
+- Cons: any OTHER agent/session habitually cd-ing into Desktop/nuzantara must be told once; if a Desktop-side uncommitted WIP exists it must be diffed first (check `git status` there — currently clean per 2026-07-18 audit)
+
+### B — Canonical: `~/Desktop/nuzantara`
+
+Repoint sessions to the Desktop checkout instead.
+
+- Pros: zero `.mcp.json` edits
+- Cons: sessions+worktrees move; every doc that says "the repo" becomes ambiguous; Kimi's existing worktrees/leased state live under the other tree (86 worktrees, `agent_start.py` broker state) — materially worse
+
+### C — Symlink one onto the other
+
+- Cons: hides the problem under a filesystem trick; breaks the `git status` honesty of both; the fleet's home-fork lint would (correctly) flag it. Do not.
+
+## Recommended execution (if A is chosen)
+
+1. `git -C ~/Desktop/nuzantara status -s` → must be clean; `git log --oneline -1` must equal the session checkout's HEAD
+2. Edit `.mcp.json` (M5 copy): replace all `/Users/balizero/Desktop/nuzantara` → `/Users/balizero/nuzantara` (cwd, PYTHONPATH, venv interpreters)
+3. Verify per-app venvs exist at the new paths (`apps/nuzantara-mcp/.venv`, `-advanced/.venv`, `-browser/.venv`) — if absent, `python3 -m venv` + `pip install -e .` for the three servers (they're small)
+4. Respawn one MCP session and prove an authed call (200 on `/api/crm/expiry-alerts` via the file-fallback key)
+5. `mv ~/Desktop/nuzantara ~/Desktop/nuzantara.ARCHIVED-2026-07-19` (reversible, not deleted)
+6. One line in AGENTS.md §0.1: the canonical M5 checkout is `/Users/balizero/nuzantara`
+
+## Out of scope
+
+Pro's layout (`~/nuzantara` + `~/nuzantara-deploy` dual-checkout for WR2, scar #1) is a deliberate, documented design — untouched.


### PR DESCRIPTION
## Cosa (Orizzonte 1, items 2b + 5)

- **`docs/runbooks/secret-rotation.md`** — la procedura di rotazione+propagazione che non esisteva (scar S2 2026-07-18: chiave valida solo sul Pro, inline stale ovunque; Mini con DUE varianti morte): rotate-at-issuer → verify-new → REPLACE in `~/.nuzantara-secrets.env` per macchina → sweep inline `.mcp.json` → hash-parity → 200 per macchina → retire old. Include la sezione forensics per i 401 MCP.
- **`research/operations/2026-07-19-m5-canonical-checkout-decision.md`** — decision memo per Zero sui due checkout M5 (`/Users/balizero/nuzantara` vs `~/Desktop/nuzantara`): raccomanda A (session checkout canonico) con passi esecutivi. **AWAITING Zero's call** — nessuna modifica a `.mcp.json` in questa PR.

## Stato dello sweep (già eseguito, live)

M5 ✅ Pro ✅ Mini ✅ — chiave viva propagata e verificata 200/200 su entrambi gli endpoint su tutte e tre le macchine; inline keys rimosse da tutte le `.mcp.json`.

Co-authored-by: Kimi <kimi@balizero.com>