### PR TITLE
fix(kbli): cache-bust must initialize RedisManager + fail loud on degraded cache

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_inspect_cache_bust.py
+++ b/apps/backend-rag/backend/scripts/kbli_inspect_cache_bust.py
@@ -78,12 +78,40 @@ async def main() -> None:
         logger.error("--only produced an empty code list, nothing to do")
         raise SystemExit(2)
 
+    # A one-shot process is NOT the app: `RedisManager` is initialized in the
+    # FastAPI lifespan, so without this call `get_cache_service()` finds no
+    # manager and silently degrades to a per-process in-memory LRU — which is
+    # EMPTY here and would make every key look absent. That is a false clean:
+    # the live web workers hold the poisoned entry in the SHARED Redis this
+    # process never connected to. (Observed 2026-07-24: the first cut of this
+    # script reported "0/4 had a cache entry" while Redis held all 4.)
+    from backend.core.redis_manager import RedisManager
+
+    RedisManager.get_instance().initialize()
+
     from backend.core.cache import get_cache_service
 
     cache = get_cache_service()
     if cache is None:
         logger.error("no cache service available — cannot verify or evict")
         raise SystemExit(2)
+
+    # Force the lazy connect, then FAIL LOUD if Redis is configured but we did
+    # not reach it. Reporting "nothing to evict" against a degraded in-memory
+    # cache is the exact false-success this tool exists to prevent, so a
+    # configured-but-unreachable Redis is an error, never a clean result.
+    cache._try_connect_redis()  # the public cache API has no eager-connect hook
+    redis_configured = bool(RedisManager.get_instance()._redis_url)
+    if redis_configured and not cache.redis_available:
+        logger.error(
+            "REDIS_URL is configured but this process could not connect — refusing to "
+            "report eviction against a per-process in-memory cache the web workers do not "
+            "share. Run this where Redis is reachable."
+        )
+        raise SystemExit(3)
+    logger.info(
+        "cache backend: %s", "shared Redis" if cache.redis_available else "in-memory (no Redis configured)"
+    )
 
     present = 0
     evicted = 0


### PR DESCRIPTION
## The tool gave a false clean on its first live run

The tracked cache-bust shipped in #3072 was run one-shot on prod to evict the 4 phantom `inspect_kbli` entries. It reported:

```
0/4 code(s) had a cache entry | 0 evicted | 0 survived
```

…while the shared Redis held **all 4** poisoned entries, and `inspect_kbli` kept serving the full pre-cure payload.

## Root cause

`RedisManager` is initialized in the FastAPI **lifespan**, not on import. A one-shot process (`fly ssh console -C python ...`) never runs that lifespan, so `get_cache_service()` finds no initialized manager and silently degrades to a **per-process in-memory LRU** — which is empty, making every key look absent. `REDIS_URL` is present in the process env the whole time; nothing connected it.

This is the *store-vs-surface* lesson turned on the cure tool itself. The re-read-after-delete guard I built can't help here: it catches a `delete()` that lied, but not a **lookup that hit the wrong (empty) cache** in the first place. A cache eviction that cannot see the shared cache is not an eviction — it is a second false-clean stacked on the first.

## Fix

- Call `RedisManager.get_instance().initialize()` before touching the cache, so a standalone run connects to the same Redis the web workers use.
- After forcing the lazy connect, **FAIL LOUD (exit 3)** when `REDIS_URL` is configured but this process could not reach Redis — never report "nothing to evict" against a degraded in-memory cache. A genuinely Redis-less deployment (no URL) still reports in-memory and proceeds.
- Log which backend was actually reached (`shared Redis` vs `in-memory`), so the operator sees it rather than infers it.

## After merge

Deploy → `--apply` on the 4 phantom codes → **confirm the log says `cache backend: shared Redis`** (proof the fix works) → re-verify `inspect_kbli` returns the honest degraded state (`risk_profile: "Not classified"`, no licences, no plantation requirements under a packaging code). The phantom cure is not declared done until that surface is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)