### PR TITLE
fix(wr2): substitute source-citation + elegant-close placeholders + placeholder-sweep hard gate (W99 class-cure)

### DIFF
--- a/scripts/wr2_html_renderer/composer.py
+++ b/scripts/wr2_html_renderer/composer.py
@@ -1054,6 +1054,49 @@ def _expand_each_blocks(html: str, slide: dict[str, Any]) -> str:
     return each_re.sub(_render_block, html)
 
 
+_TOP_LEVEL_IF_RE = re.compile(r"\{\{#if\s+([a-z_]+)\}\}(.*?)\{\{/if\}\}", re.DOTALL)
+
+
+def _expand_top_level_if_blocks(html: str, slide: dict[str, Any]) -> str:
+    """Expand ``{{#if <var>}}…{{/if}}`` blocks that sit OUTSIDE any ``{{#each}}``
+    loop (per-row ifs inside a loop — e.g. source-citation's ``{{#if note}}`` —
+    are already resolved by ``_expand_each_blocks`` before this runs, so nothing
+    from inside a loop reaches this regex). Keeps the inner content only when
+    ``slide[<var>]`` is truthy, drops the block entirely otherwise — so an
+    optional top-level field a family declares (``regulation_code``,
+    ``primary_source_url``, …) degrades gracefully instead of shipping raw
+    mustache to the renderer.
+
+    W99 class-cure (2026-07-21): this generalizes what used to be a single
+    hardcoded ``regulation_code``-only regex — a FUTURE family that adds its
+    own top-level ``{{#if}}`` is covered automatically, not by name.
+    MUST run after ``_expand_each_blocks`` (see docstring above) — running it
+    first would let a falsy per-row key (e.g. no top-level ``note`` field)
+    wrongly strip a ``{{#each}}`` block's nested ``{{#if note}}`` before the
+    loop ever materializes its rows.
+    """
+    return _TOP_LEVEL_IF_RE.sub(lambda m: m.group(2) if slide.get(m.group(1)) else "", html)
+
+
+_DEFAULT_FILTER_RE = re.compile(r'\{\{\s*([a-z_]+)\s*\|\s*default:\s*"([^"]*)"\s*\}\}')
+
+
+def _expand_default_filters(html: str, slide: dict[str, Any]) -> str:
+    """Expand Handlebars-style ``{{var | default: "..."}}`` tokens — the one
+    skeleton syntax the plain ``{{token}}`` string-replace in ``replacements``
+    (below) can't match, because the token text isn't a bare ``{{var}}``.
+    Uses ``slide[var]`` when truthy, else the literal quoted default text.
+    Currently only elegant-close's ``{{qr_caption | default: "PRIMARY SOURCE"}}``
+    uses this pattern, but the regex is generic — any future ``{{x | default:
+    "y"}}`` is covered automatically (W99 class-cure).
+    """
+    def _sub(m: re.Match[str]) -> str:
+        var, default = m.group(1), m.group(2)
+        return _html_escape(str(slide.get(var) or default))
+
+    return _DEFAULT_FILTER_RE.sub(_sub, html)
+
+
 def _qa_dialogue_fields(slide: dict[str, Any]) -> dict[str, str]:
     """Adapt the storyboarder's ``qa_pairs`` array to qa-dialogue's flat fields.
 
@@ -1368,17 +1411,44 @@ def _check_take_label_variety(slide: dict[str, Any], *, index: int) -> None:
 _ART_6_1_BODY_WORD_MIN = 25
 _ART_6_1_BODY_WORD_MAX = 50
 
+_EACH_BLOCK_STRIP_RE = re.compile(r"\{\{#each\s+[a-z_]+\}\}.*?\{\{/each\}\}", re.DOTALL)
+
+
+def _top_level_skeleton_text(skeleton: str) -> str:
+    """Strip every ``{{#each …}}…{{/each}}`` span before a name-based scan of
+    the skeleton for a top-level placeholder.
+
+    W99-shape bug found + fixed alongside the placeholder-substitution class
+    cure (2026-07-21): source-citation's per-CITATION field is also named
+    ``{{body}}`` (the citation code, e.g. "KEP-71/PJ/2026" — see
+    layouts/source-citation.md's ``{{#each citations}}`` row), which is a
+    completely different thing from a family's top-level prose ``{{body}}``
+    placeholder. A raw ``"{{body}}" in skeleton`` substring check (below,
+    formerly the whole check) can't tell the two apart — the same
+    check-on-the-wrong-scope shape as every other superscar #3 member. That
+    false-positive was a live, verified hard-blocker: calling
+    ``_check_body_word_count`` on the real source-citation skeleton with a
+    genuinely well-formed source-citation slide (title + citations, no
+    top-level body — it has none) raised "Article 6.1 hard fail: body has 0
+    words" and would have stopped ANY source-citation slide from ever
+    reaching ``_fill_placeholders`` via ``compose_carousel`` /
+    ``materialize_slide_html``, independent of the placeholder fix itself.
+    """
+    return _EACH_BLOCK_STRIP_RE.sub("", skeleton)
+
 
 def _check_body_word_count(skeleton: str, slide: dict[str, Any], *, index: int, family: str) -> None:
     """Article 6.1 hard gate: prose body text must be 25-50 words.
 
     Scope, derived from the skeleton itself (not a hardcoded family
     allow-list): the gate applies only when this family's skeleton actually
-    renders a prose `{{body}}` placeholder (editorial-text,
-    photo-headline-yellow-sub, photo-fullbleed / -top / -split,
-    source-citation, stat-card-hero — verified via `grep -l "{{body}}"
-    layouts/*.md`). Families that render STRUCTURED copy instead have no
-    `{{body}}` token and are correctly untouched:
+    renders a TOP-LEVEL prose `{{body}}` placeholder OUTSIDE any
+    `{{#each}}` loop (editorial-text, photo-headline-yellow-sub,
+    photo-fullbleed / -top / -split, stat-card-hero — verified against the
+    real skeleton text, not a raw `grep -l "{{body}}"` which also matches a
+    same-named PER-ROW field, see `_top_level_skeleton_text`). Families that
+    render STRUCTURED copy instead have no top-level `{{body}}` token and
+    are correctly untouched:
       - cover-photo: constitution explicitly exempts it ("title only") —
         and structurally it has no {{body}} either, belt-and-suspenders.
       - statement-bomb: Article 6.6 mandates the closing be a SHORT
@@ -1388,10 +1458,17 @@ def _check_body_word_count(skeleton: str, slide: dict[str, Any], *, index: int, 
         numbered-forces-list / qa-dialogue / elegant-close: structured
         item/fact/QA arrays, not a prose body — Article 6.1 doesn't cleanly
         apply to a bullet list or a QA exchange.
+      - source-citation: its ONLY `{{body}}` occurrence is the per-citation
+        code field inside `{{#each citations}}` (e.g. "KEP-71/PJ/2026") —
+        NOT a top-level prose body. Previously mis-scoped INTO this gate by
+        the raw substring check (fixed 2026-07-21 alongside the
+        placeholder-substitution class cure — see
+        `_top_level_skeleton_text`'s docstring for the live-verified crash
+        this caused).
     A new layout family automatically gets this gate the moment its skeleton
-    adopts {{body}} — no code change required.
+    adopts a TOP-LEVEL {{body}} — no code change required.
     """
-    if "{{body}}" not in skeleton:
+    if "{{body}}" not in _top_level_skeleton_text(skeleton):
         return
     body = str(slide.get("body") or slide.get("body_text") or "").strip()
     # FACTS-STACK exemption: a body the composer itself parses as LABEL: value
@@ -1478,6 +1555,39 @@ def _heading_color_override_css(slide: dict[str, Any]) -> str:
     if not rules:
         return ""
     return '\n<style data-heading-color-override="1">\n' + "\n".join(rules) + "\n</style>\n"
+
+
+_SURVIVING_PLACEHOLDER_RE = re.compile(r"\{\{[^{}]*\}\}")
+
+
+def _assert_no_surviving_placeholders(html: str, family: str) -> None:
+    """Hard gate (W99 class-cure, 2026-07-21): after every fill/expand pass in
+    ``_fill_placeholders``, NOTHING that looks like a Handlebars token
+    (``{{...}}``, including an unresolved ``{{#if}}``/``{{#each}}``/``{{/if}}``/
+    ``{{/each}}``) may survive into the rendered HTML for ANY family.
+
+    This is the exact lesson W99 already taught the codebase once — the
+    renderer KNEW ``montserrat=false`` and downgraded it to a
+    ``logger.warning`` that a 12MB run log drowned, and 6/9 slides of one
+    carousel (4/9 of it ALREADY PUBLISHED) shipped with the wrong font before
+    anyone noticed. `source-citation`'s `{{title}}` and `elegant-close`'s
+    `{{trust_marker}}`/`{{reach}}`/`{{invite}}`/`{{index}}` were the SAME
+    shape: check≠action, silent, discovered only by grep months later. This
+    gate refuses to let that recur for ANY of the 15 renderable families —
+    including ones nobody has broken yet — by failing LOUD (a hard render
+    exception) instead of quiet (a raw-mustache slide nobody looks at).
+
+    Raises ValueError naming both the family and the exact surviving tokens
+    so the failure is immediately actionable, not a blank investigation.
+    """
+    survivors = sorted(set(_SURVIVING_PLACEHOLDER_RE.findall(html)))
+    if survivors:
+        raise ValueError(
+            f"placeholder-sweep gate: family={family!r} shipped with unfilled "
+            f"placeholder(s) {survivors!r} — _fill_placeholders must substitute "
+            "or strip every {{...}} token before a slide can render (W99 "
+            "class-cure: check≠action must never ship silently again)."
+        )
 
 
 def _fill_placeholders(
@@ -1604,12 +1714,6 @@ def _fill_placeholders(
             # the non-facts branch only. No-op if the body has no key number.
             body_html = _emphasize_key_numbers(body_html)
 
-    # {{#if regulation_code}} ... {{/if}}
-    if reg:
-        html = re.sub(r"\{\{#if regulation_code\}\}(.*?)\{\{/if\}\}", r"\1", html, flags=re.DOTALL)
-    else:
-        html = re.sub(r"\{\{#if regulation_code\}\}.*?\{\{/if\}\}", "", html, flags=re.DOTALL)
-
     # statement-bomb uses {{statement}}; map from headline/body
     statement = (slide.get("statement") or headline or body).strip()
 
@@ -1662,6 +1766,17 @@ def _fill_placeholders(
     # the scalar placeholder pass. Previously unhandled → raw mustache shipped.
     html = _expand_each_blocks(html, slide)
 
+    # Top-level {{#if <var>}}…{{/if}} blocks (regulation_code / primary_source_url),
+    # run AFTER _expand_each_blocks so a per-row nested if (e.g. source-citation's
+    # {{#if note}}) is already resolved and can't be mistaken for a top-level one.
+    # `reg` (computed above, with its regulation_code/primary_regulation_code alias
+    # already resolved) is injected under its canonical key so the alias keeps
+    # working through the now-generic expander.
+    html = _expand_top_level_if_blocks(html, {**slide, "regulation_code": reg})
+    # {{qr_caption | default: "..."}} — the one skeleton token that isn't a bare
+    # {{var}} (elegant-close only today; see _expand_default_filters docstring).
+    html = _expand_default_filters(html, slide)
+
     replacements = {
         "{{heading}}": headline,
         "{{subheading}}": subhead,
@@ -1680,6 +1795,24 @@ def _fill_placeholders(
         # numbered-forces-list giant numeral (extracted above from the
         # headline's leading integer). Empty for every other family.
         "{{numeral}}": numeral,
+        # source-citation's top-level title ("SUMBER"/"SOURCES"). DISCOVERED GAP
+        # (PR #2942, verified by grep — zero hits): never substituted anywhere
+        # before this fix. Default empty so an untitled slide degrades to a
+        # blank kicker instead of leaking raw mustache.
+        "{{title}}": _html_escape((slide.get("title") or "").strip()),
+        # elegant-close's content fields. DISCOVERED GAP (PR #2942, same grep):
+        # trust_marker/reach/invite were never substituted anywhere either —
+        # the whole family rendered broken end-to-end. Default empty (never
+        # invent brand copy) so a slide missing one of these degrades to a
+        # blank line rather than a literal {{trust_marker}}.
+        "{{trust_marker}}": _html_escape((slide.get("trust_marker") or "").strip()),
+        "{{reach}}": _html_escape((slide.get("reach") or "").strip()),
+        "{{invite}}": _html_escape((slide.get("invite") or "").strip()),
+        # elegant-close's data-slide-index attribute — found by this fix's own
+        # placeholder sweep (not in the PR #2942 discovery list), same unfilled
+        # shape. `slide_number` is the documented slides_json field (module
+        # docstring above) every real slide already carries.
+        "{{index}}": _html_escape(str(slide.get("slide_number") or "").strip()),
     }
     # qa-dialogue: map qa_pairs → the template's flat voice_a/voice_b fields.
     for fk, fv in _qa_dialogue_fields(slide).items():
@@ -1760,6 +1893,12 @@ def _fill_placeholders(
             html = html.replace("</body>", _BAR_ITEMS_BLOCK_CSS + "</body>", 1)
         else:
             html = html + _BAR_ITEMS_BLOCK_CSS
+
+    # Hard gate (W99 class-cure): every fill/expand pass above is done — refuse
+    # to hand back HTML that still carries an unresolved {{...}} token, for
+    # ANY family. See _assert_no_surviving_placeholders' docstring for why this
+    # must be a raised exception, not a logger.warning.
+    _assert_no_surviving_placeholders(html, family)
 
     return html
 

--- a/scripts/wr2_html_renderer/tests/test_article6_1_word_count.py
+++ b/scripts/wr2_html_renderer/tests/test_article6_1_word_count.py
@@ -119,6 +119,29 @@ def test_innocence_cover_family_has_no_body_placeholder():
     C._check_body_word_count(skeleton, slide, index=1, family="cover-photo")  # no raise
 
 
+def test_innocence_source_citation_per_row_body_field_is_not_top_level():
+    """Regression, 2026-07-21: source-citation's {{#each citations}} row has
+    its OWN {{body}} field (the citation CODE, e.g. "KEP-71/PJ/2026") — a raw
+    `"{{body}}" in skeleton` substring check can't tell that apart from a
+    top-level prose {{body}} placeholder, and previously hard-failed EVERY
+    source-citation slide (even a perfectly well-formed one with no
+    top-level body at all — it has none) with "Article 6.1 hard fail: body
+    has 0 words". Live-verified before this fix; now a structural no-op for
+    this family, matching its real skeleton contract."""
+    skeleton = C._extract_skeleton("source-citation")
+    assert "{{body}}" in skeleton  # the per-row field IS there (raw substring)
+    assert "{{body}}" not in C._top_level_skeleton_text(skeleton)  # but not top-level
+    slide = {
+        "title": "SUMBER",
+        "citations": [
+            {"body": "KEP-71/PJ/2026", "issuer": "DJP", "date": "30 April 2026",
+             "url": "https://pajak.go.id/x"},
+        ],
+    }
+    result = C._check_body_word_count(skeleton, slide, index=8, family="source-citation")
+    assert result is None  # did not raise
+
+
 def test_sweep_real_layout_library_body_placeholder_families_match_expectation():
     """Ground-truth sweep (guard-conformance doctrine): the families this
     module's docstring claims render {{body}} must match what's actually in

--- a/scripts/wr2_html_renderer/tests/test_placeholder_sweep_gate.py
+++ b/scripts/wr2_html_renderer/tests/test_placeholder_sweep_gate.py
@@ -1,0 +1,328 @@
+"""W99 class-cure: placeholder-substitution + hard sweep gate (2026-07-21,
+PR #2942 discovery -> Phase-3 composer.py follow-up).
+
+The discovery (verified live this session by grep, zero hits before this
+fix): source-citation's top-level {{title}} and elegant-close's
+{{trust_marker}}/{{reach}}/{{invite}}/{{primary_source_url}}-gated
+{{qr_caption}} were NEVER substituted anywhere in
+composer._fill_placeholders -- both families rendered broken end-to-end,
+independent of the typed Carousel IR. The sweep this test file adds ALSO
+found a sixth, previously-undiscovered instance in the same family:
+elegant-close's `data-slide-index="{{index}}"` was equally unfilled.
+
+This is the exact check!=action shape W99 already named (composer.
+_normalize_skeleton checked loose, replaced strict -- 6/9 slides of one
+carousel, 4/9 of it ALREADY PUBLISHED, rendered in the wrong font before
+anyone noticed because the renderer KNEW and downgraded to a
+logger.warning). The class cure is not "patch the two named families" --
+it is a hard, unconditional gate wired into _fill_placeholders itself
+(_assert_no_surviving_placeholders) that raises ValueError naming the
+family + surviving tokens the moment ANY {{...}} token would ship, plus a
+sweep of every RENDERABLE_FAMILIES skeleton so a future family that adds
+an unfilled placeholder is caught at build time, not months later by grep.
+
+Guilt: a synthetic skeleton with an unmapped {{bogus}} token raises.
+Innocence: all 15 real layout families, filled with a representative slide
+dict, render with zero surviving {{...}} tokens.
+"""
+from pathlib import Path
+
+import pytest
+
+from wr2_html_renderer.composer import (
+    RENDERABLE_FAMILIES,
+    _assert_no_surviving_placeholders,
+    _expand_default_filters,
+    _expand_top_level_if_blocks,
+    _extract_skeleton,
+    _fill_placeholders,
+    _hero_bg_to_img,
+    _normalize_skeleton,
+)
+
+# Families whose skeleton renders a full-bleed/CSS-background hero photo via
+# {{image_url}} (composer._hero_bg_to_img rewrites the .hero div -> <img> for
+# these before _fill_placeholders runs, mirroring compose_carousel's real
+# per-slide pipeline order).
+_HERO_FAMILIES = {
+    "cover-photo",
+    "photo-headline-yellow-sub",
+    "photo-fullbleed",
+    "photo-fullbleed-top",
+    "photo-fullbleed-split",
+}
+
+# One representative, fully-populated slide dict per RENDERABLE family, field
+# names verified against the real layouts/<family>.md skeletons +
+# scripts/wr2_carousel_ir.py's to_composer_dict projection (same session).
+_REPRESENTATIVE_SLIDES: dict[str, dict] = {
+    "cover-photo": {
+        "headline": "IDR 2.815 TRILLION FROM VISAS ALONE",
+        "subhead": "BKPM DATA Q1 2026",
+        "regulation_code": "PP 28/2025",
+    },
+    "photo-headline-yellow-sub": {
+        "headline": "THE RULE MOST VILLAS BREAK",
+        "subhead": "ZONING",
+        "body": "Leasehold status alone does not clear commercial zoning.",
+    },
+    "photo-fullbleed": {
+        "headline": "THE CRACKDOWN, IN NUMBERS",
+        "subhead": "PMA RENTAL",
+        "body": "1,204 units inspected across three regencies this quarter.",
+        "regulation_code": "Perpres 95/2024",
+    },
+    "photo-fullbleed-top": {
+        "headline": "A NEW FILING WINDOW OPENS",
+        "subhead": "TAX",
+        "body": "SPT Tahunan extensions now run through the end of May.",
+    },
+    "photo-fullbleed-split": {
+        "headline": "TWO PATHS, ONE DEADLINE",
+        "subhead": "KITAS",
+        "body": "Renewal or conversion -- both close on the same date.",
+        "regulation_code": "Permenkumham 22/2023",
+    },
+    "editorial-text": {
+        "headline": "WHY THE NUMBER MOVED",
+        "subhead": "CONTEXT",
+        "body": "A methodology change explains most of the year-on-year swing.",
+    },
+    "qa-dialogue": {
+        "qa_pairs": [
+            {"voice": "INVESTOR", "line": "IS JAPAN VISA-FREE?"},
+            {"voice": "BALI ZERO", "line": "NO. NOT ON THE LIST."},
+        ],
+    },
+    "timeline-pinboard": {
+        "headline": "HOW WE GOT HERE",
+        "events": [
+            {"date": "2024", "label": "FRAMEWORK ISSUED", "accent": "white"},
+            {"date": "2026", "label": "ENFORCEMENT BEGINS", "accent": "yellow"},
+        ],
+    },
+    "dark-status-list": {
+        "headline": "WHERE EACH TRACK STANDS",
+        "list_items": [
+            {"label": "FRAMEWORK", "value": "Perpres 95/2024", "status": "neutral"},
+            {"label": "BVK LIST", "value": "16 nationalities", "status": "positive"},
+        ],
+    },
+    "evidence-carved": {
+        "headline": "THE EVIDENCE",
+        "facts": [
+            {"idx": 1, "this": "1,204 units inspected."},
+            {"idx": 2, "this": "312 notices issued."},
+        ],
+        "take_label": "OUR READ",
+        "take_line": "Enforcement is now systematic, not spot-check.",
+    },
+    "statement-bomb": {
+        "statement": "THE RULE CHANGED. MOST OWNERS DID NOT NOTICE.",
+    },
+    "elegant-close": {
+        "slide_number": 9,
+        "trust_marker": "LICENSED KONSULTAN PAJAK - REGISTERED PPJK",
+        "reach": "ZANTARA@BALIZERO.COM",
+        "invite": "IF YOUR CASE TOUCHES THIS - A 30-MIN CALL CONFIRMS NEXT STEPS.",
+        "primary_source_url": "https://pajak.go.id/kep-71",
+        "qr_caption": "PRIMARY SOURCE",
+    },
+    "source-citation": {
+        "title": "SUMBER",
+        "citations": [
+            {
+                "body": "KEP-71/PJ/2026",
+                "issuer": "DJP - Direktorat Jenderal Pajak",
+                "date": "30 April 2026",
+                "url": "https://www.pajak.go.id/kep-71",
+                "note": "Surat keputusan resmi, dapat diunduh sebagai PDF",
+            },
+        ],
+    },
+    "stat-card-hero": {
+        "headline": "2.815T",
+        "subhead": "TOTAL VISA REVENUE",
+        "body": "BKPM Q1 2026 filing, verbatim.",
+        "chart": {
+            "rows": [
+                {"label": "2025", "value": "IDR 2.645T"},
+                {"label": "2026", "value": "IDR 2.815T"},
+            ],
+        },
+    },
+    "numbered-forces-list": {
+        "headline": "3 FORCES BEHIND THE RISE",
+        "items": [
+            {"label": "DEMAND", "value": "Post-pandemic rebound"},
+            {"label": "ENFORCEMENT", "value": "Fewer unlicensed operators"},
+            {"label": "RATES", "value": "Visa fee schedule reset"},
+        ],
+    },
+}
+
+
+def _fill_family(family: str, slide: dict) -> str:
+    """Run the same skeleton -> normalize -> (hero rewrite) -> fill pipeline
+    compose_carousel/materialize_slide_html use for one family."""
+    skeleton = _normalize_skeleton(_extract_skeleton(family))
+    hero_filename = "slide-01-hero.jpg" if family in _HERO_FAMILIES else None
+    if hero_filename:
+        skeleton = _hero_bg_to_img(skeleton, hero_filename)
+    return _fill_placeholders(
+        skeleton,
+        slide,
+        hero_filename=hero_filename,
+        cover_family=(family == "cover-photo"),
+        family=family,
+    )
+
+
+class TestPlaceholderSweepGateGuilt:
+    """The gate itself: an unmapped {{...}} token must hard-fail, loud."""
+
+    def test_unmapped_placeholder_raises(self):
+        bogus = "<html><head></head><body>{{heading}}{{bogus_field}}</body></html>"
+        with pytest.raises(ValueError, match=r"placeholder-sweep gate"):
+            _fill_placeholders(bogus, {"headline": "X"}, hero_filename=None, family="fake-family")
+
+    def test_raised_error_names_family_and_token(self):
+        bogus = "<html><head></head><body>{{nope}}</body></html>"
+        with pytest.raises(ValueError, match=r"fake-family.*\{\{nope\}\}|\{\{nope\}\}.*fake-family"):
+            _fill_placeholders(bogus, {}, hero_filename=None, family="fake-family")
+
+    def test_unresolved_if_block_raises(self):
+        """A top-level {{#if}} whose var is never in `slide` at all (typo, or a
+        future family authored wrong) must still fail loud, not ship the
+        literal {{#if}}/{{/if}} markers."""
+        bogus = "<html><head></head><body>{{#if some_flag}}TEXT{{/if}}</body></html>"
+        # some_flag absent -> block content included is irrelevant here: the
+        # var name itself is never in the slide, so this is guilt only if the
+        # generic if-expander is bypassed. Exercise the real fill path:
+        out_or_raise = None
+        try:
+            out_or_raise = _fill_placeholders(bogus, {}, hero_filename=None, family="fake-family")
+        except ValueError:
+            out_or_raise = "RAISED"
+        # Either the block was correctly dropped (falsy some_flag -> no
+        # surviving token, gate passes) OR it raised -- both are acceptable
+        # outcomes for an absent var; what must NEVER happen is a literal
+        # "{{#if" surviving into a passing return.
+        if out_or_raise != "RAISED":
+            assert "{{#if" not in out_or_raise
+            assert "{{/if}}" not in out_or_raise
+
+    def test_direct_gate_function_raises_on_survivor(self):
+        with pytest.raises(ValueError, match=r"placeholder-sweep gate"):
+            _assert_no_surviving_placeholders("<div>{{leftover}}</div>", "some-family")
+
+    def test_direct_gate_function_passes_on_clean_html(self):
+        result = _assert_no_surviving_placeholders("<div>all good</div>", "some-family")
+        assert result is None  # did not raise
+
+
+class TestPlaceholderSweepInnocence:
+    """All 15 renderable families, representative data, zero survivors."""
+
+    def test_representative_slides_cover_every_renderable_family(self):
+        """Guard the guard: the corpus above must not silently drift out of
+        sync with RENDERABLE_FAMILIES (W84 blind-scan discipline)."""
+        assert set(_REPRESENTATIVE_SLIDES.keys()) == RENDERABLE_FAMILIES
+
+    @pytest.mark.parametrize("family", sorted(RENDERABLE_FAMILIES))
+    def test_family_renders_with_zero_surviving_placeholders(self, family):
+        layouts_dir = Path.home() / ".claude" / "skills" / "bali-zero-brand" / "layouts"
+        if not (layouts_dir / f"{family}.md").is_file():
+            pytest.skip("brand layouts dir not present on this machine")
+        slide = _REPRESENTATIVE_SLIDES[family]
+        out = _fill_family(family, slide)
+        assert "{{" not in out, f"{family} shipped raw mustache: {out}"
+
+    def test_source_citation_title_is_filled(self):
+        """Pinned regression: the exact PR #2942 discovery."""
+        out = _fill_family("source-citation", _REPRESENTATIVE_SLIDES["source-citation"])
+        assert "SUMBER" in out
+        assert "{{title}}" not in out
+
+    def test_elegant_close_content_fields_are_filled(self):
+        """Pinned regression: the exact PR #2942 discovery (trust_marker/
+        reach/invite), plus the {{index}} instance this sweep also found."""
+        out = _fill_family("elegant-close", _REPRESENTATIVE_SLIDES["elegant-close"])
+        assert "LICENSED KONSULTAN PAJAK" in out
+        assert "ZANTARA@BALIZERO.COM" in out
+        assert "30-MIN CALL" in out
+        assert 'data-slide-index="9"' in out
+        for token in ("{{trust_marker}}", "{{reach}}", "{{invite}}", "{{index}}"):
+            assert token not in out
+
+    def test_elegant_close_qr_branch_uses_provided_caption(self):
+        out = _fill_family("elegant-close", _REPRESENTATIVE_SLIDES["elegant-close"])
+        assert "qr-closing__caption" in out
+        assert "PRIMARY SOURCE" in out
+        assert "{{qr_caption" not in out
+
+    def test_elegant_close_qr_branch_absent_drops_block_cleanly(self):
+        """Innocence for the {{#if primary_source_url}} branch: when the
+        slide has no primary_source_url, the whole QR block -- including its
+        {{qr_caption | default: ...}} token -- must be dropped, not left
+        half-filled."""
+        slide = {
+            k: v
+            for k, v in _REPRESENTATIVE_SLIDES["elegant-close"].items()
+            if k not in ("primary_source_url", "qr_caption")
+        }
+        out = _fill_family("elegant-close", slide)
+        assert "qr-closing__caption" not in out
+        assert "{{qr_caption" not in out
+        assert "{{" not in out
+
+    def test_elegant_close_qr_caption_falls_back_to_default_when_unset(self):
+        """The {{qr_caption | default: "PRIMARY SOURCE"}} filter: an explicit
+        primary_source_url with NO qr_caption override still fills from the
+        skeleton's own literal default text, never leaks the filter syntax."""
+        slide = {
+            **{
+                k: v
+                for k, v in _REPRESENTATIVE_SLIDES["elegant-close"].items()
+                if k != "qr_caption"
+            },
+        }
+        out = _fill_family("elegant-close", slide)
+        assert "PRIMARY SOURCE" in out
+        assert "{{qr_caption" not in out
+
+
+class TestGenericIfAndDefaultFilterHelpers:
+    """Unit-level guilt+innocence for the two new generic expanders."""
+
+    def test_top_level_if_keeps_block_when_truthy(self):
+        html = "<div>{{#if flag}}SHOWN{{/if}}</div>"
+        out = _expand_top_level_if_blocks(html, {"flag": "yes"})
+        assert out == "<div>SHOWN</div>"
+
+    def test_top_level_if_drops_block_when_falsy(self):
+        html = "<div>{{#if flag}}SHOWN{{/if}}</div>"
+        out = _expand_top_level_if_blocks(html, {})
+        assert out == "<div></div>"
+
+    def test_top_level_if_is_generic_not_hardcoded_to_regulation_code(self):
+        """The class-cure claim: a brand-new var name (never enumerated by
+        name anywhere in composer.py) is still covered."""
+        html = "<div>{{#if some_future_field}}X{{/if}}</div>"
+        assert _expand_top_level_if_blocks(html, {"some_future_field": True}) == "<div>X</div>"
+        assert _expand_top_level_if_blocks(html, {}) == "<div></div>"
+
+    def test_default_filter_uses_slide_value_when_present(self):
+        html = '{{qr_caption | default: "PRIMARY SOURCE"}}'
+        out = _expand_default_filters(html, {"qr_caption": "SUMBER ASLI"})
+        assert out == "SUMBER ASLI"
+
+    def test_default_filter_falls_back_to_literal_default(self):
+        html = '{{qr_caption | default: "PRIMARY SOURCE"}}'
+        out = _expand_default_filters(html, {})
+        assert out == "PRIMARY SOURCE"
+
+    def test_default_filter_escapes_slide_value(self):
+        html = '{{qr_caption | default: "PRIMARY SOURCE"}}'
+        out = _expand_default_filters(html, {"qr_caption": "A & B"})
+        assert out == "A &amp; B"


### PR DESCRIPTION
## Summary

Phase-3 prerequisite of the editorial-intelligence program (W99-shape territory: check≠action, superscar #3). PR #2942 discovered — grep-verified, zero hits — that two of the 15 WR2 layout families rendered broken end-to-end: `source-citation`'s top-level `{{title}}` and `elegant-close`'s `{{trust_marker}}`/`{{reach}}`/`{{invite}}`/`{{primary_source_url}}`-gated `{{qr_caption}}` were never substituted anywhere in `composer._fill_placeholders`. The mandate demanded the CLASS cure (a sweep + hard gate across all 15 families), not just patching the two named ones.

## The bug

`_fill_placeholders` had per-family scalar substitution for `{{heading}}`/`{{body}}`/`{{statement}}`/etc., but two families' own top-level content fields were never wired in:

- **source-citation**: `{{title}}` (the "SUMBER"/"SOURCES" kicker) — never in `replacements`.
- **elegant-close**: `{{trust_marker}}`, `{{reach}}`, `{{invite}}` — never in `replacements`. Its `{{#if primary_source_url}}…{{/if}}` QR block also had no generic top-level-if handling (only `regulation_code` had a hardcoded regex), so even a slide that *did* set `primary_source_url` couldn't render the block, and `{{qr_caption | default: "PRIMARY SOURCE"}}` uses a filter syntax no existing code path understood.
- The sweep this PR adds found a **sixth, previously-undiscovered** instance in the same family: elegant-close's `data-slide-index="{{index}}"` was equally unfilled.

## The class cure

- **`_expand_top_level_if_blocks`** — generalizes the old `regulation_code`-only regex into a generic `{{#if <var>}}…{{/if}}` expander (runs *after* `_expand_each_blocks` so a per-row nested if, e.g. source-citation's `{{#if note}}`, is never mistaken for a top-level one). Fixes `primary_source_url` and covers any future family's top-level conditional automatically, not by name.
- **`_expand_default_filters`** — handles `{{qr_caption | default: "PRIMARY SOURCE"}}`, the one skeleton token that isn't a bare `{{var}}`.
- **`_assert_no_surviving_placeholders`** — wired as the *last* step of `_fill_placeholders` (both call sites: `compose_carousel` and `materialize_slide_html`). If any `{{...}}` token survives in the final HTML for **any** family, it raises `ValueError` naming the family + exact tokens. Fail loud, not `logger.warning` — W99's own lesson was a renderer that *knew* `montserrat=false` and downgraded it to a warning nobody read; this gate refuses to let that recur for this class of bug.

## An additional discovered-and-fixed blocker (same disease shape)

Verifying the *full* production pipeline (not just `_fill_placeholders` in isolation), `_check_slide_constitution_gates` → `_check_body_word_count` raised `"Article 6.1 hard fail: body has 0 words"` for a **perfectly well-formed** source-citation slide. Root cause: that gate scoped source-citation into its 25-50-word body check via a raw `"{{body}}" in skeleton` substring test — but source-citation's *only* `{{body}}` occurrence is a **per-citation row field** inside `{{#each citations}}` (the citation code, e.g. `KEP-71/PJ/2026`), not a top-level prose body at all. Same check≠action shape as the placeholder bug, just in a different gate. Without this fix, source-citation would still hard-fail via `compose_carousel`/`materialize_slide_html` even with the placeholder substitution fixed — so "this cures the manual path" would have been false. Fixed via `_top_level_skeleton_text` (strips `{{#each}}` spans before the scope check), with a pinned regression test.

## Test evidence

- `scripts/wr2_html_renderer/tests/test_placeholder_sweep_gate.py` (new, 32 tests): guilt (synthetic `{{bogus}}` raises) + innocence (all 15 `RENDERABLE_FAMILIES`, representative slide dicts, real skeletons from disk, zero surviving tokens) + unit coverage for the two new generic expanders + the QR-branch present/absent/default-fallback cases.
- `scripts/wr2_html_renderer/tests/test_article6_1_word_count.py`: +1 pinned regression for the Article 6.1 false-positive.
- Full `scripts/wr2_html_renderer/tests/` battery: **154/154** (121 baseline + 32 new + 1 regression).
- CI-parity `wr2-queue-tests.yml` battery (`test_wr2_carousel_ir.py` + 6 others): **197/197**.
- `ruff check` + the repo's `lint_test_reward_hacking.py` anti-reward-hacking linter: clean.
- No existing test asserted the old broken behavior — zero test-behavior changes, only additions.

## Test plan

- [x] `pytest scripts/wr2_html_renderer/tests/` — 154/154 pass
- [x] CI-parity `wr2-queue-tests.yml` battery — 197/197 pass
- [x] `ruff check` on all touched files — clean
- [x] `scripts/lint_test_reward_hacking.py` — clean
- [x] Manual end-to-end verification: source-citation and elegant-close slides now pass `_check_slide_constitution_gates` → `_fill_placeholders` with zero surviving `{{...}}` tokens, matching what `compose_carousel`/`materialize_slide_html` would actually run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
