### PR TITLE
fix(ci): arm the 33 packages/core test files no workflow ever ran

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -446,6 +446,32 @@ jobs:
           cd apps/${{ matrix.app }}
           npm run test:coverage:check
 
+      # WS4 governance: `packages/core` is the shared design-system (tokens,
+      # ThemeProvider, SystemPulse, ComplianceRadar, FactBadge, …) that every
+      # workspace/portal page renders through. It shipped 33 test files / 123
+      # tests that NO workflow ever executed: apps/mouth's vitest config scopes
+      # `include` to `src/**`, and packages/core/vitest.config.ts had no caller.
+      # Built, never armed (cicatrix-superscar #2) — a green CI was asserting
+      # nothing about the components WS2/WS3 landed.
+      #
+      # Deliberately a STEP of the already-required `Frontend Tests (Next.js)
+      # (mouth, true)` leg, NOT a new job or matrix entry: branch protection
+      # pins required contexts by NAME, so a new name would be born unrequired
+      # and would need a settings change nobody would make (W69 — required
+      # checks disarmed). Attaching here means it gates from the merge onward.
+      #
+      # `cd packages/core` resolves vitest/jsdom/@vitejs/plugin-react upward
+      # from the ROOT node_modules (verified: nothing is nested under
+      # apps/mouth, and packages/core/node_modules holds no packages), so the
+      # existing root `npm install` above is all the setup it needs. No
+      # coverage gate: packages/core has no established coverage target yet —
+      # same posture as the admin-dashboard leg.
+      - name: Run packages/core tests (shared design-system suite)
+        if: matrix.app == 'mouth'
+        run: |
+          cd packages/core
+          npx vitest --run
+
       - name: Upload coverage
         if: matrix.coverage
         uses: codecov/codecov-action@v7


### PR DESCRIPTION
## What

`packages/core` — the shared design system every kita./my. page renders through — ships **33 test files / 123 tests that no workflow has ever executed**.

`apps/mouth`'s vitest config scopes `include` to `src/**`, and `packages/core/vitest.config.ts` had no caller anywhere in `.github/workflows/`. So every component the WS2/WS3 train landed (`SystemPulse`, `ComplianceRadar`, `FactBadge`, `ThemeProvider`, `MatterCard`, …) has had a test suite that green CI was silently not running. Cicatrix superscar **#2 — built ≠ armed**.

## Measured, not assumed

| check | result |
|---|---|
| suite health before arming | **33 files / 123 tests green, ~40s** |
| does the step bite? | injected a failing test → `npx vitest --run` exits **1** |
| dependency resolution | vitest / jsdom / `@vitejs/plugin-react` / `@testing-library/react` all in **root** `node_modules`, nothing nested under `apps/mouth`, and `packages/core/node_modules` holds no packages — so `cd packages/core` resolves upward and the existing root `npm install` is the only setup needed |
| `actionlint` | RC=0 |

## Why a step, and not a new job

Branch protection pins required contexts **by name**. A new job or matrix entry would be born as a *new* check name — absent from `required_status_checks.contexts`, therefore not required, and it would stay that way until someone edits repo settings (W69, required checks disarmed). Attaching it to the already-required `Frontend Tests (Next.js) (mouth, true)` leg means it gates from this merge onward, with no settings change and no second arming step.

## Relationship to #3227 (checked before opening, not after)

**#3227 also runs the `packages/core` suite** — `npm run test:coverage -w packages/core` — so I checked whether this PR was redundant before opening it. It is not, and the difference is the whole point of this one:

- #3227 puts it in a **new job**, `packages-core-tests` / *"Shared Core Package Tests"*. That name is not among the 25 contexts in `required_status_checks`, so it is born **unrequired** — it would report, never block, until someone edits repo settings (W69 again).
- This PR attaches to a leg that is **already required**, so it gates from merge with no settings change.

They are complementary: #3227 brings new tests, `packages/core` devDependencies, workspace membership and a coverage gate; this brings the required-check attachment. Different regions of `tests.yml` (a step inside `frontend-tests` vs. a new job block), so no textual conflict expected. If both land, the core suite runs twice — ~40s, cheap next to leaving it ungated. Flagged on #3227 so the end state is chosen rather than defaulted.

## Scope

One file, one step, 26 lines — 25 of which are the comment explaining the two traps above so the next person doesn't "tidy" it into a separate job.

Closes the *core tests in CI* item of WS4 governance (`docs/design/2026-07-19-garuda-os-unified-surfaces/PLAN.md`).
