### PR TITLE
fix(rag): contain cross-client memory bleed on shared internal identity (P0-MEM, W-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 327 routers · 657 services
+- Backend: FastAPI · 327 routers · 658 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 33 · Packages: 6

--- a/apps/backend-rag/backend/services/rag/agentic/_memory_identity.py
+++ b/apps/backend-rag/backend/services/rag/agentic/_memory_identity.py
@@ -1,0 +1,83 @@
+"""
+Single source of truth for "is this user_id a non-personal/shared memory identity?".
+
+WHY (P0-MEM, 2026-07-24)
+------------------------
+Path B (WhatsApp) authenticates every sender with a SHARED internal key.
+``hybrid_auth.py`` resolves that shared key to ONE fixed pseudo-identity —
+``user_id="wa-mirror-internal"``, ``email="wa-mirror-internal@balizero.com"`` —
+for EVERY WhatsApp sender (there is no per-phone identity resolution yet;
+that is a later W-1 item). ``agentic_rag.py`` substitutes this fixed
+pseudo-identity as the long-term memory ``user_id``.
+
+Long-term memory was keying on this ONE shared id at two chokepoints:
+
+  * WRITE — ``memory_handler.save_conversation_memory`` only skipped the
+    literal string ``"anonymous"``, so every WhatsApp client's facts were
+    saved under the shared bucket.
+  * READ  — ``context_manager.get_user_context`` fetched facts keyed on
+    ``user_id``, so the shared bucket was read back into ANY client's
+    context.
+
+Net effect: cross-client memory bleed (UU PDP violation) — client A's
+facts could surface in client B's WhatsApp conversation.
+
+This module makes "which identities are non-personal / shared-service,
+and therefore must never anchor long-term memory" EXPLICIT, NAMED, and
+TESTABLE, and is imported by both chokepoints so they can never drift
+out of sync again.
+
+Scope note: this is CONTAINMENT, not the full fix. It does not touch
+in-thread ``conversation_history`` (API-supplied per request, not keyed
+on this user_id — unaffected) and does not delete any existing shared
+facts already persisted under the shared id; it only stops them being
+read back, and stops new ones being written. The real fix — resolving
+each WhatsApp sender to a stable per-phone pseudonymous subject — is a
+later, separate W-1 item.
+"""
+
+from __future__ import annotations
+
+# Identities that must NEVER anchor long-term (cross-session) memory —
+# they represent either "no authenticated subject" (anonymous) or a
+# SHARED service/internal identity backing multiple real end-users
+# (wa-mirror-internal, in either bare or email form).
+NON_PERSONAL_MEMORY_IDS: frozenset[str] = frozenset(
+    {
+        "anonymous",
+        "wa-mirror-internal",
+        "wa-mirror-internal@balizero.com",
+    },
+)
+
+
+def is_non_personal_memory_identity(user_id: str | None) -> bool:
+    """
+    True if ``user_id`` must NOT be used to save or read long-term memory.
+
+    Covers:
+      - ``None`` or empty/whitespace-only strings (no real subject).
+      - Any identity in :data:`NON_PERSONAL_MEMORY_IDS`, matched
+        case-insensitively after stripping surrounding whitespace (e.g.
+        ``"WA-Mirror-Internal@BaliZero.com"`` still matches).
+
+    Does NOT do substring/prefix matching (guard-over-match family,
+    cicatrix #3) — ``"wa-mirror-internal2"`` or
+    ``"somewa-mirror-internal@balizero.com"`` are real, distinct
+    identifiers and correctly return ``False``.
+
+    Args:
+        user_id: User identifier (email, UUID, or shared-service id).
+            ``None``-safe.
+
+    Returns:
+        ``True`` if this identity must be excluded from long-term memory
+        save/read (anonymous or shared/service identity); ``False`` for a
+        real per-user identity.
+    """
+    if not user_id:
+        return True
+    normalized = user_id.strip().lower()
+    if not normalized:
+        return True
+    return normalized in NON_PERSONAL_MEMORY_IDS

--- a/apps/backend-rag/backend/services/rag/agentic/context_manager.py
+++ b/apps/backend-rag/backend/services/rag/agentic/context_manager.py
@@ -24,6 +24,7 @@ from typing import Any
 import asyncpg
 
 from backend.services.memory import MemoryOrchestrator, get_memory_cache
+from backend.services.rag.agentic._memory_identity import is_non_personal_memory_identity
 
 logger = logging.getLogger(__name__)
 
@@ -284,9 +285,13 @@ async def get_user_context(
     # Keep original user_id (email) for memory queries
     original_user_id = user_id
 
-    if not db_pool or not user_id or user_id == "anonymous":
+    # P0-MEM containment: treat the shared/service identity (e.g. the
+    # WhatsApp wa-mirror-internal pseudo-identity) exactly like
+    # "anonymous" — never fetch facts keyed on a bucket shared by many
+    # real clients. See is_non_personal_memory_identity docstring.
+    if not db_pool or is_non_personal_memory_identity(user_id):
         logger.debug(
-            "🧠 [ContextManager] DB Pool missing or user anonymous, returning empty context",
+            "🧠 [ContextManager] DB Pool missing or non-personal identity, returning empty context",
         )
         return context
 

--- a/apps/backend-rag/backend/services/rag/agentic/memory_handler.py
+++ b/apps/backend-rag/backend/services/rag/agentic/memory_handler.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING
 
 import asyncpg
 
+from backend.services.rag.agentic._memory_identity import is_non_personal_memory_identity
+
 if TYPE_CHECKING:
     from backend.app.metrics import MetricsCollector
     from backend.services.memory import MemoryOrchestrator
@@ -129,13 +131,16 @@ class MemoryHandler:
             metrics_collector: Optional metrics collector for recording lock contention
 
         Note:
-            - Skips anonymous users (user_id == "anonymous")
+            - Skips anonymous AND non-personal/shared-service identities
+              (see is_non_personal_memory_identity — P0-MEM containment:
+              the shared wa-mirror-internal WhatsApp identity must never
+              anchor long-term memory, same treatment as "anonymous")
             - Non-blocking: uses asyncio.create_task() in caller
             - Logs success metrics (facts extracted/saved, processing time)
             - Gracefully handles errors without failing the main flow
             - Lock timeout: configurable (default 5 seconds)
         """
-        if not user_id or user_id == "anonymous":
+        if is_non_personal_memory_identity(user_id):
             return
 
         # Evict unlocked entries when dict grows too large

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_memory_identity_containment.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_memory_identity_containment.py
@@ -1,0 +1,276 @@
+"""
+Containment tests for the shared/service-identity memory bleed (P0-MEM).
+
+Path B (WhatsApp) authenticates every sender via a SHARED internal key
+(``hybrid_auth.py``), which resolves to ONE fixed pseudo-identity
+(``wa-mirror-internal`` / ``wa-mirror-internal@balizero.com``) for every
+client. Before this fix that shared id was used as the long-term memory
+``user_id`` key on both the write side (``memory_handler.save_conversation_memory``)
+and the read side (``context_manager.get_user_context``) — so facts from
+ANY client were saved AND read back under one shared bucket, bleeding
+across clients (UU PDP violation).
+
+Containment: a single predicate, ``is_non_personal_memory_identity``,
+applied at both chokepoints so the shared identity is treated exactly
+like ``"anonymous"`` — no save, no read. In-thread ``conversation_history``
+(API-supplied, not keyed on this user_id) is untouched by this fix and is
+NOT covered here — see ``test_context_manager.py`` for that contract.
+
+GUILT = the shared identity must be blocked.
+INNOCENCE = real authenticated users must be unaffected (no regression).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.services.rag.agentic import context_manager as module
+from backend.services.rag.agentic._memory_identity import (
+    NON_PERSONAL_MEMORY_IDS,
+    is_non_personal_memory_identity,
+)
+from backend.services.rag.agentic.context_manager import get_user_context
+from backend.services.rag.agentic.memory_handler import MemoryHandler
+
+# ============================================================
+# Predicate contract — is_non_personal_memory_identity
+# ============================================================
+
+NON_PERSONAL_CASES = [
+    None,
+    "",
+    "   ",
+    "anonymous",
+    "Anonymous",
+    "ANONYMOUS",
+    "wa-mirror-internal",
+    "WA-Mirror-Internal",
+    "WA-MIRROR-INTERNAL",
+    "wa-mirror-internal@balizero.com",
+    "WA-Mirror-Internal@BaliZero.com",
+    "  wa-mirror-internal@balizero.com  ",
+]
+
+PERSONAL_CASES = [
+    "real.client@example.com",
+    "user@test.com",
+    "marco@example.com",
+    "wa-mirror-internal2",  # near-miss, must NOT match (no bare-substring trap)
+    "not-wa-mirror-internal",
+    "somewa-mirror-internal@balizero.com",
+]
+
+
+@pytest.mark.parametrize("value", NON_PERSONAL_CASES)
+def test_is_non_personal_memory_identity_true_cases(value: str | None) -> None:
+    assert is_non_personal_memory_identity(value) is True
+
+
+@pytest.mark.parametrize("value", PERSONAL_CASES)
+def test_is_non_personal_memory_identity_false_cases(value: str) -> None:
+    assert is_non_personal_memory_identity(value) is False
+
+
+def test_non_personal_memory_ids_contains_expected_identities() -> None:
+    assert NON_PERSONAL_MEMORY_IDS == frozenset(
+        {"anonymous", "wa-mirror-internal", "wa-mirror-internal@balizero.com"},
+    )
+
+
+# ============================================================
+# WRITE chokepoint — memory_handler.save_conversation_memory
+# ============================================================
+
+
+@dataclass
+class FakeProcessResult:
+    success: bool = True
+    facts_extracted: int = 1
+    facts_saved: int = 1
+    processing_time_ms: float = 1.0
+
+
+@pytest.fixture
+def handler() -> MemoryHandler:
+    return MemoryHandler(db_pool=MagicMock())
+
+
+@pytest.fixture
+def mock_orchestrator() -> AsyncMock:
+    orch = AsyncMock()
+    orch.process_conversation = AsyncMock(return_value=FakeProcessResult())
+    return orch
+
+
+@pytest.mark.asyncio
+async def test_save_guilt_shared_identity_email(
+    handler: MemoryHandler,
+    mock_orchestrator: AsyncMock,
+) -> None:
+    """GUILT: the shared wa-mirror-internal EMAIL form must never persist facts."""
+    handler._memory_orchestrator = mock_orchestrator
+    await handler.save_conversation_memory(
+        user_id="wa-mirror-internal@balizero.com",
+        query="q",
+        answer="a",
+    )
+    mock_orchestrator.process_conversation.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_guilt_shared_identity_bare(
+    handler: MemoryHandler,
+    mock_orchestrator: AsyncMock,
+) -> None:
+    """GUILT: the shared wa-mirror-internal BARE form must never persist facts."""
+    handler._memory_orchestrator = mock_orchestrator
+    await handler.save_conversation_memory(
+        user_id="wa-mirror-internal",
+        query="q",
+        answer="a",
+    )
+    mock_orchestrator.process_conversation.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_innocence_real_client(
+    handler: MemoryHandler,
+    mock_orchestrator: AsyncMock,
+) -> None:
+    """INNOCENCE: a real authenticated client must still get memory saved (no regression)."""
+    handler._memory_orchestrator = mock_orchestrator
+    await handler.save_conversation_memory(
+        user_id="real.client@example.com",
+        query="q",
+        answer="a",
+    )
+    mock_orchestrator.process_conversation.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_save_regression_anonymous_still_skipped(
+    handler: MemoryHandler,
+    mock_orchestrator: AsyncMock,
+) -> None:
+    """REGRESSION: pre-existing anonymous-skip behaviour must be preserved."""
+    handler._memory_orchestrator = mock_orchestrator
+    await handler.save_conversation_memory(user_id="anonymous", query="q", answer="a")
+    mock_orchestrator.process_conversation.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_regression_empty_user_still_skipped(
+    handler: MemoryHandler,
+    mock_orchestrator: AsyncMock,
+) -> None:
+    """REGRESSION: pre-existing empty-user-skip behaviour must be preserved."""
+    handler._memory_orchestrator = mock_orchestrator
+    await handler.save_conversation_memory(user_id="", query="q", answer="a")
+    mock_orchestrator.process_conversation.assert_not_called()
+
+
+# ============================================================
+# READ chokepoint — context_manager.get_user_context
+# ============================================================
+
+EMPTY_CONTEXT: dict[str, Any] = {
+    "profile": None,
+    "history": [],
+    "facts": [],
+    "collective_facts": [],
+    "entities": {},
+}
+
+
+def _patch_fetchers(monkeypatch: pytest.MonkeyPatch) -> tuple[AsyncMock, AsyncMock]:
+    profile_mock = AsyncMock(return_value={"profile": {"name": "Marco"}, "history": [], "entities": {}})
+    memory_mock = AsyncMock(
+        return_value={
+            "facts": ["some fact"],
+            "collective_facts": [],
+            "timeline_summary": None,
+            "kg_entities": [],
+            "summary": None,
+            "counters": None,
+            "memory_context": None,
+        },
+    )
+    monkeypatch.setattr(module, "fetch_profile_and_history", profile_mock)
+    monkeypatch.setattr(module, "fetch_memory_facts", memory_mock)
+    return profile_mock, memory_mock
+
+
+@pytest.mark.asyncio
+async def test_get_user_context_guilt_shared_identity_bare(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GUILT: shared bare identity must get the neutral empty context, no fetch."""
+    profile_mock, memory_mock = _patch_fetchers(monkeypatch)
+
+    result = await get_user_context(MagicMock(), "wa-mirror-internal")
+
+    assert result == EMPTY_CONTEXT
+    profile_mock.assert_not_called()
+    memory_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_user_context_guilt_shared_identity_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GUILT: shared email-form identity must get the neutral empty context, no fetch."""
+    profile_mock, memory_mock = _patch_fetchers(monkeypatch)
+
+    result = await get_user_context(MagicMock(), "wa-mirror-internal@balizero.com")
+
+    assert result == EMPTY_CONTEXT
+    profile_mock.assert_not_called()
+    memory_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_user_context_innocence_real_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INNOCENCE: a real authenticated client must still get profile+facts fetched."""
+    profile_mock, memory_mock = _patch_fetchers(monkeypatch)
+
+    result = await get_user_context(MagicMock(), "real.client@example.com")
+
+    profile_mock.assert_awaited_once()
+    memory_mock.assert_awaited_once()
+    assert result["facts"] == ["some fact"]
+    assert result["profile"] == {"name": "Marco"}
+
+
+@pytest.mark.asyncio
+async def test_get_user_context_regression_anonymous_still_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REGRESSION: pre-existing anonymous-skip behaviour must be preserved,
+    even when a real (non-None) db_pool is supplied."""
+    profile_mock, memory_mock = _patch_fetchers(monkeypatch)
+
+    result = await get_user_context(MagicMock(), "anonymous")
+
+    assert result == EMPTY_CONTEXT
+    profile_mock.assert_not_called()
+    memory_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_user_context_regression_no_db_pool_still_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REGRESSION: pre-existing no-db_pool-skip behaviour must be preserved."""
+    profile_mock, memory_mock = _patch_fetchers(monkeypatch)
+
+    result = await get_user_context(None, "real.client@example.com")
+
+    assert result == EMPTY_CONTEXT
+    profile_mock.assert_not_called()
+    memory_mock.assert_not_called()

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 657 services · 1228 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 658 services · 1229 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## P0-MEM containment (W-1)

On the live WhatsApp path every sender authenticates as ONE fixed shared pseudo-identity (`wa-mirror-internal`, from `hybrid_auth`), which was used as the long-term memory key — so clients' facts were saved AND read under one shared bucket (cross-client bleed, UU PDP).

**Fix (containment, reversible):** a single predicate `is_non_personal_memory_identity()` applied at both memory chokepoints — the WRITE (`save_conversation_memory`) and the fact READ (`get_user_context`) — skipping long-term memory for the shared/anonymous identities, same treatment as `anonymous`. In-thread `conversation_history` (API-supplied, not keyed on this id) is untouched. Existing shared facts become inert (never read again) — no prod data deleted.

**Gate (generator≠grader):** Sonnet built; a Fable session re-verified the diff line-by-line on disk, re-ran the tests (30/30 containment guilt+innocence on the real call path; 63 nearby no-regression), and ran an independent cross-family adversarial review (Kimi K3 — Codex seat dead on 401 auth, GLM dead on balance) → verdict SOUND. Two residual leads (a third unguarded call site; the literal-invariant) were closed on disk: `fetch_memory_facts`/:196 is transitively protected (only caller is inside the guarded entry, after the guard), and `hybrid_auth` returns hardcoded literals both covered by the predicate.

The full fix (per-phone pseudonymous subject, hashed — not the phone in clear) is a later W-1 item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)