### PR TITLE
fix(whatsapp): remove dormant full price-list injection from WA persona

### DIFF
--- a/apps/backend-rag/backend/prompts/whatsapp_persona.py
+++ b/apps/backend-rag/backend/prompts/whatsapp_persona.py
@@ -6,179 +6,19 @@ Key: no markdown, plain text only, human tone.
 
 NOTE: Base prompt now comes from zantara_core.py (Single Source of Truth).
 This module keeps the dynamic build_system_prompt() for per-message context
-(client name, language, first message flag, pricing table).
+(client name, language, first message flag).
+
+Prices are NEVER injected here — ``PricingTool`` is the only source of
+truth (project CLAUDE.md Golden Rule #11 / Data Invariant). A prior version
+of this module dumped the ENTIRE 2026 price JSON into the system prompt as
+a plain-text block; that violated the rule in spirit even though the code
+path (``process_whatsapp_message``'s Gemini-fallback branch, Path A) is
+dormant in production — the live Meta Inbox number is routed elsewhere
+before this module is ever reached. Removed 2026-07-21 rather than left as
+a landmine for a future routing refactor.
 """
 
-import json
-import logging
-from pathlib import Path
-
 from backend.prompts.zantara_core import ZANTARA_MASTER_TEMPLATE
-
-logger = logging.getLogger(__name__)
-
-
-# Localized labels for each pricing category in the JSON dataset.
-# Keys must match category keys in bali_zero_official_prices_2026.json.
-_CATEGORY_LABELS_BY_LANG: dict[str, dict[str, str]] = {
-    "en": {
-        "single_entry_visas": "SINGLE ENTRY VISAS",
-        "multiple_entry_visas": "MULTIPLE ENTRY VISAS",
-        "kitas_permits": "KITAS (residence permits)",
-        "kitap_permits": "KITAP (permanent permits)",
-        "tax_accounting": "TAX & ACCOUNTING",
-        "company_services": "COMPANY SERVICES",
-        "consultant_services": "CONSULTANT SERVICES",
-        "other_process": "OTHER PROCESSES",
-        "urgent_processing": "URGENT PROCESSING (additional cost)",
-    },
-    "it": {
-        "single_entry_visas": "VISTI SINGLE ENTRY",
-        "multiple_entry_visas": "VISTI MULTIPLE ENTRY",
-        "kitas_permits": "KITAS (permessi di soggiorno)",
-        "kitap_permits": "KITAP (permessi permanenti)",
-        "tax_accounting": "TASSE & CONTABILITÀ",
-        "company_services": "SERVIZI AZIENDALI",
-        "consultant_services": "SERVIZI DI CONSULENZA",
-        "other_process": "ALTRI PROCESSI",
-        "urgent_processing": "URGENZE (costo aggiuntivo)",
-    },
-    "id": {
-        "single_entry_visas": "VISA SINGLE ENTRY",
-        "multiple_entry_visas": "VISA MULTIPLE ENTRY",
-        "kitas_permits": "KITAS (izin tinggal terbatas)",
-        "kitap_permits": "KITAP (izin tinggal tetap)",
-        "tax_accounting": "PAJAK & AKUNTANSI",
-        "company_services": "LAYANAN PERUSAHAAN",
-        "consultant_services": "LAYANAN KONSULTAN",
-        "other_process": "PROSES LAINNYA",
-        "urgent_processing": "LAYANAN URGENT (biaya tambahan)",
-    },
-}
-
-# "Exchange rate" intro line per language (kept short to mirror the original).
-_EXCHANGE_RATE_INTRO_BY_LANG: dict[str, str] = {
-    "en": "Exchange rate: approx. 15,385 IDR per 1 USD\n",
-    "it": "Tasso di cambio: circa 15.385 IDR per 1 USD\n",
-    "id": "Kurs: sekitar 15.385 IDR per 1 USD\n",
-}
-
-# Inline "approximately" word in the per-row USD price annotation.
-_APPROX_BY_LANG: dict[str, str] = {
-    "en": "approx.",
-    "it": "circa",
-    "id": "sekitar",
-}
-
-
-def _format_2026_entry(name: str, entry: dict, _approx: str) -> str | None:
-    """Render a 2026 service entry as plain text.
-
-    Returns ``None`` for malformed entries. Handles single ``price`` and
-    ``tier_range`` (low–high) shapes equally.
-    """
-    if not isinstance(entry, dict):
-        return None
-    display_name = entry.get("name") or name
-    price = (entry.get("price") or "").strip()
-    tier_range = entry.get("tier_range")
-    if not price and isinstance(tier_range, (list, tuple)) and len(tier_range) == 2:
-        low = (tier_range[0] or "").strip().replace("IDR", "").strip()
-        high = (tier_range[1] or "").strip().replace("IDR", "").strip()
-        if low and high:
-            price = f"Rp {low} – {high}"
-    if not price:
-        return None
-    notes = entry.get("notes", "")
-    note_str = f" ({notes})" if notes else ""
-    duration = entry.get("duration", "")
-    duration_str = f" — {duration}" if duration else ""
-    return f"{display_name}: {price}{duration_str}{note_str}"
-
-
-def _load_full_pricing(lang: str = "en") -> str:
-    """Load ALL prices from the 2026 JSON and format as plain text.
-
-    Args:
-        lang: Language code for category labels and intro/approx wording.
-              Falls back to ``"en"`` if the requested lang is not registered.
-
-    The 2026 file uses ``{name: {price, tier_range, ...}}`` per category
-    instead of the legacy ``[{code, price_idr, ...}]`` list, so we no
-    longer surface ``code = name`` keys; the entry's own ``name`` field
-    is the human label.
-    """
-    pricing_file = Path(__file__).parent.parent / "data" / "bali_zero_official_prices_2026.json"
-    try:
-        if not pricing_file.exists():
-            return ""
-        with open(pricing_file, encoding="utf-8") as f:
-            data = json.load(f)
-        services = data.get("services", {})
-
-        category_labels = _CATEGORY_LABELS_BY_LANG.get(
-            lang,
-            _CATEGORY_LABELS_BY_LANG["en"],
-        )
-        intro = _EXCHANGE_RATE_INTRO_BY_LANG.get(
-            lang,
-            _EXCHANGE_RATE_INTRO_BY_LANG["en"],
-        )
-        approx = _APPROX_BY_LANG.get(lang, _APPROX_BY_LANG["en"])
-
-        sections = [intro]
-
-        for cat_key, cat_label in category_labels.items():
-            items = services.get(cat_key, {})
-            if not items:
-                continue
-            lines = [f"\n{cat_label}"]
-            # ``tax_accounting`` has one extra nesting level (sub-blocks).
-            if cat_key == "tax_accounting" and isinstance(items, dict):
-                for sub_block_name, sub_block in items.items():
-                    if not isinstance(sub_block, dict) or not sub_block:
-                        continue
-                    lines.append(f"  {sub_block_name}")
-                    for entry_name, entry in sub_block.items():
-                        formatted = _format_2026_entry(entry_name, entry, approx)
-                        if formatted:
-                            lines.append(f"    {formatted}")
-            elif isinstance(items, dict):
-                for entry_name, entry in items.items():
-                    formatted = _format_2026_entry(entry_name, entry, approx)
-                    if formatted:
-                        lines.append(formatted)
-            elif isinstance(items, list):
-                # Legacy shape — preserved for safety.
-                for item in items:
-                    if not isinstance(item, dict):
-                        continue
-                    code = item.get("code", "?")
-                    name = item.get("name", "")
-                    price_idr = item.get("price_idr", 0)
-                    price_usd = item.get("price_usd_approx", 0)
-                    notes = item.get("notes", "")
-                    note_str = f" ({notes})" if notes else ""
-                    lines.append(
-                        f"{code} = {name}: {price_idr:,} IDR ({approx} ${price_usd} USD){note_str}",
-                    )
-            sections.append("\n".join(lines))
-
-        return "\n".join(sections)
-    except Exception as e:
-        logger.warning("Failed to load pricing for WhatsApp persona: %s", e)
-        return ""
-
-
-# Cache pricing tables per language so we build each one only once at import.
-_PRICING_TABLES: dict[str, str] = {
-    lang: _load_full_pricing(lang) for lang in _CATEGORY_LABELS_BY_LANG
-}
-
-# Backwards-compat alias — defaults to English (was Italian; this is the bug
-# fix at the heart of this PR). Callers that did not pass a language used to
-# always get Italian labels even for English-speaking clients.
-_PRICING_TABLE = _PRICING_TABLES["en"]
 
 # Base prompt from single source of truth
 _BASE_PROMPT = ZANTARA_MASTER_TEMPLATE
@@ -266,11 +106,8 @@ def build_system_prompt(
 
     greeting_note = templates["greeting"] if is_first_message else templates["no_greeting"]
 
-    # Pick the localized pricing table (falls back to EN inside the dict).
-    pricing_table = _PRICING_TABLES.get(lang, _PRICING_TABLES["en"])
-
-    # Critical rule + price-list header — kept multilingual so an English-speaking
-    # client never sees Italian instructions in their system context.
+    # Critical rule — kept multilingual so an English-speaking client never
+    # sees Italian instructions in their system context.
     expert_rules: dict[str, str] = {
         "en": (
             'CRITICAL RULE: NEVER tell the client "I don\'t have access", '
@@ -309,14 +146,6 @@ def build_system_prompt(
     }
     expert_rule = expert_rules.get(lang, expert_rules["en"])
 
-    pricing_headers: dict[str, str] = {
-        "en": "OFFICIAL BALI ZERO 2026 PRICE LIST (use ONLY these prices, never invent):",
-        "it": "LISTINO PREZZI UFFICIALE BALI ZERO 2026 (usa SOLO questi prezzi, mai inventare):",
-        "id": "DAFTAR HARGA RESMI BALI ZERO 2026 (gunakan HANYA harga ini, jangan dibuat-buat):",
-        "de": "OFFIZIELLE BALI ZERO 2026 PREISLISTE (verwenden Sie NUR diese Preise, niemals erfinden):",
-    }
-    pricing_header = pricing_headers.get(lang, pricing_headers["en"])
-
     client_context_headers: dict[str, str] = {
         "en": "CLIENT CONTEXT:",
         "it": "CONTESTO CLIENTE:",
@@ -334,10 +163,7 @@ def build_system_prompt(
 {client_context_header}
 {context_section}
 
-{greeting_note}
-
-{pricing_header}
-{pricing_table}"""
+{greeting_note}"""
 
     return prompt
 

--- a/apps/backend-rag/backend/tests/unit/prompts/test_whatsapp_persona.py
+++ b/apps/backend-rag/backend/tests/unit/prompts/test_whatsapp_persona.py
@@ -1,0 +1,81 @@
+"""
+Regression guard: the WhatsApp persona must never inject a full price list.
+
+Context (FIX 1, 2026-07-21): ``backend/prompts/whatsapp_persona.py`` used to
+have a ``_load_full_pricing()`` helper that dumped the ENTIRE 2026 price
+JSON (``bali_zero_official_prices_2026.json``) into ``build_system_prompt()``'s
+output under an "OFFICIAL BALI ZERO 2026 PRICE LIST" header — a full
+price-list injection that violates the "prices ONLY from PricingTool"
+golden rule in spirit (project CLAUDE.md §8 Golden Rule #11 / §9 Data
+Invariants). The call site (``process_whatsapp_message``'s Gemini-fallback
+branch in ``app/routers/whatsapp_chat.py``, "Path A") is dormant in
+production today — the live Meta Inbox number is routed elsewhere before
+this module is ever reached — but a routing refactor could silently
+reactivate it. This test pins the fix so the landmine cannot come back.
+"""
+
+import json
+from pathlib import Path
+
+from backend.prompts import whatsapp_persona
+from backend.prompts.whatsapp_persona import build_system_prompt
+
+# Exact header strings the old _load_full_pricing() injected, one per
+# language build_system_prompt supports.
+_OLD_PRICE_LIST_HEADERS = [
+    "OFFICIAL BALI ZERO 2026 PRICE LIST",
+    "LISTINO PREZZI UFFICIALE BALI ZERO 2026",
+    "DAFTAR HARGA RESMI BALI ZERO 2026",
+    "OFFIZIELLE BALI ZERO 2026 PREISLISTE",
+]
+
+_PRICING_FILE = (
+    Path(__file__).resolve().parents[3] / "data" / "bali_zero_official_prices_2026.json"
+)
+
+
+def test_load_full_pricing_helper_removed():
+    """The helper that dumped the JSON price file must not exist anymore —
+    its mere presence was the landmine (importable/callable even while the
+    one call site was dormant)."""
+    assert not hasattr(whatsapp_persona, "_load_full_pricing")
+    assert not hasattr(whatsapp_persona, "_PRICING_TABLE")
+    assert not hasattr(whatsapp_persona, "_PRICING_TABLES")
+
+
+def test_build_system_prompt_never_contains_price_list_header():
+    """No language variant of build_system_prompt() output may contain the
+    old 'use ONLY these prices' price-list header."""
+    for lang in ("en", "it", "id", "de"):
+        prompt = build_system_prompt(detected_language=lang)
+        for header in _OLD_PRICE_LIST_HEADERS:
+            assert header not in prompt, (
+                f"build_system_prompt(lang={lang!r}) still injects a full "
+                f"price-list header ({header!r}) — the landmine regressed."
+            )
+
+
+def test_build_system_prompt_never_contains_a_real_priced_entry():
+    """Sanity anchor: a real entry from the 2026 price JSON must not leak
+    verbatim into the persona prompt (would only happen if the full-dump
+    behavior were reintroduced)."""
+    assert _PRICING_FILE.exists(), f"Expected pricing file missing: {_PRICING_FILE}"
+    data = json.loads(_PRICING_FILE.read_text(encoding="utf-8"))
+    sample_entry = data["services"]["single_entry_visas"]["B1 Visa on Arrival (VOA)"]
+
+    prompt = build_system_prompt(detected_language="en")
+    assert sample_entry["price"] not in prompt
+    assert "B1 Visa on Arrival (VOA)" not in prompt
+
+
+def test_build_system_prompt_still_builds_a_persona_prompt():
+    """The refactor must not break the function — it still returns a
+    non-empty, per-language system prompt built on ZANTARA_MASTER_TEMPLATE."""
+    prompt = build_system_prompt(
+        client_name="Test Client",
+        is_first_message=True,
+        detected_language="en",
+    )
+    assert isinstance(prompt, str)
+    assert prompt.strip()
+    assert "Test Client" in prompt

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`327 routers · 656 services · 1223 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`327 routers · 656 services · 1224 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
Recovered from a pushed-but-never-proposed branch (task #50 origin-branch reconciliation sweep). Single, narrow fix: removes a dormant full price-list injection from the WhatsApp persona — dead code removal, per PricingTool-only golden rule (CLAUDE.md §8.11).

## Test plan
- [ ] CI required checks green
- [ ] Confirm WA persona still resolves prices via PricingTool only, nothing else depended on the removed injection path

🤖 Recovered via fleet reconciliation sweep (task #50)