### PR TITLE
fix(kbli): re-emit batch-a-members.json canonical pin (stale since #3114)

### DIFF
--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "fd181cd8e5cc77159d8a7a4d4758ca68e17dceb5",
-  "canonical_sha256": "bc8c9879ddebccd091f3027603642be75261bb5d497375759cf5ae7953bb904f",
+  "canonical_revision": "e653b3556d169e9cbaee3916288821051a2ae68b",
+  "canonical_sha256": "87c8d0cadfe6f5c24110f86699d29c06067755e96263d3f2b2617cb54b4fade0",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",


### PR DESCRIPTION
## Summary
Main has carried a stale `canonical_sha256` pin in `data/kbli-filiera/membership/batch-a-members.json` since PR #3114 merged (2026-07-25T13:27:36Z) — an independent fix built in parallel on that PR's branch lost the race against auto-merge and never landed. Any future PR touching `scripts/kbli_filiera/**` re-triggers the same 5 test failures this fixes (`kbli-filiera-vault-compilers` CI check, scar W88 content-pin discipline).

- Regenerated via the sanctioned compiler (`scripts/kbli_filiera/emit_batch_membership.py --apply`) against current main.
- Mechanical, not editorial: dry-run census before/after is byte-identical (A-serving/pp28=5, A-empty/gap=216, in_scope=5, total=221). Diff is exactly 2 lines: `canonical_revision` + `canonical_sha256`.
- `canonical_sha256` matches the value from the orphaned fix (`87c8d0cadfe6...`), confirming the canonical dataset has not changed again since #3114.

## Test plan
- [x] `python3 -m pytest scripts/kbli_filiera/tests/test_emit_batch_calibration{,_v2,_v3}.py -q` — 87 passed locally (Mini worktree)
- [x] `kbli-filiera-vault-compilers` CI check on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
