### PR TITLE
fix(ci): inventory-check asks "did THIS PR make it worse", not "is main perfect"

### DIFF
--- a/.github/workflows/docs-guardian.yml
+++ b/.github/workflows/docs-guardian.yml
@@ -6,6 +6,9 @@ on:
       - "docs/**"
       - "scripts/docs_audit.py"
       - "scripts/docs_guardian.sh"
+      - "scripts/docs_inventory_regen.sh"
+      - "scripts/docs_inventory_blame.py"
+      - "scripts/tests/test_docs_inventory_blame.py"
       - ".github/workflows/docs-guardian.yml"
 
 concurrency:
@@ -25,14 +28,75 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Verify inventory is up-to-date
+      # The guard's own corpus runs FIRST and in the SAME workflow that enforces
+      # it: a rule about who is to blame is exactly the kind that fails silently
+      # in the permissive direction, and a test no workflow names is decoration.
+      # Cheap (pure functions, <1s) so it costs nothing to put ahead of the two
+      # regenerations below.
+      - name: The blame rule proves guilt AND innocence
         run: |
-          python scripts/docs_audit.py --check \
-            --whitelist "docs/ARCHITECTURE_DECISION_RECORDS.md" \
-            --whitelist "docs/API_REFERENCE.md" \
-            --whitelist "AUTONOMOUS_OPS.md" \
-            --whitelist "docs/PRO_AIR_CONNECTION.md" \
-            --cluster "automation-autonomy:docs/archive/autonomy-history/AUTOMATION_AUTONOMY_PLAN_v3_1.md,docs/archive/autonomy-history/AUTOMATION_AUTONOMY_SYSTEM_V3_2.md,docs/AUTOMATION_AUTONOMY_SYSTEM_V3_3.md,docs/archive/autonomy-history/AUTOMATION_AUTONOMY_NB1_SUBMISSION.md:docs/AUTOMATION_AUTONOMY_SYSTEM_V3_3.md" \
-            --cluster "automations-catalog:docs/archive/ACTIVE_AUTOMATIONS.md,docs/archive/AUTOMATION_MODEL_MAP.md,docs/AUTOMATIONS.md:docs/AUTOMATIONS.md" \
-            --cluster "system-map:docs/archive/system-map-history/SYSTEM_MAP_4D.md,docs/archive/system-map-history/SYSTEM_OVERVIEW.md,docs/archive/system-map-history/CODEBASE_THEMATIC_AREAS.md,docs/LIVING_ARCHITECTURE.md:docs/LIVING_ARCHITECTURE.md" \
-            --cluster "system-audit:docs/archive/SYSTEM_AUDIT_2026-04-03.md,docs/SYSTEM_AUDIT_FINAL_2026-04-03.md:docs/SYSTEM_AUDIT_FINAL_2026-04-03.md"
+          set -euo pipefail
+          python3 -m pip install --quiet pytest
+          python3 -m pytest scripts/tests/test_docs_inventory_blame.py -q -rs
+
+      # Why this job regenerates the inventory TWICE (once at HEAD, once at the
+      # base) instead of the single `docs_audit.py --check` it used to run:
+      #
+      # `--check` compares the committed table byte-for-byte against a freshly
+      # generated one and fails on ANY difference. `docs/DOCS_INVENTORY.md` is
+      # derived from the WHOLE repository, and main here moves every ~20 minutes,
+      # so that rule asked each PR to make a global artifact exactly correct at
+      # merge time — including drift it did not cause. Both halves of that bit,
+      # measured on 2026-07-26:
+      #
+      #   * #3106 edited two docs/superpowers/** files without regenerating and
+      #     merged (this gate is not a required context). The NEXT docs-touching
+      #     PR, #3149, inherited the red — and the hunt for a cause it never had
+      #     is what uncovered the nine-day death of the refresh organ.
+      #   * The organ's OWN PR #3203 failed on a single line, `**Orphans:** 65`
+      #     vs `64`, because main moved between its 09:13Z regeneration and the
+      #     15:11Z check. It cannot win that race: regeneration plus CI is longer
+      #     than the interval between merges.
+      #
+      # So the gate now asks the question it always meant to ask — "did THIS PR
+      # make it worse?" — by generating at both ends and comparing the drift.
+      # scripts/docs_inventory_blame.py holds the rule and its guilt/innocence
+      # corpus. The base is `pull_request.base.sha`: the tip this PR is measured
+      # against, which is exactly what the merge ref already contains. (Not the
+      # W102 trap — that scar is about enumerating CHANGED FILES, where two-dot
+      # and merge-base disagree; here both ends are whole-tree regenerations.)
+      #
+      # Each side runs the base's OWN copy of scripts/docs_inventory_regen.sh,
+      # deliberately: a PR that changes the classifier SHOULD see its own logic
+      # change show up as drift it must commit.
+      - name: Snapshot the committed inventory at HEAD and at the base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/inv"
+          cp docs/DOCS_INVENTORY.md "$RUNNER_TEMP/inv/committed_head.md"
+          git worktree add --detach "$RUNNER_TEMP/base" "$BASE_SHA"
+          cp "$RUNNER_TEMP/base/docs/DOCS_INVENTORY.md" "$RUNNER_TEMP/inv/committed_base.md"
+
+      - name: Regenerate at HEAD
+        run: |
+          set -euo pipefail
+          bash scripts/docs_inventory_regen.sh
+          cp docs/DOCS_INVENTORY.md "$RUNNER_TEMP/inv/generated_head.md"
+
+      - name: Regenerate at the base
+        working-directory: ${{ runner.temp }}/base
+        run: |
+          set -euo pipefail
+          bash scripts/docs_inventory_regen.sh
+          cp docs/DOCS_INVENTORY.md "$RUNNER_TEMP/inv/generated_base.md"
+
+      - name: Is this PR to blame for the inventory being out of date?
+        run: |
+          set -euo pipefail
+          python3 scripts/docs_inventory_blame.py \
+            --committed-base "$RUNNER_TEMP/inv/committed_base.md" \
+            --generated-base "$RUNNER_TEMP/inv/generated_base.md" \
+            --committed-head "$RUNNER_TEMP/inv/committed_head.md" \
+            --generated-head "$RUNNER_TEMP/inv/generated_head.md"

--- a/scripts/docs_inventory_blame.py
+++ b/scripts/docs_inventory_blame.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Decide whether a PR is to BLAME for docs/DOCS_INVENTORY.md being out of date.
+
+Why this exists
+---------------
+`docs_audit.py --check` compares the committed inventory byte-for-byte against a
+freshly generated one and fails on ANY difference. For a table derived from the
+WHOLE repository, in a repo where main moves every ~20 minutes, that asks each
+PR to make a global artifact exactly correct at merge time — including drift it
+did not cause.
+
+Measured consequences of that rule, both on 2026-07-26:
+
+  * PR #3106 redacted a key in two `docs/superpowers/**` files without
+    regenerating. It merged (this gate is not a required context). The NEXT
+    docs-touching PR, #3149, inherited the red it did not earn.
+  * The refresh organ's own PR #3203 failed its own gate on a ONE-LINE
+    difference — `**Orphans:** 65` committed vs `64` generated — because main
+    moved between the 09:13Z regeneration and the 15:11Z check. The organ
+    cannot win a race it is structurally guaranteed to lose.
+
+The rule this implements
+------------------------
+    A PR fails only if it makes the inventory MORE inconsistent than the base
+    already is.
+
+Concretely: compute the set of drifting KEYS at the base and at the head. A key
+present at head but not at base is the PR's fault. A key present at both is
+pre-existing main drift, reported but not charged to this PR. Fewer keys at head
+than base means the PR is repairing drift — which is exactly what the refresh
+organ does, and it must not be punished for it.
+
+This is the "compare the PR-CAUSED delta, never the absolute state" cure that
+`.claude/skills/modus/PENDING-ARMS.md` has carried as open since 2026-07-16.
+
+What a KEY is
+-------------
+One per table row, keyed by the document path — the unit a human can act on.
+Aggregate lines (`| LIVE | 625 | 67% |`, `**Drift:** 0 · ... · **Orphans:** 65`)
+are deliberately NOT keys: they are consequences of the rows, so a counter that
+moves because some other PR archived a doc is never this PR's fault. If a PR
+genuinely changes rows, those rows are charged to it and the counters follow.
+
+Deliberately NOT parsing `--check`'s printed diff
+-------------------------------------------------
+`docs_audit.print_check_delta()` truncates its output at 200 lines and appends
+"... diff truncated after N lines ...". Parsing that would silently under-count
+drift keys on a large diff and let a guilty PR pass — a display cap read as a
+complete list (scar W97). This compares the FILES.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# A table row: `| docs/FOO.md | LIVE | 12 | 2026-07-01 | ... |`
+# The key is the first cell. Rows whose first cell is a header/among the status
+# summary block are excluded by _is_doc_key below.
+_ROW_RE = re.compile(r"^\|\s*(?P<key>[^|]+?)\s*\|")
+
+# First-cell values that appear in the summary block or the header, not as docs.
+_NON_DOC_KEYS = frozenset(
+    {"Status", "Count", "LIVE", "STALE", "ARCHIVED", "Doc", "Path", "File"}
+)
+
+
+def _is_doc_key(key: str) -> bool:
+    """True when the first cell names a document rather than a summary label."""
+    if not key or key in _NON_DOC_KEYS:
+        return False
+    if set(key) <= set("-: "):  # markdown separator row `| ------- | :--- |`
+        return False
+    return key.endswith(".md")
+
+
+def row_map(content: str) -> dict[str, str]:
+    """Map doc path -> full row line, for every table row naming a document."""
+    out: dict[str, str] = {}
+    for line in content.splitlines():
+        m = _ROW_RE.match(line)
+        if not m:
+            continue
+        key = m.group("key").strip().strip("`[]")
+        # `[`docs/x.md`](docs/x.md)` style cells: take the link text.
+        key = re.sub(r"^\[(.*?)\]\(.*\)$", r"\1", key).strip("`")
+        if _is_doc_key(key):
+            out[key] = line.strip()
+    return out
+
+
+def drifting_keys(committed: str, generated: str) -> set[str]:
+    """Keys whose row differs between the committed and generated tables.
+
+    Includes rows added or removed, not only rows whose cells changed — a doc
+    that appears in one table and not the other is drift of the loudest kind.
+    """
+    a, b = row_map(committed), row_map(generated)
+    changed = {k for k in a.keys() & b.keys() if a[k] != b[k]}
+    return changed | (a.keys() ^ b.keys())
+
+
+def _read(p: Path) -> str:
+    try:
+        return p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(f"docs_inventory_blame: cannot read {p}: {exc}") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--committed-base", type=Path, required=True)
+    ap.add_argument("--generated-base", type=Path, required=True)
+    ap.add_argument("--committed-head", type=Path, required=True)
+    ap.add_argument("--generated-head", type=Path, required=True)
+    ap.add_argument(
+        "--max-listed",
+        type=int,
+        default=40,
+        help="cap on keys PRINTED per bucket; counts are always reported in full",
+    )
+    args = ap.parse_args(argv)
+
+    base = drifting_keys(_read(args.committed_base), _read(args.generated_base))
+    head = drifting_keys(_read(args.committed_head), _read(args.generated_head))
+
+    introduced = sorted(head - base)
+    inherited = sorted(head & base)
+    repaired = sorted(base - head)
+
+    def show(label: str, keys: list[str]) -> None:
+        # Never print a truncated list as if it were whole (W97): the count is
+        # stated first and the elision is explicit.
+        print(f"{label}: {len(keys)}")
+        for k in keys[: args.max_listed]:
+            print(f"    {k}")
+        if len(keys) > args.max_listed:
+            print(f"    … {len(keys) - args.max_listed} more not listed above")
+
+    if repaired:
+        show("inventory rows this PR REPAIRS", repaired)
+    if inherited:
+        show("pre-existing drift on the base (NOT charged to this PR)", inherited)
+
+    if not introduced:
+        print(
+            "docs_inventory_blame: PASS — this PR introduces no new inventory drift."
+        )
+        return 0
+
+    show("inventory rows this PR makes STALE", introduced)
+    print(
+        "::error::This PR changes docs in ways the committed "
+        "docs/DOCS_INVENTORY.md does not reflect. Regenerate it in THIS commit "
+        "(`bash scripts/docs_inventory_regen.sh`) — a derived artifact must land "
+        "with the change that derives it, never in a follow-up (scar W86). Rows "
+        "already drifting on the base are listed separately above and are not "
+        "your responsibility.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_docs_inventory_blame.py
+++ b/scripts/tests/test_docs_inventory_blame.py
@@ -1,0 +1,191 @@
+"""Tests for scripts/docs_inventory_blame.py — the blame-scoping half of the
+docs inventory gate.
+
+Both guilt cases are taken from real 2026-07-26 incidents rather than invented:
+
+  * #3106 changed docs without regenerating, so the NEXT docs PR (#3149)
+    inherited a red it did not earn. A PR in #3106's position must still FAIL.
+  * The refresh organ's PR #3203 failed on a single counter line
+    (`**Orphans:** 65` vs `64`) because main moved between its regeneration and
+    the check. A PR in #3203's position must PASS.
+
+The two must hold at once — which is the whole point: the old rule could not
+tell them apart, because it compared the absolute state instead of the delta.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "docs_inventory_blame.py"
+
+sys.path.insert(0, str(SCRIPT.parent))
+import docs_inventory_blame as blame  # noqa: E402
+
+
+def _table(rows: dict[str, str], *, orphans: int = 10) -> str:
+    """Build an inventory-shaped table: summary block + one row per doc."""
+    body = "\n".join(f"| {p} | {cells} |" for p, cells in rows.items())
+    return (
+        "# Docs Inventory\n\n"
+        "| Status   | Count | % |\n"
+        "| -------- | ----: | -: |\n"
+        f"| LIVE     |   {len(rows)} | 67% |\n"
+        "| STALE    |     6 | 1% |\n"
+        "| ARCHIVED |   307 | 33% |\n\n"
+        f"**Drift:** 0 · **Broken links:** 2 · **Orphans:** {orphans}\n\n"
+        "| Doc | Status |\n| --- | --- |\n" + body + "\n"
+    )
+
+
+BASE_ROWS = {
+    "docs/A.md": "LIVE | 3 | 2026-07-01",
+    "docs/B.md": "LIVE | 9 | 2026-07-02",
+    "docs/C.md": "ARCHIVED | 99 | 2026-01-05",
+}
+
+
+def _run(tmp_path: Path, cb: str, gb: str, ch: str, gh: str) -> subprocess.CompletedProcess:
+    paths = {}
+    for name, content in (
+        ("committed_base", cb),
+        ("generated_base", gb),
+        ("committed_head", ch),
+        ("generated_head", gh),
+    ):
+        p = tmp_path / f"{name}.md"
+        p.write_text(content, encoding="utf-8")
+        paths[name] = str(p)
+    return subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "--committed-base", paths["committed_base"],
+            "--generated-base", paths["generated_base"],
+            "--committed-head", paths["committed_head"],
+            "--generated-head", paths["generated_head"],
+        ],
+        capture_output=True, text=True,
+    )
+
+
+# --------------------------------------------------------------------------
+# GUILT — the PR really did make the inventory worse
+# --------------------------------------------------------------------------
+
+
+def test_guilt_pr_changes_a_doc_without_regenerating(tmp_path):
+    """#3106's shape: docs edited, table left untouched. Must FAIL.
+
+    Base is fully consistent, so every drifting row at head is this PR's doing.
+    """
+    clean = _table(BASE_ROWS)
+    head_generated = _table({**BASE_ROWS, "docs/B.md": "STALE | 40 | 2026-07-02"})
+    r = _run(tmp_path, clean, clean, clean, head_generated)
+    assert r.returncode == 1, r.stdout
+    assert "docs/B.md" in r.stdout
+    assert "makes STALE" in r.stdout
+
+
+def test_guilt_pr_adds_a_doc_without_adding_its_row(tmp_path):
+    """A brand-new doc missing from the table is drift of the loudest kind."""
+    clean = _table(BASE_ROWS)
+    head_generated = _table({**BASE_ROWS, "docs/NEW.md": "LIVE | 0 | 2026-07-26"})
+    r = _run(tmp_path, clean, clean, clean, head_generated)
+    assert r.returncode == 1
+    assert "docs/NEW.md" in r.stdout
+
+
+def test_guilt_new_drift_is_charged_even_when_the_base_already_drifts(tmp_path):
+    """Inheriting drift must not become a licence to add more.
+
+    Base already drifts on A; the PR additionally breaks B. A is reported as
+    inherited, B is charged, and the run fails.
+    """
+    committed_base = _table(BASE_ROWS)
+    generated_base = _table({**BASE_ROWS, "docs/A.md": "STALE | 91 | 2026-07-01"})
+    generated_head = _table(
+        {**BASE_ROWS, "docs/A.md": "STALE | 91 | 2026-07-01",
+         "docs/B.md": "ARCHIVED | 91 | 2026-07-02"}
+    )
+    r = _run(tmp_path, committed_base, generated_base, committed_base, generated_head)
+    assert r.returncode == 1
+    assert "docs/B.md" in r.stdout
+    assert "NOT charged to this PR" in r.stdout and "docs/A.md" in r.stdout
+
+
+# --------------------------------------------------------------------------
+# INNOCENCE — the drift is real but not this PR's fault
+# --------------------------------------------------------------------------
+
+
+def test_innocence_pr_inherits_the_bases_drift_unchanged(tmp_path):
+    """#3149's shape: someone else left main dirty; this PR touched docs for
+    unrelated reasons. Identical drift at base and head ⇒ PASS."""
+    committed = _table(BASE_ROWS)
+    generated = _table({**BASE_ROWS, "docs/A.md": "STALE | 91 | 2026-07-01"})
+    r = _run(tmp_path, committed, generated, committed, generated)
+    assert r.returncode == 0, r.stdout
+    assert "PASS" in r.stdout
+
+
+def test_innocence_counter_only_difference_does_not_fail(tmp_path):
+    """#3203's shape, and the exact line it died on: `**Orphans:** 65` vs `64`.
+
+    Aggregate counters are consequences of the rows. A counter that moves
+    because some OTHER PR archived a doc can never be this PR's fault, so a
+    difference confined to the summary block must not fail anyone.
+    """
+    committed = _table(BASE_ROWS, orphans=65)
+    generated = _table(BASE_ROWS, orphans=64)
+    r = _run(tmp_path, committed, committed, committed, generated)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_innocence_the_refresh_organ_repairing_drift_passes(tmp_path):
+    """The organ's whole job is to REMOVE drift. Fewer drifting rows at head
+    than at base must pass — punishing the repair is how the organ starved."""
+    stale_committed = _table(BASE_ROWS)
+    fresh = _table({**BASE_ROWS, "docs/A.md": "STALE | 91 | 2026-07-01"})
+    # base drifts on A; the organ commits the regenerated table, so head is clean
+    r = _run(tmp_path, stale_committed, fresh, fresh, fresh)
+    assert r.returncode == 0, r.stdout
+    assert "REPAIRS" in r.stdout and "docs/A.md" in r.stdout
+
+
+# --------------------------------------------------------------------------
+# Shape pins
+# --------------------------------------------------------------------------
+
+
+def test_summary_block_rows_are_never_treated_as_documents(tmp_path):
+    """`| LIVE | 625 | 67% |` is a summary line, not a doc named "LIVE"."""
+    m = blame.row_map(_table(BASE_ROWS))
+    assert set(m) == set(BASE_ROWS)
+    assert not any(k in m for k in ("LIVE", "STALE", "ARCHIVED", "Status", "Doc"))
+
+
+def test_parser_reads_every_row_of_the_real_inventory(tmp_path):
+    """Anchor to the real artifact: the row count must equal the summary block's
+    own LIVE+STALE+ARCHIVED total. A parser that silently reads half the table
+    would make the subset test pass by seeing no drift at all."""
+    import re
+
+    content = (REPO_ROOT / "docs" / "DOCS_INVENTORY.md").read_text(encoding="utf-8")
+    counts = {
+        s: int(n)
+        for s, n in re.findall(r"^\|\s*(LIVE|STALE|ARCHIVED)\s*\|\s*(\d+)", content, re.M)
+    }
+    assert counts, "could not read the summary block — has the table shape changed?"
+    assert len(blame.row_map(content)) == sum(counts.values())
+
+
+def test_added_and_removed_rows_both_count_as_drift(tmp_path):
+    """Symmetry: a row only in `generated` and a row only in `committed` are
+    both drift. Testing one direction would leave deletions invisible."""
+    a = _table(BASE_ROWS)
+    b = _table({k: v for k, v in BASE_ROWS.items() if k != "docs/C.md"})
+    assert blame.drifting_keys(a, b) == {"docs/C.md"}
+    assert blame.drifting_keys(b, a) == {"docs/C.md"}


### PR DESCRIPTION
## The rule this replaces

`docs_audit.py --check` compared the committed `docs/DOCS_INVENTORY.md`
byte-for-byte against a freshly generated one and failed on ANY difference.
That table is derived from the WHOLE repository, and main here moves every ~20
minutes, so the rule asked every docs-touching PR to make a global artifact
exactly correct **at merge time** — including drift it did not cause.

Both halves of that bit on 2026-07-26, and neither is hypothetical:

- **#3106** edited two `docs/superpowers/**` files without regenerating and
  merged (this gate is not a required context). The next docs PR, **#3149**,
  inherited the red. Chasing a cause it never had is what uncovered the refresh
  organ's nine-day death.
- The organ's **own** PR **#3203** failed on one line — `**Orphans:** 65` vs
  `64` — because main moved between its 09:13Z regeneration and the 15:11Z
  check. It cannot win that race: regeneration plus CI is longer than the gap
  between merges. The cure for calendar rot was being blocked by repo velocity.

## The new rule

`scripts/docs_inventory_blame.py`: generate at HEAD **and** at the base, compare
the two sets of drifting rows, fail only on keys present at HEAD and absent at
the base.

- Drift the base already carries is **reported and not charged**.
- Fewer drifting rows than the base is a **repair** — precisely the organ's job,
  and it must not be punished for doing it.

This is the "compare the PR-CAUSED delta, never the absolute state" cure that
`PENDING-ARMS.md` has carried open since 2026-07-16. The wall-clock half was
already fixed (P3-prime `as_of=None`); this is the other half.

## Three decisions worth stating

- **Keys are table ROWS, one per document.** Aggregate lines (`| LIVE | 625 |
  67% |`, `**Drift:** … **Orphans:** 65`) are deliberately not keys: they are
  consequences of rows, so a counter that moves because someone else archived a
  doc can never be this PR's fault. That is literally the line #3203 died on.
- **It compares the FILES, never `--check`'s printed diff**, which truncates at
  200 lines — parsing that would under-count drift on a large diff and let a
  guilty PR through (scar W97). The tool's own listing prints the count *before*
  the elision for the same reason.
- **Each side runs the base's own copy of `docs_inventory_regen.sh`**, so a PR
  that changes the classifier correctly sees its own logic change as drift it
  must commit.

Base is `pull_request.base.sha` — the tip the merge ref already contains. Not
the W102 trap: that scar is about enumerating *changed files*, where two-dot and
merge-base disagree; both ends here are whole-tree regenerations.

## Tests, and the control that did not work

They run in the **same workflow that enforces the rule** (a test no workflow
names is decoration), and both guilt cases are the real incidents above.

- Reverting to the old absolute-state rule fails **6 of 9**.
- Blaming every drifting key while keeping row-scoping fails the
  inherited-drift case.
- A third control — treating summary lines as documents — **did not
  discriminate**, because the `**Orphans:**` line is not a table row and so is
  never a key under any variant. Recorded rather than dressed up as coverage it
  does not provide.

## How to read this PR's own checks

It touches `docs-guardian.yml` and the new script, both in the workflow's
`paths:` filter, so **the new gate runs on itself**. `inventory-check` is not a
required context, so auto-merge is deliberately NOT armed until that check is
observed green — otherwise a broken gate could merge itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)