### PR TITLE
fix(ci): pin the flip-branch name, and make it unique per ATTEMPT (delta after #3207)

### DIFF
--- a/.github/workflows/docs-inventory-refresh.yml
+++ b/.github/workflows/docs-inventory-refresh.yml
@@ -141,7 +141,24 @@ jobs:
         run: |
           set -euo pipefail
           DATE_SLUG=$(date -u +%Y-%m-%d)
-          BRANCH="docs/auto-sync-inventory-${DATE_SLUG}"
+          # The branch name must be unique PER RUN, not per day. This organ is
+          # scheduled TWICE daily (09:xx and 20:xx UTC), and both runs once
+          # derived the same `docs/auto-sync-inventory-${DATE_SLUG}`. So the
+          # first run to push its branch and then die before that PR merged
+          # left an orphan branch, and every later run — building its branch
+          # fresh from main — was rejected against it:
+          #   ! [rejected] docs/auto-sync-inventory-2026-07-25 (non-fast-forward)
+          # which converts ONE transient failure into a PERMANENT outage. Lived
+          # it: 17 consecutive red runs, 2026-07-17 → 2026-07-25, nine days in
+          # which docs/DOCS_INVENTORY.md never refreshed on main.
+          # `delete_branch_on_merge` does NOT cover this — a run that dies
+          # before its PR merges leaves no merge to trigger the deletion.
+          # GITHUB_RUN_ATTEMPT is in the name too: re-running a failed run
+          # reuses its RUN_ID and would reproduce the very same collision.
+          # Cost of uniqueness: a failed-after-push run leaves one orphan
+          # branch behind. That is inert (nothing collides with it now) and is
+          # reported by scripts/branch_graveyard_cleanup.sh.
+          BRANCH="docs/auto-sync-inventory-${DATE_SLUG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
           # P3-prime: "Refresh PR logs 'advanced N flips, eligibility
           # recomputed'" — surfaced in BOTH the commit message and the PR

--- a/scripts/tests/test_docs_inventory_refresh_liveness.py
+++ b/scripts/tests/test_docs_inventory_refresh_liveness.py
@@ -437,3 +437,78 @@ def test_real_repo_slug_constant_is_the_correct_one():
     # --repo really is required, not just documented as such in prose.
     assert "--repo REPO" in result.stdout
     assert "[--repo" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Scar pin: the flip-branch name must be unique PER RUN, not per day.
+#
+# The organ is scheduled twice daily and both runs once derived the same
+# `docs/auto-sync-inventory-${DATE_SLUG}`. A run that pushed that branch and
+# then died before its PR merged left it orphaned, and every later run was
+# rejected against it (non-fast-forward) — one transient failure became a
+# permanent outage: 17 consecutive red runs, 2026-07-17 → 2026-07-25.
+#
+# This lives in THIS file on purpose: it is named on a real pytest line in
+# .github/workflows/immune-enforcement.yml, so it actually executes. A new
+# file under scripts/tests/ would be collected by no workflow and would sit
+# green forever (superscar #2 — written, not armed).
+# ---------------------------------------------------------------------------
+
+REFRESH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs-inventory-refresh.yml"
+
+# Tokens that make a branch name differ between two runs of the same UTC day.
+# The date slug alone does not: that IS the defect being pinned.
+_PER_RUN_TOKENS = ("GITHUB_RUN_ID", "github.run_id")
+
+
+def _branch_assignment() -> str:
+    """The right-hand side of the workflow's `BRANCH=` assignment.
+
+    Fails loudly if the assignment cannot be found rather than returning ""
+    and letting the assertions below pass against nothing — a check that
+    silently examines an empty string is decoration (W97/W102: a blind scan
+    is not a clean scan).
+    """
+    for line in REFRESH_WORKFLOW.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("BRANCH="):
+            return stripped[len("BRANCH=") :]
+    raise AssertionError(
+        f"no `BRANCH=` assignment found in {REFRESH_WORKFLOW} — the flip-branch "
+        "naming moved or was renamed; re-anchor this pin instead of deleting it."
+    )
+
+
+def _is_unique_per_run(rhs: str) -> bool:
+    """The predicate under test, applied to a branch-name expression."""
+    return any(token in rhs for token in _PER_RUN_TOKENS)
+
+
+def test_flip_branch_name_is_unique_per_run() -> None:
+    """INNOCENCE: the branch name as it stands today satisfies the predicate."""
+    rhs = _branch_assignment()
+    assert _is_unique_per_run(rhs), (
+        f"flip-branch name {rhs} carries no per-run token — two runs of the "
+        "same UTC day would derive the same branch, and one failed-after-push "
+        "run would then wedge every later run (non-fast-forward) forever."
+    )
+    # The date slug is still wanted for human readability; uniqueness is
+    # ADDITIVE to it, not a replacement. Pins that the fix didn't drop it.
+    assert "DATE_SLUG" in rhs
+    # The prefix every downstream consumer matches on (the liveness guardian's
+    # ORGAN_PR_BRANCH_PREFIX, and the workflow comments) must survive.
+    assert rhs.lstrip('"').startswith(liveness.ORGAN_PR_BRANCH_PREFIX)
+
+
+def test_the_pin_would_have_caught_the_nine_day_outage() -> None:
+    """GUILT: the historical date-only name is rejected by the same predicate.
+
+    Without this half, `test_flip_branch_name_is_unique_per_run` could be
+    passing because the predicate is trivially true rather than because the
+    defect is gone.
+    """
+    historical = '"docs/auto-sync-inventory-${DATE_SLUG}"'
+    assert not _is_unique_per_run(historical)
+    # And a re-run reuses GITHUB_RUN_ID, so the attempt counter matters too:
+    # without it, re-running a failed run reproduces the exact collision.
+    assert "GITHUB_RUN_ATTEMPT" in _branch_assignment()


### PR DESCRIPTION
> **Scope narrowed 2026-07-27.** This PR opened while #3207 was in flight, and #3207 landed the
> same cure first: it run-scopes the flip branch (`…-${DATE_SLUG}-${GITHUB_RUN_ID}`) with a good
> comment. **The nine-day-outage fix is #3207's, not this one's.** Conflicts were resolved by
> taking main's version of both files wholesale and re-applying only the delta below — never a
> hand-merge of two versions of one fix. The original body of this PR described the whole fix and
> is superseded by what follows.

## What is left after #3207

### 1. `GITHUB_RUN_ATTEMPT` — re-running a failed run reuses its run id

`GITHUB_RUN_ID` alone is not unique per *attempt*. That matters here specifically because failure
mode #1 of the same outage (`GitHub Actions is not permitted to create or approve pull requests`)
kills the run **after** its branch is pushed. So an attempt that pushes and then dies leaves the
branch behind, and clicking "re-run" reproduces the identical
`! [rejected] … (non-fast-forward)` that run-scoping was added to kill. The attempt counter is
the only component of the name that differs between attempt 1 and attempt 2.

```diff
-BRANCH="docs/auto-sync-inventory-${DATE_SLUG}-${GITHUB_RUN_ID}"
+BRANCH="docs/auto-sync-inventory-${DATE_SLUG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
```

### 2. A tripwire — #3207 fixed the workflow but pinned nothing

Its test-file changes cover the alert cooldown; the branch name is held only by a comment, and a
comment does not fail CI. Nothing on main fails today if someone reverts to a date-only name.

**Guilt proved empirically on both names that really shipped** — the date-only one that caused the
outage, *and* #3207's `RUN_ID`-only cure, which is correct for the twice-daily case and still
collides on a re-run. Innocence: 34/34 pass, the date slug is still required (readability), and
the prefix contract is asserted against `liveness.ORGAN_PR_BRANCH_PREFIX` rather than a copy of
the string.

The pin lives in the test file `.github/workflows/immune-enforcement.yml` already names on a real
pytest line. `scripts/tests/` is collected by **no glob** in this repo, so a new file there would
sit green forever (superscar #2 — written, not armed).

## One unrelated line, not of this PR's making

`docs/AUTOMATIONS_REFERENCE.md` on main is not prettier-clean — one markdown table cell with an
unescaped cron `0 * * * *`. A merge commit stages every file the merge brings in, so our own
pre-commit prettier gate blocks **any** merge-of-main into **any** branch until that line is
fixed. Formatted rather than bypassed; `--no-verify` is not an option.

## Class audit (unchanged, still holds)

`docs-inventory-refresh.yml` is the **only** workflow in this repo that opens PRs — checked for
both `gh pr create` and the `create-pull-request` actions. No sibling self-healer died in the same
window for the same reason.

## Still not fixed, deliberately not here

The liveness guardian for this organ was red — **correctly** — for the whole outage, ~4 runs a
day, and it changed nothing: its only consumer is the Actions tab. A guardian with no reader is
instrumentation, not protection. That wants its own change, not a drive-by in this diff.
