### PR TITLE
feat(ci): telegram-secret-healthcheck — on-demand proof the alert lane is armed

### DIFF
--- a/.github/workflows/telegram-secret-healthcheck.yml
+++ b/.github/workflows/telegram-secret-healthcheck.yml
@@ -1,0 +1,96 @@
+name: telegram-secret-healthcheck
+
+# On-demand proof that the Telegram alert lane is actually ARMED (superscar #2,
+# esiste≠armato). 13 workflows in this repo send owner alerts through
+# secrets.TELEGRAM_BOT_TOKEN; every one of them swallows the send result
+# (`curl ... || true`, output to /dev/null), so a dead/rotated token fails
+# SILENTLY — the workflow stays green while no alert ever reaches Zero. This
+# was live on 2026-07-24: the Actions secret was last set 2026-04-11 but the
+# bot token was fleet-rotated 2026-07-14, so getMe returned
+# {"ok":false,"error_code":401} and nobody knew until it surfaced in a
+# hot-zone-pr-gate log (scar W102 GOTCHA).
+#
+# This gate does the opposite of those alert steps: it reads the API result and
+# FAILS LOUD when the token cannot authenticate. Run it after any bot-token
+# rotation to confirm the alert lane is live again.
+#
+# workflow_dispatch only — never on a schedule/PR, so it never spams and never
+# blocks anything. It sends NO message by default (getMe is a read-only probe);
+# opt into a real owner message with the send_test_message input.
+#
+# Injection hygiene: the only input is a boolean; secrets and inputs are passed
+# via env: and referenced as "$VAR" in run:, never expanded inline into the
+# command string. The token is never echoed — only the API's ok/error fields.
+
+on:
+  workflow_dispatch:
+    inputs:
+      send_test_message:
+        description: "Also send a real test message to the owner chat (default: getMe only, no message)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Telegram bot token authenticates (getMe)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: getMe — token must authenticate
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          set -uo pipefail
+
+          if [ -z "${BOT:-}" ]; then
+            echo "::error::secrets.TELEGRAM_BOT_TOKEN is empty — the alert lane is unarmed"
+            exit 1
+          fi
+
+          # getMe is read-only: it validates the token without sending anything.
+          RESP="$(curl -sS -m 15 "https://api.telegram.org/bot${BOT}/getMe" || true)"
+
+          if [ "$(printf '%s' "$RESP" | jq -r '.ok // false')" != "true" ]; then
+            # Surface the API error WITHOUT ever echoing the token.
+            DESC="$(printf '%s' "$RESP" | jq -r '"\(.error_code // "?") \(.description // "no description")"' 2>/dev/null || echo "unparseable response")"
+            echo "::error::TELEGRAM_BOT_TOKEN did NOT authenticate — getMe returned: ${DESC}"
+            echo "::error::The alert lane is DEAD. Rotate the secret: gh secret set TELEGRAM_BOT_TOKEN --repo ${GITHUB_REPOSITORY}"
+            exit 1
+          fi
+
+          USERNAME="$(printf '%s' "$RESP" | jq -r '.result.username // "?"')"
+          echo "✅ getMe ok — bot @${USERNAME} authenticates. Alert lane is armed."
+
+      - name: sendMessage — optional real delivery to owner
+        if: ${{ inputs.send_test_message }}
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+
+          if [ -z "${CHAT:-}" ]; then
+            echo "::error::secrets.TELEGRAM_OWNER_CHAT_ID is empty — cannot deliver"
+            exit 1
+          fi
+
+          TEXT="✅ telegram-secret-healthcheck: alert lane verified live
+          ${RUN_URL}"
+
+          RESP="$(curl -sS -m 15 -X POST \
+            "https://api.telegram.org/bot${BOT}/sendMessage" \
+            -d "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}" || true)"
+
+          if [ "$(printf '%s' "$RESP" | jq -r '.ok // false')" != "true" ]; then
+            DESC="$(printf '%s' "$RESP" | jq -r '"\(.error_code // "?") \(.description // "no description")"' 2>/dev/null || echo "unparseable response")"
+            echo "::error::sendMessage FAILED — token authenticates but delivery failed: ${DESC}"
+            echo "::error::Check TELEGRAM_OWNER_CHAT_ID and that the bot can message that chat."
+            exit 1
+          fi
+
+          echo "✅ Test message delivered to the owner chat — check Telegram."


### PR DESCRIPTION
## Insight

13 workflows in this repo alert the owner through `secrets.TELEGRAM_BOT_TOKEN`, and every
one swallows the send result (`curl ... || true`, output to `/dev/null`). So when the token
went stale — the Actions secret was last set **2026-04-11** while the bot token was
fleet-rotated **2026-07-14** — `getMe` returned `{"ok":false,"error_code":401}` and every
alert died **silently** while the workflows stayed green. It only surfaced because a getMe
401 happened to print in a `hot-zone-pr-gate` log (scar W102). That is superscar #2 in its
purest form: exists ≠ armed.

## Studio

`.github/workflows/telegram-secret-healthcheck.yml` — a `workflow_dispatch`-only gate that
does the **opposite** of those alert steps: it calls `getMe` (read-only, sends nothing) and
**fails loud** if the token cannot authenticate, printing the exact `gh secret set` fix.
Opt into a real owner-chat delivery with the `send_test_message` input. Run it after any
bot-token rotation to prove the alert lane is live again.

- Never scheduled, never on PR → no spam, blocks nothing.
- Injection-safe: the only input is a boolean; secrets go via `env:`, never inlined into `run:`.
- The token is never echoed — only the API's `ok`/`error_code`/`description` fields.

## Verification

- `actionlint` clean.
- `jq` parsing smoke-tested locally on both branches:
  `{"ok":false,"error_code":401,...}` → `false` + `401 Unauthorized`; ok → username.
- Post-merge it becomes dispatchable; the intended first run is right after the pending
  `TELEGRAM_BOT_TOKEN` rotation, to turn the currently-dead alert lane green on the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
