### PR TITLE
fix(wa-tester): match bot replies arriving via WhatsApp @lid JID (scar #3)

### DIFF
--- a/apps/wa-mirror/scripts/wa-tester-core.ts
+++ b/apps/wa-mirror/scripts/wa-tester-core.ts
@@ -11,6 +11,7 @@
 // parameters) so it can be unit-tested without a live WhatsApp connection.
 // The live-socket glue lives in scripts/wa-tester.ts and imports from here.
 
+import { parseJid } from "../bridge/filters.js";
 import { normalizePhone, phoneDigits } from "../bridge/phone.js";
 
 // ---------------------------------------------------------------------------
@@ -65,6 +66,49 @@ export function matchesBotRecipient(value: string): boolean {
   if (normalized && phoneDigits(normalized) === BOT_PHONE_DIGITS) return true;
   const rawDigits = jidPart.replace(/\D/g, "");
   return rawDigits.length > 0 && rawDigits === BOT_PHONE_DIGITS;
+}
+
+// ---------------------------------------------------------------------------
+// Receive-side matcher — scar #3 UNDER-match (WhatsApp LID rollout).
+//
+// `matchesBotRecipient` above is the SEND-side guard: it only ever sees a
+// battery author's plain value (phone/JID string), never a live Baileys
+// remoteJid. Receive-side used to do `m.key.remoteJid !== BOT_JID` — strict
+// string equality against the bot's `@s.whatsapp.net` phone-JID. Under
+// WhatsApp's `@lid` (Linked Identity Device) rollout, the SAME bot
+// conversation can arrive tagged with an opaque `@lid` identifier instead
+// of the phone-JID (Baileys reassigns this per-session, not something the
+// tester controls) — the strict `!==` silently drops every reply that
+// arrives that way, producing `reply_count: 0` even though the bot answered
+// (verified against Postgres ground truth). This is the classic guard
+// UNDER-match: the check watches one literal form and goes quiet when the
+// same fact shows up in another form.
+// ---------------------------------------------------------------------------
+
+/**
+ * True if `remoteJid` is the bot's own conversation — either directly (the
+ * phone-JID form) or via a `@lid` JID that `resolvedLidPhoneE164` (an
+ * out-of-band Baileys `signalRepository.lidMapping.getPNForLID` lookup,
+ * performed by the live-socket caller) resolved to the bot's number.
+ *
+ * Fails CLOSED like `matchesBotRecipient`: an unresolved or non-matching LID
+ * (`resolvedLidPhoneE164` null/other) is NOT the bot — a reply from some
+ * other contact must never be misattributed to the bot just because both
+ * arrived as LIDs.
+ */
+export function isBotReplyJid(
+  remoteJid: string | null | undefined,
+  resolvedLidPhoneE164: string | null,
+): boolean {
+  const parsed = parseJid(remoteJid);
+  if (parsed.kind === "phone") {
+    return phoneDigits(parsed.phone) === BOT_PHONE_DIGITS;
+  }
+  if (parsed.kind === "lid") {
+    if (!resolvedLidPhoneE164) return false;
+    return phoneDigits(resolvedLidPhoneE164) === BOT_PHONE_DIGITS;
+  }
+  return false;
 }
 
 export type AllowlistViolation = { ok: false; error: string };

--- a/apps/wa-mirror/scripts/wa-tester.ts
+++ b/apps/wa-mirror/scripts/wa-tester.ts
@@ -43,6 +43,7 @@ import {
   buildQuestionResult,
   buildTranscript,
   extractMessageText,
+  isBotReplyJid,
   isPairedFromCreds,
   parseMessageTimestampMs,
   shouldReconnect,
@@ -333,8 +334,43 @@ async function connectPairedSocket(): Promise<WASocket> {
   return sock;
 }
 
+/**
+ * Reverse-resolves a `@lid` (Linked Identity Device) JID to the phone
+ * number WhatsApp has it mapped to, via Baileys' own in-session signal
+ * store — same API surface as bridge/session.ts's `resolveLidToPhone`
+ * (FIX 3, 2026-05-26), but WITHOUT that fix's Postgres write-back:
+ * wa-tester's boundary is explicitly "does NOT touch Postgres/CRM" (see
+ * file header), and this is a one-shot on-demand tool, not a persistent
+ * mirror worth caching for. Fails CLOSED (returns null) on any error or
+ * unresolved LID — `isBotReplyJid` treats null as "not the bot".
+ */
+async function resolveLidToPhoneDigits(
+  sock: WASocket,
+  lid: string,
+): Promise<string | null> {
+  try {
+    const sockAny = sock as unknown as {
+      signalRepository?: {
+        lidMapping?: {
+          getPNForLID?: (lid: string) => Promise<string | null>;
+        };
+      };
+    };
+    const result = await sockAny.signalRepository?.lidMapping?.getPNForLID?.(
+      lid.includes("@") ? lid : `${lid}@lid`,
+    );
+    if (!result) return null;
+    const digits = result.split("@")[0]?.split(":")[0]?.replace(/\D/g, "");
+    return digits && digits.length > 0 ? digits : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Subscribes to messages.upsert scoped ONLY to the bot's JID conversation.
- * Privacy rail: every other chat/event is ignored and never logged. */
+ * Privacy rail: every other chat/event is ignored and never logged.
+ * Matches BOTH the bot's phone-JID and its `@lid` form (scar #3 UNDER-match
+ * fix, 2026-07-20) — see isBotReplyJid's doc comment in wa-tester-core.ts. */
 function collectReplies(
   sock: WASocket,
   sentAtMs: number,
@@ -346,10 +382,15 @@ function collectReplies(
     quietPeriodS: QUIET_PERIOD_S,
   });
 
-  const onUpsert = (event: BaileysEventMap["messages.upsert"]) => {
+  const onUpsert = async (event: BaileysEventMap["messages.upsert"]) => {
     if (event.type !== "notify") return;
     for (const m of event.messages) {
-      if (m.key?.remoteJid !== BOT_JID) continue; // ignore every other chat, no exceptions
+      const remoteJid = m.key?.remoteJid;
+      let resolvedLidPhoneDigits: string | null = null;
+      if (remoteJid?.endsWith("@lid")) {
+        resolvedLidPhoneDigits = await resolveLidToPhoneDigits(sock, remoteJid);
+      }
+      if (!isBotReplyJid(remoteJid, resolvedLidPhoneDigits)) continue; // ignore every other chat, no exceptions
       if (m.key?.fromMe) continue; // our own outbound echo, not a bot reply
       const text = extractMessageText(m.message);
       if (!text) continue;

--- a/apps/wa-mirror/tests/wa-tester-core.test.ts
+++ b/apps/wa-mirror/tests/wa-tester-core.test.ts
@@ -15,6 +15,7 @@ import {
   buildTranscript,
   checkRecipientAllowlist,
   extractMessageText,
+  isBotReplyJid,
   isPairedFromCreds,
   matchesBotRecipient,
   parseMessageTimestampMs,
@@ -441,5 +442,51 @@ describe("isPairedFromCreds — guilt + innocence (QR-companion vs pairing-code 
         me: { id: "628213465159:1@s.whatsapp.net" },
       }),
     ).toBe(true);
+  });
+});
+
+describe("isBotReplyJid — guilt + innocence (scar #3 UNDER-match, WhatsApp LID rollout)", () => {
+  it("[guilt] bot's own phone-JID form matches (pre-existing behaviour, preserved)", () => {
+    expect(isBotReplyJid(BOT_JID, null)).toBe(true);
+  });
+
+  it("[guilt] bot's phone-JID with a multi-device :N suffix still matches", () => {
+    expect(isBotReplyJid("628213465159:5@s.whatsapp.net", null)).toBe(true);
+  });
+
+  it("[guilt] a @lid JID that resolves to the bot's phone matches (the actual bug this fixes)", () => {
+    expect(isBotReplyJid("224112131756075@lid", "+628213465159")).toBe(true);
+  });
+
+  it("[guilt] @lid resolution may come back as bare digits, not just E.164", () => {
+    expect(isBotReplyJid("224112131756075@lid", "628213465159")).toBe(true);
+  });
+
+  it("[innocence-1] a @lid JID that resolves to a DIFFERENT phone must NOT match", () => {
+    expect(isBotReplyJid("224112131756075@lid", "+6281234567890")).toBe(false);
+  });
+
+  it("[innocence-2] a @lid JID that fails to resolve (null) must NOT match — fail closed", () => {
+    expect(isBotReplyJid("224112131756075@lid", null)).toBe(false);
+  });
+
+  it("[innocence-3] some other contact's phone-JID must NOT match", () => {
+    expect(isBotReplyJid("6281234567890@s.whatsapp.net", null)).toBe(false);
+  });
+
+  it("[innocence-4] a resolved LID phone must NOT rescue an unrelated remoteJid", () => {
+    // resolvedLidPhoneE164 is only consulted when remoteJid itself is a LID —
+    // it must never leak into matching a phone-JID it wasn't resolved from.
+    expect(isBotReplyJid("6281234567890@s.whatsapp.net", "+628213465159")).toBe(
+      false,
+    );
+  });
+
+  it("[innocence-5] group/broadcast/empty JIDs never match", () => {
+    expect(isBotReplyJid("123456-789@g.us", "+628213465159")).toBe(false);
+    expect(isBotReplyJid("status@broadcast", "+628213465159")).toBe(false);
+    expect(isBotReplyJid(null, "+628213465159")).toBe(false);
+    expect(isBotReplyJid(undefined, "+628213465159")).toBe(false);
+    expect(isBotReplyJid("", "+628213465159")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- `collectReplies()` dropped every bot reply that WhatsApp tagged with an opaque `@lid` identifier instead of the bot's phone-JID (strict `remoteJid !== BOT_JID`), producing `reply_count: 0` even when the bot had actually answered (verified against Postgres ground truth) — a scar #3 guard UNDER-match.
- Adds `isBotReplyJid()` (pure, unit-tested) which matches either the bot's phone-JID directly or a `@lid` JID reverse-resolved via Baileys' `signalRepository.lidMapping.getPNForLID` — the same API `bridge/session.ts` already uses for this exact purpose, minus its Postgres write-back (wa-tester's boundary is explicitly no-Postgres/no-CRM). Fails closed: an unresolved or non-matching LID is never treated as the bot.
- Send-side allowlist (`matchesBotRecipient`, THE ONE RULE) is untouched — this is instrumentation-only on the receive path.

## Test plan
- [x] `npx vitest run` — 107/107 passed (54 in `wa-tester-core.test.ts`, including 9 new guilt+innocence cases for `isBotReplyJid`)
- [x] `npx tsc --noEmit` — clean
- [x] Manual verification against the real bot: out of scope for CI per file header ("Live-socket glue... exercised manually against the real bot, not in CI")

🤖 Generated with [Claude Code](https://claude.com/claude-code)