### PR TITLE
🎨 Palette: Fix active consulting localization on TeamVerificationBadge

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -87,3 +87,8 @@
 
 **Learning:** Sidebars that are visually animated off-screen using CSS transitions (e.g., `transform: translateX`) remain in the active document flow unless hidden or made inert. This allows screen readers and keyboard users (via the Tab key) to focus hidden elements inside the sidebar, creating a confusing and unexpected keyboard experience. Applying the standard HTML `inert` attribute (natively supported in React 19) when the sidebar is closed ensures all interactive children are completely removed from the tab order.
 **Action:** Always apply `inert={!isOpen ? true : undefined}` (or similar) to sliding or off-screen panels/drawers to keep the keyboard navigation and tab flow clean and expected.
+
+## 2026-07-21 - [Localization Accuracy for Asynchronous States]
+
+**Learning:** Translating asynchronous/in-progress states (e.g., "Our specialists are verifying") using the same translations as finished states (e.g., "Verified by") in secondary locales creates highly misleading and confusing UX. Non-English users would see false indicators of completion.
+**Action:** Ensure that different interaction states (e.g., active versus complete) always map to distinct, accurate localized labels across all supported languages.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -351,7 +351,7 @@ jobs:
           npm audit --audit-level=high --omit=dev --json > "$RUNNER_TEMP/audit.json" || true
           python3 - "$RUNNER_TEMP/audit.json" <<'PY'
           import json, sys
-          WAIVE = {"GHSA-frvp-7c67-39w9", "GHSA-9mqv-5hh9-4cgg", "GHSA-c96f-x56v-gq3h", "GHSA-mh99-v99m-4gvg"}
+          WAIVE = {"GHSA-frvp-7c67-39w9", "GHSA-9mqv-5hh9-4cgg", "GHSA-c96f-x56v-gq3h"}
           data = json.load(open(sys.argv[1]))
           bad = []
           for name, vuln in (data.get("vulnerabilities") or {}).items():

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -351,7 +351,7 @@ jobs:
           npm audit --audit-level=high --omit=dev --json > "$RUNNER_TEMP/audit.json" || true
           python3 - "$RUNNER_TEMP/audit.json" <<'PY'
           import json, sys
-          WAIVE = {"GHSA-frvp-7c67-39w9", "GHSA-9mqv-5hh9-4cgg", "GHSA-c96f-x56v-gq3h"}
+          WAIVE = {"GHSA-frvp-7c67-39w9", "GHSA-9mqv-5hh9-4cgg", "GHSA-c96f-x56v-gq3h", "GHSA-mh99-v99m-4gvg"}
           data = json.load(open(sys.argv[1]))
           bad = []
           for name, vuln in (data.get("vulnerabilities") or {}).items():

--- a/apps/mouth/src/components/chat/TeamVerificationBadge.test.tsx
+++ b/apps/mouth/src/components/chat/TeamVerificationBadge.test.tsx
@@ -25,6 +25,30 @@ describe("TeamVerificationBadge", () => {
     expect(screen.getByText(/Our Legal specialists are verifying/i)).toBeDefined();
   });
 
+  it("renders consulting state in Italian", () => {
+    vi.mocked(useChatLocale).mockReturnValue("it");
+    render(<TeamVerificationBadge status="consulting" domainLabel="Legal" />);
+    expect(screen.getByText(/I nostri specialisti di Legal stanno verificando/i)).toBeDefined();
+  });
+
+  it("renders consulting state in Indonesian", () => {
+    vi.mocked(useChatLocale).mockReturnValue("id");
+    render(<TeamVerificationBadge status="consulting" domainLabel="Imigrasi" />);
+    expect(screen.getByText(/Spesialis Imigrasi kami sedang memverifikasi/i)).toBeDefined();
+  });
+
+  it("renders consulting state in French", () => {
+    vi.mocked(useChatLocale).mockReturnValue("fr");
+    render(<TeamVerificationBadge status="consulting" domainLabel="Legal" />);
+    expect(screen.getByText(/Nos spécialistes de Legal vérifient/i)).toBeDefined();
+  });
+
+  it("renders consulting state in Russian", () => {
+    vi.mocked(useChatLocale).mockReturnValue("ru");
+    render(<TeamVerificationBadge status="consulting" domainLabel="Legal" />);
+    expect(screen.getByText(/Наши специалисты по Legal проверяют/i)).toBeDefined();
+  });
+
   it("renders verified state in Italian", () => {
     vi.mocked(useChatLocale).mockReturnValue("it");
     render(<TeamVerificationBadge status="verified" domainLabel="Legal" />);

--- a/apps/mouth/src/components/chat/TeamVerificationBadge.tsx
+++ b/apps/mouth/src/components/chat/TeamVerificationBadge.tsx
@@ -13,10 +13,10 @@ interface TeamVerificationBadgeProps {
 
 const LABELS: Record<string, (domain: string) => string> = {
   en: (d) => `Our ${d} specialists are verifying`,
-  it: (d) => `Verificato dal team ${d}`,
-  id: (d) => `Diverifikasi oleh tim ${d}`,
-  fr: (d) => `Vérifié par l'équipe ${d}`,
-  ru: (d) => `Подтверждено командой ${d}`,
+  it: (d) => `I nostri specialisti di ${d} stanno verificando`,
+  id: (d) => `Spesialis ${d} kami sedang memverifikasi`,
+  fr: (d) => `Nos spécialistes de ${d} vérifient`,
+  ru: (d) => `Наши специалисты по ${d} проверяют`,
 };
 
 const VERIFIED_LABELS: Record<string, (domain: string) => string> = {


### PR DESCRIPTION
💡 What: Corrected the localized strings for the active "consulting" status under Italian (it), Indonesian (id), French (fr), and Russian (ru) inside the `TeamVerificationBadge` component. Also updated the unit test suite to verify correct mapping and interpolation.

🎯 Why: Previously, non-English users would see false indicators of completion ("Verified by [domain] team") when the status was actively "consulting" ("Our [domain] specialists are verifying"), leading to misleading UX.

♿ Accessibility & Localization: Ensures different asynchronous interaction states correctly translate across all supported languages, preventing confusion.

---
*PR created automatically by Jules for task [6563664360704338329](https://jules.google.com/task/6563664360704338329) started by @Balizero1987*