### PR TITLE
fix(pricing): align ERP/MERP to UU 63/2024 (re-entry auto-included in KITAS/KITAP)

### DIFF
--- a/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+++ b/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
@@ -487,7 +487,7 @@
         "duration": "",
         "validity": "",
         "notes": "",
-        "description_en": "Permanent residence permit (KITAP) for investors holding shares in a PT PMA, bundled with Multiple Exit Re-entry Permit (MERP).",
+        "description_en": "Permanent residence permit (KITAP) for investors holding shares in a PT PMA, bundled with Multiple Exit Re-entry Permit (MERP). The Multiple Exit Re-entry Permit (MERP) is automatically included in the KITAP per UU 63/2024 — no separate document or fee.",
         "icon_id": "kitap-permanent"
       },
       "Dependent KITAP + MERP": {
@@ -497,7 +497,7 @@
         "duration": "",
         "validity": "",
         "notes": "",
-        "description_en": "Permanent residence permit (KITAP) for dependent family members of a primary KITAP holder, bundled with Multiple Exit Re-entry Permit (MERP).",
+        "description_en": "Permanent residence permit (KITAP) for dependent family members of a primary KITAP holder, bundled with Multiple Exit Re-entry Permit (MERP). The Multiple Exit Re-entry Permit (MERP) is automatically included in the KITAP per UU 63/2024 — no separate document or fee.",
         "icon_id": "kitap-permanent"
       },
       "Retirement KITAP + MERP": {
@@ -507,7 +507,7 @@
         "duration": "",
         "validity": "",
         "notes": "",
-        "description_en": "Permanent residence permit (KITAP) for retirees who have already held a Retirement KITAS, bundled with Multiple Exit Re-entry Permit (MERP).",
+        "description_en": "Permanent residence permit (KITAP) for retirees who have already held a Retirement KITAS, bundled with Multiple Exit Re-entry Permit (MERP). The Multiple Exit Re-entry Permit (MERP) is automatically included in the KITAP per UU 63/2024 — no separate document or fee.",
         "icon_id": "kitap-permanent"
       }
     },
@@ -995,17 +995,17 @@
         "duration": "",
         "validity": "",
         "notes": "+ Rp 300.000 for urgent processing",
-        "description_en": "Exit Permit Only (EPO) for KITAS or KITAP holders permanently leaving Indonesia and surrendering their stay permit.",
+        "description_en": "Exit Permit Only (EPO) for KITAS or KITAP holders permanently leaving Indonesia and surrendering their stay permit (onshore — filed from within Indonesia).",
         "icon_id": "other-epo"
       },
       "ERP (Exit Re-entry Permit)": {
-        "name": "ERP (Exit Re-entry Permit)",
+        "name": "ERP (Exit Permit Only — Offshore)",
         "price": "800.000 IDR",
         "tier_range": null,
         "duration": "",
         "validity": "",
         "notes": "+ Rp 500.000 for urgent processing",
-        "description_en": "Single-use Exit Re-entry Permit (ERP) for KITAS holders travelling abroad and returning before permit expiry.",
+        "description_en": "Exit Permit Only (Offshore) for KITAS/KITAP holders who are already abroad and will not return to Indonesia, terminating their stay permit remotely (offshore). Distinct from EPO (onshore). Note: re-entry is now automatically included in the KITAS/KITAP per UU 63/2024 — no separate re-entry product.",
         "icon_id": "other-erp"
       },
       "Driving License": {


### PR DESCRIPTION
Aligns the pricing SSOT (`bali_zero_official_prices_2026.json`) with **UU 63/2024**: the standalone re-entry product no longer exists — re-entry is now automatically integrated into the KITAS/KITAP on issuance.

**Changes (6 lines, data JSON only — no code):**
- **ERP** → redefined from *Exit Re-entry Permit (single-use re-entry)* to **Exit Permit Only (Offshore)** (cancels/closes a KITAS from abroad). Price **800k unchanged**.
- **EPO** → clarified **onshore** (distinct from ERP offshore).
- **KITAP + MERP** (Investor/Dependent/Retirement) → MERP **auto-included per UU 63/2024** (no separate doc/fee).

**Safety:** dict keys preserved (renewal_rules + fuzzy pricing_bridge unaffected). Local verify: PricingService loads · `test_pricing_router` 18/18 · `test_data_invariant_tripwires` 3/3 · pre-push full suite (19k) passed.

Aligns prod pricing with the revised visa-card catalog (ERP card reformulated to Exit Permit Only Offshore). Ground-truth: NB-2 Immigration (UU 63/2024, PP 45/2024, Permenkumham 22/2023).

🤖 Generated with [Claude Code](https://claude.com/claude-code)