### PR TITLE
fix(activation-plan): regulatory-watcher partial-cascade bug + MCP get_collection_stats

### DIFF
--- a/apps/backend-rag/backend/app/routers/health.py
+++ b/apps/backend-rag/backend/app/routers/health.py
@@ -1014,9 +1014,11 @@ async def collections_health(request: Request) -> dict[str, Any]:
     except Exception as e:
         logger.warning("Failed to get collection freshness: %s", e)
 
-    # Get live point counts from Qdrant
+    # Get live point counts + vector config from Qdrant (per-collection, not the
+    # in-process op-counter get_qdrant_stats() below returns only an aggregate for).
     qdrant_stats = await get_qdrant_stats()
     live_counts: dict[str, int] = {}
+    live_config: dict[str, dict[str, Any]] = {}
     try:
         client = _get_qdrant_client()
         response = await client.get("/collections")
@@ -1028,14 +1030,24 @@ async def collections_health(request: Request) -> dict[str, Any]:
                 try:
                     coll_response = await client.get(f"/collections/{coll_name}")
                     coll_response.raise_for_status()
-                    points = coll_response.json().get("result", {}).get("points_count", 0)
-                    live_counts[coll_name] = points
+                    result = coll_response.json().get("result", {})
+                    live_counts[coll_name] = result.get("points_count", 0)
+                    vectors = result.get("config", {}).get("params", {}).get("vectors", {})
+                    live_config[coll_name] = {
+                        "status": result.get("status", "unknown"),
+                        # Named-vector collections (hybrid dense+sparse) nest per
+                        # vector name here instead of a flat size/distance pair —
+                        # same simplification as QdrantClient.get_stats() (qdrant_db.py).
+                        "vector_size": vectors.get("size") if isinstance(vectors, dict) else None,
+                        "distance": vectors.get("distance") if isinstance(vectors, dict) else None,
+                        "segments_count": result.get("segments_count"),
+                    }
                 except Exception:
                     pass
     except Exception as e:
         logger.warning("Failed to get live Qdrant counts: %s", e)
 
-    # Merge freshness + live counts
+    # Merge freshness + live counts + live config
     collections: dict[str, Any] = {}
     all_names = set(freshness.keys()) | set(live_counts.keys())
     for name in sorted(all_names):
@@ -1043,6 +1055,7 @@ async def collections_health(request: Request) -> dict[str, Any]:
         if name in freshness:
             entry.update(freshness[name])
         entry["live_points"] = live_counts.get(name, None)
+        entry.update(live_config.get(name, {}))
         collections[name] = entry
 
     return {

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_health.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_health.py
@@ -123,3 +123,49 @@ class TestHealthRouter:
             result = await get_qdrant_stats()
             assert result["collections"] == 0
             assert "error" in result
+
+    def test_collections_health_includes_vector_config(self, app, client):
+        """2026-07-19 audit lever #11: /health/collections must return real
+        per-collection vector_size/distance/status/segments_count, not just a
+        bare point count — get_collection_stats' docstring promised this and
+        the MCP tool used to proxy a different, always-near-zero endpoint
+        instead. Pin the fields here so a regression is caught at this layer,
+        not rediscovered by re-auditing the MCP tool by hand."""
+        mock_client = AsyncMock()
+
+        collections_resp = MagicMock()
+        collections_resp.json.return_value = {
+            "result": {"collections": [{"name": "kbli_2025_final"}]},
+        }
+        collections_resp.raise_for_status = MagicMock()
+
+        detail_resp = MagicMock()
+        detail_resp.json.return_value = {
+            "result": {
+                "points_count": 1563,
+                "status": "green",
+                "segments_count": 4,
+                "config": {"params": {"vectors": {"size": 1536, "distance": "Cosine"}}},
+            },
+        }
+        detail_resp.raise_for_status = MagicMock()
+
+        async def get_side_effect(url):
+            return collections_resp if url == "/collections" else detail_resp
+
+        mock_client.get = AsyncMock(side_effect=get_side_effect)
+        # AsyncMock().is_closed is itself a truthy auto-attribute, so without
+        # this _get_qdrant_client() reads "closed" and silently replaces the
+        # mock with a brand-new REAL httpx.AsyncClient (proved live: the first
+        # draft of this test hit actual Qdrant Cloud and got real collections).
+        mock_client.is_closed = False
+        health_mod._qdrant_client = mock_client
+
+        response = client.get("/health/collections")
+        assert response.status_code == 200
+        entry = response.json()["collections"]["kbli_2025_final"]
+        assert entry["live_points"] == 1563
+        assert entry["vector_size"] == 1536
+        assert entry["distance"] == "Cosine"
+        assert entry["status"] == "green"
+        assert entry["segments_count"] == 4

--- a/apps/nuzantara-mcp-advanced/nuzantara_mcp_advanced/server.py
+++ b/apps/nuzantara-mcp-advanced/nuzantara_mcp_advanced/server.py
@@ -554,13 +554,19 @@ async def check_system_health() -> dict:
 async def get_collection_stats() -> dict:
     """
     Get Qdrant collection statistics.
-    
+
     Returns:
-        Vector counts, sizes, and health for all collections
+        Per-collection point counts, vector size/distance, status, and
+        freshness for every canonical collection.
     """
+    # 2026-07-19 audit finding (activation-plan lever #11): this tool used to hit
+    # /health/metrics/qdrant — the SAME in-process op-counter get_qdrant_metrics()
+    # returns, always near-zero on a fresh process and carrying zero per-collection
+    # data despite the docstring's promise. /health/collections is the endpoint
+    # that actually walks Qdrant's own /collections + /collections/{name}.
     try:
         client = _get_health_client()
-        resp = await client.get("/health/metrics/qdrant")
+        resp = await client.get("/health/collections")
         return resp.json()
     except Exception as e:
         return {"error": str(e)}

--- a/infra/launchagents/wrappers/regulatory-watcher-run.sh
+++ b/infra/launchagents/wrappers/regulatory-watcher-run.sh
@@ -227,6 +227,43 @@ ensure_delta() {
     return 1
 }
 
+# 2026-07-20 live find: a delta can satisfy the schema (new_today_count + deltas
+# keys) while the model admits `partial:true` — proved live when Claude+agy+Codex
+# all missed on the same run and ollama qwen3.5 (no web access) answered "I cannot
+# browse JDIH/peraturan.go.id... I will provide a JSON structure reflecting zero
+# new findings" and then emitted a schema-valid {new_today_count:0, partial:true}
+# stub. ensure_delta()'s schema check (has the right KEYS) cannot tell that stub
+# apart from a real completed scan that genuinely found nothing — only `partial`
+# does. A false "0 new" is worse than a visible gap: a gap is honestly absent,
+# this looks like a clean day and silently is not one.
+delta_is_partial() {
+    [ -f "$DELTA_JSON" ] || return 1
+    "$PYBIN" -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+sys.exit(0 if d.get("partial") else 1)
+' "$DELTA_JSON"
+}
+
+# Tiers 1-3 use this: a partial stub does NOT count as success — remove it (so
+# the next tier's ensure_delta() does not short-circuit on the stale file via
+# its own "[ -f "$DELTA_JSON" ] && return 0" check) and let the cascade continue.
+# Tier 4 (last resort, nothing left to cascade to) calls plain ensure_delta()
+# and handles partial-acceptance itself (DEGRADED, never silent-clean).
+ensure_full_delta() {
+    local _out="$1"
+    ensure_delta "$_out" || return 1
+    if delta_is_partial; then
+        echo "[$(date)] delta landed but partial=true (tier admitted incomplete/no-access scan) — rejecting, cascading to next tier" >> "$LOG"
+        rm -f "$DELTA_JSON"
+        return 1
+    fi
+    return 0
+}
+
 # W84 trampoline follow-up (2026-07-06): in the sshd context the login Keychain
 # is LOCKED, so the claude CLI cannot read its OAuth credentials and dies with
 # "Not logged in" — proved live at the 05:08 trampolined run. Fall back to the
@@ -244,7 +281,7 @@ fi
 echo "[$(date)] tier 1 — claude sonnet" >> "$LOG"
 "$HOME/.local/bin/claude" --print --model claude-sonnet-5 "$PROMPT_CLAUDE" >"$TMPOUT" 2>&1
 EXIT=$?
-if [ $EXIT -eq 0 ] && ! grep -qE "out of extra usage|usage limit|quota exceeded|rate.limit" "$TMPOUT" && ensure_delta "$TMPOUT"; then
+if [ $EXIT -eq 0 ] && ! grep -qE "out of extra usage|usage limit|quota exceeded|rate.limit" "$TMPOUT" && ensure_full_delta "$TMPOUT"; then
     SUCCESS=1
     USED_LLM="claude-sonnet-5"
 elif [ $EXIT -eq 0 ]; then
@@ -258,7 +295,7 @@ if [ $SUCCESS -eq 0 ]; then
     > "$TMPOUT"
     printf '%s' "$PROMPT_GENERIC" | /Users/nuzantara/.local/bin/agy -p --print-timeout 5m >"$TMPOUT" 2>&1
     EXIT=$?
-    if [ $EXIT -eq 0 ] && ! grep -qE "quota|limit|429|exhausted|TerminalQuotaError" "$TMPOUT" && ensure_delta "$TMPOUT"; then
+    if [ $EXIT -eq 0 ] && ! grep -qE "quota|limit|429|exhausted|TerminalQuotaError" "$TMPOUT" && ensure_full_delta "$TMPOUT"; then
         SUCCESS=1
         USED_LLM="gemini-3.1-pro-agy"
     fi
@@ -274,14 +311,19 @@ if [ $SUCCESS -eq 0 ]; then
     # contexts run from $HOME which is not a trusted repo → --skip-git-repo-check.
     /opt/homebrew/bin/codex exec --sandbox workspace-write --skip-git-repo-check "$PROMPT_GENERIC" </dev/null >"$TMPOUT" 2>&1
     EXIT=$?
-    if [ $EXIT -eq 0 ] && ! grep -qE "usage.limit|quota|exhausted" "$TMPOUT" && ensure_delta "$TMPOUT"; then
+    if [ $EXIT -eq 0 ] && ! grep -qE "usage.limit|quota|exhausted" "$TMPOUT" && ensure_full_delta "$TMPOUT"; then
         SUCCESS=1
         USED_LLM="codex-gpt-5.5"
     fi
     cat "$TMPOUT" >> "$LOG"
 fi
 
-# Tier 4: Ollama local (always available, lower quality but free + unlimited)
+# Tier 4: Ollama local (always available, lower quality but free + unlimited).
+# Last resort — nothing left to cascade to, so a partial result is accepted
+# rather than discarded, but it is marked DEGRADED (never silently "clean")
+# so proprioception/heartbeat can distinguish "genuinely 0 new" from "no tier
+# could actually check".
+DEGRADED=0
 if [ $SUCCESS -eq 0 ]; then
     echo "[$(date)] tier 3 failed/exhausted — falling back to ollama qwen3.5:9b local" >> "$LOG"
     > "$TMPOUT"
@@ -290,11 +332,18 @@ if [ $SUCCESS -eq 0 ]; then
     if [ $EXIT -eq 0 ] && ensure_delta "$TMPOUT"; then
         SUCCESS=1
         USED_LLM="ollama-qwen3.5:9b-local"
+        if delta_is_partial; then
+            DEGRADED=1
+            echo "[$(date)] tier 4 landed but partial=true — ALL 4 tiers failed to complete a real scan, accepting as DEGRADED (not a clean 0-new day)" >> "$LOG"
+        fi
     fi
     cat "$TMPOUT" >> "$LOG"
 fi
 
-if [ $SUCCESS -eq 1 ]; then
+if [ $SUCCESS -eq 1 ] && [ $DEGRADED -eq 1 ]; then
+    echo "[$(date)] regulatory-watcher run DEGRADED — used: $USED_LLM (partial: no tier completed a real scan)" >> "$LOG"
+    organism_hb_set degraded "used ${USED_LLM}, partial=true — no tier completed a real scan"
+elif [ $SUCCESS -eq 1 ]; then
     echo "[$(date)] regulatory-watcher run complete — used: $USED_LLM" >> "$LOG"
     organism_hb_set ok "used ${USED_LLM}"
 

--- a/research/operations/2026-07-19-balizero-kb-activation-plan.md
+++ b/research/operations/2026-07-19-balizero-kb-activation-plan.md
@@ -46,6 +46,32 @@ sources:
   not prod (fly-split-brain class, no P0).
 - Lever #5 (`/api/drive/*` fix): started by this session — see PR reference below
   once opened.
+- **Lever #7 DONE** (2026-07-20): root cause found by reading the actual log
+  (not guessed) — a live run showed Claude+agy+Codex all missing in the same
+  cascade, and ollama qwen3.5 (no web access) emitted a schema-valid
+  `{new_today_count:0, partial:true}` stub instead of a real scan; the old
+  `ensure_delta()` schema check (right KEYS present) could not distinguish
+  that from a genuine clean day. Fixed: `ensure_full_delta()` rejects+cascades
+  a partial stub past tiers 1-3; tier 4 (last resort) accepts it but marks the
+  run DEGRADED via the existing `organism_hb_set` heartbeat channel instead of
+  logging it identically to a clean run. Home-fork pair synced + verified via
+  `scripts/lint_home_fork.py --check`. The audit's original "52% day-coverage"
+  gaps (05-31→06-10, 06-18→06-28) predate this wrapper's W81/W84 hardening
+  (dated 2026-07-05/06) and are not reproduced live — the NEW live failure mode
+  found today (false-clean, not a visible gap) is the one this fix closes.
+- **Lever #11 PARTIALLY DONE** (2026-07-20): `get_collection_stats` now calls
+  `/health/collections` (extended with `status`/`vector_size`/`distance`/
+  `segments_count`) instead of the op-counter endpoint `get_qdrant_metrics`
+  also used — fixes the "returns the same zeroed op-counter" half. The RBAC
+  `unknown`-role half is NOT a bug: `apps/nuzantara-mcp/nuzantara_mcp/auth.py`'s
+  fail-closed default for direct/bypass callers (any interactive Claude Code
+  session via the tracked `.mcp.json`, which sets no `AGENT_ROLE`) is deliberate
+  per that module's own docstring, and `roles.yaml` has no non-admin role
+  covering these tools today — inventing one or granting `admin` to interactive
+  sessions is a privilege-boundary call, left open below for Zero rather than
+  decided unilaterally under the K7 cure's own "identity resolution FIRST"
+  principle (identifying the right principal/role is the missing step, not
+  mine to skip by picking one).
 
 ## Standing rules for this ledger
 
@@ -53,6 +79,22 @@ sources:
 2. Levers owned by other live lanes (S3 visa) are tracked here but never executed
    from this lane — reconcile at boundaries, don't collide (scar family #5).
 3. New levers discovered while working land HERE first, then get an owner.
+
+## §Solo-operatore — open from lever #11 (2026-07-20)
+
+`apps/nuzantara-mcp`'s per-tool RBAC (`auth.py`) fails closed to `unknown` for
+any caller with no `AGENT_ROLE` env var — this is every interactive Claude Code
+session on the tracked `.mcp.json` (which sets `PYTHONPATH`/`LANGSMITH_*` but
+no `AGENT_ROLE`). `roles.yaml` today has 4 roles (`visa_specialist`,
+`tax_consultant`, `company_setup`, `admin`); none cover `get_collection_stats`/
+`get_qdrant_metrics`, and `admin` is a `*` wildcard — granting it to every
+interactive session would be broad, not least-privilege. Zero's call: (a) add
+a new scoped role (e.g. read-only observability) to `roles.yaml` + wire
+`AGENT_ROLE` for interactive sessions in `.mcp.json`, or (b) leave `unknown`
+fail-closed as designed and accept that self-inspection tools stay 403 from
+direct sessions (route through the team-agent wrapper instead, which already
+sets a role). Not decided here — it changes who can see what across an MCP
+server multiple tools share.
 
 ## Adversarial review
 


### PR DESCRIPTION
## Summary

Two independent fixes from the Bali Zero KB activation-plan ledger (`research/operations/2026-07-19-balizero-kb-activation-plan.md`, Lane A), each an atomic commit:

- **Lever #7** — `regulatory-watcher-run.sh`'s 4-tier LLM cascade could bank a schema-valid-but-empty `{new_today_count:0, partial:true}` stub as SUCCESS when a lower tier (ollama, no web access) admitted it couldn't actually check sources. Live find today: Claude+agy+Codex all missed in one run, and the resulting "0 new" looked identical to a genuine clean day. `ensure_full_delta()` now rejects+cascades a partial stub past tiers 1-3; only tier 4 (last resort) accepts it, marked **DEGRADED** via the existing organism heartbeat channel. Home-fork pair (`~/scripts/regulatory-watcher-run.sh`) synced, `scripts/lint_home_fork.py --check` clean.
- **Lever #11** — `get_collection_stats` (nuzantara-mcp-advanced) proxied the same in-process op-counter endpoint as `get_qdrant_metrics`, despite its docstring promising real per-collection stats. Repointed at `/health/collections` (already did the real Qdrant `/collections` + `/collections/{name}` walk for point counts), extended with `status`/`vector_size`/`distance`/`segments_count`. The RBAC `unknown`-role half of that lever is **not fixed** — it's a deliberate fail-closed default with no scoped non-admin role available; left as an explicit `§Solo-operatore` note in the ledger for Zero rather than guessed at.

Ledger updated in the same PR (lever #7 DONE, lever #11 partial + operator note).

## Test plan

- [x] New regression test `test_collections_health_includes_vector_config` (TDD red→green, caught a real `AsyncMock().is_closed` truthy-default footgun during authoring — fixed in the test itself)
- [x] `delta_is_partial()` unit-verified standalone (guilt: partial=true detected; innocence: partial=false / missing key / absent file all correctly pass through)
- [x] `zsh -n` syntax check on the modified wrapper
- [x] Full targeted regression: `backend/tests/services/rag/` + `backend/tests/unit/app/routers/test_health.py` → 1200 passed, 17 skipped, 0 failed
- [x] Import chain smoke (`get_current_user`) — OK
- [x] `scripts/lint_home_fork.py --check` — clean (70/70 pairs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)