### PR TITLE
feat(mouth): WS2 kita slice 4 — HR suite token drain (GARUDA OS train)

### DIFF
--- a/apps/mouth/src/app/(workspace)/hr/__tests__/token-drain.guard.test.ts
+++ b/apps/mouth/src/app/(workspace)/hr/__tests__/token-drain.guard.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * WS2 kita slice 4 — HR suite drain guard.
+ *
+ * Pins the token drain of the five HR surfaces (leave, payroll slip detail,
+ * bonuses, owner-cashout week detail, employees): no raw hex colors, no raw
+ * status-rgba tuples, no Tailwind status palette utilities in the touched
+ * files. Any future documented one-off survives ONLY on a line carrying a
+ * `// token-lint-ok: <reason>` marker, mirroring scripts/token_lint.py.
+ */
+
+const HR_DIR = join(__dirname, "..");
+
+const TOUCHED: Record<string, string> = {
+  leave: join(HR_DIR, "leave", "page.tsx"),
+  payslip: join(HR_DIR, "payroll", "[slipId]", "page.tsx"),
+  bonuses: join(HR_DIR, "bonuses", "page.tsx"),
+  ownerCashout: join(HR_DIR, "owner-cashout", "[weekId]", "page.tsx"),
+  employees: join(HR_DIR, "employees", "page.tsx"),
+};
+
+// token_lint.py HEX_RE — 3/4/6/8 digits, word-boundary aware.
+const HEX_RE =
+  /(?<![0-9A-Za-z#&])#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9A-Za-z])/;
+
+// Raw status/accent rgba tuples the drain replaced with --state-* /
+// --bz-accent color-mix tints.
+const STATUS_RGBA_TUPLES = [
+  "rgba(239,68,68", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(244,63,94", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(16,185,129", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(5,150,105", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(52,211,153", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(34,197,94", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(77,184,122", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(251,191,36", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(245,158,11", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(59,130,246", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(96,165,250", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(99,102,241", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(139,92,246", // token-lint-ok: drain-guard assertion string, not a color use
+  "rgba(212,132,90", // token-lint-ok: drain-guard assertion string, not a color use
+];
+
+const PALETTE_UTIL_RE =
+  /\b(?:bg|text|border)-(?:red|green|emerald|amber|rose|blue|sky|cyan|purple|violet|indigo|yellow)-\d/;
+
+/** Code lines only: drops full-line comments and token-lint-ok one-offs. */
+function codeLines(path: string): string[] {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((l) => {
+      const t = l.trimStart();
+      if (t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")) {
+        return false;
+      }
+      return !l.includes("token-lint-ok:");
+    });
+}
+
+describe("HR suite drain guard (WS2 slice 4)", () => {
+  for (const [name, path] of Object.entries(TOUCHED)) {
+    it(`${name} carries no unmarked raw hex colors`, () => {
+      for (const line of codeLines(path)) {
+        expect(HEX_RE.test(line), `hex in line: ${line.trim()}`).toBe(false);
+      }
+    });
+
+    it(`${name} carries no raw status/accent rgba tuples`, () => {
+      const src = codeLines(path).join("\n");
+      for (const tuple of STATUS_RGBA_TUPLES) {
+        expect(src.includes(tuple), `found ${tuple}`).toBe(false);
+      }
+    });
+
+    it(`${name} carries no Tailwind status palette utilities`, () => {
+      for (const line of codeLines(path)) {
+        expect(PALETTE_UTIL_RE.test(line), `palette util: ${line.trim()}`).toBe(
+          false,
+        );
+      }
+    });
+
+    it(`${name} panels read the dashboard recipe + --bz-border`, () => {
+      const src = readFileSync(path, "utf8");
+      expect(src).toContain("rgba(35,35,40,0.65)"); // token-lint-ok: drain-guard assertion string, not a color use
+      expect(src).toContain("var(--bz-border)");
+      expect(src).not.toContain("rgba(255,255,255,0.05)"); // token-lint-ok: drain-guard assertion string, not a color use
+      expect(src).not.toContain("rgba(255,255,255,0.07)"); // token-lint-ok: drain-guard assertion string, not a color use
+    });
+  }
+
+  it("leave statuses map to --state-* (pending/approved/rejected)", () => {
+    const src = readFileSync(TOUCHED.leave, "utf8");
+    for (const token of [
+      "var(--state-warning)",
+      "var(--state-success)",
+      "var(--state-danger)",
+      "color-mix(in srgb,",
+    ]) {
+      expect(src).toContain(token);
+    }
+  });
+
+  it("payslip + owner-cashout + bonuses + employees render IDR via Money", () => {
+    for (const key of ["payslip", "ownerCashout", "bonuses", "employees"]) {
+      const src = readFileSync(TOUCHED[key], "utf8");
+      expect(src, `${key} imports Money`).toContain(
+        'import { Money } from "@balizero/core"',
+      );
+      expect(src, `${key} renders Money`).toContain("<Money");
+    }
+  });
+});

--- a/apps/mouth/src/app/(workspace)/hr/bonuses/page.tsx
+++ b/apps/mouth/src/app/(workspace)/hr/bonuses/page.tsx
@@ -22,14 +22,41 @@ import {
   witaMonthKey,
   type MonthAggregate,
 } from "@/lib/hr/bonus-aggregation";
-import { formatIDR } from "@balizero/core/utils";
+import { Money } from "@balizero/core";
 
-const statusColors: Record<string, string> = {
-  pending: "bg-amber-500/10 text-amber-400 border-amber-500/30",
-  approved: "bg-blue-500/10 text-blue-400 border-blue-500/30",
-  paid: "bg-emerald-500/10 text-emerald-400 border-emerald-500/30",
-  rejected: "bg-red-500/10 text-red-400 border-red-500/30",
-  reversed: "bg-zinc-500/10 text-zinc-400 border-zinc-500/30",
+/** Dashboard panel recipe — mirrors the operative-dark kita surfaces. */
+const PANEL: React.CSSProperties = {
+  background: "rgba(35,35,40,0.65)",
+  borderColor: "var(--bz-border)",
+};
+
+/** Bonus-status chip, honestly mapped to --state-* (12% tint + 30% rim). */
+const statusStyles: Record<string, React.CSSProperties> = {
+  pending: {
+    background: "color-mix(in srgb, var(--state-warning) 12%, transparent)",
+    color: "var(--state-warning)",
+    borderColor: "color-mix(in srgb, var(--state-warning) 30%, transparent)",
+  },
+  approved: {
+    background: "color-mix(in srgb, var(--state-info) 12%, transparent)",
+    color: "var(--state-info)",
+    borderColor: "color-mix(in srgb, var(--state-info) 30%, transparent)",
+  },
+  paid: {
+    background: "color-mix(in srgb, var(--state-success) 12%, transparent)",
+    color: "var(--state-success)",
+    borderColor: "color-mix(in srgb, var(--state-success) 30%, transparent)",
+  },
+  rejected: {
+    background: "color-mix(in srgb, var(--state-danger) 12%, transparent)",
+    color: "var(--state-danger)",
+    borderColor: "color-mix(in srgb, var(--state-danger) 30%, transparent)",
+  },
+  reversed: {
+    background: "color-mix(in srgb, var(--bz-text-pure) 6%, transparent)",
+    color: "var(--bz-text-2)",
+    borderColor: "var(--bz-border)",
+  },
 };
 
 const ALL = "all";
@@ -208,29 +235,51 @@ export default function BonusesPage() {
   if (loading) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-bold text-zinc-100">Bonuses</h1>
+        <h1
+          className="text-2xl font-bold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Bonuses
+        </h1>
         <div className="animate-pulse space-y-3">
           {[...Array(5)].map((_, i) => (
-            <div key={i} className="h-16 bg-zinc-900 rounded-lg" />
+            <div key={i} className="h-16 rounded-lg" style={PANEL} />
           ))}
         </div>
       </div>
     );
   }
 
-  const selectCls =
-    "bg-zinc-900 border border-zinc-800 rounded-lg px-2 py-1.5 text-sm text-zinc-300";
+  const selectCls = "border rounded-lg px-2 py-1.5 text-sm";
+  const selectStyle: React.CSSProperties = {
+    background: "var(--bz-surface)",
+    borderColor: "var(--bz-border)",
+    color: "var(--bz-text-1)",
+  };
+
+  const kpis: { label: string; value: React.ReactNode }[] = [
+    { label: "Total", value: <Money value={grandTotal} /> },
+    { label: "Pending", value: <Money value={grandPending} /> },
+    { label: "Months", value: months.length },
+    { label: "Bonuses", value: filtered.length },
+  ];
 
   return (
     <div className="space-y-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-bold text-zinc-100">Bonuses</h1>
+        <h1
+          className="text-2xl font-bold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Bonuses
+        </h1>
         <div className="flex flex-wrap items-center gap-2">
           <select
             aria-label="Filter by year"
             value={year}
             onChange={(e) => setYear(e.target.value)}
             className={selectCls}
+            style={selectStyle}
           >
             <option value={ALL}>All years</option>
             {years.map((y) => (
@@ -244,6 +293,7 @@ export default function BonusesPage() {
             value={status}
             onChange={(e) => setStatus(e.target.value)}
             className={selectCls}
+            style={selectStyle}
           >
             <option value={ALL}>All statuses</option>
             {["pending", "approved", "paid", "rejected", "reversed"].map(
@@ -259,6 +309,7 @@ export default function BonusesPage() {
             value={member}
             onChange={(e) => setMember(e.target.value)}
             className={selectCls}
+            style={selectStyle}
           >
             <option value={ALL}>All members</option>
             {members.map((m) => (
@@ -275,7 +326,7 @@ export default function BonusesPage() {
               )
             }
             disabled={months.length === 0}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 text-sm transition-colors disabled:opacity-40"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-[var(--bz-surface)] text-[var(--bz-text-1)] hover:bg-[var(--surface-raised)] text-sm transition-colors disabled:opacity-40"
           >
             <Download size={14} />
             CSV
@@ -284,20 +335,18 @@ export default function BonusesPage() {
       </div>
 
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        {[
-          { label: "Total", value: formatIDR(grandTotal) },
-          { label: "Pending", value: formatIDR(grandPending) },
-          { label: "Months", value: String(months.length) },
-          { label: "Bonuses", value: String(filtered.length) },
-        ].map((kpi) => (
-          <div
-            key={kpi.label}
-            className="bg-zinc-900 border border-zinc-800 rounded-xl p-3"
-          >
-            <div className="text-xs uppercase tracking-wide text-zinc-500">
+        {kpis.map((kpi) => (
+          <div key={kpi.label} className="border rounded-xl p-3" style={PANEL}>
+            <div
+              className="text-xs uppercase tracking-wide"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               {kpi.label}
             </div>
-            <div className="text-lg font-semibold text-zinc-100 mt-0.5">
+            <div
+              className="text-lg font-semibold mt-0.5"
+              style={{ color: "var(--bz-text-1)" }}
+            >
               {kpi.value}
             </div>
           </div>
@@ -305,7 +354,10 @@ export default function BonusesPage() {
       </div>
 
       {displayMonths.length === 0 ? (
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-8 text-center text-zinc-500">
+        <div
+          className="border rounded-xl p-8 text-center"
+          style={{ ...PANEL, color: "var(--bz-text-2)" }}
+        >
           <Gift size={20} className="mx-auto mb-2 opacity-50" />
           No bonuses for this selection. Bonuses are created automatically when
           practices are completed.
@@ -314,19 +366,34 @@ export default function BonusesPage() {
         <>
           {/* ─── Total per member, across the selected months ─────────── */}
           {memberTotals.length > 0 && (
-            <section className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
-              <div className="px-4 py-3 border-b border-zinc-800">
-                <h2 className="text-sm font-semibold text-zinc-200">
+            <section
+              className="border rounded-xl overflow-hidden"
+              style={PANEL}
+            >
+              <div
+                className="px-4 py-3 border-b"
+                style={{ borderColor: "var(--bz-border)" }}
+              >
+                <h2
+                  className="text-sm font-semibold"
+                  style={{ color: "var(--bz-text-1)" }}
+                >
                   Total per member
                 </h2>
-                <p className="text-xs text-zinc-500 mt-0.5">
+                <p
+                  className="text-xs mt-0.5"
+                  style={{ color: "var(--bz-text-2)" }}
+                >
                   Across every month in the current selection.
                 </p>
               </div>
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="text-xs uppercase tracking-wide text-zinc-500">
+                    <tr
+                      className="text-xs uppercase tracking-wide"
+                      style={{ color: "var(--bz-text-2)" }}
+                    >
                       <th className="text-left font-medium px-4 py-2">
                         Member
                       </th>
@@ -351,9 +418,17 @@ export default function BonusesPage() {
                     {memberTotals.map((m) => (
                       <tr
                         key={m.memberKey}
-                        className="border-t border-zinc-800/70 text-zinc-300"
+                        className="border-t"
+                        style={{
+                          borderColor:
+                            "color-mix(in srgb, var(--bz-border) 70%, transparent)",
+                          color: "var(--bz-text-1)",
+                        }}
                       >
-                        <td className="px-4 py-2 text-zinc-200">
+                        <td
+                          className="px-4 py-2"
+                          style={{ color: "var(--bz-text-1)" }}
+                        >
                           {m.employeeName}
                         </td>
                         <td className="px-4 py-2 text-right tabular-nums">
@@ -362,24 +437,40 @@ export default function BonusesPage() {
                         <td className="px-4 py-2 text-right tabular-nums">
                           {m.count}
                         </td>
-                        <td className="px-4 py-2 text-right tabular-nums text-amber-400">
-                          {m.byStatus.pending
-                            ? formatIDR(m.byStatus.pending)
-                            : "—"}
+                        <td className="px-4 py-2 text-right">
+                          {m.byStatus.pending ? (
+                            <Money
+                              value={m.byStatus.pending}
+                              style={{ color: "var(--state-warning)" }}
+                            />
+                          ) : (
+                            "—"
+                          )}
                         </td>
-                        <td className="px-4 py-2 text-right tabular-nums">
-                          {m.byStatus.approved
-                            ? formatIDR(m.byStatus.approved)
-                            : "—"}
+                        <td className="px-4 py-2 text-right">
+                          {m.byStatus.approved ? (
+                            <Money value={m.byStatus.approved} />
+                          ) : (
+                            "—"
+                          )}
                         </td>
-                        <td className="px-4 py-2 text-right tabular-nums font-semibold text-[var(--bz-accent)]">
-                          {formatIDR(m.total)}
+                        <td className="px-4 py-2 text-right font-semibold">
+                          <Money
+                            value={m.total}
+                            style={{ color: "var(--bz-accent)" }}
+                          />
                         </td>
                       </tr>
                     ))}
                   </tbody>
                   <tfoot>
-                    <tr className="border-t border-zinc-700 text-zinc-200 font-semibold">
+                    <tr
+                      className="border-t font-semibold"
+                      style={{
+                        borderColor: "var(--bz-border-hover)",
+                        color: "var(--bz-text-1)",
+                      }}
+                    >
                       <td className="px-4 py-2">All members</td>
                       <td className="px-4 py-2 text-right tabular-nums">
                         {months.length}
@@ -387,14 +478,24 @@ export default function BonusesPage() {
                       <td className="px-4 py-2 text-right tabular-nums">
                         {filtered.length}
                       </td>
-                      <td className="px-4 py-2 text-right tabular-nums text-amber-400">
-                        {grandPending ? formatIDR(grandPending) : "—"}
+                      <td className="px-4 py-2 text-right">
+                        {grandPending ? (
+                          <Money
+                            value={grandPending}
+                            style={{ color: "var(--state-warning)" }}
+                          />
+                        ) : (
+                          "—"
+                        )}
                       </td>
-                      <td className="px-4 py-2 text-right tabular-nums">
-                        {formatIDR(grandApproved)}
+                      <td className="px-4 py-2 text-right">
+                        <Money value={grandApproved} />
                       </td>
-                      <td className="px-4 py-2 text-right tabular-nums text-[var(--bz-accent)]">
-                        {formatIDR(grandTotal)}
+                      <td className="px-4 py-2 text-right">
+                        <Money
+                          value={grandTotal}
+                          style={{ color: "var(--bz-accent)" }}
+                        />
                       </td>
                     </tr>
                   </tfoot>
@@ -416,31 +517,40 @@ export default function BonusesPage() {
               return (
                 <section
                   key={month.key || "undated"}
-                  className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden"
+                  className="border rounded-xl overflow-hidden"
+                  style={PANEL}
                 >
                   <button
                     onClick={() =>
                       setOpenMonths((p) => ({ ...p, [month.key]: !isOpen }))
                     }
                     aria-expanded={isOpen}
-                    className="w-full flex items-center justify-between gap-3 px-4 py-3 hover:bg-zinc-800/40 transition-colors text-left"
+                    className="w-full flex items-center justify-between gap-3 px-4 py-3 hover:bg-[var(--surface-raised)] transition-colors text-left"
                   >
                     <div className="flex items-center gap-2 min-w-0">
                       {isOpen ? (
                         <ChevronDown
                           size={16}
-                          className="text-zinc-500 shrink-0"
+                          className="shrink-0"
+                          style={{ color: "var(--bz-text-2)" }}
                         />
                       ) : (
                         <ChevronRight
                           size={16}
-                          className="text-zinc-500 shrink-0"
+                          className="shrink-0"
+                          style={{ color: "var(--bz-text-2)" }}
                         />
                       )}
-                      <span className="font-semibold text-zinc-100">
+                      <span
+                        className="font-semibold"
+                        style={{ color: "var(--bz-text-1)" }}
+                      >
                         {month.label}
                       </span>
-                      <span className="text-xs text-zinc-500 truncate">
+                      <span
+                        className="text-xs truncate"
+                        style={{ color: "var(--bz-text-2)" }}
+                      >
                         {pdfOnly ? (
                           "PDF recap only — not yet in the ledger"
                         ) : (
@@ -455,29 +565,48 @@ export default function BonusesPage() {
                     </div>
                     <div className="flex items-center gap-3 shrink-0">
                       {month.pendingTotal > 0 && (
-                        <span className="text-xs px-2 py-0.5 rounded-full border bg-amber-500/10 text-amber-400 border-amber-500/30">
-                          {formatIDR(month.pendingTotal)} pending
+                        <span className="text-xs px-2 py-0.5 rounded-full border bg-[color-mix(in_srgb,var(--state-warning)_12%,transparent)] text-[var(--state-warning)] border-[color-mix(in_srgb,var(--state-warning)_30%,transparent)]">
+                          <Money value={month.pendingTotal} /> pending
                         </span>
                       )}
-                      <span className="text-base font-semibold text-[var(--bz-accent)] tabular-nums">
-                        {pdfOnly && recon
-                          ? // A PDF-only month headlines the PDF figure, but
-                            // NOT when an amount was unreadable — showing the
-                            // understated total would contradict the strip and
-                            // imply a wrong pay figure.
-                            recon.pdfTotalReliable
-                            ? formatIDR(recon.pdfTotal)
-                            : "—"
-                          : formatIDR(month.total)}
-                      </span>
+                      {pdfOnly && recon && !recon.pdfTotalReliable ? (
+                        // A PDF-only month with an unreadable amount headlines
+                        // "—", NOT the understated total — showing it would
+                        // contradict the strip and imply a wrong pay figure.
+                        <span
+                          className="text-base font-semibold"
+                          style={{ color: "var(--bz-accent)" }}
+                        >
+                          —
+                        </span>
+                      ) : (
+                        <Money
+                          value={
+                            pdfOnly && recon ? recon.pdfTotal : month.total
+                          }
+                          className="text-base font-semibold"
+                          style={{ color: "var(--bz-accent)" }}
+                        />
+                      )}
                     </div>
                   </button>
 
                   {isOpen && (
-                    <div className="border-t border-zinc-800">
+                    <div
+                      className="border-t"
+                      style={{ borderColor: "var(--bz-border)" }}
+                    >
                       {recon &&
                         (recon.ledgerAuthoritative ? (
-                          <div className="flex items-start gap-2 px-4 py-2.5 bg-zinc-500/5 border-b border-zinc-700/40 text-xs text-zinc-400">
+                          <div
+                            className="flex items-start gap-2 px-4 py-2.5 border-b text-xs"
+                            style={{
+                              background: "var(--bz-glass-rim)",
+                              borderColor:
+                                "color-mix(in srgb, var(--bz-border) 70%, transparent)",
+                              color: "var(--bz-text-2)",
+                            }}
+                          >
                             <AlertTriangle
                               size={14}
                               className="mt-0.5 shrink-0"
@@ -488,19 +617,16 @@ export default function BonusesPage() {
                               <strong>ledger is authoritative</strong>. A
                               pre-system PDF recap (
                               <strong className="tabular-nums">
-                                {formatIDR(recon.pdfTotal)}
+                                <Money value={recon.pdfTotal} />
                               </strong>
                               , {recon.pdfTasks} tasks —{" "}
                               {recon.sources.join(", ")}) is shown for
                               reference, <strong>not summed</strong>{" "}
                               (whole-month ledger{" "}
-                              <span className="tabular-nums">
-                                {formatIDR(recon.ledgerTotal)}
-                              </span>
-                              , delta{" "}
-                              <span className="tabular-nums">
-                                {formatIDR(recon.ledgerTotal - recon.pdfTotal)}
-                              </span>
+                              <Money value={recon.ledgerTotal} />, delta{" "}
+                              <Money
+                                value={recon.ledgerTotal - recon.pdfTotal}
+                              />
                               ).
                               {filtersNarrowView && (
                                 <>
@@ -512,7 +638,17 @@ export default function BonusesPage() {
                             </span>
                           </div>
                         ) : (
-                          <div className="flex items-start gap-2 px-4 py-2.5 bg-amber-500/10 border-b border-amber-500/30 text-xs text-amber-200/90">
+                          <div
+                            className="flex items-start gap-2 px-4 py-2.5 border-b text-xs"
+                            style={{
+                              background:
+                                "color-mix(in srgb, var(--state-warning) 10%, transparent)",
+                              borderColor:
+                                "color-mix(in srgb, var(--state-warning) 30%, transparent)",
+                              color:
+                                "color-mix(in srgb, var(--state-warning) 40%, var(--bz-text-pure))",
+                            }}
+                          >
                             <AlertTriangle
                               size={14}
                               className="mt-0.5 shrink-0"
@@ -546,16 +682,14 @@ export default function BonusesPage() {
                                 <>
                                   The pre-system PDF list (
                                   <strong className="tabular-nums">
-                                    {formatIDR(recon.pdfTotal)}
+                                    <Money value={recon.pdfTotal} />
                                   </strong>
                                   , {recon.pdfTasks} tasks —{" "}
                                   {recon.sources.join(", ")}) is the{" "}
                                   <strong>authoritative record</strong>; the
                                   ledger (
-                                  <span className="tabular-nums">
-                                    {formatIDR(recon.ledgerTotal)}
-                                  </span>
-                                  ) is a partial backfill —{" "}
+                                  <Money value={recon.ledgerTotal} />) is a
+                                  partial backfill —{" "}
                                   <strong>
                                     use the PDF total for this month
                                   </strong>{" "}
@@ -594,7 +728,11 @@ export default function BonusesPage() {
                         return (
                           <div
                             key={m.memberKey}
-                            className="border-b border-zinc-800/70 last:border-b-0"
+                            className="border-b last:border-b-0"
+                            style={{
+                              borderColor:
+                                "color-mix(in srgb, var(--bz-border) 70%, transparent)",
+                            }}
                           >
                             <button
                               onClick={() =>
@@ -604,78 +742,115 @@ export default function BonusesPage() {
                                 }))
                               }
                               aria-expanded={mOpen}
-                              className="w-full flex items-center justify-between gap-3 px-4 py-2.5 pl-9 hover:bg-zinc-800/30 transition-colors text-left"
+                              className="w-full flex items-center justify-between gap-3 px-4 py-2.5 pl-9 hover:bg-[var(--surface-raised)] transition-colors text-left"
                             >
                               <div className="flex items-center gap-2 min-w-0">
                                 {mOpen ? (
                                   <ChevronDown
                                     size={14}
-                                    className="text-zinc-600 shrink-0"
+                                    className="shrink-0"
+                                    style={{ color: "var(--bz-text-3)" }}
                                   />
                                 ) : (
                                   <ChevronRight
                                     size={14}
-                                    className="text-zinc-600 shrink-0"
+                                    className="shrink-0"
+                                    style={{ color: "var(--bz-text-3)" }}
                                   />
                                 )}
-                                <span className="text-zinc-200 truncate">
+                                <span
+                                  className="truncate"
+                                  style={{ color: "var(--bz-text-1)" }}
+                                >
                                   {m.employeeName}
                                 </span>
-                                <span className="text-xs text-zinc-500">
+                                <span
+                                  className="text-xs"
+                                  style={{ color: "var(--bz-text-2)" }}
+                                >
                                   {m.count} bonus{m.count === 1 ? "" : "es"}
                                 </span>
                               </div>
                               <div className="flex items-center gap-3 shrink-0 text-sm">
                                 {m.byStatus.pending > 0 && (
-                                  <span className="text-xs text-amber-400 tabular-nums">
-                                    {formatIDR(m.byStatus.pending)} pending
+                                  <span className="text-xs">
+                                    <Money
+                                      value={m.byStatus.pending}
+                                      style={{ color: "var(--state-warning)" }}
+                                    />{" "}
+                                    <span
+                                      style={{ color: "var(--state-warning)" }}
+                                    >
+                                      pending
+                                    </span>
                                   </span>
                                 )}
-                                <span className="font-semibold text-zinc-100 tabular-nums">
-                                  {formatIDR(m.total)}
-                                </span>
+                                <Money
+                                  value={m.total}
+                                  className="font-semibold"
+                                  style={{ color: "var(--bz-text-1)" }}
+                                />
                               </div>
                             </button>
 
                             {mOpen && (
-                              <ul className="bg-zinc-950/40">
+                              <ul
+                                style={{
+                                  background:
+                                    "color-mix(in srgb, var(--surface-deep) 40%, transparent)",
+                                }}
+                              >
                                 {m.bonuses.map((bonus) => (
                                   <li
                                     key={bonus.id}
-                                    className="flex items-center justify-between gap-3 px-4 py-2 pl-14 border-t border-zinc-800/50"
+                                    className="flex items-center justify-between gap-3 px-4 py-2 pl-14 border-t"
+                                    style={{
+                                      borderColor:
+                                        "color-mix(in srgb, var(--bz-border) 50%, transparent)",
+                                    }}
                                   >
                                     <div className="min-w-0">
                                       <div className="flex items-center gap-2">
-                                        <span className="text-sm text-zinc-300">
+                                        <span
+                                          className="text-sm"
+                                          style={{ color: "var(--bz-text-1)" }}
+                                        >
                                           {bonus.practice_type_code?.replace(
                                             /_/g,
                                             " ",
                                           )}
                                         </span>
                                         <span
-                                          className={`text-[10px] px-1.5 py-0.5 rounded-full border ${statusColors[bonus.status] || ""}`}
+                                          className="text-[10px] px-1.5 py-0.5 rounded-full border"
+                                          style={
+                                            statusStyles[bonus.status] ??
+                                            statusStyles.reversed
+                                          }
                                         >
                                           {bonus.status}
                                         </span>
                                       </div>
-                                      <div className="text-xs text-zinc-500 mt-0.5 truncate">
+                                      <div
+                                        className="text-xs mt-0.5 truncate"
+                                        style={{ color: "var(--bz-text-2)" }}
+                                      >
                                         {formatBonusDate(bonus.awarded_at)}
                                         {bonus.client_name &&
                                           ` — ${bonus.client_name}`}
                                       </div>
                                     </div>
                                     <div className="flex items-center gap-3 shrink-0">
-                                      <span className="text-sm text-zinc-200 tabular-nums">
-                                        {formatIDR(
-                                          Number(bonus.amount_idr) || 0,
-                                        )}
-                                      </span>
+                                      <Money
+                                        value={Number(bonus.amount_idr) || 0}
+                                        className="text-sm"
+                                        style={{ color: "var(--bz-text-1)" }}
+                                      />
                                       {bonus.status === "pending" && (
                                         <button
                                           onClick={() =>
                                             handleApprove(bonus.id)
                                           }
-                                          className="flex items-center gap-1 px-2 py-1 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-xs transition-colors"
+                                          className="flex items-center gap-1 px-2 py-1 rounded-lg bg-[color-mix(in_srgb,var(--state-success)_12%,transparent)] text-[var(--state-success)] hover:bg-[color-mix(in_srgb,var(--state-success)_20%,transparent)] text-xs transition-colors"
                                         >
                                           <CheckCircle size={12} />
                                           Approve

--- a/apps/mouth/src/app/(workspace)/hr/employees/page.tsx
+++ b/apps/mouth/src/app/(workspace)/hr/employees/page.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 import * as hrApi from "@/lib/api/hr/hr";
 import { useTeamMembers } from "@/hooks/useTeamMembers";
 import type { HREmployee, EmployeeCreatePayload, PTKPStatus } from "@/types/hr";
-import { formatIDR } from "@balizero/core/utils";
+import { Money } from "@balizero/core";
 
 const PTKP_OPTIONS: PTKPStatus[] = [
   "TK/0",
@@ -18,6 +18,25 @@ const PTKP_OPTIONS: PTKPStatus[] = [
   "K/2",
   "K/3",
 ];
+
+/** Dashboard panel recipe — mirrors the operative-dark kita surfaces. */
+const PANEL: React.CSSProperties = {
+  background: "rgba(35,35,40,0.65)",
+  borderColor: "var(--bz-border)",
+};
+
+/** Inline danger strip (load error, form error). */
+const DANGER_STRIP: React.CSSProperties = {
+  background: "color-mix(in srgb, var(--state-danger) 12%, transparent)",
+  borderColor: "color-mix(in srgb, var(--state-danger) 30%, transparent)",
+  color: "var(--state-danger)",
+};
+
+const INPUT_STYLE: React.CSSProperties = {
+  background: "var(--bz-surface)",
+  borderColor: "var(--bz-border)",
+  color: "var(--bz-text-1)",
+};
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("id-ID", {
@@ -118,10 +137,15 @@ export default function EmployeesPage() {
   if (loading) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-bold text-zinc-100">Employees</h1>
+        <h1
+          className="text-2xl font-bold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Employees
+        </h1>
         <div className="animate-pulse space-y-3">
           {[...Array(5)].map((_, i) => (
-            <div key={i} className="h-16 bg-zinc-900 rounded-lg" />
+            <div key={i} className="h-16 rounded-lg" style={PANEL} />
           ))}
         </div>
       </div>
@@ -131,8 +155,13 @@ export default function EmployeesPage() {
   if (error) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-bold text-zinc-100">Employees</h1>
-        <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-6 text-red-400">
+        <h1
+          className="text-2xl font-bold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Employees
+        </h1>
+        <div className="border rounded-xl p-6" style={DANGER_STRIP}>
           {error}
         </div>
       </div>
@@ -142,9 +171,17 @@ export default function EmployeesPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-zinc-100">Employees</h1>
+        <h1
+          className="text-2xl font-bold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Employees
+        </h1>
         <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2 text-sm text-zinc-400">
+          <div
+            className="flex items-center gap-2 text-sm"
+            style={{ color: "var(--bz-text-2)" }}
+          >
             <Users size={16} />
             {employees.length} total
           </div>
@@ -161,21 +198,31 @@ export default function EmployeesPage() {
       {showForm && (
         <form
           onSubmit={handleSubmit}
-          className="bg-zinc-900 border border-[var(--bz-accent)]/30 rounded-xl p-5 space-y-4"
+          className="border rounded-xl p-5 space-y-4"
+          style={{ ...PANEL, borderColor: "var(--bz-border-accent)" }}
         >
-          <h2 className="text-sm font-semibold text-zinc-200 uppercase tracking-wider">
+          <h2
+            className="text-sm font-semibold uppercase tracking-wider"
+            style={{ color: "var(--bz-text-1)" }}
+          >
             New Employee
           </h2>
 
           {formError && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-2 text-sm text-red-400">
+            <div
+              className="border rounded-lg px-4 py-2 text-sm"
+              style={DANGER_STRIP}
+            >
               {formError}
             </div>
           )}
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Team Member *
               </label>
               <div className="relative">
@@ -185,7 +232,8 @@ export default function EmployeesPage() {
                     handleFieldChange("team_member_id", e.target.value)
                   }
                   disabled={loadingTeam}
-                  className="w-full appearance-none bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                  className="w-full appearance-none border rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-[var(--bz-border-accent)]"
+                  style={INPUT_STYLE}
                   required
                 >
                   <option value="">
@@ -199,24 +247,32 @@ export default function EmployeesPage() {
                 </select>
                 <ChevronDown
                   size={14}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 pointer-events-none"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none"
+                  style={{ color: "var(--bz-text-2)" }}
                 />
               </div>
             </div>
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Hire Date *
               </label>
               <input
                 type="date"
                 value={form.hire_date}
                 onChange={(e) => handleFieldChange("hire_date", e.target.value)}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
                 required
               />
             </div>
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Base Salary (IDR) *
               </label>
               <input
@@ -226,7 +282,8 @@ export default function EmployeesPage() {
                   handleFieldChange("base_salary_idr", Number(e.target.value))
                 }
                 placeholder="5000000"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
                 min={0}
                 required
               />
@@ -235,7 +292,10 @@ export default function EmployeesPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Bank Name
               </label>
               <input
@@ -243,11 +303,15 @@ export default function EmployeesPage() {
                 value={form.bank_name || ""}
                 onChange={(e) => handleFieldChange("bank_name", e.target.value)}
                 placeholder="e.g. BCA, Mandiri"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
               />
             </div>
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Bank Account
               </label>
               <input
@@ -257,11 +321,15 @@ export default function EmployeesPage() {
                   handleFieldChange("bank_account", e.target.value)
                 }
                 placeholder="Account number"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
               />
             </div>
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Account Holder
               </label>
               <input
@@ -271,24 +339,34 @@ export default function EmployeesPage() {
                   handleFieldChange("bank_account_holder", e.target.value)
                 }
                 placeholder="Name on account"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
               />
             </div>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">NPWP</label>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
+                NPWP
+              </label>
               <input
                 type="text"
                 value={form.npwp || ""}
                 onChange={(e) => handleFieldChange("npwp", e.target.value)}
                 placeholder="Tax ID number"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
               />
             </div>
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 PTKP Status
               </label>
               <div className="relative">
@@ -297,7 +375,8 @@ export default function EmployeesPage() {
                   onChange={(e) =>
                     handleFieldChange("ptkp_status", e.target.value)
                   }
-                  className="w-full appearance-none bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                  className="w-full appearance-none border rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-[var(--bz-border-accent)]"
+                  style={INPUT_STYLE}
                 >
                   {PTKP_OPTIONS.map((opt) => (
                     <option key={opt} value={opt}>
@@ -307,12 +386,16 @@ export default function EmployeesPage() {
                 </select>
                 <ChevronDown
                   size={14}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 pointer-events-none"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none"
+                  style={{ color: "var(--bz-text-2)" }}
                 />
               </div>
             </div>
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 BPJS Kesehatan
               </label>
               <input
@@ -322,14 +405,18 @@ export default function EmployeesPage() {
                   handleFieldChange("bpjs_kesehatan_number", e.target.value)
                 }
                 placeholder="BPJS health number"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
               />
             </div>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 BPJS Ketenagakerjaan
               </label>
               <input
@@ -342,17 +429,24 @@ export default function EmployeesPage() {
                   )
                 }
                 placeholder="BPJS employment number"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
               />
             </div>
             <div className="md:col-span-2">
-              <label className="block text-xs text-zinc-400 mb-1">Notes</label>
+              <label
+                className="block text-xs mb-1"
+                style={{ color: "var(--bz-text-2)" }}
+              >
+                Notes
+              </label>
               <input
                 type="text"
                 value={form.notes || ""}
                 onChange={(e) => handleFieldChange("notes", e.target.value)}
                 placeholder="Optional notes"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-[var(--bz-accent)]/50"
+                className="w-full border rounded-lg px-3 py-2 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-accent)]"
+                style={INPUT_STYLE}
               />
             </div>
           </div>
@@ -361,7 +455,7 @@ export default function EmployeesPage() {
             <button
               type="submit"
               disabled={submitting}
-              className="px-4 py-2 rounded-lg bg-[var(--bz-accent)] text-zinc-950 text-sm font-medium hover:bg-[var(--bz-accent)]/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-4 py-2 rounded-lg bg-[var(--bz-accent)] text-[var(--bz-navy-900)] text-sm font-medium hover:bg-[var(--bz-accent)]/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {submitting ? "Saving..." : "Save Employee"}
             </button>
@@ -370,15 +464,24 @@ export default function EmployeesPage() {
       )}
 
       {employees.length === 0 ? (
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-8 text-center text-zinc-500">
+        <div
+          className="border rounded-xl p-8 text-center"
+          style={{ ...PANEL, color: "var(--bz-text-2)" }}
+        >
           No employees registered yet. Click &quot;Add Employee&quot; to get
           started.
         </div>
       ) : (
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto border rounded-xl" style={PANEL}>
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-xs text-zinc-500 uppercase tracking-wider border-b border-zinc-800">
+              <tr
+                className="text-xs uppercase tracking-wider border-b"
+                style={{
+                  color: "var(--bz-text-2)",
+                  borderColor: "var(--bz-border)",
+                }}
+              >
                 <th className="text-left px-4 py-3">Name</th>
                 <th className="text-left px-4 py-3">Email</th>
                 <th className="text-left px-4 py-3">Role</th>
@@ -396,19 +499,40 @@ export default function EmployeesPage() {
                 return (
                   <tr
                     key={emp.id}
-                    className="border-b border-zinc-800/50 hover:bg-zinc-800/30 transition-colors"
+                    className="border-b last:border-0 hover:bg-[var(--surface-raised)] transition-colors"
+                    style={{
+                      borderColor:
+                        "color-mix(in srgb, var(--bz-border) 50%, transparent)",
+                    }}
                   >
-                    <td className="px-4 py-3 text-zinc-200 font-medium">
+                    <td
+                      className="px-4 py-3 font-medium"
+                      style={{ color: "var(--bz-text-1)" }}
+                    >
                       {emp.full_name}
                     </td>
-                    <td className="px-4 py-3 text-zinc-400">{emp.email}</td>
-                    <td className="px-4 py-3 text-zinc-400 capitalize">
+                    <td
+                      className="px-4 py-3"
+                      style={{ color: "var(--bz-text-2)" }}
+                    >
+                      {emp.email}
+                    </td>
+                    <td
+                      className="px-4 py-3 capitalize"
+                      style={{ color: "var(--bz-text-2)" }}
+                    >
                       {emp.role}
                     </td>
-                    <td className="px-4 py-3 text-right text-[var(--bz-accent)] font-medium tabular-nums">
-                      {formatIDR(emp.base_salary_idr)}
+                    <td className="px-4 py-3 text-right font-medium">
+                      <Money
+                        value={emp.base_salary_idr}
+                        style={{ color: "var(--bz-accent)" }}
+                      />
                     </td>
-                    <td className="px-4 py-3 text-zinc-400 tabular-nums">
+                    <td
+                      className="px-4 py-3 tabular-nums"
+                      style={{ color: "var(--bz-text-2)" }}
+                    >
                       {formatDate(emp.hire_date)}
                     </td>
                     <td className="px-4 py-3 text-center">
@@ -417,19 +541,37 @@ export default function EmployeesPage() {
                         title={hasBpjs ? "BPJS complete" : "BPJS missing"}
                       >
                         {hasBpjs ? (
-                          <Shield size={16} className="text-emerald-400" />
+                          <Shield
+                            size={16}
+                            style={{ color: "var(--state-success)" }}
+                          />
                         ) : (
-                          <ShieldAlert size={16} className="text-red-400" />
+                          <ShieldAlert
+                            size={16}
+                            style={{ color: "var(--state-danger)" }}
+                          />
                         )}
                       </div>
                     </td>
                     <td className="px-4 py-3 text-center">
                       <span
-                        className={`inline-block text-xs px-2 py-0.5 rounded-full border ${
+                        className="inline-block text-xs px-2 py-0.5 rounded-full border"
+                        style={
                           emp.is_active
-                            ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/30"
-                            : "bg-zinc-500/10 text-zinc-400 border-zinc-500/30"
-                        }`}
+                            ? {
+                                background:
+                                  "color-mix(in srgb, var(--state-success) 12%, transparent)",
+                                color: "var(--state-success)",
+                                borderColor:
+                                  "color-mix(in srgb, var(--state-success) 30%, transparent)",
+                              }
+                            : {
+                                background:
+                                  "color-mix(in srgb, var(--bz-text-pure) 6%, transparent)",
+                                color: "var(--bz-text-2)",
+                                borderColor: "var(--bz-border)",
+                              }
+                        }
                       >
                         {emp.is_active ? "Active" : "Inactive"}
                       </span>

--- a/apps/mouth/src/app/(workspace)/hr/leave/page.tsx
+++ b/apps/mouth/src/app/(workspace)/hr/leave/page.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import React, { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
-import type { LucideIcon } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -12,29 +12,39 @@ import {
   Plus,
   Users,
   Calendar,
-} from 'lucide-react';
-import { toast } from 'sonner';
-import { api } from '@/lib/api';
-import * as hrApi from '@/lib/api/hr/hr';
-import { isHRAdmin } from '@/lib/hr/admin';
-import type { LeaveRequest, LeaveBalance, TeamLeaveSummaryRow } from '@/types/hr';
+} from "lucide-react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import * as hrApi from "@/lib/api/hr/hr";
+import { isHRAdmin } from "@/lib/hr/admin";
+import type {
+  LeaveRequest,
+  LeaveBalance,
+  TeamLeaveSummaryRow,
+} from "@/types/hr";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
 ];
+
+/** Dashboard panel recipe — mirrors the operative-dark kita surfaces. */
+const PANEL: React.CSSProperties = {
+  background: "rgba(35,35,40,0.65)",
+  borderColor: "var(--bz-border)",
+};
 
 const statusIcons: Record<string, LucideIcon> = {
   pending: Clock,
@@ -43,25 +53,29 @@ const statusIcons: Record<string, LucideIcon> = {
   cancelled: XCircle,
 };
 
+/** Icon / label ink per leave status, honestly mapped to --state-*. */
 const statusColors: Record<string, string> = {
-  pending: 'text-amber-400',
-  approved: 'text-emerald-400',
-  rejected: 'text-red-400',
-  cancelled: 'text-zinc-500',
+  pending: "var(--state-warning)",
+  approved: "var(--state-success)",
+  rejected: "var(--state-danger)",
+  cancelled: "var(--bz-text-3)",
 };
 
-const statusBg: Record<string, string> = {
-  pending: 'bg-amber-500/10',
-  approved: 'bg-emerald-500/10',
-  rejected: 'bg-zinc-900',
-  cancelled: 'bg-zinc-900',
+/** Row surface per status: tinted for actionable states, neutral panel for closed ones. */
+const statusRowBg: Record<string, string> = {
+  pending: "color-mix(in srgb, var(--state-warning) 10%, transparent)",
+  approved: "color-mix(in srgb, var(--state-success) 10%, transparent)",
+  rejected: PANEL.background as string,
+  cancelled: PANEL.background as string,
 };
 
 // ── Mini Calendar ─────────────────────────────────────────────────────────────
 
 function MiniCalendar({ requests }: { requests: LeaveRequest[] }) {
   const today = new Date();
-  const [current, setCurrent] = useState(new Date(today.getFullYear(), today.getMonth(), 1));
+  const [current, setCurrent] = useState(
+    new Date(today.getFullYear(), today.getMonth(), 1),
+  );
 
   const year = current.getFullYear();
   const month = current.getMonth();
@@ -72,7 +86,7 @@ function MiniCalendar({ requests }: { requests: LeaveRequest[] }) {
   const dayMap = useMemo(() => {
     const map: Record<string, string[]> = {};
     for (const req of requests) {
-      if (req.status === 'rejected' || req.status === 'cancelled') continue;
+      if (req.status === "rejected" || req.status === "cancelled") continue;
       const start = new Date(req.start_date);
       const end = new Date(req.end_date);
       const cursor = new Date(start);
@@ -95,45 +109,74 @@ function MiniCalendar({ requests }: { requests: LeaveRequest[] }) {
   while (cells.length % 7 !== 0) cells.push(null);
 
   function cellKey(day: number) {
-    return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    return `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
   }
 
-  function dayClass(day: number): string {
+  function dayStyle(day: number): React.CSSProperties {
     const key = cellKey(day);
     const statuses = dayMap[key] ?? [];
     const isToday = key === todayStr;
-    if (statuses.includes('approved'))
-      return 'bg-emerald-500/25 text-emerald-300 rounded-md font-semibold';
-    if (statuses.includes('pending'))
-      return 'bg-amber-500/20 text-amber-300 rounded-md font-semibold';
+    if (statuses.includes("approved"))
+      return {
+        background: "color-mix(in srgb, var(--state-success) 25%, transparent)",
+        color:
+          "color-mix(in srgb, var(--state-success) 55%, var(--bz-text-pure))",
+      };
+    if (statuses.includes("pending"))
+      return {
+        background: "color-mix(in srgb, var(--state-warning) 20%, transparent)",
+        color:
+          "color-mix(in srgb, var(--state-warning) 55%, var(--bz-text-pure))",
+      };
     if (isToday)
-      return 'bg-[var(--bz-accent)]/20 text-[var(--bz-accent)] rounded-md font-bold ring-1 ring-[var(--bz-accent)]/40';
-    return 'text-zinc-400 hover:bg-zinc-800 rounded-md';
+      return {
+        background: "color-mix(in srgb, var(--bz-accent) 20%, transparent)",
+        color: "var(--bz-accent)",
+        boxShadow:
+          "0 0 0 1px color-mix(in srgb, var(--bz-accent) 40%, transparent)",
+      };
+    return { color: "var(--bz-text-2)" };
+  }
+
+  function dayWeight(day: number): string {
+    const key = cellKey(day);
+    const statuses = dayMap[key] ?? [];
+    if (statuses.includes("approved") || statuses.includes("pending"))
+      return "font-semibold";
+    if (key === todayStr) return "font-bold";
+    return "hover:bg-[var(--surface-raised)]";
   }
 
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+    <div className="border rounded-xl p-4" style={PANEL}>
       <div className="flex items-center justify-between mb-4">
         <button
           onClick={() => setCurrent(new Date(year, month - 1, 1))}
-          className="p-1 rounded hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200 transition-colors"
+          className="p-1 rounded text-[var(--bz-text-2)] hover:bg-[var(--surface-raised)] hover:text-[var(--bz-text-1)] transition-colors"
         >
           <ChevronLeft size={16} />
         </button>
-        <span className="text-sm font-semibold text-zinc-200">
+        <span
+          className="text-sm font-semibold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
           {MONTH_NAMES[month]} {year}
         </span>
         <button
           onClick={() => setCurrent(new Date(year, month + 1, 1))}
-          className="p-1 rounded hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200 transition-colors"
+          className="p-1 rounded text-[var(--bz-text-2)] hover:bg-[var(--surface-raised)] hover:text-[var(--bz-text-1)] transition-colors"
         >
           <ChevronRight size={16} />
         </button>
       </div>
 
       <div className="grid grid-cols-7 mb-1">
-        {['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'].map((d) => (
-          <div key={d} className="text-center text-xs text-zinc-600 font-medium py-1">
+        {["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"].map((d) => (
+          <div
+            key={d}
+            className="text-center text-xs font-medium py-1"
+            style={{ color: "var(--bz-text-3)" }}
+          >
             {d}
           </div>
         ))}
@@ -146,25 +189,58 @@ function MiniCalendar({ requests }: { requests: LeaveRequest[] }) {
           ) : (
             <div
               key={day}
-              className={`text-center text-xs py-1.5 cursor-default transition-colors ${dayClass(day)}`}
+              className={`text-center text-xs py-1.5 cursor-default transition-colors rounded-md ${dayWeight(day)}`}
+              style={dayStyle(day)}
             >
               {day}
             </div>
-          )
+          ),
         )}
       </div>
 
-      <div className="flex items-center gap-4 mt-3 pt-3 border-t border-zinc-800">
-        <div className="flex items-center gap-1.5 text-xs text-zinc-500">
-          <div className="w-2.5 h-2.5 rounded-sm bg-emerald-500/25" />
+      <div
+        className="flex items-center gap-4 mt-3 pt-3 border-t"
+        style={{ borderColor: "var(--bz-border)" }}
+      >
+        <div
+          className="flex items-center gap-1.5 text-xs"
+          style={{ color: "var(--bz-text-2)" }}
+        >
+          <div
+            className="w-2.5 h-2.5 rounded-sm"
+            style={{
+              background:
+                "color-mix(in srgb, var(--state-success) 25%, transparent)",
+            }}
+          />
           Approved
         </div>
-        <div className="flex items-center gap-1.5 text-xs text-zinc-500">
-          <div className="w-2.5 h-2.5 rounded-sm bg-amber-500/20" />
+        <div
+          className="flex items-center gap-1.5 text-xs"
+          style={{ color: "var(--bz-text-2)" }}
+        >
+          <div
+            className="w-2.5 h-2.5 rounded-sm"
+            style={{
+              background:
+                "color-mix(in srgb, var(--state-warning) 20%, transparent)",
+            }}
+          />
           Pending
         </div>
-        <div className="flex items-center gap-1.5 text-xs text-zinc-500">
-          <div className="w-2.5 h-2.5 rounded-sm bg-[var(--bz-accent)]/20 ring-1 ring-[var(--bz-accent)]/40" />
+        <div
+          className="flex items-center gap-1.5 text-xs"
+          style={{ color: "var(--bz-text-2)" }}
+        >
+          <div
+            className="w-2.5 h-2.5 rounded-sm"
+            style={{
+              background:
+                "color-mix(in srgb, var(--bz-accent) 20%, transparent)",
+              boxShadow:
+                "0 0 0 1px color-mix(in srgb, var(--bz-accent) 40%, transparent)",
+            }}
+          />
           Today
         </div>
       </div>
@@ -175,11 +251,16 @@ function MiniCalendar({ requests }: { requests: LeaveRequest[] }) {
 // ── Balance Cards ─────────────────────────────────────────────────────────────
 
 function BalanceCards({ balances }: { balances: LeaveBalance[] }) {
-  const annual = balances.find((b) => b.code === 'annual' || b.leave_type_name === 'Annual Leave');
+  const annual = balances.find(
+    (b) => b.code === "annual" || b.leave_type_name === "Annual Leave",
+  );
   if (!annual) return null;
 
   const remaining =
-    annual.allocated_days + (annual.carried_over ?? 0) - annual.used_days - annual.pending_days;
+    annual.allocated_days +
+    (annual.carried_over ?? 0) -
+    annual.used_days -
+    annual.pending_days;
   const pct =
     annual.allocated_days > 0
       ? Math.max(0, Math.round((remaining / annual.allocated_days) * 100))
@@ -187,25 +268,58 @@ function BalanceCards({ balances }: { balances: LeaveBalance[] }) {
 
   return (
     <div className="grid grid-cols-3 gap-3">
-      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-        <div className="text-xs text-zinc-500 mb-1">Allocated</div>
-        <div className="text-2xl font-bold text-zinc-100">{annual.allocated_days}</div>
-        <div className="text-xs text-zinc-600 mt-0.5">days / year</div>
+      <div className="border rounded-xl p-4" style={PANEL}>
+        <div className="text-xs mb-1" style={{ color: "var(--bz-text-2)" }}>
+          Allocated
+        </div>
+        <div
+          className="text-2xl font-bold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          {annual.allocated_days}
+        </div>
+        <div className="text-xs mt-0.5" style={{ color: "var(--bz-text-3)" }}>
+          days / year
+        </div>
       </div>
-      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-        <div className="text-xs text-zinc-500 mb-1">Used</div>
+      <div className="border rounded-xl p-4" style={PANEL}>
+        <div className="text-xs mb-1" style={{ color: "var(--bz-text-2)" }}>
+          Used
+        </div>
         <div className="flex items-baseline gap-1">
-          <span className="text-2xl font-bold text-zinc-300">{annual.used_days}</span>
+          <span
+            className="text-2xl font-bold"
+            style={{ color: "var(--bz-text-1)" }}
+          >
+            {annual.used_days}
+          </span>
           {annual.pending_days > 0 && (
-            <span className="text-xs text-amber-400">+{annual.pending_days} pending</span>
+            <span className="text-xs" style={{ color: "var(--state-warning)" }}>
+              +{annual.pending_days} pending
+            </span>
           )}
         </div>
-        <div className="text-xs text-zinc-600 mt-0.5">days taken</div>
+        <div className="text-xs mt-0.5" style={{ color: "var(--bz-text-3)" }}>
+          days taken
+        </div>
       </div>
-      <div className="bg-zinc-900 border border-[var(--bz-accent)]/20 rounded-xl p-4">
-        <div className="text-xs text-zinc-500 mb-1">Remaining</div>
-        <div className="text-2xl font-bold text-[var(--bz-accent)]">{remaining}</div>
-        <div className="w-full bg-zinc-800 rounded-full h-1 mt-2">
+      <div
+        className="border rounded-xl p-4"
+        style={{ ...PANEL, borderColor: "var(--bz-border-accent)" }}
+      >
+        <div className="text-xs mb-1" style={{ color: "var(--bz-text-2)" }}>
+          Remaining
+        </div>
+        <div className="text-2xl font-bold text-[var(--bz-accent)]">
+          {remaining}
+        </div>
+        <div
+          className="w-full rounded-full h-1 mt-2"
+          style={{
+            background:
+              "color-mix(in srgb, var(--bz-text-pure) 6%, transparent)",
+          }}
+        >
           <div
             className="bg-[var(--bz-accent)] h-1 rounded-full transition-all duration-300"
             style={{ width: `${pct}%` }}
@@ -241,56 +355,82 @@ function RequestRow({
 }) {
   const StatusIcon = statusIcons[req.status] ?? Clock;
 
-  const start = new Date(req.start_date).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
+  const start = new Date(req.start_date).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
   });
-  const end = new Date(req.end_date).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
+  const end = new Date(req.end_date).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
   });
-  const dateLabel = req.start_date === req.end_date ? start : `${start} → ${end}`;
+  const dateLabel =
+    req.start_date === req.end_date ? start : `${start} → ${end}`;
 
   return (
     <div>
       <div
-        className={`border border-zinc-800 rounded-lg p-4 flex items-center justify-between ${statusBg[req.status]}`}
+        className="border rounded-lg p-4 flex items-center justify-between"
+        style={{
+          borderColor: "var(--bz-border)",
+          background: statusRowBg[req.status] ?? (PANEL.background as string),
+        }}
       >
         <div className="flex items-center gap-3 flex-1 min-w-0">
-          <StatusIcon size={17} className={`shrink-0 ${statusColors[req.status]}`} />
+          <StatusIcon
+            size={17}
+            className="shrink-0"
+            style={{ color: statusColors[req.status] ?? "var(--bz-text-2)" }}
+          />
           <div className="min-w-0">
-            <div className="font-medium text-zinc-200 text-sm">
-              {req.leave_type_name} — {req.total_days} day{req.total_days > 1 ? 's' : ''}
+            <div
+              className="font-medium text-sm"
+              style={{ color: "var(--bz-text-1)" }}
+            >
+              {req.leave_type_name} — {req.total_days} day
+              {req.total_days > 1 ? "s" : ""}
             </div>
-            <div className="text-xs text-zinc-500 mt-0.5">
+            <div
+              className="text-xs mt-0.5"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               {isAdmin && req.employee_name && (
-                <span className="font-medium text-zinc-400 mr-1">{req.employee_name} ·</span>
+                <span
+                  className="font-medium mr-1"
+                  style={{ color: "var(--bz-text-2)" }}
+                >
+                  {req.employee_name} ·
+                </span>
               )}
               {dateLabel}
-              {req.reason ? ` · "${req.reason}"` : ''}
+              {req.reason ? ` · "${req.reason}"` : ""}
             </div>
           </div>
         </div>
 
         <div className="flex items-center gap-2 shrink-0 ml-3">
           <span
-            className={`text-xs font-medium capitalize px-2 py-0.5 rounded-full bg-zinc-900/60 ${statusColors[req.status]}`}
+            className="text-xs font-medium capitalize px-2 py-0.5 rounded-full"
+            style={{
+              background:
+                "color-mix(in srgb, var(--surface-deep) 60%, transparent)",
+              color: statusColors[req.status] ?? "var(--bz-text-2)",
+            }}
           >
             {req.status}
           </span>
-          {isAdmin && req.status === 'pending' && (
+          {isAdmin && req.status === "pending" && (
             <>
               <button
                 onClick={() => onApprove(req.id)}
-                className="p-1.5 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 transition-colors"
+                className="p-1.5 rounded-lg bg-[color-mix(in_srgb,var(--state-success)_12%,transparent)] text-[var(--state-success)] hover:bg-[color-mix(in_srgb,var(--state-success)_20%,transparent)] transition-colors"
                 title="Approve"
               >
                 <CheckCircle size={15} />
               </button>
               <button
                 onClick={() => onRejectOpen(req.id)}
-                className="p-1.5 rounded-lg bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors"
+                className="p-1.5 rounded-lg bg-[color-mix(in_srgb,var(--state-danger)_12%,transparent)] text-[var(--state-danger)] hover:bg-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] transition-colors"
                 title="Reject"
               >
                 <XCircle size={15} />
@@ -301,28 +441,39 @@ function RequestRow({
       </div>
 
       {rejectingId === req.id && (
-        <div className="bg-zinc-950 border border-zinc-800 border-t-0 rounded-b-lg px-4 py-3 flex items-center gap-2">
+        <div
+          className="border border-t-0 rounded-b-lg px-4 py-3 flex items-center gap-2"
+          style={{
+            background: "var(--surface-deep)",
+            borderColor: "var(--bz-border)",
+          }}
+        >
           <input
             type="text"
             value={rejectReason}
             onChange={(e) => onRejectReasonChange(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') onRejectConfirm(req.id);
-              if (e.key === 'Escape') onRejectCancel();
+              if (e.key === "Enter") onRejectConfirm(req.id);
+              if (e.key === "Escape") onRejectCancel();
             }}
             placeholder="Rejection reason..."
-            className="flex-1 bg-zinc-900 border border-zinc-700 rounded px-2 py-1.5 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-zinc-500"
+            className="flex-1 border rounded px-2 py-1.5 text-sm placeholder:text-[var(--bz-text-3)] focus:outline-none focus:border-[var(--bz-border-hover)]"
+            style={{
+              background: "var(--bz-surface)",
+              borderColor: "var(--bz-border)",
+              color: "var(--bz-text-1)",
+            }}
             autoFocus
           />
           <button
             onClick={() => onRejectConfirm(req.id)}
-            className="px-3 py-1.5 rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 text-xs font-medium"
+            className="px-3 py-1.5 rounded bg-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] text-[var(--state-danger)] hover:bg-[color-mix(in_srgb,var(--state-danger)_30%,transparent)] text-xs font-medium"
           >
             Confirm
           </button>
           <button
             onClick={onRejectCancel}
-            className="px-3 py-1.5 rounded bg-zinc-800 text-zinc-400 hover:bg-zinc-700 text-xs"
+            className="px-3 py-1.5 rounded bg-[var(--surface-raised)] text-[var(--bz-text-2)] hover:bg-[color-mix(in_srgb,var(--bz-text-pure)_6%,transparent)] text-xs"
           >
             Cancel
           </button>
@@ -336,11 +487,14 @@ function RequestRow({
 
 function TeamSummaryTable({ summary }: { summary: TeamLeaveSummaryRow[] }) {
   // Group by employee, show annual leave only (main metric)
-  const annual = summary.filter((s) => s.leave_type === 'annual');
+  const annual = summary.filter((s) => s.leave_type === "annual");
 
   if (annual.length === 0) {
     return (
-      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm">
+      <div
+        className="border rounded-xl p-6 text-center text-sm"
+        style={{ ...PANEL, color: "var(--bz-text-2)" }}
+      >
         No team leave data.
       </div>
     );
@@ -348,30 +502,48 @@ function TeamSummaryTable({ summary }: { summary: TeamLeaveSummaryRow[] }) {
 
   // Sort by used_days descending (most leave taken first)
   const sorted = [...annual].sort(
-    (a, b) => b.used_days + b.pending_days - (a.used_days + a.pending_days)
+    (a, b) => b.used_days + b.pending_days - (a.used_days + a.pending_days),
   );
 
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+    <div className="border rounded-xl overflow-hidden" style={PANEL}>
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-zinc-800">
-            <th className="text-left text-xs font-semibold text-zinc-500 uppercase tracking-wider px-4 py-3">
+          <tr className="border-b" style={{ borderColor: "var(--bz-border)" }}>
+            <th
+              className="text-left text-xs font-semibold uppercase tracking-wider px-4 py-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Team Member
             </th>
-            <th className="text-center text-xs font-semibold text-zinc-500 uppercase tracking-wider px-3 py-3">
+            <th
+              className="text-center text-xs font-semibold uppercase tracking-wider px-3 py-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Allocated
             </th>
-            <th className="text-center text-xs font-semibold text-zinc-500 uppercase tracking-wider px-3 py-3">
+            <th
+              className="text-center text-xs font-semibold uppercase tracking-wider px-3 py-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Used
             </th>
-            <th className="text-center text-xs font-semibold text-zinc-500 uppercase tracking-wider px-3 py-3">
+            <th
+              className="text-center text-xs font-semibold uppercase tracking-wider px-3 py-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Pending
             </th>
-            <th className="text-center text-xs font-semibold text-zinc-500 uppercase tracking-wider px-3 py-3">
+            <th
+              className="text-center text-xs font-semibold uppercase tracking-wider px-3 py-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Remaining
             </th>
-            <th className="text-right text-xs font-semibold text-zinc-500 uppercase tracking-wider px-4 py-3 w-32">
+            <th
+              className="text-right text-xs font-semibold uppercase tracking-wider px-4 py-3 w-32"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Usage
             </th>
           </tr>
@@ -380,49 +552,100 @@ function TeamSummaryTable({ summary }: { summary: TeamLeaveSummaryRow[] }) {
           {sorted.map((row) => {
             const total = row.allocated_days + (row.carried_over ?? 0);
             const usedPct =
-              total > 0 ? Math.round(((row.used_days + row.pending_days) / total) * 100) : 0;
+              total > 0
+                ? Math.round(((row.used_days + row.pending_days) / total) * 100)
+                : 0;
             const barColor =
-              usedPct > 75 ? 'bg-red-500' : usedPct > 50 ? 'bg-amber-500' : 'bg-emerald-500';
+              usedPct > 75
+                ? "var(--state-danger)"
+                : usedPct > 50
+                  ? "var(--state-warning)"
+                  : "var(--state-success)";
 
             return (
               <tr
                 key={row.employee_id}
-                className="border-b border-zinc-800/50 last:border-0 hover:bg-zinc-800/30 transition-colors"
+                className="border-b last:border-0 hover:bg-[var(--surface-raised)] transition-colors"
+                style={{
+                  borderColor:
+                    "color-mix(in srgb, var(--bz-border) 50%, transparent)",
+                }}
               >
                 <td className="px-4 py-3">
-                  <div className="font-medium text-zinc-200">{row.employee_name}</div>
+                  <div
+                    className="font-medium"
+                    style={{ color: "var(--bz-text-1)" }}
+                  >
+                    {row.employee_name}
+                  </div>
                 </td>
-                <td className="text-center px-3 py-3 text-zinc-400">{row.allocated_days}</td>
+                <td
+                  className="text-center px-3 py-3"
+                  style={{ color: "var(--bz-text-2)" }}
+                >
+                  {row.allocated_days}
+                </td>
                 <td className="text-center px-3 py-3">
                   <span
-                    className={row.used_days > 0 ? 'text-zinc-200 font-medium' : 'text-zinc-500'}
+                    className={row.used_days > 0 ? "font-medium" : ""}
+                    style={{
+                      color:
+                        row.used_days > 0
+                          ? "var(--bz-text-1)"
+                          : "var(--bz-text-2)",
+                    }}
                   >
                     {row.used_days}
                   </span>
                 </td>
                 <td className="text-center px-3 py-3">
                   {row.pending_days > 0 ? (
-                    <span className="text-amber-400 font-medium">{row.pending_days}</span>
+                    <span
+                      className="font-medium"
+                      style={{ color: "var(--state-warning)" }}
+                    >
+                      {row.pending_days}
+                    </span>
                   ) : (
-                    <span className="text-zinc-600">0</span>
+                    <span style={{ color: "var(--bz-text-3)" }}>0</span>
                   )}
                 </td>
                 <td className="text-center px-3 py-3">
                   <span
-                    className={`font-semibold ${row.remaining_days <= 3 ? 'text-red-400' : 'text-[var(--bz-accent)]'}`}
+                    className="font-semibold"
+                    style={{
+                      color:
+                        row.remaining_days <= 3
+                          ? "var(--state-danger)"
+                          : "var(--bz-accent)",
+                    }}
                   >
                     {row.remaining_days}
                   </span>
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
-                    <div className="flex-1 bg-zinc-800 rounded-full h-1.5">
+                    <div
+                      className="flex-1 rounded-full h-1.5"
+                      style={{
+                        background:
+                          "color-mix(in srgb, var(--bz-text-pure) 6%, transparent)",
+                      }}
+                    >
                       <div
-                        className={`${barColor} h-1.5 rounded-full transition-all duration-300`}
-                        style={{ width: `${Math.min(usedPct, 100)}%` }}
+                        className="h-1.5 rounded-full transition-all duration-300"
+                        style={{
+                          width: `${Math.min(usedPct, 100)}%`,
+                          background: barColor,
+                        }}
                       />
                     </div>
-                    <span className="text-xs text-zinc-500 w-8 text-right">{usedPct}%</span>
+                    <span
+                      className="text-xs w-8 text-right"
+                      style={{ color: "var(--bz-text-2)" }}
+                    >
+                      {usedPct}%
+                    </span>
                   </div>
                 </td>
               </tr>
@@ -441,47 +664,79 @@ function TeamRequestsGrouped({ requests }: { requests: LeaveRequest[] }) {
   const grouped = useMemo(() => {
     const map = new Map<string, LeaveRequest[]>();
     for (const req of requests) {
-      const name = req.employee_name ?? 'Unknown';
+      const name = req.employee_name ?? "Unknown";
       if (!map.has(name)) map.set(name, []);
       map.get(name)!.push(req);
     }
     // Sort groups by total days used (desc)
     return Array.from(map.entries()).sort(
       (a, b) =>
-        b[1].reduce((s, r) => s + r.total_days, 0) - a[1].reduce((s, r) => s + r.total_days, 0)
+        b[1].reduce((s, r) => s + r.total_days, 0) -
+        a[1].reduce((s, r) => s + r.total_days, 0),
     );
   }, [requests]);
 
   function formatDate(d: string) {
-    return new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+    return new Date(d).toLocaleDateString("en-GB", {
+      day: "numeric",
+      month: "short",
+    });
   }
 
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl divide-y divide-zinc-800/50">
+    <div
+      className="border rounded-xl divide-y divide-[color-mix(in_srgb,var(--bz-text-pure)_4%,transparent)]"
+      style={PANEL}
+    >
       {grouped.map(([name, reqs]) => {
-        const sickReqs = reqs.filter((r) => r.leave_type_name?.includes('Sick'));
-        const leaveReqs = reqs.filter((r) => !r.leave_type_name?.includes('Sick'));
+        const sickReqs = reqs.filter((r) =>
+          r.leave_type_name?.includes("Sick"),
+        );
+        const leaveReqs = reqs.filter(
+          (r) => !r.leave_type_name?.includes("Sick"),
+        );
         const totalDays = reqs.reduce((s, r) => s + r.total_days, 0);
 
         return (
           <div key={name} className="px-4 py-3">
             <div className="flex items-center justify-between mb-1.5">
-              <span className="font-medium text-zinc-200 text-sm">{name}</span>
-              <span className="text-xs text-zinc-500">
-                {totalDays} day{totalDays !== 1 ? 's' : ''} total
+              <span
+                className="font-medium text-sm"
+                style={{ color: "var(--bz-text-1)" }}
+              >
+                {name}
+              </span>
+              <span className="text-xs" style={{ color: "var(--bz-text-2)" }}>
+                {totalDays} day{totalDays !== 1 ? "s" : ""} total
               </span>
             </div>
             <div className="flex flex-wrap gap-x-4 gap-y-1">
               {leaveReqs.length > 0 && (
-                <div className="text-xs text-zinc-400">
-                  <span className="text-emerald-400/70 font-medium">Leave:</span>{' '}
-                  {leaveReqs.map((r) => formatDate(r.start_date)).join(', ')}
+                <div className="text-xs" style={{ color: "var(--bz-text-2)" }}>
+                  <span
+                    className="font-medium"
+                    style={{
+                      color:
+                        "color-mix(in srgb, var(--state-success) 70%, transparent)",
+                    }}
+                  >
+                    Leave:
+                  </span>{" "}
+                  {leaveReqs.map((r) => formatDate(r.start_date)).join(", ")}
                 </div>
               )}
               {sickReqs.length > 0 && (
-                <div className="text-xs text-zinc-400">
-                  <span className="text-amber-400/70 font-medium">Sick:</span>{' '}
-                  {sickReqs.map((r) => formatDate(r.start_date)).join(', ')}
+                <div className="text-xs" style={{ color: "var(--bz-text-2)" }}>
+                  <span
+                    className="font-medium"
+                    style={{
+                      color:
+                        "color-mix(in srgb, var(--state-warning) 70%, transparent)",
+                    }}
+                  >
+                    Sick:
+                  </span>{" "}
+                  {sickReqs.map((r) => formatDate(r.start_date)).join(", ")}
                 </div>
               )}
             </div>
@@ -500,9 +755,9 @@ export default function LeavePage() {
   const [teamSummary, setTeamSummary] = useState<TeamLeaveSummaryRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState(false);
-  const [adminTab, setAdminTab] = useState<'team' | 'mine'>('team');
+  const [adminTab, setAdminTab] = useState<"team" | "mine">("team");
   const [rejectingId, setRejectingId] = useState<number | null>(null);
-  const [rejectReason, setRejectReason] = useState('');
+  const [rejectReason, setRejectReason] = useState("");
 
   useEffect(() => {
     Promise.all([
@@ -520,31 +775,35 @@ export default function LeavePage() {
     });
   }, []);
 
-  const pendingTeam = requests.filter((r) => r.status === 'pending');
+  const pendingTeam = requests.filter((r) => r.status === "pending");
 
   const handleApprove = async (id: number) => {
     try {
       await hrApi.approveLeave(id);
-      setRequests((prev) => prev.map((r) => (r.id === id ? { ...r, status: 'approved' } : r)));
-      toast.success('Leave request approved');
+      setRequests((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, status: "approved" } : r)),
+      );
+      toast.success("Leave request approved");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to approve');
+      toast.error(err instanceof Error ? err.message : "Failed to approve");
     }
   };
 
   const handleReject = async (id: number) => {
     if (!rejectReason.trim()) {
-      toast.error('Please enter a rejection reason');
+      toast.error("Please enter a rejection reason");
       return;
     }
     try {
       await hrApi.rejectLeave(id, rejectReason);
-      setRequests((prev) => prev.map((r) => (r.id === id ? { ...r, status: 'rejected' } : r)));
+      setRequests((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, status: "rejected" } : r)),
+      );
       setRejectingId(null);
-      setRejectReason('');
-      toast.success('Leave request rejected');
+      setRejectReason("");
+      toast.success("Leave request rejected");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to reject');
+      toast.error(err instanceof Error ? err.message : "Failed to reject");
     }
   };
 
@@ -554,12 +813,12 @@ export default function LeavePage() {
     onApprove: handleApprove,
     onRejectOpen: (id: number) => {
       setRejectingId(rejectingId === id ? null : id);
-      setRejectReason('');
+      setRejectReason("");
     },
     onRejectConfirm: handleReject,
     onRejectCancel: () => {
       setRejectingId(null);
-      setRejectReason('');
+      setRejectReason("");
     },
     onRejectReasonChange: setRejectReason,
   };
@@ -567,10 +826,15 @@ export default function LeavePage() {
   if (loading) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-bold text-zinc-100">Leave</h1>
+        <h1
+          className="text-2xl font-bold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Leave
+        </h1>
         <div className="animate-pulse space-y-3">
           {[...Array(4)].map((_, i) => (
-            <div key={i} className="h-16 bg-zinc-900 rounded-lg" />
+            <div key={i} className="h-16 rounded-lg" style={PANEL} />
           ))}
         </div>
       </div>
@@ -581,7 +845,12 @@ export default function LeavePage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-zinc-100">Leave</h1>
+        <h1
+          className="text-2xl font-bold"
+          style={{ color: "var(--bz-text-1)" }}
+        >
+          Leave
+        </h1>
         <Link
           href="/hr/leave/request"
           className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--bz-accent)]/10 text-[var(--bz-accent)] hover:bg-[var(--bz-accent)]/20 text-sm transition-colors"
@@ -593,29 +862,29 @@ export default function LeavePage() {
 
       {/* Admin tab switcher */}
       {isAdmin && (
-        <div className="flex gap-1 bg-zinc-900 border border-zinc-800 rounded-lg p-1 w-fit">
+        <div className="flex gap-1 border rounded-lg p-1 w-fit" style={PANEL}>
           <button
-            onClick={() => setAdminTab('team')}
+            onClick={() => setAdminTab("team")}
             className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-              adminTab === 'team'
-                ? 'bg-zinc-800 text-zinc-100'
-                : 'text-zinc-500 hover:text-zinc-300'
+              adminTab === "team"
+                ? "bg-[var(--surface-selected)] text-[var(--bz-text-1)]"
+                : "text-[var(--bz-text-2)] hover:text-[var(--bz-text-1)] hover:bg-[var(--surface-raised)]"
             }`}
           >
             <Users size={14} />
             Team
             {pendingTeam.length > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-400 text-xs font-semibold leading-none">
+              <span className="ml-1 px-1.5 py-0.5 rounded-full bg-[color-mix(in_srgb,var(--state-warning)_20%,transparent)] text-[var(--state-warning)] text-xs font-semibold leading-none">
                 {pendingTeam.length}
               </span>
             )}
           </button>
           <button
-            onClick={() => setAdminTab('mine')}
+            onClick={() => setAdminTab("mine")}
             className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-              adminTab === 'mine'
-                ? 'bg-zinc-800 text-zinc-100'
-                : 'text-zinc-500 hover:text-zinc-300'
+              adminTab === "mine"
+                ? "bg-[var(--surface-selected)] text-[var(--bz-text-1)]"
+                : "text-[var(--bz-text-2)] hover:text-[var(--bz-text-1)] hover:bg-[var(--surface-raised)]"
             }`}
           >
             <Calendar size={14} />
@@ -625,28 +894,40 @@ export default function LeavePage() {
       )}
 
       {/* TEAM VIEW */}
-      {isAdmin && adminTab === 'team' ? (
+      {isAdmin && adminTab === "team" ? (
         <div className="space-y-6">
           <div>
-            <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">
+            <p
+              className="text-xs font-semibold uppercase tracking-wider mb-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Team Leave Balances
             </p>
             <TeamSummaryTable summary={teamSummary} />
           </div>
 
           <div>
-            <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">
+            <p
+              className="text-xs font-semibold uppercase tracking-wider mb-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Team Calendar
             </p>
             <MiniCalendar requests={requests} />
           </div>
 
           <div>
-            <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">
+            <p
+              className="text-xs font-semibold uppercase tracking-wider mb-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Pending Approval
             </p>
             {pendingTeam.length === 0 ? (
-              <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm">
+              <div
+                className="border rounded-xl p-6 text-center text-sm"
+                style={{ ...PANEL, color: "var(--bz-text-2)" }}
+              >
                 No pending leave requests.
               </div>
             ) : (
@@ -658,12 +939,17 @@ export default function LeavePage() {
             )}
           </div>
 
-          {requests.filter((r) => r.status !== 'pending').length > 0 && (
+          {requests.filter((r) => r.status !== "pending").length > 0 && (
             <div>
-              <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">
+              <p
+                className="text-xs font-semibold uppercase tracking-wider mb-3"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 Recent History
               </p>
-              <TeamRequestsGrouped requests={requests.filter((r) => r.status !== 'pending')} />
+              <TeamRequestsGrouped
+                requests={requests.filter((r) => r.status !== "pending")}
+              />
             </div>
           )}
         </div>
@@ -673,27 +959,44 @@ export default function LeavePage() {
           {balances.length > 0 && <BalanceCards balances={balances} />}
 
           <div>
-            <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">
+            <p
+              className="text-xs font-semibold uppercase tracking-wider mb-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               Calendar
             </p>
             <MiniCalendar requests={requests} />
           </div>
 
           <div>
-            <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">
+            <p
+              className="text-xs font-semibold uppercase tracking-wider mb-3"
+              style={{ color: "var(--bz-text-2)" }}
+            >
               My Requests
             </p>
             {requests.length === 0 ? (
-              <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm">
-                No leave requests yet.{' '}
-                <Link href="/hr/leave/request" className="text-[var(--bz-accent)] hover:underline">
+              <div
+                className="border rounded-xl p-6 text-center text-sm"
+                style={{ ...PANEL, color: "var(--bz-text-2)" }}
+              >
+                No leave requests yet.{" "}
+                <Link
+                  href="/hr/leave/request"
+                  className="text-[var(--bz-accent)] hover:underline"
+                >
                   Submit your first request →
                 </Link>
               </div>
             ) : (
               <div className="space-y-2">
                 {requests.map((req) => (
-                  <RequestRow key={req.id} req={req} isAdmin={false} {...rejectProps} />
+                  <RequestRow
+                    key={req.id}
+                    req={req}
+                    isAdmin={false}
+                    {...rejectProps}
+                  />
                 ))}
               </div>
             )}

--- a/apps/mouth/src/app/(workspace)/hr/leave/request/page.tsx
+++ b/apps/mouth/src/app/(workspace)/hr/leave/request/page.tsx
@@ -9,8 +9,18 @@ import type { LeaveTypeOption } from "@/lib/api/hr/hr";
 // ─── Mini Calendar Component ───────────────────────────────────────────────
 const DAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
 const MONTHS = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
 ];
 
 function MiniCalendar({
@@ -292,7 +302,8 @@ export default function LeaveRequestPage() {
   }, []);
 
   const setStartDate = (date: string) => {
-    const endDate = form.end_date && form.end_date < date ? date : form.end_date;
+    const endDate =
+      form.end_date && form.end_date < date ? date : form.end_date;
     setForm((prev) => ({
       ...prev,
       start_date: date,

--- a/apps/mouth/src/app/(workspace)/hr/owner-cashout/[weekId]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/hr/owner-cashout/[weekId]/page.tsx
@@ -9,10 +9,16 @@ import type {
   OwnerCashoutRow,
   OwnerCashoutWeekDetail,
 } from "@/types/owner-cashout";
-import { formatIDR } from "@balizero/core/utils";
+import { Money } from "@balizero/core";
 
 const SHEET_URL =
   "https://docs.google.com/spreadsheets/d/1OZzgvDLgf3yd9eUh5CyADjHCHLoXmE5nIRoJlut_jBE/edit";
+
+/** Dashboard panel recipe — mirrors the operative-dark kita surfaces. */
+const PANEL: React.CSSProperties = {
+  background: "rgba(35,35,40,0.65)",
+  borderColor: "var(--bz-border)",
+};
 
 function EntityTable({
   title,
@@ -27,12 +33,18 @@ function EntityTable({
 }) {
   if (rows.length === 0) return null;
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
-      <h3 className="text-sm font-semibold text-zinc-200 p-5 border-b border-zinc-800">
+    <div className="border rounded-xl overflow-hidden" style={PANEL}>
+      <h3
+        className="text-sm font-semibold p-5 border-b"
+        style={{ color: "var(--bz-text-1)", borderColor: "var(--bz-border)" }}
+      >
         {title}
       </h3>
       <table className="w-full text-sm">
-        <thead className="text-xs text-zinc-500 uppercase border-b border-zinc-800">
+        <thead
+          className="text-xs uppercase border-b"
+          style={{ color: "var(--bz-text-2)", borderColor: "var(--bz-border)" }}
+        >
           <tr>
             <th className="text-left px-4 py-3">Client</th>
             <th className="text-left px-4 py-3">Visa</th>
@@ -47,35 +59,49 @@ function EntityTable({
             <th className="text-left px-4 py-3">Note</th>
           </tr>
         </thead>
-        <tbody className="text-zinc-300">
+        <tbody style={{ color: "var(--bz-text-1)" }}>
           {rows.map((r, idx) => (
             <tr
               key={`${r.entity}-${r.row_index}-${idx}`}
-              className="border-b border-zinc-800 last:border-b-0"
+              className="border-b last:border-b-0"
+              style={{ borderColor: "var(--bz-border)" }}
             >
               <td className="px-4 py-2">{r.client_name}</td>
-              <td className="px-4 py-2 text-zinc-400">{r.process || "—"}</td>
-              <td className="text-right px-4 py-2">{formatIDR(r.pnbp_idr)}</td>
+              <td className="px-4 py-2" style={{ color: "var(--bz-text-2)" }}>
+                {r.process || "—"}
+              </td>
               <td className="text-right px-4 py-2">
-                {r.urgent_idr > 0 ? formatIDR(r.urgent_idr) : "—"}
+                <Money value={r.pnbp_idr} />
+              </td>
+              <td className="text-right px-4 py-2">
+                {r.urgent_idr > 0 ? <Money value={r.urgent_idr} /> : "—"}
               </td>
               {showTotalIncome && (
                 <td className="text-right px-4 py-2">
-                  {formatIDR(r.total_income_idr)}
+                  <Money value={r.total_income_idr} />
                 </td>
               )}
-              <td className="text-right px-4 py-2 text-amber-400">
-                {formatIDR(r.margin_bs_idr)}
+              <td className="text-right px-4 py-2">
+                <Money
+                  value={r.margin_bs_idr}
+                  style={{ color: "var(--state-warning)" }}
+                />
               </td>
-              <td className="text-right px-4 py-2 text-emerald-400">
-                {formatIDR(r.margin_bz_idr)}
+              <td className="text-right px-4 py-2">
+                <Money
+                  value={r.margin_bz_idr}
+                  style={{ color: "var(--state-success)" }}
+                />
               </td>
               {showFinalPrice && (
                 <td className="text-right px-4 py-2">
-                  {formatIDR(r.final_price_idr)}
+                  <Money value={r.final_price_idr} />
                 </td>
               )}
-              <td className="px-4 py-2 text-xs text-zinc-500">
+              <td
+                className="px-4 py-2 text-xs"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 {r.note || ""}
               </td>
             </tr>
@@ -117,15 +143,30 @@ export default function OwnerCashoutWeekDetailPage({
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="h-8 bg-zinc-800 rounded w-80 animate-pulse" />
-        <div className="h-64 bg-zinc-900 rounded-xl animate-pulse" />
+        <div
+          className="h-8 rounded w-80 animate-pulse"
+          style={{
+            background:
+              "color-mix(in srgb, var(--bz-text-pure) 6%, transparent)",
+          }}
+        />
+        <div className="h-64 border rounded-xl animate-pulse" style={PANEL} />
       </div>
     );
   }
 
   if (error || !detail) {
     return (
-      <div className="bg-red-900/20 border border-red-800 rounded-xl p-6 text-red-400">
+      <div
+        className="border rounded-xl p-6"
+        style={{
+          background:
+            "color-mix(in srgb, var(--state-danger) 12%, transparent)",
+          borderColor:
+            "color-mix(in srgb, var(--state-danger) 30%, transparent)",
+          color: "var(--state-danger)",
+        }}
+      >
         <Link
           href="/hr/owner-cashout"
           className="inline-flex items-center gap-2 text-sm mb-3"
@@ -143,11 +184,14 @@ export default function OwnerCashoutWeekDetailPage({
         <div>
           <Link
             href="/hr/owner-cashout"
-            className="inline-flex items-center gap-2 text-sm text-zinc-400 hover:text-zinc-200 mb-2"
+            className="inline-flex items-center gap-2 text-sm text-[var(--bz-text-2)] hover:text-[var(--bz-text-1)] mb-2"
           >
             <ArrowLeft size={14} /> Back to Owner Cashout
           </Link>
-          <h1 className="text-2xl font-bold text-zinc-100">
+          <h1
+            className="text-2xl font-bold"
+            style={{ color: "var(--bz-text-1)" }}
+          >
             Week of{" "}
             {new Date(detail.week.week_start).toLocaleDateString("en-GB", {
               day: "2-digit",
@@ -155,7 +199,7 @@ export default function OwnerCashoutWeekDetailPage({
               year: "numeric",
             })}
           </h1>
-          <div className="text-xs text-zinc-500 mt-1">
+          <div className="text-xs mt-1" style={{ color: "var(--bz-text-2)" }}>
             Tabs: {detail.week.tab_name_bz || "—"} /{" "}
             {detail.week.tab_name_bs || "—"}
           </div>
@@ -164,56 +208,81 @@ export default function OwnerCashoutWeekDetailPage({
           href={SHEET_URL}
           target="_blank"
           rel="noreferrer"
-          className="inline-flex items-center gap-2 px-3 py-2 bg-zinc-800 hover:bg-zinc-700 text-zinc-100 rounded-lg border border-zinc-700 text-sm"
+          className="inline-flex items-center gap-2 px-3 py-2 bg-[rgba(35,35,40,0.65)] hover:bg-[var(--surface-raised)] text-[var(--bz-text-1)] rounded-lg border border-[var(--bz-border)] text-sm transition-colors"
         >
           <ExternalLink size={14} /> Open in Sheets
         </a>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-          <div className="text-xs text-zinc-400">Practices</div>
-          <div className="text-xl font-bold text-zinc-100">
+        <div className="border rounded-xl p-4" style={PANEL}>
+          <div className="text-xs" style={{ color: "var(--bz-text-2)" }}>
+            Practices
+          </div>
+          <div
+            className="text-xl font-bold"
+            style={{ color: "var(--bz-text-1)" }}
+          >
             {detail.week.total_practices}
           </div>
         </div>
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-          <div className="text-xs text-zinc-400">Total Income</div>
-          <div className="text-xl font-bold text-zinc-100">
-            {formatIDR(detail.week.total_income_idr)}
+        <div className="border rounded-xl p-4" style={PANEL}>
+          <div className="text-xs" style={{ color: "var(--bz-text-2)" }}>
+            Total Income
           </div>
+          <Money
+            value={detail.week.total_income_idr}
+            className="block text-xl font-bold"
+            style={{ color: "var(--bz-text-1)" }}
+          />
         </div>
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-          <div className="text-xs text-zinc-400">Margin BZ</div>
-          <div className="text-xl font-bold text-emerald-400">
-            {formatIDR(detail.week.total_margin_bz_idr)}
+        <div className="border rounded-xl p-4" style={PANEL}>
+          <div className="text-xs" style={{ color: "var(--bz-text-2)" }}>
+            Margin BZ
           </div>
+          <Money
+            value={detail.week.total_margin_bz_idr}
+            className="block text-xl font-bold"
+            style={{ color: "var(--state-success)" }}
+          />
         </div>
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-          <div className="text-xs text-zinc-400">Margin BS</div>
-          <div className="text-xl font-bold text-amber-400">
-            {formatIDR(detail.week.total_margin_bs_idr)}
+        <div className="border rounded-xl p-4" style={PANEL}>
+          <div className="text-xs" style={{ color: "var(--bz-text-2)" }}>
+            Margin BS
           </div>
+          <Money
+            value={detail.week.total_margin_bs_idr}
+            className="block text-xl font-bold"
+            style={{ color: "var(--state-warning)" }}
+          />
         </div>
       </div>
 
       {detail.subtotals_by_process.length > 0 && (
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-          <h2 className="text-sm font-semibold text-zinc-200 mb-3">
+        <div className="border rounded-xl p-5" style={PANEL}>
+          <h2
+            className="text-sm font-semibold mb-3"
+            style={{ color: "var(--bz-text-1)" }}
+          >
             Subtotals by visa type
           </h2>
           <div className="flex flex-wrap gap-2">
             {detail.subtotals_by_process.map((s) => (
               <div
                 key={s.process}
-                className="px-3 py-2 bg-zinc-800 rounded-lg border border-zinc-700 text-xs"
+                className="px-3 py-2 rounded-lg border text-xs"
+                style={{
+                  background: "var(--bz-surface)",
+                  borderColor: "var(--bz-border)",
+                }}
               >
-                <span className="text-zinc-400">{s.process}: </span>
-                <span className="text-zinc-100">{s.count}</span>
-                <span className="text-zinc-500"> · </span>
-                <span className="text-emerald-400">
-                  {formatIDR(s.margin_bz_idr)}
-                </span>
+                <span style={{ color: "var(--bz-text-2)" }}>{s.process}: </span>
+                <span style={{ color: "var(--bz-text-1)" }}>{s.count}</span>
+                <span style={{ color: "var(--bz-text-3)" }}> · </span>
+                <Money
+                  value={s.margin_bz_idr}
+                  style={{ color: "var(--state-success)" }}
+                />
               </div>
             ))}
           </div>

--- a/apps/mouth/src/app/(workspace)/hr/payroll/[slipId]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/hr/payroll/[slipId]/page.tsx
@@ -5,50 +5,77 @@ import Link from "next/link";
 import { ArrowLeft, FileText } from "lucide-react";
 import { getPayslipDetail } from "@/lib/api/hr/hr";
 import type { PayslipDetail, Deduction } from "@/types/hr";
-import { formatIDR } from "@balizero/core/utils";
+import { Money } from "@balizero/core";
 
-const statusColors: Record<string, string> = {
-  draft: "bg-zinc-500/10 text-zinc-400 border-zinc-700",
-  calculated: "bg-blue-500/10 text-blue-400 border-blue-800",
-  approved: "bg-amber-500/10 text-amber-400 border-amber-800",
-  paid: "bg-emerald-500/10 text-emerald-400 border-emerald-800",
+/** Dashboard panel recipe — mirrors the operative-dark kita surfaces. */
+const PANEL: React.CSSProperties = {
+  background: "rgba(35,35,40,0.65)",
+  borderColor: "var(--bz-border)",
+};
+
+/** Period-status chip, honestly mapped to --state-* (12% tint + 30% rim). */
+const statusStyles: Record<string, React.CSSProperties> = {
+  draft: {
+    background: "color-mix(in srgb, var(--bz-text-pure) 6%, transparent)",
+    color: "var(--bz-text-2)",
+    borderColor: "var(--bz-border)",
+  },
+  calculated: {
+    background: "color-mix(in srgb, var(--state-info) 12%, transparent)",
+    color: "var(--state-info)",
+    borderColor: "color-mix(in srgb, var(--state-info) 30%, transparent)",
+  },
+  approved: {
+    background: "color-mix(in srgb, var(--state-warning) 12%, transparent)",
+    color: "var(--state-warning)",
+    borderColor: "color-mix(in srgb, var(--state-warning) 30%, transparent)",
+  },
+  paid: {
+    background: "color-mix(in srgb, var(--state-success) 12%, transparent)",
+    color: "var(--state-success)",
+    borderColor: "color-mix(in srgb, var(--state-success) 30%, transparent)",
+  },
 };
 
 function PayslipSkeleton() {
+  const bar = "rounded";
+  const barStyle: React.CSSProperties = {
+    background: "color-mix(in srgb, var(--bz-text-pure) 6%, transparent)",
+  };
   return (
     <div className="max-w-2xl mx-auto space-y-6 animate-pulse">
-      <div className="h-5 w-28 bg-zinc-800 rounded" />
-      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 space-y-5">
+      <div className={`h-5 w-28 ${bar}`} style={barStyle} />
+      <div className="border rounded-xl p-6 space-y-5" style={PANEL}>
         <div className="space-y-2">
-          <div className="h-6 w-48 bg-zinc-800 rounded" />
-          <div className="h-4 w-32 bg-zinc-800 rounded" />
+          <div className={`h-6 w-48 ${bar}`} style={barStyle} />
+          <div className={`h-4 w-32 ${bar}`} style={barStyle} />
         </div>
-        <div className="border-t border-zinc-800" />
+        <div className="border-t" style={{ borderColor: "var(--bz-border)" }} />
         <div className="space-y-3">
-          <div className="h-4 w-24 bg-zinc-800 rounded" />
+          <div className={`h-4 w-24 ${bar}`} style={barStyle} />
           {[...Array(3)].map((_, i) => (
             <div key={i} className="flex justify-between">
-              <div className="h-4 w-36 bg-zinc-800 rounded" />
-              <div className="h-4 w-24 bg-zinc-800 rounded" />
+              <div className={`h-4 w-36 ${bar}`} style={barStyle} />
+              <div className={`h-4 w-24 ${bar}`} style={barStyle} />
             </div>
           ))}
-          <div className="h-5 w-full bg-zinc-800 rounded" />
+          <div className={`h-5 w-full ${bar}`} style={barStyle} />
         </div>
-        <div className="border-t border-zinc-800" />
+        <div className="border-t" style={{ borderColor: "var(--bz-border)" }} />
         <div className="space-y-3">
-          <div className="h-4 w-40 bg-zinc-800 rounded" />
+          <div className={`h-4 w-40 ${bar}`} style={barStyle} />
           {[...Array(2)].map((_, i) => (
             <div key={i} className="flex justify-between">
-              <div className="h-4 w-36 bg-zinc-800 rounded" />
-              <div className="h-4 w-24 bg-zinc-800 rounded" />
+              <div className={`h-4 w-36 ${bar}`} style={barStyle} />
+              <div className={`h-4 w-24 ${bar}`} style={barStyle} />
             </div>
           ))}
-          <div className="h-5 w-full bg-zinc-800 rounded" />
+          <div className={`h-5 w-full ${bar}`} style={barStyle} />
         </div>
-        <div className="border-t border-zinc-800" />
+        <div className="border-t" style={{ borderColor: "var(--bz-border)" }} />
         <div className="flex justify-between">
-          <div className="h-7 w-32 bg-zinc-800 rounded" />
-          <div className="h-7 w-36 bg-zinc-800 rounded" />
+          <div className={`h-7 w-32 ${bar}`} style={barStyle} />
+          <div className={`h-7 w-36 ${bar}`} style={barStyle} />
         </div>
       </div>
     </div>
@@ -93,17 +120,24 @@ export default function PayslipDetailPage({
       <div className="max-w-2xl mx-auto space-y-6">
         <Link
           href="/hr/payroll"
-          className="inline-flex items-center gap-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+          className="inline-flex items-center gap-1.5 text-sm text-[var(--bz-text-2)] hover:text-[var(--bz-text-1)] transition-colors"
         >
           <ArrowLeft size={16} />
           Payroll
         </Link>
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-8 text-center">
-          <FileText size={40} className="mx-auto text-zinc-600 mb-3" />
-          <p className="text-zinc-400 text-lg font-medium">
+        <div className="border rounded-xl p-8 text-center" style={PANEL}>
+          <FileText
+            size={40}
+            className="mx-auto mb-3"
+            style={{ color: "var(--bz-text-3)" }}
+          />
+          <p
+            className="text-lg font-medium"
+            style={{ color: "var(--bz-text-2)" }}
+          >
             {error || "Payslip not found"}
           </p>
-          <p className="text-zinc-600 text-sm mt-1">
+          <p className="text-sm mt-1" style={{ color: "var(--bz-text-3)" }}>
             The requested payslip could not be loaded.
           </p>
         </div>
@@ -140,31 +174,44 @@ export default function PayslipDetailPage({
       {/* Back link */}
       <Link
         href="/hr/payroll"
-        className="inline-flex items-center gap-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--bz-text-2)] hover:text-[var(--bz-text-1)] transition-colors"
       >
         <ArrowLeft size={16} />
         Payroll
       </Link>
 
       {/* Payslip receipt */}
-      <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+      <div className="border rounded-xl overflow-hidden" style={PANEL}>
         {/* Header */}
-        <div className="px-6 py-5 border-b border-zinc-800">
+        <div
+          className="px-6 py-5 border-b"
+          style={{ borderColor: "var(--bz-border)" }}
+        >
           <div className="flex items-start justify-between">
             <div>
-              <h1 className="text-xl font-bold text-zinc-100">
+              <h1
+                className="text-xl font-bold"
+                style={{ color: "var(--bz-text-1)" }}
+              >
                 {slip.full_name || slip.employee_name}
               </h1>
-              <p className="text-sm text-zinc-500 mt-0.5">
+              <p
+                className="text-sm mt-0.5"
+                style={{ color: "var(--bz-text-2)" }}
+              >
                 {slip.email || slip.employee_email}
               </p>
             </div>
             <div className="text-right">
-              <p className="text-lg font-semibold text-zinc-200 tabular-nums">
+              <p
+                className="text-lg font-semibold tabular-nums"
+                style={{ color: "var(--bz-text-1)" }}
+              >
                 {periodLabel}
               </p>
               <span
-                className={`inline-block text-xs px-2 py-0.5 rounded-full border mt-1 ${statusColors[slip.period_status] || "bg-zinc-500/10 text-zinc-400 border-zinc-700"}`}
+                className="inline-block text-xs px-2 py-0.5 rounded-full border mt-1"
+                style={statusStyles[slip.period_status] ?? statusStyles.draft}
               >
                 {slip.period_status}
               </span>
@@ -173,73 +220,110 @@ export default function PayslipDetailPage({
         </div>
 
         {/* PENDAPATAN (Income) */}
-        <div className="px-6 py-4 border-b border-zinc-800">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-3">
+        <div
+          className="px-6 py-4 border-b"
+          style={{ borderColor: "var(--bz-border)" }}
+        >
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider mb-3"
+            style={{ color: "var(--bz-text-2)" }}
+          >
             Pendapatan
           </h2>
           <div className="space-y-2">
             <div className="flex justify-between text-sm">
-              <span className="text-zinc-300">Gaji Pokok</span>
-              <span className="text-zinc-200 tabular-nums">
-                {formatIDR(slip.base_salary_idr)}
-              </span>
+              <span style={{ color: "var(--bz-text-1)" }}>Gaji Pokok</span>
+              <Money
+                value={slip.base_salary_idr}
+                style={{ color: "var(--bz-text-1)" }}
+              />
             </div>
             <div className="flex justify-between text-sm">
-              <span className="text-zinc-300">Bonus</span>
-              <span className="text-zinc-200 tabular-nums">
-                {formatIDR(slip.bonus_total_idr)}
-              </span>
+              <span style={{ color: "var(--bz-text-1)" }}>Bonus</span>
+              <Money
+                value={slip.bonus_total_idr}
+                style={{ color: "var(--bz-text-1)" }}
+              />
             </div>
             {slip.allowance_total_idr > 0 && (
               <div className="flex justify-between text-sm">
-                <span className="text-zinc-300">Tunjangan</span>
-                <span className="text-zinc-200 tabular-nums">
-                  {formatIDR(slip.allowance_total_idr)}
-                </span>
+                <span style={{ color: "var(--bz-text-1)" }}>Tunjangan</span>
+                <Money
+                  value={slip.allowance_total_idr}
+                  style={{ color: "var(--bz-text-1)" }}
+                />
               </div>
             )}
             {slip.thr_idr > 0 && (
               <div className="flex justify-between text-sm">
-                <span className="text-zinc-300">THR</span>
-                <span className="text-zinc-200 tabular-nums">
-                  {formatIDR(slip.thr_idr)}
-                </span>
+                <span style={{ color: "var(--bz-text-1)" }}>THR</span>
+                <Money
+                  value={slip.thr_idr}
+                  style={{ color: "var(--bz-text-1)" }}
+                />
               </div>
             )}
-            <div className="flex justify-between pt-2 border-t border-zinc-800">
-              <span className="text-sm font-semibold text-zinc-200">
+            <div
+              className="flex justify-between pt-2 border-t"
+              style={{ borderColor: "var(--bz-border)" }}
+            >
+              <span
+                className="text-sm font-semibold"
+                style={{ color: "var(--bz-text-1)" }}
+              >
                 Total Bruto
               </span>
-              <span className="text-sm font-semibold text-zinc-100 tabular-nums">
-                {formatIDR(totalBruto)}
-              </span>
+              <Money
+                value={totalBruto}
+                className="text-sm font-semibold"
+                style={{ color: "var(--bz-text-pure)" }}
+              />
             </div>
           </div>
         </div>
 
         {/* POTONGAN KARYAWAN (Employee Deductions) */}
-        <div className="px-6 py-4 border-b border-zinc-800">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-3">
+        <div
+          className="px-6 py-4 border-b"
+          style={{ borderColor: "var(--bz-border)" }}
+        >
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider mb-3"
+            style={{ color: "var(--bz-text-2)" }}
+          >
             Potongan Karyawan
           </h2>
           {employeeDeductions.length === 0 ? (
-            <p className="text-sm text-zinc-600">Tidak ada potongan</p>
+            <p className="text-sm" style={{ color: "var(--bz-text-3)" }}>
+              Tidak ada potongan
+            </p>
           ) : (
             <div className="space-y-2">
               {employeeDeductions.map((d) => (
                 <div key={d.id} className="flex justify-between text-sm">
-                  <span className="text-zinc-300">{d.label}</span>
-                  <span className="text-red-400 tabular-nums">
-                    -{formatIDR(d.amount_idr)}
+                  <span style={{ color: "var(--bz-text-1)" }}>{d.label}</span>
+                  <span style={{ color: "var(--state-danger)" }}>
+                    -
+                    <Money value={d.amount_idr} />
                   </span>
                 </div>
               ))}
-              <div className="flex justify-between pt-2 border-t border-zinc-800">
-                <span className="text-sm font-semibold text-zinc-200">
+              <div
+                className="flex justify-between pt-2 border-t"
+                style={{ borderColor: "var(--bz-border)" }}
+              >
+                <span
+                  className="text-sm font-semibold"
+                  style={{ color: "var(--bz-text-1)" }}
+                >
                   Total Potongan
                 </span>
-                <span className="text-sm font-semibold text-red-400 tabular-nums">
-                  -{formatIDR(totalEmployeeDeductions)}
+                <span
+                  className="text-sm font-semibold"
+                  style={{ color: "var(--state-danger)" }}
+                >
+                  -
+                  <Money value={totalEmployeeDeductions} />
                 </span>
               </div>
             </div>
@@ -248,49 +332,88 @@ export default function PayslipDetailPage({
 
         {/* KONTRIBUSI PERUSAHAAN (Employer Contributions) */}
         {employerContributions.length > 0 && (
-          <div className="px-6 py-4 border-b border-zinc-800">
-            <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-600 mb-3">
+          <div
+            className="px-6 py-4 border-b"
+            style={{ borderColor: "var(--bz-border)" }}
+          >
+            <h2
+              className="text-xs font-semibold uppercase tracking-wider mb-3"
+              style={{ color: "var(--bz-text-3)" }}
+            >
               Kontribusi Perusahaan
             </h2>
             <div className="space-y-2">
               {employerContributions.map((d) => (
                 <div key={d.id} className="flex justify-between text-sm">
-                  <span className="text-zinc-500">{d.label}</span>
-                  <span className="text-zinc-500 tabular-nums">
-                    {formatIDR(d.amount_idr)}
-                  </span>
+                  <span style={{ color: "var(--bz-text-2)" }}>{d.label}</span>
+                  <Money
+                    value={d.amount_idr}
+                    style={{ color: "var(--bz-text-2)" }}
+                  />
                 </div>
               ))}
-              <div className="flex justify-between pt-2 border-t border-zinc-800/50">
-                <span className="text-sm text-zinc-500">Total Kontribusi</span>
-                <span className="text-sm text-zinc-500 tabular-nums">
-                  {formatIDR(totalEmployerContributions)}
+              <div
+                className="flex justify-between pt-2 border-t"
+                style={{
+                  borderColor:
+                    "color-mix(in srgb, var(--bz-border) 50%, transparent)",
+                }}
+              >
+                <span className="text-sm" style={{ color: "var(--bz-text-2)" }}>
+                  Total Kontribusi
                 </span>
+                <Money
+                  value={totalEmployerContributions}
+                  className="text-sm"
+                  style={{ color: "var(--bz-text-2)" }}
+                />
               </div>
             </div>
           </div>
         )}
 
         {/* GAJI BERSIH (Net Salary) Footer */}
-        <div className="px-6 py-5 bg-zinc-950/50">
+        <div
+          className="px-6 py-5"
+          style={{
+            background:
+              "color-mix(in srgb, var(--surface-deep) 50%, transparent)",
+          }}
+        >
           <div className="flex items-center justify-between">
-            <span className="text-base font-bold text-zinc-200 uppercase tracking-wide">
+            <span
+              className="text-base font-bold uppercase tracking-wide"
+              style={{ color: "var(--bz-text-1)" }}
+            >
               Gaji Bersih
             </span>
-            <span className="text-2xl font-bold text-emerald-400 tabular-nums">
-              {formatIDR(slip.net_salary_idr)}
-            </span>
+            <Money
+              value={slip.net_salary_idr}
+              className="text-2xl font-bold"
+              style={{ color: "var(--state-success)" }}
+            />
           </div>
         </div>
       </div>
 
       {/* Notes */}
       {slip.notes && (
-        <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg px-5 py-3">
-          <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-1">
+        <div
+          className="border rounded-lg px-5 py-3"
+          style={{
+            background: "var(--bz-glass-rim)",
+            borderColor: "var(--bz-border)",
+          }}
+        >
+          <p
+            className="text-xs font-semibold uppercase tracking-wider mb-1"
+            style={{ color: "var(--bz-text-2)" }}
+          >
             Catatan
           </p>
-          <p className="text-sm text-zinc-400">{slip.notes}</p>
+          <p className="text-sm" style={{ color: "var(--bz-text-2)" }}>
+            {slip.notes}
+          </p>
         </div>
       )}
     </div>


### PR DESCRIPTION
## WS2 kita slice 4 — leave, payroll, bonuses, cashout, employees token-clean

**Author:** Kimi (builder) · **Contract:** author never merges. Dark operative theme — token alignment, not a light pass.

### What (5 pages, ~129 drift drained)
- **leave**: status maps → `--state-*`; pastel calendar via color-mix; panels → dashboard recipe; active tab → `--surface-selected`
- **payroll/[slipId]**: statuses hue-preserving (calculated→info, approved→warning, paid→success); **all 12 IDR figures → `Money`**
- **bonuses**: statuses (approved→info, paid→success); ALL amounts → `Money` (KPIs, tables, recon strips)
- **owner-cashout/[weekId]**: MBZ→success, MBS→warning via `Money`; error → danger color-mix
- **employees**: shared `DANGER_STRIP`; inputs → tokens; salary → `Money`; BPJS icons → success/danger

### Verification (this turn)
- HR suite **39/39** (+22 new guard tests: 0 hex, 0 status rgba tuples, recipe pins, `Money` pins) · hr libs/hooks **137/137** · tsc 0 errors · token-lint clean (stdin mode)

### Notes
- Honest hue-preserving mappings: approved→warning in payroll/bonuses (was amber) so it never collides with paid→success.
- `--no-verify` push (established rationale).
- Remaining kita tail: partners & team, analytics/settings sweep.