### PR TITLE
feat(observability): expose real FAQ/semantic cache hit-rate; stop mislabeling generic cache

### DIFF
--- a/apps/backend-rag/backend/app/metrics.py
+++ b/apps/backend-rag/backend/app/metrics.py
@@ -113,6 +113,26 @@ faq_cache_api_cost_saved_usd = safe_register_counter(
     "Estimated API cost savings from FAQ cache (USD)",
 )
 
+# Semantic Cache Metrics (Redis-backed exact + embedding-similarity lookup,
+# backend/services/search/semantic_cache.py — the SECOND cache tier checked
+# in the WA orchestrator hot path, after the FAQ cache misses; see
+# orchestrator_core.py::check_semantic_cache). Previously had NO Prometheus
+# counters at all — added 2026-07-21 so the real hit-rate is observable
+# instead of only inferable from log lines.
+semantic_cache_hits_total = safe_register_counter(
+    "zantara_semantic_cache_hits_total",
+    "Total semantic cache hits (exact Redis key match or cosine-similarity match)",
+    ["match_type"],  # exact, semantic
+)
+semantic_cache_misses_total = safe_register_counter(
+    "zantara_semantic_cache_misses_total",
+    "Total semantic cache misses (no exact or similar-enough entry found)",
+)
+semantic_cache_errors_total = safe_register_counter(
+    "zantara_semantic_cache_errors_total",
+    "Total semantic cache lookup errors (Redis/embedding failures)",
+)
+
 # Phase-0 curated-cache safety rails (FATAL 1/4, research/operations/
 # 2026-07-17-full-domain-cache-design.md §8)
 faq_cache_domain_mismatch_averted_total = safe_register_counter(

--- a/apps/backend-rag/backend/app/routers/health.py
+++ b/apps/backend-rag/backend/app/routers/health.py
@@ -213,6 +213,27 @@ def _check_resource_thresholds(process_mode: str | None) -> tuple[str | None, st
     return None, None
 
 
+def _counter_snapshot(counter: Any) -> tuple[int, dict[str, int]]:
+    """Read a Prometheus Counter's CURRENT value via its public collect() API.
+
+    Returns (total, breakdown) — total summed across every label
+    combination, breakdown keyed by the joined label values (empty dict
+    for a counter with no labels). This is a snapshot of THIS process'
+    in-memory counter (prometheus_client keeps state per-process, not
+    per-fleet) — see the "scope" field on faq_semantic_cache below.
+    """
+    total = 0
+    breakdown: dict[str, int] = {}
+    for sample in counter.collect()[0].samples:
+        if not sample.name.endswith("_total"):
+            continue  # skip the paired "_created" timestamp samples
+        total += int(sample.value)
+        if sample.labels:
+            key = ",".join(f"{k}={v}" for k, v in sorted(sample.labels.items()))
+            breakdown[key] = int(sample.value)
+    return total, breakdown
+
+
 @router.get(
     "",
     response_model=HealthResponse,
@@ -503,18 +524,81 @@ async def detailed_health(request: Request) -> dict[str, Any]:
     except Exception as e:
         services["health_monitor"] = {"status": "error", "critical": False, "error": str(e)}
 
-    # Check Query Cache
+    # Check generic query cache (backend.core.cache.CacheService — powers
+    # KG/query-expansion/embedding caching, e.g. kg_cache.py, query_expansion.py,
+    # search_service.py). NOT the WA orchestrator's FAQ/semantic cache — see
+    # faq_semantic_cache below for that. Renamed 2026-07-21 (was "query_cache",
+    # which read as "the WA cache" but measured a different service entirely).
     try:
         from backend.core.cache import get_cache_service
 
         cache_stats = get_cache_service().get_stats()
-        services["query_cache"] = {
+        services["generic_query_cache"] = {
             "status": "healthy",
             "critical": False,
             "details": cache_stats,
         }
     except Exception as e:
-        services["query_cache"] = {"status": "unavailable", "critical": False, "error": str(e)}
+        services["generic_query_cache"] = {
+            "status": "unavailable",
+            "critical": False,
+            "error": str(e),
+        }
+
+    # Check FAQ + semantic cache — the two tiers the WA orchestrator actually
+    # checks before the expensive ReAct loop (orchestrator_core.py:
+    # check_faq_cache / check_semantic_cache). Reads the real Prometheus
+    # counters those methods increment, NOT the generic cache above.
+    try:
+        from backend.app.metrics import (
+            faq_cache_errors_total,
+            faq_cache_hits_total,
+            faq_cache_misses_total,
+            semantic_cache_errors_total,
+            semantic_cache_hits_total,
+            semantic_cache_misses_total,
+        )
+
+        faq_hits, faq_hits_by_domain = _counter_snapshot(faq_cache_hits_total)
+        faq_misses, _ = _counter_snapshot(faq_cache_misses_total)
+        faq_errors, _ = _counter_snapshot(faq_cache_errors_total)
+        faq_total = faq_hits + faq_misses
+
+        sem_hits, sem_hits_by_match_type = _counter_snapshot(semantic_cache_hits_total)
+        sem_misses, _ = _counter_snapshot(semantic_cache_misses_total)
+        sem_errors, _ = _counter_snapshot(semantic_cache_errors_total)
+        sem_total = sem_hits + sem_misses
+
+        services["faq_semantic_cache"] = {
+            "status": "healthy",
+            "critical": False,
+            "details": {
+                # Made explicit on purpose: prometheus_client counters are
+                # process-local. This process may be one of several Fly
+                # machines/workers — this is NOT a fleet-wide hit-rate.
+                "scope": "per-worker (this process only), since last restart — NOT a fleet-wide aggregate",
+                "faq_cache": {
+                    "hits": faq_hits,
+                    "misses": faq_misses,
+                    "errors": faq_errors,
+                    "hit_rate": round(faq_hits / faq_total, 3) if faq_total else None,
+                    "hits_by_domain": faq_hits_by_domain,
+                },
+                "semantic_cache": {
+                    "hits": sem_hits,
+                    "misses": sem_misses,
+                    "errors": sem_errors,
+                    "hit_rate": round(sem_hits / sem_total, 3) if sem_total else None,
+                    "hits_by_match_type": sem_hits_by_match_type,
+                },
+            },
+        }
+    except Exception as e:
+        services["faq_semantic_cache"] = {
+            "status": "unavailable",
+            "critical": False,
+            "error": str(e),
+        }
 
     # Check Rate Limiter
     try:

--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
@@ -393,6 +393,12 @@ class OrchestratorCore:
                     set_span_attribute("cache_hit", "true")
                     set_span_status("ok")
 
+                    from backend.app.metrics import semantic_cache_hits_total
+
+                    semantic_cache_hits_total.labels(
+                        match_type=cached.get("cache_hit", "unknown"),
+                    ).inc()
+
                     cached_result = cached.get("result", cached)
                     answer = cached_result.get("answer", "")
                     sources = cached_result.get("sources", [])
@@ -407,9 +413,17 @@ class OrchestratorCore:
                         document_count=len(sources),
                     )
                 set_span_attribute("cache_hit", "false")
+
+                from backend.app.metrics import semantic_cache_misses_total
+
+                semantic_cache_misses_total.inc()
             except (KeyError, ValueError, RuntimeError) as e:
                 logger.warning("Cache lookup failed: %s", e, exc_info=True)
                 set_span_status("error", str(e))
+
+                from backend.app.metrics import semantic_cache_errors_total
+
+                semantic_cache_errors_total.inc()
 
         return None
 

--- a/apps/backend-rag/backend/tests/routers/test_health.py
+++ b/apps/backend-rag/backend/tests/routers/test_health.py
@@ -151,3 +151,56 @@ class TestHealthEndpoints:
         assert body["status"] == "degraded"
         assert body["services"]["database"]["status"] == "healthy"
         assert body["services"]["redis"]["details"]["connected"] is True
+
+    @pytest.mark.integration
+    def test_detailed_health_reports_real_faq_and_semantic_cache_hit_rate(
+        self,
+        app: FastAPI,
+        client: TestClient,
+    ) -> None:
+        """faq_semantic_cache must report the WA orchestrator's real FAQ +
+        semantic cache counters — not the unrelated generic CacheService
+        (backend.core.cache) that the old "query_cache" block exposed under
+        a name that read as "the WA cache". Regression guard for the
+        cache-hit-rate blind spot fixed 2026-07-21."""
+        from backend.app.metrics import (
+            faq_cache_hits_total,
+            faq_cache_misses_total,
+            semantic_cache_hits_total,
+            semantic_cache_misses_total,
+        )
+        from backend.app.routers.health import _counter_snapshot
+
+        faq_hits_before, _ = _counter_snapshot(faq_cache_hits_total)
+        faq_misses_before, _ = _counter_snapshot(faq_cache_misses_total)
+        sem_hits_before, _ = _counter_snapshot(semantic_cache_hits_total)
+        sem_misses_before, _ = _counter_snapshot(semantic_cache_misses_total)
+
+        # Simulate one hit + one miss on each cache tier.
+        faq_cache_hits_total.labels(domain="tax").inc()
+        faq_cache_misses_total.inc()
+        semantic_cache_hits_total.labels(match_type="semantic").inc()
+        semantic_cache_misses_total.inc()
+
+        response = client.get("/health/detailed")
+
+        assert response.status_code == 200
+        services = response.json()["services"]
+
+        # Old misleading key must be gone; renamed key present.
+        assert "query_cache" not in services
+        assert "generic_query_cache" in services
+
+        cache = services["faq_semantic_cache"]
+        assert cache["status"] == "healthy"
+        assert cache["details"]["scope"].startswith("per-worker")
+
+        faq = cache["details"]["faq_cache"]
+        assert faq["hits"] == faq_hits_before + 1
+        assert faq["misses"] == faq_misses_before + 1
+        assert faq["hits_by_domain"]["domain=tax"] >= 1
+
+        semantic = cache["details"]["semantic_cache"]
+        assert semantic["hits"] == sem_hits_before + 1
+        assert semantic["misses"] == sem_misses_before + 1
+        assert semantic["hits_by_match_type"]["match_type=semantic"] >= 1


### PR DESCRIPTION
## Problem
The WA bot's speed rests on cache-first (FAQ exact-match + semantic cache early-return before the ReAct loop). But `/health/detailed`'s `query_cache` block measured a DIFFERENT service (`backend.core.cache.CacheService` — KG/expansion/embedding), NOT the orchestrator's FAQ/semantic caches. Result: we were blind to the real hit-rate (the metric showed 0.0% and misled diagnosis). Semantic cache had ZERO machine-readable counters at all.

## Fix (read-only observability only — no cache behavior change)
- Added Prometheus counters for semantic cache (`semantic_cache_hits/misses/errors_total`), mirroring the existing FAQ counter pattern; instrumented the hit/miss/error branches in `check_semantic_cache` with `.inc()` calls only (hot-path early-return logic untouched).
- New `/health/detailed` `faq_semantic_cache` block reading the REAL counters (FAQ + semantic), via a `_counter_snapshot()` helper over the public Prometheus `.collect()` API.
- Renamed the misleading `query_cache` block → `generic_query_cache` with a comment on what it actually measures (verified no consumer keys on the old field).

## Honest scoping
Numbers are **per-worker, since-boot** (prometheus_client counters are process-local; Fly runs >1 worker) — labeled verbatim in a `scope` field, NOT presented as a fleet aggregate (avoids a W89 proxy-lie). A true fleet number needs a scraping Prometheus server (out of scope).

## Tests
`test_health.py`: increments both counter families, asserts deltas reflected, asserts `query_cache` key gone + `generic_query_cache`/`faq_semantic_cache` present. Health 7 passed; orchestrator cache suites 93 passed; §11 pre-deploy set 91 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)