### PR TITLE
chore(home-fork): promote the cron-agent-python core to canon + arm the garuda redis gates

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -387,6 +387,48 @@
       "live": "~/Library/LaunchAgents/com.nuzantara.log-rotate.daily.plist",
       "repo": "infra/launchagents/com.nuzantara.log-rotate.daily.plist",
       "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/run.sh",
+      "repo": "scripts/cron-agent-python/run.sh",
+      "_note": "W104 promotion (2026-07-25). THE entry point of the cron-agent-python organism: 16 crontab lines exec it (`run.sh <job>`), and --discover flagged it UNDECLARED once per line. Carries the REDISCLI_AUTH export that re-armed redis auth for every job in the tree.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/agent_job.py",
+      "repo": "scripts/cron-agent-python/agent_job.py",
+      "_note": "W104 promotion (2026-07-25). Shared base class every job imports (send_telegram, backend_api, run ledger, redis event bus). STRUCTURALLY INVISIBLE to lint_home_fork --discover, which only resolves payloads named by a plist/crontab — an imported module is never an entry point, so the most load-bearing file in the tree could never be flagged. Declared explicitly for that reason.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/log_anomaly_detector.py",
+      "repo": "scripts/cron-agent-python/log_anomaly_detector.py",
+      "_note": "W104 promotion (2026-07-25): the cured job — positional log freshness + dedup that grades the redis REPLY instead of the exit code. Same lint blind spot as agent_job.py (exec'd via run.sh, never named directly).",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/intel_radar_daily_digest.py",
+      "repo": "scripts/cron-agent-python/intel_radar_daily_digest.py",
+      "_note": "W104 promotion (2026-07-25): the one tree payload --discover DID flag (executed straight from com.balizero.intel-radar-daily-digest.plist, bypassing run.sh — which is why agent_job.py now derives REDISCLI_AUTH at import time too).",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/curiosity_batch.py",
+      "repo": "scripts/cron-agent-python/curiosity_batch.py",
+      "_note": "W104 sweep (2026-07-25): was the ONLY file of this tree already tracked (promoted by #1510) and it had DRIFTED — undeclared, so --check was blind to it. Divergence was comment-only (1 hunk, code byte-identical): live still carried the pre-#1510 note about a plaintext DB-password fallback that #1510 had stripped as a cicatrix-#4 leak. Verified no credential in the live copy, then realigned live from repo canon.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/garuda-consumer.sh",
+      "repo": "infra/launchagents/wrappers/garuda-consumer.sh",
+      "_note": "W104 class-audit (2026-07-25): armed by com.garuda.consumer.daily, was UNDECLARED. Its `if ! redis-cli ping` preflight was decorative — redis-cli exits 0 on NOAUTH — so the gate passed unauthenticated. Now grades the reply (== PONG) AND exports REDISCLI_AUTH, because tightening the gate without supplying the credential would have taken the cron offline. guilt/innocence/scar-pin proven live 3/3.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/garuda-gap-detector.sh",
+      "repo": "infra/launchagents/wrappers/garuda-gap-detector.sh",
+      "_note": "W104 class-audit (2026-07-25): same decorative `redis-cli ping` gate as garuda-consumer.sh, armed by com.garuda.gap-detector.twice-daily. Same cure, same 3/3 proof.",
+      "machines": ["pro"]
     }
   ],
   "allow": [

--- a/infra/launchagents/wrappers/garuda-consumer.sh
+++ b/infra/launchagents/wrappers/garuda-consumer.sh
@@ -1,0 +1,53 @@
+#!/bin/zsh
+# garuda-consumer.sh — Bridge consumer: garuda:raw → Neo4j
+# LaunchAgent: com.garuda.consumer.daily (06:15 WITA)
+# Uses Nexus venv (has neo4j 6.1) via adhoc-signed python (TCC bypass)
+set -uo pipefail
+
+NEXUS_DIR="/Users/nuzantara/Desktop/OSINT-Nexus"
+VENV_PY="${NEXUS_DIR}/.venv/bin/python"
+LOG="/Users/nuzantara/logs/garuda-consumer.log"
+
+echo "" >> "$LOG"
+echo "=== Garuda Consumer (Neo4j Bridge) — $(date '+%Y-%m-%d %H:%M:%S %Z') ===" >> "$LOG"
+
+# Nexus venv python is adhoc-signed → can read ~/Desktop/ under launchd
+if [ ! -x "$VENV_PY" ]; then
+    echo "[garuda-consumer] FATAL: Nexus venv python not found at $VENV_PY" >> "$LOG"
+    exit 2
+fi
+
+# Redis on this host requires AUTH. Give redis-cli the credential via
+# REDISCLI_AUTH (which it reads natively) rather than `-a`, so the secret never
+# lands in argv / `ps`. Extracted in a SUBSHELL so nothing else from the secrets
+# file leaks into this job's environment.
+if [[ -z "${REDISCLI_AUTH:-}" && -f "$HOME/.nuzantara-secrets.env" ]]; then
+    _redis_pw="$(set -a; source "$HOME/.nuzantara-secrets.env" >/dev/null 2>&1; printf '%s' "${REDIS_PASSWORD:-}")"
+    if [[ -n "$_redis_pw" ]]; then
+        export REDISCLI_AUTH="$_redis_pw"
+    fi
+    unset _redis_pw
+fi
+
+# Check Redis reachable — grade the REPLY, not the exit code (scar W104):
+# redis-cli EXITS 0 even when the server refuses the command, answering
+# `NOAUTH Authentication required.` on stdout. `if ! redis-cli ping` therefore
+# passed unauthenticated, making this gate decorative.
+if [ "$(redis-cli ping 2>/dev/null)" != "PONG" ]; then
+    echo "[garuda-consumer] FATAL: Redis unreachable or refusing (no PONG)" >> "$LOG"
+    exit 3
+fi
+
+# Check Neo4j reachable (bolt port)
+if ! /usr/bin/nc -z localhost 17687 2>/dev/null; then
+    echo "[garuda-consumer] FATAL: Neo4j unreachable on port 17687" >> "$LOG"
+    exit 4
+fi
+
+# Run bridge consumer from Nexus dir (one-shot: reads new entries)
+cd "$NEXUS_DIR"
+"$VENV_PY" -m bridge.consumer >> "$LOG" 2>&1
+
+EXIT_CODE=$?
+echo "[$(date '+%H:%M:%S')] Consumer exit=$EXIT_CODE" >> "$LOG"
+exit $EXIT_CODE

--- a/infra/launchagents/wrappers/garuda-gap-detector.sh
+++ b/infra/launchagents/wrappers/garuda-gap-detector.sh
@@ -1,0 +1,50 @@
+#!/bin/zsh
+# garuda-gap-detector.sh — Gap detector: Neo4j → nexus:gaps
+# LaunchAgent: com.garuda.gap-detector.twice-daily (07:00 + 18:00 WITA)
+set -uo pipefail
+
+NEXUS_DIR="/Users/nuzantara/Desktop/OSINT-Nexus"
+VENV_PY="${NEXUS_DIR}/.venv/bin/python"
+LOG="/Users/nuzantara/logs/garuda-gap-detector.log"
+export NEXUS_GAP_DEDUPE_SECONDS="${NEXUS_GAP_DEDUPE_SECONDS:-21600}"
+
+echo "" >> "$LOG"
+echo "=== Gap Detector — $(date '+%Y-%m-%d %H:%M:%S %Z') ===" >> "$LOG"
+
+if [ ! -x "$VENV_PY" ]; then
+    echo "[gap-detector] FATAL: Nexus venv python not found" >> "$LOG"
+    exit 2
+fi
+
+# Redis on this host requires AUTH. Give redis-cli the credential via
+# REDISCLI_AUTH (which it reads natively) rather than `-a`, so the secret never
+# lands in argv / `ps`. Extracted in a SUBSHELL so nothing else from the secrets
+# file leaks into this job's environment.
+if [[ -z "${REDISCLI_AUTH:-}" && -f "$HOME/.nuzantara-secrets.env" ]]; then
+    _redis_pw="$(set -a; source "$HOME/.nuzantara-secrets.env" >/dev/null 2>&1; printf '%s' "${REDIS_PASSWORD:-}")"
+    if [[ -n "$_redis_pw" ]]; then
+        export REDISCLI_AUTH="$_redis_pw"
+    fi
+    unset _redis_pw
+fi
+
+# Grade the REPLY, not the exit code (scar W104): redis-cli EXITS 0 even when
+# the server refuses the command, answering `NOAUTH Authentication required.`
+# on stdout — so `if ! redis-cli ping` passed unauthenticated and this gate was
+# decorative.
+if [ "$(redis-cli ping 2>/dev/null)" != "PONG" ]; then
+    echo "[gap-detector] FATAL: Redis unreachable or refusing (no PONG)" >> "$LOG"
+    exit 3
+fi
+
+if ! /usr/bin/nc -z localhost 17687 2>/dev/null; then
+    echo "[gap-detector] FATAL: Neo4j unreachable on port 17687" >> "$LOG"
+    exit 4
+fi
+
+cd "$NEXUS_DIR"
+"$VENV_PY" -m bridge.gap_detector >> "$LOG" 2>&1
+
+EXIT_CODE=$?
+echo "[$(date '+%H:%M:%S')] Gap detector exit=$EXIT_CODE" >> "$LOG"
+exit $EXIT_CODE

--- a/scripts/cron-agent-python/agent_job.py
+++ b/scripts/cron-agent-python/agent_job.py
@@ -1,0 +1,1071 @@
+"""
+Shared library for cron-agent-python jobs.
+
+Provides:
+- AgentJob: base class with run_ledger, idempotency, Telegram alerts, Claude Agent SDK integration
+- Helpers: send_telegram, curl_json, backend_api, claude_synthesize
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import socket
+import sys
+import time
+import traceback
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+import httpx
+import structlog
+
+HOME = Path.home()
+STATE_DIR = HOME / ".cron-agent-python"
+LOG_DIR = HOME / "logs" / "cron-agent-python"
+
+# A redis-cli reply that begins with one of these is a server REFUSAL, not a
+# value — and redis-cli still exits 0 when it happens (verified 2026-07-25).
+_REDIS_ERR_RE = re.compile(
+    r"^(NOAUTH|WRONGPASS|NOPERM|ERR|LOADING|BUSY|READONLY|MASTERDOWN|CLUSTERDOWN)\b"
+)
+
+# redis-cli reads REDISCLI_AUTH natively. Deriving it here (not only in run.sh)
+# covers jobs launched straight from a LaunchAgent — e.g.
+# com.balizero.intel-radar-daily-digest, which sources the secrets file but
+# exports only REDIS_PASSWORD, a name redis-cli ignores. Passing the secret via
+# the environment keeps it out of argv / `ps`.
+if not os.environ.get("REDISCLI_AUTH") and os.environ.get("REDIS_PASSWORD"):
+    os.environ["REDISCLI_AUTH"] = os.environ["REDIS_PASSWORD"]
+SECRETS_FILE = HOME / ".nuzantara-secrets.env"
+WITA = timezone(timedelta(hours=8))
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _load_secrets() -> None:
+    if not SECRETS_FILE.exists():
+        return
+    for line in SECRETS_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, val = line.split("=", 1)
+            val = val.strip().strip('"').strip("'")
+            os.environ.setdefault(key.strip(), val)
+
+
+def _prefer_local_pg_tunnel() -> None:
+    """Use the local Fly Postgres proxy when present.
+
+    Secrets stay as the canonical flycast DSN; LaunchAgents can run through
+    `fly proxy 15432:5432 -a nuzantara-postgres` without duplicating credentials.
+    """
+    local_dsn = os.environ.get("DATABASE_URL_LOCAL")
+    if local_dsn:
+        os.environ["DATABASE_URL"] = local_dsn
+        return
+
+    dsn = os.environ.get("DATABASE_URL", "")
+    if "nuzantara-postgres.flycast" not in dsn:
+        return
+
+    try:
+        with socket.create_connection(("127.0.0.1", 15432), timeout=0.2):
+            pass
+    except OSError:
+        return
+
+    os.environ["DATABASE_URL"] = (
+        dsn.replace("nuzantara-postgres.flycast:5432", "127.0.0.1:15432")
+        .replace("nuzantara-postgres.flycast", "127.0.0.1:15432")
+    )
+
+
+def _force_oauth_only() -> None:
+    """Remove any ANTHROPIC_API_KEY to force Claude Agent SDK down the OAuth
+    Max-plan path via keychain. Prevents accidental pay-per-token billing.
+
+    The SDK tries ANTHROPIC_API_KEY first if set. Removing it makes the SDK
+    fall back to the OAuth token stored in macOS keychain (Claude Max plan).
+    """
+    if "ANTHROPIC_API_KEY" in os.environ:
+        del os.environ["ANTHROPIC_API_KEY"]
+
+
+_load_secrets()
+_prefer_local_pg_tunnel()
+_force_oauth_only()
+
+
+def _hash(data: Any) -> str:
+    return hashlib.sha256(json.dumps(data, sort_keys=True, default=str).encode()).hexdigest()[:12]
+
+
+@dataclass
+class RunLedgerEntry:
+    run_id: str
+    job: str
+    step: str
+    inputs_hash: str
+    outputs_hash: str
+    side_effects: list[str]
+    error: str | None
+    duration_s: float
+    ts: str
+
+
+@dataclass
+class RunResult:
+    status: str  # "ok", "error", "timeout"
+    duration_s: float
+    side_effects: list[str] = field(default_factory=list)
+    output: str = ""
+    error: str | None = None
+
+
+class AgentJob:
+    """Base class for all cron agent jobs.
+
+    Subclass and implement `async def run()`. Returns RunResult.
+    """
+
+    # Override in subclass
+    name: str = "unnamed-job"
+    telegram_chat_id: str = ""  # defaults to TELEGRAM_OWNER_CHAT_ID
+    timeout_s: int = 600
+
+    def __init__(self) -> None:
+        self.run_id = f"{self.name}-{int(time.time())}"
+        self.started_at = time.time()
+        self.ledger: list[RunLedgerEntry] = []
+        self.logger = structlog.get_logger(self.name).bind(run_id=self.run_id)
+        self.state_file = STATE_DIR / f"{self.name}.state.json"
+        self.log_file = LOG_DIR / f"{self.name}.log"
+        self.lock_file = STATE_DIR / f"{self.name}.lock"
+        self._side_effects: list[str] = []
+
+    # ─── Lock (PID-based for macOS) ────────────────────────────────────────
+
+    def acquire_lock(self) -> bool:
+        if self.lock_file.exists():
+            try:
+                old_pid = int(self.lock_file.read_text().strip())
+                os.kill(old_pid, 0)  # check if alive
+                return False  # lock held
+            except (ValueError, ProcessLookupError, PermissionError):
+                self.lock_file.unlink(missing_ok=True)
+        self.lock_file.write_text(str(os.getpid()))
+        return True
+
+    def release_lock(self) -> None:
+        self.lock_file.unlink(missing_ok=True)
+
+    # ─── Run ledger ────────────────────────────────────────────────────────
+
+    def log_step(
+        self,
+        step: str,
+        inputs: Any = None,
+        outputs: Any = None,
+        error: str | None = None,
+        side_effect: str | None = None,
+        duration_s: float = 0.0,
+    ) -> None:
+        entry = RunLedgerEntry(
+            run_id=self.run_id,
+            job=self.name,
+            step=step,
+            inputs_hash=_hash(inputs) if inputs is not None else "",
+            outputs_hash=_hash(outputs) if outputs is not None else "",
+            side_effects=[side_effect] if side_effect else [],
+            error=error,
+            duration_s=duration_s,
+            ts=datetime.now(WITA).isoformat(),
+        )
+        self.ledger.append(entry)
+        if side_effect:
+            self._side_effects.append(side_effect)
+        self.logger.info(step, error=error, duration_s=duration_s, side_effect=side_effect)
+
+    # ─── Telegram ──────────────────────────────────────────────────────────
+
+    async def send_telegram(self, msg: str, chat_id: str | None = None) -> bool:
+        token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+        if not token:
+            self.logger.warning("telegram_skipped", reason="no_token")
+            return False
+        chat = chat_id or self.telegram_chat_id or os.environ.get("TELEGRAM_OWNER_CHAT_ID", "1125336968")
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                r = await client.post(
+                    f"https://api.telegram.org/bot{token}/sendMessage",
+                    data={"chat_id": chat, "text": msg, "parse_mode": "HTML"},
+                )
+                success = r.status_code == 200
+                if success:
+                    self._side_effects.append(f"telegram:{chat}")
+                return success
+        except Exception as e:
+            self.logger.error("telegram_error", error=str(e))
+            return False
+
+    # ─── Backend API ───────────────────────────────────────────────────────
+
+    async def backend_api(
+        self,
+        path: str,
+        method: str = "GET",
+        params: dict | None = None,
+        json_body: dict | None = None,
+        timeout: float = 30.0,
+    ) -> dict | None:
+        base = "https://nuzantara-rag.fly.dev"
+        api_key = os.environ.get("NUZANTARA_API_KEY", "")
+        headers = {"X-API-Key": api_key} if api_key else {}
+        url = f"{base}{path}"
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                r = await client.request(
+                    method, url, params=params, json=json_body, headers=headers
+                )
+                r.raise_for_status()
+                return r.json()
+        except Exception as e:
+            self.logger.error("backend_api_error", path=path, error=str(e))
+            return None
+
+    # ─── Claude Agent SDK (bounded synthesis) ──────────────────────────────
+
+    async def claude_synthesize(
+        self,
+        prompt: str,
+        max_turns: int = 3,
+        effort: str | None = None,
+        system_prompt: str | None = None,
+        model: str | None = None,
+        task_budget: int | None = None,
+        betas: list[str] | None = None,
+        fork_from_session: str | None = None,
+        enable_checkpointing: bool = False,
+        auto_failure_hook: bool = True,
+        subagents: dict[str, dict[str, Any]] | None = None,
+        tools_allowed: list[str] | None = None,
+        adaptive_thinking: bool = False,
+    ) -> str:
+        """Use Claude SDK for bounded reasoning/synthesis.
+
+        Routing: reads `agent_config.get_config(self.name)` to pick default
+        model/effort/task_budget per tier. Callers can override any of those
+        by passing the kwargs explicitly.
+
+        Advanced flags (2026-04-17):
+          - fork_from_session: if set, fork an existing session_id so prompt
+            cache is preserved (punto 2 del roadmap potenzialita')
+          - enable_checkpointing: snapshot files before Edit/Write for rollback
+            (punto 1 del roadmap potenzialita')
+          - auto_failure_hook: register PostToolUseFailure hook that records
+            failures in memory.db as 'unresolved' (punto 4 del roadmap)
+          - subagents: dict {name: {description, prompt, model, effort, tools}}
+            — main agent can dispatch to specialists via Task tool (punto 3)
+          - tools_allowed: override empty tools list (required when subagents
+            need main to invoke Task tool)
+          - adaptive_thinking: if True, enable thinking={"type":"adaptive"}
+            so Opus 4.7 auto-modulates reasoning depth per query complexity
+            (Opus 4.7 only — no-op on Sonnet/Haiku)
+
+        Use ONLY for narrative output from collected data. Do NOT give it tools
+        that cause side effects — the deterministic Python code owns those.
+        """
+        from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions, HookMatcher
+        from claude_agent_sdk.types import AgentDefinition
+
+        # Resolve routing config (plan §1+§2)
+        from agent_config import get_config, MODEL_OPUS_47
+
+        cfg = get_config(self.name)
+        resolved_model = model or cfg["model"]
+        resolved_effort = effort or cfg["effort"]
+        resolved_budget = task_budget if task_budget is not None else cfg.get("task_budget")
+        resolved_betas = list(betas) if betas is not None else list(cfg.get("betas") or [])
+
+        # CLI compat: Claude Code CLI (shell-out) currently only accepts
+        # low|medium|high|max for --effort. xhigh is SDK/settings-only. Map
+        # xhigh → high at call time to avoid "invalid argument" from the CLI.
+        if resolved_effort == "xhigh":
+            self.logger.debug(
+                "effort_downgraded_for_cli",
+                original="xhigh",
+                effective="high",
+                model=resolved_model,
+            )
+            resolved_effort = "high"
+
+        # task_budget only applies to Opus 4.7 (beta currently model-specific).
+        # If model != Opus 4.7, skip task_budget even if configured.
+        # tools_allowed overrides empty list (needed when main uses Task to call subagents)
+        resolved_tools: list[str] = list(tools_allowed) if tools_allowed else []
+
+        # B5 2026-05-15: fallback_model auto-switches Opus 4.7 → Sonnet 4.6 when
+        # the primary model is overloaded or quota-exhausted. SDK-native.
+        # Maps cron-agent default Opus → Sonnet, Sonnet → Haiku, Haiku → Haiku.
+        from agent_config import MODEL_SONNET_46, MODEL_HAIKU_45
+        if resolved_model == MODEL_OPUS_47:
+            resolved_fallback = MODEL_SONNET_46
+        elif resolved_model == MODEL_SONNET_46:
+            resolved_fallback = MODEL_HAIKU_45
+        else:
+            resolved_fallback = MODEL_HAIKU_45
+
+        opts_kwargs: dict[str, Any] = {
+            "max_turns": max_turns,
+            "effort": resolved_effort,  # type: ignore[arg-type]
+            "system_prompt": system_prompt,
+            "model": resolved_model,
+            "fallback_model": resolved_fallback,
+            "tools": resolved_tools,
+            "allowed_tools": resolved_tools,
+            "permission_mode": "bypassPermissions",
+            "setting_sources": [],  # skip user hooks (avoid SessionStart hang)
+        }
+
+        # ── Sub-agents (specialist dispatch via Task tool) ──────────────
+        if subagents:
+            sdk_agents: dict[str, AgentDefinition] = {}
+            for name, spec in subagents.items():
+                sdk_agents[name] = AgentDefinition(
+                    description=spec.get("description", f"Specialist {name}"),
+                    prompt=spec["prompt"],
+                    tools=spec.get("tools"),
+                    model=spec.get("model"),
+                    effort=spec.get("effort"),
+                    maxTurns=spec.get("max_turns", 3),
+                    permissionMode="bypassPermissions",
+                )
+            opts_kwargs["agents"] = sdk_agents
+            # Main must have Task tool available to dispatch to subagents
+            if "Task" not in resolved_tools:
+                resolved_tools.append("Task")
+                opts_kwargs["tools"] = resolved_tools
+                opts_kwargs["allowed_tools"] = resolved_tools
+        if resolved_budget and resolved_model == MODEL_OPUS_47:
+            opts_kwargs["task_budget"] = {"total": int(resolved_budget)}  # type: ignore[typeddict-item]
+        if resolved_betas:
+            opts_kwargs["betas"] = resolved_betas  # type: ignore[typeddict-item]
+
+        # ── File checkpointing (snapshot before Edit/Write for rollback) ─
+        if enable_checkpointing:
+            opts_kwargs["enable_file_checkpointing"] = True
+
+        # ── Adaptive thinking (Opus 4.7 auto-modulates reasoning depth) ──
+        if adaptive_thinking and resolved_model == MODEL_OPUS_47:
+            opts_kwargs["thinking"] = {"type": "adaptive"}  # type: ignore[typeddict-item]
+
+        # ── Fork session (inherit prompt cache from a prior run) ─────────
+        if fork_from_session:
+            opts_kwargs["resume"] = fork_from_session
+            opts_kwargs["fork_session"] = True
+            self.logger.info("session_fork", parent=fork_from_session[:36])
+
+        # ── Auto-failure hook (record failures as 'unresolved' memory) ────
+        if auto_failure_hook:
+            job_name = self.name
+            job_logger = self.logger
+
+            async def _post_fail_hook(input_data, tool_use_id, ctx):
+                try:
+                    tool_name = input_data.get("tool_name", "?")
+                    err_msg = input_data.get("error", "")[:200]
+                    tool_in = str(input_data.get("tool_input", ""))[:150]
+                    mem_cli = Path.home() / ".claude" / "scripts" / "mem"
+                    if mem_cli.exists():
+                        import subprocess
+                        content = (
+                            f"cron-agent {job_name} tool_failure: {tool_name}"
+                            f" on {tool_in} → {err_msg}"
+                        )
+                        subprocess.run(
+                            [str(mem_cli), "save", "unresolved", content, "7"],
+                            capture_output=True, timeout=10, check=False,
+                        )
+                    job_logger.warning(
+                        "tool_use_failure_captured",
+                        tool=tool_name, error=err_msg[:120],
+                    )
+                except Exception as e:
+                    job_logger.error("post_fail_hook_error", error=str(e))
+                return {}  # empty dict = allow continuation
+
+            opts_kwargs["hooks"] = {
+                "PostToolUseFailure": [HookMatcher(hooks=[_post_fail_hook])],
+            }
+
+        self.log_step(
+            "claude_synthesize_start",
+            inputs={
+                "model_used": resolved_model,
+                "effort_used": resolved_effort,
+                "task_budget_advisory": resolved_budget if resolved_model == MODEL_OPUS_47 else None,
+                "betas": resolved_betas,
+                "forked_from": fork_from_session[:36] if fork_from_session else None,
+                "checkpointing": enable_checkpointing,
+                "auto_failure_hook": auto_failure_hook,
+                "subagents": list(subagents.keys()) if subagents else None,
+                "tools": resolved_tools or None,
+                "adaptive_thinking": adaptive_thinking and resolved_model == MODEL_OPUS_47,
+            },
+        )
+
+        opts = ClaudeAgentOptions(**opts_kwargs)
+        chunks: list[str] = []
+        last_usage: dict | None = None
+        captured_session_id: str | None = None
+        try:
+            async with ClaudeSDKClient(options=opts) as client:
+                await client.query(prompt)
+                async for msg in client.receive_response():
+                    # Accumulate text content
+                    content = getattr(msg, "content", None)
+                    if isinstance(content, list):
+                        for block in content:
+                            text = getattr(block, "text", None)
+                            if text:
+                                chunks.append(text)
+                    elif isinstance(content, str):
+                        chunks.append(content)
+                    # Capture usage if exposed on msg
+                    usage = getattr(msg, "usage", None)
+                    if usage:
+                        last_usage = usage if isinstance(usage, dict) else getattr(usage, "__dict__", None)
+                    # Capture session_id for future fork_session chains
+                    sid = getattr(msg, "session_id", None)
+                    if sid and not captured_session_id:
+                        captured_session_id = sid
+        except Exception as e:
+            self.logger.error(
+                "claude_synthesize_error",
+                error=str(e),
+                model_used=resolved_model,
+                effort_used=resolved_effort,
+            )
+            return f"[synthesis error: {e}]"
+
+        # Log usage if present (task_budget_consumed_tokens when Opus 4.7 beta active)
+        if last_usage:
+            self.log_step(
+                "claude_synthesize_done",
+                outputs={
+                    "model_used": resolved_model,
+                    "task_budget_consumed": last_usage.get("task_budget_consumed_tokens")
+                    if isinstance(last_usage, dict) else None,
+                    "input_tokens": last_usage.get("input_tokens") if isinstance(last_usage, dict) else None,
+                    "output_tokens": last_usage.get("output_tokens") if isinstance(last_usage, dict) else None,
+                    "cache_read_input_tokens": last_usage.get("cache_read_input_tokens")
+                    if isinstance(last_usage, dict) else None,
+                    "cache_creation_input_tokens": last_usage.get("cache_creation_input_tokens")
+                    if isinstance(last_usage, dict) else None,
+                    "session_id": captured_session_id[:36] if captured_session_id else None,
+                },
+            )
+
+        # Persist session_id for future fork_session reuse (scope: hourly)
+        if captured_session_id:
+            try:
+                scope = f"synth-hourly:{datetime.now(WITA).strftime('%Y-%m-%d-%H')}"
+                save_session(self.name, captured_session_id, scope=scope)
+            except Exception as e:
+                self.logger.debug("session_save_skipped", error=str(e))
+
+        return "\n".join(chunks).strip()
+
+    # ─── Entry point ───────────────────────────────────────────────────────
+
+    async def run(self) -> RunResult:
+        """Subclass MUST override this."""
+        raise NotImplementedError
+
+    async def _run_with_timeout(self) -> RunResult:
+        try:
+            return await asyncio.wait_for(self.run(), timeout=self.timeout_s)
+        except asyncio.TimeoutError:
+            return RunResult(
+                status="timeout",
+                duration_s=time.time() - self.started_at,
+                side_effects=self._side_effects,
+                error=f"timeout after {self.timeout_s}s",
+            )
+        except Exception as e:
+            tb = traceback.format_exc()
+            self.logger.error("run_exception", error=str(e), traceback=tb)
+            return RunResult(
+                status="error",
+                duration_s=time.time() - self.started_at,
+                side_effects=self._side_effects,
+                error=f"{type(e).__name__}: {e}",
+            )
+
+    def _write_state(self, result: RunResult) -> None:
+        state = {
+            "job": self.name,
+            "run_id": self.run_id,
+            "ts": int(time.time()),
+            "status": result.status,
+            "duration_s": round(result.duration_s, 2),
+            "side_effects": result.side_effects,
+            "error": result.error,
+            "host": socket.gethostname(),
+            "ledger": [asdict(e) for e in self.ledger],
+        }
+        self.state_file.write_text(json.dumps(state, indent=2, default=str))
+
+    def _exit_code(self, result: RunResult) -> int:
+        """Fail-hard policy: if no side effects happened AND status != ok → exit 1.
+
+        This implements the 'never allow empty success' principle.
+        """
+        if result.status == "ok":
+            # Even if status is ok, verify side effects were produced for jobs that need them
+            if hasattr(self, "requires_side_effects") and self.requires_side_effects:
+                if not result.side_effects:
+                    return 1
+            return 0
+        return 1
+
+    async def _publish_redis_event(self, result: RunResult) -> None:
+        """VADEMECUM §1 point 8 — publish Redis stream event if significant.
+
+        Stream: `cron:<job_name>` — one per job, other organs can subscribe.
+        Also: `cron:reports` — aggregated stream for L2 correlators (es. tech-orchestrator).
+
+        Event only if significant: status!=ok OR side_effects produced OR partial errors.
+        Graceful degradation: if Redis down, log warning and continue.
+        """
+        try:
+            import subprocess
+
+            partial_errors = sum(1 for e in self.ledger if e.error)
+            significant = (
+                result.status != "ok"
+                or len(result.side_effects) > 0
+                or partial_errors > 0
+            )
+            if not significant:
+                return
+
+            event = {
+                "job": self.name,
+                "run_id": self.run_id,
+                "status": result.status,
+                "duration_s": f"{result.duration_s:.2f}",
+                "side_effects": ",".join(result.side_effects)[:200],
+                "partial_errors": str(partial_errors),
+                "ts": str(int(time.time())),
+            }
+            if result.error:
+                event["error"] = result.error[:200]
+
+            # Build redis-cli XADD command
+            xadd_args = ["redis-cli", "-t", "3", "XADD", f"cron:reports", "MAXLEN", "~", "5000", "*"]
+            for k, v in event.items():
+                xadd_args.extend([k, v])
+
+            # Also emit on job-specific stream
+            xadd_job = ["redis-cli", "-t", "3", "XADD", f"cron:{self.name}", "MAXLEN", "~", "500", "*"]
+            for k, v in event.items():
+                xadd_job.extend([k, v])
+
+            def _xadd(argv: list, stream: str) -> bool:
+                """Run one XADD and report whether Redis actually accepted it.
+
+                Fix (2026-07-25): `check=False` used to swallow a non-zero exit
+                without raising, so the except-branch below never fired. When
+                Redis gained a password, redis-cli returned NOAUTH on every call
+                and this method still logged `redis_event_published` — 7957
+                times, while the stream stayed frozen for 26.5 days. A producer
+                that grades itself on "I ran the command" is blind by
+                construction; grade on what the backend answered.
+                """
+                out = subprocess.run(
+                    argv, capture_output=True, text=True, timeout=5, check=False,
+                )
+                reply = (out.stdout or "").strip()
+                # redis-cli EXITS 0 even when the server refuses the command —
+                # the error comes back as a REPLY on stdout ("NOAUTH ...",
+                # "WRONGPASS ..."). Grading on returncode grades the proxy.
+                refused = bool(_REDIS_ERR_RE.match(reply))
+                if out.returncode != 0 or refused:
+                    self.logger.warning(
+                        "redis_publish_rejected",
+                        stream=stream,
+                        rc=out.returncode,
+                        detail=reply[:120] or (out.stderr or "").strip()[:120],
+                    )
+                    return False
+                return True
+
+            published = _xadd(xadd_args, "cron:reports")
+            published = _xadd(xadd_job, f"cron:{self.name}") and published
+
+            if published:
+                self.logger.info("redis_event_published", stream=f"cron:{self.name}")
+        except Exception as e:
+            self.logger.warning("redis_publish_failed", error=str(e))
+
+    def _reflect(self, result: RunResult) -> None:
+        """VADEMECUM §1 point 4 — reflection post-run into SQLite KB.
+
+        Writes a structured reflection to ~/.claude/memory.db via the mem CLI.
+        On error, the reflection also calls claude --print to generate a 'lesson'
+        from the error context (only if the error is non-trivial).
+
+        Failure to reflect is logged but does not affect exit code.
+        """
+        try:
+            import subprocess
+
+            mem_cli = Path.home() / ".claude" / "scripts" / "mem"
+            if not mem_cli.exists():
+                return  # MOS not available — skip silently
+
+            # Build reflection content
+            content_parts = [
+                f"job={self.name}",
+                f"run_id={self.run_id}",
+                f"status={result.status}",
+                f"duration_s={result.duration_s:.2f}",
+                f"side_effects={len(result.side_effects)}",
+            ]
+            if result.error:
+                content_parts.append(f"error={result.error[:200]}")
+
+            # Pick memory type + importance based on outcome
+            # Check if any step in the ledger had an error (partial failures matter)
+            partial_errors = sum(1 for e in self.ledger if e.error)
+
+            if result.status == "ok" and partial_errors == 0:
+                # Routine full-success — skip to avoid memory spam
+                # Only save unusual successes (long duration or many side effects)
+                if result.duration_s < 60 and len(result.side_effects) <= 2:
+                    return
+                mem_type = "fact"
+                importance = 4
+            elif result.status == "ok":
+                # Partial success — worth noting
+                mem_type = "discovery"
+                importance = 5
+            else:
+                mem_type = "unresolved"
+                importance = 7  # failure — worth remembering
+
+            content = f"cron-agent-python {self.name}: {result.status} in {result.duration_s:.1f}s"
+            if result.error:
+                content += f" — {result.error[:150]}"
+
+            subprocess.run(
+                [str(mem_cli), "save", mem_type, content, str(importance)],
+                capture_output=True, timeout=10, check=False,
+            )
+        except Exception as e:
+            # Don't fail the job if reflection fails
+            self.logger.warning("reflection_failed", error=str(e))
+
+
+async def run_job(job: AgentJob, send_alerts: bool = True) -> int:
+    """Main entrypoint. Use from cron job scripts."""
+    if not job.acquire_lock():
+        job.logger.info("skipped", reason="lock_held")
+        return 0  # not an error — previous run still active
+
+    try:
+        result = await job._run_with_timeout()
+        job._write_state(result)
+        job._reflect(result)  # VADEMECUM §1 point 4 — reflection in KB
+        await job._publish_redis_event(result)  # VADEMECUM §1 point 8 — event bus
+
+        if result.status != "ok" and send_alerts:
+            await job.send_telegram(
+                f"❌ <b>{job.name}</b> {result.status} ({result.duration_s:.1f}s)\n"
+                f"{result.error or 'no error details'}"
+            )
+
+        return job._exit_code(result)
+    finally:
+        job.release_lock()
+
+
+def main(job_class: type[AgentJob]) -> None:
+    """CLI entrypoint for subclass scripts."""
+    job = job_class()
+    exit_code = asyncio.run(run_job(job))
+    sys.exit(exit_code)
+
+
+# ─── Session resume helpers (Feature 4 — session resume) ───────────────────
+# SQLite DB at ~/.cron-agent-python/sessions.db
+# Each job can have a daily or weekly session ID stored here.
+# Use with `claude --resume <session_id>` or `claude -c <session_id>`.
+
+_SESSIONS_DB = STATE_DIR / "sessions.db"
+
+
+def _sessions_db() -> Any:
+    """Return sqlite3 connection to sessions.db."""
+    import sqlite3
+    conn = sqlite3.connect(str(_SESSIONS_DB))
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            job TEXT NOT NULL,
+            scope TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            last_used INTEGER NOT NULL,
+            PRIMARY KEY (job, scope)
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+def get_or_create_session(job_name: str, scope: str = "daily") -> str | None:
+    """Get or create a Claude CLI session ID for a job.
+
+    Args:
+        job_name: Name of the job (e.g., "compliance-ops").
+        scope: Session scope — "daily" (new each day), "weekly" (new each week),
+               "persistent" (never expires).
+
+    Returns:
+        Session ID string or None if sessions.db unavailable.
+
+    Usage:
+        session_id = get_or_create_session("compliance-ops", scope="daily")
+        if session_id:
+            # Use: claude --resume {session_id} -p "today's context..."
+            # Or:  claude -c {session_id} -p "..."
+    """
+    import sqlite3
+    try:
+        conn = _sessions_db()
+        now = int(time.time())
+
+        # Check if existing session is still in scope
+        row = conn.execute(
+            "SELECT session_id, created_at FROM sessions WHERE job=? AND scope=?",
+            (job_name, scope)
+        ).fetchone()
+
+        if row:
+            session_id, created_at = row
+            age_hours = (now - created_at) / 3600
+
+            # Check if within scope window
+            if scope == "daily" and age_hours < 24:
+                conn.execute("UPDATE sessions SET last_used=? WHERE job=? AND scope=?",
+                             (now, job_name, scope))
+                conn.commit()
+                return session_id
+            elif scope == "weekly" and age_hours < 168:  # 7 days
+                conn.execute("UPDATE sessions SET last_used=? WHERE job=? AND scope=?",
+                             (now, job_name, scope))
+                conn.commit()
+                return session_id
+            elif scope == "persistent":
+                conn.execute("UPDATE sessions SET last_used=? WHERE job=? AND scope=?",
+                             (now, job_name, scope))
+                conn.commit()
+                return session_id
+            else:
+                # Expired — delete and create new
+                conn.execute("DELETE FROM sessions WHERE job=? AND scope=?", (job_name, scope))
+                conn.commit()
+
+        # Create new session via claude CLI
+        import subprocess
+        # Start a minimal session to get a session ID
+        result = subprocess.run(
+            ["claude", "--print", f"Session start for {job_name} {scope} {datetime.now(WITA).strftime('%Y-%m-%d')}"],
+            capture_output=True, text=True, timeout=30,
+            env={**os.environ, "ANTHROPIC_API_KEY": ""},
+        )
+        # Extract session ID from output (claude CLI outputs session_id in metadata)
+        import re
+        session_match = re.search(r'session[_-]?id["\s:]+([a-f0-9-]{36})', result.stdout + result.stderr, re.IGNORECASE)
+        if not session_match:
+            # Try environment variable approach
+            env_result = subprocess.run(
+                ["claude", "--print", "--output-format=json", f"Session init {job_name}"],
+                capture_output=True, text=True, timeout=30,
+                env={**os.environ, "ANTHROPIC_API_KEY": ""},
+            )
+            try:
+                data = json.loads(env_result.stdout)
+                session_id = data.get("session_id") or data.get("sessionId")
+            except Exception:
+                session_id = None
+        else:
+            session_id = session_match.group(1)
+
+        if session_id:
+            conn.execute(
+                "INSERT OR REPLACE INTO sessions (job, scope, session_id, created_at, last_used) VALUES (?,?,?,?,?)",
+                (job_name, scope, session_id, now, now)
+            )
+            conn.commit()
+
+        conn.close()
+        return session_id
+
+    except Exception as e:
+        structlog.get_logger("sessions").warning("session_error", job=job_name, error=str(e))
+        return None
+
+
+def save_session(job_name: str, session_id: str, scope: str = "daily") -> None:
+    """Manually save a session ID (call after a successful claude run to capture its session_id)."""
+    import sqlite3
+    try:
+        conn = _sessions_db()
+        now = int(time.time())
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions (job, scope, session_id, created_at, last_used) VALUES (?,?,?,?,?)",
+            (job_name, scope, session_id, now, now)
+        )
+        conn.commit()
+        conn.close()
+    except Exception as e:
+        structlog.get_logger("sessions").warning("session_save_error", job=job_name, error=str(e))
+
+
+def get_latest_session(
+    job_name: str,
+    max_age_hours: int = 2,
+    scope_prefix: str | None = None,
+) -> str | None:
+    """Return the most recent session_id for `job_name` within max_age_hours.
+
+    Used to fork a prior synthesize() run and inherit its prompt cache.
+    Caller passes the returned id as `fork_from_session` to claude_synthesize.
+
+    Args:
+        job_name: the cron agent name.
+        max_age_hours: ignore sessions older than this (default 2h — matches
+          Anthropic prompt cache 1h TTL plus a grace window).
+        scope_prefix: optional filter (e.g. "synth-hourly:" to only get
+          synthesize-originated sessions).
+
+    Returns:
+        Latest session_id or None if no fresh session exists.
+    """
+    import sqlite3
+    try:
+        conn = _sessions_db()
+        now = int(time.time())
+        cutoff = now - max_age_hours * 3600
+        if scope_prefix:
+            row = conn.execute(
+                "SELECT session_id, created_at FROM sessions "
+                "WHERE job=? AND scope LIKE ? AND created_at >= ? "
+                "ORDER BY created_at DESC LIMIT 1",
+                (job_name, f"{scope_prefix}%", cutoff),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT session_id, created_at FROM sessions "
+                "WHERE job=? AND created_at >= ? "
+                "ORDER BY created_at DESC LIMIT 1",
+                (job_name, cutoff),
+            ).fetchone()
+        conn.close()
+        return row[0] if row else None
+    except Exception as e:
+        structlog.get_logger("sessions").debug("latest_session_error", job=job_name, error=str(e))
+        return None
+
+
+# ─── WebSearch / WebFetch helpers ──────────────────────────────────────────
+# Fallback chain: Brave Search API → DuckDuckGo HTML
+# Brave API key loaded from secrets (BRAVE_API_KEY).
+# Cache: Redis key `bz:websearch:<hash>` with 24h TTL.
+
+_BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
+_DDG_SEARCH_URL = "https://html.duckduckgo.com/html/"
+_SEARCH_CACHE_TTL = 86400  # 24h
+
+
+def _search_cache_key(query: str) -> str:
+    return f"bz:websearch:{hashlib.md5(query.encode()).hexdigest()[:12]}"
+
+
+async def web_search(
+    query: str,
+    count: int = 5,
+    freshness: str | None = None,
+    logger: Any = None,
+) -> list[dict]:
+    """Search the web via Brave API → DuckDuckGo fallback.
+
+    Returns list of dicts with keys: title, url, description.
+    Results cached in Redis for 24h (same query = 0 API calls).
+
+    Args:
+        query: Search query string.
+        count: Max results to return (1-10).
+        freshness: Optional time filter — "pd" (past day), "pw" (past week),
+                   "pm" (past month), "py" (past year).
+        logger: Optional structlog logger for debug output.
+
+    Geographic note: Brave API has global coverage including Indonesia (.id).
+    DuckDuckGo fallback is also global.
+    """
+    import subprocess
+    log = logger or structlog.get_logger("web_search")
+    cache_key = _search_cache_key(f"{query}:{count}:{freshness}")
+
+    # Check Redis cache first
+    try:
+        cached = subprocess.run(
+            ["redis-cli", "GET", cache_key],
+            capture_output=True, text=True, timeout=3
+        )
+        if cached.returncode == 0 and cached.stdout.strip() not in ("", "(nil)"):
+            results = json.loads(cached.stdout.strip())
+            log.debug("web_search_cache_hit", query=query[:50], results=len(results))
+            return results
+    except Exception:
+        pass
+
+    # Try Brave Search API
+    brave_key = os.environ.get("BRAVE_API_KEY", "")
+    results: list[dict] = []
+
+    if brave_key:
+        try:
+            params: dict = {"q": query, "count": min(count, 10)}
+            if freshness:
+                params["freshness"] = freshness
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                r = await client.get(
+                    _BRAVE_SEARCH_URL,
+                    params=params,
+                    headers={
+                        "Accept": "application/json",
+                        "Accept-Encoding": "gzip",
+                        "X-Subscription-Token": brave_key,
+                    },
+                )
+                if r.status_code == 200:
+                    data = r.json()
+                    web_results = data.get("web", {}).get("results", [])
+                    results = [
+                        {
+                            "title": item.get("title", ""),
+                            "url": item.get("url", ""),
+                            "description": item.get("description", ""),
+                            "source": "brave",
+                        }
+                        for item in web_results[:count]
+                    ]
+                    log.debug("web_search_brave_ok", query=query[:50], results=len(results))
+                elif r.status_code == 429:
+                    log.warning("web_search_brave_rate_limit", query=query[:50])
+        except Exception as e:
+            log.warning("web_search_brave_error", error=str(e))
+
+    # Fallback: DuckDuckGo HTML
+    if not results:
+        try:
+            import re
+            async with httpx.AsyncClient(timeout=15.0, follow_redirects=True, verify=False) as client:
+                r = await client.post(
+                    _DDG_SEARCH_URL,
+                    data={"q": query},
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; NuzantaraCron/1.0)",
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                )
+                html = r.text
+                # Parse DDG HTML results
+                result_pattern = re.compile(
+                    r'class="result__title".*?<a[^>]+href="([^"]+)"[^>]*>(.*?)</a>'
+                    r'.*?class="result__snippet"[^>]*>(.*?)</(?:a|span|div)>',
+                    re.DOTALL | re.IGNORECASE,
+                )
+                for m in result_pattern.finditer(html[:100000]):
+                    url = m.group(1)
+                    title = re.sub(r'<[^>]+>', '', m.group(2)).strip()
+                    desc = re.sub(r'<[^>]+>', '', m.group(3)).strip()
+                    desc = re.sub(r'\s+', ' ', desc)
+                    if url and title and len(results) < count:
+                        results.append({
+                            "title": title[:200],
+                            "url": url,
+                            "description": desc[:400],
+                            "source": "ddg",
+                        })
+            log.debug("web_search_ddg_ok", query=query[:50], results=len(results))
+        except Exception as e:
+            log.warning("web_search_ddg_error", error=str(e))
+
+    # Cache results in Redis
+    if results:
+        try:
+            subprocess.run(
+                ["redis-cli", "SET", cache_key, json.dumps(results), "EX", str(_SEARCH_CACHE_TTL)],
+                capture_output=True, timeout=3
+            )
+        except Exception:
+            pass
+
+    return results
+
+
+async def web_fetch(
+    url: str,
+    extract_text: bool = True,
+    timeout: float = 15.0,
+    logger: Any = None,
+) -> dict:
+    """Fetch a URL and return HTML/text content.
+
+    Args:
+        url: URL to fetch.
+        extract_text: If True, strip HTML tags and return clean text.
+        timeout: HTTP timeout in seconds.
+        logger: Optional structlog logger.
+
+    Returns:
+        Dict with: url, status, html (raw), text (clean), error.
+    """
+    import re
+    log = logger or structlog.get_logger("web_fetch")
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            r = await client.get(
+                url,
+                headers={"User-Agent": "Mozilla/5.0 (compatible; NuzantaraCron/1.0)"},
+            )
+            html = r.text
+            text = ""
+            if extract_text:
+                # Remove scripts, styles, then strip tags
+                text = re.sub(r'<(script|style)[^>]*>.*?</\1>', ' ', html, flags=re.DOTALL | re.IGNORECASE)
+                text = re.sub(r'<[^>]+>', ' ', text)
+                text = re.sub(r'\s+', ' ', text).strip()
+            return {
+                "url": str(r.url),
+                "status": r.status_code,
+                "ok": 200 <= r.status_code < 300,
+                "html": html[:50000],
+                "text": text[:20000] if extract_text else "",
+            }
+    except Exception as e:
+        log.warning("web_fetch_error", url=url, error=str(e))
+        return {"url": url, "status": 0, "ok": False, "html": "", "text": "", "error": str(e)}

--- a/scripts/cron-agent-python/agent_job.py
+++ b/scripts/cron-agent-python/agent_job.py
@@ -982,7 +982,12 @@ async def web_search(
     if not results:
         try:
             import re
-            async with httpx.AsyncClient(timeout=15.0, follow_redirects=True, verify=False) as client:
+            # TLS verification stays ON. This fallback's HTML is parsed into
+            # search results that are fed straight into LLM synthesis prompts,
+            # so a MITM here is a prompt-injection channel into an unattended
+            # agent. `verify=False` bought nothing: probed 3x on Pro 2026-07-25,
+            # verified and unverified returned identical status/bytes.
+            async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
                 r = await client.post(
                     _DDG_SEARCH_URL,
                     data={"q": query},

--- a/scripts/cron-agent-python/intel_radar_daily_digest.py
+++ b/scripts/cron-agent-python/intel_radar_daily_digest.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Intel Radar — daily digest (18:00 WITA).
+
+# Organo: intel-radar-daily-digest (cron-agent-python) →
+#   produce: 1 Telegram digest/day to Zero
+#           + UPDATE intel_radar_findings SET processed=true
+#           + NOTIFY intel_radar_batch_ready (Postgres) for downstream consumers
+# Consuma: intel_radar_findings WHERE processed=false (last 24h)
+#
+# Ruolo: rifrazione editoriale. Le ricerche orarie del radar accumulano
+#         findings in DB silenziosamente. Una volta al giorno, alle 18:00 WITA,
+#         questo job legge le findings non-processate, le raggruppa per tier
+#         (L1/L2/L3) + per dominio prevalente, manda 1 messaggio Telegram a
+#         Zero (executive summary) e marca processed=true. Lo scraper poi pesca.
+#
+# Replaces: l'orario Telegram di intel_radar.py (rimosso nel refactor 2026-04-26).
+#           Frequenza: 24× → 1× al giorno (riduzione spam Telegram, aumento qualità).
+
+Idempotency: marking processed=true is the watermark. Re-running the same day
+won't re-notify (zero unprocessed rows). The daemon never DELETEs findings —
+only flips the boolean. Decay is owned by E.6 (PR-1.5).
+
+Usage:
+    python3 intel_radar_daily_digest.py             # normal run
+    python3 intel_radar_daily_digest.py --dry-run   # SELECT only, no UPDATE/notify
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+
+class IntelRadarDailyDigestJob(AgentJob):
+    name = "intel-radar-daily-digest"
+    timeout_s = 60
+    requires_side_effects = True  # we always either send digest or log "no findings"
+
+    def __init__(self, dry_run: bool = False) -> None:
+        super().__init__()
+        self.dry_run = dry_run
+
+    async def run(self) -> RunResult:
+        try:
+            import asyncpg
+        except ImportError:
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="asyncpg_missing",
+            )
+
+        dsn = os.getenv("DATABASE_URL")
+        if not dsn:
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="database_url_missing",
+            )
+
+        try:
+            conn = await asyncpg.connect(dsn, timeout=10)
+        except Exception as exc:
+            self.logger.error("db_connect_failed", error=str(exc))
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output=f"db_connect_failed: {exc}",
+            )
+
+        try:
+            # SELECT unprocessed findings from last 24h.
+            # Order by tier (L1 first) then observed_at (newest first) for digest readability.
+            rows = await conn.fetch(
+                """
+                SELECT id, query, query_tier, url, canonical_url, title, description,
+                       source_domain, observed_at, source
+                FROM intel_radar_findings
+                WHERE processed = FALSE
+                  AND observed_at > NOW() - INTERVAL '24 hours'
+                ORDER BY
+                    CASE query_tier WHEN 'L1' THEN 1 WHEN 'L2' THEN 2 ELSE 3 END,
+                    observed_at DESC
+                """
+            )
+            self.log_step("fetch_done", outputs={"rows": len(rows)})
+
+            if not rows:
+                self.log_step(
+                    "no_unprocessed_findings",
+                    outputs={"rows": 0},
+                    side_effect="no_unprocessed_findings",
+                )
+                return RunResult(
+                    status="ok",
+                    duration_s=self._elapsed(),
+                    side_effects=self._side_effects,
+                    output="no_unprocessed_findings",
+                )
+
+            # Build digest message — grouped by tier, top 5 per tier by observed_at.
+            msg = self._compose_message(rows)
+
+            if self.dry_run:
+                self.log_step("dry_run", outputs={"would_send": True, "msg_chars": len(msg)})
+                print(msg)
+                return RunResult(
+                    status="ok",
+                    duration_s=self._elapsed(),
+                    side_effects=self._side_effects,
+                    output=f"dry_run: {len(rows)} rows",
+                )
+
+            # Send Telegram.
+            ok = await self.send_telegram(msg)
+            self.log_step(
+                "telegram_send",
+                outputs={"ok": ok, "rows": len(rows)},
+                side_effect="intel_radar_daily_digest" if ok else None,
+            )
+
+            # Mark processed = TRUE (transactional, all or nothing).
+            ids = [r["id"] for r in rows]
+            await conn.execute(
+                """
+                UPDATE intel_radar_findings
+                SET processed = TRUE, processed_at = NOW()
+                WHERE id = ANY($1::uuid[])
+                """,
+                ids,
+            )
+            self.log_step("mark_processed", outputs={"updated": len(ids)})
+
+            # Emit NOTIFY for downstream consumers (intel-scraper supervisor, future).
+            await conn.execute(
+                "SELECT pg_notify('intel_radar_batch_ready', $1)",
+                json.dumps({"count": len(ids), "ts": datetime.now(timezone.utc).isoformat()}),
+            )
+            self.log_step("notify_emit", outputs={"channel": "intel_radar_batch_ready"})
+
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output=f"digest_sent: {len(rows)} findings",
+            )
+        finally:
+            await conn.close()
+
+    def _compose_message(self, rows: list) -> str:
+        """Compose Telegram HTML digest message.
+
+        Layout:
+          Header: count + window
+          Per-tier section (L1/L2/L3): top 3-5 findings each, with title + domain
+          Footer: total + handoff hint
+        """
+        import html as _html
+
+        now = datetime.now(WITA)
+        by_tier: dict[str, list] = defaultdict(list)
+        domain_counter: Counter = Counter()
+
+        for r in rows:
+            by_tier[r["query_tier"]].append(r)
+            if r["source_domain"]:
+                domain_counter[r["source_domain"]] += 1
+
+        lines: list[str] = [
+            f"📰 <b>Intel Radar — Daily Digest</b>",
+            f"<i>{now.strftime('%a %d %b %Y, %H:%M WITA')}</i>",
+            f"{len(rows)} findings · "
+            + " · ".join(f"{tier}={len(by_tier.get(tier, []))}" for tier in ("L1", "L2", "L3")),
+            "",
+        ]
+
+        tier_labels = {
+            "L1": "🔵 <b>L1 — Core</b> (visa/kitas/KBLI/OSS/pajak)",
+            "L2": "🟢 <b>L2 — Adjacent</b> (banking/property/tourism)",
+            "L3": "🟡 <b>L3 — Lateral</b> (rupiah/ASEAN/macro)",
+        }
+        for tier in ("L1", "L2", "L3"):
+            tier_rows = by_tier.get(tier, [])
+            if not tier_rows:
+                continue
+            lines.append(tier_labels[tier])
+            for r in tier_rows[:5]:
+                title = _html.escape((r["title"] or "?")[:120])
+                domain = r["source_domain"] or "—"
+                lines.append(f"  • <b>{title}</b>")
+                lines.append(f"    <i>{_html.escape(domain)}</i>")
+            if len(tier_rows) > 5:
+                lines.append(f"  <i>… +{len(tier_rows) - 5} more</i>")
+            lines.append("")
+
+        if domain_counter:
+            top_domains = ", ".join(f"{d} ({c})" for d, c in domain_counter.most_common(3))
+            lines.append(f"<i>Top domains:</i> {_html.escape(top_domains)}")
+
+        lines.append("")
+        lines.append("<i>↓ Handoff to scraper queue (auto)</i>")
+
+        return "\n".join(lines)
+
+    def _elapsed(self) -> float:
+        import time
+        return time.time() - self.started_at
+
+
+def _run_dry_run() -> int:
+    """Synchronous entry-point for --dry-run flag (no AgentJob ledger overhead)."""
+    job = IntelRadarDailyDigestJob(dry_run=True)
+    asyncio.run(job.run())
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Intel Radar daily digest")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print digest without UPDATE/notify/Telegram")
+    args, _unknown = parser.parse_known_args()
+
+    if args.dry_run:
+        sys.exit(_run_dry_run())
+
+    main(IntelRadarDailyDigestJob)

--- a/scripts/cron-agent-python/log_anomaly_detector.py
+++ b/scripts/cron-agent-python/log_anomaly_detector.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Log Anomaly Detector — runs every 5min for 4.5min window (supervisor pattern).
+
+# Organo: log-anomaly-detector (cron-agent-python, Monitor pattern) → produce:
+#         Telegram alert (se anomalia) + Redis event `cron:log-anomaly-detector`
+# Consuma da: ~/logs/ (cron logs), fly logs (Fly.io streaming)
+#
+# Ruolo: sentinella live. Invece di aspettare il prossimo ciclo cron,
+#         monitora i log in streaming e reagisce in secondi su anomalie.
+#         Implementa il Monitor pattern: zero token durante silenzio,
+#         sveglia immediata su pattern match.
+
+Monitors:
+  1. Local cron-agent-python logs (FATAL, Traceback, ERROR × 3+)
+  2. fly logs streaming (OOMKilled, 502, 503, panic, connection refused)
+
+Deduplication: 30min cooldown per pattern match (Redis TTL).
+Max 3 alerts per run to avoid spam.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import re
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import (
+    AgentJob, RunResult, WITA, LOG_DIR, main, _REDIS_ERR_RE,
+)
+
+
+# Log patterns to watch (regex → severity)
+LOG_PATTERNS: list[tuple[str, str, str]] = [
+    # (regex, severity, label)
+    (r"FATAL|CRITICAL", "RED", "fatal_error"),
+    (r"Traceback \(most recent", "RED", "python_exception"),
+    (r"circuit_breaker_opened", "YELLOW", "circuit_breaker"),
+    (r"ERROR.*CRM.*unreachable|CRM backend unreachable", "RED", "crm_down"),
+    (r"telegram.*failed|telegram_failed", "YELLOW", "telegram_issue"),
+    (r"timeout after \d+s", "YELLOW", "job_timeout"),
+    # Audit 2026-04-19: core-guardian was failing silently for >24h because
+    # the cron wrapper referenced a script that didn't exist. Add patterns
+    # to catch that class of breakage.
+    (r"script not found|No such file or directory", "RED", "script_not_found"),
+    (r"\bexit code [1-9]\d*\b", "RED", "non_zero_exit"),
+]
+
+# Extra log dirs to scan beyond LOG_DIR (cron-agent-python).
+# cron-agent.sh (bash-tier) writes to ~/logs/cron-agent/, which the
+# original implementation ignored — hiding failures like core-guardian.
+EXTRA_LOG_DIRS = [Path.home() / "logs" / "cron-agent"]
+
+# Fly.io log patterns
+FLY_PATTERNS: list[tuple[str, str, str]] = [
+    (r"OOMKilled", "RED", "oom_killed"),
+    (r"502 Bad Gateway|503 Service Unavailable", "RED", "gateway_error"),
+    (r"panic:", "RED", "go_panic"),
+    (r"connection refused", "YELLOW", "connection_refused"),
+    (r"Traceback \(most recent", "RED", "python_exception"),
+    (r"Error starting app|App crashed", "RED", "app_crash"),
+]
+
+# Cooldown: don't re-alert same pattern within 30min
+ALERT_COOLDOWN_TTL = 1800
+# Fix C (2026-04-17): reduced from 270→60. Cron runs every 5min, and we only
+# care about NEW errors — a 1-min streaming window is sufficient. Cuts cron
+# runtime from 261s → ~60s, saving 80% execution time without missing events.
+WATCH_WINDOW_S = 60
+MAX_ALERTS_PER_RUN = 3
+
+# Fix A (2026-04-17): only scan log lines whose timestamp is within this
+# window. Prevents re-alerting on old errors already surfaced hours earlier.
+LOG_FRESHNESS_S = 600  # 10 min
+
+# Fix B (2026-04-17): per-line-hash dedup TTL. If the same exact log line has
+# been alerted before (within this window), skip it.
+LINE_DEDUP_TTL = 86400  # 24h
+LINE_DEDUP_PREFIX = "bz:log-anomaly:linehash"
+
+# Regex to extract "YYYY-MM-DD HH:MM:SS" or ISO8601 ts from structlog / fly logs.
+_TS_PATTERN = re.compile(
+    r"(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2})"
+)
+
+
+def _parse_ts(line: str) -> datetime | None:
+    """Extract the line's own timestamp, or None if it carries none."""
+    m = _TS_PATTERN.search(line)
+    if not m:
+        return None
+    try:
+        return datetime.strptime(
+            m.group(1).replace("T", " "), "%Y-%m-%d %H:%M:%S",
+        )
+    except Exception:
+        return None
+
+
+def _fresh_lines(lines: list[str], cutoff: datetime) -> list[str]:
+    """Keep lines at/after cutoff, dating each one by POSITION.
+
+    Fix D (2026-07-25): a line with no timestamp of its own inherits the last
+    timestamp seen ABOVE it — log files are chronological. The previous
+    per-line check defaulted timestamp-less lines to "fresh", and the line the
+    RED pattern matches is literally `Traceback (most recent call last):`,
+    which never carries a timestamp. So a 2026-07-05 traceback sitting in the
+    last-500-line window of a quiet log stayed eternally fresh and re-alerted
+    every 5 minutes for 20 days (fact-checker, intel-feed-processor,
+    vision-doc-extractor — all three jobs healthy, all three alerts false).
+
+    Lines above the first timestamp in the window are still treated as fresh
+    (conservative — nothing dates them either way).
+    """
+    out: list[str] = []
+    current: datetime | None = None
+    for line in lines:
+        ts = _parse_ts(line)
+        if ts is not None:
+            current = ts
+        if current is None or current >= cutoff:
+            out.append(line)
+    return out
+
+
+class LogAnomalyDetectorJob(AgentJob):
+    name = "log-anomaly-detector"
+    timeout_s = 300
+    requires_side_effects = False
+
+    async def run(self) -> RunResult:
+        self.log_step("start")
+        alerts: list[dict] = []
+
+        # Run both watchers in parallel with shared timeout
+        local_task = asyncio.create_task(self._watch_local_logs(alerts))
+        fly_task = asyncio.create_task(self._watch_fly_logs(alerts))
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(local_task, fly_task, return_exceptions=True),
+                timeout=WATCH_WINDOW_S,
+            )
+        except asyncio.TimeoutError:
+            pass
+        except Exception as e:
+            self.log_step("watch_error", outputs={"error": str(e)})
+
+        self.log_step("watch_done", outputs={"alerts": len(alerts)})
+
+        if alerts:
+            msg = self._compose_alert(alerts)
+            ok = await self.send_telegram(msg)
+            self.log_step("telegram_sent", outputs={"ok": ok},
+                          side_effect="anomaly_alert" if ok else None)
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=f"alerts={len(alerts)}",
+        )
+
+    async def _watch_local_logs(self, alerts: list) -> None:
+        """Watch recent cron-agent-python log files for error patterns.
+
+        Fix A: filter lines by timestamp (only LOG_FRESHNESS_S recent).
+        Fix B: dedup by (line-content) hash via Redis (LINE_DEDUP_TTL).
+        """
+        log_dirs = [LOG_DIR, *EXTRA_LOG_DIRS]
+        all_logs: list = []
+        for d in log_dirs:
+            if d.exists():
+                all_logs.extend(d.glob("*.log"))
+
+        if not all_logs:
+            return
+
+        log_files = sorted(
+            all_logs,
+            key=lambda f: f.stat().st_mtime, reverse=True,
+        )[:10]
+
+        freshness_cutoff = datetime.now() - timedelta(seconds=LOG_FRESHNESS_S)
+
+        for log_file in log_files:
+            try:
+                content = log_file.read_text(errors="ignore")
+                lines = content.splitlines()[-500:]  # bigger window; we filter by ts next
+
+                # Fix A + D: keep only lines dated (by position) within the
+                # freshness window — see _fresh_lines().
+                fresh_lines = _fresh_lines(lines, freshness_cutoff)
+                if not fresh_lines:
+                    continue
+
+                # Collect matches per (pattern, severity, label), dedup by line hash
+                matches_by_label: dict = defaultdict(list)
+                for line in fresh_lines:
+                    for pattern, severity, label in LOG_PATTERNS:
+                        if re.search(pattern, line, re.IGNORECASE):
+                            matches_by_label[(pattern, severity, label)].append(line)
+                            break  # one label per line
+
+                for (pattern, severity, label), matched_lines in matches_by_label.items():
+                    if len(alerts) >= MAX_ALERTS_PER_RUN:
+                        break
+                    # Fix B: line-hash dedup — filter out lines alerted in last 24h
+                    unseen = [
+                        ln for ln in matched_lines
+                        if await self._line_is_unseen(ln)
+                    ]
+                    if not unseen:
+                        continue
+                    # Fix: per-label cooldown still applies (30 min global)
+                    if not await self._should_alert(f"local:{label}"):
+                        continue
+                    alerts.append({
+                        "source": f"local/{log_file.name}",
+                        "severity": severity,
+                        "label": label,
+                        "count": len(unseen),
+                        "sample": unseen[-1][:150],
+                    })
+            except Exception as e:
+                self.logger.debug(
+                    "local_watch_error", file=log_file.name, error=str(e),
+                )
+
+    async def _watch_fly_logs(self, alerts: list) -> None:
+        """Stream fly logs for nuzantara-rag and watch for error patterns.
+
+        Fly logs are streamed — already fresh (no need for Fix A timestamp
+        filter). Fix B applies: line-hash dedup prevents alerting same exact
+        line across runs.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "fly", "logs", "--app", "nuzantara-rag",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+
+            async def read_stream():
+                async for raw_line in proc.stdout:
+                    if len(alerts) >= MAX_ALERTS_PER_RUN:
+                        break
+                    line = raw_line.decode(errors="ignore").strip()
+                    for pattern, severity, label in FLY_PATTERNS:
+                        if re.search(pattern, line, re.IGNORECASE):
+                            # Fix B: skip if this exact line already alerted
+                            if not await self._line_is_unseen(line):
+                                break
+                            if await self._should_alert(f"fly:{label}"):
+                                alerts.append({
+                                    "source": "fly:nuzantara-rag",
+                                    "severity": severity,
+                                    "label": label,
+                                    "count": 1,
+                                    "sample": line[:200],
+                                })
+                            break
+
+            # WATCH_WINDOW_S is now 60s (Fix C). Reserve 10s for parallel tasks.
+            await asyncio.wait_for(
+                read_stream(), timeout=max(WATCH_WINDOW_S - 10, 10),
+            )
+            proc.kill()
+
+        except asyncio.TimeoutError:
+            pass
+        except Exception as e:
+            self.logger.debug("fly_watch_error", error=str(e))
+
+    def _redis_reply(self, argv: list[str]) -> str | None:
+        """Run a redis-cli command; return its reply, or None if Redis refused.
+
+        Fix (2026-07-25): redis-cli exits 0 even when the server rejects the
+        command, delivering the error as a reply on stdout. The previous code
+        compared that reply to "1", so `NOAUTH Authentication required.` read as
+        "key absent" and BOTH dedup layers failed open — silently, for weeks,
+        at 288 Telegram alerts a day. A refusal now returns None and is LOGGED,
+        so the degradation is visible instead of merely loud.
+        """
+        try:
+            out = subprocess.run(
+                argv, capture_output=True, text=True, timeout=3,
+            )
+        except Exception as e:
+            self.logger.warning("redis_dedup_unavailable", detail=str(e)[:120])
+            return None
+        reply = (out.stdout or "").strip()
+        if out.returncode != 0 or _REDIS_ERR_RE.match(reply):
+            self.logger.warning(
+                "redis_dedup_refused",
+                detail=reply[:120] or f"rc={out.returncode}",
+            )
+            return None
+        return reply
+
+    async def _should_alert(self, dedup_key: str) -> bool:
+        """Return True if this alert key hasn't been sent recently (30min cooldown)."""
+        redis_key = f"bz:log-anomaly:{dedup_key}"
+        reply = self._redis_reply(["redis-cli", "EXISTS", redis_key])
+        if reply is None:
+            # Backend refused/unreachable: alert rather than go blind. Losing a
+            # real alarm is worse than repeating one — and the warning above
+            # names the degradation, which is what was missing before.
+            return True
+        if reply == "1":
+            return False  # within cooldown
+        self._redis_reply(
+            ["redis-cli", "SET", redis_key, "1", "EX", str(ALERT_COOLDOWN_TTL)]
+        )
+        return True
+
+    async def _line_is_unseen(self, line: str) -> bool:
+        """Return True if this exact line hasn't been alerted within LINE_DEDUP_TTL.
+
+        Fix B: prevents the same identical error line from triggering repeated
+        alerts across runs (the primary cause of the 11-alerts-in-2h spam).
+        """
+        h = hashlib.sha1(line.encode("utf-8", errors="ignore")).hexdigest()[:16]
+        key = f"{LINE_DEDUP_PREFIX}:{h}"
+        reply = self._redis_reply(["redis-cli", "EXISTS", key])
+        if reply is None:
+            return True  # see _redis_reply: refusal is logged, not swallowed
+        if reply == "1":
+            return False
+        self._redis_reply(
+            ["redis-cli", "SET", key, "1", "EX", str(LINE_DEDUP_TTL)]
+        )
+        return True
+
+    def _compose_alert(self, alerts: list[dict]) -> str:
+        now = datetime.now(WITA)
+        red_alerts = [a for a in alerts if a["severity"] == "RED"]
+        icon = "🔴" if red_alerts else "🟡"
+        lines = [
+            f"{icon} <b>Log Anomaly</b> — {len(alerts)} issues",
+            f"{now.strftime('%H:%M WITA')}",
+            "",
+        ]
+        for a in alerts:
+            sev_icon = "🔴" if a["severity"] == "RED" else "🟡"
+            lines.append(f"{sev_icon} <b>{a['label']}</b> [{a['source']}]")
+            if a.get("sample"):
+                lines.append(f"  <code>{a['sample'][:150]}</code>")
+        return "\n".join(lines)
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(LogAnomalyDetectorJob)

--- a/scripts/cron-agent-python/run.sh
+++ b/scripts/cron-agent-python/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Cron wrapper for cron-agent-python jobs.
+# Usage: run.sh <job-name>
+# Ensures:
+#   - Minimal PATH (homebrew, pyenv, local bin)
+#   - Secrets sourced from ~/.zshrc.secrets (TELEGRAM_BOT_TOKEN etc.)
+#   - No ANTHROPIC_API_KEY leaked (OAuth Max plan only, $0)
+#   - venv Python used
+set -uo pipefail
+
+JOB="${1:?usage: run.sh <job-name>}"
+SCRIPT_DIR="/Users/nuzantara/scripts/cron-agent-python"
+VENV_PY="/Users/nuzantara/scripts/cron-agent-venv/bin/python"
+SCRIPT="$SCRIPT_DIR/${JOB//-/_}.py"
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "ERROR: script not found: $SCRIPT" >&2
+    exit 127
+fi
+
+export PATH="/opt/homebrew/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/Users/nuzantara/.local/bin:/usr/local/bin:/usr/bin:/bin"
+export HOME="/Users/nuzantara"
+export USER="nuzantara"
+
+# Source secrets (TELEGRAM_BOT_TOKEN, TELEGRAM_OWNER_CHAT_ID, GITHUB_TOKEN, …).
+# cron runs with a clean env — without this, agent_job.py falls back to
+# `reason=no_token` and the job "succeeds" silently without ever paging.
+# `set -a` exports every variable the sourced file assigns; the unset of
+# ANTHROPIC_API_KEY below must happen AFTER sourcing, so even if the secrets
+# file defines it the paid-API-key kill-switch still wins.
+if [[ -f "$HOME/.zshrc.secrets" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$HOME/.zshrc.secrets"
+    set +a
+fi
+
+# Redis on this host requires AUTH (password added ~2026-06-29), but every
+# `redis-cli` call in this tree invokes the bare binary with no credentials.
+# redis-cli then answers NOAUTH and prints nothing on stdout, which callers
+# read as "key absent" — so the cron:reports event bus silently stopped
+# publishing and the log-anomaly dedup failed OPEN (288 spurious Telegram
+# alerts/day). REDIS_PASSWORD lives in ~/.nuzantara-secrets.env, NOT in
+# ~/.zshrc.secrets sourced above. Pass it via REDISCLI_AUTH — redis-cli reads
+# that natively — instead of `-a`, so the secret never lands in argv/`ps`.
+# Extracted in a SUBSHELL so nothing else from that file leaks into the job env
+# (in particular ANTHROPIC_API_KEY, killed below, must stay killed).
+if [[ -z "${REDISCLI_AUTH:-}" && -f "$HOME/.nuzantara-secrets.env" ]]; then
+    _redis_pw="$(set -a; source "$HOME/.nuzantara-secrets.env" >/dev/null 2>&1; printf '%s' "${REDIS_PASSWORD:-}")"
+    if [[ -n "$_redis_pw" ]]; then
+        export REDISCLI_AUTH="$_redis_pw"
+    fi
+    unset _redis_pw
+fi
+
+# Force clean auth env (prevent accidental pay-per-token) — MUST run after
+# sourcing secrets so the kill-switch has the last word.
+unset ANTHROPIC_API_KEY
+
+exec "$VENV_PY" "$SCRIPT"


### PR DESCRIPTION
Follow-up to **W104** (PR #3105). The cure that stopped the 288-alerts/day Telegram spam lived only in an **untracked HOME tree on Pro** — unreproducible from the repo and silently divergent by construction (superscar #1).

## Promoted verbatim

Byte-identical is a requirement, not a style choice: the declared-pair check is a sha256 comparison, so repo and live must match exactly (hardcoded paths included).

| file | why this one |
|---|---|
| `run.sh` | **THE** entry point — 16 crontab lines exec it. Carries the `REDISCLI_AUTH` export that re-armed redis auth for the whole tree. |
| `agent_job.py` | Shared base every job imports. **Structurally invisible** to `lint_home_fork.py --discover`, which only resolves payloads *named* by a plist/crontab — an imported module is never an entry point, so the most load-bearing file in the tree could never be flagged. Declared by hand for exactly that reason. |
| `log_anomaly_detector.py` | The cured job. |
| `intel_radar_daily_digest.py` | The one tree payload `--discover` **did** flag (run straight from a plist, bypassing `run.sh` — which is why `agent_job.py` now also derives `REDISCLI_AUTH` at import time). |

Declared pairs **70 → 77**.

## Found while sweeping

`curiosity_batch.py` — the only file of this tree already tracked (#1510) — **had drifted**. It was never declared, so `--check` was blind to it too. The divergence was comment-only (1 hunk, code byte-identical): the live copy still carried the pre-#1510 note about a plaintext DB-password fallback that #1510 had stripped as a cicatrix-#4 leak. Verified no credential in the live copy, then realigned live from repo canon.

## Two decorative gates cured (W104 class-audit)

`garuda-consumer.sh` and `garuda-gap-detector.sh` guarded on `if ! redis-cli ping`, which **passes unauthenticated** because redis-cli exits 0 on NOAUTH. They now grade the reply (`== PONG`) **and** export `REDISCLI_AUTH` — tightening the gate without supplying the credential would have taken both crons offline. Proven live on Pro **3/3**: scar-pin (old gate passes unauthenticated), guilt (new gate blocks on NOAUTH), innocence (new gate returns PONG, no cron taken offline).

## Second commit: security-review findings

A background review of the promotion commit flagged two items in `agent_job.py`. Both are pre-existing in code promoted verbatim, and they resolve differently:

- **FIXED — TLS verification disabled.** The DDG fallback built its httpx client with `verify=False`. Its HTML is parsed into search results fed straight into LLM synthesis prompts, so a MITM there is a **prompt-injection channel into an unattended agent**. Measured before changing anything: verified and unverified return identical status/bytes over 3 repeats, so removing it is functionally neutral. Live copy realigned in the same step.
- **ACKNOWLEDGED, not changed — `permission_mode: "bypassPermissions"`.** These jobs run headless under cron, where nobody can answer a permission prompt, and the call defaults to `tools=[]`/`allowed_tools=[]`. Measured: of the 3 callers of `claude_synthesize`, **zero** pass `tools_allowed` and **zero** pass `subagents=`, so no live call ever receives a tool. The empty tool list is the actual control and it already holds; changing permission semantics across 16 live crons is a separate mandate with real breakage risk.

## Exposure review (this repo is public)

Scanned all 28 files by pattern before publishing: **0 hardcoded secrets, 0 client PII, 0 emails/phones**; every credential read from env. The one long-literal hits were false positives (`application/json`, an API path, a notebook UUID). The Telegram owner chat-id at `agent_job.py:205` adds nothing new — it is already in 187 tracked files including `CLAUDE.md`.

## Not fixed here (open, reported)

`web_search()` returns **0 results for every caller**: `BRAVE_API_KEY` is unset so the primary path never runs, and DuckDuckGo now answers **202** with markup that no longer contains `result__title`, the parser's anchor. Measured identical under both verify settings, so pre-existing and unrelated to the TLS change. It still logs `web_search_ddg_ok`. Another superscar #2. Provisioning a Brave key is a credential decision.

Also for the record: `--discover` reports **211** undeclared HOME payloads on Pro in total. These 7 are a drop; the rest stays open debt.


## Third commit: the `gateway` check was right — migrated to `tg_notify.py`

The required `gateway` check failed this PR, and it was **naming a missing organ, not blocking one**. `scripts/tg_notify.py` has existed since **2026-07-06**, born from Zero's mandate *"non posso più ricevere 600 messaggi al giorno"*, and it owns a daily P0 budget plus dedup-by-key. In other words: the organism already had the exact antibody for the flood this PR is a follow-up to — **288 alerts/day would have collapsed into one counted message** — and this tree was routing around it with a direct sender.

`AgentJob.send_telegram` is the single choke point for **all 30 callers** of the tree, so one method carries the family:

- **Grades the reported STATUS, never the exit code.** `tg_notify.py` never fails its caller by contract, so `rc=0` proves nothing — the same trap as `_REDIS_ERR_RE` two screens above, and the trap the *first* W104 antibody fell into (an rc check, decorative by construction).
- **`tier` defaults to `p0`**, so the ~27 unmigrated HOME callers keep today's latency and merely gain the cap they lacked. Budget overflow degrades to the digest: delayed, never dropped.
- **A non-owner `chat_id` is refused loudly**, not redirected — the gateway delivers to the owner chat only, and silently rerouting would hand someone else's message to Zero. Verified live on Pro: no job sets one.
- Per call site: job failure → `p0` keyed on the job name (a job failing every 5 min costs one alert plus a counter) · log-anomaly → `p0` keyed on the sorted `(source, label)` set and deliberately **not** the count, so a rising count still collapses · intel-radar → `digest`.

**Armed-check before routing anything to `digest`** (famiglia #2 — otherwise the spam just moves into a black hole): `com.nuzantara.tg-digest-flush` runs at `StartInterval=43200` (12h), last flush `sent=true` with 73 events, queue accumulating normally. That 12h latency is precisely why the default is `p0` and not `digest`.

**Proof — 11/11 on Pro's cron venv**, hermetic (`TG_DRY_RUN`, throwaway spool, no production state per W96). Guilt: gateway resolves in repo layout; digest spools then dedups on the second call; log stays on disk; p0 sends; budget overflow spools instead of flooding. Innocence: foreign chat refused, owner chat accepted, unknown tier degrades to `p0` without dropping the message. `lint_tg_direct_senders.py`: **clean, 7980 files scanned** (not a blind scan).

**Two ledger lines opened rather than skipped silently** (`.claude/skills/modus/PENDING-ARMS.md`): the HOME copies stay on the direct sender until after the merge — they are declared pairs, so a HOME ahead of Pro's checkout reads as a breach and the healer would refresh it *from canon*, reverting the deploy (the spam itself is already cured live) — and the status-grading has no CI pin yet, because the `gateway` job installs only pytest and a real pin needs `structlog`/`httpx` stubbed plus a HOME redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
