### PR TITLE
fix(sota-social): capture kpi_timeline.csv + weekly_report_2026-07-25.md from Pro's misplaced output

### DIFF
--- a/research/sota-social-2026-v1/kpi_timeline.csv
+++ b/research/sota-social-2026-v1/kpi_timeline.csv
@@ -1,0 +1,2 @@
+date,instagram_lead,instagram_authority,instagram_audience,linkedin_lead,linkedin_authority,linkedin_audience,tiktok_lead,tiktok_authority,tiktok_audience,threads_lead,threads_authority,threads_audience,newsletter_lead,newsletter_authority,newsletter_audience
+2026-07-25,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0

--- a/research/sota-social-2026-v1/weekly_report_2026-07-25.md
+++ b/research/sota-social-2026-v1/weekly_report_2026-07-25.md
@@ -1,0 +1,29 @@
+# SOTA Weekly Report — 2026-07-25
+
+
+## Deltas vs baseline (per channel × pillar)
+
+### instagram
+- [OK] lead: +0.0%
+- [OK] authority: +0.0%
+- [OK] audience: +0.0%
+
+### linkedin
+- [OK] lead: +0.0%
+- [OK] authority: +0.0%
+- [OK] audience: +0.0%
+
+### tiktok
+- [OK] lead: +0.0%
+- [OK] authority: +0.0%
+- [OK] audience: +0.0%
+
+### threads
+- [OK] lead: +0.0%
+- [OK] authority: +0.0%
+- [OK] audience: +0.0%
+
+### newsletter
+- [OK] lead: +0.0%
+- [OK] authority: +0.0%
+- [OK] audience: +0.0%


### PR DESCRIPTION
## Summary
- Task #64 (Pro working-tree triage) classified `apps/research/sota-social-2026-v1/{kpi_timeline.csv,weekly_report_2026-07-25.md}` on Pro's disk as real artifacts never captured (root cause fixed separately in #3251 — `m13_weekly.py`'s repo-root fallback landed output under `apps/research/` instead of `research/`).
- Both files relocated to their intended path (`research/sota-social-2026-v1/`), content MD5-verified byte-identical to Pro's copies before shipping.
- Shipped server-side (GitHub contents API) — content-only capture, no code change; CI still runs the full required suite regardless of push path.
- `apps/research/` left in place on Pro (no delete on a live H24 runtime); a follow-up sweep can remove the stray copy once this is confirmed on main.

## Test plan
- [x] MD5 of local copy == MD5 of Pro source, both files
- [x] Confirmed absent on `origin/main` before shipping (`git cat-file -e`)
- [x] Parent directory `research/sota-social-2026-v1/` already tracked on main — no new-directory edge case
- [ ] CI required checks (content-only diff, no Python/TS surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)