### PR TITLE
fix(tests): a Postgres ROLE is cluster-scope — cloning the database isolates nothing

### DIFF
--- a/apps/backend-rag/backend/tests/services/visa_engine/test_activation_writer.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_activation_writer.py
@@ -1044,7 +1044,15 @@ async def test_function_not_executable_by_unprivileged_role(repo: VisaEngineRepo
     PUBLIC by default at CREATE FUNCTION time; migration 251 explicitly
     revokes it. Proven by creating a throwaway, privilege-free role and
     confirming it (and therefore PUBLIC) has no EXECUTE grant."""
-    probe_role = "visa_test_probe_norights"
+    # Unique per run, like the provisioning test below (`suffix = uuid4().hex[:10]`).
+    # A ROLE is CLUSTER-scope: it lives in `pg_authid`, shared by every database in
+    # the instance. The pre-push hook isolates runs by cloning the DATABASE
+    # (`nuzantara_test_run_$$`), which gives this test no protection at all — two
+    # concurrent pushes both ran `CREATE ROLE visa_test_probe_norights` and the
+    # second died on `pg_authid_rolname_index`, blocking a push over a diff that
+    # never touched visa_engine. A crash between CREATE and DROP also used to strand
+    # the fixed name and fail every later run until someone dropped it by hand.
+    probe_role = f"visa_test_probe_norights_{uuid.uuid4().hex[:10]}"
     async with repo.db_pool.acquire() as conn:
         try:
             await conn.execute(f"CREATE ROLE {probe_role} NOLOGIN")
@@ -1058,7 +1066,7 @@ async def test_function_not_executable_by_unprivileged_role(repo: VisaEngineRepo
             )
             assert has_exec is False
         finally:
-            await conn.execute(f"DROP ROLE {probe_role}")
+            await conn.execute(f"DROP ROLE IF EXISTS {probe_role}")
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
A test created a Postgres **ROLE** under a fixed name. Roles are **cluster-scope**, so the
pre-push hook's per-run isolation — which clones the *database* — gives this test no protection
at all, and the second concurrent runner hits `DuplicateObjectError`.

## What actually broke

`test_activation_writer.py` created `visa_test_probe_norights` — a constant. Under fleet
contention (several worktrees pushing at once, which is the normal state on this machine) two
runners raced the same `CREATE ROLE` and the loser failed the push on a test that has nothing
to do with the diff being pushed.

## Why the existing isolation does not cover it

The pre-push hook isolates by cloning the database (`nuzantara_test_run_$$`). That is the right
primitive for tables, rows, sequences — everything that lives *inside* a database. A ROLE does
not: it lives in `pg_authid`, which is **shared by every database in the instance**. Cloning the
database moves the test to a new schema namespace and leaves it in the exact same role namespace
it was colliding in.

This is the generalisable part, and it is why the fix is a comment as much as it is a uuid:
**"the suite is isolated" is scoped, and the scope is the database.** Anything cluster-scope —
roles, tablespaces, replication slots, `pg_settings` at cluster level — is outside it.

## The fix

Unique per run, matching the convention the provisioning test in the same file already used
(`suffix = uuid4().hex[:10]`), plus a `finally: DROP ROLE IF EXISTS` so a failing assertion
cannot leak the role into the cluster for the next runner to trip over.

## Verification — deterministic, not "I ran it twice"

The race itself is not a reliable prover: I reproduced nothing across repeated concurrent runs,
and reporting that as evidence would have been reporting luck. So the proof is a property, not a
timing window — `prove_role_deterministic.sh` runs the *same test twice in the same cluster*:

| tree | result |
|---|---|
| BEFORE (fixed name) | second run fails `DuplicateObjectError` — the collision, on demand |
| AFTER (uuid suffix) | both runs pass |

A class-audit over the sibling suites found **exactly one** other cluster-scope creator, and it
was already uuid-suffixed — so this is the last of its kind rather than the first of a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
