### PR TITLE
feat(crm): give the E33 Day-90 scanner a heartbeat, and a switch that tells the truth

### DIFF
--- a/.github/workflows/cron-notifiers-e33-guarantee-scan.yml
+++ b/.github/workflows/cron-notifiers-e33-guarantee-scan.yml
@@ -1,0 +1,32 @@
+name: cron - notifiers e33-guarantee-scan (daily 07:10 WITA)
+on:
+  schedule:
+    - cron: "10 23 * * *" # 23:10 UTC = 07:10 WITA next day
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-notifiers-e33-guarantee-scan-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # The E33 Day-90 guarantee gate: for every open Second Home case this
+      # builds the Day 30/60/75 escalation toward the 90-day evidence deadline
+      # and the annual-maintenance recurrence, then hands them to the existing
+      # AlertsEngine (dedup + severity promotion + team dispatch).
+      #
+      # Inert until system_settings.e33_guarantee_scan_enabled = "true" — the
+      # endpoint answers {"status":"blocked"} otherwise, and the switch is the
+      # deliberate go-live gesture, not this schedule (same posture as
+      # cron-notifiers-compliance-forecast).
+      #
+      # Scheduled 40 min after compliance-forecast (22:30 UTC) so the two
+      # AlertsEngine writers never contend for the same dedup window.
+      - name: POST /api/cron/notifiers/e33-guarantee-scan
+        run: |
+          curl -fsS -X POST https://nuzantara-rag.fly.dev/api/cron/notifiers/e33-guarantee-scan \
+            -H "X-API-Key: ${{ secrets.NUZANTARA_API_KEY }}" \
+            -w '\nHTTP %{http_code} in %{time_total}s\n'

--- a/apps/backend-rag/backend/app/routers/cron_notifiers.py
+++ b/apps/backend-rag/backend/app/routers/cron_notifiers.py
@@ -284,18 +284,30 @@ async def run_e33_guarantee_scan(request: Request) -> dict[str, Any]:
 
     from backend.services.crm.e33_guarantee_scanner import (
         E33GuaranteeScanner,
-        is_scan_enabled,
+        ScanSwitchState,
+        resolve_scan_switch,
     )
 
-    if not await is_scan_enabled(db_pool):
+    switch = await resolve_scan_switch(db_pool)
+    if not switch.is_enabled:
+        # Both states block, but they are not the same event: an absent row
+        # means nobody ever armed the organ (it can sit dead indefinitely and
+        # look healthy), while an explicit non-"true" value is a recorded
+        # decision. Reporting them identically is what let this scanner ship
+        # un-armed and unnoticed — see the scanner module docstring.
+        unprovisioned = switch is ScanSwitchState.UNPROVISIONED
         logger.warning(
-            "E33 guarantee scan BLOCKED — awaiting owner approval "
-            "(set e33_guarantee_scan_enabled=true)"
+            "E33 guarantee scan BLOCKED — %s (switch '%s')",
+            "kill switch NEVER PROVISIONED" if unprovisioned else "explicitly disabled",
+            "e33_guarantee_scan_enabled",
         )
         return {
             "service": "e33_guarantee_scan",
             "status": "blocked",
-            "reason": "awaiting_owner_approval",
+            "switch_state": switch.value,
+            "reason": (
+                "switch_not_provisioned" if unprovisioned else "awaiting_owner_approval"
+            ),
         }
 
     scanner = E33GuaranteeScanner(db_pool)

--- a/apps/backend-rag/backend/services/crm/e33_guarantee_scanner.py
+++ b/apps/backend-rag/backend/services/crm/e33_guarantee_scanner.py
@@ -20,12 +20,30 @@ no WhatsApp/client notifications are sent by this scanner.
 
 Kill switch: system_settings.e33_guarantee_scan_enabled must be "true"
 (same blocked-by-default posture as visa_expiry_notifier_enabled).
+
+UNPROVISIONED vs DISABLED (2026-07-25)
+--------------------------------------
+The switch has THREE meaningful states, not two. A missing row and a row set
+to "false" both block the scan, but they mean opposite things operationally:
+
+- **UNPROVISIONED** (no row): nobody ever decided. The organ was built and
+  deployed — table, scanner, cron endpoint — and then left un-armed without
+  anyone noticing, because "blocked" reads like a decision. This is the
+  superscar-#2 shape ("esiste != armato"): the failure is invisible precisely
+  because it looks identical to the healthy fail-closed state.
+- **DISABLED** (row exists, value != "true"): somebody decided, and the
+  decision is recorded and auditable.
+
+``resolve_scan_switch`` reports which one it is so the endpoint and the logs
+can too. Nothing about the fail-closed behaviour changes: both non-ENABLED
+states block, and an absent row still blocks.
 """
 
 from __future__ import annotations
 
 import logging
 from datetime import date
+from enum import Enum
 from typing import Any
 
 import asyncpg
@@ -36,22 +54,69 @@ logger = logging.getLogger(__name__)
 
 _KILL_SWITCH_KEY: str = "e33_guarantee_scan_enabled"
 
+#: The exact stored value that arms the scan. Anything else blocks.
+_ENABLED_VALUE: str = "true"
 
-async def is_scan_enabled(db_pool: asyncpg.Pool) -> bool:
-    """Check the kill switch in system_settings. Blocked unless "true"."""
+
+class ScanSwitchState(str, Enum):
+    """Resolved state of the E33 guarantee-scan kill switch."""
+
+    #: No row for the key — the organ was never armed (nor deliberately disabled).
+    UNPROVISIONED = "unprovisioned"
+    #: Row exists but is not the enabling value — a recorded decision to hold.
+    DISABLED = "disabled"
+    #: Row exists and arms the scan.
+    ENABLED = "enabled"
+
+    @property
+    def is_enabled(self) -> bool:
+        """True only for :attr:`ENABLED` — both other states fail closed."""
+        return self is ScanSwitchState.ENABLED
+
+
+async def resolve_scan_switch(db_pool: asyncpg.Pool) -> ScanSwitchState:
+    """Resolve the kill switch into one of three explicit states.
+
+    Distinguishes "never provisioned" from "deliberately disabled" — see the
+    module docstring. Fail-closed is unchanged: only the exact string
+    ``"true"`` yields :attr:`ScanSwitchState.ENABLED`.
+    """
     async with db_pool.acquire() as conn:
-        value = await conn.fetchval(
+        row = await conn.fetchrow(
             "SELECT value FROM system_settings WHERE key = $1",
             _KILL_SWITCH_KEY,
         )
-    enabled = value == "true"
-    if not enabled:
-        logger.info(
-            "E33GuaranteeScanner: disabled by kill switch '%s' (value=%r)",
+
+    if row is None:
+        logger.warning(
+            "E33GuaranteeScanner: kill switch '%s' has NO ROW in system_settings — "
+            "the scanner is un-armed, not disabled. The Day-90 guarantee gate is "
+            "therefore not being monitored for any open E33 case. Arming it is a "
+            "one-line value change on that key (owner decision).",
             _KILL_SWITCH_KEY,
-            value,
         )
-    return enabled
+        return ScanSwitchState.UNPROVISIONED
+
+    value = row["value"]
+    if value == _ENABLED_VALUE:
+        return ScanSwitchState.ENABLED
+
+    logger.info(
+        "E33GuaranteeScanner: disabled by kill switch '%s' (value=%r) — "
+        "an explicit recorded decision, not a missing arming step.",
+        _KILL_SWITCH_KEY,
+        value,
+    )
+    return ScanSwitchState.DISABLED
+
+
+async def is_scan_enabled(db_pool: asyncpg.Pool) -> bool:
+    """Check the kill switch in system_settings. Blocked unless "true".
+
+    Thin boolean view over :func:`resolve_scan_switch`, kept for callers that
+    only need the yes/no.
+    """
+    return (await resolve_scan_switch(db_pool)).is_enabled
 
 
 class E33GuaranteeScanner:
@@ -114,4 +179,9 @@ class E33GuaranteeScanner:
         return result
 
 
-__all__ = ["E33GuaranteeScanner", "is_scan_enabled"]
+__all__ = [
+    "E33GuaranteeScanner",
+    "ScanSwitchState",
+    "is_scan_enabled",
+    "resolve_scan_switch",
+]

--- a/apps/backend-rag/backend/tests/services/crm/test_e33_guarantee_switch.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_e33_guarantee_switch.py
@@ -1,0 +1,94 @@
+"""E33 guarantee-scan kill switch — three-state resolution.
+
+The scanner ships blocked-by-default, which is correct. What was NOT correct
+is that a *missing* switch row and a *deliberately disabled* switch were
+indistinguishable: both blocked, both logged the same "awaiting owner
+approval", and the endpoint answered the same reason. That is the shape that
+let the organ ship un-armed and stay invisible (superscar #2, esiste != armato).
+
+Guilt: an absent row must be reported as UNPROVISIONED, distinctly.
+Innocence: an explicitly disabled switch must still read as a recorded
+decision, and near-miss values must never arm the scan.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.crm.e33_guarantee_scanner import (
+    ScanSwitchState,
+    is_scan_enabled,
+    resolve_scan_switch,
+)
+
+
+def _pool(row: dict[str, str] | None):
+    """Minimal asyncpg-pool double returning ``row`` from ``fetchrow``."""
+
+    class _Pool:
+        def acquire(self):
+            class _Cm:
+                async def __aenter__(self_inner):
+                    class _Conn:
+                        async def fetchrow(self_conn, sql, *args):
+                            assert "system_settings" in sql
+                            assert args == ("e33_guarantee_scan_enabled",)
+                            return row
+
+                    return _Conn()
+
+                async def __aexit__(self_inner, *exc):
+                    return False
+
+            return _Cm()
+
+    return _Pool()
+
+
+@pytest.mark.asyncio
+async def test_absent_row_is_unprovisioned_not_disabled():
+    """GUILT: no row at all is the un-armed state, and says so."""
+    state = await resolve_scan_switch(_pool(None))
+
+    assert state is ScanSwitchState.UNPROVISIONED
+    assert state is not ScanSwitchState.DISABLED
+    assert state.is_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_false_is_disabled_not_unprovisioned():
+    """INNOCENCE: a recorded 'false' is a decision, not a missing arming step."""
+    state = await resolve_scan_switch(_pool({"value": "false"}))
+
+    assert state is ScanSwitchState.DISABLED
+    assert state is not ScanSwitchState.UNPROVISIONED
+    assert state.is_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_true_arms_the_scan():
+    state = await resolve_scan_switch(_pool({"value": "true"}))
+
+    assert state is ScanSwitchState.ENABLED
+    assert state.is_enabled is True
+
+
+@pytest.mark.parametrize("value", ["True", "TRUE", " true", "true ", "1", "yes", ""])
+@pytest.mark.asyncio
+async def test_near_miss_values_never_arm_the_scan(value: str):
+    """Fail-closed: only the exact string 'true' enables — unchanged behaviour."""
+    state = await resolve_scan_switch(_pool({"value": value}))
+
+    assert state is ScanSwitchState.DISABLED
+    assert state.is_enabled is False
+
+
+@pytest.mark.parametrize(
+    ("row", "expected"),
+    [(None, False), ({"value": "false"}, False), ({"value": "true"}, True)],
+)
+@pytest.mark.asyncio
+async def test_boolean_view_matches_resolved_state(row, expected):
+    """`is_scan_enabled` stays a faithful thin view over the three-state resolver."""
+    assert await is_scan_enabled(_pool(row)) is expected
+    assert (await resolve_scan_switch(_pool(row))).is_enabled is expected

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`329 routers · 666 services · 1241 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`329 routers · 666 services · 1242 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
The E33 Day-90 guarantee scanner existed and nothing called it. Its kill switch could not
distinguish "never armed" from "deliberately parked" — both answered `false`, so a scanner
that had simply never been provisioned looked exactly like one an owner had switched off.

Two changes:

**A heartbeat.** `.github/workflows/cron-notifiers-e33-guarantee-scan.yml` POSTs the existing
endpoint daily at 07:10 WITA. actionlint clean.

**A switch that distinguishes.** `resolve_scan_switch()` returns a three-state
`ScanSwitchState` — `UNPROVISIONED` (no row in `system_settings`: un-armed, logged as a
warning), `DISABLED` (an explicit recorded decision, logged as info), `ENABLED`. The endpoint
now reports `switch_state` and a `reason` of `switch_not_provisioned` vs
`awaiting_owner_approval`, instead of returning a flat "blocked" that silently claims a
decision nobody made. `is_scan_enabled()` is kept as the boolean view so no caller changes.

Still fail-closed: absent row does NOT arm the scanner. The point is that it now says so.

**Tests** — `test_e33_guarantee_switch.py`, 13 cases, all pass in 0.01s:
- guilt: absent row resolves UNPROVISIONED, not DISABLED
- innocence: an explicit `"false"` resolves DISABLED, not UNPROVISIONED
- near-miss corpus: `"True"`, `"TRUE"`, `" true"`, `"true "`, `"1"`, `"yes"`, `""` never arm
- boolean-view parity between `is_scan_enabled()` and the enum

Pre-push suite: 100%, 0 failures.

Docsync regen travels in the same commit (W86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)