### PR TITLE
fix(rag): contain WA persona-override forgery + tool-arg smuggling (P0-ID/P0-ARG, W-1)

### DIFF
--- a/apps/backend-rag/backend/app/core/config.py
+++ b/apps/backend-rag/backend/app/core/config.py
@@ -1056,6 +1056,23 @@ class Settings(BaseSettings):
     wa_mirror_crm_write_key: str | None = None
     wa_mirror_crm_write_enabled: bool = False
 
+    # Scoped service key EXCLUSIVE to wa_inbox_bot.py's own call to
+    # POST /api/agentic-rag/query, used ONLY to gate WA sender-profile
+    # resolution (owner/team persona override — P0-ID, hardened 2026-07-24).
+    # DISTINCT from wa_mirror_internal_key BY DESIGN: that key is shared with
+    # other Pro-side scripts (e.g. wa-mirror-auto-promote-leads), and an
+    # earlier version of this fix gated profile resolution on
+    # `role=="internal"` (granted to ANY holder of the shared key) plus a
+    # phone parsed from the client-supplied `user_id` body field — closable
+    # by any shared-key holder sending `user_id="whatsapp_<owner's PUBLIC
+    # WA number>"` (the number is documented-public, see
+    # whatsapp_identity.py). This key has no such gap: only a request
+    # carrying THIS specific secret can trigger profile resolution at all.
+    # Header: X-WA-Bot-Profile-Key. Unset → profile resolution silently
+    # never fires (fail-safe: no persona override, not an open door).
+    # Rotate via `fly secrets set WA_INBOX_BOT_PROFILE_KEY=...`.
+    wa_inbox_bot_profile_key: str | None = None
+
     hf_api_key: str | None = None  # Set via HF_API_KEY env var
 
     # ========================================

--- a/apps/backend-rag/backend/app/routers/agentic_rag.py
+++ b/apps/backend-rag/backend/app/routers/agentic_rag.py
@@ -258,18 +258,24 @@ class AgenticQueryRequest(BaseModel):
         None  # Direct history from frontend
     )
     channel: str | None = None  # Channel overlay: "website", "webapp", "whatsapp", etc.
-    # NOTE (P0-ID containment, 2026-07-24): there used to be a `profile`
-    # field here that let a caller declare its own WA sender persona
-    # (creator/team), trusted whenever `current_user.role == "internal"`
-    # AND this `channel` field said "whatsapp". Both gates were forgeable
-    # by ANY holder of the shared `X-Internal-Key` (it authenticates more
-    # than the WA bot — see `_resolve_trusted_wa_profile` below) simply by
-    # setting a body field. Removed: the server now RE-DERIVES the sender
-    # profile itself from `user_id` via the same `resolve_sender_identity`
-    # DB lookup `wa_inbox_bot.py` already trusts — no client-declared
-    # persona is accepted at all. `channel` stays (still used for the
-    # WA prompt overlay elsewhere) but no longer participates in any
-    # trust decision.
+    # NOTE (P0-ID containment, 2026-07-24, hardened same day after
+    # adversarial review): there used to be a `profile` field here that let
+    # a caller declare its own WA sender persona (creator/team), trusted
+    # whenever `current_user.role == "internal"` AND this `channel` field
+    # said "whatsapp". Both gates were forgeable by ANY holder of the shared
+    # `X-Internal-Key` simply by setting body fields. A first fix removed
+    # `profile`/`channel` from the decision and re-derived the sender from a
+    # phone parsed out of `user_id` instead — but `user_id` is ITSELF a
+    # client-settable body field, and the owner's WA number is documented-
+    # public (see `whatsapp_identity.py`), so that was the identical bug
+    # relocated, not closed: any shared-key holder could still send
+    # `user_id="whatsapp_<public owner number>"`. Real fix: profile
+    # resolution now requires a SECOND secret exclusive to wa_inbox_bot.py
+    # (`X-WA-Bot-Profile-Key`, see `_verify_wa_inbox_bot_profile_key` below)
+    # — no request body field can influence the outcome at all; only that
+    # dedicated credential plus real `team_members`/env-roster data can.
+    # `channel` stays (still used for the WA prompt overlay elsewhere) but
+    # never participates in any trust decision.
     # Latency knob (additive, optional): a caller expecting a fast reply
     # (e.g. the WhatsApp bot, see research/operations/2026-07-20-wa-bot-latency.md)
     # may request a lower ReAct step cap. Never allowed to RAISE the cap —
@@ -291,36 +297,56 @@ def _extract_whatsapp_phone(user_id: str | None) -> str | None:
     return match.group("phone") if match else None
 
 
+async def _verify_wa_inbox_bot_profile_key(request: Request) -> bool:
+    """True only if this request carries wa_inbox_bot.py's OWN dedicated
+    secret (`X-WA-Bot-Profile-Key`, `settings.wa_inbox_bot_profile_key`,
+    Fly secret `WA_INBOX_BOT_PROFILE_KEY`).
+
+    P0-ID hardening (2026-07-24, second pass after adversarial review): the
+    generic `X-Internal-Key` → `role="internal"` (`hybrid_auth.py`) is a
+    SHARED secret held by more than just the WA bot (e.g. Pro-side scripts
+    like wa-mirror-auto-promote-leads hitting `crm_clients.py`) — gating
+    profile resolution on that role alone (as an earlier version of this fix
+    did, combined with a phone parsed out of the client-settable `user_id`
+    field) meant ANY holder of the shared key could send
+    `user_id="whatsapp_<owner's public WA number>"` and forge the creator
+    persona. This dependency checks a SECOND, narrower secret that ONLY
+    wa_inbox_bot.py is provisioned with — no request body field, and no
+    other internal-key holder, can satisfy it.
+
+    Deliberately a soft boolean, never an HTTPException: a missing/wrong key
+    just means "no profile override" (identical to any other non-WA
+    caller), not an auth failure for the query itself — every other caller
+    of this endpoint (JWT web users, anonymous, other internal scripts)
+    is completely unaffected and never sends this header at all.
+    """
+    configured = getattr(settings, "wa_inbox_bot_profile_key", None)
+    if not configured:
+        return False
+    provided = request.headers.get("X-WA-Bot-Profile-Key")
+    return bool(provided and provided == configured)
+
+
 async def _resolve_trusted_wa_profile(
-    current_user: dict[str, Any] | None,
+    is_wa_inbox_bot: bool,
     user_id: str | None,
     db_pool: Any | None,
 ) -> dict[str, Any] | None:
     """Server-derived WA sender profile (P0-ID containment, 2026-07-24).
 
-    Replaces the old client-supplied `profile` request field. `X-Internal-Key`
-    (`settings.wa_mirror_internal_key`) is a SHARED secret — `hybrid_auth.py`
-    grants the identical `role="internal"` pseudo-identity to every holder,
-    and that key authenticates more than the WA bot (e.g. Pro-side scripts
-    like wa-mirror-auto-promote-leads hitting `crm_clients.py`). A bare
-    `role == "internal"` check is therefore NOT scoped to "this specific
-    request came from wa_inbox_bot.py resolving a real WhatsApp sender".
-
-    Narrow-first fix (Zero-ratified 2026-07-24, spec Q6): instead of trusting
-    a client-declared `profile` dict gated on a client-settable `channel`
-    field, the server independently RE-RESOLVES the sender from the phone
-    number embedded in `user_id` (`whatsapp_<phone>`, the same shape
+    Replaces the old client-supplied `profile` request field. Trust is
+    gated on `is_wa_inbox_bot` (see `_verify_wa_inbox_bot_profile_key`) —
+    the caller's OWN dedicated secret, never a body field. Once trusted,
+    the server independently RE-RESOLVES the sender from the phone number
+    embedded in `user_id` (`whatsapp_<phone>`, the same shape
     `wa_inbox_bot.py` has always sent) via `resolve_sender_identity` — the
-    exact DB/env lookup `wa_inbox_bot.py` itself uses. No request body field
-    can influence the outcome; only real `team_members`/env-roster data can.
-    A full typed identity envelope (binding the shared key to a specific
-    service + request nonce) is the deferred follow-up, same quarter.
+    exact DB/env lookup `wa_inbox_bot.py` itself uses.
 
     Returns None (no override — the pre-existing, still-correct behavior)
-    unless `current_user` is the shared WA internal identity AND `user_id`
-    is WA-shaped AND that phone resolves to `owner` or `team`.
+    unless the caller holds the dedicated WA-bot secret AND `user_id` is
+    WA-shaped AND that phone resolves to `owner` or `team`.
     """
-    if not current_user or current_user.get("role") != "internal":
+    if not is_wa_inbox_bot:
         return None
     phone = _extract_whatsapp_phone(user_id)
     if phone is None:
@@ -384,6 +410,7 @@ async def query_agentic_rag(
     current_user: dict | None = Depends(get_current_user_optional),
     orchestrator: AgenticRAGOrchestrator = Depends(get_orchestrator),
     db_pool: Any | None = Depends(get_optional_database_pool),
+    is_wa_inbox_bot: bool = Depends(_verify_wa_inbox_bot_profile_key),
 ) -> AgenticQueryResponse:
     """
     Esegue una query usando il sistema Agentic RAG completo.
@@ -395,7 +422,7 @@ async def query_agentic_rag(
     and records performance metrics for comparison.
     """
     trusted_profile = await _resolve_trusted_wa_profile(
-        current_user, request.user_id, db_pool
+        is_wa_inbox_bot, request.user_id, db_pool
     )
 
     # SECURITY: Use authenticated user if available, otherwise session-based
@@ -480,8 +507,8 @@ async def query_agentic_rag(
         if conversation_history:
             query_kwargs["conversation_history"] = conversation_history
         if trusted_profile is not None:
-            # WA team-assistant V1 — already authorized above (403 on any
-            # untrusted attempt) by `_is_trusted_wa_profile_caller`.
+            # WA team-assistant V1 — already gated above (`_resolve_trusted_wa_profile`
+            # returns None for anyone but a request holding `X-WA-Bot-Profile-Key`).
             query_kwargs["profile"] = trusted_profile
         if request.max_steps is not None:
             query_kwargs["max_steps"] = request.max_steps

--- a/apps/backend-rag/backend/app/routers/agentic_rag.py
+++ b/apps/backend-rag/backend/app/routers/agentic_rag.py
@@ -19,7 +19,7 @@ from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from backend.app.core.config import settings
 from backend.app.dependencies import (
@@ -39,6 +39,7 @@ from backend.services.agents.team_agent_config import (
 )
 from backend.services.rag.agentic import AgenticRAGOrchestrator
 from backend.services.rag.evaluation import ABTestManager, MetricsTracker
+from backend.services.whatsapp_identity import resolve_sender_identity
 
 logger = logging.getLogger(__name__)
 
@@ -246,20 +247,6 @@ class ImageInput(BaseModel):
     name: str  # Original filename
 
 
-class InternalSenderProfile(BaseModel):
-    """Narrow service-to-service profile — accepted ONLY from the dedicated
-    WA internal-service identity + `channel="whatsapp"` (see
-    `_is_trusted_wa_profile_caller` at the route below). `extra="forbid"`
-    so this transport can never be used to smuggle an unreviewed field past
-    validation — every field this payload can carry is enumerated here."""
-
-    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
-
-    role: Literal["creator", "team"]
-    name: str | None = Field(default=None, min_length=1, max_length=255)
-    email: str | None = Field(default=None, min_length=3, max_length=320)
-
-
 class AgenticQueryRequest(BaseModel):
     query: str
     user_id: str | None = "anonymous"
@@ -271,20 +258,18 @@ class AgenticQueryRequest(BaseModel):
         None  # Direct history from frontend
     )
     channel: str | None = None  # Channel overlay: "website", "webapp", "whatsapp", etc.
-    # WA team-assistant V1 (additive, optional): a caller that has already
-    # resolved the sender's identity out-of-band (e.g. wa_inbox_bot.py via
-    # backend/services/whatsapp_identity.py) can pass it here so the
-    # orchestrator's is_creator/is_team persona check
-    # (prompt_builder.py build_system_prompt) sees it explicitly — see
-    # research/operations/2026-07-19-wa-bot-team-assistant-v1.md. This field
-    # crosses the api-to-rag process boundary, but query_agentic_rag
-    # authorizes it against the server-derived WA internal-service identity
-    # (SECURITY, 2026-07-20 — see `_is_trusted_wa_profile_caller`) before
-    # forwarding it: client/JWT/generic-API-key callers cannot self-declare
-    # a privileged persona, and the closed `InternalSenderProfile` schema
-    # rejects any field this contract doesn't enumerate. None remains a
-    # complete no-op for every existing caller.
-    profile: InternalSenderProfile | None = None
+    # NOTE (P0-ID containment, 2026-07-24): there used to be a `profile`
+    # field here that let a caller declare its own WA sender persona
+    # (creator/team), trusted whenever `current_user.role == "internal"`
+    # AND this `channel` field said "whatsapp". Both gates were forgeable
+    # by ANY holder of the shared `X-Internal-Key` (it authenticates more
+    # than the WA bot — see `_resolve_trusted_wa_profile` below) simply by
+    # setting a body field. Removed: the server now RE-DERIVES the sender
+    # profile itself from `user_id` via the same `resolve_sender_identity`
+    # DB lookup `wa_inbox_bot.py` already trusts — no client-declared
+    # persona is accepted at all. `channel` stays (still used for the
+    # WA prompt overlay elsewhere) but no longer participates in any
+    # trust decision.
     # Latency knob (additive, optional): a caller expecting a fast reply
     # (e.g. the WhatsApp bot, see research/operations/2026-07-20-wa-bot-latency.md)
     # may request a lower ReAct step cap. Never allowed to RAISE the cap —
@@ -295,32 +280,63 @@ class AgenticQueryRequest(BaseModel):
     max_steps: int | None = Field(default=None, ge=1)
 
 
-def _is_trusted_wa_profile_caller(
-    current_user: dict[str, Any] | None,
-    channel: str | None,
-) -> bool:
-    """Return whether auth resolved to the dedicated WA internal service.
+_WHATSAPP_USER_ID_RE = re.compile(r"^whatsapp_(?P<phone>.+)$")
 
-    SECURITY (2026-07-20): `X-Internal-Key` (`settings.wa_mirror_internal_key`)
-    is a SHARED secret — `hybrid_auth.py` grants the exact same
-    `role="internal"` pseudo-identity to every holder, and that key is used
-    by more than just the WhatsApp bot (e.g. Pro-side scripts like
-    wa-mirror-auto-promote-leads hitting `crm_clients.py`). A bare
+
+def _extract_whatsapp_phone(user_id: str | None) -> str | None:
+    """Pull the phone out of a `whatsapp_<phone>` user_id, else None."""
+    if not user_id:
+        return None
+    match = _WHATSAPP_USER_ID_RE.match(user_id)
+    return match.group("phone") if match else None
+
+
+async def _resolve_trusted_wa_profile(
+    current_user: dict[str, Any] | None,
+    user_id: str | None,
+    db_pool: Any | None,
+) -> dict[str, Any] | None:
+    """Server-derived WA sender profile (P0-ID containment, 2026-07-24).
+
+    Replaces the old client-supplied `profile` request field. `X-Internal-Key`
+    (`settings.wa_mirror_internal_key`) is a SHARED secret — `hybrid_auth.py`
+    grants the identical `role="internal"` pseudo-identity to every holder,
+    and that key authenticates more than the WA bot (e.g. Pro-side scripts
+    like wa-mirror-auto-promote-leads hitting `crm_clients.py`). A bare
     `role == "internal"` check is therefore NOT scoped to "this specific
-    request came from wa_inbox_bot.py resolving a real WhatsApp sender" —
-    it only proves "the caller knows the shared internal key". Requiring
-    `channel == "whatsapp"` too (which `wa_inbox_bot.py` always sets, see
-    `_rag_client_headers`/payload construction) narrows the override to its
-    sole intended consumer without adding a second secret. `role == "admin"`
-    (X-Debug-Key) is deliberately NOT accepted here — no shipped caller
-    needs it, and least-privilege beats convenience for a persona-escalation
-    vector. Request-body fields never participate in this decision.
+    request came from wa_inbox_bot.py resolving a real WhatsApp sender".
+
+    Narrow-first fix (Zero-ratified 2026-07-24, spec Q6): instead of trusting
+    a client-declared `profile` dict gated on a client-settable `channel`
+    field, the server independently RE-RESOLVES the sender from the phone
+    number embedded in `user_id` (`whatsapp_<phone>`, the same shape
+    `wa_inbox_bot.py` has always sent) via `resolve_sender_identity` — the
+    exact DB/env lookup `wa_inbox_bot.py` itself uses. No request body field
+    can influence the outcome; only real `team_members`/env-roster data can.
+    A full typed identity envelope (binding the shared key to a specific
+    service + request nonce) is the deferred follow-up, same quarter.
+
+    Returns None (no override — the pre-existing, still-correct behavior)
+    unless `current_user` is the shared WA internal identity AND `user_id`
+    is WA-shaped AND that phone resolves to `owner` or `team`.
     """
-    return bool(
-        current_user
-        and current_user.get("role") == "internal"
-        and channel == "whatsapp"
-    )
+    if not current_user or current_user.get("role") != "internal":
+        return None
+    phone = _extract_whatsapp_phone(user_id)
+    if phone is None:
+        return None
+    identity = await resolve_sender_identity(phone, db_pool)
+    role = identity.get("role")
+    if role == "owner":
+        return {"role": "creator"}
+    if role == "team":
+        profile: dict[str, Any] = {"role": "team"}
+        if identity.get("team_member"):
+            profile["name"] = identity["team_member"]
+        if identity.get("team_member_email"):
+            profile["email"] = identity["team_member_email"]
+        return profile
+    return None  # client / unknown → no privileged override
 
 
 class WorkspaceQueryRequest(BaseModel):
@@ -378,22 +394,9 @@ async def query_agentic_rag(
     **A/B TESTING**: Automatically assigns users to retrieval strategy variants
     and records performance metrics for comparison.
     """
-    trusted_profile: dict[str, Any] | None = None
-    if request.profile is not None:
-        if not _is_trusted_wa_profile_caller(current_user, request.channel):
-            logger.warning(
-                "agentic_rag.profile_override_denied",
-                extra={
-                    "authenticated": current_user is not None,
-                    "auth_role": current_user.get("role") if current_user else None,
-                    "channel": request.channel,
-                },
-            )
-            raise HTTPException(
-                status_code=403,
-                detail="Profile override is restricted to the WhatsApp internal service.",
-            )
-        trusted_profile = request.profile.model_dump(exclude_none=True)
+    trusted_profile = await _resolve_trusted_wa_profile(
+        current_user, request.user_id, db_pool
+    )
 
     # SECURITY: Use authenticated user if available, otherwise session-based
     if current_user:

--- a/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
+++ b/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
@@ -113,15 +113,36 @@ def _rag_client_headers() -> dict[str, str]:
     "role=internal" pseudo-user, the same channel Pro-side internal scripts use.
     Without this the bot can NEVER generate a reply (every call → 401 → worker
     marks the row failed).
+
+    ALSO sends X-WA-Bot-Profile-Key (settings.wa_inbox_bot_profile_key, Fly
+    secret WA_INBOX_BOT_PROFILE_KEY) — a SECOND secret exclusive to this
+    process, distinct from X-Internal-Key (which other Pro-side scripts also
+    hold). `agentic_rag.py::_verify_wa_inbox_bot_profile_key` gates WA
+    sender-profile resolution (owner/team persona override) on THIS key
+    specifically, not on the shared internal-key role (P0-ID hardening,
+    2026-07-24). Missing → profile resolution simply never fires for this
+    bot's calls (fail-safe degrade, not a 401 — the query itself still works).
     """
+    headers: dict[str, str] = {}
     internal_key = getattr(settings, "wa_mirror_internal_key", None)
     if internal_key:
-        return {"X-Internal-Key": internal_key}
-    logger.warning(
-        "wa-inbox bot: WA_MIRROR_INTERNAL_KEY not configured — "
-        "RAG calls will be rejected by HybridAuthMiddleware (401)"
-    )
-    return {}
+        headers["X-Internal-Key"] = internal_key
+    else:
+        logger.warning(
+            "wa-inbox bot: WA_MIRROR_INTERNAL_KEY not configured — "
+            "RAG calls will be rejected by HybridAuthMiddleware (401)"
+        )
+    profile_key = getattr(settings, "wa_inbox_bot_profile_key", None)
+    if profile_key:
+        headers["X-WA-Bot-Profile-Key"] = profile_key
+    else:
+        logger.warning(
+            "wa-inbox bot: WA_INBOX_BOT_PROFILE_KEY not configured — "
+            "owner/team persona override will never resolve for this bot's "
+            "queries (query itself still works; degrades to client-shaped "
+            "persona only)"
+        )
+    return headers
 
 
 async def _get_rag_client() -> httpx.AsyncClient:

--- a/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
+++ b/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
@@ -42,7 +42,6 @@ import httpx
 
 from backend.app.core.config import settings
 from backend.app.rag_proxy import get_rag_worker_url
-from backend.services.whatsapp_identity import resolve_sender_identity
 
 logger = logging.getLogger("zantara.backend")
 
@@ -148,29 +147,6 @@ async def close_rag_client() -> None:
         _rag_client = None
 
 
-def _profile_from_identity(identity: dict[str, Any]) -> dict[str, Any] | None:
-    """Map a resolved sender identity to the RAG request's ``profile`` field.
-
-    Only ``owner``/``team`` produce a profile — ``client``/``unknown`` (and
-    any identity resolution fail-safe fallback, which also lands on
-    ``unknown``) return ``None`` so the caller omits the ``profile`` key
-    entirely. That is the innocence contract for this feature: a client or
-    an unrecognized sender's RAG payload must stay byte-identical to the
-    pre-identity-wiring shape.
-    """
-    role = identity.get("role")
-    if role == "owner":
-        return {"role": "creator"}
-    if role == "team":
-        profile: dict[str, Any] = {"role": "team"}
-        if identity.get("team_member"):
-            profile["name"] = identity["team_member"]
-        if identity.get("team_member_email"):
-            profile["email"] = identity["team_member_email"]
-        return profile
-    return None
-
-
 async def _load_thread_context(
     pool: asyncpg.Pool, thread_id: int
 ) -> tuple[str, list[dict[str, str]]]:
@@ -241,13 +217,14 @@ async def generate_bot_reply(pool: asyncpg.Pool, thread: Any) -> str:
     if not query:
         raise RuntimeError(f"wa-inbox bot: no customer message in thread {thread_id}")
 
-    # Team-assistant V1 (identity-gated, additive): resolve_sender_identity
-    # is fail-safe by design (any error → {"role": "unknown"}), so this can
-    # never raise and never changes behavior for client/unknown senders —
-    # see _profile_from_identity docstring for the innocence contract.
-    identity = await resolve_sender_identity(phone, pool)
-    profile = _profile_from_identity(identity)
-
+    # Team-assistant V1 (2026-07-19) used to resolve the sender's identity
+    # HERE and forward it as a `profile` request field. P0-ID containment
+    # (2026-07-24) moved that same `resolve_sender_identity` lookup
+    # server-side (`agentic_rag.py::_resolve_trusted_wa_profile`) — the
+    # server no longer trusts a client-declared profile at all, so doing
+    # the lookup here too would be a redundant DB round-trip on this
+    # latency-critical path (research/operations/2026-07-20-wa-bot-latency.md)
+    # for a value nobody reads anymore.
     payload: dict[str, Any] = {
         "query": query,
         "user_id": f"whatsapp_{phone}",
@@ -266,8 +243,6 @@ async def generate_bot_reply(pool: asyncpg.Pool, thread: Any) -> str:
         # ReAct step) is untouched — the answer-quality safety net stays.
         "max_steps": 2,
     }
-    if profile is not None:
-        payload["profile"] = profile
 
     # P9 admission gate — bound in-flight RAG calls from this api process
     # (see _get_bot_generation_semaphore docstring). Scoped tightly around

--- a/apps/backend-rag/backend/services/rag/agentic/tool_executor.py
+++ b/apps/backend-rag/backend/services/rag/agentic/tool_executor.py
@@ -32,6 +32,32 @@ from backend.services.tools.definitions import BaseTool, ToolCall
 
 logger = logging.getLogger(__name__)
 
+_RESERVED_ARG_PREFIX = "_"
+
+
+def _strip_reserved_args(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Drop any LLM-supplied key that looks like a server-reserved field.
+
+    Security (P0-ARG containment, 2026-07-24): `execute_tool` injects
+    server-controlled context (`_user_id`, `_caller_profile`) into
+    `arguments` near the end, but only when ITS OWN server-derived value
+    is truthy — see the two `if ...: arguments["_..."] = ...` lines below.
+    Before this fix, if the LLM's tool-call `arguments` dict (attacker-
+    steerable via prompt injection in the conversation) already contained
+    a same-named key, that injected value survived untouched whenever the
+    server had nothing of its own to overwrite it with — a client/unknown
+    caller's crafted `_caller_profile={"role": "creator"}` argument would
+    reach `tool.execute(**arguments)` unfiltered. Stripping every leading-
+    underscore key from the LLM-supplied dict — before the authorizer even
+    sees it, AND again immediately before the trusted re-injection — makes
+    every server-injected field structurally unforgeable: no LLM-facing
+    tool schema declares a leading-underscore parameter (verified across
+    `backend/services/tools/` 2026-07-24), so this never drops a
+    legitimate argument.
+    """
+    return {k: v for k, v in arguments.items() if not k.startswith(_RESERVED_ARG_PREFIX)}
+
+
 # Module-level singletons — set by service_initializer.py at app startup.
 # Before Phase 3 wiring, the authorizer was a bare ToolAuthorizer() with no
 # dependencies. Now it may have a ConfirmationService. Both are replaced once
@@ -231,6 +257,11 @@ async def execute_tool(
     """
     start_time = time.time()
 
+    # P0-ARG containment: strip any LLM-supplied reserved-prefix key BEFORE
+    # anything (including the authorizer below) sees `arguments` — see
+    # `_strip_reserved_args` docstring.
+    arguments = _strip_reserved_args(arguments)
+
     # Security: Rate limiting - max 10 tool executions per query
     if tool_execution_counter is not None:
         tool_execution_counter["count"] += 1
@@ -338,6 +369,10 @@ async def execute_tool(
     # Authoritative args after the authorizer (possibly mutated in
     # Phase 3+; Phase 2 returns args unchanged).
     arguments = auth_result.args
+    # P0-ARG containment: strip again immediately before the trusted
+    # re-injection below — defense in depth against a future authorizer
+    # mutation accidentally echoing a reserved-looking key back unchanged.
+    arguments = _strip_reserved_args(arguments)
 
     try:
         # Pass user_id to tools that need it (e.g., MCPSuperTool for admin

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_agentic_rag_router.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_agentic_rag_router.py
@@ -787,23 +787,19 @@ class TestExtractWhatsappPhone:
 
 
 class TestResolveTrustedWaProfile:
-    """P0-ID containment (2026-07-24): replaces the old client-supplied
-    `profile` request field (removed — no longer exists on
-    `AgenticQueryRequest`) and its `_is_trusted_wa_profile_caller` gate
-    (a client-settable `channel` field was, per the spec's council audit,
-    forgeable by ANY holder of the shared `X-Internal-Key`, not just the
-    WA bot). The server now RE-DERIVES the sender's profile itself via
-    `resolve_sender_identity`, keyed on the phone embedded in `user_id`
-    (`whatsapp_<phone>`) — no request body field can influence the
-    outcome. See `agentic_rag.py::_resolve_trusted_wa_profile`."""
-
-    @staticmethod
-    def _internal_user():
-        return {
-            "role": "internal",
-            "email": "wa-mirror-internal@balizero.com",
-            "user_id": "wa-mirror-internal",
-        }
+    """P0-ID containment (2026-07-24, hardened same day after adversarial
+    review): replaces the old client-supplied `profile` request field
+    (removed — no longer exists on `AgenticQueryRequest`). A FIRST version
+    of this fix re-derived the sender from a phone parsed out of the
+    client-settable `user_id` field, gated only on the SHARED
+    `role=="internal"` identity — an independent review found this was the
+    identical forgery bug relocated, not closed: the owner's WA number is
+    documented-public, so ANY holder of the shared `X-Internal-Key` could
+    send `user_id="whatsapp_<owner number>"` and get the creator persona.
+    The real fix gates resolution on `is_wa_inbox_bot` (see
+    `_verify_wa_inbox_bot_profile_key` — a SECOND secret exclusive to
+    wa_inbox_bot.py, never a request body field). These tests target
+    `_resolve_trusted_wa_profile` directly with that boolean explicit."""
 
     @pytest.mark.asyncio
     async def test_owner_phone_yields_creator_profile(self):
@@ -814,7 +810,7 @@ class TestResolveTrustedWaProfile:
             new=AsyncMock(return_value={"role": "owner"}),
         ):
             result = await _resolve_trusted_wa_profile(
-                self._internal_user(), "whatsapp_62811000111", None
+                True, "whatsapp_62811000111", None
             )
         assert result == {"role": "creator"}
 
@@ -833,14 +829,14 @@ class TestResolveTrustedWaProfile:
             ),
         ):
             result = await _resolve_trusted_wa_profile(
-                self._internal_user(), "whatsapp_62811000222", None
+                True, "whatsapp_62811000222", None
             )
         assert result == {"role": "team", "name": "Ari", "email": "ari@balizero.com"}
 
     @pytest.mark.asyncio
     async def test_client_or_unknown_phone_yields_no_override(self):
         """Innocence: a resolved client/unknown sender never gets a
-        privileged persona."""
+        privileged persona, even WITH the dedicated bot key."""
         from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
 
         for identity in ({"role": "client", "client_id": 1}, {"role": "unknown"}):
@@ -849,14 +845,33 @@ class TestResolveTrustedWaProfile:
                 new=AsyncMock(return_value=identity),
             ):
                 result = await _resolve_trusted_wa_profile(
-                    self._internal_user(), "whatsapp_62899999999", None
+                    True, "whatsapp_62899999999", None
                 )
             assert result is None
 
     @pytest.mark.asyncio
     async def test_non_whatsapp_user_id_short_circuits_before_any_lookup(self):
-        """Innocence: even a fully-trusted internal caller gets no override
-        — and no DB lookup at all — when `user_id` isn't WA-shaped."""
+        """Innocence: even WITH the dedicated bot key, no override — and no
+        DB lookup at all — when `user_id` isn't WA-shaped."""
+        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
+
+        mock_resolve = AsyncMock(return_value={"role": "owner"})
+        with patch(
+            "backend.app.routers.agentic_rag.resolve_sender_identity", new=mock_resolve
+        ):
+            result = await _resolve_trusted_wa_profile(True, "wa-mirror-internal", None)
+        assert result is None
+        mock_resolve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_without_dedicated_bot_key_no_override_even_with_owner_phone(self):
+        """Guilt (the actual vulnerability this hardening closes): WITHOUT
+        `is_wa_inbox_bot` — i.e. any caller lacking wa_inbox_bot.py's own
+        dedicated secret, including one holding the SHARED `X-Internal-Key`
+        and sending a WA-shaped `user_id` for the documented-public owner
+        number — gets no override, and no DB lookup is even attempted.
+        This is the exact payload the pre-hardening version would have
+        granted a creator persona for."""
         from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
 
         mock_resolve = AsyncMock(return_value={"role": "owner"})
@@ -864,53 +879,75 @@ class TestResolveTrustedWaProfile:
             "backend.app.routers.agentic_rag.resolve_sender_identity", new=mock_resolve
         ):
             result = await _resolve_trusted_wa_profile(
-                self._internal_user(), "wa-mirror-internal", None
+                False, "whatsapp_62811000111", None
             )
         assert result is None
         mock_resolve.assert_not_awaited()
 
-    @pytest.mark.asyncio
-    async def test_regular_authenticated_user_gets_no_override(self):
-        """Guilt (the actual vulnerability this fix closes): a normal
-        logged-in/JWT caller cannot get a privileged persona merely by
-        having a WA-shaped `user_id` that resolves to the owner's phone —
-        only the shared internal identity is even considered, and no DB
-        lookup is attempted for anyone else."""
-        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
 
-        regular_user = {"email": "client@example.com", "user_id": "client-1"}
-        mock_resolve = AsyncMock(return_value={"role": "owner"})
+class TestVerifyWaInboxBotProfileKey:
+    """Direct coverage of the dedicated-secret gate itself."""
+
+    @staticmethod
+    def _request(header_value: str | None):
+        req = MagicMock()
+        req.headers = {"X-WA-Bot-Profile-Key": header_value} if header_value else {}
+        return req
+
+    @pytest.mark.asyncio
+    async def test_matching_key_is_true(self):
+        from backend.app.routers.agentic_rag import _verify_wa_inbox_bot_profile_key
+
         with patch(
-            "backend.app.routers.agentic_rag.resolve_sender_identity", new=mock_resolve
+            "backend.app.routers.agentic_rag.settings.wa_inbox_bot_profile_key",
+            "s3cr3t",
         ):
-            result = await _resolve_trusted_wa_profile(
-                regular_user, "whatsapp_62811000111", None
+            assert await _verify_wa_inbox_bot_profile_key(self._request("s3cr3t")) is True
+
+    @pytest.mark.asyncio
+    async def test_wrong_key_is_false(self):
+        from backend.app.routers.agentic_rag import _verify_wa_inbox_bot_profile_key
+
+        with patch(
+            "backend.app.routers.agentic_rag.settings.wa_inbox_bot_profile_key",
+            "s3cr3t",
+        ):
+            assert (
+                await _verify_wa_inbox_bot_profile_key(self._request("wrong")) is False
             )
-        assert result is None
-        mock_resolve.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_anonymous_caller_gets_no_override(self):
-        """Innocence: unauthenticated caller (current_user=None) — the
-        worst case for the escalation vector."""
-        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
+    async def test_missing_header_is_false(self):
+        from backend.app.routers.agentic_rag import _verify_wa_inbox_bot_profile_key
 
-        mock_resolve = AsyncMock(return_value={"role": "owner"})
         with patch(
-            "backend.app.routers.agentic_rag.resolve_sender_identity", new=mock_resolve
+            "backend.app.routers.agentic_rag.settings.wa_inbox_bot_profile_key",
+            "s3cr3t",
         ):
-            result = await _resolve_trusted_wa_profile(None, "whatsapp_62811000111", None)
-        assert result is None
-        mock_resolve.assert_not_awaited()
+            assert await _verify_wa_inbox_bot_profile_key(self._request(None)) is False
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_secret_is_false_even_with_a_header(self):
+        """Fail-safe: an unset secret must never accidentally match an
+        empty/None header value."""
+        from backend.app.routers.agentic_rag import _verify_wa_inbox_bot_profile_key
+
+        with patch(
+            "backend.app.routers.agentic_rag.settings.wa_inbox_bot_profile_key",
+            None,
+        ):
+            assert await _verify_wa_inbox_bot_profile_key(self._request("")) is False
 
 
 class TestWaTrustedProfileRouterWiring:
     """Router-level integration: `query_agentic_rag` must forward whatever
     `_resolve_trusted_wa_profile` returns to the orchestrator as `profile`,
-    and the wire contract must no longer accept a client-declared one."""
+    and the wire contract must no longer accept a client-declared one.
+    `is_wa_inbox_bot` is passed explicitly since these tests call the route
+    function directly (bypassing FastAPI's own dependency resolution)."""
 
     @staticmethod
-    def _base_kwargs(mock_orchestrator, current_user, user_id, channel="whatsapp"):
+    def _base_kwargs(mock_orchestrator, user_id, channel="whatsapp"):
         request_data = AgenticQueryRequest(query="Any question", channel=channel, user_id=user_id)
         mock_ab_manager = MagicMock()
         mock_ab_manager.metrics_tracker = MagicMock()
@@ -921,15 +958,15 @@ class TestWaTrustedProfileRouterWiring:
 
     @pytest.mark.asyncio
     async def test_owner_phone_profile_reaches_orchestrator(self, mock_orchestrator):
-        """Guilt: the WA bridge's shared internal identity + a phone that
-        resolves to 'owner' → creator profile forwarded to the orchestrator."""
+        """Guilt: WITH the dedicated bot key + a phone that resolves to
+        'owner' → creator profile forwarded to the orchestrator."""
         internal_user = {
             "role": "internal",
             "email": "wa-mirror-internal@balizero.com",
             "user_id": "wa-mirror-internal",
         }
         request_data, mock_ab_manager = self._base_kwargs(
-            mock_orchestrator, internal_user, "whatsapp_62811000111"
+            mock_orchestrator, "whatsapp_62811000111"
         )
 
         with (
@@ -961,10 +998,65 @@ class TestWaTrustedProfileRouterWiring:
                 current_user=internal_user,
                 orchestrator=mock_orchestrator,
                 db_pool=None,
+                is_wa_inbox_bot=True,
             )
 
         _, call_kwargs = mock_orchestrator.process_query.call_args
         assert call_kwargs.get("profile") == {"role": "creator"}
+
+    @pytest.mark.asyncio
+    async def test_shared_internal_key_alone_without_bot_key_gets_no_profile(
+        self, mock_orchestrator
+    ):
+        """Guilt (the actual vulnerability this hardening closes): a caller
+        with the SHARED `role=="internal"` identity but WITHOUT the
+        dedicated bot key (`is_wa_inbox_bot=False`) — even sending the
+        exact owner-phone-shaped `user_id` a real attacker would use — gets
+        no profile at all."""
+        internal_user = {
+            "role": "internal",
+            "email": "wa-mirror-internal@balizero.com",
+            "user_id": "wa-mirror-internal",
+        }
+        request_data, mock_ab_manager = self._base_kwargs(
+            mock_orchestrator, "whatsapp_62811000111"
+        )
+        mock_resolve = AsyncMock(return_value={"role": "owner"})
+
+        with (
+            patch(
+                "backend.app.routers.agentic_rag.get_current_user",
+                return_value=internal_user,
+            ),
+            patch(
+                "backend.app.routers.agentic_rag.get_orchestrator",
+                return_value=mock_orchestrator,
+            ),
+            patch(
+                "backend.app.routers.agentic_rag.get_optional_database_pool",
+                return_value=None,
+            ),
+            patch(
+                "backend.app.routers.agentic_rag.get_ab_test_manager",
+                return_value=mock_ab_manager,
+            ),
+            patch(
+                "backend.app.routers.agentic_rag.resolve_sender_identity", new=mock_resolve
+            ),
+        ):
+            from backend.app.routers.agentic_rag import query_agentic_rag
+
+            await query_agentic_rag(
+                request=request_data,
+                current_user=internal_user,
+                orchestrator=mock_orchestrator,
+                db_pool=None,
+                is_wa_inbox_bot=False,
+            )
+
+        _, call_kwargs = mock_orchestrator.process_query.call_args
+        assert "profile" not in call_kwargs
+        mock_resolve.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_client_phone_no_profile_reaches_orchestrator(self, mock_orchestrator):
@@ -973,7 +1065,7 @@ class TestWaTrustedProfileRouterWiring:
         orchestrator, matching the pre-identity-wiring shape."""
         internal_user = {"role": "internal", "email": "wa-mirror-internal@balizero.com"}
         request_data, mock_ab_manager = self._base_kwargs(
-            mock_orchestrator, internal_user, "whatsapp_62899999999"
+            mock_orchestrator, "whatsapp_62899999999"
         )
 
         with (
@@ -1005,6 +1097,7 @@ class TestWaTrustedProfileRouterWiring:
                 current_user=internal_user,
                 orchestrator=mock_orchestrator,
                 db_pool=None,
+                is_wa_inbox_bot=True,
             )
 
         _, call_kwargs = mock_orchestrator.process_query.call_args

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_agentic_rag_router.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_agentic_rag_router.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException, Request
+from fastapi import Request
 
 backend_path = Path(__file__).parent.parent.parent.parent.parent / "backend"
 if str(backend_path) not in sys.path:
@@ -762,20 +762,156 @@ class TestAgenticQueryResponse:
                 get_optional_database_pool(mock_request)
 
 
-class TestProfileFieldPrivilegeGuard:
-    """Adversarial-review fix (2026-07-20, hardened same day after an
-    independent cross-check — see spec `## Adversarial review`): `request.
-    profile` must only be honored for the WA bot's own server-to-server hop
-    — `role="internal"` AND `channel="whatsapp"` — never for an arbitrary/
-    anonymous caller, and never for any OTHER holder of the shared
-    `X-Internal-Key` (it is not exclusive to the WA bot — see
-    `_is_trusted_wa_profile_caller` docstring). An untrusted attempt to set
-    `profile` is now a hard 403, not a silent drop. See agentic_rag.py::
-    query_agentic_rag + `_is_trusted_wa_profile_caller`."""
+class TestExtractWhatsappPhone:
+    """Pure-function coverage for `_extract_whatsapp_phone` — the gate that
+    decides whether `_resolve_trusted_wa_profile` even attempts a DB lookup."""
+
+    def test_whatsapp_shaped_user_id_extracts_phone(self):
+        from backend.app.routers.agentic_rag import _extract_whatsapp_phone
+
+        assert _extract_whatsapp_phone("whatsapp_628123456789") == "628123456789"
+
+    def test_bare_shared_identity_is_not_whatsapp_shaped(self):
+        """Innocence: the shared pseudo-identity's own `user_id` value
+        must NOT itself parse as a phone."""
+        from backend.app.routers.agentic_rag import _extract_whatsapp_phone
+
+        assert _extract_whatsapp_phone("wa-mirror-internal") is None
+
+    def test_none_and_empty_user_id(self):
+        from backend.app.routers.agentic_rag import _extract_whatsapp_phone
+
+        assert _extract_whatsapp_phone(None) is None
+        assert _extract_whatsapp_phone("") is None
+        assert _extract_whatsapp_phone("whatsapp_") is None
+
+
+class TestResolveTrustedWaProfile:
+    """P0-ID containment (2026-07-24): replaces the old client-supplied
+    `profile` request field (removed — no longer exists on
+    `AgenticQueryRequest`) and its `_is_trusted_wa_profile_caller` gate
+    (a client-settable `channel` field was, per the spec's council audit,
+    forgeable by ANY holder of the shared `X-Internal-Key`, not just the
+    WA bot). The server now RE-DERIVES the sender's profile itself via
+    `resolve_sender_identity`, keyed on the phone embedded in `user_id`
+    (`whatsapp_<phone>`) — no request body field can influence the
+    outcome. See `agentic_rag.py::_resolve_trusted_wa_profile`."""
 
     @staticmethod
-    def _base_kwargs(mock_orchestrator, current_user, profile, channel="whatsapp"):
-        request_data = AgenticQueryRequest(query="Any question", channel=channel, profile=profile)
+    def _internal_user():
+        return {
+            "role": "internal",
+            "email": "wa-mirror-internal@balizero.com",
+            "user_id": "wa-mirror-internal",
+        }
+
+    @pytest.mark.asyncio
+    async def test_owner_phone_yields_creator_profile(self):
+        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
+
+        with patch(
+            "backend.app.routers.agentic_rag.resolve_sender_identity",
+            new=AsyncMock(return_value={"role": "owner"}),
+        ):
+            result = await _resolve_trusted_wa_profile(
+                self._internal_user(), "whatsapp_62811000111", None
+            )
+        assert result == {"role": "creator"}
+
+    @pytest.mark.asyncio
+    async def test_team_phone_yields_team_profile_with_name_and_email(self):
+        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
+
+        with patch(
+            "backend.app.routers.agentic_rag.resolve_sender_identity",
+            new=AsyncMock(
+                return_value={
+                    "role": "team",
+                    "team_member": "Ari",
+                    "team_member_email": "ari@balizero.com",
+                }
+            ),
+        ):
+            result = await _resolve_trusted_wa_profile(
+                self._internal_user(), "whatsapp_62811000222", None
+            )
+        assert result == {"role": "team", "name": "Ari", "email": "ari@balizero.com"}
+
+    @pytest.mark.asyncio
+    async def test_client_or_unknown_phone_yields_no_override(self):
+        """Innocence: a resolved client/unknown sender never gets a
+        privileged persona."""
+        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
+
+        for identity in ({"role": "client", "client_id": 1}, {"role": "unknown"}):
+            with patch(
+                "backend.app.routers.agentic_rag.resolve_sender_identity",
+                new=AsyncMock(return_value=identity),
+            ):
+                result = await _resolve_trusted_wa_profile(
+                    self._internal_user(), "whatsapp_62899999999", None
+                )
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_non_whatsapp_user_id_short_circuits_before_any_lookup(self):
+        """Innocence: even a fully-trusted internal caller gets no override
+        — and no DB lookup at all — when `user_id` isn't WA-shaped."""
+        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
+
+        mock_resolve = AsyncMock(return_value={"role": "owner"})
+        with patch(
+            "backend.app.routers.agentic_rag.resolve_sender_identity", new=mock_resolve
+        ):
+            result = await _resolve_trusted_wa_profile(
+                self._internal_user(), "wa-mirror-internal", None
+            )
+        assert result is None
+        mock_resolve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_regular_authenticated_user_gets_no_override(self):
+        """Guilt (the actual vulnerability this fix closes): a normal
+        logged-in/JWT caller cannot get a privileged persona merely by
+        having a WA-shaped `user_id` that resolves to the owner's phone —
+        only the shared internal identity is even considered, and no DB
+        lookup is attempted for anyone else."""
+        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
+
+        regular_user = {"email": "client@example.com", "user_id": "client-1"}
+        mock_resolve = AsyncMock(return_value={"role": "owner"})
+        with patch(
+            "backend.app.routers.agentic_rag.resolve_sender_identity", new=mock_resolve
+        ):
+            result = await _resolve_trusted_wa_profile(
+                regular_user, "whatsapp_62811000111", None
+            )
+        assert result is None
+        mock_resolve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_anonymous_caller_gets_no_override(self):
+        """Innocence: unauthenticated caller (current_user=None) — the
+        worst case for the escalation vector."""
+        from backend.app.routers.agentic_rag import _resolve_trusted_wa_profile
+
+        mock_resolve = AsyncMock(return_value={"role": "owner"})
+        with patch(
+            "backend.app.routers.agentic_rag.resolve_sender_identity", new=mock_resolve
+        ):
+            result = await _resolve_trusted_wa_profile(None, "whatsapp_62811000111", None)
+        assert result is None
+        mock_resolve.assert_not_awaited()
+
+
+class TestWaTrustedProfileRouterWiring:
+    """Router-level integration: `query_agentic_rag` must forward whatever
+    `_resolve_trusted_wa_profile` returns to the orchestrator as `profile`,
+    and the wire contract must no longer accept a client-declared one."""
+
+    @staticmethod
+    def _base_kwargs(mock_orchestrator, current_user, user_id, channel="whatsapp"):
+        request_data = AgenticQueryRequest(query="Any question", channel=channel, user_id=user_id)
         mock_ab_manager = MagicMock()
         mock_ab_manager.metrics_tracker = MagicMock()
         mock_ab_manager.metrics_tracker.record_query_metrics = AsyncMock()
@@ -784,21 +920,16 @@ class TestProfileFieldPrivilegeGuard:
         return request_data, mock_ab_manager
 
     @pytest.mark.asyncio
-    async def test_internal_role_on_whatsapp_channel_profile_is_forwarded(
-        self, mock_orchestrator
-    ):
-        """Guilt: the WA bot's internal-key pseudo-user (role='internal')
-        on channel='whatsapp' legitimately sets profile — it resolved
-        sender identity itself, out-of-band, against Postgres. Must reach
-        the orchestrator as a plain dict."""
+    async def test_owner_phone_profile_reaches_orchestrator(self, mock_orchestrator):
+        """Guilt: the WA bridge's shared internal identity + a phone that
+        resolves to 'owner' → creator profile forwarded to the orchestrator."""
         internal_user = {
             "role": "internal",
             "email": "wa-mirror-internal@balizero.com",
             "user_id": "wa-mirror-internal",
         }
-        profile = {"role": "team", "name": "Ari", "email": "ari@balizero.com"}
         request_data, mock_ab_manager = self._base_kwargs(
-            mock_orchestrator, internal_user, profile, channel="whatsapp"
+            mock_orchestrator, internal_user, "whatsapp_62811000111"
         )
 
         with (
@@ -817,6 +948,10 @@ class TestProfileFieldPrivilegeGuard:
             patch(
                 "backend.app.routers.agentic_rag.get_ab_test_manager",
                 return_value=mock_ab_manager,
+            ),
+            patch(
+                "backend.app.routers.agentic_rag.resolve_sender_identity",
+                new=AsyncMock(return_value={"role": "owner"}),
             ),
         ):
             from backend.app.routers.agentic_rag import query_agentic_rag
@@ -829,193 +964,16 @@ class TestProfileFieldPrivilegeGuard:
             )
 
         _, call_kwargs = mock_orchestrator.process_query.call_args
-        assert call_kwargs.get("profile") == profile
+        assert call_kwargs.get("profile") == {"role": "creator"}
 
     @pytest.mark.asyncio
-    async def test_admin_role_profile_is_rejected(self, mock_orchestrator):
-        """Guilt (hardened 2026-07-20): an admin caller (X-Debug-Key) is
-        NOT trusted for profile override — no shipped caller needs it, and
-        least-privilege beats convenience for a persona-escalation vector.
-        Must 403, never reach the orchestrator."""
-        admin_user = {"role": "admin", "email": "admin@internal", "user_id": "admin"}
-        profile = {"role": "creator"}
-        request_data, mock_ab_manager = self._base_kwargs(
-            mock_orchestrator, admin_user, profile, channel="whatsapp"
-        )
-
-        with (
-            patch(
-                "backend.app.routers.agentic_rag.get_current_user",
-                return_value=admin_user,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_orchestrator",
-                return_value=mock_orchestrator,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_optional_database_pool",
-                return_value=None,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_ab_test_manager",
-                return_value=mock_ab_manager,
-            ),
-        ):
-            from backend.app.routers.agentic_rag import query_agentic_rag
-
-            with pytest.raises(HTTPException) as exc_info:
-                await query_agentic_rag(
-                    request=request_data,
-                    current_user=admin_user,
-                    orchestrator=mock_orchestrator,
-                    db_pool=None,
-                )
-
-        assert exc_info.value.status_code == 403
-        mock_orchestrator.process_query.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_internal_role_off_whatsapp_channel_is_rejected(self, mock_orchestrator):
-        """Guilt (the exact gap the independent cross-check found): the
-        shared `X-Internal-Key` also authenticates OTHER Pro-side scripts
-        (e.g. wa-mirror-auto-promote-leads) that get the identical
-        role='internal' pseudo-identity but are not the WA bot resolving a
-        real sender. Without the channel pin, any of those could set
-        profile freely. Same internal_user as the trusted test, but
-        channel != 'whatsapp' -> must 403."""
-        internal_user = {
-            "role": "internal",
-            "email": "wa-mirror-internal@balizero.com",
-            "user_id": "wa-mirror-internal",
-        }
-        profile = {"role": "team", "email": "victim@balizero.com"}
-        request_data, mock_ab_manager = self._base_kwargs(
-            mock_orchestrator, internal_user, profile, channel="website"
-        )
-
-        with (
-            patch(
-                "backend.app.routers.agentic_rag.get_current_user",
-                return_value=internal_user,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_orchestrator",
-                return_value=mock_orchestrator,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_optional_database_pool",
-                return_value=None,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_ab_test_manager",
-                return_value=mock_ab_manager,
-            ),
-        ):
-            from backend.app.routers.agentic_rag import query_agentic_rag
-
-            with pytest.raises(HTTPException) as exc_info:
-                await query_agentic_rag(
-                    request=request_data,
-                    current_user=internal_user,
-                    orchestrator=mock_orchestrator,
-                    db_pool=None,
-                )
-
-        assert exc_info.value.status_code == 403
-        mock_orchestrator.process_query.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_regular_authenticated_user_profile_is_rejected(self, mock_orchestrator):
-        """Innocence (the actual vulnerability this fix closes): a normal
-        logged-in client cannot self-declare role='creator'/'team' by
-        putting it in the request body — must 403, never reach the
-        orchestrator/persona layer."""
-        regular_user = {"email": "client@example.com", "user_id": "client-1"}
-        profile = {"role": "creator"}  # attempted escalation
-        request_data, mock_ab_manager = self._base_kwargs(
-            mock_orchestrator, regular_user, profile, channel="whatsapp"
-        )
-
-        with (
-            patch(
-                "backend.app.routers.agentic_rag.get_current_user",
-                return_value=regular_user,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_orchestrator",
-                return_value=mock_orchestrator,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_optional_database_pool",
-                return_value=None,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_ab_test_manager",
-                return_value=mock_ab_manager,
-            ),
-        ):
-            from backend.app.routers.agentic_rag import query_agentic_rag
-
-            with pytest.raises(HTTPException) as exc_info:
-                await query_agentic_rag(
-                    request=request_data,
-                    current_user=regular_user,
-                    orchestrator=mock_orchestrator,
-                    db_pool=None,
-                )
-
-        assert exc_info.value.status_code == 403
-        mock_orchestrator.process_query.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_anonymous_caller_profile_is_rejected(self, mock_orchestrator):
-        """Innocence: an unauthenticated caller (current_user=None) — the
-        worst case for the escalation vector — must also 403."""
-        profile = {"role": "team"}  # attempted escalation
-        request_data, mock_ab_manager = self._base_kwargs(
-            mock_orchestrator, None, profile, channel="whatsapp"
-        )
-
-        with (
-            patch(
-                "backend.app.routers.agentic_rag.get_current_user",
-                return_value=None,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_orchestrator",
-                return_value=mock_orchestrator,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_optional_database_pool",
-                return_value=None,
-            ),
-            patch(
-                "backend.app.routers.agentic_rag.get_ab_test_manager",
-                return_value=mock_ab_manager,
-            ),
-        ):
-            from backend.app.routers.agentic_rag import query_agentic_rag
-
-            with pytest.raises(HTTPException) as exc_info:
-                await query_agentic_rag(
-                    request=request_data,
-                    current_user=None,
-                    orchestrator=mock_orchestrator,
-                    db_pool=None,
-                )
-
-        assert exc_info.value.status_code == 403
-        mock_orchestrator.process_query.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_no_profile_in_request_is_still_a_no_op(self, mock_orchestrator):
-        """Innocence: the pre-existing, non-WA callers (profile absent
-        entirely) must remain completely unaffected by this guard —
-        including on channels/roles that would otherwise fail the
-        trust check, since the check is only reached when profile is set."""
+    async def test_client_phone_no_profile_reaches_orchestrator(self, mock_orchestrator):
+        """Innocence: a resolved client/unknown sender's request is
+        completely unaffected — no `profile` key at all reaches the
+        orchestrator, matching the pre-identity-wiring shape."""
         internal_user = {"role": "internal", "email": "wa-mirror-internal@balizero.com"}
         request_data, mock_ab_manager = self._base_kwargs(
-            mock_orchestrator, internal_user, None, channel="website"
+            mock_orchestrator, internal_user, "whatsapp_62899999999"
         )
 
         with (
@@ -1034,6 +992,10 @@ class TestProfileFieldPrivilegeGuard:
             patch(
                 "backend.app.routers.agentic_rag.get_ab_test_manager",
                 return_value=mock_ab_manager,
+            ),
+            patch(
+                "backend.app.routers.agentic_rag.resolve_sender_identity",
+                new=AsyncMock(return_value={"role": "unknown"}),
             ),
         ):
             from backend.app.routers.agentic_rag import query_agentic_rag
@@ -1048,27 +1010,14 @@ class TestProfileFieldPrivilegeGuard:
         _, call_kwargs = mock_orchestrator.process_query.call_args
         assert "profile" not in call_kwargs
 
-    def test_profile_schema_rejects_unknown_fields(self):
-        """Guilt: `InternalSenderProfile` is a closed schema (`extra=
-        "forbid"`) — the transport cannot be used to smuggle an unreviewed
-        field (e.g. a future `permissions`/`is_admin` key) past validation,
-        even before the route-level trust check runs."""
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            AgenticQueryRequest(
-                query="test",
-                channel="whatsapp",
-                profile={"role": "team", "permissions": ["all"]},
-            )
-
-    def test_profile_schema_rejects_unknown_role(self):
-        """Guilt: `role` is a closed Literal — cannot be e.g. 'admin'."""
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            AgenticQueryRequest(
-                query="test",
-                channel="whatsapp",
-                profile={"role": "admin"},
-            )
+    def test_request_schema_has_no_client_declarable_profile_field(self):
+        """Guilt: the old client-declared `profile` field is gone from the
+        wire contract entirely — Pydantic silently drops an unknown
+        `profile` key (default `extra="ignore"`), it can never reach the
+        model, let alone influence identity."""
+        req = AgenticQueryRequest(
+            query="test",
+            channel="whatsapp",
+            **{"profile": {"role": "creator"}},
+        )
+        assert not hasattr(req, "profile")

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_tool_executor.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_tool_executor.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.services.rag.agentic.tool_executor import (
+    _strip_reserved_args,
     execute_tool,
     parse_native_function_call,
     parse_tool_call,
@@ -377,6 +378,97 @@ class TestExecuteTool:
 
         call_kwargs = execute_spy.call_args[1]
         assert "_caller_profile" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_llm_injected_caller_profile_is_stripped_when_server_has_none(self):
+        """P0-ARG containment (2026-07-24), guilt: an LLM-supplied
+        `_caller_profile` (attacker-steerable via prompt injection in the
+        conversation, simulating a client/unknown caller trying to smuggle
+        a privileged persona into a tool call) must NOT survive to
+        `tool.execute` just because the server itself has no profile to
+        inject. Before the fix, `if caller_profile:` being falsy meant the
+        injected key was never overwritten — it passed straight through."""
+        tool = MockTool("test_tool")
+        tool_map = {"test_tool": tool}
+        execute_spy = AsyncMock(return_value="success")
+        tool.execute = execute_spy
+
+        forged_args = {
+            "arg1": "value1",
+            "_caller_profile": {"role": "creator"},
+        }
+        await execute_tool(tool_map, "test_tool", forged_args, caller_profile=None)
+
+        call_kwargs = execute_spy.call_args[1]
+        assert call_kwargs["arg1"] == "value1"
+        assert "_caller_profile" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_llm_injected_user_id_is_stripped_when_server_has_none(self):
+        """P0-ARG containment: same class of bug, `_user_id` variant."""
+        tool = MockTool("test_tool")
+        tool_map = {"test_tool": tool}
+        execute_spy = AsyncMock(return_value="success")
+        tool.execute = execute_spy
+
+        forged_args = {"arg1": "value1", "_user_id": "zero@balizero.com"}
+        await execute_tool(tool_map, "test_tool", forged_args, user_id=None)
+
+        call_kwargs = execute_spy.call_args[1]
+        assert "_user_id" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_server_profile_always_wins_over_llm_forged_one(self):
+        """P0-ARG containment, guilt: even when the LLM's `arguments` dict
+        carries its OWN `_caller_profile` (attempted escalation) AND the
+        server has a real one to inject (e.g. a genuine team member's
+        request), the server's value must be what reaches the tool —
+        never the forged one, and never a merge of both."""
+        tool = MockTool("test_tool")
+        tool_map = {"test_tool": tool}
+        execute_spy = AsyncMock(return_value="success")
+        tool.execute = execute_spy
+
+        forged_args = {"arg1": "value1", "_caller_profile": {"role": "creator"}}
+        real_profile = {"role": "team", "email": "member@balizero.com"}
+        await execute_tool(
+            tool_map, "test_tool", forged_args, caller_profile=real_profile
+        )
+
+        call_kwargs = execute_spy.call_args[1]
+        assert call_kwargs["_caller_profile"] == real_profile
+
+    @pytest.mark.asyncio
+    async def test_innocence_normal_args_survive_the_strip(self):
+        """Innocence: ordinary, non-reserved argument names (no leading
+        underscore) are never touched by the P0-ARG strip."""
+        tool = MockTool("test_tool")
+        tool_map = {"test_tool": tool}
+        execute_spy = AsyncMock(return_value="success")
+        tool.execute = execute_spy
+
+        await execute_tool(
+            tool_map,
+            "test_tool",
+            {"client_id": 42, "query": "quanto costa un KITAS?"},
+        )
+
+        call_kwargs = execute_spy.call_args[1]
+        assert call_kwargs["client_id"] == 42
+        assert call_kwargs["query"] == "quanto costa un KITAS?"
+
+    def test_strip_reserved_args_pure_function(self):
+        """Direct unit coverage of the helper: strips every leading-
+        underscore key, leaves everything else untouched."""
+        result = _strip_reserved_args(
+            {
+                "client_id": 1,
+                "_user_id": "forged",
+                "_caller_profile": {"role": "creator"},
+                "_anything_else_reserved_shaped": "x",
+            }
+        )
+        assert result == {"client_id": 1}
 
     @pytest.mark.asyncio
     async def test_value_error_handling(self):

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
@@ -33,6 +33,7 @@ class _Conn:
         self._rows = rows
         self._fetchrow_result = fetchrow_result
         self._fetchrow_error = fetchrow_error
+        self.fetchrow_calls = 0
 
     async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
         return self._rows
@@ -42,6 +43,7 @@ class _Conn:
         # No table-routing needed here — these tests either want "no match"
         # (default None, both lookups miss → role=unknown) or "DB down"
         # (fetchrow_error, raised on the first lookup it makes).
+        self.fetchrow_calls += 1
         if self._fetchrow_error is not None:
             raise self._fetchrow_error
         return self._fetchrow_result
@@ -288,103 +290,66 @@ async def test_bot_generation_semaphore_bounds_concurrent_rag_calls(monkeypatch)
     assert client.post.await_count == 5
 
 
-# ── Team-assistant V1: sender-identity → RAG `profile` field ──────────────
-# Runs the REAL resolve_sender_identity (not mocked) end-to-end through
-# generate_bot_reply — only the RAG POST is mocked. Innocence contract:
-# client/unknown/db-down payloads stay byte-identical to the
-# pre-identity-wiring shape (no "profile" key at all). Guilt: a resolved
-# owner/team sender's payload carries an explicit `profile`.
+# ── P0-ID containment (2026-07-24): no client-side profile field anymore ──
+# Team-assistant V1 (2026-07-19) used to resolve the sender's identity HERE
+# and forward it as an explicit `profile` request field. That mechanism was
+# removed: the RAG router now re-derives the same identity server-side
+# (`agentic_rag.py::_resolve_trusted_wa_profile`) from `user_id`, so a
+# client-declared `profile` can never be forged. These tests assert the new
+# innocence contract: `generate_bot_reply`'s payload NEVER carries a
+# `profile` key, and NEVER calls a DB-backed identity lookup of its own,
+# regardless of whether the sender is owner/team/client/unknown or the DB
+# is down — that work is no longer this function's job.
 
 
 @pytest.mark.asyncio
-async def test_owner_number_adds_creator_profile(monkeypatch):
+@pytest.mark.parametrize(
+    ("owner_env", "team_env", "fetchrow_result", "fetchrow_error", "phone"),
+    [
+        pytest.param("62811000111", None, None, None, "62811000111", id="owner"),
+        pytest.param(
+            None, "62811000222:Test Member Alpha", None, None, "62811000222", id="team-env"
+        ),
+        pytest.param(
+            None,
+            None,
+            {"id": "tm-1", "display_name": "Test Member Beta", "email": "beta@balizero.com"},
+            None,
+            "62811000333",
+            id="team-db",
+        ),
+        pytest.param(None, None, None, None, "62899999999", id="unknown"),
+        pytest.param(
+            None,
+            None,
+            None,
+            asyncpg.PostgresError("db down"),
+            "62899999999",
+            id="db-down",
+        ),
+    ],
+)
+async def test_payload_never_carries_a_profile_key(
+    monkeypatch, owner_env, team_env, fetchrow_result, fetchrow_error, phone
+):
     monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
-    monkeypatch.setenv("WHATSAPP_OWNER_NUMBERS", "62811000111")
-    monkeypatch.delenv("WHATSAPP_TEAM_NUMBERS", raising=False)
+    if owner_env:
+        monkeypatch.setenv("WHATSAPP_OWNER_NUMBERS", owner_env)
+    else:
+        monkeypatch.delenv("WHATSAPP_OWNER_NUMBERS", raising=False)
+    if team_env:
+        monkeypatch.setenv("WHATSAPP_TEAM_NUMBERS", team_env)
+    else:
+        monkeypatch.delenv("WHATSAPP_TEAM_NUMBERS", raising=False)
     captured = _mock_rag(monkeypatch, {"abstain": False, "answer": "ok"})
-    pool = _Pool(_ROWS_NEWEST_FIRST)  # env resolves before any DB lookup
+    pool = _Pool(_ROWS_NEWEST_FIRST, fetchrow_result=fetchrow_result, fetchrow_error=fetchrow_error)
 
-    await wa_inbox_bot.generate_bot_reply(pool, _thread(phone="62811000111"))
-
-    assert captured["json"]["profile"] == {"role": "creator"}
-
-
-@pytest.mark.asyncio
-async def test_team_env_number_adds_team_profile(monkeypatch):
-    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
-    monkeypatch.delenv("WHATSAPP_OWNER_NUMBERS", raising=False)
-    monkeypatch.setenv("WHATSAPP_TEAM_NUMBERS", "62811000222:Test Member Alpha")
-    captured = _mock_rag(monkeypatch, {"abstain": False, "answer": "ok"})
-    pool = _Pool(_ROWS_NEWEST_FIRST)
-
-    await wa_inbox_bot.generate_bot_reply(pool, _thread(phone="62811000222"))
-
-    assert captured["json"]["profile"] == {"role": "team", "name": "Test Member Alpha"}
-
-
-@pytest.mark.asyncio
-async def test_team_db_hit_adds_team_profile_with_email(monkeypatch):
-    """DB-resolved team hit (no env override) must include email in profile."""
-    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
-    monkeypatch.delenv("WHATSAPP_OWNER_NUMBERS", raising=False)
-    monkeypatch.delenv("WHATSAPP_TEAM_NUMBERS", raising=False)
-    captured = _mock_rag(monkeypatch, {"abstain": False, "answer": "ok"})
-    pool = _Pool(
-        _ROWS_NEWEST_FIRST,
-        fetchrow_result={
-            "id": "tm-1",
-            "display_name": "Test Member Beta",
-            "email": "beta.tester@balizero.com",
-        },
-    )
-
-    await wa_inbox_bot.generate_bot_reply(pool, _thread(phone="62811000333"))
-
-    assert captured["json"]["profile"] == {
-        "role": "team",
-        "name": "Test Member Beta",
-        "email": "beta.tester@balizero.com",
-    }
-
-
-@pytest.mark.asyncio
-async def test_client_and_unknown_payload_has_no_profile_key(monkeypatch):
-    """Innocence contract: no owner/team match → payload identical to the
-    pre-identity-wiring shape (no 'profile' key at all)."""
-    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
-    monkeypatch.delenv("WHATSAPP_OWNER_NUMBERS", raising=False)
-    monkeypatch.delenv("WHATSAPP_TEAM_NUMBERS", raising=False)
-    captured = _mock_rag(monkeypatch, {"abstain": False, "answer": "ok"})
-    pool = _Pool(_ROWS_NEWEST_FIRST)  # fetchrow_result=None → both lookups miss
-
-    await wa_inbox_bot.generate_bot_reply(pool, _thread(phone="62899999999"))
+    await wa_inbox_bot.generate_bot_reply(pool, _thread(phone=phone))
 
     sent = captured["json"]
     assert "profile" not in sent
-    assert sent == {
-        "query": "Quanto costa un KITAS?",
-        "user_id": "whatsapp_62899999999",
-        "session_id": "wa_meta_session_7",
-        "conversation_history": [
-            {"role": "user", "content": "Ciao"},
-            {"role": "assistant", "content": "Ciao! Come posso aiutarti?"},
-        ],
-        "channel": "whatsapp",
-        "max_steps": 2,
-    }
-
-
-@pytest.mark.asyncio
-async def test_identity_db_down_fails_safe_no_profile_key(monkeypatch):
-    """resolve_sender_identity fails safe to 'unknown' on a DB error — the
-    payload must stay identical, not raise, not guess a profile."""
-    monkeypatch.setenv("WA_INBOX_BOT_AUTOREPLY", "true")
-    monkeypatch.delenv("WHATSAPP_OWNER_NUMBERS", raising=False)
-    monkeypatch.delenv("WHATSAPP_TEAM_NUMBERS", raising=False)
-    captured = _mock_rag(monkeypatch, {"abstain": False, "answer": "ok"})
-    pool = _Pool(_ROWS_NEWEST_FIRST, fetchrow_error=asyncpg.PostgresError("db down"))
-
-    answer = await wa_inbox_bot.generate_bot_reply(pool, _thread(phone="62899999999"))
-
-    assert answer == "ok"
-    assert "profile" not in captured["json"]
+    # fetchrow (team/client DB lookups) would only ever fire from a local
+    # identity resolution — asserting it was never called proves the
+    # function truly stopped resolving identity itself, not just that it
+    # happened to drop the key afterward.
+    assert pool._conn.fetchrow_calls == 0

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_inbox_bot.py
@@ -182,27 +182,59 @@ async def test_escalate_marker_stripped(monkeypatch):
 
 def test_rag_client_headers_sends_internal_key_when_configured(monkeypatch):
     monkeypatch.setattr(wa_inbox_bot.settings, "wa_mirror_internal_key", "secret-xyz")
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_inbox_bot_profile_key", None)
     headers = wa_inbox_bot._rag_client_headers()
     assert headers == {"X-Internal-Key": "secret-xyz"}
 
 
 def test_rag_client_headers_omits_internal_key_and_warns_when_unset(monkeypatch, caplog):
     monkeypatch.setattr(wa_inbox_bot.settings, "wa_mirror_internal_key", None)
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_inbox_bot_profile_key", None)
     with caplog.at_level("WARNING"):
         headers = wa_inbox_bot._rag_client_headers()
     assert headers == {}
     assert any("WA_MIRROR_INTERNAL_KEY not configured" in r.message for r in caplog.records)
 
 
+# ── P0-ID hardening: dedicated X-WA-Bot-Profile-Key (2026-07-24) ──
+# Distinct from X-Internal-Key by design — see agentic_rag.py's
+# `_verify_wa_inbox_bot_profile_key` for why the shared internal key alone
+# was not enough to gate persona-override resolution safely.
+
+
+def test_rag_client_headers_sends_both_keys_when_both_configured(monkeypatch):
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_mirror_internal_key", "secret-xyz")
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_inbox_bot_profile_key", "bot-only-secret")
+    headers = wa_inbox_bot._rag_client_headers()
+    assert headers == {
+        "X-Internal-Key": "secret-xyz",
+        "X-WA-Bot-Profile-Key": "bot-only-secret",
+    }
+
+
+def test_rag_client_headers_omits_profile_key_and_warns_when_unset(monkeypatch, caplog):
+    """Innocence: an unset profile key degrades gracefully — the query
+    itself must still be sent (X-Internal-Key alone is enough for that),
+    only the persona-override channel is silently unavailable."""
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_mirror_internal_key", "secret-xyz")
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_inbox_bot_profile_key", None)
+    with caplog.at_level("WARNING"):
+        headers = wa_inbox_bot._rag_client_headers()
+    assert headers == {"X-Internal-Key": "secret-xyz"}
+    assert any("WA_INBOX_BOT_PROFILE_KEY not configured" in r.message for r in caplog.records)
+
+
 @pytest.mark.asyncio
 async def test_get_rag_client_applies_internal_key_header(monkeypatch):
-    """End-to-end: the cached client carries the X-Internal-Key header."""
+    """End-to-end: the cached client carries both service-auth headers."""
     monkeypatch.setattr(wa_inbox_bot, "_rag_client", None)
     monkeypatch.setattr(wa_inbox_bot.settings, "wa_mirror_internal_key", "secret-xyz")
+    monkeypatch.setattr(wa_inbox_bot.settings, "wa_inbox_bot_profile_key", "bot-only-secret")
     monkeypatch.setattr(wa_inbox_bot, "get_rag_worker_url", lambda: "http://rag.internal:8080")
     client = await wa_inbox_bot._get_rag_client()
     try:
         assert client.headers.get("x-internal-key") == "secret-xyz"
+        assert client.headers.get("x-wa-bot-profile-key") == "bot-only-secret"
     finally:
         await client.aclose()
         wa_inbox_bot._rag_client = None


### PR DESCRIPTION
## Summary

Two P0 containment items from the Zantara-bot W-1 workstream (spec: `research/operations/2026-07-24-zantara-bot-consultant-assistant-spec.md`, PR #3031):

- **P0-ID** — the WhatsApp inbox bot's privileged "creator/team" persona override was forgeable. It used to trust a client-supplied `profile`/`channel` request field outright. A first server-side fix (commit `4e43df972f`) re-resolved the phone server-side but keyed trust off the shared `X-Internal-Key` + a client-controlled `user_id` body field — an independent adversarial review found this still forgeable: any caller holding that widely-shared key could send `user_id="whatsapp_<owner's publicly documented WA number>"` and get the creator override. This PR (commit `314e01f405`) replaces that with a **dedicated secret exclusive to `wa_inbox_bot.py`** (`X-WA-Bot-Profile-Key` / `WA_INBOX_BOT_PROFILE_KEY`), modeled on the existing `wa_mirror_crm_write_key`/`X-CRM-Write-Key` precedent in this codebase for exactly this class of problem. The override now requires BOTH the dedicated key AND `resolve_sender_identity()` resolving the phone to owner/team — fails closed if the secret is unconfigured.
- **P0-ARG** — `tool_executor.execute_tool` could have LLM-supplied tool-call arguments (`_caller_profile`, `_user_id`) survive to `tool.execute(**arguments)` if the server had nothing of its own to overwrite them with. Fixed via `_strip_reserved_args()`, called before the RBAC authorizer sees `arguments` and again immediately before the trusted re-injection.

## Review

Two independent adversarial reviews (generator≠grader, per the spec's AUTO-MERGE-OFF requirement for this change class):
1. First review found the v1 P0-ID design insufficient (see above) — corrected.
2. Second review (fresh context, this PR's actual diff) verdict: **SHIP**. Verified: single writer/reader of the new header, genuinely distinct config field, strict AND-gate with no fallback, fail-safe `resolve_sender_identity`, no other code path sets `profile` (and `stream_query`/`/stream`+`/workspace-stream` structurally cannot carry it — no `profile` param exists there at all), and test coverage directly targeting the historical exploit payload.

I independently re-verified the load-bearing claims from both reviews against the actual files in this turn (not trusting the reviewer's report alone), per the repo's anti-hallucination discipline.

## Test plan

- [x] `test_agentic_rag_router.py` — new `TestExtractWhatsappPhone`, `TestResolveTrustedWaProfile`, `TestVerifyWaInboxBotProfileKey`, `TestWaTrustedProfileRouterWiring` (incl. guilt tests replaying the exact v1 exploit payload, asserting no override + `resolve_sender_identity` never called)
- [x] `test_tool_executor.py` — new tests proving LLM-forged `_caller_profile`/`_user_id` are stripped and the server's real profile always wins
- [x] `test_wa_inbox_bot.py` — parametrized test proving no client-side profile resolution happens anymore (redundant DB round-trip removed) + header-sending tests for both secrets
- [x] ruff clean on all 5 touched files
- [x] import chain check (`from backend.app.dependencies import get_current_user`) OK
- [x] Full backend suite green in pre-push (2 pre-existing order-dependent flakes reproduced identically in isolation — unrelated to this diff, not touched)
- [ ] Deploy + PROVE-LIVE (post-merge, this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>