### PR TITLE
fix(mouth): wire E33 Second Home price to PricingTool, fix IDR-suffix bug

### DIFF
--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -5,6 +5,15 @@ import { useTranslation } from "@/i18n";
 import type { Locale } from "@/i18n/types";
 import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 import { ConsentBanner } from "@/components/visa/ConsentBanner";
+import { usePricingData } from "@/hooks/usePricingData";
+
+// PricingTool SSOT key (bali_zero_official_prices_2026.json). Matches the
+// key registered in PRICING_FALLBACK (components/book/book-data.ts).
+const E33_LIVE_PRICE_KEY = "E33 Second Home (5 Years)";
+// Static fallback — never blank, never a stranding spinner. Kept identical
+// to PRICING_FALLBACK's entry for this key so the figure never visibly
+// shifts between "live" and "fallback" states.
+const E33_FALLBACK_PRICE = "IDR 39,000,000";
 
 /**
  * E33 Second Home Visa landing — Fit-Memo funnel (2026-07-24).
@@ -87,6 +96,8 @@ function LanguageSwitcher() {
 
 export function SecondHomeLanding() {
   const { t } = useTranslation();
+  const { price: livePrice } = usePricingData(E33_LIVE_PRICE_KEY);
+  const price = livePrice ?? E33_FALLBACK_PRICE;
 
   const faqItems = [1, 2, 3, 4, 5, 6].map((n) => ({
     q: t(`secondHome.faq.q${n}`),
@@ -388,7 +399,7 @@ export function SecondHomeLanding() {
               color: "var(--accent-funnel-text, var(--accent-funnel))",
             }}
           >
-            IDR 39,000,000
+            {price}
           </div>
           <p
             style={{

--- a/apps/mouth/src/components/book/book-data.ts
+++ b/apps/mouth/src/components/book/book-data.ts
@@ -211,6 +211,10 @@ export const PRICING_FALLBACK: Record<string, string> = {
   "E33G Multiple Entry": "Rp 9,5M",
   "KITAS Retirement": "Rp 22M",
   "PT PMA": "Rp 20M",
+  // Matches bali_zero_official_prices_2026.json PricingTool SSOT key
+  // ("E33 Second Home (5 Years)") and the canonical display format used on
+  // the /visa/second-home landing page and services_data.ts.
+  "E33 Second Home (5 Years)": "IDR 39,000,000",
 };
 
 // ─── i18n ────────────────────────────────────────────────────────────────────

--- a/apps/mouth/src/components/services/ServicePricing.tsx
+++ b/apps/mouth/src/components/services/ServicePricing.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { Check, X, Info, Phone } from "lucide-react";
 import type { ServicePackage } from "@/data/services_data";
 import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
+import { usePricingData } from "@/hooks/usePricingData";
 
 // ServiceData without icon (React component cannot be serialized)
 type ServiceDataWithoutIcon = Omit<
@@ -48,6 +49,68 @@ function getVisaPackageColor(name: string): {
     border: "border-sky-500/40 hover:border-sky-400",
     badge: "bg-sky-500",
   };
+}
+
+// A raw digit-and-separator string ("39.000.000", "10.000.000") gets an
+// " IDR" suffix appended by the renderer below. Anything that already
+// contains letters — an already-formatted live value ("IDR 39,000,000"), a
+// placeholder ("Check live pricing"), or "Contact" — must render as-is.
+// Word/entity check on shape, never a substring/keyword list (cicatrix
+// family #3 — guard-over-match): a new placeholder string added later still
+// classifies correctly without touching this function.
+function isNumericPrice(price: string): boolean {
+  return /^\d[\d.,]*$/.test(price);
+}
+
+/**
+ * Resolves a package's display price: live PricingTool value (via
+ * `usePricingData`, when the package declares `livePriceKey`) falling back
+ * to the static `pkg.price` literal — never blank, never a stranding
+ * spinner. `usePricingData(null)` is a documented no-op (no fetch, no
+ * loading state), so this is safe to call unconditionally for every
+ * package, including the ones with no live pricing wired yet.
+ */
+function usePackagePrice(pkg: ServicePackage): string {
+  const { price: livePrice } = usePricingData(pkg.livePriceKey ?? null);
+  return livePrice ?? pkg.price;
+}
+
+function PriceValue({
+  pkg,
+  variant,
+}: {
+  pkg: ServicePackage;
+  variant: "card" | "modal";
+}) {
+  const price = usePackagePrice(pkg);
+
+  if (price === "Contact") {
+    return (
+      <span className="text-2xl font-bold text-accent-blue-editorial">
+        Contact for quote
+      </span>
+    );
+  }
+
+  const amount = isNumericPrice(price) ? (
+    <>
+      <span className="text-3xl font-bold text-white">{price}</span>
+      <span className="text-white/40 text-sm ml-2">IDR</span>
+    </>
+  ) : (
+    <span className="text-3xl font-bold text-white">{price}</span>
+  );
+
+  if (variant === "card") {
+    return amount;
+  }
+
+  return (
+    <div>
+      {amount}
+      <p className="text-[#22c55e] text-sm mt-1">All-inclusive pricing</p>
+    </div>
+  );
 }
 
 export default function ServicePricing({ service, slug }: ServicePricingProps) {
@@ -107,18 +170,7 @@ export default function ServicePricing({ service, slug }: ServicePricingProps) {
                   </p>
 
                   <div className="mb-6">
-                    {pkg.price === "Contact" ? (
-                      <span className="text-2xl font-bold text-accent-blue-editorial">
-                        Contact for quote
-                      </span>
-                    ) : (
-                      <>
-                        <span className="text-3xl font-bold text-white">
-                          {pkg.price}
-                        </span>
-                        <span className="text-white/40 text-sm ml-2">IDR</span>
-                      </>
-                    )}
+                    <PriceValue pkg={pkg} variant="card" />
                   </div>
 
                   <ul className="space-y-3 mb-6">
@@ -191,21 +243,7 @@ export default function ServicePricing({ service, slug }: ServicePricingProps) {
 
               {/* Price */}
               <div className="bg-[#051C2C] rounded-xl p-4 mb-6">
-                {selectedPackage.price === "Contact" ? (
-                  <span className="text-2xl font-bold text-accent-blue-editorial">
-                    Contact for quote
-                  </span>
-                ) : (
-                  <div>
-                    <span className="text-3xl font-bold text-white">
-                      {selectedPackage.price}
-                    </span>
-                    <span className="text-white/40 text-sm ml-2">IDR</span>
-                    <p className="text-[#22c55e] text-sm mt-1">
-                      All-inclusive pricing
-                    </p>
-                  </div>
-                )}
+                <PriceValue pkg={selectedPackage} variant="modal" />
               </div>
 
               {/* Features */}

--- a/apps/mouth/src/data/services_data.ts
+++ b/apps/mouth/src/data/services_data.ts
@@ -4,12 +4,19 @@ import { Globe, Building2, Calculator, Home } from "lucide-react";
 export interface ServicePackage {
   name: string;
   description: string;
+  /** Static fallback price (rendered as-is when no live price is available —
+   *  never blank, never a spinner: see `livePriceKey`). */
   price: string;
   features: string[];
   popular: boolean;
   /** Optional deep-link to a dedicated landing page (rendered in the
    *  pricing modal below the WhatsApp CTA). */
   link?: { href: string; label: string };
+  /** Optional PricingTool SSOT key (matches
+   *  `bali_zero_official_prices_2026.json`) — when set, the renderer wires
+   *  this package to `usePricingData(livePriceKey)` via SWR and falls back
+   *  to the static `price` literal above if the live fetch has nothing. */
+  livePriceKey?: string;
 }
 
 export interface ServiceData {
@@ -403,7 +410,11 @@ export const SERVICES_DATA: Record<string, ServiceData> = {
       {
         name: "E33 - Second Home Visa",
         description: "Long-term residence (USD 130k+ deposit) — all-inclusive",
-        price: "39.000.000",
+        // Fallback only — live value comes from PricingTool via livePriceKey
+        // below. Format ("IDR 39,000,000") matches the canonical string used
+        // on the /visa/second-home landing page and PRICING_FALLBACK.
+        price: "IDR 39,000,000",
+        livePriceKey: "E33 Second Home (5 Years)",
         features: [
           "Up to 5 years initial validity",
           "No sponsor required",

--- a/apps/mouth/src/hooks/usePricingData.ts
+++ b/apps/mouth/src/hooks/usePricingData.ts
@@ -11,20 +11,32 @@ interface PricingResult {
   isError: boolean;
 }
 
-export function usePricingData(serviceKey: string): PricingResult {
+/**
+ * Fetch a live price by SSOT service key. Pass `null` to skip the fetch
+ * entirely (e.g. a package with no live pricing wired yet) — SWR treats a
+ * `null` key as "don't fetch", so no network call is made and `price` is
+ * always `null` in that case.
+ */
+export function usePricingData(serviceKey: string | null): PricingResult {
   const { data, error, isLoading } = useSWR(
-    `/api/pricing/calculate?service=${encodeURIComponent(serviceKey)}`,
+    serviceKey
+      ? `/api/pricing/calculate?service=${encodeURIComponent(serviceKey)}`
+      : null,
     fetcher,
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       shouldRetryOnError: false,
-      fallbackData: { price: PRICING_FALLBACK[serviceKey] ?? null },
+      fallbackData: serviceKey
+        ? { price: PRICING_FALLBACK[serviceKey] ?? null }
+        : undefined,
     },
   );
 
   return {
-    price: data?.price ?? PRICING_FALLBACK[serviceKey] ?? null,
+    price:
+      (serviceKey ? (data?.price ?? PRICING_FALLBACK[serviceKey]) : null) ??
+      null,
     isLoading,
     isError: !!error,
   };


### PR DESCRIPTION
## Summary
- E33 Second Home pricing card rendered a hardcoded literal instead of PricingTool (Golden Rule #11) — wired to the existing `usePricingData` SWR hook on both surfaces that display it.
- Fixes a real rendering bug affecting 4 live packages (E33G Digital Nomad x2, E33E/F Retirement x2): any `pkg.price` that wasn't the literal "Contact" got a blind " IDR" suffix appended, so "Check live pricing" rendered as "Check live pricingIDR".
- Verified before opening: `origin/main` has zero `livePriceKey` occurrences, no `isNumericPrice` suffix-gating, and `usePricingData` still takes a non-nullable `serviceKey` — none of this has shipped elsewhere. PR #3084 (E33 Second Home landing page, merged) touches 3 of the same files but built the landing page, not this pricing-display fix.

## Test plan
- [x] Author's own run: apps/mouth vitest full suite — 256 files / 2275 tests passed, `tsc --noEmit` clean, eslint clean
- [x] Verified content not already on main (blob + keyword check, W88-compliant — no ancestor/cherry/patch-id/three-dot)

Rescued from an orphaned worktree during a fleet-wide unpushed-work census — reviewed and opened by a teammate session, not the original author.