### PR TITLE
feat(mouth): exclude noIndex articles from getAllArticles listing/feed surfaces

### DIFF
--- a/apps/mouth/src/lib/blog/articles.ts
+++ b/apps/mouth/src/lib/blog/articles.ts
@@ -801,6 +801,12 @@ export const getAllArticles = unstable_cache(
       const article = await getMdxArticleBySlug(folderCategory, slug);
       if (!article) continue;
 
+      // noIndex articles leave every listing/feed surface (sitemap/robots
+      // already exclude them via getNoIndexSlugs) but stay on disk and remain
+      // reachable at their direct URL: the article page resolves single
+      // articles through getArticleBySlug/getArticleByLocale, not this fn.
+      if (article.noIndex) continue;
+
       if (
         options?.featured !== undefined &&
         article.featured !== options.featured

--- a/apps/mouth/src/lib/blog/noindex-filter.test.ts
+++ b/apps/mouth/src/lib/blog/noindex-filter.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getAllArticles, getArticleBySlug, getNoIndexSlugs } from "./articles";
+
+// Hermetic: strip the ISR cache wrapper (Next server-only) and force the
+// backend fetch to fail fast so getAllArticles falls back to the real
+// on-disk MDX corpus (same "real, offline" convention as
+// homepage-layout-guard.test.ts — no network, no backend).
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: unknown) => fn,
+}));
+
+// Real on-disk articles carrying `noIndex: true` (editorial rewrite queue —
+// files stay on disk, they only leave listing/feed surfaces).
+const NOINDEX_SLUGS = ["perfect-storm-bali-2026", "kerobokan-traffic-trial"];
+// A stable indexable article that must keep listing.
+const INDEXABLE_SLUG = "vat-ppn-guide";
+
+describe("noIndex listing filter", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("offline in test")),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fixture sanity: the noIndex slugs are still flagged on disk", async () => {
+    const noIndexSlugs = await getNoIndexSlugs();
+    for (const slug of NOINDEX_SLUGS) {
+      expect(noIndexSlugs.has(slug)).toBe(true);
+    }
+    expect(noIndexSlugs.has(INDEXABLE_SLUG)).toBe(false);
+  });
+
+  it("excludes noIndex articles from getAllArticles (listing + feed source)", async () => {
+    const { articles, total } = await getAllArticles({ limit: 500 });
+    const slugs = articles.map((a) => a.slug);
+
+    for (const slug of NOINDEX_SLUGS) {
+      expect(slugs).not.toContain(slug);
+    }
+    // `total` reflects the filtered set before pagination.
+    expect(total).toBeGreaterThanOrEqual(articles.length);
+  });
+
+  it("keeps indexable articles listed", async () => {
+    const { articles } = await getAllArticles({
+      category: "taxes",
+      limit: 500,
+    });
+    expect(articles.map((a) => a.slug)).toContain(INDEXABLE_SLUG);
+  });
+
+  it("excludes noIndex articles under a category filter too", async () => {
+    const { articles } = await getAllArticles({
+      category: "living",
+      limit: 500,
+    });
+    const slugs = articles.map((a) => a.slug);
+    for (const slug of NOINDEX_SLUGS) {
+      expect(slugs).not.toContain(slug);
+    }
+  });
+
+  it("keeps the direct article page working (getArticleBySlug by slug)", async () => {
+    // The renderer resolves single articles via getArticleBySlug, NOT
+    // getAllArticles — a noIndex article must remain reachable at its URL.
+    const article = await getArticleBySlug(
+      "lifestyle",
+      "perfect-storm-bali-2026",
+    );
+    expect(article).not.toBeNull();
+    expect(article?.noIndex).toBe(true);
+  });
+});


### PR DESCRIPTION
## Filtro noIndex in getAllArticles() (master list 0.5, decisione owner 2026-07-23)

Gli articoli con `noIndex: true` erano esclusi da sitemap/robots/llms ma restavano in listing /insights, /feed RSS e API blog.

### Contenuto
- `apps/mouth/src/lib/blog/articles.ts` — `if (article.noIndex) continue;` nel merge loop di `getAllArticles()`
- Copertura automatica: /feed RSS, listing news/marketing/v2, `/api/blog/articles`, `/api/blog/homepage-hero`, helper derivati (featured, category, search fallback)
- Le pagine articolo restano raggiungibili via `getArticleBySlug` — reversibile, i file restano per la riscrittura editoriale
- Nuovo test `noindex-filter.test.ts` (5 test)

### Test
27/27 vitest verdi (blog), tsc verde in pre-commit.

### Note
- Edge case verificati: homepage hero curation, nessun `generateStaticParams` da aggiornare
- Compone con `e33-content-freeze`: al merge di entrambi, i 16 articoli contraddittori escono da ogni superficie di listing

🤖 Kimi (Air-M5) — review & merge via sessione Claude.
