### PR TITLE
docs(oauth): mark CLAUDE_CODE_OAUTH_TOKEN_3 as retired (MAX not renewed)

### DIFF
--- a/apps/mata-garuda/mata_garuda/runtime/cli_runtime.py
+++ b/apps/mata-garuda/mata_garuda/runtime/cli_runtime.py
@@ -43,7 +43,13 @@ DEFAULT_TIMEOUT = 300
 CLAUDE_TOKEN_VARS = [
     "CLAUDE_CODE_OAUTH_TOKEN_1",  # antonellosiano@gmail.com
     "CLAUDE_CODE_OAUTH_TOKEN_2",  # kaiser198719871987@gmail.com
-    "CLAUDE_CODE_OAUTH_TOKEN_3",  # sianoantonello@gmail.com
+    # RETIRED 2026-07-25 (Zero): l'abbonamento MAX dietro lo slot 3 non viene
+    # rinnovato; la credenziale e' stata rimossa da ~/.nuzantara-secrets.env su
+    # M5+Pro+Mini. La voce resta in lista di proposito: ogni consumatore salta i
+    # token vuoti, quindi la posizione e' riusabile per un seat futuro senza
+    # toccare le 6 liste di enumerazione sparse nel repo. Prove-live 2026-07-25:
+    # la cascata su Pro fa 1(limit) -> 2(limit) -> 4(PONG), slot 3 mai tentato.
+    "CLAUDE_CODE_OAUTH_TOKEN_3",  # RITIRATO — slot libero
     "CLAUDE_CODE_OAUTH_TOKEN_4",  # applevisionpro1987@gmail.com (4th MAX x20)
     "CLAUDE_CODE_OAUTH_TOKEN_5",  # zero@balizero.com (Team premium seat — weekly-capped, last-resort)
 ]


### PR DESCRIPTION
Zero cancelled the MAX subscription behind slot 3 (2026-07-25). The credential was removed from `~/.nuzantara-secrets.env` on M5, Pro and Mini — perms 600 preserved, slots 1/2/4/5 untouched, each verified in a clean `env -i` shell.

**No code changed, deliberately.** Every consumer already skips empty tokens (`[ -z "$token" ] && continue`), so dropping the credential retires the seat everywhere at once — and position 3 stays reusable for a future seat without touching the six enumeration lists (`claude-cascade.sh`, `ai-dispatch.sh`, `wr2-ig-metrics-analyst-run.sh`, `claude_oauth_client.py`, `cli_runtime.py`, and their tests).

This PR only marks the slot as retired so a future session does not read the hole as a bug and "repair" it. It also drops a personal address from a public repo.

**Prove-live on Pro after removal:**
```
[try] claude-token-1-env -> exit=1 (weekly limit)
[try] claude-token-2-env -> exit=1 (weekly limit)
                            <- slot 3 never attempted
[try] claude-token-4-env -> PONG
```

Revert path: remove the `# RETIRED-2026-07-25 ` prefix from the line in `~/.nuzantara-secrets.env`.

Flagged, NOT addressed here: this file maps `_1`=antonellosiano / `_2`=kaiser while memory `reference_dual_max_slots_2026_05_19` maps them the other way round. Both agree on `_3`, so the retirement is unambiguous; the 1<->2 contradiction needs resolving before any decision that depends on which seat is which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)