### PR TITLE
feat(ci): scheduled main-integration run + verdict-liveness alert (tasks #37, #41)

### DIFF
--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -259,12 +259,31 @@ jobs:
     # producing verdicts at all", because it only ever sees individual
     # events, never the gap between them.
     #
-    # This job asks a different question, every 15 minutes: how long
-    # since main's tests.yml last produced a REAL conclusion (success,
-    # failure, or timed_out — not cancelled) on a push or schedule run?
-    # It alerts only once the gap exceeds THRESHOLD_MINUTES, then again
-    # every ESCALATION_MINUTES while the gap keeps growing — "one alert
-    # per outage", not one per 15-minute check, computed purely from
+    # This job asks a different question, every 15 minutes: is there a
+    # commit on `main` newer than the last REAL tests.yml conclusion
+    # (success, failure, or timed_out — not cancelled, on a push or
+    # schedule run), and if so, how long has it sat unjudged?
+    #
+    # Deliberately NOT "how long since the last verdict, period" — that
+    # was the first version of this job, caught before shipping: with
+    # tests.yml's schedule now every 2h (task #37), a quiet main with no
+    # pushes only ever gets a fresh verdict every ~2h, so a naive
+    # verdict-to-now clock would breach THRESHOLD_MINUTES=45 on EVERY
+    # ordinary quiet stretch and re-alert on every escalation boundary
+    # for hours — alarm fatigue built in on day one, exactly the failure
+    # mode this job exists to avoid from the opposite direction. A main
+    # that hasn't moved since its last verdict is fully verified no
+    # matter how much wall-clock time has passed; there is nothing to
+    # alarm about. So staleness is measured from the moment main's HEAD
+    # first diverged from the last-verified commit, not from the verdict
+    # timestamp itself — a fresh push gets a 45-minute grace period
+    # before this job says anything, and a quiet main never breaches at
+    # all, because `current head == last verified sha` short-circuits to
+    # zero staleness regardless of how old that verdict is.
+    #
+    # It alerts once the gap exceeds THRESHOLD_MINUTES, then again every
+    # ESCALATION_MINUTES while the gap keeps growing — "one alert per
+    # outage", not one per 15-minute check, computed purely from
     # timestamp arithmetic so there is no external state to persist or to
     # go stale itself.
     #
@@ -298,24 +317,65 @@ jobs:
           CHECK_INTERVAL_MINUTES=15
           ESCALATION_MINUTES=60
 
+          CURRENT_HEAD=$(gh api "repos/${REPO}/commits/main" --jq '.sha')
+
           # Lookback of 30 completed runs comfortably covers even a long
           # cancellation streak (tonight's worst was 15 of 20) while
           # staying a single cheap API call.
-          LAST_TS=$(gh api "repos/${REPO}/actions/workflows/tests.yml/runs?branch=main&status=completed&per_page=30" \
-            --jq '[.workflow_runs[] | select((.event=="push" or .event=="schedule") and (.conclusion=="success" or .conclusion=="failure" or .conclusion=="timed_out"))] | sort_by(.updated_at) | last | .updated_at // empty')
+          LAST_RUN=$(gh api "repos/${REPO}/actions/workflows/tests.yml/runs?branch=main&status=completed&per_page=30" \
+            --jq '[.workflow_runs[] | select((.event=="push" or .event=="schedule") and (.conclusion=="success" or .conclusion=="failure" or .conclusion=="timed_out"))] | sort_by(.updated_at) | last')
+          LAST_VERIFIED_SHA=$(echo "${LAST_RUN}" | jq -r '.head_sha // empty')
+          LAST_VERIFIED_AT=$(echo "${LAST_RUN}" | jq -r '.updated_at // empty')
 
           NOW_EPOCH=$(date -u +%s)
-          if [ -z "${LAST_TS}" ]; then
-            # No qualifying run at all within the lookback window — treat
-            # as maximally stale rather than silently passing.
+          UNVERIFIED_SHA=""
+
+          if [ -z "${LAST_VERIFIED_SHA}" ]; then
+            # No qualifying run at all within the lookback window — we
+            # don't even know main's last verified state, so anything on
+            # main is by definition long-unverified. Maximally stale.
             STALE_MINUTES=999999
+            UNVERIFIED_SHA="${CURRENT_HEAD}"
+          elif [ "${LAST_VERIFIED_SHA}" = "${CURRENT_HEAD}" ]; then
+            # main's current tip IS what was last verified — fully caught
+            # up, no matter how long ago that verdict ran. THE FIX: a
+            # 2-hour-old verdict on an unchanged main is not staleness,
+            # it's main correctly having nothing new to test. Without this
+            # branch, a quiet night with tests.yml's 2h schedule cadence
+            # would breach THRESHOLD_MINUTES on every ordinary gap between
+            # scheduled runs and re-alert on every escalation boundary —
+            # caught in review before shipping, not by a test.
+            STALE_MINUTES=0
           else
-            LAST_EPOCH=$(date -u -d "${LAST_TS}" +%s)
-            STALE_MINUTES=$(( (NOW_EPOCH - LAST_EPOCH) / 60 ))
+            # main has moved past what was last verified. Staleness is
+            # measured from when the FIRST unverified commit landed, not
+            # from the old verdict's own timestamp — a main that gained
+            # one commit five minutes ago gets its full grace period
+            # instead of inheriting whatever age the previous verdict
+            # happened to have. `compare` orders `commits[]` oldest-first
+            # (base-exclusive, head-inclusive, matches `git log
+            # base..head`); known residual gap, not solved here: it caps
+            # at 250 commits, irrelevant at this repo's push cadence but
+            # named so it isn't mistaken for unconditional.
+            FIRST_UNVERIFIED_AT=$(gh api "repos/${REPO}/compare/${LAST_VERIFIED_SHA}...${CURRENT_HEAD}" \
+              --jq '.commits[0].commit.committer.date // empty')
+            if [ -z "${FIRST_UNVERIFIED_AT}" ]; then
+              # SHAs differ but compare returned no commits — shouldn't
+              # happen; defensive fallback, not a silent pass.
+              STALE_MINUTES=999999
+            else
+              FIRST_UNVERIFIED_EPOCH=$(date -u -d "${FIRST_UNVERIFIED_AT}" +%s)
+              STALE_MINUTES=$(( (NOW_EPOCH - FIRST_UNVERIFIED_EPOCH) / 60 ))
+            fi
+            UNVERIFIED_SHA="${CURRENT_HEAD}"
           fi
 
-          echo "stale_minutes=${STALE_MINUTES}" >> "$GITHUB_OUTPUT"
-          echo "last_verdict_at=${LAST_TS}" >> "$GITHUB_OUTPUT"
+          {
+            echo "stale_minutes=${STALE_MINUTES}"
+            echo "last_verified_sha=${LAST_VERIFIED_SHA}"
+            echo "last_verified_at=${LAST_VERIFIED_AT}"
+            echo "unverified_sha=${UNVERIFIED_SHA}"
+          } >> "$GITHUB_OUTPUT"
 
           # STALE_MINUTES==999999 (no qualifying run found at all) is
           # handled BEFORE the escalation-boundary math, not through it:
@@ -340,13 +400,15 @@ jobs:
             fi
           fi
 
-      - name: Telegram alert — main has produced no test verdict in a while
+      - name: Telegram alert — main has an unverified commit sitting too long
         if: steps.check.outputs.should_alert == 'true'
         env:
           BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
           STALE: ${{ steps.check.outputs.stale_minutes }}
-          LAST: ${{ steps.check.outputs.last_verdict_at }}
+          LAST_SHA: ${{ steps.check.outputs.last_verified_sha }}
+          LAST_AT: ${{ steps.check.outputs.last_verified_at }}
+          UNVERIFIED_SHA: ${{ steps.check.outputs.unverified_sha }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -354,8 +416,10 @@ jobs:
             echo "::warning::Telegram secrets missing — cannot alert"
             exit 0
           fi
-          LAST_DISPLAY="${LAST:-never (no qualifying run found)}"
-          TEXT="main has had no completed tests.yml verdict (success/failure) in ${STALE} min — last: ${LAST_DISPLAY}. Runs may be queued-then-cancelled under load (task #41) -- https://github.com/${REPO}/actions/workflows/tests.yml?query=branch%3Amain"
+          LAST_DISPLAY="${LAST_SHA:-unknown}"
+          [ -n "${LAST_AT}" ] && LAST_DISPLAY="${LAST_DISPLAY} (${LAST_AT})"
+          SHORT_UNVERIFIED="${UNVERIFIED_SHA:0:7}"
+          TEXT="main has an unverified commit (${SHORT_UNVERIFIED}) with no completed tests.yml verdict in ${STALE} min — last verified: ${LAST_DISPLAY}. Runs may be queued-then-cancelled under load (task #41) -- https://github.com/${REPO}/commits/main"
           curl -sS -m 10 -X POST "https://api.telegram.org/bot${BOT}/sendMessage" \
             --data-urlencode "chat_id=${CHAT}" \
             --data-urlencode "text=${TEXT}"

--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -147,6 +147,11 @@ on:
       - WR2 master template guard
       - wr2-queue-tests
     types: [completed]
+  # Task #41 (2026-07-26): see the `verdict-liveness` job below for why this
+  # exists — a reactive workflow_run watcher structurally cannot see the
+  # absence of an event, only events themselves.
+  schedule:
+    - cron: "*/15 * * * *"
 
 concurrency:
   # One in-flight job per commit — the coalescing mechanism. When several
@@ -155,7 +160,17 @@ concurrency:
   # for that SHA and only the last one survives to send. It re-derives the
   # failing set fresh from the API at send-time (next step), so correctness
   # never depends on which specific triggering event happened to win.
-  group: main-push-failure-watch-${{ github.event.workflow_run.head_sha }}
+  #
+  # Task #41 addendum: `github.event.workflow_run.head_sha` doesn't exist
+  # under this workflow's own new `schedule` trigger (no workflow_run
+  # payload on that event at all — it resolves to an empty string, not an
+  # error), which would put every scheduled liveness check into the SAME
+  # degenerate group regardless of when it ran. Give schedule-triggered
+  # runs of THIS workflow their own group instead, independent of
+  # head_sha, so a `verdict-liveness` run in flight yields to a fresher
+  # one rather than colliding with — or hiding behind — the alert job's
+  # per-commit grouping.
+  group: ${{ github.event_name == 'schedule' && 'main-push-failure-watch-verdict-liveness' || format('main-push-failure-watch-{0}', github.event.workflow_run.head_sha) }}
   cancel-in-progress: true
 
 jobs:
@@ -165,7 +180,15 @@ jobs:
     # on the PR, or operator-initiated — see header comment for the
     # 2026-07-26/task #37 widening from push-only to push-or-schedule).
     # `cancelled` is excluded deliberately — see header comment.
+    # `github.event_name == 'workflow_run'` is a defensive, explicit guard
+    # against this job's own workflow now also carrying a `schedule`
+    # trigger (task #41, added below) — the `github.event.workflow_run.*`
+    # comparisons already evaluate to false under a schedule event on
+    # their own (missing-object property access is null, not an error, in
+    # GitHub Actions expressions), but stating it plainly beats relying on
+    # that implicit behavior being remembered correctly by a future editor.
     if: >-
+      github.event_name == 'workflow_run' &&
       (github.event.workflow_run.event == 'push' ||
        github.event.workflow_run.event == 'schedule') &&
       github.event.workflow_run.head_branch == 'main' &&
@@ -216,6 +239,123 @@ jobs:
           SHORT_SHA="${SHA:0:7}"
           LIST=$(paste -sd, /tmp/failing.txt)
           TEXT="main push failing (${SHORT_SHA}): ${LIST} -- https://github.com/${REPO}/commits/${SHA}"
+          curl -sS -m 10 -X POST "https://api.telegram.org/bot${BOT}/sendMessage" \
+            --data-urlencode "chat_id=${CHAT}" \
+            --data-urlencode "text=${TEXT}"
+
+  verdict-liveness:
+    # Task #41 (2026-07-26). The `alert` job above is REACTIVE — it fires
+    # on a completed workflow_run event, and `cancelled` is deliberately
+    # excluded from its condition (see header comment): a normal
+    # supersede-cancel of ONE run is routine, not a silent failure, and
+    # alerting on every one would be the exact fatigue this watcher exists
+    # to avoid. But that exclusion has a blind spot measured live tonight:
+    # main's tests.yml went from a completed verdict every ~20-25 minutes
+    # to NONE for 75+ minutes, entirely via `cancelled` conclusions
+    # superseding queued runs (task #37's finding — `cancel-in-progress:
+    # false` only protects a run that already started), and `alert` never
+    # said a word — a reactive per-event watcher with `cancelled` excluded
+    # cannot distinguish "one routine supersede" from "main has stopped
+    # producing verdicts at all", because it only ever sees individual
+    # events, never the gap between them.
+    #
+    # This job asks a different question, every 15 minutes: how long
+    # since main's tests.yml last produced a REAL conclusion (success,
+    # failure, or timed_out — not cancelled) on a push or schedule run?
+    # It alerts only once the gap exceeds THRESHOLD_MINUTES, then again
+    # every ESCALATION_MINUTES while the gap keeps growing — "one alert
+    # per outage", not one per 15-minute check, computed purely from
+    # timestamp arithmetic so there is no external state to persist or to
+    # go stale itself.
+    #
+    # THRESHOLD_MINUTES=45 sits clear of the measured healthy gap (~20-25
+    # min) without living on the edge of normal. That number is a design
+    # choice grounded in one night's data, not a claim that a future
+    # outage will last exactly as long — see
+    # discovery_a_cure_pinned_to_todays_world_becomes_tomorrows_bug.
+    #
+    # Known residual gap: if this job's own `gh api` call fails (network
+    # blip, rate limit) the step errors under `set -euo pipefail` and the
+    # job shows red in the Actions UI — but nothing downstream watches
+    # THIS workflow's own runs (workflow_run chaining is deliberately not
+    # self-referential, see header comment), so a failure here is only
+    # visible to whoever looks. Same class of gap as the `alert` job
+    # itself; not solved here, named so it isn't mistaken for solved.
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: main-verdict-liveness
+      cancel-in-progress: true
+    steps:
+      - name: Check time since main's last completed tests.yml verdict
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          THRESHOLD_MINUTES=45
+          CHECK_INTERVAL_MINUTES=15
+          ESCALATION_MINUTES=60
+
+          # Lookback of 30 completed runs comfortably covers even a long
+          # cancellation streak (tonight's worst was 15 of 20) while
+          # staying a single cheap API call.
+          LAST_TS=$(gh api "repos/${REPO}/actions/workflows/tests.yml/runs?branch=main&status=completed&per_page=30" \
+            --jq '[.workflow_runs[] | select((.event=="push" or .event=="schedule") and (.conclusion=="success" or .conclusion=="failure" or .conclusion=="timed_out"))] | sort_by(.updated_at) | last | .updated_at // empty')
+
+          NOW_EPOCH=$(date -u +%s)
+          if [ -z "${LAST_TS}" ]; then
+            # No qualifying run at all within the lookback window — treat
+            # as maximally stale rather than silently passing.
+            STALE_MINUTES=999999
+          else
+            LAST_EPOCH=$(date -u -d "${LAST_TS}" +%s)
+            STALE_MINUTES=$(( (NOW_EPOCH - LAST_EPOCH) / 60 ))
+          fi
+
+          echo "stale_minutes=${STALE_MINUTES}" >> "$GITHUB_OUTPUT"
+          echo "last_verdict_at=${LAST_TS}" >> "$GITHUB_OUTPUT"
+
+          # STALE_MINUTES==999999 (no qualifying run found at all) is
+          # handled BEFORE the escalation-boundary math, not through it:
+          # "we don't even know when main last passed" is categorically
+          # worse than a known, bounded staleness, and the boundary
+          # heuristic below is tuned for a value that climbs by roughly
+          # CHECK_INTERVAL_MINUTES every check — a caught-by-its-own-test
+          # bug found the sentinel does NOT reliably land within a
+          # check-interval of an escalation boundary, so it could go
+          # silent on the one input most needing an alert.
+          if [ "${STALE_MINUTES}" -ge 999999 ]; then
+            echo "should_alert=true" >> "$GITHUB_OUTPUT"
+          elif [ "${STALE_MINUTES}" -lt "${THRESHOLD_MINUTES}" ]; then
+            echo "should_alert=false" >> "$GITHUB_OUTPUT"
+          else
+            OVERFLOW=$(( STALE_MINUTES - THRESHOLD_MINUTES ))
+            BOUNDARY=$(( OVERFLOW % ESCALATION_MINUTES ))
+            if [ "${OVERFLOW}" -lt "${CHECK_INTERVAL_MINUTES}" ] || [ "${BOUNDARY}" -lt "${CHECK_INTERVAL_MINUTES}" ]; then
+              echo "should_alert=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_alert=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Telegram alert — main has produced no test verdict in a while
+        if: steps.check.outputs.should_alert == 'true'
+        env:
+          BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          STALE: ${{ steps.check.outputs.stale_minutes }}
+          LAST: ${{ steps.check.outputs.last_verdict_at }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BOT}" ] || [ -z "${CHAT}" ]; then
+            echo "::warning::Telegram secrets missing — cannot alert"
+            exit 0
+          fi
+          LAST_DISPLAY="${LAST:-never (no qualifying run found)}"
+          TEXT="main has had no completed tests.yml verdict (success/failure) in ${STALE} min — last: ${LAST_DISPLAY}. Runs may be queued-then-cancelled under load (task #41) -- https://github.com/${REPO}/actions/workflows/tests.yml?query=branch%3Amain"
           curl -sS -m 10 -X POST "https://api.telegram.org/bot${BOT}/sendMessage" \
             --data-urlencode "chat_id=${CHAT}" \
             --data-urlencode "text=${TEXT}"

--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -14,13 +14,25 @@ name: Main-push Failure Watch
 # by watcher-conformance.yml, which fails CI if this file's `workflows:` list
 # drifts from the live workflow census.
 #
-# SCOPE: alerts ONLY for a push-triggered run on `main` — not for
-# pull_request runs (already visible on the PR itself) and not for
-# schedule/workflow_dispatch runs on other branches. The `workflows:` list
-# below is DELIBERATELY over-inclusive (every workflow in the repo, this
-# file's own name excluded) so listing it never requires a push:main
-# judgment call — real filtering happens in the job `if:` below, on the
-# actual event + branch of the run that just completed.
+# SCOPE: alerts for a push-triggered OR schedule-triggered run on `main` —
+# not for pull_request runs (already visible on the PR itself) and not for
+# workflow_dispatch runs (operator-initiated; the operator is already
+# watching). The `workflows:` list below is DELIBERATELY over-inclusive
+# (every workflow in the repo, this file's own name excluded) so listing it
+# never requires a push:main/schedule:main judgment call — real filtering
+# happens in the job `if:` below, on the actual event + branch of the run
+# that just completed.
+#
+# Widened to `schedule` 2026-07-26 (task #37): task #37 added the first
+# schedule-triggered workflow that targets main (`Tests & Coverage`'s
+# hourly run, decoupled from push cadence precisely because push-triggered
+# runs on main were measured spending most of their life queued-then-
+# cancelled — see tests.yml's `on.schedule` comment). Excluding `schedule`
+# here would have meant building a health check whose own failures nobody
+# gets told about — the exact "esiste ≠ armato" disease this watcher exists
+# to cure, just at one more remove. `schedule` always fires against the
+# default branch only, so `head_branch == 'main'` is not a new constraint
+# for it, only `event` needed widening.
 #
 # GOTCHAS (verified 2026-07-26 against GitHub's docs + this repo's live API,
 # not assumed):
@@ -148,12 +160,14 @@ concurrency:
 
 jobs:
   alert:
-    # Scope to an actual push-to-main run, not a pull_request/schedule/
-    # workflow_dispatch run on some other branch (those are either already
-    # visible on the PR, or not the "landed silently broken" disease this
-    # exists for). `cancelled` is excluded deliberately — see header comment.
+    # Scope to an actual push-to-main or schedule-on-main run, not a
+    # pull_request/workflow_dispatch run (those are either already visible
+    # on the PR, or operator-initiated — see header comment for the
+    # 2026-07-26/task #37 widening from push-only to push-or-schedule).
+    # `cancelled` is excluded deliberately — see header comment.
     if: >-
-      github.event.workflow_run.event == 'push' &&
+      (github.event.workflow_run.event == 'push' ||
+       github.event.workflow_run.event == 'schedule') &&
       github.event.workflow_run.head_branch == 'main' &&
       (github.event.workflow_run.conclusion == 'failure' ||
        github.event.workflow_run.conclusion == 'timed_out')
@@ -167,7 +181,7 @@ jobs:
         # message instead of exactly 1 — degraded, never silent.
         run: sleep 90
 
-      - name: Aggregate every currently-failing push-to-main run on this commit
+      - name: Aggregate every currently-failing push-or-schedule main run on this commit
         id: agg
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -175,8 +189,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh api "repos/${REPO}/actions/runs?head_sha=${SHA}&event=push&status=completed" \
-            --paginate --jq '.workflow_runs[] | select(.conclusion=="failure" or .conclusion=="timed_out") | .name' \
+          # No server-side `event=` filter here (task #37 widening): the API
+          # only accepts one `event=` value per call, and this now needs
+          # push OR schedule, so the OR moves into the jq select below
+          # instead of two round-trips. head_sha already scopes this to one
+          # commit, so the extra rows filtered out client-side are cheap.
+          gh api "repos/${REPO}/actions/runs?head_sha=${SHA}&status=completed" \
+            --paginate --jq '.workflow_runs[] | select((.event=="push" or .event=="schedule") and (.conclusion=="failure" or .conclusion=="timed_out")) | .name' \
             | sort -u > /tmp/failing.txt
           COUNT=$(wc -l < /tmp/failing.txt | tr -d ' ')
           echo "count=${COUNT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,15 +6,42 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+  # Task #37 (2026-07-26): main's push-triggered suite is measured to spend
+  # most of its life QUEUED, not running — 28 of 38 recent attempts on this
+  # workflow were cancelled before a runner ever picked them up, because
+  # `cancel-in-progress: false` only protects a run that already started;
+  # a run still waiting for a slot is superseded unconditionally by the next
+  # push to the same concurrency group. Net effect: main can go a long
+  # stretch with no completed test verdict even though every push "ran" a
+  # workflow. This hourly run is independent proof-of-health, decoupled from
+  # push cadence — it runs the exact same job graph as a push/PR run (no
+  # duplicated logic to drift), against whatever is on main at the top of
+  # the hour, and it gets its own concurrency group below so it never
+  # queues behind — or evicts — a push-triggered run. :17 offset dodges the
+  # top-of-hour stampede (same convention as docs-inventory-refresh-liveness.yml).
+  schedule:
+    - cron: "17 * * * *"
 
 # Merge-train spec §10.2 (2026-06-12): cancel-in-progress must NOT apply to
 # main — back-to-back merges were cancelling the in-flight main run, so
 # commits landed on main UNTESTED and a future auto-revert guardian could
 # not attribute a green→red window to a single commit. PR refs keep
 # cancelling (newest push wins); every main push now runs to completion.
+#
+# Task #37 addendum: a schedule-triggered run must NOT share a group with
+# push-triggered main runs. `github.ref` is `refs/heads/main` for BOTH a
+# push-to-main and a schedule run (schedule always fires against the
+# default branch) — grouping on `github.ref` alone would put the hourly
+# run back in direct contention with push-triggered runs for the same
+# runner slot, reproducing the exact starvation this run exists to work
+# around. Scheduled runs get a dedicated, ref-independent group instead;
+# self-collision across two scheduled runs is a non-issue in practice
+# (job timeouts are well under the 1h cadence) but cancel-in-progress
+# stays false for it anyway, for the same reason it stays false for main:
+# a run that started should always get to report its verdict.
 concurrency:
-  group: tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: tests-${{ github.event_name == 'schedule' && 'schedule-main' || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:
   backend-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,21 +6,39 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
-  # Task #37 (2026-07-26): main's push-triggered suite is measured to spend
-  # most of its life QUEUED, not running — 28 of 38 recent attempts on this
-  # workflow were cancelled before a runner ever picked them up, because
-  # `cancel-in-progress: false` only protects a run that already started;
-  # a run still waiting for a slot is superseded unconditionally by the next
-  # push to the same concurrency group. Net effect: main can go a long
-  # stretch with no completed test verdict even though every push "ran" a
-  # workflow. This hourly run is independent proof-of-health, decoupled from
-  # push cadence — it runs the exact same job graph as a push/PR run (no
-  # duplicated logic to drift), against whatever is on main at the top of
-  # the hour, and it gets its own concurrency group below so it never
-  # queues behind — or evicts — a push-triggered run. :17 offset dodges the
-  # top-of-hour stampede (same convention as docs-inventory-refresh-liveness.yml).
+  # Task #37 (2026-07-26). STRUCTURAL claim, not a snapshot of one night:
+  # `cancel-in-progress: false` (below) protects a run that has already
+  # STARTED — a run still QUEUED for a runner slot is superseded
+  # unconditionally by the next push to the same concurrency group,
+  # regardless of that setting. Under any sufficiently busy stretch, main
+  # can go a long stretch with no completed test verdict even though every
+  # push technically "ran" a workflow. (One specific night's measurement —
+  # 28/38 recent attempts cancelled, main's last verdict over an hour
+  # stale — motivated building this, but that number is a snapshot of one
+  # convoy, not the justification; it had already resolved by the time
+  # this shipped. Do not re-derive urgency from it later. A cure pinned to
+  # tonight's world is tomorrow's bug.)
+  #
+  # This scheduled run is independent proof-of-health, decoupled from push
+  # cadence — it runs the exact same job graph as a push/PR run (no
+  # duplicated logic to drift), against whatever is on main when it fires,
+  # and it gets its own concurrency group below so it never queues behind
+  # — or evicts — a push-triggered run.
+  #
+  # Cadence: every 2h, not hourly. A full run of this job graph measured
+  # ~43 minutes wall-clock on a loaded night — hourly would be a ~72% duty
+  # cycle on the runners this workflow already competes for, and slots are
+  # the binding constraint main's own velocity runs into (task #37's own
+  # finding). Task #41's separate verdict-liveness check (see
+  # main-push-failure-watch.yml) is the FAST heartbeat now — it's a cheap
+  # API-only poll every 15 min, no runner-heavy job — so this run's job
+  # is no longer to detect an outage quickly, only to periodically produce
+  # a real full-suite verdict against main's current head (catching
+  # interaction bugs invisible to per-PR testing) at a sustainable cost.
+  # :17 offset dodges the top-of-hour stampede (same convention as
+  # docs-inventory-refresh-liveness.yml).
   schedule:
-    - cron: "17 * * * *"
+    - cron: "17 */2 * * *"
 
 # Merge-train spec §10.2 (2026-06-12): cancel-in-progress must NOT apply to
 # main — back-to-back merges were cancelling the in-flight main run, so
@@ -31,17 +49,27 @@ on:
 # Task #37 addendum: a schedule-triggered run must NOT share a group with
 # push-triggered main runs. `github.ref` is `refs/heads/main` for BOTH a
 # push-to-main and a schedule run (schedule always fires against the
-# default branch) — grouping on `github.ref` alone would put the hourly
+# default branch) — grouping on `github.ref` alone would put the scheduled
 # run back in direct contention with push-triggered runs for the same
 # runner slot, reproducing the exact starvation this run exists to work
-# around. Scheduled runs get a dedicated, ref-independent group instead;
-# self-collision across two scheduled runs is a non-issue in practice
-# (job timeouts are well under the 1h cadence) but cancel-in-progress
-# stays false for it anyway, for the same reason it stays false for main:
-# a run that started should always get to report its verdict.
+# around. Scheduled runs get a dedicated, ref-independent group instead.
+#
+# cancel-in-progress is the OPPOSITE value for the scheduled group,
+# deliberately: `false` is what protects a push-triggered main run (a
+# started verdict should always get to report, and cancelling it on the
+# next push is what silently starved main in the first place). `true` is
+# correct for the scheduled group for the mirror-image reason — if a new
+# scheduled run starts while the previous is still going (job overrunning
+# the 2h cadence under load), the older run is testing a `main` that no
+# longer exists, so the freshest run should win, not the oldest. Same
+# flag, opposite correct value, because the underlying question differs:
+# "protect a verdict in flight" vs "don't waste a slot re-testing a stale
+# head". Do not "fix" this to match main's `false` — that was tried
+# nowhere, noted here only because the asymmetry looks like a bug at a
+# glance.
 concurrency:
   group: tests-${{ github.event_name == 'schedule' && 'schedule-main' || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'schedule' || github.ref != 'refs/heads/main' }}
 
 jobs:
   backend-tests:

--- a/scripts/verify_main_watch_schedule_scope.py
+++ b/scripts/verify_main_watch_schedule_scope.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+Task #37 guilt/innocence proof for .github/workflows/main-push-failure-watch.yml's
+alert job, after widening its scope from push-only to push-or-schedule.
+
+NOT a general GitHub Actions expression interpreter — deliberately narrow,
+same "known limit" style as scripts/verify_post_deploy_health_reachability.py
+(task #19) and scripts/check_watcher_coverage.py. This hand-encodes the
+semantics of exactly ONE job's `if:` plus one aggregation step's jq `select`
+as they exist in this repo today.
+
+Why the widening exists: task #37 added `.github/workflows/tests.yml`'s
+first `schedule:` trigger that targets main (hourly, decoupled from push
+cadence — see tests.yml's own `on.schedule` comment for the measured
+starvation this works around). Before this change, `main-push-failure-
+watch.yml`'s alert job fired ONLY on `github.event.workflow_run.event ==
+'push'` — a schedule-triggered failure of the exact same workflow, on the
+exact same branch, with the exact same conclusion, would silently NOT
+alert. That is cron-theater-by-omission (superscar #2, "Esiste ≠ Armato"):
+a health check exists, but its own failure is invisible. The fix widens
+the `if:` to `event == 'push' OR event == 'schedule'`, and widens the
+aggregation step's jq `select` the same way (it had its own independent
+`event=push` filter, server-side via the `gh api` query param this time,
+not the job-level `if:` — missing this second spot would have left the
+top-level gate open while the aggregate always counted zero schedule
+failures, silently suppressing the Telegram message anyway).
+
+Self-check: if a future edit changes this job's `if:` or the aggregation
+step's `run:` script in the YAML, this script fails loudly (exit 2) instead
+of silently proving the wrong thing.
+"""
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "main-push-failure-watch.yml"
+JOB_NAME = "alert"
+
+# `if: >-` is a YAML *folded* block scalar: GitHub Actions/PyYAML fold a
+# normal-indent line break into a single space but preserve the newline
+# before any MORE-indented continuation line — exact whitespace/newline
+# placement after folding is not worth hand-predicting here, so
+# EXPECTED_IF is written as one logical string and compared via
+# _normalize(), which collapses all whitespace runs (including newlines)
+# to a single space before comparing.
+EXPECTED_IF = (
+    "(github.event.workflow_run.event == 'push' || "
+    "github.event.workflow_run.event == 'schedule') && "
+    "github.event.workflow_run.head_branch == 'main' && "
+    "(github.event.workflow_run.conclusion == 'failure' || "
+    "github.event.workflow_run.conclusion == 'timed_out')"
+)
+
+AGGREGATE_STEP_NAME = "Aggregate every currently-failing push-or-schedule main run on this commit"
+EXPECTED_AGGREGATE_SELECT_SUBSTRING = (
+    'select((.event=="push" or .event=="schedule") '
+    'and (.conclusion=="failure" or .conclusion=="timed_out"))'
+)
+
+
+def _normalize(s: str) -> str:
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _step_by_name(job: dict, name: str) -> dict | None:
+    for step in job.get("steps") or []:
+        if step.get("name") == name:
+            return step
+    return None
+
+
+def self_check() -> None:
+    """Fail loudly if the YAML no longer matches what this script models."""
+    data = yaml.safe_load(WORKFLOW.read_text())
+    job = (data.get("jobs") or {}).get(JOB_NAME)
+    if job is None:
+        print(f"FATAL: job '{JOB_NAME}' not found in {WORKFLOW}", file=sys.stderr)
+        sys.exit(2)
+
+    if_raw = (job.get("if") or "").strip()
+    if _normalize(if_raw) != _normalize(EXPECTED_IF):
+        print(
+            f"FATAL: {JOB_NAME}.if drifted from what this script models.\n"
+            f"  expected: {EXPECTED_IF!r}\n"
+            f"  actual:   {if_raw!r}\n"
+            "  Update EXPECTED_IF and alert_fires() below to match the new\n"
+            "  YAML before trusting this script's verdict again.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    step = _step_by_name(job, AGGREGATE_STEP_NAME)
+    if step is None:
+        print(
+            f"FATAL: step '{AGGREGATE_STEP_NAME}' not found in job '{JOB_NAME}'.\n"
+            "  This script's aggregate-scope proof assumes this step exists\n"
+            "  by this exact name — a rename silently breaks it.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    run_raw = _normalize(step.get("run") or "")
+    if _normalize(EXPECTED_AGGREGATE_SELECT_SUBSTRING) not in run_raw:
+        print(
+            f"FATAL: step '{AGGREGATE_STEP_NAME}'.run no longer contains the\n"
+            "  jq select this script models.\n"
+            f"  expected substring: {EXPECTED_AGGREGATE_SELECT_SUBSTRING!r}\n"
+            f"  actual run script:  {step.get('run')!r}\n"
+            "  Update EXPECTED_AGGREGATE_SELECT_SUBSTRING and\n"
+            "  counts_toward_aggregate() below to match the new YAML before\n"
+            "  trusting this script's verdict again.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def alert_fires(event: str, head_branch: str, conclusion: str) -> bool:
+    """Models the job-level `if:` on the `alert` job."""
+    return (
+        event in ("push", "schedule")
+        and head_branch == "main"
+        and conclusion in ("failure", "timed_out")
+    )
+
+
+def counts_toward_aggregate(event: str, conclusion: str) -> bool:
+    """Models the aggregation step's jq `select(...)` clause.
+
+    Unlike alert_fires(), this has no head_branch check — the `gh api`
+    call is already scoped to one commit's head_sha, and every workflow_run
+    for a given head_sha on THIS repo shares one branch context in
+    practice for the push/schedule case this models (a PR-triggered run on
+    the same SHA would carry event=='pull_request', already excluded by
+    the event check below).
+    """
+    return event in ("push", "schedule") and conclusion in ("failure", "timed_out")
+
+
+# (label, event, head_branch, conclusion, expect_fires)
+ALERT_SCENARIOS = [
+    (
+        "GUILT — schedule-triggered run on main fails (task #37's new case: "
+        "the hourly Tests & Coverage run breaks and nobody was told before "
+        "this widening)",
+        "schedule", "main", "failure", True,
+    ),
+    (
+        "GUILT — schedule-triggered run on main times out",
+        "schedule", "main", "timed_out", True,
+    ),
+    (
+        "INNOCENCE — push-triggered run on main fails (pre-existing case, "
+        "must still fire after the widening)",
+        "push", "main", "failure", True,
+    ),
+    (
+        "INNOCENCE — pull_request-triggered run fails: already visible on "
+        "the PR itself, must not alert",
+        "pull_request", "main", "failure", False,
+    ),
+    (
+        "INNOCENCE — workflow_dispatch-triggered run on main fails: "
+        "operator-initiated, operator is already watching",
+        "workflow_dispatch", "main", "failure", False,
+    ),
+    (
+        "INNOCENCE — schedule-triggered run on a non-main branch fails "
+        "(structurally near-impossible — schedule only fires against the "
+        "default branch — but the guard should not rely on that alone)",
+        "schedule", "some-other-branch", "failure", False,
+    ),
+    (
+        "INNOCENCE — schedule-triggered run on main is cancelled: excluded "
+        "deliberately (see header comment), a routine supersede is not a "
+        "silent failure",
+        "schedule", "main", "cancelled", False,
+    ),
+    (
+        "INNOCENCE — schedule-triggered run on main succeeds",
+        "schedule", "main", "success", False,
+    ),
+]
+
+# (label, event, conclusion, expect_counts)
+AGGREGATE_SCENARIOS = [
+    (
+        "GUILT — schedule failure must be counted (this is the exact gap "
+        "the widening closes: an open top-level if: with an aggregate "
+        "still hardcoded to event=push would silently suppress the "
+        "Telegram message)",
+        "schedule", "failure", True,
+    ),
+    (
+        "INNOCENCE — push failure still counted (pre-existing case)",
+        "push", "failure", True,
+    ),
+    (
+        "INNOCENCE — pull_request run on the same head_sha not counted",
+        "pull_request", "failure", False,
+    ),
+    (
+        "INNOCENCE — schedule run that succeeded is not counted",
+        "schedule", "success", False,
+    ),
+]
+
+
+def main() -> None:
+    self_check()
+
+    failures = []
+
+    print("== alert job if: (push-or-schedule widening) ==")
+    for label, event, head_branch, conclusion, expect in ALERT_SCENARIOS:
+        got = alert_fires(event, head_branch, conclusion)
+        ok = got == expect
+        print(f"[{'PASS' if ok else 'FAIL'}] {label}\n"
+              f"         event={event} head_branch={head_branch} "
+              f"conclusion={conclusion} -> alert_fires={got} (expected {expect})")
+        if not ok:
+            failures.append(label)
+
+    print("\n== aggregate step jq select (mirrors the same widening) ==")
+    for label, event, conclusion, expect in AGGREGATE_SCENARIOS:
+        got = counts_toward_aggregate(event, conclusion)
+        ok = got == expect
+        print(f"[{'PASS' if ok else 'FAIL'}] {label}\n"
+              f"         event={event} conclusion={conclusion} "
+              f"-> counts_toward_aggregate={got} (expected {expect})")
+        if not ok:
+            failures.append(label)
+
+    total = len(ALERT_SCENARIOS) + len(AGGREGATE_SCENARIOS)
+    if failures:
+        print(f"\n{len(failures)}/{total} scenarios FAILED", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\nAll {total} scenarios PASS.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_main_watch_schedule_scope.py
+++ b/scripts/verify_main_watch_schedule_scope.py
@@ -37,14 +37,30 @@ Task #41 verdict-liveness, why it exists: a REACTIVE per-event watcher
 with `cancelled` excluded cannot distinguish "one routine supersede" from
 "main has stopped producing verdicts at all" — it only ever sees
 individual events, never the gap between them. `verdict-liveness` instead
-polls every 15 minutes and alerts once the gap since the last real
-(non-cancelled) tests.yml conclusion on main exceeds a threshold, then
+polls every 15 minutes and alerts once main has a commit that has sat
+without a real (non-cancelled) tests.yml conclusion for too long, then
 again on a bounded escalation cadence — "one alert per outage", computed
 purely from timestamp arithmetic, no external state.
 
+Design correction caught in review, before shipping (team-lead, not a
+test): the FIRST version of `verdict-liveness` measured staleness as
+"now minus the last verdict's own timestamp" — verdict-to-now, not
+commit-to-verdict. With tests.yml's schedule cadence at every 2 hours
+(task #37), a quiet main with no pushes only ever gets a fresh verdict
+every ~2h, so that measure would breach THRESHOLD_MINUTES=45 on EVERY
+ordinary quiet stretch and re-alert on every escalation boundary for
+hours — alarm fatigue built in on day one, from the opposite direction of
+the `cancelled`-exclusion bug this job exists to fix. The corrected
+design compares main's CURRENT head commit against the last-verified
+commit's SHA: if they're equal, main is fully caught up regardless of how
+old that verdict is (zero staleness); if they differ, staleness is
+measured from when the first unverified commit landed, not from the old
+verdict's timestamp. `compute_stale_minutes()` below models this.
+
 Self-check: if a future edit changes either job's `if:`, the aggregation
-step's `run:` script, or the escalation constants in the YAML, this script
-fails loudly (exit 2) instead of silently proving the wrong thing.
+step's `run:` script, the escalation constants, or the commit-comparison
+logic in the YAML, this script fails loudly (exit 2) instead of silently
+proving the wrong thing.
 """
 import re
 import sys
@@ -83,6 +99,13 @@ EXPECTED_AGGREGATE_SELECT_SUBSTRING = (
 
 CHECK_STEP_NAME = "Check time since main's last completed tests.yml verdict"
 EXPECTED_ESCALATION_CONSTANTS = ("THRESHOLD_MINUTES=45", "CHECK_INTERVAL_MINUTES=15", "ESCALATION_MINUTES=60")
+
+# The specific substring that proves the quiet-period fix is present: the
+# branch that short-circuits staleness to zero when main's current head
+# equals the last-verified SHA. Checking for this exact comparison (not
+# just "the constants exist") is what catches a future edit that reverts
+# to the verdict-to-now measure while leaving the constants untouched.
+EXPECTED_QUIET_PERIOD_SHORT_CIRCUIT = '"${LAST_VERIFIED_SHA}" = "${CURRENT_HEAD}"'
 
 
 def _normalize(s: str) -> str:
@@ -181,6 +204,22 @@ def self_check() -> None:
         )
         sys.exit(2)
 
+    if EXPECTED_QUIET_PERIOD_SHORT_CIRCUIT not in check_run_raw:
+        print(
+            f"FATAL: step '{CHECK_STEP_NAME}'.run no longer contains the\n"
+            "  quiet-period short-circuit (current head == last verified sha\n"
+            "  -> zero staleness) this script models.\n"
+            f"  expected substring: {EXPECTED_QUIET_PERIOD_SHORT_CIRCUIT!r}\n"
+            "  Without this branch, a quiet main re-alerts on every ordinary\n"
+            "  gap between scheduled tests.yml runs — the exact bug caught\n"
+            "  in review before this job first shipped. Update\n"
+            "  EXPECTED_QUIET_PERIOD_SHORT_CIRCUIT and compute_stale_minutes()\n"
+            "  below to match the new YAML before trusting this script's\n"
+            "  verdict again.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
 
 def alert_fires(
     top_event_name: str, wr_event: str, head_branch: str, conclusion: str
@@ -208,6 +247,43 @@ def liveness_job_runs(top_event_name: str) -> bool:
 
 
 UNKNOWN_STALE_SENTINEL = 999999
+
+
+def compute_stale_minutes(
+    last_verified_sha: str | None,
+    current_head_sha: str,
+    first_unverified_epoch: int | None,
+    now_epoch: int,
+) -> int:
+    """Models the commit-aware staleness computation in the `Check time
+    since main's last completed tests.yml verdict` step.
+
+    THIS is the design correction caught in review (see module docstring)
+    before the job first shipped — the version this replaces measured
+    `now - last_verdict_timestamp` unconditionally, which breaches a
+    45-minute threshold on every ordinary gap between 2-hourly scheduled
+    runs on a quiet main. The fix: staleness is about UNVERIFIED COMMITS,
+    not about elapsed time since a verdict happened to be produced.
+
+    `last_verified_sha=None` models "no qualifying run found in the
+    lookback window at all" -> unconditionally unknown/maximally stale
+    (mirrors `should_alert`'s own UNKNOWN_STALE_SENTINEL handling one
+    layer up).
+    `last_verified_sha == current_head_sha` models "main hasn't moved
+    since the last real verdict" -> zero staleness, REGARDLESS of how
+    long ago that verdict ran. This is the fix.
+    Otherwise, staleness is `now - first_unverified_epoch` — the age of
+    the OLDEST commit past the last verified one, not the verdict's own
+    (stale) timestamp. `first_unverified_epoch=None` models the
+    defensive "SHAs differ but compare returned no commits" fallback.
+    """
+    if last_verified_sha is None:
+        return UNKNOWN_STALE_SENTINEL
+    if last_verified_sha == current_head_sha:
+        return 0
+    if first_unverified_epoch is None:
+        return UNKNOWN_STALE_SENTINEL
+    return (now_epoch - first_unverified_epoch) // 60
 
 
 def should_alert(
@@ -392,6 +468,42 @@ ESCALATION_SCENARIOS = [
     ),
 ]
 
+# (label, last_verified_sha, current_head_sha, first_unverified_epoch,
+#  now_epoch, expect_stale_minutes)
+# Uses relative epochs (0 = "now") rather than real timestamps for
+# readability — only the DIFFERENCE matters to compute_stale_minutes().
+STALE_MINUTES_SCENARIOS = [
+    (
+        "INNOCENCE (THE FIX) — main's current head IS the last verified "
+        "sha: a quiet main with no pushes, verdict is 3 hours old (well "
+        "past a naive 45-min verdict-to-now threshold) but there is "
+        "NOTHING NEW to verify. Must be zero staleness, not 180.",
+        "sha-a", "sha-a", -3 * 60 * 60, 0, 0,
+    ),
+    (
+        "GUILT — main moved past the last verified sha 50 minutes ago: "
+        "real, known staleness past threshold",
+        "sha-a", "sha-b", -50 * 60, 0, 50,
+    ),
+    (
+        "INNOCENCE — main moved past the last verified sha only 5 "
+        "minutes ago: within the grace period, not yet stale",
+        "sha-a", "sha-b", -5 * 60, 0, 5,
+    ),
+    (
+        "GUILT — no qualifying run found at all (last_verified_sha is "
+        "None): unconditionally unknown/maximally stale, regardless of "
+        "current_head_sha or timestamps",
+        None, "sha-b", None, 0, UNKNOWN_STALE_SENTINEL,
+    ),
+    (
+        "GUILT (defensive fallback) — SHAs differ but the compare API "
+        "returned no commits (first_unverified_epoch is None): treated "
+        "as maximally stale, not silently passed as zero",
+        "sha-a", "sha-b", None, 0, UNKNOWN_STALE_SENTINEL,
+    ),
+]
+
 
 def main() -> None:
     self_check()
@@ -439,11 +551,23 @@ def main() -> None:
         if not ok:
             failures.append(label)
 
+    print("\n== verdict-liveness commit-aware staleness (task #41, quiet-period fix) ==")
+    for label, last_sha, head_sha, first_epoch, now_epoch, expect in STALE_MINUTES_SCENARIOS:
+        got = compute_stale_minutes(last_sha, head_sha, first_epoch, now_epoch)
+        ok = got == expect
+        print(f"[{'PASS' if ok else 'FAIL'}] {label}\n"
+              f"         last_verified_sha={last_sha} current_head_sha={head_sha} "
+              f"first_unverified_epoch={first_epoch} now_epoch={now_epoch} "
+              f"-> stale_minutes={got} (expected {expect})")
+        if not ok:
+            failures.append(label)
+
     total = (
         len(ALERT_SCENARIOS)
         + len(AGGREGATE_SCENARIOS)
         + len(LIVENESS_JOB_SCENARIOS)
         + len(ESCALATION_SCENARIOS)
+        + len(STALE_MINUTES_SCENARIOS)
     )
     if failures:
         print(f"\n{len(failures)}/{total} scenarios FAILED", file=sys.stderr)

--- a/scripts/verify_main_watch_schedule_scope.py
+++ b/scripts/verify_main_watch_schedule_scope.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
 """
-Task #37 guilt/innocence proof for .github/workflows/main-push-failure-watch.yml's
-alert job, after widening its scope from push-only to push-or-schedule.
+Guilt/innocence proof for .github/workflows/main-push-failure-watch.yml,
+covering two changes made to it on 2026-07-26:
+
+  - Task #37: widened the `alert` job's scope from push-only to
+    push-or-schedule, after `tests.yml` grew its first `schedule:`
+    trigger targeting main.
+  - Task #41: added a second job, `verdict-liveness`, that alerts on the
+    ABSENCE of a completed test verdict rather than reacting to any one
+    event — closing the blind spot the task #37 widening alone leaves:
+    `alert` deliberately excludes `cancelled` (see header comment), so a
+    long streak of cancelled-via-supersede runs produces zero events
+    `alert` would ever fire on, even after the widening.
 
 NOT a general GitHub Actions expression interpreter — deliberately narrow,
 same "known limit" style as scripts/verify_post_deploy_health_reachability.py
 (task #19) and scripts/check_watcher_coverage.py. This hand-encodes the
-semantics of exactly ONE job's `if:` plus one aggregation step's jq `select`
-as they exist in this repo today.
+semantics of exactly two jobs' `if:` conditions, one aggregation step's jq
+`select`, and one escalation-arithmetic step, as they exist in this repo
+today.
 
-Why the widening exists: task #37 added `.github/workflows/tests.yml`'s
-first `schedule:` trigger that targets main (hourly, decoupled from push
-cadence — see tests.yml's own `on.schedule` comment for the measured
-starvation this works around). Before this change, `main-push-failure-
+Task #37 widening, why it exists: before this change, `main-push-failure-
 watch.yml`'s alert job fired ONLY on `github.event.workflow_run.event ==
 'push'` — a schedule-triggered failure of the exact same workflow, on the
 exact same branch, with the exact same conclusion, would silently NOT
@@ -25,9 +33,18 @@ not the job-level `if:` — missing this second spot would have left the
 top-level gate open while the aggregate always counted zero schedule
 failures, silently suppressing the Telegram message anyway).
 
-Self-check: if a future edit changes this job's `if:` or the aggregation
-step's `run:` script in the YAML, this script fails loudly (exit 2) instead
-of silently proving the wrong thing.
+Task #41 verdict-liveness, why it exists: a REACTIVE per-event watcher
+with `cancelled` excluded cannot distinguish "one routine supersede" from
+"main has stopped producing verdicts at all" — it only ever sees
+individual events, never the gap between them. `verdict-liveness` instead
+polls every 15 minutes and alerts once the gap since the last real
+(non-cancelled) tests.yml conclusion on main exceeds a threshold, then
+again on a bounded escalation cadence — "one alert per outage", computed
+purely from timestamp arithmetic, no external state.
+
+Self-check: if a future edit changes either job's `if:`, the aggregation
+step's `run:` script, or the escalation constants in the YAML, this script
+fails loudly (exit 2) instead of silently proving the wrong thing.
 """
 import re
 import sys
@@ -37,7 +54,8 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "main-push-failure-watch.yml"
-JOB_NAME = "alert"
+ALERT_JOB_NAME = "alert"
+LIVENESS_JOB_NAME = "verdict-liveness"
 
 # `if: >-` is a YAML *folded* block scalar: GitHub Actions/PyYAML fold a
 # normal-indent line break into a single space but preserve the newline
@@ -46,7 +64,8 @@ JOB_NAME = "alert"
 # EXPECTED_IF is written as one logical string and compared via
 # _normalize(), which collapses all whitespace runs (including newlines)
 # to a single space before comparing.
-EXPECTED_IF = (
+EXPECTED_ALERT_IF = (
+    "github.event_name == 'workflow_run' && "
     "(github.event.workflow_run.event == 'push' || "
     "github.event.workflow_run.event == 'schedule') && "
     "github.event.workflow_run.head_branch == 'main' && "
@@ -54,11 +73,16 @@ EXPECTED_IF = (
     "github.event.workflow_run.conclusion == 'timed_out')"
 )
 
+EXPECTED_LIVENESS_IF = "github.event_name == 'schedule'"
+
 AGGREGATE_STEP_NAME = "Aggregate every currently-failing push-or-schedule main run on this commit"
 EXPECTED_AGGREGATE_SELECT_SUBSTRING = (
     'select((.event=="push" or .event=="schedule") '
     'and (.conclusion=="failure" or .conclusion=="timed_out"))'
 )
+
+CHECK_STEP_NAME = "Check time since main's last completed tests.yml verdict"
+EXPECTED_ESCALATION_CONSTANTS = ("THRESHOLD_MINUTES=45", "CHECK_INTERVAL_MINUTES=15", "ESCALATION_MINUTES=60")
 
 
 def _normalize(s: str) -> str:
@@ -75,27 +99,29 @@ def _step_by_name(job: dict, name: str) -> dict | None:
 def self_check() -> None:
     """Fail loudly if the YAML no longer matches what this script models."""
     data = yaml.safe_load(WORKFLOW.read_text())
-    job = (data.get("jobs") or {}).get(JOB_NAME)
-    if job is None:
-        print(f"FATAL: job '{JOB_NAME}' not found in {WORKFLOW}", file=sys.stderr)
+    jobs = data.get("jobs") or {}
+
+    alert_job = jobs.get(ALERT_JOB_NAME)
+    if alert_job is None:
+        print(f"FATAL: job '{ALERT_JOB_NAME}' not found in {WORKFLOW}", file=sys.stderr)
         sys.exit(2)
 
-    if_raw = (job.get("if") or "").strip()
-    if _normalize(if_raw) != _normalize(EXPECTED_IF):
+    if_raw = (alert_job.get("if") or "").strip()
+    if _normalize(if_raw) != _normalize(EXPECTED_ALERT_IF):
         print(
-            f"FATAL: {JOB_NAME}.if drifted from what this script models.\n"
-            f"  expected: {EXPECTED_IF!r}\n"
+            f"FATAL: {ALERT_JOB_NAME}.if drifted from what this script models.\n"
+            f"  expected: {EXPECTED_ALERT_IF!r}\n"
             f"  actual:   {if_raw!r}\n"
-            "  Update EXPECTED_IF and alert_fires() below to match the new\n"
-            "  YAML before trusting this script's verdict again.",
+            "  Update EXPECTED_ALERT_IF and alert_fires() below to match the\n"
+            "  new YAML before trusting this script's verdict again.",
             file=sys.stderr,
         )
         sys.exit(2)
 
-    step = _step_by_name(job, AGGREGATE_STEP_NAME)
+    step = _step_by_name(alert_job, AGGREGATE_STEP_NAME)
     if step is None:
         print(
-            f"FATAL: step '{AGGREGATE_STEP_NAME}' not found in job '{JOB_NAME}'.\n"
+            f"FATAL: step '{AGGREGATE_STEP_NAME}' not found in job '{ALERT_JOB_NAME}'.\n"
             "  This script's aggregate-scope proof assumes this step exists\n"
             "  by this exact name — a rename silently breaks it.",
             file=sys.stderr,
@@ -115,14 +141,111 @@ def self_check() -> None:
         )
         sys.exit(2)
 
+    liveness_job = jobs.get(LIVENESS_JOB_NAME)
+    if liveness_job is None:
+        print(f"FATAL: job '{LIVENESS_JOB_NAME}' not found in {WORKFLOW}", file=sys.stderr)
+        sys.exit(2)
 
-def alert_fires(event: str, head_branch: str, conclusion: str) -> bool:
-    """Models the job-level `if:` on the `alert` job."""
+    liveness_if_raw = (liveness_job.get("if") or "").strip()
+    if _normalize(liveness_if_raw) != _normalize(EXPECTED_LIVENESS_IF):
+        print(
+            f"FATAL: {LIVENESS_JOB_NAME}.if drifted from what this script models.\n"
+            f"  expected: {EXPECTED_LIVENESS_IF!r}\n"
+            f"  actual:   {liveness_if_raw!r}\n"
+            "  Update EXPECTED_LIVENESS_IF below to match the new YAML before\n"
+            "  trusting this script's verdict again.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    check_step = _step_by_name(liveness_job, CHECK_STEP_NAME)
+    if check_step is None:
+        print(
+            f"FATAL: step '{CHECK_STEP_NAME}' not found in job '{LIVENESS_JOB_NAME}'.\n"
+            "  This script's escalation-arithmetic proof assumes this step\n"
+            "  exists by this exact name — a rename silently breaks it.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    check_run_raw = check_step.get("run") or ""
+    missing_constants = [c for c in EXPECTED_ESCALATION_CONSTANTS if c not in check_run_raw]
+    if missing_constants:
+        print(
+            f"FATAL: step '{CHECK_STEP_NAME}'.run no longer contains the\n"
+            "  escalation constants this script models.\n"
+            f"  missing: {missing_constants!r}\n"
+            "  Update EXPECTED_ESCALATION_CONSTANTS and should_alert() below\n"
+            "  to match the new YAML before trusting this script's verdict\n"
+            "  again.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def alert_fires(
+    top_event_name: str, wr_event: str, head_branch: str, conclusion: str
+) -> bool:
+    """Models the job-level `if:` on the `alert` job.
+
+    `top_event_name` is `github.event_name` — what triggered THIS
+    workflow's own run (always 'workflow_run' in real traffic, except
+    when the new task #41 `schedule` trigger fires this same workflow,
+    in which case `github.event.workflow_run` doesn't exist at all).
+    `wr_event` is `github.event.workflow_run.event` — what triggered the
+    OTHER workflow whose completion is being reported on.
+    """
     return (
-        event in ("push", "schedule")
+        top_event_name == "workflow_run"
+        and wr_event in ("push", "schedule")
         and head_branch == "main"
         and conclusion in ("failure", "timed_out")
     )
+
+
+def liveness_job_runs(top_event_name: str) -> bool:
+    """Models the job-level `if:` on the `verdict-liveness` job."""
+    return top_event_name == "schedule"
+
+
+UNKNOWN_STALE_SENTINEL = 999999
+
+
+def should_alert(
+    stale_minutes: int,
+    threshold: int = 45,
+    check_interval: int = 15,
+    escalation: int = 60,
+) -> bool:
+    """Models the escalation arithmetic in the `Check time since main's
+    last completed tests.yml verdict` step.
+
+    Unknown (no qualifying run found at all in the lookback window):
+    ALWAYS alert, every check — deliberately NOT routed through the
+    boundary-crossing math below. Caught by this script's own guilt
+    scenario before shipping: `stale_minutes - threshold` for the
+    sentinel value doesn't reliably land within `check_interval` of an
+    `escalation` boundary, so the boundary heuristic can go silent on
+    the single worst-case input it most needs to catch. "We don't even
+    know when main last passed" is categorically worse than "known,
+    bounded staleness" and gets its own unconditional branch instead of
+    trusting arithmetic tuned for a different case to also cover it.
+    Healthy: stale_minutes < threshold -> no alert.
+    First breach: the first check to observe stale_minutes >= threshold
+    has overflow (stale_minutes - threshold) somewhere in
+    [0, check_interval) — see the step's own comment for why that window
+    is guaranteed regardless of exactly when the breach occurred between
+    two 15-minute checks.
+    Reminder: once overflow crosses a multiple of `escalation`, alert
+    again — bounded, "one alert per outage segment" rather than one per
+    15-minute check.
+    """
+    if stale_minutes >= UNKNOWN_STALE_SENTINEL:
+        return True
+    if stale_minutes < threshold:
+        return False
+    overflow = stale_minutes - threshold
+    boundary = overflow % escalation
+    return overflow < check_interval or boundary < check_interval
 
 
 def counts_toward_aggregate(event: str, conclusion: str) -> bool:
@@ -138,48 +261,55 @@ def counts_toward_aggregate(event: str, conclusion: str) -> bool:
     return event in ("push", "schedule") and conclusion in ("failure", "timed_out")
 
 
-# (label, event, head_branch, conclusion, expect_fires)
+# (label, top_event_name, wr_event, head_branch, conclusion, expect_fires)
 ALERT_SCENARIOS = [
     (
         "GUILT — schedule-triggered run on main fails (task #37's new case: "
-        "the hourly Tests & Coverage run breaks and nobody was told before "
-        "this widening)",
-        "schedule", "main", "failure", True,
+        "the scheduled Tests & Coverage run breaks and nobody was told "
+        "before the task #37 widening)",
+        "workflow_run", "schedule", "main", "failure", True,
     ),
     (
         "GUILT — schedule-triggered run on main times out",
-        "schedule", "main", "timed_out", True,
+        "workflow_run", "schedule", "main", "timed_out", True,
     ),
     (
         "INNOCENCE — push-triggered run on main fails (pre-existing case, "
         "must still fire after the widening)",
-        "push", "main", "failure", True,
+        "workflow_run", "push", "main", "failure", True,
     ),
     (
         "INNOCENCE — pull_request-triggered run fails: already visible on "
         "the PR itself, must not alert",
-        "pull_request", "main", "failure", False,
+        "workflow_run", "pull_request", "main", "failure", False,
     ),
     (
         "INNOCENCE — workflow_dispatch-triggered run on main fails: "
         "operator-initiated, operator is already watching",
-        "workflow_dispatch", "main", "failure", False,
+        "workflow_run", "workflow_dispatch", "main", "failure", False,
     ),
     (
         "INNOCENCE — schedule-triggered run on a non-main branch fails "
         "(structurally near-impossible — schedule only fires against the "
         "default branch — but the guard should not rely on that alone)",
-        "schedule", "some-other-branch", "failure", False,
+        "workflow_run", "schedule", "some-other-branch", "failure", False,
     ),
     (
         "INNOCENCE — schedule-triggered run on main is cancelled: excluded "
         "deliberately (see header comment), a routine supersede is not a "
         "silent failure",
-        "schedule", "main", "cancelled", False,
+        "workflow_run", "schedule", "main", "cancelled", False,
     ),
     (
         "INNOCENCE — schedule-triggered run on main succeeds",
-        "schedule", "main", "success", False,
+        "workflow_run", "schedule", "main", "success", False,
+    ),
+    (
+        "INNOCENCE (task #41 self-trigger safety) — this workflow's OWN "
+        "schedule trigger (the verdict-liveness path) must never be "
+        "mistaken for a workflow_run report, even with matching-looking "
+        "sub-fields",
+        "schedule", "push", "main", "failure", False,
     ),
 ]
 
@@ -206,19 +336,76 @@ AGGREGATE_SCENARIOS = [
     ),
 ]
 
+# (label, top_event_name, expect_runs)
+LIVENESS_JOB_SCENARIOS = [
+    (
+        "GUILT — this workflow's own schedule trigger must run the "
+        "liveness job (the whole point of task #41)",
+        "schedule", True,
+    ),
+    (
+        "INNOCENCE — a workflow_run event (the alert job's trigger) must "
+        "not also run the liveness job",
+        "workflow_run", False,
+    ),
+]
+
+# (label, stale_minutes, expect_alert)
+ESCALATION_SCENARIOS = [
+    (
+        "INNOCENCE — healthy gap, well under threshold (measured healthy "
+        "gap tonight was ~20-25 min)",
+        20, False,
+    ),
+    (
+        "INNOCENCE — just under threshold",
+        44, False,
+    ),
+    (
+        "GUILT — first breach, exactly at threshold: must alert",
+        45, True,
+    ),
+    (
+        "GUILT — first breach, a few minutes past threshold (still within "
+        "one check-interval of crossing)",
+        50, True,
+    ),
+    (
+        "INNOCENCE — well past first breach but not yet at the next "
+        "escalation boundary: must NOT re-alert (this is what makes it "
+        "'one alert per outage' instead of one per 15-min check)",
+        90, False,
+    ),
+    (
+        "GUILT — crossed the 60-minute escalation boundary past first "
+        "breach (45 + 60 = 105): reminder must fire",
+        105, True,
+    ),
+    (
+        "INNOCENCE — between escalation boundaries again",
+        150, False,
+    ),
+    (
+        "GUILT — no qualifying run found at all in the lookback window: "
+        "treated as maximally stale, must alert, not silently pass",
+        999999, True,
+    ),
+]
+
 
 def main() -> None:
     self_check()
 
     failures = []
 
-    print("== alert job if: (push-or-schedule widening) ==")
-    for label, event, head_branch, conclusion, expect in ALERT_SCENARIOS:
-        got = alert_fires(event, head_branch, conclusion)
+    print("== alert job if: (push-or-schedule widening + self-trigger safety) ==")
+    for label, top_event, wr_event, head_branch, conclusion, expect in ALERT_SCENARIOS:
+        got = alert_fires(top_event, wr_event, head_branch, conclusion)
         ok = got == expect
         print(f"[{'PASS' if ok else 'FAIL'}] {label}\n"
-              f"         event={event} head_branch={head_branch} "
-              f"conclusion={conclusion} -> alert_fires={got} (expected {expect})")
+              f"         top_event={top_event} wr_event={wr_event} "
+              f"head_branch={head_branch} conclusion={conclusion} "
+              f"-> alert_fires={got} (expected {expect})")
         if not ok:
             failures.append(label)
 
@@ -232,7 +419,32 @@ def main() -> None:
         if not ok:
             failures.append(label)
 
-    total = len(ALERT_SCENARIOS) + len(AGGREGATE_SCENARIOS)
+    print("\n== verdict-liveness job if: (task #41) ==")
+    for label, top_event, expect in LIVENESS_JOB_SCENARIOS:
+        got = liveness_job_runs(top_event)
+        ok = got == expect
+        print(f"[{'PASS' if ok else 'FAIL'}] {label}\n"
+              f"         top_event={top_event} "
+              f"-> liveness_job_runs={got} (expected {expect})")
+        if not ok:
+            failures.append(label)
+
+    print("\n== verdict-liveness escalation arithmetic (task #41) ==")
+    for label, stale_minutes, expect in ESCALATION_SCENARIOS:
+        got = should_alert(stale_minutes)
+        ok = got == expect
+        print(f"[{'PASS' if ok else 'FAIL'}] {label}\n"
+              f"         stale_minutes={stale_minutes} "
+              f"-> should_alert={got} (expected {expect})")
+        if not ok:
+            failures.append(label)
+
+    total = (
+        len(ALERT_SCENARIOS)
+        + len(AGGREGATE_SCENARIOS)
+        + len(LIVENESS_JOB_SCENARIOS)
+        + len(ESCALATION_SCENARIOS)
+    )
     if failures:
         print(f"\n{len(failures)}/{total} scenarios FAILED", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Task #37 + #41 — scheduled main-integration run + verdict-liveness alert

Built as one design per team-lead's direction (same file, same root cause: `cancelled` conclusions are the only signal main's own test suite produces under queue saturation, and the reactive `alert` job deliberately excludes them to avoid alert-fatigue).

### tests.yml — scheduled main-integration run (task #37)

- New `schedule:` trigger, `cron: "17 */2 * * *"` (every 2h, `:17` offset dodges the top-of-hour stampede — same convention as `docs-inventory-refresh-liveness.yml`).
- Runs the exact same job graph as push/PR (`backend-tests`, `mcp-tests`, `frontend-tests`, `e2e-tests`, `test-summary`) — zero duplicated logic to drift.
- Own concurrency group (`tests-schedule-main`), independent of `github.ref`, so it never queues behind — or evicts — a push-triggered run.
- `cancel-in-progress: true` for the scheduled group — the **opposite** of the push group's `false`, deliberately. `false` protects a started push-triggered verdict (cancelling it is what silently starved main). `true` is correct for the scheduled group for the mirror-image reason: a new scheduled run starting while the previous is still going means the older run is testing a `main` that no longer exists, so the freshest should win. Documented in the code so nobody "fixes" it back to match.
- Cadence chosen as every 2h, not hourly: a full run measured ~43 min wall-clock under load — hourly would be a ~72% duty cycle on runners this workflow already competes for. Task #41's liveness check (below) is the fast heartbeat now, so this run's job shifted from "detect an outage quickly" to "periodically produce a real full-suite verdict at sustainable cost."
- Justification is the **structural** claim, not a one-night number: `cancel-in-progress: false` only protects a run that has already STARTED — a run still QUEUED is superseded unconditionally by the next push to the same group, true at any load. The specific "main hasn't had a verdict since 01:45Z" measurement that motivated building this had already resolved by ship time; it's not cited as ongoing justification.

### main-push-failure-watch.yml — two changes

**1. `alert` job widened from push-only to push-or-schedule.** Before, the job's `if:` fired only on `github.event.workflow_run.event == 'push'` — a schedule-triggered failure of the same workflow, same branch, same conclusion, would silently not alert. Widened the `if:` and the aggregation step's jq `select` (which had its own independent `event=push` filter). Also added an explicit `github.event_name == 'workflow_run'` guard, defensive/self-documenting now that this file has two trigger types.

**2. New `verdict-liveness` job (task #41).** The `alert` job is reactive and deliberately excludes `cancelled` (alert-fatigue avoidance, see its header comment) — but that exclusion means a long streak of cancelled-via-supersede runs produces zero events `alert` will ever fire on. Measured live: main went from a completed verdict every ~20-25 min to none for 75+ min, entirely via `cancelled`, and `alert` never said a word.

`verdict-liveness` polls every 15 minutes and asks a different question: **is there a commit on `main` newer than the last real (non-cancelled) tests.yml conclusion, and how long has it sat unjudged?** Alerts once past a 45-minute threshold, then again every 60 min while ongoing — "one alert per outage", computed from timestamp arithmetic, no external state.

**Design correction made in review, before shipping (team-lead caught this, not a test):** the first version measured staleness as "now minus the last verdict's own timestamp." With `tests.yml`'s 2h schedule cadence, a quiet main with no pushes only ever gets a fresh verdict every ~2h — that measure would breach the 45-min threshold on *every* ordinary quiet stretch and re-alert on every escalation boundary for hours. Fixed by comparing main's current HEAD against the last-verified run's `head_sha`: equal → zero staleness regardless of verdict age (a quiet main is fully verified, not stale); differ → staleness is measured from when the *first* unverified commit landed (via the compare API), not from the old verdict's timestamp, so a main that gained one commit 5 minutes ago still gets its full grace period.

**Known residual edge case, named not solved** (team-lead flagged, confirmed non-blocking): the commit-comparison assumes the last-verified run's `head_sha` is an ancestor of current main. If main were ever force-pushed or its history rewritten, GitHub's compare API would report `status: "diverged"` and `commits[0]` would no longer mean "the first commit since the verdict." This repo's L2 policy forbids force-push to main, so the ancestor assumption holds in practice — not building a `status == "diverged"` fallback branch for a case that can't currently occur, but naming it here so a future change to that policy is the trigger to revisit this, not a silent surprise.

### Guilt / innocence proof

`scripts/verify_main_watch_schedule_scope.py` — **28/28 scenarios pass**, covering both jobs' `if:` conditions, the aggregate jq select, the escalation arithmetic, and the commit-aware staleness computation. The scenario literally named `"THE FIX"` is the one that pins the quiet-period correction: a 3-hour-old verdict on an unchanged main must compute zero staleness, not 180.

Self-check extended to four independently guilt-proved surfaces (mutated each, confirmed `exit 2` naming the exact drift, restored byte-identical, reverified clean):
1. `alert` job's `if:` string
2. `verdict-liveness` job's `if:` string
3. An escalation constant inside the check step's `run:` script
4. The literal quiet-period short-circuit comparison (`"${LAST_VERIFIED_SHA}" = "${CURRENT_HEAD}"`) — not just that the constants exist, but that the actual comparison runs. A bug found by the guilt corpus itself, before shipping: the "no qualifying run found" sentinel (999999) didn't reliably land inside the 15-min escalation-boundary window tuned for a normally-climbing value — fixed with an explicit unconditional branch, in both the live bash and the Python model.

### Verification

- `actionlint` clean on both files (also fixed a genuine new SC2129 style finding from the extra `GITHUB_OUTPUT` writes, grouped into one redirect).
- Both files parse via `yaml.safe_load`.
- Pre-commit hooks (lease-check, anti-reward-hacking lint, secret scan, Prettier, Python lint, off-limits-file check) all passed clean.
- Non-required by design: neither new trigger has a `pull_request` path, so this is structurally decoupled from PR merge gating.

