### PR TITLE
fix(rag): record llm cost events for gateway raw generate_content calls

### DIFF
--- a/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
+++ b/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
@@ -1016,9 +1016,7 @@ Return ONLY valid JSON, no markdown."""
                         from google import genai
 
                         creds_json = settings.google_credentials_json
-                        project_id = os.environ.get(
-                            "GOOGLE_PROJECT_ID", "gen-lang-client-0498009027"
-                        )
+                        project_id = os.environ.get("GOOGLE_PROJECT_ID", "nuzantara")
                         location = os.environ.get("GOOGLE_LOCATION", "us-central1")
 
                         if creds_json:

--- a/apps/backend-rag/backend/services/rag/agentic/llm_gateway.py
+++ b/apps/backend-rag/backend/services/rag/agentic/llm_gateway.py
@@ -733,6 +733,7 @@ class LLMGateway:
                 contents.append({"role": "user", "parts": current_content_parts})
 
             # 3. Call model with full history (with timeout to avoid hang)
+            _llm_call_t0 = time.perf_counter()
             response = await asyncio.wait_for(
                 client._client.aio.models.generate_content(
                     model=model_name,
@@ -788,6 +789,31 @@ class LLMGateway:
                     getattr(response.usage_metadata, "candidates_token_count", 0) or 0
                 )
 
+            # Indestructible cost ledger (see
+            # backend/services/observability/llm_cost_recorder.py). This call
+            # goes straight to the raw SDK (client._client.aio.models.
+            # generate_content) instead of GenAIClient.generate_content(), so
+            # it bypasses that method's own recording — record here to avoid
+            # undercounting the llm_cost_events ledger. Fail-open: recorder
+            # errors never break the chat response.
+            try:
+                from backend.services.llm_clients.pricing import calculate_cost
+                from backend.services.observability import record_llm_call
+
+                cost_usd = calculate_cost(prompt_tokens, completion_tokens, model_name)
+                await record_llm_call(
+                    provider="gemini",
+                    model=model_name,
+                    input_tokens=prompt_tokens,
+                    output_tokens=completion_tokens,
+                    cost_usd=cost_usd,
+                    success=True,
+                    latency_ms=round((time.perf_counter() - _llm_call_t0) * 1000),
+                    endpoint="rag.gateway.chat",
+                )
+            except Exception as rec_exc:
+                logger.warning("llm_cost recorder failed for gateway: %s", rec_exc)
+
             token_usage = create_token_usage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
@@ -816,6 +842,7 @@ class LLMGateway:
             if has_images:
                 logger.info(f"🖼️ Vision mode: sending {len(images)} images to {model_name}")
 
+            _llm_call_t0 = time.perf_counter()
             response = await asyncio.wait_for(
                 client._client.aio.models.generate_content(
                     model=model_name,
@@ -833,6 +860,28 @@ class LLMGateway:
                 completion_tokens = (
                     getattr(response.usage_metadata, "candidates_token_count", 0) or 0
                 )
+
+            # Indestructible cost ledger (see
+            # backend/services/observability/llm_cost_recorder.py). Same raw
+            # SDK bypass as the chat-history branch above — record here so
+            # the llm_cost_events ledger doesn't undercount. Fail-open.
+            try:
+                from backend.services.llm_clients.pricing import calculate_cost
+                from backend.services.observability import record_llm_call
+
+                cost_usd = calculate_cost(prompt_tokens, completion_tokens, model_name)
+                await record_llm_call(
+                    provider="gemini",
+                    model=model_name,
+                    input_tokens=prompt_tokens,
+                    output_tokens=completion_tokens,
+                    cost_usd=cost_usd,
+                    success=True,
+                    latency_ms=round((time.perf_counter() - _llm_call_t0) * 1000),
+                    endpoint="rag.gateway.chat",
+                )
+            except Exception as rec_exc:
+                logger.warning("llm_cost recorder failed for gateway: %s", rec_exc)
 
             token_usage = create_token_usage(
                 prompt_tokens=prompt_tokens,

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_llm_gateway_cost_recorder.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_llm_gateway_cost_recorder.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for the llm_cost_events recording added to LLMGateway._call_model().
+
+Context: LLMGateway._call_model() calls the raw google-genai SDK directly
+(``client._client.aio.models.generate_content``) instead of going through
+``GenAIClient.generate_content()``, so it historically bypassed
+``record_llm_call`` entirely — the Postgres ``llm_cost_events`` ledger
+undercounted real Gemini traffic (~3x, verified against AI Studio usage
+2026-07-17/19: 182 real gemini-3.5-flash requests vs 66 recorded).
+
+These tests cover both raw call sites inside ``_call_model``:
+- the chat-history branch (``chat`` has a ``.history`` attribute)
+- the fallback/no-history branch (``chat`` is ``None``)
+
+and assert the fail-open contract: a recorder exception must never break
+the chat response.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.rag.agentic.llm_gateway import LLMGateway
+
+
+def _make_fake_response(prompt_tokens: int = 42, completion_tokens: int = 7) -> SimpleNamespace:
+    """Build a fake google-genai response with usage_metadata + text."""
+    return SimpleNamespace(
+        text="Hello from Gemini",
+        candidates=[],
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=prompt_tokens,
+            candidates_token_count=completion_tokens,
+        ),
+    )
+
+
+@pytest.fixture
+def gateway_with_raw_client():
+    """LLMGateway whose genai client exposes the raw SDK call path used by
+    _call_model (client._client.aio.models.generate_content)."""
+    with patch("backend.services.rag.agentic.llm_gateway.get_genai_client") as mock_get:
+        mock_client = MagicMock()
+        mock_client.is_available = True
+        mock_client._client.aio.models.generate_content = AsyncMock(
+            return_value=_make_fake_response(),
+        )
+        mock_get.return_value = mock_client
+        gw = LLMGateway()
+        gw._available = True
+        yield gw, mock_client
+
+
+class TestCallModelRecordsCost:
+    @pytest.mark.asyncio
+    async def test_fallback_branch_records_llm_call_once(self, gateway_with_raw_client):
+        """chat=None takes the 'Fallback: Build content directly' branch
+        (~line 820) — must record exactly once with real token counts."""
+        gateway, _mock_client = gateway_with_raw_client
+
+        with patch(
+            "backend.services.observability.record_llm_call",
+            new_callable=AsyncMock,
+        ) as mock_record:
+            text, response, usage = await gateway._call_model(
+                "gemini-3-flash",
+                with_tools=False,
+                chat=None,
+                message="hi",
+                images=None,
+            )
+
+        assert text == "Hello from Gemini"
+        mock_record.assert_awaited_once()
+        call_kwargs = mock_record.call_args.kwargs
+        assert call_kwargs["provider"] == "gemini"
+        assert call_kwargs["model"] == "gemini-3-flash"
+        assert call_kwargs["input_tokens"] == 42
+        assert call_kwargs["output_tokens"] == 7
+        assert call_kwargs["success"] is True
+        assert call_kwargs["endpoint"] == "rag.gateway.chat"
+        assert call_kwargs["cost_usd"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_chat_history_branch_records_llm_call_once(self, gateway_with_raw_client):
+        """chat with a .history attribute takes the chat-session branch
+        (~line 737) — must also record exactly once."""
+        gateway, _mock_client = gateway_with_raw_client
+        chat = SimpleNamespace(history=[])
+
+        with patch(
+            "backend.services.observability.record_llm_call",
+            new_callable=AsyncMock,
+        ) as mock_record:
+            text, response, usage = await gateway._call_model(
+                "gemini-3-flash",
+                with_tools=False,
+                chat=chat,
+                message="hi",
+                images=None,
+            )
+
+        assert text == "Hello from Gemini"
+        mock_record.assert_awaited_once()
+        call_kwargs = mock_record.call_args.kwargs
+        assert call_kwargs["provider"] == "gemini"
+        assert call_kwargs["input_tokens"] == 42
+        assert call_kwargs["output_tokens"] == 7
+
+    @pytest.mark.asyncio
+    async def test_recorder_exception_does_not_break_response(self, gateway_with_raw_client):
+        """Fail-open: if record_llm_call raises, _call_model must still
+        return the real response instead of propagating the recorder error."""
+        gateway, _mock_client = gateway_with_raw_client
+
+        with patch(
+            "backend.services.observability.record_llm_call",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("db pool not initialised"),
+        ):
+            text, response, usage = await gateway._call_model(
+                "gemini-3-flash",
+                with_tools=False,
+                chat=None,
+                message="hi",
+                images=None,
+            )
+
+        assert text == "Hello from Gemini"
+        assert usage.prompt_tokens == 42
+        assert usage.completion_tokens == 7


### PR DESCRIPTION
## Summary

Fixes an LLM cost-event undercount in the agentic RAG gateway, plus a stale-config hygiene fix.

### Task 1 — cost ledger undercount (main fix)

`LLMGateway._call_model()` (`apps/backend-rag/backend/services/rag/agentic/llm_gateway.py`) calls the raw google-genai SDK directly at two sites — `client._client.aio.models.generate_content(...)` in the chat-history branch (~line 737) and the fallback/no-history branch (~line 820). Both bypass `GenAIClient.generate_content()` and therefore never call `record_llm_call`, so the Postgres `llm_cost_events` ledger has been undercounting real Gemini traffic.

**Evidence**: 182 real `gemini-3.5-flash` requests in AI Studio usage (2026-07-17 → 2026-07-19) vs 66 recorded in `llm_cost_events` — ~3x undercount.

**Fix**: mirror the existing fail-open cost-recording pattern from `genai_client.py`'s `generate_content()`/`generate_structured()` (lines ~424-443, ~609-629) at both raw call sites:
- Extract `prompt_tokens`/`completion_tokens` from `response.usage_metadata` (safe `getattr`, 0 fallback — matches the existing token-extraction code right above each new block).
- `cost_usd = calculate_cost(prompt_tokens, completion_tokens, model_name)`.
- `await record_llm_call(provider="gemini", model=model_name, ..., endpoint="rag.gateway.chat")`.
- Entire block wrapped in `try/except Exception: logger.warning(...)` — fail-open, cost tracking must never break a live chat response.

**Other call sites scanned**: went through `llm_gateway.py` and `chat_session.py` end-to-end. `ChatSession.send_message()` in `chat_session.py` (agentic) wraps the raw sync SDK chat object returned by `GenAIClient.start_chat()`, but it's dead code on the live path — `_call_model` only ever reads `chat.history` to build `contents` for the raw `generate_content` call; it never calls `chat.send_message()`. Confirmed via grep that every caller of `create_chat_with_history()` (kbli_notebook_chat.py, kbli_notebook.py, kg_orchestrator.py, orchestrator_core.py, orchestrator_streaming_core.py) only ever routes through `gateway.send_message()`.

**Found but NOT covered here** (out of scope, noted for follow-up): `genai_client.py::GenAIClient.generate_content_stream()` (~line 631) calls `self._client.aio.models.generate_content_stream(...)` directly and has **no** cost recording at all — no `usage_metadata` extraction, no `record_llm_call`. It's used by `ChatSession.send_message_stream()` (genai_client.py), which is in turn used by `zantara_ai_client.py` and `gemini_service.py` (`generate_response_stream`, Jaksel-style streaming path) — both look like live channel surfaces. Fixing this is non-trivial (needs to accumulate `usage_metadata` from the final stream chunk, which the current generator doesn't even capture) and out of scope for a minimal-diff PR — flagging for a follow-up.

### Task 2 — stale GCP project fallback (hygiene)

`apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py:1020` had a hardcoded fallback `"GOOGLE_PROJECT_ID", "gen-lang-client-0498009027"` for the Vertex AI genai client used in KG extraction. Verified today: no fleet account can access that project id — it's stale/orphaned. The real project backing the prod Gemini key is `nuzantara`. Changed the fallback default accordingly.

## Test plan

- [x] New focused unit test `backend/tests/unit/services/rag/agentic/test_llm_gateway_cost_recorder.py` (3 tests): fallback-branch call records `record_llm_call` once with `provider="gemini"` + nonzero token counts; chat-history-branch call does the same; a `record_llm_call` exception does NOT break the response (fail-open).
- [x] Ran full gateway regression suite alongside the new tests: `PYTHONPATH=. pytest backend/tests/services/rag/agentic/test_llm_gateway.py backend/tests/unit/services/rag/agentic/test_llm_gateway.py backend/tests/unit/services/rag/agentic/test_llm_gateway_comprehensive.py backend/tests/unit/services/rag/agentic/test_llm_gateway_cost_recorder.py -q` → **57 passed**.
- [x] CLAUDE.md pre-deploy import-chain check: `python -c "from backend.app.dependencies import get_current_user; print('OK')"` → OK.
- [x] CLAUDE.md pre-deploy core RAG regression: `PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py -q` → **91 passed**.

## Caveat found during this PR (unrelated to the diff)

The `.husky/pre-commit` Python-linting step shells out to a bare `ruff` on `$PATH` — but `ruff` is only installed inside `apps/backend-rag/.venv/bin/`, not on the ambient `$PATH` the git hook runs under. `xargs ruff check` fails with exit 127 ("command not found"), and because the pipeline redirects stderr to `/dev/null`, the hook misreports it as `❌ Python linting failed on staged files. Please fix ruff issues.` — a lie-red, not a real lint failure (ruff itself passes clean on the changed files when run from the venv). Worked around it locally by prepending the venv's `bin/` to `PATH` for the commit; not fixed in this PR since it's outside the assigned scope, but worth a follow-up (candidate cicatrix family #2 "Esiste ≠ Armato" — a guard that reports red for the wrong reason).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>