### PR TITLE
fix(magazine): allow hosted readers without role bindings

### DIFF
--- a/apps/bali-zero-magazine/app/api/media/[digest]/route.ts
+++ b/apps/bali-zero-magazine/app/api/media/[digest]/route.ts
@@ -1,24 +1,11 @@
 import {
   authorize,
-  type RoleAllowlist,
+  parseRoleAllowlist,
 } from "../../../../lib/server/authorization.ts";
 import { requireViewer } from "../../../../lib/server/identity.ts";
 import { resolvePublishedMedia } from "../../../../lib/server/media.ts";
 import { getMagazineBindings } from "../../../../lib/server/runtime-bindings.ts";
 import { mediaSecurityHeaders } from "../../../../lib/server/security.ts";
-
-function roleAllowlist(raw: string | undefined): RoleAllowlist {
-  if (raw === undefined) throw new TypeError("role allowlist is required");
-  const parsed: unknown = JSON.parse(raw);
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
-    throw new TypeError("invalid role allowlist");
-  const candidate = parsed as Partial<RoleAllowlist>;
-  return {
-    version: candidate.version ?? "",
-    analysts: candidate.analysts ?? [],
-    operators: candidate.operators ?? [],
-  };
-}
 
 function denied(status: 401 | 404): Response {
   return new Response(null, { status, headers: mediaSecurityHeaders() });
@@ -30,7 +17,7 @@ export async function GET(
 ): Promise<Response> {
   const bindings = getMagazineBindings();
   try {
-    const roles = roleAllowlist(bindings.ROLE_ALLOWLIST_JSON);
+    const roles = parseRoleAllowlist(bindings.ROLE_ALLOWLIST_JSON);
     const viewer = await requireViewer(request.headers, {
       actorKeySecret: bindings.ACTOR_KEY_SECRET ?? "",
       roleAllowlist: roles,

--- a/apps/bali-zero-magazine/app/research/page.tsx
+++ b/apps/bali-zero-magazine/app/research/page.tsx
@@ -3,7 +3,7 @@ import {
   WorkspaceAccessRequired,
 } from "@/components/magazine-shell";
 import { ResearchWorkbench } from "@/components/research-workbench";
-import { authorize } from "@/lib/server/authorization";
+import { authorize, parseRoleAllowlist } from "@/lib/server/authorization";
 import { requireMagazineViewer } from "@/lib/server/magazine-read-model";
 import { publicResearchJob } from "@/lib/server/research-http";
 import {
@@ -26,11 +26,7 @@ export default async function ResearchPage() {
   if (bindings.DB === undefined)
     throw new Error("Research database is unavailable");
   const catalog = parseResearchCatalog(bindings.RESEARCH_CATALOG_JSON);
-  const allowlist = JSON.parse(bindings.ROLE_ALLOWLIST_JSON ?? "{}") as {
-    version: string;
-    analysts: string[];
-    operators: string[];
-  };
+  const allowlist = parseRoleAllowlist(bindings.ROLE_ALLOWLIST_JSON);
   const repository = createResearchRepository(bindings.DB);
   const [jobs, evidence] = await Promise.all([
     repository.listJobs(),

--- a/apps/bali-zero-magazine/lib/server/authorization.ts
+++ b/apps/bali-zero-magazine/lib/server/authorization.ts
@@ -27,6 +27,12 @@ export type AuthorizationDecision = Readonly<{
   reason: "allowed" | "permission_denied";
 }>;
 
+const READ_ONLY_ROLE_ALLOWLIST: RoleAllowlist = {
+  version: "roles.read-only.v1",
+  analysts: [],
+  operators: [],
+};
+
 const ROLE_PERMISSIONS: Readonly<Record<Role, ReadonlySet<Permission>>> = {
   reader: new Set(["magazine:read"]),
   analyst: new Set(["magazine:read", "research:create", "research:cancel-own"]),
@@ -62,6 +68,26 @@ export function validateRoleAllowlist(
   if (new Set(memberships).size !== memberships.length) {
     throw new TypeError("duplicate actor key in role allowlist");
   }
+}
+
+export function parseRoleAllowlist(raw: string | undefined): RoleAllowlist {
+  if (raw === undefined) return READ_ONLY_ROLE_ALLOWLIST;
+
+  const value: unknown = JSON.parse(raw);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("invalid role allowlist");
+  }
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).sort().join(",") !== "analysts,operators,version") {
+    throw new TypeError("invalid role allowlist");
+  }
+  const allowlist = {
+    version: record.version,
+    analysts: record.analysts,
+    operators: record.operators,
+  } as RoleAllowlist;
+  validateRoleAllowlist(allowlist);
+  return allowlist;
 }
 
 export function effectiveRole(

--- a/apps/bali-zero-magazine/lib/server/identity.ts
+++ b/apps/bali-zero-magazine/lib/server/identity.ts
@@ -33,13 +33,22 @@ export async function requireViewer(
   if (rawEmail === null || rawEmail.trim() === "") {
     throw new TypeError("authenticated user is required");
   }
-  if (!config.actorKeySecret)
-    throw new TypeError("actor key secret is required");
+  const normalizedEmail = normalizeWorkspaceEmail(rawEmail);
   validateRoleAllowlist(config.roleAllowlist);
-  const actorKey = await hmacSha256Hex(
-    config.actorKeySecret,
-    normalizeWorkspaceEmail(rawEmail),
-  );
+  if (!config.actorKeySecret) {
+    if (
+      config.roleAllowlist.analysts.length > 0 ||
+      config.roleAllowlist.operators.length > 0
+    ) {
+      throw new TypeError("actor key secret is required for privileged roles");
+    }
+    return {
+      actorKey: "0".repeat(64),
+      role: "reader",
+      roleConfigVersion: config.roleAllowlist.version,
+    };
+  }
+  const actorKey = await hmacSha256Hex(config.actorKeySecret, normalizedEmail);
   return {
     actorKey,
     role: effectiveRole(actorKey, config.roleAllowlist),

--- a/apps/bali-zero-magazine/lib/server/magazine-read-model.ts
+++ b/apps/bali-zero-magazine/lib/server/magazine-read-model.ts
@@ -5,8 +5,8 @@ import type {
   EditionPlacementV1,
   StoryVersionV1,
 } from "../contracts/publication.ts";
-import type { RoleAllowlist, Viewer } from "./authorization.ts";
-import { authorize } from "./authorization.ts";
+import type { Viewer } from "./authorization.ts";
+import { authorize, parseRoleAllowlist } from "./authorization.ts";
 import { isAssetEligible } from "./asset-eligibility.ts";
 import { requireViewer } from "./identity.ts";
 import type {
@@ -169,20 +169,6 @@ type AssetRow = Readonly<{
   status: string;
   rights_status: string;
 }>;
-
-function parseRoleAllowlist(raw: string | undefined): RoleAllowlist {
-  if (raw === undefined) throw new TypeError("role allowlist is required");
-  const parsed: unknown = JSON.parse(raw);
-  if (typeof parsed !== "object" || parsed === null) {
-    throw new TypeError("role allowlist is invalid");
-  }
-  const candidate = parsed as Partial<RoleAllowlist>;
-  return {
-    version: candidate.version ?? "",
-    analysts: candidate.analysts ?? [],
-    operators: candidate.operators ?? [],
-  };
-}
 
 export async function requireMagazineViewer(): Promise<Viewer | null> {
   try {

--- a/apps/bali-zero-magazine/lib/server/research-http.ts
+++ b/apps/bali-zero-magazine/lib/server/research-http.ts
@@ -1,33 +1,12 @@
 import type { Permission, RoleAllowlist, Viewer } from "./authorization.ts";
-import { authorize, validateRoleAllowlist } from "./authorization.ts";
+import { authorize, parseRoleAllowlist } from "./authorization.ts";
 import { requireViewer } from "./identity.ts";
 import type { ResearchJobView } from "./research-repository.ts";
 import { getMagazineBindings } from "./runtime-bindings.ts";
 import { privateNoStoreHeaders } from "./security.ts";
 
 export function currentResearchRoleAllowlist(): RoleAllowlist {
-  const raw = getMagazineBindings().ROLE_ALLOWLIST_JSON;
-  if (raw === undefined) throw new TypeError("role allowlist is required");
-  const value: unknown = JSON.parse(raw);
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new TypeError("invalid role allowlist");
-  }
-  const record = value as Record<string, unknown>;
-  if (
-    Object.keys(record).sort().join(",") !== "analysts,operators,version" ||
-    typeof record.version !== "string" ||
-    !Array.isArray(record.analysts) ||
-    !Array.isArray(record.operators)
-  ) {
-    throw new TypeError("invalid role allowlist");
-  }
-  const current = {
-    version: record.version,
-    analysts: record.analysts as readonly string[],
-    operators: record.operators as readonly string[],
-  };
-  validateRoleAllowlist(current);
-  return current;
+  return parseRoleAllowlist(getMagazineBindings().ROLE_ALLOWLIST_JSON);
 }
 
 export async function authorizeResearchRequest(

--- a/apps/bali-zero-magazine/tests/authorization.test.mjs
+++ b/apps/bali-zero-magazine/tests/authorization.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { authorize } from "../lib/server/authorization.ts";
+import { authorize, parseRoleAllowlist } from "../lib/server/authorization.ts";
 import { requireViewer } from "../lib/server/identity.ts";
 
 const actorKeySecret = "test-actor-key-secret-with-enough-entropy";
@@ -22,6 +22,38 @@ test("authorization defaults an authenticated workspace user to reader", async (
     "role",
     "roleConfigVersion",
   ]);
+});
+
+test("missing optional role bindings allow authenticated read-only access", async () => {
+  const allowlist = parseRoleAllowlist(undefined);
+  const viewer = await requireViewer(
+    new Headers({ "oai-authenticated-user-email": "reader@example.com" }),
+    { actorKeySecret: "", roleAllowlist: allowlist },
+  );
+  assert.equal(viewer.role, "reader");
+  assert.equal(authorize(viewer, "magazine:read", allowlist).allowed, true);
+  assert.equal(authorize(viewer, "research:create", allowlist).allowed, false);
+  assert.equal(authorize(viewer, "ops:create", allowlist).allowed, false);
+});
+
+test("privileged role bindings still require an actor-key secret", async () => {
+  await assert.rejects(
+    () =>
+      requireViewer(
+        new Headers({
+          "oai-authenticated-user-email": "operator@example.com",
+        }),
+        {
+          actorKeySecret: "",
+          roleAllowlist: {
+            version: "roles.v1",
+            analysts: [],
+            operators: ["0".repeat(64)],
+          },
+        },
+      ),
+    /actor key secret is required for privileged roles/,
+  );
 });
 
 test("authorization normalizes email before deriving the actor key", async () => {

--- a/apps/bali-zero-magazine/tests/magazine-render.test.mjs
+++ b/apps/bali-zero-magazine/tests/magazine-render.test.mjs
@@ -711,7 +711,11 @@ const magazineWorkerPromise = import(
 
 async function render(
   pathname,
-  { authenticated = true, db = createFixtureDb() } = {},
+  {
+    authenticated = true,
+    db = createFixtureDb(),
+    runtimeBindings = appEnv(db),
+  } = {},
 ) {
   const { default: worker } = await magazineWorkerPromise;
   const headers = new Headers({ accept: "text/html" });
@@ -720,7 +724,7 @@ async function render(
   }
   return worker.fetch(
     new Request(`http://localhost${pathname}`, { headers }),
-    appEnv(db),
+    runtimeBindings,
     {
       waitUntil() {},
       passThroughOnException() {},
@@ -956,6 +960,23 @@ test("anonymous readers receive a protected shell without editorial data", async
     html,
     /Bali visa files move to a stricter evidence standard/,
   );
+});
+
+test("Sites-authenticated readers can read when optional role bindings are absent", async () => {
+  const db = createFixtureDb();
+  const response = await render("/", {
+    db,
+    runtimeBindings: {
+      DB: db,
+      ASSETS: {
+        fetch: async () => new Response("Not found", { status: 404 }),
+      },
+    },
+  });
+  assertProtectedHtml(response);
+  const html = await response.text();
+  assert.match(html, /The Morning File/);
+  assert.doesNotMatch(html, /Workspace access required/i);
 });
 
 test("worker security wrapper mutates protected HTML only", async () => {


### PR DESCRIPTION
## Problem

The authenticated ChatGPT Sites deployment falls into Workspace access required when optional ROLE_ALLOWLIST_JSON and ACTOR_KEY_SECRET bindings are not configured.

## Solution

- allow authenticated Sites users to read the magazine when optional privilege bindings are absent
- preserve fail-closed behavior for Research and Operations mutations
- fail closed when privileged roles are configured without the signing secret
- centralize role parsing and cover the hosted-reader fallback with tests

## Verification

- npm run typecheck
- npm run lint
- npm run test:unit — 168/168 passed
- npm run build
- repository pre-push gate — passed

## Deployment note

This restores private read access after independent review and merge. It does not publish editorial content, enable external distribution, or arm the morning/breaking automations.