### PR TITLE
fix(kg): redact API key from client-init log (CodeQL #4019)

### DIFF
--- a/apps/backend-rag/backend/services/knowledge_graph/incremental_builder.py
+++ b/apps/backend-rag/backend/services/knowledge_graph/incremental_builder.py
@@ -4,6 +4,7 @@ Integrates with AutonomousScheduler for automatic incremental KG updates
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 from datetime import datetime, timedelta, timezone
@@ -81,8 +82,12 @@ class KGIncrementalBuilder:
 
                 # Initialize with Google AI Studio API key
                 self._gemini_client = genai.Client(api_key=api_key)
+                # Log a non-reversible fingerprint, never the key material, so we can
+                # still verify (e.g. against the WhatsApp bot's key) WHICH key is in
+                # use without leaking it in clear text (CodeQL #4019).
+                key_fp = hashlib.sha256(api_key.encode()).hexdigest()[:8] if api_key else "none"
                 logger.info(
-                    f"✅ Gemini client initialized with Google AI Studio (API key: {api_key[:10]}...)",
+                    "✅ Gemini client initialized with Google AI Studio (key fp=%s)", key_fp
                 )
             except ImportError:
                 logger.warning("⚠️ google-genai SDK not available")


### PR DESCRIPTION
## What

`KGIncrementalBuilder._get_gemini_client()` logged the first 10 characters of
the live Google AI Studio API key in cleartext on every client
initialization:

```python
logger.info(
    f"✅ Gemini client initialized with Google AI Studio (API key: {api_key[:10]}...)",
)
```

Replaced with a non-reversible `sha256[:8]` fingerprint via lazy `%s`
logging (no f-string in the logger call, per repo clean-logging rule):

```python
key_fp = hashlib.sha256(api_key.encode()).hexdigest()[:8] if api_key else "none"
logger.info(
    "✅ Gemini client initialized with Google AI Studio (key fp=%s)", key_fp
)
```

## Why

CodeQL flagged this HIGH severity (clear-text logging of sensitive
information) — this maps to superscar family **#4 "Secret in the clear"**
in this repo's cicatrix ledger, this time via application logs rather than
filesystem permissions. Fly log retention + any downstream log aggregation
means 10 chars of a live API key persisting in cleartext is a real exposure
surface, not just a lint nit.

The fingerprint preserves the operationally useful part of the original
log line — confirming WHICH key is active (e.g. verifying the
KG-dedicated `KG_GOOGLE_API_KEY` is isolated from the WhatsApp bot's
shared `GOOGLE_API_KEY`, per the comment right above this code) — without
ever printing recoverable key material. `sha256` is one-way; 8 hex chars
is enough to distinguish two known keys without brute-force risk mattering
(this isn't a password hash, it's a diagnostic tag).

Defensive `else "none"` branch added even though the code path is
currently unreachable (guarded by an earlier `if not api_key: return None`)
in case that guard is ever refactored.

## Scope

Swept all 3 files named in the finding for sibling cleartext key/token/secret
logging (`api_key[:`, `key[:`, `token[:`, f-string/`%`-interpolated secrets):

- `apps/backend-rag/backend/services/knowledge_graph/incremental_builder.py` — **1 instance found and fixed** (the one above)
- `apps/backend-rag/scripts/kg_incremental_extraction.py` — none found (keys only used in headers/kwargs, never logged)
- `apps/backend-rag/backend/llm/genai_client.py` — none found (existing log lines mention env var *names* like `GOOGLE_APPLICATION_CREDENTIALS`, never values)

No other behavior changed.

Closes CodeQL alert #4019.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py -q` — 67 passed
- [x] `PYTHONPATH=. pytest backend/tests/unit/services/knowledge_graph/test_incremental_builder_live_path.py backend/tests/unit/services/knowledge_graph/test_incremental_builder.py backend/tests/services/knowledge_graph/test_incremental_builder.py -q` — 45 passed (no test asserted the old cleartext log text, so no test edits were needed)
- [x] `python -c "from backend.app.dependencies import get_current_user; print('OK')"` (import-chain check, ran as part of pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>