### PR TITLE
chore(nb-health): 2026-07-27 daily curation report

### DIFF
--- a/research/nb-health/2026-07-27-curation.md
+++ b/research/nb-health/2026-07-27-curation.md
@@ -1,0 +1,63 @@
+# NB Arsenal Health + Curation Report — 2026-07-27 (daily + Mode C full pass)
+
+## Health Summary
+- Total: 58 notebooks (inventory 2026-07-26T20:01 UTC), 5,670 sources (+26 vs yesterday's 5,644)
+- Healthy: 57 | Empty: 1 | Broken: 0 | Stale: 0 (schema has no stale flag — not computed, per historical convention)
+- Near-cap (500/500): 3 — NB-INTEL-AIResearch, NB-INTEL-Press, NB-INTEL-AIResearch-2 (Overflow), unchanged from yesterday, zero headroom
+
+## NB-INTEL family (deltas vs 2026-07-26)
+- Immigration: 190 (+6) | Tax: 185 (+3) | Regulation: 123 (+1) — all have room
+- Press: 500/500 AT CAP (unchanged) | AIResearch: 500/500 AT CAP (unchanged) | AIResearch-2 Overflow: 500/500 AT CAP (unchanged)
+- Press-2 Overflow: 1 src, unchanged — feeder still appears inactive/unrouted
+
+## Newly empty / transitions
+- "Labor Law Research May 2025" (bafceb4f) — still 0 sources, unchanged
+
+## Mode C — Full pass, all 5 NB-INTEL
+
+### Data coverage caveat
+Titles read in full for Immigration; partial for Tax (~30/185, first page); Press/Regulation/AIResearch
+titles NOT visible this pass — inventory JSON paginates past the 2-read hard budget for this run.
+Findings below are limited strictly to what was actually read.
+
+### Near-dup / exact-title clusters (eyeballed)
+1. CLUSTER Immigration-LHKPN — 3 exact-title-dup pairs: "LHKPN FELUCIA SENGKY RATNA (KEPALA KANTOR
+   WILAYAH)" x2, "LHKPN GEDE DUDY DUWITA (KEPALA KANTOR IMIGRASI) 2025" x2, "LHKPN R. HARYO SAKTI
+   (KEPALA KANTOR IMIGRASI) 2024" x2. Reason: identical titles adjacent in listing.
+2. CLUSTER Immigration-PeraturanMenteri — 14 exact-title-dup pairs: Peraturan BKPM No.6/2026, Peraturan
+   Dirjen Imigrasi No.14/2025 + IMI-0367.GR.01.01, Peraturan Kepala BPJS No.7/2026, Peraturan Menteri
+   Hukum No.8/9/10/12/14/22 (2023/2025/2026, both "Hukum" and "Hukum dan HAM"/"Hak Asasi Manusia"
+   phrasings), Peraturan Menteri Imigrasi dan Pemasyarakatan No.3/2026, Peraturan Menteri Kesehatan
+   No.11/2026 — each title appears exactly twice consecutively.
+3. CLUSTER Immigration-Permenkumham/RUU — Permenkumham No.9/2024 x2, Permenkumham No.10/2026 x2, plus
+   a 3-way near-dup on citizenship-bill titles ("[RUU] Kewarganegaraan Republik Indonesia" / "[RUU]
+   Rancangan Undang-Undang..." x2 / "[Rancangan Undang-Undang] Rancangan Undang Undang..." x2).
+4. CLUSTER Tax-Coretax — "Dari layar lebar menuju era perpajakan digital: Coretax DJP menata masa depan
+   fiskal Indonesia - ANTARA News Riau" appears twice consecutively in visible Tax titles.
+
+**Caveat on all 4 clusters**: regulatory citations must stay verbatim per policy. These are proposed
+merges (keep 1, remove dup) ONLY if source URL confirms a true duplicate ingest — NOT summarization.
+Verify URL/canonical link before any `nlm rm`. Propose only, no action taken.
+
+### Data-quality flag (not a dedup proposal)
+- Immigration NB has ~124 of its 190 sources titled `nlm_feed_<hash>.txt` (raw feeder dump
+  placeholders, no resolved title) — roughly 2/3 of the notebook. Suggests the feeder pipeline is
+  landing untitled raw text rather than resolved article titles. Worth an operator check on the
+  Immigration feeder, independent of dedup.
+
+### Summarization (Press only, clusters >=10)
+- Not assessed this pass — Press titles unreadable within the 2-read budget. Prior-day proposals
+  (Golden Visa ~14, Second Home Visa ~10, Marketplace-tax ~12, from 2026-07-26) presumed still pending
+  operator review; not re-verified today.
+
+### Stale sources (>90d)
+- Not determinable from titles-only inventory (no per-source date field). Unchanged limitation.
+
+## Operator actions
+- [ ] Verify URLs for the ~19 Immigration exact-title-dup pairs above before any removal (verbatim rule)
+- [ ] Investigate Immigration feeder producing untitled `nlm_feed_*.txt` sources (~124/190)
+- [ ] Carry-over from 2026-07-26: Press-2 overflow feeder inactive (1 src); AIResearch+AIResearch-2 both
+      at cap, zero headroom
+- [ ] Full Press/Regulation/AIResearch title sweep deferred — needs a pass with larger read budget
+
+No Telegram sent (broken=0, below 3-broken threshold).


### PR DESCRIPTION
## Summary
- Daily nb-curator pass (Mode B health-check + Mode C dedup/summarize full pass).
- 58 NBs / 5,670 sources (+26), 0 broken, 1 empty (unchanged).
- Full title read on Immigration + partial Tax surfaces 22 exact-title-dup pairs in
  regulatory citations (LHKPN, Peraturan Menteri, Permenkumham/RUU) + 1 in Tax —
  propose-only, pending URL verification (verbatim-citation rule preserved).
- Press/Regulation/AIResearch title sweep deferred (paginated past this run's read budget).

Docs-only addition (`research/nb-health/`), no code paths touched.

## Test plan
- [x] pre-commit hooks passed locally
- [x] pre-push path-aware gate: research/** allowlisted, full suite skipped by design
- [ ] CI required checks green (auto-merge armed)