### PR TITLE
fix(sota): m13_weekly repo-root resolution — export the var, drop the off-by-one

### DIFF
--- a/apps/backend-rag/backend/services/sota_loop/m13_weekly.py
+++ b/apps/backend-rag/backend/services/sota_loop/m13_weekly.py
@@ -31,12 +31,47 @@ logger = logging.getLogger("sota.m13.weekly")
 
 
 def _repo_root() -> Path:
-    """Resolve monorepo root — set by wr2-cron-wrapper.sh as NUZANTARA_REPO_ROOT."""
+    """Resolve monorepo root — set by wr2-cron-wrapper.sh as NUZANTARA_REPO_ROOT.
+
+    W105-shaped fix (2026-07-27): the wrapper resolves REPO_ROOT for its own
+    `cd` but historically never exported it, so this always fell through to a
+    `Path(__file__).resolve().parents[N]` guess — and that guess was itself
+    off by one (parents[4] from this file lands on `apps/`, not repo root),
+    which is exactly how `research/sota-social-2026-v1/` output ended up at
+    `apps/research/sota-social-2026-v1/` for weeks. Same shape as the cure in
+    scripts/agent_start.py (#3197, merge 3fbef8c085) — signature-guarded git
+    derivation instead of a fragile parents[N] count. Note the git PLUMBING
+    differs from infra/claude-hooks/worktree_isolation.py::_derive_repo_root
+    on purpose: that hook wants "where is MAIN" (so `--git-common-dir`, which
+    resolves to the shared admin dir even from inside a worktree, is correct
+    for it); this script wants "where is the checkout I am actually running
+    from" (so `--show-toplevel`, which resolves to the current worktree's own
+    root, is correct here) — verified they diverge inside a worktree. Two
+    tools solving different questions are allowed to pick different git
+    plumbing; they'd be wrong to invent two different answers to the SAME
+    question. The wrapper now also exports NUZANTARA_REPO_ROOT directly
+    (scripts/wr2-cron-wrapper.sh), so this derivation is the fallback path,
+    not the primary one in production.
+    """
     env = os.environ.get("NUZANTARA_REPO_ROOT")
     if env:
         return Path(env)
-    # Fallback: from backend/services/sota_loop/m13_weekly.py go 4 up.
-    return Path(__file__).resolve().parents[4]
+    try:
+        tl = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=Path(__file__).resolve().parent,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if tl.returncode == 0 and tl.stdout.strip():
+            root = Path(tl.stdout.strip())
+            if (root / "scripts" / "agent_start.py").is_file():
+                return root
+    except Exception:
+        pass
+    # Last-resort fallback: from backend/services/sota_loop/m13_weekly.py go 5 up.
+    return Path(__file__).resolve().parents[5]
 
 
 async def kill_switch_on(conn) -> bool:

--- a/apps/backend-rag/backend/tests/unit/services/sota_loop/test_m13_weekly_repo_root.py
+++ b/apps/backend-rag/backend/tests/unit/services/sota_loop/test_m13_weekly_repo_root.py
@@ -1,0 +1,95 @@
+"""Tests for m13_weekly.py's `_repo_root()` — the path-resolution bug found
+2026-07-27 while classifying Pro's permanently-dirty working tree (task #64).
+
+Context: `wr2-cron-wrapper.sh` resolved `REPO_ROOT` for its own `cd` but never
+exported it as `NUZANTARA_REPO_ROOT` for the child python process, so
+`_repo_root()` always fell through to `Path(__file__).resolve().parents[N]` —
+and that fallback was itself off by one (parents[4] from this file lands on
+`apps/`, not the repo root). Both bugs stacked to write this module's weekly
+report to `apps/research/sota-social-2026-v1/` instead of
+`research/sota-social-2026-v1/` for several weeks.
+
+The fix, same shape as scripts/agent_start.py's cure (#3197, W105): prefer
+the env var, then a signature-guarded `git rev-parse --show-toplevel`
+derivation (deliberately NOT `--git-common-dir` — that resolves to the MAIN
+checkout even from inside a worktree, which is what
+infra/claude-hooks/worktree_isolation.py wants for ITS question ("where is
+main"); this module wants "where is the checkout I am actually running
+from", which `--show-toplevel` answers correctly and `--git-common-dir` does
+not), then the corrected file-relative guess as a last resort.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from backend.services.sota_loop.m13_weekly import _repo_root
+
+_THIS_REPO_ROOT = Path(__file__).resolve().parents[7]
+
+
+def test_env_var_wins_when_set(monkeypatch) -> None:
+    monkeypatch.setenv("NUZANTARA_REPO_ROOT", "/some/explicit/override")
+    assert _repo_root() == Path("/some/explicit/override")
+
+
+def test_show_toplevel_derivation_finds_the_real_repo_root(monkeypatch) -> None:
+    """INNOCENCE: with no env var, a real invocation inside this checkout
+    must land on the actual repo root — not `apps/`, not any other ancestor.
+    This is the case the old off-by-one fallback got wrong, and it must also
+    be the CURRENT checkout's root, not necessarily main's (worktree-safe —
+    `--show-toplevel`, not `--git-common-dir`; the two diverge inside a
+    worktree, verified live: `--git-common-dir` in this very worktree
+    resolves to the outer main checkout's .git, `--show-toplevel` resolves
+    to this worktree's own root)."""
+    monkeypatch.delenv("NUZANTARA_REPO_ROOT", raising=False)
+    root = _repo_root()
+    assert root == _THIS_REPO_ROOT
+    assert (root / "scripts" / "agent_start.py").is_file()
+    assert root.name != "apps"
+
+
+def test_final_fallback_math_is_correct_if_derivation_is_ever_unavailable(
+    monkeypatch,
+) -> None:
+    """GUILT-style regression pin: even if git ever becomes unavailable (the
+    only path the old bug could hide in), the literal parents[N] count must
+    still land on the repo root, not on `apps/`. This is the exact arithmetic
+    that was wrong before (parents[4] -> apps/); pinning parents[5] here
+    means a future refactor that moves this file will fail this test loudly
+    instead of silently mis-writing output again."""
+    import backend.services.sota_loop.m13_weekly as m13_weekly_module
+
+    module_file = Path(m13_weekly_module.__file__).resolve()
+    assert module_file.parents[5] == _THIS_REPO_ROOT
+    assert module_file.parents[4].name == "apps"
+
+
+def test_derivation_rejects_a_toplevel_without_the_repo_signature(monkeypatch, tmp_path) -> None:
+    """GUILT: if `git rev-parse --show-toplevel` ever resolves to somewhere
+    that is NOT this repo (e.g. this file got HOME-fork-copied to a location
+    inside an unrelated git checkout — cicatrix superscar #1), the signature
+    guard must refuse to trust it and fall through to the file-relative
+    fallback, rather than silently writing output under a foreign root. This
+    is exercised by mocking the subprocess boundary directly (the function
+    hardcodes cwd=this-file's-own-directory, so a plain chdir in the test
+    would not reach the code path it claims to exercise — the mock is the
+    honest way to inject the failure)."""
+    monkeypatch.delenv("NUZANTARA_REPO_ROOT", raising=False)
+    foreign_root = tmp_path / "not-nuzantara"
+    foreign_root.mkdir()
+
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = f"{foreign_root}\n"
+    monkeypatch.setattr(
+        subprocess, "run", MagicMock(return_value=fake_result)
+    )
+
+    root = _repo_root()
+
+    # Rejected the mocked-foreign toplevel and fell all the way through to
+    # the file-relative fallback — which lands on the real repo root.
+    assert root != foreign_root
+    assert root == _THIS_REPO_ROOT

--- a/scripts/tests/test_wr2_cron_wrapper.py
+++ b/scripts/tests/test_wr2_cron_wrapper.py
@@ -128,3 +128,41 @@ def test_pg_proxy_unreachable_writes_heartbeat_matching_log(tmp_path) -> None:
     hb = _heartbeat(tmp_path, "pro.wr2_wrapper_guard.test.fake.module")
     assert hb["status"] == "error"
     assert "15432" in hb["note"]
+
+
+def test_repo_root_is_exported_before_either_guard_can_exit(tmp_path) -> None:
+    """Regression pin for the 2026-07-27 finding (task #64): REPO_ROOT was
+    resolved for the wrapper's own `cd` but never re-exported, so every
+    python module reading NUZANTARA_REPO_ROOT via os.environ always fell
+    through to its own file-relative guess — confirmed live on
+    m13_weekly.py, which wrote its weekly report to apps/research/... instead
+    of research/... for weeks.
+
+    Both existing guards above (DATABASE_URL_LOCAL missing, pg-proxy down)
+    can exit the wrapper before it ever reaches `exec ... python -m
+    $MODULE`, so there is no way to observe the export by inspecting the
+    child process's environment through a real end-to-end run without a live
+    Postgres proxy. This is a static check instead: the export must appear
+    in the source BEFORE both guard blocks, so the fix holds regardless of
+    which guard (if any) later exits — the exact invariant this fix needs.
+    A guard reordered above the export in the future would fail this test
+    even though every existing behavioral test above would still pass."""
+    lines = _WRAPPER.read_text(encoding="utf-8").splitlines()
+
+    export_idx = next(
+        (i for i, line in enumerate(lines) if line.strip().startswith("export NUZANTARA_REPO_ROOT=")),
+        None,
+    )
+    guard1_idx = next(
+        (i for i, line in enumerate(lines) if "DATABASE_URL_LOCAL not set" in line), None
+    )
+    guard2_idx = next(
+        (i for i, line in enumerate(lines) if "cannot reach 127.0.0.1:15432" in line), None
+    )
+
+    assert export_idx is not None, "export NUZANTARA_REPO_ROOT= line not found in the wrapper"
+    assert guard1_idx is not None and guard2_idx is not None, (
+        "one of the two known guards moved or was renamed — update this test's anchors"
+    )
+    assert export_idx < guard1_idx
+    assert export_idx < guard2_idx

--- a/scripts/wr2-cron-wrapper.sh
+++ b/scripts/wr2-cron-wrapper.sh
@@ -46,6 +46,13 @@ if [[ "${WR2_CRON_ENABLED:-true}" == "false" || "${!ORGAN_VAR:-true}" == "false"
 fi
 
 REPO_ROOT="${NUZANTARA_REPO_ROOT:-$HOME/nuzantara}"
+# Resolved above for our own `cd` below, but never re-exported for the child
+# python process — every module reading NUZANTARA_REPO_ROOT via os.environ
+# always fell through to its own file-relative guess. Confirmed live 2026-07-27:
+# m13_weekly.py's guess landed one directory too shallow (apps/ instead of
+# repo root), writing its weekly report to apps/research/... instead of
+# research/.... Export it so the resolved value actually reaches the module.
+export NUZANTARA_REPO_ROOT="$REPO_ROOT"
 SECRETS_FILE="${NUZANTARA_SECRETS:-$HOME/.nuzantara-secrets.env}"
 LOG_DIR="${WR2_LOG_DIR:-$HOME/.openclaw/workspace/logs/war-room-v2}"
 mkdir -p "$LOG_DIR"


### PR DESCRIPTION
## Summary
Task #64 item 5, held separately per sequencing. Real bug traced to two stacked defects, both fixed:

1. **`scripts/wr2-cron-wrapper.sh`** resolved `REPO_ROOT` for its own `cd` but never re-exported it as `NUZANTARA_REPO_ROOT` — every python module reading that env var always saw `None`, regardless of what the wrapper itself correctly resolved.
2. **`m13_weekly.py`'s own fallback**, `Path(__file__).resolve().parents[4]`, was itself off-by-one (lands on `apps/`, not repo root, from this file's actual location).

Both stacked to write the weekly SOTA report to `apps/research/sota-social-2026-v1/` instead of `research/sota-social-2026-v1/` for several weeks (the 2 stray files were already relocated in a prior commit, not part of this PR).

**Not fixed as a bigger off-by-one.** `parents[5]` would just be the same fragile construct — move the file once, it silently breaks again with no error. This repo already cured the identical shape once (`scripts/agent_start.py`, #3197/W105): derive from git plumbing, signature-guarded, kept as fallback only.

**One deliberate divergence from that precedent, verified live:** `infra/claude-hooks/worktree_isolation.py::_derive_repo_root` uses `--git-common-dir` because it wants "where is MAIN" (correct for its job — protecting the main checkout even when invoked from a worktree). This module wants "where is the checkout I'm actually running from" — `--show-toplevel` answers that; `--git-common-dir` does not (confirmed: inside `.worktrees/ops-64b`, `--git-common-dir` resolves to the outer main checkout's `.git`, `--show-toplevel` resolves to the worktree's own root). Two tools answering *different* questions correctly pick different plumbing; they'd only be wrong to invent two answers to the *same* question.

**Scope, deliberately held:** `grep -rl NUZANTARA_REPO_ROOT` also hits `m13_checkpoint.py`, `m13_monthly.py`, `codex_visual_dispatch.py`, `codex_xhigh_fix.py`, `codex_visual_orchestrator.py`, `codex_tri_llm_review.py`. None of those are touched here — same pattern, individually unverified, not asserted broken and not silently fixed either.

## Tests
- `apps/backend-rag/backend/tests/unit/services/sota_loop/test_m13_weekly_repo_root.py` (new) — env-var precedence, real `--show-toplevel` derivation lands on the actual repo root (not `apps/`), the corrected `parents[5]` fallback math is pinned literally, and a mocked-foreign-toplevel case confirms the signature guard rejects it rather than trusting it. Caught its own off-by-one (`parents[6]` vs `parents[7]` from the deeper test-file path) on first run — fixed after actually running it, not by eyeballing.
- `scripts/tests/test_wr2_cron_wrapper.py` (extended) — static ordering check: the `export NUZANTARA_REPO_ROOT=` line must appear before both existing guard blocks in the wrapper's source, so the export holds regardless of which guard (if any) later exits. A full behavioral E2E wasn't feasible here — both existing guards can exit before the wrapper ever reaches `exec ... python -m $MODULE`, so there's no way to observe the export through the child process without a live Postgres proxy.

All 4 tests run locally before shipping: `4 passed` (new file) + `3 passed, 1 skipped` (existing wrapper suite, pg-proxy skip is its documented self-skip behavior, unrelated to this change).

## Method
Shipped server-side via the GitHub contents API — CI is the authoritative gate regardless of push path (same rationale as #3242/#3244/#3246). Verified main hadn't drifted on any of these 3 touched files between branching and shipping, and diffed every shipped file back against what was tested locally: byte-identical.

## Test plan
- [x] All 4 tests passed locally against the exact content shipped (verified byte-identical post-ship)
- [x] `bash -n scripts/wr2-cron-wrapper.sh` — syntax OK
- [x] `python3 -m py_compile` on `m13_weekly.py` — OK
- [ ] CI required checks (will run automatically on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)