### PR TITLE
fix(deps): bump brace-expansion override to >=5.0.8 (GHSA-mh99-v99m-4gvg ReDoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1196,19 +1196,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "apps/autonomous-lab/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "apps/autonomous-lab/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -12864,15 +12851,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -23350,6 +23337,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "sharp": "^0.35.3",
     "dompurify": ">=3.4.0",
     "qs": ">=6.15.2",
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.8",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "sharp": ">=0.35.3"
@@ -170,7 +170,7 @@
     "picomatch": ">=4.0.4",
     "effect": ">=3.20.0",
     "handlebars": ">=4.7.9",
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.8",
     "vite": ">=8.0.4",
     "follow-redirects": ">=1.16.0",
     "uuid": ">=14.0.0",


### PR DESCRIPTION
## What

A newly-published high-severity advisory **GHSA-mh99-v99m-4gvg** (ReDoS in `brace-expansion`) flags all versions `<=5.0.7`. The root `package.json` already pinned `brace-expansion: >=5.0.6`, which resolved to the now-vulnerable **5.0.7** — turning the required **Frontend Tests (mouth) / npm audit** gate red on **every PR repo-wide** (the advisory landed after recent PRs' checks last ran; discovered while shipping an unrelated WR2 PR).

## Fix

Bump both the `resolutions` and `overrides` pins to `>=5.0.8` (the patched release). **Remediation, not a waiver** — the 3 advisories on the audit WAIVE-list have no patched version available; this one does, so it gets fixed, not waived.

## Verify

- Exact CI audit gate reproduced at repo root with the fix → **GATE OK** (0 high / 0 critical; 3 moderates below the `--audit-level=high` threshold).
- `npm ci --dry-run --ignore-scripts` on **node 24** (the `npm lock honors manifest` required gate) → **RC=0**.
- Lock regenerated on node 24 (`--package-lock-only`): `brace-expansion` 5.0.7→5.0.8, plus an incidental dedup of a redundant nested `react@18.3.1` in autonomous-lab (already forced to 19.2.6 by the pre-existing react override) and a dev-flag reconciliation on `loose-envify` — node-24-canonical, no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)