### PR TITLE
fix(mouth): make E33 Second Home landing reachable from articles + funnel

### DIFF
--- a/apps/mouth/src/app/visa/clock/page.tsx
+++ b/apps/mouth/src/app/visa/clock/page.tsx
@@ -18,6 +18,7 @@ const VISA_OPTIONS = [
   { code: "C7A", label: "C7A Music/Art" },
   { code: "C7B", label: "C7B Sport" },
   { code: "E33G", label: "E33G Digital Nomad KITAS" },
+  { code: "E33", label: "E33 Second Home KITAS" },
   { code: "E28A", label: "E28A Investor KITAS" },
   { code: "E23", label: "E23 Work KITAS" },
   { code: "E33F", label: "E33F Retirement KITAS" },

--- a/apps/mouth/src/app/visa/page.tsx
+++ b/apps/mouth/src/app/visa/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   AppBranchSelector,
   AppFrame,
@@ -58,29 +59,41 @@ export default function VisaEntryPage() {
         </video>
       </div>
 
-      <div style={{ position: "relative", zIndex: 1, display: "grid", gap: "var(--space-5, 2rem)" }}>
+      <div
+        style={{
+          position: "relative",
+          zIndex: 1,
+          display: "grid",
+          gap: "var(--space-5, 2rem)",
+        }}
+      >
         {/* Live marker */}
-        <div style={{
-          position: "absolute",
-          top: "-2.5rem",
-          right: 0,
-          fontSize: "0.6rem",
-          opacity: 0.5,
-          letterSpacing: "0.18em",
-          textTransform: "uppercase",
-          color: "var(--color-text-muted)",
-          display: "flex",
-          alignItems: "center",
-          gap: "6px",
-        }}>
-          <span aria-hidden style={{
-            display: "inline-block",
-            width: "6px",
-            height: "6px",
-            borderRadius: "50%",
-            background: "var(--accent-funnel)",
-            animation: "bz-live-pulse 2.4s ease-in-out infinite",
-          }} />
+        <div
+          style={{
+            position: "absolute",
+            top: "-2.5rem",
+            right: 0,
+            fontSize: "0.6rem",
+            opacity: 0.5,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+            color: "var(--color-text-muted)",
+            display: "flex",
+            alignItems: "center",
+            gap: "6px",
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              display: "inline-block",
+              width: "6px",
+              height: "6px",
+              borderRadius: "50%",
+              background: "var(--accent-funnel)",
+              animation: "bz-live-pulse 2.4s ease-in-out infinite",
+            }}
+          />
           Ambient · Bali
         </div>
 
@@ -90,18 +103,37 @@ export default function VisaEntryPage() {
             {
               id: "clock",
               title: "Yes, I'm here",
-              description: "Tell us which visa and when you entered. We'll build your expiry timeline.",
+              description:
+                "Tell us which visa and when you entered. We'll build your expiry timeline.",
               href: "/visa/clock",
             },
             {
               id: "match",
               title: "No, I'm planning",
-              description: "Answer 4 short questions. We'll recommend the right visa and show the cost.",
+              description:
+                "Answer 4 short questions. We'll recommend the right visa and show the cost.",
               href: "/visa/match",
             },
           ]}
           onSelect={(opt) => tracker.branchSelected(opt.id)}
         />
+
+        <p
+          style={{
+            textAlign: "center",
+            fontSize: "var(--text-sm, 0.88rem)",
+            color: "var(--color-text-muted)",
+            margin: 0,
+          }}
+        >
+          Buying property or keeping USD 130,000+ in savings?{" "}
+          <Link
+            href="/visa/second-home"
+            style={{ color: "var(--accent-funnel)" }}
+          >
+            See the Second Home Visa (E33) →
+          </Link>
+        </p>
 
         <style>{`
           @keyframes bz-live-pulse {

--- a/apps/mouth/src/content/articles/immigration/indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.mdx
@@ -67,6 +67,8 @@ The Second Home Visa — officially _Visa Rumah Kedua_ — was launched by Indon
 
 ---
 
+**Ready to apply?** See the [Second Home Visa (E33) hub](/visa/second-home) for eligibility, pricing, and next steps — or ask Zantara AI below.
+
 <AskZantara
   question="Have questions about this topic?"
   placeholder="Ask Zantara AI for personalized advice..."

--- a/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-kitas-e33-the-complete-2025-framework.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-kitas-e33-the-complete-2025-framework.mdx
@@ -94,6 +94,8 @@ For clients choosing the E33B bank deposit route, the 90-day post-issuance windo
 
 ---
 
+**Ready to apply?** See the [Second Home Visa (E33) hub](/visa/second-home) for eligibility, pricing, and next steps — or ask Zantara AI below.
+
 <AskZantara
   question="Have questions about this topic?"
   placeholder="Ask Zantara AI for personalized advice..."

--- a/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded.mdx
@@ -94,6 +94,8 @@ For clients weighing the five-year versus ten-year option, the decision is less 
 
 ---
 
+**Ready to apply?** See the [Second Home Visa (E33) hub](/visa/second-home) for eligibility, pricing, and next steps — or ask Zantara AI below.
+
 <AskZantara
   question="Have questions about this topic?"
   placeholder="Ask Zantara AI for personalized advice..."

--- a/apps/mouth/src/content/articles/immigration/live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.mdx
+++ b/apps/mouth/src/content/articles/immigration/live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.mdx
@@ -57,6 +57,8 @@ This article from PNB Immigration Law Firm covers long-term residency options in
 
 ---
 
+**Ready to apply?** See the [Second Home Visa (E33) hub](/visa/second-home) for eligibility, pricing, and next steps — or ask Zantara AI below.
+
 <AskZantara
   question="Have questions about this topic?"
   placeholder="Ask Zantara AI for personalized advice..."

--- a/apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx
+++ b/apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx
@@ -69,6 +69,7 @@ ogImage: "/static/insights/immigration/second-home-visa-indonesia.jpg"
 ogType: "article"
 twitterCard: "summary_large_image"
 ---
+
 import { HeaderWhatsAppCTA } from "@/components/blog/HeaderWhatsAppCTA";
 
 ## What Is the Second Home Visa?
@@ -306,6 +307,7 @@ While the SHV includes multiple entry-exit privileges, extended absences (180+ c
 
 **Interested in the Second Home Visa?** Bali Zero guides you through the entire process, from financial documentation to SKTT registration. We handle all 5 stages so you can focus on enjoying your new home.
 
+- **Full guide & free fit memo:** [balizero.com/visa/second-home](/visa/second-home)
 - **Email:** hello@balizero.com
-<HeaderWhatsAppCTA />
+  <HeaderWhatsAppCTA />
 - **Website:** [balizero.com](https://balizero.com)


### PR DESCRIPTION
## Summary
- `/visa/second-home` existed but was orphaned: not linked from any of its 5 source articles, not offered on `/visa`, reachable only 3 clicks deep inside a pricing modal.
- Verified before opening: `origin/main`'s `visa/page.tsx` and `visa/clock/page.tsx` have zero mentions of "second-home" — the discoverability gap is real and unfixed on main.

## Caution — same-file overlap with an already-merged PR
This branch touches the same 5 second-home article `.mdx` files as **PR #3039** (E33 content freeze, merged 2026-07-23 — fixed a 1000x price error, CTA links, oracle mis-indexing, noIndex flags). The purposes are disjoint (navigation/reachability here vs factual/CTA corrections there) and I found no semantic duplication, but this branch predates #3039 so it may not apply cleanly — **please check the diff for conflicts before merging**, don't rely on the green mergeable check alone if the article content looks different from what you expect.

## Test plan
- [x] Verified content not already on main (blob + keyword check, W88-compliant)
- [ ] CI (this worktree has no `apps/backend-rag/.venv` — pre-push hook deferred to CI per repo convention)

Rescued from an orphaned worktree during a fleet-wide unpushed-work census — reviewed and opened by a teammate session, not the original author.