### PR TITLE
fix(pricing): VOA issuance price 750k -> 790k IDR (GARUDA_VOA pilot)

### DIFF
--- a/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+++ b/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
@@ -16,7 +16,7 @@
     "single_entry_visas": {
       "B1 Visa on Arrival (VOA)": {
         "name": "B1 Visa on Arrival (VOA)",
-        "price": "750.000 IDR",
+        "price": "790.000 IDR",
         "tier_range": null,
         "duration": "30 days",
         "validity": "Single entry, extendable once (+30 days)",


### PR DESCRIPTION
## What

Bali Zero **B1 Visa on Arrival (VOA) issuance** price: **750.000 → 790.000 IDR**.

Zero directive 2026-07-24 (GARUDA_VOA pilot): *"790k invece di 750k, prezzo nostro per voa"*.

## Where (single source of truth)

`apps/backend-rag/backend/data/bali_zero_official_prices_2026.json` — the PricingTool canonical catalog read by `PricingService._load_prices()`. Consumed by:
- WhatsApp bot `get_pricing` tool
- `/api/pricing/all` + `/api/pricing/search`
- mouth website (live backend API — VOA is NOT in the synced static `company_services`, so no frontend file change needed)

Goes live on backend deploy.

## Scope / safety

- **VOA issuance ONLY.** VOA Extension (850.000), C1 Tourism (2.300.000), every other price **unchanged**.
- `"750.000 IDR"` was **unique** to the VOA entry → no wrong-entry risk.
- JSON validity re-verified; frontend `sync_frontend_prices.py --check` = OK (no drift).

## Out of scope (pre-existing, flagged not bundled)

`practice_types` has **no `visa_voa` row in prod** (migration_123 was never applied there), so there is no stale DB `base_price` to fix in this PR. If VOA is later added to `practice_types` for invoicing, it must be seeded at **790.000**. Qdrant `bali_zero_pricing_hybrid` is a known pre-existing-stale secondary mirror (2025 data, used only for scenario aggregation) — not the authoritative VOA quote source; separate hygiene follow-up.

## Verification

Self-verified from multiple angles (value, uniqueness, JSON parse, frontend sync-check, consumer grep, prod practice_types read-only check). External LLM adversarial pass (Codex/Kimi) unavailable at build time (Codex OAuth logged-out; Kimi timeout) — CI gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)