### PR TITLE
feat(infra): independent qdrant backup retention guard (cicatrix #2)

### DIFF
--- a/scripts/qdrant_backup_retention.sh
+++ b/scripts/qdrant_backup_retention.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# qdrant_backup_retention.sh — independent retention guard for ~/backups/qdrant-snapshots
+#
+# WHY (cicatrix #2 — "esiste ≠ armato" / don't trust the producer's own green):
+#   The two Qdrant backup producers already self-prune their OWN outputs inline:
+#     * fly-qdrant-backup.sh:214 — keeps last 7 `qdrant-*.tar.gz`  (KEEP_LOCAL=7)
+#     * qdrant-snapshot.sh:216   — keeps last 4 `<coll>_*.snapshot` per collection (KEEP_LOCAL=4)
+#   Tigris S3 holds the authoritative REMOTE copies (KEEP_REMOTE=30), so local
+#   pruning is a convenience-layer cleanup, never the sole DR copy.
+#
+#   This guard does NOT replace the producers. It is an INDEPENDENT daily backstop:
+#     1. ORPHAN SWEEP (the one genuinely-uncovered growth vector) — session dirs
+#        named `YYYYMMDD-HHMM/` left behind by a fly-qdrant-backup.sh run that
+#        CRASHED between `mkdir "$SESSION_DIR"` (:63) and `rm -rf "$SESSION_DIR"`
+#        (:171). NEITHER producer ever cleans an OLD orphan (fly only rm -rf's the
+#        current run's dir). Observed live: `20260618-0308/` = 144 MB leaked.
+#     2. BACKSTOP PRUNE — re-enforces the SAME thresholds as the producers, so if a
+#        producer's inline prune silently breaks (xargs fail / KEEP misconfig /
+#        producer stops running), drift is caught. In steady state this is a NO-OP.
+#     3. FOOTPRINT READ — reports total bytes and WARNs past a soft cap (an
+#        independent liveness read of real state, not a trust of the producer exit).
+#
+# Scope is HARD-LOCKED to a path ending in `/backups/qdrant-snapshots`. It never
+# touches `fly-postgres/`, `postgres/`, or any sibling backup dir. It only ever
+# removes files/dirs that match the exact producer-emitted name patterns.
+#
+# Usage:
+#   qdrant_backup_retention.sh            # DRY-RUN (default): report only, remove nothing
+#   qdrant_backup_retention.sh --apply    # act
+# Kill switch:  QDRANT_RETENTION_ENABLED=false
+# Test override: QDRANT_BACKUP_ROOT=/some/.../backups/qdrant-snapshots (must keep the suffix)
+#
+# Targets /bin/bash 3.2 (the only bash on the Pro/M5 fleet) — no bash-4 features.
+set -euo pipefail
+
+QDRANT_RETENTION_ENABLED="${QDRANT_RETENTION_ENABLED:-true}"
+BACKUP_ROOT="${QDRANT_BACKUP_ROOT:-$HOME/backups/qdrant-snapshots}"
+KEEP_TARGZ="${QDRANT_KEEP_TARGZ:-7}"              # mirror fly-qdrant-backup.sh KEEP_LOCAL
+KEEP_SNAP_PER_COLL="${QDRANT_KEEP_SNAP:-4}"       # mirror qdrant-snapshot.sh   KEEP_LOCAL
+ORPHAN_DIR_KEEP_DAYS="${QDRANT_ORPHAN_KEEP_DAYS:-14}"
+SOFT_CAP_GB="${QDRANT_SOFT_CAP_GB:-12}"
+LOG_FILE="${QDRANT_RETENTION_LOG:-$HOME/logs/qdrant-backup-retention.log}"
+
+APPLY=false
+[ "${1:-}" = "--apply" ] && APPLY=true
+
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+ts()  { date +%Y-%m-%dT%H:%M:%S%z; }
+log() { echo "[$(ts)] $*" | tee -a "$LOG_FILE" >&2; }
+
+# True if a Qdrant backup PRODUCER is currently running — we must not prune an
+# in-flight session dir nor race a producer's concurrent mutation of the dir
+# (neither producer takes a lock). Degrades to "not running" if pgrep is absent
+# (not our fleet). Pattern overridable for tests via QDRANT_PRODUCER_PROC_RE.
+producer_running() {
+  command -v pgrep >/dev/null 2>&1 || return 1
+  if [ -n "${QDRANT_PRODUCER_PROC_RE:-}" ]; then
+    pgrep -f "$QDRANT_PRODUCER_PROC_RE" >/dev/null 2>&1 && return 0
+    return 1
+  fi
+  pgrep -f 'fly-qdrant-backup' >/dev/null 2>&1 && return 0
+  pgrep -f 'qdrant-snapshot'   >/dev/null 2>&1 && return 0
+  return 1
+}
+
+# ── Kill switch ──────────────────────────────────────────────────────────────
+enabled_lc=$(printf '%s' "$QDRANT_RETENTION_ENABLED" | tr 'A-Z' 'a-z')
+case "$enabled_lc" in
+  0|false|no|off) log "DISABLED via QDRANT_RETENTION_ENABLED=$QDRANT_RETENTION_ENABLED — exit 0"; exit 0 ;;
+esac
+
+# ── Scope guard (refuse anything not clearly the qdrant-snapshots backup dir) ──
+case "$BACKUP_ROOT" in
+  */backups/qdrant-snapshots) : ;;
+  *) log "REFUSE: BACKUP_ROOT '$BACKUP_ROOT' does not end in /backups/qdrant-snapshots — exit 2"; exit 2 ;;
+esac
+if [ "$BACKUP_ROOT" = "$HOME" ] || [ "$BACKUP_ROOT" = "/" ] || [ -z "$BACKUP_ROOT" ]; then
+  log "REFUSE: unsafe BACKUP_ROOT '$BACKUP_ROOT' — exit 2"; exit 2
+fi
+
+MODE="DRY-RUN"; $APPLY && MODE="APPLY"
+log "=== qdrant-backup-retention START ($MODE) root=$BACKUP_ROOT keep_targz=$KEEP_TARGZ keep_snap/coll=$KEEP_SNAP_PER_COLL orphan_days=$ORPHAN_DIR_KEEP_DAYS ==="
+
+# Sibling-race / TOCTOU guard: never prune while a producer is writing this dir.
+if producer_running; then
+  log "SKIP: a qdrant backup producer is running — retry next cron run — exit 0"; exit 0
+fi
+
+if [ ! -d "$BACKUP_ROOT" ]; then
+  # Absent dir is a normal state (producers recreate it on next run; this session
+  # archived+removed it 2026-07-19). Nothing to prune.
+  log "root absent — nothing to do (producers recreate on next run) — exit 0"; exit 0
+fi
+
+removed_count=0
+freed_bytes=0
+traversed=0
+
+fsize()     { stat -f '%z' "$1" 2>/dev/null || stat -c '%s' "$1" 2>/dev/null || echo 0; }
+# `|| true` neutralises a find/stat TOCTOU (a file vanishing mid-scan makes find
+# exit non-zero → pipefail → set -e would abort AFTER deletes, defeating the guard).
+dir_bytes() { { find "$1" -type f -exec stat -f '%z' {} + 2>/dev/null || true; } | awk '{s+=$1} END{print s+0}'; }
+
+remove_file() {
+  f="$1"; why="$2"; b=$(fsize "$f")
+  if $APPLY; then
+    if rm -f "$f"; then
+      log "  REMOVED [$why] $(basename "$f") (${b}B)"; removed_count=$((removed_count+1)); freed_bytes=$((freed_bytes+b))
+    else
+      log "  WARN could not remove $f"
+    fi
+  else
+    log "  WOULD-REMOVE [$why] $(basename "$f") (${b}B)"; removed_count=$((removed_count+1)); freed_bytes=$((freed_bytes+b))
+  fi
+}
+
+remove_dir() {
+  d="$1"; why="$2"; b=$(dir_bytes "$d")
+  if $APPLY; then
+    # scope-safe recursive clear (never `rm -rf ~`): empty contents then rmdir
+    find "$d" -mindepth 1 -delete 2>/dev/null || true
+    if rmdir "$d" 2>/dev/null; then
+      log "  REMOVED-DIR [$why] $(basename "$d")/ (${b}B)"; removed_count=$((removed_count+1)); freed_bytes=$((freed_bytes+b))
+    else
+      log "  WARN could not rmdir $d"
+    fi
+  else
+    log "  WOULD-REMOVE-DIR [$why] $(basename "$d")/ (${b}B)"; removed_count=$((removed_count+1)); freed_bytes=$((freed_bytes+b))
+  fi
+}
+
+# ── 1) ORPHAN session-dir sweep (the real uncovered vector) ──────────────────
+# Only dirs whose name is exactly the producer TIMESTAMP format YYYYMMDD-HHMM,
+# older than ORPHAN_DIR_KEEP_DAYS (dir mtime ≈ crash time). Anything else: skip.
+while IFS= read -r d; do
+  [ -z "$d" ] && continue
+  traversed=$((traversed+1))
+  remove_dir "$d" "orphan-session-dir >${ORPHAN_DIR_KEEP_DAYS}d"
+done < <(find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d \
+              -name '[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]' \
+              -mtime +"$ORPHAN_DIR_KEEP_DAYS" 2>/dev/null | sort)
+
+# ── 2) BACKSTOP: qdrant-*.tar.gz keep newest KEEP_TARGZ (mirrors producer) ────
+targz=()
+while IFS= read -r line; do [ -n "$line" ] && targz+=("$line"); done < <(ls -t "$BACKUP_ROOT"/qdrant-*.tar.gz 2>/dev/null || true)
+if [ "${#targz[@]}" -gt "$KEEP_TARGZ" ]; then
+  idx=0
+  for f in "${targz[@]}"; do
+    if [ "$idx" -ge "$KEEP_TARGZ" ]; then traversed=$((traversed+1)); remove_file "$f" "tar.gz backstop keep-$KEEP_TARGZ"; fi
+    idx=$((idx+1))
+  done
+fi
+
+# ── 3) BACKSTOP: per-collection <coll>_*.snapshot keep newest KEEP_SNAP_PER_COLL
+# Collection key = filename with trailing `_YYYYMMDD-HHMM.snapshot` stripped.
+colls=()
+while IFS= read -r line; do [ -n "$line" ] && colls+=("$line"); done < <(ls "$BACKUP_ROOT"/*_[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9].snapshot 2>/dev/null | sed -E 's|.*/||; s/_[0-9]{8}-[0-9]{4}\.snapshot$//' | sort -u || true)
+if [ "${#colls[@]}" -gt 0 ]; then
+  for coll in "${colls[@]}"; do
+    [ -z "$coll" ] && continue
+    snaps=()
+    while IFS= read -r line; do [ -n "$line" ] && snaps+=("$line"); done < <(ls -t "$BACKUP_ROOT/${coll}"_[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9].snapshot 2>/dev/null || true)
+    if [ "${#snaps[@]}" -gt "$KEEP_SNAP_PER_COLL" ]; then
+      idx=0
+      for f in "${snaps[@]}"; do
+        if [ "$idx" -ge "$KEEP_SNAP_PER_COLL" ]; then traversed=$((traversed+1)); remove_file "$f" "snapshot backstop keep-$KEEP_SNAP_PER_COLL/coll[$coll]"; fi
+        idx=$((idx+1))
+      done
+    fi
+  done
+fi
+
+# ── Footprint read (independent liveness, W84 blind-scan note) ────────────────
+total_bytes=$(dir_bytes "$BACKUP_ROOT")
+total_gb=$(awk -v b="$total_bytes" 'BEGIN{printf "%.2f", b/1073741824}')
+if [ "$traversed" -eq 0 ]; then
+  log "note: 0 prune-candidates traversed (dir present but nothing matched retention patterns)"
+fi
+cap_hit=""
+if awk -v b="$total_bytes" -v cap="$SOFT_CAP_GB" 'BEGIN{exit !(b > cap*1073741824)}'; then
+  cap_hit="  ⚠️ OVER SOFT CAP ${SOFT_CAP_GB}G"
+fi
+freed_gb=$(awk -v b="$freed_bytes" 'BEGIN{printf "%.2f", b/1073741824}')
+verb="would-free"; $APPLY && verb="freed"
+log "=== COMPLETE ($MODE): $removed_count candidate(s), $verb ${freed_gb}G — footprint now ${total_gb}G${cap_hit} ==="
+exit 0

--- a/scripts/test_qdrant_backup_retention.sh
+++ b/scripts/test_qdrant_backup_retention.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Tripwire test for qdrant_backup_retention.sh (guilt + innocence).
+# Self-contained: builds a synthetic backups/qdrant-snapshots fixture in a temp
+# dir, exercises dry-run / apply / idempotence / scope-guard / kill-switch /
+# absent-dir, asserts exactly what is pruned and what is preserved.
+# Targets /bin/bash 3.2 (fleet default). Run: bash scripts/test_qdrant_backup_retention.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/qdrant_backup_retention.sh"
+ROOT="$(mktemp -d "${TMPDIR:-/tmp}/qretfix.XXXXXX")"
+FIX="$ROOT/backups/qdrant-snapshots"
+PASS=0; FAIL=0
+ok(){ echo "  ✅ $1"; PASS=$((PASS+1)); }
+no(){ echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+have(){ [ -e "$FIX/$1" ]; }
+cleanup(){ find "$ROOT" -mindepth 1 -delete 2>/dev/null || true; rmdir "$ROOT" 2>/dev/null || true; }
+trap cleanup EXIT
+
+build(){
+  find "$ROOT" -mindepth 1 -delete 2>/dev/null || true
+  mkdir -p "$FIX"
+  # 9 tar.gz, increasing mtime t1..t9 (t9 newest) → keep 7 newest, remove 2 oldest
+  i=1; for m in 202601010001 202601020001 202601030001 202601040001 202601050001 202601060001 202601070001 202601080001 202601090001; do
+    f="$FIX/qdrant-2026010${i}-000${i}.tar.gz"; echo "dummy$i" > "$f"; touch -t "$m" "$f"; i=$((i+1)); done
+  # collection A: 6 snapshots → keep 4 newest, remove 2 oldest
+  i=1; for m in 202602010001 202602020001 202602030001 202602040001 202602050001 202602060001; do
+    f="$FIX/colA_2026020${i}-000${i}.snapshot"; echo "a$i" > "$f"; touch -t "$m" "$f"; i=$((i+1)); done
+  # collection B: 3 snapshots → keep all (under threshold)
+  i=1; for m in 202603010001 202603020001 202603030001; do
+    f="$FIX/colB_2026030${i}-000${i}.snapshot"; echo "b$i" > "$f"; touch -t "$m" "$f"; i=$((i+1)); done
+  # orphan OLD session dir (mtime -30d) → sweep ; orphan RECENT (-2d) → keep
+  mkdir -p "$FIX/20260101-0300"; echo x > "$FIX/20260101-0300/legal_hybrid.snapshot"; touch -t "$(date -v-30d +%Y%m%d%H%M 2>/dev/null || date -d '30 days ago' +%Y%m%d%H%M)" "$FIX/20260101-0300"
+  mkdir -p "$FIX/20260718-0300"; echo y > "$FIX/20260718-0300/partial.snapshot";     touch -t "$(date -v-2d  +%Y%m%d%H%M 2>/dev/null || date -d '2 days ago'  +%Y%m%d%H%M)" "$FIX/20260718-0300"
+  # decoys — must NEVER be touched
+  echo readme > "$FIX/README.txt"
+  mkdir -p "$FIX/not-a-timestamp"; echo z > "$FIX/not-a-timestamp/keep.me"; touch -t "$(date -v-99d +%Y%m%d%H%M 2>/dev/null || date -d '99 days ago' +%Y%m%d%H%M)" "$FIX/not-a-timestamp"
+}
+
+echo "═══ TEST 1: DRY-RUN removes nothing, reports the right candidates ═══"
+build
+OUT=$(QDRANT_BACKUP_ROOT="$FIX" bash "$SCRIPT" 2>&1); RC=$?
+[ $RC -eq 0 ] && ok "dry-run exit 0" || no "dry-run exit $RC"
+allpresent=true
+for f in qdrant-20260101-0001.tar.gz colA_20260201-0001.snapshot 20260101-0300; do have "$f" || allpresent=false; done
+$allpresent && ok "dry-run left ALL files on disk" || no "dry-run deleted something (must not)"
+c=$(grep -c "WOULD-REMOVE" <<<"$OUT")
+[ "$c" -eq 5 ] && ok "dry-run flagged exactly 5 (2 tar.gz + 2 colA + 1 orphan)" || no "dry-run flagged $c (expected 5)"
+
+echo "═══ TEST 2: APPLY removes exactly the right set, keeps the rest ═══"
+build
+OUT=$(QDRANT_BACKUP_ROOT="$FIX" bash "$SCRIPT" --apply 2>&1); RC=$?
+[ $RC -eq 0 ] && ok "apply exit 0" || no "apply exit $RC"
+gone=true
+for f in qdrant-20260101-0001.tar.gz qdrant-20260102-0002.tar.gz colA_20260201-0001.snapshot colA_20260202-0002.snapshot 20260101-0300; do have "$f" && gone=false; done
+$gone && ok "removed the 5 expected (2 oldest tar.gz, 2 oldest colA, OLD orphan)" || no "some expected-removed still present"
+kept=true
+for f in qdrant-20260103-0003.tar.gz qdrant-20260109-0009.tar.gz colA_20260203-0003.snapshot colA_20260206-0006.snapshot colB_20260301-0001.snapshot colB_20260303-0003.snapshot 20260718-0300 20260718-0300/partial.snapshot README.txt not-a-timestamp not-a-timestamp/keep.me; do
+  have "$f" || { kept=false; echo "    MISSING (should keep): $f"; }; done
+$kept && ok "KEPT 7 tar.gz + 4 colA + 3 colB + recent-orphan + decoys" || no "deleted something it should keep"
+n=$(find "$FIX" -maxdepth 1 -name 'qdrant-*.tar.gz' | wc -l | tr -d ' '); [ "$n" -eq 7 ] && ok "tar.gz count == 7" || no "tar.gz == $n (want 7)"
+n=$(find "$FIX" -maxdepth 1 -name 'colA_*.snapshot' | wc -l | tr -d ' '); [ "$n" -eq 4 ] && ok "colA count == 4" || no "colA == $n (want 4)"
+
+echo "═══ TEST 3: idempotent — 2nd apply is a NO-OP ═══"
+OUT=$(QDRANT_BACKUP_ROOT="$FIX" bash "$SCRIPT" --apply 2>&1); RC=$?
+c=$(grep -c "REMOVED" <<<"$OUT" || true)
+[ $RC -eq 0 ] && [ "$c" -eq 0 ] && ok "2nd apply removed 0 (idempotent)" || no "2nd apply removed $c (rc=$RC)"
+
+echo "═══ TEST 4: scope guard refuses a non-qdrant / \$HOME root ═══"
+OUT=$(QDRANT_BACKUP_ROOT="/tmp/evil" bash "$SCRIPT" --apply 2>&1); RC=$?
+[ $RC -eq 2 ] && ok "refused bad root (exit 2)" || no "bad root exit $RC (want 2)"
+OUT=$(QDRANT_BACKUP_ROOT="$HOME" bash "$SCRIPT" --apply 2>&1); RC=$?
+[ $RC -eq 2 ] && ok "refused \$HOME (exit 2)" || no "\$HOME exit $RC (want 2)"
+
+echo "═══ TEST 5: kill switch ═══"
+build
+OUT=$(QDRANT_RETENTION_ENABLED=false QDRANT_BACKUP_ROOT="$FIX" bash "$SCRIPT" --apply 2>&1); RC=$?
+c=$(find "$FIX" -maxdepth 1 -name 'qdrant-*.tar.gz' | wc -l | tr -d ' ')
+[ $RC -eq 0 ] && [ "$c" -eq 9 ] && ok "kill switch = no-op (9 tar.gz untouched)" || no "kill switch acted (rc=$RC, tar.gz=$c)"
+
+echo "═══ TEST 6: absent dir is a clean no-op ═══"
+OUT=$(QDRANT_BACKUP_ROOT="/tmp/nope/backups/qdrant-snapshots" bash "$SCRIPT" --apply 2>&1); RC=$?
+{ [ $RC -eq 0 ] && grep -q "root absent" <<<"$OUT"; } && ok "absent dir exit 0 'root absent'" || no "absent dir rc=$RC"
+
+echo "═══ TEST 7: skips (exit 0, no prune) while a producer is running ═══"
+build
+# 2-command script body so `sh -c` does NOT exec-optimise the sentinel out of argv
+/bin/sh -c ": SENTINEL_qretprod_$$ ; sleep 60" &
+FAKE=$!
+sleep 1
+OUT=$(QDRANT_PRODUCER_PROC_RE="SENTINEL_qretprod_$$" QDRANT_BACKUP_ROOT="$FIX" bash "$SCRIPT" --apply 2>&1); RC=$?
+kill "$FAKE" 2>/dev/null || true; wait "$FAKE" 2>/dev/null || true
+n=$(find "$FIX" -maxdepth 1 -name 'qdrant-*.tar.gz' | wc -l | tr -d ' ')
+{ [ $RC -eq 0 ] && grep -q "SKIP:" <<<"$OUT" && [ "$n" -eq 9 ]; } && ok "producer running → SKIP exit 0, 9 tar.gz + orphan untouched" || no "producer-skip failed (rc=$RC, tar.gz=$n)"
+# and with NO producer running, the same sentinel pattern → normal prune resumes
+OUT=$(QDRANT_PRODUCER_PROC_RE="SENTINEL_qretprod_nomatch_$$" QDRANT_BACKUP_ROOT="$FIX" bash "$SCRIPT" --apply 2>&1); RC=$?
+n=$(find "$FIX" -maxdepth 1 -name 'qdrant-*.tar.gz' | wc -l | tr -d ' ')
+{ [ $RC -eq 0 ] && [ "$n" -eq 7 ]; } && ok "no producer → prune resumes (tar.gz 9→7)" || no "resume failed (rc=$RC, tar.gz=$n)"
+
+echo ""
+echo "═══════════ RESULT: $PASS passed, $FAIL failed ═══════════"
+[ $FAIL -eq 0 ]


### PR DESCRIPTION
## What
`scripts/qdrant_backup_retention.sh` — an **independent daily backstop** for `~/backups/qdrant-snapshots` on the Pro.

## Why (cicatrix #2 — "esiste ≠ armato / don't trust the producer's green")
Both Qdrant backup producers already self-prune their own outputs inline:
- `fly-qdrant-backup.sh:214` → keeps 7 `qdrant-*.tar.gz`
- `qdrant-snapshot.sh:216` → keeps 4 `<coll>_*.snapshot` per collection (Tigris S3 keeps 30 remote)

So `qdrant-snapshots` is steady-state **bounded (~5.5G), not a runaway** (an earlier "no retention" flag was a misdiagnosis, corrected). The genuinely-uncovered vector = **orphan session dirs** `YYYYMMDD-HHMM/` left by a `fly-qdrant-backup.sh` run that CRASHED between `mkdir "$SESSION_DIR"` (:63) and its `rm -rf` (:171) — cleaned by NEITHER producer. Observed live: `20260618-0308/` = 144 MB leaked. There is also no independent check that the inline prunes actually fired.

## What the guard does
1. **Orphan sweep** — session dirs named exactly `YYYYMMDD-HHMM/` older than 14d.
2. **Backstop prune** — re-enforce the SAME thresholds as the producers (keep 7 tar.gz, keep 4 .snapshot/coll). NO-OP in steady state; catches drift if a producer's inline prune silently breaks.
3. **Footprint read** — report bytes + WARN past a 12G soft cap.

## Safety
- **Dry-run default**; `--apply` to act.
- Scope **hard-locked** to a `*/backups/qdrant-snapshots` path (refuses `$HOME`/other → exit 2).
- Kill switch `QDRANT_RETENTION_ENABLED=false`.
- **Producer-liveness SKIP** (`pgrep`) — never prunes an in-flight session dir nor races a concurrent producer (sibling-race/TOCTOU).
- `dir_bytes` neutralises a find/stat TOCTOU that could abort under `set -e` after deletes.
- Targets `/bin/bash 3.2.57` — the fleet's only bash (no bash-4 constructs).

## Tests
`scripts/test_qdrant_backup_retention.sh` — **15 guilt+innocence assertions** (sort-order, decoy-preservation, idempotence, scope-refuse, kill-switch, absent-dir, producer-skip). All green. Adversarially reviewed (generator≠grader); both findings (dir_bytes set-e trap, orphan-sweep liveness) fixed + regression-tested.

Arms daily 05:00 on the Pro via crontab (after merge+deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)