### PR TITLE
docs(wr2): editorial-intelligence design spec + real-code evidence (2-grader red-teamed)

### DIFF
--- a/.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md
+++ b/.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md
@@ -1,0 +1,348 @@
+---
+title: WR2 Editorial Intelligence — design accurato (dal disco-rotto al planner editoriale)
+date: 2026-07-21
+status: SPEC v1 — RED-TEAMED (2 grader indipendenti, §7). Attende ratifica Zero (Legge 5 su brand/costituzione) + i 3 pre-build gate come condizione di BUILD.
+mandate: Zero — "come diamo alla WR2 una intelligenza editoriale tale, e non un disco rotto che ripete schemi fissi" + "disegnamolo con accuratezza e vediamo se altri sistemi nel mondo possiamo vedere il loro codice"
+method: session architect (Fable) + 3 seat che hanno LETTO IL CODICE REALE (repo clonati, commit SHA, file:line) + 2 red-team indipendenti (Sonnet con accesso-repo & DB-live; Kimi K3 cross-family)
+grounded_by: WR2 file:line VERIFICATI su disco 2026-07-21 (ri-letti da un secondo grader + query sul DB live); STORM/gpt-researcher/gpt-newspaper/instructor/outlines/pydantic codice reale letto
+---
+
+## 0. La diagnosi accurata (VERIFICATA su disco + DB live, da due letture indipendenti)
+
+Il "disco rotto" non è un difetto di scrittura del modello. È che **una sola chiamata** decide
+tutto insieme — register, arco, spina, copy di ogni slide, prompt immagini — e a valle il contratto
+dati è **una sola forma piatta**. Sotto quella pressione un modello collassa sul pattern più vicino.
+Quattro fatti dal codice WR2, ognuno ri-verificato da un secondo grader questo turno (§7):
+
+1. **Il contratto slide è UNA forma piatta.** `_normalise_slides` (`wr2_draft_generator.py:1417`,
+   dict costruito a `:1441-1453`) appiattisce OGNI slide in `{slide_number, slide_type(str libera,
+default "body" a `:1443`), is_cover, is_hero_image, headline[:80], subhead, body[:500],
+image_prompt, tonal_palette, image_mode, image_url}`. Grep dell'intero file per
+   `list_items`/`qa_pairs`/`timeline_events`/`stat_value` = **zero hit**: nessuna struttura tipizzata
+   per-forma. Timeline, dialogo, fact-stack, stat-card possono solo diventare `body` in prosa.
+
+2. **Il renderer ha 15 layout, il produttore AUTONOMO ne raggiunge 4.** `RENDERABLE_FAMILIES`
+   (`composer.py:51-67`) = **15 famiglie** reali e skeletonate (incl. qa-dialogue, timeline-pinboard,
+   dark-status-list, evidence-carved, source-citation, stat-card-hero, numbered-forces-list,
+   elegant-close). Ma `map_slide_to_family` (`composer.py:112-172`) senza pin esplicito ha solo 4
+   `return` raggiungibili: `cover-photo` (`:147`), `editorial-text` (`:163`,`:172`), `statement-bomb`
+   (`:164`), `photo-headline-yellow-sub` (`:166`). Le altre 11 solo via pin `layout_family` esplicito
+   (`:143-145`), e grep di `wr2_draft_generator.py` per `layout_family` = **zero hit**. **Prova sul DB
+   live**: `topic_type_log` ultimi 60gg → `{null: 46, "cover-photo": 1}` — 46/47 righe (97.9%) senza
+   alcun segnale layout: il branch-pin è codice morto nel produttore autonomo.
+   → **NUANCE (dal 2° grader, RAFFORZA il claim):** le 11 famiglie NON sono morte system-wide. Il path
+   **manuale/interattivo** (`wr2-storyboarder`, `composer.py:996-1060`) emette GIÀ `list_items`/`events`/
+   `qa_pairs` + pin `layout_family` e pilota tutte e 15. Quindi il buco è **specifico del produttore
+   autonomo** (quello che fa il volume quotidiano ~1/giorno), e **la forma tipizzata che serve a Move A
+   ESISTE GIÀ internamente** — Move A PORTA una forma provata sul path manuale, non ne inventa una nuova.
+
+3. **Una sola chiamata monolitica.** `claude_compose_slides` (`:1071-1097`, singolo `complete_async`,
+   `model="claude-opus-4-7"`) è chiamata una volta per tentativo dentro il loop di `_process_one`
+   (`:1835-1852`). Il commento del codice stesso (`:1838-1841`) lo dichiara: _"composes brief+storyboard
+   in one shot, not two"_. Register + tutti i copy delle slide escono da QUELLA chiamata.
+
+4. **L'unico asse con stato è l'unico che varia** (register/image-mode via `topic_type_log`).
+
+**Il framing accurato**: l'intelligenza non manca al renderer (15 layout, il produttore autonomo ne
+usa 4). Manca al **contratto di generazione autonomo**, che sa dire una sola frase piatta. Il redesign
+APOA che colpisce Zero usa timeline, triad, label:value, statement, cover, photo-panel, CTA — **tutte
+famiglie che il nostro renderer già possiede e che il path manuale già pilota**. Quel livello è
+raggiungibile col renderer di oggi, SE il produttore autonomo sapesse produrre contenuto strutturato
+e decidere la struttura a monte.
+
+---
+
+## 1. Che i migliori del mondo fanno ESATTAMENTE questo — provato leggendo il loro codice
+
+Tre seat hanno clonato e letto il sorgente reale (non nominato — letto). L'accordo è cross-family
+(W100: l'accordo mente quando è same-family; questo è l'opposto).
+
+**Stanford STORM** (`stanford-oval/storm`, MIT, commit `fb951af7`) — il planner→writer di
+riferimento in produzione:
+
+- L'outline è generato SENZA prosa e parsato in un albero di `ArticleSectionNode`
+  (`interface.py:136-159`); **`content=None` è lo stato esplicito "non ancora scritto"**
+  (`storm_dataclass.py::from_outline_str:437-474`).
+- Il writer (`article_generation.py::generate_article:53-133`) per ogni sezione affetta l'outline
+  al SOLO sottoalbero di quella sezione — **non vede mai le sorelle** (né outline né prosa).
+- Scrittura in **parallelo reale** (`ThreadPoolExecutor(max_workers=10)`), merge finale a **zero LLM**.
+- Decoupling così forte da **sopravvivere al confine di processo**: l'outline è persistito su
+  `storm_gen_outline.txt` e ricaricabile in un'invocazione CLI separata (`engine.py:341-441`).
+
+**gpt-researcher** (`assafelovic/gpt-researcher`, Apache-2.0, `5d84d2f5`):
+`EditorAgent.plan_research` (`editor.py:22-50`) emette un outline JSON piatto `{title, sections}`
+senza prosa; `WriterAgent.write_sections` (`writer.py:32-71`) ha il **divieto esplicito di
+riscrivere i corpi** — scrive solo titolo/TOC/intro/conclusione attorno alle sezioni già finite.
+
+> **Contratto minimo, ridotto all'essenza (STORM+gpt-researcher):**
+> `plan(context) → lista_ordinata[slot]` (nessuna prosa) → per ogni slot IN PARALLELO
+> `write(slot, contesto_ristretto_allo_slot, frame_condiviso) → content` → `merge` stupido.
+
+**gpt-newspaper** (`assafelovic/gpt-newspaper`, `b86aff2d`) — letto come **monito**: il suo
+critic-loop è un `if response == 'None'` (string-equality sull'output grezzo, `critique.py:28`),
+**senza cap sul numero di giri** — un critico confuso cicla all'infinito. La nostra loop DEVE avere
+il cap (già lo abbiamo nel kicker-guard) e check su CONTENUTO/entità, non su string-match.
+
+**Verdetto framework (provato dal codice, non opinione):** LangGraph/CrewAI sono cablaggio-archi
+sottile — in gpt-newspaper il 100% della logica vive in classi plain-Python `run()`, il grafo è 4
+`add_edge`. Adottare un framework **RE-CENTRALIZZEREBBE lo stato in-process**, regredendo la
+durabilità launchd+Postgres che WR2 già ha → esattamente la famiglia-scar #2 "esiste≠armato". **Si
+adotta la FORMA (planner/writer, critic-gated loop, check-deterministico-prima-del-giudizio-LLM),
+si rifiuta il framework.**
+
+---
+
+## 2. Il design — 5 mosse + un critico sdoppiato (ognuna shippabile, l'ordine de-rischia)
+
+### Mossa A — Carousel IR: la grammatica tipizzata delle slide ★ fondamento, sblocca le 11 famiglie nel produttore autonomo
+
+Unione discriminata di ~8 forme-slide, ognuna mappata a famiglie che GIÀ abbiamo — **e la forma
+strutturata esiste già sul path manuale** (`composer.py:996-1060`: `list_items`/`events`/`qa_pairs`),
+quindi è un PORT, non un'invenzione. Enforcement = **validate + retry sul JSON grezzo del CLI**
+(pattern instructor, SENZA SDK Anthropic — provato eseguendo la forma WR2 a 7 slide contro pydantic
+2.13.4). Ricetta reale, portata verbatim da `instructor/v2/core/json.py` (MIT) + `pydantic
+Field(discriminator=...)`:
+
+```python
+# forme (estratto — 8 kind totali)
+class FactStackSlide(BaseModel):
+    kind: Literal["fact_stack"]; heading: str; facts: List[str]
+class TimelineSlide(BaseModel):
+    kind: Literal["timeline"]; heading: str; steps: List[str]
+Slide = Annotated[Union[ProseSlide, StatementSlide, FactStackSlide, QaDialogueSlide,
+    StatusListSlide, TimelineSlide, StatCardSlide, CtaSlide], Field(discriminator="kind")]
+SlideList = TypeAdapter(List[Slide])
+
+def generate_slides(prompt, max_retries=3) -> List[Slide]:
+    ctx = prompt
+    for attempt in range(1, max_retries+1):
+        raw = call_claude_cli(ctx)                       # nostro path OAuth, mai SDK
+        json_str = extract_json_from_codeblock(raw)      # port MIT da instructor
+        try:
+            return SlideList.validate_json(json_str)     # SUCCESS
+        except (ValidationError, json.JSONDecodeError) as e:
+            if attempt == max_retries: raise             # → fallback tipizzato, NON coerce-a-prosa
+            ctx = f"{prompt}\n\nValidation errors:\n{e}\nFix them; previous attempt:\n{raw}"
+```
+
+| kind                      | campi               | famiglia renderer già esistente               |
+| ------------------------- | ------------------- | --------------------------------------------- |
+| cover / prose / statement | (come oggi)         | cover-photo / editorial-text / statement-bomb |
+| fact_stack `rows[]`       | label,value         | **evidence-carved**                           |
+| status_list `items[]`     | heading,items,hot[] | **dark-status-list**                          |
+| timeline `steps[]`        | date,event,current  | **timeline-pinboard**                         |
+| triad `items[3]`          | title,desc          | **numbered-forces-list**                      |
+| qa `pairs[]`              | q,a                 | **qa-dialogue**                               |
+| stat                      | value,unit,context  | **stat-card-hero**                            |
+| citation                  | claim,sources[]     | **source-citation**                           |
+
+**VALIDAZIONE LENIENT-FIRST (correzione red-team BLOCKER-1, §7).** Il normalizzatore di oggi è
+_coercitivo_ (tronca `[:80]`/`[:500]`, defaulta, non alza MAI su un campo storto) — ed è quello che
+tiene il fail-rate basso (**2 parse_error / 125 draft storici = 1.6%**, e oggi sono hard-fail a zero
+retry). Una discriminated-union _stretta_ alza `ValidationError` su un solo enum sbagliato → rischio
+concreto di spike di regen che brucia quota MAX allo shakeout. Quindi la validazione è a due livelli:
+**stretta SOLO sul discriminatore `kind` + i campi obbligatori-per-kind**; **lenient (coerce/tronca/
+default, come oggi) su tutto il resto scalare**. E l'end-state a retry esausto è **esplicito**: NON
+"coerce a un kind semplice" (obiezione Kimi #3: i kind-fallback sono sempre i semplici → ri-collasso
+sui 4 layout dalla porta di servizio), ma **park del deck** (facts-first park backstop già esistente)
+oppure fill minimale che **PRESERVA il `kind` pianificato**. Budget CLI **per-deck bounded** (guardia
+finestra-cron: planner + N-writer × retry può esplodere — vedi §5). **Caveat onesto**: la costrizione
+grammar-level FSM (outlines) è impossibile col CLI (serve accesso ai logit token-per-token) — noi
+possiamo solo validate+retry sul testo finito. È sufficiente. Questa mossa cura anche i finding Codex
+C/D (fact-extractor su dialetto sbagliato; language-gate cieca ai campi ricchi) via projection
+condivise `reader_texts()`/`claim_bearing_segments()`.
+
+### Mossa B — Planner → Writer: separare DECIDERE da SCRIVERE ★ il cuore anti-disco-rotto
+
+Il monolite diventa DUE stadi, esattamente la forma STORM/gpt-researcher:
+
+- **Planner ("l'editor")** — input: brief + liveness-tier + tema + Creative Ledger. Output: un PIANO
+  piccolo, JSON, ZERO prosa, modellato sull'outline-object provato (STORM `content=None` +
+  gpt-researcher flat list):
+  ```json
+  {
+    "spine": "...",
+    "arc": "news_alert",
+    "slides": [
+      {
+        "slot_id": 1,
+        "role": "hook",
+        "kind": "cover",
+        "heading_intent": "...",
+        "bullet_promise_n": null,
+        "body": null,
+        "hero": true
+      },
+      {
+        "slot_id": 3,
+        "role": "discovery",
+        "kind": "triad",
+        "heading_intent": "3 conditions",
+        "bullet_promise_n": 3,
+        "body": null,
+        "hero": false
+      }
+    ]
+  }
+  ```
+  **CHI PROPONE ≠ CHI DISPONE (correzione red-team cross-family Kimi, obiezione #1 — §7).** L'arco è
+  la decisione PIÙ content-dipendente del deck: metterla in codice cieco al contenuto è l'errore. Quindi:
+  il **CODICE PROPONE** priori — pesi + **penalità di cooldown SOFT** dal Ledger — e il **planner-LLM
+  DISPONE**, sceglie l'arco DAL CONTENUTO dentro quei vincoli. Un content-override esplicito è lecito:
+  una settimana genuinamente breaking (cascata PMK/Omnibus) può ri-scegliere `news_alert` due giorni di
+  fila — è un **repeat GIUSTIFICATO**, loggato come tale, non una violazione. **Maschere HARD solo sugli
+  assi di SUPERFICIE** dove il contenuto è indifferente (palette, kicker, subhead-pattern, register).
+  Mai una maschera hard che forzi un arco sbagliato su una storia che ne chiede un altro.
+- **Writer ("il redattore")** — riceve brief + piano bloccato + il proprio slot, **PIÙ gli
+  `heading_intent` delle slide sorelle** (non il loro copy — abbastanza per ritmo, callback,
+  escalation; non abbastanza per riscriverle). Correzione red-team obiezione Kimi #2: col writer
+  slot-cieco puro (STORM stretto) **nessuno possiede la continuità di voce** e il deck resta monotono
+  all'orecchio anche con layout vari. Le teste-vicine danno un proprietario alla voce cross-slide.
+  Riempie il copy tipizzato; `body=null → content`. Parallelizzabile per-slot.
+
+Beneficio provato da STORM: il critico può **rigenerare la singola slide** invece dell'intero
+carosello (cura diretta degli scar bullet-promise/closer di WR2). Il "take = Our read" muore: l'angolo
+è dimensione di prima classe che ruota.
+
+### Mossa C — La Spina come campo di prima classe ★ l'insight APOA
+
+`spine` = idea-guida scelta UNA VOLTA dal planner, con **check falsificabile**: il closer echeggia la
+spina del cover? Un disco rotto non passa — non HA una spina. **Il check è ENTITÀ/INTENTO, mai
+bare-substring** (scar #3, sotto): l'"echo" si misura su chiave-fatto/entità condivisa, non su
+sotto-stringa letterale.
+
+### Mossa D — Creative Ledger: memoria editoriale come stato interrogabile — E CHIUSO SUL RISULTATO
+
+Generalizzare il lookback register a TUTTI gli assi. Una riga/draft: `(spine_gist, arc_id, hook_type,
+kicker, subhead_pattern, layout_families[], register, palette, hero_concept_class)`. Il planner deriva
+cooldown per-asse (soft su arco, hard sugli assi di superficie). "Non ripetere" diventa una query. La
+cura kicker (#2873) è il PRIMO asse; il ledger la generalizza.
+
+- **CHIUSO SUL RISULTATO (correzione Kimi #1 — open-loop):** il ledger registra anche l'ESITO —
+  pubblicato (atto Legge-5 dell'umano) / parked / metriche IG — non solo "draftato". Senza segnale di
+  reward è un indice-dedup, non memoria: non imparerebbe mai che i deck `deadline` sono quelli che Zero
+  pubblica. Il reward si aggancia al loop metriche IG già esistente (§WR2 corner).
+- **BACKFILL degli assi nuovi (correzione Sonnet BLOCKER-2):** `spine_gist`/`arc_id`/`hook_type` NON
+  esistevano quando i 34 deck furono fatti. Il backfill è un **pass di labeling LLM** che
+  reverse-engineerizza arco/spina dal copy finito, **con QA a campione umano** (è un task fuzzy, ha il
+  suo error-rate) — budgettato dentro lo step-4, NON dato per scontato. **Cold-start esplicito:** finché
+  il ledger è rado (primi ~20 deck) i cooldown sono soft/quasi-uniformi; è accettabile (uniforme È vario)
+  ma va detto, non nascosto.
+
+### Mossa E — Arc Grammar: archi come libreria combinatoria scelta per tema+liveness
+
+`news_alert`, `myth_buster`, `deadline`, `worked_example`… ogni arco = sequenza di ruoli; ogni ruolo
+→ famiglie con alternate. Breaking → arco stretto 5-6; evergreen → arco ricco 9. È QUESTO che fa
+"adattare al momento e al tema". L'arco 33/33 identico muore. **Nota (Sonnet MAJOR-4):** 4 archi sono
+POCHI per un cooldown domain-partizionato (`fetch_recent_same_domain` è domain-scoped) — la libreria va
+ampliata a ~6-8 archi prima che il cooldown sull'asse-arco abbia margine, altrimenti l'escape "proceed
+anyway (WARN)" scatta spesso proprio sull'arco.
+
+### Il Critico — SDOPPIATO (correzione dal codice reale) + DISCIPLINA GUARD-CONFORMANCE
+
+Dal `run_overseer_checks.js` di `Maazsiddiqui01/linkedin-carousel-generator` (MIT, `f5963e99`):
+un critico editoriale COMPLETO costruibile a **zero LLM** quando i difetti sono strutturalmente
+verificabili. Due strati, il primo gratis:
+
+1. **Pre-gate deterministico ($0, 0ms, PRIMA del critico costoso)** — pattern reali: Jaccard
+   anti-duplicati (`:41-52`), bullet-count/ceiling (`:118-132`), CTA-presence, coverage ratio
+   (`:221-237`), sequenza-chip (`:265-286`). Da noi: closer-echeggia-spina, bullet-promise
+   (heading "TRE"→3 bullet), nessun body caps-wall, ogni slide ha un `kind`, kicker-unico (già
+   half-fatto, `_kicker_collision:668`).
+   **⚠️ SCAR #3 — ogni guardia deterministica È una nuova istanza della famiglia più recidiva
+   dell'organismo (guard over/under-match: W68/W72/W73/W82/W83/W84/W85/W91/W92/W94/W95/W99, 8+ volte).
+   REQUISITO HARD (Sonnet MAJOR-3, non negoziabile): NESSUN gate ship senza corpus guilt+innocence
+   registrato in `infra/guard-conformance/registry.json` + CI `guard-conformance.yml`.** Il Jaccard
+   normalizza VIA il boilerplate legale indonesiano (strip token `Pasal/ayat/berdasarkan…`) PRIMA della
+   similarità, o falsa-positiva su ogni contenuto regolatorio (obiezione Kimi #3). "closer echeggia
+   spina" = match su entità/chiave-fatto, MAI sotto-stringa.
+2. **Giudizio LLM (wr2-critic) solo sul soggettivo** — tono, forza narrativa, brand-voice — dopo che
+   il pre-gate ha già bocciato il verificabile a costo zero. E con **cap sui giri** (monito
+   gpt-newspaper: il loro non ce l'ha e può ciclare all'infinito). **Limite dichiarato (Kimi #2 +
+   Sonnet MINOR-8):** il critico LLM è same-family del generatore → indipendenza di CONTESTO, non di
+   GIUDIZIO. Il vero sensore di taste resta l'umano a `drafted` + le metriche IG; il critico LLM non
+   "chiude" da solo l'asse-gusto.
+
+---
+
+## 3. Sequenza di rollout (ognuna vale da sola; l'ordine de-rischia)
+
+1. **IR tipizzata + projection condivise** (A) — sblocca 11 layout nel produttore autonomo, è il
+   contratto che regge tutto. Shadow-mode + replay dei 34 deck storici, con un **GATE ESPLICITO:
+   misurare il fail-rate della validazione stretta sul replay PRIMA del cutover** (Sonnet BLOCKER-1);
+   se lo spike è reale si tara la lenient-first / il fallback prima di andare live.
+2. **Pre-gate deterministico** (Critico strato-1) — cheap, indipendente, valore immediato; ogni gate
+   con corpus guilt+innocence (guard-conformance) fin dal primo.
+3. **Planner/Writer dual-run** (B) — shadow accanto al monolite, poi cutover. **Il planner porta i
+   campi `spine`/`arc` GIÀ da qui (shape inerte)** così lo step-4 li ATTIVA senza ri-tagliare il
+   planner (Sonnet MAJOR-5: risolve la dipendenza step3↔step4).
+4. **Spine + Ledger + Arc** (C/D/E) sopra il planner — attiva enforcement spina + selezione
+   arco-da-contenuto + backfill LLM con QA.
+5. **Critico narrativo LLM** (strato-2) con cap.
+   Metrics-gated: il bandit sui pesi del planner è un lever a **~6+ mesi** (n≥200 a ~1/giorno — misurato:
+   `topic_type_log` 47 righe / 45gg ≈ 1.04/giorno), NON near-term. Non è il motore della varietà iniziale.
+
+## 4. Cosa NON toccare (load-bearing, verificato)
+
+- Il renderer + i 15 layout: NON è la malattia, è la cura già costruita. Adattare il contratto, non
+  il CSS. — Facts-first + park (scar fondante; è ANCHE l'end-state del retry esausto). — Generator≠grader
+  (planner/writer/critico seat separati). — Legge 5 (stop a `drafted`). — Ban SDK Anthropic (l'IR valida
+  sulla stringa CLI). — **Niente framework** (LangGraph/CrewAI regredirebbero la durabilità
+  launchd+Postgres; provato dal codice di gpt-newspaper). — **INVARIANTE PERSISTENZA (Sonnet MINOR-7,
+  requisito hard):** piano-planner + Creative Ledger vivono in **Postgres**, mai stato in-process
+  mid-request; nessuna "cache di efficienza" in-memory che un futuro ingegnere sarebbe tentato di
+  aggiungere — sarebbe la scar #2 di ritorno.
+
+## 5. Tradeoff onesto (con i numeri, non a mano)
+
+Più stadi = più chiamate/latenza. **Sizing (Sonnet MAJOR-6):** oggi worst-case
+`MAX_DRAFTS_PER_RUN=2` × 3 tentativi × 1 call = **6 call OAuth/run**. Domani planner + 8 writer × 3
+tentativi × 2 draft = fino a **~54 call/run (~9×)**, ognuna col timeout 300s (`:1092`) → rischio
+finestra-rolling-5h del MAX plan. NON fatale a 1/giorno, ma **va bounded**: cap retry per-slot (≤2),
+cap budget-call per-deck, writer paralleli ma contati contro quota. È l'UNICO modo per cui la varietà
+smette di essere una richiesta nel prompt e diventa proprietà strutturale verificabile PRIMA del render.
+
+**Rischio-madre onesto (Goodhart — Kimi #2):** l'entropia-layout è un PROXY. Il bersaglio vero è la
+varietà _percepita dal lettore_, che vive nell'angolo/voce, non solo nei layout. Le mosse strutturali
+sono **necessarie-non-sufficienti**: l'asse-gusto è posseduto da (a) arco scelto-dal-contenuto, (b)
+continuità-di-voce via heading-sorelle, (c) il loop umano-pubblica + metriche-IG come reward. Se
+misuriamo solo "12/15 layout usati" e l'engagement resta piatto, abbiamo Goodhartato il proxy. Il
+successo si dichiara sull'esito IG + sul tasso-di-riscrittura-umana a `drafted`, non sull'entropia.
+
+## 6. Provenienza codice reale (3 seat, tutto clonato + letto — report grezzi archiviati come sibling)
+
+- STORM `fb951af7` + gpt-researcher `5d84d2f5` → `2026-07-21-oss-code-reading-storm-gptresearcher.md` (766 righe)
+- gpt-newspaper `b86aff2d` + crewAI-examples `da94a91e` + linkedin-carousel-gen `f5963e99` →
+  `2026-07-21-oss-code-reading-statemachine-gptnewspaper.md` (240 righe)
+- instructor `47fdb2c` + outlines `cb095ba` + pydantic 2.13.4 (eseguito) + BAML `be5e7cd` →
+  `2026-07-21-oss-code-reading-typed-pydantic-instructor.md` (673 righe)
+
+## 7. Red-team — 2 grader INDIPENDENTI (generator≠grader; io ho scritto, loro hanno gradato)
+
+- **Grader 1 — Sonnet 5, accesso-repo + DB live.** Verdetto **SHIP-WITH-FIXES**. Ha ri-letto e
+  CONFERMATO tutti e 4 i claim file:line (con query Postgres: 46/47 righe recenti senza segnale layout)
+  e aggiunto la nuance §0.2 (path manuale già tipizzato). Fix pretesi e INTEGRATI: BLOCKER-1
+  (lenient-first + gate fail-rate su replay + fallback kind-preserving, §Mossa-A/§3.1), BLOCKER-2
+  (backfill LLM+QA + cold-start, §Mossa-D), MAJOR-3 (guard-conformance corpus, §Critico), MAJOR-4 (arco
+  library ~6-8, §Mossa-E), MAJOR-5 (spine-shape dallo step-3, §3.3), MAJOR-6 (sizing 9×, §5), MINOR-7
+  (invariante Postgres, §4), MINOR-8 (limite taste, §Critico/§5).
+- **Grader 2 — Kimi K3, cross-family, design-only.** Verdetto **FLAWED-ma-salvabile** ("chassis sano,
+  teoria editoriale da correggere"). 3 obiezioni, tutte INTEGRATE: #1 selezione-assi content-blind +
+  ledger open-loop (→ chi-propone≠chi-dispone §Mossa-B + ledger chiuso §Mossa-D), #2 Goodhart/taste +
+  voce cross-slide senza proprietario (→ heading-sorelle §Mossa-B + rischio-madre §5), #3 retry→fallback
+  ri-collassa + Jaccard sul boilerplate (→ fallback kind-preserving §Mossa-A + normalizzazione Jaccard
+  §Critico).
+- **Convergenza** dei due grader (seat diversi, accessi diversi): stesso nucleo su taste-vs-struttura e
+  su retry-fallback → alta confidenza che sono i punti veri, non rumore di un singolo seat.
+
+## 8. Decisioni Zero-gated (Legge 5 — la sessione NON le prende; sono di brand/costituzione)
+
+Il BUILD parte solo dopo ratifica di questi (più i 3 pre-build gate: fail-rate-replay, guilt+innocence
+corpus, sizing-quota):
+
+1. La libreria degli **archi** (quali 6-8, e le loro sequenze di ruoli) — è voce editoriale/brand.
+2. La regola **"caps solo su heading, mai sui body"** (già matura, Zero-gated).
+3. Lo slot-franchise **"The Bali Zero read"** come ruolo ricorrente d'apertura/chiusura.
+4. La **rotazione palette per tema**.
+   Tutto il resto (IR tipizzata, planner/writer, ledger, pre-gate deterministico) è ingegneria interna,
+   non tocca ciò che esce su IG finché Zero non pubblica.

--- a/.claude/skills/wr2/_research/2026-07-21-oss-code-reading-statemachine-gptnewspaper.md
+++ b/.claude/skills/wr2/_research/2026-07-21-oss-code-reading-statemachine-gptnewspaper.md
@@ -1,0 +1,241 @@
+# OSS editorial multi-agent / state-machine survey — real code, real paths
+
+All repos below were physically cloned/fetched in this session to
+`/private/tmp/claude-501/-Users-balizero-nuzantara/1ec39280-48a4-48d9-9aeb-8d7ec9e668f2/scratchpad/oss/`
+and read with `Read`/`grep` in this turn. Nothing here is recalled from training data.
+
+## 1. Verification table
+
+| Repo                                                                          | Verdict                                                          | What was actually read                                                                                                                                                                                                                                                                                                                                                                                                | Commit / SHA                                            | License                                                                                                                                                            |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `assafelovic/gpt-newspaper`                                                   | ✅ VERIFIED                                                      | `backend/langgraph_agent.py`, `backend/agents/{search,curator,writer,critique,designer,editor,publisher}.py`, `backend/agents/__init__.py`, `backend/server.py`, `app.py`, `requirements.txt`, `README.md`, `LICENCE` — full repo, 22 files                                                                                                                                                                           | `b86aff2d2c208c6abc44a51f443948bfae2d08cc` (2024-02-24) | MIT (Copyright Rotem Weiss)                                                                                                                                        |
+| `crewAIInc/crewAI-examples` — `crews/instagram_post/`                         | ✅ VERIFIED                                                      | `agents.py`, `tasks.py`, `main.py`, `README.md`                                                                                                                                                                                                                                                                                                                                                                       | `da94a91e691e1cf5b3151416bb15b5b62729bea8` (2026-04-20) | repo has no separate per-crew LICENSE file checked; parent org is Apache-2.0 upstream (not re-verified at file level — flag as unconfirmed at sub-dir granularity) |
+| `crewAIInc/crewAI-examples` — `flows/write_a_book_with_flows/`                | ✅ VERIFIED                                                      | `src/.../main.py` (BookFlow), `crews/write_book_chapter_crew/config/agents.yaml`, `crews/write_book_chapter_crew/write_book_chapter_crew.py`                                                                                                                                                                                                                                                                          | same commit as above                                    | same as above                                                                                                                                                      |
+| `crewAIInc/crewAI-examples` — `flows/content_creator_flow/`                   | ❌ CANNOT VERIFY                                                 | Directory exists in the tree as a `160000` gitlink (`git ls-tree` confirms mode `160000 commit 1c87aeef9b...`) but there is **no `.gitmodules`** in the repo and the working directory is empty after clone — it is an orphaned/broken submodule reference, not fetchable content. Did not fabricate contents.                                                                                                        |                                                         |                                                                                                                                                                    |
+| `langchain-ai/langgraph` `examples/multi_agent/`                              | ❌ NOT PURSUED (not "cannot verify" — deliberately out of scope) | Confirmed via `gh api` listing that only `hierarchical_agent_teams.ipynb` and `multi-agent-collaboration.ipynb` exist there — both are the well-known "Researcher + Chart-Generator" pattern, not editorial/content production. Listed but not deep-read since it doesn't match the editorial-production ask and a real hit (CrewAI) was already found — reported here for transparency rather than silently omitted. |                                                         |                                                                                                                                                                    |
+| `ghana7989/linkedin-carousel-generator`                                       | ✅ VERIFIED (but not load-bearing)                               | Full file tree read (`git ls-tree`) — it's a React/NestJS SaaS editor (manual drag-and-drop carousel builder), no AI slide-structure decision logic to extract. Mentioned for completeness, not cited further.                                                                                                                                                                                                        | `31d8ec481aad0ca2fcbeb4d1d9055e5e92a64685`              | not read                                                                                                                                                           |
+| `Maazsiddiqui01/linkedin-carousel-generator` ("AntiGravity Slides Generator") | ✅ VERIFIED                                                      | `schemas/carousel.schema.json`, `scripts/build_carousel.js`, `scripts/run_overseer_checks.js`, `README.md`, `LICENSE`                                                                                                                                                                                                                                                                                                 | `f5963e9986b68d7d00f1f44bf57996a5b4fe6442` (2026-02-23) | MIT (Copyright Maaz Siddiqui)                                                                                                                                      |
+
+Yesterday's sibling pass named repos that turned out not to exist — this pass replaces that with only repos that were physically fetched. Two secondary candidates that came up in search (`santmun/...`, `TaliNata/...`, `Lindadao92/...`) were **not** cloned/read and are therefore **not cited** anywhere below — they are absent from this report by design, not silently assumed real.
+
+---
+
+## 2. gpt-newspaper mechanism deep-dive
+
+### 2a. The graph wiring — `backend/langgraph_agent.py` (full file, 59 lines)
+
+```python
+# backend/langgraph_agent.py:1-58
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from langgraph.graph import Graph
+
+from .agents import SearchAgent, CuratorAgent, WriterAgent, DesignerAgent, EditorAgent, PublisherAgent, CritiqueAgent
+
+
+class MasterAgent:
+    def __init__(self):
+        self.output_dir = f"outputs/run_{int(time.time())}"
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    def run(self, queries: list, layout: str):
+        # Initialize agents
+        search_agent = SearchAgent()
+        curator_agent = CuratorAgent()
+        writer_agent = WriterAgent()
+        critique_agent = CritiqueAgent()
+        designer_agent = DesignerAgent(self.output_dir)
+        editor_agent = EditorAgent(layout)
+        publisher_agent = PublisherAgent(self.output_dir)
+
+        # Define a Langchain graph
+        workflow = Graph()
+
+        # Add nodes for each agent
+        workflow.add_node("search", search_agent.run)
+        workflow.add_node("curate", curator_agent.run)
+        workflow.add_node("write", writer_agent.run)
+        workflow.add_node("critique", critique_agent.run)
+        workflow.add_node("design", designer_agent.run)
+
+        # Set up edges
+        workflow.add_edge('search', 'curate')
+        workflow.add_edge('curate', 'write')
+        workflow.add_edge('write', 'critique')
+        workflow.add_conditional_edges(start_key='critique',
+                                       condition=lambda x: "accept" if x['critique'] is None else "revise",
+                                       conditional_edge_mapping={"accept": "design", "revise": "write"})
+
+        # set up start and end nodes
+        workflow.set_entry_point("search")
+        workflow.set_finish_point("design")
+
+        # compile the graph
+        chain = workflow.compile()
+
+        # Execute the graph for each query in parallel
+        with ThreadPoolExecutor() as executor:
+            parallel_results = list(executor.map(lambda q: chain.invoke({"query": q}), queries))
+
+        # Compile the final newspaper
+        newspaper_html = editor_agent.run(parallel_results)
+        newspaper_path = publisher_agent.run(newspaper_html)
+
+        return newspaper_path
+```
+
+Key facts, verbatim from the code:
+
+- **6 nodes, 4 unconditional edges, 1 conditional edge.** `Editor` and `Publisher` are deliberately kept **outside** the per-article graph — they run once, after `ThreadPoolExecutor` fans the whole per-query graph out in parallel (one compiled `chain` invoked once per topic in `queries`). The state-machine is per-article; the newspaper assembly is a plain post-loop step, not a graph node.
+- **The state object is the article `dict` itself** — there is no separate `State` TypedDict/Pydantic model. `chain.invoke({"query": q})` seeds the state with a single key, and every node function receives and returns the _same dict_, mutating it via `.update()`. LangGraph's `Graph` (not the newer `StateGraph`) just threads this dict node-to-node.
+- **The loop is a 2-way conditional edge keyed on a single field's truthiness**: `condition=lambda x: "accept" if x['critique'] is None else "revise"`. No max-retry counter, no loop-breaker — in this codebase the critic is trusted to eventually emit `None`.
+
+### 2b. The shared state — what actually flows through the dict
+
+Reconstructing the schema from every `.update()` / key-read across the 5 node files (there is no explicit schema file — this is itself a transferable lesson, see §3):
+
+| Key                                      | Written by                                                                              | Read by                                                                                                               |
+| ---------------------------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `query`                                  | seed (`chain.invoke({"query": q})`)                                                     | curator, writer, designer (`article["query"]` in `curator.py:41`, `writer.py:97`, `designer.py:33`)                   |
+| `sources`                                | `search.py:22` (`article["sources"] = res[0]`)                                          | `curator.py:41` (filters in place), `writer.py:97`                                                                    |
+| `image`                                  | `search.py:23`                                                                          | `designer.py:21`                                                                                                      |
+| `title`, `date`, `paragraphs`, `summary` | `writer.py:63` (`json.loads(response)`, merged via `article.update(...)`)               | `designer.py:19-22`, `editor.py:47-49`                                                                                |
+| `critique`                               | `critique.py:29/33` (`{'critique': None}` or `{'critique': response, 'message': None}`) | the conditional edge in `langgraph_agent.py:40`, and `writer.py:93` (`article.get("critique")`)                       |
+| `message`                                | `writer.py:90` (`self.revise()` return, `response['message']`)                          | read back by critique's next prompt (`critique.py:20-21`, textually referencing "if you noticed the field 'message'") |
+| `html`, `path`                           | `designer.py:28,38`                                                                     | `editor.py` (via the parallel list of article dicts)                                                                  |
+
+This is the crux of the pattern: **the state IS a growing dict with no fixed contract** — every node is free to read any key any prior node wrote, and the "schema" is only discoverable by grepping every node file. There is zero runtime validation that a key exists before it's read (e.g. `writer.py:97` does `article["sources"]` — a `KeyError` if curator failed to set it — no try/except).
+
+### 2c. One agent node in full — `backend/agents/writer.py`
+
+```python
+# backend/agents/writer.py:92-98
+def run(self, article: dict):
+    critique = article.get("critique")
+    if critique is not None:
+        article.update(self.revise(article))
+    else:
+        article.update(self.writer(article["query"], article["sources"]))
+    return article
+```
+
+This is the entire "role isolation" mechanism: `WriterAgent.run()` is the ONLY function LangGraph calls for the `"write"` node. Internally it branches on whether `critique` is present in the state — first pass writes from scratch (`writer()`, `writer.py:39-63`, forcing a JSON contract via `response_format: json_object` and a hardcoded `sample_json` template embedded in the prompt string), subsequent passes call `revise()` (`writer.py:65-90`) which is a **different prompt with a different expected-JSON shape** (`sample_revise_json`, only `paragraphs` + `message`, no `title`/`date`/`summary` — meaning revision passes silently keep the ORIGINAL title/date/summary since `.update()` only overwrites returned keys). Role isolation = one class, one `run(article) -> article` contract, all decision logic (write-vs-revise) lives inside that one node — the graph itself carries zero business logic, only wiring.
+
+### 2d. The critic→writer feedback edge
+
+```python
+# backend/agents/critique.py:9-37 (full file)
+def critique(self, article: dict):
+    prompt = [{
+        "role": "system",
+        "content": "You are a newspaper writing critique. Your sole purpose is to provide short feedback on a written "
+                   "article so the writer will know what to fix.\n "
+    }, {
+        "role": "user",
+        "content": f"Today's date is {datetime.now().strftime('%d/%m/%Y')}\n."
+                   f"{str(article)}\n"
+                   f"Your task is to provide a really short feedback on the article only if necessary.\n"
+                   f"if you think the article is good, please return None.\n"
+                   f"if you noticed the field 'message' in the article, it means the writer has revised the article"
+                    f"based on your previous critique. you can provide feedback on the revised article or just "
+                   f"return None if you think the article is good.\n"
+                    f"Please return a string of your critique or None.\n"
+    }]
+    lc_messages = convert_openai_messages(prompt)
+    response = ChatOpenAI(model='gpt-4', max_retries=1).invoke(lc_messages).content
+    if response == 'None':
+        return {'critique': None}
+    else:
+        print(f"For article: {article['title']}")
+        print(f"Feedback: {response}\n")
+        return {'critique': response, 'message': None}
+
+def run(self, article: dict):
+    article.update(self.critique(article))
+    return article
+```
+
+Combined with the conditional edge in `langgraph_agent.py:39-41`:
+
+```python
+workflow.add_conditional_edges(start_key='critique',
+                               condition=lambda x: "accept" if x['critique'] is None else "revise",
+                               conditional_edge_mapping={"accept": "design", "revise": "write"})
+```
+
+The gate is: **critic returns a literal Python `None`/string `'None'` (string comparison against the LLM's raw text output, `critique.py:28`) → conditional edge reads `x['critique'] is None` → routes to `"design"` (exit the loop) or `"write"` (loop back)**. Notable fragility read directly in the code, not inferred: the gate is a brittle string-equality check on raw LLM output (`if response == 'None':` — any deviation like `"None."` or `"None, looks good"` would fail to close the loop), and there is **no loop-count cap** — an adversarial or confused critic could in principle loop forever (bounded only by `max_retries=1` on the _ChatOpenAI call itself_, not on the graph traversal).
+
+---
+
+## 3. The transferable pattern, stripped of framework
+
+What LangGraph is actually buying gpt-newspaper, concretely, from the code read above:
+
+1. **Edge wiring + traversal loop** (`workflow.add_edge`, `add_conditional_edges`, `.compile()`, `chain.invoke`) — replaces what would otherwise be a hand-written `while` loop.
+2. **Nothing else.** There is no `StateGraph` typed schema in this codebase (it uses the older untyped `Graph`), no checkpointing, no persistence, no human-in-the-loop primitives, no streaming, no automatic retries, no parallel-node fan-out inside the graph (the parallelism is a bare `ThreadPoolExecutor.map` OUTSIDE the graph, `langgraph_agent.py:51-52`). Every node is a plain Python class with a `run(article: dict) -> dict` method — could be a bare function.
+
+**Minimal contract, framework-free equivalent (would cost ~15 lines in plain Python):**
+
+```python
+def run_article_pipeline(query: str) -> dict:
+    article = {"query": query}
+    article.update(search(article))
+    article.update(curate(article))
+    while True:
+        article.update(write(article))
+        article.update(critique(article))
+        if article["critique"] is None:
+            break
+    article.update(design(article))
+    return article
+```
+
+This is _exactly_ what the compiled LangGraph chain does at runtime for this specific graph shape (linear + one back-edge) — a `while`-loop with an exit condition. The framework earns its keep only when the shape gets more branchy (multiple conditional exits, subgraphs, need for checkpointed resume across process restarts, or you want a visual graph / LangSmith trace of the state transitions for free). For a graph this shape (5 nodes, 1 loop-back, no branching, no checkpoint requirement), a `while` loop **costs less and is strictly more debuggable** (no need to understand `Graph()` vs `StateGraph()` semantics, no dependency on `langchain.adapters.openai.convert_openai_messages` which is itself a `langchain` compatibility shim visible in every node file's imports) — this is the actual answer to "could it be done without a framework": **yes, trivially, for this shape**, and the repo's own code proves it by putting ZERO business logic in the graph layer — 100% of the interesting logic (write-vs-revise branch, critique done-check, source curation) lives in plain-Python `run()` methods that don't touch LangGraph at all. LangGraph here is exclusively wiring glue around code that would work identically called directly.
+
+The CrewAI examples independently confirm the same lesson from the opposite direction: `write_a_book_with_flows/src/.../main.py:50-89` uses `@listen(generate_book_outline)` + `asyncio.gather(*tasks)` to fan out chapter-writing — i.e. even CrewAI's own "Flow" abstraction, when it needs real fan-out concurrency, drops to bare `asyncio.create_task`/`asyncio.gather` (`main.py:81,85`) rather than a framework primitive. The framework supplies decorators for wiring (`@start`, `@listen`) and a `Crew`/`Process.sequential` container for role-based agent teams (`write_book_chapter_crew.py:42-50`), but the actual parallel dispatch is plain asyncio underneath.
+
+`Maazsiddiqui01/linkedin-carousel-generator` is the sharpest real-world data point for "no framework at all": it is **100% plain Node.js scripts + a JSON schema + a deterministic pipeline runner** (`scripts/build_carousel.js:75-99`, sequential `spawnSync` steps: chart-gen → image-gen → render → validate → **overseer** → performance-log, each step gating the next via `.success`), with the "critic" role (`scripts/run_overseer_checks.js`) implemented as **deterministic heuristics, not an LLM call** — Jaccard-similarity duplicate detection (`run_overseer_checks.js:41-52`), bullet-count/length thresholds (`:118-132`), workflow-chip sequence validation (`:265-286`), visual-coverage-ratio checks against a configurable target (`:221-237`). It proves a full editorial-critic gate can be built with zero LLM calls and zero framework when the failure modes are structurally checkable (duplication, missing CTA, out-of-sequence numbering, coverage ratio) — reserving LLM judgment only for what's genuinely subjective.
+
+---
+
+## 4. WR2 mapping
+
+Grounded in the actual live WR2 code (verified this turn, not recalled):
+
+- `/Users/balizero/nuzantara/scripts/wr2_draft_generator.py` — 2162 lines, plain Python, `asyncpg` for Postgres (`:45`, `:2069` `asyncpg.create_pool`), **one function `claude_compose_slides()` (`:1071-1097`) makes a single `complete_async(..., model="claude-opus-4-7", timeout_s=300)` call that returns the entire slide JSON** (`_extract_json(resp.text)`) — confirming the prompt's framing: "one monolithic Claude call for the whole carousel."
+- No `import langgraph` / `import crewai` anywhere under `scripts/wr2*.py` (grep run this turn returned zero matches).
+- Orchestration is `infra/launchagents/com.balizero.wr2.*.plist` (launchd) chaining separate cron-scheduled scripts (`wr2_draft_generator.py` → `wr2_canva_*` → `wr2_ig_publish.py`, etc.) — i.e. WR2's "graph" already exists, but it is expressed as **separate OS processes wired by launchd + a Postgres queue table**, not as in-process node objects.
+- There IS a distinct critic role already: the `wr2-critic` subagent (per this session's system prompt, agent catalog) runs on rendered PNGs as a Step-5 gate in the interactive `wr2-design-architect` pipeline — a SEPARATE, non-cron pipeline from `wr2_draft_generator.py`. That interactive pipeline already has brief-interpreter → storyboarder → layout-composer → critic role-split, dispatched via the `Agent` tool, not a graph library.
+
+**What maps 1:1 from gpt-newspaper's mechanism:**
+
+| gpt-newspaper concept                                   | WR2 equivalent today                                                                                                                                                    |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `article` dict threaded through nodes                   | Postgres row(s) in the WR2 queue table, threaded through pipeline stages (already superior: durable + inspectable vs. an in-memory dict)                                |
+| `critique.py` conditional-edge loop (`accept`/`revise`) | Already exists as a _separate_ interactive gate (`wr2-critic` subagent), NOT wired into the cron `wr2_draft_generator.py` monolithic-call path — this is the actual gap |
+| One node = one Python class with `run()`                | WR2 already does this at the _process_ level (one script per stage) — finer-grained than gpt-newspaper's in-process nodes                                               |
+| `ThreadPoolExecutor` fan-out across topics              | WR2 queue table + launchd cron intervals already provides this (coarser-grained, cross-process)                                                                         |
+
+**Should WR2 adopt a framework (LangGraph/CrewAI), or replicate the pattern in its existing plain-Python+DB idiom?**
+
+Argued directly from the code read above, not in the abstract: **replicate the pattern, don't adopt a framework.**
+
+1. **gpt-newspaper's own code proves the framework adds no business value for a loop-shaped graph** — every interesting behavior (write-vs-revise, critique-done-check) lives in plain-Python node methods; the graph layer is 4 lines of edge declarations. WR2's monolithic-call gap is structurally the same shape as gpt-newspaper's write→critique loop — closing it needs a `while`-with-exit-condition around `claude_compose_slides()`, which is a ~20-line change to `wr2_draft_generator.py`, not a new dependency.
+2. **WR2 already has the harder infrastructure gpt-newspaper lacks**: durable state (Postgres row, survives process crash — gpt-newspaper's in-memory dict does NOT survive a crash mid-graph, since `Graph.compile()` gives no checkpointing in the version this repo pins, `requirements.txt:2` bare `langgraph`), and process-level isolation via launchd (crash of one stage doesn't kill the whole run, unlike gpt-newspaper's single Python process running the whole `ThreadPoolExecutor`). Introducing LangGraph would mean _re-deriving inside a single process_ durability WR2's launchd+Postgres design gets for free — a straight regression per CLAUDE.md's own `PYTHONPATH=. python -m backend.module` / async-first / Postgres invariants (§8-9), and per the repo's `W64/W34 asyncpg silent-death` scar family (cicatrix #2) — a framework that re-centralizes state in-process is exactly the shape that produces "esiste ≠ armato" (green but the underlying worker died) failures the org has been burned by repeatedly.
+3. **The one thing worth lifting verbatim is the deterministic-overseer pattern from `Maazsiddiqui01`**, not a graph library: `run_overseer_checks.js` shows a **non-LLM, non-framework critic** — structural checks (duplicate-content Jaccard similarity, bullet-count ceilings, CTA-presence, visual-coverage ratio, chip-sequence validation) that catch a large class of defects for $0 and 0ms LLM latency, BEFORE the expensive LLM-judge (`wr2-critic`) is invoked. WR2 currently has zero deterministic pre-gate of this kind in `wr2_draft_generator.py` — bolting a cheap structural-checks function (repeated-phrase/duplicate-bullet detection, bullet-length ceilings, CTA/closer-presence, kicker-uniqueness — some of which, e.g. `_kicker_collision` at `wr2_draft_generator.py:668`, WR2 already half-has) directly ahead of the Opus call, or directly after it as a fast-fail before the (expensive, slow) `wr2-critic` vision pass, is a genuine, cheap, framework-free win extractable from this research.
+4. **Net verdict**: adopt the _shape_ (state-with-role-isolation, critic-gated loop, deterministic-check-before-LLM-judge), reject the _framework_ — consistent with WR2's existing architecture (plain Python + launchd + Postgres, per CLAUDE.md §12/§WR2 corner) and with the org's own documented scar pattern against introducing new stateful abstractions into a system whose reliability model is built on process isolation + DB durability, not in-process graph state.
+
+---
+
+## Files/paths referenced in this report (all read this session)
+
+- `/private/tmp/claude-501/.../scratchpad/oss/gpt-newspaper/backend/langgraph_agent.py`
+- `/private/tmp/claude-501/.../scratchpad/oss/gpt-newspaper/backend/agents/{search,curator,writer,critique,designer,editor,publisher,__init__}.py`
+- `/private/tmp/claude-501/.../scratchpad/oss/gpt-newspaper/backend/server.py`, `app.py`, `requirements.txt`, `README.md`, `LICENCE`
+- `/private/tmp/claude-501/.../scratchpad/oss/crewAI-examples/crews/instagram_post/{agents,tasks,main}.py`, `README.md`
+- `/private/tmp/claude-501/.../scratchpad/oss/crewAI-examples/flows/write_a_book_with_flows/src/write_a_book_with_flows/main.py`
+- `/private/tmp/claude-501/.../scratchpad/oss/crewAI-examples/flows/write_a_book_with_flows/src/write_a_book_with_flows/crews/write_book_chapter_crew/{write_book_chapter_crew.py, config/agents.yaml}`
+- `/private/tmp/claude-501/.../scratchpad/oss/lcg-maaz/{schemas/carousel.schema.json, scripts/build_carousel.js, scripts/run_overseer_checks.js, README.md, LICENSE}`
+- `/Users/balizero/nuzantara/scripts/wr2_draft_generator.py` (lines 45, 1071-1097, 2069, 668)
+- `/Users/balizero/nuzantara/infra/launchagents/com.balizero.wr2.*.plist`

--- a/.claude/skills/wr2/_research/2026-07-21-oss-code-reading-storm-gptresearcher.md
+++ b/.claude/skills/wr2/_research/2026-07-21-oss-code-reading-storm-gptresearcher.md
@@ -1,0 +1,770 @@
+# Staged / Outline-First Content Generation — Real-Code Research Report
+
+Method used: `git clone --depth 1` into
+`/private/tmp/claude-501/-Users-balizero-nuzantara/1ec39280-48a4-48d9-9aeb-8d7ec9e668f2/scratchpad/oss/`
+for both targets. Both clones succeeded (no WebFetch fallback needed). All code excerpts below were
+read directly from the cloned working trees with the `Read` tool in this session — nothing is quoted
+from memory or from a prior report.
+
+## 1. Verification table
+
+| Repo                         | Verified?            | Commit read                                             | License                                                  | Clone path                           |
+| ---------------------------- | -------------------- | ------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------ |
+| `stanford-oval/storm`        | YES — read real code | `fb951af7744dab086e34962e9bc6fe878e145f8` (2025-09-30)  | MIT (Copyright 2024 Stanford Open Virtual Assistant Lab) | `.../scratchpad/oss/storm/`          |
+| `assafelovic/gpt-researcher` | YES — read real code | `5d84d2f5553e70a2765a8ff3a0d2672d60437ce8` (2026-07-14) | Apache License 2.0                                       | `.../scratchpad/oss/gpt-researcher/` |
+
+Files actually opened and read in this session (not summarized from docs, not paraphrased from a README):
+
+**STORM**
+
+- `knowledge_storm/storm_wiki/modules/outline_generation.py` (168 lines, read in full)
+- `knowledge_storm/storm_wiki/modules/storm_dataclass.py` (505 lines, read in full)
+- `knowledge_storm/interface.py` (609 lines, read in full)
+- `knowledge_storm/storm_wiki/modules/article_generation.py` (177 lines, read in full)
+- `knowledge_storm/storm_wiki/engine.py` (442 lines, read in full)
+- `knowledge_storm/utils.py` (excerpt: `clean_up_outline` L457-505, `clean_up_section` L506-538, `parse_article_into_dict` L553-593)
+
+**gpt-researcher**
+
+- `multi_agents/agents/editor.py` (169 lines, read in full)
+- `multi_agents/agents/writer.py` (147 lines, read in full)
+- `multi_agents/agents/researcher.py` (58 lines, read in full)
+- `gpt_researcher/skills/writer.py` (266 lines, read in full)
+- `gpt_researcher/utils/validators.py` (excerpt: `Subtopic`/`Subtopics` classes L8-26)
+- `gpt_researcher/utils/llm.py` (excerpt: `construct_subtopics` L155-185+)
+- Directory listings of `gpt_researcher/` and `multi_agents/` confirmed via `find`, not assumed.
+
+No repo was described without being fetched. Nothing below is invented.
+
+---
+
+## 2. STORM mechanism deep-dive
+
+STORM's pipeline (`knowledge_storm/storm_wiki/engine.py`) is **four independently-invokable, disk-persisted
+stages**: knowledge curation → outline generation → article generation → article polishing. Each stage
+has its own `do_X: bool` flag in `STORMWikiRunner.run()`, and if a stage is skipped, its input is
+**reloaded from a file on disk** rather than passed in memory — meaning outline generation and article
+writing are not just logically separate functions, they're operationally decoupled processes that can
+run in different invocations of the tool entirely.
+
+### 2a. Outline generation
+
+File: `knowledge_storm/storm_wiki/modules/outline_generation.py`
+
+```python
+# L11-72
+class StormOutlineGenerationModule(OutlineGenerationModule):
+    def __init__(self, outline_gen_lm: Union[dspy.dsp.LM, dspy.dsp.HFModel]):
+        super().__init__()
+        self.outline_gen_lm = outline_gen_lm
+        self.write_outline = WriteOutline(engine=self.outline_gen_lm)
+
+    def generate_outline(
+        self,
+        topic: str,
+        information_table: StormInformationTable,
+        old_outline: Optional[StormArticle] = None,
+        callback_handler: BaseCallbackHandler = None,
+        return_draft_outline=False,
+    ) -> Union[StormArticle, Tuple[StormArticle, StormArticle]]:
+        ...
+        concatenated_dialogue_turns = sum(
+            [conv for (_, conv) in information_table.conversations], []
+        )
+        result = self.write_outline(
+            topic=topic,
+            dlg_history=concatenated_dialogue_turns,
+            callback_handler=callback_handler,
+        )
+        article_with_outline_only = StormArticle.from_outline_str(
+            topic=topic, outline_str=result.outline
+        )
+        ...
+        return article_with_outline_only
+```
+
+The outline is produced by a `dspy.Module` (`WriteOutline`, L75-125) that does a **two-pass LLM call**:
+first a naive outline from the LLM's own parametric knowledge (`self.draft_page_outline`, using
+`WritePageOutline` signature), then a refinement pass conditioned on the collected research dialogue
+(`self.write_page_outline`, using `WritePageOutlineFromConv` signature, L153-167). The dspy `Signature`
+docstring is literally the prompt contract handed to the model:
+
+```python
+# L128-138
+class WritePageOutline(dspy.Signature):
+    """Write an outline for a Wikipedia page.
+    Here is the format of your writing:
+    1. Use "#" Title" to indicate section title, "##" Title" to indicate subsection title, "###" Title" to indicate subsubsection title, and so on.
+    2. Do not include other information.
+    3. Do not include topic name itself in the outline.
+    """
+    topic = dspy.InputField(prefix="The topic you want to write: ", format=str)
+    outline = dspy.OutputField(prefix="Write the Wikipedia page outline:\n", format=str)
+```
+
+So the outline is **plain markdown headers as a string** — the LLM output format is literally `#`/`##`/`###`.
+There is no forced JSON schema at generation time.
+
+### 2b. The outline data structure
+
+The markdown string is immediately parsed into a real in-memory **tree**, not kept as text. This happens
+in `knowledge_storm/storm_wiki/modules/storm_dataclass.py`, class `StormArticle` (subclass of `Article`
+in `interface.py`), backed by `ArticleSectionNode`:
+
+```python
+# interface.py L136-159
+class ArticleSectionNode:
+    """
+    The ArticleSectionNode is the dataclass for handling the section of the article.
+    The content storage, section writing preferences are defined in this node.
+    """
+    def __init__(self, section_name: str, content=None):
+        self.section_name = section_name
+        self.content = content
+        self.children = []
+        self.preference = None
+
+    def add_child(self, new_child_node, insert_to_front=False):
+        if insert_to_front:
+            self.children.insert(0, new_child_node)
+        else:
+            self.children.append(new_child_node)
+
+    def remove_child(self, child):
+        self.children.remove(child)
+```
+
+```python
+# interface.py L162-165
+class Article(ABC):
+    def __init__(self, topic_name):
+        self.root = ArticleSectionNode(topic_name)
+```
+
+The markdown → tree parser is `StormArticle.from_outline_str` (`storm_dataclass.py` L437-474). It's a
+classic stack-based header-depth parser: it counts `#` characters per line to get `level`, pops the stack
+until it finds the right parent depth, and appends:
+
+```python
+# storm_dataclass.py L437-474
+@classmethod
+def from_outline_str(cls, topic: str, outline_str: str):
+    lines = []
+    try:
+        lines = outline_str.split("\n")
+        lines = [line.strip() for line in lines if line.strip()]
+    except:
+        pass
+
+    instance = cls(topic)
+    if lines:
+        ...
+        node_stack = [(0, instance.root)]  # Stack to keep track of (level, node)
+
+        for line in lines:
+            level = line.count("#") - adjust_level
+            section_name = line.replace("#", "").strip()
+
+            if section_name == topic:
+                continue
+
+            new_node = ArticleSectionNode(section_name)
+
+            while node_stack and level <= node_stack[-1][0]:
+                node_stack.pop()
+
+            node_stack[-1][1].add_child(new_node)
+            node_stack.append((level, new_node))
+    return instance
+```
+
+So: **outline representation = a real n-ary tree of `ArticleSectionNode` objects, each with
+`section_name`, `content` (initially `None`), and `children`**, wrapped in a `StormArticle` whose `.root`
+is the topic node. `content` stays empty until the writing stage fills it in — the tree IS the contract
+between outline stage and writer stage, and `content=None` on every leaf is the explicit "not yet written"
+state.
+
+`get_outline_tree()` (`interface.py` L193-230, overridden identically in `storm_dataclass.py` L414-421)
+exposes this same tree as a nested `Dict[str, Dict]` for external consumption (e.g. UI rendering) — proof
+the representation is meant to be introspected structurally, not just re-serialized to text.
+
+### 2c. How the outline constrains/feeds the writer stage
+
+File: `knowledge_storm/storm_wiki/modules/article_generation.py`, class `StormArticleGenerationModule`.
+The full driving method:
+
+```python
+# article_generation.py L53-133
+def generate_article(
+    self,
+    topic: str,
+    information_table: StormInformationTable,
+    article_with_outline: StormArticle,
+    callback_handler: BaseCallbackHandler = None,
+) -> StormArticle:
+    information_table.prepare_table_for_retrieval()
+
+    if article_with_outline is None:
+        article_with_outline = StormArticle(topic_name=topic)
+
+    sections_to_write = article_with_outline.get_first_level_section_names()
+
+    section_output_dict_collection = []
+    if len(sections_to_write) == 0:
+        ...
+    else:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.max_thread_num
+        ) as executor:
+            future_to_sec_title = {}
+            for section_title in sections_to_write:
+                if section_title.lower().strip() == "introduction":
+                    continue
+                if section_title.lower().strip().startswith("conclusion") \
+                        or section_title.lower().strip().startswith("summary"):
+                    continue
+                section_query = article_with_outline.get_outline_as_list(
+                    root_section_name=section_title, add_hashtags=False
+                )
+                queries_with_hashtags = article_with_outline.get_outline_as_list(
+                    root_section_name=section_title, add_hashtags=True
+                )
+                section_outline = "\n".join(queries_with_hashtags)
+                future_to_sec_title[
+                    executor.submit(
+                        self.generate_section,
+                        topic,
+                        section_title,
+                        information_table,
+                        section_outline,
+                        section_query,
+                    )
+                ] = section_title
+
+            for future in as_completed(future_to_sec_title):
+                section_output_dict_collection.append(future.result())
+
+    article = copy.deepcopy(article_with_outline)
+    for section_output_dict in section_output_dict_collection:
+        article.update_section(
+            parent_section_name=topic,
+            current_section_content=section_output_dict["section_content"],
+            current_section_info_list=section_output_dict["collected_info"],
+        )
+    article.post_processing()
+    return article
+```
+
+This is the **exact answer to "how the outline is passed to and constrains the writing stage."** The
+outline object (`article_with_outline`, a `StormArticle` tree) is walked to get `sections_to_write =
+article_with_outline.get_first_level_section_names()` — i.e. the writer only ever sees the top-level
+section names as its unit of work. For each top-level section, `get_outline_as_list(root_section_name=X)`
+is called TWICE:
+
+1. without hashtags → `section_query` — a flat list of that section's own subsection names, used purely
+   as **retrieval queries** to pull the top-k relevant snippets for that section only
+   (`information_table.retrieve_information`).
+2. with hashtags → `section_outline` — the markdown-rendered slice of the outline tree **scoped to that
+   section's subtree only** (its own sub-headers, re-indented), which is what's actually shown to the
+   writer LLM as its structural brief.
+
+So each writer call gets: (topic, its own scoped mini-outline, its own section name, its own
+retrieved evidence) — it never sees the other sections' outline or content, and it cannot see or write
+outside its assigned subtree.
+
+### 2d. Section writing is genuinely parallel and independently scoped
+
+`generate_section` (L33-51) is the per-section unit of work:
+
+```python
+# article_generation.py L33-51
+def generate_section(
+    self, topic, section_name, information_table, section_outline, section_query
+):
+    collected_info: List[Information] = []
+    if information_table is not None:
+        collected_info = information_table.retrieve_information(
+            queries=section_query, search_top_k=self.retrieve_top_k
+        )
+    output = self.section_gen(
+        topic=topic,
+        outline=section_outline,
+        section=section_name,
+        collected_info=collected_info,
+    )
+    return {
+        "section_name": section_name,
+        "section_content": output.section,
+        "collected_info": collected_info,
+    }
+```
+
+This is dispatched into a real `concurrent.futures.ThreadPoolExecutor(max_workers=self.max_thread_num)`
+(default `max_thread_num=10`, set in `STORMWikiRunnerArguments`, `engine.py` L162-168) — one thread per
+top-level section, fully parallel, collected via `as_completed`. Each thread's LLM call is fully
+independent: separate `dspy.Predict` invocation of `ConvToSection`/`WriteSection`
+(`article_generation.py` L136-177), with its own `dspy.settings.context(lm=self.engine)`. No shared
+mutable state is touched inside the loop — results are only merged back into the tree afterward, sequentially,
+via `article.update_section(...)` (L126-131), which re-parses the returned markdown text into subsections
+and grafts it onto the matching node of the (deep-copied) outline tree.
+
+`WriteSection`'s dspy Signature (L162-177) is again the literal writer contract:
+
+```python
+# article_generation.py L162-177
+class WriteSection(dspy.Signature):
+    """Write a Wikipedia section based on the collected information.
+    Here is the format of your writing:
+        1. Use "#" Title" ... "##" Title" ... to indicate section/subsection title.
+        2. Use [1], [2], ..., [n] in line ... You DO NOT need to include a References
+           or Sources section to list the sources at the end.
+    """
+    info = dspy.InputField(prefix="The collected information:\n", format=str)
+    topic = dspy.InputField(prefix="The topic of the page: ", format=str)
+    section = dspy.InputField(prefix="The section you need to write: ", format=str)
+    output = dspy.OutputField(
+        prefix="Write the section with proper inline citations (Start your writing with # section title. Don't include the page title or try to write other sections):\n",
+        format=str,
+    )
+```
+
+### 2e. Stage decoupling is enforced at the orchestrator level, not just logically
+
+`STORMWikiRunner.run()` (`engine.py` L341-441) treats each stage as independently resumable, persisting
+and reloading via the filesystem:
+
+```python
+# engine.py L393-424 (abridged)
+outline: StormArticle = None
+if do_generate_outline:
+    if information_table is None:
+        information_table = self._load_information_table_from_local_fs(...)
+    outline = self.run_outline_generation_module(
+        information_table=information_table, callback_handler=callback_handler
+    )
+
+draft_article: StormArticle = None
+if do_generate_article:
+    if information_table is None:
+        information_table = self._load_information_table_from_local_fs(...)
+    if outline is None:
+        outline = self._load_outline_from_local_fs(
+            topic=topic,
+            outline_local_path=os.path.join(self.article_output_dir, "storm_gen_outline.txt"),
+        )
+    draft_article = self.run_article_generation_module(
+        outline=outline, information_table=information_table, callback_handler=callback_handler,
+    )
+```
+
+And `run_outline_generation_module` (L237-254) dumps the outline to a plain-text file
+(`storm_gen_outline.txt`) immediately after generation — this is the literal file the writer stage reloads
+from disk if invoked as a separate process (`--do-generate-article` without `--do-generate-outline` on
+the CLI). This is as decoupled as a planner→writer split gets: they don't even need to run in the same
+process invocation.
+
+---
+
+## 3. gpt-researcher — plan/research/write separation
+
+`gpt-researcher` ships two relevant systems in the same repo: (a) the base `gpt_researcher/` package,
+which has a lightweight typed "subtopics" outline for its `DetailedReport` mode, and (b) a full
+LangGraph-based multi-agent team in `multi_agents/`, which is the closer analog to STORM's outline→write
+split (confirmed present via `find`, not assumed — `multi_agents/agents/{editor,researcher,reviewer,
+reviser,writer,publisher}.py` all exist).
+
+### 3a. The planner: `EditorAgent.plan_research`
+
+File: `multi_agents/agents/editor.py`, L22-50.
+
+```python
+async def plan_research(self, research_state: Dict[str, any]) -> Dict[str, any]:
+    initial_research = research_state.get("initial_research")
+    task = research_state.get("task")
+    include_human_feedback = task.get("include_human_feedback")
+    human_feedback = research_state.get("human_feedback")
+    max_sections = task.get("max_sections")
+
+    prompt = self._create_planning_prompt(
+        initial_research, include_human_feedback, human_feedback, max_sections)
+
+    print_agent_output("Planning an outline layout based on initial research...", agent="EDITOR")
+    plan = await call_model(
+        prompt=prompt,
+        model=task.get("model"),
+        response_format="json",
+    )
+
+    return {
+        "title": plan.get("title"),
+        "date": plan.get("date"),
+        "sections": plan.get("sections"),
+    }
+```
+
+The planning prompt (`_format_planning_instructions`, L96-116) is explicit about the outline's shape and
+about NOT writing prose yet:
+
+```python
+return f"""...
+           \nYour task is to generate an outline of sections headers for the research project
+           based on the research summary report above.
+           You must generate a maximum of {max_sections} section headers.
+           You must focus ONLY on related research topics for subheaders and do NOT include
+           introduction, conclusion and references.
+           You must return nothing but a JSON with the fields 'title' (str) and
+           'sections' (maximum {max_sections} section headers) with the following structure:
+           '{{title: string research title, date: today's date,
+           sections: ['section header 1', 'section header 2', 'section header 3' ...]}}'."""
+```
+
+**This is a flat outline** — just a JSON list of section-title strings — unlike STORM's nested `#`/`##`/`###`
+tree. It's the minimum viable outline schema: title + ordered list of slot-names. There's an initial
+research pass (`run_initial_research`, in `researcher.py` L34-44) that gathers a summary BEFORE planning
+even happens — the planner's prompt is conditioned on that summary (`initial_research`), analogous to
+STORM's conversation-history-informed outline refinement.
+
+### 3b. The outline data structure (typed, for the simpler single-process path)
+
+For the plain `GPTResearcher` (non-multi-agent) `DetailedReport` path, the "outline" unit is a Pydantic
+model, `gpt_researcher/utils/validators.py` L8-26:
+
+```python
+class Subtopic(BaseModel):
+    """Model representing a single research subtopic."""
+    task: str = Field(description="Task name", min_length=1)
+
+class Subtopics(BaseModel):
+    """Model representing a collection of research subtopics."""
+    subtopics: List[Subtopic] = []
+```
+
+Constructed via `construct_subtopics()` in `gpt_researcher/utils/llm.py` (L155-185+), which uses
+LangChain's `PydanticOutputParser(pydantic_object=Subtopics)` to force the LLM's output into that schema
+— a stricter contract than STORM's raw markdown-string outline, at the cost of a flatter (non-nested)
+structure. This confirms gpt-researcher's design intentionally trades hierarchy depth for schema
+strictness where it can.
+
+### 3c. Fan-out: each planned section becomes an independent research+write sub-agent, run in parallel
+
+File: `multi_agents/agents/editor.py`, `run_parallel_research` (L52-77) + `_create_workflow` (L126-144).
+
+```python
+async def run_parallel_research(self, research_state: Dict[str, any]) -> Dict[str, List[str]]:
+    agents = self._initialize_agents()
+    workflow = self._create_workflow()
+    chain = workflow.compile()
+
+    queries = research_state.get("sections")
+    title = research_state.get("title")
+
+    self._log_parallel_research(queries)
+
+    final_drafts = [
+        chain.ainvoke(self._create_task_input(
+            research_state, query, title), config={"tags": ["gpt-researcher"]})
+        for query in queries
+    ]
+    research_results = [
+        result["draft"] for result in await asyncio.gather(*final_drafts)
+    ]
+    return {"research_data": research_results}
+```
+
+```python
+def _create_workflow(self) -> StateGraph:
+    agents = self._initialize_agents()
+    workflow = StateGraph(DraftState)
+
+    workflow.add_node("researcher", agents["research"].run_depth_research)
+    workflow.add_node("reviewer", agents["reviewer"].run)
+    workflow.add_node("reviser", agents["reviser"].run)
+
+    workflow.set_entry_point("researcher")
+    workflow.add_edge("researcher", "reviewer")
+    workflow.add_edge("reviser", "reviewer")
+    workflow.add_conditional_edges(
+        "reviewer",
+        self._route_draft_review,
+        {"accept": END, "revise": "reviser"},
+    )
+    return workflow
+```
+
+Each `query` in `research_state.get("sections")` (i.e. every outline slot the planner emitted) gets its
+**own LangGraph sub-workflow instance**, launched concurrently via a list comprehension of
+`chain.ainvoke(...)` fed into `asyncio.gather(*final_drafts)` — the async analog of STORM's
+`ThreadPoolExecutor`. Crucially, the sub-workflow is not just "write prose for this slot" — it's a full
+**researcher → reviewer → reviser loop per section** (a self-critique cycle absent from STORM's
+single-pass writer), with `reviewer` conditionally routing back to `reviser` until accepted.
+
+Each section's researcher (`multi_agents/agents/researcher.py`, `run_depth_research`, L46-58) spins up a
+**complete standalone `GPTResearcher` instance** scoped to that one section as its own sub-topic, doing
+its own web search AND its own writing:
+
+```python
+async def run_depth_research(self, draft_state: dict):
+    task = draft_state.get("task")
+    topic = draft_state.get("topic")
+    parent_query = task.get("query")
+    source = task.get("source", "web")
+    verbose = task.get("verbose")
+    ...
+    research_draft = await self.run_subtopic_research(parent_query=parent_query, subtopic=topic,
+                                                      verbose=verbose, source=source, headers=self.headers)
+    return {"draft": research_draft}
+```
+
+```python
+async def run_subtopic_research(self, parent_query: str, subtopic: str, verbose: bool = True, source="web", headers=None):
+    try:
+        report = await self.research(parent_query=parent_query, query=subtopic,
+                                     research_report="subtopic_report", verbose=verbose, source=source, tone=self.tone, headers=None)
+    except Exception as e:
+        print(f"{Fore.RED}Error in researching topic {subtopic}: {e}{Style.RESET_ALL}")
+        report = None
+    return {subtopic: report}
+```
+
+```python
+async def research(self, query: str, research_report: str = "research_report",
+                   parent_query: str = "", verbose=True, source="web", tone=None, headers=None):
+    researcher = GPTResearcher(query=query, report_type=research_report, parent_query=parent_query,
+                               verbose=verbose, report_source=source, tone=tone, websocket=self.websocket, headers=self.headers)
+    await researcher.conduct_research()
+    report = await researcher.write_report()
+    return report
+```
+
+Note `report_type=research_report="subtopic_report"` and `parent_query=parent_query` — this
+`report_type` value is read back inside `ReportGenerator.write_report`
+(`gpt_researcher/skills/writer.py` L114-120): when `report_type == "subtopic_report"`, the prompt is
+given `main_topic=self.researcher.parent_query` plus `existing_headers` (so it can avoid duplicating
+headers already written by sibling sections) — i.e. **the section-level writer is aware of its slot's
+scope AND of the overall topic**, but not of sibling sections' actual prose, only their header list. This
+is a slightly looser isolation boundary than STORM's (which passes zero cross-section awareness).
+
+### 3d. The top-level "writer" only glues, never re-writes bodies
+
+File: `multi_agents/agents/writer.py`. Once every section sub-workflow's draft lands in
+`research_state["research_data"]` (a list, one entry per section, already fully written), the top-level
+`WriterAgent.write_sections` (L32-71) does NOT rewrite section bodies. It's given the **already-written**
+`research_data` as raw string context and asked only for glue content — table of contents, introduction,
+conclusion, sources list:
+
+```python
+sample_json = """
+{
+  "table_of_contents": A table of contents in markdown syntax (using '-') based on the research headers and subheaders,
+  "introduction": An indepth introduction to the topic in markdown syntax and hyperlink references to relevant sources,
+  "conclusion": A conclusion to the entire research based on all research data in markdown syntax and hyperlink references to relevant sources,
+  "sources": A list with strings of all used source links in the entire research data in markdown syntax and apa citation format. ...
+}
+"""
+...
+async def write_sections(self, research_state: dict):
+    query = research_state.get("title")
+    data = research_state.get("research_data")
+    ...
+    prompt = [
+        {"role": "system", "content": "You are a research writer. ..."},
+        {"role": "user", "content": f"...Research data: {str(data)}\n..."
+            f"Your task is to write an in depth, well written and detailed "
+            f"introduction and conclusion to the research report based on the provided research data. "
+            f"Do not include headers in the results.\n..."},
+    ]
+    response = await call_model(prompt, task.get("model"), response_format="json")
+    return response
+```
+
+`WriterAgent.run` (L98-146) then merges `{**research_layout_content, "headers": headers}` — i.e. the
+final artifact is: (planner's title) + (glue JSON: TOC/intro/conclusion/sources) + (the list of
+already-independently-written section bodies, assembled downstream by the publisher, not shown here but
+confirmed present as `multi_agents/agents/publisher.py`). The separation of concerns is total: **planner
+decides section names, N parallel section-sub-agents research+write+revise their own body independently,
+and a final pass writes only the connective tissue (title/TOC/intro/conclusion) around bodies it never
+touches.**
+
+---
+
+## 4. The transferable pattern, stripped of STORM/gpt-researcher specifics
+
+Distilling both systems down to what's actually load-bearing (present in both, independently arrived at):
+
+1. **A cheap, structural first pass produces a _slot list_, not prose.** STORM: markdown headers.
+   gpt-researcher: a JSON array of section-title strings (or a strict Pydantic list for the simpler path).
+   The slot list is generated from a _summary_ of the gathered material (STORM: perspective-guided
+   dialogue history; gpt-researcher: `initial_research`), not from raw unprocessed source dumps — the
+   planner sees a condensed signal, not everything the writer will later see.
+
+2. **The slot list is parsed into an addressable structure before writing starts** — STORM makes this a
+   real object tree (`ArticleSectionNode`, parent/children, `content=None` = "not yet written" is a first-class
+   state); gpt-researcher keeps it flatter (a list of strings) because its writer step doesn't need
+   nesting, only isolation.
+
+3. **Each slot's writer receives a _scoped_ view, not the whole plan.** STORM: `section_outline` is the
+   outline sliced to just that section's own subtree; `section_query` is that subtree's headers used only
+   to retrieve that section's own evidence. gpt-researcher: each section gets its own `GPTResearcher`
+   instance scoped to `query=subtopic`, told the `parent_query`/`main_topic` for framing but not shown
+   sibling bodies (only sibling _headers_, and only in the subtopic-report prompt path). **The writer never
+   receives the planner's private reasoning — only the resolved slot assignment plus enough shared context
+   (topic/title, and in gpt-researcher's case existing headers) to stay coherent with its neighbors.**
+
+4. **Slot-writing is embarrassingly parallel and mechanically enforced as such** — not an accident of
+   async code, but an explicit `ThreadPoolExecutor`/`asyncio.gather` fan-out with a fixed worker cap
+   (STORM `max_thread_num`, default 10). Both systems treat "no slot depends on another slot's finished
+   prose" as an architectural invariant, which is _what makes the parallelism safe_, not just fast.
+
+5. **A merge step reassembles the parts, and it is dumb by design.** STORM: `article.update_section(...)`
+   grafts each returned section markdown back onto the matching tree node — no LLM call, pure
+   string/tree surgery, only the citation index gets touched. gpt-researcher: the top-level `WriterAgent`
+   is explicitly barred from rewriting bodies (its prompt: _"Do not include headers in the results"_) — its
+   only creative job is the connective tissue (title, TOC, intro, conclusion) that references but never
+   duplicates the sections. The reassembly step is the one place structure and prose meet again, and both
+   systems keep the LLM's role there minimal and non-authoritative over content it didn't generate.
+
+6. **Decoupling is strong enough to survive a process boundary.** STORM literally writes the outline to a
+   flat file (`storm_gen_outline.txt`) and can resume article generation in a _separate CLI invocation_
+   that reloads it from disk. This is the strongest form of "planner and writer are different concerns" —
+   not just different function calls in one call stack, but different _stages of a job_ that don't need to
+   share a process, a context window, or even a wall-clock session.
+
+**Minimal contract, stripped to essence**: `plan(condensed_context) -> ordered_list[slot_id]`, then for
+each `slot_id` independently and in parallel: `write(slot_id, scoped_context(slot_id), shared_frame) ->
+content`, then `merge(ordered_list[(slot_id, content)]) -> final_artifact` where merge does no
+free-generation, only assembly + minimal connective glue. The planner never writes prose. The per-slot
+writer never sees other slots' prose while writing (STORM: literally cannot, no channel exists;
+gpt-researcher: is told not to duplicate other slots' headers, and is architecturally isolated as its own
+sub-agent instance). The merge step is prose-light and structure-heavy.
+
+---
+
+## 5. WR2 mapping
+
+Current WR2 shape (per the task brief): ONE Claude call produces the whole 7-9-slide carousel JSON
+(structure + copy + everything, in one shot), then a renderer routes slides to layouts. That single call
+is doing what STORM/gpt-researcher split into 2-3 stages plus a fan-out.
+
+### 5a. What maps to "planner"
+
+The **planner's job, by the STORM/gpt-researcher contract, is exactly: decide the slot list, not the
+prose that fills it.** For a WR2 carousel that's:
+
+- the narrative **arc** (Hook → Frame → Discovery → Closing, per the existing `wr2-storyboarder` agent
+  description — this agent already half-does this today, but currently in the same shot as the copy)
+- the **spine**: how many slides (4-10, bounded), and which slide is the hero
+- each slide's **role** (Hook / Frame / Discovery-N / Closing / elegant-close) — this is the WR2 analog of
+  STORM's `section_name` / gpt-researcher's `sections: [...]` string list
+- each slide's **layout family** assignment (a WR2-specific field neither STORM nor gpt-researcher has an
+  analog for, since they don't route to visual templates — this would be WR2's own addition to the slot
+  schema, decided at plan time because layout choice affects how much copy that slot can hold, i.e. the
+  planner needs to know the writer's budget before dispatching)
+- the **bullet-promise contract** per slot if the heading announces N items (Article 6.3 in the brand
+  constitution) — this is metadata _about_ the slot, decided before the slot's body copy exists, exactly
+  like STORM's `section_outline` string is metadata the writer receives, not writes.
+
+The planner does **not** write final heading/body copy — same as STORM's planner never writes `output.section`
+and gpt-researcher's `EditorAgent.plan_research` never writes body prose, only `title`+`sections`.
+
+### 5b. What maps to "writer"
+
+The **writer's job is: given one slide's role + its scoped context (brief facts relevant to THAT slide,
+not the whole brief), produce that slide's heading/body/image-prompt** — analogous to STORM's
+`generate_section(topic, section_name, information_table, section_outline, section_query)` or
+gpt-researcher's per-section `GPTResearcher(query=subtopic, parent_query=parent_query,
+report_type="subtopic_report")`.
+
+Concretely, per-slide fan-out would look like STORM's `ThreadPoolExecutor` loop: N slide-writer calls, one
+per planned slot, each receiving:
+
+- the slide's role + heading-intent (from the plan)
+- the slice of the brief relevant to that slide (STORM's `section_query`/`section_outline` scoping —
+  today WR2's storyboarder gets the WHOLE brief for ALL slides at once, which is the single-shot pattern
+  this research is meant to break)
+- the shared frame: topic, audience segment, voice register, the overall title/hook (so slides don't
+  contradict each other — this is gpt-researcher's `existing_headers` mechanism: give siblings' _headers_,
+  never their bodies)
+- NOT the other slides' body copy — exactly the isolation STORM enforces architecturally and
+  gpt-researcher enforces by convention.
+
+### 5c. The intermediate outline-object for a carousel
+
+Modeling directly on STORM's `ArticleSectionNode` tree (adapted: a carousel is flat/ordered, not deeply
+nested, so gpt-researcher's flatter `Subtopics` list is actually the closer shape) plus WR2's own
+slot-metadata needs:
+
+```json
+{
+  "topic": "PMK 37/2025 exemption threshold",
+  "arc": "hook-frame-discovery-closing",
+  "slides": [
+    {
+      "slot_id": 1,
+      "role": "hook",
+      "layout_family": "cover-statement",
+      "heading_intent": "the number everyone gets wrong",
+      "bullet_promise_n": null,
+      "body": null,
+      "hero": true,
+      "image_prompt": null
+    },
+    {
+      "slot_id": 2,
+      "role": "frame",
+      "layout_family": "context-bilingual",
+      "heading_intent": "what 'dikecualikan' actually means",
+      "bullet_promise_n": null,
+      "body": null,
+      "hero": false,
+      "image_prompt": null
+    },
+    {
+      "slot_id": 3,
+      "role": "discovery-1",
+      "layout_family": "bullet-list",
+      "heading_intent": "3 conditions that trigger the exemption",
+      "bullet_promise_n": 3,
+      "body": null,
+      "hero": false,
+      "image_prompt": null
+    },
+    {
+      "slot_id": 7,
+      "role": "closing",
+      "layout_family": "cta-statement",
+      "heading_intent": "what to check before you file",
+      "bullet_promise_n": null,
+      "body": null,
+      "hero": false,
+      "image_prompt": null
+    }
+  ]
+}
+```
+
+`body: null` here is the direct analog of STORM's `ArticleSectionNode.content = None` — an explicit,
+inspectable "not yet written" state on every slot, set once by the planner and filled in independently by
+N parallel writer calls, one per `slot_id`, each constrained to write only its own `body`/`heading`/
+`image_prompt` fields and forbidden from touching `role`/`layout_family`/`bullet_promise_n` (those are the
+planner's structural decisions, immutable inputs to the writer — same non-negotiable boundary as STORM's
+writer never altering `section_name` or tree shape, only `content`).
+
+The **merge step** (renderer routing slides to layouts, per WR2's existing architecture) stays exactly
+what it already is — pure assembly, no LLM — which already matches STORM's `article.update_section()` /
+gpt-researcher's publisher: the one part of WR2's current pipeline that's already correctly "dumb by
+design" per the pattern in §4.
+
+**What changes concretely if WR2 adopts this**: today's ONE Claude call becomes 1 planner call (small,
+cheap, JSON-schema-constrained like gpt-researcher's `Subtopics`) + up to 9 parallel writer calls (each
+scoped only to its slide, cheap individually, running concurrently the way STORM's
+`ThreadPoolExecutor(max_workers=N)` does) + the existing deterministic renderer merge. This buys: (a) each
+writer call can retry/regenerate independently without regenerating the whole carousel (STORM's
+resumability-from-disk benefit, scaled down to "resumability per slide"); (b) `wr2-critic`'s retry-feedback
+loop (which today has to reason about the whole 7-9-slide JSON at once) could target individual `slot_id`s
+for re-write, the same way gpt-researcher's `reviewer`→`reviser` sub-loop operates per-section rather than
+on the whole report; (c) the bullet-promise-rule and layout-budget constraints become plan-time decisions
+the writer is handed rather than something the single mega-call has to self-enforce across 9 slides
+simultaneously, which is exactly the kind of cross-cutting consistency failure a single-shot generation is
+structurally worst at (WR2's own scars — Article 6.3 bullet-promise violations, §"WR2 slide-7 closer
+statement-bomb" in memory — are precisely the failure mode this pattern is designed to prevent, by making
+each slot's contract explicit and separately verifiable before prose exists).

--- a/.claude/skills/wr2/_research/2026-07-21-oss-code-reading-typed-pydantic-instructor.md
+++ b/.claude/skills/wr2/_research/2026-07-21-oss-code-reading-typed-pydantic-instructor.md
@@ -1,0 +1,678 @@
+# Real-code survey: schema-constrained / discriminated-union generation
+
+Method: every file below was fetched from GitHub via `gh api repos/<owner>/<repo>/contents/<path>`
+(base64-decoded), or is the actual installed package on disk (`pydantic==2.13.4` in
+`/Users/balizero/.local/share/mise/installs/python/3.11.15/lib/python3.11/site-packages/pydantic/`).
+The pydantic discriminated-union recipe was additionally **executed locally** (not just read) to
+prove the exact error text a retry loop would see. HEAD SHAs captured 2026-07-21.
+
+## 1. Verification table
+
+| Library                             | Org (verified)                                                                     | ✅/❌ | Files actually read                                                                                                                                                                                                                                                                   | License    | HEAD SHA                                   |
+| ----------------------------------- | ---------------------------------------------------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------ |
+| **instructor**                      | `567-labs/instructor` (moved from `jxnl/instructor`, confirmed via `gh repo view`) | ✅    | `instructor/v2/core/retry.py` (544 lines), `instructor/v2/core/response.py` (560), `instructor/v2/core/registry.py` (379), `instructor/v2/providers/anthropic/handlers.py` (932), `instructor/v2/core/json.py` (JSON-extraction helpers), `docs/concepts/unions.md`                   | MIT        | `47fdb2ca07119d389a3c0e8bc28b9930b814f294` |
+| **outlines**                        | `dottxt-ai/outlines`                                                               | ✅    | `src/outlines/backends/outlines_core.py` (294), `src/outlines/backends/base.py`, `src/outlines/processors/base_logits_processor.py` (137), `src/outlines/types/json_schema_utils.py` (197), `src/outlines/types/dsl.py` (1013, skimmed)                                               | Apache-2.0 | `cb095ba70fbd5bde4f612c4a996631f00834c7ba` |
+| **pydantic** (discriminated unions) | `pydantic/pydantic`                                                                | ✅    | `docs/concepts/unions.md` (617 lines, real doc matching installed v2.13 — has a `version-added v2.13` marker confirming version match) + local `pydantic/fields.py` (`discriminator` kwarg, lines 79/134/938.../1235) + **empirically executed** against installed `pydantic==2.13.4` | MIT        | `2294b52862478f3ef0fa0afd3cfdc9acba3881b0` |
+| **BAML** (optional)                 | `BoundaryML/baml`                                                                  | ✅    | `engine/baml-lib/jsonish/README.md`, `engine/baml-lib/jsonish/src/deserializer/coercer/coerce_union.rs` (full file, ~140 lines)                                                                                                                                                       | Apache-2.0 | `be5e7cd57b4768da2ad40a3d65ec7340f4de902f` |
+
+Local install confirmed: `pip show pydantic` → `Version: 2.13.4`, `Location:
+/Users/balizero/.local/share/mise/installs/python/3.11.15/lib/python3.11/site-packages`.
+`instructor` and `outlines` are **not** installed in this environment (`pip show` returned
+nothing, `find / -iname "*instructor*"/"*outlines*"` found nothing) — their code was read
+exclusively from GitHub, never fabricated.
+
+**Naming note (important, self-correcting):** the task description said instructor's retry loop
+lives in `instructor/retry.py` / `process_response.py`. That was true of instructor v1. The
+current `main` branch has migrated to a `v2/` architecture with a registry-of-handlers pattern —
+`instructor/core/retry.py` and `instructor/processing/schema.py` etc. now exist only as
+3-line **compatibility re-export shims** (`from instructor.v2.core.retry import *`) pointing at
+`instructor/v2/core/retry.py`, `instructor/v2/core/response.py`, `instructor/v2/providers/<provider>/handlers.py`.
+I read the actual v2 files, not the shims, and the code below is against them.
+
+---
+
+## 2. The discriminated-union generation pattern, in real code
+
+### 2a. DECLARE — N shapes as a tagged union (pydantic, real doc example, path `docs/concepts/unions.md:195-232`)
+
+```python
+from typing import Literal
+from pydantic import BaseModel, Field, ValidationError
+
+
+class Cat(BaseModel):
+    pet_type: Literal['cat']
+    meows: int
+
+
+class Dog(BaseModel):
+    pet_type: Literal['dog']
+    barks: float
+
+
+class Lizard(BaseModel):
+    pet_type: Literal['reptile', 'lizard']
+    scales: bool
+
+
+class Model(BaseModel):
+    pet: Cat | Dog | Lizard = Field(discriminator='pet_type')
+    n: int
+```
+
+instructor's own docs (`docs/concepts/unions.md` in the instructor repo, not pydantic's) show the
+identical pattern used directly as the `response_model`:
+
+```python
+from typing import Literal, Union
+from pydantic import BaseModel
+import instructor
+
+
+class UserQuery(BaseModel):
+    type: Literal["user"]
+    username: str
+
+
+class SystemQuery(BaseModel):
+    type: Literal["system"]
+    command: str
+
+
+Query = Union[UserQuery, SystemQuery]
+
+client = instructor.from_provider("openai/gpt-4.1-mini")
+response = client.create(
+    response_model=Query,
+    messages=[{"role": "user", "content": "Parse: user lookup jsmith"}],
+)
+```
+
+Note instructor's doc uses `Union[A, B]` _without_ an explicit `Field(discriminator=...)` — it
+relies on Pydantic's **smart-union** mode (tries each member, picks the best match) rather than a
+tag lookup. For >2-3 members or when shapes overlap, pydantic's own docs recommend the explicit
+`discriminator=` form because smart-union is O(n) trial-validation and can pick the wrong member on
+ambiguous input; tag-based dispatch is O(1) and unambiguous. **For WR2's 7-way union, use explicit
+`discriminator=`, not bare `Union[...]`.**
+
+### 2b. VALIDATE — a raw JSON string, empirically run against the exact WR2 shape
+
+I did not just read this pattern — I **executed it** against the real installed `pydantic==2.13.4`
+to see the actual validation-error text a retry loop would receive:
+
+```python
+from typing import Literal, Union, Annotated, List
+from pydantic import BaseModel, Field, ValidationError, TypeAdapter
+
+class ProseSlide(BaseModel):
+    kind: Literal["prose"]
+    heading: str
+    body: str
+
+class StatementSlide(BaseModel):
+    kind: Literal["statement"]
+    statement: str
+
+class FactStackSlide(BaseModel):
+    kind: Literal["fact_stack"]
+    heading: str
+    facts: List[str]
+
+Slide = Annotated[
+    Union[ProseSlide, StatementSlide, FactStackSlide],
+    Field(discriminator="kind"),
+]
+
+class Carousel(BaseModel):
+    slides: List[Slide]
+```
+
+Good input parses to the right concrete classes:
+
+```
+>>> Carousel.model_validate_json('{"slides": [{"kind":"prose","heading":"H","body":"B"}, ...]}')
+GOOD PARSE: ['ProseSlide', 'StatementSlide', 'FactStackSlide']
+```
+
+Bad input (missing field + unknown tag) produces this **real, observed** error — this is the exact
+string you'd feed back to the LLM:
+
+```
+2 validation errors for Carousel
+slides.0.prose.body
+  Field required [type=missing, input_value={'kind': 'prose', 'heading': 'H'}, input_type=dict]
+    For further information visit https://errors.pydantic.dev/2.13/v/missing
+slides.1
+  Input tag 'unknown_shape' found using 'kind' does not match any of the expected tags: 'prose', 'statement', 'fact_stack' [type=union_tag_invalid, input_value={'kind': 'unknown_shape', 'x': 1}, input_type=dict]
+    For further information visit https://errors.pydantic.dev/2.13/v/union_tag_invalid
+```
+
+Two properties matter for the retry loop:
+
+1. **Per-item location** (`slides.0.prose.body`, `slides.1`) — the LLM can be told _which slide,
+   which shape, which field_ is wrong, not just "invalid JSON".
+2. **Legal-tag enumeration on a bad discriminator** (`does not match any of the expected tags:
+'prose', 'statement', 'fact_stack'`) — pydantic itself lists your 7 valid `kind` values in the
+   error, which is free prompt material for the reask message.
+
+### 2c. RETRY — instructor's real retry loop feeding the ValidationError back
+
+This is the mechanism instructor actually ships, read verbatim from
+`instructor/v2/core/retry.py` (567-labs/instructor, MIT, SHA `47fdb2c`):
+
+```python
+_RETRYABLE_PARSE_ERRORS = (
+    ValidationError,
+    json.JSONDecodeError,
+    AsyncValidationError,
+    ResponseParsingError,
+)
+
+def retry_sync_v2(func, response_model, provider, mode, context, max_retries,
+                   args, kwargs, strict, hooks=None) -> T_Model:
+    ...
+    handlers = mode_registry.get_handlers(provider, mode)
+    max_retries_instance = Retrying(
+        stop=stop_after_attempt(max(max_retries, 0) + 1),
+        retry=retry_if_exception_type(_RETRYABLE_PARSE_ERRORS),
+        reraise=True,
+    )
+    ...
+    for attempt in max_retries_instance:
+        with attempt:
+            response = func(*args, **kwargs)          # call the LLM
+            ...
+            try:
+                parsed = handlers.response_parser(      # parse+validate raw text
+                    response=response,
+                    response_model=response_model,
+                    validation_context=context,
+                    strict=strict,
+                    stream=stream,
+                    is_async=False,
+                )
+                return _finalize_parsed_response(parsed, response)   # SUCCESS -> return
+            except _RETRYABLE_PARSE_ERRORS as e:
+                failed_attempts.append(FailedAttempt(attempt_number, e, response))
+                kwargs = handlers.reask_handler(          # build the NEXT prompt
+                    kwargs=kwargs, response=response, exception=e,
+                )
+                raise   # tenacity catches this -> loops to next attempt with new kwargs
+```
+
+`tenacity` (a normal PyPI retry library, not Anthropic-SDK-specific) drives the loop;
+`handlers.response_parser` and `handlers.reask_handler` are the two swappable functions per
+provider/mode. The provider-specific implementation that matters for a **CLI-shelled-out, raw-text**
+setup is `AnthropicJSONHandler` in `instructor/v2/providers/anthropic/handlers.py:631-759`
+(same repo, same SHA):
+
+```python
+class AnthropicJSONHandler(AnthropicHandlerBase):
+    mode = Mode.JSON
+
+    def handle_reask(self, kwargs, response, exception) -> dict[str, Any]:
+        kwargs = kwargs.copy()
+        text_blocks = [c for c in response.content if c.type == "text"]
+        text_content = text_blocks[-1].text if text_blocks else "No text content found in response"
+        reask_msg = {
+            "role": "user",
+            "content": (
+                "Validation Errors found:\n"
+                f"{exception}\nRecall the function correctly, fix the errors found in "
+                f"the following attempt:\n{text_content}"
+            ),
+        }
+        kwargs["messages"].append(reask_msg)
+        return kwargs
+
+    def _parse_json_response(self, response, response_model, validation_context, strict):
+        ...
+        extra_text = extract_json_from_codeblock(text)   # <-- works on RAW TEXT, no SDK object needed
+        if strict:
+            return response_model.model_validate_json(extra_text, context=validation_context, strict=strict)
+        parsed = json.loads(extra_text, strict=False)
+        return response_model.model_validate(parsed, context=validation_context, strict=strict)
+```
+
+`extract_json_from_codeblock` (`instructor/v2/core/json.py`, same repo) is the single most
+directly liftable function for our case — it takes an arbitrary text blob (markdown fences,
+reasoning preamble, anything) and returns **the last balanced `{...}`/`[...]` span that parses as
+valid JSON** — with a documented security rationale:
+
+```python
+def extract_json_from_codeblock(content: str) -> str:
+    """Extract the last JSON object- or array-like span from a text block.
+
+    Returns the LAST complete JSON object, not the first. The LLM's own
+    structured output is the authoritative JSON and appears last; JSON that
+    appeared earlier may have originated from user input embedded in the
+    prompt and was referenced in the model's reasoning. Returning the first
+    object allowed prompt-injection to hijack the parsed output.
+    """
+    candidates: list[str] = []
+    search_index = 0
+    while search_index < len(content):
+        start_index = next((i for i in range(search_index, len(content))
+                             if content[i] in "{["), None)
+        if start_index is None:
+            break
+        start_char = content[start_index]
+        end_stack = ["}" if start_char == "{" else "]"]
+        in_string = False
+        escape_next = False
+        candidate_found = False
+        for end_index in range(start_index + 1, len(content)):
+            char = content[end_index]
+            if escape_next:
+                escape_next = False
+            elif char == "\\" and in_string:
+                escape_next = True
+            elif char == '"':
+                in_string = not in_string
+            if in_string:
+                continue
+            if char in "{[":
+                end_stack.append("}" if char == "{" else "]")
+                continue
+            if end_stack and char == end_stack[-1]:
+                end_stack.pop()
+                if not end_stack:
+                    candidate = content[start_index:end_index + 1]
+                    try:
+                        json.loads(candidate)
+                    except Exception:
+                        break
+                    candidates.append(candidate)
+                    search_index = end_index + 1
+                    candidate_found = True
+                    break
+        if not candidate_found:
+            search_index = start_index + 1
+    return candidates[-1] if candidates else content
+```
+
+Put together, instructor's whole "works on raw JSON string" chain is:
+**raw CLI stdout text → `extract_json_from_codeblock` → `json.loads` → `Model.model_validate` →
+on `ValidationError`, string-format the error + append the previous raw text as a `user` message
+→ call the LLM again → repeat up to N times (tenacity `stop_after_attempt`).**
+None of it touches the Anthropic SDK object model — `response.content[...].type == "text"` is the
+only Anthropic-shaped bit, and even that is trivially replaced by "the CLI's stdout string" in our
+case.
+
+---
+
+## 3. Grammar-level constraint (outlines) — what it guarantees, and why we can't use it
+
+outlines (dottxt-ai/outlines, Apache-2.0, SHA `cb095ba7`) does NOT validate-after-the-fact. It
+compiles the JSON Schema into a **regex**, the regex into a **finite-state machine (`Index`)** over
+the model's actual token vocabulary, and then masks the logits **at every single decoding step** so
+the sampler is physically unable to emit a token that would violate the schema.
+
+`src/outlines/backends/outlines_core.py` (real code):
+
+```python
+from outlines_core import Guide, Index, Vocabulary
+from outlines_core.json_schema import build_regex_from_schema
+
+class OutlinesCoreBackend(BaseBackend):
+    def get_json_schema_logits_processor(self, json_schema: str, whitespace_pattern=None):
+        regex = build_regex_from_schema(json_schema, whitespace_pattern)   # JSON Schema -> regex
+        return self.get_regex_logits_processor(regex)
+
+    def get_regex_logits_processor(self, regex: str):
+        index = Index(regex, self.vocabulary)         # regex -> FSM compiled over the token vocab
+        return OutlinesCoreLogitsProcessor(index, self.tensor_library_name)
+
+
+class OutlinesCoreLogitsProcessor(OutlinesLogitsProcessor):
+    def _setup(self, batch_size, vocab_size):
+        ...
+        self._guides = [Guide(self.index) for _ in range(batch_size)]     # one FSM state-tracker per sequence
+        self._bitmasks = [self.allocate_token_bitmask(vocab_size) for _ in range(batch_size)]
+
+    def process_logits(self, input_ids, logits):
+        if self.is_first_token:
+            self._setup(batch_size, vocab_size)
+        else:
+            for i in range(batch_size):
+                last_token_id = ...
+                self._guides[i].advance(token_id=last_token_id, ...)      # advance FSM state by the token just sampled
+        return self.bias_logits(batch_size, logits)                       # mask disallowed tokens to -inf BEFORE sampling
+
+    def _bias_logits_torch(self, batch_size, logits):
+        for i in range(batch_size):
+            fill_next_token_bitmask(self._guides[i], self._bitmasks[i])   # which tokens are FSM-legal right now?
+            apply_token_bitmask_inplace(logits[i], self._bitmasks[i])     # zero out everything else
+        return logits
+```
+
+`src/outlines/processors/base_logits_processor.py` shows this is wired in as a HuggingFace/vLLM/
+llama.cpp-style `LogitsProcessor` — a callback invoked by the model's own decoding loop on **every**
+generated token, not something bolted on after generation. This is why it's called "grammar-level
+enforcement" — the LLM is **structurally incapable** of producing an invalid token at any position,
+as opposed to instructor, which lets the LLM emit whatever it wants and then rejects/retries.
+
+For unions specifically: `src/outlines/types/json_schema_utils.py` turns a JSON-Schema `anyOf`/type-
+list into a Python `Union[...]` (and, via `build_regex_from_schema`, into a regex alternation `(A|B|C)`
+at the FSM level) — so a 7-way discriminated union becomes 7 alternative regex branches the FSM can
+walk, and the sampler can only ever complete one of them. Real excerpt:
+
+```python
+# src/outlines/types/json_schema_utils.py
+if isinstance(t, list):
+    # JSON Schema allows ``type`` to be a list of type names, e.g. the
+    # common nullable form ``["string", "null"]``. Map each member to a
+    # Python type and combine them into a Union (mirroring the ``anyOf``
+    # the regex backend uses for type arrays).
+    members = tuple(schema_type_to_python({**schema, "type": member}, caller_target_type) for member in t)
+    return Union[members] if members else Any
+```
+
+**Why we cannot use this**: it requires **white-box access to per-token logits** — it only works
+against `Transformers`, `LlamaCpp`, or `MLXLM` model objects that outlines drives directly in-process
+(`src/outlines/backends/outlines_core.py` imports `outlines.models.llamacpp.LlamaCpp`,
+`outlines.models.mlxlm.MLXLM`, `outlines.models.transformers.Transformers` — all local, in-process
+model wrappers with logits access). The `claude` CLI is a black box: we get finished stdout text, no
+logits, no per-token callback hook, no ability to bias sampling. There is no "outlines but for a
+subprocess" mode — the guarantee outlines makes is fundamentally a decoding-time property that only
+the entity actually running the forward pass can enforce.
+
+---
+
+## 4. BAML's schema-aligned recovery (optional target) — a third, different mechanism
+
+BoundaryML/baml (Apache-2.0, SHA `be5e7cd5`) ships a Rust deserializer called **jsonish**
+(`engine/baml-lib/jsonish/`) that is neither "validate then retry" (instructor) nor "constrain
+during decode" (outlines). It is **best-effort schema-aligned coercion of a single, possibly-broken
+LLM text response**, with no second LLM call required. Its own README states the contract:
+
+```
+pub fn from_str(
+    of: &OutputFormatContent,
+    target: &FieldType,
+    raw_string: &str,
+    allow_partials: bool,
+) -> Result<BamlValueWithFlags>
+```
+
+> "It provides a guarantee that the schema is able to be flexibly parsed out from the input.
+> Some scenarios include: Finding objects when there is prefixing and post fixed text. Parsing in
+> field names with aliases. Casting to the right type. Wrapping around arrays when necessary.
+> Obeying constraints."
+
+For unions specifically, `coerce_union.rs::coerce_union()` (full real function read) tries **every
+variant** of the union against the parsed-but-imperfect value, scores each attempt (0 = perfect
+match), and short-circuits on the first perfect score; otherwise it calls `array_helper::pick_best`
+to choose the least-bad candidate:
+
+```rust
+pub(super) fn coerce_union(ctx, union_target, value) -> Result<BamlValueWithFlags, ParsingError> {
+    let all_options = options.iter_include_null();
+    let mut parsed: Vec<Result<BamlValueWithFlags, ParsingError>> = Vec::new();
+    let mut best_score = i32::MAX;
+
+    for (i, option) in all_options.iter().enumerate() {
+        let result = option.coerce(ctx, union_target, value);
+        if let Ok(mut val) = result {
+            let score = val.score();
+            if score == 0 {
+                val.add_flag(Flag::UnionMatch(i, vec![]));
+                return Ok(val);          // perfect match on this variant -> done, no retry needed
+            }
+            if score < best_score { best_score = score; }
+            parsed.push(Ok(val));
+        } else {
+            parsed.push(result);
+        }
+    }
+    array_helper::pick_best(ctx, union_target, &parsed)   // otherwise pick least-bad variant
+}
+```
+
+There's also a `union_variant_hint` optimization for **arrays of unions** (exactly our shape — a
+list of 7-typed slides): if the previous array element matched variant index `i`, it tries variant
+`i` first on the next element, on the (correct) assumption that carousels/lists tend to be
+locally homogeneous in shape. This is a nice, liftable _heuristic_ even outside BAML: order your
+Pydantic union members by "what the last slide was" as a soft hint, though Pydantic's own
+discriminator dispatch is O(1) by tag so the hint mostly saves nothing there — it matters more for
+BAML/jsonish because coercion there is a trial-based score, not a tag lookup.
+
+**Why this is interesting but not directly liftable**: this is a ~140-line snippet inside a large
+Rust crate (`baml-lib/jsonish`) that is part of a full compiler/runtime (BAML has its own DSL, code-
+gen, and Python/TS client bindings) — there's no standalone pip-installable "just the flexible
+parser" story without pulling in the whole BAML toolchain. It's real, it's read, but "lift the
+pattern" here means "replicate the _idea_ (score every union-variant coercion, prefer perfect
+matches, degrade gracefully to best-effort)" in Python, not literally reuse the code.
+
+---
+
+## 5. The minimal liftable recipe for WR2
+
+Grounded directly in the real code above (instructor's retry architecture + reask-message format +
+`extract_json_from_codeblock`, plus the empirically-verified pydantic discriminated-union pattern).
+This works entirely on **the `claude` CLI's raw stdout text** — no Anthropic SDK, no per-token
+access, nothing instructor/outlines/BAML themselves would need to be `pip install`ed for (though
+`pip install instructor` just for `extract_json_from_codeblock` + the JSON-mode reask-message
+string is defensible too, since it's MIT and provider-agnostic on the parsing side).
+
+```python
+"""wr2_slide_schema.py — discriminated-union slide contract + validate-and-retry
+against the `claude` CLI. Pattern lifted from:
+  - instructor v2 AnthropicJSONHandler.handle_reask / _parse_json_response
+    (github.com/567-labs/instructor, instructor/v2/providers/anthropic/handlers.py)
+  - instructor v2 extract_json_from_codeblock (instructor/v2/core/json.py)
+  - pydantic Field(discriminator=...) tagged unions (docs.pydantic.dev/concepts/unions,
+    empirically verified against installed pydantic==2.13.4)
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Annotated, List, Literal, Union
+
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+
+
+# --- 2a. DECLARE the 7 slide shapes as a tagged union ------------------------
+
+class ProseSlide(BaseModel):
+    kind: Literal["prose"]
+    heading: str
+    body: str
+
+class StatementSlide(BaseModel):
+    kind: Literal["statement"]
+    statement: str
+
+class FactStackSlide(BaseModel):
+    kind: Literal["fact_stack"]
+    heading: str
+    facts: List[str]
+
+class QaDialogueSlide(BaseModel):
+    kind: Literal["qa_dialogue"]
+    question: str
+    answer: str
+
+class StatusListSlide(BaseModel):
+    kind: Literal["status_list"]
+    heading: str
+    items: List[str]
+
+class TimelineSlide(BaseModel):
+    kind: Literal["timeline"]
+    heading: str
+    steps: List[str]
+
+class StatCardSlide(BaseModel):
+    kind: Literal["stat_card"]
+    stat: str
+    label: str
+
+class CtaSlide(BaseModel):
+    kind: Literal["cta"]
+    heading: str
+    action: str
+
+Slide = Annotated[
+    Union[
+        ProseSlide, StatementSlide, FactStackSlide, QaDialogueSlide,
+        StatusListSlide, TimelineSlide, StatCardSlide, CtaSlide,
+    ],
+    Field(discriminator="kind"),
+]
+
+SlideList = TypeAdapter(List[Slide])
+
+
+# --- 2b/2c. extract-JSON-from-free-text + VALIDATE + RETRY loop -------------
+# extract_json_from_codeblock: ported verbatim from instructor/v2/core/json.py
+# (MIT-licensed, small, self-contained — the one function actually worth
+#  copying wholesale rather than depending on the instructor package).
+
+def extract_json_from_codeblock(content: str) -> str:
+    candidates: list[str] = []
+    search_index = 0
+    while search_index < len(content):
+        start_index = next(
+            (i for i in range(search_index, len(content)) if content[i] in "{["), None
+        )
+        if start_index is None:
+            break
+        start_char = content[start_index]
+        end_stack = ["}" if start_char == "{" else "]"]
+        in_string = False
+        escape_next = False
+        candidate_found = False
+        for end_index in range(start_index + 1, len(content)):
+            char = content[end_index]
+            if escape_next:
+                escape_next = False
+            elif char == "\\" and in_string:
+                escape_next = True
+            elif char == '"':
+                in_string = not in_string
+            if in_string:
+                continue
+            if char in "{[":
+                end_stack.append("}" if char == "{" else "]")
+                continue
+            if end_stack and char == end_stack[-1]:
+                end_stack.pop()
+                if not end_stack:
+                    candidate = content[start_index:end_index + 1]
+                    try:
+                        json.loads(candidate)
+                    except Exception:
+                        break
+                    candidates.append(candidate)
+                    search_index = end_index + 1
+                    candidate_found = True
+                    break
+        if not candidate_found:
+            search_index = start_index + 1
+    return candidates[-1] if candidates else content
+
+
+def call_claude_cli(prompt: str) -> str:
+    """Our sanctioned path: shell out to `claude`, MAX-plan OAuth quota.
+    Never anthropic.Anthropic(api_key=...) — see CLAUDE.md §5."""
+    result = subprocess.run(
+        ["claude", "--print"],
+        input=prompt,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def generate_slides(prompt: str, max_retries: int = 3) -> List[Slide]:
+    """instructor's retry_sync_v2 shape, minus tenacity/registry machinery,
+    minus any SDK object — works on a raw text string from the CLI."""
+    messages_context = prompt
+    last_raw_text = ""
+
+    for attempt in range(1, max_retries + 1):
+        raw_text = call_claude_cli(messages_context)
+        last_raw_text = raw_text
+        json_str = extract_json_from_codeblock(raw_text)
+
+        try:
+            slides = SlideList.validate_json(json_str)
+            return slides                              # SUCCESS
+        except (ValidationError, json.JSONDecodeError) as e:
+            if attempt == max_retries:
+                raise
+            # instructor's AnthropicJSONHandler.handle_reask, adapted to plain text:
+            messages_context = (
+                f"{prompt}\n\n"
+                "Your previous attempt failed validation.\n"
+                f"Validation errors found:\n{e}\n"
+                "Recall the schema and fix the errors found in the following attempt:\n"
+                f"{last_raw_text}"
+            )
+    raise RuntimeError("unreachable")
+```
+
+What each numbered piece maps to, concretely:
+
+- **2a** = the pydantic `Annotated[Union[...], Field(discriminator="kind")]` block — proven to
+  route on the `kind` tag and to raise `union_tag_invalid` with the full legal-tag list on a bad
+  tag (see §2b above, real output).
+- **2b** = `extract_json_from_codeblock` (verbatim port of instructor's real function) +
+  `SlideList.validate_json(...)` — the `TypeAdapter(List[Slide])` form (also empirically tested
+  above under "TypeAdapter direct on the union") is what you want when the top-level LLM output is
+  a bare JSON array of slides rather than a wrapper object.
+- **2c** = the retry-with-reask loop, structurally identical to `retry_sync_v2` in
+  `instructor/v2/core/retry.py` (try → validate → on `ValidationError` build a new prompt that
+  includes the error text + previous raw output → loop), but with `tenacity` and the
+  provider-handler-registry stripped out since we only ever have one "provider" (the CLI) and one
+  "mode" (raw JSON in free text) — instructor's registry indirection exists to support 40+
+  provider/mode combinations we don't have.
+
+---
+
+## 6. Honest caveat — what we can and cannot use
+
+**Cannot use (grammar-level / decode-time constraint, outlines-style):**
+
+- outlines' FSM/logits-bitmask mechanism requires being the process that runs the forward pass and
+  owns the logits tensor (`Transformers`/`LlamaCpp`/`MLXLM` model objects, `process_logits(input_ids,
+logits)` called every token). The `claude` CLI gives us finished stdout text and nothing else —
+  no token-level hook exists to intercept. There is no partial/adapted version of this technique for
+  a black-box subprocess; the guarantee ("every sampled token is schema-legal") is _definitionally_
+  a property of the sampler, not of anything downstream. This also rules out vLLM/TGI-style
+  structured-decoding backends (`llguidance`, `xgrammar` — both present as sibling backends in
+  `src/outlines/backends/`) for the same reason: they all bias logits pre-sampling inside the
+  inference server.
+- Anthropic's own hosted structured-output feature (seen referenced in
+  `instructor/v2/providers/anthropic/handlers.py:762` as `AnthropicStructuredOutputsHandler`, using
+  an `output_format` parameter) is the closest first-party equivalent for Claude specifically, but
+  it's an API-level feature reached through the Python SDK/HTTP API — not exposed through the
+  `claude` CLI's `--print` text mode, so it's in the same "cannot use" bucket for us right now.
+
+**Can use (post-hoc validation + retry, instructor-style — this is the one for WR2):**
+
+- Pydantic `Field(discriminator=...)` tagged unions: pure Python, zero dependency beyond pydantic
+  (already a project dependency), works on any JSON string from any source, gives precise
+  per-item/per-field error locations and enumerates legal discriminator tags on a bad tag — verified
+  empirically above.
+- instructor's retry-with-reask _shape_ (try → parse → validate → on failure, build a follow-up
+  prompt containing the exact validation error + the previous raw output → retry N times): this is
+  provider-agnostic in spirit even though instructor's own implementation is registry-dispatched
+  per SDK object type. We reimplement the ~30-line core loop directly against `claude` CLI stdout
+  (§5 above) rather than depending on the `instructor` package, since instructor's value-add
+  (39-provider dispatch, streaming, tool-call parsing) is all SDK-shaped scaffolding we don't need —
+  the part worth lifting is the _loop shape_ and the _reask message format_, both of which are
+  trivial to reproduce and don't require adding `instructor` (and transitively `openai`, its default
+  dependency) to the project.
+- `extract_json_from_codeblock`: small, self-contained, MIT, directly portable — worth copying
+  verbatim rather than re-deriving, since its "last balanced JSON span, not first" behavior encodes
+  a real security lesson (prompt-injection via earlier JSON in the text) that's easy to get wrong on
+  a first pass.
+- BAML's "score every union variant, take the best" _idea_ (not code) is a reasonable enhancement
+  if we ever get slides that are close-but-not-exact matches to a shape (e.g. a `fact_stack` with an
+  extra unexpected field) — Pydantic's discriminator dispatch is strict/exact on the tag, so a
+  scoring fallback pass is something to consider later if the retry loop proves too expensive in
+  practice, but it is not needed for a first implementation.


### PR DESCRIPTION
Design spec + real-code survey answering "vediamo il loro codice" for WR2's move from the fixed-pattern producer to a typed planner/writer editorial machine, grounded on WR2 file:line verified on disk + live DB.

This is a **docs-only artifact** — 4 new markdown files under `.claude/skills/wr2/_research/`, no production code, no schema, no runtime path touched. Consuming production surfaces: **none**.

Red-teamed by 2 independent graders (generator != grader): Sonnet with repo + live-DB access (verdict: SHIP-WITH-FIXES, all 4 file:line claims confirmed) and Kimi K3 cross-family (verdict: FLAWED-but-salvageable). All fixes from both rounds are integrated into the spec.

The BUILD itself is Zero-gated (Legge 5) — this PR proposes an architecture, it does not implement one. §8 of the spec calls out 4 decisions that need Zero's explicit ruling before build starts:
- the arc library (which narrative arcs get canonized)
- the caps-only-on-headings typographic rule
- the "The Bali Zero read" franchise slot
- palette rotation policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)