### PR TITLE
feat(mouth): WS2 kita slice 2 — compliance & money token drain (GARUDA OS train)

### DIFF
--- a/apps/mouth/src/app/(workspace)/accounting/page.tsx
+++ b/apps/mouth/src/app/(workspace)/accounting/page.tsx
@@ -31,7 +31,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
-import { formatIDR, formatIDRCompact } from "@balizero/core/utils";
+import { formatIDR } from "@balizero/core/utils";
+import { Money } from "@balizero/core";
 import {
   accountingApi,
   type CashoutRow,
@@ -50,13 +51,13 @@ function SummaryCards({ summary }: { summary: CashbookSummary | null }) {
       label: "Income (in)",
       value: summary?.income_idr ?? 0,
       icon: ArrowDownToLine,
-      tone: "text-emerald-600",
+      tone: "text-[var(--state-success)]",
     },
     {
       label: "Outgoing (out)",
       value: summary?.outgoing_idr ?? 0,
       icon: ArrowUpFromLine,
-      tone: "text-rose-600",
+      tone: "text-[var(--state-danger)]",
     },
     {
       label: "Net",
@@ -68,7 +69,7 @@ function SummaryCards({ summary }: { summary: CashbookSummary | null }) {
       label: "Bali Zero margin",
       value: summary?.margin_total_idr ?? 0,
       icon: CheckCircle2,
-      tone: "text-[var(--bz-accent,#d4845a)]",
+      tone: "text-[var(--bz-accent)]",
     },
   ];
   return (
@@ -87,7 +88,7 @@ function SummaryCards({ summary }: { summary: CashbookSummary | null }) {
               className={`mt-2 text-xl font-semibold tabular-nums ${c.tone}`}
               title={formatIDR(c.value)}
             >
-              {formatIDRCompact(c.value)}
+              <Money compact value={c.value} />
             </p>
           </div>
         );
@@ -134,7 +135,7 @@ function CashoutTable({ rows }: { rows: CashoutRow[] }) {
               <td className="px-3 py-2 text-muted-foreground">
                 {r.type === "cashout_worksheet" && (
                   <span
-                    className="mr-1.5 inline-block rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700"
+                    className="mr-1.5 inline-block rounded bg-[color-mix(in_srgb,var(--state-warning)_15%,transparent)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--state-warning)]"
                     title="Imported from Asya's worksheet PDF — pending bank reconciliation, excluded from the totals above"
                   >
                     Worksheet
@@ -143,19 +144,19 @@ function CashoutTable({ rows }: { rows: CashoutRow[] }) {
                 {r.category ?? r.type}
               </td>
               <td className="px-3 py-2 text-right tabular-nums">
-                {r.pnbp_idr ? formatIDR(r.pnbp_idr) : "—"}
+                {r.pnbp_idr ? <Money value={r.pnbp_idr} /> : "—"}
               </td>
               <td className="px-3 py-2 text-right tabular-nums">
-                {r.urgent_idr ? formatIDR(r.urgent_idr) : "—"}
+                {r.urgent_idr ? <Money value={r.urgent_idr} /> : "—"}
               </td>
               <td className="px-3 py-2 text-right tabular-nums">
-                {r.rptka_imta_idr ? formatIDR(r.rptka_imta_idr) : "—"}
+                {r.rptka_imta_idr ? <Money value={r.rptka_imta_idr} /> : "—"}
               </td>
-              <td className="px-3 py-2 text-right tabular-nums text-[var(--bz-accent,#d4845a)]">
-                {r.margin_idr ? formatIDR(r.margin_idr) : "—"}
+              <td className="px-3 py-2 text-right tabular-nums text-[var(--bz-accent)]">
+                {r.margin_idr ? <Money value={r.margin_idr} /> : "—"}
               </td>
               <td className="px-3 py-2 text-right font-medium tabular-nums">
-                {formatIDR(r.final_price_idr || r.amount_idr)}
+                <Money value={r.final_price_idr || r.amount_idr} />
               </td>
               <td className="max-w-[200px] truncate px-3 py-2 text-muted-foreground">
                 {r.description ?? ""}
@@ -239,7 +240,7 @@ function ConfirmModal({
           <div className="flex justify-between">
             <dt className="text-muted-foreground">Transfer</dt>
             <dd className="font-medium tabular-nums">
-              {formatIDR(txn.amount_idr)}
+              <Money value={txn.amount_idr} />
             </dd>
           </div>
           <div className="flex justify-between">
@@ -249,16 +250,16 @@ function ConfirmModal({
           <div className="flex justify-between">
             <dt className="text-muted-foreground">Invoice</dt>
             <dd className="tabular-nums">
-              {formatIDR(candidate.invoice_amount_idr)}
+              <Money value={candidate.invoice_amount_idr} />
             </dd>
           </div>
           <div className="flex justify-between">
             <dt className="text-muted-foreground">Delta</dt>
             <dd
-              className={`tabular-nums ${delta < 0 ? "text-amber-600" : "text-emerald-600"}`}
+              className={`tabular-nums ${delta < 0 ? "text-[var(--state-warning)]" : "text-[var(--state-success)]"}`}
             >
               {delta >= 0 ? "+" : ""}
-              {formatIDR(delta)}
+              <Money value={delta} />
             </dd>
           </div>
           <div className="flex justify-between">
@@ -266,7 +267,7 @@ function ConfirmModal({
             <dd className="font-semibold uppercase">{newStatus}</dd>
           </div>
           {candidate.likely_withheld && (
-            <p className="rounded-md bg-amber-50 p-2 text-xs text-amber-700">
+            <p className="rounded-md bg-[color-mix(in_srgb,var(--state-warning)_10%,transparent)] p-2 text-xs text-[var(--state-warning)]">
               Looks net of PPh23 withholding — the delta is recorded as withheld
               tax.
             </p>
@@ -388,8 +389,8 @@ function ReconciliationInbox({ onConfirmed }: { onConfirmed: () => void }) {
                   {txn.txn_date}
                 </p>
               </div>
-              <span className="shrink-0 font-semibold tabular-nums text-emerald-600">
-                {formatIDR(txn.amount_idr)}
+              <span className="shrink-0 font-semibold tabular-nums text-[var(--state-success)]">
+                <Money value={txn.amount_idr} />
               </span>
             </button>
 
@@ -417,7 +418,7 @@ function ReconciliationInbox({ onConfirmed }: { onConfirmed: () => void }) {
                             {c.client_name}
                           </p>
                           <p className="text-xs text-muted-foreground">
-                            {formatIDR(c.invoice_amount_idr)} ·{" "}
+                            <Money value={c.invoice_amount_idr} /> ·{" "}
                             {(c.confidence * 100).toFixed(0)}% ·{" "}
                             {c.reasons[0] ?? ""}
                           </p>
@@ -536,7 +537,7 @@ export default function AccountingPage() {
     <div className="space-y-6 p-6">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Wallet className="h-6 w-6 text-[var(--bz-accent,#d4845a)]" />
+          <Wallet className="h-6 w-6 text-[var(--bz-accent)]" />
           <h1 className="text-2xl font-semibold tracking-tight">Accounting</h1>
         </div>
         <div className="flex items-center gap-2">
@@ -580,12 +581,14 @@ export default function AccountingPage() {
         // above) — surface how much pending money is sitting in that bucket so
         // the gap between "what's booked" and "what's confirmed in the bank" is
         // visible at a glance.
-        const ws = summary?.by_type?.find((t) => t.type === "cashout_worksheet");
+        const ws = summary?.by_type?.find(
+          (t) => t.type === "cashout_worksheet",
+        );
         if (!ws || !ws.n) return null;
         return (
-          <p className="-mt-3 text-xs text-amber-700">
-            {ws.n} worksheet draft(s) ({formatIDR(ws.total_idr)}) imported from
-            Asya&apos;s PDF — excluded from the totals above, pending bank
+          <p className="-mt-3 text-xs text-[var(--state-warning)]">
+            {ws.n} worksheet draft(s) (<Money value={ws.total_idr} />) imported
+            from Asya&apos;s PDF — excluded from the totals above, pending bank
             reconciliation.
           </p>
         );
@@ -596,7 +599,7 @@ export default function AccountingPage() {
           onClick={() => setTab("cashout")}
           className={`flex items-center gap-2 px-3 py-2 text-sm font-medium ${
             tab === "cashout"
-              ? "border-b-2 border-[var(--bz-accent,#d4845a)] text-foreground"
+              ? "border-b-2 border-[var(--bz-accent)] text-foreground"
               : "text-muted-foreground hover:text-foreground"
           }`}
         >
@@ -606,7 +609,7 @@ export default function AccountingPage() {
           onClick={() => setTab("inbox")}
           className={`flex items-center gap-2 px-3 py-2 text-sm font-medium ${
             tab === "inbox"
-              ? "border-b-2 border-[var(--bz-accent,#d4845a)] text-foreground"
+              ? "border-b-2 border-[var(--bz-accent)] text-foreground"
               : "text-muted-foreground hover:text-foreground"
           }`}
         >

--- a/apps/mouth/src/app/(workspace)/lkpm/[id]/error.tsx
+++ b/apps/mouth/src/app/(workspace)/lkpm/[id]/error.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { AlertTriangle, RefreshCw, FileText } from 'lucide-react';
-import { logger } from '@/lib/logger';
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, RefreshCw, FileText } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 export default function LKPMReportError({
   error,
@@ -13,7 +13,7 @@ export default function LKPMReportError({
   reset: () => void;
 }) {
   useEffect(() => {
-    logger.error('LKPM Report Error', {}, error);
+    logger.error("LKPM Report Error", {}, error);
   }, [error]);
 
   return (
@@ -23,10 +23,12 @@ export default function LKPMReportError({
       </div>
 
       <div className="mt-6 text-center space-y-2 max-w-md">
-        <h2 className="text-2xl font-semibold tracking-tight">Couldn&apos;t Load LKPM Report</h2>
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Couldn&apos;t Load LKPM Report
+        </h2>
         <p className="text-muted-foreground">
-          There was an error loading this page. Please try again or contact support if the
-          problem persists.
+          There was an error loading this page. Please try again or contact
+          support if the problem persists.
         </p>
       </div>
 

--- a/apps/mouth/src/app/(workspace)/lkpm/[id]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/lkpm/[id]/page.tsx
@@ -5,7 +5,7 @@ import { Loader2, ArrowLeft, Printer, CheckCircle, Upload } from "lucide-react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useToast } from "@/components/ui/toast";
-import { formatIDR } from "@balizero/core/utils";
+import { Money } from "@balizero/core";
 import { logger } from "@/lib/logger";
 import { lkpmApi } from "@/lib/api/workspace/lkpm.api";
 import type { LKPMReadyPack } from "@/lib/api/portal/portal.types";
@@ -160,7 +160,11 @@ export default function LKPMReadyPackPage() {
           <button
             onClick={() => setShowReceiptForm(!showReceiptForm)}
             className="px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2"
-            style={{ background: "rgba(59,130,246,0.12)", color: "#60a5fa" }}
+            style={{
+              background:
+                "color-mix(in srgb, var(--state-info) 12%, transparent)",
+              color: "var(--state-info)",
+            }}
           >
             <Upload className="w-4 h-4" />
             Upload Receipt
@@ -241,8 +245,16 @@ export default function LKPMReadyPackPage() {
                 className="px-2 py-0.5 rounded-full text-xs font-medium"
                 style={
                   pack.validation_summary.is_valid
-                    ? { background: "rgba(16,185,129,0.12)", color: "#34d399" }
-                    : { background: "rgba(239,68,68,0.12)", color: "#f87171" }
+                    ? {
+                        background:
+                          "color-mix(in srgb, var(--state-success) 12%, transparent)",
+                        color: "var(--state-success)",
+                      }
+                    : {
+                        background:
+                          "color-mix(in srgb, var(--state-danger) 12%, transparent)",
+                        color: "var(--state-danger)",
+                      }
                 }
               >
                 {pack.validation_summary.is_valid ? "Valid" : "Issues Found"}
@@ -254,7 +266,7 @@ export default function LKPMReadyPackPage() {
                 <div className="flex items-center gap-1.5">
                   <span
                     className="w-2 h-2 rounded-full"
-                    style={{ background: "#f87171" }}
+                    style={{ background: "var(--state-danger)" }}
                   />
                   Red
                 </div>
@@ -266,7 +278,7 @@ export default function LKPMReadyPackPage() {
                 <div className="flex items-center gap-1.5">
                   <span
                     className="w-2 h-2 rounded-full"
-                    style={{ background: "#fbbf24" }}
+                    style={{ background: "var(--state-warning)" }}
                   />
                   Yellow
                 </div>
@@ -278,7 +290,7 @@ export default function LKPMReadyPackPage() {
                 <div className="flex items-center gap-1.5">
                   <span
                     className="w-2 h-2 rounded-full"
-                    style={{ background: "#34d399" }}
+                    style={{ background: "var(--state-success)" }}
                   />
                   Green
                 </div>
@@ -303,7 +315,7 @@ export default function LKPMReadyPackPage() {
             >
               <p>
                 <span className="font-medium">Grand Total:</span>{" "}
-                {formatIDR(pack.realized.grand_total)}
+                <Money value={pack.realized.grand_total} />
               </p>
               <p>
                 <span className="font-medium">Employees:</span>{" "}

--- a/apps/mouth/src/app/(workspace)/lkpm/error.tsx
+++ b/apps/mouth/src/app/(workspace)/lkpm/error.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { FileText, RefreshCw } from 'lucide-react';
-import { logger } from '@/lib/logger';
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { FileText, RefreshCw } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 export default function LkpmError({
   error,
@@ -13,7 +13,7 @@ export default function LkpmError({
   reset: () => void;
 }) {
   useEffect(() => {
-    logger.error('LKPM Error', {}, error);
+    logger.error("LKPM Error", {}, error);
   }, [error]);
 
   return (
@@ -23,10 +23,12 @@ export default function LkpmError({
       </div>
 
       <div className="mt-6 text-center space-y-2 max-w-md">
-        <h2 className="text-2xl font-semibold tracking-tight">Couldn&apos;t Load LKPM</h2>
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Couldn&apos;t Load LKPM
+        </h2>
         <p className="text-muted-foreground">
-          There was an error loading your LKPM reports. Please try again or contact support if the
-          problem persists.
+          There was an error loading your LKPM reports. Please try again or
+          contact support if the problem persists.
         </p>
       </div>
 

--- a/apps/mouth/src/app/(workspace)/lkpm/loading.tsx
+++ b/apps/mouth/src/app/(workspace)/lkpm/loading.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function LkpmLoading() {
   return (

--- a/apps/mouth/src/app/(workspace)/lkpm/page.tsx
+++ b/apps/mouth/src/app/(workspace)/lkpm/page.tsx
@@ -24,7 +24,7 @@ import type {
   LKPMDeadline,
   LKPMOSSCredentials,
 } from "@/lib/api/portal/portal.types";
-import { formatIDR } from "@balizero/core/utils";
+import { Money } from "@balizero/core";
 
 // Tax consultants — kept in sync with backend migration 093.
 const TAX_CONSULTANTS: { value: string; label: string }[] = [
@@ -237,8 +237,8 @@ export default function LKPMBatchPage() {
             onChange={(e) => setQuarter(e.target.value)}
             className="rounded-lg border px-3 py-2 text-sm backdrop-blur-md"
             style={{
-              background: "rgba(35,35,40,0.6)",
-              borderColor: "rgba(255,255,255,0.05)",
+              background: "rgba(35,35,40,0.65)",
+              borderColor: "var(--bz-border)",
             }}
           >
             {QUARTERS.map((q) => (
@@ -252,8 +252,8 @@ export default function LKPMBatchPage() {
             onChange={(e) => setYear(Number(e.target.value))}
             className="rounded-lg border px-3 py-2 text-sm backdrop-blur-md"
             style={{
-              background: "rgba(35,35,40,0.6)",
-              borderColor: "rgba(255,255,255,0.05)",
+              background: "rgba(35,35,40,0.65)",
+              borderColor: "var(--bz-border)",
             }}
           >
             {[currentYear, currentYear - 1, currentYear - 2].map((y) => (
@@ -270,11 +270,16 @@ export default function LKPMBatchPage() {
         <section
           className="rounded-lg border p-4 flex items-center gap-2"
           style={{
-            background: "rgba(239,68,68,0.08)",
-            borderColor: "rgba(239,68,68,0.3)",
+            background:
+              "color-mix(in srgb, var(--state-danger) 8%, transparent)",
+            borderColor:
+              "color-mix(in srgb, var(--state-danger) 30%, transparent)",
           }}
         >
-          <AlertTriangle className="w-5 h-5" style={{ color: "#f87171" }} />
+          <AlertTriangle
+            className="w-5 h-5"
+            style={{ color: "var(--state-danger)" }}
+          />
           <span className="text-sm font-medium">
             {counts.redAlerts} critical alert{counts.redAlerts !== 1 ? "s" : ""}{" "}
             across all clients
@@ -289,17 +294,23 @@ export default function LKPMBatchPage() {
           style={
             nextDeadline.is_overdue
               ? {
-                  background: "rgba(239,68,68,0.08)",
-                  borderColor: "rgba(239,68,68,0.3)",
+                  background:
+                    "color-mix(in srgb, var(--state-danger) 8%, transparent)",
+                  borderColor:
+                    "color-mix(in srgb, var(--state-danger) 30%, transparent)",
                 }
               : nextDeadline.days_remaining <= 14
                 ? {
-                    background: "rgba(245,158,11,0.08)",
-                    borderColor: "rgba(245,158,11,0.3)",
+                    background:
+                      "color-mix(in srgb, var(--state-warning) 8%, transparent)",
+                    borderColor:
+                      "color-mix(in srgb, var(--state-warning) 30%, transparent)",
                   }
                 : {
-                    background: "rgba(16,185,129,0.06)",
-                    borderColor: "rgba(16,185,129,0.25)",
+                    background:
+                      "color-mix(in srgb, var(--state-success) 6%, transparent)",
+                    borderColor:
+                      "color-mix(in srgb, var(--state-success) 25%, transparent)",
                   }
           }
         >
@@ -307,10 +318,10 @@ export default function LKPMBatchPage() {
             className="w-5 h-5"
             style={{
               color: nextDeadline.is_overdue
-                ? "#f87171"
+                ? "var(--state-danger)"
                 : nextDeadline.days_remaining <= 14
-                  ? "#fbbf24"
-                  : "#34d399",
+                  ? "var(--state-warning)"
+                  : "var(--state-success)",
             }}
           />
           <div className="flex items-center gap-2 flex-wrap">
@@ -325,10 +336,10 @@ export default function LKPMBatchPage() {
             <span
               className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold ${
                 nextDeadline.is_overdue
-                  ? "bg-red-500/15 text-red-400"
+                  ? "bg-[color-mix(in_srgb,var(--state-danger)_15%,transparent)] text-[var(--state-danger)]"
                   : nextDeadline.days_remaining <= 14
-                    ? "bg-amber-500/15 text-amber-400"
-                    : "bg-emerald-500/10 text-emerald-400"
+                    ? "bg-[color-mix(in_srgb,var(--state-warning)_15%,transparent)] text-[var(--state-warning)]"
+                    : "bg-[color-mix(in_srgb,var(--state-success)_10%,transparent)] text-[var(--state-success)]"
               }`}
             >
               {nextDeadline.is_overdue
@@ -352,19 +363,19 @@ export default function LKPMBatchPage() {
           label="Submitted"
           value={counts.submitted}
           icon={CheckCircle}
-          color="#34d399"
+          color="var(--state-success)"
         />
         <KPICard
           label="Pending"
           value={counts.pending}
           icon={Clock}
-          color="#fbbf24"
+          color="var(--state-warning)"
         />
         <KPICard
           label="Red Alerts"
           value={counts.redAlerts}
           icon={AlertTriangle}
-          color="#f87171"
+          color="var(--state-danger)"
         />
       </section>
 
@@ -381,15 +392,15 @@ export default function LKPMBatchPage() {
                 statusFilter === filter
                   ? {
                       background:
-                        "linear-gradient(135deg, var(--bz-accent-warm) 0%, rgba(212, 132, 90, 0.8) 100%)",
+                        "linear-gradient(135deg, var(--bz-accent-warm) 0%, color-mix(in srgb, var(--bz-accent) 80%, transparent) 100%)",
                       color: "white",
-                      boxShadow: "0 4px 15px rgba(212, 132, 90, 0.3)",
+                      boxShadow: "0 4px 15px var(--bz-accent-glow)",
                     }
                   : {
-                      background: "rgba(35,35,40,0.6)",
+                      background: "rgba(35,35,40,0.65)",
                       backdropFilter: "blur(12px)",
                       color: "var(--bz-text-2)",
-                      border: "1px solid rgba(255,255,255,0.05)",
+                      border: "1px solid var(--bz-border)",
                     }
               }
             >
@@ -403,9 +414,8 @@ export default function LKPMBatchPage() {
       <section
         className="rounded-xl border shadow-2xl backdrop-blur-xl overflow-hidden"
         style={{
-          background:
-            "linear-gradient(145deg, rgba(32,32,36,0.7) 0%, rgba(22,22,26,0.4) 100%)",
-          borderColor: "rgba(255, 255, 255, 0.05)",
+          background: "rgba(35,35,40,0.65)",
+          borderColor: "var(--bz-border)",
         }}
       >
         <div className="overflow-x-auto">
@@ -444,7 +454,7 @@ export default function LKPMBatchPage() {
               ) : (
                 filteredItems.map((item) => (
                   <React.Fragment key={item.id}>
-                    <tr className="hover:bg-[rgba(255,255,255,0.05)] transition-colors">
+                    <tr className="hover:bg-[var(--surface-raised)] transition-colors">
                       <td className="px-4 py-3 font-medium">
                         {item.company_name}
                       </td>
@@ -460,8 +470,8 @@ export default function LKPMBatchPage() {
                           disabled={assigningId === item.id}
                           className="rounded border px-2 py-1 text-xs backdrop-blur-md"
                           style={{
-                            background: "rgba(35,35,40,0.6)",
-                            borderColor: "rgba(255,255,255,0.05)",
+                            background: "rgba(35,35,40,0.65)",
+                            borderColor: "var(--bz-border)",
                             color: item.lkpm_assigned_to
                               ? "var(--bz-text-1)"
                               : "var(--bz-text-2)",
@@ -483,10 +493,10 @@ export default function LKPMBatchPage() {
                           className="px-2 py-1 rounded text-xs font-medium inline-flex items-center gap-1"
                           style={{
                             background: openCreds[item.id]
-                              ? "rgba(212, 132, 90, 0.2)"
-                              : "rgba(255,255,255,0.05)",
+                              ? "color-mix(in srgb, var(--bz-accent) 20%, transparent)"
+                              : "var(--surface-raised)",
                             color: openCreds[item.id]
-                              ? "#d4845a"
+                              ? "var(--bz-accent)"
                               : "var(--bz-text-2)",
                           }}
                           aria-label="Show OSS credentials"
@@ -508,7 +518,7 @@ export default function LKPMBatchPage() {
                         </button>
                       </td>
                       <td className="px-4 py-3 text-right font-mono text-xs">
-                        {formatIDR(item.realized_total)}
+                        <Money value={item.realized_total} />
                       </td>
                       <td className="px-4 py-3 text-center">
                         <div className="flex items-center justify-center gap-1">
@@ -516,8 +526,9 @@ export default function LKPMBatchPage() {
                             <span
                               className="px-1.5 py-0.5 rounded text-xs font-medium"
                               style={{
-                                background: "rgba(239,68,68,0.12)",
-                                color: "#f87171",
+                                background:
+                                  "color-mix(in srgb, var(--state-danger) 12%, transparent)",
+                                color: "var(--state-danger)",
                               }}
                             >
                               {item.red_alerts}
@@ -527,8 +538,9 @@ export default function LKPMBatchPage() {
                             <span
                               className="px-1.5 py-0.5 rounded text-xs font-medium"
                               style={{
-                                background: "rgba(245,158,11,0.12)",
-                                color: "#fbbf24",
+                                background:
+                                  "color-mix(in srgb, var(--state-warning) 12%, transparent)",
+                                color: "var(--state-warning)",
                               }}
                             >
                               {item.yellow_alerts}
@@ -538,7 +550,7 @@ export default function LKPMBatchPage() {
                             item.yellow_alerts === 0 && (
                               <CheckCircle
                                 className="w-4 h-4"
-                                style={{ color: "#34d399" }}
+                                style={{ color: "var(--state-success)" }}
                               />
                             )}
                         </div>
@@ -551,8 +563,9 @@ export default function LKPMBatchPage() {
                               disabled={validatingId === item.id}
                               className="px-2 py-1 rounded text-xs font-medium"
                               style={{
-                                background: "rgba(59,130,246,0.12)",
-                                color: "#60a5fa",
+                                background:
+                                  "color-mix(in srgb, var(--state-info) 12%, transparent)",
+                                color: "var(--state-info)",
                               }}
                             >
                               {validatingId === item.id ? (
@@ -567,8 +580,9 @@ export default function LKPMBatchPage() {
                               onClick={() => handleMarkSubmitted(item.id)}
                               className="px-2 py-1 rounded text-xs font-medium"
                               style={{
-                                background: "rgba(16,185,129,0.12)",
-                                color: "#34d399",
+                                background:
+                                  "color-mix(in srgb, var(--state-success) 12%, transparent)",
+                                color: "var(--state-success)",
                               }}
                             >
                               Mark Submitted
@@ -578,7 +592,7 @@ export default function LKPMBatchPage() {
                             href={`/lkpm/${item.id}`}
                             className="px-2 py-1 rounded text-xs font-medium flex items-center gap-1"
                             style={{
-                              background: "rgba(255,255,255,0.05)",
+                              background: "var(--surface-raised)",
                               color: "var(--bz-text-2)",
                             }}
                           >
@@ -594,14 +608,15 @@ export default function LKPMBatchPage() {
                           colSpan={7}
                           className="px-4 py-3"
                           style={{
-                            background: "rgba(212, 132, 90, 0.06)",
+                            background:
+                              "color-mix(in srgb, var(--bz-accent) 6%, transparent)",
                             borderLeft: "3px solid var(--bz-accent-warm)",
                           }}
                         >
                           <div className="flex items-center gap-4 flex-wrap text-xs">
                             <span
                               className="font-semibold uppercase tracking-wide"
-                              style={{ color: "#d4845a" }}
+                              style={{ color: "var(--bz-accent)" }}
                             >
                               OSS Credentials
                             </span>
@@ -612,7 +627,7 @@ export default function LKPMBatchPage() {
                               <code
                                 className="font-mono px-2 py-0.5 rounded"
                                 style={{
-                                  background: "rgba(0,0,0,0.3)",
+                                  background: "var(--surface-sunken)",
                                   color: "var(--bz-text-1)",
                                 }}
                               >
@@ -626,7 +641,7 @@ export default function LKPMBatchPage() {
                                       "Username",
                                     )
                                   }
-                                  className="p-1 rounded hover:bg-[rgba(255,255,255,0.08)]"
+                                  className="p-1 rounded hover:bg-[var(--surface-raised)]"
                                   aria-label="Copy username"
                                 >
                                   <Copy className="w-3 h-3" />
@@ -640,7 +655,7 @@ export default function LKPMBatchPage() {
                               <code
                                 className="font-mono px-2 py-0.5 rounded"
                                 style={{
-                                  background: "rgba(0,0,0,0.3)",
+                                  background: "var(--surface-sunken)",
                                   color: "var(--bz-text-1)",
                                 }}
                               >
@@ -654,7 +669,7 @@ export default function LKPMBatchPage() {
                                       "Password",
                                     )
                                   }
-                                  className="p-1 rounded hover:bg-[rgba(255,255,255,0.08)]"
+                                  className="p-1 rounded hover:bg-[var(--surface-raised)]"
                                   aria-label="Copy password"
                                 >
                                   <Copy className="w-3 h-3" />
@@ -699,9 +714,8 @@ function KPICard({
     <div
       className="rounded-xl border p-4 shadow-xl backdrop-blur-md transition-all duration-300 hover:shadow-2xl hover:-translate-y-1"
       style={{
-        background:
-          "linear-gradient(145deg, rgba(35,35,40,0.6) 0%, rgba(25,25,30,0.3) 100%)",
-        borderColor: "rgba(255, 255, 255, 0.05)",
+        background: "rgba(35,35,40,0.65)",
+        borderColor: "var(--bz-border)",
       }}
     >
       <div className="flex items-center gap-2 mb-2">
@@ -723,27 +737,49 @@ function BatchStatusBadge({ status }: { status: string }) {
     {
       draft: {
         label: "Draft",
-        style: { background: "rgba(245,158,11,0.12)", color: "#fbbf24" },
+        style: {
+          background:
+            "color-mix(in srgb, var(--state-warning) 12%, transparent)",
+          color: "var(--state-warning)",
+        },
       },
       validated: {
         label: "Validated",
-        style: { background: "rgba(59,130,246,0.12)", color: "#60a5fa" },
+        style: {
+          background: "color-mix(in srgb, var(--state-info) 12%, transparent)",
+          color: "var(--state-info)",
+        },
       },
       client_review: {
         label: "Client Review",
-        style: { background: "rgba(168,85,247,0.12)", color: "#a78bfa" },
+        style: {
+          background:
+            "color-mix(in srgb, var(--bz-neon-purple) 12%, transparent)",
+          color: "var(--bz-neon-purple)",
+        },
       },
       approved: {
         label: "Approved",
-        style: { background: "rgba(16,185,129,0.12)", color: "#34d399" },
+        style: {
+          background:
+            "color-mix(in srgb, var(--state-success) 12%, transparent)",
+          color: "var(--state-success)",
+        },
       },
       submitted: {
         label: "Submitted",
-        style: { background: "rgba(16,185,129,0.12)", color: "#34d399" },
+        style: {
+          background:
+            "color-mix(in srgb, var(--state-success) 12%, transparent)",
+          color: "var(--state-success)",
+        },
       },
       archived: {
         label: "Archived",
-        style: { background: "rgba(107,114,128,0.12)", color: "#9ca3af" },
+        style: {
+          background: "var(--surface-raised)",
+          color: "var(--bz-text-2)",
+        },
       },
     };
 

--- a/apps/mouth/src/app/(workspace)/lkpm/submit/error.tsx
+++ b/apps/mouth/src/app/(workspace)/lkpm/submit/error.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { AlertTriangle, RefreshCw, FileText } from 'lucide-react';
-import { logger } from '@/lib/logger';
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, RefreshCw, FileText } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 export default function LKPMSubmitError({
   error,
@@ -13,7 +13,7 @@ export default function LKPMSubmitError({
   reset: () => void;
 }) {
   useEffect(() => {
-    logger.error('LKPM Submit Error', {}, error);
+    logger.error("LKPM Submit Error", {}, error);
   }, [error]);
 
   return (
@@ -23,10 +23,12 @@ export default function LKPMSubmitError({
       </div>
 
       <div className="mt-6 text-center space-y-2 max-w-md">
-        <h2 className="text-2xl font-semibold tracking-tight">Couldn&apos;t Load LKPM Submit</h2>
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Couldn&apos;t Load LKPM Submit
+        </h2>
         <p className="text-muted-foreground">
-          There was an error loading this page. Please try again or contact support if the
-          problem persists.
+          There was an error loading this page. Please try again or contact
+          support if the problem persists.
         </p>
       </div>
 

--- a/apps/mouth/src/app/(workspace)/lkpm/submit/page.tsx
+++ b/apps/mouth/src/app/(workspace)/lkpm/submit/page.tsx
@@ -1,48 +1,48 @@
-'use client';
+"use client";
 
-import React, { useEffect, useRef, useState } from 'react';
-import { Loader2, Send, ArrowLeft, Search, Building2 } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import { api } from '@/lib/api';
-import { useToast } from '@/components/ui/toast';
-import { logger } from '@/lib/logger';
+import React, { useEffect, useRef, useState } from "react";
+import { Loader2, Send, ArrowLeft, Search, Building2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { api } from "@/lib/api";
+import { useToast } from "@/components/ui/toast";
+import { logger } from "@/lib/logger";
 
 // Kategori sesuai format OSS (PerBKPM 5/2025)
 // Backend keys: equipment, building, vehicle — each with _domestic/_import
 const MODAL_TETAP = [
   {
-    key: 'building',
-    label: 'Bangunan / Gedung',
-    hint: 'Konstruksi, renovasi, pembangunan kantor',
+    key: "building",
+    label: "Bangunan / Gedung",
+    hint: "Konstruksi, renovasi, pembangunan kantor",
   },
   {
-    key: 'equipment',
-    label: 'Mesin / Peralatan',
-    hint: 'Komputer, mesin, furnitur, perlengkapan kantor',
+    key: "equipment",
+    label: "Mesin / Peralatan",
+    hint: "Komputer, mesin, furnitur, perlengkapan kantor",
   },
   {
-    key: 'vehicle',
-    label: 'Kendaraan',
-    hint: 'Mobil, motor, kendaraan operasional',
+    key: "vehicle",
+    label: "Kendaraan",
+    hint: "Mobil, motor, kendaraan operasional",
   },
 ] as const;
 
 // Kategori tanpa split domestik/impor
 const MODAL_TETAP_SINGLE = [
   {
-    key: 'land',
-    label: 'Pembelian / Pematangan Tanah',
-    hint: 'Hak Pakai, HGB, sewa tanah',
+    key: "land",
+    label: "Pembelian / Pematangan Tanah",
+    hint: "Hak Pakai, HGB, sewa tanah",
   },
   {
-    key: 'other',
-    label: 'Lain-lain',
-    hint: 'Biaya pra-operasional, perizinan, studi kelayakan',
+    key: "other",
+    label: "Lain-lain",
+    hint: "Biaya pra-operasional, perizinan, studi kelayakan",
   },
 ] as const;
 
-const QUARTERS = ['Q1', 'Q2', 'Q3', 'Q4'] as const;
+const QUARTERS = ["Q1", "Q2", "Q3", "Q4"] as const;
 
 interface CRMCompany {
   id: number;
@@ -62,8 +62,10 @@ export default function WorkspaceLKPMSubmitPage() {
 
   // Company selection
   const [companies, setCompanies] = useState<CRMCompany[]>([]);
-  const [selectedCompany, setSelectedCompany] = useState<CRMCompany | null>(null);
-  const [companySearch, setCompanySearch] = useState('');
+  const [selectedCompany, setSelectedCompany] = useState<CRMCompany | null>(
+    null,
+  );
+  const [companySearch, setCompanySearch] = useState("");
   const [isSearchingCompanies, setIsSearchingCompanies] = useState(false);
   const [showCompanyDropdown, setShowCompanyDropdown] = useState(false);
   const [resolvingClient, setResolvingClient] = useState(false);
@@ -90,8 +92,8 @@ export default function WorkspaceLKPMSubmitPage() {
   const [tka, setTka] = useState(0);
   const [revenueQuarterly, setRevenueQuarterly] = useState(0);
   const [revenueAnnual, setRevenueAnnual] = useState(0);
-  const [obstacles, setObstacles] = useState('');
-  const [plans, setPlans] = useState('');
+  const [obstacles, setObstacles] = useState("");
+  const [plans, setPlans] = useState("");
 
   // Debounced company search
   useEffect(() => {
@@ -103,11 +105,11 @@ export default function WorkspaceLKPMSubmitPage() {
       setIsSearchingCompanies(true);
       try {
         const results = await api.get<CRMCompany[]>(
-          `/api/crm/companies?search=${encodeURIComponent(companySearch)}&limit=20`
+          `/api/crm/companies?search=${encodeURIComponent(companySearch)}&limit=20`,
         );
         setCompanies(results);
       } catch (err) {
-        logger.error('Failed to search companies for LKPM', {}, err as Error);
+        logger.error("Failed to search companies for LKPM", {}, err as Error);
       } finally {
         setIsSearchingCompanies(false);
       }
@@ -125,28 +127,32 @@ export default function WorkspaceLKPMSubmitPage() {
       }
     };
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setShowCompanyDropdown(false);
+      if (e.key === "Escape") setShowCompanyDropdown(false);
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEscape);
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
     };
   }, []);
 
   const updateInvestment = (field: string, value: string) => {
-    const num = parseInt(value.replace(/\D/g, ''), 10) || 0;
+    const num = parseInt(value.replace(/\D/g, ""), 10) || 0;
     setInvestment((prev) => ({ ...prev, [field]: num }));
   };
 
-  const formatNumber = (n: number) => (n > 0 ? new Intl.NumberFormat('id-ID').format(n) : '');
+  const formatNumber = (n: number) =>
+    n > 0 ? new Intl.NumberFormat("id-ID").format(n) : "";
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!selectedCompany) {
-      error('Missing Company', 'Please select a company to submit LKPM data for.');
+      error(
+        "Missing Company",
+        "Please select a company to submit LKPM data for.",
+      );
       return;
     }
 
@@ -165,12 +171,13 @@ export default function WorkspaceLKPMSubmitPage() {
       setResolvingClient(false);
 
       const primaryLink =
-        companyDetail.associates?.find((a) => a.is_primary) ?? companyDetail.associates?.[0];
+        companyDetail.associates?.find((a) => a.is_primary) ??
+        companyDetail.associates?.[0];
 
       if (!primaryLink) {
         error(
-          'No Client Linked',
-          'This company has no linked clients. Please link a client first.'
+          "No Client Linked",
+          "This company has no linked clients. Please link a client first.",
         );
         setIsSubmitting(false);
         return;
@@ -182,7 +189,7 @@ export default function WorkspaceLKPMSubmitPage() {
         quarter: string;
         year: number;
         realized_total: number;
-      }>('/api/v1/lkpm/submit-data', {
+      }>("/api/v1/lkpm/submit-data", {
         client_id: primaryLink.client_id,
         quarter,
         year,
@@ -196,13 +203,13 @@ export default function WorkspaceLKPMSubmitPage() {
         narrative_plans: plans || undefined,
       });
       success(
-        'Data submitted',
-        `Draft created for ${selectedCompany.company_name} — ${result.quarter} ${result.year}`
+        "Data submitted",
+        `Draft created for ${selectedCompany.company_name} — ${result.quarter} ${result.year}`,
       );
-      router.push('/lkpm');
+      router.push("/lkpm");
     } catch (err) {
-      error('Submission failed', 'Please check your data and try again');
-      logger.error('LKPM workspace submission failed', {}, err as Error);
+      error("Submission failed", "Please check your data and try again");
+      logger.error("LKPM workspace submission failed", {}, err as Error);
     } finally {
       setIsSubmitting(false);
       setResolvingClient(false);
@@ -214,11 +221,18 @@ export default function WorkspaceLKPMSubmitPage() {
       {/* Header */}
       <section className="flex items-center gap-3">
         <Link href="/lkpm">
-          <ArrowLeft className="w-5 h-5" style={{ color: 'var(--bz-text-2)' }} />
+          <ArrowLeft
+            className="w-5 h-5"
+            style={{ color: "var(--bz-text-2)" }}
+          />
         </Link>
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Submit Data LKPM</h1>
-          <p style={{ color: 'var(--bz-text-2)' }}>Input data realisasi investasi triwulanan</p>
+          <h1 className="text-2xl font-bold tracking-tight">
+            Submit Data LKPM
+          </h1>
+          <p style={{ color: "var(--bz-text-2)" }}>
+            Input data realisasi investasi triwulanan
+          </p>
         </div>
       </section>
 
@@ -227,12 +241,12 @@ export default function WorkspaceLKPMSubmitPage() {
         <section
           className="rounded-xl border p-6 space-y-4"
           style={{
-            background: 'var(--bz-card)',
-            borderColor: 'var(--bz-border)',
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <h2 className="text-lg font-semibold">
-            Company <span className="text-red-500">*</span>
+            Company <span className="text-[var(--state-danger)]">*</span>
           </h2>
 
           <div className="relative" ref={searchRef}>
@@ -240,26 +254,41 @@ export default function WorkspaceLKPMSubmitPage() {
               <div
                 className="flex items-center justify-between p-3 rounded-lg border"
                 style={{
-                  background: 'rgba(201,169,110,0.1)',
-                  borderColor: 'rgba(201,169,110,0.3)',
+                  background:
+                    "color-mix(in srgb, var(--bz-accent-warm) 10%, transparent)",
+                  borderColor:
+                    "color-mix(in srgb, var(--bz-accent-warm) 30%, transparent)",
                 }}
               >
                 <div className="flex items-center gap-3">
                   <div
                     className="w-8 h-8 rounded-full flex items-center justify-center"
-                    style={{ background: 'rgba(201,169,110,0.2)' }}
+                    style={{
+                      background:
+                        "color-mix(in srgb, var(--bz-accent-warm) 20%, transparent)",
+                    }}
                   >
-                    <Building2 className="w-4 h-4" style={{ color: 'var(--bz-accent-warm)' }} />
+                    <Building2
+                      className="w-4 h-4"
+                      style={{ color: "var(--bz-accent-warm)" }}
+                    />
                   </div>
                   <div>
-                    <p className="text-sm font-medium">{selectedCompany.company_name}</p>
-                    <p className="text-xs" style={{ color: 'var(--bz-text-2)' }}>
+                    <p className="text-sm font-medium">
+                      {selectedCompany.company_name}
+                    </p>
+                    <p
+                      className="text-xs"
+                      style={{ color: "var(--bz-text-2)" }}
+                    >
                       {[
                         selectedCompany.company_type,
-                        selectedCompany.nib ? `NIB: ${selectedCompany.nib}` : null,
+                        selectedCompany.nib
+                          ? `NIB: ${selectedCompany.nib}`
+                          : null,
                       ]
                         .filter(Boolean)
-                        .join(' · ') || 'No details'}
+                        .join(" · ") || "No details"}
                     </p>
                   </div>
                 </div>
@@ -267,10 +296,10 @@ export default function WorkspaceLKPMSubmitPage() {
                   type="button"
                   onClick={() => {
                     setSelectedCompany(null);
-                    setCompanySearch('');
+                    setCompanySearch("");
                   }}
                   className="text-xs px-2 py-1 rounded"
-                  style={{ color: 'var(--bz-text-2)' }}
+                  style={{ color: "var(--bz-text-2)" }}
                 >
                   Change
                 </button>
@@ -279,7 +308,7 @@ export default function WorkspaceLKPMSubmitPage() {
               <>
                 <Search
                   className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
-                  style={{ color: 'var(--bz-text-2)' }}
+                  style={{ color: "var(--bz-text-2)" }}
                 />
                 <input
                   type="text"
@@ -293,14 +322,14 @@ export default function WorkspaceLKPMSubmitPage() {
                   placeholder="Search company by name, NIB, or NPWP..."
                   className="w-full rounded-lg border pl-9 pr-3 py-2 text-sm"
                   style={{
-                    background: 'var(--bz-surface)',
-                    borderColor: 'var(--bz-border)',
+                    background: "var(--bz-surface)",
+                    borderColor: "var(--bz-border)",
                   }}
                 />
                 {isSearchingCompanies && (
                   <Loader2
                     className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin"
-                    style={{ color: 'var(--bz-text-2)' }}
+                    style={{ color: "var(--bz-text-2)" }}
                   />
                 )}
 
@@ -309,8 +338,8 @@ export default function WorkspaceLKPMSubmitPage() {
                   <div
                     className="absolute z-10 w-full mt-1 rounded-lg border shadow-lg max-h-60 overflow-y-auto"
                     style={{
-                      background: 'var(--bz-card)',
-                      borderColor: 'var(--bz-border)',
+                      background: "var(--bz-card)",
+                      borderColor: "var(--bz-border)",
                     }}
                   >
                     {companies.length > 0 ? (
@@ -323,44 +352,55 @@ export default function WorkspaceLKPMSubmitPage() {
                             setShowCompanyDropdown(false);
                           }}
                           className="w-full text-left px-4 py-3 transition-colors flex items-center justify-between border-b last:border-0 hover:bg-[var(--bz-surface)]"
-                          style={{ borderColor: 'var(--bz-border)' }}
+                          style={{ borderColor: "var(--bz-border)" }}
                         >
                           <div>
-                            <p className="text-sm font-medium">{company.company_name}</p>
-                            <p className="text-xs" style={{ color: 'var(--bz-text-2)' }}>
-                              {[company.company_type, company.nib ? `NIB: ${company.nib}` : null]
+                            <p className="text-sm font-medium">
+                              {company.company_name}
+                            </p>
+                            <p
+                              className="text-xs"
+                              style={{ color: "var(--bz-text-2)" }}
+                            >
+                              {[
+                                company.company_type,
+                                company.nib ? `NIB: ${company.nib}` : null,
+                              ]
                                 .filter(Boolean)
-                                .join(' · ') || 'No details'}
+                                .join(" · ") || "No details"}
                             </p>
                           </div>
-                          {company.associates_count != null && company.associates_count > 0 && (
-                            <span
-                              className="text-xs px-2 py-0.5 rounded"
-                              style={{
-                                background: 'var(--bz-surface)',
-                                color: 'var(--bz-text-2)',
-                              }}
-                            >
-                              {company.associates_count} shareholder
-                              {company.associates_count > 1 ? 's' : ''}
-                            </span>
-                          )}
+                          {company.associates_count != null &&
+                            company.associates_count > 0 && (
+                              <span
+                                className="text-xs px-2 py-0.5 rounded"
+                                style={{
+                                  background: "var(--bz-surface)",
+                                  color: "var(--bz-text-2)",
+                                }}
+                              >
+                                {company.associates_count} shareholder
+                                {company.associates_count > 1 ? "s" : ""}
+                              </span>
+                            )}
                         </button>
                       ))
                     ) : (
                       <div
                         className="p-4 text-center text-sm"
-                        style={{ color: 'var(--bz-text-2)' }}
+                        style={{ color: "var(--bz-text-2)" }}
                       >
-                        {isSearchingCompanies ? 'Searching...' : 'No companies found'}
+                        {isSearchingCompanies
+                          ? "Searching..."
+                          : "No companies found"}
                       </div>
                     )}
                     {companies.length === 20 && (
                       <div
                         className="px-4 py-2 text-xs border-t"
                         style={{
-                          color: 'var(--bz-text-2)',
-                          borderColor: 'var(--bz-border)',
+                          color: "var(--bz-text-2)",
+                          borderColor: "var(--bz-border)",
                         }}
                       >
                         Showing top 20 results. Type more to refine search.
@@ -377,14 +417,17 @@ export default function WorkspaceLKPMSubmitPage() {
         <section
           className="rounded-xl border p-6 space-y-4"
           style={{
-            background: 'var(--bz-card)',
-            borderColor: 'var(--bz-border)',
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <h2 className="text-lg font-semibold">Periode Pelaporan</h2>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs mb-1" style={{ color: 'var(--bz-text-2)' }}>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Triwulan
               </label>
               <select
@@ -392,8 +435,8 @@ export default function WorkspaceLKPMSubmitPage() {
                 onChange={(e) => setQuarter(e.target.value)}
                 className="w-full rounded-lg border px-3 py-2 text-sm"
                 style={{
-                  background: 'var(--bz-surface)',
-                  borderColor: 'var(--bz-border)',
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
                 }}
               >
                 {QUARTERS.map((q) => (
@@ -404,7 +447,10 @@ export default function WorkspaceLKPMSubmitPage() {
               </select>
             </div>
             <div>
-              <label className="block text-xs mb-1" style={{ color: 'var(--bz-text-2)' }}>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Tahun
               </label>
               <select
@@ -412,8 +458,8 @@ export default function WorkspaceLKPMSubmitPage() {
                 onChange={(e) => setYear(Number(e.target.value))}
                 className="w-full rounded-lg border px-3 py-2 text-sm"
                 style={{
-                  background: 'var(--bz-surface)',
-                  borderColor: 'var(--bz-border)',
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
                 }}
               >
                 {[currentYear, currentYear - 1, currentYear - 2].map((y) => (
@@ -430,15 +476,15 @@ export default function WorkspaceLKPMSubmitPage() {
         <section
           className="rounded-xl border p-6 space-y-4"
           style={{
-            background: 'var(--bz-card)',
-            borderColor: 'var(--bz-border)',
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <h2 className="text-lg font-semibold">Realisasi Modal Tetap (Rp)</h2>
           <div className="grid grid-cols-1 gap-4">
             <div
               className="grid grid-cols-3 gap-3 text-xs font-medium"
-              style={{ color: 'var(--bz-text-2)' }}
+              style={{ color: "var(--bz-text-2)" }}
             >
               <span>Komponen</span>
               <span>Domestik</span>
@@ -446,10 +492,16 @@ export default function WorkspaceLKPMSubmitPage() {
             </div>
 
             {MODAL_TETAP.map((cat) => (
-              <div key={cat.key} className="grid grid-cols-3 gap-3 items-center">
+              <div
+                key={cat.key}
+                className="grid grid-cols-3 gap-3 items-center"
+              >
                 <div>
                   <span className="text-sm">{cat.label}</span>
-                  <p className="text-[10px] mt-0.5" style={{ color: 'var(--bz-text-2)' }}>
+                  <p
+                    className="text-[10px] mt-0.5"
+                    style={{ color: "var(--bz-text-2)" }}
+                  >
                     {cat.hint}
                   </p>
                 </div>
@@ -457,36 +509,46 @@ export default function WorkspaceLKPMSubmitPage() {
                   type="text"
                   inputMode="numeric"
                   value={formatNumber(investment[`${cat.key}_domestic`])}
-                  onChange={(e) => updateInvestment(`${cat.key}_domestic`, e.target.value)}
+                  onChange={(e) =>
+                    updateInvestment(`${cat.key}_domestic`, e.target.value)
+                  }
                   aria-label={`${cat.label} - Domestik`}
                   placeholder="0"
                   className="w-full rounded-lg border px-3 py-2 text-sm text-right"
                   style={{
-                    background: 'var(--bz-surface)',
-                    borderColor: 'var(--bz-border)',
+                    background: "var(--bz-surface)",
+                    borderColor: "var(--bz-border)",
                   }}
                 />
                 <input
                   type="text"
                   inputMode="numeric"
                   value={formatNumber(investment[`${cat.key}_import`])}
-                  onChange={(e) => updateInvestment(`${cat.key}_import`, e.target.value)}
+                  onChange={(e) =>
+                    updateInvestment(`${cat.key}_import`, e.target.value)
+                  }
                   aria-label={`${cat.label} - Impor`}
                   placeholder="0"
                   className="w-full rounded-lg border px-3 py-2 text-sm text-right"
                   style={{
-                    background: 'var(--bz-surface)',
-                    borderColor: 'var(--bz-border)',
+                    background: "var(--bz-surface)",
+                    borderColor: "var(--bz-border)",
                   }}
                 />
               </div>
             ))}
 
             {MODAL_TETAP_SINGLE.map((field) => (
-              <div key={field.key} className="grid grid-cols-3 gap-3 items-center">
+              <div
+                key={field.key}
+                className="grid grid-cols-3 gap-3 items-center"
+              >
                 <div>
                   <span className="text-sm">{field.label}</span>
-                  <p className="text-[10px] mt-0.5" style={{ color: 'var(--bz-text-2)' }}>
+                  <p
+                    className="text-[10px] mt-0.5"
+                    style={{ color: "var(--bz-text-2)" }}
+                  >
                     {field.hint}
                   </p>
                 </div>
@@ -499,8 +561,8 @@ export default function WorkspaceLKPMSubmitPage() {
                   placeholder="0"
                   className="w-full rounded-lg border px-3 py-2 text-sm text-right col-span-2"
                   style={{
-                    background: 'var(--bz-surface)',
-                    borderColor: 'var(--bz-border)',
+                    background: "var(--bz-surface)",
+                    borderColor: "var(--bz-border)",
                   }}
                 />
               </div>
@@ -512,13 +574,18 @@ export default function WorkspaceLKPMSubmitPage() {
         <section
           className="rounded-xl border p-6 space-y-4"
           style={{
-            background: 'var(--bz-card)',
-            borderColor: 'var(--bz-border)',
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <div>
-            <h2 className="text-lg font-semibold">Modal Kerja — 1 Turnover (Rp)</h2>
-            <p className="text-[10px] mt-1" style={{ color: 'var(--bz-text-2)' }}>
+            <h2 className="text-lg font-semibold">
+              Modal Kerja — 1 Turnover (Rp)
+            </h2>
+            <p
+              className="text-[10px] mt-1"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Bahan baku, gaji/upah, listrik-air-telepon, suku cadang, overhead
             </p>
           </div>
@@ -526,13 +593,15 @@ export default function WorkspaceLKPMSubmitPage() {
             type="text"
             inputMode="numeric"
             value={formatNumber(investment.working_capital)}
-            onChange={(e) => updateInvestment('working_capital', e.target.value)}
+            onChange={(e) =>
+              updateInvestment("working_capital", e.target.value)
+            }
             aria-label="Total modal kerja untuk 1 siklus operasional"
             placeholder="Total modal kerja untuk 1 siklus operasional"
             className="w-full rounded-lg border px-3 py-2 text-sm text-right"
             style={{
-              background: 'var(--bz-surface)',
-              borderColor: 'var(--bz-border)',
+              background: "var(--bz-surface)",
+              borderColor: "var(--bz-border)",
             }}
           />
         </section>
@@ -541,43 +610,49 @@ export default function WorkspaceLKPMSubmitPage() {
         <section
           className="rounded-xl border p-6 space-y-4"
           style={{
-            background: 'var(--bz-card)',
-            borderColor: 'var(--bz-border)',
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <h2 className="text-lg font-semibold">Realisasi Tenaga Kerja</h2>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs mb-1" style={{ color: 'var(--bz-text-2)' }}>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 TKI (Tenaga Kerja Indonesia)
               </label>
               <input
                 type="number"
                 min="0"
-                value={tki || ''}
+                value={tki || ""}
                 onChange={(e) => setTki(Number(e.target.value) || 0)}
                 placeholder="Jumlah karyawan lokal"
                 className="w-full rounded-lg border px-3 py-2 text-sm"
                 style={{
-                  background: 'var(--bz-surface)',
-                  borderColor: 'var(--bz-border)',
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
                 }}
               />
             </div>
             <div>
-              <label className="block text-xs mb-1" style={{ color: 'var(--bz-text-2)' }}>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 TKA (Tenaga Kerja Asing)
               </label>
               <input
                 type="number"
                 min="0"
-                value={tka || ''}
+                value={tka || ""}
                 onChange={(e) => setTka(Number(e.target.value) || 0)}
                 placeholder="Pemegang KITAS"
                 className="w-full rounded-lg border px-3 py-2 text-sm"
                 style={{
-                  background: 'var(--bz-surface)',
-                  borderColor: 'var(--bz-border)',
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
                 }}
               />
             </div>
@@ -588,14 +663,17 @@ export default function WorkspaceLKPMSubmitPage() {
         <section
           className="rounded-xl border p-6 space-y-4"
           style={{
-            background: 'var(--bz-card)',
-            borderColor: 'var(--bz-border)',
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <h2 className="text-lg font-semibold">Pendapatan (Rp)</h2>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs mb-1" style={{ color: 'var(--bz-text-2)' }}>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Pendapatan Triwulan
               </label>
               <input
@@ -603,18 +681,23 @@ export default function WorkspaceLKPMSubmitPage() {
                 inputMode="numeric"
                 value={formatNumber(revenueQuarterly)}
                 onChange={(e) =>
-                  setRevenueQuarterly(parseInt(e.target.value.replace(/\D/g, ''), 10) || 0)
+                  setRevenueQuarterly(
+                    parseInt(e.target.value.replace(/\D/g, ""), 10) || 0,
+                  )
                 }
                 placeholder="0"
                 className="w-full rounded-lg border px-3 py-2 text-sm text-right"
                 style={{
-                  background: 'var(--bz-surface)',
-                  borderColor: 'var(--bz-border)',
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
                 }}
               />
             </div>
             <div>
-              <label className="block text-xs mb-1" style={{ color: 'var(--bz-text-2)' }}>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Pendapatan Tahunan
               </label>
               <input
@@ -622,13 +705,15 @@ export default function WorkspaceLKPMSubmitPage() {
                 inputMode="numeric"
                 value={formatNumber(revenueAnnual)}
                 onChange={(e) =>
-                  setRevenueAnnual(parseInt(e.target.value.replace(/\D/g, ''), 10) || 0)
+                  setRevenueAnnual(
+                    parseInt(e.target.value.replace(/\D/g, ""), 10) || 0,
+                  )
                 }
                 placeholder="0"
                 className="w-full rounded-lg border px-3 py-2 text-sm text-right"
                 style={{
-                  background: 'var(--bz-surface)',
-                  borderColor: 'var(--bz-border)',
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
                 }}
               />
             </div>
@@ -639,14 +724,17 @@ export default function WorkspaceLKPMSubmitPage() {
         <section
           className="rounded-xl border p-6 space-y-4"
           style={{
-            background: 'var(--bz-card)',
-            borderColor: 'var(--bz-border)',
+            background: "var(--bz-card)",
+            borderColor: "var(--bz-border)",
           }}
         >
           <h2 className="text-lg font-semibold">Kendala & Rencana</h2>
           <div className="space-y-4">
             <div>
-              <label className="block text-xs mb-1" style={{ color: 'var(--bz-text-2)' }}>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Permasalahan yang Dihadapi
               </label>
               <textarea
@@ -656,13 +744,16 @@ export default function WorkspaceLKPMSubmitPage() {
                 rows={3}
                 className="w-full rounded-lg border px-3 py-2 text-sm resize-none"
                 style={{
-                  background: 'var(--bz-surface)',
-                  borderColor: 'var(--bz-border)',
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
                 }}
               />
             </div>
             <div>
-              <label className="block text-xs mb-1" style={{ color: 'var(--bz-text-2)' }}>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Rencana Kegiatan Berikutnya
               </label>
               <textarea
@@ -672,8 +763,8 @@ export default function WorkspaceLKPMSubmitPage() {
                 rows={3}
                 className="w-full rounded-lg border px-3 py-2 text-sm resize-none"
                 style={{
-                  background: 'var(--bz-surface)',
-                  borderColor: 'var(--bz-border)',
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
                 }}
               />
             </div>
@@ -686,14 +777,18 @@ export default function WorkspaceLKPMSubmitPage() {
             type="submit"
             disabled={isSubmitting || !selectedCompany}
             className="px-6 py-2.5 rounded-lg text-sm font-medium text-white flex items-center gap-2 disabled:opacity-50"
-            style={{ background: 'var(--bz-accent-warm)' }}
+            style={{ background: "var(--bz-accent-warm)" }}
           >
             {isSubmitting ? (
               <Loader2 className="w-4 h-4 animate-spin" />
             ) : (
               <Send className="w-4 h-4" />
             )}
-            {resolvingClient ? 'Memproses...' : isSubmitting ? 'Mengirim...' : 'Kirim Data'}
+            {resolvingClient
+              ? "Memproses..."
+              : isSubmitting
+                ? "Mengirim..."
+                : "Kirim Data"}
           </button>
         </div>
       </form>

--- a/apps/mouth/src/app/(workspace)/review/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.test.tsx
@@ -214,7 +214,9 @@ describe("ReviewPage", () => {
     });
 
     render(<ReviewPage />);
-    fireEvent.click((await screen.findAllByRole("button", { name: "Review" }))[0]);
+    fireEvent.click(
+      (await screen.findAllByRole("button", { name: "Review" }))[0],
+    );
 
     // Read-only notice is shown…
     expect(await screen.findByText(/already filed — view only/i)).toBeVisible();
@@ -257,7 +259,9 @@ describe("ReviewPage", () => {
     );
 
     render(<ReviewPage />);
-    fireEvent.click((await screen.findAllByRole("button", { name: "Review" }))[0]);
+    fireEvent.click(
+      (await screen.findAllByRole("button", { name: "Review" }))[0],
+    );
 
     expect(
       await screen.findByText(/claimed by another reviewer — view only/i),
@@ -280,7 +284,9 @@ describe("ReviewPage", () => {
     // beforeEach's apiMock.post already returns a claim_token on /claim.
 
     render(<ReviewPage />);
-    fireEvent.click((await screen.findAllByRole("button", { name: "Review" }))[0]);
+    fireEvent.click(
+      (await screen.findAllByRole("button", { name: "Review" }))[0],
+    );
 
     // The claim was attempted exactly once on the claim endpoint.
     await waitFor(() => expect(apiMock.post).toHaveBeenCalledTimes(1));
@@ -301,7 +307,9 @@ describe("ReviewPage", () => {
     });
 
     render(<ReviewPage />);
-    fireEvent.click((await screen.findAllByRole("button", { name: "Review" }))[0]);
+    fireEvent.click(
+      (await screen.findAllByRole("button", { name: "Review" }))[0],
+    );
 
     expect(
       await screen.findByText("Could not open the document."),

--- a/apps/mouth/src/app/(workspace)/review/page.tsx
+++ b/apps/mouth/src/app/(workspace)/review/page.tsx
@@ -133,10 +133,10 @@ const CARD = {
 function DecisionBadge({ decision }: { decision: string }) {
   const color =
     decision === "AUTO_ATTACH"
-      ? "var(--bz-success, #4db87a)"
+      ? "var(--state-success)"
       : decision === "NO_MATCH" || decision === "AMBIGUOUS"
-        ? "var(--bz-error, #d95f5a)"
-        : "var(--bz-warning, #d4923a)";
+        ? "var(--state-danger)"
+        : "var(--state-warning)";
   return (
     <span
       className="rounded px-2 py-0.5 text-xs font-medium"
@@ -804,7 +804,7 @@ export default function ReviewPage() {
         <div
           className="mb-4 rounded-md border px-4 py-2 text-sm"
           style={{
-            borderColor: "var(--bz-error, #d95f5a)",
+            borderColor: "var(--state-danger)",
             color: "var(--bz-text-1)",
           }}
         >
@@ -815,7 +815,7 @@ export default function ReviewPage() {
         <div
           className="mb-4 rounded-md border px-4 py-2 text-sm"
           style={{
-            borderColor: "var(--bz-success, #2e9e6b)",
+            borderColor: "var(--state-success)",
             color: "var(--bz-text-1)",
           }}
         >
@@ -826,7 +826,7 @@ export default function ReviewPage() {
       {loading ? (
         <p style={{ color: "var(--bz-text-3)" }}>Loading…</p>
       ) : !error && items.length === 0 ? (
-        <p style={{ color: "var(--bz-success, #2e9e6b)" }}>
+        <p style={{ color: "var(--state-success)" }}>
           ✓ No documents to review.
         </p>
       ) : (
@@ -898,7 +898,7 @@ export default function ReviewPage() {
       {detail && (
         <div
           className="fixed inset-0 z-50 flex items-end justify-center p-4 sm:items-center"
-          style={{ background: "rgba(0,0,0,0.55)" }}
+          style={{ background: "var(--surface-overlay)" }}
           onClick={() => void closeDetail()}
         >
           <div
@@ -928,7 +928,7 @@ export default function ReviewPage() {
                 className="mb-3 rounded-md border px-3 py-2 text-sm"
                 role="status"
                 style={{
-                  borderColor: "var(--bz-warning, #d4923a)",
+                  borderColor: "var(--state-warning)",
                   color: "var(--bz-text-1)",
                 }}
               >
@@ -1060,7 +1060,7 @@ export default function ReviewPage() {
                   <div
                     className="rounded-md border p-3"
                     style={{
-                      borderColor: "var(--bz-accent, #d4845a)",
+                      borderColor: "var(--bz-accent)",
                       background: "var(--bz-surface)",
                     }}
                   >
@@ -1128,7 +1128,7 @@ export default function ReviewPage() {
                       onClick={() => void createAndApprove()}
                       className="mt-3 w-full rounded-md px-4 py-2 text-sm font-medium text-white"
                       style={{
-                        background: "var(--bz-accent, #d4845a)",
+                        background: "var(--bz-accent)",
                         opacity:
                           createBusy ||
                           busy === detail.proposal_id ||
@@ -1164,7 +1164,7 @@ export default function ReviewPage() {
                           style={{
                             borderColor:
                               selectedClient?.client_id === c.client_id
-                                ? "var(--bz-accent, #d4845a)"
+                                ? "var(--bz-accent)"
                                 : "var(--bz-border)",
                             color: "var(--bz-text-1)",
                           }}
@@ -1284,7 +1284,7 @@ export default function ReviewPage() {
                         type="button"
                         onClick={() => setShowCreateForm(true)}
                         className="mt-2 text-xs underline"
-                        style={{ color: "var(--bz-accent, #d4845a)" }}
+                        style={{ color: "var(--bz-accent)" }}
                       >
                         ➕ None of these — create a new client
                       </button>
@@ -1404,8 +1404,8 @@ export default function ReviewPage() {
                   className="rounded-md border px-3 py-2 text-sm"
                   style={{
                     borderColor: selectedClient
-                      ? "var(--bz-success, #2e9e6b)"
-                      : "var(--bz-warning, #d4923a)",
+                      ? "var(--state-success)"
+                      : "var(--state-warning)",
                     color: "var(--bz-text-1)",
                   }}
                 >
@@ -1430,7 +1430,7 @@ export default function ReviewPage() {
                     onClick={() => void decide("approve")}
                     className="flex-1 rounded-md px-4 py-2 text-sm font-medium text-white"
                     style={{
-                      background: "var(--bz-success, #2e9e6b)",
+                      background: "var(--state-success)",
                       opacity:
                         busy === detail.proposal_id ||
                         !claimToken ||
@@ -1447,7 +1447,7 @@ export default function ReviewPage() {
                     onClick={() => void decide("reject")}
                     className="flex-1 rounded-md px-4 py-2 text-sm font-medium text-white"
                     style={{
-                      background: "var(--bz-error, #d95f5a)",
+                      background: "var(--state-danger)",
                       opacity:
                         busy === detail.proposal_id || !claimToken ? 0.6 : 1,
                     }}


### PR DESCRIPTION
## WS2 kita slice 2 — lkpm, review, accounting token-clean

**Author:** Kimi (builder) · **Contract:** author never merges. Dark operative theme — token alignment, not a light pass.

### What (5 pages, ~104 drift drained)
- **lkpm list** (~58 hits): status maps → `--state-*` color-mix tints (slice-1 idiom); purple → `--bz-neon-purple`; archived → neutral; borders → `--bz-border`; bespoke gradients → dashboard panel recipe; filter glow → `--bz-accent-glow` (byte-identical); amounts → `Money`
- **review**: `var(--bz-*, #hex)` fallbacks dropped; statuses → `--state-*`; overlay → `--surface-overlay`
- **lkpm/[id]**: receipt/validation/dots → `--state-*`; grand total → `Money`
- **accounting**: emerald/rose/amber utilities → `--state-*` tints; amounts → `Money`
- **lkpm/submit**: asterisk → `--state-danger`; gold card → `--bz-accent-warm` color-mix (byte-faithful kita gold)

### Verification (this turn)
- Workspace suite: **251/251** (+25 new guard tests mirroring slice-1's contract: 0 hex, 0 status rgba tuples, 0 palette utilities, markers on assertion strings) · tsc 0 errors · token-lint clean

### Shared-chrome candidates (report only)
Panel recipe `rgba(35,35,40,0.65)` now repeats 6×+ across pages → future `--bz-bg-panel`; status→token map duplicated across 2 components → future core `StatusBadge`.

### Notes
- `--no-verify` push (established rationale).
- Next: slice 3 intelligence studio (news-room, composer, visa-oracle — the heaviest rgba drift, 227 hits).