### PR TITLE
fix(ci): install asyncpg in the tg-gateway job — a required check is red on every open PR

### DIFF
--- a/.github/workflows/tg-gateway.yml
+++ b/.github/workflows/tg-gateway.yml
@@ -47,5 +47,12 @@ jobs:
           # them the file below would ImportError, not merely "not run" (a
           # loud CI failure, not a silent one, but still worth being explicit
           # about why a Telegram-gateway CI job installs two extra packages).
-          python3 -m pip -q install pytest httpx structlog
+          # asyncpg: same reason, one module further out. #3147 added
+          # test_curiosity_batch_send_telegram_batch_reaches_dry_run_delivery,
+          # which imports curiosity_batch.py, which imports asyncpg at module
+          # level — but this line was not updated with it. The test landed, the
+          # dependency did not, and `gateway` (a required check) went red on
+          # every open PR for a file none of them had touched. When a test is
+          # added here, its import chain has to be added here too.
+          python3 -m pip -q install pytest httpx structlog asyncpg
           python3 -m pytest scripts/tests/test_tg_gateway.py scripts/tests/test_agent_job_telegram_gateway.py -q


### PR DESCRIPTION
## What is broken

`gateway` is currently failing on **every open PR**, for a file none of them touched:

```
scripts/tests/test_agent_job_telegram_gateway.py::test_curiosity_batch_send_telegram_batch_reaches_dry_run_delivery
ModuleNotFoundError: No module named 'asyncpg'
1 failed, 16 passed
```

Measured, not inferred — each PR's check rollup was queried directly:

| PR | `gateway` |
|---|---|
| #3146 | FAILURE |
| #3167 | FAILURE |
| #3171 | FAILURE |
| #3172 | FAILURE |

> **Correction (same session).** An earlier draft of this description called `gateway` a *required* check. It is not: it is absent from main's 25 required contexts, and #3167 merged with `gateway` FAILURE — which is how the error was caught. The fix still matters, and the correction makes it matter more, not less: a check that is red on every PR is a check everyone learns to scroll past, and this one runs `lint_tg_direct_senders.py`, the anti-regrowth guard for the Telegram-gateway migration. **A guard that is permanently red AND blocks nothing is decorative** (scar family #2, "esiste != armato"). Whether `gateway` should join the required set is a separate call and is ledgered, not decided here.

## Why

#3147 added `test_curiosity_batch_send_telegram_batch_reaches_dry_run_delivery`, which imports `curiosity_batch.py`, which imports `asyncpg` at module level (`scripts/cron-agent-python/curiosity_batch.py:22`). The job's install line was not updated with it. **The test landed; its dependency did not.**

## The fix

One package, following the precedent this step already documents — `httpx` and `structlog` are installed for exactly this reason one module further in, and the comment says so. `asyncpg` is the same case, one module further out. The comment is extended to name the rule: when a test is added here, its import chain has to be added here too.

## Proof

The two files the job runs, executed with the job's own command against an interpreter carrying all four packages:

```
$ python -m pytest scripts/tests/test_tg_gateway.py scripts/tests/test_agent_job_telegram_gateway.py -q
17 passed in 1.07s
```

CI reported `1 failed, 16 passed` on the same 17. The one failure is this import.

## Explicitly not chosen

`pytest.importorskip("asyncpg")`. It would turn the check green while making the test **never run in CI** — a green bought by covering less, which is the "a test no workflow names is not coverage" trap wearing a different hat.