### PR TITLE
fix(wr2): export PATH in wr2-script-wrapper.sh (Codex node-shebang under launchd)

### DIFF
--- a/infra/openclaw/wr2/README.md
+++ b/infra/openclaw/wr2/README.md
@@ -36,6 +36,9 @@ For now, manual sync after merge.
 ## Current version
 
 `wr2-script-wrapper.sh` includes:
+- Export `PATH` with `/opt/homebrew/bin` prepended (launchd's default PATH
+  omits it — breaks any `#!/usr/bin/env node` shebang, incl. the Codex CLI
+  invoked by `wr2_image_generator.py`) — bug discovered 2026-07-22
 - Source `~/.nuzantara-secrets.env` + `~/.nuzantara-backend-secrets.env`
 - Force-override `DATABASE_URL` to `DATABASE_URL_LOCAL` (pg-proxy
   127.0.0.1:15432) — bug discovered 2026-05-06
@@ -50,3 +53,4 @@ For now, manual sync after merge.
 |---|---|---|
 | 2026-05-06 | DATABASE_URL_LOCAL override | flycast hostname unreachable from Pro |
 | 2026-05-19 | Venv-preflight auto-heal | 84h silent crashloop 2026-05-16→2026-05-19 |
+| 2026-07-22 | `export PATH` incl. `/opt/homebrew/bin` | Codex `env: node: No such file or directory` under launchd's minimal PATH — same signature already cured in `scripts/auth_sentinel_cron.sh` (2026-07-12), never propagated here |

--- a/infra/openclaw/wr2/wr2-script-wrapper.sh
+++ b/infra/openclaw/wr2/wr2-script-wrapper.sh
@@ -36,6 +36,17 @@ shift
 REPO_ROOT="${WR2_REPO_ROOT:-${HOME}/nuzantara-deploy}"
 SECRETS_FILE="${HOME}/.nuzantara-secrets.env"
 
+# 0. PATH — launchd hands this wrapper a minimal PATH (no /opt/homebrew/bin).
+# wr2_image_generator.py's Codex lane execs CODEX_BIN="/opt/homebrew/bin/codex"
+# directly (absolute path, so it launches), but that file's shebang is
+# `#!/usr/bin/env node` — `env` resolves `node` via PATH, which launchd never
+# populates with Homebrew's prefix. Result: "codex exit=127: env: node: No
+# such file or directory", indistinguishable from a Codex quota-exhaust
+# failure unless you inspect the exact error text. Same signature already
+# cured in scripts/auth_sentinel_cron.sh (2026-07-12) but never propagated to
+# this sibling wrapper — found 2026-07-22 diagnosing a stuck WR2 cover image.
+export PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
 # 1. Secrets — source primary then backend-specific (additive)
 if [[ -f "$SECRETS_FILE" ]]; then
     # shellcheck disable=SC1090


### PR DESCRIPTION
## Summary

Root-caused (2026-07-22) why last night's WR2 cover-image generation failed with `codex exit=127: env: node: No such file or directory` — and why the failure persisted even after Node.js was freshly installed on Pro tonight (`brew install node`, was already present as an unlinked 25.9.0_2 keg, now linked at 26.5.0).

**Real cause**: `wr2_image_generator.py`'s `CODEX_BIN = "/opt/homebrew/bin/codex"` uses an absolute path, so Codex itself always launches — but `/opt/homebrew/bin/codex` is a `#!/usr/bin/env node` script. `env` resolves `node` via `PATH`, and launchd hands `wr2-script-wrapper.sh` a minimal PATH that never includes `/opt/homebrew/bin`. Reproduced exactly with `env -i bash -c '... codex exec ...'` → identical `env: node: No such file or directory`.

**Precedent**: the exact same bug (same error text) was already found and cured in `scripts/auth_sentinel_cron.sh` on 2026-07-12 (`export PATH=".../opt/homebrew/bin..."`, see that file's own comment) — but never propagated to this sibling WR2 wrapper. This PR closes that gap.

## Class-audit (sibling call-sites checked this session)

| Script | Codex-exposed? | Status |
|---|---|---|
| `infra/openclaw/wr2/wr2-script-wrapper.sh` | Yes — launches `scripts/wr2_image_generator.py`/`wr2_draft_generator.py`/`wr2_canva_pdf_render.py`, all touch `CODEX_BIN` | **Fixed here** |
| `scripts/wr2-cron-wrapper.sh` | No — only launches `backend.*` modules; grepped, zero backend modules touch Codex | Confirmed out of scope |
| `scripts/auth_sentinel_cron.sh` | Yes | Already fixed 2026-07-12 (this PR's precedent) |
| `scripts/ai-dispatch.sh`, `scripts/supervisor_autofix_tier2.sh` | Yes, but interactive-only (no launchd plist references either on Pro) + already soft-degrade (`command -v codex` check) | Confirmed out of scope |

## Change

`infra/openclaw/wr2/wr2-script-wrapper.sh`: prepend `${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` to `PATH` (preserving whatever launchd already provided at the tail), before any secrets sourcing or exec. `infra/openclaw/wr2/README.md`: doc-sync (current-version bullet + changelog row), per this directory's own sync-protocol convention.

## Verification

- `bash -n` syntax check: clean.
- Full local pre-push suite (path-aware classifier correctly routed to FULL suite — `.sh`/`.md` files aren't on the innocent allowlist): green.
- Root-cause mechanically reproduced pre-fix (`env -i` minimal-env simulation) and the live Codex PONG probe confirmed post-fix on Pro directly (`export PATH="/opt/homebrew/bin:$PATH"; cd ~/nuzantara-deploy && codex exec --sandbox read-only "reply with exactly: PONG"` → `PONG`, model gpt-5.6-sol, 17.8k tokens, no quota error).

## Scope boundary

This PR is the repo-tracked source only (`infra/openclaw/` is a documented mirror — see that dir's own README "Sync protocol"). Deploying to the live `~/.openclaw/bin/wr2/wr2-script-wrapper.sh` copy on Pro, and a PROVE-LIVE run of the actual image-generation lane through the fixed wrapper, are the next step after merge — owned by this session per the ship-lifecycle rule, not left to the codeowner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)