### PR TITLE
fix(drive): normalize Drive v3 payloads — restore /api/drive/files and /search

### DIFF
--- a/apps/backend-rag/backend/services/integrations/drive/drive_operations.py
+++ b/apps/backend-rag/backend/services/integrations/drive/drive_operations.py
@@ -9,6 +9,17 @@ from backend.services.integrations.drive.drive_audit import drive_operation
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+
+
+def _normalize_drive_file(f: dict[str, Any]) -> dict[str, Any]:
+    """Drive API v3 returns no `type` field and `size` as a string (absent for
+    folders and Google-native docs); the team_drive router contract requires
+    `type` ('file'|'folder') and an int `size` on every item."""
+    f["type"] = "folder" if f.get("mimeType") == _FOLDER_MIME_TYPE else "file"
+    f["size"] = int(f.get("size") or 0)
+    return f
+
 
 class DriveOperationsManager:
     """
@@ -69,7 +80,9 @@ class DriveOperationsManager:
         # Propaga l'errore HTTP (che verrà catturato dal decoratore @drive_operation per i log)
         response.raise_for_status()
 
-        return response.json()
+        data = response.json()
+        data["files"] = [_normalize_drive_file(f) for f in data.get("files", [])]
+        return data
 
     @drive_operation("search_files")
     async def search_files(
@@ -109,7 +122,7 @@ class DriveOperationsManager:
             params=params,
         )
         response.raise_for_status()
-        return response.json().get("files", [])
+        return [_normalize_drive_file(f) for f in response.json().get("files", [])]
 
     @drive_operation("get_file_metadata")
     async def get_file_metadata(self, user_email: str, file_id: str) -> dict[str, Any]:
@@ -130,7 +143,7 @@ class DriveOperationsManager:
         )
         response.raise_for_status()
 
-        return response.json()
+        return _normalize_drive_file(response.json())
 
     async def _token(self, user_email: str) -> str:
         token = await self.auth_manager.get_access_token(user_email)

--- a/apps/backend-rag/backend/tests/services/integrations/test_drive_operations_normalization.py
+++ b/apps/backend-rag/backend/tests/services/integrations/test_drive_operations_normalization.py
@@ -1,0 +1,102 @@
+"""Regression tests for Drive API v3 payload normalization (2026-07-19 audit find).
+
+Google Drive v3 `files.list`/`files.get` return `mimeType` but NO `type` field,
+and `size` as a STRING (absent entirely for folders and Google-native docs).
+The team_drive router contract needs both: `FileItem.type` is a required str
+(so `FileItem(**f)` on a raw payload 500s with a Pydantic ValidationError —
+the exact live failure on GET /api/drive/files and /api/drive/search), and
+the permission filter reads `f["type"]` directly (KeyError for non-admins).
+
+These tests pin the normalization at the DriveOperationsManager layer so every
+consumer receives router-contract-ready dicts. Mock pattern mirrors
+test_drive_operations_mutations.py (no network).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.services.integrations.drive.drive_operations import DriveOperationsManager
+
+pytestmark = pytest.mark.asyncio
+
+USER = "zero@balizero.com"
+
+RAW_FOLDER = {
+    "id": "folder-1",
+    "name": "PERATURAN",
+    "mimeType": "application/vnd.google-apps.folder",
+    # Drive sends no `size` and no `type` for folders
+    "modifiedTime": "2026-07-01T00:00:00.000Z",
+}
+RAW_FILE = {
+    "id": "file-1",
+    "name": "PP Nomor 28 Tahun 2025.pdf",
+    "mimeType": "application/pdf",
+    "size": "2048",  # Drive v3 returns size as a string
+    "modifiedTime": "2026-07-02T00:00:00.000Z",
+    "webViewLink": "https://drive.google.com/file/d/file-1/view",
+}
+
+
+def _resp(json_body: dict[str, Any] | list[Any] | None = None, status: int = 200) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.raise_for_status = MagicMock()
+    r.json = MagicMock(return_value=json_body if json_body is not None else {})
+    return r
+
+
+def _manager(get_response: MagicMock) -> DriveOperationsManager:
+    auth = MagicMock()
+    auth.get_access_token = AsyncMock(return_value="tok-123")
+    http = MagicMock()
+    http.get = AsyncMock(return_value=get_response)
+    return DriveOperationsManager(auth_manager=auth, http_client=http, audit=MagicMock())
+
+
+async def test_list_files_normalizes_type_and_size():
+    mgr = _manager(_resp({"files": [dict(RAW_FOLDER), dict(RAW_FILE)], "nextPageToken": "npt"}))
+    out = await mgr.list_files(USER)
+
+    folder, file = out["files"]
+    assert folder["type"] == "folder"
+    assert folder["size"] == 0
+    assert file["type"] == "file"
+    assert file["size"] == 2048  # int, not "2048"
+    assert out["nextPageToken"] == "npt"  # passthrough untouched
+
+
+async def test_search_files_normalizes_every_hit():
+    mgr = _manager(_resp({"files": [dict(RAW_FILE), dict(RAW_FOLDER)]}))
+    out = await mgr.search_files(USER, query="peraturan")
+
+    assert [f["type"] for f in out] == ["file", "folder"]
+    assert all(isinstance(f["size"], int) for f in out)
+
+
+async def test_get_file_metadata_normalized():
+    mgr = _manager(_resp(dict(RAW_FOLDER)))
+    out = await mgr.get_file_metadata(USER, "folder-1")
+
+    assert out["type"] == "folder"
+    assert out["size"] == 0
+
+
+async def test_normalized_payload_satisfies_router_fileitem_contract():
+    """The live 500: FileItem(**raw_google_payload) → ValidationError (`type` missing).
+
+    Build FileItem from the normalized manager output to pin the full contract.
+    """
+    from backend.app.routers.team_drive import FileItem
+
+    mgr = _manager(_resp({"files": [dict(RAW_FOLDER), dict(RAW_FILE)]}))
+    out = await mgr.list_files(USER)
+
+    items = [FileItem(**f) for f in out["files"]]  # raises before the fix
+    assert items[0].type == "folder"
+    assert items[1].type == "file"
+    assert items[1].size == 2048


### PR DESCRIPTION
## Summary
Root-cause fix for the `/api/drive/*` regression found live by the 2026-07-19 KB audit (lever #5 of the Bali Zero activation plan, PR #2814): the God-Object refactor left `DriveOperationsManager` returning **raw** Drive API v3 JSON (`mimeType`, string `size`, no `type`), while the `team_drive` router builds `FileItem(**f)` with `type: str` REQUIRED and permission-filters on `f["type"]` → `GET /api/drive/files` and `/api/drive/search` 500'd (Pydantic ValidationError, correlation IDs in the audit log), non-admin path would KeyError.

**Fix at the manager layer** so every consumer gets contract-ready dicts: `_normalize_drive_file()` derives `type` from `mimeType` and coerces `size` to int — applied in `list_files`, `search_files`, `get_file_metadata`.

## Verification
- TDD: 4 regression tests written first, red on the old code (the FileItem round-trip test reproduces the exact live 500), green after — `backend/tests/services/integrations/test_drive_operations_normalization.py`.
- Full `backend/tests/services/integrations/` suite: **125 passed**.
- Import-chain smoke: `from backend.app.dependencies import get_current_user` OK.
- Class-audit of all `.list_files/.search_files/.get_file_metadata` call-sites: live consumer = team_drive router (heals); `admin_drive_setup.py:85` and `legal_ingestion_service.py:360` construct `TeamDriveService()` without `db_pool`/`user_email` — dead since before this change, untouched (noted for the activation-plan ledger).

## Known-out-of-scope
`/api/drive/stats` never existed in this router — the MCP `get_drive_storage_stats` tool points at a phantom endpoint (404). Tracked as its own lever in the activation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)