### PR TITLE
fix(backend-rag): persist verification_score onto AgentState (dead-wiring)

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/reasoning.py
+++ b/apps/backend-rag/backend/services/rag/agentic/reasoning.py
@@ -977,6 +977,37 @@ Do not invent information. If the context is insufficient, admit it.
                     if "citations" in processed:
                         state.sources = processed["citations"]
 
+                    # Dead-wiring fix (2026-07-20): this is the AUTHORITATIVE
+                    # `processed` result for the answer actually being
+                    # returned above — if self-correction ran, `processed`
+                    # was reassigned to the retry pipeline's fresh verdict on
+                    # the CORRECTED answer; re-reading here (rather than
+                    # persisting the pre-correction verification_score local
+                    # from before the retry) is what keeps the score
+                    # attached to the text it actually describes. Before
+                    # this fix, verification_score/verdict_available were
+                    # computed but never survived past this function —
+                    # orchestrator_response.py's CoreResult reads
+                    # getattr(state, "verification_score", 0.0), and nothing
+                    # ever set that attribute, so every response reported
+                    # 0.0 regardless of the real score. Only persist when
+                    # verdict_available: an unparseable/placeholder score is
+                    # not a real judgment, and reporting it as the
+                    # client-facing verification_status would swap one lie
+                    # ("always 0.0") for another ("fake pass/fail"). Leaving
+                    # state at its default keeps CoreResult's derived
+                    # verification_status="unchecked" — the honest label for
+                    # "we never got a real verdict".
+                    final_verdict_available = processed.get(
+                        "verdict_available",
+                        verdict_available,
+                    )
+                    if final_verdict_available:
+                        state.verification_score = processed.get(
+                            "verification_score",
+                            verification_score,
+                        )
+
                     logger.info(
                         f"✅ [Pipeline] Response processed: "
                         f"verification={processed.get('verification_status', 'unknown')}, "

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave1.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave1.py
@@ -918,6 +918,10 @@ class TestPipelineProcessing:
         assert pipeline.process.await_count == 2
         # corrected answer installed
         assert result_state.final_answer == "corrected answer"
+        # 2026-07-20 dead-wiring fix: the LAST computed score (post-correction,
+        # verdict_available implicitly True) must survive onto state — it
+        # used to stay at the schema default 0.0 forever (never assigned).
+        assert result_state.verification_score == 0.9
 
     @pytest.mark.asyncio
     async def test_pipeline_verdict_unavailable_skips_self_correction(self, engine):
@@ -977,6 +981,17 @@ class TestPipelineProcessing:
         assert call["i"] == 1
         # Original (never "corrected") answer stands
         assert result_state.final_answer == "original answer"
+        # 2026-07-20 dead-wiring fix, fail-closed half: verdict_available=False
+        # means the 0.5 score is a placeholder, not a real judgment — it must
+        # NOT be persisted onto state (that would swap "always lies 0.0" for
+        # "sometimes lies with a fake score"). AgentState is a plain
+        # dataclass with no declared verification_score field, so "never
+        # persisted" means the attribute stays genuinely absent — matching
+        # exactly how orchestrator_response.py reads it
+        # (getattr(state, "verification_score", 0.0)), which is what keeps
+        # CoreResult's derived status the honest "unchecked".
+        assert not hasattr(result_state, "verification_score")
+        assert getattr(result_state, "verification_score", 0.0) == 0.0
 
     @pytest.mark.asyncio
     async def test_pipeline_error_falls_back_to_post_process(self, engine):
@@ -1016,3 +1031,56 @@ class TestPipelineProcessing:
         # R30: pipeline raised, but post_process_response installed a non-None result
         mock_pp.assert_called_once()
         assert result_state.final_answer == "post-processed fallback"
+
+    @pytest.mark.asyncio
+    async def test_pipeline_verification_passes_persists_score_on_state(self, engine):
+        """2026-07-20 dead-wiring fix, guilt case: the common happy path —
+        pipeline verifies successfully (score >= 0.7, verdict_available
+        True, no self-correction needed) — must persist the real score onto
+        state.verification_score so CoreResult (orchestrator_response.py's
+        getattr(state, "verification_score", 0.0)) reports the truth instead
+        of the schema default 0.0 it silently returned on every request."""
+        pipeline = MagicMock()
+        pipeline.process = AsyncMock(
+            return_value={
+                "response": "well-verified answer",
+                "verification_score": 0.95,
+                "verdict_available": True,
+                "verification_status": "passed",
+            },
+        )
+        from backend.services.rag.agentic.reasoning import ReasoningEngine
+
+        local_engine = ReasoningEngine(tool_map={}, response_pipeline=pipeline)
+
+        state = AgentState(query="q", max_steps=1, current_step=0, intent_type="simple")
+
+        gateway = _mk_gateway(
+            send_message_side_effect=lambda *a, **k: _llm_response(
+                "Final Answer: well-verified answer",
+            ),
+            has_tools=True,
+        )
+
+        with (
+            patch(
+                "backend.services.rag.agentic.reasoning.detect_query_language",
+                return_value="ENGLISH",
+            ),
+            patch(
+                "backend.services.rag.agentic.reasoning.calculate_evidence_score", return_value=0.8
+            ),
+            patch("backend.services.rag.agentic.reasoning.is_critical_domain", return_value=False),
+            patch("backend.services.rag.agentic.reasoning.parse_tool_call", return_value=None),
+            patch("backend.services.rag.agentic.reasoning.is_valid_tool_call", return_value=False),
+            patch(
+                "backend.services.rag.agentic.reasoning.post_process_response",
+                new_callable=AsyncMock,
+                return_value="processed",
+            ),
+        ):
+            result_state, _, _, _ = await _run_loop(local_engine, gateway, state)
+
+        # Only one pass — high score means no self-correction round-trip
+        assert pipeline.process.await_count == 1
+        assert result_state.verification_score == 0.95


### PR DESCRIPTION
## Summary

`reasoning.py`'s ReAct pipeline computes `verification_score`/`verdict_available` on every response but never persisted them onto `AgentState` — `orchestrator_response.py`'s `CoreResult` reads `getattr(state, "verification_score", 0.0)`, so every response silently reported `0.0` regardless of the real verifier score. Root cause: two distinct `AgentState` classes exist with the same name (`schema.py`'s `CoreResult` — a *response* model that owns the `verification_score: float = 0.0` field — vs `definitions.py`'s `AgentState`, the actual ReAct working-state dataclass, which never declared the field at all).

Second, deeper bug found while writing the regression test: the self-correction retry re-runs `response_pipeline.process()` on the corrected answer and reassigns `processed`, but a naive fix (persist right after the first pipeline call) would have attached the **stale pre-correction score** to the corrected final answer — wrong text/score pairing, worse than the original bug in that respect. Fixed by persisting after the self-correction block, re-reading whichever `processed` dict is authoritative at that point.

Fail-closed: only persists when `verdict_available` is true — an unparseable/placeholder score is not a real judgment, and reporting it would swap "always lies 0.0" for "sometimes lies with a fake score". `AgentState` has no `__slots__`, so "never persisted" means the attribute stays genuinely absent, matching exactly how `orchestrator_response.py` reads it (`getattr(..., 0.0)`), keeping `CoreResult`'s derived `verification_status` at the honest `"unchecked"`.

**Explicitly out of scope** (deliberate, documented in commit): the A/B reranker/hybrid/query-expansion "wire vs remove" architectural decision noted in the same task — that's a product-direction call, not a safe low-risk cleanup, left untouched.

## Test plan

- 3 new/extended tests in `test_orchestrator_state_machine_wave1.py::TestPipelineProcessing`:
  - guilt (happy path, no self-correction): score persists (`0.95`)
  - guilt (self-correction ran): the **post-correction** score persists (`0.9`), not the stale pre-correction one
  - innocence (`verdict_available=False`): attribute stays genuinely absent (`hasattr` false), `CoreResult` default (`0.0`) still applies
- 128 targeted agentic/rag tests pass
- 5 pre-existing, unrelated test-isolation flakes (`test_prompt_builder.py` ×3, `test_reasoning_utils.py::TestDetectTeamQuery` ×2) ruled out via rigorous stash/unstash comparison (present identically on `origin/main` base, only under the full combined suite — not caused by this diff)
- Full suite: 19161 passed, 227 skipped (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>