### PR TITLE
feat(wr2): typed Carousel IR + shadow-replay harness (editorial-intelligence Phase 1)

### DIFF
--- a/.github/workflows/wr2-queue-tests.yml
+++ b/.github/workflows/wr2-queue-tests.yml
@@ -22,12 +22,15 @@ on:
       - "scripts/wr2_queue_writer.py"
       - "scripts/wr2_rerender_local.py"
       - "scripts/wr2_html_renderer/**"
+      - "scripts/wr2_carousel_ir.py"
+      - "scripts/wr2_ir_shadow_replay.py"
       - "scripts/tests/test_wr2_queue_hygiene.py"
       - "scripts/tests/test_wr2_visibility_chain.py"
       - "scripts/tests/test_wr2_rerender_requeue.py"
       - "scripts/tests/test_wr2_queue_locking.py"
       - "scripts/tests/test_wr2_pipeline_consolidation.py"
       - "scripts/tests/test_wr2_daily_reconciler.py"
+      - "scripts/tests/test_wr2_carousel_ir.py"
       - "scripts/tests/conftest.py"
       - "apps/backend-rag/backend/services/canva_renderer_v2/_pg.py"
       - ".github/workflows/wr2-queue-tests.yml"
@@ -61,4 +64,5 @@ jobs:
             scripts/tests/test_wr2_queue_locking.py \
             scripts/tests/test_wr2_pipeline_consolidation.py \
             scripts/tests/test_wr2_daily_reconciler.py \
+            scripts/tests/test_wr2_carousel_ir.py \
             -q

--- a/scripts/tests/test_wr2_carousel_ir.py
+++ b/scripts/tests/test_wr2_carousel_ir.py
@@ -1,0 +1,430 @@
+"""Tests for wr2_carousel_ir.py — the typed Carousel IR (WR2 editorial-
+intelligence Phase 1, spec §2 "Mossa A").
+
+Four batteries:
+  - Guilt+innocence corpus for SlideDeck/Slide validation (guard-conformance
+    discipline — cicatrix-superscar.md family #3: no gate ships without
+    both a colpevolezza AND an innocenza case).
+  - extract_json_from_codeblock edges (ported from instructor v2, MIT).
+  - Projection: for EVERY one of the 11 kinds, to_composer_dict(...) ->
+    the REAL (imported, not reimplemented) composer.map_slide_to_family
+    resolves to the intended layout family. This is the core Phase-1
+    assertion — the whole point of the typed IR is that it reaches the 11
+    layouts the autonomous producer currently can't (spec §0.2).
+  - generate_slides_typed's validate-and-retry loop against a fake call_fn.
+
+No DB, no CLI subprocess, no network — wr2_carousel_ir.py has zero I/O side
+effects by design, so all but the smoke test in wr2_ir_shadow_replay.py run
+instantly and deterministically.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import wr2_carousel_ir as ir  # noqa: E402
+from wr2_html_renderer.composer import map_slide_to_family  # noqa: E402
+
+
+def _deck(slides: list[dict], register: str = "analitico") -> dict:
+    return {"register": register, "slides": slides}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Guilt corpus — payloads that MUST fail
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGuiltCorpus:
+    def test_unknown_kind_rejected(self):
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(_deck([{"kind": "bogus", "headline": "x"}]))
+
+    def test_missing_required_field_per_kind_rejected(self):
+        # prose requires `body` — absent here.
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(_deck([{"kind": "prose", "headline": "H"}]))
+
+    def test_empty_facts_list_rejected(self):
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(_deck([{"kind": "fact_stack", "heading": "H", "facts": []}]))
+
+    def test_qa_single_pair_rejected(self):
+        # qa-dialogue is a fixed 2-voice layout — 1 pair cannot fill it.
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(
+                _deck([{"kind": "qa", "pairs": [{"voice": "A", "line": "x"}]}])
+            )
+
+    def test_triad_single_item_rejected(self):
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(
+                _deck([{"kind": "triad", "heading": "H", "items": [{"title": "A", "desc": "a"}]}])
+            )
+
+    def test_status_list_empty_items_rejected(self):
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(_deck([{"kind": "status_list", "heading": "H", "items": []}]))
+
+    def test_timeline_empty_steps_rejected(self):
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(_deck([{"kind": "timeline", "heading": "H", "steps": []}]))
+
+    def test_citation_empty_sources_rejected(self):
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(
+                _deck([{"kind": "citation", "claim": "C", "sources": []}])
+            )
+
+    def test_kind_flip_mid_list_rejected(self):
+        """Second slide DECLARES kind=prose but only carries fact_stack-shaped
+        fields (heading/facts, no body) — kind and shape disagree, so the
+        REQUIRED `body` field for prose is missing."""
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(_deck([
+                {"kind": "cover", "headline": "OK COVER"},
+                {"kind": "prose", "heading": "H", "facts": ["a", "b"]},
+            ]))
+
+    def test_invalid_register_rejected(self):
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(
+                _deck([{"kind": "statement", "statement": "X"}], register="not-a-real-tone")
+            )
+
+    def test_empty_required_string_after_coercion_rejected(self):
+        # whitespace-only "statement" coerces to "" — still required content.
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(_deck([{"kind": "statement", "statement": "   "}]))
+
+    def test_wrong_type_for_list_field_rejected(self):
+        with pytest.raises(ValidationError):
+            ir.SlideDeck.model_validate(
+                _deck([{"kind": "fact_stack", "heading": "H", "facts": "not a list"}])
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Innocence corpus — edge-legit payloads that MUST pass
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestInnocenceCorpus:
+    def test_long_headline_truncated_not_rejected(self):
+        deck = ir.SlideDeck.model_validate(
+            _deck([{"kind": "prose", "headline": "X" * 300, "body": "body text"}])
+        )
+        assert len(deck.slides[0].headline) == 80
+
+    def test_long_body_truncated_not_rejected(self):
+        deck = ir.SlideDeck.model_validate(
+            _deck([{"kind": "prose", "headline": "H", "body": "Y" * 900}])
+        )
+        assert len(deck.slides[0].body) == 500
+
+    def test_long_cover_image_prompt_truncated_not_rejected(self):
+        deck = ir.SlideDeck.model_validate(
+            _deck([{"kind": "cover", "headline": "H", "image_prompt": "P" * 900}])
+        )
+        assert len(deck.slides[0].image_prompt) == 600
+
+    def test_missing_optional_subhead_defaults_empty(self):
+        deck = ir.SlideDeck.model_validate(_deck([{"kind": "prose", "headline": "H", "body": "b"}]))
+        assert deck.slides[0].subhead == ""
+
+    def test_unicode_content_passes(self):
+        deck = ir.SlideDeck.model_validate(_deck([
+            {
+                "kind": "prose",
+                "headline": "Perpres No. 5 — İstisna €",
+                "body": "Teks unicode berjalan lancar ✓ 日本語 test",
+            },
+        ]))
+        assert "İstisna" in deck.slides[0].headline
+        assert "日本語" in deck.slides[0].body
+
+    def test_extra_unknown_fields_tolerated(self):
+        deck = ir.SlideDeck.model_validate(_deck([
+            {"kind": "statement", "statement": "ZERO PENALTY", "totally_unexpected_field": {"nested": True}},
+        ]))
+        assert deck.slides[0].statement == "ZERO PENALTY"
+
+    def test_status_item_invalid_status_token_defaults_neutral(self):
+        deck = ir.SlideDeck.model_validate(_deck([
+            {
+                "kind": "status_list",
+                "heading": "H",
+                "items": [{"label": "A", "value": "B", "status": "not-a-real-status"}],
+            },
+        ]))
+        assert deck.slides[0].items[0].status == "neutral"
+
+    def test_mixed_kind_list_is_fine(self):
+        """A list with DIFFERENT kinds across slides is normal, not guilt —
+        each element validates independently against its own declared kind."""
+        deck = ir.SlideDeck.model_validate(_deck([
+            {"kind": "cover", "headline": "COVER"},
+            {"kind": "qa", "pairs": [{"voice": "A", "line": "q"}, {"voice": "B", "line": "a"}]},
+            {"kind": "statement", "statement": "DONE"},
+        ]))
+        assert [s.kind for s in deck.slides] == ["cover", "qa", "statement"]
+
+    def test_non_string_scalar_coerced_not_rejected(self):
+        # a number where a string was expected — lenient coercion, not a hard fail.
+        deck = ir.SlideDeck.model_validate(_deck([{"kind": "stat", "value": 2815}]))
+        assert deck.slides[0].value == "2815"
+
+    def test_triad_extra_items_within_cap_pass(self):
+        items = [{"title": f"T{i}", "desc": f"D{i}"} for i in range(5)]
+        deck = ir.SlideDeck.model_validate(_deck([{"kind": "triad", "heading": "H", "items": items}]))
+        assert len(deck.slides[0].items) == 5
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# extract_json_from_codeblock — ported from instructor v2 (MIT)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractJsonFromCodeblock:
+    def test_fenced_json_block(self):
+        raw = 'Here is your answer:\n```json\n{"a": 1}\n```\nThanks!'
+        assert ir.extract_json_from_codeblock(raw) == '{"a": 1}'
+
+    def test_fenced_block_no_json_tag(self):
+        raw = '```\n{"a": 1}\n```'
+        assert ir.extract_json_from_codeblock(raw) == '{"a": 1}'
+
+    def test_bare_json(self):
+        raw = '{"a": 1, "b": [1, 2, 3]}'
+        assert ir.extract_json_from_codeblock(raw) == raw
+
+    def test_prose_wrapped_json(self):
+        raw = "Sure, here you go: {\"a\": 1} — hope that helps!"
+        assert ir.extract_json_from_codeblock(raw) == '{"a": 1}'
+
+    def test_trailing_junk_after_json(self):
+        raw = '{"a": 1}\n\nEOF garbage garbage'
+        assert ir.extract_json_from_codeblock(raw) == '{"a": 1}'
+
+    def test_nested_braces_in_strings(self):
+        raw = '{"a": "text with { and } inside a string", "b": 2}'
+        result = ir.extract_json_from_codeblock(raw)
+        assert json.loads(result) == {"a": "text with { and } inside a string", "b": 2}
+
+    def test_escaped_quote_inside_string_does_not_confuse_scanner(self):
+        raw = r'{"a": "she said \"hi\" to {ignore this}"}'
+        result = ir.extract_json_from_codeblock(raw)
+        assert json.loads(result)["a"] == 'she said "hi" to {ignore this}'
+
+    def test_no_json_returns_content_unchanged(self):
+        raw = "no json here at all"
+        assert ir.extract_json_from_codeblock(raw) == raw
+
+    def test_realistic_wrapper_object(self):
+        raw = (
+            'Here is the deck:\n```json\n'
+            '{"register": "analitico", "slides": [{"kind": "statement", "statement": "X"}]}\n'
+            '```\n'
+        )
+        result = ir.extract_json_from_codeblock(raw)
+        parsed = json.loads(result)
+        assert parsed["register"] == "analitico"
+        assert parsed["slides"][0]["kind"] == "statement"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Projection -> REAL composer.map_slide_to_family (core Phase-1 assertion)
+# ─────────────────────────────────────────────────────────────────────────
+
+_SAMPLE_SLIDES: dict[str, dict] = {
+    "cover": {"kind": "cover", "headline": "Cover Headline", "subhead": "tag"},
+    "prose": {"kind": "prose", "headline": "H", "body": "body text long enough to be real"},
+    "statement": {"kind": "statement", "statement": "ZERO PENALTY"},
+    "fact_stack": {"kind": "fact_stack", "heading": "Facts", "facts": ["fact one", "fact two"]},
+    "status_list": {
+        "kind": "status_list",
+        "heading": "Status",
+        "items": [{"label": "A", "value": "B", "status": "positive"}],
+    },
+    "timeline": {
+        "kind": "timeline",
+        "heading": "TL",
+        "steps": [{"date": "2026", "label": "X", "current": True}],
+    },
+    "triad": {
+        "kind": "triad",
+        "heading": "Forces",
+        "items": [{"title": "A", "desc": "a"}, {"title": "B", "desc": "b"}, {"title": "C", "desc": "c"}],
+    },
+    "qa": {"kind": "qa", "pairs": [{"voice": "A", "line": "q"}, {"voice": "B", "line": "a"}]},
+    "stat": {"kind": "stat", "value": "2.815T", "unit": "IDR", "label": "REVENUE", "context": "context text"},
+    "citation": {
+        "kind": "citation",
+        "claim": "Claim text",
+        "sources": [{"code": "PMK 37/2025", "issuer": "DJP"}],
+    },
+    "cta": {"kind": "cta", "invite": "Learn more", "trust_marker": "Verified", "reach": "10k"},
+}
+
+
+class TestProjectionResolvesRealFamily:
+    """The core Phase-1 assertion: every one of the 11 kinds, projected via
+    to_composer_dict, resolves to its intended family through the REAL
+    (imported, not reimplemented) composer.map_slide_to_family."""
+
+    def test_all_11_kinds_covered_by_the_sample_set(self):
+        assert set(_SAMPLE_SLIDES) == set(ir.SLIDE_KIND_TO_FAMILY)
+        assert len(_SAMPLE_SLIDES) == 11
+
+    @pytest.mark.parametrize("kind", sorted(_SAMPLE_SLIDES))
+    def test_kind_resolves_intended_family(self, kind: str):
+        payload = _SAMPLE_SLIDES[kind]
+        deck = ir.SlideDeck.model_validate(_deck([payload]))
+        slide = deck.slides[0]
+        cdict = ir.to_composer_dict(slide, index=1, total=1)
+        resolved = map_slide_to_family(cdict, 1, 1)
+        assert resolved == ir.SLIDE_KIND_TO_FAMILY[kind]
+        # every resolved family must also be one composer actually skeletons
+        # (never one of the UNDEFINED_FAMILIES from tokens.json with no .md).
+        from wr2_html_renderer.composer import RENDERABLE_FAMILIES
+        assert resolved in RENDERABLE_FAMILIES
+
+    def test_fact_stack_facts_become_numbered_dict_rows(self):
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["fact_stack"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        assert cdict["facts"] == [
+            {"idx": 1, "this": "fact one"},
+            {"idx": 2, "this": "fact two"},
+        ]
+
+    def test_triad_numeral_prefix_injected_into_headline(self):
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["triad"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        # numbered-forces-list extracts {{numeral}} by regex on a leading
+        # integer in the headline (composer.py `^(\d+)\s+(.*)$`) — the
+        # projection must supply it there, there is no other way to set it.
+        assert cdict["headline"].startswith("3 ")
+
+    def test_qa_pairs_use_voice_line_keys_not_q_a(self):
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["qa"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        assert cdict["qa_pairs"][0] == {"voice": "A", "line": "q"}
+        assert cdict["qa_pairs"][1] == {"voice": "B", "line": "a"}
+
+    def test_timeline_current_step_maps_to_yellow_accent(self):
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["timeline"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        assert cdict["events"][0]["accent"] == "yellow"
+
+    def test_timeline_non_current_step_maps_to_white_accent(self):
+        payload = {
+            "kind": "timeline",
+            "heading": "TL",
+            "steps": [{"date": "2020", "label": "past", "current": False}],
+        }
+        deck = ir.SlideDeck.model_validate(_deck([payload]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        assert cdict["events"][0]["accent"] == "white"
+
+    def test_stat_unit_value_split_into_lead_rest_headline(self):
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["stat"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        assert cdict["headline"] == "IDR / 2.815T"
+
+    def test_stat_without_unit_headline_is_bare_value(self):
+        payload = {"kind": "stat", "value": "42%"}
+        deck = ir.SlideDeck.model_validate(_deck([payload]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        assert cdict["headline"] == "42%"
+
+    def test_cover_is_flagged_hero_and_cover(self):
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["cover"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        assert cdict["is_cover"] is True
+        assert cdict["is_hero_image"] is True
+
+    def test_non_cover_slide_is_not_flagged_hero(self):
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["prose"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=2, total=5)
+        assert cdict["is_cover"] is False
+        assert cdict["is_hero_image"] is False
+
+    def test_citation_row_body_key_carries_the_code(self):
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["citation"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=1, total=1)
+        assert cdict["citations"][0]["body"] == "PMK 37/2025"
+        assert cdict["citations"][0]["issuer"] == "DJP"
+
+    def test_explicit_layout_family_pin_is_honoured_before_auto_routing(self):
+        """composer.map_slide_to_family checks an explicit `layout_family`
+        pin FIRST (composer.py:143-145) — this is exactly why the projection
+        works regardless of index/total/slide_type auto-routing heuristics.
+        Prove it directly: a mid-deck fact_stack (index != 1, index != total)
+        still resolves to evidence-carved, not the auto-router's default."""
+        deck = ir.SlideDeck.model_validate(_deck([_SAMPLE_SLIDES["fact_stack"]]))
+        cdict = ir.to_composer_dict(deck.slides[0], index=3, total=7)
+        resolved = map_slide_to_family(cdict, 3, 7)
+        assert resolved == "evidence-carved"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# generate_slides_typed — validate-and-retry loop against a fake call_fn
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGenerateSlidesTypedRetryLoop:
+    def test_invalid_then_invalid_then_valid(self):
+        responses = iter([
+            "not json at all",
+            '{"register": "analitico", "slides": [{"kind": "bogus"}]}',
+            '{"register": "analitico", "slides": [{"kind": "statement", "statement": "OK"}]}',
+        ])
+        calls: list[str] = []
+
+        def fake_call(prompt: str) -> str:
+            calls.append(prompt)
+            return next(responses)
+
+        deck = ir.generate_slides_typed("base prompt", fake_call, max_retries=3)
+        assert deck.slides[0].statement == "OK"
+        assert len(calls) == 3
+        # the 2nd/3rd prompts must carry the validation-error reask context,
+        # not just the bare original prompt repeated verbatim.
+        assert "Validation errors found" in calls[1]
+        assert "Validation errors found" in calls[2]
+        assert calls[0] == "base prompt"
+
+    def test_always_invalid_raises_exhausted(self):
+        def fake_call(prompt: str) -> str:
+            return "garbage, not json"
+
+        with pytest.raises(ir.IRValidationExhausted) as exc_info:
+            ir.generate_slides_typed("base prompt", fake_call, max_retries=3)
+        assert exc_info.value.last_raw_text == "garbage, not json"
+
+    def test_valid_first_try_only_one_call(self):
+        calls: list[str] = []
+
+        def fake_call(prompt: str) -> str:
+            calls.append(prompt)
+            return '{"register": "analitico", "slides": [{"kind": "statement", "statement": "OK"}]}'
+
+        ir.generate_slides_typed("base prompt", fake_call, max_retries=3)
+        assert len(calls) == 1
+
+    def test_exhausted_error_carries_last_raw_and_error(self):
+        def fake_call(prompt: str) -> str:
+            return '{"register": "not-a-tone", "slides": []}'
+
+        with pytest.raises(ir.IRValidationExhausted) as exc_info:
+            ir.generate_slides_typed("base prompt", fake_call, max_retries=2)
+        assert exc_info.value.last_error
+        assert "not-a-tone" in exc_info.value.last_raw_text

--- a/scripts/wr2_carousel_ir.py
+++ b/scripts/wr2_carousel_ir.py
@@ -1,0 +1,980 @@
+#!/usr/bin/env python3
+"""wr2_carousel_ir.py — typed Carousel IR (WR2 editorial-intelligence Phase 1).
+
+ADDITIVE / SHADOW ONLY. Nothing in `wr2_draft_generator.py` or
+`scripts/wr2_html_renderer/composer.py` imports this module, and this PR does
+not modify either file — production behavior is byte-identical before/after.
+This module exists to be exercised by `wr2_ir_shadow_replay.py` against
+historical decks. Wiring it into the live autonomous pipeline is Phase 3,
+itself gated by the 4-LLM panel per CLAUDE.md §6 — not this PR.
+
+Implements Mossa A of the ratified spec:
+    .claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md
+    §2 "Carousel IR: la grammatica tipizzata delle slide" + §3 rollout step 1.
+
+Design (spec §2, "VALIDAZIONE LENIENT-FIRST", red-team BLOCKER-1):
+  - A pydantic v2 discriminated union `Slide` over 11 kinds: cover, prose,
+    statement, fact_stack, status_list, timeline, triad, qa, stat, citation,
+    cta. Discriminator = `kind` (a `Literal`).
+  - STRICT validation is scoped to exactly two things: the `kind` tag itself
+    (pydantic raises `union_tag_invalid` on an unknown tag), and the
+    per-kind structurally-required field(s) — e.g. `fact_stack.facts` must
+    be a non-empty list (an empty list is not "a fact stack"); `qa.pairs`
+    needs >=2 entries (qa-dialogue is a fixed 2-voice layout downstream).
+  - EVERY other scalar (headline/subhead/body/…) is LENIENT: coerced to
+    `str`, truncated, defaulted — mirroring the tolerances
+    `wr2_draft_generator._normalise_slides` already applies today
+    (headline[:80], body[:500], subhead via a `_cap_subhead`-style
+    word/char cap; see `_lenient_str`/`_cap_len`/`_cap_subhead` below,
+    ported/mirrored from wr2_draft_generator.py:1386-1414,1441-1453). A
+    strict union on every scalar risks a regen-spike that burns MAX-plan
+    quota at shakeout for zero real gain — the *shape* (kind) is what must
+    be right, not every character budget.
+  - Kind-preservation is a HARD design rule (spec §2, Kimi red-team
+    objection #3): at retry-exhaustion `IRValidationExhausted` is raised —
+    the CALLER decides park, never this module. There is no fallback here
+    that silently coerces a richly-shaped slide down to prose/statement
+    just because validation failed; that would re-collapse onto the same 4
+    auto-reachable layouts (spec §0.2) the whole design exists to escape.
+
+`to_composer_dict()` projects a validated Slide into the EXACT dict shape
+`scripts/wr2_html_renderer/composer.py` consumes for that layout family.
+Field names were VERIFIED against the real skeleton `.md` files under
+`skills/bali-zero-brand/layouts/` + composer.py's `_fill_placeholders` /
+`_expand_each_blocks` / `_qa_dialogue_fields` (this session, 2026-07-21) —
+NOT guessed from the spec's summary table, which uses simplified field
+names ("label,value" for fact_stack; "q,a" for qa; "date,event,current" for
+timeline) that do not match the real composer contract for several kinds.
+See the per-branch comments in `to_composer_dict` for the corrections, with
+composer.py line citations and two DISCOVERED GAPS (source-citation's
+`{{title}}` and elegant-close's `trust_marker`/`reach`/`invite`/… are never
+substituted by `_fill_placeholders` at all — verified by grep, zero hits).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import warnings
+from typing import Annotated, Any, Callable, Literal, Union
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+)
+
+logger = logging.getLogger("wr2.carousel_ir")
+
+# pydantic's ModelMetaclass inherits from abc.ABCMeta, which defines a
+# `.register()` classmethod (virtual-subclass registration) — a field
+# LITERALLY named "register" shadows it, and pydantic emits a class-
+# definition-time UserWarning about it. Harmless (verified: the field
+# validates/serializes correctly either way) and unavoidable here since
+# "register" is the production JSON key (wr2_draft_generator._normalise_
+# slides reads `parsed.get("register")` — the IR wrapper must match it
+# verbatim). Scoped narrowly to SlideDeck's class body only.
+warnings.filterwarnings(
+    "ignore",
+    message='Field name "register" in "SlideDeck" shadows an attribute',
+    category=UserWarning,
+)
+
+# ─────────────────────────────────────────────────────────────────────────
+# Lenient scalar helpers — mirror wr2_draft_generator._normalise_slides
+# (wr2_draft_generator.py:1441-1453) and _cap_subhead (:1386-1414).
+# Duplicated (not imported) on purpose: this module must stay importable
+# standalone with ZERO I/O/DB/CLI side effects, so unit tests never need a
+# database, a subprocess, or the wr2_draft_generator module's own import
+# surface. wr2_ir_shadow_replay.py is the one place that DOES import
+# wr2_draft_generator, for its prompt-assembly helpers.
+# ─────────────────────────────────────────────────────────────────────────
+
+_HEADLINE_MAX = 80
+_BODY_MAX = 500
+_IMAGE_PROMPT_MAX = 600
+_SUBHEAD_MAX_WORDS = 6
+_SUBHEAD_MAX_CHARS = 32
+
+_VALID_TONES = frozenset({
+    "rituale", "analitico", "ironico", "militante", "pedagogico", "poetico", "tecnico",
+})
+
+_VALID_STATUS_TOKENS = frozenset({"neutral", "critical", "positive"})
+
+
+def _lenient_str(v: Any) -> str:
+    """Coerce anything to a stripped str. Never raises."""
+    if v is None:
+        return ""
+    if isinstance(v, str):
+        return v.strip()
+    return str(v).strip()
+
+
+def _cap_len(s: str, n: int) -> str:
+    return s[:n]
+
+
+def _cap_subhead(text: str, max_words: int = _SUBHEAD_MAX_WORDS, max_chars: int = _SUBHEAD_MAX_CHARS) -> str:
+    """Port of wr2_draft_generator._cap_subhead (wr2_draft_generator.py:1386-1414):
+    hard-cap to 1-6 words, then trim to a word boundary under max_chars. No
+    ellipsis — a clean shorter kicker beats a truncated one."""
+    words = text.strip().split()
+    if not words:
+        return ""
+    capped = " ".join(words[:max_words])
+    if len(capped) <= max_chars:
+        return capped
+    trimmed: list[str] = []
+    length = 0
+    for w in capped.split():
+        extra = len(w) + (1 if trimmed else 0)
+        if length + extra > max_chars:
+            break
+        trimmed.append(w)
+        length += extra
+    if not trimmed:
+        trimmed = [capped.split()[0]]
+    return " ".join(trimmed)
+
+
+def _require_nonempty(v: str, field_name: str) -> str:
+    """Post-coercion guard for fields this module treats as structurally
+    required content (not just structurally-present keys): an empty string
+    after lenient coercion is still a real content failure worth a retry,
+    not a silently-accepted blank slide."""
+    if not v:
+        raise ValueError(f"{field_name} must be non-empty after coercion")
+    return v
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 1. Slide kinds — discriminated union over 11 shapes
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class CoverSlide(BaseModel):
+    """→ cover-photo. Composer fields: headline, subhead(ing), optional
+    regulation_code (constitution Art 9.3 hard rule — always slide 1)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["cover"]
+    headline: str
+    subhead: str = ""
+    regulation_code: str = ""
+    image_prompt: str = ""
+
+    @field_validator("headline", mode="before")
+    @classmethod
+    def _v_headline(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "headline")
+
+    @field_validator("subhead", mode="before")
+    @classmethod
+    def _v_subhead(cls, v: Any) -> str:
+        return _cap_subhead(_lenient_str(v))
+
+    @field_validator("regulation_code", mode="before")
+    @classmethod
+    def _v_regulation_code(cls, v: Any) -> str:
+        return _lenient_str(v)
+
+    @field_validator("image_prompt", mode="before")
+    @classmethod
+    def _v_image_prompt(cls, v: Any) -> str:
+        # Mirrors wr2_draft_generator._normalise_slides' image_prompt[:600]
+        # cap (wr2_draft_generator.py:1449).
+        return _cap_len(_lenient_str(v), _IMAGE_PROMPT_MAX)
+
+
+class ProseSlide(BaseModel):
+    """→ editorial-text. Composer fields: headline, subhead(ing), body."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["prose"]
+    headline: str
+    body: str
+    subhead: str = ""
+
+    @field_validator("headline", mode="before")
+    @classmethod
+    def _v_headline(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "headline")
+
+    @field_validator("body", mode="before")
+    @classmethod
+    def _v_body(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _BODY_MAX), "body")
+
+    @field_validator("subhead", mode="before")
+    @classmethod
+    def _v_subhead(cls, v: Any) -> str:
+        return _cap_subhead(_lenient_str(v))
+
+
+class StatementSlide(BaseModel):
+    """→ statement-bomb. Composer field: statement (falls back to
+    headline/body if absent, but this kind IS the statement — required)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["statement"]
+    statement: str
+
+    @field_validator("statement", mode="before")
+    @classmethod
+    def _v_statement(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "statement")
+
+
+class FactStackSlide(BaseModel):
+    """→ evidence-carved. `facts` is a non-empty list of fact lines (spec §2
+    code block: `facts: List[str]` — matches the REAL each-loop contract,
+    `{{#each facts}}...{{this}}...{{/each}}`, verified against
+    skills/bali-zero-brand/layouts/evidence-carved.md:115-120 +
+    scripts/wr2_html_renderer/tests/test_each_block_render.py's own guilt
+    case `{"facts": ["FACT ONE", "FACT TWO"]}`)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["fact_stack"]
+    heading: str
+    facts: list[str] = Field(min_length=1)
+    take_label: str = ""
+    take_line: str = ""
+
+    @field_validator("heading", mode="before")
+    @classmethod
+    def _v_heading(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "heading")
+
+    @field_validator("facts", mode="before")
+    @classmethod
+    def _v_facts(cls, v: Any) -> Any:
+        if not isinstance(v, list):
+            return v  # let pydantic raise its own type error
+        return [_cap_len(_lenient_str(x), _BODY_MAX) for x in v]
+
+    @field_validator("take_label", "take_line", mode="before")
+    @classmethod
+    def _v_take(cls, v: Any) -> str:
+        return _lenient_str(v)
+
+
+class StatusItem(BaseModel):
+    """Row shape for dark-status-list's {{#each items}} — label/value/status,
+    verified against layouts/dark-status-list.md:67-72. `status` drives the
+    CSS class `status-{{status}}`; only 3 tokens have real styling."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    label: str
+    value: str
+    status: Literal["neutral", "critical", "positive"] = "neutral"
+
+    @field_validator("label", "value", mode="before")
+    @classmethod
+    def _v_scalars(cls, v: Any) -> str:
+        return _lenient_str(v)
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _v_status(cls, v: Any) -> str:
+        s = _lenient_str(v).lower() or "neutral"
+        if s not in _VALID_STATUS_TOKENS:
+            logger.warning("StatusItem.status=%r not in %s — defaulting to 'neutral'", s, sorted(_VALID_STATUS_TOKENS))
+            return "neutral"
+        return s
+
+
+class StatusListSlide(BaseModel):
+    """→ dark-status-list. `items` non-empty (a status list with zero rows
+    is not a status list)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["status_list"]
+    heading: str
+    items: list[StatusItem] = Field(min_length=1)
+
+    @field_validator("heading", mode="before")
+    @classmethod
+    def _v_heading(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "heading")
+
+
+class TimelineStep(BaseModel):
+    """Row shape for timeline-pinboard's {{#each events}} — date/label(+accent),
+    verified against layouts/timeline-pinboard.md:59-66. `current` is an
+    IR-level editorial concept ("this is where we are now"); the projection
+    derives the composer's `accent` token from it — see to_composer_dict."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    date: str
+    label: str
+    current: bool = False
+
+    @field_validator("date", "label", mode="before")
+    @classmethod
+    def _v_scalars(cls, v: Any) -> str:
+        return _lenient_str(v)
+
+    @field_validator("current", mode="before")
+    @classmethod
+    def _v_current(cls, v: Any) -> bool:
+        if isinstance(v, str):
+            return v.strip().lower() in {"true", "yes", "1", "current"}
+        return bool(v)
+
+
+class TimelineSlide(BaseModel):
+    """→ timeline-pinboard. `steps` non-empty."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["timeline"]
+    heading: str
+    steps: list[TimelineStep] = Field(min_length=1)
+
+    @field_validator("heading", mode="before")
+    @classmethod
+    def _v_heading(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "heading")
+
+
+class TriadItem(BaseModel):
+    """Row shape for numbered-forces-list's {{#each items}} — label/value,
+    verified against layouts/numbered-forces-list.md:68-76."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    title: str
+    desc: str
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def _v_title(cls, v: Any) -> str:
+        return _lenient_str(v)
+
+    @field_validator("desc", mode="before")
+    @classmethod
+    def _v_desc(cls, v: Any) -> str:
+        return _cap_len(_lenient_str(v), _BODY_MAX)
+
+
+class TriadSlide(BaseModel):
+    """→ numbered-forces-list. `items` min 2 (a "forces" list of 1 is not a
+    list) — NOT hard-locked to exactly 3 despite the name: the renderer's
+    numeral-extraction (regex on the headline's leading integer) generalizes
+    to any N, so an editorially-justified 2 or 4 is not a structural error.
+    Capped at 6 (a sane display ceiling for this layout's numeral+item grid,
+    not a hard composer limit)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["triad"]
+    heading: str
+    items: list[TriadItem] = Field(min_length=2, max_length=6)
+
+    @field_validator("heading", mode="before")
+    @classmethod
+    def _v_heading(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "heading")
+
+
+class QaPair(BaseModel):
+    """Row shape for qa-dialogue — voice/line, verified against the pinned
+    regression test scripts/wr2_html_renderer/tests/test_each_block_render.py
+    (`{"voice": "INVESTOR", "line": "IS JAPAN VISA-FREE?"}`) and
+    composer._qa_dialogue_fields (composer.py:1057-1074). NOT the spec
+    table's simplified "q,a" field names."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    voice: str
+    line: str
+
+    @field_validator("voice", mode="before")
+    @classmethod
+    def _v_voice(cls, v: Any) -> str:
+        return _lenient_str(v)
+
+    @field_validator("line", mode="before")
+    @classmethod
+    def _v_line(cls, v: Any) -> str:
+        return _cap_len(_lenient_str(v), _BODY_MAX)
+
+
+class QaSlide(BaseModel):
+    """→ qa-dialogue. `pairs` min 2 (composer._qa_dialogue_fields only ever
+    renders the first two, `for idx, key in ((0,"a"),(1,"b"))` —
+    composer.py:1069 — a fixed 2-voice layout, not an N-turn dialogue; fewer
+    than 2 pairs cannot fill both voices)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["qa"]
+    pairs: list[QaPair] = Field(min_length=2)
+
+
+class StatSlide(BaseModel):
+    """→ stat-card-hero. `value` required; `unit`/`label`/`context` lenient.
+    Composer fields: heading (supports a "UNIT / VALUE" split,
+    composer.py:1564-1566), subheading (label above), body (caption below
+    the optional chart)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["stat"]
+    value: str
+    unit: str = ""
+    label: str = ""
+    context: str = ""
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _v_value(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "value")
+
+    @field_validator("unit", "label", mode="before")
+    @classmethod
+    def _v_short(cls, v: Any) -> str:
+        return _cap_subhead(_lenient_str(v))
+
+    @field_validator("context", mode="before")
+    @classmethod
+    def _v_context(cls, v: Any) -> str:
+        return _cap_len(_lenient_str(v), _BODY_MAX)
+
+
+class CitationSource(BaseModel):
+    """Row shape for source-citation's {{#each citations}} — body(=code)/
+    issuer/date/url/note, verified against layouts/source-citation.md:31-36.
+    NOTE: the row's `body` key is the citation CODE text — unrelated to the
+    slide-level `{{body}}` placeholder used by other families."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    code: str
+    issuer: str = ""
+    date: str = ""
+    url: str = ""
+    note: str = ""
+
+    @field_validator("code", mode="before")
+    @classmethod
+    def _v_code(cls, v: Any) -> str:
+        return _lenient_str(v)
+
+    @field_validator("issuer", "date", "url", "note", mode="before")
+    @classmethod
+    def _v_scalars(cls, v: Any) -> str:
+        return _lenient_str(v)
+
+
+class CitationSlide(BaseModel):
+    """→ source-citation. `sources` non-empty. `claim` is required content
+    (projects to the skeleton's top-level `{{title}}` — see the DISCOVERED
+    GAP note in to_composer_dict: composer never actually substitutes
+    {{title}}, verified by grep)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["citation"]
+    claim: str
+    sources: list[CitationSource] = Field(min_length=1)
+
+    @field_validator("claim", mode="before")
+    @classmethod
+    def _v_claim(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _HEADLINE_MAX), "claim")
+
+
+class CtaSlide(BaseModel):
+    """→ elegant-close. `invite` required content (the core call-to-action
+    line). See the DISCOVERED GAP note in to_composer_dict: NONE of this
+    family's top-level fields (trust_marker/reach/invite/…) are ever
+    substituted by composer._fill_placeholders today — verified by grep,
+    zero hits for all of them."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: Literal["cta"]
+    invite: str
+    trust_marker: str = ""
+    reach: str = ""
+
+    @field_validator("invite", mode="before")
+    @classmethod
+    def _v_invite(cls, v: Any) -> str:
+        return _require_nonempty(_cap_len(_lenient_str(v), _BODY_MAX), "invite")
+
+    @field_validator("trust_marker", "reach", mode="before")
+    @classmethod
+    def _v_scalars(cls, v: Any) -> str:
+        return _cap_subhead(_lenient_str(v))
+
+
+Slide = Annotated[
+    Union[
+        CoverSlide,
+        ProseSlide,
+        StatementSlide,
+        FactStackSlide,
+        StatusListSlide,
+        TimelineSlide,
+        TriadSlide,
+        QaSlide,
+        StatSlide,
+        CitationSlide,
+        CtaSlide,
+    ],
+    Field(discriminator="kind"),
+]
+
+SlideListAdapter: TypeAdapter[list[Slide]] = TypeAdapter(list[Slide])
+
+# kind (string) -> composer layout_family (string). All 11 targets are in
+# composer.RENDERABLE_FAMILIES (composer.py:51-67) — verified this session.
+SLIDE_KIND_TO_FAMILY: dict[str, str] = {
+    "cover": "cover-photo",
+    "prose": "editorial-text",
+    "statement": "statement-bomb",
+    "fact_stack": "evidence-carved",
+    "status_list": "dark-status-list",
+    "timeline": "timeline-pinboard",
+    "triad": "numbered-forces-list",
+    "qa": "qa-dialogue",
+    "stat": "stat-card-hero",
+    "citation": "source-citation",
+    "cta": "elegant-close",
+}
+
+
+class SlideDeck(BaseModel):
+    """Top-level wrapper — mirrors the production JSON shape
+    `{"register": ..., "slides": [...]}` (wr2_draft_generator._normalise_slides
+    reads `parsed.get("register")` / `parsed.get("slides")`)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    register: str
+    slides: list[Slide]
+
+    @field_validator("register", mode="before")
+    @classmethod
+    def _v_register(cls, v: Any) -> str:
+        # Deliberately STRICT — the one deck-level field this module does NOT
+        # treat leniently, mirroring wr2_draft_generator._normalise_slides'
+        # own choice (wr2_draft_generator.py:1418-1422, hard ValueError on an
+        # invalid register). register drives voice/tone for the WHOLE deck;
+        # silently defaulting it risks a content/voice mismatch, which is a
+        # worse failure mode than one extra retry.
+        s = _lenient_str(v).lower()
+        if s not in _VALID_TONES:
+            raise ValueError(f"invalid register={s!r} (allowed: {sorted(_VALID_TONES)})")
+        return s
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 2. extract_json_from_codeblock — ported VERBATIM from instructor v2
+#    (instructor/v2/core/json.py, MIT license, github.com/567-labs/instructor)
+#    via .claude/skills/wr2/_research/2026-07-21-oss-code-reading-typed-
+#    pydantic-instructor.md §5 (this session re-verified the port against
+#    that evidence file's own copy, byte-for-byte identical algorithm).
+#    Balanced-brace/bracket scanner: walks the text, tracks string/escape
+#    state so braces INSIDE quoted strings don't confuse the stack, and
+#    returns the LAST valid top-level JSON span found (a model's raw stdout
+#    often has prose before/after the JSON, or a fenced ```json block).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def extract_json_from_codeblock(content: str) -> str:
+    candidates: list[str] = []
+    search_index = 0
+    while search_index < len(content):
+        start_index = next(
+            (i for i in range(search_index, len(content)) if content[i] in "{["), None
+        )
+        if start_index is None:
+            break
+        start_char = content[start_index]
+        end_stack = ["}" if start_char == "{" else "]"]
+        in_string = False
+        escape_next = False
+        candidate_found = False
+        for end_index in range(start_index + 1, len(content)):
+            char = content[end_index]
+            if escape_next:
+                escape_next = False
+            elif char == "\\" and in_string:
+                escape_next = True
+            elif char == '"':
+                in_string = not in_string
+            if in_string:
+                continue
+            if char in "{[":
+                end_stack.append("}" if char == "{" else "]")
+                continue
+            if end_stack and char == end_stack[-1]:
+                end_stack.pop()
+                if not end_stack:
+                    candidate = content[start_index : end_index + 1]
+                    try:
+                        json.loads(candidate)
+                    except Exception:
+                        break
+                    candidates.append(candidate)
+                    search_index = end_index + 1
+                    candidate_found = True
+                    break
+        if not candidate_found:
+            search_index = start_index + 1
+    return candidates[-1] if candidates else content
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 3. validate + retry loop
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class IRValidationExhausted(RuntimeError):
+    """Raised when max_retries is exhausted without a valid SlideDeck.
+
+    The CALLER decides what to do next (park the deck, fall back to a
+    kind-preserving fill, …) — this module never silently coerces a failed
+    validation into a simpler kind (spec §2, Kimi objection #3: "i
+    kind-fallback sono sempre i semplici -> ri-collasso sui 4 layout")."""
+
+    def __init__(self, message: str, *, last_raw_text: str, last_error: str):
+        super().__init__(message)
+        self.last_raw_text = last_raw_text
+        self.last_error = last_error
+
+
+def validate_slides(json_str: str) -> SlideDeck:
+    """Validate a raw JSON string against SlideDeck. Raises ValidationError /
+    json.JSONDecodeError on failure — callers wanting the retry loop should
+    use generate_slides_typed instead of calling this directly."""
+    return SlideDeck.model_validate_json(json_str)
+
+
+def generate_slides_typed(
+    prompt: str,
+    call_fn: Callable[[str], str],
+    max_retries: int = 3,
+) -> SlideDeck:
+    """Validate-and-retry loop against `call_fn` (sync text-in/text-out).
+
+    `call_fn` is INJECTED so this module never itself shells out to the
+    `claude` CLI or touches the network — that responsibility stays with the
+    caller (wr2_ir_shadow_replay.py wraps backend.llm.claude_oauth_client.
+    complete_async). This keeps wr2_carousel_ir.py import-safe with zero
+    I/O/DB/network side effects: a plain Python fake for `call_fn` is all
+    the retry-loop unit test needs.
+
+    Reask pattern ported from instructor's AnthropicJSONHandler.handle_reask
+    (see the OSS evidence file §2c / §5), adapted to plain text: on failure
+    the next prompt = original prompt + the validation errors + the failed
+    raw output, so the model can see exactly what it got wrong.
+
+    Raises IRValidationExhausted after `max_retries` failed attempts.
+    """
+    ctx = prompt
+    last_raw = ""
+    last_err: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        raw = call_fn(ctx)
+        last_raw = raw
+        json_str = extract_json_from_codeblock(raw)
+        try:
+            deck = validate_slides(json_str)
+        except (ValidationError, json.JSONDecodeError) as e:
+            last_err = e
+            logger.warning(
+                "Carousel IR validation failed (attempt %d/%d): %s", attempt, max_retries, e,
+            )
+            if attempt == max_retries:
+                break
+            ctx = (
+                f"{prompt}\n\n"
+                "Your previous attempt failed validation.\n"
+                f"Validation errors found:\n{e}\n"
+                "Recall the schema and fix the errors found in the following attempt:\n"
+                f"{raw}"
+            )
+            continue
+        if attempt > 1:
+            logger.info("Carousel IR validated on retry %d/%d", attempt, max_retries)
+        return deck
+    raise IRValidationExhausted(
+        f"Carousel IR validation exhausted after {max_retries} attempts: {last_err}",
+        last_raw_text=last_raw,
+        last_error=str(last_err) if last_err else "unknown",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 4. to_composer_dict — projection to the composer-compatible dict shape
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def to_composer_dict(slide: Slide, *, index: int, total: int) -> dict[str, Any]:
+    """Project a validated typed Slide into the exact dict shape
+    `scripts/wr2_html_renderer/composer.py` consumes for its layout family.
+
+    Sets `layout_family` EXPLICITLY — composer.map_slide_to_family honours
+    an explicit pin before any auto-routing heuristic (composer.py:143-145,
+    `explicit = (slide.get("layout_family") or "").strip(); if explicit in
+    RENDERABLE_FAMILIES: return explicit`), so this projection is immune to
+    the auto-router's 4-family collapse (spec §0.2) regardless of what the
+    IR's `kind` maps to.
+    """
+    base: dict[str, Any] = {
+        "slide_number": index,
+        "is_cover": False,
+        "is_hero_image": False,
+    }
+
+    if isinstance(slide, CoverSlide):
+        base.update({
+            "layout_family": "cover-photo",
+            "is_cover": True,
+            "is_hero_image": True,
+            "headline": slide.headline,
+            "subhead": slide.subhead,
+            "image_prompt": slide.image_prompt,
+        })
+        if slide.regulation_code:
+            base["regulation_code"] = slide.regulation_code
+        return base
+
+    if isinstance(slide, ProseSlide):
+        base.update({
+            "layout_family": "editorial-text",
+            "headline": slide.headline,
+            "subhead": slide.subhead,
+            "body": slide.body,
+        })
+        return base
+
+    if isinstance(slide, StatementSlide):
+        base.update({
+            "layout_family": "statement-bomb",
+            "statement": slide.statement,
+        })
+        return base
+
+    if isinstance(slide, FactStackSlide):
+        # evidence-carved's {{#each facts}} wants §-numbered rows: dict rows
+        # {"idx": N, "this": text} render "§N  text" (verified against
+        # skills/bali-zero-brand/layouts/evidence-carved.md:115-120 +
+        # composer._expand_each_blocks's dict-row branch). A plain
+        # scalar-string row ALSO binds {{this}}, but leaves the §-marker
+        # BLANK — {{idx}} is only ever populated from a dict-row key, never
+        # auto-enumerated by the composer itself — so this projection
+        # upgrades to the numbered dict-row shape rather than the bare
+        # strings the pinned regression test exercises.
+        base.update({
+            "layout_family": "evidence-carved",
+            "headline": slide.heading,
+            "facts": [{"idx": i, "this": f} for i, f in enumerate(slide.facts, start=1)],
+        })
+        if slide.take_label:
+            base["take_label"] = slide.take_label
+        if slide.take_line:
+            base["take_line"] = slide.take_line
+        return base
+
+    if isinstance(slide, StatusListSlide):
+        base.update({
+            "layout_family": "dark-status-list",
+            "headline": slide.heading,
+            "list_items": [
+                {"label": it.label, "value": it.value, "status": it.status}
+                for it in slide.items
+            ],
+        })
+        return base
+
+    if isinstance(slide, TimelineSlide):
+        # timeline-pinboard's each-row fields are accent/date/label (verified
+        # against layouts/timeline-pinboard.md:59-66) — NOT the spec table's
+        # simplified "date,event,current". `current` is an IR-level editorial
+        # concept; the projection derives the composer's `accent` token from
+        # it (yellow = "we are here", white = past/future) rather than
+        # exposing "current" to the skeleton directly.
+        base.update({
+            "layout_family": "timeline-pinboard",
+            "headline": slide.heading,
+            "events": [
+                {"date": s.date, "label": s.label, "accent": "yellow" if s.current else "white"}
+                for s in slide.steps
+            ],
+        })
+        return base
+
+    if isinstance(slide, TriadSlide):
+        # numbered-forces-list's {{numeral}} is NOT a settable field —
+        # composer extracts it by REGEX from a leading integer in the
+        # headline itself (`_fill_placeholders`, composer.py:1528-1534:
+        # `^(\d+)\s+(.*)$`), so the projection formats headline as
+        # "<N> <heading>" to trigger it. Each-row fields are label/value
+        # (layouts/numbered-forces-list.md:68-76), fed via the "items"
+        # each-alias (composer.py:998-1003).
+        base.update({
+            "layout_family": "numbered-forces-list",
+            "headline": f"{len(slide.items)} {slide.heading}".strip(),
+            "items": [{"label": it.title, "value": it.desc} for it in slide.items],
+        })
+        return base
+
+    if isinstance(slide, QaSlide):
+        # qa-dialogue only ever renders the FIRST TWO pairs (composer.
+        # _qa_dialogue_fields, composer.py:1069, `for idx, key in
+        # ((0,"a"),(1,"b"))`) — a fixed 2-voice layout, not an N-turn
+        # dialogue. Row keys are voice/line (matching the storyboarder
+        # contract + the pinned regression test
+        # scripts/wr2_html_renderer/tests/test_each_block_render.py), NOT
+        # the spec table's simplified "q,a".
+        base.update({
+            "layout_family": "qa-dialogue",
+            "qa_pairs": [{"voice": p.voice, "line": p.line} for p in slide.pairs],
+        })
+        return base
+
+    if isinstance(slide, StatSlide):
+        # stat-card-hero: `heading` supports a "UNIT / VALUE" split into a
+        # small unit line + big accent value (composer.py:1564-1566, the
+        # family == "stat-card-hero" special-case); `subheading` is the
+        # label above; `body` is the caption below the (optional) chart. No
+        # `chart` is emitted for a single-stat IR slide — the
+        # {{#each chart_rows}} block cleanly drops itself when absent
+        # (verified: test_each_block_render.py "absent-array: block dropped").
+        headline = f"{slide.unit} / {slide.value}" if slide.unit else slide.value
+        base.update({
+            "layout_family": "stat-card-hero",
+            "headline": headline,
+            "subhead": slide.label,  # _fill_placeholders fills {{subheading}} from "subhead"/"subheading"
+            "body": slide.context,
+        })
+        return base
+
+    if isinstance(slide, CitationSlide):
+        # DISCOVERED GAP (verified this session, grep composer.py for
+        # "title" = zero hits): source-citation's top-level {{title}}
+        # placeholder is NEVER substituted anywhere in _fill_placeholders.
+        # We still emit the field the skeleton textually names ("title"),
+        # per the mandate to match the real skeleton contract rather than
+        # invent a workaround field name composer doesn't look for either —
+        # see the PR description / final report for the Phase-3 composer.py
+        # follow-up this implies. Per-citation row fields are
+        # body/issuer/date/url/note (layouts/source-citation.md:31-36) —
+        # "body" here is the row's citation CODE text, unrelated to the
+        # top-level {{body}} placeholder other families use.
+        base.update({
+            "layout_family": "source-citation",
+            "title": slide.claim,
+            "citations": [
+                {
+                    "body": s.code,
+                    "issuer": s.issuer,
+                    "date": s.date,
+                    "url": s.url,
+                    **({"note": s.note} if s.note else {}),
+                }
+                for s in slide.sources
+            ],
+        })
+        return base
+
+    if isinstance(slide, CtaSlide):
+        # DISCOVERED GAP (verified this session, grep composer.py for
+        # "trust_marker"/"reach"/"invite"/"primary_source_url"/"qr_caption" =
+        # zero hits for all of them): elegant-close's top-level content
+        # fields are ALSO never substituted by _fill_placeholders — this
+        # family appears effectively unwired end-to-end today, consistent
+        # with the spec's diagnosis that most of the 11 non-auto-reachable
+        # families are underbaked. Emitted verbatim per the skeleton's own
+        # field names; see final report for the Phase-3 follow-up.
+        base.update({
+            "layout_family": "elegant-close",
+            "trust_marker": slide.trust_marker,
+            "reach": slide.reach,
+            "invite": slide.invite,
+        })
+        return base
+
+    raise TypeError(f"to_composer_dict: unhandled slide kind {type(slide)!r}")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 5. Inert brand constants (Phase 1 — NOT consumed by production; a future
+#    Phase 3, itself gated by the 4-LLM panel, is the only place these would
+#    ever get wired into a live render).
+#
+#    ⚠️ PROVENANCE CAVEAT (verified 2026-07-21, this session): the ratified
+#    spec (.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-
+#    design.md §8) lists the arc slate, the caps-only-on-headings rule, "The
+#    Bali Zero read" closer slot, and the palette-per-domain map as
+#    "Decisioni Zero-gated (Legge 5) ... la sessione NON le prende" — i.e.
+#    NOT YET ratified on disk as of this session (re-read verbatim this
+#    turn; §8 is a REQUEST for ratification, not a ratification record; no
+#    later commit/PR closes it — `gh pr list --search "editorial-
+#    intelligence"` returns only the spec PR #2936 itself). The build
+#    mandate that produced this module described these as "ratified" — that
+#    claim does not hold up against the spec file's own text on disk, so
+#    everything below is a DRAFT/PROPOSED shape only, pending Zero's actual
+#    §8 ratification, NOT a record of a decision that happened. Shipping
+#    this draft carries zero live-behavior risk (Phase 1 is shadow-only,
+#    nothing here is read by production) — but do not let its mere presence
+#    in a merged PR be mistaken for ratification-by-commit.
+# ─────────────────────────────────────────────────────────────────────────
+
+CAPS_POLICY = "headings_only"  # PROPOSED, spec §8 item 2 (Zero-gated, UNRATIFIED)
+
+# PROPOSED 7-arc slate with role sequences (spec §8 item 1, UNRATIFIED — the
+# spec itself only names the count/examples "quali 6-8, e le loro sequenze
+# di ruoli — è voce editoriale/brand", it does not specify the sequences).
+# Role vocabulary follows the spec's own Mossa-B planner JSON example (§2:
+# roles "hook"/"discovery") extended with the obvious siblings a slide-role
+# grammar needs. Sequence length follows §Mossa-E ("breaking -> arco stretto
+# 5-6; evergreen -> arco ricco 9") — this is a STARTING shape for Zero to
+# react to/amend, not a claim of institutional voice.
+ARCS: dict[str, list[str]] = {
+    "news_alert": ["hook", "context", "fact_stack", "impact", "close"],
+    "deadline": ["hook", "deadline_fact", "consequence", "action", "close"],
+    "myth_buster": ["hook", "myth", "reality", "evidence", "close"],
+    "worked_example": ["hook", "scenario", "steps", "outcome", "close"],
+    "comparison": ["hook", "option_a", "option_b", "verdict", "close"],
+    "explainer": ["hook", "context", "mechanism", "implication", "close"],
+    "status_roundup": ["hook", "item", "item", "item", "close"],
+}
+
+# PROPOSED palette-per-domain (spec §8 item 4, UNRATIFIED). immigration/tax/
+# company use REAL brand tokens (skills/bali-zero-brand/tokens.json +
+# constitution.md "Palette" table): antracite #373D42, accent yellow
+# #F4C430, status red #C8102E, bg.black #000000. property's "paper/cream"
+# has NO existing token (tokens.json has no cream/paper entry) — its hex
+# here is an INVENTED placeholder, flagged accordingly; a real value needs a
+# tokens.json addition + Zero sign-off, not this module.
+PALETTE_BY_DOMAIN: dict[str, dict[str, str]] = {
+    "immigration": {"primary": "#373D42", "accent": "#F4C430"},
+    "tax": {"primary": "#373D42", "accent": "#C8102E"},
+    "company": {"primary": "#000000", "accent": "#F4C430"},
+    # "#F5F0E6" is an INVENTED placeholder — no cream/paper brand token exists yet.
+    "property": {"primary": "#F5F0E6", "accent": "#373D42"},
+    "breaking": {"primary": "#C8102E", "accent": "#000000"},
+}
+
+# PROPOSED recurring role slot (spec §8 item 3, UNRATIFIED): "The Bali Zero
+# read" as the standing name for the closer's take/point-of-view role. A
+# future Phase 3 would use it as e.g. the default take_label on a
+# fact_stack's closing take.
+CLOSER_FRANCHISE_LABEL = "The Bali Zero read"

--- a/scripts/wr2_ir_shadow_replay.py
+++ b/scripts/wr2_ir_shadow_replay.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""wr2_ir_shadow_replay.py — Phase 1 shadow-replay harness for the typed
+Carousel IR (wr2_carousel_ir.py) against historical WR2 decks.
+
+ADDITIVE / SHADOW ONLY. This script never writes to `war_room_drafts` (the
+`--fetch` mode issues SELECT only) and never touches
+`wr2_draft_generator.py` / `scripts/wr2_html_renderer/composer.py` at
+runtime beyond IMPORTING their pure helper functions for reuse — it does not
+modify either file, and neither is wired to call anything in this module or
+in `wr2_carousel_ir.py`. Implements spec §3 rollout step 1's shadow-mode gate:
+"misurare il fail-rate della validazione stretta sul replay PRIMA del
+cutover" — this harness produces that measurement, it does not act on it.
+
+Two modes:
+
+  --fetch --out <fixture.json> [--limit N]
+      Read-only query against Postgres (asyncpg, DSN from env DATABASE_URL —
+      the same convention wr2_draft_generator.py:2064 uses) selecting
+      historical decks with a usable brief_json. Dumps them to a local JSON
+      fixture. NEVER writes to the DB.
+
+      Population note (verified empirically via mcp__postgres-nuzantara__
+      query this session, NOT trusted from the build mandate's stated "~34"):
+      `SELECT status, count(*) FROM war_room_drafts GROUP BY status` shows
+      status='rendered' at 63 rows, of which 61 have a non-null brief_json.
+      "~34" does not match any status/filter combination found on the live
+      table — this harness selects on the verified filter
+      (status='rendered' AND brief_json IS NOT NULL, 61 rows) rather than
+      the unverified number.
+
+  --replay --fixture <fixture.json> --out <metrics.json> [--limit N]
+      For each deck, builds the typed composition prompt by REUSING
+      production's own prompt assembly (wr2_draft_generator._build_draft_prompt
+      — system instructions + brief context + liveness/tone steer, imported
+      directly, not reimplemented) with ONE swapped section: the trailing
+      output-format directive is replaced with the typed-JSON-schema
+      instructions (_TYPED_SCHEMA_DIRECTIVE below). Calls the SAME model
+      production uses for composition (wr2_draft_generator.claude_compose_
+      slides pins model="claude-opus-4-7", wr2_draft_generator.py:1091) via
+      the sanctioned OAuth CLI path (backend.llm.claude_oauth_client.
+      complete_async — never the banned Anthropic SDK). Runs
+      wr2_carousel_ir.generate_slides_typed's validate-and-retry loop, then
+      resolves every slide's family via the REAL composer.map_slide_to_family
+      (imported, not reimplemented) and checks it matches the kind's
+      intended family. Writes per-deck results + aggregate metrics to the
+      --out path, incrementally (resumable — a deck already present in an
+      existing --out file is skipped on re-run).
+
+Rate-limit friendly by design: sequential calls only (never concurrent), a
+configurable --sleep between decks, and a per-deck try/except so one bad
+deck (timeout, malformed brief, OAuth hiccup) never kills the whole run.
+
+This script does NOT run the full historical replay itself — quota spend at
+that scale is the orchestrator's call, per the build mandate. It DOES
+support `--replay --limit 1` as an end-to-end smoke test when the `claude`
+CLI/OAuth is available in the calling environment.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+_BACKEND_RAG = _REPO_ROOT / "apps" / "backend-rag"
+if str(_BACKEND_RAG) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_RAG))
+
+import wr2_carousel_ir as ir  # noqa: E402
+import wr2_draft_generator as wr2dg  # noqa: E402  (prompt-assembly REUSE only — see module docstring)
+from wr2_html_renderer.composer import map_slide_to_family  # noqa: E402
+
+logger = logging.getLogger("wr2.ir_shadow_replay")
+
+# SAME model wr2_draft_generator.claude_compose_slides pins for slide
+# composition (wr2_draft_generator.py:1091) — the shadow replay must measure
+# the model production would actually use, not a cheaper substitute.
+_COMPOSE_MODEL = "claude-opus-4-7"
+
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_ID_PHONE_RE = re.compile(r"\+?62[\s-]?8\d{2}[\s-]?\d{3,4}[\s-]?\d{3,4}")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# --fetch: read-only historical-deck pull
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _scrub_pii(obj: Any) -> Any:
+    """Defensive regex scrub over the fetched brief_json before it lands in
+    a local fixture file. `war_room_drafts` has NO client_id / FK into the
+    clients table (verified via information_schema.columns this session)
+    and every brief_json sampled is public regulatory/tourism-news content
+    (a real row was read this session — Bali tourism-levy story, zero PII).
+    This is belt-and-suspenders, not a load-bearing filter — any hit is
+    logged so a human can audit, and this function makes NO completeness
+    promise. SYMBIOSIS Law 2 / UU PDP boundary."""
+    text = json.dumps(obj, ensure_ascii=False)
+    hits = len(_EMAIL_RE.findall(text)) + len(_ID_PHONE_RE.findall(text))
+    if hits:
+        logger.warning("PII-shaped pattern found (%d hits) — redacting before fixture write", hits)
+        text = _EMAIL_RE.sub("[EMAIL-REDACTED]", text)
+        text = _ID_PHONE_RE.sub("[PHONE-REDACTED]", text)
+        return json.loads(text)
+    return obj
+
+
+async def _fetch_decks(out_path: Path, limit: int | None) -> int:
+    import asyncpg  # local import: --replay mode must not require asyncpg to be installed
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise SystemExit(
+            "DATABASE_URL not set (read-only fetch — see scripts/pg.sh for the "
+            "canonical proxy DSN, or export DATABASE_URL directly)"
+        )
+    conn = await asyncpg.connect(dsn=dsn)
+    try:
+        # Verified filter (this session, mcp__postgres-nuzantara__query,
+        # read-only role): status='rendered' AND brief_json IS NOT NULL =
+        # 61 rows. NEVER a write — SELECT only.
+        sql = (
+            "SELECT id, topic, register, brief_json, created_at "
+            "FROM war_room_drafts "
+            "WHERE status = 'rendered' AND brief_json IS NOT NULL "
+            "ORDER BY created_at ASC"
+        )
+        if limit:
+            sql += " LIMIT $1"
+            rows = await conn.fetch(sql, limit)
+        else:
+            rows = await conn.fetch(sql)
+    finally:
+        await conn.close()
+
+    decks: list[dict[str, Any]] = []
+    for r in rows:
+        brief = r["brief_json"]
+        if isinstance(brief, str):
+            brief = json.loads(brief)
+        brief = _scrub_pii(brief)
+        decks.append({
+            "id": str(r["id"]),
+            "topic": r["topic"],
+            "register": r["register"],
+            "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+            "brief_json": brief,
+        })
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(decks, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info("Fetched %d decks -> %s", len(decks), out_path)
+    return len(decks)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# --replay: typed-prompt composition + validate + family-resolution check
+# ─────────────────────────────────────────────────────────────────────────
+
+_TYPED_SCHEMA_DIRECTIVE = """OUTPUT FORMAT — TYPED CAROUSEL IR (Phase-1 shadow replay; NOT the production flat schema)
+
+Return ONE JSON object: {"register": "<one of: rituale|analitico|ironico|militante|pedagogico|poetico|tecnico>", "slides": [...]}.
+
+Every slide is a JSON object with a "kind" field (EXACTLY one of the 11 below) plus that kind's own fields. Slide 1 is ALWAYS kind="cover". Pick the kind that fits what THIS slide is actually doing — a list of facts is fact_stack, not prose; a back-and-forth is qa, not two statement slides; a step-by-step is timeline; a 2-4-way breakdown is triad; a single number is stat.
+
+  kind="cover"       headline (str, required), subhead (str), regulation_code (str), image_prompt (str)
+  kind="prose"       headline (str, required), body (str, required), subhead (str)
+  kind="statement"   statement (str, required) — a 3-15 word punch line, never a paragraph
+  kind="fact_stack"  heading (str, required), facts (list[str], required, >=1 — each item is ONE fact line), take_label (str), take_line (str)
+  kind="status_list" heading (str, required), items (list[{label, value, status: "neutral"|"critical"|"positive"}], required, >=1)
+  kind="timeline"    heading (str, required), steps (list[{date, label, current: bool}], required, >=1)
+  kind="triad"       heading (str, required), items (list[{title, desc}], required, 2-6 items — e.g. "3 forces behind the rise")
+  kind="qa"          pairs (list[{voice, line}], required, >=2 — first two entries are the two voices in the exchange)
+  kind="stat"        value (str, required), unit (str), label (str), context (str)
+  kind="citation"    claim (str, required), sources (list[{code, issuer, date, url, note}], required, >=1)
+  kind="cta"         invite (str, required), trust_marker (str), reach (str)
+
+Worked examples (illustrative SHAPE only — invent real content grounded in the article above, never reuse this text):
+
+{"kind": "cover", "headline": "NEW LEVY RAISES RP 369 BILLION", "subhead": "TOURISM", "regulation_code": "", "image_prompt": "wide shot of a Bali beach at golden hour, editorial photography"}
+
+{"kind": "fact_stack", "heading": "THE NUMBERS", "facts": ["7,050,314 foreign arrivals in 2025", "Rp369 billion collected via the tourist levy", "Only 34% compliance so far"], "take_label": "The Bali Zero read", "take_line": "Demand is not the problem here — enforcement is."}
+
+{"kind": "qa", "pairs": [{"voice": "INVESTOR", "line": "IS THE LEVY NEW?"}, {"voice": "BALI ZERO", "line": "NO. ENFORCEMENT IS."}]}
+
+Produce the full slide-shaped JSON NOW as ONE JSON object matching the kinds above exactly (a ```json fence is fine, or bare JSON — both parse). No text outside the JSON object.
+"""
+
+_PROD_DIRECTIVE_MARKER = "Produce the full "
+
+
+def _swap_output_format(base_prompt: str, typed_schema_block: str) -> str:
+    """The ONE swapped section (mandate STEP 3): everything ABOVE the
+    production directive — system instructions + brief context + liveness/
+    tone steer — is kept verbatim (it came straight out of wr2_draft_
+    generator._build_draft_prompt); only the trailing free-form-JSON
+    instruction is replaced with the typed-schema directive. Falls back to
+    APPENDING rather than crashing if production's prompt phrasing drifts —
+    never silently drops the brief context."""
+    idx = base_prompt.rfind(_PROD_DIRECTIVE_MARKER)
+    if idx == -1:
+        logger.warning(
+            "typed-prompt swap marker %r not found in base prompt — appending "
+            "typed schema after the full base prompt instead of swapping",
+            _PROD_DIRECTIVE_MARKER,
+        )
+        return f"{base_prompt}\n\n{typed_schema_block}"
+    return f"{base_prompt[:idx].rstrip()}\n\n{typed_schema_block}"
+
+
+def _build_typed_prompt(deck: dict[str, Any]) -> str:
+    brief = deck.get("brief_json") or {}
+    topic = deck.get("topic") or brief.get("article_title") or ""
+    summary = brief.get("article_summary") or ""
+    source_url = brief.get("source_url") or ""
+    enrichment = brief.get("enrichment")
+    live_reasons = brief.get("live_news_reasons")
+    liveness_tier = brief.get("liveness_tier") or ""
+
+    base_prompt = wr2dg._build_draft_prompt(
+        topic,
+        summary,
+        source_url,
+        enrichment=enrichment,
+        live_reasons=live_reasons,
+        avoid_steer="",
+        liveness_tier=liveness_tier,
+        recent_kickers=None,
+    )
+    return _swap_output_format(base_prompt, _TYPED_SCHEMA_DIRECTIVE)
+
+
+def _make_call_fn() -> Callable[[str], str]:
+    """Sync text-in/text-out wrapper over the sanctioned OAuth CLI path
+    (backend.llm.claude_oauth_client.complete_async — never the banned
+    Anthropic SDK, never ANTHROPIC_API_KEY). generate_slides_typed's
+    contract is a plain sync callable (mirrors the OSS evidence's
+    subprocess.run-based call_claude_cli) — this closure bridges that to
+    the repo's async client via a fresh asyncio.run() per call, which is
+    safe here because the replay driver itself is plain sync/sequential
+    (never inside a running event loop when this is invoked)."""
+    from backend.llm.claude_oauth_client import complete_async
+
+    def call_fn(prompt: str) -> str:
+        async def _call() -> str:
+            resp = await complete_async(
+                prompt,
+                model=_COMPOSE_MODEL,
+                timeout_s=300,
+                endpoint="wr2_ir_shadow_replay",
+            )
+            return resp.text
+
+        return asyncio.run(_call())
+
+    return call_fn
+
+
+def _replay_one(deck: dict[str, Any], *, max_retries: int) -> dict[str, Any]:
+    deck_id = deck["id"]
+    result: dict[str, Any] = {"id": deck_id, "topic": deck.get("topic")}
+
+    try:
+        typed_prompt = _build_typed_prompt(deck)
+    except Exception as e:  # a malformed brief must not kill the run
+        result.update({"status": "error", "attempts": 0, "error": f"prompt-build failed: {e!r}"})
+        return result
+
+    call_fn = _make_call_fn()
+    call_count = {"n": 0}
+
+    def counting_call_fn(p: str) -> str:
+        call_count["n"] += 1
+        return call_fn(p)
+
+    t0 = time.perf_counter()
+    try:
+        deck_obj = ir.generate_slides_typed(typed_prompt, counting_call_fn, max_retries=max_retries)
+    except ir.IRValidationExhausted as e:
+        result.update({
+            "status": "fail_after_retries",
+            "attempts": call_count["n"],
+            "error": str(e),
+            "last_raw_text_head": e.last_raw_text[:2000],
+            "wall_s": round(time.perf_counter() - t0, 1),
+        })
+        return result
+    except Exception as e:  # per-deck try/except: one bad deck never kills the run
+        result.update({
+            "status": "error",
+            "attempts": call_count["n"],
+            "error": repr(e),
+            "wall_s": round(time.perf_counter() - t0, 1),
+        })
+        return result
+
+    total = len(deck_obj.slides)
+    kinds: list[str] = []
+    families: list[dict[str, str]] = []
+    resolved_ok = True
+    for i, s in enumerate(deck_obj.slides, start=1):
+        kinds.append(s.kind)
+        cdict = ir.to_composer_dict(s, index=i, total=total)
+        resolved = map_slide_to_family(cdict, i, total)
+        expected = ir.SLIDE_KIND_TO_FAMILY[s.kind]
+        families.append({"kind": s.kind, "expected_family": expected, "resolved_family": resolved})
+        if resolved != expected:
+            resolved_ok = False
+
+    result.update({
+        "status": "ok",
+        "attempts": call_count["n"],
+        "register": deck_obj.register,
+        "slide_count": total,
+        "kinds": kinds,
+        "families": families,
+        "family_resolution_ok": resolved_ok,
+        "wall_s": round(time.perf_counter() - t0, 1),
+    })
+    return result
+
+
+def _aggregate(results: list[dict[str, Any]]) -> dict[str, Any]:
+    n = len(results)
+    ok = [r for r in results if r.get("status") == "ok"]
+    first_try = [r for r in ok if r.get("attempts") == 1]
+    within_1_retry = [r for r in ok if isinstance(r.get("attempts"), int) and r["attempts"] <= 2]
+    failed = [r for r in results if r.get("status") in ("fail_after_retries", "error")]
+
+    kind_histogram: dict[str, int] = {}
+    family_counts: dict[str, int] = {}
+    resolved_total = 0
+    resolved_ok_total = 0
+    for r in ok:
+        for k in r.get("kinds", []):
+            kind_histogram[k] = kind_histogram.get(k, 0) + 1
+        for f in r.get("families", []):
+            family_counts[f["resolved_family"]] = family_counts.get(f["resolved_family"], 0) + 1
+            resolved_total += 1
+            if f["resolved_family"] == f["expected_family"]:
+                resolved_ok_total += 1
+
+    return {
+        "n_decks": n,
+        "first_try_valid_rate": round(len(first_try) / n, 3) if n else None,
+        "valid_within_1_retry_rate": round(len(within_1_retry) / n, 3) if n else None,
+        "fail_after_3_rate": round(len(failed) / n, 3) if n else None,
+        "kind_histogram": kind_histogram,
+        "family_resolution": {
+            "resolved_pct": round(resolved_ok_total / resolved_total, 3) if resolved_total else None,
+            "per_family_counts": family_counts,
+        },
+        "per_deck": results,
+    }
+
+
+def _write_metrics(out_path: Path, results: list[dict[str, Any]]) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(_aggregate(results), indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _run_replay(fixture_path: Path, out_path: Path, *, limit: int | None, sleep_s: float, max_retries: int) -> None:
+    decks: list[dict[str, Any]] = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if limit:
+        decks = decks[:limit]
+
+    results: list[dict[str, Any]] = []
+    done_ids: set[str] = set()
+    if out_path.exists():
+        try:
+            prior = json.loads(out_path.read_text(encoding="utf-8"))
+            results = prior.get("per_deck", [])
+            done_ids = {r["id"] for r in results if "id" in r}
+            if done_ids:
+                logger.info("Resuming: %d decks already in %s", len(done_ids), out_path)
+        except Exception:
+            logger.warning("Could not parse existing %s as prior results — starting fresh", out_path)
+
+    for i, deck in enumerate(decks):
+        if deck["id"] in done_ids:
+            continue
+        logger.info("[%d/%d] replaying deck %s (%s)", i + 1, len(decks), deck["id"], str(deck.get("topic", ""))[:60])
+        try:
+            r = _replay_one(deck, max_retries=max_retries)
+        except Exception as e:  # belt-and-suspenders at the outer loop too
+            r = {"id": deck["id"], "status": "error", "error": repr(e)}
+        results.append(r)
+        _write_metrics(out_path, results)  # incremental — safe to Ctrl-C / resume
+        if i < len(decks) - 1:
+            time.sleep(sleep_s)
+
+    _write_metrics(out_path, results)
+    logger.info("Replay complete: %d decks -> %s", len(results), out_path)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--fetch", action="store_true", help="Read-only fetch of historical decks into a JSON fixture")
+    mode.add_argument("--replay", action="store_true", help="Replay decks from a fixture through the typed IR")
+    parser.add_argument("--out", type=Path, help="Output path (--fetch: fixture JSON; --replay: metrics JSON)")
+    parser.add_argument("--fixture", type=Path, help="Input fixture JSON (--replay only)")
+    parser.add_argument("--limit", type=int, default=None, help="Cap the number of decks processed")
+    parser.add_argument("--sleep", type=float, default=3.0, help="Seconds between deck calls in --replay")
+    parser.add_argument("--max-retries", type=int, default=3, help="Validate-and-retry attempts per deck")
+    args = parser.parse_args()
+
+    if args.fetch:
+        if not args.out:
+            parser.error("--fetch requires --out <fixture.json>")
+        n = asyncio.run(_fetch_decks(args.out, args.limit))
+        print(f"Fetched {n} decks -> {args.out}")
+        return 0
+
+    if not args.fixture:
+        parser.error("--replay requires --fixture <fixture.json>")
+    if not args.out:
+        parser.error("--replay requires --out <metrics.json>")
+    _run_replay(args.fixture, args.out, limit=args.limit, sleep_s=args.sleep, max_retries=args.max_retries)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 1 of the WR2 editorial-intelligence design ([`.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md`](../blob/main/.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md), §2 "Mossa A — Carousel IR" + §3 rollout step 1): a typed Carousel IR and a shadow-replay harness to measure it against historical decks before any production cutover.

**ADDITIVE ONLY.** `scripts/wr2_draft_generator.py` and `scripts/wr2_html_renderer/composer.py` are untouched — zero diff, confirmed by `git diff --stat` before commit. Nothing in either production file imports or calls anything added here. Production behavior is byte-identical before/after this PR.

### What it adds

- **`scripts/wr2_carousel_ir.py`** — a pydantic v2 discriminated union (`Slide`, discriminator `kind`) over 11 slide kinds: `cover, prose, statement, fact_stack, status_list, timeline, triad, qa, stat, citation, cta`. Validation is lenient-first per spec §2 (red-team BLOCKER-1): strict only on the `kind` tag and each kind's structurally-required field(s); every other scalar is coerced/truncated/defaulted, mirroring `wr2_draft_generator._normalise_slides`'s existing tolerances (headline[:80], body[:500], subhead word/char cap). `to_composer_dict()` projects a validated slide into the exact dict shape `composer.py`'s layout skeletons consume — field names verified this session against the real `.md` skeleton files + `_fill_placeholders`/`_expand_each_blocks`/`_qa_dialogue_fields` source, not guessed from the spec's simplified summary table (several kinds diverge from that table — documented per-branch in code, e.g. qa uses `voice`/`line` not `q`/`a`, timeline uses `accent`/`date`/`label` not `date`/`event`/`current`). `generate_slides_typed()` runs a validate-and-retry loop (max 3 attempts) and raises `IRValidationExhausted` on exhaustion — it never silently coerces a failed slide down to a simpler kind (kind-preservation is a hard design rule, spec §2 Kimi red-team objection #3).
- **`scripts/wr2_ir_shadow_replay.py`** — `--fetch` (read-only Postgres pull of historical decks with a usable `brief_json`, asyncpg, `DATABASE_URL` env) and `--replay` (builds the typed prompt by REUSING production's own `wr2_draft_generator._build_draft_prompt` with one swapped section — the output-format directive — then calls the same `claude-opus-4-7` model production uses, validates, and checks family-resolution via the REAL `composer.map_slide_to_family`). Writes per-deck + aggregate metrics (`first_try_valid_rate`, `valid_within_1_retry_rate`, `fail_after_3_rate`, `kind_histogram`, `family_resolution`). Sequential, rate-limit-friendly, resumable, per-deck try/except.
- **`scripts/tests/test_wr2_carousel_ir.py`** — 59 tests: guilt+innocence validation corpus, `extract_json_from_codeblock` edge cases (ported verbatim from instructor v2, MIT — attribution in code), per-kind projection → real `map_slide_to_family` resolution for all 11/11 kinds (the core Phase-1 assertion), retry-loop against a fake `call_fn`.
- **`.github/workflows/wr2-queue-tests.yml`** — wired the new test file + module paths into the existing WR2 CI battery (already has the right dependency footprint — `pydantic` was already installed there) so this isn't "exists but not armed" (cicatrix-superscar.md family #2).

### Verification this session

- Real end-to-end smoke: `--replay --limit 1` against the live `claude-opus-4-7` OAuth CLI produced a 7-slide, 6-kind deck (cover/statement/status_list/prose×2/citation/cta) that **validated on the first attempt** with **100% family-resolution accuracy**.
- `--fetch --limit 3` against the live read-only Postgres proxy confirmed the query path.
- 164/164 new+adjacent tests pass; full `scripts/wr2_html_renderer/tests/` + related batteries pass except one **pre-existing, unrelated** failure (`test_wr2_smart_hero.py::test_routing_layout_family_typo_falls_through_to_auto`) confirmed present on unmodified `main` too — a stale test assertion from before the 2026-07-11 `stat-card-hero` promotion out of `UNDEFINED_FAMILIES` (composer.py's own inline comment documents the promotion). Not touched by this PR; flagged as a discovered pre-existing issue.

### Discovered gaps (documented in-code, NOT fixed — out of scope for this additive-only PR)

- `source-citation`'s top-level `{{title}}` and `elegant-close`'s `trust_marker`/`reach`/`invite`/`primary_source_url`/`qr_caption` are **never substituted anywhere** in `composer._fill_placeholders` (verified by grep, zero hits for all of them) — both families render broken end-to-end today, independent of this IR. A Phase-3 `composer.py` fix is implied.
- The spec's §8 brand decisions (7-arc slate + role sequences, caps-only-on-headings, "The Bali Zero read" closer, palette-per-domain) are **not yet Zero-ratified on disk** as of this session — re-read the spec file verbatim this turn; §8 is explicitly a request-for-ratification ("Decisioni Zero-gated ... la sessione NON le prende"), and no later commit/PR closes it. The inert `ARCS`/`PALETTE_BY_DOMAIN`/`CAPS_POLICY`/`CLOSER_FRANCHISE_LABEL` constants in `wr2_carousel_ir.py` are built anyway (Phase 1 is shadow-only — nothing here is read by production) but are explicitly labeled DRAFT/PROPOSED in code, with a loud provenance-caveat comment, not presented as a ratification record.
- Historical-deck population: the build mandate assumed "~34 rendered/published decks"; the verified live count (`SELECT status, count(*) FROM war_room_drafts GROUP BY status`) is **61** rows with `status='rendered' AND brief_json IS NOT NULL` — the harness's `--fetch` filter uses the verified number, not the unverified one.
- The full 61-deck replay was **not run** — quota spend at that scale is the orchestrator's call, per the build mandate. Only the 1-deck smoke test above was executed.

## Test plan

- [x] `scripts/tests/test_wr2_carousel_ir.py` — 59/59 pass standalone
- [x] Combined with the existing WR2 queue battery (exact CI invocation, `PYTHONPATH=apps/backend-rag`) — 164/164 pass
- [x] `scripts/wr2_html_renderer/tests/` full suite — 121/121 pass (untouched, proves no regression)
- [x] `actionlint` on the modified workflow — clean
- [x] Live smoke: `--fetch --limit 3` + `--replay --limit 1` against real Postgres + real Claude OAuth CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
