### PR TITLE
test(kbli): gate the membership pin from a suite that is already required

### DIFF
--- a/apps/mouth/src/lib/kbli-canonical-pins.test.ts
+++ b/apps/mouth/src/lib/kbli-canonical-pins.test.ts
@@ -1,0 +1,104 @@
+// =============================================================================
+// CANONICAL PIN GATE — the derived pins on the KBLI canonical must agree with it.
+//
+// WHY THIS LIVES IN apps/mouth, guarding a repo-root filiera artifact.
+//
+// The canonical KBLI dataset carries derived pins that go stale the instant a cure
+// rewrites it. Two of them exist, and their histories diverge in a way that is the
+// whole reason this file was written:
+//
+//   * the SIDECAR pin (`apps/mouth/data/kbli-dataset-version.json`) is guarded by
+//     `kbli-dataset-version.test.ts` inside "Frontend Tests (Next.js) (mouth, true)",
+//     which is a REQUIRED check. Every filiera compiler grew an `update_sidecar()`
+//     that bumps it automatically.
+//   * the MEMBERSHIP pin (`data/kbli-filiera/membership/batch-a-members.json`,
+//     `canonical_sha256`) is guarded only by `kbli-filiera-vault-compilers`, which is
+//     NOT among main's required contexts. No compiler bumps it. It has now been
+//     missed three times — #3114 (repaired out-of-band by #3130) and twice on #3181.
+//
+// The gate that can BLOCK got engineered around; the gate that cannot got forgotten.
+// So the membership pin is asserted HERE, from the one required suite that runs on
+// every PR (`tests.yml` has no path filter) — no branch-protection change needed.
+//
+// It cannot be fixed inside the compilers instead: `emit_batch_membership.py` fences
+// on "working canonical == HEAD's blob", so it refuses to run while a cure holds the
+// canonical dirty. The re-emit is structurally a separate, later step — which is
+// exactly why a human keeps forgetting it and why a machine has to ask.
+//
+// REMEDIATION when this fails: `python3 scripts/kbli_filiera/emit_batch_membership.py --apply`
+// then verify the diff moved ONLY `canonical_revision` + `canonical_sha256` — if
+// `members` moved too, the cure changed WHO is in the batch, which is a different and
+// much larger claim than a provenance refresh.
+// =============================================================================
+
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+// Anchored to this file, not to cwd — same discipline as kbli-internal-leak.test.ts:
+// the verdict must not depend on whether vitest was invoked from apps/mouth (CI) or
+// from the repo root (local sweep).
+const REPO_ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../../../..",
+);
+
+const CANONICAL = path.join(
+  REPO_ROOT,
+  "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
+);
+const MEMBERSHIP = path.join(
+  REPO_ROOT,
+  "data/kbli-filiera/membership/batch-a-members.json",
+);
+
+// Every published copy of the same dataset. Measured byte-identical on main; the
+// filiera compilers keep them in sync via scripts/sync_kbli_dataset.sh.
+const COPIES = [
+  "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
+  "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json",
+  "apps/kbli-navigator/data/kbli-2025.json",
+];
+
+const sha256 = (file: string) =>
+  crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+
+describe("KBLI canonical derived pins", () => {
+  it("fails loudly if an input is missing, instead of passing blind", () => {
+    // W102: a gate whose input vanished must accuse itself, not report all-clear.
+    for (const f of [CANONICAL, MEMBERSHIP]) {
+      expect(fs.existsSync(f), `gate input missing: ${f}`).toBe(true);
+    }
+  });
+
+  it("membership canonical_sha256 matches the canonical on disk — re-emit it when a cure moves the dataset", () => {
+    const membership = JSON.parse(fs.readFileSync(MEMBERSHIP, "utf-8")) as {
+      canonical_sha256?: string;
+    };
+    // A legacy artifact predating the field would silently skip this assertion —
+    // demand it, so "no pin" can never read as "pin agrees".
+    expect(
+      typeof membership.canonical_sha256,
+      "batch-a-members.json carries no canonical_sha256 — re-emit it",
+    ).toBe("string");
+
+    expect(
+      membership.canonical_sha256,
+      "membership pin is stale: run `python3 scripts/kbli_filiera/emit_batch_membership.py --apply`",
+    ).toBe(sha256(CANONICAL));
+  });
+
+  it("every published copy of the canonical is byte-identical", () => {
+    const hashes = COPIES.map((rel) => {
+      const abs = path.join(REPO_ROOT, rel);
+      expect(fs.existsSync(abs), `canonical copy missing: ${rel}`).toBe(true);
+      return `${rel} -> ${sha256(abs)}`;
+    });
+    const distinct = new Set(hashes.map((h) => h.split(" -> ")[1]));
+    expect(
+      distinct.size,
+      `canonical copies diverged — run scripts/sync_kbli_dataset.sh:\n${hashes.join("\n")}`,
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Puts the batch-A **membership pin** behind a check that can actually block, and pins the
canonical copy-sync invariant alongside it.

## Why this exists

The canonical KBLI dataset carries derived pins that go stale the instant a cure rewrites it.
Two exist, and their histories diverge in a way that *is* the finding:

| pin | guarded by | required? | automated in the compilers? |
|---|---|---|---|
| `apps/mouth/data/kbli-dataset-version.json` | `kbli-dataset-version.test.ts` → **Frontend Tests (Next.js) (mouth, true)** | **yes** | yes — every compiler grew an `update_sidecar()` |
| `batch-a-members.json::canonical_sha256` | `kbli-filiera-vault-compilers` | **no** | **no compiler touches it** |

The gate that can BLOCK got engineered around; the gate that cannot got forgotten — three times:
**#3114** (auto-merged with the check red, repaired out-of-band by **#3130**) and twice on **#3181**.
A check that cannot fail the merge does not change behaviour. It only records, after the fact,
that behaviour was already wrong.

## Scope note — this does NOT pre-empt the open Zero ruling

`PENDING-ARMS.md` already carries a line (opened 2026-07-25, owner `operator[business]`) asking
whether `kbli-filiera-vault-compilers` **should be added to the required set**. That is a policy
call and it stays open and untouched.

This PR deliberately takes the other road: it asserts the specific pin from a suite that is
*already* required, so the protection lands without a branch-protection change (which is
operator-only anyway) and without anyone having to decide the policy question first. If Zero later
rules that the whole vault-compilers battery should be required, this test becomes redundant
belt-and-braces, not a conflict.

## Why it can't live in the compilers instead

`emit_batch_membership.py` fences on *"working canonical == HEAD's blob"* and refuses to run while
a cure holds the canonical dirty. The re-emit is therefore structurally a **later** step than the
write that invalidates it — which is precisely why a human keeps forgetting it, and why a machine
has to ask.

## Verification

Baseline **3/3** green, `guard-conformance` **0 violations**. Non-vacuous by mutation — each mutant
kills exactly its own assertion:

| mutant | test killed |
|---|---|
| corrupt `canonical_sha256` | the pin test |
| drop the field entirely (a legacy artifact) | the pin test |
| desync one published copy | the copy-sync test |
| remove a gate input | the fail-loud test |

The second one is the one worth having: without an explicit type assertion, an artifact carrying
**no** pin would have read as "pin agrees" — absence passing silently as agreement.

Paths anchor to the test file rather than `cwd`, so the verdict is identical whether vitest runs
from `apps/mouth` (CI) or the repo root (local sweep) — the discipline `kbli-internal-leak.test.ts`
documents in its own comment. Missing inputs fail loudly instead of passing blind (W102: a gate
whose input vanished must accuse itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
