### PR TITLE
fix(backend-rag): QdrantClient.get() sends with_payload/with_vector as body fields, not query params

### DIFF
--- a/apps/backend-rag/backend/core/qdrant_db.py
+++ b/apps/backend-rag/backend/core/qdrant_db.py
@@ -933,22 +933,30 @@ class QdrantClient:
             client = await self._get_client()
             url = f"/collections/{self.collection_name}/points"
 
-            # Qdrant retrieve endpoint
-            payload = {"ids": ids}
+            # Qdrant retrieve endpoint (POST /collections/{name}/points).
+            # BUG FIX (2026-07-19, verified live task #22): with_payload/with_vector
+            # are JSON BODY fields on this endpoint, NOT query params — Qdrant's
+            # REST API silently ignores them when sent as query params, so any
+            # caller passing include=[...] got 200 OK with the flags dropped
+            # (empty payload/vectors, scar family #2 "green but not working").
+            # Ref: https://api.qdrant.tech/api-reference/points/get-points
+            # (PointRequest schema: ids / with_payload / with_vector — singular
+            # "with_vector", not "with_vectors").
+            payload: dict[str, Any] = {"ids": ids}
             if include:
-                # Map Qdrant include to Qdrant with_payload/with_vectors
+                # Map Qdrant-compatible include to Qdrant with_payload/with_vector
                 with_payload = "payload" in include or "metadatas" in include
-                with_vectors = "embeddings" in include
-                params = {}
+                with_vector = "embeddings" in include
                 if with_payload:
-                    params["with_payload"] = True
-                if with_vectors:
-                    params["with_vectors"] = True
+                    payload["with_payload"] = True
+                if with_vector:
+                    payload["with_vector"] = True
             else:
-                params = {"with_payload": True, "with_vectors": True}
+                payload["with_payload"] = True
+                payload["with_vector"] = True
 
             try:
-                response = await client.post(url, json=payload, params=params)
+                response = await client.post(url, json=payload)
                 response.raise_for_status()
 
                 results = response.json().get("result", [])

--- a/apps/backend-rag/backend/tests/unit/core/test_qdrant_client_methods.py
+++ b/apps/backend-rag/backend/tests/unit/core/test_qdrant_client_methods.py
@@ -3,6 +3,7 @@ Unit tests for QdrantClient methods (get, delete, peek, hybrid_search, upsert_do
 Target: >95% coverage
 """
 
+import json
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -93,6 +94,96 @@ class TestQdrantClientGet:
 
             assert result["ids"] == []
             assert result["documents"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_with_include_sends_flags_in_json_body_not_query_params(self, client):
+        """
+        GUILT test (bug fix 2026-07-19, verified live task #22): Qdrant's
+        points-retrieve endpoint (POST /collections/{name}/points) only
+        honors with_payload/with_vector as JSON BODY fields — it silently
+        ignores them as query params (200 OK, empty payload/vectors; scar
+        family #2 "green but not working").
+
+        Uses a real httpx.MockTransport so we inspect the ACTUAL wire-level
+        Request (query string vs body), not a mocked `.post()` call — a
+        mock on `.post()` alone can't distinguish `params=` from `json=`.
+
+        This test FAILS against the pre-fix implementation (which sent
+        `params={"with_payload": True, "with_vectors": True}` alongside an
+        `{"ids": ids}`-only body): the flags would show up in
+        `request.url.params` and be absent from the JSON body.
+        """
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {"id": "1", "vector": [0.1, 0.2], "payload": {"text": "hi"}},
+                    ],
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(base_url="http://qdrant-test", transport=transport) as real_http_client:
+            with patch.object(client, "_get_client", return_value=real_http_client):
+                result = await client.get(["1"], include=["embeddings", "payload"])
+
+        request = captured["request"]
+
+        # Guilt: the flags must NOT be query params (that's the bug location).
+        assert "with_payload" not in request.url.params
+        assert "with_vector" not in request.url.params
+        assert "with_vectors" not in request.url.params
+
+        # Fix: the flags must be in the JSON body, using Qdrant's real
+        # (singular) field name "with_vector", not "with_vectors".
+        body = json.loads(request.content)
+        assert body["ids"] == ["1"]
+        assert body["with_payload"] is True
+        assert body["with_vector"] is True
+        assert "with_vectors" not in body
+
+        # And the round-trip actually recovers payload + vector now.
+        assert result["embeddings"] == [[0.1, 0.2]]
+        assert result["documents"] == ["hi"]
+
+    @pytest.mark.asyncio
+    async def test_get_without_include_still_works(self, client):
+        """
+        INNOCENCE test: a plain get() with no `include` (the common case,
+        e.g. delete-verification / existence-check callers) must keep
+        working exactly as before — full payload + vector fetch, flags
+        still land in the JSON body.
+        """
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {"id": "1", "vector": [0.4, 0.5], "payload": {"text": "hello"}},
+                    ],
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(base_url="http://qdrant-test", transport=transport) as real_http_client:
+            with patch.object(client, "_get_client", return_value=real_http_client):
+                result = await client.get(["1"])
+
+        request = captured["request"]
+        body = json.loads(request.content)
+        assert body == {"ids": ["1"], "with_payload": True, "with_vector": True}
+        assert "with_payload" not in request.url.params
+
+        assert result["ids"] == ["1"]
+        assert result["embeddings"] == [[0.4, 0.5]]
+        assert result["documents"] == ["hello"]
 
 
 class TestQdrantClientDelete:


### PR DESCRIPTION
## Bug (verified live during task #22, 2026-07-19)

`backend/core/qdrant_db.py::QdrantClient.get()` sent `with_payload`/`with_vectors`
as **query params** on the points-retrieve endpoint (`POST /collections/{name}/points`).
Qdrant's REST API only honors these flags in the **JSON body** — confirmed against
the official docs (`PointRequest` schema: `ids` / `with_payload` / `with_vector`,
https://api.qdrant.tech/api-reference/points/get-points). Query-param flags are
silently ignored, so any caller passing `include=[...]` got a **200 OK with the
flags dropped** — scar family #2, "green but not working".

Bonus finding: the old code also used the field name `with_vectors` (plural).
Qdrant's actual body field for this endpoint is `with_vector` (singular) — so
even relocating the flag without renaming it would have kept the vector request
silently ignored.

## Fix

Move `with_payload`/`with_vector` into the JSON body alongside `ids`, using the
correct (singular) field name. Preserves the original conditional-omission
semantics (a flag is only added to the body when true), just relocated —
mechanical fix, no redesign of the `include` mapping semantics.

## Class audit (W89 — all `.get(` call sites on this client)

Grepped every call site of `QdrantClient.get(` across `apps/backend-rag/backend/`
(excluding tests):

- **`backend/app/routers/memory_vector.py:244`** — the only production call
  site: `db.get(ids=[request.memory_id], include=["embeddings"])`, used by
  `POST /api/memory-vector/similar` to fetch a memory's own vector before
  searching for neighbors. Under the bug, `with_vector=True` was requested via
  query param and silently ignored → Qdrant's default (`with_vector=False`)
  applied → the endpoint could never retrieve a usable embedding for the
  requested memory (falls into the "Invalid embedding format returned by
  vector store" 500 branch in that handler). No caller compensates with a
  second retrieve, so the fix is a pure mechanical improvement here — the
  endpoint starts actually working instead of silently failing.
- All other files matching `.get(` on this class were either test fixtures
  (`test_qdrant_client_methods.py`, `test_qdrant_db_comprehensive.py`) or
  unrelated `dict.get()` / `os.getenv()` calls — no other production callers
  found.

Out of scope (flagged, not touched): `scroll()`/`peek()` in the same file also
set `with_vectors` (plural, wrong field name) in the body, but both want
`with_vector=False`, which is Qdrant's own default — so the wrong field name
is currently harmless there (unlike `get()`, where the intended value was
`True`). Left alone to keep this PR mechanical and single-purpose.

## Tests (guilt + innocence, `test_qdrant_client_methods.py`)

Added two tests using a **real `httpx.MockTransport`** (so the actual wire-level
`Request` is inspected — a mocked `.post()` call can't distinguish `params=`
from `json=`):

- `test_get_with_include_sends_flags_in_json_body_not_query_params` — asserts
  the flags are absent from `request.url.params` and present in the JSON body
  with the correct field name. **Guilt verified empirically**: manually
  reverted `qdrant_db.py` to the pre-fix `params=` version, re-ran this test,
  confirmed it fails (`AssertionError: assert 'with_payload' not in
  QueryParams('with_payload=true&with_vectors=true')`), then restored the fix
  and confirmed all tests pass again.
- `test_get_without_include_still_works` — innocence: a plain `get()` call
  with no `include` (the common full-fetch path) is unaffected.

## Verification

- `PYTHONPATH=. pytest backend/tests/unit/core/test_qdrant_client_methods.py backend/tests/unit/core/test_qdrant_db_comprehensive.py backend/tests/unit/core/test_qdrant_collection_ops.py backend/tests/unit/core/test_qdrant_search.py backend/tests/unit/core/test_qdrant_filter_conversion.py backend/tests/unit/core/test_qdrant_flat_payload.py backend/tests/unit/app/routers/test_memory_vector.py` → 123 passed
- Full pre-push suite (path-aware gate ran FULL since these files aren't on the innocent allowlist): 18287 passed, 165 skipped
- FastAPI import-chain smoke: OK

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>