### PR TITLE
fix(wa-tester): isPaired must accept QR-companion flow — creds.me presence, not only registered flag

### DIFF
--- a/apps/wa-mirror/scripts/wa-tester-core.ts
+++ b/apps/wa-mirror/scripts/wa-tester-core.ts
@@ -378,3 +378,21 @@ export function transcriptHasZeroReplyQuestion(
 ): boolean {
   return transcript.summary.questions_with_zero_replies > 0;
 }
+
+// ---------------------------------------------------------------------------
+// Pairing-state detection (pure) — used by --status / --send-battery's
+// isPaired() gate in scripts/wa-tester.ts.
+// ---------------------------------------------------------------------------
+
+export type StoredCreds = { registered?: boolean; me?: { id?: string } };
+
+/**
+ * True if the on-disk creds.json indicates a paired session, under EITHER
+ * Baileys pairing flow. `registered` is set only by the pairing-CODE flow;
+ * QR-companion pairing (the flow wa-tester's `--pair` actually drives) sets
+ * `creds.me` instead and leaves `registered: false` — a session paired via
+ * QR is very much paired even though `registered` reads false.
+ */
+export function isPairedFromCreds(creds: StoredCreds): boolean {
+  return creds.registered === true || typeof creds.me?.id === "string";
+}

--- a/apps/wa-mirror/scripts/wa-tester.ts
+++ b/apps/wa-mirror/scripts/wa-tester.ts
@@ -43,11 +43,13 @@ import {
   buildQuestionResult,
   buildTranscript,
   extractMessageText,
+  isPairedFromCreds,
   parseMessageTimestampMs,
   shouldReconnect,
   transcriptHasZeroReplyQuestion,
   validateBattery,
   type QuestionResult,
+  type StoredCreds,
 } from "./wa-tester-core.js";
 
 const logger = pino({
@@ -75,8 +77,9 @@ async function ensureStateDir(): Promise<void> {
 async function isPaired(): Promise<boolean> {
   try {
     const raw = await readFile(path.join(STATE_DIR, "creds.json"), "utf8");
-    const creds = JSON.parse(raw) as { registered?: boolean };
-    return creds.registered === true;
+    const creds = JSON.parse(raw) as StoredCreds;
+    // QR-companion pairing sets creds.me, not creds.registered (pairing-code flow only)
+    return isPairedFromCreds(creds);
   } catch {
     return false;
   }

--- a/apps/wa-mirror/tests/wa-tester-core.test.ts
+++ b/apps/wa-mirror/tests/wa-tester-core.test.ts
@@ -15,6 +15,7 @@ import {
   buildTranscript,
   checkRecipientAllowlist,
   extractMessageText,
+  isPairedFromCreds,
   matchesBotRecipient,
   parseMessageTimestampMs,
   shouldReconnect,
@@ -420,5 +421,25 @@ describe("buildQuestionResult / buildTranscript — transcript assembly", () => 
       results: [answered, silent],
     });
     expect(transcriptHasZeroReplyQuestion(oneSilent)).toBe(true);
+  });
+});
+
+describe("isPairedFromCreds — guilt + innocence (QR-companion vs pairing-code flow)", () => {
+  it("[guilt] neither registered nor me.id present → NOT paired", () => {
+    expect(isPairedFromCreds({})).toBe(false);
+    expect(isPairedFromCreds({ registered: false })).toBe(false);
+  });
+
+  it("[innocence-1] pairing-code flow: registered:true → paired", () => {
+    expect(isPairedFromCreds({ registered: true })).toBe(true);
+  });
+
+  it("[innocence-2] QR-companion flow: registered:false + me.id present → paired", () => {
+    expect(
+      isPairedFromCreds({
+        registered: false,
+        me: { id: "628213465159:1@s.whatsapp.net" },
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
The wa-tester's isPaired check only accepted `creds.registered === true`, which Baileys sets ONLY in the pairing-code flow. The QR-companion flow (the one actually used to pair Zero's number on 2026-07-19) sets `creds.me` while `registered` stays false → tester reported NOT_PAIRED after a successful QR pairing. Hot-patched on the Pro runtime same day (proven live); this lands the same fix in the repo so the runtime and repo stop diverging (scar family #1, HOME-fork/runtime drift).

Fix: `return creds.registered === true || typeof creds.me?.id === "string";`

## Test plan
- Pre-push suite passed (full backend gate).
- Live proof already exists: with this exact logic the paired session on Pro reports PAIRED and the battery sender works (it found the P0 outbox bug — #2812).

🤖 Generated with [Claude Code](https://claude.com/claude-code)