### PR TITLE
feat(crm): E33 case lifecycle + Day-90 guarantee tracker (migration 259)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 329 routers · 660 services
+- Backend: FastAPI · 329 routers · 662 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 33 · Packages: 6

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 329 routers · 662 services
+- Backend: FastAPI · 329 routers · 663 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 33 · Packages: 6

--- a/apps/backend-rag/backend/app/routers/cron_notifiers.py
+++ b/apps/backend-rag/backend/app/routers/cron_notifiers.py
@@ -266,6 +266,43 @@ async def run_compliance_forecast(request: Request) -> dict[str, Any]:
     return response
 
 
+@router.post("/e33-guarantee-scan")
+async def run_e33_guarantee_scan(request: Request) -> dict[str, Any]:
+    """Scan open E33 Second Home cases and persist Day-90 / annual-maintenance alerts.
+
+    Loads non-terminal E33 cases, builds per-case compliance forecasts
+    (Day-90 guarantee gate with Day 30/60/75 escalation + annual maintenance
+    recurrence) and feeds them to the existing AlertsEngine — same
+    persist/dedup/promote path as /compliance-forecast. Team dispatch only;
+    nothing client-facing (Legge 5).
+
+    Kill switch: system_settings.e33_guarantee_scan_enabled must be "true"
+    (blocked by default, same posture as visa_expiry_notifier_enabled).
+    """
+    _verify_api_key(request)
+    db_pool = _get_db_pool(request)
+
+    from backend.services.crm.e33_guarantee_scanner import (
+        E33GuaranteeScanner,
+        is_scan_enabled,
+    )
+
+    if not await is_scan_enabled(db_pool):
+        logger.warning(
+            "E33 guarantee scan BLOCKED — awaiting owner approval "
+            "(set e33_guarantee_scan_enabled=true)"
+        )
+        return {
+            "service": "e33_guarantee_scan",
+            "status": "blocked",
+            "reason": "awaiting_owner_approval",
+        }
+
+    scanner = E33GuaranteeScanner(db_pool)
+    result = await scanner.scan()
+    return {"service": "e33_guarantee_scan", **result}
+
+
 @router.post("/email-health")
 async def run_email_health(request: Request) -> dict[str, Any]:
     """Run retry + stale-detection + escalation + daily report for email.

--- a/apps/backend-rag/backend/db/migrations_v2/259_e33_case_lifecycle.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/259_e33_case_lifecycle.sql
@@ -1,0 +1,72 @@
+-- Migration 259: E33 Second Home case lifecycle (CRM backend, Fase 3.2).
+--
+-- Purpose:
+--   Persistence for the E33 Second Home client case lifecycle modelled in
+--   backend/services/crm/e33_lifecycle.py (stages FIT_MEMO → … → RENEWAL /
+--   EPO / STATUS_CHANGE, with ITAP_EVAL gated off until the letter-006 Q7
+--   reply). The coarse CRM practice status keeps flowing through
+--   practice_state_machine.py; this table carries the E33-specific case
+--   stages underneath an on_process practice (optional practice_id link).
+--
+-- NO-CUSTODY SOP (owner decision 2026-07-23):
+--   Bali Zero NEVER holds client funds. The evidence JSONB stores REFERENCES
+--   ONLY — document ids, kinds, issue/filing dates, confirmations — never
+--   account numbers, balances or amounts. There are deliberately NO amount /
+--   balance / account columns in this table. PII stays minimal per UU PDP:
+--   the case links to the CRM client by id; names/passports live in clients.
+--
+-- Dependents:
+--   dependent_code / principal_case_id model the dependent relationship
+--   (candidate codes E31B/E31E/E31H/E31J, PENDING official confirmation —
+--   enforced in code via the configurable DEFAULT_DEPENDENT_CODES, not in
+--   this DDL, so a confirmed code change is a code edit, not a migration).
+--
+-- Day-90 gate:
+--   guarantee_proof_deadline is a stored snapshot of entry/ITAS + 90 days,
+--   refreshed by E33CaseRepository.save() on every write; the authoritative
+--   computation stays in code (compute_guarantee_deadline). Alert schedule
+--   (Day 30/60/75) is computed in code and delivered through the existing
+--   compliance_alerts machinery — no alert state is duplicated here.
+
+CREATE TABLE IF NOT EXISTS e33_cases (
+    case_id                  TEXT PRIMARY KEY,
+    client_id                INTEGER NOT NULL REFERENCES clients(id),
+    practice_id              INTEGER REFERENCES practices(id),
+    basis                    TEXT NOT NULL
+                             CHECK (basis IN ('deposit', 'property')),
+    stage                    TEXT NOT NULL
+                             CHECK (stage IN (
+                                 'fit_memo', 'bank_precheck', 'application',
+                                 'payment', 'visa_issued', 'entry',
+                                 'itas_active', 'guarantee_proof_due',
+                                 'annual_maintenance', 'renewal',
+                                 'epo', 'status_change', 'itap_eval'
+                             )),
+    owner_email              TEXT,
+    entry_date               DATE,
+    itas_date                DATE,
+    guarantee_proof_deadline DATE,
+    dependent_code           TEXT,
+    principal_case_id        TEXT REFERENCES e33_cases(case_id),
+    dependents               JSONB NOT NULL DEFAULT '[]'::jsonb,
+    evidence                 JSONB NOT NULL DEFAULT '[]'::jsonb,
+    stage_history            JSONB NOT NULL DEFAULT '[]'::jsonb,
+    stayguard_eligible       BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_e33_cases_client ON e33_cases (client_id);
+CREATE INDEX IF NOT EXISTS idx_e33_cases_stage ON e33_cases (stage);
+CREATE INDEX IF NOT EXISTS idx_e33_cases_guarantee_deadline
+    ON e33_cases (guarantee_proof_deadline)
+    WHERE guarantee_proof_deadline IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_e33_cases_principal ON e33_cases (principal_case_id)
+    WHERE principal_case_id IS NOT NULL;
+
+-- === ROLLBACK ===
+DROP INDEX IF EXISTS idx_e33_cases_principal;
+DROP INDEX IF EXISTS idx_e33_cases_guarantee_deadline;
+DROP INDEX IF EXISTS idx_e33_cases_stage;
+DROP INDEX IF EXISTS idx_e33_cases_client;
+DROP TABLE IF EXISTS e33_cases;

--- a/apps/backend-rag/backend/services/compliance/alerts_engine.py
+++ b/apps/backend-rag/backend/services/compliance/alerts_engine.py
@@ -38,6 +38,10 @@ _DOCTYPE_TO_CATEGORY: dict[str, str] = {
     "kitas": "visa_expiry",
     "passport": "document_expiry",
     "license": "license_renewal",
+    # E33 Second Home lifecycle (services/crm/e33_lifecycle.py) — the Day-90
+    # guarantee gate and the annual maintenance recurrence.
+    "e33_guarantee": "guarantee_proof",
+    "e33_maintenance": "guarantee_proof",
 }
 
 

--- a/apps/backend-rag/backend/services/compliance/renewal_rules.py
+++ b/apps/backend-rag/backend/services/compliance/renewal_rules.py
@@ -274,6 +274,11 @@ RENEWAL_RULES: dict[str, RenewalRule] = {
         notes="Annual permit for foreign workers. Usually bundled with Working KITAS renewal.",
     ),
     # ── E33 Second Home (5y permit — guarantee must be maintained) ───────
+    # TODO(senior variants): E33E/E33F senior renewals (income-based, NO
+    # deposit guarantee) also match the "e33"/"second home" patterns below
+    # and would incorrectly inherit the deposit-oriented required_docs.
+    # Add a senior-specific rule (pension/income proof docs) BEFORE E33E/E33F
+    # renewals are sold, and place it earlier in RULE_PRIORITY_ORDER.
     "e33_second_home_renewal": RenewalRule(
         rule_id="e33_second_home_renewal",
         document_types=("visa", "kitas"),

--- a/apps/backend-rag/backend/services/compliance/renewal_rules.py
+++ b/apps/backend-rag/backend/services/compliance/renewal_rules.py
@@ -273,6 +273,26 @@ RENEWAL_RULES: dict[str, RenewalRule] = {
         complexity=2.0,
         notes="Annual permit for foreign workers. Usually bundled with Working KITAS renewal.",
     ),
+    # ── E33 Second Home (5y permit — guarantee must be maintained) ───────
+    "e33_second_home_renewal": RenewalRule(
+        rule_id="e33_second_home_renewal",
+        document_types=("visa", "kitas"),
+        visa_type_patterns=("e33", "second home"),
+        processing_days=30,
+        lead_time_days=120,
+        recommended_start_days=150,
+        renewal_pricing_key=None,  # owner-set all-inclusive pricing; no catalog key yet
+        required_docs=(
+            "valid_passport",
+            "current_itas_card",
+            "guarantee_proof_bank_confirmation_or_property_title",
+            "domicile_letter",
+        ),
+        complexity=2.0,
+        notes="E33 Second Home renewal — verify the USD 130k BUMN deposit (or "
+        "USD 1M property) is still maintained before filing. Day-90 guarantee "
+        "gate tracked separately by services/crm/e33_lifecycle.py.",
+    ),
     # ── Fallback rule — unknown/generic visa ─────────────────────────────────
     "generic_visa_renewal": RenewalRule(
         rule_id="generic_visa_renewal",
@@ -297,6 +317,7 @@ RULE_PRIORITY_ORDER: tuple[str, ...] = (
     "kitas_working_extend",
     "kitas_freelance_extend",
     "kitas_remote_worker_extend",
+    "e33_second_home_renewal",
     "kitas_investor_extend",
     "kitas_retirement_extend",
     "kitas_spouse_extend",

--- a/apps/backend-rag/backend/services/compliance/templates_i18n.py
+++ b/apps/backend-rag/backend/services/compliance/templates_i18n.py
@@ -149,6 +149,35 @@ TEMPLATE_REGISTRY: dict[TemplateCategory, dict[TemplateField, dict[LangCode, str
             "id": "Tinjau dampak operasional",
         },
     },
+    "guarantee_proof": {
+        "title": {
+            "it": "E33 Second Home — prova di garanzia",
+            "en": "E33 Second Home — guarantee proof",
+            "id": "E33 Second Home — bukti jaminan",
+        },
+        "body": {
+            "it": (
+                "La prova della garanzia E33 ({{ doc_type }}) è dovuta tra "
+                "{{ days_until }} giorni. Il deposito/proprietà deve essere "
+                "dimostrato all'Immigrazione e mantenuto per la validità del permesso."
+            ),
+            "en": (
+                "The E33 guarantee proof ({{ doc_type }}) is due in "
+                "{{ days_until }} days. The deposit/property must be evidenced "
+                "to Immigration and maintained for the permit validity."
+            ),
+            "id": (
+                "Bukti jaminan E33 ({{ doc_type }}) jatuh tempo dalam "
+                "{{ days_until }} hari. Deposit/properti harus dibuktikan ke "
+                "Imigrasi dan dipertahankan selama masa berlaku izin."
+            ),
+        },
+        "action": {
+            "it": "Invia la prova di garanzia all'Immigrazione tramite Bali Zero",
+            "en": "File the guarantee proof with Immigration via Bali Zero",
+            "id": "Serahkan bukti jaminan ke Imigrasi melalui Bali Zero",
+        },
+    },
     "document_expiry": {
         "title": {
             "it": "Documento {{ doc_type }} in scadenza",

--- a/apps/backend-rag/backend/services/crm/e33_case_repository.py
+++ b/apps/backend-rag/backend/services/crm/e33_case_repository.py
@@ -1,0 +1,268 @@
+"""E33CaseRepository — asyncpg persistence for e33_cases (migration 259).
+
+Mirrors the AlertRepository pattern (pool or single-connection binding for
+transaction-scoped tests). Serialization of history/evidence/dependents to
+JSONB happens here; the lifecycle model in ``e33_lifecycle.py`` stays
+persistence-free and pure.
+
+No-custody SOP applies at this boundary too: the table stores evidence
+REFERENCES (document ids, dates, confirmations) — never account numbers,
+balances or amounts (enforced upstream by
+``e33_lifecycle.validate_evidence_metadata``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime
+from typing import Any
+
+import asyncpg
+
+from backend.services.crm.e33_lifecycle import (
+    DependentLink,
+    E33Case,
+    E33Stage,
+    EvidenceKind,
+    EvidenceRef,
+    GuaranteeBasis,
+    StageTransition,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── (de)serialization helpers ──────────────────────────────────────────────────
+
+
+def _evidence_to_dict(e: EvidenceRef) -> dict[str, Any]:
+    return {
+        "evidence_id": e.evidence_id,
+        "kind": e.kind.value,
+        "document_ref": e.document_ref,
+        "issued_date": e.issued_date.isoformat() if e.issued_date else None,
+        "filed_date": e.filed_date.isoformat() if e.filed_date else None,
+        "confirmed_by": e.confirmed_by,
+        "metadata": e.metadata,
+    }
+
+
+def _evidence_from_dict(d: dict[str, Any]) -> EvidenceRef:
+    return EvidenceRef(
+        evidence_id=d["evidence_id"],
+        kind=EvidenceKind(d["kind"]),
+        document_ref=d["document_ref"],
+        issued_date=date.fromisoformat(d["issued_date"]) if d.get("issued_date") else None,
+        filed_date=date.fromisoformat(d["filed_date"]) if d.get("filed_date") else None,
+        confirmed_by=d.get("confirmed_by"),
+        metadata=d.get("metadata") or {},
+    )
+
+
+def _dependent_to_dict(d: DependentLink) -> dict[str, Any]:
+    return {"code": d.code, "client_id": d.client_id, "relationship": d.relationship}
+
+
+def _dependent_from_dict(d: dict[str, Any]) -> DependentLink:
+    return DependentLink(code=d["code"], client_id=d["client_id"], relationship=d["relationship"])
+
+
+def _transition_to_dict(t: StageTransition) -> dict[str, Any]:
+    return {
+        "from_stage": t.from_stage.value if t.from_stage else None,
+        "to_stage": t.to_stage.value,
+        "at": t.at.isoformat(),
+        "actor": t.actor,
+        "note": t.note,
+    }
+
+
+def _transition_from_dict(d: dict[str, Any]) -> StageTransition:
+    return StageTransition(
+        from_stage=E33Stage(d["from_stage"]) if d.get("from_stage") else None,
+        to_stage=E33Stage(d["to_stage"]),
+        at=datetime.fromisoformat(d["at"]),
+        actor=d.get("actor"),
+        note=d.get("note"),
+    )
+
+
+def _jsonb(value: Any) -> Any:
+    """asyncpg returns jsonb as str on some drivers — normalize to Python."""
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def case_to_row(case: E33Case) -> dict[str, Any]:
+    """Flatten an E33Case to e33_cases column values."""
+    return {
+        "case_id": case.case_id,
+        "client_id": case.client_id,
+        "practice_id": case.practice_id,
+        "basis": case.basis.value,
+        "stage": case.stage.value,
+        "owner_email": case.owner,
+        "entry_date": case.entry_date,
+        "itas_date": case.itas_date,
+        "guarantee_proof_deadline": case.guarantee_deadline,
+        "dependent_code": case.dependent_code,
+        "principal_case_id": case.principal_case_id,
+        "dependents": json.dumps([_dependent_to_dict(d) for d in case.dependents]),
+        "evidence": json.dumps([_evidence_to_dict(e) for e in case.evidence]),
+        "stage_history": json.dumps([_transition_to_dict(t) for t in case.history]),
+        "stayguard_eligible": case.stayguard_eligible,
+        "created_at": case.created_at,
+    }
+
+
+def row_to_case(row: dict[str, Any]) -> E33Case:
+    """Rebuild an E33Case from an e33_cases row."""
+    case = E33Case(
+        case_id=row["case_id"],
+        client_id=row["client_id"],
+        practice_id=row.get("practice_id"),
+        basis=GuaranteeBasis(row["basis"]),
+        stage=E33Stage(row["stage"]),
+        owner=row.get("owner_email"),
+        entry_date=row.get("entry_date"),
+        itas_date=row.get("itas_date"),
+        dependent_code=row.get("dependent_code"),
+        principal_case_id=row.get("principal_case_id"),
+        dependents=[_dependent_from_dict(d) for d in _jsonb(row.get("dependents")) or []],
+        evidence=[_evidence_from_dict(d) for d in _jsonb(row.get("evidence")) or []],
+        history=[_transition_from_dict(d) for d in _jsonb(row.get("stage_history")) or []],
+        created_at=row.get("created_at") or datetime.now(),
+    )
+    return case
+
+
+# ── Repository ─────────────────────────────────────────────────────────────────
+
+_COLUMNS = (
+    "case_id, client_id, practice_id, basis, stage, owner_email,"
+    " entry_date, itas_date, guarantee_proof_deadline,"
+    " dependent_code, principal_case_id,"
+    " dependents, evidence, stage_history, stayguard_eligible, created_at"
+)
+
+
+class E33CaseRepository:
+    """CRUD for e33_cases. Read-heavy paths stay idempotent."""
+
+    def __init__(self, db_pool: asyncpg.Pool) -> None:
+        self._pool = db_pool
+        self._conn: asyncpg.Connection | None = None
+
+    @classmethod
+    def with_connection(cls, conn: asyncpg.Connection) -> E33CaseRepository:
+        """Bind the repo to a single pre-acquired connection (tests)."""
+        inst = cls.__new__(cls)
+        inst._pool = None  # type: ignore[assignment]
+        inst._conn = conn
+        return inst
+
+    async def _exec(self, fn_name: str, query: str, *args: Any) -> Any:
+        if self._conn is not None:
+            return await getattr(self._conn, fn_name)(query, *args)
+        async with self._pool.acquire() as conn:
+            return await getattr(conn, fn_name)(query, *args)
+
+    async def insert(self, case: E33Case) -> E33Case:
+        """Insert a new case. Raises asyncpg.UniqueViolationError on dup id."""
+        r = case_to_row(case)
+        await self._exec(
+            "execute",
+            f"""
+            INSERT INTO e33_cases ({_COLUMNS})
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13::jsonb,$14::jsonb,$15,$16)
+            """,
+            r["case_id"],
+            r["client_id"],
+            r["practice_id"],
+            r["basis"],
+            r["stage"],
+            r["owner_email"],
+            r["entry_date"],
+            r["itas_date"],
+            r["guarantee_proof_deadline"],
+            r["dependent_code"],
+            r["principal_case_id"],
+            r["dependents"],
+            r["evidence"],
+            r["stage_history"],
+            r["stayguard_eligible"],
+            r["created_at"],
+        )
+        logger.info("E33 case inserted: %s (client=%s)", case.case_id, case.client_id)
+        return case
+
+    async def save(self, case: E33Case) -> None:
+        """Persist mutable state after advance()/add_evidence() calls."""
+        r = case_to_row(case)
+        await self._exec(
+            "execute",
+            """
+            UPDATE e33_cases
+               SET practice_id = $2,
+                   stage = $3,
+                   owner_email = $4,
+                   entry_date = $5,
+                   itas_date = $6,
+                   guarantee_proof_deadline = $7,
+                   dependents = $8::jsonb,
+                   evidence = $9::jsonb,
+                   stage_history = $10::jsonb,
+                   stayguard_eligible = $11,
+                   updated_at = now()
+             WHERE case_id = $1
+            """,
+            r["case_id"],
+            r["practice_id"],
+            r["stage"],
+            r["owner_email"],
+            r["entry_date"],
+            r["itas_date"],
+            r["guarantee_proof_deadline"],
+            r["dependents"],
+            r["evidence"],
+            r["stage_history"],
+            r["stayguard_eligible"],
+        )
+
+    async def load(self, case_id: str) -> E33Case | None:
+        record = await self._exec(
+            "fetchrow",
+            f"SELECT {_COLUMNS} FROM e33_cases WHERE case_id = $1",
+            case_id,
+        )
+        return row_to_case(dict(record)) if record else None
+
+    async def list_by_client(self, client_id: int) -> list[E33Case]:
+        records = await self._exec(
+            "fetch",
+            f"SELECT {_COLUMNS} FROM e33_cases WHERE client_id = $1 ORDER BY created_at",
+            client_id,
+        )
+        return [row_to_case(dict(r)) for r in records]
+
+    async def list_open_guarantee_cases(self) -> list[E33Case]:
+        """Cases whose Day-90 gate or annual maintenance may need alerts.
+
+        Returns non-terminal cases at ITAS_ACTIVE or later — the alert
+        builder (``E33Case.build_case_forecasts``) decides what is actually
+        due; this query is the coarse DB-side filter for a future scanner.
+        """
+        records = await self._exec(
+            "fetch",
+            f"""
+            SELECT {_COLUMNS} FROM e33_cases
+             WHERE stage IN ('itas_active', 'guarantee_proof_due', 'annual_maintenance')
+             ORDER BY guarantee_proof_deadline NULLS LAST
+            """,
+        )
+        return [row_to_case(dict(r)) for r in records]
+
+
+__all__ = ["E33CaseRepository", "case_to_row", "row_to_case"]

--- a/apps/backend-rag/backend/services/crm/e33_guarantee_scanner.py
+++ b/apps/backend-rag/backend/services/crm/e33_guarantee_scanner.py
@@ -1,0 +1,117 @@
+"""E33 Guarantee Scanner — Day-90 / annual-maintenance alert generation.
+
+Entry point for the cron layer (`app/routers/cron_notifiers.py`,
+POST /api/cron/notifiers/e33-guarantee-scan), following the same
+service-per-endpoint pattern as StalePracticeNotifier / LKPMDeadlineNotifier.
+
+Flow (mirrors the run_compliance_forecast integration):
+  1. E33CaseRepository.list_open_guarantee_cases() — non-terminal cases at
+     ITAS_ACTIVE or later (coarse DB-side filter).
+  2. E33Case.build_case_forecasts(today=today) — pure per-case computation
+     of the Day-90 guarantee gate and the annual-maintenance recurrence.
+  3. AlertsEngine.generate_alerts(forecasts) — the EXISTING compliance
+     organ handles dedup, severity promotion (Day 30 → 60 → 75 escalation
+     rides the stable compliance_item_ref), persistence to
+     compliance_alerts, and team dispatch.
+
+Legge 5: nothing here is client-facing. Alerts are persisted and dispatched
+through the same team channels the existing compliance-forecast flow uses —
+no WhatsApp/client notifications are sent by this scanner.
+
+Kill switch: system_settings.e33_guarantee_scan_enabled must be "true"
+(same blocked-by-default posture as visa_expiry_notifier_enabled).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any
+
+import asyncpg
+
+from backend.services.crm.e33_case_repository import E33CaseRepository
+
+logger = logging.getLogger(__name__)
+
+_KILL_SWITCH_KEY: str = "e33_guarantee_scan_enabled"
+
+
+async def is_scan_enabled(db_pool: asyncpg.Pool) -> bool:
+    """Check the kill switch in system_settings. Blocked unless "true"."""
+    async with db_pool.acquire() as conn:
+        value = await conn.fetchval(
+            "SELECT value FROM system_settings WHERE key = $1",
+            _KILL_SWITCH_KEY,
+        )
+    enabled = value == "true"
+    if not enabled:
+        logger.info(
+            "E33GuaranteeScanner: disabled by kill switch '%s' (value=%r)",
+            _KILL_SWITCH_KEY,
+            value,
+        )
+    return enabled
+
+
+class E33GuaranteeScanner:
+    """Scans open E33 cases and feeds due forecasts into the AlertsEngine."""
+
+    def __init__(
+        self,
+        db_pool: asyncpg.Pool,
+        *,
+        pricing_service: Any = None,
+        alerts_engine: Any = None,
+    ) -> None:
+        """
+        Args:
+            db_pool:         Active asyncpg connection pool.
+            pricing_service: Optional pre-loaded PricingService (shared with
+                             the caller to avoid a second lookup).
+            alerts_engine:   Optional pre-built AlertsEngine (tests/dry runs).
+        """
+        self._db_pool = db_pool
+        self._pricing_service = pricing_service
+        self._alerts_engine = alerts_engine
+
+    def _engine(self) -> Any:
+        if self._alerts_engine is not None:
+            return self._alerts_engine
+        from backend.services.compliance.alert_wiring import build_alerts_engine
+        from backend.services.pricing.pricing_service import get_pricing_service
+
+        pricing = self._pricing_service or get_pricing_service()
+        return build_alerts_engine(self._db_pool, pricing_service=pricing)
+
+    async def scan(self, *, today: date | None = None) -> dict[str, Any]:
+        """Run one scan pass. ``today`` is injectable for deterministic tests."""
+        today = today or date.today()
+        repo = E33CaseRepository(self._db_pool)
+        cases = await repo.list_open_guarantee_cases()
+
+        forecasts = []
+        for case in cases:
+            try:
+                forecasts.extend(case.build_case_forecasts(today=today))
+            except Exception as exc:  # resilience: one bad case doesn't kill the batch
+                logger.error(
+                    "E33 forecast build failed for case %s: %s (skipping)",
+                    case.case_id,
+                    exc,
+                )
+
+        alerts = await self._engine().generate_alerts(forecasts)
+
+        result = {
+            "status": "ok",
+            "scan_date": today.isoformat(),
+            "cases_scanned": len(cases),
+            "forecasts_built": len(forecasts),
+            "alerts_generated": len(alerts),
+        }
+        logger.info("E33GuaranteeScanner: %s", result)
+        return result
+
+
+__all__ = ["E33GuaranteeScanner", "is_scan_enabled"]

--- a/apps/backend-rag/backend/services/crm/e33_lifecycle.py
+++ b/apps/backend-rag/backend/services/crm/e33_lifecycle.py
@@ -1,0 +1,672 @@
+"""E33 Second Home — client case lifecycle model (CRM).
+
+Extends the existing practice/journey/compliance machinery for the E33
+Second Home visa vertical; it does NOT replace it:
+
+- The coarse CRM practice status still flows through
+  ``practice_state_machine.py`` (inquiry → … → completed). This module models
+  the E33-specific *case* stages that live underneath an ``on_process``
+  practice, mirroring that file's validated-transition pattern.
+- Compliance deadlines computed here (the Day-90 guarantee-proof gate and the
+  annual maintenance recurrence) are emitted as
+  ``backend.services.compliance.predictive_engine.ComplianceForecast`` objects,
+  so the existing ``AlertsEngine`` (dedup → ``compliance_alerts`` → dispatcher)
+  carries persistence, i18n and delivery. No parallel alert framework.
+- Expiry-driven E33 renewals are covered by the existing
+  ``PredictiveComplianceEngine`` via the ``e33_second_home_renewal`` rule in
+  ``renewal_rules.py`` — deliberately not duplicated here.
+
+NO-CUSTODY SOP (owner decision 2026-07-23, non-negotiable)
+-----------------------------------------------------------
+Bali Zero NEVER holds, routes, or observes client funds. The USD 130,000
+own-name BUMN-bank deposit (or the USD 1,000,000 qualifying property) is
+placed and kept by the CLIENT. This model therefore stores EVIDENCE
+REFERENCES ONLY: document ids, issuing party, dates, filing confirmations.
+It must never store account numbers, balances, amounts, IBANs or any other
+financial-instrument detail — ``EvidenceRef`` has no such fields by design
+and its free-form ``metadata`` dict is rejected by
+:func:`validate_evidence_metadata` if custody-flavoured keys appear.
+PII is kept minimal per UU PDP: a case links to the CRM client by id only;
+names/passports stay in the CRM client record.
+
+Dependents (E31B/E31E/E31H/E31J) are PENDING official confirmation
+(letter 006, ``research/secondhome/e33-letter-response-tracker.md``): the
+relationship is modelled, but the allowed codes live in the configurable
+``DEFAULT_DEPENDENT_CODES`` constant — never hardcoded in logic.
+
+ITAP_EVAL is modelled but gated behind ``E33_ITAP_EVAL_ENABLED = False``:
+ITAP conversion marketing is forbidden until the written letter-006 Q7
+reply arrives (owner decision 2026-07-23).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from enum import Enum
+from typing import Any
+
+from backend.services.compliance.predictive_engine import ComplianceForecast
+from backend.services.compliance.priority_scorer import calculate_priority
+
+logger = logging.getLogger(__name__)
+
+
+# ── Stages ────────────────────────────────────────────────────────────────────
+
+
+class E33Stage(str, Enum):
+    """Lifecycle stages of an E33 Second Home case."""
+
+    FIT_MEMO = "fit_memo"  # free fit assessment (owner decision: FREE)
+    BANK_PRECHECK = "bank_precheck"  # BUMN bank pre-check of deposit route
+    APPLICATION = "application"  # visa application dossier
+    PAYMENT = "payment"  # PNBP/service payment step
+    VISA_ISSUED = "visa_issued"  # visa granted, pre-entry
+    ENTRY = "entry"  # client entered Indonesia
+    ITAS_ACTIVE = "itas_active"  # ITAS (stay permit) activated
+    GUARANTEE_PROOF_DUE = "guarantee_proof_due"  # 90-day evidence gate open
+    ANNUAL_MAINTENANCE = "annual_maintenance"  # gate cleared; yearly upkeep
+    RENEWAL = "renewal"  # permit renewal in progress
+    EPO = "epo"  # Exit Permit Only — terminal
+    STATUS_CHANGE = "status_change"  # moved to another permit — terminal
+    ITAP_EVAL = "itap_eval"  # ITAP evaluation (gated, see E33_ITAP_EVAL_ENABLED)
+
+
+class GuaranteeBasis(str, Enum):
+    """Which qualifying-guarantee route the case uses.
+
+    Mid-permit basis switch (deposit ↔ property) is BELUM_DIATUR_PUBLIK in
+    the E33 fact registry — a basis change mid-permit is therefore NOT a
+    normal transition and must go through STATUS_CHANGE handling instead.
+    """
+
+    DEPOSIT = "deposit"  # USD 130,000 own-name at a BUMN state bank
+    PROPERTY = "property"  # USD 1,000,000 qualifying completed strata title
+
+
+# Forward transitions. Back-edges allow one-step correction only.
+VALID_TRANSITIONS: dict[E33Stage, set[E33Stage]] = {
+    E33Stage.FIT_MEMO: {E33Stage.BANK_PRECHECK},
+    E33Stage.BANK_PRECHECK: {E33Stage.APPLICATION, E33Stage.FIT_MEMO},
+    E33Stage.APPLICATION: {E33Stage.PAYMENT, E33Stage.BANK_PRECHECK},
+    E33Stage.PAYMENT: {E33Stage.VISA_ISSUED, E33Stage.APPLICATION},
+    E33Stage.VISA_ISSUED: {E33Stage.ENTRY},
+    E33Stage.ENTRY: {E33Stage.ITAS_ACTIVE},
+    E33Stage.ITAS_ACTIVE: {
+        E33Stage.GUARANTEE_PROOF_DUE,
+        E33Stage.EPO,
+        E33Stage.STATUS_CHANGE,
+        E33Stage.ITAP_EVAL,
+    },
+    E33Stage.GUARANTEE_PROOF_DUE: {
+        E33Stage.ANNUAL_MAINTENANCE,
+        E33Stage.EPO,
+        E33Stage.STATUS_CHANGE,
+    },
+    E33Stage.ANNUAL_MAINTENANCE: {
+        E33Stage.RENEWAL,
+        E33Stage.EPO,
+        E33Stage.STATUS_CHANGE,
+        E33Stage.ITAP_EVAL,
+    },
+    E33Stage.RENEWAL: {E33Stage.ITAS_ACTIVE},
+    E33Stage.EPO: set(),  # terminal
+    E33Stage.STATUS_CHANGE: set(),  # terminal
+    E33Stage.ITAP_EVAL: {E33Stage.STATUS_CHANGE},
+}
+
+TERMINAL_STAGES: frozenset[E33Stage] = frozenset({E33Stage.EPO, E33Stage.STATUS_CHANGE})
+
+# Stages in which the ITAS is live (post-entry, pre-terminal).
+ACTIVE_PERMIT_STAGES: frozenset[E33Stage] = frozenset(
+    {E33Stage.ITAS_ACTIVE, E33Stage.GUARANTEE_PROOF_DUE, E33Stage.ANNUAL_MAINTENANCE}
+)
+
+# ITAP conversion marketing is forbidden until the written letter-006 Q7
+# reply (owner decision 2026-07-23). Flip to True only after that reply.
+E33_ITAP_EVAL_ENABLED: bool = False
+
+
+class E33InvalidTransitionError(Exception):
+    """Raised when an E33 case stage transition is not allowed."""
+
+    def __init__(self, from_stage: E33Stage, to_stage: E33Stage, reason: str = "") -> None:
+        self.from_stage = from_stage
+        self.to_stage = to_stage
+        self.reason = reason
+        msg = f"Invalid E33 transition: {from_stage.value} → {to_stage.value}"
+        if reason:
+            msg += f" ({reason})"
+        super().__init__(msg)
+
+
+def validate_transition(
+    from_stage: E33Stage,
+    to_stage: E33Stage,
+    *,
+    itap_eval_enabled: bool = E33_ITAP_EVAL_ENABLED,
+) -> bool:
+    """Validate an E33 case stage transition.
+
+    Mirrors ``practice_state_machine.validate_transition``: same-stage is a
+    no-op, unknown/terminal states and missing edges raise.
+
+    Raises:
+        E33InvalidTransitionError: If the transition is not allowed.
+    """
+    if from_stage == to_stage:
+        return True
+    allowed = VALID_TRANSITIONS.get(from_stage, set())
+    if to_stage not in allowed:
+        raise E33InvalidTransitionError(
+            from_stage,
+            to_stage,
+            f"allowed transitions from '{from_stage.value}': {sorted(s.value for s in allowed)}",
+        )
+    if to_stage == E33Stage.ITAP_EVAL and not itap_eval_enabled:
+        raise E33InvalidTransitionError(
+            from_stage,
+            to_stage,
+            "ITAP evaluation is gated until the letter-006 Q7 written reply",
+        )
+    logger.debug("E33 transition validated: %s → %s", from_stage.value, to_stage.value)
+    return True
+
+
+# ── Dependents (codes pending official confirmation — configurable) ───────────
+
+# Candidate dependent codes from the E33 research corner, PENDING official
+# confirmation (letter 006). Overridable per-call; never hardcoded in logic.
+DEFAULT_DEPENDENT_CODES: tuple[str, ...] = ("E31B", "E31E", "E31H", "E31J")
+
+
+class UnknownDependentCodeError(ValueError):
+    """Raised when a dependent code is not in the allowed set."""
+
+
+@dataclass(frozen=True)
+class DependentLink:
+    """Link from a principal E33 case to a dependent (spouse/child/parent).
+
+    ``code`` is the dependent visa code (candidate values in
+    ``DEFAULT_DEPENDENT_CODES``, pending official confirmation).
+    ``client_id`` references the CRM client record — no PII is copied here.
+    """
+
+    code: str
+    client_id: int
+    relationship: str  # "spouse" | "child" | "parent" | free text until confirmed
+
+
+def validate_dependent_code(
+    code: str,
+    *,
+    allowed: tuple[str, ...] = DEFAULT_DEPENDENT_CODES,
+) -> str:
+    """Validate a dependent code against the allowed (configurable) set."""
+    if code not in allowed:
+        raise UnknownDependentCodeError(
+            f"Unknown dependent code {code!r}; allowed: {allowed}. "
+            "Codes are pending official confirmation — extend "
+            "DEFAULT_DEPENDENT_CODES only after the letter-006 reply."
+        )
+    return code
+
+
+# ── Evidence (no-custody) ─────────────────────────────────────────────────────
+
+
+class EvidenceKind(str, Enum):
+    """Evidence categories. All are REFERENCES, never financial data."""
+
+    BANK_CONFIRMATION = "bank_confirmation"  # bank letter confirming the deposit exists
+    PROPERTY_TITLE = "property_title"  # proof of the qualifying property
+    IMMIGRATION_FILING = "immigration_filing"  # proof submitted to Immigration
+    IMMIGRATION_RECEIPT = "immigration_receipt"  # Immigration acknowledgement
+    OTHER = "other"
+
+
+# Keys that would turn an evidence record into custody data. Normalized
+# (lower-cased, separators stripped) before matching.
+FORBIDDEN_METADATA_KEYS: frozenset[str] = frozenset(
+    {
+        "accountnumber",
+        "account",
+        "balance",
+        "amount",
+        "iban",
+        "swift",
+        "nomorrekening",
+        "norekening",
+        "norek",
+        "saldo",
+        "jumlah",
+    }
+)
+
+
+class CustodyViolationError(ValueError):
+    """Raised when evidence metadata would breach the no-custody SOP."""
+
+
+def _normalize_key(key: str) -> str:
+    return "".join(ch for ch in key.lower() if ch.isalnum())
+
+
+def validate_evidence_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Reject evidence metadata that would breach the no-custody SOP.
+
+    Bali Zero never holds or observes client funds: account numbers,
+    balances and amounts are forbidden in case evidence. Only document
+    references, dates and confirmations may be stored.
+    """
+    for key in metadata:
+        if _normalize_key(str(key)) in FORBIDDEN_METADATA_KEYS:
+            raise CustodyViolationError(
+                f"Evidence metadata key {key!r} breaches the no-custody SOP: "
+                "store document references and dates only, never account "
+                "numbers, balances or amounts."
+            )
+    return metadata
+
+
+@dataclass(frozen=True)
+class EvidenceRef:
+    """Reference to a piece of guarantee evidence — metadata only.
+
+    ``document_ref`` is a pointer to the CRM/Drive document (id or path),
+    never the document content and never financial-instrument data.
+    """
+
+    evidence_id: str
+    kind: EvidenceKind
+    document_ref: str  # CRM document id / Drive file id — never account data
+    issued_date: date | None = None  # when the bank/notary issued the proof
+    filed_date: date | None = None  # when it was filed to Immigration
+    confirmed_by: str | None = None  # team member who verified the reference
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        validate_evidence_metadata(self.metadata)
+
+
+# ── Day-90 guarantee gate + annual maintenance ────────────────────────────────
+
+# The qualifying guarantee must be evidenced to Immigration within 90 days
+# of entry/ITAS and MAINTAINED for the permit validity.
+GUARANTEE_PROOF_WINDOW_DAYS: int = 90
+# Alert schedule: days AFTER the anchor (entry/ITAS date) at which alerts
+# fire — Day 30 / 60 / 75, i.e. 60 / 30 / 15 days before the deadline.
+GUARANTEE_ALERT_DAYS_AFTER: tuple[int, ...] = (30, 60, 75)
+# Annual maintenance: re-confirm the guarantee is maintained each ITAS
+# anniversary; alerts start this many days before it.
+ANNUAL_MAINTENANCE_ALERT_DAYS_BEFORE: int = 60
+
+# Severity mapping aligned with AlertSeverity (info > 60d, warning ≤ 60d,
+# urgent ≤ 30d, critical ≤ 7d or overdue). Values are the strings
+# AlertsEngine._urgency_to_severity passes through unchanged.
+_SEVERITY_INFO = "info"
+_SEVERITY_WARNING = "warning"
+_SEVERITY_URGENT = "urgent"
+_SEVERITY_CRITICAL = "critical"
+
+# matched_rule_id values carried into ComplianceForecast.compliance_item_ref
+# (stable → AlertsEngine dedup/promotion works across the Day 30/60/75 run).
+RULE_ID_GUARANTEE_PROOF = "e33_guarantee_proof_90d"
+RULE_ID_ANNUAL_MAINTENANCE = "e33_annual_maintenance"
+
+# document_type values — mapped to the "guarantee_proof" template category in
+# alerts_engine._DOCTYPE_TO_CATEGORY.
+DOCTYPE_GUARANTEE = "e33_guarantee"
+DOCTYPE_MAINTENANCE = "e33_maintenance"
+
+
+def severity_for_days_until(days_until: int) -> str:
+    """Map days-until-deadline to an alert severity string."""
+    if days_until < 0 or days_until <= 7:
+        return _SEVERITY_CRITICAL
+    if days_until <= 30:
+        return _SEVERITY_URGENT
+    if days_until <= 60:
+        return _SEVERITY_WARNING
+    return _SEVERITY_INFO
+
+
+@dataclass(frozen=True)
+class GuaranteeMilestone:
+    """One alert milestone of the Day-90 guarantee gate."""
+
+    day_after_anchor: int  # e.g. 30
+    at: date  # absolute calendar date the alert fires
+    days_until_deadline: int  # days remaining on that date (e.g. 60)
+
+
+def compute_guarantee_deadline(anchor: date) -> date:
+    """Deadline = anchor (entry/ITAS date) + GUARANTEE_PROOF_WINDOW_DAYS."""
+    return anchor + timedelta(days=GUARANTEE_PROOF_WINDOW_DAYS)
+
+
+def guarantee_alert_schedule(
+    anchor: date,
+    *,
+    alert_days: tuple[int, ...] = GUARANTEE_ALERT_DAYS_AFTER,
+) -> list[GuaranteeMilestone]:
+    """Compute the Day 30/60/75 alert schedule for the guarantee gate."""
+    return [
+        GuaranteeMilestone(
+            day_after_anchor=d,
+            at=anchor + timedelta(days=d),
+            days_until_deadline=GUARANTEE_PROOF_WINDOW_DAYS - d,
+        )
+        for d in alert_days
+    ]
+
+
+def next_itas_anniversary(itas_date: date, *, today: date) -> date:
+    """Next yearly ITAS anniversary on or after ``today`` (Feb-29 safe)."""
+
+    def _shift(years: int) -> date:
+        try:
+            return itas_date.replace(year=itas_date.year + years)
+        except ValueError:  # Feb 29 → Feb 28 in non-leap years
+            return itas_date.replace(year=itas_date.year + years, day=28)
+
+    years = max(1, today.year - itas_date.year)
+    anniv = _shift(years)
+    while anniv < today:
+        years += 1
+        anniv = _shift(years)
+    return anniv
+
+
+# ── Case ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StageTransition:
+    """One recorded stage change (append-only history entry)."""
+
+    from_stage: E33Stage | None  # None for the initial stage
+    to_stage: E33Stage
+    at: datetime
+    actor: str | None = None
+    note: str | None = None
+
+
+@dataclass
+class E33Case:
+    """An E33 Second Home client case.
+
+    Links to the CRM by ids only (PII-minimal per UU PDP): ``client_id`` is
+    the CRM client, ``practice_id`` the coarse CRM practice whose status
+    still follows ``practice_state_machine``. ``owner`` is the assigned team
+    member (same ``assigned_to`` semantics as practices).
+    """
+
+    case_id: str
+    client_id: int
+    basis: GuaranteeBasis
+    stage: E33Stage = E33Stage.FIT_MEMO
+    practice_id: int | None = None
+    owner: str | None = None
+    entry_date: date | None = None
+    itas_date: date | None = None
+    dependent_code: str | None = None  # set when THIS case is a dependent
+    principal_case_id: str | None = None  # set when THIS case is a dependent
+    dependents: list[DependentLink] = field(default_factory=list)
+    evidence: list[EvidenceRef] = field(default_factory=list)
+    history: list[StageTransition] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+    # ── Stage machine ────────────────────────────────────────────────────
+
+    def advance(
+        self,
+        to_stage: E33Stage,
+        *,
+        at: datetime,
+        actor: str | None = None,
+        note: str | None = None,
+        occurred_on: date | None = None,
+        itap_eval_enabled: bool = E33_ITAP_EVAL_ENABLED,
+    ) -> StageTransition:
+        """Move the case to a new stage, recording history and key dates.
+
+        ``occurred_on`` pins the legal date of ENTRY / ITAS_ACTIVE events
+        (defaults to ``at.date()``) — it anchors the Day-90 computation.
+        """
+        validate_transition(self.stage, to_stage, itap_eval_enabled=itap_eval_enabled)
+        transition = StageTransition(
+            from_stage=self.stage, to_stage=to_stage, at=at, actor=actor, note=note
+        )
+        self.history.append(transition)
+        self.stage = to_stage
+        if to_stage == E33Stage.ENTRY:
+            self.entry_date = occurred_on or at.date()
+        elif to_stage == E33Stage.ITAS_ACTIVE:
+            self.itas_date = occurred_on or at.date()
+        logger.info("E33 case %s: %s → %s", self.case_id, transition.from_stage, to_stage.value)
+        return transition
+
+    # ── Evidence ─────────────────────────────────────────────────────────
+
+    def add_evidence(self, evidence: EvidenceRef) -> None:
+        """Attach an evidence reference (no-custody validated at build)."""
+        self.evidence.append(evidence)
+        logger.info(
+            "E33 case %s: evidence %s (%s) attached",
+            self.case_id,
+            evidence.evidence_id,
+            evidence.kind.value,
+        )
+
+    @property
+    def guarantee_basis_evidence_complete(self) -> bool:
+        """Basis proof exists: bank confirmation (deposit) or title (property)."""
+        if self.basis == GuaranteeBasis.DEPOSIT:
+            return any(e.kind == EvidenceKind.BANK_CONFIRMATION for e in self.evidence)
+        return any(e.kind == EvidenceKind.PROPERTY_TITLE for e in self.evidence)
+
+    @property
+    def guarantee_proof_filed(self) -> bool:
+        """The guarantee proof has been filed to Immigration."""
+        return any(
+            e.kind == EvidenceKind.IMMIGRATION_FILING and e.filed_date is not None
+            for e in self.evidence
+        )
+
+    @property
+    def guarantee_evidence_complete(self) -> bool:
+        """Basis proof collected AND filed to Immigration."""
+        return self.guarantee_basis_evidence_complete and self.guarantee_proof_filed
+
+    # ── Day-90 gate ──────────────────────────────────────────────────────
+
+    @property
+    def guarantee_anchor(self) -> date | None:
+        """Anchor date for the 90-day gate: ITAS date preferred, entry fallback."""
+        return self.itas_date or self.entry_date
+
+    @property
+    def guarantee_deadline(self) -> date | None:
+        """Day-90 deadline, or None before entry/ITAS."""
+        anchor = self.guarantee_anchor
+        return compute_guarantee_deadline(anchor) if anchor else None
+
+    # ── StayGuard hook ───────────────────────────────────────────────────
+
+    @property
+    def stayguard_eligible(self) -> bool:
+        """StayGuard (annual monitoring retainer) eligibility flag.
+
+        Owner decision: StayGuard launches only after this tracker exists and
+        is offered to E33 clients whose permit is live AND whose Day-90
+        guarantee evidence is complete (ITAS_ACTIVE-or-later with the basis
+        proof filed to Immigration). Pure computation — no pricing, no
+        sending; the commercial offer is a separate follow-up.
+        """
+        return self.stage in ACTIVE_PERMIT_STAGES and self.guarantee_evidence_complete
+
+    # ── Forecasts (AlertsEngine integration) ─────────────────────────────
+
+    def build_case_forecasts(self, *, today: date) -> list[ComplianceForecast]:
+        """Build compliance forecasts for this case as of ``today``.
+
+        Emits at most:
+        - one Day-90 guarantee-proof forecast, once the first alert milestone
+          (Day 30 after anchor) is reached, while the proof is unfiled;
+        - one annual-maintenance forecast when inside the pre-anniversary
+          alert window, once the gate is cleared.
+
+        Returns ``ComplianceForecast`` objects ready for
+        ``AlertsEngine.generate_alerts`` — dedup keys are stable across runs
+        (``compliance_item_ref`` is constant per item), so severity promotion
+        carries the Day 30 → 60 → 75 escalation.
+        """
+        forecasts: list[ComplianceForecast] = []
+        if self.stage in TERMINAL_STAGES:
+            return forecasts
+
+        guarantee_fc = self._build_guarantee_forecast(today=today)
+        if guarantee_fc is not None:
+            forecasts.append(guarantee_fc)
+
+        maintenance_fc = self._build_maintenance_forecast(today=today)
+        if maintenance_fc is not None:
+            forecasts.append(maintenance_fc)
+
+        return forecasts
+
+    def _build_guarantee_forecast(self, *, today: date) -> ComplianceForecast | None:
+        anchor = self.guarantee_anchor
+        if anchor is None or self.guarantee_proof_filed:
+            return None
+        if self.stage not in ACTIVE_PERMIT_STAGES:
+            return None
+        deadline = compute_guarantee_deadline(anchor)
+        first_alert_day = min(GUARANTEE_ALERT_DAYS_AFTER)
+        days_until = (deadline - today).days
+        if (today - anchor).days < first_alert_day and days_until >= 0:
+            return None  # before the Day-30 milestone — nothing to alert yet
+
+        urgency = severity_for_days_until(days_until)
+        priority = calculate_priority(
+            days_until_action=days_until,
+            estimated_revenue_idr=None,
+            complexity=2.0,
+        )
+        if self.basis == GuaranteeBasis.DEPOSIT:
+            required_docs = [
+                "bank_confirmation_letter_bumn",
+                "immigration_filing_receipt",
+            ]
+        else:
+            required_docs = [
+                "property_title_proof",
+                "immigration_filing_receipt",
+            ]
+        return ComplianceForecast(
+            client_id=self.client_id,
+            client_name="",  # PII-minimal: name resolved downstream from CRM
+            assigned_to=self.owner,
+            document_type=DOCTYPE_GUARANTEE,
+            current_visa_type="E33",
+            expiry_date=deadline,
+            days_until_expiry=days_until,
+            matched_rule_id=RULE_ID_GUARANTEE_PROOF,
+            processing_days=0,
+            lead_time_start=anchor,
+            recommended_action_by=anchor + timedelta(days=min(GUARANTEE_ALERT_DAYS_AFTER)),
+            days_until_action=days_until,
+            estimated_revenue_idr=None,
+            renewal_pricing_key=None,
+            priority_score=priority.score,
+            urgency_level=urgency,
+            required_docs=required_docs,
+            has_active_renewal_practice=False,
+            notes=(
+                "E33 Day-90 gate: guarantee proof must be evidenced to "
+                "Immigration within 90 days of entry/ITAS and maintained for "
+                "the permit validity."
+            ),
+        )
+
+    def _build_maintenance_forecast(self, *, today: date) -> ComplianceForecast | None:
+        if self.stage != E33Stage.ANNUAL_MAINTENANCE or self.itas_date is None:
+            return None
+        anniversary = next_itas_anniversary(self.itas_date, today=today)
+        days_until = (anniversary - today).days
+        if days_until > ANNUAL_MAINTENANCE_ALERT_DAYS_BEFORE:
+            return None
+
+        urgency = severity_for_days_until(days_until)
+        priority = calculate_priority(
+            days_until_action=days_until,
+            estimated_revenue_idr=None,
+            complexity=1.5,
+        )
+        return ComplianceForecast(
+            client_id=self.client_id,
+            client_name="",
+            assigned_to=self.owner,
+            document_type=DOCTYPE_MAINTENANCE,
+            current_visa_type="E33",
+            expiry_date=anniversary,
+            days_until_expiry=days_until,
+            matched_rule_id=RULE_ID_ANNUAL_MAINTENANCE,
+            processing_days=0,
+            lead_time_start=anniversary - timedelta(days=ANNUAL_MAINTENANCE_ALERT_DAYS_BEFORE),
+            recommended_action_by=anniversary
+            - timedelta(days=ANNUAL_MAINTENANCE_ALERT_DAYS_BEFORE),
+            days_until_action=days_until,
+            estimated_revenue_idr=None,
+            renewal_pricing_key=None,
+            priority_score=priority.score,
+            urgency_level=urgency,
+            required_docs=[
+                "fresh_bank_confirmation_or_property_title",
+                "current_itas_card",
+            ],
+            has_active_renewal_practice=False,
+            notes=(
+                "E33 annual maintenance: re-confirm the qualifying guarantee "
+                "(deposit/property) is still maintained at the ITAS anniversary."
+            ),
+        )
+
+
+__all__ = [
+    "ACTIVE_PERMIT_STAGES",
+    "ANNUAL_MAINTENANCE_ALERT_DAYS_BEFORE",
+    "DEFAULT_DEPENDENT_CODES",
+    "DOCTYPE_GUARANTEE",
+    "DOCTYPE_MAINTENANCE",
+    "E33_ITAP_EVAL_ENABLED",
+    "FORBIDDEN_METADATA_KEYS",
+    "GUARANTEE_ALERT_DAYS_AFTER",
+    "GUARANTEE_PROOF_WINDOW_DAYS",
+    "RULE_ID_ANNUAL_MAINTENANCE",
+    "RULE_ID_GUARANTEE_PROOF",
+    "TERMINAL_STAGES",
+    "VALID_TRANSITIONS",
+    "CustodyViolationError",
+    "DependentLink",
+    "E33Case",
+    "E33InvalidTransitionError",
+    "E33Stage",
+    "EvidenceKind",
+    "EvidenceRef",
+    "GuaranteeBasis",
+    "GuaranteeMilestone",
+    "StageTransition",
+    "UnknownDependentCodeError",
+    "compute_guarantee_deadline",
+    "guarantee_alert_schedule",
+    "next_itas_anniversary",
+    "severity_for_days_until",
+    "validate_dependent_code",
+    "validate_evidence_metadata",
+    "validate_transition",
+]

--- a/apps/backend-rag/backend/services/crm/e33_lifecycle.py
+++ b/apps/backend-rag/backend/services/crm/e33_lifecycle.py
@@ -260,10 +260,13 @@ def validate_evidence_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
 
     Bali Zero never holds or observes client funds: account numbers,
     balances and amounts are forbidden in case evidence. Only document
-    references, dates and confirmations may be stored.
+    references, dates and confirmations may be stored. Matching is
+    substring-based on the normalized key so compound keys such as
+    ``account_balance`` or ``deposit_amount`` are caught too.
     """
     for key in metadata:
-        if _normalize_key(str(key)) in FORBIDDEN_METADATA_KEYS:
+        norm_key = _normalize_key(str(key))
+        if any(forbidden in norm_key for forbidden in FORBIDDEN_METADATA_KEYS):
             raise CustodyViolationError(
                 f"Evidence metadata key {key!r} breaches the no-custody SOP: "
                 "store document references and dates only, never account "

--- a/apps/backend-rag/backend/services/crm/e33_lifecycle.py
+++ b/apps/backend-rag/backend/services/crm/e33_lifecycle.py
@@ -26,6 +26,13 @@ It must never store account numbers, balances, amounts, IBANs or any other
 financial-instrument detail — ``EvidenceRef`` has no such fields by design
 and its free-form ``metadata`` dict is rejected by
 :func:`validate_evidence_metadata` if custody-flavoured keys appear.
+
+Validated boundary (explicit scope decision): the no-custody guard validates
+evidence metadata KEYS only. ``document_ref``, ``note`` and metadata VALUES
+are free-text by design and are NOT content-scanned — keeping custody data
+out of those free-text fields is a CRM/UI-layer responsibility (input forms
+must not offer amount/account fields). A unit test pins this boundary so it
+is read as a documented decision, not a gap.
 PII is kept minimal per UU PDP: a case links to the CRM client by id only;
 names/passports stay in the CRM client record.
 
@@ -263,6 +270,11 @@ def validate_evidence_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     references, dates and confirmations may be stored. Matching is
     substring-based on the normalized key so compound keys such as
     ``account_balance`` or ``deposit_amount`` are caught too.
+
+    Scope: metadata KEYS only. Values, ``document_ref`` and ``note`` are
+    free-text and NOT scanned (see module docstring — validated boundary);
+    keeping custody data out of free-text fields is a CRM/UI-layer
+    responsibility.
     """
     for key in metadata:
         norm_key = _normalize_key(str(key))

--- a/apps/backend-rag/backend/tests/services/crm/test_e33_lifecycle.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_e33_lifecycle.py
@@ -307,6 +307,21 @@ class TestNoCustody:
                 metadata={bad_key: "anything"},
             )
 
+    @pytest.mark.parametrize(
+        "bad_key",
+        ["account_balance", "deposit_amount", "bank_account", "total_saldo", "swift_code"],
+    )
+    def test_compound_custody_keys_rejected(self, bad_key: str):
+        """Gemini F3-review blocker: exact-match normalization let compound
+        keys bypass the no-custody SOP; substring matching must catch them."""
+        with pytest.raises(CustodyViolationError):
+            EvidenceRef(
+                evidence_id="ev_x",
+                kind=EvidenceKind.BANK_CONFIRMATION,
+                document_ref="drive:file1",
+                metadata={bad_key: "anything"},
+            )
+
     def test_reference_metadata_accepted(self):
         ev = EvidenceRef(
             evidence_id="ev_ok",

--- a/apps/backend-rag/backend/tests/services/crm/test_e33_lifecycle.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_e33_lifecycle.py
@@ -8,16 +8,21 @@ are deterministic.
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.services.compliance.alerts_engine import _DOCTYPE_TO_CATEGORY
+from backend.services.compliance.alerts_engine import _DOCTYPE_TO_CATEGORY, AlertsEngine
 from backend.services.compliance.renewal_rules import match_rule
 from backend.services.compliance.templates_i18n import (
     TEMPLATE_REGISTRY,
     render_template,
 )
-from backend.services.crm.e33_case_repository import case_to_row, row_to_case
+from backend.services.crm.e33_case_repository import (
+    E33CaseRepository,
+    case_to_row,
+    row_to_case,
+)
 from backend.services.crm.e33_lifecycle import (
     DEFAULT_DEPENDENT_CODES,
     DOCTYPE_GUARANTEE,
@@ -459,3 +464,131 @@ class TestRepositorySerialization:
         assert restored.evidence[0].kind == EvidenceKind.BANK_CONFIRMATION
         assert restored.dependents[0].code == "E31B"
         assert restored.stayguard_eligible is True
+
+
+# ── No-custody boundary pinning (documented scope decision) ──────────────────
+
+
+class TestNoCustodyBoundary:
+    def test_document_ref_is_not_content_scanned(self):
+        """Pin the documented boundary: the guard validates metadata KEYS only.
+
+        document_ref is free-text and NOT scanned — keeping custody data out
+        of free-text fields is a CRM/UI-layer responsibility (see module
+        docstring). This test exists so the boundary is read as a decision,
+        not mistaken for a gap.
+        """
+        ev = EvidenceRef(
+            evidence_id="ev_boundary",
+            kind=EvidenceKind.BANK_CONFIRMATION,
+            document_ref="free text mentioning account_number and balance",
+        )
+        assert "account_number" in ev.document_ref  # accepted by design
+
+
+# ── AlertsEngine integration (stubbed persistence, no DB) ────────────────────
+
+
+class _StubAlertRepo:
+    """In-memory AlertRepository stand-in (find/insert/promote only)."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, object] = {}
+
+    async def find_active_by_dedup_key(self, dedup_key: str):
+        return self.rows.get(dedup_key)
+
+    async def insert(self, row):
+        self.rows[row.dedup_key] = row
+        return row
+
+    async def promote(self, alert_id: str, *, new_severity: str, new_days_until: int):
+        row = next(r for r in self.rows.values() if r.alert_id == alert_id)
+        row.severity = new_severity
+        row.days_until = new_days_until
+        return row
+
+
+def _engine_with_stub_repo() -> tuple[AlertsEngine, _StubAlertRepo, AsyncMock]:
+    pricing = MagicMock()
+    pricing.get_price = MagicMock(return_value=None)
+    dispatcher = AsyncMock()
+    dispatcher.dispatch = AsyncMock(return_value=True)
+    engine = AlertsEngine(MagicMock(), pricing=pricing, dispatcher=dispatcher)
+    stub = _StubAlertRepo()
+    engine._repo = stub
+    return engine, stub, dispatcher
+
+
+class TestAlertsEngineIntegration:
+    @pytest.mark.asyncio
+    async def test_case_forecast_produces_guarantee_proof_alert(self):
+        case = _case(stage=E33Stage.ITAS_ACTIVE, itas_date=date(2026, 8, 15))
+        forecasts = case.build_case_forecasts(today=date(2026, 9, 14))  # Day 30
+        engine, _stub, dispatcher = _engine_with_stub_repo()
+
+        alerts = await engine.generate_alerts(forecasts)
+
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.category == "guarantee_proof"
+        assert alert.severity == "warning"  # 60 days until deadline
+        assert alert.compliance_item_ref == RULE_ID_GUARANTEE_PROOF
+        assert "60 days" in alert.message_en
+        dispatcher.dispatch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dedup_and_severity_promotion_across_milestones(self):
+        case = _case(stage=E33Stage.ITAS_ACTIVE, itas_date=date(2026, 8, 15))
+        engine, _stub, dispatcher = _engine_with_stub_repo()
+
+        day30 = await engine.generate_alerts(case.build_case_forecasts(today=date(2026, 9, 14)))
+        dispatcher.reset_mock()
+
+        # Same milestone again → dedup: existing alert, no re-dispatch.
+        again = await engine.generate_alerts(case.build_case_forecasts(today=date(2026, 9, 14)))
+        assert again[0].alert_id == day30[0].alert_id
+        dispatcher.dispatch.assert_not_awaited()
+
+        # Day 60 (30 left, urgent) → severity promotion on the same dedup key.
+        promoted = await engine.generate_alerts(case.build_case_forecasts(today=date(2026, 10, 14)))
+        assert promoted[0].alert_id == day30[0].alert_id
+        assert promoted[0].severity == "urgent"
+        dispatcher.dispatch.assert_awaited_once()
+
+
+# ── Repository through with_connection (stubbed connection, no DB) ────────────
+
+
+class TestRepositoryWithConnection:
+    @pytest.mark.asyncio
+    async def test_insert_binds_case_columns(self):
+        conn = AsyncMock()
+        repo = E33CaseRepository.with_connection(conn)
+        case = _walk_to_annual_maintenance(_case())
+
+        await repo.insert(case)
+
+        conn.execute.assert_awaited_once()
+        bind_args = conn.execute.await_args.args
+        assert bind_args[1] == case.case_id  # first bind param after the SQL
+        assert bind_args[2] == case.client_id
+        assert bind_args[4] == case.basis.value
+
+    @pytest.mark.asyncio
+    async def test_load_round_trip_via_stubbed_connection(self):
+        conn = AsyncMock()
+        repo = E33CaseRepository.with_connection(conn)
+        case = _walk_to_annual_maintenance(_case())
+        for ev in _filed_guarantee_evidence():
+            case.add_evidence(ev)
+        conn.fetchrow = AsyncMock(return_value=case_to_row(case))
+
+        loaded = await repo.load(case.case_id)
+
+        assert loaded is not None
+        assert loaded.case_id == case.case_id
+        assert loaded.stage == case.stage
+        assert loaded.guarantee_deadline == case.guarantee_deadline
+        assert loaded.stayguard_eligible is True
+        assert len(loaded.evidence) == 2

--- a/apps/backend-rag/backend/tests/services/crm/test_e33_lifecycle.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_e33_lifecycle.py
@@ -1,0 +1,446 @@
+"""Unit tests for the E33 Second Home case lifecycle model.
+
+Fixed-clock pattern (same style as tests/services/visa_check/test_clock.py):
+all deadline/alert computations take an explicit ``today``/``at`` so tests
+are deterministic.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from backend.services.compliance.alerts_engine import _DOCTYPE_TO_CATEGORY
+from backend.services.compliance.renewal_rules import match_rule
+from backend.services.compliance.templates_i18n import (
+    TEMPLATE_REGISTRY,
+    render_template,
+)
+from backend.services.crm.e33_case_repository import case_to_row, row_to_case
+from backend.services.crm.e33_lifecycle import (
+    DEFAULT_DEPENDENT_CODES,
+    DOCTYPE_GUARANTEE,
+    DOCTYPE_MAINTENANCE,
+    RULE_ID_ANNUAL_MAINTENANCE,
+    RULE_ID_GUARANTEE_PROOF,
+    CustodyViolationError,
+    DependentLink,
+    E33Case,
+    E33InvalidTransitionError,
+    E33Stage,
+    EvidenceKind,
+    EvidenceRef,
+    GuaranteeBasis,
+    UnknownDependentCodeError,
+    compute_guarantee_deadline,
+    guarantee_alert_schedule,
+    next_itas_anniversary,
+    severity_for_days_until,
+    validate_dependent_code,
+    validate_transition,
+)
+
+AT = datetime(2026, 8, 1, 9, 0, tzinfo=timezone.utc)
+
+
+def _case(**kwargs) -> E33Case:
+    defaults = {
+        "case_id": "e33case_test1",
+        "client_id": 42,
+        "basis": GuaranteeBasis.DEPOSIT,
+        "owner": "surya@balizero.com",
+    }
+    defaults.update(kwargs)
+    return E33Case(**defaults)
+
+
+def _walk_to_annual_maintenance(case: E33Case) -> E33Case:
+    """Drive a case through the full happy path."""
+    case.advance(E33Stage.BANK_PRECHECK, at=AT)
+    case.advance(E33Stage.APPLICATION, at=AT)
+    case.advance(E33Stage.PAYMENT, at=AT)
+    case.advance(E33Stage.VISA_ISSUED, at=AT)
+    case.advance(E33Stage.ENTRY, at=AT, occurred_on=date(2026, 8, 10))
+    case.advance(E33Stage.ITAS_ACTIVE, at=AT, occurred_on=date(2026, 8, 15))
+    case.advance(E33Stage.GUARANTEE_PROOF_DUE, at=AT)
+    case.advance(E33Stage.ANNUAL_MAINTENANCE, at=AT)
+    return case
+
+
+def _filed_guarantee_evidence() -> list[EvidenceRef]:
+    return [
+        EvidenceRef(
+            evidence_id="ev_bank_1",
+            kind=EvidenceKind.BANK_CONFIRMATION,
+            document_ref="drive:file123",
+            issued_date=date(2026, 8, 20),
+        ),
+        EvidenceRef(
+            evidence_id="ev_filing_1",
+            kind=EvidenceKind.IMMIGRATION_FILING,
+            document_ref="crm:doc456",
+            filed_date=date(2026, 9, 1),
+            confirmed_by="surya@balizero.com",
+        ),
+    ]
+
+
+# ── State machine ──────────────────────────────────────────────────────────────
+
+
+class TestTransitions:
+    def test_full_happy_path(self):
+        case = _walk_to_annual_maintenance(_case())
+        assert case.stage == E33Stage.ANNUAL_MAINTENANCE
+        assert len(case.history) == 8
+        assert case.history[0].from_stage is None or case.history[0].from_stage == E33Stage.FIT_MEMO
+
+    def test_invalid_jump_raises(self):
+        case = _case()
+        with pytest.raises(E33InvalidTransitionError):
+            case.advance(E33Stage.APPLICATION, at=AT)  # skips bank_precheck
+
+    def test_same_stage_is_noop(self):
+        assert validate_transition(E33Stage.FIT_MEMO, E33Stage.FIT_MEMO) is True
+
+    def test_back_edge_one_step(self):
+        case = _case()
+        case.advance(E33Stage.BANK_PRECHECK, at=AT)
+        case.advance(E33Stage.FIT_MEMO, at=AT)  # allowed correction
+        assert case.stage == E33Stage.FIT_MEMO
+
+    def test_epo_is_terminal(self):
+        case = _case(stage=E33Stage.ITAS_ACTIVE)
+        case.advance(E33Stage.EPO, at=AT)
+        with pytest.raises(E33InvalidTransitionError):
+            case.advance(E33Stage.RENEWAL, at=AT)
+
+    def test_status_change_is_terminal(self):
+        case = _case(stage=E33Stage.GUARANTEE_PROOF_DUE)
+        case.advance(E33Stage.STATUS_CHANGE, at=AT)
+        with pytest.raises(E33InvalidTransitionError):
+            case.advance(E33Stage.ANNUAL_MAINTENANCE, at=AT)
+
+    def test_renewal_reenters_itas_active(self):
+        case = _walk_to_annual_maintenance(_case())
+        case.advance(E33Stage.RENEWAL, at=AT)
+        case.advance(E33Stage.ITAS_ACTIVE, at=AT, occurred_on=date(2031, 8, 20))
+        assert case.stage == E33Stage.ITAS_ACTIVE
+        assert case.itas_date == date(2031, 8, 20)
+
+    def test_itap_eval_gated_by_default(self):
+        case = _walk_to_annual_maintenance(_case())
+        with pytest.raises(E33InvalidTransitionError, match="gated"):
+            case.advance(E33Stage.ITAP_EVAL, at=AT)
+
+    def test_itap_eval_allowed_when_enabled(self):
+        case = _walk_to_annual_maintenance(_case())
+        case.advance(E33Stage.ITAP_EVAL, at=AT, itap_eval_enabled=True)
+        assert case.stage == E33Stage.ITAP_EVAL
+
+    def test_entry_and_itas_dates_recorded(self):
+        case = _case(stage=E33Stage.VISA_ISSUED)
+        case.advance(E33Stage.ENTRY, at=AT, occurred_on=date(2026, 8, 10))
+        case.advance(E33Stage.ITAS_ACTIVE, at=AT, occurred_on=date(2026, 8, 15))
+        assert case.entry_date == date(2026, 8, 10)
+        assert case.itas_date == date(2026, 8, 15)
+        assert case.guarantee_anchor == date(2026, 8, 15)
+
+
+# ── Day-90 guarantee gate ──────────────────────────────────────────────────────
+
+
+class TestGuaranteeGate:
+    def test_deadline_is_anchor_plus_90(self):
+        assert compute_guarantee_deadline(date(2026, 8, 15)) == date(2026, 11, 13)
+
+    def test_anchor_prefers_itas_over_entry(self):
+        case = _case(
+            stage=E33Stage.ITAS_ACTIVE,
+            entry_date=date(2026, 8, 10),
+            itas_date=date(2026, 8, 15),
+        )
+        assert case.guarantee_anchor == date(2026, 8, 15)
+        entry_only = _case(stage=E33Stage.ENTRY, entry_date=date(2026, 8, 10))
+        assert entry_only.guarantee_anchor == date(2026, 8, 10)
+
+    def test_alert_schedule_day_30_60_75(self):
+        schedule = guarantee_alert_schedule(date(2026, 8, 15))
+        assert [(m.day_after_anchor, m.days_until_deadline) for m in schedule] == [
+            (30, 60),
+            (60, 30),
+            (75, 15),
+        ]
+        assert schedule[0].at == date(2026, 9, 14)
+        assert schedule[2].at == date(2026, 10, 29)
+
+    def test_severity_boundaries(self):
+        assert severity_for_days_until(61) == "info"
+        assert severity_for_days_until(60) == "warning"
+        assert severity_for_days_until(31) == "warning"
+        assert severity_for_days_until(30) == "urgent"
+        assert severity_for_days_until(8) == "urgent"
+        assert severity_for_days_until(7) == "critical"
+        assert severity_for_days_until(-1) == "critical"
+
+    def _active_case(self) -> E33Case:
+        return _case(
+            stage=E33Stage.ITAS_ACTIVE,
+            entry_date=date(2026, 8, 10),
+            itas_date=date(2026, 8, 15),
+        )
+
+    def test_no_forecast_before_day_30(self):
+        case = self._active_case()
+        # Day 29 after anchor — first milestone not reached yet.
+        assert case.build_case_forecasts(today=date(2026, 9, 13)) == []
+
+    def test_forecast_at_day_30(self):
+        case = self._active_case()
+        forecasts = case.build_case_forecasts(today=date(2026, 9, 14))
+        assert len(forecasts) == 1
+        fc = forecasts[0]
+        assert fc.matched_rule_id == RULE_ID_GUARANTEE_PROOF
+        assert fc.document_type == DOCTYPE_GUARANTEE
+        assert fc.days_until_expiry == 60
+        assert fc.urgency_level == "warning"
+        assert fc.expiry_date == date(2026, 11, 13)
+        assert fc.client_id == 42
+
+    def test_forecast_escalates_day_60_and_75(self):
+        case = self._active_case()
+        fc60 = case.build_case_forecasts(today=date(2026, 10, 14))[0]
+        assert fc60.days_until_expiry == 30
+        assert fc60.urgency_level == "urgent"
+        fc75 = case.build_case_forecasts(today=date(2026, 10, 29))[0]
+        assert fc75.days_until_expiry == 15
+        assert fc75.urgency_level == "urgent"
+
+    def test_overdue_forecast_is_critical(self):
+        case = self._active_case()
+        fc = case.build_case_forecasts(today=date(2026, 11, 20))[0]
+        assert fc.days_until_expiry < 0
+        assert fc.urgency_level == "critical"
+
+    def test_no_forecast_once_proof_filed(self):
+        case = self._active_case()
+        for ev in _filed_guarantee_evidence():
+            case.add_evidence(ev)
+        assert case.build_case_forecasts(today=date(2026, 10, 14)) == []
+
+    def test_no_forecast_for_terminal_stage(self):
+        case = _case(
+            stage=E33Stage.EPO,
+            entry_date=date(2026, 8, 10),
+            itas_date=date(2026, 8, 15),
+        )
+        assert case.build_case_forecasts(today=date(2026, 10, 14)) == []
+
+    def test_property_basis_required_docs(self):
+        case = _case(
+            basis=GuaranteeBasis.PROPERTY,
+            stage=E33Stage.ITAS_ACTIVE,
+            itas_date=date(2026, 8, 15),
+        )
+        fc = case.build_case_forecasts(today=date(2026, 9, 14))[0]
+        assert "property_title_proof" in fc.required_docs
+
+
+# ── Annual maintenance ─────────────────────────────────────────────────────────
+
+
+class TestAnnualMaintenance:
+    def test_next_anniversary_same_day(self):
+        assert next_itas_anniversary(date(2026, 8, 15), today=date(2027, 8, 15)) == date(
+            2027, 8, 15
+        )
+
+    def test_next_anniversary_rolls_to_next_year(self):
+        assert next_itas_anniversary(date(2026, 8, 15), today=date(2027, 9, 1)) == date(2028, 8, 15)
+
+    def test_next_anniversary_feb29_safe(self):
+        assert next_itas_anniversary(date(2028, 2, 29), today=date(2029, 1, 1)) == date(2029, 2, 28)
+
+    def _maintained_case(self) -> E33Case:
+        # Gate cleared = proof filed (the transition precondition in practice).
+        case = _walk_to_annual_maintenance(_case())
+        for ev in _filed_guarantee_evidence():
+            case.add_evidence(ev)
+        case.itas_date = date(2026, 8, 15)
+        return case
+
+    def test_maintenance_forecast_inside_window(self):
+        case = self._maintained_case()
+        forecasts = case.build_case_forecasts(today=date(2027, 7, 15))
+        assert len(forecasts) == 1
+        fc = forecasts[0]
+        assert fc.matched_rule_id == RULE_ID_ANNUAL_MAINTENANCE
+        assert fc.document_type == DOCTYPE_MAINTENANCE
+        assert fc.days_until_expiry == 31
+        assert fc.urgency_level == "warning"
+
+    def test_maintenance_no_forecast_outside_window(self):
+        case = self._maintained_case()
+        assert case.build_case_forecasts(today=date(2027, 5, 1)) == []
+
+    def test_maintenance_not_emitted_before_gate_cleared(self):
+        case = _case(stage=E33Stage.GUARANTEE_PROOF_DUE, itas_date=date(2026, 8, 15))
+        forecasts = case.build_case_forecasts(today=date(2027, 7, 15))
+        assert all(fc.matched_rule_id != RULE_ID_ANNUAL_MAINTENANCE for fc in forecasts)
+
+
+# ── No-custody + PII guardrails ────────────────────────────────────────────────
+
+
+class TestNoCustody:
+    @pytest.mark.parametrize(
+        "bad_key",
+        ["balance", "account_number", "Amount", "nomor_rekening", "saldo", "iban"],
+    )
+    def test_custody_keys_rejected(self, bad_key: str):
+        with pytest.raises(CustodyViolationError):
+            EvidenceRef(
+                evidence_id="ev_x",
+                kind=EvidenceKind.BANK_CONFIRMATION,
+                document_ref="drive:file1",
+                metadata={bad_key: "anything"},
+            )
+
+    def test_reference_metadata_accepted(self):
+        ev = EvidenceRef(
+            evidence_id="ev_ok",
+            kind=EvidenceKind.BANK_CONFIRMATION,
+            document_ref="drive:file1",
+            metadata={"bank_name": "Bank Mandiri", "letter_date": "2026-08-20"},
+        )
+        assert ev.metadata["bank_name"] == "Bank Mandiri"
+
+    def test_evidence_complete_requires_basis_and_filing(self):
+        case = _case(stage=E33Stage.ITAS_ACTIVE, itas_date=date(2026, 8, 15))
+        case.add_evidence(_filed_guarantee_evidence()[0])  # bank confirmation only
+        assert case.guarantee_basis_evidence_complete is True
+        assert case.guarantee_evidence_complete is False
+        case.add_evidence(_filed_guarantee_evidence()[1])  # filing
+        assert case.guarantee_evidence_complete is True
+
+    def test_property_basis_needs_title_not_bank_letter(self):
+        case = _case(basis=GuaranteeBasis.PROPERTY)
+        case.add_evidence(_filed_guarantee_evidence()[0])
+        assert case.guarantee_basis_evidence_complete is False
+        case.add_evidence(
+            EvidenceRef(
+                evidence_id="ev_title",
+                kind=EvidenceKind.PROPERTY_TITLE,
+                document_ref="drive:file999",
+                issued_date=date(2026, 8, 20),
+            )
+        )
+        assert case.guarantee_basis_evidence_complete is True
+
+
+# ── StayGuard hook ─────────────────────────────────────────────────────────────
+
+
+class TestStayGuard:
+    def test_not_eligible_before_itas(self):
+        assert _case().stayguard_eligible is False
+
+    def test_not_eligible_without_complete_evidence(self):
+        case = _case(stage=E33Stage.ITAS_ACTIVE, itas_date=date(2026, 8, 15))
+        assert case.stayguard_eligible is False
+
+    def test_eligible_with_evidence_complete(self):
+        case = _case(stage=E33Stage.ITAS_ACTIVE, itas_date=date(2026, 8, 15))
+        for ev in _filed_guarantee_evidence():
+            case.add_evidence(ev)
+        assert case.stayguard_eligible is True
+
+    def test_not_eligible_when_terminal(self):
+        case = _case(stage=E33Stage.EPO, itas_date=date(2026, 8, 15))
+        for ev in _filed_guarantee_evidence():
+            case.add_evidence(ev)
+        assert case.stayguard_eligible is False
+
+
+# ── Dependents (configurable codes) ────────────────────────────────────────────
+
+
+class TestDependents:
+    def test_default_codes_accepted(self):
+        for code in DEFAULT_DEPENDENT_CODES:
+            assert validate_dependent_code(code) == code
+
+    def test_unknown_code_rejected(self):
+        with pytest.raises(UnknownDependentCodeError):
+            validate_dependent_code("E31Z")
+
+    def test_codes_configurable(self):
+        assert validate_dependent_code("E31Z", allowed=("E31Z",)) == "E31Z"
+
+    def test_dependent_link_on_case(self):
+        case = _case()
+        link = DependentLink(code="E31B", client_id=77, relationship="spouse")
+        case.dependents.append(link)
+        assert case.dependents[0].code == "E31B"
+
+
+# ── Alerts-engine wiring ───────────────────────────────────────────────────────
+
+
+class TestAlertsWiring:
+    def test_doctypes_map_to_registered_category(self):
+        for doctype in (DOCTYPE_GUARANTEE, DOCTYPE_MAINTENANCE):
+            category = _DOCTYPE_TO_CATEGORY[doctype]
+            assert category in TEMPLATE_REGISTRY
+
+    def test_guarantee_template_renders_with_forecast_kwargs(self):
+        body = render_template(
+            "guarantee_proof", "body", "en", days_until=60, doc_type="e33_guarantee"
+        )
+        assert "60 days" in body
+
+    def test_forecast_shapes_compatible_with_engine(self):
+        case = _case(stage=E33Stage.ITAS_ACTIVE, itas_date=date(2026, 8, 15))
+        fc = case.build_case_forecasts(today=date(2026, 9, 14))[0]
+        # AlertsEngine reads these verbatim.
+        assert fc.urgency_level in {"info", "warning", "urgent", "critical"}
+        assert fc.matched_rule_id  # becomes compliance_item_ref (dedup key)
+        assert fc.renewal_pricing_key is None  # no pricing — evidence deadline
+
+    def test_renewal_rule_matches_e33(self):
+        rule = match_rule("kitas", "E33 Second Home")
+        assert rule.rule_id == "e33_second_home_renewal"
+
+    def test_renewal_rule_does_not_steal_e33g(self):
+        # E33G remote worker has its own rule earlier in priority order.
+        rule = match_rule("kitas", "E33G Remote Worker")
+        assert rule.rule_id == "kitas_remote_worker_extend"
+
+
+# ── Repository (de)serialization round-trip ────────────────────────────────────
+
+
+class TestRepositorySerialization:
+    def test_case_row_round_trip(self):
+        case = _walk_to_annual_maintenance(_case(practice_id=123))
+        for ev in _filed_guarantee_evidence():
+            case.add_evidence(ev)
+        case.dependents.append(DependentLink(code="E31B", client_id=77, relationship="spouse"))
+
+        row = case_to_row(case)
+        assert row["guarantee_proof_deadline"] == date(2026, 11, 13)
+        assert row["stayguard_eligible"] is True
+        assert row["stage"] == "annual_maintenance"
+
+        restored = row_to_case(row)
+        assert restored.case_id == case.case_id
+        assert restored.stage == case.stage
+        assert restored.basis == case.basis
+        assert restored.entry_date == case.entry_date
+        assert restored.itas_date == case.itas_date
+        assert len(restored.history) == len(case.history)
+        assert len(restored.evidence) == 2
+        assert restored.evidence[0].kind == EvidenceKind.BANK_CONFIRMATION
+        assert restored.dependents[0].code == "E31B"
+        assert restored.stayguard_eligible is True

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`329 routers · 660 services · 1237 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`329 routers · 662 services · 1238 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`329 routers · 662 services · 1238 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`329 routers · 663 services · 1238 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Fase 3.2 — E33 case lifecycle + Day-90 guarantee tracker

Modello del ciclo di vita del caso E33 nel CRM, costruito **sul machinery esistente** (nessun framework parallelo).

### Riutilizzo
- Pattern state-machine di `practice_state_machine.py`
- `AlertsEngine` + dedup + severity promotion + i18n per le scadenze (Day-90 e mantenimento annuale emessi come forecast)
- `renewal_rules.py` per i rinnovi E33 (senza rubare precedenza a E33G — testato)
- `templates_i18n.py` per la nuova categoria `guarantee_proof` (it/en/id)

### Costruito
- `services/crm/e33_lifecycle.py` — 13 stadi (FIT_MEMO → … → ITAS_ACTIVE → GUARANTEE_PROOF_DUE → ANNUAL_MAINTENANCE → RENEWAL/EPO/STATUS_CHANGE; ITAP_EVAL modellato ma **hard-gated** `E33_ITAP_EVAL_ENABLED=False` fino a risposta lettera 006 Q7)
- Day-90: deadline da data ITAS, alert Day 30/60/75 con escalation severity nativa
- **No-custody enforced in codice**: `validate_evidence_metadata` rifiuta chiavi account/balance/saldo/norek (`CustodyViolationError`); migrazione 259 senza colonne finanziarie, con `-- === ROLLBACK ===` (NON applicata)
- Dependent come `DependentLink` con codici default E31B/E31E/E31H/E31J marcati pending-confirmation, overridable
- `stayguard_eligible` calcolato (ITAS attivo + evidence basis depositata) — nessun prezzo, nessun invio
- Repository asyncpg con round-trip JSONB

### Test
50 nuovi (transizioni, Day-90, no-custody matrix, StayGuard, repo) + suite visa_check/compliance/CRM verdi (gli unici errori sono i noti asyncpg-env su Air-M5).

### Follow-up documentati (non costruiti)
Cron scanner → `AlertsEngine`, applicazione migrazione 259 su Pro, surfacing portal, notifiche WhatsApp (Legge 5), flusso commerciale StayGuard, abilitazione ITAP_EVAL post-risposta.

🤖 Kimi (Air-M5) — review seat in allegato.
