### PR TITLE
feat(kbli): surface additive BPS 2020↔2025 crosswalk ancestors on /kbli pages (Batch-B step 4)

### DIFF
--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -934,6 +934,66 @@ export default async function KBLICodePage({
                 </div>
               )}
 
+              {/* Official BPS 2020↔2025 crosswalk ancestors (gate-verified provenance —
+                  additive, DISTINCT from the pp28-sourced "Previous codes" above; the
+                  legacy list stays untouched. Batch-B step 4, 2026-07-25). Shown only for
+                  the OSS-native codes that carry the field. */}
+              {kbli.transition.bpsCrosswalk &&
+                kbli.transition.bpsCrosswalk.codes.length > 0 && (
+                  <div
+                    className="mt-3 flex items-start gap-3 rounded-xl p-4"
+                    style={{
+                      background: "var(--kbli-bg-elevated)",
+                      border: "1px solid var(--kbli-border)",
+                    }}
+                  >
+                    <span
+                      className="mt-0.5 shrink-0 inline-flex items-center rounded-full px-2.5 py-1 text-xs font-bold"
+                      style={{
+                        background: "rgba(139, 156, 247, 0.1)",
+                        color: "var(--kbli-accent2)",
+                        border: "1px solid rgba(139, 156, 247, 0.2)",
+                      }}
+                    >
+                      BPS crosswalk
+                    </span>
+                    <div className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
+                      <span>
+                        Official BPS 2020 → 2025 crosswalk ancestors:{" "}
+                      </span>
+                      {kbli.transition.bpsCrosswalk.codes.map((c, i) => (
+                        // key includes the index: the data has zero duplicate
+                        // ancestor codes today, but this stays unique if a future
+                        // crosswalk re-run ever repeats one.
+                        <span key={`${c}-${i}`}>
+                          {/* Rendered as PLAIN TEXT — never a link. These are
+                              KBLI-2020 identifiers, but /kbli/<c> is a 2025 page.
+                              317 of these ancestor codes coincide with an
+                              UNRELATED 2025 code, so a link would land the client
+                              on a different-vintage activity (KBLI2020:X ≠
+                              KBLI2025:X = client harm); the remainder are just
+                              self-links. Linking is never useful and sometimes
+                              harmful, so we never link a crosswalk ancestor. */}
+                          <span className="font-mono font-bold text-[var(--foreground-secondary)]">
+                            {c}
+                          </span>
+                          {i <
+                            (kbli.transition.bpsCrosswalk?.codes.length ?? 0) -
+                              1 && ", "}
+                        </span>
+                      ))}
+                      <p className="mt-2 text-[11px] text-[var(--foreground-muted)]">
+                        Source: the BPS 2020↔2025 conversion table, mechanically
+                        extracted and acceptance-gate verified. It shows which
+                        2020 codes map to this 2025 code —{" "}
+                        <strong>provenance only, not a licensing claim</strong>:
+                        the regulatory regime of these predecessor codes has not
+                        been adjudicated as transferring.
+                      </p>
+                    </div>
+                  </div>
+                )}
+
               {/* Article card for non-Gold pages */}
               {article && (
                 <a

--- a/apps/mouth/src/lib/kbli-data.server.ts
+++ b/apps/mouth/src/lib/kbli-data.server.ts
@@ -300,6 +300,15 @@ function transformCode(
       previousCodes: raw.pp28_sources || [],
       mappingNote: raw.mapping_note || undefined,
       aggregationNote: raw.aggregation_note || undefined,
+      bpsCrosswalk: raw.bps_2020_ancestors
+        ? {
+            codes: raw.bps_2020_ancestors.codes || [],
+            adjudicationStatus:
+              raw.bps_2020_ancestors.adjudication_status || "mechanical-only",
+            inheritanceVerdict:
+              raw.bps_2020_ancestors.inheritance_verdict || "not-adjudicated",
+          }
+        : undefined,
     },
     intel,
     // L4 — Bali sovereign-local status (national PMA openness != Bali registrability)

--- a/apps/mouth/src/lib/kbli-data.test.ts
+++ b/apps/mouth/src/lib/kbli-data.test.ts
@@ -102,4 +102,59 @@ describe("kbli-data", () => {
     expect(getHeroStyle("I").gradient).not.toEqual(getHeroStyle("J").gradient);
     expect(getHeroStyle(null)).toEqual(getHeroStyle("unknown"));
   });
+
+  // Batch-B step 4 (2026-07-25): the additive `bps_2020_ancestors` canonical
+  // field surfaces as `transition.bpsCrosswalk`, DISTINCT from the pp28-sourced
+  // `previousCodes`. These are the guilt+innocence + no-regression tripwires.
+  describe("bps_2020_ancestors → transition.bpsCrosswalk (additive, no regression)", () => {
+    it("derives bpsCrosswalk on an OSS-native Batch-B code and shows the honest mechanical-only status", () => {
+      // 01111 is OSS-native (_l2_status is null) and carries the field.
+      const code = getCode("01111");
+      expect(code).toBeDefined();
+      const bps = code?.transition.bpsCrosswalk;
+      expect(bps).toBeDefined();
+      expect(bps?.codes.length).toBeGreaterThan(0);
+      // At this migration step NOTHING is adjudicated — the surface must NOT
+      // imply a licensing/regime transfer. Mechanical presence ≠ inheritance.
+      expect(bps?.adjudicationStatus).toBe("mechanical-only");
+      expect(bps?.inheritanceVerdict).toBe("not-adjudicated");
+      // Regression guard: the legacy pp28-sourced list is UNTOUCHED alongside it.
+      expect(Array.isArray(code?.transition.previousCodes)).toBe(true);
+    });
+
+    it("leaves bpsCrosswalk undefined on a Batch-A (no_oss_risk) code and keeps previousCodes intact", () => {
+      // 01287 is _l2_status: no_oss_risk → out of Batch-B scope, no field.
+      const code = getCode("01287");
+      expect(code).toBeDefined();
+      expect(code?.transition.bpsCrosswalk).toBeUndefined();
+      expect(Array.isArray(code?.transition.previousCodes)).toBe(true);
+    });
+
+    it("carries bpsCrosswalk on exactly the 1,338 OSS-native codes and never with an empty codes list", () => {
+      const codes = getAllCodes();
+      const withBps = codes.filter((c) => c.transition.bpsCrosswalk);
+      // EXPECTED_BATCH_B in scripts/kbli_filiera/populate_bps_ancestors.py — the
+      // frontend surface is content-bound to the same OSS-native count. If a
+      // future cure changes Batch-B membership, this breaking is a feature: it
+      // forces re-verification of the honesty framing on both sides.
+      expect(withBps.length).toBe(1338);
+      // Never render an empty/degenerate crosswalk element.
+      for (const c of withBps) {
+        const bps = c.transition.bpsCrosswalk!;
+        expect(bps.codes.length).toBeGreaterThan(0);
+        expect(typeof bps.adjudicationStatus).toBe("string");
+        expect(typeof bps.inheritanceVerdict).toBe("string");
+      }
+    });
+
+    it("never clobbers previousCodes — every code still exposes it as an array", () => {
+      // The change is purely additive; previousCodes must remain present and an
+      // array on ALL codes (both those that gained bpsCrosswalk and those that
+      // did not), never turned undefined by the new derivation.
+      const codes = getAllCodes();
+      expect(
+        codes.every((c) => Array.isArray(c.transition.previousCodes)),
+      ).toBe(true);
+    });
+  });
 });

--- a/apps/mouth/src/lib/kbli-data.ts
+++ b/apps/mouth/src/lib/kbli-data.ts
@@ -427,6 +427,15 @@ function transformRecord(raw: KBLIRawCode): KBLICode {
     kbli2020Source: raw.kbli_2020_source,
     mappingNote: raw.mapping_note,
     aggregationNote: raw.aggregation_note,
+    bpsCrosswalk: raw.bps_2020_ancestors
+      ? {
+          codes: raw.bps_2020_ancestors.codes ?? [],
+          adjudicationStatus:
+            raw.bps_2020_ancestors.adjudication_status ?? "mechanical-only",
+          inheritanceVerdict:
+            raw.bps_2020_ancestors.inheritance_verdict ?? "not-adjudicated",
+        }
+      : undefined,
   };
 
   return {

--- a/apps/mouth/src/lib/kbli-types.ts
+++ b/apps/mouth/src/lib/kbli-types.ts
@@ -73,6 +73,9 @@ export interface KBLIRawCode {
   sektor_id: string | null;
   status_mapping: KBLIMappingStatus;
   pp28_sources: string[];
+  /** BPS 2020↔2025 official crosswalk ancestry (additive canonical field, Batch-B step 2,
+   *  2026-07-25). Present only on the 1,338 OSS-native codes; absent on Batch-A (no-scope). */
+  bps_2020_ancestors?: KBLIBpsAncestorsRaw;
   pma_status: KBLIPmaRawStatus;
   pma_max_asing: number | "special"; // "special" = open-with-special-conditions (47221-class), no clean %
   pma_kondisi: string | null;
@@ -259,6 +262,16 @@ export interface KBLILicenseByScale {
   fictivePositive: boolean;
 }
 
+/** Raw shape of the additive `bps_2020_ancestors` canonical field (subset we render).
+ *  Mechanical provenance only: `inheritance_verdict` stays `not-adjudicated` until a
+ *  per-code D1/D5 adjudication — an ancestor's presence never implies the licensing
+ *  regime transfers (design §2.2/§4). */
+export interface KBLIBpsAncestorsRaw {
+  codes: string[];
+  adjudication_status: string;
+  inheritance_verdict: string;
+}
+
 /** Transition information from KBLI 2020 to 2025 */
 export interface KBLITransition {
   mappingStatus: KBLIMappingStatus;
@@ -266,6 +279,13 @@ export interface KBLITransition {
   kbli2020Source?: string;
   mappingNote?: string;
   aggregationNote?: string;
+  /** Gate-verified BPS 2020→2025 crosswalk ancestors (provenance-only, additive; distinct
+   *  from the legacy `previousCodes` which is sourced from the unstable `pp28_sources`). */
+  bpsCrosswalk?: {
+    codes: string[];
+    adjudicationStatus: string;
+    inheritanceVerdict: string;
+  };
 }
 
 /** Processed KBLI code — frontend-friendly version */


### PR DESCRIPTION
## What

Surfaces the additive canonical field `bps_2020_ancestors` (populated on the 1,338
OSS-native codes by #3082) as a new, clearly-labeled **"BPS crosswalk"** element on
`balizero.com/kbli/<code>`. This is **Batch-B step 4** of the KBLI Navigator
BKPM-presentable program.

**Additive, zero regression.** The new element is DISTINCT from and leaves
BYTE-UNTOUCHED the existing pp28-sourced "Previous codes (KBLI 2020)" element (diff
is 100% insertions on the render path).

## Honesty framing (client-facing north star)

The element is labeled **provenance ONLY** — it renders the field's `mechanical-only`
/ `not-adjudicated` state and states verbatim: *"not a licensing claim: the regulatory
regime of these predecessor codes has not been adjudicated as transferring."* It never
implies the 2020 codes' licensing transfers to the 2025 code.

## Cross-family adversarial gate caught a real BLOCKER

Generator≠grader (Kimi K3; Codex 401-dead). First draft linked each ancestor code to
`/kbli/<c>`. But ancestor codes are **KBLI-2020 vintage** while `/kbli/<c>` is a **2025**
page. Verified against real data (1,338 hosts):

| class | count | behavior |
|---|---|---|
| identity (A==host) | 813 | self-link (useless) |
| non-identity, A exists as a *different* 2025 code | **317** | **wrong-vintage link → client harm** |
| non-identity, A absent in 2025 | 1,125 | plain text (safe) |

**Fix:** BPS crosswalk ancestors now render as **plain text, never linked**. The whole
harm class is removed; linking a crosswalk ancestor is never useful anyway (`KBLI2020:X ≠
KBLI2025:X`).

## Changes (apps/mouth only — data-plane + backend untouched)

- `kbli-types.ts` — `KBLIBpsAncestorsRaw` + `bps_2020_ancestors?` on `KBLIRawCode` + `bpsCrosswalk?` on `KBLITransition`
- `kbli-data.ts` / `kbli-data.server.ts` — derive `transition.bpsCrosswalk` in both loaders
- `kbli/[code]/page.tsx` — additive render block, plain-text ancestors, honest note
- `kbli-data.test.ts` — 4 regression tests (Batch-B derivation, Batch-A undefined, exact 1,338-count tied to `EXPECTED_BATCH_B`, `previousCodes` never clobbered)

## Verification

- `tsc --noEmit` RC=0 · 11/11 `kbli-data` tests pass
- **Consumer map:** grep-verified single consuming surface (only these 4 files read the field repo-wide; `backend-rag` = 0 readers)
- PROVE-LIVE after Vercel rebuild: curl a Batch-B `/kbli/<code>` and confirm the element renders plain-text ancestors + honest framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
