### PR TITLE
fix(backend): register /api/visa/* family as public endpoints (v1 funnel dead since PR #108)

### DIFF
--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -476,6 +476,43 @@ _VISA_ORACLE = (
         Category.VISA_ORACLE,
         "Visa types catalog — used by Next.js SSG at build time",
     ),
+    # Visa Check v1 homepage funnel (routers/visa_check.py, mounted at /api/visa).
+    # Anonymous, no PII (nationality/purpose/budget only), rate-limited per-IP
+    # by RateLimitMiddleware via the "/api/" bucket (120 req/min). The hash IS
+    # the access token for result pages. Registered 2026-07-23: the funnel was
+    # dead in prod since 2026-04-25 (PR #108) because these routes were never
+    # declared public — HybridAuth returned 401 to every anonymous call.
+    # Exact/template matches only — no blanket "/api/visa/" prefix.
+    PublicEndpoint(
+        "/api/visa/check/start",
+        Category.VISA_ORACLE,
+        "Visa Check funnel branch selector — anonymous yes/no routing, no data persisted",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/visa/clock",
+        Category.VISA_ORACLE,
+        "Visa Check Clock submission — anonymous overstay-timeline wizard, no PII",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/visa/match",
+        Category.VISA_ORACLE,
+        "Visa Check Match submission — anonymous visa recommendation, no PII",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/visa/clock/{hash}",
+        Category.VISA_ORACLE,
+        "Visa Check Clock result page — shareable URL, the hash is the access token",
+        match="template",
+    ),
+    PublicEndpoint(
+        "/api/visa/match/{hash}",
+        Category.VISA_ORACLE,
+        "Visa Check Match result page — shareable URL, the hash is the access token",
+        match="template",
+    ),
 )
 
 _BRIDGE = (

--- a/apps/backend-rag/backend/tests/security/test_mutating_routes_are_gated.py
+++ b/apps/backend-rag/backend/tests/security/test_mutating_routes_are_gated.py
@@ -260,6 +260,24 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
         "POST", "/api/v1/kbli-notebook/chat",
         "KBLI Explorer — public business-classification chat, no PII.",
     ),
+    # ── Visa Check v1 funnel (routers/visa_check.py): anonymous wizard,
+    #    restored public 2026-07-23 (funnel dead since PR #108 — routes were
+    #    mounted but never registered in PUBLIC_ENDPOINTS). The result-page
+    #    hash IS the access token; per-IP rate-limited via the /api/ bucket. ──
+    IntentionalPublicMutation(
+        "POST", "/api/visa/check/start",
+        "Branch selector — pure yes/no routing, nothing persisted.",
+    ),
+    IntentionalPublicMutation(
+        "POST", "/api/visa/clock",
+        "Clock submission — anonymous overstay-timeline insert "
+        "(visa_type/entry_date/client_fingerprint only, no PII).",
+    ),
+    IntentionalPublicMutation(
+        "POST", "/api/visa/match",
+        "Match submission — anonymous visa-recommendation insert "
+        "(nationality/purpose/duration/budget only, no PII).",
+    ),
     # ── Marketing: explicit registry rows, standard opt-in/opt-out shape ──
     IntentionalPublicMutation(
         "POST", "/api/blog/ask",

--- a/apps/backend-rag/backend/tests/unit/middleware/test_public_endpoints_registry.py
+++ b/apps/backend-rag/backend/tests/unit/middleware/test_public_endpoints_registry.py
@@ -224,3 +224,106 @@ class TestHelperFunctions:
         assert entry is not None
         assert entry.match == "exact"
         assert entry.prefix == "/"
+
+
+class TestVisaCheckPublicRegistration:
+    """Guilt+innocence for the /api/visa/* Visa Check v1 funnel.
+
+    Regression (PR #108, 2026-04-25): routers/visa_check.py was mounted but
+    never registered here, so HybridAuthMiddleware 401'd every anonymous
+    call and the public funnel was dead in prod. The 5 routes must resolve
+    as public via exact/template matches only — no blanket /api/visa/ prefix.
+    """
+
+    @pytest.fixture
+    def middleware(self):
+        from backend.middleware.hybrid_auth import HybridAuthMiddleware
+
+        return HybridAuthMiddleware(MagicMock())
+
+    def _mock_request(self, path: str, method: str = "GET"):
+        req = MagicMock()
+        req.url.path = path
+        req.method = method
+        req.headers.get.return_value = None
+        req.client.host = "127.0.0.1"
+        return req
+
+    def test_visa_check_endpoints_are_public(self, middleware):
+        """Guilt: all 5 visa_check routes resolve as public."""
+        public_paths = [
+            "/api/visa/check/start",
+            "/api/visa/clock",
+            "/api/visa/match",
+            "/api/visa/clock/a1b2c3d4e5f6",
+            "/api/visa/match/a1b2c3d4e5f6",
+        ]
+        for path in public_paths:
+            assert middleware.is_public_endpoint(self._mock_request(path)), (
+                f"Visa Check path {path!r} must be public"
+            )
+
+    def test_visa_check_entries_use_exact_or_template_match(self):
+        """Entries must not be prefix matches — no blanket /api/visa/ opening."""
+        for prefix, expected_match in (
+            ("/api/visa/check/start", "exact"),
+            ("/api/visa/clock", "exact"),
+            ("/api/visa/match", "exact"),
+            ("/api/visa/clock/{hash}", "template"),
+            ("/api/visa/match/{hash}", "template"),
+        ):
+            entry = next(e for e in PUBLIC_ENDPOINTS if e.prefix == prefix)
+            assert entry.match == expected_match
+            assert entry.category.value == "visa_oracle"
+
+    def test_visa_check_near_miss_paths_are_not_public(self, middleware):
+        """Innocence: sibling/lookalike paths must still require auth."""
+        not_public = [
+            "/api/visaevil/match",  # near-miss prefix lookalike
+            "/api/visa",  # bare root, not a route
+            "/api/visa/",  # trailing-slash root, not a route
+            "/api/visa/clockadmin",  # exact-match sibling of /api/visa/clock
+            "/api/visa/match/abc/def",  # template is single-segment only
+            "/api/visa/unknown",  # unregistered sibling under /api/visa/
+        ]
+        for path in not_public:
+            assert not middleware.is_public_endpoint(self._mock_request(path)), (
+                f"Path {path!r} must NOT be public"
+            )
+
+    def test_visa_check_rate_limit_class(self):
+        """Anonymous visa_check traffic is rate-limited per-IP via the generic
+        "/api/" bucket (120 req/min) — same class as /api/v1/visa-oracle/*."""
+        from backend.middleware.rate_limiter import RateLimitMiddleware
+
+        rl = RateLimitMiddleware(app=MagicMock())
+        for path in (
+            "/api/visa/check/start",
+            "/api/visa/clock",
+            "/api/visa/match",
+            "/api/visa/clock/a1b2c3d4e5f6",
+            "/api/visa/match/a1b2c3d4e5f6",
+        ):
+            assert rl._get_rate_limit(path) == (120, 60)
+
+    @pytest.mark.asyncio
+    async def test_anonymous_post_passes_dispatch_without_csrf(self, middleware):
+        """CSRF posture: validate_csrf() is only invoked inside the cookie-JWT
+        branch of authenticate_request, which dispatch() never reaches for
+        registered-public paths (Step 1 short-circuit). An anonymous POST with
+        no cookie and no X-CSRF-Token header must therefore pass the middleware.
+        """
+        from unittest.mock import AsyncMock
+
+        req = self._mock_request("/api/visa/match", method="POST")
+        req.headers = {}  # real dict: no cookies, no X-CSRF-Token, no user-agent
+        req.cookies = {}
+        response = MagicMock()
+        response.headers = {}
+        call_next = AsyncMock(return_value=response)
+
+        result = await middleware.dispatch(req, call_next)
+
+        call_next.assert_awaited_once()
+        assert result is response
+        assert result.headers["X-Auth-Type"] == "public"


### PR DESCRIPTION
## Root cause

The public Visa Check v1 funnel (`routers/visa_check.py`, mounted at `/api/visa`) has been dead in prod since 2026-04-25 (PR #108): the 5 routes were mounted but never registered in `backend/app/auth/public_endpoints.py`, so `HybridAuthMiddleware` (fail-closed) returns **401 `Authentication required`** to every anonymous call.

Live probes (2026-07-23):
- `GET` + `POST /api/visa/match` → 401
- `POST /api/visa/clock` → 401
- `GET /api/visa/match/{hash}` → 401

The mouth frontend proxies all `/api/*` to the Fly backend via a catch-all, so the fix is purely backend.

## Change (purely additive, 158 insertions, 0 deletions)

`apps/backend-rag/backend/app/auth/public_endpoints.py` — registers the 5 visa_check routes under `Category.VISA_ORACLE` (same family/precedent as `/api/v1/visa-oracle/recommend`), with **exact/template matches only — no blanket `/api/visa/` prefix**:

| Path | Match | Why |
|---|---|---|
| `POST /api/visa/check/start` | exact | branch selector, nothing persisted |
| `POST /api/visa/clock` | exact | anonymous Clock submission, no PII |
| `POST /api/visa/match` | exact | anonymous Match submission, no PII |
| `GET /api/visa/clock/{hash}` | template | shareable result page — the hash IS the access token |
| `GET /api/visa/match/{hash}` | template | shareable result page — the hash IS the access token |

Nothing else touched: no router, middleware, rate-limiter, or service changes. `services/visa_engine/**` untouched (owned by another lane).

`apps/backend-rag/backend/tests/security/test_mutating_routes_are_gated.py` — the pre-push full suite surfaced the `test_every_public_mutating_route_is_accounted_for` security gate (1 failure of ~17k tests): the 3 new public POST routes must be declared. Added to `INTENTIONALLY_PUBLIC_MUTATIONS` (reviewed-safe allowlist) with reviewed reasons, in the anonymous-quiz section next to the visa-oracle rows. The 2 GET result routes are non-mutating and need no row.

## CSRF posture (verified, no wiring needed)

`validate_csrf()` is only invoked inside the cookie-JWT branch of `authenticate_request` (`hybrid_auth.py:432`). `dispatch()` short-circuits registered-public paths at Step 1 and never reaches it — identical to how the existing anonymous POST `/api/v1/visa-oracle/recommend` works. A new dispatch-level test proves an anonymous POST with no cookie and no `X-CSRF-Token` header passes the middleware.

## Rate limit

Unchanged, by design: anonymous traffic is limited per-IP by `RateLimitMiddleware` via the generic `/api/` bucket (120 req/min) — the same class as `/api/v1/visa-oracle/*` and `/api/lead/capture` (the other anonymous DB-writing funnel POST). A test pins this class. Tightening to a dedicated funnel-write bucket is a deliberate follow-up decision (see below), not part of this minimal hotfix.

## Tests added (`test_public_endpoints_registry.py`, new class `TestVisaCheckPublicRegistration`)

- **Guilt:** all 5 paths resolve as public via `HybridAuthMiddleware.is_public_endpoint`.
- **Innocence:** `/api/visaevil/match`, `/api/visa`, `/api/visa/`, `/api/visa/clockadmin`, `/api/visa/match/abc/def`, `/api/visa/unknown` are NOT public.
- Entries are exact/template (no blanket prefix), category `visa_oracle`.
- Rate-limit class pinned to `(120, 60)` via the `/api/` bucket.
- Dispatch-level CSRF proof (anonymous POST passes without CSRF token).
- Existing B2 drift test (`test_every_entry_resolves`) passes — all 5 entries resolve to mounted FastAPI routes.

## Verification

- `pytest backend/tests/unit/middleware/test_public_endpoints_registry.py backend/tests/unit/middleware/test_hybrid_auth.py backend/tests/unit/middleware/test_rate_limiter_middleware.py backend/tests/services/visa_check/` → **123 passed**
- `pytest backend/tests/security/test_mutating_routes_are_gated.py` → **11 passed**
- **Full pre-push suite** (`pytest backend/tests/ --ignore=backend/tests/e2e`, CI-parity env against a cloned test DB): first run 1 failed / rest passed — the mutating-routes security gate above; fixed by the `INTENTIONALLY_PUBLIC_MUTATIONS` rows; the push-time hook re-runs the full suite as the final gate.
- `ruff check` on all changed files → clean. Pre-commit hooks (anti-reward-hacking, secrets, import chain) → all passed.
- `ruff format --check` fails on the changed files **identically on `main`** (pre-existing drift, verified via `git show main:...`); the unrelated reformat hunks were reverted to keep this diff purely additive.
- `mypy`: not runnable — module not installed in `apps/backend-rag/.venv` (did not install packages to keep the env untouched).
- Independent `codex exec` review: **FIX-FIRST** with 3 findings, all assessed as pre-existing/systemic or precedent-consistent, none introduced by this diff:
  1. *Rate-limiter keys on raw path → per-hash buckets + hash in logs/metric labels.* Pre-existing for **all** templated public paths (incl. `/api/auth/verify-magic/{token}`, portal invite tokens) — a systemic `rate_limiter.py`/`hybrid_auth.py` change, out of scope for a minimal hotfix. Worth a dedicated follow-up PR (normalize limiter key to route template, redact tokens from labels).
  2. *Anonymous writes at 120/min.* Matches the established class for anonymous funnel writes (`/api/lead/capture`, `/api/v1/visa-oracle/recommend`). Follow-up candidate: dedicated shared funnel-write bucket.
  3. *Tests bless config, not enforcement.* Partially addressed here (dispatch-level CSRF test; 429 enforcement already covered by `test_rate_limiter_middleware.py`). Method-blindness of the registry is a schema-level change, out of scope.
  - Codex explicitly confirmed: **no auth-weakening, no sibling-path exposure, no CSRF regression** in this diff.

## NOT verified

- Live prod behavior post-deploy (deploy is CI/Claude-session gated, not done by this lane).
- mypy type check (module unavailable in venv).
- End-to-end funnel from balizero.com through the mouth proxy.

🤖 Generated with Kimi Code (lane W0a, Visa Oracle v2)
