### PR TITLE
fix(docs): redact live-shaped Google API key from public docs

### DIFF
--- a/docs/superpowers/solidification-prompts/13-cowork-frontend.md
+++ b/docs/superpowers/solidification-prompts/13-cowork-frontend.md
@@ -1,4 +1,5 @@
 # SOLIDIFICATION PROMPT 13 — Frontend (mouth)
+
 # Machine: COWORK | Model: Claude Opus 4.6 MAX | Component: Frontend
 
 ---
@@ -35,13 +36,14 @@ apps/mouth/
   next.config.*                                        # Next.js configuration
   tailwind.config.*                                    # Tailwind configuration
   package.json                                         # Dependencies
-  
+
 packages/core/
   styles/bz-tokens.css                                 # Design tokens (--bz-base, --bz-accent)
   components/BZLogo.tsx                                # Logo component
 ```
 
 Mappa:
+
 1. **Route structure**: quante route, come sono organizzate (public vs auth vs portal)
 2. **Component architecture**: component library, design system, riuso
 3. **State management**: che pattern (Zustand, Context, Redux, niente?)
@@ -58,7 +60,9 @@ Mappa:
 Per il brainstorming su Cowork, usa le risorse disponibili:
 
 ### 2a. Research: Next.js production patterns
+
 Cerca best practice per:
+
 - Next.js 14+ App Router production optimization
 - Multi-subdomain Next.js architecture
 - Design system with Tailwind CSS (tokens, components)
@@ -67,7 +71,9 @@ Cerca best practice per:
 - Cross-domain SSO with httpOnly cookies
 
 ### 2b. Code analysis
+
 Analizza il codice per:
+
 1. Components senza TypeScript types (any, unknown abusati)
 2. API calls senza error handling (no try/catch, no error boundary)
 3. Re-render non necessari (missing memo, useMemo, useCallback)
@@ -76,6 +82,7 @@ Analizza il codice per:
 6. Accessibilita: form senza label, button senza aria-label, contrast ratio
 
 ### 2c. Self-reflection critica
+
 - 1841 file TSX: sono tutti necessari? Dead components?
 - Multi-subdomain: la logica di routing e chiara o spaghetti?
 - Design tokens: sono usati consistentemente o ci sono colori hardcoded?
@@ -87,6 +94,7 @@ Analizza il codice per:
 ## FASE 3 — PIANO DI SOLIDIFICAZIONE
 
 ### A. PULIZIA
+
 - Dead code: componenti non importati, route non raggiungibili
 - Type cleanup: eliminare `any`, aggiungere types mancanti
 - Import cleanup: dipendenze non usate in package.json
@@ -94,6 +102,7 @@ Analizza il codice per:
 - Component consolidation: componenti simili → uno condiviso
 
 ### B. IRROBUSTIMENTO
+
 - Error boundaries: per ogni sezione principale (portal, admin, public)
 - Loading states: skeleton loader consistenti, non spinner random
 - API error handling: retry automatico per errori transient, messaging chiaro per errori permanenti
@@ -102,6 +111,7 @@ Analizza il codice per:
 - Offline handling: basic offline indicator + cache per dati critici
 
 ### C. POTENZIAMENTO
+
 - Performance: Lighthouse score > 90 su tutte le pagine principali
 - Bundle optimization: dynamic import per moduli pesanti, code splitting aggressivo
 - Image optimization: next/image ovunque, responsive sizes, WebP
@@ -110,6 +120,7 @@ Analizza il codice per:
 - Accessibility: WCAG 2.1 AA compliance sulle pagine principali
 
 ### D. AUTOMATISMO EVOLUTIVO
+
 - Lighthouse CI: check automatico su ogni PR (fail se score scende)
 - Bundle size tracking: alert se bundle cresce > 5% su una PR
 - Type coverage: metric tracking (% di file con zero `any`)
@@ -117,6 +128,7 @@ Analizza il codice per:
 - Visual regression: screenshot testing su pagine critiche (portal, KBLI)
 
 ### E. METRICHE
+
 - Lighthouse Performance: > 90
 - LCP: < 2.5s
 - FID/INP: < 100ms
@@ -130,6 +142,7 @@ Analizza il codice per:
 ## FASE 4 — VALIDAZIONE
 
 Scrivi script/test di validazione:
+
 1. Lighthouse audit su pagine principali (kita, portal login, KBLI)
 2. TypeScript strict mode check (trova `any` e type errors)
 3. Unused dependency detection (`depcheck`)
@@ -148,6 +161,6 @@ Scrivi script/test di validazione:
 - Design tokens: `packages/core/styles/bz-tokens.css` (--bz-base: #0c0c0e, --bz-accent: #d4845a)
 - Logo: `packages/core/components/BZLogo.tsx` (balizero-logo-clean.png)
 - KBLI: 1,563 pagine SSG in `/kbli/[code]`
-- Maps: Google Maps API key `AIzaSyCWPZb1_aSV_NVvS9ZSR0Mlq9El8qO8uLQ`
+- Maps: Google Maps API key `<GOOGLE_API_KEY_REDACTED>` — redacted 2026-07-25: a live key must never appear in this public repo; read it from the environment.
 - Portal: cinematic Balinese gate login
 - QA post-deploy: screenshot automatici con claude-in-chrome

--- a/docs/superpowers/specs/2026-04-18-pf3a-prime-perf-ux-design.md
+++ b/docs/superpowers/specs/2026-04-18-pf3a-prime-perf-ux-design.md
@@ -188,7 +188,7 @@ Per `superpowers:verification-before-completion`:
 
 ## 5. Constraints / hard rules
 
-- Maps API key `AIzaSyCWPZb1_aSV_NVvS9ZSR0Mlq9El8qO8uLQ` unchanged (note: char 21 is lowercase `l`, not digit `1` — verified against production `/prime` page load).
+- Maps API key `<GOOGLE_API_KEY_REDACTED>` unchanged (verified against production `/prime` page load) — redacted 2026-07-25: a live key must never appear in this public repo; read it from the environment.
 - Backend `/api/prime/zoning` contract unchanged.
 - `packages/core/styles/bz-tokens.css` read-only — all new components use existing `--bz-*` tokens.
 - `packages/core/components/BZLogo.tsx` untouched.


### PR DESCRIPTION
## Summary

- `Balizero1987/Teman2` is a **public** repo. Two tracked files contained a string matching the live Google API key shape (`AIza[0-9A-Za-z_-]{35}`, no placeholder markers):
  - `docs/superpowers/solidification-prompts/13-cowork-frontend.md`
  - `docs/superpowers/specs/2026-04-18-pf3a-prime-perf-ux-design.md`
- Verified independently (hashing each match, values never displayed) that **both files contained the same key**.
- Corroborating evidence this key was actually scraped: a sibling lane's local `.env` copy of `GOOGLE_API_KEY` returned Google's `403 "Your API key was reported as leaked"` on every model call today. Google auto-revokes keys it finds published in public repos.
- A broader scan of tracked files for other credential shapes (OpenAI `sk-`, Anthropic `sk-ant-`, GitHub `ghp_`/`github_pat_`, Slack `xox*`, AWS `AKIA`, Meta `EAA`) found no other exposure — this is the only leak found.

## What this PR does

- Redacts both occurrences at HEAD, replacing the live-shaped string with the placeholder `` `<GOOGLE_API_KEY_REDACTED>` `` plus an inline note ("redacted 2026-07-25 — a live key must never appear in this public repo; read it from the environment").
- Also drops a stray editorial note in the spec file that described an internal character of the key (position/case detail) — no longer meaningful once redacted, and unnecessary residual detail about the key's structure.
- Re-verified post-edit: `git grep -lE "AIza[0-9A-Za-z_-]{35}"` returns nothing.
- Prettier reformatted pre-existing spacing issues in the solidification-prompts file to satisfy the repo's pre-commit lint gate — no content change beyond that.

## Explicitly OUT of scope — history is NOT purged

**This PR only removes the key from HEAD.** The key remains reachable in this repo's git history (previous commits). Rewriting history (filter-repo / BFG + force-push) is a separate, heavier operation with its own force-push risk and was intentionally left out of this PR's scope.

**Required follow-up (operator action — only the Google Cloud account holder can do this):**
1. **Rotate/regenerate** the Google API key in Google Cloud Console (the leaked one is likely already auto-revoked by Google per the corroborating evidence above, but formal rotation should still be confirmed).
2. Decide separately whether/when to purge the key from git history.
3. Set the new key only via environment variable / secrets manager — never commit it to a tracked file again.

## Test plan

- [x] `git grep -lE "AIza[0-9A-Za-z_-]{35}"` on the worktree returns no matches (clean)
- [x] Pre-commit hook's own "Golden Rule #6: hardcoded secrets" check passed
- [x] Pre-push hook: docs-only change, backend suite correctly skipped by the path-aware allowlist
- [x] Push verified live via `git ls-remote origin agent/air-m5/docs/redact-google-keys`
- [ ] Operator: rotate/confirm-revoked the Google API key (see above)

Auto-merge intentionally NOT armed on this PR — leaving merge to the codeowner given the credential-rotation follow-up is operator-only and should be acknowledged before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)