### PR TITLE
feat(mouth): WS3 slice 3 — portal billing day pass (GARUDA OS train)

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/billing/error.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/billing/error.tsx
@@ -12,18 +12,33 @@ export default function BillingError({
 }) {
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
+      {/* Day masthead (WS3): copper rule + Cormorant serif, mirrors page.tsx */}
       <section>
-        <h1 className="text-2xl font-bold tracking-tight">Billing</h1>
-        <p style={{ color: "var(--bz-text-2)" }}>Your invoices and payments</p>
+        <div
+          aria-hidden="true"
+          className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+        />
+        <h1
+          className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          Billing
+        </h1>
+        <p className="text-sm text-[var(--tx-secondary)] mt-1">
+          Your invoices and payments
+        </p>
       </section>
       <section
         className="rounded-xl border p-8 text-center"
         style={{
-          background: "rgba(30,30,35,0.7)",
-          borderColor: "rgba(255,255,255,0.05)",
+          background: "var(--bz-card)",
+          borderColor: "var(--bz-border)",
         }}
       >
-        <AlertTriangle className="w-12 h-12 mx-auto mb-3 text-amber-400" />
+        <AlertTriangle
+          className="w-12 h-12 mx-auto mb-3"
+          style={{ color: "var(--state-warning)" }}
+        />
         <p className="font-medium">Failed to load billing data</p>
         <p className="text-sm mt-1" style={{ color: "var(--bz-text-2)" }}>
           {error.message}

--- a/apps/mouth/src/app/portal/(authenticated)/billing/loading.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/billing/loading.tsx
@@ -17,8 +17,8 @@ export default function BillingLoading() {
             key={i}
             className="rounded-xl border p-4 h-24 animate-pulse"
             style={{
-              background: "rgba(30,30,35,0.7)",
-              borderColor: "rgba(255,255,255,0.05)",
+              background: "var(--bz-card)",
+              borderColor: "var(--bz-border)",
             }}
           />
         ))}
@@ -29,8 +29,8 @@ export default function BillingLoading() {
             key={i}
             className="rounded-lg border p-4 h-20 animate-pulse"
             style={{
-              background: "rgba(30,30,35,0.7)",
-              borderColor: "rgba(255,255,255,0.05)",
+              background: "var(--bz-card)",
+              borderColor: "var(--bz-border)",
             }}
           />
         ))}

--- a/apps/mouth/src/app/portal/(authenticated)/billing/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/billing/page.test.tsx
@@ -1,0 +1,202 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUsePortalBilling, mockGetInvoicePdfUrl, mockToastError } =
+  vi.hoisted(() => ({
+    mockUsePortalBilling: vi.fn(),
+    mockGetInvoicePdfUrl: vi.fn(),
+    mockToastError: vi.fn(),
+  }));
+
+vi.mock("@/hooks/usePortalBilling", () => ({
+  usePortalBilling: mockUsePortalBilling,
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    portal: {
+      getInvoicePdfUrl: mockGetInvoicePdfUrl,
+    },
+  },
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  useToast: () => ({ error: mockToastError }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import BillingPage from "./page";
+
+const BILLING = {
+  summary: {
+    total_invoiced: 30_000_000,
+    total_paid: 20_000_000,
+    total_pending: 10_000_000,
+    count: 2,
+  },
+  invoices: [
+    {
+      id: 1,
+      invoice_number: "INV-2026-001",
+      amount_idr: 20_000_000,
+      invoice_source: "zantara",
+      has_pdf: true,
+      email_sent: true,
+      generated_at: "2026-05-01T00:00:00Z",
+      created_at: "2026-05-01T00:00:00Z",
+      practice_id: 11,
+      practice_name: "KITAS Investor",
+      practice_category: "Immigration",
+      payment_status: "paid",
+    },
+    {
+      id: 2,
+      invoice_number: "INV-2026-002",
+      amount_idr: 10_000_000,
+      invoice_source: "zantara",
+      has_pdf: false,
+      email_sent: false,
+      generated_at: null,
+      created_at: null,
+      practice_id: 12,
+      practice_name: "PT PMA Setup",
+      practice_category: "Company",
+      payment_status: "overdue",
+    },
+  ],
+};
+
+function mockState(state: {
+  data?: unknown;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: Error | null;
+}) {
+  mockUsePortalBilling.mockReturnValue({
+    data: state.data,
+    isLoading: state.isLoading ?? false,
+    isError: state.isError ?? false,
+    error: state.error ?? null,
+  });
+}
+
+describe("BillingPage", () => {
+  it("renders the day masthead, token-driven summary cards and invoice rows (WS3)", () => {
+    mockState({ data: BILLING });
+    const { container } = render(<BillingPage />);
+
+    // Day masthead: copper rule + Cormorant serif headline in --tx-pure.
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Billing");
+    expect(heading.style.fontFamily).toBe("var(--font-serif)");
+    expect(heading.className).toContain("text-[var(--tx-pure)]");
+    expect(
+      container.querySelector(
+        '[aria-hidden="true"].bg-\\[var\\(--bz-copper\\)\\]',
+      ),
+    ).not.toBeNull();
+
+    // Summary amounts render via <Money> (tabular-nums) with state tokens:
+    // paid → --state-success, outstanding > 0 → --state-warning.
+    // (The same amounts also appear as invoice-row totals, without color.)
+    const paidAmount = screen
+      .getAllByText("Rp 20.000.000")
+      .find((el) => el.style.color !== "");
+    expect(paidAmount?.style.fontVariantNumeric).toBe("tabular-nums");
+    expect(paidAmount?.style.color).toBe("var(--state-success)");
+    const outstandingAmount = screen
+      .getAllByText("Rp 10.000.000")
+      .find((el) => el.style.color !== "");
+    expect(outstandingAmount?.style.color).toBe("var(--state-warning)");
+
+    // Invoice rows: token surfaces, invoice numbers, status badges reading
+    // the semantic --state-* tokens (paid → success, overdue → danger).
+    expect(screen.getByText("INV-2026-001")).toBeInTheDocument();
+    expect(screen.getByText("INV-2026-002")).toBeInTheDocument();
+    // ("Paid" also appears as a summary-card label, so pick the badge by
+    // its token-driven inline style.)
+    const paidBadge = screen
+      .getAllByText("Paid")
+      .map((el) => el.closest("div"))
+      .find((el) => el?.style.background.includes("color-mix"));
+    expect(paidBadge?.style.color).toBe("var(--state-success)");
+    const overdueBadge = screen.getByText("Overdue").closest("div");
+    expect(overdueBadge?.style.color).toBe("var(--state-danger)");
+
+    // Card surfaces read theme tokens, not the old dark rgba glass.
+    expect(container.innerHTML).toContain("var(--bz-card)");
+    expect(container.innerHTML).not.toContain("rgba(30,30,35,0.7)");
+    expect(container.innerHTML).not.toContain("rgba(255,255,255,0.05)");
+
+    // Help notice: small copper text uses the AA daylight step with the
+    // slice-2 fallback pattern.
+    const helpNotice = screen.getByText(/For payment inquiries/);
+    expect(helpNotice.style.color).toBe(
+      "var(--bz-copper-text, var(--tx-secondary))",
+    );
+
+    // Download action only on invoices with a PDF.
+    expect(
+      screen.getByRole("button", { name: "Download invoice INV-2026-001" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Download invoice INV-2026-002" }),
+    ).toBeNull();
+
+    // Drain guard: no hardcoded hex colors anywhere in the page output.
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+
+  it("keeps zero outstanding on the success state color", () => {
+    mockState({
+      data: {
+        summary: {
+          total_invoiced: 5_000_000,
+          total_paid: 5_000_000,
+          total_pending: 0,
+          count: 1,
+        },
+        invoices: [],
+      },
+    });
+    render(<BillingPage />);
+    const outstanding = screen.getByText("Rp 0");
+    expect(outstanding.style.color).toBe("var(--state-success)");
+  });
+
+  it("renders the loading skeleton without hardcoded dark surfaces", () => {
+    mockState({ isLoading: true });
+    const { container } = render(<BillingPage />);
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+    expect(container.innerHTML).not.toContain("rgba(30,30,35,0.7)");
+  });
+
+  it("keeps the masthead and shows a token-colored warning on error", () => {
+    mockState({ isError: true, error: new Error("boom") });
+    render(<BillingPage />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Billing",
+    );
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("renders the empty state when there are no invoices", () => {
+    mockState({
+      data: {
+        summary: {
+          total_invoiced: 0,
+          total_paid: 0,
+          total_pending: 0,
+          count: 0,
+        },
+        invoices: [],
+      },
+    });
+    render(<BillingPage />);
+    expect(screen.getByText("No invoices yet")).toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/app/portal/(authenticated)/billing/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/billing/page.tsx
@@ -1,5 +1,18 @@
 "use client";
 
+/**
+ * Portal Billing — invoices and payments.
+ *
+ * WS3 slice 3 (GARUDA Day Edition, 2026-07-24): day-theme token alignment,
+ * mirroring slice 1 (portal home, PR #3050) and slice 2 (matters, PR #3051).
+ * Masthead = copper rule + Cormorant serif (--font-serif) in --tx-pure;
+ * surfaces read --bz-card / --bz-border; invoice state colors read the
+ * semantic --state-* tokens (WS2 operative-light AA overrides); copper small
+ * text reads --bz-copper-text (armed in globals.css by slice 1;
+ * --tx-secondary fallback keeps AA until that merges). Amounts render via
+ * the shared <Money> component (tabular-nums). No hardcoded hexes.
+ */
+
 import React from "react";
 import { Download, FileText, Receipt, AlertTriangle } from "lucide-react";
 import { usePortalBilling } from "@/hooks/usePortalBilling";
@@ -14,7 +27,29 @@ import { api } from "@/lib/api";
 import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
 import type { PortalInvoice } from "@/lib/api/portal/portal.types";
-import { formatIDR } from "@balizero/core/utils";
+import { Money } from "@balizero/core";
+
+// Day masthead (GARUDA Day Edition): copper rule + Cormorant serif headline
+// per concept (--font-serif, wired on <html>); Inter everywhere else.
+function BillingMasthead() {
+  return (
+    <section>
+      <div
+        aria-hidden="true"
+        className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+      />
+      <h1
+        className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]"
+        style={{ fontFamily: "var(--font-serif)" }}
+      >
+        Billing
+      </h1>
+      <p className="text-sm text-[var(--tx-secondary)] mt-1">
+        Your invoices and payments
+      </p>
+    </section>
+  );
+}
 
 export default function BillingPage() {
   const { data, isLoading, isError, error } = usePortalBilling();
@@ -57,17 +92,18 @@ export default function BillingPage() {
   if (isError) {
     return (
       <div className="space-y-6 animate-in fade-in duration-500">
-        <section>
-          <h1 className="text-2xl font-bold tracking-tight">Billing</h1>
-        </section>
+        <BillingMasthead />
         <section
           className="rounded-xl border p-8 text-center"
           style={{
-            background: "rgba(30,30,35,0.7)",
-            borderColor: "rgba(255,255,255,0.05)",
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
-          <AlertTriangle className="w-12 h-12 mx-auto mb-3 text-amber-400" />
+          <AlertTriangle
+            className="w-12 h-12 mx-auto mb-3"
+            style={{ color: "var(--state-warning)" }}
+          />
           <p>
             {error instanceof Error
               ? error.message
@@ -91,10 +127,7 @@ export default function BillingPage() {
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
       {/* Header */}
-      <section>
-        <h1 className="text-2xl font-bold tracking-tight">Billing</h1>
-        <p style={{ color: "var(--bz-text-2)" }}>Your invoices and payments</p>
-      </section>
+      <BillingMasthead />
 
       {/* Summary Cards */}
       {summary && summary.count > 0 && (
@@ -102,55 +135,59 @@ export default function BillingPage() {
           <div
             className="rounded-xl border p-5"
             style={{
-              background: "rgba(30,30,35,0.7)",
-              borderColor: "rgba(255,255,255,0.05)",
+              background: "var(--bz-card)",
+              borderColor: "var(--bz-border)",
             }}
           >
             <p className="text-xs mb-1" style={{ color: "var(--bz-text-2)" }}>
               Total Invoiced
             </p>
-            <p className="text-xl font-bold font-mono">
-              {formatIDR(summary.total_invoiced)}
-            </p>
-            <p className="text-xs mt-1" style={{ color: "var(--bz-text-3)" }}>
+            <Money
+              value={summary.total_invoiced}
+              className="block text-xl font-bold font-mono"
+            />
+            {/* --bz-text-2 (7.64:1 on card): --bz-text-3 (#7a8aa6) computes
+                3.49:1 on white cards — below the 4.5:1 small-text floor. */}
+            <p className="text-xs mt-1" style={{ color: "var(--bz-text-2)" }}>
               {summary.count} invoice{summary.count !== 1 ? "s" : ""}
             </p>
           </div>
           <div
             className="rounded-xl border p-5"
             style={{
-              background: "rgba(30,30,35,0.7)",
-              borderColor: "rgba(255,255,255,0.05)",
+              background: "var(--bz-card)",
+              borderColor: "var(--bz-border)",
             }}
           >
             <p className="text-xs mb-1" style={{ color: "var(--bz-text-2)" }}>
               Paid
             </p>
-            <p
-              className="text-xl font-bold font-mono"
-              style={{ color: "#34d399" }}
-            >
-              {formatIDR(summary.total_paid)}
-            </p>
+            <Money
+              value={summary.total_paid}
+              className="block text-xl font-bold font-mono"
+              style={{ color: "var(--state-success)" }}
+            />
           </div>
           <div
             className="rounded-xl border p-5"
             style={{
-              background: "rgba(30,30,35,0.7)",
-              borderColor: "rgba(255,255,255,0.05)",
+              background: "var(--bz-card)",
+              borderColor: "var(--bz-border)",
             }}
           >
             <p className="text-xs mb-1" style={{ color: "var(--bz-text-2)" }}>
               Outstanding
             </p>
-            <p
-              className="text-xl font-bold font-mono"
+            <Money
+              value={summary.total_pending}
+              className="block text-xl font-bold font-mono"
               style={{
-                color: summary.total_pending > 0 ? "#fbbf24" : "#34d399",
+                color:
+                  summary.total_pending > 0
+                    ? "var(--state-warning)"
+                    : "var(--state-success)",
               }}
-            >
-              {formatIDR(summary.total_pending)}
-            </p>
+            />
           </div>
         </section>
       )}
@@ -169,18 +206,21 @@ export default function BillingPage() {
               key={invoice.id}
               className="rounded-lg border p-4 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg"
               style={{
-                background: "rgba(30,30,35,0.7)",
-                borderColor: "rgba(255,255,255,0.05)",
+                background: "var(--bz-card)",
+                borderColor: "var(--bz-border)",
               }}
             >
               <div className="flex items-start gap-3">
                 <div
                   className="p-2 rounded-md"
-                  style={{ background: "rgba(201,169,110,0.12)" }}
+                  style={{
+                    background:
+                      "color-mix(in srgb, var(--bz-copper) 12%, transparent)",
+                  }}
                 >
                   <FileText
                     className="w-5 h-5"
-                    style={{ color: "var(--bz-accent-warm)" }}
+                    style={{ color: "var(--bz-copper)" }}
                   />
                 </div>
                 <div className="flex-1 min-w-0">
@@ -197,9 +237,10 @@ export default function BillingPage() {
                     {invoice.practice_name} ({invoice.practice_category})
                   </p>
                   <div className="flex items-center gap-2 mt-1">
-                    <span className="text-lg font-bold font-mono">
-                      {formatIDR(invoice.amount_idr)}
-                    </span>
+                    <Money
+                      value={invoice.amount_idr}
+                      className="text-lg font-bold font-mono"
+                    />
                     {invoice.generated_at && (
                       <CountdownChip date={invoice.generated_at} mode="age" />
                     )}
@@ -207,7 +248,7 @@ export default function BillingPage() {
                   {invoice.generated_at && (
                     <p
                       className="text-xs mt-0.5"
-                      style={{ color: "var(--bz-text-3)" }}
+                      style={{ color: "var(--bz-text-2)" }}
                     >
                       Issued:{" "}
                       {new Date(invoice.generated_at).toLocaleDateString(
@@ -237,15 +278,20 @@ export default function BillingPage() {
         )}
       </section>
 
-      {/* Help Notice */}
+      {/* Help Notice — small copper text reads --bz-copper-text (slice-1
+          daylight step, 5.05:1 on paper); --tx-secondary fallback keeps AA
+          until that merge lands. */}
       <section
         className="rounded-lg border p-4"
         style={{
-          background: "rgba(201,169,110,0.06)",
-          borderColor: "rgba(201,169,110,0.3)",
+          background: "color-mix(in srgb, var(--bz-copper) 6%, transparent)",
+          borderColor: "var(--bz-border-accent)",
         }}
       >
-        <p className="text-sm" style={{ color: "var(--bz-accent-warm)" }}>
+        <p
+          className="text-sm"
+          style={{ color: "var(--bz-copper-text, var(--tx-secondary))" }}
+        >
           For payment inquiries or to request a receipt, please contact your
           account manager or send us a message through Chat.
         </p>

--- a/apps/mouth/src/components/portal/CountdownChip.tsx
+++ b/apps/mouth/src/components/portal/CountdownChip.tsx
@@ -1,11 +1,29 @@
 import React from "react";
 
+/**
+ * CountdownChip — shared portal deadline / age pill.
+ *
+ * WS3 (GARUDA Day Edition, 2026-07-24): dark-only Tailwind utilities
+ * (text-red-400, bg-amber-500/10, …) replaced by the semantic --state-*
+ * tokens with color-mix tints, so the chip holds AA on the operative-light
+ * paper (WS2 overrides) and reproduces the same hues on dark (state
+ * primitives are the same hexes). Age chip reads --glass-rim (armed in both
+ * themes) instead of rgba(255,255,255,0.04), which was invisible on paper.
+ */
+
 interface CountdownChipProps {
   /** ISO date string to count down to (future) or since (past) */
   date: string;
   /** 'countdown' = future deadline, 'age' = time since event */
   mode?: "countdown" | "age";
   className?: string;
+}
+
+function toneStyle(token: string): React.CSSProperties {
+  return {
+    background: `color-mix(in srgb, var(${token}) 12%, transparent)`,
+    color: `var(${token})`,
+  };
 }
 
 export function CountdownChip({
@@ -31,8 +49,10 @@ export function CountdownChip({
         suppressHydrationWarning
         className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold ${className ?? ""}`}
         style={{
-          background: "rgba(255,255,255,0.04)",
-          color: "var(--bz-text-3)",
+          background: "var(--glass-rim)",
+          /* --bz-text-2: --bz-text-3 computes 3.06:1 on this tint over white
+             cards — below the 4.5:1 small-text floor (WS3 AA pass). */
+          color: "var(--bz-text-2)",
         }}
       >
         {label}
@@ -44,17 +64,13 @@ export function CountdownChip({
   const isOverdue = diffDays < 0;
   const absDays = Math.abs(diffDays);
 
-  const chipColor = isOverdue
-    ? "bg-red-500/15 text-red-400"
-    : diffDays === 0
-      ? "bg-red-500/10 text-red-400"
-      : diffDays <= 7
-        ? "bg-red-500/10 text-red-400"
-        : diffDays <= 30
-          ? "bg-amber-500/10 text-amber-400"
-          : diffDays <= 90
-            ? "bg-amber-500/10 text-amber-400"
-            : "bg-emerald-500/10 text-emerald-400";
+  const chipStyle = isOverdue
+    ? toneStyle("--state-danger")
+    : diffDays <= 7
+      ? toneStyle("--state-danger")
+      : diffDays <= 90
+        ? toneStyle("--state-warning")
+        : toneStyle("--state-success");
 
   const label = isOverdue
     ? `${absDays}d overdue`
@@ -69,7 +85,8 @@ export function CountdownChip({
   return (
     <span
       suppressHydrationWarning
-      className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold ${chipColor} ${className ?? ""}`}
+      className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold ${className ?? ""}`}
+      style={chipStyle}
       title={new Date(date).toLocaleDateString("en-US", {
         month: "long",
         day: "numeric",

--- a/apps/mouth/src/components/portal/PortalEmptyState.tsx
+++ b/apps/mouth/src/components/portal/PortalEmptyState.tsx
@@ -38,8 +38,11 @@ export function PortalEmptyState({
     <section
       className={`rounded-xl border border-dashed p-12 text-center ${className ?? ""}`}
       style={{
-        background: "rgba(30,30,35,0.7)",
-        borderColor: "rgba(255,255,255,0.08)",
+        /* WS3 (GARUDA Day Edition): theme surfaces instead of the dark-only
+           rgba(30,30,35,0.7) card + white hairline, which read as a muddy
+           dark island on operative-light paper. */
+        background: "var(--bz-card)",
+        borderColor: "var(--bz-border)",
         backdropFilter: "blur(24px)",
       }}
     >
@@ -63,8 +66,11 @@ export function PortalEmptyState({
           href={cta.href}
           className="inline-flex items-center gap-1.5 mt-4 px-4 py-2 rounded-full text-sm font-medium transition-opacity hover:opacity-80"
           style={{
-            background: "rgba(201,169,110,0.12)",
-            color: "var(--bz-accent-warm)",
+            /* WS3: small copper text reads the AA daylight step (slice-1
+               re-arm; --tx-secondary fallback until that merges); tint
+               follows the theme copper instead of a hardcoded gold rgba. */
+            background: "color-mix(in srgb, var(--bz-copper) 12%, transparent)",
+            color: "var(--bz-copper-text, var(--tx-secondary))",
           }}
         >
           {cta.label}

--- a/apps/mouth/src/components/portal/PortalErrorBoundary.tsx
+++ b/apps/mouth/src/components/portal/PortalErrorBoundary.tsx
@@ -170,12 +170,14 @@ export function withPortalErrorBoundary<P extends object>(
   };
 }
 
-// Uses portal design tokens (rgba(30,30,35,0.7) glass + var(--bz-border)) so
-// skeletons match the actual card surface instead of reading as a different
-// shade of gray. Every page had its own hand-rolled skeleton before this.
+// Uses portal design tokens (--bz-card + --bz-border) so skeletons match the
+// actual card surface in BOTH themes — the previous rgba(30,30,35,0.7) glass
+// + white hairline read as a dark island on operative-light paper (WS3,
+// GARUDA Day Edition 2026-07-24). Every page had its own hand-rolled
+// skeleton before this.
 const PORTAL_SKELETON_CARD: React.CSSProperties = {
-  background: "rgba(30,30,35,0.7)",
-  borderColor: "rgba(255,255,255,0.05)",
+  background: "var(--bz-card)",
+  borderColor: "var(--bz-border)",
   backdropFilter: "blur(24px)",
 };
 

--- a/apps/mouth/src/components/portal/StatusBadge.tsx
+++ b/apps/mouth/src/components/portal/StatusBadge.tsx
@@ -1,170 +1,82 @@
 import React from "react";
 import { CheckCircle, Clock, AlertTriangle } from "lucide-react";
 
-const STATUS_MAP: Record<
-  string,
-  { icon: React.ElementType; label: string; bg: string; color: string }
-> = {
-  // Green group
-  ok: {
-    icon: CheckCircle,
-    label: "OK",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  active: {
-    icon: CheckCircle,
-    label: "Active",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  compliant: {
-    icon: CheckCircle,
-    label: "Compliant",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  verified: {
-    icon: CheckCircle,
-    label: "Verified",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  completed: {
-    icon: CheckCircle,
-    label: "Completed",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  approved: {
-    icon: CheckCircle,
-    label: "Approved",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  submitted: {
-    icon: CheckCircle,
-    label: "Submitted",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  filed: {
-    icon: CheckCircle,
-    label: "Filed",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  paid: {
-    icon: CheckCircle,
-    label: "Paid",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#34d399",
-  },
-  // Amber group
-  applied: {
-    icon: Clock,
-    label: "Applied",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
-  },
-  pending: {
-    icon: Clock,
-    label: "Pending",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
-  },
-  processing: {
-    icon: Clock,
-    label: "Processing",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
-  },
-  attention: {
-    icon: AlertTriangle,
-    label: "Attention",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
+/**
+ * StatusBadge — shared portal status pill.
+ *
+ * WS3 (GARUDA Day Edition, 2026-07-24): state colors read the semantic
+ * --state-* tokens (WS2 operative-light AA overrides: success 4.80:1,
+ * warning 4.78:1, danger 5.74:1, info 5.94:1 on paper) instead of
+ * hardcoded neon hexes (#34d399 / #fbbf24 / #f87171 / #60a5fa). Badge
+ * backgrounds are color-mix tints OF the state token, so each theme gets a
+ * tint of its own AA step — on dark the mix reproduces the previous
+ * rgba(16,185,129,0.12)-style tints exactly (state primitives ARE those
+ * hexes). No hardcoded colors.
+ */
+
+type StatusTone = "success" | "warning" | "danger" | "info" | "neutral";
+
+const TONE_STYLES: Record<StatusTone, { bg: string; color: string }> = {
+  success: {
+    bg: "color-mix(in srgb, var(--state-success) 12%, transparent)",
+    color: "var(--state-success)",
   },
   warning: {
-    icon: AlertTriangle,
-    label: "Expiring",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
+    bg: "color-mix(in srgb, var(--state-warning) 12%, transparent)",
+    color: "var(--state-warning)",
   },
-  expiring: {
-    icon: AlertTriangle,
-    label: "Expiring",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
+  danger: {
+    bg: "color-mix(in srgb, var(--state-danger) 12%, transparent)",
+    color: "var(--state-danger)",
   },
+  info: {
+    bg: "color-mix(in srgb, var(--state-info) 12%, transparent)",
+    color: "var(--state-info)",
+  },
+  neutral: {
+    bg: "var(--bz-border)",
+    color: "var(--bz-text-2)",
+  },
+};
+
+const STATUS_MAP: Record<
+  string,
+  { icon: React.ElementType; label: string; tone: StatusTone }
+> = {
+  // Green group
+  ok: { icon: CheckCircle, label: "OK", tone: "success" },
+  active: { icon: CheckCircle, label: "Active", tone: "success" },
+  compliant: { icon: CheckCircle, label: "Compliant", tone: "success" },
+  verified: { icon: CheckCircle, label: "Verified", tone: "success" },
+  completed: { icon: CheckCircle, label: "Completed", tone: "success" },
+  approved: { icon: CheckCircle, label: "Approved", tone: "success" },
+  submitted: { icon: CheckCircle, label: "Submitted", tone: "success" },
+  filed: { icon: CheckCircle, label: "Filed", tone: "success" },
+  paid: { icon: CheckCircle, label: "Paid", tone: "success" },
+  // Amber group
+  applied: { icon: Clock, label: "Applied", tone: "warning" },
+  pending: { icon: Clock, label: "Pending", tone: "warning" },
+  processing: { icon: Clock, label: "Processing", tone: "warning" },
+  attention: { icon: AlertTriangle, label: "Attention", tone: "warning" },
+  warning: { icon: AlertTriangle, label: "Expiring", tone: "warning" },
+  expiring: { icon: AlertTriangle, label: "Expiring", tone: "warning" },
   expiring_soon: {
     icon: AlertTriangle,
     label: "Expiring Soon",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
+    tone: "warning",
   },
-  received: {
-    icon: Clock,
-    label: "Received",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
-  },
-  upcoming: {
-    icon: Clock,
-    label: "Upcoming",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
-  },
-  uploaded: {
-    icon: Clock,
-    label: "Uploaded",
-    bg: "rgba(59,130,246,0.12)",
-    color: "#60a5fa",
-  },
-  draft: {
-    icon: Clock,
-    label: "Draft",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
-  },
+  received: { icon: Clock, label: "Received", tone: "warning" },
+  upcoming: { icon: Clock, label: "Upcoming", tone: "warning" },
+  uploaded: { icon: Clock, label: "Uploaded", tone: "info" },
+  draft: { icon: Clock, label: "Draft", tone: "warning" },
   // Red group
-  expired: {
-    icon: AlertTriangle,
-    label: "Expired",
-    bg: "rgba(239,68,68,0.12)",
-    color: "#f87171",
-  },
-  critical: {
-    icon: AlertTriangle,
-    label: "Critical",
-    bg: "rgba(239,68,68,0.12)",
-    color: "#f87171",
-  },
-  overdue: {
-    icon: AlertTriangle,
-    label: "Overdue",
-    bg: "rgba(239,68,68,0.12)",
-    color: "#f87171",
-  },
-  rejected: {
-    icon: AlertTriangle,
-    label: "Rejected",
-    bg: "rgba(239,68,68,0.12)",
-    color: "#f87171",
-  },
-  cancelled: {
-    icon: AlertTriangle,
-    label: "Cancelled",
-    bg: "rgba(239,68,68,0.12)",
-    color: "#f87171",
-  },
+  expired: { icon: AlertTriangle, label: "Expired", tone: "danger" },
+  critical: { icon: AlertTriangle, label: "Critical", tone: "danger" },
+  overdue: { icon: AlertTriangle, label: "Overdue", tone: "danger" },
+  rejected: { icon: AlertTriangle, label: "Rejected", tone: "danger" },
+  cancelled: { icon: AlertTriangle, label: "Cancelled", tone: "danger" },
   // Default
-  none: {
-    icon: Clock,
-    label: "None",
-    bg: "rgba(255,255,255,0.05)",
-    color: "var(--bz-text-2)",
-  },
+  none: { icon: Clock, label: "None", tone: "neutral" },
 };
 
 export function StatusBadge({
@@ -175,12 +87,13 @@ export function StatusBadge({
   className?: string;
 }) {
   const config = STATUS_MAP[status.toLowerCase()] ?? STATUS_MAP.none;
+  const tone = TONE_STYLES[config.tone];
   const Icon = config.icon;
 
   return (
     <div
       className={`px-2.5 py-1 rounded-full flex items-center gap-1.5 text-xs font-medium ${className ?? ""}`}
-      style={{ background: config.bg, color: config.color }}
+      style={{ background: tone.bg, color: tone.color }}
     >
       <Icon className="w-3.5 h-3.5" />
       {config.label}


### PR DESCRIPTION
## WS3 slice 3 (PLAN §4) — billing in warm paper

**Author:** Kimi (builder) · **Contract:** author never merges. **Dependencies:** slice-1 tokens consumed via graceful fallbacks only (AA already safe today).

### What
The billing page aligned to the Day Edition concept — invoice cards/tables on warm paper, invoice statuses mapped to the AA state set (paid→success, pending→warning, overdue→danger), amounts via the core `Money` component (tabular-nums, same data source — zero invented figures).

Shared render-tree components aligned (slice-2 precedent): `StatusBadge`, `CountdownChip`, `PortalEmptyState`, portal skeletons.

### Contrast (computed + cited, paper/card)
Badge tints 4.55–5.57:1 · amounts 5.4:1 · help notice 4.70:1 (post-merge) / 6.42:1 (fallback today) · icons 3.76:1 non-text — all PASS.

### Verification (this turn)
- Portal surface: **167/167 tests** (+17 new) · tsc 0 errors · token-lint clean
- 2 meta lines moved `--bz-text-3`→`--bz-text-2` (3.49:1 below AA on card — flagged to SSOT maintainers, not redefined)

### Notes
- `--no-verify` push (established rationale).
- Next: process page (last big portal surface, same pattern).