### PR TITLE
fix(backend-rag): knowledge_visa jsonb cast on native text[] columns (ex #31)

### DIFF
--- a/apps/backend-rag/backend/app/routers/knowledge_visa.py
+++ b/apps/backend-rag/backend/app/routers/knowledge_visa.py
@@ -285,15 +285,17 @@ async def update_visa_type(
         values = []
         param_idx = 1
 
-        # Fields that are JSONB and need serialization
+        # Fields that are genuine JSONB (dict) columns and need to_jsonb()
+        # serialization. requirements/restrictions/allowed_activities/
+        # benefits/process_steps/tips are native Postgres `text[]` columns
+        # (verified via information_schema, 2026-07-20) — NOT jsonb. Casting
+        # them ::text::jsonb here was a hard Postgres type error ("column X
+        # is of type text[] but expression is of type jsonb") that broke
+        # every PUT touching those fields; they must be bound as plain
+        # Python lists via the "else" branch below, same as migration_043's
+        # proven-working direct UPDATE pattern.
         jsonb_fields = {
             "cost_details",
-            "requirements",
-            "restrictions",
-            "allowed_activities",
-            "benefits",
-            "process_steps",
-            "tips",
             "metadata",
         }
 
@@ -390,9 +392,9 @@ async def create_visa_type(
                 foreign_eligible, metadata, created_at, last_updated
             ) VALUES (
                 $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
-                $13::text::jsonb, $14::text::jsonb, $15::text::jsonb,
-                $16::text::jsonb, $17::text::jsonb, $18::text::jsonb,
-                $19::text::jsonb, $20, $21::text::jsonb, NOW(), NOW()
+                $13::text::jsonb, $14, $15,
+                $16, $17, $18,
+                $19, $20, $21::text::jsonb, NOW(), NOW()
             )
             RETURNING *
             """,
@@ -408,17 +410,24 @@ async def create_visa_type(
             visa.processing_timeline,
             visa.cost_visa,
             visa.cost_extension,
-            # ::text::jsonb on all 8 jsonb columns below — the app pools
-            # register a jsonb codec (encoder=json.dumps); a bare param
-            # inferred as jsonb double-encodes to_jsonb()'s already-serialized
-            # string into a jsonb string scalar.
+            # ::text::jsonb only for genuine JSONB columns (cost_details,
+            # metadata) — the app pools register a jsonb codec
+            # (encoder=json.dumps); a bare param inferred as jsonb double-
+            # encodes to_jsonb()'s already-serialized string into a jsonb
+            # string scalar, so those two go through to_jsonb()+cast.
+            # requirements/restrictions/allowed_activities/benefits/
+            # process_steps/tips are native Postgres text[] columns (verified
+            # via information_schema, 2026-07-20) — bind the Python list
+            # directly, no cast, no to_jsonb(): a ::text::jsonb cast against
+            # text[] is a hard Postgres type error, same root cause as the
+            # broken PUT (migration_043 uses this same direct-list pattern).
             to_jsonb(visa.cost_details),
-            to_jsonb(visa.requirements),
-            to_jsonb(visa.restrictions),
-            to_jsonb(visa.allowed_activities),
-            to_jsonb(visa.benefits),
-            to_jsonb(visa.process_steps),
-            to_jsonb(visa.tips),
+            visa.requirements,
+            visa.restrictions,
+            visa.allowed_activities,
+            visa.benefits,
+            visa.process_steps,
+            visa.tips,
             visa.foreign_eligible,
             to_jsonb(visa.metadata),
         )

--- a/apps/backend-rag/backend/tests/app/routers/test_knowledge_visa_jsonb_cast.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_knowledge_visa_jsonb_cast.py
@@ -1,0 +1,185 @@
+"""Integration tests for knowledge_visa.py's jsonb/text[] cast bug (ex #31).
+
+Root cause: visa_types.requirements/restrictions/allowed_activities/
+benefits/process_steps/tips are native Postgres `text[]` columns (verified
+via information_schema, 2026-07-20) — NOT jsonb. POST and PUT both cast
+those params `::text::jsonb`, which is a hard Postgres type error against a
+text[] column ("column X is of type text[] but expression is of type
+jsonb"). A mocked-pool unit test cannot catch this — the failure is a real
+SQL type mismatch, not a Python-level one — so this test runs against a
+real Postgres, matching this repo's own "reproduce the bug on the real call
+path" lesson (apps/backend-rag/CLAUDE.md, Migration Runner scar).
+
+Skips cleanly if the DB/table/columns are unreachable or unmigrated.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import AsyncGenerator
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+import backend.app.routers.knowledge_visa as knowledge_visa_module
+from backend.app.dependencies import get_database_pool
+
+pytestmark = pytest.mark.integration
+
+_DB_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
+)
+
+_ARRAY_FIELDS = (
+    "requirements",
+    "restrictions",
+    "allowed_activities",
+    "benefits",
+    "process_steps",
+    "tips",
+)
+
+
+async def _init_jsonb_codec(conn: asyncpg.Connection) -> None:
+    """Match backend/app/core/database.py::get_db_pool's init callback — the
+    production pool registers a jsonb/json codec (encoder/decoder=json).
+    Without it, the fixture pool would round-trip jsonb columns as raw
+    strings, silently diverging from what the real app dependency does.
+    """
+    await conn.set_type_codec(
+        "jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
+    )
+    await conn.set_type_codec(
+        "json", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
+    )
+
+
+@pytest_asyncio.fixture(scope="function")
+async def pool() -> AsyncGenerator[asyncpg.Pool, None]:
+    try:
+        p = await asyncpg.create_pool(
+            _DB_URL, min_size=1, max_size=5, init=_init_jsonb_codec
+        )
+    except (OSError, asyncpg.PostgresError) as exc:
+        pytest.skip(f"DB unreachable: {exc}")
+        return
+
+    skip_reason: str | None = None
+    try:
+        async with p.acquire() as conn:
+            exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema='public' AND table_name='visa_types')",
+            )
+            if not exists:
+                skip_reason = "visa_types table missing in test DB"
+            else:
+                for field in _ARRAY_FIELDS:
+                    udt = await conn.fetchval(
+                        "SELECT udt_name FROM information_schema.columns "
+                        "WHERE table_name='visa_types' AND column_name=$1",
+                        field,
+                    )
+                    if udt != "_text":
+                        skip_reason = (
+                            f"visa_types.{field} is '{udt}', expected native "
+                            "text[] ('_text') — schema drifted from what this "
+                            "test asserts"
+                        )
+                        break
+        if skip_reason is None:
+            yield p
+    finally:
+        await p.close()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+
+def _make_app(pool: asyncpg.Pool) -> FastAPI:
+    application = FastAPI()
+    application.include_router(knowledge_visa_module.router)
+    application.dependency_overrides[get_database_pool] = lambda: pool
+    application.dependency_overrides[knowledge_visa_module.get_admin_user] = lambda: {
+        "id": "1",
+        "email": "zero@balizero.com",
+        "role": "admin",
+    }
+    return application
+
+
+async def _cleanup(pool: asyncpg.Pool, visa_id: int) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM visa_types WHERE id = $1", visa_id)
+
+
+@pytest.mark.asyncio
+async def test_create_then_update_array_and_jsonb_fields_round_trip(
+    pool: asyncpg.Pool,
+) -> None:
+    """Guilt case: before the fix, both POST and PUT 500'd with a Postgres
+    type error the instant an array field (e.g. allowed_activities) or a
+    genuine jsonb field (cost_details) was set — the ::text::jsonb cast
+    against a text[] column is invalid DDL, unconditionally, for any value.
+    """
+    app = _make_app(pool)
+    transport = ASGITransport(app=app)
+    code = f"TEST-{uuid.uuid4().hex[:8].upper()}"
+
+    async with AsyncClient(transport=transport, base_url="http://t") as ac:
+        created = await ac.post(
+            "/api/knowledge/visa/",
+            json={
+                "code": code,
+                "name": "Test Visa",
+                "category": "Business",
+                "requirements": ["Passport", "Photo"],
+                "restrictions": ["No employment"],
+                "allowed_activities": ["Business meetings"],
+                "benefits": ["Multiple entry"],
+                "process_steps": ["Apply", "Pay", "Collect"],
+                "tips": ["Bring extra copies"],
+                "cost_details": {"visa_fee": 500000, "service_fee": 300000},
+            },
+        )
+        assert created.status_code == 200, created.text
+        body = created.json()
+        visa_id = body["id"]
+        try:
+            # Array fields round-tripped as native lists, not JSON-string blobs.
+            assert body["requirements"] == ["Passport", "Photo"]
+            assert body["allowed_activities"] == ["Business meetings"]
+            # Genuine jsonb field round-tripped as a dict.
+            assert body["cost_details"] == {
+                "visa_fee": 500000,
+                "service_fee": 300000,
+            }
+
+            updated = await ac.put(
+                f"/api/knowledge/visa/{visa_id}",
+                json={
+                    "allowed_activities": ["Business meetings", "Site visits"],
+                    "restrictions": ["No employment", "No enrollment in school"],
+                    "metadata": {"reviewed_by": "test"},
+                },
+            )
+            assert updated.status_code == 200, updated.text
+            updated_body = updated.json()
+            assert updated_body["allowed_activities"] == [
+                "Business meetings",
+                "Site visits",
+            ]
+            assert updated_body["restrictions"] == [
+                "No employment",
+                "No enrollment in school",
+            ]
+            assert updated_body["metadata"] == {"reviewed_by": "test"}
+            # Untouched array field survives the partial update unchanged.
+            assert updated_body["requirements"] == ["Passport", "Photo"]
+        finally:
+            await _cleanup(pool, visa_id)

--- a/apps/backend-rag/backend/tests/db/test_jsonb_double_encoding_class_guard.py
+++ b/apps/backend-rag/backend/tests/db/test_jsonb_double_encoding_class_guard.py
@@ -67,14 +67,17 @@ PROTECTED_JSONB_COLUMNS: dict[str, tuple[str, ...]] = {
     "failed_messages": ("metadata",),
     "naga_sessions": ("action_items", "sub_questions"),
     "crm_workspace_ai_snapshots": ("facts",),
+    # Corrected 2026-07-20 (ex #31): requirements/restrictions/
+    # allowed_activities/benefits/process_steps/tips are native Postgres
+    # text[] columns (verified live via information_schema), NOT jsonb — the
+    # 2026-07-16 sweep that seeded this registry inferred "protected" from
+    # the *code's* pre-existing (buggy) ::text::jsonb-cast pattern rather
+    # than the real column type, so it baked the bug's own premise in as
+    # ground truth. text[] is a different wire type than jsonb; the codec's
+    # jsonb encode/decode hook never touches it, so the double-encoding
+    # disease this guard exists to catch structurally cannot occur there.
     "visa_types": (
         "cost_details",
-        "requirements",
-        "restrictions",
-        "allowed_activities",
-        "benefits",
-        "process_steps",
-        "tips",
         "metadata",
     ),
     "conversations": ("messages", "metadata"),
@@ -370,6 +373,48 @@ def test_innocence_unrelated_table_does_not_fire():
         )
     """
     assert _scan_source(src, "synthetic.py") == []
+
+
+def test_innocence_visa_types_array_columns_do_not_require_cast():
+    """INNOCENCE: the actual shipped knowledge_visa.py POST shape (ex #31) —
+    cost_details/metadata cast ::text::jsonb, the 6 native text[] columns
+    bound as raw lists with no cast at all — must not fire, even though a
+    to_jsonb() serializer call is present elsewhere in the same statement
+    (for cost_details/metadata)."""
+    src = """
+        row = await conn.fetchrow(
+            \"\"\"
+            INSERT INTO visa_types (
+                code, name, category, cost_details,
+                requirements, restrictions, allowed_activities,
+                benefits, process_steps, tips, metadata
+            ) VALUES (
+                $1, $2, $3, $4::text::jsonb,
+                $5, $6, $7, $8, $9, $10, $11::text::jsonb
+            )
+            \"\"\",
+            code, name, category, to_jsonb(cost_details),
+            requirements, restrictions, allowed_activities,
+            benefits, process_steps, tips, to_jsonb(metadata),
+        )
+    """
+    assert _scan_source(src, "synthetic.py") == []
+
+
+def test_guilt_visa_types_real_jsonb_column_missing_cast_fires():
+    """GUILT: the registry correction must not blind the guard to a real
+    regression on visa_types' genuinely-protected columns (cost_details,
+    metadata) — only the 6 text[] columns were removed."""
+    src = """
+        row = await conn.fetchrow(
+            \"\"\"
+            INSERT INTO visa_types (code, cost_details, metadata)
+            VALUES ($1, $2, $3)
+            \"\"\",
+            code, to_jsonb(cost_details), to_jsonb(metadata),
+        )
+    """
+    assert _scan_source(src, "synthetic.py") != []
 
 
 def test_innocence_unprotected_column_on_protected_table_does_not_fire():

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_activation_writer.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_activation_writer.py
@@ -1024,50 +1024,71 @@ async def test_ownership_and_grant_boundary_real_roles(repo: VisaEngineRepositor
 
     async with repo.db_pool.acquire() as conn:
         try:
+            # The whole provisioning phase below (CREATE ROLE through the
+            # final schema GRANT) requires the SAME elevated privilege the
+            # test's own finally-block comment assumes ("the connecting
+            # (superuser) role"): CREATE ROLE alone isn't sufficient — a
+            # non-superuser with CREATEROLE can create a role without
+            # thereby gaining membership in it, so the very next step
+            # (ALTER TABLE ... OWNER TO <role just created>) fails with the
+            # identical InsufficientPrivilegeError on a test-runner role
+            # that merely has CREATEROLE but not superuser (observed on a
+            # local dev Postgres, 2026-07-20). One try/except for the whole
+            # phase, not just the CREATE ROLE calls — a role created but
+            # never successfully owned/granted anything is equally unable
+            # to "mirror the real boundary" this test exists to assert.
             try:
                 await conn.execute(f"CREATE ROLE {owner_role} NOLOGIN")
                 await conn.execute(f"CREATE ROLE {serving_role} NOLOGIN")
                 await conn.execute(f"CREATE ROLE {executor_role} NOLOGIN")
+
+                # 1. Simulate TODAY's prod state: the serving role owns both
+                #    tables (mirrors `backend_rag_v2` being both table owner
+                #    AND serving role — F1+F2's own documented starting point).
+                await conn.execute(f"ALTER TABLE public.visa_rule_packs OWNER TO {serving_role}")
+                await conn.execute(
+                    f"ALTER TABLE public.visa_ruleset_activations OWNER TO {serving_role}"
+                )
+
+                # 2. The operator provisioning script's REQUIRED steps
+                #    (migration header, F1+F2 / P0-2): move BOTH tables' AND
+                #    all 5 functions' ownership to the ledger-owner role,
+                #    THEN revoke direct DML from the now-non-owning serving
+                #    role, THEN grant EXECUTE-only to the executor role.
+                await conn.execute(f"ALTER TABLE public.visa_rule_packs OWNER TO {owner_role}")
+                await conn.execute(
+                    f"ALTER TABLE public.visa_ruleset_activations OWNER TO {owner_role}"
+                )
+                await conn.execute(
+                    f"ALTER FUNCTION public.visa_activate_rule_pack(uuid, text, text) OWNER TO {owner_role}"
+                )
+                for fn in trigger_functions:
+                    await conn.execute(f"ALTER FUNCTION public.{fn}() OWNER TO {owner_role}")
+                await conn.execute(
+                    f"REVOKE INSERT, UPDATE, DELETE ON public.visa_rule_packs, "
+                    f"public.visa_ruleset_activations FROM {serving_role}"
+                )
+                await conn.execute(
+                    f"GRANT EXECUTE ON FUNCTION public.visa_activate_rule_pack(uuid, text, text) "
+                    f"TO {executor_role}"
+                )
+                # DISCOVERED WHILE WRITING THIS TEST (P1-6): `CREATE OR
+                # REPLACE FUNCTION` checks schema-level CREATE privilege
+                # independent of function ownership (Postgres does not
+                # exempt "replace" from the schema ACL check even though it
+                # exempts it from needing to already own the target).
+                # Migration 251's rollback runs `CREATE OR REPLACE FUNCTION
+                # public.reject_visa_*` — so `visa_ledger_owner` needs
+                # `CREATE ON SCHEMA public` too, not just object ownership,
+                # or a post-hardening rollback fails with "permission
+                # denied for schema public". Folded into the migration
+                # header's provisioning steps + PENDING-ARMS.md.
+                await conn.execute(f"GRANT CREATE ON SCHEMA public TO {owner_role}")
             except asyncpg.exceptions.InsufficientPrivilegeError:
-                pytest.skip("test DB role lacks CREATE ROLE — cannot mirror the real boundary")
-
-            # 1. Simulate TODAY's prod state: the serving role owns both
-            #    tables (mirrors `backend_rag_v2` being both table owner
-            #    AND serving role — F1+F2's own documented starting point).
-            await conn.execute(f"ALTER TABLE public.visa_rule_packs OWNER TO {serving_role}")
-            await conn.execute(f"ALTER TABLE public.visa_ruleset_activations OWNER TO {serving_role}")
-
-            # 2. The operator provisioning script's REQUIRED steps
-            #    (migration header, F1+F2 / P0-2): move BOTH tables' AND
-            #    all 5 functions' ownership to the ledger-owner role,
-            #    THEN revoke direct DML from the now-non-owning serving
-            #    role, THEN grant EXECUTE-only to the executor role.
-            await conn.execute(f"ALTER TABLE public.visa_rule_packs OWNER TO {owner_role}")
-            await conn.execute(f"ALTER TABLE public.visa_ruleset_activations OWNER TO {owner_role}")
-            await conn.execute(
-                f"ALTER FUNCTION public.visa_activate_rule_pack(uuid, text, text) OWNER TO {owner_role}"
-            )
-            for fn in trigger_functions:
-                await conn.execute(f"ALTER FUNCTION public.{fn}() OWNER TO {owner_role}")
-            await conn.execute(
-                f"REVOKE INSERT, UPDATE, DELETE ON public.visa_rule_packs, "
-                f"public.visa_ruleset_activations FROM {serving_role}"
-            )
-            await conn.execute(
-                f"GRANT EXECUTE ON FUNCTION public.visa_activate_rule_pack(uuid, text, text) "
-                f"TO {executor_role}"
-            )
-            # DISCOVERED WHILE WRITING THIS TEST (P1-6): `CREATE OR REPLACE
-            # FUNCTION` checks schema-level CREATE privilege independent of
-            # function ownership (Postgres does not exempt "replace" from
-            # the schema ACL check even though it exempts it from needing
-            # to already own the target). Migration 251's rollback runs
-            # `CREATE OR REPLACE FUNCTION public.reject_visa_*` — so
-            # `visa_ledger_owner` needs `CREATE ON SCHEMA public` too, not
-            # just object ownership, or a post-hardening rollback fails
-            # with "permission denied for schema public". Folded into the
-            # migration header's provisioning steps + PENDING-ARMS.md.
-            await conn.execute(f"GRANT CREATE ON SCHEMA public TO {owner_role}")
+                pytest.skip(
+                    "test DB role lacks privilege to create/own throwaway "
+                    "roles — cannot mirror the real boundary"
+                )
 
             # --- P0-2 machine assertion: every one of the 5 functions is
             #     now owned by the ledger-owner role, never the serving

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 654 services · 1218 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 654 services · 1219 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

`visa_types.requirements/restrictions/allowed_activities/benefits/process_steps/tips` are native Postgres `text[]` columns (verified via `information_schema`, 2026-07-20) — NOT jsonb. Both `POST` and `PUT` in `knowledge_visa.py` cast those params `::text::jsonb`, a hard Postgres type error against a `text[]` column (`column X is of type text[] but expression is of type jsonb`), breaking every write touching one of those 6 fields. Only `cost_details`/`metadata` are genuine jsonb columns and keep the `to_jsonb()::text::jsonb` pattern (needed to avoid the app pool's jsonb codec double-encoding an already-serialized string). `migration_043` already used the correct direct-list pattern for these columns — the router just never matched it.

Root cause was discovered by lane #25 (worked around with a direct UPDATE, migration_043-style, rather than fixing the router). This PR fixes the router itself.

Verified empirically against a throwaway local Postgres replicating the production `visa_types` schema: the pre-fix code reproducibly threw `asyncpg.exceptions.DatatypeMismatchError` on the exact predicted column, and the fix resolves it with a full POST+PUT round-trip.

**Two adjacent fixes, both discovered getting this PR to a green push:**

1. `test_jsonb_double_encoding_class_guard.py` (W89)'s `PROTECTED_JSONB_COLUMNS` registry had `visa_types`' 6 `text[]` columns listed as protected jsonb columns — inherited from pattern-matching the pre-fix (buggy) code rather than the real schema, so the guard's own premise baked in the bug it should have caught. Corrected to the 2 genuine jsonb columns, with new guilt+innocence tests anchoring the correction (scar family #3 antidote).
2. `test_ownership_and_grant_boundary_real_roles` (unrelated visa_engine test) had an incomplete privilege guard: it already skipped gracefully on `InsufficientPrivilegeError` for `CREATE ROLE`, but not for the very next step (`ALTER TABLE ... OWNER TO <role just created>`), which needs the same elevated privilege a non-superuser `CREATEROLE` holder doesn't automatically get — blocking every push on this machine. Confirmed pre-existing and unrelated to this diff via stash comparison. Widened the same already-established guard to the whole provisioning phase, matching the test's own `finally`-block comment ("the connecting (superuser) role").

## Test plan

- New integration test `test_knowledge_visa_jsonb_cast.py`: real-Postgres POST+PUT round-trip (mocked-pool tests can't catch this — it's a genuine SQL type error, not a Python-level one), matches this repo's own "reproduce on the real call path" convention (`test_intake_gate.py`). Skips cleanly if the local test DB lacks the `visa_types` table/schema.
- Guilt case reproduced and verified against a throwaway local Postgres: `asyncpg.exceptions.DatatypeMismatchError: column "requirements" is of type text[] but expression is of type jsonb` — exact predicted error, confirmed via `git stash` (fix present → passes; fix stashed out → fails identically).
- `test_jsonb_double_encoding_class_guard.py`: 11/11 pass including the corrected `test_no_offenders_in_repo` repo-wide sweep, plus 2 new guilt+innocence tests anchoring the `visa_types` registry correction.
- `test_activation_writer.py`: 28 passed, 2 skipped (both pre-existing skip conditions, now including the widened one) — 0 failures.
- Full suite: 19174 passed, 229 skipped, 0 failed (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>