### PR TITLE
feat(magazine): render approved story media

### DIFF
--- a/apps/bali-zero-magazine/app/api/story-media/[slug]/route.ts
+++ b/apps/bali-zero-magazine/app/api/story-media/[slug]/route.ts
@@ -1,0 +1,45 @@
+import {
+  authorize,
+  parseRoleAllowlist,
+} from "../../../../lib/server/authorization.ts";
+import { requireViewer } from "../../../../lib/server/identity.ts";
+import { resolvePublishedStoryMedia } from "../../../../lib/server/media.ts";
+import { getMagazineBindings } from "../../../../lib/server/runtime-bindings.ts";
+import { mediaSecurityHeaders } from "../../../../lib/server/security.ts";
+
+function denied(status: 401 | 404): Response {
+  return new Response(null, { status, headers: mediaSecurityHeaders() });
+}
+
+export async function GET(
+  request: Request,
+  context: Readonly<{ params: Promise<Readonly<{ slug: string }>> }>,
+): Promise<Response> {
+  const bindings = getMagazineBindings();
+  try {
+    const roles = parseRoleAllowlist(bindings.ROLE_ALLOWLIST_JSON);
+    const viewer = await requireViewer(request.headers, {
+      actorKeySecret: bindings.ACTOR_KEY_SECRET ?? "",
+      roleAllowlist: roles,
+    });
+    if (!authorize(viewer, "magazine:read", roles).allowed) return denied(401);
+  } catch {
+    return denied(401);
+  }
+  if (bindings.DB === undefined || bindings.MEDIA === undefined)
+    return denied(404);
+  const { slug } = await context.params;
+  const media = await resolvePublishedStoryMedia(
+    bindings.DB,
+    bindings.MEDIA,
+    slug,
+  );
+  if (media === null) return denied(404);
+  const headers = mediaSecurityHeaders({
+    "Content-Type": media.mimeType,
+    "Content-Length": String(media.bytes.byteLength),
+  });
+  const body = new ArrayBuffer(media.bytes.byteLength);
+  new Uint8Array(body).set(media.bytes);
+  return new Response(body, { status: 200, headers });
+}

--- a/apps/bali-zero-magazine/app/globals.css
+++ b/apps/bali-zero-magazine/app/globals.css
@@ -308,6 +308,35 @@ main {
   z-index: 1;
 }
 
+.editorial-visual--image {
+  padding: 0;
+}
+
+.editorial-visual--image::after {
+  background: linear-gradient(
+    180deg,
+    transparent 58%,
+    rgba(0, 0, 0, 0.42) 100%
+  );
+  inset: 0;
+  height: auto;
+  transform: none;
+  width: auto;
+}
+
+.editorial-visual img {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.editorial-visual--dispatch,
+.editorial-visual--domain {
+  aspect-ratio: 3 / 2;
+  margin-bottom: 0.8rem;
+}
+
 .dispatch-column {
   border-left: 1px solid var(--rule);
   display: flex;

--- a/apps/bali-zero-magazine/components/story-card.tsx
+++ b/apps/bali-zero-magazine/components/story-card.tsx
@@ -8,15 +8,30 @@ type StoryCardProps = Readonly<{
 }>;
 
 export function StoryCard({ story, variant = "domain" }: StoryCardProps) {
+  const showVisual =
+    variant === "hero" || (variant !== "breaking" && story.imageAvailable);
+
   return (
     <article className={`story-card story-card--${variant}`}>
-      {variant === "hero" ? (
+      {showVisual ? (
         <div
-          className="editorial-visual"
-          role="img"
-          aria-label={story.imageAlt}
+          className={`editorial-visual editorial-visual--${variant}${
+            story.imageAvailable ? " editorial-visual--image" : ""
+          }`}
         >
-          <span>Editorial visual pending verified media</span>
+          {story.imageAvailable ? (
+            // The authenticated same-origin route must not pass through an
+            // optimizer, because optimizer requests do not carry the viewer.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={`/api/story-media/${encodeURIComponent(story.slug)}`}
+              alt={story.imageAlt}
+              loading={variant === "hero" ? "eager" : "lazy"}
+              fetchPriority={variant === "hero" ? "high" : "auto"}
+            />
+          ) : (
+            <span>Editorial visual pending verified media</span>
+          )}
         </div>
       ) : null}
       <div className="story-card-copy">

--- a/apps/bali-zero-magazine/lib/server/magazine-read-model.ts
+++ b/apps/bali-zero-magazine/lib/server/magazine-read-model.ts
@@ -41,6 +41,7 @@ export type StoryCardView = Readonly<{
   confidence: StoryVersionV1["confidence"];
   publishedAt: string;
   imageAlt: string;
+  imageAvailable: boolean;
 }>;
 
 export type SourceStatusView = Readonly<{
@@ -220,6 +221,7 @@ function normalizeStory(
     confidence: story.confidence,
     publishedAt: story.published_at,
     imageAlt: asset?.altText ?? `Editorial visual context for ${story.title}`,
+    imageAvailable: asset !== null,
   };
 }
 

--- a/apps/bali-zero-magazine/lib/server/media.ts
+++ b/apps/bali-zero-magazine/lib/server/media.ts
@@ -58,6 +58,7 @@ const MIME_EXTENSION = {
   "image/webp": "webp",
 } as const;
 const SHA256 = /^[a-f0-9]{64}$/;
+const PUBLIC_STORY_SLUG = /^[a-z0-9](?:[a-z0-9-]{0,198}[a-z0-9])?$/;
 
 function equalsAt(
   bytes: Uint8Array,
@@ -497,7 +498,20 @@ export async function resolvePublishedMedia(
     )
     .bind(digest)
     .first<EligibleAssetRow>();
-  if (row === null || row.sha256 !== digest) return null;
+  return resolveEligibleMedia(bucket, row, digest);
+}
+
+async function resolveEligibleMedia(
+  bucket: R2BucketLike,
+  row: EligibleAssetRow | null,
+  expectedDigest?: string,
+): Promise<ResolvedMedia | null> {
+  if (
+    row === null ||
+    (expectedDigest !== undefined && row.sha256 !== expectedDigest)
+  )
+    return null;
+  const digest = row.sha256;
   const extension = MIME_EXTENSION[row.mime_type];
   if (extension === undefined) return null;
   const canonicalKey = `assets/sha256/${digest}.${extension}`;
@@ -514,4 +528,44 @@ export async function resolvePublishedMedia(
   } catch {
     return null;
   }
+}
+
+export async function resolvePublishedStoryMedia(
+  db: D1DatabaseLike,
+  bucket: R2BucketLike,
+  slug: string,
+): Promise<ResolvedMedia | null> {
+  if (!PUBLIC_STORY_SLUG.test(slug)) return null;
+  const row = await db
+    .prepare(
+      `SELECT a.sha256, a.r2_key, a.mime_type,
+              a.byte_count, a.width, a.height
+       FROM stories s
+       JOIN story_versions sv
+         ON sv.story_id = s.story_id AND sv.version = s.current_version
+       JOIN story_asset_references sar
+         ON sar.packet_id = sv.packet_id AND sar.story_id = sv.story_id
+        AND sar.version = sv.version
+       JOIN assets a ON a.sha256 = sar.asset_sha256
+       JOIN asset_sources source ON source.canonical_sha256 = a.sha256
+       WHERE s.slug = ?
+         AND sar.publication_state = 'published'
+         AND sv.publication_state = 'published'
+         AND ${assetEligibilitySql("source")}
+         AND NOT EXISTS (
+           SELECT 1 FROM story_visibility_events visibility
+           WHERE visibility.story_id = sv.story_id
+             AND visibility.visibility_seq = (
+               SELECT max(latest.visibility_seq)
+               FROM story_visibility_events latest
+               WHERE latest.story_id = sv.story_id
+             )
+             AND visibility.desired_quarantined = 1
+         )
+       ORDER BY source.created_at DESC, a.sha256
+       LIMIT 1`,
+    )
+    .bind(slug)
+    .first<EligibleAssetRow>();
+  return resolveEligibleMedia(bucket, row);
 }

--- a/apps/bali-zero-magazine/tests/magazine-render.test.mjs
+++ b/apps/bali-zero-magazine/tests/magazine-render.test.mjs
@@ -768,6 +768,11 @@ test("magazine front page renders editorial priority, five domains, coverage, an
   assert.match(html, /18 July 2026/i);
   assert.match(html, /The Morning File/);
   assert.match(html, /Bali visa files move to a stricter evidence standard/);
+  assert.match(
+    html,
+    /<img[^>]+src="\/api\/story-media\/bali-visa-evidence-standard"[^>]+alt="A reviewed immigration dossier arranged beside a verification checklist"/i,
+  );
+  assert.doesNotMatch(html, /Editorial visual pending verified media/i);
   assert.match(html, /Breaking/);
   assert.match(html, /Primary-source refresh changes the compliance watchlist/);
   for (const section of [

--- a/apps/bali-zero-magazine/tests/media-route.test.mjs
+++ b/apps/bali-zero-magazine/tests/media-route.test.mjs
@@ -20,6 +20,10 @@ const routePath = new URL(
   "../app/api/media/[digest]/route.ts",
   import.meta.url,
 );
+const storyRoutePath = new URL(
+  "../app/api/story-media/[slug]/route.ts",
+  import.meta.url,
+);
 const mediaModulePath = new URL("../lib/server/media.ts", import.meta.url);
 const routeExists = existsSync(routePath) && existsSync(mediaModulePath);
 
@@ -28,8 +32,16 @@ test("authenticated media route and resolver exist", () => {
   assert.ok(existsSync(mediaModulePath), "missing media resolver");
 });
 
+test("story media route exists", () => {
+  assert.ok(existsSync(storyRoutePath), "missing story media route");
+});
+
 async function loadRoute() {
   return (await import(routePath)).GET;
+}
+
+async function loadStoryRoute() {
+  return (await import(storyRoutePath)).GET;
 }
 
 async function publishVisibleAsset({
@@ -141,6 +153,46 @@ async function getMedia(handler, digest, bindings, authenticated = true) {
     handler(request, { params: Promise.resolve({ digest }) }),
   );
 }
+
+async function getStoryMedia(handler, slug, bindings, authenticated = true) {
+  const headers = authenticated
+    ? { "oai-authenticated-user-email": "reader@balizero.com" }
+    : {};
+  const request = new Request(
+    `https://magazine.example/api/story-media/${encodeURIComponent(slug)}`,
+    { headers },
+  );
+  return runWithMagazineBindings(bindings, () =>
+    handler(request, { params: Promise.resolve({ slug }) }),
+  );
+}
+
+test("story media route serves the approved image without exposing its digest in HTML", async () => {
+  const handler = await loadStoryRoute();
+  const { db, media, metadata, story } = await publishVisibleAsset();
+  const bindings = runtimeBindings(db, media);
+
+  assert.equal(
+    (await getStoryMedia(handler, story.slug, bindings, false)).status,
+    401,
+  );
+  const response = await getStoryMedia(handler, story.slug, bindings);
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "image/png");
+  assert.equal((await response.text()).includes(metadata.sha256), false);
+  assert.equal(
+    (await getStoryMedia(handler, "missing-story", bindings)).status,
+    404,
+  );
+
+  const hostedBindings = { ...bindings };
+  delete hostedBindings.ACTOR_KEY_SECRET;
+  delete hostedBindings.ROLE_ALLOWLIST_JSON;
+  assert.equal(
+    (await getStoryMedia(handler, story.slug, hostedBindings)).status,
+    200,
+  );
+});
 
 test(
   "media route serves only an authenticated visible current association",


### PR DESCRIPTION
## Summary

- render approved story assets on hero, dispatch, and domain cards
- resolve private media through a public story slug without exposing canonical digests
- preserve authenticated read-only Sites fallback and fail-closed revocation and quarantine checks

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit` (170 passed)
- repository pre-push suite passed