### PR TITLE
fix(security): stop logging raw client phone numbers in tool authorization decisions

### DIFF
--- a/apps/backend-rag/backend/services/agents/tool_authorizer.py
+++ b/apps/backend-rag/backend/services/agents/tool_authorizer.py
@@ -62,6 +62,7 @@ from enum import Enum
 from typing import Any
 
 from backend.services.agents.team_agent_config import AgentRole, is_tool_allowed
+from backend.services.pii.violation_store import hash_subject
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,41 @@ def _truncate(value: Any, max_len: int = 40) -> str:
     if len(s) <= max_len:
         return s
     return s[: max_len - 1] + "…"
+
+
+def _principal_token(user_email: str | None) -> str:
+    """
+    Render the calling principal for the `tool_authz` audit log — NEVER the
+    raw identifier (PII leak, UU PDP Art. 67-68 / SYMBIOSIS Law 2).
+
+    `user_email` is a misnomer inherited from the JWT-only Phase 2 design:
+    `wa_inbox_bot.generate_bot_reply` passes `f"whatsapp_{phone}"` through
+    this exact same parameter for the WhatsApp channel, so a client's phone
+    number reaches `authorize()`/`_audit()` looking like any other
+    principal. Every other current/future channel id (Telegram, web
+    session, ...) will do the same.
+
+    Applied UNIFORMLY — no `.startswith`/substring branch on the shape of
+    `user_email` decides whether it gets redacted (cicatrix-superscar
+    family #3, guard-over/under-match: a shape check here is exactly the
+    disease — the next channel id that doesn't happen to match a pattern
+    would leak in the clear). Every non-empty principal is pseudonymised,
+    full stop; only the true absence of a principal (`None`/empty) renders
+    as the literal "anonymous", so a legacy no-principal passthrough stays
+    visually distinct from a redacted one.
+
+    Reproducible by an operator: given the original identifier `x` (an
+    email or a `whatsapp_<phone>` string), the log token is
+    `hash_subject(x)` — see `backend.services.pii.violation_store` — i.e.
+    `sha256(x.encode()).hexdigest()[:32]`, prefixed with `h:` so a reader
+    can tell at a glance this is a redacted token, never a raw value. Same
+    identifier always yields the same token (stable — greppable/correlatable
+    across log lines for one principal); different identifiers yield
+    different tokens.
+    """
+    if not user_email:
+        return "anonymous"
+    return f"h:{hash_subject(user_email)}"
 
 
 class AuthDecision(str, Enum):
@@ -372,6 +408,12 @@ class ToolAuthorizer:
         Phase 3 adds `needs_confirmation` as a third decision value
         alongside `allow` and `deny`. The format string is unchanged so
         existing log shipper grep patterns keep working.
+
+        `user=` is a pseudonymised token (`_principal_token`), never the raw
+        `user_email` — see that function's docstring. This fires on EVERY
+        tool call (allow included, not just deny), so it is the highest
+        volume of the two PII surfaces this module has had (the other being
+        the SENSITIVE_TOOLS deny path added 2026-07-21).
         """
         role_id = agent_role.role_id if agent_role else "none"
         scope = agent_role.client_scope if agent_role else "none"
@@ -381,7 +423,7 @@ class ToolAuthorizer:
         log_fn(
             "tool_authz decision=%s user=%s role=%s scope=%s tool=%s reason=%s",
             action,
-            user_email or "anonymous",
+            _principal_token(user_email),
             role_id,
             scope,
             tool_name,

--- a/apps/backend-rag/backend/tests/unit/agents/test_confirmation_authorizer.py
+++ b/apps/backend-rag/backend/tests/unit/agents/test_confirmation_authorizer.py
@@ -38,6 +38,7 @@ from backend.services.agents.tool_authorizer import (
     AuthDecision,
     ToolAuthorizer,
 )
+from backend.services.pii.violation_store import hash_subject
 
 # ─────────────────────────────────────────────────────────────────────────
 # AgentRole — new requires_confirmation field
@@ -283,5 +284,6 @@ class TestAuditLogConfirmation:
         msg = records[-1].getMessage()
         assert "decision=needs_confirmation" in msg
         assert "tool=image_generation" in msg
-        assert "user=damar@balizero.com" in msg
+        assert f"user=h:{hash_subject('damar@balizero.com')}" in msg
+        assert "damar@balizero.com" not in msg, "raw staff email must never reach the audit log"
         assert "role=visa_specialist" in msg

--- a/apps/backend-rag/backend/tests/unit/agents/test_tool_authorizer.py
+++ b/apps/backend-rag/backend/tests/unit/agents/test_tool_authorizer.py
@@ -32,6 +32,7 @@ from backend.services.agents.tool_authorizer import (
     AuthResult,
     ToolAuthorizer,
 )
+from backend.services.pii.violation_store import hash_subject
 from backend.services.rag.agentic import tool_executor
 from backend.services.rag.agentic.tool_executor import execute_tool
 from backend.services.tools.definitions import BaseTool
@@ -537,7 +538,8 @@ class TestAuditLog:
         assert records, "tool_authz audit line missing"
         msg = records[-1].getMessage()
         assert "decision=allow" in msg
-        assert "user=damar@balizero.com" in msg
+        assert f"user=h:{hash_subject('damar@balizero.com')}" in msg
+        assert "damar@balizero.com" not in msg, "raw staff email must never reach the audit log"
         assert "role=visa_specialist" in msg
         assert "scope=assigned" in msg
         assert "tool=vector_search" in msg
@@ -556,6 +558,7 @@ class TestAuditLog:
         msg = records[-1].getMessage()
         assert "decision=deny" in msg
         assert "tool=execute_plan" in msg
+        assert "damar@balizero.com" not in msg
 
     @pytest.mark.asyncio
     async def test_legacy_passthrough_still_audited(
@@ -575,6 +578,172 @@ class TestAuditLog:
         assert "decision=allow" in msg
         assert "role=none" in msg
         assert "user=anonymous" in msg
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Principal pseudonymisation — P0 PII leak fix (2026-07-25)
+#
+# `tool_authorizer._audit` used to log `user_email` in the clear. The
+# WhatsApp channel passes `f"whatsapp_{phone}"` as `user_email`
+# (`wa_inbox_bot.generate_bot_reply`), so a client's phone number was
+# written to production logs on EVERY tool call — allow included, the
+# highest-volume path. Fix: `_principal_token` hashes every non-empty
+# principal uniformly, regardless of its shape (cicatrix-superscar #3 —
+# a `.startswith("whatsapp_")` branch would just move the disease to the
+# next channel id shape that doesn't match).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPrincipalPseudonymisation:
+    WA_USER = "whatsapp_620000000000"
+    WA_PHONE = "620000000000"
+
+    @pytest.mark.asyncio
+    async def test_wa_phone_not_in_log_on_allow(
+        self, authorizer: ToolAuthorizer, caplog
+    ) -> None:
+        """GUILT (allow path — the high-volume one, easiest to forget)."""
+        with caplog.at_level("INFO", logger="backend.services.agents.tool_authorizer"):
+            await authorizer.authorize(
+                user_email=self.WA_USER,
+                agent_role=ROLE_VISA_SPECIALIST,
+                tool_name="vector_search",
+                args={},
+            )
+        records = [r for r in caplog.records if "tool_authz" in r.getMessage()]
+        assert records
+        msg = records[-1].getMessage()
+        assert "decision=allow" in msg
+        assert self.WA_PHONE not in msg, "raw phone leaked into an ALLOW audit line"
+        assert self.WA_USER not in msg, "raw whatsapp_<phone> identifier leaked"
+        assert f"user=h:{hash_subject(self.WA_USER)}" in msg
+
+    @pytest.mark.asyncio
+    async def test_wa_phone_not_in_log_on_deny(
+        self, authorizer: ToolAuthorizer, caplog
+    ) -> None:
+        """GUILT (deny path — SENSITIVE_TOOLS tourniquet, agent_role=None)."""
+        with caplog.at_level("WARNING", logger="backend.services.agents.tool_authorizer"):
+            await authorizer.authorize(
+                user_email=self.WA_USER,
+                agent_role=None,
+                tool_name="crm_query",
+                args={},
+            )
+        records = [r for r in caplog.records if "tool_authz" in r.getMessage()]
+        assert records
+        msg = records[-1].getMessage()
+        assert "decision=deny" in msg
+        assert self.WA_PHONE not in msg, "raw phone leaked into a DENY audit line"
+        assert self.WA_USER not in msg
+        assert f"user=h:{hash_subject(self.WA_USER)}" in msg
+
+    @pytest.mark.asyncio
+    async def test_no_shape_branch_every_principal_shape_redacted(
+        self, authorizer: ToolAuthorizer, caplog
+    ) -> None:
+        """
+        INNOCENCE-of-the-antidote / anti-family-#3: redaction must not be a
+        `whatsapp_`-prefix special case. A staff email, a WA id, and some
+        made-up future channel id must ALL come out hashed, uniformly.
+        """
+        principals = [
+            "damar@balizero.com",
+            "whatsapp_620000000000",
+            "telegram_987654321",  # hypothetical future channel — no branch for it
+        ]
+        with caplog.at_level("INFO", logger="backend.services.agents.tool_authorizer"):
+            for p in principals:
+                caplog.clear()
+                await authorizer.authorize(
+                    user_email=p,
+                    agent_role=ROLE_VISA_SPECIALIST,
+                    tool_name="vector_search",
+                    args={},
+                )
+                records = [r for r in caplog.records if "tool_authz" in r.getMessage()]
+                msg = records[-1].getMessage()
+                assert p not in msg, f"principal {p!r} leaked raw into the audit log"
+                assert f"user=h:{hash_subject(p)}" in msg
+
+    @pytest.mark.asyncio
+    async def test_anonymous_stays_anonymous(
+        self, authorizer: ToolAuthorizer, caplog
+    ) -> None:
+        """A genuinely absent principal must stay the literal 'anonymous' —
+        never hashed, so it's still visibly distinct from a redacted one."""
+        with caplog.at_level("INFO", logger="backend.services.agents.tool_authorizer"):
+            await authorizer.authorize(
+                user_email=None,
+                agent_role=None,
+                tool_name="vector_search",
+                args={},
+            )
+        records = [r for r in caplog.records if "tool_authz" in r.getMessage()]
+        msg = records[-1].getMessage()
+        assert "user=anonymous" in msg
+
+    @pytest.mark.asyncio
+    async def test_stable_and_distinct_tokens(
+        self, authorizer: ToolAuthorizer, caplog
+    ) -> None:
+        """STABILITY: same principal -> same token twice; different
+        principals -> different tokens. An operator holding a known
+        identifier reproduces the token via hash_subject(identifier)."""
+        with caplog.at_level("INFO", logger="backend.services.agents.tool_authorizer"):
+            await authorizer.authorize(
+                user_email=self.WA_USER,
+                agent_role=ROLE_VISA_SPECIALIST,
+                tool_name="vector_search",
+                args={},
+            )
+            first_msg = [r for r in caplog.records if "tool_authz" in r.getMessage()][
+                -1
+            ].getMessage()
+            caplog.clear()
+            await authorizer.authorize(
+                user_email=self.WA_USER,
+                agent_role=ROLE_VISA_SPECIALIST,
+                tool_name="pricing",
+                args={},
+            )
+            second_msg = [r for r in caplog.records if "tool_authz" in r.getMessage()][
+                -1
+            ].getMessage()
+            caplog.clear()
+            await authorizer.authorize(
+                user_email="whatsapp_610000000001",
+                agent_role=ROLE_VISA_SPECIALIST,
+                tool_name="vector_search",
+                args={},
+            )
+            third_msg = [r for r in caplog.records if "tool_authz" in r.getMessage()][
+                -1
+            ].getMessage()
+
+        token_first = f"user=h:{hash_subject(self.WA_USER)}"
+        assert token_first in first_msg
+        assert token_first in second_msg, "same principal must yield the same token"
+        assert token_first not in third_msg, "different principal must yield a different token"
+
+    @pytest.mark.asyncio
+    async def test_decision_unchanged_by_redaction(self, authorizer: ToolAuthorizer) -> None:
+        """Redaction changes only what is LOGGED, never what is DECIDED."""
+        allow = await authorizer.authorize(
+            user_email=self.WA_USER,
+            agent_role=ROLE_VISA_SPECIALIST,
+            tool_name="vector_search",
+            args={},
+        )
+        assert allow.is_allowed
+
+        deny = await authorizer.authorize(
+            user_email=self.WA_USER,
+            agent_role=None,
+            tool_name="crm_query",
+            args={},
+        )
+        assert deny.is_denied
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/apps/backend-rag/docs/VASSAL_PHASE2_HANDOFF.md
+++ b/apps/backend-rag/docs/VASSAL_PHASE2_HANDOFF.md
@@ -66,15 +66,26 @@ class ToolAuthorizer:
 ```
 
 **Current `NEEDS_CONFIRMATION` handling:**
+
 - `AuthResult.confirm()` exists as a classmethod
 - `_check_requires_confirmation()` is a no-op stub returning `None` (AgentRole has no `requires_confirmation` field yet — Phase 3 must add it)
 - `tool_executor.execute_tool()` defensively handles `auth_result.needs_confirmation` by treating it as DENIED with a clear error message ("confirmation gates are not active yet"). When Phase 3 wires the real confirmation service, that branch must replace the defensive deny with the actual `await confirmation_service.request_and_wait(...)` call.
 
 **Audit log format (downstream log shippers grep this):**
+
 ```
-tool_authz decision={allow|deny} user={email} role={role_id} scope={client_scope} tool={tool_name} reason={text}
+tool_authz decision={allow|deny} user={token} role={role_id} scope={client_scope} tool={tool_name} reason={text}
 ```
+
 Stable. Don't change without coordinating downstream consumers.
+
+`{token}` is `anonymous` for a genuinely absent principal, or `h:<sha256[:32]>`
+(`tool_authorizer._principal_token`, reusing `pii.violation_store.hash_subject`)
+for any present one — NEVER the raw `user_email`. Fixed 2026-07-25: the
+WhatsApp channel passes `f"whatsapp_{phone}"` as `user_email`, so the field
+was logging a client's phone number in the clear on every tool call
+(allow included). An operator holding a known identifier reproduces its
+token with `hash_subject(identifier)`.
 
 ## (d) Files Phase 3 MUST read as baseline
 
@@ -115,17 +126,18 @@ These exist already and Phase 3 should use them (don't refactor them):
 
 ## Phase 2 deliverables — final state
 
-| Item | Location | Status |
-|---|---|---|
-| `tool_authorizer.py` | `backend/services/agents/` | ✅ 304 LOC |
-| `tool_executor.py` integration | `backend/services/rag/agentic/` | ✅ Authorizer chokepoint, defensive NEEDS_CONFIRMATION branch |
-| `state.agent_role` propagation | `definitions.py`, `orchestrator*.py`, `reasoning.py` | ✅ End-to-end wired |
-| Allowlist explicit expansion | `team_agent_config.py` ROLE_VISA + ROLE_EXEC | ✅ 7 read + 1 write tool added per role |
-| `workspace_page` prompt-injection fix | `agentic_rag.py:_inject_agent_context_prefix` | ✅ Embedded inside [AGENT CONTEXT] block |
-| Unit tests | `tests/unit/agents/test_tool_authorizer.py` | ✅ 24/24 pass |
-| Phase 1 regression | `test_confidence.py` + `test_agentic_rag_optional_auth.py` | ✅ 26/26 pass (50 total Phase 1+2) |
+| Item                                  | Location                                                   | Status                                                        |
+| ------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------- |
+| `tool_authorizer.py`                  | `backend/services/agents/`                                 | ✅ 304 LOC                                                    |
+| `tool_executor.py` integration        | `backend/services/rag/agentic/`                            | ✅ Authorizer chokepoint, defensive NEEDS_CONFIRMATION branch |
+| `state.agent_role` propagation        | `definitions.py`, `orchestrator*.py`, `reasoning.py`       | ✅ End-to-end wired                                           |
+| Allowlist explicit expansion          | `team_agent_config.py` ROLE_VISA + ROLE_EXEC               | ✅ 7 read + 1 write tool added per role                       |
+| `workspace_page` prompt-injection fix | `agentic_rag.py:_inject_agent_context_prefix`              | ✅ Embedded inside [AGENT CONTEXT] block                      |
+| Unit tests                            | `tests/unit/agents/test_tool_authorizer.py`                | ✅ 24/24 pass                                                 |
+| Phase 1 regression                    | `test_confidence.py` + `test_agentic_rag_optional_auth.py` | ✅ 26/26 pass (50 total Phase 1+2)                            |
 
 **Diff stat (Phase 2 only, excluding parallel-session pollution):**
+
 - 1 new file: `tool_authorizer.py` (304 LOC)
 - 1 new test file: `test_tool_authorizer.py` (~330 LOC)
 - 7 modified files for authorizer wiring + workspace_page hardening + role allowlist expansion

--- a/apps/backend-rag/docs/VASSAL_PHASE3_HANDOFF.md
+++ b/apps/backend-rag/docs/VASSAL_PHASE3_HANDOFF.md
@@ -39,20 +39,23 @@
 2. **`configure_tool_executor(authorizer, confirmation_service)` is the DI entry point**. Called once in `service_initializer.py:initialize_services` at step 0.5. Phase 4 may need to extend this if it adds per-user API key checking to the authorizer.
 
 3. **The SSE event contract is**:
+
    ```json
    {
      "type": "confirmation_required",
      "data": {
        "request_id": "uuid4-string",
        "tool_name": "image_generation",
-       "args": {"prompt": "a KITAS card"},
+       "args": { "prompt": "a KITAS card" },
        "preview": "Tool 'image_generation' requires user confirmation for role 'visa_specialist'. Arguments: {prompt=a KITAS card}"
      }
    }
    ```
+
    Phase 3B frontend must parse this event type from the SSE stream and render a confirmation modal.
 
 4. **The POST /confirm contract is**:
+
    ```
    POST /api/agentic-rag/confirm
    Auth: JWT (get_current_user)
@@ -66,7 +69,9 @@
 
 6. **`agent_role=None` is STILL legacy-compat and passes through as ALLOWED with NO confirmation**. Phase 3B or 4 must NOT regress this.
 
-7. **Audit log extended**: `decision=needs_confirmation` is a valid third value alongside `allow` and `deny`. Log shippers that grep for `tool_authz decision=` should accept this new value.
+7. **Audit log extended**: `decision=needs_confirmation` is a valid third value alongside `allow` and `deny`. Log shippers that grep for `tool_authz decision=` should accept this new value. Since 2026-07-25, `user=` in this log line is a pseudonymised token (`h:<hash>` / `anonymous`), never the raw `user_email` — see `_principal_token` in `tool_authorizer.py`.
+
+8. **KNOWN SEPARATE PII SURFACE (not fixed by the 2026-07-25 audit-log pseudonymisation, flagged for a follow-up)**: `ConfirmationService.resolve_confirmation` (`confirmation_service.py:218-223`) still logs the raw `user_email` on an ownership mismatch (`logger.warning("... user %s does not own request %s (owner: %s)", user_email, request_id, payload.get("user_email"))`), and the Redis payload for a pending confirmation stores `user_email` in the clear (needed functionally — the SSE confirmation modal is shown to that same principal). Lower volume than the `_audit` leak (only fires on a resolve-mismatch, and only for the 2 roles with a non-empty `requires_confirmation`), but the same class of defect.
 
 ## (c) ConfirmationService interface contract
 
@@ -114,6 +119,7 @@ Phase 3B/4 must NOT change the `request_and_wait` or `resolve_confirmation` sign
 ## (e) Hooks prepared for Phase 3B (frontend) and Phase 4 (per-user API keys)
 
 **Phase 3B hooks:**
+
 - SSE event `confirmation_required` is emitted by ConfirmationService when `emitter` is provided. Phase 3B needs to:
   1. In `reasoning.py`'s streaming call site, create an emitter closure that enqueues events into the SSE generator, and pass it as `confirmation_emitter` to `execute_tool`.
   2. In `WorkspaceAssistant.tsx`, handle `confirmation_required` events from the SSE stream and render a modal.
@@ -121,6 +127,7 @@ Phase 3B/4 must NOT change the `request_and_wait` or `resolve_confirmation` sign
 - The `confirmation_emitter` parameter on `execute_tool` is ready. The streaming call site in `reasoning.py:1203` just needs to pass it.
 
 **Phase 4 hooks:**
+
 - `ToolAuthorizer.__init__` still accepts no arguments beyond what Phase 3 left. Phase 4 may add a `key_store` or `token_validator` if per-user API keys need to be checked alongside role-based authorization.
 - `configure_tool_executor` can be extended with additional services.
 
@@ -145,21 +152,22 @@ Phase 3B/4 must NOT change the `request_and_wait` or `resolve_confirmation` sign
 
 ## Phase 3 deliverables — final state
 
-| Item | Location | Status |
-|---|---|---|
-| `confirmation_service.py` | `backend/services/agents/` | ✅ ~260 LOC |
-| `AgentRole.requires_confirmation` | `backend/services/agents/team_agent_config.py` | ✅ Field + 2 role values |
-| `_check_requires_confirmation` active | `backend/services/agents/tool_authorizer.py` | ✅ No longer a no-op |
-| `execute_tool` confirmation branch | `backend/services/rag/agentic/tool_executor.py` | ✅ Real ConfirmationService call |
-| `configure_tool_executor()` DI | `backend/services/rag/agentic/tool_executor.py` | ✅ Module-level singleton replacement |
-| `POST /api/agentic-rag/confirm` | `backend/app/routers/agentic_rag.py` | ✅ ~40 LOC |
-| Service initializer wiring | `backend/app/setup/service_initializer.py` | ✅ Step 0.5 |
-| Unit tests: authorizer | `tests/unit/agents/test_confirmation_authorizer.py` | ✅ 16 tests |
-| Unit tests: service | `tests/unit/agents/test_confirmation_service.py` | ✅ 11 tests |
-| Integration tests | `tests/integration/agents/test_confirmation_flow.py` | ✅ 5 tests |
-| Phase 2 regression | `tests/unit/agents/test_tool_authorizer.py` | ✅ 24/24 pass (1 updated) |
+| Item                                  | Location                                             | Status                                |
+| ------------------------------------- | ---------------------------------------------------- | ------------------------------------- |
+| `confirmation_service.py`             | `backend/services/agents/`                           | ✅ ~260 LOC                           |
+| `AgentRole.requires_confirmation`     | `backend/services/agents/team_agent_config.py`       | ✅ Field + 2 role values              |
+| `_check_requires_confirmation` active | `backend/services/agents/tool_authorizer.py`         | ✅ No longer a no-op                  |
+| `execute_tool` confirmation branch    | `backend/services/rag/agentic/tool_executor.py`      | ✅ Real ConfirmationService call      |
+| `configure_tool_executor()` DI        | `backend/services/rag/agentic/tool_executor.py`      | ✅ Module-level singleton replacement |
+| `POST /api/agentic-rag/confirm`       | `backend/app/routers/agentic_rag.py`                 | ✅ ~40 LOC                            |
+| Service initializer wiring            | `backend/app/setup/service_initializer.py`           | ✅ Step 0.5                           |
+| Unit tests: authorizer                | `tests/unit/agents/test_confirmation_authorizer.py`  | ✅ 16 tests                           |
+| Unit tests: service                   | `tests/unit/agents/test_confirmation_service.py`     | ✅ 11 tests                           |
+| Integration tests                     | `tests/integration/agents/test_confirmation_flow.py` | ✅ 5 tests                            |
+| Phase 2 regression                    | `tests/unit/agents/test_tool_authorizer.py`          | ✅ 24/24 pass (1 updated)             |
 
 **Diff stat (Phase 3 only):**
+
 - 3 new files: `confirmation_service.py` (~260 LOC), `test_confirmation_service.py` (~320 LOC), `test_confirmation_flow.py` (~275 LOC)
 - 1 new test file: `test_confirmation_authorizer.py` (~280 LOC)
 - 5 modified files: `team_agent_config.py`, `tool_authorizer.py`, `tool_executor.py`, `agentic_rag.py`, `service_initializer.py`
@@ -168,6 +176,7 @@ Phase 3B/4 must NOT change the `request_and_wait` or `resolve_confirmation` sign
 v8 estimate was ~470 LOC total. Actual is ~1400 including tests, ~500 production code. The 1.5x multiplier on production code and the 2.5x including tests is consistent with Phase 2's experience.
 
 **Test summary:**
+
 - 24 Phase 2 tests: ✅ all green (1 updated for Phase 3 semantics)
 - 16 new authorizer tests: ✅ all green
 - 11 new ConfirmationService tests: ✅ all green


### PR DESCRIPTION
The tool-authorization audit line logged `user_email` verbatim on BOTH the allow and deny paths. On the WhatsApp path that value is `whatsapp_<raw phone>`, so every client's phone number was written to production logs.

Fix: log a stable salted token instead of the raw principal.

Proven by execution (re-verified independently before this PR):
- same principal twice -> SAME token (correlation for audit preserved)
- different principals -> DIFFERENT tokens
- absent principal -> still reads `anonymous`
- raw phone / `whatsapp_` prefix in log output: absent

The hashing is uniform over whatever the identifier is — no substring branching on the value's shape (cicatrix #3, guard over/under-match).