### PR TITLE
fix(ingest): retarget ingest_2026_laws.py off the orphaned legal_unified_2026 collection

### DIFF
--- a/apps/backend-rag/scripts/ingest_2026_laws.py
+++ b/apps/backend-rag/scripts/ingest_2026_laws.py
@@ -89,7 +89,13 @@ LAWS_2026 = [
     },
 ]
 
-COLLECTION_NAME = "legal_unified_2026"
+# "legal_unified_2026" was a dead end: absent from collection_registry.py's
+# CANONICAL_COLLECTION_ALIASES (so LegalIngestionService's preflight allowlist
+# rejects it) and never selected by any live retrieval routing table
+# (multi_hop.py / query_planner.py / kg_orchestrator.py / agentic/tools.py all
+# route legal-domain queries to "legal_unified" only). Content ingested under
+# the old name would sit in Qdrant unreachable by any user-facing query.
+COLLECTION_NAME = "legal_unified"
 SOURCE_DIR = PROJECT_ROOT / "data/kb_sources/2026_updates"
 
 


### PR DESCRIPTION
## Summary
- `legal_unified_2026` is absent from `collection_registry.py`'s `CANONICAL_COLLECTION_ALIASES`, so `LegalIngestionService`'s preflight allowlist (`ALLOWED_CANONICAL_COLLECTIONS = {legal_unified, tax_genius}`) rejects it — every invocation of `ingest_2026_laws.py` fails at service construction, before any document-specific processing (`LegalIngestIntegrityError`, hit live 2026-07-21 attempting to ingest PMK_1_2026).
- It's also never selected by any live retrieval routing table (`multi_hop.py` / `query_planner.py` / `kg_orchestrator.py` / `agentic/tools.py` all route legal-domain queries to `legal_unified` only) — content ingested under the old name would sit in Qdrant unreachable by any user-facing query.
- One-line fix: point at the canonical, actively-queried `legal_unified` collection instead (same target the sibling `ingest_tier1_gaps.py` already uses correctly).
- Pre-existing `legal_unified_2026` collection (15,410 points) is untouched by this change — those points remain orphaned from live retrieval; rescuing them is a separate follow-up, not addressed here.

## Verification
Side-effect-free import check (no Qdrant/Postgres touched):
```
canonicalize_collection_name("legal_unified_2026") -> "legal_unified_2026" -> allowed? False   (old, reproduces the crash)
canonicalize_collection_name("legal_unified")      -> "legal_unified"      -> allowed? True    (new, fixed)
```

## Test plan
- [x] Import-chain verification confirms the fix resolves the preflight allowlist rejection
- [ ] Live re-run of `ingest_2026_laws.py` against the 4 remaining 2026-vintage documents (PP_9_2026, Pergub_Bali_14_2023, SE_Gubernur_Bali_09_2025, PMK_1_2026) — in progress separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
