### PR TITLE
fix(mouth): render disclaimer on NEEDS_INPUT + PII-free submit-failure telemetry

### DIFF
--- a/apps/backend-rag/backend/app/routers/analytics.py
+++ b/apps/backend-rag/backend/app/routers/analytics.py
@@ -117,6 +117,7 @@ FUNNEL_APP_EVENTS: frozenset[str] = frozenset(
         "app_branch_selected",
         "app_form_started",
         "app_form_submitted",
+        "app_form_submit_failed",
         "app_wizard_step_completed",
         "app_wizard_abandoned",
         "app_result_viewed",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/react";
+import { OutcomeSheet } from "./OutcomeSheet";
+import type { EvaluatedCandidate, EvaluateResult } from "../_lib/mock-engine";
+import type { Language } from "../_lib/flow";
+
+/**
+ * W0b regression guard (2026-07-23): the shared footer — WhatsApp escape
+ * hatch, print/copy, assumptions receipt and the 4-line Ditjen disclaimer —
+ * was wrapped in `result.state !== "NEEDS_INPUT"`, so the NEEDS_INPUT
+ * terminal state rendered with no disclaimer and no way out (spec §A.3.2:
+ * "the escape hatch is always present", never a dead end; §A.9: the 4-line
+ * disclaimer is KEEP-verbatim under every verdict). These tests pin the
+ * disclaimer + footer on ALL five terminal states, in both languages, and
+ * the print anatomy (recap + disclaimer print; CTAs stay screen-only).
+ */
+
+const TODAY = new Date("2026-07-23T12:00:00Z");
+
+const FACTS = { in_indonesia: "yes", category: "tourism" };
+
+const DISCLAIMER_EN = [
+  "This is a private decision-support demonstration, not a government service.",
+  "The result reflects only the facts you entered and the cited sample ruleset above.",
+  "It is not an approval, a guarantee, or a filing.",
+  "Complex or flagged cases always go to a human — Ditjen Imigrasi decides, not this tool.",
+];
+
+const DISCLAIMER_ID = [
+  "Ini demonstrasi alat bantu keputusan privat, bukan layanan pemerintah.",
+  "Hasil ini hanya mencerminkan data yang Anda masukkan dan aturan contoh yang dikutip di atas.",
+  "Ini bukan persetujuan, jaminan, atau pengajuan resmi.",
+  "Kasus kompleks atau ditandai selalu diteruskan ke manusia — Ditjen Imigrasi yang memutuskan, bukan alat ini.",
+];
+
+const CANDIDATE: EvaluatedCandidate = {
+  code: "B1",
+  nameI18nKey: "visa.B1.name",
+  taglineI18nKey: "visa.B1.tagline",
+  allInclusivePriceIDR: 500000,
+  timelineDays: [3, 7],
+  eligibility: "eligible",
+  requirementI18nKeys: ["req.passport_valid"],
+  categories: ["tourism"],
+};
+
+function resultFor(state: EvaluateResult["state"]): EvaluateResult {
+  const base: EvaluateResult = {
+    state,
+    candidates: [],
+    assumptions: [{ questionId: "tourism_duration" }],
+    pathsRemaining: 0,
+  };
+  if (state === "SUPPORTED_CANDIDATES") {
+    return { ...base, candidates: [CANDIDATE], pathsRemaining: 1 };
+  }
+  if (state === "NO_SUPPORTED_PATH") {
+    return { ...base, alternativeCategories: ["remote", "business", "other"] };
+  }
+  return base;
+}
+
+const ALL_STATES: EvaluateResult["state"][] = [
+  "SUPPORTED_CANDIDATES",
+  "NEEDS_INPUT",
+  "HUMAN_REVIEW_REQUIRED",
+  "NO_SUPPORTED_PATH",
+  "TEMPORARILY_UNAVAILABLE",
+];
+
+function renderSheet(
+  state: EvaluateResult["state"],
+  language: Language = "en",
+) {
+  return render(
+    <OutcomeSheet
+      language={language}
+      result={resultFor(state)}
+      facts={FACTS}
+      today={TODAY}
+    />,
+  );
+}
+
+describe("OutcomeSheet — shared footer on every terminal state (W0b)", () => {
+  it.each(ALL_STATES)(
+    "renders the 4-line disclaimer on %s (EN, verbatim)",
+    (state) => {
+      const { container } = renderSheet(state);
+      const disclaimer = container.querySelector(".oracle-disclaimer");
+      expect(disclaimer).not.toBeNull();
+      for (const line of DISCLAIMER_EN) {
+        expect(disclaimer).toHaveTextContent(line);
+      }
+    },
+  );
+
+  it.each(ALL_STATES)(
+    "renders the 4-line disclaimer on %s in Indonesian (EN/ID parity)",
+    (state) => {
+      const { container } = renderSheet(state, "id");
+      const disclaimer = container.querySelector(".oracle-disclaimer");
+      expect(disclaimer).not.toBeNull();
+      for (const line of DISCLAIMER_ID) {
+        expect(disclaimer).toHaveTextContent(line);
+      }
+    },
+  );
+
+  it("NEEDS_INPUT keeps the escape hatch + receipt + print/copy (never a dead end)", () => {
+    const { container } = renderSheet("NEEDS_INPUT");
+    // §A.3.2: "Talk to an adviser instead" is always present.
+    const cta = screen.getByRole("link", { name: /continue on whatsapp/i });
+    expect(cta.getAttribute("href")).toContain("wa.me/");
+    // Assumptions receipt + freshness stamp are the honesty anchor of an
+    // abstention state — they must render here too.
+    expect(
+      screen.getByText("Assumptions & caveats, dated"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Sample ruleset 2026\.07-prototype/),
+    ).toBeInTheDocument();
+    // Print + copy controls stay available.
+    expect(
+      screen.getByRole("button", { name: /print \/ save as pdf/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /copy summary/i }),
+    ).toBeInTheDocument();
+    // QR encodes byte-identically the visible WhatsApp link (existing
+    // invariant — must hold on NEEDS_INPUT too).
+    const qr = container.querySelector("[data-qr-value]");
+    expect(qr?.getAttribute("data-qr-value")).toBe(cta.getAttribute("href"));
+  });
+
+  it("gates the candidate-referencing next-steps copy on NEEDS_INPUT", () => {
+    // "Gather the documents listed above" points at a checklist that exists
+    // only when candidates exist — rendering it on NEEDS_INPUT would dangle.
+    renderSheet("NEEDS_INPUT");
+    expect(screen.queryByText("Your next 3 steps")).not.toBeInTheDocument();
+  });
+
+  it("keeps next-steps on SUPPORTED_CANDIDATES (checklist present)", () => {
+    // Only this state is pinned: the default step copy ("documents listed
+    // above") is unambiguously correct here. Visibility on the other three
+    // states is pre-existing main behavior, deliberately left untouched by
+    // W0b (flagged for content review — step 2 dangles where no checklist
+    // renders).
+    renderSheet("SUPPORTED_CANDIDATES");
+    expect(screen.getByText("Your next 3 steps")).toBeInTheDocument();
+  });
+
+  it("print anatomy on NEEDS_INPUT: answers recap + disclaimer print, CTAs stay screen-only", () => {
+    const { container } = renderSheet("NEEDS_INPUT");
+    // The print-only "your answers" recap renders (facts were answered).
+    expect(container.querySelector(".oracle-print-only")).not.toBeNull();
+    // Disclaimer + receipt are NOT hidden from print…
+    expect(
+      container.querySelector(".oracle-disclaimer.oracle-no-print"),
+    ).toBeNull();
+    expect(
+      container.querySelector(".oracle-receipt.oracle-no-print"),
+    ).toBeNull();
+    // …while the interactive CTAs/actions are.
+    expect(
+      container.querySelector(".oracle-whatsapp-cta")?.closest("section"),
+    ).toHaveClass("oracle-no-print");
+    expect(container.querySelector(".oracle-outcome-actions")).toHaveClass(
+      "oracle-no-print",
+    );
+  });
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
@@ -452,134 +452,141 @@ export function OutcomeSheet({
         </>
       )}
 
+      {/* W0b (legal-disclaimer fix, 2026-07-23): only the next-3-steps
+          section stays gated — its copy ("Gather the documents listed
+          above") references the candidate checklist, which exists only
+          when candidates exist. Everything below renders on ALL FIVE
+          terminal states, NEEDS_INPUT included: spec §A.3.2 makes
+          NEEDS_INPUT a first-class terminal legal-advice state whose
+          escape hatch "is always present" and which must never render as
+          a dead end, and the 4-line disclaimer (KEEP verbatim, spec §A.9)
+          is the legal floor under every verdict. Previously this guard
+          wrapped the whole footer, so NEEDS_INPUT rendered with no
+          WhatsApp handoff, no assumptions receipt, no print/copy and no
+          disclaimer at all. */}
       {result.state !== "NEEDS_INPUT" && (
-        <>
-          <section>
-            <h2 className="oracle-outcome__section-title">
-              {translate(language, "outcome.next_steps_title")}
-            </h2>
-            <ol className="oracle-next-steps">
-              {[1, 2, 3].map((n) => (
-                <li key={n}>
-                  <span className="oracle-next-steps__index oracle-tabular-nums">
-                    {n}
-                  </span>
-                  <span>
-                    {translate(
-                      language,
-                      `outcome.next_steps.default.${n}` as I18nKey,
-                    )}
-                  </span>
-                </li>
-              ))}
-            </ol>
-          </section>
-
-          <section
-            className="oracle-no-print"
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "var(--space-4)",
-              alignItems: "center",
-            }}
-          >
-            <a
-              className="oracle-whatsapp-cta"
-              href={whatsappUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <MessageCircle aria-hidden="true" size={18} />
-              {translate(language, "outcome.whatsapp_cta")}
-            </a>
-            {/* Item 3: a real, scannable QR encoding the exact same
-                pre-loaded wa.me URL as the link beside it — the link
-                itself is the text alternative (never aria-hidden). */}
-            <OracleQrCode
-              value={whatsappUrl}
-              label={translate(language, "outcome.qr_aria" as I18nKey)}
-            />
-          </section>
-
-          <section className="oracle-outcome-actions oracle-no-print">
-            <button
-              type="button"
-              className="oracle-print-cta"
-              onClick={() => window.print()}
-            >
-              <Printer aria-hidden="true" size={18} />
-              {translate(language, "outcome.print_cta" as I18nKey)}
-            </button>
-            <button
-              type="button"
-              className="oracle-copy-cta"
-              data-copy-state={copyState}
-              onClick={handleCopySummary}
-            >
-              {copyState === "copied" ? (
-                <Check aria-hidden="true" size={18} />
-              ) : copyState === "failed" ? (
-                <CircleAlert aria-hidden="true" size={18} />
-              ) : (
-                <Copy aria-hidden="true" size={18} />
-              )}
-              {translate(
-                language,
-                copyState === "copied"
-                  ? ("outcome.copy_confirmed" as I18nKey)
-                  : copyState === "failed"
-                    ? ("outcome.copy_failed" as I18nKey)
-                    : ("outcome.copy_cta" as I18nKey),
-              )}
-            </button>
-            <span role="status" aria-live="polite" className="oracle-sr-only">
-              {copyState === "copied"
-                ? translate(language, "outcome.copy_confirmed" as I18nKey)
-                : copyState === "failed"
-                  ? translate(language, "outcome.copy_failed" as I18nKey)
-                  : ""}
-            </span>
-          </section>
-
-          <section className="oracle-receipt">
-            <h2
-              className="oracle-outcome__section-title"
-              style={{ marginBottom: 0 }}
-            >
-              {translate(language, "outcome.assumptions_receipt_title")}
-            </h2>
-            {result.assumptions.length === 0 ? (
-              <p style={{ margin: 0 }}>
-                {translate(language, "outcome.assumptions_receipt_empty")}
-              </p>
-            ) : (
-              <ul style={{ margin: 0, paddingLeft: "1.1rem" }}>
-                {result.assumptions.map((a: Assumption) => (
-                  <li key={a.questionId}>
-                    {translate(
-                      language,
-                      `assumption.${a.questionId}` as I18nKey,
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-            <p className="oracle-tabular-nums" style={{ margin: 0 }}>
-              {translate(language, "outcome.freshness_stamp", {
-                date: freshnessDate,
-              })}
-            </p>
-          </section>
-
-          <section className="oracle-disclaimer">
-            <p>{translate(language, "outcome.disclaimer.not_government")}</p>
-            <p>{translate(language, "outcome.disclaimer.based_on_facts")}</p>
-            <p>{translate(language, "outcome.disclaimer.not_approval")}</p>
-            <p>{translate(language, "outcome.disclaimer.complex_to_human")}</p>
-          </section>
-        </>
+        <section>
+          <h2 className="oracle-outcome__section-title">
+            {translate(language, "outcome.next_steps_title")}
+          </h2>
+          <ol className="oracle-next-steps">
+            {[1, 2, 3].map((n) => (
+              <li key={n}>
+                <span className="oracle-next-steps__index oracle-tabular-nums">
+                  {n}
+                </span>
+                <span>
+                  {translate(
+                    language,
+                    `outcome.next_steps.default.${n}` as I18nKey,
+                  )}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
       )}
+
+      <section
+        className="oracle-no-print"
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "var(--space-4)",
+          alignItems: "center",
+        }}
+      >
+        <a
+          className="oracle-whatsapp-cta"
+          href={whatsappUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <MessageCircle aria-hidden="true" size={18} />
+          {translate(language, "outcome.whatsapp_cta")}
+        </a>
+        {/* Item 3: a real, scannable QR encoding the exact same
+            pre-loaded wa.me URL as the link beside it — the link
+            itself is the text alternative (never aria-hidden). */}
+        <OracleQrCode
+          value={whatsappUrl}
+          label={translate(language, "outcome.qr_aria" as I18nKey)}
+        />
+      </section>
+
+      <section className="oracle-outcome-actions oracle-no-print">
+        <button
+          type="button"
+          className="oracle-print-cta"
+          onClick={() => window.print()}
+        >
+          <Printer aria-hidden="true" size={18} />
+          {translate(language, "outcome.print_cta" as I18nKey)}
+        </button>
+        <button
+          type="button"
+          className="oracle-copy-cta"
+          data-copy-state={copyState}
+          onClick={handleCopySummary}
+        >
+          {copyState === "copied" ? (
+            <Check aria-hidden="true" size={18} />
+          ) : copyState === "failed" ? (
+            <CircleAlert aria-hidden="true" size={18} />
+          ) : (
+            <Copy aria-hidden="true" size={18} />
+          )}
+          {translate(
+            language,
+            copyState === "copied"
+              ? ("outcome.copy_confirmed" as I18nKey)
+              : copyState === "failed"
+                ? ("outcome.copy_failed" as I18nKey)
+                : ("outcome.copy_cta" as I18nKey),
+          )}
+        </button>
+        <span role="status" aria-live="polite" className="oracle-sr-only">
+          {copyState === "copied"
+            ? translate(language, "outcome.copy_confirmed" as I18nKey)
+            : copyState === "failed"
+              ? translate(language, "outcome.copy_failed" as I18nKey)
+              : ""}
+        </span>
+      </section>
+
+      <section className="oracle-receipt">
+        <h2
+          className="oracle-outcome__section-title"
+          style={{ marginBottom: 0 }}
+        >
+          {translate(language, "outcome.assumptions_receipt_title")}
+        </h2>
+        {result.assumptions.length === 0 ? (
+          <p style={{ margin: 0 }}>
+            {translate(language, "outcome.assumptions_receipt_empty")}
+          </p>
+        ) : (
+          <ul style={{ margin: 0, paddingLeft: "1.1rem" }}>
+            {result.assumptions.map((a: Assumption) => (
+              <li key={a.questionId}>
+                {translate(language, `assumption.${a.questionId}` as I18nKey)}
+              </li>
+            ))}
+          </ul>
+        )}
+        <p className="oracle-tabular-nums" style={{ margin: 0 }}>
+          {translate(language, "outcome.freshness_stamp", {
+            date: freshnessDate,
+          })}
+        </p>
+      </section>
+
+      <section className="oracle-disclaimer">
+        <p>{translate(language, "outcome.disclaimer.not_government")}</p>
+        <p>{translate(language, "outcome.disclaimer.based_on_facts")}</p>
+        <p>{translate(language, "outcome.disclaimer.not_approval")}</p>
+        <p>{translate(language, "outcome.disclaimer.complex_to_human")}</p>
+      </section>
     </div>
   );
 }

--- a/apps/mouth/src/app/visa/clock/page.test.tsx
+++ b/apps/mouth/src/app/visa/clock/page.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import VisaClockPage from "./page";
+
+/**
+ * W0b telemetry regression guard (2026-07-23): same silent-death pattern
+ * as visa/match — submit failure was swallowed into `setError` with no
+ * event. Failure telemetry carries endpoint + status only, never the
+ * visa type / entry date (Law 2).
+ */
+
+const trackerMocks = vi.hoisted(() => ({
+  formStarted: vi.fn(),
+  formSubmitted: vi.fn(),
+  formSubmitFailed: vi.fn(),
+}));
+
+vi.mock("@balizero/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@balizero/core")>();
+  return {
+    ...actual,
+    useFunnelApp: () => ({
+      viewed: vi.fn(),
+      formStarted: trackerMocks.formStarted,
+      formSubmitted: trackerMocks.formSubmitted,
+      formSubmitFailed: trackerMocks.formSubmitFailed,
+    }),
+  };
+});
+
+const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+
+function fillAndSubmit() {
+  fireEvent.change(screen.getByLabelText("Entry date"), {
+    target: { value: "2026-07-01" },
+  });
+  fireEvent.change(screen.getByLabelText("Visa type"), {
+    target: { value: "B1" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Show my timeline" }));
+}
+
+describe("VisaClockPage — submit telemetry (W0b)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+  });
+
+  it("HTTP error fires app_form_submit_failed with status, payload-free", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+    render(<VisaClockPage />);
+    fillAndSubmit();
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /could not build your timeline/i,
+      ),
+    );
+    expect(trackerMocks.formSubmitted).toHaveBeenCalledWith([
+      "visa_type",
+      "entry_date",
+    ]);
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledTimes(1);
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+      "/api/visa/clock",
+      503,
+    );
+    // Law 2: no form values in the failure event.
+    const emitted = JSON.stringify(trackerMocks.formSubmitFailed.mock.calls);
+    expect(emitted).not.toContain("2026-07-01");
+    expect(emitted).not.toContain("B1");
+  });
+
+  it("network failure (fetch rejects) fires the event with status null", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    render(<VisaClockPage />);
+    fillAndSubmit();
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+      "/api/visa/clock",
+      null,
+    );
+  });
+
+  it("2xx with an unparseable body reports the HTTP status, not null", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    });
+    render(<VisaClockPage />);
+    fillAndSubmit();
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+      "/api/visa/clock",
+      200,
+    );
+  });
+
+  it("successful submit fires no failure event", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ hash: "xyz789" }),
+    });
+    render(<VisaClockPage />);
+    fillAndSubmit();
+
+    await waitFor(() => expect(trackerMocks.formSubmitted).toHaveBeenCalled());
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(trackerMocks.formSubmitFailed).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/app/visa/clock/page.tsx
+++ b/apps/mouth/src/app/visa/clock/page.tsx
@@ -52,6 +52,10 @@ export default function VisaClockPage() {
     setPending(true);
     setError(null);
     tracker.formSubmitted(["visa_type", "entry_date"]);
+    // Same silent-death fix as visa/match: capture the HTTP status so the
+    // failure event can carry it — endpoint + status only, never the
+    // visa type / entry date values (Law 2).
+    let status: number | null = null;
     try {
       const res = await fetch("/api/visa/clock", {
         method: "POST",
@@ -62,10 +66,16 @@ export default function VisaClockPage() {
           in_country_now: true,
         }),
       });
-      if (!res.ok) throw new Error(`${res.status}`);
+      // Status recorded for ANY completed response — a 2xx whose JSON
+      // parse fails must not be misreported as a network failure (null).
+      status = res.status;
+      if (!res.ok) {
+        throw new Error(`${res.status}`);
+      }
       const { hash } = (await res.json()) as { hash: string };
       router.push(`/visa/clock/${hash}`);
     } catch {
+      tracker.formSubmitFailed("/api/visa/clock", status);
       setError("Could not build your timeline. Please try again.");
       setPending(false);
     }

--- a/apps/mouth/src/app/visa/match/page.test.tsx
+++ b/apps/mouth/src/app/visa/match/page.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import VisaMatchPage from "./page";
+
+/**
+ * W0b telemetry regression guard (2026-07-23): the v1 visa funnel died
+ * silently for 3 months because submit failure was swallowed into
+ * `setSubmitError` with no event — wizard-starts vs successful submissions
+ * were unmeasurable. These tests pin: attempt fires `formSubmitted`,
+ * failure fires `formSubmitFailed(endpoint, status)` — and the failure
+ * event NEVER carries form values (Law 2: no nationality/purpose/budget
+ * in analytics).
+ */
+
+const trackerMocks = vi.hoisted(() => ({
+  formStarted: vi.fn(),
+  formSubmitted: vi.fn(),
+  formSubmitFailed: vi.fn(),
+}));
+
+vi.mock("@balizero/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@balizero/core")>();
+  return {
+    ...actual,
+    useFunnelApp: () => ({
+      viewed: vi.fn(),
+      formStarted: trackerMocks.formStarted,
+      formSubmitted: trackerMocks.formSubmitted,
+      formSubmitFailed: trackerMocks.formSubmitFailed,
+      wizardStep: vi.fn(),
+      wizardAbandoned: vi.fn(),
+    }),
+  };
+});
+
+const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+
+/** Drive the real AppWizard through all 4 steps to the submit. */
+function completeWizard() {
+  fireEvent.change(screen.getByLabelText("Nationality"), {
+    target: { value: "ITA" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Next" }));
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: "Work remotely for a foreign employer",
+    }),
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Next" }));
+  // Duration has no validation gate — default 6 months stands.
+  fireEvent.click(screen.getByRole("button", { name: "Next" }));
+  fireEvent.click(screen.getByRole("button", { name: "Under IDR 50M" }));
+  fireEvent.click(screen.getByRole("button", { name: "See result" }));
+}
+
+describe("VisaMatchPage — submit telemetry (W0b)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    fetchMock.mockReset();
+  });
+
+  it("HTTP error fires app_form_submit_failed with status, payload-free", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    render(<VisaMatchPage />);
+    completeWizard();
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /could not compute a recommendation/i,
+      ),
+    );
+    expect(trackerMocks.formSubmitted).toHaveBeenCalledWith([
+      "nationality",
+      "purpose",
+      "budget",
+    ]);
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledTimes(1);
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+      "/api/visa/match",
+      500,
+    );
+    // Law 2: the failure event must not become a PII channel.
+    const emitted = JSON.stringify(trackerMocks.formSubmitFailed.mock.calls);
+    expect(emitted).not.toContain("ITA");
+    expect(emitted).not.toContain("work_remote");
+    expect(emitted).not.toContain("under_50m");
+  });
+
+  it("network failure (fetch rejects) fires the event with status null", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    render(<VisaMatchPage />);
+    completeWizard();
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+      "/api/visa/match",
+      null,
+    );
+  });
+
+  it("2xx with an unparseable body reports the HTTP status, not null", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    });
+    render(<VisaMatchPage />);
+    completeWizard();
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+      "/api/visa/match",
+      200,
+    );
+  });
+
+  it("successful submit fires no failure event and no error UI", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ hash: "abc123" }),
+    });
+    render(<VisaMatchPage />);
+    completeWizard();
+
+    await waitFor(() => expect(trackerMocks.formSubmitted).toHaveBeenCalled());
+    // Let the router.push microtask flush.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(trackerMocks.formSubmitFailed).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/app/visa/match/page.tsx
+++ b/apps/mouth/src/app/visa/match/page.tsx
@@ -251,6 +251,11 @@ export default function VisaMatchPage() {
   const onComplete = async (values: Record<string, unknown>) => {
     setSubmitError(null);
     tracker.formSubmitted(Object.keys(values));
+    // HTTP status captured OUTSIDE the catch so the failure telemetry can
+    // report it — the swallowed `setSubmitError` below was the v1 funnel's
+    // silent-death hole (3 months unmeasured). Law 2: the failure event
+    // carries endpoint + status only, never the form values.
+    let status: number | null = null;
     try {
       const res = await fetch("/api/visa/match", {
         method: "POST",
@@ -262,10 +267,16 @@ export default function VisaMatchPage() {
           budget_band: String(values.budget ?? ""),
         }),
       });
-      if (!res.ok) throw new Error(`${res.status}`);
+      // Status recorded for ANY completed response — a 2xx whose JSON
+      // parse fails must not be misreported as a network failure (null).
+      status = res.status;
+      if (!res.ok) {
+        throw new Error(`${res.status}`);
+      }
       const { hash } = (await res.json()) as { hash: string };
       router.push(`/visa/match/${hash}`);
     } catch {
+      tracker.formSubmitFailed("/api/visa/match", status);
       setSubmitError(
         <>
           We could not compute a recommendation. Please try again or{" "}

--- a/apps/mouth/src/lib/funnel-app-events.test.ts
+++ b/apps/mouth/src/lib/funnel-app-events.test.ts
@@ -1,0 +1,59 @@
+import { APP_EVENTS, createFunnelAppTracker } from "@balizero/core/analytics";
+
+/**
+ * CI enforcement (W0b, 2026-07-23): the module-local copy of these
+ * assertions lives in packages/core/analytics/funnel-app.test.ts, but the
+ * CI frontend matrix only runs apps/mouth's vitest (include: `src/**`) —
+ * packages/core has no CI job and its own vitest config cannot resolve
+ * `@vitejs/plugin-react` (pre-existing). This file makes the Law-2 payload
+ * shape of `app_form_submit_failed` enforced where CI actually runs, via
+ * the same `@balizero/core/analytics` alias the pages import.
+ */
+
+const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+
+describe("app_form_submit_failed — Law 2 payload shape (CI guard)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("gtag", vi.fn());
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true });
+    document.cookie = "bz_session=; Max-Age=0; path=/";
+  });
+
+  it("is registered in APP_EVENTS (backend allowlist parity anchor)", () => {
+    // The backend FUNNEL_APP_EVENTS frozenset mirrors APP_EVENTS — enforced
+    // bidirectionally by test_analytics_funnel_parity.py.
+    expect(APP_EVENTS).toContain("app_form_submit_failed");
+  });
+
+  it("emits exactly {type, app, endpoint, status} — nothing else", async () => {
+    const tracker = createFunnelAppTracker("visa_match");
+    await tracker.formSubmitFailed("/api/visa/match", 503);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.event).toBe("app_form_submit_failed");
+    expect(body.payload).toEqual({
+      type: "app_form_submit_failed",
+      app: "visa_match",
+      endpoint: "/api/visa/match",
+      status: 503,
+    });
+    // Law 2 canaries: nothing that resembles an answer value may appear
+    // anywhere in the serialized request (payload, session, or hostname).
+    const wire = (init as RequestInit).body as string;
+    expect(wire).not.toContain("ITA");
+    expect(wire).not.toContain("nationality");
+    expect(wire).not.toContain("2026-07-01");
+  });
+
+  it("network-failure status is null (distinct from any HTTP status)", async () => {
+    const tracker = createFunnelAppTracker("visa_clock");
+    await tracker.formSubmitFailed("/api/visa/clock", null);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.payload.status).toBeNull();
+  });
+});

--- a/packages/core/analytics/funnel-app.test.ts
+++ b/packages/core/analytics/funnel-app.test.ts
@@ -61,6 +61,7 @@ describe("funnel-app", () => {
     await tracker.branchSelected("pma");
     await tracker.formStarted("sector");
     await tracker.formSubmitted(["sector"]);
+    await tracker.formSubmitFailed("/api/kbli/decode", 500);
     await tracker.wizardStep(1, 3);
     await tracker.wizardAbandoned(2);
     await tracker.resultViewed("abc123");
@@ -80,5 +81,46 @@ describe("funnel-app", () => {
     expect(new Set(emitted)).toEqual(
       new Set(APP_EVENTS as readonly FunnelAppEvent["type"][]),
     );
+  });
+
+  it("app_form_submit_failed carries endpoint + status only — never form values", async () => {
+    // Law 2 / MYTHOS §6: the failure signal that closes the silent-funnel
+    // gap (v1 visa funnel died unmeasured for 3 months) must not become a
+    // PII channel — no nationality, no dates, no payload keys, no message
+    // text that could embed user input.
+    const tracker = createFunnelAppTracker("visa_match");
+    await tracker.formSubmitFailed("/api/visa/match", 503);
+    await tracker.formSubmitFailed("/api/visa/match", null);
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const payloads = fetchMock.mock.calls.map(
+      ([, init]) =>
+        (
+          JSON.parse((init as RequestInit).body as string) as {
+            payload: Record<string, unknown>;
+          }
+        ).payload,
+    );
+    expect(payloads[0]).toEqual({
+      type: "app_form_submit_failed",
+      app: "visa_match",
+      endpoint: "/api/visa/match",
+      status: 503,
+    });
+    expect(payloads[1]).toEqual({
+      type: "app_form_submit_failed",
+      app: "visa_match",
+      endpoint: "/api/visa/match",
+      status: null,
+    });
+    for (const payload of payloads) {
+      expect(Object.keys(payload).sort()).toEqual([
+        "app",
+        "endpoint",
+        "status",
+        "type",
+      ]);
+    }
   });
 });

--- a/packages/core/analytics/funnel-app.ts
+++ b/packages/core/analytics/funnel-app.ts
@@ -24,6 +24,7 @@ export const APP_EVENTS = [
   "app_branch_selected",
   "app_form_started",
   "app_form_submitted",
+  "app_form_submit_failed",
   "app_wizard_step_completed",
   "app_wizard_abandoned",
   "app_result_viewed",
@@ -44,6 +45,16 @@ export type FunnelAppEvent =
       type: "app_form_submitted";
       app: FunnelAppName;
       payload_keys: string[];
+    }
+  | {
+      /** Submit attempt FAILED (HTTP error or network failure). Law 2 /
+       * MYTHOS §6: carries ONLY the endpoint and the HTTP status — never
+       * form values (no nationality, no dates, no payload keys). `status`
+       * is null when fetch rejected before any response (network down). */
+      type: "app_form_submit_failed";
+      app: FunnelAppName;
+      endpoint: string;
+      status: number | null;
     }
   | {
       type: "app_wizard_step_completed";
@@ -156,6 +167,13 @@ export function createFunnelAppTracker(app: FunnelAppName) {
         type: "app_form_submitted",
         app,
         payload_keys: payloadKeys,
+      }),
+    formSubmitFailed: (endpoint: string, status: number | null) =>
+      emitFunnelAppEvent({
+        type: "app_form_submit_failed",
+        app,
+        endpoint,
+        status,
       }),
     wizardStep: (step: number, total: number) =>
       emitFunnelAppEvent({


### PR DESCRIPTION
## Root cause

Two verified defects on the live visa surfaces (lane W0b, Visa Oracle v2):

1. **Legal-disclaimer bug (Law-2-adjacent).** In `apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx` the guard `result.state !== "NEEDS_INPUT"` wrapped the *entire* shared footer — next steps, WhatsApp CTA + QR, print/copy, assumptions receipt AND the 4-line Ditjen disclaimer — so the NEEDS_INPUT terminal state rendered with no disclaimer and no escape hatch. In engine mode NEEDS_INPUT is a first-class terminal legal-advice state (binding spec `research/visa/2026-07-19-kimi-uiux-adaptation-spec.md` §A.3.2: *"the escape hatch is always present"*, *"never render NEEDS_INPUT as a dead end"*; §A.9: the 4-line disclaimer is KEEP-verbatim under every verdict).

2. **Telemetry gap.** The v1 funnel died silently for 3 months: `apps/mouth/src/app/visa/match/page.tsx` fires `tracker.formSubmitted(...)` on attempt and swallows submit failure into `setSubmitError` with no failure event — wizard-starts vs successful submissions were unmeasurable. `apps/mouth/src/app/visa/clock/page.tsx` had the identical swallow pattern.

## What changed

- **`OutcomeSheet.tsx`** — the `!== NEEDS_INPUT` guard now wraps ONLY the next-3-steps section (its copy — *"Gather the documents listed above"* — references the candidate checklist, which exists only when candidates exist; per-state step copy is a content decision outside this lane). The WhatsApp escape hatch + QR, print/copy actions, assumptions receipt + freshness stamp, and the verbatim 4-line disclaimer (EN/ID copy untouched — moved, not rewritten) now render on ALL five terminal states, NEEDS_INPUT included, screen and print.
- **`packages/core/analytics/funnel-app.ts`** — new `app_form_submit_failed` event (`{type, app, endpoint, status}` — endpoint + HTTP status ONLY; `status: null` when fetch rejected before any response; **never form values** — Law 2) + `tracker.formSubmitFailed(endpoint, status)`, following the module's existing naming conventions.
- **`apps/backend-rag/backend/app/routers/analytics.py`** — `FUNNEL_APP_EVENTS` allowlist mirror (parity enforced bidirectionally by `test_analytics_funnel_parity.py`; without it the event would 422-silently like the MYTHOS D11 defect).
- **`visa/match/page.tsx` + `visa/clock/page.tsx`** — the failure path now emits `formSubmitFailed(endpoint, status)`; `status` is captured for ANY completed response, so a 2xx with an unparseable JSON body reports `200`, not `null` (codex finding #2).

## Tests

- NEW `_components/OutcomeSheet.test.tsx` (14 tests): disclaimer renders verbatim on all 5 states in EN **and** ID; NEEDS_INPUT keeps the escape hatch / receipt / print-copy and the QR↔href byte-identity invariant; next-steps gated on NEEDS_INPUT; print anatomy (answers recap + disclaimer print; CTAs stay `oracle-no-print`).
- NEW `visa/match/page.test.tsx` + `visa/clock/page.test.tsx` (4 tests each, real AppWizard/AppHeroForm driven end-to-end): HTTP error → event with status + PII-canary assertions; network failure → `null`; 2xx + bad JSON → `200`; success → no failure event.
- NEW `src/lib/funnel-app-events.test.ts` (3 tests): Law-2 payload shape enforced where CI actually runs (codex finding #4 — packages/core has no CI job and its own vitest config can't resolve `@vitejs/plugin-react`, pre-existing on main).
- `packages/core/analytics/funnel-app.test.ts` — new helper added to the exhaustiveness test + exact-payload test (4 tests, local run green).

## Verification

- Focused vitest: **86/86 green** (incl. all 74 pre-existing visa-oracle tests; zero regressions).
- Backend: `test_analytics_funnel_parity.py` **6/6**; `test_analytics.py` green (data-driven off `ALLOWED_EVENTS`, now covers the new event end-to-end).
- `tsc --noEmit` clean; prettier clean; pre-commit hooks green (typecheck, ruff, off-limits guard, FastAPI import chain).

## Independent grade (codex exec, verdict FIX-FIRST) → disposition

1. **P1 "PII-free not enforced end-to-end"** — rejected with rationale: the event is a compile-time discriminated-union variant with constant-string endpoints at both callsites; free-string params are the existing taxonomy-wide convention (`cta_label`, `destination`, `branch`); exact payload shape is pinned by tests in both suites. Re-architecting the analytics taxonomy is out of a two-fix lane.
2. **P2 2xx parse error recorded as `null`** — FIXED (status assigned immediately after `fetch`; regression tests added in both page suites).
3. **P2 next-steps copy dangles on 3 other states** — PRE-EXISTING main behavior, untouched by mandate; the test no longer pins it. Flagged for content/owner review: step 2 (*"documents listed above"*) dangles on HUMAN_REVIEW_REQUIRED / NO_SUPPORTED_PATH / TEMPORARILY_UNAVAILABLE — needs a per-state copy decision (EN/ID), not an engineering drive-by.
4. **P2 payload-shape test not in CI** — FIXED (`src/lib/funnel-app-events.test.ts` runs in mouth's vitest = the CI path).

No a11y regressions found by the reviewer; none introduced (no aria/role changes; sections moved verbatim).

## Not verified

- `npm run lint` (eslint) crashes repo-wide on main too (eslint 10.3.0 vs eslint-plugin-react `getFilename` incompatibility — reproduces on untouched files on main): pre-existing environment issue; eslint could not be run on the changed files. typecheck + prettier + tests cover the gap as far as possible here.
- No e2e run (per lane instructions); e2e specs carry no assertions on the old NEEDS_INPUT empty-footer behavior (grepped).

No auto-merge, no merge — generator≠grader: a Claude session verifies and merges.
