### PR TITLE
feat(pricing): add E33 Second Home (5 Years) at IDR 39M to official 2026 price list

### DIFF
--- a/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+++ b/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
@@ -318,6 +318,16 @@
         "description_en": "Onshore extension of an existing E33G Remote Worker KITAS.",
         "icon_id": "kitas-remote"
       },
+      "E33 Second Home (5 Years)": {
+        "name": "E33 Second Home (5 Years)",
+        "price": "39.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "5 years",
+        "notes": "All-inclusive price. Requires the client's own qualifying USD 130,000 deposit at a state-owned Indonesian bank (or USD 1,000,000 qualifying property); Bali Zero never holds client funds.",
+        "description_en": "Second Home Visa / KITAS (E33) for foreigners who hold a qualifying USD 130,000 deposit in their own name at a state-owned Indonesian bank (or a USD 1,000,000 qualifying property). Valid 5 years, renewable; non-working residency. Bali Zero manages document preparation, submission, and the 90-day post-grant commitment gate; the deposit always remains in the client's own account.",
+        "icon_id": "kitas-investor"
+      },
       "Spouse 1 Year (Altus/Onshore)": {
         "name": "Spouse 1 Year (Altus/Onshore)",
         "price": "13.500.000 IDR",


### PR DESCRIPTION
## What
Adds **E33 Second Home (5 Years) = IDR 39.000.000 all-inclusive** to `kitas_permits` in `bali_zero_official_prices_2026.json` (the PricingTool SSOT). The E33 Second Home was previously absent (only E33G Remote Worker existed — a different visa).

## Price basis
Set by Zero (business decision, Legge 5). Positioned inside the **verified Indonesian market band 35–45M all-in** (research PR #2975): above the Flado/Bali-Visas floor, below BBC's 45M, carrying the managed differentiator. Single all-inclusive price per the no-anatomy rule; the client's own USD 130,000 deposit stays in their own account (Bali Zero never holds funds).

## Verified locally
- JSON valid; `PricingService._load_prices()` loads it
- `get_kitas_prices()` and `search_service("second home visa")` both serve it at 39.000.000 IDR
- pricing service tests pass

## Open (NOT set — flagged to Zero, not invented)
10-year variant · family/dependent price · offshore/onshore split. Only the 5y main-applicant is fixed.

## Post-merge to go LIVE
Deploy `nuzantara-rag` → prove-live via MCP `search_service_pricing` (prod serves the old catalogue until deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)