### PR TITLE
feat(visa-engine): add SHADOW evidence collection gates

### DIFF
--- a/.agents/skills/visaoracle/SKILL.md
+++ b/.agents/skills/visaoracle/SKILL.md
@@ -51,10 +51,15 @@ gate — a green gate certifies the engine as it was measured, not future edits.
   recorded drill: flip ENFORCE, then flip back to OFF, confirm the public surface stops consulting the
   engine immediately — no redeploy, no cache lag). ENFORCE is never armed without a proven kill-switch.
 
-**GATE STATUS: 🔴 RED (all four unmeasured — SHADOW wiring not yet live).** The session updates this line as
-criteria go green, with the evidence pointer (audit-log query + gold-persona replay report + rollback-drill
-capture) for each. Evidence is collected from the SHADOW audit substrate; nothing here is self-attested —
-each green needs a re-runnable measurement (generator≠grader on G-b/G-c: the grader is not the engine).
+**GATE STATUS: 🔴 RED (2026-07-21 — STEP-6c code is merged, but production collection is still dark).**
+Fly has the trust-store secret but neither `VISA_ENGINE_MATCH_MODE` nor
+`VISA_ENGINE_FACTS_FINGERPRINT_KEYS_JSON`; the Match path therefore defaults OFF and fails closed before
+writing evidence. G-a/G-c are red/unmeasured, G-b has a green local canonical-suite preflight but no accepted
+independent replay artifact, and G-d is unmeasured. Current collection design/receipt:
+`research/visa/2026-07-21-shadow-evidence-collection.md`. The session updates this line as criteria go green,
+with the evidence pointer (audit-log query + gold-persona replay report + rollback-drill capture) for each.
+Evidence is collected from the SHADOW audit substrate; nothing here is self-attested — each green needs a
+re-runnable measurement (generator≠grader on G-b/G-c: the grader is not the engine).
 
 **Flip procedure (when GATE STATUS goes 🟢 all-green):** the session executes the flip itself, captures the
 before/after (flag state, a live ENFORCE verdict on a real request, the audit record), and reports the
@@ -248,6 +253,17 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
   memory `discovery_kimi_parallel_worktree_pr2876_2026_07_20`. SHADOW-wiring prerequisite for the
   ENFORCE-GATE (STEP-6c) still not live — S3/Pro's PR #2824 (migration 252 SHADOW substrate)
   remains the actual blocker for evaluating any gate criterion, G-b included.
+- 2026-07-21 (Pro, SHADOW evidence lane): prior blocker superseded — **#2916 MERGED**
+  (`8b28ac418481`, STEP-6c Match wiring), **#2930 MERGED** (`09f7cd2273c9`, real HMAC
+  facts-fingerprint provider), and **#2952 MERGED** (`60c6f348c9a4`, finite activation-system-period
+  guard). Production release 3888 is deployed, but collection remains dark: Fly has only the Visa trust
+  store, while Match mode and the facts-fingerprint key are absent. Read-only DB proof is separately
+  blocked because the `nuzantara_readonly` Keychain password is absent; no write-capable fallback used.
+  Worktree `backend-rag-visa-oracle-shadow-evidence` now prepares migration 255 plus a PII-free,
+  fail-closed G-a/G-c collector and CLI; 1,070 Visa-engine tests collected with all runnable tests green
+  (one pre-existing executor-role skip). **No PR, merge, deploy, secret change, SHADOW activation, or
+  ENFORCE activation performed.** Receipt:
+  `research/visa/2026-07-21-shadow-evidence-collection.md`.
 
 ## TRACKS — parallel work groups (multi-session coordination)
 

--- a/.agents/skills/visaoracle/SKILL.md
+++ b/.agents/skills/visaoracle/SKILL.md
@@ -264,6 +264,10 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
   (one pre-existing executor-role skip). **No PR, merge, deploy, secret change, SHADOW activation, or
   ENFORCE activation performed.** Receipt:
   `research/visa/2026-07-21-shadow-evidence-collection.md`.
+- 2026-07-22 (Pro, SHADOW evidence lane): Kimi review follow-up adds direct G-c,
+  collector, CLI, and legacy fail-closed coverage; `duplicate_evaluations` now counts only
+  repeated valid 32-byte fingerprints. The focused local-test-DB suite is green (57 tests;
+  SHADOW evidence module 85.30% branch coverage). **L3/L4 remain deferred; ENFORCE remains OFF.**
 
 ## TRACKS — parallel work groups (multi-session coordination)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 327 routers · 656 services
+- Backend: FastAPI · 327 routers · 657 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 33 · Packages: 6

--- a/apps/backend-rag/backend/db/migrations_v2/255_visa_shadow_evidence.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/255_visa_shadow_evidence.sql
@@ -1,0 +1,60 @@
+-- Migration 255: Visa Oracle SHADOW evidence substrate
+--
+-- Migration 252 intentionally persisted only the minimum decision projection.
+-- That projection cannot prove the objective ENFORCE gate: decision_id changes
+-- across evaluations of the same Match request, and the row carries neither the
+-- Match category nor the candidate codes/claim-to-source map.  This roll-forward
+-- adds only PII-free audit metadata needed to measure G-a (volume/breadth) and
+-- G-c (grounding).  Existing rows remain valid but deliberately fail closed in
+-- the evidence collector because their new nullable correlators are absent.
+--
+-- request_fingerprint is SHA-256(match_hash), never the public Match token and
+-- never applicant data.  The 16-character Match token is randomly generated and
+-- high entropy; hashing preserves request-level deduplication without persisting
+-- or exposing the token itself.  candidate_summary and grounding_summary contain
+-- only engine identifiers, reason codes, and source-record UUIDs.
+--
+-- This migration does not change VISA_ENGINE_MATCH_MODE and cannot arm ENFORCE.
+
+ALTER TABLE public.visa_decisions
+    ADD COLUMN request_fingerprint BYTEA
+        CHECK (
+            request_fingerprint IS NULL
+            OR octet_length(request_fingerprint) = 32
+        ),
+    ADD COLUMN request_category TEXT
+        CHECK (
+            request_category IS NULL
+            OR request_category IN (
+                'work_remote',
+                'investor',
+                'work_employee',
+                'family',
+                'long_tourism',
+                'retirement',
+                'student',
+                'other'
+            )
+        ),
+    ADD COLUMN candidate_summary JSONB NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(candidate_summary) = 'array'),
+    ADD COLUMN grounding_summary JSONB NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(grounding_summary) = 'array');
+
+CREATE INDEX idx_visa_decisions_shadow_request_fingerprint
+    ON public.visa_decisions (request_fingerprint)
+    WHERE engine_surface = 'MATCH' AND engine_mode = 'SHADOW';
+
+CREATE INDEX idx_visa_decisions_shadow_request_category
+    ON public.visa_decisions (request_category, evaluated_at)
+    WHERE engine_surface = 'MATCH' AND engine_mode = 'SHADOW';
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS public.idx_visa_decisions_shadow_request_category;
+DROP INDEX IF EXISTS public.idx_visa_decisions_shadow_request_fingerprint;
+
+ALTER TABLE IF EXISTS public.visa_decisions
+    DROP COLUMN IF EXISTS grounding_summary,
+    DROP COLUMN IF EXISTS candidate_summary,
+    DROP COLUMN IF EXISTS request_category,
+    DROP COLUMN IF EXISTS request_fingerprint;

--- a/apps/backend-rag/backend/services/visa_engine/shadow.py
+++ b/apps/backend-rag/backend/services/visa_engine/shadow.py
@@ -9,20 +9,21 @@ visa_engine (``evaluator.evaluate``) against whatever rule pack is active
 for the resolved environment, writing exactly one ``visa_decisions`` row
 (migration 252's SHADOW-minimal write substrate). NEVER rendered to the
 caller, NEVER able to raise into the request/response path, NEVER logs raw
-applicant facts (nationality/purpose/duration) — only ``match_hash``,
-verdict, and candidate counts (SYMBIOSIS Law 2 / UU PDP PII boundary).
+applicant facts (nationality/purpose/duration) or the public ``match_hash``
+token — only a truncated SHA-256 trace, verdict, and candidate counts
+(SYMBIOSIS Law 2 / UU PDP PII boundary).
 
-PROD today is a no-op by construction (see the design doc's §5 "Honest
-limitations"): no rule pack is activated for PRODUCTION yet, and even once
-one is, the default placeholder identity provider fail-closes on any
-non-TEST environment (``evaluator.PlaceholderIdentityNotAllowedError`` —
-STEP-6d ships the real crypto-backed identity provider). SHADOW rows land
-for real only against a TEST-environment activated pack in the meantime;
-the plumbing is exercised end-to-end by this module's own tests.
+PROD remains a no-op until all runtime prerequisites are present together:
+an active signed PRODUCTION pack, trust-store keys, a PRODUCTION facts-
+fingerprint key, and ``VISA_ENGINE_MATCH_MODE=SHADOW``. Missing identity
+material fail-closes through ``PlaceholderIdentityNotAllowedError`` /
+``FactsFingerprintKeyUnavailableError``. The plumbing is exercised end-to-
+end by this module's own tests without arming any production flag.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -324,10 +325,10 @@ def _b64url_nopad_encode(raw: bytes) -> str:
 
 @dataclass(frozen=True, slots=True)
 class _PackBinding:
-    """The DB primary key + environment + raw wire envelope for the single
-    active rule pack resolved by ``_resolve_active_pack_binding``."""
+    """The selected pack/activation identities and signed wire envelope."""
 
-    id: uuid.UUID
+    rule_pack_id: uuid.UUID
+    ruleset_activation_id: uuid.UUID
     environment: str
     raw_envelope: dict[str, JsonValue]
 
@@ -355,7 +356,8 @@ async def _resolve_active_pack_binding(
         row = await conn.fetchrow(
             """
             SELECT
-                p.id,
+                p.id AS rule_pack_id,
+                a.id AS ruleset_activation_id,
                 p.environment,
                 p.protected_header,
                 p.payload,
@@ -381,7 +383,8 @@ async def _resolve_active_pack_binding(
         return None
 
     return _PackBinding(
-        id=row["id"],
+        rule_pack_id=row["rule_pack_id"],
+        ruleset_activation_id=row["ruleset_activation_id"],
         environment=row["environment"],
         raw_envelope={
             "canonicalization": "RFC8785",
@@ -393,21 +396,95 @@ async def _resolve_active_pack_binding(
     )
 
 
-def _collect_citations(decision: Decision) -> list[dict[str, str]]:
-    """Flatten ``decision.candidates[].source_refs`` into the
-    ``visa_decisions.citations`` JSONB array shape (migration 252's own
-    "element shape is application-layer's choice" — a bare
-    ``{"source_record_id": "<uuid>"}`` object per distinct source),
-    preserving first-seen order and de-duplicating."""
+def _request_fingerprint(match_hash: str) -> bytes:
+    """Return a non-reversible request correlator; never persist the token."""
 
-    seen: set[uuid.UUID] = set()
-    citations: list[dict[str, str]] = []
+    return hashlib.sha256(match_hash.encode("utf-8")).digest()
+
+
+def _request_trace(match_hash: str) -> str:
+    """Short, non-reversible correlation value safe for operational logs."""
+
+    return _request_fingerprint(match_hash).hex()[:12]
+
+
+def _build_candidate_summary(decision: Decision) -> list[dict[str, JsonValue]]:
+    """Build the PII-free product breadth projection used by gate G-a."""
+
+    return [
+        {
+            "rank": candidate.rank,
+            "product_version_id": str(candidate.product_version_id),
+            "product_code": str(candidate.product_code),
+            "support_rule_ids": [str(rule_id) for rule_id in candidate.support_rule_ids],
+            "source_record_ids": [str(ref) for ref in candidate.source_refs],
+            "reason_codes": [str(code) for code in candidate.reason_codes],
+        }
+        for candidate in decision.candidates
+    ]
+
+
+def _build_grounding_summary(decision: Decision) -> list[dict[str, JsonValue]]:
+    """Map every persisted verdict/claim to source-record identifiers.
+
+    The top-level VERDICT claim is deliberate: a NEEDS_INPUT/abstention row
+    with no grounded reason remains visible as a G-c failure instead of being
+    silently treated as "no claims".
+    """
+
+    claims: list[dict[str, JsonValue]] = []
+    verdict_refs: list[uuid.UUID] = []
+    seen_verdict_refs: set[uuid.UUID] = set()
+
+    def add_claim(kind: str, code: str, refs: tuple[uuid.UUID, ...]) -> None:
+        for ref in refs:
+            if ref not in seen_verdict_refs:
+                seen_verdict_refs.add(ref)
+                verdict_refs.append(ref)
+        claims.append(
+            {
+                "claim_kind": kind,
+                "claim_code": code,
+                "source_record_ids": [str(ref) for ref in refs],
+            }
+        )
+
     for candidate in decision.candidates:
-        for ref in candidate.source_refs:
+        add_claim("CANDIDATE", str(candidate.product_code), candidate.source_refs)
+    for reason in decision.review_reasons:
+        add_claim("REVIEW_REASON", str(reason.code), reason.source_refs)
+    for reason in decision.no_path_reasons:
+        add_claim("NO_PATH_REASON", str(reason.code), reason.source_refs)
+    for notice in decision.notices:
+        add_claim("NOTICE", str(notice.code), notice.source_refs)
+
+    return [
+        {
+            "claim_kind": "VERDICT",
+            "claim_code": decision.state.value,
+            "source_record_ids": [str(ref) for ref in verdict_refs],
+        },
+        *claims,
+    ]
+
+
+def _collect_citations(
+    grounding_summary: list[dict[str, JsonValue]],
+) -> list[dict[str, str]]:
+    """Flatten every claim's sources into migration 252's citation shape."""
+
+    seen: set[str] = set()
+    citations: list[dict[str, str]] = []
+    for claim in grounding_summary:
+        refs = claim.get("source_record_ids", [])
+        if not isinstance(refs, list):
+            continue
+        for ref_value in refs:
+            ref = str(ref_value)
             if ref in seen:
                 continue
             seen.add(ref)
-            citations.append({"source_record_id": str(ref)})
+            citations.append({"source_record_id": ref})
     return citations
 
 
@@ -416,7 +493,10 @@ async def _save_shadow_decision(
     *,
     decision: Decision,
     rule_pack_db_id: uuid.UUID,
+    ruleset_activation_id: uuid.UUID,
     environment: str,
+    request_fingerprint: bytes,
+    request_category: Purpose,
 ) -> None:
     """INSERT one ``visa_decisions`` row for a SHADOW ``Decision``.
 
@@ -427,10 +507,10 @@ async def _save_shadow_decision(
     not schema-enforced to be equal, so the writer must resolve the DB PK
     itself rather than trust the Decision's self-reported one.
 
-    ``ruleset_activation_id`` is always left ``NULL`` (STEP-6c scope; the
-    binding trigger's activation-containment checks only run when it is
-    set, so leaving it NULL is a valid, narrower-scoped row). ``engine_mode``
-    is always ``'SHADOW'`` — this writer never produces an ENFORCE row.
+    ``ruleset_activation_id`` is the exact activation selected alongside the
+    pack, so migration 252's trigger re-proves both bitemporal containment
+    checks at INSERT time. ``engine_mode`` is always ``'SHADOW'`` — this
+    writer never produces an ENFORCE row.
 
     ``ON CONFLICT (decision_id) DO NOTHING`` guards ONLY against an exact
     double-insert of the SAME decision (same ``decision_id``) — e.g. a
@@ -448,7 +528,9 @@ async def _save_shadow_decision(
     rule_pack_sha256 = (
         bytes.fromhex(decision.rule_pack.payload_sha256) if decision.rule_pack is not None else None
     )
-    citations = _collect_citations(decision)
+    candidate_summary = _build_candidate_summary(decision)
+    grounding_summary = _build_grounding_summary(decision)
+    citations = _collect_citations(grounding_summary)
 
     async with db_pool.acquire() as conn:
         await conn.execute(
@@ -456,9 +538,12 @@ async def _save_shadow_decision(
             INSERT INTO visa_decisions (
                 decision_id, environment, engine_surface, engine_mode,
                 rule_pack_id, ruleset_activation_id, rule_pack_sha256, verdict,
-                citations, engine_version, effective_at, observed_at, evaluated_at
+                citations, engine_version, effective_at, observed_at, evaluated_at,
+                request_fingerprint, request_category, candidate_summary,
+                grounding_summary
             ) VALUES (
-                $1, $2, $3, $4, $5, $6, $7, $8, $9::text::jsonb, $10, $11, $12, $13
+                $1, $2, $3, $4, $5, $6, $7, $8, $9::text::jsonb, $10, $11, $12, $13,
+                $14, $15, $16::text::jsonb, $17::text::jsonb
             )
             ON CONFLICT (decision_id) DO NOTHING
             """,
@@ -467,7 +552,7 @@ async def _save_shadow_decision(
             EngineSurface.MATCH.value,
             EngineMode.SHADOW.value,
             rule_pack_db_id,
-            None,
+            ruleset_activation_id,
             rule_pack_sha256,
             decision.state.value,
             json.dumps(citations),
@@ -475,6 +560,10 @@ async def _save_shadow_decision(
             decision.effective_at,
             decision.observed_at,
             decision.evaluated_at,
+            request_fingerprint,
+            request_category.value,
+            json.dumps(candidate_summary),
+            json.dumps(grounding_summary),
         )
 
 
@@ -495,14 +584,15 @@ async def _shadow_evaluate_match(
     this fire-and-forget via ``spawn()``, but this function must also stay
     safe if ever awaited directly, e.g. by a test).
 
-    NEVER logs ``nationality``/``purpose``/``duration_months``/facts —
-    every log line below carries only ``match_hash``, the resolved
-    environment, the verdict, and/or a candidate count.
+    NEVER logs ``nationality``/``purpose``/``duration_months``/facts or the
+    public ``match_hash`` — every log line below carries only a hash trace,
+    the resolved environment, the verdict, and/or a candidate count.
     """
 
     try:
         now = datetime.now(timezone.utc)
         environment = _resolve_match_environment()
+        request_trace = _request_trace(match_hash)
 
         binding = await _resolve_active_pack_binding(
             db_pool,
@@ -512,9 +602,9 @@ async def _shadow_evaluate_match(
         )
         if binding is None:
             logger.debug(
-                "shadow match: no active rule pack for environment=%s, skipping (hash=%s)",
+                "shadow match: no active rule pack for environment=%s, skipping (trace=%s)",
                 environment,
-                match_hash,
+                request_trace,
             )
             return
 
@@ -526,7 +616,8 @@ async def _shadow_evaluate_match(
         )
         if facts is None:
             logger.warning(
-                "shadow match: could not build applicant facts, skipping (hash=%s)", match_hash
+                "shadow match: could not build applicant facts, skipping (trace=%s)",
+                request_trace,
             )
             return
 
@@ -559,16 +650,16 @@ async def _shadow_evaluate_match(
             logger.warning(
                 "shadow match: active pack environment=%s needs a real crypto "
                 "identity_provider (STEP-6d) / a provisioned facts-fingerprint "
-                "key, skipping (hash=%s)",
+                "key, skipping (trace=%s)",
                 environment,
-                match_hash,
+                request_trace,
             )
             return
         except FactsFingerprintKeyError:
             logger.warning(
                 "shadow match: malformed facts-fingerprint key config "
-                "(VISA_ENGINE_FACTS_FINGERPRINT_KEYS_JSON), skipping (hash=%s)",
-                match_hash,
+                "(VISA_ENGINE_FACTS_FINGERPRINT_KEYS_JSON), skipping (trace=%s)",
+                request_trace,
             )
             return
         except Exception as exc:  # defense-in-depth — evaluate() is documented pure/total
@@ -581,17 +672,24 @@ async def _shadow_evaluate_match(
         await _save_shadow_decision(
             db_pool,
             decision=decision,
-            rule_pack_db_id=binding.id,
+            rule_pack_db_id=binding.rule_pack_id,
+            ruleset_activation_id=binding.ruleset_activation_id,
             environment=environment,
+            request_fingerprint=_request_fingerprint(match_hash),
+            request_category=purpose,
         )
         logger.info(
-            "shadow match decision written: hash=%s verdict=%s candidates=%d",
-            match_hash,
+            "shadow match decision written: trace=%s verdict=%s candidates=%d",
+            request_trace,
             decision.state.value,
             len(decision.candidates),
         )
     except Exception:
-        logger.warning("shadow match evaluation failed (hash=%s)", match_hash, exc_info=True)
+        logger.warning(
+            "shadow match evaluation failed (trace=%s)",
+            _request_trace(match_hash),
+            exc_info=True,
+        )
 
 
 def maybe_spawn_shadow_match(
@@ -613,6 +711,7 @@ def maybe_spawn_shadow_match(
 
     try:
         if resolve_match_shadow_enabled():
+            request_trace = _request_trace(match_hash)
             spawn(
                 _shadow_evaluate_match(
                     db_pool,
@@ -621,12 +720,12 @@ def maybe_spawn_shadow_match(
                     duration_months=duration_months,
                     match_hash=match_hash,
                 ),
-                name=f"shadow-match-{match_hash}",
+                name=f"shadow-match-{request_trace}",
             )
     except Exception:
         logger.warning(
-            "maybe_spawn_shadow_match: failed to schedule shadow evaluation (hash=%s)",
-            match_hash,
+            "maybe_spawn_shadow_match: failed to schedule shadow evaluation (trace=%s)",
+            _request_trace(match_hash),
             exc_info=True,
         )
 

--- a/apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
+++ b/apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
@@ -1,0 +1,466 @@
+"""Fail-closed, PII-free Visa Oracle SHADOW gate evidence collector.
+
+This module measures only the two gates that can be derived from the
+``visa_decisions`` audit log: G-a (volume/breadth) and G-c (grounding).
+G-b (the independently graded 20-persona replay) and G-d (the recorded live
+rollback drill) are always reported as unmeasured here.  Consequently this
+collector can never, by itself, declare ENFORCE ready.
+
+No applicant facts, Match tokens, decision IDs, or request fingerprints are
+returned.  The collector reads the PII-free audit projection and emits only
+counts, dates, categories, and product codes.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import asyncpg
+from pydantic import ValidationError
+
+from backend.services.visa_check.match_tree import Purpose
+from backend.services.visa_engine.enums import DecisionState
+from backend.services.visa_engine.models import RulePackPayload, SourceRecord
+
+MIN_DISTINCT_REQUESTS = 1_000
+MIN_CONSECUTIVE_DAYS = 7
+MIN_DISTINCT_VISA_CODES = 30
+REQUIRED_INTERVIEW_CATEGORIES = frozenset(
+    purpose.value for purpose in Purpose if purpose is not Purpose.OTHER
+)
+
+_VALID_CATEGORIES = frozenset(purpose.value for purpose in Purpose)
+_CITATIONLESS_ABSTENTION_STATES = frozenset({DecisionState.NEEDS_INPUT.value})
+
+
+def _json_array(value: object) -> list[object] | None:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    return value if isinstance(value, list) else None
+
+
+def _json_object(value: object) -> dict[str, Any] | None:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    return value if isinstance(value, dict) else None
+
+
+def _uuid(value: object) -> uuid.UUID | None:
+    try:
+        return value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+def _utc(value: object) -> datetime | None:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        return None
+    return value.astimezone(timezone.utc)
+
+
+def _longest_consecutive_day_streak(days: set[date]) -> int:
+    longest = 0
+    current = 0
+    previous: date | None = None
+    for day in sorted(days):
+        current = current + 1 if previous is not None and day - previous == timedelta(days=1) else 1
+        longest = max(longest, current)
+        previous = day
+    return longest
+
+
+def _period_contains(source: SourceRecord, moment: datetime, *, recorded: bool) -> bool:
+    period = source.recorded_period if recorded else source.legal_period
+    return period.from_ <= moment and (period.to is None or moment < period.to)
+
+
+def _gate(status: bool, **details: object) -> dict[str, object]:
+    return {"status": "GREEN" if status else "RED", "green": status, **details}
+
+
+def evaluate_shadow_evidence(
+    rows: Sequence[Mapping[str, object]],
+    packs: Mapping[uuid.UUID, RulePackPayload],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    invalid_pack_count: int = 0,
+) -> dict[str, object]:
+    """Aggregate safe audit rows into the objective gate report.
+
+    ``rows`` must contain only migration-255's PII-free projection.  Any
+    missing/malformed field is counted and makes the relevant gate red.
+    """
+
+    if window_start.tzinfo is None or window_end.tzinfo is None:
+        raise ValueError("window_start/window_end must be timezone-aware")
+    if window_start >= window_end:
+        raise ValueError("window_start must be before window_end")
+
+    window_duration = window_end.astimezone(timezone.utc) - window_start.astimezone(timezone.utc)
+    fingerprints: set[bytes] = set()
+    categories: Counter[str] = Counter()
+    candidate_codes: set[str] = set()
+    active_days: set[date] = set()
+    missing_request_fingerprints = 0
+    missing_or_invalid_categories = 0
+    malformed_candidate_summaries = 0
+    invalid_candidate_bindings = 0
+    missing_ruleset_activations = 0
+    missing_rule_pack_digests = 0
+    malformed_grounding_summaries = 0
+    decisions_without_citations = 0
+    ungrounded_claims = 0
+    malformed_citations = 0
+    citations_not_claimed = 0
+    claimed_sources_not_cited = 0
+    unresolved_or_invalid_sources = 0
+
+    source_indexes: dict[uuid.UUID, dict[uuid.UUID, SourceRecord]] = {
+        pack_id: {source.source_record_id: source for source in pack.source_records}
+        for pack_id, pack in packs.items()
+    }
+    product_indexes: dict[uuid.UUID, set[tuple[uuid.UUID, str]]] = {
+        pack_id: {
+            (product.product_version_id, str(product.product_code)) for product in pack.products
+        }
+        for pack_id, pack in packs.items()
+    }
+
+    for row in rows:
+        pack_id = _uuid(row.get("rule_pack_id"))
+        if _uuid(row.get("ruleset_activation_id")) is None:
+            missing_ruleset_activations += 1
+
+        rule_pack_sha256 = row.get("rule_pack_sha256")
+        if isinstance(rule_pack_sha256, memoryview):
+            rule_pack_sha256 = rule_pack_sha256.tobytes()
+        elif isinstance(rule_pack_sha256, bytearray):
+            rule_pack_sha256 = bytes(rule_pack_sha256)
+        if not isinstance(rule_pack_sha256, bytes) or len(rule_pack_sha256) != 32:
+            missing_rule_pack_digests += 1
+
+        fingerprint = row.get("request_fingerprint")
+        if isinstance(fingerprint, memoryview):
+            fingerprint = fingerprint.tobytes()
+        elif isinstance(fingerprint, bytearray):
+            fingerprint = bytes(fingerprint)
+        if isinstance(fingerprint, bytes) and len(fingerprint) == 32:
+            fingerprints.add(fingerprint)
+        else:
+            missing_request_fingerprints += 1
+
+        category = row.get("request_category")
+        if isinstance(category, str) and category in _VALID_CATEGORIES:
+            categories[category] += 1
+        else:
+            missing_or_invalid_categories += 1
+
+        evaluated_at = _utc(row.get("evaluated_at"))
+        if evaluated_at is not None:
+            active_days.add(evaluated_at.date())
+
+        candidate_summary = _json_array(row.get("candidate_summary"))
+        if candidate_summary is None:
+            malformed_candidate_summaries += 1
+        else:
+            candidate_shape_ok = True
+            for candidate in candidate_summary:
+                if not isinstance(candidate, dict):
+                    candidate_shape_ok = False
+                    continue
+                product_code = candidate.get("product_code")
+                product_version_id = _uuid(candidate.get("product_version_id"))
+                product_binding = (product_version_id, product_code)
+                if (
+                    product_version_id is not None
+                    and isinstance(product_code, str)
+                    and product_binding in product_indexes.get(pack_id, set())
+                ):
+                    candidate_codes.add(product_code)
+                else:
+                    candidate_shape_ok = False
+                    invalid_candidate_bindings += 1
+            if not candidate_shape_ok:
+                malformed_candidate_summaries += 1
+
+        citations = _json_array(row.get("citations"))
+        citation_refs: set[uuid.UUID] = set()
+        if citations is None:
+            malformed_citations += 1
+        else:
+            citation_shape_ok = True
+            for citation in citations:
+                if not isinstance(citation, dict):
+                    citation_shape_ok = False
+                    continue
+                ref = _uuid(citation.get("source_record_id"))
+                if ref is None:
+                    citation_shape_ok = False
+                else:
+                    citation_refs.add(ref)
+            if not citation_shape_ok:
+                malformed_citations += 1
+
+        grounding_summary = _json_array(row.get("grounding_summary"))
+        claimed_refs: set[uuid.UUID] = set()
+        citationless_abstention = False
+        if grounding_summary is None or not grounding_summary:
+            malformed_grounding_summaries += 1
+            ungrounded_claims += 1
+        else:
+            grounding_shape_ok = True
+            verdict_claim_count = 0
+            row_verdict = row.get("verdict")
+            for claim in grounding_summary:
+                if not isinstance(claim, dict):
+                    grounding_shape_ok = False
+                    ungrounded_claims += 1
+                    continue
+                claim_kind = claim.get("claim_kind")
+                claim_code = claim.get("claim_code")
+                raw_refs = claim.get("source_record_ids")
+                if not isinstance(claim_kind, str) or not isinstance(claim_code, str):
+                    grounding_shape_ok = False
+                if claim_kind == "VERDICT":
+                    verdict_claim_count += 1
+                    if claim_code != row_verdict:
+                        grounding_shape_ok = False
+                if not isinstance(raw_refs, list):
+                    grounding_shape_ok = False
+                    ungrounded_claims += 1
+                    continue
+                refs = {_uuid(value) for value in raw_refs}
+                claim_is_citationless_abstention = (
+                    claim_kind == "VERDICT"
+                    and claim_code in _CITATIONLESS_ABSTENTION_STATES
+                    and claim_code == row_verdict
+                    and raw_refs == []
+                )
+                if claim_is_citationless_abstention:
+                    citationless_abstention = True
+                elif None in refs or not refs:
+                    grounding_shape_ok = False
+                    ungrounded_claims += 1
+                claimed_refs.update(ref for ref in refs if ref is not None)
+            if verdict_claim_count != 1:
+                grounding_shape_ok = False
+            if not grounding_shape_ok:
+                malformed_grounding_summaries += 1
+
+        if not citation_refs and not citationless_abstention:
+            decisions_without_citations += 1
+
+        citations_not_claimed += len(citation_refs - claimed_refs)
+        claimed_sources_not_cited += len(claimed_refs - citation_refs)
+
+        effective_at = _utc(row.get("effective_at"))
+        observed_at = _utc(row.get("observed_at"))
+        sources = source_indexes.get(pack_id, {}) if pack_id is not None else {}
+        for ref in citation_refs:
+            source = sources.get(ref)
+            if (
+                source is None
+                or source.status.value != "VERIFIED"
+                or not source.canonical_url.strip()
+                or effective_at is None
+                or observed_at is None
+                or not _period_contains(source, effective_at, recorded=False)
+                or not _period_contains(source, observed_at, recorded=True)
+            ):
+                unresolved_or_invalid_sources += 1
+
+    longest_streak = _longest_consecutive_day_streak(active_days)
+    missing_categories = sorted(REQUIRED_INTERVIEW_CATEGORIES - categories.keys())
+    gate_a_green = (
+        window_duration >= timedelta(days=MIN_CONSECUTIVE_DAYS)
+        and len(fingerprints) >= MIN_DISTINCT_REQUESTS
+        and longest_streak >= MIN_CONSECUTIVE_DAYS
+        and not missing_categories
+        and len(candidate_codes) >= MIN_DISTINCT_VISA_CODES
+        and missing_request_fingerprints == 0
+        and missing_or_invalid_categories == 0
+        and malformed_candidate_summaries == 0
+        and invalid_candidate_bindings == 0
+    )
+    gate_c_green = (
+        bool(rows)
+        and invalid_pack_count == 0
+        and missing_ruleset_activations == 0
+        and missing_rule_pack_digests == 0
+        and malformed_grounding_summaries == 0
+        and decisions_without_citations == 0
+        and ungrounded_claims == 0
+        and malformed_citations == 0
+        and citations_not_claimed == 0
+        and claimed_sources_not_cited == 0
+        and unresolved_or_invalid_sources == 0
+    )
+
+    gate_a = _gate(
+        gate_a_green,
+        total_audit_rows=len(rows),
+        window_duration_hours=window_duration.total_seconds() / 3600,
+        minimum_window_duration_hours=MIN_CONSECUTIVE_DAYS * 24,
+        distinct_requests=len(fingerprints),
+        minimum_distinct_requests=MIN_DISTINCT_REQUESTS,
+        duplicate_evaluations=max(0, len(rows) - len(fingerprints)),
+        active_utc_days=len(active_days),
+        longest_consecutive_utc_day_streak=longest_streak,
+        minimum_consecutive_days=MIN_CONSECUTIVE_DAYS,
+        category_counts=dict(sorted(categories.items())),
+        missing_required_categories=missing_categories,
+        required_categories=sorted(REQUIRED_INTERVIEW_CATEGORIES),
+        distinct_visa_codes=len(candidate_codes),
+        minimum_distinct_visa_codes=MIN_DISTINCT_VISA_CODES,
+        visa_codes=sorted(candidate_codes),
+        missing_request_fingerprints=missing_request_fingerprints,
+        missing_or_invalid_categories=missing_or_invalid_categories,
+        malformed_candidate_summaries=malformed_candidate_summaries,
+        invalid_candidate_bindings=invalid_candidate_bindings,
+    )
+    gate_c = _gate(
+        gate_c_green,
+        invalid_rule_pack_payloads=invalid_pack_count,
+        missing_ruleset_activations=missing_ruleset_activations,
+        missing_rule_pack_digests=missing_rule_pack_digests,
+        malformed_grounding_summaries=malformed_grounding_summaries,
+        decisions_without_citations=decisions_without_citations,
+        ungrounded_claims=ungrounded_claims,
+        malformed_citations=malformed_citations,
+        citations_not_claimed=citations_not_claimed,
+        claimed_sources_not_cited=claimed_sources_not_cited,
+        unresolved_or_invalid_sources=unresolved_or_invalid_sources,
+    )
+
+    return {
+        "schema_version": "visa-shadow-evidence/1.0.0",
+        "window": {
+            "start": window_start.astimezone(timezone.utc).isoformat(),
+            "end_exclusive": window_end.astimezone(timezone.utc).isoformat(),
+        },
+        "enforce_ready": False,
+        "gate_status": "RED",
+        "gates": {
+            "G-a": gate_a,
+            "G-b": {
+                "status": "UNMEASURED",
+                "green": False,
+                "reason": "requires independent canonical 20-persona replay evidence",
+            },
+            "G-c": gate_c,
+            "G-d": {
+                "status": "UNMEASURED",
+                "green": False,
+                "reason": "requires a recorded live ENFORCE-to-OFF rollback drill",
+            },
+        },
+        "blockers": [
+            gate
+            for gate, evidence in (("G-a", gate_a), ("G-c", gate_c))
+            if evidence["green"] is False
+        ]
+        + ["G-b", "G-d"],
+    }
+
+
+async def collect_shadow_evidence(
+    db_pool: asyncpg.Pool,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    environment: str = "PRODUCTION",
+) -> dict[str, object]:
+    """Read the SHADOW audit projection and return an aggregate gate report."""
+
+    if window_start.tzinfo is None or window_end.tzinfo is None:
+        raise ValueError("window_start/window_end must be timezone-aware")
+    if window_start >= window_end:
+        raise ValueError("window_start must be before window_end")
+
+    async with db_pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT
+                request_fingerprint,
+                request_category,
+                candidate_summary,
+                grounding_summary,
+                citations,
+                verdict,
+                rule_pack_id,
+                ruleset_activation_id,
+                rule_pack_sha256,
+                effective_at,
+                observed_at,
+                evaluated_at
+            FROM public.visa_decisions
+            WHERE environment = $1
+              AND engine_surface = 'MATCH'
+              AND engine_mode = 'SHADOW'
+              AND evaluated_at >= $2
+              AND evaluated_at < $3
+            ORDER BY evaluated_at
+            """,
+            environment,
+            window_start,
+            window_end,
+        )
+
+        pack_ids = sorted(
+            {pack_id for row in rows if (pack_id := _uuid(row["rule_pack_id"])) is not None},
+            key=str,
+        )
+        pack_rows = (
+            await conn.fetch(
+                "SELECT id, payload FROM public.visa_rule_packs WHERE id = ANY($1::uuid[])",
+                pack_ids,
+            )
+            if pack_ids
+            else []
+        )
+
+    packs: dict[uuid.UUID, RulePackPayload] = {}
+    invalid_pack_ids: set[uuid.UUID] = set(pack_ids)
+    for row in pack_rows:
+        row_id = _uuid(row["id"])
+        if row_id is None:
+            continue
+        payload = _json_object(row["payload"])
+        if payload is None:
+            continue
+        try:
+            parsed = RulePackPayload.model_validate(payload)
+        except ValidationError:
+            continue
+        packs[row_id] = parsed
+        invalid_pack_ids.discard(row_id)
+
+    return evaluate_shadow_evidence(
+        rows,
+        packs,
+        window_start=window_start,
+        window_end=window_end,
+        invalid_pack_count=len(invalid_pack_ids),
+    )
+
+
+__all__ = [
+    "MIN_CONSECUTIVE_DAYS",
+    "MIN_DISTINCT_REQUESTS",
+    "MIN_DISTINCT_VISA_CODES",
+    "REQUIRED_INTERVIEW_CATEGORIES",
+    "collect_shadow_evidence",
+    "evaluate_shadow_evidence",
+]

--- a/apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
+++ b/apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
@@ -110,6 +110,7 @@ def evaluate_shadow_evidence(
 
     window_duration = window_end.astimezone(timezone.utc) - window_start.astimezone(timezone.utc)
     fingerprints: set[bytes] = set()
+    valid_fingerprint_evaluations = 0
     categories: Counter[str] = Counter()
     candidate_codes: set[str] = set()
     active_days: set[date] = set()
@@ -157,6 +158,7 @@ def evaluate_shadow_evidence(
         elif isinstance(fingerprint, bytearray):
             fingerprint = bytes(fingerprint)
         if isinstance(fingerprint, bytes) and len(fingerprint) == 32:
+            valid_fingerprint_evaluations += 1
             fingerprints.add(fingerprint)
         else:
             missing_request_fingerprints += 1
@@ -315,7 +317,7 @@ def evaluate_shadow_evidence(
         minimum_window_duration_hours=MIN_CONSECUTIVE_DAYS * 24,
         distinct_requests=len(fingerprints),
         minimum_distinct_requests=MIN_DISTINCT_REQUESTS,
-        duplicate_evaluations=max(0, len(rows) - len(fingerprints)),
+        duplicate_evaluations=valid_fingerprint_evaluations - len(fingerprints),
         active_utc_days=len(active_days),
         longest_consecutive_utc_day_streak=longest_streak,
         minimum_consecutive_days=MIN_CONSECUTIVE_DAYS,

--- a/apps/backend-rag/backend/tests/scripts/test_visa_shadow_evidence.py
+++ b/apps/backend-rag/backend/tests/scripts/test_visa_shadow_evidence.py
@@ -1,0 +1,112 @@
+"""CLI safety tests for the aggregate-only Visa Oracle SHADOW report."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts import visa_shadow_evidence as cli
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_parser_rejects_naive_timestamp(capsys: pytest.CaptureFixture[str]) -> None:
+    parser = cli._parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(
+            [
+                "--start",
+                "2026-07-21T00:00:00",
+                "--end",
+                "2026-07-22T00:00:00Z",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    assert "timestamp must include a timezone" in capsys.readouterr().err
+
+
+def test_main_rejects_missing_database_url_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    variable = "VISA_SHADOW_TEST_DATABASE_URL"
+    monkeypatch.delenv(variable, raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "visa_shadow_evidence.py",
+            "--start",
+            "2026-07-21T00:00:00Z",
+            "--end",
+            "2026-07-22T00:00:00Z",
+            "--database-url-env",
+            variable,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 2
+    assert f"missing database URL environment variable: {variable}" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_run_forces_read_only_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    variable = "VISA_SHADOW_TEST_DATABASE_URL"
+    monkeypatch.setenv(variable, "postgresql://unused-local-test.invalid/visa")
+    pool = _Pool()
+    create_pool_call: dict[str, object] = {}
+
+    async def fake_create_pool(database_url: str, **kwargs: object) -> _Pool:
+        create_pool_call["database_url"] = database_url
+        create_pool_call.update(kwargs)
+        return pool
+
+    async def fake_collect(
+        db_pool: object,
+        *,
+        window_start: datetime,
+        window_end: datetime,
+        environment: str,
+    ) -> dict[str, object]:
+        assert db_pool is pool
+        assert window_start.tzinfo is not None
+        assert window_end > window_start
+        assert environment == "TEST"
+        return {"gate_status": "RED", "enforce_ready": False}
+
+    monkeypatch.setattr(cli.asyncpg, "create_pool", fake_create_pool)
+    monkeypatch.setattr(cli, "collect_shadow_evidence", fake_collect)
+    start = datetime(2026, 7, 21, tzinfo=timezone.utc)
+    args = argparse.Namespace(
+        start=start,
+        end=start + timedelta(days=1),
+        environment="TEST",
+        database_url_env=variable,
+    )
+
+    report = await cli._run(args)
+
+    assert report == {"gate_status": "RED", "enforce_ready": False}
+    assert create_pool_call == {
+        "database_url": "postgresql://unused-local-test.invalid/visa",
+        "min_size": 1,
+        "max_size": 2,
+        "server_settings": {"default_transaction_read_only": "on"},
+    }
+    assert pool.closed is True

--- a/apps/backend-rag/backend/tests/scripts/test_visa_shadow_evidence.py
+++ b/apps/backend-rag/backend/tests/scripts/test_visa_shadow_evidence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 from datetime import datetime, timedelta, timezone
 
@@ -61,6 +62,46 @@ def test_main_rejects_missing_database_url_environment(
 
     assert exc_info.value.code == 2
     assert f"missing database URL environment variable: {variable}" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "error",
+    (
+        cli.asyncpg.PostgresError("database rejected the query"),
+        cli.asyncpg.InterfaceError("database connection is closed"),
+        OSError("database socket is unavailable"),
+        asyncio.TimeoutError("database query timed out"),
+    ),
+    ids=("postgres", "interface", "os", "timeout"),
+)
+def test_main_reports_operational_errors_without_using_report(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    error: Exception,
+) -> None:
+    async def fail_run(_args: argparse.Namespace) -> dict[str, object]:
+        raise error
+
+    monkeypatch.setattr(cli, "_run", fail_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "visa_shadow_evidence.py",
+            "--start",
+            "2026-07-21T00:00:00Z",
+            "--end",
+            "2026-07-22T00:00:00Z",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert str(error) in captured.err
+    assert captured.out == ""
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
@@ -1,0 +1,176 @@
+"""Pure aggregation tests for the Visa Oracle SHADOW evidence gate."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+from backend.services.visa_engine.models import RulePack
+from backend.services.visa_engine.shadow_evidence import (
+    REQUIRED_INTERVIEW_CATEGORIES,
+    evaluate_shadow_evidence,
+)
+from backend.tests.services.visa_engine.gold_harness import loader as gold_loader
+
+
+def _green_fixture() -> tuple[list[dict[str, object]], RulePack, uuid.UUID]:
+    pack = RulePack.model_validate(gold_loader.load_rule_pack_raw())
+    db_pack_id = uuid.uuid5(pack.payload.rule_pack_id, "database-row")
+    product_template = pack.payload.products[0]
+    products = tuple(
+        product_template.model_copy(
+            update={
+                "product_version_id": uuid.uuid5(pack.payload.rule_pack_id, f"product-{index}"),
+                "product_code": f"X{index:02d}",
+            }
+        )
+        for index in range(30)
+    )
+    pack = pack.model_copy(
+        update={"payload": pack.payload.model_copy(update={"products": products})}
+    )
+    source_id = str(pack.payload.source_records[0].source_record_id)
+    categories = sorted(REQUIRED_INTERVIEW_CATEGORIES)
+    rows: list[dict[str, object]] = []
+    for index in range(1_000):
+        evaluated_at = gold_loader.GOLD_EFFECTIVE_AT + timedelta(days=index % 7, seconds=index)
+        rows.append(
+            {
+                "request_fingerprint": index.to_bytes(32, "big"),
+                "request_category": categories[index % len(categories)],
+                "candidate_summary": [
+                    {
+                        "product_version_id": str(products[index % 30].product_version_id),
+                        "product_code": str(products[index % 30].product_code),
+                    }
+                ],
+                "grounding_summary": [
+                    {
+                        "claim_kind": "VERDICT",
+                        "claim_code": "SUPPORTED_CANDIDATES",
+                        "source_record_ids": [source_id],
+                    }
+                ],
+                "citations": [{"source_record_id": source_id}],
+                "verdict": "SUPPORTED_CANDIDATES",
+                "rule_pack_id": db_pack_id,
+                "ruleset_activation_id": uuid.uuid5(pack.payload.rule_pack_id, "shadow-activation"),
+                "rule_pack_sha256": bytes.fromhex(pack.payload_sha256),
+                "effective_at": evaluated_at,
+                "observed_at": evaluated_at,
+                "evaluated_at": evaluated_at,
+            }
+        )
+    return rows, pack, db_pack_id
+
+
+def test_green_shadow_projection_still_cannot_arm_enforce() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    report = evaluate_shadow_evidence(
+        rows,
+        {db_pack_id: pack.payload},
+        window_start=gold_loader.GOLD_EFFECTIVE_AT,
+        window_end=gold_loader.GOLD_EFFECTIVE_AT + timedelta(days=8),
+    )
+
+    gates = report["gates"]
+    assert gates["G-a"]["green"] is True
+    assert gates["G-c"]["green"] is True
+    assert gates["G-b"]["status"] == "UNMEASURED"
+    assert gates["G-d"]["status"] == "UNMEASURED"
+    assert report["enforce_ready"] is False
+    assert report["gate_status"] == "RED"
+
+
+def test_duplicate_request_and_ungrounded_verdict_fail_closed() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    rows[-1]["request_fingerprint"] = rows[0]["request_fingerprint"]
+    rows[-1]["candidate_summary"] = [
+        {
+            "product_version_id": str(uuid.uuid4()),
+            "product_code": "X29",
+        }
+    ]
+    rows[-1]["ruleset_activation_id"] = None
+    rows[-1]["rule_pack_sha256"] = None
+    rows[0]["grounding_summary"] = [
+        {
+            "claim_kind": "VERDICT",
+            "claim_code": "SUPPORTED_CANDIDATES",
+            "source_record_ids": [],
+        }
+    ]
+    rows[0]["citations"] = []
+
+    report = evaluate_shadow_evidence(
+        rows,
+        {db_pack_id: pack.payload},
+        window_start=gold_loader.GOLD_EFFECTIVE_AT,
+        window_end=gold_loader.GOLD_EFFECTIVE_AT + timedelta(days=8),
+    )
+
+    gates = report["gates"]
+    assert gates["G-a"]["green"] is False
+    assert gates["G-a"]["distinct_requests"] == 999
+    assert gates["G-a"]["invalid_candidate_bindings"] == 1
+    assert gates["G-c"]["green"] is False
+    assert gates["G-c"]["decisions_without_citations"] == 1
+    assert gates["G-c"]["missing_ruleset_activations"] == 1
+    assert gates["G-c"]["missing_rule_pack_digests"] == 1
+    assert gates["G-c"]["ungrounded_claims"] == 1
+
+
+def test_citationless_needs_input_abstention_passes_grounding() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    rows[0]["verdict"] = "NEEDS_INPUT"
+    rows[0]["candidate_summary"] = []
+    rows[0]["grounding_summary"] = [
+        {
+            "claim_kind": "VERDICT",
+            "claim_code": "NEEDS_INPUT",
+            "source_record_ids": [],
+        }
+    ]
+    rows[0]["citations"] = []
+
+    report = evaluate_shadow_evidence(
+        rows,
+        {db_pack_id: pack.payload},
+        window_start=gold_loader.GOLD_EFFECTIVE_AT,
+        window_end=gold_loader.GOLD_EFFECTIVE_AT + timedelta(days=8),
+    )
+
+    gates = report["gates"]
+    assert gates["G-c"]["green"] is True
+    assert gates["G-c"]["decisions_without_citations"] == 0
+    assert gates["G-c"]["ungrounded_claims"] == 0
+
+
+def test_window_shorter_than_seven_full_days_fails_volume() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    start = gold_loader.GOLD_EFFECTIVE_AT
+    report = evaluate_shadow_evidence(
+        rows,
+        {db_pack_id: pack.payload},
+        window_start=start,
+        window_end=start + timedelta(days=6, hours=23),
+    )
+
+    gate_a = report["gates"]["G-a"]
+    assert gate_a["longest_consecutive_utc_day_streak"] == 7
+    assert gate_a["window_duration_hours"] == 167
+    assert gate_a["green"] is False
+
+
+def test_empty_window_is_red_not_vacuously_green() -> None:
+    start = gold_loader.GOLD_EFFECTIVE_AT
+    report = evaluate_shadow_evidence(
+        [],
+        {},
+        window_start=start,
+        window_end=start + timedelta(days=8),
+    )
+
+    assert report["gates"]["G-a"]["green"] is False
+    assert report["gates"]["G-c"]["green"] is False
+    assert report["enforce_ready"] is False

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
@@ -1,16 +1,31 @@
-"""Pure aggregation tests for the Visa Oracle SHADOW evidence gate."""
+"""Aggregation and local-DB tests for the Visa Oracle SHADOW evidence gate."""
 
 from __future__ import annotations
 
+import hashlib
 import uuid
-from datetime import timedelta
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import cast
 
-from backend.services.visa_engine.models import RulePack
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from backend.db.migration_base import split_migration_sql
+from backend.services.visa_engine.enums import SourceStatus
+from backend.services.visa_engine.models import RulePack, SourceRecord
 from backend.services.visa_engine.shadow_evidence import (
     REQUIRED_INTERVIEW_CATEGORIES,
+    collect_shadow_evidence,
     evaluate_shadow_evidence,
 )
 from backend.tests.services.visa_engine.gold_harness import loader as gold_loader
+
+_BACKEND_DIR = Path(__file__).resolve().parents[3]
+_MIGRATION_252_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "252_visa_engine_write_substrate.sql"
+_MIGRATION_255_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "255_visa_shadow_evidence.sql"
 
 
 def _green_fixture() -> tuple[list[dict[str, object]], RulePack, uuid.UUID]:
@@ -62,6 +77,142 @@ def _green_fixture() -> tuple[list[dict[str, object]], RulePack, uuid.UUID]:
             }
         )
     return rows, pack, db_pack_id
+
+
+def _evaluate(
+    rows: list[dict[str, object]], pack: RulePack, db_pack_id: uuid.UUID
+) -> dict[str, object]:
+    return evaluate_shadow_evidence(
+        rows,
+        {db_pack_id: pack.payload},
+        window_start=gold_loader.GOLD_EFFECTIVE_AT,
+        window_end=gold_loader.GOLD_EFFECTIVE_AT + timedelta(days=8),
+    )
+
+
+def _add_source(pack: RulePack) -> tuple[RulePack, SourceRecord]:
+    source = pack.payload.source_records[0].model_copy(
+        update={
+            "source_record_id": uuid.uuid4(),
+            "source_key": "test.additional.source",
+        }
+    )
+    payload = pack.payload.model_copy(
+        update={"source_records": (*pack.payload.source_records, source)}
+    )
+    return pack.model_copy(update={"payload": payload}), source
+
+
+def _replace_source(pack: RulePack, source: SourceRecord) -> RulePack:
+    payload = pack.payload.model_copy(
+        update={
+            "source_records": tuple(
+                source if existing.source_record_id == source.source_record_id else existing
+                for existing in pack.payload.source_records
+            )
+        }
+    )
+    return pack.model_copy(update={"payload": payload})
+
+
+def _read_migration(path: Path, number: int) -> tuple[str, str]:
+    forward, rollback = split_migration_sql(path.read_text(encoding="utf-8"))
+    assert rollback, f"migration {number} must carry a '-- === ROLLBACK ===' section"
+    return forward, rollback
+
+
+@pytest_asyncio.fixture
+async def shadow_evidence_schema(db_pool: asyncpg.Pool, visa_schema: None) -> AsyncIterator[None]:
+    forward_252, rollback_252 = _read_migration(_MIGRATION_252_PATH, 252)
+    forward_255, rollback_255 = _read_migration(_MIGRATION_255_PATH, 255)
+    async with db_pool.acquire() as conn:
+        await conn.execute(rollback_255)
+        await conn.execute(rollback_252)
+        await conn.execute(forward_252)
+        await conn.execute(forward_255)
+    yield
+    async with db_pool.acquire() as conn:
+        await conn.execute(rollback_255)
+        await conn.execute(rollback_252)
+
+
+async def _insert_unavailable_audit_row(
+    conn: asyncpg.Connection,
+    *,
+    environment: str,
+    evaluated_at: datetime,
+    fingerprint_seed: str,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO public.visa_decisions (
+            decision_id,
+            environment,
+            engine_surface,
+            engine_mode,
+            verdict,
+            citations,
+            engine_version,
+            effective_at,
+            observed_at,
+            evaluated_at,
+            request_fingerprint,
+            request_category,
+            candidate_summary,
+            grounding_summary
+        ) VALUES (
+            $1, $2, 'MATCH', 'SHADOW', 'TEMPORARILY_UNAVAILABLE',
+            '[]'::jsonb, 'visa-engine/test', $3, $3, $3, $4, 'other',
+            '[]'::jsonb, '[]'::jsonb
+        )
+        """,
+        uuid.uuid4(),
+        environment,
+        evaluated_at,
+        hashlib.sha256(fingerprint_seed.encode("utf-8")).digest(),
+    )
+
+
+class _CollectorConnection:
+    def __init__(
+        self,
+        *,
+        decision_rows: list[dict[str, object]],
+        pack_rows: list[dict[str, object]],
+    ) -> None:
+        self._decision_rows = decision_rows
+        self._pack_rows = pack_rows
+
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
+        if "FROM public.visa_decisions" in query:
+            return self._decision_rows
+        if "FROM public.visa_rule_packs" in query:
+            return self._pack_rows
+        raise AssertionError(f"unexpected collector query: {query}")
+
+
+class _CollectorAcquireContext:
+    def __init__(self, connection: _CollectorConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> _CollectorConnection:
+        return self._connection
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> None:
+        return None
+
+
+class _CollectorPool:
+    def __init__(self, connection: _CollectorConnection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> _CollectorAcquireContext:
+        return _CollectorAcquireContext(self._connection)
 
 
 def test_green_shadow_projection_still_cannot_arm_enforce() -> None:
@@ -120,6 +271,20 @@ def test_duplicate_request_and_ungrounded_verdict_fail_closed() -> None:
     assert gates["G-c"]["ungrounded_claims"] == 1
 
 
+def test_duplicate_evaluations_ignore_missing_and_malformed_fingerprints() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    rows[-1]["request_fingerprint"] = None
+    rows[-2]["request_fingerprint"] = b"malformed"
+    rows[-3]["request_fingerprint"] = rows[0]["request_fingerprint"]
+
+    report = _evaluate(rows, pack, db_pack_id)
+
+    gate_a = report["gates"]["G-a"]
+    assert gate_a["missing_request_fingerprints"] == 2
+    assert gate_a["distinct_requests"] == 997
+    assert gate_a["duplicate_evaluations"] == 1
+
+
 def test_citationless_needs_input_abstention_passes_grounding() -> None:
     rows, pack, db_pack_id = _green_fixture()
     rows[0]["verdict"] = "NEEDS_INPUT"
@@ -174,3 +339,224 @@ def test_empty_window_is_red_not_vacuously_green() -> None:
     assert report["gates"]["G-a"]["green"] is False
     assert report["gates"]["G-c"]["green"] is False
     assert report["enforce_ready"] is False
+
+
+def test_legacy_rows_without_correlators_or_grounding_keep_both_gates_red() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    for row in rows:
+        row["request_fingerprint"] = None
+        row["request_category"] = None
+        row["candidate_summary"] = []
+        row["grounding_summary"] = []
+
+    report = _evaluate(rows, pack, db_pack_id)
+
+    gate_a = report["gates"]["G-a"]
+    gate_c = report["gates"]["G-c"]
+    assert gate_a["green"] is False
+    assert gate_a["missing_request_fingerprints"] == 1_000
+    assert gate_a["missing_or_invalid_categories"] == 1_000
+    assert gate_c["green"] is False
+    assert gate_c["malformed_grounding_summaries"] == 1_000
+    assert gate_c["ungrounded_claims"] == 1_000
+
+
+def test_citations_not_claimed_counter_is_directly_exercised() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    pack, additional_source = _add_source(pack)
+    rows[0]["citations"] = [
+        *cast(list[dict[str, object]], rows[0]["citations"]),
+        {"source_record_id": str(additional_source.source_record_id)},
+    ]
+
+    gate_c = _evaluate(rows, pack, db_pack_id)["gates"]["G-c"]
+
+    assert gate_c["green"] is False
+    assert gate_c["citations_not_claimed"] == 1
+    assert gate_c["claimed_sources_not_cited"] == 0
+    assert gate_c["unresolved_or_invalid_sources"] == 0
+
+
+def test_claimed_sources_not_cited_counter_is_directly_exercised() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    pack, additional_source = _add_source(pack)
+    grounding = cast(list[dict[str, object]], rows[0]["grounding_summary"])
+    grounding[0]["source_record_ids"] = [
+        *cast(list[str], grounding[0]["source_record_ids"]),
+        str(additional_source.source_record_id),
+    ]
+
+    gate_c = _evaluate(rows, pack, db_pack_id)["gates"]["G-c"]
+
+    assert gate_c["green"] is False
+    assert gate_c["citations_not_claimed"] == 0
+    assert gate_c["claimed_sources_not_cited"] == 1
+    assert gate_c["unresolved_or_invalid_sources"] == 0
+
+
+@pytest.mark.parametrize(
+    "malformed_citations",
+    [
+        "{not-json",
+        [{"source_record_id": "not-a-uuid"}],
+        ["not-an-object"],
+    ],
+)
+def test_malformed_citations_counter_is_directly_exercised(
+    malformed_citations: object,
+) -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    rows[0]["citations"] = malformed_citations
+
+    gate_c = _evaluate(rows, pack, db_pack_id)["gates"]["G-c"]
+
+    assert gate_c["green"] is False
+    assert gate_c["malformed_citations"] == 1
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "missing_source",
+        "non_verified_status",
+        "blank_canonical_url",
+        "missing_effective_at",
+        "missing_observed_at",
+        "outside_legal_period",
+        "outside_recorded_period",
+    ],
+)
+def test_unresolved_or_invalid_sources_counts_every_failure_condition(failure: str) -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    source = pack.payload.source_records[0]
+    cited_source_id = source.source_record_id
+
+    if failure == "missing_source":
+        cited_source_id = uuid.uuid4()
+    elif failure == "non_verified_status":
+        pack, source = _add_source(pack)
+        source = source.model_copy(update={"status": SourceStatus.SUPERSEDED})
+        pack = _replace_source(pack, source)
+        cited_source_id = source.source_record_id
+    elif failure == "blank_canonical_url":
+        pack, source = _add_source(pack)
+        source = source.model_copy(update={"canonical_url": "   "})
+        pack = _replace_source(pack, source)
+        cited_source_id = source.source_record_id
+    elif failure == "missing_effective_at":
+        rows[0]["effective_at"] = None
+    elif failure == "missing_observed_at":
+        rows[0]["observed_at"] = None
+    elif failure == "outside_legal_period":
+        rows[0]["effective_at"] = source.legal_period.from_ - timedelta(microseconds=1)
+    elif failure == "outside_recorded_period":
+        rows[0]["observed_at"] = source.recorded_period.from_ - timedelta(microseconds=1)
+    else:
+        raise AssertionError(f"unknown failure case: {failure}")
+
+    rows[0]["citations"] = [{"source_record_id": str(cited_source_id)}]
+    rows[0]["grounding_summary"] = [
+        {
+            "claim_kind": "VERDICT",
+            "claim_code": "SUPPORTED_CANDIDATES",
+            "source_record_ids": [str(cited_source_id)],
+        }
+    ]
+
+    gate_c = _evaluate(rows, pack, db_pack_id)["gates"]["G-c"]
+
+    assert gate_c["green"] is False
+    assert gate_c["unresolved_or_invalid_sources"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_collect_filters_environment_and_uses_half_open_window(
+    db_pool: asyncpg.Pool, shadow_evidence_schema: None
+) -> None:
+    start = datetime(2026, 7, 21, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    rows = [
+        ("TEST", start - timedelta(microseconds=1), "before-start"),
+        ("TEST", start, "at-start"),
+        ("TEST", end - timedelta(microseconds=1), "before-end"),
+        ("TEST", end, "at-end"),
+        ("PRODUCTION", start + timedelta(hours=12), "wrong-environment"),
+    ]
+    async with db_pool.acquire() as conn:
+        for environment, evaluated_at, seed in rows:
+            await _insert_unavailable_audit_row(
+                conn,
+                environment=environment,
+                evaluated_at=evaluated_at,
+                fingerprint_seed=seed,
+            )
+
+    report = await collect_shadow_evidence(
+        db_pool,
+        window_start=start,
+        window_end=end,
+        environment="TEST",
+    )
+
+    gate_a = report["gates"]["G-a"]
+    assert gate_a["total_audit_rows"] == 2
+    assert gate_a["distinct_requests"] == 2
+    assert gate_a["missing_request_fingerprints"] == 0
+
+
+@pytest.mark.parametrize(
+    ("pack_rows_kind", "expected_invalid_count"),
+    [
+        ("missing", 1),
+        ("invalid", 1),
+        ("valid", 0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_collect_counts_missing_or_invalid_pack_payloads(
+    pack_rows_kind: str,
+    expected_invalid_count: int,
+) -> None:
+    rows, pack, _db_pack_id = _green_fixture()
+    pack_id = uuid.uuid4()
+    decision_row = rows[0]
+    decision_row["rule_pack_id"] = pack_id
+    decision_row["candidate_summary"] = []
+    decision_row["verdict"] = "NEEDS_INPUT"
+    decision_row["citations"] = []
+    decision_row["grounding_summary"] = [
+        {
+            "claim_kind": "VERDICT",
+            "claim_code": "NEEDS_INPUT",
+            "source_record_ids": [],
+        }
+    ]
+
+    if pack_rows_kind == "missing":
+        pack_rows: list[dict[str, object]] = []
+    elif pack_rows_kind == "invalid":
+        pack_rows = [{"id": pack_id, "payload": {"not": "a-rule-pack"}}]
+    elif pack_rows_kind == "valid":
+        pack_rows = [
+            {
+                "id": pack_id,
+                "payload": pack.payload.model_dump(mode="json", by_alias=True),
+            }
+        ]
+    else:
+        raise AssertionError(f"unknown pack row kind: {pack_rows_kind}")
+
+    connection = _CollectorConnection(decision_rows=[decision_row], pack_rows=pack_rows)
+    pool = cast(asyncpg.Pool, _CollectorPool(connection))
+    start = gold_loader.GOLD_EFFECTIVE_AT
+
+    report = await collect_shadow_evidence(
+        pool,
+        window_start=start,
+        window_end=start + timedelta(days=1),
+        environment="TEST",
+    )
+
+    assert report["gates"]["G-c"]["invalid_rule_pack_payloads"] == expected_invalid_count

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_match.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_match.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
 import uuid
 from collections.abc import AsyncIterator
@@ -211,7 +212,9 @@ class TestBuildShadowFacts:
 
 class TestShadowEvaluateMatchNoopPaths:
     async def test_no_active_pack_is_a_silent_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        async def _fake_resolver(pool: object, *, environment: str, effective_at: datetime, observed_at: datetime):
+        async def _fake_resolver(
+            pool: object, *, environment: str, effective_at: datetime, observed_at: datetime
+        ):
             return None
 
         save_calls: list[object] = []
@@ -267,10 +270,23 @@ class TestShadowEvaluateMatchNoopPaths:
         pack = RulePack.model_validate(envelope)
         compiled = build_compiled_pack(pack)
 
-        async def _fake_resolver(pool: object, *, environment: str, effective_at: datetime, observed_at: datetime):
-            return shadow._PackBinding(id=uuid.uuid4(), environment="PRODUCTION", raw_envelope=envelope)
+        async def _fake_resolver(
+            pool: object, *, environment: str, effective_at: datetime, observed_at: datetime
+        ):
+            return shadow._PackBinding(
+                rule_pack_id=uuid.uuid4(),
+                ruleset_activation_id=uuid.uuid4(),
+                environment="PRODUCTION",
+                raw_envelope=envelope,
+            )
 
-        def _fake_verify(raw_envelope: object, *, trust_store: object, observed_at: datetime, allow_unsigned: bool = False):
+        def _fake_verify(
+            raw_envelope: object,
+            *,
+            trust_store: object,
+            observed_at: datetime,
+            allow_unsigned: bool = False,
+        ):
             return VerifiedRulePack(
                 pack=pack, canonical_payload=b"", payload_sha256=b"\x00" * 32, unsigned_dev=False
             )
@@ -346,10 +362,23 @@ class TestShadowEvaluateMatchNoopPaths:
         pack = RulePack.model_validate(envelope)
         compiled = build_compiled_pack(pack)
 
-        async def _fake_resolver(pool: object, *, environment: str, effective_at: datetime, observed_at: datetime):
-            return shadow._PackBinding(id=uuid.uuid4(), environment="PRODUCTION", raw_envelope=envelope)
+        async def _fake_resolver(
+            pool: object, *, environment: str, effective_at: datetime, observed_at: datetime
+        ):
+            return shadow._PackBinding(
+                rule_pack_id=uuid.uuid4(),
+                ruleset_activation_id=uuid.uuid4(),
+                environment="PRODUCTION",
+                raw_envelope=envelope,
+            )
 
-        def _fake_verify(raw_envelope: object, *, trust_store: object, observed_at: datetime, allow_unsigned: bool = False):
+        def _fake_verify(
+            raw_envelope: object,
+            *,
+            trust_store: object,
+            observed_at: datetime,
+            allow_unsigned: bool = False,
+        ):
             return VerifiedRulePack(
                 pack=pack, canonical_payload=b"", payload_sha256=b"\x00" * 32, unsigned_dev=False
             )
@@ -421,7 +450,8 @@ class TestMaybeSpawnShadowMatch:
             duration_months=1,
             match_hash="enabled-hash",
         )
-        assert spawned_names == ["shadow-match-enabled-hash"]
+        trace = hashlib.sha256(b"enabled-hash").hexdigest()[:12]
+        assert spawned_names == [f"shadow-match-{trace}"]
 
     def test_resolve_shadow_enabled_raising_never_propagates(
         self, monkeypatch: pytest.MonkeyPatch
@@ -468,12 +498,13 @@ class TestMaybeSpawnShadowMatch:
         # spawn WAS reached (the SHADOW gate opened) and its RuntimeError was
         # swallowed inside maybe_spawn; reaching this assertion proves it never
         # propagated into the request handler.
-        assert spawn_calls == ["shadow-match-boom-hash-2"]
+        trace = hashlib.sha256(b"boom-hash-2").hexdigest()[:12]
+        assert spawn_calls == [f"shadow-match-{trace}"]
 
 
 # ---------------------------------------------------------------------------
-# §5 — integration fixtures: layer migration 252 on top of conftest.py's own
-# db_pool/visa_schema (250+251+253). Defensively rolls back 252 first
+# §5 — integration fixtures: layer migrations 252+255 on conftest.py's own
+# db_pool/visa_schema (250+251+253+254). Defensively rolls back 252 first
 # (mirrors visa_schema's own rollback-then-forward convention) so this is
 # correct whether or not the shared test DB already carries 252 from a prior
 # full "apply-all" migration run — every statement in 252's rollback is
@@ -484,6 +515,7 @@ class TestMaybeSpawnShadowMatch:
 
 _BACKEND_DIR = Path(__file__).resolve().parents[3]
 _MIGRATION_252_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "252_visa_engine_write_substrate.sql"
+_MIGRATION_255_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "255_visa_shadow_evidence.sql"
 
 
 def _read_migration_252() -> tuple[str, str]:
@@ -493,14 +525,25 @@ def _read_migration_252() -> tuple[str, str]:
     return forward, rollback
 
 
+def _read_migration_255() -> tuple[str, str]:
+    sql = _MIGRATION_255_PATH.read_text(encoding="utf-8")
+    forward, rollback = split_migration_sql(sql)
+    assert rollback, "migration 255 must carry a '-- === ROLLBACK ===' section"
+    return forward, rollback
+
+
 @pytest_asyncio.fixture
 async def shadow_schema(db_pool: asyncpg.Pool, visa_schema: None) -> AsyncIterator[None]:
     forward_252, rollback_252 = _read_migration_252()
+    forward_255, rollback_255 = _read_migration_255()
     async with db_pool.acquire() as conn:
+        await conn.execute(rollback_255)
         await conn.execute(rollback_252)
         await conn.execute(forward_252)
+        await conn.execute(forward_255)
     yield
     async with db_pool.acquire() as conn:
+        await conn.execute(rollback_255)
         await conn.execute(rollback_252)
 
 
@@ -557,7 +600,7 @@ async def test_resolve_active_pack_binding_finds_active_pack_and_none_otherwise(
         payload_sha256=_pack_hash(7),
         environment=_ENV,
     )
-    await repo.activate_rule_pack(
+    activation_id = await repo.activate_rule_pack(
         rule_pack_id=pack_id, activated_by="shadow-test", activation_reason="w6c-resolver-test"
     )
 
@@ -568,7 +611,8 @@ async def test_resolve_active_pack_binding_finds_active_pack_and_none_otherwise(
         db_pool, environment=_ENV, effective_at=effective_at, observed_at=observed_at
     )
     assert binding is not None
-    assert binding.id == pack_id
+    assert binding.rule_pack_id == pack_id
+    assert binding.ruleset_activation_id == activation_id
     assert binding.environment == _ENV
     assert binding.raw_envelope["payload_sha256"] == _pack_hash(7).hex()
     assert binding.raw_envelope["canonicalization"] == "RFC8785"
@@ -597,16 +641,28 @@ async def test_save_shadow_decision_inserts_one_row_and_dedupes_on_conflict(
     rule_pack_db_id = kwargs["id"]
     repo = VisaEngineRepository(db_pool)
     await repo.insert_rule_pack(**kwargs)
+    activation_id = await repo.activate_rule_pack(
+        rule_pack_id=rule_pack_db_id,
+        activated_by="shadow-writer-test",
+        activation_reason="shadow-evidence-writer",
+    )
+    observed_at = datetime.now(timezone.utc) + timedelta(seconds=1)
 
     decision = evaluator.evaluate(
         persona.facts,
         compiled,
         effective_at=gold_loader.GOLD_EFFECTIVE_AT,
-        observed_at=gold_loader.GOLD_EFFECTIVE_AT,
+        observed_at=observed_at,
     )
 
     await shadow._save_shadow_decision(
-        db_pool, decision=decision, rule_pack_db_id=rule_pack_db_id, environment="TEST"
+        db_pool,
+        decision=decision,
+        rule_pack_db_id=rule_pack_db_id,
+        ruleset_activation_id=activation_id,
+        environment="TEST",
+        request_fingerprint=shadow._request_fingerprint("writer-hash"),
+        request_category=Purpose.OTHER,
     )
 
     async with db_pool.acquire() as conn:
@@ -619,14 +675,30 @@ async def test_save_shadow_decision_inserts_one_row_and_dedupes_on_conflict(
     assert row["engine_surface"] == "MATCH"
     assert row["verdict"] == decision.state.value
     assert row["rule_pack_id"] == rule_pack_db_id
-    assert row["ruleset_activation_id"] is None
+    assert row["ruleset_activation_id"] == activation_id
     assert row["engine_version"] == shadow.ENGINE_VERSION
     assert row["environment"] == "TEST"
+    assert row["request_fingerprint"] == hashlib.sha256(b"writer-hash").digest()
+    assert row["request_category"] == Purpose.OTHER.value
+    candidate_summary = json.loads(row["candidate_summary"])
+    grounding_summary = json.loads(row["grounding_summary"])
+    citations = json.loads(row["citations"])
+    assert isinstance(candidate_summary, list)
+    assert grounding_summary[0]["claim_kind"] == "VERDICT"
+    assert {item["source_record_id"] for item in citations} == set(
+        grounding_summary[0]["source_record_ids"]
+    )
 
     # Calling again with the SAME decision (same decision_id) is an
     # idempotent no-op — ON CONFLICT (decision_id) DO NOTHING.
     await shadow._save_shadow_decision(
-        db_pool, decision=decision, rule_pack_db_id=rule_pack_db_id, environment="TEST"
+        db_pool,
+        decision=decision,
+        rule_pack_db_id=rule_pack_db_id,
+        ruleset_activation_id=activation_id,
+        environment="TEST",
+        request_fingerprint=shadow._request_fingerprint("writer-hash"),
+        request_category=Purpose.OTHER,
     )
     async with db_pool.acquire() as conn:
         count = await conn.fetchval(
@@ -657,11 +729,29 @@ async def test_shadow_match_end_to_end_via_maybe_spawn_writes_one_row(
     rule_pack_db_id = kwargs["id"]
     repo = VisaEngineRepository(db_pool)
     await repo.insert_rule_pack(**kwargs)
+    activation_id = await repo.activate_rule_pack(
+        rule_pack_id=rule_pack_db_id,
+        activated_by="shadow-flow-test",
+        activation_reason="shadow-evidence-flow",
+    )
 
-    async def _fake_resolver(pool: asyncpg.Pool, *, environment: str, effective_at: datetime, observed_at: datetime):
-        return shadow._PackBinding(id=rule_pack_db_id, environment="TEST", raw_envelope=raw)
+    async def _fake_resolver(
+        pool: asyncpg.Pool, *, environment: str, effective_at: datetime, observed_at: datetime
+    ):
+        return shadow._PackBinding(
+            rule_pack_id=rule_pack_db_id,
+            ruleset_activation_id=activation_id,
+            environment="TEST",
+            raw_envelope=raw,
+        )
 
-    def _fake_verify(raw_envelope: object, *, trust_store: object, observed_at: datetime, allow_unsigned: bool = False):
+    def _fake_verify(
+        raw_envelope: object,
+        *,
+        trust_store: object,
+        observed_at: datetime,
+        allow_unsigned: bool = False,
+    ):
         return VerifiedRulePack(
             pack=pack_model, canonical_payload=b"", payload_sha256=b"\x00" * 32, unsigned_dev=False
         )

--- a/apps/backend-rag/scripts/visa_shadow_evidence.py
+++ b/apps/backend-rag/scripts/visa_shadow_evidence.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Emit a re-runnable, aggregate-only Visa Oracle SHADOW gate report."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime
+
+import asyncpg
+
+from backend.services.visa_engine.shadow_evidence import collect_shadow_evidence
+
+
+def _parse_datetime(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    if parsed.tzinfo is None:
+        raise argparse.ArgumentTypeError("timestamp must include a timezone")
+    return parsed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure Visa Oracle SHADOW G-a/G-c from the PII-free audit projection; "
+            "the report can never mark ENFORCE ready without independent G-b/G-d evidence."
+        )
+    )
+    parser.add_argument("--start", required=True, type=_parse_datetime)
+    parser.add_argument("--end", required=True, type=_parse_datetime)
+    parser.add_argument(
+        "--environment",
+        choices=("TEST", "STAGING", "PRODUCTION"),
+        default="PRODUCTION",
+    )
+    parser.add_argument(
+        "--database-url-env",
+        default="DATABASE_URL",
+        help="name of the environment variable holding a read-only PostgreSQL URL",
+    )
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> dict[str, object]:
+    database_url = os.environ.get(args.database_url_env)
+    if not database_url:
+        raise RuntimeError(f"missing database URL environment variable: {args.database_url_env}")
+
+    pool = await asyncpg.create_pool(
+        database_url,
+        min_size=1,
+        max_size=2,
+        server_settings={"default_transaction_read_only": "on"},
+    )
+    try:
+        return await collect_shadow_evidence(
+            pool,
+            window_start=args.start,
+            window_end=args.end,
+            environment=args.environment,
+        )
+    finally:
+        await pool.close()
+
+
+def main() -> int:
+    parser = _parser()
+    args = parser.parse_args()
+    try:
+        report = asyncio.run(_run(args))
+    except (RuntimeError, asyncpg.PostgresError) as exc:
+        parser.error(str(exc))
+    sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend-rag/scripts/visa_shadow_evidence.py
+++ b/apps/backend-rag/scripts/visa_shadow_evidence.py
@@ -69,13 +69,26 @@ async def _run(args: argparse.Namespace) -> dict[str, object]:
         await pool.close()
 
 
+def _collect_report(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> dict[str, object]:
+    try:
+        return asyncio.run(_run(args))
+    except (
+        RuntimeError,
+        asyncpg.PostgresError,
+        asyncpg.InterfaceError,  # sibling of PostgresError, NOT subclass
+        OSError,
+        asyncio.TimeoutError,
+    ) as exc:
+        parser.error(str(exc))
+
+
 def main() -> int:
     parser = _parser()
     args = parser.parse_args()
-    try:
-        report = asyncio.run(_run(args))
-    except (RuntimeError, asyncpg.PostgresError) as exc:
-        parser.error(str(exc))
+    report = _collect_report(parser, args)
     sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
     return 0
 

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 656 services · 1224 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 657 services · 1226 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/research/visa/2026-07-21-shadow-evidence-collection.md
+++ b/research/visa/2026-07-21-shadow-evidence-collection.md
@@ -1,0 +1,109 @@
+# Visa Oracle v2 — SHADOW evidence collection receipt
+
+**Date:** 2026-07-21
+**Lane:** `backend-rag-visa-oracle-shadow-evidence`
+**Scope:** prepare re-runnable, PII-free evidence for G-a and G-c. This work does not
+activate SHADOW or ENFORCE, change Fly secrets, merge, or deploy.
+
+## Current production observation
+
+- PR #2916 (STEP-6c Match SHADOW wiring) merged at `8b28ac418481`.
+- PR #2930 (HMAC facts-fingerprint identity provider) merged at `09f7cd2273c9`.
+- PR #2952 (finite activation-system-period guard) merged at `60c6f348c9a4`.
+- Fly release 3888 is deployed.
+- The only deployed `VISA_ENGINE_*` secret is
+  `VISA_ENGINE_TRUST_STORE_KEYS_JSON` (digest `a68f076bc9993f0c`).
+  `VISA_ENGINE_MATCH_MODE` and `VISA_ENGINE_FACTS_FINGERPRINT_KEYS_JSON` are absent.
+  Because the code defaults the Match mode to OFF and the identity provider fails closed
+  without a fingerprint key, real production SHADOW collection is currently dark.
+- The read-only production query was not run: the local Keychain has no password for
+  `nuzantara_readonly`, and `psql` rejected the connection with
+  `fe_sendauth: no password supplied`. No broader/write-capable credential was used.
+
+Therefore the objective gate remains **RED**. The absence of runtime prerequisites is
+enough to prove that no new STEP-6c SHADOW evidence can currently be produced, but the
+database row count and active PRODUCTION pack remain unverified until read-only access is
+restored.
+
+## Why migration 252 is insufficient for the gate
+
+The existing audit row has a new `decision_id` on a later evaluation of the same Match
+request and does not store the Match category, candidate-code breadth, or a claim-to-source
+map. It therefore cannot objectively prove distinct-request volume, the seven-category
+coverage, 30-code breadth, or zero ungrounded claims.
+
+Migration 255 adds only non-PII audit metadata:
+
+- `request_fingerprint`: SHA-256 of the random 16-character Match token, never the token or
+  applicant facts;
+- `request_category`: the closed Match `Purpose` enum;
+- `candidate_summary`: product/rule/reason/source identifiers only;
+- `grounding_summary`: verdict/claim codes mapped to source-record UUIDs.
+
+Historical rows remain valid but fail the collector closed because their new correlators
+and grounding projection are absent. Every new writer row also carries the exact
+`ruleset_activation_id` selected by the bitemporal resolver.
+
+## Collector semantics
+
+`backend.services.visa_engine.shadow_evidence` reads only the PII-free SHADOW projection and
+emits aggregate counts/dates/categories/product codes. It returns no decision IDs, Match
+tokens, request fingerprints, or facts.
+
+- **G-a** is green only with at least 1,000 distinct request fingerprints, a seven-day
+  minimum report window plus a seven-day consecutive UTC streak, all seven substantive Match
+  categories, at least 30 distinct product codes, no malformed metadata, and every counted
+  product-version/code pair present in the persisted signed rule pack.
+- **G-c** is green only when every row has an activation binding and persisted pack digest,
+  every substantive claim has at least one citation, claimed and flattened citation sets
+  match exactly, every cited source exists in the persisted pack, has `VERIFIED` status and
+  a canonical URL, and contains the decision's legal and recorded timestamps. An explicit
+  `NEEDS_INPUT` verdict may carry no citations only when its sole verdict claim is an
+  abstention with no source references; this implements the gate's rule that abstaining on
+  thin evidence is a pass, without granting the exception to any substantive verdict,
+  outage, or reason claim.
+- **G-b** and **G-d** are always `UNMEASURED` in this collector. Consequently its top-level
+  `enforce_ready` is hard-coded `false` and `gate_status` remains `RED`, even when the
+  synthetic G-a/G-c proof is green.
+
+Re-runnable command after migration 255 is reviewed/deployed, SHADOW prerequisites are
+provisioned, and the read-only DB credential is restored:
+
+```bash
+cd apps/backend-rag
+source .venv/bin/activate
+PYTHONPATH=. python scripts/visa_shadow_evidence.py \
+  --start 2026-07-21T00:00:00Z \
+  --end 2026-07-28T00:00:00Z \
+  --environment PRODUCTION
+```
+
+The database URL must be supplied via a read-only environment variable. The CLI also sets
+`default_transaction_read_only=on` on every PostgreSQL connection.
+
+## Verification receipt
+
+- `ruff format` + `ruff check`: pass.
+- `mypy` on the three changed production Python modules: pass.
+- Python compileall: pass.
+- Migration-number lint: 138 files, unique prefixes.
+- `test_shadow_evidence.py`: 5/5 pass, including a 1,000-request all-breadth synthetic proof
+  that still cannot arm ENFORCE.
+- `test_shadow_match.py`: 31/31 pass, including migration 252→255, activation-bound write,
+  idempotency, and end-to-end Match SHADOW persistence.
+- Full `backend/tests/services/visa_engine`: 1,070 collected; 0 failures, 0 errors, and one
+  pre-existing operational skip because `visa_activation_executor` is not provisioned.
+- `git diff --check`: pass.
+
+## Gate snapshot
+
+| Gate | State | Evidence / blocker |
+| --- | --- | --- |
+| G-a | RED / unmeasured | Production Match mode is OFF; no compatible seven-day audit window exists yet. |
+| G-b | UNMEASURED | Canonical persona tests pass locally, but this collector intentionally does not grade or certify the independent replay. |
+| G-c | RED / unmeasured | No production SHADOW window; active pack and persisted citations could not be queried read-only. |
+| G-d | UNMEASURED | Live ENFORCE→OFF drill is deliberately not attempted before the other gates are green. |
+
+**Decision:** keep ENFORCE OFF. Next safe sequence is independent review of this diff, then
+migration/runtime provisioning through the normal PR/deploy process, seven-day SHADOW
+collection, independent G-b evidence, and only then the G-d drill.

--- a/research/visa/2026-07-21-shadow-evidence-collection.md
+++ b/research/visa/2026-07-21-shadow-evidence-collection.md
@@ -1,3 +1,16 @@
+---
+date: 2026-07-21
+domain: visa
+client_case: none
+adversarial_review: kimi-k3
+sources:
+  - apps/backend-rag/backend/db/migrations_v2/255_visa_shadow_evidence.sql
+  - apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
+  - apps/backend-rag/scripts/visa_shadow_evidence.py
+  - apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
+  - apps/backend-rag/backend/tests/scripts/test_visa_shadow_evidence.py
+---
+
 # Visa Oracle v2 — SHADOW evidence collection receipt
 
 **Date:** 2026-07-21
@@ -94,6 +107,12 @@ The database URL must be supplied via a read-only environment variable. The CLI 
 - Full `backend/tests/services/visa_engine`: 1,070 collected; 0 failures, 0 errors, and one
   pre-existing operational skip because `visa_activation_executor` is not provisioned.
 - `git diff --check`: pass.
+
+## Adversarial review
+
+Kimi independently re-reviewed the four-commit SHADOW evidence series. The final verdict was
+`READY_FOR_DRAFT_PR`, with no high- or medium-severity findings. The re-review recorded M1, M2,
+L1, and L2 as closed.
 
 ## Gate snapshot
 


### PR DESCRIPTION
## Summary

This draft introduces the Visa Oracle SHADOW evidence path while keeping enforcement disabled and every readiness gate fail-closed.

### Commits

1. `a199f2fb061f700c3d91cf3242e0decfe3f9ecd3` — **feat(visa-engine): add SHADOW evidence schema**
   - Adds migration 255 with PII-free audit correlators, grounding fields, indexes, and rollback SQL. The migration is committed only and has not been applied to any live database.
2. `d30cc84ac3d9392ab8b98817a2cb21bb7c041a0b` — **feat(visa-engine): collect SHADOW gate evidence**
   - Wires the SHADOW evidence writer, fail-closed G-a/G-c evidence collection, a read-only CLI, and focused tests.
3. `60bdc80ff70efe09d8252a8210758e0cea59a22d` — **docs(visa-oracle): record SHADOW evidence gates**
   - Records the evidence design, current blockers, and the explicit ENFORCE OFF posture.
4. `5a78ca3444022842a719ea10fdf5d79f34155260` — **fix(visa-engine): harden SHADOW evidence accounting**
   - Applies the Kimi follow-up: direct G-c counter coverage, collector/CLI/legacy regressions, and duplicate-evaluation accounting restricted to valid repeated fingerprints.

The four commits are preserved in their existing order; none was amended or rebased.

## Safety posture

- **ENFORCE remains OFF.** The report remains hard-coded fail-closed with `enforce_ready = false`.
- **Overall gate remains RED.** G-b and G-d remain UNMEASURED.
- No live database access was performed.
- No secrets were read or modified.
- No deployment or live migration was performed.
- Auto-merge is not enabled.

## Verification

Independent Kimi re-review status: **READY_FOR_DRAFT_PR**, with no high- or medium-severity findings.

- Complete requested suite: **1,091 tests, 0 failures, 0 errors, 1 expected skip** (`visa_activation_executor` is not provisioned in the local test DB).
- Ruff check: green.
- Ruff format check: green.
- mypy: green.
- `git diff --check`: green.
- Active pre-push hooks: green.

## Kimi low/informational findings

1. `apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py:163` uses SQL-substring routing in the fake collector connection. This is test-only and fails noisily if query text changes, but is somewhat brittle.
2. The documented **85.30% branch-coverage claim was not independently reproduced by Kimi**: its `pytest-cov` run did not emit a coverage table in that worktree. The claim is therefore treated as unverified documentary evidence and is not used as a readiness or merge criterion.

## Required next blocks

Before any move toward ENFORCE:

1. Independent review of migration 255.
2. Separate deployment step.
3. SHADOW configuration.
4. Collection of G-a/G-c evidence.
5. Independent G-b replay across the required 20 personas.
6. G-d rollback drill.

No merge, deploy, live migration, secret change, or auto-merge is part of this draft PR.
