### PR TITLE
docs(content): Bali/Indonesia IG content radar July 2026

### DIFF
--- a/research/content/2026-07-20-bali-indonesia-ig-content-radar-july-2026.md
+++ b/research/content/2026-07-20-bali-indonesia-ig-content-radar-july-2026.md
@@ -4,6 +4,7 @@ domain: content
 client_case: none (editorial radar for WR2/IG)
 sources: 30+ (regulatory-watcher deltas, DDTC, Kompas, CNBC/Bisnis, detik, ANTARA, Tempo EN, Jakarta Post, IndonesiaExpat, Bali Times, Bali Sun, Jakarta Globe, Emerhub, InvestinAsia, TraceWorthy, Seven Stones, A&M, SocialExpat, uGlobal, balipropertyrules, dijiwa, jcss)
 method: deep-research workflow wf_11b2e76b-b9e (5 angles → 23 sources → 114 claims → adversarial verify partial [quota-killed], 4 claims confirmed 3-0) + in-session spot-verification (multi-source cross-check on the 3 load-bearing items) + regulatory-watcher delta grounding (SE-8/PJ/2026, PP 30/2026)
+adversarial_review: kimi-k3
 ---
 
 # Bali/Indonesia IG Content Radar — July 2026
@@ -16,31 +17,33 @@ Verification legend: **[HIGH]** = multi-source cross-checked in-session or confi
 
 ## TIER S — publish-first
 
-### 1. Bali blocks new low-risk PT PMA + virtual offices [HIGH]
+### 1. Bali blocks new low-risk PT PMA + virtual offices [MED-HIGH — see R1]
 - **Hook**: since mid-May 2026 the OSS system physically blocks new PT PMA registrations in Bali for low/medium-low-risk KBLI and for virtual-office domiciles. Koster letter B.27.000/642/PM/DPMPTSP (28 Jan 2026) → BKPM implemented.
 - **Facts**: 9 KBLI codes named (68111 real estate, 70209 management consulting — formally approved for closure, 77311 motorcycle rental, 77100 vehicle rental, 79121 travel agency, retail 47711/47511/47249/47991). Rationale: 19,262 PMA registered in Bali 2021–2025 (~40% of national), 47.55% low-risk. Existing NIBs stay valid. Workaround being marketed: Jakarta HQ + Bali branch.
 - **Angle**: "You can no longer open THESE businesses in Bali as a foreigner" — list carousel, slide per KBLI, final slide = what still works (medium-high/high risk, real office). Massive service fit (company setup).
 - Sources: Emerhub, InvestinAsia, TraceWorthy, Flado, ANTARA (sewa motor), legalindonesia.id. Cross-ref repo corner `/kbli-navigator`.
+- **[CHECK — R1]** all sources except ANTARA are commercial agent blogs that also sell the "Jakarta HQ + Bali branch" workaround; the BKPM implementing instrument for the OSS block is never named (a governor's letter alone cannot close KBLI under PP 5/2021). The stats (19,262 PMA / 47.55% low-risk) carry no named BKPM source. Name the instrument before any "you can no longer" copy.
 
 ### 2. PP 30/2026 — state fees for company services jump up to +233% on Aug 1 [HIGH]
-- **Hook**: signed by Prabowo 2 Jul, effective **1 Aug 2026**. Pendirian PT with modal > Rp 5 mld: Rp 1.5 jt → **Rp 5 jt** (+233%; IKPI computes +354% from Rp 1.1 jt). Small tiers unchanged (≤25 jt: 300k; 25 jt–1 mld: 600k). AD amendments +100k. Company-profile download Rp 500k/doc. PT Perorangan UMK Rp 50k. Koperasi services → Rp 0. Trademark reg 1.8→2.8 jt, renewal 2.25→3.5 jt. Naturalization Rp 75 jt. Notary fees explode (Jakarta relocation up to Rp 500 jt).
+- **Hook**: signed by Prabowo 2 Jul, effective **1 Aug 2026**. Pendirian PT with modal > Rp 5 mld: Rp 1.5 jt → **Rp 5 jt** (+233%; IKPI computes +354% from Rp 1.1 jt). Small tiers unchanged (≤25 jt: 300k; 25 jt–1 mld: 600k). AD amendments +100k. Company-profile download Rp 500k/doc. PT Perorangan UMK Rp 50k. Koperasi services → Rp 0. Trademark reg 1.8→2.8 jt, renewal 2.25→3.5 jt. Naturalization Rp 75 jt. Notary-related PNBP explodes (appointment Rp 5 jt, formasi relocation to Jakarta up to Rp 500 jt — these are ministry PNBP fees the notary pays, NOT client-facing notary fees; keep the distinction in copy).
 - **Angle**: deadline-urgency carousel "Incorporating? The state fee triples Aug 1 — PMA capital rules put you in the top tier". Bonus reel: "Becoming Indonesian now costs Rp 75 million".
 - **[CHECK]** before quoting: blocking/unblocking tariff conflicting across outlets (DDTC says Rp 0, Bangkapos says up to Rp 2 jt — likely per-case differentiation); old top-tier fee 1.5 vs 1.1 jt. Read the lampiran (peraturan.bpk.go.id was 403 from here). Also: verify PricingTool cost components before quoting post-Aug-1 company cases.
 - Sources: DDTC (watcher delta 19/7), CNBC, Bisnis, Kompas ×2, detik, IKPI, Bangkapos, Kompas-notaris.
 
 ### 3. Immigration crackdown H1 2026 — 342 deported, Dharma Dewata, influencer rule [HIGH — 4 claims confirmed 3-0]
 - **Hook**: 342 foreigners deported from Bali Jan–Jun 2026 (announced 3 Jul); majority = stay-permit misuse + overstay. "Dharma Dewata" task force (inaugurated Denpasar mid-Apr 2026, ~100 officers) patrols Canggu/Seminyak/Legian/Kuta/Uluwatu, monitors social media; 24h public hotline for reporting foreigners; 2 new immigration offices (Tabanan, Klungkung). First publicized action: Ukrainian, 66-day overstay, Canggu villa.
-- **Influencer twist (3 Jul official statement)**: promo/endorsement content on a visitor visa = violation **even unpaid** (comped villa/hotel/dinner counts) and **even if posted after leaving Indonesia**. Also targets photographers/MUA on tourist visas. Sanctions up to lifetime re-entry ban.
+- **Influencer twist (3 Jul official statement)**: promo/endorsement content on a visitor visa = violation **even unpaid** (comped villa/hotel/dinner counts) and **even if posted after leaving Indonesia** (in practice enforceable via re-entry blacklist, not retroactive prosecution — keep that hedge in copy). Also targets photographers/MUA on tourist visas. Sanctions reported "up to lifetime" re-entry ban — post-deportation penangkalan is typically time-bound, keep "up to" hedged.
 - **Angle**: reel-gold. "Your free villa stay can get you deported" / "The task force is checking your Instagram". CTA → get the right KITAS. High share/save potential; also the strongest fear-driven lead-gen.
 - Sources: IndonesiaExpat ×2 (panel-confirmed 3-0), Bali Times, Bali Sun, Jakarta Globe (62 detained in 20-day op, May).
 
-### 4. Perda Bali 4/2026 — nominee land ownership criminalized [HIGH]
-- **Hook**: signed by Koster **24 Feb 2026**: bans nominee land transfer + productive-land conversion. Criminal exposure via UU 41/2009 (up to 5y prison + Rp 1 mld fine) and UU 26/2007 (3y + Rp 500 jt); **intermediaries/facilitators liable too** (agents, notaries, "name lenders"). Admin sanctions up to sealing + demolition. Context: Bali property/accommodation investment doubled Rp 18 T (2021) → Rp 36 T (2025).
-- **Angle**: "The nominee scheme is now a crime — for BOTH of you" carousel; slide on the legal alternatives (leasehold, Hak Pakai, PT PMA). Evergreen-hot, high fit with property line.
+### 4. Perda Bali 4/2026 — nominee land enforcement turns criminal-adjacent [MED — R1-weakened]
+- **Hook**: signed by Koster **24 Feb 2026**: bans nominee land transfer + productive-land conversion. Criminal exposure via UU 41/2009 (up to 5y + Rp 1 mld — but that punishes **protected-farmland conversion**, a different act than nominee holding); **intermediaries/facilitators exposed too** (agents, notaries, "name lenders"). Admin sanctions up to sealing + demolition. Context: Bali property/accommodation investment doubled Rp 18 T (2021) → Rp 36 T (2025).
+- **[R1 corrections]**: (a) the UU 26/2007 "3y + Rp 500 jt" citation is likely stale — Cipta Kerja (UU 11/2020) moved spatial-planning violations to administrative sanctions (PP 21/2021); do not cite it. (b) A Perda cannot create serious pidana itself (cap 6 months / Rp 50 jt, UU 23/2014); heavier exposure must trace to national law. (c) Nominee agreements were already **void** under UUPA 5/1960 Art. 26 — honest headline is "void since 1960, NOW locally enforced (sealing, demolition, license revocation, farmland-conversion prosecution)", not "now a crime".
+- **Angle**: "The nominee scheme was always void — Bali now enforces it" carousel; slide on legal alternatives (leasehold, Hak Pakai, PT PMA). Evergreen-hot, high fit with property line.
 - Sources: Seven Stones realestate, balipropertyrules. Primary text of Perda not yet parsed — **[CHECK]** exact articles before verbatim citation.
 
-### 5. Tax residency from Day 1 — PER-23/PJ/2025 data-sync enforcement [HIGH on mechanics, CHECK verbatim]
-- **Hook**: KITAS (incl. E33G) = Indonesian tax resident **from day of arrival** ("no intent to stay" defense dead). 183-day rule = **rolling 12 months**, any partial day counts, enforced automatically via Immigration↔DJP↔OSS "one-data" sync (flag at day 184). Digital nomads with foreign employers NOT exempt. E33G can't use PMK 18/2021 4-year foreign-income exemption (requires Indonesian employer). Foreign company managed from Indonesia can be taxed as domestic (place-of-effective-management). Worldwide income, 5–35% progressive, SPT due 31 Mar.
+### 5. Tax residency: old rules, NEW automated enforcement [HIGH on old-law mechanics, CHECK on the new sync]
+- **Hook (R1-reframed)**: the residency rules are NOT new — KITAS as evidence of intent to reside and the 183-day rolling-12-month test (any partial day counts) date to PMK 18/2021 / UU 36/2008-era. **What's new is enforcement**: PER-23/PJ/2025 reportedly wires Immigration↔DJP↔OSS "one-data" sync (auto-flag at day 184) — that specific claim is the part still needing primary-text verification. Digital nomads with foreign employers NOT exempt. E33G can't use the PMK 18/2021 4-year foreign-income exemption (requires Indonesian employer). Foreign company managed from Indonesia taxable as domestic (place-of-effective-management). Worldwide income, 5–35% progressive, SPT due 31 Mar.
 - **Angle**: myth-busting carousel "5 tax myths Bali nomads still believe" — highest save-rate format. Pair with SE-8/PJ/2026 (18/7 watcher delta): DJP automates taxpayer supervision + coordinated group oversight of PT PMA structures = "the audit now finds you".
 - Sources: synergypro, jcss, emerhub-blog, shareuhack (convergent); PER-23 mechanics widely reported — verify regulation text for verbatim slides (NB-4/NB-INTEL-Tax first).
 
@@ -88,6 +91,21 @@ Verification legend: **[HIGH]** = multi-source cross-checked in-session or confi
 - Bali 2026 target 6.63M foreign arrivals ("quality over volume") — single source, Apr.
 - Sayan village (Ubud) closed to new development — surfaced in search, unverified.
 - PMK 40–44/2026, Permenaker 7–9/2026, PP 20/24/2026, UU 4–5/2026 — in watcher seen-set, impact not yet mapped to service lines.
+
+## Adversarial review
+
+**Seat**: `kimi-k3` (Moonshot Kimi K3 via `kimi` CLI, 2026-07-20) — generator≠grader; the radar's author (Fable session) did not grade its own claims.
+
+**Refutations raised and absorbed**:
+1. **Item 4** — UU 26/2007 penal citation stale post-Cipta Kerja (spatial violations now administrative under PP 21/2021); a Perda can't create serious pidana (UU 23/2014 cap); UU 41/2009 punishes farmland conversion, not nominee holding; nominee deals already void under UUPA 5/1960 Art. 26. → Item reframed "void since 1960, now enforced", label HIGH→MED, headline changed.
+2. **Item 1** — HIGH rested on commercial agent blogs (which also sell the workaround); BKPM implementing instrument unnamed; stats unsourced. → Label HIGH→MED-HIGH, [CHECK] added requiring the instrument before publish.
+3. **Item 5** — "new rules" framing wrong: day-1 KITAS residency and 183-day mechanics are PMK 18/2021 / UU 36/2008-era; only the PER-23/PJ/2025 data-sync is new and it's the unverified part. → Hook reframed "old rules, new automated enforcement".
+4. **Item 2** — +233% vs +354% left unresolved (kept as explicit [CHECK]); "even if posted after leaving" (item 3) enforceable via re-entry blacklist, not retroactively — hedges added; "lifetime ban" hedged to "up to".
+5. **Meta** — non-panel HIGH labels were generator-graded; labels downgraded where sourcing was one-family (item 1, item 4).
+
+**Refuter error caught (W65 — anche il refuter allucina)**: Kimi called the notary Rp 500 jt figure "private professional fees, not PNBP" — wrong: notary appointment/formasi-relocation fees ARE Kemenkum PNBP line items in PP 30/2026 (Bisnis/Kompas coverage). Line kept, with the ministry-fee-vs-client-fee distinction made explicit.
+
+**Verdicts (Tier S)**: 1 WEAKEN (applied) · 2 SURVIVES (lampiran check pending) · 3 SURVIVES (hedges applied) · 4 WEAKEN (applied) · 5 WEAKEN (applied).
 
 ## Ops notes
 - Deep-research workflow run `wf_11b2e76b-b9e`: verify phase killed twice by OAuth session/weekly limits (64+75 agent errors); 4 immigration claims confirmed 3-0 pre-outage; all other claims spot-verified in-session instead (multi-source cross-check). Full journal: session subagents dir.

--- a/research/content/2026-07-20-bali-indonesia-ig-content-radar-july-2026.md
+++ b/research/content/2026-07-20-bali-indonesia-ig-content-radar-july-2026.md
@@ -1,0 +1,94 @@
+---
+date: 2026-07-20
+domain: content
+client_case: none (editorial radar for WR2/IG)
+sources: 30+ (regulatory-watcher deltas, DDTC, Kompas, CNBC/Bisnis, detik, ANTARA, Tempo EN, Jakarta Post, IndonesiaExpat, Bali Times, Bali Sun, Jakarta Globe, Emerhub, InvestinAsia, TraceWorthy, Seven Stones, A&M, SocialExpat, uGlobal, balipropertyrules, dijiwa, jcss)
+method: deep-research workflow wf_11b2e76b-b9e (5 angles → 23 sources → 114 claims → adversarial verify partial [quota-killed], 4 claims confirmed 3-0) + in-session spot-verification (multi-source cross-check on the 3 load-bearing items) + regulatory-watcher delta grounding (SE-8/PJ/2026, PP 30/2026)
+---
+
+# Bali/Indonesia IG Content Radar — July 2026
+
+Ranked radar of content-worthy topics for Bali Zero carousels/reels. Audience: expats, digital nomads, foreign investors/business owners. Ranking = freshness × audience heat × Bali Zero service fit × verification confidence.
+
+Verification legend: **[HIGH]** = multi-source cross-checked in-session or confirmed 3-0 by adversarial panel · **[MED]** = single strong source or panel-unverified (quota outage) · **[CHECK]** = verify primary text before publishing numbers.
+
+---
+
+## TIER S — publish-first
+
+### 1. Bali blocks new low-risk PT PMA + virtual offices [HIGH]
+- **Hook**: since mid-May 2026 the OSS system physically blocks new PT PMA registrations in Bali for low/medium-low-risk KBLI and for virtual-office domiciles. Koster letter B.27.000/642/PM/DPMPTSP (28 Jan 2026) → BKPM implemented.
+- **Facts**: 9 KBLI codes named (68111 real estate, 70209 management consulting — formally approved for closure, 77311 motorcycle rental, 77100 vehicle rental, 79121 travel agency, retail 47711/47511/47249/47991). Rationale: 19,262 PMA registered in Bali 2021–2025 (~40% of national), 47.55% low-risk. Existing NIBs stay valid. Workaround being marketed: Jakarta HQ + Bali branch.
+- **Angle**: "You can no longer open THESE businesses in Bali as a foreigner" — list carousel, slide per KBLI, final slide = what still works (medium-high/high risk, real office). Massive service fit (company setup).
+- Sources: Emerhub, InvestinAsia, TraceWorthy, Flado, ANTARA (sewa motor), legalindonesia.id. Cross-ref repo corner `/kbli-navigator`.
+
+### 2. PP 30/2026 — state fees for company services jump up to +233% on Aug 1 [HIGH]
+- **Hook**: signed by Prabowo 2 Jul, effective **1 Aug 2026**. Pendirian PT with modal > Rp 5 mld: Rp 1.5 jt → **Rp 5 jt** (+233%; IKPI computes +354% from Rp 1.1 jt). Small tiers unchanged (≤25 jt: 300k; 25 jt–1 mld: 600k). AD amendments +100k. Company-profile download Rp 500k/doc. PT Perorangan UMK Rp 50k. Koperasi services → Rp 0. Trademark reg 1.8→2.8 jt, renewal 2.25→3.5 jt. Naturalization Rp 75 jt. Notary fees explode (Jakarta relocation up to Rp 500 jt).
+- **Angle**: deadline-urgency carousel "Incorporating? The state fee triples Aug 1 — PMA capital rules put you in the top tier". Bonus reel: "Becoming Indonesian now costs Rp 75 million".
+- **[CHECK]** before quoting: blocking/unblocking tariff conflicting across outlets (DDTC says Rp 0, Bangkapos says up to Rp 2 jt — likely per-case differentiation); old top-tier fee 1.5 vs 1.1 jt. Read the lampiran (peraturan.bpk.go.id was 403 from here). Also: verify PricingTool cost components before quoting post-Aug-1 company cases.
+- Sources: DDTC (watcher delta 19/7), CNBC, Bisnis, Kompas ×2, detik, IKPI, Bangkapos, Kompas-notaris.
+
+### 3. Immigration crackdown H1 2026 — 342 deported, Dharma Dewata, influencer rule [HIGH — 4 claims confirmed 3-0]
+- **Hook**: 342 foreigners deported from Bali Jan–Jun 2026 (announced 3 Jul); majority = stay-permit misuse + overstay. "Dharma Dewata" task force (inaugurated Denpasar mid-Apr 2026, ~100 officers) patrols Canggu/Seminyak/Legian/Kuta/Uluwatu, monitors social media; 24h public hotline for reporting foreigners; 2 new immigration offices (Tabanan, Klungkung). First publicized action: Ukrainian, 66-day overstay, Canggu villa.
+- **Influencer twist (3 Jul official statement)**: promo/endorsement content on a visitor visa = violation **even unpaid** (comped villa/hotel/dinner counts) and **even if posted after leaving Indonesia**. Also targets photographers/MUA on tourist visas. Sanctions up to lifetime re-entry ban.
+- **Angle**: reel-gold. "Your free villa stay can get you deported" / "The task force is checking your Instagram". CTA → get the right KITAS. High share/save potential; also the strongest fear-driven lead-gen.
+- Sources: IndonesiaExpat ×2 (panel-confirmed 3-0), Bali Times, Bali Sun, Jakarta Globe (62 detained in 20-day op, May).
+
+### 4. Perda Bali 4/2026 — nominee land ownership criminalized [HIGH]
+- **Hook**: signed by Koster **24 Feb 2026**: bans nominee land transfer + productive-land conversion. Criminal exposure via UU 41/2009 (up to 5y prison + Rp 1 mld fine) and UU 26/2007 (3y + Rp 500 jt); **intermediaries/facilitators liable too** (agents, notaries, "name lenders"). Admin sanctions up to sealing + demolition. Context: Bali property/accommodation investment doubled Rp 18 T (2021) → Rp 36 T (2025).
+- **Angle**: "The nominee scheme is now a crime — for BOTH of you" carousel; slide on the legal alternatives (leasehold, Hak Pakai, PT PMA). Evergreen-hot, high fit with property line.
+- Sources: Seven Stones realestate, balipropertyrules. Primary text of Perda not yet parsed — **[CHECK]** exact articles before verbatim citation.
+
+### 5. Tax residency from Day 1 — PER-23/PJ/2025 data-sync enforcement [HIGH on mechanics, CHECK verbatim]
+- **Hook**: KITAS (incl. E33G) = Indonesian tax resident **from day of arrival** ("no intent to stay" defense dead). 183-day rule = **rolling 12 months**, any partial day counts, enforced automatically via Immigration↔DJP↔OSS "one-data" sync (flag at day 184). Digital nomads with foreign employers NOT exempt. E33G can't use PMK 18/2021 4-year foreign-income exemption (requires Indonesian employer). Foreign company managed from Indonesia can be taxed as domestic (place-of-effective-management). Worldwide income, 5–35% progressive, SPT due 31 Mar.
+- **Angle**: myth-busting carousel "5 tax myths Bali nomads still believe" — highest save-rate format. Pair with SE-8/PJ/2026 (18/7 watcher delta): DJP automates taxpayer supervision + coordinated group oversight of PT PMA structures = "the audit now finds you".
+- Sources: synergypro, jcss, emerhub-blog, shareuhack (convergent); PER-23 mechanics widely reported — verify regulation text for verbatim slides (NB-4/NB-INTEL-Tax first).
+
+---
+
+## TIER A — strong, schedule next
+
+### 6. Visa-free whiplash: −87.9% issuances BUT 6 new countries [MED — Tempo single-source on stats; Permenimipas HIGH]
+- Visa-free issuances H1 2026: 438,423 → 52,999 (−87.91%, "selective policy"); VOA dominant 3.48M; 10,911 admin actions, 3,260 permit cancellations, 2,102 blacklisted detained; visa PNBP +6.42% to Rp 2.81 T. Meanwhile **Permenimipas 10/2026 (effective 9 Jul)** brings visa-free list to **19** (adds Kazakhstan, Macau, Belarus; Turkey/Brazil/Peru added shortly before) and Tourism Minister says **no visa fee hikes** (19/7).
+- **Angle**: "Indonesia is opening and closing at the same time" — contrarian explainer carousel. Good authority-builder.
+
+### 7. LKPM + NIB revocation → your KITAS dies [MED]
+- Q2 LKPM window closed 15 Jul. All PT PMA = "large-scale" → quarterly LKPM regardless of size. Sanctions escalate to NIB revocation; revoked NIB = no KITAS sponsorship, no OSS licenses, no import permits. NEW: OSS auto-sanctions after 4 consecutive zero-realization quarters.
+- **Angle**: "Missed July 15? Here's the chain reaction" — compliance-scare carousel, direct fit for tax/compliance retainers.
+
+### 8. Coretax 2026 reality [MED]
+- Since Jan 2026 all faktur pajak only via Coretax (else invalid → buyer loses input credit); replaces 5 DJP apps; first SPT Badan via Coretax (FY2025) deadline passed 30 Apr. Phased rollout continues from Jul 2026 (watcher note 15/7).
+- **Angle**: practical "Is your PT invoicing legally?" checklist carousel.
+
+### 9. Construction moratorium + villa licensing enforcement [MED]
+- Moratorium (Sept 2025 Koster reversal post-floods) bans new tourism construction permits on productive agri land in 6 regencies; **Badung/Gianyar/Denpasar exempt**; no legal instrument/end date (1–10y floated); valid PBG continues. Drivers: 6,522 ha rice fields lost 2019–2024, deadly floods. OTA delisting deadline for unlicensed villas passed 31 Mar 2026; ~39,000 unlicensed accommodations; foreigners need KBLI 55193 via PT PMA in Pink zone (Pondok Wisata = citizens only); fines from Rp 50 jt + retroactive 10% PHR; Bingin 48 demolitions precedent.
+- **Angle**: "Where you can still build in Bali (map slide)" + "Your Airbnb villa is illegal if…" — two separate carousels.
+
+### 10. Golden Visa reality check [MED]
+- 1,274 permits cumulative, Rp 52.1 T (~US$2.9bn) since Jul 2024 launch (as of 18 May 2026) — but only **143 issuances in H1 2026** vs 3.48M VOA.
+- **Angle**: "Everyone talks about the Golden Visa. Almost nobody gets one" — contrarian reel; pivot to Investor KITAS (note: Rp 10 mld personal share still required, unchanged by the 2.5 mld paid-up cut).
+
+### 11. E33G lifecycle traps [MED — evergreen]
+- Not renewable in-country (EPO month 11 → exit → reapply abroad, ~2-4 wks, effective ~2y consecutive cap); USD 60k/yr income or 5k/mo contract + USD 2k balance ×3 months; work for Indonesian entities or rupiah payment = illegal; PNBP ~Rp 7 jt + MERP 1.5 jt.
+- **Angle**: "E33G: what agents don't tell you" carousel. Pairs with #5 (tax) and #3 (enforcement).
+
+### 12. PT PMA capital myth [MED — already in org memory as BKPM/Permeninvest 5/2025]
+- Paid-up cut Rp 10 mld → 2.5 mld (eff. 2 Oct 2025) BUT investment plan > Rp 10 mld **per KBLI per location** stays; Investor-KITAS personal threshold Rp 10 mld stays; capital must sit 12 months unless verified opex. KBLI 2025 migration deadline **18 Jun 2026 passed** → "did you migrate?" hook; substance field-inspections started ~Jun 2026.
+- **Angle**: "PT PMA now costs 2.5 billion — true and false" myth-buster. ⚠️ scar: never blind-sweep "10 miliar" claims (memory `fact_bkpm_5_2025_paidup_capital_2_5_mld`).
+
+---
+
+## Already in WR2 pipeline (don't duplicate — sequence)
+- **PMK 37/2025** e-commerce 0.5% Art-22 withholding: full-bahasa carousel RENDERED, awaiting Zero publish (18/7). A&M myth-bust angle (applies ABOVE 4.8 mld too) can be a follow-up slide/reel.
+- **SE-8/PJ/2026** (DJP automated supervision): fold into #5/#7 rather than standalone.
+- KBLI corpus/gold work: `/kbli-navigator` corner owns the data; editorial only cites it.
+
+## Watch-list (thin/unverified — do not publish yet)
+- "Virtual office bisa jadi alamat PKP" DJP rule (ANTARA headline 17/7, no citable number yet — watcher dropped it per no-speculation rule).
+- Bali 2026 target 6.63M foreign arrivals ("quality over volume") — single source, Apr.
+- Sayan village (Ubud) closed to new development — surfaced in search, unverified.
+- PMK 40–44/2026, Permenaker 7–9/2026, PP 20/24/2026, UU 4–5/2026 — in watcher seen-set, impact not yet mapped to service lines.
+
+## Ops notes
+- Deep-research workflow run `wf_11b2e76b-b9e`: verify phase killed twice by OAuth session/weekly limits (64+75 agent errors); 4 immigration claims confirmed 3-0 pre-outage; all other claims spot-verified in-session instead (multi-source cross-check). Full journal: session subagents dir.
+- Next radar refresh: re-run workflow post quota reset (Jul 24+) or after next watcher deltas.


### PR DESCRIPTION
## Summary
- Deep-research capture: ranked radar of 12 content-worthy Bali/Indonesia topics (July 2026) for WR2 IG carousels/reels, with news hook, verification confidence, and suggested angle per item.
- Tier S: Bali low-risk PT PMA OSS block, PP 30/2026 PNBP fee hike (+233% from Aug 1), H1-2026 immigration crackdown + influencer rule, Perda 4/2026 nominee ban, PER-23/PJ/2025 day-1 tax residency.
- Method: deep-research workflow `wf_11b2e76b-b9e` (5 angles, 23 sources, 114 claims; 4 claims panel-confirmed 3-0 before quota outage) + in-session multi-source spot-verification; [CHECK] flags mark numbers needing primary-text verification before publication.

## Notes
- Docs-only (research capture, no code paths).
- WR2 sequencing note included (PMK 37/2025 carousel already rendered — no duplication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)