### PR TITLE
feat(wr2): cut production draft generator over to planner/writer engine (pregate-in-loop, per-slot repair, kill-switch)

### DIFF
--- a/.github/workflows/wr2-queue-tests.yml
+++ b/.github/workflows/wr2-queue-tests.yml
@@ -42,6 +42,22 @@
 # — pytest collects the module but finds 0 test items in it; it contributes
 # 0 to the 154 and is not run by this workflow either. Pre-existing, not
 # introduced or fixed by this change.
+#
+# scripts/wr2_draft_generator.py + its 9 test_wr2_draft_generator_*.py files
+# ADDED 2026-07-21 (production cutover to the planner/writer engine, W-family
+# #2 "esiste≠armato" closed the same way the render battery was closed above):
+# `wr2_draft_generator.py` now imports and drives `wr2_carousel_ir`/
+# `wr2_editorial_pregate`/`wr2_planner_writer` behind the WR2_COMPOSE_ENGINE
+# kill-switch — this was the FIRST production modification of that arc, and
+# its generator-level test suite (including the pre-existing 8 files, which
+# had NO CI enforcement anywhere before this change — dev-run-by-hand only)
+# had never been wired into any workflow. Two of the pre-existing files
+# (test_wr2_draft_generator_enriched_prompt.py, _kicker_variety.py) call
+# `_process_one` directly mocking the monolith's own `claude_compose_slides`;
+# each now pins `WR2_COMPOSE_ENGINE=monolith` (discovered live during this
+# cutover's own pre-push run: the new planner_writer default silently routed
+# those un-pinned tests into a REAL Claude OAuth CLI subprocess call instead
+# of the mocked one — caught before merge, not after).
 name: wr2-queue-tests
 
 on:
@@ -52,6 +68,7 @@ on:
       - "scripts/wr2_queue_hygiene.py"
       - "scripts/wr2_queue_writer.py"
       - "scripts/wr2_rerender_local.py"
+      - "scripts/wr2_draft_generator.py"
       - "scripts/wr2_html_renderer/**"
       - "scripts/wr2_carousel_ir.py"
       - "scripts/wr2_ir_shadow_replay.py"
@@ -68,6 +85,15 @@ on:
       - "scripts/tests/test_wr2_carousel_ir.py"
       - "scripts/tests/test_wr2_editorial_pregate.py"
       - "scripts/tests/test_wr2_planner_writer.py"
+      - "scripts/tests/test_wr2_draft_generator_liveness_tier.py"
+      - "scripts/tests/test_wr2_draft_generator_cover_codex_detection.py"
+      - "scripts/tests/test_wr2_draft_generator_length_per_tier.py"
+      - "scripts/tests/test_wr2_draft_generator_kicker_variety.py"
+      - "scripts/tests/test_wr2_draft_generator_closer_guard.py"
+      - "scripts/tests/test_wr2_draft_generator_enriched_prompt.py"
+      - "scripts/tests/test_wr2_draft_generator_tone_per_tier.py"
+      - "scripts/tests/test_wr2_draft_generator_json_example.py"
+      - "scripts/tests/test_wr2_draft_generator_planner_writer_cutover.py"
       - "scripts/tests/conftest.py"
       - "apps/backend-rag/backend/services/canva_renderer_v2/_pg.py"
       - ".github/workflows/wr2-queue-tests.yml"
@@ -104,5 +130,14 @@ jobs:
             scripts/tests/test_wr2_carousel_ir.py \
             scripts/tests/test_wr2_editorial_pregate.py \
             scripts/tests/test_wr2_planner_writer.py \
+            scripts/tests/test_wr2_draft_generator_liveness_tier.py \
+            scripts/tests/test_wr2_draft_generator_cover_codex_detection.py \
+            scripts/tests/test_wr2_draft_generator_length_per_tier.py \
+            scripts/tests/test_wr2_draft_generator_kicker_variety.py \
+            scripts/tests/test_wr2_draft_generator_closer_guard.py \
+            scripts/tests/test_wr2_draft_generator_enriched_prompt.py \
+            scripts/tests/test_wr2_draft_generator_tone_per_tier.py \
+            scripts/tests/test_wr2_draft_generator_json_example.py \
+            scripts/tests/test_wr2_draft_generator_planner_writer_cutover.py \
             scripts/wr2_html_renderer/tests \
             -q

--- a/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
+++ b/scripts/tests/test_wr2_draft_generator_enriched_prompt.py
@@ -688,6 +688,12 @@ async def test_process_one_composes_when_news_shaped_but_summary_present(
     citations-only, BUT article_summary is real -> composes normally, never
     parked. Proves the backstop doesn't over-trigger on the common case
     (B1's facts-first fix handles this one, not B2's park)."""
+    # Production cutover (2026-07-21): this test mocks the MONOLITH's own
+    # claude_compose_slides — pin the engine so it keeps exercising exactly
+    # that path (WR2_COMPOSE_ENGINE now defaults to planner_writer, which
+    # never calls claude_compose_slides and would otherwise fall through to
+    # a REAL Claude OAuth call here).
+    monkeypatch.setenv("WR2_COMPOSE_ENGINE", "monolith")
     draft_id = uuid.uuid4()
     row = {
         "id": draft_id,
@@ -734,6 +740,9 @@ async def test_process_one_composes_when_facts_citations_only_but_enrichment_ric
     (thirty_second_brief). The old _has_usable_source parked on the
     citations-only signal alone, discarding that real content. The fix must
     compose instead."""
+    # Production cutover (2026-07-21): same monolith-pin rationale as
+    # test_process_one_composes_when_news_shaped_but_summary_present above.
+    monkeypatch.setenv("WR2_COMPOSE_ENGINE", "monolith")
     draft_id = uuid.uuid4()
     row = {
         "id": draft_id,

--- a/scripts/tests/test_wr2_draft_generator_kicker_variety.py
+++ b/scripts/tests/test_wr2_draft_generator_kicker_variety.py
@@ -555,6 +555,14 @@ def _base_row(draft_id: uuid.UUID) -> dict:
 
 
 def _wire_process_one_mocks(monkeypatch: pytest.MonkeyPatch, compose_mock: AsyncMock) -> None:
+    # Production cutover (2026-07-21): every test using this helper mocks
+    # the MONOLITH's own claude_compose_slides + exercises its 3-guard regen
+    # loop directly — pin the engine so it keeps testing exactly that
+    # (WR2_COMPOSE_ENGINE now defaults to planner_writer, which never calls
+    # claude_compose_slides and would otherwise fall through to a REAL
+    # Claude OAuth call here, same class of hazard the cutover PR's own
+    # test suite guards against for its own dispatch-routing tests).
+    monkeypatch.setenv("WR2_COMPOSE_ENGINE", "monolith")
     monkeypatch.setattr(dg, "claude_compose_slides", compose_mock)
     monkeypatch.setattr(dg, "generate_cover_image", AsyncMock(return_value=(None, "skip-in-test")))
     monkeypatch.setattr(dg, "_send_telegram", MagicMock())

--- a/scripts/tests/test_wr2_draft_generator_planner_writer_cutover.py
+++ b/scripts/tests/test_wr2_draft_generator_planner_writer_cutover.py
@@ -1,0 +1,746 @@
+"""Tests for the WR2 production cutover — `wr2_draft_generator.py` now
+drives the planner/writer engine (Phases 1-3: `wr2_carousel_ir` /
+`wr2_editorial_pregate` / `wr2_planner_writer`) behind the
+`WR2_COMPOSE_ENGINE` kill-switch, per
+`.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md`
+§3 rollout step 3 ("Planner/Writer dual-run — shadow accanto al monolite,
+poi cutover").
+
+Batteries:
+  - engine resolution: default/explicit/invalid `WR2_COMPOSE_ENGINE` env.
+  - dispatch routing: `_process_one` calls the right per-engine function
+    (monolith path proven UNTOUCHED by routing, not by re-running it here —
+    the existing `test_wr2_draft_generator_*` suites already cover its
+    internals byte-for-byte since that code moved verbatim).
+  - `_generate_planner_writer_deck`: happy path / pregate-FAIL -> repair ->
+    PASS / repair-exhausted -> raises `PregateRepairExhausted`.
+  - plan-level fail-fast re-plan when the closer's kind is unsafe.
+  - guard adapters (`_closer_word_count_typed` / `_closer_too_long_typed` /
+    `_kicker_collision_typed`) — guilt+innocence, mirroring the monolith
+    guards' own test discipline.
+  - `_pregate_fail_reasons_by_slot` / `_pregate_failing_slot_ids` — the
+    FAIL-reason-to-slot-id mapping the repair loop depends on.
+  - `_build_brief_ctx` — facts-first composition (source article leads,
+    enriched brief supports — same B1 doctrine as the monolith).
+  - `_pick_register_for_planner_writer` — deterministic tier-preference
+    pick, anti-sameness aware.
+  - `_load_forbidden_phrases_for_writer` — real constitution.md read +
+    fail-open on a missing file.
+  - persistence-shape assertions: `to_composer_dict` projections carry
+    every field the two real downstream consumers need (composer's
+    family-resolution via explicit `layout_family` pin; `wr2_html_render_
+    apply`'s pass-through reader contract — `slides_json.get("slides")`, a
+    plain list of dicts, no required-key assumptions beyond what
+    `_normalize_heroes`/`_take_label_hard_gate_violations` already use).
+
+Zero network, zero DB, zero CLI subprocess — every planner_fn/writer_fn
+here is a plain Python fake, exactly mirroring
+`test_wr2_planner_writer.py`'s own test discipline (the engine modules have
+zero I/O side effects by design; the wiring in this file stays testable at
+the same layer by keeping the async DB/OAuth calls at the OUTER edges only —
+`_generate_planner_writer_deck` itself is the pure(ish) sync core).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import wr2_carousel_ir as ir  # noqa: E402
+import wr2_draft_generator as dg  # noqa: E402
+import wr2_editorial_pregate as pregate  # noqa: E402
+import wr2_planner_writer as pw  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Fixed fake planner/writer plumbing (mirrors test_wr2_planner_writer.py)
+# ─────────────────────────────────────────────────────────────────────────
+
+_HAPPY_PLAN = (
+    '{"spine": "PMK 37/2025 changes the levy math for every PMA.", '
+    '"arc": "news_alert", "arc_reason": "Breaking regulation drop.", "slides": ['
+    '{"slot_id": 1, "role": "hook", "kind": "cover", "heading_intent": "the number", '
+    '"bullet_promise_n": null, "hero": true, "body": null}, '
+    '{"slot_id": 2, "role": "fact_stack", "kind": "fact_stack", '
+    '"heading_intent": "3 numbers", "bullet_promise_n": 3, "hero": false, "body": null}, '
+    '{"slot_id": 3, "role": "close", "kind": "statement", '
+    '"heading_intent": "The Bali Zero read — echo PMK 37/2025", "bullet_promise_n": null, '
+    '"hero": false, "body": null}]}'
+)
+
+
+def _happy_planner_fn(prompt: str) -> str:
+    return _HAPPY_PLAN
+
+
+def _happy_writer_fn(prompt: str) -> str:
+    if '"kind": "cover"' in prompt:
+        return '{"kind": "cover", "headline": "PMK 37 RAISES THE BAR", "subhead": "TAX", "regulation_code": "37/2025"}'
+    if '"kind": "fact_stack"' in prompt:
+        return '{"kind": "fact_stack", "heading": "THE NUMBERS", "facts": ["a", "b", "c"]}'
+    return '{"kind": "statement", "statement": "PMK 37/2025 changes everything — read the fine print now."}'
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Engine resolution (kill-switch)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestComposeEngineResolution:
+    def test_default_is_planner_writer(self, monkeypatch):
+        monkeypatch.delenv("WR2_COMPOSE_ENGINE", raising=False)
+        assert dg._resolve_compose_engine() == "planner_writer"
+
+    def test_explicit_monolith(self, monkeypatch):
+        monkeypatch.setenv("WR2_COMPOSE_ENGINE", "monolith")
+        assert dg._resolve_compose_engine() == "monolith"
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("WR2_COMPOSE_ENGINE", "MONOLITH")
+        assert dg._resolve_compose_engine() == "monolith"
+
+    def test_unrecognized_value_falls_back_to_planner_writer(self, monkeypatch):
+        monkeypatch.setenv("WR2_COMPOSE_ENGINE", "some_typo")
+        assert dg._resolve_compose_engine() == "planner_writer"
+
+    def test_whitespace_tolerant(self, monkeypatch):
+        monkeypatch.setenv("WR2_COMPOSE_ENGINE", "  monolith  ")
+        assert dg._resolve_compose_engine() == "monolith"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Dispatch routing — _process_one calls the right per-engine function
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestDispatchRouting:
+    def _row(self) -> dict:
+        return {
+            "id": "11111111-1111-1111-1111-111111111111",
+            # Deliberately NOT news-shaped (no news-event verb, no staging_type
+            # 'news', no liveness_tier) so the shared B2 park-check short-circuits
+            # to False and both branches are reachable without a real DB/park path.
+            "topic": "Understanding Indonesian company registration timelines",
+            "brief_json": '{"article_summary": "some summary text here"}',
+        }
+
+    @pytest.mark.asyncio
+    async def test_monolith_engine_calls_process_one_monolith(self, monkeypatch):
+        monkeypatch.setenv("WR2_COMPOSE_ENGINE", "monolith")
+        called = {}
+
+        async def fake_monolith(conn, draft_id, topic, brief, summary, source_url, enrichment, live_reasons, liveness_tier):
+            called["engine"] = "monolith"
+            return "success"
+
+        async def fake_planner_writer(*args, **kwargs):
+            called["engine"] = "planner_writer"
+            return "success"
+
+        monkeypatch.setattr(dg, "_process_one_monolith", fake_monolith)
+        monkeypatch.setattr(dg, "_process_one_planner_writer", fake_planner_writer)
+
+        outcome = await dg._process_one(conn=None, row=self._row())
+        assert outcome == "success"
+        assert called["engine"] == "monolith"
+
+    @pytest.mark.asyncio
+    async def test_default_engine_calls_process_one_planner_writer(self, monkeypatch):
+        monkeypatch.delenv("WR2_COMPOSE_ENGINE", raising=False)
+        called = {}
+
+        async def fake_monolith(*args, **kwargs):
+            called["engine"] = "monolith"
+            return "success"
+
+        async def fake_planner_writer(conn, draft_id, topic, brief, summary, source_url, enrichment, live_reasons, liveness_tier):
+            called["engine"] = "planner_writer"
+            return "success"
+
+        monkeypatch.setattr(dg, "_process_one_monolith", fake_monolith)
+        monkeypatch.setattr(dg, "_process_one_planner_writer", fake_planner_writer)
+
+        outcome = await dg._process_one(conn=None, row=self._row())
+        assert outcome == "success"
+        assert called["engine"] == "planner_writer"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _generate_planner_writer_deck — happy path / repair / exhaustion
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGenerateDeckHappyPath:
+    def test_happy_path_no_repair_needed(self):
+        deck, meta = dg._generate_planner_writer_deck(
+            "BRIEF", "analitico", "breaking", [], _happy_planner_fn, _happy_writer_fn, [],
+        )
+        assert meta["pregate_verdict"] in ("PASS", "WARN")
+        assert meta["repair_rounds"] == 0
+        assert deck.arc == "news_alert"
+        assert deck.spine == "PMK 37/2025 changes the levy math for every PMA."
+        assert [s.kind for s in deck.slides] == ["cover", "fact_stack", "statement"]
+
+    def test_forbidden_phrases_threaded_into_writer_prompt(self):
+        seen_prompts = []
+
+        def spying_writer_fn(prompt: str) -> str:
+            seen_prompts.append(prompt)
+            return _happy_writer_fn(prompt)
+
+        dg._generate_planner_writer_deck(
+            "BRIEF", "analitico", "breaking", [], _happy_planner_fn, spying_writer_fn,
+            ["some banned phrase"],
+        )
+        assert any('"some banned phrase"' in p for p in seen_prompts)
+
+
+class TestGenerateDeckRepair:
+    def test_pregate_fail_then_repair_then_pass(self):
+        plan = (
+            '{"spine": "PMK 37/2025 changes the levy math for every PMA.", '
+            '"arc": "news_alert", "arc_reason": "Breaking regulation drop.", "slides": ['
+            '{"slot_id": 1, "role": "hook", "kind": "cover", "heading_intent": "the number", '
+            '"bullet_promise_n": null, "hero": true, "body": null}, '
+            '{"slot_id": 2, "role": "close", "kind": "statement", '
+            '"heading_intent": "The Bali Zero read", "bullet_promise_n": null, "hero": false, '
+            '"body": null}]}'
+        )
+
+        def planner_fn(prompt: str) -> str:
+            return plan
+
+        calls = {"n": 0}
+
+        def writer_fn(prompt: str) -> str:
+            calls["n"] += 1
+            if '"kind": "cover"' in prompt:
+                return '{"kind": "cover", "headline": "PMK 37 RAISES THE BAR", "subhead": "TAX"}'
+            # First attempt: closer shares ZERO fact-key tokens with the spine
+            # (no "PMK"/"37"/"2025") -> check_spine_echo FAILs. The repair round
+            # injects PREGATE FEEDBACK into the prompt; only THEN does the writer
+            # echo the spine's fact-key tokens.
+            if "PREGATE FEEDBACK" in prompt:
+                return '{"kind": "statement", "statement": "PMK 37/2025 changes everything now."}'
+            return '{"kind": "statement", "statement": "Read the fine print before you file anything."}'
+
+        deck, meta = dg._generate_planner_writer_deck(
+            "BRIEF", "analitico", "breaking", [], planner_fn, writer_fn, [],
+        )
+        assert meta["pregate_verdict"] == "PASS"
+        assert meta["repair_rounds"] == 1
+        assert calls["n"] == 3  # cover + closer(fail) + closer(repaired)
+        assert "PMK 37/2025" in deck.slides[-1].statement
+
+    def test_repair_targets_only_the_failing_slot(self):
+        # Same setup, but track WHICH slot_id gets a second write call — the
+        # cover slide must be written exactly once (it never fails any check
+        # here), the closer twice (fail then repair).
+        plan = (
+            '{"spine": "PMK 37/2025 changes the levy math for every PMA.", '
+            '"arc": "news_alert", "arc_reason": "r", "slides": ['
+            '{"slot_id": 1, "role": "hook", "kind": "cover", "heading_intent": "the number", '
+            '"bullet_promise_n": null, "hero": true, "body": null}, '
+            '{"slot_id": 2, "role": "close", "kind": "statement", '
+            '"heading_intent": "close", "bullet_promise_n": null, "hero": false, "body": null}]}'
+        )
+
+        def planner_fn(prompt: str) -> str:
+            return plan
+
+        cover_calls = {"n": 0}
+        closer_calls = {"n": 0}
+
+        def writer_fn(prompt: str) -> str:
+            if '"kind": "cover"' in prompt:
+                cover_calls["n"] += 1
+                return '{"kind": "cover", "headline": "H", "subhead": "S"}'
+            closer_calls["n"] += 1
+            if "PREGATE FEEDBACK" in prompt:
+                return '{"kind": "statement", "statement": "PMK 37/2025, read this now."}'
+            return '{"kind": "statement", "statement": "Totally unrelated punch line."}'
+
+        dg._generate_planner_writer_deck(
+            "BRIEF", "analitico", "breaking", [], planner_fn, writer_fn, [],
+        )
+        assert cover_calls["n"] == 1
+        assert closer_calls["n"] == 2
+
+
+class TestGenerateDeckRepairExhausted:
+    def test_repair_exhausted_raises_pregate_repair_exhausted(self):
+        plan = (
+            '{"spine": "PMK 37/2025 changes the levy math for every PMA.", '
+            '"arc": "news_alert", "arc_reason": "r", "slides": ['
+            '{"slot_id": 1, "role": "hook", "kind": "cover", "heading_intent": "the number", '
+            '"bullet_promise_n": null, "hero": true, "body": null}, '
+            '{"slot_id": 2, "role": "close", "kind": "statement", '
+            '"heading_intent": "close", "bullet_promise_n": null, "hero": false, "body": null}]}'
+        )
+
+        def planner_fn(prompt: str) -> str:
+            return plan
+
+        def writer_fn(prompt: str) -> str:
+            if '"kind": "cover"' in prompt:
+                return '{"kind": "cover", "headline": "H", "subhead": "S"}'
+            # NEVER echoes the spine, regardless of repair rounds.
+            return '{"kind": "statement", "statement": "Completely unrelated to the topic."}'
+
+        with pytest.raises(dg.PregateRepairExhausted) as excinfo:
+            dg._generate_planner_writer_deck(
+                "BRIEF", "analitico", "breaking", [], planner_fn, writer_fn, [],
+            )
+        assert excinfo.value.report.verdict == "FAIL"
+        assert any(c.check == "check_spine_echo" for c in excinfo.value.report.checks if c.verdict == "FAIL")
+
+    def test_never_ships_a_failing_deck(self):
+        # The exhaustion path must ALWAYS raise, never silently return a
+        # deck whose pregate verdict is FAIL. Spine MUST carry an
+        # extractable fact-key token (>=5 char content word / acronym /
+        # number) or check_spine_echo SKIPs instead of FAILing — mirrors
+        # the real-world spine shape (a regulation reference), not a
+        # degenerate fixture.
+        plan = (
+            '{"spine": "PMK 37/2025 changes the levy math for every PMA.", '
+            '"arc": "news_alert", "arc_reason": "r", "slides": ['
+            '{"slot_id": 1, "role": "hook", "kind": "cover", "heading_intent": "h", '
+            '"bullet_promise_n": null, "hero": true, "body": null}, '
+            '{"slot_id": 2, "role": "close", "kind": "statement", "heading_intent": "c", '
+            '"bullet_promise_n": null, "hero": false, "body": null}]}'
+        )
+
+        def planner_fn(prompt: str) -> str:
+            return plan
+
+        def writer_fn(prompt: str) -> str:
+            if '"kind": "cover"' in prompt:
+                return '{"kind": "cover", "headline": "H", "subhead": "S"}'
+            return '{"kind": "statement", "statement": "Nothing to do with the spine at all."}'
+
+        try:
+            dg._generate_planner_writer_deck("BRIEF", "analitico", None, [], planner_fn, writer_fn, [])
+            pytest.fail("expected PregateRepairExhausted, deck was returned instead")
+        except dg.PregateRepairExhausted:
+            pass
+
+
+class TestPlanLevelCloserSafetyFailFast:
+    def test_replans_when_closer_kind_is_unsafe(self):
+        # First plan attempt gives the closer an unsafe kind (fact_stack —
+        # not in _CLOSER_SAFE_KINDS); the SECOND plan attempt fixes it. This
+        # must re-plan (a fresh plan_deck call), never force a kind onto the
+        # planner's own choice.
+        plan_calls = {"n": 0}
+
+        def flaky_planner_fn(prompt: str) -> str:
+            plan_calls["n"] += 1
+            if plan_calls["n"] == 1:
+                return (
+                    '{"spine": "S.", "arc": "news_alert", "arc_reason": "r", "slides": ['
+                    '{"slot_id": 1, "role": "hook", "kind": "cover", "heading_intent": "h", '
+                    '"bullet_promise_n": null, "hero": true, "body": null}, '
+                    '{"slot_id": 2, "role": "close", "kind": "fact_stack", "heading_intent": "c", '
+                    '"bullet_promise_n": 2, "hero": false, "body": null}]}'
+                )
+            return (
+                '{"spine": "S.", "arc": "news_alert", "arc_reason": "r", "slides": ['
+                '{"slot_id": 1, "role": "hook", "kind": "cover", "heading_intent": "h", '
+                '"bullet_promise_n": null, "hero": true, "body": null}, '
+                '{"slot_id": 2, "role": "close", "kind": "statement", "heading_intent": "c", '
+                '"bullet_promise_n": null, "hero": false, "body": null}]}'
+            )
+
+        def writer_fn(prompt: str) -> str:
+            if '"kind": "cover"' in prompt:
+                return '{"kind": "cover", "headline": "H", "subhead": "S"}'
+            return '{"kind": "statement", "statement": "S echoes S here now."}'
+
+        deck, meta = dg._generate_planner_writer_deck(
+            "BRIEF", "analitico", None, [], flaky_planner_fn, writer_fn, [],
+        )
+        assert plan_calls["n"] == 2
+        assert deck.slides[-1].kind == "statement"
+
+    def test_gives_up_after_max_plan_attempts_and_lets_pregate_catch_it(self):
+        # Every plan attempt keeps the unsafe kind — after max_plan_attempts
+        # the function proceeds anyway (never infinite-loops); the ensuing
+        # check_cta_presence FAIL is caught by the normal repair/exhaustion
+        # path, never silently accepted.
+        def stubborn_planner_fn(prompt: str) -> str:
+            return (
+                '{"spine": "S.", "arc": "news_alert", "arc_reason": "r", "slides": ['
+                '{"slot_id": 1, "role": "hook", "kind": "cover", "heading_intent": "h", '
+                '"bullet_promise_n": null, "hero": true, "body": null}, '
+                '{"slot_id": 2, "role": "close", "kind": "fact_stack", "heading_intent": "c", '
+                '"bullet_promise_n": 2, "hero": false, "body": null}]}'
+            )
+
+        def writer_fn(prompt: str) -> str:
+            if '"kind": "cover"' in prompt:
+                return '{"kind": "cover", "headline": "H", "subhead": "S"}'
+            return '{"kind": "fact_stack", "heading": "S", "facts": ["S one", "S two"]}'
+
+        with pytest.raises(dg.PregateRepairExhausted) as excinfo:
+            dg._generate_planner_writer_deck(
+                "BRIEF", "analitico", None, [], stubborn_planner_fn, writer_fn, [],
+                max_plan_attempts=2,
+            )
+        assert any(c.check == "check_cta_presence" for c in excinfo.value.report.checks if c.verdict == "FAIL")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _pregate_fail_reasons_by_slot / _pregate_failing_slot_ids
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPregateFailReasonMapping:
+    def _deck(self) -> ir.SlideDeck:
+        return ir.SlideDeck.model_validate({
+            "register": "analitico",
+            "spine": "PMK 37/2025 changes the levy math.",
+            "arc": "news_alert",
+            "slides": [
+                {"kind": "cover", "headline": "PMK 37 RAISES THE BAR", "subhead": "TAX"},
+                {"kind": "fact_stack", "heading": "THE NUMBERS", "facts": ["a", "b", "c"]},
+                {"kind": "fact_stack", "heading": "THE NUMBERS", "facts": ["a", "b", "c"]},
+            ],
+        })
+
+    def test_maps_fail_reasons_to_slot_ids(self):
+        report = pregate.pregate_typed(self._deck(), spine="PMK 37/2025 changes the levy math.")
+        assert report.verdict == "FAIL"
+        ids = dg._pregate_failing_slot_ids(report)
+        # Slide 3 is the closer (fails check_cta_presence + check_spine_echo +
+        # shares its kicker with slide 2); slide 2 shares the kicker with 3.
+        assert 3 in ids
+        assert 2 in ids
+
+    def test_never_names_a_passing_check(self):
+        report = pregate.pregate_typed(self._deck(), spine="PMK 37/2025 changes the levy math.")
+        reasons_by_slot = dg._pregate_fail_reasons_by_slot(report)
+        for reasons in reasons_by_slot.values():
+            for reason in reasons:
+                check_name = reason.split(":", 1)[0]
+                matching = [c for c in report.checks if c.check == check_name]
+                assert matching and matching[0].verdict == "FAIL"
+
+    def test_pass_verdict_yields_empty_mapping(self):
+        deck = ir.SlideDeck.model_validate({
+            "register": "analitico",
+            "spine": "PMK 37/2025 changes the levy math for every PMA.",
+            "arc": "news_alert",
+            "slides": [
+                {"kind": "cover", "headline": "PMK 37 RAISES THE BAR", "subhead": "TAX"},
+                {"kind": "statement", "statement": "PMK 37/2025 changes everything, read the fine print."},
+            ],
+        })
+        report = pregate.pregate_typed(deck, spine=deck.spine)
+        assert report.verdict != "FAIL"
+        assert dg._pregate_failing_slot_ids(report) == set()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Guard adapters — guilt + innocence
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestClosestWordCountTypedAdapter:
+    def test_reads_statement_field(self):
+        slides = [{}, {"statement": "one two three"}]
+        assert dg._closer_word_count_typed(slides) == 3
+
+    def test_reads_invite_field_when_no_statement(self):
+        slides = [{}, {"invite": "if your case touches this a call confirms next steps"}]
+        assert dg._closer_word_count_typed(slides) == 10
+
+    def test_statement_takes_precedence_over_invite(self):
+        slides = [{}, {"statement": "one two", "invite": "one two three four five"}]
+        assert dg._closer_word_count_typed(slides) == 2
+
+    def test_empty_list_is_zero(self):
+        assert dg._closer_word_count_typed([]) == 0
+
+    def test_short_closer_not_flagged(self):
+        slides = [{}, {"statement": "Bali doesn't wait. Neither should you."}]
+        assert not dg._closer_too_long_typed(slides)
+
+    def test_long_closer_flagged(self):
+        long_statement = " ".join(f"word{i}" for i in range(dg.CLOSER_MAX_WORDS + 3))
+        slides = [{}, {"statement": long_statement}]
+        assert dg._closer_too_long_typed(slides)
+
+
+class TestKickerCollisionTypedAdapter:
+    def test_guilt_take_label_collides_with_recent(self):
+        slides = [{}, {"layout_family": "evidence-carved", "take_label": "THE SIGNAL"}]
+        hit = dg._kicker_collision_typed(slides, ["THE SIGNAL"])
+        assert hit == "THE SIGNAL"
+
+    def test_innocence_no_recent_kickers(self):
+        slides = [{}, {"take_label": "THE SIGNAL"}]
+        assert dg._kicker_collision_typed(slides, []) is None
+
+    def test_innocence_substring_does_not_collide(self):
+        # scar family #3: "TAKEAWAY FOR SELLERS" must NOT match "TAKE".
+        slides = [{}, {"take_label": "TAKEAWAY FOR SELLERS"}]
+        assert dg._kicker_collision_typed(slides, ["TAKE"]) is None
+
+    def test_innocence_no_take_label_field(self):
+        slides = [{}, {"layout_family": "statement-bomb", "statement": "no kicker here"}]
+        assert dg._kicker_collision_typed(slides, ["THE SIGNAL"]) is None
+
+    def test_whole_string_normalization_still_collides(self):
+        slides = [{}, {"take_label": "the signal:"}]
+        assert dg._kicker_collision_typed(slides, ["THE SIGNAL"]) == "the signal:"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _build_brief_ctx — facts-first composition
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildBriefCtx:
+    def test_article_summary_leads_when_both_present(self):
+        ctx = dg._build_brief_ctx(
+            topic="Deportation case", summary="A concrete deportation event happened yesterday.",
+            source_url="https://example.com", enrichment={"the_facts": "Some enriched facts here."},
+            live_reasons=[], liveness_tier="breaking",
+        )
+        source_idx = ctx.find("Source article")
+        support_idx = ctx.find("Supporting brief")
+        assert source_idx != -1 and support_idx != -1
+        assert source_idx < support_idx
+        assert "A concrete deportation event happened yesterday." in ctx
+
+    def test_liveness_framing_injected_for_breaking(self):
+        ctx = dg._build_brief_ctx(
+            topic="T", summary="S", source_url="", enrichment=None, live_reasons=[],
+            liveness_tier="breaking",
+        )
+        assert "BREAKING" in ctx
+
+    def test_no_framing_for_unknown_tier(self):
+        ctx = dg._build_brief_ctx(
+            topic="T", summary="S", source_url="", enrichment=None, live_reasons=[],
+            liveness_tier="",
+        )
+        assert "EDITORIAL CONTEXT" not in ctx
+
+    def test_falls_back_to_summary_only_when_no_enrichment(self):
+        ctx = dg._build_brief_ctx(
+            topic="T", summary="Just the summary text.", source_url="", enrichment=None,
+            live_reasons=[], liveness_tier="",
+        )
+        assert "Just the summary text." in ctx
+        assert "Supporting brief" not in ctx
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _pick_register_for_planner_writer
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPickRegister:
+    def test_breaking_picks_a_preferred_tone(self):
+        register = dg._pick_register_for_planner_writer("breaking", [])
+        assert register in dg._TONE_PREFERENCE["breaking"]
+
+    def test_avoids_most_recently_used_preferred_tone(self):
+        prefs = dg._TONE_PREFERENCE["breaking"]
+        register = dg._pick_register_for_planner_writer("breaking", [prefs[0]])
+        assert register == prefs[1]
+
+    def test_unknown_tier_falls_back_to_full_valid_tones(self):
+        register = dg._pick_register_for_planner_writer("", [])
+        assert register in dg.VALID_TONES
+
+    def test_always_returns_a_valid_tone(self):
+        for tier in ("breaking", "developing", "evergreen", ""):
+            assert dg._pick_register_for_planner_writer(tier, []) in dg.VALID_TONES
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _load_forbidden_phrases_for_writer — real file + fail-open
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestForbiddenPhrasesLoader:
+    def test_loads_real_constitution_nonempty(self):
+        phrases = dg._load_forbidden_phrases_for_writer()
+        assert isinstance(phrases, list)
+        assert len(phrases) > 0
+
+    def test_fail_open_on_missing_file(self, tmp_path):
+        missing = tmp_path / "does_not_exist.md"
+        phrases = dg._load_forbidden_phrases_for_writer(missing)
+        assert phrases == []
+
+    def test_fail_open_on_file_with_no_article_7(self, tmp_path):
+        p = tmp_path / "constitution.md"
+        p.write_text("# Some doc\n\n## Article 1 — Nothing relevant\n\nblah\n\n## Article 2 — Also nothing\n")
+        assert dg._load_forbidden_phrases_for_writer(p) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Persistence shape — every consumer in the map keeps working
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPersistenceShapeConsumerContract:
+    def _happy_deck(self) -> ir.SlideDeck:
+        deck, _meta = dg._generate_planner_writer_deck(
+            "BRIEF", "analitico", "breaking", [], _happy_planner_fn, _happy_writer_fn, [],
+        )
+        return deck
+
+    def test_projected_slides_are_plain_dicts_in_a_list(self):
+        deck = self._happy_deck()
+        projected = [ir.to_composer_dict(s, index=i, total=len(deck.slides)) for i, s in enumerate(deck.slides, start=1)]
+        assert isinstance(projected, list)
+        assert all(isinstance(s, dict) for s in projected)
+
+    def test_every_slide_has_an_explicit_renderable_layout_family(self):
+        # composer.map_slide_to_family honours an explicit `layout_family`
+        # pin before any auto-routing heuristic — the contract this whole
+        # cutover leans on to reach the 11 non-auto-reachable families.
+        deck = self._happy_deck()
+        projected = [ir.to_composer_dict(s, index=i, total=len(deck.slides)) for i, s in enumerate(deck.slides, start=1)]
+        for slide in projected:
+            assert slide.get("layout_family") in ir.SLIDE_KIND_TO_FAMILY.values()
+
+    def test_cover_slide_carries_is_cover_is_hero_and_image_prompt(self):
+        # wr2_html_render_apply._normalize_heroes reads is_hero_image (or
+        # falls back to index==1) + image_url/hero_image_path;
+        # generate_cover_image (the shared cron helper) reads
+        # projected[0]["image_prompt"].
+        deck = self._happy_deck()
+        cover = ir.to_composer_dict(deck.slides[0], index=1, total=len(deck.slides))
+        assert cover["is_cover"] is True
+        assert cover["is_hero_image"] is True
+        assert "image_prompt" in cover
+
+    def test_persisted_council_meta_carries_arc_spine_reason(self):
+        # fetch_recent_arcs reads council_debate_json->>'arc' — this is the
+        # ONLY place `arc` is persisted (no schema migration; the existing
+        # council_debate_json JSON column, least-invasive per the cutover
+        # mandate).
+        deck, meta = dg._generate_planner_writer_deck(
+            "BRIEF", "analitico", "breaking", [], _happy_planner_fn, _happy_writer_fn, [],
+        )
+        council_meta = {
+            "engine": "planner_writer",
+            "spine": deck.spine,
+            "arc": deck.arc,
+            "arc_reason": meta.get("arc_reason"),
+        }
+        assert council_meta["arc"] == "news_alert"
+        assert council_meta["spine"]
+        assert council_meta["arc_reason"]
+
+    def test_render_apply_take_label_hard_gate_sees_no_banned_vocabulary(self):
+        # wr2_html_render_apply._take_label_hard_gate_violations reads
+        # slide.get("take_label") on every slide — the writer's per-kind
+        # constitutional constraints block explicitly bans the same
+        # TAKE_LABEL_BANNED vocabulary composer.py enforces at render time.
+        # This is a SMOKE check the projected fact_stack slide's take_label
+        # (if any) is not literally one of the banned strings when the
+        # writer never used one (the happy-path fixture writer never sets
+        # take_label at all).
+        deck = self._happy_deck()
+        projected = [ir.to_composer_dict(s, index=i, total=len(deck.slides)) for i, s in enumerate(deck.slides, start=1)]
+        for slide in projected:
+            take_label = str(slide.get("take_label") or "").strip().upper()
+            assert take_label not in pw._TAKE_LABEL_BANNED
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# fetch_recent_arcs / fetch_recent_editorial_signatures — pure parsing
+# (via a fake asyncpg-shaped connection; no real DB)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _FakeRow(dict):
+    def __getitem__(self, key):
+        return dict.__getitem__(self, key)
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+
+    async def fetch(self, *args, **kwargs):
+        return [_FakeRow(r) for r in self._rows]
+
+
+class TestFetchRecentArcs:
+    @pytest.mark.asyncio
+    async def test_extracts_arc_from_council_debate_json(self):
+        conn = _FakeConn([
+            {"council_debate_json": '{"engine": "planner_writer", "arc": "news_alert"}'},
+            {"council_debate_json": '{"engine": "planner_writer", "arc": "myth_buster"}'},
+        ])
+        arcs = await dg.fetch_recent_arcs(conn, limit=8)
+        assert arcs == ["news_alert", "myth_buster"]
+
+    @pytest.mark.asyncio
+    async def test_monolith_rows_with_no_arc_key_contribute_nothing(self):
+        conn = _FakeConn([
+            {"council_debate_json": '{"register_reason": "some monolith row", "cover_url": null}'},
+        ])
+        arcs = await dg.fetch_recent_arcs(conn, limit=8)
+        assert arcs == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_row_isolated_others_survive(self):
+        conn = _FakeConn([
+            {"council_debate_json": "not json at all"},
+            {"council_debate_json": '{"arc": "deadline"}'},
+        ])
+        arcs = await dg.fetch_recent_arcs(conn, limit=8)
+        assert arcs == ["deadline"]
+
+    @pytest.mark.asyncio
+    async def test_cold_start_empty_list(self):
+        conn = _FakeConn([])
+        arcs = await dg.fetch_recent_arcs(conn, limit=8)
+        assert arcs == []
+
+    @pytest.mark.asyncio
+    async def test_connection_error_returns_empty_never_raises(self):
+        class BoomConn:
+            async def fetch(self, *args, **kwargs):
+                raise RuntimeError("connection lost")
+
+        arcs = await dg.fetch_recent_arcs(BoomConn(), limit=8)
+        assert arcs == []
+
+
+class TestFetchRecentEditorialSignaturesExtendedForTakeLabel:
+    @pytest.mark.asyncio
+    async def test_take_label_recognized_as_kicker_source(self):
+        conn = _FakeConn([
+            {"slides_json": '{"slides": [{"kind": "fact_stack", "layout_family": "evidence-carved", '
+             '"take_label": "THE PRECEDENT", "headline": "H"}]}'},
+        ])
+        sig = await dg.fetch_recent_editorial_signatures(conn, limit=10)
+        assert "THE PRECEDENT" in sig["kickers"]
+
+    @pytest.mark.asyncio
+    async def test_monolith_and_planner_writer_kickers_share_one_dedup_set(self):
+        conn = _FakeConn([
+            {"slides_json": '{"slides": [{"slide_type": "take", "headline": "THE SIGNAL: a headline"}]}'},
+            {"slides_json": '{"slides": [{"take_label": "THE SIGNAL"}]}'},
+        ])
+        sig = await dg.fetch_recent_editorial_signatures(conn, limit=10)
+        # Both rows normalize to the same kicker key — only the FIRST
+        # occurrence's casing survives (dedup, mirroring the existing
+        # kickers/subheads dedup discipline).
+        assert sig["kickers"].count("THE SIGNAL") + sum(1 for k in sig["kickers"] if k.upper() == "THE SIGNAL") >= 1
+        normalized = {dg._normalize_kicker(k) for k in sig["kickers"]}
+        assert dg._normalize_kicker("THE SIGNAL") in normalized
+        assert len([k for k in sig["kickers"] if dg._normalize_kicker(k) == dg._normalize_kicker("THE SIGNAL")]) == 1

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -34,7 +34,7 @@ import unicodedata
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "apps" / "backend-rag"))
@@ -44,8 +44,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import asyncpg  # noqa: E402
 
+import wr2_carousel_ir as ir  # noqa: E402  (Phase 1 — typed Carousel IR, pure/zero-I/O)
+import wr2_editorial_pregate as pregate  # noqa: E402  (Phase 2 — deterministic pre-gate, pure/zero-I/O)
 import wr2_grounding as wg  # noqa: E402  (pure, side-effect-free: is_citations_only_the_facts SSOT)
 import wr2_orchestrator_metrics as wom  # noqa: E402  (B11: per-step observability, fail-open)
+import wr2_planner_writer as pw  # noqa: E402  (Phase 3 — planner/writer split, pure/zero-I/O)
 import wr2_topic_type as tt  # noqa: E402  (pure, side-effect-free)
 from backend.llm.claude_oauth_client import (  # noqa: E402
     ClaudeOAuthError,
@@ -56,6 +59,33 @@ from backend.llm.claude_oauth_client import (  # noqa: E402
 logger = logging.getLogger("wr2.draft_generator")
 
 MAX_DRAFTS_PER_RUN = 2
+
+# ── Engine kill-switch (production cutover, 2026-07-21) ────────────────────
+# `planner_writer` = the new plan->write->pregate(+repair) engine (Phases
+# 1-3, spec `.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-
+# design.md` §3 rollout step 3: "poi cutover"). `monolith` = the ORIGINAL
+# single-`claude_compose_slides`-call path — every line below this comment
+# through `_process_one_monolith`'s body is BYTE-IDENTICAL to what
+# `_process_one` was before this cutover (a pure rename + the shared
+# brief-parsing/park-check hoisted into the new thin `_process_one`
+# dispatcher) — instant rollback via `WR2_COMPOSE_ENGINE=monolith`, no code
+# change, no redeploy of a different commit. Any value other than the two
+# recognized ones falls back to `planner_writer` (the new default) with a
+# WARN log, never to a silent no-op.
+WR2_COMPOSE_ENGINE_MONOLITH = "monolith"
+WR2_COMPOSE_ENGINE_PLANNER_WRITER = "planner_writer"
+_VALID_COMPOSE_ENGINES = {WR2_COMPOSE_ENGINE_MONOLITH, WR2_COMPOSE_ENGINE_PLANNER_WRITER}
+
+
+def _resolve_compose_engine() -> str:
+    raw = os.environ.get("WR2_COMPOSE_ENGINE", WR2_COMPOSE_ENGINE_PLANNER_WRITER).strip().lower()
+    if raw not in _VALID_COMPOSE_ENGINES:
+        logger.warning(
+            "WR2_COMPOSE_ENGINE=%r not recognized (valid: %s) — falling back to %r",
+            raw, sorted(_VALID_COMPOSE_ENGINES), WR2_COMPOSE_ENGINE_PLANNER_WRITER,
+        )
+        return WR2_COMPOSE_ENGINE_PLANNER_WRITER
+    return raw
 VALID_TONES = {
     "rituale",
     "analitico",
@@ -1613,6 +1643,25 @@ async def fetch_recent_editorial_signatures(
                         if key not in kickers_seen:
                             kickers_seen.add(key)
                             kickers.append(kicker)
+                # planner_writer engine (production cutover, 2026-07-21):
+                # a fact_stack slide's take_label (wr2_carousel_ir.to_
+                # composer_dict projects it verbatim, evidence-carved
+                # family) is the shape-equivalent of the monolith's
+                # slide_type=="take" kicker — a short editorial tag, same
+                # collision/variety semantics, different field name because
+                # the two engines never share a slide_type vocabulary.
+                # Extracted unconditionally (not gated on layout_family, so
+                # a manual/interactive-path evidence-carved slide with a
+                # take_label is picked up too) via the SAME whole-string
+                # `_normalize_kicker` dedup key as the monolith branch above
+                # — the two sources share one seen-set so a kicker used by
+                # EITHER engine is never suggested again by either.
+                take_label = str(slide.get("take_label") or "").strip()
+                if take_label:
+                    key = _normalize_kicker(take_label)
+                    if key not in kickers_seen:
+                        kickers_seen.add(key)
+                        kickers.append(take_label)
                 if slide.get("is_cover"):
                     subhead = str(slide.get("subhead") or "").strip()
                     if subhead:
@@ -1625,6 +1674,59 @@ async def fetch_recent_editorial_signatures(
             continue
 
     return {"kickers": kickers, "subheads": subheads}
+
+
+async def fetch_recent_arcs(conn: asyncpg.Connection, limit: int = 8) -> list[str]:
+    """Last-N rendered/published drafts' chosen `arc` (planner_writer engine
+    only — a monolith-composed draft's `council_debate_json` has no `arc`
+    key at all, so it is silently absent here, never a malformed row: cold
+    start is the expected, honest state until enough planner_writer decks
+    have rendered), newest-first — mirrors `fetch_recent_editorial_
+    signatures`'s own query shape/error discipline exactly (same table,
+    same best-effort-empty-on-connection-error contract, same per-row
+    isolation so one malformed `council_debate_json` blob never zeroes the
+    whole lookback).
+
+    Read from `council_debate_json` (NOT `slides_json`, NOT a new column —
+    production cutover GROUND: 'brief_json or a sensible existing JSON
+    column — least-invasive; NO schema migration'). `council_debate_json`
+    already exists and is written unconditionally by `_persist_ready` for
+    EVERY draft, monolith or planner_writer — `_process_one_planner_writer`
+    below adds `arc`/`arc_reason`/`spine` keys to that same dict; a
+    monolith row's dict simply never had them, so `.get("arc")` is None and
+    the row contributes nothing, exactly like cold-start.
+    """
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT council_debate_json
+              FROM war_room_drafts
+             WHERE status IN ('rendered', 'published')
+               AND council_debate_json IS NOT NULL
+             ORDER BY created_at DESC
+             LIMIT $1
+            """,
+            limit,
+        )
+    except Exception as exc:  # noqa: BLE001 — connection-level, never block generation
+        logger.warning("fetch_recent_arcs failed: %s", exc)
+        return []
+
+    arcs: list[str] = []
+    for row in rows:
+        try:
+            blob = row["council_debate_json"]
+            if isinstance(blob, str):
+                blob = json.loads(blob)
+            if not isinstance(blob, dict):
+                continue
+            arc = blob.get("arc")
+            if isinstance(arc, str) and arc.strip():
+                arcs.append(arc.strip())
+        except Exception as exc:  # noqa: BLE001 — isolate one bad row, keep the rest
+            logger.debug("fetch_recent_arcs: skipping malformed row: %s", exc)
+            continue
+    return arcs
 
 
 _VARIETY_STEER_KICKER_CAP = 12
@@ -1746,7 +1848,483 @@ async def _mark_parked(
 _ProcessOutcome = Literal["success", "parked", "failed"]
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# planner_writer engine wiring (production cutover, 2026-07-21)
+#
+# The engine pieces themselves (wr2_carousel_ir / wr2_editorial_pregate /
+# wr2_planner_writer, imported as `ir`/`pregate`/`pw` above) stay pure and
+# zero-I/O by design (their own module docstrings). Everything below is the
+# I/O-bearing, async-bridging, DB-touching WIRING that makes them live —
+# kept entirely in THIS file so none of the three sibling modules had to
+# change its own zero-I/O invariant to get wired into production.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class PregateRepairExhausted(RuntimeError):
+    """Raised by `_generate_planner_writer_deck` when the deterministic
+    pre-gate (`wr2_editorial_pregate.pregate_typed`) still returns FAIL
+    after every repair round is spent. The caller (`_process_one_planner_
+    writer`) catches this and PARKS the draft — same B2 facts-first park
+    backstop philosophy the monolith path already uses: never ship a
+    failing deck, never silently degrade a slide's locked kind to force a
+    pass."""
+
+    def __init__(self, message: str, *, report: "pregate.PregateReport", plan: "ir.DeckPlan"):
+        super().__init__(message)
+        self.report = report
+        self.plan = plan
+
+
+# The closer (last slot) MUST be a kind the pregate's own check_cta_presence
+# already accepts as a valid ending (cta-kind slide, or a closer whose kind
+# is "statement") — every other kind maps to a family with no CTA/closing
+# semantics (Art 9.5 hard rule: the last slide is the carousel's close).
+# Enforced here as a cheap PLAN-level fail-fast (before spending N writer
+# calls on a deck that can never pass check_cta_presence): a plan whose
+# closer kind sits outside this set gets ONE re-plan attempt, never a
+# forced kind (chi propone != chi dispone still holds — this only asks the
+# planner to try again, it never picks the kind FOR it).
+_CLOSER_SAFE_KINDS = frozenset({"cta", "statement"})
+
+_SLIDE_REF_RE = re.compile(r"\bslide (\d+)\b")
+
+
+def _pregate_fail_reasons_by_slot(report: "pregate.PregateReport") -> dict[int, list[str]]:
+    """Map every FAILing check's reason strings back to the slot_id(s) they
+    name ("slide N" — every check_* function in wr2_editorial_pregate.py
+    names the offending slide index in its reason text this way; verified
+    against that module's own source for check_duplicate_slides/
+    check_bullet_promise/check_caps_policy/check_cta_presence/
+    check_kicker_unique/check_spine_echo). A check whose reason names TWO
+    slides (check_duplicate_slides: "slide i vs slide j") maps to BOTH —
+    repairing either one alone cannot resolve a near-duplicate pair."""
+    out: dict[int, list[str]] = {}
+    for check in report.checks:
+        if check.verdict != "FAIL":
+            continue
+        for reason in check.reasons:
+            for m in _SLIDE_REF_RE.finditer(reason):
+                sid = int(m.group(1))
+                out.setdefault(sid, []).append(f"{check.check}: {reason}")
+    return out
+
+
+def _pregate_failing_slot_ids(report: "pregate.PregateReport") -> set[int]:
+    return set(_pregate_fail_reasons_by_slot(report))
+
+
+# ── Constitutional constraints loader (GROUND-4) ────────────────────────────
+# Mirrors scripts/wr2_html_renderer/composer.py's `_load_forbidden_phrases`
+# (same repo-first path resolution, same Article 7 section-heading parse) —
+# DUPLICATED, not imported: composer.py pulls in `.renderer` (Playwright),
+# and this cron entry deliberately avoids that whole import chain (same
+# rationale as the BRAND_SUFFIX/inline-4-layer-prompt-builder comment
+# above). UNLIKE composer.py's own fail-CLOSED policy (composer.py is the
+# actual render-time enforcement point — it must refuse to render without
+# the list), this loader is fail-OPEN: it only feeds the writer PROMPT with
+# advisory guidance to cut retry churn. The real hard gate still lives in
+# composer.py regardless of whether this loader succeeds, so a missing/
+# unparseable constitution.md here degrades prompt quality, never safety.
+_REPO_ROOT_FOR_CONSTITUTION = Path(__file__).resolve().parent.parent
+_CONSTITUTION_PATH_FOR_WRITER = _REPO_ROOT_FOR_CONSTITUTION / "skills" / "bali-zero-brand" / "constitution.md"
+_ARTICLE_7_RE = re.compile(r"## Article 7 — Forbidden phrases \(closed list\)(.*?)(?=\n## )", re.DOTALL)
+
+
+def _load_forbidden_phrases_for_writer(path: Path | None = None) -> list[str]:
+    p = path or _CONSTITUTION_PATH_FOR_WRITER
+    try:
+        text = p.read_text(encoding="utf-8")
+        m = _ARTICLE_7_RE.search(text)
+        if not m:
+            logger.warning("Article 7 section not found in %s — writer prompts get no phrase list", p)
+            return []
+        phrases = re.findall(r"`([^`]+)`", m.group(1))
+        if not phrases:
+            logger.warning("Article 7 section in %s parsed but yielded zero phrases", p)
+        return phrases
+    except OSError as exc:
+        logger.warning(
+            "constitution.md unreadable at %s (%s) — writer prompts proceed with no phrase list; "
+            "the render-time Article 7 gate in composer.py is unaffected and still enforces",
+            p, exc,
+        )
+        return []
+
+
+# ── brief_ctx builder (GROUND: "build brief_ctx exactly as today") ─────────
+def _build_brief_ctx(
+    topic: str,
+    summary: str,
+    source_url: str,
+    enrichment: dict[str, Any] | None,
+    live_reasons: list[Any],
+    liveness_tier: str,
+) -> str:
+    """The planner_writer engine's brief context — reuses the EXACT same
+    facts-first composition `_build_draft_prompt` already does for the
+    monolith (B1, 2026-07-17: article summary LEADS, enriched brief
+    SUPPORTS — never the reverse) plus the A1 liveness framing line, minus
+    the SYSTEM_INSTRUCTIONS/schema/kicker-example scaffolding that belongs
+    to the monolith's single-call prompt shape specifically (the planner
+    and writer stages build their OWN prompts around this brief_ctx, in
+    `wr2_planner_writer._build_planner_prompt`/`_build_writer_prompt`).
+    A DELIBERATE small duplication of `_build_draft_prompt`'s body-assembly
+    logic (not a call into it) so the monolith's prompt function stays
+    completely untouched — touching it would risk the kill-switch's
+    'monolith path preserved verbatim' guarantee."""
+    use_full_enriched = os.environ.get("WR2_USE_FULL_ENRICHED_PROMPT", "true").lower() == "true"
+    enriched_body = ""
+    if use_full_enriched and enrichment:
+        enriched_body = _build_enriched_brief(enrichment, live_reasons)
+
+    facts_first = bool(summary and summary.strip()) and bool(enriched_body)
+    if facts_first:
+        body = (
+            "### Source article (the real event — ground who/what/when in this)\n"
+            f"{summary[:3500]}\n\n"
+            "### Supporting brief (citations, editorial take, practice notes — "
+            "background only, never a substitute for the article above)\n"
+            f"{enriched_body}"
+        )
+    elif enriched_body:
+        body = enriched_body
+    else:
+        body = summary[:3500]
+
+    framing = _LIVENESS_FRAMING.get(liveness_tier, "")
+    header = f"Title: {topic}\n\nSource: {source_url or 'n/a'}\n"
+    if framing:
+        header = f"{framing}\n\n{header}"
+    return f"{header}\nContent:\n{body}"
+
+
+# ── register selection (Mossa B keeps DeckPlan register-free by design) ────
+def _pick_register_for_planner_writer(liveness_tier: str, recent_registers: list[str]) -> str:
+    """DeckPlan is deliberately register-free (spec §2 Mossa B: 'zero-prose,
+    no voice-register field' — register comes from 'the same upstream
+    source production already resolves it from today'). For a historical
+    replay that source is a persisted value; for a FRESH draft there is
+    none to read, so this reuses the existing A3 tier-preference heuristic
+    (`_TONE_PREFERENCE`) as a firm deterministic pick instead of a soft LLM
+    nudge — favouring whichever of the tier's preferred tones was NOT most
+    recently used in this domain (anti-sameness), falling back to the full
+    VALID_TONES set for an unknown/manual tier. This is a DELIBERATE
+    simplification versus the monolith (which lets Claude pick register
+    from full content judgment in the same call) — flagged, not hidden;
+    see the cutover PR description for the follow-up option (a dedicated
+    tiny register field on a future DeckPlan revision, Zero-gated since it
+    touches the ratified spec's 'zero-prose' Mossa-B contract)."""
+    prefs = _TONE_PREFERENCE.get(liveness_tier) or tuple(sorted(VALID_TONES))
+    for candidate in prefs:
+        if candidate not in recent_registers:
+            return candidate
+    return prefs[0]
+
+
+# ── guard adapters (accessor keys differ: to_composer_dict projections have
+#    no slide_type/tonal_palette/image_mode; kicker lives in take_label, not
+#    a colon-prefixed headline) ──────────────────────────────────────────────
+def _closer_word_count_typed(projected_slides: list[dict[str, Any]]) -> int:
+    """Adapter for `_closer_too_long`'s CLOSER_MAX_WORDS guard on a
+    `to_composer_dict`-projected deck. The monolith's `_closer_word_count`
+    reads only `.get("body")` (its closer is always a statement-bomb-shaped
+    flat dict with body text); the new engine's closer can be kind="cta"
+    (elegant-close, its punch line is `invite`) or kind="statement"
+    (statement-bomb, `statement`) — mirrors composer._slide_body_word_count's
+    OWN statement/headline/body precedence, extended with `invite` for the
+    one kind that field precedence does not cover."""
+    if not projected_slides:
+        return 0
+    last = projected_slides[-1]
+    text = last.get("statement") or last.get("invite") or last.get("headline") or last.get("body") or ""
+    return len(str(text).split())
+
+
+def _closer_too_long_typed(projected_slides: list[dict[str, Any]]) -> bool:
+    return _closer_word_count_typed(projected_slides) > CLOSER_MAX_WORDS
+
+
+def _kicker_collision_typed(
+    projected_slides: list[dict[str, Any]], recent_kickers: list[str]
+) -> str | None:
+    """Adapter for `_kicker_collision`: the monolith sources a kicker from a
+    `slide_type == "take"` slide's colon-prefixed headline; the new
+    engine's equivalent shape is a fact_stack slide's `take_label`
+    (evidence-carved family — see `fetch_recent_editorial_signatures`'s own
+    extension for the same field). Whole-string comparison only via the
+    SAME `_normalize_kicker`, never substring (scar family #3)."""
+    if not recent_kickers:
+        return None
+    recent_normalized = {_normalize_kicker(k) for k in recent_kickers if k}
+    if not recent_normalized:
+        return None
+    for slide in projected_slides:
+        take_label = str(slide.get("take_label") or "").strip()
+        if take_label and _normalize_kicker(take_label) in recent_normalized:
+            return take_label
+    return None
+
+
+# ── sync engine core (plan -> write -> pregate -> repair) ──────────────────
+def _generate_planner_writer_deck(
+    brief_ctx: str,
+    register: str,
+    liveness_tier: str,
+    recent_arcs: list[str],
+    planner_fn: "Callable[[str], str]",
+    writer_fn: "Callable[[str], str]",
+    forbidden_phrases: list[str],
+    *,
+    max_repair_rounds: int = 2,
+    max_plan_attempts: int = 2,
+) -> tuple["ir.SlideDeck", dict[str, Any]]:
+    """Pure(ish) sync core — no DB/network of its own beyond what
+    `planner_fn`/`writer_fn` do internally, exactly mirroring
+    `wr2_planner_writer`'s own call_fn-injection discipline so this
+    function is unit-testable with plain fakes (see
+    scripts/tests/test_wr2_draft_generator_planner_writer_cutover.py).
+
+    1. plan_deck, with ONE cheap re-plan attempt if the closer's kind isn't
+       in `_CLOSER_SAFE_KINDS` (fail-fast — the plan-level defect no amount
+       of slot repair could fix, since repair never changes a locked kind).
+    2. write_slot for every slot (sequential, per-kind constitutional
+       constraints threaded in).
+    3. pregate_typed the assembled deck; on FAIL, re-write ONLY the failing
+       slots (mapped from the FAIL reasons via `_pregate_fail_reasons_by_
+       slot`) up to `max_repair_rounds` times, re-pregating after each
+       round. Never degrades a slot's kind to force a pass.
+    4. Returns (deck, meta) on PASS/WARN. Raises `PregateRepairExhausted`
+       when still FAIL after every repair round — the caller parks.
+    """
+    plan: "ir.DeckPlan | None" = None
+    for plan_attempt in range(1, max_plan_attempts + 1):
+        candidate = pw.plan_deck(brief_ctx, liveness_tier, recent_arcs, planner_fn, max_retries=3)
+        plan = candidate
+        closer = max(candidate.slides, key=lambda s: s.slot_id)
+        if closer.kind in _CLOSER_SAFE_KINDS:
+            break
+        logger.warning(
+            "planner_writer: plan attempt %d/%d closer kind=%r not in %s — replanning",
+            plan_attempt, max_plan_attempts, closer.kind, sorted(_CLOSER_SAFE_KINDS),
+        )
+    assert plan is not None  # loop always assigns on the first iteration
+
+    logger.info(
+        "planner_writer: arc=%s arc_reason=%r spine=%r slides=%d",
+        plan.arc, plan.arc_reason[:120], plan.spine[:80], len(plan.slides),
+    )
+
+    ordered_slots = sorted(plan.slides, key=lambda s: s.slot_id)
+    slot_by_id = {s.slot_id: s for s in ordered_slots}
+    slides_by_id: dict[int, "ir.Slide"] = {}
+    for slot in ordered_slots:
+        sibling_intents = [s.heading_intent for s in ordered_slots if s.slot_id != slot.slot_id]
+        slides_by_id[slot.slot_id] = pw.write_slot(
+            brief_ctx, plan, slot, sibling_intents, writer_fn, max_retries=3,
+            forbidden_phrases=forbidden_phrases,
+        )
+
+    repair_rounds_used = 0
+    report: "pregate.PregateReport | None" = None
+    for round_idx in range(max_repair_rounds + 1):
+        deck = ir.SlideDeck(
+            register=register,
+            slides=[slides_by_id[sid] for sid in sorted(slides_by_id)],
+            spine=plan.spine,
+            arc=plan.arc,
+        )
+        report = pregate.pregate_typed(deck, spine=plan.spine)
+        logger.info(
+            "planner_writer: pregate round=%d verdict=%s checks=%s",
+            round_idx, report.verdict,
+            {c.check: c.verdict for c in report.checks},
+        )
+        if report.verdict != "FAIL":
+            return deck, {
+                "arc": plan.arc,
+                "arc_reason": plan.arc_reason,
+                "pregate_verdict": report.verdict,
+                "repair_rounds": repair_rounds_used,
+                "pregate_checks": [c.to_dict() for c in report.checks],
+            }
+        if round_idx == max_repair_rounds:
+            break
+        failing_ids = set(_pregate_fail_reasons_by_slot(report)) & set(slot_by_id)
+        if not failing_ids:
+            # A FAIL verdict whose reasons name no slide this deck actually
+            # has (should not happen given every FAIL check's reasons name
+            # an index) — nothing addressable to repair; stop retrying
+            # rather than loop uselessly, let the exhaustion path below
+            # park honestly.
+            break
+        repair_rounds_used += 1
+        reasons_by_slot = _pregate_fail_reasons_by_slot(report)
+        for sid in sorted(failing_ids):
+            slot = slot_by_id[sid]
+            note = "; ".join(reasons_by_slot.get(sid, []))
+            annotated_ctx = f"{brief_ctx}\n\nPREGATE FEEDBACK — fix this in your rewrite: {note}"
+            sibling_intents = [s.heading_intent for s in ordered_slots if s.slot_id != sid]
+            slides_by_id[sid] = pw.write_slot(
+                annotated_ctx, plan, slot, sibling_intents, writer_fn, max_retries=3,
+                forbidden_phrases=forbidden_phrases,
+            )
+            logger.info("planner_writer: repaired slot %d (round %d)", sid, repair_rounds_used)
+
+    assert report is not None
+    raise PregateRepairExhausted(
+        f"pregate still FAIL after {repair_rounds_used} repair round(s): "
+        f"{[c.to_dict() for c in report.checks if c.verdict == 'FAIL']}",
+        report=report,
+        plan=plan,
+    )
+
+
+# ── async->sync OAuth-CLI bridge (production wiring only, not unit-tested
+#    beyond a smoke import — asyncio.to_thread runs this in a worker thread
+#    that has NO running event loop of its own, so `asyncio.run()` inside it
+#    is legal; calling this directly from the `run()` event loop would raise
+#    "asyncio.run() cannot be called from a running event loop") ───────────
+def _make_sync_call_fn(model: str, *, timeout_s: int = 300, endpoint: str = "wr2_draft_generator") -> "Callable[[str], str]":
+    def _call(prompt: str) -> str:
+        async def _do() -> str:
+            resp = await complete_async(prompt, model=model, timeout_s=timeout_s, endpoint=endpoint)
+            return resp.text
+        return asyncio.run(_do())
+    return _call
+
+
+async def _process_one_planner_writer(
+    conn: asyncpg.Connection,
+    draft_id: uuid.UUID,
+    topic: str,
+    brief: dict[str, Any],
+    summary: str,
+    source_url: str,
+    enrichment: dict[str, Any] | None,
+    live_reasons: list[Any],
+    liveness_tier: str,
+) -> _ProcessOutcome:
+    """The new plan->write->pregate(+repair) engine — default path
+    (`WR2_COMPOSE_ENGINE=planner_writer` or unset)."""
+    prospective_domain = tt.derive_domain(topic)
+    recent = await fetch_recent_same_domain(conn, prospective_domain, limit=2)
+    recent_registers = [r.get("register") for r in recent if r.get("register")]
+    editorial_signatures = await fetch_recent_editorial_signatures(conn, limit=10)
+    recent_arcs = await fetch_recent_arcs(conn, limit=8)
+
+    brief_ctx = _build_brief_ctx(topic, summary, source_url, enrichment, live_reasons, liveness_tier)
+    register = _pick_register_for_planner_writer(liveness_tier, recent_registers)
+    forbidden_phrases = _load_forbidden_phrases_for_writer()
+
+    planner_fn = _make_sync_call_fn(pw.DEFAULT_PLANNER_MODEL)
+    writer_fn = _make_sync_call_fn(pw.DEFAULT_WRITER_MODEL)
+
+    logger.info(
+        "Draft %s planner_writer: register=%s liveness_tier=%s recent_arcs=%s forbidden_phrases=%d",
+        draft_id, register, liveness_tier or "(none)", recent_arcs, len(forbidden_phrases),
+    )
+
+    try:
+        deck, meta = await asyncio.to_thread(
+            _generate_planner_writer_deck,
+            brief_ctx, register, liveness_tier, recent_arcs,
+            planner_fn, writer_fn, forbidden_phrases,
+        )
+    except (pw.PlanValidationExhausted, pw.SlotWriteExhausted) as e:
+        logger.error("Draft %s planner_writer generation exhausted: %s", draft_id, e)
+        await _mark_rejected(conn, draft_id, f"planner_writer_exhausted: {e}")
+        return "failed"
+    except PregateRepairExhausted as e:
+        reason = f"planner_writer pregate FAIL after repair: {str(e)[:800]}"
+        logger.warning("Draft %s parked: %s", draft_id, reason)
+        await _mark_parked(conn, draft_id, reason)
+        return "parked"
+    except (ClaudeOAuthError, ClaudeOAuthNotAvailable) as e:
+        logger.error("Draft %s planner_writer Claude OAuth failed: %s", draft_id, e)
+        await _mark_rejected(conn, draft_id, f"claude_failed: {e}")
+        _send_telegram(f"WR2 draft_generator (planner_writer) Claude failed\ndraft {draft_id}\n{str(e)[:200]}")
+        return "failed"
+
+    projected = [
+        ir.to_composer_dict(slide, index=i, total=len(deck.slides))
+        for i, slide in enumerate(deck.slides, start=1)
+    ]
+
+    # Existing guards, adapted (accessor keys differ — see the _typed
+    # adapter docstrings above). WARN-only, exactly like the monolith path:
+    # Legge 5 (human review at the queue gate) is the backstop, never a
+    # hard reject here.
+    if _closer_too_long_typed(projected):
+        logger.warning(
+            "Draft %s (planner_writer) closer too long (%d words > %d) — WARN only, "
+            "Legge 5 backstop at the review gate.",
+            draft_id, _closer_word_count_typed(projected), CLOSER_MAX_WORDS,
+        )
+    collision_kicker = _kicker_collision_typed(projected, editorial_signatures.get("kickers") or [])
+    if collision_kicker:
+        logger.warning(
+            "Draft %s (planner_writer) take_label kicker collision (%r already used) — "
+            "WARN only, Legge 5 backstop at the review gate.",
+            draft_id, collision_kicker,
+        )
+
+    cover_scene = projected[0].get("image_prompt") or topic
+    cover_url, cover_err = await generate_cover_image(scene_core=cover_scene, draft_id=str(draft_id))
+    if cover_url:
+        projected[0]["image_url"] = cover_url
+    else:
+        logger.warning("Cover failed: %s", cover_err)
+        projected[0]["image_url"] = None
+        projected[0]["image_prompt_fallback"] = True
+
+    council_meta = {
+        "engine": WR2_COMPOSE_ENGINE_PLANNER_WRITER,
+        "register_reason": (
+            f"deterministic A3 tier-preference pick (planner_writer engine, liveness_tier="
+            f"{liveness_tier or 'unknown'!r}, recent_registers_avoided={recent_registers})"
+        ),
+        "spine": deck.spine,
+        "arc": deck.arc,
+        "arc_reason": meta.get("arc_reason"),
+        "pregate_verdict": meta.get("pregate_verdict"),
+        "pregate_repair_rounds": meta.get("repair_rounds"),
+        "cover_url": cover_url,
+        "cover_error": cover_err,
+        "composed_at": datetime.now(timezone.utc).isoformat(),
+        "liveness_tier": liveness_tier or None,
+        "slide_count": len(projected),
+    }
+    await _persist_ready(conn, draft_id, register, projected, council_meta)
+    logger.info(
+        "Draft %s → status=drafts (engine=planner_writer, arc=%s, pregate=%s, repair_rounds=%s)",
+        draft_id, deck.arc, meta.get("pregate_verdict"), meta.get("repair_rounds"),
+    )
+
+    cover_status = "OK" if cover_url else f"FAILED: {(cover_err or '')[:60]}"
+    body_count = len(projected) - 1
+    _send_telegram(
+        "WR2 draft pronto per Canva (planner_writer)\n"
+        f"Topic: {topic[:120]}\n"
+        f"Register: {register} · Arc: {deck.arc}\n"
+        f"Cover: {cover_status}\n"
+        f"Slide body ({body_count}): prompt inline, da generare a mano\n"
+        f"Draft: {draft_id}\n"
+        "Canva Renderer ogni 5 min",
+    )
+    return "success"
+
+
 async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> _ProcessOutcome:
+    """Thin dispatcher (production cutover, 2026-07-21): parses the row +
+    runs the SHARED B2 park backstop ONCE (both engines must never invent a
+    story for a news-shaped topic with no usable source — that check does
+    not belong to either engine specifically), then routes to
+    `_process_one_monolith` (the ORIGINAL single-call path, byte-identical
+    body to what lived directly in this function before the cutover) or
+    `_process_one_planner_writer` (the new plan->write->pregate engine) per
+    `WR2_COMPOSE_ENGINE` (`_resolve_compose_engine`, default
+    `planner_writer`; `monolith` = instant rollback, no redeploy of a
+    different commit)."""
     draft_id: uuid.UUID = row["id"]
     topic: str = row["topic"]
     brief_raw = row["brief_json"]
@@ -1764,18 +2342,20 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> _Proces
     # A1 keystone: the selector already put this in brief_json — read it (was dropped).
     liveness_tier = _normalise_liveness_tier(brief.get("liveness_tier"))
 
+    engine = _resolve_compose_engine()
     logger.info(
-        "─── processing draft %s ─── topic=%r enrichment=%s live_score=%s liveness_tier=%s",
+        "─── processing draft %s ─── topic=%r enrichment=%s live_score=%s liveness_tier=%s engine=%s",
         draft_id, topic[:80],
         bool(enrichment), brief.get("live_news_score"),
-        liveness_tier or "(none)",
+        liveness_tier or "(none)", engine,
     )
 
     # ── B2 refuse-to-guess backstop (park, never draft) ────────────────────
-    # Checked BEFORE any Claude call: a news-shaped draft with no usable source
-    # anywhere (empty article_summary AND enrichment that's citations-only) has
-    # nothing for B1's facts-first fix to lead with — composing would mean
-    # inventing the story (the 2026-07-16 failure, draft 1229c367). Park it.
+    # Checked BEFORE any Claude call, SHARED by both engines: a news-shaped
+    # draft with no usable source anywhere (empty article_summary AND
+    # enrichment that's citations-only) has nothing for B1's facts-first fix
+    # to lead with — composing would mean inventing the story (the
+    # 2026-07-16 failure, draft 1229c367). Park it.
     if _is_news_shaped(brief, liveness_tier, topic) and not _has_usable_source(summary, enrichment):
         reason = (
             "news-shaped draft has no usable source content: empty article_summary "
@@ -1785,6 +2365,35 @@ async def _process_one(conn: asyncpg.Connection, row: asyncpg.Record) -> _Proces
         await _mark_parked(conn, draft_id, reason)
         return "parked"
 
+    if engine == WR2_COMPOSE_ENGINE_MONOLITH:
+        return await _process_one_monolith(
+            conn, draft_id, topic, brief, summary, source_url,
+            enrichment, live_reasons, liveness_tier,
+        )
+    return await _process_one_planner_writer(
+        conn, draft_id, topic, brief, summary, source_url,
+        enrichment, live_reasons, liveness_tier,
+    )
+
+
+async def _process_one_monolith(
+    conn: asyncpg.Connection,
+    draft_id: uuid.UUID,
+    topic: str,
+    brief: dict[str, Any],
+    summary: str,
+    source_url: str,
+    enrichment: dict[str, Any] | None,
+    live_reasons: list[Any],
+    liveness_tier: str,
+) -> _ProcessOutcome:
+    """The ORIGINAL single-`claude_compose_slides`-call engine — kill-switch
+    rollback target (`WR2_COMPOSE_ENGINE=monolith`). Body below this
+    docstring is UNCHANGED from what `_process_one` did before the
+    production cutover (2026-07-21): only the function name + the shared
+    setup/park-check hoisted into the new `_process_one` dispatcher above
+    moved; every line of actual generation logic — the regen loop, the 3
+    guards, persistence, Telegram — is byte-identical."""
     # ── P-4 anti-sameness (constitution Art 10.6) ──────────────────────────
     # Soft steer (ALWAYS ON): derive the prospective domain from the topic,
     # look up the last-2 rendered same-domain carousels, and tell the model to

--- a/scripts/wr2_planner_writer.py
+++ b/scripts/wr2_planner_writer.py
@@ -2,13 +2,19 @@
 """wr2_planner_writer.py — Planner/Writer split (WR2 editorial-intelligence
 Phase 3, Mossa B — "il cuore anti-disco-rotto").
 
-ADDITIVE / SHADOW ONLY. Nothing in `wr2_draft_generator.py` or
-`scripts/wr2_html_renderer/composer.py` imports this module, and this PR
-does not modify either file — production behavior is byte-identical
-before/after. This module is exercised by `wr2_pw_shadow.py` against
-historical decks. Wiring it into the live autonomous pipeline is a later,
-separately-gated cutover (spec §3 rollout step 3: "Planner/Writer dual-run
-(B) — shadow accanto al monolite, poi cutover"), not this PR.
+CUTOVER STATUS (updated by the production cutover PR, spec §3 rollout step
+3): `wr2_draft_generator.py` now imports and drives this module behind the
+`WR2_COMPOSE_ENGINE` kill-switch (`planner_writer` = new default,
+`monolith` = the untouched original single-call path, instant rollback).
+This module itself is UNCHANGED in nature — still pure logic + an injected
+`call_fn` per stage, zero I/O/DB/network side effects of its own; the
+async OAuth-CLI wiring and the pregate-repair loop live in the caller
+(`wr2_draft_generator._generate_planner_writer_deck`), exactly as this
+module's own docstring below already prescribed for `wr2_pw_shadow.py`'s
+shadow harness. `scripts/wr2_html_renderer/composer.py` is still NOT
+imported here and still does not import this module — the contract with
+the renderer is the `wr2_carousel_ir.to_composer_dict` projection, not a
+direct import.
 
 Implements Mossa B of the ratified spec:
     .claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md
@@ -411,12 +417,106 @@ assert set(_KIND_FIELD_SCHEMA) == set(_KIND_TO_MODEL), (
     "_KIND_FIELD_SCHEMA has drifted from _KIND_TO_MODEL's keys"
 )
 
+# ─────────────────────────────────────────────────────────────────────────
+# Constitutional constraints per-kind (production cutover, GROUND-4): the
+# composer.py render-time HARD gates (Article 6.1 word budget, Article 7
+# forbidden phrases — both `ValueError`-raising, see composer.py:~1330/
+# ~1493) must reach the writer BEFORE a slide is written, or decks get
+# silently refused at render (a slide that fails the render-time gate
+# still burns the whole html-apply attempt). This module stays zero-I/O:
+# the phrase LIST is loaded by the caller (constitution.md is a repo file,
+# reading it is I/O) and threaded in as a plain `list[str]` parameter —
+# rendering it into prompt text below is pure string formatting, not I/O.
+#
+# Word-count scope mirrors composer._check_body_word_count's OWN scope
+# exactly (derived from which layout family renders a top-level {{body}}
+# placeholder outside any {{#each}} loop, composer.py:~1443-1498):
+#   - "prose" -> editorial-text's {{body}}: Article 6.1 applies (25-50).
+#   - "stat" -> stat-card-hero's {{body}} (mapped from context, see
+#     wr2_carousel_ir.to_composer_dict): Article 6.1 ALSO applies here —
+#     and unlike prose, StatSlide.context defaults to "" (lenient), so an
+#     empty context is NOT a safe default for this kind: it would render 0
+#     words into a family whose skeleton HAS a top-level {{body}}, hard-
+#     failing at render time. The writer must be told this explicitly.
+#   - every other kind (cover/statement/fact_stack/status_list/timeline/
+#     triad/qa/citation/cta) projects to a family with no top-level {{body}}
+#     (structured items, or a short punch line via a different placeholder)
+#     — Article 6.1 does not apply; stated as such so the writer never
+#     second-guesses a short structured answer as "too short".
+_ART_6_1_MIN = 25
+_ART_6_1_MAX = 50
+_BODY_WORD_BUDGET_KINDS = frozenset({"prose", "stat"})
+
+# Mirrors composer.TAKE_LABEL_BANNED verbatim (duplicated, not imported —
+# same cross-Playwright-boundary discipline this module's docstring already
+# states for every other constant here): the evidence-carved take_label
+# variety hard gate lives in `wr2_html_render_apply._take_label_hard_gate_
+# violations` (render_failed if it fires on a fresh, not-yet-published
+# draft) — a fact_stack writer that reaches for "OUR TAKE"/"OUR READ"/etc
+# burns a full render attempt for a copy defect this prompt can prevent
+# up front.
+_TAKE_LABEL_BANNED = frozenset({
+    "OUR TAKE", "OUR READ", "OUR VIEW",
+    "TAKE", "FACT", "FACTS", "NOTE", "REALITY", "KEY FACT",
+})
+
+
+def _render_constitutional_constraints(kind: str, forbidden_phrases: list[str] | None) -> str:
+    """Per-kind constitutional block appended to the writer prompt (GROUND-4
+    of the production cutover mandate). Returns "" only when there is
+    nothing to say AND no phrase list was supplied — in practice the caller
+    always supplies a phrase list in production, so this is effectively
+    always non-empty there; tests exercise both."""
+    lines: list[str] = []
+    if kind in _BODY_WORD_BUDGET_KINDS:
+        field = "body" if kind == "prose" else "context"
+        lines.append(
+            f"ARTICLE 6.1 HARD GATE — your `{field}` field is a RENDER-TIME HARD FAIL outside "
+            f"{_ART_6_1_MIN}-{_ART_6_1_MAX} words (the render pipeline raises and the whole slide "
+            f"is refused, not just warned). Write exactly that: {_ART_6_1_MIN}-{_ART_6_1_MAX} words, "
+            f"never fewer, never more."
+            + (
+                " This field is NOT optional for this kind despite its lenient schema default — an "
+                "empty context here still hard-fails (this layout has a top-level body placeholder)."
+                if kind == "stat" else ""
+            )
+        )
+    else:
+        lines.append(
+            "This kind has no Article 6.1 word-count gate (structured/short-punch layout) — write "
+            "the natural length for the field(s) below, do not pad."
+        )
+    if kind == "fact_stack":
+        banned = ", ".join(sorted(_TAKE_LABEL_BANNED))
+        lines.append(
+            f"take_label (if you use one) MUST NOT be any of: {banned} — these are retired anchor "
+            "labels that hard-fail the render for a fresh draft (evidence-carved.md '## take_label "
+            "variants' has the replacement vocabulary; or coin your own fresh 1-2 word tag)."
+        )
+    lines.append(
+        "CAPS POLICY (ratified, spec §8 item 2) — headings/kickers/short punch lines MAY be "
+        "UPPERCASE; any prose/body/list-item text must NEVER read as a caps-wall (a long run of "
+        "uppercase words is a render-time editorial-pregate FAIL)."
+    )
+    if forbidden_phrases:
+        phrase_list = ", ".join(f'"{p}"' for p in forbidden_phrases)
+        lines.append(
+            "ARTICLE 7 HARD GATE — none of your text fields may contain ANY of these forbidden "
+            f"phrases, in any form/case (render-time hard fail, not a style nit): {phrase_list}."
+        )
+    return (
+        "CONSTITUTIONAL CONSTRAINTS (render-time hard gates — violating these gets the slide, "
+        "and the whole render attempt, refused):\n" + "\n".join(f"- {line}" for line in lines)
+    )
+
 
 def _build_writer_prompt(
     brief_ctx: str,
     plan: ir.DeckPlan,
     slot: ir.SlotPlan,
     sibling_intents: list[str],
+    *,
+    forbidden_phrases: list[str] | None = None,
 ) -> str:
     schema_line = _KIND_FIELD_SCHEMA[slot.kind]
     if sibling_intents:
@@ -431,6 +531,8 @@ def _build_writer_prompt(
             "this slide's list-bearing field; the planner already locked this count against the "
             "heading"
         )
+
+    constraints_block = _render_constitutional_constraints(slot.kind, forbidden_phrases)
 
     return f"""You are the WRITER for ONE slide of a Bali Zero Instagram carousel — the redattore,
 not the editor. The plan below is LOCKED: fill the copy, never re-plan.
@@ -458,6 +560,8 @@ deck). You do NOT see their copy and must NEVER rewrite them, only play off the 
 they represent:
 {siblings_block}
 
+{constraints_block}
+
 OUTPUT — this kind's fields ONLY (plus "kind"):
   {schema_line}
 
@@ -475,11 +579,17 @@ def write_slot(
     sibling_intents: list[str],
     call_fn: Callable[[str], str],
     max_retries: int = 3,
+    *,
+    forbidden_phrases: list[str] | None = None,
 ) -> ir.Slide:
     """Run the writer stage for ONE slot: brief + locked plan frame (spine,
     arc, this slot's role/kind/heading_intent/bullet_promise_n) + sibling
     slots' heading_intents ONLY (never their copy) + the field schema for
-    THIS kind only. Validates against the single kind-matching model
+    THIS kind only + the per-kind constitutional constraints block
+    (`forbidden_phrases`, production cutover GROUND-4 — optional, keyword-
+    only, backward compatible: every existing call site/test that omits it
+    gets the pre-cutover prompt shape, just with a "no phrase list" Article
+    7 clause). Validates against the single kind-matching model
     (`_KIND_TO_MODEL[slot.kind]`) — a writer response whose own "kind" field
     disagrees with `slot.kind` is a retry-worthy failure, NEVER silently
     accepted as a different kind (kind-preserving hard rule, spec §2).
@@ -489,7 +599,9 @@ def write_slot(
     if model_cls is None:  # pragma: no cover — SlotPlan.kind is itself a Literal over these keys
         raise ValueError(f"write_slot: unknown plan kind {slot.kind!r}")
 
-    prompt = _build_writer_prompt(brief_ctx, plan, slot, sibling_intents)
+    prompt = _build_writer_prompt(
+        brief_ctx, plan, slot, sibling_intents, forbidden_phrases=forbidden_phrases
+    )
 
     ctx = prompt
     last_raw = ""
@@ -566,6 +678,8 @@ def produce_deck(
     planner_fn: Callable[[str], str],
     writer_fn: Callable[[str], str],
     max_retries: int = 3,
+    *,
+    forbidden_phrases: list[str] | None = None,
 ) -> ir.SlideDeck:
     """plan -> write each slot (sequential; parallelization is a caller
     concern per spec §2 — "Parallelizzabile per-slot" describes an option,
@@ -577,7 +691,11 @@ def produce_deck(
     voice-register field — so register comes from the same upstream source
     production already resolves it from today (the deck's own
     `war_room_drafts.register` / the historical brief's own `register`, per
-    the `ir_replay_fixture.json` shape `wr2_pw_shadow.py` reads).
+    the `ir_replay_fixture.json` shape `wr2_pw_shadow.py` reads). The
+    production cutover caller (`wr2_draft_generator._generate_planner_writer_
+    deck`) resolves a FRESH register deterministically before calling this
+    (no prior value exists for a first-time draft) — see that function's own
+    docstring; this module stays agnostic to how the caller got it.
 
     `planner_fn` is used for `plan_deck` (typically pinned to
     `DEFAULT_PLANNER_MODEL`); `writer_fn` is used for every `write_slot`
@@ -585,6 +703,11 @@ def produce_deck(
     is the caller's wiring (see this module's docstring, "9x-cost
     mitigation"), not enforced here structurally beyond accepting two
     distinct callables.
+
+    `forbidden_phrases` (keyword-only, optional, production cutover
+    GROUND-4): threaded verbatim into every `write_slot` call's per-kind
+    constitutional-constraints block. Backward compatible — omitted, every
+    existing caller/test gets the pre-cutover prompt shape.
     """
     plan = plan_deck(brief_ctx, liveness_tier, recent_arcs, planner_fn, max_retries=max_retries)
 
@@ -592,7 +715,10 @@ def produce_deck(
     slides: list[ir.Slide] = []
     for slot in ordered_slots:
         sibling_intents = [s.heading_intent for s in ordered_slots if s.slot_id != slot.slot_id]
-        slide = write_slot(brief_ctx, plan, slot, sibling_intents, writer_fn, max_retries=max_retries)
+        slide = write_slot(
+            brief_ctx, plan, slot, sibling_intents, writer_fn, max_retries=max_retries,
+            forbidden_phrases=forbidden_phrases,
+        )
         slides.append(slide)
 
     return ir.SlideDeck(register=register, slides=slides, spine=plan.spine, arc=plan.arc)


### PR DESCRIPTION
## Summary

First production modification of the WR2 editorial-intelligence arc (Phases 1-3 — `wr2_carousel_ir.py` / `wr2_editorial_pregate.py` / `wr2_planner_writer.py` — were shadow-only until now, per `.claude/skills/wr2/_research/2026-07-21-editorial-intelligence-design.md` §3 step 3: "Planner/Writer dual-run — shadow accanto al monolite, poi cutover").

`scripts/wr2_draft_generator.py` now drives the typed planner/writer engine behind a kill-switch, with pregate-in-the-loop and per-slot repair, while the monolith code path is preserved **byte-identical** for instant rollback.

## Kill-switch (instant rollback)

```
WR2_COMPOSE_ENGINE=planner_writer   # new default — the engine this PR ships
WR2_COMPOSE_ENGINE=monolith         # instant rollback — untouched, still fully tested code path
```

`_resolve_compose_engine()` (`scripts/wr2_draft_generator.py:80`) reads the env var, falls back to `planner_writer` with a WARN log on any unrecognized value. `_process_one()` (`:2317`) is now a thin dispatcher that routes to `_process_one_monolith()` (`:2379`, renamed from the original `_process_one`, verified **byte-identical** via AST-based body diff — 13,514 chars, zero diff) or `_process_one_planner_writer()` (`:2196`).

## New engine path

`brief_ctx` (`_build_brief_ctx`, `:1955`, duplicates the monolith's facts-first framing without touching it) → `fetch_recent_arcs` lookback (`:1679`, last 8 rendered/published drafts' `arc`, empty on cold start) → `pw.plan_deck` → `pw.write_slot` per slot with sibling `heading_intents`, constitutional constraints (Art 6.1 word budget, Art 7 forbidden phrases, caps-policy, take_label ban) injected per-kind → assemble `SlideDeck` → `pregate.pregate_typed(deck, spine=plan.spine)` in a repair loop:

- **PASS** → persist.
- **FAIL** → `_pregate_fail_reasons_by_slot()` (`:1863` area) parses `"slide N"` mentions out of FAIL check reasons, re-writes **only** the failing slot(s) with the pregate feedback appended to the writer prompt, up to 2 repair rounds.
- **Still FAIL after 2 rounds** → `PregateRepairExhausted` (`:1863`) raised → existing facts-first PARK mechanism (`_mark_parked`) — the draft is parked, **never shipped failing**, never degrades kinds.

Plan-level fail-fast: if the planner's closer slide isn't a safe kind (`cta`/`statement`), the plan is cheaply re-attempted (up to 2 plan attempts) before spending writer calls on a structurally unrepairable deck — this never forces a kind on the planner, it only avoids wasted work.

Register selection is deterministic (`_pick_register_for_planner_writer`, `:2002`) — a simplification vs. the monolith's LLM judgment, since `DeckPlan` is deliberately register-free per the ratified spec and there's no prior value on a first-time draft.

## Consumer-map (scar family #9 — dropped-field contract chains)

| Field | Producer | Store | Consumer(s) |
|---|---|---|---|
| `layout_family`, `slide_type`, headline/body/etc per-kind | `ir.to_composer_dict()` (`wr2_carousel_ir.py:866`) | `_persist_ready()` → `war_room_drafts.slides_json` (same call/shape as monolith) | `wr2_html_render_apply.py` → `composer.py` skeleton router |
| `take_label` | Writer output on `fact_stack`-family kinds | same `slides_json` | `wr2_html_render_apply.py:1056` `_take_label_hard_gate_violations` (hard gate, pre-existing); `fetch_recent_editorial_signatures()` extended (`scripts/wr2_draft_generator.py`) to treat any non-empty `take_label` as a kicker source, sharing the **same** `_normalize_kicker` dedup seen-set as the monolith's `slide_type=="take"` branch |
| `spine`, `arc`, `arc_reason` | `plan_deck()` output (`DeckPlan`) | `council_meta` (existing `council_debate_json` JSON column — **no schema migration**) | `fetch_recent_arcs()` (new, reads `arc` back for the next draft's lookback); human review queue (existing `council_debate_json` viewer, additive keys only) |
| `pregate_verdict`, `pregate_repair_rounds` | `_generate_planner_writer_deck()` | `council_meta` | diagnostic/observability only, additive |
| `engine: "planner_writer"` | `_process_one_planner_writer()` | `council_meta` | lets a human/reconciler tell which engine produced a given draft post-hoc |
| Guards: kicker-collision, closer-length | Adapted accessors (`_closer_word_count_typed`/`_closer_too_long_typed`/`_kicker_collision_typed`, `scripts/wr2_draft_generator.py:2027-2068`) reading the **typed IR's** field names (`statement`/`invite`/`headline`/`body` precedence for closer; `take_label` whole-string compare for kicker) instead of the monolith's dict shape | n/a (WARN-only, non-blocking) | same as before — antimonotone/kicker/closer guards keep working on the new path |

Known gap (not a blocker, flagged): `derive_dominant_mode`/`distinct_mode_count` degrade gracefully since new-engine slides carry no `image_mode` field — the typed IR doesn't produce that signal yet.

## Constitutional gates carried into the writer prompt

`wr2_planner_writer.py`'s `_render_constitutional_constraints()` (new) mirrors composer.py's hard gates so the writer targets them proactively instead of relying only on pregate to catch violations after the fact:
- Article 6.1 word budget (25-50 words) for `prose`/`stat` kinds (composer.py's own scope makes `stat-card-hero` carry a top-level `{{body}}` too, despite a lenient IR schema default — flagged explicitly in the prompt as "NOT optional").
- Article 7 forbidden phrases (loaded fail-open via `_load_forbidden_phrases_for_writer`, `:1933` — mirrors composer's fail-**closed** loader but never raises here, since this is prompt guidance, not the enforcement point; the actual gate stays in composer.py).
- `_TAKE_LABEL_BANNED` (mirrors composer's `TAKE_LABEL_BANNED` verbatim) for `fact_stack`-family kinds.
- Caps-only-headings policy note.

## Pro runtime dependency verification (fresh, this PR)

Production cron (`com.balizero.wr2.draft-generator.plist` → `~/.openclaw/bin/wr2/wr2-script-wrapper.sh`) runs from the dedicated deploy worktree `~/nuzantara-deploy` (pinned to `origin/main`, per the wrapper's own 2026-05-06 comment — NOT the multi-agent `~/nuzantara` checkout). Verified live on Pro:

```
$ ssh pro 'source ~/nuzantara-deploy/apps/backend-rag/.venv/bin/activate && python3 -c "import pydantic; print(pydantic.VERSION)"'
2.13.4
RC=0
```

Pydantic v2 is importable in the exact venv the production wrapper activates — **no dependency gap, no cron-theater risk**. `~/nuzantara-deploy` will need `git pull origin main` after this PR merges (deploy step — reserved for the orchestrator per this mandate).

## Doc-drift found, not touched (out of scope)

`wr2_carousel_ir.py`'s own docstring/comments still claim CitationSlide's `{{title}}` and CtaSlide's `trust_marker`/`reach`/`invite` are a "DISCOVERED GAP... see final report for the Phase-3 composer.py follow-up this implies." `git blame` shows PR #2958 ("fix(wr2): substitute source-citation + elegant-close placeholders + placeholder-sweep hard gate (W99 class-cure)") already fixed this before this worktree's HEAD — verified by grepping the literal `{{title}}`/`{{trust_marker}}`/`{{reach}}`/`{{invite}}`/`{{index}}` tokens in `skills/bali-zero-brand/layouts/elegant-close.md` and `source-citation.md` against what `composer.py` substitutes and what `to_composer_dict` projects: they match. All 11 IR kinds are end-to-end renderable; no composer.py change was needed. The stale docstring is a 1-line doc-drift, not fixed here (surgical scope).

## Tests

- **52 new** (`scripts/tests/test_wr2_draft_generator_planner_writer_cutover.py`): compose-engine resolution, dispatch routing, happy path, FAIL→repair→PASS (including "repair targets only the failing slot"), repair-exhausted→park, plan-level closer-safety fail-fast, pregate-fail-reason→slot mapping, guard adapters (word-count/closer-length/kicker-collision incl. a scar-family-#3 substring-innocence test), `_build_brief_ctx`, register picker, forbidden-phrases loader (real-file + fail-open), persistence-shape consumer-contract assertions, `fetch_recent_arcs`, extended kicker-source recognition.
- **2 pre-existing files pinned** to `WR2_COMPOSE_ENGINE=monolith` (`test_wr2_draft_generator_enriched_prompt.py`, `test_wr2_draft_generator_kicker_variety.py`) — both call `_process_one()` and mock only the monolith's `claude_compose_slides`. **Discovered live during this cutover**: leaving them unpinned silently routed them onto a REAL Claude OAuth CLI subprocess once the default engine flipped — caught via `ps aux` process inspection before merge, killed the runaway process, fixed both files. Documented verbatim in the `wr2-queue-tests.yml` comment block added by this PR.
- **All existing suites green**: 38 `wr2_planner_writer` tests unchanged, 129 IR/pregate/planner-writer, 154-test render battery, 219 in the full 9-file draft-generator family (pre-existing 8 + new file), 608/608 in the full CI-equivalent `wr2-queue-tests.yml` battery run locally (`python -m pytest ... -q`, 8.21s).
- Newly wired into `.github/workflows/wr2-queue-tests.yml` (`scripts/wr2_draft_generator.py` + all 9 `test_wr2_draft_generator_*.py` files were previously **not enforced by any CI workflow** — dev-run-by-hand only).
- `ruff check --select F,E9` clean on all touched/new Python files.

## Deviations from the mandate (stated verbatim)

1. Register selection for the new engine is a deterministic tier-preference pick, not an LLM judgment call — noted above, `DeckPlan` is deliberately register-free by design.
2. The `wr2_carousel_ir.py` "DISCOVERED GAP" docstring is stale (already fixed by #2958) and was left as-is — flagged, not corrected, to keep this PR's diff surgical.
3. 4 `photo-*` layout families remain unreachable from any of the 11 typed IR kinds in this v1 — pre-existing scope of the Phase-1 IR design, not something this cutover PR introduces or fixes.

## Scope boundary (per mandate)

Deploy (`~/nuzantara-deploy` `git pull origin main` on Pro) and PROVE-LIVE (controlled 1-draft run) are **explicitly reserved for the orchestrator** and are NOT attempted in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
