### PR TITLE
fix(automations): 4 MAX seats as slots 1-4, Team premium as slot 5 (last-resort)

### DIFF
--- a/apps/backend-rag/scripts/auto_verifier.py
+++ b/apps/backend-rag/scripts/auto_verifier.py
@@ -92,7 +92,7 @@ _VERIFIER_EXHAUSTED: dict[str, str] = {}
 
 def _verifier_token_chain() -> list[tuple[str, str]]:
     chain: list[tuple[str, str]] = []
-    for i in (1, 2, 3, 4):
+    for i in (1, 2, 3, 4, 5):
         tok = os.environ.get(f"CLAUDE_CODE_OAUTH_TOKEN_{i}", "").strip()
         if tok:
             chain.append((f"token_{i}", tok))

--- a/apps/backend-rag/scripts/verified_generator.py
+++ b/apps/backend-rag/scripts/verified_generator.py
@@ -264,7 +264,7 @@ _GEN_EXHAUSTED: dict[str, str] = {}
 
 def _gen_token_chain() -> list[tuple[str, str]]:
     chain: list[tuple[str, str]] = []
-    for i in (1, 2, 3, 4):
+    for i in (1, 2, 3, 4, 5):
         tok = os.environ.get(f"CLAUDE_CODE_OAUTH_TOKEN_{i}", "").strip()
         if tok:
             chain.append((f"token_{i}", tok))

--- a/apps/bali-intel-scraper/scripts/bz_image_style.py
+++ b/apps/bali-intel-scraper/scripts/bz_image_style.py
@@ -413,7 +413,7 @@ _IMG_EXHAUSTED_TOKENS: dict[str, str] = {}
 def _load_img_token_chain() -> list[tuple[str, str]]:
     """Load ordered list of (label, oauth_token) for image prompt generation."""
     chain: list[tuple[str, str]] = []
-    for i in (1, 2, 3, 4):
+    for i in (1, 2, 3, 4, 5):
         tok = os.environ.get(f"CLAUDE_CODE_OAUTH_TOKEN_{i}", "").strip()
         if tok:
             chain.append((f"token_{i}", tok))

--- a/apps/evaluator/nlm_deep_research/t4_monitor.py
+++ b/apps/evaluator/nlm_deep_research/t4_monitor.py
@@ -310,7 +310,7 @@ class T4RelevanceFilter:
         # the macOS-keychain-stored token.
         env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
         for key in ("CLAUDE_CODE_OAUTH_TOKEN_1", "CLAUDE_CODE_OAUTH_TOKEN_2",
-                    "CLAUDE_CODE_OAUTH_TOKEN_3", "CLAUDE_CODE_OAUTH_TOKEN_4", "CLAUDE_CODE_OAUTH_TOKEN"):
+                    "CLAUDE_CODE_OAUTH_TOKEN_3", "CLAUDE_CODE_OAUTH_TOKEN_4", "CLAUDE_CODE_OAUTH_TOKEN_5", "CLAUDE_CODE_OAUTH_TOKEN"):
             tok = os.environ.get(key, "").strip()
             if tok:
                 env["CLAUDE_CODE_OAUTH_TOKEN"] = tok

--- a/apps/mata-garuda/mata_garuda/agents/daily_briefing_agent.py
+++ b/apps/mata-garuda/mata_garuda/agents/daily_briefing_agent.py
@@ -177,6 +177,7 @@ def _tldr_claude(title: str, content: str) -> str:
         "CLAUDE_CODE_OAUTH_TOKEN_2",
         "CLAUDE_CODE_OAUTH_TOKEN_3",
         "CLAUDE_CODE_OAUTH_TOKEN_4",
+        "CLAUDE_CODE_OAUTH_TOKEN_5",
         "CLAUDE_CODE_OAUTH_TOKEN",
     ]
     for var in token_vars:

--- a/apps/mata-garuda/mata_garuda/agents/weekly_digest_agent.py
+++ b/apps/mata-garuda/mata_garuda/agents/weekly_digest_agent.py
@@ -115,6 +115,7 @@ def call_claude(prompt: str, timeout: int = 120) -> str:
         "CLAUDE_CODE_OAUTH_TOKEN_2",
         "CLAUDE_CODE_OAUTH_TOKEN_3",
         "CLAUDE_CODE_OAUTH_TOKEN_4",
+        "CLAUDE_CODE_OAUTH_TOKEN_5",
         "CLAUDE_CODE_OAUTH_TOKEN",
     ]
     for var in token_vars:

--- a/apps/mata-garuda/mata_garuda/runtime/cli_runtime.py
+++ b/apps/mata-garuda/mata_garuda/runtime/cli_runtime.py
@@ -41,7 +41,8 @@ CLAUDE_TOKEN_VARS = [
     "CLAUDE_CODE_OAUTH_TOKEN_1",  # antonellosiano@gmail.com
     "CLAUDE_CODE_OAUTH_TOKEN_2",  # kaiser198719871987@gmail.com
     "CLAUDE_CODE_OAUTH_TOKEN_3",  # sianoantonello@gmail.com
-    "CLAUDE_CODE_OAUTH_TOKEN_4",  # fourth automation account
+    "CLAUDE_CODE_OAUTH_TOKEN_4",  # applevisionpro1987@gmail.com (4th MAX x20)
+    "CLAUDE_CODE_OAUTH_TOKEN_5",  # zero@balizero.com (Team premium seat — weekly-capped, last-resort)
 ]
 
 # Rate limit detection patterns in stderr/stdout

--- a/apps/mata-garuda/scripts/run_ai_digest.py
+++ b/apps/mata-garuda/scripts/run_ai_digest.py
@@ -158,6 +158,7 @@ def call_claude_synthesis(prompt: str) -> str:
         "CLAUDE_CODE_OAUTH_TOKEN_2",
         "CLAUDE_CODE_OAUTH_TOKEN_3",
         "CLAUDE_CODE_OAUTH_TOKEN_4",
+        "CLAUDE_CODE_OAUTH_TOKEN_5",
     ]
 
     for var in token_vars:

--- a/infra/launchagents/wrappers/cron-agent.sh
+++ b/infra/launchagents/wrappers/cron-agent.sh
@@ -211,7 +211,7 @@ leaving no output (W89 class-audit, regulatory-watcher incident 2026-07-05)."
     # 4-token OAuth fallback chain
     local tokens=()
     local labels=()
-    for i in 1 2 3 4; do
+    for i in 1 2 3 4 5; do
         local var_name="CLAUDE_CODE_OAUTH_TOKEN_${i}"
         local tok="${!var_name:-}"
         if [[ -n "$tok" ]]; then

--- a/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
+++ b/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
@@ -50,7 +50,7 @@ set +a
 # MAX-4 → expose the un-suffixed CLAUDE_CODE_OAUTH_TOKEN that the `claude` CLI reads
 # (the _1/_2/_3/_4 suffix is a client convention; the bare CLI ignores it).
 if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
-  export CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN_1:-${CLAUDE_CODE_OAUTH_TOKEN_2:-${CLAUDE_CODE_OAUTH_TOKEN_3:-${CLAUDE_CODE_OAUTH_TOKEN_4:-}}}}"
+  export CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN_1:-${CLAUDE_CODE_OAUTH_TOKEN_2:-${CLAUDE_CODE_OAUTH_TOKEN_3:-${CLAUDE_CODE_OAUTH_TOKEN_4:-${CLAUDE_CODE_OAUTH_TOKEN_5:-}}}}}"
 fi
 
 

--- a/scripts/ai-dispatch.sh
+++ b/scripts/ai-dispatch.sh
@@ -431,7 +431,7 @@ run_claude() {
     check_safety "$prompt"
 
     # Multi-account fallback: try each CLAUDE_CODE_OAUTH_TOKEN_N, then keychain
-    local token_vars=("CLAUDE_CODE_OAUTH_TOKEN_1" "CLAUDE_CODE_OAUTH_TOKEN_2" "CLAUDE_CODE_OAUTH_TOKEN_3" "CLAUDE_CODE_OAUTH_TOKEN_4")
+    local token_vars=("CLAUDE_CODE_OAUTH_TOKEN_1" "CLAUDE_CODE_OAUTH_TOKEN_2" "CLAUDE_CODE_OAUTH_TOKEN_3" "CLAUDE_CODE_OAUTH_TOKEN_4" "CLAUDE_CODE_OAUTH_TOKEN_5")
     local tried=0
 
     for tv in "${token_vars[@]}" "keychain"; do

--- a/scripts/dlq_autopilot.py
+++ b/scripts/dlq_autopilot.py
@@ -290,7 +290,7 @@ _EXHAUSTED_TOKENS: dict[str, str] = {}  # label → reason (per-process latch)
 def _load_token_chain() -> list[tuple[str, str]]:
     """Load ordered list of (label, oauth_token) to try."""
     chain: list[tuple[str, str]] = []
-    for i in (1, 2, 3, 4):
+    for i in (1, 2, 3, 4, 5):
         tok = os.environ.get(f"CLAUDE_CODE_OAUTH_TOKEN_{i}", "").strip()
         if tok:
             chain.append((f"token_{i}", tok))

--- a/scripts/tests/test_claude_oauth_slot4_coverage.py
+++ b/scripts/tests/test_claude_oauth_slot4_coverage.py
@@ -1,4 +1,10 @@
-"""Regression coverage for the fourth Claude OAuth subscription slot."""
+"""Regression coverage for the Claude OAuth subscription slots.
+
+Consumers cascade across the four MAX x20 seats (slots 1-4) and then the
+zero@balizero.com Team premium seat (slot 5, weekly-capped, last-resort).
+Each sentinel asserts the consumer reaches the NEW frontier slot (5), which
+implies the earlier slots are present too.
+"""
 
 from pathlib import Path
 
@@ -7,49 +13,49 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-SLOT4_CONSUMERS = (
+SLOT5_CONSUMERS = (
     (
         "infra/launchagents/wrappers/claude-cascade.sh",
-        "claude-acct4:tier2c-claude-acct4",
+        "claude-zero-team:tier2d-claude-zero-team",
     ),
-    ("infra/launchagents/wrappers/cron-agent.sh", "for i in 1 2 3 4; do"),
+    ("infra/launchagents/wrappers/cron-agent.sh", "for i in 1 2 3 4 5; do"),
     (
         "infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh",
-        "${CLAUDE_CODE_OAUTH_TOKEN_4:-}",
+        "${CLAUDE_CODE_OAUTH_TOKEN_5:-}",
     ),
-    ("scripts/ai-dispatch.sh", '"CLAUDE_CODE_OAUTH_TOKEN_4"'),
-    ("scripts/dlq_autopilot.py", "for i in (1, 2, 3, 4):"),
-    ("scripts/wr2_html_renderer/claude_vision.py", '"CLAUDE_CODE_OAUTH_TOKEN_4"'),
-    ("scripts/zantara-gateway/claude_client.py", "for i in (1, 2, 3, 4):"),
-    ("apps/backend-rag/scripts/auto_verifier.py", "for i in (1, 2, 3, 4):"),
-    ("apps/backend-rag/scripts/verified_generator.py", "for i in (1, 2, 3, 4):"),
-    ("apps/bali-intel-scraper/scripts/bz_image_style.py", "for i in (1, 2, 3, 4):"),
-    ("apps/evaluator/nlm_deep_research/t4_monitor.py", '"CLAUDE_CODE_OAUTH_TOKEN_4"'),
+    ("scripts/ai-dispatch.sh", '"CLAUDE_CODE_OAUTH_TOKEN_5"'),
+    ("scripts/dlq_autopilot.py", "for i in (1, 2, 3, 4, 5):"),
+    ("scripts/wr2_html_renderer/claude_vision.py", '"CLAUDE_CODE_OAUTH_TOKEN_5"'),
+    ("scripts/zantara-gateway/claude_client.py", "for i in (1, 2, 3, 4, 5):"),
+    ("apps/backend-rag/scripts/auto_verifier.py", "for i in (1, 2, 3, 4, 5):"),
+    ("apps/backend-rag/scripts/verified_generator.py", "for i in (1, 2, 3, 4, 5):"),
+    ("apps/bali-intel-scraper/scripts/bz_image_style.py", "for i in (1, 2, 3, 4, 5):"),
+    ("apps/evaluator/nlm_deep_research/t4_monitor.py", '"CLAUDE_CODE_OAUTH_TOKEN_5"'),
     (
         "apps/mata-garuda/mata_garuda/agents/daily_briefing_agent.py",
-        '"CLAUDE_CODE_OAUTH_TOKEN_4"',
+        '"CLAUDE_CODE_OAUTH_TOKEN_5"',
     ),
     (
         "apps/mata-garuda/mata_garuda/agents/weekly_digest_agent.py",
-        '"CLAUDE_CODE_OAUTH_TOKEN_4"',
+        '"CLAUDE_CODE_OAUTH_TOKEN_5"',
     ),
     (
         "apps/mata-garuda/mata_garuda/runtime/cli_runtime.py",
-        '"CLAUDE_CODE_OAUTH_TOKEN_4"',
+        '"CLAUDE_CODE_OAUTH_TOKEN_5"',
     ),
-    ("apps/mata-garuda/scripts/run_ai_digest.py", '"CLAUDE_CODE_OAUTH_TOKEN_4"'),
+    ("apps/mata-garuda/scripts/run_ai_digest.py", '"CLAUDE_CODE_OAUTH_TOKEN_5"'),
 )
 
 
-@pytest.mark.parametrize(("relative_path", "slot4_sentinel"), SLOT4_CONSUMERS)
-def test_every_automation_consumer_reaches_slot4(
+@pytest.mark.parametrize(("relative_path", "slot5_sentinel"), SLOT5_CONSUMERS)
+def test_every_automation_consumer_reaches_slot5(
     relative_path: str,
-    slot4_sentinel: str,
+    slot5_sentinel: str,
 ) -> None:
     source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
 
-    assert slot4_sentinel in source, (
-        f"{relative_path} no longer reaches CLAUDE_CODE_OAUTH_TOKEN_4"
+    assert slot5_sentinel in source, (
+        f"{relative_path} no longer reaches CLAUDE_CODE_OAUTH_TOKEN_5"
     )
 
 

--- a/scripts/wr2_html_renderer/claude_vision.py
+++ b/scripts/wr2_html_renderer/claude_vision.py
@@ -211,7 +211,7 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int | No
     # any interactive config login. (scar #1 HOME-fork-adjacent: the slot→bare
     # mapping lived only in a shell wrapper, not in the code that needs it.)
     if not env.get("CLAUDE_CODE_OAUTH_TOKEN"):
-        for _slot in ("CLAUDE_CODE_OAUTH_TOKEN_1", "CLAUDE_CODE_OAUTH_TOKEN_2", "CLAUDE_CODE_OAUTH_TOKEN_3", "CLAUDE_CODE_OAUTH_TOKEN_4"):
+        for _slot in ("CLAUDE_CODE_OAUTH_TOKEN_1", "CLAUDE_CODE_OAUTH_TOKEN_2", "CLAUDE_CODE_OAUTH_TOKEN_3", "CLAUDE_CODE_OAUTH_TOKEN_4", "CLAUDE_CODE_OAUTH_TOKEN_5"):
             _val = env.get(_slot)
             if _val:
                 env["CLAUDE_CODE_OAUTH_TOKEN"] = _val

--- a/scripts/zantara-gateway/claude_client.py
+++ b/scripts/zantara-gateway/claude_client.py
@@ -41,7 +41,7 @@ _sdk_import_warned = False
 def _token_chain() -> list[tuple[str, str]]:
     """Build ordered list of (label, token_or_empty) for fallback."""
     chain: list[tuple[str, str]] = []
-    for i in (1, 2, 3, 4):
+    for i in (1, 2, 3, 4, 5):
         tok = os.environ.get(f"CLAUDE_CODE_OAUTH_TOKEN_{i}", "").strip()
         if tok:
             chain.append((f"token_{i}", tok))


### PR DESCRIPTION
## What
Follow-up to #3014, correcting the OAuth cascade ordering per Zero's ruling (2026-07-23).

All **four** MAX x20 seats occupy slots 1-4 (rolling 5h, no weekly cap); the `zero@balizero.com` **Team premium** seat is **slot 5** — last-resort overflow only, because it is weekly-capped and must not be reached before the MAX seats are exhausted (protects interactive premium quota).

## Change
- Every automation consumer extended `1/2/3/4 → 1/2/3/4/5` (loops, lists, nested defaults): dlq_autopilot, zantara-gateway/claude_client, auto_verifier, verified_generator, bz_image_style, wr2_html_renderer/claude_vision, t4_monitor, mata-garuda {daily_briefing, weekly_digest, cli_runtime, run_ai_digest}, ai-dispatch.sh, cron-agent.sh, wr2-ig-metrics-analyst-run.sh.
- `cli_runtime.py`: slot 4 = applevisionpro1987@ (4th MAX), slot 5 = zero@ Team.
- Slot-coverage regression test updated to assert the slot-5 frontier; claude-cascade.sh tier-order test kept (zero-team last).

## Excluded (unchanged)
Backend RAG prod request path `backend/llm/claude_oauth_client.py` — weekly-capped premium seat stays out of the high-volume hot path (Zero's decision).

## Secret mapping (out-of-band, all 3 machines, verified)
`~/.nuzantara-secrets.env`: `_1/_2/_3` = 3 existing MAX, `_4` = applevision (4th MAX), `_5` = Team — all `export`, cross-machine hash-consistent, clean-env prove-live reaches token_1..5.

## Tests
slot-coverage 16/16 · mata-garuda test_meta_agent 49/49 · zantara-gateway test_claude_client 18/18 · py_compile + bash -n green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)