### PR TITLE
fix(backup): judge the artifact, not the exit code — a local-only copy is not a backup

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -94,6 +94,8 @@ jobs:
               scripts/tests/test_docs_inventory_regen.py|\
               scripts/lib/fly_credential.sh|\
               scripts/test_fly_credential.sh|\
+              scripts/lib/offsite_verify.sh|\
+              scripts/test_offsite_verify.sh|\
               scripts/fly-pg-backup.sh|\
               scripts/wr2-cron-wrapper.sh|\
               scripts/cron-wrapper.sh|\
@@ -157,6 +159,13 @@ jobs:
           # No `if [ -f ]` skip here: this file is on main, so absent means deleted, and a
           # deleted corpus must go red rather than quietly pass.
           bash scripts/test_fly_credential.sh
+
+      - name: Off-site artifact gate corpus (guilt + innocence)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # The gate that makes fly-pg-backup.sh judge the ARTIFACT instead of its own
+          # last line. Named here at birth, for the same reason as the corpus above.
+          bash scripts/test_offsite_verify.sh
 
       - name: declared-pairs.json is valid JSON with sane shape
         if: steps.paths.outputs.relevant == 'true'

--- a/scripts/fly-pg-backup.sh
+++ b/scripts/fly-pg-backup.sh
@@ -80,6 +80,25 @@ if [ -z "$_fly_cred_lib" ]; then
 fi
 # shellcheck source=lib/fly_credential.sh
 source "$_fly_cred_lib"
+
+# Same lookup for the off-site verifier (2026-07-27). Also fatal-if-absent: without
+# it this script would go back to judging itself by reaching its own last line.
+_offsite_lib=""
+for _cand in "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/offsite_verify.sh" \
+             "$HOME/nuzantara/scripts/lib/offsite_verify.sh"; do
+    if [ -f "$_cand" ]; then _offsite_lib="$_cand"; break; fi
+done
+if [ -z "$_offsite_lib" ]; then
+    log "ERROR: scripts/lib/offsite_verify.sh not found — cannot verify the artifact. Aborting."
+    exit 1
+fi
+# shellcheck source=lib/offsite_verify.sh
+source "$_offsite_lib"
+
+# Set to 1 ONLY by a remote listing that shows tonight's object. Every path that
+# ends without it is a night with no off-site backup, and must exit non-zero so the
+# alarm in cron-wrapper.sh fires. See the header of lib/offsite_verify.sh.
+OFFSITE_OK=0
 # Probe with the job, not with `auth whoami`: a token scoped to a DIFFERENT app
 # passes whoami and then dies on "Could not find App". Listing this app's
 # machines is the cheapest call that proves the credential can do the work —
@@ -260,15 +279,32 @@ elif command -v aws &> /dev/null; then
         log "WARN: Local backup retained at $BACKUP_FILE — restore manually if needed."
         log "WARN: Fix: regenerate Tigris creds via 'fly storage update nuzantara-backups' or reconcile keys in ~/Desktop/secretkey.env."
     else
-        AWS_ACCESS_KEY_ID="$TIGRIS_KEY" \
+        # 2026-07-27: the rc used to be discarded (`2>/dev/null`, no check) and the
+        # "Uploaded" line printed unconditionally — a claim, not an observation.
+        set +e
+        UPLOAD_OUT=$(AWS_ACCESS_KEY_ID="$TIGRIS_KEY" \
         AWS_SECRET_ACCESS_KEY="$TIGRIS_SECRET" \
         aws s3 cp "$BACKUP_FILE" \
             "s3://$TIGRIS_BUCKET/postgres/$(basename "$BACKUP_FILE")" \
             --endpoint-url "$TIGRIS_ENDPOINT" \
-            --region auto 2>/dev/null
-        log "Uploaded to Tigris: s3://$TIGRIS_BUCKET/postgres/$(basename "$BACKUP_FILE")"
+            --region auto 2>&1)
+        UPLOAD_RC=$?
+        set -e
+        [ $UPLOAD_RC -ne 0 ] && log "WARN: upload rc=$UPLOAD_RC: $(echo "$UPLOAD_OUT" | tail -2 | tr '\n' ' ')"
 
-        # Cleanup old remote backups (keep last KEEP_REMOTE)
+        # Ask the REMOTE, always — including when the upload claimed success.
+        if AWS_ACCESS_KEY_ID="$TIGRIS_KEY" AWS_SECRET_ACCESS_KEY="$TIGRIS_SECRET" \
+           verify_offsite_object "$TIGRIS_BUCKET" "$TIGRIS_ENDPOINT" "$(basename "$BACKUP_FILE")"; then
+            OFFSITE_OK=1
+            log "Verified off-site: s3://$TIGRIS_BUCKET/postgres/$(basename "$BACKUP_FILE")"
+        else
+            log "ERROR: upload finished but the object is NOT in the bucket."
+        fi
+
+        # Cleanup old remote backups (keep last KEEP_REMOTE) — only once tonight's
+        # object is confirmed present. Pruning after a FAILED upload would delete a
+        # good old backup to make room for one that never arrived.
+        if [ "$OFFSITE_OK" -eq 1 ]; then
         AWS_ACCESS_KEY_ID="$TIGRIS_KEY" \
         AWS_SECRET_ACCESS_KEY="$TIGRIS_SECRET" \
         aws s3 ls "s3://$TIGRIS_BUCKET/postgres/" \
@@ -281,6 +317,7 @@ elif command -v aws &> /dev/null; then
                 --region auto 2>/dev/null
             log "Removed old remote: $old"
         done
+        fi
     fi
 else
     log "WARN: aws CLI not found, skipping Tigris upload. Install: brew install awscli"
@@ -290,4 +327,16 @@ fi
 ls -t "$BACKUP_DIR"/nuzantara-fly-*.sql.gz 2>/dev/null | tail -n +$((KEEP_LOCAL + 1)) | xargs rm -f 2>/dev/null || true
 log "Local backups kept: $KEEP_LOCAL"
 
-log "Backup complete ✅"
+# The single verdict. Before 2026-07-27 every branch above fell through to an
+# unconditional "Backup complete ✅" and exit 0 — including the one that skipped the
+# upload entirely on a failed credentials preflight. Since the only alarm in this chain
+# fires on a non-zero exit (cron-wrapper.sh:276), a dead Tigris credential produced a
+# GREEN night with no off-site copy, and the local copy is pruned after KEEP_LOCAL days.
+# Measured: 2026-07-15 has no object for either nightly run, and nothing said so.
+if [ "$OFFSITE_OK" -eq 1 ]; then
+    log "Backup complete ✅"
+else
+    log "ERROR: NO OFF-SITE BACKUP TONIGHT — a local-only copy is not a backup."
+    log "ERROR: local file kept at $BACKUP_FILE (pruned after KEEP_LOCAL=$KEEP_LOCAL days)."
+    exit 1
+fi

--- a/scripts/lib/offsite_verify.sh
+++ b/scripts/lib/offsite_verify.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# offsite_verify.sh — ask the REMOTE whether the object is actually there.
+#
+# Why this exists (2026-07-27, backup audit). fly-pg-backup.sh judged its own success
+# by reaching the end of the script, never by the artifact:
+#
+#   * `aws s3 cp ... 2>/dev/null` — stderr discarded, exit code never read — was followed
+#     unconditionally by `log "Uploaded to Tigris: ..."`. That line was a CLAIM, not an
+#     observation.
+#   * when the credentials preflight failed, the script logged WARNs, skipped the upload
+#     entirely, and still ended with `Backup complete ✅` and exit 0. Since the only alarm
+#     in the chain fires on a non-zero exit (cron-wrapper.sh), a Tigris credential problem
+#     produced a GREEN night with no off-site copy at all — and the local copy is pruned
+#     after KEEP_LOCAL=7 days.
+#
+# Measured consequence: 2026-07-15 has no object in the bucket for either nightly run,
+# while the 03:20 state file records {"status":"ok","exit_code":0} and the 03:00 log simply
+# stops mid-upload. Two runs, no declared failure, no backup.
+#
+# So the rule this file enforces: a backup that is not off-site is not a backup, and the
+# only thing allowed to say the object exists is the remote listing.
+#
+# Deliberately NOT a substring check — `foo.sql.gz` must not be satisfied by
+# `foo.sql.gz.partial` or by `other-foo.sql.gz` (superscar #3: match the entity, not the
+# shape). The listing is anchored on the exact basename in the name column.
+
+# verify_offsite_object <bucket> <endpoint> <key_basename>
+#   rc 0 -> the remote listing shows exactly this object
+#   rc 1 -> it does not, or the listing itself could not be trusted
+# Reads AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from the environment, like the caller.
+verify_offsite_object() {
+    local bucket="$1" endpoint="$2" key="$3"
+    local prefix="${4:-postgres}"
+    local attempt out rc had_e=0
+    local nap="${OFFSITE_VERIFY_RETRY_SLEEP:-3}"
+
+    # Save errexit and restore it exactly as found. A bare `set -e` here would switch
+    # errexit ON in any caller that did not have it — which is not this function's call
+    # to make, and which killed the corpus on its first guilt case.
+    case $- in *e*) had_e=1 ;; esac
+
+    if [ -z "$bucket" ] || [ -z "$endpoint" ] || [ -z "$key" ]; then
+        echo "verify_offsite_object: missing argument (bucket/endpoint/key)" >&2
+        return 1
+    fi
+    if ! command -v aws >/dev/null 2>&1; then
+        echo "verify_offsite_object: aws CLI absent — cannot verify, so cannot claim success" >&2
+        return 1
+    fi
+
+    # Two attempts: a listing taken the instant after a write is the one place a
+    # transient could legitimately lie. Anything beyond that is a real absence.
+    for attempt in 1 2; do
+        set +e
+        out=$(aws s3 ls "s3://$bucket/$prefix/" --endpoint-url "$endpoint" --region auto 2>&1)
+        rc=$?
+        [ $had_e -eq 1 ] && set -e
+        if [ $rc -ne 0 ]; then
+            echo "verify_offsite_object: listing failed rc=$rc: $(echo "$out" | head -1)" >&2
+            if [ $attempt -eq 2 ]; then return 1; fi
+            [ "$nap" != "0" ] && sleep "$nap"
+            continue
+        fi
+        # `aws s3 ls` prints: <date> <time> <size> <name>. Judge the NAME column only,
+        # and demand the whole field — never a substring of a longer name.
+        if printf '%s\n' "$out" | awk -v want="$key" '{ if ($NF == want) found=1 } END { exit found ? 0 : 1 }'; then
+            return 0
+        fi
+        if [ $attempt -eq 2 ]; then break; fi
+        [ "$nap" != "0" ] && sleep "$nap"
+    done
+
+    echo "verify_offsite_object: '$key' is NOT in s3://$bucket/$prefix/" >&2
+    return 1
+}

--- a/scripts/test_offsite_verify.sh
+++ b/scripts/test_offsite_verify.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Proof for scripts/lib/offsite_verify.sh — GUILT and INNOCENCE.
+#
+# The gate exists because the backup judged itself by reaching the end of the script
+# instead of by the artifact (see the header of offsite_verify.sh). So the proof has to
+# do the opposite of what the old code did: it must show the verifier says NO in every
+# world where the object is not really there, including the worlds that look like success.
+#
+#   GUILT     — object absent; listing refused (bad creds); aws CLI missing; a name that
+#               merely CONTAINS ours (`...sql.gz.partial`); a DIFFERENT object of the same
+#               day. Each must return 1, because in each of them a backup does not exist.
+#   INNOCENCE — the object is present, among many others -> 0. A legitimate success must
+#               not be turned into an alarm, or the gate gets disabled and we are back to
+#               superscar #2.
+#
+# The `.partial` and same-day cases are the ones a substring check would get wrong; they
+# are here because the whole family this repo keeps re-living is guards that match a SHAPE
+# and believe they matched an ENTITY.
+#
+# No network and no credential: `aws` is a stub that prints a listing per world.
+set -uo pipefail
+export OFFSITE_VERIFY_RETRY_SLEEP=0   # nessuna attesa nei test: le assenze qui sono vere, non transitorie
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP="$(mktemp -d)"
+# absolute path: the last world under test strips PATH down to a dir with no aws,
+# and a trap that cannot find `rm` turns a passing corpus into exit 127.
+trap '/bin/rm -rf "$TMP"' EXIT
+
+cat > "$TMP/aws" <<'STUB'
+#!/bin/sh
+# STUB_RC      -> exit code of the listing (non-zero = the listing itself failed)
+# STUB_LISTING -> what the listing prints
+[ "${STUB_RC:-0}" -ne 0 ] && { echo "An error occurred (InvalidAccessKeyId)" >&2; exit "$STUB_RC"; }
+printf '%s\n' "$STUB_LISTING"
+exit 0
+STUB
+chmod +x "$TMP/aws"
+
+# shellcheck source=lib/offsite_verify.sh
+. "$HERE/lib/offsite_verify.sh"
+
+PASS=0; FAIL=0
+KEY="nuzantara-fly-20260727-0300.sql.gz"
+REAL_LISTING="2026-07-26 03:02:32  383945210 nuzantara-fly-20260726-0300.sql.gz
+2026-07-27 03:02:32  383945210 $KEY
+2026-07-27 03:22:42  383560761 nuzantara-fly-20260727-0320.sql.gz"
+
+run () {  # run <name> <expected_rc> <PATH-has-aws?> ; env STUB_* set by caller
+    local name="$1" want="$2" withaws="$3" got
+    if [ "$withaws" = "yes" ]; then export PATH="$TMP:$PATH_ORIG"; else export PATH="$TMP/empty"; fi
+    set +e; verify_offsite_object "nuzantara-backups" "https://fly.storage.tigris.dev" "$KEY" >/dev/null 2>&1; got=$?; set -e
+    if [ "$got" = "$want" ]; then PASS=$((PASS+1)); printf '  ok    %-58s rc=%s\n' "$name" "$got"
+    else FAIL=$((FAIL+1)); printf '  FAIL  %-58s rc=%s (atteso %s)\n' "$name" "$got" "$want"; fi
+}
+PATH_ORIG="$PATH"; mkdir -p "$TMP/empty"
+
+echo "INNOCENCE — un successo vero non deve diventare un allarme"
+STUB_RC=0 STUB_LISTING="$REAL_LISTING" run "oggetto presente tra gli altri" 0 yes
+
+echo "GUILT — ogni mondo in cui il backup NON esiste"
+STUB_RC=0 STUB_LISTING="2026-07-26 03:02:32 383945210 nuzantara-fly-20260726-0300.sql.gz" \
+    run "oggetto assente (la notte del 15/7)" 1 yes
+STUB_RC=1 STUB_LISTING="" \
+    run "listing rifiutato (credenziali Tigris morte)" 1 yes
+STUB_RC=0 STUB_LISTING="2026-07-27 03:02:32 12345 ${KEY}.partial" \
+    run "un nome che CONTIENE il nostro (.partial)" 1 yes
+STUB_RC=0 STUB_LISTING="2026-07-27 03:22:42 383560761 nuzantara-fly-20260727-0320.sql.gz" \
+    run "altro oggetto dello stesso giorno, non il nostro" 1 yes
+STUB_RC=0 STUB_LISTING="$REAL_LISTING" \
+    run "aws assente — non si puo' verificare, quindi non si afferma" 1 no
+
+echo
+export PATH="$PATH_ORIG"
+echo "pass=$PASS fail=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## What was wrong

`fly-pg-backup.sh` declared success by reaching its own last line. Two paths made that a lie:

- `aws s3 cp … 2>/dev/null` discarded stderr and **never read the exit code**, then logged
  `Uploaded to Tigris` unconditionally — a claim, not an observation;
- when the Tigris credentials preflight failed, the script logged WARNs, **skipped the upload
  entirely**, and still ended with `Backup complete ✅` and **exit 0**. The only alarm in this
  chain fires on a non-zero exit (`cron-wrapper.sh:276`), so a dead Tigris credential produced a
  **green night with no off-site copy**, and the local copy is pruned after `KEEP_LOCAL=7` days.

## Measured, not hypothesised

**2026-07-15 has no object in the bucket for either nightly run**, while the 03:20 state file
records `{"status":"ok","exit_code":0,"attempts":2,"duration_s":323}` and the 03:00 log simply
stops mid-upload after `pg_dump header verified OK`. Two runs, no declared failure, no backup.
Ruled out retention: pruning deletes the **oldest**, and 10/7 is still present.

Same audit: **31 of 88** recorded runs of the 03:20 path failed (35%), four of them on the
wall-clock cap raised in #3231 (`exit=124` at `2716s` = `3 × 900s`). Redundancy between the 03:00
and 03:20 runs is what has been hiding this.

## The fix

`scripts/lib/offsite_verify.sh` asks the **remote** whether the object is there, matching the
whole name column — `foo.sql.gz` is not satisfied by `foo.sql.gz.partial`, nor by another object
of the same day (superscar #3: the entity, not the shape). It saves and restores the caller's
`errexit` rather than forcing `set -e` — a defect its own corpus caught on the first run.

`fly-pg-backup.sh` now sets `OFFSITE_OK` only from that verification, and **every path that ends
without it exits 1** so the alarm fires. Remote pruning happens only once tonight's object is
confirmed, so a failed upload can no longer delete a good old backup to make room for one that
never arrived.

## Proof

`scripts/test_offsite_verify.sh` — **guilt**: absent / listing refused / `.partial` / another
same-day object / `aws` missing. **Innocence**: present among many others → 0, so a real success
is never turned into an alarm and nobody gains a reason to disable the gate. 6/6, `shellcheck`
clean. Named in `immune-enforcement.yml` **at birth** — a corpus no workflow runs is not coverage,
which is the exact defect #3231 had to fix for the credential corpus.

Both nightly runs of 2026-07-27 completed and were verified in the bucket while this was being
written (`0300` 385,664,897 B at 03:20:38; `0320` 385,220,160 B at 03:37:29), so the gate is
being introduced against a known-good baseline rather than during an outage.