### PR TITLE
feat(kbli): tier-scoped partial detach primitive in cure_canonical_collisions.py

### DIFF
--- a/scripts/kbli_filiera/cure_canonical_collisions.py
+++ b/scripts/kbli_filiera/cure_canonical_collisions.py
@@ -76,6 +76,44 @@ now-detached payload):
     replacement string, only writes what the spec author already
     independently verified.
 
+Tier-scoped partial detach extension (2026-07-21, PENDING-ARMS L8 gate
+§3.4/§5.1b — e.g. 93114/93191/93193: records with ONE genuinely sound
+per_skala tier and ONE genuinely defective tier, where a full-array detach
+would destroy the sound tier's verified provenance):
+
+  - "action": "partial_detach" (OPTIONAL spec-entry key, mutually exclusive
+    with "metadata_only") — when present, REQUIRES a companion
+    "tier_selector" dict (see below). Only the per_skala row(s) matching the
+    selector are moved into the disputed key; every other row in the same
+    per_skala array is left in place, byte-identical.
+  - tier_selector: a dict of field -> expected-value constraints a per_skala
+    row must ALL satisfy to be selected for detach. `skala_usaha` is
+    compared as a SET (order-independent — the same logical tier can be
+    re-serialized with a different array order across lots/re-pulls); every
+    other key (typically `kategori_risiko`, optionally `jangka_waktu` or
+    another discriminator already present on the row) is compared by plain
+    equality. An array-INDEX selector was deliberately rejected: per_skala's
+    row order is not a guaranteed-stable contract across dataset
+    regenerations, so indexing could silently detach the wrong tier if the
+    source ever reorders rows — matching on content (kategori_risiko +
+    skala_usaha) is the robust choice.
+  - Idempotent + no-clobber, same discipline as the full detach: if NO row
+    in the record's current per_skala matches the selector, this is either
+    (a) already cured — a prior run already moved it and disputed_key is
+    present, so needs_detach is False and only other requested corrections
+    (if any) still apply — or (b) an unrecognised prior state (no
+    disputed_key either) — "ambiguous-skip", exactly like the full-detach
+    guard: never touched, no clobber.
+  - Appends to (never overwrites) an existing disputed_key value when one is
+    already present as a list — e.g. a second partial_detach on the same
+    record curing a second tier in a later lot. Raises CureError if the
+    existing disputed_key value isn't a list (an incompatible prior shape
+    this compiler does not know how to merge into safely).
+  - NOT YET SUPPORTED: a record carrying `per_skala_legacy` combined with
+    `action: partial_detach` raises CureError rather than guessing how the
+    two folding rules should interact — nothing in the current backlog needs
+    that combination.
+
 Usage:
   # dry run (default) — prints a per-code diff summary, writes nothing
   python scripts/kbli_filiera/cure_canonical_collisions.py
@@ -175,6 +213,7 @@ class CurePlan:
         needs_pp28_sources: bool = False,
         needs_zantaraopener: bool = False,
         metadata_only: bool = False,
+        partial_detach: bool = False,
     ) -> None:
         self.code = code
         self.status = status
@@ -189,6 +228,7 @@ class CurePlan:
         self.needs_pp28_sources = needs_pp28_sources
         self.needs_zantaraopener = needs_zantaraopener
         self.metadata_only = metadata_only
+        self.partial_detach = partial_detach
 
     def describe(self) -> str:
         note_preview = (self.data_note[:80] + "…") if len(self.data_note) > 80 else self.data_note
@@ -202,7 +242,12 @@ class CurePlan:
                 f"{self.disputed_key!r} key; could be a different prior cure"
             )
         actions: list[str] = []
-        if self.needs_detach:
+        if self.needs_detach and self.partial_detach:
+            actions.append(
+                f"per_skala {self.current_row_count} matched row(s) -> moved to "
+                f"{self.disputed_key} (sibling tier(s) left untouched)"
+            )
+        elif self.needs_detach:
             actions.append(
                 f"per_skala {self.current_row_count} row(s) -> 0 "
                 f"(fold per_skala_legacy: {self.folds_legacy}, disputed_key: {self.disputed_key})"
@@ -237,12 +282,76 @@ def _current_zantaraopener(record: dict[str, Any]) -> Any:
     return intel.get("zantaraOpener") if isinstance(intel, dict) else None
 
 
+def _tier_matches(row: Any, selector: dict[str, Any]) -> bool:
+    """True when every key in `selector` matches `row`'s corresponding field.
+
+    `skala_usaha` is compared as a SET (order-independent — the same
+    logical tier can be re-serialized with a different array order across
+    lots/PP28 re-pulls); every other key is compared by plain equality
+    (typically `kategori_risiko`, optionally another discriminator already
+    present on the row).
+    """
+    if not isinstance(row, dict):
+        return False
+    for key, wanted in selector.items():
+        if key == "skala_usaha":
+            actual = row.get("skala_usaha")
+            if not isinstance(actual, list) or set(actual) != set(wanted):
+                return False
+        elif row.get(key) != wanted:
+            return False
+    return True
+
+
+def _split_tiers(
+    current_per_skala: Any, tier_selector: dict[str, Any]
+) -> tuple[list[Any], list[Any]]:
+    """Split a per_skala list into (matching, remaining) per `tier_selector`.
+
+    Matching on content (never on array index — see the module docstring's
+    "Tier-scoped partial detach extension" for why index would be fragile).
+    """
+    matching: list[Any] = []
+    remaining: list[Any] = []
+    if not isinstance(current_per_skala, list):
+        return matching, remaining
+    for row in current_per_skala:
+        if _tier_matches(row, tier_selector):
+            matching.append(row)
+        else:
+            remaining.append(row)
+    return matching, remaining
+
+
 def plan_cure(record: dict[str, Any], entry: dict[str, Any], disputed_key: str) -> CurePlan:
     code = entry["code"]
-    metadata_only = entry.get("action") == "metadata_only"
+    action = entry.get("action")
+    metadata_only = action == "metadata_only"
+    partial_detach = action == "partial_detach"
     current_per_skala = record.get("per_skala")
 
-    if metadata_only:
+    matching_rows: list[Any] = []
+    if partial_detach:
+        if "per_skala_legacy" in record:
+            raise CureError(
+                f"{code}: action='partial_detach' combined with per_skala_legacy is not "
+                "supported by this compiler yet"
+            )
+        tier_selector = entry.get("tier_selector")
+        if not isinstance(tier_selector, dict) or not tier_selector:
+            raise CureError(
+                f"{code}: action='partial_detach' requires a non-empty 'tier_selector' dict"
+            )
+        matching_rows, _remaining = _split_tiers(current_per_skala, tier_selector)
+        has_disputed = disputed_key in record
+        # No row currently matches the selector: either already cured (a
+        # prior run already moved it, disputed_key present) or an
+        # unrecognised prior state (no disputed_key either) — same
+        # no-clobber discipline as the full-detach ambiguous-skip below.
+        if not matching_rows and not has_disputed:
+            return CurePlan(code, "ambiguous-skip", disputed_key=disputed_key)
+        needs_detach = bool(matching_rows)
+    elif metadata_only:
         # per_skala is COMPLETELY out of scope for a metadata_only entry —
         # never detached, never folded, never checked for the ambiguous prior
         # -state (that gate exists only to protect an about-to-detach write
@@ -289,12 +398,15 @@ def plan_cure(record: dict[str, Any], entry: dict[str, Any], disputed_key: str) 
     ):
         return CurePlan(code, "already-cured", disputed_key=disputed_key)
 
-    row_count = len(current_per_skala) if isinstance(current_per_skala, list) else 0
+    if partial_detach:
+        row_count = len(matching_rows)
+    else:
+        row_count = len(current_per_skala) if isinstance(current_per_skala, list) else 0
     return CurePlan(
         code,
         "apply",
         current_row_count=row_count,
-        folds_legacy="per_skala_legacy" in record,
+        folds_legacy=(not partial_detach) and "per_skala_legacy" in record,
         disputed_key=disputed_key,
         data_note=entry["data_note"],
         needs_detach=needs_detach,
@@ -304,21 +416,31 @@ def plan_cure(record: dict[str, Any], entry: dict[str, Any], disputed_key: str) 
         needs_pp28_sources=needs_pp28_sources,
         needs_zantaraopener=needs_zantaraopener,
         metadata_only=metadata_only,
+        partial_detach=partial_detach,
     )
 
 
 def apply_cure(record: dict[str, Any], entry: dict[str, Any], disputed_key: str) -> dict[str, Any]:
     """Return a NEW record dict with the cure applied. Four idempotent parts:
 
-    1. DETACH — only when per_skala is non-empty AND the entry is NOT
-       "action": "metadata_only": move the current per_skala (folding
-       per_skala_legacy if present) into the disputed key inserted immediately after
-       per_skala, and set per_skala -> []. If per_skala is ALREADY [], this is skipped
-       so a re-run never clobbers the previously-preserved disputed block with [].
-       A metadata_only entry skips this whole part unconditionally — per_skala
-       (and any disputed key) is copied through completely untouched, even when
-       currently non-empty (the standalone metadata-fix class: a HEALTHY
-       OSS-native per_skala that must never be detached).
+    1. DETACH — three mutually exclusive modes, driven by the spec entry's
+       "action" key:
+       - (default, no "action" key) FULL DETACH — only when per_skala is
+         non-empty: move the current per_skala (folding per_skala_legacy if
+         present) into the disputed key inserted immediately after
+         per_skala, and set per_skala -> []. If per_skala is ALREADY [],
+         this is skipped so a re-run never clobbers the previously-preserved
+         disputed block with [].
+       - "action": "metadata_only" — per_skala (and any disputed key) is
+         copied through completely untouched, even when currently
+         non-empty (the standalone metadata-fix class: a HEALTHY OSS-native
+         per_skala that must never be detached).
+       - "action": "partial_detach" — only the per_skala row(s) matching the
+         entry's "tier_selector" are moved into the disputed key (appended
+         if one already exists as a list); every other row stays in
+         per_skala, byte-identical. If NO row currently matches the
+         selector, per_skala/disputed_key are copied through untouched
+         (either already cured by a prior run, or nothing to do).
     2. WHATYOUNEED — when the spec supplies `whatYouNeed`, (re)write
        intel_2026.whatYouNeed to the honest-gap text (existing sub-key, order preserved).
     3. METADATA CORRECTION (Lot 2 extension + 2026-07-19 pp28_sources_correction +
@@ -329,15 +451,55 @@ def apply_cure(record: dict[str, Any], entry: dict[str, Any], disputed_key: str)
        get a metadata-only correction with no detach, or both together.
     4. _data_note is (re)set at the end (same string -> idempotent).
     """
-    metadata_only = entry.get("action") == "metadata_only"
+    action = entry.get("action")
+    metadata_only = action == "metadata_only"
+    partial_detach = action == "partial_detach"
     current_per_skala = record.get("per_skala")
 
-    if metadata_only or current_per_skala == []:
+    if partial_detach:
+        if "per_skala_legacy" in record:
+            raise CureError(
+                f"{entry['code']}: action='partial_detach' combined with per_skala_legacy "
+                "is not supported by this compiler yet"
+            )
+        tier_selector = entry.get("tier_selector")
+        if not isinstance(tier_selector, dict) or not tier_selector:
+            raise CureError(
+                f"{entry['code']}: action='partial_detach' requires a non-empty "
+                "'tier_selector' dict"
+            )
+        matching_rows, remaining_rows = _split_tiers(current_per_skala, tier_selector)
+        if not matching_rows:
+            # Nothing currently matches the selector: already moved by a
+            # prior run (or nothing to do) — copy through untouched, do not
+            # touch the disputed key at all (no-clobber).
+            new_record: dict[str, Any] = dict(record)
+        else:
+            existing_disputed = record.get(disputed_key)
+            if existing_disputed is None:
+                disputed_value: Any = matching_rows
+            elif isinstance(existing_disputed, list):
+                disputed_value = list(existing_disputed) + matching_rows
+            else:
+                raise CureError(
+                    f"{entry['code']}: existing {disputed_key!r} is not a list — cannot "
+                    "append a partial_detach tier to an incompatible disputed shape"
+                )
+            new_record = {}
+            for key, value in record.items():
+                if key == disputed_key:
+                    continue  # re-written (possibly appended-to) at the per_skala position below
+                if key == "per_skala":
+                    new_record["per_skala"] = copy.deepcopy(remaining_rows)
+                    new_record[disputed_key] = copy.deepcopy(disputed_value)
+                    continue
+                new_record[key] = value
+    elif metadata_only or current_per_skala == []:
         # metadata_only: per_skala is out of scope entirely, whatever its
         # current value — copy the record through as-is, touch only (2)-(4).
-        # Already-detached (non-metadata_only): preserve the existing
-        # disputed block, only touch (2)+(3)+(4).
-        new_record: dict[str, Any] = dict(record)
+        # Already-detached (non-metadata_only, non-partial_detach): preserve
+        # the existing disputed block, only touch (2)+(3)+(4).
+        new_record = dict(record)
     else:
         disputed_value: Any
         if "per_skala_legacy" in record:

--- a/scripts/kbli_filiera/tests/test_cure_canonical_collisions.py
+++ b/scripts/kbli_filiera/tests/test_cure_canonical_collisions.py
@@ -419,3 +419,199 @@ def test_non_metadata_only_entry_on_healthy_per_skala_still_detaches_as_before()
     out = cure.apply_cure(rec, entry, DISPUTED_KEY)
     assert out["per_skala"] == []
     assert out[DISPUTED_KEY] == [{"kategori_risiko": "Rendah"}]
+
+
+
+# ---------------------------------------------------------------------------
+# Tier-scoped partial detach extension (2026-07-21, PENDING-ARMS L8 gate
+# §3.4/§5.1b) — "action": "partial_detach" + "tier_selector". Unblocks curing
+# multi-tier records with one sound + one defective tier (93114/93191/93193)
+# without destroying verified provenance in the sound tier.
+# ---------------------------------------------------------------------------
+
+
+def _two_tier_rows():
+    """A synthetic two-tier per_skala shaped like a real multi-tier record
+    (e.g. 93114): one Menengah Rendah tier (the sound one) and one Tinggi
+    tier (the one flagged for detach). Fixture data only — not a real code."""
+    return [
+        {
+            "skala_usaha": ["Mikro", "Kecil", "Menengah"],
+            "kategori_risiko": "Menengah Rendah",
+            "perizinan": "NIB dan Sertifikat Standar",
+            "fiktif_positif": True,
+        },
+        {
+            "skala_usaha": ["Menengah", "Besar"],
+            "kategori_risiko": "Tinggi",
+            "perizinan": "NIB dan Izin",
+            "fiktif_positif": True,
+        },
+    ]
+
+
+TIER_SELECTOR_TINGGI = {"kategori_risiko": "Tinggi", "skala_usaha": ["Besar", "Menengah"]}
+
+
+def test_guilt_full_detach_on_multitier_record_still_detaches_fully() -> None:
+    """INNOCENCE control for the new action flag: an entry with NO 'action'
+    key (or action absent), on a MULTI-tier per_skala, must still detach the
+    WHOLE array exactly as before — the new partial_detach capability must
+    never leak into the default code path."""
+    rows = _two_tier_rows()
+    rec = _record(per_skala=rows)
+    entry = {"code": "51103", "data_note": "n", "whatYouNeed": "gap"}
+    plan = cure.plan_cure(rec, entry, DISPUTED_KEY)
+    assert plan.status == "apply"
+    assert plan.needs_detach is True
+    assert plan.partial_detach is False
+    out = cure.apply_cure(rec, entry, DISPUTED_KEY)
+    assert out["per_skala"] == [], "full detach empties per_skala entirely, both tiers included"
+    assert out[DISPUTED_KEY] == rows, "both tiers preserved verbatim in the disputed key"
+
+
+def test_plan_partial_detach_flags_only_matched_tier() -> None:
+    rows = _two_tier_rows()
+    rec = _record(per_skala=rows)
+    entry = {
+        "code": "93114",
+        "action": "partial_detach",
+        "tier_selector": TIER_SELECTOR_TINGGI,
+        "data_note": "Tinggi/golf tier has zero PP28 backing",
+    }
+    plan = cure.plan_cure(rec, entry, DISPUTED_KEY)
+    assert plan.status == "apply"
+    assert plan.needs_detach is True
+    assert plan.partial_detach is True
+    assert plan.current_row_count == 1, "only the ONE matched row, not both tiers"
+
+
+def test_apply_partial_detach_moves_only_flagged_tier_sound_tier_byte_identical() -> None:
+    """The core guilt+innocence guarantee for this primitive: the flagged
+    (Tinggi) tier moves to the disputed key; the sound (Menengah Rendah) tier
+    survives in per_skala BYTE-IDENTICAL (same dict content, untouched)."""
+    rows = _two_tier_rows()
+    sound_tier = copy.deepcopy(rows[0])
+    defective_tier = copy.deepcopy(rows[1])
+    rec = _record(per_skala=rows)
+    entry = {
+        "code": "93114",
+        "action": "partial_detach",
+        "tier_selector": TIER_SELECTOR_TINGGI,
+        "data_note": "Tinggi/golf tier has zero PP28 backing",
+    }
+    out = cure.apply_cure(rec, entry, DISPUTED_KEY)
+
+    assert out["per_skala"] == [sound_tier], "sound tier survives alone in per_skala, byte-identical"
+    assert out[DISPUTED_KEY] == [defective_tier], "only the flagged tier moved to the disputed key"
+    assert out["_data_note"] == "Tinggi/golf tier has zero PP28 backing"
+    # the input record itself must never be mutated (defensive-copy discipline)
+    assert rec["per_skala"] == rows, "apply_cure must not mutate its input record in place"
+
+
+def test_partial_detach_is_idempotent_second_run_is_a_noop() -> None:
+    rows = _two_tier_rows()
+    sound_tier = copy.deepcopy(rows[0])
+    defective_tier = copy.deepcopy(rows[1])
+    rec = _record(per_skala=rows)
+    entry = {
+        "code": "93114",
+        "action": "partial_detach",
+        "tier_selector": TIER_SELECTOR_TINGGI,
+        "data_note": "n",
+    }
+    once = cure.apply_cure(rec, entry, DISPUTED_KEY)
+    plan_again = cure.plan_cure(once, entry, DISPUTED_KEY)
+    assert plan_again.status == "already-cured", "re-run must recognise the prior partial detach"
+    twice = cure.apply_cure(once, entry, DISPUTED_KEY)
+    assert twice["per_skala"] == [sound_tier]
+    assert twice[DISPUTED_KEY] == [defective_tier], "second run must not duplicate the moved tier"
+
+
+def test_plan_partial_detach_ambiguous_skip_when_selector_matches_nothing() -> None:
+    """Same no-clobber discipline as the full-detach guard: if the selector
+    matches no row AND there is no pre-existing disputed key, refuse to
+    touch the record (a spec/selector bug must not silently no-op)."""
+    rec = _record(per_skala=[_two_tier_rows()[0]])  # only the sound tier present
+    entry = {
+        "code": "93114",
+        "action": "partial_detach",
+        "tier_selector": TIER_SELECTOR_TINGGI,
+        "data_note": "n",
+    }
+    plan = cure.plan_cure(rec, entry, DISPUTED_KEY)
+    assert plan.status == "ambiguous-skip"
+
+
+def test_partial_detach_requires_tier_selector() -> None:
+    rec = _record(per_skala=_two_tier_rows())
+    entry = {"code": "93114", "action": "partial_detach", "data_note": "n"}
+    with pytest.raises(cure.CureError):
+        cure.plan_cure(rec, entry, DISPUTED_KEY)
+    with pytest.raises(cure.CureError):
+        cure.apply_cure(rec, entry, DISPUTED_KEY)
+
+
+def test_partial_detach_rejects_per_skala_legacy_combination() -> None:
+    rec = _record(per_skala=_two_tier_rows())
+    rec["per_skala_legacy"] = [{"kategori_risiko": "old"}]
+    entry = {
+        "code": "93114",
+        "action": "partial_detach",
+        "tier_selector": TIER_SELECTOR_TINGGI,
+        "data_note": "n",
+    }
+    with pytest.raises(cure.CureError):
+        cure.plan_cure(rec, entry, DISPUTED_KEY)
+    with pytest.raises(cure.CureError):
+        cure.apply_cure(rec, entry, DISPUTED_KEY)
+
+
+def test_apply_partial_detach_appends_to_existing_disputed_list() -> None:
+    """A second partial_detach on the same record (a later lot curing a
+    second tier) must APPEND to the existing disputed list, never overwrite
+    it — the first tier's preserved provenance must survive."""
+    rows = _two_tier_rows()
+    prior_disputed_tier = {"kategori_risiko": "Rendah", "skala_usaha": ["Mikro"], "src": "prior lot"}
+    rec = _record(per_skala=rows)
+    rec[DISPUTED_KEY] = [prior_disputed_tier]
+    entry = {
+        "code": "93114",
+        "action": "partial_detach",
+        "tier_selector": TIER_SELECTOR_TINGGI,
+        "data_note": "n",
+    }
+    out = cure.apply_cure(rec, entry, DISPUTED_KEY)
+    assert out[DISPUTED_KEY] == [prior_disputed_tier, rows[1]], "appended, prior entry preserved"
+    assert out["per_skala"] == [rows[0]]
+
+
+def test_apply_partial_detach_raises_on_incompatible_existing_disputed_shape() -> None:
+    rows = _two_tier_rows()
+    rec = _record(per_skala=rows)
+    rec[DISPUTED_KEY] = {"per_skala": rows, "per_skala_legacy": []}  # legacy-fold shape, not a list
+    entry = {
+        "code": "93114",
+        "action": "partial_detach",
+        "tier_selector": TIER_SELECTOR_TINGGI,
+        "data_note": "n",
+    }
+    with pytest.raises(cure.CureError):
+        cure.apply_cure(rec, entry, DISPUTED_KEY)
+
+
+def test_tier_selector_skala_usaha_matches_regardless_of_order() -> None:
+    """skala_usaha is compared as a SET — a reordered array (e.g. a re-pull
+    that changed serialization order) must still match the same tier."""
+    rows = _two_tier_rows()
+    rows[1]["skala_usaha"] = list(reversed(rows[1]["skala_usaha"]))  # ["Besar", "Menengah"]
+    rec = _record(per_skala=rows)
+    entry = {
+        "code": "93114",
+        "action": "partial_detach",
+        "tier_selector": {"kategori_risiko": "Tinggi", "skala_usaha": ["Menengah", "Besar"]},
+        "data_note": "n",
+    }
+    plan = cure.plan_cure(rec, entry, DISPUTED_KEY)
+    assert plan.status == "apply"
+    assert plan.current_row_count == 1


### PR DESCRIPTION
## Summary
- Adds a new spec-entry `"action": "partial_detach"` + companion `"tier_selector"` to `scripts/kbli_filiera/cure_canonical_collisions.py`'s cure-spec schema, mutually exclusive with the existing `"metadata_only"` action.
- `tier_selector` matches a per_skala row by content (`kategori_risiko` plain equality + `skala_usaha` set-equality, order-independent) — array-INDEX matching was deliberately rejected since row order isn't a guaranteed-stable contract across dataset regenerations.
- Only the matched tier(s) move into the existing `per_skala_disputed_<key>` preservation array (appended if one already exists as a list); every sibling tier stays in `per_skala`, byte-identical.
- Idempotent + no-clobber, same discipline as the existing full detach: re-running when nothing currently matches the selector is recognized as already-cured (or `ambiguous-skip` if no disputed key exists either — never silently no-ops on a possible spec bug).
- `per_skala_legacy` + `partial_detach` combination explicitly raises `CureError` (not yet supported, nothing in the current backlog needs it).
- Unblocks curing KBLI codes 93114/93191/93193 (PENDING-ARMS, opened Lot 8, `.claude/skills/modus/PENDING-ARMS.md` §L8 gate 3.4/5.1b) — those records have one genuinely sound tier and one genuinely defective tier, and a full-array detach would have destroyed the sound tier's verified provenance.
- **This PR is pure compiler/tooling work** — no real KBLI code's data is touched; all tests use synthetic fixture data modeled on the real 93114 shape (verified by direct read-only inspection of the canonical dataset, not transcribed into the diff). Curing 93114/93191/93193 themselves is an explicit follow-up once the conductor adjudicates the actual cure spec.

## Test plan
- [x] Guilt+innocence pair as specified in PENDING-ARMS: `test_guilt_full_detach_on_multitier_record_still_detaches_fully` (full detach on a multi-tier record still detaches the WHOLE array) + `test_apply_partial_detach_moves_only_flagged_tier_sound_tier_byte_identical` (partial detach moves only the flagged tier, sound tier survives byte-identical)
- [x] 9 additional tests: plan-flags-only-matched-tier, idempotent re-run, ambiguous-skip on non-matching selector, missing-tier_selector raises, per_skala_legacy combo raises, append-to-existing-disputed-list, incompatible-disputed-shape raises, skala_usaha set-order-independence
- [x] `scripts/kbli_filiera/tests/test_cure_canonical_collisions.py` — 32/32 passed
- [x] Full dependent-test sweep (`test_cure_metadata_pp28_sources.py`, `test_cure_restore_per_ancestor.py`, `test_emit_batch_membership.py`, all 9 `test_kbli_batch_a_lotN_registry.py`, `test_kbli_false_friend_registry.py`, `test_kbli_metadata_fixes_registry.py`, `test_kbli_metadata_residuals_52101_10433.py`) — 1100 passed, 1 skipped, 0 failed (315s, real subprocess invocations against the actual canonical dataset)
- [x] `python3 -m py_compile` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)