### PR TITLE
feat(visa-engine): E33 Second Home vertical — fact paths, real products, pricing bridge, gold harness

### DIFF
--- a/apps/backend-rag/backend/services/visa_check/catalogue.py
+++ b/apps/backend-rag/backend/services/visa_check/catalogue.py
@@ -315,7 +315,7 @@ def _build_meta() -> dict[VisaType, VisaMeta]:
                 1,
                 365 * 5,
             ),  # Permenkumham 22/2023 Pasal 113: >=5y first grant -> 10y cumulative cap
-            min_budget_idr=500_000_000,  # USD 130k deposit route — high-budget tier
+            min_budget_idr=500_000_000,  # commercial tier flag, not the legal USD 130k deposit threshold
             notes="Base Second Home (bank route): USD 130,000 own-name deposit at a "
             "state-owned (BUMN) bank, or USD 1,000,000 qualifying completed "
             "strata-title property. 5-year first grant, no sponsor, non-working residency.",

--- a/apps/backend-rag/backend/services/visa_check/catalogue.py
+++ b/apps/backend-rag/backend/services/visa_check/catalogue.py
@@ -45,6 +45,7 @@ class VisaType(str, Enum):
     E28A = "E28A"  # Investor KITAS 2y
     E30A = "E30A"  # Education (basic & secondary)
     E31 = "E31"  # Family KITAS
+    E33 = "E33"  # Second Home (base, 5y) — bank deposit / property route
     E33E = "E33E"  # Second Home Elder 5y (golden)
     E33F = "E33F"  # Second Home Elder 1y
     E33G = "E33G"  # Second Home Remote Worker / Digital Nomad
@@ -299,6 +300,28 @@ def _build_meta() -> dict[VisaType, VisaMeta]:
             notes="Spouse/dependent of KITAS/KITAP holder.",
             seed_source=SEED,
             duration_source=NB2,
+        ),
+        VisaType.E33: VisaMeta(
+            name_en="Second Home Visa",
+            name_id="Visa Rumah Kedua",
+            category="KITAS/Limited Stay",
+            # Empty on purpose: the match wizard has no second-home branch
+            # (match_tree.Purpose has no SECOND_HOME tag), so base E33 is
+            # never surfaced by recommend_visa — it exists here for the
+            # pricing bridge and catalogue completeness only.
+            purposes=frozenset(),
+            duration_days=365 * 5,
+            extensions=(
+                1,
+                365 * 5,
+            ),  # Permenkumham 22/2023 Pasal 113: >=5y first grant -> 10y cumulative cap
+            min_budget_idr=500_000_000,  # USD 130k deposit route — high-budget tier
+            notes="Base Second Home (bank route): USD 130,000 own-name deposit at a "
+            "state-owned (BUMN) bank, or USD 1,000,000 qualifying completed "
+            "strata-title property. 5-year first grant, no sponsor, non-working residency.",
+            seed_source=SEED,
+            duration_source=NB2,
+            fit_tags=frozenset({FitTag.GOLDEN_VISA}),
         ),
         VisaType.E33E: VisaMeta(
             name_en="Second Home Visa Elderly for 5 Years Golden Visa",

--- a/apps/backend-rag/backend/services/visa_check/pricing_bridge.py
+++ b/apps/backend-rag/backend/services/visa_check/pricing_bridge.py
@@ -59,6 +59,7 @@ _SEARCH_HINTS: dict[VisaType, tuple[str, ...]] = {
         "Spouse 1 Year (Offshore)",
         "Family",
     ),
+    VisaType.E33: ("E33 Second Home (5 Years)", "E33 Second Home"),
     VisaType.E33E: ("Retirement KITAP + MERP", "Retirement"),
     VisaType.E33F: ("Retirement (Offshore)", "Retirement"),
     VisaType.E33G: ("E33G Remote Worker (Offshore)", "E33G Remote Worker"),

--- a/apps/backend-rag/backend/services/visa_engine/ast.py
+++ b/apps/backend-rag/backend/services/visa_engine/ast.py
@@ -572,7 +572,7 @@ def _leaf_lookup(
 
     Returns ``(referenced_facts, unknown_facts, is_unknown, value_or_none)``.
     A fact path absent from the snapshot (should not happen for a snapshot
-    built by ``FactRegistry.derive()``, which always populates all 38 paths)
+    built by ``FactRegistry.derive()``, which always populates all 43 paths)
     is treated as UNKNOWN rather than raising — the same fail-safe posture
     as an explicit ``UnknownFact`` entry.
     """

--- a/apps/backend-rag/backend/services/visa_engine/contracts/condition.schema.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/condition.schema.json
@@ -292,7 +292,7 @@
       "type": "object"
     },
     "FactPath": {
-      "description": "Every fact path the engine may ever reference \u2014 35 applicant-collected\n+ 3 derived (spec \u00a72 ``ApplicantFactPath`` + ``FactPath``).\n\nClosed by design (spec \u00a75.2): a Condition's ``fact`` field and a Rule's\n``required_facts`` array are both typed against this enum, so a rule\nthat references an unknown fact path is a Pydantic ``ValidationError``\nat parse time, not a runtime surprise. ``fact_registry.py`` layers typed\nmetadata (value kind, PII class, commercial flag) on top of this same\nvocabulary \u2014 see that module's docstring for why both exist.",
+      "description": "Every fact path the engine may ever reference \u2014 40 applicant-collected\n+ 3 derived (spec \u00a72 ``ApplicantFactPath`` + ``FactPath``, extended by the\n``secondhome.*`` group for the E33 Second Home vertical, 2026-07-23).\n\nClosed by design (spec \u00a75.2): a Condition's ``fact`` field and a Rule's\n``required_facts`` array are both typed against this enum, so a rule\nthat references an unknown fact path is a Pydantic ``ValidationError``\nat parse time, not a runtime surprise. ``fact_registry.py`` layers typed\nmetadata (value kind, PII class, commercial flag) on top of this same\nvocabulary \u2014 see that module's docstring for why both exist.",
       "enum": [
         "person.birth_date",
         "person.nationalities",
@@ -325,6 +325,11 @@
         "study.level",
         "study.admission_confirmed",
         "study.sponsor_confirmed",
+        "secondhome.bank_deposit_usd",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.qualifying_property_value_usd",
+        "secondhome.passive_monthly_income_usd",
         "process.application_channel",
         "process.wants_onshore_conversion",
         "commercial.service_fee_budget_idr",

--- a/apps/backend-rag/backend/services/visa_engine/contracts/contract.schema.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/contract.schema.json
@@ -209,7 +209,7 @@
     },
     "ApplicantFactsData": {
       "additionalProperties": false,
-      "description": "``ApplicantFacts.facts`` (spec \u00a72) \u2014 ``additionalProperties: false``\nwith all 35 keys required. Field order mirrors ``enums.FactPath``'s\n``person.*``/``immigration.*``/``intent.*``/``work.*``/``investment.*``/\n``family.*``/``study.*``/``process.*``/``commercial.*`` grouping.\n\n``populate_by_name=False`` (PR1b item 4): every wire key here is a dotted\n``FactPath`` string (e.g. ``\"person.birth_date\"``) that cannot be a\nPython attribute name, so each field carries a Python-safe name\n(``person_birth_date``) purely to exist in the class body, with the\ndotted string as its ``alias``. Allowing the Python name to *also*\npopulate the model would let a caller construct\n``ApplicantFactsData(person_birth_date=...)`` directly \u2014 a name that\nnever appears on the wire (every real payload is alias-keyed JSON/dict),\nso accepting it is pure smuggling surface with no legitimate caller.",
+      "description": "``ApplicantFacts.facts`` (spec \u00a72) \u2014 ``additionalProperties: false``\nwith all 40 keys required. Field order mirrors ``enums.FactPath``'s\n``person.*``/``immigration.*``/``intent.*``/``work.*``/``investment.*``/\n``family.*``/``study.*``/``secondhome.*``/``process.*``/``commercial.*``\ngrouping.\n\n``populate_by_name=False`` (PR1b item 4): every wire key here is a dotted\n``FactPath`` string (e.g. ``\"person.birth_date\"``) that cannot be a\nPython attribute name, so each field carries a Python-safe name\n(``person_birth_date``) purely to exist in the class body, with the\ndotted string as its ``alias``. Allowing the Python name to *also*\npopulate the model would let a caller construct\n``ApplicantFactsData(person_birth_date=...)`` directly \u2014 a name that\nnever appears on the wire (every real payload is alias-keyed JSON/dict),\nso accepting it is pure smuggling surface with no legitimate caller.",
       "properties": {
         "commercial.service_fee_budget_idr": {
           "discriminator": {
@@ -697,6 +697,96 @@
           ],
           "title": "Process.Wants Onshore Conversion"
         },
+        "secondhome.bank_deposit_at_state_bank": {
+          "discriminator": {
+            "mapping": {
+              "KNOWN": "#/$defs/KnownBoolean",
+              "UNKNOWN": "#/$defs/UnknownFact"
+            },
+            "propertyName": "status"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/UnknownFact"
+            },
+            {
+              "$ref": "#/$defs/KnownBoolean"
+            }
+          ],
+          "title": "Secondhome.Bank Deposit At State Bank"
+        },
+        "secondhome.bank_deposit_in_own_name": {
+          "discriminator": {
+            "mapping": {
+              "KNOWN": "#/$defs/KnownBoolean",
+              "UNKNOWN": "#/$defs/UnknownFact"
+            },
+            "propertyName": "status"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/UnknownFact"
+            },
+            {
+              "$ref": "#/$defs/KnownBoolean"
+            }
+          ],
+          "title": "Secondhome.Bank Deposit In Own Name"
+        },
+        "secondhome.bank_deposit_usd": {
+          "discriminator": {
+            "mapping": {
+              "KNOWN": "#/$defs/KnownNonNegativeInteger",
+              "UNKNOWN": "#/$defs/UnknownFact"
+            },
+            "propertyName": "status"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/UnknownFact"
+            },
+            {
+              "$ref": "#/$defs/KnownNonNegativeInteger"
+            }
+          ],
+          "title": "Secondhome.Bank Deposit Usd"
+        },
+        "secondhome.passive_monthly_income_usd": {
+          "discriminator": {
+            "mapping": {
+              "KNOWN": "#/$defs/KnownNonNegativeInteger",
+              "UNKNOWN": "#/$defs/UnknownFact"
+            },
+            "propertyName": "status"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/UnknownFact"
+            },
+            {
+              "$ref": "#/$defs/KnownNonNegativeInteger"
+            }
+          ],
+          "title": "Secondhome.Passive Monthly Income Usd"
+        },
+        "secondhome.qualifying_property_value_usd": {
+          "discriminator": {
+            "mapping": {
+              "KNOWN": "#/$defs/KnownNonNegativeInteger",
+              "UNKNOWN": "#/$defs/UnknownFact"
+            },
+            "propertyName": "status"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/UnknownFact"
+            },
+            {
+              "$ref": "#/$defs/KnownNonNegativeInteger"
+            }
+          ],
+          "title": "Secondhome.Qualifying Property Value Usd"
+        },
         "study.admission_confirmed": {
           "discriminator": {
             "mapping": {
@@ -874,6 +964,11 @@
         "study.level",
         "study.admission_confirmed",
         "study.sponsor_confirmed",
+        "secondhome.bank_deposit_usd",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.qualifying_property_value_usd",
+        "secondhome.passive_monthly_income_usd",
         "process.application_channel",
         "process.wants_onshore_conversion",
         "commercial.service_fee_budget_idr",
@@ -1662,7 +1757,7 @@
       "type": "object"
     },
     "FactPath": {
-      "description": "Every fact path the engine may ever reference \u2014 35 applicant-collected\n+ 3 derived (spec \u00a72 ``ApplicantFactPath`` + ``FactPath``).\n\nClosed by design (spec \u00a75.2): a Condition's ``fact`` field and a Rule's\n``required_facts`` array are both typed against this enum, so a rule\nthat references an unknown fact path is a Pydantic ``ValidationError``\nat parse time, not a runtime surprise. ``fact_registry.py`` layers typed\nmetadata (value kind, PII class, commercial flag) on top of this same\nvocabulary \u2014 see that module's docstring for why both exist.",
+      "description": "Every fact path the engine may ever reference \u2014 40 applicant-collected\n+ 3 derived (spec \u00a72 ``ApplicantFactPath`` + ``FactPath``, extended by the\n``secondhome.*`` group for the E33 Second Home vertical, 2026-07-23).\n\nClosed by design (spec \u00a75.2): a Condition's ``fact`` field and a Rule's\n``required_facts`` array are both typed against this enum, so a rule\nthat references an unknown fact path is a Pydantic ``ValidationError``\nat parse time, not a runtime surprise. ``fact_registry.py`` layers typed\nmetadata (value kind, PII class, commercial flag) on top of this same\nvocabulary \u2014 see that module's docstring for why both exist.",
       "enum": [
         "person.birth_date",
         "person.nationalities",
@@ -1695,6 +1790,11 @@
         "study.level",
         "study.admission_confirmed",
         "study.sponsor_confirmed",
+        "secondhome.bank_deposit_usd",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.qualifying_property_value_usd",
+        "secondhome.passive_monthly_income_usd",
         "process.application_channel",
         "process.wants_onshore_conversion",
         "commercial.service_fee_budget_idr",
@@ -2725,7 +2825,7 @@
       "type": "object"
     },
     "RelationType": {
-      "enum": ["SPOUSE", "CHILD", "PARENT", "DEPENDENT", "OTHER"],
+      "enum": ["SPOUSE", "CHILD", "PARENT", "SIBLING", "DEPENDENT", "OTHER"],
       "title": "RelationType",
       "type": "string"
     },

--- a/apps/backend-rag/backend/services/visa_engine/enums.py
+++ b/apps/backend-rag/backend/services/visa_engine/enums.py
@@ -273,6 +273,7 @@ class RelationType(str, Enum):
     SPOUSE = "SPOUSE"
     CHILD = "CHILD"
     PARENT = "PARENT"
+    SIBLING = "SIBLING"
     DEPENDENT = "DEPENDENT"
     OTHER = "OTHER"
 
@@ -380,13 +381,14 @@ class Environment(str, Enum):
 
 
 # ---------------------------------------------------------------------------
-# FactPath — the closed 38-path fact vocabulary (35 applicant + 3 derived; spec §2 ``FactPath``)
+# FactPath — the closed 43-path fact vocabulary (40 applicant + 3 derived; spec §2 ``FactPath``)
 # ---------------------------------------------------------------------------
 
 
 class FactPath(str, Enum):
-    """Every fact path the engine may ever reference — 35 applicant-collected
-    + 3 derived (spec §2 ``ApplicantFactPath`` + ``FactPath``).
+    """Every fact path the engine may ever reference — 40 applicant-collected
+    + 3 derived (spec §2 ``ApplicantFactPath`` + ``FactPath``, extended by the
+    ``secondhome.*`` group for the E33 Second Home vertical, 2026-07-23).
 
     Closed by design (spec §5.2): a Condition's ``fact`` field and a Rule's
     ``required_facts`` array are both typed against this enum, so a rule
@@ -434,6 +436,16 @@ class FactPath(str, Enum):
     STUDY_LEVEL = "study.level"
     STUDY_ADMISSION_CONFIRMED = "study.admission_confirmed"
     STUDY_SPONSOR_CONFIRMED = "study.sponsor_confirmed"
+    # secondhome.* — E33 Second Home vertical (bank-route scope, owner decision
+    # 2026-07-23): the qualifying-basis facts the base E33 / E33E / E33F
+    # eligibility rules test. ``bank_deposit_*`` is one deposit, evidenced as
+    # a whole (amount + state-owned-bank (BUMN) placement + own-name holder);
+    # split deposits are never modeled (owner decision: never offered).
+    SECONDHOME_BANK_DEPOSIT_USD = "secondhome.bank_deposit_usd"
+    SECONDHOME_BANK_DEPOSIT_AT_STATE_BANK = "secondhome.bank_deposit_at_state_bank"
+    SECONDHOME_BANK_DEPOSIT_IN_OWN_NAME = "secondhome.bank_deposit_in_own_name"
+    SECONDHOME_QUALIFYING_PROPERTY_VALUE_USD = "secondhome.qualifying_property_value_usd"
+    SECONDHOME_PASSIVE_MONTHLY_INCOME_USD = "secondhome.passive_monthly_income_usd"
     # process.*
     PROCESS_APPLICATION_CHANNEL = "process.application_channel"
     PROCESS_WANTS_ONSHORE_CONVERSION = "process.wants_onshore_conversion"
@@ -446,7 +458,7 @@ class FactPath(str, Enum):
     DERIVED_HAS_INDONESIAN_CITIZENSHIP = "derived.has_indonesian_citizenship"
 
 
-#: The 35 applicant-collected paths (everything except ``derived.*``).
+#: The 40 applicant-collected paths (everything except ``derived.*``).
 APPLICANT_FACT_PATHS: frozenset[FactPath] = frozenset(
     path for path in FactPath if not path.value.startswith("derived.")
 )

--- a/apps/backend-rag/backend/services/visa_engine/fact_registry.py
+++ b/apps/backend-rag/backend/services/visa_engine/fact_registry.py
@@ -2,7 +2,7 @@
 
 Source: ``research/visa/2026-07-17-visa-oracle-v2-round2-codex-engine-
 concretization.md`` §1 (module layout, ``fact_registry.py``) and §2
-(``ApplicantFacts.facts`` — the 35 collected paths + the 3 ``derived.*``
+(``ApplicantFacts.facts`` — the 40 collected paths + the 3 ``derived.*``
 paths this catalog also carries).
 
 Why this exists alongside ``enums.FactPath``: ``FactPath`` is the *closed
@@ -148,7 +148,9 @@ def _spec(
 
 
 #: Default catalog seeded 1:1 from spec §2 ``ApplicantFacts.facts.properties``
-#: (35 entries) plus the 3 ``derived.*`` paths from spec §2 ``FactPath``.
+#: (35 entries) plus the 3 ``derived.*`` paths from spec §2 ``FactPath``,
+#: plus the 5 ``secondhome.*`` paths added for the E33 Second Home vertical
+#: (2026-07-23, bank-route owner scope) — 43 entries total.
 #: PII classification rationale: immigration status/violation history and
 #: investment capital amounts are SENSITIVE (UU PDP heightened-treatment
 #: analogues per CLAUDE.md §14 — closest to "criminal"/"financial" data in
@@ -283,7 +285,7 @@ _DEFAULT_SPECS: tuple[FactSpec, ...] = (
         FactPath.FAMILY_RELATION_TO_SPONSOR,
         FactValueKind.STRING,
         "relation_enum",
-        allowed_values=frozenset({"SPOUSE", "CHILD", "PARENT", "DEPENDENT", "OTHER"}),
+        allowed_values=frozenset({"SPOUSE", "CHILD", "PARENT", "SIBLING", "DEPENDENT", "OTHER"}),
     ),
     _spec(
         FactPath.FAMILY_SPONSOR_NATIONALITIES,
@@ -312,6 +314,41 @@ _DEFAULT_SPECS: tuple[FactSpec, ...] = (
     ),
     _spec(FactPath.STUDY_ADMISSION_CONFIRMED, FactValueKind.BOOLEAN, "boolean"),
     _spec(FactPath.STUDY_SPONSOR_CONFIRMED, FactValueKind.BOOLEAN, "boolean"),
+    # secondhome.* — E33 Second Home vertical (2026-07-23, bank-route scope).
+    # USD amounts are SENSITIVE (financial data, same UU PDP rationale as the
+    # IDR investment capital facts); the placement/holder booleans are
+    # PERSONAL (they describe the applicant's banking arrangement, not an
+    # amount). No BSI/sharia or split-deposit variant facts exist by design:
+    # both are FORBIDDEN claims until the official letters are answered (see
+    # research/secondhome/README.md), so the vocabulary cannot express them.
+    _spec(
+        FactPath.SECONDHOME_BANK_DEPOSIT_USD,
+        FactValueKind.INTEGER,
+        "money_usd",
+        pii_class=PiiClass.SENSITIVE,
+    ),
+    _spec(
+        FactPath.SECONDHOME_BANK_DEPOSIT_AT_STATE_BANK,
+        FactValueKind.BOOLEAN,
+        "boolean",
+    ),
+    _spec(
+        FactPath.SECONDHOME_BANK_DEPOSIT_IN_OWN_NAME,
+        FactValueKind.BOOLEAN,
+        "boolean",
+    ),
+    _spec(
+        FactPath.SECONDHOME_QUALIFYING_PROPERTY_VALUE_USD,
+        FactValueKind.INTEGER,
+        "money_usd",
+        pii_class=PiiClass.SENSITIVE,
+    ),
+    _spec(
+        FactPath.SECONDHOME_PASSIVE_MONTHLY_INCOME_USD,
+        FactValueKind.INTEGER,
+        "money_usd",
+        pii_class=PiiClass.SENSITIVE,
+    ),
     _spec(
         FactPath.PROCESS_APPLICATION_CHANNEL,
         FactValueKind.STRING,

--- a/apps/backend-rag/backend/services/visa_engine/models.py
+++ b/apps/backend-rag/backend/services/visa_engine/models.py
@@ -834,7 +834,7 @@ StudyLevelFact = Annotated[UnknownFact | KnownStudyLevel, Field(discriminator="s
 
 
 # ---------------------------------------------------------------------------
-# ApplicantFacts (spec §2) — the 35 applicant-collected fact paths, each
+# ApplicantFacts (spec §2) — the 40 applicant-collected fact paths, each
 # typed per its own *Fact union above. Field names use Python-safe
 # identifiers with the dotted wire name as the Pydantic alias (same pattern
 # as ``TimeRange.from_``/``alias="from"``) since a dotted path cannot be a
@@ -844,9 +844,10 @@ StudyLevelFact = Annotated[UnknownFact | KnownStudyLevel, Field(discriminator="s
 
 class ApplicantFactsData(BaseModel):
     """``ApplicantFacts.facts`` (spec §2) — ``additionalProperties: false``
-    with all 35 keys required. Field order mirrors ``enums.FactPath``'s
+    with all 40 keys required. Field order mirrors ``enums.FactPath``'s
     ``person.*``/``immigration.*``/``intent.*``/``work.*``/``investment.*``/
-    ``family.*``/``study.*``/``process.*``/``commercial.*`` grouping.
+    ``family.*``/``study.*``/``secondhome.*``/``process.*``/``commercial.*``
+    grouping.
 
     ``populate_by_name=False`` (PR1b item 4): every wire key here is a dotted
     ``FactPath`` string (e.g. ``"person.birth_date"``) that cannot be a
@@ -920,6 +921,24 @@ class ApplicantFactsData(BaseModel):
     study_level: Annotated[StudyLevelFact, Field(alias="study.level")]
     study_admission_confirmed: Annotated[BooleanFact, Field(alias="study.admission_confirmed")]
     study_sponsor_confirmed: Annotated[BooleanFact, Field(alias="study.sponsor_confirmed")]
+    # secondhome.* — E33 Second Home vertical (2026-07-23). USD amounts use
+    # NonNegativeIntegerFact, NOT MoneyFact: ``KnownMoney`` is documented as
+    # an IDR amount (spec §2 ``KnownMoney``), and these three are USD.
+    secondhome_bank_deposit_usd: Annotated[
+        NonNegativeIntegerFact, Field(alias="secondhome.bank_deposit_usd")
+    ]
+    secondhome_bank_deposit_at_state_bank: Annotated[
+        BooleanFact, Field(alias="secondhome.bank_deposit_at_state_bank")
+    ]
+    secondhome_bank_deposit_in_own_name: Annotated[
+        BooleanFact, Field(alias="secondhome.bank_deposit_in_own_name")
+    ]
+    secondhome_qualifying_property_value_usd: Annotated[
+        NonNegativeIntegerFact, Field(alias="secondhome.qualifying_property_value_usd")
+    ]
+    secondhome_passive_monthly_income_usd: Annotated[
+        NonNegativeIntegerFact, Field(alias="secondhome.passive_monthly_income_usd")
+    ]
     process_application_channel: Annotated[
         ApplicationChannelFact, Field(alias="process.application_channel")
     ]

--- a/apps/backend-rag/backend/services/visa_engine/shadow.py
+++ b/apps/backend-rag/backend/services/visa_engine/shadow.py
@@ -228,9 +228,9 @@ def _resolve_nationality_alpha2(nationality: str) -> str | None:
 
 
 def _default_unknown_facts() -> dict[str, UnknownFact]:
-    """The 35 applicant-collected fact paths, each defaulted to
+    """The 40 applicant-collected fact paths, each defaulted to
     ``UnknownFact(reason=NOT_ASKED)`` — a Match wizard submission never
-    asked the other 32 facts a full visa_oracle interview would. Sharing one
+    asked the other 37 facts a full visa_oracle interview would. Sharing one
     frozen ``UnknownFact`` instance across every key is safe (immutable
     model, no per-key state).
     """
@@ -246,13 +246,13 @@ def build_shadow_facts(
     duration_months: int,
     match_hash: str,
 ) -> ApplicantFacts | None:
-    """Adapt a 4-field Match submission into a full 35-key ``ApplicantFacts``.
+    """Adapt a 4-field Match submission into a full 40-key ``ApplicantFacts``.
 
-    Every one of the 35 fields is built defensively: the 3 KNOWN-able ones
+    Every one of the 40 fields is built defensively: the 3 KNOWN-able ones
     (``person.nationalities``/``intent.purposes``/``intent.stay_days``) are
     each attempted in their own ``try/except`` — a failure on any single
     field degrades ONLY that field to its ``UnknownFact`` default, never
-    aborts the whole build. The remaining 32 stay ``UNKNOWN(NOT_ASKED)``.
+    aborts the whole build. The remaining 37 stay ``UNKNOWN(NOT_ASKED)``.
     Returns ``None`` only if the ``ApplicantFacts`` construction fails
     entirely (e.g. the facts dict itself is somehow malformed) — the whole
     SHADOW evaluation aborts silently in that case (caller logs and returns).

--- a/apps/backend-rag/backend/tests/services/visa_check/test_catalogue.py
+++ b/apps/backend-rag/backend/tests/services/visa_check/test_catalogue.py
@@ -51,7 +51,7 @@ class TestEnumStability:
     def test_b211a_removed(self):
         assert not hasattr(VisaType, "B211A"), "B211A must not exist — it is not in the seed"
 
-    def test_all_19_codes_present(self):
+    def test_all_20_codes_present(self):
         expected = {
             "B1",
             "C1",
@@ -69,6 +69,7 @@ class TestEnumStability:
             "E28A",
             "E30A",
             "E31",
+            "E33",
             "E33E",
             "E33F",
             "E33G",

--- a/apps/backend-rag/backend/tests/services/visa_engine/_gold_fixtures.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/_gold_fixtures.py
@@ -598,7 +598,7 @@ def build_gold_compiled_pack() -> CompiledRulePack:
 
 _UNKNOWN_NOT_ASKED = {"status": "UNKNOWN", "reason": "NOT_ASKED"}
 
-#: Every one of the 35 fact paths defaulted to a KNOWN, "safe/neutral" value —
+#: Every one of the 40 fact paths defaulted to a KNOWN, "safe/neutral" value —
 #: a fully-answered, boring baseline applicant (adult, non-calling-country,
 #: no violations, offshore, non-onshore-conversion) that no rule in
 #: ``_build_rules`` flags. Every persona overrides only its OWN distinguishing
@@ -651,6 +651,15 @@ _BASELINE_FACTS: dict[str, dict[str, Any]] = {
     "study.level": _UNKNOWN_NOT_ASKED,
     "study.admission_confirmed": _UNKNOWN_NOT_ASKED,
     "study.sponsor_confirmed": _UNKNOWN_NOT_ASKED,
+    # secondhome.* (E33 vertical): UNKNOWN by default — no rule in
+    # ``_build_rules`` references these paths, so they never influence the
+    # evaluator-suite personas; they exist here only because
+    # ``ApplicantFactsData`` requires all 40 keys.
+    "secondhome.bank_deposit_usd": _UNKNOWN_NOT_ASKED,
+    "secondhome.bank_deposit_at_state_bank": _UNKNOWN_NOT_ASKED,
+    "secondhome.bank_deposit_in_own_name": _UNKNOWN_NOT_ASKED,
+    "secondhome.qualifying_property_value_usd": _UNKNOWN_NOT_ASKED,
+    "secondhome.passive_monthly_income_usd": _UNKNOWN_NOT_ASKED,
     "process.application_channel": {"status": "KNOWN", "value": "OFFSHORE"},
     "process.wants_onshore_conversion": {"status": "KNOWN", "value": False},
     "commercial.service_fee_budget_idr": {"status": "KNOWN", "value": 0},

--- a/apps/backend-rag/backend/tests/services/visa_engine/conftest.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/conftest.py
@@ -173,9 +173,9 @@ def make_rule_pack(payload: M.RulePackPayload, *, environment: str = "TEST") -> 
 
 
 def make_applicant_facts(*, assessment_id: uuid.UUID | None = None) -> M.ApplicantFacts:
-    """Every one of the 35 fact paths as an ``UnknownFact`` (the simplest
+    """Every one of the 40 fact paths as an ``UnknownFact`` (the simplest
     valid ``facts`` payload — proves the "all keys required, additionalProperties:
-    false" shape without needing 35 different ``Known*`` builders).
+    false" shape without needing 40 different ``Known*`` builders).
     """
     unknown = {"status": "UNKNOWN", "reason": "NOT_ASKED"}
     facts = {
@@ -210,6 +210,11 @@ def make_applicant_facts(*, assessment_id: uuid.UUID | None = None) -> M.Applica
         "study.level": unknown,
         "study.admission_confirmed": unknown,
         "study.sponsor_confirmed": unknown,
+        "secondhome.bank_deposit_usd": unknown,
+        "secondhome.bank_deposit_at_state_bank": unknown,
+        "secondhome.bank_deposit_in_own_name": unknown,
+        "secondhome.qualifying_property_value_usd": unknown,
+        "secondhome.passive_monthly_income_usd": unknown,
         "process.application_channel": unknown,
         "process.wants_onshore_conversion": unknown,
         "commercial.service_fee_budget_idr": unknown,

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/adapter.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/adapter.py
@@ -54,7 +54,8 @@ them as bugs):
    across every product in that bucket, deduplicated and sorted for
    determinism -- there is no dedicated "global-only" rule stage in this
    pack (every review/hard-filter trigger in the designed pack is GLOBAL
-   scope, so it fires identically for every product; the union is therefore
+   scope except the E33E-scoped ``hr-e33e-age-band-55-59`` BERSYARAT band
+   rule, which for the current personas never fires TRUE, so the union is
    always a singleton set in this harness's personas, but the aggregation
    code does not assume that).
 """

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/adapter.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/adapter.py
@@ -31,7 +31,7 @@ never ``backend.services.visa_engine.models.Decision``) so that once PR5
 lands, the persona replay tests in this package can be repointed at the real
 ``evaluate()`` by swapping this module's two entry points
 (``evaluate_product`` / ``evaluate_all``) for thin calls into PR5's API --
-the 20 persona fixtures and their expectations do not change.
+the 23 persona fixtures and their expectations do not change.
 
 Deliberate simplifications documented up front (so a reviewer does not read
 them as bugs):
@@ -39,7 +39,7 @@ them as bugs):
 1. ``missing_facts`` on a ``ProductProof``/``GlobalDecision`` is the raw
    ``ConditionResult.unknown_facts`` set, NOT translated from a
    ``derived.*`` fact back to its applicant-collected dependency (spec's
-   ``underlying_applicant_facts`` helper). None of this harness's 20 gold
+   ``underlying_applicant_facts`` helper). None of this harness's 23 gold
    personas ever produces an UNKNOWN ``derived.*`` fact as the safety-critical
    culprit (every persona supplies a definite ``person.birth_date``, so
    ``derived.is_minor``/``derived.age_years`` always resolve to a known
@@ -54,8 +54,9 @@ them as bugs):
    across every product in that bucket, deduplicated and sorted for
    determinism -- there is no dedicated "global-only" rule stage in this
    pack (every review/hard-filter trigger in the designed pack is GLOBAL
-   scope except the E33E-scoped ``hr-e33e-age-band-55-59`` BERSYARAT band
-   rule, which for the current personas never fires TRUE, so the union is
+   scope except the E33E/E33F-scoped ``hr-e33e-e33f-age-band-55-59``
+   BERSYARAT band rule, which fires TRUE only for RETIREMENT-purpose
+   applicants aged 55-59 (persona 21), so the union is
    always a singleton set in this harness's personas, but the aggregation
    code does not assume that).
 """

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/expectations.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/expectations.py
@@ -23,9 +23,14 @@ Two authoring tiers per persona (see each persona JSON's ``expected`` key):
      19-07-2026 audit that caught exactly this gap for E33G against three
      TOURISM-only personas before it shipped).
    - ``DOMINANT_GLOBAL``: a GLOBAL HARD_FILTER/HUMAN_REVIEW rule in the
-     designed pack fires identically for every product (this harness's pack
-     never scopes a HARD_FILTER/HUMAN_REVIEW rule to PRODUCTS), so every
-     product collapses to the same EXCLUDED/REVIEW/BLOCKED_UNKNOWN outcome.
+     designed pack fires identically for every product, so every product
+     collapses to the same EXCLUDED/REVIEW/BLOCKED_UNKNOWN outcome. (The one
+     PRODUCTS-scoped HUMAN_REVIEW rule in the pack --
+     ``hr-e33e-age-band-55-59`` on E33E, the Permenkumham 11/2024 55-vs-60
+     BERSYARAT band -- is inert for every persona that uses this default:
+     all of them are either blocked earlier by a GLOBAL rule or are aged
+     outside the 55-59 band, so it never fires TRUE and never becomes the
+     UNKNOWN that gates the decision.)
 """
 
 from __future__ import annotations

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/expectations.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/expectations.py
@@ -26,11 +26,12 @@ Two authoring tiers per persona (see each persona JSON's ``expected`` key):
      designed pack fires identically for every product, so every product
      collapses to the same EXCLUDED/REVIEW/BLOCKED_UNKNOWN outcome. (The one
      PRODUCTS-scoped HUMAN_REVIEW rule in the pack --
-     ``hr-e33e-age-band-55-59`` on E33E, the Permenkumham 11/2024 55-vs-60
-     BERSYARAT band -- is inert for every persona that uses this default:
-     all of them are either blocked earlier by a GLOBAL rule or are aged
-     outside the 55-59 band, so it never fires TRUE and never becomes the
-     UNKNOWN that gates the decision.)
+     ``hr-e33e-e33f-age-band-55-59`` on E33E+E33F, the Permenkumham 11/2024
+     55-vs-60 BERSYARAT band -- is purpose-guarded to RETIREMENT and inert
+     for every persona that uses this default: all of them are either
+     blocked earlier by a GLOBAL rule or declare no RETIREMENT purpose, so
+     it never fires TRUE and never becomes the UNKNOWN that gates the
+     decision.)
 """
 
 from __future__ import annotations

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/gold_rule_pack.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/gold_rule_pack.json
@@ -59,6 +59,97 @@
         "verified_at": "2026-07-17T00:00:00Z",
         "verified_by": "gold-harness-authoring",
         "supersedes_source_record_id": null
+      },
+      {
+        "source_record_id": "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a01",
+        "source_key": "imigrasi.go.id.e33-secondhome.2026-07-19",
+        "version": 1,
+        "authority_type": "OFFICIAL_PORTAL",
+        "status": "VERIFIED",
+        "jurisdiction": "ID",
+        "title": "Ditjen Imigrasi official Second Home Visa (E33) pages — deposit/property/income thresholds",
+        "publisher": "Direktorat Jenderal Imigrasi",
+        "canonical_url": "https://www.imigrasi.go.id/",
+        "language": "id",
+        "document_number": null,
+        "locators": [],
+        "content_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "legal_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "recorded_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-19T00:00:00Z",
+        "verified_at": "2026-07-19T00:00:00Z",
+        "verified_by": "gold-harness-authoring",
+        "supersedes_source_record_id": null
+      },
+      {
+        "source_record_id": "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a02",
+        "source_key": "permenkumham.22.2023",
+        "version": 1,
+        "authority_type": "PRIMARY_LAW",
+        "status": "VERIFIED",
+        "jurisdiction": "ID",
+        "title": "Permenkumham 22 Tahun 2023 — Pasal 113 cumulative stay caps (>=5y first grant: 10y cap; <5y: 6y cap) and Pasal 185 first-grant durations",
+        "publisher": "Kementerian Hukum dan HAM",
+        "canonical_url": "https://peraturan.bpk.go.id/",
+        "language": "id",
+        "document_number": "Permenkumham 22 Tahun 2023",
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 113"
+          }
+        ],
+        "content_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "legal_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "recorded_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-21T00:00:00Z",
+        "verified_at": "2026-07-21T00:00:00Z",
+        "verified_by": "gold-harness-authoring",
+        "supersedes_source_record_id": null
+      },
+      {
+        "source_record_id": "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a03",
+        "source_key": "permenkumham.11.2024",
+        "version": 1,
+        "authority_type": "PRIMARY_LAW",
+        "status": "VERIFIED",
+        "jurisdiction": "ID",
+        "title": "Permenkumham 11 Tahun 2024 — senior age threshold amended to 55 (Pasal 33(2)(j)(4)) while Pasal 33(10)(d) still reads 60; operate on 55, disclose the 55-59 band ambiguity",
+        "publisher": "Kementerian Hukum dan HAM",
+        "canonical_url": "https://peraturan.bpk.go.id/",
+        "language": "id",
+        "document_number": "Permenkumham 11 Tahun 2024",
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 33"
+          }
+        ],
+        "content_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "legal_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "recorded_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-21T00:00:00Z",
+        "verified_at": "2026-07-21T00:00:00Z",
+        "verified_by": "gold-harness-authoring",
+        "supersedes_source_record_id": null
       }
     ],
     "products": [
@@ -321,13 +412,13 @@
         "public_catalog": true
       },
       {
-        "product_version_id": "83e860db-3e7a-42c8-8e8e-64c7d03dd540",
-        "product_code": "E33R",
+        "product_version_id": "2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33e5",
+        "product_code": "E33E",
         "legacy_codes": [],
         "legacy_slugs": [],
         "names": {
-          "id": "Visa E33R (gold harness)",
-          "en": "E33R product (gold harness)"
+          "id": "Visa Rumah Kedua Lansia untuk 5 Tahun (Golden Visa)",
+          "en": "Second Home Visa Elderly for 5 Years (E33E, Golden Visa)"
         },
         "category": "LIMITED_STAY",
         "status": "ACTIVE",
@@ -342,9 +433,55 @@
           "entry_count": "MULTIPLE"
         },
         "stay_policy": {
-          "kind": "VARIABLE_BY_GRANT",
-          "minimum_days": null,
-          "maximum_days": null
+          "kind": "FIXED_DAYS",
+          "minimum_days": 1,
+          "maximum_days": 1825
+        },
+        "extension_policy": {
+          "allowed": false,
+          "maximum_extensions": 0,
+          "days_per_extension": null
+        },
+        "clock_policy": {
+          "available": true,
+          "anchor": "PERMIT_ISSUED_AT",
+          "checkpoints": []
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "e33e_second_home_elderly_5y"
+        },
+        "source_refs": [
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a01",
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a03"
+        ],
+        "public_catalog": true
+      },
+      {
+        "product_version_id": "2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33f6",
+        "product_code": "E33F",
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "id": "Visa Rumah Kedua Lansia untuk 1 Tahun",
+          "en": "Second Home Visa Elderly for 1 Year (E33F)"
+        },
+        "category": "LIMITED_STAY",
+        "status": "ACTIVE",
+        "valid_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "covered_purposes": ["RETIREMENT"],
+        "prohibited_activities": [],
+        "sponsor_types": ["NONE"],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "minimum_days": 1,
+          "maximum_days": 365
         },
         "extension_policy": {
           "allowed": true,
@@ -358,9 +495,12 @@
         },
         "pricing_key": {
           "category": "kitas_permits",
-          "item_key": "e33r_retirement"
+          "item_key": "e33f_second_home_elderly_1y"
         },
-        "source_refs": ["c43c40ab-387a-46a1-a2a0-996692ee833e"],
+        "source_refs": [
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a01",
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a03"
+        ],
         "public_catalog": true
       },
       {
@@ -450,13 +590,13 @@
         "public_catalog": true
       },
       {
-        "product_version_id": "9f91257a-2df8-4495-b22f-2a6abb949e51",
-        "product_code": "E33S",
+        "product_version_id": "2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33e0",
+        "product_code": "E33",
         "legacy_codes": [],
         "legacy_slugs": [],
         "names": {
-          "id": "Visa E33S (gold harness)",
-          "en": "E33S product (gold harness)"
+          "id": "Visa Rumah Kedua (Second Home)",
+          "en": "Second Home Visa (E33)"
         },
         "category": "LIMITED_STAY",
         "status": "ACTIVE",
@@ -472,8 +612,8 @@
         },
         "stay_policy": {
           "kind": "FIXED_DAYS",
-          "minimum_days": 1825,
-          "maximum_days": 3650
+          "minimum_days": 1,
+          "maximum_days": 1825
         },
         "extension_policy": {
           "allowed": true,
@@ -487,9 +627,12 @@
         },
         "pricing_key": {
           "category": "kitas_permits",
-          "item_key": "e33s_second_home"
+          "item_key": "e33_second_home"
         },
-        "source_refs": ["c43c40ab-387a-46a1-a2a0-996692ee833e"],
+        "source_refs": [
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a01",
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a02"
+        ],
         "public_catalog": true
       }
     ],
@@ -943,7 +1086,7 @@
         "product_version_ids": ["5fcfb488-ae0c-4739-ad81-0b8b7d0b1701"]
       },
       {
-        "rule_id": "el-e33r-retirement",
+        "rule_id": "el-e33e-retirement",
         "stage": "ELIGIBILITY",
         "scope": "PRODUCTS",
         "priority": 100,
@@ -963,6 +1106,26 @@
               "op": "gte",
               "fact": "derived.age_years",
               "value": 55
+            },
+            {
+              "op": "gte",
+              "fact": "secondhome.bank_deposit_usd",
+              "value": 50000
+            },
+            {
+              "op": "eq",
+              "fact": "secondhome.bank_deposit_at_state_bank",
+              "value": true
+            },
+            {
+              "op": "eq",
+              "fact": "secondhome.bank_deposit_in_own_name",
+              "value": true
+            },
+            {
+              "op": "gte",
+              "fact": "secondhome.passive_monthly_income_usd",
+              "value": 3000
             }
           ]
         },
@@ -972,11 +1135,95 @@
           "covered_purposes": ["RETIREMENT"]
         },
         "on_unknown": "NEEDS_INPUT",
-        "required_facts": ["intent.purposes", "derived.age_years"],
-        "source_refs": ["c43c40ab-387a-46a1-a2a0-996692ee833e"],
-        "explanation_key": "explain.el_e33r_retirement",
+        "required_facts": [
+          "intent.purposes",
+          "derived.age_years",
+          "secondhome.bank_deposit_usd",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.passive_monthly_income_usd"
+        ],
+        "source_refs": [
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a01",
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a03"
+        ],
+        "explanation_key": "explain.el_e33e_retirement",
         "safety_critical": false,
-        "product_version_ids": ["83e860db-3e7a-42c8-8e8e-64c7d03dd540"]
+        "product_version_ids": ["2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33e5"]
+      },
+      {
+        "rule_id": "hr-e33e-age-band-55-59",
+        "stage": "HUMAN_REVIEW",
+        "scope": "PRODUCTS",
+        "priority": 70,
+        "valid_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "between",
+          "fact": "derived.age_years",
+          "lower": 55,
+          "upper": 59
+        },
+        "effect": {
+          "type": "REQUIRE_REVIEW",
+          "reason_code": "SECOND_HOME_SENIOR_AGE_AMBIGUITY_REVIEW"
+        },
+        "on_unknown": "HUMAN_REVIEW",
+        "required_facts": ["derived.age_years"],
+        "source_refs": ["7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a03"],
+        "explanation_key": "explain.hr_e33e_age_band_55_59",
+        "safety_critical": false,
+        "product_version_ids": ["2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33e5"]
+      },
+      {
+        "rule_id": "el-e33f-retirement",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-17T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "intersects",
+              "fact": "intent.purposes",
+              "values": ["RETIREMENT"]
+            },
+            {
+              "op": "gte",
+              "fact": "derived.age_years",
+              "value": 55
+            },
+            {
+              "op": "gte",
+              "fact": "secondhome.passive_monthly_income_usd",
+              "value": 3000
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "RETIREMENT_INCOME_ONLY_SUPPORTED",
+          "covered_purposes": ["RETIREMENT"]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "derived.age_years",
+          "secondhome.passive_monthly_income_usd"
+        ],
+        "source_refs": [
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a01",
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a03"
+        ],
+        "explanation_key": "explain.el_e33f_retirement",
+        "safety_critical": false,
+        "product_version_ids": ["2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33f6"]
       },
       {
         "rule_id": "el-e30-student",
@@ -1050,7 +1297,7 @@
         "product_version_ids": ["ec84d6ca-b9a7-4a69-a8b7-097d634d0cba"]
       },
       {
-        "rule_id": "el-e33s-secondhome",
+        "rule_id": "el-e33-secondhome",
         "stage": "ELIGIBILITY",
         "scope": "PRODUCTS",
         "priority": 100,
@@ -1067,9 +1314,34 @@
               "values": ["SECOND_HOME"]
             },
             {
-              "op": "eq",
-              "fact": "process.application_channel",
-              "value": "OFFSHORE"
+              "op": "any",
+              "args": [
+                {
+                  "op": "all",
+                  "args": [
+                    {
+                      "op": "gte",
+                      "fact": "secondhome.bank_deposit_usd",
+                      "value": 130000
+                    },
+                    {
+                      "op": "eq",
+                      "fact": "secondhome.bank_deposit_at_state_bank",
+                      "value": true
+                    },
+                    {
+                      "op": "eq",
+                      "fact": "secondhome.bank_deposit_in_own_name",
+                      "value": true
+                    }
+                  ]
+                },
+                {
+                  "op": "gte",
+                  "fact": "secondhome.qualifying_property_value_usd",
+                  "value": 1000000
+                }
+              ]
             }
           ]
         },
@@ -1079,11 +1351,20 @@
           "covered_purposes": ["SECOND_HOME"]
         },
         "on_unknown": "NEEDS_INPUT",
-        "required_facts": ["intent.purposes", "process.application_channel"],
-        "source_refs": ["c43c40ab-387a-46a1-a2a0-996692ee833e"],
-        "explanation_key": "explain.el_e33s_secondhome",
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.bank_deposit_usd",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.qualifying_property_value_usd"
+        ],
+        "source_refs": [
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a01",
+          "7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a02"
+        ],
+        "explanation_key": "explain.el_e33_secondhome",
         "safety_critical": false,
-        "product_version_ids": ["9f91257a-2df8-4495-b22f-2a6abb949e51"]
+        "product_version_ids": ["2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33e0"]
       }
     ]
   },

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/gold_rule_pack.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/gold_rule_pack.json
@@ -1152,7 +1152,7 @@
         "product_version_ids": ["2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33e5"]
       },
       {
-        "rule_id": "hr-e33e-age-band-55-59",
+        "rule_id": "hr-e33e-e33f-age-band-55-59",
         "stage": "HUMAN_REVIEW",
         "scope": "PRODUCTS",
         "priority": 70,
@@ -1161,21 +1161,34 @@
           "to": null
         },
         "when": {
-          "op": "between",
-          "fact": "derived.age_years",
-          "lower": 55,
-          "upper": 59
+          "op": "all",
+          "args": [
+            {
+              "op": "intersects",
+              "fact": "intent.purposes",
+              "values": ["RETIREMENT"]
+            },
+            {
+              "op": "between",
+              "fact": "derived.age_years",
+              "lower": 55,
+              "upper": 59
+            }
+          ]
         },
         "effect": {
           "type": "REQUIRE_REVIEW",
           "reason_code": "SECOND_HOME_SENIOR_AGE_AMBIGUITY_REVIEW"
         },
         "on_unknown": "HUMAN_REVIEW",
-        "required_facts": ["derived.age_years"],
+        "required_facts": ["intent.purposes", "derived.age_years"],
         "source_refs": ["7f3a9c1e-2b4d-4e5f-9a6b-1c2d3e4f5a03"],
-        "explanation_key": "explain.hr_e33e_age_band_55_59",
+        "explanation_key": "explain.hr_e33e_e33f_age_band_55_59",
         "safety_critical": false,
-        "product_version_ids": ["2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33e5"]
+        "product_version_ids": [
+          "2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33e5",
+          "2c7f1a94-5b6d-4e3a-9c8f-7d2e1b0a33f6"
+        ]
       },
       {
         "rule_id": "el-e33f-retirement",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/01_tourist_simple.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/01_tourist_simple.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/02_business_c2.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/02_business_c2.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/03_overstay_hard_filter_exclusion.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/03_overstay_hard_filter_exclusion.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "ONSHORE_CONVERSION"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/04_unknown_safety_critical_blocked.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/04_unknown_safety_critical_blocked.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/05_human_review_active_overstay.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/05_human_review_active_overstay.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "ONSHORE_CONVERSION"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/06_family_dependent_spouse.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/06_family_dependent_spouse.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/07_retiree.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/07_retiree.json
@@ -1,6 +1,6 @@
 {
   "persona_id": "07_retiree",
-  "narrative": "British retiree, 61, settling in Bali long-term on a retirement permit.",
+  "narrative": "British retiree, 61, settling in Bali long-term on a retirement permit, with a USD 60,000 own-name deposit at a state-owned (BUMN) bank and USD 3,500/month passive income -- qualifies for both the E33E 5-year golden track and the E33F 1-year income-only track.",
   "notes": "",
   "facts": {
     "person.birth_date": {
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "KNOWN",
+      "value": 60000
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "KNOWN",
+      "value": true
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "KNOWN",
+      "value": true
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "KNOWN",
+      "value": 3500
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"
@@ -148,9 +168,14 @@
     "global_state": "SUPPORTED_CANDIDATES",
     "global_reason_codes": [],
     "products": {
-      "E33R": {
+      "E33E": {
         "proof_state": "SUPPORTED",
         "reason_codes": ["RETIREMENT_SUPPORTED"],
+        "covered_purposes": ["RETIREMENT"]
+      },
+      "E33F": {
+        "proof_state": "SUPPORTED",
+        "reason_codes": ["RETIREMENT_INCOME_ONLY_SUPPORTED"],
         "covered_purposes": ["RETIREMENT"]
       }
     },

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/08_remote_worker.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/08_remote_worker.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/09_investor.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/09_investor.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/10_student_blocked_unknown_eligibility.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/10_student_blocked_unknown_eligibility.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "UNVERIFIED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/11_medical.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/11_medical.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/12_journalist_other_purpose_review.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/12_journalist_other_purpose_review.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/13_diaspora_second_home.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/13_diaspora_second_home.json
@@ -1,11 +1,11 @@
 {
   "persona_id": "13_diaspora_second_home",
-  "narrative": "Dutch-passport former Indonesian national returning under the Second Home track, applying offshore.",
-  "notes": "Diaspora/ex-WNI framing is carried in the narrative, not a dedicated fact: the closed 38-path FactPath vocabulary has no 'former citizen' flag, so the scenario is modeled as any foreign-nationality applicant declaring SECOND_HOME purpose -- the product-level mechanics are identical to a non-diaspora Second Home applicant by design.",
+  "narrative": "Dutch-passport former Indonesian national returning under the Second Home track (base E33 bank-deposit route), applying offshore.",
+  "notes": "Diaspora/ex-WNI framing is carried in the narrative, not a dedicated fact: the closed 43-path FactPath vocabulary has no 'former citizen' flag, so the scenario is modeled as any foreign-nationality applicant declaring SECOND_HOME purpose with a qualifying own-name USD 150,000 deposit at a state-owned (BUMN) Indonesian bank (above the USD 130,000 threshold) -- the product-level mechanics are identical to a non-diaspora Second Home applicant by design. Birth date places the applicant at 49 on GOLD_EFFECTIVE_AT, deliberately OUTSIDE the E33E 55-59 BERSYARAT review band so the senior products resolve mechanically UNSUPPORTED (no purpose overlap) rather than REVIEW.",
   "facts": {
     "person.birth_date": {
       "status": "KNOWN",
-      "value": "1970-10-10"
+      "value": "1976-10-10"
     },
     "person.nationalities": {
       "status": "KNOWN",
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "KNOWN",
+      "value": 150000
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "KNOWN",
+      "value": true
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "KNOWN",
+      "value": true
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"
@@ -148,7 +168,7 @@
     "global_state": "SUPPORTED_CANDIDATES",
     "global_reason_codes": [],
     "products": {
-      "E33S": {
+      "E33": {
         "proof_state": "SUPPORTED",
         "reason_codes": ["SECOND_HOME_SUPPORTED"],
         "covered_purposes": ["SECOND_HOME"]

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/14_calling_visa_nationality.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/14_calling_visa_nationality.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/15_minor_without_guardian.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/15_minor_without_guardian.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/16_multi_purpose_applicant.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/16_multi_purpose_applicant.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/17_boundary_ages_dates.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/17_boundary_ages_dates.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "ONSHORE_CONVERSION"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/18_nfc_unicode_name.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/18_nfc_unicode_name.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/19_leap_day_birth.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/19_leap_day_birth.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "OFFSHORE"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/20_contradictory_facts_no_crash.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/20_contradictory_facts_no_crash.json
@@ -127,6 +127,26 @@
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
     },
+    "secondhome.bank_deposit_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.passive_monthly_income_usd": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
     "process.application_channel": {
       "status": "KNOWN",
       "value": "ONSHORE_CONVERSION"

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/21_senior_age_band_review.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/21_senior_age_band_review.json
@@ -1,19 +1,19 @@
 {
-  "persona_id": "13_diaspora_second_home",
-  "narrative": "Dutch-passport former Indonesian national returning under the Second Home track (base E33 bank-deposit route), applying offshore.",
-  "notes": "Diaspora/ex-WNI framing is carried in the narrative, not a dedicated fact: the closed 43-path FactPath vocabulary has no 'former citizen' flag, so the scenario is modeled as any foreign-nationality applicant declaring SECOND_HOME purpose with a qualifying own-name USD 150,000 deposit at a state-owned (BUMN) Indonesian bank (above the USD 130,000 threshold) -- the product-level mechanics are identical to a non-diaspora Second Home applicant by design. The applicant is 55 on GOLD_EFFECTIVE_AT: the E33E/E33F 55-59 BERSYARAT review rule (hr-e33e-e33f-age-band-55-59) does NOT fire here because it is purpose-guarded to RETIREMENT, so the senior products resolve mechanically UNSUPPORTED (no purpose overlap).",
+  "persona_id": "21_senior_age_band_review",
+  "narrative": "Australian retiree, 57, with a USD 60,000 own-name BUMN-bank deposit and USD 3,500/month passive income -- financially qualified for both senior tracks, but inside the Permenkumham 11/2024 55-59 age ambiguity band.",
+  "notes": "Exercises hr-e33e-e33f-age-band-55-59 firing TRUE: age 57 on GOLD_EFFECTIVE_AT (in the 55-59 BERSYARAT band where Pasal 33(2)(j)(4) reads 55 but Pasal 33(10)(d) still reads 60) plus RETIREMENT purpose. Both E33E and E33F must route to REVIEW (signed-disclosure human review, owner decision 2026-07-23: no hard block), never SUPPORTED and never UNSUPPORTED. Global decision is HUMAN_REVIEW_REQUIRED with the band reason code.",
   "facts": {
     "person.birth_date": {
       "status": "KNOWN",
-      "value": "1970-10-10"
+      "value": "1969-03-15"
     },
     "person.nationalities": {
       "status": "KNOWN",
-      "value": ["NL"]
+      "value": ["AU"]
     },
     "person.marital_status": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": "MARRIED"
     },
     "immigration.currently_in_indonesia": {
       "status": "KNOWN",
@@ -41,7 +41,7 @@
     },
     "intent.purposes": {
       "status": "KNOWN",
-      "value": ["SECOND_HOME"]
+      "value": ["RETIREMENT"]
     },
     "intent.stay_days": {
       "status": "UNKNOWN",
@@ -129,7 +129,7 @@
     },
     "secondhome.bank_deposit_usd": {
       "status": "KNOWN",
-      "value": 150000
+      "value": 60000
     },
     "secondhome.bank_deposit_at_state_bank": {
       "status": "KNOWN",
@@ -144,8 +144,8 @@
       "reason": "NOT_ASKED"
     },
     "secondhome.passive_monthly_income_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 3500
     },
     "process.application_channel": {
       "status": "KNOWN",
@@ -165,18 +165,25 @@
     }
   },
   "expected": {
-    "global_state": "SUPPORTED_CANDIDATES",
-    "global_reason_codes": [],
+    "global_state": "HUMAN_REVIEW_REQUIRED",
+    "global_reason_codes": ["SECOND_HOME_SENIOR_AGE_AMBIGUITY_REVIEW"],
     "products": {
-      "E33": {
-        "proof_state": "SUPPORTED",
-        "reason_codes": ["SECOND_HOME_SUPPORTED"],
-        "covered_purposes": ["SECOND_HOME"]
+      "E33E": {
+        "proof_state": "REVIEW",
+        "reason_codes": ["SECOND_HOME_SENIOR_AGE_AMBIGUITY_REVIEW"]
+      },
+      "E33F": {
+        "proof_state": "REVIEW",
+        "reason_codes": ["SECOND_HOME_SENIOR_AGE_AMBIGUITY_REVIEW"]
       }
     },
     "default": {
       "kind": "UNSUPPORTED_NO_PURPOSE_OVERLAP",
-      "requested_purposes": ["SECOND_HOME"]
+      "requested_purposes": ["RETIREMENT"]
+    },
+    "extra_checks": {
+      "derived_age_years": 57,
+      "derived_is_minor": false
     }
   }
 }

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/22_second_home_property_route.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/22_second_home_property_route.json
@@ -1,15 +1,15 @@
 {
-  "persona_id": "13_diaspora_second_home",
-  "narrative": "Dutch-passport former Indonesian national returning under the Second Home track (base E33 bank-deposit route), applying offshore.",
-  "notes": "Diaspora/ex-WNI framing is carried in the narrative, not a dedicated fact: the closed 43-path FactPath vocabulary has no 'former citizen' flag, so the scenario is modeled as any foreign-nationality applicant declaring SECOND_HOME purpose with a qualifying own-name USD 150,000 deposit at a state-owned (BUMN) Indonesian bank (above the USD 130,000 threshold) -- the product-level mechanics are identical to a non-diaspora Second Home applicant by design. The applicant is 55 on GOLD_EFFECTIVE_AT: the E33E/E33F 55-59 BERSYARAT review rule (hr-e33e-e33f-age-band-55-59) does NOT fire here because it is purpose-guarded to RETIREMENT, so the senior products resolve mechanically UNSUPPORTED (no purpose overlap).",
+  "persona_id": "22_second_home_property_route",
+  "narrative": "Canadian applicant, 45, qualifying for the base Second Home visa through a completed strata-title property valued at USD 1,200,000 instead of a bank deposit.",
+  "notes": "Exercises the property alternative of el-e33-secondhome's OR branch: no bank deposit facts at all (UNKNOWN), qualifying property KNOWN above the USD 1,000,000 threshold. The Kleene `any` resolves TRUE on the property arm despite the deposit arm being UNKNOWN, so E33 is SUPPORTED.",
   "facts": {
     "person.birth_date": {
       "status": "KNOWN",
-      "value": "1970-10-10"
+      "value": "1981-04-20"
     },
     "person.nationalities": {
       "status": "KNOWN",
-      "value": ["NL"]
+      "value": ["CA"]
     },
     "person.marital_status": {
       "status": "UNKNOWN",
@@ -128,20 +128,20 @@
       "reason": "NOT_ASKED"
     },
     "secondhome.bank_deposit_usd": {
-      "status": "KNOWN",
-      "value": 150000
-    },
-    "secondhome.bank_deposit_at_state_bank": {
-      "status": "KNOWN",
-      "value": true
-    },
-    "secondhome.bank_deposit_in_own_name": {
-      "status": "KNOWN",
-      "value": true
-    },
-    "secondhome.qualifying_property_value_usd": {
       "status": "UNKNOWN",
       "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_at_state_bank": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.bank_deposit_in_own_name": {
+      "status": "UNKNOWN",
+      "reason": "NOT_ASKED"
+    },
+    "secondhome.qualifying_property_value_usd": {
+      "status": "KNOWN",
+      "value": 1200000
     },
     "secondhome.passive_monthly_income_usd": {
       "status": "UNKNOWN",

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/23_second_home_deposit_wrong_bank.json
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/fixtures/personas/23_second_home_deposit_wrong_bank.json
@@ -1,15 +1,15 @@
 {
-  "persona_id": "13_diaspora_second_home",
-  "narrative": "Dutch-passport former Indonesian national returning under the Second Home track (base E33 bank-deposit route), applying offshore.",
-  "notes": "Diaspora/ex-WNI framing is carried in the narrative, not a dedicated fact: the closed 43-path FactPath vocabulary has no 'former citizen' flag, so the scenario is modeled as any foreign-nationality applicant declaring SECOND_HOME purpose with a qualifying own-name USD 150,000 deposit at a state-owned (BUMN) Indonesian bank (above the USD 130,000 threshold) -- the product-level mechanics are identical to a non-diaspora Second Home applicant by design. The applicant is 55 on GOLD_EFFECTIVE_AT: the E33E/E33F 55-59 BERSYARAT review rule (hr-e33e-e33f-age-band-55-59) does NOT fire here because it is purpose-guarded to RETIREMENT, so the senior products resolve mechanically UNSUPPORTED (no purpose overlap).",
+  "persona_id": "23_second_home_deposit_wrong_bank",
+  "narrative": "German applicant, 52, with a USD 130,000 own-name deposit at a PRIVATE (non-BUMN) Indonesian bank and no qualifying property -- the amount meets the threshold but the state-owned-bank condition fails.",
+  "notes": "Negative boundary for el-e33-secondhome: deposit exactly at the USD 130,000 threshold but secondhome.bank_deposit_at_state_bank=false, and the property arm definitely below threshold (KNOWN 250,000), so the whole any-branch resolves FALSE (never UNKNOWN) and E33 is mechanically UNSUPPORTED with SECOND_HOME missing -- a wrong-bank deposit must never produce a SUPPORTED or BLOCKED_UNKNOWN verdict.",
   "facts": {
     "person.birth_date": {
       "status": "KNOWN",
-      "value": "1970-10-10"
+      "value": "1974-01-15"
     },
     "person.nationalities": {
       "status": "KNOWN",
-      "value": ["NL"]
+      "value": ["DE"]
     },
     "person.marital_status": {
       "status": "UNKNOWN",
@@ -129,19 +129,19 @@
     },
     "secondhome.bank_deposit_usd": {
       "status": "KNOWN",
-      "value": 150000
+      "value": 130000
     },
     "secondhome.bank_deposit_at_state_bank": {
       "status": "KNOWN",
-      "value": true
+      "value": false
     },
     "secondhome.bank_deposit_in_own_name": {
       "status": "KNOWN",
       "value": true
     },
     "secondhome.qualifying_property_value_usd": {
-      "status": "UNKNOWN",
-      "reason": "NOT_ASKED"
+      "status": "KNOWN",
+      "value": 250000
     },
     "secondhome.passive_monthly_income_usd": {
       "status": "UNKNOWN",
@@ -165,13 +165,12 @@
     }
   },
   "expected": {
-    "global_state": "SUPPORTED_CANDIDATES",
+    "global_state": "NO_SUPPORTED_PATH",
     "global_reason_codes": [],
     "products": {
       "E33": {
-        "proof_state": "SUPPORTED",
-        "reason_codes": ["SECOND_HOME_SUPPORTED"],
-        "covered_purposes": ["SECOND_HOME"]
+        "proof_state": "UNSUPPORTED",
+        "missing_purposes": ["SECOND_HOME"]
       }
     },
     "default": {

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/loader.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/loader.py
@@ -1,7 +1,14 @@
 """Loaders for the gold-harness fixtures: the designed RulePack (source JSON,
-compiled via the REAL compiler) and the 20 gold personas (source JSON,
+compiled via the REAL compiler) and the 23 gold personas (source JSON,
 validated against the closed FactPath vocabulary and parsed into real
 ``models.ApplicantFacts`` Pydantic objects -- never a hand-rolled shape).
+
+E33 product modeling note (JSON has no comment syntax and ``RulePack`` is
+``extra="forbid"``, so this lives here): base E33's ``extension_policy``
+(allowed, 1 x 1825d) models the Permenkumham 22/2023 Pasal 113 renewal path
+(>=5y first grant -> 10y cumulative cap), while E33E's (not allowed, 0)
+deliberately models the golden 5-year senior grant as a single block --
+conservative: no renewal is claimed until the regulation text confirms one.
 """
 
 from __future__ import annotations

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/loader.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/loader.py
@@ -34,7 +34,7 @@ PERSONAS_DIR = FIXTURES_DIR / "personas"
 #: back-reference into the DB-fixture-heavy sibling conftest module).
 GOLD_EFFECTIVE_AT = datetime(2026, 7, 17, 0, 0, 0, tzinfo=timezone.utc)
 
-#: The full closed 35-key wire vocabulary (``ApplicantFactsData``'s aliases),
+#: The full closed 40-key wire vocabulary (``ApplicantFactsData``'s aliases),
 #: used to fail loudly if a persona fixture is missing a key or carries an
 #: extra one -- Pydantic's own ``extra="forbid"``/required-field validation
 #: already enforces this at ``ApplicantFacts.model_validate()`` time; this
@@ -88,7 +88,7 @@ def _validate_wire_keys(persona_id: str, raw_facts: dict[str, Any]) -> None:
     extra = got - APPLICANT_FACT_WIRE_KEYS
     if missing or extra:
         raise ValueError(
-            f"persona {persona_id!r}: facts do not match the closed 35-path "
+            f"persona {persona_id!r}: facts do not match the closed 40-path "
             f"FactPath vocabulary -- missing={sorted(missing)} extra={sorted(extra)}"
         )
 

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/replay_report.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/replay_report.py
@@ -1,5 +1,5 @@
 """Machine-readable replay-report generator -- the evidence artifact the
-ENFORCE gate (Visa Oracle v2 skill, criterion G-b) cites: "20/20 gold
+ENFORCE gate (Visa Oracle v2 skill, criterion G-b) cites: "23/23 gold
 personas replay through the engine with zero unexplained divergences".
 
 Not a fixture -- this module is RUN, never committed output. Two entry

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/test_gold_replay.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/test_gold_replay.py
@@ -1,4 +1,4 @@
-"""Gold-persona replay: for each of the 20 gold personas x each of the 10
+"""Gold-persona replay: for each of the 20 gold personas x each of the 11
 products in the designed gold rule pack, run the REAL evaluator
 (``ast.evaluate_condition`` + ``compiler.build_compiled_pack``, via this
 package's ``adapter.py``) and assert the resulting proof state -- plus
@@ -31,8 +31,8 @@ PERSONAS = loader.load_all_personas()
 PRODUCT_CODES = sorted(p.product_code for p in PACK.products)
 
 assert len(PERSONAS) == 20, f"expected exactly 20 gold personas, found {len(PERSONAS)}"
-assert len(PRODUCT_CODES) == 10, (
-    f"expected exactly 10 products in the gold pack, found {len(PRODUCT_CODES)}"
+assert len(PRODUCT_CODES) == 11, (
+    f"expected exactly 11 products in the gold pack, found {len(PRODUCT_CODES)}"
 )
 
 _PERSONAS_BY_ID = {p.persona_id: p for p in PERSONAS}
@@ -60,7 +60,7 @@ RESULTS = _evaluate_every_persona()
 
 
 class TestPersonaProductReplay:
-    """20 personas x 10 products = 200 (persona, product) proof assertions."""
+    """20 personas x 11 products = 220 (persona, product) proof assertions."""
 
     @pytest.mark.parametrize("persona_id", sorted(_PERSONAS_BY_ID))
     @pytest.mark.parametrize("product_code", PRODUCT_CODES)

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/test_gold_replay.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/test_gold_replay.py
@@ -1,4 +1,4 @@
-"""Gold-persona replay: for each of the 20 gold personas x each of the 11
+"""Gold-persona replay: for each of the 23 gold personas x each of the 11
 products in the designed gold rule pack, run the REAL evaluator
 (``ast.evaluate_condition`` + ``compiler.build_compiled_pack``, via this
 package's ``adapter.py``) and assert the resulting proof state -- plus
@@ -30,7 +30,7 @@ PACK = loader.load_and_compile_rule_pack()
 PERSONAS = loader.load_all_personas()
 PRODUCT_CODES = sorted(p.product_code for p in PACK.products)
 
-assert len(PERSONAS) == 20, f"expected exactly 20 gold personas, found {len(PERSONAS)}"
+assert len(PERSONAS) == 23, f"expected exactly 23 gold personas, found {len(PERSONAS)}"
 assert len(PRODUCT_CODES) == 11, (
     f"expected exactly 11 products in the gold pack, found {len(PRODUCT_CODES)}"
 )
@@ -60,7 +60,7 @@ RESULTS = _evaluate_every_persona()
 
 
 class TestPersonaProductReplay:
-    """20 personas x 11 products = 220 (persona, product) proof assertions."""
+    """23 personas x 11 products = 253 (persona, product) proof assertions."""
 
     @pytest.mark.parametrize("persona_id", sorted(_PERSONAS_BY_ID))
     @pytest.mark.parametrize("product_code", PRODUCT_CODES)

--- a/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/test_metamorphic_properties.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/gold_harness/test_metamorphic_properties.py
@@ -1,4 +1,4 @@
-"""Three metamorphic properties asserted across ALL 20 gold personas, run
+"""Three metamorphic properties asserted across ALL 23 gold personas, run
 against the REAL evaluator (never re-derived by hand):
 
 (a) **Monotonicity** -- de-knowing a single known fact (KNOWN -> UNKNOWN)

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_fact_registry.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_fact_registry.py
@@ -1,7 +1,7 @@
 """Tests for ``backend.services.visa_engine.fact_registry``.
 
-Covers: the default catalog is seeded 1:1 with ``enums.FactPath`` (38
-entries, 35 applicant + 3 derived); ``spec()``/``missing_paths()`` behavior
+Covers: the default catalog is seeded 1:1 with ``enums.FactPath`` (43
+entries, 40 applicant + 3 derived); ``spec()``/``missing_paths()`` behavior
 (the PR1 brief's "required_facts subset-of registry" primitive); commercial
 classification exactly matches ``enums.COMMERCIAL_FACT_PATHS``; PII
 classification spot-checks per this module's own documented rationale;
@@ -43,8 +43,8 @@ class TestDefaultCatalogCompleteness:
             spec = DEFAULT_FACT_REGISTRY.spec(path)
             assert spec.path is path
 
-    def test_catalog_has_exactly_38_entries(self) -> None:
-        assert len(DEFAULT_FACT_REGISTRY.all_paths()) == 38
+    def test_catalog_has_exactly_43_entries(self) -> None:
+        assert len(DEFAULT_FACT_REGISTRY.all_paths()) == 43
 
     def test_all_paths_matches_fact_path_enum(self) -> None:
         assert DEFAULT_FACT_REGISTRY.all_paths() == frozenset(FactPath)
@@ -137,7 +137,7 @@ class TestRegistryImmutability:
         # must be impossible, not merely type-annotated as read-only.
         with pytest.raises(AttributeError):
             DEFAULT_FACT_REGISTRY._specs.clear()  # type: ignore[attr-defined]
-        assert len(DEFAULT_FACT_REGISTRY.all_paths()) == 38
+        assert len(DEFAULT_FACT_REGISTRY.all_paths()) == 43
 
     def test_specs_mapping_cannot_be_item_assigned(self) -> None:
         with pytest.raises(TypeError):
@@ -262,7 +262,7 @@ class TestValueFormatKindConsistency:
         # hotfix's __post_init__ addition must not retroactively break
         # _DEFAULT_SPECS (module import already proves this at collection
         # time; this is the explicit, readable assertion of it).
-        assert len(DEFAULT_FACT_REGISTRY.all_paths()) == 38
+        assert len(DEFAULT_FACT_REGISTRY.all_paths()) == 43
 
 
 class TestRegistryConstruction:
@@ -294,14 +294,14 @@ class TestRegistryConstruction:
             ]
         )
         assert custom.all_paths() == frozenset({FactPath.PERSON_BIRTH_DATE})
-        assert len(DEFAULT_FACT_REGISTRY.all_paths()) == 38
+        assert len(DEFAULT_FACT_REGISTRY.all_paths()) == 43
 
 
 _UNKNOWN_WIRE = {"status": "UNKNOWN", "reason": "NOT_ASKED"}
 
 
 def _applicant_facts(overrides: dict[str, Any], *, assessment_id: uuid.UUID | None = None) -> ApplicantFacts:
-    """Build an ``ApplicantFacts`` with every one of the 35 paths defaulted
+    """Build an ``ApplicantFacts`` with every one of the 40 paths defaulted
     to UNKNOWN, then override the given wire keys with KNOWN wire values —
     the minimal builder ``derive()``'s tests need (distinct from
     ``conftest.make_applicant_facts``, which is all-UNKNOWN with no override
@@ -339,6 +339,11 @@ def _applicant_facts(overrides: dict[str, Any], *, assessment_id: uuid.UUID | No
         "study.level": _UNKNOWN_WIRE,
         "study.admission_confirmed": _UNKNOWN_WIRE,
         "study.sponsor_confirmed": _UNKNOWN_WIRE,
+        "secondhome.bank_deposit_usd": _UNKNOWN_WIRE,
+        "secondhome.bank_deposit_at_state_bank": _UNKNOWN_WIRE,
+        "secondhome.bank_deposit_in_own_name": _UNKNOWN_WIRE,
+        "secondhome.qualifying_property_value_usd": _UNKNOWN_WIRE,
+        "secondhome.passive_monthly_income_usd": _UNKNOWN_WIRE,
         "process.application_channel": _UNKNOWN_WIRE,
         "process.wants_onshore_conversion": _UNKNOWN_WIRE,
         "commercial.service_fee_budget_idr": _UNKNOWN_WIRE,
@@ -372,7 +377,7 @@ class TestDeriveRequiresAwareEffectiveAt:
 
 
 class TestDeriveWireToRuntime:
-    def test_every_one_of_38_paths_present_in_snapshot(self) -> None:
+    def test_every_one_of_43_paths_present_in_snapshot(self) -> None:
         snapshot = DEFAULT_FACT_REGISTRY.derive(_applicant_facts({}), effective_at=GOLD_EFFECTIVE_AT)
         assert frozenset(snapshot.values) == frozenset(FactPath)
 
@@ -507,9 +512,9 @@ class TestCanonicalFactPayload:
         payload = canonical_fact_payload(_applicant_facts({}))
         assert list(payload.keys()) == sorted(payload.keys())
 
-    def test_covers_all_35_applicant_paths(self) -> None:
+    def test_covers_all_40_applicant_paths(self) -> None:
         payload = canonical_fact_payload(_applicant_facts({}))
-        assert len(payload) == 35
+        assert len(payload) == 40
 
     def test_is_json_serializable(self) -> None:
         import json

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_schema_contracts.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_schema_contracts.py
@@ -148,7 +148,7 @@ class TestAliasOnlyConstruction:
         assert tr.from_ == GOLD_EFFECTIVE_AT
 
     def test_applicant_facts_data_python_name_rejected(self) -> None:
-        # Isolate the populate_by_name effect: 34 of 35 keys stay correctly
+        # Isolate the populate_by_name effect: 39 of 40 keys stay correctly
         # alias-keyed, only "person.birth_date" is swapped for its Python
         # name. With populate_by_name=True this would have been accepted
         # (matched by name); alias-only construction must reject it as an

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_match.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_match.py
@@ -192,15 +192,15 @@ class TestBuildShadowFacts:
         assert f1 is not None and f2 is not None
         assert f1.assessment_id != f2.assessment_id
 
-    def test_exactly_3_known_and_32_unknown_fields(self) -> None:
+    def test_exactly_3_known_and_37_unknown_fields(self) -> None:
         facts = shadow.build_shadow_facts(
             nationality="US", purpose=Purpose.LONG_TOURISM, duration_months=2, match_hash="h5"
         )
         assert facts is not None
         statuses = [getattr(facts.facts, name).status for name in type(facts.facts).model_fields]
-        assert len(statuses) == 35
+        assert len(statuses) == 40
         assert statuses.count("KNOWN") == 3
-        assert statuses.count("UNKNOWN") == 32
+        assert statuses.count("UNKNOWN") == 37
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## E33 Second Home — engine verticale (critical path, master list 2.2-2.5) + red-team fixes

Il motore Visa Oracle v2 può finalmente valutare l'eligibilità Second Home. Scope owner: rotta bancaria (E33/E33E/E33F + dependent vocab).

### Contenuto
- **FactPath 38 → 43**: `secondhome.bank_deposit_usd`, `.bank_deposit_at_state_bank`, `.bank_deposit_in_own_name`, `.qualifying_property_value_usd`, `.passive_monthly_income_usd` (USD come NonNegativeInteger, PII SENSITIVE per UU PDP) + `RelationType.SIBLING`. Nessun fatto BSI/split-deposit per design (claim vietati)
- **Prodotti reali** nel gold rule pack (sintetici E33S/E33R rimossi): **E33** (130k BUMN own-name O proprietà 1M, 5y, cap 10y), **E33E** (55+, 50k+3k/mese, 5y), **E33F** (55+, 3k/mese solo reddito, 1y, cap 6y)
- **Regola banda 55-59** con purpose guard (red-team HIGH fix): REVIEW solo per RETIREMENT-purpose, attaccata a E33E ed E33F — gestione BERSYARAT dell'ambiguità Pasal 33 (decisione owner)
- **Pricing**: `VisaType.E33` + hint → riga esistente "E33 Second Home (5 Years)" 39M (verificato live)
- **23 personas gold** (da 20): copertura banda 55-59, rotta proprietà, deposito-banca-sbagliata; la regola di sicurezza ora spara TRUE nei test

### Red-team indipendente
Verdetto FIX-THEN-SHIP → fix applicati (`51bd12869e`): purpose guard, E33F attaccata, 3 personas di copertura. Categorie pulite: soglie, AND/OR, cap, valute, integrità asserzioni, wiring prezzi.

### Test
1135 passed non-DB (gold replay + metamorfici + visa_check). I 118 errori `asyncpg role "nuzantara"` sono ambientali (Air-M5 senza Postgres per design) — **da riverificare su Pro/CI**.

### Note merge
- Contratti/snapshot rigenerati nello stesso commit (tripwire drift)
- Dipende concettualmente da `e33-fact-registry` (verità) ma nessun conflitto file atteso

🤖 Kimi (Air-M5) — review & merge via sessione Claude.
