### PR TITLE
docs(runbooks): regen DOCSYNC index — secret-rotation runbook missing (44→45)

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -5,7 +5,7 @@
 > `python scripts/docs_sync.py`. The `docs-sync.yml` CI gate fails if stale.
 
 <!-- DOCSYNC:RUNBOOKS_INDEX_START -->
-**Runbooks:** 44 (git-tracked in `docs/runbooks/`)
+**Runbooks:** 45 (git-tracked in `docs/runbooks/`)
 
 | Runbook | Title |
 | ------- | ----- |
@@ -42,6 +42,7 @@
 | [`repomap-and-branch-cleanup.md`](repomap-and-branch-cleanup.md) | Repomap auto-injection + Branch graveyard cleanup |
 | [`review-gate.md`](review-gate.md) | Runbook — Review-gate (Pro-side tri-LLM review-only) |
 | [`runtime-dev-checkout-split.md`](runtime-dev-checkout-split.md) | Runtime/Dev checkout split — runbook (P0 shipped, P1/P2 operator-gated) |
+| [`secret-rotation.md`](secret-rotation.md) | Runbook: Secret Rotation & Fleet Propagation |
 | [`sota-loop-90gg-operations.md`](sota-loop-90gg-operations.md) | SOTA Social Loop 90gg — Operations Runbook |
 | [`synthetic-probe-cleanup.md`](synthetic-probe-cleanup.md) | Runbook — Synthetic probe cleanup emergency |
 | [`telegram-notification-gateway.md`](telegram-notification-gateway.md) | Telegram notification gateway — tg_notify / tg_digest_flush / lint |


### PR DESCRIPTION
W86-class repair PR. #2806 landed `docs/runbooks/secret-rotation.md` without the `docs_sync.py` index regen in the same commit → `docs/runbooks/README.md` DOCSYNC block is stale on main (says 44 runbooks, disk has 45, table lacks the secret-rotation row). The `check-docs-sync` gate would fail the next innocent PR touching a counted surface.

Diff = exactly the `python scripts/docs_sync.py` output (produced by the pre-commit hook in a fresh worktree off origin/main; nothing hand-edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)