### PR TITLE
docs(bot): corner §1 — Gemini prepay-depletion P0 resolved + verifier revival proven live

### DIFF
--- a/.claude/skills/bot/SKILL.md
+++ b/.claude/skills/bot/SKILL.md
@@ -20,8 +20,29 @@ WhatsApp Business (Meta Cloud API) number **+62 821-3465-159** = Zantara. Two au
 - **Bali Zero team**: work-support assistant. Check-in via WA (opens the free Meta 24h window),
   CRM nudges, PII-light briefings. Persona = "assistente operativo interno", not sales.
 
-## 1. LIVE STATE (last update 2026-07-21 ~21:00 WITA — keep current)
+## 1. LIVE STATE (last update 2026-07-22 — keep current)
 
+- **GEMINI PREPAY DEPLETION P0 (2026-07-22) — RESOLVED via top-up + verifier revival PROVEN LIVE**:
+  while carrying the RAG verifier revival to prove-live, live prod logs revealed the WHOLE bot was
+  degraded — NOT by the verifier but by `429 RESOURCE_EXHAUSTED "prepayment credits are depleted"`
+  on BOTH `gemini-3.5-flash` (primary) AND `gemini-2.5-flash` (fallback): the prepay Gemini key's
+  balance hit zero (the `discovery_gemini_api_key...2026_07_19` risk realized). Symptom: agentic LLM
+  dead → can't drive tool-retrieval → `Chunks retrieved: 0` → **abstain on EVERYTHING** (visa/tax/
+  company all `confidence:0.0`); verifier can't run either (also Gemini). Only verbatim FAQ cache
+  still served (no Gemini). Embeddings + Qdrant were fine — Gemini-only outage. Zero topped up the
+  prepay on project `nuzantara` (AI Studio, operator/billing). **Post-top-up prove-live (fly logs,
+  this turn)**: 0× 429, retrieval alive (`Chunks retrieved: 13`, confidence 0.85, real E35/E28
+  sources), and the **verifier producing real parsed verdicts** — `🛡️ [Verifier] Status:
+PARTIALLY_VERIFIED | Score: 0.75`, `[VerificationStage] ... verdict_available=True`,
+  `[self-correct] verify=24.11s` (self-correction fires). **Verifier revival (PR #2973, fence-parse
+  → `generate_structured`) = DONE + PROVEN LIVE.** The pre-topup "intermittent ~1/3 schema-fails" was
+  the depletion front, NOT strict schema (anyOf/bounds refuted on real Gemini). **OPEN follow-ups
+  (non-blocking)**: (a) enable prepay **auto-recharge / low-balance alert** (billing, operator) — the
+  only structural cure while Fly arch is "Gemini always"; (b) verifier robustness (round-3
+  schema-loosen held unpushed at `8604d7ae96`, ship only with a real before/after schema-fail
+  measurement); (c) architectural non-Gemini fallback on Fly so a 429-Gemini never zeroes the bot.
+  Detail: memory `discovery_prod_verifier_dead_fence_parse_not_leaked_key_2026_07_21` +
+  `discovery_gemini_api_key_project_orphan_ledger_undercount_2026_07_19` (§RESOLVED).
 - **🔒 P0 SECURITY — CRM/PII public exposure FIXED + DEPLOYED + PROVEN (PR #2962, 2026-07-21)**: `/api/blog/ask` (+ WA-unknown ReAct) could exfiltrate CRM whole-book PII (`crm_query`) and the full staff roster incl. pin/religion (`team_knowledge`); `/api/team/clock-in`+`/clock-out`+`/my-status` allowed impersonation (identity from body, no auth). Tourniquet (2 Codex red-team rounds, generator≠grader): `SENSITIVE_TOOLS={crm_query,timesheet,team_knowledge}` denied for `agent_role=None` in `tool_authorizer.py`; `_resolve_actor_identity` in `team_activity.py` ignores body identity for non-admin (closes email+user_id); `Depends(get_current_user)` on clock-in/out/my-status. PROVE-LIVE prod: blog/ask → `tool_authz decision=deny role=none tool=team_knowledge` (log) + graceful 0-PII answer; clock-in/out/my-status no-auth → 401; health 200. Staff no-regression + non-admin→own-identity verified by red-team + 13 unit tests (`test_team_activity_clock_identity_tourniquet.py`). Full principal-based rework (unified server-side principal, unconditional reserved-arg strip, clamp `CRMTool.limit`, timesheet email from principal, remove legacy `agent_role=None→allow`) is a SEPARATE non-P0 follow-up. Memory `discovery_crm_pii_public_exposure_blog_ask_timesheet_2026_07_21`.
 - **🎫 Collateral finding (open ticket): JWT expiry NOT enforced in prod**: `jwt_enforce_expiry=False` default (`config.py:501`, "Phase 1 audit mode"), no prod override (`JWT_ENFORCE_EXPIRY` absent from fly secrets) → expired JWTs accepted app-wide (`verify_exp` in hybrid_auth.py:473/517, auth.py:126, websocket.py:93, deps/auth.py:70). Flip = ops decision (verify refresh-token works first, blind flip logs out live sessions). Memory `discovery_crm_pii_public_exposure_blog_ask_timesheet_2026_07_21`.
 - **🎫 Collateral finding (open ticket): orphan test tree**: `apps/backend-rag/tests/` (top-level, 1189+ lines) is NOT collected by any CI workflow nor the pre-push (both scope `backend/tests/`; `pytest.ini testpaths=backend/tests`) → false coverage (scar #2). Tests there never run in gate.


### PR DESCRIPTION
## What

Updates the `/bot` corner §1 LIVE STATE with the outcome of carrying PR #2973 (RAG verifier fence-parse fix → `generate_structured`) to prove-live.

## The finding (recorded for the next bot session)

While proving the verifier revival live, prod logs revealed the **whole bot was degraded by Gemini prepay credit depletion** — `429 RESOURCE_EXHAUSTED "prepayment credits are depleted"` on BOTH `gemini-3.5-flash` (primary) AND `gemini-2.5-flash` (fallback). Agentic LLM dead → no tool-driven retrieval → abstain-on-everything. Not a verifier bug; the `discovery_gemini_api_key...2026_07_19` risk realized.

Zero topped up the prepay (project `nuzantara`, AI Studio). **Post-top-up prove-live (fly logs):**
- 0× 429; retrieval alive (`Chunks retrieved: 13`, confidence 0.85, real E35/E28 sources);
- verifier producing real parsed verdicts: `🛡️ [Verifier] Status: PARTIALLY_VERIFIED | Score: 0.75`, `verdict_available=True`, `[self-correct] verify=24.11s`.

**Verifier revival (PR #2973) = DONE + PROVEN LIVE.** The pre-topup "intermittent ~1/3 schema-fails" was the depletion front, not strict schema (anyOf/bounds already refuted on real Gemini).

## Non-blocking follow-ups noted in §1
(a) prepay **auto-recharge / low-balance alert** (operator/billing) — only structural cure while Fly is "Gemini always"; (b) verifier round-3 schema-loosen held unpushed; (c) architectural non-Gemini Fly fallback.

Docs-only (`.claude/skills/bot/SKILL.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)