### PR TITLE
fix(wr3): rotate Claude OAuth automation seats

### DIFF
--- a/scripts/tests/test_wr3_dispatch_v2_oauth_fleet.py
+++ b/scripts/tests/test_wr3_dispatch_v2_oauth_fleet.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import subprocess
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -34,6 +37,10 @@ _PROVIDER_KEYS = {
     "CLOUD_ML_REGION",
     "CLAUDE_CODE_USE_FOUNDRY",
     "FOUNDRY_API_KEY",
+    "OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GEMINI_API_KEY",
 }
 
 
@@ -172,31 +179,89 @@ def test_token_chain_is_deduplicated_and_keychain_is_last(
     ]
 
 
+def _pid_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    status = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(pid)],
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return bool(status) and not status.startswith("Z")
+
+
 @pytest.mark.asyncio
-async def test_timeout_kills_reaps_and_retries_next_seat(
+async def test_real_process_tree_timeout_kills_descendant_and_empty_rotates(
     clean_auth_env: None,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "timeout-seat")
-    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "healthy-seat")
-    hanging = _FakeProcess(hangs=True)
-    outcomes = [hanging, _FakeProcess(stdout=_success())]
-    seen_envs: list[dict[str, str]] = []
-    _install_factory(monkeypatch, outcomes, seen_envs)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "empty-seat")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_3", "healthy-seat")
+    child_pid_path = tmp_path / "descendant.pid"
+    monkeypatch.setenv("WR3_TEST_DESCENDANT_PID", str(child_pid_path))
+    claude = tmp_path / "claude"
+    claude.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
 
+token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+if token == "timeout-seat":
+    child_code = (
+        "import os,signal,time;"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+        "time.sleep(30)"
+    )
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    child = subprocess.Popen(
+        [sys.executable, "-c", child_code],
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        env=os.environ,
+    )
+    open(os.environ["WR3_TEST_DESCENDANT_PID"], "w").write(str(child.pid))
+    time.sleep(30)
+elif token == "empty-seat":
+    print(json.dumps({"type": "result", "is_error": False, "result": "  "}))
+else:
+    print(json.dumps({
+        "type": "result",
+        "is_error": False,
+        "total_cost_usd": 0.01,
+        "result": "real-tree-success",
+    }))
+""",
+        encoding="utf-8",
+    )
+    claude.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setattr(dispatch, "_agent_system_prompt", lambda _: "safe system")
+
+    started = time.monotonic()
     result = await dispatch.dispatch_claude_print(
         _contract(),
         "safe prompt",
-        timeout_ms=120,
+        timeout_ms=3000,
     )
+    elapsed = time.monotonic() - started
 
-    assert result.raw_output == "ok"
-    assert hanging.killed
-    assert hanging.reaped
-    assert [env["CLAUDE_CODE_OAUTH_TOKEN"] for env in seen_envs] == [
-        "timeout-seat",
-        "healthy-seat",
-    ]
+    assert result.raw_output == "real-tree-success"
+    assert elapsed < 3.1
+    assert child_pid_path.exists()
+    child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 1.0
+    while _pid_is_running(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not _pid_is_running(child_pid)
 
 
 @pytest.mark.asyncio
@@ -270,6 +335,65 @@ async def test_core_only_uses_existing_cross_family_cascade(
 
     assert result is expected
     gemini.assert_awaited_once_with(contract, "safe prompt")
+
+
+@pytest.mark.asyncio
+async def test_real_gemini_child_receives_only_allowlisted_environment(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    for key in _PROVIDER_KEYS:
+        monkeypatch.setenv(key, f"secret-{key}")
+    monkeypatch.setenv("SIBLING_PROVIDER_SECRET", "sibling-secret")
+    for slot in range(1, 6):
+        monkeypatch.setenv(
+            f"CLAUDE_CODE_OAUTH_TOKEN_{slot}",
+            f"oauth-secret-{slot}",
+        )
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "legacy-secret")
+
+    agy = tmp_path / "agy"
+    agy.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+dump_path = pathlib.Path(sys.stdin.read().strip())
+dump_path.write_text(json.dumps(dict(os.environ)), encoding="utf-8")
+print("gemini-safe")
+""",
+        encoding="utf-8",
+    )
+    agy.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+    contract = _contract(core=True)
+    contracts = SimpleNamespace(for_agent=lambda _: contract)
+    monkeypatch.setattr(
+        dispatch,
+        "dispatch_claude_print",
+        AsyncMock(side_effect=dispatch.ClaudeFleetExhaustedError("fleet")),
+    )
+    dump_path = tmp_path / "gemini-env.json"
+
+    result = await dispatch.dispatch_agent_v2(
+        contracts,
+        "wr3-script-editor",
+        str(dump_path),
+    )
+
+    child_env = json.loads(dump_path.read_text(encoding="utf-8"))
+    assert result.raw_output.strip() == "gemini-safe"
+    assert child_env["HOME"] == os.environ["HOME"]
+    assert child_env["PATH"] == os.environ["PATH"]
+    assert not any(
+        key.startswith(("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_"))
+        for key in child_env
+    )
+    assert not (_PROVIDER_KEYS & child_env.keys())
+    assert "SIBLING_PROVIDER_SECRET" not in child_env
 
 
 @pytest.mark.asyncio

--- a/scripts/tests/test_wr3_dispatch_v2_oauth_fleet.py
+++ b/scripts/tests/test_wr3_dispatch_v2_oauth_fleet.py
@@ -206,39 +206,25 @@ async def test_real_process_tree_timeout_kills_descendant_and_empty_rotates(
     monkeypatch.setenv("WR3_TEST_DESCENDANT_PID", str(child_pid_path))
     claude = tmp_path / "claude"
     claude.write_text(
-        """#!/usr/bin/env python3
-import json
-import os
-import signal
-import subprocess
-import sys
-import time
-
-token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
-if token == "timeout-seat":
-    child_code = (
-        "import os,signal,time;"
-        "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
-        "time.sleep(30)"
-    )
-    signal.signal(signal.SIGTERM, signal.SIG_IGN)
-    child = subprocess.Popen(
-        [sys.executable, "-c", child_code],
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-        env=os.environ,
-    )
-    open(os.environ["WR3_TEST_DESCENDANT_PID"], "w").write(str(child.pid))
-    time.sleep(30)
-elif token == "empty-seat":
-    print(json.dumps({"type": "result", "is_error": False, "result": "  "}))
-else:
-    print(json.dumps({
-        "type": "result",
-        "is_error": False,
-        "total_cost_usd": 0.01,
-        "result": "real-tree-success",
-    }))
+        """#!/bin/sh
+case "${CLAUDE_CODE_OAUTH_TOKEN:-}" in
+    timeout-seat)
+        trap '' TERM
+        (
+            trap '' TERM
+            sleep 30
+        ) &
+        child_pid=$!
+        printf '%s' "$child_pid" > "$WR3_TEST_DESCENDANT_PID"
+        wait
+        ;;
+    empty-seat)
+        printf '%s\n' '{"type":"result","is_error":false,"result":"  "}'
+        ;;
+    *)
+        printf '%s\n' '{"type":"result","is_error":false,"total_cost_usd":0.01,"result":"real-tree-success"}'
+        ;;
+esac
 """,
         encoding="utf-8",
     )
@@ -250,7 +236,7 @@ else:
     result = await dispatch.dispatch_claude_print(
         _contract(),
         "safe prompt",
-        timeout_ms=3000,
+        timeout_ms=8000,
     )
     elapsed = time.monotonic() - started
 

--- a/scripts/tests/test_wr3_dispatch_v2_oauth_fleet.py
+++ b/scripts/tests/test_wr3_dispatch_v2_oauth_fleet.py
@@ -1,0 +1,297 @@
+"""Hermetic OAuth-fleet regressions for the WR3 v2 dispatcher."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import wr3_dispatch_v2 as dispatch  # noqa: E402
+
+
+_PROVIDER_KEYS = {
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_BEDROCK_ANTHROPIC_KEY",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_PROJECT",
+    "CLOUD_ML_REGION",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "FOUNDRY_API_KEY",
+}
+
+
+@pytest.fixture
+def clean_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for slot in range(1, 6):
+        monkeypatch.delenv(f"CLAUDE_CODE_OAUTH_TOKEN_{slot}", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    for key in _PROVIDER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _contract(*, gate: bool = False, core: bool = True) -> Any:
+    return SimpleNamespace(
+        name="wr3-script-editor",
+        model="sonnet",
+        cost=SimpleNamespace(ceiling_usd=0.30),
+        cost_class="core",
+        is_gate=gate,
+        is_core=core,
+    )
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        hangs: bool = False,
+    ) -> None:
+        self._planned_returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._hangs = hangs
+        self.returncode: int | None = None
+        self.killed = False
+        self.reaped = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._hangs and not self.killed:
+            await asyncio.sleep(60)
+        self.returncode = self._planned_returncode
+        return self._stdout.encode(), self._stderr.encode()
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        self.reaped = True
+        return self.returncode or 0
+
+
+def _success(result: str = "ok") -> str:
+    return json.dumps(
+        {
+            "type": "result",
+            "is_error": False,
+            "total_cost_usd": 0.01,
+            "result": result,
+        }
+    )
+
+
+def _install_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    outcomes: list[_FakeProcess],
+    seen_envs: list[dict[str, str]],
+) -> None:
+    async def _create(*args: Any, **kwargs: Any) -> _FakeProcess:
+        seen_envs.append(kwargs["env"])
+        return outcomes.pop(0)
+
+    monkeypatch.setattr(dispatch.asyncio, "create_subprocess_exec", _create)
+    monkeypatch.setattr(dispatch.shutil, "which", lambda _: "/fake/claude")
+    monkeypatch.setattr(dispatch, "_agent_system_prompt", lambda _: "safe system")
+
+
+@pytest.mark.asyncio
+async def test_slot5_team_succeeds_after_quota_auth_empty_and_429(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tokens = [f"sentinel-secret-{slot}" for slot in range(1, 6)]
+    for slot, token in enumerate(tokens, start=1):
+        monkeypatch.setenv(f"CLAUDE_CODE_OAUTH_TOKEN_{slot}", token)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", tokens[0])
+    for key in _PROVIDER_KEYS:
+        monkeypatch.setenv(key, f"provider-secret-{key}")
+
+    outcomes = [
+        _FakeProcess(stdout="You've hit your weekly limit"),
+        _FakeProcess(stdout="authentication failed: refresh_token revoked"),
+        _FakeProcess(stdout=" \n"),
+        _FakeProcess(returncode=1, stderr="429 rate limit"),
+        _FakeProcess(stdout=_success("slot-five-success")),
+    ]
+    seen_envs: list[dict[str, str]] = []
+    _install_factory(monkeypatch, outcomes, seen_envs)
+
+    with caplog.at_level(logging.INFO, logger=dispatch.__name__):
+        result = await dispatch.dispatch_claude_print(
+            _contract(),
+            "safe prompt",
+            timeout_ms=1000,
+        )
+
+    assert result.raw_output == "slot-five-success"
+    assert [env["CLAUDE_CODE_OAUTH_TOKEN"] for env in seen_envs] == tokens
+    for env in seen_envs:
+        assert not (_PROVIDER_KEYS & env.keys())
+        assert not any(key.startswith("CLAUDE_CODE_OAUTH_TOKEN_") for key in env)
+    logs = caplog.text
+    assert "slot5-team" in logs
+    assert all(token not in logs for token in tokens)
+    assert all(f"provider-secret-{key}" not in logs for key in _PROVIDER_KEYS)
+
+
+def test_token_chain_is_deduplicated_and_keychain_is_last(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "same")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "same")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_5", "team")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "legacy")
+
+    assert dispatch._collect_claude_seats() == [
+        ("slot1", "same"),
+        ("slot5-team", "team"),
+        ("legacy", "legacy"),
+        ("keychain", ""),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_reaps_and_retries_next_seat(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "timeout-seat")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "healthy-seat")
+    hanging = _FakeProcess(hangs=True)
+    outcomes = [hanging, _FakeProcess(stdout=_success())]
+    seen_envs: list[dict[str, str]] = []
+    _install_factory(monkeypatch, outcomes, seen_envs)
+
+    result = await dispatch.dispatch_claude_print(
+        _contract(),
+        "safe prompt",
+        timeout_ms=120,
+    )
+
+    assert result.raw_output == "ok"
+    assert hanging.killed
+    assert hanging.reaped
+    assert [env["CLAUDE_CODE_OAUTH_TOKEN"] for env in seen_envs] == [
+        "timeout-seat",
+        "healthy-seat",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unknown_failure_diagnostic_redacts_oauth_secret(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "sentinel-super-secret"
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", secret)
+    outcomes = [
+        _FakeProcess(
+            returncode=2,
+            stderr=f"unexpected failure bearer {secret}",
+        )
+    ]
+    seen_envs: list[dict[str, str]] = []
+    _install_factory(monkeypatch, outcomes, seen_envs)
+
+    with pytest.raises(dispatch.WR3DispatchError) as exc_info:
+        await dispatch.dispatch_claude_print(
+            _contract(),
+            "safe prompt",
+            timeout_ms=100,
+        )
+
+    assert secret not in str(exc_info.value)
+    assert "slot1" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_unknown_json_error_result_is_not_accepted_as_success(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "error-seat")
+    error_envelope = json.dumps(
+        {"type": "result", "is_error": True, "result": "unclassified runtime failure"}
+    )
+    outcomes = [_FakeProcess(stdout=error_envelope)]
+    seen_envs: list[dict[str, str]] = []
+    _install_factory(monkeypatch, outcomes, seen_envs)
+
+    with pytest.raises(dispatch.WR3DispatchError, match="returned an error result"):
+        await dispatch.dispatch_claude_print(
+            _contract(),
+            "safe prompt",
+            timeout_ms=100,
+        )
+
+
+@pytest.mark.asyncio
+async def test_core_only_uses_existing_cross_family_cascade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _contract(core=True)
+    contracts = SimpleNamespace(for_agent=lambda _: contract)
+    expected = SimpleNamespace(raw_output="gemini-safe")
+    monkeypatch.setattr(
+        dispatch,
+        "dispatch_claude_print",
+        AsyncMock(side_effect=dispatch.ClaudeFleetExhaustedError("fleet")),
+    )
+    gemini = AsyncMock(return_value=expected)
+    monkeypatch.setattr(dispatch, "_dispatch_gemini_cli", gemini)
+
+    result = await dispatch.dispatch_agent_v2(
+        contracts,
+        "wr3-script-editor",
+        "safe prompt",
+    )
+
+    assert result is expected
+    gemini.assert_awaited_once_with(contract, "safe prompt")
+
+
+@pytest.mark.asyncio
+async def test_gate_fails_closed_without_cross_family_substitution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = _contract(gate=True, core=True)
+    contracts = SimpleNamespace(for_agent=lambda _: contract)
+    monkeypatch.setattr(
+        dispatch,
+        "dispatch_claude_print",
+        AsyncMock(side_effect=dispatch.ClaudeFleetExhaustedError("fleet")),
+    )
+    gemini = AsyncMock()
+    monkeypatch.setattr(dispatch, "_dispatch_gemini_cli", gemini)
+    monkeypatch.setattr(dispatch, "telegram_p0", AsyncMock())
+
+    with pytest.raises(dispatch.HardHaltException):
+        await dispatch.dispatch_agent_v2(
+            contracts,
+            "wr3-pre-render-gatekeeper",
+            "safe prompt",
+        )
+
+    gemini.assert_not_awaited()

--- a/scripts/tests/test_wr3_reflexion_oauth_fleet.py
+++ b/scripts/tests/test_wr3_reflexion_oauth_fleet.py
@@ -1,0 +1,220 @@
+"""Hermetic OAuth-fleet regressions for WR3 Reflexion synthesis."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import wr3_reflexion_synthesis as reflexion  # noqa: E402
+
+
+_PROVIDER_KEYS = {
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_BEDROCK_ANTHROPIC_KEY",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_PROJECT",
+    "CLOUD_ML_REGION",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "FOUNDRY_API_KEY",
+}
+
+
+@pytest.fixture
+def clean_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for slot in range(1, 6):
+        monkeypatch.delenv(f"CLAUDE_CODE_OAUTH_TOKEN_{slot}", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    for key in _PROVIDER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _synthesis(note: str = "slot-five-success") -> str:
+    return json.dumps({"week": "2026-W30", "lessons": [], "synthesis_notes": note})
+
+
+def test_slot5_team_succeeds_after_quota_auth_empty_and_429(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    tokens = [f"reflexion-secret-{slot}" for slot in range(1, 6)]
+    for slot, token in enumerate(tokens, start=1):
+        monkeypatch.setenv(f"CLAUDE_CODE_OAUTH_TOKEN_{slot}", token)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", tokens[0])
+    for key in _PROVIDER_KEYS:
+        monkeypatch.setenv(key, f"provider-secret-{key}")
+    monkeypatch.setattr(reflexion, "LLM_TIMEOUT_S", 10)
+
+    outcomes = iter(
+        [
+            (0, "weekly usage limit reached", "", False),
+            (0, "authentication failed: refresh_token revoked", "", False),
+            (0, " \n", "", False),
+            (1, "", "429 rate limit", False),
+            (0, _synthesis(), "", False),
+        ]
+    )
+    seen_envs: list[dict[str, str]] = []
+
+    def _invoke(
+        cmd: list[str],
+        prompt: str,
+        timeout_s: float,
+        env: dict[str, str],
+    ) -> tuple[int, str, str, bool]:
+        seen_envs.append(env)
+        return next(outcomes)
+
+    monkeypatch.setattr(reflexion, "_invoke_process", _invoke)
+
+    output = reflexion._run_claude_fleet("safe prompt")
+
+    assert json.loads(output or "")["synthesis_notes"] == "slot-five-success"
+    assert [env["CLAUDE_CODE_OAUTH_TOKEN"] for env in seen_envs] == tokens
+    for env in seen_envs:
+        assert not (_PROVIDER_KEYS & env.keys())
+        assert not any(key.startswith("CLAUDE_CODE_OAUTH_TOKEN_") for key in env)
+    stderr = capsys.readouterr().err
+    assert "slot5-team" in stderr
+    assert all(token not in stderr for token in tokens)
+    assert all(f"provider-secret-{key}" not in stderr for key in _PROVIDER_KEYS)
+
+
+def test_token_chain_is_deduplicated_and_keychain_is_last(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "same")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "same")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_5", "team")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "legacy")
+
+    assert reflexion._collect_claude_seats() == [
+        ("slot1", "same"),
+        ("slot5-team", "team"),
+        ("legacy", "legacy"),
+        ("keychain", ""),
+    ]
+
+
+def test_invoke_process_timeout_kills_and_reaps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakePopen:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.returncode: int | None = None
+            self.killed = False
+            self.communicate_calls = 0
+
+        def communicate(
+            self,
+            input: str | None = None,
+            timeout: float | None = None,
+        ) -> tuple[str, str]:
+            self.communicate_calls += 1
+            if self.communicate_calls == 1:
+                raise subprocess.TimeoutExpired(cmd="claude", timeout=timeout or 0)
+            return "", ""
+
+        def kill(self) -> None:
+            self.killed = True
+            self.returncode = -9
+
+    fake = _FakePopen()
+    monkeypatch.setattr(reflexion.subprocess, "Popen", lambda *a, **k: fake)
+
+    returncode, stdout, stderr, timed_out = reflexion._invoke_process(
+        ["claude"],
+        "safe prompt",
+        0.01,
+        {},
+    )
+
+    assert timed_out
+    assert returncode == -9
+    assert stdout == ""
+    assert stderr == ""
+    assert fake.killed
+    assert fake.communicate_calls == 2
+
+
+def test_unknown_diagnostic_never_logs_oauth_secret(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret = "reflexion-super-secret"
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", secret)
+
+    def _invoke(
+        cmd: list[str],
+        prompt: str,
+        timeout_s: float,
+        env: dict[str, str],
+    ) -> tuple[int, str, str, bool]:
+        return 2, "", f"unexpected failure bearer {secret}", False
+
+    monkeypatch.setattr(reflexion, "_invoke_process", _invoke)
+
+    assert reflexion._run_claude_fleet("safe prompt") is None
+    stderr = capsys.readouterr().err
+    assert secret not in stderr
+    assert "slot1" in stderr
+
+
+def test_exit_zero_invalid_schema_rotates_to_next_seat(
+    clean_auth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "invalid-seat")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "valid-seat")
+    outcomes = iter(
+        [
+            (0, '{"type":"result","is_error":true}', "", False),
+            (0, _synthesis(), "", False),
+        ]
+    )
+    monkeypatch.setattr(
+        reflexion,
+        "_invoke_process",
+        lambda cmd, prompt, timeout_s, env: next(outcomes),
+    )
+
+    output = reflexion._run_claude_fleet("safe prompt")
+
+    assert json.loads(output or "")["synthesis_notes"] == "slot-five-success"
+
+
+def test_portable_reflexion_contract_keeps_gemini_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def _run(tier: str, prompt: str) -> str | None:
+        calls.append(tier)
+        if tier == "claude":
+            return None
+        return _synthesis("gemini-portable")
+
+    monkeypatch.setattr(reflexion, "_run_tier", _run)
+
+    result = reflexion.call_llm_synthesis("safe prompt")
+
+    assert result is not None
+    assert result["synthesis_notes"] == "gemini-portable"
+    assert calls == ["claude", "gemini"]

--- a/scripts/tests/test_wr3_reflexion_oauth_fleet.py
+++ b/scripts/tests/test_wr3_reflexion_oauth_fleet.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+import time
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -31,6 +32,10 @@ _PROVIDER_KEYS = {
     "CLOUD_ML_REGION",
     "CLAUDE_CODE_USE_FOUNDRY",
     "FOUNDRY_API_KEY",
+    "OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GEMINI_API_KEY",
 }
 
 
@@ -112,45 +117,72 @@ def test_token_chain_is_deduplicated_and_keychain_is_last(
     ]
 
 
-def test_invoke_process_timeout_kills_and_reaps(
-    monkeypatch: pytest.MonkeyPatch,
+def _pid_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    status = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(pid)],
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return bool(status) and not status.startswith("Z")
+
+
+def test_real_process_tree_timeout_kills_descendant_and_respects_deadline(
+    tmp_path: Path,
 ) -> None:
-    class _FakePopen:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            self.returncode: int | None = None
-            self.killed = False
-            self.communicate_calls = 0
+    child_pid_path = tmp_path / "descendant.pid"
+    runner = tmp_path / "tree_runner.py"
+    runner.write_text(
+        """import os
+import signal
+import subprocess
+import sys
+import time
 
-        def communicate(
-            self,
-            input: str | None = None,
-            timeout: float | None = None,
-        ) -> tuple[str, str]:
-            self.communicate_calls += 1
-            if self.communicate_calls == 1:
-                raise subprocess.TimeoutExpired(cmd="claude", timeout=timeout or 0)
-            return "", ""
-
-        def kill(self) -> None:
-            self.killed = True
-            self.returncode = -9
-
-    fake = _FakePopen()
-    monkeypatch.setattr(reflexion.subprocess, "Popen", lambda *a, **k: fake)
-
-    returncode, stdout, stderr, timed_out = reflexion._invoke_process(
-        ["claude"],
-        "safe prompt",
-        0.01,
-        {},
+child_code = (
+    "import os,signal,time;"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+    "open(os.environ['WR3_TEST_DESCENDANT_PID'],'w').write(str(os.getpid()));"
+    "time.sleep(30)"
+)
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+subprocess.Popen(
+    [sys.executable, "-c", child_code],
+    stdout=sys.stdout,
+    stderr=sys.stderr,
+    env=os.environ,
+)
+time.sleep(30)
+""",
+        encoding="utf-8",
     )
+    env = dict(os.environ)
+    env["WR3_TEST_DESCENDANT_PID"] = str(child_pid_path)
+
+    started = time.monotonic()
+    returncode, stdout, stderr, timed_out = reflexion._invoke_process(
+        [sys.executable, str(runner)],
+        "safe prompt",
+        1.0,
+        env,
+    )
+    elapsed = time.monotonic() - started
 
     assert timed_out
     assert returncode == -9
     assert stdout == ""
     assert stderr == ""
-    assert fake.killed
-    assert fake.communicate_calls == 2
+    assert elapsed < 1.1
+    assert child_pid_path.exists()
+    child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 1.0
+    while _pid_is_running(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not _pid_is_running(child_pid)
 
 
 def test_unknown_diagnostic_never_logs_oauth_secret(
@@ -198,6 +230,24 @@ def test_exit_zero_invalid_schema_rotates_to_next_seat(
     output = reflexion._run_claude_fleet("safe prompt")
 
     assert json.loads(output or "")["synthesis_notes"] == "slot-five-success"
+
+
+def test_empty_transport_retries_but_honest_zero_lessons_is_valid() -> None:
+    honest_empty = _synthesis("no reliable lesson this week")
+
+    assert reflexion._retry_reason(
+        stdout="  ",
+        stderr="",
+        returncode=0,
+        valid_success=False,
+    ) == "empty-output"
+    assert reflexion._valid_synthesis_json(honest_empty)
+    assert reflexion._retry_reason(
+        stdout=honest_empty,
+        stderr="",
+        returncode=0,
+        valid_success=True,
+    ) is None
 
 
 def test_portable_reflexion_contract_keeps_gemini_fallback(

--- a/scripts/wr3_dispatch_v2.py
+++ b/scripts/wr3_dispatch_v2.py
@@ -18,7 +18,8 @@ Empirical cost on realistic brief-interpreter workload: $0.09 (~50× less
 than v1). Symbiosis Law 1 compliant (CLI subprocess wrapper) and Law 7
 compliant (real ceilings now match contract caps).
 
-Cascade Tier 2 (Gemini free OAuth) is shared with v1 — imported lazily.
+Cascade Tier 2 (Gemini free OAuth) runs locally with the same process-tree
+cleanup and credential isolation as the Claude fleet.
 """
 from __future__ import annotations
 

--- a/scripts/wr3_dispatch_v2.py
+++ b/scripts/wr3_dispatch_v2.py
@@ -23,10 +23,13 @@ Cascade Tier 2 (Gemini free OAuth) is shared with v1 — imported lazily.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import logging
 import os
+import re
 import shutil
-from dataclasses import dataclass
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -38,13 +41,13 @@ from wr3_dispatch_agent import (  # noqa: E402
     CascadeExhaustedError,
     DispatchResult,
     HardHaltException,
-    OSINTLeakError,
     WR3DispatchError,
     _dispatch_gemini_cli,
     telegram_p0,
 )
 from wr3_contracts import AgentContract, WR3Contracts
 
+logger = logging.getLogger(__name__)
 
 # Isolated cwd for `claude --print` subprocess. Empty dir → no CLAUDE.md
 # auto-discovery → minimal cached system prompt → minimal cost.
@@ -85,10 +88,119 @@ def _agent_system_prompt(slug: str) -> str:
     return _AGENT_PROMPT_CACHE[slug]
 
 
-# Symbiosis Law 1 hard rule: NEVER pass the paid per-token Anthropic key
-# to the claude subprocess. Built via string concat to avoid wr3_lint_cli_only
-# false-positive (the linter pattern-matches the literal name).
-_BANNED_KEY = "ANTHROPIC" + "_API_" + "KEY"
+# Symbiosis Law 1 hard rule: NEVER pass paid or alternate-provider credentials
+# to the Claude subprocess. The prefix is built without the banned literal so
+# wr3_lint_cli_only can keep flagging accidental reads of the paid key.
+_OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
+_PROVIDER_ENV_PREFIXES = (
+    "ANTHROPIC" + "_",
+    "AWS_",
+    "BEDROCK_",
+    "VERTEX_",
+    "FOUNDRY_",
+)
+_PROVIDER_ENV_NAMES = frozenset(
+    {
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "CLOUD_ML_REGION",
+    }
+)
+_QUOTA_RE = re.compile(
+    r"out of extra usage|usage limit|weekly limit|quota(?: exceeded)?|"
+    r"rate.?limit|too many requests|429|exhausted|hit your limit|"
+    r"capacity|overloaded|please try again later",
+    re.IGNORECASE,
+)
+_AUTH_RE = re.compile(
+    r"authentication (?:failed|required|expired)|auth required|login required|"
+    r"please (?:log in|login)|not logged in|not authenticated|"
+    r"invalid[_ ](?:grant|token)|token[_ ]revoked|refresh[_ ]token|"
+    r"unauthori[sz]ed|(?:error\D*)?401",
+    re.IGNORECASE,
+)
+_SECRET_DIAGNOSTIC_RE = re.compile(
+    r"(?i)\b(?:bearer|oauth[_ -]?token|access[_ -]?token)\b"
+    r"(\s*[:=]\s*|\s+)\S+"
+)
+
+
+class ClaudeFleetExhaustedError(WR3DispatchError):
+    """All configured Claude OAuth seats failed with retryable conditions."""
+
+
+def _collect_claude_seats(
+    source: Mapping[str, str] | None = None,
+) -> list[tuple[str, str]]:
+    """Return deduplicated OAuth seats in fleet order, then keychain."""
+    values = os.environ if source is None else source
+    seats: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for slot in range(1, 6):
+        token = values.get(f"{_OAUTH_TOKEN_ENV}_{slot}", "").strip()
+        if token and token not in seen:
+            label = "slot5-team" if slot == 5 else f"slot{slot}"
+            seats.append((label, token))
+            seen.add(token)
+    legacy = values.get(_OAUTH_TOKEN_ENV, "").strip()
+    if legacy and legacy not in seen:
+        seats.append(("legacy", legacy))
+    seats.append(("keychain", ""))
+    return seats
+
+
+def _is_provider_env(name: str) -> bool:
+    return name in _PROVIDER_ENV_NAMES or name.startswith(_PROVIDER_ENV_PREFIXES)
+
+
+def _build_claude_env(
+    token: str,
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build an OAuth-only child env with alternate providers removed."""
+    values = os.environ if source is None else source
+    env = {
+        key: value
+        for key, value in values.items()
+        if not _is_provider_env(key) and not key.startswith(_OAUTH_TOKEN_ENV)
+    }
+    if token:
+        env[_OAUTH_TOKEN_ENV] = token
+    return env
+
+
+def _sanitize_diagnostic(text: str, secrets: list[str]) -> str:
+    safe = text
+    for secret in secrets:
+        if secret:
+            safe = safe.replace(secret, "[redacted]")
+    safe = _SECRET_DIAGNOSTIC_RE.sub("credential=[redacted]", safe)
+    return " ".join(safe.split())[:300]
+
+
+def _retry_reason(
+    *,
+    stdout: str,
+    stderr: str,
+    returncode: int,
+    valid_success: bool,
+    effective_output: str,
+) -> str | None:
+    if valid_success:
+        return None
+    combined = f"{stdout}\n{stderr}"
+    if _QUOTA_RE.search(combined):
+        return "quota"
+    if _AUTH_RE.search(combined):
+        return "auth"
+    if returncode in (0, 143) and not effective_output.strip():
+        return "empty-output"
+    if not stdout.strip() and not stderr.strip():
+        return "empty-output"
+    return None
 
 
 async def dispatch_claude_print(
@@ -122,10 +234,6 @@ async def dispatch_claude_print(
 
     system_prompt = _agent_system_prompt(contract.name)
 
-    # Strip the paid per-token key (defense in depth — also stripped at
-    # supervisor invocation time, but child subprocess gets a clean env).
-    env = {k: v for k, v in os.environ.items() if k != _BANNED_KEY}
-
     args = [
         claude_bin,
         "--print",
@@ -138,59 +246,141 @@ async def dispatch_claude_print(
         prompt,
     ]
 
-    started = asyncio.get_event_loop().time()
-    proc = None
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *args,
-            cwd=str(_ISOLATED_CWD),
-            env=env,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    deadline = started + max(timeout_ms / 1000, 0.001)
+    seats = _collect_claude_seats()
+    secrets = [token for _, token in seats if token]
+    failures: list[str] = []
+
+    for index, (label, token) in enumerate(seats):
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            failures.append(f"{label}:deadline")
+            break
+        seats_left = len(seats) - index
+        seat_budget_s = max(0.001, remaining / seats_left)
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                cwd=str(_ISOLATED_CWD),
+                env=_build_claude_env(token),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            raise WR3DispatchError(
+                "`claude` CLI not on PATH. Install: https://claude.ai/code"
+            ) from exc
+
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=seat_budget_s,
+            )
+        except asyncio.TimeoutError:
+            if proc.returncode is None:
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            failures.append(f"{label}:timeout")
+            logger.warning(
+                "%s: Claude OAuth %s timed out; trying next seat",
+                contract.name,
+                label,
+            )
+            continue
+
+        stdout = stdout_bytes.decode("utf-8", "replace")
+        stderr = stderr_bytes.decode("utf-8", "replace")
+        returncode = proc.returncode or 0
+        data: dict[str, Any] | None = None
+        try:
+            parsed = json.loads(stdout)
+            if isinstance(parsed, dict):
+                data = parsed
+        except json.JSONDecodeError:
+            pass
+
+        result_text = data.get("result", "") if data is not None else ""
+        effective_output = result_text if isinstance(result_text, str) else ""
+        valid_success = (
+            returncode == 0
+            and data is not None
+            and data.get("is_error") is not True
+            and bool(effective_output.strip())
         )
-        stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(),
-            timeout=timeout_ms / 1000,
+
+        # Budget detection stays distinct from OAuth-seat exhaustion because
+        # WR3 routes cost caps according to gate/core/fallback contracts.
+        budget_scan = stderr if valid_success else f"{stdout}\n{stderr}"
+        budget_signals = (
+            "exceeded usd budget",
+            "max budget",
+            "max_budget",
+            "reached maximum budget",
+            "spending limit",
+            "spend_limit",
+            "out of credit",
+            "insufficient funds",
         )
-    except asyncio.TimeoutError as e:
-        if proc and proc.returncode is None:
-            proc.kill()
-        raise WR3DispatchError(
-            f"{contract.name}: claude --print timeout {timeout_ms}ms"
-        ) from e
+        if any(sig in budget_scan.lower() for sig in budget_signals):
+            raise BudgetExceededError(f"{contract.name}: budget cap ${ceiling} hit")
 
-    duration_ms = int((asyncio.get_event_loop().time() - started) * 1000)
-    stdout = stdout_bytes.decode("utf-8", "replace")
-    stderr = stderr_bytes.decode("utf-8", "replace")
+        reason = _retry_reason(
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+            valid_success=valid_success,
+            effective_output=effective_output,
+        )
+        if reason is not None:
+            failures.append(f"{label}:{reason}")
+            logger.warning(
+                "%s: Claude OAuth %s failed (%s); trying next seat",
+                contract.name,
+                label,
+                reason,
+            )
+            continue
 
-    # Budget exceeded detection — CLI prints "Error: Exceeded USD budget (X)".
-    combined = (stdout + " " + stderr).lower()
-    budget_signals = (
-        "exceeded usd budget", "max budget", "max_budget",
-        "reached maximum budget", "spending limit", "spend_limit",
-        "out of credit", "insufficient funds",
-    )
-    if any(sig in combined for sig in budget_signals):
-        raise BudgetExceededError(f"{contract.name}: budget cap ${ceiling} hit")
+        if returncode != 0:
+            diagnostic = _sanitize_diagnostic(stderr or stdout, secrets)
+            raise WR3DispatchError(
+                f"{contract.name}: Claude OAuth {label} exit {returncode}"
+                + (f" diagnostic={diagnostic}" if diagnostic else "")
+            )
+        if data is None:
+            diagnostic = _sanitize_diagnostic(stdout, secrets)
+            raise WR3DispatchError(
+                f"{contract.name}: Claude OAuth {label} returned non-JSON output"
+                + (f" diagnostic={diagnostic}" if diagnostic else "")
+            )
+        if data.get("is_error") is True:
+            diagnostic = _sanitize_diagnostic(effective_output or stderr, secrets)
+            raise WR3DispatchError(
+                f"{contract.name}: Claude OAuth {label} returned an error result"
+                + (f" diagnostic={diagnostic}" if diagnostic else "")
+            )
 
-    if proc.returncode != 0:
-        raise WR3DispatchError(
-            f"{contract.name}: claude exit {proc.returncode} stderr={stderr[:300]}"
+        duration_ms = int((loop.time() - started) * 1000)
+        logger.info(
+            "%s: Claude OAuth success via %s",
+            contract.name,
+            label,
+        )
+        return DispatchResult(
+            agent=contract.name,
+            cost_usd_estimated=data.get("total_cost_usd"),
+            duration_ms=duration_ms,
+            cascade_tier=1,
+            raw_output=effective_output,
         )
 
-    try:
-        data = json.loads(stdout)
-    except json.JSONDecodeError as e:
-        raise WR3DispatchError(
-            f"{contract.name}: claude returned non-JSON stdout={stdout[:300]}"
-        ) from e
-
-    return DispatchResult(
-        agent=contract.name,
-        cost_usd_estimated=data.get("total_cost_usd"),
-        duration_ms=duration_ms,
-        cascade_tier=1,
-        raw_output=data.get("result", ""),
+    summary = ", ".join(failures) or "no seats available"
+    raise ClaudeFleetExhaustedError(
+        f"{contract.name}: Claude OAuth fleet exhausted ({summary})"
     )
 
 
@@ -213,6 +403,28 @@ async def dispatch_agent_v2(
 
     try:
         return await dispatch_claude_print(contract, prompt, timeout_ms=timeout_ms)
+    except ClaudeFleetExhaustedError as e:
+        if contract.is_gate:
+            await telegram_p0(
+                f"{agent_name} exhausted the Claude OAuth fleet. "
+                f"Episode {episode_id} HALTED."
+            )
+            raise HardHaltException(str(e)) from e
+
+        if contract.is_core:
+            try:
+                return await _dispatch_gemini_cli(contract, prompt)
+            except CascadeExhaustedError:
+                await telegram_p0(
+                    f"{agent_name} OAuth fleet+cascade exhausted. "
+                    f"Episode {episode_id} FAIL."
+                )
+                raise
+
+        raise CascadeExhaustedError(
+            f"{agent_name} (non-core) Claude OAuth fleet exhausted — "
+            "no cross-family cascade for scheduled/fallback tier"
+        ) from e
     except BudgetExceededError as e:
         if contract.is_gate:
             await telegram_p0(

--- a/scripts/wr3_dispatch_v2.py
+++ b/scripts/wr3_dispatch_v2.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import re
+import signal
 import shutil
 from collections.abc import Mapping
 from pathlib import Path
@@ -42,7 +43,6 @@ from wr3_dispatch_agent import (  # noqa: E402
     DispatchResult,
     HardHaltException,
     WR3DispatchError,
-    _dispatch_gemini_cli,
     telegram_p0,
 )
 from wr3_contracts import AgentContract, WR3Contracts
@@ -98,6 +98,14 @@ _PROVIDER_ENV_PREFIXES = (
     "BEDROCK_",
     "VERTEX_",
     "FOUNDRY_",
+    "OPENAI_",
+    "DEEPSEEK_",
+    "OPENROUTER_",
+    "GEMINI_",
+    "TOGETHER_",
+    "GROQ_",
+    "MISTRAL_",
+    "COHERE_",
 )
 _PROVIDER_ENV_NAMES = frozenset(
     {
@@ -125,6 +133,33 @@ _AUTH_RE = re.compile(
 _SECRET_DIAGNOSTIC_RE = re.compile(
     r"(?i)\b(?:bearer|oauth[_ -]?token|access[_ -]?token)\b"
     r"(\s*[:=]\s*|\s+)\S+"
+)
+_PROCESS_TERM_GRACE_S = 0.25
+_PROCESS_KILL_REAP_S = 0.75
+_PROCESS_POLL_S = 0.01
+_GEMINI_ENV_ALLOWLIST = frozenset(
+    {
+        "HOME",
+        "PATH",
+        "TMPDIR",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TERM",
+        "SHELL",
+        "USER",
+        "LOGNAME",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "ALL_PROXY",
+    }
 )
 
 
@@ -172,6 +207,18 @@ def _build_claude_env(
     return env
 
 
+def _build_gemini_env(
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build a minimal OAuth-CLI environment without any provider credential."""
+    values = os.environ if source is None else source
+    return {
+        key: value
+        for key, value in values.items()
+        if key in _GEMINI_ENV_ALLOWLIST or key.startswith("LC_")
+    }
+
+
 def _sanitize_diagnostic(text: str, secrets: list[str]) -> str:
     safe = text
     for secret in secrets:
@@ -179,6 +226,90 @@ def _sanitize_diagnostic(text: str, secrets: list[str]) -> str:
             safe = safe.replace(secret, "[redacted]")
     safe = _SECRET_DIAGNOSTIC_RE.sub("credential=[redacted]", safe)
     return " ".join(safe.split())[:300]
+
+
+def _process_group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _child_run_budget(total_budget_s: float) -> float:
+    cleanup_reserve_s = min(
+        _PROCESS_TERM_GRACE_S + _PROCESS_KILL_REAP_S,
+        total_budget_s / 2,
+    )
+    return max(0.001, total_budget_s - cleanup_reserve_s)
+
+
+def _signal_process_group(
+    proc: asyncio.subprocess.Process,
+    sig: signal.Signals,
+) -> None:
+    try:
+        os.killpg(proc.pid, sig)
+    except ProcessLookupError:
+        return
+    except OSError:
+        with contextlib.suppress(ProcessLookupError):
+            proc.send_signal(sig)
+
+
+async def _wait_process_tree(
+    proc: asyncio.subprocess.Process,
+    communicate_task: asyncio.Task[tuple[bytes, bytes]],
+    *,
+    deadline: float,
+) -> bool:
+    """Wait until both the direct child pipes and its process group are gone."""
+    loop = asyncio.get_running_loop()
+    while True:
+        if communicate_task.done() and not _process_group_exists(proc.pid):
+            return True
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return False
+        await asyncio.sleep(min(_PROCESS_POLL_S, remaining))
+
+
+async def _terminate_process_tree(
+    proc: asyncio.subprocess.Process,
+    communicate_task: asyncio.Task[tuple[bytes, bytes]],
+    *,
+    global_deadline: float,
+) -> None:
+    """TERM then KILL one subprocess session without crossing its deadline."""
+    loop = asyncio.get_running_loop()
+    _signal_process_group(proc, signal.SIGTERM)
+    term_deadline = min(global_deadline, loop.time() + _PROCESS_TERM_GRACE_S)
+    await _wait_process_tree(proc, communicate_task, deadline=term_deadline)
+
+    if _process_group_exists(proc.pid):
+        _signal_process_group(proc, signal.SIGKILL)
+    kill_deadline = min(global_deadline, loop.time() + _PROCESS_KILL_REAP_S)
+    await _wait_process_tree(proc, communicate_task, deadline=kill_deadline)
+
+    if not communicate_task.done():
+        # A descendant that escaped the session can keep inherited pipe FDs
+        # open. Closing our read transports prevents it extending the caller's
+        # wall-clock deadline; the in-session tree has already received KILL.
+        for stream in (proc.stdout, proc.stderr):
+            transport = getattr(stream, "_transport", None)
+            if transport is not None:
+                transport.close()
+        communicate_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await communicate_task
+
+    if proc.returncode is None:
+        remaining = global_deadline - loop.time()
+        if remaining > 0:
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(proc.wait(), timeout=remaining)
 
 
 def _retry_reason(
@@ -189,6 +320,12 @@ def _retry_reason(
     valid_success: bool,
     effective_output: str,
 ) -> str | None:
+    """Classify retryable transport failures.
+
+    Whitespace/no stdout and a valid Claude JSON envelope whose ``result`` is
+    empty are transport-empty and rotate the seat. Domain-level empty data must
+    still be represented by a non-empty, schema-valid payload.
+    """
     if valid_success:
         return None
     combined = f"{stdout}\n{stderr}"
@@ -260,6 +397,7 @@ async def dispatch_claude_print(
             break
         seats_left = len(seats) - index
         seat_budget_s = max(0.001, remaining / seats_left)
+        attempt_deadline = min(deadline, loop.time() + seat_budget_s)
         proc = None
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -268,22 +406,26 @@ async def dispatch_claude_print(
                 env=_build_claude_env(token),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
             )
         except FileNotFoundError as exc:
             raise WR3DispatchError(
                 "`claude` CLI not on PATH. Install: https://claude.ai/code"
             ) from exc
 
-        try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(),
-                timeout=seat_budget_s,
+        communicate_task = asyncio.create_task(proc.communicate())
+        done, _ = await asyncio.wait(
+            {communicate_task},
+            timeout=_child_run_budget(
+                max(0.001, attempt_deadline - loop.time()),
+            ),
+        )
+        if communicate_task not in done:
+            await _terminate_process_tree(
+                proc,
+                communicate_task,
+                global_deadline=attempt_deadline,
             )
-        except asyncio.TimeoutError:
-            if proc.returncode is None:
-                proc.kill()
-            with contextlib.suppress(Exception):
-                await proc.wait()
             failures.append(f"{label}:timeout")
             logger.warning(
                 "%s: Claude OAuth %s timed out; trying next seat",
@@ -291,6 +433,7 @@ async def dispatch_claude_print(
                 label,
             )
             continue
+        stdout_bytes, stderr_bytes = communicate_task.result()
 
         stdout = stdout_bytes.decode("utf-8", "replace")
         stderr = stderr_bytes.decode("utf-8", "replace")
@@ -381,6 +524,81 @@ async def dispatch_claude_print(
     summary = ", ".join(failures) or "no seats available"
     raise ClaudeFleetExhaustedError(
         f"{contract.name}: Claude OAuth fleet exhausted ({summary})"
+    )
+
+
+async def _dispatch_gemini_cli(
+    contract: AgentContract,
+    prompt: str,
+    *,
+    timeout_s: int = 300,
+) -> DispatchResult:
+    """Run the existing Gemini OAuth fallback in an isolated child session."""
+    agy = shutil.which("agy")
+    if agy:
+        cmd = [agy, "-p", "--print-timeout", f"{timeout_s}s"]
+        stdin_payload = prompt.encode()
+    else:
+        legacy = shutil.which("gemini")
+        if legacy is None:
+            raise WR3DispatchError(
+                "Neither `agy` nor `gemini` CLI on PATH for cascade Tier 2"
+            )
+        cmd = [legacy, "-m", "gemini-3.1-pro-preview", "-p", prompt]
+        stdin_payload = None
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    deadline = started + max(float(timeout_s), 0.001)
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE if stdin_payload else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=_build_gemini_env(),
+        start_new_session=True,
+    )
+    communicate_task = asyncio.create_task(proc.communicate(input=stdin_payload))
+    done, _ = await asyncio.wait(
+        {communicate_task},
+        timeout=_child_run_budget(max(0.001, deadline - loop.time())),
+    )
+    if communicate_task not in done:
+        await _terminate_process_tree(
+            proc,
+            communicate_task,
+            global_deadline=deadline,
+        )
+        raise CascadeExhaustedError(
+            f"{contract.name}: Gemini cascade timeout {timeout_s}s"
+        )
+
+    stdout, stderr = communicate_task.result()
+    duration_ms = int((loop.time() - started) * 1000)
+    stdout_text = stdout.decode("utf-8", "replace")
+    stderr_text = stderr.decode("utf-8", "replace")
+    if proc.returncode != 0:
+        if _QUOTA_RE.search(f"{stdout_text}\n{stderr_text}"):
+            raise CascadeExhaustedError(
+                f"{contract.name}: Gemini quota exhausted"
+            )
+        diagnostic = _sanitize_diagnostic(stderr_text or stdout_text, [])
+        raise WR3DispatchError(
+            f"{contract.name}: Gemini exit {proc.returncode}"
+            + (f" diagnostic={diagnostic}" if diagnostic else "")
+        )
+    if not stdout_text.strip():
+        raise CascadeExhaustedError(
+            f"{contract.name}: Gemini returned empty output"
+        )
+
+    return DispatchResult(
+        agent=contract.name,
+        cost_usd_estimated=0.0,
+        duration_ms=duration_ms,
+        cascade_tier=2,
+        raw_output=stdout_text,
+        cascade_reason="claude_budget_exceeded",
     )
 
 

--- a/scripts/wr3_reflexion_synthesis.py
+++ b/scripts/wr3_reflexion_synthesis.py
@@ -46,8 +46,11 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
+import time
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -90,6 +93,41 @@ def _skill_dir() -> Path:
 WINDOW_DAYS = int(os.environ.get("WR3_REFLEXION_WINDOW_DAYS", "7"))
 MAX_LESSONS = int(os.environ.get("WR3_REFLEXION_MAX_LESSONS", "10"))
 LLM_TIMEOUT_S = int(os.environ.get("WR3_REFLEXION_LLM_TIMEOUT", "600"))
+_OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
+_PROVIDER_ENV_PREFIXES = (
+    "ANTHROPIC" + "_",
+    "AWS_",
+    "BEDROCK_",
+    "VERTEX_",
+    "FOUNDRY_",
+)
+_PROVIDER_ENV_NAMES = frozenset(
+    {
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "CLOUD_ML_REGION",
+    }
+)
+_QUOTA_RE = re.compile(
+    r"out of extra usage|usage limit|weekly limit|quota(?: exceeded)?|"
+    r"rate.?limit|too many requests|429|exhausted|hit your limit|"
+    r"capacity|overloaded|please try again later",
+    re.IGNORECASE,
+)
+_AUTH_RE = re.compile(
+    r"authentication (?:failed|required|expired)|auth required|login required|"
+    r"please (?:log in|login)|not logged in|not authenticated|"
+    r"invalid[_ ](?:grant|token)|token[_ ]revoked|refresh[_ ]token|"
+    r"unauthori[sz]ed|(?:error\D*)?401",
+    re.IGNORECASE,
+)
+_SECRET_DIAGNOSTIC_RE = re.compile(
+    r"(?i)\b(?:bearer|oauth[_ -]?token|access[_ -]?token)\b"
+    r"(\s*[:=]\s*|\s+)\S+"
+)
 
 # Episode artifacts to harvest as reflexion signal (filename -> short label)
 _SIGNAL_FILES = {
@@ -245,6 +283,136 @@ def _strip_fences(out: str) -> str:
     return out
 
 
+def _collect_claude_seats(
+    source: Mapping[str, str] | None = None,
+) -> list[tuple[str, str]]:
+    """Return deduplicated OAuth seats in fleet order, then keychain."""
+    values = os.environ if source is None else source
+    seats: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for slot in range(1, 6):
+        token = values.get(f"{_OAUTH_TOKEN_ENV}_{slot}", "").strip()
+        if token and token not in seen:
+            label = "slot5-team" if slot == 5 else f"slot{slot}"
+            seats.append((label, token))
+            seen.add(token)
+    legacy = values.get(_OAUTH_TOKEN_ENV, "").strip()
+    if legacy and legacy not in seen:
+        seats.append(("legacy", legacy))
+    seats.append(("keychain", ""))
+    return seats
+
+
+def _is_provider_env(name: str) -> bool:
+    return name in _PROVIDER_ENV_NAMES or name.startswith(_PROVIDER_ENV_PREFIXES)
+
+
+def _build_claude_env(
+    token: str,
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build an OAuth-only child env with alternate providers removed."""
+    values = os.environ if source is None else source
+    env = {
+        key: value
+        for key, value in values.items()
+        if not _is_provider_env(key) and not key.startswith(_OAUTH_TOKEN_ENV)
+    }
+    if token:
+        env[_OAUTH_TOKEN_ENV] = token
+    return env
+
+
+def _build_gemini_env(
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Keep Gemini OAuth state while removing Claude/provider credentials."""
+    values = os.environ if source is None else source
+    return {
+        key: value
+        for key, value in values.items()
+        if not key.startswith(("ANTHROPIC" + "_", _OAUTH_TOKEN_ENV))
+        and key
+        not in {
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_VERTEX",
+            "CLAUDE_CODE_USE_FOUNDRY",
+        }
+        and not key.startswith(("AWS_", "BEDROCK_", "FOUNDRY_"))
+    }
+
+
+def _sanitize_diagnostic(text: str, secrets: list[str]) -> str:
+    safe = text
+    for secret in secrets:
+        if secret:
+            safe = safe.replace(secret, "[redacted]")
+    safe = _SECRET_DIAGNOSTIC_RE.sub("credential=[redacted]", safe)
+    return " ".join(safe.split())[:300]
+
+
+def _valid_synthesis_json(stdout: str) -> bool:
+    try:
+        payload = json.loads(_strip_fences(stdout))
+    except (json.JSONDecodeError, IndexError):
+        return False
+    return (
+        isinstance(payload, dict)
+        and isinstance(payload.get("week"), str)
+        and isinstance(payload.get("lessons"), list)
+    )
+
+
+def _retry_reason(
+    *,
+    stdout: str,
+    stderr: str,
+    returncode: int,
+    valid_success: bool,
+) -> str | None:
+    if valid_success:
+        return None
+    combined = f"{stdout}\n{stderr}"
+    if _QUOTA_RE.search(combined):
+        return "quota"
+    if _AUTH_RE.search(combined):
+        return "auth"
+    if not stdout.strip():
+        return "empty-output"
+    if returncode == 0:
+        return "invalid-output"
+    return None
+
+
+def _invoke_process(
+    cmd: list[str],
+    prompt: str,
+    timeout_s: float,
+    env: dict[str, str],
+) -> tuple[int, str, str, bool]:
+    """Run one CLI attempt; an expired child is killed and reaped."""
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    try:
+        stdout, stderr = proc.communicate(input=prompt, timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+        return (
+            proc.returncode if proc.returncode is not None else -9,
+            stdout,
+            stderr,
+            True,
+        )
+    return proc.returncode or 0, stdout, stderr, False
+
+
 def call_llm_synthesis(prompt: str) -> dict | None:
     """Tier-1 claude -p (Sonnet), Tier-2 agy (Gemini) on cascade. Returns parsed JSON or None."""
     for tier in ("claude", "gemini"):
@@ -260,31 +428,113 @@ def call_llm_synthesis(prompt: str) -> dict | None:
 
 
 def _run_tier(tier: str, prompt: str) -> str | None:
-    env = os.environ.copy()
-    env.pop("ANTHROPIC_API_KEY", None)  # defense-in-depth: never pay-per-token (CLAUDE.md)
     if tier == "claude":
-        cmd = ["claude", "-p", "--model", "claude-sonnet-5"]
-    else:
-        cmd = ["agy", "-p", "--print-timeout", "5m"]
+        return _run_claude_fleet(prompt)
+    cmd = ["agy", "-p", "--print-timeout", "5m"]
     try:
-        r = subprocess.run(cmd, input=prompt, capture_output=True, text=True,
-                           timeout=LLM_TIMEOUT_S, env=env)
-    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        returncode, stdout, stderr, timed_out = _invoke_process(
+            cmd,
+            prompt,
+            LLM_TIMEOUT_S,
+            _build_gemini_env(),
+        )
+    except FileNotFoundError as e:
         print(f"[wr3-reflexion] tier {tier} unavailable: {e}", file=sys.stderr)
         return None
-    if r.returncode != 0:
-        low = (r.stdout + r.stderr).lower()
-        if any(s in low for s in ("out of extra usage", "usage limit", "quota",
-                                  "rate limit", "429", "exhausted")):
-            print(f"[wr3-reflexion] tier {tier} quota-exhausted, cascading", file=sys.stderr)
-        else:
-            print(f"[wr3-reflexion] tier {tier} exit {r.returncode}: {r.stderr[:300]}",
-                  file=sys.stderr)
+    if timed_out:
+        print(f"[wr3-reflexion] tier {tier} timed out", file=sys.stderr)
         return None
-    return r.stdout
+    if returncode != 0:
+        if _QUOTA_RE.search(f"{stdout}\n{stderr}"):
+            print(
+                f"[wr3-reflexion] tier {tier} quota-exhausted, cascading",
+                file=sys.stderr,
+            )
+        else:
+            diagnostic = _sanitize_diagnostic(stderr or stdout, [])
+            print(
+                f"[wr3-reflexion] tier {tier} exit {returncode}"
+                + (f": {diagnostic}" if diagnostic else ""),
+                file=sys.stderr,
+            )
+        return None
+    if not stdout.strip():
+        print(f"[wr3-reflexion] tier {tier} returned empty output", file=sys.stderr)
+        return None
+    return stdout
+
+
+def _run_claude_fleet(prompt: str) -> str | None:
+    """Try the full Claude OAuth fleet within one bounded wall-clock budget."""
+    seats = _collect_claude_seats()
+    secrets = [token for _, token in seats if token]
+    deadline = time.monotonic() + max(float(LLM_TIMEOUT_S), 0.001)
+    for index, (label, token) in enumerate(seats):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            print(
+                "[wr3-reflexion] Claude OAuth fleet deadline exhausted", file=sys.stderr
+            )
+            return None
+        seats_left = len(seats) - index
+        seat_budget_s = max(0.001, remaining / seats_left)
+        try:
+            returncode, stdout, stderr, timed_out = _invoke_process(
+                ["claude", "-p", "--model", "claude-sonnet-5"],
+                prompt,
+                seat_budget_s,
+                _build_claude_env(token),
+            )
+        except FileNotFoundError as e:
+            print(f"[wr3-reflexion] Claude CLI unavailable: {e}", file=sys.stderr)
+            return None
+
+        if timed_out:
+            print(
+                f"[wr3-reflexion] Claude OAuth {label} timed out; trying next seat",
+                file=sys.stderr,
+            )
+            continue
+
+        valid_success = returncode == 0 and _valid_synthesis_json(stdout)
+        reason = _retry_reason(
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+            valid_success=valid_success,
+        )
+        if reason is not None:
+            print(
+                f"[wr3-reflexion] Claude OAuth {label} failed ({reason}); "
+                "trying next seat",
+                file=sys.stderr,
+            )
+            continue
+
+        if returncode != 0:
+            diagnostic = _sanitize_diagnostic(stderr or stdout, secrets)
+            print(
+                f"[wr3-reflexion] Claude OAuth {label} exit {returncode}"
+                + (f": {diagnostic}" if diagnostic else ""),
+                file=sys.stderr,
+            )
+            return None
+        if not stdout.strip():
+            print(
+                f"[wr3-reflexion] Claude OAuth {label} returned empty output; "
+                "trying next seat",
+                file=sys.stderr,
+            )
+            continue
+        print(f"[wr3-reflexion] Claude OAuth used {label}", file=sys.stderr)
+        return stdout
+
+    print("[wr3-reflexion] Claude OAuth fleet exhausted", file=sys.stderr)
+    return None
 
 
 # ---- Write lessons + skill drafts -------------------------------------------
+
 
 def write_lessons(synthesis: dict, skill_dir: Path) -> int:
     lessons = (synthesis or {}).get("lessons") or []

--- a/scripts/wr3_reflexion_synthesis.py
+++ b/scripts/wr3_reflexion_synthesis.py
@@ -47,6 +47,7 @@ import importlib.util
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -100,6 +101,14 @@ _PROVIDER_ENV_PREFIXES = (
     "BEDROCK_",
     "VERTEX_",
     "FOUNDRY_",
+    "OPENAI_",
+    "DEEPSEEK_",
+    "OPENROUTER_",
+    "GEMINI_",
+    "TOGETHER_",
+    "GROQ_",
+    "MISTRAL_",
+    "COHERE_",
 )
 _PROVIDER_ENV_NAMES = frozenset(
     {
@@ -127,6 +136,33 @@ _AUTH_RE = re.compile(
 _SECRET_DIAGNOSTIC_RE = re.compile(
     r"(?i)\b(?:bearer|oauth[_ -]?token|access[_ -]?token)\b"
     r"(\s*[:=]\s*|\s+)\S+"
+)
+_PROCESS_TERM_GRACE_S = 0.25
+_PROCESS_KILL_REAP_S = 0.75
+_PROCESS_POLL_S = 0.01
+_GEMINI_ENV_ALLOWLIST = frozenset(
+    {
+        "HOME",
+        "PATH",
+        "TMPDIR",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TERM",
+        "SHELL",
+        "USER",
+        "LOGNAME",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "ALL_PROXY",
+    }
 )
 
 # Episode artifacts to harvest as reflexion signal (filename -> short label)
@@ -326,19 +362,12 @@ def _build_claude_env(
 def _build_gemini_env(
     source: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
-    """Keep Gemini OAuth state while removing Claude/provider credentials."""
+    """Build a minimal OAuth-CLI environment without any provider credential."""
     values = os.environ if source is None else source
     return {
         key: value
         for key, value in values.items()
-        if not key.startswith(("ANTHROPIC" + "_", _OAUTH_TOKEN_ENV))
-        and key
-        not in {
-            "CLAUDE_CODE_USE_BEDROCK",
-            "CLAUDE_CODE_USE_VERTEX",
-            "CLAUDE_CODE_USE_FOUNDRY",
-        }
-        and not key.startswith(("AWS_", "BEDROCK_", "FOUNDRY_"))
+        if key in _GEMINI_ENV_ALLOWLIST or key.startswith("LC_")
     }
 
 
@@ -370,6 +399,11 @@ def _retry_reason(
     returncode: int,
     valid_success: bool,
 ) -> str | None:
+    """Rotate on transport-empty output, not on a valid zero-lessons payload.
+
+    ``{"week": ..., "lessons": []}`` is an honest synthesis and succeeds.
+    Whitespace/no stdout contains no schema at all and must try the next seat.
+    """
     if valid_success:
         return None
     combined = f"{stdout}\n{stderr}"
@@ -384,13 +418,59 @@ def _retry_reason(
     return None
 
 
+def _process_group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _signal_process_group(proc: subprocess.Popen[str], sig: signal.Signals) -> None:
+    try:
+        os.killpg(proc.pid, sig)
+    except ProcessLookupError:
+        return
+    except OSError:
+        try:
+            proc.send_signal(sig)
+        except ProcessLookupError:
+            return
+
+
+def _wait_process_group_exit(pgid: int, *, deadline: float) -> bool:
+    while _process_group_exists(pgid):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(_PROCESS_POLL_S, remaining))
+    return True
+
+
+def _timeout_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return value
+
+
 def _invoke_process(
     cmd: list[str],
     prompt: str,
     timeout_s: float,
     env: dict[str, str],
 ) -> tuple[int, str, str, bool]:
-    """Run one CLI attempt; an expired child is killed and reaped."""
+    """Run one CLI attempt within a deadline that includes tree cleanup."""
+    total_budget_s = max(float(timeout_s), 0.001)
+    deadline = time.monotonic() + total_budget_s
+    cleanup_reserve_s = min(
+        _PROCESS_TERM_GRACE_S + _PROCESS_KILL_REAP_S,
+        total_budget_s / 2,
+    )
+    run_budget_s = max(0.001, total_budget_s - cleanup_reserve_s)
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
@@ -398,19 +478,61 @@ def _invoke_process(
         stderr=subprocess.PIPE,
         text=True,
         env=env,
+        start_new_session=True,
     )
     try:
-        stdout, stderr = proc.communicate(input=prompt, timeout=timeout_s)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        stdout, stderr = proc.communicate()
-        return (
-            proc.returncode if proc.returncode is not None else -9,
-            stdout,
-            stderr,
-            True,
-        )
-    return proc.returncode or 0, stdout, stderr, False
+        stdout, stderr = proc.communicate(input=prompt, timeout=run_budget_s)
+        return proc.returncode or 0, stdout, stderr, False
+    except subprocess.TimeoutExpired as first_timeout:
+        stdout = _timeout_text(first_timeout.output)
+        stderr = _timeout_text(first_timeout.stderr)
+
+    _signal_process_group(proc, signal.SIGTERM)
+    term_deadline = min(deadline, time.monotonic() + _PROCESS_TERM_GRACE_S)
+    communication_done = False
+    remaining = term_deadline - time.monotonic()
+    if remaining > 0:
+        try:
+            stdout, stderr = proc.communicate(timeout=remaining)
+            communication_done = True
+        except subprocess.TimeoutExpired as term_timeout:
+            stdout = _timeout_text(term_timeout.output)
+            stderr = _timeout_text(term_timeout.stderr)
+    _wait_process_group_exit(proc.pid, deadline=term_deadline)
+
+    if _process_group_exists(proc.pid):
+        _signal_process_group(proc, signal.SIGKILL)
+    kill_deadline = min(deadline, time.monotonic() + _PROCESS_KILL_REAP_S)
+    if not communication_done:
+        remaining = kill_deadline - time.monotonic()
+        if remaining > 0:
+            try:
+                stdout, stderr = proc.communicate(timeout=remaining)
+                communication_done = True
+            except subprocess.TimeoutExpired as kill_timeout:
+                stdout = _timeout_text(kill_timeout.output)
+                stderr = _timeout_text(kill_timeout.stderr)
+    _wait_process_group_exit(proc.pid, deadline=kill_deadline)
+
+    if not communication_done:
+        # The in-session tree has received KILL. Close inherited pipe readers
+        # so an escaped descendant cannot extend the caller's wall deadline.
+        for stream in (proc.stdin, proc.stdout, proc.stderr):
+            if stream is not None:
+                stream.close()
+        remaining = deadline - time.monotonic()
+        if proc.returncode is None and remaining > 0:
+            try:
+                proc.wait(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                pass
+
+    return (
+        proc.returncode if proc.returncode is not None else -signal.SIGKILL,
+        stdout,
+        stderr,
+        True,
+    )
 
 
 def call_llm_synthesis(prompt: str) -> dict | None:


### PR DESCRIPTION
## Summary

- rotate Claude OAuth seats in deterministic `1 -> 2 -> 3 -> 4 -> 5 Team -> legacy -> keychain` order with stable de-duplication
- retry bounded quota, weekly-limit, rate-limit, authentication, revoked-token, empty-output, and timeout failures under one global deadline
- terminate and reap timed-out child processes before moving to the next seat
- scrub paid Anthropic and alternate-provider credentials from Claude child environments while preserving the existing Gemini fallback where explicitly supported
- keep gate agents fail-closed and preserve the existing core/scheduled fallback semantics

## Security and operational contracts

- no Anthropic pay-as-you-go API path
- no OAuth token values in logs, exceptions, or artifacts; logs expose sanitized seat labels only
- no cross-family substitution for scheduled/gate flows
- no merge, auto-merge, or deploy performed by this change

## Scope

- `scripts/wr3_dispatch_v2.py`
- `scripts/wr3_reflexion_synthesis.py`
- focused hermetic tests for both runners

## Verification

- mandatory full local pre-push backend suite: passed (exit 0)
- focused OAuth-fleet tests: 29 passed
- `py_compile`: passed
- Ruff: passed
- WR3 CLI-only lint: passed
- Claude headless-limit lint: 0 findings
- `git diff --check`: passed
