### PR TITLE
feat(kbli): Batch-B step 2 — populate bps_2020_ancestors on 1,338 codes (mechanical-only)

### DIFF
--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
-  "lastModified": "2026-07-21",
-  "datasetSha256": "sha256:446c5f5f1fcf5c33d18d411c71843a48f398b9b7a52f1f249c507c86604cf50b",
+  "lastModified": "2026-07-24",
+  "datasetSha256": "sha256:bc8c9879ddebccd091f3027603642be75261bb5d497375759cf5ae7953bb904f",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "2df807b006a9158afef9c153e31875daf12ec727",
-  "canonical_sha256": "446c5f5f1fcf5c33d18d411c71843a48f398b9b7a52f1f249c507c86604cf50b",
+  "canonical_revision": "fd181cd8e5cc77159d8a7a4d4758ca68e17dceb5",
+  "canonical_sha256": "bc8c9879ddebccd091f3027603642be75261bb5d497375759cf5ae7953bb904f",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -307,6 +307,29 @@ AUTO_APPROVE_RULES: list[tuple[re.Pattern[str], str]] = [
         "KBLI filiera cure specs: compiler input artifacts (data-plane guard #2550), "
         "sha256 render/evidence digests by design, zero credentials",
     ),
+    # KBLI canonical dataset + its sync'd consumer copies. Since Batch-B step 2
+    # (populate_bps_ancestors.py, 2026-07-24) every OSS-native record carries a
+    # `bps_2020_ancestors.parser_run_digest` — the sha256 of the gate-certified
+    # crosswalk parse — which reads as a Hex High Entropy String. Same closed-
+    # writer-set safety as the data/kbli-filiera rule above: the canonical
+    # (data/source_documents/KBLI_2025_FINAL_CLEAN.json) is data-plane-guarded
+    # (#2550, scripts/kbli_filiera/*.py compilers only); the consumer copies are
+    # byte-identical propagations by sync_kbli_dataset.sh, enforced equal to the
+    # canonical by the check-kbli-dataset-sync CI gate — so a credential can't
+    # enter a copy without also failing that gate. These files emit sha256
+    # digests, public KBLI codes, and PP28/OSS citations only, never credentials.
+    (
+        re.compile(
+            r"(^|/)(data/source_documents/KBLI_2025_FINAL_CLEAN\.json"
+            r"|apps/mouth/data/KBLI_2025_FINAL_CLEAN\.json"
+            r"|apps/backend-rag/backend/data/KBLI_2025_FINAL_CLEAN\.json"
+            r"|apps/backend-rag/source_documents/KBLI_2025_FINAL_CLEAN\.json"
+            r"|apps/kbli-navigator/data/kbli-2025\.json)$"
+        ),
+        "KBLI canonical dataset + sync'd copies: compiler-written (data-plane guard "
+        "#2550) / sync-invariant-enforced; bps_2020_ancestors.parser_run_digest sha256 "
+        "provenance by design, zero credentials",
+    ),
     # Nuzantara Lex source manifests pin downloaded public regulations by
     # SHA-256 so the fetcher can prove byte identity across runs. These are
     # content digests, not bearer tokens or credentials.

--- a/scripts/kbli_filiera/populate_bps_ancestors.py
+++ b/scripts/kbli_filiera/populate_bps_ancestors.py
@@ -1,0 +1,377 @@
+"""Batch-B migration step (2) — bulk-populate `bps_2020_ancestors` (mechanical-only).
+
+Writes the additive canonical field `bps_2020_ancestors` (design §2.2) onto the
+**1,338 Batch-B codes** — the OSS-native population, identified by `_l2_status is
+None`. Batch A's 221 no-scope codes (`_l2_status == "no_oss_risk"`) are explicitly
+OUT of scope for this field and are never touched (design §2.2, §2.4).
+
+The edge set for each code is copied VERBATIM from the Phase-0 crosswalk relation
+artifact (`data/kbli-filiera/phase0/bps_crosswalk.json`), which the acceptance gate
+(§1.4) certified. This compiler REFUSES to run unless the gate report says the parse
+PASSED and its `parser_run_digest` matches the relation artifact's
+`output_relation_digest` — a code never gets mechanical ancestry from an uncertified
+or moved parse (W88/W90: act on a verdict only while its data-source is still the one
+that was judged). Nothing about the edges is invented here — a genuinely new-in-2025
+code (empty ancestry) is a hard error, not a silent empty write, because every Batch-B
+code was verified to carry non-empty ancestry when this tool was written (rule #9).
+
+Every written entry is `adjudication_status: mechanical-only` /
+`inheritance_verdict: not-adjudicated`: mechanical edge presence NEVER implies the
+licensing regime transfers — that is the separate D1/D5 semantic judgment the per-code
+cure-spec compilers apply later (design §2.2, §4). This tool is idempotent: a record
+that already carries `bps_2020_ancestors` is left untouched (so a later per-code
+adjudication is never clobbered by a re-run); a pre-existing entry whose
+`parser_run_digest` differs from the current relation is reported LOUD, never
+silently overwritten.
+
+Writer discipline (#2550): this compiler lives under `scripts/kbli_filiera/` and is an
+authorized writer of `data/source_documents/KBLI_2025_FINAL_CLEAN.json`. On `--apply`
+it mutates the canonical (atomic tmp+replace), then runs `sync_kbli_dataset.sh sync`
+to propagate to the consumer copies and bumps the mouth sidecar sha256 — the exact
+flow `cure_canonical_collisions.py` uses.
+
+    python scripts/kbli_filiera/populate_bps_ancestors.py            # dry-run (default)
+    python scripts/kbli_filiera/populate_bps_ancestors.py --apply    # mutate + sync + sidecar
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from kbli_filiera import bps_crosswalk_parser as parser  # noqa: E402
+from kbli_filiera import vault_common as common  # noqa: E402
+
+logger = common.setup_logger("populate_bps_ancestors")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CANONICAL = REPO_ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+DEFAULT_RELATION = REPO_ROOT / "data" / "kbli-filiera" / "phase0" / "bps_crosswalk.json"
+DEFAULT_GATE_REPORT = REPO_ROOT / "data" / "kbli-filiera" / "phase0" / "gate_report.json"
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync_kbli_dataset.sh"
+SIDECAR_PATH = REPO_ROOT / "apps" / "mouth" / "data" / "kbli-dataset-version.json"
+SIDECAR_DATASET_PATH = REPO_ROOT / "apps" / "mouth" / "data" / "KBLI_2025_FINAL_CLEAN.json"
+
+CODE_FIELD = "kode_kbli_2025"
+FIELD = "bps_2020_ancestors"
+
+# Batch membership markers (design §2.4). Batch B is the OSS-native population that
+# gets this field; Batch A is out of scope for it.
+BATCH_B_MARKER = None            # _l2_status is None
+BATCH_A_MARKER = "no_oss_risk"   # _l2_status == "no_oss_risk"
+EXPECTED_BATCH_B = 1338          # design-pinned; --expect-batch-b overrides on a real catalog change
+
+# Every bulk-written entry is mechanical-only / not-adjudicated (design §2.2).
+ADJUDICATION_STATUS = "mechanical-only"
+INHERITANCE_VERDICT = "not-adjudicated"
+ADJUDICATED_BY = "mechanical-only"
+
+
+class PopulateError(RuntimeError):
+    """A precondition/artifact mismatch severe enough to make the run's exit non-zero."""
+
+
+def _detect_indent(raw_text: str) -> int:
+    """Measure the JSON indent width from the file's own formatting rather than
+    assuming 2 — measure, don't presume (cure_canonical_collisions.py:158)."""
+    for line in raw_text.splitlines()[1:8]:
+        stripped = line.lstrip(" ")
+        leading = len(line) - len(stripped)
+        if leading > 0:
+            return leading
+    return 2
+
+
+def load_relation_artifact(path: Path) -> tuple[dict[str, dict[str, Any]], str]:
+    """Return (relation, output_relation_digest) after validating the artifact shape.
+
+    Fail-loud on any structural surprise: the relation must be a non-empty dict whose
+    every value carries exactly {codes, sebagian, source_locator}, with codes/sebagian
+    equal-length lists (a per-edge boolean each). This is the only edge source; a
+    malformed one must halt, never populate garbage."""
+    if not path.exists():
+        raise PopulateError(f"relation artifact not found: {path}")
+    art = json.loads(path.read_text(encoding="utf-8"))
+    relation = art.get("relation")
+    digest = (art.get("manifest") or {}).get("output_relation_digest")
+    if not isinstance(relation, dict) or not relation:
+        raise PopulateError(f"{path}: 'relation' missing or empty")
+    if not isinstance(digest, str) or len(digest) != 64:
+        raise PopulateError(f"{path}: manifest.output_relation_digest missing or not a sha256")
+    for code, rec in relation.items():
+        if set(rec.keys()) != {"codes", "sebagian", "source_locator"}:
+            raise PopulateError(f"{path}: relation[{code!r}] has unexpected keys {sorted(rec.keys())}")
+        codes, sebagian, sl = rec["codes"], rec["sebagian"], rec["source_locator"]
+        if not isinstance(codes, list) or not isinstance(sebagian, list) or not isinstance(sl, list):
+            raise PopulateError(f"{path}: relation[{code!r}] codes/sebagian/source_locator must be lists")
+        if len(codes) != len(sebagian):
+            raise PopulateError(
+                f"{path}: relation[{code!r}] len(codes)={len(codes)} != len(sebagian)={len(sebagian)}"
+            )
+        for loc in sl:
+            if not isinstance(loc, dict):
+                raise PopulateError(
+                    f"{path}: relation[{code!r}] source_locator entry is not an object: {loc!r}"
+                )
+    # Content-bind the digest: recompute it from the relation itself with the parser's
+    # OWN canonicalization (single source of truth, no duplicated algorithm) and refuse
+    # if the stored value lies. A hand-edit to the edges that left output_relation_digest
+    # stale is caught HERE, so the gate binding downstream is over verified content, not a
+    # self-declared field (W88 — verify by CONTENT, never trust a proxy).
+    recomputed = parser._relation_digest({"relation": relation})
+    if recomputed != digest:
+        raise PopulateError(
+            f"{path}: manifest.output_relation_digest ({digest[:16]}…) does not match the digest "
+            f"recomputed from the relation content ({recomputed[:16]}…) — the artifact was edited "
+            f"without re-stamping its digest; regenerate it with the parser before populating"
+        )
+    return relation, digest
+
+
+def assert_gate_certifies(gate_report_path: Path, relation_digest: str) -> None:
+    """Refuse to populate unless the acceptance gate PASSED on THIS exact relation.
+
+    Binds the write to the certified parse by CONTENT (the digest), not by trust that
+    the artifact on disk is the one the gate judged (W88/W90). No override flag — a
+    bypass would defeat the whole point of the gate."""
+    if not gate_report_path.exists():
+        raise PopulateError(f"gate report not found: {gate_report_path}")
+    gate = json.loads(gate_report_path.read_text(encoding="utf-8"))
+    verdict = gate.get("verdict")
+    gate_digest = gate.get("parser_run_digest")
+    if verdict != "PASS":
+        raise PopulateError(
+            f"acceptance gate verdict is {verdict!r}, not 'PASS' — refusing to populate "
+            f"(re-run bps_phase0_gate.py until the parse clears §1.4)"
+        )
+    if gate_digest != relation_digest:
+        raise PopulateError(
+            f"gate.parser_run_digest ({str(gate_digest)[:16]}…) != relation "
+            f"output_relation_digest ({relation_digest[:16]}…) — the certified parse and the "
+            f"relation on disk have diverged; re-run the gate on the current relation before populating"
+        )
+
+
+def build_field(anc: dict[str, Any], digest: str, as_of: str) -> dict[str, Any]:
+    """Assemble one `bps_2020_ancestors` value (design §2.2) from a relation entry.
+
+    Edges (codes/sebagian/source_locator) are copied verbatim; the four adjudication
+    fields are the frozen mechanical-only constants. `inheritance_verdict` is never
+    inferred from the edges — a mechanical edge set does not imply regime transfer."""
+    return {
+        "codes": list(anc["codes"]),
+        "sebagian": list(anc["sebagian"]),
+        "source_locator": copy.deepcopy(anc["source_locator"]),
+        "parser_run_digest": digest,
+        "adjudication_status": ADJUDICATION_STATUS,
+        "inheritance_verdict": INHERITANCE_VERDICT,
+        "adjudicated_by": ADJUDICATED_BY,
+        "adjudicated_at": as_of,
+    }
+
+
+def run_sync_script() -> None:
+    logger.info("running %s sync", SYNC_SCRIPT)
+    result = subprocess.run(
+        ["bash", str(SYNC_SCRIPT), "sync"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        raise PopulateError(f"sync_kbli_dataset.sh sync failed with exit {result.returncode}")
+
+
+def update_sidecar() -> None:
+    if not SIDECAR_DATASET_PATH.exists():
+        raise PopulateError(f"sidecar dataset copy missing: {SIDECAR_DATASET_PATH} (sync must run first)")
+    digest = hashlib.sha256(SIDECAR_DATASET_PATH.read_bytes()).hexdigest()
+    sidecar = json.loads(SIDECAR_PATH.read_text(encoding="utf-8"))
+    before = dict(sidecar)
+    # Idempotent: if the sidecar already pins this exact dataset, do not rewrite it — a
+    # spurious lastModified bump would be a phantom diff, and calling this unconditionally
+    # on every --apply (the recovery-safe reconcile below) must be a true no-op when
+    # nothing changed.
+    if before.get("datasetSha256") == f"sha256:{digest}":
+        logger.info("sidecar already current (%s) — no write", before.get("datasetSha256"))
+        return
+    sidecar["datasetSha256"] = f"sha256:{digest}"
+    sidecar["lastModified"] = date.today().isoformat()
+    SIDECAR_PATH.write_text(
+        json.dumps(sidecar, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    logger.info("sidecar updated: %s -> %s", before.get("datasetSha256"), sidecar["datasetSha256"])
+    logger.info("sidecar lastModified: %s -> %s", before.get("lastModified"), sidecar["lastModified"])
+
+
+def plan_and_apply(
+    records: list[dict[str, Any]],
+    relation: dict[str, dict[str, Any]],
+    digest: str,
+    as_of: str,
+    *,
+    expected_batch_b: int,
+    do_apply: bool,
+) -> tuple[int, list[str]]:
+    """Populate FIELD on every Batch-B record lacking it. Returns (n_populated, problems).
+
+    When do_apply is False the record dicts are not mutated (pure classification) —
+    the caller writes nothing. When True, records are mutated in place (the field is
+    appended to each, a clean additive diff) and the caller persists them."""
+    batch_b = [r for r in records if r.get("_l2_status") is BATCH_B_MARKER]
+    batch_a = [r for r in records if r.get("_l2_status") == BATCH_A_MARKER]
+    problems: list[str] = []
+
+    # Completeness (W97): every record must classify as Batch-B or Batch-A. A record
+    # carrying some other _l2_status is skipped by both branches — that "which batch does
+    # this get?" ambiguity must halt a bulk write, not be sailed past silently.
+    unclassified = [
+        r for r in records
+        if r.get("_l2_status") is not BATCH_B_MARKER and r.get("_l2_status") != BATCH_A_MARKER
+    ]
+    if unclassified:
+        seen = sorted({str(r.get("_l2_status")) for r in unclassified})
+        problems.append(
+            f"{len(unclassified)} record(s) have an unrecognized _l2_status (neither Batch-B "
+            f"None nor Batch-A {BATCH_A_MARKER!r}): {seen[:10]}"
+        )
+
+    # W97: the population size is a CLAIM, not a silent cap. A drift from the pinned
+    # 1,338 must be acknowledged via --expect-batch-b, never sailed past.
+    if len(batch_b) != expected_batch_b:
+        problems.append(
+            f"Batch-B population is {len(batch_b)}, expected {expected_batch_b} "
+            f"(catalog changed? re-run with --expect-batch-b {len(batch_b)} to acknowledge)"
+        )
+
+    to_populate: list[dict[str, Any]] = []
+    already_same = 0
+    already_diff: list[str] = []
+    for rec in batch_b:
+        code = rec.get(CODE_FIELD)
+        existing = rec.get(FIELD)
+        if isinstance(existing, dict):
+            # Idempotent: never clobber. A stale digest is a loud report, not an overwrite.
+            if existing.get("parser_run_digest") == digest:
+                already_same += 1
+            else:
+                already_diff.append(str(code))
+            continue
+        anc = relation.get(code)
+        if anc is None:
+            problems.append(f"Batch-B code {code!r} absent from certified relation — cannot populate")
+            continue
+        if not anc["codes"]:
+            problems.append(
+                f"Batch-B code {code!r} has EMPTY ancestry in the relation — a new-in-2025 code "
+                f"needs an explicit decision, not a silent empty write (rule #9)"
+            )
+            continue
+        to_populate.append(rec)
+
+    if already_diff:
+        problems.append(
+            f"{len(already_diff)} Batch-B code(s) already carry {FIELD} with a DIFFERENT "
+            f"parser_run_digest (not overwritten): {sorted(already_diff)[:10]}"
+            + ("…" if len(already_diff) > 10 else "")
+        )
+
+    # Post-condition (W97 anti-scope-creep): Batch-A must NEVER carry the field.
+    contaminated_a = [str(r.get(CODE_FIELD)) for r in batch_a if FIELD in r]
+    if contaminated_a:
+        problems.append(
+            f"{len(contaminated_a)} Batch-A (no-scope) code(s) carry {FIELD} — out-of-scope "
+            f"contamination: {sorted(contaminated_a)[:10]}"
+        )
+
+    logger.info(
+        "Batch-B=%d Batch-A=%d | to-populate=%d already(same-digest)=%d already(diff-digest)=%d",
+        len(batch_b), len(batch_a), len(to_populate), already_same, len(already_diff),
+    )
+
+    if do_apply:
+        for rec in to_populate:
+            rec[FIELD] = build_field(relation[rec[CODE_FIELD]], digest, as_of)
+
+    return len(to_populate), problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--canonical", type=Path, default=DEFAULT_CANONICAL, help="canonical dataset to mutate")
+    ap.add_argument("--relation", type=Path, default=DEFAULT_RELATION, help="Phase-0 crosswalk relation artifact")
+    ap.add_argument("--gate-report", type=Path, default=DEFAULT_GATE_REPORT, help="Phase-0 acceptance gate report")
+    ap.add_argument("--as-of", default=date.today().isoformat(), help="adjudicated_at date (default: today)")
+    ap.add_argument("--expect-batch-b", type=int, default=EXPECTED_BATCH_B,
+                    help=f"expected Batch-B population (default: {EXPECTED_BATCH_B})")
+    ap.add_argument("--apply", action="store_true", help="mutate the canonical (default: dry-run, writes nothing)")
+    args = ap.parse_args(argv)
+
+    relation, digest = load_relation_artifact(args.relation)
+    assert_gate_certifies(args.gate_report, digest)
+
+    if not args.canonical.exists():
+        raise PopulateError(f"canonical dataset not found: {args.canonical}")
+    raw_text = args.canonical.read_text(encoding="utf-8")
+    indent = _detect_indent(raw_text)
+    dataset = json.loads(raw_text)
+    records: list[dict[str, Any]] = dataset["data"]
+
+    print(f"populate_bps_ancestors.py — canonical={args.canonical} relation={args.relation}")
+    print(f"certified digest = {digest[:16]}…  as_of = {args.as_of}  indent = {indent}  "
+          f"mode = {'APPLY' if args.apply else 'DRY-RUN'}")
+    print("-" * 78)
+
+    n_populate, problems = plan_and_apply(
+        records, relation, digest, args.as_of,
+        expected_batch_b=args.expect_batch_b, do_apply=args.apply,
+    )
+
+    print("-" * 78)
+    print(f"summary: {n_populate} record(s) to populate with {FIELD}, {len(problems)} problem(s)")
+    for p in problems:
+        logger.error(p)
+
+    if not args.apply:
+        print("DRY RUN — no files written. Re-run with --apply to mutate the canonical.")
+        return 1 if problems else 0
+
+    if problems:
+        logger.error("problems present — refusing to write (fix the artifacts and re-run)")
+        return 1
+
+    if n_populate:
+        tmp_path = args.canonical.with_suffix(args.canonical.suffix + ".tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as f:
+                json.dump(dataset, f, ensure_ascii=False, indent=indent)
+            tmp_path.replace(args.canonical)
+            logger.info("wrote %d populated record(s) to %s", n_populate, args.canonical)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+    else:
+        logger.info("nothing new to populate — reconciling consumers + sidecar from canonical")
+
+    # Always reconcile on --apply (both steps are idempotent no-ops when already in sync).
+    # This lets a re-run RECOVER a prior partial apply where the canonical was written but
+    # sync/sidecar then failed — never a dead end that leaves consumers stale (family #2).
+    run_sync_script()
+    update_sidecar()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kbli_filiera/tests/test_populate_bps_ancestors.py
+++ b/scripts/kbli_filiera/tests/test_populate_bps_ancestors.py
@@ -1,0 +1,392 @@
+"""Tests for the Batch-B bulk compiler `populate_bps_ancestors.py`.
+
+Guilt + innocence per scar #3, on tiny synthetic fixtures (pure-stdlib, no vault
+PDF, no 36 MB canonical). The mutation must be strictly ADDITIVE (§2.2): only the
+new `bps_2020_ancestors` field appears, only on the 1,338-class Batch-B population
+(`_l2_status is None`), never on Batch A (`no_oss_risk`), and every pre-existing
+key/value survives byte-identical. The three fail-closed guards — gate must say
+PASS, gate digest must match the relation, and no edge is ever invented — each get
+a guilt case (fires on the defect) and an innocence case (does not fire on the
+legitimate neighbour).
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+FILIERA = Path(__file__).resolve().parents[1]
+if str(FILIERA) not in sys.path:
+    sys.path.insert(0, str(FILIERA))
+
+import populate_bps_ancestors as P  # noqa: E402
+from kbli_filiera import bps_crosswalk_parser as parser  # noqa: E402
+
+# A syntactically-valid but fake parse digest (64 hex). Not a credential.
+DIGEST = "a" * 64  # pragma: allowlist secret
+
+
+def _digest_of(relation: dict) -> str:
+    """The output_relation_digest the parser would stamp for this relation."""
+    return parser._relation_digest({"relation": relation})
+
+
+def _rec(code: str, l2_status, extra: dict | None = None) -> dict:
+    r = {
+        "kode_kbli_2025": code,
+        "judul": f"Judul {code}",
+        "uraian": "uraian text",
+        "_l2_status": l2_status,
+    }
+    if extra:
+        r.update(extra)
+    return r
+
+
+def _relation(spec: dict[str, list[tuple[str, bool]]]) -> dict:
+    """spec: {code2025: [(ancestor2020, sebagian_bool), ...]}."""
+    rel = {}
+    for code, edges in spec.items():
+        rel[code] = {
+            "codes": [a for a, _ in edges],
+            "sebagian": [s for _, s in edges],
+            "source_locator": [{"lampiran": 10, "pdf_page": 325, "printed_page": 311}],
+        }
+    return rel
+
+
+def _write_world(tmp_path, records, relation, *, digest=None, verdict="PASS", gate_digest=None):
+    # Default the stored digest to the parser's own recompute of this relation so the
+    # content-bind in load_relation_artifact passes; pass an explicit `digest` to force a
+    # mismatch (stale-digest guilt case) or to unit-test the gate binding in isolation.
+    stored = digest if digest is not None else _digest_of(relation)
+    canon = tmp_path / "canon.json"
+    canon.write_text(json.dumps({"data": records}, ensure_ascii=False, indent=2), encoding="utf-8")
+    rel = tmp_path / "rel.json"
+    rel.write_text(
+        json.dumps({"relation": relation, "manifest": {"output_relation_digest": stored}},
+                   ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    gate = tmp_path / "gate.json"
+    gate.write_text(
+        json.dumps({"verdict": verdict, "parser_run_digest": gate_digest or stored},
+                   ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return canon, rel, gate
+
+
+# --------------------------------------------------------------------------- #
+# build_field — schema §2.2                                                    #
+# --------------------------------------------------------------------------- #
+
+def test_build_field_schema_and_verbatim_edges():
+    anc = {"codes": ["49214", "49219"], "sebagian": [False, True],
+           "source_locator": [{"lampiran": 10, "pdf_page": 399, "printed_page": 385}]}
+    f = P.build_field(anc, DIGEST, "2026-07-24")
+    assert set(f.keys()) == {
+        "codes", "sebagian", "source_locator", "parser_run_digest",
+        "adjudication_status", "inheritance_verdict", "adjudicated_by", "adjudicated_at",
+    }
+    assert f["codes"] == ["49214", "49219"]
+    assert f["sebagian"] == [False, True]
+    assert f["source_locator"] == [{"lampiran": 10, "pdf_page": 399, "printed_page": 385}]
+    assert f["parser_run_digest"] == DIGEST
+    assert f["adjudication_status"] == "mechanical-only"
+    assert f["inheritance_verdict"] == "not-adjudicated"
+    assert f["adjudicated_by"] == "mechanical-only"
+    assert f["adjudicated_at"] == "2026-07-24"
+
+
+def test_build_field_deep_copies_edges():
+    anc = {"codes": ["49214"], "sebagian": [False],
+           "source_locator": [{"lampiran": 10, "pdf_page": 399, "printed_page": 385}]}
+    f = P.build_field(anc, DIGEST, "2026-07-24")
+    f["codes"].append("X")
+    f["source_locator"][0]["lampiran"] = 5
+    assert anc["codes"] == ["49214"]  # source untouched
+    assert anc["source_locator"][0]["lampiran"] == 10
+
+
+# --------------------------------------------------------------------------- #
+# load_relation_artifact — fail-loud on malformed edge source                  #
+# --------------------------------------------------------------------------- #
+
+def test_load_relation_ok(tmp_path):
+    relation = _relation({"01111": [("01111", False)]})
+    _, rel, _ = _write_world(tmp_path, [], relation)
+    got, digest = P.load_relation_artifact(rel)
+    assert digest == _digest_of(relation)
+    assert got["01111"]["codes"] == ["01111"]
+
+
+def test_load_relation_content_digest_mismatch_fails(tmp_path):
+    # stored digest does not match the relation content — the artifact was edited but its
+    # digest left stale; the content-bind (W88) must catch it, gate binding notwithstanding.
+    relation = _relation({"01111": [("01111", False)]})
+    _, rel, _ = _write_world(tmp_path, [], relation, digest="d" * 64)  # pragma: allowlist secret
+    with pytest.raises(P.PopulateError, match="recomputed from the relation content"):
+        P.load_relation_artifact(rel)
+
+
+def test_load_relation_locator_not_dict_fails(tmp_path):
+    rel = tmp_path / "rel.json"
+    rel.write_text(json.dumps({"relation": {"01111": {"codes": ["01111"], "sebagian": [False],
+                                                      "source_locator": ["not-a-dict"]}},
+                              "manifest": {"output_relation_digest": DIGEST}}), encoding="utf-8")
+    with pytest.raises(P.PopulateError, match="not an object"):
+        P.load_relation_artifact(rel)
+
+
+def test_load_relation_len_mismatch_fails(tmp_path):
+    rel = tmp_path / "rel.json"
+    bad = {"relation": {"01111": {"codes": ["01111", "01112"], "sebagian": [False],
+                                  "source_locator": []}},
+           "manifest": {"output_relation_digest": DIGEST}}
+    rel.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(P.PopulateError, match="len"):
+        P.load_relation_artifact(rel)
+
+
+def test_load_relation_missing_digest_fails(tmp_path):
+    rel = tmp_path / "rel.json"
+    rel.write_text(json.dumps({"relation": {"01111": {"codes": ["01111"], "sebagian": [False],
+                                                       "source_locator": []}},
+                               "manifest": {}}), encoding="utf-8")
+    with pytest.raises(P.PopulateError, match="output_relation_digest"):
+        P.load_relation_artifact(rel)
+
+
+def test_load_relation_unexpected_keys_fail(tmp_path):
+    rel = tmp_path / "rel.json"
+    rel.write_text(json.dumps({"relation": {"01111": {"codes": ["01111"], "sebagian": [False],
+                                                       "source_locator": [], "title": "X"}},
+                               "manifest": {"output_relation_digest": DIGEST}}), encoding="utf-8")
+    with pytest.raises(P.PopulateError, match="unexpected keys"):
+        P.load_relation_artifact(rel)
+
+
+# --------------------------------------------------------------------------- #
+# assert_gate_certifies — the fail-closed gate binding (W88/W90)               #
+# --------------------------------------------------------------------------- #
+
+def test_gate_pass_and_matching_digest_ok(tmp_path):
+    _, _, gate = _write_world(tmp_path, [], {}, digest=DIGEST)
+    P.assert_gate_certifies(gate, DIGEST)  # innocence: does not raise
+
+
+def test_gate_verdict_not_pass_fails(tmp_path):
+    _, _, gate = _write_world(tmp_path, [], {}, digest=DIGEST, verdict="FAIL")
+    with pytest.raises(P.PopulateError, match="not 'PASS'"):
+        P.assert_gate_certifies(gate, DIGEST)
+
+
+def test_gate_digest_mismatch_fails(tmp_path):
+    _, _, gate = _write_world(tmp_path, [], {}, digest=DIGEST, gate_digest="b" * 64)  # pragma: allowlist secret
+    with pytest.raises(P.PopulateError, match="diverged"):
+        P.assert_gate_certifies(gate, DIGEST)
+
+
+# --------------------------------------------------------------------------- #
+# plan_and_apply — populate Batch-B only, additive, idempotent                 #
+# --------------------------------------------------------------------------- #
+
+def _std_world():
+    records = [
+        _rec("01111", None),                    # Batch-B
+        _rec("01112", None),                    # Batch-B
+        _rec("77510", "no_oss_risk"),           # Batch-A (out of scope)
+    ]
+    relation = _relation({
+        "01111": [("01111", False)],
+        "01112": [("01112", False), ("01113", True)],
+        "77510": [("77100", False)],            # relation has it, but Batch-A won't be populated
+    })
+    return records, relation
+
+
+def test_populates_batch_b_only():
+    records, relation = _std_world()
+    before = copy.deepcopy(records)
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=2, do_apply=True)
+    assert problems == []
+    assert n == 2
+    by = {r["kode_kbli_2025"]: r for r in records}
+    assert "bps_2020_ancestors" in by["01111"]           # guilt: Batch-B got it
+    assert "bps_2020_ancestors" in by["01112"]
+    assert "bps_2020_ancestors" not in by["77510"]        # innocence: Batch-A did not
+    # edges verbatim from relation
+    assert by["01112"]["bps_2020_ancestors"]["codes"] == ["01112", "01113"]
+    assert by["01112"]["bps_2020_ancestors"]["sebagian"] == [False, True]
+    # additive: every original key/value survives byte-identical
+    for b in before:
+        m = by[b["kode_kbli_2025"]]
+        for k, v in b.items():
+            assert m[k] == v
+
+
+def test_dry_run_does_not_mutate():
+    records, relation = _std_world()
+    before = copy.deepcopy(records)
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=2, do_apply=False)
+    assert n == 2 and problems == []
+    assert records == before  # nothing mutated in dry-run
+
+
+def test_idempotent_skip_present_same_digest():
+    records, relation = _std_world()
+    P.plan_and_apply(records, relation, DIGEST, "2026-07-24", expected_batch_b=2, do_apply=True)
+    # second pass: everything already carries the field → 0 to populate, no problems
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=2, do_apply=True)
+    assert n == 0
+    assert problems == []
+
+
+def test_present_diff_digest_reported_not_clobbered():
+    records, relation = _std_world()
+    # pre-seed 01111 with an entry from a DIFFERENT (older) digest, e.g. tier-adjudicated
+    by = {r["kode_kbli_2025"]: r for r in records}
+    by["01111"]["bps_2020_ancestors"] = {
+        "codes": ["99999"], "sebagian": [False], "source_locator": [],
+        "parser_run_digest": "c" * 64,  # pragma: allowlist secret
+        "adjudication_status": "tier1-2-adjudicated",
+        "inheritance_verdict": "inherited-uniform",
+        "adjudicated_by": "seat-x", "adjudicated_at": "2026-07-01",
+    }
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=2, do_apply=True)
+    assert n == 1  # only 01112 populated
+    assert any("DIFFERENT" in p for p in problems)
+    # the pre-existing adjudication is NOT clobbered
+    assert by["01111"]["bps_2020_ancestors"]["adjudication_status"] == "tier1-2-adjudicated"
+    assert by["01111"]["bps_2020_ancestors"]["codes"] == ["99999"]
+
+
+def test_missing_in_relation_fails_loud():
+    records = [_rec("01111", None), _rec("09999", None)]
+    relation = _relation({"01111": [("01111", False)]})  # 09999 absent
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=2, do_apply=True)
+    assert any("absent from certified relation" in p for p in problems)
+    # the innocent one is still populated
+    assert n == 1
+
+
+def test_empty_ancestry_fails_loud():
+    records = [_rec("01111", None), _rec("09999", None)]
+    relation = _relation({"01111": [("01111", False)], "09999": []})  # empty ancestry
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=2, do_apply=True)
+    assert any("EMPTY ancestry" in p for p in problems)
+
+
+def test_batch_b_count_drift_fails_loud():
+    records, relation = _std_world()  # 2 Batch-B
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=1338, do_apply=False)
+    assert any("Batch-B population is 2, expected 1338" in p for p in problems)
+
+
+def test_unclassified_l2_status_fails_loud():
+    records = [_rec("01111", None), _rec("55555", "some_future_status")]
+    relation = _relation({"01111": [("01111", False)]})
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=1, do_apply=False)
+    assert any("unrecognized _l2_status" in p for p in problems)
+
+
+def test_batch_a_contamination_detected():
+    records, relation = _std_world()
+    by = {r["kode_kbli_2025"]: r for r in records}
+    by["77510"]["bps_2020_ancestors"] = {"codes": ["x"]}  # out-of-scope contamination
+    n, problems = P.plan_and_apply(records, relation, DIGEST, "2026-07-24",
+                                   expected_batch_b=2, do_apply=False)
+    assert any("out-of-scope contamination" in p for p in problems)
+
+
+# --------------------------------------------------------------------------- #
+# main() — wiring, exit codes, on-disk additive write                          #
+# --------------------------------------------------------------------------- #
+
+def test_main_dry_run_writes_nothing(tmp_path):
+    records, relation = _std_world()
+    canon, rel, gate = _write_world(tmp_path, records, relation)
+    before = canon.read_bytes()
+    rc = P.main(["--canonical", str(canon), "--relation", str(rel),
+                 "--gate-report", str(gate), "--expect-batch-b", "2"])
+    assert rc == 0
+    assert canon.read_bytes() == before  # untouched
+
+
+def test_main_dry_run_exit1_on_problem(tmp_path):
+    records, relation = _std_world()
+    canon, rel, gate = _write_world(tmp_path, records, relation)
+    # expected mismatch → problem → dry-run exit 1
+    rc = P.main(["--canonical", str(canon), "--relation", str(rel),
+                 "--gate-report", str(gate), "--expect-batch-b", "1338"])
+    assert rc == 1
+
+
+def test_main_apply_writes_additive(tmp_path, monkeypatch):
+    records, relation = _std_world()
+    canon, rel, gate = _write_world(tmp_path, records, relation)
+    calls = {"sync": 0, "sidecar": 0}
+    monkeypatch.setattr(P, "run_sync_script", lambda: calls.__setitem__("sync", calls["sync"] + 1))
+    monkeypatch.setattr(P, "update_sidecar", lambda: calls.__setitem__("sidecar", calls["sidecar"] + 1))
+    rc = P.main(["--canonical", str(canon), "--relation", str(rel),
+                 "--gate-report", str(gate), "--expect-batch-b", "2", "--as-of", "2026-07-24", "--apply"])
+    assert rc == 0
+    assert calls == {"sync": 1, "sidecar": 1}
+    data = json.loads(canon.read_text())["data"]
+    by = {r["kode_kbli_2025"]: r for r in data}
+    assert "bps_2020_ancestors" in by["01111"]
+    assert "bps_2020_ancestors" not in by["77510"]
+    assert by["01111"]["bps_2020_ancestors"]["adjudicated_at"] == "2026-07-24"
+
+
+def test_main_apply_reconciles_when_nothing_to_populate(tmp_path, monkeypatch):
+    # Recovery path (family #2): a second --apply with nothing new to write must STILL
+    # run sync + sidecar, so a prior partial apply (canonical written, sync failed) can be
+    # recovered by re-running — never a dead end that leaves consumers stale.
+    records, relation = _std_world()
+    canon, rel, gate = _write_world(tmp_path, records, relation)
+    calls = {"sync": 0, "sidecar": 0}
+    monkeypatch.setattr(P, "run_sync_script", lambda: calls.__setitem__("sync", calls["sync"] + 1))
+    monkeypatch.setattr(P, "update_sidecar", lambda: calls.__setitem__("sidecar", calls["sidecar"] + 1))
+    argv = ["--canonical", str(canon), "--relation", str(rel), "--gate-report", str(gate),
+            "--expect-batch-b", "2", "--apply"]
+    assert P.main(argv) == 0
+    assert calls == {"sync": 1, "sidecar": 1}      # first apply populated + reconciled
+    assert P.main(argv) == 0
+    assert calls == {"sync": 2, "sidecar": 2}      # nothing new, still reconciled
+
+
+def test_main_apply_refuses_on_failed_gate(tmp_path, monkeypatch):
+    records, relation = _std_world()
+    canon, rel, gate = _write_world(tmp_path, records, relation, verdict="FAIL")
+    before = canon.read_bytes()
+    monkeypatch.setattr(P, "run_sync_script", lambda: (_ for _ in ()).throw(AssertionError("must not sync")))
+    with pytest.raises(P.PopulateError, match="not 'PASS'"):
+        P.main(["--canonical", str(canon), "--relation", str(rel),
+                "--gate-report", str(gate), "--expect-batch-b", "2", "--apply"])
+    assert canon.read_bytes() == before  # never touched
+
+
+def test_main_apply_exit1_on_problem_no_write(tmp_path, monkeypatch):
+    records = [_rec("01111", None), _rec("09999", None)]  # 09999 missing from relation
+    relation = _relation({"01111": [("01111", False)]})
+    canon, rel, gate = _write_world(tmp_path, records, relation)
+    before = canon.read_bytes()
+    monkeypatch.setattr(P, "run_sync_script", lambda: (_ for _ in ()).throw(AssertionError("must not sync")))
+    monkeypatch.setattr(P, "update_sidecar", lambda: (_ for _ in ()).throw(AssertionError("must not sidecar")))
+    rc = P.main(["--canonical", str(canon), "--relation", str(rel),
+                 "--gate-report", str(gate), "--expect-batch-b", "2", "--apply"])
+    assert rc == 1
+    assert canon.read_bytes() == before  # problems present → refused to write


### PR DESCRIPTION
## What

**Batch-B migration step (2)** of the signed design (`research/operations/2026-07-19-kbli-batch-b-design.md` §2.2/§2.4): a deterministic **bulk compiler** that writes the additive canonical field **`bps_2020_ancestors`** (`mechanical-only`) onto the **1,338 OSS-native Batch-B codes** (`_l2_status is None`), copying each code's BPS-crosswalk edge set verbatim from the gate-certified Phase-0 relation. Batch A's 221 no-scope codes are explicitly **out of scope** for this field and are untouched.

Follows Phase-0 step (1) (acceptance gate, #3080). This field is the `bps_2020_ancestors` provenance foundation for BKPM; it is **dormant** (0 runtime readers — see consumer-map) until the per-code cure-specs (step 3) and client-facing surfacing (step 4).

## Commits

1. `feat(kbli)` — `scripts/kbli_filiera/populate_bps_ancestors.py` + 26-test suite (guilt+innocence per scar #3).
2. `chore(kbli)` — the deterministic `--apply`: `bps_2020_ancestors` on 1,338 Batch-B codes; propagated to the 5 consumer copies; mouth sidecar bumped `446c5f5f → bc8c9879`.
3. `chore(kbli)` — re-emit the Batch-A membership content-pin to the new canonical (state that must move with the canonical, #9/W86; member set byte-identical, only the sha pin refreshed).

## Fail-closed by construction

- **Gate-certified content binding (W88/W90):** refuses to run unless the gate report is `PASS` **and** its `parser_run_digest` equals the relation's `output_relation_digest`, which is itself **recomputed from the relation content** via the parser's own `_relation_digest` (no duplicated algorithm) — a hand-edit that left the stored digest stale is caught. Certified digest: `ca9e7ffc`.
- **Idempotent, never clobbers:** a record already carrying the field is skipped, so a later per-code tier adjudication is never overwritten; a pre-existing entry with a different digest is reported loud, not overwritten.
- **Fail-loud** on: a Batch-B code missing from the relation, empty ancestry (new-in-2025), a Batch-B count ≠ the pinned 1,338 (`--expect-batch-b` to acknowledge a real catalog change), an unrecognized `_l2_status`, or any Batch-A record carrying the field.
- `--apply` reconciles consumers + sidecar unconditionally (idempotent no-ops when in sync) → a re-run **recovers** a prior partial apply, never a dead end.
- `inheritance_verdict` is always `not-adjudicated` — mechanical edge presence never implies the licensing regime transfers (that is the separate D1/D5 step, §4).

## Verification

- **Additive-only, proven two ways:** semantic (1,338 records gained exactly the field; every pre-existing key/value byte-identical; Batch-A untouched; 0 value/scope drift) **and** textual (comma-normalized multiset: strictly additive, 0 deletions, +33,179 net lines). Byte-clean round-trip control confirmed.
- **415 kbli_filiera tests pass** (incl. the 4 new fail-closed guards + the 5 membership-pin tests re-greened by commit 3).
- **Consumers:** `sync_kbli_dataset.sh --check` → all 5 byte-identical to canonical; sidecar sha == mouth-copy sha.
- **Cross-family adversarial review = Kimi K3** (generator≠grader; Codex quota-dead until 2026-08-19). No blocker; its two MAJOR findings (partial-failure recovery gap, digest-as-self-declared-field) are the two fail-closed behaviours above, added in response.

## Consumer-map (merged ≠ live)

Grep-verified **0 runtime readers** of `bps_2020_ancestors` in `apps/mouth/src`, `apps/backend-rag/backend`, `apps/kbli-navigator` — every reference is the design doc, the parser, or this compiler/tests. The consuming surfaces for this increment are the **dataset stores** (5 copies + sidecar, all verified). No user-facing behaviour changes; future consumers (`previousCodes` re-point §2.3, per-code cure-specs §2.4) are named in the design and out of scope here.

## Residual (not blocking)

- Item-10 Tier-4 AQL default `0.010%` still **awaits Zero's Legge-5 ratification** (from #3080; not consumed by this PR).
- The macOS KBLI Navigator app (outside this repo) ships the dataset; its fleet deploy is operator-gated and **does not consume this field** (dormant), so no functional prove-live is pending there.
