### PR TITLE
fix(compliance): route E33E/E33F senior renewals, and un-orphan the VOA rule

### DIFF
--- a/apps/backend-rag/backend/services/compliance/renewal_rules.py
+++ b/apps/backend-rag/backend/services/compliance/renewal_rules.py
@@ -273,12 +273,78 @@ RENEWAL_RULES: dict[str, RenewalRule] = {
         complexity=2.0,
         notes="Annual permit for foreign workers. Usually bundled with Working KITAS renewal.",
     ),
-    # ── E33 Second Home (5y permit — guarantee must be maintained) ───────
-    # TODO(senior variants): E33E/E33F senior renewals (income-based, NO
-    # deposit guarantee) also match the "e33"/"second home" patterns below
-    # and would incorrectly inherit the deposit-oriented required_docs.
-    # Add a senior-specific rule (pension/income proof docs) BEFORE E33E/E33F
-    # renewals are sold, and place it earlier in RULE_PRIORITY_ORDER.
+    # ── E33 Second Home senior routes (55+) ──────────────────────────────
+    # These MUST be matched before "e33_second_home_renewal": the generic
+    # rule's patterns ("e33", "second home") are substrings of every senior
+    # string, and its checklist asks for the main-route USD 130k deposit /
+    # USD 1M property title — neither of which applies to a senior client.
+    # Matching is on the VISA CODE (language-invariant fact-key), not prose.
+    "e33e_senior_renewal": RenewalRule(
+        rule_id="e33e_senior_renewal",
+        document_types=("visa", "kitas"),
+        visa_type_patterns=("e33e",),
+        processing_days=30,
+        lead_time_days=120,
+        recommended_start_days=150,
+        renewal_pricing_key="E33E Second Home Senior (5 Years, Altus/Onshore)",
+        required_docs=(
+            "valid_passport",
+            "current_itas_card",
+            "deposit_proof_usd_50k_own_name_bumn_bank",
+            "passive_income_proof_usd_3k_per_month",
+            "domicile_letter",
+        ),
+        complexity=2.0,
+        notes="E33E senior (55+) 5-year route. The permit carries NO extension "
+        "(catalogue extensions=(0,0)) — at expiry this is a fresh application, "
+        "hence the long lead time and the new-application onshore pricing key. "
+        "Financial gate is USD 50,000 own-name BUMN deposit PLUS USD 3,000/month "
+        "passive income — NOT the main-route USD 130k deposit, and there is no "
+        "property alternative on this route.",
+    ),
+    "e33f_senior_renewal": RenewalRule(
+        rule_id="e33f_senior_renewal",
+        document_types=("visa", "kitas"),
+        visa_type_patterns=("e33f",),
+        processing_days=14,
+        lead_time_days=60,
+        recommended_start_days=75,
+        renewal_pricing_key="E33F Second Home Senior (Extend)",
+        required_docs=(
+            "valid_passport",
+            "current_itas_card",
+            "passive_income_proof_usd_3k_per_month",
+            "domicile_letter",
+        ),
+        complexity=1.0,
+        notes="E33F senior (55+) 1-year income-only route, annually renewable. "
+        "NO deposit exists on this route — never request a bank guarantee letter. "
+        "Only the USD 3,000/month passive income proof is re-validated at each "
+        "extension.",
+    ),
+    "e33_senior_route_unspecified": RenewalRule(
+        rule_id="e33_senior_route_unspecified",
+        document_types=("visa", "kitas"),
+        visa_type_patterns=("elderly", "lansia", "second home senior"),
+        processing_days=30,
+        lead_time_days=120,
+        recommended_start_days=150,
+        renewal_pricing_key=None,  # route unknown — quoting one would be a guess
+        required_docs=(
+            "valid_passport",
+            "current_itas_card",
+            "passive_income_proof_usd_3k_per_month",
+            "domicile_letter",
+            "route_confirmation_e33e_deposit_or_e33f_income_only",
+        ),
+        complexity=2.0,
+        notes="Senior second-home client whose record does not carry the E33E/E33F "
+        "code. Income proof is required on both senior routes, so it is safe to ask "
+        "for; the deposit is NOT — confirm the route before requesting documents or "
+        "quoting. Lead time is the conservative (E33E) one: contacting early is "
+        "recoverable, contacting late is not.",
+    ),
+    # ── E33 Second Home main route (5y permit — guarantee must be maintained) ──
     "e33_second_home_renewal": RenewalRule(
         rule_id="e33_second_home_renewal",
         document_types=("visa", "kitas"),
@@ -322,12 +388,19 @@ RULE_PRIORITY_ORDER: tuple[str, ...] = (
     "kitas_working_extend",
     "kitas_freelance_extend",
     "kitas_remote_worker_extend",
+    # Senior second-home routes come BEFORE the generic E33 rule: "e33" and
+    # "second home" are substrings of every senior string, so the generic rule
+    # would otherwise capture them and hand out the main-route deposit checklist.
+    "e33e_senior_renewal",
+    "e33f_senior_renewal",
+    "e33_senior_route_unspecified",
     "e33_second_home_renewal",
     "kitas_investor_extend",
     "kitas_retirement_extend",
     "kitas_spouse_extend",
     "kitas_dependent_extend",
     "imta_annual_renewal",
+    "visa_voa_extension",
     "visa_tourist_extension",
     "passport_renewal",
     "generic_visa_renewal",

--- a/apps/backend-rag/backend/services/compliance/renewal_rules.py
+++ b/apps/backend-rag/backend/services/compliance/renewal_rules.py
@@ -291,6 +291,7 @@ RENEWAL_RULES: dict[str, RenewalRule] = {
             "valid_passport",
             "current_itas_card",
             "deposit_proof_usd_50k_own_name_bumn_bank",
+            "bank_statement_3m_usd_2k_own_name",
             "passive_income_proof_usd_3k_per_month",
             "domicile_letter",
         ),
@@ -298,9 +299,12 @@ RENEWAL_RULES: dict[str, RenewalRule] = {
         notes="E33E senior (55+) 5-year route. The permit carries NO extension "
         "(catalogue extensions=(0,0)) — at expiry this is a fresh application, "
         "hence the long lead time and the new-application onshore pricing key. "
-        "Financial gate is USD 50,000 own-name BUMN deposit PLUS USD 3,000/month "
-        "passive income — NOT the main-route USD 130k deposit, and there is no "
-        "property alternative on this route.",
+        "Financial gate is CUMULATIVE, not alternative: USD 50,000 own-name BUMN "
+        "deposit AND a 3-month personal rekening koran of at least USD 2,000 AND "
+        "USD 3,000/month passive income. NOT the main-route USD 130k deposit, and "
+        "there is no property alternative on this route. NO sponsor — the page "
+        "states it outright ('Anda tidak membutuhkan penjamin/sponsor'), which is "
+        "the axis that separates this route from E33F.",
     ),
     "e33f_senior_renewal": RenewalRule(
         rule_id="e33f_senior_renewal",
@@ -313,14 +317,19 @@ RENEWAL_RULES: dict[str, RenewalRule] = {
         required_docs=(
             "valid_passport",
             "current_itas_card",
+            "sponsor_penjamin_documents",
+            "bank_statement_3m_usd_2k_own_or_sponsor",
             "passive_income_proof_usd_3k_per_month",
             "domicile_letter",
         ),
         complexity=1.0,
-        notes="E33F senior (55+) 1-year income-only route, annually renewable. "
-        "NO deposit exists on this route — never request a bank guarantee letter. "
-        "Only the USD 3,000/month passive income proof is re-validated at each "
-        "extension.",
+        notes="E33F senior 1-year route, annually renewable. NO deposit exists "
+        "here — never request a bank guarantee letter. But 'no deposit' does not "
+        "mean 'income only': the route REQUIRES a penjamin/sponsor ('Anda "
+        "membutuhkan penjamin/sponsor', the exact opposite of E33E) plus a "
+        "3-month rekening koran of at least USD 2,000, which may be held in the "
+        "foreigner's OR the sponsor's name, plus USD 3,000/month income. The "
+        "official page publishes no minimum age for E33F.",
     ),
     "e33_senior_route_unspecified": RenewalRule(
         rule_id="e33_senior_route_unspecified",
@@ -333,16 +342,20 @@ RENEWAL_RULES: dict[str, RenewalRule] = {
         required_docs=(
             "valid_passport",
             "current_itas_card",
+            "bank_statement_3m_usd_2k",
             "passive_income_proof_usd_3k_per_month",
             "domicile_letter",
-            "route_confirmation_e33e_deposit_or_e33f_income_only",
+            "route_confirmation_e33e_deposit_no_sponsor_or_e33f_sponsor_no_deposit",
         ),
         complexity=2.0,
         notes="Senior second-home client whose record does not carry the E33E/E33F "
-        "code. Income proof is required on both senior routes, so it is safe to ask "
-        "for; the deposit is NOT — confirm the route before requesting documents or "
-        "quoting. Lead time is the conservative (E33E) one: contacting early is "
-        "recoverable, contacting late is not.",
+        "code. Ask only for what BOTH routes require — the USD 2,000 3-month "
+        "rekening koran and the USD 3,000/month income. The two things that "
+        "actually diverge are asked for by neither: E33E wants a USD 50,000 "
+        "deposit and NO sponsor, E33F wants a sponsor and NO deposit. Requesting "
+        "either before the route is known sends the client after a document their "
+        "route does not have. Lead time is the conservative (E33E) one: contacting "
+        "early is recoverable, contacting late is not.",
     ),
     # ── E33 Second Home main route (5y permit — guarantee must be maintained) ──
     "e33_second_home_renewal": RenewalRule(

--- a/apps/backend-rag/backend/tests/services/compliance/test_renewal_rules.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_renewal_rules.py
@@ -229,10 +229,51 @@ class TestE33SeniorRoutes:
     def test_e33f_never_asks_for_a_deposit_or_guarantee(self) -> None:
         docs = RENEWAL_RULES["e33f_senior_renewal"].required_docs
         for doc in docs:
-            assert "deposit" not in doc, f"E33F is income-only; {doc!r} asks for a deposit"
-            assert "guarantee" not in doc, f"E33F is income-only; {doc!r} asks for a guarantee"
+            assert "deposit" not in doc, f"E33F has no deposit; {doc!r} asks for one"
+            assert "guarantee" not in doc, f"E33F has no deposit; {doc!r} asks for a guarantee"
             assert "property_title" not in doc, f"E33F has no property route; {doc!r}"
         assert "passive_income_proof_usd_3k_per_month" in docs
+
+    def test_the_two_routes_diverge_on_sponsor_as_well_as_deposit(self) -> None:
+        """The axes are CROSSED, and that is the whole reason for two rules.
+
+        imigrasi.go.id states each one outright and in opposite terms:
+        E33E "Anda TIDAK membutuhkan penjamin/sponsor" + USD 50,000 deposit;
+        E33F "Anda membutuhkan penjamin/sponsor" + no deposit at all.
+
+        Reading only the deposit axis is what produces the plausible-and-wrong
+        summary "E33F is the income-only route" — it is not: it trades the
+        deposit for a sponsor. A client sent away to prepare the wrong one of
+        these two loses the same weeks either way.
+        """
+        e33e = RENEWAL_RULES["e33e_senior_renewal"].required_docs
+        e33f = RENEWAL_RULES["e33f_senior_renewal"].required_docs
+
+        assert "deposit_proof_usd_50k_own_name_bumn_bank" in e33e
+        assert not [d for d in e33e if "sponsor" in d or "penjamin" in d], (
+            "E33E requires no sponsor — asking for one sends the client after a "
+            "document their route does not have"
+        )
+
+        assert [d for d in e33f if "sponsor" in d or "penjamin" in d], (
+            "E33F requires a penjamin/sponsor — omitting it is how a renewal "
+            "gets filed incomplete"
+        )
+        assert not [d for d in e33f if "deposit" in d]
+
+    def test_both_senior_routes_ask_for_the_3_month_2k_statement(self) -> None:
+        """Published on BOTH pages, so it is the one financial document that is
+        safe to request before the route is even known."""
+        for rule_id in (
+            "e33e_senior_renewal",
+            "e33f_senior_renewal",
+            "e33_senior_route_unspecified",
+        ):
+            docs = RENEWAL_RULES[rule_id].required_docs
+            assert [d for d in docs if d.startswith("bank_statement_3m_usd_2k")], (
+                f"{rule_id} omits the USD 2,000 3-month rekening koran that "
+                "imigrasi.go.id publishes for both senior routes"
+            )
 
     def test_e33e_asks_for_its_own_50k_deposit_not_the_main_route_one(self) -> None:
         docs = RENEWAL_RULES["e33e_senior_renewal"].required_docs
@@ -247,11 +288,15 @@ class TestE33SeniorRoutes:
 
     def test_unspecified_route_asks_to_confirm_the_route_before_documents(self) -> None:
         rule = RENEWAL_RULES["e33_senior_route_unspecified"]
-        assert "route_confirmation_e33e_deposit_or_e33f_income_only" in rule.required_docs
-        # Income proof is safe on both senior routes; a deposit is not.
+        assert (
+            "route_confirmation_e33e_deposit_no_sponsor_or_e33f_sponsor_no_deposit"
+            in rule.required_docs
+        )
+        # Safe on both senior routes; the two DIVERGENT documents are not.
         assert "passive_income_proof_usd_3k_per_month" in rule.required_docs
         for doc in rule.required_docs:
             assert "deposit_proof" not in doc, f"route unknown — {doc!r} presumes E33E"
+            assert "sponsor_penjamin" not in doc, f"route unknown — {doc!r} presumes E33F"
         # Quoting a price would presume the route.
         assert rule.renewal_pricing_key is None
 

--- a/apps/backend-rag/backend/tests/services/compliance/test_renewal_rules.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_renewal_rules.py
@@ -1,9 +1,45 @@
 """Tests for renewal_rules.py — RenewalRule matching logic."""
 
+import json
+from pathlib import Path
+
 from backend.services.compliance.renewal_rules import (
     RENEWAL_RULES,
+    RULE_PRIORITY_ORDER,
     match_rule,
 )
+
+# .../backend/tests/services/compliance/this_file.py -> parents[3] == backend/
+_PRICES_FILE = (
+    Path(__file__).resolve().parents[3] / "data" / "bali_zero_official_prices_2026.json"
+)
+
+
+def _known_pricing_keys() -> set[str]:
+    """Every service key in the price catalogue.
+
+    ``tax_accounting`` nests one level deeper than the other categories, so we
+    walk instead of assuming a flat two-level shape: an entry is any dict that
+    carries a ``name`` field.
+    """
+    assert _PRICES_FILE.is_file(), f"price catalogue not found at {_PRICES_FILE}"
+    catalogue = json.loads(_PRICES_FILE.read_text())
+
+    keys: set[str] = set()
+
+    def walk(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            if isinstance(value, dict):
+                if "name" in value:
+                    keys.add(key)
+                else:
+                    walk(value)
+
+    walk(catalogue["services"])
+    assert keys, "walked the price catalogue and found no service entries"
+    return keys
 
 
 class TestMatchRule:
@@ -123,3 +159,158 @@ class TestMatchRule:
         rule_upper = match_rule("KITAS", "INVESTOR KITAS 2 YEARS")
         # Both should match same rule family
         assert rule_lower.rule_id == rule_upper.rule_id
+
+
+# ── E33 senior routes (55+) ────────────────────────────────────────────────────
+#
+# The harm being prevented: "e33" and "second home" are substrings of every
+# senior string, so before these rules existed a senior client was handed the
+# main-route checklist and asked to prove a USD 130,000 deposit (E33F has NO
+# deposit at all) or a USD 1M property title (no such route for seniors).
+#
+# Superscar #3 discipline: every rule below carries BOTH a guilt test (it fires
+# on the case it owns) and an innocence test (it does NOT steal a neighbour).
+
+
+class TestE33SeniorRoutes:
+    # ── Guilt: the senior rules fire on their own cases ───────────────────────
+
+    def test_e33e_code_matches_senior_5y_rule(self) -> None:
+        rule = match_rule("kitas", "E33E")
+        assert rule.rule_id == "e33e_senior_renewal"
+
+    def test_e33f_code_matches_senior_1y_rule(self) -> None:
+        rule = match_rule("kitas", "E33F")
+        assert rule.rule_id == "e33f_senior_renewal"
+
+    def test_e33e_full_pricing_name_matches_by_code_not_prose(self) -> None:
+        # The code wins even though the string also contains "second home senior".
+        rule = match_rule("kitas", "E33E Second Home Senior (5 Years, Offshore)")
+        assert rule.rule_id == "e33e_senior_renewal"
+
+    def test_e33f_extend_pricing_name_matches(self) -> None:
+        rule = match_rule("kitas", "E33F Second Home Senior (Extend)")
+        assert rule.rule_id == "e33f_senior_renewal"
+
+    def test_catalogue_english_name_without_code_hits_unspecified(self) -> None:
+        # catalogue.py name_en for E33F — carries no E-code.
+        rule = match_rule("kitas", "Second Home Visa Elderly for 1 Year")
+        assert rule.rule_id == "e33_senior_route_unspecified"
+
+    def test_catalogue_indonesian_name_hits_unspecified(self) -> None:
+        # W82: the guard must not be blind to the Indonesian surface.
+        rule = match_rule("kitas", "Visa Rumah Kedua Lansia Untuk 5 Tahun")
+        assert rule.rule_id == "e33_senior_route_unspecified"
+
+    # ── Innocence: the senior rules steal nothing from their neighbours ───────
+
+    def test_main_route_e33_still_matches_main_rule(self) -> None:
+        rule = match_rule("kitas", "E33 Second Home")
+        assert rule.rule_id == "e33_second_home_renewal"
+
+    def test_remote_worker_e33g_not_stolen(self) -> None:
+        rule = match_rule("kitas", "E33G Remote Worker")
+        assert rule.rule_id == "kitas_remote_worker_extend"
+
+    def test_retirement_kitas_not_stolen(self) -> None:
+        rule = match_rule("kitas", "Retirement")
+        assert rule.rule_id == "kitas_retirement_extend"
+
+    def test_working_kitas_not_stolen(self) -> None:
+        rule = match_rule("kitas", "Working KITAS")
+        assert rule.rule_id == "kitas_working_extend"
+
+    def test_investor_kitas_not_stolen(self) -> None:
+        rule = match_rule("kitas", "KITAS Investor")
+        assert rule.rule_id == "kitas_investor_extend"
+
+    # ── The defect itself: which documents each route asks for ────────────────
+
+    def test_e33f_never_asks_for_a_deposit_or_guarantee(self) -> None:
+        docs = RENEWAL_RULES["e33f_senior_renewal"].required_docs
+        for doc in docs:
+            assert "deposit" not in doc, f"E33F is income-only; {doc!r} asks for a deposit"
+            assert "guarantee" not in doc, f"E33F is income-only; {doc!r} asks for a guarantee"
+            assert "property_title" not in doc, f"E33F has no property route; {doc!r}"
+        assert "passive_income_proof_usd_3k_per_month" in docs
+
+    def test_e33e_asks_for_its_own_50k_deposit_not_the_main_route_one(self) -> None:
+        docs = RENEWAL_RULES["e33e_senior_renewal"].required_docs
+        assert "deposit_proof_usd_50k_own_name_bumn_bank" in docs
+        assert "passive_income_proof_usd_3k_per_month" in docs
+        # The main-route checklist item must not leak onto the senior route.
+        assert "guarantee_proof_bank_confirmation_or_property_title" not in docs
+
+    def test_main_route_still_asks_for_its_guarantee(self) -> None:
+        docs = RENEWAL_RULES["e33_second_home_renewal"].required_docs
+        assert "guarantee_proof_bank_confirmation_or_property_title" in docs
+
+    def test_unspecified_route_asks_to_confirm_the_route_before_documents(self) -> None:
+        rule = RENEWAL_RULES["e33_senior_route_unspecified"]
+        assert "route_confirmation_e33e_deposit_or_e33f_income_only" in rule.required_docs
+        # Income proof is safe on both senior routes; a deposit is not.
+        assert "passive_income_proof_usd_3k_per_month" in rule.required_docs
+        for doc in rule.required_docs:
+            assert "deposit_proof" not in doc, f"route unknown — {doc!r} presumes E33E"
+        # Quoting a price would presume the route.
+        assert rule.renewal_pricing_key is None
+
+    def test_e33f_annual_lead_time_is_not_the_five_year_one(self) -> None:
+        # E33F is a 1-year permit: a 150-day contact window would fire ~7 months
+        # after issue. The 5-year routes keep the long runway.
+        e33f = RENEWAL_RULES["e33f_senior_renewal"]
+        e33e = RENEWAL_RULES["e33e_senior_renewal"]
+        assert e33f.recommended_start_days < 180
+        assert e33e.recommended_start_days > e33f.recommended_start_days
+
+
+# ── Structural tripwires over the whole rule table ─────────────────────────────
+
+
+class TestRuleTableIntegrity:
+    def test_every_rule_is_reachable_from_the_priority_order(self) -> None:
+        # A rule absent from RULE_PRIORITY_ORDER is dead code: match_rule never
+        # returns it, and the omission is silent.
+        missing = set(RENEWAL_RULES) - set(RULE_PRIORITY_ORDER)
+        assert not missing, f"rules unreachable by match_rule: {sorted(missing)}"
+
+    def test_voa_extension_is_reachable(self) -> None:
+        # visa_voa_extension was defined but absent from RULE_PRIORITY_ORDER, so
+        # every B1/VOA fell through to generic_visa_renewal: a 105-day contact
+        # window on a 30-day visa, and no price. B1 VOA is a live product.
+        rule = match_rule("visa", "B1 Visa on Arrival")
+        assert rule.rule_id == "visa_voa_extension"
+        assert rule.renewal_pricing_key == "B1 Visa on Arrival Extension"
+
+    def test_voa_does_not_steal_the_c1_tourist_extension(self) -> None:
+        rule = match_rule("visa", "C1 Tourism")
+        assert rule.rule_id == "visa_tourist_extension"
+
+    def test_priority_order_has_no_phantom_rule_ids(self) -> None:
+        phantom = set(RULE_PRIORITY_ORDER) - set(RENEWAL_RULES)
+        assert not phantom, f"RULE_PRIORITY_ORDER references undefined rules: {sorted(phantom)}"
+
+    def test_senior_rules_precede_the_generic_e33_rule(self) -> None:
+        order = list(RULE_PRIORITY_ORDER)
+        generic = order.index("e33_second_home_renewal")
+        for senior in (
+            "e33e_senior_renewal",
+            "e33f_senior_renewal",
+            "e33_senior_route_unspecified",
+        ):
+            assert order.index(senior) < generic, (
+                f"{senior} must be matched before e33_second_home_renewal, whose "
+                f'"e33"/"second home" patterns would otherwise capture it'
+            )
+
+    def test_every_renewal_pricing_key_exists_in_the_price_catalogue(self) -> None:
+        # A typo'd key does not raise — it silently yields no price on the alert.
+        known = _known_pricing_keys()
+        for rule in RENEWAL_RULES.values():
+            if rule.renewal_pricing_key is None:
+                continue
+            assert rule.renewal_pricing_key in known, (
+                f"{rule.rule_id} points at pricing key "
+                f"{rule.renewal_pricing_key!r}, which is not in "
+                f"bali_zero_official_prices_2026.json"
+            )


### PR DESCRIPTION
`renewal_rules.py` carried a TODO where the senior routes should be. Until now every E33E and
E33F client fell through to `e33_second_home_renewal`, which is the wrong rule in the way that
costs a client money: it demands **deposit proof** and quotes the Second Home price.

E33E and E33F are not one product with two codes — they diverge on the single most expensive
requirement:

| | deposit | income | renewal price key |
|---|---|---|---|
| **E33E** | USD 50k, own name, BUMN bank | USD 3k/month | `E33E Second Home Senior (5 Years, Altus/Onshore)` |
| **E33F** | **none — no deposit exists on this route** | USD 3k/month | `E33F Second Home Senior (Extend)` |

Asking an E33F holder for deposit proof is asking for a document their route never had. So each
gets its own rule with its own `required_docs`, not a shared one with a footnote.

### The third rule is the interesting one

`e33_senior_route_unspecified` matches the words clients and staff actually use — "elderly",
"lansia", "second home senior" — where the letter is unknown. It carries
`renewal_pricing_key=None` and a required doc named
`route_confirmation_e33e_deposit_or_e33f_income_only`.

That is deliberate: with the route unknown, a price is a guess, and a guessed price on a renewal
is worse than no price. The rule says "confirm which route first" instead of picking one.

### The defect the tests caught

`TestRuleTableIntegrity::test_every_rule_is_reachable_from_the_priority_order` was written to
protect the three new rules from being added and never matched. It failed on a rule I did not
write: **`visa_voa_extension`**, defined at line 209 and absent from `RULE_PRIORITY_ORDER` since
it was added. Every B1/VOA extension has been resolving to `generic_visa_renewal` — with generic
lead times and no VOA pricing key — for as long as that rule has existed.

It is in the order now. This is the whole argument for integrity tests over per-case tests: a
per-case test only covers the case you thought of, and nobody thinks of the rule they forgot.

### Tests

- **guilt**: each senior code resolves to its own rule, with the right pricing key
- **innocence**: E33 main, E33G, Retirement, Working and Investor renewals are NOT stolen by the
  new patterns (the failure mode of adding rules to a priority-ordered table)
- **documents**: E33E demands deposit proof, E33F must NOT, unspecified demands route confirmation
- **integrity**: every pricing key referenced exists in the live catalogue; every rule is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up commit: I got E33F wrong too

Before merging I checked my own table against imigrasi.go.id. Two sentences I wrote were false:
*"E33F senior 1-year income-only route"* and *"only the USD 3,000/month passive income proof is
re-validated at each extension"*.

The routes do not diverge on one axis. They diverge on **two, crossed**, and each page states its
half outright:

| | deposit | sponsor | 3-month statement | income |
|---|---|---|---|---|
| **E33E** | USD 50k, own name, BUMN | **"Anda TIDAK membutuhkan penjamin/sponsor"** | USD 2k, own name | USD 3k/mo |
| **E33F** | none | **"Anda membutuhkan penjamin/sponsor"** | USD 2k, own **or sponsor's** name | USD 3k/mo |

So E33F is not the income-only route — it trades the deposit for a **sponsor**. "Income-only" is
the plausible summary you reach by reading only the expensive axis, and it costs an E33F client the
same weeks the original defect did: they arrive without the penjamin documents. Neither did any of
my three rules ask for the USD 2,000 3-month rekening koran, which **both** pages publish.

Fixed on all three rules, including renaming the route-confirmation document from
`..._e33f_income_only` to `..._e33e_deposit_no_sponsor_or_e33f_sponsor_no_deposit` — the old name
taught the wrong thing every time it was read.

**The two new tests were guilt-proved, not assumed.** Mutating the rule table in memory four ways —
sponsor dropped from E33F, sponsor wrongly added to E33E, statement dropped from E33E, deposit
presumed on the unknown route — the assertions fire on all four. 50 pass, innocence set untouched.

Sources fetched in-session, not recalled. Auto-merge was disarmed before this commit and re-armed
after: a commit that lands after arming can be merged past (lesson from #3114).
