### PR TITLE
feat(hr): /hr/bonuses by month with per-member totals + fix UTC month bucketing

### DIFF
--- a/apps/backend-rag/backend/app/routers/hr.py
+++ b/apps/backend-rag/backend/app/routers/hr.py
@@ -259,6 +259,24 @@ async def list_bonuses(
     return {"bonuses": bonuses, "count": len(bonuses)}
 
 
+@router.get("/bonuses/historical")
+async def list_bonus_historical(
+    year: int | None = Query(None, ge=2000),
+    current_user: dict[str, Any] = Depends(get_current_user),
+    db_pool: asyncpg.Pool = Depends(get_database_pool),
+) -> dict[str, Any]:
+    """Pre-system bonus recaps imported from PDF (admin only).
+
+    A SEPARATE source from the bonus ledger, kept for reconciliation: the two
+    overlap on some months with different totals. Consumers show them side by
+    side and never add them together.
+    """
+    _require_hr_admin(current_user)
+    service = _get_hr_service(db_pool)
+    records = await service.list_bonus_historical(year)
+    return {"records": records, "count": len(records)}
+
+
 @router.post("/bonuses/{bonus_id}/approve")
 async def approve_bonus(
     bonus_id: int,

--- a/apps/backend-rag/backend/app/services/hr/hr_service.py
+++ b/apps/backend-rag/backend/app/services/hr/hr_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import calendar
 import logging
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 import asyncpg
@@ -19,6 +19,22 @@ from backend.app.utils.hr_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Bali Zero runs on WITA (UTC+8). `awarded_at` is a timestamptz and the Fly
+# Postgres session is UTC, so extracting the month straight off the column cuts
+# it at 08:00 WITA — a bonus awarded at 00:30 on the 1st is billed to the
+# PREVIOUS month. Every month/year bucket over `awarded_at` must therefore pass
+# through `AT TIME ZONE 'Asia/Makassar'` first, so payroll, the bonus summary,
+# the dashboard and the /hr/bonuses page all agree on which month a bonus
+# belongs to. The conversion is written out literally at every call site (never
+# interpolated) so a static scan can see it — see
+# test_bonus_month_bucketing_is_wita.py.
+BUSINESS_TZ = "Asia/Makassar"
+
+
+def business_today() -> date:
+    """Today's date in WITA — the server clock is UTC, the business is not."""
+    return (datetime.now(timezone.utc) + timedelta(hours=8)).date()
 
 
 class HRService:
@@ -188,14 +204,49 @@ class HRService:
                 idx += 1
 
             if month is not None and year is not None:
-                query += f" AND EXTRACT(MONTH FROM bl.awarded_at) = ${idx}"
+                query += (
+                    " AND EXTRACT(MONTH FROM"
+                    f" (bl.awarded_at AT TIME ZONE 'Asia/Makassar')) = ${idx}"
+                )
                 params.append(month)
                 idx += 1
-                query += f" AND EXTRACT(YEAR FROM bl.awarded_at) = ${idx}"
+                query += (
+                    " AND EXTRACT(YEAR FROM"
+                    f" (bl.awarded_at AT TIME ZONE 'Asia/Makassar')) = ${idx}"
+                )
                 params.append(year)
                 idx += 1
 
             query += " ORDER BY bl.awarded_at DESC"
+            rows = await conn.fetch(query, *params)
+            return [dict(r) for r in rows]
+
+    async def list_bonus_historical(
+        self,
+        year: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List the pre-system bonus recaps imported from PDF (migration 099).
+
+        These rows are an accounting record of what was paid BEFORE the bonus
+        ledger existed. They are a SEPARATE source from ``hr_bonus_ledger`` and
+        the two overlap on some months with different totals — callers must
+        present them side by side for reconciliation and must NEVER sum them.
+        """
+        async with self.db_pool.acquire() as conn:
+            query = """
+                SELECT h.id, h.employee_name, h.employee_id,
+                       h.bonus_month, h.bonus_year, h.total_amount_idr,
+                       h.task_count, h.source_pdf, h.accounting_total_data,
+                       h.accounting_not_paid, h.accounting_paid,
+                       h.imported_at, h.notes
+                FROM hr_bonus_historical h
+            """
+            params: list[Any] = []
+            if year is not None:
+                query += " WHERE h.bonus_year = $1"
+                params.append(year)
+
+            query += " ORDER BY h.bonus_year DESC, h.bonus_month DESC, h.employee_name"
             rows = await conn.fetch(query, *params)
             return [dict(r) for r in rows]
 
@@ -235,8 +286,8 @@ class HRService:
                     COALESCE(SUM(amount_idr), 0) as grand_total
                 FROM hr_bonus_ledger
                 WHERE employee_id = $1
-                  AND EXTRACT(MONTH FROM awarded_at) = $2
-                  AND EXTRACT(YEAR FROM awarded_at) = $3
+                  AND EXTRACT(MONTH FROM (awarded_at AT TIME ZONE 'Asia/Makassar')) = $2
+                  AND EXTRACT(YEAR FROM (awarded_at AT TIME ZONE 'Asia/Makassar')) = $3
             """,
                 employee_id,
                 month,
@@ -302,8 +353,8 @@ class HRService:
                         FROM hr_bonus_ledger
                         WHERE employee_id = $1
                           AND status IN ('approved', 'paid')
-                          AND EXTRACT(MONTH FROM awarded_at) = $2
-                          AND EXTRACT(YEAR FROM awarded_at) = $3
+                          AND EXTRACT(MONTH FROM (awarded_at AT TIME ZONE 'Asia/Makassar')) = $2
+                          AND EXTRACT(YEAR FROM (awarded_at AT TIME ZONE 'Asia/Makassar')) = $3
                     """,
                         emp_id,
                         month,
@@ -818,7 +869,7 @@ class HRService:
 
     async def get_admin_dashboard(self) -> dict[str, Any]:
         """Admin dashboard summary."""
-        today = date.today()
+        today = business_today()
         async with self.db_pool.acquire() as conn:
             emp_count = await conn.fetchval(
                 "SELECT COUNT(*) FROM hr_employees WHERE is_active = TRUE"
@@ -850,7 +901,7 @@ class HRService:
 
     async def get_my_dashboard(self, employee_id: int) -> dict[str, Any]:
         """Personal dashboard for a team member."""
-        today = date.today()
+        today = business_today()
         async with self.db_pool.acquire() as conn:
             # Current month bonuses
             bonuses = await conn.fetchrow(
@@ -858,8 +909,8 @@ class HRService:
                 SELECT COUNT(*) as count, COALESCE(SUM(amount_idr), 0) as total
                 FROM hr_bonus_ledger
                 WHERE employee_id = $1
-                  AND EXTRACT(MONTH FROM awarded_at) = $2
-                  AND EXTRACT(YEAR FROM awarded_at) = $3
+                  AND EXTRACT(MONTH FROM (awarded_at AT TIME ZONE 'Asia/Makassar')) = $2
+                  AND EXTRACT(YEAR FROM (awarded_at AT TIME ZONE 'Asia/Makassar')) = $3
             """,
                 employee_id,
                 today.month,

--- a/apps/backend-rag/backend/tests/unit/app/services/hr/test_bonus_month_bucketing_is_wita.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/hr/test_bonus_month_bucketing_is_wita.py
@@ -1,0 +1,84 @@
+"""Tripwire: every bonus month/year bucket must be cut on WITA, not UTC.
+
+Bali Zero operates on WITA (UTC+8) and the Fly Postgres session is UTC, so a
+bare ``EXTRACT(MONTH FROM awarded_at)`` cuts the month at 08:00 WITA: a bonus
+awarded at 00:30 on the 1st is billed to the PREVIOUS month. Live prod data
+already contains such rows.
+
+Four call sites bucket bonuses by month — ``list_bonuses``, ``get_bonus_summary``,
+``calculate_payroll`` and ``get_my_dashboard``. If any one of them drifts back to
+UTC, payroll and the /hr/bonuses accounting view stop agreeing about which month
+a bonus belongs to, and someone is paid the wrong amount. Curing one site is not
+enough — this test is the class-audit made permanent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from backend.app.services.hr import hr_service as hr_service_module
+from backend.app.services.hr.hr_service import BUSINESS_TZ, business_today
+
+_RAW_SOURCE = Path(hr_service_module.__file__).read_text(encoding="utf-8")
+
+# Adjacent Python string literals concatenate, so a single SQL clause can be
+# split across lines mid-expression. Rejoin those seams (`"` newline `f"`) so
+# the scan below sees the SQL the way Postgres will, not the way it is typed.
+SOURCE = re.sub(r'"\s*f?"', " ", _RAW_SOURCE)
+
+# `EXTRACT(<field> FROM ...awarded_at...)` — captures whatever sits between
+# EXTRACT( and the matching close, so the timezone cast is visible or absent.
+_EXTRACT_OVER_AWARDED_AT = re.compile(
+    r"EXTRACT\(\s*(MONTH|YEAR)\s+FROM\s+([^)]*awarded_at[^)]*\)?)",
+    re.IGNORECASE,
+)
+
+
+def test_business_tz_is_wita():
+    assert BUSINESS_TZ == "Asia/Makassar"
+
+
+def test_every_extract_over_awarded_at_converts_to_wita():
+    matches = _EXTRACT_OVER_AWARDED_AT.findall(SOURCE)
+    # Guard against the regex silently matching nothing (a blind-scan pass is
+    # not the same as a clean one).
+    assert len(matches) >= 4, (
+        f"expected at least 4 month/year buckets over awarded_at, found {len(matches)} — "
+        "did the queries move, or did the regex stop matching?"
+    )
+    offenders = [
+        f"EXTRACT({field} FROM {expr}"
+        for field, expr in matches
+        if BUSINESS_TZ not in expr
+    ]
+    assert not offenders, (
+        "bonus month/year buckets must convert to WITA before extracting — "
+        f"UTC-bucketing found in: {offenders}"
+    )
+
+
+def test_no_bare_extract_month_from_awarded_at_remains():
+    """The exact pre-fix shape must never come back."""
+    assert not re.search(
+        r"EXTRACT\(\s*(MONTH|YEAR)\s+FROM\s+(bl\.)?awarded_at\s*\)",
+        SOURCE,
+        re.IGNORECASE,
+    )
+
+
+def test_business_today_is_ahead_of_utc_date_at_the_boundary():
+    """WITA is UTC+8, so the business date rolls over 8 hours before UTC's."""
+    from datetime import date, datetime, timezone
+    from unittest.mock import patch
+
+    # 2026-02-28 16:30Z == 2026-03-01 00:30 WITA → the business day is March 1.
+    frozen = datetime(2026, 2, 28, 16, 30, tzinfo=timezone.utc)
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return frozen if tz else frozen.replace(tzinfo=None)
+
+    with patch.object(hr_service_module, "datetime", _FrozenDatetime):
+        assert business_today() == date(2026, 3, 1)

--- a/apps/backend-rag/backend/tests/unit/app/services/hr/test_hr_service.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/hr/test_hr_service.py
@@ -201,6 +201,38 @@ class TestBonuses:
             await hr_service.approve_bonus(999, "admin@test.com")
 
     @pytest.mark.asyncio
+    async def test_list_bonus_historical_no_filter(self, hr_service, mock_db_pool):
+        mock_db_pool._mock_conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "employee_name": "ALICE",
+                    "employee_id": 1,
+                    "bonus_month": 2,
+                    "bonus_year": 2026,
+                    "total_amount_idr": 3000000,
+                    "task_count": 16,
+                    "source_pdf": "LIST BONUS FEBRUARY 2026.pdf",
+                },
+            ]
+        )
+        result = await hr_service.list_bonus_historical()
+        assert len(result) == 1
+        assert result[0]["total_amount_idr"] == 3000000
+        # No year filter → no parameter bound.
+        _, args, _ = mock_db_pool._mock_conn.fetch.mock_calls[0]
+        assert len(args) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_bonus_historical_filters_by_year(self, hr_service, mock_db_pool):
+        mock_db_pool._mock_conn.fetch = AsyncMock(return_value=[])
+        result = await hr_service.list_bonus_historical(year=2026)
+        assert result == []
+        _, args, _ = mock_db_pool._mock_conn.fetch.mock_calls[0]
+        assert args[1] == 2026
+        assert "bonus_year = $1" in args[0]
+
+    @pytest.mark.asyncio
     async def test_get_bonus_summary(self, hr_service, mock_db_pool):
         mock_db_pool._mock_conn.fetchrow = AsyncMock(
             return_value={

--- a/apps/mouth/src/app/(workspace)/hr/bonuses/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/hr/bonuses/page.test.tsx
@@ -1,0 +1,278 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import BonusesPage from "./page";
+
+const hrApiMock = vi.hoisted(() => ({
+  listBonuses: vi.fn(),
+  listBonusHistorical: vi.fn(),
+  approveBonus: vi.fn(),
+}));
+
+vi.mock("@/lib/api/hr/hr", () => hrApiMock);
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function bonus(over: Record<string, unknown> & { id: number }) {
+  return {
+    practice_id: 0,
+    employee_id: 1,
+    payroll_period_id: null,
+    bonus_rate_id: null,
+    practice_type_code: "visa_b211",
+    amount_idr: 100_000,
+    status: "approved",
+    awarded_at: "2026-07-10T02:00:00.000Z",
+    awarded_by: null,
+    approved_by: null,
+    approved_at: null,
+    employee_name: "Surya",
+    employee_email: "surya@balizero.com",
+    practice_status: "completed",
+    client_name: null,
+    notes: null,
+    ...over,
+  };
+}
+
+/** Two members, two months — the shape accounting actually reads. */
+const BONUSES = [
+  bonus({
+    id: 1,
+    employee_id: 3,
+    employee_name: "Surya",
+    amount_idr: 2_000_000,
+  }),
+  bonus({
+    id: 2,
+    employee_id: 3,
+    employee_name: "Surya",
+    amount_idr: 500_000,
+    status: "pending",
+  }),
+  bonus({ id: 3, employee_id: 1, employee_name: "Adit", amount_idr: 750_000 }),
+  bonus({
+    id: 4,
+    employee_id: 1,
+    employee_name: "Adit",
+    amount_idr: 1_000_000,
+    awarded_at: "2026-06-10T02:00:00.000Z",
+  }),
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hrApiMock.listBonuses.mockResolvedValue({
+    bonuses: BONUSES,
+    count: BONUSES.length,
+  });
+  hrApiMock.listBonusHistorical.mockResolvedValue({ records: [], count: 0 });
+});
+
+describe("BonusesPage", () => {
+  it("shows the grand total of every bonus in the payload", async () => {
+    render(<BonusesPage />);
+    // 2.000.000 + 500.000 + 750.000 + 1.000.000
+    await waitFor(() =>
+      expect(screen.getAllByText("Rp 4.250.000").length).toBeGreaterThan(0),
+    );
+  });
+
+  it("splits the ledger into months, newest first", async () => {
+    render(<BonusesPage />);
+    await screen.findByText("July 2026");
+    const headings = screen.getAllByRole("button", { name: /2026/ });
+    expect(headings[0]).toHaveTextContent("July 2026");
+    expect(headings[1]).toHaveTextContent("June 2026");
+  });
+
+  it("totals each member inside the month — the number accounting needs", async () => {
+    render(<BonusesPage />);
+    const july = await screen.findByRole("button", { name: /July 2026/ });
+    // Newest month is expanded by default.
+    expect(july).toHaveAttribute("aria-expanded", "true");
+
+    // Surya in July = 2.000.000 + 500.000 pending
+    const suryaRow = await screen.findByRole("button", {
+      name: /Surya.*2 bonuses/,
+    });
+    expect(suryaRow).toHaveTextContent("Rp 2.500.000");
+    expect(suryaRow).toHaveTextContent("Rp 500.000 pending");
+  });
+
+  it("gives a per-member all-time total across months", async () => {
+    render(<BonusesPage />);
+    const table = await screen.findByRole("table");
+    const aditRow = within(table)
+      .getAllByRole("row")
+      .find((r) => r.textContent?.startsWith("Adit"));
+    // 750.000 (July) + 1.000.000 (June) over 2 months
+    expect(aditRow).toHaveTextContent("Rp 1.750.000");
+    expect(aditRow).toHaveTextContent("2");
+  });
+
+  it("month totals and per-member totals agree on the grand total", async () => {
+    render(<BonusesPage />);
+    const table = await screen.findByRole("table");
+    const rows = within(table).getAllByRole("row");
+    const footer = rows[rows.length - 1];
+    expect(footer).toHaveTextContent("Rp 4.250.000");
+  });
+
+  it("expands a member to reveal the individual bonus rows", async () => {
+    const user = userEvent.setup();
+    render(<BonusesPage />);
+    const suryaRow = await screen.findByRole("button", {
+      name: /Surya.*2 bonuses/,
+    });
+    await user.click(suryaRow);
+    await waitFor(() =>
+      expect(screen.getAllByText("visa b211").length).toBeGreaterThan(0),
+    );
+  });
+
+  it("filters to a single member without leaking the others", async () => {
+    const user = userEvent.setup();
+    render(<BonusesPage />);
+    await screen.findByText("July 2026");
+    await user.selectOptions(screen.getByLabelText("Filter by member"), "id:1");
+    // The member <select> still lists every name — scope the leak check to the
+    // per-member summary table, which must now hold Adit alone.
+    await waitFor(() => {
+      const rows = within(screen.getByRole("table")).getAllByRole("row");
+      expect(rows.some((r) => r.textContent?.includes("Surya"))).toBe(false);
+    });
+    expect(screen.getAllByText("Rp 1.750.000").length).toBeGreaterThan(0);
+  });
+
+  it("shows the legacy PDF recap as excluded, with the delta", async () => {
+    hrApiMock.listBonusHistorical.mockResolvedValue({
+      records: [
+        {
+          id: 1,
+          employee_name: "SURYA",
+          employee_id: 3,
+          bonus_month: 7,
+          bonus_year: 2026,
+          total_amount_idr: 3_000_000,
+          task_count: 13,
+          source_pdf: "LIST BONUS JULY 2026.pdf",
+          accounting_total_data: null,
+          accounting_not_paid: null,
+          accounting_paid: null,
+          imported_at: "2026-08-01T00:00:00.000Z",
+          notes: null,
+        },
+      ],
+      count: 1,
+    });
+    render(<BonusesPage />);
+    const strip = await screen.findByText(/Legacy PDF recap/);
+    expect(strip).toHaveTextContent("Rp 3.000.000");
+    expect(strip).toHaveTextContent("not included");
+    // July ledger = 3.250.000, PDF = 3.000.000 → delta 250.000
+    expect(strip).toHaveTextContent("Rp 250.000");
+    // And the headline total still counts the ledger only.
+    expect(screen.getAllByText("Rp 4.250.000").length).toBeGreaterThan(0);
+  });
+
+  it("scopes the legacy recap to the member filter, so the delta stays honest", async () => {
+    // Ledger July: Surya 2.500.000 + Adit 750.000. PDF July: Surya 2.000.000 +
+    // Adit 750.000. Filtered to Adit, the delta must be 0 — NOT 750.000 minus
+    // the all-members PDF total of 2.750.000.
+    hrApiMock.listBonusHistorical.mockResolvedValue({
+      records: [
+        {
+          id: 1,
+          employee_name: "SURYA",
+          employee_id: 3,
+          bonus_month: 7,
+          bonus_year: 2026,
+          total_amount_idr: 2_000_000,
+          task_count: 8,
+          source_pdf: "recap.pdf",
+          accounting_total_data: null,
+          accounting_not_paid: null,
+          accounting_paid: null,
+          imported_at: "2026-08-01T00:00:00.000Z",
+          notes: null,
+        },
+        {
+          id: 2,
+          employee_name: "ADIT",
+          employee_id: 1,
+          bonus_month: 7,
+          bonus_year: 2026,
+          total_amount_idr: 750_000,
+          task_count: 3,
+          source_pdf: "recap.pdf",
+          accounting_total_data: null,
+          accounting_not_paid: null,
+          accounting_paid: null,
+          imported_at: "2026-08-01T00:00:00.000Z",
+          notes: null,
+        },
+      ],
+      count: 2,
+    });
+    const user = userEvent.setup();
+    render(<BonusesPage />);
+    await screen.findByText(/Legacy PDF recap/);
+    await user.selectOptions(screen.getByLabelText("Filter by member"), "id:1");
+    const strip = await screen.findByText(/Legacy PDF recap/);
+    expect(strip).toHaveTextContent("Rp 750.000");
+    expect(strip).toHaveTextContent("Rp 0");
+    expect(strip).not.toHaveTextContent("Rp 2.750.000");
+  });
+
+  it("suppresses the legacy recap under a status filter — the sides stop being comparable", async () => {
+    hrApiMock.listBonusHistorical.mockResolvedValue({
+      records: [
+        {
+          id: 1,
+          employee_name: "SURYA",
+          employee_id: 3,
+          bonus_month: 7,
+          bonus_year: 2026,
+          total_amount_idr: 2_000_000,
+          task_count: 8,
+          source_pdf: "recap.pdf",
+          accounting_total_data: null,
+          accounting_not_paid: null,
+          accounting_paid: null,
+          imported_at: "2026-08-01T00:00:00.000Z",
+          notes: null,
+        },
+      ],
+      count: 1,
+    });
+    const user = userEvent.setup();
+    render(<BonusesPage />);
+    await screen.findByText(/Legacy PDF recap/);
+    await user.selectOptions(
+      screen.getByLabelText("Filter by status"),
+      "pending",
+    );
+    await waitFor(() =>
+      expect(screen.queryByText(/Legacy PDF recap/)).not.toBeInTheDocument(),
+    );
+  });
+
+  it("hides the reconciliation strip when the endpoint rejects (non-admin)", async () => {
+    hrApiMock.listBonusHistorical.mockRejectedValue(new Error("403"));
+    render(<BonusesPage />);
+    await screen.findByText("July 2026");
+    expect(screen.queryByText(/Legacy PDF recap/)).not.toBeInTheDocument();
+  });
+
+  it("renders the empty state when there are no bonuses", async () => {
+    hrApiMock.listBonuses.mockResolvedValue({ bonuses: [], count: 0 });
+    render(<BonusesPage />);
+    expect(
+      await screen.findByText(/No bonuses for this selection/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/app/(workspace)/hr/bonuses/page.tsx
+++ b/apps/mouth/src/app/(workspace)/hr/bonuses/page.tsx
@@ -1,10 +1,25 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { CheckCircle, Gift } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle,
+  ChevronDown,
+  ChevronRight,
+  Download,
+  Gift,
+} from "lucide-react";
 import { toast } from "sonner";
 import * as hrApi from "@/lib/api/hr/hr";
-import type { Bonus } from "@/types/hr";
+import type { Bonus, BonusHistoricalRecord } from "@/types/hr";
+import {
+  aggregateByMember,
+  bonusesToCsv,
+  formatBonusDate,
+  groupBonusesByMonth,
+  UNDATED_KEY,
+  witaMonthKey,
+} from "@/lib/hr/bonus-aggregation";
 import { formatIDR } from "@balizero/core/utils";
 
 const statusColors: Record<string, string> = {
@@ -15,18 +30,53 @@ const statusColors: Record<string, string> = {
   reversed: "bg-zinc-500/10 text-zinc-400 border-zinc-500/30",
 };
 
+const ALL = "all";
+
+function memberKeyOf(b: Bonus): string {
+  return b.employee_id != null
+    ? `id:${b.employee_id}`
+    : `email:${b.employee_email || b.employee_name || "unknown"}`;
+}
+
+function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export default function BonusesPage() {
   const [bonuses, setBonuses] = useState<Bonus[]>([]);
+  const [historical, setHistorical] = useState<BonusHistoricalRecord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [year, setYear] = useState<string>(ALL);
+  const [status, setStatus] = useState<string>(ALL);
+  const [member, setMember] = useState<string>(ALL);
+  const [openMonths, setOpenMonths] = useState<Record<string, boolean>>({});
+  const [openMembers, setOpenMembers] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
-    hrApi
-      .listBonuses()
-      .then((data) => {
+    async function load() {
+      try {
+        const data = await hrApi.listBonuses();
         setBonuses(data.bonuses || []);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
+      } catch {
+        /* keep the page usable — the empty state covers it */
+      }
+      try {
+        // HR-admin only. Team members get a 403 and the reconciliation strip
+        // simply stays hidden for them.
+        const hist = await hrApi.listBonusHistorical();
+        setHistorical(hist.records || []);
+      } catch {
+        setHistorical([]);
+      }
+      setLoading(false);
+    }
+    load();
   }, []);
 
   const handleApprove = async (id: number) => {
@@ -43,6 +93,92 @@ export default function BonusesPage() {
     }
   };
 
+  // ─── Filter options (derived from the unfiltered payload) ───────────
+
+  const years = useMemo(() => {
+    const set = new Set<string>();
+    for (const m of groupBonusesByMonth(bonuses)) {
+      if (m.key !== UNDATED_KEY) set.add(m.key.slice(0, 4));
+    }
+    return [...set].sort().reverse();
+  }, [bonuses]);
+
+  const members = useMemo(
+    () =>
+      aggregateByMember(bonuses).map((m) => ({
+        key: m.memberKey,
+        name: m.employeeName,
+      })),
+    [bonuses],
+  );
+
+  // ─── Filtered aggregation ───────────────────────────────────────────
+
+  const filtered = useMemo(
+    () =>
+      bonuses.filter((b) => {
+        if (status !== ALL && b.status !== status) return false;
+        // Year is read off the WITA month key, so the filter and the month
+        // buckets always agree on rows near a month/year boundary.
+        if (year !== ALL && !witaMonthKey(b.awarded_at).startsWith(year))
+          return false;
+        if (member !== ALL && memberKeyOf(b) !== member) return false;
+        return true;
+      }),
+    [bonuses, status, year, member],
+  );
+
+  const months = useMemo(() => groupBonusesByMonth(filtered), [filtered]);
+  const memberTotals = useMemo(() => aggregateByMember(filtered), [filtered]);
+
+  const grandTotal = months.reduce((s, m) => s + m.total, 0);
+  const grandPending = months.reduce((s, m) => s + m.pendingTotal, 0);
+  const grandApproved = memberTotals.reduce(
+    (s, m) => s + m.byStatus.approved,
+    0,
+  );
+
+  /**
+   * Legacy PDF recap per month key, for the reconciliation strip.
+   *
+   * Scoped to the SAME selection as the ledger it is compared against —
+   * otherwise the delta subtracts an all-members PDF total from a
+   * single-member ledger total and reads as a huge phantom shortfall. A status
+   * filter has no counterpart in the PDF recaps (they carry no status), so it
+   * makes the two sides non-comparable and suppresses the strip entirely.
+   */
+  const historicalByMonth = useMemo(() => {
+    const map = new Map<
+      string,
+      { total: number; tasks: number; sources: Set<string> }
+    >();
+    if (status !== ALL) return map;
+    const scoped =
+      member === ALL
+        ? historical
+        : historical.filter(
+            (r) => r.employee_id != null && `id:${r.employee_id}` === member,
+          );
+    for (const r of scoped) {
+      const key = `${r.bonus_year}-${String(r.bonus_month).padStart(2, "0")}`;
+      const entry = map.get(key) ?? {
+        total: 0,
+        tasks: 0,
+        sources: new Set<string>(),
+      };
+      entry.total += Number(r.total_amount_idr) || 0;
+      entry.tasks += Number(r.task_count) || 0;
+      if (r.source_pdf) entry.sources.add(r.source_pdf);
+      map.set(key, entry);
+    }
+    return map;
+  }, [historical, member, status]);
+
+  // Newest month starts expanded, the rest collapsed — DERIVED, not set by an
+  // effect: an effect would paint one frame with everything closed and only
+  // then expand. An explicit toggle writes a boolean and always wins.
+  const newestMonthKey = months.length > 0 ? months[0].key : null;
+
   if (loading) {
     return (
       <div className="space-y-4">
@@ -56,63 +192,369 @@ export default function BonusesPage() {
     );
   }
 
+  const selectCls =
+    "bg-zinc-900 border border-zinc-800 rounded-lg px-2 py-1.5 text-sm text-zinc-300";
+
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-bold text-zinc-100">Bonuses</h1>
-        <div className="flex items-center gap-2 text-sm text-zinc-400">
-          <Gift size={16} />
-          {bonuses.length} total
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            aria-label="Filter by year"
+            value={year}
+            onChange={(e) => setYear(e.target.value)}
+            className={selectCls}
+          >
+            <option value={ALL}>All years</option>
+            {years.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Filter by status"
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            className={selectCls}
+          >
+            <option value={ALL}>All statuses</option>
+            {["pending", "approved", "paid", "rejected", "reversed"].map(
+              (s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ),
+            )}
+          </select>
+          <select
+            aria-label="Filter by member"
+            value={member}
+            onChange={(e) => setMember(e.target.value)}
+            className={selectCls}
+          >
+            <option value={ALL}>All members</option>
+            {members.map((m) => (
+              <option key={m.key} value={m.key}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() =>
+              downloadCsv(
+                `bali-zero-bonuses-${year === ALL ? "all" : year}.csv`,
+                bonusesToCsv(months),
+              )
+            }
+            disabled={months.length === 0}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 text-sm transition-colors disabled:opacity-40"
+          >
+            <Download size={14} />
+            CSV
+          </button>
         </div>
       </div>
 
-      {bonuses.length === 0 ? (
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: "Total", value: formatIDR(grandTotal) },
+          { label: "Pending", value: formatIDR(grandPending) },
+          { label: "Months", value: String(months.length) },
+          { label: "Bonuses", value: String(filtered.length) },
+        ].map((kpi) => (
+          <div
+            key={kpi.label}
+            className="bg-zinc-900 border border-zinc-800 rounded-xl p-3"
+          >
+            <div className="text-xs uppercase tracking-wide text-zinc-500">
+              {kpi.label}
+            </div>
+            <div className="text-lg font-semibold text-zinc-100 mt-0.5">
+              {kpi.value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {filtered.length === 0 ? (
         <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-8 text-center text-zinc-500">
-          No bonuses yet. Bonuses are automatically created when practices are
-          completed.
+          <Gift size={20} className="mx-auto mb-2 opacity-50" />
+          No bonuses for this selection. Bonuses are created automatically when
+          practices are completed.
         </div>
       ) : (
-        <div className="space-y-2">
-          {bonuses.map((bonus) => (
-            <div
-              key={bonus.id}
-              className="bg-zinc-900 border border-zinc-800 rounded-lg p-4 flex items-center justify-between"
-            >
-              <div className="flex-1">
-                <div className="flex items-center gap-3">
-                  <span className="font-medium text-zinc-200">
-                    {bonus.practice_type_code?.replace(/_/g, " ")}
-                  </span>
-                  <span
-                    className={`text-xs px-2 py-0.5 rounded-full border ${statusColors[bonus.status] || ""}`}
-                  >
-                    {bonus.status}
-                  </span>
-                </div>
-                <div className="text-sm text-zinc-500 mt-1">
-                  {bonus.employee_name || bonus.employee_email}
-                  {bonus.client_name && ` — ${bonus.client_name}`}
-                  {" · "}
-                  {new Date(bonus.awarded_at).toLocaleDateString("id-ID")}
-                </div>
-              </div>
-              <div className="flex items-center gap-4">
-                <span className="text-lg font-semibold text-[var(--bz-accent)]">
-                  {formatIDR(bonus.amount_idr)}
-                </span>
-                {bonus.status === "pending" && (
-                  <button
-                    onClick={() => handleApprove(bonus.id)}
-                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-sm transition-colors"
-                  >
-                    <CheckCircle size={14} />
-                    Approve
-                  </button>
-                )}
-              </div>
+        <>
+          {/* ─── Total per member, across the selected months ─────────── */}
+          <section className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+            <div className="px-4 py-3 border-b border-zinc-800">
+              <h2 className="text-sm font-semibold text-zinc-200">
+                Total per member
+              </h2>
+              <p className="text-xs text-zinc-500 mt-0.5">
+                Across every month in the current selection.
+              </p>
             </div>
-          ))}
-        </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs uppercase tracking-wide text-zinc-500">
+                    <th className="text-left font-medium px-4 py-2">Member</th>
+                    <th className="text-right font-medium px-4 py-2">Months</th>
+                    <th className="text-right font-medium px-4 py-2">
+                      Bonuses
+                    </th>
+                    <th className="text-right font-medium px-4 py-2">
+                      Pending
+                    </th>
+                    <th className="text-right font-medium px-4 py-2">
+                      Approved
+                    </th>
+                    <th className="text-right font-medium px-4 py-2">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {memberTotals.map((m) => (
+                    <tr
+                      key={m.memberKey}
+                      className="border-t border-zinc-800/70 text-zinc-300"
+                    >
+                      <td className="px-4 py-2 text-zinc-200">
+                        {m.employeeName}
+                      </td>
+                      <td className="px-4 py-2 text-right tabular-nums">
+                        {m.monthCount}
+                      </td>
+                      <td className="px-4 py-2 text-right tabular-nums">
+                        {m.count}
+                      </td>
+                      <td className="px-4 py-2 text-right tabular-nums text-amber-400">
+                        {m.byStatus.pending
+                          ? formatIDR(m.byStatus.pending)
+                          : "—"}
+                      </td>
+                      <td className="px-4 py-2 text-right tabular-nums">
+                        {m.byStatus.approved
+                          ? formatIDR(m.byStatus.approved)
+                          : "—"}
+                      </td>
+                      <td className="px-4 py-2 text-right tabular-nums font-semibold text-[var(--bz-accent)]">
+                        {formatIDR(m.total)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr className="border-t border-zinc-700 text-zinc-200 font-semibold">
+                    <td className="px-4 py-2">All members</td>
+                    <td className="px-4 py-2 text-right tabular-nums">
+                      {months.length}
+                    </td>
+                    <td className="px-4 py-2 text-right tabular-nums">
+                      {filtered.length}
+                    </td>
+                    <td className="px-4 py-2 text-right tabular-nums text-amber-400">
+                      {grandPending ? formatIDR(grandPending) : "—"}
+                    </td>
+                    <td className="px-4 py-2 text-right tabular-nums">
+                      {formatIDR(grandApproved)}
+                    </td>
+                    <td className="px-4 py-2 text-right tabular-nums text-[var(--bz-accent)]">
+                      {formatIDR(grandTotal)}
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </section>
+
+          {/* ─── Month by month → member by member ────────────────────── */}
+          <div className="space-y-3">
+            {months.map((month) => {
+              const isOpen =
+                openMonths[month.key] ?? month.key === newestMonthKey;
+              const legacy = historicalByMonth.get(month.key);
+              return (
+                <section
+                  key={month.key || "undated"}
+                  className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden"
+                >
+                  <button
+                    onClick={() =>
+                      setOpenMonths((p) => ({ ...p, [month.key]: !isOpen }))
+                    }
+                    aria-expanded={isOpen}
+                    className="w-full flex items-center justify-between gap-3 px-4 py-3 hover:bg-zinc-800/40 transition-colors text-left"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      {isOpen ? (
+                        <ChevronDown
+                          size={16}
+                          className="text-zinc-500 shrink-0"
+                        />
+                      ) : (
+                        <ChevronRight
+                          size={16}
+                          className="text-zinc-500 shrink-0"
+                        />
+                      )}
+                      <span className="font-semibold text-zinc-100">
+                        {month.label}
+                      </span>
+                      <span className="text-xs text-zinc-500 truncate">
+                        {month.memberCount} member
+                        {month.memberCount === 1 ? "" : "s"} · {month.count}{" "}
+                        bonus
+                        {month.count === 1 ? "" : "es"}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0">
+                      {month.pendingTotal > 0 && (
+                        <span className="text-xs px-2 py-0.5 rounded-full border bg-amber-500/10 text-amber-400 border-amber-500/30">
+                          {formatIDR(month.pendingTotal)} pending
+                        </span>
+                      )}
+                      <span className="text-base font-semibold text-[var(--bz-accent)] tabular-nums">
+                        {formatIDR(month.total)}
+                      </span>
+                    </div>
+                  </button>
+
+                  {isOpen && (
+                    <div className="border-t border-zinc-800">
+                      {legacy && (
+                        <div className="flex items-start gap-2 px-4 py-2.5 bg-amber-500/5 border-b border-amber-500/20 text-xs text-amber-200/80">
+                          <AlertTriangle
+                            size={14}
+                            className="mt-0.5 shrink-0"
+                          />
+                          <span>
+                            Legacy PDF recap for this month:{" "}
+                            <strong className="tabular-nums">
+                              {formatIDR(legacy.total)}
+                            </strong>{" "}
+                            ({legacy.tasks} tasks —{" "}
+                            {[...legacy.sources].join(", ")}). Separate
+                            pre-system source, <strong>not included</strong> in
+                            the totals above. Delta vs ledger:{" "}
+                            <strong className="tabular-nums">
+                              {formatIDR(month.total - legacy.total)}
+                            </strong>
+                            . Confirm which source is authoritative before
+                            paying.
+                          </span>
+                        </div>
+                      )}
+
+                      {month.members.map((m) => {
+                        const mKey = `${month.key}|${m.memberKey}`;
+                        const mOpen = openMembers[mKey] ?? false;
+                        return (
+                          <div
+                            key={m.memberKey}
+                            className="border-b border-zinc-800/70 last:border-b-0"
+                          >
+                            <button
+                              onClick={() =>
+                                setOpenMembers((p) => ({
+                                  ...p,
+                                  [mKey]: !mOpen,
+                                }))
+                              }
+                              aria-expanded={mOpen}
+                              className="w-full flex items-center justify-between gap-3 px-4 py-2.5 pl-9 hover:bg-zinc-800/30 transition-colors text-left"
+                            >
+                              <div className="flex items-center gap-2 min-w-0">
+                                {mOpen ? (
+                                  <ChevronDown
+                                    size={14}
+                                    className="text-zinc-600 shrink-0"
+                                  />
+                                ) : (
+                                  <ChevronRight
+                                    size={14}
+                                    className="text-zinc-600 shrink-0"
+                                  />
+                                )}
+                                <span className="text-zinc-200 truncate">
+                                  {m.employeeName}
+                                </span>
+                                <span className="text-xs text-zinc-500">
+                                  {m.count} bonus{m.count === 1 ? "" : "es"}
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-3 shrink-0 text-sm">
+                                {m.byStatus.pending > 0 && (
+                                  <span className="text-xs text-amber-400 tabular-nums">
+                                    {formatIDR(m.byStatus.pending)} pending
+                                  </span>
+                                )}
+                                <span className="font-semibold text-zinc-100 tabular-nums">
+                                  {formatIDR(m.total)}
+                                </span>
+                              </div>
+                            </button>
+
+                            {mOpen && (
+                              <ul className="bg-zinc-950/40">
+                                {m.bonuses.map((bonus) => (
+                                  <li
+                                    key={bonus.id}
+                                    className="flex items-center justify-between gap-3 px-4 py-2 pl-14 border-t border-zinc-800/50"
+                                  >
+                                    <div className="min-w-0">
+                                      <div className="flex items-center gap-2">
+                                        <span className="text-sm text-zinc-300">
+                                          {bonus.practice_type_code?.replace(
+                                            /_/g,
+                                            " ",
+                                          )}
+                                        </span>
+                                        <span
+                                          className={`text-[10px] px-1.5 py-0.5 rounded-full border ${statusColors[bonus.status] || ""}`}
+                                        >
+                                          {bonus.status}
+                                        </span>
+                                      </div>
+                                      <div className="text-xs text-zinc-500 mt-0.5 truncate">
+                                        {formatBonusDate(bonus.awarded_at)}
+                                        {bonus.client_name &&
+                                          ` — ${bonus.client_name}`}
+                                      </div>
+                                    </div>
+                                    <div className="flex items-center gap-3 shrink-0">
+                                      <span className="text-sm text-zinc-200 tabular-nums">
+                                        {formatIDR(
+                                          Number(bonus.amount_idr) || 0,
+                                        )}
+                                      </span>
+                                      {bonus.status === "pending" && (
+                                        <button
+                                          onClick={() =>
+                                            handleApprove(bonus.id)
+                                          }
+                                          className="flex items-center gap-1 px-2 py-1 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-xs transition-colors"
+                                        >
+                                          <CheckCircle size={12} />
+                                          Approve
+                                        </button>
+                                      )}
+                                    </div>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </section>
+              );
+            })}
+          </div>
+        </>
       )}
     </div>
   );

--- a/apps/mouth/src/lib/api/hr/hr.ts
+++ b/apps/mouth/src/lib/api/hr/hr.ts
@@ -3,10 +3,11 @@
  * Uses the centralized api client for auth token management.
  */
 
-import { api } from '@/lib/api';
+import { api } from "@/lib/api";
 import type {
   AdminDashboard,
   Bonus,
+  BonusHistoricalRecord,
   BonusRate,
   BonusRatePayload,
   EmployeeCreatePayload,
@@ -20,30 +21,38 @@ import type {
   PayslipDetail,
   PersonalDashboard,
   TeamLeaveSummaryRow,
-} from '@/types/hr';
+} from "@/types/hr";
 
-const BASE = '/api/hr';
+const BASE = "/api/hr";
 
-function qs(params?: Record<string, string | number | null | undefined>): string {
-  if (!params) return '';
+function qs(
+  params?: Record<string, string | number | null | undefined>,
+): string {
+  if (!params) return "";
   const entries = Object.entries(params).filter(
-    (entry): entry is [string, string | number] => entry[1] != null
+    (entry): entry is [string, string | number] => entry[1] != null,
   );
   return entries.length
-    ? '?' + new URLSearchParams(entries.map(([k, v]) => [k, String(v)])).toString()
-    : '';
+    ? "?" +
+        new URLSearchParams(entries.map(([k, v]) => [k, String(v)])).toString()
+    : "";
 }
 
 // Dashboard
 export const getDashboard = () => api.get<AdminDashboard>(`${BASE}/dashboard`);
-export const getMyDashboard = () => api.get<PersonalDashboard>(`${BASE}/my-dashboard`);
+export const getMyDashboard = () =>
+  api.get<PersonalDashboard>(`${BASE}/my-dashboard`);
 
 // Employees
 export const listEmployees = () =>
   api.get<{ employees: HREmployee[]; count: number }>(`${BASE}/employees`);
-export const getEmployee = (id: number) => api.get<HREmployee>(`${BASE}/employees/${id}`);
+export const getEmployee = (id: number) =>
+  api.get<HREmployee>(`${BASE}/employees/${id}`);
 export const upsertEmployee = (data: EmployeeCreatePayload) =>
-  api.post<{ success: boolean; employee: HREmployee }>(`${BASE}/employees`, data);
+  api.post<{ success: boolean; employee: HREmployee }>(
+    `${BASE}/employees`,
+    data,
+  );
 
 // Bonus Rates
 export const listBonusRates = () =>
@@ -52,35 +61,55 @@ export const upsertBonusRate = (data: BonusRatePayload) =>
   api.post<{ success: boolean; rate: BonusRate }>(`${BASE}/bonus-rates`, data);
 
 // Bonuses
-export const listBonuses = (params?: Record<string, string | number | null | undefined>) =>
+export const listBonuses = (
+  params?: Record<string, string | number | null | undefined>,
+) =>
   api.get<{ bonuses: Bonus[]; count: number }>(`${BASE}/bonuses${qs(params)}`);
 export const approveBonus = (id: number) =>
-  api.post<{ success: boolean; bonus: Bonus }>(`${BASE}/bonuses/${id}/approve`, {});
+  api.post<{ success: boolean; bonus: Bonus }>(
+    `${BASE}/bonuses/${id}/approve`,
+    {},
+  );
+/** HR-admin only — 403 for team members. Callers must tolerate the rejection. */
+export const listBonusHistorical = (year?: number) =>
+  api.get<{ records: BonusHistoricalRecord[]; count: number }>(
+    `${BASE}/bonuses/historical${qs({ year })}`,
+  );
 
 // Payroll
 export const calculatePayroll = (month: number, year: number) =>
   api.post<{ success: boolean; period_id: number; employee_count: number }>(
     `${BASE}/payroll/calculate`,
-    { month, year }
+    { month, year },
   );
 export const listPayrollPeriods = () =>
-  api.get<{ periods: PayrollPeriod[]; count: number }>(`${BASE}/payroll/periods`);
-export const listPayslips = (params?: Record<string, string | number | null | undefined>) =>
-  api.get<{ payslips: Payslip[]; count: number }>(`${BASE}/payslips${qs(params)}`);
-export const getPayslipDetail = (id: number) => api.get<PayslipDetail>(`${BASE}/payslips/${id}`);
+  api.get<{ periods: PayrollPeriod[]; count: number }>(
+    `${BASE}/payroll/periods`,
+  );
+export const listPayslips = (
+  params?: Record<string, string | number | null | undefined>,
+) =>
+  api.get<{ payslips: Payslip[]; count: number }>(
+    `${BASE}/payslips${qs(params)}`,
+  );
+export const getPayslipDetail = (id: number) =>
+  api.get<PayslipDetail>(`${BASE}/payslips/${id}`);
 export const approvePayroll = (periodId: number) =>
-  api.post<{ success: boolean; period: PayrollPeriod }>(`${BASE}/payroll/${periodId}/approve`, {});
+  api.post<{ success: boolean; period: PayrollPeriod }>(
+    `${BASE}/payroll/${periodId}/approve`,
+    {},
+  );
 export const markPayrollPaid = (periodId: number) =>
   api.post<{ success: boolean; period: PayrollPeriod }>(
     `${BASE}/payroll/${periodId}/mark-paid`,
-    {}
+    {},
   );
 
 // Leave Types — backend /leave/types returns active rows only,
 // projected to the columns the dropdown needs.
 export type LeaveTypeOption = Pick<
   LeaveType,
-  'id' | 'code' | 'name' | 'default_days' | 'is_paid' | 'requires_document'
+  "id" | "code" | "name" | "default_days" | "is_paid" | "requires_document"
 >;
 
 export const getLeaveTypes = () =>
@@ -88,14 +117,33 @@ export const getLeaveTypes = () =>
 
 // Leave
 export const requestLeave = (data: LeaveRequestPayload) =>
-  api.post<{ success: boolean; request: LeaveRequest }>(`${BASE}/leave/request`, data);
-export const listLeaveRequests = (params?: Record<string, string | number | null | undefined>) =>
-  api.get<{ requests: LeaveRequest[]; count: number }>(`${BASE}/leave/requests${qs(params)}`);
-export const getLeaveBalance = (params?: Record<string, string | number | null | undefined>) =>
+  api.post<{ success: boolean; request: LeaveRequest }>(
+    `${BASE}/leave/request`,
+    data,
+  );
+export const listLeaveRequests = (
+  params?: Record<string, string | number | null | undefined>,
+) =>
+  api.get<{ requests: LeaveRequest[]; count: number }>(
+    `${BASE}/leave/requests${qs(params)}`,
+  );
+export const getLeaveBalance = (
+  params?: Record<string, string | number | null | undefined>,
+) =>
   api.get<{ balances: LeaveBalance[] }>(`${BASE}/leave/balance${qs(params)}`);
-export const getTeamLeaveSummary = (params?: Record<string, string | number | null | undefined>) =>
-  api.get<{ summary: TeamLeaveSummaryRow[] }>(`${BASE}/leave/team-summary${qs(params)}`);
+export const getTeamLeaveSummary = (
+  params?: Record<string, string | number | null | undefined>,
+) =>
+  api.get<{ summary: TeamLeaveSummaryRow[] }>(
+    `${BASE}/leave/team-summary${qs(params)}`,
+  );
 export const approveLeave = (id: number) =>
-  api.post<{ success: boolean; request: LeaveRequest }>(`${BASE}/leave/${id}/approve`, {});
+  api.post<{ success: boolean; request: LeaveRequest }>(
+    `${BASE}/leave/${id}/approve`,
+    {},
+  );
 export const rejectLeave = (id: number, reason?: string) =>
-  api.post<{ success: boolean; request: LeaveRequest }>(`${BASE}/leave/${id}/reject`, { reason });
+  api.post<{ success: boolean; request: LeaveRequest }>(
+    `${BASE}/leave/${id}/reject`,
+    { reason },
+  );

--- a/apps/mouth/src/lib/hr/bonus-aggregation.test.ts
+++ b/apps/mouth/src/lib/hr/bonus-aggregation.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import type { Bonus } from "@/types/hr";
+import {
+  aggregateByMember,
+  bonusesToCsv,
+  groupBonusesByMonth,
+  witaMonthKey,
+} from "./bonus-aggregation";
+
+/** Minimal Bonus factory — only the fields the aggregation reads. */
+function bonus(over: Partial<Bonus> & { id: number }): Bonus {
+  return {
+    practice_id: 0,
+    employee_id: 1,
+    payroll_period_id: null,
+    bonus_rate_id: null,
+    practice_type_code: "visa_b211",
+    amount_idr: 100_000,
+    status: "approved",
+    awarded_at: "2026-07-10T02:00:00.000Z",
+    awarded_by: null,
+    approved_by: null,
+    approved_at: null,
+    employee_name: "Surya",
+    employee_email: "surya@balizero.com",
+    practice_status: "completed",
+    client_name: null,
+    notes: null,
+    ...over,
+  } as Bonus;
+}
+
+describe("witaMonthKey", () => {
+  it("buckets by Asia/Makassar (WITA), not by UTC", () => {
+    // 2026-02-28T16:00Z === 2026-03-01T00:00 WITA → March, not February.
+    expect(witaMonthKey("2026-02-28T16:00:00.000Z")).toBe("2026-03");
+  });
+
+  it("keeps a mid-day UTC timestamp in its own month", () => {
+    expect(witaMonthKey("2026-07-10T02:00:00.000Z")).toBe("2026-07");
+  });
+
+  it("handles the last instant of a WITA month", () => {
+    // 2026-06-30T15:59Z === 2026-06-30T23:59 WITA → still June.
+    expect(witaMonthKey("2026-06-30T15:59:00.000Z")).toBe("2026-06");
+  });
+
+  it("returns empty string for missing or unparseable input", () => {
+    expect(witaMonthKey("")).toBe("");
+    expect(witaMonthKey("not-a-date")).toBe("");
+    expect(witaMonthKey(null as unknown as string)).toBe("");
+  });
+});
+
+describe("groupBonusesByMonth", () => {
+  it("returns months newest-first", () => {
+    const months = groupBonusesByMonth([
+      bonus({ id: 1, awarded_at: "2026-05-02T02:00:00.000Z" }),
+      bonus({ id: 2, awarded_at: "2026-07-02T02:00:00.000Z" }),
+      bonus({ id: 3, awarded_at: "2026-06-02T02:00:00.000Z" }),
+    ]);
+    expect(months.map((m) => m.key)).toEqual(["2026-07", "2026-06", "2026-05"]);
+  });
+
+  it("totals each month and splits pending out", () => {
+    const months = groupBonusesByMonth([
+      bonus({ id: 1, amount_idr: 300_000, status: "approved" }),
+      bonus({ id: 2, amount_idr: 200_000, status: "pending" }),
+      bonus({ id: 3, amount_idr: 500_000, status: "approved" }),
+    ]);
+    expect(months).toHaveLength(1);
+    expect(months[0].total).toBe(1_000_000);
+    expect(months[0].pendingTotal).toBe(200_000);
+    expect(months[0].approvedTotal).toBe(800_000);
+    expect(months[0].count).toBe(3);
+  });
+
+  it("aggregates per member inside the month, highest total first", () => {
+    const months = groupBonusesByMonth([
+      bonus({
+        id: 1,
+        employee_id: 1,
+        employee_name: "Adit",
+        amount_idr: 100_000,
+      }),
+      bonus({
+        id: 2,
+        employee_id: 3,
+        employee_name: "Surya",
+        amount_idr: 900_000,
+      }),
+      bonus({
+        id: 3,
+        employee_id: 1,
+        employee_name: "Adit",
+        amount_idr: 250_000,
+      }),
+    ]);
+    const members = months[0].members;
+    expect(members.map((m) => m.employeeName)).toEqual(["Surya", "Adit"]);
+    expect(members[0].total).toBe(900_000);
+    expect(members[1].total).toBe(350_000);
+    expect(members[1].count).toBe(2);
+    expect(months[0].memberCount).toBe(2);
+  });
+
+  it("splits a member's month total by status", () => {
+    const months = groupBonusesByMonth([
+      bonus({ id: 1, amount_idr: 400_000, status: "approved" }),
+      bonus({ id: 2, amount_idr: 150_000, status: "pending" }),
+      bonus({ id: 3, amount_idr: 50_000, status: "paid" }),
+    ]);
+    const m = months[0].members[0];
+    expect(m.total).toBe(600_000);
+    expect(m.byStatus.approved).toBe(400_000);
+    expect(m.byStatus.pending).toBe(150_000);
+    expect(m.byStatus.paid).toBe(50_000);
+  });
+
+  it("keeps the member's own bonus rows attached, newest first", () => {
+    const months = groupBonusesByMonth([
+      bonus({ id: 1, awarded_at: "2026-07-02T02:00:00.000Z" }),
+      bonus({ id: 2, awarded_at: "2026-07-20T02:00:00.000Z" }),
+    ]);
+    expect(months[0].members[0].bonuses.map((b) => b.id)).toEqual([2, 1]);
+  });
+
+  it("never drops money: undated rows land in their own bucket, sorted last", () => {
+    const months = groupBonusesByMonth([
+      bonus({ id: 1, amount_idr: 100_000 }),
+      bonus({ id: 2, amount_idr: 700_000, awarded_at: "" }),
+    ]);
+    expect(months).toHaveLength(2);
+    expect(months[1].key).toBe("");
+    expect(months[1].total).toBe(700_000);
+    const grand = months.reduce((s, m) => s + m.total, 0);
+    expect(grand).toBe(800_000);
+  });
+
+  it("separates members with the same name but different employee_id", () => {
+    const months = groupBonusesByMonth([
+      bonus({
+        id: 1,
+        employee_id: 1,
+        employee_name: "Ari",
+        amount_idr: 100_000,
+      }),
+      bonus({
+        id: 2,
+        employee_id: 9,
+        employee_name: "Ari",
+        amount_idr: 200_000,
+      }),
+    ]);
+    expect(months[0].members).toHaveLength(2);
+  });
+
+  it("coerces string amounts (BIGINT serialised as text) instead of concatenating", () => {
+    const months = groupBonusesByMonth([
+      bonus({ id: 1, amount_idr: "300000" as unknown as number }),
+      bonus({ id: 2, amount_idr: "200000" as unknown as number }),
+    ]);
+    expect(months[0].total).toBe(500_000);
+  });
+
+  it("returns an empty array for no bonuses", () => {
+    expect(groupBonusesByMonth([])).toEqual([]);
+  });
+});
+
+describe("aggregateByMember", () => {
+  it("totals each member across every month, highest first", () => {
+    const rows = aggregateByMember([
+      bonus({
+        id: 1,
+        employee_id: 1,
+        employee_name: "Adit",
+        amount_idr: 100_000,
+        awarded_at: "2026-05-02T02:00:00.000Z",
+      }),
+      bonus({
+        id: 2,
+        employee_id: 1,
+        employee_name: "Adit",
+        amount_idr: 200_000,
+        awarded_at: "2026-06-02T02:00:00.000Z",
+      }),
+      bonus({
+        id: 3,
+        employee_id: 3,
+        employee_name: "Surya",
+        amount_idr: 250_000,
+        awarded_at: "2026-06-02T02:00:00.000Z",
+      }),
+    ]);
+    expect(rows.map((r) => r.employeeName)).toEqual(["Adit", "Surya"]);
+    expect(rows[0].total).toBe(300_000);
+    expect(rows[0].monthCount).toBe(2);
+    expect(rows[0].count).toBe(2);
+    expect(rows[1].monthCount).toBe(1);
+  });
+
+  it("exposes each member's per-month totals keyed by month", () => {
+    const rows = aggregateByMember([
+      bonus({
+        id: 1,
+        amount_idr: 100_000,
+        awarded_at: "2026-05-02T02:00:00.000Z",
+      }),
+      bonus({
+        id: 2,
+        amount_idr: 400_000,
+        awarded_at: "2026-06-02T02:00:00.000Z",
+      }),
+    ]);
+    expect(rows[0].byMonth["2026-05"]).toBe(100_000);
+    expect(rows[0].byMonth["2026-06"]).toBe(400_000);
+  });
+
+  it("agrees with the month grouping on the grand total", () => {
+    const data = [
+      bonus({
+        id: 1,
+        employee_id: 1,
+        amount_idr: 100_000,
+        awarded_at: "2026-05-02T02:00:00.000Z",
+      }),
+      bonus({
+        id: 2,
+        employee_id: 2,
+        amount_idr: 250_000,
+        awarded_at: "2026-06-02T02:00:00.000Z",
+      }),
+      bonus({
+        id: 3,
+        employee_id: 2,
+        amount_idr: 300_000,
+        awarded_at: "2026-07-02T02:00:00.000Z",
+      }),
+      bonus({ id: 4, employee_id: 1, amount_idr: 700_000, awarded_at: "" }),
+    ];
+    const byMonth = groupBonusesByMonth(data).reduce((s, m) => s + m.total, 0);
+    const byMember = aggregateByMember(data).reduce((s, r) => s + r.total, 0);
+    expect(byMonth).toBe(byMember);
+    expect(byMonth).toBe(1_350_000);
+  });
+});
+
+describe("bonusesToCsv", () => {
+  it("emits one row per member per month plus a header", () => {
+    const csv = bonusesToCsv(
+      groupBonusesByMonth([
+        bonus({
+          id: 1,
+          employee_id: 1,
+          employee_name: "Adit",
+          amount_idr: 100_000,
+        }),
+        bonus({
+          id: 2,
+          employee_id: 3,
+          employee_name: "Surya",
+          amount_idr: 900_000,
+        }),
+      ]),
+    );
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe(
+      "month,employee_id,employee_name,employee_email,bonus_count,pending_idr,approved_idr,paid_idr,total_idr",
+    );
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain("2026-07");
+    expect(lines[1]).toContain("900000");
+  });
+
+  it("quotes and escapes fields containing commas or quotes", () => {
+    const csv = bonusesToCsv(
+      groupBonusesByMonth([
+        bonus({ id: 1, employee_name: 'Adit, "AD"', amount_idr: 100_000 }),
+      ]),
+    );
+    expect(csv).toContain('"Adit, ""AD"""');
+  });
+
+  it("neutralises formula injection in a name without touching the amounts", () => {
+    const csv = bonusesToCsv(
+      groupBonusesByMonth([
+        bonus({
+          id: 1,
+          employee_name: "=cmd|'/c calc'!A1",
+          amount_idr: 250_000,
+        }),
+      ]),
+    );
+    expect(csv).toContain("'=cmd");
+    expect(csv).not.toMatch(/,=cmd/);
+    // The amount is still a bare number, not text.
+    expect(csv).toContain(",250000");
+  });
+
+  it("writes amounts as bare integers so spreadsheets read them as numbers", () => {
+    const csv = bonusesToCsv(
+      groupBonusesByMonth([bonus({ id: 1, amount_idr: 1_250_000 })]),
+    );
+    expect(csv).toContain(",1250000");
+    expect(csv).not.toContain("Rp");
+  });
+});

--- a/apps/mouth/src/lib/hr/bonus-aggregation.ts
+++ b/apps/mouth/src/lib/hr/bonus-aggregation.ts
@@ -1,0 +1,294 @@
+/**
+ * Bonus aggregation for the HR /hr/bonuses accounting view.
+ *
+ * Accounting needs one number per member per month. The API returns a flat
+ * ledger, so the roll-up happens here — as pure functions, so the arithmetic
+ * that payroll depends on is unit-testable without a browser.
+ *
+ * Timezone: buckets are cut on **Asia/Makassar (WITA)**, the business
+ * timezone, NEVER on the browser's local zone. `awarded_at` is a UTC
+ * timestamptz and rows written at midnight WITA are stored as 16:00Z the
+ * previous day — bucketing on UTC (or on a laptop set to Europe/Rome) silently
+ * moves those rows into the previous month and makes two machines disagree
+ * about the same payroll. Live prod data already contains such rows.
+ */
+
+import type { Bonus, BonusStatus } from "@/types/hr";
+
+/** Business timezone for month cut-off. Bali Zero operates on WITA. */
+const BUSINESS_TZ = "Asia/Makassar";
+
+/** Bucket key used for rows whose `awarded_at` is missing or unparseable. */
+export const UNDATED_KEY = "";
+
+const monthKeyFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: BUSINESS_TZ,
+  year: "numeric",
+  month: "2-digit",
+});
+
+const monthLabelFormatter = new Intl.DateTimeFormat("en-GB", {
+  timeZone: BUSINESS_TZ,
+  year: "numeric",
+  month: "long",
+});
+
+export interface MemberMonthAggregate {
+  /** Stable identity: employee_id when present, else the email/name fallback. */
+  memberKey: string;
+  employeeId: number | null;
+  employeeName: string;
+  employeeEmail: string;
+  count: number;
+  total: number;
+  /** Amount per status. Absent statuses are 0. */
+  byStatus: Record<BonusStatus, number>;
+  /** This member's own rows for this month, newest first. */
+  bonuses: Bonus[];
+}
+
+export interface MonthAggregate {
+  /** `YYYY-MM` in WITA, or `UNDATED_KEY` for undated rows. */
+  key: string;
+  label: string;
+  count: number;
+  memberCount: number;
+  total: number;
+  pendingTotal: number;
+  approvedTotal: number;
+  members: MemberMonthAggregate[];
+}
+
+export interface MemberTotal {
+  memberKey: string;
+  employeeId: number | null;
+  employeeName: string;
+  employeeEmail: string;
+  count: number;
+  total: number;
+  /** Number of distinct months this member earned a bonus in. */
+  monthCount: number;
+  byStatus: Record<BonusStatus, number>;
+  /** Month key → total for this member. */
+  byMonth: Record<string, number>;
+}
+
+function emptyStatusMap(): Record<BonusStatus, number> {
+  return { pending: 0, approved: 0, rejected: 0, paid: 0, reversed: 0 };
+}
+
+/** Coerce an amount that may arrive as a JSON string (BIGINT) to a number. */
+function amountOf(bonus: Bonus): number {
+  const n = Number(bonus.amount_idr);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function memberKeyOf(bonus: Bonus): string {
+  if (bonus.employee_id != null) return `id:${bonus.employee_id}`;
+  return `email:${bonus.employee_email || bonus.employee_name || "unknown"}`;
+}
+
+function addStatus(
+  map: Record<BonusStatus, number>,
+  status: BonusStatus,
+  amount: number,
+): void {
+  map[status] = (map[status] ?? 0) + amount;
+}
+
+/**
+ * `YYYY-MM` of an ISO timestamp in WITA, or `UNDATED_KEY` when unparseable.
+ */
+export function witaMonthKey(awardedAt: string): string {
+  if (!awardedAt) return UNDATED_KEY;
+  const d = new Date(awardedAt);
+  if (Number.isNaN(d.getTime())) return UNDATED_KEY;
+  // en-CA renders as `YYYY-MM`, already zero-padded.
+  return monthKeyFormatter.format(d);
+}
+
+/** Human month label, e.g. `July 2026`. */
+export function witaMonthLabel(awardedAt: string): string {
+  if (!awardedAt) return "Undated";
+  const d = new Date(awardedAt);
+  if (Number.isNaN(d.getTime())) return "Undated";
+  return monthLabelFormatter.format(d);
+}
+
+/** Date of a single bonus row, rendered in WITA. */
+export function formatBonusDate(awardedAt: string): string {
+  if (!awardedAt) return "—";
+  const d = new Date(awardedAt);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-GB", {
+    timeZone: BUSINESS_TZ,
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+/**
+ * Group the flat ledger into months (newest first), and within each month into
+ * one row per member (largest total first).
+ *
+ * Every input row lands in exactly one bucket — undated rows get their own,
+ * sorted last, so the sum of the month totals always equals the sum of the
+ * payload. Accounting must never see money quietly disappear.
+ */
+export function groupBonusesByMonth(bonuses: Bonus[]): MonthAggregate[] {
+  const months = new Map<string, Map<string, MemberMonthAggregate>>();
+  const labels = new Map<string, string>();
+
+  for (const bonus of bonuses) {
+    const key = witaMonthKey(bonus.awarded_at);
+    if (!labels.has(key)) labels.set(key, witaMonthLabel(bonus.awarded_at));
+
+    let members = months.get(key);
+    if (!members) {
+      members = new Map();
+      months.set(key, members);
+    }
+
+    const mKey = memberKeyOf(bonus);
+    let member = members.get(mKey);
+    if (!member) {
+      member = {
+        memberKey: mKey,
+        employeeId: bonus.employee_id ?? null,
+        employeeName: bonus.employee_name || bonus.employee_email || "Unknown",
+        employeeEmail: bonus.employee_email || "",
+        count: 0,
+        total: 0,
+        byStatus: emptyStatusMap(),
+        bonuses: [],
+      };
+      members.set(mKey, member);
+    }
+
+    const amount = amountOf(bonus);
+    member.count += 1;
+    member.total += amount;
+    addStatus(member.byStatus, bonus.status, amount);
+    member.bonuses.push(bonus);
+  }
+
+  const result: MonthAggregate[] = [];
+  for (const [key, members] of months) {
+    const memberList = [...members.values()].sort(
+      (a, b) =>
+        b.total - a.total || a.employeeName.localeCompare(b.employeeName),
+    );
+    for (const m of memberList) {
+      m.bonuses.sort(
+        (a, b) =>
+          new Date(b.awarded_at).getTime() - new Date(a.awarded_at).getTime() ||
+          b.id - a.id,
+      );
+    }
+    result.push({
+      key,
+      label: labels.get(key) ?? "Undated",
+      count: memberList.reduce((s, m) => s + m.count, 0),
+      memberCount: memberList.length,
+      total: memberList.reduce((s, m) => s + m.total, 0),
+      pendingTotal: memberList.reduce((s, m) => s + m.byStatus.pending, 0),
+      approvedTotal: memberList.reduce((s, m) => s + m.byStatus.approved, 0),
+      members: memberList,
+    });
+  }
+
+  // Newest month first; the undated bucket always sorts last.
+  return result.sort((a, b) => {
+    if (a.key === UNDATED_KEY) return 1;
+    if (b.key === UNDATED_KEY) return -1;
+    return b.key.localeCompare(a.key);
+  });
+}
+
+/**
+ * All-time total per member (largest first) — the "totale membri, membro per
+ * membro" summary, with each member's per-month breakdown attached.
+ */
+export function aggregateByMember(bonuses: Bonus[]): MemberTotal[] {
+  const rows = new Map<string, MemberTotal>();
+
+  for (const bonus of bonuses) {
+    const mKey = memberKeyOf(bonus);
+    let row = rows.get(mKey);
+    if (!row) {
+      row = {
+        memberKey: mKey,
+        employeeId: bonus.employee_id ?? null,
+        employeeName: bonus.employee_name || bonus.employee_email || "Unknown",
+        employeeEmail: bonus.employee_email || "",
+        count: 0,
+        total: 0,
+        monthCount: 0,
+        byStatus: emptyStatusMap(),
+        byMonth: {},
+      };
+      rows.set(mKey, row);
+    }
+
+    const amount = amountOf(bonus);
+    const monthKey = witaMonthKey(bonus.awarded_at);
+    row.count += 1;
+    row.total += amount;
+    addStatus(row.byStatus, bonus.status, amount);
+    row.byMonth[monthKey] = (row.byMonth[monthKey] ?? 0) + amount;
+  }
+
+  const result = [...rows.values()];
+  for (const row of result) row.monthCount = Object.keys(row.byMonth).length;
+  return result.sort(
+    (a, b) => b.total - a.total || a.employeeName.localeCompare(b.employeeName),
+  );
+}
+
+function csvCell(value: string | number): string {
+  let s = String(value);
+  // Formula injection: a cell starting with = + - @ (or a lone tab/CR) is
+  // executed as a formula by Excel and Sheets. Only text cells reach this
+  // guard — the amount columns are written as raw numbers below — so the
+  // leading apostrophe can never turn a figure into text.
+  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+/**
+ * One CSV row per member per month — the shape accounting pastes into a sheet.
+ * Amounts are bare integers (no `Rp`, no thousands separator) so spreadsheets
+ * parse them as numbers rather than text.
+ */
+export function bonusesToCsv(months: MonthAggregate[]): string {
+  const header = [
+    "month",
+    "employee_id",
+    "employee_name",
+    "employee_email",
+    "bonus_count",
+    "pending_idr",
+    "approved_idr",
+    "paid_idr",
+    "total_idr",
+  ].join(",");
+
+  const lines = months.flatMap((month) =>
+    month.members.map((m) =>
+      [
+        csvCell(month.key || "undated"),
+        csvCell(m.employeeId ?? ""),
+        csvCell(m.employeeName),
+        csvCell(m.employeeEmail),
+        m.count,
+        m.byStatus.pending,
+        m.byStatus.approved,
+        m.byStatus.paid,
+        m.total,
+      ].join(","),
+    ),
+  );
+
+  return [header, ...lines].join("\n") + "\n";
+}

--- a/apps/mouth/src/types/hr.ts
+++ b/apps/mouth/src/types/hr.ts
@@ -5,10 +5,23 @@
 
 // ─── Enums ────────────────────────────────────────────────────────────
 
-export type BonusStatus = 'pending' | 'approved' | 'rejected' | 'paid' | 'reversed';
-export type PayrollStatus = 'draft' | 'calculated' | 'approved' | 'paid';
-export type LeaveStatus = 'pending' | 'approved' | 'rejected' | 'cancelled';
-export type PTKPStatus = 'TK/0' | 'TK/1' | 'TK/2' | 'TK/3' | 'K/0' | 'K/1' | 'K/2' | 'K/3';
+export type BonusStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "paid"
+  | "reversed";
+export type PayrollStatus = "draft" | "calculated" | "approved" | "paid";
+export type LeaveStatus = "pending" | "approved" | "rejected" | "cancelled";
+export type PTKPStatus =
+  | "TK/0"
+  | "TK/1"
+  | "TK/2"
+  | "TK/3"
+  | "K/0"
+  | "K/1"
+  | "K/2"
+  | "K/3";
 
 // ─── Employees ────────────────────────────────────────────────────────
 
@@ -90,6 +103,29 @@ export interface Bonus {
   employee_email: string;
   practice_status: string;
   client_name: string | null;
+  notes: string | null;
+}
+
+/**
+ * Pre-system bonus recap imported from PDF (migration 099).
+ *
+ * A SEPARATE source from `Bonus`/`hr_bonus_ledger`: the two overlap on some
+ * months with different totals. Show side by side for reconciliation —
+ * never add the two together.
+ */
+export interface BonusHistoricalRecord {
+  id: number;
+  employee_name: string;
+  employee_id: number | null;
+  bonus_month: number;
+  bonus_year: number;
+  total_amount_idr: number;
+  task_count: number;
+  source_pdf: string;
+  accounting_total_data: number | null;
+  accounting_not_paid: number | null;
+  accounting_paid: number | null;
+  imported_at: string;
   notes: string | null;
 }
 

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 657 services · 1226 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 657 services · 1227 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Why

`/hr/bonuses` was a flat list of every bonus row with no aggregation at all — its only
total was the row count ("370 total"). To answer "what is this person's bonus for June?"
accounting had to add rows by hand.

Mandate (Zero): *"I bonus suddividiamoli in mesi poi totale membri, membro per membro.
Così l'accounting facilmente sa quale è il reale bonus mensile del singolo."*

## What the page does now

1. **Total per member** table at the top — member × months × bonuses × pending/approved × total.
2. **One collapsible section per month**, newest first, with the month total, the member count
   and the pending sub-total in the header.
3. **Inside each month, one row per member** — count, pending/approved split, month total.
   This is the number accounting reads.
4. Expanding a member reveals the individual bonus rows (practice type, client, date, amount)
   with the existing **Approve** action — nothing from the old page is lost.
5. **Filters** (year / status / member) and a **CSV export**, one row per member per month,
   amounts as bare integers so spreadsheets parse them as numbers.

## Two defects found while building this

### 1. Bonus months were cut on UTC, not WITA — `fix(hr)` commit

`awarded_at` is a `timestamptz` and the Fly Postgres session is **UTC**, so
`EXTRACT(MONTH FROM awarded_at)` cut the month at 08:00 WITA: a bonus awarded at 00:30 on
the 1st was billed to the **previous month**. Live prod already contains 2 such rows
(`2026-02-28T16:00Z` = `2026-03-01 00:00` WITA).

All **four** call sites were affected — `list_bonuses`, `get_bonus_summary`,
`calculate_payroll`, `get_my_dashboard` — plus `date.today()` on both dashboards. Curing one
would have left payroll and the HR views disagreeing about which month a bonus belongs to.

Safe to align now: **`hr_payroll_periods` is empty** — no payroll has ever been calculated off
the old buckets, so nothing already paid is restated.

Guarded by `test_bonus_month_bucketing_is_wita.py`, proven **both ways**: passes on the
corrected source, and fails (RC=1) when a single site is regressed to the bare `EXTRACT`.

### 2. `hr_bonus_historical` was a dark table that contradicts the ledger — `feat(hr)` commit

Migration 099 imported 11 per-employee/month recaps from PDF (Rp 28.500.000). **No API and no
page has ever read it.** It overlaps the ledger on **2026-02 and 2026-03 with different
totals**, and neither source is a subset of the other:

| month | employee | PDF recap | ledger |
|---|---|---|---|
| 2026-02 | emp#3 | 3.000.000 (13 tasks) | 2.760.000 (6 rows) |
| 2026-03 | emp#2 | 2.000.000 (14 tasks) | 6.100.000 (35 rows) |

Accounting reading only the ledger would trust a contested figure for those two months. This
PR adds a read-only HR-admin-only `GET /api/hr/bonuses/historical` and renders the recap as an
explicitly **EXCLUDED** strip with the delta — scoped to the same member filter and suppressed
under a status filter, so the delta can never compare a filtered ledger total against an
all-members PDF total.

**It does not decide which source is authoritative** — see "Needs Zero" below.

## Verification

- **Against real prod data**: the aggregation module run over the live ledger (370 rows) —
  all 7 month buckets, all 8 member totals, and both grand totals match a baseline computed
  independently in SQL with `AT TIME ZONE 'Asia/Makassar'`. 63/63 checks green
  (Rp 70.760.000 grand total both ways).
- **Frontend**: 32 new tests (20 aggregation unit + 12 page component). Full `apps/mouth`
  suite 231 files / 2089 tests green.
- **Backend**: HR service suite green incl. the 2 new historical tests and the 4 tripwire tests.
- **Route order** probed live: `GET /api/hr/bonuses/historical` registers before
  `POST /api/hr/bonuses/{bonus_id}/approve`; there is no `GET /bonuses/{id}` to shadow it.
- **Adversarial gate** (generator≠grader): Codex GPT-5.6 xhigh on the full diff. Reported
  CLEAN on arithmetic / RBAC-PII / SQL / route-order / React / CSV; the two defects it did find
  (UTC-vs-WITA payroll disagreement, unscoped legacy delta) are **both fixed in this PR** with
  regression tests.

## Diff noise to expect

`src/lib/api/hr/hr.ts` and `src/types/hr.ts` show larger diffs than the ~30 lines actually
added: neither file was prettier-clean on `main`, and the pre-commit hook requires staged files
to be formatted, so `prettier --write` normalised them (single→double quotes, line wrapping).
Those hunks are formatting only — the behavioural change in both files is the
`BonusHistoricalRecord` type and the `listBonusHistorical` client.

## Needs Zero (business decision, Legge 5)

**Which source is authoritative for 2026-02 and 2026-03 — the PDF recaps or the ledger?**
Until that is answered the page shows both and sums neither. Once decided, the loser should be
reconciled or marked superseded so the strip can retire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
