### PR TITLE
feat(wr2): deterministic editorial pre-gate + guard-conformance corpus (editorial-intelligence Phase 2)

### DIFF
--- a/.github/workflows/guard-conformance.yml
+++ b/.github/workflows/guard-conformance.yml
@@ -31,6 +31,8 @@ on:
       - "scripts/test_guardrails_core_overmatch.py"
       - "infra/scar-gates/**"
       - "scripts/wr2_html_renderer/designer_loop.py"
+      - "scripts/wr2_editorial_pregate.py"
+      - "scripts/tests/test_wr2_editorial_pregate.py"
       - ".github/workflows/guard-conformance.yml"
 
 concurrency:
@@ -58,7 +60,7 @@ jobs:
           fi
           base="${{ github.event.pull_request.base.sha }}"
           if git diff --name-only "$base"...HEAD | grep -qE \
-            '^(infra/guard-conformance/|infra/claude-hooks/|scripts/hooks/|scripts/openclaw_whatsapp_bridge\.py|apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script\.py|scripts/guardrails_static_core\.py|scripts/test_guardrails_(core_)?overmatch\.py|infra/scar-gates/|scripts/wr2_html_renderer/designer_loop\.py|\.github/workflows/guard-conformance\.yml)'; then
+            '^(infra/guard-conformance/|infra/claude-hooks/|scripts/hooks/|scripts/openclaw_whatsapp_bridge\.py|apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script\.py|scripts/guardrails_static_core\.py|scripts/test_guardrails_(core_)?overmatch\.py|infra/scar-gates/|scripts/wr2_html_renderer/designer_loop\.py|scripts/wr2_editorial_pregate\.py|scripts/tests/test_wr2_editorial_pregate\.py|\.github/workflows/guard-conformance\.yml)'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/wr2-queue-tests.yml
+++ b/.github/workflows/wr2-queue-tests.yml
@@ -24,6 +24,8 @@ on:
       - "scripts/wr2_html_renderer/**"
       - "scripts/wr2_carousel_ir.py"
       - "scripts/wr2_ir_shadow_replay.py"
+      - "scripts/wr2_editorial_pregate.py"
+      - "scripts/wr2_pregate_shadow.py"
       - "scripts/tests/test_wr2_queue_hygiene.py"
       - "scripts/tests/test_wr2_visibility_chain.py"
       - "scripts/tests/test_wr2_rerender_requeue.py"
@@ -31,6 +33,7 @@ on:
       - "scripts/tests/test_wr2_pipeline_consolidation.py"
       - "scripts/tests/test_wr2_daily_reconciler.py"
       - "scripts/tests/test_wr2_carousel_ir.py"
+      - "scripts/tests/test_wr2_editorial_pregate.py"
       - "scripts/tests/conftest.py"
       - "apps/backend-rag/backend/services/canva_renderer_v2/_pg.py"
       - ".github/workflows/wr2-queue-tests.yml"
@@ -65,4 +68,5 @@ jobs:
             scripts/tests/test_wr2_pipeline_consolidation.py \
             scripts/tests/test_wr2_daily_reconciler.py \
             scripts/tests/test_wr2_carousel_ir.py \
+            scripts/tests/test_wr2_editorial_pregate.py \
             -q

--- a/infra/guard-conformance/check_guard_conformance.py
+++ b/infra/guard-conformance/check_guard_conformance.py
@@ -137,26 +137,34 @@ def is_armed(test_rel_path: str, wf_text: str) -> bool:
 # ------------------------------------------------------------------ checks
 
 
-def check_bridge(surface: dict[str, Any], wf_text: str) -> list[str]:
+def check_bridge(surface: dict[str, Any], wf_text: str, *, label: str = "bridge") -> list[str]:
+    """Generic {source, census:{method,prefix}, test_file, guards} surface
+    checker (C1 census parity, C2 guilt+innocence presence, C3 anti-phantom,
+    C4 armed-in-CI). `label` only tags violation messages (e.g. "bridge" for
+    the WhatsApp bridge `_guard_*` surface, "wr2-pregate" for the WR2
+    editorial pre-gate `check_*` surface) — the logic is shape-generic, not
+    bridge-specific, so this one function serves every surface with that
+    shape rather than growing a bridge-only copy per surface (scar #3: a
+    duplicated-not-shared checker is itself a guard the checker can't check)."""
     violations: list[str] = []
     source = REPO_ROOT / surface["source"]
     test_file = REPO_ROOT / surface["test_file"]
     prefix = surface["census"]["prefix"]
 
     if not source.exists():
-        return [f"C1[bridge] source missing on disk: {surface['source']}"]
+        return [f"C1[{label}] source missing on disk: {surface['source']}"]
 
     in_code = ast_guard_defs(source, prefix)
     in_registry = set(surface["guards"].keys())
 
     for missing in sorted(in_code - in_registry):
         violations.append(
-            f"C1[bridge] guard `{missing}` exists in code but is NOT registered "
+            f"C1[{label}] guard `{missing}` exists in code but is NOT registered "
             f"— write its guilt+innocence tests, then add it to registry.json"
         )
     for stale in sorted(in_registry - in_code):
         violations.append(
-            f"C1[bridge] registry entry `{stale}` no longer exists in code — remove or rename"
+            f"C1[{label}] registry entry `{stale}` no longer exists in code — remove or rename"
         )
 
     for guard, entry in sorted(surface["guards"].items()):
@@ -166,17 +174,17 @@ def check_bridge(surface: dict[str, Any], wf_text: str) -> list[str]:
             refs = entry.get(kind, [])
             if not refs:
                 violations.append(
-                    f"C2[bridge] `{guard}` has NO {kind} test — the #3 antidote requires both"
+                    f"C2[{label}] `{guard}` has NO {kind} test — the #3 antidote requires both"
                 )
             for ref in refs:
                 if not def_exists(test_file, ref):
                     violations.append(
-                        f"C3[bridge] `{guard}` {kind} ref `{ref}` not found as a def in "
+                        f"C3[{label}] `{guard}` {kind} ref `{ref}` not found as a def in "
                         f"{surface['test_file']} — phantom reference (W65)"
                     )
     if not is_armed(surface["test_file"], wf_text):
         violations.append(
-            f"C4[bridge] test file {surface['test_file']} is not reachable by any "
+            f"C4[{label}] test file {surface['test_file']} is not reachable by any "
             f".github/workflows/*.yml — a test that never runs is theater (W81)"
         )
     return violations
@@ -328,23 +336,28 @@ def main(argv: list[str] | None = None) -> int:
     violations: list[str] = []
     violations += check_bridge(registry["surfaces"]["bridge_reply_guards"], wf_text)
     violations += check_hooks(registry["surfaces"]["command_hooks"], wf_text)
+    violations += check_bridge(
+        registry["surfaces"]["wr2_editorial_pregate"], wf_text, label="wr2-pregate"
+    )
     violations += check_simple_surfaces(registry, wf_text)
 
     bridge_count = len(registry["surfaces"]["bridge_reply_guards"]["guards"])
     hook_count = len(registry["surfaces"]["command_hooks"]["entries"])
+    pregate_count = len(registry["surfaces"]["wr2_editorial_pregate"]["guards"])
 
     if as_json:
         print(json.dumps({
             "schema": 1,
             "bridge_guards": bridge_count,
             "hook_entries": hook_count,
+            "wr2_pregate_checks": pregate_count,
             "violations": violations,
             "conformant": not violations,
         }, indent=2))
     else:
         print(
             f"guard-conformance: {bridge_count} bridge guards, {hook_count} hook entries, "
-            f"{len(violations)} violation(s)"
+            f"{pregate_count} wr2-pregate checks, {len(violations)} violation(s)"
         )
         for v in violations:
             print(f"  ✗ {v}")

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -264,6 +264,75 @@
           "innocence": ["test_tg_lint_innocence_grandfathered_and_gateway_pass"]
         }
       }
+    },
+    "wr2_editorial_pregate": {
+      "_doc": "WR2 editorial-intelligence Phase 2 — deterministic zero-LLM pre-gate (7 check_* functions). Built in the org's most recidivist scar territory (#3, 8+ prior instances) by design, per the ratified spec's own hard requirement (2026-07-21-editorial-intelligence-design.md §2 'Il Critico — SDOPPIATO': 'NESSUN gate ship senza corpus guilt+innocence registrato'). Enforced here with the SAME shape as bridge_reply_guards (check_bridge, labeled 'wr2-pregate' in violation messages) rather than a bespoke checker.",
+      "source": "scripts/wr2_editorial_pregate.py",
+      "census": {
+        "method": "ast-def-prefix",
+        "prefix": "check_"
+      },
+      "test_file": "scripts/tests/test_wr2_editorial_pregate.py",
+      "guards": {
+        "check_duplicate_slides": {
+          "scar": ["#3-generalization"],
+          "guilt": ["test_guilt_real_duplicate_pair_fails"],
+          "innocence": [
+            "test_innocence_regulatory_slides_share_only_boilerplate",
+            "test_skip_short_slides_below_token_floor"
+          ]
+        },
+        "check_bullet_promise": {
+          "scar": ["#3-generalization"],
+          "guilt": [
+            "test_guilt_tiga_syarat_with_two_bullets_fails",
+            "test_flat_guilt_inline_numbered_body_mismatch"
+          ],
+          "innocence": [
+            "test_innocence_3_syarat_with_exactly_three_passes",
+            "test_flat_innocence_prose_body_never_penalized"
+          ]
+        },
+        "check_caps_policy": {
+          "scar": ["#3-generalization"],
+          "guilt": ["test_guilt_caps_wall_body_fails"],
+          "innocence": [
+            "test_innocence_acronyms_in_prose_not_flagged",
+            "test_innocence_statement_slide_in_caps_exempt_by_role"
+          ]
+        },
+        "check_cta_presence": {
+          "scar": ["#3-generalization"],
+          "guilt": [
+            "test_typed_guilt_no_cta_no_statement_closer_fails",
+            "test_flat_guilt_empty_closing_slide_fails"
+          ],
+          "innocence": [
+            "test_typed_innocence_last_slide_statement_passes",
+            "test_flat_innocence_closing_slide_with_content_passes"
+          ]
+        },
+        "check_kicker_unique": {
+          "scar": ["#3-generalization"],
+          "guilt": ["test_guilt_duplicate_kickers_fail"],
+          "innocence": [
+            "test_innocence_similar_but_distinct_kickers_never_substring_collide"
+          ]
+        },
+        "check_kind_coverage": {
+          "scar": ["#3-generalization"],
+          "guilt": ["test_flat_guilt_missing_slide_type_fails"],
+          "innocence": [
+            "test_typed_trivially_true_after_validation",
+            "test_flat_innocence_below_degeneracy_threshold"
+          ]
+        },
+        "check_spine_echo": {
+          "scar": ["#3-generalization"],
+          "guilt": ["test_guilt_closer_shares_zero_spine_tokens_fails"],
+          "innocence": ["test_innocence_spine_echoed_via_regulation_code_alone"]
+        }
+      }
     }
   }
 }

--- a/scripts/tests/test_wr2_editorial_pregate.py
+++ b/scripts/tests/test_wr2_editorial_pregate.py
@@ -1,0 +1,522 @@
+"""Tests for wr2_editorial_pregate.py — the deterministic, zero-LLM
+editorial pre-gate (WR2 editorial-intelligence Phase 2).
+
+GUILT+INNOCENCE DISCIPLINE (cicatrix-superscar.md #3 — guard over/under-
+match, the most recursive disease in this codebase, 8+ prior instances).
+Every one of the 7 checks below gets AT LEAST one guilt case (a real
+defect the check MUST fire on) and one innocence case (a legitimate
+adjacent shape the check must NOT fire on) — several checks also get an
+explicit SKIP case proving the check stays honestly silent when it cannot
+verify structurally, rather than guessing.
+
+The literal examples named in the build mandate are reproduced verbatim as
+tests (not paraphrased): a real duplicate pair, "TIGA syarat" with 2
+bullets, a caps-wall body, duplicate kickers, a closer with zero spine
+tokens (guilt); two regulatory slides sharing only boilerplate, "3 syarat"
+with exactly 3, a body with acronyms KITAS/NPWP/PMA not flagged, a
+statement slide in caps (exempt by role), spine echoed via the regulation
+code alone (innocence).
+
+No DB, no CLI subprocess, no network, no LLM — wr2_editorial_pregate.py has
+zero I/O side effects by design, so every test here runs instantly and
+deterministically.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import wr2_carousel_ir as ir  # noqa: E402
+import wr2_editorial_pregate as pg  # noqa: E402
+
+
+def _typed_deck(slides: list[dict], register: str = "analitico") -> ir.SlideDeck:
+    return ir.SlideDeck.model_validate({"register": register, "slides": slides})
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# check_duplicate_slides
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestDuplicateSlides:
+    def test_guilt_real_duplicate_pair_fails(self):
+        """Two prose slides whose bodies are near-copy-pasted (one word
+        changed) — a real disco-rotto duplicate. MUST fail."""
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "New Levy Announced"},
+            {
+                "kind": "prose",
+                "headline": "The details",
+                "body": (
+                    "Immigration officials confirmed the new levy will apply to all "
+                    "foreign visitors starting January covering the entire archipelago region"
+                ),
+            },
+            {
+                "kind": "prose",
+                "headline": "The recap",
+                "body": (
+                    "Immigration officials confirmed the new levy will apply to all "
+                    "foreign visitors starting January covering nearly the entire archipelago region"
+                ),
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_duplicate_slides(canon)
+        assert result.verdict == "FAIL"
+        assert any("slide 2" in r and "slide 3" in r for r in result.reasons)
+
+    def test_innocence_regulatory_slides_share_only_boilerplate(self):
+        """Two slides about GENUINELY DIFFERENT regulations, sharing only
+        Indonesian legal-citation scaffolding (Pasal/ayat/Peraturan/Menteri/
+        Nomor/Tahun) — Jaccard AFTER boilerplate-stripping must be low.
+        MUST pass (the whole point of stripping boilerplate first)."""
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Two Rules"},
+            {
+                "kind": "prose",
+                "headline": "Capital reporting rule",
+                "body": (
+                    "Pasal 5 ayat 2 Peraturan Menteri Nomor 37 Tahun 2025 mengatur kewajiban "
+                    "pelaporan modal disetor bagi perusahaan penanaman modal asing di sektor "
+                    "pariwisata perhotelan"
+                ),
+            },
+            {
+                "kind": "prose",
+                "headline": "Customs import rule",
+                "body": (
+                    "Pasal 12 ayat 3 Peraturan Menteri Nomor 8 Tahun 2024 mewajibkan importir "
+                    "mengajukan dokumen kepabeanan sebelum barang tiba di pelabuhan utama negara"
+                ),
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_duplicate_slides(canon)
+        assert result.verdict == "PASS"
+
+    def test_skip_short_slides_below_token_floor(self):
+        deck = _typed_deck([
+            {"kind": "prose", "headline": "A", "body": "Short note here"},
+            {"kind": "prose", "headline": "B", "body": "Another brief line"},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_duplicate_slides(canon)
+        assert result.verdict == "SKIP"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# check_bullet_promise
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestBulletPromise:
+    def test_guilt_tiga_syarat_with_two_bullets_fails(self):
+        deck = _typed_deck([
+            {
+                "kind": "fact_stack",
+                "heading": "TIGA syarat utama",
+                "facts": ["Syarat pertama", "Syarat kedua"],
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_bullet_promise(canon)
+        assert result.verdict == "FAIL"
+        assert any("announces 3" in r and "delivers 2" in r for r in result.reasons)
+
+    def test_innocence_3_syarat_with_exactly_three_passes(self):
+        deck = _typed_deck([
+            {
+                "kind": "fact_stack",
+                "heading": "3 syarat utama investasi",
+                "facts": ["Syarat pertama", "Syarat kedua", "Syarat ketiga"],
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_bullet_promise(canon)
+        assert result.verdict == "PASS"
+
+    def test_skip_no_slide_carries_a_verifiable_list(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Three big changes ahead"},
+            {"kind": "prose", "headline": "Overview", "body": "Explains the shifts in plain prose."},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_bullet_promise(canon)
+        assert result.verdict == "SKIP"
+
+    def test_flat_guilt_inline_numbered_body_mismatch(self):
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Cover", "body": ""},
+            {
+                "slide_number": 2,
+                "slide_type": "body",
+                "headline": "Three quick checks",
+                "body": "1. Check A. 2. Check B.",
+            },
+        ]
+        canon = pg._canon_from_flat(slides)
+        result = pg.check_bullet_promise(canon)
+        assert result.verdict == "FAIL"
+
+    def test_flat_innocence_inline_numbered_body_matches(self):
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Cover", "body": ""},
+            {
+                "slide_number": 2,
+                "slide_type": "body",
+                "headline": "Three quick checks",
+                "body": "1. Check A. 2. Check B. 3. Check C.",
+            },
+        ]
+        canon = pg._canon_from_flat(slides)
+        result = pg.check_bullet_promise(canon)
+        assert result.verdict == "PASS"
+
+    def test_flat_innocence_prose_body_never_penalized(self):
+        """A prose body that happens to mention '3' in the heading but has
+        NO bullet/numbered structure must SKIP, never FAIL — prose is not
+        (structurally) a broken list, it was never claiming to be a list."""
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Cover", "body": ""},
+            {
+                "slide_number": 2,
+                "slide_type": "body",
+                "headline": "3 things changed this year",
+                "body": "The rules shifted gradually over several months in ways nobody fully expected.",
+            },
+        ]
+        canon = pg._canon_from_flat(slides)
+        result = pg.check_bullet_promise(canon)
+        assert result.verdict == "SKIP"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# check_caps_policy
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestCapsPolicy:
+    def test_guilt_caps_wall_body_fails(self):
+        deck = _typed_deck([
+            {
+                "kind": "prose",
+                "headline": "Normal headline",
+                "body": "THIS ENTIRE BODY IS SHOUTING LOUDLY AT EVERY SINGLE READER TODAY",
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_caps_policy(canon)
+        assert result.verdict == "FAIL"
+
+    def test_innocence_acronyms_in_prose_not_flagged(self):
+        deck = _typed_deck([
+            {
+                "kind": "prose",
+                "headline": "Requirements",
+                "body": (
+                    "Foreign investors seeking KITAS and NPWP registration must also secure "
+                    "a PMA license before applying for permits"
+                ),
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_caps_policy(canon)
+        assert result.verdict == "PASS"
+
+    def test_innocence_statement_slide_in_caps_exempt_by_role(self):
+        """A statement-bomb closer in full caps sits in HEADING role — it is
+        never inspected by this check at all. Mixed into a deck with a
+        normal-case prose body so the check has something real to
+        evaluate, and still passes because the shouty text is role-exempt,
+        not because of a string-content escape hatch."""
+        deck = _typed_deck([
+            {"kind": "prose", "headline": "Context", "body": "The rule applies starting next quarter for everyone."},
+            {"kind": "statement", "statement": "THIS IS A BOLD STATEMENT ABOUT THE MARKET TODAY"},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_caps_policy(canon)
+        assert result.verdict == "PASS"
+        assert all("BOLD STATEMENT" not in r for r in result.reasons)
+
+    def test_skip_deck_with_no_body_role_text(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Cover only"},
+            {"kind": "statement", "statement": "A short punchy close"},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_caps_policy(canon)
+        assert result.verdict == "SKIP"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# check_cta_presence
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestCtaPresence:
+    def test_typed_guilt_no_cta_no_statement_closer_fails(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Cover"},
+            {"kind": "prose", "headline": "Body", "body": "Some body text here for the deck."},
+            {
+                "kind": "triad",
+                "heading": "3 forces",
+                "items": [
+                    {"title": "One", "desc": "First"},
+                    {"title": "Two", "desc": "Second"},
+                ],
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_cta_presence(canon)
+        assert result.verdict == "FAIL"
+
+    def test_typed_innocence_last_slide_statement_passes(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Cover"},
+            {"kind": "prose", "headline": "Body", "body": "Some body text here for the deck."},
+            {"kind": "statement", "statement": "The takeaway in one line"},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_cta_presence(canon)
+        assert result.verdict == "PASS"
+
+    def test_typed_innocence_cta_kind_anywhere_passes(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Cover"},
+            {"kind": "cta", "invite": "Reach out to Bali Zero today"},
+            {"kind": "prose", "headline": "Body", "body": "Closing thoughts in prose form here."},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_cta_presence(canon)
+        assert result.verdict == "PASS"
+
+    def test_flat_guilt_empty_closing_slide_fails(self):
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Cover", "body": "x"},
+            {"slide_number": 2, "slide_type": "cta", "headline": "", "subhead": "", "body": ""},
+        ]
+        canon = pg._canon_from_flat(slides)
+        result = pg.check_cta_presence(canon)
+        assert result.verdict == "FAIL"
+
+    def test_flat_innocence_closing_slide_with_content_passes(self):
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Cover", "body": "x"},
+            {"slide_number": 2, "slide_type": "cta", "headline": "Talk to us", "body": "Reach out any time."},
+        ]
+        canon = pg._canon_from_flat(slides)
+        result = pg.check_cta_presence(canon)
+        assert result.verdict == "PASS"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# check_kicker_unique
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestKickerUnique:
+    def test_guilt_duplicate_kickers_fail(self):
+        deck = _typed_deck([
+            {"kind": "prose", "headline": "THE SIGNAL: a first take", "body": "Body one for the deck here."},
+            {"kind": "prose", "headline": "THE SIGNAL: a different take", "body": "Body two for the deck here."},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_kicker_unique(canon)
+        assert result.verdict == "FAIL"
+
+    def test_innocence_similar_but_distinct_kickers_never_substring_collide(self):
+        """Reproduces the production regression this check must NOT
+        reintroduce: 'TAKEAWAY FOR SELLERS' contains 'TAKE' but must not
+        match; 'THE SIGNAL TODAY' must NOT match 'THE SIGNAL' — whole-
+        string comparison only."""
+        deck = _typed_deck([
+            {"kind": "prose", "headline": "TAKEAWAY FOR SELLERS: point one", "body": "Body one here for the deck."},
+            {"kind": "prose", "headline": "THE SIGNAL TODAY: point two", "body": "Body two here for the deck."},
+            {"kind": "prose", "headline": "THE SIGNAL: point three", "body": "Body three here for the deck."},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_kicker_unique(canon)
+        assert result.verdict == "PASS"
+
+    def test_skip_fewer_than_two_extractable_kickers(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "A genuinely long headline that runs past five words easily"},
+            {"kind": "prose", "headline": "Another quite long headline past the five word ceiling too", "body": "x body text here"},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_kicker_unique(canon)
+        assert result.verdict == "SKIP"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# check_kind_coverage
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestKindCoverage:
+    def test_typed_trivially_true_after_validation(self):
+        # Non-prose kinds so this test isolates "every slide has a valid
+        # kind" from the SEPARATE degeneracy-tripwire behavior (covered by
+        # test_typed_degeneracy_warn_when_over_70_percent_prose below).
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Cover"},
+            {"kind": "statement", "statement": "A clean closing line"},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_kind_coverage(canon)
+        assert result.verdict == "PASS"
+
+    def test_typed_degeneracy_warn_when_over_70_percent_prose(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Cover"},
+            {"kind": "prose", "headline": "A", "body": "Body text one for the deck to read here."},
+            {"kind": "prose", "headline": "B", "body": "Body text two for the deck to read here."},
+            {"kind": "prose", "headline": "C", "body": "Body text three for the deck to read here."},
+            {"kind": "prose", "headline": "D", "body": "Body text four for the deck to read here."},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_kind_coverage(canon)
+        assert result.verdict == "WARN"
+
+    def test_flat_guilt_missing_slide_type_fails(self):
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Cover", "body": "x"},
+            {"slide_number": 2, "slide_type": "", "headline": "No type", "body": "y"},
+        ]
+        canon = pg._canon_from_flat(slides)
+        result = pg.check_kind_coverage(canon)
+        assert result.verdict == "FAIL"
+
+    def test_flat_innocence_below_degeneracy_threshold(self):
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Cover", "body": "x"},
+            {"slide_number": 2, "slide_type": "fact", "headline": "A", "body": "y"},
+            {"slide_number": 3, "slide_type": "context", "headline": "B", "body": "z"},
+            {"slide_number": 4, "slide_type": "stakes", "headline": "C", "body": "w"},
+            {"slide_number": 5, "slide_type": "cta", "headline": "D", "body": "v"},
+        ]
+        canon = pg._canon_from_flat(slides)
+        result = pg.check_kind_coverage(canon)
+        assert result.verdict == "PASS"
+
+    def test_flat_degeneracy_warn_matches_production_shape(self):
+        """Mirrors the ACTUAL production histogram this session measured
+        (187/557 slides literally slide_type='body') — a deck dominated by
+        undifferentiated 'body' slides WARNs, it does not FAIL (this is a
+        tripwire on today's real corpus, not a hard block)."""
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Cover", "body": "x"},
+            {"slide_number": 2, "slide_type": "body", "headline": "A", "body": "y"},
+            {"slide_number": 3, "slide_type": "body", "headline": "B", "body": "z"},
+            {"slide_number": 4, "slide_type": "body", "headline": "C", "body": "w"},
+            {"slide_number": 5, "slide_type": "cta", "headline": "D", "body": "v"},
+        ]
+        canon = pg._canon_from_flat(slides)
+        result = pg.check_kind_coverage(canon)
+        assert result.verdict == "WARN"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# check_spine_echo
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestSpineEcho:
+    def test_guilt_closer_shares_zero_spine_tokens_fails(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "New Tourism Levy"},
+            {
+                "kind": "statement",
+                "statement": "Completely unrelated closing remarks about weather patterns elsewhere",
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        spine = "Indonesia introduces a new tourism levy affecting foreign visitors"
+        result = pg.check_spine_echo(canon, spine)
+        assert result.verdict == "FAIL"
+
+    def test_innocence_spine_echoed_via_regulation_code_alone(self):
+        """No shared prose words at all — only the bare regulation-code
+        number pair ('5/2025') repeats between spine and closer. MUST
+        pass: the fact-key match is entity-based, not a prose-overlap
+        heuristic."""
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Golden Visa Overhaul"},
+            {
+                "kind": "cta",
+                "invite": "Officials clarified how 5/2025 changes bond requirements for long-term residents",
+            },
+        ])
+        canon = pg._canon_from_typed(deck)
+        spine = "Permenimipas No. 5/2025 quietly redraws the guarantor requirement for Golden Visa holders"
+        result = pg.check_spine_echo(canon, spine)
+        assert result.verdict == "PASS"
+
+    def test_skip_when_no_spine_provided(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Cover"},
+            {"kind": "statement", "statement": "A closing line"},
+        ])
+        canon = pg._canon_from_typed(deck)
+        result = pg.check_spine_echo(canon, None)
+        assert result.verdict == "SKIP"
+        assert "never guessed" in result.reasons[0]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Public entry points — pregate_typed / pregate_flat
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPregateEntryPoints:
+    def test_pregate_typed_clean_deck_passes(self):
+        deck = _typed_deck([
+            {"kind": "cover", "headline": "Golden Visa Overhaul"},
+            {
+                "kind": "fact_stack",
+                "heading": "3 syarat utama",
+                "facts": ["Syarat pertama", "Syarat kedua", "Syarat ketiga"],
+            },
+            {"kind": "statement", "statement": "The takeaway in one clean line"},
+        ])
+        report = pg.pregate_typed(deck, spine=None)
+        assert report.deck_kind == "typed"
+        assert report.slide_count == 3
+        assert report.verdict in ("PASS", "WARN")  # SKIPs on spine_echo are expected (no spine)
+        assert len(report.checks) == 7
+        d = report.to_dict()
+        assert d["checks"][0]["check"] == "check_duplicate_slides"
+        assert isinstance(report.to_json(), str)
+
+    def test_pregate_flat_clean_deck_passes(self):
+        slides = [
+            {"slide_number": 1, "slide_type": "cover", "is_cover": True, "headline": "Golden Visa Overhaul", "body": ""},
+            {"slide_number": 2, "slide_type": "fact", "headline": "The numbers", "body": "Two million arrivals this year alone."},
+            {"slide_number": 3, "slide_type": "cta", "headline": "Talk to us", "body": "Reach out any time for guidance."},
+        ]
+        report = pg.pregate_flat(slides, spine=None)
+        assert report.deck_kind == "flat"
+        assert report.slide_count == 3
+        assert len(report.checks) == 7
+
+    def test_aggregate_verdict_fail_beats_warn_beats_pass(self):
+        results = [
+            pg.CheckResult("a", "PASS"),
+            pg.CheckResult("b", "WARN"),
+            pg.CheckResult("c", "FAIL"),
+        ]
+        assert pg._aggregate_verdict(results) == "FAIL"
+        assert pg._aggregate_verdict(results[:2]) == "WARN"
+        assert pg._aggregate_verdict(results[:1]) == "PASS"
+
+    def test_check_result_rejects_invalid_verdict(self):
+        import pytest
+        with pytest.raises(ValueError):
+            pg.CheckResult("x", "MAYBE")

--- a/scripts/wr2_editorial_pregate.py
+++ b/scripts/wr2_editorial_pregate.py
@@ -1,0 +1,712 @@
+#!/usr/bin/env python3
+"""wr2_editorial_pregate.py — deterministic, zero-LLM editorial pre-gate
+(WR2 editorial-intelligence Phase 2).
+
+ADDITIVE ONLY. Nothing in `wr2_draft_generator.py`, `wr2_carousel_ir.py`, or
+`scripts/wr2_html_renderer/composer.py` is modified or imports this module —
+this is a standalone check library exercised by tests and by
+`wr2_pregate_shadow.py` against historical decks. Wiring it into the live
+pipeline (gating a draft before it reaches the human review queue) is a
+future step, itself gated the same way Phase 1/3 are (4-LLM panel, CLAUDE.md
+§6) — not this PR.
+
+Implements the ratified spec's "Il Critico — SDOPPIATO" strato-1
+(`.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md`
+§2), the deterministic pre-gate ahead of the (expensive, slow) `wr2-critic`
+LLM judge — ported in SHAPE (not code) from
+`Maazsiddiqui01/linkedin-carousel-generator`'s `run_overseer_checks.js`
+(Jaccard duplicate-detection :41-52, bullet-count/ceiling :118-132, coverage
+:221-237 — see `.claude/skills/wr2/_research/2026-07-21-oss-code-reading-
+statemachine-gptnewspaper.md` §4 for the mapping table).
+
+SCAR #3 DISCIPLINE (cicatrix-superscar.md — guard over/under-match, the most
+recursive disease in this codebase, 8+ prior instances: W68/W72/W73/W82/W83/
+W84/W85/W91/W92/W94/W95/W99). Every check below is built to the antidote:
+  - Jaccard similarity normalizes AWAY Indonesian legal boilerplate (Pasal/
+    ayat/berdasarkan/…) BEFORE comparing, so two DIFFERENT regulatory slides
+    that merely cite similar law-citation scaffolding never false-positive
+    as duplicates (innocence).
+  - "closer echoes spine" is a fact-key/entity match (numbers, regulation
+    codes, acronyms, content-words), NEVER a bare substring test.
+  - Count-word matching (bullet-promise) is WORD-BOUNDARY, never substring
+    ("TAKEAWAY FOR SELLERS" containing "TAKE" must never fire a kicker-
+    collision, mirroring wr2_draft_generator._kicker_collision's own
+    discipline).
+  - The caps-wall check exempts by FIELD ROLE (heading vs body), never by
+    string-sniffing content — a statement-bomb closer that is legitimately
+    all-caps is exempt because of WHAT FIELD it is, not because of a regex
+    escape hatch on its text.
+Every check has a registered guilt+innocence corpus in
+`scripts/tests/test_wr2_editorial_pregate.py`, itself registered in
+`infra/guard-conformance/registry.json` under a dedicated `wr2_editorial_
+pregate` surface (see `check_wr2_editorial_pregate_surface` in
+`infra/guard-conformance/check_guard_conformance.py`) — enforced in CI.
+
+DESIGN — two entry points, one internal representation (spec §2's own
+prescription): `pregate_typed(deck, spine=None)` accepts a validated
+`wr2_carousel_ir.SlideDeck` (Phase 1's 11-kind discriminated union);
+`pregate_flat(slides, spine=None)` accepts the flat production dict shape
+`wr2_draft_generator._normalise_slides` actually emits today
+(`{slide_number, slide_type, is_cover, is_hero_image, headline, subhead,
+body, image_prompt, tonal_palette, image_mode, image_url}` — verified
+against wr2_draft_generator.py:1441-1453 this session). Both entry points
+project their input into `_CanonSlide` — a single normalized shape the 7
+`check_*` functions operate on uniformly, so there is exactly ONE
+implementation per check, not a typed/flat fork per check (less surface for
+the #3 family to grow a new head on).
+
+Pure functions only. Zero LLM calls, zero network, zero DB, zero filesystem
+I/O at import time or call time — every function here is a plain
+str/dict/pydantic-object -> CheckResult transform, so the test suite runs
+instantly and deterministically, and `wr2_pregate_shadow.py` can run this
+against hundreds of decks in well under a second of wall-clock.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger("wr2.editorial_pregate")
+
+# wr2_carousel_ir.py is a sibling script module (not a package), so it is
+# only importable with scripts/ on sys.path — same convention
+# wr2_ir_shadow_replay.py and scripts/tests/test_wr2_carousel_ir.py already
+# use. wr2_carousel_ir itself is zero-I/O (its own docstring guarantees it),
+# so this import adds no side effects.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from wr2_carousel_ir import (  # noqa: E402
+    CitationSlide,
+    CoverSlide,
+    CtaSlide,
+    FactStackSlide,
+    ProseSlide,
+    QaSlide,
+    SlideDeck,
+    StatementSlide,
+    StatSlide,
+    StatusListSlide,
+    TimelineSlide,
+    TriadSlide,
+)
+
+# ─────────────────────────────────────────────────────────────────────────
+# Structured result
+# ─────────────────────────────────────────────────────────────────────────
+
+VALID_VERDICTS = ("PASS", "FAIL", "SKIP", "WARN")
+
+
+@dataclass
+class CheckResult:
+    check: str
+    verdict: str  # PASS | FAIL | SKIP | WARN
+    reasons: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.verdict not in VALID_VERDICTS:
+            raise ValueError(f"invalid verdict {self.verdict!r} (allowed: {VALID_VERDICTS})")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"check": self.check, "verdict": self.verdict, "reasons": list(self.reasons)}
+
+
+@dataclass
+class PregateReport:
+    deck_kind: str  # "typed" | "flat"
+    slide_count: int
+    checks: list[CheckResult]
+    verdict: str  # aggregate: FAIL > WARN > PASS
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "deck_kind": self.deck_kind,
+            "slide_count": self.slide_count,
+            "verdict": self.verdict,
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+    def to_json(self, **kwargs: Any) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, **kwargs)
+
+
+def _aggregate_verdict(results: list[CheckResult]) -> str:
+    verdicts = {r.verdict for r in results}
+    if "FAIL" in verdicts:
+        return "FAIL"
+    if "WARN" in verdicts:
+        return "WARN"
+    return "PASS"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Internal canonical representation — the "one internal representation"
+# both entry points project into before any check runs.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _CanonSlide:
+    index: int  # 1-based
+    is_cover: bool
+    kind_or_type: str  # typed: pydantic discriminator ("cover", "prose", …); flat: slide_type verbatim
+    typed_origin: bool  # True iff this canon list came from a validated typed SlideDeck
+    reader_text: str  # every user-visible string on the slide, concatenated
+    heading_texts: list[str]  # HEADING-ROLE text (headline/statement/heading/kicker-ish — MAY be caps)
+    body_texts: list[str]  # BODY-ROLE text (prose/list-item content — must NEVER be a caps-wall)
+    kicker_source: str  # the one text field a kicker would be extracted from
+    count_heading_text: str  # text scanned for an announced item-count ("3 things", "TIGA syarat")
+    list_count: int | None  # delivered item count, when this slide kind/body structurally carries one
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Shared low-level helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+_ID_BOILERPLATE_TOKENS = frozenset({
+    "pasal", "ayat", "berdasarkan", "peraturan", "menteri", "nomor",
+    "tahun", "huruf", "jo", "juncto",
+})
+
+
+def _normalize_for_jaccard(text: str) -> set[str]:
+    """Lowercase + strip punctuation via \\w+ tokenization, then drop
+    digit-only tokens and Indonesian legal-boilerplate tokens BEFORE
+    similarity is computed — so two DIFFERENT regulatory slides that merely
+    share law-citation scaffolding ("Pasal 5 ayat 2 Peraturan Menteri Nomor
+    ...") never false-positive as near-duplicates (spec §2, Kimi red-team
+    objection #3)."""
+    normalized = unicodedata.normalize("NFKC", text or "").lower()
+    tokens = re.findall(r"\w+", normalized)
+    return {
+        t for t in tokens
+        if not t.isdigit() and t not in _ID_BOILERPLATE_TOKENS
+    }
+
+
+_DUPLICATE_JACCARD_THRESHOLD = 0.80
+_DUPLICATE_MIN_TOKENS = 6
+
+
+_COUNT_WORDS: dict[str, int] = {
+    "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9,
+    "dua": 2, "tiga": 3, "empat": 4, "lima": 5, "enam": 6, "tujuh": 7, "delapan": 8, "sembilan": 9,
+}
+_COUNT_PATTERN = re.compile(
+    r"\b(?:[2-9]|" + "|".join(sorted(_COUNT_WORDS, key=len, reverse=True)) + r")\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_announced_count(text: str) -> int | None:
+    """First word-boundary count token in `text` (digit 2-9, or an EN/ID
+    count word). Never a substring match — `\\b...\\b` on the WHOLE token,
+    so e.g. "2025" never matches (no boundary between its digits) and
+    "istiga..." never matches "tiga". Returns None when no count is
+    announced (callers SKIP, never guess)."""
+    m = _COUNT_PATTERN.search(text or "")
+    if not m:
+        return None
+    tok = m.group(0)
+    if tok.isdigit():
+        return int(tok)
+    return _COUNT_WORDS.get(tok.lower())
+
+
+_NEWLINE_BULLET_RE = re.compile(r"(?:^|\n)\s*[-*•‣◦]\s+", re.MULTILINE)
+_INLINE_NUMBERED_RE = re.compile(r"(?<!\d)([1-9]\d?)[.)]\s+")
+
+
+def _flat_body_bullet_count(body: str) -> int | None:
+    """Delivered item count for a FLAT slide's `body` text, or None when the
+    body has no structurally-verifiable list shape (plain prose — the
+    overwhelming majority of today's production bodies, verified this
+    session: 3/557 historical slides have any bullet/numbered structure at
+    all). Returning None here is a SKIP signal, not a violation — a prose
+    paragraph that happens to mention a number in its heading is not
+    (structurally) a broken bullet-promise; it simply has nothing this
+    check can verify (innocence: prose stays silent, never penalized for
+    not being a list it never claimed via structure to be)."""
+    body = body or ""
+    newline_bullets = _NEWLINE_BULLET_RE.findall(body)
+    if newline_bullets:
+        return len(newline_bullets)
+    nums = _INLINE_NUMBERED_RE.findall(body)
+    if len(nums) < 2:
+        return None
+    try:
+        seq = [int(n) for n in nums]
+    except ValueError:
+        return None
+    if seq[0] != 1:
+        return None
+    if not all(b - a in (0, 1) for a, b in zip(seq, seq[1:])):
+        return None
+    return len(nums)
+
+
+_CAPS_WALL_MIN_LEN = 15
+_CAPS_WALL_RATIO = 0.85
+_CAPS_ACRONYM_TOLERANCE = 4  # ignore tokens <=4 letters when computing the ratio
+
+
+def _is_caps_wall(text: str) -> bool:
+    """RATIFIED brand rule (spec §8 item 2, ratified by Zero 2026-07-21):
+    'caps only on headings, never on bodies'. A body/list-item text is a
+    caps-wall when it is >=15 chars AND >=85% uppercase letters, ignoring
+    short (<=4 letter) tokens so acronyms (KITAS, NPWP, PMA, KTP) embedded
+    in otherwise normal-case prose never tip the ratio on their own —
+    they're outnumbered by the surrounding lowercase prose in any real
+    sentence, so this check flags genuine caps-walls, not acronym-bearing
+    prose."""
+    stripped = (text or "").strip()
+    if len(stripped) < _CAPS_WALL_MIN_LEN:
+        return False
+    letters: list[str] = []
+    for tok in stripped.split():
+        core = "".join(ch for ch in tok if ch.isalpha())
+        if len(core) <= _CAPS_ACRONYM_TOLERANCE:
+            continue
+        letters.extend(core)
+    if not letters:
+        return False
+    upper = sum(1 for ch in letters if ch.isupper())
+    return (upper / len(letters)) >= _CAPS_WALL_RATIO
+
+
+def _extract_kicker(headline: str) -> str | None:
+    """Port of wr2_draft_generator._extract_take_kicker (wr2_draft_generator.py
+    :629-665) — duplicated rather than imported, mirroring wr2_carousel_ir.py's
+    own precedent (its docstring: 'Duplicated (not imported) on purpose: this
+    module must stay importable standalone with ZERO I/O ... side effects').
+    'KICKER: rest of the sentence' -> 'KICKER' (2-5 words before the colon);
+    a colon-less headline is treated as a kicker only if itself 1-5 words."""
+    headline = (headline or "").strip()
+    if not headline:
+        return None
+    normalized_headline = unicodedata.normalize("NFKC", headline)
+    prefix, sep, _rest = normalized_headline.partition(":")
+    if sep:
+        prefix = prefix.strip()
+        if prefix and 2 <= len(prefix.split()) <= 5:
+            return prefix
+        return None
+    if 1 <= len(normalized_headline.split()) <= 5:
+        return normalized_headline
+    return None
+
+
+def _normalize_kicker_text(text: str) -> str:
+    """Port of wr2_draft_generator._normalize_kicker (wr2_draft_generator.py
+    :609-626) — whole-STRING normalization, never used for substring
+    matching (scar family #3): NFKC fold, whitespace collapse, terminal-
+    punctuation strip, casefold."""
+    normalized = unicodedata.normalize("NFKC", text)
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = normalized.strip(" \t\r\n:;,.-–—")
+    return normalized.casefold()
+
+
+_STOPWORDS_EN = frozenset({
+    "the", "and", "for", "with", "from", "that", "this", "these", "those",
+    "have", "has", "will", "are", "was", "were", "been", "into", "onto",
+    "over", "under", "about", "after", "before", "during", "which", "what",
+    "when", "where", "while", "their", "there", "here", "your", "you",
+    "our", "its", "than", "then", "also", "still", "each", "every",
+})
+_STOPWORDS_ID = frozenset({
+    "yang", "dengan", "dari", "untuk", "pada", "dalam", "adalah", "akan",
+    "atau", "dan", "ini", "itu", "para", "oleh", "telah", "dapat", "tidak",
+    "juga", "sudah", "masih", "harus", "bagi", "sebagai", "karena",
+})
+
+_REGCODE_RE = re.compile(r"\b\d{1,4}/\d{4}\b")  # "37/2025", "5/2025" — a regulation-code number pair
+_ACRONYM_RE = re.compile(r"\b[A-Z]{2,}\b")
+_NUMBER_RE = re.compile(r"\b\d{2,}\b")
+_WORD5_RE = re.compile(r"[A-Za-z]{5,}")
+
+
+def _fact_key_tokens(text: str) -> set[str]:
+    """Entity/fact-key tokens for the spine-echo check — NEVER a bare
+    substring test (spec §2 hard rule: 'l'echo si misura su chiave-fatto/
+    entità condivisa, non su sotto-stringa letterale'). Four independent
+    signals, unioned: regulation-code number pairs ('37/2025'), uppercase
+    acronyms (KITAS, PMA — lowercased for matching), bare 2+-digit numbers
+    (catches a shared year/threshold even without a full code), and
+    content-words >=5 chars minus EN/ID stopwords."""
+    text = text or ""
+    tokens: set[str] = set()
+    tokens |= {m.group(0) for m in _REGCODE_RE.finditer(text)}
+    tokens |= {m.group(0).lower() for m in _ACRONYM_RE.finditer(text)}
+    tokens |= {m.group(0) for m in _NUMBER_RE.finditer(text)}
+    for w in _WORD5_RE.findall(text):
+        wl = w.lower()
+        if wl in _STOPWORDS_EN or wl in _STOPWORDS_ID:
+            continue
+        tokens.add(wl)
+    return tokens
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Typed-deck projection (wr2_carousel_ir.SlideDeck -> _CanonSlide)
+# ─────────────────────────────────────────────────────────────────────────
+
+# Kinds with a spec-scoped "list field" for the bullet-promise check
+# (spec §2: "fact_stack/status_list/triad/qa/timeline" — NOT stat/citation).
+_BULLET_PROMISE_KINDS = frozenset({"fact_stack", "status_list", "triad", "timeline", "qa"})
+
+
+def _typed_slide_fields(slide: Any) -> tuple[str, list[str], list[str], str, str, int | None]:
+    """(kind, heading_texts, body_texts, kicker_source, count_heading_text,
+    list_count) for one validated typed Slide. Field-ROLE assignment is the
+    caps-policy exemption mechanism (spec §8 item 2): heading_texts MAY be
+    caps (kicker/punch convention), body_texts must NEVER be a caps-wall."""
+    if isinstance(slide, CoverSlide):
+        return ("cover", [slide.headline, slide.subhead], [], slide.headline, "", None)
+    if isinstance(slide, ProseSlide):
+        return ("prose", [slide.headline, slide.subhead], [slide.body], slide.headline, "", None)
+    if isinstance(slide, StatementSlide):
+        return ("statement", [slide.statement], [], slide.statement, "", None)
+    if isinstance(slide, FactStackSlide):
+        heading = [slide.heading] + ([slide.take_label] if slide.take_label else [])
+        body = list(slide.facts) + ([slide.take_line] if slide.take_line else [])
+        return ("fact_stack", heading, body, slide.heading, slide.heading, len(slide.facts))
+    if isinstance(slide, StatusListSlide):
+        body = [t for it in slide.items for t in (it.label, it.value) if t]
+        return ("status_list", [slide.heading], body, slide.heading, slide.heading, len(slide.items))
+    if isinstance(slide, TimelineSlide):
+        body = [st.label for st in slide.steps if st.label]
+        return ("timeline", [slide.heading], body, slide.heading, slide.heading, len(slide.steps))
+    if isinstance(slide, TriadSlide):
+        body = [t for it in slide.items for t in (it.title, it.desc) if t]
+        return ("triad", [slide.heading], body, slide.heading, slide.heading, len(slide.items))
+    if isinstance(slide, QaSlide):
+        heading = [p.voice for p in slide.pairs if p.voice]  # speaker labels are kicker-like, not prose
+        body = [p.line for p in slide.pairs if p.line]
+        return ("qa", heading, body, "", "", len(slide.pairs))
+    if isinstance(slide, StatSlide):
+        heading = [t for t in (slide.value, slide.unit, slide.label) if t]
+        body = [slide.context] if slide.context else []
+        return ("stat", heading, body, slide.value, "", None)
+    if isinstance(slide, CitationSlide):
+        heading = [slide.claim] + [s.code for s in slide.sources if s.code]
+        body = [s.note for s in slide.sources if s.note]
+        return ("citation", heading, body, slide.claim, "", None)
+    if isinstance(slide, CtaSlide):
+        # The CTA line is a closer PUNCH (same register as statement-bomb),
+        # not a prose body — treated as heading-role (spec: closer slots are
+        # short/punchy by design, not a paragraph the caps rule targets).
+        heading = [t for t in (slide.invite, slide.trust_marker, slide.reach) if t]
+        return ("cta", heading, [], slide.invite, "", None)
+    raise TypeError(f"_typed_slide_fields: unhandled slide kind {type(slide)!r}")  # pragma: no cover
+
+
+def _canon_from_typed(deck: SlideDeck) -> list[_CanonSlide]:
+    out: list[_CanonSlide] = []
+    for i, s in enumerate(deck.slides, start=1):
+        kind, heading_texts, body_texts, kicker_src, count_text, list_count = _typed_slide_fields(s)
+        heading_texts = [t for t in heading_texts if t]
+        body_texts = [t for t in body_texts if t]
+        reader_text = " ".join(heading_texts + body_texts)
+        if kind in _BULLET_PROMISE_KINDS:
+            promise_count = list_count
+        else:
+            promise_count = None
+        out.append(_CanonSlide(
+            index=i,
+            is_cover=(kind == "cover"),
+            kind_or_type=kind,
+            typed_origin=True,
+            reader_text=reader_text,
+            heading_texts=heading_texts,
+            body_texts=body_texts,
+            kicker_source=kicker_src or "",
+            count_heading_text=count_text or "",
+            list_count=promise_count,
+        ))
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Flat-deck projection (production dict shape -> _CanonSlide)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _canon_from_flat(slides: list[dict[str, Any]]) -> list[_CanonSlide]:
+    out: list[_CanonSlide] = []
+    for i, s in enumerate(slides, start=1):
+        headline = str(s.get("headline") or "").strip()
+        subhead = str(s.get("subhead") or "").strip()
+        body = str(s.get("body") or "").strip()
+        slide_type = str(s.get("slide_type") or "").strip().lower()
+        is_cover = bool(s.get("is_cover")) or i == 1
+        heading_texts = [t for t in (headline, subhead) if t]
+        body_texts = [body] if body else []
+        reader_text = " ".join(heading_texts + body_texts)
+        out.append(_CanonSlide(
+            index=i,
+            is_cover=is_cover,
+            kind_or_type=slide_type,
+            typed_origin=False,
+            reader_text=reader_text,
+            heading_texts=heading_texts,
+            body_texts=body_texts,
+            kicker_source=headline,
+            count_heading_text=" ".join(t for t in (headline, subhead) if t),
+            list_count=_flat_body_bullet_count(body),
+        ))
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# The 7 checks — each a pure list[_CanonSlide] -> CheckResult transform.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def check_duplicate_slides(canon: list[_CanonSlide]) -> CheckResult:
+    """Pairwise Jaccard on normalized reader-text (boilerplate-stripped
+    FIRST). Slides with <6 content tokens after normalization are excluded
+    from comparison (too short to judge either way — SKIP, not PASS/FAIL,
+    for that slide)."""
+    eligible: list[tuple[int, set[str]]] = []
+    for c in canon:
+        toks = _normalize_for_jaccard(c.reader_text)
+        if len(toks) >= _DUPLICATE_MIN_TOKENS:
+            eligible.append((c.index, toks))
+    if len(eligible) < 2:
+        return CheckResult(
+            "check_duplicate_slides", "SKIP",
+            ["fewer than 2 slides have >=6 content tokens after boilerplate-stripped normalization"],
+        )
+    reasons: list[str] = []
+    verdict = "PASS"
+    for a in range(len(eligible)):
+        for b in range(a + 1, len(eligible)):
+            i, ta = eligible[a]
+            j, tb = eligible[b]
+            union = ta | tb
+            if not union:
+                continue
+            jacc = len(ta & tb) / len(union)
+            if jacc >= _DUPLICATE_JACCARD_THRESHOLD:
+                verdict = "FAIL"
+                reasons.append(f"slide {i} vs slide {j}: jaccard={jacc:.2f} (>= {_DUPLICATE_JACCARD_THRESHOLD})")
+    if not reasons:
+        reasons = ["no near-duplicate slide pair found"]
+    return CheckResult("check_duplicate_slides", verdict, reasons)
+
+
+def check_bullet_promise(canon: list[_CanonSlide]) -> CheckResult:
+    """If a heading/subhead announces a count (word-boundary digit 2-9 or
+    EN/ID count word), the slide's list-bearing field must deliver exactly
+    N items. Typed: fact_stack/status_list/triad/qa/timeline kinds. Flat:
+    bodies with a verifiable bullet/numbered-line structure. SKIPs (per
+    slide) when no count is announced OR the slide has no verifiable
+    delivered-count signal — never guesses, never penalizes prose for not
+    being a list it never structurally claimed to be."""
+    reasons: list[str] = []
+    any_judged = False
+    verdict = "PASS"
+    for c in canon:
+        if c.list_count is None:
+            continue
+        n = _extract_announced_count(c.count_heading_text)
+        if n is None:
+            continue
+        any_judged = True
+        if c.list_count != n:
+            verdict = "FAIL"
+            reasons.append(
+                f"slide {c.index} ({c.kind_or_type}): heading announces {n}, delivers {c.list_count} items"
+            )
+    if not any_judged:
+        return CheckResult(
+            "check_bullet_promise", "SKIP",
+            ["no slide had both an announced count and a structurally-verifiable item list"],
+        )
+    if not reasons:
+        reasons = ["every announced count matched its delivered item count"]
+    return CheckResult("check_bullet_promise", verdict, reasons)
+
+
+def check_caps_policy(canon: list[_CanonSlide]) -> CheckResult:
+    """RATIFIED (spec §8 item 2): caps only on headings, never on bodies.
+    Exemption is by FIELD ROLE (a slide's body_texts vs heading_texts,
+    assigned at projection time per-kind/per-flat-field) — never by
+    string-sniffing the text itself."""
+    reasons: list[str] = []
+    any_checked = False
+    verdict = "PASS"
+    for c in canon:
+        for t in c.body_texts:
+            any_checked = True
+            if _is_caps_wall(t):
+                verdict = "FAIL"
+                reasons.append(f"slide {c.index} ({c.kind_or_type}): body-role text is a caps-wall: {t[:60]!r}")
+    if not any_checked:
+        return CheckResult("check_caps_policy", "SKIP", ["deck has no body-role text to evaluate"])
+    if not reasons:
+        reasons = ["no caps-wall found in any body-role field"]
+    return CheckResult("check_caps_policy", verdict, reasons)
+
+
+def check_cta_presence(canon: list[_CanonSlide]) -> CheckResult:
+    """Deck has >=1 closing slide. Typed decks have a real kind
+    discriminator, so the rule is precise: a cta-kind slide anywhere, OR
+    the closer is kind=statement. Flat decks carry `slide_type` as a free
+    string (production histogram: 76+ distinct values on 557 slides — not a
+    reliable discriminator), so the only structurally-honest signal is the
+    one production itself relies on (composer.map_slide_to_family's
+    index==total branch: the LAST slide is ALWAYS the closer regardless of
+    its label, Art 9.5 hard rule) — verify it simply carries content."""
+    if not canon:
+        return CheckResult("check_cta_presence", "SKIP", ["empty deck"])
+    last = canon[-1]
+    if canon[0].typed_origin:
+        has_cta_anywhere = any(c.kind_or_type == "cta" for c in canon)
+        last_is_statement = last.kind_or_type == "statement"
+        if has_cta_anywhere or last_is_statement:
+            reason = "cta-kind slide present" if has_cta_anywhere else f"closer (slide {last.index}) is kind=statement"
+            return CheckResult("check_cta_presence", "PASS", [reason])
+        return CheckResult(
+            "check_cta_presence", "FAIL",
+            [f"no cta-kind slide anywhere and closer (slide {last.index}, kind={last.kind_or_type}) is not a statement"],
+        )
+    if last.reader_text.strip():
+        return CheckResult("check_cta_presence", "PASS", [f"closing slide {last.index} has content"])
+    return CheckResult("check_cta_presence", "FAIL", [f"closing slide {last.index} has no text content"])
+
+
+def check_kicker_unique(canon: list[_CanonSlide]) -> CheckResult:
+    """No two slides in THIS deck share a normalized kicker (within-deck —
+    distinct from production's cross-deck `_kicker_collision`, which checks
+    against recent history; this catches a disco-rotto deck repeating its
+    own kicker on two slides). Whole-string comparison only, mirroring
+    `_normalize_kicker`'s own discipline — never substring."""
+    seen: dict[str, int] = {}
+    reasons: list[str] = []
+    verdict = "PASS"
+    extracted = 0
+    for c in canon:
+        kicker = _extract_kicker(c.kicker_source)
+        if kicker is None:
+            continue
+        extracted += 1
+        norm = _normalize_kicker_text(kicker)
+        if norm in seen:
+            verdict = "FAIL"
+            reasons.append(f"slide {seen[norm]} and slide {c.index} share kicker {kicker!r}")
+        else:
+            seen[norm] = c.index
+    if extracted < 2:
+        return CheckResult("check_kicker_unique", "SKIP", ["fewer than 2 slides yielded an extractable kicker"])
+    if not reasons:
+        reasons = ["all extracted kickers are unique within this deck"]
+    return CheckResult("check_kicker_unique", verdict, reasons)
+
+
+_PROSE_LIKE_TYPES = frozenset({"prose", "body"})
+_DEGENERACY_WARN_FRACTION = 0.70
+
+
+def check_kind_coverage(canon: list[_CanonSlide]) -> CheckResult:
+    """Typed decks: every slide has a valid kind — trivially true after
+    pydantic validation (a cheap tripwire, per spec: 'nessuna struttura
+    tipizzata... trivially true post-validation'). Flat decks: every slide
+    has a non-empty slide_type. Both also WARN (never FAIL) when >70% of
+    non-cover slides are prose/body-shaped — the degeneracy tripwire this
+    whole program exists to surface (spec §0.1's own diagnosis)."""
+    if not canon:
+        return CheckResult("check_kind_coverage", "SKIP", ["empty deck"])
+    missing = [c.index for c in canon if not c.kind_or_type]
+    verdict = "PASS"
+    reasons: list[str] = []
+    if missing:
+        verdict = "FAIL"
+        reasons.append(f"slides missing kind/slide_type: {missing}")
+    non_cover = [c for c in canon if not c.is_cover]
+    if non_cover:
+        prose_like = sum(1 for c in non_cover if c.kind_or_type in _PROSE_LIKE_TYPES)
+        frac = prose_like / len(non_cover)
+        if frac > _DEGENERACY_WARN_FRACTION:
+            if verdict == "PASS":
+                verdict = "WARN"
+            reasons.append(
+                f"{prose_like}/{len(non_cover)} ({frac:.0%}) non-cover slides are prose/body-shaped "
+                f"— degeneracy tripwire (> {_DEGENERACY_WARN_FRACTION:.0%})"
+            )
+    if not reasons:
+        reasons = ["every slide has a kind/slide_type; below the prose/body degeneracy threshold"]
+    return CheckResult("check_kind_coverage", verdict, reasons)
+
+
+def check_spine_echo(canon: list[_CanonSlide], spine: str | None) -> CheckResult:
+    """When a `spine` (the deck's chosen guiding idea, spec §2 Mossa C) is
+    supplied, the closer must echo it via a shared fact-key/entity token —
+    NEVER a bare substring test. SKIP (honest N/A) when no spine is given:
+    this function never guesses one from the copy."""
+    if spine is None:
+        return CheckResult("check_spine_echo", "SKIP", ["no spine provided — never guessed from the copy"])
+    spine_tokens = _fact_key_tokens(spine)
+    if not spine_tokens:
+        return CheckResult("check_spine_echo", "SKIP", ["spine text yielded no extractable fact-key tokens"])
+    if not canon:
+        return CheckResult("check_spine_echo", "SKIP", ["empty deck"])
+    closer = canon[-1]
+    closer_tokens = _fact_key_tokens(closer.reader_text)
+    shared = spine_tokens & closer_tokens
+    if shared:
+        return CheckResult(
+            "check_spine_echo", "PASS",
+            [f"closer (slide {closer.index}) shares fact-key token(s): {sorted(shared)[:5]}"],
+        )
+    return CheckResult(
+        "check_spine_echo", "FAIL",
+        [f"closer (slide {closer.index}) shares zero fact-key tokens with the spine"],
+    )
+
+
+_STRUCTURAL_CHECKS: tuple[Callable[[list[_CanonSlide]], CheckResult], ...] = (
+    check_duplicate_slides,
+    check_bullet_promise,
+    check_caps_policy,
+    check_cta_presence,
+    check_kicker_unique,
+    check_kind_coverage,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Public entry points
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def pregate_typed(deck: SlideDeck, spine: str | None = None) -> PregateReport:
+    """Run the full pre-gate over a validated typed `wr2_carousel_ir.SlideDeck`."""
+    canon = _canon_from_typed(deck)
+    results = [fn(canon) for fn in _STRUCTURAL_CHECKS]
+    results.append(check_spine_echo(canon, spine))
+    return PregateReport(
+        deck_kind="typed", slide_count=len(canon), checks=results, verdict=_aggregate_verdict(results),
+    )
+
+
+def pregate_flat(slides: list[dict[str, Any]], spine: str | None = None) -> PregateReport:
+    """Run the full pre-gate over the flat production slide-dict shape
+    (`wr2_draft_generator._normalise_slides`'s own output shape) — this is
+    what gives immediate value on today's live corpus, no Phase-1/3 cutover
+    required."""
+    canon = _canon_from_flat(slides)
+    results = [fn(canon) for fn in _STRUCTURAL_CHECKS]
+    results.append(check_spine_echo(canon, spine))
+    return PregateReport(
+        deck_kind="flat", slide_count=len(canon), checks=results, verdict=_aggregate_verdict(results),
+    )

--- a/scripts/wr2_pregate_shadow.py
+++ b/scripts/wr2_pregate_shadow.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""wr2_pregate_shadow.py — Phase 2 shadow-measurement harness for the
+deterministic editorial pre-gate (wr2_editorial_pregate.py) against
+historical WR2 decks.
+
+ADDITIVE / SHADOW ONLY / ZERO LLM. This script never writes to
+`war_room_drafts` (the `--fetch` mode issues SELECT only) and never touches
+`wr2_draft_generator.py` / `scripts/wr2_html_renderer/composer.py` — it does
+not modify either file, and neither imports `wr2_editorial_pregate.py`.
+Implements the Phase-2 build mandate's deliverable metric: "the pre-gate
+would have flagged X of N existing decks, breakdown by check" — computed in
+well under a second because every check in wr2_editorial_pregate.py is a
+pure function (no LLM call, no network, no DB write).
+
+Two modes:
+
+  --fetch --out <fixture.json> [--limit N]
+      Read-only query against Postgres (asyncpg, DSN from env DATABASE_URL
+      — same convention wr2_draft_generator.py:2064 / wr2_ir_shadow_replay.py
+      already use) selecting historical decks with a rendered `slides_json`
+      — the REAL production slide copy (headline/subhead/body/slide_type
+      per slide, the `_normalise_slides` output shape), NOT `brief_json`
+      (which only carries the source article, not what was actually
+      drafted — insufficient for this harness). Dumps to a local JSON
+      fixture: `[{id, topic, register, status, created_at, slides: [...]}]`.
+      NEVER writes to the DB.
+
+  --shadow --fixture <fixture.json> --out <report.json> [--limit N]
+      Runs `wr2_editorial_pregate.pregate_flat` over every deck's `slides`,
+      aggregates FAIL/WARN/SKIP counts per check across the corpus, and
+      writes per-check totals + full per-deck detail to --out. No `spine`
+      is passed (production does not carry one yet — Mossa C/spine-as-
+      first-class-field is a later step in the ratified spec) so
+      `check_spine_echo` SKIPs on every deck; this is expected and reported
+      honestly in the totals, never hidden or backfilled with a guess.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import wr2_editorial_pregate as pg  # noqa: E402
+
+logger = logging.getLogger("wr2.pregate_shadow")
+
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_ID_PHONE_RE = re.compile(r"\+?62[\s-]?8\d{2}[\s-]?\d{3,4}[\s-]?\d{3,4}")
+
+_CHECK_NAMES: tuple[str, ...] = (
+    "check_duplicate_slides",
+    "check_bullet_promise",
+    "check_caps_policy",
+    "check_cta_presence",
+    "check_kicker_unique",
+    "check_kind_coverage",
+    "check_spine_echo",
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# --fetch: read-only historical-deck pull (production slide copy)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _scrub_pii(obj: Any) -> Any:
+    """Same belt-and-suspenders scrub as wr2_ir_shadow_replay._scrub_pii —
+    `war_room_drafts` has no client_id/FK into the clients table (verified
+    via information_schema.columns), and every slides_json sampled this
+    session is public regulatory/tourism editorial copy (zero PII hits on
+    the full 63-deck corpus, verified this session). This makes no
+    completeness promise; any hit is logged for human audit. SYMBIOSIS Law
+    2 / UU PDP boundary."""
+    text = json.dumps(obj, ensure_ascii=False)
+    hits = len(_EMAIL_RE.findall(text)) + len(_ID_PHONE_RE.findall(text))
+    if hits:
+        logger.warning("PII-shaped pattern found (%d hits) — redacting before fixture write", hits)
+        text = _EMAIL_RE.sub("[EMAIL-REDACTED]", text)
+        text = _ID_PHONE_RE.sub("[PHONE-REDACTED]", text)
+        return json.loads(text)
+    return obj
+
+
+async def _fetch_decks(out_path: Path, limit: int | None) -> int:
+    import asyncpg  # local import: --shadow mode must not require asyncpg to be installed
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise SystemExit(
+            "DATABASE_URL not set (read-only fetch — see scripts/pg.sh for the "
+            "canonical proxy DSN, or export DATABASE_URL directly)"
+        )
+    conn = await asyncpg.connect(dsn=dsn)
+    try:
+        # Verified filter (this session, mcp__postgres-nuzantara__query /
+        # scripts/pg.sh, read-only role): status='rendered' AND
+        # slides_json IS NOT NULL = 63 rows, 557 slides total.
+        sql = (
+            "SELECT id, topic, register, status, created_at, slides_json->'slides' AS slides "
+            "FROM war_room_drafts "
+            "WHERE status = 'rendered' AND slides_json IS NOT NULL "
+            "ORDER BY created_at ASC"
+        )
+        if limit:
+            sql += " LIMIT $1"
+            rows = await conn.fetch(sql, limit)
+        else:
+            rows = await conn.fetch(sql)
+    finally:
+        await conn.close()
+
+    decks: list[dict[str, Any]] = []
+    for r in rows:
+        slides = r["slides"]
+        if isinstance(slides, str):
+            slides = json.loads(slides)
+        deck = {
+            "id": str(r["id"]),
+            "topic": r["topic"],
+            "register": r["register"],
+            "status": r["status"],
+            "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+            "slides": slides or [],
+        }
+        decks.append(_scrub_pii(deck))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(decks, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info("Fetched %d decks -> %s", len(decks), out_path)
+    return len(decks)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# --shadow: run the deterministic pre-gate over the fixture
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _run_shadow(fixture_path: Path, out_path: Path, *, limit: int | None) -> dict[str, Any]:
+    decks: list[dict[str, Any]] = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if limit:
+        decks = decks[:limit]
+
+    per_check_fail: dict[str, int] = dict.fromkeys(_CHECK_NAMES, 0)
+    per_check_warn: dict[str, int] = dict.fromkeys(_CHECK_NAMES, 0)
+    per_check_skip: dict[str, int] = dict.fromkeys(_CHECK_NAMES, 0)
+    aggregate_verdicts: dict[str, int] = {"PASS": 0, "FAIL": 0, "WARN": 0}
+    per_deck: list[dict[str, Any]] = []
+    n_errors = 0
+
+    for deck in decks:
+        slides = deck.get("slides") or []
+        try:
+            report = pg.pregate_flat(slides, spine=None)
+        except Exception as e:  # one malformed deck must never kill the run
+            n_errors += 1
+            per_deck.append({"id": deck.get("id"), "topic": deck.get("topic"), "error": repr(e)})
+            continue
+        aggregate_verdicts[report.verdict] = aggregate_verdicts.get(report.verdict, 0) + 1
+        per_deck.append({
+            "id": deck.get("id"),
+            "topic": deck.get("topic"),
+            "slide_count": report.slide_count,
+            "verdict": report.verdict,
+            "checks": [c.to_dict() for c in report.checks],
+        })
+        for c in report.checks:
+            if c.verdict == "FAIL":
+                per_check_fail[c.check] = per_check_fail.get(c.check, 0) + 1
+            elif c.verdict == "WARN":
+                per_check_warn[c.check] = per_check_warn.get(c.check, 0) + 1
+            elif c.verdict == "SKIP":
+                per_check_skip[c.check] = per_check_skip.get(c.check, 0) + 1
+
+    result: dict[str, Any] = {
+        "n_decks": len(decks),
+        "n_errors": n_errors,
+        "aggregate_verdicts": aggregate_verdicts,
+        "decks_flagged_fail": aggregate_verdicts.get("FAIL", 0),
+        "decks_flagged_warn": aggregate_verdicts.get("WARN", 0),
+        "per_check_fail_count": per_check_fail,
+        "per_check_warn_count": per_check_warn,
+        "per_check_skip_count": per_check_skip,
+        "per_deck": per_deck,
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info("Shadow run complete: %d decks -> %s", len(decks), out_path)
+    return result
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--fetch", action="store_true", help="Read-only fetch of historical decks' production slides into a JSON fixture")
+    mode.add_argument("--shadow", action="store_true", help="Run the pre-gate over a fixture and report per-check violation counts")
+    parser.add_argument("--out", type=Path, help="Output path (--fetch: fixture JSON; --shadow: report JSON)")
+    parser.add_argument("--fixture", type=Path, help="Input fixture JSON (--shadow only)")
+    parser.add_argument("--limit", type=int, default=None, help="Cap the number of decks processed")
+    args = parser.parse_args()
+
+    if args.fetch:
+        if not args.out:
+            parser.error("--fetch requires --out <fixture.json>")
+        n = asyncio.run(_fetch_decks(args.out, args.limit))
+        print(f"Fetched {n} decks -> {args.out}")
+        return 0
+
+    if not args.fixture:
+        parser.error("--shadow requires --fixture <fixture.json>")
+    if not args.out:
+        parser.error("--shadow requires --out <report.json>")
+    result = _run_shadow(args.fixture, args.out, limit=args.limit)
+    print(json.dumps({
+        "n_decks": result["n_decks"],
+        "n_errors": result["n_errors"],
+        "aggregate_verdicts": result["aggregate_verdicts"],
+        "per_check_fail_count": result["per_check_fail_count"],
+        "per_check_warn_count": result["per_check_warn_count"],
+        "per_check_skip_count": result["per_check_skip_count"],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 2 of the WR2 editorial-intelligence program: a **deterministic, zero-LLM, zero-network/DB editorial pre-gate** that runs ahead of the expensive `wr2-critic` LLM judge, per the ratified spec's "Il Critico — SDOPPIATO" (`.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md` §2). Ported in *shape* (not code) from `Maazsiddiqui01/linkedin-carousel-generator`'s `run_overseer_checks.js` (Jaccard duplicate-detection, bullet-count, CTA/coverage checks — MIT).

**ADDITIVE ONLY** — `scripts/wr2_draft_generator.py`, `scripts/wr2_html_renderer/composer.py`, and `scripts/wr2_carousel_ir.py` are untouched (verified: `git diff --stat` against those three paths is empty).

## What it adds

- **`scripts/wr2_editorial_pregate.py`** (new, 712 lines) — 7 pure-function checks:
  - `check_duplicate_slides` — pairwise Jaccard on reader-text, **boilerplate-stripped first** (Pasal/ayat/berdasarkan/Peraturan/Menteri/Nomor/Tahun/huruf/jo/juncto + digit-only tokens removed) so two different regulatory slides never false-positive on shared legal scaffolding.
  - `check_bullet_promise` — heading/subhead announcing a count (word-boundary digit 2-9 or EN/ID count word) must match the delivered item count (typed: fact_stack/status_list/triad/qa/timeline; flat: bodies with verifiable bullet/numbered structure).
  - `check_caps_policy` — enforces the **RATIFIED** brand rule (spec §8 item 2, ratified by Zero 2026-07-21): caps only on headings, never on bodies. Exemption is by **field role** (heading vs body, assigned per-kind at projection time), never by string-sniffing.
  - `check_cta_presence` — deck has a real closer (typed: `cta` kind anywhere or last-slide `statement`; flat: last slide has content — mirrors `composer.map_slide_to_family`'s own Art 9.5 "last slide is always the closer" rule, since flat `slide_type` is a free string with 76+ distinct values in production, not a reliable discriminator).
  - `check_kicker_unique` — no two slides in the SAME deck share a normalized kicker (within-deck; distinct from production's existing cross-deck `_kicker_collision`). Whole-string comparison, mirrors `_normalize_kicker`'s own discipline — never substring (proven against the exact regression the production code itself worries about: "TAKEAWAY FOR SELLERS" containing "TAKE" must not match "THE SIGNAL TODAY" must not match "THE SIGNAL").
  - `check_kind_coverage` — every slide has a valid kind/slide_type (trivially true post-validation for typed decks); **WARNs** (never FAILs) when >70% of non-cover slides are prose/body-shaped — the degeneracy tripwire the whole program exists to surface.
  - `check_spine_echo` — when a `spine` is supplied, the closer must share a **fact-key/entity token** with it (numbers, regulation-code pairs like "37/2025", uppercase acronyms, content-words) — never a bare substring test. SKIPs honestly when no spine is given (never guesses one from the copy).

  Two entry points share one internal `_CanonSlide` representation: `pregate_typed(deck, spine=None)` (accepts a validated `wr2_carousel_ir.SlideDeck`) and `pregate_flat(slides, spine=None)` (accepts the flat production dict shape `wr2_draft_generator._normalise_slides` actually emits today — this is what gives immediate value on the live corpus).

- **`scripts/tests/test_wr2_editorial_pregate.py`** (new, 33 tests) — full guilt+innocence corpus per check (cicatrix-superscar.md family #3 discipline — the org's most recidivist guard-disease, 8+ prior instances: W68/W72/W73/W82/W83/W84/W85/W91/W92/W94/W95/W99). Every literal example named in the build mandate is reproduced verbatim: a real duplicate pair, "TIGA syarat" with 2 bullets, a caps-wall body, duplicate kickers, a closer with zero spine tokens (guilt); two regulatory slides sharing only boilerplate, "3 syarat" with exactly 3, a body with acronyms KITAS/NPWP/PMA not flagged, a statement slide in caps (exempt by role), spine echoed via the regulation code alone (innocence). Wired into `.github/workflows/wr2-queue-tests.yml`.

- **`infra/guard-conformance/registry.json` + `check_guard_conformance.py`** — registered a new `wr2_editorial_pregate` surface (7 `check_*` functions, AST-censused). Generalized `check_bridge` into a shared, `label`-parameterized checker (was bridge-specific in name only — the logic was already shape-generic) rather than duplicating a bridge-only copy. **0 violations** — every check proven guilt+innocence+non-phantom+armed-in-CI (verified locally, output below).

- **`scripts/wr2_pregate_shadow.py`** (new, 241 lines) — `--fetch` (read-only `slides_json` pull from `war_room_drafts`, PII-scrubbed same as `wr2_ir_shadow_replay.py`'s precedent) / `--shadow` (runs `pregate_flat` over the fetched corpus, aggregates per-check FAIL/WARN/SKIP counts). Zero LLM cost, runs the full 61-deck corpus in well under a second.

## Shadow-measurement result (the Phase-2 deliverable metric)

Ran against **61 of 63** `status='rendered'` historical decks (2/63 use a *different*, richer schema from the manual/interactive `wr2-storyboarder` pipeline — `heading`/`subheading`/`index`/`layout_family`/`list_items` instead of `headline`/`subhead`/`slide_number`/`slide_type` — out of this Phase's contracted scope, see report for detail):

| Aggregate verdict | Decks |
|---|---|
| PASS | 32 |
| WARN | 27 |
| FAIL | 2 |

Per-check breakdown (FAIL / WARN / SKIP out of 61):

| Check | FAIL | WARN | SKIP |
|---|---|---|---|
| check_duplicate_slides | 0 | 0 | 1 |
| check_bullet_promise | 0 | 0 | 58 |
| check_caps_policy | 0 | 0 | 1 |
| check_cta_presence | 0 | 0 | 0 |
| check_kicker_unique | **2** | 0 | 1 |
| check_kind_coverage | 0 | **27** | 0 |
| check_spine_echo | 0 | 0 | 61 |

**Findings:**
- The 2 `check_kicker_unique` FAILs are a genuine, real defect the pre-gate catches: two published decks ("Bali 2026 Investment Visa Landscape" and "Inside Bali's International School Landscape") both repeat the kicker **"Our read"** verbatim on slide 2 AND slide 10 of the same deck.
- The 27 `check_kind_coverage` WARNs directly confirm the ratified spec's own §0.1 diagnosis: ~44% of the autonomous-producer corpus is prose/body-degenerate (>70% of non-cover slides carry no structural signal beyond a free-text label).
- `check_bullet_promise` SKIPs on 58/61 decks — only 3/557 historical slides (measured this session) have any bullet/numbered structure at all, confirming today's flat production bodies are almost entirely unstructured prose.
- `check_spine_echo` SKIPs on all 61 (honestly — no `spine` field exists in production data yet; Mossa C/spine-as-first-class-field is a later step in the ratified spec).

## Guard-conformance proof

```
guard-conformance: 10 bridge guards, 11 hook entries, 7 wr2-pregate checks, 0 violation(s)
  ✓ every censused guard has guilt+innocence proofs, no phantoms, all armed in CI
```

## Test plan

- [x] `pytest scripts/tests/test_wr2_editorial_pregate.py -q` — 33 passed
- [x] `pytest scripts/tests/test_wr2_queue_hygiene.py scripts/tests/test_wr2_visibility_chain.py scripts/tests/test_wr2_rerender_requeue.py scripts/tests/test_wr2_queue_locking.py scripts/tests/test_wr2_pipeline_consolidation.py scripts/tests/test_wr2_daily_reconciler.py scripts/tests/test_wr2_carousel_ir.py scripts/tests/test_wr2_editorial_pregate.py -q` — 197 passed (no regression on the existing WR2 queue/IR battery)
- [x] `python3 infra/guard-conformance/check_guard_conformance.py` — 0 violations
- [x] `ruff check` on all 3 new files — clean
- [x] Verified `wr2_draft_generator.py` / `composer.py` / `wr2_carousel_ir.py` are byte-unchanged
- [x] Shadow-measurement run over the 61-deck live corpus (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)