### PR TITLE
fix(mouth): gate next-steps on SUPPORTED_CANDIDATES

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
@@ -12,6 +12,9 @@ import type { Language } from "../_lib/flow";
  * disclaimer is KEEP-verbatim under every verdict). These tests pin the
  * disclaimer + footer on ALL five terminal states, in both languages, and
  * the print anatomy (recap + disclaimer print; CTAs stay screen-only).
+ * Follow-up (owner call 2026-07-23, Fable MEDIUM): next-steps is pinned to
+ * SUPPORTED_CANDIDATES only — its step copy references the candidate
+ * checklist, absent on every other state.
  */
 
 const TODAY = new Date("2026-07-23T12:00:00Z");
@@ -132,19 +135,25 @@ describe("OutcomeSheet — shared footer on every terminal state (W0b)", () => {
     expect(qr?.getAttribute("data-qr-value")).toBe(cta.getAttribute("href"));
   });
 
-  it("gates the candidate-referencing next-steps copy on NEEDS_INPUT", () => {
-    // "Gather the documents listed above" points at a checklist that exists
-    // only when candidates exist — rendering it on NEEDS_INPUT would dangle.
-    renderSheet("NEEDS_INPUT");
-    expect(screen.queryByText("Your next 3 steps")).not.toBeInTheDocument();
-  });
+  it.each([
+    "NEEDS_INPUT",
+    "HUMAN_REVIEW_REQUIRED",
+    "NO_SUPPORTED_PATH",
+    "TEMPORARILY_UNAVAILABLE",
+  ] as const)(
+    "hides next-steps on %s (no candidate checklist to reference)",
+    (state) => {
+      // "Gather the documents listed above" points at a checklist that exists
+      // only under SUPPORTED_CANDIDATES — anywhere else the section dangles.
+      // Gated on SUPPORTED_CANDIDATES (owner call 2026-07-23, Fable MEDIUM).
+      renderSheet(state);
+      expect(screen.queryByText("Your next 3 steps")).not.toBeInTheDocument();
+    },
+  );
 
   it("keeps next-steps on SUPPORTED_CANDIDATES (checklist present)", () => {
-    // Only this state is pinned: the default step copy ("documents listed
-    // above") is unambiguously correct here. Visibility on the other three
-    // states is pre-existing main behavior, deliberately left untouched by
-    // W0b (flagged for content review — step 2 dangles where no checklist
-    // renders).
+    // The only state where the default step copy ("documents listed above")
+    // is unambiguously correct: the candidate checklist renders above it.
     renderSheet("SUPPORTED_CANDIDATES");
     expect(screen.getByText("Your next 3 steps")).toBeInTheDocument();
   });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
@@ -452,19 +452,17 @@ export function OutcomeSheet({
         </>
       )}
 
-      {/* W0b (legal-disclaimer fix, 2026-07-23): only the next-3-steps
-          section stays gated — its copy ("Gather the documents listed
-          above") references the candidate checklist, which exists only
-          when candidates exist. Everything below renders on ALL FIVE
-          terminal states, NEEDS_INPUT included: spec §A.3.2 makes
-          NEEDS_INPUT a first-class terminal legal-advice state whose
-          escape hatch "is always present" and which must never render as
-          a dead end, and the 4-line disclaimer (KEEP verbatim, spec §A.9)
-          is the legal floor under every verdict. Previously this guard
-          wrapped the whole footer, so NEEDS_INPUT rendered with no
-          WhatsApp handoff, no assumptions receipt, no print/copy and no
-          disclaimer at all. */}
-      {result.state !== "NEEDS_INPUT" && (
+      {/* W0b (legal-disclaimer fix, 2026-07-23): the footer below renders
+          on ALL FIVE terminal states — disclaimer/receipt/handoff are the
+          legal floor under every verdict, NEEDS_INPUT included (spec
+          §A.3.2/§A.9). The next-3-steps section is instead gated on
+          SUPPORTED_CANDIDATES only (owner call 2026-07-23, Fable MEDIUM):
+          its step-2 copy ("Gather the documents listed above") references
+          the candidate checklist, which exists only when candidates exist
+          (visas is [] on every other state) — on HUMAN_REVIEW_REQUIRED /
+          NO_SUPPORTED_PATH / TEMPORARILY_UNAVAILABLE / NEEDS_INPUT the
+          section dangled. */}
+      {result.state === "SUPPORTED_CANDIDATES" && (
         <section>
           <h2 className="oracle-outcome__section-title">
             {translate(language, "outcome.next_steps_title")}


### PR DESCRIPTION
Follow-up to Fable's MEDIUM on #3033 (owner call 2026-07-23: "fai tu").

The next-3-steps copy ("Gather the documents listed above") references the candidate checklist, which exists only under SUPPORTED_CANDIDATES (`visas=[]` on every other state). The W0b guard (`!== NEEDS_INPUT`) let the section dangle on HUMAN_REVIEW_REQUIRED / NO_SUPPORTED_PATH / TEMPORARILY_UNAVAILABLE. Now gated on `=== "SUPPORTED_CANDIDATES"`; the shared footer/disclaimer stays on all five states (W0b invariant untouched).

Tests: OutcomeSheet.test.tsx 17/17 (new it.each pins hidden-on-4-states + visible-on-supported); full (visa-oracle) vitest 78/78 green.

No auto-merge armed.