### PR TITLE
fix(scripts): launchagent_reconcile allow-list beats basename-collision canon

### DIFF
--- a/scripts/launchagent_reconcile.py
+++ b/scripts/launchagent_reconcile.py
@@ -431,8 +431,23 @@ def reconcile(
                 continue
             if _is_under(rp, agents_dir.resolve()):
                 continue
+            norm = _normalize_home_path(rp, home)
+            in_declared_lives = norm is not None and norm in declared_lives
+            # "allow"-only match (not a declared pair): a human already ruled this
+            # HOME path unrelated to the repo (TCC bridge, vendor binary,
+            # separate-repo tool with no canon by design). _repo_canon_for() matches
+            # by BASENAME ALONE — a generic name like "run.sh" can coincidentally
+            # collide with an unrelated repo file and produce a spurious "canon", which
+            # must never override that human ruling (guard-over-match, superscar #3
+            # sibling: same-name ≠ same-entity). A declared PAIR's real canon is
+            # untouched by this branch — its DIVERGED check still fires below.
+            allow_only = not in_declared_lives and _is_declared_or_allowed(
+                rp, home, set(), home_fork_allow
+            )
             canon = _repo_canon_for(rp)
-            if canon is not None and filecmp.cmp(str(canon), str(rp), shallow=False):
+            if allow_only:
+                pass
+            elif canon is not None and filecmp.cmp(str(canon), str(rp), shallow=False):
                 canon_paired.append({"label": label, "file": f.name, "target": t,
                                      "canon": str(canon.relative_to(repo_root))})
             elif canon is None and _is_declared_or_allowed(

--- a/scripts/tests/test_launchagent_reconcile.py
+++ b/scripts/tests/test_launchagent_reconcile.py
@@ -164,6 +164,36 @@ def test_home_fork_target_allow_listed_not_a_fork(world):
     assert r["canon_paired"] == []
 
 
+def test_allow_listed_target_ignores_basename_collision_canon(world):
+    """Live bug 2026-07-26 (Mini healer tick): _repo_canon_for() matches by
+    BASENAME ALONE, so an allow-listed standalone tool (e.g.
+    ~/.local/bin/zero-design/run.sh, a Node webapp launcher, no repo canon by
+    design) can coincidentally collide with an UNRELATED repo file sharing the
+    same generic name (e.g. scripts/cron-agent-python/run.sh, a totally
+    different cron wrapper) and get reported DIVERGED — even though the human
+    already ruled this path unrelated via the allow-list. Guard-over-match,
+    superscar #3 sibling: same basename is not the same entity."""
+    payload = world["home"] / ".local" / "bin" / "zero-design" / "run.sh"
+    payload.parent.mkdir(parents=True)
+    payload.write_text("#!/bin/zsh\nnode local-webapp-server.mjs --lan\n")
+    unrelated_canon = world["repo"] / "scripts" / "cron-agent-python" / "run.sh"
+    unrelated_canon.parent.mkdir(parents=True)
+    unrelated_canon.write_text("#!/usr/bin/env bash\necho totally unrelated cron wrapper\n")
+    hf_dir = world["repo"] / "infra" / "home-fork"
+    hf_dir.mkdir(parents=True)
+    (hf_dir / "declared-pairs.json").write_text(
+        json.dumps({"pairs": [], "allow": ["~/.local/bin/zero-design/*"]})
+    )
+    write_plist(
+        world["agents"] / "com.balizero.zerodesign.studio.plist",
+        "com.balizero.zerodesign.studio",
+        program_args=[str(payload)],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert r["home_fork_target"] == []
+    assert r["canon_paired"] == []
+
+
 def test_home_fork_target_declared_pair_live_not_a_fork(world):
     """A target whose ~-path exactly matches a declared pair's 'live' field
     is tracked by lint_home_fork.py's --check sha256 flow already — not a


### PR DESCRIPTION
## Summary
- `_repo_canon_for()` in `scripts/launchagent_reconcile.py` matches HOME wrapper targets by **basename alone**. A path already ruled "unrelated to the repo" via `declared-pairs.json`'s `allow` list (e.g. `~/.local/bin/zero-design/run.sh`, a standalone Node webapp launcher with no repo canon by design) could still collide with an unrelated repo file sharing the same generic name (`scripts/cron-agent-python/run.sh`, a completely different cron wrapper) and get reported `DIVERGED` — overriding a human's explicit allow-listing on a same-name-≠-same-entity coincidence (guard-over-match, cicatrix superscar #3 sibling).
- Fix: an allow-only match (not a declared pair) now short-circuits *before* the canon lookup, so a basename collision can never override it. A declared pair's real `DIVERGED` check is untouched (regression-pinned by the pre-existing `test_declared_pair_with_matching_canon_still_reaches_canon_paired`).
- Verified live on Mini: `com.balizero.zerodesign.studio` drops out of `home_fork_target` (was 3 findings including this false positive, now 2 — the remaining two are separately tracked: `healer.4h` is self-modification-banned for the healer, `regie-resume` has no repo canon by design).

Found + fixed during an autonomous HEALER-MANDATE tick on Mini-Pro2 (receptor: proprioception `launchagent_canon` DIVERGED, `home_fork_target: 3`).

## Test plan
- [x] `scripts/tests/test_launchagent_reconcile.py` — 35/35 passed (new guilt test `test_allow_listed_target_ignores_basename_collision_canon`; pre-existing regression guard `test_declared_pair_with_matching_canon_still_reaches_canon_paired` still green)
- [x] Live re-run of `scripts/launchagent_reconcile.py --json` on Mini confirms the false positive is gone and `canon_paired` count grows accordingly
- [x] pre-commit + pre-push hooks green (full suite ran, path-aware classifier correctly escalated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)