### PR TITLE
fix(kg): decouple cadence from lock TTL to end retry poisoning + isolate KG Gemini key

### DIFF
--- a/apps/backend-rag/backend/services/knowledge_graph/incremental_builder.py
+++ b/apps/backend-rag/backend/services/knowledge_graph/incremental_builder.py
@@ -5,6 +5,8 @@ Integrates with AutonomousScheduler for automatic incremental KG updates
 
 import asyncio
 import logging
+import os
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import asyncpg
@@ -139,7 +141,6 @@ class KGIncrementalBuilder:
 
         # Import incremental extractor
         try:
-            import os
             import sys
             from pathlib import Path
 
@@ -318,7 +319,6 @@ async def run_knowledge_graph_incremental_build(db_pool: asyncpg.Pool) -> dict[s
 async def _persist_kg_verdict(db_pool: asyncpg.Pool, stats: dict[str, Any]) -> None:
     """Upsert the last-run verdict so liveness is a DB probe, not a log grep."""
     import json
-    from datetime import datetime, timezone
 
     payload = {
         "ran_at": datetime.now(timezone.utc).isoformat(),
@@ -340,26 +340,109 @@ async def _persist_kg_verdict(db_pool: asyncpg.Pool, stats: dict[str, Any]) -> N
     )
 
 
-async def _kg_incremental_loop(db_pool: asyncpg.Pool, interval_seconds: int) -> None:
-    """Daily incremental KG extraction on the live path."""
-    from backend.services.misc.autonomous_scheduler import _acquire_task_lock
+async def _get_last_kg_run_ts(db_pool: asyncpg.Pool) -> datetime | None:
+    """Read the cadence-driving timestamp: when did a run last persist a verdict?
+
+    This is a plain DB read, deliberately decoupled from the Redis dedup
+    lock's TTL (root cause 2026-07-19: the lock TTL used to double as the
+    cadence signal — see module docstring above `_kg_incremental_loop`).
+    Returns None if no verdict has ever been persisted, or if the read
+    itself fails (fail-open: treated as "never ran" by the caller, same
+    fail-open philosophy as `_acquire_task_lock` on Redis errors).
+    """
+    try:
+        async with db_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT updated_at FROM system_settings WHERE key = 'kg_incremental_last'",
+            )
+            return row["updated_at"] if row else None
+    except Exception as e:
+        logger.error("[kg-incremental] failed to read last-run timestamp: %s", e)
+        return None
+
+
+async def _kg_incremental_tick(
+    db_pool: asyncpg.Pool,
+    interval_seconds: int,
+    lock_ttl_seconds: int,
+) -> None:
+    """One check-cycle: due? acquire the short dedup lock? run + persist + release.
+
+    Cadence ("has a run succeeded within the last `interval_seconds`?") is
+    driven by the `system_settings.kg_incremental_last.updated_at` DB
+    timestamp. The Redis lock only dedups concurrent workers during an
+    active run — it is released in a `finally` (compare-and-delete, so a
+    worker never deletes a lock it doesn't own) and additionally bounded by
+    `lock_ttl_seconds` so a hard-killed run frees the lock in hours, not a
+    full cadence window.
+    """
+    from backend.services.misc.autonomous_scheduler import (
+        _acquire_task_lock,
+        _release_task_lock,
+    )
+
+    last_run_ts = await _get_last_kg_run_ts(db_pool)
+    if last_run_ts is not None:
+        age = datetime.now(timezone.utc) - last_run_ts
+        if age < timedelta(seconds=interval_seconds):
+            logger.debug(
+                "[kg-incremental] not due yet (last run %s ago, cadence %ss)",
+                age,
+                interval_seconds,
+            )
+            return
+
+    if not await _acquire_task_lock("kg_incremental_builder", lock_ttl_seconds):
+        logger.debug("[kg-incremental] another worker holds the lock")
+        return
+
+    try:
+        stats = await run_knowledge_graph_incremental_build(db_pool)
+        try:
+            await _persist_kg_verdict(db_pool, stats)
+        except Exception as e:
+            logger.error("[kg-incremental] verdict persist failed: %s", e)
+    finally:
+        await _release_task_lock("kg_incremental_builder")
+
+
+async def _kg_incremental_loop(
+    db_pool: asyncpg.Pool,
+    interval_seconds: int,
+    check_interval_seconds: int | None = None,
+    lock_ttl_seconds: int | None = None,
+) -> None:
+    """Daily incremental KG extraction on the live path.
+
+    SCAR 2026-07-19: the old design acquired the Redis dedup lock with
+    TTL = interval_seconds (24h) BEFORE running, and used that same 24h
+    lock as the cadence signal. A run that crashed mid-flight (rate-limited
+    ~2.5-3.7h run on a 2GB Fly machine that redeploys/OOMs) left the 24h
+    lock held with no verdict persisted, so every subsequent boot's acquire
+    returned False and the run stayed poisoned for a full day.
+
+    Fix: cadence and dedup are two different concerns now. Every short
+    `check_interval_seconds` (default KG_CHECK_INTERVAL=3600, 1h) this loop
+    asks `_kg_incremental_tick` whether a run is due (DB timestamp, not lock
+    TTL) and — only if so — acquires a short `lock_ttl_seconds` (default
+    KG_LOCK_TTL=14400, 4h) lock for the duration of the run, released in a
+    `finally`. A crash now retries within ~1h (next tick) instead of ~24h,
+    and even a killed process frees the lock within hours via its TTL. The
+    run is already idempotent (dedups by processed chunk-ids), so a resumed
+    run safely picks up where it left off.
+    """
+    check_interval = check_interval_seconds or int(os.environ.get("KG_CHECK_INTERVAL", "3600"))
+    lock_ttl = lock_ttl_seconds or int(os.environ.get("KG_LOCK_TTL", "14400"))
 
     await asyncio.sleep(120)  # let the app finish booting before Qdrant scans
     while True:
         try:
-            if await _acquire_task_lock("kg_incremental_builder", interval_seconds):
-                stats = await run_knowledge_graph_incremental_build(db_pool)
-                try:
-                    await _persist_kg_verdict(db_pool, stats)
-                except Exception as e:
-                    logger.error("[kg-incremental] verdict persist failed: %s", e)
-            else:
-                logger.debug("[kg-incremental] another worker holds the lock")
+            await _kg_incremental_tick(db_pool, interval_seconds, lock_ttl)
         except asyncio.CancelledError:
             raise
         except Exception as e:  # the loop must survive anything
             logger.error("[kg-incremental] run crashed: %s", e, exc_info=True)
-        await asyncio.sleep(interval_seconds)
+        await asyncio.sleep(check_interval)
 
 
 def start_kg_incremental_task(
@@ -372,8 +455,6 @@ def start_kg_incremental_task(
     MAX_RPM) and extraction is dedup-idempotent via processed chunk ids, so
     an armed default is safe; ENABLE_KG_INCREMENTAL=false is the kill switch.
     """
-    import os
-
     if os.environ.get("ENABLE_KG_INCREMENTAL", "true").lower() in {"false", "0", "no"}:
         logger.info("[kg-incremental] disabled via ENABLE_KG_INCREMENTAL")
         return None

--- a/apps/backend-rag/backend/services/knowledge_graph/incremental_builder.py
+++ b/apps/backend-rag/backend/services/knowledge_graph/incremental_builder.py
@@ -63,9 +63,14 @@ class KGIncrementalBuilder:
             try:
                 from google import genai
 
-                # Use GOOGLE_API_KEY (Google AI Studio)
+                # Prefer a KG-dedicated key (KG_GOOGLE_API_KEY) so this feeder can
+                # be moved to an isolated Gemini project/key without touching the
+                # WhatsApp bot's shared GOOGLE_API_KEY. Falls back to the shared
+                # settings chain until KG_GOOGLE_API_KEY is set anywhere (additive,
+                # no behavior change until then).
                 api_key = (
-                    settings.google_api_key
+                    os.environ.get("KG_GOOGLE_API_KEY")
+                    or settings.google_api_key
                     or settings.google_ai_studio_key
                     or settings.google_imagen_api_key
                 )

--- a/apps/backend-rag/backend/services/misc/autonomous_scheduler.py
+++ b/apps/backend-rag/backend/services/misc/autonomous_scheduler.py
@@ -101,6 +101,44 @@ async def _acquire_task_lock(task_name: str, ttl_seconds: int) -> bool:
         return True  # On error, run anyway
 
 
+# Atomic compare-and-delete: only remove the lock if it still holds THIS
+# worker's identity. A plain DEL would let a worker whose lock already
+# expired (e.g. it overran ttl_seconds) delete a *different* worker's lock
+# that has since acquired the same key.
+_RELEASE_LOCK_LUA = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
+
+async def _release_task_lock(task_name: str) -> bool:
+    """
+    Release a distributed task lock, but ONLY if this worker still holds it.
+
+    Pairs with `_acquire_task_lock`. Callers should acquire a short-TTL lock
+    for the duration of a task and release it in a `finally` block so a
+    crashed/killed task does not hold the lock for its full TTL (still a
+    safety net, just no longer the only exit).
+
+    Returns True if this worker's lock was released, False otherwise
+    (already expired, held by another worker, or Redis unavailable).
+    """
+    client = await _get_redis()
+    if client is None:
+        return False  # No Redis = nothing to release
+
+    lock_key = f"{_LOCK_PREFIX}{task_name}"
+    try:
+        released = await client.eval(_RELEASE_LOCK_LUA, 1, lock_key, _WORKER_ID)
+        return bool(released)
+    except Exception as e:
+        logger.debug("Lock release error for %s: %s", task_name, e)
+        return False
+
+
 @dataclass
 class ScheduledTask:
     """A scheduled autonomous task"""

--- a/apps/backend-rag/backend/tests/services/knowledge_graph/test_incremental_builder.py
+++ b/apps/backend-rag/backend/tests/services/knowledge_graph/test_incremental_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -107,9 +108,27 @@ async def test_run_knowledge_graph_incremental_build_delegates_to_builder(
 def test_get_gemini_client_returns_none_when_google_key_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delenv("KG_GOOGLE_API_KEY", raising=False)
     monkeypatch.setattr(builder_module.settings, "google_api_key", "")
     monkeypatch.setattr(builder_module.settings, "google_ai_studio_key", "")
     monkeypatch.setattr(builder_module.settings, "google_imagen_api_key", "")
     builder = KGIncrementalBuilder(db_pool=None)
 
     assert builder._get_gemini_client() is None
+
+
+def test_get_gemini_client_prefers_kg_google_api_key_over_shared_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """KG extraction isolates its key from the WhatsApp bot's shared GOOGLE_API_KEY."""
+    monkeypatch.setenv("KG_GOOGLE_API_KEY", "kg-dedicated-key")
+    monkeypatch.setattr(builder_module.settings, "google_api_key", "shared-bot-key")
+    builder = KGIncrementalBuilder(db_pool=None)
+
+    mock_genai = MagicMock()
+    with patch.dict(
+        "sys.modules", {"google": MagicMock(genai=mock_genai), "google.genai": mock_genai}
+    ):
+        builder._get_gemini_client()
+
+    assert mock_genai.Client.call_args.kwargs["api_key"] == "kg-dedicated-key"

--- a/apps/backend-rag/backend/tests/unit/services/knowledge_graph/test_incremental_builder.py
+++ b/apps/backend-rag/backend/tests/unit/services/knowledge_graph/test_incremental_builder.py
@@ -77,7 +77,10 @@ class TestInit:
 
 class TestGetGeminiClient:
     @patch("backend.services.knowledge_graph.incremental_builder.settings")
-    def test_no_api_key_returns_none(self, mock_settings: MagicMock) -> None:
+    def test_no_api_key_returns_none(
+        self, mock_settings: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("KG_GOOGLE_API_KEY", raising=False)
         mock_settings.google_api_key = None
         mock_settings.google_ai_studio_key = None
         mock_settings.google_imagen_api_key = None
@@ -86,6 +89,44 @@ class TestGetGeminiClient:
         with patch.dict("sys.modules", {"google": MagicMock(), "google.genai": MagicMock()}):
             result = b._get_gemini_client()
         assert result is None
+
+    @patch("backend.services.knowledge_graph.incremental_builder.settings")
+    def test_prefers_kg_google_api_key_env_over_shared_settings(
+        self, mock_settings: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """KG extraction must isolate its key from the WhatsApp bot's shared one."""
+        monkeypatch.setenv("KG_GOOGLE_API_KEY", "kg-dedicated-key")
+        mock_settings.google_api_key = "shared-bot-key"
+        mock_settings.google_ai_studio_key = None
+        mock_settings.google_imagen_api_key = None
+
+        mock_genai = MagicMock()
+        b = KGIncrementalBuilder()
+        with patch.dict(
+            "sys.modules", {"google": MagicMock(genai=mock_genai), "google.genai": mock_genai}
+        ):
+            b._get_gemini_client()
+
+        assert mock_genai.Client.call_args.kwargs["api_key"] == "kg-dedicated-key"
+
+    @patch("backend.services.knowledge_graph.incremental_builder.settings")
+    def test_falls_back_to_shared_settings_when_kg_key_unset(
+        self, mock_settings: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Additive: behavior is unchanged until KG_GOOGLE_API_KEY is set anywhere."""
+        monkeypatch.delenv("KG_GOOGLE_API_KEY", raising=False)
+        mock_settings.google_api_key = "shared-bot-key"
+        mock_settings.google_ai_studio_key = None
+        mock_settings.google_imagen_api_key = None
+
+        mock_genai = MagicMock()
+        b = KGIncrementalBuilder()
+        with patch.dict(
+            "sys.modules", {"google": MagicMock(genai=mock_genai), "google.genai": mock_genai}
+        ):
+            b._get_gemini_client()
+
+        assert mock_genai.Client.call_args.kwargs["api_key"] == "shared-bot-key"
 
     @patch("backend.services.knowledge_graph.incremental_builder.settings")
     def test_import_error_returns_none(self, mock_settings: MagicMock) -> None:

--- a/apps/backend-rag/backend/tests/unit/services/knowledge_graph/test_incremental_builder_live_path.py
+++ b/apps/backend-rag/backend/tests/unit/services/knowledge_graph/test_incremental_builder_live_path.py
@@ -5,14 +5,28 @@ Necropsy follow-up 2026-07-14: the builder was doubly unarmed — registered on
 the dead AutonomousScheduler AND gated by an ENABLE_KG_INCREMENTAL env never
 set on Fly. The live path is the loop; these tests pin its contract the same
 way TestLiveLoopStarter does for the WhatsApp guardian (§10d).
+
+SCAR 2026-07-19: the original loop acquired the Redis dedup lock with
+TTL = interval_seconds (24h) BEFORE running, and that same TTL doubled as the
+cadence signal. A run that crashed mid-flight left the 24h lock held with no
+verdict persisted, so every subsequent boot's acquire returned False and the
+run stayed poisoned for a full day. The fix decouples cadence (DB timestamp
+read via `_get_last_kg_run_ts`) from dedup (short-TTL Redis lock, released in
+a `finally` via `_release_task_lock`). These tests were rewritten to pin the
+NEW contract: `_kg_incremental_tick` for the single-cycle logic and
+`_kg_incremental_loop` for the check-interval polling shell around it.
 """
 
+import asyncio
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from backend.services.knowledge_graph.incremental_builder import (
+    _get_last_kg_run_ts,
     _kg_incremental_loop,
+    _kg_incremental_tick,
     _persist_kg_verdict,
     start_kg_incremental_task,
 )
@@ -44,9 +58,49 @@ class TestStartKgIncrementalTask:
         assert start_kg_incremental_task(None) is None
 
 
-class TestKgIncrementalLoop:
+class TestGetLastKgRunTs:
     @pytest.mark.asyncio
-    async def test_runs_build_and_persists_verdict_when_lock_held(self):
+    async def test_returns_timestamp_when_verdict_exists(self):
+        ts = datetime(2026, 7, 15, 3, 0, tzinfo=timezone.utc)
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value={"updated_at": ts})
+
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await _get_last_kg_run_ts(pool)
+
+        assert result == ts
+        sql = conn.fetchrow.await_args.args[0]
+        assert "kg_incremental_last" in sql
+        assert "system_settings" in sql
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_never_ran(self):
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value=None)
+
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        assert await _get_last_kg_run_ts(pool) is None
+
+    @pytest.mark.asyncio
+    async def test_fails_open_to_none_on_db_error(self):
+        pool = MagicMock()
+        pool.acquire.side_effect = RuntimeError("db unavailable")
+
+        # Fail-open: a broken DB read must not crash the loop — treated as
+        # "never ran" by the caller, same philosophy as _acquire_task_lock
+        # falling open on Redis errors.
+        assert await _get_last_kg_run_ts(pool) is None
+
+
+class TestKgIncrementalTick:
+    @pytest.mark.asyncio
+    async def test_runs_when_never_ran_and_lock_available(self):
         runs: list[dict] = []
         verdicts: list[dict] = []
 
@@ -58,19 +112,22 @@ class TestKgIncrementalLoop:
         async def fake_persist(db_pool, stats):
             verdicts.append(stats)
 
-        sleeps = []
-
-        async def fake_sleep(seconds):
-            sleeps.append(seconds)
-            if len(sleeps) >= 2:  # boot sleep + first interval sleep
-                raise StopAsyncIteration
-
         with (
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._get_last_kg_run_ts",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
             patch(
                 "backend.services.misc.autonomous_scheduler._acquire_task_lock",
                 new_callable=AsyncMock,
                 return_value=True,
-            ),
+            ) as mock_acquire,
+            patch(
+                "backend.services.misc.autonomous_scheduler._release_task_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_release,
             patch(
                 "backend.services.knowledge_graph.incremental_builder."
                 "run_knowledge_graph_incremental_build",
@@ -80,18 +137,212 @@ class TestKgIncrementalLoop:
                 "backend.services.knowledge_graph.incremental_builder._persist_kg_verdict",
                 side_effect=fake_persist,
             ),
+        ):
+            await _kg_incremental_tick(MagicMock(), 86400, 14400)
+
+        assert len(runs) == 1
+        assert verdicts == runs
+        mock_acquire.assert_awaited_once_with("kg_incremental_builder", 14400)
+        mock_release.assert_awaited_once_with("kg_incremental_builder")
+
+    @pytest.mark.asyncio
+    async def test_skips_when_not_due(self):
+        """Cadence honors the DB timestamp: <24h since last success -> skip."""
+        recent = datetime.now(timezone.utc) - timedelta(hours=2)
+        build = AsyncMock()
+
+        with (
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._get_last_kg_run_ts",
+                new_callable=AsyncMock,
+                return_value=recent,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._acquire_task_lock",
+                new_callable=AsyncMock,
+            ) as mock_acquire,
+            patch(
+                "backend.services.knowledge_graph.incremental_builder."
+                "run_knowledge_graph_incremental_build",
+                build,
+            ),
+        ):
+            await _kg_incremental_tick(MagicMock(), 86400, 14400)
+
+        build.assert_not_awaited()
+        mock_acquire.assert_not_awaited()  # not-due short-circuits before the lock
+
+    @pytest.mark.asyncio
+    async def test_runs_when_due_after_full_cadence(self):
+        """>=24h since last success -> due, run proceeds."""
+        stale = datetime.now(timezone.utc) - timedelta(hours=25)
+        build = AsyncMock(return_value={"status": "ok"})
+
+        with (
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._get_last_kg_run_ts",
+                new_callable=AsyncMock,
+                return_value=stale,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._acquire_task_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._release_task_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "backend.services.knowledge_graph.incremental_builder."
+                "run_knowledge_graph_incremental_build",
+                build,
+            ),
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._persist_kg_verdict",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _kg_incremental_tick(MagicMock(), 86400, 14400)
+
+        build.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_run_when_lock_not_held(self):
+        build = AsyncMock()
+
+        with (
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._get_last_kg_run_ts",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._acquire_task_lock",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._release_task_lock",
+                new_callable=AsyncMock,
+            ) as mock_release,
+            patch(
+                "backend.services.knowledge_graph.incremental_builder."
+                "run_knowledge_graph_incremental_build",
+                build,
+            ),
+        ):
+            await _kg_incremental_tick(MagicMock(), 86400, 14400)
+
+        build.assert_not_awaited()
+        mock_release.assert_not_awaited()  # never acquired -> nothing to release
+
+    @pytest.mark.asyncio
+    async def test_lock_released_even_when_run_raises(self):
+        """A crashed run must not poison the lock for its full TTL (SCAR 2026-07-19)."""
+        build = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with (
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._get_last_kg_run_ts",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._acquire_task_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._release_task_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_release,
+            patch(
+                "backend.services.knowledge_graph.incremental_builder."
+                "run_knowledge_graph_incremental_build",
+                build,
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await _kg_incremental_tick(MagicMock(), 86400, 14400)
+
+        mock_release.assert_awaited_once_with("kg_incremental_builder")
+
+    @pytest.mark.asyncio
+    async def test_lock_released_even_when_persist_raises(self):
+        """Verdict-persist failure (already caught internally) must still release."""
+        build = AsyncMock(return_value={"status": "ok"})
+        persist = AsyncMock(side_effect=RuntimeError("db write failed"))
+
+        with (
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._get_last_kg_run_ts",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._acquire_task_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "backend.services.misc.autonomous_scheduler._release_task_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_release,
+            patch(
+                "backend.services.knowledge_graph.incremental_builder."
+                "run_knowledge_graph_incremental_build",
+                build,
+            ),
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._persist_kg_verdict",
+                persist,
+            ),
+        ):
+            await _kg_incremental_tick(MagicMock(), 86400, 14400)
+
+        mock_release.assert_awaited_once_with("kg_incremental_builder")
+
+
+class TestKgIncrementalLoop:
+    @pytest.mark.asyncio
+    async def test_loop_boots_then_ticks_on_check_interval(self, monkeypatch):
+        monkeypatch.setenv("KG_CHECK_INTERVAL", "3600")
+        monkeypatch.setenv("KG_LOCK_TTL", "14400")
+
+        ticks: list[tuple] = []
+        sleeps: list[float] = []
+
+        async def fake_tick(db_pool, interval_seconds, lock_ttl_seconds):
+            ticks.append((interval_seconds, lock_ttl_seconds))
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+            if len(sleeps) >= 3:  # boot sleep + 2 tick-interval sleeps
+                raise StopAsyncIteration
+
+        with (
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._kg_incremental_tick",
+                side_effect=fake_tick,
+            ),
             patch("asyncio.sleep", side_effect=fake_sleep),
             pytest.raises(StopAsyncIteration),
         ):
             await _kg_incremental_loop(MagicMock(), 86400)
 
-        assert len(runs) == 1
-        assert verdicts == runs
+        assert sleeps[0] == 120  # boot delay preserved
+        assert sleeps[1:] == [3600, 3600]  # KG_CHECK_INTERVAL, not the 24h cadence
+        assert len(ticks) == 2
+        assert all(t == (86400, 14400) for t in ticks)
 
     @pytest.mark.asyncio
-    async def test_skips_run_when_lock_not_held(self):
-        build = AsyncMock()
-        sleeps = []
+    async def test_loop_survives_tick_exception(self):
+        """The loop must never die — a per-tick exception is caught and logged."""
+        sleeps: list[float] = []
 
         async def fake_sleep(seconds):
             sleeps.append(seconds)
@@ -100,21 +351,33 @@ class TestKgIncrementalLoop:
 
         with (
             patch(
-                "backend.services.misc.autonomous_scheduler._acquire_task_lock",
+                "backend.services.knowledge_graph.incremental_builder._kg_incremental_tick",
                 new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "backend.services.knowledge_graph.incremental_builder."
-                "run_knowledge_graph_incremental_build",
-                build,
+                side_effect=RuntimeError("tick blew up"),
             ),
             patch("asyncio.sleep", side_effect=fake_sleep),
             pytest.raises(StopAsyncIteration),
         ):
-            await _kg_incremental_loop(MagicMock(), 86400)
+            await _kg_incremental_loop(MagicMock(), 86400, check_interval_seconds=60)
 
-        build.assert_not_awaited()
+        # Loop kept going past the exception (reached the second sleep).
+        assert len(sleeps) == 2
+
+    @pytest.mark.asyncio
+    async def test_loop_propagates_cancellation(self):
+        async def fake_sleep(seconds):
+            return None
+
+        with (
+            patch(
+                "backend.services.knowledge_graph.incremental_builder._kg_incremental_tick",
+                new_callable=AsyncMock,
+                side_effect=asyncio.CancelledError(),
+            ),
+            patch("asyncio.sleep", side_effect=fake_sleep),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await _kg_incremental_loop(MagicMock(), 86400, check_interval_seconds=60)
 
 
 class TestPersistKgVerdict:

--- a/apps/backend-rag/backend/tests/unit/services/misc/test_autonomous_scheduler.py
+++ b/apps/backend-rag/backend/tests/unit/services/misc/test_autonomous_scheduler.py
@@ -12,10 +12,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.services.misc.autonomous_scheduler import (
+    _WORKER_ID,
     AutonomousScheduler,
     ScheduledTask,
     _acquire_task_lock,
     _get_client,
+    _release_task_lock,
     close_scheduler_client,
     get_autonomous_scheduler,
 )
@@ -160,6 +162,70 @@ class TestAcquireTaskLock:
 
         result = await _acquire_task_lock("test_task", 300)
         assert result is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _release_task_lock
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestReleaseTaskLock:
+    """
+    SCAR 2026-07-19: a crashed KG run held its 24h-TTL lock with no way to
+    release early, poisoning retries for a full day. `_release_task_lock`
+    lets a `finally` block free the lock immediately — but ONLY if this
+    worker still owns it (compare-and-delete), so it never deletes a lock a
+    different worker acquired after this one's TTL expired.
+    """
+
+    @pytest.mark.asyncio
+    @patch("backend.services.misc.autonomous_scheduler._get_redis", new_callable=AsyncMock)
+    async def test_no_redis_returns_false(self, mock_get_redis: AsyncMock) -> None:
+        mock_get_redis.return_value = None
+        result = await _release_task_lock("test_task")
+        assert result is False
+
+    @pytest.mark.asyncio
+    @patch("backend.services.misc.autonomous_scheduler._get_redis", new_callable=AsyncMock)
+    async def test_releases_own_lock(self, mock_get_redis: AsyncMock) -> None:
+        mock_redis = AsyncMock()
+        mock_redis.eval = AsyncMock(return_value=1)  # Lua DEL returns 1 on success
+        mock_get_redis.return_value = mock_redis
+
+        result = await _release_task_lock("test_task")
+
+        assert result is True
+        mock_redis.eval.assert_awaited_once()
+        args = mock_redis.eval.await_args.args
+        # (script, numkeys, key, worker_id) — the compare value must be THIS
+        # worker's identity, never a bare DEL.
+        assert args[1] == 1
+        assert args[2] == "nuzantara:scheduler:lock:test_task"
+        assert args[3] == _WORKER_ID
+
+    @pytest.mark.asyncio
+    @patch("backend.services.misc.autonomous_scheduler._get_redis", new_callable=AsyncMock)
+    async def test_does_not_release_foreign_lock(self, mock_get_redis: AsyncMock) -> None:
+        """Lua script returns 0 when GET != our worker id — nothing was deleted."""
+        mock_redis = AsyncMock()
+        mock_redis.eval = AsyncMock(return_value=0)
+        mock_get_redis.return_value = mock_redis
+
+        result = await _release_task_lock("test_task")
+        assert result is False
+
+    @pytest.mark.asyncio
+    @patch("backend.services.misc.autonomous_scheduler._get_redis", new_callable=AsyncMock)
+    async def test_redis_error_returns_false(self, mock_get_redis: AsyncMock) -> None:
+        mock_redis = AsyncMock()
+        mock_redis.eval = AsyncMock(side_effect=ConnectionError("Redis down"))
+        mock_get_redis.return_value = mock_redis
+
+        # Unlike acquire (fail-open=True/"run anyway"), release fails closed
+        # to False — an unreleased lock just expires via its own TTL, which
+        # is safe; a *falsely reported* release is not.
+        result = await _release_task_lock("test_task")
+        assert result is False
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/apps/backend-rag/scripts/kg_incremental_extraction.py
+++ b/apps/backend-rag/scripts/kg_incremental_extraction.py
@@ -61,7 +61,7 @@ def retry_qdrant(max_retries=3, delay=2):
 import asyncpg
 import httpx
 
-from backend.llm.genai_client import get_genai_client
+from backend.llm.genai_client import GenAIClient, get_genai_client
 from backend.llm.ollama_client import ollama_chat_kg
 
 try:
@@ -927,7 +927,12 @@ async def main():
                 return
         else:
             try:
-                gemini = get_genai_client()
+                # Prefer a KG-dedicated key (KG_GOOGLE_API_KEY) so this feeder can
+                # be isolated from the WhatsApp bot's shared GOOGLE_API_KEY without
+                # touching bot code. Falls back to the shared settings chain (same
+                # as get_genai_client()) until KG_GOOGLE_API_KEY is set anywhere.
+                kg_api_key = os.environ.get("KG_GOOGLE_API_KEY")
+                gemini = GenAIClient(api_key=kg_api_key) if kg_api_key else get_genai_client()
                 if getattr(gemini, "is_available", True):
                     logger.info("✅ GenAI Client initialized")
                 else:


### PR DESCRIPTION
## Summary

The KG incremental extraction loop (`apps/backend-rag/backend/services/knowledge_graph/incremental_builder.py::_kg_incremental_loop`, service_initializer §10f) has not completed a run since 2026-07-15 despite a nominal 24h cadence.

**Root cause (verified live from Redis + DB 2026-07-19):** `_kg_incremental_loop` called `_acquire_task_lock(name, ttl_seconds)` with **TTL = interval = 86400s (24h) BEFORE running**, then the run itself takes ~2.5-3.7h (rate-limited MAX_RPM=15 over ~2000 chunks) on a 2GB Fly machine that redeploys/OOMs mid-run. A crashed run leaves the 24h lock held with no verdict persisted → every subsequent boot's acquire returns `False` → skip → the run stays poisoned for a full day. Live proof at investigation time: lock held with ~20h TTL remaining, but last DB verdict (`system_settings.kg_incremental_last`) was from 2026-07-15.

## What this PR does

**Commit 1 — lock lifecycle fix.** Decouples two conflated concerns:
- **Cadence** ("has a run succeeded in the last 24h?") is now driven by the `system_settings.kg_incremental_last.updated_at` DB timestamp (new `_get_last_kg_run_ts`), not the lock TTL.
- **Cross-worker dedup** keeps the Redis lock, but sized to run-duration + margin (`KG_LOCK_TTL`, default `14400`s/4h, not 24h) and released in a `finally` via a new `_release_task_lock()` compare-and-delete helper (Lua `GET`+`DEL`) in `autonomous_scheduler.py` — a worker never deletes a lock it doesn't own.
- The loop now polls every `KG_CHECK_INTERVAL` (default `3600`s/1h) via a new single-cycle `_kg_incremental_tick()`, instead of sleeping the full 24h cadence — a crash now retries within ~1h instead of ~24h, and a killed process frees the lock within hours via its TTL regardless.
- The run is already idempotent (dedups by processed chunk-ids), so a resumed run safely picks up where it left off.

**Commit 2 — isolated-key plumbing (additive, no behavior change until the env is set).** The KG path currently reads `settings.google_api_key` — the SHARED prepay key of the WhatsApp bot — in `KGIncrementalBuilder._get_gemini_client()` and in `scripts/kg_incremental_extraction.py`. Both now prefer a dedicated `KG_GOOGLE_API_KEY` env var, falling back to the existing settings chain when unset. Lets a future isolated Gemini project/key take over the KG path without touching the bot.

**docs-sync**: checked `python scripts/docs_sync.py --check` — already green on this branch's base (a prior merge to `main` already regenerated the stale `AI_ONBOARDING.md` counters left by #2845), and `--diff` shows no drift introduced by this PR either. No third commit needed.

### New env vars (both optional, safe defaults — no action required to preserve current behavior)

| Var | Default | Purpose |
|---|---|---|
| `KG_CHECK_INTERVAL` | `3600` (1h) | How often the loop checks whether a run is due |
| `KG_LOCK_TTL` | `14400` (4h) | Redis dedup lock TTL for the duration of an active run |
| `KG_GOOGLE_API_KEY` | unset → falls back to `settings.google_api_key` | Dedicated Gemini key for KG extraction, isolated from the WhatsApp bot's shared key |

### Explicitly OUT of scope (separate sequenced ops steps, not in this PR)

- Disabling/redeploying the old Fly loop behavior — this PR ships code only, no Fly secrets touched, no `fly deploy` run.
- Any Mini-side LaunchAgent migration.
- Actually setting `KG_GOOGLE_API_KEY` to a real isolated key anywhere — the plumbing is additive and inert until that's done.

## Test plan

- [x] `PYTHONPATH=. python -c "from backend.app.dependencies import get_current_user; print('OK')"` — import chain OK
- [x] New/updated unit tests (mocked Redis + db_pool):
  - `backend/tests/unit/services/misc/test_autonomous_scheduler.py::TestReleaseTaskLock` — own-lock release (compare-and-delete succeeds), foreign-lock no-op (GET mismatch → no delete), Redis-unavailable/-error fail-closed to `False`
  - `backend/tests/unit/services/knowledge_graph/test_incremental_builder_live_path.py` — rewrote `TestKgIncrementalLoop` (previously pinned the old TTL-as-cadence contract) around the new `_kg_incremental_tick`/`_get_last_kg_run_ts` contract: not-due skip, due-after-cadence run, lock-not-held skip, **lock released even when the run raises**, **lock released even when verdict-persist raises**, loop survives per-tick exceptions, loop propagates `CancelledError`
  - `backend/tests/unit/services/knowledge_graph/test_incremental_builder.py` + `backend/tests/services/knowledge_graph/test_incremental_builder.py` — `KG_GOOGLE_API_KEY` preferred when set, falls back to `settings.google_api_key` when unset
- [x] `PYTHONPATH=. pytest backend/tests/unit/services/knowledge_graph/ backend/tests/services/knowledge_graph/ backend/tests/unit/services/misc/test_autonomous_scheduler.py -q` → 312 passed, 1 skipped
- [x] `PYTHONPATH=. pytest backend/tests/services/rag/ -q` (CLAUDE.md pre-deploy critical path) → 1194 passed, 17 skipped
- [x] `ruff check` + `ruff format --check` on all changed files — clean (one pre-existing, unrelated formatting drift in `autonomous_scheduler.py` at a Drive Changes Polling log line, not touched by this diff, left as-is)
- [x] `python scripts/docs_sync.py --check` — green, no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>