### PR TITLE
chore(intel): promote orphaned nb-monitor report-2026-W30

### DIFF
--- a/research/nb-monitor/report-2026-W30.md
+++ b/research/nb-monitor/report-2026-W30.md
@@ -1,0 +1,167 @@
+---
+date: 2026-07-27
+adversarial_review: exempt-machine-generated
+---
+
+# NB Mitochondrial Value Monitor — 2026-W30
+
+_Generated at 2026-07-26T18:30:05+00:00_
+
+## Ranking
+
+| rank | name | tier | rf7 | rf30 | Δ vs lastweek | age (d) |
+|---:|---|:---:|---:|---:|---:|---:|
+| 1 | `NB-3: Company Setup — Indonesia 2025` | IDLE | 1 | 1 | +0 | 59 |
+| 2 | `` | IDLE | 1 | 1 | +0 | 59 |
+| 3 | `HGB Property Research 2025-2026` | IDLE | 1 | 1 | +0 | 59 |
+| 4 | `Regulatory Research May 2026` | IDLE | 1 | 1 | +0 | 59 |
+| 5 | `Veo Flow Ecosystem Research 2026` | IDLE | 1 | 1 | +0 | 59 |
+| 6 | `Arming Claude Code May 2026 — deep research` | IDLE | 1 | 1 | +0 | 59 |
+| 7 | `Nuzantara CRM autonomous DB Workspace Drive sync research 2026-05-09` | IDLE | 1 | 1 | +0 | 59 |
+| 8 | `` | IDLE | 1 | 1 | +0 | 59 |
+| 9 | `Bali Minimum Wage 2025 Research` | IDLE | 1 | 1 | +0 | 59 |
+| 10 | `UU Cipta Kerja 2025-2026 Research` | IDLE | 1 | 1 | +0 | 59 |
+| 11 | `NB-2: Immigration & Visa — Indonesia 2025` | DYING | 0 | 1 | +0 | 59 |
+| 12 | `NB-INTEL-Immigration — Daily Immigration Intelligence` | DYING | 0 | 1 | +0 | 59 |
+| 13 | `NB-4 — Tax & Fiscal Indonesia | Bali Zero` | DYING | 0 | 0 | +0 | 59 |
+| 14 | `NB-INTEL-Tax — Daily Tax/Fiscal Intelligence` | DYING | 0 | 0 | +0 | 59 |
+| 15 | `NB-INTEL-Press — Daily Press Intelligence` | DYING | 0 | 0 | +0 | 59 |
+| 16 | `NB-INTEL-Regulation — Daily Regulatory Intelligence` | DYING | 0 | 0 | +0 | 59 |
+| 17 | `NB-1: Nuzantara Codebase & Architecture` | DYING | 0 | 0 | +0 | 59 |
+| 18 | `WA CRM Enrichment Architecture 2026` | DYING | 0 | 0 | +0 | 59 |
+| 19 | `NB-7 Editorial & Content Strategy 2025 — Bali Zero` | DYING | 0 | 0 | +0 | 59 |
+| 20 | `ANALISI-LEGALE-ZANTARA` | DYING | 0 | 0 | +0 | 59 |
+| 21 | `Immigration Regulation Search 2025-2026` | DYING | 0 | 0 | +0 | 59 |
+| 22 | `KITAS Research 2025-2026` | DYING | 0 | 0 | +0 | 59 |
+| 23 | `KITAP Research 2025-2026` | DYING | 0 | 0 | +0 | 59 |
+| 24 | `Indonesian Tax Updates 2025-2026` | DYING | 0 | 0 | +0 | 59 |
+| 25 | `Meet 2026-05-13 Salvatore Iorio — Bali Real Estate` | DYING | 0 | 0 | +0 | 59 |
+| 26 | `[ARCHIVED-DELETE-2026-05-07] NB-NLM-ELEVATION — SOTA research & brainstorm 2026-04-25` | DYING | 0 | 0 | +0 | 59 |
+| 27 | `[MERGED-INTO-dc5d01cd-2026-05-07] Claude Code optimization research 2026-04-21` | DYING | 0 | 0 | +0 | 59 |
+| 28 | `[MERGED-INTO-d2a05271-2026-05-07] Digital Sovereignty & Ancestral Wisdom AI` | DYING | 0 | 0 | +0 | 59 |
+| 29 | `[MERGED-INTO-dc5d01cd-2026-05-07] World Models 2026 — Comprehensive Survey (Genie, Waypoint, GameNGen, SORA)` | DYING | 0 | 0 | +0 | 59 |
+| 30 | `[ARCHIVED-DELETE-2026-05-07] Analisi Video AI Agency` | DYING | 0 | 0 | +0 | 59 |
+| 31 | `[MERGED-INTO-dc5d01cd-2026-05-07] Nexus — Palantir Architecture Deep Research` | DYING | 0 | 0 | +0 | 59 |
+| 32 | `NB-6 Operations & Compliance Indonesia 2025 — Bali Zero` | DYING | 0 | 0 | +0 | 59 |
+| 33 | `Piano di Ristrutturazione e Conformità per PT Wirramanda` | DYING | 0 | 0 | +0 | 59 |
+| 34 | `Agenti in Evoluzione: Rapporto sulla Ricerca 2026` | DYING | 0 | 0 | +0 | 59 |
+| 35 | `[EXPORTED-2026-05-07] BZ Morning News — Multi-Domain Briefing` | DYING | 0 | 0 | +0 | 59 |
+| 36 | `Bali Zero Setup Guide Mac+Mobile — Cinematic ID` | DYING | 0 | 0 | +0 | 59 |
+| 37 | `WR2 Badung HOREKA Waste Carousel Verification 2026-05-11` | DYING | 0 | 0 | +0 | 59 |
+| 38 | `Labor Regulatory Check May 2026` | DYING | 0 | 0 | +0 | 59 |
+| 39 | `CRM sync open-source patterns fast import 2026-05-09` | DYING | 0 | 0 | +0 | 59 |
+| 40 | `Kura Kura Bali Crisis 2026-05-12 — OSINT briefing` | DYING | 0 | 0 | +0 | 59 |
+| 41 | `Ciclo di Vita e Manutenzione dei Sistemi Informativi NotebookLM` | DYING | 0 | 0 | +0 | 59 |
+| 42 | `AI Evolutionary Frontier quicktime 2026 — ALTK/DGM/PTB/SoM` | DYING | 0 | 0 | +0 | 59 |
+| 43 | `NLM Video Falla Research 2026-05-08` | DYING | 0 | 0 | +0 | 59 |
+| 44 | `NIB PMA Regulations 2025-2026 Research` | DYING | 0 | 0 | +0 | 59 |
+| 45 | `Employment Regulations 2025-2026` | DYING | 0 | 0 | +0 | 59 |
+| 46 | `NB-14: Claude Code Session Memory` | DYING | 0 | 0 | +0 | 59 |
+| 47 | `NB-5 — Property & Real Estate Indonesia 2025` | DYING | 0 | 0 | +0 | 59 |
+| 48 | `NB-9: Research Lab` | DYING | 0 | 0 | +0 | 59 |
+| 49 | `NB-META-LIFECYCLE-STUDY-2026-05-04` | DYING | 0 | 0 | +0 | 59 |
+| 50 | `NB-DESIGN-AGENT — Bali Zero AI Design Agent Architecture` | DYING | 0 | 0 | +0 | 59 |
+| 51 | `NB-0 Meta-NLM — System Reflection` | DYING | 0 | 0 | +0 | 59 |
+| 52 | `NB-HARARI — Yuval Noah Harari on AI (2021-2026)` | DYING | 0 | 0 | +0 | 59 |
+| 53 | `Regulatory Research 2025-2026` | DYING | 0 | 0 | +0 | 59 |
+| 54 | `August 2025 Income Tax Return for The Creative Agency` | DYING | 0 | 0 | +0 | 59 |
+| 55 | `Labor Law Research 2025-2026` | DYING | 0 | 0 | +0 | 59 |
+| 56 | `Codex Config Deep Research 2026 — Nuzantara Operator` | DYING | 0 | 0 | +0 | 59 |
+| 57 | `Codex 5.5 best practices May 2026` | DYING | 0 | 0 | +0 | 59 |
+| 58 | `NB-AGENTS` | DYING | 0 | 0 | +0 | 59 |
+| 59 | `NB-0: Zantara Cognitive Identity Blueprint` | DYING | 0 | 0 | +0 | 59 |
+| 60 | `NB-12: Bali Zero Business Intelligence` | DYING | 0 | 0 | +0 | 59 |
+| 61 | `NB-11: Bali Zero Ops Live` | DYING | 0 | 0 | +0 | 59 |
+| 62 | `NB-13: Bali Zero System Telemetry` | DYING | 0 | 0 | +0 | 59 |
+| 63 | `NB-8 Expat Life Bali 2025` | DYING | 0 | 0 | +0 | 59 |
+| 64 | `NB-10: Team Guides — Bali Zero` | DYING | 0 | 0 | +0 | 59 |
+| 65 | `MATA GARUDA — Self-Improving Agent Research` | DYING | 0 | 0 | +0 | 59 |
+| 66 | `MATA GARUDA — Open Source Intel Tools` | DYING | 0 | 0 | +0 | 59 |
+| 67 | `Mata Garuda — Self-Evolving Agent Research` | DYING | 0 | 0 | +0 | 59 |
+| 68 | `MATA GARUDA — Intelligence Architecture Research` | DYING | 0 | 0 | +0 | 59 |
+| 69 | `NB-INTEL-AIResearch — Daily AI Intelligence` | DYING | 0 | 0 | +0 | 59 |
+| 70 | `Labor Law Research May 2025` | DYING | 0 | 0 | +0 | 59 |
+| 71 | `Tax Changes Research 2025-2026` | DYING | 0 | 0 | +0 | 59 |
+| 72 | `Veo Competitors 2026` | DYING | 0 | 0 | +0 | 59 |
+| 73 | `NB-PROBE-SANDBOX-2026-05` | DYING | 0 | 0 | +0 | 59 |
+
+<details>
+<summary>Diagnostic columns (skill_derivation_count, downstream_cite_rate, freshness, push_success, instrumentation_status)</summary>
+
+| name | skill_derivation_count | downstream_cite_rate | source_freshness_age_days | push_success_rate | instrumentation_status |
+|---|---:|---:|---:|---:|:---|
+| `NB-3: Company Setup — Indonesia 2025` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `HGB Property Research 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Regulatory Research May 2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Veo Flow Ecosystem Research 2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Arming Claude Code May 2026 — deep research` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Nuzantara CRM autonomous DB Workspace Drive sync research 2026-05-09` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Bali Minimum Wage 2025 Research` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `UU Cipta Kerja 2025-2026 Research` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-2: Immigration & Visa — Indonesia 2025` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-Immigration — Daily Immigration Intelligence` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-4 — Tax & Fiscal Indonesia | Bali Zero` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-Tax — Daily Tax/Fiscal Intelligence` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-Press — Daily Press Intelligence` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-Regulation — Daily Regulatory Intelligence` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-1: Nuzantara Codebase & Architecture` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `WA CRM Enrichment Architecture 2026` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-7 Editorial & Content Strategy 2025 — Bali Zero` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `ANALISI-LEGALE-ZANTARA` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Immigration Regulation Search 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `KITAS Research 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `KITAP Research 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Indonesian Tax Updates 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Meet 2026-05-13 Salvatore Iorio — Bali Real Estate` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[ARCHIVED-DELETE-2026-05-07] NB-NLM-ELEVATION — SOTA research & brainstorm 2026-04-25` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[MERGED-INTO-dc5d01cd-2026-05-07] Claude Code optimization research 2026-04-21` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[MERGED-INTO-d2a05271-2026-05-07] Digital Sovereignty & Ancestral Wisdom AI` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[MERGED-INTO-dc5d01cd-2026-05-07] World Models 2026 — Comprehensive Survey (Genie, Waypoint, GameNGen, SORA)` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[ARCHIVED-DELETE-2026-05-07] Analisi Video AI Agency` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[MERGED-INTO-dc5d01cd-2026-05-07] Nexus — Palantir Architecture Deep Research` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-6 Operations & Compliance Indonesia 2025 — Bali Zero` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Piano di Ristrutturazione e Conformità per PT Wirramanda` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Agenti in Evoluzione: Rapporto sulla Ricerca 2026` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `[EXPORTED-2026-05-07] BZ Morning News — Multi-Domain Briefing` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Bali Zero Setup Guide Mac+Mobile — Cinematic ID` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `WR2 Badung HOREKA Waste Carousel Verification 2026-05-11` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Labor Regulatory Check May 2026` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `CRM sync open-source patterns fast import 2026-05-09` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Kura Kura Bali Crisis 2026-05-12 — OSINT briefing` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Ciclo di Vita e Manutenzione dei Sistemi Informativi NotebookLM` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `AI Evolutionary Frontier quicktime 2026 — ALTK/DGM/PTB/SoM` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NLM Video Falla Research 2026-05-08` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NIB PMA Regulations 2025-2026 Research` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Employment Regulations 2025-2026` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-14: Claude Code Session Memory` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-5 — Property & Real Estate Indonesia 2025` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-9: Research Lab` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-META-LIFECYCLE-STUDY-2026-05-04` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-DESIGN-AGENT — Bali Zero AI Design Agent Architecture` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-0 Meta-NLM — System Reflection` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-HARARI — Yuval Noah Harari on AI (2021-2026)` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Regulatory Research 2025-2026` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `August 2025 Income Tax Return for The Creative Agency` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Labor Law Research 2025-2026` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Codex Config Deep Research 2026 — Nuzantara Operator` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Codex 5.5 best practices May 2026` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-AGENTS` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-0: Zantara Cognitive Identity Blueprint` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-12: Bali Zero Business Intelligence` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-11: Bali Zero Ops Live` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-13: Bali Zero System Telemetry` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-8 Expat Life Bali 2025` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-10: Team Guides — Bali Zero` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `MATA GARUDA — Self-Improving Agent Research` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `MATA GARUDA — Open Source Intel Tools` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Mata Garuda — Self-Evolving Agent Research` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `MATA GARUDA — Intelligence Architecture Research` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-INTEL-AIResearch — Daily AI Intelligence` | N/A | N/A | N/A | 0.21 | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Labor Law Research May 2025` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Tax Changes Research 2025-2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `Veo Competitors 2026` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+| `NB-PROBE-SANDBOX-2026-05` | N/A | N/A | N/A | N/A | cookie_refresh_pending;pending_qdrant_local_post_fase1;pending_oracle_logging_post_fase4 |
+
+</details>


### PR DESCRIPTION
## Summary
Task #64 (Pro working-tree classification), item 6 — sequenced separately from Batch A (#3244) because it touches the R1 adversarial-review gate (`research/**/*.md` scope).

`com.nuzantara.nb-mitochondrial-monitor.daily` (runs daily 02:30 WITA on Pro, confirmed alive — `LastExitStatus=0`, today's log shows a clean `weekly report written... completed run, processed=73`) generates this weekly NB value-ranking report but nothing captures it on main. Only `report-2026-W24.md` (mid-June, already on main) and this W30 report existed on Pro's disk — W25 through W29 are gone with no trace anywhere, so the capture chain broke for ~5-6 cycles with nothing recoverable for those weeks; W30 is what's actually retrievable now. Same shape as the earlier `docs(intel): promote orphaned regulatory-watcher deltas + nb-health reports` precedent (#1463).

**R1 gate note**: that precedent (`f93fb0ed3`/`3ba58a6e5`) landed 2026-06-15, three weeks *before* the R1 gate existed (introduced 2026-07-06, #2032) — its frontmatter-less file was never actually tested against the current gate, so it isn't directly reusable as a template. This file instead uses the gate's own designed escape hatch: `adversarial_review: exempt-machine-generated` (PASS condition 2b in `scripts/check_adversarial_review.py` — skips the review-section requirement, matches the script's own test fixture literally). This is a raw generated ranking table with zero interpretive claims, not a research deliverable — the right fit for `exempt-`, not a real cross-family review (that's what task #24 exists to prevent bypassing) and not silently deleting the key requirement either.

Verified locally against the actual gate script before shipping: `PASS — 1 research file(s) carry a valid adversarial review`.

Worth a second look by whoever next touches NB health (not chased here, out of scope for a capture-only task): every ranked notebook in this snapshot shows `age=59d, Δ+0` vs last week.

## Method
Shipped server-side via the GitHub contents API, same rationale as #3242/#3244 — CI is authoritative regardless of push path.

## Test plan
- [x] Ran `scripts/check_adversarial_review.py` locally against the exact shipped content before opening this PR: PASS, exit 0
- [ ] CI required checks including the R1 gate (will run automatically on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)