### PR TITLE
feat(mouth): rescue 3 orphaned tax article translation pairs

### DIFF
--- a/apps/mouth/src/content/articles/tax/coretax-spt-tahunan-2025-panduan-bali-zero.id.mdx
+++ b/apps/mouth/src/content/articles/tax/coretax-spt-tahunan-2025-panduan-bali-zero.id.mdx
@@ -1,0 +1,354 @@
+---
+title: "CoreTax DJP 2025: Panduan SPT Tahunan untuk Klien Bali Zero"
+slug: "coretax-spt-tahunan-2025-panduan-bali-zero"
+description: "Panduan praktis SPT Tahunan 2025 via CoreTax untuk PT PMA dan profesional klien Bali Zero. Deadline, langkah pengisian, error umum, dan cara Bali Zero handle proses dari awal sampai submit."
+excerpt: "CoreTax adalah satu-satunya sistem untuk SPT Tahunan 2025. Ini panduan dari Bali Zero: siapa yang wajib, apa yang berbeda dari sistem lama, error apa yang paling sering terjadi — dan bagaimana kami handle prosesnya untuk Anda."
+category: "tax"
+tags:
+  - CoreTax
+  - SPT Tahunan
+  - DJP Online
+  - e-filing pajak
+  - PT PMA pajak
+  - PPh Badan
+  - sertifikat elektronik
+  - SPT 2025
+publishedAt: "2026-07-22"
+updatedAt: "2026-07-22"
+author:
+  name: "Subhi Darajat"
+  avatar: "/static/team/subhi.jpg"
+  role: "Tax & Compliance Analyst"
+featured: false
+adversarial_review: "surya"
+readingTime: 14
+difficulty: "intermediate"
+aiGenerated: false
+tableOfContents: true
+relatedArticles:
+  - "coretax-vs-djp-online-what-changed"
+  - "coretax-login-errors-fixes-2026"
+  - "coretax-npwp16-vs-npwp15-foreigners"
+  - "tax-compliance-checklist-pt-pma"
+  - "tax-calendar-indonesia"
+seoTitle: "CoreTax SPT Tahunan 2025: Panduan Lengkap untuk PT PMA & Profesional"
+seoDescription: "Deadline SPT Badan 2025 sudah lewat? Panduan CoreTax untuk PT PMA dan klien Bali Zero: langkah-langkah, error umum, dan cara kami handle prosesnya untuk Anda."
+faq:
+  - question: "Apa deadline SPT Tahunan 2025 untuk PT PMA?"
+    answer: "SPT Tahunan Badan untuk tahun pajak 2025 memiliki deadline 30 April 2026. DJP memberikan relaksasi perpanjangan hingga 31 Mei 2026 tanpa sanksi administrasi, karena penerapan CoreTax yang masih dalam masa adaptasi. Setelah 31 Mei 2026, denda keterlambatan IDR 1.000.000 berlaku."
+  - question: "Apakah semua PT PMA wajib pakai CoreTax untuk SPT 2025?"
+    answer: "Ya. Mulai tahun pajak 2025 (dilaporkan 2026), seluruh Wajib Pajak Badan termasuk PT PMA diwajibkan menggunakan sistem CoreTax di coretaxdjp.pajak.go.id untuk pelaporan SPT Tahunan. DJP Online tidak lagi menerima SPT Tahunan baru."
+  - question: "Kenapa SPT Tahunan Badan di CoreTax sering error 'Operasi Gagal'?"
+    answer: "Error 'Operasi Gagal' saat menyimpan data SPT Badan di CoreTax paling sering disebabkan oleh Lampiran L6 (Angsuran PPh Pasal 25) yang tidak terisi lengkap. Periksa kembali bagian ini meskipun perusahaan Anda tidak wajib angsuran — kolom perlu diisi atau disesuaikan agar sistem dapat memproses."
+aiOptimization:
+  primaryQuestion: "Bagaimana cara melaporkan SPT Tahunan 2025 via CoreTax DJP untuk PT PMA?"
+  answerSnippet: "Login ke coretaxdjp.pajak.go.id menggunakan NPWP 16 digit (tambahkan '0' di depan NPWP 15 digit lama). Masuk ke menu SPT > Buat Konsep SPT > pilih PPh Badan tahun pajak 2025. Isi mulai dari induk, lampiran keuangan, rekonsiliasi fiskal, dan lampiran-lampiran. Tandatangani dengan sertifikat elektronik + passphrase. Deadline: 30 April 2026 (relaksasi s/d 31 Mei 2026). Denda keterlambatan: IDR 1.000.000."
+  entityMentions:
+    - type: "GovernmentOrganization"
+      name: "Direktorat Jenderal Pajak (DJP)"
+    - type: "SoftwareApplication"
+      name: "CoreTax DJP"
+      sameAs: "https://coretaxdjp.pajak.go.id"
+contentStructure:
+  hasHowTo: true
+  hasFAQ: true
+  hasTable: true
+canonicalUrl: "https://balizero.com/tax/coretax-spt-tahunan-2025-panduan-bali-zero"
+ogType: "article"
+twitterCard: "summary_large_image"
+locale: "id"
+---
+import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
+import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+import {
+  KeyTakeaway,
+  InfoCard,
+  AskZantara,
+} from "@/components/blog/interactive";
+
+# CoreTax DJP 2025: Panduan SPT Tahunan untuk Klien Bali Zero
+
+<KeyTakeaway>
+  **TL;DR:** SPT Tahunan 2025 wajib melalui CoreTax (coretaxdjp.pajak.go.id).
+  Deadline SPT Badan: 30 April 2026, relaksasi s/d **31 Mei 2026** tanpa denda.
+  Login: NPWP 16 digit + password + passphrase sertifikat elektronik. Error
+  paling umum: Lampiran L6 kosong, sertifikat tidak valid, data tidak sinkron
+  dengan e-Bupot. Bali Zero handle proses dari persiapan dokumen sampai submit —
+  klien hanya perlu approve dan tanda tangan digital.
+</KeyTakeaway>
+
+<HeaderWhatsAppCTA />
+
+---
+
+## CoreTax: Bukan Pilihan, Tapi Kewajiban
+
+Sejak 2025, **DJP Online resmi tidak lagi menerima SPT Tahunan baru**. Seluruh pelaporan — termasuk SPT PPh Badan (Form 1771) untuk PT PMA — wajib dilakukan melalui sistem CoreTax Administration System (Sistem Inti Administrasi Perpajakan) di **coretaxdjp.pajak.go.id**.
+
+Ini bukan sekadar pergantian tampilan website. CoreTax adalah infrastruktur perpajakan baru yang mengintegrasikan e-Filing, e-Faktur, e-Bupot, e-Billing, dan manajemen sertifikat elektronik ke dalam satu platform. Prosesnya berbeda secara fundamental dari DJP Online, dan kurva belajarnya — terutama untuk asing yang baru kenal sistem perpajakan Indonesia — curam.
+
+Panduan ini dibuat khusus untuk klien Bali Zero: foreign founders, PT PMA, dan profesional yang perlu memahami apa yang terjadi di balik layar ketika kami mengelola SPT mereka.
+
+---
+
+## Siapa yang Wajib Lapor via CoreTax?
+
+### Wajib Pajak Badan (PT PMA)
+
+Setiap PT PMA yang:
+
+- Terdaftar sebagai Wajib Pajak Badan di Indonesia
+- Aktif selama tahun pajak 2025, bahkan jika belum ada pendapatan
+- Memiliki NPWP aktif (termasuk yang statusnya Non-Efektif — perlu konfirmasi ke KPP)
+
+**Form yang digunakan: SPT 1771**
+
+### Wajib Pajak Orang Pribadi (Praktisi, Konsultan)
+
+Klien individu — pengacara, konsultan, freelancer asing dengan NPWP — juga wajib CoreTax untuk SPT Tahunan Pribadi (Form 1770 atau 1770S).
+
+<InfoCard variant="note" title="Tentang Pengelompokan PNP dan PK">
+
+Brief internal Bali Zero menyebut "PNP" (Pengusaha Non-PKP) dan "PK"
+(Pengusaha Kena Pajak). Dari perspektif SPT Tahunan, pembedaan yang lebih
+relevan adalah Wajib Pajak Badan (Form 1771) vs. Wajib Pajak Orang Pribadi
+(Form 1770/1770S). PKP status memengaruhi kewajiban PPN, bukan kewajiban SPT
+Tahunan PPh. **[PERLU VALIDASI SURYA]: konfirmasi apakah pengelompokan PNP/PK
+yang dimaksud dalam brief merujuk ke konteks berbeda di internal Bali Zero.**
+
+</InfoCard>
+
+---
+
+## Deadline SPT Tahunan 2025 — Angka yang Penting
+
+| Jenis WP                   | Form                  | Deadline Normal                  | Relaksasi 2026        | Denda Terlambat |
+| -------------------------- | --------------------- | -------------------------------- | --------------------- | --------------- |
+| **Orang Pribadi**          | 1770 / 1770S / 1770SS | 31 Maret 2026                    | _tidak ada relaksasi_ | IDR 100.000     |
+| **Badan (PT PMA)**         | 1771                  | 30 April 2026                    | **31 Mei 2026**       | IDR 1.000.000   |
+| **Badan (periode khusus)** | 1771                  | 4 bulan setelah akhir tahun buku | _sesuai periode_      | IDR 1.000.000   |
+
+<InfoCard variant="warning" title="Relaksasi Badan Hanya Sampai 31 Mei 2026">
+
+DJP melalui pengumuman resmi memberikan relaksasi perpanjangan pelaporan SPT
+Tahunan Badan tahun pajak 2025 dari 30 April ke **31 Mei 2026**, tanpa
+pengenaan sanksi administrasi IDR 1.000.000. Relaksasi ini diberikan karena
+proses adaptasi sistem CoreTax yang masih berjalan. **Setelah 31 Mei 2026,
+sanksi berlaku penuh.** Sumber: pengumuman resmi pajak.go.id dan Kemenkeu.
+
+</InfoCard>
+
+Keterlambatan SPT Tahunan bukan hanya soal denda. Konsekuensi praktis yang sering diabaikan:
+
+- Proses perpanjangan KITAS/ITAS yang memerlukan bukti kepatuhan pajak akan terhambat
+- Aplikasi kredit bank atau tender pemerintah memerlukan Surat Keterangan Fiskal yang hanya keluar jika SPT sudah dilaporkan
+- DJP dapat menerbitkan SP2DK (Surat Permintaan Penjelasan atas Data dan Keterangan) yang membuka potensi pemeriksaan
+
+---
+
+## Fitur CoreTax 2025 yang Relevan untuk SPT Badan
+
+### 1. Pengisian Online Terintegrasi
+
+Berbeda dengan DJP Online yang menerima upload file CSV/XML, CoreTax mengharuskan pengisian langsung di sistem. Form 1771 diisi secara terstruktur:
+
+- **Induk SPT**: Identitas WP, jenis usaha, ringkasan keuangan
+- **Lampiran I**: Penghasilan neto komersial
+- **Lampiran II**: Harga Pokok Penjualan (HPP)
+- **Lampiran III**: Kredit pajak (PPh 22, 23, 24, 25)
+- **Lampiran IV**: PPh Final dan penghasilan bukan objek pajak
+- **Lampiran V**: Daftar pemegang saham dan penyertaan modal
+- **Lampiran VI**: Angsuran PPh 25 _(ini yang sering jadi sumber error)_
+- **Rekonsiliasi Fiskal**: Koreksi antara laba komersial dan laba fiskal
+
+### 2. Validasi Real-Time
+
+CoreTax memvalidasi data saat diisi, bukan setelah submit. Ini berarti:
+
+- Angka yang tidak seimbang (aset ≠ liabilitas + ekuitas) akan langsung ditolak
+- NPWP pihak ketiga yang tidak valid langsung terflag
+- Duplikasi e-Bupot terdeteksi sebelum masuk ke SPT
+
+### 3. Cross-Referencing Otomatis dengan e-Bupot
+
+CoreTax secara otomatis mencocokkan Bukti Potong yang diterima klien dengan SPT yang dilaporkan. Artinya:
+
+- Jika ada klien Anda yang memotong PPh 23 atas jasa yang dibayarkan ke PT Anda, data itu sudah ada di CoreTax sebelum Anda mengisinya
+- Ketidaksesuaian (mismatch) antara bukti potong yang diterima dan kredit pajak yang diklaim akan dideteksi secara otomatis
+
+### 4. Tanda Tangan Digital dengan Passphrase
+
+Semua submission di CoreTax memerlukan **sertifikat elektronik** yang dikeluarkan DJP, dilengkapi dengan **passphrase** — bukan sekadar password login biasa. Ini adalah lapisan keamanan untuk tanda tangan digital pada dokumen resmi.
+
+Dalam praktiknya, konsultan pajak bersertifikat seperti Bali Zero beroperasi menggunakan akun direktur sebagai Person in Charge (PIC) PT — tidak diperlukan surat kuasa bermeterai terpisah untuk akses operasional harian di CoreTax.
+
+---
+
+## Error Paling Umum dan Cara Mengatasinya
+
+Berdasarkan pengalaman proses SPT klien Bali Zero dan laporan publik dari para akuntan, berikut error yang paling sering muncul:
+
+### Error 1: "Operasi Gagal" saat Simpan SPT
+
+**Penyebab utama:** Lampiran L6 (Angsuran PPh Pasal 25) tidak terisi lengkap, meskipun perusahaan tidak wajib angsuran.
+
+**Solusi:**
+
+1. Akses Lampiran L6 secara langsung dari menu form
+2. Verifikasi apakah ada field yang masih kosong atau bernilai nol tanpa konfirmasi
+3. Jika perusahaan tidak wajib angsuran PPh 25 (karena baru berdiri atau penghasilan neto fiskal nol), pastikan field diisi "0" bukan dikosongkan
+
+### Error 2: Server Error 500/501/401
+
+**Penyebab:** Traffic tinggi (periode deadline), cache browser, atau session timeout.
+
+**Solusi:**
+
+1. Bersihkan cache dan cookies browser sepenuhnya
+2. Gunakan mode Incognito/Private Window
+3. Coba browser berbeda (Chrome direkomendasikan DJP)
+4. Akses di luar jam sibuk: sebelum pukul 08.00 WIB atau setelah pukul 20.00 WIB
+5. Simpan draft secara berkala — CoreTax menyediakan fitur "Simpan Konsep" yang sebaiknya digunakan setiap 10-15 menit
+
+Satu hal yang perlu dipahami dengan tegas: DJP tidak menyediakan tanda terima pelaporan manual sebagai pengganti submission CoreTax jika server mengalami gangguan di hari tenggat. Tidak ada mekanisme backup resmi yang menjamin keabsahan laporan yang gagal terkirim akibat downtime. Oleh karena itu, praktik terbaik yang konsisten diterapkan konsultan pajak berpengalaman adalah menyelesaikan dan mengajukan SPT jauh sebelum batas waktu — minimal tiga hingga lima hari kerja sebelum tanggal tenggat.
+
+### Error 3: Sertifikat Elektronik Tidak Valid / Passphrase Ditolak
+
+**Penyebab:** Sertifikat kedaluwarsa, passphrase lupa, atau sertifikat belum divalidasi setelah reset.
+
+**Solusi:**
+
+1. Akses: _Portal Saya > Profil Saya > Nomor Identifikasi Eksternal > Digital Certificate_
+2. Klik **"Periksa Status"** — pastikan status "Valid"
+3. Jika kedaluwarsa atau invalid: minta pembaruan melalui _Portal Saya > Permintaan Kode Otorisasi/Sertifikat Elektronik_
+4. Setelah reset passphrase, validasi ulang status sebelum submit SPT
+
+**Catatan Sertel/EFIN:** Berdasarkan konfirmasi DJP, prosedur ini tidak dapat dikuasakan kepada pihak ketiga mana pun di seluruh KPP Indonesia. Hanya salah satu pemegang saham (shareholder) perusahaan yang dapat hadir langsung untuk mengajukan permohonan.
+
+Passphrase berbeda dari password login. Passphrase digunakan khusus untuk tanda tangan dokumen dan harus memenuhi syarat: minimal 8 karakter, mengandung huruf kapital, huruf kecil, angka, dan karakter khusus.
+
+### Error 4: Data Tidak Sinkron dengan E-Bupot
+
+**Penyebab:** Bukti potong yang diterima dari klien belum masuk ke sistem, atau ada perbedaan data antara yang Anda klaim dan yang tercatat di DJP.
+
+**Solusi:**
+
+1. Minta konfirmasi dari pihak yang menerbitkan Bukti Potong bahwa mereka sudah submit ke DJP via CoreTax
+2. Periksa menu _e-Bupot Masuk_ di CoreTax — semua bukti potong yang masuk ke NPWP Anda seharusnya terdaftar di sini
+3. Jika ada mismatch antara nilai, hubungi penerbit bukti potong untuk pembetulan
+
+### Error 5: Periode SPT Tidak Muncul
+
+**Penyebab:** Bukan bug, melainkan konflik antara periode pembukuan yang terdaftar di profil CoreTax dengan yang sebenarnya digunakan.
+
+**Solusi:** Cek _Portal Saya > Profil Saya > Informasi Umum_. Pastikan periode pembukuan yang tercatat di sistem sesuai dengan tahun buku perusahaan (Januari-Desember, atau periode khusus jika ada).
+
+---
+
+## Dokumen yang Perlu Disiapkan Sebelum Mengisi SPT 1771
+
+Untuk PT PMA, dokumen-dokumen ini perlu tersedia sebelum mulai mengisi:
+
+| Dokumen                                | Keterangan                                 |
+| -------------------------------------- | ------------------------------------------ |
+| **Laporan Keuangan** (P&L + Neraca)    | Per 31 Desember 2025, dalam Rupiah         |
+| **Rekonsiliasi Fiskal**                | Koreksi beda tetap dan beda waktu          |
+| **Bukti Potong yang Diterima**         | PPh 22, 23, 24 dari pihak ketiga           |
+| **Slip Setoran PPh 25**                | Semua bukti cicilan bulanan sepanjang 2025 |
+| **Daftar Penyusutan Fiskal**           | Per metode fiskal, bukan komersial         |
+| **Data Pemegang Saham**                | Nama, NPWP/NIK, persentase kepemilikan     |
+| **Sertifikat Elektronik + Passphrase** | Untuk tanda tangan digital submission      |
+| **Bukti Bagi Hasil / Dividen**         | Jika ada distribusi ke pemegang saham 2025 |
+
+<InfoCard variant="note" title="Laporan Keuangan Audit: Wajib atau Tidak?">
+
+PT PMA dengan omzet di atas IDR 50 miliar wajib melampirkan laporan keuangan
+yang telah diaudit oleh Akuntan Publik terdaftar. Di bawah IDR 50 miliar,
+laporan keuangan internal sudah cukup sebagai lampiran SPT — meskipun tetap
+disarankan untuk memiliki laporan yang dipersiapkan secara profesional untuk
+menghindari koreksi fiskal yang signifikan.
+
+</InfoCard>
+
+---
+
+## Timeline SPT Badan: Dari Persiapan ke Submit
+
+Untuk klien Bali Zero, ini timeline kerja yang kami ikuti:
+
+| Tahap                      | Kegiatan                                                            | Siapa                           |
+| -------------------------- | ------------------------------------------------------------------- | ------------------------------- |
+| **Februari – Maret**       | Pengumpulan dokumen, rekonsiliasi bank, finalisasi laporan keuangan | Klien → Bali Zero               |
+| **April**                  | Rekonsiliasi fiskal, kalkulasi PPh Badan terutang, review e-Bupot   | Bali Zero                       |
+| **Pertengahan April**      | Draft SPT dikirim ke klien untuk review dan persetujuan             | Bali Zero → Klien               |
+| **Akhir April / Awal Mei** | Input ke CoreTax, validasi sistem, resolve errors                   | Bali Zero                       |
+| **Sebelum 31 Mei**         | Pengiriman passphrase sertifikat dari klien → Submit final          | Klien approve, Bali Zero submit |
+
+**Peran klien di proses ini:** Review laporan keuangan yang sudah disiapkan tim kami, berikan persetujuan, dan kirimkan passphrase sertifikat elektronik untuk tanda tangan. Proses teknis di CoreTax kami handle sepenuhnya.
+
+---
+
+## Apa yang Berbeda untuk SPT 2025 vs. Tahun Sebelumnya?
+
+Jika Anda (atau akuntan Anda) sudah pernah lapor via DJP Online, ini yang berubah signifikan:
+
+| Aspek               | DJP Online (Sebelum 2025)                  | CoreTax (2025 dan seterusnya)                 |
+| ------------------- | ------------------------------------------ | --------------------------------------------- |
+| Cara pengisian      | Upload file CSV/XML                        | Input langsung online                         |
+| Tanda tangan        | EFIN atau e-Signature terpisah             | Passphrase sertifikat elektronik terintegrasi |
+| Validasi            | Setelah upload/submit                      | Real-time saat pengisian                      |
+| Cross-check e-Bupot | Manual                                     | Otomatis dari sistem                          |
+| Error langsung      | Tidak ada (baru tahu setelah diproses DJP) | Terdeteksi sebelum submit                     |
+| Akses multi-user    | Tidak ada                                  | Admin bisa ditetapkan per akun                |
+
+---
+
+<ArticleClusterCTA slug="coretax-spt-tahunan-2025-panduan-bali-zero" />
+
+## Jika Anda Sudah Melewati Deadline
+
+Jika SPT Badan 2025 belum dilaporkan dan sudah melewati 31 Mei 2026:
+
+1. **Laporkan segera** — semakin lama ditunda, semakin besar risiko SP2DK atau pemeriksaan
+2. **Hitung dan bayar denda** — IDR 1.000.000 via Kode Billing di CoreTax (menu e-Billing > Denda/Sanksi SPT)
+3. **Bayar kekurangan pajak** (jika ada) — sebelum submit SPT, karena SPT harus dalam kondisi "nihil" atau "lebih bayar" saat diajukan
+4. **Tidak ada amnesti untuk ini** — relaksasi 31 Mei sudah berakhir; sanksi berlaku langsung
+
+---
+
+## Catatan untuk Tim Surya
+
+**Status: PARTIALLY VALIDATED — Angel (23 Jul 2026)**
+
+- Q1 (Sertel/EFIN): VALIDATED — tidak bisa dikuasakan, hanya shareholder
+- Q2 (Role management): VALIDATED — akun direktur sebagai PIC, tidak butuh surat kuasa bermeterai
+- Q3 (CoreTax down): VALIDATED — tidak ada tanda terima manual, submit sebelum tenggat adalah SOP
+
+⚠️ **Questions for regulatory review — WAJIB sebelum publikasi:**
+
+**Pertanyaan Kritis:**
+
+1. **Deadline krusial untuk klien Bali Zero**: Dari pengalaman handling SPT klien, apakah ada deadline antara (_interim deadline_) yang sering terlewat selain batas akhir April/Mei? Misalnya: deadline pembayaran angsuran PPh 25, deadline penyampaian laporan keuangan ke Kementerian Hukum, atau laporan LKPM yang berinteraksi dengan proses SPT?
+
+2. **Error paling sering untuk klien Bali Zero**: Dari kasus-kasus nyata yang ditangani, bagian SPT 1771 mana yang paling sering menyebabkan masalah? Apakah ada error spesifik CoreTax yang sudah ditemukan solusinya di internal Bali Zero dan belum dipublikasikan?
+
+3. **Passphrase dan akses klien asing**: Proses pengiriman passphrase dari klien asing (yang mungkin berada di luar negeri saat deadline) — apakah ada prosedur khusus? Power of Attorney untuk kuasa WP di CoreTax?
+
+4. **Konfirmasi relaksasi**: Relaksasi 31 Mei 2026 untuk SPT Badan 2025 — apakah ini sudah terlewat saat artikel dipublikasikan (22 Juli 2026)? Jika ya, bagian deadline perlu diupdate untuk fokus ke "cara lapor sekarang meski terlambat" dan sanksi yang berlaku.
+
+5. **Status DJP Online**: Apakah DJP Online benar-benar sudah 100% non-aktif untuk SPT Tahunan baru, atau masih ada fungsi tertentu yang masih aktif?
+
+---
+
+_PT PMA Anda belum lapor SPT 2025, atau masih stuck di proses CoreTax? Tim Bali Zero handle proses dari A-Z — termasuk persiapan laporan keuangan, rekonsiliasi fiskal, input CoreTax, dan submit. Hubungi kami via WhatsApp._
+
+<AskZantara
+  context="CoreTax DJP, SPT Tahunan 2025, SPT Badan, PT PMA pajak, deadline SPT, sertifikat elektronik, passphrase CoreTax"
+  placeholder="Tanyakan soal SPT Tahunan dan CoreTax..."
+  suggestedQuestions={[
+    "Sudah lewat deadline 31 Mei, apa yang harus saya lakukan sekarang?",
+    "Bagaimana cara setup akun CoreTax untuk PT PMA baru?",
+    "Error 'Operasi Gagal' di SPT 1771 — cara memperbaikinya?",
+    "Berapa biaya Bali Zero untuk handle SPT Tahunan PT PMA?",
+  ]}
+/>

--- a/apps/mouth/src/content/articles/tax/coretax-spt-tahunan-2025-panduan-bali-zero.it.mdx
+++ b/apps/mouth/src/content/articles/tax/coretax-spt-tahunan-2025-panduan-bali-zero.it.mdx
@@ -1,0 +1,345 @@
+---
+title: "CoreTax DJP 2025: Panduan SPT Tahunan untuk Klien Bali Zero"
+slug: "coretax-spt-tahunan-2025-panduan-bali-zero"
+description: "Panduan praktis SPT Tahunan 2025 via CoreTax untuk PT PMA dan profesional klien Bali Zero. Deadline, langkah pengisian, error umum, dan cara Bali Zero handle proses dari awal sampai submit."
+excerpt: "CoreTax adalah satu-satunya sistem untuk SPT Tahunan 2025. Ini panduan dari Bali Zero: siapa yang wajib, apa yang berbeda dari sistem lama, error apa yang paling sering terjadi — dan bagaimana kami handle prosesnya untuk Anda."
+category: "tax"
+tags:
+  - CoreTax
+  - SPT Tahunan
+  - DJP Online
+  - e-filing pajak
+  - PT PMA pajak
+  - PPh Badan
+  - sertifikat elektronik
+  - SPT 2025
+publishedAt: "2026-07-22"
+updatedAt: "2026-07-22"
+author:
+  name: "Subhi Darajat"
+  avatar: "/static/team/subhi.jpg"
+  role: "Tax & Compliance Analyst"
+featured: false
+adversarial_review: "surya"
+readingTime: 14
+difficulty: "intermediate"
+aiGenerated: false
+tableOfContents: true
+relatedArticles:
+  - "coretax-vs-djp-online-what-changed"
+  - "coretax-login-errors-fixes-2026"
+  - "coretax-npwp16-vs-npwp15-foreigners"
+  - "tax-compliance-checklist-pt-pma"
+  - "tax-calendar-indonesia"
+seoTitle: "CoreTax SPT Tahunan 2025: Panduan Lengkap untuk PT PMA & Profesional"
+seoDescription: "Deadline SPT Badan 2025 sudah lewat? Panduan CoreTax untuk PT PMA dan klien Bali Zero: langkah-langkah, error umum, dan cara kami handle prosesnya untuk Anda."
+faq:
+  - question: "Apa deadline SPT Tahunan 2025 untuk PT PMA?"
+    answer: "SPT Tahunan Badan untuk tahun pajak 2025 memiliki deadline 30 April 2026. DJP memberikan relaksasi perpanjangan hingga 31 Mei 2026 tanpa sanksi administrasi, karena penerapan CoreTax yang masih dalam masa adaptasi. Setelah 31 Mei 2026, denda keterlambatan IDR 1.000.000 berlaku."
+  - question: "Apakah semua PT PMA wajib pakai CoreTax untuk SPT 2025?"
+    answer: "Ya. Mulai tahun pajak 2025 (dilaporkan 2026), seluruh Wajib Pajak Badan termasuk PT PMA diwajibkan menggunakan sistem CoreTax di coretaxdjp.pajak.go.id untuk pelaporan SPT Tahunan. DJP Online tidak lagi menerima SPT Tahunan baru."
+  - question: "Kenapa SPT Tahunan Badan di CoreTax sering error 'Operasi Gagal'?"
+    answer: "Error 'Operasi Gagal' saat menyimpan data SPT Badan di CoreTax paling sering disebabkan oleh Lampiran L6 (Angsuran PPh Pasal 25) yang tidak terisi lengkap. Periksa kembali bagian ini meskipun perusahaan Anda tidak wajib angsuran — kolom perlu diisi atau disesuaikan agar sistem dapat memproses."
+aiOptimization:
+  primaryQuestion: "Bagaimana cara melaporkan SPT Tahunan 2025 via CoreTax DJP untuk PT PMA?"
+  answerSnippet: "Login ke coretaxdjp.pajak.go.id menggunakan NPWP 16 digit (tambahkan '0' di depan NPWP 15 digit lama). Masuk ke menu SPT > Buat Konsep SPT > pilih PPh Badan tahun pajak 2025. Isi mulai dari induk, lampiran keuangan, rekonsiliasi fiskal, dan lampiran-lampiran. Tandatangani dengan sertifikat elektronik + passphrase. Deadline: 30 April 2026 (relaksasi s/d 31 Mei 2026). Denda keterlambatan: IDR 1.000.000."
+  entityMentions:
+    - type: "GovernmentOrganization"
+      name: "Direktorat Jenderal Pajak (DJP)"
+    - type: "SoftwareApplication"
+      name: "CoreTax DJP"
+      sameAs: "https://coretaxdjp.pajak.go.id"
+contentStructure:
+  hasHowTo: true
+  hasFAQ: true
+  hasTable: true
+canonicalUrl: "https://balizero.com/tax/coretax-spt-tahunan-2025-panduan-bali-zero"
+ogType: "article"
+twitterCard: "summary_large_image"
+locale: "it"
+---
+import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
+import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+import {
+  KeyTakeaway,
+  InfoCard,
+  AskZantara,
+} from "@/components/blog/interactive";
+
+# CoreTax DJP 2025: Guida alla Dichiarazione Unica per i Clienti Bali Zero
+
+<KeyTakeaway>
+  **TL;DR:** La Dichiarazione Unica 2025 deve essere presentata tramite CoreTax (coretaxdjp.pajak.go.id).
+  Scadenza per le Società: 30 aprile 2026, con una proroga fino al **31 maggio 2026** senza multe.
+  Accesso: NPWP 16 cifre + password + passphrase del certificato elettronico. Errori
+  più comuni: Allegato L6 vuoto, certificato non valido, dati non sincronizzati
+  con l'e-Bupot. Bali Zero gestisce l'intero processo dalla preparazione della documentazione fino alla presentazione — i clienti devono solo approvare e firmare digitalmente.
+</KeyTakeaway>
+
+<HeaderWhatsAppCTA />
+
+---
+
+## CoreTax: Non è un'Opzione, è un Obbligo
+
+Dal 2025, **DJP Online non accetta più nuove Dichiarazioni Uniche**. Tutte le dichiarazioni — incluse quelle per le Società di Investimento Estero (PT PMA) — devono essere presentate attraverso il sistema CoreTax Administration System (Sistema Intero Amministrativo Fiscale) su **coretaxdjp.pajak.go.id**.
+
+Questo non è solo un cambio di aspetto del sito web. CoreTax è una nuova infrastruttura fiscale che integra e-Filing, e-Fattura, e-Bupot, e-Billing e la gestione dei certificati elettronici in un unico piattaforma. Il processo è fondamentalmente diverso da DJP Online, e la curva di apprendimento — soprattutto per gli stranieri che si avvicinano per la prima volta al sistema fiscale indonesiano — è ripida.
+
+Questa guida è stata creata appositamente per i clienti di Bali Zero: fondatori stranieri, PT PMA e professionisti che devono comprendere ciò che accade dietro le quinte quando gestiamo le loro dichiarazioni fiscali.
+
+---
+
+## Chi Deve Presentare la Dichiarazione Unica tramite CoreTax?
+
+### Soggetti Obbligati alle Imposte sulle Società (PT PMA)
+
+Ogni PT PMA che:
+
+- È iscritta come Soggetto Obbligato alle Imposte sulle Società in Indonesia
+- È operativa durante l'anno fiscale 2025, anche se non ha generato reddito
+- Possiede un NPWP attivo (inclusi quelli con stato Non-Efettivo — richiedere conferma al KPP)
+
+**Modulo utilizzato: SPT 1771**
+
+### Soggetti Obbligati alle Imposte sulle Persone Fisiche (Professionisti, Consulenti)
+
+Clienti individuali — avvocati, consulenti, freelance stranieri con NPWP — sono anch'essi obbligati a utilizzare CoreTax per la Dichiarazione Unica Personale (Modulo 1770 o 1770S).
+
+<InfoCard variant="note" title="Sui Gruppi PNP e PK">
+
+La breve interna di Bali Zero menziona "PNP" (Imprenditore Non Soggetto a IVA) e "PK"
+(Imprenditore Soggetto a IVA). Dal punto di vista della Dichiarazione Unica, la distinzione più rilevante è tra Soggetti Obbligati alle Imposte sulle Società (Modulo 1771) e Soggetti Obbligati alle Imposte sulle Persone Fisiche (Modulo 1770/1770S). Lo status di PKP influisce sull'obbligo IVA, non sull'obbligo della Dichiarazione Unica PPh. **[NECESSARIA VALIDAZIONE DI SURYA]: confermare se il raggruppamento PNP/PK menzionato nella breve si riferisce a un contesto diverso all'interno di Bali Zero.**
+
+</InfoCard>
+
+---
+
+## Scadenze per la Dichiarazione Unica 2025 — Numeri Importanti
+
+| Tipo di Soggetto Obbligato         | Modulo                  | Scadenza Normale                  | Proroga 2026        | Multa per Ritardo |
+| --------------------------         | ---------------------     | -------------------------------- | --------------------- | --------------- |
+| **Persone Fisiche**                | 1770 / 1770S / 1770SS   | 31 marzo 2026                    | _nessuna proroga_   | IDR 100.000     |
+| **Società (PT PMA)**               | 1771                    | 30 aprile 2026                   | **31 maggio 2026**  | IDR 1.000.000   |
+| **Società (periodo speciale)**     | 1771                    | 4 mesi dopo la fine dell'anno fiscale | _secondo periodo_ | IDR 1.000.000   |
+
+<InfoCard variant="warning" title="La Proroga per le Società è Solo Fino al 31 Maggio 2026">
+
+La DJP, attraverso un annuncio ufficiale, ha concesso una proroga per la presentazione della Dichiarazione Unica delle Società per l'anno fiscale 2025, da 30 aprile a **31 maggio 2026**, senza applicazione della sanzione amministrativa di IDR 1.000.000. La proroga è stata concessa a causa del processo di adattamento al sistema CoreTax che è ancora in corso. **Dopo il 31 maggio 2026, le sanzioni si applicano pienamente.** Fonte: annuncio ufficiale di pajak.go.id e del Ministero delle Finanze.
+
+</InfoCard>
+
+Il ritardo nella presentazione della Dichiarazione Unica non è solo una questione di multe. Le conseguenze pratiche spesso trascurate sono:
+
+- Il processo di rinnovo del KITAS/ITAS che richiede la prova della conformità fiscale sarà ritardato
+- Le richieste di credito bancario o di gare governative richiedono una Certificazione Fiscale che viene rilasciata solo se la Dichiarazione Unica è stata presentata
+- La DJP può emettere un SP2DK (Comunicazione di Richiesta di Spiegazioni sui Dati e le Informazioni) che apre la possibilità di un controllo
+
+---
+
+## Funzionalità di CoreTax 2025 Rilevanti per la Dichiarazione delle Società
+
+### 1. Compilazione Online Integrata
+
+A differenza di DJP Online che accettava l'upload di file CSV/XML, CoreTax richiede la compilazione diretta nel sistema. Il Modulo 1771 viene compilato in modo strutturato:
+
+- **Dichiarazione Principale**: Identità del Soggetto Obbligato, tipo di attività, riepilogo finanziario
+- **Allegato I**: Reddito netto commerciale
+- **Allegato II**: Costo del Bene Venduto (HPP)
+- **Allegato III**: Credito d'imposta (PPh 22, 23, 24, 25)
+- **Allegato IV**: PPh Definitivo e reddito non soggetto a imposta
+- **Allegato V**: Elenco degli azionisti e delle partecipazioni
+- **Allegato VI**: Ratei di PPh 25 _(questo è spesso la fonte di errori)_
+- **Reconciliazione Fiscale**: Correzione tra il profitto commerciale e il profitto fiscale
+
+### 2. Validazione in Tempo Reale
+
+CoreTax valida i dati durante la compilazione, non dopo l'invio. Questo significa:
+
+- Numeri non bilanciati (attivo ≠ passivo + patrimonio netto) vengono rifiutati immediatamente
+- NPWP di terzi non validi vengono immediatamente segnalati
+- Duplicati di e-Bupot vengono rilevati prima di entrare nella dichiarazione
+
+### 3. Cross-Referencing Automatico con l'e-Bupot
+
+CoreTax confronta automaticamente i Buoni di Potting ricevuti dai clienti con la dichiarazione presentata. Questo significa:
+
+- Se uno dei vostri clienti ha trattenuto PPh 23 per un servizio pagato alla vostra PT, quei dati sono già presenti in CoreTax prima che voi li compiliate
+- Discrepanze (mismatch) tra i buoni di potting ricevuti e i crediti d'imposta rivendicati vengono rilevate automaticamente
+
+### 4. Firma Digitale con Passphrase
+
+Tutti gli invii in CoreTax richiedono un **certificato elettronico** rilasciato dalla DJP, completato con una **passphrase** — non solo una password di accesso. Questo è uno strato di sicurezza per la firma digitale sui documenti ufficiali.
+
+Nella pratica, consulenti fiscali certificati come Bali Zero operano utilizzando l'account del direttore come Responsabile (PIC) della PT — non è richiesto un mandato a bollo separato per l'accesso operativo quotidiano in CoreTax.
+
+---
+
+## Errori Più Comuni e Come Risolverli
+
+In base all'esperienza del processo di dichiarazione dei clienti di Bali Zero e ai rapporti pubblici degli contabili, ecco gli errori più comuni:
+
+### Errore 1: "Operazione Non Riuscita" durante il Salvataggio della Dichiarazione
+
+**Causa principale:** L'Allegato L6 (Ratei di PPh Articolo 25) non è stato compilato in modo completo, anche se l'azienda non è obbligata a ratei.
+
+**Soluzione:**
+
+1. Accedere all'Allegato L6 direttamente dal menu del modulo
+2. Verificare se ci sono campi vuoti o con valore zero senza conferma
+3. Se l'azienda non è obbligata a ratei di PPh 25 (perché nuova o con reddito netto fiscale zero), assicurarsi che i campi siano compilati con "0" e non lasciati vuoti
+
+### Errore 2: Errore del Server 500/501/401
+
+**Causa:** Traffico elevato (periodo di scadenza), cache del browser o sessione scaduta.
+
+**Soluzione:**
+
+1. Pulire completamente la cache e i cookie del browser
+2. Utilizzare la modalità Incognito/Finestra Privata
+3. Provare con un browser diverso (Chrome è consigliato dalla DJP)
+4. Accedere fuori dagli orari di punta: prima delle 08.00 o dopo le 20.00
+5. Salvare il draft in modo regolare — CoreTax offre la funzione "Salva Bozza" che dovrebbe essere utilizzata ogni 10-15 minuti
+
+Una cosa che deve essere compresa chiaramente: la DJP non fornisce un ricevuta di presentazione manuale come alternativa all'invio CoreTax se il server ha problemi il giorno della scadenza. Non esiste un meccanismo di backup ufficiale che garantisca la validità delle dichiarazioni non inviate a causa di un downtime. Pertanto, la pratica migliore adottata costantemente dai consulenti fiscali esperti è completare e presentare la dichiarazione molto prima della scadenza — almeno tre a cinque giorni lavorativi prima della data limite.
+
+### Errore 3: Certificato Elettronico Non Valido / Passphrase Rifiutata
+
+**Causa:** Certificato scaduto, passphrase dimenticata o certificato non validato dopo il reset.
+
+**Soluzione:**
+
+1. Accedere: _Il Mio Portale > Il Mio Profilo > Identificativo Esterno > Certificato Digitale_
+2. Cliccare **"Controlla Stato"** — assicurarsi che lo stato sia "Valido"
+3. Se scaduto o non valido: richiedere l'aggiornamento tramite _Il Mio Portale > Richiesta Codice di Autorizzazione/Certificato Elettronico_
+4. Dopo il reset della passphrase, validare nuovamente lo stato prima di inviare la dichiarazione
+
+**Nota Sertel/EFIN:** Secondo la conferma della DJP, questa procedura non può essere delegata a terzi in nessun KPP in Indonesia. Solo uno degli azionisti (shareholder) dell'azienda può presentarsi personalmente per richiedere l'autorizzazione.
+
+La passphrase è diversa dalla password di accesso. La passphrase viene utilizzata esclusivamente per la firma dei documenti e deve rispettare i requisiti: almeno 8 caratteri, contenere lettere maiuscole, minuscole, numeri e caratteri speciali.
+
+### Errore 4: Dati Non Sincronizzati con l'e-Bupot
+
+**Causa:** I buoni di potting ricevuti dai clienti non sono ancora entrati nel sistema, o ci sono discrepanze tra i dati che rivendicate e quelli registrati dalla DJP.
+
+**Soluzione:**
+
+1. Chiedere una conferma alla parte emittente del Buono di Potting che abbiano già inviato alla DJP tramite CoreTax
+2. Controllare il menu _e-Bupot Ricevuti_ in CoreTax — tutti i buoni di potting ricevuti dal vostro NPWP dovrebbero essere elencati qui
+3. Se ci sono discrepanze nei valori, contattare l'emittente del buono per la correzione
+
+### Errore 5: Periodo della Dichiarazione Non Visualizzato
+
+**Causa:** Non è un bug, ma un conflitto tra il periodo contabile registrato nel profilo CoreTax e quello effettivamente utilizzato.
+
+**Soluzione:** Controllare _Il Mio Portale > Il Mio Profilo > Informazioni Generali_. Assicurarsi che il periodo contabile registrato nel sistema corrisponda all'anno fiscale dell'azienda (Gennaio-Dicembre, o periodo speciale se applicabile).
+
+---
+
+## Documenti Necessari Prima di Compilare la SPT 1771
+
+Per le PT PMA, questi documenti devono essere disponibili prima di iniziare:
+
+| Documento                                | Descrizione                                 |
+| --------------------------------------     | ------------------------------------------ |
+| **Bilancio** (P&L + Bilancio Patrimoniale) | Al 31 dicembre 2025, in Rupiah         |
+| **Reconciliazione Fiscale**                | Correzione delle differenze permanenti e temporanee          |
+| **Buoni di Potting Ricevuti**         | PPh 22, 23, 24 da terzi           |
+| **Ricevute di Pagamento PPh 25**                | Tutte le prove di ratei mensili durante il 2025 |
+| **Elenco delle Ammortizzazioni Fiscali**           | Per il metodo fiscale, non commerciale         |
+| **Dati degli Azionisti**                | Nome, NPWP/NIK, percentuale di proprietà     |
+| **Certificato Elettronico + Passphrase** | Per la firma digitale dell'invio      |
+| **Prove di Dividendi / Utili**         | Se ci sono distribuzioni agli azionisti nel 2025 |
+
+<InfoCard variant="note" title="Bilancio Audit: Obbligatorio o No?">
+
+Le PT PMA con un fatturato superiore a IDR 50 miliardi devono allegare un bilancio
+auditato da un Contabile Pubblico iscritto. Sotto i IDR 50 miliardi,
+il bilancio interno è sufficiente come allegato alla dichiarazione — anche se
+è comunque consigliato avere un bilancio preparato professionalmente per
+evitare correzioni fiscali significative.
+
+</InfoCard>
+
+---
+
+## Timeline della Dichiarazione delle Società: Dalla Preparazione all'Invio
+
+Per i clienti di Bali Zero, questa è la timeline che seguiamo:
+
+| Fase                      | Attività                                                            | Chi                           |
+| -------------------------- | ------------------------------------------------------------------- | ------------------------------- |
+| **Febbraio – Marzo**       | Raccolta documenti, riconciliazione bancaria, finalizzazione del bilancio | Cliente → Bali Zero               |
+| **Aprile**                  | Reconciliazione fiscale, calcolo dell'imposta sulle società dovuta, revisione e-Bupot   | Bali Zero                       |
+| **Metà Aprile**      | Bozza della dichiarazione inviata al cliente per la revisione e l'approvazione             | Bali Zero → Cliente               |
+| **Fine Aprile / Inizio Maggio** | Inserimento in CoreTax, validazione del sistema, risoluzione degli errori                   | Bali Zero                       |
+| **Prima del 31 Maggio**         | Invio della passphrase del certificato dal cliente → Invio finale          | Cliente approva, Bali Zero invia |
+
+**Ruolo del cliente in questo processo:** Revisionare il bilancio preparato dal nostro team, fornire l'approvazione e inviare la passphrase del certificato elettronico per la firma. Il processo tecnico in CoreTax lo gestiamo interamente noi.
+
+---
+
+## Cosa è Diverso per la Dichiarazione 2025 rispetto agli Anni Precedenti?
+
+Se voi (o il vostro contabile) avete già presentato tramite DJP Online, ecco ciò che è cambiato in modo significativo:
+
+| Aspetto               | DJP Online (Prima del 2025)                  | CoreTax (2025 e seguenti)                 |
+| ------------------- | ------------------------------------------ | --------------------------------------------- |
+| Modalità di compilazione      | Upload di file CSV/XML                        | Compilazione diretta online                         |
+| Firma        | EFIN o e-Signature separata             | Passphrase del certificato elettronico integrata |
+| Validazione            | Dopo l'upload/invio                      | In tempo reale durante la compilazione                      |
+| Cross-check e-Bupot | Manuale                                     | Automatico dal sistema                          |
+| Errori immediati      | No (si scopre solo dopo il processing della DJP) | Rilevati prima dell'invio                     |
+| Accesso multi-utente    | No                                  | Amministratore può essere assegnato per account                |
+
+---
+
+<ArticleClusterCTA slug="coretax-spt-tahunan-2025-panduan-bali-zero" />
+
+## Se Avete Superato la Scadenza
+
+Se la Dichiarazione delle Società 2025 non è stata presentata e è già passato il 31 maggio 2026:
+
+1. **Presentatela immediatamente** — più si aspetta, maggiore è il rischio di SP2DK o di un controllo
+2. **Calcolate e pagate la multa** — IDR 1.000.000 tramite Codice di Fatturazione in CoreTax (menu e-Billing > Multe/Sanzioni SPT)
+3. **Pagare l'eventuale imposta mancante** (se presente) — prima di inviare la dichiarazione, perché la dichiarazione deve essere in condizione "nula" o "sovrappagata" al momento della presentazione
+4. **Non c'è amnistia per questo** — la proroga al 31 maggio è terminata; le sanzioni si applicano immediatamente
+
+---
+
+## Note per il Team Surya
+
+**Stato: PARZIALMENTE VALIDATO — Angel (23 lug 2026)**
+
+- Q1 (Sertel/EFIN): VALIDATO — non può essere delegato, solo azionista
+- Q2 (Gestione ruoli): VALIDATO — account del direttore come PIC, non è richiesto un mandato a bollo
+- Q3 (CoreTax down): VALIDATO — non c'è ricevuta manuale, inviare prima della scadenza è la procedura standard
+
+⚠️ **Domande per la revisione regolamentare — OBBLIGATORIE prima della pubblicazione:**
+
+**Domande Critiche:**
+
+1. **Scadenza cruciale per i clienti di Bali Zero**: Dall'esperienza nella gestione delle dichiarazioni dei clienti, ci sono scadenze intermedie (_interim deadline_) che spesso vengono dimenticate oltre alla scadenza finale di aprile/maggio? Ad esempio: scadenza del pagamento dei ratei di PPh 25, scadenza della presentazione del bilancio al Ministero della Giustizia, o la presentazione del LKPM che interagisce con il processo della dichiarazione?
+
+2. **Errore più frequente per i clienti di Bali Zero**: Dalle situazioni reali gestite, quale parte del Modulo 1771 causa più problemi? Ci sono errori specifici di CoreTax che sono già stati risolti internamente da Bali Zero e non sono stati pubblicati?
+
+3. **Passphrase e accesso del cliente straniero**: Processo di invio della passphrase da parte del cliente straniero (che potrebbe trovarsi all'estero durante la scadenza) — c'è una procedura speciale? Mandato per l'autorizzazione del Soggetto Obbligato in CoreTax?
+
+4. **Conferma della proroga**: La proroga al 31 maggio 2026 per la Dichiarazione delle Società 2025 — è già scaduta al momento della pubblicazione dell'articolo (22 luglio 2026)? Se sì, la sezione delle scadenze deve essere aggiornata per concentrarsi su "come presentare ora anche se in ritardo" e sulle sanzioni applicabili.
+
+5. **Stato di DJP Online**: È vero che DJP Online è completamente disattivato per le nuove Dichiarazioni Uniche, o ci sono ancora funzioni attive?
+
+---
+
+_La vostra PT PMA non ha ancora presentato la Dichiarazione 2025, o siete bloccati nel processo CoreTax? Il team di Bali Zero gestisce l'intero processo da A a Z — incluso la preparazione del bilancio, la reconciliazione fiscale, l'inserimento in CoreTax e l'invio. Contattateci via WhatsApp._
+
+<AskZantara
+  context="CoreTax DJP, Dichiarazione Unica 2025, Dichiarazione delle Società, PT PMA tasse, scadenza dichiarazione, certificato elettronico, passphrase CoreTax"
+  placeholder="Chiedi sulla Dichiarazione Unica e CoreTax..."
+  suggestedQuestions={[
+    "È già passata la scadenza del 31 maggio, cosa devo fare ora?",
+    "Come impostare l'account CoreTax per una nuova PT PMA?",
+    "Errore 'Operazione Non Riuscita' nel Modulo 1771 — come risolverlo?",
+    "Qual è il costo di Bali Zero per gestire la Dichiarazione Unica della PT PMA?",
+  ]}
+/>

--- a/apps/mouth/src/content/articles/tax/pp-20-2026-perubahan-investor-asing-indonesia.id.mdx
+++ b/apps/mouth/src/content/articles/tax/pp-20-2026-perubahan-investor-asing-indonesia.id.mdx
@@ -1,0 +1,130 @@
+---
+title: "PP 20/2026: Dampak dan Perubahan Strategis bagi Investor Asing di Indonesia"
+slug: "pp-20-2026-perubahan-investor-asing-indonesia"
+publishedAt: "2026-07-25"
+updatedAt: "2026-07-25"
+author: "Bali Zero Editorial Team"
+category: "tax"
+tags: ["pajak", "PP 20/2026", "Investasi Asing", "Regulasi", "PT PMA"]
+seoTitle: "Dampak PP 20/2026 untuk Investor Asing & PT PMA di Indonesia | Bali Zero"
+seoDescription: "Analisis PP 20/2026 dan dampaknya bagi investor asing. Pahami perubahan tarif PT PMA, aturan agregasi omzet, dan kebijakan anti-suap yang berlaku 2026."
+excerpt: "PP 20/2026 menutup celah penghindaran pajak. Investor asing dan PT PMA perlu evaluasi ulang arsitektur fiskal mereka sebelum Q3 2026."
+adversarial_review: "tax-team"
+locale: "id"
+---
+import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
+import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+import {
+  KeyTakeaway,
+  InfoCard,
+  AskZantara,
+} from "@/components/blog/interactive";
+
+# PP 20/2026: Dampak dan Perubahan Strategis bagi Investor Asing di Indonesia
+
+<KeyTakeaway>
+  **TL;DR:** Peraturan Pemerintah Nomor 20 Tahun 2026 (PP 20/2026) yang berlaku
+  sejak 22 April 2026 memperketat pengawasan perpajakan bagi investor asing dan
+  PT PMA di Indonesia. Perubahan mencakup klasifikasi PPh Final UMKM 0,5%,
+  aturan agregasi penghasilan (worldwide income), penegasan biaya nondeductible
+  termasuk klaim entertainment (Pasal 20A), dan penerapan prinsip substance over
+  form untuk mendeteksi penghindaran pajak.
+</KeyTakeaway>
+
+<HeaderWhatsAppCTA />
+
+---
+
+## Ringkasan Eksekutif: Reformasi Perpajakan PP 20/2026
+
+Pemerintah Indonesia resmi menerbitkan Peraturan Pemerintah Nomor 20 Tahun 2026 (PP 20/2026) sebagai penyesuaian atas PP 55/2022 dan UU Harmonisasi Peraturan Perpajakan (UU HPP). Regulasi baru ini dirancang untuk menciptakan keadilan iklim investasi sekaligus menutup berbagai celah hukum (_tax loopholes_) yang selama ini dimanfaatkan oleh investor asing dan badan usaha penanaman modal asing (PT PMA).
+
+Bagi ekosistem investasi di Bali dan Indonesia secara umum, PP 20/2026 memberikan kepastian hukum tetapi memperketat kepatuhan fiskal (_fiscal compliance_). Investor dan pendiri perusahaan asing tidak lagi dapat mengandalkan struktur skema pajak sederhana tanpa pembukuan yang sah.
+
+---
+
+## Perubahan Utama PP 20/2026 bagi Investor Asing dan PT PMA
+
+### 1. Penegasan Klasifikasi PPh Final UMKM 0,5%
+
+PP 20/2026 mempertegas batas eligibilitas skema PPh Final 0,5% untuk UMKM:
+
+- Skema tarif 0,5% hanya berlaku untuk kegiatan usaha riil (_active business_) dengan omzet tidak melebihi IDR 4,8 miliar per tahun.
+- Penghasilan dari jasa profesional / pekerjaan bebas (_independent personal services_) secara tegas dikecualikan dari PPh Final 0,5%, terlepas dari apakah pendirinya menggunakan PT Perorangan atau PT PMA.
+- PT PMA yang menjalankan usaha perdagangan atau manufaktur tetap dapat memanfaatkan skema ini selama memenuhi syarat omzet dan jangka waktu yang ditentukan regulasi.
+
+---
+
+### 2. Aturan Agregasi Omzet dan Worldwide Income
+
+Salah satu poin utama dalam PP 20/2026 adalah penegasan penggabungan omzet dan pengawasan atas penghasilan global (_worldwide income_):
+
+- DJP memperluas koordinasi pertukaran informasi keuangan otomatis (AEOI) untuk melacak aset dan penghasilan WNA di luar negeri.
+- Agregasi omzet berlaku untuk grup usaha terafiliasi guna mencegah pemecahan badan usaha (_split-up_) semata-mata untuk menikmati tarif pajak rendah.
+
+<InfoCard variant="warning" title="Penting: Status Tax Residency & Tax Treaty">
+
+Perlu dicatat bahwa penerapan aturan agregasi ini tidak berlaku secara otomatis bagi seluruh WNA. Status perpajakan seseorang — apakah ia telah menjadi Subjek Pajak Dalam Negeri (SPDN) atau masih berstatus Subjek Pajak Luar Negeri (SPLN) — menentukan apakah worldwide income-nya masuk dalam perhitungan. Lebih jauh, perjanjian penghindaran pajak berganda (tax treaty) antara Indonesia dan negara asal WNA dapat memberikan perlindungan atau pengecualian tertentu yang perlu diverifikasi case-by-case. Jika Anda memiliki pendapatan dari luar negeri dan berencana menetap di Indonesia, konsultasikan posisi Anda dengan konsultan pajak sebelum mengambil asumsi.
+
+</InfoCard>
+
+---
+
+### 3. Ketentuan Biaya Entertainment dan Anti-Suap (Pasal 20A)
+
+Pasal 20A PP 20/2026 mempertegas aturan mengenai pengeluaran perusahaan yang dapat dikurangkan (_deductible expenses_) dan yang tidak dapat dikurangkan (_nondeductible expenses_):
+
+Penting untuk dipahami bahwa Pasal 20A tidak otomatis mengklasifikasikan seluruh biaya entertainment sebagai pengeluaran ilegal. DJP dapat menolak pengurangan biaya hanya jika terdapat indikasi bahwa pembayaran tersebut berkaitan dengan suap, gratifikasi, atau uang pelicin. Dalam praktik audit, risiko koreksi fiskal pada PT PMA lebih sering dipicu oleh kurangnya dokumentasi bisnis yang memadai — tidak adanya kontrak, bukti transaksi, atau keterangan tujuan bisnis yang jelas — bukan semata-mata karena status PMA-nya. Mitigasi terbaik: pastikan setiap biaya entertainment didukung oleh bukti transaksi lengkap dan dokumentasi tujuan bisnis yang dapat dipertanggungjawabkan.
+
+---
+
+### 4. Transparansi Beneficial Ownership & Substance Over Form
+
+DJP kini secara aktif menerapkan prinsip _substance over form_ (mengutamakan substansi ekonomi di atas bentuk formal hukum). Hal ini berdampak pada:
+
+- Perusahaan nominee atau PT PMA pasif tanpa aktivitas operasional riil (_shell companies_) rentan dikoreksi secara fiskal.
+- Pelaporan pemilik manfaat (_Beneficial Ownership_) menjadi wajib dan disinkronkan dengan data Kemenkumham serta sistem CoreTax.
+
+---
+
+## Implikasi Praktis bagi PT PMA dan Langkah Mitigasi
+
+Untuk memastikan kelangsungan operasional dan menghindari sanksi administratif atau pemeriksaan pajak, manajemen PT PMA disarankan mengambil langkah-langkah berikut:
+
+1. **Review Arsitektur Pajak**: Audit struktur pendapatan perusahaan dan pastikan pengkategorian PPh Final vs. PPh Pasal 17/23 sudah tepat.
+2. **Lengkapi Daftar Nominatif**: Seluruh biaya entertainment dan representasi wajib dilengkapi daftar nominatif yang mencantumkan nama penerima, jumlah, dan tujuan bisnis.
+3. **Validasi Tax Residency**: Konfirmasi status SPDN vs. SPLN bagi direktur dan pemegang saham asing serta pelajari treaty benefit yang berlaku.
+4. **Persiapan Pembukuan di CoreTax**: Pastikan seluruh laporan keuangan tersusun rapi dalam standar Akuntansi Indonesia (SAK) untuk integrasi CoreTax.
+
+---
+
+<ArticleClusterCTA slug="pp-20-2026-perubahan-investor-asing-indonesia" />
+
+## Catatan untuk Tim Surya
+
+**Status: PARTIALLY VALIDATED — Angel (23 Jul 2026)**
+
+- Q6 (Worldwide income agregasi): VALIDATED — tidak berlaku otomatis, butuh analisis status tax residency + tax treaty case-by-case
+- Q7 (Pasal 20A entertainment): VALIDATED — risiko dari kurangnya dokumentasi bisnis, bukan status PMA
+
+⚠️ **Questions for regulatory review — WAJIB sebelum publikasi:**
+
+**Pertanyaan Kritis:**
+
+1. **Worldwide Income & SPDN**: Bagaimana kriteria teknis penetapan 183 hari bagi pemegang KITAS/KITAP di Bali yang sering keluar-masuk Indonesia dalam konteks penghitungan worldwide income di CoreTax?
+2. **Daftar Nominatif Entertainment**: Apakah DJP mengeluarkan format baku baru di CoreTax untuk melampirkan daftar nominatif biaya entertainment sesuai Pasal 20A?
+
+---
+
+_Memerlukan bantuan untuk evaluasi dampak PP 20/2026 pada PT PMA Anda? Bali Zero Tax Desk siap membantu penataan ulang kepatuhan dan pembukuan pajak perusahaan Anda. Hubungi kami melalui WhatsApp atau tanyakan langsung pada Zantara AI._
+
+<AskZantara
+  context="PP 20/2026, PT PMA pajak, investor asing Indonesia, worldwide income, Pasal 20A entertainment, CoreTax DJP"
+  placeholder="Tanyakan dampak PP 20/2026 bagi bisnis Anda..."
+  suggestedQuestions={[
+    "Bagaimana PP 20/2026 memengaruhi tarif pajak PT PMA saya?",
+    "Apakah pendapatan saya di luar negeri wajib dilaporkan ke DJP?",
+    "Apa syarat agar biaya entertainment bisa diklaim sebagai deductible expense?",
+    "Bagaimana cara Bali Zero mendampingi audit pajak PT PMA?",
+  ]}
+/>

--- a/apps/mouth/src/content/articles/tax/pp-20-2026-perubahan-investor-asing-indonesia.it.mdx
+++ b/apps/mouth/src/content/articles/tax/pp-20-2026-perubahan-investor-asing-indonesia.it.mdx
@@ -1,0 +1,125 @@
+---
+title: "PP 20/2026: Dampak dan Perubahan Strategis bagi Investor Asing di Indonesia"
+slug: "pp-20-2026-perubahan-investor-asing-indonesia"
+publishedAt: "2026-07-25"
+updatedAt: "2026-07-25"
+author: "Bali Zero Editorial Team"
+category: "tax"
+tags: ["pajak", "PP 20/2026", "Investasi Asing", "Regulasi", "PT PMA"]
+seoTitle: "Dampak PP 20/2026 untuk Investor Asing & PT PMA di Indonesia | Bali Zero"
+seoDescription: "Analisis PP 20/2026 dan dampaknya bagi investor asing. Pahami perubahan tarif PT PMA, aturan agregasi omzet, dan kebijakan anti-suap yang berlaku 2026."
+excerpt: "PP 20/2026 menutup celah penghindaran pajak. Investor asing dan PT PMA perlu evaluasi ulang arsitektur fiskal mereka sebelum Q3 2026."
+adversarial_review: "tax-team"
+locale: "it"
+---
+import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
+import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+import {
+  KeyTakeaway,
+  InfoCard,
+  AskZantara,
+} from "@/components/blog/interactive";
+
+# PP 20/2026: Impatto e Cambiamenti Strategici per gli Investitori Stranieri in Indonesia
+
+<KeyTakeaway>
+  **TL;DR:** Il Decreto Presidenziale n. 20 del 2026 (PP 20/2026), entrato in vigore il 22 aprile 2026, ha rafforzato il controllo fiscale sugli investitori stranieri e sulle società a responsabilità limitata con investimenti stranieri (PT PMA) in Indonesia. I cambiamenti includono la classificazione dell'IRPEF finale per le PMI al 0,5%, le regole di aggregazione del reddito (worldwide income), l'approfondimento delle spese non deducibili, inclusi i claim per intrattenimento (Articolo 20A), e l'applicazione del principio di sostanza rispetto alla forma per rilevare l'evasione fiscale.
+</KeyTakeaway>
+
+<HeaderWhatsAppCTA />
+
+---
+
+## Sintesi Esecutiva: Riforma Fiscale PP 20/2026
+
+Il governo indonesiano ha ufficialmente emanato il Decreto Presidenziale n. 20 del 2026 (PP 20/2026) come aggiornamento del PP 55/2022 e della Legge sull'Armonizzazione delle Norme Fiscali (UU HPP). Questa nuova regolamentazione è stata progettata per creare un ambiente equo per gli investimenti, al contempo chiudendo varie lacune legali (_tax loopholes_) che fino ad ora erano state sfruttate dagli investitori stranieri e dalle società a responsabilità limitata con investimenti stranieri (PT PMA).
+
+Per l'ecosistema degli investimenti a Bali e in Indonesia in generale, il PP 20/2026 offre certezza giuridica ma rafforza il rispetto delle norme fiscali (_fiscal compliance_). Gli investitori e i fondatori di aziende straniere non possono più contare su schemi fiscali semplici senza una contabilità legale.
+
+---
+
+## Principali Modifiche del PP 20/2026 per gli Investitori Stranieri e le PT PMA
+
+### 1. Clarificazione della Classificazione dell'IRPEF Finale per le PMI al 0,5%
+
+Il PP 20/2026 chiarisce i limiti di idoneità per lo schema dell'IRPEF finale al 0,5% per le PMI:
+
+- Lo schema dell'aliquota del 0,5% è applicabile solo alle attività commerciali attive (_active business_) con un fatturato non superiore a 4,8 miliardi di IDR all'anno.
+- I redditi da servizi professionali / lavoro autonomo (_independent personal services_) sono espressamente esclusi dall'IRPEF finale al 0,5%, indipendentemente dal fatto che i fondatori utilizzino una società individuale o una PT PMA.
+- Le PT PMA che svolgono attività commerciali o di produzione possono comunque beneficiare di questo schema purché rispettino i requisiti di fatturato e durata stabiliti dalla normativa.
+
+---
+
+### 2. Regole di Aggregazione del Fatturato e Reddito Globale
+
+Uno dei punti principali del PP 20/2026 è la chiarificazione sull'aggregazione del fatturato e il controllo sul reddito globale (_worldwide income_):
+
+- L'Amministrazione Fiscale (DJP) ha ampliato la collaborazione nell'interscambio automatico di informazioni finanziarie (AEOI) per tracciare gli asset e i redditi dei cittadini stranieri all'estero.
+- L'aggregazione del fatturato si applica ai gruppi di aziende affiliate per prevenire la frammentazione aziendale (_split-up_) solo per godere di aliquote fiscali basse.
+
+<InfoCard variant="warning" title="Importante: Status di Residenza Fiscale e Trattato Fiscale">
+
+Va notato che l'applicazione di queste regole di aggregazione non si applica automaticamente a tutti i cittadini stranieri. Lo status fiscale di una persona — se è diventato Soggetto di Imposta Interno (SPDN) o mantiene lo status di Soggetto di Imposta Estero (SPLN) — determina se il suo reddito globale è incluso nel calcolo. Inoltre, il trattato per l'evitazione della doppia imposizione (tax treaty) tra Indonesia e il paese d'origine del cittadino straniero può offrire protezioni o esenzioni specifiche che devono essere verificate caso per caso. Se hai redditi all'estero e hai intenzione di stabilirti in Indonesia, consulta un consulente fiscale prima di fare qualsiasi ipotesi.
+
+</InfoCard>
+
+---
+
+### 3. Disposizioni sulle Spese di Intrattenimento e Anticorruzione (Articolo 20A)
+
+L'Articolo 20A del PP 20/2026 chiarisce le regole sulle spese aziendali deducibili (_deductible expenses_) e non deducibili (_nondeductible expenses_):
+
+È importante capire che l'Articolo 20A non classifica automaticamente tutte le spese di intrattenimento come illegittime. La DJP può rifiutare la deduzione delle spese solo se vi sono indizi che i pagamenti siano correlati a tangenti, regali o mance. Nella pratica degli audit, il rischio di correzione fiscale per le PT PMA è più spesso scatenato dalla mancanza di documentazione aziendale sufficiente — assenza di contratti, prove di transazione o motivazioni commerciali chiare — e non solo dallo status di PT PMA. La mitigazione migliore: assicurati che ogni spesa di intrattenimento sia supportata da prove di transazione complete e da documentazione delle motivazioni commerciali verificabili.
+
+---
+
+### 4. Trasparenza della Proprietà Effettiva e Sostanza rispetto alla Forma
+
+La DJP sta ora applicando attivamente il principio di _substance over form_ (priorità alla sostanza economica rispetto alla forma legale). Questo ha impatti su:
+
+- Le società nominee o PT PMA passive senza attività operative reali (_shell companies_) sono vulnerabili a correzioni fiscali.
+- La dichiarazione della proprietà effettiva (_Beneficial Ownership_) è obbligatoria e sincronizzata con i dati del Ministero della Giustizia e del sistema CoreTax.
+
+---
+
+## Implicazioni Pratiche per le PT PMA e Misure di Mitigazione
+
+Per garantire la continuità operativa e evitare sanzioni amministrative o controlli fiscali, la gestione delle PT PMA è consigliata di adottare le seguenti misure:
+
+1. **Revisione dell'Architettura Fiscale**: Auditare la struttura dei redditi dell'azienda e assicurarsi che la classificazione tra IRPEF finale e IRPEF Articolo 17/23 sia corretta.
+2. **Completare l'Elenco Nominativo**: Tutte le spese di intrattenimento e rappresentanza devono essere accompagnate da un elenco nominativo che includa il nome del destinatario, l'importo e la motivazione commerciale.
+3. **Validare lo Status di Residenza Fiscale**: Confermare lo status di SPDN vs. SPLN per i direttori e gli azionisti stranieri e studiare i benefici del trattato fiscale applicabile.
+4. **Preparazione della Contabilità in CoreTax**: Assicurarsi che tutti i bilanci siano ben organizzati secondo gli standard contabili indonesiani (SAK) per l'integrazione in CoreTax.
+
+---
+
+<ArticleClusterCTA slug="pp-20-2026-perubahan-investor-asing-indonesia" />
+
+## Note per il Team Surya
+
+**Stato: PARZIALMENTE VALIDATO — Angel (23 lug 2026)**
+
+- Q6 (Aggregazione del reddito globale): VALIDATO — non si applica automaticamente, richiede un'analisi dello status di residenza fiscale + trattato fiscale caso per caso
+- Q7 (Articolo 20A intrattenimento): VALIDATO — il rischio deriva dalla mancanza di documentazione aziendale, non dallo status di PT PMA
+
+⚠️ **Domande per la revisione regolamentare — OBBLIGATORIE prima della pubblicazione:**
+
+**Domande Critiche:**
+
+1. **Reddito Globale & SPDN**: Quali sono i criteri tecnici per stabilire i 183 giorni per i detentori di KITAS/KITAP a Bali che entrano ed escono frequentemente dall'Indonesia nel contesto del calcolo del reddito globale in CoreTax?
+2. **Elenco Nominativo Intrattenimento**: La DJP ha emesso un nuovo formato standard in CoreTax per allegare l'elenco nominativo delle spese di intrattenimento in base all'Articolo 20A?
+
+---
+
+_Hai bisogno di aiuto per valutare l'impatto del PP 20/2026 sulla tua PT PMA? Il Bali Zero Tax Desk è pronto a supportarti nel riorganizzare il rispetto delle norme e la contabilità fiscale della tua azienda. Contattaci via WhatsApp o chiedi direttamente a Zantara AI._
+
+<AskZantara
+  context="PP 20/2026, tasse PT PMA, investitori stranieri in Indonesia, reddito globale, intrattenimento Articolo 20A, CoreTax DJP"
+  placeholder="Chiedi l'impatto del PP 20/2026 sul tuo business..."
+  suggestedQuestions={[
+    "Come il PP 20/2026 influisce sull'aliquota fiscale della mia PT PMA?",
+    "Devo dichiarare i miei redditi all'estero alla DJP?",
+    "Quali sono i requisiti per poter richiedere la deduzione delle spese di intrattenimento?",
+    "Come Bali Zero supporta l'audit fiscale della PT PMA?",
+  ]}
+/>

--- a/apps/mouth/src/content/articles/tax/pph-final-umkm-profesi-khusus.id.mdx
+++ b/apps/mouth/src/content/articles/tax/pph-final-umkm-profesi-khusus.id.mdx
@@ -1,0 +1,305 @@
+---
+title: "PPh Final UMKM untuk Profesi Khusus: Pengacara, Dokter, Notaris — Siapa yang Bisa, Siapa yang Tidak"
+slug: "pph-final-umkm-profesi-khusus"
+description: "Apakah pengacara, dokter, atau notaris yang mendirikan PT Perorangan bisa pakai PPh Final UMKM 0.5%? Jawabannya tegas di PP 20/2026 — dan lebih kompleks dari yang disangka."
+excerpt: "Banyak profesional mendirikan PT Perorangan dengan harapan bisa bayar PPh Final UMKM 0.5%. PP 20/2026 mengatakan: tidak semua bisa. Ini peta lengkap siapa yang eligible, siapa yang tidak, dan apa konsekuensinya."
+category: "tax"
+tags:
+  - PPh Final UMKM
+  - profesi liberal
+  - PT Perorangan
+  - pajak pengacara
+  - pajak dokter
+  - pajak notaris
+  - PP 20/2026
+  - pekerjaan bebas
+publishedAt: "2026-07-22"
+updatedAt: "2026-07-22"
+author:
+  name: "Subhi Darajat"
+  avatar: "/static/team/subhi.jpg"
+  role: "Tax & Compliance Analyst"
+featured: false
+adversarial_review: "surya"
+readingTime: 12
+difficulty: "intermediate"
+aiGenerated: false
+tableOfContents: true
+relatedArticles:
+  - "pp-20-2026-who-keeps-the-05-tax-and-who-loses-it"
+  - "indonesia-umkm-tax-reforms-pp-20-2026"
+  - "freelancer-tax-guide"
+  - "tax-for-freelancers-indonesia-2026"
+seoTitle: "PPh Final UMKM Profesi Khusus: Pengacara, Dokter, Notaris Bisa?"
+seoDescription: "PP 20/2026 mempertegas: profesi bebas (pengacara, dokter, notaris) tidak bisa pakai PPh Final 0.5%. Pahami aturannya sebelum terlanjur salah lapor."
+faq:
+  - question: "Apakah dokter yang punya PT Perorangan bisa pakai PPh Final UMKM 0.5%?"
+    answer: "Tidak. Berdasarkan PP 20/2026, penghasilan dari praktik dokter dikategorikan sebagai pekerjaan bebas (pekerjaan bebas) yang secara eksplisit dikecualikan dari skema PPh Final UMKM 0.5%. Dokter wajib menggunakan tarif umum progresif Pasal 17 UU PPh, atau skema NPPN jika omzet di bawah IDR 4.8 miliar dan tidak menyelenggarakan pembukuan penuh."
+  - question: "Siapa saja profesi yang termasuk pekerjaan bebas dan tidak bisa pakai PPh Final UMKM?"
+    answer: "Berdasarkan PP 55/2022 yang dipertegas PP 20/2026: pengacara, dokter, notaris, PPAT, akuntan publik, arsitek, konsultan, aktuaris, penilai, pelatih, peneliti, seniman, influencer, content creator, agen asuransi, dan berbagai profesi independen lainnya. Semua wajib menggunakan mekanisme umum PPh."
+  - question: "Apakah ada cara legal agar profesional bisa bayar pajak lebih rendah dari 22%?"
+    answer: "Ya. Profesional dengan omzet di bawah IDR 4.8 miliar bisa menggunakan Norma Penghitungan Penghasilan Neto (NPPN), yang menerapkan persentase norma (berbeda per profesi, umumnya 30%-50% dari omzet bruto) sebagai pengganti pembukuan penuh. Hasil penghitungan neto kemudian dikenai tarif progresif Pasal 17, bukan 0.5% dari bruto."
+aiOptimization:
+  primaryQuestion: "Apakah pengacara, dokter, dan notaris bisa menggunakan PPh Final UMKM 0.5% di Indonesia?"
+  answerSnippet: "Tidak. Berdasarkan PP 20/2026 yang berlaku sejak 22 April 2026, penghasilan dari pekerjaan bebas — termasuk pengacara, dokter, notaris, akuntan, konsultan, arsitek, dan profesi independen lainnya — secara eksplisit dikecualikan dari skema PPh Final UMKM 0.5%. Profesi-profesi ini wajib menggunakan tarif progresif Pasal 17 UU PPh atau skema Norma Penghitungan Penghasilan Neto (NPPN)."
+  entityMentions:
+    - type: "Regulation"
+      name: "Peraturan Pemerintah Nomor 20 Tahun 2026 (PP 20/2026)"
+    - type: "Regulation"
+      name: "Peraturan Pemerintah Nomor 55 Tahun 2022 (PP 55/2022)"
+    - type: "GovernmentOrganization"
+      name: "Direktorat Jenderal Pajak (DJP)"
+canonicalUrl: "https://balizero.com/tax/pph-final-umkm-profesi-khusus"
+ogType: "article"
+twitterCard: "summary_large_image"
+contentStructure:
+  hasFAQ: true
+  hasTable: true
+locale: "id"
+---
+import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
+import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+import {
+  KeyTakeaway,
+  InfoCard,
+  AskZantara,
+} from "@/components/blog/interactive";
+
+# PPh Final UMKM untuk Profesi Khusus: Pengacara, Dokter, Notaris — Siapa yang Bisa, Siapa yang Tidak
+
+<KeyTakeaway>
+  **Jawaban singkat:** Profesi bebas — pengacara, dokter, notaris, konsultan,
+  akuntan, arsitek, dan puluhan profesi independen lainnya — **tidak bisa**
+  menggunakan PPh Final UMKM 0.5%, bahkan jika omzet di bawah IDR 4.8 miliar dan
+  sudah mendirikan PT Perorangan. PP 20/2026 (berlaku 22 April 2026) mempertegas
+  pengecualian ini. Mekanisme yang berlaku: tarif progresif Pasal 17 UU PPh,
+  atau NPPN jika tidak menyelenggarakan pembukuan penuh.
+</KeyTakeaway>
+
+<HeaderWhatsAppCTA />
+
+---
+
+## Mengapa Ini Masalah Sekarang
+
+Selama beberapa tahun terakhir, ada pola yang berkembang di kalangan profesional — pengacara, dokter spesialis, notaris, konsultan manajemen — yang mendirikan **PT Perorangan** dengan satu tujuan sederhana: mengakses PPh Final UMKM tarif 0.5%.
+
+Logikanya terdengar masuk akal. PT Perorangan adalah badan hukum yang sah sejak UU Cipta Kerja 2020. Jika PT biasa bisa masuk skema UMKM, kenapa PT Perorangan milik dokter tidak?
+
+**Jawabannya ada pada PP 20/2026** — yang secara eksplisit mempertegas bahwa bukan _bentuk badan hukumnya_ yang menentukan eligibilitas, melainkan _jenis penghasilan_ yang dihasilkan. Dan penghasilan dari pekerjaan bebas (_pekerjaan bebas_) tidak pernah masuk dalam cakupan skema PPh Final UMKM — bukan sejak PP 20/2026, melainkan sejak regulasi ini dibuat.
+
+Yang berubah adalah: DJP sekarang punya sistem untuk mendeteksinya.
+
+---
+
+## Apa Itu "Pekerjaan Bebas" Menurut DJP?
+
+Sebelum membahas siapa yang tidak bisa pakai skema UMKM, penting memahami definisi hukumnya. **Pekerjaan bebas** (independent professional work) didefinisikan sebagai:
+
+> _Pekerjaan yang dilakukan oleh orang pribadi yang mempunyai keahlian khusus sebagai usaha untuk memperoleh penghasilan yang tidak terikat oleh suatu hubungan kerja._
+
+Kata kuncinya: **keahlian khusus** + **tidak terikat hubungan kerja**. Ini yang membedakan profesional dari pedagang atau pengusaha UMKM biasa.
+
+---
+
+## Peta Profesi: Bisa, Tidak Bisa, dan Abu-Abu
+
+### Profesi yang TIDAK Bisa Menggunakan PPh Final UMKM
+
+Berdasarkan PP 55/2022 Pasal 56 yang dipertegas PP 20/2026, daftar profesi berikut dikecualikan secara eksplisit dari skema 0.5%:
+
+| Kategori                      | Profesi                                                                    |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| **Tenaga Ahli Hukum**         | Pengacara, Notaris, PPAT, Pejabat Lelang                                   |
+| **Tenaga Medis**              | Dokter umum, Dokter spesialis, Dokter gigi, Bidan, Fisioterapis            |
+| **Tenaga Keuangan**           | Akuntan publik, Konsultan pajak, Aktuaris, Penilai (Appraiser)             |
+| **Profesional Teknis**        | Arsitek, Insinyur konsultan, Konsultan manajemen                           |
+| **Profesi Kreatif & Digital** | Influencer, Content creator, Blogger, Vlogger, Selebgram                   |
+| **Profesi Seni & Hiburan**    | Penyanyi, Pemain film, Sutradara, Model, Pembawa acara                     |
+| **Lainnya**                   | Peneliti, Pengarang, Penerjemah, Atlet profesional, Agen asuransi, Pelatih |
+
+<InfoCard variant="warning" title="Jebakan Umum: PT Perorangan Tidak Mengubah Jenis Penghasilan">
+
+Mendirikan PT Perorangan tidak mengubah klasifikasi penghasilan Anda. Jika
+Anda seorang dokter yang membuka klinik melalui PT Perorangan, penghasilan
+dari praktik medis tetap diklasifikasikan sebagai penghasilan pekerjaan bebas
+— bukan penghasilan usaha UMKM. Bentuk badan hukumnya tidak relevan; yang
+relevan adalah _nature_ dari kegiatan yang menghasilkan penghasilan tersebut.
+
+</InfoCard>
+
+Pertanyaan yang semakin sering muncul di lapangan: bagaimana jika seorang WNA influencer mendirikan PT PMA untuk menagih invoice atas namanya? Apakah DJP bisa menembus struktur korporasi ini? Hingga pertengahan 2026, belum terdapat preseden kasus yang terdokumentasi di Indonesia. Namun PP 20/2026 memperluas kewenangan DJP untuk menerapkan prinsip substance over form — jika tidak ada aktivitas bisnis nyata yang membedakan PT dari aktivitas personal pemiliknya, risiko koreksi fiskal tetap ada dan terus berkembang.
+
+### Siapa yang BISA Menggunakan PPh Final UMKM 0.5%?
+
+Setelah PP 20/2026, skema ini hanya tersedia untuk:
+
+1. **Wajib Pajak Orang Pribadi** — pelaku usaha (pedagang, pengusaha, produsen) dengan omzet ≤ IDR 4.8 miliar per tahun dan bukan dari pekerjaan bebas
+2. **PT Perorangan** — jika kegiatan usahanya adalah usaha (bukan praktik profesi), omzet ≤ IDR 4.8 miliar, dan sudah terdaftar menggunakan skema ini
+3. **Koperasi** — dengan masa transisi 4 tahun
+
+**Individu** mendapat keistimewaan tambahan: tidak ada batas waktu penggunaan skema (PP 20/2026 menghapus batas 7 tahun yang ada di PP 55/2022), plus exemption IDR 500 juta pertama dari omzet tahunan dikenai tarif **nol persen**.
+
+### Kewajiban Pelaporan Bulanan: Bukan Hanya Soal Profit
+
+Satu asumsi keliru yang sering muncul: PT PMA baru yang sedang merugi mengira tidak ada kewajiban lapor bulanan. Ini tidak tepat. Kewajiban menyampaikan SPT Masa tetap melekat selama terdapat transaksi yang mengandung unsur pajak, terlepas dari kondisi laba atau rugi perusahaan.
+
+Transaksi yang memicu kewajiban lapor SPT Masa antara lain:
+
+- Pembayaran gaji atau honor kepada karyawan → PPh Pasal 21
+- Penggunaan jasa dari perusahaan atau vendor lain → PPh Pasal 23
+- Pembayaran sewa ruang kantor, gudang, atau properti → PPh Pasal 4 ayat (2)
+
+SPT Masa berstatus nihil hanya berlaku jika dalam bulan tersebut benar-benar tidak ada satu pun transaksi yang mengandung unsur pemotongan atau pemungutan pajak.
+
+### Zona Abu-Abu: Case-by-Case
+
+Beberapa profesi berada di posisi yang memerlukan analisis lebih mendalam:
+
+- **Praktisi kesehatan yang menjalankan klinik / apotek sebagai usaha** (bukan praktik pribadi): perlu ditelaah apakah penghasilan dominannya dari "usaha" atau dari "layanan profesional langsung"
+- **Konsultan yang memiliki tim dan model bisnis B2B sistematis**: mungkin bisa diargumentasikan sebagai usaha, bukan pekerjaan bebas — tetapi memerlukan pendapat tertulis dari konsultan pajak terdaftar
+- **Akuntan yang menjalankan firma akuntansi dengan multiple karyawan**: berbeda dari akuntan publik yang praktik sendiri
+
+<InfoCard variant="note" title="[PERLU VALIDASI SURYA]">
+
+Apakah DJP telah mengeluarkan Keputusan atau Surat Edaran yang secara spesifik
+mengklasifikasikan profesi-profesi "zona abu-abu" ini? Dokumen KMK 202/2022
+yang disebutkan dalam brief perlu dikonfirmasi — pencarian publik tidak
+menghasilkan referensi konkret terhadap regulasi ini. Mohon verifikasi apakah
+ada keputusan DJP internal atau publikasi resmi yang lebih spesifik tentang
+eligible professions selain daftar PP 55/2022 Pasal 56.
+
+</InfoCard>
+
+---
+
+## Jika Tidak Bisa PPh Final: Apa Mekanisme Alternatifnya?
+
+Bukan berarti profesional harus langsung membayar 22%. Ada dua mekanisme yang tersedia, tergantung omzet dan kapasitas administrasi.
+
+### Opsi 1: Norma Penghitungan Penghasilan Neto (NPPN)
+
+Ini opsi yang paling relevan untuk profesional dengan omzet di bawah IDR 4.8 miliar yang tidak ingin (atau tidak mampu) menyelenggarakan pembukuan lengkap.
+
+Cara kerjanya:
+
+- DJP menetapkan **persentase norma** untuk setiap jenis profesi
+- Omzet bruto × persentase norma = penghasilan neto yang dianggap
+- Penghasilan neto dikurangi PTKP, lalu dikenai tarif progresif Pasal 17
+
+Persentase norma tiap profesi ditetapkan dalam Peraturan DJP (terakhir diperbarui dalam PMK 450/KMK.04/1997 dan perubahan-perubahannya — **[PERLU VALIDASI SURYA]: konfirmasi apakah ada perubahan norma terbaru 2025/2026**):
+
+| Profesi             | Norma (%) | Catatan                               |
+| ------------------- | --------- | ------------------------------------- |
+| Dokter              | 40%-50%   | Tergantung lokasi dan spesialisasi    |
+| Pengacara / Notaris | 50%       | Kota besar; lebih rendah di kabupaten |
+| Akuntan / Konsultan | 40%       | Profesi keuangan                      |
+| Arsitek             | 40%       | Jasa teknis                           |
+
+**Syarat NPPN:** Omzet bruto < IDR 4.8 miliar per tahun, dan harus memberitahukan ke KPP paling lambat 3 bulan pertama tahun pajak.
+
+### Opsi 2: Pembukuan + Tarif Progresif (Pasal 17 UU HPP)
+
+Bagi profesional dengan omzet lebih besar atau yang ingin mengklaim pengeluaran nyata sebagai pengurang:
+
+| Lapisan Penghasilan Kena Pajak | Tarif |
+| ------------------------------ | ----- |
+| 0 – IDR 60 juta                | 5%    |
+| IDR 60 juta – IDR 250 juta     | 15%   |
+| IDR 250 juta – IDR 500 juta    | 25%   |
+| IDR 500 juta – IDR 5 miliar    | 30%   |
+| Di atas IDR 5 miliar           | 35%   |
+
+Dengan pembukuan penuh, semua biaya yang secara nyata dikeluarkan untuk menghasilkan penghasilan dapat dikurangkan — sewa tempat praktik, alat medis, gaji staf, asuransi, dll.
+
+---
+
+## Risiko Jika Salah Klasifikasi
+
+Ini bagian yang paling kritis untuk dipahami. Kesalahan klasifikasi — profesional yang menggunakan PPh Final UMKM padahal seharusnya tidak bisa — bukan hanya masalah _kurang bayar_ yang bisa dikoreksi. Ini berpotensi menjadi:
+
+### Skenario Self-Correction (Pembetulan SPT)
+
+Jika Wajib Pajak sendiri yang menyadari dan melaporkan sebelum ada pemeriksaan:
+
+- Bayar kekurangan pajak + sanksi bunga 2% per bulan (dihitung dari tanggal jatuh tempo asli)
+- Tidak ada sanksi pidana, selama ini bukan fraud yang disengaja dan sistemik
+
+### Skenario Audit (Pemeriksaan DJP)
+
+CoreTax sekarang memiliki kemampuan cross-referencing otomatis. Jika data DJP mendeteksi:
+
+- Penghasilan dari sumber yang terklasifikasi sebagai jasa profesi (misalnya: Bukti Potong PPh 21 dari klien dengan kode "tenaga ahli")
+- Tapi SPT melaporkan sebagai PPh Final UMKM 0.5%
+
+Maka risiko meningkat ke **Surat Pemberitahuan Pemeriksaan** (SP2). Konsekuensi:
+
+- Kekurangan pajak + sanksi 50% (kenaikan) dari jumlah yang kurang dibayar
+- Bunga 2% per bulan
+- Dalam kasus fraud yang dibuktikan: sanksi pidana Pasal 39 UU KUP
+
+<InfoCard variant="warning" title="CoreTax + Coretax = Deteksi Makin Akurat">
+
+Integrasi CoreTax dengan e-Bupot membuat DJP dapat langsung mencocokkan Bukti
+Potong PPh 21 yang dikeluarkan klien Anda (dengan kode "bukan pegawai / tenaga
+ahli") dengan SPT yang Anda laporkan. Jika ada mismatch antara kode penghasilan
+dan metode perhitungan pajak, sistem akan memflag otomatis. Era di mana
+kesalahan klasifikasi tidak terdeteksi sudah berakhir.
+
+</InfoCard>
+
+---
+
+## Langkah Konkret untuk Profesional
+
+Jika Anda seorang pengacara, dokter, notaris, atau profesional lain yang selama ini menggunakan (atau berencana menggunakan) PPh Final UMKM:
+
+1. **Audit status saat ini**: Periksa metode pelaporan pajak 3 tahun terakhir. Apakah ada SPT yang melaporkan penghasilan profesi sebagai PPh Final UMKM?
+
+2. **Tentukan omzet bruto**: Di bawah IDR 4.8 miliar? NPPN adalah opsi realistis. Di atas? Pembukuan penuh jadi satu-satunya pilihan.
+
+3. **Pilih mekanisme perpajakan**: NPPN (lebih sederhana) vs. pembukuan penuh (lebih efisien jika biaya nyata besar). Ini keputusan permanen sampai ada perubahan kondisi.
+
+4. **Daftarkan NPPN ke KPP** (jika memilih opsi ini): Notifikasi tertulis harus disampaikan paling lambat 3 bulan pertama tahun pajak. Lewat dari itu, wajib pembukuan penuh untuk tahun tersebut.
+
+5. **Konsultasi pembetulan SPT**: Jika ada SPT yang perlu dikoreksi, lakukan sesegera mungkin. Self-correction jauh lebih murah dari konsekuensi audit.
+
+---
+
+<ArticleClusterCTA slug="pph-final-umkm-profesi-khusus" />
+
+## Catatan untuk Tim Surya
+
+**Status: PARTIALLY VALIDATED — Angel (23 Jul 2026)**
+
+- Q4 (SPT Masa PT PMA merugi): VALIDATED — wajib lapor jika ada transaksi PPh 21/23/4(2)
+- Q5 (Influencer corporate veil): UNRESOLVED — belum ada preseden di lapangan, tulis sebagai risiko berkembang
+
+⚠️ **Questions for regulatory review — WAJIB sebelum publikasi:**
+
+**Pertanyaan Kritis:**
+
+1. **KMK 202/2022**: Brief menyebut dokumen ini sebagai sumber daftar profesi eligible. Penelusuran publik tidak menemukan referensi yang konkret terhadap KMK bernomor ini. Mohon konfirmasi: apakah dokumen ini exist? Atau apakah yang dimaksud adalah regulasi lain (misalnya Perdirjen atau PMK lainnya) yang mengatur daftar profesi pekerjaan bebas?
+
+2. **SE-14/PJ/2021**: Brief juga menyebut surat edaran ini. Pencarian tidak menemukan kaitan langsung antara SE-14/PJ/2021 dengan PPh Final UMKM — yang ditemukan adalah PER-14/PJ/2021 (tentang SKP). Konfirmasi: apakah nomor SE ini benar? Atau ada SE lain yang lebih relevan?
+
+3. **Persentase Norma Terbaru**: Tabel NPPN dalam artikel menggunakan referensi lama (PMK 450/KMK.04/1997). Apakah ada pembaruan norma per 2025/2026 yang perlu menggantikan angka ini?
+
+4. **Zona Abu-Abu Klinik**: Apakah ada keputusan DJP yang mengklasifikasikan dokter yang menjalankan klinik (bukan praktik pribadi, dengan karyawan) sebagai "usaha" vs. "pekerjaan bebas"? Evidence internal atau BKPM?
+
+5. **Praktisi Kesehatan Lain**: Brief menyebutkan "praktisi kesehatan (dokter gigi, fisioterapi, dll) — termasuk" sebagai yang bisa PPh Final. Ini **bertentangan** dengan temuan research yang memasukkan semua tenaga medis dalam daftar pekerjaan bebas. Mohon klarifikasi: apakah ada subdivisi di dalam kategori tenaga medis yang masih bisa PPh Final UMKM?
+
+---
+
+_Profesi Anda masuk kategori mana? Bali Zero Tax Desk melakukan analisis klasifikasi penghasilan — termasuk review historis SPT dan rekomendasi metode ke depan. Hubungi kami via WhatsApp atau tanya Zantara AI._
+
+<AskZantara
+  context="PPh Final UMKM, profesi bebas, PP 20/2026, pekerjaan bebas, NPPN, tarif progresif pajak Indonesia"
+  placeholder="Tanyakan soal pajak untuk profesi Anda..."
+  suggestedQuestions={[
+    "Apakah dokter yang punya klinik bisa pakai PPh Final UMKM?",
+    "Bagaimana cara menghitung pajak dengan NPPN untuk notaris?",
+    "Saya salah lapor PPh Final selama 2 tahun, apa yang harus dilakukan?",
+    "Apakah PT Perorangan untuk profesi konsultan bisa akses skema UMKM?",
+  ]}
+/>

--- a/apps/mouth/src/content/articles/tax/pph-final-umkm-profesi-khusus.it.mdx
+++ b/apps/mouth/src/content/articles/tax/pph-final-umkm-profesi-khusus.it.mdx
@@ -1,0 +1,302 @@
+---
+title: "PPh Final UMKM untuk Profesi Khusus: Pengacara, Dokter, Notaris — Siapa yang Bisa, Siapa yang Tidak"
+slug: "pph-final-umkm-profesi-khusus"
+description: "Apakah pengacara, dokter, atau notaris yang mendirikan PT Perorangan bisa pakai PPh Final UMKM 0.5%? Jawabannya tegas di PP 20/2026 — dan lebih kompleks dari yang disangka."
+excerpt: "Banyak profesional mendirikan PT Perorangan dengan harapan bisa bayar PPh Final UMKM 0.5%. PP 20/2026 mengatakan: tidak semua bisa. Ini peta lengkap siapa yang eligible, siapa yang tidak, dan apa konsekuensinya."
+category: "tax"
+tags:
+  - PPh Final UMKM
+  - profesi liberal
+  - PT Perorangan
+  - pajak pengacara
+  - pajak dokter
+  - pajak notaris
+  - PP 20/2026
+  - pekerjaan bebas
+publishedAt: "2026-07-22"
+updatedAt: "2026-07-22"
+author:
+  name: "Subhi Darajat"
+  avatar: "/static/team/subhi.jpg"
+  role: "Tax & Compliance Analyst"
+featured: false
+adversarial_review: "surya"
+readingTime: 12
+difficulty: "intermediate"
+aiGenerated: false
+tableOfContents: true
+relatedArticles:
+  - "pp-20-2026-who-keeps-the-05-tax-and-who-loses-it"
+  - "indonesia-umkm-tax-reforms-pp-20-2026"
+  - "freelancer-tax-guide"
+  - "tax-for-freelancers-indonesia-2026"
+seoTitle: "PPh Final UMKM Profesi Khusus: Pengacara, Dokter, Notaris Bisa?"
+seoDescription: "PP 20/2026 mempertegas: profesi bebas (pengacara, dokter, notaris) tidak bisa pakai PPh Final 0.5%. Pahami aturannya sebelum terlanjur salah lapor."
+faq:
+  - question: "Apakah dokter yang punya PT Perorangan bisa pakai PPh Final UMKM 0.5%?"
+    answer: "Tidak. Berdasarkan PP 20/2026, penghasilan dari praktik dokter dikategorikan sebagai pekerjaan bebas (pekerjaan bebas) yang secara eksplisit dikecualikan dari skema PPh Final UMKM 0.5%. Dokter wajib menggunakan tarif umum progresif Pasal 17 UU PPh, atau skema NPPN jika omzet di bawah IDR 4.8 miliar dan tidak menyelenggarakan pembukuan penuh."
+  - question: "Siapa saja profesi yang termasuk pekerjaan bebas dan tidak bisa pakai PPh Final UMKM?"
+    answer: "Berdasarkan PP 55/2022 yang dipertegas PP 20/2026: pengacara, dokter, notaris, PPAT, akuntan publik, arsitek, konsultan, aktuaris, penilai, pelatih, peneliti, seniman, influencer, content creator, agen asuransi, dan berbagai profesi independen lainnya. Semua wajib menggunakan mekanisme umum PPh."
+  - question: "Apakah ada cara legal agar profesional bisa bayar pajak lebih rendah dari 22%?"
+    answer: "Ya. Profesional dengan omzet di bawah IDR 4.8 miliar bisa menggunakan Norma Penghitungan Penghasilan Neto (NPPN), yang menerapkan persentase norma (berbeda per profesi, umumnya 30%-50% dari omzet bruto) sebagai pengganti pembukuan penuh. Hasil penghitungan neto kemudian dikenai tarif progresif Pasal 17, bukan 0.5% dari bruto."
+aiOptimization:
+  primaryQuestion: "Apakah pengacara, dokter, dan notaris bisa menggunakan PPh Final UMKM 0.5% di Indonesia?"
+  answerSnippet: "Tidak. Berdasarkan PP 20/2026 yang berlaku sejak 22 April 2026, penghasilan dari pekerjaan bebas — termasuk pengacara, dokter, notaris, akuntan, konsultan, arsitek, dan profesi independen lainnya — secara eksplisit dikecualikan dari skema PPh Final UMKM 0.5%. Profesi-profesi ini wajib menggunakan tarif progresif Pasal 17 UU PPh atau skema Norma Penghitungan Penghasilan Neto (NPPN)."
+  entityMentions:
+    - type: "Regulation"
+      name: "Peraturan Pemerintah Nomor 20 Tahun 2026 (PP 20/2026)"
+    - type: "Regulation"
+      name: "Peraturan Pemerintah Nomor 55 Tahun 2022 (PP 55/2022)"
+    - type: "GovernmentOrganization"
+      name: "Direktorat Jenderal Pajak (DJP)"
+canonicalUrl: "https://balizero.com/tax/pph-final-umkm-profesi-khusus"
+ogType: "article"
+twitterCard: "summary_large_image"
+contentStructure:
+  hasFAQ: true
+  hasTable: true
+locale: "it"
+---
+import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
+import { ArticleClusterCTA } from "@/components/blog/ArticleClusterCTA";
+import {
+  KeyTakeaway,
+  InfoCard,
+  AskZantara,
+} from "@/components/blog/interactive";
+
+# PPh Final UMKM per professioni specializzate: Avvocati, Medici, Notai — Chi può e chi non può
+
+<KeyTakeaway>
+  **Risposta breve:** Le professioni libera — avvocati, medici, notai, consulenti,
+  contabili, architetti e decine di altre professioni indipendenti — **non possono**
+  utilizzare il PPh Final UMKM al 0,5%, anche se il fatturato è inferiore a IDR 4,8 miliardi e
+  hanno già costituito una PT Perorangan. Il PP 20/2026 (valido dal 22 aprile 2026) conferma
+  questa esclusione. Il meccanismo applicabile: l'aliquota progressiva dell'Articolo 17 della Legge sul PPh,
+  o NPPN se non si tiene una contabilità completa.
+</KeyTakeaway>
+
+<HeaderWhatsAppCTA />
+
+---
+
+## Perché è un problema ora
+
+Negli ultimi anni, è emerso un modello tra i professionisti — avvocati, medici specializzati, notai, consulenti di management — che costituiscono una **PT Perorangan** con un obiettivo semplice: accedere al PPh Final UMKM al tasso del 0,5%.
+
+La logica sembra plausibile. La PT Perorangan è un'entità giuridica legittima dal 2020 con la Legge Omnibus. Se una PT normale può rientrare nello schema UMKM, perché una PT Perorangan di un medico no?
+
+**La risposta sta nel PP 20/2026** — che chiarisce esplicitamente che non è la _forma giuridica_ a determinare l'idoneità, ma il _tipo di reddito_ generato. E il reddito da lavoro autonomo (_lavoro autonomo_) non è mai stato incluso nello schema PPh Final UMKM — non da quando è stato introdotto, ma da quando il PP 20/2026 lo ha confermato.
+
+Ciò che è cambiato è: la DJP ora ha un sistema per rilevarlo.
+
+---
+
+## Cos'è il "lavoro autonomo" secondo la DJP?
+
+Prima di discutere chi non può utilizzare lo schema UMKM, è importante comprendere la definizione legale. Il **lavoro autonomo** (lavoro professionale indipendente) è definito come:
+
+> _Lavoro svolto da una persona fisica che possiede una competenza specifica come attività per ottenere un reddito non vincolato da un rapporto di lavoro._
+
+Le parole chiave: **competenza specifica** + **non vincolato da un rapporto di lavoro**. Questo è ciò che distingue i professionisti dagli imprenditori o commercianti UMKM comuni.
+
+---
+
+## Mappa delle professioni: Chi può, chi non può e la zona grigia
+
+### Professioni che NON possono utilizzare il PPh Final UMKM
+
+Secondo l'Articolo 56 del PP 55/2022, rafforzato dal PP 20/2026, le seguenti professioni sono esplicitamente escluse dallo schema al 0,5%:
+
+| Categoria                      | Professioni                                                                    |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| **Personale giuridico**         | Avvocati, Notai, PPAT, Incaricati di asta                                   |
+| **Personale medico**            | Medici generali, Medici specializzati, Odontoiatri, Ostetrici, Fisioterapisti |
+| **Personale finanziario**       | Contabili pubblici, Consulenti fiscali, Attuari, Valutatori (Appraiser)      |
+| **Professionisti tecnici**      | Architetti, Ingegneri consulenti, Consulenti di management                   |
+| **Professioni creative e digitali** | Influencer, Content creator, Blogger, Vlogger, Selebgram                   |
+| **Professioni artistiche e di intrattenimento** | Cantanti, Attori, Registi, Modelli, Presentatori                     |
+| **Altri**                       | Ricercatori, Scrittori, Traduttori, Atleti professionisti, Agenti assicurativi, Allenatori |
+
+<InfoCard variant="warning" title="Trappola comune: una PT Perorangan non cambia il tipo di reddito">
+
+Costituire una PT Perorangan non cambia la classificazione del tuo reddito. Se
+sei un medico che apre un ambulatorio attraverso una PT Perorangan, il reddito
+dalla pratica medica rimane classificato come reddito da lavoro autonomo
+— non come reddito d'impresa UMKM. La forma giuridica non è rilevante; ciò
+che è rilevante è la _natura_ dell'attività che genera il reddito.
+
+</InfoCard>
+
+Una domanda sempre più frequente in campo: cosa succede se un influencer straniero costituisce una PT PMA per emettere fatture a suo nome? La DJP può superare questa struttura societaria? Fino a metà 2026, non esistono precedenti documentati in Indonesia. Tuttavia, il PP 20/2026 amplia i poteri della DJP per applicare il principio di sostanza su forma — se non esiste un'attività d'impresa reale che distingua la PT dalle attività personali del proprietario, il rischio di correzione fiscale rimane e continua a evolversi.
+
+### Chi può utilizzare il PPh Final UMKM 0,5%?
+
+Dopo il PP 20/2026, questo schema è disponibile solo per:
+
+1. **Soggetti passivi fisiche** — imprenditori (commercianti, imprenditori, produttori) con un fatturato ≤ IDR 4,8 miliardi all'anno e non da lavoro autonomo
+2. **PT Perorangan** — se l'attività è un'impresa (non una pratica professionale), con un fatturato ≤ IDR 4,8 miliardi, e registrata con questo schema
+3. **Cooperative** — con un periodo transitorio di 4 anni
+
+**I singoli** hanno un vantaggio aggiuntivo: non c'è un limite di tempo per l'utilizzo dello schema (il PP 20/2026 ha eliminato il limite di 7 anni presente nel PP 55/2022), più un'esenzione di IDR 500 milioni del primo fatturato annuo tassato al **tasso zero**.
+
+### Obblighi di dichiarazione mensile: Non solo profitto
+
+Un falso mito comune: una nuova PT PMA in perdita pensa di non avere obblighi di dichiarazione mensile. Questo non è corretto. L'obbligo di presentare la SPT Masa rimane attivo fintanto che esistono transazioni che contengono elementi di imposta, indipendentemente dallo stato di profitto o perdita dell'azienda.
+
+Le transazioni che attivano l'obbligo di dichiarazione SPT Masa includono:
+
+- Pagamento di stipendi o honorari ai dipendenti → PPh Articolo 21
+- Utilizzo di servizi da altre aziende o fornitori → PPh Articolo 23
+- Pagamento di affitti per uffici, magazzini o proprietà → PPh Articolo 4 comma (2)
+
+La SPT Masa a zero è valida solo se nel mese non è avvenuta alcuna transazione che contenga elementi di ritenuta o di riscossione di imposta.
+
+### Zona grigia: Caso per caso
+
+Alcune professioni si trovano in una posizione che richiede un'analisi più approfondita:
+
+- **Operatori sanitari che gestiscono un ambulatorio / farmacia come impresa** (non come pratica personale): è necessario verificare se il reddito principale proviene da "impresa" o da "servizio professionale diretto"
+- **Consulenti che hanno un team e un modello d'affari B2B sistematico**: potrebbe essere argomentato come impresa, non come lavoro autonomo — ma richiede un parere scritto da un consulente fiscale registrato
+- **Contabili che gestiscono uno studio contabile con diversi dipendenti**: diverso da un contabile pubblico che lavora da solo
+
+<InfoCard variant="note" title="[NECESSARIA VALIDAZIONE SURYA]">
+
+La DJP ha emesso un Decreto o una Circolare che classifica specificamente queste professioni "in zona grigia"? Il documento KMK 202/2022
+menzionato nella sintesi deve essere verificato — la ricerca pubblica non
+ha prodotto riferimenti concreti a questa regolamentazione. Si prega di verificare se
+esiste un decreto interno della DJP o una pubblicazione ufficiale più specifica sui
+professi eleggibili oltre all'elenco dell'Articolo 56 del PP 55/2022.
+
+</InfoCard>
+
+---
+
+## Se non si può usare il PPh Final: Quali sono le alternative?
+
+Non significa che i professionisti debbano pagare il 22% immediatamente. Sono disponibili due meccanismi, a seconda del fatturato e della capacità amministrativa.
+
+### Opzione 1: Norma di Calcolo del Reddito Netto (NPPN)
+
+Questa opzione è più rilevante per i professionisti con un fatturato inferiore a IDR 4,8 miliardi che non vogliono (o non possono) tenere una contabilità completa.
+
+Come funziona:
+
+- La DJP stabilisce una **percentuale normativa** per ogni tipo di professione
+- Fatturato lordo × percentuale normativa = reddito netto presunto
+- Il reddito netto viene sottratto dal PTKP, quindi applicato l'aliquota progressiva dell'Articolo 17
+
+Le percentuali normative per ogni professione sono stabilite nelle regolamentazioni della DJP (ultima aggiornata nel PMK 450/KMK.04/1997 e successive modifiche — **[NECESSARIA VALIDAZIONE SURYA]: confermare se ci sono aggiornamenti normativi nel 2025/2026**):
+
+| Professione             | Norma (%) | Note                               |
+| ------------------- | --------- | ------------------------------------- |
+| Medico              | 40%-50%   | Dipende dalla località e specializzazione    |
+| Avvocato / Notaio | 50%       | Città grandi; più basso nei distretti |
+| Contabile / Consulente | 40%       | Professioni finanziarie                      |
+| Architetto             | 40%       | Servizi tecnici                           |
+
+**Requisiti NPPN:** Fatturato lordo < IDR 4,8 miliardi all'anno, e deve essere notificato all'Ufficio delle Tasse entro i primi 3 mesi dell'anno fiscale.
+
+### Opzione 2: Contabilità + Aliquota Progressiva (Articolo 17 Legge sul PPh)
+
+Per i professionisti con un fatturato più grande o che vogliono richiedere spese reali come deduzioni:
+
+| Strato di Reddito Imponibile | Aliquota |
+| ------------------------------ | ----- |
+| 0 – IDR 60 milioni                | 5%    |
+| IDR 60 milioni – IDR 250 milioni     | 15%   |
+| IDR 250 milioni – IDR 500 milioni    | 25%   |
+| IDR 500 milioni – IDR 5 miliardi    | 30%   |
+| Oltre IDR 5 miliardi           | 35%   |
+
+Con una contabilità completa, tutte le spese effettivamente sostenute per generare reddito possono essere dedotte — affitto dello studio, attrezzature mediche, stipendi del personale, assicurazioni, ecc.
+
+---
+
+## Rischi di una classificazione errata
+
+Questa è la parte più critica da comprendere. Un errore di classificazione — un professionista che utilizza il PPh Final UMKM quando non dovrebbe — non è solo un problema di _pagamento insufficiente_ che può essere corretto. Potrebbe diventare:
+
+### Scenario di Autocorrezione (Correzione della Dichiarazione)
+
+Se il Soggetto Passivo si rende conto da solo e dichiara prima di un'ispezione:
+
+- Pagare l'importo mancante + sanzione di interesse del 2% al mese (calcolato dalla data di scadenza originale)
+- Nessuna sanzione penale, purché non si tratti di frode intenzionale e sistematica
+
+### Scenario di Audit (Ispezione della DJP)
+
+CoreTax ora ha la capacità di cross-referencing automatico. Se i dati della DJP rilevano:
+
+- Reddito da una fonte classificata come servizio professionale (ad esempio: Certificato di Ritenuta PPh 21 dal cliente con codice "personale qualificato")
+- Ma la dichiarazione presenta come PPh Final UMKM 0,5%
+
+Allora il rischio aumenta a una **Notifica di Ispezione** (SP2). Conseguenze:
+
+- Reddito mancante + sanzione del 50% (aumento) dell'importo non pagato
+- Interesse del 2% al mese
+- In caso di frode provata: sanzione penale Articolo 39 Legge sul PPh
+
+<InfoCard variant="warning" title="CoreTax + Coretax = Rilevazione sempre più precisa">
+
+L'integrazione di CoreTax con e-Bupot permette alla DJP di confrontare direttamente i Certificati di Ritenuta PPh 21 emessi dai tuoi clienti (con codice "non dipendente / personale qualificato") con la dichiarazione che hai presentato. Se c'è un mismatch tra il codice del reddito
+e il metodo di calcolo delle tasse, il sistema lo segnalerà automaticamente. L'epoca in cui
+gli errori di classificazione non venivano rilevati è finita.
+
+</InfoCard>
+
+---
+
+## Passi concreti per i professionisti
+
+Se sei un avvocato, un medico, un notaio o un altro professionista che ha utilizzato (o pianifica di utilizzare) il PPh Final UMKM:
+
+1. **Audit della situazione attuale**: Controlla il metodo di dichiarazione fiscale negli ultimi 3 anni. Ci sono state dichiarazioni che presentano reddito professionale come PPh Final UMKM?
+
+2. **Determina il fatturato lordo**: Sotto IDR 4,8 miliardi? L'NPPN è un'opzione realistica. Sopra? La contabilità completa è l'unica opzione.
+
+3. **Scegli il meccanismo fiscale**: NPPN (più semplice) vs. contabilità completa (più efficiente se le spese reali sono elevate). Questa è una decisione permanente fino a quando non cambia la situazione.
+
+4. **Iscrivi l'NPPN all'Ufficio delle Tasse** (se si sceglie questa opzione): La notifica scritta deve essere presentata entro i primi 3 mesi dell'anno fiscale. Se si va oltre, è obbligatorio la contabilità completa per quell'anno.
+
+5. **Consulta la correzione della dichiarazione**: Se ci sono dichiarazioni da correggere, fallo il prima possibile. L'autocorrezione è molto più economica delle conseguenze di un'ispezione.
+
+---
+
+<ArticleClusterCTA slug="pph-final-umkm-profesi-khusus" />
+
+## Note per il Team Surya
+
+**Stato: PARZIALMENTE VALIDATO — Angel (23 lug 2026)**
+
+- Q4 (SPT Masa PT PMA in perdita): VALIDATO — obbligo di dichiarazione se ci sono transazioni PPh 21/23/4(2)
+- Q5 (Influencer corporate veil): IRISOLTO — non ci sono precedenti in campo, scrivere come rischio in evoluzione
+
+⚠️ **Domande per la revisione regolamentare — OBBLIGATORIO prima della pubblicazione:**
+
+**Domande Critiche:**
+
+1. **KMK 202/2022**: La sintesi menziona questo documento come fonte dell'elenco delle professioni eleggibili. La ricerca pubblica non ha trovato riferimenti concreti a un KMK con questo numero. Si prega di confermare: esiste questo documento? O si intende un'altra regolamentazione (ad esempio un Perdirjen o un PMK) che disciplina l'elenco delle professioni di lavoro autonomo?
+
+2. **SE-14/PJ/2021**: La sintesi menziona anche questa circolare. La ricerca non ha trovato un collegamento diretto tra SE-14/PJ/2021 e il PPh Final UMKM — ciò che è stato trovato è PER-14/PJ/2021 (sulle SKP). Confermare: è corretto il numero di questa SE? O esiste un'altra SE più rilevante?
+
+3. **Percentuali Normative Aggiornate**: La tabella NPPN nell'articolo utilizza un riferimento datato (PMK 450/KMK.04/1997). Esistono aggiornamenti alle norme per il 2025/2026 che dovrebbero sostituire questi numeri?
+
+4. **Zona Grigia Ambulatori**: Esiste un decreto della DJP che classifica i medici che gestiscono un ambulatorio (non una pratica personale, con dipendenti) come "impresa" vs. "lavoro autonomo"? Evidenza interna o BKPM?
+
+5. **Altri Operatori Sanitari**: La sintesi menziona "operatori sanitari (odontoiatri, fisioterapisti, ecc) — inclusi" come quelli che possono usare il PPh Final. Questo **contraddice** le ricerche che includono tutti i professioni sanitarie nell'elenco del lavoro autonomo. Si prega di chiarire: esiste una suddivisione all'interno della categoria dei professioni sanitari che ancora può utilizzare il PPh Final UMKM?
+
+---
+
+-La tua professione rientra in quale categoria? Il Bali Zero Tax Desk effettua un'analisi della classificazione del reddito — inclusa la revisione storica delle dichiarazioni e le raccomandazioni per il futuro. Contattaci via WhatsApp o chiedi a Zantara AI.
+
+<AskZantara
+  context="PPh Final UMKM, professioni libere, PP 20/2026, lavoro autonomo, NPPN, aliquota progressiva fiscale Indonesia"
+  placeholder="Fai una domanda sulle tasse per la tua professione..."
+  suggestedQuestions={[
+    "Un medico con un ambulatorio può usare il PPh Final UMKM?",
+    "Come si calcola l'imposta con l'NPPN per un notaio?",
+    "Ho dichiarato male il PPh Final per 2 anni, cosa devo fare?",
+    "Una PT Perorangan per una consulenza può accedere allo schema UMKM?",
+  ]}
+/>


### PR DESCRIPTION
## What this is

Rescued unpushed work found during a fleet sweep: 6 untracked `.mdx` files sitting in Pro's dirty main checkout (`apps/mouth/src/content/articles/tax/`), never committed anywhere. Genuine authored content — full SEO frontmatter, Subhi/Bali Zero Editorial bylines, `adversarial_review` markers — not generated output.

Only these 6 paths were touched. Pro's main checkout also holds a live sibling's staged `scripts/kbli_filiera/*` work plus runtime-state churn (`published_articles.json`, `escalations_pro.jsonl`, regulatory delta json) — none of that was committed, stashed, or touched.

## Verified before rescuing

- **Not already on main**: `git cat-file -e origin/main:<path>` confirms all 6 exact paths are absent from `origin/main`.
- **Two of three families complete an already-published article**:
  - `coretax-spt-tahunan-2025-panduan-bali-zero.{id,it}.mdx` — the English base `.mdx` for this exact slug is already live on main (published 2026-07-22). This PR adds the missing ID/IT translations.
  - `pph-final-umkm-profesi-khusus.{id,it}.mdx` — same situation, English base already live (published 2026-07-22).
- **Third family checked for duplicate coverage, found distinct**: `pp-20-2026-perubahan-investor-asing-indonesia.{id,it}.mdx` covers PP 20/2026 from the **foreign-investor / PT PMA angle** (turnover-aggregation rules, anti-bribery policy). Two other PP 20/2026 articles already exist on main (`indonesia-umkm-tax-reforms-pp-20-2026`, `pp-20-2026-who-keeps-the-05-tax-and-who-loses-it`) but both cover the **UMKM/CV/freelancer 0.5% PPh Final** angle — different audience, different regulatory content. Not a duplicate.

## Known gap (flagged, not fixed here — out of rescue scope)

`pp-20-2026-perubahan-investor-asing-indonesia` has **no English base `.mdx` anywhere** (main or this branch). Per `apps/mouth/src/lib/blog/articles.ts::getAllMdxSlugs()`, the article listing/sitemap enumeration only discovers slugs via their base (non-locale-suffixed) `.mdx` file — locale-suffixed files alone aren't enough. So this slug will render correctly via a direct locale URL (`getArticleByLocale` reads `.id.mdx`/`.it.mdx` directly, no base-file dependency) but **won't surface in the article list or sitemap** until an English base file exists. Follow-up recommended, not attempted in this PR.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>