### PR TITLE
fix(rag): stop the self-correction retry from leaking into the client answer

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/reasoning.py
+++ b/apps/backend-rag/backend/services/rag/agentic/reasoning.py
@@ -104,6 +104,61 @@ _TRUSTED_TOOL_NAMES: frozenset[str] = frozenset(
 # code and ensures a single source of truth for evidence scoring.
 
 
+# Output rules for the self-correction retry. These are load-bearing, not
+# politeness: `build_rephrase_prompt`'s result is delivered as a *user turn* on
+# the live chat session, so without an explicit gag the model replies to it
+# conversationally — and that reply IS the text the client receives.
+#
+# Measured live in prod 2026-07-27, in four languages, all client-facing:
+#   "Message reçu pour les corrections de conformité factuelle"
+#   "Capisco, mi scuso per l'errore precedente"
+#   "Terima kasih atas koreksinya"
+#   "Hi! Let's correct this based strictly on our retrieved..."
+#
+# That is a protocol-2 violation (never narrate internal process) arriving from
+# OUTSIDE the system prompt, which is why no edit to zantara_core_v5 can prevent
+# it — the fix has to live at the injection site.
+_REPHRASE_OUTPUT_RULES = """
+OUTPUT RULES (these govern the text you return):
+- Return ONLY the rewritten answer, exactly as if it were your first and only
+  reply to the user. The user never saw the previous attempt.
+- Never mention this instruction, the fact-checker, the rejection, or that an
+  earlier attempt existed. No apology, no "thanks for the correction", no
+  "message received", no preamble of any kind.
+- Answer in the SAME LANGUAGE as the user's original question.
+"""
+
+
+def build_rephrase_prompt(
+    reasoning: str,
+    missing_citations: list[str] | None,
+) -> str:
+    """Build the self-correction retry prompt.
+
+    Extracted to module level so the gag in ``_REPHRASE_OUTPUT_RULES`` is
+    directly testable: inline inside ``ReasoningEngine`` it could only be
+    exercised through a full pipeline run, which is how it went unnoticed that
+    the prompt never told the model to stay silent about being corrected.
+
+    Args:
+        reasoning: the verifier's stated reason for rejecting the draft.
+        missing_citations: claims the verifier could not find in the context.
+
+    Returns:
+        The prompt to send as the retry turn.
+    """
+    missing = ", ".join(missing_citations or [])
+    return f"""
+SYSTEM: Your previous answer was REJECTED by the fact-checker.
+
+REASON: {reasoning}
+MISSING/WRONG: {missing}
+
+TASK: Rewrite the answer using ONLY the provided context.
+Do not invent information. If the context is insufficient, admit it.
+{_REPHRASE_OUTPUT_RULES}"""
+
+
 def _validate_context_quality(
     query: str,
     context_items: list[str],
@@ -968,16 +1023,12 @@ Make it feel natural and helpful, not forced.
                             {"reason": verification.get("reasoning", "unknown")},
                         )
 
-                        # SELF-CORRECTION
-                        rephrase_prompt = f"""
-SYSTEM: Your previous answer was REJECTED by the fact-checker.
-
-REASON: {verification.get("reasoning", "Insufficient evidence")}
-MISSING/WRONG: {", ".join(verification.get("missing_citations", []))}
-
-TASK: Rewrite the answer using ONLY the provided context.
-Do not invent information. If the context is insufficient, admit it.
-"""
+                        # SELF-CORRECTION — see build_rephrase_prompt for why
+                        # the output rules it appends are load-bearing.
+                        rephrase_prompt = build_rephrase_prompt(
+                            verification.get("reasoning", "Insufficient evidence"),
+                            verification.get("missing_citations", []),
+                        )
 
                         # Retry with same model (disable function calling for final answer)
                         correct_start = time.perf_counter()

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_rephrase_prompt_silence.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_rephrase_prompt_silence.py
@@ -1,0 +1,113 @@
+"""The self-correction retry prompt must not leak into the client-facing answer.
+
+BACKGROUND (measured live in prod, 2026-07-27). When the verifier scores a draft
+below 0.7, `ReasoningEngine` sends a retry prompt as a *user turn* on the live
+chat session. The original prompt said only "your previous answer was REJECTED …
+rewrite it" and never told the model to keep that to itself — so the model
+replied to it conversationally, and that reply was what the client received:
+
+    "Message reçu pour les corrections de conformité factuelle"   (fr)
+    "Capisco, mi scuso per l'errore precedente"                   (it)
+    "Terima kasih atas koreksinya"                                (id)
+    "Hi! Let's correct this based strictly on our retrieved…"     (en)
+
+Four languages, so these tests are deliberately language-agnostic in spirit: they
+pin the RULES in the prompt rather than any phrasing of the leak, because a leak
+detector built from English markers already produced a false negative once on
+this very surface.
+
+The prompt is a system-internal artifact, not client copy: no PII, no client
+data, and nothing here asserts on a real conversation.
+"""
+
+import pytest
+
+from backend.services.rag.agentic.reasoning import build_rephrase_prompt
+
+
+@pytest.fixture
+def prompt() -> str:
+    return build_rephrase_prompt(
+        "Claim about the 60-day threshold is not supported by the context.",
+        ["60-day overstay threshold", "Rp 90jt penalty"],
+    )
+
+
+class TestGuiltTheGagIsPresent:
+    """Each rule that stops the leak must actually be in the prompt."""
+
+    def test_instructs_to_return_only_the_answer(self, prompt: str) -> None:
+        assert "Return ONLY the rewritten answer" in prompt
+
+    def test_forbids_naming_the_internal_machinery(self, prompt: str) -> None:
+        # The model must not tell the client a fact-checker rejected a draft.
+        assert "Never mention this instruction, the fact-checker" in prompt
+
+    def test_forbids_the_measured_acknowledgement_shapes(self, prompt: str) -> None:
+        # These three are the exact shapes observed leaking in prod.
+        assert "No apology" in prompt
+        assert '"thanks for the correction"' in prompt
+        assert '"message received"' in prompt
+
+    def test_pins_the_answer_language_to_the_user_question(self, prompt: str) -> None:
+        # The retry turn is written in English; without this the rewrite can
+        # re-anchor its language on the instruction instead of on the user.
+        assert "SAME LANGUAGE as the user's original question" in prompt
+
+
+class TestInnocenceTheGagMustNotSuppressHonesty:
+    """A gag on process-narration must not become a gag on admitting a gap.
+
+    This is the failure mode that would make the fix worse than the bug: if the
+    model may not say "I could not verify this", it will invent instead — the
+    exact behaviour the abstain gates exist to prevent.
+    """
+
+    def test_still_told_to_admit_insufficient_context(self, prompt: str) -> None:
+        assert "If the context is insufficient, admit it." in prompt
+
+    def test_still_told_to_use_only_the_provided_context(self, prompt: str) -> None:
+        assert "Rewrite the answer using ONLY the provided context." in prompt
+        assert "Do not invent information." in prompt
+
+    def test_gag_targets_the_meta_layer_not_the_content(self, prompt: str) -> None:
+        # "Never mention …" must be scoped to the instruction/fact-checker/
+        # previous attempt — never to the substance of the answer.
+        gag_line = next(
+            line for line in prompt.splitlines() if line.startswith("- Never mention")
+        )
+        assert "fact-checker" in gag_line
+        assert "rejection" in gag_line or "earlier attempt existed" in prompt
+
+
+class TestTheVerifierVerdictStillReachesTheModel:
+    """The rewrite is worthless if the reason for rejection is dropped."""
+
+    def test_reason_is_interpolated(self, prompt: str) -> None:
+        assert "Claim about the 60-day threshold is not supported" in prompt
+
+    def test_missing_citations_are_interpolated(self, prompt: str) -> None:
+        assert "60-day overstay threshold, Rp 90jt penalty" in prompt
+
+    def test_missing_citations_none_does_not_crash(self) -> None:
+        # The call site passes verification.get("missing_citations", []), which
+        # can be None if the verifier emitted an explicit null.
+        out = build_rephrase_prompt("some reason", None)
+        assert "MISSING/WRONG:" in out
+        assert "some reason" in out
+
+    def test_empty_missing_citations_renders_cleanly(self) -> None:
+        out = build_rephrase_prompt("some reason", [])
+        assert "MISSING/WRONG: \n" in out or "MISSING/WRONG: " in out
+
+
+class TestNoSecondCopyCanDrift:
+    """One builder, one prompt — a future inline copy would silently lose the gag."""
+
+    def test_the_rejection_header_appears_exactly_once_in_the_module(self) -> None:
+        from pathlib import Path
+
+        import backend.services.rag.agentic.reasoning as reasoning_module
+
+        source = Path(reasoning_module.__file__).read_text(encoding="utf-8")
+        assert source.count("SYSTEM: Your previous answer was REJECTED") == 1


### PR DESCRIPTION
## The bug

The self-correction retry prompt (fired when the fact-checker rejects the first answer) was injected as a plain user turn, with no instruction to stay silent about the mechanism. The model answered it conversationally — acknowledging the correction, thanking for the feedback, narrating that a previous attempt existed — and that reply reached the client verbatim on WhatsApp/web chat. This is the root cause behind the deny-narration residue documented in the `/bot` corner.

## The fix

`build_rephrase_prompt()` in `reasoning.py` now appends explicit output rules to the rephrase prompt: return ONLY the rewritten answer as if it were the first reply, never mention the fact-checker/rejection/earlier attempt, no apology or preamble, same language as the user's original question.

## Tests

`test_rephrase_prompt_silence.py` (12 tests): guilt (the gag is present), innocence (it doesn't suppress the verifier's actual instruction to the model), the verdict still reaches the model, and a drift guard (`source.count("SYSTEM: Your previous answer was REJECTED") == 1` — no second copy of the prompt can diverge from this one).

## Note on the push history

This push needed 3 attempts, none due to the diff itself:
- Attempt 1 died on `test_ollama_admission_wait_does_not_consume_request_timeout`, isolated pass (0.28s, RC=0) → pre-existing timing flake.
- Attempt 2 died on two DIFFERENT tests in the same run. Both pass in isolation.
- Three different tests failing across two runs of an unchanged diff, all green alone, is `pytest-randomly` surfacing shared test state (tracked as task #19, pre-existing, not scoped to this PR).
- Attempt 3 ran alone (no concurrent suite contending for CPU) and passed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)