### PR TITLE
fix(kbli): the crosswalk row served Italian and raw Python debris to clients — and to Google's FAQ index

### DIFF
--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
   "lastModified": "2026-07-26",
-  "datasetSha256": "sha256:6284213fa6f8c2df9b4cc97aae51a813fe64da90b79d84930f15e48715711d78",
+  "datasetSha256": "sha256:8d7935b4992721cb78349ff6251b82f439812314a11a84a72706b6403053c881",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "9c89c8e3df953428c28aefb3d68cccc84d5885c9",
-  "canonical_sha256": "6284213fa6f8c2df9b4cc97aae51a813fe64da90b79d84930f15e48715711d78",
+  "canonical_revision": "600bc4f34370a9092ed75021f6f065636171c8a1",
+  "canonical_sha256": "8d7935b4992721cb78349ff6251b82f439812314a11a84a72706b6403053c881",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/scripts/kbli_filiera/cure_l23_whatchanged_language.py
+++ b/scripts/kbli_filiera/cure_l23_whatchanged_language.py
@@ -115,6 +115,45 @@ FIELDS: tuple[tuple[str, bool], ...] = (
     ("zantaraOpener", False),
 )
 
+# Client-facing fields that hang off the RECORD, not off `intel_2026`. Same
+# (name, may-normalise-whitespace) contract as FIELDS.
+#
+# These are NOT a widening for tidiness. `intel_2026.whatChanged` EMBEDS
+# `mapping_note` verbatim — measured on the pre-L2.3 canonical, `mapping_note`
+# is an exact substring of `whatChanged` in 25 of 352 records — but they are two
+# INDEPENDENT STORED COPIES, so curing one left the other untouched. The result
+# on prod today: ~157 pages render an English `whatChanged` block and an Italian
+# crosswalk row, about the same fact, on the same page.
+#
+# Both are rendered, and `mapping_note` reaches THREE surfaces:
+#   * apps/mouth/src/app/kbli/[code]/page.tsx:928-930 — visible "— {mappingNote}"
+#   * apps/mouth/src/lib/kbli-faq.ts:117 — spliced into the FAQ answer, which is
+#     ALSO emitted as FAQPage JSON-LD, i.e. structured data Google indexes.
+#
+# Whitespace normalisation is safe on both (measured: 0 of them contain a
+# newline or a 2+ space run — they are single-line machine output, the shape
+# `whatChanged` has and `whatYouNeed` does not).
+#
+# `aggregation_note` is included with its scope stated honestly: it is typed and
+# transformed in BOTH apps (mouth + kbli-navigator) but rendered by NO page or
+# component — ZERO readers. Curing it is audit-trail, not a client fix; it is
+# done here because the rule already exists and because a field that is one
+# `<span>` away from being read should not be holding 198 Italian strings.
+TOP_LEVEL_FIELDS: tuple[tuple[str, bool], ...] = (
+    ("mapping_note", True),
+    ("aggregation_note", True),
+)
+
+# Deliberately NOT cured, each for its own reason. Listed so the next session
+# does not "complete the sweep" and break something load-bearing:
+#   * `status_mapping` (1,558 records) — the MACHINE field. TransitionBadge
+#     renders it via MAPPING_STATUS_LABELS as "Direct Match" etc. Its raw token
+#     appears in a curl only because it is in the serialized props, never as
+#     visible text. Curing it would destroy the badge on every record.
+#   * `_data_note` (88 with symbols) — evidence, rendered VERBATIM as an audit
+#     trail. kbli-internal-leak.test.ts pins it as an explicit INNOCENCE case.
+#   * `uraian` — the official BPS Indonesian description.
+
 # Residue probe. Deliberately literal and deliberately NOT the cure's own rule
 # set: if it reused the rules it would report zero by construction — a check
 # that cannot fail. These are tokens that are unambiguously Italian IN THIS
@@ -352,6 +391,45 @@ def cure_dataset(
     return changed, hits, residues
 
 
+def cure_top_level(
+    payload: Any,
+    rules: list[dict[str, Any]],
+    only: set[str] | None,
+) -> tuple[int, Counter, list[tuple[str, list[str]]]]:
+    """Cure TOP_LEVEL_FIELDS on the canonical's records.
+
+    A separate pass rather than a widening of cure_dataset, on purpose: that
+    function's per-field behaviour is pinned by mutation-tested guards and there
+    is no reason to put a second container shape through it. Gold is not passed
+    here because gold carries NONE of these fields — measured, not assumed.
+
+    Same write discipline as cure_dataset: a field is written back only when a
+    declared rule fired on it.
+    """
+    changed = 0
+    hits: Counter = Counter()
+    residues: list[tuple[str, list[str]]] = []
+    for rec in _iter_records(payload):
+        code = str(rec.get(CODE_FIELD) or rec.get("kode_kbli") or rec.get("code") or "")
+        if only and code not in only:
+            continue
+        for field, normalize in TOP_LEVEL_FIELDS:
+            before = rec.get(field)
+            if not isinstance(before, str) or not before:
+                continue
+            field_hits: Counter = Counter()
+            after = cure_text(before, rules, field_hits, normalize_whitespace=normalize)
+            if field_hits and after != before:
+                rec[field] = after
+                changed += 1
+                hits.update(field_hits)
+            left = residue_markers(after) + enum_residue(after)
+            if left:
+                residues.append((f"{code}.{field}", left))
+    logger.info("canonical top-level: %d (record,field) rewritten", changed)
+    return changed, hits, residues
+
+
 def run_sync_script() -> None:
     logger.info("running %s sync", SYNC_SCRIPT)
     result = subprocess.run(
@@ -407,6 +485,11 @@ def main(argv: list[str] | None = None) -> int:
     c_changed, c_hits, c_residue = cure_dataset(
         canonical_pairs(payload), rules, only, "canonical"
     )
+
+    t_changed, t_hits, t_residue = cure_top_level(payload, rules, only)
+    c_changed += t_changed
+    c_hits += t_hits
+    c_residue += t_residue
 
     gold_payload = json.loads(args.gold.read_text(encoding="utf-8"))
     g_changed, g_hits, g_residue = cure_dataset(

--- a/scripts/kbli_filiera/tests/test_cure_l23_whatchanged_language.py
+++ b/scripts/kbli_filiera/tests/test_cure_l23_whatchanged_language.py
@@ -549,3 +549,99 @@ def test_no_field_is_left_with_unbalanced_bold_markers(mod, rules, gold_payload)
             if after != v and after.count("**") % 2 != before_n % 2:
                 bad.append((code, field))
     assert not bad, f"cure changed the bold-marker parity of: {bad[:6]}"
+
+
+# ==========================================================================
+# L2.5 — the top-level fields. `whatChanged` EMBEDS `mapping_note`, but they
+# are two independent stored copies, so curing one left the other Italian.
+# ==========================================================================
+
+def test_top_level_field_policy_is_explicit(mod):
+    policy = dict(mod.TOP_LEVEL_FIELDS)
+    assert policy == {"mapping_note": True, "aggregation_note": True}
+    # These are single-line machine output, so normalisation is safe — the
+    # opposite call from whatYouNeed, and made on measurement rather than taste.
+    assert all(policy.values())
+
+
+@pytest.mark.parametrize(
+    "before, expected",
+    [
+        (
+            "PP28 usa codice KBLI 2020 01122 (Pertanian Padi Inbrida...). Match: 80%",
+            "PP28 uses KBLI 2020 code 01122 (Pertanian Padi Inbrida...). Match: 80%",
+        ),
+        ("Dati da 01116 + 1 codici figli PP28", "data from 01116 + 1 PP28 child code(s)"),
+        # The whole value is pipeline debris — a Python list literal — and it was
+        # rendered to clients verbatim. Emptying is correct, not lossy: which 2020
+        # codes a record does and does not carry lives structurally in
+        # pp28_sources / kbli_2020_source, which is where an audit trail belongs.
+        ("Cleaned: removed invalid ['01272']", ""),
+    ],
+)
+def test_top_level_guilt_on_the_real_values(mod, rules, before, expected):
+    assert mod.cure_text(before, rules, Counter(), normalize_whitespace=True) == expected
+
+
+def test_the_debris_records_render_nothing_rather_than_a_dangling_dash(mod):
+    """Emptying `mapping_note` must not leave "— " on the page.
+
+    Asserted against the FRONTEND SOURCE, not assumed: both consumers guard on
+    truthiness, so an empty string renders nothing. If either guard is ever
+    removed, 88 pages would show a bare em-dash and this test says so.
+    """
+    page = (REPO_ROOT / "apps" / "mouth" / "src" / "app" / "kbli" / "[code]" / "page.tsx").read_text(
+        encoding="utf-8"
+    )
+    faq = (REPO_ROOT / "apps" / "mouth" / "src" / "lib" / "kbli-faq.ts").read_text(encoding="utf-8")
+    assert "kbli.transition.mappingNote && (" in page, "the crosswalk row lost its truthiness guard"
+    assert "code.transition.mappingNote ?" in faq, "the FAQ answer lost its truthiness guard"
+
+
+def test_top_level_pass_is_canonical_only_because_gold_has_no_such_fields(mod, gold_payload):
+    """Measured, not assumed — the reason cure_top_level is never handed gold."""
+    present = [
+        (code, field)
+        for code, intel in mod.gold_pairs(gold_payload)
+        if isinstance(intel, dict)
+        for field, _ in mod.TOP_LEVEL_FIELDS
+        if isinstance(intel.get(field), str) and intel[field]
+    ]
+    assert not present, f"gold unexpectedly carries top-level fields: {present[:5]}"
+
+
+def test_the_fields_deliberately_left_alone_are_not_in_scope(mod):
+    """status_mapping / _data_note / uraian must never enter either field list.
+
+    Each has a live reason: status_mapping is the machine field TransitionBadge
+    renders (curing it breaks the badge on 1,558 records); _data_note is evidence
+    rendered verbatim and is pinned as an INNOCENCE case in
+    kbli-internal-leak.test.ts; uraian is the official BPS Indonesian text.
+    This test is the tripwire against a future "let's finish the sweep".
+    """
+    in_scope = {f for f, _ in mod.FIELDS} | {f for f, _ in mod.TOP_LEVEL_FIELDS}
+    for forbidden in ("status_mapping", "_data_note", "uraian", "ruang_lingkup"):
+        assert forbidden not in in_scope, f"{forbidden} must never be cured — see the comment on TOP_LEVEL_FIELDS"
+
+
+def test_the_two_stored_copies_no_longer_contradict_each_other(mod, rules, canonical_records):
+    """The client-visible symptom this lot exists for.
+
+    `whatChanged` embeds `mapping_note` verbatim, but they are independent
+    copies: L2.3 cured the embedded one and left the source Italian, so a page
+    rendered an English block and an Italian crosswalk row about the same fact.
+    After this cure, wherever the embedding relation holds, the cured
+    `mapping_note` must still appear inside the cured `whatChanged`.
+    """
+    broken = []
+    for rec in canonical_records:
+        mn = rec.get("mapping_note")
+        wc = (rec.get("intel_2026") or {}).get("whatChanged")
+        if not isinstance(mn, str) or not mn or not isinstance(wc, str):
+            continue
+        cured_mn = mod.cure_text(mn, rules, Counter(), normalize_whitespace=True)
+        cured_wc = mod.cure_text(wc, rules, Counter(), normalize_whitespace=True)
+        # only assert on records where the embedding relation actually holds
+        if mn.strip() and mn.strip() in wc and cured_mn and cured_mn not in cured_wc:
+            broken.append(rec.get("kode_kbli_2025"))
+    assert not broken, f"cured mapping_note no longer matches its embedded copy in whatChanged: {broken[:6]}"


### PR DESCRIPTION
## What clients are reading right now

Found while running the PROVE-LIVE differential for #3196: `/kbli/01279` **still served**
`PP28 usa codice KBLI 2020 01270` after that cure merged.

Not a deploy lag and not a miss. `intel_2026.whatChanged` **embeds `mapping_note` verbatim** —
measured on the pre-#3196 canonical, `mapping_note` is an exact substring of `whatChanged` in 25 of
352 records — but they are **two independent stored copies**. #3196 cured the embedded one and left
the source Italian. The result on prod today: **~157 pages render an English `whatChanged` block and
an Italian crosswalk row about the same fact, on the same page.**

And 88 records were not merely Italian — they served a **Python list literal**. Confirmed live on
`/kbli/01272`, in the visible row *and* in the JSON-LD:

```
— Cleaned: removed invalid ['01272']
```

`mapping_note` reaches **three** client surfaces, each located in the served HTML rather than
inferred:

| surface | where |
|---|---|
| visible crosswalk row | `app/kbli/[code]/page.tsx:928-930` — `— {mappingNote}` |
| visible FAQ answer | `lib/kbli-faq.ts:117` |
| **FAQPage JSON-LD** | emitted from that same answer — structured data **Google indexes** |

## The fix

**443 (record,field) rewrites, ZERO new rules.** Every one was already matched by rules written for
`whatChanged`: `pp28_usa_codice` 157, `dati_da_codici_figli` 198, `cleaned_removed_invalid` 88. The
work was structural — these fields hang off the **record**, while `cure_dataset` iterates the
`intel_2026` container.

`cure_top_level` is a separate pass rather than a widening of `cure_dataset`: that function's
per-field behaviour is pinned by mutation-tested guards and there is no reason to push a second
container shape through it. Gold is never passed — measured, it carries none of these fields.

**Emptying the 88 debris values is correct, not lossy.** Which 2020 codes a record does and does not
carry lives structurally in `pp28_sources` / `kbli_2020_source`, which is where an audit trail
belongs. A test asserts **both** frontend consumers still guard on truthiness, so an empty value
renders nothing rather than a dangling em-dash — if either guard is ever removed, 88 pages would show
a bare `— ` and the test says so.

## What must NOT be cured — pinned as a tripwire

A future session will be tempted to "finish the sweep". A test now fails if any of these enters
scope, and the reason is recorded next to each:

- **`status_mapping`** (1,558 records) — the MACHINE field `TransitionBadge` renders as "Direct
  Match" via `MAPPING_STATUS_LABELS`. Its raw token appears in a curl only because it sits in the
  serialized props, never as visible text. **A curl grep alone would have argued for curing it and
  broken the badge on every record** — this is exactly the trap that caught me earlier in this lane.
- **`_data_note`** (88 with symbols) — evidence rendered verbatim as an audit trail; already an
  explicit INNOCENCE case in `kbli-internal-leak.test.ts`.
- **`uraian`** — the official BPS Indonesian description.

## Scope stated honestly

`aggregation_note` (198 records) is cured here, but it is **audit-trail, not a client fix**: it is
typed and transformed in BOTH apps (`mouth` + `kbli-navigator`) and rendered by **no** page or
component — zero readers. It is included because the rule already existed and because a field one
`<span>` away from being read should not be holding 198 Italian strings. The client-facing work is
the 245 `mapping_note` records.

## A consequence worth recording: this cure makes 15 audit-trail citations historical

A class audit of **every** top-level string field (not just the two cured here) found exactly two
others carrying Italian, debris or enum tokens after this PR — `status_mapping` (1,558, machine
field) and `_data_note` (123 records: 15 Italian, 105 enum). Both are deliberate.

The `_data_note` Italian is **quoted evidence**, e.g. 10433 records:

> `aggregation_note (currently 'Dati da 10433 + 1 codici figli PP28', now stale …)`

and 42999 quotes `mapping_note "PP28 usa codice KBLI 2020 42929 …"`. Those are citations of what the
canonical carried **at the time of the adjudication**, rendered verbatim by `KBLIDivergence` as an
audit trail.

**So after this PR those quotes no longer match the live fields — and that is correct.** An audit
trail records the past; the word "currently" was true when it was written. Flagged explicitly here
because the mismatch invites two wrong reactions from a future session: editing the evidence to
match (destroys the audit trail — `kbli-internal-leak.test.ts` already pins `_data_note` as an
INNOCENCE case), or re-running a cure over it. Neither. The only defensible change would be
rewording "currently" to "at the time of this adjudication", which is an editorial call on evidence
text, not a compiler job.

## Verification

- `mapping_note` Italian **0**, debris **0**, `aggregation_note` Italian **0** (was 157 / 88 / 198).
- Diff touches exactly two fields — `mapping_note` 245, `aggregation_note` 198 — verified key-by-key
  against `HEAD`; nothing else moved.
- New test asserts the **two stored copies no longer contradict**: wherever the embedding relation
  holds, the cured `mapping_note` still appears inside the cured `whatChanged`.
- Guilt cases on the three real value shapes; the exclusion tripwire; the frontend-guard assertion.
- 492 Python + 1039 `apps/mouth` tests green.
- Membership pin re-emitted (separate commit — the emitter fences on working==HEAD); `members`
  unchanged at 221.

Follows #3200 (same compiler, same lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
