### PR TITLE
fix(arsenal): retire DeepSeek from cascade scripts, arm Kimi K3 seat + kimi_client.py

### DIFF
--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -79,13 +79,15 @@ STRICT_FAIL = {AUTH_DEAD, BALANCE_DEAD, MODEL_ERR, UNKNOWN_ERR}
 # A host limitation, not a seat death — never strict-fails regardless of required-ness.
 CONTEXT_LIMITED = {CONTEXT_AUTH, CRED_UNAVAILABLE, NOT_INSTALLED}
 
-ALL_SEATS = ["claude", "glm", "kimi", "agy", "codex", "deepseek", "ollama", "nlm"]
+# deepseek RETIRED 2026-07-19 (owner order, pre-auth revoked — never top up) —
+# replacement seat kimi already present.
+ALL_SEATS = ["claude", "glm", "kimi", "agy", "codex", "ollama", "nlm"]
 
 REQUIRED_SEATS = {
     # kimi PONG-proven on all three machines 2026-07-19 (mini device-code
     # authorized by the operator same day).
     "mini": ["claude", "glm", "codex", "kimi", "ollama"],
-    "pro": ["claude", "codex", "deepseek", "kimi", "ollama", "nlm"],
+    "pro": ["claude", "codex", "kimi", "ollama", "nlm"],
     "m5": ["claude", "glm", "agy", "codex", "kimi"],
 }
 
@@ -95,7 +97,6 @@ DEFAULT_TIMEOUTS = {
     "kimi": 120,
     "agy": 120,
     "codex": 180,
-    "deepseek": 45,
     "ollama": 30,
     "nlm": 60,
 }
@@ -452,24 +453,6 @@ def probe_codex(timeout: float) -> tuple[str, str, int]:
     return status, ev, latency_ms
 
 
-def probe_deepseek(timeout: float) -> tuple[str, str, int]:
-    t0 = time.monotonic()
-    key, cred_note = load_env_master_key("DEEPSEEK_API_KEY")
-    if key is None:
-        return CRED_UNAVAILABLE, cred_note or "credential unavailable", int((time.monotonic() - t0) * 1000)
-    headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
-    body = {"model": "deepseek-v4-flash", "max_tokens": 1, "messages": [{"role": "user", "content": PONG_PROMPT}]}
-    status_code, ev = http_post_json(
-        "https://api.deepseek.com/chat/completions", headers, body, timeout, [key]
-    )
-    latency_ms = int((time.monotonic() - t0) * 1000)
-    if status_code is None:
-        return TIMEOUT if "timed out" in ev else UNKNOWN_ERR, ev, latency_ms
-    live = status_code == 200
-    status = classify_generic(f"HTTP {status_code} {ev}", live, "deepseek", is_ssh_context())
-    return status, f"HTTP {status_code} {ev}", latency_ms
-
-
 def probe_ollama(timeout: float, live_gen: bool = False) -> tuple[str, str, int]:
     t0 = time.monotonic()
     binp = resolve_bin("ollama")
@@ -525,7 +508,6 @@ PROBE_FUNCS: dict[str, Callable[..., tuple[str, str, int]]] = {
     "kimi": probe_kimi,
     "agy": probe_agy,
     "codex": probe_codex,
-    "deepseek": probe_deepseek,
     "ollama": probe_ollama,
     "nlm": probe_nlm,
 }

--- a/scripts/codex_tri_llm_review.py
+++ b/scripts/codex_tri_llm_review.py
@@ -5,7 +5,9 @@ Three independent reviewers vote on a PR diff:
 
 1. **Codex** (gpt-5.5 high, OAuth Pro) — agentic coding specialist
 2. **Claude Opus 4.7 max effort** (OAuth, free) — deep reasoning
-3. **DeepSeek Reasoner v4** (~$0.01/query, allowed by hard rule)
+3. **Kimi K3** (Moonshot, flat Allegro subscription, `kimi` CLI) — cross-family
+   second opinion. Replaces the retired DeepSeek leg (2026-07-19, owner order,
+   pre-auth revoked — never top up).
 
 Voting outcome:
 - ≥2/3 GREEN + CI green → eligible for auto-merge
@@ -41,12 +43,12 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
 
 # Hard rule: NO ANTHROPIC_API_KEY. Defense-in-depth strip.
 for forbidden in ("ANTHROPIC_API_KEY", "AWS_BEDROCK_ANTHROPIC_KEY", "VERTEX_AI_ANTHROPIC_KEY"):
@@ -77,7 +79,7 @@ logger = logging.getLogger("tri-llm-review")
 
 @dataclass
 class ReviewVerdict:
-    reviewer: str  # "codex" | "claude-opus" | "deepseek"
+    reviewer: str  # "codex" | "claude-opus" | "kimi-k3"
     verdict: str  # "green" | "yellow" | "red"
     p0_issues: list[str] = field(default_factory=list)
     p1_issues: list[str] = field(default_factory=list)
@@ -361,6 +363,25 @@ def _safe_subprocess_env() -> dict[str, str]:
     return env
 
 
+async def _communicate_or_kill(
+    proc: "asyncio.subprocess.Process", timeout: float
+) -> tuple[bytes, bytes]:
+    """communicate() with a hard kill on timeout.
+
+    ``asyncio.wait_for`` cancels the ``communicate()`` coroutine but does NOT
+    terminate the child — a hung seat CLI would linger as an orphan and
+    accumulate across panel runs (GLM R1 finding, 2026-07-19). Kill + reap
+    before re-raising so every timeout leaves zero residue.
+    """
+    try:
+        return await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
+        raise
+
+
 async def review_codex(prompt: str) -> ReviewVerdict:
     start = time.time()
     try:
@@ -380,7 +401,7 @@ async def review_codex(prompt: str) -> ReviewVerdict:
             stderr=asyncio.subprocess.PIPE,
             env=_safe_subprocess_env(),
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=600)
+        stdout, stderr = await _communicate_or_kill(proc, 600)
         duration = time.time() - start
         if proc.returncode != 0:
             return parse_verdict(
@@ -463,7 +484,7 @@ async def review_claude_opus(prompt: str) -> ReviewVerdict:
             stderr=asyncio.subprocess.PIPE,
             env=env,
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=600)
+        stdout, stderr = await _communicate_or_kill(proc, 600)
         duration = time.time() - start
         if proc.returncode != 0:
             return parse_verdict(
@@ -476,92 +497,68 @@ async def review_claude_opus(prompt: str) -> ReviewVerdict:
         return parse_verdict("claude-opus", "", time.time() - start, error=str(e))
 
 
-async def review_deepseek(prompt: str, http_client: Any) -> ReviewVerdict:
-    """DeepSeek Reasoner v4 via API (~$0.01/query — explicitly allowed).
+_KIMI_BIN_DEFAULT = str(Path.home() / ".kimi-code" / "bin" / "kimi")
 
-    The httpx.AsyncClient is owned by the caller (run_panel) and passed in
-    here. This satisfies the project's async-first rule (Golden Rule #10):
-    NEVER instantiate httpx.AsyncClient inside a method/loop — clients
-    must be persistent and closed via lifespan.
+
+def _resolve_kimi_bin() -> str | None:
+    """Resolve the ``kimi`` CLI binary defensively: env override -> the known
+    install path -> PATH lookup. Never raises."""
+    env_override = os.environ.get("KIMI_BIN")
+    if env_override and Path(env_override).exists():
+        return env_override
+    if Path(_KIMI_BIN_DEFAULT).exists():
+        return _KIMI_BIN_DEFAULT
+    return shutil.which("kimi")
+
+
+async def review_kimi(prompt: str) -> ReviewVerdict:
+    """Kimi K3 (Moonshot, flat Allegro subscription) via the local ``kimi`` CLI.
+
+    Replaces the retired DeepSeek leg (2026-07-19, owner order, pre-auth
+    revoked — never top up). Subprocess pattern (mirrors ``review_codex``),
+    NOT the httpx/API-key pattern the old DeepSeek leg used — Kimi has no
+    per-token key; it authenticates via OAuth device-code baked into the CLI
+    session, so there is no budget guard to consult here (flat sub, zero
+    marginal cost — see scripts/cost_breaker.py, kimi is an unguarded tier
+    same as ollama).
+
+    The binary is resolved defensively (``_resolve_kimi_bin``). If it cannot
+    be found, this returns an ``error`` verdict exactly like every other seat
+    does when its binary/credential is unavailable, so the W64 quorum logic
+    (``compute_outcome``) treats a missing Kimi as a dead seat — never a red
+    vote over a fixed denominator.
+
+    PII boundary (SYMBIOSIS Law 2): Kimi is a Chinese cloud — prompts must
+    never carry client PII (KTP/passport/NPWP/akta/CRM rows). This leg only
+    ever receives non-PII code diffs; keep it that way.
     """
     start = time.time()
-    api_key = os.environ.get("DEEPSEEK_API_KEY")
-    if not api_key:
-        # Try sourcing from on-disk secret files, in priority order.
-        # ~/.openclaw/workspace/.env.master is where the key actually
-        # lives on the Pro (CLAUDE.md DeepSeek arsenal note); the older
-        # ~/.nuzantara-secrets.env is kept as a fallback. Under launchd
-        # DEEPSEEK_API_KEY is never in the env, so without reading
-        # .env.master the reviewer silently returns no_api_key (W64).
-        for secrets_path in (
-            Path.home() / ".openclaw" / "workspace" / ".env.master",
-            Path.home() / ".nuzantara-secrets.env",
-        ):
-            if not secrets_path.exists():
-                continue
-            for line in secrets_path.read_text().splitlines():
-                stripped = line.strip()
-                if stripped.startswith("export "):
-                    stripped = stripped[len("export "):]
-                if stripped.startswith("DEEPSEEK_API_KEY="):
-                    api_key = stripped.split("=", 1)[1].strip().strip('"').strip("'")
-                    break
-            if api_key:
-                break
-    if not api_key:
-        return parse_verdict("deepseek", "", time.time() - start, error="no_api_key")
-
-    # Smart-spend 2026-07-14: consult the cost breaker before spending and
-    # ledger the call after — the panel already degrades gracefully to 2-way
-    # when this seat drops, so a budget refusal is a soft seat-death, not an
-    # error. Import is lazy + best-effort: a broken guard must never kill the
-    # review panel itself.
+    binp = _resolve_kimi_bin()
+    if not binp:
+        return parse_verdict("kimi-k3", "", time.time() - start, error="kimi_binary_not_found")
     try:
-        import deepseek_client as _dsc
-
-        _decision = await _dsc.budget_verdict_async()
-        if _decision.verdict is not _dsc.cost_breaker.Verdict.ALLOW:
-            return parse_verdict(
-                "deepseek", "", time.time() - start,
-                error=f"budget_{_decision.verdict.value.lower()}",
-            )
-    except Exception as exc:  # noqa: BLE001 — guard is best-effort here
-        logger.warning("deepseek budget guard unavailable (%s) — proceeding", exc)
-        _dsc = None
-
-    try:
-        r = await http_client.post(
-            "https://api.deepseek.com/chat/completions",
-            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            json={
-                "model": "deepseek-v4-pro",  # was 'deepseek-reasoner' — legacy alias silently routes to V4-Flash (cicatrix 2026-05-24)
-                "messages": [
-                    {
-                        "role": "system",
-                        "content": "You are a strict code reviewer. Output ONLY the JSON requested, no preamble.",
-                    },
-                    {"role": "user", "content": prompt},
-                ],
-                "max_tokens": 8192,
-                "temperature": 0,
-            },
+        proc = await asyncio.create_subprocess_exec(
+            binp,
+            "-m",
+            "kimi-code/k3",
+            "-p",
+            prompt,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL,
+            env=_safe_subprocess_env(),
         )
+        stdout, stderr = await _communicate_or_kill(proc, 600)
         duration = time.time() - start
-        if r.status_code != 200:
+        if proc.returncode != 0:
             return parse_verdict(
-                "deepseek", r.text[:1000], duration, error=f"http_{r.status_code}"
+                "kimi-k3", stdout.decode(errors="replace"), duration, error=stderr.decode(errors="replace")[:500]
             )
-        data = r.json()
-        content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
-        if _dsc is not None:
-            _dsc.log_cost_event(
-                str(data.get("model") or "deepseek-v4-pro"),
-                data.get("usage") or {},
-                purpose="tri-llm-review",
-            )
-        return parse_verdict("deepseek", content, duration)
+        return parse_verdict("kimi-k3", stdout.decode(errors="replace"), duration)
+    except asyncio.TimeoutError:
+        return parse_verdict("kimi-k3", "", time.time() - start, error="timeout")
     except Exception as e:
-        return parse_verdict("deepseek", "", time.time() - start, error=str(e))
+        return parse_verdict("kimi-k3", "", time.time() - start, error=str(e))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -572,37 +569,17 @@ async def review_deepseek(prompt: str, http_client: Any) -> ReviewVerdict:
 async def run_panel(prompt: str) -> list[ReviewVerdict]:
     """Run all 3 reviewers in parallel, return verdicts (one per reviewer).
 
-    Creates a single persistent httpx.AsyncClient for DeepSeek (async-first
-    rule — Golden Rule #10), used only by ``review_deepseek``. The client
-    is closed via the async context manager when this coroutine exits.
+    All three legs are now subprocess-based (codex CLI, claude CLI, kimi
+    CLI) — no persistent httpx.AsyncClient is needed here anymore (the old
+    DeepSeek leg was the only httpx consumer in this function).
     """
-    logger.info("Launching tri-LLM panel (codex + claude-opus + deepseek)")
-    try:
-        import httpx  # type: ignore[import-not-found]
-    except ImportError:
-        # Without httpx, DeepSeek leg is unavailable; degrade panel to 2-way.
-        logger.warning("httpx missing — DeepSeek leg disabled, panel runs 2-way")
-        results = await asyncio.gather(
-            review_codex(prompt),
-            review_claude_opus(prompt),
-            return_exceptions=False,
-        )
-        # Synthesize a deepseek verdict to keep schema stable
-        deepseek_skip = ReviewVerdict(
-            reviewer="deepseek",
-            verdict="red",
-            duration_s=0.0,
-            error="httpx_missing",
-        )
-        results = [*results, deepseek_skip]
-    else:
-        async with httpx.AsyncClient(timeout=600.0) as http_client:
-            results = await asyncio.gather(
-                review_codex(prompt),
-                review_claude_opus(prompt),
-                review_deepseek(prompt, http_client),
-                return_exceptions=False,
-            )
+    logger.info("Launching tri-LLM panel (codex + claude-opus + kimi-k3)")
+    results = await asyncio.gather(
+        review_codex(prompt),
+        review_claude_opus(prompt),
+        review_kimi(prompt),
+        return_exceptions=False,
+    )
 
     for r in results:
         logger.info(
@@ -722,7 +699,7 @@ def post_pr_comment(decision: PanelDecision) -> bool:
     lines += [
         "",
         "---",
-        "_Automated tri-LLM review (Codex GPT-5.5 · Claude Opus · DeepSeek V4-Pro). "
+        "_Automated tri-LLM review (Codex GPT-5.5 · Claude Opus · Kimi K3). "
         "Review-only — **merge is the operator's decision** (Legge 5). "
         "This bot never labels, approves, or merges._",
     ]

--- a/scripts/cost_breaker.py
+++ b/scripts/cost_breaker.py
@@ -5,9 +5,9 @@ The SAFE SLICE of the SOTA meta-dev-loop's GOVERN piece. This module READS the
 already-shipped cost ledger (Postgres ``llm_cost_events`` migration 117, or the
 JSONL fallback ``${LLM_COST_JSONL_ROOT:-/data}/llm_cost_log.{date}.jsonl``) and
 TRIGGERS the already-shipped cascade fallback (claude_oauth -> gemini ->
-deepseek -> ollama). It NEVER spends, NEVER calls a paid endpoint, NEVER sees
-client PII — it only sums ``cost_usd`` per provider over a time window and emits
-a verdict.
+kimi -> openrouter -> ollama). It NEVER spends, NEVER calls a paid endpoint,
+NEVER sees client PII — it only sums ``cost_usd`` per provider over a time
+window and emits a verdict.
 
 Design (gate map):
 - G1: in the ALLOW (normal) state it pushes ZERO notifications.
@@ -71,24 +71,28 @@ logger = logging.getLogger("cost_breaker")
 # Cascade topology (mirrors the regulatory-watcher-run.sh tier order)
 # ---------------------------------------------------------------------------
 
-# claude_oauth -> gemini -> deepseek -> openrouter -> ollama -> None (terminal).
+# claude_oauth -> gemini -> kimi -> openrouter -> ollama -> None (terminal).
 # ollama is local/$0 — it has NO budget and is the floor of the cascade.
+# kimi is a flat-subscription seat (Moonshot Allegro plan) — zero marginal
+# cost, same posture as ollama, so it is ALSO unguarded (deepseek RETIRED
+# 2026-07-19, owner order, pre-auth revoked — never top up; its $5.00 budget
+# slot is not carried forward, kimi does not need one).
 # openrouter is a PAID per-token path with no flat subscription, so it is the
 # last PAID tier before the free floor and it carries a conservative budget.
 CASCADE_ORDER: tuple[str, ...] = (
     "claude_oauth",
     "gemini",
-    "deepseek",
+    "kimi",
     "openrouter",
     "ollama",
 )
 
 # Providers that carry a money cost and therefore a budget (G6 coverage set).
-# ollama is excluded on purpose: local inference is free, nothing to break.
+# ollama and kimi are excluded on purpose: local inference and Kimi's flat
+# subscription are both free at the margin — nothing to break.
 GUARDED_PROVIDERS: tuple[str, ...] = (
     "claude_oauth",
     "gemini",
-    "deepseek",
     "openrouter",
 )
 
@@ -97,7 +101,6 @@ GUARDED_PROVIDERS: tuple[str, ...] = (
 _DEFAULT_BUDGET_USD: dict[str, Decimal] = {
     "claude_oauth": Decimal("20.00"),
     "gemini": Decimal("10.00"),
-    "deepseek": Decimal("5.00"),
     "openrouter": Decimal("5.00"),
 }
 
@@ -115,20 +118,20 @@ _PROVIDER_ALIASES: dict[str, str] = {
     "claude": "claude_oauth",
     "gemini": "gemini",
     "google": "gemini",
-    "deepseek": "deepseek",
+    "kimi": "kimi",
     "openrouter": "openrouter",
     "ollama": "ollama",
 }
 
 # Canonical providers whose model-suffixed variants (``<prefix>-<model>`` or
 # ``<prefix>_<model>`` or ``<prefix>/<model>``) fold onto the prefix, e.g.
-# ``gemini-2.0`` / ``deepseek-v4-pro`` / ``claude-3-5-sonnet``.
+# ``gemini-2.0`` / ``kimi-code/k3`` / ``claude-3-5-sonnet``.
 _PROVIDER_PREFIXES: tuple[str, ...] = (
     "claude_oauth",
     "claude",
     "anthropic",
     "gemini",
-    "deepseek",
+    "kimi",
     "openrouter",
     "ollama",
 )
@@ -212,7 +215,7 @@ class BreakerConfig:
     def from_env(cls, env: Mapping[str, str] | None = None) -> BreakerConfig:
         """Build a config from environment overrides.
 
-        - COST_BREAKER_BUDGET_CLAUDE_OAUTH_USD / _GEMINI_USD / _DEEPSEEK_USD
+        - COST_BREAKER_BUDGET_CLAUDE_OAUTH_USD / _GEMINI_USD / _OPENROUTER_USD
         - COST_BREAKER_THRESHOLD_FRACTION
         - COST_BREAKER_WINDOW_SECONDS
         Invalid values fall back to the conservative defaults (never crash the
@@ -295,7 +298,7 @@ def _normalize_provider(raw: Any) -> str:
     - case-insensitive, whitespace-stripped
     - exact alias hits first (``anthropic`` -> ``claude_oauth``)
     - else strip a model suffix on a known prefix (``gemini-flash`` ->
-      ``gemini``, ``deepseek-v4-pro`` -> ``deepseek``, ``claude-3-5-sonnet`` ->
+      ``gemini``, ``kimi-code/k3`` -> ``kimi``, ``claude-3-5-sonnet`` ->
       ``claude_oauth`` via the ``claude`` prefix alias)
     - else return the lower-cased token unchanged (an unknown provider stays
       unknown; the caller decides how to treat it — never silently ALLOW a paid
@@ -323,8 +326,8 @@ def _normalize_provider(raw: Any) -> str:
 def next_tier(provider: str) -> str | None:
     """Return the next cascade tier after ``provider``, or None at the floor.
 
-    claude_oauth -> gemini -> deepseek -> ollama -> None. An unknown provider
-    yields None (no safe downgrade we can assert).
+    claude_oauth -> gemini -> kimi -> openrouter -> ollama -> None. An unknown
+    provider yields None (no safe downgrade we can assert).
     """
     try:
         idx = CASCADE_ORDER.index(provider)

--- a/scripts/kimi_client.py
+++ b/scripts/kimi_client.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""kimi_client.py — thin headless wrapper around the ``kimi`` CLI.
+
+Cascade tier-Kimi wrapper: mirrors the claude-CLI-subprocess doctrine used
+elsewhere in this repo (shell out to a local OAuth-authenticated CLI, never
+touch a per-token API key). Kimi (Moonshot) is a flat-subscription seat
+(Allegro plan, OAuth device-code login) added to the arsenal 2026-07-19 as
+the replacement for the retired DeepSeek V4 Pro API (owner order, pre-auth
+revoked — never top up). See CLAUDE.md §5 "Kimi seat".
+
+HARD RULE — Chinese cloud (SYMBIOSIS Law 2, non-negotiable): NEVER pass
+client PII (KTP, passport, NPWP, akta, CRM rows, any UU PDP-regulated field)
+in a prompt to this client. Kimi is for non-PII work only (research,
+code review, cascade fallback, aggregate/health/intel synthesis) — same
+posture as the DeepSeek client it replaces.
+
+Stdlib-only (subprocess, argparse, os, sys, shutil) — no new dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("kimi_client")
+
+DEFAULT_MODEL = "kimi-code/k3"
+
+_KIMI_BIN_DEFAULT = str(Path.home() / ".kimi-code" / "bin" / "kimi")
+
+PONG_PROMPT = "Reply with exactly: PONG"
+
+
+def _resolve_kimi_bin() -> str | None:
+    """Resolve the ``kimi`` CLI binary: env override -> known install path ->
+    PATH lookup. Never raises."""
+    env_override = os.environ.get("KIMI_BIN")
+    if env_override:
+        # A dangling override must fall through, not shadow a working install
+        # (semantics aligned with codex_tri_llm_review._resolve_kimi_bin).
+        if Path(env_override).exists():
+            return env_override
+    if Path(_KIMI_BIN_DEFAULT).exists():
+        return _KIMI_BIN_DEFAULT
+    return shutil.which("kimi")
+
+
+def probe(timeout: float = 60.0) -> bool:
+    """One-shot liveness probe. Returns True iff the CLI answered PONG.
+
+    Never raises — a missing binary, a timeout, or any subprocess error all
+    resolve to False (dead seat), matching the "signaler, never actuator"
+    doctrine of scripts/arsenal_probe.py.
+    """
+    binp = _resolve_kimi_bin()
+    if not binp:
+        logger.warning("kimi_client.probe: kimi binary not found")
+        return False
+    try:
+        result = subprocess.run(
+            [binp, "-m", DEFAULT_MODEL, "-p", PONG_PROMPT],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("kimi_client.probe: subprocess failed: %s", exc)
+        return False
+    return "PONG" in result.stdout
+
+
+def run(
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+    timeout: float = 300.0,
+    cwd: str | None = None,
+) -> str:
+    """Run ``prompt`` through the ``kimi`` CLI, return stdout.
+
+    Raises RuntimeError (with a stderr excerpt) on a missing binary, a
+    non-zero exit, or a timeout — the caller decides how to degrade (e.g. a
+    cascade fallback treats this as a dead seat, never a crash of the whole
+    run).
+    """
+    binp = _resolve_kimi_bin()
+    if not binp:
+        raise RuntimeError("kimi binary not found (KIMI_BIN unset, ~/.kimi-code/bin/kimi absent, not on PATH)")
+    try:
+        result = subprocess.run(
+            [binp, "-m", model, "-p", prompt],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+            cwd=cwd,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stderr_excerpt = (exc.stderr or b"")
+        if isinstance(stderr_excerpt, bytes):
+            stderr_excerpt = stderr_excerpt.decode(errors="replace")
+        raise RuntimeError(f"kimi run timed out after {timeout}s: {stderr_excerpt[:500]}") from exc
+    except OSError as exc:
+        raise RuntimeError(f"kimi run failed to start: {exc}") from exc
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"kimi run exited {result.returncode}: {result.stderr.strip()[:500]}"
+        )
+    return result.stdout
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[2] if __doc__ else "kimi_client")
+    ap.add_argument("--probe", action="store_true", help="one-shot PONG liveness probe")
+    ap.add_argument("--model", default=DEFAULT_MODEL, help=f"model slug (default: {DEFAULT_MODEL})")
+    ap.add_argument("prompt", nargs="?", help="prompt to send (required unless --probe)")
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+    args = _parse_args(argv)
+
+    if args.probe:
+        ok = probe()
+        print("LIVE" if ok else "DEAD")
+        return 0 if ok else 1
+
+    if not args.prompt:
+        print("kimi_client: error: prompt is required unless --probe", file=sys.stderr)
+        return 2
+
+    try:
+        output = run(args.prompt, model=args.model)
+    except RuntimeError as exc:
+        print(f"kimi_client: error: {exc}", file=sys.stderr)
+        return 1
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_cost_breaker.py
+++ b/scripts/test_cost_breaker.py
@@ -9,10 +9,15 @@ Each test names the gate it falsifies. The gates (from the P9 spec):
   G2  spend in [threshold, budget) -> DEGRADE returns next tier (not STOP,
       not blind-continue).
   G3  STOP push is a CHOICE ([D]/[P]/[C]), not a bare diagnosis.
-  G6  every cascade provider in {claude_oauth, gemini, deepseek} has a
-      breaker threshold (no provider unguarded).
+  G6  every cascade provider in {claude_oauth, gemini, openrouter} has a
+      breaker threshold (no PAID provider unguarded). kimi and ollama are
+      intentionally excluded — flat-subscription / local, zero marginal cost.
 Plus: window-sum correctness with injected fake rows (provider isolation),
 next_tier cascade order + terminal None, and import-purity.
+
+DeepSeek V4 Pro API RETIRED 2026-07-19 (owner order, pre-auth revoked — never
+top up). Its replacement seat in the cascade is Kimi (flat Allegro
+subscription, unguarded like ollama — see cost_breaker.py CASCADE_ORDER).
 """
 
 from __future__ import annotations
@@ -50,11 +55,13 @@ class _SpyPush:
 @pytest.fixture()
 def config() -> cb.BreakerConfig:
     # Deterministic config independent of env: budget 10, threshold 85% = 8.5.
+    # Third provider is openrouter (the real third GUARDED tier post-DeepSeek
+    # retirement) — not kimi, which is intentionally unguarded (flat sub).
     return cb.BreakerConfig(
         budgets_usd={
             "claude_oauth": Decimal("10.00"),
             "gemini": Decimal("10.00"),
-            "deepseek": Decimal("10.00"),
+            "openrouter": Decimal("10.00"),
         },
         threshold_fraction=Decimal("0.85"),
         window_seconds=24 * 60 * 60,
@@ -99,7 +106,7 @@ def test_g2_degrade_returns_next_tier(config: cb.BreakerConfig) -> None:
 
 def test_g2_degrade_exactly_at_threshold(config: cb.BreakerConfig) -> None:
     # spend == threshold (8.50) -> DEGRADE (inclusive lower bound)
-    verdict = cb.evaluate("deepseek", Decimal("8.50"), config)
+    verdict = cb.evaluate("openrouter", Decimal("8.50"), config)
     assert verdict is cb.Verdict.DEGRADE
 
 
@@ -120,7 +127,7 @@ def test_g3_stop_pushes_a_choice(config: cb.BreakerConfig) -> None:
     spy = _SpyPush()
     # spend 10.00 >= budget 10.00 -> STOP. cooldown_sec=0 keeps the test
     # deterministic + writes no state file (P2-1 cooldown is off here).
-    decision = cb.decide("deepseek", Decimal("10.00"), config, push=spy, cooldown_sec=0)
+    decision = cb.decide("openrouter", Decimal("10.00"), config, push=spy, cooldown_sec=0)
     assert decision.verdict is cb.Verdict.STOP
     assert len(spy.calls) == 1, "STOP must push exactly once"
     msg = spy.calls[0]
@@ -132,7 +139,7 @@ def test_g3_stop_pushes_a_choice(config: cb.BreakerConfig) -> None:
 
 def test_g3_diagnosis_only_message_is_rejected(config: cb.BreakerConfig) -> None:
     # Falsifier: a message with the spend but NO options must fail the G3 check.
-    diagnosis_only = "budget deepseek exhausted: spend $10.00 / $10.00 in 24h."
+    diagnosis_only = "budget openrouter exhausted: spend $10.00 / $10.00 in 24h."
     has_options = all(opt in diagnosis_only for opt in ("[D]", "[P]", "[C]"))
     assert not has_options, "a diagnosis-only message must NOT pass the choice gate"
 
@@ -152,15 +159,17 @@ def test_g3_build_stop_message_directly(config: cb.BreakerConfig) -> None:
 
 def test_g6_every_guarded_provider_has_threshold() -> None:
     config = cb.BreakerConfig.from_env(env={})  # pure defaults
-    for provider in ("claude_oauth", "gemini", "deepseek"):
+    for provider in ("claude_oauth", "gemini", "openrouter"):
         assert config.budget_for(provider) is not None, f"{provider} has no budget (G6)"
         assert config.threshold_for(provider) is not None, f"{provider} has no threshold (G6)"
         assert config.budget_for(provider) > 0
 
 
 def test_g6_guarded_set_covers_paid_cascade_tiers() -> None:
-    # Every cascade tier that costs money must be in the guarded set.
-    paid_tiers = [t for t in cb.CASCADE_ORDER if t != "ollama"]
+    # Every cascade tier that costs real money must be in the guarded set.
+    # ollama (local) and kimi (flat Allegro subscription) are both zero
+    # marginal cost by design — neither is a "paid tier" here.
+    paid_tiers = [t for t in cb.CASCADE_ORDER if t not in ("ollama", "kimi")]
     for tier in paid_tiers:
         assert tier in cb.GUARDED_PROVIDERS, f"paid tier {tier} is unguarded (G6)"
 
@@ -170,6 +179,24 @@ def test_g6_ollama_is_unguarded_and_always_allows() -> None:
     config = cb.BreakerConfig.from_env(env={})
     assert config.budget_for("ollama") is None
     assert cb.evaluate("ollama", Decimal("9999"), config) is cb.Verdict.ALLOW
+
+
+def test_g6_kimi_is_unguarded_and_always_allows() -> None:
+    # kimi is a flat-subscription seat (Moonshot Allegro plan) — zero
+    # marginal cost, same posture as ollama; intentionally unguarded.
+    config = cb.BreakerConfig.from_env(env={})
+    assert config.budget_for("kimi") is None
+    assert cb.evaluate("kimi", Decimal("9999"), config) is cb.Verdict.ALLOW
+
+
+def test_deepseek_retired_not_in_cascade_or_guarded() -> None:
+    # DeepSeek V4 Pro API RETIRED 2026-07-19 (owner order, pre-auth revoked —
+    # never top up). Guilt-style: it must not resurface anywhere in the live
+    # cascade topology.
+    assert "deepseek" not in cb.CASCADE_ORDER
+    assert "deepseek" not in cb.GUARDED_PROVIDERS
+    assert "deepseek" not in cb._DEFAULT_BUDGET_USD
+    assert cb.next_tier("deepseek") is None
 
 
 # ---------------------------------------------------------------------------
@@ -201,10 +228,10 @@ def test_window_sum_excludes_rows_before_window() -> None:
     now = datetime(2026, 6, 8, 12, 0, 0, tzinfo=timezone.utc)
     start = now - timedelta(hours=24)
     rows = [
-        _row("deepseek", "1.00", now - timedelta(hours=1)),  # in window
-        _row("deepseek", "9.99", now - timedelta(hours=48)),  # too old
+        _row("kimi", "1.00", now - timedelta(hours=1)),  # in window
+        _row("kimi", "9.99", now - timedelta(hours=48)),  # too old
     ]
-    total = cb.sum_rows_in_window(rows, "deepseek", start)
+    total = cb.sum_rows_in_window(rows, "kimi", start)
     assert total == Decimal("1.00"), "rows older than the window must be excluded"
 
 
@@ -239,12 +266,14 @@ def test_window_sum_skips_malformed_rows() -> None:
 
 
 def test_next_tier_cascade_order() -> None:
-    # openrouter (paid per-token, no flat sub) is the last PAID tier before the
-    # free floor (P0-2), so the cascade is now
-    # claude_oauth -> gemini -> deepseek -> openrouter -> ollama.
+    # kimi (flat Allegro subscription, unguarded — replaces the retired
+    # DeepSeek leg 2026-07-19) sits between gemini and openrouter. openrouter
+    # (paid per-token, no flat sub) is the last PAID tier before the free
+    # floor (P0-2), so the cascade is now
+    # claude_oauth -> gemini -> kimi -> openrouter -> ollama.
     assert cb.next_tier("claude_oauth") == "gemini"
-    assert cb.next_tier("gemini") == "deepseek"
-    assert cb.next_tier("deepseek") == "openrouter"
+    assert cb.next_tier("gemini") == "kimi"
+    assert cb.next_tier("kimi") == "openrouter"
     assert cb.next_tier("openrouter") == "ollama"
 
 
@@ -318,7 +347,7 @@ def test_jsonl_fallback_reads_real_file(tmp_path: Path) -> None:
     f.write_text(
         "\n".join(
             [
-                f'{{"provider": "deepseek", "cost_usd": 1.5, "ts_utc": "{now.isoformat()}"}}',
+                f'{{"provider": "kimi", "cost_usd": 1.5, "ts_utc": "{now.isoformat()}"}}',
                 f'{{"provider": "gemini", "cost_usd": 9.0, "ts_utc": "{now.isoformat()}"}}',
                 "not json at all",  # malformed line must be skipped
             ],
@@ -326,7 +355,7 @@ def test_jsonl_fallback_reads_real_file(tmp_path: Path) -> None:
     )
     total = asyncio.run(
         cb.provider_spend_in_window(
-            "deepseek", 3600, jsonl_root=tmp_path, now=now,
+            "kimi", 3600, jsonl_root=tmp_path, now=now,
         ),
     )
     assert total == Decimal("1.5")
@@ -407,7 +436,7 @@ def test_p0_1_empty_but_read_source_is_known_zero_allows(config: cb.BreakerConfi
     day = now.date().isoformat()
     f = tmp_path / f"llm_cost_log.{day}.jsonl"
     f.write_text(  # a row for a DIFFERENT provider — gemini has zero, but read
-        f'{{"provider": "deepseek", "cost_usd": 1.0, "ts_utc": "{now.isoformat()}"}}\n',
+        f'{{"provider": "kimi", "cost_usd": 1.0, "ts_utc": "{now.isoformat()}"}}\n',
     )
     spend = asyncio.run(
         cb.provider_spend_in_window("gemini", 3600, jsonl_root=tmp_path, now=now),
@@ -423,11 +452,11 @@ def test_p0_1_db_zero_is_known_zero_not_unknown(config: cb.BreakerConfig) -> Non
     # A successful DB read returning 0 is KNOWN zero -> Decimal(0) -> ALLOW.
     conn = _FakeConn(0)
     spend = asyncio.run(
-        cb.provider_spend_in_window("deepseek", 3600, conn_or_pool=conn),
+        cb.provider_spend_in_window("openrouter", 3600, conn_or_pool=conn),
     )
     assert spend == Decimal("0")
     assert spend is not None
-    assert cb.evaluate("deepseek", spend, config) is cb.Verdict.ALLOW
+    assert cb.evaluate("openrouter", spend, config) is cb.Verdict.ALLOW
 
 
 def test_p0_1_unguarded_provider_unknown_still_allows(config: cb.BreakerConfig) -> None:
@@ -481,16 +510,16 @@ def test_p0_2_gemini_flash_counts_toward_gemini() -> None:
     rows = [
         _row("gemini-flash", "2.00", now - timedelta(hours=1)),
         _row("gemini-2.0", "3.00", now - timedelta(hours=2)),
-        _row("deepseek-v4-pro", "9.00", now - timedelta(hours=1)),  # not gemini
+        _row("kimi-code/k3", "9.00", now - timedelta(hours=1)),  # not gemini
     ]
     total = cb.sum_rows_in_window(rows, "gemini", start, now)
     assert total == Decimal("5.00"), "model-suffixed gemini variants fold onto gemini"
 
 
-def test_p0_2_deepseek_suffix_folds() -> None:
-    assert cb._normalize_provider("deepseek-v4-pro") == "deepseek"
-    assert cb._normalize_provider("deepseek-v4-flash") == "deepseek"
-    assert cb._normalize_provider("DeepSeek") == "deepseek"
+def test_p0_2_kimi_suffix_folds() -> None:
+    assert cb._normalize_provider("kimi-code/k3") == "kimi"
+    assert cb._normalize_provider("kimi-for-coding") == "kimi"
+    assert cb._normalize_provider("Kimi") == "kimi"
 
 
 def test_p0_2_openrouter_is_guarded_not_auto_allow() -> None:
@@ -570,10 +599,10 @@ def test_p1_2_future_dated_row_excluded_jsonl() -> None:
     now = datetime(2026, 6, 8, 12, 0, 0, tzinfo=timezone.utc)
     start = now - timedelta(hours=24)
     rows = [
-        _row("deepseek", "1.00", now - timedelta(hours=1)),  # in window
-        _row("deepseek", "99.00", now + timedelta(hours=1)),  # FUTURE — excluded
+        _row("kimi", "1.00", now - timedelta(hours=1)),  # in window
+        _row("kimi", "99.00", now + timedelta(hours=1)),  # FUTURE — excluded
     ]
-    total = cb.sum_rows_in_window(rows, "deepseek", start, now)
+    total = cb.sum_rows_in_window(rows, "kimi", start, now)
     assert total == Decimal("1.00"), "a future-dated row must not inflate spend (P1-2)"
 
 
@@ -599,11 +628,11 @@ def test_p1_3_inf_and_negative_cost_skipped() -> None:
     now = datetime(2026, 6, 8, 12, 0, 0, tzinfo=timezone.utc)
     start = now - timedelta(hours=24)
     rows = [
-        _row("deepseek", "Infinity", now - timedelta(hours=1)),  # skipped
-        _row("deepseek", "-5.00", now - timedelta(hours=2)),  # negative skipped
-        _row("deepseek", "4.00", now - timedelta(hours=3)),
+        _row("kimi", "Infinity", now - timedelta(hours=1)),  # skipped
+        _row("kimi", "-5.00", now - timedelta(hours=2)),  # negative skipped
+        _row("kimi", "4.00", now - timedelta(hours=3)),
     ]
-    total = cb.sum_rows_in_window(rows, "deepseek", start, now)
+    total = cb.sum_rows_in_window(rows, "kimi", start, now)
     assert total == Decimal("4.00")
 
 
@@ -625,23 +654,23 @@ def test_p1_3_nan_does_not_flip_verdict_to_allow(config: cb.BreakerConfig) -> No
     now = datetime(2026, 6, 8, 12, 0, 0, tzinfo=timezone.utc)
     start = now - timedelta(hours=24)
     rows = [
-        _row("deepseek", "12.00", now - timedelta(hours=1)),
-        _row("deepseek", "NaN", now - timedelta(hours=2)),
+        _row("openrouter", "12.00", now - timedelta(hours=1)),
+        _row("openrouter", "NaN", now - timedelta(hours=2)),
     ]
-    total = cb.sum_rows_in_window(rows, "deepseek", start, now)
-    assert cb.evaluate("deepseek", total, config) is cb.Verdict.STOP
+    total = cb.sum_rows_in_window(rows, "openrouter", start, now)
+    assert cb.evaluate("openrouter", total, config) is cb.Verdict.STOP
 
 
 def test_p1_3_zero_budget_config_is_unguarded_no_stop_spam() -> None:
     # A directly-constructed budget=0 must NOT STOP at every spend (STOP-spam);
     # zero budget = unguarded = ALLOW.
     cfg = cb.BreakerConfig(
-        budgets_usd={"deepseek": Decimal("0")},
+        budgets_usd={"openrouter": Decimal("0")},
         threshold_fraction=Decimal("0.85"),
         window_seconds=3600,
     )
-    assert cfg.budget_for("deepseek") is None
-    assert cb.evaluate("deepseek", Decimal("100"), cfg) is cb.Verdict.ALLOW
+    assert cfg.budget_for("openrouter") is None
+    assert cb.evaluate("openrouter", Decimal("100"), cfg) is cb.Verdict.ALLOW
 
 
 # ---------------------------------------------------------------------------
@@ -654,17 +683,17 @@ def test_p2_1_stop_push_suppressed_within_cooldown(config: cb.BreakerConfig, tmp
     monkeypatch.setattr(cb, "_COOLDOWN_STATE_DIR", tmp_path)
     spy = _SpyPush()
     # First STOP fires + sets cooldown.
-    cb.decide("deepseek", Decimal("10.00"), config, push=spy, cooldown_sec=3600)
+    cb.decide("openrouter", Decimal("10.00"), config, push=spy, cooldown_sec=3600)
     assert len(spy.calls) == 1, "first STOP must push"
     # Second STOP within cooldown is suppressed.
-    cb.decide("deepseek", Decimal("10.00"), config, push=spy, cooldown_sec=3600)
+    cb.decide("openrouter", Decimal("10.00"), config, push=spy, cooldown_sec=3600)
     assert len(spy.calls) == 1, "duplicate STOP within cooldown must be suppressed (P2-1)"
 
 
 def test_p2_1_cooldown_is_per_provider(config: cb.BreakerConfig, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cb, "_COOLDOWN_STATE_DIR", tmp_path)
     spy = _SpyPush()
-    cb.decide("deepseek", Decimal("10.00"), config, push=spy, cooldown_sec=3600)
+    cb.decide("openrouter", Decimal("10.00"), config, push=spy, cooldown_sec=3600)
     cb.decide("gemini", Decimal("10.00"), config, push=spy, cooldown_sec=3600)
     assert len(spy.calls) == 2, "a different provider has its own cooldown"
 
@@ -672,8 +701,8 @@ def test_p2_1_cooldown_is_per_provider(config: cb.BreakerConfig, tmp_path: Path,
 def test_p2_1_cooldown_zero_disables(config: cb.BreakerConfig, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cb, "_COOLDOWN_STATE_DIR", tmp_path)
     spy = _SpyPush()
-    cb.decide("deepseek", Decimal("10.00"), config, push=spy, cooldown_sec=0)
-    cb.decide("deepseek", Decimal("10.00"), config, push=spy, cooldown_sec=0)
+    cb.decide("openrouter", Decimal("10.00"), config, push=spy, cooldown_sec=0)
+    cb.decide("openrouter", Decimal("10.00"), config, push=spy, cooldown_sec=0)
     assert len(spy.calls) == 2, "cooldown_sec=0 must not suppress (every STOP pushes)"
 
 

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -577,25 +577,15 @@ def test_probe_codex_401_is_auth_dead(monkeypatch):
     assert status == ap.AUTH_DEAD
 
 
-def test_probe_deepseek_cred_unavailable_when_env_master_missing(monkeypatch):
-    monkeypatch.setattr(ap, "load_env_master_key", lambda var, path="~/x": (None, "not found"))
-    status, ev, latency = ap.probe_deepseek(timeout=5)
-    assert status == ap.CRED_UNAVAILABLE
-    assert ap.is_strict_fail(status) is False
-
-
-def test_probe_deepseek_live_on_200(monkeypatch):
-    monkeypatch.setattr(ap, "load_env_master_key", lambda var, path="~/x": ("key123456789012345678", None))
-    monkeypatch.setattr(ap, "http_post_json", lambda *a, **kw: (200, "ok"))
-    status, ev, latency = ap.probe_deepseek(timeout=5)
-    assert status == ap.LIVE
-
-
-def test_probe_deepseek_402_is_balance_dead(monkeypatch):
-    monkeypatch.setattr(ap, "load_env_master_key", lambda var, path="~/x": ("key123456789012345678", None))
-    monkeypatch.setattr(ap, "http_post_json", lambda *a, **kw: (402, "Insufficient Balance"))
-    status, ev, latency = ap.probe_deepseek(timeout=5)
-    assert status == ap.BALANCE_DEAD
+def test_deepseek_retired_not_in_all_seats_or_probe_funcs():
+    # DeepSeek V4 Pro API retired 2026-07-19 (owner order, pre-auth revoked —
+    # never top up). Guilt-style: it must not resurface as a probeable seat.
+    assert "deepseek" not in ap.ALL_SEATS
+    assert "deepseek" not in ap.PROBE_FUNCS
+    assert "deepseek" not in ap.DEFAULT_TIMEOUTS
+    assert not hasattr(ap, "probe_deepseek")
+    for machine, seats in ap.REQUIRED_SEATS.items():
+        assert "deepseek" not in seats, f"deepseek still required on {machine}"
 
 
 def test_probe_ollama_qwen_listed_is_live(monkeypatch):

--- a/scripts/tests/test_kimi_client.py
+++ b/scripts/tests/test_kimi_client.py
@@ -1,0 +1,274 @@
+"""Tests for scripts/kimi_client.py — headless Kimi K3 CLI wrapper.
+
+Module is imported via importlib.util.spec_from_file_location (not a package
+import) because scripts/ is a flat bag of standalone tools, not a Python
+package (mirrors scripts/tests/test_arsenal_probe.py).
+
+NO real subprocess/network calls anywhere in this file — every subprocess
+boundary is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "kimi_client.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("kimi_client", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+kc = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Default model — guilt test (the cascade wiring elsewhere assumes this slug)
+# ---------------------------------------------------------------------------
+
+
+def test_default_model_is_kimi_code_k3():
+    assert kc.DEFAULT_MODEL == "kimi-code/k3"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_kimi_bin — KIMI_BIN env override
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_kimi_bin_env_override_respected(monkeypatch, tmp_path):
+    custom = tmp_path / "kimi-custom"
+    custom.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("KIMI_BIN", str(custom))
+    assert kc._resolve_kimi_bin() == str(custom)
+
+
+def test_resolve_kimi_bin_dangling_env_override_falls_through(monkeypatch, tmp_path):
+    # GLM R1 2026-07-19: a dangling override must not shadow a working install.
+    monkeypatch.setenv("KIMI_BIN", "/custom/path/that/does/not/exist")
+    fake_default = tmp_path / "kimi"
+    fake_default.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(kc, "_KIMI_BIN_DEFAULT", str(fake_default))
+    assert kc._resolve_kimi_bin() == str(fake_default)
+
+
+def test_resolve_kimi_bin_falls_back_to_default_path(monkeypatch, tmp_path):
+    monkeypatch.delenv("KIMI_BIN", raising=False)
+    fake_default = tmp_path / "kimi"
+    fake_default.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(kc, "_KIMI_BIN_DEFAULT", str(fake_default))
+    assert kc._resolve_kimi_bin() == str(fake_default)
+
+
+def test_resolve_kimi_bin_falls_back_to_path_lookup(monkeypatch):
+    monkeypatch.delenv("KIMI_BIN", raising=False)
+    monkeypatch.setattr(kc, "_KIMI_BIN_DEFAULT", "/does/not/exist/kimi")
+    monkeypatch.setattr(kc.shutil, "which", lambda name: "/opt/homebrew/bin/kimi" if name == "kimi" else None)
+    assert kc._resolve_kimi_bin() == "/opt/homebrew/bin/kimi"
+
+
+def test_resolve_kimi_bin_none_when_nothing_found(monkeypatch):
+    monkeypatch.delenv("KIMI_BIN", raising=False)
+    monkeypatch.setattr(kc, "_KIMI_BIN_DEFAULT", "/does/not/exist/kimi")
+    monkeypatch.setattr(kc.shutil, "which", lambda name: None)
+    assert kc._resolve_kimi_bin() is None
+
+
+# ---------------------------------------------------------------------------
+# probe() — success / failure, never raises
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_probe_success_returns_true(monkeypatch):
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", lambda cmd, **kwargs: _FakeCompleted(0, "PONG\n", ""))
+    assert kc.probe() is True
+
+
+def test_probe_missing_binary_returns_false(monkeypatch):
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: None)
+    assert kc.probe() is False
+
+
+def test_probe_non_pong_output_returns_false(monkeypatch):
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", lambda cmd, **kwargs: _FakeCompleted(1, "No providers configured.\n", ""))
+    assert kc.probe() is False
+
+
+def test_probe_timeout_returns_false_never_raises(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 60))
+
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+    assert kc.probe() is False
+
+
+def test_probe_oserror_returns_false_never_raises(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise OSError("no such file")
+
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+    assert kc.probe() is False
+
+
+def test_probe_uses_devnull_stdin(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return _FakeCompleted(0, "PONG\n", "")
+
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+    kc.probe()
+    assert captured.get("stdin") == kc.subprocess.DEVNULL
+
+
+# ---------------------------------------------------------------------------
+# run() — success, non-zero exit raises, timeout raises
+# ---------------------------------------------------------------------------
+
+
+def test_run_success_returns_stdout(monkeypatch):
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", lambda cmd, **kwargs: _FakeCompleted(0, "review output\n", ""))
+    out = kc.run("review this diff")
+    assert out == "review output\n"
+
+
+def test_run_passes_prompt_and_model_to_cli(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeCompleted(0, "ok\n", "")
+
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+    kc.run("hello world", model="kimi-code/kimi-for-coding")
+    cmd = captured["cmd"]
+    assert cmd[0] == "/fake/kimi"
+    assert "-m" in cmd and cmd[cmd.index("-m") + 1] == "kimi-code/kimi-for-coding"
+    assert "-p" in cmd and cmd[cmd.index("-p") + 1] == "hello world"
+
+
+def test_run_missing_binary_raises_runtime_error(monkeypatch):
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: None)
+    with pytest.raises(RuntimeError, match="kimi binary not found"):
+        kc.run("prompt")
+
+
+def test_run_non_zero_exit_raises_runtime_error_with_stderr_excerpt(monkeypatch):
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", lambda cmd, **kwargs: _FakeCompleted(1, "", "boom: bad prompt"))
+    with pytest.raises(RuntimeError, match="boom: bad prompt"):
+        kc.run("prompt")
+
+
+def test_run_timeout_raises_runtime_error(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 300))
+
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="timed out"):
+        kc.run("prompt")
+
+
+def test_run_oserror_raises_runtime_error(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="failed to start"):
+        kc.run("prompt")
+
+
+def test_run_uses_devnull_stdin(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return _FakeCompleted(0, "ok\n", "")
+
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+    kc.run("prompt")
+    assert captured.get("stdin") == kc.subprocess.DEVNULL
+
+
+def test_run_passes_cwd_through(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return _FakeCompleted(0, "ok\n", "")
+
+    monkeypatch.setattr(kc, "_resolve_kimi_bin", lambda: "/fake/kimi")
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+    kc.run("prompt", cwd="/some/worktree")
+    assert captured.get("cwd") == "/some/worktree"
+
+
+# ---------------------------------------------------------------------------
+# CLI main() — --probe and prompt paths
+# ---------------------------------------------------------------------------
+
+
+def test_main_probe_flag_live_exits_0(monkeypatch, capsys):
+    monkeypatch.setattr(kc, "probe", lambda: True)
+    code = kc.main(["--probe"])
+    assert code == 0
+    assert "LIVE" in capsys.readouterr().out
+
+
+def test_main_probe_flag_dead_exits_1(monkeypatch, capsys):
+    monkeypatch.setattr(kc, "probe", lambda: False)
+    code = kc.main(["--probe"])
+    assert code == 1
+    assert "DEAD" in capsys.readouterr().out
+
+
+def test_main_no_prompt_no_probe_exits_2(capsys):
+    code = kc.main([])
+    assert code == 2
+    assert "prompt is required" in capsys.readouterr().err
+
+
+def test_main_prompt_runs_and_prints_output(monkeypatch, capsys):
+    monkeypatch.setattr(kc, "run", lambda prompt, model=kc.DEFAULT_MODEL: "the answer\n")
+    code = kc.main(["hello"])
+    assert code == 0
+    assert "the answer" in capsys.readouterr().out
+
+
+def test_main_run_failure_exits_1(monkeypatch, capsys):
+    def fake_run(prompt, model=kc.DEFAULT_MODEL):
+        raise RuntimeError("kimi exploded")
+
+    monkeypatch.setattr(kc, "run", fake_run)
+    code = kc.main(["hello"])
+    assert code == 1
+    assert "kimi exploded" in capsys.readouterr().err


### PR DESCRIPTION
## What

Cascade-debt fix after the DeepSeek retirement (Zero's order 2026-07-19): three scripts still routed to the dead seat. The tri-LLM review gate is back to 3/3 live seats.

- `scripts/arsenal_probe.py` — deepseek removed from ALL_SEATS / REQUIRED_SEATS[pro] / TIMEOUTS / PROBE_FUNCS. The `:708` deepseek-402 classify fixture is KEPT deliberately (it documents the retirement signature).
- `scripts/codex_tri_llm_review.py` — `review_deepseek` → `async def review_kimi` (subprocess, W64-aware: dead seat = error verdict, never a red vote). New `_communicate_or_kill(proc, timeout)` helper applied to ALL 3 panel legs — cures the orphan-on-timeout class (`asyncio.wait_for(proc.communicate())` cancels the coroutine but never kills the child; found by GLM R1, confirmed on all legs).
- `scripts/cost_breaker.py` — CASCADE_ORDER: claude_oauth → gemini → kimi → openrouter → ollama.
- **NEW `scripts/kimi_client.py`** — stdlib-only wrapper (KIMI_BIN env → `~/.kimi-code/bin/kimi` → PATH, dangling-override fall-through; `probe()`/`run()`/CLI). Chinese-cloud PII HARD RULE in the docstring: prompts never carry client PII.
- **NEW `scripts/tests/test_kimi_client.py`** (25 tests) + fixtures aligned in `test_cost_breaker.py` / `test_arsenal_probe.py`. 238/238 pass.

## Twin declaration (TRACK GUARDIANI overlap)

This branch touches `scripts/arsenal_probe.py`, which is a monitoring-plane surface in the Pro twin's TRACK GUARDIANI round. **This is pre-mandate work** (started before the Twin-Fable split) and is limited to the deepseek seat removal; declared in the PENDING-ARMS claim line of PR #2832.

## Review

GLM 5.2 first-call R1 (real run): found the orphan-on-timeout bug (fixed class-wide) + the dangling-KIMI_BIN edge (guilt test added). Verdicts re-probed on disk (W65).

## Gate note

First push rejected by the pre-push full suite on 2 contention flakes (subprocess TimeoutExpired + perf-timing test, load 23/10core); both pass in isolation (2/2, 9.7s) and are untouched by this diff. Re-pushed at load <8: full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)