### PR TITLE
docs(runbooks): regen README index — repair docsync stale left by #2806 (W86)

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -5,7 +5,7 @@
 > `python scripts/docs_sync.py`. The `docs-sync.yml` CI gate fails if stale.
 
 <!-- DOCSYNC:RUNBOOKS_INDEX_START -->
-**Runbooks:** 44 (git-tracked in `docs/runbooks/`)
+**Runbooks:** 45 (git-tracked in `docs/runbooks/`)
 
 | Runbook | Title |
 | ------- | ----- |
@@ -42,6 +42,7 @@
 | [`repomap-and-branch-cleanup.md`](repomap-and-branch-cleanup.md) | Repomap auto-injection + Branch graveyard cleanup |
 | [`review-gate.md`](review-gate.md) | Runbook — Review-gate (Pro-side tri-LLM review-only) |
 | [`runtime-dev-checkout-split.md`](runtime-dev-checkout-split.md) | Runtime/Dev checkout split — runbook (P0 shipped, P1/P2 operator-gated) |
+| [`secret-rotation.md`](secret-rotation.md) | Runbook: Secret Rotation & Fleet Propagation |
 | [`sota-loop-90gg-operations.md`](sota-loop-90gg-operations.md) | SOTA Social Loop 90gg — Operations Runbook |
 | [`synthetic-probe-cleanup.md`](synthetic-probe-cleanup.md) | Runbook — Synthetic probe cleanup emergency |
 | [`telegram-notification-gateway.md`](telegram-notification-gateway.md) | Telegram notification gateway — tg_notify / tg_digest_flush / lint |


### PR DESCRIPTION
docs/runbooks/README.md went stale when #2806 merged a new runbook (secret-rotation.md) without regenerating the index — the required `check-docs-sync` CI gate has been failing on every open backend PR since, including #2813, as an innocent victim of unrelated docs drift.

This PR is `python scripts/docs_sync.py` output only: runbook count bumped 44 → 45, `secret-rotation.md` added to the index table. No other file touched.

Unblocks `check-docs-sync` for all open backend PRs, including #2813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)