### PR TITLE
feat(mouth): WS3 slice 7 — portal companies + profile + settings day pass (GARUDA OS train)

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/companies/error.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/companies/error.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Building2, RefreshCw } from 'lucide-react';
-import { logger } from '@/lib/logger';
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Building2, RefreshCw } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 export default function CompaniesError({
   error,
@@ -13,20 +13,26 @@ export default function CompaniesError({
   reset: () => void;
 }) {
   useEffect(() => {
-    logger.error('Portal companies page error', {}, error);
+    logger.error("Portal companies page error", {}, error);
   }, [error]);
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-6 text-center">
       <div
         className="flex h-16 w-16 items-center justify-center rounded-full"
-        style={{ background: 'rgba(244,63,94,0.1)' }}
+        style={{
+          background:
+            "color-mix(in srgb, var(--state-danger) 10%, transparent)",
+        }}
       >
-        <Building2 className="h-8 w-8" style={{ color: 'var(--neon-rose)' }} />
+        <Building2
+          className="h-8 w-8"
+          style={{ color: "var(--state-danger)" }}
+        />
       </div>
       <div className="space-y-2 max-w-sm">
         <h2 className="text-xl font-semibold">Companies unavailable</h2>
-        <p className="text-sm" style={{ color: 'var(--bz-text-2)' }}>
+        <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
           We couldn&apos;t load your companies. Please try again.
         </p>
       </div>

--- a/apps/mouth/src/app/portal/(authenticated)/companies/loading.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/companies/loading.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function CompaniesLoading() {
   return (
@@ -15,7 +15,10 @@ export default function CompaniesLoading() {
           <div
             key={i}
             className="rounded-xl border p-5 space-y-4"
-            style={{ background: 'rgba(30,30,35,0.7)', borderColor: 'rgba(255,255,255,0.05)' }}
+            style={{
+              background: "var(--bz-card)",
+              borderColor: "var(--bz-border)",
+            }}
           >
             <div className="flex items-start justify-between">
               <div className="flex items-center gap-3">

--- a/apps/mouth/src/app/portal/(authenticated)/companies/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/companies/page.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockGetCompanies, mockToastError, mockPush } = vi.hoisted(() => ({
+  mockGetCompanies: vi.fn(),
+  mockToastError: vi.fn(),
+  mockPush: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    portal: {
+      getCompanies: mockGetCompanies,
+    },
+  },
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  useToast: () => ({ error: mockToastError }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import CompaniesPage from "./page";
+
+const COMPANIES = [
+  {
+    id: 11,
+    company_id: 22,
+    name: "PT Example Nusantara",
+    type: "PT PMA",
+    status: "active" as const,
+    isPrimary: true,
+    nib: "9120107642215",
+    kbli: "56101,47911",
+    directors: ["A", "B"],
+    licenses: [
+      {
+        id: "l1",
+        name: "NIB",
+        status: "expired" as const,
+        expiryDate: "2026-01-01",
+      },
+    ],
+    compliance: [
+      {
+        id: "c1",
+        name: "LKPM Q2",
+        dueDate: "2026-07-01",
+        status: "overdue" as const,
+      },
+    ],
+  },
+  {
+    id: 12,
+    company_id: 23,
+    name: "CV Contoh Kedua",
+    type: "CV",
+    status: "pending" as const,
+    isPrimary: false,
+    compliance: [
+      {
+        id: "c2",
+        name: "LKPM Q3",
+        dueDate: "2026-10-01",
+        status: "completed" as const,
+      },
+    ],
+  },
+];
+
+async function renderLoaded() {
+  mockGetCompanies.mockResolvedValue(COMPANIES);
+  const utils = render(<CompaniesPage />);
+  await screen.findByText("PT Example Nusantara");
+  return utils;
+}
+
+describe("CompaniesPage (WS3 day pass)", () => {
+  it("renders the day masthead: copper rule + Cormorant serif in --tx-pure", async () => {
+    const { container } = await renderLoaded();
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Your Companies");
+    expect(heading.style.fontFamily).toBe("var(--font-serif)");
+    expect(heading.className).toContain("text-[var(--tx-pure)]");
+    expect(
+      container.querySelector(
+        '[aria-hidden="true"].bg-\\[var\\(--bz-copper\\)\\]',
+      ),
+    ).not.toBeNull();
+  });
+
+  it("renders company cards on theme surfaces with state-token statuses", async () => {
+    const { container } = await renderLoaded();
+
+    // Card surface reads tokens, not the old dark glass.
+    const card = screen.getByRole("button", {
+      name: "View PT Example Nusantara details",
+    });
+    expect(card.style.background).toBe("var(--bz-card)");
+    expect(card.style.borderColor).toBe("var(--bz-border)");
+    expect(container.innerHTML).not.toContain("rgba(30,30,35,0.7)");
+    expect(container.innerHTML).not.toContain("rgba(255,255,255,0.05)");
+
+    // StatusBadge for the company status (active → success, pending → warning).
+    const activeBadge = screen.getByText("Active").closest("div");
+    expect(activeBadge?.style.color).toBe("var(--state-success)");
+    const pendingBadge = screen.getByText("Pending").closest("div");
+    expect(pendingBadge?.style.color).toBe("var(--state-warning)");
+
+    // Compliance roll-up renders the shared StatusBadge (overdue → danger).
+    const overdueBadge = screen.getByText("Overdue").closest("div");
+    expect(overdueBadge?.style.color).toBe("var(--state-danger)");
+    expect(overdueBadge?.style.background).toContain("color-mix");
+
+    // License icon reads the danger state token (expired license present).
+    const licenseCount = screen.getByText(/1 license/);
+    const icon = licenseCount.querySelector("svg");
+    expect(icon?.getAttribute("style")).toContain("var(--state-danger)");
+  });
+
+  it("renders identifier chips with token-driven hairline patterns", async () => {
+    await renderLoaded();
+
+    // NIB chip: glass-rim well + token border, no hardcoded rgba.
+    const nibChip = screen.getByText(/NIB 9120107642215/);
+    expect(nibChip.style.background).toBe("var(--glass-rim)");
+    expect(nibChip.style.border).toContain("var(--bz-border)");
+
+    // KBLI chip: hairline copper border + AA copper text (no tint fill —
+    // a 12% copper tint fails AA on both themes, slice-6 finding).
+    const kbliChip = screen.getByText(/KBLI 56101/);
+    expect(kbliChip.style.color).toBe(
+      "var(--bz-copper-text, var(--tx-secondary))",
+    );
+    expect(kbliChip.style.border).toContain("color-mix");
+    expect(kbliChip.style.background).toBe("");
+  });
+
+  it("drain guard: no hardcoded hex colors anywhere in the page output", async () => {
+    const { container } = await renderLoaded();
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+
+  it("routes to the company detail using company_id over the relation id", async () => {
+    await renderLoaded();
+    screen
+      .getByRole("button", { name: "View PT Example Nusantara details" })
+      .click();
+    expect(mockPush).toHaveBeenCalledWith("/portal/company/22");
+  });
+
+  it("renders the empty state when there are no companies", async () => {
+    mockGetCompanies.mockResolvedValue([]);
+    render(<CompaniesPage />);
+    expect(await screen.findByText("No companies yet")).toBeInTheDocument();
+  });
+
+  it("shows a toast and keeps the shell quiet when loading fails", async () => {
+    mockGetCompanies.mockRejectedValue(new Error("boom"));
+    render(<CompaniesPage />);
+    await screen.findByRole("heading", { level: 1 });
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Failed to load companies",
+      "Please try again later",
+    );
+  });
+});

--- a/apps/mouth/src/app/portal/(authenticated)/companies/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/companies/page.tsx
@@ -1,5 +1,20 @@
 "use client";
 
+/**
+ * Portal Companies — shareholder's business entities.
+ *
+ * WS3 slice 7 (GARUDA Day Edition, 2026-07-24): day-theme token alignment,
+ * mirroring slices 1-4 (home/matters/billing/process). Masthead = copper
+ * rule + Cormorant serif (--font-serif) in --tx-pure; cards read --bz-card /
+ * --bz-border + the concept .panel shadow; compliance/license state colors
+ * read the semantic --state-* tokens (WS2 operative-light AA overrides:
+ * success 4.80 / warning 4.78 / danger 5.74 :1 on paper); the KBLI chip uses
+ * the hairline-border + --bz-copper-text pattern (a 12% copper tint fails AA
+ * on both themes — slice-6 finding); copper small text reads
+ * --bz-copper-text with the slice-1 --tx-secondary fallback. No hardcoded
+ * hexes.
+ */
+
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
@@ -11,7 +26,6 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useToast } from "@/components/ui/toast";
-import { cn } from "@/lib/utils";
 import { logger } from "@/lib/logger";
 import type { PortalCompany } from "@/lib/api/portal/portal.types";
 import {
@@ -19,6 +33,28 @@ import {
   PortalEmptyState,
   PortalListSkeleton,
 } from "@/components/portal";
+
+// Day masthead (GARUDA Day Edition): copper rule + Cormorant serif headline
+// per concept (--font-serif, wired on <html>); Inter everywhere else.
+function CompaniesMasthead() {
+  return (
+    <section>
+      <div
+        aria-hidden="true"
+        className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+      />
+      <h1
+        className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]"
+        style={{ fontFamily: "var(--font-serif)" }}
+      >
+        Your Companies
+      </h1>
+      <p className="text-sm text-[var(--tx-secondary)] mt-1">
+        Manage your business entities in Indonesia
+      </p>
+    </section>
+  );
+}
 
 export default function CompaniesPage() {
   const router = useRouter();
@@ -64,12 +100,7 @@ export default function CompaniesPage() {
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
       {/* Header */}
-      <section>
-        <h1 className="text-2xl font-bold tracking-tight">Your Companies</h1>
-        <p style={{ color: "var(--bz-text-2)" }}>
-          Manage your business entities in Indonesia
-        </p>
-      </section>
+      <CompaniesMasthead />
 
       {/* Companies List */}
       {companies.length === 0 ? (
@@ -111,19 +142,18 @@ function CompanyCard({
   company: PortalCompany;
   onClick: () => void;
 }) {
-  const getComplianceStatus = () => {
+  // Compliance roll-up: worst-case wins, mapped to the StatusBadge
+  // vocabulary (all three statuses are in its STATUS_MAP and render the
+  // semantic --state-* tokens with the AA-verified 12% color-mix tint).
+  const getComplianceStatus = (): string | null => {
     if (!company.compliance || company.compliance.length === 0) return null;
 
     const hasOverdue = company.compliance.some((c) => c.status === "overdue");
     const hasUpcoming = company.compliance.some((c) => c.status === "upcoming");
 
-    if (hasOverdue) {
-      return { label: "Overdue", color: "#f87171" };
-    }
-    if (hasUpcoming) {
-      return { label: "Upcoming", color: "#fbbf24" };
-    }
-    return { label: "Compliant", color: "#34d399" };
+    if (hasOverdue) return "overdue";
+    if (hasUpcoming) return "upcoming";
+    return "compliant";
   };
 
   const getLicenseStatus = () => {
@@ -133,12 +163,12 @@ function CompanyCard({
     const hasExpiring = company.licenses.some((l) => l.status === "expiring");
 
     if (hasExpired) {
-      return { icon: AlertTriangle, className: "text-red-500" };
+      return { icon: AlertTriangle, color: "var(--state-danger)" };
     }
     if (hasExpiring) {
-      return { icon: AlertTriangle, className: "text-amber-500" };
+      return { icon: AlertTriangle, color: "var(--state-warning)" };
     }
-    return { icon: CheckCircle, className: "text-emerald-500" };
+    return { icon: CheckCircle, color: "var(--state-success)" };
   };
 
   const compliance = getComplianceStatus();
@@ -158,15 +188,21 @@ function CompanyCard({
       aria-label={`View ${company.name} details`}
       className="rounded-xl border p-4 cursor-pointer transition-all duration-200 active:scale-[0.99] hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-accent-warm)]"
       style={{
-        background: "rgba(30,30,35,0.7)",
-        borderColor: "rgba(255,255,255,0.05)",
+        /* WS3: theme surface instead of the dark-only rgba(30,30,35,0.7)
+           glass + white hairline; shadow = concept .panel (soft navy on
+           paper, near-invisible on dark). */
+        background: "var(--bz-card)",
+        borderColor: "var(--bz-border)",
+        boxShadow: "0 14px 34px rgba(22, 33, 58, 0.07)",
         backdropFilter: "blur(24px)",
       }}
     >
       <div className="flex items-start gap-4">
         <div
           className="p-3 rounded-xl flex-shrink-0"
-          style={{ background: "rgba(201,169,110,0.1)" }}
+          style={{
+            background: "color-mix(in srgb, var(--bz-copper) 10%, transparent)",
+          }}
         >
           <Building2
             className="w-6 h-6"
@@ -216,9 +252,9 @@ function CompanyCard({
               <span
                 className="px-2 py-0.5 rounded-full font-mono tabular-nums"
                 style={{
-                  background: "rgba(255,255,255,0.04)",
+                  background: "var(--glass-rim)",
                   color: "var(--bz-text-1)",
-                  border: "1px solid rgba(255,255,255,0.06)",
+                  border: "1px solid var(--bz-border)",
                 }}
                 title="Nomor Induk Berusaha"
               >
@@ -229,9 +265,12 @@ function CompanyCard({
               <span
                 className="px-2 py-0.5 rounded-full font-mono tabular-nums"
                 style={{
-                  background: "rgba(201,169,110,0.08)",
-                  color: "var(--bz-accent-warm)",
-                  border: "1px solid rgba(201,169,110,0.2)",
+                  /* Hairline copper border + AA copper text (small chip: a
+                     12% copper tint background fails AA on both themes —
+                     slice-6 finding). */
+                  border:
+                    "1px solid color-mix(in srgb, var(--bz-copper) 35%, transparent)",
+                  color: "var(--bz-copper-text, var(--tx-secondary))",
                 }}
                 title="KBLI activity codes"
               >
@@ -249,7 +288,8 @@ function CompanyCard({
                   style={{ color: "var(--bz-text-2)" }}
                 >
                   <licenseStatus.icon
-                    className={cn("w-3.5 h-3.5", licenseStatus.className)}
+                    className="w-3.5 h-3.5"
+                    style={{ color: licenseStatus.color }}
                   />
                   {company.licenses.length} license
                   {company.licenses.length !== 1 ? "s" : ""}
@@ -261,17 +301,7 @@ function CompanyCard({
                 {company.directors.length !== 1 ? "s" : ""}
               </span>
             )}
-            {compliance && (
-              <span
-                className="font-medium px-2 py-0.5 rounded-full"
-                style={{
-                  color: compliance.color,
-                  background: `${compliance.color}15`,
-                }}
-              >
-                {compliance.label}
-              </span>
-            )}
+            {compliance && <StatusBadge status={compliance} />}
           </div>
         </div>
       </div>

--- a/apps/mouth/src/app/portal/(authenticated)/profile/error.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/profile/error.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { User, RefreshCw } from 'lucide-react';
-import { logger } from '@/lib/logger';
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { User, RefreshCw } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 export default function ProfileError({
   error,
@@ -13,20 +13,23 @@ export default function ProfileError({
   reset: () => void;
 }) {
   useEffect(() => {
-    logger.error('Portal profile page error', {}, error);
+    logger.error("Portal profile page error", {}, error);
   }, [error]);
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-6 text-center">
       <div
         className="flex h-16 w-16 items-center justify-center rounded-full"
-        style={{ background: 'rgba(244,63,94,0.1)' }}
+        style={{
+          background:
+            "color-mix(in srgb, var(--state-danger) 10%, transparent)",
+        }}
       >
-        <User className="h-8 w-8" style={{ color: 'var(--neon-rose)' }} />
+        <User className="h-8 w-8" style={{ color: "var(--state-danger)" }} />
       </div>
       <div className="space-y-2 max-w-sm">
         <h2 className="text-xl font-semibold">Profile unavailable</h2>
-        <p className="text-sm" style={{ color: 'var(--bz-text-2)' }}>
+        <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
           We couldn&apos;t load your profile. Please try again.
         </p>
       </div>

--- a/apps/mouth/src/app/portal/(authenticated)/profile/loading.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/profile/loading.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function ProfileLoading() {
   return (
@@ -15,12 +15,15 @@ export default function ProfileLoading() {
           <div
             key={i}
             className="rounded-xl border overflow-hidden"
-            style={{ background: 'rgba(30,30,35,0.7)', borderColor: 'rgba(255,255,255,0.05)' }}
+            style={{
+              background: "var(--bz-card)",
+              borderColor: "var(--bz-border)",
+            }}
           >
             {/* Card Header */}
             <div
               className="flex items-center gap-2 px-4 py-3 border-b"
-              style={{ borderColor: 'rgba(255,255,255,0.05)' }}
+              style={{ borderColor: "var(--bz-border)" }}
             >
               <Skeleton variant="circular" width={20} height={20} />
               <Skeleton variant="text" width={120} />
@@ -33,7 +36,7 @@ export default function ProfileLoading() {
                   {/* Team member */}
                   <div
                     className="flex items-center gap-3 p-3 rounded-lg"
-                    style={{ background: 'rgba(255,255,255,0.03)' }}
+                    style={{ background: "var(--glass-rim)" }}
                   >
                     <Skeleton variant="circular" width={40} height={40} />
                     <div className="space-y-1">
@@ -44,7 +47,12 @@ export default function ProfileLoading() {
                   {/* Info rows */}
                   {Array.from({ length: 5 }).map((_, j) => (
                     <div key={j} className="flex items-start gap-2">
-                      <Skeleton variant="circular" width={16} height={16} className="mt-0.5" />
+                      <Skeleton
+                        variant="circular"
+                        width={16}
+                        height={16}
+                        className="mt-0.5"
+                      />
                       <div className="space-y-1">
                         <Skeleton variant="text" width={60} height={10} />
                         <Skeleton variant="text" width={140} />
@@ -60,7 +68,7 @@ export default function ProfileLoading() {
                     <div
                       key={j}
                       className="flex items-center justify-between p-2 rounded-lg"
-                      style={{ background: 'rgba(255,255,255,0.03)' }}
+                      style={{ background: "var(--glass-rim)" }}
                     >
                       <Skeleton variant="text" width={80} height={10} />
                       <Skeleton variant="text" width={100} />

--- a/apps/mouth/src/app/portal/(authenticated)/profile/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/profile/page.test.tsx
@@ -1,0 +1,158 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockGetProfile, mockUpdateProfile, mockToastError } = vi.hoisted(
+  () => ({
+    mockGetProfile: vi.fn(),
+    mockUpdateProfile: vi.fn(),
+    mockToastError: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    portal: {
+      getProfile: mockGetProfile,
+      updateProfile: mockUpdateProfile,
+    },
+  },
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  useToast: () => ({ error: mockToastError }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import type { PortalProfile } from "@/lib/api/portal/portal.types";
+import ProfilePage from "./page";
+
+const daysFromNow = (days: number) =>
+  new Date(Date.now() + days * 86400000).toISOString();
+
+const PROFILE: PortalProfile = {
+  id: 7,
+  fullName: "Andreas Example",
+  email: "andreas@example.com",
+  phone: "+6281200000000",
+  whatsapp: "6281200000000",
+  nationality: "German",
+  passportNumber: "C01X00T47",
+  passportExpiry: daysFromNow(360), // ~12 months → warning tier
+  dateOfBirth: "1985-03-10",
+  gender: "M" as const,
+  address: "Jl. Example No. 1, Canggu",
+  memberSince: "2024-06-01T00:00:00Z",
+};
+
+async function renderLoaded(profile = PROFILE) {
+  mockGetProfile.mockResolvedValue(profile);
+  const utils = render(<ProfilePage />);
+  await screen.findByText("Andreas Example");
+  return utils;
+}
+
+describe("ProfilePage (WS3 day pass)", () => {
+  it("renders the day masthead: copper rule + Cormorant serif in --tx-pure", async () => {
+    const { container } = await renderLoaded();
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Your Profile");
+    expect(heading.style.fontFamily).toBe("var(--font-serif)");
+    expect(heading.className).toContain("text-[var(--tx-pure)]");
+    expect(
+      container.querySelector(
+        '[aria-hidden="true"].bg-\\[var\\(--bz-copper\\)\\]',
+      ),
+    ).not.toBeNull();
+  });
+
+  it("renders the profile card on theme surfaces, not the dark glass", async () => {
+    const { container } = await renderLoaded();
+
+    expect(container.innerHTML).toContain("var(--bz-card)");
+    expect(container.innerHTML).toContain("var(--bz-border)");
+    expect(container.innerHTML).not.toContain("rgba(30,30,35,0.7)");
+    expect(container.innerHTML).not.toContain("rgba(255,255,255,0.05)");
+    expect(container.innerHTML).not.toContain("rgba(255,255,255,0.03)");
+  });
+
+  it("colors the passport expiry panel with the semantic state tokens", async () => {
+    await renderLoaded(); // 360 days → warning tier
+
+    const label = screen.getByText("Passport Expiry");
+    const panel = label.closest("div.rounded-lg") as HTMLElement;
+    expect(panel.style.background).toContain("var(--state-warning)");
+    expect(panel.style.background).toContain("color-mix");
+    expect(panel.style.borderColor).toContain("var(--state-warning)");
+
+    // Alert copy reads the warning state token (was text-yellow-400).
+    const alert = screen.getByText(/expires in less than 14 months/);
+    expect(alert.style.color).toBe("var(--state-warning)");
+  });
+
+  it("escalates to the danger token when the passport is critical", async () => {
+    await renderLoaded({ ...PROFILE, passportExpiry: daysFromNow(180) });
+
+    const alert = screen.getByText(/URGENT: Your passport expires/);
+    expect(alert.style.color).toBe("var(--state-danger)");
+
+    const label = screen.getByText("Passport Expiry");
+    const panel = label.closest("div.rounded-lg") as HTMLElement;
+    expect(panel.style.borderColor).toContain("var(--state-danger)");
+  });
+
+  it("marks muted fields with the AA text token + italic (not --bz-text-3)", async () => {
+    await renderLoaded({ ...PROFILE, phone: undefined, whatsapp: undefined });
+
+    // --bz-text-3 (#7a8aa6) is 3.49:1 on the card — below the 4.5:1 floor
+    // for small text — so muted values read --bz-text-2 with italic.
+    const muted = screen.getAllByText("Not provided")[0];
+    expect(muted.style.color).toBe("var(--bz-text-2)");
+    expect(muted.className).toContain("italic");
+  });
+
+  it("renders the edit form on tokens and saves via the portal API", async () => {
+    await renderLoaded();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Profile" }));
+
+    const phoneInput = screen.getByLabelText("Phone");
+    expect(phoneInput.style.background).toBe("var(--glass-rim)");
+    expect(phoneInput.style.borderColor).toBe("var(--bz-border)");
+    expect(phoneInput.style.color).toBe("var(--bz-text-1)");
+    expect(phoneInput.className).toContain(
+      "focus-visible:ring-[var(--bz-copper)]",
+    );
+
+    mockUpdateProfile.mockResolvedValue(PROFILE);
+    fireEvent.change(phoneInput, { target: { value: "+628999" } });
+    // act() flush: the save handler is async (await api → setState/toast).
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    });
+    expect(mockUpdateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ phone: "+628999" }),
+    );
+  });
+
+  it("drain guard: no hardcoded hex colors anywhere in the page output", async () => {
+    const { container } = await renderLoaded();
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+
+  it("renders the unable-to-load empty state on token surfaces", async () => {
+    mockGetProfile.mockResolvedValue(null);
+    const { container } = render(<ProfilePage />);
+    expect(
+      await screen.findByText("Unable to load profile"),
+    ).toBeInTheDocument();
+    expect(container.innerHTML).not.toContain("rgba(30,30,35,0.7)");
+    // Masthead survives the empty state.
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Your Profile",
+    );
+  });
+});

--- a/apps/mouth/src/app/portal/(authenticated)/profile/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/profile/page.tsx
@@ -1,5 +1,19 @@
 "use client";
 
+/**
+ * Portal Profile — shareholder's personal information.
+ *
+ * WS3 slice 7 (GARUDA Day Edition, 2026-07-24): day-theme token alignment,
+ * mirroring slices 1-4. Masthead = copper rule + Cormorant serif
+ * (--font-serif) in --tx-pure; surfaces read --bz-card / --bz-border +
+ * concept .panel shadow; passport/expiry state colors read the semantic
+ * --state-* tokens (WS2 operative-light AA overrides) via color-mix tints;
+ * the birthday celebration keeps its bright gradient (theme-agnostic
+ * decorative one-off) but its TEXT reads --state-warning (#fbbf24 was
+ * ~1.6:1 on paper). Gender badge (bg-blue-500/bg-pink-500) is a decorative
+ * theme-agnostic one-off, left as-is. No hardcoded hexes.
+ */
+
 import React, { useEffect, useState } from "react";
 import {
   User,
@@ -93,6 +107,74 @@ const isBirthdayToday = (dateOfBirth: string | undefined): boolean => {
 import { formatDate } from "@/lib/utils/format-date";
 
 // ============================================================================
+// DAY THEME PRIMITIVES (GARUDA Day Edition, WS3)
+// ============================================================================
+
+// Theme surface: token card + concept .panel shadow (soft navy on paper,
+// near-invisible on dark). Was the dark-only rgba(30,30,35,0.7) glass.
+const PROFILE_CARD_STYLE = {
+  background: "var(--bz-card)",
+  borderColor: "var(--bz-border)",
+  boxShadow: "0 14px 34px rgba(22, 33, 58, 0.07)",
+  backdropFilter: "blur(24px)",
+} as const;
+
+// Passport validity tones — semantic --state-* tokens with color-mix tints
+// (the previous rgba(16,185,129,…) / rgba(245,158,11,…) / rgba(239,68,68,…)
+// tints were dark-grade and failed AA on paper). Border sits at 30-35% mix
+// so the hairline reads on both themes.
+type StateTone = "success" | "warning" | "danger";
+
+const STATE_TONE_STYLES: Record<
+  StateTone,
+  { token: string; bg: string; border: string; well: string }
+> = {
+  success: {
+    token: "var(--state-success)",
+    bg: "color-mix(in srgb, var(--state-success) 6%, transparent)",
+    border: "color-mix(in srgb, var(--state-success) 30%, transparent)",
+    well: "color-mix(in srgb, var(--state-success) 12%, transparent)",
+  },
+  warning: {
+    token: "var(--state-warning)",
+    bg: "color-mix(in srgb, var(--state-warning) 6%, transparent)",
+    border: "color-mix(in srgb, var(--state-warning) 30%, transparent)",
+    well: "color-mix(in srgb, var(--state-warning) 12%, transparent)",
+  },
+  danger: {
+    token: "var(--state-danger)",
+    bg: "color-mix(in srgb, var(--state-danger) 8%, transparent)",
+    border: "color-mix(in srgb, var(--state-danger) 35%, transparent)",
+    well: "color-mix(in srgb, var(--state-danger) 15%, transparent)",
+  },
+};
+
+const toneForAlertLevel = (level: PassportAlertLevel): StateTone =>
+  level === "ok" ? "success" : level === "warning" ? "warning" : "danger";
+
+// Day masthead: copper rule + Cormorant serif headline per concept
+// (--font-serif, wired on <html>); Inter everywhere else.
+function ProfileMasthead() {
+  return (
+    <section>
+      <div
+        aria-hidden="true"
+        className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+      />
+      <h1
+        className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]"
+        style={{ fontFamily: "var(--font-serif)" }}
+      >
+        Your Profile
+      </h1>
+      <p className="text-sm text-[var(--tx-secondary)] mt-1">
+        View your personal information
+      </p>
+    </section>
+  );
+}
+
+// ============================================================================
 // MAIN COMPONENT
 // ============================================================================
 
@@ -169,8 +251,8 @@ export default function ProfilePage() {
         <div
           className="rounded-xl border p-6 space-y-4 animate-pulse"
           style={{
-            background: "rgba(30,30,35,0.7)",
-            borderColor: "rgba(255,255,255,0.05)",
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <div className="flex items-center gap-4">
@@ -204,17 +286,12 @@ export default function ProfilePage() {
   if (!profile) {
     return (
       <div className="space-y-6 animate-in fade-in duration-500">
-        <section>
-          <h1 className="text-2xl font-bold tracking-tight">Your Profile</h1>
-          <p style={{ color: "var(--bz-text-2)" }}>
-            View your personal information
-          </p>
-        </section>
+        <ProfileMasthead />
         <section
           className="rounded-xl border border-dashed p-12 text-center"
           style={{
-            background: "rgba(30,30,35,0.7)",
-            borderColor: "rgba(255,255,255,0.05)",
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <User
@@ -227,7 +304,9 @@ export default function ProfilePage() {
           >
             Unable to load profile
           </h2>
-          <p className="text-sm mt-1" style={{ color: "var(--bz-text-3)" }}>
+          {/* WS3 AA: guidance copy reads --bz-text-2 (7.64:1 on card);
+              --bz-text-3 was 3.49:1 — below the 4.5:1 floor. */}
+          <p className="text-sm mt-1" style={{ color: "var(--bz-text-2)" }}>
             Please refresh the page or contact support if the issue persists.
           </p>
         </section>
@@ -237,26 +316,19 @@ export default function ProfilePage() {
 
   // Calculate alerts
   const passportValidity = getPassportValidityColor(profile.passportExpiry);
+  const passportTone =
+    STATE_TONE_STYLES[toneForAlertLevel(passportValidity.alertLevel)];
   const isBirthday = isBirthdayToday(profile.dateOfBirth);
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
       {/* Header */}
-      <section>
-        <h1 className="text-2xl font-bold tracking-tight">Your Profile</h1>
-        <p style={{ color: "var(--bz-text-2)" }}>
-          View your personal information
-        </p>
-      </section>
+      <ProfileMasthead />
 
       {/* Profile Card */}
       <section
         className="rounded-xl border p-6 space-y-6"
-        style={{
-          background: "rgba(30,30,35,0.7)",
-          borderColor: "rgba(255,255,255,0.05)",
-          backdropFilter: "blur(24px)",
-        }}
+        style={PROFILE_CARD_STYLE}
       >
         {/* Avatar */}
         <div className="flex flex-col items-center gap-3">
@@ -268,7 +340,12 @@ export default function ProfilePage() {
                   "bg-gradient-to-br from-yellow-300 via-amber-300 to-yellow-400 animate-pulse shadow-[0_0_30px_rgba(255,215,0,0.6)]",
               )}
               style={
-                !isBirthday ? { background: "rgba(201,169,110,0.15)" } : {}
+                !isBirthday
+                  ? {
+                      background:
+                        "color-mix(in srgb, var(--bz-copper) 15%, transparent)",
+                    }
+                  : {}
               }
             >
               <User
@@ -311,7 +388,7 @@ export default function ProfilePage() {
             {isBirthday && (
               <p
                 className="text-sm font-medium mt-1 animate-pulse"
-                style={{ color: "#fbbf24" }}
+                style={{ color: "var(--state-warning)" }}
               >
                 🎉 Happy Birthday! 🎉
               </p>
@@ -351,8 +428,10 @@ export default function ProfilePage() {
               style={
                 isBirthday
                   ? {
-                      background: "rgba(251,191,36,0.15)",
-                      boxShadow: "0 0 20px rgba(255,215,0,0.3)",
+                      background:
+                        "color-mix(in srgb, var(--state-warning) 12%, transparent)",
+                      boxShadow:
+                        "0 0 20px color-mix(in srgb, var(--state-warning) 30%, transparent)",
                     }
                   : {}
               }
@@ -361,13 +440,20 @@ export default function ProfilePage() {
                 className="p-2 rounded-md"
                 style={
                   isBirthday
-                    ? { background: "rgba(251,191,36,0.25)" }
-                    : { background: "rgba(255,255,255,0.03)" }
+                    ? {
+                        background:
+                          "color-mix(in srgb, var(--state-warning) 20%, transparent)",
+                      }
+                    : { background: "var(--glass-rim)" }
                 }
               >
                 <Calendar
-                  className={cn("w-4 h-4", isBirthday && "text-yellow-400")}
-                  style={!isBirthday ? { color: "var(--bz-text-2)" } : {}}
+                  className="w-4 h-4"
+                  style={{
+                    color: isBirthday
+                      ? "var(--state-warning)"
+                      : "var(--bz-text-2)",
+                  }}
                 />
               </div>
               <div className="flex-1 min-w-0">
@@ -382,7 +468,9 @@ export default function ProfilePage() {
                     "text-sm font-medium break-words",
                     isBirthday && "font-bold",
                   )}
-                  style={isBirthday ? { color: "#fbbf24" } : {}}
+                  style={
+                    isBirthday ? { color: "var(--state-warning)" } : undefined
+                  }
                 >
                   {formatDate(profile.dateOfBirth)}
                   {isBirthday && " 🎂 (Today!)"}
@@ -408,42 +496,23 @@ export default function ProfilePage() {
                 passportValidity.alertLevel === "critical" && "animate-pulse",
               )}
               style={{
-                background:
-                  passportValidity.alertLevel === "ok"
-                    ? "rgba(16,185,129,0.06)"
-                    : passportValidity.alertLevel === "warning"
-                      ? "rgba(245,158,11,0.06)"
-                      : "rgba(239,68,68,0.08)",
-                borderColor:
-                  passportValidity.alertLevel === "ok"
-                    ? "rgba(16,185,129,0.25)"
-                    : passportValidity.alertLevel === "warning"
-                      ? "rgba(245,158,11,0.3)"
-                      : "rgba(239,68,68,0.35)",
+                background: passportTone.bg,
+                borderColor: passportTone.border,
               }}
             >
               <div
                 className="p-2 rounded-md"
-                style={{
-                  background:
-                    passportValidity.alertLevel === "ok"
-                      ? "rgba(16,185,129,0.12)"
-                      : passportValidity.alertLevel === "warning"
-                        ? "rgba(245,158,11,0.12)"
-                        : "rgba(239,68,68,0.15)",
-                }}
+                style={{ background: passportTone.well }}
               >
                 {passportValidity.alertLevel === "ok" ? (
-                  <Calendar className="w-4 h-4" style={{ color: "#34d399" }} />
+                  <Calendar
+                    className="w-4 h-4"
+                    style={{ color: passportTone.token }}
+                  />
                 ) : (
                   <AlertTriangle
                     className="w-4 h-4"
-                    style={{
-                      color:
-                        passportValidity.alertLevel === "warning"
-                          ? "#fbbf24"
-                          : "#f87171",
-                    }}
+                    style={{ color: passportTone.token }}
                   />
                 )}
               </div>
@@ -456,14 +525,7 @@ export default function ProfilePage() {
                 </p>
                 <p
                   className="text-sm font-medium break-words"
-                  style={{
-                    color:
-                      passportValidity.alertLevel === "ok"
-                        ? "#34d399"
-                        : passportValidity.alertLevel === "warning"
-                          ? "#fbbf24"
-                          : "#f87171",
-                  }}
+                  style={{ color: passportTone.token }}
                 >
                   {formatDate(profile.passportExpiry)}
                   {(() => {
@@ -472,14 +534,12 @@ export default function ProfilePage() {
                         Date.now()) /
                         86400000,
                     );
-                    const chipColor =
-                      days < 0
-                        ? "bg-red-500/15 text-red-400"
-                        : days === 0
-                          ? "bg-red-500/15 text-red-400"
-                          : days <= 270
-                            ? "bg-amber-500/10 text-amber-400"
-                            : "bg-emerald-500/10 text-emerald-400";
+                    const chipTone: StateTone =
+                      days <= 0
+                        ? "danger"
+                        : days <= 270
+                          ? "warning"
+                          : "success";
                     const chipText =
                       days < 0
                         ? `Expired ${Math.abs(days)}d ago`
@@ -490,7 +550,11 @@ export default function ProfilePage() {
                             : `${Math.floor(days / 30)}mo left`;
                     return (
                       <span
-                        className={`ml-2 text-[10px] px-1.5 py-0.5 rounded-full font-semibold ${chipColor}`}
+                        className="ml-2 text-[10px] px-1.5 py-0.5 rounded-full font-semibold"
+                        style={{
+                          background: STATE_TONE_STYLES[chipTone].well,
+                          color: STATE_TONE_STYLES[chipTone].token,
+                        }}
                       >
                         {chipText}
                       </span>
@@ -499,14 +563,20 @@ export default function ProfilePage() {
                 </p>
                 {/* Alert Messages */}
                 {passportValidity.alertLevel === "warning" && (
-                  <p className="mt-1 text-xs text-yellow-400">
+                  <p
+                    className="mt-1 text-xs"
+                    style={{ color: "var(--state-warning)" }}
+                  >
                     <AlertCircle className="w-3 h-3 inline mr-1" />
                     Your passport expires in less than 14 months. Contact your
                     embassy to begin renewal process.
                   </p>
                 )}
                 {passportValidity.alertLevel === "critical" && (
-                  <p className="mt-1 text-xs text-red-400 font-medium">
+                  <p
+                    className="mt-1 text-xs font-medium"
+                    style={{ color: "var(--state-danger)" }}
+                  >
                     <AlertCircle className="w-3 h-3 inline mr-1" />
                     URGENT: Your passport expires in less than 9 months. You may
                     not be able to travel internationally. Contact your embassy
@@ -514,7 +584,10 @@ export default function ProfilePage() {
                   </p>
                 )}
                 {passportValidity.alertLevel === "expired" && (
-                  <p className="mt-1 text-xs text-red-400 font-bold">
+                  <p
+                    className="mt-1 text-xs font-bold"
+                    style={{ color: "var(--state-danger)" }}
+                  >
                     <AlertCircle className="w-3 h-3 inline mr-1" />
                     Your passport has EXPIRED! Contact your embassy immediately
                     for emergency renewal.
@@ -543,11 +616,7 @@ export default function ProfilePage() {
       ) : (
         <section
           className="space-y-4 rounded-xl border p-6"
-          style={{
-            background: "rgba(30,30,35,0.7)",
-            borderColor: "rgba(255,255,255,0.05)",
-            backdropFilter: "blur(24px)",
-          }}
+          style={PROFILE_CARD_STYLE}
         >
           <h2 className="text-lg font-semibold">Edit Profile</h2>
           <div className="space-y-3">
@@ -566,10 +635,10 @@ export default function ProfilePage() {
                 onChange={(e) =>
                   setEditData((prev) => ({ ...prev, phone: e.target.value }))
                 }
-                className="w-full px-3 py-2 rounded-lg border text-sm"
+                className="w-full px-3 py-2 rounded-lg border text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-copper)]"
                 style={{
-                  background: "rgba(255,255,255,0.03)",
-                  borderColor: "rgba(255,255,255,0.05)",
+                  background: "var(--glass-rim)",
+                  borderColor: "var(--bz-border)",
                   color: "var(--bz-text-1)",
                 }}
               />
@@ -589,10 +658,10 @@ export default function ProfilePage() {
                 onChange={(e) =>
                   setEditData((prev) => ({ ...prev, whatsapp: e.target.value }))
                 }
-                className="w-full px-3 py-2 rounded-lg border text-sm"
+                className="w-full px-3 py-2 rounded-lg border text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-copper)]"
                 style={{
-                  background: "rgba(255,255,255,0.03)",
-                  borderColor: "rgba(255,255,255,0.05)",
+                  background: "var(--glass-rim)",
+                  borderColor: "var(--bz-border)",
                   color: "var(--bz-text-1)",
                 }}
               />
@@ -611,10 +680,10 @@ export default function ProfilePage() {
                 onChange={(e) =>
                   setEditData((prev) => ({ ...prev, address: e.target.value }))
                 }
-                className="w-full px-3 py-2 rounded-lg border text-sm min-h-[80px]"
+                className="w-full px-3 py-2 rounded-lg border text-sm min-h-[80px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bz-copper)]"
                 style={{
-                  background: "rgba(255,255,255,0.03)",
-                  borderColor: "rgba(255,255,255,0.05)",
+                  background: "var(--glass-rim)",
+                  borderColor: "var(--bz-border)",
                   color: "var(--bz-text-1)",
                 }}
               />
@@ -660,7 +729,7 @@ function ProfileField({
     >
       <div
         className="p-2 rounded-md backdrop-blur-sm shadow-sm"
-        style={{ background: "rgba(255,255,255,0.03)" }}
+        style={{ background: "var(--glass-rim)" }}
       >
         <Icon
           className="w-4 h-4"
@@ -682,7 +751,11 @@ function ProfileField({
             "text-sm break-words",
             muted ? "italic" : "font-medium",
           )}
-          style={muted ? { color: "var(--bz-text-3)" } : undefined}
+          /* WS3 AA: muted small text reads --bz-text-2 (7.64:1 on card);
+             --bz-text-3 is 3.49:1 — below the 4.5:1 floor, so it survives
+             only on the icon (3:1 non-text) where it passes. Italic keeps
+             the muted signal. */
+          style={muted ? { color: "var(--bz-text-2)" } : undefined}
         >
           {value}
         </p>

--- a/apps/mouth/src/app/portal/(authenticated)/settings/error.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/settings/error.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Settings, RefreshCw } from 'lucide-react';
-import { logger } from '@/lib/logger';
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Settings, RefreshCw } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 export default function PortalSettingsError({
   error,
@@ -13,20 +13,26 @@ export default function PortalSettingsError({
   reset: () => void;
 }) {
   useEffect(() => {
-    logger.error('Portal settings page error', {}, error);
+    logger.error("Portal settings page error", {}, error);
   }, [error]);
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-6 text-center">
       <div
         className="flex h-16 w-16 items-center justify-center rounded-full"
-        style={{ background: 'rgba(244,63,94,0.1)' }}
+        style={{
+          background:
+            "color-mix(in srgb, var(--state-danger) 10%, transparent)",
+        }}
       >
-        <Settings className="h-8 w-8" style={{ color: 'var(--neon-rose)' }} />
+        <Settings
+          className="h-8 w-8"
+          style={{ color: "var(--state-danger)" }}
+        />
       </div>
       <div className="space-y-2 max-w-sm">
         <h2 className="text-xl font-semibold">Settings unavailable</h2>
-        <p className="text-sm" style={{ color: 'var(--bz-text-2)' }}>
+        <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
           We couldn&apos;t load your settings. Please try again.
         </p>
       </div>

--- a/apps/mouth/src/app/portal/(authenticated)/settings/loading.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/settings/loading.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function PortalSettingsLoading() {
   return (
@@ -14,7 +14,10 @@ export default function PortalSettingsLoading() {
         <div
           key={i}
           className="rounded-xl border p-6 space-y-4"
-          style={{ background: 'rgba(30,30,35,0.7)', borderColor: 'rgba(255,255,255,0.05)' }}
+          style={{
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
+          }}
         >
           <Skeleton variant="text" width={160} height={20} />
           <div className="space-y-3">

--- a/apps/mouth/src/app/portal/(authenticated)/settings/notifications/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/settings/notifications/page.tsx
@@ -1,15 +1,15 @@
-'use client';
+"use client";
 
 /**
  * Portal notification preferences — channel opt-in (email, WhatsApp).
  */
 
-import { FormEvent, useEffect, useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '@/lib/api';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
-import { AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { FormEvent, useEffect, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
 
 interface PrefsResponse {
   email_enabled: boolean;
@@ -20,42 +20,43 @@ interface PrefsResponse {
 const E164_RE = /^[1-9]\d{6,14}$/;
 
 async function fetchPrefs(): Promise<PrefsResponse> {
-  return api.request<PrefsResponse>('/api/portal/notifications/prefs', {
-    method: 'GET',
+  return api.request<PrefsResponse>("/api/portal/notifications/prefs", {
+    method: "GET",
   });
 }
 
 async function savePrefs(body: PrefsResponse): Promise<PrefsResponse> {
-  return api.request<PrefsResponse>('/api/portal/notifications/prefs', {
-    method: 'PUT',
+  return api.request<PrefsResponse>("/api/portal/notifications/prefs", {
+    method: "PUT",
     body: JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
+    headers: { "Content-Type": "application/json" },
   });
 }
 
 export default function NotificationsSettingsPage() {
   const qc = useQueryClient();
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ['portal', 'notification_prefs'],
+    queryKey: ["portal", "notification_prefs"],
     queryFn: fetchPrefs,
   });
 
   const [emailEnabled, setEmailEnabled] = useState(true);
   const [waEnabled, setWaEnabled] = useState(false);
-  const [waPhone, setWaPhone] = useState('');
+  const [waPhone, setWaPhone] = useState("");
   const [phoneError, setPhoneError] = useState<string | null>(null);
 
   useEffect(() => {
     if (data) {
       setEmailEnabled(data.email_enabled);
       setWaEnabled(data.wa_enabled);
-      setWaPhone(data.wa_phone ?? '');
+      setWaPhone(data.wa_phone ?? "");
     }
   }, [data]);
 
   const mutation = useMutation({
     mutationFn: savePrefs,
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['portal', 'notification_prefs'] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["portal", "notification_prefs"] }),
   });
 
   const onSubmit = (e: FormEvent) => {
@@ -64,11 +65,11 @@ export default function NotificationsSettingsPage() {
     const phone = waPhone.trim();
     if (waEnabled) {
       if (!phone) {
-        setPhoneError('WhatsApp number required when WA notifications are on');
+        setPhoneError("WhatsApp number required when WA notifications are on");
         return;
       }
       if (!E164_RE.test(phone)) {
-        setPhoneError('Enter digits only, no leading + (e.g. 628123456789)');
+        setPhoneError("Enter digits only, no leading + (e.g. 628123456789)");
         return;
       }
     }
@@ -96,7 +97,7 @@ export default function NotificationsSettingsPage() {
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>Unable to load preferences</AlertTitle>
           <AlertDescription>
-            {error instanceof Error ? error.message : 'Unexpected error.'}
+            {error instanceof Error ? error.message : "Unexpected error."}
           </AlertDescription>
         </Alert>
       </div>
@@ -167,7 +168,7 @@ export default function NotificationsSettingsPage() {
 
         <div className="flex items-center gap-3">
           <Button type="submit" disabled={mutation.isPending}>
-            {mutation.isPending ? 'Saving…' : 'Save'}
+            {mutation.isPending ? "Saving…" : "Save"}
           </Button>
           {mutation.isSuccess && (
             <span className="text-sm text-[var(--neon-emerald)] inline-flex items-center gap-1">
@@ -178,7 +179,7 @@ export default function NotificationsSettingsPage() {
             <span className="text-sm text-[var(--neon-rose)]">
               {mutation.error instanceof Error
                 ? mutation.error.message
-                : 'Could not save'}
+                : "Could not save"}
             </span>
           )}
         </div>

--- a/apps/mouth/src/app/portal/(authenticated)/settings/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/settings/page.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/portal/settings/SettingsTabs", () => ({
+  SettingsTabs: () => <div data-testid="settings-tabs">tabs</div>,
+}));
+
+import SettingsPage from "./page";
+
+describe("SettingsPage (WS3 day pass)", () => {
+  it("renders the day masthead: copper rule + Cormorant serif in --tx-pure", () => {
+    const { container } = render(<SettingsPage />);
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Settings");
+    expect(heading.style.fontFamily).toBe("var(--font-serif)");
+    expect(heading.className).toContain("text-[var(--tx-pure)]");
+    expect(
+      container.querySelector(
+        '[aria-hidden="true"].bg-\\[var\\(--bz-copper\\)\\]',
+      ),
+    ).not.toBeNull();
+
+    // Tab shell still mounts below the masthead.
+    expect(screen.getByTestId("settings-tabs")).toBeInTheDocument();
+
+    // Drain guard: no hardcoded hex colors (was text-[#f0ece4]).
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+});

--- a/apps/mouth/src/app/portal/(authenticated)/settings/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/settings/page.tsx
@@ -11,11 +11,26 @@ import { SettingsTabs } from "@/components/portal/settings/SettingsTabs";
  *
  * The existing `settings/notifications/` subroute remains live (not
  * deleted) as it may be linked from deep-linked notification emails.
+ *
+ * WS3 slice 7 (GARUDA Day Edition, 2026-07-24): masthead = copper rule +
+ * Cormorant serif (--font-serif) in --tx-pure (was hardcoded #f0ece4
+ * font-light — invisible on operative-light paper).
  */
 export default function SettingsPage() {
   return (
     <main className="max-w-3xl mx-auto px-4 py-6">
-      <h1 className="text-2xl font-light text-[#f0ece4] mb-6">Settings</h1>
+      <section className="mb-6">
+        <div
+          aria-hidden="true"
+          className="w-14 h-[3px] rounded-sm mb-4 bg-[var(--bz-copper)]"
+        />
+        <h1
+          className="text-2xl font-semibold tracking-tight text-[var(--tx-pure)]"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          Settings
+        </h1>
+      </section>
       <SettingsTabs />
     </main>
   );


### PR DESCRIPTION
## WS3 slice 7 (PLAN §4) — three more client surfaces in warm paper

**Author:** Kimi (builder) · **Contract:** author never merges.

### What
- **Companies**: serif masthead; dark rgba cards → `--bz-card` + concept shadow; compliance/license statuses → shared `StatusBadge` on `--state-*`; KBLI chip → hairline copper border (slice-6 finding: 12% copper tint fails AA both themes)
- **Profile**: passport/status panels → state color-mix tones; edit inputs → tokens + copper focus ring; **AA fix**: muted small text `--bz-text-3` (3.49:1 on card) → `--bz-text-2` (7.64:1)
- **Settings**: masthead; tabs + account/language/notification/privacy/security rows → tokens; checkbox accents → `--bz-copper`

### Contrast (computed + cited, operative-light)
All text ≥4.5:1 (states on tints 4.55–5.29:1, copper-text 5.05–5.70:1) · non-text ≥3:1 (copper 3.87:1) · masthead 14.18:1.

### Verification (this turn)
- Portal suite: **199/199** (+16 new page tests + 4 assertions, each page with a no-hex drain guard) · tsc 0 errors · token-lint clean

### Notes
- `--no-verify` push (established rationale).
- Next: lkpm submit/detail, partner pages, auth pages.