### PR TITLE
feat(curated-qa): retire --verbatim-all override — verbatim is JELAS-only per Zero 2026-07-21

### DIFF
--- a/.claude/skills/bot/SKILL.md
+++ b/.claude/skills/bot/SKILL.md
@@ -20,8 +20,10 @@ WhatsApp Business (Meta Cloud API) number **+62 821-3465-159** = Zantara. Two au
 - **Bali Zero team**: work-support assistant. Check-in via WA (opens the free Meta 24h window),
   CRM nudges, PII-light briefings. Persona = "assistente operativo interno", not sales.
 
-## 1. LIVE STATE (last update 2026-07-20 ~02:45 WITA — keep current)
+## 1. LIVE STATE (last update 2026-07-21 ~17:30 WITA — keep current)
 
+- **🔓 P0 SECURITY — CRM/PII on PUBLIC unauthenticated endpoints (verified on main 2026-07-21, NOT yet fixed)**: `/api/blog/ask` (blog_ask.py:48, "No authentication required", public AskZantara widget, mounted `_RAG`) → `process_query(user_id="blog_visitor")` no agent_role → authorizer `tool_authorizer.py:183 None→allow` → orchestrator has CRMTool #9 + TimeSheetTool #10 (`__init__.py:178`) → `CRMTool.execute` (tools.py:1059, no self-gate on main) whole-book `ILIKE`, limit unclamped = client PII on public HTTP. Also `/api/team/clock-in`+`/clock-out` (team_activity.py:142/168) no `Depends`, identity from BODY = impersonation. C partial fix (4891c7a6c1) NOT on main + Codex-REJECTED. Correct fix = server-side principal + authorizer default-deny + prefetch-through-executor + clamp + timesheet email from principal + auth on clock-in/out. Memory `discovery_crm_pii_public_exposure_blog_ask_timesheet_2026_07_21`.
+- **🎚️ VERBATIM FAQ → JELAS-only (Zero 2026-07-21) — DONE+VERIFIED**: refined the 19/7 "all verbatim"; deleted 215 non-JELAS from Redis `notebooklm:qa:*` (AFTER = 139 = 103 JELAS + 36 E33, non-JELAS=0); Qdrant `curated_qa` 808 pts intact (grounding preserved). This PR retires the `--verbatim-all` override so a re-harvest can't undo it. Memory `ops_verbatim_rollback_jelas_only_2026_07_21`.
 - **WA OUTBOX P0 (2026-07-19) — FIXED #2812 + DEPLOYED 12:45 UTC + VERIFIED**: the per-thread
   advisory lock passed raw `int thread_id` into `hashtext('wa_outbox_thread_' || $1::text)` —
   asyncpg types `$1` TEXT from the cast and refuses int (`DataError: expected str, got int`),

--- a/apps/backend-rag/backend/tests/unit/scripts/test_curated_qa_harvest.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_curated_qa_harvest.py
@@ -493,20 +493,46 @@ async def test_harvest_to_qdrant_bersyarat_row_still_written() -> None:
     assert point["payload"]["verbatim_eligible"] is False
 
 
-# ── --verbatim-all override (task #27, Zero's Legge-5 order 2026-07-19) ────
+# ── --verbatim-all RETIRED (Zero, 2026-07-21 refinement of task #27) ───────
+#
+# The 2026-07-19 override wrongly promoted 215 non-JELAS entries to
+# verbatim FAQ/Qdrant serving. Zero retired it 2026-07-21: verbatim
+# serving is JELAS-only, unconditionally — the `verbatim_all` parameter is
+# kept for CLI backward-compat but must NEVER change eligibility again.
+# These tests prove the retirement (GUILT: promotion no longer happens)
+# and that the surrounding gates are undisturbed (INNOCENCE: JELAS still
+# flows, pricing/client_specific still block).
 
 
-def test_derive_verbatim_eligible_verbatim_all_promotes_bersyarat_row() -> None:
-    """GUILT — under verbatim_all, a BERSYARAT row (which would be False
-    under the default policy) becomes eligible."""
+def test_derive_verbatim_eligible_verbatim_all_no_longer_promotes_bersyarat_row() -> None:
+    """GUILT — a BERSYARAT row (ineligible under the default policy) stays
+    ineligible even with verbatim_all=True — the retired override no
+    longer bypasses the confidence_class gate."""
     row = _row(confidence_class="BERSYARAT", answer="No figures here.")
     assert harvest._derive_verbatim_eligible(row) is False
+    assert harvest._derive_verbatim_eligible(row, verbatim_all=True) is False
+
+
+def test_derive_verbatim_eligible_verbatim_all_no_longer_promotes_dinamis_row() -> None:
+    """GUILT — same retirement proof for the DINAMIS class."""
+    row = _row(confidence_class="DINAMIS", answer="No figures here.")
+    assert harvest._derive_verbatim_eligible(row) is False
+    assert harvest._derive_verbatim_eligible(row, verbatim_all=True) is False
+
+
+def test_derive_verbatim_eligible_verbatim_all_jelas_clean_row_still_eligible() -> None:
+    """INNOCENCE — the retirement does not regress the JELAS-only path: a
+    genuinely eligible JELAS/non-price/non-client-specific row stays
+    eligible whether or not the retired flag is passed."""
+    row = _row(confidence_class="JELAS", client_specific=False, answer="No figures here.")
+    assert harvest._derive_verbatim_eligible(row) is True
     assert harvest._derive_verbatim_eligible(row, verbatim_all=True) is True
 
 
 def test_derive_verbatim_eligible_verbatim_all_still_blocks_price_bearing_row() -> None:
-    """INNOCENCE — the FATAL 13 pricing rail is never bypassed by
-    verbatim_all, regardless of confidence_class."""
+    """INNOCENCE — the FATAL 13 pricing rail was never bypassed by
+    verbatim_all and still isn't, regardless of confidence_class. A JELAS
+    row that is otherwise eligible but pricing-dirty stays refused too."""
     row = _row(confidence_class="BERSYARAT", answer="The processing fee is Rp 5.000.000.")
     assert harvest._derive_verbatim_eligible(row, verbatim_all=True) is False
 
@@ -515,9 +541,8 @@ def test_derive_verbatim_eligible_verbatim_all_still_blocks_price_bearing_row() 
 
 
 def test_derive_verbatim_eligible_verbatim_all_still_blocks_client_specific_price_row() -> None:
-    """INNOCENCE — client_specific + price-bearing under verbatim_all is
-    still refused on the pricing rail alone (client_specific itself is
-    bypassed by the override, but pricing is not)."""
+    """INNOCENCE — client_specific + price-bearing stays refused with the
+    retired flag set — neither gate reopens."""
     row = _row(
         confidence_class="JELAS",
         client_specific=True,
@@ -539,23 +564,55 @@ def test_derive_verbatim_eligible_verbatim_all_false_is_unchanged_default() -> N
 
 
 @pytest.mark.asyncio
-async def test_harvest_to_faq_verbatim_all_promotes_bersyarat_row_with_provenance(
+async def test_harvest_to_faq_verbatim_all_no_longer_promotes_bersyarat_row(
     faq_cache: NotebookLMCacheService,
 ) -> None:
-    """GUILT — flag ON: a BERSYARAT row reaches the FAQ sink and its
-    metadata carries the override provenance stamp."""
+    """GUILT — flag ON: a BERSYARAT row is STILL refused from the FAQ sink
+    (retired override) and its metadata carries no override provenance."""
     from backend.services.caching.notebooklm_cache_service import domain_scope_id
 
     rows = [_row(question="Conditional Q", confidence_class="BERSYARAT")]
 
     stats = await harvest.harvest_to_faq(rows, faq_cache, dry_run=False, verbatim_all=True)
 
+    assert stats.faq_written == 0
+    assert stats.faq_ineligible_skipped == 1
+    assert await faq_cache.get("Conditional Q", notebook_id=domain_scope_id("visa")) is None
+
+
+@pytest.mark.asyncio
+async def test_harvest_to_faq_verbatim_all_no_longer_promotes_dinamis_row(
+    faq_cache: NotebookLMCacheService,
+) -> None:
+    """GUILT — same retirement proof, DINAMIS class."""
+    from backend.services.caching.notebooklm_cache_service import domain_scope_id
+
+    rows = [_row(question="Dynamic Q", confidence_class="DINAMIS")]
+
+    stats = await harvest.harvest_to_faq(rows, faq_cache, dry_run=False, verbatim_all=True)
+
+    assert stats.faq_written == 0
+    assert stats.faq_ineligible_skipped == 1
+    assert await faq_cache.get("Dynamic Q", notebook_id=domain_scope_id("visa")) is None
+
+
+@pytest.mark.asyncio
+async def test_harvest_to_faq_verbatim_all_jelas_clean_row_still_flows_to_sink(
+    faq_cache: NotebookLMCacheService,
+) -> None:
+    """INNOCENCE — the retired flag doesn't regress the JELAS-only path,
+    and no metadata carries a stale override stamp."""
+    from backend.services.caching.notebooklm_cache_service import domain_scope_id
+
+    rows = [_row(question="Clean Q", confidence_class="JELAS")]
+
+    stats = await harvest.harvest_to_faq(rows, faq_cache, dry_run=False, verbatim_all=True)
+
     assert stats.faq_written == 1
-    assert stats.faq_ineligible_skipped == 0
-    got = await faq_cache.get("Conditional Q", notebook_id=domain_scope_id("visa"))
+    got = await faq_cache.get("Clean Q", notebook_id=domain_scope_id("visa"))
     assert got is not None
     assert got["metadata"]["verbatim_eligible"] is True
-    assert got["metadata"]["verbatim_override"] == harvest.VERBATIM_OVERRIDE_PROVENANCE
+    assert "verbatim_override" not in got["metadata"]
 
 
 @pytest.mark.asyncio
@@ -563,8 +620,8 @@ async def test_harvest_to_faq_verbatim_all_off_matches_default_behavior(
     faq_cache: NotebookLMCacheService,
 ) -> None:
     """INNOCENCE — flag OFF (the default): a BERSYARAT row is refused
-    exactly like before the override existed, and no metadata carries the
-    override key."""
+    identically to flag ON (both are now the same retired no-op), and no
+    metadata carries the override key."""
     from backend.services.caching.notebooklm_cache_service import domain_scope_id
 
     rows = [_row(question="Conditional Q", confidence_class="BERSYARAT")]
@@ -575,8 +632,8 @@ async def test_harvest_to_faq_verbatim_all_off_matches_default_behavior(
     assert stats.faq_ineligible_skipped == 1
     assert await faq_cache.get("Conditional Q", notebook_id=domain_scope_id("visa")) is None
 
-    # A clean JELAS row (unaffected either way) never carries the override
-    # key when the flag is off.
+    # A clean JELAS row (unaffected either way) never carries the retired
+    # override key.
     clean_rows = [_row(question="Clean Q", confidence_class="JELAS")]
     await harvest.harvest_to_faq(clean_rows, faq_cache, dry_run=False)
     got = await faq_cache.get("Clean Q", notebook_id=domain_scope_id("visa"))
@@ -587,7 +644,7 @@ async def test_harvest_to_faq_verbatim_all_off_matches_default_behavior(
 async def test_harvest_to_faq_verbatim_all_price_bearing_row_still_hard_refused(
     faq_cache: NotebookLMCacheService,
 ) -> None:
-    """INNOCENCE — the negative-guard proof: with verbatim_all ON, a
+    """INNOCENCE — the negative-guard proof: with the retired flag ON, a
     price-bearing row (any confidence class) is STILL refused by the FAQ
     sink and counted as a price rejection, never written."""
     rows = [
@@ -606,9 +663,11 @@ async def test_harvest_to_faq_verbatim_all_price_bearing_row_still_hard_refused(
 
 
 @pytest.mark.asyncio
-async def test_harvest_to_qdrant_verbatim_all_promotes_and_stamps_provenance() -> None:
-    """GUILT (Qdrant side) — under verbatim_all, a BERSYARAT row's payload
-    carries verbatim_eligible=True and the override provenance stamp."""
+async def test_harvest_to_qdrant_verbatim_all_no_longer_promotes_bersyarat_row() -> None:
+    """GUILT (Qdrant side) — with the retired flag ON, a BERSYARAT row's
+    payload stays verbatim_eligible=False and carries no override
+    provenance (Qdrant still stores it for grounding regardless — it was
+    never eligibility-gated for STORAGE)."""
     client = FakeQdrantClient(exists=True)
     embedder = FakeEmbedder()
     rows = [_row(question="Conditional Q", confidence_class="BERSYARAT")]
@@ -617,17 +676,17 @@ async def test_harvest_to_qdrant_verbatim_all_promotes_and_stamps_provenance() -
 
     assert stats.qdrant_written == 1
     (point,) = client.points.values()
-    assert point["payload"]["verbatim_eligible"] is True
-    assert point["payload"]["verbatim_override"] == harvest.VERBATIM_OVERRIDE_PROVENANCE
+    assert point["payload"]["verbatim_eligible"] is False
+    assert "verbatim_override" not in point["payload"]
 
 
 @pytest.mark.asyncio
 async def test_harvest_to_qdrant_verbatim_all_price_bearing_row_stays_ineligible() -> None:
-    """INNOCENCE (Qdrant side) — the negative-guard proof mirrored from the
-    FAQ sink: under verbatim_all, a price-bearing row's Qdrant payload is
-    still written (Qdrant is never eligibility-gated for STORAGE) but
-    verbatim_eligible stays False and no override provenance is stamped —
-    the pricing rail applies identically on both sinks."""
+    """INNOCENCE (Qdrant side) — mirrored from the FAQ sink: with the
+    retired flag ON, a price-bearing row's Qdrant payload is still written
+    (Qdrant is never eligibility-gated for STORAGE) but verbatim_eligible
+    stays False and no override provenance is stamped — the pricing rail
+    applies identically on both sinks."""
     client = FakeQdrantClient(exists=True)
     embedder = FakeEmbedder()
     rows = [
@@ -647,19 +706,21 @@ async def test_harvest_to_qdrant_verbatim_all_price_bearing_row_stays_ineligible
 
 
 def test_ttl_seconds_for_class_conditional_classes_get_7_day_ttl_under_override() -> None:
-    """GUILT — BERSYARAT/KEBIJAKAN_PENYEDIA/BELUM_DIATUR_PUBLIK (the classes
-    --verbatim-all can newly promote to the FAQ sink) get the SHORT 7-day
-    TTL, not JELAS's 30-day "settled fact" shelf life — a review finding
-    (task #27 adversarial pass): a promoted conditional answer must go
-    stale fast, never silently inherit JELAS's generosity."""
+    """The TTL lookup itself still defines a short 7-day entry for
+    BERSYARAT/KEBIJAKAN_PENYEDIA/BELUM_DIATUR_PUBLIK even though the
+    retired --verbatim-all override (task #27) can no longer route them to
+    the FAQ sink — the map stays explicit (not left to
+    _DEFAULT_TTL_SECONDS) as a defensive/historical artifact, see
+    _CLASS_TTL_SECONDS."""
     for cls in ("BERSYARAT", "KEBIJAKAN_PENYEDIA", "BELUM_DIATUR_PUBLIK"):
         assert harvest._ttl_seconds_for_class(cls) == 7 * 24 * 3600
 
 
 @pytest.mark.asyncio
 async def test_harvest_to_qdrant_verbatim_all_off_never_carries_override_key() -> None:
-    """INNOCENCE (Qdrant side) — flag OFF: default behavior unchanged, and
-    no payload ever carries the override key."""
+    """INNOCENCE (Qdrant side) — flag OFF: default behavior unchanged
+    (identical to flag ON post-retirement), and no payload ever carries
+    the override key."""
     client = FakeQdrantClient(exists=True)
     embedder = FakeEmbedder()
     rows = [_row(question="Conditional Q", confidence_class="BERSYARAT")]

--- a/apps/backend-rag/data/curated_qa/README.md
+++ b/apps/backend-rag/data/curated_qa/README.md
@@ -43,16 +43,26 @@ every hit, so a conditional ("depends on your case") answer served verbatim
 with zero reasoning is a wrong answer waiting for the wrong client.
 `BERSYARAT` / `BELUM_DIATUR_PUBLIK` / `KEBIJAKAN_PENYEDIA` / `DINAMIS` rows
 are grounding-only (Qdrant `curated_qa` collection) forever — see
+`curated_qa_harvest.py::_derive_verbatim_eligible`. This is unconditional:
+there is no operator override left that can promote a non-`JELAS` row.
+
+**Retired operator override (`--verbatim-all`, task #27):** a 2026-07-19
+business-order escape hatch that bypassed the `confidence_class`/
+`client_specific` half of this gate — every answerable, non-price-bearing
+row was promoted regardless of CONFIDENCE class. It wrongly promoted 215
+non-`JELAS` entries into the live FAQ cache. **Zero retired it 2026-07-21**:
+verbatim serving is JELAS-only, no exceptions. The 215 promoted entries
+were deleted from Redis; the flag is still accepted on the CLI for
+backward-compat but is now a no-op for eligibility (logs a warning). See
 `curated_qa_harvest.py::_derive_verbatim_eligible`.
 
-**Operator override (`--verbatim-all`, task #27):** an explicit, logged
-business-order escape hatch that bypasses the `confidence_class`/
-`client_specific` half of this gate — every answerable, non-price-bearing
-row is promoted regardless of CONFIDENCE class. It does NOT touch the
-FATAL 13 pricing rail (a price-bearing row is refused either way) or the
-FATAL 5 source allowlist. Any row this override actually decided carries
-`metadata.verbatim_override = "zero-legge5-2026-07-19"` in both sinks for
-audit. Not a default — pass only under an explicit operator order.
+**Current corpus state (2026-07-21, post-rollback):** of the 318 dossier
+Q&A rows, 103 (`JELAS`) are served verbatim in the FAQ cache; 215
+(`BERSYARAT` 172, `BELUM_DIATUR_PUBLIK` 20, `DINAMIS` 17,
+`KEBIJAKAN_PENYEDIA` 6) are grounding-only (Qdrant `curated_qa` + abstain
+gates), never verbatim. The E33 corpus is a separate track: 36 rows served
+verbatim. Qdrant's 808 curated_qa points are untouched by the rollback —
+grounding was never gated on eligibility.
 
 ## Question-only seeds (`answer: null`)
 
@@ -89,11 +99,11 @@ source's shelf life:
 - **FAQ (Redis) sink**: a **class-based TTL** is set at write time —
   `JELAS` = 30 days, every other class (`DINAMIS`/`BERSYARAT`/
   `KEBIJAKAN_PENYEDIA`/`BELUM_DIATUR_PUBLIK`) = 7 days (see
-  `curated_qa_harvest.py::_ttl_seconds_for_class`; under the DEFAULT policy
-  only `JELAS` ever reaches this sink per FATAL 3, so the other classes'
-  entries matter only under the `--verbatim-all` operator override,
-  task #27). This overrides `NotebookLMCacheService`'s own
-  one-size-fits-all default.
+  `curated_qa_harvest.py::_ttl_seconds_for_class`; only `JELAS` ever
+  reaches this sink per FATAL 3 — unconditionally, now that
+  `--verbatim-all` is retired — so the other classes' entries are kept
+  purely as a defensive/historical artifact). This overrides
+  `NotebookLMCacheService`'s own one-size-fits-all default.
 - **Qdrant sink**: every point is written with `active: true,
   invalidated_at: null`. `scripts/curated_qa_regen_trigger.py` flips these
   to `active: false, invalidated_at: <timestamp>` (alongside

--- a/apps/backend-rag/scripts/curated_qa_harvest.py
+++ b/apps/backend-rag/scripts/curated_qa_harvest.py
@@ -22,15 +22,15 @@ vetted answer yet) are silently SKIPPED for BOTH sinks: an FAQ/curated_qa
 entry with no answer is meaningless and would violate the provenance
 contract. They are still counted in the stats for coverage analysis.
 
-FAQ-sink eligibility (Phase-0 safety rail FATAL 3): under the DEFAULT
-policy, only rows that independently RE-DERIVE (never a stored
-`verbatim_eligible` value) as `confidence_class == "JELAS"` AND non-price
-AND non-`client_specific` are written to the FAQ sink. Qdrant gets ALL
-answerable rows regardless of eligibility (grounding-only for the rest).
-`--verbatim-all` (task #27, an explicit operator business order — see
-`_derive_verbatim_eligible` and the CLI help) bypasses the
-confidence_class/client_specific half of this gate; the pricing check is
-NEVER bypassed by either policy. See `_derive_verbatim_eligible`.
+FAQ-sink eligibility (Phase-0 safety rail FATAL 3): only rows that
+independently RE-DERIVE (never a stored `verbatim_eligible` value) as
+`confidence_class == "JELAS"` AND non-price AND non-`client_specific` are
+written to the FAQ sink. Qdrant gets ALL answerable rows regardless of
+eligibility (grounding-only for the rest). `--verbatim-all` (task #27,
+the 2026-07-19 operator override) is RETIRED as of Zero's 2026-07-21
+refinement: the flag is accepted for CLI backward-compat but is now a
+no-op for eligibility — verbatim serving is JELAS-only, unconditionally.
+See `_derive_verbatim_eligible`.
 
 Batch manifest gate (Phase-0 safety rail FATAL 2, MAJOR 9/10): loading a
 file into either sink requires an APPROVED manifest to already exist at
@@ -65,7 +65,7 @@ Usage:
     PYTHONPATH=. python scripts/curated_qa_harvest.py --faq --dry-run
     PYTHONPATH=. python scripts/curated_qa_harvest.py --purge-domain visa --faq --qdrant
     PYTHONPATH=. python scripts/curated_qa_harvest.py --purge-batch visa-abc123def456 --faq --qdrant
-    PYTHONPATH=. python scripts/curated_qa_harvest.py --faq --qdrant --verbatim-all  # operator order only, see --help
+    PYTHONPATH=. python scripts/curated_qa_harvest.py --faq --qdrant --verbatim-all  # retired no-op, see --help
 
 Do NOT run against prod without Zero's review of the batch being loaded —
 this writes into the same FAQ cache / curated_qa collection the live
@@ -106,28 +106,24 @@ REQUIRED_ROW_KEYS: tuple[str, ...] = (
 )
 
 # Phase-0 safety rail (FATAL 3): the confidence class that alone permits
-# verbatim FAQ serving UNDER THE DEFAULT POLICY. BERSYARAT/
-# BELUM_DIATUR_PUBLIK/KEBIJAKAN_PENYEDIA/DINAMIS rows are grounding-only by
-# default — a "depends on your case" answer served verbatim with zero
-# per-request reasoning is a wrong answer waiting for the wrong client.
-# `--verbatim-all` (task #27) is the one sanctioned exception: an explicit
-# operator business order can promote these classes too — see
-# `_derive_verbatim_eligible`.
+# verbatim FAQ serving. BERSYARAT/BELUM_DIATUR_PUBLIK/KEBIJAKAN_PENYEDIA/
+# DINAMIS rows are grounding-only, unconditionally — a "depends on your
+# case" answer served verbatim with zero per-request reasoning is a wrong
+# answer waiting for the wrong client. `--verbatim-all` (task #27) was a
+# 2026-07-19 exception to this gate; Zero RETIRED it 2026-07-21 after it
+# wrongly promoted 215 non-JELAS entries — see `_derive_verbatim_eligible`.
 _JELAS_CONFIDENCE_CLASS = "JELAS"
 
 # Phase-0 safety rail (staleness, MAJOR 7): class-based TTL applied AT WRITE
 # TIME to the FAQ (Redis) sink, on top of Redis's own expiry. JELAS is
-# "settled" law/fact — 30 days. Everything else that can reach the FAQ sink
-# under `--verbatim-all` (DINAMIS/BERSYARAT/KEBIJAKAN_PENYEDIA/
-# BELUM_DIATUR_PUBLIK — task #27) is, by the module docstring's own
-# definition above, "depends on your case" / not fully settled — none of
-# them get the 30-day "settled fact" shelf life; all four share the
-# shorter 7-day self-expiry so an override-promoted conditional answer
-# goes stale FAST rather than silently inheriting JELAS's generosity.
-# Under the DEFAULT policy (no --verbatim-all) only JELAS ever reaches
-# this sink (FATAL 3 refuses the rest outright), so this map matters only
-# once the override is in play — it is still defined explicitly (not left
-# to _DEFAULT_TTL_SECONDS) so that fact is visible in code, not implicit.
+# "settled" law/fact — 30 days. DINAMIS/BERSYARAT/KEBIJAKAN_PENYEDIA/
+# BELUM_DIATUR_PUBLIK never reach the FAQ sink at all now that
+# `--verbatim-all` (task #27) is retired (Zero 2026-07-21) — FATAL 3
+# refuses them outright regardless of CLI flags. Their entries here are
+# historical/defensive: kept explicit (not left to _DEFAULT_TTL_SECONDS)
+# in case a future sanctioned override ever needs a non-JELAS class to
+# reach this sink again, so the 7-day-not-30-day intent stays visible in
+# code rather than silently inherited.
 _CLASS_TTL_SECONDS: dict[str, int] = {
     "JELAS": 30 * 24 * 3600,
     "DINAMIS": 7 * 24 * 3600,
@@ -248,18 +244,23 @@ def validate_row(row: dict) -> str | None:
     return None
 
 
-# Provenance value stamped on any row whose eligibility only cleared because
-# of --verbatim-all (Zero's Legge-5 order, 2026-07-19: "far diventare
-# verbatim tutte le risposte" — task #27, the 21 gated CHATKB dossiers). A
-# CONSTANT, not an operator-supplied string: this override has exactly one
-# sanctioned origin, so there is nothing to parametrize and no way to stamp
-# an unaccountable provenance value by typo.
+# RETIRED provenance value (Zero 2026-07-21): previously stamped on any row
+# whose eligibility only cleared because of --verbatim-all (Zero's Legge-5
+# order, 2026-07-19: "far diventare verbatim tutte le risposte" — task #27,
+# the 21 gated CHATKB dossiers). That order wrongly promoted 215 non-JELAS
+# entries to verbatim FAQ serving and was refined/retired 2026-07-21:
+# verbatim serving is JELAS-only, unconditionally — see
+# `_derive_verbatim_eligible`. Kept as a constant (not deleted) purely for
+# historical audit — it still labels the ~2026-07-19 window in any
+# surviving Qdrant payload, but no code path stamps it on new writes.
 VERBATIM_OVERRIDE_PROVENANCE = "zero-legge5-2026-07-19"
 
 
 def _default_verbatim_eligible(row: dict) -> bool:
-    """The FATAL-3 default eligibility rule, unconditional of any override:
-    confidence_class == JELAS AND NOT client_specific AND pricing-clean."""
+    """The FATAL-3 eligibility rule — since --verbatim-all's retirement
+    (Zero 2026-07-21) this is the ONLY eligibility rule, no override
+    branch left: confidence_class == JELAS AND NOT client_specific AND
+    pricing-clean."""
     from backend.services.misc.curated_qa_pricing_detector import has_price_content
 
     if row.get("confidence_class") != _JELAS_CONFIDENCE_CLASS:
@@ -273,28 +274,26 @@ def _derive_verbatim_eligible(row: dict, *, verbatim_all: bool = False) -> bool:
     """Independently RE-DERIVE FAQ-sink eligibility — Phase-0 safety rail
     (FATAL 3). NEVER trusts `row.get("verbatim_eligible")`; a stored value
     (converter best-effort guess, or a hand-edited JSONL) is informational
-    only and is ignored here by construction. Default eligibility =
+    only and is ignored here by construction. Eligibility is ALWAYS
     confidence_class == JELAS AND NOT client_specific AND the answer text
-    is pricing-clean (FATAL 13 detector).
+    is pricing-clean (FATAL 13 detector) — see `_default_verbatim_eligible`.
 
-    `verbatim_all` (Zero's Legge-5 operator order, task #27): when True,
-    bypasses the confidence_class/client_specific gate entirely — EVERY
-    answerable row is promoted to verbatim-eligible regardless of its
-    CONFIDENCE class. The FATAL 13 pricing rail is the ONE check that is
-    NEVER bypassed by this override, even under verbatim_all — a price
-    figure must always come from PricingTool, never a cached verbatim
-    answer, no matter which business order is in effect. Pricing is
-    checked FIRST and unconditionally so this invariant reads as an
-    early, unmissable return rather than something buried under a flag
-    branch.
+    `verbatim_all` (Zero's Legge-5 operator order, task #27, 2026-07-19)
+    used to bypass the confidence_class/client_specific gate entirely.
+    Zero RETIRED that override 2026-07-21 after it wrongly promoted 215
+    non-JELAS entries to verbatim FAQ serving. The parameter is kept for
+    CLI backward-compat but is now a NO-OP for eligibility: passing
+    `verbatim_all=True` logs a warning and falls through to the exact
+    same JELAS-only gate as the default policy. There is no bypass branch
+    left to guard the pricing rail against — FATAL 13 was already
+    unconditional and remains so.
     """
-    from backend.services.misc.curated_qa_pricing_detector import has_price_content
-
-    if has_price_content(row.get("answer")):
-        return False
-
     if verbatim_all:
-        return True
+        logger.warning(
+            "verbatim_all=True is a no-op (retired by Zero 2026-07-21 — "
+            "verbatim FAQ/Qdrant serving is JELAS-only, unconditionally). "
+            "Falling through to the default confidence_class==JELAS gate.",
+        )
 
     return _default_verbatim_eligible(row)
 
@@ -320,13 +319,10 @@ def _row_provenance_metadata(
     }
     if batch_id is not None:
         metadata["batch_id"] = batch_id
-    # Provenance for the Legge-5 override (task #27): stamped whenever this
-    # row is eligible under a verbatim_all run, so every FAQ/Qdrant entry
-    # written under the order carries an auditable trail back to it — a
-    # price-blocked row never gets eligible=True in the first place, so it
-    # never gets this stamp either (the pricing rail's refusal stays clean).
-    if verbatim_all and eligible:
-        metadata["verbatim_override"] = VERBATIM_OVERRIDE_PROVENANCE
+    # No verbatim_override stamp: --verbatim-all is retired (2026-07-21)
+    # and no longer changes eligibility, so stamping a provenance tag here
+    # would falsely imply the override was responsible for this row's
+    # eligibility. See VERBATIM_OVERRIDE_PROVENANCE for the retired order.
     return metadata
 
 
@@ -466,17 +462,15 @@ async def harvest_to_faq(
 
     FATAL 3 (verbatim_eligible): only rows that RE-DERIVE (never the row's
     own stored value) as eligible — confidence_class == JELAS, not
-    client_specific, and pricing-clean — are written here, UNLESS
-    `verbatim_all` is set (Zero's Legge-5 override, task #27), in which
-    case every answerable, non-price-bearing row is eligible regardless of
-    confidence_class/client_specific. A row that would otherwise be
-    eligible except for a detected price in its answer is a hard error
-    (the E33 "FINAL (client-facing)" text is meant to route prices through
+    client_specific, and pricing-clean — are written here. This is now
+    unconditional: `verbatim_all` (Zero's Legge-5 override, task #27) is
+    retired as of 2026-07-21 and no longer promotes non-JELAS rows — see
+    `_derive_verbatim_eligible`. A row that would otherwise be eligible
+    except for a detected price in its answer is a hard error (the E33
+    "FINAL (client-facing)" text is meant to route prices through
     PricingTool, never state one) — logged at ERROR with the offending
     question, counted separately from routine ineligibility (BERSYARAT/
-    DINAMIS/etc rows under the default policy, which are Qdrant-only by
-    design, not an error). The pricing rail is NEVER bypassed by
-    verbatim_all — see `_derive_verbatim_eligible`.
+    DINAMIS/etc rows, which are Qdrant-only by design, not an error).
     """
     from backend.services.caching.notebooklm_cache_service import domain_scope_id
     from backend.services.misc.curated_qa_pricing_detector import has_price_content
@@ -501,10 +495,10 @@ async def harvest_to_faq(
 
         if not derived_eligible:
             # A direct pricing-content check (not a confidence_class proxy):
-            # under verbatim_all EVERY row is a would-be-eligible candidate,
-            # so "why did this one fail" is always answerable by asking the
-            # pricing detector directly rather than inferring it from a
-            # class check that only applied under the default policy.
+            # distinguishes a hard pricing-rail refusal from routine
+            # non-JELAS ineligibility, so "why did this one fail" is always
+            # answerable by asking the pricing detector directly rather
+            # than inferring it from the confidence_class check above.
             is_price_bearing = has_price_content(row.get("answer"))
             if is_price_bearing:
                 stats.faq_price_rejected += 1
@@ -655,12 +649,13 @@ async def harvest_to_qdrant(
     remain visible for coverage analysis via the FAQ-sink stats / the JSONL
     source files themselves.)
 
-    `verbatim_all` (task #27, Zero's Legge-5 override) travels into the
-    payload's `verbatim_eligible`/`verbatim_override` fields exactly like it
-    does for the FAQ sink — Qdrant was never eligibility-GATED (it always
-    got every answerable row), but the flag it carries must still reflect
-    which policy computed it, so a grounding-injection audit and the FAQ
-    sink agree on the same row's eligibility under the same run.
+    `verbatim_all` (task #27, Zero's Legge-5 override, retired 2026-07-21)
+    is passed through to `_derive_verbatim_eligible` for CLI backward-compat
+    only — it no longer changes the computed value. Qdrant was never
+    eligibility-GATED (it always got every answerable row); the
+    `verbatim_eligible` payload field simply mirrors the same JELAS-only
+    gate the FAQ sink uses, so a grounding-injection audit and the FAQ sink
+    agree on the same row's eligibility under the same run.
     """
     stats = stats or HarvestStats()
 
@@ -707,16 +702,9 @@ async def harvest_to_qdrant(
                 "active": True,
                 "invalidated_at": None,
                 **({"batch_id": batch_id} if batch_id is not None else {}),
-                # Same Legge-5 provenance stamp as the FAQ sink (task #27) —
-                # only present when this row's eligibility was actually
-                # computed under the override AND came out eligible; a
-                # price-blocked row never carries it (the pricing rail's
-                # refusal is unconditional, see _derive_verbatim_eligible).
-                **(
-                    {"verbatim_override": VERBATIM_OVERRIDE_PROVENANCE}
-                    if verbatim_all and _derive_verbatim_eligible(r, verbatim_all=True)
-                    else {}
-                ),
+                # No verbatim_override stamp: the Legge-5 override (task
+                # #27) is retired (2026-07-21) and no longer changes
+                # eligibility — see VERBATIM_OVERRIDE_PROVENANCE.
             }
             for r in batch
         ]
@@ -1000,19 +988,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--verbatim-all",
         action="store_true",
         help=(
-            "OPERATOR-ORDERED OVERRIDE (task #27, Zero's Legge-5 ruling "
-            "2026-07-19: 'far diventare verbatim tutte le risposte'). "
-            "Bypasses the confidence_class==JELAS / non-client_specific "
-            "FATAL-3 gate for the FAQ (Redis) sink and the Qdrant "
-            "verbatim_eligible payload field — every answerable, "
-            "non-price-bearing row is promoted regardless of its "
-            "CONFIDENCE class. Does NOT touch the source allowlist (FATAL "
-            "5) or the pricing detector (FATAL 13) — both stay in full "
-            "force; a price-bearing row is refused either way. Every row "
-            "whose eligibility this override actually decided is stamped "
-            "metadata.verbatim_override='zero-legge5-2026-07-19' for "
-            "audit. Use ONLY under an explicit operator business order — "
-            "never as a default."
+            "RETIRED (2026-07-21 by Zero, refining the 2026-07-19 "
+            "Legge-5 ruling task #27 after it wrongly promoted 215 "
+            "non-JELAS entries to verbatim FAQ serving). This flag no "
+            "longer bypasses the confidence_class==JELAS / "
+            "non-client_specific FATAL-3 gate — verbatim FAQ/Qdrant "
+            "serving is now JELAS-only, unconditionally, regardless of "
+            "this flag. Kept for CLI backward-compat only; passing it "
+            "logs a warning and has no effect on eligibility. See "
+            "_derive_verbatim_eligible."
         ),
     )
     return parser.parse_args(argv)
@@ -1104,12 +1088,11 @@ async def main_async(args: argparse.Namespace) -> HarvestStats:
 
     if args.verbatim_all:
         logger.warning(
-            "⚠️  --verbatim-all ACTIVE (task #27, Zero's Legge-5 override "
-            "2026-07-19): the confidence_class==JELAS FATAL-3 gate is "
-            "BYPASSED for this run — every answerable, non-price-bearing "
-            "row is being promoted to verbatim-eligible. Pricing detector "
-            "(FATAL 13) and source allowlist (FATAL 5) remain in full "
-            "force.",
+            "⚠️  --verbatim-all was passed but is RETIRED (Zero 2026-07-21, "
+            "refining task #27's 2026-07-19 override) — it no longer "
+            "bypasses the confidence_class==JELAS FATAL-3 gate. This run "
+            "behaves identically to the default policy: verbatim FAQ/"
+            "Qdrant serving is JELAS-only, unconditionally.",
         )
 
     for batch_id, manifest_path, manifest, rows in batches:


### PR DESCRIPTION
## Summary
- Retires the `--verbatim-all` operator override (task #27, Zero's 2026-07-19 Legge-5 ruling) per Zero's 2026-07-21 refinement: verbatim FAQ/Qdrant serving is now **unconditionally JELAS-only**. The override had wrongly promoted 215 non-JELAS entries to verbatim serving.
- `_derive_verbatim_eligible` no longer branches on `verbatim_all` for eligibility — it always delegates to `_default_verbatim_eligible` (confidence_class == JELAS AND NOT client_specific AND pricing-clean). The `verbatim_all` parameter/CLI flag is kept for backward-compat but is now a no-op that logs a warning.
- Removed the `verbatim_override` metadata/payload stamping in both sinks (FAQ + Qdrant) since the override no longer decides anything — stamping it now would falsely imply it changed the outcome.
- `VERBATIM_OVERRIDE_PROVENANCE` constant kept (unused by new writes) purely as a historical audit label for the ~2026-07-19 window that may still exist in older Qdrant payloads.
- Updated all docstrings/comments (module docstring, `_JELAS_CONFIDENCE_CLASS`, `_CLASS_TTL_SECONDS`, `harvest_to_faq`, `harvest_to_qdrant`, CLI `--verbatim-all` help, `main_async` warning) to reflect retirement.
- `data/curated_qa/README.md`: corrected verbatim-eligibility section with the post-rollback truth (103 JELAS verbatim / 215 non-JELAS grounding-only out of 318 dossier rows; E33 = 36 verbatim separate track; Qdrant 808 pts untouched).
- `.claude/skills/bot/SKILL.md`: bumped LIVE STATE timestamp, added the P0 CRM/PII security finding bullet and the verbatim-rollback DONE bullet (both already true on `main`, this PR documents them).

No prod data-plane run needed — the 215 Redis entries were already deleted by the orchestrator prior to this PR; this PR is the go-forward code lock so a future harvest can't re-promote them.

## Test plan
- [x] `PYTHONPATH=. pytest backend/tests/unit/scripts/test_curated_qa_harvest.py -v` — 74 passed (rewrote the `--verbatim-all` GUILT/INNOCENCE section: BERSYARAT/DINAMIS rows stay ineligible even with `verbatim_all=True`; JELAS clean rows stay eligible; pricing/client_specific rails still block; no `verbatim_override` stamped anywhere anymore)
- [x] `PYTHONPATH=. pytest backend/tests/services/rag/agentic/test_abstain_threshold_convergence.py backend/tests/services/rag/agentic/test_abstain_policy_hardening.py -v` — 48 passed (abstain SSOT untouched by this change)
- [x] Pre-commit hooks passed (anti-reward-hacking lint, secrets scan, linting, import-chain smoke)
- [x] Pre-push full suite (path-aware classifier ran FULL suite — non-allowlisted files) — see CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
