### PR TITLE
docs(onboarding): regen DOCSYNC counters — repair stale left by #2813 (W86)

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 650 services · 1189 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 650 services · 1190 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
`docs/AI_ONBOARDING.md`'s DOCSYNC test-count digest went stale (`e05d2326bfbd` → `ae380d47a850`) when #2813 merged 132 new test lines without a counter regen — same W86 class as #2815/#2817, this time a different file the required `check-docs-sync` gate covers.

This PR is `python scripts/docs_sync.py` output only: test count bumped 1189 → 1190. No other line touched; `--check` exits 0 on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)