### PR TITLE
fix(docs-guardian): regen script defaults to gate-consistent mode — dated regen behind explicit flag

### DIFF
--- a/.github/workflows/docs-inventory-refresh.yml
+++ b/.github/workflows/docs-inventory-refresh.yml
@@ -30,11 +30,18 @@ name: Docs Inventory Refresh
 #      docstring. A doc crossing `orphan_eligible_on` no longer makes an unrelated PR red.
 #   2. The actual TIME-CROSSING decision — "has this doc's orphan_eligible_on passed?" —
 #      moves HERE, to this scheduled organ, the only place allowed to consult wall-clock
-#      for that purpose (docs_audit.py in write mode, called by "Regenerate" below with no
-#      --as-of override = real "today"). When a doc crosses, this run stamps its
-#      `orphan_flipped_on` provenance marker and the "Regenerate" step's own stderr logs
-#      `docs_audit: advanced N flip(s), eligibility recomputed: <paths>` — surfaced below
-#      into both this run's log AND the opened PR's body (steps.stats.outputs.flips).
+#      for that purpose (docs_audit.py in write mode, called by "Regenerate" below via
+#      `scripts/docs_inventory_regen.sh --organ`, which passes --as-of "$(date -u
+#      +%Y-%m-%d)" = real "today" explicitly — footgun fix 2026-07-19, PR #2626 landing
+#      incident: the SCRIPT's bare/default invocation is now GATE-CONSISTENT
+#      (--gate-consistent, never invents a flip) precisely so a PR-side contributor
+#      running the plain command cannot accidentally commit a wall-clock-driven flip the
+#      gate would then reject as drift on the SAME PR — only this scheduled organ, via
+#      the explicit --organ flag, is supposed to advance flips from real time). When a doc
+#      crosses, this run stamps its `orphan_flipped_on` provenance marker and the
+#      "Regenerate" step's own stderr logs `docs_audit: advanced N flip(s), eligibility
+#      recomputed: <paths>` — surfaced below into both this run's log AND the opened PR's
+#      body (steps.stats.outputs.flips).
 #
 # PR-creation mechanism note (2026-07-17 design decision): this repo's established,
 # empirically-verified pattern for scheduled automation PRs (nb-curator #2567, the
@@ -88,7 +95,12 @@ jobs:
           # flipped_paths) alongside the regen, so this run can surface the
           # count without a second, duplicate docs_audit.py invocation.
           DOCS_AUDIT_STATS_JSON: ${{ runner.temp }}/docs_audit_stats.json
-        run: bash scripts/docs_inventory_regen.sh
+        # --organ: this IS the scheduled refresh organ — the one caller
+        # explicitly opting INTO dated/wall-clock behavior (real "today")
+        # instead of the script's now-gate-consistent default. Footgun fix
+        # 2026-07-19, PR #2626 landing incident — see the module comment
+        # above and scripts/docs_inventory_regen.sh's own header.
+        run: bash scripts/docs_inventory_regen.sh --organ
 
       - name: Check drift
         id: drift

--- a/scripts/docs_audit.py
+++ b/scripts/docs_audit.py
@@ -126,10 +126,37 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Override 'today' for the orphan-eligibility TIME-CROSSING decision "
             "in write modes (--regen-only/--apply/default); defaults to the real "
-            "date when omitted. Deterministic-testing knob only — mutually "
-            "exclusive with --check, which NEVER consults wall-clock (P3-prime: "
-            "the merge gate verifies only tree-deterministic facts — the "
-            "scheduled refresh organ owns the time-crossing decision)."
+            "date when omitted (see --gate-consistent for a safer omitted-case "
+            "default in PR-side contexts). Deterministic-testing knob only — "
+            "mutually exclusive with --check, which NEVER consults wall-clock "
+            "(P3-prime: the merge gate verifies only tree-deterministic facts — "
+            "the scheduled refresh organ owns the time-crossing decision), and "
+            "with --gate-consistent (pick one: a specific date, or 'never "
+            "invent one')."
+        ),
+    )
+    p.add_argument(
+        "--gate-consistent",
+        action="store_true",
+        help=(
+            "Write-mode (--regen-only/--apply/default) opt-in that reproduces "
+            "--check's exact verdict-producing computation (as_of=None, "
+            "provenance from --trusted-ref) but WRITES the result instead of "
+            "comparing — i.e. 'regenerate exactly what the gate itself expects', "
+            "never a fresh wall-clock-driven flip. Footgun fix (2026-07-19, PR "
+            "#2626 landing incident): a write-mode regen run with NO --as-of "
+            "used to silently default to real 'today', so a contributor running "
+            "the plain PR-side regen path could commit fresh orphan_flipped_on "
+            "stamps that --check (always as_of=None) would then reject as drift "
+            "on the SAME PR. scripts/docs_inventory_regen.sh now passes this by "
+            "default; the scheduled refresh organ (docs-inventory-refresh.yml) "
+            "opts OUT via its own --organ flag, which passes --as-of instead — "
+            "it is the one caller that IS supposed to invent fresh flips from "
+            "real wall-clock. Mutually exclusive with --check (already "
+            "definitionally this) and --as-of (pick one). docs_audit.py's own "
+            "bare CLI default is UNCHANGED by this flag's existence — "
+            "scripts/docs_guardian.sh and any other direct caller that doesn't "
+            "pass it keeps the pre-existing real-'today' behavior."
         ),
     )
     p.add_argument(
@@ -160,9 +187,10 @@ def parse_args() -> argparse.Namespace:
             "--check mode: that file IS the PR candidate's own content, so a "
             "PR could forge or delete orphan_flipped_on markers and a gate "
             "that only re-derives its own self-consistency would pass. "
-            "Ignored outside --check (write modes trust the local working "
-            "tree, which in the organ's context is a fresh checkout of main "
-            "anyway). Default origin/main; override only for testing."
+            "Ignored outside --check/--gate-consistent (plain write modes "
+            "trust the local working tree, which in the organ's context is "
+            "a fresh checkout of main anyway). Default origin/main; override "
+            "only for testing."
         ),
     )
     args = p.parse_args()
@@ -179,6 +207,20 @@ def parse_args() -> argparse.Namespace:
             "wall-clock (P3-prime), so overriding 'today' for it is a contradiction "
             "in terms — it would smuggle a time-crossing decision back into the "
             "merge gate. Use --as-of only with a write mode."
+        )
+    if args.check and args.gate_consistent:
+        raise SystemExit(
+            "--check and --gate-consistent are mutually exclusive: --check "
+            "already IS the gate-consistent computation (as_of=None, "
+            "trusted-ref provenance) — --gate-consistent is the write-mode "
+            "counterpart that reproduces the same thing but writes the file."
+        )
+    if args.as_of and args.gate_consistent:
+        raise SystemExit(
+            "--as-of and --gate-consistent are mutually exclusive: pick a "
+            "specific date to invent fresh flips from (--as-of), or 'never "
+            "invent one, carry forward from --trusted-ref' (--gate-consistent) "
+            "— not both."
         )
     if args.as_of:
         try:
@@ -225,8 +267,11 @@ def print_check_delta(
 ) -> None:
     """Emit a compact diff when --check finds inventory drift."""
     print(
-        "docs_audit: docs/DOCS_INVENTORY.md is out of date; "
-        f"regenerate with python {Path(__file__).as_posix()}",
+        "docs_audit: docs/DOCS_INVENTORY.md is out of date; regenerate with "
+        "bash scripts/docs_inventory_regen.sh (gate-consistent by default — "
+        "safe to run and commit on a PR branch; see --gate-consistent's "
+        f"--help text for why a bare `python {Path(__file__).as_posix()}` "
+        "invocation without it can commit content this same gate then rejects).",
         file=sys.stderr,
     )
     diff = list(
@@ -1013,25 +1058,34 @@ def main() -> int:
     # provenance from a ref the PR branch does not control
     # (read_trusted_prev_flipped, fail-closed — see its docstring). Write
     # modes keep trusting the local working tree (the organ's own fresh
-    # checkout of main, already equal to the trusted ref at this point).
-    if args.check:
-        prev_flipped = read_trusted_prev_flipped(repo, args.trusted_ref)
-    else:
-        prev_flipped = parse_prev_flipped(old_content)
-
-    # `as_of` is the ONLY place `main()` decides whether "today" may be
+    # checkout of main, already equal to the trusted ref at this point) —
+    # UNLESS --gate-consistent asks for the same trusted-ref provenance
+    # --check itself uses (footgun fix, 2026-07-19: see --gate-consistent's
+    # own --help text and PENDING-ARMS.md for the PR #2626 incident this
+    # cures).
+    #
+    # `as_of` is the OTHER place `main()` decides whether "today" may be
     # consulted at all. `--check` is the merge gate: it NEVER gets an as_of,
     # full stop — structurally incapable of inventing a fresh orphan flip
     # (parse_args() already rejects `--check --as-of` as a contradiction).
-    # Write modes get either the caller's `--as-of` override (deterministic
-    # testing) or the real date (production default).
+    # `--gate-consistent` is the write-mode twin of that same guarantee:
+    # deliberately, explicitly opted INTO (never a silent default swap for
+    # EVERY write-mode caller — see docs_guardian.sh, which never asked for
+    # this and must keep its pre-existing real-'today' behavior byte-for-
+    # byte). Plain write modes with neither flag get either the caller's
+    # `--as-of` override (deterministic testing / the scheduled organ) or
+    # the real date (unchanged production default for any caller that
+    # predates/doesn't know about --gate-consistent).
     as_of: date | None
-    if args.check:
+    if args.check or args.gate_consistent:
         as_of = None
+        prev_flipped = read_trusted_prev_flipped(repo, args.trusted_ref)
     elif args.as_of:
         as_of = date.fromisoformat(args.as_of)
+        prev_flipped = parse_prev_flipped(old_content)
     else:
         as_of = datetime.now(tz=timezone.utc).date()
+        prev_flipped = parse_prev_flipped(old_content)
 
     docs = walk_docs(repo)
     rows = [

--- a/scripts/docs_inventory_regen.sh
+++ b/scripts/docs_inventory_regen.sh
@@ -81,16 +81,44 @@
 #                                                      refresh organ ONLY)
 #        DOCS_AUDIT_STATS_JSON=/path/to/out.json scripts/docs_inventory_regen.sh [--organ]
 #          (also writes the --json stats payload to that path)
+#
+# Arg parsing is STRICT (R1 review, 2026-07-20): anything other than zero
+# args or exactly `--organ` (unknown flag, `--organ` misplaced as $2, a
+# typo) exits 2 with an explicit error — it never silently falls through to
+# gate-consistent mode.
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
+# Strict arg validation (R1 red-team, 2026-07-20, PR #2863 review): the
+# original version only ever inspected `${1:-}` — any OTHER argument
+# (typo'd flag, `--organ` passed as $2, an unrelated flag like `--quiet`)
+# silently fell through to the ORGAN_MODE=false branch with zero error,
+# meaning a misconfigured caller silently got gate-consistent mode instead
+# of organ mode (or vice versa) with no signal anything was wrong — the
+# same "footgun via silent default" class this script exists to cure, just
+# one layer up at the CLI-parsing level. Now: accept ONLY zero args or
+# exactly one arg that is literally `--organ`; anything else is a hard
+# usage error (exit 2), never a silent fallback.
 ORGAN_MODE=false
-if [[ "${1:-}" == "--organ" ]]; then
-  ORGAN_MODE=true
-fi
+case "$#" in
+  0)
+    ;;
+  1)
+    if [[ "$1" == "--organ" ]]; then
+      ORGAN_MODE=true
+    else
+      echo "docs_inventory_regen.sh: unknown argument '$1' (only '--organ' is accepted, or no arguments at all)" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "docs_inventory_regen.sh: too many arguments — only a single optional '--organ' is accepted, got: $*" >&2
+    exit 2
+    ;;
+esac
 
 if [[ "$ORGAN_MODE" == "true" ]]; then
   TIME_MODE_ARGS=(--as-of "$(date -u +%Y-%m-%d)")

--- a/scripts/docs_inventory_regen.sh
+++ b/scripts/docs_inventory_regen.sh
@@ -34,16 +34,31 @@
 #      scripts/docs_guardian.sh's weekly L1 job — this script only cures the TABLE drift.
 #
 # P3-prime (2026-07-17, research/operations/2026-07-17-push-pipeline-optimization-spec.md
-# §P3): docs_audit.py --regen-only now runs in a "write mode" that deterministically
-# stamps `orphan_flipped_on` on any doc that just crossed its `orphan_eligible_on` date
-# (real "today", since no --as-of is passed here — this is the ONE legitimate place in
-# the whole pipeline allowed to consult wall-clock for that decision; --check, the PR
-# gate, never does). If $DOCS_AUDIT_STATS_JSON is set, the --json stats payload
-# (includes `flips_this_run`/`flipped_paths`) is captured there for the calling workflow
-# to surface in its PR body/log — see .github/workflows/docs-inventory-refresh.yml. Unset
-# by default so this script's plain-usage contract (scripts/docs_guardian.sh does NOT use
-# this script today, but a future caller that doesn't care about the flip count pays zero
-# extra cost) is unchanged.
+# §P3): docs_audit.py --regen-only runs in a "write mode" that deterministically stamps
+# `orphan_flipped_on` on any doc that just crossed its `orphan_eligible_on` date. If
+# $DOCS_AUDIT_STATS_JSON is set, the --json stats payload (includes
+# `flips_this_run`/`flipped_paths`) is captured there for the calling workflow to surface
+# in its PR body/log — see .github/workflows/docs-inventory-refresh.yml. Unset by default
+# so this script's plain-usage contract (scripts/docs_guardian.sh does NOT use this script
+# today, but a future caller that doesn't care about the flip count pays zero extra cost)
+# is unchanged.
+#
+# DEFAULT MODE vs --organ (footgun fix, 2026-07-19 — PR #2626 landing incident):
+#   default (no args): GATE-CONSISTENT — passes docs_audit.py --gate-consistent, which
+#     never invents a fresh orphan flip and reads provenance from --trusted-ref
+#     (origin/main), i.e. exactly the computation `inventory-check` (docs-guardian.yml)
+#     itself verifies. Safe to run on a PR branch and commit the result: the incident this
+#     cures was this script's OLD default silently consulting real wall-clock ("today"),
+#     which could advance orphan flips a contributor never intended and the PR gate
+#     (which NEVER consults wall-clock, --check is always as_of=None) would then reject as
+#     drift ON THE SAME PR that just ran this script. This is now the recommended
+#     contributor path — also what `inventory-check`'s own failure message points at.
+#   --organ: the OLD dated/wall-clock behavior, explicitly opted into — passes
+#     docs_audit.py --as-of "$(date -u +%Y-%m-%d)" (real "today"; this is the ONE
+#     legitimate place in the whole pipeline allowed to consult wall-clock for the
+#     orphan-eligibility TIME-CROSSING decision — --check, the PR gate, never does). ONLY
+#     the scheduled refresh organ (.github/workflows/docs-inventory-refresh.yml) should
+#     pass this — it is the one caller whose entire job IS advancing flips from real time.
 #
 # Exit code (revised BLOCKER-3, red-team 2026-07-18): 0 on a completed run, REGARDLESS
 # of whether content changed — docs_sync.py (write mode) and docs_audit.py --regen-only
@@ -60,14 +75,28 @@
 # P3-prime liveness guardian, which only sees whether the calling GH Actions STEP
 # succeeded, not what happened inside it.
 #
-# Usage: scripts/docs_inventory_regen.sh   (no args; run from anywhere, cd's to repo root)
-#        DOCS_AUDIT_STATS_JSON=/path/to/out.json scripts/docs_inventory_regen.sh
+# Usage: scripts/docs_inventory_regen.sh            (no args; gate-consistent; run from
+#                                                      anywhere, cd's to repo root)
+#        scripts/docs_inventory_regen.sh --organ     (dated/wall-clock mode; scheduled
+#                                                      refresh organ ONLY)
+#        DOCS_AUDIT_STATS_JSON=/path/to/out.json scripts/docs_inventory_regen.sh [--organ]
 #          (also writes the --json stats payload to that path)
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
+
+ORGAN_MODE=false
+if [[ "${1:-}" == "--organ" ]]; then
+  ORGAN_MODE=true
+fi
+
+if [[ "$ORGAN_MODE" == "true" ]]; then
+  TIME_MODE_ARGS=(--as-of "$(date -u +%Y-%m-%d)")
+else
+  TIME_MODE_ARGS=(--gate-consistent)
+fi
 
 # Kept identical to .github/workflows/docs-guardian.yml's inventory-check step args —
 # see LOCKSTEP NOTICE above.
@@ -115,10 +144,10 @@ if [[ -n "${DOCS_AUDIT_STATS_JSON:-}" ]]; then
   # --json instead of --quiet: stdout (JSON only) goes to the stats file,
   # stderr (including docs_audit's own "advanced N flip(s)..." line, P3-prime)
   # still flows to the caller's log normally.
-  python3 scripts/docs_audit.py --regen-only --json "${WHITELIST_ARGS[@]}" "${CLUSTER_ARGS[@]}" \
+  python3 scripts/docs_audit.py --regen-only --json "${TIME_MODE_ARGS[@]}" "${WHITELIST_ARGS[@]}" "${CLUSTER_ARGS[@]}" \
     >"$DOCS_AUDIT_STATS_JSON"
 else
-  python3 scripts/docs_audit.py --regen-only --quiet "${WHITELIST_ARGS[@]}" "${CLUSTER_ARGS[@]}"
+  python3 scripts/docs_audit.py --regen-only --quiet "${TIME_MODE_ARGS[@]}" "${WHITELIST_ARGS[@]}" "${CLUSTER_ARGS[@]}"
 fi
 audit_rc=$?
 if [[ "$audit_rc" -gt 1 ]]; then

--- a/scripts/tests/test_docs_audit.py
+++ b/scripts/tests/test_docs_audit.py
@@ -1107,6 +1107,80 @@ def test_p3prime_innocence_gate_consistent_regen_committed_on_branch_passes_chec
     )
 
 
+def test_p3prime_gate_consistent_ignores_forged_local_flip_uses_trusted_ref(tmp_path):
+    """GUILT/mechanism proof (R1 red-team, PR #2863, 2026-07-20): the two
+    tests above prove --gate-consistent's END-TO-END round-trip (write then
+    --check) is green, but neither one distinguishes "provenance came from
+    origin/main" from "provenance came from the local working tree" — in
+    both, local and trusted happened to already agree before the write
+    ran, so a --gate-consistent that had REGRESSED to
+    parse_prev_flipped(old_content) (the local file, exactly what --check's
+    own BLOCKER-2 fix forbids) instead of read_trusted_prev_flipped(...)
+    would have passed those tests for the wrong reason.
+
+    This test forces local and trusted to DISAGREE: origin/main records a
+    genuine organ flip (ARCHIVED), then a candidate checkout hand-forges
+    its OWN local docs/DOCS_INVENTORY.md to delete that flip (status LIVE,
+    orphan_flipped_on cleared) — the identical forge shape as
+    test_redteam_blocker2_forged_candidate_deletes_flip_caught_red, just
+    exercised against --gate-consistent's WRITE path instead of --check's
+    read-only path. If --gate-consistent honors read_trusted_prev_flipped()
+    like it's supposed to, the freshly written inventory must reproduce the
+    TRUSTED (ARCHIVED, real flip date) state, overwriting the local forgery
+    — never render the forged LIVE state back out.
+    """
+    repo = _make_git_repo_with_old_doc(tmp_path, backdate_days=200)
+    probe = json.loads(
+        _run_audit(repo, "--orphan-days", "90", "--check", "--json").stdout
+    )
+    eligible_on = date.fromisoformat(
+        {f["path"]: f for f in probe["files"]}["docs/OLD_DOC.md"]["orphan_eligible_on"]
+    )
+    late_as_of = (eligible_on + timedelta(days=10)).isoformat()
+    _run_audit(repo, "--orphan-days", "90", "--as-of", late_as_of)
+    _commit_and_push(repo, "organ flip")  # this becomes the TRUSTED main
+
+    candidate = _clone_origin(repo, tmp_path / "candidate")
+    inv_path = candidate / "docs" / "DOCS_INVENTORY.md"
+    cells = _row_cells(inv_path.read_text(), "docs/OLD_DOC.md")
+    assert cells[2].strip() == "ARCHIVED", f"test setup sanity failed: {cells}"
+    trusted_flip_date = cells[6].strip()
+    assert trusted_flip_date != "—", "test setup sanity failed: no flip date recorded"
+
+    # Forge the candidate's LOCAL working tree only (never pushed): flip
+    # removed, status reset to LIVE — same shape as the BLOCKER-2 forgery
+    # test, but this time the forged file is what --gate-consistent's WRITE
+    # step will see as "old_content" if it (incorrectly) reads local state.
+    cells[2] = " LIVE "
+    cells[6] = " — "
+    cells[11] = " — "
+    forged_row = "|".join(cells)
+    lines = inv_path.read_text().splitlines()
+    lines = [
+        forged_row if line.startswith("| docs/OLD_DOC.md |") else line
+        for line in lines
+    ]
+    inv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = _run_audit(candidate, "--orphan-days", "90", "--gate-consistent")
+    assert result.returncode in (0, 1), (
+        f"unexpected crash: {result.stdout}{result.stderr}"
+    )
+    rewritten = (candidate / "docs" / "DOCS_INVENTORY.md").read_text()
+    row = _row_cells(rewritten, "docs/OLD_DOC.md")
+    assert row[2].strip() == "ARCHIVED", (
+        "--gate-consistent must reproduce the TRUSTED (origin/main) "
+        "ARCHIVED state, not the locally-forged LIVE state — a regression "
+        "to local-file provenance would silently resurrect the doc: "
+        + rewritten
+    )
+    assert row[6].strip() == trusted_flip_date, (
+        "--gate-consistent must reproduce origin/main's ORIGINAL flip "
+        f"date ({trusted_flip_date!r}), not invent a new one or keep the "
+        f"forged blank: got {row[6].strip()!r}"
+    )
+
+
 def test_p3prime_guilt_last_touched_date_inconsistent_with_git_history(tmp_path):
     """GUILT ('date incoerenti con la storia git -> rosso'): hand-mutating
     last_touched_date to a value that disagrees with the actual git commit

--- a/scripts/tests/test_docs_audit.py
+++ b/scripts/tests/test_docs_audit.py
@@ -994,6 +994,119 @@ def test_p3prime_organ_flip_then_check_stays_green_carried_forward(tmp_path):
     assert "advanced" not in result.stderr
 
 
+# ============================================================================
+# Footgun fix (2026-07-19, PR #2626 landing incident): a write-mode regen run
+# with NO --as-of silently defaulted to real "today" for the orphan
+# time-crossing decision. scripts/docs_inventory_regen.sh's own plain-usage
+# instructions (no --as-of — that flag is documented as a deterministic-
+# testing/organ knob) meant a PR-side contributor's own regen could commit
+# fresh orphan_flipped_on stamps that --check (always as_of=None) then
+# rejected as drift ON THE SAME PR. Structural fix: --gate-consistent, a new
+# write-mode opt-in that reproduces --check's exact computation (as_of=None,
+# trusted-ref provenance) but WRITES the file. docs_inventory_regen.sh now
+# passes it by default; the scheduled organ opts OUT via its own --organ
+# flag (--as-of "$(date -u +%Y-%m-%d)").
+#
+#   GUILT     — a dated write-mode regen (the footgun shape) committed on a
+#               branch fails --check (P3I)
+#   INNOCENCE — a --gate-consistent regen committed on a branch passes
+#               --check cleanly (P3J)
+# ============================================================================
+
+
+def test_p3prime_guilt_dated_regen_committed_on_branch_fails_check(tmp_path):
+    """GUILT (footgun repro, PR #2626 2026-07-19): a write-mode regen using a
+    dated --as-of (the shape docs_inventory_regen.sh's OLD default silently
+    produced) advances a fresh orphan flip that origin/main's trusted
+    provenance never recorded. If that content is committed directly (never
+    pushed through the organ), a LATER --check on the same branch must
+    correctly flag it as drift — this is the exact failure that caught PR
+    #2626's own landing attempt, reproduced here as a permanent regression
+    proof that --check WOULD catch it (and did).
+    """
+    repo = _make_git_repo_with_old_doc(tmp_path, backdate_days=200)
+    probe = json.loads(
+        _run_audit(repo, "--orphan-days", "90", "--check", "--json").stdout
+    )
+    eligible_on = date.fromisoformat(
+        {f["path"]: f for f in probe["files"]}["docs/OLD_DOC.md"]["orphan_eligible_on"]
+    )
+    # origin/main has NO flip recorded for this doc at all (no organ run in
+    # this repo's history) — the dated regen below invents one from nothing.
+    dated_as_of = (eligible_on + timedelta(days=10)).isoformat()
+    result = _run_audit(repo, "--orphan-days", "90", "--as-of", dated_as_of)
+    assert result.returncode == 1  # "content changed" — expected for a write mode
+    inventory = (repo / "docs" / "DOCS_INVENTORY.md").read_text()
+    row = _row_cells(inventory, "docs/OLD_DOC.md")
+    assert row[2].strip() == "ARCHIVED", "sanity: the footgun shape must actually invent a flip"
+
+    # Commit the dated regen's output directly on this branch — WITHOUT
+    # pushing to origin/main first (origin/main still has no flip recorded),
+    # simulating "a contributor ran the dated/organ-mode regen locally and
+    # committed its output on their feature branch".
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "T",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "T",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "dated regen (guilty)"],
+        cwd=repo,
+        check=True,
+        env=env,
+    )
+
+    result = _run_audit(repo, "--orphan-days", "90", "--check")
+    assert result.returncode == 1, (
+        "guilt: a dated flip absent from trusted origin/main provenance must "
+        f"be flagged as drift. stdout={result.stdout} stderr={result.stderr}"
+    )
+
+
+def test_p3prime_innocence_gate_consistent_regen_committed_on_branch_passes_check(
+    tmp_path,
+):
+    """INNOCENCE (the actual fix): the SAME scenario as the guilt test above
+    — a doc genuinely past its orphan-eligibility threshold, origin/main has
+    no flip recorded for it — but the write-mode regen uses --gate-consistent
+    instead of a dated --as-of. Must produce content byte-identical to what
+    --check itself independently verifies, and committing it on a branch
+    must pass --check cleanly. This is exactly what
+    scripts/docs_inventory_regen.sh's new default invokes.
+    """
+    repo = _make_git_repo_with_old_doc(tmp_path, backdate_days=200)
+
+    # Write mode always returns 1 on content change (docs/DOCS_INVENTORY.md
+    # doesn't exist yet — creating it IS a change, same documented contract
+    # every other write-mode call in this file follows; see
+    # test_p3prime_organ_flip_then_check_stays_green_carried_forward's own
+    # baseline call a few tests above, which asserts nothing on this return
+    # code for the identical reason). What matters is the CONTENT below, and
+    # the --check call after commit+push.
+    result = _run_audit(repo, "--orphan-days", "90", "--gate-consistent")
+    assert result.returncode in (0, 1), (
+        f"unexpected crash: {result.stdout}{result.stderr}"
+    )
+    inventory = (repo / "docs" / "DOCS_INVENTORY.md").read_text()
+    row = _row_cells(inventory, "docs/OLD_DOC.md")
+    assert row[2].strip() == "LIVE", (
+        "innocence: --gate-consistent must NOT invent a fresh flip just "
+        "because the doc is genuinely old by real wall-clock"
+    )
+    assert row[6].strip() == "—"  # orphan_flipped_on column stays empty
+
+    _commit_and_push(repo, "gate-consistent regen (innocent)")
+
+    result = _run_audit(repo, "--orphan-days", "90", "--check")
+    assert result.returncode == 0, (
+        "innocence: a --gate-consistent regen committed on a branch must "
+        f"pass --check cleanly. stdout={result.stdout} stderr={result.stderr}"
+    )
+
+
 def test_p3prime_guilt_last_touched_date_inconsistent_with_git_history(tmp_path):
     """GUILT ('date incoerenti con la storia git -> rosso'): hand-mutating
     last_touched_date to a value that disagrees with the actual git commit
@@ -1155,6 +1268,29 @@ def test_p3prime_as_of_rejects_bad_format(tmp_path):
     result = _run_audit(repo, "--as-of", "not-a-date")
     assert result.returncode != 0
     assert "YYYY-MM-DD" in (result.stderr + result.stdout)
+
+
+def test_p3prime_check_and_gate_consistent_are_mutually_exclusive(tmp_path):
+    """--check + --gate-consistent is a contradiction: --check already IS the
+    gate-consistent computation (as_of=None, trusted-ref provenance) — the
+    combination is redundant-to-the-point-of-meaningless, refused at
+    argparse time rather than silently accepted as a no-op alias.
+    """
+    repo = _make_git_repo_with_old_doc(tmp_path, backdate_days=10)
+    result = _run_audit(repo, "--check", "--gate-consistent")
+    assert result.returncode != 0
+    assert "mutually exclusive" in (result.stderr + result.stdout)
+
+
+def test_p3prime_as_of_and_gate_consistent_are_mutually_exclusive(tmp_path):
+    """--as-of + --gate-consistent is a contradiction: 'invent a flip from
+    this specific date' and 'never invent one, carry forward from
+    --trusted-ref' cannot both be the instruction for the same run.
+    """
+    repo = _make_git_repo_with_old_doc(tmp_path, backdate_days=10)
+    result = _run_audit(repo, "--as-of", "2026-01-01", "--gate-consistent")
+    assert result.returncode != 0
+    assert "mutually exclusive" in (result.stderr + result.stdout)
 
 
 def test_p3prime_parse_prev_flipped_handles_missing_table(tmp_path):

--- a/scripts/tests/test_docs_inventory_regen.py
+++ b/scripts/tests/test_docs_inventory_regen.py
@@ -209,3 +209,89 @@ def test_organ_flag_passes_as_of_today_not_gate_consistent(tmp_path):
     as_of_value = captured[captured.index("--as-of") + 1]
     today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
     assert as_of_value == today, (as_of_value, today)
+
+
+# ============================================================================
+# Strict arg validation (R1 red-team, PR #2863, 2026-07-20): the FIRST
+# version of the wrapper's arg parsing only ever inspected `${1:-}` — any
+# OTHER argument (an unknown flag, `--organ` misplaced as $2, a typo) fell
+# through to ORGAN_MODE=false SILENTLY, meaning a misconfigured caller got
+# gate-consistent mode instead of organ mode (or vice versa) with zero
+# error signal — the exact "footgun via silent default" class this whole
+# script exists to cure, one layer up at the CLI-parsing level. These tests
+# prove the fix: anything other than zero args or exactly one `--organ` is
+# now a hard, explicit exit-2 usage error, and MUST NOT reach the point of
+# invoking docs_audit.py at all (no captured_argv.txt is even written).
+# ============================================================================
+
+
+def test_unknown_single_arg_is_rejected_not_silently_gate_consistent(tmp_path):
+    """GUILT: a single unrecognized argument (e.g. a typo, or an unrelated
+    flag like --quiet) must be a hard usage error, not a silent fall-through
+    to gate-consistent mode.
+    """
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_CAPTURE_ARGV
+    )
+    result = _run_regen(fake_repo, None, "--quiet")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "unknown argument" in result.stderr, result.stderr
+    assert not (fake_repo / "scripts" / "captured_argv.txt").exists(), (
+        "docs_audit.py must never be invoked when arg parsing fails"
+    )
+
+
+def test_organ_as_second_arg_is_rejected_not_silently_ignored(tmp_path):
+    """GUILT: `--organ` passed as a SECOND argument (with something else as
+    $1) must be a hard usage error, not silently treated as "no args" (the
+    original bug: only `${1:-}` was ever inspected, so `script foo --organ`
+    would silently run gate-consistent mode with --organ completely
+    ignored).
+    """
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_CAPTURE_ARGV
+    )
+    result = _run_regen(fake_repo, None, "foo", "--organ")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "too many arguments" in result.stderr, result.stderr
+    assert not (fake_repo / "scripts" / "captured_argv.txt").exists()
+
+
+def test_organ_plus_extra_arg_is_rejected(tmp_path):
+    """GUILT: `--organ` followed by anything else (`script --organ typo`)
+    must also be rejected — the fix is not just "check $1", it validates
+    the COMPLETE argument list.
+    """
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_CAPTURE_ARGV
+    )
+    result = _run_regen(fake_repo, None, "--organ", "typo")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "too many arguments" in result.stderr, result.stderr
+    assert not (fake_repo / "scripts" / "captured_argv.txt").exists()
+
+
+def test_no_args_still_works_after_strict_validation(tmp_path):
+    """INNOCENCE: the strict validation must not break the ordinary
+    zero-args call — still gate-consistent, still exit 0.
+    """
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_CAPTURE_ARGV
+    )
+    result = _run_regen(fake_repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+    captured = (fake_repo / "scripts" / "captured_argv.txt").read_text()
+    assert "--gate-consistent" in captured.split("\n"), captured
+
+
+def test_organ_alone_still_works_after_strict_validation(tmp_path):
+    """INNOCENCE: the strict validation must not break the ordinary
+    single `--organ` call — still dated/as-of mode, still exit 0.
+    """
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_CAPTURE_ARGV
+    )
+    result = _run_regen(fake_repo, None, "--organ")
+    assert result.returncode == 0, result.stdout + result.stderr
+    captured = (fake_repo / "scripts" / "captured_argv.txt").read_text()
+    assert "--as-of" in captured.split("\n"), captured

--- a/scripts/tests/test_docs_inventory_regen.py
+++ b/scripts/tests/test_docs_inventory_regen.py
@@ -36,9 +36,11 @@ def _make_fake_repo(tmp_path: Path, *, sync_exit: str, audit_exit: str) -> Path:
     return tmp_path
 
 
-def _run_regen(fake_repo: Path, env: dict | None = None) -> subprocess.CompletedProcess:
+def _run_regen(
+    fake_repo: Path, env: dict | None = None, *args: str
+) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["bash", str(fake_repo / "scripts" / "docs_inventory_regen.sh")],
+        ["bash", str(fake_repo / "scripts" / "docs_inventory_regen.sh"), *args],
         cwd=fake_repo,
         capture_output=True,
         text=True,
@@ -147,3 +149,63 @@ def test_docs_audit_stats_json_path_still_used_on_clean_run(tmp_path):
     assert result.returncode == 0, result.stdout + result.stderr
     assert stats_path.exists()
     assert '"flips_this_run": 0' in stats_path.read_text()
+
+
+# ============================================================================
+# Footgun fix (2026-07-19, PR #2626 landing incident): the wrapper's default
+# invocation used to pass docs_audit.py no time-mode flag at all, which
+# silently meant "real today" inside docs_audit.py itself (see
+# test_docs_audit.py's own guilt/innocence pair for that half). The fix has
+# a WRAPPER-side half too: the default must thread --gate-consistent, and
+# only an explicit --organ argument may thread --as-of <today> instead. The
+# stub below captures its own argv so these tests verify the WRAPPER's
+# arg-passing plumbing specifically — a bug here (e.g. --organ silently
+# swallowed, or the wrong flag threaded) would not be caught by
+# test_docs_audit.py's tests, which invoke docs_audit.py directly and never
+# exercise this wrapper's own argument-forwarding logic at all.
+# ============================================================================
+
+_STUB_AUDIT_CAPTURE_ARGV = (
+    "#!/usr/bin/env python3\n"
+    "import sys, pathlib\n"
+    "pathlib.Path(__file__).parent.joinpath('captured_argv.txt').write_text(\n"
+    "    '\\n'.join(sys.argv[1:])\n"
+    ")\n"
+    "sys.exit(0)\n"
+)
+
+
+def test_default_invocation_passes_gate_consistent_not_as_of(tmp_path):
+    """INNOCENCE (wrapper plumbing): with no arguments, the wrapper must pass
+    --gate-consistent to docs_audit.py and must NOT pass --as-of — the
+    PR-side/contributor-safe default.
+    """
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_CAPTURE_ARGV
+    )
+    result = _run_regen(fake_repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+    captured = (fake_repo / "scripts" / "captured_argv.txt").read_text()
+    assert "--gate-consistent" in captured.split("\n"), captured
+    assert "--as-of" not in captured, captured
+
+
+def test_organ_flag_passes_as_of_today_not_gate_consistent(tmp_path):
+    """GUILT/mechanism (wrapper plumbing): with --organ, the wrapper must
+    pass --as-of <today, YYYY-MM-DD> to docs_audit.py and must NOT pass
+    --gate-consistent — the scheduled refresh organ's dated/wall-clock mode,
+    now requiring this explicit opt-in instead of being the silent default.
+    """
+    import datetime
+
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_CAPTURE_ARGV
+    )
+    result = _run_regen(fake_repo, None, "--organ")
+    assert result.returncode == 0, result.stdout + result.stderr
+    captured = (fake_repo / "scripts" / "captured_argv.txt").read_text().split("\n")
+    assert "--gate-consistent" not in captured, captured
+    assert "--as-of" in captured, captured
+    as_of_value = captured[captured.index("--as-of") + 1]
+    today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+    assert as_of_value == today, (as_of_value, today)


### PR DESCRIPTION
## Summary

Structural cure for the footgun that made PR #2626's own landing attempt go red: a write-mode `docs_audit.py` regen with no `--as-of` silently defaulted to real wall-clock ("today") for the orphan-eligibility time-crossing decision. `scripts/docs_inventory_regen.sh`'s plain-usage instructions never pass `--as-of` (documented as a testing/organ-only knob), so a contributor running the plain PR-side regen path could commit fresh `orphan_flipped_on` stamps that `inventory-check` (`--check`, always `as_of=None`) then rejected as drift **on the same PR**.

- `scripts/docs_audit.py`: new `--gate-consistent` write-mode opt-in flag — reproduces `--check`'s exact computation (`as_of=None`, provenance from `--trusted-ref`/origin-main) but WRITES the result instead of comparing. `docs_audit.py`'s own bare CLI default is **unchanged** (still real-"today") so every other direct caller (`scripts/docs_guardian.sh`, the weekly Pro cron) keeps its pre-existing behavior byte-for-byte — this is an opt-in, not a global default flip.
- `scripts/docs_inventory_regen.sh`: default invocation now passes `--gate-consistent` (safe to run+commit on a PR branch). The old dated/wall-clock behavior moves behind an explicit `--organ` flag (passes `--as-of "$(date -u +%Y-%m-%d)"`).
- `.github/workflows/docs-inventory-refresh.yml`: the scheduled refresh organ (the one caller whose job IS advancing flips from real time) now explicitly opts in via `--organ`.
- `scripts/docs_audit.py`'s `--check` drift message now points contributors at the safe wrapper (`bash scripts/docs_inventory_regen.sh`) instead of a bare invocation.
- Guilt/innocence test pair in `scripts/tests/test_docs_audit.py`: a dated regen committed on a branch still fails `--check` (guilt, regression-proofs the exact PR #2626 incident); a `--gate-consistent` regen committed on a branch passes `--check` cleanly (innocence, the actual fix). Plus 2 new CLI-rail tests for the new mutual exclusions (`--check`+`--gate-consistent`, `--as-of`+`--gate-consistent`).
- Wrapper-plumbing tests in `scripts/tests/test_docs_inventory_regen.py`: default invocation threads `--gate-consistent` not `--as-of`; `--organ` threads `--as-of <today>` not `--gate-consistent`.

## Test plan
- [x] `python -m pytest scripts/tests/test_docs_audit.py scripts/tests/test_docs_inventory_regen.py -q` — 53 passed locally
- [x] Full pre-push suite green (18444 passed, 197 skipped) on push
- [ ] CI required checks green post-open

🤖 Generated with [Claude Code](https://claude.com/claude-code)