### PR TITLE
feat(magazine): prepare collector projections

### DIFF
--- a/apps/bali-zero-magazine/tests/deployed-platform.test.mjs
+++ b/apps/bali-zero-magazine/tests/deployed-platform.test.mjs
@@ -25,7 +25,7 @@ test("Pro LaunchAgents schedule morning after collectors and Breaking within ten
   );
   assert.match(morning, /com\.balizero\.magazine\.morning/);
   assert.match(breaking, /com\.balizero\.magazine\.breaking/);
-  assert.equal(numberAfter(morning, "Hour"), 6);
+  assert.equal(numberAfter(morning, "Hour"), 8);
   assert.equal(numberAfter(morning, "Minute"), 15);
   assert.ok(numberAfter(breaking, "StartInterval") <= 600);
   assert.match(
@@ -56,6 +56,7 @@ test("publisher wrapper is Pro-only, locked, timed, and payload-secret safe", as
   assert.match(wrapper, /run_with_timeout/);
   assert.match(wrapper, /security find-generic-password -s bali-zero-magazine/);
   assert.match(wrapper, /MAGAZINE_PUBLISH_ENABLED/);
+  assert.match(wrapper, /zantara_media\.cli\.magazine_prepare/);
   assert.match(wrapper, /zantara_media\.cli\.magazine_publish/);
   assert.match(wrapper, /--required-system-id/);
   assert.match(wrapper, /intel-lake mata-garuda regulatory-watcher notebooklm/);
@@ -101,7 +102,7 @@ test("automation reference includes repo-canon magazine jobs without rewriting l
   const reference = await text("docs/AUTOMATIONS_REFERENCE.md");
   assert.match(reference, /Repo-canon additions pending live snapshot/);
   assert.match(reference, /com\.balizero\.magazine\.morning/);
-  assert.match(reference, /06:15 WITA/);
+  assert.match(reference, /08:15 WITA/);
   assert.match(reference, /com\.balizero\.magazine\.breaking/);
   assert.match(reference, /600s/);
 });

--- a/apps/zantara-media/pyproject.toml
+++ b/apps/zantara-media/pyproject.toml
@@ -39,6 +39,7 @@ garuda-pool-builder = "zantara_media.cli.garuda_pool_builder:main"
 garuda-gc = "zantara_media.cli.garuda_gc:main"
 garuda-bootstrap = "zantara_media.cli.garuda_bootstrap:main"
 magazine-publish = "zantara_media.cli.magazine_publish:main"
+magazine-prepare = "zantara_media.cli.magazine_prepare:main"
 magazine-research-worker = "zantara_media.cli.magazine_research_worker:main"
 magazine-operations-worker = "zantara_media.cli.magazine_operations_worker:main"
 

--- a/apps/zantara-media/tests/magazine/test_magazine_prepare_cli.py
+++ b/apps/zantara-media/tests/magazine/test_magazine_prepare_cli.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from zantara_media.cli.magazine_prepare import fetch_intel_rows, load_intel_rows
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.query = ""
+        self.arguments: tuple[Any, ...] = ()
+        self.closed = False
+
+    async def fetch(self, query: str, *arguments: Any) -> list[dict[str, Any]]:
+        self.query = query
+        self.arguments = arguments
+        return [
+            {
+                "canonical_url": "https://example.com/story",
+                "title": "Verified public story",
+                "summary": "Public summary",
+                "source_domain": "example.com",
+                "language": "en",
+                "topic_tags": ["visa"],
+                "routing_status": "wr2",
+                "confidence_score": 0.9,
+                "first_seen_at": datetime(2026, 7, 21, tzinfo=timezone.utc),
+                "last_seen_at": datetime(2026, 7, 21, tzinfo=timezone.utc),
+                "published_at": datetime(2026, 7, 21, tzinfo=timezone.utc),
+                "is_probe_sandbox": False,
+            }
+        ]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_fetch_intel_rows_selects_only_public_columns_and_closes_connection() -> None:
+    connection = _FakeConnection()
+
+    async def connector(_: str) -> _FakeConnection:
+        return connection
+
+    cutoff = datetime(2026, 7, 21, tzinfo=timezone.utc)
+    rows = await fetch_intel_rows(
+        "postgresql://readonly@example.invalid/db",
+        cutoff=cutoff,
+        connector=connector,
+    )
+
+    assert rows[0]["title"] == "Verified public story"
+    assert "raw_payload" not in connection.query
+    assert "routing_targets" not in connection.query
+    assert "NOT is_probe_sandbox" in connection.query
+    assert "confidence_score >= 0.15" in connection.query
+    assert connection.arguments == (cutoff, 50)
+    assert connection.closed is True
+
+
+@pytest.mark.asyncio
+async def test_load_intel_rows_is_explicitly_unavailable_without_database_url() -> None:
+    rows, status = await load_intel_rows(
+        None,
+        cutoff=datetime(2026, 7, 21, tzinfo=timezone.utc),
+    )
+
+    assert rows == []
+    assert status == "unavailable"

--- a/apps/zantara-media/tests/magazine/test_source_projections.py
+++ b/apps/zantara-media/tests/magazine/test_source_projections.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from zantara_media.magazine.adapters import SanitizationError
+from zantara_media.magazine.loaders import load_named_projection
+from zantara_media.magazine.source_projections import (
+    build_intel_lake_projection,
+    build_mata_garuda_projection,
+    build_notebooklm_projection,
+    build_regulatory_projection,
+    prepare_morning_inputs,
+    resolve_published_revisions,
+)
+
+
+CUTOFF = datetime(2026, 7, 21, 0, 15, tzinfo=timezone.utc)
+
+
+def test_regulatory_delta_becomes_cited_public_story() -> None:
+    projection = build_regulatory_projection(
+        {
+            "run_at": "2026-07-21T07:58:18+08:00",
+            "today": "2026-07-21",
+            "partial": False,
+            "new_today_count": 1,
+            "seen_citations": ["PP 28/2026"],
+            "unreachable_sources": [],
+            "deltas": [
+                {
+                    "citation": "PP 28/2026",
+                    "title_id": "Perubahan aturan pelaporan",
+                    "title_en": "Reporting rules have changed",
+                    "service_line": "tax",
+                    "summary": "A new official rule changes a reporting obligation.",
+                    "impact_note": "Tax operations should review affected filing workflows.",
+                    "severity": "high",
+                    "confidence": "high",
+                    "first_seen_at": "2026-07-21T07:50:00+08:00",
+                    "source": "https://jdih.kemenkeu.go.id/example",
+                    "verbatim_excerpt": "Not copied into the public projection.",
+                }
+            ],
+        },
+        cutoff=CUTOFF,
+    )
+
+    assert projection["system_id"] == "regulatory-watcher"
+    assert projection["collector_run"]["status"] == "healthy"
+    assert projection["collector_run"]["items_eligible"] == 1
+    story = projection["candidates"][0]
+    assert story["domain"] == "tax"
+    assert story["title"] == "Reporting rules have changed"
+    assert story["claims"][0]["evidence_ids"] == ["evidence-regulatory-pp-28-2026"]
+    assert story["evidence_refs"][0]["source_type"] == "official"
+    assert story["evidence_refs"][0]["primary_document_status"] == "verified"
+    assert "verbatim_excerpt" not in json.dumps(projection)
+
+
+def test_mata_empty_feed_is_healthy_quiet_projection() -> None:
+    projection = build_mata_garuda_projection(
+        {
+            "version": 1,
+            "generated_at": "2026-07-21T07:33:04+08:00",
+            "count": 0,
+            "items": [],
+        },
+        cutoff=CUTOFF,
+    )
+
+    assert projection["system_id"] == "mata-garuda"
+    assert projection["collector_run"]["status"] == "healthy"
+    assert projection["collector_run"]["items_seen"] == 0
+    assert projection["candidates"] == []
+
+
+def test_notebook_inventory_exports_health_without_uuid_or_titles() -> None:
+    projection = build_notebooklm_projection(
+        {
+            "generated_at": "2026-07-20T23:35:43+00:00",
+            "notebook_count": 2,
+            "notebooks": [
+                {
+                    "id": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+                    "title": "Private inventory title",
+                    "source_count": 4,
+                    "health": "healthy",
+                    "near_cap": False,
+                },
+                {
+                    "id": "ffffffff-1111-4222-8333-444444444444",
+                    "title": "Another private title",
+                    "source_count": 2,
+                    "health": "healthy",
+                    "near_cap": False,
+                },
+            ],
+            "nb_intel": {},
+        },
+        cutoff=CUTOFF,
+    )
+
+    encoded = json.dumps(projection)
+    assert projection["collector_run"]["items_seen"] == 2
+    assert projection["collector_run"]["source_count"] == 6
+    assert projection["candidates"] == []
+    assert "Private inventory title" not in encoded
+    assert "aaaaaaaa-bbbb" not in encoded
+
+
+def test_revision_resolver_uses_only_completed_publication_packets(tmp_path: Path) -> None:
+    packets = tmp_path / "packets"
+    packets.mkdir()
+    morning = packets / "morning.json"
+    morning.write_text(
+        json.dumps(
+            {
+                "schema_version": "edition.v1",
+                "packet_id": "edition-complete",
+                "edition_revision": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (packets / "failed.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "edition.v1",
+                "packet_id": "edition-failed",
+                "edition_revision": 99,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (packets / "breaking.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "story.v1",
+                "packet_id": "breaking-complete",
+                "expected_breaking_revision": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+    journal = tmp_path / "outcomes.jsonl"
+    rows = [
+        {
+            "schema_version": "magazine-outcome.v1",
+            "operation_id": "/api/machine/publications/editions:edition-complete",
+            "path": "/api/machine/publications/editions",
+            "body_sha256": "a" * 64,
+            "state": "completed",
+            "response": {"ok": True},
+        },
+        {
+            "schema_version": "magazine-outcome.v1",
+            "operation_id": "/api/machine/publications/editions:edition-failed",
+            "path": "/api/machine/publications/editions",
+            "body_sha256": "b" * 64,
+            "state": "pending",
+            "response": None,
+        },
+        {
+            "schema_version": "magazine-outcome.v1",
+            "operation_id": "/api/machine/publications/breaking:breaking-complete",
+            "path": "/api/machine/publications/breaking",
+            "body_sha256": "c" * 64,
+            "state": "completed",
+            "response": {"ok": True},
+        },
+    ]
+    journal.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    revisions = resolve_published_revisions(packets, journal)
+
+    assert revisions.current_edition == 4
+    assert revisions.current_breaking == 3
+
+
+def test_intel_lake_empty_snapshot_is_a_healthy_quiet_projection() -> None:
+    projection = build_intel_lake_projection(
+        [],
+        cutoff=CUTOFF,
+        completed_at="2026-07-21T00:10:00Z",
+        status="healthy",
+    )
+
+    assert projection["collector_run"]["status"] == "healthy"
+    assert projection["collector_run"]["items_seen"] == 0
+    assert projection["candidates"] == []
+
+
+@pytest.mark.asyncio
+async def test_prepare_morning_writes_four_loadable_projections_manifest_and_empty_assets(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    state = tmp_path / "state"
+    (repo / "research/regulatory").mkdir(parents=True)
+    (repo / "research/nb-health").mkdir(parents=True)
+    (repo / "apps/mata-garuda/data").mkdir(parents=True)
+    (repo / "research/regulatory/2026-07-21-delta.json").write_text(
+        json.dumps(
+            {
+                "run_at": "2026-07-21T07:58:18+08:00",
+                "today": "2026-07-21",
+                "partial": False,
+                "new_today_count": 0,
+                "seen_citations": [],
+                "unreachable_sources": [],
+                "deltas": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo / "apps/mata-garuda/data/kita_feed.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "generated_at": "2026-07-21T07:33:04+08:00",
+                "count": 0,
+                "items": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo / "research/nb-health/nb-inventory-live.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-07-20T23:35:43+00:00",
+                "notebook_count": 0,
+                "notebooks": [],
+                "nb_intel": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = prepare_morning_inputs(
+        repo_root=repo,
+        state_dir=state,
+        cutoff=CUTOFF,
+        intel_rows=[],
+        intel_status="healthy",
+    )
+
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    systems = {item["system_id"] for item in manifest["projection_inputs"]}
+    assets = json.loads(result.asset_manifest_path.read_text(encoding="utf-8"))
+    assert systems == {
+        "intel-lake",
+        "mata-garuda",
+        "notebooklm",
+        "regulatory-watcher",
+    }
+    assert manifest["expected_current_revision"] == 0
+    assert manifest["expected_breaking_revision"] == 0
+    assert assets == {"schema_version": "asset-intents.v1", "intents": []}
+    for item in manifest["projection_inputs"]:
+        assert Path(item["projection_path"]).is_file()
+        loaded = await load_named_projection(
+            item["system_id"], Path(item["projection_path"])
+        )
+        assert loaded.system_id == item["system_id"]
+
+
+def test_prepare_morning_rejects_pii_before_any_projection_is_written(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    state = tmp_path / "state"
+
+    with pytest.raises(SanitizationError, match="SANITIZATION_PII"):
+        prepare_morning_inputs(
+            repo_root=repo,
+            state_dir=state,
+            cutoff=CUTOFF,
+            intel_rows=[
+                {
+                    "canonical_url": "https://example.com/public-story",
+                    "title": "Public story",
+                    "summary": "Passport B1234567 belongs to a private individual.",
+                    "source_domain": "example.com",
+                    "language": "en",
+                    "topic_tags": ["visa"],
+                    "confidence_score": 0.9,
+                    "first_seen_at": "2026-07-21T00:10:00Z",
+                    "last_seen_at": "2026-07-21T00:10:00Z",
+                    "published_at": "2026-07-21T00:05:00Z",
+                }
+            ],
+            intel_status="healthy",
+        )
+
+    assert not (state / "inputs").exists()

--- a/apps/zantara-media/zantara_media/cli/magazine_prepare.py
+++ b/apps/zantara-media/zantara_media/cli/magazine_prepare.py
@@ -1,0 +1,149 @@
+"""Prepare the four sanitized collector projections for a morning edition."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+import asyncpg
+
+from zantara_media.magazine.source_projections import prepare_morning_inputs
+
+logger = logging.getLogger(__name__)
+
+_INTEL_LIMIT = 50
+_INTEL_QUERY = """
+SELECT
+    canonical_url,
+    title,
+    summary,
+    source_domain,
+    language,
+    topic_tags,
+    routing_status,
+    confidence_score,
+    first_seen_at,
+    last_seen_at,
+    published_at,
+    is_probe_sandbox
+FROM intel_items
+WHERE NOT is_probe_sandbox
+  AND last_seen_at >= $1 - INTERVAL '48 hours'
+  AND routing_status IN ('blog', 'wr2', 'nb-intel', 'needs_review')
+  AND confidence_score >= 0.15
+ORDER BY confidence_score DESC, last_seen_at DESC
+LIMIT $2
+"""
+
+
+class _IntelConnection(Protocol):
+    async def fetch(self, query: str, *arguments: Any) -> Sequence[Mapping[str, Any]]: ...
+
+    async def close(self) -> None: ...
+
+
+_Connector = Callable[[str], Awaitable[_IntelConnection]]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="magazine-prepare")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    morning = subparsers.add_parser("morning")
+    morning.add_argument("--repo-root", type=Path, required=True)
+    morning.add_argument("--state-dir", type=Path, required=True)
+    morning.add_argument("--cutoff", required=True)
+    return parser
+
+
+def _cutoff(value: str) -> datetime:
+    if not value.endswith("Z"):
+        raise ValueError("cutoff must be a UTC timestamp ending in Z")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("cutoff must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+async def _connect(database_url: str) -> _IntelConnection:
+    return await asyncpg.connect(database_url)
+
+
+async def fetch_intel_rows(
+    database_url: str,
+    *,
+    cutoff: datetime,
+    connector: _Connector = _connect,
+) -> list[dict[str, Any]]:
+    """Read the closed public Intel Lake projection; never select raw columns."""
+    connection = await connector(database_url)
+    try:
+        rows = await connection.fetch(_INTEL_QUERY, cutoff, _INTEL_LIMIT)
+        return [dict(row) for row in rows]
+    finally:
+        await connection.close()
+
+
+async def load_intel_rows(
+    database_url: str | None,
+    *,
+    cutoff: datetime,
+    connector: _Connector = _connect,
+) -> tuple[list[dict[str, Any]], str]:
+    if not database_url:
+        logger.warning("intel lake unavailable reason=missing_database_url")
+        return [], "unavailable"
+    try:
+        return await fetch_intel_rows(
+            database_url,
+            cutoff=cutoff,
+            connector=connector,
+        ), "healthy"
+    except Exception as exc:  # fail closed while allowing a transparent quiet edition
+        logger.warning("intel lake unavailable error_type=%s", type(exc).__name__)
+        return [], "unavailable"
+
+
+async def async_main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    cutoff = _cutoff(args.cutoff)
+    database_url = os.environ.get("MAGAZINE_DATABASE_URL") or os.environ.get(
+        "DATABASE_URL"
+    )
+    intel_rows, intel_status = await load_intel_rows(database_url, cutoff=cutoff)
+    prepared = prepare_morning_inputs(
+        repo_root=args.repo_root.resolve(),
+        state_dir=args.state_dir.resolve(),
+        cutoff=cutoff,
+        intel_rows=intel_rows,
+        intel_status=intel_status,
+    )
+    print(
+        json.dumps(
+            {
+                "status": "prepared",
+                "intel_status": intel_status,
+                "intel_item_count": len(intel_rows),
+                "projection_count": len(prepared.projection_paths),
+                "manifest_path": str(prepared.manifest_path),
+                "asset_manifest_path": str(prepared.asset_manifest_path),
+            },
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    raise SystemExit(asyncio.run(async_main()))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/zantara-media/zantara_media/magazine/source_projections.py
+++ b/apps/zantara-media/zantara_media/magazine/source_projections.py
@@ -1,0 +1,759 @@
+"""Deterministic public projections for the Bali Zero Magazine collectors.
+
+The functions in this module are a one-way data boundary: they accept the
+small, already-public producer artifacts and emit only the closed projection
+shape consumed by :mod:`zantara_media.magazine.loaders`. Raw payloads,
+NotebookLM identifiers, source titles, and verbatim regulatory excerpts never
+cross the boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlsplit
+
+from zantara_media.magazine.adapters import default_adapter_registry
+
+
+_SLUG_PART = re.compile(r"[^a-z0-9]+")
+_ALLOWED_DOMAINS = {
+    "immigration",
+    "company",
+    "tax",
+    "property",
+    "compliance",
+    "general",
+}
+_OFFICIAL_HOST_SUFFIXES = (".go.id", ".gov.id")
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedRevisions:
+    current_edition: int = 0
+    current_breaking: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedMorningInputs:
+    manifest_path: Path
+    asset_manifest_path: Path
+    projection_paths: tuple[Path, ...]
+
+
+def _slug(value: str, *, fallback: str) -> str:
+    normalized = _SLUG_PART.sub("-", value.casefold()).strip("-")
+    return normalized[:96] or fallback
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _timestamp(value: object, *, fallback: datetime) -> str:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    else:
+        parsed = fallback
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("collector timestamp must be timezone-aware")
+    return (
+        parsed.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _instant(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _freshness(completed_at: str, cutoff: datetime) -> str:
+    age = cutoff.astimezone(timezone.utc) - _instant(completed_at)
+    if age <= timedelta(hours=36):
+        return "fresh"
+    if age <= timedelta(days=7):
+        return "delayed"
+    return "archived"
+
+
+def _public_url(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    parsed = urlsplit(value.strip())
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        return None
+    return value.strip()
+
+
+def _official_url(value: str | None) -> bool:
+    if value is None:
+        return False
+    host = (urlsplit(value).hostname or "").casefold()
+    return host.endswith(_OFFICIAL_HOST_SUFFIXES)
+
+
+def _domain(value: object) -> str:
+    normalized = str(value or "").strip().casefold().replace("_", "-")
+    aliases = {
+        "visa": "immigration",
+        "immigration": "immigration",
+        "company": "company",
+        "investment": "company",
+        "business": "company",
+        "tax": "tax",
+        "property": "property",
+        "real-estate": "property",
+        "regulatory": "compliance",
+        "regulation": "compliance",
+        "legal": "compliance",
+        "hr": "compliance",
+        "health": "compliance",
+        "compliance": "compliance",
+    }
+    result = aliases.get(normalized, normalized)
+    return result if result in _ALLOWED_DOMAINS else "general"
+
+
+def _severity(value: object, *, score: int | None = None) -> str:
+    normalized = str(value or "").strip().casefold()
+    if normalized in {"critical", "high", "medium", "low"}:
+        return normalized
+    if score is not None:
+        if score >= 5:
+            return "high"
+        if score >= 4:
+            return "medium"
+    return "low"
+
+
+def _confidence(value: object) -> str:
+    normalized = str(value or "").strip().casefold()
+    return normalized if normalized in {"high", "medium", "low"} else "medium"
+
+
+def _projection(
+    *,
+    system_id: str,
+    source_schema_version: str,
+    cutoff: datetime,
+    completed_at: str,
+    status: str,
+    collector_id: str,
+    items_seen: int,
+    candidates: Sequence[Mapping[str, Any]],
+    source_count: int,
+    unreachable_source_count: int,
+    watermark_seed: object,
+) -> dict[str, Any]:
+    watermark = f"sha256:{_digest(watermark_seed)}"
+    run_seed = {
+        "system_id": system_id,
+        "collector_id": collector_id,
+        "completed_at": completed_at,
+        "watermark": watermark,
+    }
+    freshness = _freshness(completed_at, cutoff)
+    return {
+        "schema_version": "magazine-public-projection.v1",
+        "source_schema_version": source_schema_version,
+        "system_id": system_id,
+        "cutoff": _timestamp(cutoff, fallback=cutoff),
+        "watermark": watermark,
+        "collector_run": {
+            "schema_version": "collector-run.v1",
+            "run_id": f"{system_id}-{_digest(run_seed)[:24]}",
+            "collector_id": collector_id,
+            "started_at": completed_at,
+            "completed_at": completed_at,
+            "status": status,
+            "freshness": freshness,
+            "items_seen": max(0, items_seen),
+            "items_eligible": len(candidates),
+            "source_count": max(0, source_count),
+            "unreachable_source_count": max(
+                0, min(unreachable_source_count, source_count)
+            ),
+            "watermark": watermark,
+            "verified_at": completed_at,
+        },
+        "candidates": list(candidates),
+    }
+
+
+def build_regulatory_projection(
+    payload: Mapping[str, Any], *, cutoff: datetime
+) -> dict[str, Any]:
+    completed_at = _timestamp(payload.get("run_at"), fallback=cutoff)
+    rows = payload.get("deltas", [])
+    if not isinstance(rows, list):
+        raise ValueError("regulatory deltas must be a list")
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        citation = str(row.get("citation") or "Regulatory update").strip()
+        citation_slug = _slug(citation, fallback=_digest(row)[:16])
+        source_url = _public_url(row.get("source"))
+        official = _official_url(source_url)
+        evidence_id = f"evidence-regulatory-{citation_slug}"
+        first_seen = _timestamp(row.get("first_seen_at"), fallback=_instant(completed_at))
+        title = str(row.get("title_en") or row.get("title_id") or citation).strip()
+        summary = str(row.get("summary") or title).strip()
+        service_domain = _domain(row.get("service_line"))
+        candidates.append(
+            {
+                "public_id": f"regulatory-{_digest(citation)[:24]}",
+                "slug": _slug(title, fallback=citation_slug),
+                "language": "en",
+                "domain": service_domain,
+                "severity": _severity(row.get("severity")),
+                "first_seen_at": first_seen,
+                "event_occurred_at": first_seen,
+                "updated_at": completed_at,
+                "title": title,
+                "deck": summary[:320],
+                "summary": summary,
+                "why_it_matters": str(
+                    row.get("impact_note")
+                    or "The relevant Bali Zero practice should review the verified change."
+                ).strip(),
+                "curiosity_text": f"The change is catalogued under {service_domain}.",
+                "claims": [
+                    {
+                        "claim_id": f"claim-regulatory-{citation_slug}",
+                        "claim_kind": "fact",
+                        "legal_effect": "none",
+                        "normalized_text": f"{citation}: {title}",
+                        "numeric_value": None,
+                        "numeric_unit": None,
+                        "as_of": str(payload.get("today") or "") or None,
+                        "evidence_ids": [evidence_id],
+                        "breaking_gate": "official-primary" if official else None,
+                    }
+                ],
+                "evidence_refs": [
+                    {
+                        "evidence_id": evidence_id,
+                        "root_source_id": f"root-{_digest(source_url or citation)[:24]}",
+                        "canonical_url": source_url,
+                        "publisher": (urlsplit(source_url).hostname if source_url else None)
+                        or "Regulatory Watcher",
+                        "document_citation": citation,
+                        "published_at": None,
+                        "retrieved_at": completed_at,
+                        "source_type": "official" if official else "research",
+                        "primary_document_status": "verified" if official else "unresolved",
+                        "root_resolution_status": "resolved" if source_url else "unresolved",
+                        "independence_verdict": "independent" if source_url else "ambiguous",
+                        "evidence_note": "Sanitized regulatory delta metadata.",
+                        "upstream_root_source_ids": [],
+                        "syndication_group_fingerprint": f"regulatory-{_digest(source_url or citation)[:24]}",
+                        "independence_ruleset_version": "magazine-source.v1",
+                        "independence_reason": (
+                            "Official primary host." if official else "Single-source morning evidence."
+                        ),
+                        "counts_toward_breaking": official,
+                    }
+                ],
+                "asset_digests": [],
+                "legal_effect_claim_ids": [],
+                "novelty": 0.9,
+                "recency": 1.0,
+                "operational_impact": {
+                    "critical": 1.0,
+                    "high": 0.9,
+                    "medium": 0.65,
+                    "low": 0.35,
+                }[_severity(row.get("severity"))],
+                "confidence": _confidence(row.get("confidence")),
+                "lifecycle_state": "verified",
+                "expected_current_version": 0,
+            }
+        )
+    unreachable = payload.get("unreachable_sources", [])
+    unreachable_count = len(unreachable) if isinstance(unreachable, list) else 0
+    seen = payload.get("seen_citations", [])
+    seen_count = len(seen) if isinstance(seen, list) else len(rows)
+    source_count = max(1, seen_count + unreachable_count) if rows or unreachable_count else 0
+    status = "degraded" if bool(payload.get("partial")) else "healthy"
+    return _projection(
+        system_id="regulatory-watcher",
+        source_schema_version="regulatory-public.v1",
+        cutoff=cutoff,
+        completed_at=completed_at,
+        status=status,
+        collector_id="daily-regulatory-watcher",
+        items_seen=len(rows),
+        candidates=candidates,
+        source_count=source_count,
+        unreachable_source_count=unreachable_count,
+        watermark_seed=payload,
+    )
+
+
+def build_mata_garuda_projection(
+    payload: Mapping[str, Any], *, cutoff: datetime
+) -> dict[str, Any]:
+    completed_at = _timestamp(payload.get("generated_at"), fallback=cutoff)
+    rows = payload.get("items", [])
+    if not isinstance(rows, list):
+        raise ValueError("MATA GARUDA items must be a list")
+    candidates: list[dict[str, Any]] = []
+    publishers: set[str] = set()
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        title = str(row.get("title") or "").strip()
+        if not title:
+            continue
+        url = _public_url(row.get("url"))
+        source = str(row.get("source") or "MATA GARUDA").strip()
+        publishers.add(source)
+        public_seed = url or f"{title}|{row.get('timestamp', '')}"
+        public_id = f"mata-{_digest(public_seed)[:24]}"
+        evidence_id = f"evidence-{public_id}"
+        score_value = row.get("relevance_score", 0)
+        score = int(score_value) if isinstance(score_value, (int, str)) else 0
+        observed_at = _timestamp(row.get("timestamp"), fallback=_instant(completed_at))
+        summary = str(row.get("summary") or title).strip()
+        evidence = []
+        claim_evidence: list[str] = []
+        if url is not None:
+            claim_evidence.append(evidence_id)
+            evidence.append(
+                {
+                    "evidence_id": evidence_id,
+                    "root_source_id": f"root-{_digest(url)[:24]}",
+                    "canonical_url": url,
+                    "publisher": source,
+                    "document_citation": None,
+                    "published_at": observed_at,
+                    "retrieved_at": completed_at,
+                    "source_type": "journalism",
+                    "primary_document_status": "not-primary",
+                    "root_resolution_status": "resolved",
+                    "independence_verdict": "independent",
+                    "evidence_note": "Public-safe MATA GARUDA feed entry.",
+                    "upstream_root_source_ids": [],
+                    "syndication_group_fingerprint": f"mata-{_digest(url)[:24]}",
+                    "independence_ruleset_version": "magazine-source.v1",
+                    "independence_reason": "Canonical public URL retained from the public-safe feed.",
+                    "counts_toward_breaking": False,
+                }
+            )
+        candidates.append(
+            {
+                "public_id": public_id,
+                "slug": _slug(title, fallback=public_id),
+                "language": "en",
+                "domain": _domain(row.get("domain")),
+                "severity": _severity(None, score=score),
+                "first_seen_at": observed_at,
+                "event_occurred_at": observed_at,
+                "updated_at": completed_at,
+                "title": title,
+                "deck": summary[:320],
+                "summary": summary,
+                "why_it_matters": "This public signal may affect Bali Zero clients or operations.",
+                "curiosity_text": None,
+                "claims": [
+                    {
+                        "claim_id": f"claim-{public_id}",
+                        "claim_kind": "fact" if claim_evidence else "analysis",
+                        "legal_effect": "none",
+                        "normalized_text": title,
+                        "numeric_value": None,
+                        "numeric_unit": None,
+                        "as_of": None,
+                        "evidence_ids": claim_evidence,
+                        "breaking_gate": None,
+                    }
+                ],
+                "evidence_refs": evidence,
+                "asset_digests": [],
+                "legal_effect_claim_ids": [],
+                "novelty": min(1.0, max(0.2, score / 5)),
+                "recency": 0.9,
+                "operational_impact": min(1.0, max(0.2, score / 5)),
+                "confidence": "medium",
+                "lifecycle_state": "verified",
+                "expected_current_version": 0,
+            }
+        )
+    return _projection(
+        system_id="mata-garuda",
+        source_schema_version="mata-garuda-public.v1",
+        cutoff=cutoff,
+        completed_at=completed_at,
+        status="healthy",
+        collector_id="kita-feed-generator",
+        items_seen=len(rows),
+        candidates=candidates,
+        source_count=len(publishers),
+        unreachable_source_count=0,
+        watermark_seed=payload,
+    )
+
+
+def build_notebooklm_projection(
+    payload: Mapping[str, Any], *, cutoff: datetime
+) -> dict[str, Any]:
+    completed_at = _timestamp(payload.get("generated_at"), fallback=cutoff)
+    notebooks = payload.get("notebooks", [])
+    if not isinstance(notebooks, list):
+        raise ValueError("NotebookLM notebooks must be a list")
+    source_count = 0
+    unhealthy = 0
+    for notebook in notebooks:
+        if not isinstance(notebook, Mapping):
+            continue
+        raw_count = notebook.get("source_count", 0)
+        if isinstance(raw_count, int) and not isinstance(raw_count, bool):
+            source_count += max(0, raw_count)
+        if notebook.get("health") not in {None, "healthy"}:
+            unhealthy += 1
+    return _projection(
+        system_id="notebooklm",
+        source_schema_version="notebooklm-public.v1",
+        cutoff=cutoff,
+        completed_at=completed_at,
+        status="healthy" if unhealthy == 0 else "degraded",
+        collector_id="nb-inventory",
+        items_seen=len(notebooks),
+        candidates=[],
+        source_count=source_count,
+        unreachable_source_count=unhealthy,
+        watermark_seed={
+            "generated_at": completed_at,
+            "notebook_count": len(notebooks),
+            "source_count": source_count,
+            "unhealthy": unhealthy,
+        },
+    )
+
+
+def build_intel_lake_projection(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    cutoff: datetime,
+    completed_at: str | None = None,
+    status: str = "healthy",
+) -> dict[str, Any]:
+    verified_at = _timestamp(completed_at, fallback=cutoff)
+    candidates: list[dict[str, Any]] = []
+    publishers: set[str] = set()
+    for row in rows:
+        if row.get("is_probe_sandbox") is True:
+            continue
+        title = str(row.get("title") or "").strip()
+        if not title:
+            continue
+        canonical_url = _public_url(row.get("canonical_url"))
+        publisher = str(row.get("source_domain") or "Intel Lake").strip()
+        publishers.add(publisher)
+        public_seed = canonical_url or f"{publisher}|{title}"
+        public_id = f"intel-{_digest(public_seed)[:24]}"
+        evidence_id = f"evidence-{public_id}"
+        first_seen = _timestamp(row.get("first_seen_at"), fallback=_instant(verified_at))
+        updated_at = _timestamp(row.get("last_seen_at"), fallback=_instant(verified_at))
+        summary = str(row.get("summary") or title).strip()
+        tags = row.get("topic_tags", [])
+        domain = "general"
+        if isinstance(tags, (list, tuple)):
+            for tag in tags:
+                mapped = _domain(tag)
+                if mapped != "general":
+                    domain = mapped
+                    break
+        evidence = []
+        claim_evidence: list[str] = []
+        if canonical_url is not None:
+            claim_evidence.append(evidence_id)
+            official = _official_url(canonical_url)
+            evidence.append(
+                {
+                    "evidence_id": evidence_id,
+                    "root_source_id": f"root-{_digest(canonical_url)[:24]}",
+                    "canonical_url": canonical_url,
+                    "publisher": publisher,
+                    "document_citation": None,
+                    "published_at": _timestamp(
+                        row.get("published_at"), fallback=_instant(first_seen)
+                    ),
+                    "retrieved_at": verified_at,
+                    "source_type": "official" if official else "journalism",
+                    "primary_document_status": "verified" if official else "not-primary",
+                    "root_resolution_status": "resolved",
+                    "independence_verdict": "independent",
+                    "evidence_note": "Sanitized Intel Lake canonical item.",
+                    "upstream_root_source_ids": [],
+                    "syndication_group_fingerprint": f"intel-{_digest(canonical_url)[:24]}",
+                    "independence_ruleset_version": "magazine-source.v1",
+                    "independence_reason": "Canonical public URL retained from Intel Lake.",
+                    "counts_toward_breaking": official,
+                }
+            )
+        confidence_raw = row.get("confidence_score")
+        confidence_score = (
+            float(confidence_raw)
+            if isinstance(confidence_raw, (int, float))
+            and not isinstance(confidence_raw, bool)
+            else 0.5
+        )
+        confidence_score = min(1.0, max(0.0, confidence_score))
+        confidence = (
+            "high" if confidence_score > 0.60 else "medium" if confidence_score >= 0.15 else "low"
+        )
+        candidates.append(
+            {
+                "public_id": public_id,
+                "slug": _slug(title, fallback=public_id),
+                "language": str(row.get("language") or "en").strip(),
+                "domain": domain,
+                "severity": _severity(row.get("severity")),
+                "first_seen_at": first_seen,
+                "event_occurred_at": _timestamp(
+                    row.get("published_at"), fallback=_instant(first_seen)
+                ),
+                "updated_at": updated_at,
+                "title": title,
+                "deck": summary[:320],
+                "summary": summary,
+                "why_it_matters": "This verified public signal may affect Bali Zero clients or operations.",
+                "curiosity_text": None,
+                "claims": [
+                    {
+                        "claim_id": f"claim-{public_id}",
+                        "claim_kind": "fact" if claim_evidence else "analysis",
+                        "legal_effect": "none",
+                        "normalized_text": title,
+                        "numeric_value": None,
+                        "numeric_unit": None,
+                        "as_of": None,
+                        "evidence_ids": claim_evidence,
+                        "breaking_gate": (
+                            "official-primary"
+                            if canonical_url is not None and _official_url(canonical_url)
+                            else None
+                        ),
+                    }
+                ],
+                "evidence_refs": evidence,
+                "asset_digests": [],
+                "legal_effect_claim_ids": [],
+                "novelty": 0.7,
+                "recency": 0.9,
+                "operational_impact": 0.6,
+                "confidence": confidence,
+                "lifecycle_state": "verified",
+                "expected_current_version": 0,
+            }
+        )
+    return _projection(
+        system_id="intel-lake",
+        source_schema_version="intel-public.v1",
+        cutoff=cutoff,
+        completed_at=verified_at,
+        status=status,
+        collector_id="intel-lake-public-snapshot",
+        items_seen=len(rows),
+        candidates=candidates,
+        source_count=len(publishers),
+        unreachable_source_count=0,
+        watermark_seed={"completed_at": verified_at, "candidates": candidates},
+    )
+
+
+def _unavailable_projection(
+    system_id: str, source_schema_version: str, *, cutoff: datetime
+) -> dict[str, Any]:
+    return _projection(
+        system_id=system_id,
+        source_schema_version=source_schema_version,
+        cutoff=cutoff,
+        completed_at=_timestamp(cutoff, fallback=cutoff),
+        status="unavailable",
+        collector_id=f"{system_id}-public-export",
+        items_seen=0,
+        candidates=[],
+        source_count=0,
+        unreachable_source_count=0,
+        watermark_seed={"system_id": system_id, "status": "unavailable"},
+    )
+
+
+def _read_object(path: Path) -> Mapping[str, Any] | None:
+    if not path.is_file():
+        return None
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, Mapping):
+        raise ValueError(f"collector artifact must be an object: {path}")
+    return parsed
+
+
+def _write_json_atomic(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ) + "\n"
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(body, encoding="utf-8")
+    temporary.replace(path)
+
+
+def _validate_public_projection(system_id: str, projection: Mapping[str, Any]) -> None:
+    """Apply the same closed-boundary validation used by the publication loader."""
+    if projection.get("system_id") != system_id:
+        raise ValueError("projection system_id does not match its named source")
+    registry = default_adapter_registry()
+    adapter = registry.get(system_id)
+    collector_run = projection.get("collector_run")
+    candidates = projection.get("candidates")
+    if not isinstance(collector_run, Mapping) or not isinstance(candidates, list):
+        raise ValueError("projection must contain collector_run and candidates")
+    adapter.collector_run(collector_run)
+    adapter.candidates(candidates)
+
+
+def prepare_morning_inputs(
+    *,
+    repo_root: Path,
+    state_dir: Path,
+    cutoff: datetime,
+    intel_rows: Sequence[Mapping[str, Any]],
+    intel_status: str,
+) -> PreparedMorningInputs:
+    if cutoff.tzinfo is None or cutoff.utcoffset() is None:
+        raise ValueError("cutoff must be timezone-aware")
+    edition_date = (cutoff.astimezone(timezone.utc) + timedelta(hours=8)).date().isoformat()
+    projection_dir = state_dir / "inputs" / "projections" / edition_date
+    packet_dir = state_dir / "packets"
+    journal_path = state_dir / "outcomes.jsonl"
+
+    regulatory_raw = _read_object(
+        repo_root / "research" / "regulatory" / f"{edition_date}-delta.json"
+    )
+    mata_raw = _read_object(
+        repo_root / "apps" / "mata-garuda" / "data" / "kita_feed.json"
+    )
+    notebook_raw = _read_object(
+        repo_root / "research" / "nb-health" / "nb-inventory-live.json"
+    )
+
+    projections = {
+        "intel-lake": build_intel_lake_projection(
+            intel_rows,
+            cutoff=cutoff,
+            completed_at=_timestamp(cutoff, fallback=cutoff),
+            status=intel_status,
+        ),
+        "mata-garuda": (
+            build_mata_garuda_projection(mata_raw, cutoff=cutoff)
+            if mata_raw is not None
+            else _unavailable_projection(
+                "mata-garuda", "mata-garuda-public.v1", cutoff=cutoff
+            )
+        ),
+        "notebooklm": (
+            build_notebooklm_projection(notebook_raw, cutoff=cutoff)
+            if notebook_raw is not None
+            else _unavailable_projection(
+                "notebooklm", "notebooklm-public.v1", cutoff=cutoff
+            )
+        ),
+        "regulatory-watcher": (
+            build_regulatory_projection(regulatory_raw, cutoff=cutoff)
+            if regulatory_raw is not None
+            else _unavailable_projection(
+                "regulatory-watcher", "regulatory-public.v1", cutoff=cutoff
+            )
+        ),
+    }
+    for system_id, projection in projections.items():
+        _validate_public_projection(system_id, projection)
+
+    projection_paths: list[Path] = []
+    projection_inputs: list[dict[str, str]] = []
+    for system_id in sorted(projections):
+        path = projection_dir / f"{system_id}.public.json"
+        _write_json_atomic(path, projections[system_id])
+        projection_paths.append(path)
+        projection_inputs.append(
+            {"system_id": system_id, "projection_path": str(path.resolve())}
+        )
+
+    revisions = resolve_published_revisions(packet_dir, journal_path)
+    manifest_path = state_dir / "inputs" / f"morning-{edition_date}.json"
+    _write_json_atomic(
+        manifest_path,
+        {
+            "schema_version": "magazine-morning-input.v2",
+            "projection_inputs": projection_inputs,
+            "expected_current_revision": revisions.current_edition,
+            "expected_breaking_revision": revisions.current_breaking,
+        },
+    )
+    asset_manifest_path = state_dir / "inputs" / f"assets-{edition_date}.json"
+    _write_json_atomic(
+        asset_manifest_path,
+        {"schema_version": "asset-intents.v1", "intents": []},
+    )
+    return PreparedMorningInputs(
+        manifest_path=manifest_path,
+        asset_manifest_path=asset_manifest_path,
+        projection_paths=tuple(projection_paths),
+    )
+
+
+def resolve_published_revisions(packet_dir: Path, journal_path: Path) -> PublishedRevisions:
+    if not packet_dir.is_dir() or not journal_path.is_file():
+        return PublishedRevisions()
+    completed: set[str] = set()
+    for line in journal_path.read_text(encoding="utf-8").splitlines():
+        if not line:
+            continue
+        row = json.loads(line)
+        if row.get("state") == "completed" and isinstance(row.get("operation_id"), str):
+            completed.add(str(row["operation_id"]))
+    edition_revision = 0
+    breaking_revision = 0
+    for path in packet_dir.glob("*.json"):
+        try:
+            packet = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        packet_id = packet.get("packet_id")
+        if not isinstance(packet_id, str):
+            continue
+        schema = packet.get("schema_version")
+        if schema == "edition.v1":
+            operation = f"/api/machine/publications/editions:{packet_id}"
+            if operation in completed:
+                edition_revision = max(edition_revision, int(packet["edition_revision"]))
+        elif schema == "story.v1":
+            operation = f"/api/machine/publications/breaking:{packet_id}"
+            if operation in completed:
+                breaking_revision = max(
+                    breaking_revision, int(packet["expected_breaking_revision"]) + 1
+                )
+    return PublishedRevisions(
+        current_edition=edition_revision,
+        current_breaking=breaking_revision,
+    )

--- a/docs/AUTOMATIONS_REFERENCE.md
+++ b/docs/AUTOMATIONS_REFERENCE.md
@@ -12,10 +12,10 @@ These entries are committed as repo-canon LaunchAgents but are not counted in
 the generated live totals above until installed on Pro and included in the next
 automation snapshot.
 
-| Label                            | Host | Schedule   | Purpose                                                                                                        |
-| -------------------------------- | ---- | ---------- | -------------------------------------------------------------------------------------------------------------- |
-| `com.balizero.magazine.morning`  | Pro  | 06:15 WITA | Compose/publish the internal Bali Zero Magazine morning issue after collectors; target readable by 06:30 WITA. |
-| `com.balizero.magazine.breaking` | Pro  | 600s       | Drain qualified Breaking magazine candidates within the 10-minute objective.                                   |
+| Label                            | Host | Schedule   | Purpose                                                                                                                           |
+| -------------------------------- | ---- | ---------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `com.balizero.magazine.morning`  | Pro  | 08:15 WITA | Compose/publish the internal Bali Zero Magazine morning issue after the Regulatory Watcher window; target readable by 08:30 WITA. |
+| `com.balizero.magazine.breaking` | Pro  | 600s       | Drain qualified Breaking magazine candidates within the 10-minute objective.                                                      |
 
 ---
 

--- a/docs/runbooks/bali-zero-magazine.md
+++ b/docs/runbooks/bali-zero-magazine.md
@@ -26,15 +26,16 @@ Do not install on Air-M5. The wrapper exits unless `hostname` is `Nuzantara` or 
 
 ## Cadence
 
-- Morning edition: `06:15` WITA, after collector jobs. Target human-visible publish by `06:30` WITA.
+- Morning edition: `08:15` WITA, after the 07:00 Regulatory Watcher window. Target human-visible publish by `08:30` WITA.
 - Breaking drain: every `600` seconds, meeting the 10-minute objective for qualified official-primary or two-independent-root-source signals.
 
-## Required runtime inputs
+## Runtime inputs
 
 Default state root: `/Users/nuzantara/.local/state/bali-zero-magazine`.
 
-- `inputs/morning-YYYY-MM-DD.json`: `magazine-morning-input.v2` with projection paths for `intel-lake`, `mata-garuda`, `regulatory-watcher`, and `notebooklm`.
-- `inputs/assets-YYYY-MM-DD.json`: asset intent manifest for morning publish.
+- `inputs/morning-YYYY-MM-DD.json`: generated automatically by `magazine-prepare morning`, with projection paths for `intel-lake`, `mata-garuda`, `regulatory-watcher`, and `notebooklm`.
+- `inputs/projections/YYYY-MM-DD/*.public.json`: closed, PII-rejected public projections generated from the current collector artifacts and the safe Intel Lake columns only.
+- `inputs/assets-YYYY-MM-DD.json`: generated automatically as the morning asset-intent manifest. It remains empty until a verified image asset is explicitly bound.
 - `inputs/breaking-ready.json`: `magazine-breaking-input.v2` for one qualified public candidate.
 - `inputs/breaking-assets.json`: asset intent manifest for the Breaking packet.
 

--- a/infra/launchagents/com.balizero.magazine.morning.plist
+++ b/infra/launchagents/com.balizero.magazine.morning.plist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!-- Repo canon. Pro-only LaunchAgent: morning magazine compose at 06:15 WITA, after collectors, target publish by 06:30. -->
+<!-- Repo canon. Pro-only LaunchAgent: morning magazine compose at 08:15 WITA, after collectors, target publish by 08:30. -->
 <plist version="1.0">
 <dict>
 	<key>EnvironmentVariables</key>
@@ -34,7 +34,7 @@
 	<key>StartCalendarInterval</key>
 	<dict>
 		<key>Hour</key>
-		<integer>6</integer>
+		<integer>8</integer>
 		<key>Minute</key>
 		<integer>15</integer>
 	</dict>

--- a/infra/launchagents/wrappers/bali-zero-magazine-publish.sh
+++ b/infra/launchagents/wrappers/bali-zero-magazine-publish.sh
@@ -193,6 +193,16 @@ case "$MODE" in
         ;;
 esac
 
+if [ "$MODE" = "morning" ] && [ "${MAGAZINE_PREPARE_INPUTS:-true}" = "true" ]; then
+    log "preparing collector projections mode=morning"
+    cd "$MEDIA_DIR"
+    PYTHONPATH="$MEDIA_DIR" run_with_timeout \
+        "$PYTHON_BIN" -m zantara_media.cli.magazine_prepare morning \
+        --repo-root "$ROOT" \
+        --state-dir "$STATE_DIR" \
+        --cutoff "$CUTOFF"
+fi
+
 preflight_manifest "$INPUT" >> "$LOG" 2>&1
 
 if [ "$PUBLISH_ENABLED" = "true" ]; then


### PR DESCRIPTION
## Outcome

Prepare the Bali Zero Magazine morning edition automatically from the four existing information systems without replacing them:

- Intel Lake: read-only query over safe public columns only
- MATA GARUDA: public-safe feed projection
- Regulatory Watcher: cited daily delta projection
- NotebookLM: aggregate health only; no notebook IDs or titles

The publisher wrapper now prepares and validates all four projections before composition. Missing collectors remain explicit coverage gaps, and any deterministic PII match aborts before files are written.

The morning schedule moves from 06:15 to 08:15 WITA so it actually runs after the 07:00 Regulatory Watcher window.

## Verification

- 125/125 Magazine Python tests
- Ruff clean
- 5/5 deployment/schedule tests
- plist lint clean
- wrapper dry-run end-to-end: 4 projections -> manifest -> quiet partial edition
- full repository pre-push gate passed

## Safety

- No raw Intel Lake payload columns are selected
- Notebook UUIDs and source titles never cross the projection boundary
- no LaunchAgent was loaded and no publication was triggered
- requires independent review; this PR does not deploy or arm automation