### PR TITLE
feat(visa-engine): migration 257 request_category extension + reported-only collector semantics (W1b PR-1, Fable delta 3)

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/257_visa_request_category_extension.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/257_visa_request_category_extension.sql
@@ -55,9 +55,47 @@ ALTER TABLE public.visa_decisions
 -- request_category column to exist (migration 255 applied) -- the fixture
 -- chain guarantees ordering (257's rollback always runs BEFORE 255's, which
 -- is what drops the column).
+--
+-- RELABEL-FIRST (Gemini adversarial pass, 2026-07-24, adjudicated HIGH):
+-- re-adding the 8-value CHECK re-VALIDATES every surviving row, so any
+-- 'business'/'diaspora' row written while 257 was live would make a bare
+-- rollback FAIL with a CheckViolation.  The guarded UPDATE below relabels
+-- those rows to 'other' BEFORE the constraint is restored -- a lossy but
+-- honest downgrade (the category information is genuinely being retracted
+-- by the rollback; silently failing the rollback instead would trap the
+-- database in a state no forward migration expects).  Guarded on the
+-- column's existence via information_schema so the defensive no-op path
+-- (fresh database, or 255 not yet applied) stays a no-op.
+--
+-- The relabel requires suspending migration 252's
+-- ``visa_decisions_immutable`` trigger (blanket append-only on
+-- UPDATE/DELETE) for the duration of this script: the append-only guard
+-- exists against APPLICATION mutation of the audit log, while this
+-- relabel is exactly the DDL-level operator action a rollback IS.
+-- DISABLE and ENABLE happen inside the same script, so the runner's
+-- per-migration transaction re-arms the trigger on success and rolls the
+-- DISABLE back on any failure -- the guard can never be left off.
+
+ALTER TABLE IF EXISTS public.visa_decisions
+    DISABLE TRIGGER visa_decisions_immutable;
 
 ALTER TABLE IF EXISTS public.visa_decisions
     DROP CONSTRAINT IF EXISTS visa_decisions_request_category_check;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'visa_decisions'
+          AND column_name = 'request_category'
+    ) THEN
+        UPDATE public.visa_decisions
+            SET request_category = 'other'
+            WHERE request_category IN ('business', 'diaspora');
+    END IF;
+END $$;
 
 ALTER TABLE IF EXISTS public.visa_decisions
     ADD CONSTRAINT visa_decisions_request_category_check
@@ -74,3 +112,6 @@ ALTER TABLE IF EXISTS public.visa_decisions
                 'other'
             )
         );
+
+ALTER TABLE IF EXISTS public.visa_decisions
+    ENABLE TRIGGER visa_decisions_immutable;

--- a/apps/backend-rag/backend/db/migrations_v2/257_visa_request_category_extension.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/257_visa_request_category_extension.sql
@@ -1,0 +1,76 @@
+-- Migration 257: Visa Oracle request_category extension (business + diaspora)
+--
+-- The v2 interview has 10 purpose tiles; migration 255's request_category
+-- CHECK admits only the 8 legacy values (the visa_check.match_tree.Purpose
+-- vocabulary).  W1 Fable delta 3 (binding, 2026-07-23, adjudicated in
+-- research/visa/2026-07-23-w1-evidence-machinery-brief.md Item 3) rules:
+-- extend the enum to 10 -- add 'business' and 'diaspora', keep 'other'.
+-- The rejected alternative (map both tiles to 'other') would silently
+-- miscount real end-user demand in the G-a evidence report.
+--
+-- Semantics on the collector side (shadow_evidence.py, same PR): the 7
+-- legacy substantive categories stay REQUIRED for the G-a gates;
+-- 'business'/'diaspora' rows are REPORTED (counted, honestly labeled) but
+-- NOT required, because their behavioral trees do not exist yet -- they are
+-- Track B FASE 2 lanes 2 and 6, so no honest evaluation can be demanded of
+-- them for gate-green today.
+--
+-- Mechanics: the 8-value CHECK created inline by migration 255
+-- (auto-named visa_decisions_request_category_check by Postgres) is dropped
+-- and re-added with the 10-value list.  Same roll-forward pattern as 255/
+-- 256: no backfill, no data rewrite -- existing rows keep their already-
+-- valid categories (the new value list is a strict superset, so re-
+-- validation at ADD CONSTRAINT time cannot fail on pre-257 data).
+--
+-- This migration does not change VISA_ENGINE_MATCH_MODE /
+-- VISA_ENGINE_EVALUATE_MODE and cannot arm ENFORCE.
+
+ALTER TABLE public.visa_decisions
+    DROP CONSTRAINT visa_decisions_request_category_check;
+
+ALTER TABLE public.visa_decisions
+    ADD CONSTRAINT visa_decisions_request_category_check
+        CHECK (
+            request_category IS NULL
+            OR request_category IN (
+                'work_remote',
+                'investor',
+                'work_employee',
+                'family',
+                'long_tourism',
+                'retirement',
+                'student',
+                'other',
+                'business',
+                'diaspora'
+            )
+        );
+
+-- === ROLLBACK ===
+-- Restore migration 255's exact 8-value CHECK.  IF EXISTS throughout so a
+-- defensive rollback before this migration ever ran (the test-fixture
+-- convention) is a semantic no-op: it drops whatever request_category CHECK
+-- is present (10-value if 257 was applied, 8-value if not) and re-adds the
+-- 8-value one, provided the table exists at all.  Requires the
+-- request_category column to exist (migration 255 applied) -- the fixture
+-- chain guarantees ordering (257's rollback always runs BEFORE 255's, which
+-- is what drops the column).
+
+ALTER TABLE IF EXISTS public.visa_decisions
+    DROP CONSTRAINT IF EXISTS visa_decisions_request_category_check;
+
+ALTER TABLE IF EXISTS public.visa_decisions
+    ADD CONSTRAINT visa_decisions_request_category_check
+        CHECK (
+            request_category IS NULL
+            OR request_category IN (
+                'work_remote',
+                'investor',
+                'work_employee',
+                'family',
+                'long_tourism',
+                'retirement',
+                'student',
+                'other'
+            )
+        );

--- a/apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
+++ b/apps/backend-rag/backend/services/visa_engine/shadow_evidence.py
@@ -18,6 +18,16 @@ the same fail-closed philosophy as migration 255's nullable correlators.
 G-c is intentionally NOT split: grounding quality is a property of the
 engine's output and applies to every audited row regardless of provenance.
 
+W1 Fable delta 3 (binding, 2026-07-23; migration 257): ``request_category``
+now admits 10 values -- the 7 legacy substantive categories, ``other``, and
+the two v2-interview tiles ``business``/``diaspora``.  The 7 legacy
+categories stay REQUIRED for the G-a gates; ``business``/``diaspora`` rows
+are REPORTED (counted in ``category_counts``, honestly labeled via
+``reported_only_categories``) but NEVER required for gate-green, because
+their behavioral trees do not exist yet (Track B FASE 2 order: they are
+lanes 2 and 6) -- demanding them today would require evidence no honest
+evaluation can produce.
+
 No applicant facts, Match tokens, decision IDs, or request fingerprints are
 returned.  The collector reads the PII-free audit projection and emits only
 counts, dates, categories, and product codes.
@@ -56,7 +66,17 @@ REAL_TRAFFIC_SOURCE = "real"
 #: honestly-labeled G-a-breadth gate, never G-a-vol.
 SYNTHETIC_TRAFFIC_SOURCES = frozenset({"synthetic_gold", "synthetic_driver"})
 
-_VALID_CATEGORIES = frozenset(purpose.value for purpose in Purpose)
+#: ``request_category`` values (migration 257 CHECK) that are REPORTED but
+#: NOT required for G-a gate-green: the v2 interview's ``business`` and
+#: ``diaspora`` tiles.  Their behavioral trees do not exist yet (Track B
+#: FASE 2 lanes 2 and 6), so a green gate can never honestly demand traffic
+#: in them -- but rows carrying them are real demand and must be counted and
+#: labeled, not silently folded into ``other`` (Fable delta 3).
+REPORTED_ONLY_INTERVIEW_CATEGORIES = frozenset({"business", "diaspora"})
+
+_VALID_CATEGORIES = (
+    frozenset(purpose.value for purpose in Purpose) | REPORTED_ONLY_INTERVIEW_CATEGORIES
+)
 _CITATIONLESS_ABSTENTION_STATES = frozenset({DecisionState.NEEDS_INPUT.value})
 
 
@@ -174,6 +194,7 @@ def _gate_a_report(
         category_counts=dict(sorted(accumulator.categories.items())),
         missing_required_categories=missing_categories,
         required_categories=sorted(REQUIRED_INTERVIEW_CATEGORIES),
+        reported_only_categories=sorted(REPORTED_ONLY_INTERVIEW_CATEGORIES),
         distinct_visa_codes=len(accumulator.candidate_codes),
         minimum_distinct_visa_codes=MIN_DISTINCT_VISA_CODES,
         visa_codes=sorted(accumulator.candidate_codes),
@@ -438,7 +459,7 @@ def evaluate_shadow_evidence(
     )
 
     return {
-        "schema_version": "visa-shadow-evidence/1.1.0",
+        "schema_version": "visa-shadow-evidence/1.2.0",
         "window": {
             "start": window_start.astimezone(timezone.utc).isoformat(),
             "end_exclusive": window_end.astimezone(timezone.utc).isoformat(),
@@ -567,6 +588,7 @@ __all__ = [
     "MIN_DISTINCT_REQUESTS",
     "MIN_DISTINCT_VISA_CODES",
     "REAL_TRAFFIC_SOURCE",
+    "REPORTED_ONLY_INTERVIEW_CATEGORIES",
     "REQUIRED_INTERVIEW_CATEGORIES",
     "SYNTHETIC_TRAFFIC_SOURCES",
     "collect_shadow_evidence",

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
@@ -888,10 +888,14 @@ def test_migration_257_carries_rollback_marker_and_correct_value_sets() -> None:
         "diaspora",
     ):
         assert f"'{value}'" in forward
-    # Rollback restores migration 255's exact 8-value CHECK: the two new
-    # values must NOT survive it.
-    assert "'business'" not in rollback
-    assert "'diaspora'" not in rollback
+    # The restored CHECK is migration 255's exact 8-value one: the two new
+    # values must not appear in it.  (They DO appear earlier in the rollback
+    # — the relabel-first UPDATE that downgrades live new-category rows to
+    # 'other' before the CHECK is restored, which is what makes the rollback
+    # succeed at all — so assert on the ADD CONSTRAINT tail only.)
+    restored_check = rollback.rsplit("ADD CONSTRAINT", 1)[-1]
+    assert "'business'" not in restored_check
+    assert "'diaspora'" not in restored_check
     for value in (
         "work_remote",
         "investor",
@@ -902,7 +906,7 @@ def test_migration_257_carries_rollback_marker_and_correct_value_sets() -> None:
         "student",
         "other",
     ):
-        assert f"'{value}'" in rollback
+        assert f"'{value}'" in restored_check
 
 
 @pytest.mark.integration
@@ -974,3 +978,56 @@ async def test_collect_reports_business_diaspora_as_valid_not_required(
     assert "business" not in gate["missing_required_categories"]
     assert "diaspora" not in gate["missing_required_categories"]
     assert gate["reported_only_categories"] == ["business", "diaspora"]
+
+
+@pytest.mark.integration
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_migration_257_rollback_relabels_new_categories_and_restores_check(
+    db_pool: asyncpg.Pool, shadow_evidence_schema: None
+) -> None:
+    """The rollback must SUCCEED even with 'business'/'diaspora' rows live
+    (the re-added 8-value CHECK re-validates every row): it relabels those
+    rows to 'other' BEFORE restoring the constraint — a lossy but honest
+    downgrade — and never touches legacy-category rows."""
+    _, rollback_257 = _read_migration(_MIGRATION_257_PATH, 257)
+    start = datetime(2026, 7, 23, tzinfo=timezone.utc)
+    async with db_pool.acquire() as conn:
+        for seed, category in (
+            ("biz", "business"),
+            ("diaspora", "diaspora"),
+            ("legacy", "student"),
+        ):
+            await _insert_unavailable_audit_row(
+                conn,
+                environment="TEST",
+                evaluated_at=start,
+                fingerprint_seed=seed,
+                request_category=category,
+            )
+
+        # The rollback itself must not fail on the live new-category rows...
+        await conn.execute(rollback_257)
+
+        # ...both new-category rows are relabeled to 'other'; the legacy one
+        # is untouched.
+        rows = await conn.fetch(
+            "SELECT request_category, count(*) AS n FROM public.visa_decisions GROUP BY 1"
+        )
+        counts = {row["request_category"]: row["n"] for row in rows}
+        assert counts == {"other": 2, "student": 1}
+
+        # ...and the restored CHECK is the 8-value one again.
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await _insert_unavailable_audit_row(
+                conn,
+                environment="TEST",
+                evaluated_at=start,
+                fingerprint_seed="post-rollback-biz",
+                request_category="business",
+            )
+
+        # ...and migration 252's append-only guard is re-armed: the relabel
+        # was a one-shot DDL suspension, never a lasting weakening.
+        with pytest.raises(asyncpg.exceptions.RaiseError):
+            await conn.execute("UPDATE public.visa_decisions SET engine_version = 'tamper'")

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
@@ -19,6 +19,7 @@ from backend.services.visa_engine.enums import SourceStatus
 from backend.services.visa_engine.models import RulePack, SourceRecord
 from backend.services.visa_engine.shadow_evidence import (
     REAL_TRAFFIC_SOURCE,
+    REPORTED_ONLY_INTERVIEW_CATEGORIES,
     REQUIRED_INTERVIEW_CATEGORIES,
     SYNTHETIC_TRAFFIC_SOURCES,
     collect_shadow_evidence,
@@ -30,6 +31,9 @@ _BACKEND_DIR = Path(__file__).resolve().parents[3]
 _MIGRATION_252_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "252_visa_engine_write_substrate.sql"
 _MIGRATION_255_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "255_visa_shadow_evidence.sql"
 _MIGRATION_256_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "256_visa_traffic_source.sql"
+_MIGRATION_257_PATH = (
+    _BACKEND_DIR / "db" / "migrations_v2" / "257_visa_request_category_extension.sql"
+)
 
 
 def _green_fixture() -> tuple[list[dict[str, object]], RulePack, uuid.UUID]:
@@ -128,21 +132,36 @@ def _read_migration(path: Path, number: int) -> tuple[str, str]:
 
 @pytest_asyncio.fixture
 async def shadow_evidence_schema(db_pool: asyncpg.Pool, visa_schema: None) -> AsyncIterator[None]:
+    """Layers migrations 252+255+256+257 on conftest.py's visa_schema.
+
+    Ordering note (deliberate, NOT strict reverse-dependency): 257's rollback
+    re-ADDs an 8-value CHECK constraint, which re-VALIDATES every surviving
+    ``visa_decisions`` row — so it must run only AFTER 252's rollback has
+    dropped the table (making it an ``IF EXISTS`` no-op), never while
+    257-era rows ('business'/'diaspora') can still be present. Running it
+    last also makes setup crash-robust: a previous run that died mid-test
+    can leave new-category rows behind, and the 256/255 column drops +
+    252's table drop clear them before 257's rollback is ever attempted.
+    """
     forward_252, rollback_252 = _read_migration(_MIGRATION_252_PATH, 252)
     forward_255, rollback_255 = _read_migration(_MIGRATION_255_PATH, 255)
     forward_256, rollback_256 = _read_migration(_MIGRATION_256_PATH, 256)
+    forward_257, rollback_257 = _read_migration(_MIGRATION_257_PATH, 257)
     async with db_pool.acquire() as conn:
         await conn.execute(rollback_256)
         await conn.execute(rollback_255)
         await conn.execute(rollback_252)
+        await conn.execute(rollback_257)
         await conn.execute(forward_252)
         await conn.execute(forward_255)
         await conn.execute(forward_256)
+        await conn.execute(forward_257)
     yield
     async with db_pool.acquire() as conn:
         await conn.execute(rollback_256)
         await conn.execute(rollback_255)
         await conn.execute(rollback_252)
+        await conn.execute(rollback_257)
 
 
 async def _insert_unavailable_audit_row(
@@ -152,6 +171,7 @@ async def _insert_unavailable_audit_row(
     evaluated_at: datetime,
     fingerprint_seed: str,
     traffic_source: str | None = None,
+    request_category: str = "other",
 ) -> None:
     await conn.execute(
         """
@@ -173,7 +193,7 @@ async def _insert_unavailable_audit_row(
             traffic_source
         ) VALUES (
             $1, $2, 'MATCH', 'SHADOW', 'TEMPORARILY_UNAVAILABLE',
-            '[]'::jsonb, 'visa-engine/test', $3, $3, $3, $4, 'other',
+            '[]'::jsonb, 'visa-engine/test', $3, $3, $3, $4, $6,
             '[]'::jsonb, '[]'::jsonb, $5
         )
         """,
@@ -182,6 +202,7 @@ async def _insert_unavailable_audit_row(
         evaluated_at,
         hashlib.sha256(fingerprint_seed.encode("utf-8")).digest(),
         traffic_source,
+        request_category,
     )
 
 
@@ -785,3 +806,171 @@ def test_migration_256_keeps_migrations_v2_prefixes_unique() -> None:
     _assert_unique_migration_numbers(sql_files)
     prefixes = [path.name.split("_", 1)[0] for path in sql_files]
     assert prefixes.count("256") == 1
+
+
+# ---------------------------------------------------------------------------
+# W1 Fable delta 3 (2026-07-23) — migration 257 request_category extension:
+# 'business'/'diaspora' are VALID (counted, honestly labeled) but NOT
+# required for G-a gate-green (their behavioral trees are Track B FASE 2).
+# Guilt AND innocence for both directions of the rule.
+# ---------------------------------------------------------------------------
+
+
+def test_required_interview_categories_still_the_seven_legacy() -> None:
+    assert REQUIRED_INTERVIEW_CATEGORIES == frozenset(
+        {
+            "work_remote",
+            "investor",
+            "work_employee",
+            "family",
+            "long_tourism",
+            "retirement",
+            "student",
+        }
+    )
+    assert REPORTED_ONLY_INTERVIEW_CATEGORIES == frozenset({"business", "diaspora"})
+    assert REQUIRED_INTERVIEW_CATEGORIES.isdisjoint(REPORTED_ONLY_INTERVIEW_CATEGORIES)
+    # Migration 257's CHECK admits exactly these ten values — no more.
+    assert len(REQUIRED_INTERVIEW_CATEGORIES | REPORTED_ONLY_INTERVIEW_CATEGORIES | {"other"}) == 10
+
+
+def test_business_and_diaspora_are_reported_not_required() -> None:
+    rows, pack, db_pack_id = _green_fixture()
+    categories = sorted(REQUIRED_INTERVIEW_CATEGORIES) + ["business", "diaspora"]
+    for index, row in enumerate(rows):
+        row["request_category"] = categories[index % len(categories)]
+
+    report = _evaluate(rows, pack, db_pack_id)
+    gate = report["gates"]["G-a-vol"]
+
+    # Innocence: business/diaspora count as VALID categories (never as
+    # missing-or-invalid) and are honestly reported in category_counts...
+    assert gate["missing_or_invalid_categories"] == 0
+    assert gate["category_counts"]["business"] > 0
+    assert gate["category_counts"]["diaspora"] > 0
+    # ...but are NOT required for gate-green: only the 7 legacy categories
+    # feed missing_required_categories.
+    assert gate["missing_required_categories"] == []
+    assert gate["required_categories"] == sorted(REQUIRED_INTERVIEW_CATEGORIES)
+    assert gate["reported_only_categories"] == ["business", "diaspora"]
+    assert gate["green"] is True
+
+
+def test_a_missing_legacy_category_still_fails_closed_with_ten_value_enum() -> None:
+    """Guilt: the widened enum does not dilute the 7-category requirement —
+    a window with zero 'student' rows stays RED even with plenty of
+    business/diaspora traffic."""
+    rows, pack, db_pack_id = _green_fixture()
+    categories = [c for c in sorted(REQUIRED_INTERVIEW_CATEGORIES) if c != "student"]
+    categories += ["business", "diaspora"]
+    for index, row in enumerate(rows):
+        row["request_category"] = categories[index % len(categories)]
+
+    report = _evaluate(rows, pack, db_pack_id)
+    gate = report["gates"]["G-a-vol"]
+
+    assert gate["missing_required_categories"] == ["student"]
+    assert gate["green"] is False
+
+
+def test_migration_257_carries_rollback_marker_and_correct_value_sets() -> None:
+    forward, rollback = _read_migration(_MIGRATION_257_PATH, 257)
+    for value in (
+        "work_remote",
+        "investor",
+        "work_employee",
+        "family",
+        "long_tourism",
+        "retirement",
+        "student",
+        "other",
+        "business",
+        "diaspora",
+    ):
+        assert f"'{value}'" in forward
+    # Rollback restores migration 255's exact 8-value CHECK: the two new
+    # values must NOT survive it.
+    assert "'business'" not in rollback
+    assert "'diaspora'" not in rollback
+    for value in (
+        "work_remote",
+        "investor",
+        "work_employee",
+        "family",
+        "long_tourism",
+        "retirement",
+        "student",
+        "other",
+    ):
+        assert f"'{value}'" in rollback
+
+
+@pytest.mark.integration
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_migration_257_check_admits_new_categories_and_rejects_bogus(
+    db_pool: asyncpg.Pool, shadow_evidence_schema: None
+) -> None:
+    start = datetime(2026, 7, 23, tzinfo=timezone.utc)
+    async with db_pool.acquire() as conn:
+        # Innocence: the two new categories insert cleanly.
+        await _insert_unavailable_audit_row(
+            conn,
+            environment="TEST",
+            evaluated_at=start,
+            fingerprint_seed="business-row",
+            request_category="business",
+        )
+        await _insert_unavailable_audit_row(
+            conn,
+            environment="TEST",
+            evaluated_at=start,
+            fingerprint_seed="diaspora-row",
+            request_category="diaspora",
+        )
+        # Guilt: a non-CHECK value is still rejected at the storage layer.
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await _insert_unavailable_audit_row(
+                conn,
+                environment="TEST",
+                evaluated_at=start,
+                fingerprint_seed="bogus-row",
+                request_category="not-a-category",
+            )
+
+
+@pytest.mark.integration
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_collect_reports_business_diaspora_as_valid_not_required(
+    db_pool: asyncpg.Pool, shadow_evidence_schema: None
+) -> None:
+    """End-to-end through Postgres: rows carrying the new categories survive
+    the 257 CHECK, are read back by the collector, and land in
+    category_counts without ever feeding missing_required_categories."""
+    start = datetime(2026, 7, 23, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    async with db_pool.acquire() as conn:
+        for seed, category in (("biz", "business"), ("diaspora", "diaspora")):
+            await _insert_unavailable_audit_row(
+                conn,
+                environment="TEST",
+                evaluated_at=start,
+                fingerprint_seed=seed,
+                traffic_source=REAL_TRAFFIC_SOURCE,
+                request_category=category,
+            )
+
+    report = await collect_shadow_evidence(
+        db_pool,
+        window_start=start,
+        window_end=end,
+        environment="TEST",
+    )
+
+    gate = report["gates"]["G-a-vol"]
+    assert gate["missing_or_invalid_categories"] == 0
+    assert gate["category_counts"] == {"business": 1, "diaspora": 1}
+    assert "business" not in gate["missing_required_categories"]
+    assert "diaspora" not in gate["missing_required_categories"]
+    assert gate["reported_only_categories"] == ["business", "diaspora"]


### PR DESCRIPTION
## W1b (Track A chain) — migration 257: `request_category` extension + reported-only collector semantics

**Spec (adjudicated, not re-litigated here):** `research/visa/2026-07-23-w1-evidence-machinery-brief.md` **Item 3** (Fable delta 3, binding 2026-07-23). Stacked under: nothing (base `main`). Follow-up: the evaluate read-path endpoint PR stacks **on top of this one**.

### What & why

The v2 interview has 10 purpose tiles; migration 255's `request_category` CHECK admits only the 8 legacy values (`visa_check.match_tree.Purpose` vocabulary). Fable delta 3 rules: extend the enum to 10 — add `business` and `diaspora`, keep `other`. The rejected alternative (map both tiles to `other`) would silently miscount real end-user demand in the G-a evidence report.

- **Migration `257_visa_request_category_extension.sql`** — drop the auto-named `visa_decisions_request_category_check` (255's inline column CHECK), re-add with the 10-value list. New list is a strict superset, so re-validation at `ADD CONSTRAINT` time cannot fail on pre-257 data. `-- === ROLLBACK ===` restores the exact 8-value CHECK (`IF EXISTS` throughout; ordering note in the file header). Cannot arm ENFORCE; touches no other object.
- **Collector (`shadow_evidence.py`)** — the 7 legacy substantive categories stay **REQUIRED** for the G-a gates; `business`/`diaspora` rows are **REPORTED** (counted in `category_counts`, honestly labeled via the new `reported_only_categories` field on both G-a gate reports) but **NOT required** for gate-green, because their behavioral trees do not exist yet (Track B FASE 2 lanes 2 and 6) — demanding them today would require evidence no honest evaluation can produce. Report `schema_version` 1.1.0 → 1.2.0.

### Test evidence (run on Air-M5, Pro PG tunnel `nuzantara_test`)

- `backend/tests/services/visa_engine/test_shadow_evidence.py` — **37/37 passed**:
  - guilt+innocence aggregation: new categories count as valid (never `missing_or_invalid`), appear in `category_counts`, never in `missing_required_categories`; a missing **legacy** category still fails closed with the 10-value enum;
  - constants pinned: REQUIRED = 7 legacy, REPORTED_ONLY = {business, diaspora}, disjoint, 10 total;
  - migration file: ROLLBACK marker, forward carries all 10 values, rollback exactly the legacy 8;
  - DB integration: the 257 CHECK **admits** `business`/`diaspora` inserts and **rejects** a bogus category (`CheckViolationError`); collector reads new-category rows back end-to-end;
  - fixture layers 252+255+256+257 with a documented ordering note (257's rollback re-validates surviving rows, so it runs after 252's table drop — also crash-robust).
- Migration lints (`test_migration_uniqueness.py`, `test_migration_rollback_extraction.py`): 10/10 passed.
- `ruff check` + `ruff format --check`: clean.

Full visa_engine suite note: 4 failures reproduce **identically on `main`** from this machine (M5 test-runner vs Pro DB-server clock skew; `observed_at … outside … system_period`), pre-existing and unrelated to this diff — verified by running the same tests from the main checkout.

### Out of scope (deliberate)

- No writer of the new categories yet — that lands in the stacked endpoint PR (the evaluate read-path derives/persists `request_category`).
- The MATCH↔RECOMMEND collector surface widening also lands in the endpoint PR (motivated by its writer).
