### PR TITLE
fix(wr2): declare the silent 6-word guillotine to the writer (4 kinds, 6 fields)

### DIFF
--- a/scripts/tests/test_wr2_planner_writer.py
+++ b/scripts/tests/test_wr2_planner_writer.py
@@ -418,3 +418,76 @@ class TestProduceDeckAssembly:
 
         deck = pw.produce_deck("BRIEF", "analitico", "breaking", [], out_of_order_planner_fn, self._writer_fn)
         assert [s.kind for s in deck.slides] == ["cover", "fact_stack", "statement"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The SILENT GUILLOTINE (2026-07-25) — every `_cap_subhead` field must declare
+# its budget to the writer, or production copy ships trimmed mid-phrase.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _classes_whose_validators_call_cap_subhead() -> set[str]:
+    """Derive the capped classes from the IR SOURCE, never from a hand-kept list:
+    a NEW capped field on a NEW kind must fail the test below until someone
+    declares it, instead of silently joining the guillotine."""
+    import ast
+    import inspect
+
+    tree = ast.parse(Path(inspect.getsourcefile(ir)).read_text())
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for fn in node.body:
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for sub in ast.walk(fn):
+                if isinstance(sub, ast.Name) and sub.id == "_cap_subhead":
+                    out.add(node.name)
+    return out
+
+
+def test_every_cap_subhead_field_declares_its_budget_to_the_writer() -> None:
+    """GUILT (measured live, one real deck): `_cap_subhead` hard-trims to a word
+    boundary and DISCARDS the remainder. Before this pin, not one of the six
+    capped fields told the writer, so it wrote sentences that shipped guillotined:
+    cover.subhead "A new rule just reset one", cta.trust_marker "Basis: Peraturan
+    BKPM No." (the regulation number cut off), cta.reach "Butuh hitung modal,
+    KBLI, dan" (ends on a conjunction)."""
+    capped = _classes_whose_validators_call_cap_subhead()
+    assert capped, "no _cap_subhead validator found — did the guillotine move or get renamed?"
+
+    cls_to_kind = {cls.__name__: kind for kind, cls in pw._KIND_TO_MODEL.items()}
+    checked = []
+    for cname in sorted(capped):
+        kind = cls_to_kind.get(cname)
+        if kind is None:
+            continue  # a capped model the planner cannot emit — not a writer-prompt concern
+        schema = pw._KIND_FIELD_SCHEMA[kind]
+        checked.append(kind)
+        assert pw._SUBHEAD_CAP in schema, (
+            f"kind {kind!r} ({cname}) has a _cap_subhead-trimmed field but its writer "
+            f"schema never states the budget — the writer will overrun it and the "
+            f"overrun will be silently discarded. Schema was: {schema!r}"
+        )
+    assert checked, "no capped class mapped to a planner kind — the mapping broke"
+    # the four known today; a fifth must be declared, not silently added
+    assert set(checked) == {"cover", "prose", "stat", "cta"}, checked
+
+
+def test_subhead_cap_note_matches_the_ir_constants() -> None:
+    """The prompt's numbers are INTERPOLATED from the validator's own constants —
+    a re-typed literal would drift the instruction away from the enforcement."""
+    assert str(ir._SUBHEAD_MAX_WORDS) in pw._SUBHEAD_CAP
+    assert str(ir._SUBHEAD_MAX_CHARS) in pw._SUBHEAD_CAP
+
+
+def test_cap_subhead_really_discards_the_overrun() -> None:
+    """The behaviour the prompt now warns about, pinned: this is LOSS, not wrapping."""
+    long_marker = "Basis: Peraturan BKPM Nomor 5 Tahun 2025 tentang modal disetor"
+    slide = ir.CtaSlide(kind="cta", invite="Cek dua ambang sebelum setor modal.",
+                        trust_marker=long_marker, reach="")
+    assert slide.trust_marker != long_marker
+    assert len(slide.trust_marker) <= ir._SUBHEAD_MAX_CHARS
+    assert len(slide.trust_marker.split()) <= ir._SUBHEAD_MAX_WORDS
+    assert long_marker.startswith(slide.trust_marker.rstrip())  # a prefix — the tail is gone

--- a/scripts/tests/test_wr2_smart_hero.py
+++ b/scripts/tests/test_wr2_smart_hero.py
@@ -214,12 +214,24 @@ def test_routing_layout_family_typo_falls_through_to_auto() -> None:
          "layout_family": "photo-fulbleed"}, 4, 8  # intentional typo
     )
     assert fam == "editorial-text"
-    # an UNDEFINED (named-but-no-skeleton) family is also ignored
+    # An UNDEFINED (named-but-no-skeleton) family is also ignored.
+    # DRIFT-PROOFED 2026-07-25: this used to hardcode "stat-card-hero", which
+    # GRADUATED to RENDERABLE_FAMILIES on 2026-07-11 (it gained a real skeleton).
+    # From that day the pin was correctly HONOURED and this test failed — it had
+    # stopped exercising its own invariant and just asserted a stale fact. Read the
+    # example from the set that DEFINES the concept instead of naming a member that
+    # can graduate out from under the test.
+    from wr2_html_renderer.composer import UNDEFINED_FAMILIES  # noqa: E402
+    assert UNDEFINED_FAMILIES, "no UNDEFINED family left to test the fall-through with"
+    undefined_example = sorted(UNDEFINED_FAMILIES)[0]
     fam2 = map_slide_to_family(
         {"slide_type": "body", "is_hero_image": True,
-         "layout_family": "stat-card-hero"}, 4, 8
+         "layout_family": undefined_example}, 4, 8
     )
-    assert fam2 == "photo-headline-yellow-sub"
+    assert fam2 == "photo-headline-yellow-sub", (
+        f"an UNDEFINED family ({undefined_example!r}) must fall through to auto-routing, "
+        "never be emitted as a blank skeleton"
+    )
 
 
 def test_photo_fullbleed_in_renderable_families() -> None:

--- a/scripts/wr2_carousel_ir.py
+++ b/scripts/wr2_carousel_ir.py
@@ -506,11 +506,22 @@ class CitationSlide(BaseModel):
 
 
 class CtaSlide(BaseModel):
-    """→ elegant-close. `invite` required content (the core call-to-action
-    line). See the DISCOVERED GAP note in to_composer_dict: NONE of this
-    family's top-level fields (trust_marker/reach/invite/…) are ever
-    substituted by composer._fill_placeholders today — verified by grep,
-    zero hits for all of them."""
+    """→ elegant-close. `invite` required content (the core call-to-action line).
+
+    STALE-CLAIM CORRECTED 2026-07-25. This docstring used to say "NONE of this
+    family's top-level fields (trust_marker/reach/invite/…) are ever substituted
+    by composer._fill_placeholders today — verified by grep, zero hits". That was
+    true when written and is FALSE now: PR #2958 (the W99 placeholder-sweep-gate
+    class-cure) made every RENDERABLE family fill its own tokens. Re-verified on
+    disk this session by substituting sentinels through the real compose pipeline:
+    invite / trust_marker / reach ALL render. Leaving the old note would have kept
+    scaring readers off a layout that works — and elegant-close is one of only two
+    families the planner/writer engine reaches beyond the legacy auto-routed four.
+
+    `trust_marker` and `reach` are LABEL fields: `_cap_subhead` hard-trims them to
+    _SUBHEAD_MAX_WORDS/_SUBHEAD_MAX_CHARS at a word boundary and silently discards
+    the rest, so the writer prompt MUST state that budget (it now does — see
+    wr2_planner_writer._SUBHEAD_CAP)."""
 
     model_config = ConfigDict(extra="ignore")
 

--- a/scripts/wr2_planner_writer.py
+++ b/scripts/wr2_planner_writer.py
@@ -424,9 +424,33 @@ assert set(_KIND_TO_MODEL) == set(ir.SLIDE_KIND_TO_FAMILY), (
 # docstring). Importing wr2_ir_shadow_replay here would pull in its asyncpg/
 # backend.llm import surface at module load time, which this module's own
 # zero-I/O discipline (stated in this file's module docstring) forbids.
+# The SILENT GUILLOTINE (2026-07-25, found by running the real pipeline end-to-end).
+# `wr2_carousel_ir._cap_subhead` hard-trims SIX fields across FOUR kinds to
+# _SUBHEAD_MAX_WORDS words / _SUBHEAD_MAX_CHARS chars at a word boundary:
+#     CoverSlide.subhead · ProseSlide.subhead · StatSlide.unit/label ·
+#     CtaSlide.trust_marker/reach
+# and until this change NOT ONE of the six declared that budget to the writer —
+# only `statement` ("a 3-15 word punch line") ever stated its own. So the writer
+# wrote natural sentences and the validator guillotined them mid-phrase, silently,
+# into production copy. Measured on one real deck (Perka BKPM 5/2025, opus-4-7
+# planner + sonnet-5 writer):
+#     cover.subhead    "A new rule just reset one"       -> dangling, no object
+#     cta.trust_marker "Basis: Peraturan BKPM No."       -> the regulation NUMBER cut off
+#     cta.reach        "Butuh hitung modal, KBLI, dan"   -> ends on a conjunction
+# Interpolated from the IR constants (never re-typed) so the instruction cannot
+# drift away from the validator that enforces it — pinned by
+# test_subhead_cap_note_matches_the_ir_constants.
+_SUBHEAD_CAP = (
+    f"MAX {ir._SUBHEAD_MAX_WORDS} WORDS / {ir._SUBHEAD_MAX_CHARS} chars — a LABEL, not a "
+    "sentence; longer text is hard-trimmed at a word boundary and the remainder is LOST"
+)
+
 _KIND_FIELD_SCHEMA: dict[str, str] = {
-    "cover": 'headline (str, required), subhead (str), regulation_code (str), image_prompt (str)',
-    "prose": 'headline (str, required), body (str, required), subhead (str)',
+    "cover": (
+        f'headline (str, required), subhead (str — {_SUBHEAD_CAP}), '
+        'regulation_code (str), image_prompt (str)'
+    ),
+    "prose": f'headline (str, required), body (str, required), subhead (str — {_SUBHEAD_CAP})',
     "statement": 'statement (str, required) — a 3-15 word punch line, never a paragraph',
     "fact_stack": (
         'heading (str, required), facts (list[str], required, >=1 — each item is ONE fact line), '
@@ -442,9 +466,15 @@ _KIND_FIELD_SCHEMA: dict[str, str] = {
         '"3 forces behind the rise")'
     ),
     "qa": 'pairs (list[{voice, line}], required, >=2 — first two entries are the two voices in the exchange)',
-    "stat": 'value (str, required), unit (str), label (str), context (str)',
+    "stat": (
+        f'value (str, required), unit (str — {_SUBHEAD_CAP}), '
+        f'label (str — {_SUBHEAD_CAP}), context (str)'
+    ),
     "citation": 'claim (str, required), sources (list[{code, issuer, date, url, note}], required, >=1)',
-    "cta": 'invite (str, required), trust_marker (str), reach (str)',
+    "cta": (
+        'invite (str, required — the call-to-action line), '
+        f'trust_marker (str — {_SUBHEAD_CAP}), reach (str — {_SUBHEAD_CAP})'
+    ),
 }
 assert set(_KIND_FIELD_SCHEMA) == set(_KIND_TO_MODEL), (
     "_KIND_FIELD_SCHEMA has drifted from _KIND_TO_MODEL's keys"


### PR DESCRIPTION
## What

`wr2_carousel_ir._cap_subhead` hard-trims six fields across four slide kinds at a word
boundary and **discards the remainder** — and not one of them told the writer its budget.
So the writer wrote natural sentences and the validator guillotined them, silently, into
copy a reader would see.

Found by **running** the production pipeline end-to-end (real planner `opus-4-7` + real
writer `sonnet-5`, real topic: Perka BKPM 5/2025), not by reading it. Three live instances
in a single generated deck:

| field | rendered | damage |
|---|---|---|
| `cover.subhead` | `A new rule just reset one` | dangling — no object |
| `cta.trust_marker` | `Basis: Peraturan BKPM No.` | the regulation **number** cut off |
| `cta.reach` | `Butuh hitung modal, KBLI, dan` | ends on a conjunction |

## Scope: the class, not the two fields I tripped over

All four capped kinds now declare the budget (`cover`, `prose`, `stat`, `cta`),
interpolated from the IR constants rather than re-typed, so the instruction cannot drift
from the validator that enforces it.

Why it surfaced now: `elegant-close` is one of only two families the planner/writer engine
reaches beyond the four legacy auto-routed layouts, so the guillotine finally landed on
copy that had barely ever been generated.

## Two stale claims corrected (both verified on disk, not assumed)

- **`CtaSlide` docstring** asserted its top-level fields are "never substituted by
  `composer._fill_placeholders` — verified by grep, zero hits". True when written, **false
  since #2958** (the W99 sweep-gate cure). Re-verified by pushing sentinels through the
  real compose pipeline: `invite`, `trust_marker`, `reach` all render. Left alone it would
  keep scaring readers off a layout that works.
- **`test_routing_layout_family_typo_falls_through_to_auto`** hardcoded `stat-card-hero`
  as its UNDEFINED-family example. That family graduated to `RENDERABLE_FAMILIES` on
  2026-07-11, so the pin is now correctly honoured and the test had been failing ever
  since — asserting a stale fact instead of its own invariant. **Pre-existing** (reproduced
  with this diff stashed). Drift-proofed: the example is now read from `UNDEFINED_FAMILIES`
  itself, so a future graduation cannot rot it again.

## Verify

- 3 new tests. The class test derives the capped set by walking the IR **source** (`ast`),
  so a new capped field on a new kind fails until declared.
- **CONTROL RUN**: removing the `cta` declaration fails it with the exact diagnostic; a
  re-typed literal fails the constants test.
- Full CI-canonical WR2 battery: **698 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)