### PR TITLE
feat(visa-engine): migration 256 traffic_source + G-a vol/breadth collector split (Fable deltas 1-2)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/256_visa_traffic_source.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/256_visa_traffic_source.sql
@@ -1,0 +1,54 @@
+-- Migration 256: Visa Oracle SHADOW traffic-source marker
+--
+-- Migration 255's evidence substrate cannot distinguish real end-user
+-- traffic from synthetic corpus traffic: a row written by the live SHADOW
+-- path and a row written by the gold-corpus replay driver look identical in
+-- visa_decisions.  Without that distinction the G-a volume/breadth gate is
+-- gameable -- a synthetic corpus could manufacture the 1,000 distinct
+-- requests / 7 consecutive days / 30 visa codes the gate demands, and the
+-- collector would count them as production adoption.  Fable final-gate
+-- deltas 1-2 (binding, 2026-07-23) therefore require a traffic_source
+-- marker so the evidence collector can split G-a into G-a-vol (real traffic
+-- only) and G-a-breadth (synthetic corpus, honestly labeled) and so a gate
+-- auditor can verify the split from the audit log alone.
+--
+-- Precedent: migration 187 (probe-sandbox isolation) established the
+-- storage-level isolation-flag pattern for synthetic data.  Unlike 187's
+-- NOT NULL DEFAULT false boolean, this marker is deliberately NULLABLE:
+-- rows predating this migration carry NULL, which means "unknown
+-- provenance" and is reported as `legacy` by the evidence collector,
+-- counted toward NEITHER gate.  NULLs are never backfilled with guesses --
+-- legacy rows keep failing closed exactly as they did under 255.
+--
+-- The CHECK constraint is the storage-level barrier: writers may only ever
+-- label a row 'real', 'synthetic_gold', or 'synthetic_driver'.  As of this
+-- migration no writer sets the column yet; labeling lands with the
+-- synthetic-corpus drivers and the read-path wiring in later PRs, and
+-- until then every row stays legacy (fail-closed).
+--
+-- The partial index mirrors 255's: the evidence collector is the only
+-- reader of this column and it always filters MATCH/SHADOW, so the index
+-- covers exactly that slice, ordered by created_at for windowed scans.
+--
+-- This migration does not change VISA_ENGINE_MATCH_MODE and cannot arm ENFORCE.
+
+ALTER TABLE public.visa_decisions
+    ADD COLUMN traffic_source TEXT
+        CHECK (
+            traffic_source IS NULL
+            OR traffic_source IN (
+                'real',
+                'synthetic_gold',
+                'synthetic_driver'
+            )
+        );
+
+CREATE INDEX idx_visa_decisions_shadow_traffic_source
+    ON public.visa_decisions (traffic_source, created_at)
+    WHERE engine_surface = 'MATCH' AND engine_mode = 'SHADOW';
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS public.idx_visa_decisions_shadow_traffic_source;
+
+ALTER TABLE IF EXISTS public.visa_decisions
+    DROP COLUMN IF EXISTS traffic_source;

--- a/apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
+++ b/apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
@@ -1,10 +1,22 @@
 """Fail-closed, PII-free Visa Oracle SHADOW gate evidence collector.
 
-This module measures only the two gates that can be derived from the
+This module measures only the gates that can be derived from the
 ``visa_decisions`` audit log: G-a (volume/breadth) and G-c (grounding).
 G-b (the independently graded 20-persona replay) and G-d (the recorded live
 rollback drill) are always reported as unmeasured here.  Consequently this
 collector can never, by itself, declare ENFORCE ready.
+
+Fable final-gate deltas 1-2 (binding, 2026-07-23): migration 255's
+substrate could not distinguish real end-user traffic from synthetic corpus
+traffic, so G-a is split by migration 256's ``traffic_source`` marker into
+``G-a-vol`` (rows labeled ``real`` only -- synthetic traffic can never
+manufacture production adoption) and ``G-a-breadth`` (synthetic corpus
+classes, honestly labeled in the report fields).  Rows whose
+``traffic_source`` is NULL (pre-256 legacy rows) or not one of the CHECKed
+classes are reported as ``legacy`` and counted toward NEITHER G-a gate --
+the same fail-closed philosophy as migration 255's nullable correlators.
+G-c is intentionally NOT split: grounding quality is a property of the
+engine's output and applies to every audited row regardless of provenance.
 
 No applicant facts, Match tokens, decision IDs, or request fingerprints are
 returned.  The collector reads the PII-free audit projection and emits only
@@ -17,6 +29,7 @@ import json
 import uuid
 from collections import Counter
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
@@ -34,8 +47,37 @@ REQUIRED_INTERVIEW_CATEGORIES = frozenset(
     purpose.value for purpose in Purpose if purpose is not Purpose.OTHER
 )
 
+#: ``traffic_source`` value (migration 256 CHECK) marking genuine end-user
+#: SHADOW traffic.  Only these rows may satisfy the G-a-vol gate.
+REAL_TRAFFIC_SOURCE = "real"
+
+#: ``traffic_source`` values (migration 256 CHECK) marking synthetic corpus
+#: writers (gold-corpus replay, corpus driver).  These rows feed only the
+#: honestly-labeled G-a-breadth gate, never G-a-vol.
+SYNTHETIC_TRAFFIC_SOURCES = frozenset({"synthetic_gold", "synthetic_driver"})
+
 _VALID_CATEGORIES = frozenset(purpose.value for purpose in Purpose)
 _CITATIONLESS_ABSTENTION_STATES = frozenset({DecisionState.NEEDS_INPUT.value})
+
+
+@dataclass
+class _GateAAccumulator:
+    """Per-traffic-class G-a metrics (Fable deltas 1-2 split).
+
+    One instance counts ``real`` rows (G-a-vol), the other counts synthetic
+    corpus rows (G-a-breadth).  Legacy rows are never accumulated here.
+    """
+
+    row_count: int = 0
+    fingerprints: set[bytes] = field(default_factory=set)
+    valid_fingerprint_evaluations: int = 0
+    categories: Counter[str] = field(default_factory=Counter)
+    candidate_codes: set[str] = field(default_factory=set)
+    active_days: set[date] = field(default_factory=set)
+    missing_request_fingerprints: int = 0
+    missing_or_invalid_categories: int = 0
+    malformed_candidate_summaries: int = 0
+    invalid_candidate_bindings: int = 0
 
 
 def _json_array(value: object) -> list[object] | None:
@@ -89,6 +131,59 @@ def _gate(status: bool, **details: object) -> dict[str, object]:
     return {"status": "GREEN" if status else "RED", "green": status, **details}
 
 
+def _gate_a_report(
+    accumulator: _GateAAccumulator,
+    *,
+    traffic_sources: list[str],
+    traffic_source_counts: dict[str, int],
+    window_duration: timedelta,
+) -> dict[str, object]:
+    """Build one traffic-class G-a gate report (G-a-vol or G-a-breadth).
+
+    Same thresholds and field names for both classes; the ``traffic_sources``
+    / ``traffic_source_counts`` fields label honestly which rows were counted.
+    """
+
+    longest_streak = _longest_consecutive_day_streak(accumulator.active_days)
+    missing_categories = sorted(REQUIRED_INTERVIEW_CATEGORIES - accumulator.categories.keys())
+    green = (
+        window_duration >= timedelta(days=MIN_CONSECUTIVE_DAYS)
+        and len(accumulator.fingerprints) >= MIN_DISTINCT_REQUESTS
+        and longest_streak >= MIN_CONSECUTIVE_DAYS
+        and not missing_categories
+        and len(accumulator.candidate_codes) >= MIN_DISTINCT_VISA_CODES
+        and accumulator.missing_request_fingerprints == 0
+        and accumulator.missing_or_invalid_categories == 0
+        and accumulator.malformed_candidate_summaries == 0
+        and accumulator.invalid_candidate_bindings == 0
+    )
+    return _gate(
+        green,
+        traffic_sources=traffic_sources,
+        traffic_source_counts=traffic_source_counts,
+        total_audit_rows=accumulator.row_count,
+        window_duration_hours=window_duration.total_seconds() / 3600,
+        minimum_window_duration_hours=MIN_CONSECUTIVE_DAYS * 24,
+        distinct_requests=len(accumulator.fingerprints),
+        minimum_distinct_requests=MIN_DISTINCT_REQUESTS,
+        duplicate_evaluations=accumulator.valid_fingerprint_evaluations
+        - len(accumulator.fingerprints),
+        active_utc_days=len(accumulator.active_days),
+        longest_consecutive_utc_day_streak=longest_streak,
+        minimum_consecutive_days=MIN_CONSECUTIVE_DAYS,
+        category_counts=dict(sorted(accumulator.categories.items())),
+        missing_required_categories=missing_categories,
+        required_categories=sorted(REQUIRED_INTERVIEW_CATEGORIES),
+        distinct_visa_codes=len(accumulator.candidate_codes),
+        minimum_distinct_visa_codes=MIN_DISTINCT_VISA_CODES,
+        visa_codes=sorted(accumulator.candidate_codes),
+        missing_request_fingerprints=accumulator.missing_request_fingerprints,
+        missing_or_invalid_categories=accumulator.missing_or_invalid_categories,
+        malformed_candidate_summaries=accumulator.malformed_candidate_summaries,
+        invalid_candidate_bindings=accumulator.invalid_candidate_bindings,
+    )
+
+
 def evaluate_shadow_evidence(
     rows: Sequence[Mapping[str, object]],
     packs: Mapping[uuid.UUID, RulePackPayload],
@@ -99,8 +194,12 @@ def evaluate_shadow_evidence(
 ) -> dict[str, object]:
     """Aggregate safe audit rows into the objective gate report.
 
-    ``rows`` must contain only migration-255's PII-free projection.  Any
-    missing/malformed field is counted and makes the relevant gate red.
+    ``rows`` must contain only migration-255's PII-free projection plus
+    migration 256's ``traffic_source`` marker.  Any missing/malformed field
+    is counted and makes the relevant gate red.  Rows are routed by
+    ``traffic_source``: ``real`` feeds G-a-vol, the synthetic classes feed
+    G-a-breadth, and anything else (NULL legacy rows included) feeds
+    neither.
     """
 
     if window_start.tzinfo is None or window_end.tzinfo is None:
@@ -109,15 +208,11 @@ def evaluate_shadow_evidence(
         raise ValueError("window_start must be before window_end")
 
     window_duration = window_end.astimezone(timezone.utc) - window_start.astimezone(timezone.utc)
-    fingerprints: set[bytes] = set()
-    valid_fingerprint_evaluations = 0
-    categories: Counter[str] = Counter()
-    candidate_codes: set[str] = set()
-    active_days: set[date] = set()
-    missing_request_fingerprints = 0
-    missing_or_invalid_categories = 0
-    malformed_candidate_summaries = 0
-    invalid_candidate_bindings = 0
+    vol_accumulator = _GateAAccumulator()
+    breadth_accumulator = _GateAAccumulator()
+    real_rows = 0
+    synthetic_source_counts: Counter[str] = Counter()
+    legacy_rows = 0
     missing_ruleset_activations = 0
     missing_rule_pack_digests = 0
     malformed_grounding_summaries = 0
@@ -140,6 +235,19 @@ def evaluate_shadow_evidence(
     }
 
     for row in rows:
+        traffic_source = row.get("traffic_source")
+        if traffic_source == REAL_TRAFFIC_SOURCE:
+            accumulator: _GateAAccumulator | None = vol_accumulator
+            real_rows += 1
+        elif isinstance(traffic_source, str) and traffic_source in SYNTHETIC_TRAFFIC_SOURCES:
+            accumulator = breadth_accumulator
+            synthetic_source_counts[traffic_source] += 1
+        else:
+            # NULL (pre-256 legacy rows) or any non-CHECK value: reported as
+            # legacy, counted toward NEITHER G-a gate (fail-closed).
+            accumulator = None
+            legacy_rows += 1
+
         pack_id = _uuid(row.get("rule_pack_id"))
         if _uuid(row.get("ruleset_activation_id")) is None:
             missing_ruleset_activations += 1
@@ -152,50 +260,53 @@ def evaluate_shadow_evidence(
         if not isinstance(rule_pack_sha256, bytes) or len(rule_pack_sha256) != 32:
             missing_rule_pack_digests += 1
 
-        fingerprint = row.get("request_fingerprint")
-        if isinstance(fingerprint, memoryview):
-            fingerprint = fingerprint.tobytes()
-        elif isinstance(fingerprint, bytearray):
-            fingerprint = bytes(fingerprint)
-        if isinstance(fingerprint, bytes) and len(fingerprint) == 32:
-            valid_fingerprint_evaluations += 1
-            fingerprints.add(fingerprint)
-        else:
-            missing_request_fingerprints += 1
+        if accumulator is not None:
+            accumulator.row_count += 1
 
-        category = row.get("request_category")
-        if isinstance(category, str) and category in _VALID_CATEGORIES:
-            categories[category] += 1
-        else:
-            missing_or_invalid_categories += 1
+            fingerprint = row.get("request_fingerprint")
+            if isinstance(fingerprint, memoryview):
+                fingerprint = fingerprint.tobytes()
+            elif isinstance(fingerprint, bytearray):
+                fingerprint = bytes(fingerprint)
+            if isinstance(fingerprint, bytes) and len(fingerprint) == 32:
+                accumulator.valid_fingerprint_evaluations += 1
+                accumulator.fingerprints.add(fingerprint)
+            else:
+                accumulator.missing_request_fingerprints += 1
 
-        evaluated_at = _utc(row.get("evaluated_at"))
-        if evaluated_at is not None:
-            active_days.add(evaluated_at.date())
+            category = row.get("request_category")
+            if isinstance(category, str) and category in _VALID_CATEGORIES:
+                accumulator.categories[category] += 1
+            else:
+                accumulator.missing_or_invalid_categories += 1
 
-        candidate_summary = _json_array(row.get("candidate_summary"))
-        if candidate_summary is None:
-            malformed_candidate_summaries += 1
-        else:
-            candidate_shape_ok = True
-            for candidate in candidate_summary:
-                if not isinstance(candidate, dict):
-                    candidate_shape_ok = False
-                    continue
-                product_code = candidate.get("product_code")
-                product_version_id = _uuid(candidate.get("product_version_id"))
-                product_binding = (product_version_id, product_code)
-                if (
-                    product_version_id is not None
-                    and isinstance(product_code, str)
-                    and product_binding in product_indexes.get(pack_id, set())
-                ):
-                    candidate_codes.add(product_code)
-                else:
-                    candidate_shape_ok = False
-                    invalid_candidate_bindings += 1
-            if not candidate_shape_ok:
-                malformed_candidate_summaries += 1
+            evaluated_at = _utc(row.get("evaluated_at"))
+            if evaluated_at is not None:
+                accumulator.active_days.add(evaluated_at.date())
+
+            candidate_summary = _json_array(row.get("candidate_summary"))
+            if candidate_summary is None:
+                accumulator.malformed_candidate_summaries += 1
+            else:
+                candidate_shape_ok = True
+                for candidate in candidate_summary:
+                    if not isinstance(candidate, dict):
+                        candidate_shape_ok = False
+                        continue
+                    product_code = candidate.get("product_code")
+                    product_version_id = _uuid(candidate.get("product_version_id"))
+                    product_binding = (product_version_id, product_code)
+                    if (
+                        product_version_id is not None
+                        and isinstance(product_code, str)
+                        and product_binding in product_indexes.get(pack_id, set())
+                    ):
+                        accumulator.candidate_codes.add(product_code)
+                    else:
+                        candidate_shape_ok = False
+                        accumulator.invalid_candidate_bindings += 1
+                if not candidate_shape_ok:
+                    accumulator.malformed_candidate_summaries += 1
 
         citations = _json_array(row.get("citations"))
         citation_refs: set[uuid.UUID] = set()
@@ -283,18 +394,20 @@ def evaluate_shadow_evidence(
             ):
                 unresolved_or_invalid_sources += 1
 
-    longest_streak = _longest_consecutive_day_streak(active_days)
-    missing_categories = sorted(REQUIRED_INTERVIEW_CATEGORIES - categories.keys())
-    gate_a_green = (
-        window_duration >= timedelta(days=MIN_CONSECUTIVE_DAYS)
-        and len(fingerprints) >= MIN_DISTINCT_REQUESTS
-        and longest_streak >= MIN_CONSECUTIVE_DAYS
-        and not missing_categories
-        and len(candidate_codes) >= MIN_DISTINCT_VISA_CODES
-        and missing_request_fingerprints == 0
-        and missing_or_invalid_categories == 0
-        and malformed_candidate_summaries == 0
-        and invalid_candidate_bindings == 0
+    gate_a_vol = _gate_a_report(
+        vol_accumulator,
+        traffic_sources=[REAL_TRAFFIC_SOURCE],
+        traffic_source_counts={REAL_TRAFFIC_SOURCE: real_rows},
+        window_duration=window_duration,
+    )
+    gate_a_breadth = _gate_a_report(
+        breadth_accumulator,
+        traffic_sources=sorted(SYNTHETIC_TRAFFIC_SOURCES),
+        traffic_source_counts={
+            source: synthetic_source_counts.get(source, 0)
+            for source in sorted(SYNTHETIC_TRAFFIC_SOURCES)
+        },
+        window_duration=window_duration,
     )
     gate_c_green = (
         bool(rows)
@@ -310,28 +423,6 @@ def evaluate_shadow_evidence(
         and unresolved_or_invalid_sources == 0
     )
 
-    gate_a = _gate(
-        gate_a_green,
-        total_audit_rows=len(rows),
-        window_duration_hours=window_duration.total_seconds() / 3600,
-        minimum_window_duration_hours=MIN_CONSECUTIVE_DAYS * 24,
-        distinct_requests=len(fingerprints),
-        minimum_distinct_requests=MIN_DISTINCT_REQUESTS,
-        duplicate_evaluations=valid_fingerprint_evaluations - len(fingerprints),
-        active_utc_days=len(active_days),
-        longest_consecutive_utc_day_streak=longest_streak,
-        minimum_consecutive_days=MIN_CONSECUTIVE_DAYS,
-        category_counts=dict(sorted(categories.items())),
-        missing_required_categories=missing_categories,
-        required_categories=sorted(REQUIRED_INTERVIEW_CATEGORIES),
-        distinct_visa_codes=len(candidate_codes),
-        minimum_distinct_visa_codes=MIN_DISTINCT_VISA_CODES,
-        visa_codes=sorted(candidate_codes),
-        missing_request_fingerprints=missing_request_fingerprints,
-        missing_or_invalid_categories=missing_or_invalid_categories,
-        malformed_candidate_summaries=malformed_candidate_summaries,
-        invalid_candidate_bindings=invalid_candidate_bindings,
-    )
     gate_c = _gate(
         gate_c_green,
         invalid_rule_pack_payloads=invalid_pack_count,
@@ -347,15 +438,23 @@ def evaluate_shadow_evidence(
     )
 
     return {
-        "schema_version": "visa-shadow-evidence/1.0.0",
+        "schema_version": "visa-shadow-evidence/1.1.0",
         "window": {
             "start": window_start.astimezone(timezone.utc).isoformat(),
             "end_exclusive": window_end.astimezone(timezone.utc).isoformat(),
         },
         "enforce_ready": False,
         "gate_status": "RED",
+        "traffic_source": {
+            "real": real_rows,
+            "synthetic_gold": synthetic_source_counts.get("synthetic_gold", 0),
+            "synthetic_driver": synthetic_source_counts.get("synthetic_driver", 0),
+            "legacy": legacy_rows,
+            "total_audit_rows": len(rows),
+        },
         "gates": {
-            "G-a": gate_a,
+            "G-a-vol": gate_a_vol,
+            "G-a-breadth": gate_a_breadth,
             "G-b": {
                 "status": "UNMEASURED",
                 "green": False,
@@ -370,7 +469,11 @@ def evaluate_shadow_evidence(
         },
         "blockers": [
             gate
-            for gate, evidence in (("G-a", gate_a), ("G-c", gate_c))
+            for gate, evidence in (
+                ("G-a-vol", gate_a_vol),
+                ("G-a-breadth", gate_a_breadth),
+                ("G-c", gate_c),
+            )
             if evidence["green"] is False
         ]
         + ["G-b", "G-d"],
@@ -406,7 +509,8 @@ async def collect_shadow_evidence(
                 rule_pack_sha256,
                 effective_at,
                 observed_at,
-                evaluated_at
+                evaluated_at,
+                traffic_source
             FROM public.visa_decisions
             WHERE environment = $1
               AND engine_surface = 'MATCH'
@@ -462,7 +566,9 @@ __all__ = [
     "MIN_CONSECUTIVE_DAYS",
     "MIN_DISTINCT_REQUESTS",
     "MIN_DISTINCT_VISA_CODES",
+    "REAL_TRAFFIC_SOURCE",
     "REQUIRED_INTERVIEW_CATEGORIES",
+    "SYNTHETIC_TRAFFIC_SOURCES",
     "collect_shadow_evidence",
     "evaluate_shadow_evidence",
 ]

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
@@ -14,10 +14,13 @@ import pytest
 import pytest_asyncio
 
 from backend.db.migration_base import split_migration_sql
+from backend.db.migration_manager import _assert_unique_migration_numbers
 from backend.services.visa_engine.enums import SourceStatus
 from backend.services.visa_engine.models import RulePack, SourceRecord
 from backend.services.visa_engine.shadow_evidence import (
+    REAL_TRAFFIC_SOURCE,
     REQUIRED_INTERVIEW_CATEGORIES,
+    SYNTHETIC_TRAFFIC_SOURCES,
     collect_shadow_evidence,
     evaluate_shadow_evidence,
 )
@@ -26,6 +29,7 @@ from backend.tests.services.visa_engine.gold_harness import loader as gold_loade
 _BACKEND_DIR = Path(__file__).resolve().parents[3]
 _MIGRATION_252_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "252_visa_engine_write_substrate.sql"
 _MIGRATION_255_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "255_visa_shadow_evidence.sql"
+_MIGRATION_256_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "256_visa_traffic_source.sql"
 
 
 def _green_fixture() -> tuple[list[dict[str, object]], RulePack, uuid.UUID]:
@@ -74,6 +78,7 @@ def _green_fixture() -> tuple[list[dict[str, object]], RulePack, uuid.UUID]:
                 "effective_at": evaluated_at,
                 "observed_at": evaluated_at,
                 "evaluated_at": evaluated_at,
+                "traffic_source": REAL_TRAFFIC_SOURCE,
             }
         )
     return rows, pack, db_pack_id
@@ -125,13 +130,17 @@ def _read_migration(path: Path, number: int) -> tuple[str, str]:
 async def shadow_evidence_schema(db_pool: asyncpg.Pool, visa_schema: None) -> AsyncIterator[None]:
     forward_252, rollback_252 = _read_migration(_MIGRATION_252_PATH, 252)
     forward_255, rollback_255 = _read_migration(_MIGRATION_255_PATH, 255)
+    forward_256, rollback_256 = _read_migration(_MIGRATION_256_PATH, 256)
     async with db_pool.acquire() as conn:
+        await conn.execute(rollback_256)
         await conn.execute(rollback_255)
         await conn.execute(rollback_252)
         await conn.execute(forward_252)
         await conn.execute(forward_255)
+        await conn.execute(forward_256)
     yield
     async with db_pool.acquire() as conn:
+        await conn.execute(rollback_256)
         await conn.execute(rollback_255)
         await conn.execute(rollback_252)
 
@@ -142,6 +151,7 @@ async def _insert_unavailable_audit_row(
     environment: str,
     evaluated_at: datetime,
     fingerprint_seed: str,
+    traffic_source: str | None = None,
 ) -> None:
     await conn.execute(
         """
@@ -159,17 +169,19 @@ async def _insert_unavailable_audit_row(
             request_fingerprint,
             request_category,
             candidate_summary,
-            grounding_summary
+            grounding_summary,
+            traffic_source
         ) VALUES (
             $1, $2, 'MATCH', 'SHADOW', 'TEMPORARILY_UNAVAILABLE',
             '[]'::jsonb, 'visa-engine/test', $3, $3, $3, $4, 'other',
-            '[]'::jsonb, '[]'::jsonb
+            '[]'::jsonb, '[]'::jsonb, $5
         )
         """,
         uuid.uuid4(),
         environment,
         evaluated_at,
         hashlib.sha256(fingerprint_seed.encode("utf-8")).digest(),
+        traffic_source,
     )
 
 
@@ -225,10 +237,19 @@ def test_green_shadow_projection_still_cannot_arm_enforce() -> None:
     )
 
     gates = report["gates"]
-    assert gates["G-a"]["green"] is True
+    assert gates["G-a-vol"]["green"] is True
+    assert gates["G-a-breadth"]["green"] is False
+    assert gates["G-a-breadth"]["total_audit_rows"] == 0
     assert gates["G-c"]["green"] is True
     assert gates["G-b"]["status"] == "UNMEASURED"
     assert gates["G-d"]["status"] == "UNMEASURED"
+    assert report["traffic_source"] == {
+        "real": 1_000,
+        "synthetic_gold": 0,
+        "synthetic_driver": 0,
+        "legacy": 0,
+        "total_audit_rows": 1_000,
+    }
     assert report["enforce_ready"] is False
     assert report["gate_status"] == "RED"
 
@@ -261,9 +282,9 @@ def test_duplicate_request_and_ungrounded_verdict_fail_closed() -> None:
     )
 
     gates = report["gates"]
-    assert gates["G-a"]["green"] is False
-    assert gates["G-a"]["distinct_requests"] == 999
-    assert gates["G-a"]["invalid_candidate_bindings"] == 1
+    assert gates["G-a-vol"]["green"] is False
+    assert gates["G-a-vol"]["distinct_requests"] == 999
+    assert gates["G-a-vol"]["invalid_candidate_bindings"] == 1
     assert gates["G-c"]["green"] is False
     assert gates["G-c"]["decisions_without_citations"] == 1
     assert gates["G-c"]["missing_ruleset_activations"] == 1
@@ -279,7 +300,7 @@ def test_duplicate_evaluations_ignore_missing_and_malformed_fingerprints() -> No
 
     report = _evaluate(rows, pack, db_pack_id)
 
-    gate_a = report["gates"]["G-a"]
+    gate_a = report["gates"]["G-a-vol"]
     assert gate_a["missing_request_fingerprints"] == 2
     assert gate_a["distinct_requests"] == 997
     assert gate_a["duplicate_evaluations"] == 1
@@ -321,7 +342,7 @@ def test_window_shorter_than_seven_full_days_fails_volume() -> None:
         window_end=start + timedelta(days=6, hours=23),
     )
 
-    gate_a = report["gates"]["G-a"]
+    gate_a = report["gates"]["G-a-vol"]
     assert gate_a["longest_consecutive_utc_day_streak"] == 7
     assert gate_a["window_duration_hours"] == 167
     assert gate_a["green"] is False
@@ -336,8 +357,10 @@ def test_empty_window_is_red_not_vacuously_green() -> None:
         window_end=start + timedelta(days=8),
     )
 
-    assert report["gates"]["G-a"]["green"] is False
+    assert report["gates"]["G-a-vol"]["green"] is False
+    assert report["gates"]["G-a-breadth"]["green"] is False
     assert report["gates"]["G-c"]["green"] is False
+    assert report["traffic_source"]["total_audit_rows"] == 0
     assert report["enforce_ready"] is False
 
 
@@ -351,7 +374,7 @@ def test_legacy_rows_without_correlators_or_grounding_keep_both_gates_red() -> N
 
     report = _evaluate(rows, pack, db_pack_id)
 
-    gate_a = report["gates"]["G-a"]
+    gate_a = report["gates"]["G-a-vol"]
     gate_c = report["gates"]["G-c"]
     assert gate_a["green"] is False
     assert gate_a["missing_request_fingerprints"] == 1_000
@@ -478,19 +501,20 @@ async def test_collect_filters_environment_and_uses_half_open_window(
     start = datetime(2026, 7, 21, tzinfo=timezone.utc)
     end = start + timedelta(days=1)
     rows = [
-        ("TEST", start - timedelta(microseconds=1), "before-start"),
-        ("TEST", start, "at-start"),
-        ("TEST", end - timedelta(microseconds=1), "before-end"),
-        ("TEST", end, "at-end"),
-        ("PRODUCTION", start + timedelta(hours=12), "wrong-environment"),
+        ("TEST", start - timedelta(microseconds=1), "before-start", None),
+        ("TEST", start, "at-start", REAL_TRAFFIC_SOURCE),
+        ("TEST", end - timedelta(microseconds=1), "before-end", REAL_TRAFFIC_SOURCE),
+        ("TEST", end, "at-end", None),
+        ("PRODUCTION", start + timedelta(hours=12), "wrong-environment", None),
     ]
     async with db_pool.acquire() as conn:
-        for environment, evaluated_at, seed in rows:
+        for environment, evaluated_at, seed, traffic_source in rows:
             await _insert_unavailable_audit_row(
                 conn,
                 environment=environment,
                 evaluated_at=evaluated_at,
                 fingerprint_seed=seed,
+                traffic_source=traffic_source,
             )
 
     report = await collect_shadow_evidence(
@@ -500,10 +524,69 @@ async def test_collect_filters_environment_and_uses_half_open_window(
         environment="TEST",
     )
 
-    gate_a = report["gates"]["G-a"]
+    gate_a = report["gates"]["G-a-vol"]
     assert gate_a["total_audit_rows"] == 2
     assert gate_a["distinct_requests"] == 2
     assert gate_a["missing_request_fingerprints"] == 0
+    assert report["traffic_source"] == {
+        "real": 2,
+        "synthetic_gold": 0,
+        "synthetic_driver": 0,
+        "legacy": 0,
+        "total_audit_rows": 2,
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_collect_splits_traffic_source_end_to_end(
+    db_pool: asyncpg.Pool, shadow_evidence_schema: None
+) -> None:
+    """Migration 256's column round-trips: real -> G-a-vol, synthetic ->
+    G-a-breadth, NULL -> legacy (neither), straight from the database."""
+    start = datetime(2026, 7, 21, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    rows = [
+        ("at-start", REAL_TRAFFIC_SOURCE),
+        ("gold-row", "synthetic_gold"),
+        ("driver-row", "synthetic_driver"),
+        ("legacy-row", None),
+    ]
+    async with db_pool.acquire() as conn:
+        for seed, traffic_source in rows:
+            await _insert_unavailable_audit_row(
+                conn,
+                environment="TEST",
+                evaluated_at=start,
+                fingerprint_seed=seed,
+                traffic_source=traffic_source,
+            )
+
+    report = await collect_shadow_evidence(
+        db_pool,
+        window_start=start,
+        window_end=end,
+        environment="TEST",
+    )
+
+    gates = report["gates"]
+    assert gates["G-a-vol"]["total_audit_rows"] == 1
+    assert gates["G-a-vol"]["traffic_sources"] == [REAL_TRAFFIC_SOURCE]
+    assert gates["G-a-vol"]["traffic_source_counts"] == {REAL_TRAFFIC_SOURCE: 1}
+    assert gates["G-a-breadth"]["total_audit_rows"] == 2
+    assert gates["G-a-breadth"]["traffic_sources"] == sorted(SYNTHETIC_TRAFFIC_SOURCES)
+    assert gates["G-a-breadth"]["traffic_source_counts"] == {
+        "synthetic_gold": 1,
+        "synthetic_driver": 1,
+    }
+    assert report["traffic_source"] == {
+        "real": 1,
+        "synthetic_gold": 1,
+        "synthetic_driver": 1,
+        "legacy": 1,
+        "total_audit_rows": 4,
+    }
 
 
 @pytest.mark.parametrize(
@@ -560,3 +643,145 @@ async def test_collect_counts_missing_or_invalid_pack_payloads(
     )
 
     assert report["gates"]["G-c"]["invalid_rule_pack_payloads"] == expected_invalid_count
+
+
+# ---------------------------------------------------------------------------
+# Fable final-gate deltas 1-2 (2026-07-23) — traffic_source split (migration
+# 256): real -> G-a-vol, synthetic classes -> G-a-breadth, NULL/unknown ->
+# legacy (neither).  Guilt AND innocence for each direction.
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_gold_rows_feed_breadth_never_vol() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    for row in rows:
+        row["traffic_source"] = "synthetic_gold"
+
+    report = _evaluate(rows, pack, db_pack_id)
+
+    gates = report["gates"]
+    # Innocence: the synthetic corpus DOES prove breadth...
+    assert gates["G-a-breadth"]["green"] is True
+    assert gates["G-a-breadth"]["total_audit_rows"] == 1_000
+    assert gates["G-a-breadth"]["distinct_requests"] == 1_000
+    assert gates["G-a-breadth"]["traffic_sources"] == sorted(SYNTHETIC_TRAFFIC_SOURCES)
+    assert gates["G-a-breadth"]["traffic_source_counts"] == {
+        "synthetic_gold": 1_000,
+        "synthetic_driver": 0,
+    }
+    # Guilt: ...but it can NEVER manufacture production adoption.
+    assert gates["G-a-vol"]["green"] is False
+    assert gates["G-a-vol"]["total_audit_rows"] == 0
+    assert gates["G-a-vol"]["distinct_requests"] == 0
+    assert gates["G-a-vol"]["traffic_sources"] == [REAL_TRAFFIC_SOURCE]
+    assert "G-a-vol" in report["blockers"]
+    assert "G-a-breadth" not in report["blockers"]
+
+
+def test_both_synthetic_classes_are_labeled_and_summed_in_breadth() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    for index, row in enumerate(rows):
+        row["traffic_source"] = "synthetic_gold" if index % 2 == 0 else "synthetic_driver"
+
+    report = _evaluate(rows, pack, db_pack_id)
+
+    breadth = report["gates"]["G-a-breadth"]
+    assert breadth["traffic_source_counts"] == {
+        "synthetic_gold": 500,
+        "synthetic_driver": 500,
+    }
+    assert breadth["total_audit_rows"] == 1_000
+    assert report["traffic_source"]["synthetic_gold"] == 500
+    assert report["traffic_source"]["synthetic_driver"] == 500
+    assert report["gates"]["G-a-vol"]["total_audit_rows"] == 0
+
+
+def test_null_and_unknown_sources_are_legacy_counted_toward_neither_gate() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    for index, row in enumerate(rows):
+        if index % 3 == 0:
+            row["traffic_source"] = None  # pre-256 legacy row
+        elif index % 3 == 1:
+            del row["traffic_source"]  # key absent entirely
+        else:
+            row["traffic_source"] = "not-a-checked-source"  # non-CHECK value
+
+    report = _evaluate(rows, pack, db_pack_id)
+
+    gates = report["gates"]
+    assert gates["G-a-vol"]["total_audit_rows"] == 0
+    assert gates["G-a-breadth"]["total_audit_rows"] == 0
+    assert gates["G-a-vol"]["green"] is False
+    assert gates["G-a-breadth"]["green"] is False
+    assert report["traffic_source"] == {
+        "real": 0,
+        "synthetic_gold": 0,
+        "synthetic_driver": 0,
+        "legacy": 1_000,
+        "total_audit_rows": 1_000,
+    }
+
+
+def test_mixed_traffic_split_fields_sum_to_total() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    synthetic_rows, _, _ = _green_fixture()
+    extra: list[dict[str, object]] = []
+    for index, row in enumerate(synthetic_rows[:40]):
+        clone = dict(row)
+        clone["request_fingerprint"] = (1_000 + index).to_bytes(32, "big")
+        clone["traffic_source"] = "synthetic_driver"
+        extra.append(clone)
+    rows[0]["traffic_source"] = None  # one legacy row
+    mixed = rows + extra
+
+    report = _evaluate(mixed, pack, db_pack_id)
+
+    traffic = report["traffic_source"]
+    assert traffic == {
+        "real": 999,
+        "synthetic_gold": 0,
+        "synthetic_driver": 40,
+        "legacy": 1,
+        "total_audit_rows": 1_040,
+    }
+    gates = report["gates"]
+    # Vol counts ONLY real rows: the 40 synthetic rows carry fresh
+    # fingerprints and must not leak into vol's distinct_requests.
+    assert gates["G-a-vol"]["total_audit_rows"] == 999
+    assert gates["G-a-vol"]["distinct_requests"] == 999
+    assert gates["G-a-breadth"]["total_audit_rows"] == 40
+    assert gates["G-a-breadth"]["distinct_requests"] == 40
+    assert (
+        gates["G-a-vol"]["total_audit_rows"]
+        + gates["G-a-breadth"]["total_audit_rows"]
+        + traffic["legacy"]
+        == traffic["total_audit_rows"]
+    )
+
+
+def test_grounding_gate_spans_all_traffic_sources() -> None:
+    """G-c is intentionally NOT split: a grounding defect in a synthetic row
+    is still an engine-output defect and must keep G-c red."""
+    rows, pack, db_pack_id = _green_fixture()
+    rows[0]["traffic_source"] = "synthetic_gold"
+    rows[0]["grounding_summary"] = []
+
+    report = _evaluate(rows, pack, db_pack_id)
+
+    gate_c = report["gates"]["G-c"]
+    assert gate_c["green"] is False
+    assert gate_c["malformed_grounding_summaries"] == 1
+    assert gate_c["ungrounded_claims"] == 1
+
+
+def test_migration_256_carries_rollback_marker() -> None:
+    forward, rollback = _read_migration(_MIGRATION_256_PATH, 256)
+    assert "traffic_source" in forward
+    assert "traffic_source" in rollback
+
+
+def test_migration_256_keeps_migrations_v2_prefixes_unique() -> None:
+    sql_files = sorted(_MIGRATION_256_PATH.parent.glob("*.sql"))
+    _assert_unique_migration_numbers(sql_files)
+    prefixes = [path.name.split("_", 1)[0] for path in sql_files]
+    assert prefixes.count("256") == 1


### PR DESCRIPTION
## Why

Lane **W1a (Track A)** of the Visa Oracle v2 program. The SHADOW evidence substrate (`visa_decisions`, migration 255) cannot distinguish **real end-user traffic** from **synthetic corpus traffic**: a row written by the live SHADOW path and a row written by a gold-corpus replay driver look identical, so the G-a volume/breadth gate is gameable — a synthetic corpus could manufacture the 1,000 distinct requests / 7 consecutive days / 30 visa codes the gate demands and the collector would count them as production adoption.

**Fable final-gate deltas 1-2 (binding):** add a `traffic_source` marker and split the G-a evidence collector into `G-a-vol` (real only) and `G-a-breadth` (synthetic corpus, labeled). Reference: W1 evidence-machinery brief (`research/visa/2026-07-23-w1-evidence-machinery-brief.md` — items 1 and the collector part of item 2; note: the brief file itself is not present in the repo tree at this commit, the adjudicated context came via the lane dispatch). The endpoint and the category-enum extension are intentionally **out of scope** (later PRs).

## What

- **`apps/backend-rag/backend/db/migrations_v2/256_visa_traffic_source.sql`** (new)
  - Nullable `traffic_source TEXT` on `public.visa_decisions` with `CHECK (traffic_source IS NULL OR traffic_source IN ('real','synthetic_gold','synthetic_driver'))`. NULL = pre-256 legacy rows; **never backfilled with guesses** — legacy rows keep failing closed, same philosophy as 255's nullable correlators. Mirrors migration 187's storage-level isolation-flag precedent, nullable because legacy rows exist.
  - Index `idx_visa_decisions_shadow_traffic_source` on `(traffic_source, created_at)`, partial on `engine_surface='MATCH' AND engine_mode='SHADOW'` — same predicate style as 255's two indexes, covering exactly the collector's read slice.
  - `-- === ROLLBACK ===` drops index + column (both `IF EXISTS`, like 255).
  - No writer sets the column yet (labeling lands with the synthetic-corpus drivers / read-path wiring in later PRs), so until then every row is legacy — fail-closed by default. Does not change `VISA_ENGINE_MATCH_MODE`, cannot arm ENFORCE.

- **`apps/backend-rag/backend/services/visa_engine/shadow_evidence.py`**
  - G-a is split into **`G-a-vol`** (only rows labeled `real`) and **`G-a-breadth`** (rows labeled `synthetic_gold` / `synthetic_driver`). Both gates keep the identical thresholds and field names the old G-a had (additive at field level), plus honest-labeling fields `traffic_sources` and `traffic_source_counts`.
  - New additive top-level `traffic_source` block: `{real, synthetic_gold, synthetic_driver, legacy, total_audit_rows}` — the four class counts always sum to `total_audit_rows`.
  - NULL or any non-CHECK `traffic_source` value is reported as `legacy` and counted toward **neither** G-a gate (fail-closed).
  - **G-c is intentionally NOT split**: grounding quality is a property of the engine's output and applies to every audited row regardless of provenance (documented in the module docstring).
  - `enforce_ready` stays hard-coded `False`, `gate_status` stays hard-coded `"RED"`; G-b/G-d remain UNMEASURED. Schema version bumped `visa-shadow-evidence/1.0.0` → `1.1.0`. The CLI (`scripts/visa_shadow_evidence.py`) emits this report verbatim, so the CLI output schema change is exactly: additive top-level field + G-a replaced by the two split gates.
  - `collect_shadow_evidence` now SELECTs `traffic_source` (deploy order is safe: migrations run before code deploy in the Fly workflow).

- **`apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py`**
  - Guilt **and** innocence for each direction: synthetic-gold rows turn G-a-breadth green but G-a-vol stays red with 0 rows; both synthetic classes labeled and summed; NULL / missing-key / non-CHECK values all land in `legacy` toward neither gate; mixed traffic proves 40 synthetic rows with fresh fingerprints never leak into vol's `distinct_requests`; split fields sum to the total; G-c still spans all sources; migration 256 rollback-marker + prefix-uniqueness lints; `shadow_evidence_schema` fixture now applies/rolls back 256 alongside 252/255; new end-to-end DB test round-trips the column (real→vol, gold+driver→breadth, NULL→legacy).

## Test evidence

- `pytest backend/tests/services/visa_engine/test_shadow_evidence.py -q` — **31 passed** (incl. 2 DB integration tests against `nuzantara_test` on Pro via SSH tunnel; M5 has no `nuzantara` PG role).
- `pytest backend/tests/db/test_migration_uniqueness.py backend/tests/db/test_migration_rollback_extraction.py backend/tests/scripts/test_visa_shadow_evidence.py -q` — **17 passed** (repo migration-number lint + rollback-marker lint + CLI safety).
- `ruff check` + `ruff format --check` on both changed Python files — clean.
- Pre-commit hooks all green: off-limits check, FastAPI import chain, W41 migration-number uniqueness (`scripts/lint_migration_numbers.py`), W42 rollback-marker (`scripts/lint_migration_rollback.py`), P1-STRATO1 anti-reward-hacking lint.

## Out of scope / not done

- No writer labels `traffic_source` yet (later PRs: synthetic-corpus drivers, read-path wiring).
- Endpoint and category-enum extension untouched (later PRs), `evaluator.py` untouched, no existing migration modified.
- The referenced W1 brief file is not present in the repo at this commit — flagged for the graders in case it should have been committed elsewhere.

No auto-merge, no merge — Fable/Opus gate happens before merge per program protocol.
