### PR TITLE
feat(wr2): DB-armed kicker/subhead variety steer (anti-anchoring)

### DIFF
--- a/scripts/tests/test_wr2_draft_generator_kicker_variety.py
+++ b/scripts/tests/test_wr2_draft_generator_kicker_variety.py
@@ -1,0 +1,808 @@
+"""
+Tests for the kicker/subhead variety fix (2026-07-20) + the same-day
+red-team fix round (guard-starvation, steer-reset, per-row isolation,
+schema-example de-anchor, fullwidth-colon bypass, colon-prefix lower bound,
+exhausted-pool degrade, MUST-NOT cap).
+
+PR #2544 (2026-07-16) banned "OUR TAKE"/"OUR READ"/"OUR VIEW" and added an
+example kicker list to rule #7 -- since then 3/3 decks used "THE SIGNAL: ..."
+(the FIRST example in that list). Root cause: variety instructions were
+prompt-only prose with no memory of previous output; every fixed example
+becomes an invariant. This extends the ONE axis that already had a proven
+DB-armed lookback (register/image-mode, P-4 Art 10.6) to the take-slide
+kicker and the cover subhead, and de-anchors BOTH static example surfaces
+(rule #7's "e.g." list AND the Structure JSON worked example's take-slide
+headline) so no single example can calcify again.
+
+The 2026-07-20 red-team round (Codex NO-SHIP, 4 MAJOR + 6 MINOR) additionally
+fixed: (1) guard starvation + steer-reset in the regen loop -- guards used
+to short-circuit each other and an anti-sameness retry silently discarded
+the editorial-variety steer; (2) a single malformed DB row used to zero out
+the WHOLE fetched history; (3) the Structure JSON schema example still
+taught a literal, unrotated kicker; plus 6 minor robustness fixes (fullwidth
+colon, colon-prefix word-count floor, exhausted-pool degrade, MUST-NOT cap,
+kicker-length wording, recency-clock note).
+
+These tests don't call Claude -- pure helpers + mocked asyncpg conn.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import wr2_draft_generator as dg  # noqa: E402
+from wr2_draft_generator import (  # noqa: E402
+    KICKER_EXAMPLE_VOCABULARY,
+    _VARIETY_STEER_KICKER_CAP,
+    _build_draft_prompt,
+    _build_variety_steer,
+    _extract_take_kicker,
+    _kicker_collision,
+    _normalize_kicker,
+    _render_kicker_examples,
+    _render_schema_kicker,
+    _sample_kickers,
+    fetch_recent_editorial_signatures,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _extract_take_kicker
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_extract_kicker_colon_shape() -> None:
+    assert _extract_take_kicker("THE SIGNAL: A headline, not a rule") == "THE SIGNAL"
+
+
+def test_extract_kicker_preserves_original_casing() -> None:
+    """Extraction returns the deck's own casing verbatim -- normalization
+    for matching happens separately in _normalize_kicker."""
+    assert _extract_take_kicker("Our read: the door got selective") == "Our read"
+
+
+def test_extract_kicker_no_colon_short_headline_uses_whole_headline() -> None:
+    """No colon, <=5 words -> the whole headline is treated as the kicker."""
+    assert _extract_take_kicker("The Upshot Today") == "The Upshot Today"
+
+
+def test_extract_kicker_no_colon_long_headline_is_skipped() -> None:
+    """No colon, >5 words -> not a kicker shape, skip (None)."""
+    headline = "This headline has more than five words total"
+    assert len(headline.split()) > 5
+    assert _extract_take_kicker(headline) is None
+
+
+def test_extract_kicker_long_colon_prefix_is_skipped() -> None:
+    """A >5-word prefix before the colon is not a 2-5 word kicker -- skip
+    rather than mis-signature it."""
+    headline = "This is a really really long kicker prefix here: the rest"
+    prefix = headline.partition(":")[0]
+    assert len(prefix.split()) > 5
+    assert _extract_take_kicker(headline) is None
+
+
+def test_extract_kicker_empty_headline_returns_none() -> None:
+    assert _extract_take_kicker("") is None
+    assert _extract_take_kicker(None) is None  # type: ignore[arg-type]
+
+
+def test_extract_kicker_single_word_colon_prefix_is_skipped() -> None:
+    """2026-07-20 red-team MINOR #6: a ONE-word prefix before the colon is a
+    scene-setter/dateline, not a kicker (rule #7's kicker is always a short
+    PHRASE, 2-5 words). 'BALI: THE DOOR JUST CLOSED' must be skipped."""
+    assert _extract_take_kicker("BALI: THE DOOR JUST CLOSED") is None
+
+
+def test_extract_kicker_two_word_colon_prefix_is_kept() -> None:
+    """Lower bound is 2, not 3 -- a legitimate 2-word kicker still extracts."""
+    assert _extract_take_kicker("THE CATCH: something happened") == "THE CATCH"
+
+
+def test_extract_kicker_fullwidth_colon_is_caught() -> None:
+    """2026-07-20 red-team MINOR #5: a fullwidth colon (U+FF1A) NFKC-folds
+    to ASCII ':' -- must not bypass extraction. Returned text comes from the
+    NFKC-normalized string (casing untouched)."""
+    headline = "THE SIGNAL： fresh angle"  # U+FF1A fullwidth colon
+    assert _extract_take_kicker(headline) == "THE SIGNAL"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _normalize_kicker
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_normalize_kicker_case_and_trailing_punct() -> None:
+    assert _normalize_kicker("THE SIGNAL:") == _normalize_kicker("the signal")
+
+
+def test_normalize_kicker_nbsp_folds_to_space() -> None:
+    """NFKC folds NBSP (U+00A0) to a plain space before whitespace collapse."""
+    nbsp_variant = "THE SIGNAL"
+    assert _normalize_kicker(nbsp_variant) == _normalize_kicker("THE SIGNAL")
+
+
+def test_normalize_kicker_never_touches_internal_punctuation() -> None:
+    """Internal hyphen ('THE TRADE-OFF') is not a terminal char, must survive."""
+    assert "-" in _normalize_kicker("THE TRADE-OFF")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _kicker_collision -- GUILT (must fire)
+# ─────────────────────────────────────────────────────────────────────────
+
+def _take_slide(headline: str) -> dict:
+    return {"slide_type": "take", "headline": headline}
+
+
+def test_collision_guilt_plain_match() -> None:
+    slides = [_take_slide("The Signal: fresh angle")]
+    hit = _kicker_collision(slides, ["THE SIGNAL"])
+    assert hit == "The Signal"  # verbatim, this deck's own casing
+
+
+def test_collision_guilt_recent_has_trailing_colon() -> None:
+    """Robustness: the recorded recent kicker itself carries a trailing
+    colon (e.g. extracted sloppily upstream) -- normalization strips it on
+    both sides, so the match still fires."""
+    slides = [_take_slide("The Signal: fresh angle")]
+    hit = _kicker_collision(slides, ["THE SIGNAL:"])
+    assert hit == "The Signal"
+
+
+def test_collision_guilt_nbsp_variant() -> None:
+    """Robustness: an NBSP standing in for a space in the recent history
+    must not defeat the match (NFKC-fold, mirrors composer.py's guard)."""
+    slides = [_take_slide("The Signal: fresh angle")]
+    hit = _kicker_collision(slides, ["THE SIGNAL"])
+    assert hit == "The Signal"
+
+
+def test_collision_guilt_fullwidth_colon_deck_headline() -> None:
+    """2026-07-20 red-team MAJOR #4 item (d): the NEW deck's headline uses a
+    fullwidth colon -- extraction must still catch it (MINOR #5), and the
+    resulting kicker must still collide against the recent history."""
+    slides = [_take_slide("THE SIGNAL： a fresh spin")]
+    hit = _kicker_collision(slides, ["THE SIGNAL"])
+    assert hit == "THE SIGNAL"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _kicker_collision -- INNOCENCE (must NOT fire, whole-string only)
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_collision_innocence_unrelated_kicker() -> None:
+    slides = [_take_slide("The Precedent: a different angle")]
+    assert _kicker_collision(slides, ["THE SIGNAL"]) is None
+
+
+def test_collision_innocence_substring_not_whole_word() -> None:
+    """'TAKEAWAY FOR SELLERS' contains 'TAKE' as a substring but must not
+    collide with a recent kicker 'TAKE' -- whole-string only (scar family #3)."""
+    slides = [_take_slide("TAKEAWAY FOR SELLERS")]
+    assert _kicker_collision(slides, ["TAKE"]) is None
+
+
+def test_collision_innocence_superset_phrase() -> None:
+    """'THE SIGNAL TODAY' must not collide with 'THE SIGNAL' -- whole-string,
+    not prefix/contains match."""
+    slides = [_take_slide("THE SIGNAL TODAY")]
+    assert _kicker_collision(slides, ["THE SIGNAL"]) is None
+
+
+def test_collision_innocence_no_recent_history() -> None:
+    slides = [_take_slide("THE SIGNAL: fresh")]
+    assert _kicker_collision(slides, []) is None
+
+
+def test_collision_innocence_non_take_slide_ignored() -> None:
+    """A slide that happens to contain a colliding headline but is NOT a
+    take-slide must not trigger collision (only slide_type == 'take' counts)."""
+    slides = [{"slide_type": "body", "headline": "THE SIGNAL: not actually a take"}]
+    assert _kicker_collision(slides, ["THE SIGNAL"]) is None
+
+
+def test_collision_innocence_single_word_colon_prefix() -> None:
+    """2026-07-20 red-team MAJOR #4 item (e): 'BALI: THE DOOR JUST CLOSED'
+    has a 1-word colon-prefix -- not extracted as a kicker at all (MINOR
+    #6), so it can never collide, even against a maximally-permissive
+    recent list."""
+    slides = [_take_slide("BALI: THE DOOR JUST CLOSED")]
+    assert _kicker_collision(slides, ["BALI", "THE DOOR JUST CLOSED"]) is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _build_variety_steer
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_variety_steer_empty_history_is_empty_string() -> None:
+    assert _build_variety_steer({"kickers": [], "subheads": []}) == ""
+
+
+def test_variety_steer_contains_kickers_and_subheads() -> None:
+    sig = {"kickers": ["THE SIGNAL", "THE UPSHOT"], "subheads": ["VISA UPDATE"]}
+    steer = _build_variety_steer(sig)
+    assert "THE SIGNAL" in steer
+    assert "THE UPSHOT" in steer
+    assert "VISA UPDATE" in steer
+    assert "MUST NOT" in steer  # kicker line is a hard ban in prompt language
+
+
+def test_variety_steer_kickers_only() -> None:
+    steer = _build_variety_steer({"kickers": ["THE SIGNAL"], "subheads": []})
+    assert "THE SIGNAL" in steer
+    assert steer  # non-empty
+
+
+def test_variety_steer_subheads_only() -> None:
+    steer = _build_variety_steer({"kickers": [], "subheads": ["TAX ALERT"]})
+    assert "TAX ALERT" in steer
+    assert steer
+
+
+def test_variety_steer_caps_kicker_list_at_12() -> None:
+    """2026-07-20 red-team MAJOR #4 item (g) / MINOR #8: the MUST-NOT list
+    is capped at _VARIETY_STEER_KICKER_CAP (12) even when the fetched
+    history carries more -- and the stated count in the sentence matches
+    the CAPPED length, not the raw one."""
+    assert _VARIETY_STEER_KICKER_CAP == 12
+    many_kickers = [f"KICKER NUMBER {i}" for i in range(20)]
+    steer = _build_variety_steer({"kickers": many_kickers, "subheads": []})
+    for k in many_kickers[:12]:
+        assert k in steer
+    for k in many_kickers[12:]:
+        assert k not in steer
+    assert "the last 12 take-slide kickers" in steer
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _sample_kickers / _render_kicker_examples -- example rotation / de-anchoring
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_render_examples_excludes_recent_kicker() -> None:
+    random.seed(1)
+    rendered = _render_kicker_examples(["THE SIGNAL"])
+    assert '"THE SIGNAL"' not in rendered
+
+
+def test_render_examples_returns_exactly_three() -> None:
+    random.seed(2)
+    rendered = _render_kicker_examples([])
+    # Each example is a quoted phrase separated by ", " -- count the quoted groups.
+    assert rendered.count('"') == 6  # 3 examples * 2 quote chars each
+
+
+def test_render_examples_deterministic_with_seeded_random() -> None:
+    random.seed(42)
+    first = _render_kicker_examples(["THE SIGNAL"])
+    random.seed(42)
+    second = _render_kicker_examples(["THE SIGNAL"])
+    assert first == second
+
+
+def test_render_examples_all_entries_come_from_vocabulary() -> None:
+    random.seed(3)
+    rendered = _render_kicker_examples([])
+    normalized_vocab = {_normalize_kicker(k) for k in KICKER_EXAMPLE_VOCABULARY}
+    for part in rendered.split(", "):
+        stripped = part.strip('"')
+        assert _normalize_kicker(stripped) in normalized_vocab
+
+
+def test_render_examples_exhausted_pool_returns_empty_string() -> None:
+    """2026-07-20 red-team MAJOR #4 item (f) / MINOR #7: when recent history
+    covers the ENTIRE vocabulary, _render_kicker_examples must return "" --
+    NEVER fall back to sampling from the (recently-used) full vocabulary,
+    which would silently reintroduce a banned kicker as a "suggestion"."""
+    rendered = _render_kicker_examples(list(KICKER_EXAMPLE_VOCABULARY))
+    assert rendered == ""
+
+
+def test_sample_kickers_exhausted_pool_returns_empty_list() -> None:
+    assert _sample_kickers(list(KICKER_EXAMPLE_VOCABULARY), 3) == []
+    assert _sample_kickers(list(KICKER_EXAMPLE_VOCABULARY), 1) == []
+
+
+def test_render_system_instructions_degrades_gracefully_when_exhausted() -> None:
+    """The rule #7 sentence stays grammatical (no bare 'e.g.  --') when the
+    example pool is exhausted -- MINOR #7's degrade-instead-of-empty policy."""
+    prompt = _build_draft_prompt(
+        topic="X", summary="body", source_url="",
+        recent_kickers=list(KICKER_EXAMPLE_VOCABULARY),
+    )
+    assert "e.g.  —" not in prompt
+    assert "used up the usual examples" in prompt
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _render_schema_kicker -- Structure JSON example de-anchor (MAJOR #3)
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_schema_kicker_excludes_recent_history() -> None:
+    """2026-07-20 red-team MAJOR #4 item (h): the Structure JSON example's
+    take-slide kicker must never render a recently-used kicker. Repeated
+    with many seeds to make a false pass (lucky sample) implausible."""
+    for seed in range(20):
+        random.seed(seed)
+        kicker = _render_schema_kicker(["THE SIGNAL"])
+        assert _normalize_kicker(kicker) != _normalize_kicker("THE SIGNAL")
+
+
+def test_schema_kicker_falls_back_to_generic_label_when_exhausted() -> None:
+    kicker = _render_schema_kicker(list(KICKER_EXAMPLE_VOCABULARY))
+    assert kicker == dg._SCHEMA_KICKER_FALLBACK
+    # The fallback is definitionally not IN the vocabulary, so it can never
+    # coincide with an actual recently-used kicker.
+    assert _normalize_kicker(kicker) not in {
+        _normalize_kicker(k) for k in KICKER_EXAMPLE_VOCABULARY
+    }
+
+
+def test_build_draft_prompt_exhausted_pool_schema_uses_angle_bracket_placeholder() -> None:
+    """2026-07-20 red-team round-3 item (c): the round-1 fallback
+    "YOUR FRESH KICKER" was ITSELF a static, teachable-looking string never
+    checked against history. Locked down as fixed: on an exhausted pool the
+    rendered Structure JSON schema line must carry the angle-bracket
+    TEMPLATE SLOT (unambiguously "fill this in", not a candidate kicker),
+    never the old literal fallback, and never any real vocabulary entry
+    (which would defeat the whole de-anchoring point)."""
+    prompt = _build_draft_prompt(
+        topic="X", summary="body", source_url="",
+        recent_kickers=list(KICKER_EXAMPLE_VOCABULARY),
+    )
+    assert '"headline": "<COIN A FRESH 2-4 WORD KICKER>: ...",' in prompt
+    assert "YOUR FRESH KICKER" not in prompt
+    for vocab_kicker in KICKER_EXAMPLE_VOCABULARY:
+        assert f'"headline": "{vocab_kicker}: ...",' not in prompt
+
+
+def test_build_draft_prompt_schema_headline_never_renders_recent_kicker() -> None:
+    """End-to-end: the FULL rendered prompt's Structure JSON example must
+    not contain the recently-used kicker as its take-slide headline."""
+    for seed in range(10):
+        random.seed(seed)
+        prompt = _build_draft_prompt(
+            topic="X", summary="body", source_url="", recent_kickers=["THE SIGNAL"],
+        )
+        assert '"headline": "THE SIGNAL: ...",' not in prompt
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _build_draft_prompt wiring -- both tokens resolved, examples threaded
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_build_draft_prompt_threads_recent_kickers_into_examples() -> None:
+    random.seed(7)
+    expected_examples = _render_kicker_examples(["THE SIGNAL"])
+    random.seed(7)
+    prompt = _build_draft_prompt(
+        topic="X", summary="body", source_url="", recent_kickers=["THE SIGNAL"],
+    )
+    assert expected_examples in prompt
+
+
+def test_build_draft_prompt_default_recent_kickers_is_none_safe() -> None:
+    """Existing call sites (no recent_kickers arg) must keep working, and
+    BOTH placeholder tokens must always be resolved."""
+    prompt = _build_draft_prompt(topic="X", summary="body", source_url="")
+    assert "__KICKER_EXAMPLES__" not in prompt
+    assert "__KICKER_EXAMPLE_TAKE__" not in prompt
+
+
+def test_build_draft_prompt_kicker_word_count_guidance_is_2_to_4() -> None:
+    """2026-07-20 red-team MINOR #9: the vocabulary includes 4-word entries
+    ('READ THE FINE PRINT') -- rule #7's stated word-count range must say
+    2-4, not the old (too-narrow) 2-3."""
+    prompt = _build_draft_prompt(topic="X", summary="body", source_url="")
+    assert "2-4 words" in prompt
+    assert "2-3 words" not in prompt
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# fetch_recent_editorial_signatures -- DB best-effort + per-row isolation
+# ─────────────────────────────────────────────────────────────────────────
+
+def _slides_row(slides: list[dict], *, as_json_string: bool = False):
+    blob = {"slides": slides}
+    return {"slides_json": json.dumps(blob) if as_json_string else blob}
+
+
+@pytest.mark.asyncio
+async def test_fetch_signatures_extracts_kickers_and_subheads() -> None:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            _slides_row(
+                [
+                    {"slide_type": "cover", "is_cover": True, "subhead": "VISA UPDATE"},
+                    {"slide_type": "take", "headline": "THE SIGNAL: a fresh angle"},
+                ]
+            ),
+        ]
+    )
+    sig = await fetch_recent_editorial_signatures(conn, limit=10)
+    assert sig["kickers"] == ["THE SIGNAL"]
+    assert sig["subheads"] == ["VISA UPDATE"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_signatures_handles_json_string_slides_json() -> None:
+    """slides_json may arrive as a JSON string from asyncpg (no jsonb codec
+    registered on this connection) -- mirrors wr2_daily_reconciler.py /
+    wr2_fact_checker.py's defensive isinstance(str) parsing."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            _slides_row(
+                [{"slide_type": "take", "headline": "THE UPSHOT: something"}],
+                as_json_string=True,
+            ),
+        ]
+    )
+    sig = await fetch_recent_editorial_signatures(conn, limit=10)
+    assert sig["kickers"] == ["THE UPSHOT"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_signatures_case_insensitive_dedup_keeps_first_casing_and_order() -> None:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            _slides_row([{"slide_type": "take", "headline": "The Signal: first"}]),
+            _slides_row([{"slide_type": "take", "headline": "THE SIGNAL: duplicate"}]),
+            _slides_row([{"slide_type": "take", "headline": "The Upshot: second"}]),
+        ]
+    )
+    sig = await fetch_recent_editorial_signatures(conn, limit=10)
+    # Dedup keeps the FIRST occurrence's casing; order preserved (newest-first
+    # is the row order the SQL already sorts by, this function just doesn't
+    # reorder further).
+    assert sig["kickers"] == ["The Signal", "The Upshot"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_signatures_best_effort_on_fetch_exception() -> None:
+    """conn.fetch raising -> empty shape, no exception propagates."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=RuntimeError("connection reset"))
+    sig = await fetch_recent_editorial_signatures(conn, limit=10)
+    assert sig == {"kickers": [], "subheads": []}
+
+
+@pytest.mark.asyncio
+async def test_fetch_signatures_best_effort_on_malformed_json() -> None:
+    """A row whose slides_json string doesn't parse must not crash the
+    whole lookback -- best-effort degrade to empty (single-row case)."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[{"slides_json": "{not valid json"}])
+    sig = await fetch_recent_editorial_signatures(conn, limit=10)
+    assert sig == {"kickers": [], "subheads": []}
+
+
+@pytest.mark.asyncio
+async def test_fetch_signatures_empty_rows_returns_empty_shape() -> None:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[])
+    sig = await fetch_recent_editorial_signatures(conn, limit=10)
+    assert sig == {"kickers": [], "subheads": []}
+
+
+@pytest.mark.asyncio
+async def test_fetch_signatures_mixed_good_malformed_good_keeps_both_good_rows() -> None:
+    """2026-07-20 red-team MAJOR #4 item (c) / MAJOR #2: per-row isolation.
+    Row order is good -> malformed -> good; the malformed row (index 1)
+    must be skipped WITHOUT wiping the surrounding good rows' kickers. The
+    OLD single try/except-around-the-whole-loop shape would have zeroed
+    out ALL THREE rows' worth of history on this exact input."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            _slides_row([{"slide_type": "take", "headline": "THE UPSHOT: first good row"}]),
+            {"slides_json": "{not valid json at all"},
+            _slides_row([{"slide_type": "take", "headline": "THE PRECEDENT: second good row"}]),
+        ]
+    )
+    sig = await fetch_recent_editorial_signatures(conn, limit=10)
+    assert sig["kickers"] == ["THE UPSHOT", "THE PRECEDENT"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Regen wiring -- unified escalation accumulation (MAJOR #1)
+# ─────────────────────────────────────────────────────────────────────────
+
+def _fake_slides_response(
+    take_headline: str = "Headline 2", closer_body: str = "Short close now."
+) -> dict:
+    return {
+        "register": "analitico",
+        "register_reason": "test",
+        "slides": [
+            {
+                "slide_number": i,
+                "slide_type": "cover" if i == 1 else ("take" if i == 2 else ("cta" if i == 6 else "body")),
+                "is_cover": i == 1,
+                "is_hero_image": i == 1,
+                "headline": take_headline if i == 2 else f"Headline {i}",
+                "subhead": "TEST TAG" if i == 1 else "",
+                "body": (closer_body if i == 6 else f"Body copy for slide {i}."),
+                "image_prompt": "editorial scene" if i == 1 else "",
+            }
+            for i in range(1, 7)
+        ],
+    }
+
+
+def _base_row(draft_id: uuid.UUID) -> dict:
+    return {
+        "id": draft_id,
+        "topic": "New KITAS Rule Takes Effect",
+        "brief_json": {
+            "article_summary": "A concrete news event happened today with real facts.",
+            "enrichment": {},
+            "staging_type": "regulation",
+            "liveness_tier": None,
+            "source_url": "https://example.com",
+        },
+    }
+
+
+def _wire_process_one_mocks(monkeypatch: pytest.MonkeyPatch, compose_mock: AsyncMock) -> None:
+    monkeypatch.setattr(dg, "claude_compose_slides", compose_mock)
+    monkeypatch.setattr(dg, "generate_cover_image", AsyncMock(return_value=(None, "skip-in-test")))
+    monkeypatch.setattr(dg, "_send_telegram", MagicMock())
+    monkeypatch.setattr(dg.wom, "resolve_carousel_id", AsyncMock(return_value="cid-test"))
+    monkeypatch.setattr(dg.wom, "record_step", AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_process_one_regenerates_on_kicker_collision_then_accepts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loop-level integration (mirrors the B2 _process_one pattern in
+    test_wr2_draft_generator_enriched_prompt.py): the DB lookback reports
+    'THE SIGNAL' as a recently-used kicker; the first compose attempt
+    reuses it (collision -> regen); the second attempt coins a fresh
+    kicker -> accepted. Proves the guard fires even though
+    WR2_ANTIMONOTONE_ENFORCE defaults to off (this guard is unconditional)."""
+    draft_id = uuid.uuid4()
+    row = _base_row(draft_id)
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    async def _fetch_side_effect(sql, *args, **kwargs):  # noqa: ANN001, ARG001
+        if "slides_json" in sql:
+            return [_slides_row([{"slide_type": "take", "headline": "THE SIGNAL: prior"}])]
+        return []
+
+    conn.fetch = AsyncMock(side_effect=_fetch_side_effect)
+
+    compose_mock = AsyncMock(
+        side_effect=[
+            _fake_slides_response("THE SIGNAL: reused kicker"),  # attempt 1: collides
+            _fake_slides_response("THE UPSHOT: fresh angle"),  # attempt 2: fresh
+        ]
+    )
+    _wire_process_one_mocks(monkeypatch, compose_mock)
+
+    outcome = await dg._process_one(conn, row)
+
+    assert outcome == "success"
+    assert compose_mock.await_count == 2
+
+    second_call_kwargs = compose_mock.await_args_list[1].kwargs
+    assert "THE SIGNAL" in second_call_kwargs["avoid_steer"]
+    assert "reused the kicker" in second_call_kwargs["avoid_steer"]
+
+    persist_calls = [c for c in conn.execute.call_args_list if "status" in c.args[0]]
+    assert any("'drafts'" in c.args[0] for c in persist_calls)
+
+
+@pytest.mark.asyncio
+async def test_process_one_closer_and_kicker_both_fire_no_starvation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2026-07-20 red-team MAJOR #4 item (a): the FIRST attempt has BOTH a
+    too-long closer AND a colliding kicker. The OLD structure's closer
+    guard `continue`d immediately, so the kicker guard never ran on that
+    attempt's output and the model never learned about the collision. The
+    FIXED structure evaluates every guard before deciding, so the SECOND
+    attempt's prompt must carry BOTH escalation messages."""
+    draft_id = uuid.uuid4()
+    row = _base_row(draft_id)
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    async def _fetch_side_effect(sql, *args, **kwargs):  # noqa: ANN001, ARG001
+        if "slides_json" in sql:
+            return [_slides_row([{"slide_type": "take", "headline": "THE SIGNAL: prior"}])]
+        return []
+
+    conn.fetch = AsyncMock(side_effect=_fetch_side_effect)
+
+    long_closer = " ".join(f"word{i}" for i in range(dg.CLOSER_MAX_WORDS + 5))
+    compose_mock = AsyncMock(
+        side_effect=[
+            # attempt 1: closer too long AND kicker collides
+            _fake_slides_response("THE SIGNAL: reused kicker", closer_body=long_closer),
+            # attempt 2: both fixed -> accepted
+            _fake_slides_response("THE UPSHOT: fresh angle", closer_body="Short close now."),
+        ]
+    )
+    _wire_process_one_mocks(monkeypatch, compose_mock)
+
+    outcome = await dg._process_one(conn, row)
+
+    assert outcome == "success"
+    assert compose_mock.await_count == 2
+
+    second_call_steer = compose_mock.await_args_list[1].kwargs["avoid_steer"]
+    # No starvation: BOTH the closer escalation AND the kicker escalation
+    # are present in the SAME retry prompt.
+    assert "closer" in second_call_steer.lower()
+    assert "reused the kicker" in second_call_steer
+    assert "THE SIGNAL" in second_call_steer
+
+
+@pytest.mark.asyncio
+async def test_process_one_antimonotone_regen_preserves_editorial_variety(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2026-07-20 red-team MAJOR #4 item (b): after an anti-sameness-style
+    regen, the retry prompt must STILL contain the EDITORIAL VARIETY block.
+    The OLD code rebuilt `avoid_steer = _build_avoid_steer(recent) + (...)`
+    from scratch on an anti-sameness collision, silently dropping the
+    editorial-variety steer computed before the loop -- a "steer reset" bug
+    this test locks down as fixed (base_steer is now immutable inside the
+    loop; only `escalations` accumulates)."""
+    draft_id = uuid.uuid4()
+    row = _base_row(draft_id)
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    async def _fetch_side_effect(sql, *args, **kwargs):  # noqa: ANN001, ARG001
+        if "slides_json" in sql:
+            # Non-empty editorial history -> _build_variety_steer produces a
+            # real EDITORIAL VARIETY block (kicker chosen so it never
+            # collides with either fake response's headline below).
+            return [_slides_row([{"slide_type": "take", "headline": "THE CATCH: prior"}])]
+        if "topic_type_log" in sql:
+            return [{"register": "analitico", "dominant_mode": "event-photo"}]
+        return []
+
+    conn.fetch = AsyncMock(side_effect=_fetch_side_effect)
+
+    monkeypatch.setenv("WR2_ANTIMONOTONE_ENFORCE", "true")
+    monkeypatch.setattr(dg.tt, "derive_domain", lambda topic: "visa")  # noqa: ARG005
+    monkeypatch.setattr(dg.tt, "derive_dominant_mode", lambda slides_json: "event-photo")  # noqa: ARG005
+
+    collide_calls = {"n": 0}
+
+    def _collides(register, dominant_mode, recent):  # noqa: ARG001
+        collide_calls["n"] += 1
+        return collide_calls["n"] == 1  # collide on attempt 1 only
+
+    monkeypatch.setattr(dg.tt, "collides_with_recent", _collides)
+
+    compose_mock = AsyncMock(
+        side_effect=[
+            _fake_slides_response("THE UPSHOT: attempt one"),
+            _fake_slides_response("THE PRECEDENT: attempt two"),
+        ]
+    )
+    _wire_process_one_mocks(monkeypatch, compose_mock)
+
+    outcome = await dg._process_one(conn, row)
+
+    assert outcome == "success"
+    assert compose_mock.await_count == 2
+
+    second_call_steer = compose_mock.await_args_list[1].kwargs["avoid_steer"]
+    assert "EDITORIAL VARIETY" in second_call_steer
+    assert "THE CATCH" in second_call_steer
+    assert "forbidden combination" in second_call_steer  # antimonotone escalation present too
+
+
+@pytest.mark.asyncio
+async def test_process_one_multi_guard_escalation_not_exclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2026-07-20 red-team round-3 item (a) (MAJOR #1 residue): when BOTH
+    the closer guard and the kicker guard fire on the same attempt, the
+    closer escalation must NOT claim exclusivity ("Rewrite ONLY the
+    closer") -- that wording contradicts the kicker escalation riding the
+    SAME retry prompt, which also demands a change. The retry prompt must
+    carry BOTH instructions without either claiming to be the only one."""
+    draft_id = uuid.uuid4()
+    row = _base_row(draft_id)
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    async def _fetch_side_effect(sql, *args, **kwargs):  # noqa: ANN001, ARG001
+        if "slides_json" in sql:
+            return [_slides_row([{"slide_type": "take", "headline": "THE SIGNAL: prior"}])]
+        return []
+
+    conn.fetch = AsyncMock(side_effect=_fetch_side_effect)
+
+    long_closer = " ".join(f"word{i}" for i in range(dg.CLOSER_MAX_WORDS + 5))
+    compose_mock = AsyncMock(
+        side_effect=[
+            _fake_slides_response("THE SIGNAL: reused kicker", closer_body=long_closer),
+            _fake_slides_response("THE UPSHOT: fresh angle", closer_body="Short close now."),
+        ]
+    )
+    _wire_process_one_mocks(monkeypatch, compose_mock)
+
+    outcome = await dg._process_one(conn, row)
+
+    assert outcome == "success"
+    assert compose_mock.await_count == 2
+
+    second_call_steer = compose_mock.await_args_list[1].kwargs["avoid_steer"]
+    assert "ONLY the closer" not in second_call_steer
+    # Both escalations are still present -- dropping "ONLY" must not have
+    # silently dropped the CONTENT of the closer guidance either.
+    assert "Rewrite the closer" in second_call_steer
+    assert "reused the kicker" in second_call_steer
+
+
+@pytest.mark.asyncio
+async def test_process_one_resolved_guard_escalation_cleared_next_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2026-07-20 red-team round-3 item (b) (MINOR "clear-on-pass"):
+    attempt 0 has a too-long closer (fires) with a fresh kicker (passes).
+    Attempt 1 fixes the closer (passes) but reuses a kicker (fires). The
+    THIRD attempt's prompt must NOT carry attempt 0's now-stale closer
+    escalation (which would misdescribe attempt 1 -- its closer was fine)
+    but MUST carry the live kicker escalation from attempt 1."""
+    draft_id = uuid.uuid4()
+    row = _base_row(draft_id)
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    async def _fetch_side_effect(sql, *args, **kwargs):  # noqa: ANN001, ARG001
+        if "slides_json" in sql:
+            return [_slides_row([{"slide_type": "take", "headline": "THE SIGNAL: prior"}])]
+        return []
+
+    conn.fetch = AsyncMock(side_effect=_fetch_side_effect)
+
+    long_closer = " ".join(f"word{i}" for i in range(dg.CLOSER_MAX_WORDS + 5))
+    compose_mock = AsyncMock(
+        side_effect=[
+            # attempt 0: closer too long, kicker fresh -> only "closer" fires
+            _fake_slides_response("THE UPSHOT: attempt zero", closer_body=long_closer),
+            # attempt 1: closer fixed, kicker reused -> "closer" resolved, "kicker" fires
+            _fake_slides_response("THE SIGNAL: attempt one", closer_body="Short close now."),
+            # attempt 2: both fine -> accepted
+            _fake_slides_response("THE PRECEDENT: attempt two", closer_body="Short close now."),
+        ]
+    )
+    _wire_process_one_mocks(monkeypatch, compose_mock)
+
+    outcome = await dg._process_one(conn, row)
+
+    assert outcome == "success"
+    assert compose_mock.await_count == 3
+
+    third_call_steer = compose_mock.await_args_list[2].kwargs["avoid_steer"]
+    # The resolved closer objection from attempt 0 must be GONE.
+    assert "Rewrite the closer" not in third_call_steer
+    assert "was too long" not in third_call_steer
+    # The live kicker objection from attempt 1 must still be present.
+    assert "reused the kicker" in third_call_steer
+    assert "THE SIGNAL" in third_call_steer

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -26,9 +26,11 @@ import asyncio
 import json
 import logging
 import os
+import random
 import re
 import sys
 import time
+import unicodedata
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -313,6 +315,42 @@ def _send_telegram(text: str) -> None:
 # Claude prompt (English output)
 # ─────────────────────────────────────────────────────────────────────────
 
+# ── Kicker/subhead variety (2026-07-20) ─────────────────────────────────────
+# PR #2544 (2026-07-16) banned "OUR TAKE"/"OUR READ"/"OUR VIEW" and added an
+# example kicker list to rule #7 below — since then 3/3 decks used "THE
+# SIGNAL: …" (the FIRST example in that list). Root cause: variety
+# instructions were prompt-only prose with NO memory of previous output —
+# every fixed example becomes the new invariant because it is the only
+# concrete thing the model can anchor on. This mirrors the ONE axis that
+# already has a proven DB-armed lookback (register/image-mode, P-4 Art 10.6:
+# `fetch_recent_same_domain` + `_build_avoid_steer` below) and extends the
+# same pattern to the take-slide kicker and the cover subhead, PLUS
+# de-anchors the static example list itself (`_render_kicker_examples`) so
+# no single example can calcify again. 2026-07-20 red-team MAJOR #3: the
+# Structure JSON worked example (below, slide 2) had its OWN static anchor
+# ("THE NET EFFECT: ...") — same disease, second site — so it gets its own
+# token + single-kicker sample via the same exclusion logic.
+_KICKER_EXAMPLES_TOKEN = "__KICKER_EXAMPLES__"
+_KICKER_EXAMPLE_TAKE_TOKEN = "__KICKER_EXAMPLE_TAKE__"
+
+KICKER_EXAMPLE_VOCABULARY: tuple[str, ...] = (
+    "THE UPSHOT",
+    "WHERE THIS LANDS",
+    "THE NET EFFECT",
+    "THE STAKES",
+    "THE SIGNAL",
+    "BETWEEN THE LINES",
+    "WHAT CHANGES NOW",
+    "THE QUIET PART",
+    "READ THE FINE PRINT",
+    "THE REAL COST",
+    "FOLLOW THE MONEY",
+    "THE PRECEDENT",
+    "WHY NOW",
+    "THE CATCH",
+    "THE TRADE-OFF",
+)
+
 SYSTEM_INSTRUCTIONS = """You are the Draft Composer of War Room 2.0 for Bali Zero (https://balizero.com).
 
 Bali Zero is an Indonesian business-services agency serving international expats, foreign investors, digital nomads and retirees — primarily English-speaking, from ~50 countries. The Italian community is one slice among many; never default to Italian.
@@ -446,17 +484,19 @@ STORYTELLING DIRECTIVES (overrides any default factual mode):
    needed.
 
 7. Bali Zero "take" slides (typically slide 2 and the last slide): open the
-   headline with a short UPPERCASE editorial-stance kicker (2-3 words —
-   e.g. "THE UPSHOT", "WHERE THIS LANDS", "THE NET EFFECT", "THE STAKES",
-   "THE SIGNAL", "BETWEEN THE LINES", "WHAT CHANGES NOW" — or coin a new
-   one in the same register if none fits this angle), then continue in
-   first-person editorial voice, NOT as a third-party legal summary. Pick
-   the kicker that fits THIS carousel; never default to the same one two
-   carousels running. NEVER use "OUR TAKE" / "OUR READ" / "OUR VIEW" —
-   those were single-example placeholders that became an invariant because
-   they were the only example ever shown, not a fixed slot to fill in. Also
-   NEVER "THE BOTTOM LINE" — that's a banned filler heading pattern
-   elsewhere in the doctrine (2026-07-16 red-team finding #3).
+   headline with a short UPPERCASE editorial-stance kicker (2-4 words —
+   __KICKER_EXAMPLES__), then continue in first-person editorial voice,
+   NOT as a third-party legal summary. Pick the kicker that fits THIS
+   carousel; never default to the same one two carousels running. NEVER use
+   "OUR TAKE" / "OUR READ" / "OUR VIEW" — those were single-example
+   placeholders that became an invariant because they were the only
+   example ever shown, not a fixed slot to fill in. Also NEVER "THE BOTTOM
+   LINE" — that's a banned filler heading pattern elsewhere in the doctrine
+   (2026-07-16 red-team finding #3). (2026-07-20: the example list above is
+   ROTATED per generation and EXCLUDES recently-used kickers — a static
+   example list is exactly how a single entry calcifies into a new
+   invariant, the same failure mode this rule already fixed once for the
+   OUR-TAKE family.)
 
 8. The "What This Means For You" type closer (the last slide): SHORT, DIRECT,
    action-oriented. Two sentences max. Ends with the Bali Zero CTA.
@@ -490,7 +530,7 @@ Structure:
       "slide_type": "take",
       "is_cover": false,
       "is_hero_image": false,
-      "headline": "THE NET EFFECT: ...",
+      "headline": "__KICKER_EXAMPLE_TAKE__: ...",
       "body": "First-person editorial take — reads as clean text-on-color, no photo needed."
     },
     {
@@ -555,6 +595,189 @@ ALSO MANDATORY: vary the `image_mode` (one of the 9 slugs above) across the
 HERO slides — use at least 4 DISTINCT modes per carousel; never let one scene
 type dominate the whole carousel.
 """
+
+
+# ── Kicker toolkit (2026-07-20) ─────────────────────────────────────────────
+# Pure, side-effect-free helpers shared by the DB lookback (fetch_recent_
+# editorial_signatures below), the regen guard (_kicker_collision, wired into
+# _process_one's generation loop) and the prompt-example de-anchor
+# (_render_kicker_examples). Grouped here, next to SYSTEM_INSTRUCTIONS, since
+# they all operate on the rule #7 kicker shape ("UPPERCASE KICKER: rest of
+# the sentence") that lives in that prompt text.
+
+
+def _normalize_kicker(text: str) -> str:
+    """Whole-string normalization for kicker collision matching. Mirrors
+    `wr2_html_renderer.composer._normalize_take_label` verbatim (NFKC fold,
+    whitespace collapse, terminal-punctuation strip, casefold) — duplicated
+    rather than imported: the composer module sits behind the Playwright
+    render-path import chain, which this launchd-invoked cron entry
+    deliberately avoids (see the BRAND_SUFFIX comment above re: why
+    backend.services.visual is inlined instead of imported). NFKC folds
+    NBSP and other compatibility-whitespace lookalikes to plain ASCII space;
+    `\\s+` collapse catches doubled/embedded whitespace; the terminal-punct
+    strip catches a trailing colon/dash a writer tacked on ("THE SIGNAL:");
+    casefold is the Unicode-correct case fold. Still whole-STRING, never
+    substring — callers only ever use this before an exact-set membership
+    check (scar family #3 over-match discipline)."""
+    normalized = unicodedata.normalize("NFKC", text)
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = normalized.strip(" \t\r\n:;,.-–—")
+    return normalized.casefold()
+
+
+def _extract_take_kicker(headline: str) -> str | None:
+    """Pull the editorial kicker off a take-slide headline (rule #7's
+    "UPPERCASE 2-4 word kicker, then a colon, then the take" shape — e.g.
+    "THE SIGNAL: A headline, not a rule" -> "THE SIGNAL").
+
+    NFKC-normalizes the headline BEFORE partitioning on ":" (2026-07-20
+    red-team MINOR #5): a fullwidth colon (U+FF1A, "："), which NFKC folds
+    to ASCII ":", would otherwise bypass extraction entirely — the colon
+    branch below never triggers on a fullwidth colon in the RAW string, so
+    the whole headline falls through to the no-colon path instead and can
+    get rejected as too long. Casing is untouched by NFKC, so the returned
+    text still reads naturally.
+
+    The colon-prefix path requires 2-5 words (2026-07-20 MINOR #6): a
+    single word before the colon ("BALI: THE DOOR JUST CLOSED") is a
+    scene-setter/dateline, not a kicker — rule #7's kicker is always a
+    short PHRASE. Falls back to the WHOLE headline when there is no colon,
+    but only if it is itself short enough to plausibly BE a kicker (1-5
+    words) — matches the take_label convention headlines sometimes use
+    without a colon separator. A long colon-less headline, a 1-word colon
+    prefix, or an over-long prefix before the colon, is not a kicker — just
+    an unusual take-slide the model wrote — so we skip it (return None)
+    rather than mis-signature it: a wrong signature would falsely accuse a
+    later attempt of colliding on words it never actually coined."""
+    headline = (headline or "").strip()
+    if not headline:
+        return None
+    normalized_headline = unicodedata.normalize("NFKC", headline)
+    prefix, sep, _rest = normalized_headline.partition(":")
+    if sep:
+        prefix = prefix.strip()
+        if prefix and 2 <= len(prefix.split()) <= 5:
+            return prefix
+        return None
+    if 1 <= len(normalized_headline.split()) <= 5:
+        return normalized_headline
+    return None
+
+
+def _kicker_collision(
+    slides: list[dict[str, Any]], recent_kickers: list[str]
+) -> str | None:
+    """Whole-string collision check between THIS deck's take-slide kicker(s)
+    and the recent-history kickers. Never substring (scar family #3:
+    "TAKEAWAY FOR SELLERS" contains "TAKE" but must not match; "THE SIGNAL
+    TODAY" must NOT match "THE SIGNAL" — both compared as complete
+    normalized strings via set membership, not `in`). Returns the offending
+    kicker verbatim (this deck's own casing, for the log/steer message) or
+    None."""
+    if not recent_kickers:
+        return None
+    recent_normalized = {_normalize_kicker(k) for k in recent_kickers if k}
+    if not recent_normalized:
+        return None
+    for slide in slides:
+        if slide.get("slide_type") != "take":
+            continue
+        kicker = _extract_take_kicker(str(slide.get("headline") or ""))
+        if kicker and _normalize_kicker(kicker) in recent_normalized:
+            return kicker
+    return None
+
+
+def _sample_kickers(recent_kickers: list[str] | None, k: int) -> list[str]:
+    """Sample up to `k` kickers from KICKER_EXAMPLE_VOCABULARY, EXCLUDING
+    (normalized) any kicker used by a recent carousel. Shared by
+    `_render_kicker_examples` (rule #7's "e.g." list, k=3) and
+    `_render_schema_kicker` (the Structure JSON worked example's take-slide
+    headline, k=1 — 2026-07-20 red-team MAJOR #3) so neither prompt surface
+    ever teaches a kicker the variety steer just banned in the SAME
+    prompt. Returns FEWER than k (down to zero) if the pool is exhausted
+    after exclusion — callers decide how to degrade (MINOR #7: falling
+    back to the full, recently-used vocabulary here would silently
+    reintroduce a banned kicker)."""
+    excluded = {_normalize_kicker(k_) for k_ in (recent_kickers or []) if k_}
+    pool = [v for v in KICKER_EXAMPLE_VOCABULARY if _normalize_kicker(v) not in excluded]
+    return random.sample(pool, k=min(k, len(pool)))
+
+
+def _render_kicker_examples(recent_kickers: list[str] | None = None) -> str:
+    """Render up to 3 example kickers from KICKER_EXAMPLE_VOCABULARY as a
+    quoted, comma-joined string for rule #7's "e.g. ..." list — the
+    de-anchoring fix: a STATIC example list is exactly how "THE SIGNAL"
+    became the new invariant after PR #2544 banned "OUR READ" (it was the
+    first, and only ever, example).
+
+    Returns "" when `_sample_kickers` exhausts the pool (2026-07-20
+    red-team MINOR #7) — the caller, `_render_kicker_examples_clause`,
+    degrades the surrounding sentence to a no-examples instruction rather
+    than ever falling back to the full (recently-used) vocabulary. Callers
+    that need determinism (tests) seed the module `random` instance before
+    calling; production calls take whatever PRNG state the process is
+    on — this is example ROTATION, not a security surface."""
+    sampled = _sample_kickers(recent_kickers, 3)
+    return ", ".join(f'"{k}"' for k in sampled)
+
+
+def _render_kicker_examples_clause(recent_kickers: list[str] | None = None) -> str:
+    """Render rule #7's full "e.g. ... — or coin a new one..." clause as a
+    grammatical instruction in BOTH modes (2026-07-20 red-team MINOR #7):
+    when `_render_kicker_examples` has examples to show, and when recent
+    history has exhausted the vocabulary and it returns "". A naive
+    "e.g.  — or coin a new one..." (empty examples spliced into the static
+    template) would read as broken prompt text."""
+    examples = _render_kicker_examples(recent_kickers)
+    if examples:
+        return (
+            f"e.g. {examples} — or coin a new one in the same register if "
+            "none fits this angle"
+        )
+    return (
+        "coin a new one in the same register that fits this angle — recent "
+        "carousels have already used up the usual examples"
+    )
+
+
+# Round-2 red-team (2026-07-20): the round-1 fallback "YOUR FRESH KICKER"
+# was ITSELF a static, teachable-looking string — same disease one level
+# down, and never checked against history either. An angle-bracket
+# TEMPLATE SLOT reads unambiguously as "fill this in", never as a literal
+# kicker to imitate, so once the pool is exhausted this needs no history
+# check at all — it can never coincide with a real kicker by construction.
+_SCHEMA_KICKER_FALLBACK = "<COIN A FRESH 2-4 WORD KICKER>"
+
+
+def _render_schema_kicker(recent_kickers: list[str] | None = None) -> str:
+    """Sample ONE kicker for the Structure JSON worked example's take-slide
+    headline (2026-07-20 red-team MAJOR #3): the schema example used to
+    teach a literal "THE NET EFFECT" kicker regardless of history — a
+    second static anchor point, identical in kind to the rule #7 list this
+    whole patch de-anchors. Falls back to `_SCHEMA_KICKER_FALLBACK` — an
+    angle-bracket template slot, not a candidate kicker — when the pool is
+    exhausted (MINOR #7's degrade policy applied here too)."""
+    sampled = _sample_kickers(recent_kickers, 1)
+    return sampled[0] if sampled else _SCHEMA_KICKER_FALLBACK
+
+
+def _render_system_instructions(recent_kickers: list[str] | None = None) -> str:
+    """SYSTEM_INSTRUCTIONS with rule #7's example-kicker placeholder AND the
+    Structure JSON example's take-slide-headline placeholder filled in for
+    this generation call. Kept as a function rather than baked into the
+    SYSTEM_INSTRUCTIONS constant itself: test_wr2_draft_generator_
+    json_example.py imports SYSTEM_INSTRUCTIONS directly and asserts on its
+    static "Structure:" JSON example — that contract must keep working
+    without a live random/DB call (the two tokens remain literal, unquoted
+    text inside a JSON string value there, so json.loads() still parses
+    the un-substituted constant)."""
+    return (
+        SYSTEM_INSTRUCTIONS
+        .replace(_KICKER_EXAMPLES_TOKEN, _render_kicker_examples_clause(recent_kickers))
+        .replace(_KICKER_EXAMPLE_TAKE_TOKEN, _render_schema_kicker(recent_kickers))
+    )
 
 
 def _build_enriched_brief(enrichment: dict[str, Any], live_reasons: list[str] | None) -> str:
@@ -660,6 +883,7 @@ def _build_draft_prompt(
     live_reasons: list[str] | None = None,
     avoid_steer: str = "",
     liveness_tier: str = "",
+    recent_kickers: list[str] | None = None,
 ) -> str:
     """Build the slide-composition prompt.
 
@@ -680,6 +904,12 @@ def _build_draft_prompt(
       - WR2_USE_FULL_ENRICHED_PROMPT == "false" (legacy opt-out), OR
       - enrichment dict is empty / missing all expected fields.
     Falls back to the enriched brief alone when `summary` is empty.
+
+    `recent_kickers` (2026-07-20): optional list of take-kickers used by
+    recent carousels, threaded through to `_render_system_instructions` so
+    rule #7's worked example list never suggests a kicker that's also
+    banned by the variety steer in `avoid_steer`. Defaults to None so
+    existing call sites are unaffected.
     """
     use_full_enriched = os.environ.get("WR2_USE_FULL_ENRICHED_PROMPT", "true").lower() == "true"
 
@@ -723,7 +953,9 @@ def _build_draft_prompt(
         "breaking": "6-7", "developing": "7-8", "evergreen": "9-10",
     }.get(liveness_tier, "6-8")
 
-    return f"""{SYSTEM_INSTRUCTIONS}{avoid_steer}{steer_block}
+    system_instructions = _render_system_instructions(recent_kickers)
+
+    return f"""{system_instructions}{avoid_steer}{steer_block}
 
 ---
 
@@ -844,11 +1076,13 @@ async def claude_compose_slides(
     live_reasons: list[str] | None = None,
     avoid_steer: str = "",
     liveness_tier: str = "",
+    recent_kickers: list[str] | None = None,
 ) -> dict[str, Any]:
     prompt = _build_draft_prompt(
         topic, summary, source_url,
         enrichment=enrichment, live_reasons=live_reasons,
         avoid_steer=avoid_steer, liveness_tier=liveness_tier,
+        recent_kickers=recent_kickers,
     )
     logger.info("Calling Claude OAuth for slide composition (prompt %d chars)", len(prompt))
     t0 = time.perf_counter()
@@ -1307,6 +1541,139 @@ def _build_avoid_steer(recent: list[dict[str, Any]]) -> str:
     )
 
 
+async def fetch_recent_editorial_signatures(
+    conn: asyncpg.Connection, limit: int = 10
+) -> dict[str, list[str]]:
+    """Last-N rendered/published drafts' take-slide kickers + cover subheads,
+    newest-first (2026-07-20 — extends the P-4 pattern above to the axis
+    that had NO DB-armed lookback: see the module comment above
+    KICKER_EXAMPLE_VOCABULARY for why).
+
+    Returns {"kickers": [...], "subheads": [...]}, both order-preserving and
+    deduped case-insensitively (keeps the FIRST occurrence's original casing
+    for display in the steer block — see `_build_variety_steer`).
+
+    Best-effort like its sibling `fetch_recent_same_domain`: any
+    CONNECTION-level exception (table/column not migrated yet on this DB,
+    network drop) returns the empty shape so generation is NEVER blocked
+    by this lookback. A single malformed ROW (bad JSON, unexpected shape)
+    is isolated per-row (2026-07-20 red-team MAJOR #2): it's skipped and
+    logged at debug, but the OTHER rows' history still survives — the
+    original single try/except around the whole loop meant one bad legacy
+    row could silently zero out an otherwise-healthy history.
+
+    `created_at DESC` orders by draft-CREATION time, not by when the
+    carousel actually rendered/published (MINOR #10) — an older draft that
+    finishes rendering later than a newer one can be shadowed out of the
+    top-`limit` window. Accepted as an approximation, not fixed: the drift
+    is bounded by the WR2 pipeline's own processing latency (hours, not
+    days) and self-heals as soon as it renders.
+    """
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT slides_json
+              FROM war_room_drafts
+             WHERE status IN ('rendered', 'published')
+               AND slides_json IS NOT NULL
+             ORDER BY created_at DESC
+             LIMIT $1
+            """,
+            limit,
+        )
+    except Exception as exc:  # noqa: BLE001 — connection-level, never block generation
+        logger.warning("fetch_recent_editorial_signatures failed: %s", exc)
+        return {"kickers": [], "subheads": []}
+
+    kickers: list[str] = []
+    kickers_seen: set[str] = set()
+    subheads: list[str] = []
+    subheads_seen: set[str] = set()
+
+    for row in rows:
+        try:
+            # slides_json arrives as a dict OR a JSON string depending on the
+            # asyncpg codec registration on this connection — mirrors the
+            # exact defensive pattern wr2_daily_reconciler.py /
+            # wr2_fact_checker.py already use for the same column.
+            blob = row["slides_json"]
+            if isinstance(blob, str):
+                blob = json.loads(blob)
+            slides = blob.get("slides") if isinstance(blob, dict) else blob
+            if not isinstance(slides, list):
+                continue
+
+            for slide in slides:
+                if not isinstance(slide, dict):
+                    continue
+                if slide.get("slide_type") == "take":
+                    kicker = _extract_take_kicker(str(slide.get("headline") or ""))
+                    if kicker:
+                        key = _normalize_kicker(kicker)
+                        if key not in kickers_seen:
+                            kickers_seen.add(key)
+                            kickers.append(kicker)
+                if slide.get("is_cover"):
+                    subhead = str(slide.get("subhead") or "").strip()
+                    if subhead:
+                        key = _normalize_kicker(subhead)
+                        if key not in subheads_seen:
+                            subheads_seen.add(key)
+                            subheads.append(subhead)
+        except Exception as exc:  # noqa: BLE001 — isolate one bad row, keep the rest
+            logger.debug("fetch_recent_editorial_signatures: skipping malformed row: %s", exc)
+            continue
+
+    return {"kickers": kickers, "subheads": subheads}
+
+
+_VARIETY_STEER_KICKER_CAP = 12
+
+
+def _build_variety_steer(sig: dict[str, list[str]]) -> str:
+    """Render the recent take-kicker + cover-subhead history as a soft-steer
+    block, mirroring `_build_avoid_steer`'s shape. Empty history (both lists
+    empty) -> empty string, so this never touches the prompt when there's
+    nothing to steer away from.
+
+    The kicker line is phrased as a MUST-NOT (whole-phrase match, enforced
+    by `_kicker_collision`'s regen guard in the generation loop). The
+    subhead line is phrased as a softer "avoid the same formula" nudge —
+    spec calls for a ban only on kickers; subheads have no regen guard.
+
+    The MUST-NOT kicker list is capped at `_VARIETY_STEER_KICKER_CAP`
+    (2026-07-20 red-team MINOR #8): `fetch_recent_editorial_signatures`
+    can return up to ~2x its draft `limit` (a draft's cover AND closer are
+    both often "take"-type slides), and an uncapped list bloats the prompt
+    without adding real steering value beyond the most recent handful. The
+    cap is local to THIS rendering — `_kicker_collision`'s regen guard and
+    `_render_system_instructions`'s example de-anchor still see the FULL
+    uncapped history via `sig["kickers"]` directly."""
+    kickers = (sig.get("kickers") or [])[:_VARIETY_STEER_KICKER_CAP]
+    subheads = sig.get("subheads") or []
+    if not kickers and not subheads:
+        return ""
+
+    lines = ["\n\nEDITORIAL VARIETY (2026-07-20):"]
+    if kickers:
+        kicker_list = ", ".join(f"{k!r}" for k in kickers)
+        lines.append(
+            f"the last {len(kickers)} take-slide kickers we used were: "
+            f"{kicker_list}. The take-slide kicker in THIS carousel MUST NOT "
+            "be any of these (whole-phrase match) — coin a FRESH kicker that "
+            "fits THIS carousel's specific angle."
+        )
+    if subheads:
+        subhead_list = ", ".join(f"{s!r}" for s in subheads)
+        lines.append(
+            f"Recent cover subheads were: {subhead_list} — avoid repeating "
+            'the same formula (e.g. don\'t produce yet another "X ALERT" if '
+            "the recent list is saturated with ALERT/UPDATE variants). "
+            "Subheads are a soft steer here, not a ban."
+        )
+    return "\n".join(lines)
+
+
 async def _persist_ready(
     conn: asyncpg.Connection,
     draft_id: uuid.UUID,
@@ -1427,14 +1794,47 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> _Proces
     # real data. The "unknown" domain bucket is never constrained.
     prospective_domain = tt.derive_domain(topic)
     recent = await fetch_recent_same_domain(conn, prospective_domain, limit=2)
-    avoid_steer = _build_avoid_steer(recent)
+
+    # ── Kicker/subhead variety lookback (2026-07-20) ────────────────────────
+    # ALWAYS ON (unlike the domain anti-sameness above, whose HARD reject
+    # loop only engages when WR2_ANTIMONOTONE_ENFORCE=true) — see the module
+    # comment above KICKER_EXAMPLE_VOCABULARY for why this axis needed its
+    # own DB-armed lookback. `editorial_signatures["kickers"]` also threads
+    # into claude_compose_slides below so rule #7's worked-example list
+    # never suggests a kicker this same steer just banned.
+    editorial_signatures = await fetch_recent_editorial_signatures(conn, limit=10)
+
+    # `base_steer` is the ALWAYS-ON portion (domain anti-sameness + editorial
+    # variety), computed ONCE. Per-attempt regen feedback lives in
+    # `escalations` below and is APPENDED on top of this every attempt — it
+    # is never rebuilt from scratch (2026-07-20 red-team MAJOR #1: the old
+    # anti-sameness retry rebuilt `avoid_steer = _build_avoid_steer(recent) +
+    # (...)`, which silently discarded the EDITORIAL VARIETY block and any
+    # closer/kicker escalation accumulated on prior attempts — a "steer
+    # reset" bug).
+    base_steer = _build_avoid_steer(recent) + _build_variety_steer(editorial_signatures)
+
     enforce = os.environ.get("WR2_ANTIMONOTONE_ENFORCE", "false").lower() == "true"
     max_regen = 2  # => up to 3 total generation attempts
 
     parsed: dict[str, Any] | None = None
     register = ""
     slides: list[dict[str, Any]] = []
+    # Regen-feedback accumulator, keyed by guard name (2026-07-20 red-team
+    # MAJOR #1, refined round-2 MINOR "clear-on-pass"). Each guard that
+    # fires on an attempt SETS its own key, replacing any PREVIOUS message
+    # from the SAME guard (so repeated A4 failures don't duplicate lines);
+    # each guard that does NOT fire POPS its own key (so a RESOLVED
+    # objection — one whose "Your PREVIOUS attempt..." wording would
+    # otherwise go stale and misdescribe the attempt that's actually about
+    # to be retried — disappears instead of riding along forever). Every
+    # OTHER guard's entry is left untouched either way — the next attempt's
+    # prompt is `base_steer` plus only the escalations still LIVE, from any
+    # guard, in guard-name order.
+    escalations: dict[str, str] = {}
     for attempt in range(max_regen + 1):
+        avoid_steer = base_steer + "".join(escalations.values())
+
         # B11: per-step observability (wr2_orchestrator_metrics, migration 203 —
         # had zero writer before this). Wraps the single Claude call that stands
         # in for the interactive path's brief_interpreter (this script composes
@@ -1448,6 +1848,7 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> _Proces
                 topic=topic, summary=summary, source_url=source_url,
                 enrichment=enrichment, live_reasons=live_reasons,
                 avoid_steer=avoid_steer, liveness_tier=liveness_tier,
+                recent_kickers=editorial_signatures.get("kickers"),
             )
         except (ClaudeOAuthError, ClaudeOAuthNotAvailable) as e:
             _wom_error = e
@@ -1485,11 +1886,28 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> _Proces
             await _mark_rejected(conn, draft_id, f"normalise_error: {e}")
             return "failed"
 
+        # Evaluate ALL regen guards against THIS attempt's slides — never
+        # short-circuit on the first hit (2026-07-20 red-team MAJOR #1: the
+        # old structure had each guard `continue` immediately on firing,
+        # which meant a long closer STARVED the kicker-collision and
+        # anti-sameness guards of ever running on that attempt's output —
+        # a real defect could ship because only the FIRST guard in source
+        # order ever got a chance to object). `fired` collects every guard
+        # that objected; the retry/accept decision is made ONCE at the end,
+        # after all three have had a look.
+        fired = False
+
         # A4 closer guard (tier-independent, flag-independent): if the closing
         # statement-bomb body is too long it wraps into a text-brick. WARN + a
         # targeted regen asking the model to compress it — never a hard reject.
-        # Checked BEFORE anti-sameness so it works even with WR2_ANTIMONOTONE off.
         if _closer_too_long(slides):
+            fired = True
+            escalations["closer"] = (
+                "\n\nYour PREVIOUS attempt's LAST slide (the closer) was too long "
+                f"({_closer_word_count(slides)} words). Rewrite the closer as a "
+                f"single-line bold statement of at most {CLOSER_MAX_WORDS} words "
+                "(apply any other corrections requested below/above as well)."
+            )
             if attempt < max_regen:
                 logger.warning(
                     "Draft %s closer too long (%d words > %d) — regenerating for a "
@@ -1497,48 +1915,92 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> _Proces
                     draft_id, _closer_word_count(slides), CLOSER_MAX_WORDS,
                     attempt + 1, max_regen,
                 )
-                avoid_steer = avoid_steer + (
-                    "\n\nYour PREVIOUS attempt's LAST slide (the closer) was too long "
-                    f"({_closer_word_count(slides)} words). Rewrite ONLY the closer as a "
-                    f"single-line bold statement of at most {CLOSER_MAX_WORDS} words."
+            else:
+                logger.warning(
+                    "Draft %s closer still too long (%d words) after %d retries — "
+                    "proceeding anyway (WARN); Legge 5 backstop at the review gate.",
+                    draft_id, _closer_word_count(slides), max_regen,
                 )
-                continue  # regenerate
-            logger.warning(
-                "Draft %s closer still too long (%d words) after %d retries — "
-                "proceeding anyway (WARN); Legge 5 backstop at the review gate.",
-                draft_id, _closer_word_count(slides), max_regen,
-            )
+        else:
+            # Resolved: this guard no longer objects, so its (possibly
+            # stale, "PREVIOUS attempt"-worded) message must not ride the
+            # next prompt (2026-07-20 red-team round-2 MINOR).
+            escalations.pop("closer", None)
 
-        # Derived signature of THIS draft for the anti-sameness check.
+        # Kicker-collision regen guard (2026-07-20, mirrors A4 above: tier-
+        # and flag-INDEPENDENT — this must fire even when
+        # WR2_ANTIMONOTONE_ENFORCE is off, unlike the domain anti-sameness
+        # check below it). WARN + a single targeted regen, never a hard
+        # reject; Legge 5 (human review) is the backstop if it persists.
+        collision_kicker = _kicker_collision(
+            slides, editorial_signatures.get("kickers") or []
+        )
+        if collision_kicker:
+            fired = True
+            escalations["kicker"] = (
+                f"\n\nYour PREVIOUS attempt reused the kicker {collision_kicker!r} "
+                "which recent carousels already used. Choose a DIFFERENT "
+                "kicker — coin a fresh one for this angle."
+            )
+            if attempt < max_regen:
+                logger.warning(
+                    "Draft %s take-kicker collision (%r already used by a "
+                    "recent carousel) — regenerating for a fresh kicker "
+                    "(attempt %d/%d).",
+                    draft_id, collision_kicker, attempt + 1, max_regen,
+                )
+            else:
+                logger.warning(
+                    "Draft %s take-kicker collision persisted after %d retries "
+                    "(%r) — proceeding anyway (WARN); Legge 5 backstop at the "
+                    "review gate.",
+                    draft_id, max_regen, collision_kicker,
+                )
+        else:
+            escalations.pop("kicker", None)
+
+        # P-4 anti-sameness (constitution Art 10.6): the HARD reject only
+        # engages when WR2_ANTIMONOTONE_ENFORCE=true (default OFF) — when
+        # off, `antimonotone_collision` is always False, matching the
+        # original "always accept on this axis" behaviour.
         slides_envelope = {"slides": slides}
         dominant_mode = tt.derive_dominant_mode(slides_envelope)
-
-        if (
-            not enforce
-            or prospective_domain == tt.UNKNOWN
-            or not tt.collides_with_recent(register, dominant_mode, recent)
-        ):
-            break  # accepted (enforcement off, unknown domain, or no collision)
-
-        if attempt < max_regen:
-            logger.warning(
-                "Anti-sameness collision (domain=%s register=%s mode=%s) vs recent "
-                "%s — regenerating (attempt %d/%d).",
-                prospective_domain, register, dominant_mode, recent,
-                attempt + 1, max_regen,
-            )
-            # Strengthen the steer on retry so the model does not repeat itself.
-            avoid_steer = _build_avoid_steer(recent) + (
+        antimonotone_collision = (
+            enforce
+            and prospective_domain != tt.UNKNOWN
+            and tt.collides_with_recent(register, dominant_mode, recent)
+        )
+        if antimonotone_collision:
+            fired = True
+            escalations["antimonotone"] = (
                 "\n\nYour PREVIOUS attempt repeated a forbidden combination. "
                 f"Do NOT use register={register!r} with image-mode={dominant_mode!r} "
                 "again. Change at least one of them."
             )
+            if attempt < max_regen:
+                logger.warning(
+                    "Anti-sameness collision (domain=%s register=%s mode=%s) vs recent "
+                    "%s — regenerating (attempt %d/%d).",
+                    prospective_domain, register, dominant_mode, recent,
+                    attempt + 1, max_regen,
+                )
+            else:
+                logger.warning(
+                    "Anti-sameness collision persisted after %d retries "
+                    "(domain=%s register=%s mode=%s) — proceeding anyway (WARN).",
+                    max_regen, prospective_domain, register, dominant_mode,
+                )
         else:
-            logger.warning(
-                "Anti-sameness collision persisted after %d retries "
-                "(domain=%s register=%s mode=%s) — proceeding anyway (WARN).",
-                max_regen, prospective_domain, register, dominant_mode,
-            )
+            escalations.pop("antimonotone", None)
+
+        if not fired:
+            break  # accepted — no guard objected to this attempt's output
+
+        if attempt < max_regen:
+            continue  # regenerate with every guard's accumulated escalation
+        # Last attempt exhausted: every guard that still objects has already
+        # logged its own "proceeding anyway" WARN above — fall out of the
+        # loop and ship what we have (Legge 5 backstop at the review gate).
 
     assert parsed is not None  # loop always sets parsed or returns
 


### PR DESCRIPTION
## Summary

- **Diagnosis**: PR #2544 banned "OUR TAKE"/"OUR READ"/"OUR VIEW" and added an example kicker list to the take-slide prompt rule — since then 3/3 decks used "THE SIGNAL: ..." (the first example in that list), replaying the same disease that produced 30x "Our read" before it. Root cause: variety instructions were prompt-only prose with no memory of previous output, so every fixed example calcifies into the new invariant.
- **Mechanism**: extends the ONE axis that already had a proven DB-armed lookback (register/image-mode anti-sameness, P-4 Art 10.6) to the take-slide kicker and the cover subhead:
  - `fetch_recent_editorial_signatures` — last-N rendered/published drafts' kickers + subheads, per-row isolated (one malformed row never zeroes the whole history)
  - `_build_variety_steer` — MUST-NOT kicker steer (capped at 12) + soft subhead nudge, always on
  - `_kicker_collision` regen guard — whole-string match (never substring), unified into a single guard-escalation loop with the pre-existing closer guard and the (flag-gated) anti-sameness guard so no guard starves another and no retry silently resets the accumulated steer
  - Example-list de-anchoring: rule #7's "e.g." list AND the Structure JSON worked example's take-slide headline are both rotated per generation, excluding recently-used kickers, with a graceful degrade (never falls back to the exhausted, recently-used vocabulary) when history saturates the pool
- **Adversarial rounds**: 3 rounds of Codex (`gpt-5.6-sol`) red-team review — round 1 NO-SHIP (4 MAJOR + 6 MINOR: guard starvation, steer-reset, schema-example anchor, per-row DB isolation, fullwidth-colon bypass, colon-prefix floor, exhausted-pool fallback, MUST-NOT cap, word-count wording, recency-clock note), round 2 re-gate 7/8 cured (3 residual: closer-escalation exclusivity wording, stale-escalation clearing, teachable-string fallback), round 3 all cured.
- **Tests**: 93 tests across `test_wr2_draft_generator_kicker_variety.py` (56), `test_wr2_draft_generator_json_example.py` (5), `test_wr2_draft_generator_closer_guard.py` (11), `test_wr2_pipeline_consolidation.py` (21) — all green, plus the full pre-push suite (18444 passed, 198 skipped).

## Test plan

- [x] `apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_wr2_draft_generator_kicker_variety.py scripts/tests/test_wr2_draft_generator_json_example.py scripts/tests/test_wr2_draft_generator_closer_guard.py scripts/tests/test_wr2_pipeline_consolidation.py -q` → 93 passed
- [x] `ruff check` + `py_compile` clean
- [x] Full pre-push suite (18444 passed, 198 skipped) — confirmed via the M5 pre-push gate on this push
- [ ] Post-merge: PROVE-LIVE on the next `wr2_draft_generator.py` cron run (05:15 WITA) — confirm a generated deck's take-kicker differs from the last N rendered/published decks

🤖 Generated with [Claude Code](https://claude.com/claude-code)