### PR TITLE
fix(hooks+regulatory-watcher): pin W105's orphan-directory case + make recover_delta() evasion visible (#68)

### DIFF
--- a/infra/claude-hooks/test_w105_nested_worktree_removal.py
+++ b/infra/claude-hooks/test_w105_nested_worktree_removal.py
@@ -43,6 +43,23 @@ permanent false block, fixed by making it consult `_looks_like_worktree` first.
 `_worktrees_strictly_inside` applies the same entity test to its dead-registry
 filesystem fallback.
 
+W105-#68 (2026-07-27), the LIVE-registry sibling of the round-2 dead-registry case
+above. Measured live on Pro: a session created `.worktrees/regulatory-watcher-2026-07-25/`
+directly (never `git worktree add`) to stage a manual regulatory-scan result, then tried
+to clean up its own scratch dir and got blocked — with the registry very much ALIVE
+(other real worktrees present). `test_orphan_directory_allowed_with_live_registry`
+below reproduces that exact shape (a `.worktrees/<name>` directory with no `.git`,
+absent from `git worktree list`, sitting as a SIBLING of a real registered worktree —
+not nested inside one) against the round-2-fixed hook and confirms it already resolves
+correctly: `_resolve_under_worktrees` still falls through to the legacy `rel.parts[0]`
+truncation for this candidate (that fallback line does not itself distinguish "registry
+dead" from "registry alive but this path just isn't in it"), but `_worktree_is_dirty`'s
+`_looks_like_worktree` gate (the round-2 cure) catches it downstream and reports
+"not dirty" regardless — so the removal is correctly ALLOWED. This case was previously
+UNPINNED: `_degraded_registry_round2`'s `plain` case covers the same directory SHAPE
+but only under a starved registry. Pinning the live-registry path here so a future
+refactor of the fallback cannot silently regress the incident that actually happened.
+
 Run:  python3 infra/claude-hooks/test_w105_nested_worktree_removal.py
       pytest infra/claude-hooks/test_w105_nested_worktree_removal.py -q
 """
@@ -364,17 +381,67 @@ def evaluate() -> list[str]:
     return fails
 
 
+def _orphan_directory_live_registry_case() -> list[str]:
+    """W105-#68: a `.worktrees/<name>` directory that is NOT a registered worktree
+    (no `.git`, absent from `git worktree list`), sitting as a SIBLING of a real
+    worktree — registry alive, not starved. This is the exact shape of the
+    2026-07-25 incident. GUILT case included so this pins both directions: the
+    orphan is removable, but a genuinely dirty registered worktree next to it
+    still blocks.
+    """
+    if not shutil.which("git"):
+        return []
+    fails: list[str] = []
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="w105_68_orphan_"))
+    try:
+        root, hook = _build_repo(tmp)
+        rr = str(root)
+        # a REAL worktree, so `git worktree list` is alive and non-empty.
+        real = _add_worktree(root, root / ".worktrees" / "real", "b/real")
+
+        # the orphan: plain directory, never `git worktree add`-ed, no `.git`.
+        orphan = root / ".worktrees" / "regulatory-watcher-2026-07-25" / "research" / "regulatory"
+        orphan.mkdir(parents=True)
+        (orphan / "2026-07-25-delta.json").write_text('{"fake":"delta"}\n')
+
+        if _run_hook(hook, f"rm -rf {orphan.parent.parent}", rr, rr) == 2:
+            fails.append("BIT-INNOCENT (live-registry orphan): rm -rf a `.worktrees/<x>` "
+                          "directory that is not a registered worktree, alongside a live "
+                          "registry → expected ALLOW (nothing git-tracked can be lost)")
+
+        # GUILT, same repo: the real registered worktree, made dirty, still blocks —
+        # confirms the orphan-innocence above isn't from a guard that went blind.
+        (real / "UNTRACKED.txt").write_text("real worktree's uncommitted work\n")
+        if _run_hook(hook, f"rm -rf {real}", rr, rr) != 2:
+            fails.append("WENT-BLIND (live-registry orphan sibling): rm -rf a DIRTY "
+                          "unarmed REGISTERED worktree, sitting next to the orphan case "
+                          "above → expected BLOCK")
+    finally:
+        try:
+            _git(["worktree", "prune"], tmp / "main")
+        except Exception:
+            pass
+        shutil.rmtree(tmp, ignore_errors=True)
+    return fails
+
+
 def test_w105_nested_worktree_removal():
     fails = evaluate()
     assert not fails, "W105 nested-worktree removal regressions:\n" + "\n".join(fails)
 
 
+def test_w105_68_orphan_directory_live_registry():
+    fails = _orphan_directory_live_registry_case()
+    assert not fails, "W105-#68 orphan-directory regressions:\n" + "\n".join(fails)
+
+
 if __name__ == "__main__":
-    f = evaluate()
+    f = evaluate() + _orphan_directory_live_registry_case()
     if f:
         print(f"=== {len(f)} FAIL ===")
         for x in f:
             print("  [FAIL] " + x)
         sys.exit(1)
-    print("=== W105 OK (nested removal allowed; outer, subdir and dirty-nested still blocked) ===")
+    print("=== W105 OK (nested removal allowed; outer, subdir and dirty-nested still blocked; "
+          "live-registry orphan directory allowed) ===")
     sys.exit(0)

--- a/infra/launchagents/wrappers/regulatory-watcher-run.sh
+++ b/infra/launchagents/wrappers/regulatory-watcher-run.sh
@@ -179,6 +179,21 @@ recover_delta() {
           && echo "[$(date)] W81-fix: recovered delta from branch $_wt_branch -> main" >> "$LOG"
         return 0
     fi
+    # W105-#68 (2026-07-27): an exact-name miss above is not proof nothing exists
+    # for today. Measured live 2026-07-25: a manually-produced, COMPLETE
+    # (non-partial) delta with real findings sat for two days under
+    # .worktrees/regulatory-watcher-2026-07-25/research/regulatory/, renamed to
+    # `...manual-session-DO-NOT-RECOVER` specifically to defeat the glob above —
+    # and nothing logged that it had happened, so the evasion was indistinguishable
+    # from an honest absence. Do NOT auto-recover a near-miss (an unverified rename
+    # could be untrustworthy content the operator meant to discard) but DO log it,
+    # so the next reader of this log can go look instead of assuming a clean day.
+    setopt local_options null_glob
+    local -a _near_misses
+    _near_misses=( "$HOME"/nuzantara/.worktrees/*/research/regulatory/*"$DATE"*(N.om) )
+    if (( ${#_near_misses} > 0 )); then
+        echo "[$(date)] W105-#68: ${#_near_misses} file(s) under .worktrees/*/research/regulatory/ mention $DATE but do not match the exact expected name $DELTA_BASENAME — NOT auto-recovered, needs a manual look: ${_near_misses[*]}" >> "$LOG"
+    fi
     return 1
 }
 

--- a/scripts/tests/test_regulatory_watcher_recover_delta.py
+++ b/scripts/tests/test_regulatory_watcher_recover_delta.py
@@ -1,0 +1,136 @@
+"""Test for `recover_delta()` in infra/launchagents/wrappers/regulatory-watcher-run.sh.
+
+Context (task #68, 2026-07-27): a manually-produced, COMPLETE regulatory delta for
+2026-07-25 sat for two days under `.worktrees/regulatory-watcher-2026-07-25/research/
+regulatory/`, renamed to `2026-07-25-delta.json.manual-session-DO-NOT-RECOVER`
+specifically to defeat `recover_delta()`'s exact-name glob — and nothing in the log
+said so. The fix adds a near-miss detector: files under `.worktrees/*/research/
+regulatory/` that mention today's date but do not match the exact expected basename
+get LOGGED (not auto-recovered — an unverified rename could be untrustworthy content)
+so the evasion leaves a trace instead of being indistinguishable from a quiet day.
+
+Isolation: the whole script is NOT sourced (its top-level does a live TCC probe, a
+lock-file dance and an LLM cascade). Only the `recover_delta` function body is
+extracted by marker and sourced into a throwaway zsh driver with a fake `$HOME` —
+same "test one function in isolation" approach the Python hook tests in
+infra/claude-hooks/ use via importlib, applied to the zsh side.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WRAPPER = _REPO_ROOT / "infra" / "launchagents" / "wrappers" / "regulatory-watcher-run.sh"
+
+_FUNC_RE = re.compile(r"\nrecover_delta\(\) \{.*?\n\}\n", re.DOTALL)
+
+
+def _extract_recover_delta() -> str:
+    text = _WRAPPER.read_text(encoding="utf-8")
+    m = _FUNC_RE.search(text)
+    assert m, "recover_delta() function not found in the wrapper — anchor drifted"
+    return m.group(0)
+
+
+def _run(tmp_path: Path, date: str, extra_files: dict[str, str]) -> tuple[int, str, str]:
+    """Set up `$HOME/nuzantara/.worktrees/*/research/regulatory/` per `extra_files`
+    (relative path -> content) and call `recover_delta` for `date`. Returns
+    (returncode, log contents, DELTA_JSON contents-or-empty).
+    """
+    home = tmp_path / "home"
+    for rel, content in extra_files.items():
+        p = home / "nuzantara" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    log = tmp_path / "watcher.log"
+    delta_json = tmp_path / f"{date}-delta.json"
+    (home / "nuzantara").mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=home / "nuzantara", capture_output=True)
+
+    driver = tmp_path / "driver.sh"
+    driver.write_text(
+        "#!/bin/zsh\n"
+        f"HOME={home}\n"
+        f'DATE="{date}"\n'
+        f'DELTA_BASENAME="{date}-delta.json"\n'
+        f'DELTA_JSON="{delta_json}"\n'
+        f'LOG="{log}"\n'
+        + _extract_recover_delta()
+        + "\nrecover_delta\n"
+        "exit $?\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(["zsh", str(driver)], capture_output=True, text=True, timeout=15)
+    log_text = log.read_text(encoding="utf-8") if log.exists() else ""
+    delta_text = delta_json.read_text(encoding="utf-8") if delta_json.exists() else ""
+    return proc.returncode, log_text, delta_text
+
+
+def test_no_hit_no_near_miss_logs_nothing(tmp_path) -> None:
+    """INNOCENCE: an ordinary quiet day (nothing under .worktrees/ at all) must not
+    print a W105-#68 line — that would be a false near-miss alarm on every clean run.
+    """
+    rc, log, delta = _run(tmp_path, "2026-07-25", extra_files={})
+    assert rc == 1
+    assert "W105-#68" not in log
+    assert delta == ""
+
+
+def test_exact_match_still_recovers_unchanged(tmp_path) -> None:
+    """GUILT/regression: the pre-existing exact-name recovery path must be untouched
+    by the near-miss addition — this is the behavior task #64/#3244 already relies on.
+    """
+    rc, log, delta = _run(
+        tmp_path,
+        "2026-07-26",
+        extra_files={".worktrees/some-lane/research/regulatory/2026-07-26-delta.json": '{"real":true}\n'},
+    )
+    assert rc == 0
+    assert "W81-fix: recovered delta from worktree file" in log
+    assert delta.strip() == '{"real":true}'
+    # the near-miss path must not ALSO fire when the exact match already returned.
+    assert "W105-#68" not in log
+
+
+def test_near_miss_glob_is_scoped_to_worktrees_dir(tmp_path) -> None:
+    """INNOCENCE, scope check: the near-miss glob only looks under
+    `.worktrees/*/research/regulatory/` (mirroring the exact-match glob above it) —
+    a same-date file living directly under `research/regulatory/` (the ordinary,
+    already-on-main location) must NOT trigger a W105-#68 line. That path is not a
+    stranded/quarantined candidate; it is either already captured or none of
+    recover_delta()'s business.
+    """
+    rc, log, delta = _run(
+        tmp_path,
+        "2026-07-25",
+        extra_files={
+            "research/regulatory/2026-07-25-delta.json"
+            ".manual-session-DO-NOT-RECOVER": '{"real":true,"quarantined":true}\n'
+        },
+    )
+    assert rc == 1
+    assert "W105-#68" not in log
+    assert delta == ""
+
+
+def test_near_miss_under_worktree_shaped_dir_is_logged(tmp_path) -> None:
+    """The real incident shape: `.worktrees/<name>/research/regulatory/<date>-delta
+    .json.manual-session-DO-NOT-RECOVER` — a directory that is not even a registered
+    git worktree, per task #68's guard finding. `recover_delta()` globs by
+    filesystem shape only (no `git worktree list` check), so it should already see
+    into it; the fix is making it SPEAK when what it sees does not match."""
+    rc, log, delta = _run(
+        tmp_path,
+        "2026-07-25",
+        extra_files={
+            ".worktrees/regulatory-watcher-2026-07-25/research/regulatory/"
+            "2026-07-25-delta.json.manual-session-DO-NOT-RECOVER": '{"real":true,"quarantined":true}\n'
+        },
+    )
+    assert rc == 1  # never auto-recovered — content is unverified by shape alone
+    assert delta == ""  # DELTA_JSON must stay empty, not silently populated
+    assert "W105-#68" in log
+    assert "2026-07-25-delta.json.manual-session-DO-NOT-RECOVER" in log
+    assert "NOT auto-recovered" in log


### PR DESCRIPTION
## Summary

Task #68 (born from task #67's diagnosis): tracing why a real 2026-07-25 regulatory
finding sat quarantined for two days instead of shipping, found a false block from
`worktree_isolation.py`'s W80 guard on a directory that was never a real git worktree,
followed by a session defeating `recover_delta()`'s recovery glob rather than
committing the file or surfacing the block.

**Finding 1 — the guard is already fixed, just unpinned.** Empirically verified
(not just read) against the CURRENT hook: the W105 round-2 fixes (#3156, #3174,
merged 2026-07-26 — the day AFTER this incident) already make
`_worktree_is_dirty()` refuse to answer for a path that isn't a real worktree root
(`_looks_like_worktree()` gate), so a live-registry orphan `.worktrees/<name>`
directory is already correctly ALLOWED to be removed. No code fix needed there.
What was missing: a regression test for this specific shape — the only existing
coverage (`_degraded_registry_round2`'s `plain` case) exercises the SAME directory
shape but only under a starved `git worktree list`, not the live-registry case
that actually happened. Added `test_w105_68_orphan_directory_live_registry`
(guilt+innocence, same repo) to pin it.

**Finding 2 — the evasion surface, which needed a real fix.** `recover_delta()`
globs for an EXACT basename match under `.worktrees/*/research/regulatory/`. A
file that carries today's date but a different name (the actual incident: renamed
to `...manual-session-DO-NOT-RECOVER` to defeat this exact glob) is silently
invisible — the log says nothing, so an evasion looks identical to an honest quiet
day. Added a second, narrower glob that fires only when the primary recovery
already failed: any near-miss gets LOGGED (count + paths), never auto-recovered
(an unverified rename could be untrustworthy content — this makes the evasion
visible, it does not trust it).

## What this does NOT do
Does not touch the still-quarantined `2026-07-25-delta.json.manual-session-DO-NOT-RECOVER`
file itself or its one still-uncaptured finding (SE-8/PJ/2026) — that's a data/repair
question left for task #67's follow-up, not this structural fix.

## Test plan
- [x] `python3 infra/claude-hooks/test_w105_nested_worktree_removal.py` — all cases pass, including the new one (also ran via `pytest -v`, 2 passed)
- [x] `pytest scripts/tests/test_regulatory_watcher_recover_delta.py -v` — 4/4 pass (quiet day, exact-match unchanged, out-of-scope near-miss ignored, in-scope near-miss logged+not-recovered)
- [x] `zsh -n infra/launchagents/wrappers/regulatory-watcher-run.sh` — syntax OK
- [ ] CI required checks

Note for whoever redeploys: `infra/launchagents/wrappers/regulatory-watcher-run.sh` is repo canon; SessionStart proprioception currently flags `~/scripts/regulatory-watcher-run.sh` on M5 as diverged (pre-existing P1, not introduced here) — needs propagation after merge, same pattern as `wr2-cron-wrapper.sh` after #3251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)