### PR TITLE
docs(onboarding): regen DOCSYNC quick-numbers — test count 1189→1190 (#2816 follow-up)

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 650 services · 1189 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 650 services · 1190 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
W86-class repair. #2816 added `test_drive_operations_normalization.py` (1189→1190 tests) but the DOCSYNC bump commit was pushed after auto-merge had already fired — orphaned on the branch, main stale. Diff = exact `scripts/docs_sync.py` output on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)