### PR TITLE
fix(ci): hot-zone gate read a two-dot diff and false-blocked innocent PRs

### DIFF
--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -76,7 +76,38 @@ jobs:
           fetch-depth: 0
 
       # ---------------------------------------------------------------------
+      # Step 1bis — Self-test the changed-file enumerator (guilt + innocence)
+      #
+      # The gate's rules were never the weak part — its INPUT was. Run the
+      # corpus on every PR so the enumerator can never regress to a proxy that
+      # lies about what the branch authored (scar 2026-07-24, PR #3057).
+      # ---------------------------------------------------------------------
+      #
+      # NB: this job checks out the BASE ref (main), never PR head — so the
+      # `-f` guard below is a one-shot bootstrap window (main does not have the
+      # corpus until this very PR lands), NOT a disarm vector: once on main, a
+      # PR deleting the file cannot make the step skip, because the step reads
+      # main's copy.
+      - name: Self-test changed-file enumerator
+        if: steps.kill_switch.outputs.disabled != 'true'
+        continue-on-error: false
+        run: |
+          set -u
+          if [[ -f scripts/ci/test_hotzone_changed_files.sh ]]; then
+            bash scripts/ci/test_hotzone_changed_files.sh
+          else
+            echo "::notice::enumerator corpus not in base checkout yet (bootstrap run)"
+          fi
+
+      # ---------------------------------------------------------------------
       # Step 2 — Enumerate changed files (PR diff)
+      #
+      # Merge-base anchored (three-dot semantics) — what this branch AUTHORED,
+      # not how it differs from main's tip. A two-dot `git diff BASE HEAD` also
+      # lists everything main gained since the branch point, which on 2026-07-24
+      # made this gate hard-block PR #3057 (2 content MDX files) for "modifying
+      # .github/CODEOWNERS" it never touched. Rationale + fallbacks live in
+      # scripts/ci/hotzone_changed_files.sh.
       # ---------------------------------------------------------------------
       - name: Enumerate changed files
         if: steps.kill_switch.outputs.disabled != 'true'
@@ -84,18 +115,30 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -u
           echo "Base SHA: $BASE_SHA"
           echo "Head SHA: $HEAD_SHA"
 
-          git fetch --no-tags --depth=200 origin "$HEAD_SHA" 2>&1 | tail -5 || true
-
-          if ! git cat-file -e "$HEAD_SHA" 2>/dev/null; then
-            echo "::warning::HEAD SHA $HEAD_SHA not in fetched history — using merge-base fallback"
-            CHANGED=""
+          if [[ -f scripts/ci/hotzone_changed_files.sh ]]; then
+            if ! CHANGED=$(bash scripts/ci/hotzone_changed_files.sh \
+                             "$BASE_SHA" "$HEAD_SHA" "${PR_NUMBER:-}"); then
+              echo "::error::Could not determine the changed-file set — failing closed"
+              exit 1
+            fi
           else
-            CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>&1 || true)
+            # Bootstrap window only (base checkout predates the helper).
+            # Same semantics: merge-base anchored, fail-closed, never blind-empty.
+            git fetch --no-tags --depth=200 origin "$HEAD_SHA" >/dev/null 2>&1 || true
+            MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)
+            if [[ -z "$MERGE_BASE" ]]; then
+              echo "::error::merge-base unresolvable for $BASE_SHA..$HEAD_SHA — failing closed"
+              exit 1
+            fi
+            CHANGED=$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA")
           fi
 
           echo "--- Changed files ---"

--- a/scripts/ci/hotzone_changed_files.sh
+++ b/scripts/ci/hotzone_changed_files.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# hotzone_changed_files.sh — enumerate the files a PR *itself* changed.
+#
+# WHY THIS EXISTS (scar 2026-07-24, superscar #9 "il proxy mente sullo stato"):
+#   hot-zone-pr-gate.yml used `git diff --name-only "$BASE_SHA" "$HEAD_SHA"` —
+#   a TWO-DOT diff between the two tips. `github.event.pull_request.base.sha` is
+#   the CURRENT tip of main, so for any branch that is behind main the two-dot
+#   diff also lists, as "changed", every file MAIN gained since the branch point
+#   (in reverse). PR #3057 (2 content MDX files, author SubBZ2026) was therefore
+#   reported as touching `.github/CODEOWNERS` + 3 workflows + a migration, and the
+#   CODEOWNERS self-mod gate hard-blocked an innocent PR. The gate was not wrong
+#   about its rule — its INPUT was a lying proxy.
+#
+# THE FIX: anchor on the merge-base (three-dot semantics), which is exactly what
+#   GitHub's own "Files changed" tab shows: "what did this branch author since it
+#   diverged", never "how does this branch differ from main's tip".
+#
+#   NB for future readers: cicatrix W88 warns that `git diff main...branch` lies —
+#   that warning is about a DIFFERENT question ("is this content already on main
+#   after a squash?"), where the merge-base is stale by construction. Here the
+#   question is "what did this PR author?", and merge-base anchoring is the
+#   correct answer. Do not "fix" this back to two-dot.
+#
+# FAIL-LOUD, NEVER BLIND (superscar #2): if the merge-base cannot be resolved we
+#   deepen the fetch, then fall back to the PR files API, and only then exit
+#   non-zero. We never emit an empty list on failure — an empty list would make
+#   every downstream hot-zone check silently pass (a disarmed gate that still
+#   reports green).
+#
+# Usage:  hotzone_changed_files.sh <BASE_SHA> <HEAD_SHA> [PR_NUMBER]
+# Output: one path per line on stdout; diagnostics on stderr.
+# Exit:   0 = list produced (possibly empty because the PR is genuinely empty)
+#         3 = could not determine the changed set (caller MUST treat as failure)
+set -uo pipefail
+
+BASE_SHA="${1:-}"
+HEAD_SHA="${2:-}"
+PR_NUMBER="${3:-}"
+
+if [[ -z "$BASE_SHA" || -z "$HEAD_SHA" ]]; then
+  echo "hotzone_changed_files: BASE_SHA and HEAD_SHA are required" >&2
+  exit 3
+fi
+
+log() { echo "hotzone_changed_files: $*" >&2; }
+
+# --- 1. Make sure both endpoints are present locally ------------------------
+if ! git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
+  git fetch --no-tags --depth=200 origin "$HEAD_SHA" >/dev/null 2>&1 || true
+fi
+if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+  git fetch --no-tags origin "$BASE_SHA" >/dev/null 2>&1 || true
+fi
+
+# --- 2. Resolve the merge-base, deepening if the history is shallow ---------
+merge_base=""
+resolve_merge_base() {
+  git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null
+}
+merge_base="$(resolve_merge_base)"
+
+if [[ -z "$merge_base" ]]; then
+  log "merge-base not reachable — deepening history"
+  if [[ -f "$(git rev-parse --git-dir)/shallow" ]]; then
+    git fetch --unshallow --no-tags origin >/dev/null 2>&1 \
+      || git fetch --deepen=1000 --no-tags origin >/dev/null 2>&1 \
+      || true
+  else
+    git fetch --no-tags origin >/dev/null 2>&1 || true
+  fi
+  merge_base="$(resolve_merge_base)"
+fi
+
+# --- 3. Emit the branch-authored file set -----------------------------------
+if [[ -n "$merge_base" ]]; then
+  log "merge-base $merge_base (base $BASE_SHA, head $HEAD_SHA)"
+  git diff --name-only "$merge_base" "$HEAD_SHA"
+  exit 0
+fi
+
+# --- 4. Fallback: ask GitHub for the authoritative PR file list -------------
+if [[ -n "$PR_NUMBER" && -n "${GITHUB_REPOSITORY:-}" ]] && command -v gh >/dev/null 2>&1; then
+  log "merge-base unresolvable — falling back to PR files API for #$PR_NUMBER"
+  if api_out="$(gh api --paginate \
+        "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+        --jq '.[].filename' 2>/dev/null)"; then
+    printf '%s\n' "$api_out"
+    exit 0
+  fi
+  log "PR files API call failed"
+fi
+
+log "FATAL: cannot determine changed files — refusing to emit a blind-empty list"
+exit 3

--- a/scripts/ci/test_hotzone_changed_files.sh
+++ b/scripts/ci/test_hotzone_changed_files.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Guilt + innocence corpus for scripts/ci/hotzone_changed_files.sh
+# (superscar #3 antidote: "nessuna guardia mergiata senza un test di innocenza
+#  E di colpevolezza" — here the guard is the gate's INPUT, which is where the
+#  2026-07-24 false-block actually came from).
+#
+# GUILT     — a branch that really edits .github/CODEOWNERS is still reported.
+# INNOCENCE — a branch that edits only content, while MAIN moved ahead and
+#             touched .github/CODEOWNERS, is NOT reported as touching it.
+# SCAR-PIN  — the old two-dot implementation IS shown to fail the innocence case,
+#             so the test can never go vacuously green after a refactor.
+#
+# Runs in any POSIX-ish shell with git. No network, no fixtures on disk.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNDER_TEST="$SCRIPT_DIR/hotzone_changed_files.sh"
+FAILURES=0
+
+fail() { echo "  ✗ $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ✓ $*"; }
+
+if [[ ! -x "$UNDER_TEST" ]]; then
+  echo "FATAL: $UNDER_TEST missing or not executable"
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --------------------------------------------------------------- fixture repo
+# initial ──● main ──● (main edits CODEOWNERS: the "innocent bystander" commit)
+#            \
+#             ●  feature-content   (edits only an article)
+#             ●  feature-codeowners (edits CODEOWNERS for real)
+git init -q "$TMP/repo"
+cd "$TMP/repo"
+git config user.email test@example.com
+git config user.name "hotzone test"
+git config commit.gpgsign false
+
+mkdir -p .github apps/mouth/src/content/articles/tax
+printf 'apps/** @Balizero1987\n' > .github/CODEOWNERS
+printf 'original article\n' > apps/mouth/src/content/articles/tax/a.mdx
+git add -A && git commit -qm "initial"
+INITIAL="$(git rev-parse HEAD)"
+
+# main moves ahead and touches the hot-zone file
+printf 'apps/** @Balizero1987\ndocs/** @Balizero1987\n' > .github/CODEOWNERS
+git add -A && git commit -qm "main: extend CODEOWNERS"
+MAIN_TIP="$(git rev-parse HEAD)"
+
+# innocent branch, forked BEFORE main's CODEOWNERS commit
+git checkout -q -b feature-content "$INITIAL"
+printf 'corrected article\n' > apps/mouth/src/content/articles/tax/a.mdx
+git add -A && git commit -qm "content: fix article"
+CONTENT_HEAD="$(git rev-parse HEAD)"
+
+# guilty branch, also forked before, that really edits CODEOWNERS
+git checkout -q -b feature-codeowners "$INITIAL"
+printf 'apps/** @someone-else\n' > .github/CODEOWNERS
+git add -A && git commit -qm "chore: self-mod CODEOWNERS"
+CODEOWNERS_HEAD="$(git rev-parse HEAD)"
+
+git checkout -q "$MAIN_TIP"
+
+echo "TEST hotzone_changed_files.sh"
+
+# ------------------------------------------------------------------- GUILT
+out="$("$UNDER_TEST" "$MAIN_TIP" "$CODEOWNERS_HEAD" 2>/dev/null)"
+if grep -qx '\.github/CODEOWNERS' <<< "$out"; then
+  pass "guilt: real CODEOWNERS edit is reported"
+else
+  fail "guilt: real CODEOWNERS edit MISSED (output: ${out//$'\n'/, })"
+fi
+
+# --------------------------------------------------------------- INNOCENCE
+out="$("$UNDER_TEST" "$MAIN_TIP" "$CONTENT_HEAD" 2>/dev/null)"
+if grep -qx '\.github/CODEOWNERS' <<< "$out"; then
+  fail "innocence: content-only branch falsely reported as touching CODEOWNERS"
+else
+  pass "innocence: content-only branch behind main does not touch CODEOWNERS"
+fi
+if grep -qx 'apps/mouth/src/content/articles/tax/a\.mdx' <<< "$out"; then
+  pass "innocence: the branch's own file IS still reported"
+else
+  fail "innocence: the branch's own file went missing (output: ${out//$'\n'/, })"
+fi
+
+# ---------------------------------------------------------------- SCAR PIN
+# The pre-fix implementation must demonstrably fail the innocence case,
+# otherwise this test proves nothing.
+old_out="$(git diff --name-only "$MAIN_TIP" "$CONTENT_HEAD")"
+if grep -qx '\.github/CODEOWNERS' <<< "$old_out"; then
+  pass "scar-pin: the old two-dot diff DOES produce the false positive"
+else
+  fail "scar-pin: two-dot no longer reproduces the scar — test is vacuous, revisit it"
+fi
+
+# ------------------------------------------------------- FAIL-LOUD, NOT BLIND
+# An unresolvable pair must exit non-zero, never print an empty pass.
+if out="$("$UNDER_TEST" "$MAIN_TIP" 0000000000000000000000000000000000000000 2>/dev/null)"; then
+  fail "fail-loud: unresolvable head exited 0 (blind-empty pass) — output: '$out'"
+else
+  pass "fail-loud: unresolvable head exits non-zero instead of passing blind"
+fi
+
+echo
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "FAIL — $FAILURES assertion(s) failed"
+  exit 1
+fi
+echo "PASS — guilt + innocence + scar-pin + fail-loud"


### PR DESCRIPTION
## Insight

`hot-zone-pr-gate.yml`'s `Enumerate changed files` step compared the two tips —
`git diff --name-only "$BASE_SHA" "$HEAD_SHA"` — and `github.event.pull_request.base.sha`
is main's **current** tip. So for any branch that is behind main, the "changed" set also
contained, in reverse, every file **main** had gained since the branch point.

Live consequence today: **PR #3057** (author SubBZ2026) changes exactly 2 content MDX files,
yet this gate reported `.github/CODEOWNERS`, 3 workflows, a migration and 4 LaunchAgent
wrappers as touched, and the CODEOWNERS self-mod check hard-blocked it — `Hot-zone enforcement`
is a required check, so an innocent content PR was unmergeable. Evidence in job `89366521538`:

```
HOT-ZONE HIT: .github/CODEOWNERS
##[error]Non-owner actor SubBZ2026 modified .github/CODEOWNERS
```

The gate's *rule* was never wrong. Its **input** was a lying proxy — superscar #9
("un segnale di STATO letto da un proxy invece che dal CONTENUTO reale").

## Studio

- `scripts/ci/hotzone_changed_files.sh` — merge-base anchored enumeration (what the branch
  **authored**, i.e. GitHub's own "Files changed" semantics), with deepen + PR-files-API
  fallbacks and **fail-loud** on an unresolvable pair. It never emits a blind-empty list:
  an empty list would make every downstream hot-zone check silently pass — a disarmed gate
  still reporting green (superscar #2).
- `scripts/ci/test_hotzone_changed_files.sh` — guilt + innocence corpus (superscar #3):
  - **guilt**: a branch that really edits `.github/CODEOWNERS` is still reported;
  - **innocence**: a content-only branch behind a main that edited CODEOWNERS is not;
  - **scar-pin**: the old two-dot diff *does* reproduce the false positive, so the corpus
    can never go vacuously green after a refactor;
  - **fail-loud**: an unresolvable head exits non-zero instead of passing blind.
- The gate now **self-tests its own enumerator on every run**.

Note for future readers: cicatrix **W88** warns that `main...branch` lies — that is a
different question ("is this content already on main after a squash?"), where the merge-base
is stale by construction. Here the question is "what did this PR author?", and merge-base
anchoring is the correct answer. The script comment says so explicitly.

## Verification

- `bash scripts/ci/test_hotzone_changed_files.sh` → 5/5 locally (guilt, innocence ×2,
  scar-pin, fail-loud).
- `actionlint .github/workflows/hot-zone-pr-gate.yml` → clean.
- Empirical proof of the diagnosis: `gh pr update-branch 3057` (which makes the two-dot
  diff accidentally accurate again) flipped `Hot-zone enforcement` from FAILURE to SUCCESS
  with no content change to that PR.
- This PR's own hot-zone job runs the **bootstrap** branch of the step (the base checkout
  is main, which does not have the helper yet) — its `--- Changed files ---` block should
  list only the 3 files of this PR.

## Collateral finding (not fixed here)

The same step's Telegram alert answers `{"ok":false,"error_code":401,"description":"Unauthorized"}`
— the `TELEGRAM_BOT_TOKEN` Actions secret is dead, so a *real* CODEOWNERS self-mod would
block the PR but never reach Zero (superscar #2, esiste≠armato). Rotation is a credential
action, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
