### PR TITLE
fix(kbli): stop printing internal pipeline symbols at KBLI readers

### DIFF
--- a/apps/mouth/src/components/kbli/BaliStatusBadge.tsx
+++ b/apps/mouth/src/components/kbli/BaliStatusBadge.tsx
@@ -1,3 +1,4 @@
+import { BALI_STATUS_CONFIG } from "@/lib/kbli-status-labels";
 import { cn } from "@/lib/utils";
 
 // L4 Bali status — the sovereign-local layer. National PMA openness (L2) != Bali registrability (L4).
@@ -34,90 +35,9 @@ interface BaliStatusBadgeProps {
   size?: "sm" | "md";
 }
 
-const config: Record<
-  string,
-  { label: string; icon: string; tone: "ok" | "warn" | "block" }
-> = {
-  OK_or_HIGHER_RISK: { label: "Registrable in Bali", icon: "✅", tone: "ok" },
-  // Nationally TERBUKA and the Besar scale is Menengah-Tinggi/Tinggi → survives the
-  // Bali risk-class moratorium → registrable by a PT PMA in Bali (#1814 risk-tier pass).
-  APERTO_BALI_RISCHIO_ALTO: {
-    label: "Open in Bali (high-risk tier)",
-    icon: "✅",
-    tone: "ok",
-  },
-  BLOCCATO_CLASSE_RISCHIO: {
-    label: "Blocked in Bali (risk-class moratorium)",
-    icon: "🚫",
-    tone: "block",
-  },
-  // Nationally TERBUKA but the Besar scale is Rendah/Menengah-Rendah → blocked by the
-  // 2026 Bali PMA moratorium (Gov. letter B.27.000/642). Resolved by #1814 risk-tier pass.
-  CHIUSO_MORATORIA_BALI: {
-    label: "Closed in Bali (2026 moratorium)",
-    icon: "🚫",
-    tone: "block",
-  },
-  // Closed by a national sector regulator regardless of risk tier (e.g. Bank Indonesia,
-  // BAPETEN) — structurally closed to private/PMA capital. Resolved by #1814.
-  CHIUSO_REGOLATORE_SETTORIALE: {
-    label: "Closed (sector regulator)",
-    icon: "🚫",
-    tone: "block",
-  },
-  // Besar-scale risk is low on some ruang lingkup but higher on others: OSS computes
-  // risk per (code × scope × scale), so registrability depends on the declared scope.
-  // (deep research 2026-06-20: rejection is on "tingkat risiko", not on the code.)
-  BLOCCATO_DIPENDE_SCOPE: {
-    label: "Conditional in Bali — depends on declared scope",
-    icon: "⚠️",
-    tone: "warn",
-  },
-  // No Usaha Besar scale row in OSS → activity reserved for cooperatives/MSME under
-  // Perpres 10/2021 (amended 49/2021), Lampiran II Pasal 5(1)(a). A PT PMA is Usaha
-  // Besar by law (UU 6/2023 + Permeninves 5/2025) and cannot register it.
-  CHIUSO_PMA_NO_BESAR: {
-    label: "Reserved for MSME — closed to PT PMA",
-    icon: "🚫",
-    tone: "block",
-  },
-  // No OSS-RBA risk scope at all (404): special/sectoral regime — finance (OJK/BI),
-  // pharma (BPOM), and other sensitive activities licensed outside the ordinary RBA
-  // flow. Not mechanically caught by the low-risk Bali block → verify case-by-case.
-  NEEDS_REVIEW_NO_OSS_SCOPE: {
-    label: "Special regime — verify case-by-case",
-    icon: "❓",
-    tone: "warn",
-  },
-  CHIUSO_BALI: { label: "Closed for PMA in Bali", icon: "🚫", tone: "block" },
-  CHIUSO_BALI_PROPOSTO: {
-    label: "Closure proposed (Bali)",
-    icon: "⚠️",
-    tone: "warn",
-  },
-  TERTUTUP: { label: "Closed to foreigners", icon: "🚫", tone: "block" },
-  TERBATAS: { label: "Restricted (foreign cap)", icon: "⚠️", tone: "warn" },
-  TERTUTUP_CANDIDATE: {
-    label: "Likely closed — verify",
-    icon: "❓",
-    tone: "warn",
-  },
-  TERBATAS_CANDIDATE: {
-    label: "Likely restricted — verify",
-    icon: "❓",
-    tone: "warn",
-  },
-  // GARUDA-FILIERA Fase-1 cure #4 (2026-07-17): the risk tier this verdict
-  // depended on was carried over from a different activity through a
-  // code-number collision and has been detached — the moratorium
-  // applicability is genuinely unresolved, not "verify a special regime"
-  // (NEEDS_REVIEW_NO_OSS_SCOPE) or a known ok/blocked verdict.
-  NON_CLASSIFICABILE: {
-    label: "Bali status not classifiable — verify",
-    icon: "❓",
-    tone: "warn",
-  },
-};
+// The label/icon/tone table now lives in `@/lib/kbli-status-labels` so the editorial
+// renderer resolves a status to the SAME words this badge shows. Values unchanged.
+const config = BALI_STATUS_CONFIG;
 
 const toneClass = {
   ok: "bg-[var(--kbli-pma-open-bg)] text-[var(--kbli-pma-open)] border-[var(--kbli-pma-open)]/20",

--- a/apps/mouth/src/components/kbli/KBLIEditorial.tsx
+++ b/apps/mouth/src/components/kbli/KBLIEditorial.tsx
@@ -1,4 +1,8 @@
 import { MarkdownClient } from "@/components/kbli/MarkdownClient";
+import {
+  humanizeInternalEnums,
+  humanizeStatValue,
+} from "@/lib/kbli-status-labels";
 import type { KBLIEditorialContent } from "@/lib/kbli-types";
 
 /**
@@ -6,23 +10,35 @@ import type { KBLIEditorialContent } from "@/lib/kbli-types";
  * page leads with: display headline, standfirst dek, "By the numbers" sidebar
  * card, editorial body, pull-quote. Server component, no client JS of its own.
  * Content arrives only through scripts/kbli_apply_editorials.py gates, so this
- * component renders it verbatim (markdown body via MarkdownClient).
+ * component renders it verbatim (markdown body via MarkdownClient) — with ONE
+ * exception: internal pipeline symbols are resolved to the labels the KBLI
+ * badges already use (see `@/lib/kbli-status-labels`). The editorial pass
+ * authored these articles by narrating the JSON record, so `OK_or_HIGHER_RISK`
+ * reached readers on 908 "By the numbers" cells and 725 times inside prose.
+ * The mapping changes no verdict — symbol and label denote the same fact.
  */
-export function KBLIEditorial({ editorial }: { editorial: KBLIEditorialContent }) {
+export function KBLIEditorial({
+  editorial,
+}: {
+  editorial: KBLIEditorialContent;
+}) {
   return (
     <article className="relative">
       <header className="mb-8" style={{ maxWidth: "820px" }}>
         <h2
           className="mb-4 font-bold leading-tight"
-          style={{ fontSize: "clamp(1.6rem, 3.2vw, 2.4rem)", letterSpacing: "-0.02em" }}
+          style={{
+            fontSize: "clamp(1.6rem, 3.2vw, 2.4rem)",
+            letterSpacing: "-0.02em",
+          }}
         >
-          {editorial.headline}
+          {humanizeInternalEnums(editorial.headline)}
         </h2>
         <p
           className="leading-relaxed"
           style={{ fontSize: "1.125rem", color: "var(--kbli-text-secondary)" }}
         >
-          {editorial.standfirst}
+          {humanizeInternalEnums(editorial.standfirst)}
         </p>
       </header>
 
@@ -49,7 +65,9 @@ export function KBLIEditorial({ editorial }: { editorial: KBLIEditorialContent }
                 >
                   {n.label}
                 </dt>
-                <dd className="mt-0.5 text-sm font-semibold">{n.value}</dd>
+                <dd className="mt-0.5 text-sm font-semibold">
+                  {humanizeStatValue(n.value)}
+                </dd>
               </div>
             ))}
           </dl>
@@ -57,7 +75,9 @@ export function KBLIEditorial({ editorial }: { editorial: KBLIEditorialContent }
       )}
 
       <div className="kbli-prose" style={{ maxWidth: "720px" }}>
-        <MarkdownClient withKbliLinks>{editorial.body}</MarkdownClient>
+        <MarkdownClient withKbliLinks>
+          {humanizeInternalEnums(editorial.body)}
+        </MarkdownClient>
       </div>
 
       {editorial.pullQuote && (
@@ -69,7 +89,7 @@ export function KBLIEditorial({ editorial }: { editorial: KBLIEditorialContent }
             maxWidth: "640px",
           }}
         >
-          {editorial.pullQuote}
+          {humanizeInternalEnums(editorial.pullQuote)}
         </blockquote>
       )}
     </article>

--- a/apps/mouth/src/lib/kbli-data.server.ts
+++ b/apps/mouth/src/lib/kbli-data.server.ts
@@ -1,3 +1,7 @@
+import {
+  humanizeInternalEnums,
+  humanizeIntelBlock,
+} from "@/lib/kbli-status-labels";
 import fs from "fs";
 import path from "path";
 import type {
@@ -128,9 +132,22 @@ export function getCode(code: string): KBLICode | undefined {
   return loadAllCodes().map.get(code);
 }
 
-/** Get gold content for a single code */
+/**
+ * Get gold content for a single code.
+ *
+ * Cured at THIS choke point, not at the call sites: the gold layout on
+ * `/kbli/[code]` renders `gold.whatChanged` / `gold.whatYouNeed` /
+ * `gold.baliContext` / `gold.zantaraOpener` / `gold.tkaInfo` DIRECTLY, bypassing
+ * `transformCode`'s merged `intel` entirely — so the loader cure never reached
+ * them and 113 of the 428 gold codes were still printing `MATCH_CON_AGGREGAZIONE`
+ * and friends at readers (whatChanged 111, whatYouNeed 11, baliContext 3,
+ * zantaraOpener 2). Curing the accessor covers the page, `/api/kbli/gold/[code]`
+ * and any future consumer at once. Found by the adversarial review of this
+ * change, then re-measured against the gold file before fixing.
+ */
 export function getGoldContent(code: string): KBLIGoldContent | null {
-  return loadGoldData()[code] ?? null;
+  const raw = loadGoldData()[code];
+  return raw ? humanizeIntelBlock(raw) : null;
 }
 
 /** Check if a code has gold content */
@@ -243,27 +260,32 @@ function transformCode(
   const goldBaliMisleads =
     !!raw.l4_bali?.blocked &&
     /\b(PT PMA|100% foreign|foreign-owned|open to foreign)\b/i.test(goldBali);
-  const intel = goldEntry
-    ? {
-        whatItMeans: goldEntry.whatItMeans || "",
-        whatYouNeed: goldEntry.whatYouNeed || "",
-        whatChanged: goldEntry.whatChanged || "",
-        baliContext: goldBaliMisleads && liveBali ? liveBali : goldBali,
-        zantaraOpener: goldEntry.zantaraOpener || "",
-        youllAlsoNeed: goldEntry.youllAlsoNeed || "",
-        coverImage: raw.intel_2026?.coverImage || null,
-      }
-    : raw.intel_2026
+  // Internal pipeline symbols resolved to the labels the badges use — the gold
+  // layer inherited the same narration, so it needs the same pass. Presentation
+  // only; no verdict changes. See @/lib/kbli-status-labels.
+  const intel = humanizeIntelBlock(
+    goldEntry
       ? {
-          whatItMeans: raw.intel_2026.whatItMeans || "",
-          whatYouNeed: raw.intel_2026.whatYouNeed || "",
-          whatChanged: raw.intel_2026.whatChanged || "",
-          baliContext: raw.intel_2026.baliContext || "",
-          zantaraOpener: raw.intel_2026.zantaraOpener || "",
-          youllAlsoNeed: raw.intel_2026.youllAlsoNeed || "",
-          coverImage: raw.intel_2026.coverImage || null,
+          whatItMeans: goldEntry.whatItMeans || "",
+          whatYouNeed: goldEntry.whatYouNeed || "",
+          whatChanged: goldEntry.whatChanged || "",
+          baliContext: goldBaliMisleads && liveBali ? liveBali : goldBali,
+          zantaraOpener: goldEntry.zantaraOpener || "",
+          youllAlsoNeed: goldEntry.youllAlsoNeed || "",
+          coverImage: raw.intel_2026?.coverImage || null,
         }
-      : undefined;
+      : raw.intel_2026
+        ? {
+            whatItMeans: raw.intel_2026.whatItMeans || "",
+            whatYouNeed: raw.intel_2026.whatYouNeed || "",
+            whatChanged: raw.intel_2026.whatChanged || "",
+            baliContext: raw.intel_2026.baliContext || "",
+            zantaraOpener: raw.intel_2026.zantaraOpener || "",
+            youllAlsoNeed: raw.intel_2026.youllAlsoNeed || "",
+            coverImage: raw.intel_2026.coverImage || null,
+          }
+        : undefined,
+  );
 
   return {
     code,
@@ -315,7 +337,10 @@ function transformCode(
     baliL4: raw.l4_bali?.status
       ? {
           status: raw.l4_bali.status,
-          reason: raw.l4_bali.reason || "",
+          // Reader-facing prose (badge tooltip + generated FAQ answer) — cured like
+          // the editorial layer. `_data_note` deliberately stays verbatim: there the
+          // symbol is cited AS EVIDENCE of divergence, not narrated at a reader.
+          reason: humanizeInternalEnums(raw.l4_bali.reason || ""),
           confidence: raw.l4_bali.confidence || "MEDIUM",
           needsReview: !!raw.l4_bali.needs_review,
           blocked: !!raw.l4_bali.blocked,

--- a/apps/mouth/src/lib/kbli-data.ts
+++ b/apps/mouth/src/lib/kbli-data.ts
@@ -4,6 +4,10 @@
 // Runs server-side at build time (Next.js static generation).
 // =============================================================================
 
+import {
+  humanizeInternalEnums,
+  humanizeIntelBlock,
+} from "@/lib/kbli-status-labels";
 import fs from "fs";
 import path from "path";
 import type {
@@ -452,14 +456,24 @@ function transformRecord(raw: KBLIRawCode): KBLICode {
     transition,
     tier: assignTier(code),
     keywords: extractKeywords(raw.judul, raw.uraian),
-    intel_2026: raw.intel_2026,
+    // Internal pipeline symbols (OK_or_HIGHER_RISK, BPS_ONLY, …) are resolved to
+    // the labels the KBLI badges use, at the loader, so no reader-facing surface
+    // can leak one by being the surface nobody remembered to wrap. Presentation
+    // only — the verdict itself is untouched. See @/lib/kbli-status-labels.
+    intel_2026: humanizeIntelBlock(raw.intel_2026),
     // L4 — Bali sovereign-local status (national PMA openness != Bali registrability).
     // Mirrors the transform in kbli-data.server.ts; this is the module the
     // /kbli/[code] page actually consumes via getCode()/getAllCodes().
     baliL4: raw.l4_bali?.status
       ? {
           status: raw.l4_bali.status,
-          reason: raw.l4_bali.reason || "",
+          // Reader-facing prose: it is the badge tooltip AND is embedded verbatim
+          // into the generated FAQ answer (kbli-faq.ts). 8 codes narrate
+          // "Previous status: OK_or_HIGHER_RISK" — same cure as the editorial layer.
+          // NOTE the deliberate asymmetry with `_data_note`, which is NOT humanised:
+          // there the symbol is a verbatim CITATION of the canonical record used as
+          // divergence evidence, and rewriting evidence would corrupt the audit trail.
+          reason: humanizeInternalEnums(raw.l4_bali.reason || ""),
           confidence: raw.l4_bali.confidence || "MEDIUM",
           needsReview: !!raw.l4_bali.needs_review,
           blocked: !!raw.l4_bali.blocked,

--- a/apps/mouth/src/lib/kbli-internal-leak.test.ts
+++ b/apps/mouth/src/lib/kbli-internal-leak.test.ts
@@ -1,0 +1,214 @@
+// =============================================================================
+// INTERNAL-LEAK GATE — measured on the REAL canonical, not on fixtures.
+//
+// The editorial pass authored the 1,559 articles by narrating the JSON record,
+// so pipeline vocabulary reached readers. Two distinct leaks, measured
+// 2026-07-25 on `data/KBLI_2025_FINAL_CLEAN.json`:
+//
+//   (a) SYMBOLS — `OK_or_HIGHER_RISK`, `BPS_ONLY`, … : 908 "By the numbers"
+//       cells + 725 occurrences in editorial prose. CURED at render by
+//       `humanizeIntelBlock` (kbli-status-labels.ts). This file proves the cure
+//       covers the whole catalogue, on the real data, and stays at zero.
+//
+//   (b) RAW FIELD NAMES — `l4_bali_blocked is false`, `pma_max_asing`, … on 392
+//       codes. NOT curable by a label map: the sentences have to be rewritten.
+//       That is a data-plane job (editorial regeneration). Until then this file
+//       PINS the debt with a ratchet: the count may fall, never rise. A silent
+//       re-growth is the failure mode this gate exists to make impossible.
+//
+// Rationale for gating (b) instead of ignoring it: an unmeasured defect that
+// only a human eye can see is a defect that grows. Superscar #2 — "esiste ≠
+// armato": a cure with no probe is a cure you cannot prove tomorrow.
+// =============================================================================
+
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+import { deriveProvenance } from "./kbli-provenance";
+import {
+  INTERNAL_ENUM_LABELS,
+  humanizeInternalEnums,
+  humanizeIntelBlock,
+} from "./kbli-status-labels";
+import type { KBLIRawDataFile } from "./kbli-types";
+
+// Anchored to this file, not to cwd: the gate must give the same verdict whether
+// vitest is invoked from apps/mouth (CI) or from the repo root (local sweep).
+const DATA_PATH = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../../data/KBLI_2025_FINAL_CLEAN.json",
+);
+const GOLD_PATH = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../../data/kbli-gold-all.json",
+);
+
+/**
+ * Every string anywhere under `intel_2026`, collected GENERICALLY.
+ *
+ * Deliberately NOT an allow list of known fields: an allow list is blind to the
+ * next field somebody adds, and that is exactly how `whoThisIsFor` (1,186
+ * records, rendered at kbli/[code]/page.tsx) escaped both the cure and the first
+ * draft of this gate. Walking everything makes the gate fail-closed — a new
+ * reader-facing field is covered the day it appears.
+ *
+ * The two structural keys skipped here MUST match `INTEL_NON_READER_KEYS` in the
+ * cure; they are re-declared rather than imported so this gate keeps an
+ * independent opinion of what a reader sees, instead of grading the cure with
+ * the cure's own definition.
+ */
+const NON_READER_KEYS = new Set(["_l3_regen", "coverImage"]);
+
+function readerFacingStrings(node: unknown, acc: string[] = []): string[] {
+  if (typeof node === "string") {
+    acc.push(node);
+  } else if (Array.isArray(node)) {
+    for (const item of node) readerFacingStrings(item, acc);
+  } else if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(
+      node as Record<string, unknown>,
+    )) {
+      if (!NON_READER_KEYS.has(key)) readerFacingStrings(value, acc);
+    }
+  }
+  return acc;
+}
+
+function loadCanonical() {
+  const parsed = JSON.parse(
+    fs.readFileSync(DATA_PATH, "utf-8"),
+  ) as KBLIRawDataFile;
+  return parsed.data;
+}
+
+const SYMBOL_RE = new RegExp(
+  `(?<![A-Za-z0-9_])(${Object.keys(INTERNAL_ENUM_LABELS)
+    .sort((a, b) => b.length - a.length)
+    .join("|")})(?![A-Za-z0-9_])`,
+);
+
+/**
+ * Raw canonical field names. Word-boundary anchored (never bare substring,
+ * superscar #3) and ordered longest-first only for reporting clarity.
+ */
+const RAW_FIELD_NAMES = [
+  "l4_bali_blocked",
+  "l4_bali",
+  "per_skala_disputed",
+  "per_skala_legacy",
+  "per_skala",
+  "_l2_status",
+  "_l2_source",
+  "_data_note",
+  "pp28_sources",
+  "status_mapping",
+  "ruang_lingkup",
+  "intel_2026",
+  "pma_max_asing",
+  "pma_kondisi",
+  "bps_2020_ancestors",
+];
+const FIELD_RE = new RegExp(
+  `(?<![A-Za-z0-9_])(${RAW_FIELD_NAMES.join("|")})(?![A-Za-z0-9_])`,
+);
+
+describe("internal-leak gate (real canonical)", () => {
+  const records = loadCanonical();
+
+  it("loads the full catalogue", () => {
+    expect(records.length).toBe(1559);
+  });
+
+  it("the raw data still carries the symbol leak this cure exists for", () => {
+    // Guilt side of the gate: if this ever hits zero the cure has become
+    // unnecessary at render (the data was fixed upstream) and this file should
+    // be revisited rather than left asserting a cure nothing needs.
+    const leaking = records.filter((r) =>
+      readerFacingStrings(r.intel_2026).some((s) => SYMBOL_RE.test(s)),
+    );
+    expect(leaking.length).toBeGreaterThan(0);
+  });
+
+  it("ZERO internal symbols survive the render-layer cure, across all 1,559", () => {
+    const survivors: { code: string; sample: string }[] = [];
+    for (const r of records) {
+      for (const s of readerFacingStrings(humanizeIntelBlock(r.intel_2026))) {
+        const m = s.match(SYMBOL_RE);
+        if (m) survivors.push({ code: r.kode_kbli_2025, sample: m[0] });
+      }
+    }
+    expect(survivors.slice(0, 10)).toEqual([]);
+    expect(survivors.length).toBe(0);
+  });
+
+  it("l4_bali.reason is cured too — it is a tooltip AND is embedded in the FAQ answer", () => {
+    // 8 codes narrate "Previous status: OK_or_HIGHER_RISK" inside the Bali reason,
+    // which kbli-faq.ts splices verbatim into a client-facing answer.
+    const leaking = records.filter(
+      (r) =>
+        typeof r.l4_bali?.reason === "string" &&
+        SYMBOL_RE.test(r.l4_bali.reason),
+    );
+    expect(leaking.length).toBeGreaterThan(0); // guilt: the defect is real
+    for (const r of leaking) {
+      expect(SYMBOL_RE.test(humanizeInternalEnums(r.l4_bali!.reason!))).toBe(
+        false,
+      );
+    }
+  });
+
+  it("INNOCENCE: `_data_note` is evidence and must stay verbatim, symbols included", () => {
+    // 88 codes cite the canonical record AS PROOF of a divergence — e.g.
+    // "carries canonical status_mapping='CODICE_RINUMERATO', pp28_sources=[…]".
+    // KBLIDivergence renders this verbatim as an audit trail. Rewriting a quoted
+    // symbol would edit the evidence, so the cure must NOT reach this field: no
+    // loader humanises `_data_note`, and this test fails if one ever starts.
+    const withSymbol = records.filter(
+      (r) => typeof r._data_note === "string" && SYMBOL_RE.test(r._data_note),
+    );
+    expect(withSymbol.length).toBeGreaterThan(0);
+
+    const provenanceNotes = records
+      .map((r) => deriveProvenance(r).dataNote)
+      .filter((n): n is string => typeof n === "string");
+    const stillQuoting = provenanceNotes.filter((n) => SYMBOL_RE.test(n));
+    expect(stillQuoting.length).toBe(withSymbol.length);
+  });
+
+  it("covers the GOLD layer too — the surface the code page renders directly", () => {
+    // The gold layout on /kbli/[code] renders gold.whatChanged & co. straight
+    // from getGoldContent(), never through transformCode's merged intel. The
+    // first draft of this cure missed it entirely: 113 of 428 gold codes were
+    // still printing symbols. A canonical-only gate cannot see this file, so it
+    // is measured here explicitly.
+    const gold = JSON.parse(fs.readFileSync(GOLD_PATH, "utf-8"));
+    const entries: Record<string, unknown> = gold.data ?? gold;
+    const codes = Object.keys(entries);
+    expect(codes.length).toBeGreaterThan(400);
+
+    const rawLeaking = codes.filter((c) =>
+      readerFacingStrings(entries[c]).some((s) => SYMBOL_RE.test(s)),
+    );
+    expect(rawLeaking.length).toBeGreaterThan(0); // guilt: the defect is real
+
+    const curedLeaking = codes.filter((c) =>
+      readerFacingStrings(humanizeIntelBlock(entries[c])).some((s) =>
+        SYMBOL_RE.test(s),
+      ),
+    );
+    expect(curedLeaking).toEqual([]);
+  });
+
+  it("pins the raw-field-name debt with a ratchet — it may fall, never rise", () => {
+    // Measured 2026-07-25 on the canonical: 392 codes narrate a raw field name
+    // (`l4_bali_blocked is false`, `pma_max_asing`, …) inside editorial prose.
+    // Only an editorial rewrite can remove these; a label map cannot. When a
+    // regeneration lot lands, LOWER this number — never raise it.
+    const BASELINE = 392;
+    const leaking = records.filter((r) =>
+      readerFacingStrings(r.intel_2026).some((s) => FIELD_RE.test(s)),
+    );
+    expect(leaking.length).toBeLessThanOrEqual(BASELINE);
+  });
+});

--- a/apps/mouth/src/lib/kbli-status-labels.test.ts
+++ b/apps/mouth/src/lib/kbli-status-labels.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BALI_STATUS_CONFIG,
+  INTERNAL_ENUM_LABELS,
+  humanizeInternalEnums,
+  humanizeIntelBlock,
+  humanizeStatValue,
+} from "./kbli-status-labels";
+
+/**
+ * GUILT + INNOCENCE, per cicatrix superscar #3: a guard that only proves it
+ * fires is half a guard. Every "it resolves X" here has a sibling proving it
+ * leaves the neighbouring legitimate string alone.
+ */
+describe("humanizeStatValue — structured cells", () => {
+  // ---- GUILT: the symbols that actually reached readers -------------------
+  it("resolves the symbol that leaked onto 908 By-the-numbers cells", () => {
+    expect(humanizeStatValue("OK_or_HIGHER_RISK")).toBe("Registrable in Bali");
+  });
+
+  it("resolves every Bali symbol that is not a term of art", () => {
+    expect(humanizeStatValue("CHIUSO_MORATORIA_BALI")).toBe(
+      "Closed in Bali (2026 moratorium)",
+    );
+    expect(humanizeStatValue("BLOCCATO_CLASSE_RISCHIO")).toBe(
+      "Blocked in Bali (risk-class moratorium)",
+    );
+    expect(humanizeStatValue("NON_CLASSIFICABILE")).toBe(
+      "Bali status not classifiable — verify",
+    );
+    expect(humanizeStatValue("CHIUSO_PMA_NO_BESAR")).toBe(
+      "Reserved for MSME — closed to PT PMA",
+    );
+  });
+
+  it("resolves the crosswalk symbols to the TransitionBadge wording", () => {
+    expect(humanizeStatValue("BPS_ONLY")).toBe("New in 2025");
+    expect(humanizeStatValue("MATCH_LANGSUNG")).toBe("Direct Match");
+    expect(humanizeStatValue("CODICE_RINUMERATO")).toBe("Renumbered");
+    expect(humanizeStatValue("MATCH_CON_AGGREGAZIONE")).toBe("Aggregated");
+  });
+
+  it("tolerates surrounding whitespace on a structured cell", () => {
+    expect(humanizeStatValue("  OK_or_HIGHER_RISK ")).toBe(
+      "Registrable in Bali",
+    );
+  });
+
+  // ---- INNOCENCE: what must survive untouched -----------------------------
+  it("leaves the Indonesian terms of art alone — they are the product's vocabulary", () => {
+    expect(humanizeStatValue("TERBUKA")).toBe("TERBUKA");
+    expect(humanizeStatValue("TERTUTUP")).toBe("TERTUTUP");
+    expect(humanizeStatValue("TERBATAS")).toBe("TERBATAS");
+  });
+
+  it("never translates TERBUKA's siblings asymmetrically", () => {
+    // The three terms travel together in the annexes; humanising only the
+    // negative ones would make the same sidebar bilingual with itself.
+    const terms = ["TERBUKA", "TERTUTUP", "TERBATAS"];
+    for (const t of terms) expect(humanizeStatValue(t)).toBe(t);
+  });
+
+  it("leaves ordinary editorial cell values byte-identical", () => {
+    for (const v of [
+      "100%",
+      "Perpres 10/2021, 49/2021",
+      "Rp 2.5 billion",
+      "Menengah Tinggi",
+      "None retrievable (404)",
+      "",
+    ]) {
+      expect(humanizeStatValue(v)).toBe(v);
+    }
+  });
+
+  it("does not resolve an unknown symbol by guessing a near neighbour", () => {
+    expect(humanizeStatValue("OK_or_LOWER_RISK")).toBe("OK_or_LOWER_RISK");
+    expect(humanizeStatValue("BPS_ONLY_2020")).toBe("BPS_ONLY_2020");
+    expect(humanizeStatValue("ok_or_higher_risk")).toBe("ok_or_higher_risk");
+  });
+});
+
+describe("humanizeInternalEnums — prose", () => {
+  // ---- GUILT --------------------------------------------------------------
+  it("resolves the symbol inside a real editorial sentence", () => {
+    expect(
+      humanizeInternalEnums(
+        "Its Bali status is OK_or_HIGHER_RISK, with the reason given that OSS risk at Besar scale is high.",
+      ),
+    ).toBe(
+      "Its Bali status is Registrable in Bali, with the reason given that OSS risk at Besar scale is high.",
+    );
+  });
+
+  it("resolves a symbol wrapped in markdown inline code", () => {
+    expect(
+      humanizeInternalEnums("the Bali status is `OK_or_HIGHER_RISK`"),
+    ).toBe("the Bali status is `Registrable in Bali`");
+  });
+
+  it("resolves several symbols in one passage", () => {
+    expect(
+      humanizeInternalEnums("mapping BPS_ONLY, Bali OK_or_HIGHER_RISK."),
+    ).toBe("mapping New in 2025, Bali Registrable in Bali.");
+  });
+
+  // ---- INNOCENCE ----------------------------------------------------------
+  it("does not let a shorter symbol eat a longer one that shares its prefix", () => {
+    // TERTUTUP is a term of art (never rewritten) and TERTUTUP_CANDIDATE is a
+    // symbol; a naive substring pass would emit "Closed to foreigners_CANDIDATE".
+    expect(humanizeInternalEnums("status TERTUTUP_CANDIDATE here")).toBe(
+      "status Likely closed — verify here",
+    );
+    expect(humanizeInternalEnums("status TERBATAS_CANDIDATE here")).toBe(
+      "status Likely restricted — verify here",
+    );
+  });
+
+  it("does not fire on a symbol glued into a longer identifier", () => {
+    expect(
+      humanizeInternalEnums("XBPS_ONLY and BPS_ONLYX and BPS_ONLY_V2"),
+    ).toBe("XBPS_ONLY and BPS_ONLYX and BPS_ONLY_V2");
+  });
+
+  it("leaves prose with no internal symbol byte-identical", () => {
+    const prose =
+      "KBLI 68112 is TERBUKA — open to 100% foreign ownership via PT PMA. " +
+      "The Bali moratorium blocks Low and Medium-Low risk activities island-wide.";
+    expect(humanizeInternalEnums(prose)).toBe(prose);
+  });
+
+  it("is idempotent — a label carries no symbol to resolve again", () => {
+    const once = humanizeInternalEnums("Bali status is OK_or_HIGHER_RISK.");
+    expect(humanizeInternalEnums(once)).toBe(once);
+  });
+
+  it("passes an empty string through", () => {
+    expect(humanizeInternalEnums("")).toBe("");
+  });
+});
+
+describe("humanizeIntelBlock — the loader choke point", () => {
+  it("cleans prose fields, editorial prose and byTheNumbers cells at once", () => {
+    const out = humanizeIntelBlock({
+      whatChanged: "KBLI 2020→2025 mapping (BPS_ONLY).",
+      whatYouNeed: "Bali: OK_or_HIGHER_RISK.",
+      baliContext: null,
+      coverImage: "/covers/x.png",
+      editorial: {
+        headline: "A carbon code with no OSS scope",
+        standfirst: "Bali reads OK_or_HIGHER_RISK.",
+        body: "The record says the Bali status is OK_or_HIGHER_RISK.",
+        pullQuote: "Marked OK_or_HIGHER_RISK.",
+        byTheNumbers: [
+          { label: "Bali status", value: "OK_or_HIGHER_RISK" },
+          { label: "National status", value: "TERBUKA" },
+          { label: "Ceiling", value: "100%" },
+        ],
+      },
+    });
+
+    expect(out.whatChanged).toBe("KBLI 2020→2025 mapping (New in 2025).");
+    expect(out.whatYouNeed).toBe("Bali: Registrable in Bali.");
+    expect(out.editorial.standfirst).toBe("Bali reads Registrable in Bali.");
+    expect(out.editorial.body).toBe(
+      "The record says the Bali status is Registrable in Bali.",
+    );
+    expect(out.editorial.pullQuote).toBe("Marked Registrable in Bali.");
+    expect(out.editorial.byTheNumbers).toEqual([
+      { label: "Bali status", value: "Registrable in Bali" },
+      { label: "National status", value: "TERBUKA" },
+      { label: "Ceiling", value: "100%" },
+    ]);
+  });
+
+  it("preserves non-string members and unknown keys, and never mutates its input", () => {
+    const input = {
+      whatChanged: "Bali OK_or_HIGHER_RISK.",
+      baliContext: null,
+      coverImage: "/covers/x.png",
+      someFutureKey: { nested: true },
+    };
+    const snapshot = JSON.stringify(input);
+    const out = humanizeIntelBlock(input);
+
+    expect(JSON.stringify(input)).toBe(snapshot); // input untouched
+    expect(out.baliContext).toBeNull();
+    expect(out.coverImage).toBe("/covers/x.png");
+    expect(out.someFutureKey).toEqual({ nested: true });
+    expect(out).not.toBe(input);
+  });
+
+  it("covers fields no allow list mentioned — whoThisIsFor and nested tkaInfo", () => {
+    // The regression this test exists for: `whoThisIsFor` (1,186 records,
+    // rendered on the code page) and `tkaInfo.insight` were invisible to the
+    // first, allow-list-based version of the cure.
+    const out = humanizeIntelBlock({
+      whoThisIsFor: "Founders whose Bali status reads OK_or_HIGHER_RISK.",
+      tkaInfo: {
+        insight: "Mapping is BPS_ONLY.",
+        relevantPositions: ["Director — BLOCCATO_CLASSE_RISCHIO note"],
+      },
+      aFieldInventedTomorrow: "Bali OK_or_HIGHER_RISK.",
+    });
+
+    expect(out.whoThisIsFor).toBe(
+      "Founders whose Bali status reads Registrable in Bali.",
+    );
+    expect(out.tkaInfo.insight).toBe("Mapping is New in 2025.");
+    expect(out.tkaInfo.relevantPositions).toEqual([
+      "Director — Blocked in Bali (risk-class moratorium) note",
+    ]);
+    expect(out.aFieldInventedTomorrow).toBe("Bali Registrable in Bali.");
+  });
+
+  it("INNOCENCE: leaves machine-metadata keys byte-identical", () => {
+    // `_l3_regen` records WHAT the pipeline did; a symbol there is a fact about
+    // the run, not a sentence aimed at a reader. Rewriting it falsifies the
+    // regeneration audit trail. `coverImage` is an asset path.
+    const out = humanizeIntelBlock({
+      _l3_regen: {
+        model: "sonnet",
+        note: "regenerated from OK_or_HIGHER_RISK branch",
+        fact_gate: "BPS_ONLY",
+      },
+      coverImage: "/covers/OK_or_HIGHER_RISK.png",
+      whatItMeans: "Bali OK_or_HIGHER_RISK.",
+    });
+
+    expect(out._l3_regen).toEqual({
+      model: "sonnet",
+      note: "regenerated from OK_or_HIGHER_RISK branch",
+      fact_gate: "BPS_ONLY",
+    });
+    expect(out.coverImage).toBe("/covers/OK_or_HIGHER_RISK.png");
+    expect(out.whatItMeans).toBe("Bali Registrable in Bali."); // still cured
+  });
+
+  it("passes undefined / null / non-objects straight through", () => {
+    expect(humanizeIntelBlock(undefined)).toBeUndefined();
+    expect(humanizeIntelBlock(null)).toBeNull();
+    expect(humanizeIntelBlock("string")).toBe("string");
+  });
+
+  it("survives an editorial with no byTheNumbers", () => {
+    const out = humanizeIntelBlock({
+      editorial: { headline: "H", body: "Bali OK_or_HIGHER_RISK." } as Record<
+        string,
+        unknown
+      >,
+    });
+    expect(out.editorial.body).toBe("Bali Registrable in Bali.");
+    expect(out.editorial.byTheNumbers).toBeUndefined();
+  });
+});
+
+describe("map integrity", () => {
+  it("keeps the badge table and the humaniser in lockstep", () => {
+    // A status the badge can render but the humaniser cannot resolve would put
+    // two different words for one verdict on the same page.
+    const TERMS_OF_ART = new Set(["TERBUKA", "TERTUTUP", "TERBATAS"]);
+    for (const [key, cfg] of Object.entries(BALI_STATUS_CONFIG)) {
+      if (TERMS_OF_ART.has(key)) {
+        expect(INTERNAL_ENUM_LABELS[key]).toBeUndefined();
+      } else {
+        expect(INTERNAL_ENUM_LABELS[key]).toBe(cfg.label);
+      }
+    }
+  });
+
+  it("never maps a symbol to something that still looks like a symbol", () => {
+    for (const label of Object.values(INTERNAL_ENUM_LABELS)) {
+      expect(label).not.toMatch(/^[A-Z][A-Za-z]*(_[A-Za-z]+)+$/);
+    }
+  });
+});

--- a/apps/mouth/src/lib/kbli-status-labels.ts
+++ b/apps/mouth/src/lib/kbli-status-labels.ts
@@ -1,0 +1,223 @@
+/**
+ * Canonical enum → human-label map for the KBLI navigator.
+ *
+ * WHY THIS FILE EXISTS (measured 2026-07-25 on the 1,559-code canonical):
+ * the editorial layer (`intel_2026.editorial`) was authored by narrating the
+ * JSON record, so internal pipeline enums reached the client verbatim —
+ * `Bali status: OK_or_HIGHER_RISK` on 908 "By the numbers" cells across 1,141
+ * codes (73% of the catalog), plus 725 occurrences inside editorial prose.
+ * `OK_or_HIGHER_RISK` is not vocabulary; it is a pipeline symbol.
+ *
+ * The human labels already existed — in `BaliStatusBadge` and `TransitionBadge`.
+ * They were simply not reachable from the editorial renderer. This module is
+ * the single source of truth both badges and the editorial renderer now share,
+ * so a status can never be spelled two ways on the same page.
+ *
+ * BOUNDARY — this is a PRESENTATION mapping, never a fact change. The symbol
+ * and its label denote exactly the same verdict; nothing is added, softened or
+ * inferred. The underlying data debt (the editorial layer narrating raw fields
+ * such as `l4_bali_blocked`) stays visible internally and is measured by
+ * `kbli-internal-leak.test.ts`, which ratchets it down and never up.
+ *
+ * MATCHING DISCIPLINE (cicatrix superscar #3 — guard over-match): resolution is
+ * EXACT-KEY only for structured values and WORD-BOUNDARY-anchored for prose.
+ * Never a bare substring: `TERTUTUP` must not eat `TERTUTUP_CANDIDATE`, and an
+ * unknown symbol must fall through verbatim rather than be guessed at.
+ */
+
+export type BaliStatusTone = "ok" | "warn" | "block";
+
+export interface BaliStatusConfig {
+  label: string;
+  icon: string;
+  tone: BaliStatusTone;
+}
+
+/**
+ * L4 Bali status — the sovereign-local layer. National PMA openness (L2) is not
+ * Bali registrability (L4). Source: schema-v2 `l4_bali` (moratorium 2026-05-13,
+ * Gubernur letter B.27.000/642/PM/DPMPTSP).
+ */
+export const BALI_STATUS_CONFIG: Record<string, BaliStatusConfig> = {
+  OK_or_HIGHER_RISK: { label: "Registrable in Bali", icon: "✅", tone: "ok" },
+  // Nationally TERBUKA and the Besar scale is Menengah-Tinggi/Tinggi → survives the
+  // Bali risk-class moratorium → registrable by a PT PMA in Bali (#1814 risk-tier pass).
+  APERTO_BALI_RISCHIO_ALTO: {
+    label: "Open in Bali (high-risk tier)",
+    icon: "✅",
+    tone: "ok",
+  },
+  BLOCCATO_CLASSE_RISCHIO: {
+    label: "Blocked in Bali (risk-class moratorium)",
+    icon: "🚫",
+    tone: "block",
+  },
+  // Nationally TERBUKA but the Besar scale is Rendah/Menengah-Rendah → blocked by the
+  // 2026 Bali PMA moratorium (Gov. letter B.27.000/642). Resolved by #1814 risk-tier pass.
+  CHIUSO_MORATORIA_BALI: {
+    label: "Closed in Bali (2026 moratorium)",
+    icon: "🚫",
+    tone: "block",
+  },
+  // Closed by a national sector regulator regardless of risk tier (e.g. Bank Indonesia,
+  // BAPETEN) — structurally closed to private/PMA capital. Resolved by #1814.
+  CHIUSO_REGOLATORE_SETTORIALE: {
+    label: "Closed (sector regulator)",
+    icon: "🚫",
+    tone: "block",
+  },
+  // Besar-scale risk is low on some ruang lingkup but higher on others: OSS computes
+  // risk per (code × scope × scale), so registrability depends on the declared scope.
+  // (deep research 2026-06-20: rejection is on "tingkat risiko", not on the code.)
+  BLOCCATO_DIPENDE_SCOPE: {
+    label: "Conditional in Bali — depends on declared scope",
+    icon: "⚠️",
+    tone: "warn",
+  },
+  // No Usaha Besar scale row in OSS → activity reserved for cooperatives/MSME under
+  // Perpres 10/2021 (amended 49/2021), Lampiran II Pasal 5(1)(a). A PT PMA is Usaha
+  // Besar by law (UU 6/2023 + Permeninves 5/2025) and cannot register it.
+  CHIUSO_PMA_NO_BESAR: {
+    label: "Reserved for MSME — closed to PT PMA",
+    icon: "🚫",
+    tone: "block",
+  },
+  // No OSS-RBA risk scope at all (404): special/sectoral regime — finance (OJK/BI),
+  // pharma (BPOM), and other sensitive activities licensed outside the ordinary RBA
+  // flow. Not mechanically caught by the low-risk Bali block → verify case-by-case.
+  NEEDS_REVIEW_NO_OSS_SCOPE: {
+    label: "Special regime — verify case-by-case",
+    icon: "❓",
+    tone: "warn",
+  },
+  CHIUSO_BALI: { label: "Closed for PMA in Bali", icon: "🚫", tone: "block" },
+  CHIUSO_BALI_PROPOSTO: {
+    label: "Closure proposed (Bali)",
+    icon: "⚠️",
+    tone: "warn",
+  },
+  TERTUTUP: { label: "Closed to foreigners", icon: "🚫", tone: "block" },
+  TERBATAS: { label: "Restricted (foreign cap)", icon: "⚠️", tone: "warn" },
+  TERTUTUP_CANDIDATE: {
+    label: "Likely closed — verify",
+    icon: "❓",
+    tone: "warn",
+  },
+  TERBATAS_CANDIDATE: {
+    label: "Likely restricted — verify",
+    icon: "❓",
+    tone: "warn",
+  },
+  // GARUDA-FILIERA Fase-1 cure #4 (2026-07-17): the risk tier this verdict
+  // depended on was carried over from a different activity through a
+  // code-number collision and has been detached — the moratorium
+  // applicability is genuinely unresolved, not "verify a special regime"
+  // (NEEDS_REVIEW_NO_OSS_SCOPE) or a known ok/blocked verdict.
+  NON_CLASSIFICABILE: {
+    label: "Bali status not classifiable — verify",
+    icon: "❓",
+    tone: "warn",
+  },
+};
+
+/** KBLI 2020 → 2025 crosswalk verdict, as labelled by `TransitionBadge`. */
+export const MAPPING_STATUS_LABELS: Record<string, string> = {
+  MATCH_LANGSUNG: "Direct Match",
+  CODICE_RINUMERATO: "Renumbered",
+  MATCH_CON_AGGREGAZIONE: "Aggregated",
+  BPS_ONLY: "New in 2025",
+};
+
+/**
+ * Indonesian regulatory terms of art. These are NOT internal symbols: they are
+ * the words the investment annexes, OSS and every Bali Zero surface use, and the
+ * product deliberately teaches them alongside their English gloss. Translating
+ * them here would make the same page say "TERBUKA" in a badge and "Open" in the
+ * sidebar — and would silently drop the reader's link to the official wording.
+ */
+const TERMS_OF_ART = new Set(["TERBUKA", "TERTUTUP", "TERBATAS"]);
+
+/**
+ * Every internal symbol that must never reach a reader, mapped to the label the
+ * product already uses for it elsewhere. Terms of art are excluded by design.
+ */
+export const INTERNAL_ENUM_LABELS: Record<string, string> = Object.fromEntries([
+  ...Object.entries(BALI_STATUS_CONFIG)
+    .filter(([key]) => !TERMS_OF_ART.has(key))
+    .map(([key, cfg]) => [key, cfg.label] as const),
+  ...Object.entries(MAPPING_STATUS_LABELS),
+]);
+
+/**
+ * Humanise a STRUCTURED value (e.g. an `editorial.byTheNumbers` cell).
+ * Exact-key resolution after trimming; anything unrecognised — including a term
+ * of art, a number, a free-text cell — is returned byte-identical.
+ */
+export function humanizeStatValue(value: string): string {
+  const label = INTERNAL_ENUM_LABELS[value.trim()];
+  return label ?? value;
+}
+
+// Longest-first so a longer symbol is offered before any shorter one that shares
+// its prefix; the trailing boundary makes this belt-and-braces, not the guard.
+const ENUM_TOKEN_RE = new RegExp(
+  `(?<![A-Za-z0-9_])(${Object.keys(INTERNAL_ENUM_LABELS)
+    .sort((a, b) => b.length - a.length)
+    .join("|")})(?![A-Za-z0-9_])`,
+  "g",
+);
+
+/**
+ * Humanise internal symbols appearing inside PROSE (editorial body, standfirst,
+ * pull-quote). Word-boundary anchored on both sides and `_`-aware, so
+ * `TERTUTUP_CANDIDATE` resolves as itself and never as `TERTUTUP` + `_CANDIDATE`.
+ * Prose that contains no known symbol is returned unchanged.
+ */
+export function humanizeInternalEnums(text: string): string {
+  if (!text) return text;
+  return text.replace(ENUM_TOKEN_RE, (match) => INTERNAL_ENUM_LABELS[match]);
+}
+
+/**
+ * Keys under `intel_2026` whose strings are NOT prose shown to a reader, and so
+ * must survive byte-identical. Kept as a DENY list, deliberately: an allow list
+ * of prose fields silently misses the next field somebody adds — `whoThisIsFor`
+ * (1,186 records, rendered on the code page) was exactly that miss, caught by
+ * the adversarial review of this change. Deny-listing makes new fields covered
+ * by default, and `kbli-internal-leak.test.ts` walks the block generically so a
+ * field that should have been denied fails the gate instead of leaking.
+ *
+ *  - `_l3_regen` — regeneration provenance (model, source, fact_gate). Machine
+ *    metadata: a symbol there is a record OF the pipeline, not a message to a
+ *    reader, and rewriting it would falsify the audit trail.
+ *  - `coverImage` — an asset path.
+ */
+const INTEL_NON_READER_KEYS = new Set(["_l3_regen", "coverImage"]);
+
+/**
+ * Humanise every reader-facing string inside an `intel_2026` block, at the data
+ * loader, so a symbol cannot survive by reaching a surface nobody remembered to
+ * wrap. Walks the WHOLE block — prose fields, `editorial`, `byTheNumbers` cells,
+ * `tkaInfo`, arrays, any future nesting — skipping `INTEL_NON_READER_KEYS`.
+ * Non-strings pass through untouched and the input is never mutated.
+ *
+ * Idempotent: a label contains no symbol, so re-applying is a no-op — the
+ * component-level calls in `KBLIEditorial` remain valid defence in depth.
+ */
+export function humanizeIntelBlock<T>(intel: T): T {
+  return humanizeDeep(intel) as T;
+}
+
+function humanizeDeep(node: unknown): unknown {
+  if (typeof node === "string") return humanizeInternalEnums(node);
+  if (Array.isArray(node)) return node.map(humanizeDeep);
+  if (node && typeof node === "object") {
+    const src = node as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(src)) {
+      out[key] = INTEL_NON_READER_KEYS.has(key) ? value : humanizeDeep(value);
+    }
+    return out;
+  }
+  return node;
+}


### PR DESCRIPTION
## The defect (measured on the shipped data, not inferred)

`intel_2026.editorial` was authored by an LLM **narrating the JSON record**, so internal
symbols reached readers verbatim on the live product:

| leak | measured |
|---|---|
| `Bali status: OK_or_HIGHER_RISK` in "By the numbers" cells | **908 cells across 1,141 codes** (73% of the catalogue) |
| same symbols inside editorial prose | 725 occurrences |
| `l4_bali.reason` | 8 |
| GOLD layer (`kbli-gold-content.json`) | **113 of 428 codes** |

A reader on `balizero.com/kbli/64995` saw `OK_or_HIGHER_RISK` where the badge two
inches away already said "Open (higher risk tier)".

## The fix — at RENDER, no data touched

`apps/mouth/src/lib/kbli-status-labels.ts` resolves each symbol to the label
`BaliStatusBadge` / `TransitionBadge` **already used**. The labels existed; they were
simply unreachable from the editorial renderer. Symbol and label denote the same
verdict — this is presentation, no fact moves, no data-plane write.

Deliberate non-targets, both test-pinned:
- **TERBUKA / TERTUTUP / TERBATAS stay Indonesian** — terms of art the product teaches.
- **`_data_note` stays verbatim** — there a symbol is a *citation* of the record, used as
  divergence evidence. Rewriting evidence corrupts the audit trail.

Coverage is a **deny list** (walk everything, skip only `_l3_regen` + `coverImage`), so a
field added tomorrow is covered by default. An allow list had already missed
`whoThisIsFor` — 1,186 records, rendered at `page.tsx:742`.

## Gate

Cross-family adversarial review (generator≠grader) returned **2 real BLOCKERs**, both
re-measured on disk before acting:
1. the gold layout renders `gold.*` **directly** from `getGoldContent()`, bypassing the
   loader cure entirely → cured at that choke point, which covers the page and
   `/api/kbli/gold/[code]` at once;
2. the first version of the gate was blind to that same file.

`kbli-internal-leak.test.ts` is an immune organ, not a unit test: it measures **both real
data files** and asserts guilt (raw data still leaks) → **zero survivors after cure across
all 1,559 codes and the 428 gold codes** → innocence (`_data_note` untouched). It also
**ratchets a separate debt it cannot fix**: 392 codes narrate raw *field names*
("l4_bali_blocked is false", `pma_max_asing`) — that class needs an editorial rewrite; the
ratchet only falls.

## Verification

- 1048 tests pass (`apps/mouth` lib + kbli components), `npm run typecheck -w apps/mouth` clean.
- PROVE-LIVE after Vercel: `balizero.com/kbli/64995` (no `OK_or_HIGHER_RISK`) and a gold
  code, e.g. `/kbli/10732` (no `MATCH_CON_AGGREGAZIONE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)