### PR TITLE
fix(cron): drop PYTHONPATH=. from KG staging promotion workflow

### DIFF
--- a/.github/workflows/cron-kg-staging-promotion.yml
+++ b/.github/workflows/cron-kg-staging-promotion.yml
@@ -10,6 +10,11 @@ name: Cron — KG staging promotion
 #   2. repo variable KG_PROMOTION_MODE=apply (changes schedule behavior)
 # Runs are chunked short transactions + advisory-lock singleton, so a dropped
 # ssh session costs at most one ~25-row rollback and the next run resumes.
+#
+# SCAR (2026-07-19, first scheduled run failed): do NOT prefix the command with
+# `PYTHONPATH=.` — on the Fly image it shadows the interpreter's site-packages
+# and `import asyncpg` dies (same class as the Wave-4 migration scar; plain
+# `cd /app && python -m ...` is the only correct form).
 
 on:
   schedule:
@@ -46,7 +51,7 @@ jobs:
           flyctl ssh console \
             --app nuzantara-rag \
             --process-group api \
-            --command "/bin/sh -c 'cd /app && PYTHONPATH=. python -m backend.scripts.kg_staging_promotion --${MODE}'" 2>&1 | tee promotion.log
+            --command "/bin/sh -c 'cd /app && python -m backend.scripts.kg_staging_promotion --${MODE}'" 2>&1 | tee promotion.log
 
       - name: Upload run report
         if: always()


### PR DESCRIPTION
## Cosa (H1.1)
Prima run schedulata di `cron-kg-staging-promotion.yml` fallita: il comando flyctl ssh era prefissato con `PYTHONPATH=.`, che sull'immagine Fly fa shadowing dei site-packages dell'interprete → `import asyncpg` muore.

## Fix
- Rimosso il prefisso `PYTHONPATH=.`: la forma corretta è `cd /app && python -m backend.scripts.kg_staging_promotion --${MODE}` (stessa classe di scar della Wave-4 migration).
- Aggiunto commento SCAR in testa al workflow per prevenire regressioni.

## Verifica empirica
`workflow_dispatch` con `mode=dry-run` rilanciato sul branch di questa PR come prova che la run va verde prima del merge.

Co-authored-by: Kimi <kimi@balizero.com>