### PR TITLE
ci(wr2): run the render-test battery (incl. placeholder-sweep gate) in wr2-queue-tests — it was trigger-only (scar #2)

### DIFF
--- a/.github/workflows/wr2-queue-tests.yml
+++ b/.github/workflows/wr2-queue-tests.yml
@@ -10,7 +10,38 @@
 # Dependency footprint probed empirically 2026-07-13: pytest pytest-asyncio
 # asyncpg numpy pydantic httpx is the minimal set that runs the full battery
 # (asyncpg/pydantic/httpx via wr2_html_render_apply → backend _pg/llm chain,
-# numpy via the renderer's critic_signals).
+# numpy via the renderer's critic_signals). Pillow added 2026-07-21 (Pillow:
+# test_ocr_override_classifier.py does `from PIL import Image`, and that
+# file is the ONLY consumer — every other renderer module import checked
+# empirically has zero Pillow/Playwright at module level).
+#
+# scripts/wr2_html_renderer/tests/ ADDED 2026-07-21 (cicatrix-superscar #2,
+# "esiste≠armato"): this workflow triggers on scripts/wr2_html_renderer/**
+# changes (paths below) but never actually ran the 154-test render battery
+# living there (incl. the 32 placeholder-sweep-gate tests from PR #2958,
+# the W99 class-cure) — it was enforced only by a developer running pytest
+# by hand before push, never by CI. Directory arg (not enumerated files) so
+# future test files in this dir are auto-collected without another workflow
+# edit — verified empirically 2026-07-21: `python -m pytest
+# scripts/wr2_html_renderer/tests/ -q` with ONLY `PYTHONPATH=apps/backend-rag`
+# (no `scripts` on the path) collects and passes all 154 tests. Known
+# residual fragility (not fixed here, scope stayed surgical): 4 of the 13
+# test files (test_fonts_injection.py, test_ocr_override_classifier.py,
+# test_placeholder_sweep_gate.py, test_swipe_indicator.py) import
+# `wr2_html_renderer.*` directly with no sys.path setup of their own — they
+# only resolve because pytest's alphabetical collection order imports an
+# earlier file (e.g. test_article2_3_palette_signal.py) first, which DOES
+# `sys.path.insert(0, .../scripts)` at module level, and that mutation
+# leaks for the rest of the pytest process. Works today, is order-dependent;
+# a future test file sorting before all four AND lacking its own
+# sys.path.insert would break silently. scripts/wr2_html_renderer/tests/
+# has no conftest.py to anchor this properly — flagged, not fixed, here.
+#
+# scripts/wr2_html_renderer/tests/test_each_block_render.py is a standalone
+# script (def main() + `if __name__ == "__main__"`, zero test_*() functions)
+# — pytest collects the module but finds 0 test items in it; it contributes
+# 0 to the 154 and is not run by this workflow either. Pre-existing, not
+# introduced or fixed by this change.
 name: wr2-queue-tests
 
 on:
@@ -54,7 +85,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install battery dependencies
-        run: python -m pip install --quiet pytest pytest-asyncio asyncpg numpy pydantic httpx
+        run: python -m pip install --quiet pytest pytest-asyncio asyncpg numpy pydantic httpx Pillow
 
       - name: Run WR2 queue test battery
         env:
@@ -69,4 +100,5 @@ jobs:
             scripts/tests/test_wr2_daily_reconciler.py \
             scripts/tests/test_wr2_carousel_ir.py \
             scripts/tests/test_wr2_editorial_pregate.py \
+            scripts/wr2_html_renderer/tests \
             -q


### PR DESCRIPTION
Closes an esiste≠armato gap found while gating #2958: `.github/workflows/wr2-queue-tests.yml` lists `scripts/wr2_html_renderer/**` in its path TRIGGERS but its pytest invocation never ran the render battery — the 154 render tests (incl. the 32 new W99 placeholder-sweep-gate tests) were enforced only by the voluntary client-side pre-push hook. This wires the battery into the CI invocation so the sweep gate is server-side enforced.

Adds enforcement, weakens nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)