### PR TITLE
docs(kbli): corner LIVE STATE — W1 public-surface honesty pass shipped + proven-live

### DIFF
--- a/.claude/skills/kbli-navigator/SKILL.md
+++ b/.claude/skills/kbli-navigator/SKILL.md
@@ -173,13 +173,18 @@ false-friends **49213, 51103, 51203, 20111, 50115, 60312, 64310**:
   estimate a risk tier by analogy).
 - **Surfaces 5 & 6 — `apps/kbli-navigator` (knowledge.balizero.com; it is a Next.js/Vercel+Netlify
   app, NOT the "native desktop app" §5 describes — mislabel found during Batch-B design work,
-  ALIGN-FLEET TODO):** (5) its `data/kbli-2025.json` was untracked in the 2026-03-28 cleanup and
-  rotted (1,563 records, zero quarantine markers, 68112 still MICE) — **cure lane in flight**,
-  branch `agent/air-m5/frontend/kbli-navigator-dataset-desync` (conductor-gated), re-tracking +
-  extending `scripts/sync_kbli_dataset.sh`/`check-kbli-dataset-sync`. (6)
-  `apps/kbli-navigator/lib/kbli-gold-content.ts` (~45K lines, hand-authored, separate from mouth
-  gold) OVERRIDES cured data on 68112/49213 pages (verified in built HTML) — **OPEN, queued, task
-  #19**.
+  ALIGN-FLEET TODO): BOTH CURED ON MAIN — re-verified on `origin/main` 2026-07-24, this entry
+  previously said otherwise and was STALE.** (5) `data/kbli-2025.json` now carries **1,559**
+  records (not the rotted 1,563) and 68112 reads correctly — residential title, `per_skala: []`,
+  `per_skala_disputed_pp28_mice` + `_l2_status` + `_data_note` markers present; the desync cure
+  landed. (6) `lib/kbli-gold-content.ts` no longer overrides the cure: its 68112 entry is the
+  honest-gap text that NAMES the collision ("code-number collision … MICE-venue rental … do not
+  apply to residential leasing and have been removed"), and 49213 correctly frames AKDP/AKAP as
+  the DIFFERENT regulatory basis it is excluded from. **Do NOT re-open these as work items.**
+  Residual on this app: it is **SSO-gated** (`/kbli/<code>` → 307 → `kita.balizero.com/login`),
+  so it is an INTERNAL/team surface, not an anonymous-public one — anonymous curl can never
+  prove-live it (cf. [[discovery_nuzantara_rag_401_precedes_routing_2026_07_22]]); a real
+  prove-live there needs authenticated browser QA.
 - **Mouth gold cure LIVE** (#2794): 10 gold records' detached-code echoes cured
   (whatYouNeed/zantaraOpener/baliContext), PROVE-LIVE on 68123/60103; 63-phantom triage table
   `scripts/kbli_gold_remap_table_status.json` (48 unmapped / 8 ambiguous-SPLIT / 7
@@ -481,8 +486,9 @@ corner (flagged only, nothing fixed here):**
    cured for the 73 quarantined rows by `kbli_documents_cure.py` (#2796, 2026-07-19), whole-table
    builder still missing (PENDING-ARMS)** · intel_2026/editorial → baked prose · `apps/kbli-navigator`
    app (knowledge.balizero.com — Next.js, NOT a native desktop app, see LIVE STATE) → its own
-   `data/kbli-2025.json` fork (stale, cure in flight) AND its own `lib/kbli-gold-content.ts`
-   override layer (OPEN, task #19) · NB sources. Fix the class across ALL consumers or explicitly
+   `data/kbli-2025.json` fork AND its own `lib/kbli-gold-content.ts` override layer (**both CURED
+   on main, re-verified 2026-07-24 — still consumers to check on every future cure, but not open
+   work items**) · NB sources. Fix the class across ALL consumers or explicitly
    park the rest; "merged" ≠ "live" ≠ "every surface".
 7. **Derived layers need invalidation**: after correcting any source fact, list which derived fields
    (gold whatYouNeed, editorial, l4_bali reason, KG properties, NB) were generated FROM it and

--- a/.claude/skills/kbli-navigator/SKILL.md
+++ b/.claude/skills/kbli-navigator/SKILL.md
@@ -67,6 +67,31 @@ landed ABOVE the existing override floors, so the floors aged out silently (W98 
 and fixed here (#3052); a parallel lane shipped the same cure with strictly higher floors first (#3053,
 `hono >=4.12.31`) so #3052 was closed as superseded — verified by CONTENT on main (W88), not by proxy.
 
+**4th-SURFACE LEAK FOUND & CURED IN PROD — 2026-07-24, same session, no PR needed (data-plane
+apply of already-merged cures).** Hunting for remaining W1-class public lies, a read-only census of
+`kbli_documents` against canonical found the Lot-8/Lot-9 cures had landed on canonical + KG + Qdrant
+but **skipped the 4th surface**: of the **217** codes whose canonical `per_skala` is `[]` (detached,
+licensing disputed/unverifiable), **18 still carried populated `per_skala` rows in `kbli_documents`**
+— which `chat_kbli` injects VERBATIM into the LLM context, i.e. the exact 50113 disease still live
+on WhatsApp/webchat. All 18 were the sport/klub cluster: `91425` + `93113/93115/93121/93122/93123/
+93124/93125/93126/93127/93128/93129/93192/93193/93194/93195/93197/93199`; none carried `_data_note`,
+confirming the cure had simply never been run for them.
+Cure: `kbli_documents_cure.py --only <18> --dataset <raw URL pinned to main SHA `5d689084d1`> --apply`,
+run on Fly (the dataset is NOT in the image — pass a **commit-pinned** raw URL, never a moving `main`).
+Dry-run first: 18/18 eligible, 0 skipped, all `[GAP]` class. All 18 verified eligible beforehand
+(`per_skala_disputed_pp28_collision` marker + `intel_2026.whatYouNeed` present) so the tool wrote only
+canonical-derived honest-gap prose — never an invented value (rule #9).
+**VERIFIED INDEPENDENTLY after apply** (re-read via the read-only role, not the tool's own report):
+the 18 → 0 licensing rows / 18 `_data_note`; forensic archive `kbli_documents_archive` captured 18
+pre-cure rows; and the **global** invariant now holds — **217 detached codes, 0 still serving
+licensing**. **PROVE-LIVE on the consuming surface**: `chat_kbli` for 93121 now answers _"the specific
+risk tier and exact licensing workflows … are currently unconfirmed … We do not estimate or guess risk
+tiers … verify directly at oss.go.id"_, and states the capital doctrine correctly (2.5bn paid-up +
+
+> 10bn investment, BKPM 5/2025 superseding 4/2021 — #2813's generation-layer fix confirmed working).
+> **Standing check for every future lot**: after a cure lands on canonical, re-run the
+> detached-vs-`kbli_documents` census — a lot can be "closed" on 3 surfaces and still lie on the 4th.
+
 **W1 is CLOSED. Next per the Codex program: W2 (Batch-B prep — still NO-GO without Zero) / W3+.**
 
 **Batch A CLOSED 2026-07-21 (114/114, 0 remaining)** — the full "A-serving" 114-code sweep
@@ -483,8 +508,9 @@ corner (flagged only, nothing fixed here):**
    **`kbli_documents` (Postgres) → `chat_kbli` LLM context via
    `_fetch_parent_documents_from_kbli_table()` + direct 5-digit lookup
    (`apps/backend-rag/backend/app/routers/kbli_notebook_chat.py:635,699`) — the 4th surface,
-   cured for the 73 quarantined rows by `kbli_documents_cure.py` (#2796, 2026-07-19), whole-table
-   builder still missing (PENDING-ARMS)** · intel_2026/editorial → baked prose · `apps/kbli-navigator`
+   cured by `kbli_documents_cure.py` (#2796, 2026-07-19) — and **RECONCILED 2026-07-24: all 217
+   canonical-detached codes now serve 0 licensing rows here (was 18 leaking, see LIVE STATE)**;
+   whole-table builder still missing (PENDING-ARMS)** · intel_2026/editorial → baked prose · `apps/kbli-navigator`
    app (knowledge.balizero.com — Next.js, NOT a native desktop app, see LIVE STATE) → its own
    `data/kbli-2025.json` fork AND its own `lib/kbli-gold-content.ts` override layer (**both CURED
    on main, re-verified 2026-07-24 — still consumers to check on every future cure, but not open

--- a/.claude/skills/kbli-navigator/SKILL.md
+++ b/.claude/skills/kbli-navigator/SKILL.md
@@ -26,7 +26,48 @@ pattern_, NOT the goal. The goal is a navigator where every rendered risk / lice
 fact is either government-sourced (with a citable locator + vintage) or an honest declared gap —
 zero silent cross-vintage fill anywhere in the catalog. §5 is the plan that gets us there.
 
-## 1. LIVE STATE (last update 2026-07-21 — keep current)
+## 1. LIVE STATE (last update 2026-07-24 — keep current)
+
+**W1 PUBLIC-SURFACE HONESTY PASS — SHIPPED & PROVEN-LIVE 2026-07-24 (PR #3049, squash `23fa765e61`).**
+Context: a Codex session (rollout `019f83fc`) had been conducting a 7-work-package program (W0→W7) to
+take the Navigator to BKPM-presentable. W0 (census/governance/role-contract) closed 2026-07-23; its W1
+commits were authored locally but **never survived** (worktree lost, no branch). Zero's read of that
+stretch — _"siamo da 10 giorni su W0"_ / _"molto controllo, zero miglioramenti visibili"_ — is the
+standing constraint on this program: **W1+ must produce visible product change, not more governance docs.**
+Reconciling W1's 5 declared targets against disk found only 2 real:
+
+- **`46100`** — FALSE ALARM. The batch-B design's own REV-2 self-correction (`d7d9486007`, "46100/52101
+  were not inconsistent") already retracted it; `52101`/`10433` were cured in #2786. Nothing to do.
+- **`68112` / `93114`** — already cured and live (Fase-1 cure + #2926). Nothing to do.
+- **"~30% Blocked in Bali" hero stat** (`apps/mouth/src/app/kbli/page.tsx`) — CURED. Was a hardcoded
+  guess whose tooltip asserted the moratorium as settled law. Now **computed at render from
+  `getAllCodes()`** (`baliL4.blocked` → 518/1559 = 33%; same in-memory cache `getSections()` already
+  uses, zero extra I/O) so it self-corrects as cures land, and the copy matches the F15 posture +
+  `KBLIProvenancePanel`'s existing "conservative posture" register: _"a working assessment, not a
+  certified legal determination."_
+- **PT PMA capital claim** in `buying-a-bali-villa-in-2026-…` (**EN/IT/ID/RU, all 4 locales**) — CURED.
+  Asserted a flat "IDR 10bn minimum authorized capital", conflating the two BKPM 5/2025 thresholds.
+  Now: **2.5bn paid-up at incorporation + a separate >10bn total investment plan per KBLI line**, and
+  states the nuance the article had dropped — **for hospitality/property, land+building ARE inside that
+  total** (they're excluded for other sectors). Grounded on two already-correct in-repo articles
+  (`bkpm-regulation-5-2025-fdi.mdx`, `consulting-business-guide.it.mdx`) read BEFORE editing —
+  deliberately NOT a regex sweep on "10 miliar" (rule #1/F-BKPM: E28A KITAS's 10bn is a genuine,
+  unrelated immigration threshold and was verified untouched).
+
+**PROVE-LIVE (both consuming surfaces, curl'd on prod):** `balizero.com/kbli` serves `~33%` + the new
+tooltip · the villa article serves the corrected claim in EN and — via the **`?lang=` query param, NOT
+a URL suffix** (locale routing gotcha, cost one false-negative probe) — in IT/ID/RU, stale copy gone in
+all four. `llms-full.txt` deliberately NOT hand-committed: `npm run build` regenerates it from source
+content, so the fix propagates on the next Vercel build (hand-committing it would have dragged 11 days
+of unrelated derived drift + tripped the PII gate, which is exactly where the lost Codex W1 got stuck).
+
+**Collateral (repo-wide, not KBLI):** this PR was blocked for hours by a red `npm audit` gate failing on
+EVERY open PR — 3 new advisories (`hono` ≤4.12.26, `@hono/node-server` ≤2.0.9, `find-my-way` ≤9.6.0)
+landed ABOVE the existing override floors, so the floors aged out silently (W98 / family #2). Diagnosed
+and fixed here (#3052); a parallel lane shipped the same cure with strictly higher floors first (#3053,
+`hono >=4.12.31`) so #3052 was closed as superseded — verified by CONTENT on main (W88), not by proxy.
+
+**W1 is CLOSED. Next per the Codex program: W2 (Batch-B prep — still NO-GO without Zero) / W3+.**
 
 **Batch A CLOSED 2026-07-21 (114/114, 0 remaining)** — the full "A-serving" 114-code sweep
 (113 A-serving/pp28 + 80190 A-serving/orphan) is done. Final tally: 109 full detach + 2


### PR DESCRIPTION
## Summary
Pure-docs corner update. Records the outcome of the **W1 public-surface honesty pass** (shipped in #3049, squash `23fa765e61`, proven-live on prod) into `.claude/skills/kbli-navigator/SKILL.md` §1 LIVE STATE, so the next session inherits it instead of re-deriving it.

What the entry now captures:
- The **W0→W7 program context** (Codex rollout `019f83fc`) and the fact that its W1 commits were authored locally but **never survived** — worktree lost, no branch. Plus Zero's standing constraint on the program: *W1+ must produce visible product change, not more governance*.
- **W1's 5 declared targets reconciled against disk**: `46100` was a false alarm already retracted by the batch-B design's own REV-2 self-correction; `68112`/`93114` were already cured; only 2 were real.
- The **two cures** and how each was grounded: the Bali-block hero stat is now computed at render from `getAllCodes()` (self-correcting, zero extra I/O) with F15-conformant copy; the PT PMA capital claim now states the BKPM 5/2025 two-threshold doctrine across 4 locales, verified against 2 already-correct in-repo articles rather than regex-sweeping "10 miliar" (E28A's 10bn is a genuine unrelated immigration threshold — confirmed untouched).
- **PROVE-LIVE evidence** on both consuming surfaces, plus the **`?lang=` locale-routing gotcha** (translations are NOT URL-suffixed) that produced one false-negative probe.
- Why `llms-full.txt` was **deliberately not hand-committed** (build-time regenerated; hand-committing drags 11 days of unrelated derived drift and trips the PII gate — exactly where the lost Codex W1 got stuck).
- The collateral **repo-wide npm audit floor rot** (W98 / cicatrix family #2) and why #3052 was closed as superseded by #3053 — verified by CONTENT on main per W88, not by proxy.

## Test plan
- [x] `prettier --check` clean
- [x] Pre-commit hooks green
- [x] Zero code/data changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)