### PR TITLE
chore(intel): preserve published article history

### DIFF
--- a/apps/bali-intel-scraper/data/published_articles.json
+++ b/apps/bali-intel-scraper/data/published_articles.json
@@ -1909,6 +1909,456 @@
       "url": "https://absvisa.com/what-chinese-digital-workers-should-know-before-living-in-bali/",
       "title": "What Chinese Digital Workers Should Know Before Living ...",
       "published_at": "2026-07-14T01:58:56.751032"
+    },
+    {
+      "url": "https://www.posbali.net/berita/1427455843/urus-dokumen-imigrasi-lebih-mudah-bisa-sambil-belanja-5-fasilitas-yang-diurus-di-immigration-lounge",
+      "title": "Urus Dokumen Imigrasi Lebih Mudah, Bisa Sambil Belanja, 5 Fasilitas yang Diurus di Immigration Lounge    - Pos Bali",
+      "published_at": "2026-07-15T01:43:52.595816"
+    },
+    {
+      "url": "https://www.viv.co.id/read/162654/djp-transaksi-pajak-satu-pintu-lewat-coretax-mulai-juli-2026",
+      "title": "DJP: Coretax Jadi Sistem Inti Administrasi Pajak Juli 2026",
+      "published_at": "2026-07-15T01:43:52.595834"
+    },
+    {
+      "url": "https://www.balipost.com/news/2026/07/14/566200/Puluhan-KBLI-PMA-Diblokir-Pemprov...html",
+      "title": "Puluhan KBLI PMA Diblokir! Pemprov Bali Perketat Celah Investasi Ilegal dan Praktik Nominee | BALIPOST.com",
+      "published_at": "2026-07-15T01:43:52.595839"
+    },
+    {
+      "url": "https://xpnd.co.id/blogs/outsourcing-payroll-new-business-indonesia/",
+      "title": "Outsourcing Payroll for New Businesses in Indonesia",
+      "published_at": "2026-07-15T01:43:52.595843"
+    },
+    {
+      "url": "https://www.abc.net.au/news/2026-07-12/family-of-perth-man-cameron-hughes-questions-bali-death/106907308",
+      "title": "Family of Perth man Cameron Hughes raises questions about his Bali detention centre death  - ABC News",
+      "published_at": "2026-07-15T01:43:52.595847"
+    },
+    {
+      "url": "https://balivisaclinic.com/bali-s-2027-golden-visa-an-investor-s-guide-to-long-term-residency-wit/",
+      "title": "Bali’s 2027 Golden Visa: An Investor’s Guide to Long-Term Residency with Bali Visa Clinic — Bali Visa Clinic Concierge",
+      "published_at": "2026-07-15T01:43:52.595850"
+    },
+    {
+      "url": "https://www.balipost.com/news/2026/07/12/565808/Semester-I-2026,Penerbitan-BVK...html",
+      "title": "Semester I 2026, Penerbitan BVK Dipangkas 87 Persen Saring WNA Berkualitas | BALIPOST.com",
+      "published_at": "2026-07-15T01:43:52.595853"
+    },
+    {
+      "url": "https://indonesiaexpat.id/news/immigration-cuts-visa-free-entry-by-87-91-focuses-on-high-quality-foreign-nationals/",
+      "title": "Immigration Cuts Visa-Free Entry by 87.91%, Focuses on High-Quality Foreign Nationals",
+      "published_at": "2026-07-15T01:43:52.595856"
+    },
+    {
+      "url": "https://indonesiaexpat.id/business-property/why-the-islands-architectural-identity-matters-more-than-ever/",
+      "title": "Why the Island’s Architectural Identity Matters More Than Ever",
+      "published_at": "2026-07-15T01:43:52.595859"
+    },
+    {
+      "url": "https://indonesiaexpat.id/lifestyle/food-drink/osteria-gia-takes-over-sunday-brunch-at-w-bali-seminyak/",
+      "title": "Osteria GIA Takes Over Sunday Brunch at W Bali – Seminyak",
+      "published_at": "2026-07-15T01:43:52.595863"
+    },
+    {
+      "url": "https://indonesiaexpat.id/lifestyle/food-drink/from-ocean-to-table-experience-sofitel-bali-nusa-duas-new-catch-grill-adventure/",
+      "title": "From Ocean to Table: Experience Sofitel Bali Nusa Dua’s New Catch & Grill Adventure",
+      "published_at": "2026-07-15T01:43:52.595866"
+    },
+    {
+      "url": "https://www.cnnindonesia.com/nasional/20260714194334-12-1380742/15-wna-china-dan-vietnam-ditangkap-usai-buka-lowongan-kerja-curi-data",
+      "title": "15 WNA China dan Vietnam Ditangkap Usai Buka Lowongan Kerja Curi Data",
+      "published_at": "2026-07-15T01:43:52.595870"
+    },
+    {
+      "url": "https://www.fortuneidn.com/news/lima-tahun-tertahan-di-10-djp-pacu-tax-ratio-tembus-15-00-6cmtl-241575",
+      "title": "Lima Tahun Tertahan di 10%, DJP Pacu Tax Ratio Tembus 15% | FORTUNE Indonesia",
+      "published_at": "2026-07-15T01:43:52.595873"
+    },
+    {
+      "url": "https://kriptova.com/berita/pojk-aset-kripto-2026/",
+      "title": "POJK Aset Kripto 2026: Skema Pajak 0.1% dan Perlindungan Investor Baru",
+      "published_at": "2026-07-15T01:43:52.595877"
+    },
+    {
+      "url": "https://tentangkepri.com/13/07/2026/empat-marketplace-resmi-pungut-pph-pedagang-online-djp-bukan-pajak-baru/",
+      "title": "Empat Marketplace Resmi Pungut PPh Pedagang Online, DJP: Bukan Pajak Baru | TentangKepri.com",
+      "published_at": "2026-07-15T01:43:52.595880"
+    },
+    {
+      "url": "https://mataram.antaranews.com/berita/245760/pemohon-second-home-visa-di-bali-2022-masih-nihil",
+      "title": "Pemohon \"second home visa\" di Bali 2022 masih nihil - ANTARA News Mataram",
+      "published_at": "2026-07-16T01:40:16.835265"
+    },
+    {
+      "url": "https://polresdenpasar.com/sanksi-tegas-pelanggaran-izin-tinggal-nomad-digital-asing-di-wilayah-bali/",
+      "title": "Sanksi Tegas Pelanggaran Izin Tinggal Nomad Digital Asing di Wilayah Bali - POLRES DENPASAR",
+      "published_at": "2026-07-16T01:40:16.835289"
+    },
+    {
+      "url": "https://baliutama.web.id/langkah-tegas-pemprov-bali-persempit-celah-investasi/",
+      "title": "Langkah Tegas Pemprov Bali Persempit Celah Investasi",
+      "published_at": "2026-07-16T01:40:16.835297"
+    },
+    {
+      "url": "https://investinasia.id/blog/how-to-change-your-pt-pmas-kbli-code-in-indonesia/",
+      "title": "How to Change Your PT PMA's KBLI Code in Indonesia | InvestinAsia",
+      "published_at": "2026-07-16T01:40:16.835302"
+    },
+    {
+      "url": "https://mataram.antaranews.com/berita/229277/eks-wni-dan-wna-bisa-gunakan-visa-rumah-kedua",
+      "title": "Eks WNI dan WNA bisa gunakan visa rumah kedua - ANTARA News Mataram",
+      "published_at": "2026-07-16T01:40:16.835310"
+    },
+    {
+      "url": "https://en.vietnamplus.vn/indonesia-tightens-visa-free-entry-policy-post348269.vnp",
+      "title": "Indonesia tightens visa-free entry policy",
+      "published_at": "2026-07-16T01:40:16.835316"
+    },
+    {
+      "url": "https://mataram.antaranews.com/berita/357531/kemenkumham-bali-menekankan-harmonisasi-aturan-family-office",
+      "title": "Kemenkumham Bali menekankan harmonisasi aturan \"family office\" - ANTARA News Mataram",
+      "published_at": "2026-07-16T01:40:16.835321"
+    },
+    {
+      "url": "https://visa-indonesia.com/bali-tips/best-places-to-live-in-bali/",
+      "title": "Best Places to Live in Bali for Expats: An Area Guide by Lifestyle - Visa Indonesia",
+      "published_at": "2026-07-16T01:40:16.835327"
+    },
+    {
+      "url": "https://indonesiaexpat.id/outreach/observations/house-versus-apartment-in-jakarta-a-choice-that-reflects-our-values/",
+      "title": "House Versus Apartment in Jakarta: A Choice That Reflects Our Values",
+      "published_at": "2026-07-16T01:40:16.835332"
+    },
+    {
+      "url": "https://magnumestate.com/blog/bali-visa-application-guide-2026",
+      "title": "Bali Visa Application Guide 2026: Types, Cost & How to Apply",
+      "published_at": "2026-07-16T01:40:16.835337"
+    },
+    {
+      "url": "https://www.liputan6.com/bisnis/read/8246101/jalankan-mandat-dpr-pemerintah-kebut-coretax-dan-pajak-digital",
+      "title": "Jalankan Mandat DPR, Pemerintah Kebut Coretax dan Pajak Digital",
+      "published_at": "2026-07-16T01:40:16.835343"
+    },
+    {
+      "url": "https://www.pantau.com/news/353159/imigrasi-pangkas-bebas-visa-87-persen-untuk-perketat-seleksi-wna-berkualitas",
+      "title": "Imigrasi Pangkas Bebas Visa 87 Persen untuk Perketat Seleksi WNA Berkualitas - Pantau.com",
+      "published_at": "2026-07-16T01:40:16.835348"
+    },
+    {
+      "url": "https://www.nusabali.com/berita/225558/dpmptsp-bali-penutupan-puluhan-kbli-pma-tak-ganggu-target-investasi-bali",
+      "title": "NUSABALI.com\n                    - DPMPTSP Bali: Penutupan Puluhan KBLI PMA Tak Ganggu Target Investasi Bali",
+      "published_at": "2026-07-16T01:40:16.835353"
+    },
+    {
+      "url": "https://muc.co.id/id/expert-insight/mencermati-penjualan-saham-perusahaan-privat-oleh-subyek-pajak-luar-negeri",
+      "title": "Mencermati Penjualan Saham Perusahaan Privat  oleh Subyek Pajak Luar Negeri",
+      "published_at": "2026-07-16T01:40:16.835359"
+    },
+    {
+      "url": "https://frconsultantindonesia.com/blog/legalitas-perusahaan/fr-PsTOf/cara-mengurus-izin-usaha-secara-online-melalui-oss-rba-tanpa-ribet",
+      "title": "Cara Mengurus Izin Usaha Secara Online Melalui OSS RBA Tanpa Ribet | FR Consultant Indonesia",
+      "published_at": "2026-07-16T01:40:16.835365"
+    },
+    {
+      "url": "https://jogja.antaranews.com/berita/715059/golden-visa-di-indonesia-gaet-investasi-rp4-triliun",
+      "title": "Golden Visa di Indonesia gaet investasi Rp4 triliun - ANTARA News Yogyakarta - Berita Terkini Yogyakarta",
+      "published_at": "2026-07-17T01:44:01.304122"
+    },
+    {
+      "url": "https://beritabisnis.com/empat-marketplace-jadi-pemungut-pph-berlaku-efektif-1-agustus-2026",
+      "title": "Empat Marketplace Jadi Pemungut PPh, Berlaku Efektif 1 Agustus 2026 | Berita Bisnis Hari Ini",
+      "published_at": "2026-07-17T01:44:01.304140"
+    },
+    {
+      "url": "https://xpnd.co.id/blogs/property-pt-pma-indonesia/",
+      "title": "Property PT PMA Indonesia: Legal Guide 2026",
+      "published_at": "2026-07-17T01:44:01.304143"
+    },
+    {
+      "url": "https://voffice.co.id/blog/en/can-resellers-set-up-a-pt-without-a-physical-office-in-indonesia/",
+      "title": "Can Resellers Set Up a PT Without a Physical Office in Indonesia? | vOffice",
+      "published_at": "2026-07-17T01:44:01.304146"
+    },
+    {
+      "url": "https://balidiscovery.com/",
+      "title": "Bali Discovery",
+      "published_at": "2026-07-17T01:44:01.304149"
+    },
+    {
+      "url": "https://mataram.antaranews.com/berita/228121/imigrasi-manfaatkan-kegiatan-ktt-g20-perkenalkan-second-home-visa",
+      "title": "Imigrasi manfaatkan kegiatan KTT G20 perkenalkan \"second home visa\" - ANTARA News Mataram",
+      "published_at": "2026-07-17T01:44:01.304151"
+    },
+    {
+      "url": "https://indonesiaexpat.id/news/transnusa-to-launch-direct-bali-phuket-route-starting-september-2026/",
+      "title": "TransNusa to Launch Direct Bali–Phuket Route Starting September 2026",
+      "published_at": "2026-07-17T01:44:01.304154"
+    },
+    {
+      "url": "https://gokepri.com/content-creator-hingga-konsultan-tak-lagi-bisa-gunakan-pph-final-05-persen/",
+      "title": "Content Creator hingga Konsultan Tak Lagi Bisa Gunakan PPh Final 0,5 Persen",
+      "published_at": "2026-07-17T01:44:01.304156"
+    },
+    {
+      "url": "https://thebalitimes.com/headlines/indonesia-slashes-visa-free-entry-as-border-controls-tighten/",
+      "title": "Indonesia Slashes Visa-Free Entry as Border Controls Tighten - The Bali Times",
+      "published_at": "2026-07-17T01:44:01.304158"
+    },
+    {
+      "url": "https://www.kalbardigital.com/nusantara/597457446/pengawasan-orang-asing-diperketat-bebas-visa-dikurangi",
+      "title": "Pengawasan Orang Asing Diperketat, Bebas Visa Dikurangi - Kalbar Digital",
+      "published_at": "2026-07-17T01:44:01.304161"
+    },
+    {
+      "url": "https://news.batampos.co.id/djp-tunjuk-shopee-tokopedia-blibli-dan-lazada-pungut-pph-pedagang-marketplace-2/",
+      "title": "DJP Tunjuk Shopee, Tokopedia, Blibli, dan Lazada Pungut PPh Pedagang Marketplace – News",
+      "published_at": "2026-07-17T01:44:01.304164"
+    },
+    {
+      "url": "https://heybali.info/news/three-foreign-nationals-deported-from-bali-after-authorities-say-they-worked-on-tourist-visas/",
+      "title": "Three Foreign Nationals Deported From Bali After Authorities Say They Worked on Tourist Visas - Hey Bali News: Bali in the News",
+      "published_at": "2026-07-17T01:44:01.304166"
+    },
+    {
+      "url": "https://www.thetraveler.org/the-costly-visa-trap-catching-australians-on-bali-holidays/",
+      "title": "The costly visa trap catching Australians on Bali holidays",
+      "published_at": "2026-07-17T01:44:01.304169"
+    },
+    {
+      "url": "https://kliklegal.com/penyesuaian-kbli-2025-rups-tahunan-dan-lkpm-tiga-agenda-kepatuhan-juli-2026/",
+      "title": "Penyesuaian KBLI 2025, RUPS Tahunan, Dan LKPM: Tiga Agenda Kepatuhan Juli 2026 - KlikLegal",
+      "published_at": "2026-07-17T01:44:01.304172"
+    },
+    {
+      "url": "https://indonews.id/artikel/352934/Mengendalikan-Lonjakan-Fiktif-Positif-Pasca-PP-28-2025-untuk-Memperkuat-Kepastian-Hukum-dan-Kepercayaan-Investor/",
+      "title": "Mengendalikan Lonjakan Fiktif Positif Pasca PP 28/2025 untuk Memperkuat Kepastian Hukum dan Kepercayaan Investor",
+      "published_at": "2026-07-17T01:44:01.304174"
+    },
+    {
+      "url": "https://denpasar.kompas.com/read/2026/07/15/171833978/kerja-di-bali-dengan-visa-kunjungan-3-wna-pelanggar-izin-tinggal",
+      "title": "Kerja di Bali dengan Visa Kunjungan, 3 WNA Pelanggar Izin Tinggal Dideportasi",
+      "published_at": "2026-07-18T01:55:28.988926"
+    },
+    {
+      "url": "https://www.pajakonline.com/djp-nonaktifkan-massal-npwp-istri-secara-otomatis/",
+      "title": "DJP Nonaktifkan Massal NPWP Istri Secara Otomatis – PajakOnline.com",
+      "published_at": "2026-07-18T01:55:28.988942"
+    },
+    {
+      "url": "https://indonesiahouse.com/indonesia-considers-major-overhaul-of-foreign-property-ownership-laws-sparking-diverse-industry-reactions/",
+      "title": "Indonesia Considers Major Overhaul of Foreign Property Ownership Laws, Sparking Diverse Industry Reactions",
+      "published_at": "2026-07-18T01:55:28.988945"
+    },
+    {
+      "url": "https://www.viva.co.id/bisnis/1913700-biaya-bikin-pt-resmi-naik-mulai-agustus-2026-pendirian-perusahaan-bermodal-besar-kini-tembus-rp5-juta",
+      "title": "Biaya Bikin PT Resmi Naik Mulai Agustus 2026, Pendirian Perusahaan Bermodal Besar Kini Tembus Rp5 Juta",
+      "published_at": "2026-07-18T01:55:28.988948"
+    },
+    {
+      "url": "https://mataram.antaranews.com/berita/474829/tanam-modal-properti-bisa-bikin-investor-indonesia-meraih-golden-visa-yunani",
+      "title": "Tanam modal properti bisa bikin investor Indonesia meraih Golden Visa Yunani - ANTARA News Mataram",
+      "published_at": "2026-07-18T01:55:28.988950"
+    },
+    {
+      "url": "https://ekonomi.bisnis.com/read/20260716/259/1988582/tiru-uea-insentif-pajak-setengah-abad-untuk-pusat-finansial-ri-pfii",
+      "title": "Tiru UEA, Insentif Pajak Setengah Abad untuk Pusat Finansial RI (PFII)",
+      "published_at": "2026-07-18T01:55:28.988953"
+    },
+    {
+      "url": "https://indonesiaexpat.id/news/bali-immigration-deploys-104-officers-for-dharma-dewata-patrols/",
+      "title": "Bali Immigration Deploys 104 Officers for Dharma Dewata Patrols",
+      "published_at": "2026-07-18T01:55:28.988955"
+    },
+    {
+      "url": "https://indonesiaexpat.id/lifestyle/food-drink/balis-newest-tables-july-2026/",
+      "title": "Bali’s Newest Tables – July 2026",
+      "published_at": "2026-07-18T01:55:28.988957"
+    },
+    {
+      "url": "https://en.tempo.co/read/2114247/lawyer-denies-febrie-adriansyah-received-money-from-tan-kian",
+      "title": "Lawyer Denies Febrie Adriansyah Received Money from Tan Kian",
+      "published_at": "2026-07-18T01:55:28.988960"
+    },
+    {
+      "url": "https://www.tuahkepri.com/izin-tinggal-10-pekerja-tka-di-tobong-bata-dompak-tidak-sesuai-dengan-kegiatan/",
+      "title": "Izin Tinggal 10 Pekerja TKA di Tobong Bata Dompak Tidak Sesuai Dengan Kegiatan – Tuah Kepri",
+      "published_at": "2026-07-18T01:55:28.988962"
+    },
+    {
+      "url": "https://destinationbali.id/guides/can-i-work-as-a-digital-nomad-in-bali",
+      "title": "Can I Work as a Digital Nomad in Bali? 2026 Guide",
+      "published_at": "2026-07-18T01:55:28.988965"
+    },
+    {
+      "url": "https://www.taxcenterunsika.com/punya-kripto-tidak-dilaporkan-siap-siap-kena-senggol-kerja-sama-pajak-global/",
+      "title": "Punya Kripto Tidak Dilaporkan? Siap-Siap Kena ‘Senggol’ Kerja Sama Pajak Global! – Tax Center UNSIKA",
+      "published_at": "2026-07-18T01:55:28.988969"
+    },
+    {
+      "url": "https://www.antaranews.com/berita/5651755/kemenimipas-terbitkan-regulasi-penambahan-enam-negara-penerima-bvk",
+      "title": "Kemenimipas terbitkan regulasi penambahan enam negara penerima BVK - ANTARA News",
+      "published_at": "2026-07-18T01:55:28.988972"
+    },
+    {
+      "url": "https://www.travelnews.co.za/article/indonesia-warns-influencers-to-use-work-visas",
+      "title": "Indonesia warns influencers to use work visas | Travelnews",
+      "published_at": "2026-07-18T01:55:28.988974"
+    },
+    {
+      "url": "https://golaw.id/blog/punya-penghasilan-dari-luar-negeri-cek-aturan-pph-final-05/",
+      "title": "Punya Penghasilan dari Luar Negeri? Cek Aturan PPh Final 0,5% - Blog Golaw ID",
+      "published_at": "2026-07-18T01:55:28.988976"
+    },
+    {
+      "url": "https://ntt.newsline.id/2026/07/16/3777/",
+      "title": "DIGITAL NOMAD VISA (E33G): Solusi atau Malah Salah Sasaran? - Newsline-NTT",
+      "published_at": "2026-07-19T02:04:36.564943"
+    },
+    {
+      "url": "https://biro-jasa.org/kbli-2025-kapan-berlaku/",
+      "title": "KBLI 2025 Kapan Berlaku? Ini Jadwal Resmi Implementasi dan Dampaknya bagi OSS",
+      "published_at": "2026-07-19T02:04:36.564965"
+    },
+    {
+      "url": "https://indonesia.24jamnews.com/ekonomi/114417381652/semester-i-2026-jadi-titik-balik-penerimaan-pajak-reformasi-djp-mulai-memberikan-dampak-positif-nasional",
+      "title": "Semester I-2026 Jadi Titik Balik Penerimaan Pajak, Reformasi DJP Mulai Memberikan Dampak Positif Nasional - Indonesia24jam.com",
+      "published_at": "2026-07-19T02:04:36.564971"
+    },
+    {
+      "url": "https://pozuelorural.com/2026/07/16/navigating-digital-entry-permits-for-the-southeast-asian-country/",
+      "title": "Navigating Digital Entry Permits for the Southeast Asian Country - PozueloRural.com",
+      "published_at": "2026-07-19T02:04:36.564976"
+    },
+    {
+      "url": "https://sumsel.antaranews.com/berita/691467/imigrasi-palembang-tawarkan-wna-visa-rumah-kedua",
+      "title": "Imigrasi Palembang tawarkan WNA visa rumah kedua - ANTARA News Sumatera Selatan",
+      "published_at": "2026-07-19T02:04:36.564981"
+    },
+    {
+      "url": "https://www.letsmoveindonesia.com/indonesia-visa-on-arrival-voa-everything-you-need-to-know/",
+      "title": "Indonesia Visa on Arrival VOA 2026: Everything You Need to Know - Indonesia Visa on Arrival VOA 2026: Everything You Need to Know",
+      "published_at": "2026-07-19T02:04:36.564985"
+    },
+    {
+      "url": "https://www.suara.com/bisnis/2026/07/17/091726/indonesia-siapkan-karpet-merah-investor-asing-di-bali-pajak-nol-rupiah",
+      "title": "Indonesia Siapkan 'Karpet Merah' Investor Asing di Bali, Pajak Nol Rupiah!",
+      "published_at": "2026-07-19T02:04:36.564990"
+    },
+    {
+      "url": "https://xpnd.co.id/blogs/withholding-tax-royalties-indonesia/",
+      "title": "Withholding Tax Royalties Indonesia: 3-Test Guide | XPND",
+      "published_at": "2026-07-19T02:04:36.564995"
+    },
+    {
+      "url": "https://riau.antaranews.com/berita/448179/kantor-virtual-bisa-jadi-alamat-pkp-djp-terbitkan-aturan-baru-yang-wajib-dipahami-pelaku-usaha",
+      "title": "Kantor Virtual bisa jadi alamat PKP, DJP terbitkan aturan baru yang wajib dipahami pelaku usaha - ANTARA News Riau",
+      "published_at": "2026-07-19T02:04:36.564999"
+    },
+    {
+      "url": "https://destinationbali.id/guides/is-bali-still-an-affordable-expat-haven-in",
+      "title": "Is Bali Still an Affordable Expat Haven in 2026?",
+      "published_at": "2026-07-19T02:04:36.565003"
+    },
+    {
+      "url": "https://kabar24.bisnis.com/read/20260717/79/1988432/visa-makin-mahal-di-banyak-negara-indonesia-bidik-peluang-rebut-wisatawan-global",
+      "title": "Visa Makin Mahal di Banyak Negara, Indonesia Bidik Peluang Rebut Wisatawan Global",
+      "published_at": "2026-07-19T02:04:36.565008"
+    },
+    {
+      "url": "https://www.motoworldexplorer.com/2026/07/digital-nomad-visas-in-2026-which.html",
+      "title": "Digital Nomad Visas in 2026: Which Countries Actually Make ...",
+      "published_at": "2026-07-19T02:04:36.565013"
+    },
+    {
+      "url": "https://taxvisory.co.id/2026/07/16/membongkar-pmk-nomor-8-tahun-2026-era-baru-transparansi-ragam-data-di-tangan-ditjen-pajak/",
+      "title": "Membongkar PMK Nomor 8 Tahun 2026: Era Baru Transparansi Ragam Data di Tangan Ditjen Pajak | Taxvisory",
+      "published_at": "2026-07-19T02:04:36.565017"
+    },
+    {
+      "url": "https://legalmp.id/cara-urus-izin-usaha-dagang-ud-lewat-oss-syarat-keuntungan-dan-aturan-terbaru/",
+      "title": "Cara Urus Izin Usaha Dagang (UD) Lewat OSS: Syarat, Keuntungan, dan Aturan Terbaru - LegalMP",
+      "published_at": "2026-07-19T02:04:36.565022"
+    },
+    {
+      "url": "https://livuma.com/monthly-rentals",
+      "title": "Monthly Rentals in Bali | Livuma",
+      "published_at": "2026-07-19T02:04:36.565026"
+    },
+    {
+      "url": "https://www.letsmoveindonesia.com/indonesia-revises-citizenship-fees-as-new-pnbp-rules-take-effect-in-august-2026/",
+      "title": "Indonesia Revises Citizenship Fees as New PNBP Rules ...",
+      "published_at": "2026-07-21T01:53:28.633906"
+    },
+    {
+      "url": "https://www.pantau.com/ekonomi/354315/ekonom-minta-pengawasan-ketat-pfii-untuk-cegah-celah-penghindaran-pajak",
+      "title": "Ekonom Minta Pengawasan Ketat PFII untuk Cegah Celah Penghindaran Pajak - Pantau.com",
+      "published_at": "2026-07-21T01:53:28.633935"
+    },
+    {
+      "url": "https://smartlegal.id/perizinan-berusaha/2026/07/18/naik-skala-bisnis-wajib-lakukan-perubahan-data-oss-perusahaan/",
+      "title": "Naik Skala Bisnis? Wajib Lakukan Perubahan Data OSS Perusahaan  - SmartLegal.id",
+      "published_at": "2026-07-21T01:53:28.633939"
+    },
+    {
+      "url": "https://www.traceworthy.com/foreign-land-ownership-bali/",
+      "title": "Foreign Land Ownership in Bali: What Is Lawful - TraceWorthy",
+      "published_at": "2026-07-21T01:53:28.633943"
+    },
+    {
+      "url": "https://destinationbali.id/guides/is-50-000-enough-to-live-in-bali-a-reality-check",
+      "title": "Is $50000 Enough to Live in Bali? A 2026 Reality Check",
+      "published_at": "2026-07-21T01:53:28.633946"
+    },
+    {
+      "url": "https://livenworkindonesia.com/virtual-office/bali-virtual-office/",
+      "title": "Bali Virtual Office",
+      "published_at": "2026-07-21T01:53:28.633949"
+    },
+    {
+      "url": "https://simplyinvestasia.com/explore-by-countries/indonesia/balis-big-leap-from-holiday-paradise-to-international-financial-centre/",
+      "title": "Bali’s ‘big leap’: from holiday paradise to international financial centre – Simply Invest Asia",
+      "published_at": "2026-07-21T01:53:28.633953"
+    },
+    {
+      "url": "https://habarindonesia.id/imigrasi-ternate-tka-tambang-pulau-obi-masuk-lewat-manado-seluruh-dokumen-diawasi-ketat/",
+      "title": "Imigrasi Ternate, TKA Tambang Pulau Obi Masuk Lewat Manado, Seluruh Dokumen Diawasi Ketat - Habar Indonesia",
+      "published_at": "2026-07-21T01:53:28.633956"
+    },
+    {
+      "url": "https://riau.antaranews.com/berita/448233/dari-layar-lebar-menuju-era-perpajakan-digital-coretax-djp-menata-masa-depan-fiskal-indonesia",
+      "title": "Dari layar lebar menuju era perpajakan digital: Coretax DJP menata masa depan fiskal Indonesia - ANTARA News Riau",
+      "published_at": "2026-07-21T01:53:28.633959"
+    },
+    {
+      "url": "https://presmedia.id/perketat-penerbitan-visa-wna-imigrasi-tolak-87-persen-pengajuan-pada-semester-i-2026/",
+      "title": "Perketat Penerbitan Visa WNA, Imigrasi Tolak 87 Persen Pengajuan pada Semester I 2026",
+      "published_at": "2026-07-21T01:53:28.633962"
+    },
+    {
+      "url": "https://www.merdeka.com/peristiwa/read/8249027/djp-perkuat-pengawasan-pajak-berbasis-teknologi-dan-data-libatkan-babinsa-bhabinkamtibmas",
+      "title": "DJP Perkuat Pengawasan Pajak Berbasis Teknologi dan Data, Libatkan Babinsa-Bhabinkamtibmas - merdeka.com",
+      "published_at": "2026-07-21T01:53:28.633965"
+    },
+    {
+      "url": "https://jatimtimes.com/baca/3331347221/20260718/064100/indonesia-tambah-3-negara-bebas-visa-kunjungan-kini-total-jadi-19-negara",
+      "title": "Indonesia Tambah 3 Negara Bebas Visa Kunjungan, Kini Total Jadi 19 Negara",
+      "published_at": "2026-07-21T01:53:28.633969"
+    },
+    {
+      "url": "https://livuma.com/properties-for-sale",
+      "title": "Properties for Sale in Bali | Livuma",
+      "published_at": "2026-07-21T01:53:28.633972"
+    },
+    {
+      "url": "https://wise.com/jp/blog/indonesia-digital-nomad-visa",
+      "title": "インドネシアのデジタルノマドビザの申請条件は？【2026年最新】 - Wise",
+      "published_at": "2026-07-21T01:53:28.633976"
+    },
+    {
+      "url": "https://id.headtopics.com/news/surat-edaran-baru-djp-intip-rekening-kini-bisa-lewat-aset-85747416",
+      "title": "Surat Edaran Baru DJP: Intip Rekening Kini Bisa Lewat Aset Kripto - Aset Kripto | Pajak Berita",
+      "published_at": "2026-07-21T01:53:28.633979"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- recover the audited Pro runtime `published_articles.json` snapshot
- append exactly 90 public article records without changing the existing 382 records
- preserve the canonical `url`, `title`, and `published_at` schema

## Validation

- JSON parse: pass
- append-only comparison: 382 -> 472 records
- URL validation: 472/472 unique; 90/90 new URLs valid and absent from the base
- record schema and timestamps: pass
- `git diff --check`: pass
- pre-commit hooks: pass
- repository pre-push full Python suite: pass

No merge or deployment is requested by this PR.
