### PR TITLE
feat(ci): prepush allowlist v3 — .github/workflows/*.yml + scripts/tests/*.py (task #43)

### DIFF
--- a/scripts/prepush_classify.py
+++ b/scripts/prepush_classify.py
@@ -81,6 +81,56 @@ inputs, CONVERGED findings):
   `.claude/skills/modus/PENDING-ARMS.md`, owner = orchestrator session,
   non-blocking.
 
+v3 EXTENSION (2026-07-26, task #43): MEASURED, not hypothetical — a fleet
+night where nearly every diff touched CI/guards/scripts (task #16's
+scripts/tests/ sweep, #39's .husky/pre-push fix, #43 itself) drove up to
+13 concurrent `pytest backend/tests/` suites on a 10-core M5 laptop, one
+convoy 54min in and still climbing (~98min projected). Root cause: the
+allowlist did not yet recognize two path classes that are provably
+INNOCENT with respect to `pytest backend/tests/` specifically — the exact
+gate this module exists to skip:
+
+  - `.github/workflows/*.yml` — a workflow file is never imported by, or
+    collected into, a `pytest backend/tests/` run; it has its own gates
+    (`actionlint`, hot-zone enforcement) for its own correctness. The
+    PRE-EXISTING `.github/workflows/tests.yml` entry in
+    NEVER_INNOCENT_EXACT_PATHS is checked FIRST and is untouched by this
+    broader rule — editing the workflow that DEFINES the required test
+    run still forces full, unconditionally (proof:
+    test_edge_never_innocent_exact_paths_are_not_on_the_allowlist, which
+    iterates the exact-path set generically and would fail if this
+    ordering ever broke).
+  - `scripts/tests/*.py` — the 235-file suite audited in task #16, tests
+    OF the ops/immune-system scripts under the repo-root `scripts/`
+    directory. VERIFIED (not assumed) structurally incapable of affecting
+    `pytest backend/tests/`'s outcome: (a) `.husky/pre-push` invokes it as
+    `( cd apps/backend-rag && ... pytest backend/tests/ ... )` — the
+    collection root is `apps/backend-rag/backend/tests/`, a different
+    filesystem branch entirely from repo-root `scripts/tests/`; (b) a
+    repo-wide grep for any import of the repo-root `scripts.tests`
+    package from anywhere under `apps/backend-rag/` returns zero real
+    hits (the only matches are prose in comments/docstrings naming the
+    file, and unrelated code in the OTHER, differently-nested
+    `apps/backend-rag/backend/tests/scripts/` directory, which resolves
+    `from scripts.X import Y` against `apps/backend-rag/scripts/` per its
+    own conftest.py — a same-named but structurally unrelated tree, not
+    to be confused with the one this rule allowlists).
+    `scripts/tests/conftest.py` stays forced-full regardless (the
+    directory-independent NEVER_INNOCENT_BASENAMES net, checked before
+    any allowlist rule); `scripts/tests/__init__.py` is verified empty
+    and additionally unreachable by the same import-chain argument;
+    `scripts/tests/fixtures/` is verified to contain only `.md` fixture
+    data, no `.py`, so the `.py`-suffix scoping does not admit anything
+    there either; the one `.sh` file in the directory
+    (`test_prepush_failclosed.sh`) is out of scope for this suffix rule
+    and correctly stays unknown -> full, conservative by construction.
+
+  Verified by piping real path lists through the CLI end-to-end, not by
+  reading the code and reasoning about it (mandate, task #43) — see the
+  new guilt+innocence pairs in scripts/tests/test_prepush_classify.py and
+  the direct `echo ... | python3 scripts/prepush_classify.py` runs logged
+  in the task #43 PR body.
+
 CONTRACT
 --------
 Input:  a list of repo-relative file paths, one per line, via:
@@ -157,7 +207,11 @@ VERDICT_SKIP = "skip-backend"
 # old bare-prefix ALLOWLIST_INNOCENT_PREFIXES into the suffix-scoped
 # ALLOWLIST_PREFIX_SUFFIX_PAIRS mechanism (MUST-FIX: extension-blindness),
 # added `..`-traversal + embedded-newline rejection (HARDENING-2).
-ALLOWLIST_VERSION = 2
+# v3 (2026-07-26, task #43): added .github/workflows (.yml) and
+# scripts/tests (.py) — two path classes measured (not assumed) to be
+# structurally incapable of affecting `pytest backend/tests/` — see the
+# module-docstring "v3 EXTENSION" section above for the verification.
+ALLOWLIST_VERSION = 3
 
 # ---------------------------------------------------------------------------
 # NEVER_INNOCENT_EXACT_PATHS — checked FIRST, unconditionally, before any
@@ -227,6 +281,39 @@ NEVER_INNOCENT_BASENAMES: frozenset[str] = frozenset(
 #                         EXCLUDED by this suffix scoping — they are not on
 #                         the allowed-suffix list, so they fall to
 #                         "unknown -> full" like any other .py change would.
+#   .github/workflows/**   v3 (task #43): scoped to `.yml` ONLY. A workflow
+#                         file is never imported by or collected into a
+#                         `pytest backend/tests/` run — see the module
+#                         docstring's "v3 EXTENSION" for the full argument.
+#                         `.github/workflows/tests.yml` itself is exempted
+#                         from this rule via NEVER_INNOCENT_EXACT_PATHS
+#                         (checked BEFORE this loop, so it still forces
+#                         full). The 1 real .txt file verified living in
+#                         this SAME directory
+#                         (catE-paid-anthropic-baseline.txt) is correctly
+#                         EXCLUDED by suffix scoping. Nothing outside
+#                         .github/workflows/ (e.g. .github/CODEOWNERS,
+#                         .github/actions/**) is admitted by this rule —
+#                         the prefix is workflows/ specifically, not .github
+#                         wholesale.
+#   scripts/tests/**       v3 (task #43): scoped to `.py` ONLY. The 235-file
+#                         suite audited in task #16 — tests OF the repo's
+#                         ops/immune-system scripts, verified structurally
+#                         unreachable from `pytest backend/tests/` (module
+#                         docstring, "v3 EXTENSION"). `conftest.py` under
+#                         this directory still forces full regardless (the
+#                         directory-independent NEVER_INNOCENT_BASENAMES
+#                         net, checked before this loop).
+#                         `scripts/tests/__init__.py` is verified empty and
+#                         admitted by this suffix rule like any other .py
+#                         file here — deliberate, not an oversight.
+#                         `scripts/tests/fixtures/` is verified to contain
+#                         only .md fixture data (no .py), so this scoping
+#                         does not admit anything from it. The 1 real .sh
+#                         file verified living in this SAME directory
+#                         (test_prepush_failclosed.sh) is correctly
+#                         EXCLUDED by suffix scoping — falls to
+#                         "unknown -> full" like any other .sh change would.
 #
 # Deliberately NOT `.claude/**` wholesale: `.claude/hooks/` (control-plane —
 # contains codex-spalla-trigger.sh, verified on disk), `.claude/scripts/`,
@@ -250,6 +337,8 @@ ALLOWLIST_PREFIX_SUFFIX_PAIRS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (".claude/commands", (".md",)),
     (".claude/agents", (".md",)),
     ("infra/launchagents", (".plist", ".sh")),
+    (".github/workflows", (".yml",)),
+    ("scripts/tests", (".py",)),
 )
 
 

--- a/scripts/tests/test_prepush_classify.py
+++ b/scripts/tests/test_prepush_classify.py
@@ -129,18 +129,41 @@ def test_guilt_classifier_self_edit() -> None:
 
 
 def test_guilt_tests_workflow_file() -> None:
+    """v3 (task #43) makes this the LOAD-BEARING proof, not a redundant one:
+    .github/workflows is now a broadly-allowlisted prefix (.yml suffix), so
+    this specifically proves the NEVER_INNOCENT_EXACT_PATHS exact-path
+    override for tests.yml — the workflow that DEFINES the required test
+    run — still wins over the broader rule (checked first in
+    _innocent_reason, before the allowlist loop is ever reached)."""
     verdict, _ = pc.classify([".github/workflows/tests.yml"])
     assert verdict == pc.VERDICT_FULL
 
 
-def test_guilt_other_github_workflow_file() -> None:
-    """Under the allowlist inversion, ALL of .github/** forces full — not
-    just tests.yml (the original mandate's narrower rule). No .github/**
-    path is ever allowlisted (panel point 4: 'reusable Actions' is an
-    easily-forgotten path), so this is strictly MORE conservative than the
-    pre-inversion design, in the safe direction."""
-    verdict, _ = pc.classify([".github/workflows/immune-enforcement.yml"])
+def test_guilt_github_workflows_non_yml_file() -> None:
+    """.github/workflows/ is scoped to .yml ONLY (v3) — the 1 real .txt file
+    verified living in that directory must not be swept in by a
+    directory-only rule."""
+    verdict, unknown = pc.classify([".github/workflows/catE-paid-anthropic-baseline.txt"])
     assert verdict == pc.VERDICT_FULL
+    assert unknown == [".github/workflows/catE-paid-anthropic-baseline.txt"]
+
+
+def test_guilt_github_dir_outside_workflows() -> None:
+    """The v3 rule's prefix is .github/workflows specifically, not .github
+    wholesale — a path elsewhere under .github/ (CODEOWNERS, actions/**)
+    must still force full."""
+    verdict, unknown = pc.classify([".github/CODEOWNERS"])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == [".github/CODEOWNERS"]
+
+
+def test_guilt_github_workflows_lookalike_prefix() -> None:
+    """cicatrix-superscar.md #3 (guard over-match) on the new rule: a longer
+    sibling directory name that merely STARTS WITH '.github/workflows' must
+    not match."""
+    verdict, unknown = pc.classify([".github/workflows-archive/old.yml"])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == [".github/workflows-archive/old.yml"]
 
 
 def test_guilt_frontend_app_file() -> None:
@@ -220,6 +243,41 @@ def test_guilt_launchagents_python_script_suffix_mismatch() -> None:
     verdict, unknown = pc.classify(["infra/launchagents/chronic_failure_digest.py"])
     assert verdict == pc.VERDICT_FULL
     assert unknown == ["infra/launchagents/chronic_failure_digest.py"]
+
+
+def test_guilt_scripts_tests_shell_script_suffix_mismatch() -> None:
+    """scripts/tests/ is scoped to .py ONLY (v3) — the 1 real .sh file
+    verified living in that directory must not be swept in by a
+    directory-only rule."""
+    verdict, unknown = pc.classify(["scripts/tests/test_prepush_failclosed.sh"])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == ["scripts/tests/test_prepush_failclosed.sh"]
+
+
+def test_guilt_scripts_tests_conftest_still_forced_full() -> None:
+    """Directly-scoped proof (not just 'anywhere' via
+    test_guilt_conftest_anywhere_forces_full_even_under_docs) that the v3
+    scripts/tests/ allowlist entry does not swallow the one file it must
+    never swallow: scripts/tests/conftest.py, a REAL file on disk, stays
+    forced full via NEVER_INNOCENT_BASENAMES, checked before the allowlist
+    loop."""
+    verdict, unknown = pc.classify(["scripts/tests/conftest.py"])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == ["scripts/tests/conftest.py"]
+
+
+def test_guilt_scripts_tests_lookalike_prefix() -> None:
+    """cicatrix-superscar.md #3 (guard over-match) on the new rule: a longer
+    sibling directory name that merely STARTS WITH 'scripts/tests' must not
+    match."""
+    verdict, unknown = pc.classify(["scripts/testsuite/foo.py"])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == ["scripts/testsuite/foo.py"]
+
+
+def test_guilt_scripts_tests_prefix_not_at_path_start() -> None:
+    verdict, _ = pc.classify(["vendor/mirror/scripts/tests/foo.py"])
+    assert verdict == pc.VERDICT_FULL
 
 
 def test_guilt_non_root_markdown_file_forces_full() -> None:
@@ -507,6 +565,37 @@ def test_innocence_infra_launchagents_plist() -> None:
 def test_innocence_infra_launchagents_wrapper_sh() -> None:
     verdict, _ = pc.classify(["infra/launchagents/some_wrapper.sh"])
     assert verdict == pc.VERDICT_SKIP
+
+
+def test_innocence_github_workflows_yml() -> None:
+    """v3 (task #43): a .yml file under .github/workflows/, OTHER than
+    tests.yml (see test_guilt_tests_workflow_file for that exempted case),
+    now skips — measured 2026-07-26 to be structurally incapable of
+    affecting `pytest backend/tests/`'s outcome (module docstring, 'v3
+    EXTENSION'). This is the same real file the pre-v3 guilt test used,
+    now moved to innocence because the rule it demonstrated changed."""
+    verdict, unknown = pc.classify([".github/workflows/immune-enforcement.yml"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_scripts_tests_test_file() -> None:
+    """v3 (task #43): a scripts/tests/test_*.py file — the 235-file suite
+    audited in task #16 — now skips. Real file, verified on disk."""
+    verdict, unknown = pc.classify(["scripts/tests/test_guardrail_liveness.py"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_scripts_tests_init_py() -> None:
+    """scripts/tests/__init__.py is admitted by the same .py suffix rule as
+    any other file in the directory — deliberate, not an oversight: verified
+    empty on disk, and additionally unreachable from `pytest backend/tests/`
+    by the same import-chain argument as the test_*.py files (module
+    docstring, 'v3 EXTENSION')."""
+    verdict, unknown = pc.classify(["scripts/tests/__init__.py"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
 
 
 def test_innocence_root_level_markdown() -> None:

--- a/scripts/tests/test_prepush_classify.py
+++ b/scripts/tests/test_prepush_classify.py
@@ -280,6 +280,16 @@ def test_guilt_scripts_tests_prefix_not_at_path_start() -> None:
     assert verdict == pc.VERDICT_FULL
 
 
+def test_guilt_scripts_non_tests_python_file_still_forces_full() -> None:
+    """task #43 mandate, verbatim: 'a .py under scripts/ that is NOT
+    scripts/tests/ still escalates to full'. The prefix is scripts/tests
+    specifically, not scripts/ wholesale — a sibling script one directory up
+    must not be swept in. Real file, verified on disk."""
+    verdict, unknown = pc.classify(["scripts/agent_start.py"])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == ["scripts/agent_start.py"]
+
+
 def test_guilt_non_root_markdown_file_forces_full() -> None:
     """Only ROOT-level *.md is allowlisted — a nested one is not covered by
     that rule (though it may separately be covered by docs/** etc. if it
@@ -583,6 +593,36 @@ def test_innocence_scripts_tests_test_file() -> None:
     """v3 (task #43): a scripts/tests/test_*.py file — the 235-file suite
     audited in task #16 — now skips. Real file, verified on disk."""
     verdict, unknown = pc.classify(["scripts/tests/test_guardrail_liveness.py"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_workflow_only_diff_skips() -> None:
+    """task #43 mandate, verbatim: 'a workflow-only diff ... skip[s]'. A
+    real multi-file diff touching only .github/workflows/*.yml files (not
+    tests.yml) must skip as a whole, not just file-by-file."""
+    verdict, unknown = pc.classify(
+        [
+            ".github/workflows/scripts-tests-sweep.yml",
+            ".github/workflows/immune-enforcement.yml",
+            ".github/workflows/actionlint.yml",
+        ]
+    )
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_scripts_tests_only_diff_skips() -> None:
+    """task #43 mandate, verbatim: 'a scripts/tests-only diff ... skip[s]'.
+    A real multi-file diff touching only scripts/tests/test_*.py files must
+    skip as a whole."""
+    verdict, unknown = pc.classify(
+        [
+            "scripts/tests/test_guardrail_liveness.py",
+            "scripts/tests/test_prepush_classify.py",
+            "scripts/tests/test_modus_green_gate.py",
+        ]
+    )
     assert verdict == pc.VERDICT_SKIP
     assert unknown == []
 


### PR DESCRIPTION
## Summary

MEASURED, not hypothetical: a fleet night where nearly every diff touched CI/guards/scripts drove up to 13 concurrent `pytest backend/tests/` suites on a 10-core M5 laptop, one convoy 54min in and still climbing (~98min projected) — GitHub Actions itself had 0 queued runs; the bottleneck was entirely local machine contention, not CI slots.

Root cause: `scripts/prepush_classify.py`'s fail-closed allowlist did not yet recognize two path classes provably innocent w.r.t. `pytest backend/tests/` specifically:

- **`.github/workflows/*.yml`** — never imported by or collected into a `pytest backend/tests/` run; has its own gates (`actionlint`, hot-zone enforcement). `tests.yml` itself stays exempted via the pre-existing `NEVER_INNOCENT_EXACT_PATHS` override, checked before this rule — unaffected by the broader entry.
- **`scripts/tests/*.py`** — the 235-file suite from task #16. VERIFIED (not assumed): `.husky/pre-push` invokes `pytest backend/tests/` from `cd apps/backend-rag`, whose `testpaths = backend/tests` collection root structurally excludes the repo-root `scripts/tests/` tree, and a repo-wide grep found zero real imports of the repo-root `scripts.tests` package from anywhere under `apps/backend-rag/`. (Caught and corrected a trap in the original task framing: `apps/backend-rag/backend/tests/scripts/` is a same-named-but-unrelated tree that genuinely DOES feed the backend suite — this PR does not touch it.)

**Honest caveat for review**: this removes the allowlist-attributable share of the ~100min tax. The other half tonight was fleet-wide machine contention (dozens of concurrent agent sessions, not just pytest suites) — a separate, orthogonal problem this PR does not claim to fix.

Follows the module's existing single mechanism exactly — suffix-scoped `(prefix, suffixes)` pairs, no bare prefix, `ALLOWLIST_VERSION` 2→3.

## What changed

- `scripts/prepush_classify.py`: two new allowlist entries + v3 doc block (module docstring + per-entry comment) matching the file's existing documentation style.
- `scripts/tests/test_prepush_classify.py`: converted one now-stale guilt test to innocence (a v2 fact the v3 change makes false — left it lying-green would be worse than red), added 12 new guilt+innocence pairs covering both entries: suffix-mismatch-in-the-same-real-directory, lookalike-sibling-prefix, prefix-not-at-path-start, a `.py`-under-`scripts/`-but-not-`scripts/tests/` guilt case, and multi-file workflow-only / scripts-tests-only innocence diffs. 86/86 pass.

## Verification (piped real file lists through the CLI, not just unit tests)

```
.github/workflows/scripts-tests-sweep.yml  -> skip-backend
.github/workflows/tests.yml                -> full   (exemption holds)
scripts/tests/test_guardrail_liveness.py   -> skip-backend
scripts/tests/conftest.py                  -> full
scripts/agent_start.py (sibling, non-tests) -> full
3× .yml workflow-only diff                 -> skip-backend (as a whole)
3× scripts/tests-only diff                 -> skip-backend (as a whole)
[sweep.yml, test_prepush_classify.py, prepush_classify.py] -> full  (self-edit caught)
```

One honest note: this PR's own diff touches `scripts/prepush_classify.py`, itself a `NEVER_INNOCENT_EXACT_PATH` — so this push paid the full local suite on its own first push, by design. It doesn't get to skip the tax it removes for everyone else. (Verified clean: 0 real FAILED/ERROR lines in the local run, `git ls-remote` confirms the pushed SHA matches HEAD exactly.)

## Test plan

- [x] `ruff check` clean on both files
- [x] `python3 -m pytest scripts/tests/test_prepush_classify.py -q` — 86/86 pass
- [x] Live CLI verification of every guilt+innocence shape above
- [x] Local `.husky/pre-push` full suite ran clean on this branch's own push (0 real failures)

Task #43 (M5 supervisor run, 2026-07-26).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>