### PR TITLE
fix(backup): size the prod-PG timeouts to a measured dump, and arm the corpus that ran nowhere

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -92,6 +92,12 @@ jobs:
               scripts/tests/test_docs_audit.py|\
               scripts/tests/test_docs_inventory_refresh_liveness.py|\
               scripts/tests/test_docs_inventory_regen.py|\
+              scripts/lib/fly_credential.sh|\
+              scripts/test_fly_credential.sh|\
+              scripts/fly-pg-backup.sh|\
+              scripts/wr2-cron-wrapper.sh|\
+              scripts/cron-wrapper.sh|\
+              scripts/tests/test_fly_backup_timeouts.py|\
               .claude/skills/modus/PENDING-ARMS.md|\
               .github/workflows/immune-enforcement.yml)
                 RELEVANT=true
@@ -131,6 +137,7 @@ jobs:
             scripts/tests/test_docs_audit.py \
             scripts/tests/test_docs_inventory_refresh_liveness.py \
             scripts/tests/test_docs_inventory_regen.py \
+            scripts/tests/test_fly_backup_timeouts.py \
             scripts/test_lint_test_reward_hacking.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"
@@ -141,6 +148,15 @@ jobs:
             fi
           done
           exit $fail
+
+      - name: Fly credential resolver corpus (shell, guilt + innocence, both historical worlds)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # W106: shipped with #3176 and named by NO workflow until now, so its 24 checks
+          # ran nowhere — a test no workflow names is not coverage, it only looks like it.
+          # No `if [ -f ]` skip here: this file is on main, so absent means deleted, and a
+          # deleted corpus must go red rather than quietly pass.
+          bash scripts/test_fly_credential.sh
 
       - name: declared-pairs.json is valid JSON with sane shape
         if: steps.paths.outputs.relevant == 'true'

--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -42,7 +42,13 @@ SENTINEL_JOB_KEY="$(echo "$JOB_NAME" | tr '-' '_')"
 #   3. CRON_TIMEOUT env var (global crontab override)
 #   4. 300s hard default
 case "$SENTINEL_JOB_KEY" in
-    fly_pg_backup)      _job_default=900 ;;   # PG dump+gzip+upload Tigris
+    # 2026-07-26: was 900. This is the OUTER cap and it covers dump + SFTP + Tigris
+    # upload + verify, so it must exceed fly-pg-backup.sh's own DUMP_TIMEOUT (2400) plus
+    # its SFTP_TIMEOUT (900) — raising only the inner cap would have changed nothing,
+    # because this one fires first. Measured that day: the dump alone took ~815s (vs ~90s
+    # the day before) on an unchanged 2749MB database, with the primary's `cpu` health
+    # check failing. See the comment block in fly-pg-backup.sh.
+    fly_pg_backup)      _job_default=3600 ;;  # PG dump+gzip+upload Tigris
     fly_qdrant_backup)  _job_default=600 ;;   # Qdrant snapshot+upload
     knowledge_graph_builder) _job_default=900 ;;  # full KG rebuild
     *)                  _job_default="" ;;

--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -45,7 +45,7 @@ case "$SENTINEL_JOB_KEY" in
     # 2026-07-26: was 900. This is the OUTER cap and it covers dump + SFTP + Tigris
     # upload + verify, so it must exceed fly-pg-backup.sh's own DUMP_TIMEOUT (2400) plus
     # its SFTP_TIMEOUT (900) — raising only the inner cap would have changed nothing,
-    # because this one fires first. Measured that day: the dump alone took ~815s (vs ~90s
+    # because this one fires first. Timed that day: the dump alone took ~1150s (vs ~90s
     # the day before) on an unchanged 2749MB database, with the primary's `cpu` health
     # check failing. See the comment block in fly-pg-backup.sh.
     fly_pg_backup)      _job_default=3600 ;;  # PG dump+gzip+upload Tigris

--- a/scripts/fly-pg-backup.sh
+++ b/scripts/fly-pg-backup.sh
@@ -38,7 +38,17 @@ FLY_BIN="${FLY_BIN:-/opt/homebrew/bin/fly}"
 KEEP_LOCAL=7
 KEEP_REMOTE=30
 MAX_RETRIES=3
-DUMP_TIMEOUT=900   # in-machine pg_dump+gzip wall-clock cap
+# A timeout is a CEILING for a hung job, not a claim about how long the work takes.
+# Both of these were sized against a ~90s dump; on 2026-07-26 the same dump of the same
+# 2749MB database on the same shared-cpu-2x machine ran at ~570-660 KB/s — ~815s — with
+# exactly one pg_dump alive (counted on the machine, so the rate is not self-contention)
+# and the primary's own `cpu` health check failing ("system spent 3.13s of the last 10
+# seconds waiting on cpu"). 900s would have left ~85s for SFTP + Tigris upload + gunzip
+# verify, which historically need ~90s: the nightly would have died at ~97% of the work.
+# Raised to ~3x the slow-day observation so a bad-CPU-neighbour day cannot silently eat
+# the backup. If the machine is healthy the job simply finishes early — a ceiling costs
+# nothing when it is not reached. The slowness itself is a separate, unexplained finding.
+DUMP_TIMEOUT=2400  # in-machine pg_dump+gzip wall-clock cap (~815s observed 2026-07-26)
 SFTP_TIMEOUT=900   # SFTP transfer wall-clock cap (~5min observed for ~360MB over DERP)
 
 # Tigris credentials (set by fly storage create)

--- a/scripts/fly-pg-backup.sh
+++ b/scripts/fly-pg-backup.sh
@@ -39,16 +39,17 @@ KEEP_LOCAL=7
 KEEP_REMOTE=30
 MAX_RETRIES=3
 # A timeout is a CEILING for a hung job, not a claim about how long the work takes.
-# Both of these were sized against a ~90s dump; on 2026-07-26 the same dump of the same
-# 2749MB database on the same shared-cpu-2x machine ran at ~570-660 KB/s — ~815s — with
-# exactly one pg_dump alive (counted on the machine, so the rate is not self-contention)
-# and the primary's own `cpu` health check failing ("system spent 3.13s of the last 10
-# seconds waiting on cpu"). 900s would have left ~85s for SFTP + Tigris upload + gunzip
-# verify, which historically need ~90s: the nightly would have died at ~97% of the work.
-# Raised to ~3x the slow-day observation so a bad-CPU-neighbour day cannot silently eat
-# the backup. If the machine is healthy the job simply finishes early — a ceiling costs
-# nothing when it is not reached. The slowness itself is a separate, unexplained finding.
-DUMP_TIMEOUT=2400  # in-machine pg_dump+gzip wall-clock cap (~815s observed 2026-07-26)
+# Both of these were sized against a ~90s dump. Timed end-to-end on 2026-07-26 (one dump
+# alive, counted on the machine, so the rate is not self-contention): the SAME dump of the
+# SAME 2749MB database on the SAME shared-cpu-2x machine took ~1150s to produce a complete
+# 385,503,996-byte file — rate swinging between ~660 and ~130 KB/s within the single run,
+# while the primary's own `cpu` health check was failing ("system spent 3.13s of the last
+# 10 seconds waiting on cpu"; vm check 2/3, replica 3/3 and idle). The old 900s cap would
+# have killed it at ~78% of the work — and the OUTER wrapper cap, also 900s, would have
+# fired sooner still. Raised to ~2x the measured slow run so a worse CPU-neighbour day
+# cannot silently eat the backup. If the machine is healthy the job finishes early: a
+# ceiling costs nothing when it is not reached. The slowness itself is NOT diagnosed here.
+DUMP_TIMEOUT=2400  # in-machine pg_dump+gzip wall-clock cap (~1150s measured 2026-07-26)
 SFTP_TIMEOUT=900   # SFTP transfer wall-clock cap (~5min observed for ~360MB over DERP)
 
 # Tigris credentials (set by fly storage create)

--- a/scripts/tests/test_fly_backup_timeouts.py
+++ b/scripts/tests/test_fly_backup_timeouts.py
@@ -1,0 +1,105 @@
+"""The prod-Postgres backup has THREE nested wall-clock caps, and the outermost one wins.
+
+`cron-wrapper.sh` wraps the whole job in `gtimeout <per-job default>`; inside it,
+`fly-pg-backup.sh` caps the dump with `DUMP_TIMEOUT` and the download with `SFTP_TIMEOUT`.
+If the outer cap is not larger than the sum of the inner ones, the inner caps are decoration:
+the wrapper kills the job before they can ever fire, and raising them changes nothing.
+
+That is not hypothetical. On 2026-07-26 all three were 900: the dump alone measured ~815s
+(~570-660 KB/s on an unchanged 2749MB database, with exactly one pg_dump alive on the machine
+and the primary's own `cpu` health check failing), leaving ~85s for an SFTP + Tigris upload +
+gunzip verify that historically need ~90s. Raising only `DUMP_TIMEOUT` would have looked like a
+fix and changed nothing at all.
+
+These tests assert the ORDERING, not the specific numbers — the numbers are free to move as the
+machine's speed changes; what must never regress is that the outer cap can accommodate the inner
+ones. Guilt (an inverted pair is caught) and innocence (the real files pass) are both asserted,
+because a check that only ever sees the passing case proves nothing about what it would reject.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CRON_WRAPPER = REPO_ROOT / "scripts" / "cron-wrapper.sh"
+BACKUP_SCRIPT = REPO_ROOT / "scripts" / "fly-pg-backup.sh"
+
+# Anchored so a value mentioned in prose or in another job's row cannot be mistaken for the
+# assignment (the substring-instead-of-entity failure this repo files under superscar #3).
+_OUTER_RE = re.compile(r"^\s*fly_pg_backup\)\s*_job_default=(\d+)\s*;;", re.M)
+_INNER_RE = r"^{name}=(\d+)"
+
+
+def _outer_cap(text: str) -> int:
+    matches = _OUTER_RE.findall(text)
+    assert matches, "no `fly_pg_backup) _job_default=<n>` row found in cron-wrapper.sh"
+    assert len(matches) == 1, f"ambiguous: {len(matches)} fly_pg_backup rows, expected exactly 1"
+    return int(matches[0])
+
+
+def _inner_cap(text: str, name: str) -> int:
+    matches = re.findall(_INNER_RE.format(name=name), text, re.M)
+    assert matches, f"no `{name}=<n>` assignment found in fly-pg-backup.sh"
+    assert len(matches) == 1, f"ambiguous: {len(matches)} {name} assignments, expected exactly 1"
+    return int(matches[0])
+
+
+def _violates(outer: int, dump: int, sftp: int) -> bool:
+    """True when the outer cap cannot accommodate the inner ones (inner caps are decoration)."""
+    return outer < dump + sftp
+
+
+def test_outer_cap_can_accommodate_both_inner_caps() -> None:
+    """INNOCENCE: the caps as actually committed are coherent."""
+    outer = _outer_cap(CRON_WRAPPER.read_text())
+    backup = BACKUP_SCRIPT.read_text()
+    dump = _inner_cap(backup, "DUMP_TIMEOUT")
+    sftp = _inner_cap(backup, "SFTP_TIMEOUT")
+
+    assert not _violates(outer, dump, sftp), (
+        f"cron-wrapper's fly_pg_backup cap ({outer}s) is below DUMP_TIMEOUT ({dump}s) + "
+        f"SFTP_TIMEOUT ({sftp}s) = {dump + sftp}s. The wrapper fires first, so the inner "
+        f"caps can never be reached and raising them is a no-op."
+    )
+
+
+def test_inverted_pair_is_caught() -> None:
+    """GUILT: the exact shape that shipped on 2026-07-26 is rejected."""
+    assert _violates(outer=900, dump=900, sftp=900)
+    # and the near-miss that motivated this file: inner raised, outer forgotten
+    assert _violates(outer=900, dump=2400, sftp=900)
+
+
+def test_dump_cap_covers_the_slowest_observed_run() -> None:
+    """A ceiling below a MEASURED duration is a scheduled failure, not a safety margin.
+
+    ~815s was observed on 2026-07-26 with a single dump running; the cap must clear it with
+    room, since that day was not the worst a shared-cpu machine can do.
+    """
+    dump = _inner_cap(BACKUP_SCRIPT.read_text(), "DUMP_TIMEOUT")
+    assert dump >= 1600, (
+        f"DUMP_TIMEOUT={dump}s leaves no margin over the ~815s dump measured 2026-07-26; "
+        f"a 2x slower day would kill the backup at ~97% of the work."
+    )
+
+
+def test_parsers_reject_ambiguity_rather_than_guessing() -> None:
+    """A parser that silently picks the first of several matches is a proxy that can lie."""
+    two_rows = "    fly_pg_backup)      _job_default=900 ;;\n    fly_pg_backup)      _job_default=99 ;;\n"
+    try:
+        _outer_cap(two_rows)
+    except AssertionError as exc:
+        assert "ambiguous" in str(exc)
+    else:
+        raise AssertionError("two conflicting rows were silently resolved instead of rejected")
+
+    # prose mentioning the name must not be read as an assignment
+    prose_only = "# DUMP_TIMEOUT=900 was the old value\n"
+    try:
+        _inner_cap(prose_only, "DUMP_TIMEOUT")
+    except AssertionError as exc:
+        assert "no `DUMP_TIMEOUT=<n>` assignment" in str(exc)
+    else:
+        raise AssertionError("a commented-out value was read as the live assignment")


### PR DESCRIPTION
## Tonight's nightly would have failed again — for a new reason

The credential inversion (#3176) is cured, so `fly-pg-backup` now gets *past* `resolve primary machine` and actually dumps. That exposed the next wall.

Timed end-to-end on Pro tonight, with **exactly one `pg_dump` alive** (counted on the machine, so the rate is not self-contention):

| | 2026-07-25 | tonight |
|---|---|---|
| `pg_dump` + gzip, same 2749MB database | ~90s | **~1150s** |
| SFTP leg | ~37s | ~238s |
| final artifact | 383,560,761 B | 385,503,996 B (complete, footer verified) |

All three wall-clock caps were `900`. The **outer** one — `cron-wrapper.sh`'s per-job default — covers dump + SFTP + upload + verify and **fires first**, so raising only `DUMP_TIMEOUT` would have looked like a fix and changed nothing at all. Both are raised:

- `DUMP_TIMEOUT` 900 → **2400** (~2.1x the measured slow run)
- outer per-job cap 900 → **3600** (> 2400 + `SFTP_TIMEOUT` 900)

`SFTP_TIMEOUT` stays 900: 238s measured, 3.8x margin.

If the machine is healthy the job simply finishes early — a ceiling costs nothing when it is not reached.

## Why it got slow is NOT diagnosed here, and is not claimed to be

The database did not grow, `/data` has 16G free, and the rate swings 5x *inside* one run. A controlled comparison (identical command, same app, same region, same `shared-cpu-2x:2048MB`, back to back) points at the machine, not the workload:

```
connect-only baseline (both pay)        4s
REPLICA 5683e090f3d228  gzip 128MB      5s   ->  ~1s of work
PRIMARY 0801696b541568  gzip 128MB     16s   -> ~12s of work
```

Fly's own `vm` check agrees and is **failing** on the primary: `[x] cpu: system spent 3.13s of the last 10 seconds waiting on cpu` (2/3 checks; replica 3/3, load 0.11). `/proc/pressure/cpu` reads `some avg60≈35-46` while **io-pressure is ~0** — CPU, not disk.

Raising a ceiling is protection, not a diagnosis. The remedy (a primary restart so repmgr fails over and the VM likely lands off a noisy host) is a production-DB failover and is ledgered as `operator[business]`, not done here.

## Two guards, both mutation-proved rather than merely green

**`scripts/tests/test_fly_backup_timeouts.py`** asserts the **ordering** (`outer >= dump + sftp`), not the numbers, so the caps stay free to move as the machine's speed changes.

| control | result |
|---|---|
| restore the `900/900/900` world that actually shipped | **2 of 4 fail** |
| the near-miss: inner raised, outer forgotten | **1 fails** |
| as committed | **4/4 green** |

It also refuses to guess: two conflicting rows, or a commented-out value, are rejected rather than silently read as the live assignment.

**`scripts/test_fly_credential.sh`** — shipped with #3176 and named by **no workflow**, so its 24 checks ran nowhere. A test no workflow names is not coverage, it only looks like it. Now executed by `immune-enforcement`, deliberately **without** an `if [ -f ]` skip: the file is on main, so absent means deleted, and a deleted corpus must go red rather than quietly pass.

Sentinel paths extended so both fire on changes to the scripts they guard. `actionlint` clean.

## Blast radius

Two constants and one CI wiring. No behaviour changes when the machine is healthy. The consuming chain was mapped before claiming it lands (both nightly schedules pick this up from one checkout):

| schedule | path | gets `DUMP_TIMEOUT`? | gets the outer cap? |
|---|---|---|---|
| 03:00 `fly-backup.sh` | → `~/scripts/fly-pg-backup.sh` (symlink → repo) | yes | n/a — `cron-state.sh` imposes none |
| 03:20 `cron-wrapper.sh` | same symlink | yes | yes |

**Production is already safe regardless of this PR**: tonight's dump was salvaged, verified (`ERRBYTES=0`, `gunzip -t`, and the `-- PostgreSQL database dump complete` footer compared against a known-good dump) and mirrored off-site to Tigris.
