### PR TITLE
fix(husky): W101 sibling on line 133 — RANGE_FROM aborts pre-push under sh -e

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -130,7 +130,15 @@ else
             if [ "$remote_sha" = "$ZERO_SHA" ]; then
                 # New branch/ref not yet on the remote — diff from where it
                 # forked off main, i.e. every commit this push is introducing.
-                RANGE_FROM="$(git merge-base origin/main "$local_sha" 2>/dev/null)"
+                # W101 sibling (2026-07-26): a BARE X="$(...)" assignment takes the
+                # substitution's exit status under this wrapper's sh -e, so a failing
+                # `git merge-base` (no common ancestor, corrupt local_sha, etc.) would
+                # abort the whole hook HERE — before the `[ -z "$RANGE_FROM" ]` check
+                # two lines down ever runs, exactly as the already-fixed VERDICT_OUTPUT
+                # line 164 documents. `|| RANGE_FROM=""` makes the failure land IN the
+                # variable instead of killing the script, so the existing fail-closed
+                # check below still fires and degrades to the FULL suite as designed.
+                RANGE_FROM="$(git merge-base origin/main "$local_sha" 2>/dev/null)" || RANGE_FROM=""
                 if [ -z "$RANGE_FROM" ]; then
                     DIFF_ERROR=1
                     break
@@ -300,8 +308,15 @@ else
     # evaporates. The bug stayed latent from #2489 until nuzantara_test happened
     # to be re-created with owner=test — while template-owner == cloner nothing
     # showed. Deriving the owner keeps the clone faithful whoever pushes.
+    # Same bare-assignment shape as the two fixed above (W101 family). Not
+    # currently exploitable — the pipeline's exit status is `tr`'s, and `tr`
+    # with these fixed, valid arguments cannot itself fail — but that safety
+    # is INCIDENTAL to psql's success, not designed, and the `if [ -n ... ]`
+    # two lines down already documents "unreadable owner must not wedge the
+    # push" as the intent. Hardening removes the reliance on tr's behaviour
+    # rather than the documented `[ -n ]` check ever actually doing the job.
     TEMPLATE_OWNER="$("$PSQL" -h 127.0.0.1 -p 5432 -d postgres -tAc \
-        "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = '$PRE_PUSH_DB';" 2>/dev/null | tr -d '[:space:]')"
+        "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = '$PRE_PUSH_DB';" 2>/dev/null | tr -d '[:space:]')" || TEMPLATE_OWNER=""
     if [ -n "$TEMPLATE_OWNER" ]; then
         OWNER_CLAUSE=" OWNER \"$TEMPLATE_OWNER\""
     else

--- a/scripts/tests/test_prepush_failclosed.sh
+++ b/scripts/tests/test_prepush_failclosed.sh
@@ -93,6 +93,83 @@ else
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# Case 5 (guilt, RANGE_FROM NEW pattern, task #39, 2026-07-26): the sibling
+# bug on line 133 — a failing `git merge-base` must degrade cleanly to
+# DIFF_ERROR=1 instead of aborting the script before that check runs. Uses a
+# REAL `git merge-base` failure (bogus ref, no valid object) rather than a
+# synthetic `exit 2`, so this pins the actual command that was broken, not
+# just the general shell-semantics shape already covered by Case 1.
+# `git merge-base HEAD <bogus>` fails purely on local ref resolution — no
+# network, no dependency on an `origin` remote existing.
+# ---------------------------------------------------------------------------
+out5="$(sh -e -c '
+    RANGE_FROM="$(git merge-base HEAD definitely-not-a-valid-ref-xyz123 2>/dev/null)" || RANGE_FROM=""
+    if [ -z "$RANGE_FROM" ]; then
+        echo "DIFF_ERROR=1"
+    else
+        echo "DIFF_ERROR=0"
+    fi
+    echo "reached-end"
+' 2>/dev/null)"
+if [ "$out5" = "$(printf 'DIFF_ERROR=1\nreached-end')" ]; then
+    note_pass "guilt (RANGE_FROM NEW pattern) — failing merge-base degrades to DIFF_ERROR=1 and script continues"
+else
+    note_fail "guilt (RANGE_FROM NEW pattern) — expected DIFF_ERROR=1 + reached-end, got: $out5"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6 (innocence, RANGE_FROM NEW pattern): a SUCCEEDING merge-base (the
+# ordinary case — a normal push whose branch has a real common ancestor)
+# must behave exactly as before the fix — RANGE_FROM gets a real value,
+# DIFF_ERROR stays unset, and execution reaches the classifier. Uses
+# `git merge-base HEAD HEAD` — always succeeds, returns HEAD's own sha, zero
+# dependency on any particular branch topology or fetched remote.
+# ---------------------------------------------------------------------------
+out6="$(sh -e -c '
+    RANGE_FROM="$(git merge-base HEAD HEAD 2>/dev/null)" || RANGE_FROM=""
+    if [ -z "$RANGE_FROM" ]; then
+        echo "DIFF_ERROR=1"
+    else
+        echo "DIFF_ERROR=0 reached-classifier"
+    fi
+' 2>/dev/null)"
+if [ "$out6" = "DIFF_ERROR=0 reached-classifier" ]; then
+    note_pass "innocence (RANGE_FROM NEW pattern) — a normal successful merge-base still reaches the classifier"
+else
+    note_fail "innocence (RANGE_FROM NEW pattern) — expected DIFF_ERROR=0 reached-classifier, got: $out6"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 7 (tripwire, task #39): grep the LIVE hook file — a bare unguarded
+# RANGE_FROM="$( ... )" (no "|| RANGE_FROM=" on the same line) must never
+# reappear. Mirrors Case 4's method for the sibling variable.
+# ---------------------------------------------------------------------------
+if [ ! -f "$HOOK_FILE" ]; then
+    note_fail "tripwire (RANGE_FROM) — $HOOK_FILE not found (cannot verify)"
+else
+    bad_lines5="$(grep -n 'RANGE_FROM="\$(' "$HOOK_FILE" | grep -v '|| RANGE_FROM=' || true)"
+    if [ -z "$bad_lines5" ]; then
+        note_pass "tripwire (RANGE_FROM) — no bare unguarded RANGE_FROM=\"\$(...)\" in $HOOK_FILE"
+    else
+        note_fail "tripwire (RANGE_FROM) — bare unguarded RANGE_FROM assignment reintroduced in $HOOK_FILE: $bad_lines5"
+    fi
+
+    # TEMPLATE_OWNER's assignment is a line-continued (\) statement — the
+    # opening "TEMPLATE_OWNER=\"$(" and the closing "|| TEMPLATE_OWNER=..."
+    # guard live on DIFFERENT physical lines, so (unlike Cases 4/7's single-
+    # line assignments) a same-line grep would false-positive FAIL even when
+    # the guard is present. Widen the window: -A2 pulls the assignment line
+    # plus its two continuation lines, then check the guard is anywhere in
+    # that block.
+    owner_block="$(grep -A2 'TEMPLATE_OWNER="\$(' "$HOOK_FILE" || true)"
+    if [ -n "$owner_block" ] && printf '%s' "$owner_block" | grep -q '|| TEMPLATE_OWNER='; then
+        note_pass "tripwire (TEMPLATE_OWNER) — no bare unguarded TEMPLATE_OWNER=\"\$(...)\" in $HOOK_FILE"
+    else
+        note_fail "tripwire (TEMPLATE_OWNER) — bare unguarded TEMPLATE_OWNER assignment reintroduced in $HOOK_FILE: $owner_block"
+    fi
+fi
+
 echo "---"
 echo "$pass passed, $fail failed"
 


### PR DESCRIPTION
## Summary

`.husky/pre-push`'s own fail-closed contract says a failed `git merge-base`/`git diff` must degrade to the FULL suite. Line 133's bare `RANGE_FROM="$(git merge-base origin/main "$local_sha" 2>/dev/null)"` couldn't honor that: under husky's `sh -e` wrapper, a bare command-substitution assignment takes the substitution's exit status, so a non-zero `git merge-base` (no common ancestor, corrupt local_sha) aborted the whole hook right there — before the `[ -z "$RANGE_FROM" ]` fail-closed check two lines down ever ran. Symptom: a push that dies near-instantly having printed only the two opening echoes, indistinguishable from "still running."

Same bug as the already-fixed `VERDICT_OUTPUT` (line 164, W101) reappearing on a sibling line — the cure was applied to one instance and not the other.

## Changes

- **RANGE_FROM** (line 133): same errexit-immune idiom already proven at line 164 — `|| RANGE_FROM=""`.
- **TEMPLATE_OWNER**: same bare-assignment shape, hardened too. Not currently exploitable (the pipeline's exit status is `tr -d`'s, which can't fail on these fixed args) — that safety is incidental to `tr`, not designed, and the next line already documents graceful-degradation intent. Hardened for defense-in-depth.
- **Full-file audit**, all 7 command-substitution assignments checked and each classified:
  - `PYTHON_BIN` / `UNION_FILE` / `PG_ISREADY` / `PSQL`: internal `|| fallback` inside the substitution itself → substitution's own exit status is always 0 → safe, unaffected by this bug class.
  - `VERDICT_OUTPUT` (line 164): already has the errexit-immune capture — original W101 fix, untouched.
  - The classifier-schema check (`elif [ "$(psql ...)" != "t" ]`): the substitution sits inside an if/elif **condition**, which `sh -e` exempts from errexit regardless of the inner command's exit status — structurally different from a bare assignment, safe.

## Tests

Extended `scripts/tests/test_prepush_failclosed.sh` (not a parallel file) with 4 new cases:
- guilt: a **real** failing `git merge-base` (bogus ref, not a synthetic exit code) degrades cleanly to `DIFF_ERROR=1` and the script continues past it.
- innocence: a **real** succeeding `git merge-base HEAD HEAD` still reaches the classifier, `DIFF_ERROR` unset.
- tripwire (RANGE_FROM): mirrors the existing VERDICT_OUTPUT tripwire.
- tripwire (TEMPLATE_OWNER): widened to a 2-line grep window since this assignment is `\`-continued across two physical lines — a same-line grep would have false-positived FAIL even with the guard correctly present (caught and fixed during this same session, before it shipped).

Verified independently: reverted each fix in a throwaway copy of the hook and confirmed both new tripwires actually flag the old bare pattern (not vacuous). 8/8 passing: `sh scripts/tests/test_prepush_failclosed.sh`.

## Hot zone

`.husky/pre-push` is in the path of every lane's push. Per team-lead's explicit instruction this PR is opened **unarmed** — no auto-merge — for a deliberate manual read and merge.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>