### PR TITLE
feat(mouth): WS3 slice 4 — portal process day pass (GARUDA OS train)

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/process/[practiceId]/error.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/[practiceId]/error.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { FolderKanban, RefreshCw, ArrowLeft } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { logger } from '@/lib/logger';
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { FolderKanban, RefreshCw, ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { logger } from "@/lib/logger";
 
 export default function PracticeDetailError({
   error,
@@ -16,20 +16,26 @@ export default function PracticeDetailError({
   const router = useRouter();
 
   useEffect(() => {
-    logger.error('Portal practice detail page error', {}, error);
+    logger.error("Portal practice detail page error", {}, error);
   }, [error]);
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-6 text-center">
       <div
         className="flex h-16 w-16 items-center justify-center rounded-full"
-        style={{ background: 'rgba(244,63,94,0.1)' }}
+        style={{
+          background:
+            "color-mix(in srgb, var(--state-danger) 10%, transparent)",
+        }}
       >
-        <FolderKanban className="h-8 w-8" style={{ color: 'var(--neon-rose)' }} />
+        <FolderKanban
+          className="h-8 w-8"
+          style={{ color: "var(--state-danger)" }}
+        />
       </div>
       <div className="space-y-2 max-w-sm">
         <h2 className="text-xl font-semibold">Practice unavailable</h2>
-        <p className="text-sm" style={{ color: 'var(--bz-text-2)' }}>
+        <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
           We couldn&apos;t load this practice. Please try again.
         </p>
       </div>

--- a/apps/mouth/src/app/portal/(authenticated)/process/[practiceId]/loading.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/[practiceId]/loading.tsx
@@ -1,5 +1,8 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { Skeleton } from "@/components/ui/skeleton";
 
+// WS3 slice 4 (GARUDA Day Edition): skeleton panel reads --bz-card /
+// --bz-border (was rgba(30,30,35,0.7) + white rgba hairline — a near-black
+// panel flashing on the warm-paper page).
 export default function PracticeDetailLoading() {
   return (
     <div className="space-y-6 p-2">
@@ -15,7 +18,10 @@ export default function PracticeDetailLoading() {
       {/* Timeline */}
       <div
         className="rounded-xl border p-6 space-y-4"
-        style={{ background: 'rgba(30,30,35,0.7)', borderColor: 'rgba(255,255,255,0.05)' }}
+        style={{
+          background: "var(--bz-card)",
+          borderColor: "var(--bz-border)",
+        }}
       >
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className="flex items-center gap-3">

--- a/apps/mouth/src/app/portal/(authenticated)/process/[practiceId]/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/[practiceId]/page.test.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import type { ProcessTimelineData } from "@/lib/schemas/process";
+
+const { mockUseProcessTimeline } = vi.hoisted(() => ({
+  mockUseProcessTimeline: vi.fn(),
+}));
+
+vi.mock("@/hooks/useProcessTimeline", () => ({
+  useProcessTimeline: (practiceId: string) =>
+    mockUseProcessTimeline(practiceId),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import PracticeDetailPage from "./page";
+
+function makeData(
+  overrides: Partial<ProcessTimelineData> = {},
+): ProcessTimelineData {
+  return {
+    practice_id: 603,
+    practice_name: "KITAS Investor",
+    practice_category: "VISA",
+    current_status: "on_process",
+    assigned_to: null,
+    steps: [
+      {
+        status: "inquiry",
+        label: "Inquiry",
+        completed: true,
+        is_current: false,
+        changed_at: "2026-06-01T09:00:00Z",
+        changed_by: "team",
+      },
+      {
+        status: "on_process",
+        label: "On Process",
+        completed: false,
+        is_current: true,
+        changed_at: "2026-07-10T09:00:00Z",
+        changed_by: "team",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+// The page calls React `use(params)`, so it suspends on first mount: render
+// inside an awaited act() + Suspense boundary so the resolved promise
+// unrolls and the page content commits.
+async function renderPage(overrides: Partial<ProcessTimelineData> = {}) {
+  mockUseProcessTimeline.mockReturnValue({
+    data: makeData(overrides),
+    error: undefined,
+    isLoading: false,
+    mutate: vi.fn(),
+  });
+  await act(async () => {
+    render(
+      <React.Suspense fallback={null}>
+        <PracticeDetailPage params={Promise.resolve({ practiceId: "603" })} />
+      </React.Suspense>,
+    );
+  });
+}
+
+describe("PracticeDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the practice name in the Day serif masthead", async () => {
+    await renderPage();
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: "KITAS Investor",
+    });
+    expect(heading).toHaveStyle({ fontFamily: "var(--font-serif)" });
+    expect(heading.className).toContain("text-[var(--tx-pure)]");
+    // Category reads copper-text with the slice-1 fallback
+    expect(screen.getByText("VISA").className).toContain(
+      "text-[var(--bz-copper-text,var(--tx-secondary))]",
+    );
+  });
+
+  it("links back to the process list with the copper-text accent", async () => {
+    await renderPage();
+    const back = screen.getByRole("link", { name: /all practices/i });
+    expect(back).toHaveAttribute("href", "/portal/process");
+    expect(back.className).toContain(
+      "text-[var(--bz-copper-text,var(--tx-secondary))]",
+    );
+  });
+
+  it("drives timeline step badges from semantic --state-* tokens", async () => {
+    await renderPage();
+    // on_process → --state-info (was raw #d4845a / --bz-accent)
+    const badge = screen.getAllByLabelText("Status: On Process")[0];
+    expect(badge.style.color).toContain("--state-info");
+    // completed inquiry step → neutral text-tertiary token
+    const inquiryBadge = screen.getAllByLabelText("Status: Inquiry")[0];
+    expect(inquiryBadge.style.color).toContain("--text-tertiary");
+  });
+
+  it("shows the blocked CTA with --state-danger styling when cancelled", async () => {
+    await renderPage({
+      current_status: "cancelled",
+      assigned_to: "legal team",
+    });
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/Practice blocked: legal team\./i);
+    const icon = alert.querySelector("svg");
+    expect(icon).toHaveStyle({ color: "var(--state-danger)" });
+  });
+
+  it("renders the error state with a working retry", async () => {
+    const mutate = vi.fn();
+    mockUseProcessTimeline.mockReturnValue({
+      data: undefined,
+      error: new Error("boom"),
+      isLoading: false,
+      mutate,
+    });
+    await act(async () => {
+      render(
+        <React.Suspense fallback={null}>
+          <PracticeDetailPage params={Promise.resolve({ practiceId: "603" })} />
+        </React.Suspense>,
+      );
+    });
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/Unable to load the timeline/i);
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the loading skeleton while fetching", async () => {
+    mockUseProcessTimeline.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      mutate: vi.fn(),
+    });
+    await act(async () => {
+      render(
+        <React.Suspense fallback={null}>
+          <PracticeDetailPage params={Promise.resolve({ practiceId: "603" })} />
+        </React.Suspense>,
+      );
+    });
+    expect(screen.getByLabelText("Loading timeline")).toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/app/portal/(authenticated)/process/[practiceId]/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/[practiceId]/page.tsx
@@ -1,4 +1,17 @@
 "use client";
+
+/**
+ * Portal Practice Detail — single practice timeline.
+ *
+ * WS3 slice 4 (GARUDA Day Edition, 2026-07-24): day-theme token alignment,
+ * mirroring slice 1 (portal home, PR 3050) and slice 2 (matters, PR 3051).
+ * Masthead = Cormorant serif (--font-serif) in --tx-pure. Copper accents
+ * read --bz-copper-text (armed in globals.css by slice 1, with the
+ * --tx-secondary fallback keeping AA until that merges). State colors
+ * read the semantic --state-* tokens (WS2 operative-light AA overrides).
+ * No hardcoded hexes.
+ */
+
 import { useState, use } from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
@@ -26,7 +39,7 @@ export default function PracticeDetailPage({ params }: Props) {
       <main className="max-w-3xl mx-auto px-4 py-6">
         <Link
           href="/portal/process"
-          className="inline-flex items-center gap-1 text-xs text-[#c9a96e]/60 hover:text-[#c9a96e] mb-6 uppercase tracking-[2px]"
+          className="inline-flex items-center gap-1 text-xs text-[var(--bz-copper-text,var(--tx-secondary))] hover:text-[var(--tx-pure)] mb-6 uppercase tracking-[2px]"
         >
           <ArrowLeft className="w-3 h-3" aria-hidden />
           All practices
@@ -34,11 +47,18 @@ export default function PracticeDetailPage({ params }: Props) {
 
         {data && (
           <header className="mb-6">
-            <h1 className="text-2xl font-light text-[#f0ece4]">
+            <div
+              aria-hidden="true"
+              className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+            />
+            <h1
+              className="text-2xl font-semibold text-[var(--tx-pure)]"
+              style={{ fontFamily: "var(--font-serif)" }}
+            >
               {data.practice_name ?? "Practice"}
             </h1>
             {data.practice_category && (
-              <p className="text-xs text-[#c9a96e]/60 uppercase tracking-[2px] mt-1">
+              <p className="text-xs text-[var(--bz-copper-text,var(--tx-secondary))] uppercase tracking-[2px] mt-1">
                 {data.practice_category}
               </p>
             )}
@@ -50,12 +70,15 @@ export default function PracticeDetailPage({ params }: Props) {
         {error && !isLoading && (
           <div
             role="alert"
-            className="rounded-lg p-4 border border-white/10 text-sm"
+            className="rounded-lg p-4 border text-sm"
+            style={{ borderColor: "var(--bz-border)" }}
           >
-            <p className="mb-2 text-[#f0ece4]">Unable to load the timeline.</p>
+            <p className="mb-2 text-[var(--tx-primary)]">
+              Unable to load the timeline.
+            </p>
             <button
               onClick={() => mutate()}
-              className="text-xs uppercase tracking-[2px] text-[#d4845a] hover:underline"
+              className="text-xs uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))] hover:underline"
             >
               Retry
             </button>

--- a/apps/mouth/src/app/portal/(authenticated)/process/error.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/error.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { ClipboardList, RefreshCw } from 'lucide-react';
-import { logger } from '@/lib/logger';
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { ClipboardList, RefreshCw } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 export default function ProcessError({
   error,
@@ -13,20 +13,26 @@ export default function ProcessError({
   reset: () => void;
 }) {
   useEffect(() => {
-    logger.error('Portal process page error', {}, error);
+    logger.error("Portal process page error", {}, error);
   }, [error]);
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-6 text-center">
       <div
         className="flex h-16 w-16 items-center justify-center rounded-full"
-        style={{ background: 'rgba(244,63,94,0.1)' }}
+        style={{
+          background:
+            "color-mix(in srgb, var(--state-danger) 10%, transparent)",
+        }}
       >
-        <ClipboardList className="h-8 w-8" style={{ color: 'var(--neon-rose)' }} />
+        <ClipboardList
+          className="h-8 w-8"
+          style={{ color: "var(--state-danger)" }}
+        />
       </div>
       <div className="space-y-2 max-w-sm">
         <h2 className="text-xl font-semibold">Process data unavailable</h2>
-        <p className="text-sm" style={{ color: 'var(--bz-text-2)' }}>
+        <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
           We couldn&apos;t load your process information. Please try again.
         </p>
       </div>

--- a/apps/mouth/src/app/portal/(authenticated)/process/loading.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/loading.tsx
@@ -1,5 +1,8 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { Skeleton } from "@/components/ui/skeleton";
 
+// WS3 slice 4 (GARUDA Day Edition): skeleton cards read --bz-card /
+// --bz-border / --glass-rim (was rgba(30,30,35,0.7) + white rgba hairlines
+// — near-black panels flashing on the warm-paper page).
 export default function ProcessLoading() {
   return (
     <div className="space-y-6 p-2">
@@ -15,12 +18,15 @@ export default function ProcessLoading() {
           <div
             key={i}
             className="rounded-xl border overflow-hidden"
-            style={{ background: 'rgba(30,30,35,0.7)', borderColor: 'rgba(255,255,255,0.05)' }}
+            style={{
+              background: "var(--bz-card)",
+              borderColor: "var(--bz-border)",
+            }}
           >
             {/* Card Header */}
             <div
               className="flex items-center justify-between px-5 py-4 border-b"
-              style={{ borderColor: 'rgba(255,255,255,0.05)' }}
+              style={{ borderColor: "var(--bz-border)" }}
             >
               <div className="flex items-center gap-3">
                 <Skeleton variant="circular" width={36} height={36} />
@@ -38,7 +44,10 @@ export default function ProcessLoading() {
                 <div
                   key={j}
                   className="rounded-lg border p-3 flex items-center gap-3"
-                  style={{ background: 'rgba(255,255,255,0.02)', borderColor: 'rgba(255,255,255,0.05)' }}
+                  style={{
+                    background: "var(--glass-rim)",
+                    borderColor: "var(--bz-border)",
+                  }}
                 >
                   <Skeleton variant="rounded" width={32} height={32} />
                   <div className="flex-1 space-y-1">

--- a/apps/mouth/src/app/portal/(authenticated)/process/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/page.test.tsx
@@ -13,11 +13,14 @@ const { mockGetProfile, mockGetMyRequiredDocuments, mockUploadClientDocument } =
 
 vi.mock("next/dynamic", () => ({
   default: (
-    loader: () => Promise<{ default: React.ComponentType<Record<string, unknown>> }>,
+    loader: () => Promise<{
+      default: React.ComponentType<Record<string, unknown>>;
+    }>,
   ) => {
     const Component = (props: Record<string, unknown>) => {
-      const [Resolved, setResolved] =
-        React.useState<React.ComponentType<Record<string, unknown>> | null>(null);
+      const [Resolved, setResolved] = React.useState<React.ComponentType<
+        Record<string, unknown>
+      > | null>(null);
       React.useEffect(() => {
         loader().then((mod) => setResolved(() => mod.default));
       }, []);
@@ -65,18 +68,17 @@ vi.mock("@/hooks/usePortalProcessTimeline", () => ({
 }));
 
 vi.mock("@/components/ui/dialog", () => ({
-  Dialog: ({
-    open,
-    children,
-  }: {
-    open: boolean;
-    children: React.ReactNode;
-  }) => (open ? <div>{children}</div> : null),
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
   DialogContent: ({ children }: { children: React.ReactNode }) => (
     <div role="dialog">{children}</div>
   ),
-  DialogHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
 }));
 
 vi.mock("@/components/ui/toast", () => ({
@@ -189,5 +191,53 @@ describe("PortalProcessPage", () => {
         },
       ]);
     });
+  });
+
+  it("drives practice/doc status styling from semantic --state-* tokens (WS3 day pass)", async () => {
+    mockGetMyRequiredDocuments.mockResolvedValue([pendingDocument]);
+
+    const { default: PortalProcessPage } = await import("./page");
+    render(<PortalProcessPage />);
+
+    // Practice status chip (waiting_documents → --state-warning)
+    const chip = await screen.findByText("Waiting for Documents");
+    expect(chip).toHaveStyle({ color: "var(--state-warning)" });
+
+    // "Documents Required" banner + required badge read the same token
+    // (the stats grid carries a "Documents Required" label too — pick the
+    // warning-styled banner title)
+    const bannerTitle = (await screen.findAllByText("Documents Required")).find(
+      (el) => el.style.color.includes("--state-warning"),
+    );
+    expect(bannerTitle).toBeDefined();
+    expect(screen.getByText("Required")).toHaveStyle({
+      color: "var(--state-warning)",
+    });
+
+    // Doc status badge (pending → --state-warning)
+    expect(screen.getByText("Pending")).toHaveStyle({
+      color: "var(--state-warning)",
+    });
+
+    // Pending stat value uses --state-warning (was text-amber-400)
+    const statsLabel = screen.getByText("Pending Upload");
+    const statValue = statsLabel.parentElement?.querySelector(
+      "p.text-2xl",
+    ) as HTMLElement;
+    expect(statValue).toHaveStyle({ color: "var(--state-warning)" });
+  });
+
+  it("renders the Day masthead: copper rule + Cormorant serif headline", async () => {
+    mockGetMyRequiredDocuments.mockResolvedValue([pendingDocument]);
+
+    const { default: PortalProcessPage } = await import("./page");
+    render(<PortalProcessPage />);
+
+    const heading = await screen.findByRole("heading", {
+      level: 1,
+      name: "My Processes",
+    });
+    expect(heading).toHaveStyle({ fontFamily: "var(--font-serif)" });
+    expect(heading.className).toContain("text-[var(--tx-pure)]");
   });
 });

--- a/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
@@ -49,67 +49,83 @@ import {
   statusToBaton,
 } from "@/components/portal/PracticeBaton";
 
-// Status configurations
+// Status configurations — WS3 slice 4 (GARUDA Day Edition, 2026-07-24):
+// state colors read the semantic --state-* tokens (WS2 operative-light AA
+// overrides: success 4.80 / warning 4.78 / danger 5.74 / info 5.94 :1 on
+// paper) instead of Tailwind dark-grade utilities (text-amber-500 & co.
+// fail AA on paper). `fg` is a full CSS color expression; chipStyle()
+// derives the 12% tint background from it.
 const STATUS_CONFIG = {
   pending: {
-    color: "bg-amber-500/10 text-amber-500",
+    fg: "var(--state-warning)",
     icon: <Clock className="w-4 h-4" />,
     label: "Pending",
   },
   uploaded: {
-    color: "bg-blue-500/10 text-blue-500",
+    fg: "var(--state-info)",
     icon: <Upload className="w-4 h-4" />,
     label: "Uploaded",
   },
   verified: {
-    color: "bg-green-500/10 text-green-500",
+    fg: "var(--state-success)",
     icon: <CheckCircle className="w-4 h-4" />,
     label: "Verified",
   },
   rejected: {
-    color: "bg-red-500/10 text-red-500",
+    fg: "var(--state-danger)",
     icon: <X className="w-4 h-4" />,
     label: "Rejected",
   },
 } as const;
 
-// Process status mapping with colors (mirrored from CRM workspace)
-const PROCESS_STATUS_CONFIG: Record<string, { label: string; color: string }> =
-  {
-    inquiry: { label: "Inquiry", color: "bg-slate-500/10 text-slate-400" },
-    quotation_sent: {
-      label: "Quotation Sent",
-      color: "bg-blue-500/10 text-blue-400",
-    },
-    sending_invoice: {
-      label: "Sending Invoice",
-      color: "bg-blue-500/10 text-blue-400",
-    },
-    payment_pending: {
-      label: "Payment Pending",
-      color: "bg-amber-500/10 text-amber-400",
-    },
-    waiting_payment: {
-      label: "Waiting for Payment",
-      color: "bg-amber-500/10 text-amber-400",
-    },
-    in_progress: { label: "In Progress", color: "bg-sky-500/10 text-sky-400" },
-    on_process: { label: "On Process", color: "bg-sky-500/10 text-sky-400" },
-    waiting_documents: {
-      label: "Waiting for Documents",
-      color: "bg-orange-500/10 text-orange-400",
-    },
-    submitted_to_gov: {
-      label: "Submitted to Government",
-      color: "bg-purple-500/10 text-purple-400",
-    },
-    approved: {
-      label: "Approved",
-      color: "bg-emerald-500/10 text-emerald-400",
-    },
-    completed: { label: "Completed", color: "bg-green-500/10 text-green-400" },
-    cancelled: { label: "Cancelled", color: "bg-red-500/10 text-red-400" },
+/** Chip colors: fg at full strength, bg as a 12% tint of the same color. */
+function chipStyle(fg: string): React.CSSProperties {
+  return {
+    color: fg,
+    backgroundColor: `color-mix(in srgb, ${fg} 12%, transparent)`,
   };
+}
+
+// Process status mapping with colors (mirrored from CRM workspace).
+// Honest day mapping (slice-4 brief): done → success, current/in-flight →
+// info, waiting-on-client → warning, blocked/cancelled → danger,
+// early/neutral → --text-tertiary (4.77:1 on paper), money-in-flight →
+// copper via --bz-copper-text (slice-1 fallback until PR #3050 merges).
+const PROCESS_STATUS_CONFIG: Record<string, { label: string; fg: string }> = {
+  inquiry: { label: "Inquiry", fg: "var(--text-tertiary, var(--tx-tertiary))" },
+  quotation_sent: {
+    label: "Quotation Sent",
+    fg: "var(--bz-copper-text, var(--tx-secondary))",
+  },
+  sending_invoice: {
+    label: "Sending Invoice",
+    fg: "var(--bz-copper-text, var(--tx-secondary))",
+  },
+  payment_pending: {
+    label: "Payment Pending",
+    fg: "var(--state-warning)",
+  },
+  waiting_payment: {
+    label: "Waiting for Payment",
+    fg: "var(--state-warning)",
+  },
+  in_progress: { label: "In Progress", fg: "var(--state-info)" },
+  on_process: { label: "On Process", fg: "var(--state-info)" },
+  waiting_documents: {
+    label: "Waiting for Documents",
+    fg: "var(--state-warning)",
+  },
+  submitted_to_gov: {
+    label: "Submitted to Government",
+    fg: "var(--state-info)",
+  },
+  approved: {
+    label: "Approved",
+    fg: "var(--state-success)",
+  },
+  completed: { label: "Completed", fg: "var(--state-success)" },
+  cancelled: { label: "Cancelled", fg: "var(--state-danger)" },
+};
 
 // Keep compat for any old references
 const PROCESS_STATUS_LABELS: Record<string, string> = Object.fromEntries(
@@ -119,7 +135,9 @@ const PROCESS_STATUS_LABELS: Record<string, string> = Object.fromEntries(
 const PORTAL_CARD_STYLE = {
   background: "var(--bz-elevated)",
   borderColor: "var(--bz-border)",
-  boxShadow: "0 12px 32px rgba(15, 23, 42, 0.08)",
+  // GARUDA Day concept .panel shadow — soft navy on paper, near-invisible
+  // on dark (harmless there).
+  boxShadow: "0 14px 34px rgba(22, 33, 58, 0.07)",
 } as const;
 
 const PORTAL_CARD_MUTED_STYLE = {
@@ -141,7 +159,8 @@ const StatusBadge = memo(
     return (
       <Badge
         variant="secondary"
-        className={`${config.color} flex items-center gap-1`}
+        className="flex items-center gap-1"
+        style={chipStyle(config.fg)}
       >
         {config.icon}
         {config.label}
@@ -209,7 +228,7 @@ function DocumentUploadModal({
         <div className="space-y-4">
           <div
             className="p-3 rounded-lg backdrop-blur-md"
-            style={{ background: "rgba(255,255,255,0.03)" }}
+            style={{ background: "var(--glass-rim)" }}
           >
             <p className="font-medium">{document.document_label}</p>
             {document.description && (
@@ -243,8 +262,8 @@ function DocumentUploadModal({
               placeholder="Add any notes about this document..."
               className="w-full px-3 py-2 rounded-lg border text-sm min-h-[80px]"
               style={{
-                background: "rgba(255,255,255,0.03)",
-                borderColor: "rgba(255,255,255,0.05)",
+                background: "var(--glass-rim)",
+                borderColor: "var(--bz-border)",
                 color: "var(--bz-text-1)",
               }}
             />
@@ -326,7 +345,11 @@ function ProcessCard({
               {process.processName}
             </h3>
             <span
-              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${PROCESS_STATUS_CONFIG[process.processStatus]?.color || "bg-slate-500/10 text-slate-400"}`}
+              className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+              style={chipStyle(
+                PROCESS_STATUS_CONFIG[process.processStatus]?.fg ||
+                  "var(--text-tertiary, var(--tx-tertiary))",
+              )}
             >
               {PROCESS_STATUS_CONFIG[process.processStatus]?.label ||
                 process.processStatus}
@@ -372,7 +395,7 @@ function ProcessCard({
           <button
             onClick={() => setShowTimeline(!showTimeline)}
             className="text-xs font-medium flex items-center gap-1 transition-opacity hover:opacity-80"
-            style={{ color: "var(--bz-accent-warm)" }}
+            style={{ color: "var(--bz-copper-text, var(--tx-secondary))" }}
           >
             {showTimeline ? "Hide Timeline" : "View Timeline"}
           </button>
@@ -383,7 +406,7 @@ function ProcessCard({
                   <div
                     className="w-4 h-4 border-2 border-t-transparent rounded-full animate-spin"
                     style={{
-                      borderColor: "var(--bz-accent-warm)",
+                      borderColor: "var(--bz-copper)",
                       borderTopColor: "transparent",
                     }}
                   />
@@ -399,7 +422,7 @@ function ProcessCard({
               ) : (
                 <p
                   className="text-xs py-2"
-                  style={{ color: "var(--bz-text-3)" }}
+                  style={{ color: "var(--text-tertiary, var(--bz-text-3))" }}
                 >
                   No timeline data available
                 </p>
@@ -468,9 +491,12 @@ function ProcessCard({
               <div
                 key={doc.id}
                 id={`doc-${doc.id}`}
-                className={`p-4 flex items-start justify-between gap-3 ${
-                  doc.is_required ? "border-l-2 border-l-amber-500" : ""
-                }`}
+                className="p-4 flex items-start justify-between gap-3"
+                style={
+                  doc.is_required
+                    ? { borderLeft: "2px solid var(--state-warning)" }
+                    : undefined
+                }
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
@@ -478,7 +504,8 @@ function ProcessCard({
                     {doc.is_required && (
                       <Badge
                         variant="secondary"
-                        className="text-[10px] bg-amber-500/10 text-amber-500"
+                        className="text-[10px]"
+                        style={chipStyle("var(--state-warning)")}
                       >
                         Required
                       </Badge>
@@ -516,13 +543,16 @@ function ProcessCard({
                 {doc.status === "uploaded" && (
                   <Badge
                     variant="secondary"
-                    className="bg-blue-500/10 text-blue-500"
+                    style={chipStyle("var(--state-info)")}
                   >
                     Under Review
                   </Badge>
                 )}
                 {doc.status === "verified" && (
-                  <CheckCircle className="w-5 h-5 text-green-500" />
+                  <CheckCircle
+                    className="w-5 h-5"
+                    style={{ color: "var(--state-success)" }}
+                  />
                 )}
                 {doc.status === "rejected" && (
                   <Button
@@ -561,38 +591,41 @@ export default function PortalProcessPage() {
   );
 
   // Load profile and documents — stable reference, no toast dependency in deps
-  const loadData = useCallback(async (options?: {
-    showLoading?: boolean;
-    showErrorToast?: boolean;
-  }) => {
-    const showLoading = options?.showLoading ?? true;
-    const showErrorToast = options?.showErrorToast ?? true;
-    try {
-      if (showLoading) {
-        setIsLoading(true);
-      }
+  const loadData = useCallback(
+    async (options?: { showLoading?: boolean; showErrorToast?: boolean }) => {
+      const showLoading = options?.showLoading ?? true;
+      const showErrorToast = options?.showErrorToast ?? true;
+      try {
+        if (showLoading) {
+          setIsLoading(true);
+        }
 
-      // Get profile
-      const profileData = await api.portal.getProfile();
-      setProfile({ id: profileData.id, fullName: profileData.fullName });
+        // Get profile
+        const profileData = await api.portal.getProfile();
+        setProfile({ id: profileData.id, fullName: profileData.fullName });
 
-      // Get required documents via portal-scoped endpoint. The CRM version
-      // 403s for plain client JWTs — this route resolves client_id from
-      // the caller's JWT so shareholders can load their own checklist.
-      const docs =
-        (await api.portal.getMyRequiredDocuments()) as ClientRequiredDocument[];
-      setDocuments(docs);
-    } catch (err) {
-      if (showErrorToast) {
-        toastRef.current.error("Failed to load data", "Please try again later");
+        // Get required documents via portal-scoped endpoint. The CRM version
+        // 403s for plain client JWTs — this route resolves client_id from
+        // the caller's JWT so shareholders can load their own checklist.
+        const docs =
+          (await api.portal.getMyRequiredDocuments()) as ClientRequiredDocument[];
+        setDocuments(docs);
+      } catch (err) {
+        if (showErrorToast) {
+          toastRef.current.error(
+            "Failed to load data",
+            "Please try again later",
+          );
+        }
+        logger.error("Failed to load process data", {}, err as Error);
+      } finally {
+        if (showLoading) {
+          setIsLoading(false);
+        }
       }
-      logger.error("Failed to load process data", {}, err as Error);
-    } finally {
-      if (showLoading) {
-        setIsLoading(false);
-      }
-    }
-  }, []); // stable — no deps that change every render
+    },
+    [],
+  ); // stable — no deps that change every render
 
   useEffect(() => {
     loadData();
@@ -701,10 +734,21 @@ export default function PortalProcessPage() {
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500 max-w-4xl mx-auto">
-      {/* Header */}
+      {/* Header — Day masthead (GARUDA Day Edition): copper rule + Cormorant
+          serif headline per concept (--font-serif, wired on <html>); Inter
+          everywhere else. */}
       <section>
-        <h1 className="text-2xl font-bold tracking-tight">My Processes</h1>
-        <p style={{ color: "var(--bz-text-2)" }}>
+        <div
+          aria-hidden="true"
+          className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+        />
+        <h1
+          className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          My Processes
+        </h1>
+        <p className="text-sm mt-1" style={{ color: "var(--tx-secondary)" }}>
           Track your active processes and upload required documents
         </p>
       </section>
@@ -737,7 +781,12 @@ export default function PortalProcessPage() {
             <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
               Pending Upload
             </p>
-            <p className="text-2xl font-bold text-amber-400">{pendingDocs}</p>
+            <p
+              className="text-2xl font-bold"
+              style={{ color: "var(--state-warning)" }}
+            >
+              {pendingDocs}
+            </p>
           </div>
           <div
             className="rounded-xl border p-4"
@@ -746,7 +795,10 @@ export default function PortalProcessPage() {
             <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
               Completion
             </p>
-            <p className="text-2xl font-bold text-green-400">
+            <p
+              className="text-2xl font-bold"
+              style={{ color: "var(--state-success)" }}
+            >
               {completionRate}%
             </p>
           </div>
@@ -773,11 +825,29 @@ export default function PortalProcessPage() {
       ) : (
         <div className="space-y-4">
           {pendingDocs > 0 && (
-            <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4 flex items-start gap-3">
-              <AlertTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
+            <div
+              className="rounded-lg p-4 flex items-start gap-3"
+              style={{
+                background: "var(--bz-card)",
+                border:
+                  "1px solid color-mix(in srgb, var(--state-warning) 30%, transparent)",
+              }}
+            >
+              <AlertTriangle
+                className="w-5 h-5 shrink-0 mt-0.5"
+                style={{ color: "var(--state-warning)" }}
+              />
               <div>
-                <p className="font-medium text-amber-600">Documents Required</p>
-                <p className="text-sm text-amber-600/80">
+                <p
+                  className="font-medium"
+                  style={{ color: "var(--state-warning)" }}
+                >
+                  Documents Required
+                </p>
+                <p
+                  className="text-sm"
+                  style={{ color: "var(--state-warning)" }}
+                >
                   You have {pendingDocs} document{pendingDocs > 1 ? "s" : ""}{" "}
                   waiting to be uploaded. Please upload them to proceed with
                   your process.

--- a/apps/mouth/src/components/portal/PracticeBaton.tsx
+++ b/apps/mouth/src/components/portal/PracticeBaton.tsx
@@ -70,8 +70,11 @@ const BATON_STYLE: Record<Baton, BatonStyle> = {
     label: "Your turn",
     sub: "Action needed from you",
     fg: "var(--bz-accent)", // vibrant copper — demands attention
-    bg: "rgba(212,132,90,0.12)",
-    ring: "rgba(212,132,90,0.40)",
+    // WS3 slice 4: tints derive from the token (was raw rgba(212,132,90,*),
+    // frozen at the dark-grade copper), so the chip follows the daylight
+    // copper step when slice-1 re-arms --bz-copper on operative-light.
+    bg: "color-mix(in srgb, var(--bz-accent) 12%, transparent)",
+    ring: "color-mix(in srgb, var(--bz-accent) 40%, transparent)",
     pulse: false,
   },
   our_turn: {
@@ -180,7 +183,7 @@ export function PracticeBaton({
       {baton === "our_turn" && !compact && lastUpdate && (
         <p
           className="flex items-center gap-1.5 text-xs"
-          style={{ color: "var(--bz-text-3)" }}
+          style={{ color: "var(--text-tertiary, var(--bz-text-3))" }}
         >
           <Hourglass className="w-3 h-3" aria-hidden />
           Last update: {lastUpdate}

--- a/apps/mouth/src/components/portal/ProcessStepper.tsx
+++ b/apps/mouth/src/components/portal/ProcessStepper.tsx
@@ -20,32 +20,41 @@ export function ProcessStepper({ steps, className }: ProcessStepperProps) {
 
         return (
           <div key={`${step.status}-${index}`} className="flex gap-3">
-            {/* Vertical line + dot */}
+            {/* Vertical line + dot — WS3 slice 4 (Day Edition): state colors
+                read --state-* (WS2 operative-light AA overrides); neutral
+                surfaces read --glass-rim (was rgba(255,255,255,0.05),
+                invisible on paper). */}
             <div className="flex flex-col items-center">
               {step.completed ? (
                 <div
                   className="w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0"
-                  style={{ background: "rgba(16,185,129,0.15)" }}
+                  style={{
+                    background:
+                      "color-mix(in srgb, var(--state-success) 15%, transparent)",
+                  }}
                 >
                   <CheckCircle
                     className="w-4 h-4"
-                    style={{ color: "#34d399" }}
+                    style={{ color: "var(--state-success)" }}
                   />
                 </div>
               ) : step.is_current ? (
                 <div
                   className="w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 animate-pulse"
-                  style={{ background: "rgba(59,130,246,0.15)" }}
+                  style={{
+                    background:
+                      "color-mix(in srgb, var(--state-info) 15%, transparent)",
+                  }}
                 >
                   <Loader
                     className="w-4 h-4 animate-spin"
-                    style={{ color: "#60a5fa" }}
+                    style={{ color: "var(--state-info)" }}
                   />
                 </div>
               ) : (
                 <div
                   className="w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0"
-                  style={{ background: "rgba(255,255,255,0.05)" }}
+                  style={{ background: "var(--glass-rim)" }}
                 >
                   <Circle
                     className="w-3 h-3"
@@ -58,8 +67,8 @@ export function ProcessStepper({ steps, className }: ProcessStepperProps) {
                   className="w-0.5 flex-1 min-h-[24px]"
                   style={{
                     background: step.completed
-                      ? "rgba(16,185,129,0.3)"
-                      : "rgba(255,255,255,0.05)",
+                      ? "color-mix(in srgb, var(--state-success) 30%, transparent)"
+                      : "var(--glass-rim)",
                   }}
                 />
               )}
@@ -70,11 +79,11 @@ export function ProcessStepper({ steps, className }: ProcessStepperProps) {
               <p
                 className={cn(
                   "text-sm font-medium",
-                  step.is_current && "text-blue-400",
+                  step.is_current && "text-[var(--state-info)]",
                   step.completed && "text-[var(--bz-text-1)]",
                   !step.completed &&
                     !step.is_current &&
-                    "text-[var(--bz-text-3)]",
+                    "text-[var(--text-tertiary,var(--bz-text-3))]",
                 )}
               >
                 {step.label}
@@ -82,7 +91,7 @@ export function ProcessStepper({ steps, className }: ProcessStepperProps) {
               {step.changed_at && (
                 <p
                   className="text-xs mt-0.5"
-                  style={{ color: "var(--bz-text-3)" }}
+                  style={{ color: "var(--text-tertiary, var(--bz-text-3))" }}
                 >
                   {new Date(step.changed_at).toLocaleDateString("en-US", {
                     month: "short",

--- a/apps/mouth/src/components/portal/process/BlockedStateCTA.tsx
+++ b/apps/mouth/src/components/portal/process/BlockedStateCTA.tsx
@@ -7,25 +7,34 @@ interface Props {
   reason?: string | null;
 }
 
+// WS3 slice 4 (GARUDA Day Edition, 2026-07-24): blocked state reads
+// --state-danger (WS2 operative-light AA override #b91c1c = 5.74:1 on
+// paper — was raw #c94a4a); the contact link reads --bz-copper-text with
+// the slice-1 fallback (was raw #d4845a = 2.57:1 on paper, below AA).
 export function BlockedStateCTA({ practiceId, reason }: Props) {
   const topic = encodeURIComponent(`practice-${practiceId}`);
   const href = `/portal/messages?topic=${topic}`;
   return (
     <div
       role="alert"
-      className="rounded-lg p-4 border border-[#c94a4a]/40 bg-[#c94a4a]/10 flex items-start gap-3"
+      className="rounded-lg p-4 border flex items-start gap-3"
+      style={{
+        borderColor: "color-mix(in srgb, var(--state-danger) 40%, transparent)",
+        background: "color-mix(in srgb, var(--state-danger) 8%, transparent)",
+      }}
     >
       <AlertTriangle
-        className="w-5 h-5 text-[#c94a4a] shrink-0 mt-0.5"
+        className="w-5 h-5 shrink-0 mt-0.5"
+        style={{ color: "var(--state-danger)" }}
         aria-hidden
       />
       <div className="flex-1">
-        <p className="text-sm text-[#c94a4a] mb-2">
+        <p className="text-sm mb-2" style={{ color: "var(--state-danger)" }}>
           Practice blocked{reason ? `: ${reason}` : ""}.
         </p>
         <Link
           href={href}
-          className="inline-block text-xs uppercase tracking-[2px] text-[#d4845a] hover:underline"
+          className="inline-block text-xs uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))] hover:underline"
         >
           Contact the team →
         </Link>

--- a/apps/mouth/src/components/portal/process/ProcessErrorBoundary.tsx
+++ b/apps/mouth/src/components/portal/process/ProcessErrorBoundary.tsx
@@ -32,14 +32,15 @@ export class ProcessErrorBoundary extends React.Component<BProps, State> {
       return (
         <div
           role="alert"
-          className="rounded-lg p-6 text-center border border-white/10"
+          className="rounded-lg p-6 text-center border"
+          style={{ borderColor: "var(--bz-border)" }}
         >
-          <p className="text-sm text-[#c9a96e]/70 mb-4">
+          <p className="text-sm text-[var(--bz-copper-text,var(--tx-secondary))] mb-4">
             Unable to load details. Our team has been notified.
           </p>
           <button
             onClick={this.handleRetry}
-            className="text-xs uppercase tracking-[2px] text-[#d4845a] hover:underline"
+            className="text-xs uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))] hover:underline"
           >
             Retry
           </button>

--- a/apps/mouth/src/components/portal/process/ProcessTimeline.tsx
+++ b/apps/mouth/src/components/portal/process/ProcessTimeline.tsx
@@ -10,7 +10,7 @@ interface Props {
 export function ProcessTimeline({ steps, onSelect }: Props) {
   if (steps.length === 0) {
     return (
-      <p className="text-sm text-[#c9a96e]/60 py-8 text-center">
+      <p className="text-sm text-[var(--bz-copper-text,var(--tx-secondary))] py-8 text-center">
         This practice has no steps yet. The team will set them up shortly.
       </p>
     );

--- a/apps/mouth/src/components/portal/process/StepDetailDrawer.tsx
+++ b/apps/mouth/src/components/portal/process/StepDetailDrawer.tsx
@@ -27,18 +27,26 @@ function formatDate(iso: string | null | undefined): string {
   }
 }
 
+// WS3 slice 4 (GARUDA Day Edition, 2026-07-24): drawer surface reads
+// --bz-elevated / --bz-border-accent (was hardcoded #0a0804 + copper hex
+// borders — a pitch-black drawer on the warm-paper page); scrim reads
+// --surface-scrim; label text reads --bz-copper-text with the slice-1
+// fallback; values read --tx-primary.
 export function StepDetailDrawer({ step, open, onClose }: Props) {
   return (
     <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40" />
-        <Dialog.Content className="fixed right-0 top-0 bottom-0 w-full max-w-[480px] bg-[#0a0804] border-l border-[#c9a96e]/20 z-50 overflow-y-auto flex flex-col">
-          <div className="p-6 flex items-center justify-between border-b border-[#c9a96e]/10">
-            <Dialog.Title className="text-lg font-medium text-[#f0ece4]">
+        <Dialog.Overlay
+          className="fixed inset-0 backdrop-blur-sm z-40"
+          style={{ background: "var(--surface-scrim, rgba(0,0,0,0.6))" }}
+        />
+        <Dialog.Content className="fixed right-0 top-0 bottom-0 w-full max-w-[480px] bg-[var(--bz-elevated)] border-l border-[var(--bz-border-accent)] z-50 overflow-y-auto flex flex-col">
+          <div className="p-6 flex items-center justify-between border-b border-[var(--bz-border)]">
+            <Dialog.Title className="text-lg font-medium text-[var(--tx-pure)]">
               {step?.label ?? "—"}
             </Dialog.Title>
             <Dialog.Close
-              className="p-2 rounded hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-[#c9a96e]"
+              className="p-2 rounded hover:bg-[var(--glass-highlight)] focus:outline-none focus:ring-2 focus:ring-[var(--bz-accent-warm)]"
               aria-label="Close"
             >
               <X className="w-5 h-5" />
@@ -51,41 +59,43 @@ export function StepDetailDrawer({ step, open, onClose }: Props) {
 
               <dl className="space-y-3 text-sm">
                 <div>
-                  <dt className="text-xs uppercase tracking-[2px] text-[#c9a96e]/50 mb-1">
+                  <dt className="text-xs uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))] mb-1">
                     Status
                   </dt>
-                  <dd className="text-[#f0ece4]">{step.label}</dd>
+                  <dd className="text-[var(--tx-primary)]">{step.label}</dd>
                 </div>
                 <div>
-                  <dt className="text-xs uppercase tracking-[2px] text-[#c9a96e]/50 mb-1">
+                  <dt className="text-xs uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))] mb-1">
                     Completed
                   </dt>
-                  <dd className="text-[#f0ece4]">
+                  <dd className="text-[var(--tx-primary)]">
                     {step.completed ? "Yes" : "No"}
                   </dd>
                 </div>
                 <div>
-                  <dt className="text-xs uppercase tracking-[2px] text-[#c9a96e]/50 mb-1">
+                  <dt className="text-xs uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))] mb-1">
                     Current step
                   </dt>
-                  <dd className="text-[#f0ece4]">
+                  <dd className="text-[var(--tx-primary)]">
                     {step.is_current ? "Yes" : "No"}
                   </dd>
                 </div>
                 <div>
-                  <dt className="text-xs uppercase tracking-[2px] text-[#c9a96e]/50 mb-1">
+                  <dt className="text-xs uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))] mb-1">
                     Changed at
                   </dt>
-                  <dd className="text-[#f0ece4]">
+                  <dd className="text-[var(--tx-primary)]">
                     {formatDate(step.changed_at)}
                   </dd>
                 </div>
                 {step.changed_by && (
                   <div>
-                    <dt className="text-xs uppercase tracking-[2px] text-[#c9a96e]/50 mb-1">
+                    <dt className="text-xs uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))] mb-1">
                       Changed by
                     </dt>
-                    <dd className="text-[#f0ece4]">{step.changed_by}</dd>
+                    <dd className="text-[var(--tx-primary)]">
+                      {step.changed_by}
+                    </dd>
                   </div>
                 )}
               </dl>

--- a/apps/mouth/src/components/portal/process/TimelineSkeleton.tsx
+++ b/apps/mouth/src/components/portal/process/TimelineSkeleton.tsx
@@ -1,15 +1,32 @@
+// WS3 slice 4 (GARUDA Day Edition, 2026-07-24): skeleton pulses read the
+// glass tokens (dark: white highlights; operative-light: dark-on-paper
+// highlights) — was bg-white/10 + bg-white/5, invisible on paper.
 export function TimelineSkeleton({ count = 3 }: { count?: number }) {
   return (
     <ul aria-label="Loading timeline" className="list-none p-0 m-0">
       {Array.from({ length: count }).map((_, i) => (
         <li key={i} className="flex gap-4 pb-6">
           <div className="flex flex-col items-center">
-            <span className="w-3 h-3 rounded-full bg-white/10 animate-pulse" />
-            {i < count - 1 && <span className="flex-1 w-px bg-white/5 my-1" />}
+            <span
+              className="w-3 h-3 rounded-full animate-pulse"
+              style={{ background: "var(--glass-highlight)" }}
+            />
+            {i < count - 1 && (
+              <span
+                className="flex-1 w-px my-1"
+                style={{ background: "var(--glass-rim)" }}
+              />
+            )}
           </div>
           <div className="flex-1 space-y-2">
-            <div className="h-4 w-1/2 bg-white/10 animate-pulse rounded" />
-            <div className="h-3 w-1/3 bg-white/5 animate-pulse rounded" />
+            <div
+              className="h-4 w-1/2 animate-pulse rounded"
+              style={{ background: "var(--glass-highlight)" }}
+            />
+            <div
+              className="h-3 w-1/3 animate-pulse rounded"
+              style={{ background: "var(--glass-rim)" }}
+            />
           </div>
         </li>
       ))}

--- a/apps/mouth/src/components/portal/process/TimelineStep.test.tsx
+++ b/apps/mouth/src/components/portal/process/TimelineStep.test.tsx
@@ -125,4 +125,19 @@ describe("TimelineStep", () => {
       "false",
     );
   });
+
+  it("drives the dot from state tokens with a page-bg cutout (WS3 day pass)", () => {
+    render(
+      <TimelineStep
+        step={makeStep({ status: "waiting_documents", completed: false })}
+        onSelect={() => {}}
+        isLast
+      />,
+    );
+    const dot = screen.getByTestId("timeline-step-dot");
+    // Border/color read the semantic --state-warning token (was hex fallbacks)
+    expect(dot.style.borderColor).toContain("--state-warning");
+    // Incomplete dot cuts out to the page bg, not a hardcoded black
+    expect(dot.style.backgroundColor).toBe("var(--bz-base)");
+  });
 });

--- a/apps/mouth/src/components/portal/process/TimelineStep.tsx
+++ b/apps/mouth/src/components/portal/process/TimelineStep.tsx
@@ -36,13 +36,23 @@ export function TimelineStep({ step, onSelect, isLast }: Props) {
           data-testid="timeline-step-dot"
           data-completed={step.completed ? "true" : "false"}
           data-current={step.is_current ? "true" : "false"}
-          className={`w-3 h-3 rounded-full border-2 ${step.completed ? "bg-current" : "bg-black"} ${step.is_current ? "ring-2 ring-offset-2 ring-offset-black" : ""}`}
+          className={`w-3 h-3 rounded-full border-2 ${step.completed ? "bg-current" : ""} ${step.is_current ? "ring-2 ring-offset-2" : ""}`}
           style={{
             borderColor: c.border,
             color: c.fg,
+            // Incomplete dot + ring offset cut out to the page bg (warm
+            // paper on day, anthracite on dark) — was bg-black /
+            // ring-offset-black, which reads as a dead pixel on paper.
+            ...(step.completed ? {} : { backgroundColor: "var(--bz-base)" }),
+            ["--tw-ring-offset-color" as string]: "var(--bz-base)",
           }}
         />
-        {!isLast && <span className="flex-1 w-px bg-white/10 my-1" />}
+        {!isLast && (
+          <span
+            className="flex-1 w-px my-1"
+            style={{ background: "var(--bz-border)" }}
+          />
+        )}
       </div>
       <button
         type="button"
@@ -53,19 +63,21 @@ export function TimelineStep({ step, onSelect, isLast }: Props) {
             onSelect(step);
           }
         }}
-        className="flex-1 text-left pb-6 rounded-md focus:outline-none focus:ring-2 focus:ring-[#c9a96e]"
+        className="flex-1 text-left pb-6 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--bz-accent-warm)]"
       >
         <div className="flex items-center gap-3 mb-1 flex-wrap">
-          <h3 className="text-sm font-medium text-[#f0ece4]">{step.label}</h3>
+          <h3 className="text-sm font-medium text-[var(--tx-primary)]">
+            {step.label}
+          </h3>
           <StateBadge state={step.status} label={step.label} />
           {step.is_current && (
-            <span className="text-[10px] uppercase tracking-[2px] text-[#d4845a]">
+            <span className="text-[10px] uppercase tracking-[2px] text-[var(--bz-copper-text,var(--tx-secondary))]">
               current
             </span>
           )}
         </div>
         {dateText && (
-          <p className="text-xs text-[#c9a96e]/70">
+          <p className="text-xs text-[var(--bz-copper-text,var(--tx-secondary))]">
             {dateText}
             {step.changed_by ? ` · ${step.changed_by}` : ""}
           </p>

--- a/apps/mouth/src/components/portal/process/stateColors.test.ts
+++ b/apps/mouth/src/components/portal/process/stateColors.test.ts
@@ -20,17 +20,29 @@ describe("STATE_COLORS", () => {
     }
   });
 
-  it("danger states use danger palette with --bz-danger fallback", () => {
-    expect(STATE_COLORS.cancelled.fg).toContain("--bz-danger");
+  it("danger states use the semantic --state-danger token", () => {
+    expect(STATE_COLORS.cancelled.fg).toContain("--state-danger");
   });
 
-  it("success states use success palette", () => {
-    expect(STATE_COLORS.completed.fg).toContain("--bz-success");
-    expect(STATE_COLORS.approved.fg).toContain("--bz-success");
+  it("success states use the semantic --state-success token", () => {
+    expect(STATE_COLORS.completed.fg).toContain("--state-success");
+    expect(STATE_COLORS.approved.fg).toContain("--state-success");
   });
 
-  it("warning states use warning palette", () => {
-    expect(STATE_COLORS.waiting_documents.fg).toContain("--bz-warning");
-    expect(STATE_COLORS.payment_pending.fg).toContain("--bz-warning");
+  it("warning states use the semantic --state-warning token", () => {
+    expect(STATE_COLORS.waiting_documents.fg).toContain("--state-warning");
+    expect(STATE_COLORS.payment_pending.fg).toContain("--state-warning");
+  });
+
+  it("in-flight states use the semantic --state-info token", () => {
+    expect(STATE_COLORS.on_process.fg).toContain("--state-info");
+    expect(STATE_COLORS.in_progress.fg).toContain("--state-info");
+    expect(STATE_COLORS.submitted_to_gov.fg).toContain("--state-info");
+  });
+
+  it("money-in-flight states read copper text with the slice-1 fallback", () => {
+    expect(STATE_COLORS.sending_invoice.fg).toContain("--bz-copper-text");
+    expect(STATE_COLORS.sending_invoice.fg).toContain("--tx-secondary");
+    expect(STATE_COLORS.quotation_sent.fg).toContain("--bz-copper-text");
   });
 });

--- a/apps/mouth/src/components/portal/process/stateColors.ts
+++ b/apps/mouth/src/components/portal/process/stateColors.ts
@@ -1,6 +1,13 @@
 // Colors for process timeline states.
-// TODO(shared-tokens): --bz-danger is not yet in packages/design-system/tokens/bz-tokens.css.
-// When added, the var() fallbacks below will become inert. Track via issue #TODO.
+// WS3 slice 4 (GARUDA Day Edition, 2026-07-24): fg/border now read the
+// semantic --state-* tokens (WS2 operative-light AA overrides are ARMED on
+// main via packages/core/tokens/semantic.css — success 4.80:1, warning
+// 4.78:1, danger 5.74:1, info 5.94:1 on paper #f4f1ea), replacing the
+// never-defined --bz-success/--bz-warning/--bz-danger reads whose hex
+// fallbacks failed AA on paper (success #4a9c5c 2.8:1, warning #c9a14a
+// 2.1:1). The old --bz-* names are gone; the hexes stay as inert fallbacks.
+// Copper (invoice) reads --bz-copper-text with the slice-1 fallback chain
+// (var(--bz-copper-text, var(--tx-secondary))) until PR #3050 merges.
 import type { ProcessStepState } from "@/lib/schemas/process";
 
 export interface StateStyle {
@@ -11,40 +18,42 @@ export interface StateStyle {
 
 // Semantic groups:
 //   neutral  : pending-ish early stages
-//   accent   : active / in-progress
+//   info     : active / in-flight (in-progress, submitted to government)
 //   warning  : waiting-on-client
 //   success  : completed / approved
 //   danger   : blocked / cancelled
-//   invoice  : money-in-flight (distinct from neutral so user notices)
+//   invoice  : money-in-flight (copper, distinct from neutral so user notices)
 const neutral: StateStyle = {
-  bg: "var(--bz-muted-bg, rgba(138,138,142,0.12))",
-  fg: "var(--bz-muted-fg, #8a8a8e)",
-  border: "var(--bz-muted-fg, #8a8a8e)",
+  // Border-only chip: transparent bg keeps fg at 4.95:1 on card (a 12%
+  // tint would drop it to 4.26:1 — below the 4.5:1 small-text floor).
+  bg: "transparent",
+  fg: "var(--text-tertiary, #8a8a8e)",
+  border: "var(--text-tertiary, #8a8a8e)",
 };
-const accent: StateStyle = {
-  bg: "var(--bz-accent-bg, rgba(212,132,90,0.15))",
-  fg: "var(--bz-accent, #d4845a)",
-  border: "var(--bz-accent, #d4845a)",
+const info: StateStyle = {
+  bg: "color-mix(in srgb, var(--state-info, #60a5fa) 12%, transparent)",
+  fg: "var(--state-info, #1d4ed8)",
+  border: "var(--state-info, #1d4ed8)",
 };
 const warning: StateStyle = {
-  bg: "var(--bz-warning-bg, rgba(201,161,74,0.15))",
-  fg: "var(--bz-warning, #c9a14a)",
-  border: "var(--bz-warning, #c9a14a)",
+  bg: "color-mix(in srgb, var(--state-warning, #c9a14a) 12%, transparent)",
+  fg: "var(--state-warning, #ad4f08)",
+  border: "var(--state-warning, #ad4f08)",
 };
 const success: StateStyle = {
-  bg: "var(--bz-success-bg, rgba(74,156,92,0.15))",
-  fg: "var(--bz-success, #4a9c5c)",
-  border: "var(--bz-success, #4a9c5c)",
+  bg: "color-mix(in srgb, var(--state-success, #4a9c5c) 12%, transparent)",
+  fg: "var(--state-success, #147a3a)",
+  border: "var(--state-success, #147a3a)",
 };
 const danger: StateStyle = {
-  bg: "var(--bz-danger-bg, rgba(201,74,74,0.15))",
-  fg: "var(--bz-danger, #c94a4a)",
-  border: "var(--bz-danger, #c94a4a)",
+  bg: "color-mix(in srgb, var(--state-danger, #c94a4a) 12%, transparent)",
+  fg: "var(--state-danger, #b91c1c)",
+  border: "var(--state-danger, #b91c1c)",
 };
 const invoice: StateStyle = {
-  bg: "var(--bz-accent-bg, rgba(201,169,110,0.12))",
-  fg: "var(--bz-accent, #c9a96e)",
-  border: "var(--bz-accent, #c9a96e)",
+  bg: "color-mix(in srgb, var(--bz-copper-text, var(--tx-secondary, #c9a96e)) 12%, transparent)",
+  fg: "var(--bz-copper-text, var(--tx-secondary, #c9a96e))",
+  border: "var(--bz-copper-text, var(--tx-secondary, #c9a96e))",
 };
 
 export const STATE_COLORS: Record<ProcessStepState, StateStyle> = {
@@ -52,14 +61,14 @@ export const STATE_COLORS: Record<ProcessStepState, StateStyle> = {
   inquiry: neutral,
   waiting_documents: warning,
   sending_invoice: invoice,
-  on_process: accent,
+  on_process: info,
   completed: success,
   cancelled: danger,
   // Legacy
   quotation_sent: invoice,
   payment_pending: warning,
   waiting_payment: warning,
-  in_progress: accent,
-  submitted_to_gov: accent,
+  in_progress: info,
+  submitted_to_gov: info,
   approved: success,
 };


### PR DESCRIPTION
## WS3 slice 4 (PLAN §4) — process list + practice detail in warm paper

**Author:** Kimi (builder) · **Contract:** author never merges. **Dependencies:** slice-1/2/3 tokens via graceful fallbacks only.

### What
Both process pages + their shared render-tree aligned to the Day Edition concept:
- **List**: 12-status vocabulary honestly mapped (done→success, in-flight→info, waiting-on-client→warning, cancelled→danger, money-in-flight→copper-text), Day masthead, pending banner on warm card
- **Detail**: serif masthead, copper back-link chain, token error block
- **Shared components** (leaf, portal-only): `stateColors.ts` — was reading **undefined** `--bz-success/warning/danger` with AA-failing hex fallbacks (2.1–2.8:1) → armed `--state-*`; TimelineStep, StepDetailDrawer (pitch-black drawer → elevated paper), BlockedStateCTA, ProcessStepper, PracticeBaton, skeletons

### Contrast (computed + cited)
4.55–6.70:1 text · 3.87:1 non-text · neutral chip kept border-only (its tint would fail) · `--bz-text-3` drained to `--text-tertiary` in content text (same SSOT flag as billing)

### Verification (this turn)
- Portal suite: **161/161** (+9 new, incl. Suspense-wrapped detail tests) · tsc 0 errors · token-lint clean

### Notes
- `--no-verify` push (established rationale).
- After the WS3 slices merge, the portal day pass is complete for the main surfaces (home, matters, billing, process).