### PR TITLE
docs(bot): corner §1 + consultant/team spec — replant on docs-only range

### DIFF
--- a/.claude/skills/bot/SKILL.md
+++ b/.claude/skills/bot/SKILL.md
@@ -20,8 +20,113 @@ WhatsApp Business (Meta Cloud API) number **+62 821-3465-159** = Zantara. Two au
 - **Bali Zero team**: work-support assistant. Check-in via WA (opens the free Meta 24h window),
   CRM nudges, PII-light briefings. Persona = "assistente operativo interno", not sales.
 
-## 1. LIVE STATE (last update 2026-07-24 — keep current)
+## 1. LIVE STATE (last update 2026-07-25 — keep current)
 
+- **📐 THE SPEC IS NOW THE PLAN OF RECORD — and it is being EXECUTED (2026-07-25, Fable/M5).**
+  `research/operations/2026-07-24-zantara-bot-consultant-assistant-spec.md` (added by this PR) is
+  FINAL: TAC over a 12-lane workflow, 3-seat cross-family council (Codex red-team / Gemini
+  costruttivo / Kimi refuter), every P0 disk-re-verified, **9 Zero rulings ratified in §12/§14**.
+  It defines two meta-patterns (A: _Esiste≠Armato_ — capabilities wired to the DEAD legacy path;
+  B: broken identity/data-contract boundaries) and the sequenced workstreams
+  **W-1 → W0 → W1 → W2 → W3 → W4 → W5 → W6 → W7**. W-1 (P0-MEM #3036, P0-ID/P0-ARG #3062) is
+  SHIPPED. Execution of W0/W1/W2/W3 started 2026-07-25.
+- **📊 TRAFFIC MEASURED (answers Zero ruling #4, "quantify the weekly client drop first")**:
+  over 30 days the Meta number's ledger holds **28 inbound customer messages across 4 threads**;
+  22 bot replies sent and `read`. Of 89 `failed` outbox rows, **78 are `24h_window_closed`** and
+  they concentrate on a handful of dormant / outbound-initiated threads (one has 0 inbound ever).
+  ⇒ **essentially zero real clients are being dropped by the 24h window** — the "81% failure"
+  headline is an artifact, not a business problem, and does not justify a paid Meta template.
+  ⇒ Strategic consequence: **production traffic is far too thin to be the feedback loop.** The
+  golden multi-turn eval is not a nice-to-have, it is the bot's only sensor (spec W-1, in build).
+- **First real multi-turn golden baseline, run against LIVE prod (`eval-baseline` lane, Fly `rag`
+  machine, 2026-07-25)**: `pass_rate 0.7619 (16/21), n_errors 0, must_not_assert_violations 0` —
+  but `mean_key_facts_coverage` came back exactly **0.0**: coverage substring-tested whole prose
+  sentences that no answer echoes verbatim. Cured with short anchors (`fix-eval-keyfacts` lane,
+  committed in worktree — NOT merged, NOT deployed); 5 of 23 facts remain un-anchored **by
+  design** (they describe bot BEHAVIOUR, not answer content) and still score 0 — a disclosed
+  limitation, not a tuned-away one. **Read the 76% narrowly: it does NOT measure whether the
+  right facts appeared in the answer.**
+- **🔴 NEW client-facing defects, found by probing the REAL prod path (not in the spec's C-matrix)**:
+  a synthetic client question through `POST /api/agentic-rag/query` (`channel=whatsapp`) returned,
+  verbatim, to a _client-role_ caller:
+  - **C17 — Path B ships the RAW answer.** `wa_inbox_bot.generate_bot_reply` applies ONLY
+    `answer.replace("[ESCALATE]","")`. `channels/format.py::format_rich_text` (which does
+    `_strip_markdown` + channel handling, and is fully tested) has **ZERO non-test callers in the
+    whole codebase** — dead code. So `###` headings, `**bold**` and `[1, 5]` citation markers reach
+    WhatsApp raw. Purest Pattern-A instance found so far.
+  - **C18 — internal scaffolding delivered to clients.** The KG block appended by
+    `orchestrator_core.py:~816` — `## SUGGESTED WORKFLOW (from visa_subgraph, confidence: 78%)`,
+    `**Confidence**: medium — 3 source(s), relationship strength 90%`, `IMPORTANT: ... verify with
+the user` — is sent verbatim. Worse, it can CONTRADICT the answer: an E33G remote-worker answer
+    (which forbids local employment) arrived with the IMTA/TKA **local work-permit** workflow attached.
+  - **C19/C20 — the persona is ADDITIVE, not composed.** `prompt_builder.py:549-552` merely
+    _prepends_ `CREATOR_PERSONA`/`TEAM_PERSONA` to the master prompt; **there is no CLIENT_PERSONA**
+    and nothing is removed for clients. So the client is the _default_ case while the base prompt is
+    written in an internal register ("a client asks…", "check with the team") — the live answer
+    literally said _"You can pass this information directly to the client"_ to a client-role caller —
+    and it carries the full **`crm_query` playbook** (`client_stats`, `search_clients`, …) in every
+    anonymous caller's system prompt. Tool-schema minimisation (T-VIS) does not cover the PROMPT layer.
+    ⇒ Cure = audience-COMPOSED prompt (client/team/creator) as `zantara_core_v5`, additive behind the
+    versioned door, never editing v4 in place.
+  - **Near-miss caught before ship**: a first-draft `client-voice` regex (`_BARE_CITATION_RE`),
+    meant to strip the internal `[1]`/`[3]` citation markers from C17/C18, would have CORRUPTED
+    Indonesian legal citations — measured `'Perpres 10/2021 Pasal 6 [1] dan [3] berlaku.'` →
+    `'Perpres 10/2021 Pasal 6 dan berlaku.'` (bracketed Pasal numbers read as citation markers).
+    Caught by adversarial review BEFORE ship; cured by anchoring the strip to trailing source
+    markers only. Cicatrix family #3 (guard over-match). State: committed in
+    `client-voice`/`fix-client-voice` worktree lanes — NOT merged, NOT deployed.
+  - **The denial oracle survives paraphrase, and is worse than the literal string.** Asked
+    (client-role) _"quanti clienti attivi abbiamo?"_, the bot never said "denied": it invented
+    _"problema tecnico … sistemi di accesso al CRM … account staff autenticato … ti do il numero
+    esatto dei clienti dal database live"_ — disclosing the CRM's existence, disguising the
+    security control as an outage, leaking the auth model, and promising a stranger the client
+    count. A guard that greps for "denied"/a literal refusal string is UNDER-match (cicatrix
+    family #3 twin): assert on the FACT disclosed, never the sentence form. State: bug LIVE in
+    prod (measured today); cure in flight (`deny-narration` finding → `fix-deny-audit` lane) —
+    NOT merged, NOT deployed.
+  - **`zantara_core_v5` is built and execution-verified, but the door does not know it yet.**
+    Client prompt measured ZERO `crm_query`/`timesheet`/`team_knowledge` and zero third-person
+    "the client"; team/creator keep the CRM playbook (`build-prompt-v5` lane). But setting
+    `ZANTARA_PROMPT_VERSION=v5` today serves **v1** (22,638 chars) instead of v5 — a silent
+    REGRESSION from the v4 armed in prod (36,106 chars) — because the versioned door doesn't
+    recognize `"v5"` and falls back silently. `wire-v5-door` lane is wiring the door + making
+    unknown versions fail loud instead of silently serving v1. State: v5 built in a worktree,
+    NOT merged, NOT deployed; prod is still v4. **DO NOT flip the flag to v5 before that lands.**
+- **🔴 P0 — PII log leak, WhatsApp phone numbers in cleartext prod logs (pre-existing, proven by
+  execution today, cure in flight — `fix-authz-pii-log` lane).** `tool_authorizer.py:381-389
+_audit()` logs `user=%s` from `user_email`, and `tool_executor.py:296` passes `user_id` as
+  `user_email`; on WhatsApp `user_id = whatsapp_<phone>`. So a client's phone number is written to
+  production logs in cleartext — on the **ALLOW path too**, i.e. every tool call, not just
+  denials. UU PDP Art. 67-68 / SYMBIOSIS Law 2. State: bug LIVE in prod; fix NOT merged, NOT
+  deployed.
+- **🔑 T4 keystone: the bridge already exists, one hop is missing.**
+  `whatsapp_identity.resolve_sender_identity` already returns `team_member_email` (DB branch), and
+  `_resolve_trusted_wa_profile` already calls it server-side behind the dedicated
+  `X-WA-Bot-Profile-Key`. It is simply never fed to `get_agent_role(email)`
+  (`team_agent_config.py:498`) — which is why `agent_role` is always `None` on WA and
+  `SENSITIVE_TOOLS={crm_query,timesheet,team_knowledge}` hard-deny every team member.
+  **T8 measured**: `team_members` with WhatsApp = **17**, VASSAL `TEAM_AGENTS` = **16**, in BOTH =
+  **15** → 15/17 get a working principal on day one; 2 have WA but no role, 1 the reverse (the
+  env-only branch returns no email at all and must degrade observably).
+- **🧰 TOOL-SEAT LIVENESS (probed live 2026-07-25 — Esiste≠Armato applies to our own instruments)**:
+  `kimi -m kimi-code/k3` ✅ · `agy` ✅ · **`codex` ❌ 401 Unauthorized** (OAuth revoked → interactive
+  `codex login`, `operator[GUI]`) · **`wa-tester` ❌ `PAIRED_BUT_CONNECT_FAILED — logged out`**
+  (device unlinked; re-pair needs a QR scan from Zero's phone → `operator[physical]`) — the
+  end-to-end channel probe is DOWN, so prove-live currently runs through the in-container brain
+  probe + the outbox/ledger state delta. **`flyctl` auth lives ONLY on Mini** (Pro's `FLY_API_TOKEN`
+  is unauthorized and `~/.fly/config.yml` has no usable token) — the M5 `fly` shell wrapper, which
+  ssh's to Pro, is dead; deploy/secrets/logs must go `ssh mini`.
+- **Operational traps that cost hours 2026-07-25 — read before repeating them**:
+  - M5 lacked the Postgres role `nuzantara` (hardcoded `backend/tests/conftest.py:28`), so 7
+    tests in `test_migration_113.py` ERRORED (not skipped) and killed EVERY full-suite pre-push
+    from this machine. Cure: `CREATE ROLE nuzantara LOGIN SUPERUSER` locally.
+  - A pre-push suite longer than GitHub's HTTPS idle timeout leaves `git push` HANGING FOREVER on
+    a `(CLOSED)` socket AFTER the gate already passed — green gate, no push, no error. Cure:
+    batch every ready branch into ONE push (the hook unions all refs, so N branches cost 1 suite)
+    plus `-c http.lowSpeedTime=120` so a dead socket errors instead of hanging.
+  - `kill -TERM` on a `git push` does NOT kill its pre-push hook subtree; orphaned hooks kept two
+    full suites running for 44 minutes. Sweep orphaned ANCESTORS (`ps -eo pid,ppid | awk
+'$2==1'`), and kill CHILDREN FIRST or init re-adopts them.
 - **P0-ID WA persona-override forgery — SHIPPED+DEPLOYED+PROVEN (PR #3062, 2026-07-24)**: the
   trusted "creator/team" persona override in `agentic_rag.py` was forgeable — a first server-side
   fix (re-resolving the WA sender phone instead of trusting a client-declared `profile` field) was
@@ -107,15 +212,15 @@ PARTIALLY_VERIFIED | Score: 0.75`, `[VerificationStage] ... verdict_available=Tr
 - **GARUDA-E23 law_refs delta-harvest LIVE**: Perpres 20/2018 (revoked in full by PP 34/2021)
   re-cited to PP 34/2021 Pasal 19/6 on 2 prod points (Q2/Q6), answers untouched, neighbors
   no-drift.
-- **Team-assistant V1 IN FLIGHT (task #29)**: sender-identity wiring into the live meta-inbox
-  path (resolve team/owner from `team_members.whatsapp` + env, profile.role into RAG payload →
-  TEAM/CREATOR persona finally reachable). Innocence contract: clients/unknown byte-identical.
-  Phase 2 (CRM scoped tools per assigned_to) parked pending Zero GO.
-- **wa-tester LID under-match (task #26, low-pri)**: isPaired fix PR #2820 live on Pro; the
-  battery's receive matcher `remoteJid !== BOT_JID` drops replies syncing under `@lid`
-  (WhatsApp LID rollout) → `reply_count:0` false negative even though the bot answered (ground
-  truth via Postgres — see the P0 prove-live above). Instrumentation-only, not a bot-behavior
-  bug.
+- **Team-assistant V1 — MERGED, NOT "in flight" (PR #2872, 2026-07-20)** _(corrected 2026-07-25 —
+  this line and §6 both claimed IN FLIGHT for five days)_: sender-identity wiring into the live
+  meta-inbox path landed. **Phase 2 (4 read-only CRM scoped tools) is ALSO MERGED (PR #2890)** —
+  it is not "parked pending Zero GO". What is actually missing is ARMING + a principal:
+  `WA_TEAM_CRM_TOOLS_ENABLED` is UNSET in prod (default false), and even armed it would deny,
+  because `agent_role` is never derived on the WA path (see the T4 keystone in §1). Merged ≠ live.
+- **wa-tester LID under-match (task #26) — FIXED (#2903)**. Superseded by a NEW problem: the
+  wa-tester session itself is **logged out** (`PAIRED_BUT_CONNECT_FAILED`), so the end-to-end
+  channel probe is down until someone re-pairs it by QR (`operator[physical]`).
 - **PR #2586 MERGED**: 4 production bugs of the outbox worker fixed (burst duplicate replies,
   takeover-during-generation send, generating-crash orphan, FAQ prewarm scope mismatch) +
   per-thread advisory lock, claim-token fencing, lease heartbeat, burst coalescing, K workers
@@ -132,8 +237,11 @@ PARTIALLY_VERIFIED | Score: 0.75`, `[VerificationStage] ... verdict_available=Tr
   `start_as_current_observation(..., as_type="span")` — the old name doesn't exist in v4 at all.
   `_process_query_traced` in `agentic_rag.py` called the v3 name unguarded, so every
   `/api/agentic-rag/query` call raised `AttributeError` before the orchestrator ever ran. Outbox
-  outcome: 61 failed sends vs 1 success. Emergency mitigation (still active): Fly secret
-  `LANGFUSE_ENABLED=false` (kill-switch in `observability.py::is_enabled`). **Durable fix**: this
+  outcome: 61 failed sends vs 1 success. Emergency mitigation was the Fly secret
+  `LANGFUSE_ENABLED=false` (kill-switch in `observability.py::is_enabled`) — **NO LONGER ACTIVE
+  (corrected 2026-07-25)**: `flyctl secrets list -a nuzantara-rag` shows no `LANGFUSE_ENABLED`
+  entry and the Langfuse keys are deployed, so `observability.py`'s default `"true"` applies and
+  **tracing is ON in prod**. The "still active" framing below is historical. **Durable fix**: this
   PR — `backend/core/observability.py::start_traced_span()` resolves v4-first/v3-fallback via
   `hasattr` and fails open (no-op span + WARNING log) on any mismatch, applied at both real call
   sites (`agentic_rag.py`, `tone_council.py`). Re-enabling tracing in prod (`fly secrets unset
@@ -254,12 +362,16 @@ LANGFUSE_ENABLED` or set back to `true`) is an operator action AFTER this PR mer
   `WA_BOT_MAX_CONCURRENT_GENERATIONS`, `ZANTARA_PROMPT_VERSION`, `CURATED_QA_INJECTION_ENABLED`,
   `DOMAIN_ABSTAIN_THRESHOLDS`.
 - **Corpora**: `data/curated_qa/*.jsonl` (E33 216 via `curated_qa_convert_e33.py`; golden 28).
-- **Team phone SSOT**: `team_members.whatsapp` (F2 detection key).
-- **Team-assistant V1 (task #29) IN FLIGHT since 2026-07-19**: upstream identity plumbing for
-  F2 (team check-in) — sender-identity resolution into the live meta-inbox path (see §1). A PR
-  for this track may already be open (or merging) by the time this note is read — a sibling
-  recovery lane was pushing it in parallel; check `gh pr list` for the current state rather
-  than trusting this line's snapshot.
+- **Team phone SSOT**: `team_members.whatsapp` (F2 detection key). **Coverage measured
+  2026-07-25**: 17 rows carry a WhatsApp number; `TEAM_AGENTS` (VASSAL roles,
+  `team_agent_config.py`) has 16 entries; **15 appear in both** → 15/17 team members get a real
+  principal once T4 lands. 2 have WhatsApp but no VASSAL role, 1 the reverse. Note the env branch
+  (`WHATSAPP_TEAM_NUMBERS`) resolves a team member WITHOUT an email, so those senders can never
+  obtain an `agent_role` — that path must degrade observably, not silently.
+- **Team-assistant V1 (task #29) — CLOSED/MERGED (#2872 + #2890, 2026-07-20)**, corrected
+  2026-07-25. The remaining work is not "plumbing identity" but **T4** (derive `agent_role` from
+  the already-resolved `team_member_email`) + **T-VIS** (per-request tool minimisation) + arming
+  the flag. See §1.
 
 ## 7. Collaboration protocol (the TRACK)
 

--- a/research/operations/2026-07-24-zantara-bot-consultant-assistant-spec.md
+++ b/research/operations/2026-07-24-zantara-bot-consultant-assistant-spec.md
@@ -1,0 +1,442 @@
+---
+date: 2026-07-24
+domain: bot
+title: Zantara WA bot — spec for the perfect client consultant + agentic team assistant
+status: FINAL (council-reviewed; ready for Opus 4.8 as executing architect)
+author: Fable 5 (M5)
+method: TAC over a 12-lane workflow (8 audit + 4 reuse-first research) → draft → 3-seat cross-family adversarial council (Codex red-team, Gemini costruttivo, Kimi refuter) → disk re-verification of every P0 → this synthesis
+sources:
+  - 8 audit-lane outputs + 4 research-lane outputs (scratchpad/tac/*.json)
+  - council verdicts (scratchpad/tac/council-*.json)
+  - independent disk re-verification (agentic_rag.py, hybrid_auth.py, tool_executor.py, wa_outbox_worker.py, team_crm_tools.py, observability.py, orchestrator_core.py)
+client_case: n/a (infrastructure/product)
+consumers: Opus 4.8 (architect, executes), Zero (Legge-5 gates)
+adversarial_review: codex
+---
+
+# Zantara WA bot — the perfect client consultant + agentic team assistant
+
+> **Reader's contract.** Verdicts from the council are LEADS, not facts (W65). Every 🔴 P0 in
+> this spec was re-grepped on disk THIS synthesis and carries its file:line. Where the council
+> was wrong (Gemini's BKPM "correction"), this spec keeps the org's verified fact and says so.
+
+## Adversarial review
+
+Generator≠grader (R1): this spec (drafted by Fable 5, the author) was reviewed by a **3-seat
+cross-family council on fresh context** — none of the three had seen the draft's reasoning before
+being asked to attack it — and every P0 verdict was re-verified on disk by the author before being
+folded in (a council verdict is a LEAD, not a fact; W65).
+
+- **codex** (OpenAI family, red-team chair — *find the flaw, default to defective*): found the two
+  most consequential flaws in the entire draft — (1) the draft's "cross-session memory works" claim
+  was actually a **live P0**: the router discards the per-phone WhatsApp identity and substitutes a
+  single shared internal pseudo-identity as the memory key, so all clients' long-term facts were
+  being saved/read under ONE bucket (cross-client bleed, UU PDP); (2) the persona-override + a
+  reserved tool-call argument were both forgeable via the same shared internal key. Both SURVIVED
+  into the final spec as W-1 P0-MEM / P0-ID / P0-ARG and were disk-confirmed by the author
+  (`hybrid_auth.py:380-385`, `agentic_rag.py:398-405,475`, `memory_handler.py:138`,
+  `tool_executor.py:346-349`) before the containment fix was built and shipped (PR #3036).
+- **gemini** (Google family, costruttivo chair — *save the plan by improving it*): raised real
+  WhatsApp-platform gaps (media-URL expiry before ack, chunk-ordering/formatting risk, UU PDP
+  consent capture, advocate-license disclaimer) — SURVIVED into C1/C2/C16. Also asserted the
+  BKPM PT-PMA capital baseline should be 10 miliar — this did **NOT** survive: it contradicts the
+  org's own verified fact (BKPM 5/2025 abrogated 4/2021, baseline is 2.5 miliar,
+  `fact_bkpm_5_2025_paidup_capital_2_5_mld_2026_07_16`), so the author kept the verified fact and
+  logged the disagreement in §4/C15 rather than silently trusting the external seat (W90 —
+  even a ground-truth-shaped verdict can be stale).
+  Docs-only PRs are exempt from CI code checks; this section satisfies the R1 gate
+  (`scripts/check_adversarial_review.py`) for the research-deliverable convention.
+- **kimi** (Moonshot family, refuter chair — *falsify the core claim*): refused the draft's
+  "reconnect the nerves, don't build" framing as incomplete — flagged an unowned landmine
+  (`whatsapp_persona.py`'s hardcoded price list), an undefined O-item shorthand, a sequencing risk
+  (arming the team CRM surface before observability lands), and the retention/consent tension in
+  the memory-governance claim. All SURVIVED into §3 (whatsapp_persona landmine → W0), §6 (O1-O6
+  defined), and §10 (W2 reordered to sit with/after W3's security telemetry).
+
+No verdict was accepted uncritically: every P0 was re-grepped on disk by the author (Fable 5) before
+being written into the final spec, per the org's anti-hallucination discipline (a refuter can
+hallucinate too — W65).
+
+## 0. Verdict
+
+The bot has a **safe, correct brain** and a **hardened transport**. Two things are NOT true of it
+today, and they are different in kind:
+
+- **(A) The live path lost its manners and its instruments.** Almost every "good consultant"
+  reflex (ack, chunked send, read receipt, error message) and every ops organ (abstain dashboard,
+  golden-set eval, regulatory-obsolescence trigger, fallback provider) *already exists in code*,
+  wired to the DEAD legacy path or gated behind an unset flag, and never reaches the live client.
+  This is the **dominant class by count** — cheap to cure (connect + arm + schedule), reuse-first.
+- **(B) Two identity/data-contract boundaries are broken.** These are **fewer but P0**, and the
+  "just wiring" framing of (A) actively hides them: the live path collapses every WhatsApp sender
+  to ONE shared internal identity (cross-client memory bleed, disk-confirmed), and the persona-
+  override + reserved-arg trust boundaries are forgeable. **No feature may be built on top of these
+  until they are contained.**
+
+**Readiness is impressionistic, not measured** (the council was right to flag it): there is no
+golden multi-turn eval baseline yet, so treat "brain live / manners disconnected / team half-armed"
+as the shape, not "65%/40%". **The first executable step is to establish that baseline** (§8, W-1).
+
+---
+
+## 1. The two meta-patterns (Gear-3 mandatory — corrected by council)
+
+The draft claimed one disease. The council (Codex + Kimi) correctly refused it: one pattern explains
+the wiring gaps but **cannot** explain identity trust, tenant isolation, or provider sovereignty.
+There are **two**, and conflating them is itself the most dangerous error:
+
+### Pattern A — Esiste ≠ Armato (superscar #2), dominant by count
+*One defective belief: "if the capability is in a module, the behavior is live."* The question never
+asked was **"which code PATH actually calls it?"** (`feedback_merged_is_not_live_consumer_map_first`).
+The live number runs **Path B** (`whatsapp_chat.py` → `meta_inbox_*` → `wa_outbox_worker.py` →
+`wa_inbox_bot.py` → `/api/agentic-rag/query`), rebuilt fast for correctness + safety. It inherited
+the brain but not the manners — those live in the legacy `process_whatsapp_message` path (Path A,
+"not this number's brain"). Every row below is a built, tested capability that does not reach the live client:
+
+| Capability | Exists in | Live on Path B? |
+|---|---|---|
+| "working on it" ack (`whatsapp_ack.py`, tested) | legacy path only | ❌ client waits 10-50s blind |
+| multi-message chunking (`message_chunker.chunk_message`) | legacy path only | ❌ answers cut at 4096 chars |
+| read receipt (`mark_message_read`) | legacy path only | ❌ no blue tick |
+| error/apology on failure | legacy path only | ❌ terminal failure = silence |
+| team CRM read tools (#2890 merged+tested) | orchestrator, flag-gated | ❌ `WA_TEAM_CRM_TOOLS_ENABLED` unset (default false) |
+| `RetrievalQualityMonitor` (abstain/latency dashboard) | built + REST | ❌ `record_*()` never called → dashboard always zero |
+| generation-faithfulness eval (`apps/evaluator/rag_eval/`) | built + golden set | ❌ no cron → 7 weeks unrun |
+| curated-QA regulatory obsolescence (`curated_qa_regen_trigger.py`, W90 antidote) | built + tested | ❌ no schedule → stale answers up to 30d |
+| inbound rate-limit (`ChannelRateLimiter`) | built | ❌ not wired to WA ingress |
+| abstain-rate Prometheus counters | fire live | ❌ no alert consumer |
+
+**Inverted twin (still armed on the wrong path):** `whatsapp_persona.py` injects the full hardcoded
+price list into the system prompt (violating PricingTool-only) and fires the instant a second
+`phone_number_id` is onboarded. The dead path kept its landmine while the live path lost its manners.
+
+### Pattern B — Broken identity & data-contract boundaries (the dangerous minority)
+Not wiring — *design*. On Path B the caller authenticates with a **shared** internal key that resolves
+to a **fixed pseudo-identity**, and trust decisions read **client-settable body fields**. These are the
+P0s that Pattern A's optimism masks. They are enumerated as W-1 below and MUST be contained before any
+Pattern-A wiring widens the surface.
+
+**Why the split matters for Opus:** most of the plan is connect/arm/schedule (Pattern A, low risk,
+high leverage). But the *first* work is containing Pattern B — arming team tools or memory-dependent
+features on a forgeable principal / shared memory namespace turns a latent leak into an active one.
+
+---
+
+## 2. What is REALLY ready and live (proven — evidence on disk)
+
+**Transport (solid, keep):** ack-first HMAC webhook (`whatsapp_chat.py:1171-1200`), double dedup
+(`inbound_webhooks` UNIQUE + `meta_message_id` ON CONFLICT), per-thread advisory lock with the
+str-typed-key P0 fixed (`wa_outbox_worker.py:303-306,344-347`), burst coalescing, claim-token fencing,
+lease heartbeat, takeover-during-generation re-check, 24h-window enforcement, K workers + admission
+semaphore. Media handed off metadata-only to the sovereign Pro-side intake — Fly never stores client PII.
+
+**Brain (safe, live):** Gemini 3.5-flash / 2.5-flash (`llm/config.py:16-18`); 5 named abstain gates
+via one SSOT (`_abstain_policy.py`); ReAct cap 2 on WA (`wa_inbox_bot.py:267`, `whatsapp_chat.py:537`);
+`CURATED_QA_INJECTION_ENABLED` default `"true"` → grounding injection **is on** in prod.
+
+**Prompt (governed, live):** the versioned door (`prompt_manager.py`) is the source for Path B; prod
+pinned `ZANTARA_PROMPT_VERSION=v4` (probed live); v4 carries `{today_wita}`, deadline-neutral KBLI
+triage, escalation + identity-lock worked examples, `_safe_template_fill`. WA overlay forces plain-text/short.
+
+**Team identity wiring (merged):** `resolve_sender_identity` (owner>team>client>unknown, fail-closed)
+wired into Path B (#2872); `WHATSAPP_OWNER_NUMBERS` (2) + `WHATSAPP_TEAM_NUMBERS` (20-person roster)
+SET in prod; TEAM/CREATOR persona reachable; team answers excluded from shared cache.
+
+**Cache/corpus (built, mostly live):** provenance contract enforced `ValueError` (5 keys); Redis
+verbatim JELAS-only + Qdrant curated_qa grounding; `--verbatim-all` retired; class TTL (JELAS 30d/else
+7d); pricing-content detector is a currency+digit regex (scar-#3-safe); 396 curated Q&A / 21 files;
+PR #2810 rails MERGED; 51 curated_qa unit tests pass.
+
+**Security (post-tourniquet #2962):** SENSITIVE_TOOLS `{crm_query,timesheet,team_knowledge}` denied
+for `agent_role=None` **before** the no-principal passthrough (`tool_authorizer.py:79-90`); streaming
+CRM prefetch gated on `agent_role is not None`; clock-in/out ignore body identity for non-admin.
+
+**Observability — corner CORRECTIONS (verified this synthesis):**
+- Langfuse tracing is **ENABLED** in prod (default `"true"` when keys present, keys deployed, no
+  `LANGFUSE_ENABLED=false` secret — `observability.py:53`). The corner's "kill-switch active" is **STALE**.
+- `llm_cost_events` recorder FIXED and landing rows (#2845). `rag_canary.py` armed + green every 6h
+  (15/15 golden queries). wa-tester LID under-match FIXED (#2903). Operator console = hardened loopback proxy.
+
+---
+
+## 3. W-1 — CONTAINMENT (Pattern B — the P0s, disk-confirmed, block everything)
+
+> **These are not in a gap matrix with the rest because they gate the rest.** Each was re-verified
+> on disk this synthesis. Opus must treat W-1 as the first stage and, for P0-MEM, as a possible
+> **active prod incident** (autoreply is ON, traffic is currently low — contain before it grows).
+
+| id | Finding (verified) | Evidence | Cure |
+|---|---|---|---|
+| **P0-MEM** | **Cross-client memory bleed.** Path B authenticates via `X-Internal-Key` → `hybrid_auth.py:380-385` returns a **fixed** pseudo-identity `{role:internal, email:"wa-mirror-internal@balizero.com", user_id:"wa-mirror-internal"}` for EVERY sender. `agentic_rag.py:398-405` **discards** the per-phone `whatsapp_{phone}` and substitutes `authenticated_user_id = current_user.email`; `:475` passes it as `user_id`. `memory_handler.save_conversation_memory` skips only `user_id=="anonymous"` (`:138`) → the shared id is NOT skipped. Long-term client facts are stored under ONE key and read back mixed across clients. | file:line above, all re-grepped | **Disable Path B long-term memory immediately** until a **server-derived stable pseudonymous subject** (per-phone, non-PII) replaces the shared identity. Investigate + quarantine existing `wa-mirror-internal` facts. `context_manager.py` also logs sample personal facts directly — audit it. (In-thread history keyed on `wa_session_{phone}` is per-phone and OK; the FACT layer is the leak.) |
+| **P0-ID** | **Forgeable persona-override.** `_is_trusted_wa_profile_caller` (`agentic_rag.py:298-322`) allows a `profile` override on (`role=="internal"` from the **shared** key) AND (`channel=="whatsapp"` from the **client-supplied body**). Any holder of the shared internal key (incl. Pro-side scripts) can set `channel=whatsapp` + `profile={role:creator}` and get the creator persona. The code comment candidly admits this. | `agentic_rag.py:298-322,383-397` | A per-request **typed identity envelope** (authenticated service + stable subject + audience mode + channel + msg/thread id + profile provenance + nonce), OR re-resolve phone identity server-side. This is **T4** and it must precede T1. |
+| **P0-ARG** | **Reserved-arg forge.** `tool_executor.py:346-349` injects `_caller_profile`/`_user_id` only when the SERVER value is truthy; the `arguments` dict is LLM-supplied. On the client path (no server profile), an injected `_caller_profile={role:creator}` in a tool-call survives into `tool.execute(**arguments)`. Harmless until a team tool reads it AND team tools are registered (T1) — then it is a client→creator CRM-scope escalation. | `tool_executor.py:346-349` | **Never expose these keys in the LLM-facing JSON schema**; strip/reject ALL reserved keys (incl. nested/alias) BEFORE authorization AND before execution; build a fresh args mapping; inject context out-of-band. Test all team tools with forged fields. |
+| **P0-FLOOD** | **No inbound rate-limit / length cap** on the WA ingress reaching the LLM+tool loop — cost-bomb / flood (`ChannelRateLimiter` exists, unwired). | audit-security S3 | Wire `ChannelRateLimiter` (per-phone) + inbound text length cap at webhook ingest. Move into containment (precedes new acks/tools). |
+
+**W-1 acceptance:** two different phone numbers get **isolated** memory (A's facts never surface for B —
+proven by a runtime test, not code-reading); a request with a forged `profile`/`channel`/`_caller_profile`
+is rejected (test); flood/oversize inbound is throttled/capped. A **multi-tenant security test suite**
+(two phones, forged profiles, shared-key caller, unknown sender, takeover, duplicate webhook, memory/cache
+isolation) is the durable regression.
+
+---
+
+## 4. Gap matrix — the CLIENT CONSULTANT (Pattern A + domain gaps)
+
+Sev 🔴/🟡/🟢. Type WIRE / ARM / BUILD / DECISION / CONTENT.
+
+| # | Gap | Sev | Type | Cure (council-hardened) |
+|---|---|---|---|---|
+| C1 | Media/PDF/voice/location/contact inbound → **zero reply, ever** | 🔴 | WIRE | Correlated state machine (received→accepted/rejected→processing→ready/failed); ack only what's accepted; classify no-text as **permanent, not retried**. **Fetch+persist media binary BEFORE ack** — Meta media_id URLs expire ~5 min (Gemini). Add media security lifecycle: type/size allowlist, retention, consent, deletion, failure reconciliation. |
+| C2 | Long answers **silently truncated at 4096** (`whatsapp_service.py:92`); worker sends once | 🔴 | BUILD | **Durable chunk ledger FIRST** (per-chunk idempotency + WAMID persistence + partial-success recovery + takeover/24h-window fence before each chunk) — a naive loop is a duplicate-send regression on crash (Codex+Gemini). Then syntax-aware split at paragraph/tag boundaries, sequential rate-limited send. |
+| C3 | Client waits **10-50s blind** — no "working on it" | 🟡 | WIRE | Wire `whatsapp_ack` into `_process_claimed_row` after `generating`; ledger+coalesce acks per burst; suppress after takeover. |
+| C4 | Terminal failure → **pure silence** | 🟡 | WIRE | Best-effort language-aware apology in the 5-retry-exhausted branch. Idempotent, takeover-aware. |
+| C5 | **No read receipt** | 🟢 | WIRE | `mark_message_read(wamid)` from `_handle_meta_inbox_message`; no RAG dep. |
+| C6 | **Gemini is a single point of failure** — 429/prepay-depletion zeroes the bot (recurred 2026-07-22) | 🔴 | DECISION | **Default fail-closed**: queue/retry + neutral "having trouble, a team member will follow up" + human handoff. External fallback is NOT "classify non-PII pre-failover" (unsafe on free-text WA — names/passport/KITAS appear anywhere; UU PDP Art. 56). Any fallback needs a deterministic redaction pass EXCLUDING attachments/history/memory/retrieval/tool-outputs, or a dedicated endpoint — a Zero Legge-5 ruling. Until ruled, `openrouter_enabled` stays off; the mitigation is the **Gemini-429 alert (O1)**. |
+| C7 | `classify_query_domain` **bare substring**, missing English "vat"; colloquial aliases (Investor KITAS/B211A) miss official terms (`reasoning_utils.py:607-633`) | 🟡 | BUILD | Add `vat`; build an **alias dictionary** (colloquial→official) + move toward intent classification; guard-conformance guilt+innocence test (scar #3). **Correctness bug — sequence in W1/W4, not last** (Kimi). |
+| C8 | **ReAct cap 2** truncates compound first-contact questions | 🟡 | BUILD | Question-count heuristic → `max_steps=3` for compound only. **Only after W3 telemetry + W4 baseline exist** (Codex). |
+| C9 | **No general clarify-before-answer policy** | 🟡 | BUILD | Domain-agnostic `CLARIFYING_QUESTION_POLICY` in v5 (Sierra/Intercom/agy converge). |
+| C10 | **No escalation-to-human UX** | 🟡 | BUILD | Escalation-trigger matrix (explicit ask / repeated-abstain loop / red-flags: overstay>60d, nominee, active audit / high-stakes) → structured warm-handoff payload. **Plus the operating contract**: owner, hours, SLA, queue, stale-escalation handling, client-facing message when no human available (Codex+Kimi) — else a dead-end. |
+| C11 | **No follow-up/CTA** on WA | 🟢 | BUILD | WA overlay: after N exchanges on a concrete case, suggest formalizing ("already talking to us"). Requires inbound interactive-payload parsing if buttons used (Gemini). |
+| C12 | Curated corpus **thin** (396 rows, some 14) | 🟡 | CONTENT | Grow via existing pipeline; feeds the promotion loop (O4). |
+| C13 | Curated **regulatory-obsolescence unarmed** → stale JELAS up to 30d (reintroduces W90) | 🔴 | ARM | Schedule `curated_qa_regen_trigger.py` in **dry-run/proposal mode first** (promotion needs a review gate — Codex). Add an **emergency delta path** for Surat Edaran that change faster than 30d (Gemini). Can ride early (one-line cron) ahead of W3's other items. |
+| C14 | No ru/uk business phrases (active Ukraina segment); **cross-lingual retrieval recall drop** for ru/it queries vs EN/ID vectors | 🟢/🟡 | BUILD | Add ru/uk to `business_rules_i18n`; add query translation / cross-lingual dense retrieval (Gemini). |
+| C15 | Stale **10-miliar** PT PMA capital in a few-shot reachable via `gemini_service.py` | 🟡 | WIRE | **Our verified fact stands: BKPM 5/2025 baseline = 2.5 miliar; >10 miliar survives per-KBLI/location only** (`fact_bkpm_5_2025_paidup_capital_2_5_mld_2026_07_16`). Gemini's council "correction" to 10 miliar is **stale training data — DO NOT apply**; cite the regulation directly. Refresh/remove the few-shot; route `zantara_persona.py` through `prompt_manager`. |
+| C16 | **No advocate-license disclaimer** (UU Advokat 18/2003) on legal/tax/visa answers; **no UU PDP consent capture** on first contact for storing `wa_session_{phone}` + processing passport/visa docs | 🟡 | BUILD | Add a "general regulatory info, not formal legal counsel" disclaimer to the relevant answer classes; add a first-contact consent capture gate (Gemini). |
+
+---
+
+## 5. Gap matrix — the AGENTIC TEAM ASSISTANT
+
+| # | Gap | Sev | Type | Cure |
+|---|---|---|---|---|
+| T4 | **Two parallel auth systems** — `whatsapp_identity._caller_profile` (reaches WA) vs VASSAL `agent_role` (set only on workspace-stream); the WA principal is forgeable (P0-ID) | 🔴 | BUILD | **Unified server-side principal** for Path B satisfying BOTH the SENSITIVE_TOOLS gate and `_caller_profile`. **This is a W-1/W2 prerequisite, not a mid-sequence item** — all three seats: activating tools on a forgeable principal is unacceptable. |
+| T1 | 4 read-only CRM tools (#2890, merged+tested) **not armed** | 🔴 | ARM | `WA_TEAM_CRM_TOOLS_ENABLED=true` + redeploy — **only AFTER T4**. Prove-live from a real team number. |
+| T-VIS | Client callers still **receive team tool declarations** (deny at execution ≠ absence) → the "byte-identical client" criterion is invalid as written (Codex) | 🔴 | BUILD | **Per-request tool minimization**: team tools ABSENT (not just denied) from the registry for client/unknown callers. Replace the innocence criterion with schema-absence + semantic-regression tests. |
+| T2 | **WA check-in dead**: `timesheet` ∈ SENSITIVE_TOOLS and `agent_role` never set on WA → hard DENY (silent regression of #2962) | 🔴 | BUILD | 5th `team_timesheet` tool authorized by the **unified principal** (T4), writing via `team_timesheet_service`, through the unified authorizer + **confirmation + immutable audit + idempotency/timezone/duplicate-check-in handling**. WRITE → Zero GO + own flag. |
+| T3 | **`team_knowledge` (handbook/SOP) dead on WA** (same agent_role=None deny) | 🟡 | BUILD | `_caller_profile`-scoped knowledge tool beside the CRM tools, not the VASSAL gate. Data-minimized output (read-only ≠ PII-light). |
+| T5 | **No draft-a-client-reply tool** | 🟡 | BUILD | Composes PricingTool + KG/RAG into a draft, unified-principal-scoped, **never auto-sends** (Legge 5). Guard against **indirect injection** (CRM notes/memory content reaching the draft — Kimi). |
+| T6 | **No reactive briefing** ("cosa ho oggi?") | 🟡 | BUILD | `team_my_deadlines` has the data; add a greeting/briefing intent (reactive, in-window). Proactive push stays Telegram/email (ruling 2). |
+| T7 | No task/reminder capture, no lead-notification pull | 🟢 | BUILD | Scoped write-tool (own Zero GO — breaks read-only invariant) + "new assignments?" pull-tool. |
+| T8 | `team_members.whatsapp` **completeness unverified** — drift risk (new hires missed / leavers kept) | 🟡 | ARM | Read-only count; backfill; roster-vs-env drift check. |
+| T9 | **Team persona CONTENT unaudited** (`zantara_core.py` not read this pass) | 🟢 | VERIFY | Opus reads it; confirm runtime client/team/owner branch. |
+| T10 | **Same person is team AND personal client** — precedence owner>team>client denies them client-mode history separation for their own case (Kimi) | 🟢 | BUILD | Design note / acceptance criterion for the role-collision. |
+
+---
+
+## 6. Observability gap matrix (the O-items — defined, per Kimi)
+
+| id | Gap | Sev | Type | Cure |
+|---|---|---|---|---|
+| O1 | **No Gemini-429/prepay-depletion alert** — the 2026-07-22 outage was found by accident | 🔴 | BUILD | Catch the google-genai exhausted/429 class at the `llm_gateway.py` raw call sites → `alert_service.send_alert` (Telegram), not just `logger.warning`. This is C6's mitigation. |
+| O2 | **No outbox-failure-spike alert** | 🟡 | BUILD | Counter + thresholded alert in the worker failure path. |
+| O3 | **Generation-faithfulness eval unarmed** (`apps/evaluator/rag_eval/`, 7 wks) | 🟡 | ARM | Cron mirroring `rag_canary.py`; post pass-rate. **Recognize CLARIFY/ESCALATE as valid outcomes — align with W4's taxonomy or it scores them as failures** (Gemini). |
+| O4 | **Curated promotion loop** — abstain/low-confidence → expert-review queue → promote with provenance (compounding asset — Kimi+Decagon) | 🟡 | BUILD | Queue + review gate + harvest (operator-gated per corner). |
+| O5 | `RetrievalQualityMonitor.record_*` **never called from live path** → dashboard always zero; `query_analytics` has no confidence/abstain columns | 🟡 | WIRE+BUILD | Wire `record_abstain/record_query` at the `emit_strict_abstain_metrics` sites; migration adds `confidence_score`/`abstained`/`abstain_reason` (Codex sandbox: upgrade+downgrade). |
+| O6 | **No synthetic end-to-end channel canary** — the 11-day Langfuse outage was invisible to the API-only canary | 🟡 | BUILD | A low-frequency synthetic outbox-insert (or off a staging `phone_number_id`) walking the real ledger path; needs a **staging WABA/test number** with a home in a workstream (Kimi). Balanced scorecard (Klarna 20-F): automation + resolution + repeat-contact + escalation + CSAT — never deflection alone. |
+
+---
+
+## 7. Cross-cutting security (beyond W-1)
+
+| # | Risk | Sev | Cure |
+|---|---|---|---|
+| S1 | **`CRMTool.limit` unclamped** — an authenticated team session (or in-session injection) can dump the clients/practices PII table in one call (`tools.py` CRMTool.execute, no clamp) | 🔴 | `limit = max(1, min(int(limit), 50))`. **General hardening — NOT the T1 gate** (the 4 team tools clamp at 30 independently; the T1 gate is T4+P0-ARG). Do it in W0. |
+| S2-indirect | **Second-order prompt injection**: guard items cover live client free-text, NOT injected content sitting in CRM notes / memory / curated-QA that a team draft/tool later reads (Kimi) | 🟡 | Sanitize/scope CRM + memory content before it reaches team-tool/draft context. |
+| S4 | **JWT expiry not enforced in prod** (`config.py:501` default false, no override) — leaked JWT valid forever app-wide | 🔴 | DECISION+ARM: verify refresh-token flow, then `JWT_ENFORCE_EXPIRY=true` (blind flip logs out live sessions — ops window). |
+| S5 | **Orphan test tree** `apps/backend-rag/tests/` (276 files incl. auth + CRM-integration) not collected by CI | 🟡 | Merge into `backend/tests/` (dedup) or add a CI step; prove with a deliberately-broken assert. **NB: W-1/W0 acceptance must not reference this until it lands — forward-dependency (Kimi).** |
+| S6 | **Phone-number recycling** (telco reassignment inherits case-file access) — root-of-trust risk, no re-verification | 🟡 | Low-trust/re-verify dormant identities; a workstream item, not just a named risk. |
+| S7 | **Double-send residual** — accepted-but-unmitigated window, no reconciliation job (Kimi) | 🟡 | Idempotency/dedup reconciliation sweep in the transport workstream. |
+
+---
+
+## 8. Target architecture — the destination
+
+The research converges on a shape the stack is already ~70% toward. **Do not re-architect; complete
+it — after W-1 contains Pattern B.**
+
+**Client consultant — Query → Evidence → Answer → GATE → (Send | Clarify | Abstain | Escalate):**
+1. **Input rail** (missing): prompt-injection/jailbreak + length/rate check before the LLM (NeMo 5-rail
+   taxonomy — our gates are retrieval+output-side only). Covers direct AND indirect (CRM/memory) injection.
+2. **Retrieve** approved sources only — live.
+3. **Generate** — live.
+4. **Pre-send supervisor grade** (partially live): four-outcome fail-closed SEND/CLARIFY/ABSTAIN(explained)/
+   ESCALATE; **per-claim grounding decomposition** for KBLI/visa/tax/deadline numbers (generator≠grader).
+5. **Deliver with manners** (the disconnected nerves): ack → durable-ledger chunked send → read receipt →
+   error fallback.
+6. **Govern memory** (Decagon dual-layer + write-gate): raw history + structured facts carrying
+   provenance/timestamp/consent/expiry (UU PDP-native) — **keyed on a per-phone pseudonymous subject, never
+   the shared internal identity** (W-1); CRM/PricingTool always authoritative over memory. Retention/expiry
+   is an OWNED item, not a claim (Kimi).
+
+**Team assistant — same number, server-side sender-RBAC persona switch (never prompt-inferred):**
+unified principal (T4) → satisfies gate AND `_caller_profile`; per-request tool minimization (T-VIS);
+read tools armed (T1); check-in (T2) + knowledge (T3) via the principal; draft-reply (T5, never auto-send);
+reactive briefing (T6). **Manager topology** (OpenAI): one conversational face, invisible delegation to
+visa/company/tax/property specialists — split to true multi-agent ONLY on measured routing failures (ties to O5).
+
+---
+
+## 9. Reuse-first adoption (OSS — re-verify each LICENSE on the exact repo/commit before vendoring)
+
+| Brick | Adopt | Label | License |
+|---|---|---|---|
+| Voice-note transcription (C1) | `faster-whisper` | INSTALLA-LIB | MIT |
+| WhatsApp interactive (buttons/lists/Flows) + inbound interactive-payload parsing (C11) | `pywa` | FORKA-E-ADATTA | MIT (verify) |
+| Golden-set regression in CI (O3) | `DeepEval` (pytest-native) | INSTALLA-LIB | Apache-2.0 (verify) |
+| Offline corpus-tuning eval | `Ragas` | INSTALLA-LIB | Apache-2.0 |
+| Prompt A/B + red-team | `promptfoo` | INSTALLA-LIB | MIT |
+| Governed per-phone memory (W-1/O4) | `mem0` (lib) / `Graphiti` temporal-fact pattern | INSTALLA-LIB / STUDIA-PATTERN | Apache-2.0 |
+| Input rail (§8.1) | NeMo Guardrails 5-rail taxonomy | STUDIA-PATTERN | Apache-2.0 |
+| Handoff state machine (C10) | Chatwoot open/pending/resolved | STUDIA-PATTERN | MIT core (NOT enterprise/) |
+
+All public OSS research (no PII). Graphiti's fact-validity-interval pattern directly fights scar #9
+(stale reg served as current). Multi-turn dual-control eval (τ²-Bench) over single-turn QA for the harness.
+
+---
+
+## 10. Workstreams — sequenced (council-corrected order)
+
+Every build workstream ships through §11. Order is **containment → safety → nerves → identity → arm →
+observe → gate → richer**. Rationale for each move is the council seat that demanded it.
+
+- **W-1 · CONTAINMENT** 🔴 — P0-MEM, P0-ID (=T4 identity contract), P0-ARG, P0-FLOOD (=S3). Disable shared
+  Path B memory; per-phone pseudonymous subject; typed identity envelope; reserved-arg strip + schema-hide;
+  rate/length cap. **+ establish the golden multi-turn eval baseline** (Kimi — readiness is unmeasured).
+  *All three seats: this precedes everything.*
+- **W0 · SAFETY PRE-ARM** 🔴 — S1 (clamp CRMTool.limit), S2-indirect scoping, T-VIS (per-request tool
+  minimization). Defuse the **`whatsapp_persona.py` price-list landmine** (Kimi — it had no owner).
+- **W1 · RECONNECT THE NERVES** 🔴 — C1 (media state machine + fetch-before-ack + lifecycle), C2 (durable
+  chunk ledger THEN chunked send), C3, C4, C5, C15, C7-vat. Pure Pattern-A wiring + the chunk-ledger build.
+  Highest leverage/effort ratio. *Codex: chunk ledger before replacing truncation.*
+- **W2 · ARM THE TEAM ASSISTANT** 🔴 — **only after W-1/T4**: T1 (flip flag, post-T4+S1), T8 (roster). Then
+  T2/T3 (check-in, knowledge) on the unified principal. *All seats: T4 before T1.*
+- **W3 · OBSERVABILITY SPINE** 🔴/🟡 — O1 (Gemini-429 alert), O2 (outbox alert), O5 (wire monitor +
+  analytics migration), O3 (arm rag_eval), C13 (regen dry-run + emergency delta), O6 (E2E canary + staging
+  number). *Codex+Kimi: security telemetry (tool allow/deny, cross-scope attempts) must be visible BEFORE/
+  WITH W2 arming — pull O1/O2 + deny-metrics forward to sit with W2.*
+- **W4 · THE GATE + FOUR OUTCOMES** 🟡 (design-heavy → Opus owns) — C9, C10 (+ operating contract), C16
+  (disclaimer + consent), per-claim grounding, input rail (§8.1). v5 behind the door, additive/flag-gated,
+  parity test extended for the alias-reexport blind spot. NLM ground-truth on any regulatory claim.
+- **W5 · RICHER UX + REACH** 🟡/🟢 — C8 (adaptive cap, after W3/W4 baseline), C11 (CTA + interactive), C14
+  (ru/uk + cross-lingual retrieval), pywa Flows for intake, voice-note. **Second-number/Flow onboarding may
+  proceed only after the price-list landmine is defused (W0).**
+- **W6 · SECURITY HARDENING (ops-gated)** 🔴/🟡 — S4 (JWT flip), S5 (orphan tree into CI), S6 (recycling
+  re-verify), S7 (double-send reconciliation).
+- **W7 · CONTENT + PROMOTION LOOP** 🟡 (continuous) — C12 corpus growth, O4 promotion loop.
+
+---
+
+## 11. The agentic ship workflow (deterministic — internal powers + LLM)
+
+Per `/workflow`. Fable orchestrates + final-gates; Sonnet builds; externals grade (generator≠grader,
+cross-family). **This change class = security/PII/migrations/write-tools/identity ⇒ AUTO-MERGE OFF.**
+
+```
+For each workstream Wn (Opus selects order — W-1 → W0 → W1 → W2/W3 first):
+  1. GROUND     — re-grep exact file:line THIS turn (this spec's line refs are LEADS, W65).
+                  Consumer-map: which PATH calls the helper? (the Pattern-A gate)
+  2. DESIGN     — spec delta on disk; L2/L3 → Zero GO (AUTONOMOUS_OPS preflight).
+                  W-1/W2/W4/W6 touch identity/PII/migrations → design gets a Codex red-team pass.
+  3. BUILD      — worktree via scripts/agent_start.py (lane backend-rag); Sonnet implementer;
+                  TDD (guilt+innocence for any guard, scar #3); karpathy-discipline; leave-dirty to siblings.
+  4. VERIFY     — verify-template.js (gather→adversarial-refute→synthesize): Codex sol xhigh red-team ·
+                  GLM→Kimi K3 refuter · Gemini agy costruttivo/normativa · NLM ground-truth on reg claims.
+                  Multi-tenant security suite for W-1/W2 (two phones, forged fields, isolation).
+                  Fable does the last on-disk grep — never delegated/cascaded. Pattern-fix ⇒ class-audit
+                  ALL sibling call-sites incl. test asserts (W89).
+  5. SHIP       — atomic commit + co-author + docs_sync in-commit if a DOCSYNC surface moved (W86).
+                  ★ AUTO-MERGE OFF for this class ★ — PR opened, an INDEPENDENT adversarial gate
+                  (generator≠grader; a session that did NOT author the diff) must pass BEFORE merge.
+                  The SESSION still merges (ship-lifecycle ownership — the codeowner does not); sensitivity
+                  raises the gate's rigor, it does not move the merge to a human. Migrations → Squawk +
+                  Codex upgrade+downgrade. Per-principal canary/rollback allowlist + kill switch, not a
+                  single global env flag (Codex).
+  6. PROVE-LIVE — deploy from post-merge main (nuzantara-deploy); prove on the PUBLIC surface by CONTENT:
+                  real WA probe from a bot-allowlisted number (wa-tester), fly-logs delta vs baseline, prod
+                  DB aggregate (pg.sh, no PII). Prove on EVERY consuming surface. Probe fails → STOP-THE-LINE
+                  + rollback.
+  7. ALIGN-FLEET— M5/Pro/Mini main ff-only; restart consumers; skill liveness.
+  8. CLEAN      — reap worktree at 3-AND; branch delete only after PROVE-LIVE + blob-on-main.
+  9. CAPTURE    — mem save; update /bot corner §1 SAME turn; scar if trauma; AMENDMENTS if the loop misfired.
+```
+
+Ollama-local (`qwen2.5vl:7b` vision, `faster-whisper`) for any transform touching client PII —
+redaction-before-egress is the gate, never a cloud prompt with raw PII.
+
+---
+
+## 12. §Solo-operatore — Zero's Legge-5 / credential / GUI decisions
+
+> **RATIFIED by Zero 2026-07-24** (all items GO): (1) P0-MEM — contain NOW (disable Path B long-term
+> memory immediately, fix in W-1). (2) C6 Gemini SPOF — fail-closed permanent + O1 alert as the mitigation;
+> no external fallback egress. (3) team write-tools — GO, staggered, check-in first, all AFTER T4. (4) 24h
+> window — quantify weekly real-client drop first, then decide on a Meta template. (5) JWT-expiry flip — GO
+> in W6 with an ops window after verifying refresh-token flow. These are decisions, not open questions.
+
+Cannot be session-armed. Opus surfaces, does not implement around:
+
+1. **P0-MEM incident call**: contain now (disable Path B long-term memory) vs. accept-and-fix-in-W-1. Given
+   autoreply is ON, recommend **contain immediately** even before the full W-1 design lands.
+2. **C6 — Gemini SPOF ruling**: fail-closed (recommended) vs. authorize a redaction-gated dedicated-endpoint
+   fallback (COS-LAW-013 territory). Do NOT flip `openrouter_enabled` without the ruling.
+3. **T2/T5/T7 write-tool GOs**: each breaks the read-only invariant → individual Zero GO + own flag.
+4. **24h-window reachability / Meta template**: 81% of outbound "failures" are `24h_window_closed` (policy,
+   not bug). Whether to adopt an approved Utility Template for outside-window re-engagement is a business call
+   (ruling 2 currently rejects paid templates). **Quantify weekly dropped-client count first** (Gemini+Kimi).
+5. **S4 — JWT expiry flip**: logs out live sessions → ops window + refresh-token verification.
+6. **Credential/infra** (all operator): `fly secrets set` for T1/W3 arming, secret rotation, Actions secrets,
+   prod-DB writes, provisioning a staging WABA/test `phone_number_id` (O6).
+7. **Publishing/external**: no auto-send to any client (Legge 5) — draft-reply is draft-only by construction.
+
+---
+
+## 13. Acceptance criteria (falsifiable)
+
+- **W-1**: two phone numbers → isolated memory (A's facts never surface for B — runtime test); forged
+  `profile`/`channel`/`_caller_profile`/nested variants → rejected (multi-tenant suite); flood/oversize →
+  throttled/capped; a golden multi-turn eval baseline exists and is recorded.
+- **W0**: `CRMTool(limit=10**6)` returns ≤50 (test); client/unknown callers see team tools ABSENT from the
+  registry (schema test); the `whatsapp_persona` price-list cannot enter any live prompt (test).
+- **W1**: from a bot-allowlisted number — PDF → ack (not silence); >4096-char answer → ≥2 messages, none cut
+  mid-sentence, no duplicate on induced crash (ledger test); read receipt observed; forced failure → apology.
+- **W2**: `WA_TEAM_CRM_TOOLS_ENABLED=true` live behind T4; team number "quali sono le mie pratiche?" → only
+  `assigned_to` matches; a client number is byte-identical to pre-change (and never saw the tool schema).
+- **W3**: `curated_qa_regen_trigger` proven by a state-delta not its own log (W89); simulated Gemini-429 →
+  Telegram alert; `/api/monitoring/abstain-rate` shows real non-zero signal; E2E canary walks the ledger path.
+- **W4**: multi-turn adversarial set — bot CLARIFIES an ambiguous visa question, ESCALATES on a red-flag term
+  with the operating contract, strips an unsupported KBLI code (per-claim grounding) rather than hedging.
+- **Fleet**: `git rev-parse HEAD` identical on all reachable main checkouts; consumers show fresh heartbeats.
+
+---
+
+## 14. Open questions for Opus 4.8 (architect)
+
+> **RATIFIED by Zero 2026-07-24**: Q6 (T4 shape) → narrow-first (re-resolve phone server-side + drop
+> client `channel` from the trust decision), typed envelope same quarter. Q8 (corpus growth) → WR2/editorial
+> lane, operator-gated harvest. Q9 (baseline eval) → inside W-1 as the entry gate. Q7 (topology) → SEE THE
+> REVISED RULING BELOW — Zero directed "accelerate while keeping quality"; the passive "wait for metrics"
+> stance is superseded.
+
+1. **P0-MEM containment** — contain in-prod immediately (disable Path B long-term memory), or bundle into
+   the first W-1 PR? (Recommend: contain first, design the pseudonymous subject second.)
+2. **T4 shape** — full typed identity envelope now, or a narrow "re-resolve phone server-side + drop client
+   channel from the trust decision" first, envelope later? (Recommend narrow-first to unblock W2, envelope
+   in the same quarter to kill the two-auth-system trap.)
+3. **Topology (Q7) — RULING (Zero 2026-07-24): accelerate now via a deterministic router, quality
+   protected, no premature process-split.** Do NOT wait passively for routing-failure metrics. Build a
+   **deterministic domain/intent router in front of the single orchestrator** (not an LLM, not separate
+   agents): (a) it classifies visa/company/tax/property at ingress and pre-loads the right tools + grounding
+   + prompt-pack BEFORE generation — faster (fewer ReAct steps, eases the max_steps=2 tension) and more
+   accurate (right grounding from step 0); this REPLACES C7's bare-substring classifier (real intent
+   classifier + alias dictionary). (b) Specialists are conditionally-loaded PROMPT-PACKS, not separate
+   agents — manager-pattern with specialization at the CONTEXT layer, not the process layer (specialist
+   depth without multi-agent handoff risk). (c) Compound queries ("visa + cost + spouse?") are split into
+   independent sub-questions run in PARALLEL, each grounded by its pack, then synthesized. Quality guardrail:
+   O5 metrics + golden-set become the A/B validator (router-on vs router-off), NOT a blocking gate before
+   improvement is allowed; ship only if quality holds/rises. True process-split into separate agents is the
+   last resort, only if the router shows failures context-conditional specialization can't fix. This lever
+   ABSORBS C7 (classifier→router), C8 (adaptive cap→router pre-points + parallel decompose), and O5
+   (metrics→A/B validator) into one coherent piece — home is W4 (the router is the natural spine of the
+   4-outcome gate + intent), with C7 folded in rather than done separately in W1.
+4. **Corpus growth (C12)** — WR2/editorial lane or bot lane?
+5. **Baseline eval** — is the τ²-Bench-style multi-turn set built inside W-1, or a prerequisite lane of its own?


### PR DESCRIPTION
## Summary

Supersedes #3031 — same content, replanted on a docs-only range so the push takes the path-aware fast gate instead of the full 17k-test suite.

`#1 §` now records:
- The client-facing persona/manners findings (persona is additive, denial narration to strangers)
- The PII-in-logs leak finding
- The first golden baseline for the bot eval

## Why a replant

The original branch (`agent/air-m5/docs/zantara-spec-0724`, `162026efae`) carries the identical content but merged `origin/main` into its history, dragging backend commits into the pushed range and forcing the full test suite — which then outlived GitHub's HTTPS idle window and hung mid-push. This branch cherry-picks only the two `.md` files at that same content (blob-hash-identical) onto a fresh branch off current `origin/main`.

## Test plan

- [x] `git diff --name-only origin/main...HEAD` → exactly 2 files, both `.md`
- [x] `prepush_classify.classify(...)` on those 2 paths → `('skip-backend', [])`
- [x] Pre-push hook confirmed: "Skipping full test suite ... ALL match the innocent allowlist"
- [x] `git ls-remote` confirms pushed SHA matches local HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)