### PR TITLE
fix(drive): bound get_storage_stats by wall-clock time, not just page count

### DIFF
--- a/apps/backend-rag/backend/services/integrations/drive/drive_operations.py
+++ b/apps/backend-rag/backend/services/integrations/drive/drive_operations.py
@@ -135,7 +135,12 @@ class DriveOperationsManager:
         `about.get` call — independent of the walk below. `files_count`/
         `folders_count`/`storage_by_type`/`largest_files` come from a
         paginated `files.list` walk (pageSize 1000, capped at `max_pages`
-        pages OR `max_seconds` wall-clock time, whichever hits first).
+        pages OR `max_seconds` cumulative wall-clock time between pages,
+        whichever hits first). This bounds the common case (many pages each
+        completing normally) but is cooperative, not preemptive: the deadline
+        is only consulted between completed page fetches, so a single slow
+        request is bounded only by the shared http client's own timeout, not
+        by `max_seconds` (Kimi K3 cross-family review, 2026-07-20).
         If the drive has more pages than the cap allows, `truncated=True` and
         `scanned_pages` say so explicitly — a partial count is never returned
         silently as if it were the total.

--- a/apps/backend-rag/backend/services/integrations/drive/drive_operations.py
+++ b/apps/backend-rag/backend/services/integrations/drive/drive_operations.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Any
 
 import httpx
@@ -125,13 +126,16 @@ class DriveOperationsManager:
         return [_normalize_drive_file(f) for f in response.json().get("files", [])]
 
     @drive_operation("get_storage_stats")
-    async def get_storage_stats(self, user_email: str, max_pages: int = 20) -> dict[str, Any]:
+    async def get_storage_stats(
+        self, user_email: str, max_pages: int = 20, max_seconds: float = 10.0
+    ) -> dict[str, Any]:
         """Aggregate storage statistics for the team Drive.
 
         `storage_used_bytes`/`storage_limit_bytes` come from a single, exact
         `about.get` call — independent of the walk below. `files_count`/
         `folders_count`/`storage_by_type`/`largest_files` come from a
-        paginated `files.list` walk (pageSize 1000, capped at `max_pages`).
+        paginated `files.list` walk (pageSize 1000, capped at `max_pages`
+        pages OR `max_seconds` wall-clock time, whichever hits first).
         If the drive has more pages than the cap allows, `truncated=True` and
         `scanned_pages` say so explicitly — a partial count is never returned
         silently as if it were the total.
@@ -142,10 +146,12 @@ class DriveOperationsManager:
         about_response = await self.http_client.get(
             "https://www.googleapis.com/drive/v3/about",
             headers=headers,
-            params={"fields": "storageQuota"},
+            params={"fields": "storageQuota,user"},
         )
         about_response.raise_for_status()
-        quota = about_response.json().get("storageQuota", {})
+        about_data = about_response.json()
+        quota = about_data.get("storageQuota", {})
+        quota_measured_as = about_data.get("user", {}).get("emailAddress")
 
         files_count = 0
         folders_count = 0
@@ -154,6 +160,7 @@ class DriveOperationsManager:
         page_token: str | None = None
         scanned_pages = 0
         truncated = False
+        walk_deadline = time.monotonic() + max_seconds
 
         while True:
             params: dict[str, Any] = {
@@ -187,7 +194,7 @@ class DriveOperationsManager:
             page_token = data.get("nextPageToken")
             if not page_token:
                 break
-            if scanned_pages >= max_pages:
+            if scanned_pages >= max_pages or time.monotonic() >= walk_deadline:
                 truncated = True
                 break
 
@@ -200,6 +207,7 @@ class DriveOperationsManager:
         return {
             "storage_used_bytes": int(quota.get("usage") or 0),
             "storage_limit_bytes": int(limit) if limit else None,
+            "quota_measured_as": quota_measured_as,
             "files_count": files_count,
             "folders_count": folders_count,
             "storage_by_type": storage_by_type,

--- a/apps/backend-rag/backend/tests/services/integrations/test_drive_operations_storage_stats.py
+++ b/apps/backend-rag/backend/tests/services/integrations/test_drive_operations_storage_stats.py
@@ -234,12 +234,28 @@ async def test_get_storage_stats_honestly_flags_truncation_when_wall_clock_deadl
 async def test_get_storage_stats_does_not_falsely_flag_wall_clock_truncation_when_fast():
     """Innocence: a walk that finishes before the deadline must not be reported
     truncated — proves the wall-clock check above is measuring the deadline,
-    not a bug that always trips it."""
-    mgr = _manager([_resp(ABOUT_RESP), _resp({"files": []})])
+    not a bug that always trips it.
+
+    Cross-family review (Kimi K3, 2026-07-20) caught the first version of this
+    test being vacuous: a single page with no `nextPageToken` breaks the loop
+    via `if not page_token: break` BEFORE the deadline check is ever reached,
+    so it never exercised the `time.monotonic() >= walk_deadline` branch at
+    all — it would have passed even if that condition were replaced with
+    `or True`. Fixed by using a 2-page walk so the check's False path (page 1
+    has a `nextPageToken`, is under the deadline, and the walk continues) is
+    what's actually under test."""
+    page1 = _resp(
+        {
+            "files": [_file("f1", "a.pdf", "application/pdf", "100")],
+            "nextPageToken": "tok-2",
+        }
+    )
+    page2 = _resp({"files": []})
+    mgr = _manager([_resp(ABOUT_RESP), page1, page2])
 
     with patch("backend.services.integrations.drive.drive_operations.time.monotonic") as mock_clock:
         mock_clock.side_effect = [0.0, 1.0]
         out = await mgr.get_storage_stats(USER, max_pages=20, max_seconds=10.0)
 
     assert out["truncated"] is False
-    assert out["scanned_pages"] == 1
+    assert out["scanned_pages"] == 2

--- a/apps/backend-rag/backend/tests/services/integrations/test_drive_operations_storage_stats.py
+++ b/apps/backend-rag/backend/tests/services/integrations/test_drive_operations_storage_stats.py
@@ -19,7 +19,7 @@ Mock pattern mirrors test_drive_operations_normalization.py / _mutations.py
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -35,7 +35,8 @@ ABOUT_RESP = {
         "usage": "1048576000",  # 1000 MB
         "usageInDrive": "1048576000",
         "usageInDriveTrash": "0",
-    }
+    },
+    "user": {"emailAddress": "zero@balizero.com"},
 }
 
 
@@ -75,6 +76,7 @@ async def test_get_storage_stats_reports_exact_total_from_about_endpoint():
 
     assert out["storage_used_bytes"] == 1048576000
     assert out["storage_limit_bytes"] == 32985348833280
+    assert out["quota_measured_as"] == "zero@balizero.com"
     assert out["files_count"] == 0
     assert out["folders_count"] == 0
 
@@ -198,6 +200,46 @@ async def test_get_storage_stats_does_not_falsely_flag_truncation_under_cap():
     mgr = _manager([_resp(ABOUT_RESP), _resp({"files": []})])
 
     out = await mgr.get_storage_stats(USER, max_pages=1)
+
+    assert out["truncated"] is False
+    assert out["scanned_pages"] == 1
+
+
+async def test_get_storage_stats_honestly_flags_truncation_when_wall_clock_deadline_hit():
+    """Guilt (wall-clock twin of the max_pages guilt test above): a slow Drive API
+    that would blow past max_seconds must be cut off THERE, not left to run
+    unbounded just because max_pages hasn't been reached yet — max_pages alone
+    does not bound response time (confirmed in prod: 45.5s against real data,
+    still under a max_pages=20 cap that never tripped)."""
+    endless_page = _resp(
+        {
+            "files": [_file("f1", "a.pdf", "application/pdf", "100")],
+            "nextPageToken": "keeps-going",
+        }
+    )
+    mgr = _manager([_resp(ABOUT_RESP), endless_page, endless_page, endless_page])
+
+    with patch("backend.services.integrations.drive.drive_operations.time.monotonic") as mock_clock:
+        # deadline-setup call returns 0.0 (walk_deadline = 0.0 + max_seconds);
+        # first loop check returns a value already >= walk_deadline (10.0) so it
+        # truncates immediately after scanning exactly 1 page.
+        mock_clock.side_effect = [0.0, 10.0]
+        out = await mgr.get_storage_stats(USER, max_pages=20, max_seconds=10.0)
+
+    assert out["truncated"] is True
+    assert out["scanned_pages"] == 1
+    assert out["files_count"] == 1
+
+
+async def test_get_storage_stats_does_not_falsely_flag_wall_clock_truncation_when_fast():
+    """Innocence: a walk that finishes before the deadline must not be reported
+    truncated — proves the wall-clock check above is measuring the deadline,
+    not a bug that always trips it."""
+    mgr = _manager([_resp(ABOUT_RESP), _resp({"files": []})])
+
+    with patch("backend.services.integrations.drive.drive_operations.time.monotonic") as mock_clock:
+        mock_clock.side_effect = [0.0, 1.0]
+        out = await mgr.get_storage_stats(USER, max_pages=20, max_seconds=10.0)
 
     assert out["truncated"] is False
     assert out["scanned_pages"] == 1


### PR DESCRIPTION
## Summary
- Follow-up to #2898 (lever #5 residual, `research/operations/2026-07-19-balizero-kb-activation-plan.md`). Production diagnosis via `fly ssh console` against the real Bali Zero Team Drive showed the walk takes **45.5s** to scan just its first 20 pages (still truncated) — `max_pages` alone doesn't bound wall-clock latency, and two real 30s MCP client timeouts followed post-deploy.
- Adds `max_seconds: float = 10.0` alongside `max_pages: int = 20`; the walk truncates honestly (`truncated`/`scanned_pages` unchanged) on whichever cap hits first.
- Adds `quota_measured_as` (from `about.get`'s `user.emailAddress`) to the response. Separately confirmed (via `fly ssh console` with a real `asyncpg` pool) that the "system" OAuth token this endpoint uses is currently broken in prod, causing fallback to a Service Account whose own quota is genuinely 0 — a real, pre-existing, out-of-scope issue. `quota_measured_as` stops a future `storage_used_bytes: 0` from being silently mistaken for the real account's usage.

## Test plan
- [x] 12/12 targeted tests pass (`test_drive_operations_storage_stats.py` + `test_team_drive_stats_endpoint.py`), including 2 new guilt/innocence pairs pinning the wall-clock cutoff behavior via `unittest.mock.patch("time.monotonic")`.
- [x] Full backend suite: 19,270 passed / 117 skipped (pre-push hook, path-aware classifier ran FULL suite since these files aren't on the innocent allowlist).
- [ ] PROVE-LIVE: real `mcp__nuzantara-mcp__get_drive_storage_stats()` call returns fast (<10s) with real data post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)