### PR TITLE
fix(scripts): arsenal_probe recognizes claude CLI weekly-limit as QUOTA_DEAD

### DIFF
--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -179,7 +179,8 @@ _AUTH_DEAD_PAT = re.compile(
     r"\b401\b|authentication failed|token_revoked|refresh_token_reused|oauth token", re.IGNORECASE
 )
 _QUOTA_DEAD_PAT = re.compile(
-    r"out of extra usage|usage limit|quota|\b429\b|rate.?limit|exhausted", re.IGNORECASE
+    r"out of extra usage|usage limit|weekly limit|quota|\b429\b|rate.?limit|exhausted",
+    re.IGNORECASE,
 )
 _BALANCE_DEAD_PAT = re.compile(r"\b402\b|insufficient balance", re.IGNORECASE)
 _MODEL_ERR_PAT = re.compile(r"\b1211\b|unknown model", re.IGNORECASE)

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -106,6 +106,7 @@ def test_quota_strings_classify_quota_dead():
         "429 too many requests",
         "rate limit exceeded",
         "quota exhausted",
+        "You've hit your weekly limit · resets 9am (Asia/Makassar)",
     ]:
         assert (
             ap.classify_generic(ev, live_signal=False, seat="claude", ssh_context=False) == ap.QUOTA_DEAD
@@ -122,6 +123,13 @@ def test_quota_dead_never_matches_401_evidence():
 
 def test_unrecognized_evidence_classifies_unknown_err():
     ev = "connection reset by peer, no idea why"
+    assert ap.classify_generic(ev, live_signal=False, seat="claude", ssh_context=False) == ap.UNKNOWN_ERR
+
+
+def test_weekly_word_alone_does_not_classify_quota_dead():
+    # innocence: "weekly" in an unrelated sentence must not fall through to
+    # quota-dead — only the "weekly limit" phrase (the real claude CLI wording) does.
+    ev = "weekly digest job completed successfully"
     assert ap.classify_generic(ev, live_signal=False, seat="claude", ssh_context=False) == ap.UNKNOWN_ERR
 
 


### PR DESCRIPTION
## Summary
- `_QUOTA_DEAD_PAT` in `scripts/arsenal_probe.py` had no branch for "weekly limit" — the actual string the `claude` CLI prints when the MAX-plan weekly cap is hit (`You've hit your weekly limit · resets 9am (Asia/Makassar)`, observed live in `~/.organism/arsenal/last.json` on Mini this tick).
- It fell through to `UNKNOWN_ERR` (a `STRICT_FAIL` status), tripping proprioception's `arsenal_seats` P1 alarm for what is actually a self-resetting quota cooldown, not an unknown/auth failure.
- Added the phrase to the pattern + a guilt test (the real observed string → `QUOTA_DEAD`) and an innocence test ("weekly digest job completed" → stays `UNKNOWN_ERR`, per scar-family #3 guard-conformance discipline).

Found + fixed during an autonomous HEALER-MANDATE tick on Mini-Pro2 (receptor: `arsenal_seats` DIVERGED, `claude: UNKNOWN_ERR`).

## Test plan
- [x] `scripts/tests/test_arsenal_probe.py` — 112/112 passed (backend-rag venv pytest)
- [x] pre-commit + pre-push hooks green (full suite ran, path-aware classifier correctly escalated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)