### PR TITLE
fix(mouth): kill /insights?tag= prompt-leak — render guard + robots + CI guard + pipeline hardening

### DIFF
--- a/.github/workflows/lint-content-reasoning-leak.yml
+++ b/.github/workflows/lint-content-reasoning-leak.yml
@@ -1,0 +1,51 @@
+name: Content lint — reasoning-leak in published MDX
+
+# Fails the PR if a content MDX file under apps/mouth/src/content/articles/
+# contains raw LLM chain-of-thought / translation-meta ("Thinking...",
+# "Wait, looking at the input:", "TESTO DA TRADURRE", "Output: ONLY the
+# translation"). Born from the 2026-07-21 "/insights?tag= prompt leak": an old
+# translation pipeline wrote a reasoning model's monologue into 20 *.id.mdx
+# files — into tags:/description: frontmatter AND body — and the contaminated
+# tags rendered as /insights?tag=<garbage> URLs Google crawled.
+#
+# Single source of truth: scripts/lint_content_reasoning_leak.py (self-contained,
+# ships a --selftest guilt+innocence corpus so the patterns can't silently rot).
+
+on:
+  pull_request:
+    paths:
+      - "apps/mouth/src/content/articles/**/*.mdx"
+      - "scripts/lint_content_reasoning_leak.py"
+      - ".github/workflows/lint-content-reasoning-leak.yml"
+
+concurrency:
+  group: lint-content-reasoning-leak-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Detect reasoning-leak in content MDX
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Self-test (guilt + innocence must both hold)
+        run: python scripts/lint_content_reasoning_leak.py --selftest
+
+      - name: Scan published content MDX
+        run: python scripts/lint_content_reasoning_leak.py
+
+      - name: Show fix guidance on failure
+        if: failure()
+        run: |
+          echo "::error::Raw LLM reasoning leaked into published content MDX."
+          echo "This is the 2026-07-21 /insights?tag= leak class. Do NOT hand-strip:"
+          echo "re-translate the affected article via the hardened pipeline"
+          echo "(scripts/translate-articles.py now refuses to write leaked output),"
+          echo "then re-run this lint locally: python scripts/lint_content_reasoning_leak.py"

--- a/apps/mouth/src/app/(blog)/[category]/[slug]/ArticleClient.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/[slug]/ArticleClient.tsx
@@ -521,7 +521,7 @@ export function ArticleClient({
                     {article.tags.map((tag) => (
                       <Link
                         key={tag}
-                        href={`/insights?tag=${tag}`}
+                        href={`/insights?tag=${encodeURIComponent(tag)}`}
                         className="px-3 py-1 rounded-full bg-white/5 text-white/70 text-sm hover:bg-white/10 hover:text-white transition-colors"
                       >
                         {tag}

--- a/apps/mouth/src/app/robots.ts
+++ b/apps/mouth/src/app/robots.ts
@@ -14,6 +14,13 @@ import type { MetadataRoute } from "next";
 const ALLOW = ["/", "/_next/static/", "/_next/image"];
 
 const DISALLOW = [
+  // Tag-filtered listing URLs (`/insights?tag=`, `/?tag=`) are duplicate-content
+  // parameter pages that nothing on the site actually consumes (no searchParams
+  // reader). They are pure crawl-budget waste — and the 2026-07-21 leak turned
+  // them into `/insights?tag=<raw-LLM-reasoning>` URLs Google indexed. Block the
+  // param outright; canonical content lives at the un-parametrised path.
+  "/*?tag=",
+  "/*&tag=",
   "/dashboard",
   "/clients",
   "/chat",

--- a/apps/mouth/src/lib/blog/articles.ts
+++ b/apps/mouth/src/lib/blog/articles.ts
@@ -84,14 +84,62 @@ function normalizeCategory(rawCategory: string): ArticleCategory {
  * wrapped). This is the single boundary where tags become iterable — every
  * downstream consumer (`.map`, `.length`, `[...tags]`) is then safe.
  */
+// Render-layer backstop for the 2026-07-21 "/insights?tag= prompt leak": an old
+// translation pipeline wrote raw LLM chain-of-thought into `tags:` frontmatter
+// ("Wait, the input text is:", "Input:", "Thinking..."). Those tags rendered as
+// `/insights?tag=<garbage>` links that Google crawled. The durable fixes are the
+// CI guard (scripts/lint_content_reasoning_leak.py) + content re-translation, but
+// this is the LAST boundary before a tag becomes a crawlable URL, so it drops any
+// unmistakable reasoning-leak tag and trims the title-split punctuation artefacts
+// ("unexpected:" -> "unexpected"). Conservative by design — legit multi-word tags
+// ("pt pma", "second home visa", "output vat") must survive (see articles.test.ts).
+const REASONING_LEAK_TAG = [
+  /(^|\W)(input|output)\s*:/i, // "Input:" / "Output:" (colon = the leak form; "output vat" is safe)
+  /(^|\W)wait\s*,/i, // "Wait, looking at the input..."
+  /\bthinking\.\.\./i,
+  /\bthe (input|source|original)\b/i,
+  /\blooking at the\b/i,
+  /\bword for word\b/i,
+  /\bno explanations?\b[\s.,:*]*(only|output|the translation)/i,
+  /\bas an ai\b/i,
+  /\brispondi solo\b/i,
+  /\btesto da tradurre\b/i,
+  /\*+\s*self[-\s]?correction/i,
+] as const;
+
+function isReasoningLeakTag(tag: string): boolean {
+  if (tag.length > 45) return true; // tags are short labels, not sentences
+  if (tag.trim().split(/\s+/).length >= 5) return true; // sentence-like
+  return REASONING_LEAK_TAG.some((rx) => rx.test(tag));
+}
+
+/** Strip title-split punctuation artefacts: "unexpected:" -> "unexpected". Keeps
+ *  internal apostrophes/hyphens/spaces ("tempeh's", "pt pma"). */
+function cleanTag(tag: string): string {
+  return tag
+    .replace(/^[\s"'*.:,;–—-]+/, "")
+    .replace(/[\s"'*.:,;–—-]+$/, "")
+    .trim();
+}
+
 export function normalizeTags(raw: unknown): string[] {
-  if (Array.isArray(raw)) {
-    return raw.filter((t): t is string => typeof t === "string");
+  const arr = Array.isArray(raw)
+    ? raw.filter((t): t is string => typeof t === "string")
+    : typeof raw === "string" && raw.trim().length > 0
+      ? [raw.trim()]
+      : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of arr) {
+    if (isReasoningLeakTag(t)) continue; // drop garbage before it can become a URL
+    const c = cleanTag(t);
+    if (!c) continue;
+    const key = c.toLowerCase();
+    if (seen.has(key)) continue; // de-dup after cleaning ("roots:" and "roots")
+    seen.add(key);
+    out.push(c);
   }
-  if (typeof raw === "string" && raw.trim().length > 0) {
-    return [raw.trim()];
-  }
-  return [];
+  return out;
 }
 
 /**

--- a/apps/mouth/src/lib/blog/normalize-tags.test.ts
+++ b/apps/mouth/src/lib/blog/normalize-tags.test.ts
@@ -69,4 +69,57 @@ describe("normalizeTags", () => {
       expect(() => out.join(",")).not.toThrow();
     }
   });
+
+  // ── 2026-07-21 "/insights?tag= prompt leak" regression guard ────────────
+  // An old translation pipeline wrote raw LLM chain-of-thought into `tags:`
+  // frontmatter; those tags rendered as /insights?tag=<garbage> URLs Google
+  // crawled. normalizeTags is the last boundary before a tag becomes a URL.
+
+  it("drops unmistakable reasoning-leak tags (guilt)", () => {
+    expect(
+      normalizeTags([
+        "immigration",
+        "Wait, the input text is:",
+        "Input:",
+        "Output: ONLY the translation",
+        "Thinking...",
+        "Wait, looking at the source:",
+        "The input has no MDX syntax (no #, **, [], etc), just new lines.",
+        "kitas",
+      ]),
+    ).toEqual(["immigration", "kitas"]);
+  });
+
+  it("keeps legit tags, incl. multi-word and vat-input/output (innocence)", () => {
+    expect(
+      normalizeTags([
+        "immigration",
+        "pt pma",
+        "second home visa",
+        "digital nomad",
+        "output vat", // "output" WITHOUT a colon is a real tax term
+        "input tax",
+        "bali_news",
+      ]),
+    ).toEqual([
+      "immigration",
+      "pt pma",
+      "second home visa",
+      "digital nomad",
+      "output vat",
+      "input tax",
+      "bali_news",
+    ]);
+  });
+
+  it("strips title-split punctuation artefacts and de-dups after cleaning", () => {
+    // Real EN source tags were title-word-split: ["unexpected:", "roots:"].
+    expect(normalizeTags(["unexpected:", "roots:", "tempeh's"])).toEqual([
+      "unexpected",
+      "roots",
+      "tempeh's",
+    ]);
+    // "roots:" cleans to "roots" — must not duplicate a bare "roots".
+    expect(normalizeTags(["roots:", "roots"])).toEqual(["roots"]);
+  });
 });

--- a/scripts/lint_content_reasoning_leak.py
+++ b/scripts/lint_content_reasoning_leak.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Fail CI when a content MDX file contains raw LLM reasoning/translation leak.
+
+WHY THIS EXISTS (scar 2026-07-21 — "the /insights?tag= prompt leak"):
+An OLD translation pipeline fed a reasoning model an *empty* source slot and
+wrote the model's raw chain-of-thought (``Thinking...``, ``*Self-correction:*``,
+``Wait, looking at the input:``) verbatim into 25 ``*.{id,fr,ru}.mdx`` files —
+into ``tags:``/``description:``/``answerSnippet`` frontmatter AND the body. The
+contaminated ``tags`` then rendered as ``/insights?tag=<garbage>`` links that
+Google crawled. Documentation did not stop it; this hook does (CLAUDE.md §7:
+"se una regola critica è violabile, scrivi un hook").
+
+WHAT IT DOES:
+Scans ``apps/mouth/src/content/articles/**/*.mdx`` for translation-reasoning
+leak markers. A match anywhere (frontmatter or body) fails the build so the
+file can never be committed/republished.
+
+DESIGN (scar #3 guard-over/under-match — match INTENT, test guilt AND
+innocence): markers are multi-word *translation-meta* phrases, never a bare
+substring like "wait" (legit prose says "Wait for your number to be called").
+Run ``--selftest`` to prove both guilt and innocence corpora.
+
+FAIL-VISIBLE (scar #2/W84 blind-scan): scanning zero files is exit 2, never a
+silent green.
+
+Usage:
+    python scripts/lint_content_reasoning_leak.py            # scan default dir
+    python scripts/lint_content_reasoning_leak.py --path P   # scan a path
+    python scripts/lint_content_reasoning_leak.py --selftest # guilt+innocence
+Exit: 0 clean · 1 leak(s) found · 2 nothing scanned (blind) · 3 selftest fail
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DIR = REPO_ROOT / "apps" / "mouth" / "src" / "content" / "articles"
+
+# Translation chain-of-thought / prompt-echo signatures. Every entry is a
+# multi-word phrase that a reasoning model emits when it narrates its own
+# translation process — NOT a word a real visa/tax/property article uses.
+# Case-insensitive. Keep each anchored enough that legit prose cannot trip it.
+_LEAK_PATTERNS: list[str] = [
+    r"\bthinking\.\.\.",                       # reasoning-model preamble
+    r"<think>",
+    # asterisk-emphasised form ONLY — reasoning models write ``*Self-correction:*``.
+    # Bare "Self-Correction" is a real tax concept (Pembetulan SPT) and must pass.
+    r"\*+\s*self[-\s]?correction",
+    r"\bwait,\s+(looking at|the input|the source|the original|the prompt|the user|i'?ll|let'?s|usually|if|is |\")",
+    r"\blooking at the (input|source|words|structure|original|prompt|text)\b",
+    r"\bthe (input|source) text is\b",
+    r"\bthe (input|source|original) is:\s*$",
+    r"\btranslate (it |them |word for word)",
+    r"\bif i translate\b",
+    r"\bonly the translation\b",
+    # translation-instruction form ONLY — must sit next to only/output/translation.
+    # Bare "with no explanation" is legit prose (bank-statement red flags etc.).
+    r"\bno explanations?\b[\s.,:*]*(only|output|response|just|the translation)",
+    r"\boutput\s*(format)?\s*:?\s*(\*?only\*?|no explanations)",
+    r"\brispondi solo con la traduzione\b",     # the Italian old-pipeline prompt
+    r"\btesto da tradurre\b",
+    r"\bthe user (provided|forgot|wants|asked|meant)\b",
+    r"\bthe prompt (says|is|ends|provided)\b",
+    r"\bas an ai\b",
+    r"\bi (cannot|can't) (translate|perform)\b",
+    r"\bre-?evaluate the input\b",
+    r"\bfinal check of the input\b",
+]
+
+_COMPILED = [re.compile(p, re.IGNORECASE) for p in _LEAK_PATTERNS]
+
+
+def scan_text(text: str) -> list[tuple[int, str, str]]:
+    """Return list of (line_no, matched_snippet, line) for every leak hit."""
+    hits: list[tuple[int, str, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        for rx in _COMPILED:
+            m = rx.search(line)
+            if m:
+                hits.append((i, m.group(0).strip(), line.strip()[:120]))
+                break  # one hit per line is enough to flag it
+    return hits
+
+
+def scan_file(path: Path) -> list[tuple[int, str, str]]:
+    try:
+        return scan_text(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError) as exc:  # unreadable = surface it
+        return [(0, f"<unreadable: {exc}>", "")]
+
+
+def iter_mdx(root: Path):
+    yield from sorted(root.rglob("*.mdx"))
+
+
+def run_scan(root: Path) -> int:
+    if not root.exists():
+        print(f"::error:: content path not found: {root}", file=sys.stderr)
+        return 2
+    files = list(iter_mdx(root))
+    if not files:
+        # blind-scan guard: zero files traversed is NOT a clean pass (W84).
+        print(f"::error:: no .mdx files under {root} — refusing silent green", file=sys.stderr)
+        return 2
+
+    leaked: dict[Path, list[tuple[int, str, str]]] = {}
+    for f in files:
+        hits = scan_file(f)
+        if hits:
+            leaked[f] = hits
+
+    if not leaked:
+        print(f"OK: {len(files)} content MDX scanned, zero reasoning-leak markers.")
+        return 0
+
+    total = sum(len(h) for h in leaked.values())
+    print(
+        f"REASONING-LEAK: {len(leaked)} file(s), {total} line(s) — raw LLM "
+        f"chain-of-thought/translation-meta leaked into published content.\n",
+        file=sys.stderr,
+    )
+    for f, hits in leaked.items():
+        rel = f.relative_to(REPO_ROOT) if REPO_ROOT in f.parents else f
+        for line_no, snippet, line in hits[:6]:
+            print(f"  {rel}:{line_no}: [{snippet}]  {line}", file=sys.stderr)
+        if len(hits) > 6:
+            print(f"  … +{len(hits) - 6} more in this file", file=sys.stderr)
+    return 1
+
+
+# ── Self-test: guilt AND innocence (scar #3) ────────────────────────────────
+
+_GUILTY = [
+    'description: "Thinking...\\nProfessional Translator (Italian/English)"',
+    '  - "Wait, the input text is:"',
+    '  - "Wait, looking at the source:"',
+    "  - Wait, the user provided them on separate lines.",
+    '  - "Input:"\n  - "Output: ONLY the translation."',
+    "*Self-correction:* If I respond saying please provide the text.",
+    "As an AI, I should wait for the text or indicate it is missing.",
+    "If I translate word for word with line breaks:",
+    "Rispondi SOLO con la traduzione.",
+]
+
+_INNOCENT = [
+    "- Wait for your number to be called at the immigration office.",
+    "- Waiting for investor KITAS sponsorship to be approved.",
+    "- Note: English support is limited, bring a translator.",
+    "The input VAT (PPN Masukan) can be credited against output VAT.",
+    "tags: [\"immigration\", \"kitas\", \"pt pma\", \"second home visa\"]",
+    "Gemini 3 shows strong native reasoning on math benchmarks.",  # tech article prose — see note
+    "Bali's zoning map decides where you can build.",
+    "## Facts\n\nIndonesia tightened passport rules in 2026.",
+    # real near-misses found on first live scan (2026-07-21) — must stay clear:
+    "| Self-correction (Pembetulan SPT) (Pasal 8(2)) | Reference rate + 0% |",
+    "## Voluntary Disclosure and Self-Correction",
+    "| Government correspondence | No, use professional translator | Formal Bahasa |",
+    "First, verify your NPWP status and confirm whether you meet the threshold.",
+]
+
+
+def selftest() -> int:
+    failed = False
+    for s in _GUILTY:
+        if not scan_text(s):
+            print(f"SELFTEST FAIL (guilt missed): {s!r}", file=sys.stderr)
+            failed = True
+    for s in _INNOCENT:
+        hits = scan_text(s)
+        if hits:
+            print(f"SELFTEST FAIL (innocent flagged): {s!r} -> {hits}", file=sys.stderr)
+            failed = True
+    if failed:
+        return 3
+    print(f"SELFTEST OK: {len(_GUILTY)} guilty caught, {len(_INNOCENT)} innocent cleared.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--path", default=str(DEFAULT_DIR), help="dir or file to scan")
+    ap.add_argument("--selftest", action="store_true", help="run guilt+innocence corpus")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    target = Path(args.path)
+    if target.is_file():
+        hits = scan_file(target)
+        if not hits:
+            print(f"OK: {target} clean.")
+            return 0
+        for line_no, snippet, line in hits:
+            print(f"  {target}:{line_no}: [{snippet}]  {line}", file=sys.stderr)
+        return 1
+    return run_scan(target)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/translate-articles.py
+++ b/scripts/translate-articles.py
@@ -103,6 +103,27 @@ def patch_frontmatter_locale(fm_block: str, locale: str) -> str:
     return fm_block.rstrip().rsplit("---", 1)[0] + f'locale: "{locale}"\n---\n'
 
 
+# Post-generation guard (scar 2026-07-21). The old pipeline wrote raw
+# reasoning-model chain-of-thought straight into 20 .id.mdx files (``Thinking...``,
+# ``Wait, looking at the input:``, ``TESTO DA TRADURRE``). ``think: false`` +
+# the "no preamble" prompt make that rare now, but a model can still ignore both
+# — so we REFUSE to write output that narrates its own translation process.
+_REASONING_LEAK_RE = re.compile(
+    r"thinking\.\.\.|<think>|\bwait,\s+(looking at|the input|the source|the original|the prompt)"
+    r"|\bthe (input|source) text is\b|\blooking at the (input|source|prompt|original)\b"
+    r"|\bonly the translation\b|\bno explanations?\b[\s.,:*]*(only|output|the translation)"
+    r"|\brispondi solo con la traduzione\b|\btesto da tradurre\b|\bas an ai\b"
+    r"|\*+\s*self[-\s]?correction|\bthe user (provided|forgot|wants|hasn'?t)\b",
+    re.IGNORECASE,
+)
+
+
+def looks_like_reasoning_leak(text: str) -> str | None:
+    """Return the offending snippet if the model leaked its reasoning, else None."""
+    m = _REASONING_LEAK_RE.search(text)
+    return m.group(0) if m else None
+
+
 def call_ollama(prompt: str, timeout: float = 1200) -> str:
     """Call Ollama chat API. Returns the generated text."""
     payload = {
@@ -208,6 +229,13 @@ def translate_article(article: dict, lang: str, force: bool, skip_existing: bool
 
     if not translated or len(translated) < 50:
         logger.error(f"  FAIL: Translation too short ({len(translated)} chars) for {slug}")
+        return False
+
+    leak = looks_like_reasoning_leak(translated)
+    if leak:
+        # Never persist chain-of-thought as an article (scar 2026-07-21). Fail
+        # loudly so a re-run/human handles it — do NOT write partial garbage.
+        logger.error(f"  FAIL: reasoning leak in output for {slug} [{leak!r}] — not written")
         return False
 
     # Build output


### PR DESCRIPTION
## The bug (Subhi's GSC audit, 2026-07-21)

Google crawled `/insights?tag=Input:` and `/insights?tag=Wait, the input text is:`. Root cause is **not** a tag generator — an **old** `scripts/translate-articles.py` (Italian-prompt reasoning model, fed an **empty** source slot) wrote its raw chain-of-thought (`Thinking...`, `TESTO DA TRADURRE`, `Wait, looking at the input:`) verbatim into **20 `apps/mouth/src/content/articles/**/*.id.mdx`** files — into `tags:`/`description:`/`answerSnippet` frontmatter AND body. The contaminated tags rendered as `/insights?tag=<garbage>` links.

Nothing on the site consumes `?tag=` (no `searchParams` reader) — these are dead duplicate-content param URLs.

## This PR = stop-the-bleed + prevention (content re-translation is a follow-up PR)

- **`normalizeTags` (articles.ts)** — the last boundary before a tag becomes a URL: drops unmistakable reasoning-leak tags **sitewide** and trims title-split punctuation (`unexpected:` → `unexpected`). Conservative: legit tags (`pt pma`, `output vat`, `input tax`) survive. +3 guilt/innocence vitest cases (**12/12 pass**).
- **`ArticleClient.tsx`** — `encodeURIComponent` on the tag href (defense in depth).
- **`robots.ts`** — `Disallow /*?tag=` + `/*&tag=` added to shared `DISALLOW` (every UA group inherits it).
- **`scripts/lint_content_reasoning_leak.py` + CI workflow** — fails the build if any content MDX contains reasoning-leak markers. Self-contained `--selftest` guilt+innocence corpus (9 guilty / 12 innocent). Catches all 20 live files; **zero false positives** (verified vs legit "Self-Correction"/Pembetulan SPT, "use professional translator", "with no explanation", "native reasoning").
- **`translate-articles.py`** — post-generation guard: REFUSE to write output that narrates its own translation process (the exact miss that produced the garbage).

## Follow-ups (not this PR)
- **PR2 (content)**: re-translate the 20 `.id.mdx` via the hardened pipeline + SEA-LION on Pro (Zero chose re-translate over quarantine). Then Subhi native-review.
- **GSC de-index** of already-crawled `/insights?tag=*` URLs — operator[GUI], owned by Subhi (has Search Console access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)