### PR TITLE
feat(mouth): E33 Second Home landing page /visa/second-home (Fit-Memo funnel)

### DIFF
--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -141,7 +141,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // 6. Visa funnel pages (balizero.com/visa — consolidated 2026-04-21,
   // was previously at visa.balizero.com; the subdomain now 302-redirects
   // to these canonical paths via middleware.ts).
-  const visaPaths = ["/visa", "/visa/match", "/visa/clock"];
+  const visaPaths = [
+    "/visa",
+    "/visa/match",
+    "/visa/clock",
+    "/visa/second-home",
+  ];
   routes.push(...visaPaths.map((p) => ({ url: `${baseUrl}${p}` })));
 
   // 7. KBLI Sector pages (/kbli/sectors + /kbli/sectors/[id])

--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { Phone } from "lucide-react";
+import { useTranslation } from "@/i18n";
+import type { Locale } from "@/i18n/types";
+import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
+import { ConsentBanner } from "@/components/visa/ConsentBanner";
+
+/**
+ * E33 Second Home Visa landing — Fit-Memo funnel (2026-07-24).
+ *
+ * Claims discipline (research/secondhome/e33-fact-registry.json + owner
+ * decisions 2026-07-23):
+ *  - Base E33: USD 130,000 own-name deposit at a state-owned (BUMN) bank
+ *    OR USD 1,000,000 completed strata-title property. First grant up to
+ *    5 years, renewable (10-year cumulative cap, Pasal 113).
+ *  - Price: IDR 39,000,000 all-inclusive for the base E33 — NEVER
+ *    decomposed into PNBP + service fee. Dependent add-on is DRAFT, so no
+ *    dependent price appears anywhere on this page.
+ *  - The fit memo is FREE; there is no "apply now" flow — the only CTA is
+ *    the WhatsApp lead handoff.
+ *  - FORBIDDEN until the official letters answer: BSI sharia equivalence,
+ *    split deposits, ITAP/KITAP conversion, "any bank" placement. None of
+ *    these appear in the copy — keep it that way.
+ */
+
+const PAGE_PATH = "/visa/second-home";
+const SWITCHER_LOCALES: Locale[] = ["en", "id", "it"];
+
+const sectionStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "var(--space-3, 1rem)",
+};
+
+const eyebrowStyle: React.CSSProperties = {
+  fontSize: "0.62rem",
+  letterSpacing: "0.15em",
+  textTransform: "uppercase",
+  opacity: 0.5,
+  color: "var(--color-text-muted)",
+  margin: 0,
+};
+
+const cardStyle: React.CSSProperties = {
+  background: "var(--surface-raised)",
+  border: "1px solid var(--color-border-subtle)",
+  borderRadius: 12,
+  padding: "var(--space-4, 1.5rem)",
+  display: "grid",
+  gap: "var(--space-2, 0.5rem)",
+  alignContent: "start",
+};
+
+function LanguageSwitcher() {
+  const { locale, setLocale } = useTranslation();
+  return (
+    <div
+      role="group"
+      aria-label="Language"
+      style={{ display: "flex", gap: 4, justifyContent: "flex-end" }}
+    >
+      {SWITCHER_LOCALES.map((l) => (
+        <button
+          key={l}
+          type="button"
+          onClick={() => setLocale(l)}
+          aria-pressed={locale === l}
+          style={{
+            padding: "4px 10px",
+            borderRadius: 4,
+            border: `1px solid ${locale === l ? "var(--accent-funnel)" : "var(--color-border-subtle)"}`,
+            background: locale === l ? "var(--surface-raised)" : "transparent",
+            color: "var(--text-primary)",
+            fontSize: "0.75rem",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            cursor: "pointer",
+            minHeight: 32,
+          }}
+        >
+          {l}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function SecondHomeLanding() {
+  const { t } = useTranslation();
+
+  const faqItems = [1, 2, 3, 4, 5, 6].map((n) => ({
+    q: t(`secondHome.faq.q${n}`),
+    a: t(`secondHome.faq.a${n}`),
+  }));
+
+  return (
+    <div style={{ display: "grid", gap: "var(--space-6, 3rem)" }}>
+      <LanguageSwitcher />
+
+      {/* ── HERO ── */}
+      <section
+        style={{ ...sectionStyle, paddingTop: "var(--space-2, 0.5rem)" }}
+      >
+        <p style={eyebrowStyle}>{t("secondHome.hero.eyebrow")}</p>
+        <h1
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.9rem, 5vw, 2.8rem)",
+            lineHeight: 1.15,
+            color: "var(--text-primary)",
+          }}
+        >
+          {t("secondHome.hero.title")}
+        </h1>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "clamp(1rem, 2.4vw, 1.15rem)",
+            lineHeight: 1.6,
+            color: "var(--color-text-muted)",
+            maxWidth: "46rem",
+          }}
+        >
+          {t("secondHome.hero.subtitle")}
+        </p>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "var(--space-3, 1rem)",
+            marginTop: "var(--space-2, 0.5rem)",
+          }}
+        >
+          {[1, 2, 3].map((n) => (
+            <div
+              key={n}
+              style={{ ...cardStyle, padding: "var(--space-3, 1rem)" }}
+            >
+              <div
+                style={{
+                  fontFamily: "var(--font-serif, Georgia, serif)",
+                  fontSize: "1.3rem",
+                  color: "var(--accent-funnel-text, var(--accent-funnel))",
+                }}
+              >
+                {t(`secondHome.hero.stat${n}v`)}
+              </div>
+              <div
+                style={{
+                  fontSize: "0.7rem",
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {t(`secondHome.hero.stat${n}l`)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── TWO QUALIFYING ROUTES ── */}
+      <section style={sectionStyle}>
+        <p style={eyebrowStyle}>{t("secondHome.routes.eyebrow")}</p>
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.4rem, 3.4vw, 1.9rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {t("secondHome.routes.title")}
+        </h2>
+        <div
+          style={{
+            display: "grid",
+            gap: "var(--space-3, 1rem)",
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+          }}
+        >
+          {(["a", "b"] as const).map((route) => (
+            <div key={route} style={cardStyle}>
+              <div
+                style={{
+                  fontSize: "0.7rem",
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {t(`secondHome.routes.${route}.title`)}
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-serif, Georgia, serif)",
+                  fontSize: "1.5rem",
+                  color: "var(--accent-funnel-text, var(--accent-funnel))",
+                }}
+              >
+                {t(`secondHome.routes.${route}.amount`)}
+              </div>
+              <p
+                style={{
+                  margin: 0,
+                  lineHeight: 1.6,
+                  color: "var(--text-primary)",
+                }}
+              >
+                {t(`secondHome.routes.${route}.body`)}
+              </p>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "var(--text-sm, 0.88rem)",
+                  lineHeight: 1.5,
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {t(`secondHome.routes.${route}.note`)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── WHO IT'S FOR ── */}
+      <section style={sectionStyle}>
+        <p style={eyebrowStyle}>{t("secondHome.who.eyebrow")}</p>
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.4rem, 3.4vw, 1.9rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {t("secondHome.who.title")}
+        </h2>
+        <div
+          style={{
+            display: "grid",
+            gap: "var(--space-3, 1rem)",
+            gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+          }}
+        >
+          {(["base", "e33e", "e33f"] as const).map((track) => (
+            <div key={track} style={cardStyle}>
+              <div
+                style={{
+                  fontWeight: 600,
+                  color: "var(--text-primary)",
+                }}
+              >
+                {t(`secondHome.who.${track}.title`)}
+              </div>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "var(--text-sm, 0.92rem)",
+                  lineHeight: 1.6,
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {t(`secondHome.who.${track}.body`)}
+              </p>
+            </div>
+          ))}
+        </div>
+        <div style={cardStyle}>
+          <div style={{ fontWeight: 600, color: "var(--text-primary)" }}>
+            {t("secondHome.who.family.title")}
+          </div>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-sm, 0.92rem)",
+              lineHeight: 1.6,
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {t("secondHome.who.family.body")}
+          </p>
+        </div>
+        <div style={cardStyle}>
+          <div style={{ fontWeight: 600, color: "var(--text-primary)" }}>
+            {t("secondHome.who.nowork.title")}
+          </div>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-sm, 0.92rem)",
+              lineHeight: 1.6,
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {t("secondHome.who.nowork.body")}
+          </p>
+        </div>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "var(--text-sm, 0.82rem)",
+            lineHeight: 1.5,
+            color: "var(--color-text-muted)",
+            fontStyle: "italic",
+          }}
+        >
+          {t("secondHome.who.ageNote")}
+        </p>
+      </section>
+
+      {/* ── WHAT BALI ZERO DOES + PRICE ── */}
+      <section style={sectionStyle}>
+        <p style={eyebrowStyle}>{t("secondHome.how.eyebrow")}</p>
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.4rem, 3.4vw, 1.9rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {t("secondHome.how.title")}
+        </h2>
+        <div
+          style={{
+            display: "grid",
+            gap: "var(--space-3, 1rem)",
+            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+          }}
+        >
+          {[1, 2, 3].map((step) => (
+            <div key={step} style={cardStyle}>
+              <div
+                style={{
+                  fontSize: "0.7rem",
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  color: "var(--accent-funnel-text, var(--accent-funnel))",
+                }}
+              >
+                {t(`secondHome.how.step${step}.label`)}
+              </div>
+              <div style={{ fontWeight: 600, color: "var(--text-primary)" }}>
+                {t(`secondHome.how.step${step}.title`)}
+              </div>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "var(--text-sm, 0.92rem)",
+                  lineHeight: 1.6,
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {t(`secondHome.how.step${step}.body`)}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Price — single all-inclusive figure, never decomposed */}
+        <div
+          style={{
+            ...cardStyle,
+            border: "1px solid var(--accent-funnel)",
+            textAlign: "center",
+            justifyItems: "center",
+            gap: "var(--space-1, 0.3rem)",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "0.7rem",
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {t("secondHome.how.priceLabel")}
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--font-serif, Georgia, serif)",
+              fontSize: "clamp(2rem, 5vw, 2.6rem)",
+              color: "var(--accent-funnel-text, var(--accent-funnel))",
+            }}
+          >
+            IDR 39,000,000
+          </div>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-sm, 0.88rem)",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {t("secondHome.how.priceNote")}
+          </p>
+        </div>
+      </section>
+
+      {/* ── 90-DAY COMPLIANCE DUTY ── */}
+      <section style={sectionStyle}>
+        <p style={eyebrowStyle}>{t("secondHome.duty.eyebrow")}</p>
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.4rem, 3.4vw, 1.9rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {t("secondHome.duty.title")}
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            lineHeight: 1.7,
+            color: "var(--text-primary)",
+            maxWidth: "46rem",
+          }}
+        >
+          {t("secondHome.duty.body")}
+        </p>
+      </section>
+
+      {/* ── FAQ (visible; mirrors SECOND_HOME_FAQS used for JSON-LD) ── */}
+      <section style={sectionStyle}>
+        <p style={eyebrowStyle}>{t("secondHome.faq.eyebrow")}</p>
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.4rem, 3.4vw, 1.9rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {t("secondHome.faq.title")}
+        </h2>
+        <div style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}>
+          {faqItems.map((item) => (
+            <details key={item.q} style={{ ...cardStyle, gap: 0 }}>
+              <summary
+                style={{
+                  cursor: "pointer",
+                  fontWeight: 600,
+                  color: "var(--text-primary)",
+                }}
+              >
+                {item.q}
+              </summary>
+              <p
+                style={{
+                  margin: "var(--space-2, 0.5rem) 0 0",
+                  fontSize: "var(--text-sm, 0.92rem)",
+                  lineHeight: 1.6,
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {item.a}
+              </p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {/* ── CTA — the only action: free Fit Memo via WhatsApp handoff ── */}
+      <section
+        style={{
+          ...cardStyle,
+          gap: "var(--space-3, 1rem)",
+          textAlign: "center",
+          justifyItems: "center",
+          padding: "var(--space-5, 2rem)",
+        }}
+      >
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.4rem, 3.4vw, 1.9rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {t("secondHome.cta.title")}
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            lineHeight: 1.6,
+            color: "var(--color-text-muted)",
+            maxWidth: "38rem",
+          }}
+        >
+          {t("secondHome.cta.body")}
+        </p>
+        <WhatsAppLeadButton
+          source="cta_handoff"
+          context={{
+            page: PAGE_PATH,
+            product: "e33_second_home",
+            service_interest: "second_home",
+          }}
+          whatsappContext={[
+            { label: "Product", value: "E33 Second Home Visa" },
+            { label: "Fit memo", value: "Free assessment" },
+            { label: "Page", value: PAGE_PATH },
+          ]}
+          utm={{ page: PAGE_PATH }}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
+            borderRadius: 8,
+            background: "#25D366",
+            color: "#fff",
+            fontWeight: 600,
+            textDecoration: "none",
+            minHeight: 44,
+          }}
+        >
+          <Phone size={18} aria-hidden />
+          {t("secondHome.cta.button")}
+        </WhatsAppLeadButton>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "var(--text-sm, 0.82rem)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          {t("secondHome.cta.note")}
+        </p>
+      </section>
+
+      <ConsentBanner />
+    </div>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/layout.tsx
+++ b/apps/mouth/src/app/visa/second-home/layout.tsx
@@ -1,0 +1,13 @@
+import { I18nProvider } from "@/i18n";
+
+export default function SecondHomeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Route-level provider — the /visa segment layout has no I18nProvider
+  // ancestor. lint_i18n_providers contract: the provider must live in the
+  // calling file itself or in an ancestor layout.tsx. Missing keys in fr/ru
+  // fall back to EN (src/i18n/index.tsx).
+  return <I18nProvider>{children}</I18nProvider>;
+}

--- a/apps/mouth/src/app/visa/second-home/page.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { I18nProvider } from "@/i18n";
+import { SecondHomeLanding } from "./SecondHomeLanding";
+
+/**
+ * E33 Second Home landing — content guard (2026-07-24).
+ *
+ * The page is a Fit-Memo funnel with hard claims discipline
+ * (research/secondhome/e33-fact-registry.json + owner decisions
+ * 2026-07-23). These tests pin:
+ *  - the required verified claims are rendered (routes, price, 90-day duty);
+ *  - the price is the single all-inclusive figure;
+ *  - FORBIDDEN claims never appear (BSI/sharia equivalence, split deposits,
+ *    ITAP conversion, "any bank" placement);
+ *  - the only CTA is the WhatsApp lead handoff (free fit memo);
+ *  - the ID locale renders (i18n wiring works).
+ */
+
+function renderLanding() {
+  return render(
+    <I18nProvider>
+      <SecondHomeLanding />
+    </I18nProvider>,
+  );
+}
+
+describe("SecondHomeLanding", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders the hero, both qualifying routes, and the all-inclusive price", () => {
+    renderLanding();
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      /up to 5 years/i,
+    );
+    // Two qualifying routes — the only two verified bases.
+    expect(screen.getAllByText(/USD 130,000/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/USD 1,000,000/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/state-owned \(BUMN\)/i).length).toBeGreaterThan(
+      0,
+    );
+    // Single all-inclusive figure, never decomposed.
+    expect(screen.getByText("IDR 39,000,000")).toBeInTheDocument();
+  });
+
+  it("covers the senior tracks, no-work-rights, and the 90-day duty", () => {
+    renderLanding();
+
+    expect(screen.getByText(/E33E — Senior, 5 years/)).toBeInTheDocument();
+    expect(screen.getByText(/E33F — Senior, 1 year/)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/does not authorize employment/i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("heading", { name: /90-day evidence duty/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("the only CTA is the free fit memo WhatsApp handoff", () => {
+    renderLanding();
+
+    const cta = screen.getByRole("link", { name: /free fit memo/i });
+    expect(cta).toHaveAttribute("data-lead-source", "cta_handoff");
+    // No "apply now" flow anywhere on the page.
+    expect(screen.queryByRole("link", { name: /apply/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /apply/i })).toBeNull();
+  });
+
+  it("never states a forbidden claim", () => {
+    const { container } = renderLanding();
+    const text = container.textContent ?? "";
+
+    // bsi_sharia_accepted / split_deposit_accepted / itap_after_3y_criteria /
+    // bank_proof_format — all pending in the fact registry, forbidden on-page.
+    expect(text).not.toMatch(/BSI|sharia/i);
+    expect(text).not.toMatch(/split/i);
+    expect(text).not.toMatch(/ITAP|KITAP|permanent residence/i);
+    expect(text).not.toMatch(/any (Indonesian )?bank/i);
+    // Dependent add-on is DRAFT — no hard dependent price.
+    expect(text).not.toMatch(/12,000,000|12\.000\.000/);
+  });
+
+  it("renders the Indonesian locale when selected", () => {
+    renderLanding();
+
+    fireEvent.click(screen.getByRole("button", { name: "id" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      /Tinggal di Indonesia hingga 5 tahun/,
+    );
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/page.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { I18nProvider } from "@/i18n";
+import { BreadcrumbJsonLd, FAQJsonLd } from "@/components/seo";
+import { SECOND_HOME_FAQS } from "@/lib/seo/faq-data";
+import { SecondHomeLanding } from "./SecondHomeLanding";
+
+export const metadata: Metadata = {
+  title: "E33 Second Home Visa Indonesia 2026 | Free Fit Memo | Bali Zero",
+  description:
+    "Indonesia's Second Home Visa (E33): up to 5 years of long-term residence via a USD 130,000 own-name deposit at a state-owned Indonesian bank or USD 1,000,000 completed strata-title property. Free fit memo from Bali Zero.",
+  openGraph: {
+    title: "E33 Second Home Visa Indonesia — Bali Zero",
+    description:
+      "Up to 5 years of residence in Indonesia, renewable to 10. Qualify with a USD 130,000 own-name BUMN bank deposit or USD 1,000,000 completed strata-title property. Start with a free fit memo.",
+    type: "website",
+  },
+  alternates: {
+    canonical: "https://balizero.com/visa/second-home",
+  },
+};
+
+const breadcrumbItems = [
+  { name: "Home", url: "https://balizero.com" },
+  { name: "Visa", url: "https://balizero.com/visa" },
+  {
+    name: "Second Home Visa (E33)",
+    url: "https://balizero.com/visa/second-home",
+  },
+];
+
+export default function SecondHomeVisaPage() {
+  return (
+    <>
+      {/* Server-side JSON-LD — included in static HTML for Googlebot.
+          FAQ copy mirrors the page's localized FAQ section (EN canonical). */}
+      <BreadcrumbJsonLd items={breadcrumbItems} />
+      <FAQJsonLd items={SECOND_HOME_FAQS} />
+      {/* Page-level provider — same pattern as portal/forgot-password: the
+          /visa segment layout has no I18nProvider ancestor. Missing keys in
+          fr/ru fall back to EN (src/i18n/index.tsx). */}
+      <I18nProvider>
+        <SecondHomeLanding />
+      </I18nProvider>
+    </>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/page.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { I18nProvider } from "@/i18n";
 import { BreadcrumbJsonLd, FAQJsonLd } from "@/components/seo";
 import { SECOND_HOME_FAQS } from "@/lib/seo/faq-data";
 import { SecondHomeLanding } from "./SecondHomeLanding";
@@ -35,12 +34,10 @@ export default function SecondHomeVisaPage() {
           FAQ copy mirrors the page's localized FAQ section (EN canonical). */}
       <BreadcrumbJsonLd items={breadcrumbItems} />
       <FAQJsonLd items={SECOND_HOME_FAQS} />
-      {/* Page-level provider — same pattern as portal/forgot-password: the
-          /visa segment layout has no I18nProvider ancestor. Missing keys in
-          fr/ru fall back to EN (src/i18n/index.tsx). */}
-      <I18nProvider>
-        <SecondHomeLanding />
-      </I18nProvider>
+      {/* The I18nProvider lives in this route's layout.tsx — required by
+          the lint_i18n_providers contract (provider in the calling file or
+          an ancestor layout, not a sibling page wrapper). */}
+      <SecondHomeLanding />
     </>
   );
 }

--- a/apps/mouth/src/components/services/ServicePricing.tsx
+++ b/apps/mouth/src/components/services/ServicePricing.tsx
@@ -250,6 +250,16 @@ export default function ServicePricing({ service, slug }: ServicePricingProps) {
                 Chat on WhatsApp
               </WhatsAppLeadButton>
 
+              {/* Optional deep-link to a dedicated landing page */}
+              {selectedPackage.link && (
+                <Link
+                  href={selectedPackage.link.href}
+                  className="flex items-center justify-center gap-2 w-full px-6 py-3 rounded-xl border border-white/20 text-white font-medium hover:bg-white/10 transition-colors mb-3"
+                >
+                  {selectedPackage.link.label} →
+                </Link>
+              )}
+
               <Link
                 href="/chat"
                 className="flex items-center justify-center gap-2 w-full px-6 py-3 rounded-xl border border-white/20 text-white font-medium hover:bg-white/10 transition-colors"

--- a/apps/mouth/src/data/services_data.ts
+++ b/apps/mouth/src/data/services_data.ts
@@ -7,6 +7,9 @@ export interface ServicePackage {
   price: string;
   features: string[];
   popular: boolean;
+  /** Optional deep-link to a dedicated landing page (rendered in the
+   *  pricing modal below the WhatsApp CTA). */
+  link?: { href: string; label: string };
 }
 
 export interface ServiceData {
@@ -400,13 +403,17 @@ export const SERVICES_DATA: Record<string, ServiceData> = {
       {
         name: "E33 - Second Home Visa",
         description: "Long-term residence (USD 130k+ deposit)",
-        price: "Contact",
+        price: "39.000.000",
         features: [
           "Up to 5 years initial validity",
           "No sponsor required",
           "Bring family members",
         ],
         popular: false,
+        link: {
+          href: "/visa/second-home",
+          label: "Second Home Visa guide — free fit memo",
+        },
       },
       {
         name: "E35A - Working Holiday",

--- a/apps/mouth/src/data/services_data.ts
+++ b/apps/mouth/src/data/services_data.ts
@@ -402,7 +402,7 @@ export const SERVICES_DATA: Record<string, ServiceData> = {
       // ═══════════════════════════════════════════════════════════
       {
         name: "E33 - Second Home Visa",
-        description: "Long-term residence (USD 130k+ deposit)",
+        description: "Long-term residence (USD 130k+ deposit) — all-inclusive",
         price: "39.000.000",
         features: [
           "Up to 5 years initial validity",

--- a/apps/mouth/src/i18n/locales/en.json
+++ b/apps/mouth/src/i18n/locales/en.json
@@ -289,5 +289,107 @@
     "errors": {
       "network": "Network error"
     }
+  },
+  "secondHome": {
+    "hero": {
+      "eyebrow": "E33 — Second Home Visa",
+      "title": "Live in Indonesia for up to 5 years — on your own funds",
+      "subtitle": "The Second Home Visa is a long-term residence permit for financially established applicants. No sponsor, no employer — your own financial commitment is the basis. Start with a free fit memo.",
+      "stat1v": "5 years",
+      "stat1l": "First grant, renewable",
+      "stat2v": "USD 130,000",
+      "stat2l": "Own-name BUMN deposit",
+      "stat3v": "Free",
+      "stat3l": "Fit memo assessment"
+    },
+    "routes": {
+      "eyebrow": "Qualifying",
+      "title": "Two ways to qualify",
+      "a": {
+        "title": "Route A — Bank deposit",
+        "amount": "USD 130,000",
+        "body": "A deposit in your own name at a state-owned (BUMN) Indonesian bank. The funds stay yours — the deposit is the evidence of financial commitment.",
+        "note": "We prepare the evidence file in the format imigrasi expects, and coordinate the bank confirmation with you."
+      },
+      "b": {
+        "title": "Route B — Property",
+        "amount": "USD 1,000,000",
+        "body": "A completed strata-title property (hak milik atas satuan rumah susun) worth at least USD 1,000,000.",
+        "note": "Completed strata-title only — off-plan purchases and leasehold do not qualify."
+      }
+    },
+    "who": {
+      "eyebrow": "Who it's for",
+      "title": "Three tracks, one residence",
+      "base": {
+        "title": "E33 — Base (up to 5 years)",
+        "body": "For financially established individuals and families. First grant up to 5 years, renewable — up to 10 years of cumulative stay."
+      },
+      "e33e": {
+        "title": "E33E — Senior, 5 years",
+        "body": "Age 55+. USD 50,000 deposit at a state-owned bank plus USD 3,000/month income. Five-year validity."
+      },
+      "e33f": {
+        "title": "E33F — Senior, 1 year",
+        "body": "Age 55+. USD 3,000/month income only — no deposit required. One-year validity."
+      },
+      "family": {
+        "title": "Bringing family",
+        "body": "A family add-on is available: eligible family members can join through dependent routes. We confirm the current dependent rules and costs in your fit memo."
+      },
+      "nowork": {
+        "title": "No work rights",
+        "body": "The E33 is a residence permit — it does not authorize employment in Indonesia. Paid work requires a separate work permit/KITAS."
+      },
+      "ageNote": "Senior age threshold: we operate on 55+ per Permenkumham 11/2024 and the live imigrasi guidance. One provision of the regulation still reads 60 — for ages 55–59 we confirm eligibility individually before filing."
+    },
+    "how": {
+      "eyebrow": "How it works",
+      "title": "What Bali Zero does",
+      "step1": {
+        "label": "Step 1 — Free",
+        "title": "Fit memo",
+        "body": "Message us on WhatsApp. We assess which route and track actually fits your situation — free, no obligation."
+      },
+      "step2": {
+        "label": "Step 2",
+        "title": "Evidence review",
+        "body": "We review your deposit or property evidence against what imigrasi actually asks for — before anything is filed."
+      },
+      "step3": {
+        "label": "Step 3",
+        "title": "Filing",
+        "body": "We prepare and file the application, coordinate with imigrasi, and track it through to the grant."
+      },
+      "priceLabel": "Base E33 — all-inclusive",
+      "priceNote": "One figure, everything included. Senior tracks and family add-ons are priced in your free fit memo."
+    },
+    "duty": {
+      "eyebrow": "After the grant",
+      "title": "The 90-day evidence duty",
+      "body": "Once your permit is granted, you have 90 days to evidence that the commitment is real: the deposit placed in your own name, or the qualifying property secured. We track this deadline with you from day one, so the permit stays clean."
+    },
+    "faq": {
+      "eyebrow": "Questions",
+      "title": "Frequently asked questions",
+      "q1": "What is the E33 Second Home Visa for Indonesia?",
+      "a1": "The E33 Second Home Visa is a long-term residence permit for financially established applicants. The first grant is up to 5 years and it is renewable, with a 10-year cumulative cap. It is a pure residence permit and does not authorize employment in Indonesia.",
+      "q2": "How do I qualify for the Second Home Visa?",
+      "a2": "Two qualifying routes: a USD 130,000 deposit in your own name at a state-owned (BUMN) Indonesian bank, or a USD 1,000,000 completed strata-title property (hak milik atas satuan rumah susun). Off-plan and leasehold property do not qualify.",
+      "q3": "Can I work in Indonesia on a Second Home Visa?",
+      "a3": "No. The E33 is a residence permit only — it does not authorize employment. Paid work in Indonesia requires a separate work permit/KITAS.",
+      "q4": "Is there a senior option for the Second Home Visa?",
+      "a4": "Yes. E33E (age 55+, 5 years) requires a USD 50,000 deposit at a state-owned bank plus USD 3,000/month income. E33F (age 55+, 1 year) requires USD 3,000/month income only, with no deposit.",
+      "q5": "Can my family join me on a Second Home Visa?",
+      "a5": "A family add-on is available — eligible family members can join through dependent routes. The current dependent rules and costs are confirmed individually during the free fit memo.",
+      "q6": "How much does the Second Home Visa cost with Bali Zero?",
+      "a6": "IDR 39,000,000 all-inclusive for the base E33 — one figure, everything included. The fit memo that assesses your route is free."
+    },
+    "cta": {
+      "title": "Start with a free fit memo",
+      "body": "Tell us your situation on WhatsApp. We reply with an honest read: which route fits, what evidence you'll need, and the exact price for your case. No obligation.",
+      "button": "Get my free Fit Memo →",
+      "note": "Typical first reply on WhatsApp in under 5 hours."
+    }
   }
 }

--- a/apps/mouth/src/i18n/locales/id.json
+++ b/apps/mouth/src/i18n/locales/id.json
@@ -289,5 +289,107 @@
     "errors": {
       "network": "Kesalahan jaringan"
     }
+  },
+  "secondHome": {
+    "hero": {
+      "eyebrow": "E33 — Visa Second Home",
+      "title": "Tinggal di Indonesia hingga 5 tahun — dengan dana Anda sendiri",
+      "subtitle": "Visa Second Home adalah izin tinggal jangka panjang bagi pemohon dengan kondisi finansial mapan. Tanpa sponsor, tanpa pemberi kerja — komitmen finansial Anda sendiri yang menjadi dasar. Mulai dengan fit memo gratis.",
+      "stat1v": "5 tahun",
+      "stat1l": "Izin pertama, dapat diperpanjang",
+      "stat2v": "USD 130.000",
+      "stat2l": "Deposito atas nama sendiri di bank BUMN",
+      "stat3v": "Gratis",
+      "stat3l": "Penilaian fit memo"
+    },
+    "routes": {
+      "eyebrow": "Kualifikasi",
+      "title": "Dua cara memenuhi syarat",
+      "a": {
+        "title": "Jalur A — Deposito bank",
+        "amount": "USD 130.000",
+        "body": "Deposito atas nama Anda sendiri di bank BUMN Indonesia. Dana tetap milik Anda — deposito ini menjadi bukti komitmen finansial.",
+        "note": "Kami menyiapkan berkas bukti sesuai format yang diminta imigrasi, dan mengoordinasikan konfirmasi bank bersama Anda."
+      },
+      "b": {
+        "title": "Jalur B — Properti",
+        "amount": "USD 1.000.000",
+        "body": "Properti strata-title yang sudah selesai dibangun (hak milik atas satuan rumah susun) senilai minimal USD 1.000.000.",
+        "note": "Hanya strata-title yang sudah selesai — pembelian off-plan dan leasehold tidak memenuhi syarat."
+      }
+    },
+    "who": {
+      "eyebrow": "Untuk siapa",
+      "title": "Tiga jalur, satu izin tinggal",
+      "base": {
+        "title": "E33 — Dasar (hingga 5 tahun)",
+        "body": "Untuk individu dan keluarga dengan kondisi finansial mapan. Izin pertama hingga 5 tahun, dapat diperpanjang — total tinggal kumulatif hingga 10 tahun."
+      },
+      "e33e": {
+        "title": "E33E — Senior, 5 tahun",
+        "body": "Usia 55+. Deposito USD 50.000 di bank BUMN ditambah penghasilan USD 3.000/bulan. Berlaku lima tahun."
+      },
+      "e33f": {
+        "title": "E33F — Senior, 1 tahun",
+        "body": "Usia 55+. Hanya penghasilan USD 3.000/bulan — tanpa deposito. Berlaku satu tahun."
+      },
+      "family": {
+        "title": "Membawa keluarga",
+        "body": "Tersedia add-on keluarga: anggota keluarga yang memenuhi syarat dapat ikut melalui jalur dependen. Aturan dependen dan biayanya kami konfirmasi dalam fit memo Anda."
+      },
+      "nowork": {
+        "title": "Tanpa hak kerja",
+        "body": "E33 adalah izin tinggal — tidak memberikan hak bekerja di Indonesia. Pekerjaan berbayar memerlukan izin kerja/KITAS terpisah."
+      },
+      "ageNote": "Batas usia senior: kami berpatokan pada 55+ sesuai Permenkumham 11/2024 dan panduan resmi imigrasi. Satu pasal dalam regulasi masih menyebut 60 — untuk usia 55–59 tahun kami konfirmasi kelayakan secara individual sebelum pengajuan."
+    },
+    "how": {
+      "eyebrow": "Cara kerja",
+      "title": "Yang Bali Zero lakukan",
+      "step1": {
+        "label": "Langkah 1 — Gratis",
+        "title": "Fit memo",
+        "body": "Hubungi kami di WhatsApp. Kami menilai jalur dan track mana yang paling sesuai dengan situasi Anda — gratis, tanpa kewajiban."
+      },
+      "step2": {
+        "label": "Langkah 2",
+        "title": "Review bukti",
+        "body": "Kami meninjau bukti deposito atau properti Anda sesuai yang benar-benar diminta imigrasi — sebelum ada yang diajukan."
+      },
+      "step3": {
+        "label": "Langkah 3",
+        "title": "Pengajuan",
+        "body": "Kami menyiapkan dan mengajukan permohonan, berkoordinasi dengan imigrasi, dan memantaunya hingga terbit."
+      },
+      "priceLabel": "E33 dasar — all-inclusive",
+      "priceNote": "Satu angka, semua sudah termasuk. Jalur senior dan add-on keluarga dihitung dalam fit memo gratis Anda."
+    },
+    "duty": {
+      "eyebrow": "Setelah izin terbit",
+      "title": "Kewajiban bukti 90 hari",
+      "body": "Setelah izin Anda terbit, Anda memiliki 90 hari untuk membuktikan bahwa komitmennya nyata: deposito telah ditempatkan atas nama Anda sendiri, atau properti yang memenuhi syarat telah diamankan. Kami memantau tenggat ini bersama Anda sejak hari pertama, agar izin Anda tetap bersih."
+    },
+    "faq": {
+      "eyebrow": "Pertanyaan",
+      "title": "Pertanyaan yang sering diajukan",
+      "q1": "Apa itu Visa Second Home E33 Indonesia?",
+      "a1": "Visa Second Home E33 adalah izin tinggal jangka panjang bagi pemohon dengan kondisi finansial mapan. Izin pertama hingga 5 tahun dan dapat diperpanjang, dengan batas kumulatif 10 tahun. Ini murni izin tinggal dan tidak memberikan hak bekerja di Indonesia.",
+      "q2": "Bagaimana cara memenuhi syarat Visa Second Home?",
+      "a2": "Dua jalur kualifikasi: deposito USD 130.000 atas nama Anda sendiri di bank BUMN Indonesia, atau properti strata-title yang sudah selesai dibangun senilai USD 1.000.000 (hak milik atas satuan rumah susun). Properti off-plan dan leasehold tidak memenuhi syarat.",
+      "q3": "Apakah saya bisa bekerja di Indonesia dengan Visa Second Home?",
+      "a3": "Tidak. E33 hanyalah izin tinggal — tidak memberikan hak bekerja. Pekerjaan berbayar di Indonesia memerlukan izin kerja/KITAS terpisah.",
+      "q4": "Apakah ada opsi senior untuk Visa Second Home?",
+      "a4": "Ada. E33E (usia 55+, 5 tahun) memerlukan deposito USD 50.000 di bank BUMN ditambah penghasilan USD 3.000/bulan. E33F (usia 55+, 1 tahun) hanya memerlukan penghasilan USD 3.000/bulan, tanpa deposito.",
+      "q5": "Apakah keluarga saya bisa ikut dengan Visa Second Home?",
+      "a5": "Tersedia add-on keluarga — anggota keluarga yang memenuhi syarat dapat ikut melalui jalur dependen. Aturan dependen terkini dan biayanya dikonfirmasi secara individual dalam fit memo gratis.",
+      "q6": "Berapa biaya Visa Second Home dengan Bali Zero?",
+      "a6": "IDR 39.000.000 all-inclusive untuk E33 dasar — satu angka, semua sudah termasuk. Fit memo untuk menilai jalur Anda gratis."
+    },
+    "cta": {
+      "title": "Mulai dengan fit memo gratis",
+      "body": "Ceritakan situasi Anda di WhatsApp. Kami balas dengan penilaian jujur: jalur mana yang cocok, bukti apa yang Anda perlukan, dan harga pasti untuk kasus Anda. Tanpa kewajiban.",
+      "button": "Dapatkan Fit Memo gratis →",
+      "note": "Balasan pertama di WhatsApp biasanya kurang dari 5 jam."
+    }
   }
 }

--- a/apps/mouth/src/i18n/locales/it.json
+++ b/apps/mouth/src/i18n/locales/it.json
@@ -289,5 +289,107 @@
     "errors": {
       "network": "Errore di rete"
     }
+  },
+  "secondHome": {
+    "hero": {
+      "eyebrow": "E33 — Visto Second Home",
+      "title": "Vivi in Indonesia fino a 5 anni — con i tuoi fondi",
+      "subtitle": "Il visto Second Home è un permesso di soggiorno a lungo termine per richiedenti con solide disponibilità economiche. Nessuno sponsor, nessun datore di lavoro — la base è il tuo impegno finanziario. Si parte da un fit memo gratuito.",
+      "stat1v": "5 anni",
+      "stat1l": "Primo rilascio, rinnovabile",
+      "stat2v": "USD 130.000",
+      "stat2l": "Deposito a tuo nome in banca statale",
+      "stat3v": "Gratuito",
+      "stat3l": "Valutazione fit memo"
+    },
+    "routes": {
+      "eyebrow": "Requisiti",
+      "title": "Due modi per qualificarsi",
+      "a": {
+        "title": "Percorso A — Deposito bancario",
+        "amount": "USD 130.000",
+        "body": "Un deposito intestato a te presso una banca statale indonesiana (BUMN). I fondi restano tuoi — il deposito è la prova dell'impegno finanziario.",
+        "note": "Prepariamo il dossier probatorio nel formato richiesto dall'imigrasi e coordiniamo con te la conferma della banca."
+      },
+      "b": {
+        "title": "Percorso B — Proprietà",
+        "amount": "USD 1.000.000",
+        "body": "Una proprietà strata-title completata (hak milik atas satuan rumah susun) del valore di almeno USD 1.000.000.",
+        "note": "Solo strata-title completata — acquisti off-plan e leasehold non sono validi."
+      }
+    },
+    "who": {
+      "eyebrow": "Per chi è",
+      "title": "Tre percorsi, un solo soggiorno",
+      "base": {
+        "title": "E33 — Base (fino a 5 anni)",
+        "body": "Per individui e famiglie con solide disponibilità economiche. Primo rilascio fino a 5 anni, rinnovabile — fino a 10 anni di soggiorno cumulativo."
+      },
+      "e33e": {
+        "title": "E33E — Senior, 5 anni",
+        "body": "Età 55+. Deposito di USD 50.000 presso una banca statale più reddito di USD 3.000/mese. Validità cinque anni."
+      },
+      "e33f": {
+        "title": "E33F — Senior, 1 anno",
+        "body": "Età 55+. Solo reddito di USD 3.000/mese — nessun deposito. Validità un anno."
+      },
+      "family": {
+        "title": "Portare la famiglia",
+        "body": "È disponibile un add-on famiglia: i familiari idonei possono aggregarsi tramite i percorsi per dipendenti. Regole e costi aggiornati li confermiamo nel tuo fit memo."
+      },
+      "nowork": {
+        "title": "Nessun diritto al lavoro",
+        "body": "L'E33 è un permesso di soggiorno — non autorizza il lavoro in Indonesia. Il lavoro retribuito richiede un permesso di lavoro/KITAS separato."
+      },
+      "ageNote": "Soglia di età senior: operiamo su 55+ secondo il Permenkumham 11/2024 e le indicazioni ufficiali dell'imigrasi. Un articolo del regolamento riporta ancora 60 — per i 55–59 anni confermiamo l'idoneità caso per caso prima della presentazione."
+    },
+    "how": {
+      "eyebrow": "Come funziona",
+      "title": "Cosa fa Bali Zero",
+      "step1": {
+        "label": "Passo 1 — Gratuito",
+        "title": "Fit memo",
+        "body": "Scrivici su WhatsApp. Valutiamo quale percorso e quale track si adattano davvero alla tua situazione — gratis, senza impegno."
+      },
+      "step2": {
+        "label": "Passo 2",
+        "title": "Verifica delle prove",
+        "body": "Verifichiamo le prove del deposito o della proprietà rispetto a ciò che l'imigrasi richiede davvero — prima di presentare qualsiasi cosa."
+      },
+      "step3": {
+        "label": "Passo 3",
+        "title": "Presentazione",
+        "body": "Prepariamo e presentiamo la domanda, coordiniamo con l'imigrasi e la seguiamo fino al rilascio."
+      },
+      "priceLabel": "E33 base — tutto incluso",
+      "priceNote": "Una cifra sola, tutto compreso. Percorsi senior e add-on famiglia sono quotati nel tuo fit memo gratuito."
+    },
+    "duty": {
+      "eyebrow": "Dopo il rilascio",
+      "title": "L'obbligo di prova entro 90 giorni",
+      "body": "Una volta rilasciato il permesso, hai 90 giorni per dimostrare che l'impegno è reale: il deposito intestato a te, o la proprietà qualificante acquisita. Monitoriamo questa scadenza con te fin dal primo giorno, perché il permesso resti in regola."
+    },
+    "faq": {
+      "eyebrow": "Domande",
+      "title": "Domande frequenti",
+      "q1": "Cos'è il visto Second Home E33 per l'Indonesia?",
+      "a1": "Il visto Second Home E33 è un permesso di soggiorno a lungo termine per richiedenti con solide disponibilità economiche. Il primo rilascio dura fino a 5 anni ed è rinnovabile, con un limite cumulativo di 10 anni. È un puro permesso di soggiorno e non autorizza il lavoro in Indonesia.",
+      "q2": "Come ci si qualifica per il visto Second Home?",
+      "a2": "Due percorsi: un deposito di USD 130.000 intestato a te presso una banca statale indonesiana (BUMN), oppure una proprietà strata-title completata del valore di USD 1.000.000 (hak milik atas satuan rumah susun). Off-plan e leasehold non sono validi.",
+      "q3": "Posso lavorare in Indonesia con il visto Second Home?",
+      "a3": "No. L'E33 è solo un permesso di soggiorno — non autorizza il lavoro. Il lavoro retribuito in Indonesia richiede un permesso di lavoro/KITAS separato.",
+      "q4": "Esiste un'opzione senior per il visto Second Home?",
+      "a4": "Sì. L'E33E (55+, 5 anni) richiede un deposito di USD 50.000 presso una banca statale più un reddito di USD 3.000/mese. L'E33F (55+, 1 anno) richiede solo il reddito di USD 3.000/mese, senza deposito.",
+      "q5": "La mia famiglia può aggregarsi con il visto Second Home?",
+      "a5": "È disponibile un add-on famiglia — i familiari idonei possono aggregarsi tramite i percorsi per dipendenti. Regole e costi aggiornati vengono confermati individualmente nel fit memo gratuito.",
+      "q6": "Quanto costa il visto Second Home con Bali Zero?",
+      "a6": "IDR 39.000.000 tutto incluso per l'E33 base — una cifra sola, tutto compreso. Il fit memo che valuta il tuo percorso è gratuito."
+    },
+    "cta": {
+      "title": "Inizia con un fit memo gratuito",
+      "body": "Raccontaci la tua situazione su WhatsApp. Ti rispondiamo con una valutazione onesta: quale percorso conviene, quali prove serviranno e il prezzo esatto per il tuo caso. Senza impegno.",
+      "button": "Richiedi il Fit Memo gratuito →",
+      "note": "Prima risposta su WhatsApp in genere entro 5 ore."
+    }
   }
 }

--- a/apps/mouth/src/lib/seo/faq-data.ts
+++ b/apps/mouth/src/lib/seo/faq-data.ts
@@ -107,6 +107,51 @@ export const BUSINESS_FAQS: FAQItem[] = [
   },
 ];
 
+// Second Home Visa (E33) FAQs — mirrored by the localized FAQ section on
+// /visa/second-home. Every claim is checked against
+// research/secondhome/e33-fact-registry.json (2026-07-24):
+// no BSI/sharia equivalence, no split deposits, no ITAP conversion, no
+// "any bank" placement — those stay forbidden until the official letters
+// answer. Price is the single all-inclusive figure, never decomposed.
+export const SECOND_HOME_FAQS: FAQItem[] = [
+  {
+    question: "What is the E33 Second Home Visa for Indonesia?",
+    answer:
+      "The E33 Second Home Visa is a long-term residence permit for financially established applicants. The first grant is up to 5 years and it is renewable, with a 10-year cumulative cap. It is a pure residence permit and does not authorize employment in Indonesia.",
+    category: "visas",
+  },
+  {
+    question: "How do I qualify for the Second Home Visa?",
+    answer:
+      "Two qualifying routes: a USD 130,000 deposit in your own name at a state-owned (BUMN) Indonesian bank, or a USD 1,000,000 completed strata-title property (hak milik atas satuan rumah susun). Off-plan and leasehold property do not qualify.",
+    category: "visas",
+  },
+  {
+    question: "Can I work in Indonesia on a Second Home Visa?",
+    answer:
+      "No. The E33 is a residence permit only — it does not authorize employment. Paid work in Indonesia requires a separate work permit/KITAS.",
+    category: "visas",
+  },
+  {
+    question: "Is there a senior option for the Second Home Visa?",
+    answer:
+      "Yes. E33E (age 55+, 5 years) requires a USD 50,000 deposit at a state-owned bank plus USD 3,000/month income. E33F (age 55+, 1 year) requires USD 3,000/month income only, with no deposit.",
+    category: "visas",
+  },
+  {
+    question: "Can my family join me on a Second Home Visa?",
+    answer:
+      "A family add-on is available — eligible family members can join through dependent routes. The current dependent rules and costs are confirmed individually during the free fit memo.",
+    category: "visas",
+  },
+  {
+    question: "How much does the Second Home Visa cost with Bali Zero?",
+    answer:
+      "IDR 39,000,000 all-inclusive for the base E33 — one figure, everything included. The fit memo that assesses your route is free.",
+    category: "visas",
+  },
+];
+
 // Generate JSON-LD schema from FAQ items
 export function generateFAQSchema(items: FAQItem[]) {
   return {


### PR DESCRIPTION
## Fase 3.1 — Landing `/visa/second-home` (Fit-Memo gratuito)

Landing dedicata al verticale E33 Second Home, in modalità **Fit-Memo-only** (decisioni owner 2026-07-23: Fit Memo gratis, niente "apply now", prezzo unico mai scomposto).

### Contenuto
- `visa/second-home/page.tsx` + `SecondHomeLanding.tsx` — hero, due rotte (deposito BUMN USD 130k own-name / proprietà USD 1M strata-title), senior E33E/E33F, no-work-rights, 90-day evidence duty, blocco prezzo unico IDR 39.000.000, FAQ, CTA
- i18n EN/ID/IT (66 chiavi ciascuno, parità verificata; FR/RU rimandate — fallback EN)
- `SECOND_HOME_FAQS` in `faq-data.ts` (JSON-LD), sitemap aggiornata, line-item E33 in `services_data.ts` con link al landing nel pricing modal
- CTA = `WhatsAppLeadButton` esistente (POST /api/lead/capture, source `cta_handoff`) con attributo prodotto nel context (`product: e33_second_home`, `service_interest: second_home`) — nessun nuovo endpoint, nessun enum (evitato il 422 silenzioso)

### Claims audit
Ogni claim mappato al fact registry (`research/secondhome/`): BUMN-only, strata-only, 5 anni + cap 10, senior figures, no-work, 90-day. Claim vietati (BSI, split deposit, ITAP, any-bank) **assenti e inchiodati da test dedicato**. Dependent: "family add-on available" senza prezzo (bozza 12M non ancora approvata).

### Test
5 nuovi (page convention) + 527 esistenti verdi; tsc pulito.

🤖 Kimi (Air-M5) — review seat in allegato.
