### PR TITLE
fix(ci): split tg-gateway's anti-regrowth lint from its pytest guard-pins

### DIFF
--- a/.github/workflows/tg-gateway.yml
+++ b/.github/workflows/tg-gateway.yml
@@ -4,6 +4,32 @@ name: tg-gateway
 # - the three gateway selftests (hermetic, no network)
 # - the direct-sender lint: a NEW file calling api.telegram.org outside
 #   infra/tg-gateway/grandfathered.json fails the PR (family can only shrink)
+#
+# Task #35 fix (2026-07-26): the anti-regrowth lint above and a separate
+# pytest suite ("Guard pins") used to live in ONE job (`gateway`). That
+# meant the job's single conclusion could not distinguish "someone regrew a
+# direct Telegram sender" from "an unrelated import in the pytest suite is
+# broken" — measured 2026-07-26 03:30Z: `gateway` red on 5 of 10 open PRs
+# (#3181 #3180 #3178 #3176 #3146) purely from a missing `asyncpg` install
+# (already fixed on main by #3175, landed 03:03:42Z — those 5 PRs' `gateway`
+# checks are stale runs cached from BEFORE the fix landed, not a live
+# recurrence: verified locally in a clean venv against current main, 17/17
+# pass with the exact CI install+pytest command). The STRUCTURAL problem
+# survives the dependency fix on its own: nothing stopped the NEXT unrelated
+# pytest breakage from making `gateway`'s verdict unreadable again the same
+# way. `gateway` is not a required context today, so this went unnoticed —
+# nothing blocked, nobody looked (superscar #2, exists ≠ armed, crossed with
+# alert-fatigue: an always-red gate is not a gate).
+#
+# Fix: split into two independent jobs. `gateway` now carries ONLY the
+# anti-regrowth lint + its own hermetic selftests — a regrowth violation is
+# the only thing that can turn it red. `guard-pins-pytest` carries the
+# broader pytest suite (which imports agent_job.py's full dependency tree —
+# httpx/structlog/asyncpg — and can break for reasons that have nothing to
+# do with direct Telegram senders) as its own job with its own conclusion.
+# Neither job is a required context (unchanged by this fix, per instruction
+# — a required check that is permanently red blocks the entire merge queue,
+# which is a worse failure mode than an unread one).
 
 on:
   pull_request:
@@ -23,6 +49,7 @@ on:
 
 jobs:
   gateway:
+    name: gateway (anti-regrowth lint)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -40,6 +67,13 @@ jobs:
       - name: Direct-sender lint (anti-regrowth + monotone grandfather)
         run: python3 scripts/lint_tg_direct_senders.py
 
+  guard-pins-pytest:
+    name: guard-pins-pytest (gateway integration tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
       - name: Guard pins (pytest)
         run: |
           # httpx/structlog: agent_job.py imports both at module level, and
@@ -50,9 +84,12 @@ jobs:
           # asyncpg: same reason, one module further out. #3147 added
           # test_curiosity_batch_send_telegram_batch_reaches_dry_run_delivery,
           # which imports curiosity_batch.py, which imports asyncpg at module
-          # level — but this line was not updated with it. The test landed, the
-          # dependency did not, and `gateway` (a required check) went red on
-          # every open PR for a file none of them had touched. When a test is
-          # added here, its import chain has to be added here too.
+          # level. #3175 closed that specific gap (2026-07-26). When a NEW
+          # test is added here, its import chain has to be added here too —
+          # that is now this job's problem alone: a future dependency gap here
+          # can no longer mask a regrown direct Telegram sender in `gateway`
+          # above, and a `gateway` violation can no longer hide behind this
+          # job's own unrelated breakage. Task #35 split this out of `gateway`
+          # for exactly that reason (2026-07-26).
           python3 -m pip -q install pytest httpx structlog asyncpg
           python3 -m pytest scripts/tests/test_tg_gateway.py scripts/tests/test_agent_job_telegram_gateway.py -q


### PR DESCRIPTION
## What

`.github/workflows/tg-gateway.yml`'s `gateway` job carried two unrelated
responsibilities in one job/one conclusion: the anti-regrowth lint (a NEW
file calling `api.telegram.org` outside `infra/tg-gateway/grandfathered.json`
fails the PR) and a separate "Guard pins" pytest suite. One conclusion meant
the job could not distinguish "someone regrew a direct Telegram sender" from
"an unrelated import in the pytest suite is broken."

Measured 2026-07-26 03:30Z: `gateway` red on 5 of 10 open PRs (#3181 #3180
#3178 #3176 #3146) from a missing `asyncpg` install in the pytest step —
**already fixed on main by #3175**, landed 03:03:42Z, 27 minutes before the
measurement. Verified locally that those 5 PRs' red checks are **stale runs
cached from before #3175 landed**, not a live recurrence: PR #3181's
`gateway` run started 03:02:02Z (before the fix merged) and completed
03:05:47Z; in a clean venv against current `main`, the exact CI
install+pytest command passes 17/17.

The structural defect survives the dependency fix on its own — nothing
stops the *next* unrelated pytest breakage from making `gateway`'s verdict
unreadable again the same way. `gateway` is not a required context, so this
went unnoticed: nothing blocked, nobody looked.

## How

Split into two independent jobs, no shared conclusion:

- **`gateway`** — hermetic selftests + the direct-sender lint only. A
  regrowth violation is now the only thing that can turn it red.
- **`guard-pins-pytest`** — the pytest suite (which pulls in `agent_job.py`'s
  full dependency tree — httpx/structlog/asyncpg — and can break for reasons
  that have nothing to do with direct Telegram senders) as its own job with
  its own conclusion.

Neither job promoted to required — per instruction, a permanently-red
required check blocks the entire merge queue, which is a worse failure mode
than an unread one. This PR does not touch branch protection at all.

`infra/guard-conformance/registry.json`'s `tg-gateway-lint` entry references
the source file (`scripts/lint_tg_direct_senders.py`) and test file, not job
names — checked, unaffected by this split.

## Guilt / innocence proof

Run locally before commit, against the real scripts (no synthetic harness):

- **Innocence** — clean tree: all 3 selftests pass
  (`tg_notify.py`/`tg_digest_flush.py`/`lint_tg_direct_senders.py
  --selftest`), direct-sender lint exits 0 (8041 files scanned, 155
  grandfathered), `guard-pins-pytest`'s exact step (fresh venv, same install
  command) — 17/17 pass.
- **Guilt** — a synthetic direct-Telegram-sender file. First attempt with
  the file merely written to disk showed "clean" — wrong, because
  `lint_tg_direct_senders.py` scans `git ls-files` (tracked files only), so
  an untracked file is invisible to it. Corrected by `git add`-staging the
  synthetic file: lint now correctly fails, naming the exact file
  (`lint_tg: FAIL — 1 NEW direct Telegram sender(s) ... scripts/synthetic_direct_sender_task35.py`).
  Unstaged and removed; lint returns to clean (same 8041/155 baseline).

## Verification

- `actionlint .github/workflows/tg-gateway.yml`: 0 findings.
- Pre-commit hooks (lease-check, anti-reward-hacking lint, secrets scan,
  Prettier, Python lint, off-limits-file check) all passed.
- `origin/main` merged into the branch immediately before push (already up
  to date).
- Push verified via `git ls-remote origin refs/heads/<branch>` matching
  local `HEAD`.

## Not armed

Per instruction: CI-config change — not armed for `--auto --squash` on
open. Awaiting explicit merge call.

Related: task #23 (nothing watches workflow failures generically — this
was found via a live specimen of exactly that gap), task #17 (same
`scripts/cron-agent-python/` tree).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>