### PR TITLE
fix(wr2): rank axis-engagement by median + a +25% materiality bar (Zero's ruling)

### DIFF
--- a/scripts/tests/test_wr2_creative_ledger.py
+++ b/scripts/tests/test_wr2_creative_ledger.py
@@ -299,7 +299,10 @@ def _write_queue(tmp_path, posts) -> Path:
 
 
 def test_axis_engagement_aggregates_ranks_and_drops_noise(tmp_path) -> None:
-    # guilt: mean reach per axis value, sorted high→low; noise-guard drops n<3.
+    # guilt: median reach per axis value, sorted high→low; noise-guard drops n<3.
+    # (Every value in a group is identical here, so mean == median — this test is
+    # deliberately estimator-BLIND. The estimator itself is pinned by the skew
+    # tests below, which is exactly what this one could never catch.)
     posts = (
         [_post(reach=30000, layout="cover-photo") for _ in range(3)]        # mean 30k, n=3
         + [_post(reach=5000, layout="dark-status-list") for _ in range(4)]  # mean 5k,  n=4
@@ -311,9 +314,167 @@ def test_axis_engagement_aggregates_ranks_and_drops_noise(tmp_path) -> None:
     assert vals == ["cover-photo", "dark-status-list"]   # sorted high→low
     assert "rare-once" not in vals                        # n<_MIN_AXIS_SAMPLES dropped
     assert lf[0][2] == 3                                  # n reported
-    assert abs(lf[0][1] - 30000) < 1                      # mean reach
+    assert abs(lf[0][1] - 30000) < 1                      # reach statistic reported
     assert ae.total_posts == 9                            # every reach>0 post counted
     assert ae.has_signal
+
+
+# ── SKEW: rank by MEDIAN, not mean (2026-07-25 study on the real corpus) ────
+# These four reproduce the measured shape: one viral post was 31.6% of all reach
+# in the live corpus, and the mean therefore ranked its CARRIER. Every assertion
+# below FAILS under `sum(rs)/len(rs)` — that is the point (a test that passes
+# under both estimators pins nothing; the 31 pre-existing ones all did).
+
+# Verbatim reach vectors measured on the Pro's review queue, 2026-07-25.
+_REAL_COVER_PHOTO = [141240, 23704, 1360, 1220, 1193, 1185, 1140]   # mean 24,435 · median 1,220
+_REAL_STATEMENT_BOMB = [47284, 34088, 30383, 23160, 13402, 2835, 1830, 683]  # mean 19,208 · median 18,281
+
+
+def test_axis_engagement_ranks_by_median_not_mean_on_skewed_corpus(tmp_path) -> None:
+    """GUILT (the scar): one viral post must not crown its layout.
+
+    Under the old mean ranking cover-photo (24,435) outranked statement-bomb
+    (19,208) purely on the 141,240 outlier, while its TYPICAL post (1,220) is
+    below the corpus median. Median inverts it — correctly."""
+    posts = (
+        [_post(reach=r, layout="cover-photo") for r in _REAL_COVER_PHOTO]
+        + [_post(reach=r, layout="statement-bomb") for r in _REAL_STATEMENT_BOMB]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    vals = [v for v, _, _ in ae.by_axis["layout_family_primary"]]
+    assert vals[0] == "statement-bomb", "the consistently-strong layout must rank first"
+    assert vals[-1] == "cover-photo", "the outlier-carried layout must rank LAST, not first"
+
+
+def test_axis_engagement_reports_the_median_value_not_the_mean(tmp_path) -> None:
+    """The NUMBER handed to the planner must be the typical post, not the average."""
+    posts = [_post(reach=r, layout="cover-photo") for r in _REAL_COVER_PHOTO]
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    _, stat, n = ae.by_axis["layout_family_primary"][0]
+    assert n == 7
+    assert abs(stat - 1220) < 1, f"expected the median 1,220, got {stat}"
+    assert stat < 2000, "the 24,435 mean would be a 20x overstatement of a typical post"
+
+
+def test_axis_engagement_exposes_corpus_median_baseline(tmp_path) -> None:
+    """The corpus baseline must be carried so the hint cannot overstate a tie."""
+    posts = (
+        [_post(reach=1000, layout="a") for _ in range(3)]
+        + [_post(reach=3000, layout="b") for _ in range(3)]
+        + [_post(reach=9000, layout="c") for _ in range(3)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    assert abs(ae.corpus_median - 3000) < 1     # median of the 9 counted posts
+    assert ae.total_posts == 9
+
+
+def test_axis_engagement_unskewed_corpus_still_ranks_the_higher_value_first(tmp_path) -> None:
+    """INNOCENCE: where mean and median agree, the fix changes nothing."""
+    posts = (
+        [_post(reach=r, layout="strong") for r in (9000, 10000, 11000)]
+        + [_post(reach=r, layout="weak") for r in (1000, 1100, 1200)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    vals = [v for v, _, _ in ae.by_axis["layout_family_primary"]]
+    assert vals == ["strong", "weak"]
+
+
+def test_engagement_hint_declares_median_and_states_the_corpus_baseline(tmp_path) -> None:
+    """The prompt must not call a median an 'avg', and must give the baseline."""
+    posts = (
+        [_post(reach=r, layout="cover-photo", tone="rituale") for r in _REAL_COVER_PHOTO]
+        + [_post(reach=r, layout="statement-bomb", tone="militante") for r in _REAL_STATEMENT_BOMB]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    hint = wcl.build_engagement_hint(ae)
+    assert "typical reach" in hint
+    assert "avg reach" not in hint, "a median labelled 'avg' misinforms the planner"
+    assert "MEDIAN" in hint
+    assert f"~{int(ae.corpus_median):,}" in hint, "corpus baseline must be stated"
+    # The outlier-carried layout is not merely demoted — with a below-baseline
+    # median (1,220 vs a 2,835 corpus median here) it is not named AT ALL.
+    # Under the old mean it ranked FIRST and would appear: this is the assertion
+    # that makes this test non-vacuous.
+    assert "statement-bomb" in hint
+    assert "cover-photo" not in hint
+
+
+def test_hint_never_calls_a_below_baseline_value_higher_reaching(tmp_path) -> None:
+    """GUILT: rank is not strength — the #2 of a weak axis can sit AT or BELOW the
+    typical post. Measured on the real corpus: `analitico` ranked #2 among tones
+    with median 2,237 while the corpus median was 2,288. Naming it "higher-
+    reaching" would have been false, and the planner acts on that word."""
+    posts = (
+        [_post(reach=9000, tone="genuinely-strong") for _ in range(3)]
+        + [_post(reach=3000, tone="exactly-baseline") for _ in range(3)]
+        + [_post(reach=2000, tone="below-baseline") for _ in range(3)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    assert abs(ae.corpus_median - 3000) < 1
+    # all three are RANKED (each has n=3, so they survive the noise guard)…
+    assert [v for v, _, _ in ae.by_axis["tone_register_primary"]] == [
+        "genuinely-strong", "exactly-baseline", "below-baseline",
+    ]
+    # …but only the one that BEATS the baseline may be named to the planner.
+    assert [v for v, _, _ in ae.above_baseline("tone_register_primary")] == ["genuinely-strong"]
+    hint = wcl.build_engagement_hint(ae)
+    assert "genuinely-strong" in hint
+    assert "below-baseline" not in hint
+    assert "exactly-baseline" not in hint, "a TIE with the typical post is not 'higher-reaching'"
+
+
+def test_hint_is_empty_when_nothing_beats_the_baseline(tmp_path) -> None:
+    """INNOCENCE/safe-state: an axis with no real winner is simply not named, and
+    a corpus with no winner anywhere degrades to the byte-identical no-hint path
+    rather than inventing a recommendation."""
+    posts = [_post(reach=5000, tone="only-one-value") for _ in range(6)]
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    assert ae.has_signal                      # the axis IS aggregated…
+    assert ae.above_baseline("tone_register_primary") == []   # …but nothing beats itself
+    assert wcl.build_engagement_hint(ae) == ""
+
+
+def test_engagement_hint_has_no_baseline_clause_without_signal() -> None:
+    """INNOCENCE: no signal → empty hint (byte-identical pre-Fase-4b path)."""
+    assert wcl.build_engagement_hint(wcl.AxisEngagement(by_axis={}, total_posts=0)) == ""
+
+
+def test_unknown_baseline_degrades_to_rank_only_and_states_no_baseline() -> None:
+    """`corpus_median == 0.0` is the 'baseline unknown' sentinel (cold corpus, or
+    a non-finite median guarded upstream): above_baseline must NOT filter — it
+    degrades to rank-only, the pre-baseline behaviour — and the hint must not
+    print a bogus '~0' baseline clause. Discriminates the `corpus_median > 0`
+    guards: without them this filters everything out / prints '~0'."""
+    ae = wcl.AxisEngagement(
+        by_axis={"layout_family_primary": [("a", 900.0, 3), ("b", 100.0, 3)]},
+        total_posts=6,
+        corpus_median=0.0,
+    )
+    assert [v for v, _, _ in ae.above_baseline("layout_family_primary")] == ["a", "b"]
+    hint = wcl.build_engagement_hint(ae)
+    assert "a (~900 typical reach, n=3)" in hint
+    assert "TYPICAL post in this corpus" not in hint, "no baseline known → no baseline claim"
+    assert "~0" not in hint
+
+
+def test_non_finite_median_from_finite_elements_is_dropped_not_crashed(tmp_path) -> None:
+    """GUILT (red-team #3, reproduced on disk): every ELEMENT can be finite while
+    the MEDIAN overflows — statistics.median of an even-sized group averages the
+    two middle values and 1e308 + 1e308 == inf. `int(inf)` raises OverflowError
+    inside build_engagement_hint, whose production caller does not wrap it, so
+    element-level isfinite is not enough to keep the never-blocks promise."""
+    import math as _m
+    posts = (
+        [_post(reach=1e308, layout="overflows") for _ in range(4)]   # median -> inf
+        + [_post(reach=5000, layout="sane") for _ in range(3)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    vals = [v for v, _, _ in ae.by_axis.get("layout_family_primary", [])]
+    assert "overflows" not in vals, "a non-finite median must be dropped, not ranked"
+    assert vals == ["sane"]
+    assert ae.total_posts == 7          # the posts themselves ARE counted (finite reach)
+    assert _m.isfinite(ae.corpus_median)
+    wcl.build_engagement_hint(ae)       # must not raise — this is the whole point
 
 
 def test_axis_engagement_missing_queue_is_empty(tmp_path) -> None:
@@ -359,7 +520,13 @@ def test_hint_names_layout_and_tone_but_not_domain(tmp_path) -> None:
 
 
 def test_hint_states_sample_size_and_goodhart_caveat(tmp_path) -> None:
-    posts = [_post(reach=30000, layout="cover-photo", tone="rituale") for _ in range(4)]
+    # Needs CONTRAST: a single-value corpus has no winner by construction (the one
+    # value IS the corpus median, so nothing beats the baseline) and correctly
+    # yields an empty hint. The weak arm below supplies the baseline to beat.
+    posts = (
+        [_post(reach=30000, layout="cover-photo", tone="rituale") for _ in range(4)]
+        + [_post(reach=1000, layout="dark-status-list", tone="analitico") for _ in range(5)]
+    )
     hint = wcl.build_engagement_hint(wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts)))
     assert "n=4" in hint          # sample size stated inline (weak-signal honesty)
     assert "NOT a rule" in hint   # Goodhart caveat present
@@ -385,11 +552,13 @@ def test_axis_engagement_excludes_nan_and_inf_reach_without_crashing(tmp_path) -
         [_post(reach=_m.nan, layout="nan-poison") for _ in range(3)]
         + [_post(reach=_m.inf, layout="inf-poison") for _ in range(3)]
         + [_post(reach=5000, layout="clean") for _ in range(3)]
+        + [_post(reach=500, layout="modest") for _ in range(4)]  # baseline to beat
     )
     ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
     vals = [v for v, _, _ in ae.by_axis.get("layout_family_primary", [])]
-    assert vals == ["clean"]              # only finite-reach values survive
-    assert ae.total_posts == 3            # nan/inf posts never counted
+    assert vals == ["clean", "modest"]    # only finite-reach values survive
+    assert "nan-poison" not in vals and "inf-poison" not in vals
+    assert ae.total_posts == 7            # nan/inf posts never counted
     hint = wcl.build_engagement_hint(ae)  # int(nan) would raise here without the guard
     assert "clean" in hint
     assert "poison" not in hint

--- a/scripts/tests/test_wr2_creative_ledger.py
+++ b/scripts/tests/test_wr2_creative_ledger.py
@@ -643,3 +643,107 @@ def test_plan_deck_empty_hint_leaves_prompt_without_hint_block() -> None:
         pw.plan_deck("BRIEF", "breaking", ["news_alert"], call_fn, max_retries=1)
     assert seen
     assert "ENGAGEMENT HINT" not in seen[0]
+
+
+# ── materiality bar (+25%, Zero 2026-07-25) ──────────────────────────────────
+
+
+def test_a_marginal_edge_over_the_baseline_is_not_named(tmp_path) -> None:
+    """GUILT: the exact hole the >baseline version shipped with — 30 posts at
+    5,000 and 3 at 5,100 would name the 3-post value on a +2% edge. It clears
+    `> corpus_median` and must NOT clear the materiality bar."""
+    posts = (
+        [_post(reach=5000, tone="the-whole-corpus") for _ in range(30)]
+        + [_post(reach=5100, tone="marginal-winner") for _ in range(3)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    assert abs(ae.corpus_median - 5000) < 1
+    # It IS ranked first, and it DOES beat the bare baseline…
+    assert ae.by_axis["tone_register_primary"][0][0] == "marginal-winner"
+    assert 5100 > ae.corpus_median
+    # …but +2% is not a finding.
+    assert ae.above_baseline("tone_register_primary") == []
+    assert "marginal-winner" not in wcl.build_engagement_hint(ae)
+
+
+def test_a_material_edge_is_still_named(tmp_path) -> None:
+    """INNOCENCE: the bar must not silence a real signal. Same shape, real gap."""
+    posts = (
+        [_post(reach=5000, tone="the-whole-corpus") for _ in range(30)]
+        + [_post(reach=9000, tone="genuine-winner") for _ in range(3)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    assert [v for v, _, _ in ae.above_baseline("tone_register_primary")] == ["genuine-winner"]
+    assert "genuine-winner" in wcl.build_engagement_hint(ae)
+
+
+def test_the_bar_is_exclusive_at_exactly_the_multiplier(tmp_path) -> None:
+    """EDGE: sitting exactly ON the bar is not beating it (strict `>`), and one
+    reach unit above it is. Pins the comparison operator, not just the constant."""
+    base = 1000.0
+    bar = base * wcl._MATERIALITY_MULTIPLIER
+    posts = (
+        [_post(reach=base, tone="corpus") for _ in range(9)]
+        + [_post(reach=bar, tone="exactly-on-the-bar") for _ in range(3)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    assert abs(ae.corpus_median - base) < 1
+    assert ae.above_baseline("tone_register_primary") == []
+
+    posts2 = (
+        [_post(reach=base, tone="corpus") for _ in range(9)]
+        + [_post(reach=bar + 1, tone="just-over-the-bar") for _ in range(3)]
+    )
+    ae2 = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts2))
+    assert [v for v, _, _ in ae2.above_baseline("tone_register_primary")] == ["just-over-the-bar"]
+
+
+def test_hint_states_the_bar_and_never_calls_a_listed_value_marginal(tmp_path) -> None:
+    """The prompt must size the claim. It must NOT keep saying values may beat
+    the baseline 'only marginally' — with the bar armed that is false, and it
+    would tell the planner to discount exactly the material ones."""
+    posts = (
+        [_post(reach=1000, tone="corpus", layout="dark-status-list") for _ in range(9)]
+        + [_post(reach=9000, tone="strong", layout="statement-bomb") for _ in range(3)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    hint = wcl.build_engagement_hint(ae)
+    pct = int(round((wcl._MATERIALITY_MULTIPLIER - 1) * 100))
+    assert f"at least {pct}%" in hint, "the bar must be stated, not implied"
+    assert "only marginally" not in hint
+    # Absence is explained, so the planner does not read a silent axis as "no data".
+    assert "withheld as noise" in hint
+
+
+def test_one_axis_can_go_silent_while_the_other_survives_the_bar(tmp_path) -> None:
+    """The MEASURED consequence Zero accepted on 2026-07-25, pinned so it cannot
+    regress silently.
+
+    On the real corpus (50 posts, baseline 2,288) the best TONE — `militante`,
+    median 2,835 — sits at 1.24x and misses the +25% bar by 26 reach, while the
+    LAYOUT axis is untouched (statement-bomb 7.99x). The two axes are
+    INDEPENDENT groupings over the same posts, so a two-arm fixture cannot
+    reproduce it; this reproduces the measured RATIO instead (1,240 over a
+    baseline of 1,000 = the same 1.24x), which is what the assertion is about.
+    Lower the bar and this test says so."""
+    posts = (
+        # bulk: sets the corpus baseline at 1,000
+        [_post(reach=1000, layout="dark-status-list", tone="analitico") for _ in range(9)]
+        # top tone — beats the baseline, misses the bar (the real militante shape)
+        + [_post(reach=1240, layout="qa-dialogue", tone="militante") for _ in range(3)]
+        # a genuinely strong LAYOUT, whose tones are singletons (n<_MIN_AXIS_SAMPLES)
+        # so they are noise-guarded out and cannot rescue the tone axis
+        + [_post(reach=8000, layout="statement-bomb", tone=f"one-off-{i}") for i in range(3)]
+    )
+    ae = wcl.fetch_axis_engagement(queue_path=_write_queue(tmp_path, posts))
+    assert abs(ae.corpus_median - 1000) < 1
+
+    tone_rows = {v: m for v, m, _ in ae.by_axis["tone_register_primary"]}
+    assert tone_rows["militante"] > ae.corpus_median, "it DOES beat the bare baseline…"
+    assert tone_rows["militante"] < ae.corpus_median * wcl._MATERIALITY_MULTIPLIER, "…not the bar"
+    assert ae.above_baseline("tone_register_primary") == [], "tone axis goes silent"
+
+    hint = wcl.build_engagement_hint(ae)
+    assert "militante" not in hint
+    assert "statement-bomb" in hint, "the layout signal must survive the bar"
+    assert "qa-dialogue" not in hint, "1.24x does not earn the word on either axis"

--- a/scripts/wr2_creative_ledger.py
+++ b/scripts/wr2_creative_ledger.py
@@ -306,6 +306,15 @@ _PLANNER_HINT_AXES: tuple[str, ...] = ("layout_family_primary", "tone_register_p
 _MIN_AXIS_SAMPLES = 3
 # Cap how many high performers we name per axis in the hint (keep it a nudge).
 _HINT_TOP_N = 2
+# How far above the corpus baseline a value must sit before it earns the word
+# "higher-reaching". Beating the typical post by a hair is not a finding — with
+# n=8 samples a few percent is inside the noise. Zero's call, 2026-07-25: +25%.
+# MEASURED CONSEQUENCE on the corpus of the day (50 posts, baseline 2,288):
+# layout is untouched (statement-bomb 7.99x, qa-dialogue 2.05x — the real
+# signals), and the TONE axis goes silent, because its best value `militante`
+# sits at 1.24x — it misses the bar by 26 reach. That silence is the point:
+# a tone that reaches like a typical post is not a tone worth nudging toward.
+_MATERIALITY_MULTIPLIER = 1.25
 
 
 @dataclass(frozen=True)
@@ -329,7 +338,7 @@ class AxisEngagement:
         return (self.by_axis.get(axis) or [])[:n]
 
     def above_baseline(self, axis: str, n: int = _HINT_TOP_N) -> list[tuple[str, float, int]]:
-        """Top-n values that actually BEAT the corpus median.
+        """Top-n values that beat the corpus median by a MATERIAL margin.
 
         Ranking alone is not evidence of strength: the top-2 of a weak axis are
         still the top-2. Measured 2026-07-25 on the real corpus — `analitico`
@@ -345,21 +354,21 @@ class AxisEngagement:
             is structurally unnameable: it defines the baseline it would have to
             beat. Defensible (it has no contrast to be better THAN), but it means
             absence here is NOT evidence of weakness;
-          - there is NO materiality threshold. 30 posts at 5,000 + 3 at 5,100
-            names the 3-post value on a +2% edge. Mitigated, not eliminated, by
-            the hint stating the baseline, the n, and "only marginally" inline —
-            the planner is given what it needs to discount it. A minimum edge
-            (e.g. >=1.25x baseline) would close it, but on the real corpus that
-            bar would also silence the tone axis entirely (militante 2,835 vs a
-            2,288 baseline = +24%), so WHERE to put it is an EDITORIAL call for
-            Zero, not a statistical one. Ledgered, deliberately not decided here.
+          - the materiality bar is a JUDGEMENT, not a derivation. Zero set it at
+            `_MATERIALITY_MULTIPLIER` (+25%) on 2026-07-25, closing the hole the
+            first version shipped with: a bare `> baseline` names a 3-post value
+            on a +2% edge over 30 posts. There is no statistical procedure that
+            hands you 1.25 — it is an editorial statement about how large an
+            edge has to be before it is worth steering on, and it is deliberately
+            NOT tuned per axis (a per-axis bar would be fitted to this corpus).
 
         `corpus_median == 0.0` means "baseline unknown" (cold corpus, or a
         non-finite median guarded upstream) and degrades to rank-only — exactly
         the pre-baseline behaviour, never a raise."""
         rows = self.by_axis.get(axis) or []
         if self.corpus_median > 0:
-            rows = [r for r in rows if r[1] > self.corpus_median]
+            bar = self.corpus_median * _MATERIALITY_MULTIPLIER
+            rows = [r for r in rows if r[1] > bar]
         return rows[:n]
 
     @property
@@ -494,12 +503,18 @@ def build_engagement_hint(ae: AxisEngagement) -> str:
         lines.append(f"  - higher-reaching {_AXIS_LABEL.get(axis, axis)}: {named}")
     if not lines:
         return ""
-    # State the corpus baseline so a value that merely TIES the typical post
-    # cannot read as a winner (militante measured 2,835 vs a 2,288 corpus median
-    # — "higher-reaching" would badly overstate a 24% edge without this line).
+    # State the corpus baseline AND the bar, so the planner can size the claim
+    # instead of taking "higher-reaching" on trust. The wording tracks
+    # `_MATERIALITY_MULTIPLIER`: saying "some beat it only marginally" was true
+    # of the >baseline version and became a LIE the moment the bar rose — the
+    # prompt would have told the planner to discount exactly the values now
+    # guaranteed material.
+    _pct = int(round((_MATERIALITY_MULTIPLIER - 1) * 100))
     baseline = (
         f" For scale, the TYPICAL post in this corpus reaches ~{int(ae.corpus_median):,}; "
-        "only values that actually beat that are listed, and some beat it only marginally."
+        f"only values reaching at least {_pct}% above that are listed — anything "
+        "closer to typical is withheld as noise, so an axis may be absent here "
+        "simply because nothing beat the bar."
         if ae.corpus_median > 0
         else ""
     )

--- a/scripts/wr2_creative_ledger.py
+++ b/scripts/wr2_creative_ledger.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import statistics
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from typing import Any
@@ -270,6 +271,29 @@ async def fetch_creative_ledger(conn: Any, limit: int = 8) -> LedgerSnapshot:
 #   - so this is a SOFT, INFORMATIONAL hint to the planner, never a numeric
 #     weight on selection, and every axis value below `_MIN_AXIS_SAMPLES` is
 #     dropped as too-noisy-to-rank.
+#
+# RANK BY MEDIAN, NOT MEAN (2026-07-25 — measured, not theorised). The first
+# retrospective study over the real corpus (50 posts with reach, run read-only
+# on the Pro) found IG reach is extremely long-tailed: min 516 / median 2,288 /
+# mean 8,936 / max 141,240 — a SINGLE post is 31.6% of all reach in the corpus.
+# Ranking by mean therefore ranked the outlier's carrier, not the layout:
+#   cover-photo n=7 -> [141240, 23704, 1360, 1220, 1193, 1185, 1140]
+#                      mean 24,435 (#1)  but median 1,220 (LAST)
+#   rituale     n=5 -> [141240, 1360, 1220, 1193, 1185]
+#                      mean 29,240 (#1)  but median 1,220 (LAST)
+#   statement-bomb n=8 -> median 18,281 — 5 of 8 above 13k, robustly strong.
+# So the hint was naming the two WEAKEST typical performers as the winners. The
+# `n >= _MIN_AXIS_SAMPLES` guard defends against small samples but NOT against
+# SKEW: rituale has n=5, passes the guard, and its typical post (1,220) is BELOW
+# the corpus median. Median is the estimable statistic here; with one
+# observation carrying a third of the corpus the mean is not estimable at all.
+# KNOWN TENSION (deliberate, documented not hidden): median discards tail upside
+# — a layout that goes viral 1-in-7 could win on TOTAL reach while losing on the
+# typical post. That is an EDITORIAL objective choice (reliable reach per post vs
+# expected total), not a statistical one, and it is Zero's call; until it is made,
+# the defensible default is the robust statistic. `corpus_median` is carried into
+# the hint so "higher-reaching" cannot overstate a value that merely ties the
+# corpus baseline.
 # Source of truth is the review-queue JSON (`wr2_queue_writer._resolve_queue_
 # path`), read best-effort: any error → empty signal, generation never blocked.
 
@@ -288,16 +312,55 @@ _HINT_TOP_N = 2
 class AxisEngagement:
     """Per-axis engagement summary from the review queue's published history.
 
-    `by_axis[axis]` is a list of `(value, mean_reach, n)` sorted high→low,
+    `by_axis[axis]` is a list of `(value, MEDIAN_reach, n)` sorted high→low,
     restricted to values with `n >= _MIN_AXIS_SAMPLES`. Empty everywhere when
     there is no usable signal (cold start / unreadable queue) — a caller then
-    gets an empty hint and the planner behaves exactly as before (falsifiable)."""
+    gets an empty hint and the planner behaves exactly as before (falsifiable).
+
+    `corpus_median` is the median reach over ALL counted posts (0.0 when there
+    are none) — the baseline a per-value median must be judged against, so the
+    hint cannot present a value that merely ties the corpus as "higher-reaching"."""
 
     by_axis: dict[str, list[tuple[str, float, int]]]
     total_posts: int
+    corpus_median: float = 0.0
 
     def top(self, axis: str, n: int = _HINT_TOP_N) -> list[tuple[str, float, int]]:
         return (self.by_axis.get(axis) or [])[:n]
+
+    def above_baseline(self, axis: str, n: int = _HINT_TOP_N) -> list[tuple[str, float, int]]:
+        """Top-n values that actually BEAT the corpus median.
+
+        Ranking alone is not evidence of strength: the top-2 of a weak axis are
+        still the top-2. Measured 2026-07-25 on the real corpus — `analitico`
+        (median 2,237) ranked #2 among tones while the TYPICAL post of the whole
+        corpus reaches 2,288, so the hint was about to call a BELOW-baseline
+        value "higher-reaching". Absolute comparison against the baseline, not
+        just rank, is what makes the claim true. An axis where nothing beats the
+        baseline is simply not named (→ possibly an empty hint → the planner
+        falls back to the byte-identical no-hint path, the designed safe state).
+
+        DECLARED LIMITS (cross-family red-team #2, 2026-07-25 — known, not hidden):
+          - the groups ARE the corpus, so a value holding the MAJORITY of posts
+            is structurally unnameable: it defines the baseline it would have to
+            beat. Defensible (it has no contrast to be better THAN), but it means
+            absence here is NOT evidence of weakness;
+          - there is NO materiality threshold. 30 posts at 5,000 + 3 at 5,100
+            names the 3-post value on a +2% edge. Mitigated, not eliminated, by
+            the hint stating the baseline, the n, and "only marginally" inline —
+            the planner is given what it needs to discount it. A minimum edge
+            (e.g. >=1.25x baseline) would close it, but on the real corpus that
+            bar would also silence the tone axis entirely (militante 2,835 vs a
+            2,288 baseline = +24%), so WHERE to put it is an EDITORIAL call for
+            Zero, not a statistical one. Ledgered, deliberately not decided here.
+
+        `corpus_median == 0.0` means "baseline unknown" (cold corpus, or a
+        non-finite median guarded upstream) and degrades to rank-only — exactly
+        the pre-baseline behaviour, never a raise."""
+        rows = self.by_axis.get(axis) or []
+        if self.corpus_median > 0:
+            rows = [r for r in rows if r[1] > self.corpus_median]
+        return rows[:n]
 
     @property
     def has_signal(self) -> bool:
@@ -318,7 +381,7 @@ def _resolve_queue_path(explicit: Any) -> Any:
 
 
 def fetch_axis_engagement(queue_path: Any = None) -> AxisEngagement:
-    """Aggregate mean reach per editorial axis from the review queue's PUBLISHED
+    """Aggregate MEDIAN reach per editorial axis from the review queue's PUBLISHED
     posts that carry engagement_metrics. Best-effort: a missing/unreadable queue
     → empty signal (never raises, never blocks generation). External-only posts
     are included (they are still real IG engagement for the axis), but items
@@ -343,6 +406,7 @@ def fetch_axis_engagement(queue_path: Any = None) -> AxisEngagement:
         return AxisEngagement(by_axis={}, total_posts=0)
 
     reach_by: dict[str, dict[str, list[float]]] = {a: defaultdict(list) for a in _ENGAGEMENT_AXES}
+    all_reaches: list[float] = []
     total = 0
     for it in items:
         if not isinstance(it, dict):
@@ -360,13 +424,14 @@ def fetch_axis_engagement(queue_path: Any = None) -> AxisEngagement:
         except (TypeError, ValueError):
             continue
         # NaN/Infinity survive `<= 0` (every nan/inf comparison is False) and would
-        # both poison the mean AND crash int(mean) in build_engagement_hint —
+        # both poison the statistic AND crash int(...) in build_engagement_hint —
         # json.loads accepts NaN/Infinity by default, so a Python-written queue can
         # legitimately carry them (cross-family red-team D1, 2026-07-25). isfinite is
         # the single guard that keeps the best-effort "never blocks generation" promise.
         if not math.isfinite(reach) or reach <= 0:
             continue
         total += 1
+        all_reaches.append(reach)
         for axis in _ENGAGEMENT_AXES:
             val = it.get(axis)
             if isinstance(val, str) and val.strip():
@@ -374,15 +439,33 @@ def fetch_axis_engagement(queue_path: Any = None) -> AxisEngagement:
 
     by_axis: dict[str, list[tuple[str, float, int]]] = {}
     for axis, buckets in reach_by.items():
-        ranked = [
-            (val, sum(rs) / len(rs), len(rs))
-            for val, rs in buckets.items()
-            if len(rs) >= _MIN_AXIS_SAMPLES
-        ]
+        ranked = []
+        for val, rs in buckets.items():
+            if len(rs) < _MIN_AXIS_SAMPLES:
+                continue
+            # MEDIAN, not mean — one viral post is 31.6% of this corpus's reach
+            # and the mean simply ranked its carrier (see the block comment above).
+            med = statistics.median(rs)
+            # Every ELEMENT is finite (guarded in the loop above), but the median
+            # of an EVEN-sized group averages the two middle values and
+            # 1e308 + 1e308 == inf. `int(inf)` then raises OverflowError inside
+            # build_engagement_hint, whose caller does NOT wrap it
+            # (wr2_draft_generator.py:2237) — that would break this module's
+            # "never blocks generation" promise. Element-level isfinite is NOT
+            # sufficient; the computed statistic needs its own guard.
+            # (cross-family red-team finding #3, 2026-07-25, reproduced on disk.)
+            if not math.isfinite(med):
+                continue
+            ranked.append((val, med, len(rs)))
         ranked.sort(key=lambda t: t[1], reverse=True)
         if ranked:
             by_axis[axis] = ranked
-    return AxisEngagement(by_axis=by_axis, total_posts=total)
+    corpus_median = statistics.median(all_reaches) if all_reaches else 0.0
+    if not math.isfinite(corpus_median):
+        # Same overflow path. 0.0 is the honest "baseline unknown" sentinel:
+        # above_baseline() then degrades to rank-only instead of raising.
+        corpus_median = 0.0
+    return AxisEngagement(by_axis=by_axis, total_posts=total, corpus_median=corpus_median)
 
 
 _AXIS_LABEL = {
@@ -401,17 +484,31 @@ def build_engagement_hint(ae: AxisEngagement) -> str:
     (spec §5 Goodhart guard)."""
     lines: list[str] = []
     for axis in _PLANNER_HINT_AXES:
-        top = ae.top(axis)
+        # above_baseline, NOT top: the top-2 of a weak axis are still the top-2,
+        # and calling a below-corpus-median value "higher-reaching" is a lie the
+        # planner would act on (see AxisEngagement.above_baseline).
+        top = ae.above_baseline(axis)
         if not top:
             continue
-        named = ", ".join(f"{val} (~{int(mr):,} avg reach, n={n})" for val, mr, n in top)
+        named = ", ".join(f"{val} (~{int(mr):,} typical reach, n={n})" for val, mr, n in top)
         lines.append(f"  - higher-reaching {_AXIS_LABEL.get(axis, axis)}: {named}")
     if not lines:
         return ""
+    # State the corpus baseline so a value that merely TIES the typical post
+    # cannot read as a winner (militante measured 2,835 vs a 2,288 corpus median
+    # — "higher-reaching" would badly overstate a 24% edge without this line).
+    baseline = (
+        f" For scale, the TYPICAL post in this corpus reaches ~{int(ae.corpus_median):,}; "
+        "only values that actually beat that are listed, and some beat it only marginally."
+        if ae.corpus_median > 0
+        else ""
+    )
     return (
         "\n\nENGAGEMENT HINT (weak signal — LLM-inferred labels over a small "
-        f"sample of {ae.total_posts} past posts; treat as a gentle nudge, NOT a "
-        "rule):\n"
+        f"sample of {ae.total_posts} past posts. Reach is the MEDIAN (typical) "
+        "post, NOT the mean: this corpus is long-tailed and a single viral post "
+        "otherwise dominates every average. Treat as a gentle nudge, NOT a rule."
+        f"{baseline}):\n"
         + "\n".join(lines)
         + "\nWhen the story genuinely fits one of these, it is worth reaching "
         "for — but CONTENT-FIT and VARIETY still decide. Do not force a "

--- a/scripts/wr2_draft_generator.py
+++ b/scripts/wr2_draft_generator.py
@@ -2248,11 +2248,17 @@ async def _process_one_planner_writer(
     # the socket's self-probe — when it prints reward_live>0 the loop has closed.
     logger.info(
         "Draft %s planner_writer: register=%s liveness_tier=%s recent_arcs=%s "
-        "ledger_entries=%d reward_live=%d engagement_signal=%s(n=%d) "
+        "ledger_entries=%d reward_live=%d engagement_signal=%s(n=%d,injected=%s) "
         "forbidden_phrases=%d",
         draft_id, register, liveness_tier or "(none)", recent_arcs,
         len(ledger.entries), ledger.reward_live_count,
+        # has_signal alone would LIE now (cicatrix #2): since the baseline filter
+        # landed, an axis can rank values and still name none of them (nothing
+        # beats the corpus median) — signal=True while the prompt gets NOTHING.
+        # `injected` is the honest probe: it reports what actually reached the
+        # planner, not what was merely aggregated. (red-team finding #6b.)
         axis_engagement.has_signal, axis_engagement.total_posts,
+        bool(engagement_hint),
         len(forbidden_phrases),
     )
 


### PR DESCRIPTION
The axis-engagement hint tells the WR2 planner which layout/tone values "reach higher". It ranked
them by **mean**. On this corpus the mean is the outlier.

## The measurement (real corpus, 50 posts with reach>0)

`min=516 · median=2,288 · mean=8,936 · max=141,240` — **one post is 31.6% of all reach in the corpus.**

That single post inverts two of the four recommended values:

| axis | by MEAN | by MEDIAN |
|---|---|---|
| layout | `cover-photo`, `statement-bomb` | `statement-bomb`, `qa-dialogue` — **cover-photo goes first → LAST** |
| tone | `rituale`, `militante` | `militante`, `analitico` — **rituale goes first → LAST** |

`rituale` has n=5, so the `n>=3` noise-guard passes it — and its *typical* post (1,220) is **below** the
corpus median (2,288). The hint was steering the planner toward the two worst values. The guard
protects against small samples; it does nothing against **skew**, which is the channel this arrived on.

## Zero's ruling: the bar is +25%, not "above baseline"

The first cure (`> corpus_median`) had a hole named in its own docstring: no **materiality** threshold.
30 posts at 5,000 and 3 at 5,100 would let the 3-post value be named on a 2% edge. `_MATERIALITY_MULTIPLIER = 1.25`.

**Consequence measured before writing the code** (baseline 2,288 → bar 2,861):

- layout **survives** — `statement-bomb` at 7.99×, `qa-dialogue` at 2.05×;
- tone **goes silent** — `militante` sits at 1.24× and misses the bar by **26 reach**.

The silence is the point: a tone that reaches like a typical post has not earned the right to steer the
planner. Net effect on the real prompt = one line fewer, verified by rendering both versions against the
live queue.

## The trap that only rendering the prompt exposed

Reading the code did not show it. The prompt clause said *"some beat it only marginally"* — true at 1.0×,
**false** at 1.25×, and it would have told the planner to discount exactly the values now guaranteed
material. **When you raise a threshold, the text describing it is part of the threshold.** The percentage
is now interpolated from the constant so it can never drift, and the prompt states that an absent axis
means "nothing cleared the bar" — so silence doesn't read as "no data".

The bar is deliberately **not per-axis**: a per-axis bar would be fitted to this corpus.

## Tests

41 → 46. The new five pin the behaviour that is easy to regress: a marginal edge is **not** named, a
material one still is, the bar is exclusive exactly at the multiplier, the hint never calls a listed
value "marginal", and one axis can go silent while the other survives.

The silent-tone fixture reproduces the **measured ratio** (1,240 over a 1,000 baseline) rather than
gluing real labels together — an earlier draft failed because it treated tone and layout as one grouping
when they are independent groupings over the same posts.

## Confound, stated

Layout is not assigned at random — it is chosen to fit the story. "statement-bomb reaches more" may
partly be "stories that deserve statement-bomb are more shareable". This study cannot separate them,
which is one more reason this stays a soft nudge and never becomes a weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)