### PR TITLE
fix(kbli): tracked inspect_kbli cache-bust — curing the store is not curing the surface

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_inspect_cache_bust.py
+++ b/apps/backend-rag/backend/scripts/kbli_inspect_cache_bust.py
@@ -1,0 +1,132 @@
+"""
+kbli_inspect_cache_bust.py — evict `inspect_kbli`'s per-code Redis cache entries
+so a data-plane cure actually reaches WhatsApp/webchat.
+
+WHY THIS EXISTS (2026-07-24). `inspect_kbli`
+(`GET /api/v1/kbli-notebook/inspect/{code}`, `kbli_notebook.py:352`) caches the
+whole assembled `KBLIDetail` under `kbli_inspect_v2_{code}`, with a TTL from
+`get_kbli_ttl()` that is **30 days** for most codes (12h only for 471/472/563/
+661/62, 7d for 55/41/86/05..09). Every KBLI cure so far — the 8-code pilot, the
+86-code `kbli_documents` cure, the 18-code 4th-surface cure, the 4-code phantom
+cure — has had to evict this cache afterwards, and every one of them did it with
+an ad-hoc snippet that left no trace. This script is that step, tracked.
+
+Concrete failure it prevents (observed live, 2026-07-24): the phantom-row cure
+detached all 53 REQUIRES edges for 26120/60111/82920/85598 and marked the nodes
+`NOT_IN_KBLI_2025`; the DB was independently re-verified clean; and
+`inspect_kbli` still served the FULL pre-cure payload — `TERBUKA`, `REGULATED`,
+`Menengah Rendah`, 27 licences including plantation requirements under a
+packaging code — because a diagnostic call made BEFORE the cure had populated a
+30-day cache entry. Curing the store is not curing the surface (see memory
+`feedback_merged_is_not_live_consumer_map_first_2026_07_16`).
+
+WHAT IT DOES: for each `--only` code, reports whether `kbli_inspect_v2_{code}`
+is currently present, and with `--apply` deletes it and RE-READS to confirm the
+key is actually gone. The re-read matters: `CacheService.delete()` returning
+True is the client's claim, not evidence, and a Redis-unavailable fallback path
+silently degrades to an in-process LRU that a different worker process does not
+share. Reporting present/deleted/still lets a caller see a lie.
+
+SCOPE DISCIPLINE: `--only` is MANDATORY — there is no sweep. Evicting the whole
+keyspace would cost a full cold rebuild of every code page on the next request
+for no benefit; a cure knows exactly which codes it touched.
+
+USAGE (dry-run is the default; nothing is evicted without --apply):
+    PYTHONPATH=. python backend/scripts/kbli_inspect_cache_bust.py --only 82920
+    fly ssh console -a nuzantara-rag -C \\
+        "python /app/backend/scripts/kbli_inspect_cache_bust.py --only 26120,60111,82920,85598 --apply"
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("kbli_inspect_cache_bust")
+
+# Must stay in lockstep with kbli_notebook.py:352. If that key format changes,
+# this script silently evicts nothing and every cure after it ships a live lie —
+# so the format is pinned by a test rather than trusted to stay in sync.
+CACHE_KEY_TEMPLATE = "kbli_inspect_v2_{code}"
+
+
+def cache_key(code: str) -> str:
+    """Pure — the exact key `inspect_kbli` writes for a code."""
+    return CACHE_KEY_TEMPLATE.format(code=code)
+
+
+def parse_codes(raw: str) -> list[str]:
+    """Pure — split/clean `--only`, preserving caller order, dropping blanks."""
+    return [c.strip() for c in (raw or "").split(",") if c.strip()]
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="evict (default: report only)")
+    ap.add_argument(
+        "--only",
+        required=True,
+        help="comma-separated 5-digit codes whose cache entry to evict (never a sweep)",
+    )
+    args = ap.parse_args()
+
+    codes = parse_codes(args.only)
+    if not codes:
+        logger.error("--only produced an empty code list, nothing to do")
+        raise SystemExit(2)
+
+    from backend.core.cache import get_cache_service
+
+    cache = get_cache_service()
+    if cache is None:
+        logger.error("no cache service available — cannot verify or evict")
+        raise SystemExit(2)
+
+    present = 0
+    evicted = 0
+    survived: list[str] = []
+
+    for code in codes:
+        key = cache_key(code)
+        before = await cache.get(key)
+        if before is None:
+            logger.info("  %s: no cache entry (nothing to evict)", code)
+            continue
+        present += 1
+        if not args.apply:
+            logger.info("  %s: cache entry PRESENT — would evict %s", code, key)
+            continue
+
+        await cache.delete(key)
+        # Re-read rather than trusting delete()'s return: that is the client's
+        # claim, and a Redis-unavailable fallback silently uses a per-process
+        # LRU another worker does not share.
+        after = await cache.get(key)
+        if after is None:
+            evicted += 1
+            logger.info("  %s: EVICTED (re-read confirms gone)", code)
+        else:
+            survived.append(code)
+            logger.error("  %s: delete reported success but the key is STILL READABLE", code)
+
+    mode = "APPLIED" if args.apply else "DRY-RUN"
+    logger.info(
+        "%s: %d/%d code(s) had a cache entry | %d evicted | %d survived",
+        mode,
+        present,
+        len(codes),
+        evicted,
+        len(survived),
+    )
+    if survived:
+        logger.error("keys that survived eviction: %s", ", ".join(survived))
+        raise SystemExit(1)
+    if not args.apply and present:
+        logger.info("dry-run complete — rerun with --apply to evict")
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_inspect_cache_bust.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_inspect_cache_bust.py
@@ -1,0 +1,45 @@
+"""Unit tests for kbli_inspect_cache_bust.py.
+
+The load-bearing invariant is NOT the eviction loop — it is that this script's
+key format matches the one `inspect_kbli` actually writes. If those drift, the
+script reports "no cache entry (nothing to evict)" for every code, a cure
+declares itself proven-live, and WhatsApp/webchat keep serving the pre-cure
+payload for up to 30 days. That is the exact failure this tool exists to
+prevent, so it is pinned against the router's own source rather than restated.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from backend.scripts.kbli_inspect_cache_bust import cache_key, parse_codes
+
+ROUTER = Path(__file__).resolve().parents[3] / "app" / "routers" / "kbli_notebook.py"
+
+
+def test_key_format_matches_the_router_that_writes_it():
+    """Anti-drift: read the key literal out of `kbli_notebook.py` and confirm
+    this script builds the same string. A rename on either side fails here
+    instead of silently evicting nothing in production."""
+    src = ROUTER.read_text(encoding="utf-8")
+    m = re.search(r'cache_key\s*=\s*f"([^"]*\{code\}[^"]*)"', src)
+    assert m, f"could not find the inspect cache key literal in {ROUTER}"
+    router_key = m.group(1).replace("{code}", "82920")
+    assert cache_key("82920") == router_key
+
+
+def test_cache_key_is_per_code():
+    assert cache_key("82920") != cache_key("82921")
+    assert "82920" in cache_key("82920")
+
+
+def test_parse_codes_preserves_order_and_drops_blanks():
+    assert parse_codes("26120, 60111 ,82920,,85598") == ["26120", "60111", "82920", "85598"]
+
+
+def test_parse_codes_empty_input_yields_empty_list():
+    """Feeds the caller's exit-2 refusal — an empty scope must never be read as
+    "nothing needed evicting"."""
+    assert parse_codes("") == []
+    assert parse_codes(" , , ") == []

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 658 services · 1230 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 658 services · 1231 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Why now

The phantom-row cure (#3070) landed and was independently verified in the DB: **0 REQUIRES edges** left on the 4 phantom nodes, all marked `NOT_IN_KBLI_2025`, 53 detached edges archived (19/2/27/5 — exact match to the pre-cure counts). `chat_kbli` is proven-live and now answers that `82920` is an obsolete KBLI 2020 code that cannot be used on OSS.

**`inspect_kbli` still served the FULL pre-cure payload** — `TERBUKA`, `REGULATED`, `Menengah Rendah`, 27 licences including plantation requirements (`peta digital Izin Usaha Perkebunan`) under a **packaging** code.

Root cause: `inspect_kbli` caches the whole assembled `KBLIDetail` under `kbli_inspect_v2_{code}` (`kbli_notebook.py:352`) with a TTL from `get_kbli_ttl()` that is **30 days** for most codes. A diagnostic call made *before* the cure had populated that entry. Redis is configured in prod, so it also survives a machine restart.

The store was cured. The surface was not — [[feedback_merged_is_not_live_consumer_map_first_2026_07_16]].

## Why a tracked tool rather than another snippet

**Every** KBLI cure so far has needed this step — the 8-code pilot, the 86-code `kbli_documents` cure, the 18-code 4th-surface cure, today's 4-code phantom cure — and **every one did it with an ad-hoc snippet that left no trace in the repo**. That is the untracked-payload smell of superscar #1, repeated four times. This is the step, tracked, tested, and reusable by the next cure.

## Design

- **`--only` is MANDATORY, no sweep flag.** Evicting the whole keyspace would force a cold rebuild of every code page for no benefit; a cure knows exactly which codes it touched.
- **Re-reads after deleting** instead of trusting `CacheService.delete()`'s return value. That return is the *client's claim*, not evidence — and the Redis-unavailable path silently degrades to a per-process LRU that another worker does not share. A key that survives eviction is reported explicitly and **exits 1**, rather than passing as success.
- Dry-run is the default and reports present/absent per code.

## The test that actually matters

The load-bearing invariant is not the eviction loop — it is that this script's key format matches the one the router *writes*. If they drift, the script reports "no cache entry (nothing to evict)" for every code, a cure declares itself proven-live, and WhatsApp/webchat keep serving the pre-cure payload for up to 30 days.

So the test **reads the key literal out of `kbli_notebook.py`'s own source** and asserts this script builds the same string, rather than restating the format. A rename on either side fails in CI instead of silently evicting nothing in production.

## After merge

Deploy → `--apply` on `26120,60111,82920,85598` → re-verify `inspect_kbli` returns the honest degraded state (`risk_profile: "Not classified"`, no licences). The phantom cure is **not** declared done until that surface is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)