### PR TITLE
fix(kbli-navigator): cure March-stale dataset fork — sync + CI parity with mouth copy

### DIFF
--- a/.github/workflows/check-kbli-dataset-sync.yml
+++ b/.github/workflows/check-kbli-dataset-sync.yml
@@ -26,6 +26,7 @@ on:
       - "source_documents/KBLI_2025_FINAL_CLEAN.json"
       - "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
       - "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+      - "apps/kbli-navigator/data/kbli-2025.json"
       - "scripts/sync_kbli_dataset.sh"
       - ".github/workflows/check-kbli-dataset-sync.yml"
   push:
@@ -35,6 +36,7 @@ on:
       - "source_documents/KBLI_2025_FINAL_CLEAN.json"
       - "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
       - "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+      - "apps/kbli-navigator/data/kbli-2025.json"
       - "scripts/sync_kbli_dataset.sh"
       - ".github/workflows/check-kbli-dataset-sync.yml"
 

--- a/.gitignore
+++ b/.gitignore
@@ -702,8 +702,13 @@ docs/team-guides/*.pdf
 
 # KBLI JSON duplicates (keep only source_documents canonical)
 apps/mouth/data/KBLI_2025_FINAL_CLEAN.json
-apps/kbli-navigator/data/kbli-2025.json
 apps/backend-rag/source_documents/
+# apps/kbli-navigator/data/kbli-2025.json is NOT ignored (scar #1 HOME-fork cure,
+# 2026-07-19): it used to be untracked here, which let it silently rot to a
+# 2026-03-28 snapshot while balizero.com/kbli moved on. It is now a tracked,
+# byte-identical mirror of canonical kept in sync by scripts/sync_kbli_dataset.sh
+# + CI check-kbli-dataset-sync — same discipline as the mouth copy above.
+!apps/kbli-navigator/data/kbli-2025.json
 
 # Generated/state JSON files
 apps/backend-rag/coverage_report.json

--- a/apps/kbli-navigator/lib/__tests__/kbli-data.test.ts
+++ b/apps/kbli-navigator/lib/__tests__/kbli-data.test.ts
@@ -1,0 +1,89 @@
+// =============================================================================
+// kbli-data.test.ts — guilt/innocence regression for the quarantine transform.
+//
+// Context (scar #1 HOME-fork, 2026-07-19): apps/kbli-navigator/data/kbli-2025.json
+// used to be an untracked local artifact that rotted to a 2026-03-28 snapshot
+// while the canonical KBLI dataset moved on (68112/49213/... code-number
+// collisions got quarantined: per_skala -> [], the disputed block preserved
+// under per_skala_disputed_<source>, an honest _data_note attached). Now that
+// scripts/sync_kbli_dataset.sh keeps this file byte-identical to canonical,
+// this test locks in that transformRecord() (lib/kbli-data.ts) handles a
+// quarantined record correctly:
+//   - GUILT:     a quarantined code (68112) renders NO licensing rows (the
+//                disputed block is never resurrected) but the honest-gap
+//                intel_2026.whatYouNeed text IS present and readable.
+//   - INNOCENCE: a healthy code with real per_skala (55101) renders its
+//                licensing rows unchanged.
+//
+// Run: cd apps/kbli-navigator && npx tsx lib/__tests__/kbli-data.test.ts
+// No test framework — plain node:assert, non-zero exit on failure.
+// =============================================================================
+
+import assert from "node:assert/strict";
+import { getCode, getAllCodes } from "../kbli-data";
+
+function guiltCase() {
+  const kbli = getCode("68112");
+  assert.ok(kbli, "68112 must be present in the dataset");
+
+  // No licensing rows rendered — the code-collision disputed block must
+  // never be resurrected via transformRecord (it only ever reads
+  // raw.per_skala, never per_skala_disputed_*).
+  assert.deepEqual(
+    kbli!.licensing,
+    [],
+    "68112 (quarantined) must render zero licensing rows, not the disputed PP28/MICE block",
+  );
+
+  // Honest-gap prose must be present and legible (this is what the page
+  // renders instead of a false risk/license claim for a non-gold code).
+  assert.ok(
+    kbli!.intel_2026?.whatYouNeed,
+    "68112 must carry an intel_2026.whatYouNeed honest-gap explanation",
+  );
+  assert.match(
+    kbli!.intel_2026!.whatYouNeed!,
+    /not yet defined|not.{0,15}published|no risk-based/i,
+    "68112's whatYouNeed must state the licensing gap honestly, not assert a resolved risk level",
+  );
+
+  console.log("PASS guilt: 68112 — empty licensing, honest gap prose present");
+}
+
+function innocenceCase() {
+  const kbli = getCode("55101");
+  assert.ok(kbli, "55101 must be present in the dataset");
+
+  assert.ok(
+    kbli!.licensing.length > 0,
+    "55101 (healthy code, real per_skala) must render its licensing rows unchanged",
+  );
+  assert.ok(
+    kbli!.licensing[0].riskCategory,
+    "55101's primary licensing tier must carry a real risk category",
+  );
+
+  console.log(
+    `PASS innocence: 55101 — ${kbli!.licensing.length} licensing row(s) rendered unchanged`,
+  );
+}
+
+function datasetShapeSanity() {
+  // Regression for the March-stale fork itself: canonical carries 1,559
+  // records, not the old untracked snapshot's 1,563 (4 phantom rows the
+  // 2026-03-28 file had that were later removed from canonical).
+  const all = getAllCodes();
+  assert.equal(
+    all.length,
+    1559,
+    "kbli-2025.json must match canonical's 1,559 records (was 1,563 in the stale March fork)",
+  );
+  console.log(
+    `PASS dataset-shape: ${all.length} records loaded (canonical, not the stale fork)`,
+  );
+}
+
+guiltCase();
+innocenceCase();
+datasetShapeSanity();
+console.log("\nAll kbli-data.ts quarantine-transform checks passed.");

--- a/scripts/sync_kbli_dataset.sh
+++ b/scripts/sync_kbli_dataset.sh
@@ -20,6 +20,10 @@
 #   data/source_documents/KBLI_2025_FINAL_CLEAN.json    (tracked, secondary fallback)
 #   apps/mouth/data/KBLI_2025_FINAL_CLEAN.json          (tracked, balizero.com/kbli prod)
 #   apps/backend-rag/backend/data/KBLI_2025_FINAL_CLEAN.json  (gitignored, was MARCIA zombie)
+#   apps/kbli-navigator/data/kbli-2025.json             (tracked, knowledge.balizero.com —
+#     DIFFERENT basename than canonical, same {metadata,data:[...]} shape/records; was
+#     `git rm --cached`'d in ab1d5b02c0 (2026-03-28) and quietly rotted to that snapshot
+#     ever since — no build step ever regenerated it. Re-tracked 2026-07-19, scar #1.)
 #
 # REPAIRED:
 #   apps/backend-rag/source_documents/KBLI_2025_FINAL_CLEAN.json
@@ -28,8 +32,9 @@
 #
 # OUT OF SCOPE (handled by the native-app deploy script, not the repo):
 #   ~/Desktop/kbli-navigator-app/Resources/KBLI_2025_FINAL_CLEAN.json
-#     — lives outside the repo; deploy/install-3mac.sh copies it from the app's own
-#       Resources/. If you change canonical, re-run the app build+deploy to refresh it.
+#     — the standalone macOS app (OUTSIDE this repo, NOT apps/kbli-navigator/ above).
+#       deploy/install-3mac.sh copies it from the app's own Resources/. If you change
+#       canonical, re-run the app build+deploy to refresh it.
 #
 # Usage:
 #   scripts/sync_kbli_dataset.sh           # propagate canonical → all consumers
@@ -49,6 +54,7 @@ CONSUMERS=(
   "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
   "apps/backend-rag/backend/data/KBLI_2025_FINAL_CLEAN.json"
   "apps/backend-rag/source_documents/KBLI_2025_FINAL_CLEAN.json"
+  "apps/kbli-navigator/data/kbli-2025.json"
 )
 
 MODE="${1:-sync}"


### PR DESCRIPTION
## Summary

`apps/kbli-navigator/data/kbli-2025.json` (the dataset behind `knowledge.balizero.com`, a login-gated team tool) was git-untracked in `ab1d5b02c0` (2026-03-28 repo cleanup) and quietly rotted to that snapshot ever since — 1,563 records, zero `per_skala_disputed_*` quarantine markers, still carrying the 68112 code-number collision (MICE licensing on what is now a residential-leasing code) and other fabricated `per_skala` rows. `scripts/sync_kbli_dataset.sh` + CI `check-kbli-dataset-sync` only ever covered the `apps/mouth` copy — this app's copy was invisible to both. The team reads this data and quotes it to clients.

This is the scar-#1 (HOME-fork) antidote applied to a 5th consumer copy, matching the mouth copy's existing discipline:

- `scripts/sync_kbli_dataset.sh`: add `apps/kbli-navigator/data/kbli-2025.json` as a tracked, byte-identical consumer of canonical (the `CONSUMERS` loop is filename-agnostic, so the different basename is not an issue).
- `.gitignore`: negate the file-specific ignore that untracked it in the first place; the broader `data/*.json` glob and the mouth-copy exclusion are untouched.
- `.github/workflows/check-kbli-dataset-sync.yml`: add the new consumer to both `pull_request` and `push` path triggers so future drift fails CI exactly like the mouth copy.
- `apps/kbli-navigator/lib/__tests__/kbli-data.test.ts`: new guilt/innocence regression (plain `node:assert` run via `npx tsx` — this app has no test framework installed) proving `transformRecord()` needs **no code change**: a quarantined code (68112, `per_skala: []`) renders zero licensing rows without resurrecting the disputed PP28/MICE block, a healthy code (55101, real `per_skala`) renders unchanged, and the record count is pinned to canonical's 1,559 (not the stale fork's 1,563).

## Verification

- Twin-grep: no open PR/branch/worktree touching this surface before starting.
- `npx tsx apps/kbli-navigator/lib/__tests__/kbli-data.test.ts` → 3/3 PASS.
- `tsc --noEmit` on the app → clean.
- Full `next build` → 1,591 SSG pages generated, zero crashes. Spot-verified in the built HTML that the 6 non-gold cured codes (51103, 51203, 20111, 50115, 60312, 64310) now render the honest `intel_2026.whatYouNeed` gap prose instead of the old fabricated risk data — no further code change needed for them.
- Conductor independently re-ran the same guilt/innocence test and `cmp`-verified the new copy is byte-identical to canonical.

## Not fixed here (flagged as a follow-up task, not a one-liner)

`apps/kbli-navigator/lib/kbli-gold-content.ts` — a separate ~45K-line hand-authored per-code content file (distinct from `apps/mouth`'s gold corpus and untouched by the mouth gold cure in #2794) — still asserts stale/wrong licensing prose for the 2 collision codes that happen to be gold-tier in *this* app (68112, 49213). Verified live in the built HTML that this overrides the now-correct data for those two pages: 68112's page still describes itself as "NON-RESIDENTIAL property" leasing with "Low risk (Rendah), NIB only, issued automatically", and 49213's page still shows a "Low risk" narrative that now directly contradicts its own (correctly restored) `Menengah Tinggi` risk badge on the same page. This needs the same image-verified, corroborated-sourcing methodology as the other GARUDA-FILIERA cures, not a hand-edit — tracked as a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)