### PR TITLE
feat(infra): promote 15 cron-agent-python job files to repo (task #17)

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -429,6 +429,96 @@
       "repo": "infra/launchagents/wrappers/garuda-gap-detector.sh",
       "_note": "W104 class-audit (2026-07-25): same decorative `redis-cli ping` gate as garuda-consumer.sh, armed by com.garuda.gap-detector.twice-daily. Same cure, same 3/3 proof.",
       "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/daily_ops.py",
+      "repo": "scripts/cron-agent-python/daily_ops.py",
+      "_note": "task #17 promotion (2026-07-26): part of the 15-file cron-agent-python census (16 crontab lines through run.sh, only log-anomaly-detector had a repo twin before this). Reads client_name via a runtime .get() accessor, no hardcoded identity — pattern+structural double-pass clean.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/pajak_monitor.py",
+      "repo": "scripts/cron-agent-python/pajak_monitor.py",
+      "_note": "task #17 promotion (2026-07-26). Fixed in the same commit: a hardcoded absolute path /Users/nuzantara/scripts (fingerprints the ops host's username/home layout, this organism's own HOME-fork anti-pattern) — now derived from __file__.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/intel_radar.py",
+      "repo": "scripts/cron-agent-python/intel_radar.py",
+      "_note": "task #17 promotion (2026-07-26). Clean on both passes; DSN via os.getenv(DATABASE_URL), no hardcoded credentials.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/fly_watcher.py",
+      "repo": "scripts/cron-agent-python/fly_watcher.py",
+      "_note": "task #17 promotion (2026-07-26). Clean on both passes.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/client_health_monitor.py",
+      "repo": "scripts/cron-agent-python/client_health_monitor.py",
+      "_note": "task #17 promotion (2026-07-26). Clean on both passes; no direct creds, all CRM/DB access via agent_job's shared helpers.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/compliance_ops.py",
+      "repo": "scripts/cron-agent-python/compliance_ops.py",
+      "_note": "task #17 promotion (2026-07-26). Reads client_name via runtime .get() accessors, no hardcoded identity.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/system_doctor.py",
+      "repo": "scripts/cron-agent-python/system_doctor.py",
+      "_note": "task #17 promotion (2026-07-26). Clean on both passes. Its single rule (telegram_alert side-effect AND status==\"ok\" simultaneously) gates tech_orchestrator's deploy path — see #20.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/bi_exchange_rate.py",
+      "repo": "scripts/cron-agent-python/bi_exchange_rate.py",
+      "_note": "task #17 promotion (2026-07-26). Clean on both passes.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/oss_monitor.py",
+      "repo": "scripts/cron-agent-python/oss_monitor.py",
+      "_note": "task #17 promotion (2026-07-26). Fixed in the same commit: a hardcoded absolute path /Users/nuzantara/scripts — now derived from __file__, same fix as pajak_monitor.py/imigrasi_monitor.py.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/imigrasi_monitor.py",
+      "repo": "scripts/cron-agent-python/imigrasi_monitor.py",
+      "_note": "task #17 promotion (2026-07-26). Fixed in the same commit: a hardcoded absolute path /Users/nuzantara/scripts — now derived from __file__, same fix as pajak_monitor.py/oss_monitor.py.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/intel_feed_processor.py",
+      "repo": "scripts/cron-agent-python/intel_feed_processor.py",
+      "_note": "task #17 promotion (2026-07-26). Clean on both passes.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/fact_checker.py",
+      "repo": "scripts/cron-agent-python/fact_checker.py",
+      "_note": "task #17 promotion (2026-07-26). Clean on both passes.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/tdd_pipeline.py",
+      "repo": "scripts/cron-agent-python/tdd_pipeline.py",
+      "_note": "task #17/#42 promotion (2026-07-26). Fixed in the same commit: success path logged only a hash via log_step() while the failure path logged plaintext — 3mo/14 runs/18 successful writes into the live checkout, none reconstructable. Added its own explicit plaintext success log (filename + tests_added + test path, none PII) mirroring the failure branch's shape; shared log_step() hashing left untouched (used by PII-handling siblings). Uses --dangerously-skip-permissions unattended — see #42.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/vision_doc_extractor.py",
+      "repo": "scripts/cron-agent-python/vision_doc_extractor.py",
+      "_note": "task #17 promotion (2026-07-26). Redacted in the same commit: NB_OPS_ID_DEFAULT (a NotebookLM UUID) and a hardcoded Telegram chat id were fallback literals with no credential SHAPE (invisible to pattern scans, only a docstring said what they pointed to) — both now env-required, fail loud when unset. Also noted (not fixed): _push_to_nb2() shells out to an nlm CLI binary that does not exist on Pro — dormant, 0/620 runs ever exercised it, same fail-open-by-never-exercised shape as tech_orchestrator's diff gate.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/cron-agent-python/tech_orchestrator.py",
+      "repo": "scripts/cron-agent-python/tech_orchestrator.py",
+      "_note": "task #17/#20 promotion (2026-07-26). Fixed in the same commit: diff_size_check()'s subprocess.run had no check=True, so a nonzero git-diff returncode never raised and empty stdout on failure was byte-identical to a genuinely clean tree — safe:True either way. Dormant in practice (0/3067 runs over 3.5mo acted) but a proven fail-open behind a door nobody has opened yet. Now returns safe:False with the git error surfaced. correlate() itself deliberately untouched. Meta-finding across this census: tech_orchestrator (3067 runs/0 actions), vision_doc_extractor (620/0), tdd_pipeline (42 attempts/18) — 2 of 3 never once entered their own core execution path in 3+ months, each hiding a latent defect nobody could discover because the trigger never fired.",
+      "machines": ["pro"]
     }
   ],
   "allow": [

--- a/scripts/cron-agent-python/agent_job.py
+++ b/scripts/cron-agent-python/agent_job.py
@@ -134,7 +134,11 @@ def _tg_gateway() -> Path | None:
     candidates += [
         Path(__file__).resolve().parent.parent / "tg_notify.py",  # repo checkout
         HOME / "nuzantara" / "scripts" / "tg_notify.py",
-        HOME / "Desktop" / "nuzantara" / "scripts" / "tg_notify.py",
+        # No old TCC-protected-home fallback here (dropped 2026-07-27, #3259
+        # antidotes): the repo moved out of the user's home Desktop folder on
+        # 2026-07-16 for TCC immunity (W84 — launchd can silently lose that
+        # grant); a candidate list is not an exemption from that move, it is
+        # the same hazard one entry deeper.
     ]
     for path in candidates:
         if path.is_file():

--- a/scripts/cron-agent-python/bi_exchange_rate.py
+++ b/scripts/cron-agent-python/bi_exchange_rate.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+BI Exchange Rate Scraper — daily 07:00 WITA.
+
+# Organo: bi-exchange-rate (cron-agent-python, browser scraper) → produce:
+#         Redis cache key `bz:exchange_rate:latest` + Telegram digest
+#         consumato da: CRM PricingTool, client invoices, daily-ops
+# Consuma da: bi.go.id (public, no auth)
+#
+# Ruolo: sensore finanziario. Aggiorna tassi di cambio IDR prima dell'apertura
+#         business. CRM usa questi tassi per calcoli automatici.
+
+Fetches Bank Indonesia official exchange rates (kurs tengah BI).
+Parses HTML table for USD, EUR, SGD, AUD (primary currencies for Bali Zero clients).
+Stores in Redis + sends Telegram digest.
+Fallback: api.exchangerate-api.com (free tier) if BI site unreachable.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+from browser_job import BrowserJob
+
+
+# Currencies we care about for Bali Zero
+CURRENCIES_OF_INTEREST = {"USD", "EUR", "SGD", "AUD", "GBP", "JPY", "CNY"}
+
+# Redis key
+REDIS_KEY = "bz:exchange_rate:latest"
+REDIS_EXPIRY = 86400 * 2  # 48h
+
+# BI kurs tengah URL
+BI_URL = "https://www.bi.go.id/id/statistik/informasi-kurs/transaksi-bi/Default.aspx"
+# Fallback: simpler BI API endpoint (JSON)
+BI_API_URL = "https://www.bi.go.id/biwebservice/wskursbi.asmx/getCursTransaksiBI10"
+
+
+class BiExchangeRateJob(BrowserJob):
+    name = "bi-exchange-rate"
+    target_url = BI_URL
+    timeout_s = 120
+    page_timeout_ms = 20000
+    requires_side_effects = True
+
+    async def run(self) -> RunResult:
+        """Override: try BI API first (JSON), fallback to HTML scrape."""
+        # PR-C4 (2026-04-30): BI native API broken since 2026-04-22; HTML primary now.
+        data = await self._try_html_scrape()
+
+        if not data:
+            # Last resort: exchangerate-api.com free tier
+            data = await self._try_fallback_api()
+
+        if not data:
+            await self.send_telegram(
+                f"❌ <b>bi-exchange-rate</b> — tutti i sources falliti\n"
+                f"{datetime.now(WITA).strftime('%H:%M WITA')}"
+            )
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                error="all sources failed (BI API, HTML, fallback)",
+            )
+
+        # Store in Redis
+        redis_ok = await self._store_redis(data)
+
+        # Send Telegram digest
+        msg = self._compose_message(data)
+        tg_ok = await self.send_telegram(msg)
+        self.log_step("telegram_send", outputs={"ok": tg_ok},
+                      side_effect="exchange_rate_digest" if tg_ok else None,
+                      error=None if tg_ok else "telegram_failed")
+
+        if not tg_ok:
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                error="Telegram delivery failed",
+            )
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=json.dumps(data, default=str),
+        )
+
+    async def _try_bi_api(self) -> dict | None:
+        """Try BI SOAP/REST API (JSON response)."""
+        try:
+            import httpx
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                r = await client.get(BI_API_URL, headers={"Accept": "application/json"})
+                if r.status_code != 200:
+                    return None
+                # BI returns XML or JSON depending on content negotiation
+                text = r.text
+                rates = self._parse_bi_xml(text)
+                if rates:
+                    self.log_step("bi_api_ok", outputs={"currencies": len(rates)})
+                    return {"source": "bi_api", "rates": rates, "ts": int(time.time())}
+        except Exception as e:
+            self.logger.warning("bi_api_error", error=str(e))
+        return None
+
+    def _parse_bi_xml(self, text: str) -> dict[str, float] | None:
+        """Parse BI XML/HTML response for kurs tengah."""
+        rates: dict[str, float] = {}
+        # Pattern: USD | 16,240.00 (kurs tengah)
+        # XML pattern from BI API
+        patterns = [
+            r'<kode_valas>([A-Z]{3})</kode_valas>.*?<kurs_tengah>([\d.,]+)</kurs_tengah>',
+            r'([A-Z]{3})\s*\|\s*[\d.,]+\s*\|\s*([\d.,]+)',
+        ]
+        for pattern in patterns:
+            matches = re.findall(pattern, text, re.DOTALL)
+            for currency, value in matches:
+                if currency in CURRENCIES_OF_INTEREST:
+                    try:
+                        clean = value.replace(",", "").replace(".", "")
+                        # BI format: 16,240.00 = 16240.00 IDR per 1 unit
+                        clean_val = re.sub(r'[^\d.]', '', value)
+                        rates[currency] = float(clean_val)
+                    except ValueError:
+                        pass
+        return rates if rates else None
+
+    async def _try_html_scrape(self) -> dict | None:
+        """Fallback: scrape BI HTML page."""
+        try:
+            if not await self._check_robots(self.target_url):
+                return None
+            await self.random_delay(1.0, 2.0)
+            page = await self.fetch_page(self.target_url)
+            html = page["html"]
+            rates = self._parse_bi_html(html)
+            if rates:
+                self.log_step("bi_html_ok", outputs={"currencies": len(rates)})
+                return {"source": "bi_html", "rates": rates, "ts": int(time.time())}
+        except Exception as e:
+            self.logger.warning("bi_html_error", error=str(e))
+        return None
+
+    def _parse_bi_html(self, html: str) -> dict[str, float] | None:
+        """Extract kurs tengah from BI HTML table."""
+        rates: dict[str, float] = {}
+        # Match table rows with currency codes
+        row_pattern = re.compile(
+            r'<tr[^>]*>.*?([A-Z]{3})\s*(?:Dolar|Euro|Dollar|Pound|Yen|Yuan|Frank|Ringgit|Bath)?'
+            r'.*?(?:kurs[-_]tengah|tengah).*?([\d.,]+)',
+            re.IGNORECASE | re.DOTALL
+        )
+        for m in row_pattern.finditer(html[:50000]):
+            currency = m.group(1)
+            if currency in CURRENCIES_OF_INTEREST:
+                try:
+                    rates[currency] = float(m.group(2).replace(",", ""))
+                except ValueError:
+                    pass
+        return rates if rates else None
+
+    async def _try_fallback_api(self) -> dict | None:
+        """Last resort: free exchangerate-api.com (IDR base)."""
+        try:
+            import httpx
+            url = "https://open.er-api.com/v6/latest/USD"
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                r = await client.get(url)
+                if r.status_code != 200:
+                    return None
+                data = r.json()
+                idr_per_usd = data.get("rates", {}).get("IDR")
+                if not idr_per_usd:
+                    return None
+                # Convert: all rates → IDR
+                rates = {}
+                base_rates = data.get("rates", {})
+                for cur in CURRENCIES_OF_INTEREST:
+                    if cur in base_rates and base_rates[cur] > 0:
+                        rates[cur] = idr_per_usd / base_rates[cur]
+                rates["USD"] = idr_per_usd
+                self.log_step("fallback_api_ok", outputs={"currencies": len(rates)})
+                return {"source": "fallback_api", "rates": rates, "ts": int(time.time())}
+        except Exception as e:
+            self.logger.warning("fallback_api_error", error=str(e))
+        return None
+
+    async def _store_redis(self, data: dict) -> bool:
+        """Store rates in Redis with 48h expiry."""
+        try:
+            import subprocess
+            payload = json.dumps(data)
+            result = subprocess.run(
+                ["redis-cli", "SET", REDIS_KEY, payload, "EX", str(REDIS_EXPIRY)],
+                capture_output=True, text=True, timeout=5
+            )
+            ok = result.returncode == 0 and "OK" in result.stdout
+            self.log_step("redis_store", outputs={"ok": ok, "key": REDIS_KEY},
+                          side_effect="redis_exchange_rate" if ok else None)
+            return ok
+        except Exception as e:
+            self.logger.error("redis_store_error", error=str(e))
+            return False
+
+    def _compose_message(self, data: dict) -> str:
+        now = datetime.now(WITA)
+        source_tag = {"bi_api": "BI API", "bi_html": "BI HTML", "fallback_api": "Fallback"}.get(
+            data.get("source", ""), data.get("source", "?")
+        )
+        rates = data.get("rates", {})
+        lines = [
+            f"💱 <b>Kurs BI</b> — {now.strftime('%Y-%m-%d %H:%M WITA')}",
+            f"<i>Source: {source_tag}</i>",
+            "",
+        ]
+        # Priority order
+        for cur in ["USD", "EUR", "SGD", "AUD", "GBP", "JPY", "CNY"]:
+            if cur in rates:
+                rate = rates[cur]
+                if cur == "JPY":
+                    lines.append(f"🇯🇵 {cur}/IDR: {rate:,.2f}")
+                else:
+                    lines.append(f"{'🇺🇸' if cur=='USD' else '🇪🇺' if cur=='EUR' else '🇸🇬' if cur=='SGD' else '🇦🇺' if cur=='AUD' else '🇬🇧' if cur=='GBP' else '🇨🇳'} {cur}/IDR: {rate:,.2f}")
+
+        lines.append("")
+        lines.append(f"📦 Cached: <code>{REDIS_KEY}</code>")
+        return "\n".join(lines)
+
+    def scrape(self, html: str, text: str) -> dict:
+        """Not used — run() is fully overridden."""
+        return {}
+
+
+if __name__ == "__main__":
+    main(BiExchangeRateJob)

--- a/scripts/cron-agent-python/client_health_monitor.py
+++ b/scripts/cron-agent-python/client_health_monitor.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Client Health Monitor — daily 14:00 WITA.
+
+# Organo: client-health-monitor (cron-agent-python) → produce: Telegram
+#         summary (chat Zero) + separate burnout alert (owner-only, se RED)
+#         + reflection memory.db
+# Consuma da: crm_clients, crm_analytics team_performance (Fly backend)
+#
+# Ruolo: sentinella relazionale. L'organismo monitora il carico umano
+#         sulla squadra — un membro overloaded e' churn risk per il cliente
+#         e health risk per la persona. Nessun LLM nel path (threshold
+#         deterministici da CLAUDE.md policy).
+
+Reports client engagement health:
+- Client stats (total, active, by status, by team)
+- Team performance (conversion rate, revenue, active load)
+- Burnout signals (overloaded team members = churn risk indicator)
+- Top team by load (for redistribution suggestions)
+
+Telegram summary with team metrics + action flags.
+Fail-hard if CRM unreachable.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+
+# Thresholds (match CLAUDE.md burnout policy)
+BURNOUT_ACTIVE_THRESHOLD = 15  # >15 active practices = overload
+BURNOUT_ACTIVE_YELLOW = 10     # >10 = warning
+CHURN_INACTIVE_RATIO_THRESHOLD = 0.7  # if inactive/total > 70% on a team member
+
+
+class ClientHealthMonitor(AgentJob):
+    name = "client-health-monitor"
+    timeout_s = 180
+    requires_side_effects = True  # must send Telegram summary
+
+    async def run(self) -> RunResult:
+        # ── Collect ──────────────────────────────────────────────────────
+        clients_overview = await self.backend_api("/api/crm/clients/stats/overview")
+        self.log_step("fetch_clients_stats", outputs=clients_overview,
+                      error=None if clients_overview else "failed")
+
+        if not clients_overview:
+            # Fail hard: can't reach CRM
+            await self.send_telegram(
+                "❌ <b>client-health-monitor</b> — CRM unreachable\n"
+                f"{datetime.now(WITA).strftime('%H:%M WITA')}"
+            )
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                error="CRM clients/stats/overview failed",
+            )
+
+        team_performance = await self.backend_api("/api/crm/analytics/team/performance")
+        self.log_step("fetch_team_performance", outputs={"count": len(team_performance) if team_performance else 0},
+                      error=None if team_performance else "skipped_or_failed")
+
+        # ── Analyze ──────────────────────────────────────────────────────
+        total_clients = clients_overview.get("total", 0)
+        by_status = clients_overview.get("by_status", {})
+        by_team = clients_overview.get("by_team_member", [])
+
+        # Top 5 team by load
+        top_team = sorted(by_team, key=lambda t: t.get("count", 0), reverse=True)[:5]
+
+        # Burnout detection
+        burnout_red: list[dict] = []
+        burnout_yellow: list[dict] = []
+
+        if team_performance and isinstance(team_performance, list):
+            for member in team_performance:
+                active = member.get("active_clients", 0)
+                email = member.get("member_email", "?")
+                conv_rate = member.get("conversion_rate", 0)
+                revenue = member.get("revenue_generated", 0)
+
+                if active >= BURNOUT_ACTIVE_THRESHOLD:
+                    burnout_red.append({
+                        "member": email.split("@")[0],
+                        "active": active,
+                        "conversion_rate": conv_rate,
+                    })
+                elif active >= BURNOUT_ACTIVE_YELLOW:
+                    burnout_yellow.append({
+                        "member": email.split("@")[0],
+                        "active": active,
+                        "conversion_rate": conv_rate,
+                    })
+
+        # Churn indicators
+        inactive = by_status.get("inactive", 0)
+        active = by_status.get("active", 0)
+        churn_rate_pct = (inactive / total_clients * 100) if total_clients else 0
+
+        # Top revenue performer
+        top_revenue_member = None
+        if team_performance:
+            by_rev = sorted(team_performance, key=lambda m: m.get("revenue_generated", 0) or 0, reverse=True)
+            if by_rev:
+                top_revenue_member = by_rev[0]
+
+        # ── Compose message ──────────────────────────────────────────────
+        msg = self._compose_message(
+            total_clients=total_clients,
+            by_status=by_status,
+            churn_rate_pct=churn_rate_pct,
+            top_team=top_team,
+            burnout_red=burnout_red,
+            burnout_yellow=burnout_yellow,
+            top_revenue_member=top_revenue_member,
+        )
+
+        # ── Deliver ──────────────────────────────────────────────────────
+        ok = await self.send_telegram(msg)
+        self.log_step("telegram_send", outputs={"ok": ok},
+                      side_effect="client_health_summary" if ok else None,
+                      error=None if ok else "telegram_failed")
+
+        # Burnout alert (separate message to owner if RED)
+        if burnout_red:
+            burnout_msg = self._compose_burnout_alert(burnout_red)
+            await self.send_telegram(burnout_msg)
+            self._side_effects.append("burnout_alert")
+            self.log_step("burnout_alert_sent", outputs={"count": len(burnout_red)})
+
+        if not ok:
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output=msg,
+                error="Telegram delivery failed",
+            )
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=msg,
+        )
+
+    def _compose_message(
+        self,
+        total_clients: int,
+        by_status: dict,
+        churn_rate_pct: float,
+        top_team: list[dict],
+        burnout_red: list[dict],
+        burnout_yellow: list[dict],
+        top_revenue_member: dict | None,
+    ) -> str:
+        now = datetime.now(WITA)
+
+        # Overall icon
+        if burnout_red:
+            icon = "🔴"
+        elif burnout_yellow or churn_rate_pct > 10:
+            icon = "🟡"
+        else:
+            icon = "🟢"
+
+        lines = [
+            f"{icon} <b>Client Health Report</b>",
+            f"{now.strftime('%Y-%m-%d %H:%M WITA')}",
+            "",
+            "<b>Client stats</b>",
+            f"📊 Totale: <b>{total_clients}</b>",
+        ]
+
+        # Status breakdown
+        for status in ("active", "prospect", "lead", "inactive"):
+            if status in by_status:
+                pct = by_status[status] / total_clients * 100 if total_clients else 0
+                emoji = {"active": "✅", "prospect": "🟦", "lead": "🆕", "inactive": "⚪"}[status]
+                lines.append(f"{emoji} {status.capitalize()}: {by_status[status]} ({pct:.1f}%)")
+
+        lines.append(f"📉 Churn rate: {churn_rate_pct:.1f}%")
+
+        # Top team by load
+        if top_team:
+            lines.append("")
+            lines.append("<b>Top 5 team (by client load)</b>")
+            for m in top_team:
+                email = m.get("assigned_to", "?")
+                name = email.split("@")[0] if "@" in email else email
+                count = m.get("count", 0)
+                lines.append(f"• {name}: {count} clienti")
+
+        # Burnout warnings
+        if burnout_red:
+            lines.append("")
+            lines.append("🚨 <b>BURNOUT RED</b> (>15 active)")
+            for b in burnout_red:
+                lines.append(f"• {b['member']}: {b['active']} active (conv: {b['conversion_rate']:.0f}%)")
+
+        if burnout_yellow:
+            lines.append("")
+            lines.append("⚠️ <b>BURNOUT YELLOW</b> (10-15 active)")
+            for b in burnout_yellow:
+                lines.append(f"• {b['member']}: {b['active']} active")
+
+        # Top revenue
+        if top_revenue_member:
+            email = top_revenue_member.get("member_email", "?")
+            name = email.split("@")[0]
+            rev = top_revenue_member.get("revenue_generated", 0)
+            rev_m = rev / 1_000_000 if rev else 0
+            lines.append("")
+            lines.append(f"💰 Top revenue: <b>{name}</b> — {rev_m:.0f}M IDR")
+
+        # Action flag
+        if burnout_red:
+            lines.append("")
+            lines.append("👉 Considera redistribuzione carichi.")
+
+        return "\n".join(lines)
+
+    def _compose_burnout_alert(self, burnout_red: list[dict]) -> str:
+        lines = [
+            "🚨 <b>BURNOUT RISK ALERT</b>",
+            "Team members with >15 active practices:",
+            "",
+        ]
+        for b in burnout_red:
+            lines.append(f"• <b>{b['member']}</b> — {b['active']} active (conv: {b['conversion_rate']:.0f}%)")
+        lines.append("")
+        lines.append("👉 Considera redistribuzione. Questo messaggio va solo a owner.")
+        return "\n".join(lines)
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(ClientHealthMonitor)

--- a/scripts/cron-agent-python/compliance_ops.py
+++ b/scripts/cron-agent-python/compliance_ops.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Compliance Ops — every 6h (00, 06, 12, 18 WITA).
+
+# Organo: compliance-ops (cron-agent-python) → produce: Telegram summary
+#         (counts + critical items) + reflection memory.db
+# Consuma da: crm_expiry_alerts, crm_practices API (Fly backend)
+#
+# Ruolo: guardiano delle scadenze. Tocca soldi/clienti/legal — zona sensibile.
+#         Nessun LLM nel path (deterministic per fedelta'). Vede documenti
+#         critici prima che scadano e notifica con abbastanza anticipo per
+#         agire (7d/30d threshold).
+
+Phase 1 — Compliance Autopilot:
+  - Expiring documents: critical (<=7d), warning (<=30d)
+  - Unpaid invoices >30d old
+
+Phase 2 — Practice Lifecycle:
+  - Stale practices (no update 14+ days)
+  - Practices with pending docs >7d
+  - Completed practices missing invoice
+
+Telegram summary with counts and top critical items.
+Fail-hard if we can't reach CRM API.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+
+class ComplianceOpsJob(AgentJob):
+    name = "compliance-ops"
+    timeout_s = 300
+    requires_side_effects = True  # must send Telegram summary
+
+    async def run(self) -> RunResult:
+        # PR-C4 (2026-04-30): session_id was captured but never used for fork/resume.
+        # Removed get_or_create_session — it spawns claude --print which times out
+        # every run (30s) and CLAUDE.md says "no LLM in compliance — deterministic".
+        today = datetime.now(WITA).strftime("%Y-%m-%d")
+
+        # ── Phase 1: Compliance ──────────────────────────────────────────
+        # Expiry summary (fast signal)
+        expiry_summary = await self.backend_api("/api/crm/expiry-alerts/summary")
+        self.log_step("fetch_expiry_summary", outputs=expiry_summary,
+                      error=None if expiry_summary else "failed")
+        if expiry_summary is None:
+            # Fail hard: can't reach CRM
+            await self.send_telegram(
+                "❌ <b>compliance-ops</b> — CRM backend unreachable\n"
+                f"{datetime.now(WITA).strftime('%H:%M WITA')}"
+            )
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                error="CRM backend unreachable (expiry-alerts/summary failed)",
+            )
+
+        counts = expiry_summary.get("counts", {})
+        urgent = expiry_summary.get("urgent_alerts", [])
+
+        # Expiring detail (for critical items — only if urgent present)
+        critical_items = []
+        if counts.get("red", 0) > 0 or counts.get("expired", 0) > 0:
+            expiry_detail = await self.backend_api(
+                "/api/crm/expiry-alerts", params={"days_ahead": 14}
+            )
+            self.log_step("fetch_expiry_detail", outputs={"count": len(expiry_detail or [])})
+            if expiry_detail:
+                items = expiry_detail if isinstance(expiry_detail, list) else expiry_detail.get("items", [])
+                for item in items[:10]:
+                    days = item.get("days_remaining", item.get("days_until_expiry", 999))
+                    if days is not None and days <= 7:
+                        critical_items.append({
+                            "client": item.get("client_name", item.get("client", "?")),
+                            "doc_type": item.get("document_type", item.get("type", "?")),
+                            "days": days,
+                        })
+
+        # ── Phase 2: Practice Lifecycle ──────────────────────────────────
+        practices_stats = await self.backend_api("/api/crm/practices/stats/overview")
+        self.log_step("fetch_practices_stats", outputs=practices_stats,
+                      error=None if practices_stats else "failed")
+
+        # Active practices (to scan for stale)
+        active_practices = await self.backend_api("/api/crm/practices/active")
+        self.log_step("fetch_active_practices",
+                      outputs={"count": len(active_practices) if isinstance(active_practices, list) else 0},
+                      error=None if active_practices is not None else "failed")
+
+        stale_count = 0
+        pending_docs_count = 0
+        missing_invoice_count = 0
+        stale_practices: list[dict] = []
+
+        if isinstance(active_practices, list):
+            now = datetime.now(WITA)
+            stale_threshold = now - timedelta(days=14)
+            pending_threshold = now - timedelta(days=7)
+
+            for p in active_practices:
+                # Stale: no update in 14+ days
+                updated_at = p.get("updated_at") or p.get("last_modified")
+                if updated_at:
+                    try:
+                        ts = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+                        if ts < stale_threshold.replace(tzinfo=ts.tzinfo):
+                            stale_count += 1
+                            stale_practices.append({
+                                "id": p.get("id"),
+                                "client": p.get("client_name", "?"),
+                                "practice_type": p.get("practice_type", "?"),
+                                "days_since": (now.replace(tzinfo=ts.tzinfo) - ts).days,
+                            })
+                    except Exception:
+                        pass
+
+                # Pending docs
+                if p.get("status") in ("awaiting_documents", "docs_pending"):
+                    updated_at = p.get("updated_at")
+                    if updated_at:
+                        try:
+                            ts = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+                            if ts < pending_threshold.replace(tzinfo=ts.tzinfo):
+                                pending_docs_count += 1
+                        except Exception:
+                            pass
+
+                # Completed without invoice (heuristic: status completed but no invoice_id)
+                if p.get("status") == "completed" and not p.get("invoice_id"):
+                    missing_invoice_count += 1
+
+        # ── Assemble report ──────────────────────────────────────────────
+        report_data = {
+            "expiry_counts": counts,
+            "critical_count": len(critical_items),
+            "critical_items": critical_items[:5],
+            "practices_total": practices_stats.get("total_practices", 0) if practices_stats else 0,
+            "practices_active": practices_stats.get("active_practices", 0) if practices_stats else 0,
+            "stale_count": stale_count,
+            "stale_items": stale_practices[:3],
+            "pending_docs_count": pending_docs_count,
+            "missing_invoice_count": missing_invoice_count,
+        }
+
+        # ── Build Telegram message (deterministic, no LLM needed) ────────
+        msg = self._compose_message(report_data)
+
+        # ── Send ─────────────────────────────────────────────────────────
+        ok = await self.send_telegram(msg)
+        self.log_step("telegram_send", outputs={"ok": ok},
+                      side_effect="compliance_summary" if ok else None,
+                      error=None if ok else "telegram_failed")
+
+        if not ok:
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output=msg,
+                error="Telegram delivery failed",
+            )
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=msg,
+        )
+
+    def _compose_message(self, data: dict) -> str:
+        now = datetime.now(WITA)
+        counts = data["expiry_counts"]
+        total_alerts = counts.get("red", 0) + counts.get("yellow", 0) + counts.get("expired", 0)
+
+        # Determine severity icon
+        if counts.get("expired", 0) > 0 or counts.get("red", 0) > 0:
+            icon = "🔴"
+        elif counts.get("yellow", 0) > 0 or data["stale_count"] > 5:
+            icon = "🟡"
+        else:
+            icon = "🟢"
+
+        lines = [
+            f"{icon} <b>Compliance Report</b>",
+            f"{now.strftime('%Y-%m-%d %H:%M WITA')}",
+            "",
+            "<b>Phase 1 — Documenti</b>",
+            f"🔴 Scaduti: {counts.get('expired', 0)}",
+            f"⚠️ Critici (≤7d): {counts.get('red', 0)}",
+            f"🟡 Warning (≤30d): {counts.get('yellow', 0)}",
+            f"✅ Verdi: {counts.get('green', 0)}",
+        ]
+
+        if data["critical_items"]:
+            lines.append("")
+            lines.append("<b>Scadenze critiche:</b>")
+            for item in data["critical_items"]:
+                lines.append(f"• {item['client']} — {item['doc_type']} ({item['days']}d)")
+
+        lines.extend([
+            "",
+            "<b>Phase 2 — Pratiche</b>",
+            f"📋 Totali attive: {data['practices_active']}",
+            f"🕐 Stale (&gt;14d): {data['stale_count']}",
+            f"📂 Pending docs (&gt;7d): {data['pending_docs_count']}",
+            f"💰 Senza fattura: {data['missing_invoice_count']}",
+        ])
+
+        if data["stale_items"]:
+            lines.append("")
+            lines.append("<b>Pratiche stale top:</b>")
+            for p in data["stale_items"]:
+                lines.append(f"• #{p['id']} {p['client']} — {p['practice_type']} ({p['days_since']}d)")
+
+        # Action required
+        needs_action = (
+            counts.get("expired", 0) > 0 or
+            counts.get("red", 0) > 0 or
+            data["missing_invoice_count"] > 0
+        )
+        if needs_action:
+            lines.append("")
+            lines.append("👉 <b>Azione richiesta.</b>")
+
+        return "\n".join(lines)
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(ComplianceOpsJob)

--- a/scripts/cron-agent-python/daily_ops.py
+++ b/scripts/cron-agent-python/daily_ops.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Daily Ops — daily 08:00 WITA.
+
+# Organo: daily-ops (cron-agent-python) → produce: Telegram briefing (chat Zero) +
+#         reflection in memory.db → consuma da: CRM API Fly backend
+#
+# Ruolo nell'organismo: sveglia il team al mattino con snapshot business.
+# Upstream: crm_clients, crm_practices, crm_expiry_alerts (Fly backend)
+# Downstream: Zero legge su Telegram, decide priorità giornata.
+
+Phase 1 — Business Orchestration: CRM stats + expiring practices + renewals.
+Phase 2 — Daily Ops: compose briefing via Claude SDK narrative synthesis.
+
+Uses deterministic Python for data collection, Claude SDK for narrative synthesis,
+Telegram for delivery. Fail-hard if Telegram delivery fails.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+
+class DailyOpsJob(AgentJob):
+    name = "daily-ops"
+    timeout_s = 300
+    requires_side_effects = True  # must send Telegram
+
+    async def run(self) -> RunResult:
+        today = datetime.now(WITA).strftime("%Y-%m-%d")
+
+        # ── Phase 1: collect data ─────────────────────────────────────────
+        data: dict = {"date": today}
+
+        # CRM client stats
+        clients = await self.backend_api("/api/crm/clients/stats/overview")
+        self.log_step("fetch_clients_stats", outputs=clients, error=None if clients else "failed")
+        if clients:
+            data["clients"] = {
+                "total": clients.get("total_clients", 0),
+                "active": clients.get("active_clients", 0),
+                "new_this_month": clients.get("new_this_month", 0),
+            }
+
+        # Practice stats
+        practices = await self.backend_api("/api/crm/practices/stats/overview")
+        self.log_step("fetch_practices_stats", outputs=practices, error=None if practices else "failed")
+        if practices:
+            data["practices"] = {
+                "total": practices.get("total_practices", 0),
+                "active": practices.get("active_practices", 0),
+                "completed_this_month": practices.get("completed_this_month", 0),
+                "pending": practices.get("pending_practices", 0),
+            }
+
+        # Expiring documents (90 days ahead)
+        expiring = await self.backend_api("/api/crm/expiry-alerts", params={"days_ahead": 90})
+        self.log_step("fetch_expiry_alerts", outputs=expiring, error=None if expiring else "failed")
+        critical_expiring = []
+        if expiring and isinstance(expiring, dict):
+            items = expiring.get("alerts", []) or expiring.get("items", []) or []
+            # Filter critical (<= 7 days)
+            for item in items:
+                days = item.get("days_remaining", item.get("days_until_expiry", 999))
+                if days is not None and days <= 7:
+                    critical_expiring.append(item)
+            data["expiring"] = {
+                "total_90d": len(items),
+                "critical_7d": len(critical_expiring),
+                "critical_items": [
+                    {
+                        "client": i.get("client_name", i.get("client", "?")),
+                        "doc_type": i.get("document_type", i.get("type", "?")),
+                        "days": i.get("days_remaining", i.get("days_until_expiry", "?")),
+                    }
+                    for i in critical_expiring[:5]
+                ],
+            }
+
+        # Upcoming renewals
+        renewals = await self.backend_api("/api/crm/practices/renewals/upcoming", params={"days": 30})
+        self.log_step("fetch_renewals", outputs=renewals, error=None if renewals is not None else "failed")
+        if renewals:
+            renewal_items = renewals if isinstance(renewals, list) else renewals.get("items", [])
+            data["renewals_30d"] = len(renewal_items)
+
+        # ── Phase 2: narrative synthesis ──────────────────────────────────
+        synth_prompt = (
+            "Compose a concise daily operational briefing in Italian for the Bali Zero team. "
+            "Use this JSON data as input. Output MUST be plain text (no markdown headers) "
+            "suitable for a Telegram message, 5-8 lines, with emoji bullets (📊 ⚠️ ✅ 📅). "
+            "Start with 'Buongiorno team.' and end with 'Buona giornata.'.\n\n"
+            f"DATA:\n{data}\n\n"
+            "Focus on: critical expiring docs, practice load, renewals this month. "
+            "Flag anything needing urgent attention. Be specific with numbers."
+        )
+
+        narrative = await self.claude_synthesize(
+            prompt=synth_prompt,
+            max_turns=1,
+            effort="low",
+            system_prompt="You are a senior ops coordinator. Output only the final message text, nothing else.",
+            adaptive_thinking=True,  # Opus 4.7 auto-modulates thinking depth
+        )
+        self.log_step("synthesize_narrative", outputs={"len": len(narrative)}, error=None if narrative else "empty")
+
+        if not narrative or narrative.startswith("[synthesis error"):
+            # Fallback to deterministic summary
+            narrative = self._fallback_summary(data)
+            self.log_step("fallback_summary", outputs={"len": len(narrative)})
+
+        # ── Phase 3: delivery ─────────────────────────────────────────────
+        header = f"📅 <b>Daily Ops {today}</b>\n\n"
+        full_msg = header + narrative
+        ok = await self.send_telegram(full_msg)
+        self.log_step("telegram_send", outputs={"ok": ok}, side_effect=f"telegram_briefing" if ok else None,
+                      error=None if ok else "telegram_failed")
+
+        if not ok:
+            return RunResult(
+                status="error",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output=narrative,
+                error="Telegram delivery failed — briefing not sent",
+            )
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=narrative,
+        )
+
+    def _elapsed(self) -> float:
+        import time
+        return time.time() - self.started_at
+
+    def _fallback_summary(self, data: dict) -> str:
+        lines = ["Buongiorno team."]
+        if "clients" in data:
+            c = data["clients"]
+            lines.append(f"📊 Clienti: {c['active']}/{c['total']} attivi, {c['new_this_month']} nuovi questo mese")
+        if "practices" in data:
+            p = data["practices"]
+            lines.append(f"📋 Pratiche: {p['active']} attive, {p['pending']} in attesa, {p['completed_this_month']} completate")
+        if "expiring" in data:
+            e = data["expiring"]
+            lines.append(f"⚠️ Scadenze: {e['critical_7d']} critiche (≤7gg), {e['total_90d']} totali (≤90gg)")
+            for item in e.get("critical_items", [])[:3]:
+                lines.append(f"   • {item['client']} — {item['doc_type']} ({item['days']}gg)")
+        if data.get("renewals_30d"):
+            lines.append(f"📅 Rinnovi: {data['renewals_30d']} nei prossimi 30gg")
+        lines.append("Buona giornata.")
+        return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    main(DailyOpsJob)

--- a/scripts/cron-agent-python/fact_checker.py
+++ b/scripts/cron-agent-python/fact_checker.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+Fact Checker — pre-publish validation for Intel articles and content.
+
+# Organo: fact-checker (cron-agent-python) → produce:
+#         JSON validation report + Telegram alert (se flag trovati)
+#         consumato da: Intel Scraper pipeline (pre-publish gate)
+# Consuma da: ~/.intel_scraper/staged-for-publish/ (articoli pronti a publish)
+#             web_search() per verifica affermazioni
+#
+# Ruolo: sentinella qualità. Prima che un articolo venga pubblicato su
+#        kita.balizero.com, verifica le affermazioni fattuali chiave.
+#        Auto-flag content outdated o non verificabile. Zero costo.
+
+Process:
+  1. Read staged articles from publish queue
+  2. Extract factual claims (numbers, dates, legal references)
+  3. web_search() to verify each claim
+  4. Flag if: unverifiable, contradicted by search, outdated (>6mo)
+  5. Write validation report JSON
+  6. Block publish if RED flags found, allow with warnings if YELLOW
+
+Usage:
+  - Called by Intel Scraper pipeline before publish
+  - Or run as standalone cron to audit recent publications
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main, web_search, web_fetch
+
+STAGED_FOR_PUBLISH_DIR = Path.home() / ".intel_scraper" / "staged-for-publish"
+VALIDATION_REPORTS_DIR = Path.home() / ".intel_scraper" / "validation-reports"
+BLOCKED_DIR = Path.home() / ".intel_scraper" / "blocked"
+
+# Max articles to check per run
+MAX_ARTICLES_PER_RUN = 5
+
+# Patterns that indicate factual claims worth checking
+CLAIM_PATTERNS = [
+    # Legal references
+    re.compile(r"(?:Perpres|PP|Permenkumham|UU|PMK|Permendag)\s*(?:No\.?|Nomor)?\s*[\d/]+(?:/\d+)?", re.IGNORECASE),
+    # Percentages
+    re.compile(r"\d+(?:\.\d+)?\s*%\s+(?:of\s+)?(?:ownership|saham|stake|foreign)", re.IGNORECASE),
+    # Specific dates with significance
+    re.compile(r"(?:effective|berlaku)\s+(?:since|since|dari|sejak)?\s+\d{1,2}\s+\w+\s+\d{4}", re.IGNORECASE),
+    # Monetary thresholds
+    re.compile(r"(?:minimum|minimum|wajib)\s+(?:investment|investasi|modal)\s+(?:of\s+)?(?:USD|IDR|Rp)?\s*[\d,\.]+", re.IGNORECASE),
+    # Visa/permit names
+    re.compile(r"(?:KITAS|KITAP|B211A|C6[12]|e-visa|visa on arrival|voa)", re.IGNORECASE),
+]
+
+
+class FactCheckerJob(AgentJob):
+    name = "fact-checker"
+    timeout_s = 300
+    requires_side_effects = False
+
+    async def run(self) -> RunResult:
+        STAGED_FOR_PUBLISH_DIR.mkdir(parents=True, exist_ok=True)
+        VALIDATION_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+        BLOCKED_DIR.mkdir(parents=True, exist_ok=True)
+
+        # Find articles staged for publish
+        articles = list(STAGED_FOR_PUBLISH_DIR.glob("*.json"))[:MAX_ARTICLES_PER_RUN]
+
+        if not articles:
+            self.log_step("no_articles_to_check")
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="no_articles_to_check",
+            )
+
+        self.log_step("check_start", inputs={"count": len(articles)})
+        reports = []
+        blocked = 0
+        warned = 0
+
+        for article_file in articles:
+            try:
+                article = json.loads(article_file.read_text())
+                report = await self._check_article(article)
+                reports.append(report)
+
+                # Write validation report
+                report_file = VALIDATION_REPORTS_DIR / f"{article_file.stem}_validation.json"
+                report_file.write_text(json.dumps(report, indent=2, default=str))
+
+                if report["verdict"] == "BLOCKED":
+                    # Move to blocked dir
+                    import shutil
+                    shutil.move(str(article_file), str(BLOCKED_DIR / article_file.name))
+                    blocked += 1
+                elif report["verdict"] == "WARNED":
+                    warned += 1
+                    # Leave in place but add _warned suffix to indicate reviewed
+            except Exception as e:
+                self.logger.error("check_error", file=article_file.name, error=str(e))
+
+        self.log_step("check_done", outputs={
+            "total": len(articles), "blocked": blocked, "warned": warned,
+            "passed": len(articles) - blocked - warned,
+        })
+
+        # Alert if anything blocked
+        if blocked > 0 or warned > 0:
+            msg = self._compose_report(reports, blocked, warned)
+            ok = await self.send_telegram(msg)
+            self.log_step("telegram_sent", side_effect="fact_check_alert" if ok else None)
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=json.dumps({"total": len(articles), "blocked": blocked, "warned": warned}),
+        )
+
+    async def _check_article(self, article: dict) -> dict:
+        """Run fact checks on a single article. Returns validation report."""
+        content = article.get("the_facts", "") or article.get("content", "")
+        title = article.get("headline", "") or article.get("title", "?")
+        article_id = article.get("id", "unknown")
+
+        claims = self._extract_claims(content)
+        claim_results = []
+        red_flags = 0
+        yellow_flags = 0
+
+        for claim in claims[:5]:  # check up to 5 claims per article
+            result = await self._verify_claim(claim)
+            claim_results.append(result)
+            if result["status"] == "RED":
+                red_flags += 1
+            elif result["status"] == "YELLOW":
+                yellow_flags += 1
+
+        verdict = "PASSED"
+        if red_flags > 0:
+            verdict = "BLOCKED"
+        elif yellow_flags > 1:
+            verdict = "WARNED"
+
+        return {
+            "article_id": article_id,
+            "title": title[:100],
+            "verdict": verdict,
+            "red_flags": red_flags,
+            "yellow_flags": yellow_flags,
+            "claims_checked": len(claim_results),
+            "claim_results": claim_results,
+            "checked_at": datetime.now(WITA).isoformat(),
+        }
+
+    def _extract_claims(self, content: str) -> list[str]:
+        """Extract verifiable factual claims from content."""
+        claims = []
+        seen: set = set()
+        for pattern in CLAIM_PATTERNS:
+            for m in pattern.finditer(content[:5000]):
+                claim = m.group(0).strip()
+                if claim not in seen and len(claim) > 5:
+                    seen.add(claim)
+                    # Get surrounding context (50 chars before + match + 100 after)
+                    start = max(0, m.start() - 50)
+                    end = min(len(content), m.end() + 100)
+                    context = content[start:end].strip()
+                    claims.append(context[:300])
+        return claims[:10]
+
+    async def _verify_claim(self, claim: str) -> dict:
+        """Verify a single claim via web search + LLM with inline citations."""
+        query = f"Indonesia {claim[:100]} official"
+
+        results = await web_search(query, count=3, freshness="py", logger=self.logger)
+
+        if not results:
+            return {
+                "claim": claim[:100],
+                "status": "YELLOW",
+                "reason": "unverifiable",
+                "sources": [],
+            }
+
+        # Heuristic fast-path (cheap, catches obvious cases)
+        result_titles = " ".join(r.get("title", "") for r in results).lower()
+        result_descs = " ".join(r.get("description", "") for r in results).lower()
+        combined = result_titles + " " + result_descs
+
+        heur_status = None
+        heur_reason = None
+        if any(kw in combined for kw in ["repealed", "abolished", "no longer",
+                                         "expired", "canceled", "tidak berlaku",
+                                         "dicabut"]):
+            heur_status = "RED"
+            heur_reason = "possible_repeal"
+        elif any(kw in combined for kw in ["amended", "updated", "new regulation",
+                                           "perubahan", "terbaru", "pengganti"]):
+            heur_status = "YELLOW"
+            heur_reason = "possible_update"
+
+        # LLM verification (Sonnet 4.6 via routing — claim analysis, cheap)
+        # with soft-cite pattern: ask model to cite inline as [S1], [S2], etc.
+        llm_result = await self._verify_with_llm(claim, results)
+
+        if llm_result is None:
+            # LLM call failed — fall back to heuristic
+            return {
+                "claim": claim[:100],
+                "status": heur_status or "GREEN",
+                "reason": heur_reason or "verified_heuristic",
+                "sources": [r.get("url", "") for r in results[:2]],
+            }
+
+        # LLM wins; log heuristic for comparison
+        if heur_status and heur_status != llm_result["status"]:
+            self.logger.info(
+                "verify_heur_vs_llm_mismatch",
+                claim=claim[:80],
+                heur=heur_status,
+                llm=llm_result["status"],
+            )
+
+        return {
+            "claim": claim[:100],
+            "status": llm_result["status"],
+            "reason": llm_result["reason"],
+            "citations": llm_result.get("citations", []),
+            "sources": [r.get("url", "") for r in results[:3]],
+        }
+
+    async def _verify_with_llm(self, claim: str, results: list[dict]) -> dict | None:
+        """LLM-grade verification with inline-citation pattern.
+
+        Asks Claude to classify RED/YELLOW/GREEN and cite source as [S<N>].
+        Regex-parses inline citations since OAuth Max plan doesn't propagate
+        structured citation blocks.
+
+        Returns dict {status, reason, citations} or None on SDK error.
+        """
+        sources_blob = "\n\n".join(
+            f"[S{i+1}] {r.get('title','')} — {r.get('description','')[:300]} "
+            f"({r.get('url','')})"
+            for i, r in enumerate(results[:3])
+        )
+
+        prompt = (
+            f"Claim to verify: {claim[:400]}\n\n"
+            f"Available sources:\n{sources_blob}\n\n"
+            f"Classify the claim:\n"
+            f"  RED: source explicitly contradicts, repeals, or supersedes it\n"
+            f"  YELLOW: source suggests ambiguity, recent change, or partial support\n"
+            f"  GREEN: source supports claim\n\n"
+            f"Output exactly this JSON (no prose, no fences):\n"
+            f'{{"status":"RED|YELLOW|GREEN","reason":"<short reason>",'
+            f'"citations":["S1","S2"]}}\n'
+            f"Cite ONLY sources you actually used to reach the verdict."
+        )
+
+        out = await self.claude_synthesize(
+            prompt=prompt,
+            max_turns=1,
+            system_prompt=(
+                "You are a fact-checker. Output a single JSON object, nothing else. "
+                "Cite sources as [S1], [S2], [S3]. Zero invention."
+            ),
+        )
+
+        if not out or out.startswith("[synthesis error"):
+            return None
+
+        # Strip possible fences
+        raw = out.strip()
+        if raw.startswith("```"):
+            raw = raw.split("```", 2)[1]
+            if raw.lstrip().startswith("json"):
+                raw = raw.split("\n", 1)[1] if "\n" in raw else raw
+            raw = raw.rsplit("```", 1)[0]
+        raw = raw.strip()
+
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            self.logger.warning("verify_llm_json_parse_failed", raw=raw[:200])
+            return None
+
+        status = parsed.get("status", "YELLOW").upper()
+        if status not in ("RED", "YELLOW", "GREEN"):
+            status = "YELLOW"
+        return {
+            "status": status,
+            "reason": str(parsed.get("reason", "llm_verdict"))[:200],
+            "citations": parsed.get("citations", []) or [],
+        }
+
+    def _compose_report(self, reports: list[dict], blocked: int, warned: int) -> str:
+        now = datetime.now(WITA)
+        icon = "🔴" if blocked > 0 else "🟡"
+        lines = [
+            f"{icon} <b>Fact Check Report</b>",
+            f"{now.strftime('%Y-%m-%d %H:%M WITA')}",
+            "",
+            f"Checked: {len(reports)} articles",
+            f"🔴 BLOCKED: {blocked}",
+            f"🟡 WARNED: {warned}",
+            f"✅ PASSED: {len(reports) - blocked - warned}",
+            "",
+        ]
+        for r in reports:
+            if r["verdict"] in ("BLOCKED", "WARNED"):
+                v_icon = "🔴" if r["verdict"] == "BLOCKED" else "🟡"
+                lines.append(f"{v_icon} {r['title'][:80]}")
+                lines.append(f"  Red: {r['red_flags']}, Yellow: {r['yellow_flags']}")
+                # Show first red/yellow claim
+                for cr in r.get("claim_results", []):
+                    if cr["status"] in ("RED", "YELLOW"):
+                        lines.append(f"  • {cr['claim'][:80]} → {cr['reason']}")
+                        break
+        return "\n".join(lines)
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(FactCheckerJob)

--- a/scripts/cron-agent-python/fly_watcher.py
+++ b/scripts/cron-agent-python/fly_watcher.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+Fly Deploy Watcher — event-driven deploy monitoring (Monitor pattern).
+
+# Organo: fly-watcher (cron-agent-python, monitor pattern) → produce:
+#         Telegram alert (deploy success/fail) + Redis event `cron:fly-watcher`
+#         consumato da: tech-orchestrator, ops team
+# Consuma da: fly logs --app nuzantara-rag (streaming subprocess)
+#
+# Ruolo: sentinella deploy. Sostituisce polling fly status ogni 15s con
+#         event-driven stream watching. Zero token durante silenzio.
+#         Implementa il Monitor pattern di Claude Agent SDK in Python asyncio.
+
+Pattern: stream fly logs → match deploy patterns → publish Redis event + Telegram.
+
+Replaces the polling pattern in fly-health-check.sh with event-driven:
+  BEFORE: cron every 30min, fly status call, parse output
+  AFTER: streaming log watch, instant reaction on pattern match
+
+Modes:
+  1. watch-deploy: Triggered after fly deploy, watch for completion
+  2. watch-health: Continuous log tail, alert on error patterns
+  3. check-now: Single health snapshot (backward compat)
+
+Usage:
+  python fly_watcher.py                    # check-now mode
+  python fly_watcher.py watch-deploy       # watch until deploy done/failed
+  bash run.sh fly-watcher                  # check-now via cron wrapper
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+# Fly apps to monitor
+FLY_APPS = ["nuzantara-rag", "nuzantara-postgres", "nuzantara-qdrant"]
+
+# Deploy success/failure patterns
+DEPLOY_SUCCESS_PATTERNS = [
+    r"v\d+ deployed successfully",
+    r"deployed successfully",
+    r"Deployment complete",
+    r"Release v\d+ created",
+    r"Machine.*started",
+]
+DEPLOY_FAIL_PATTERNS = [
+    r"Error.*deploy",
+    r"deployment.*failed",
+    r"Machine.*failed",
+    r"Error creating release",
+    r"health check.*failed",
+]
+
+# Health alert patterns (for watch-health mode)
+HEALTH_ALERT_PATTERNS = [
+    r"OOMKilled",
+    r"502 Bad Gateway",
+    r"503 Service Unavailable",
+    r"panic:",
+    r"FATAL",
+    r"out of memory",
+    r"connection refused",
+]
+
+# Lifespan-stuck detector — incident 2026-04-29.
+# FastAPI lifespan logs "Middleware registered" but never reaches
+# "Application startup complete". Caused by drive_poll_service flooding
+# the event loop when ServiceAccountDriveService was missing get_file_metadata.
+# Memories 1865 / 1867 / 1870, scar entry in cicatrix-scars.md.
+LIFESPAN_PROGRESS_MARKER = r"Middleware registered"
+LIFESPAN_COMPLETE_MARKER = r"Application startup complete"
+LIFESPAN_STUCK_LOG_LINES = 400
+
+# Max seconds to watch deploy stream
+DEPLOY_WATCH_TIMEOUT = 600  # 10 min
+
+
+class FlyWatcherJob(AgentJob):
+    name = "fly-watcher"
+    timeout_s = 300
+    requires_side_effects = False
+
+    def __init__(self, mode: str = "check-now") -> None:
+        super().__init__()
+        self.mode = mode
+        # fly v0.4.49 regression: does not read access_token from ~/.fly/config.yml
+        self._fly_token = self._read_fly_token()
+
+    @staticmethod
+    def _read_fly_token() -> str:
+        import re
+        config = Path.home() / ".fly" / "config.yml"
+        try:
+            for line in config.read_text().splitlines():
+                m = re.match(r'^access_token:\s*"?([^"]+)"?', line)
+                if m:
+                    return m.group(1).strip()
+        except Exception:
+            pass
+        return ""
+
+    def _fly_cmd(self, *args: str) -> list[str]:
+        base = ["/opt/homebrew/bin/fly"]
+        if self._fly_token:
+            base += ["-t", self._fly_token]
+        return base + list(args)
+
+    async def run(self) -> RunResult:
+        if self.mode == "watch-deploy":
+            return await self._watch_deploy()
+        elif self.mode == "watch-health":
+            return await self._watch_health()
+        else:
+            return await self._check_now()
+
+    async def _check_now(self) -> RunResult:
+        """Single health snapshot — backward compatible with old cron."""
+        self.log_step("check_now_start")
+
+        # Parallel HTTP + fly status checks
+        checks = await asyncio.gather(
+            self._http_check("https://nuzantara-rag.fly.dev/health"),
+            self._http_check("https://balizero.com", timeout=10.0),
+            self._shell_check(self._fly_cmd("status", "--app", "nuzantara-rag"), timeout=15.0),
+            self._shell_check(["redis-cli", "ping"], timeout=5.0),
+            self._lifespan_stuck_check("nuzantara-rag"),
+            return_exceptions=True,
+        )
+
+        backend = checks[0] if not isinstance(checks[0], Exception) else {"ok": False, "error": str(checks[0])}
+        frontend = checks[1] if not isinstance(checks[1], Exception) else {"ok": False, "error": str(checks[1])}
+        fly_rag = checks[2] if not isinstance(checks[2], Exception) else {"ok": False, "error": str(checks[2])}
+        redis = checks[3] if not isinstance(checks[3], Exception) else {"ok": False, "error": str(checks[3])}
+        lifespan = checks[4] if not isinstance(checks[4], Exception) else {"ok": True, "skipped": True, "error": str(checks[4])}
+
+        failures = []
+        if not backend.get("ok"):
+            failures.append(f"backend: HTTP {backend.get('status', '?')} ({backend.get('error', '?')[:60]})")
+        if not frontend.get("ok"):
+            failures.append(f"frontend: {frontend.get('error', '?')[:60]}")
+        if not fly_rag.get("ok"):
+            failures.append("fly_rag: status failed")
+        if not redis.get("ok") or "PONG" not in redis.get("stdout", ""):
+            failures.append(f"redis: {redis.get('error', redis.get('stdout', '?'))[:40]}")
+        if not lifespan.get("ok") and not lifespan.get("skipped"):
+            failures.append(f"lifespan_stuck: {lifespan.get('reason', 'unknown')}")
+
+        self.log_step("check_now_done", outputs={"failures": len(failures)})
+
+        if failures:
+            # Deduplicate alerts (don't spam if same failure)
+            failure_hash = str(hash(tuple(failures)))
+            last_hash_key = "bz:fly-watcher:last-failure-hash"
+            import subprocess
+            last_hash = subprocess.run(
+                ["redis-cli", "GET", last_hash_key],
+                capture_output=True, text=True, timeout=3
+            ).stdout.strip()
+
+            msg = (
+                f"🚨 <b>Fly Health Alert</b>\n"
+                f"{datetime.now(WITA).strftime('%Y-%m-%d %H:%M WITA')}\n\n"
+                + "\n".join(f"• {f}" for f in failures)
+            )
+
+            if last_hash != failure_hash:
+                ok = await self.send_telegram(msg)
+                self.log_step("telegram_alert", outputs={"ok": ok},
+                              side_effect="fly_health_alert" if ok else None)
+                # Store hash with 30min TTL (avoid duplicate alerts)
+                subprocess.run(
+                    ["redis-cli", "SET", last_hash_key, failure_hash, "EX", "1800"],
+                    capture_output=True, timeout=3
+                )
+            else:
+                self.log_step("alert_deduplicated", outputs={"reason": "same_failure_within_30min"})
+
+        else:
+            # Clear dedup hash on success
+            import subprocess
+            subprocess.run(
+                ["redis-cli", "DEL", "bz:fly-watcher:last-failure-hash"],
+                capture_output=True, timeout=3
+            )
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=f"failures={len(failures)}",
+        )
+
+    async def _watch_deploy(self) -> RunResult:
+        """Event-driven deploy watcher — streams fly logs until complete/failed.
+
+        This is the Monitor pattern: zero token when deploy is running normally,
+        instant reaction when success/failure pattern matches.
+        """
+        self.log_step("watch_deploy_start", inputs={"app": "nuzantara-rag"})
+
+        matched_pattern = None
+        matched_line = None
+        start = time.time()
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *self._fly_cmd("logs", "--app", "nuzantara-rag"),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+
+            async def read_with_timeout():
+                nonlocal matched_pattern, matched_line
+                async for raw_line in proc.stdout:
+                    line = raw_line.decode(errors="ignore").strip()
+                    if not line:
+                        continue
+
+                    # Check success patterns
+                    for pattern in DEPLOY_SUCCESS_PATTERNS:
+                        if re.search(pattern, line, re.IGNORECASE):
+                            matched_pattern = "success"
+                            matched_line = line
+                            return
+
+                    # Check failure patterns
+                    for pattern in DEPLOY_FAIL_PATTERNS:
+                        if re.search(pattern, line, re.IGNORECASE):
+                            matched_pattern = "failure"
+                            matched_line = line
+                            return
+
+                    # Timeout check inline
+                    if time.time() - start > DEPLOY_WATCH_TIMEOUT:
+                        matched_pattern = "timeout"
+                        return
+
+            await asyncio.wait_for(read_with_timeout(), timeout=DEPLOY_WATCH_TIMEOUT + 30)
+            proc.kill()
+
+        except asyncio.TimeoutError:
+            matched_pattern = "timeout"
+        except Exception as e:
+            self.log_step("watch_error", outputs={"error": str(e)})
+
+        duration = time.time() - start
+        self.log_step("watch_deploy_done", outputs={
+            "pattern": matched_pattern, "line": (matched_line or "")[:100], "duration_s": duration
+        })
+
+        if matched_pattern == "success":
+            msg = (
+                f"✅ <b>Deploy completato</b>\n"
+                f"{datetime.now(WITA).strftime('%H:%M WITA')} — {duration:.0f}s\n"
+                f"<code>{(matched_line or '')[:200]}</code>"
+            )
+            ok = await self.send_telegram(msg)
+            self.log_step("deploy_success_alert", side_effect="deploy_success" if ok else None)
+        elif matched_pattern == "failure":
+            msg = (
+                f"❌ <b>Deploy FALLITO</b>\n"
+                f"{datetime.now(WITA).strftime('%H:%M WITA')}\n"
+                f"<code>{(matched_line or '')[:200]}</code>"
+            )
+            ok = await self.send_telegram(msg)
+            self.log_step("deploy_fail_alert", side_effect="deploy_failure" if ok else None)
+        else:
+            # Timeout — run check-now to get current status
+            self.log_step("deploy_timeout_fallback")
+
+        return RunResult(
+            status="ok" if matched_pattern == "success" else "error" if matched_pattern == "failure" else "ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=matched_pattern or "unknown",
+        )
+
+    async def _watch_health(self) -> RunResult:
+        """Continuous log anomaly watcher (supervisor pattern).
+
+        Stream fly logs, react instantly on error patterns.
+        Typically run via background process, not cron.
+        """
+        self.log_step("watch_health_start")
+        alerts_sent = 0
+        max_alerts = 5  # don't spam
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *self._fly_cmd("logs", "--app", "nuzantara-rag"),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+
+            async def watch():
+                nonlocal alerts_sent
+                async for raw_line in proc.stdout:
+                    line = raw_line.decode(errors="ignore").strip()
+                    for pattern in HEALTH_ALERT_PATTERNS:
+                        if re.search(pattern, line, re.IGNORECASE) and alerts_sent < max_alerts:
+                            msg = (
+                                f"🚨 <b>Live Log Alert</b>\n"
+                                f"<code>{line[:300]}</code>"
+                            )
+                            await self.send_telegram(msg)
+                            alerts_sent += 1
+                            self.log_step("live_alert", outputs={"pattern": pattern, "alerts": alerts_sent})
+
+            await asyncio.wait_for(watch(), timeout=self.timeout_s)
+            proc.kill()
+
+        except asyncio.TimeoutError:
+            pass
+        except Exception as e:
+            self.log_step("watch_health_error", outputs={"error": str(e)})
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=f"alerts_sent={alerts_sent}",
+        )
+
+    async def _http_check(self, url: str, timeout: float = 15.0) -> dict:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            try:
+                start = time.time()
+                r = await client.get(url)
+                return {
+                    "url": url,
+                    "status": r.status_code,
+                    "latency_ms": int((time.time() - start) * 1000),
+                    "ok": 200 <= r.status_code < 300,
+                }
+            except Exception as e:
+                return {"url": url, "ok": False, "error": str(e)}
+
+    async def _shell_check(self, cmd: list[str], timeout: float = 30.0) -> dict:
+        try:
+            proc = await asyncio.wait_for(
+                asyncio.create_subprocess_exec(
+                    *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+                ),
+                timeout=timeout,
+            )
+            stdout, stderr = await proc.communicate()
+            return {
+                "cmd": " ".join(cmd),
+                "ok": proc.returncode == 0,
+                "stdout": stdout.decode(errors="ignore")[:300],
+            }
+        except asyncio.TimeoutError:
+            return {"cmd": " ".join(cmd), "ok": False, "error": "timeout"}
+        except Exception as e:
+            return {"cmd": " ".join(cmd), "ok": False, "error": str(e)}
+
+    async def _lifespan_stuck_check(self, app: str) -> dict:
+        # Pulls the last LIFESPAN_STUCK_LOG_LINES from `fly logs --no-tail` and
+        # decides: if any line contains LIFESPAN_PROGRESS_MARKER but none
+        # contains LIFESPAN_COMPLETE_MARKER, FastAPI startup is stuck.
+        # Skips silently when fly CLI is unreachable to avoid false positives
+        # in degraded environments.
+        try:
+            proc = await asyncio.wait_for(
+                asyncio.create_subprocess_exec(
+                    *self._fly_cmd("logs", "--app", app, "--no-tail", "-n", str(LIFESPAN_STUCK_LOG_LINES)),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                ),
+                timeout=20.0,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=20.0)
+        except asyncio.TimeoutError:
+            return {"ok": True, "skipped": True, "reason": "fly_logs_timeout"}
+        except Exception as e:
+            return {"ok": True, "skipped": True, "reason": f"fly_logs_error:{e}"}
+
+        text = stdout.decode(errors="ignore")
+        progress_seen = bool(re.search(LIFESPAN_PROGRESS_MARKER, text))
+        complete_seen = bool(re.search(LIFESPAN_COMPLETE_MARKER, text))
+
+        if progress_seen and not complete_seen:
+            return {
+                "ok": False,
+                "reason": (
+                    f"FastAPI lifespan never reached "
+                    f"'{LIFESPAN_COMPLETE_MARKER}' (last {LIFESPAN_STUCK_LOG_LINES} log lines)"
+                ),
+            }
+        return {"ok": True, "progress_seen": progress_seen, "complete_seen": complete_seen}
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+def _main_with_mode() -> None:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "check-now"
+    job = FlyWatcherJob(mode=mode)
+    import asyncio as _asyncio
+    from agent_job import run_job
+    exit_code = _asyncio.run(run_job(job))
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    _main_with_mode()

--- a/scripts/cron-agent-python/imigrasi_monitor.py
+++ b/scripts/cron-agent-python/imigrasi_monitor.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+Immigration Regulation Monitor — daily 06:00 WITA.
+
+# Organo: imigrasi-monitor (cron-agent-python, browser scraper) → produce:
+#         Telegram alert (nuovi regolamenti) + Intel Stage 1 JSON
+#         consumato da: Intel Scraper pipeline, compliance-ops, NLM ingest
+# Consuma da: imigrasi.go.id (public), peraturan.go.id (public)
+#
+# Ruolo: antenna normativa immigrazione. Rileva nuovi circulari, peraturan,
+#         e comunicasi dari Ditjen Imigrasi prima che impattino clienti.
+#         Ogni nuova normativa → Intel Stage 1 feed → enrichment pipeline.
+
+Monitors:
+  - imigrasi.go.id/berita — news/announcements
+  - imigrasi.go.id/layanan — service updates
+  - peraturan.go.id (filter: imigrasi keyword)
+
+Output:
+  - Redis set `bz:imigrasi:seen_urls` for deduplication
+  - Intel Stage 1 JSON files in ~/.intel_scraper/incoming/
+  - Telegram alert with new regulation summary
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+from browser_job import BrowserJob
+
+
+IMIGRASI_NEWS_URL = "https://www.imigrasi.go.id/berita"
+IMIGRASI_PRODUK_HUKUM_URL = "https://www.imigrasi.go.id/produk-hukum/peraturan-pemerintah"
+IMIGRASI_WNA_URL = "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian"
+PERATURAN_URL = "https://peraturan.go.id/search?q=imigrasi&type=peraturan"
+
+REDIS_KEY_SEEN = "bz:imigrasi:seen_urls"
+REDIS_EXPIRY = 86400 * 90  # 90 days
+
+# Intel Stage 1 output dir (matches bali-intel-scraper input)
+INTEL_INCOMING_DIR = Path.home() / ".intel_scraper" / "incoming"
+
+
+class ImigrasiMonitorJob(BrowserJob):
+    name = "imigrasi-monitor"
+    target_url = IMIGRASI_NEWS_URL
+    timeout_s = 240
+    page_timeout_ms = 20000
+    requires_side_effects = False  # only fires if new regulations found
+
+    async def run(self) -> RunResult:
+        """Multi-source regulation monitoring."""
+        all_items: list[dict] = []
+
+        # Source 1: imigrasi.go.id/berita
+        items_berita = await self._fetch_imigrasi_berita()
+        all_items.extend(items_berita)
+        self.log_step("fetch_berita", outputs={"count": len(items_berita)})
+
+        await self.random_delay(2.0, 4.0)
+
+        # Source 2: imigrasi.go.id/produk-hukum (legal products)
+        items_layanan = await self._fetch_imigrasi_produk_hukum()
+        all_items.extend(items_layanan)
+        self.log_step("fetch_produk_hukum", outputs={"count": len(items_layanan)})
+
+        # Deduplicate by URL
+        seen_urls = await self._get_seen_urls()
+        new_items = [i for i in all_items if i.get("url") and i["url"] not in seen_urls]
+        self.log_step("dedup", outputs={"new": len(new_items), "total": len(all_items)})
+
+        if not new_items:
+            self._record_success()
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="no_new_regulations",
+            )
+
+        # Mark as seen
+        await self._mark_seen([i["url"] for i in new_items])
+
+        # Write Intel Stage 1 feed
+        intel_count = self._write_intel_feed(new_items)
+        if intel_count > 0:
+            self._side_effects.append(f"intel_feed:{intel_count}")
+            self.log_step("intel_feed_written", outputs={"count": intel_count})
+
+        # Telegram alert
+        msg = self._compose_alert(new_items)
+        ok = await self.send_telegram(msg)
+        self.log_step("telegram_send", outputs={"ok": ok},
+                      side_effect="imigrasi_alert" if ok else None,
+                      error=None if ok else "telegram_failed")
+
+        self._record_success()
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=json.dumps(new_items[:5], default=str),
+        )
+
+    async def _fetch_imigrasi_berita(self) -> list[dict]:
+        """Fetch imigrasi.go.id/berita news items."""
+        if not await self._check_robots(IMIGRASI_NEWS_URL):
+            return []
+        try:
+            page = await self.fetch_page(IMIGRASI_NEWS_URL)
+            return self._parse_imigrasi_articles(page["html"], source="imigrasi_berita")
+        except Exception as e:
+            self.logger.warning("berita_fetch_error", error=str(e))
+            return []
+
+    async def _fetch_imigrasi_produk_hukum(self) -> list[dict]:
+        """Fetch imigrasi.go.id legal products (peraturan pemerintah)."""
+        if not await self._check_robots(IMIGRASI_PRODUK_HUKUM_URL):
+            return []
+        try:
+            page = await self.fetch_page(IMIGRASI_PRODUK_HUKUM_URL)
+            return self._parse_imigrasi_articles(page["html"], source="imigrasi_produk_hukum")
+        except Exception as e:
+            self.logger.warning("produk_hukum_fetch_error", error=str(e))
+            return []
+
+    async def _fetch_peraturan(self) -> list[dict]:
+        """Fetch peraturan.go.id search for imigrasi regulations."""
+        if not await self._check_robots(PERATURAN_URL):
+            return []
+        try:
+            page = await self.fetch_page(PERATURAN_URL)
+            return self._parse_peraturan(page["html"])
+        except Exception as e:
+            self.logger.warning("peraturan_fetch_error", error=str(e))
+            return []
+
+    def _parse_imigrasi_articles(self, html: str, source: str) -> list[dict]:
+        """Parse article links from imigrasi.go.id."""
+        items = []
+        seen: set = set()
+
+        # Extract article links with titles
+        patterns = [
+            # Standard article cards
+            re.compile(
+                r'<a[^>]+href="(https?://(?:www\.)?imigrasi\.go\.id/[^"]+)"[^>]*>'
+                r'\s*(?:<[^>]+>)*\s*([^<]{15,300})\s*(?:</[^>]+>)*\s*</a>',
+                re.DOTALL | re.IGNORECASE,
+            ),
+            # Relative URLs
+            re.compile(
+                r'<a[^>]+href="(/(?:berita|layanan|info|pengumuman)/[^"]+)"[^>]*>'
+                r'\s*(?:<[^>]+>)*\s*([^<]{15,300})\s*(?:</[^>]+>)*\s*</a>',
+                re.DOTALL | re.IGNORECASE,
+            ),
+        ]
+        base_url = "https://www.imigrasi.go.id"
+        for pattern in patterns:
+            for m in pattern.finditer(html[:100000]):
+                url = m.group(1)
+                if not url.startswith("http"):
+                    url = f"{base_url}{url}"
+                title = re.sub(r'<[^>]+>', '', m.group(2)).strip()
+                title = re.sub(r'\s+', ' ', title)
+                if (url not in seen and title and len(title) >= 15
+                        and "imigrasi.go.id" in url):
+                    seen.add(url)
+                    items.append({
+                        "url": url,
+                        "title": title[:300],
+                        "source": source,
+                        "scraped_at": datetime.now(WITA).isoformat(),
+                        "type": "news" if "berita" in url else "service",
+                    })
+        return items[:15]
+
+    def _parse_peraturan(self, html: str) -> list[dict]:
+        """Parse peraturan.go.id search results."""
+        items = []
+        seen: set = set()
+        pattern = re.compile(
+            r'<a[^>]+href="(https?://peraturan\.go\.id/[^"]*)"[^>]*>'
+            r'\s*(?:<[^>]+>)*\s*([^<]{15,300})\s*',
+            re.DOTALL | re.IGNORECASE,
+        )
+        for m in pattern.finditer(html[:80000]):
+            url = m.group(1)
+            title = re.sub(r'<[^>]+>', '', m.group(2)).strip()
+            title = re.sub(r'\s+', ' ', title)
+            if (url not in seen and title and len(title) >= 15
+                    and any(kw in title.lower() for kw in ["imigras", "keimigras", "visa", "kitas", "kitap"])):
+                seen.add(url)
+                items.append({
+                    "url": url,
+                    "title": title[:300],
+                    "source": "peraturan_go_id",
+                    "scraped_at": datetime.now(WITA).isoformat(),
+                    "type": "regulation",
+                })
+        return items[:10]
+
+    async def _get_seen_urls(self) -> set:
+        """Get previously seen URLs from Redis set."""
+        try:
+            result = subprocess.run(
+                ["redis-cli", "SMEMBERS", REDIS_KEY_SEEN],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                return set(result.stdout.strip().splitlines())
+        except Exception:
+            pass
+        return set()
+
+    async def _mark_seen(self, urls: list[str]) -> None:
+        """Add URLs to Redis seen set."""
+        try:
+            for url in urls:
+                subprocess.run(
+                    ["redis-cli", "SADD", REDIS_KEY_SEEN, url],
+                    capture_output=True, timeout=5
+                )
+            subprocess.run(
+                ["redis-cli", "EXPIRE", REDIS_KEY_SEEN, str(REDIS_EXPIRY)],
+                capture_output=True, timeout=5
+            )
+        except Exception as e:
+            self.logger.warning("redis_mark_error", error=str(e))
+
+    def _write_intel_feed(self, items: list[dict]) -> int:
+        """Write Intel Stage 1 JSON files for pipeline processing."""
+        try:
+            INTEL_INCOMING_DIR.mkdir(parents=True, exist_ok=True)
+            count = 0
+            for item in items:
+                ts = int(time.time())
+                filename = f"imigrasi_{ts}_{hashlib.md5(item['url'].encode()).hexdigest()[:8]}.json"
+                feed_file = INTEL_INCOMING_DIR / filename
+                feed_file.write_text(json.dumps({
+                    "source": item.get("source", "imigrasi"),
+                    "url": item["url"],
+                    "title": item["title"],
+                    "type": item.get("type", "news"),
+                    "scraped_at": item.get("scraped_at"),
+                    "pipeline": "intel_stage1",
+                }, indent=2))
+                count += 1
+
+                # Intel Lake Wave 3 (2026-05-12): dual-write to local SQLite
+                # outbox so the lake observation table sees this finding.
+                # Best-effort — failure must not block the existing flow.
+                try:
+                    import sys as _sys  # noqa: PLC0415
+                    # task #17 (2026-07-26): was a literal "/Users/nuzantara/scripts" —
+                    # fingerprints the ops host's username/home layout, and it is this
+                    # organism's own catalogued HOME-fork anti-pattern. Derived from
+                    # __file__ instead: this file lives at <...>/scripts/cron-agent-python/,
+                    # intel_lake_outbox.py lives one level up at <...>/scripts/.
+                    _sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+                    from intel_lake_outbox import enqueue as _lake_enqueue  # type: ignore
+                    _ch = hashlib.sha256(
+                        (item["title"] + " " + item["url"]).encode()
+                    ).hexdigest()[:32]
+                    _lake_enqueue(
+                        "imigrasi_monitor",
+                        {
+                            "producer_name": "imigrasi_monitor",
+                            "canonical_url": item["url"],
+                            "content_hash": _ch,
+                            "title": item["title"][:500],
+                            "summary": item.get("summary", "")[:2000] if item.get("summary") else None,
+                            "source_domain": "imigrasi.go.id",
+                            "language": "id",
+                            "jurisdiction": "ID-national",
+                            "topic_tags": ["visa", "immigration", item.get("type", "news")],
+                            "published_at": item.get("scraped_at"),
+                            "score": None,
+                            "raw_payload": {
+                                "pipeline": "intel_stage1",
+                                "type": item.get("type", "news"),
+                            },
+                        },
+                    )
+                except Exception as exc:
+                    self.logger.warning("intel_lake_enqueue_failed", error=str(exc), url=item.get("url", "")[:80])
+            return count
+        except Exception as e:
+            self.logger.error("intel_feed_error", error=str(e))
+            return 0
+
+    def _compose_alert(self, new_items: list[dict]) -> str:
+        now = datetime.now(WITA)
+        # Group by type
+        regulations = [i for i in new_items if i.get("type") == "regulation"]
+        news = [i for i in new_items if i.get("type") != "regulation"]
+
+        lines = [
+            f"🛂 <b>Imigrasi Monitor</b> — {len(new_items)} new",
+            f"{now.strftime('%Y-%m-%d %H:%M WITA')}",
+            "",
+        ]
+
+        if regulations:
+            lines.append(f"<b>📜 Peraturan ({len(regulations)}):</b>")
+            for r in regulations[:3]:
+                lines.append(f"• {r['title'][:150]}")
+
+        if news:
+            lines.append(f"\n<b>📰 Berita/Layanan ({len(news)}):</b>")
+            for n in news[:3]:
+                lines.append(f"• {n['title'][:150]}")
+
+        if len(new_items) > 6:
+            lines.append(f"\n... +{len(new_items) - 6} altri")
+
+        lines.append(f"\n📦 Intel feed: {len(new_items)} items → pipeline")
+        return "\n".join(lines)
+
+    def scrape(self, html: str, text: str) -> dict:
+        """Not used — run() is fully overridden."""
+        return {}
+
+
+if __name__ == "__main__":
+    main(ImigrasiMonitorJob)

--- a/scripts/cron-agent-python/intel_feed_processor.py
+++ b/scripts/cron-agent-python/intel_feed_processor.py
@@ -32,7 +32,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from agent_job import AgentJob, RunResult, WITA, main, web_fetch
 
 INCOMING_DIR = Path.home() / ".intel_scraper" / "incoming"
-INTEL_ROOT = Path.home() / "Desktop" / "nuzantara" / "apps" / "bali-intel-scraper"
+INTEL_ROOT = Path.home() / "nuzantara" / "apps" / "bali-intel-scraper"
 STAGING_DIR = INTEL_ROOT / "data" / "staging" / "news"
 PROCESSED_DIR = Path.home() / ".intel_scraper" / "processed"
 

--- a/scripts/cron-agent-python/intel_feed_processor.py
+++ b/scripts/cron-agent-python/intel_feed_processor.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Intel Feed Processor — processes incoming items from browser scrapers.
+
+# Organo: intel-feed-processor (cron-agent-python) → produce:
+#         JSON files in Intel Scraper staging dir per downstream enrichment
+#         + Telegram digest (nuovi item → pipeline)
+# Consuma da: ~/.intel_scraper/incoming/ (imigrasi-monitor, oss-monitor output)
+#
+# Ruolo: bridge fra browser scrapers e Intel pipeline esistente.
+#         Prende item JSON dalla incoming dir, valida, deduplicates,
+#         e li sposta in staging per l'enrichment Claude CLI.
+
+Stage 1 bridge: picks up items written by imigrasi_monitor, oss_monitor
+and any future browser scrapers, validates them, then moves to Intel
+staging dir for downstream enrichment.
+
+Parallel processing: validates N items in parallel (asyncio.gather).
+Uses web_fetch() to grab additional context per item.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main, web_fetch
+
+INCOMING_DIR = Path.home() / ".intel_scraper" / "incoming"
+INTEL_ROOT = Path.home() / "Desktop" / "nuzantara" / "apps" / "bali-intel-scraper"
+STAGING_DIR = INTEL_ROOT / "data" / "staging" / "news"
+PROCESSED_DIR = Path.home() / ".intel_scraper" / "processed"
+
+# Max items to process per run (avoid overloading the pipeline)
+MAX_ITEMS_PER_RUN = 20
+
+
+class IntelFeedProcessorJob(AgentJob):
+    name = "intel-feed-processor"
+    timeout_s = 300
+    requires_side_effects = False  # only if items processed
+
+    async def run(self) -> RunResult:
+        # Setup dirs
+        INCOMING_DIR.mkdir(parents=True, exist_ok=True)
+        PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
+
+        # Find incoming items
+        incoming_files = list(INCOMING_DIR.glob("*.json"))
+        if not incoming_files:
+            self.log_step("no_incoming_items")
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="no_incoming_items",
+            )
+
+        # Limit per run
+        batch = incoming_files[:MAX_ITEMS_PER_RUN]
+        self.log_step("batch_start", inputs={"count": len(batch), "total_pending": len(incoming_files)})
+
+        # Process in parallel
+        results = await asyncio.gather(
+            *[self._process_item(f) for f in batch],
+            return_exceptions=True,
+        )
+
+        ok_count = sum(1 for r in results if r is True)
+        err_count = sum(1 for r in results if r is not True)
+        self.log_step("batch_done", outputs={"ok": ok_count, "errors": err_count})
+
+        if ok_count > 0:
+            msg = (
+                f"📥 <b>Intel Feed</b> — {ok_count} items → pipeline\n"
+                f"{datetime.now(WITA).strftime('%H:%M WITA')}"
+            )
+            if STAGING_DIR.exists():
+                pending = len(list(STAGING_DIR.glob("*.json")))
+                msg += f"\nPending in staging: {pending}"
+            await self.send_telegram(msg)
+            self._side_effects.append(f"intel_items_staged:{ok_count}")
+            self.log_step("telegram_sent", outputs={"ok": ok_count})
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=f"ok={ok_count} errors={err_count}",
+        )
+
+    async def _process_item(self, item_file: Path) -> bool:
+        """Process a single incoming item file. Returns True on success."""
+        try:
+            raw = json.loads(item_file.read_text())
+        except Exception as e:
+            self.logger.warning("invalid_json", file=item_file.name, error=str(e))
+            item_file.unlink(missing_ok=True)
+            return False
+
+        url = raw.get("url", "")
+        title = raw.get("title", "")
+        source = raw.get("source", "unknown")
+
+        if not url or not title:
+            self.logger.warning("missing_fields", file=item_file.name)
+            item_file.unlink(missing_ok=True)
+            return False
+
+        # Fetch additional context if URL is accessible
+        content = raw.get("content", "")
+        if not content and url.startswith("http"):
+            try:
+                page = await web_fetch(url, extract_text=True, timeout=10.0, logger=self.logger)
+                if page.get("ok") and page.get("text"):
+                    content = page["text"][:3000]  # limit for staging
+            except Exception:
+                pass
+
+        # Build staging item
+        ts = int(time.time())
+        item_id = f"{source}_{ts}_{item_file.stem}"
+        staging_item = {
+            "id": item_id,
+            "url": url,
+            "title": title,
+            "source": source,
+            "content": content,
+            "type": raw.get("type", "news"),
+            "scraped_at": raw.get("scraped_at", datetime.now(WITA).isoformat()),
+            "pipeline_stage": "stage1_collected",
+        }
+
+        # Write to staging dir (if Intel Scraper exists)
+        try:
+            if STAGING_DIR.exists():
+                staging_file = STAGING_DIR / f"{item_id}.json"
+                staging_file.write_text(json.dumps(staging_item, indent=2))
+            else:
+                # Intel scraper not available — just archive
+                PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
+                archive_file = PROCESSED_DIR / f"{item_id}.json"
+                archive_file.write_text(json.dumps(staging_item, indent=2))
+        except Exception as e:
+            self.logger.error("staging_write_error", error=str(e))
+            return False
+
+        # Move original to processed
+        shutil.move(str(item_file), str(PROCESSED_DIR / item_file.name))
+        self.logger.debug("item_staged", id=item_id, source=source)
+        return True
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(IntelFeedProcessorJob)

--- a/scripts/cron-agent-python/intel_radar.py
+++ b/scripts/cron-agent-python/intel_radar.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""
+Intel Radar — hourly web search for Bali Zero business intelligence.
+
+# Organo: intel-radar (cron-agent-python) →
+#   produce: rows in `intel_radar_findings` (canonical handoff to scraper)
+#   + Redis cache `bz:intel-radar:seen` per deduplicazione hot-path
+# Consuma da: Brave Search API → DuckDuckGo fallback (web_search helper)
+#
+# Ruolo: ricercatore proattivo. Cerca notizie rilevanti per il business
+#         (investimento, visa, normative, mercato) e le accumula in DB.
+#         Il digest serale (intel_radar_daily_digest.py) le legge, riassume,
+#         e notifica Zero. Lo scraper le pesca processed=true & not picked.
+#
+# Refactor 2026-04-26 (PR-1 §A):
+#   - freshness pw → pd (giorno, non settimana)
+#   - 12 query flat → 3 tier × 12 query (L1/L2/L3) ruotanti per ora WITA
+#   - Telegram digest orario rimosso → solo INSERT in intel_radar_findings
+#     (digest serale separato in intel_radar_daily_digest.py)
+#   - Feature-flag INTEL_RADAR_PERSIST_DB / INTEL_RADAR_FRESHNESS retrocompat
+
+Tier rotation by hour-of-day WITA (UTC+8):
+  - 0-7   → L1 (core: visa, kitas, KBLI, OSS, BPN, pajak, BPJS)
+  - 8-15  → L2 (adjacent: banking, fintech, real estate, tourism stats, expat)
+  - 16-23 → L3 (lateral: rupiah/dollar, ASEAN, US/China-Indonesia, G20, COP)
+
+Each hour: 1 query from the active tier (round-robin within tier).
+Total daily queries: 24 (was 24, no change in volume — only tier-aware).
+
+Deduplication:
+  - Redis hot path: 7-day TTL set of URL hashes (preserves old logic for backward compat)
+  - DB hard dedup: UNIQUE(canonical_url) on intel_radar_findings (migration 139)
+
+Output: only DB INSERT (when INTEL_RADAR_PERSIST_DB=true). Telegram is silent.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
+
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))  # for intel_lake_outbox
+from agent_job import AgentJob, RunResult, WITA, main, web_search
+
+# Intel Lake Wave 1 (2026-05-12): dual-write to local SQLite outbox so the
+# observations table on Fly backend gets every finding even when intel_radar_findings
+# ON CONFLICT DO NOTHING skips an insert. Best-effort: failure to enqueue
+# MUST NOT break the main radar flow.
+try:
+    from intel_lake_outbox import enqueue as _lake_enqueue  # type: ignore
+    _LAKE_ENABLED = True
+except Exception:
+    _LAKE_ENABLED = False
+    _lake_enqueue = None  # type: ignore
+
+
+# Three tier query rotation (12 queries each).
+# L1 = CORE: regulatory and operational queries Bali Zero clients ask weekly.
+L1_QUERIES = [
+    "investasi asing Indonesia regulation terbaru",
+    "digital nomad visa Bali update",
+    "KITAS KITAP regulation Indonesia terbaru",
+    "company formation Indonesia PT PMA new rules",
+    "pajak tax regulation Indonesia terbaru",
+    "OSS perizinan update Indonesia",
+    "BKPM permit foreign investment Indonesia",
+    "BPJS kesehatan ketenagakerjaan terbaru",
+    "BPN sertifikat tanah hak guna bangunan",
+    "KBLI klasifikasi baku lapangan usaha update",
+    "imigrasi visa on arrival Indonesia",
+    "pajak penghasilan PPh 21 25 terbaru",
+]
+
+# L2 = ADJACENT: market and ecosystem signals that affect clients indirectly.
+L2_QUERIES = [
+    "perbankan Indonesia foreign account regulation",
+    "fintech Indonesia OJK regulation terbaru",
+    "Bali real estate market property law",
+    "tourism statistics Indonesia BPS",
+    "expat events conference Indonesia",
+    "Indonesia startup ecosystem investment",
+    "Bali property ownership foreigner regulation",
+    "Indonesia e-commerce regulation update",
+    "OJK fintech P2P lending Indonesia",
+    "Bank Indonesia rupiah policy update",
+    "Indonesia economic outlook quarterly",
+    "Bali tourism recovery 2026",
+]
+
+# L3 = LATERAL: macro/geopolitical signals — slow-moving but high-impact tail risks.
+L3_QUERIES = [
+    "rupiah dollar exchange Indonesia outlook",
+    "ASEAN policy Indonesia integration",
+    "US Indonesia trade investment relations",
+    "China Indonesia investment infrastructure",
+    "G20 Indonesia outcome statement",
+    "COP climate Indonesia commitment",
+    "Bali climate disaster risk",
+    "Indonesia geopolitical strategic position",
+    "ASEAN summit outcomes Indonesia",
+    "Indonesia inflation interest rate Bank Indonesia",
+    "global supply chain Indonesia impact",
+    "regional cooperation Indonesia Pacific",
+]
+
+
+def _active_tier(hour: int) -> str:
+    """Return tier label for the given hour-of-day (WITA, 0-23)."""
+    if 0 <= hour <= 7:
+        return "L1"
+    if 8 <= hour <= 15:
+        return "L2"
+    return "L3"
+
+
+def _tier_queries(tier: str) -> list[str]:
+    return {"L1": L1_QUERIES, "L2": L2_QUERIES, "L3": L3_QUERIES}[tier]
+
+
+REDIS_SEEN_KEY = "bz:intel-radar:seen"
+REDIS_SEEN_TTL = 86400 * 7  # 7 days
+
+
+# URL canonicalization — strip tracking params + fragment, lowercase host.
+# Used for UNIQUE(canonical_url) dedup at the DB layer.
+_TRACKING_PARAM_RE = re.compile(r"^(utm_|fbclid|gclid|mc_eid|mc_cid|_ga|ref$|src$)", re.I)
+
+
+def _canonical_url(raw: str) -> str:
+    try:
+        p = urlparse(raw.strip())
+        host = (p.netloc or "").lower()
+        # Strip default ports
+        host = host.replace(":80", "").replace(":443", "")
+        # Filter tracking query params
+        if p.query:
+            keep = {k: v for k, v in parse_qs(p.query, keep_blank_values=False).items()
+                    if not _TRACKING_PARAM_RE.match(k)}
+            query = urlencode(keep, doseq=True) if keep else ""
+        else:
+            query = ""
+        path = (p.path or "/").rstrip("/") or "/"
+        return urlunparse((p.scheme.lower() or "https", host, path, "", query, "")).rstrip("?")
+    except Exception:
+        return raw.lower().strip()
+
+
+def _content_hash(title: str, description: str) -> str:
+    """sha256 of title + ' ' + description, lowercased + whitespace-normalized."""
+    text = f"{(title or '').strip()} {(description or '').strip()}".lower()
+    text = re.sub(r"\s+", " ", text)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class IntelRadarJob(AgentJob):
+    name = "intel-radar"
+    timeout_s = 120
+    requires_side_effects = False  # only side effects if new intel found
+
+    async def run(self) -> RunResult:
+        # Pick query based on current hour: tier from hour bucket, query from
+        # round-robin within tier (uses hour itself as index for determinism).
+        now = datetime.now(WITA)
+        hour = now.hour
+        tier = _active_tier(hour)
+        queries = _tier_queries(tier)
+        query = queries[hour % len(queries)]
+
+        # Freshness: 'pd' (past day) by default; can be overridden via env for
+        # backward-compat with older cron schedules that wanted weekly window.
+        freshness = os.getenv("INTEL_RADAR_FRESHNESS", "pd")
+
+        self.log_step(
+            "search_start",
+            inputs={"query": query, "hour": hour, "tier": tier, "freshness": freshness},
+        )
+
+        results = await web_search(query, count=5, freshness=freshness, logger=self.logger)
+        self.log_step(
+            "search_done",
+            outputs={
+                "results": len(results),
+                "source": results[0]["source"] if results else "none",
+            },
+        )
+
+        if not results:
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="no_results",
+            )
+
+        # Hot-path dedup via Redis (preserves legacy behavior).
+        new_results = self._filter_new(results)
+        self.log_step("dedup_redis", outputs={"new": len(new_results), "total": len(results)})
+
+        if not new_results:
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="no_new_intel",
+            )
+
+        # Mark seen in Redis (7-day TTL).
+        self._mark_seen(new_results)
+
+        # DB persistence (feature-flagged for safe rollout).
+        if os.getenv("INTEL_RADAR_PERSIST_DB", "false").lower() == "true":
+            inserted = await self._persist_to_db(query, tier, new_results)
+            self.log_step(
+                "db_persist",
+                outputs={"inserted": inserted, "candidates": len(new_results)},
+                side_effect="intel_radar_findings_insert" if inserted > 0 else None,
+            )
+
+        # No Telegram. Daily digest job (intel_radar_daily_digest.py at 18:00 WITA)
+        # reads from intel_radar_findings WHERE processed=false and notifies once/day.
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=json.dumps(
+                {
+                    "tier": tier,
+                    "query": query,
+                    "new": len(new_results),
+                },
+                default=str,
+            ),
+        )
+
+    async def _persist_to_db(
+        self,
+        query: str,
+        tier: str,
+        results: list[dict],
+    ) -> int:
+        """INSERT findings into intel_radar_findings.
+
+        Returns the count of rows actually inserted (UNIQUE(canonical_url) may
+        skip duplicates already seen in earlier runs).
+        """
+        try:
+            import asyncpg  # local import: only loaded when flag enabled
+        except ImportError:
+            self.logger.error("asyncpg_missing", msg="install asyncpg or unset INTEL_RADAR_PERSIST_DB")
+            return 0
+
+        dsn = os.getenv("DATABASE_URL")
+        if not dsn:
+            self.logger.error("database_url_missing")
+            return 0
+
+        inserted = 0
+        try:
+            conn = await asyncpg.connect(dsn, timeout=10)
+        except Exception as exc:
+            self.logger.error("db_connect_failed", error=str(exc))
+            return 0
+
+        try:
+            for r in results:
+                url = (r.get("url") or "").strip()
+                if not url:
+                    continue
+                canonical = _canonical_url(url)
+                title = r.get("title") or ""
+                description = r.get("description") or ""
+                content_hash = _content_hash(title, description)
+                source = r.get("source") or "brave"
+                # Sprint 5: defense-in-depth — DB function COALESCEs to
+                # 'unknown' but Python fallback avoids NULL crossing the
+                # asyncpg boundary. urlparse() can yield empty netloc on
+                # non-standard URLs (file://, data:, etc.).
+                source_domain = urlparse(canonical).netloc or "unknown"
+
+                published_at = r.get("published_at") or r.get("age")
+                # Best-effort parse: only accept ISO-ish strings; otherwise NULL.
+                published_dt = None
+                if published_at and isinstance(published_at, str):
+                    try:
+                        published_dt = datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+                    except ValueError:
+                        published_dt = None
+
+                # Step 1: INSERT finding (fail-soft per existing contract).
+                # If duplicate URL, fetch the existing id for re-tagging
+                # as a corroboration signal (Sprint 5 R3 verdict).
+                finding_id = None
+                is_corroboration = False
+                try:
+                    rec = await conn.fetchrow(
+                        """
+                        INSERT INTO intel_radar_findings (
+                            query, query_tier, url, canonical_url, content_hash,
+                            title, description, source_domain, published_at, source
+                        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                        ON CONFLICT (canonical_url) DO NOTHING
+                        RETURNING id
+                        """,
+                        query, tier, url, canonical, content_hash,
+                        title[:500], description[:2000], source_domain, published_dt, source,
+                    )
+                    if rec is not None:
+                        finding_id = rec["id"]
+                        inserted += 1
+                    else:
+                        # Duplicate URL — fetch existing id so we can re-tag
+                        # provenance and bump credibility (corroboration).
+                        existing = await conn.fetchrow(
+                            "SELECT id FROM intel_radar_findings WHERE canonical_url = $1",
+                            canonical,
+                        )
+                        if existing is not None:
+                            finding_id = existing["id"]
+                            is_corroboration = True
+                except Exception as exc:
+                    self.logger.warning("db_insert_failed", url=url[:80], error=str(exc))
+                    continue
+
+                # Step 2: tag provenance via mata_garuda DB function.
+                # SEPARATE try/except (best-effort, R1 verdict) — finding row
+                # is already committed; provenance failure must NOT trigger
+                # rollback or skip the next finding. Pattern copied from WR2
+                # _tag_provenance_safe().
+                if finding_id is not None:
+                    try:
+                        await conn.fetchval(
+                            "SELECT mata_garuda.tag_intel_finding($1, $2, $3, $4, $5)",
+                            finding_id, source_domain, query, tier, is_corroboration,
+                        )
+                    except Exception as exc:
+                        self.logger.warning(
+                            "tag_provenance_failed",
+                            finding_id=finding_id,
+                            error=str(exc),
+                        )
+
+                # Step 3 (Intel Lake Wave 1, 2026-05-12):
+                # Enqueue to local SQLite outbox for downstream lake dispatch.
+                # ALWAYS enqueue regardless of INSERT/ON CONFLICT outcome —
+                # intel_observations table is append-only (every producer-hit
+                # counts as a trust signal). Drain worker
+                # ~/scripts/intel-lake-outbox-drain.py posts batches every 60s.
+                # Best-effort: outbox failure MUST NOT block the radar.
+                if _LAKE_ENABLED and _lake_enqueue is not None:
+                    try:
+                        _lake_enqueue(
+                            "intel_radar",
+                            {
+                                "producer_name": "intel_radar",
+                                "canonical_url": canonical,
+                                "content_hash": content_hash,
+                                "title": title[:500],
+                                "summary": description[:2000],
+                                "source_domain": source_domain,
+                                "language": None,
+                                "jurisdiction": None,
+                                "topic_tags": [tier.lower(), source],
+                                "published_at": published_dt.isoformat() if published_dt else None,
+                                "score": None,
+                                "raw_payload": {
+                                    "query": query,
+                                    "tier": tier,
+                                    "source": source,
+                                    "url": url,
+                                    "is_corroboration": is_corroboration,
+                                    "finding_id": str(finding_id) if finding_id else None,
+                                },
+                            },
+                        )
+                    except Exception as exc:
+                        self.logger.warning(
+                            "lake_enqueue_failed",
+                            url=url[:80],
+                            error=str(exc),
+                        )
+        finally:
+            await conn.close()
+
+        return inserted
+
+    def _url_hash(self, url: str) -> str:
+        return hashlib.md5(url.encode()).hexdigest()[:12]
+
+    def _filter_new(self, results: list[dict]) -> list[dict]:
+        try:
+            out = subprocess.run(
+                ["redis-cli", "SMEMBERS", REDIS_SEEN_KEY],
+                capture_output=True, text=True, timeout=3,
+            )
+            seen: set = set(out.stdout.strip().splitlines()) if out.returncode == 0 else set()
+            return [r for r in results if self._url_hash(r.get("url", "")) not in seen]
+        except Exception:
+            return results
+
+    def _mark_seen(self, results: list[dict]) -> None:
+        try:
+            for r in results:
+                h = self._url_hash(r.get("url", ""))
+                subprocess.run(
+                    ["redis-cli", "SADD", REDIS_SEEN_KEY, h],
+                    capture_output=True, timeout=3,
+                )
+            subprocess.run(
+                ["redis-cli", "EXPIRE", REDIS_SEEN_KEY, str(REDIS_SEEN_TTL)],
+                capture_output=True, timeout=3,
+            )
+        except Exception:
+            pass
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(IntelRadarJob)

--- a/scripts/cron-agent-python/oss_monitor.py
+++ b/scripts/cron-agent-python/oss_monitor.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+OSS System Announcements Monitor — every 2h (08:00-22:00 WITA).
+
+# Organo: oss-monitor (cron-agent-python, browser scraper) → produce:
+#         Telegram alert (se nuovi annunci) + Redis hash `bz:oss:announcements`
+#         consumato da: ops team, compliance-ops, daily-ops
+# Consuma da: oss.go.id (public, no auth required for announcements page)
+#
+# Ruolo: sentinella OSS. Monitora annunci e comunicasi sistema OSS
+#         (downtime, nuove procedure, aggiornamenti normativa perizinan).
+#         OSS è critico per PT PMA, NIB, perizinan — downtime impatta clienti.
+
+Monitors oss.go.id for:
+  - System announcements / pengumuman
+  - Maintenance windows
+  - New procedure updates
+  - Service status changes
+
+Deduplication via Redis hash (url → hash of content).
+Alerts only on NEW announcements not seen before.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+from browser_job import BrowserJob
+
+
+OSS_ANNOUNCEMENTS_URL = "https://oss.go.id/id/pengumuman"
+OSS_BERITA_URL = "https://oss.go.id/id/berita"
+OSS_HOME_URL = "https://oss.go.id/id"
+REDIS_KEY = "bz:oss:announcements"
+REDIS_EXPIRY = 86400 * 30  # 30 days (keep seen announcements)
+
+
+class OssMonitorJob(BrowserJob):
+    name = "oss-monitor"
+    target_url = OSS_ANNOUNCEMENTS_URL
+    timeout_s = 180
+    page_timeout_ms = 20000
+    requires_side_effects = False  # only fires side effects if new announcements
+
+    async def run(self) -> RunResult:
+        """Fetch OSS announcements, diff against known, alert on new."""
+        # Check robots
+        if not await self._check_robots(self.target_url):
+            return RunResult(status="error", duration_s=self._elapsed(),
+                             error="robots.txt disallows")
+
+        # Fetch berita page (contains article slugs in Next.js RSC payload)
+        await self.random_delay(1.0, 3.0)
+        try:
+            page = await self.fetch_page(OSS_BERITA_URL)
+            html = page["html"]
+        except Exception as e:
+            self._record_failure()
+            return RunResult(status="error", duration_s=self._elapsed(),
+                             side_effects=self._side_effects,
+                             error=f"fetch failed: {e}")
+
+        self.log_step("fetch_done", outputs={"html_len": len(html)})
+
+        # Parse announcements from RSC payload
+        announcements = self._parse_announcements(html)
+        self.log_step("parse_done", outputs={"count": len(announcements)})
+
+        # Deduplicate against Redis
+        new_announcements = await self._filter_new(announcements)
+        self.log_step("dedup_done", outputs={"new": len(new_announcements), "total": len(announcements)})
+
+        if not new_announcements:
+            # No new announcements — silent success
+            self._record_success()
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="no_new_announcements",
+            )
+
+        # Store new in Redis
+        await self._mark_seen(new_announcements)
+
+        # Alert via Telegram
+        msg = self._compose_alert(new_announcements)
+        ok = await self.send_telegram(msg)
+        self.log_step("telegram_send", outputs={"ok": ok},
+                      side_effect="oss_alert" if ok else None,
+                      error=None if ok else "telegram_failed")
+
+        self._record_success()
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=json.dumps(new_announcements, default=str),
+        )
+
+    def _parse_announcements(self, html: str) -> list[dict]:
+        """Extract announcement items from OSS Next.js RSC HTML.
+
+        OSS uses Next.js with RSC streaming — article data is embedded in
+        self.__next_f.push payloads as JSON strings containing slugs.
+        """
+        import json as _json
+        announcements = []
+        seen_slugs: set = set()
+
+        # Extract Next.js RSC payloads
+        payloads = re.findall(r'self\.__next_f\.push\(\[1,(.+?)\]\)', html, re.DOTALL)
+        for payload in payloads:
+            try:
+                decoded = _json.loads(payload)  # payload is a JSON string
+            except Exception:
+                continue
+            # Extract slugs (only Indonesian ones, skip English duplicates)
+            slugs = re.findall(r'"slug":"([a-z0-9][a-z0-9\-]{10,}[a-z0-9])"', decoded)
+            for slug in slugs:
+                # Skip English duplicate slugs (contain apostrophe escapes or English words)
+                if slug in seen_slugs:
+                    continue
+                if any(kw in slug for kw in ["'s-", "women", "commitment-of", "service-declaration:"]):
+                    continue
+                seen_slugs.add(slug)
+                # Convert slug to readable title
+                title = slug.replace("-", " ").title()
+                announcements.append({
+                    "title": title[:300],
+                    "date": "",
+                    "hash": hashlib.md5(slug.encode()).hexdigest()[:12],
+                    "url": f"https://oss.go.id/id/berita/{slug}",
+                })
+
+        return announcements[:20]
+
+    async def _filter_new(self, announcements: list[dict]) -> list[dict]:
+        """Return only announcements not previously seen (via Redis hash)."""
+        if not announcements:
+            return []
+        try:
+            result = subprocess.run(
+                ["redis-cli", "HKEYS", REDIS_KEY],
+                capture_output=True, text=True, timeout=5
+            )
+            known: set = set(result.stdout.strip().splitlines()) if result.returncode == 0 else set()
+            return [a for a in announcements if a.get("hash") not in known]
+        except Exception as e:
+            self.logger.warning("redis_filter_error", error=str(e))
+            return announcements
+
+    async def _mark_seen(self, announcements: list[dict]) -> None:
+        """Mark announcements as seen in Redis."""
+        try:
+            for ann in announcements:
+                h = ann.get("hash", "")
+                if h:
+                    subprocess.run(
+                        ["redis-cli", "HSET", REDIS_KEY, h,
+                         json.dumps({"title": ann["title"], "url": ann.get("url", ""), "ts": int(time.time())})],
+                        capture_output=True, timeout=5
+                    )
+
+                # Intel Lake Wave 3 (2026-05-12): dual-write to local SQLite
+                # outbox. Best-effort — failure must not block existing flow.
+                try:
+                    import hashlib as _h, sys as _sys  # noqa: PLC0415
+                    # task #17 (2026-07-26): was a literal "/Users/nuzantara/scripts" —
+                    # fingerprints the ops host's username/home layout, and it is this
+                    # organism's own catalogued HOME-fork anti-pattern. Derived from
+                    # __file__ instead: this file lives at <...>/scripts/cron-agent-python/,
+                    # intel_lake_outbox.py lives one level up at <...>/scripts/.
+                    _sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+                    from intel_lake_outbox import enqueue as _lake_enqueue  # type: ignore
+                    url = ann.get("url", "") or f"oss://announcement/{h}"
+                    title = ann.get("title", "")
+                    _ch = _h.sha256((title + " " + url).encode()).hexdigest()[:32]
+                    _lake_enqueue(
+                        "oss_monitor",
+                        {
+                            "producer_name": "oss_monitor",
+                            "canonical_url": url,
+                            "content_hash": _ch,
+                            "title": title[:500],
+                            "summary": ann.get("summary", "")[:2000] if ann.get("summary") else None,
+                            "source_domain": "oss.go.id",
+                            "language": "id",
+                            "jurisdiction": "ID-national",
+                            "topic_tags": ["pma", "bkpm", "oss", "regulation", "announcement"],
+                            "published_at": ann.get("date") or None,
+                            "score": None,
+                            "raw_payload": {
+                                "redis_hash": h,
+                                "type": "announcement",
+                            },
+                        },
+                    )
+                except Exception as exc:
+                    self.logger.warning("intel_lake_enqueue_failed", error=str(exc), url=ann.get("url", "")[:80])
+
+            subprocess.run(
+                ["redis-cli", "EXPIRE", REDIS_KEY, str(REDIS_EXPIRY)],
+                capture_output=True, timeout=5
+            )
+        except Exception as e:
+            self.logger.warning("redis_mark_error", error=str(e))
+
+    def _compose_alert(self, new_announcements: list[dict]) -> str:
+        now = datetime.now(WITA)
+        lines = [
+            f"📢 <b>OSS Announcement</b> ({len(new_announcements)} new)",
+            f"{now.strftime('%Y-%m-%d %H:%M WITA')}",
+            "",
+        ]
+        for ann in new_announcements[:5]:
+            date = f" ({ann['date']})" if ann.get("date") else ""
+            lines.append(f"• {ann['title'][:200]}{date}")
+
+        if len(new_announcements) > 5:
+            lines.append(f"... +{len(new_announcements) - 5} altri")
+
+        lines.append("")
+        lines.append(f"🔗 <a href='https://oss.go.id/id/pengumuman'>oss.go.id/pengumuman</a>")
+        return "\n".join(lines)
+
+    def scrape(self, html: str, text: str) -> dict:
+        """Not used — run() is fully overridden."""
+        return {}
+
+
+if __name__ == "__main__":
+    main(OssMonitorJob)

--- a/scripts/cron-agent-python/pajak_monitor.py
+++ b/scripts/cron-agent-python/pajak_monitor.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+Pajak (Tax) Regulation Monitor — daily 08:00 WITA.
+
+# Organo: pajak-monitor (cron-agent-python, browser scraper) → produce:
+#         Telegram alert (nuove normative) + Intel Stage 1 JSON
+# Consuma da: pajak.go.id (DJP — Direktorat Jenderal Pajak) public pages
+#
+# Ruolo: antenna normativa fiscale. Monitora nuove peraturan pajak
+#         rilevanti per clienti Bali Zero (PPN, PPh, PBJT, incentivi).
+#         Ogni nuova normativa fiscale → Intel Stage 1 pipeline → enrichment.
+
+Monitors:
+  - pajak.go.id/peraturan-terbaru (new tax regulations)
+  - pajak.go.id/siaran-pers (press releases)
+
+Output:
+  - Redis set `bz:pajak:seen_urls` for deduplication
+  - Intel Stage 1 JSON files in ~/.intel_scraper/incoming/
+  - Telegram alert with new regulation summary
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main, web_search
+from browser_job import BrowserJob
+
+PAJAK_PERATURAN_URL = "https://pajak.go.id/id/index-peraturan"
+PAJAK_SIARAN_PERS_URL = "https://pajak.go.id/id/siaran-pers-page"
+
+REDIS_KEY_SEEN = "bz:pajak:seen_urls"
+REDIS_EXPIRY = 86400 * 90  # 90 days
+
+INTEL_INCOMING_DIR = Path.home() / ".intel_scraper" / "incoming"
+
+# Tax keywords relevant to Bali Zero clients
+# Broad coverage: any DJP regulation is potentially relevant
+RELEVANT_KEYWORDS = [
+    "ppn", "vat", "pph", "withholding", "pbjt",
+    "wna", "warga negara asing", "foreign", "asing",
+    "bea", "cukai", "fiskal", "tax holiday",
+    "penanaman modal", "investasi", "pt pma",
+    # Broad tax/regulation terms — catch all DJP content
+    "pajak", "perpajakan", "kurs", "tarif", "peraturan",
+    "kebijakan", "pmk", "kep-", "per-", "djp",
+]
+
+
+class PajakMonitorJob(BrowserJob):
+    name = "pajak-monitor"
+    target_url = "https://pajak.go.id"
+    timeout_s = 240
+    requires_side_effects = False
+
+    async def run(self) -> RunResult:
+        """Multi-source tax regulation monitoring."""
+        all_items: list[dict] = []
+
+        # Source 1: pajak.go.id peraturan terbaru
+        items_peraturan = await self._fetch_page_items(
+            PAJAK_PERATURAN_URL, source="pajak_peraturan"
+        )
+        all_items.extend(items_peraturan)
+        self.log_step("fetch_peraturan", outputs={"count": len(items_peraturan)})
+
+        await self.random_delay(2.0, 4.0)
+
+        # Source 2: pajak.go.id siaran pers
+        items_siaran = await self._fetch_page_items(
+            PAJAK_SIARAN_PERS_URL, source="pajak_siaran_pers"
+        )
+        all_items.extend(items_siaran)
+        self.log_step("fetch_siaran_pers", outputs={"count": len(items_siaran)})
+
+        # Source 3: Brave web search for latest DJP regulations
+        search_items = await self._search_djp_updates()
+        all_items.extend(search_items)
+        self.log_step("search_djp", outputs={"count": len(search_items)})
+
+        # Filter by relevance (tax topics relevant to Bali Zero)
+        relevant = [i for i in all_items if self._is_relevant(i.get("title", ""))]
+        self.log_step("relevance_filter", outputs={"relevant": len(relevant), "total": len(all_items)})
+
+        # Deduplicate
+        seen_urls = await self._get_seen_urls()
+        new_items = [i for i in relevant if i.get("url") and i["url"] not in seen_urls]
+        self.log_step("dedup", outputs={"new": len(new_items), "total": len(relevant)})
+
+        if not new_items:
+            self._record_success()
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="no_new_regulations",
+            )
+
+        # Mark seen + write Intel feed
+        await self._mark_seen([i["url"] for i in new_items])
+        intel_count = self._write_intel_feed(new_items)
+        if intel_count > 0:
+            self._side_effects.append(f"intel_feed:{intel_count}")
+
+        # Telegram alert
+        msg = self._compose_alert(new_items)
+        ok = await self.send_telegram(msg)
+        self.log_step("telegram_send", side_effect="pajak_alert" if ok else None)
+
+        self._record_success()
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=json.dumps(new_items[:3], default=str),
+        )
+
+    async def _fetch_page_items(self, url: str, source: str) -> list[dict]:
+        """Fetch and parse items from a pajak.go.id page."""
+        if not await self._check_robots(url):
+            return []
+        try:
+            await self.random_delay(1.0, 2.0)
+            page = await self.fetch_page(url)
+            return self._parse_pajak_html(page["html"], source=source, base_url=url)
+        except Exception as e:
+            self.logger.warning("fetch_error", url=url, error=str(e))
+            return []
+
+    def _parse_pajak_html(self, html: str, source: str, base_url: str) -> list[dict]:
+        """Parse pajak.go.id Drupal HTML for regulation/news links.
+
+        pajak.go.id is a Drupal 9 site (not Next.js).
+        Pattern: <a href="/id/peraturan/slug">REG-NUM</a> followed by <span>TITLE</span>
+        """
+        items = []
+        seen: set = set()
+        base_domain = "https://pajak.go.id"
+
+        # Primary: Drupal pattern — link + span title immediately after
+        for m in re.finditer(
+            r'href="(/id/(?:peraturan|siaran-pers|berita)[^"]+)"[^>]*>[^<]*</a>'
+            r'.*?<span[^>]*>([^<]{10,})</span>',
+            html[:200000], re.DOTALL | re.IGNORECASE
+        ):
+            href = m.group(1)
+            if href.startswith("/"):
+                href = f"{base_domain}{href}"
+            title = m.group(2).strip()
+            title = re.sub(r'\s+', ' ', title)
+            if href not in seen and len(title) > 10:
+                seen.add(href)
+                items.append({
+                    "url": href,
+                    "title": title[:300],
+                    "source": source,
+                    "scraped_at": datetime.now(WITA).isoformat(),
+                    "type": "tax_regulation" if "/peraturan/" in href else "tax_news",
+                })
+
+        # Fallback: any pajak.go.id content links with meaningful titles
+        if not items:
+            for m in re.finditer(
+                r'<a[^>]+href="(/id/(?:peraturan|siaran-pers-page|berita-page|siaran-pers|berita)[^"]*)"[^>]*>(.*?)</a>',
+                html[:200000], re.DOTALL | re.IGNORECASE
+            ):
+                href = m.group(1)
+                if href.startswith("/"):
+                    href = f"{base_domain}{href}"
+                title = re.sub(r'<[^>]+>', '', m.group(2)).strip()
+                title = re.sub(r'\s+', ' ', title)
+                # Derive title from slug if link text is just a regulation number
+                if len(title) < 15:
+                    slug = href.split("/")[-1]
+                    title = slug.replace("-", " ").title()
+                if href not in seen and len(title) > 10:
+                    seen.add(href)
+                    items.append({
+                        "url": href,
+                        "title": title[:300],
+                        "source": source,
+                        "scraped_at": datetime.now(WITA).isoformat(),
+                        "type": "tax_regulation" if "/peraturan/" in href else "tax_news",
+                    })
+
+        return items[:10]
+
+    async def _search_djp_updates(self) -> list[dict]:
+        """Use web_search to find latest DJP regulation news."""
+        try:
+            results = await web_search(
+                "DJP Direktorat Jenderal Pajak peraturan terbaru 2025",
+                count=5,
+                freshness="pw",
+                logger=self.logger,
+            )
+            items = []
+            for r in results:
+                if "pajak" in r.get("url", "").lower() or "djp" in r.get("url", "").lower():
+                    items.append({
+                        "url": r["url"],
+                        "title": r.get("title", "?")[:300],
+                        "source": "web_search",
+                        "scraped_at": datetime.now(WITA).isoformat(),
+                        "type": "tax_news",
+                    })
+            return items[:5]
+        except Exception as e:
+            self.logger.warning("search_error", error=str(e))
+            return []
+
+    def _is_relevant(self, title: str) -> bool:
+        """Check if a regulation title is relevant to Bali Zero clients."""
+        title_lower = title.lower()
+        return any(kw in title_lower for kw in RELEVANT_KEYWORDS)
+
+    async def _get_seen_urls(self) -> set:
+        try:
+            result = subprocess.run(
+                ["redis-cli", "SMEMBERS", REDIS_KEY_SEEN],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                return set(result.stdout.strip().splitlines())
+        except Exception:
+            pass
+        return set()
+
+    async def _mark_seen(self, urls: list[str]) -> None:
+        try:
+            for url in urls:
+                subprocess.run(["redis-cli", "SADD", REDIS_KEY_SEEN, url], capture_output=True, timeout=5)
+            subprocess.run(["redis-cli", "EXPIRE", REDIS_KEY_SEEN, str(REDIS_EXPIRY)], capture_output=True, timeout=5)
+        except Exception:
+            pass
+
+    def _write_intel_feed(self, items: list[dict]) -> int:
+        try:
+            INTEL_INCOMING_DIR.mkdir(parents=True, exist_ok=True)
+            count = 0
+            for item in items:
+                ts = int(time.time())
+                fn = f"pajak_{ts}_{hashlib.md5(item['url'].encode()).hexdigest()[:8]}.json"
+                (INTEL_INCOMING_DIR / fn).write_text(json.dumps({
+                    "source": item.get("source", "pajak"),
+                    "url": item["url"],
+                    "title": item["title"],
+                    "type": item.get("type", "tax_regulation"),
+                    "scraped_at": item.get("scraped_at"),
+                    "pipeline": "intel_stage1",
+                }, indent=2))
+                count += 1
+
+                # Intel Lake Wave 3 (2026-05-12): dual-write to local SQLite
+                # outbox. Best-effort — failure must not block existing flow.
+                try:
+                    import sys as _sys  # noqa: PLC0415
+                    # task #17 (2026-07-26): was a literal "/Users/nuzantara/scripts" —
+                    # fingerprints the ops host's username/home layout, and it is this
+                    # organism's own catalogued HOME-fork anti-pattern. Derived from
+                    # __file__ instead: this file lives at <...>/scripts/cron-agent-python/,
+                    # intel_lake_outbox.py lives one level up at <...>/scripts/.
+                    _sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+                    from intel_lake_outbox import enqueue as _lake_enqueue  # type: ignore
+                    _ch = hashlib.sha256(
+                        (item["title"] + " " + item["url"]).encode()
+                    ).hexdigest()[:32]
+                    _lake_enqueue(
+                        "pajak_monitor",
+                        {
+                            "producer_name": "pajak_monitor",
+                            "canonical_url": item["url"],
+                            "content_hash": _ch,
+                            "title": item["title"][:500],
+                            "summary": item.get("summary", "")[:2000] if item.get("summary") else None,
+                            "source_domain": "pajak.go.id",
+                            "language": "id",
+                            "jurisdiction": "ID-national",
+                            "topic_tags": ["tax", "pajak", item.get("type", "tax_regulation")],
+                            "published_at": item.get("scraped_at"),
+                            "score": None,
+                            "raw_payload": {
+                                "pipeline": "intel_stage1",
+                                "type": item.get("type", "tax_regulation"),
+                            },
+                        },
+                    )
+                except Exception as exc:
+                    self.logger.warning("intel_lake_enqueue_failed", error=str(exc), url=item.get("url", "")[:80])
+            return count
+        except Exception as e:
+            self.logger.error("intel_feed_error", error=str(e))
+            return 0
+
+    def _compose_alert(self, new_items: list[dict]) -> str:
+        now = datetime.now(WITA)
+        import html as _html
+        lines = [
+            f"💰 <b>Pajak Monitor</b> — {len(new_items)} new",
+            f"{now.strftime('%Y-%m-%d %H:%M WITA')}",
+            "",
+        ]
+        for item in new_items[:5]:
+            title = _html.escape(item["title"][:150])
+            lines.append(f"• {title}")
+        if len(new_items) > 5:
+            lines.append(f"... +{len(new_items) - 5} altri")
+        lines.append(f"\n📦 Intel feed: {len(new_items)} items")
+        return "\n".join(lines)
+
+    def scrape(self, html: str, text: str) -> dict:
+        return {}
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(PajakMonitorJob)

--- a/scripts/cron-agent-python/system_doctor.py
+++ b/scripts/cron-agent-python/system_doctor.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+System Doctor — every 4h (:00).
+
+# Organo: system-doctor (cron-agent-python, L1 diagnostic) → produce:
+#         state.json (consumato da tech-orchestrator L2) + Telegram alert
+#         (se YELLOW/RED) + reflection in memory.db
+# Consuma da: Fly.io status, HTTP health endpoints, Redis ping, subprocess
+#
+# Ruolo: occhi e naso dell'organismo. Rileva infra degradation prima
+#         che diventi business outage. L2 (tech-orchestrator) correla i
+#         suoi segnali e decide azioni.
+
+Runs 4 parallel specialist checks (db_diagnoser, vector_diagnoser,
+runtime_diagnoser, services_diagnoser), triages into GREEN/YELLOW/RED,
+applies LOW-risk auto-fixes, synthesizes narrative via Claude SDK if issues.
+
+No LangGraph — plain asyncio gather. Each diagnoser owns its domain.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import TypedDict
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+
+# ─── Shared helpers ────────────────────────────────────────────────────────
+
+
+async def _http_check(url: str, timeout: float = 15.0) -> dict:
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            start = time.time()
+            r = await client.get(url)
+            return {
+                "url": url,
+                "status": r.status_code,
+                "latency_ms": int((time.time() - start) * 1000),
+                "ok": 200 <= r.status_code < 300,
+                "body_preview": r.text[:300],
+            }
+        except Exception as e:
+            return {"url": url, "ok": False, "error": str(e), "latency_ms": -1}
+
+
+async def _shell_check(cmd: list[str], timeout: float = 30.0) -> dict:
+    try:
+        proc = await asyncio.wait_for(
+            asyncio.create_subprocess_exec(
+                *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+            ),
+            timeout=timeout,
+        )
+        stdout, stderr = await proc.communicate()
+        return {
+            "cmd": " ".join(cmd),
+            "exit_code": proc.returncode,
+            "ok": proc.returncode == 0,
+            "stdout": stdout.decode(errors="ignore")[:500],
+            "stderr": stderr.decode(errors="ignore")[:500],
+        }
+    except asyncio.TimeoutError:
+        return {"cmd": " ".join(cmd), "ok": False, "error": "timeout"}
+    except Exception as e:
+        return {"cmd": " ".join(cmd), "ok": False, "error": str(e)}
+
+
+# ─── 4 Diagnosers (run in parallel) ────────────────────────────────────────
+
+
+async def db_diagnoser() -> dict:
+    """Checks: Fly Postgres status + Redis ping."""
+    results = await asyncio.gather(
+        _shell_check(["fly", "status", "--app", "nuzantara-postgres"], timeout=20.0),
+        _shell_check(["redis-cli", "ping"], timeout=5.0),
+        return_exceptions=True,
+    )
+    fly_pg = results[0] if not isinstance(results[0], Exception) else {"ok": False, "error": str(results[0])}
+    redis = results[1] if not isinstance(results[1], Exception) else {"ok": False, "error": str(results[1])}
+
+    issues = []
+    if not fly_pg.get("ok"):
+        issues.append(("RED", "fly_postgres", f"fly status failed: {fly_pg.get('error', fly_pg.get('stderr', '?')[:100])}"))
+    if not redis.get("ok"):
+        issues.append(("RED", "redis", f"PING failed: {redis.get('error', '?')}"))
+    elif "PONG" not in redis.get("stdout", ""):
+        issues.append(("YELLOW", "redis", f"unexpected response: {redis.get('stdout', '?')[:50]}"))
+
+    return {"domain": "db", "checks": {"fly_postgres": fly_pg, "redis": redis}, "issues": issues}
+
+
+async def vector_diagnoser() -> dict:
+    """Checks: local Qdrant daemon (launchd) + Qdrant HTTP health.
+
+    Qdrant runs as the LOCAL MOS daemon (com.balizero.qdrant.daemon on :6333),
+    NOT on Fly — there is no nuzantara-qdrant Fly app (only nuzantara-rag +
+    nuzantara-postgres). The previous Fly target was a phantom that emitted a
+    permanent false RED/YELLOW every run. Fixed 2026-06-19 (TAC alert-flood).
+    """
+    results = await asyncio.gather(
+        _shell_check(["launchctl", "list", "com.balizero.qdrant.daemon"], timeout=10.0),
+        _http_check("http://localhost:6333/healthz", timeout=10.0),
+        return_exceptions=True,
+    )
+    daemon = results[0] if not isinstance(results[0], Exception) else {"ok": False, "error": str(results[0])}
+    qd_http = results[1] if not isinstance(results[1], Exception) else {"ok": False, "error": str(results[1])}
+
+    issues = []
+    if not daemon.get("ok"):
+        issues.append(("RED", "qdrant_daemon", "com.balizero.qdrant.daemon not loaded"))
+    if not qd_http.get("ok"):
+        issues.append(("YELLOW", "qdrant_http", f"localhost:6333/healthz unreachable ({qd_http.get('error', '?')[:80]})"))
+
+    return {"domain": "vector", "checks": {"qdrant_daemon": daemon, "qdrant_http": qd_http}, "issues": issues}
+
+
+async def runtime_diagnoser() -> dict:
+    """Checks: backend-rag health + Drive health (token expiry)."""
+    import re
+    results = await asyncio.gather(
+        _http_check("https://nuzantara-rag.fly.dev/health"),
+        _http_check("https://nuzantara-rag.fly.dev/api/admin/drive/health"),
+        _shell_check(["fly", "status", "--app", "nuzantara-rag"], timeout=20.0),
+        return_exceptions=True,
+    )
+    backend = results[0] if not isinstance(results[0], Exception) else {"ok": False, "error": str(results[0])}
+    drive = results[1] if not isinstance(results[1], Exception) else {"ok": False, "error": str(results[1])}
+    fly_rag = results[2] if not isinstance(results[2], Exception) else {"ok": False, "error": str(results[2])}
+
+    issues = []
+
+    # Backend
+    if not backend.get("ok"):
+        issues.append(("RED", "backend", f"HTTP {backend.get('status', '?')}, err={backend.get('error', '?')[:80]}"))
+    elif backend.get("latency_ms", 0) > 3000:
+        issues.append(("YELLOW", "backend", f"slow ({backend['latency_ms']}ms)"))
+
+    # Fly RAG
+    if not fly_rag.get("ok"):
+        issues.append(("RED", "fly_rag", "fly status failed"))
+
+    # Drive token
+    if not drive.get("ok"):
+        issues.append(("YELLOW", "drive", "health endpoint unreachable"))
+    else:
+        body = drive.get("body_preview", "")
+        m = re.search(r'"time_left_seconds":(-?[\d.]+)', body)
+        if m:
+            secs = float(m.group(1))
+            days = secs / 86400
+            if days < 0:
+                issues.append(("RED", "drive", f"token EXPIRED ({abs(days):.1f}d ago)"))
+            elif days < 7:
+                issues.append(("RED", "drive", f"token expires in {days:.1f}d"))
+            elif days < 14:
+                issues.append(("YELLOW", "drive", f"token expires in {days:.1f}d"))
+
+    return {"domain": "runtime", "checks": {"backend": backend, "drive": drive, "fly_rag": fly_rag}, "issues": issues}
+
+
+async def services_diagnoser() -> dict:
+    """Checks: balizero.com frontend availability."""
+    frontend = await _http_check("https://balizero.com", timeout=10.0)
+    issues = []
+    if not frontend.get("ok"):
+        issues.append(("RED", "frontend", f"balizero.com down (HTTP {frontend.get('status', frontend.get('error', '?'))})"))
+    elif frontend.get("latency_ms", 0) > 5000:
+        issues.append(("YELLOW", "frontend", f"slow ({frontend['latency_ms']}ms)"))
+    return {"domain": "services", "checks": {"frontend": frontend}, "issues": issues}
+
+
+async def cron_agent_diagnoser() -> dict:
+    """Scans ~/logs/cron-agent{,-python}/*.log for recent failures.
+
+    Looks for 'ERROR' / 'script not found' / 'Traceback' / 'exit code [1-9]' in
+    the last ~2h of each log. Absence of any run in >6h on a cron that should
+    tick at least hourly also counts as YELLOW. Audit 2026-04-19 showed the
+    existing diagnosers miss silent failures like core-guardian's missing
+    wrapper script because they only probed HTTP/Redis/DB health.
+    """
+    import os
+    import re
+    import time
+
+    from pathlib import Path as _Path
+
+    log_dirs = [_Path.home() / "logs" / "cron-agent", _Path.home() / "logs" / "cron-agent-python"]
+    error_re = re.compile(r"\b(ERROR|Traceback|script not found|No such file or directory)\b")
+    exit_re = re.compile(r"exit code [1-9]")
+    now = time.time()
+    window_s = 2 * 3600  # look at last 2h of each log
+
+    issues: list[tuple[str, str, str]] = []
+    checks: dict[str, dict] = {}
+    for d in log_dirs:
+        if not d.is_dir():
+            continue
+        for log in d.glob("*.log"):
+            try:
+                st = log.stat()
+            except OSError:
+                continue
+            age_s = now - st.st_mtime
+            # Age-gate: a log that has not been written within the diagnoser
+            # window is a DEAD job, not a failing one. Counting its stale tail
+            # produces a false RED (e.g. core-guardian.log untouched for 52
+            # days still reported its old errors). Skip it — staleness of a
+            # job-that-should-tick is a separate concern handled elsewhere.
+            if age_s > window_s:
+                checks[log.name] = {"age_s": int(age_s), "err_hits_tail": 0, "stale_skipped": True}
+                continue
+            # Only the tail is relevant; read at most the last 64KB.
+            try:
+                with log.open("rb") as fh:
+                    fh.seek(max(0, st.st_size - 65536))
+                    tail = fh.read().decode("utf-8", errors="replace")
+            except OSError as e:
+                issues.append(("YELLOW", f"log:{log.name}", f"unreadable: {e}"))
+                continue
+            # Dedupe: count UNIQUE lines that match either regex, not the sum of
+            # both findalls. A single line like "ERROR ... exit code 1" matches
+            # BOTH error_re and exit_re and was previously counted twice,
+            # inflating err_hits past the RED threshold on a single real error.
+            err_lines = {
+                i
+                for i, line in enumerate(tail.splitlines())
+                if error_re.search(line) or exit_re.search(line)
+            }
+            err_hits = len(err_lines)
+            checks[log.name] = {"age_s": int(age_s), "err_hits_tail": err_hits}
+            if err_hits >= 3:
+                # Repeated failures = broken job, not a blip.
+                issues.append(("RED", f"cron:{log.stem}", f"{err_hits} error lines in last 64KB"))
+            elif err_hits >= 1:
+                issues.append(("YELLOW", f"cron:{log.stem}", f"{err_hits} error lines in last 64KB"))
+    return {"domain": "cron_agent", "checks": checks, "issues": issues}
+
+
+# ─── Main job ──────────────────────────────────────────────────────────────
+
+
+class SystemDoctor(AgentJob):
+    name = "system-doctor"
+    timeout_s = 600
+    requires_side_effects = False  # GREEN runs don't need side effects
+
+    async def run(self) -> RunResult:
+        self.log_step("gather_health_start")
+
+        # ── 5 diagnosers in parallel ──────────────────────────────────────
+        diag_results = await asyncio.gather(
+            db_diagnoser(),
+            vector_diagnoser(),
+            runtime_diagnoser(),
+            services_diagnoser(),
+            cron_agent_diagnoser(),
+            return_exceptions=True,
+        )
+
+        all_issues: list[tuple[str, str, str]] = []
+        all_checks: dict = {}
+        for r in diag_results:
+            if isinstance(r, Exception):
+                all_issues.append(("RED", "diagnoser", str(r)[:100]))
+            else:
+                domain = r.get("domain", "?")
+                all_checks[domain] = r.get("checks", {})
+                all_issues.extend(r.get("issues", []))
+
+        self.log_step("gather_health_done", outputs={"issues": len(all_issues), "domains": len(all_checks)})
+
+        # ── Triage ────────────────────────────────────────────────────────
+        triage = "GREEN"
+        if any(s == "RED" for s, _, _ in all_issues):
+            triage = "RED"
+        elif any(s == "YELLOW" for s, _, _ in all_issues):
+            triage = "YELLOW"
+
+        self.log_step("triage", outputs={"level": triage, "issues": len(all_issues)})
+
+        # ── Auto-fix (LOW-risk only) ──────────────────────────────────────
+        fixes: list[str] = []
+        if triage == "RED":
+            for severity, service, detail in all_issues:
+                if service == "backend" and severity == "RED" and (
+                    "HTTP 5" in detail or "timeout" in detail.lower()
+                ):
+                    r = await _shell_check(
+                        ["fly", "machines", "restart", "--app", "nuzantara-rag"],
+                        timeout=60.0,
+                    )
+                    if r.get("ok"):
+                        fixes.append("restarted fly machines (nuzantara-rag)")
+                        self._side_effects.append("fly_restart:nuzantara-rag")
+            self.log_step("auto_fix", outputs={"fixes": len(fixes)})
+
+        # ── Compose report ────────────────────────────────────────────────
+        report_text = self._compose_report(triage, all_issues, fixes)
+
+        # ── Deliver (only if not GREEN to avoid spam) ─────────────────────
+        if triage in ("YELLOW", "RED"):
+            ok = await self.send_telegram(report_text)
+            self.log_step(
+                "telegram_send",
+                outputs={"ok": ok},
+                side_effect="telegram_alert" if ok else None,
+                error=None if ok else "telegram_failed",
+            )
+        else:
+            self.log_step("telegram_skipped", outputs={"reason": "GREEN_no_spam"})
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=report_text,
+        )
+
+    def _compose_report(
+        self,
+        triage: str,
+        issues: list[tuple[str, str, str]],
+        fixes: list[str],
+    ) -> str:
+        emoji = {"GREEN": "🟢", "YELLOW": "🟡", "RED": "🔴"}.get(triage, "❓")
+        lines = [
+            f"{emoji} <b>System Doctor</b> — {triage}",
+            f"{datetime.now(WITA).strftime('%H:%M WITA')}",
+        ]
+
+        if triage == "GREEN":
+            lines.append("All services healthy ✅")
+        else:
+            red = [i for i in issues if i[0] == "RED"]
+            yel = [i for i in issues if i[0] == "YELLOW"]
+            if red:
+                lines.append(f"\n<b>🔴 RED ({len(red)}):</b>")
+                for _, svc, det in red:
+                    lines.append(f"• {svc}: {det}")
+            if yel:
+                lines.append(f"\n<b>🟡 YELLOW ({len(yel)}):</b>")
+                for _, svc, det in yel:
+                    lines.append(f"• {svc}: {det}")
+            if fixes:
+                lines.append("\n<b>✅ Auto-fixes applied:</b>")
+                for f in fixes:
+                    lines.append(f"• {f}")
+
+        return "\n".join(lines)
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(SystemDoctor)

--- a/scripts/cron-agent-python/tdd_pipeline.py
+++ b/scripts/cron-agent-python/tdd_pipeline.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+TDD Pipeline — weekly on Monday 09:00 WITA.
+
+# Organo: tdd-pipeline (cron-agent-python, --agents pattern) → produce:
+#         Test files in backend-rag/tests/ + Telegram report
+# Consuma da: backend-rag/backend/services/ (recently modified files)
+#
+# Ruolo: dev velocity. Scansiona services/ per file modificati nell'ultima
+#         settimana senza test corrispondenti. Invoca Claude Code con pattern
+#         --agents (planner → test_writer → code_writer → reviewer) per
+#         generare test. Max 3 target files per run (token budget).
+
+Process:
+  1. Find recently modified .py files in backend/services/ without tests
+  2. For each (up to MAX_TARGETS): invoke claude with --agents JSON pipeline
+  3. Verify generated tests run (pytest --collect-only)
+  4. Report results via Telegram
+
+Usage:
+  bash run.sh tdd-pipeline
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+BACKEND_ROOT = Path.home() / "Desktop" / "nuzantara" / "apps" / "backend-rag"
+SERVICES_DIR = BACKEND_ROOT / "backend" / "services"
+TESTS_DIR = BACKEND_ROOT / "backend" / "tests" / "services"
+
+# Max service files to process per run (token budget control)
+MAX_TARGETS = 3
+# Files modified within this many days
+RECENCY_DAYS = 7
+
+# Claude Code binary (macOS: installed to ~/.local/bin/claude)
+CLAUDE_BIN = str(Path.home() / ".local" / "bin" / "claude")
+
+
+class TddPipelineJob(AgentJob):
+    name = "tdd-pipeline"
+    timeout_s = 600  # 10min per file × 3 = 30min, but capped
+    requires_side_effects = False
+
+    async def run(self) -> RunResult:
+        if not BACKEND_ROOT.exists():
+            return RunResult(
+                status="error", duration_s=self._elapsed(),
+                error="backend-rag not found", side_effects=[],
+            )
+
+        # Find targets: recently modified services without tests
+        targets = self._find_targets()
+        self.log_step("scan_targets", outputs={"targets": len(targets)})
+
+        if not targets:
+            return RunResult(
+                status="ok", duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="no_targets",
+            )
+
+        results: list[dict] = []
+        for svc_file in targets[:MAX_TARGETS]:
+            result = await self._run_tdd_agent(svc_file)
+            results.append(result)
+            self.log_step(
+                "tdd_agent_done",
+                inputs={"file": svc_file.name},
+                outputs={"status": result.get("status"), "tests_added": result.get("tests_added", 0)},
+            )
+            await asyncio.sleep(2)  # brief pause between targets
+
+        passed = sum(1 for r in results if r.get("status") == "ok")
+        failed = len(results) - passed
+
+        msg = self._compose_report(results)
+        ok = await self.send_telegram(msg)
+        self.log_step("telegram_sent", side_effect="tdd_report" if ok else None)
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=json.dumps({"targets": len(targets), "processed": len(results),
+                                "passed": passed, "failed": failed}),
+        )
+
+    def _find_targets(self) -> list[Path]:
+        """Find recently modified service files without corresponding tests."""
+        if not SERVICES_DIR.exists():
+            return []
+
+        cutoff = time.time() - (RECENCY_DAYS * 86400)
+        targets = []
+
+        for svc_file in SERVICES_DIR.rglob("*.py"):
+            if svc_file.name.startswith("_") or "test" in svc_file.name:
+                continue
+            # Check recency
+            if svc_file.stat().st_mtime < cutoff:
+                continue
+            # Check for corresponding test file
+            rel_path = svc_file.relative_to(SERVICES_DIR)
+            expected_test = TESTS_DIR / rel_path.parent / f"test_{svc_file.name}"
+            if expected_test.exists():
+                continue  # test exists, skip
+            targets.append(svc_file)
+
+        # Sort by modification time (most recent first)
+        targets.sort(key=lambda f: f.stat().st_mtime, reverse=True)
+        return targets
+
+    async def _run_tdd_agent(self, svc_file: Path) -> dict[str, Any]:
+        """Run Claude Code TDD pipeline for a single service file."""
+        rel_path = svc_file.relative_to(BACKEND_ROOT)
+        test_rel = Path("backend/tests/services") / svc_file.relative_to(SERVICES_DIR).parent / f"test_{svc_file.name}"
+        test_abs = BACKEND_ROOT / test_rel
+
+        # Build the --agents JSON for the TDD pipeline
+        agents_config = {
+            "agents": [
+                {
+                    "name": "planner",
+                    "model": "claude-haiku-4-5-20251001",
+                    "prompt": (
+                        f"Read {rel_path} and output ONLY a JSON object with: "
+                        "'module_purpose' (1 sentence), "
+                        "'public_functions' (list of function names to test), "
+                        "'test_scenarios' (list of 3-5 test case descriptions). "
+                        "No code, no explanations, JSON only."
+                    ),
+                    "output_key": "plan",
+                },
+                {
+                    "name": "test_writer",
+                    "model": "claude-sonnet-4-6",
+                    "prompt": (
+                        f"Using the plan from the planner agent, write pytest tests for {rel_path}. "
+                        f"Save to {test_rel}. "
+                        "Rules: PYTHONPATH=. imports, async tests with pytest-asyncio, "
+                        "mock external deps (httpx, asyncpg, redis), "
+                        "no database connections in tests, "
+                        "test only the public API from the plan."
+                    ),
+                    "depends_on": ["planner"],
+                },
+                {
+                    "name": "reviewer",
+                    "model": "claude-haiku-4-5-20251001",
+                    "prompt": (
+                        f"Review {test_rel} for: import errors, missing fixtures, "
+                        "correct async/sync annotations, proper mocking. "
+                        "Fix any issues found. Report ONLY: 'LGTM' or list of fixes applied."
+                    ),
+                    "depends_on": ["test_writer"],
+                },
+            ]
+        }
+
+        prompt = (
+            f"TDD pipeline for {rel_path}. "
+            "Planner analyzes the service, test_writer writes tests, reviewer fixes issues. "
+            f"Target: {test_rel}"
+        )
+
+        try:
+            # Check if claude binary exists
+            if not Path(CLAUDE_BIN).exists():
+                return await self._run_tdd_simple(svc_file, test_abs, rel_path, test_rel)
+
+            proc = await asyncio.create_subprocess_exec(
+                CLAUDE_BIN,
+                "--dangerously-skip-permissions",
+                "-p", prompt,
+                "--agents", json.dumps(agents_config),
+                "--model", "claude-sonnet-4-6",
+                "--output-format", "text",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(BACKEND_ROOT),
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=180)
+            output = stdout.decode(errors="replace").strip()
+
+            if proc.returncode != 0:
+                self.logger.warning(
+                    "tdd_agent_failed",
+                    file=svc_file.name,
+                    returncode=proc.returncode,
+                    stderr=stderr.decode(errors="replace")[:200],
+                )
+                return {"file": svc_file.name, "status": "error", "error": f"exit {proc.returncode}"}
+
+            # Verify test file was created and is collectible
+            tests_added = await self._verify_tests(test_abs)
+            # task #17/#42 (2026-07-26): the failure branch above logs plaintext via
+            # self.logger.warning; success left NO plaintext trace — log_step()'s
+            # hash-on-inputs/outputs was the only record, into a state.json overwritten
+            # every run. Measured: 3 months, 14 runs, 18 successful writes into the live
+            # checkout, none reconstructable from any log/state/git-history. "An
+            # unattended writer whose success path logs a hash cannot be held
+            # accountable for anything it did." None of these three fields are PII —
+            # service filenames + relative test path, same class of data the failure
+            # path already logs in plaintext.
+            self.logger.info(
+                "tdd_agent_succeeded",
+                file=svc_file.name,
+                tests_added=tests_added,
+                test_path=str(test_rel),
+            )
+            return {"file": svc_file.name, "status": "ok", "tests_added": tests_added, "output": output[:200]}
+
+        except asyncio.TimeoutError:
+            return {"file": svc_file.name, "status": "error", "error": "timeout_180s"}
+        except Exception as e:
+            return {"file": svc_file.name, "status": "error", "error": str(e)[:100]}
+
+    async def _run_tdd_simple(
+        self, svc_file: Path, test_abs: Path, rel_path: Path, test_rel: Path
+    ) -> dict[str, Any]:
+        """Fallback: invoke claude via subprocess without --agents (single-pass)."""
+        try:
+            if not Path(CLAUDE_BIN).exists():
+                return {"file": svc_file.name, "status": "skip", "error": "claude binary not found"}
+
+            prompt = (
+                f"Write pytest tests for `{rel_path}`. "
+                f"Save to `{test_rel}`. "
+                "Use PYTHONPATH=. imports, mock external deps (httpx, asyncpg, redis), "
+                "pytest-asyncio for async tests, no real DB connections."
+            )
+            proc = await asyncio.create_subprocess_exec(
+                CLAUDE_BIN,
+                "--dangerously-skip-permissions",
+                "-p", prompt,
+                "--model", "claude-sonnet-4-6",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(BACKEND_ROOT),
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+            if proc.returncode != 0:
+                return {"file": svc_file.name, "status": "error", "error": f"exit {proc.returncode}"}
+            tests_added = await self._verify_tests(test_abs)
+            return {"file": svc_file.name, "status": "ok", "tests_added": tests_added}
+        except Exception as e:
+            return {"file": svc_file.name, "status": "error", "error": str(e)[:100]}
+
+    async def _verify_tests(self, test_file: Path) -> int:
+        """Run pytest --collect-only on the generated test file. Returns test count."""
+        if not test_file.exists():
+            return 0
+        try:
+            venv_pytest = BACKEND_ROOT / ".venv" / "bin" / "pytest"
+            pytest_bin = str(venv_pytest) if venv_pytest.exists() else "pytest"
+            proc = await asyncio.create_subprocess_exec(
+                pytest_bin,
+                str(test_file),
+                "--collect-only",
+                "-q",
+                "--no-header",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(BACKEND_ROOT),
+                env={**os.environ, "PYTHONPATH": str(BACKEND_ROOT)},
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
+            output = stdout.decode(errors="replace")
+            # Count "test_" items collected
+            return output.count("<Function test_")
+        except Exception:
+            return 0
+
+    def _compose_report(self, results: list[dict]) -> str:
+        now = datetime.now(WITA)
+        passed = [r for r in results if r.get("status") == "ok"]
+        failed = [r for r in results if r.get("status") != "ok"]
+        icon = "✅" if not failed else "⚠️"
+        lines = [
+            f"{icon} <b>TDD Pipeline</b> — {len(results)} files",
+            f"{now.strftime('%Y-%m-%d %H:%M WITA')}",
+            "",
+        ]
+        for r in passed:
+            n = r.get("tests_added", 0)
+            lines.append(f"✅ {r['file']} (+{n} tests)")
+        for r in failed:
+            lines.append(f"❌ {r['file']} — {r.get('error', '?')[:60]}")
+        return "\n".join(lines)
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(TddPipelineJob)

--- a/scripts/cron-agent-python/tdd_pipeline.py
+++ b/scripts/cron-agent-python/tdd_pipeline.py
@@ -35,7 +35,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent))
 from agent_job import AgentJob, RunResult, WITA, main
 
-BACKEND_ROOT = Path.home() / "Desktop" / "nuzantara" / "apps" / "backend-rag"
+BACKEND_ROOT = Path.home() / "nuzantara" / "apps" / "backend-rag"
 SERVICES_DIR = BACKEND_ROOT / "backend" / "services"
 TESTS_DIR = BACKEND_ROOT / "backend" / "tests" / "services"
 

--- a/scripts/cron-agent-python/tech_orchestrator.py
+++ b/scripts/cron-agent-python/tech_orchestrator.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""
+Tech Orchestrator (L2) — every 4h at :30.
+
+# Organo: tech-orchestrator (cron-agent-python, L2 correlator) → produce:
+#         Telegram brief operazionale + azioni fly/git/deploy (condizionali)
+# Consuma da: system-doctor state.json, weekly-dep-audit state.json (L1 agents)
+#
+# Ruolo: cervello decisionale. Correla segnali multipli, applica guardrails
+#         deterministici (blackout/deploy-in-progress/diff-gate), delega fix
+#         bounded a Claude SDK con can_use_tool safety. Se l'organismo ha un
+#         immune system, qui e' il T-helper che orchestra la risposta.
+# Simbiosi: non decide autonomamente deploy se diff tocca file critici
+#         (fly.toml, dependencies.py, alembic) — escalate a Zero sempre.
+
+Reads L1 agent outputs (system-doctor, weekly-dep-audit), correlates signals,
+decides remediation, executes LOW-risk fixes, delegates MEDIUM fixes to Claude
+Code CLI, and reports HIGH issues for human review.
+
+Uses full Claude Agent SDK:
+- can_use_tool hook for deploy safety (diff-size gate, critical files check)
+- max_turns + max_budget_usd hard caps (prevent runaway)
+- PreToolUse / PostToolUseFailure hooks for audit trail
+- Streaming ToolUseBlock inspection
+
+Guardrails (deterministic, no LLM):
+- Blackout 00:00-03:00 WITA → skip
+- Deploy-in-progress → no deploy actions
+- Diff-size gate → >3 files or critical paths → no deploy
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+STATE_DIR = Path.home() / ".cron-agent-python"
+
+
+# ─── Guardrails (deterministic) ─────────────────────────────────────────────
+
+def is_blackout() -> bool:
+    """00:00-03:00 WITA = no action window."""
+    hour = datetime.now(WITA).hour
+    return 0 <= hour < 3
+
+
+async def is_deploy_in_progress() -> bool:
+    """Check fly status for 'deploy' keyword."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "fly", "status", "--app", "nuzantara-rag",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=20.0)
+        return b"deploy" in stdout.lower()
+    except Exception:
+        return False
+
+
+def diff_size_check() -> dict:
+    """Returns {safe: bool, files: list, critical: list}."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(Path.home() / "Desktop" / "nuzantara"),
+             "diff", "--name-only", "HEAD", "--", "apps/backend-rag/backend/"],
+            capture_output=True, text=True, timeout=10,
+        )
+        # task #17/#20 fail-open fix (2026-07-26): `subprocess.run` here had no
+        # `check=True`, so a nonzero returncode (dead/unreadable path — a stale
+        # `~/Desktop/nuzantara` compat symlink is the only thing standing
+        # between this and a permanently-open gate) never raised, and empty
+        # stdout on a failed `git diff` is byte-identical to empty stdout on a
+        # genuinely clean tree: `files = []` -> `safe = True`. A gate that
+        # cannot measure the diff must not authorise a deploy.
+        if r.returncode != 0:
+            return {"safe": False, "files": [], "critical": [], "error": f"git diff exited {r.returncode}: {r.stderr.strip()}"}
+        files = [f for f in r.stdout.strip().split("\n") if f]
+        critical_patterns = ["dependencies.py", "fly.toml", ".env", "alembic/env.py"]
+        critical = [f for f in files if any(p in f for p in critical_patterns)]
+        safe = len(files) <= 3 and len(critical) == 0
+        return {"safe": safe, "files": files, "critical": critical}
+    except Exception as e:
+        return {"safe": False, "files": [], "critical": [], "error": str(e)}
+
+
+# ─── Load L1 reports ────────────────────────────────────────────────────────
+
+def load_l1_report(name: str) -> dict | None:
+    """Read state.json from a sibling agent job (fallback path)."""
+    f = STATE_DIR / f"{name}.state.json"
+    if not f.exists():
+        return None
+    try:
+        d = json.loads(f.read_text())
+        # Fresh if run in last 24h
+        age = time.time() - d.get("ts", 0)
+        if age > 86400:
+            return None
+        return d
+    except Exception:
+        return None
+
+
+async def consume_redis_events(streams: list[str], max_age_s: int = 3600) -> list[dict]:
+    """Read recent events from Redis cron:reports stream.
+
+    VADEMECUM §1 point 8 — event-driven. Preferred over load_l1_report (polling).
+    Returns list of event dicts from specified streams, filtered by age.
+
+    Graceful degradation: if Redis down, returns empty list.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "redis-cli", "-t", "3",
+            "XREVRANGE", "cron:reports", "+", "-", "COUNT", "20",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        if proc.returncode != 0:
+            return []
+    except Exception:
+        return []
+
+    # Parse redis-cli output: alternating lines
+    # <id>\n<field1>\n<value1>\n<field2>\n<value2>\n...
+    lines = stdout.decode().strip().split("\n")
+    events: list[dict] = []
+    now = time.time()
+    i = 0
+    while i < len(lines):
+        stream_id = lines[i].strip()
+        if not stream_id or "-" not in stream_id:
+            i += 1
+            continue
+        # Read fields
+        event: dict[str, str] = {"_stream_id": stream_id}
+        i += 1
+        while i < len(lines) and "-" not in lines[i]:
+            key = lines[i].strip()
+            i += 1
+            if i < len(lines):
+                val = lines[i].strip()
+                event[key] = val
+                i += 1
+        # Filter by job name and age
+        if event.get("job") in streams:
+            ts = int(event.get("ts", 0))
+            if now - ts <= max_age_s:
+                events.append(event)
+    return events
+
+
+# ─── Correlation analysis (rule-based) ──────────────────────────────────────
+
+def correlate(
+    system_doctor: dict | None,
+    weekly_dep_audit: dict | None,
+) -> list[dict]:
+    """Return list of issues with classification.
+
+    Each issue: {severity: LOW|MED|HIGH, category: str, description: str,
+                 auto_fix: callable | None, delegate_prompt: str | None}
+    """
+    issues: list[dict] = []
+
+    # system-doctor signals — handle both dict (from state.json) and Redis event format
+    sd = system_doctor or {}
+    sd_status = sd.get("status", "?")
+    # Redis events store side_effects as comma-separated string; state.json as list
+    raw_side_effects = sd.get("side_effects", [])
+    if isinstance(raw_side_effects, str):
+        sd_side_effects = raw_side_effects.split(",")
+    else:
+        sd_side_effects = raw_side_effects
+
+    # If system-doctor detected RED (via telegram_alert side effect) → investigate
+    if any("telegram_alert" in s for s in sd_side_effects) and sd_status == "ok":
+        issues.append({
+            "severity": "MED",
+            "category": "infra_alert",
+            "description": "system-doctor alerted — check infra health",
+            "auto_fix": None,
+            "delegate_prompt": None,
+        })
+
+    # weekly-dep-audit signals
+    # (not yet migrated, skip for now)
+
+    return issues
+
+
+# ─── Remediation actions ────────────────────────────────────────────────────
+
+
+async def restart_backend() -> dict:
+    """LOW-risk: restart nuzantara-rag Fly machines."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "fly", "machines", "restart", "--app", "nuzantara-rag",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60.0)
+        ok = proc.returncode == 0
+        return {"ok": ok, "stdout": stdout.decode()[:300], "stderr": stderr.decode()[:300]}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ─── Main tech orchestrator job ─────────────────────────────────────────────
+
+
+class TechOrchestrator(AgentJob):
+    name = "tech-orchestrator"
+    timeout_s = 900
+    requires_side_effects = False
+
+    async def run(self) -> RunResult:
+        actions_taken: list[str] = []
+        pending_human: list[str] = []
+
+        # ── Guardrail 1: blackout ───────────────────────────────────────
+        if is_blackout():
+            self.log_step("blackout_skip", outputs={"hour": datetime.now(WITA).hour})
+            return RunResult(status="ok", duration_s=self._elapsed(),
+                             side_effects=[], output="BLACKOUT 00-03 WITA — skipped")
+
+        # ── Guardrail 2: deploy in progress ─────────────────────────────
+        deploy_in_progress = await is_deploy_in_progress()
+        self.log_step("check_deploy_in_progress", outputs={"in_progress": deploy_in_progress})
+
+        # ── Guardrail 3: diff size ──────────────────────────────────────
+        diff = diff_size_check()
+        self.log_step("diff_size_check", outputs=diff)
+
+        # ── Step 1: load L1 reports (prefer Redis stream, fallback filesystem) ──
+        # VADEMECUM §1 point 8 — event-driven Redis consumer.
+        l1_events = await consume_redis_events(
+            streams=["system-doctor", "weekly-dep-audit"],
+            max_age_s=3600 * 6,  # last 6h
+        )
+        self.log_step("consume_redis_events", outputs={"count": len(l1_events)})
+
+        # Deduplicate by job (keep most recent)
+        latest_by_job: dict[str, dict] = {}
+        for ev in l1_events:
+            job = ev.get("job", "")
+            if job not in latest_by_job or ev.get("ts", "0") > latest_by_job[job].get("ts", "0"):
+                latest_by_job[job] = ev
+
+        # Fallback to filesystem state.json if Redis has nothing
+        sd = latest_by_job.get("system-doctor") or load_l1_report("system-doctor")
+        dep = latest_by_job.get("weekly-dep-audit") or load_l1_report("weekly-dep-audit")
+        self.log_step("load_l1_reports", outputs={
+            "system_doctor": sd is not None,
+            "weekly_dep_audit": dep is not None,
+            "source": "redis" if latest_by_job else "filesystem",
+        })
+
+        if sd is None and dep is None:
+            # No fresh data → passive
+            self.log_step("no_fresh_data", outputs={"action": "no-op"})
+            await self.send_telegram(
+                "🔧 <b>Tech Orchestrator</b>\n"
+                "No fresh L1 data (system-doctor / weekly-dep-audit). Skipping correlation."
+            )
+            return RunResult(status="ok", duration_s=self._elapsed(),
+                             side_effects=self._side_effects,
+                             output="No L1 data available")
+
+        # ── Step 2: correlation ─────────────────────────────────────────
+        issues = correlate(sd, dep)
+        self.log_step("correlate", outputs={
+            "issues_count": len(issues),
+            "severities": [i["severity"] for i in issues],
+        })
+
+        # ── Step 3: remediation ─────────────────────────────────────────
+        for issue in issues:
+            sev = issue["severity"]
+            cat = issue["category"]
+            desc = issue["description"]
+
+            if sev == "LOW":
+                # Auto-act (if we have auto_fix)
+                fn = issue.get("auto_fix")
+                if fn:
+                    r = await fn()
+                    actions_taken.append(f"{cat}: {r}")
+                    self._side_effects.append(f"auto_fix:{cat}")
+                    self.log_step(f"auto_fix:{cat}", outputs=r)
+
+            elif sev == "MED":
+                # Delegate to Claude SDK with strict tool budget
+                prompt = issue.get("delegate_prompt")
+                if prompt and not deploy_in_progress:
+                    result = await self._delegate_with_sdk(prompt, category=cat)
+                    actions_taken.append(f"{cat}: delegated → {result[:100]}")
+                    self.log_step(f"delegate:{cat}", outputs={"len": len(result)})
+
+            elif sev == "HIGH":
+                pending_human.append(f"[{cat}] {desc}")
+
+        # ── Step 4: deploy rule (only if fixes applied AND diff safe) ──
+        deployed = False
+        if actions_taken and diff["safe"] and not deploy_in_progress:
+            # Check tests first (deterministic)
+            tests_ok = await self._run_tests()
+            self.log_step("pre_deploy_tests", outputs={"ok": tests_ok})
+            if tests_ok:
+                deploy_result = await self._deploy()
+                deployed = deploy_result["ok"]
+                actions_taken.append(f"deploy: {'OK' if deployed else 'FAILED'}")
+                self._side_effects.append("fly_deploy" if deployed else "fly_deploy_failed")
+                self.log_step("deploy", outputs=deploy_result)
+
+        # ── Step 5: compose Telegram brief ──────────────────────────────
+        brief = self._compose_brief(
+            sd=sd, dep=dep, issues=issues,
+            actions_taken=actions_taken,
+            pending_human=pending_human,
+            deployed=deployed,
+            diff=diff,
+        )
+
+        # Skip Telegram if nothing interesting (GREEN path)
+        if actions_taken or pending_human or (sd and "telegram_alert" in sd.get("side_effects", [])):
+            await self.send_telegram(brief)
+
+        return RunResult(
+            status="ok",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=brief,
+        )
+
+    # ── SDK delegation (bounded) ────────────────────────────────────────
+
+    async def _delegate_with_sdk(self, prompt: str, category: str) -> str:
+        """Delegate a MED-severity fix to Claude via SDK with hard caps.
+
+        Uses:
+        - max_turns=5 (prevent infinite loops)
+        - can_use_tool callback (block dangerous tools)
+        - PreToolUse / PostToolUseFailure hooks (audit)
+        """
+        from claude_agent_sdk import (
+            ClaudeSDKClient,
+            ClaudeAgentOptions,
+            PermissionResultAllow,
+            PermissionResultDeny,
+            HookMatcher,
+        )
+
+        audit: list[dict] = []
+
+        async def can_use_tool(name: str, input: dict, ctx: Any):
+            """Safety: block rm -rf, git push, fly deploy."""
+            if name == "Bash":
+                cmd = input.get("command", "")
+                dangerous = ["rm -rf", "git push", "fly deploy", "DROP TABLE", "DELETE FROM"]
+                if any(d in cmd for d in dangerous):
+                    audit.append({"denied": True, "tool": name, "reason": f"dangerous: {cmd[:80]}"})
+                    return PermissionResultDeny(message=f"Blocked dangerous command: {cmd[:80]}")
+            audit.append({"tool": name, "input_preview": str(input)[:100]})
+            return PermissionResultAllow()
+
+        # Routing: use Opus 4.7 high effort for orchestration (enables
+        # native parallel tool calls when tasks are independent).
+        from agent_config import get_config, MODEL_OPUS_47
+        cfg = get_config(self.name)
+        resolved_model = cfg["model"]
+        resolved_effort = cfg["effort"]
+        if resolved_effort == "xhigh":
+            resolved_effort = "high"  # CLI compat
+
+        opts = ClaudeAgentOptions(
+            max_turns=5,
+            effort=resolved_effort,
+            model=resolved_model,
+            permission_mode="bypassPermissions",
+            can_use_tool=can_use_tool,
+            setting_sources=[],
+            tools=["Bash", "Read", "Edit"],  # narrow tool set
+            thinking={"type": "adaptive"} if resolved_model == MODEL_OPUS_47 else None,  # type: ignore[arg-type]
+            system_prompt=(
+                "You are a focused fix agent for a single issue. "
+                "Make minimal changes. Do not modify dependencies.py, fly.toml, "
+                ".env, or alembic/. When steps are INDEPENDENT (e.g. reading 3 "
+                "unrelated files, running 2 non-conflicting Bash commands), "
+                "emit their tool_use blocks IN PARALLEL in the same turn to "
+                "minimize latency. Serialize only when step B depends on A's "
+                "output."
+            ),
+        )
+
+        chunks: list[str] = []
+        try:
+            async with ClaudeSDKClient(options=opts) as client:
+                await client.query(prompt)
+                async for msg in client.receive_response():
+                    content = getattr(msg, "content", None)
+                    if isinstance(content, list):
+                        for block in content:
+                            text = getattr(block, "text", None)
+                            if text:
+                                chunks.append(text)
+                    elif isinstance(content, str):
+                        chunks.append(content)
+        except Exception as e:
+            return f"[delegate error: {e}]"
+
+        self.log_step(f"delegate_audit:{category}", outputs={"calls": len(audit)})
+        return "\n".join(chunks).strip()
+
+    # ── Deploy helpers ──────────────────────────────────────────────────
+
+    async def _run_tests(self) -> bool:
+        """Run core backend tests."""
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                "cd ~/nuzantara/apps/backend-rag && "
+                "source .venv/bin/activate && "
+                "PYTHONPATH=. timeout 120 pytest backend/tests/services/rag/test_confidence.py -x --tb=line -q",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=150.0)
+            return proc.returncode == 0
+        except Exception:
+            return False
+
+    async def _deploy(self) -> dict:
+        """Deploy backend-rag (rolling)."""
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                "cd ~/nuzantara/apps/backend-rag && fly deploy --strategy rolling",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=480.0)
+            return {
+                "ok": proc.returncode == 0,
+                "stdout": stdout.decode()[-500:],
+                "stderr": stderr.decode()[-500:],
+            }
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+    # ── Brief composition ──────────────────────────────────────────────
+
+    def _compose_brief(self, sd, dep, issues, actions_taken, pending_human, deployed, diff) -> str:
+        lines = [
+            "🔧 <b>Tech Orchestrator</b>",
+            f"{datetime.now(WITA).strftime('%H:%M WITA')}",
+        ]
+
+        # L1 status
+        sd_icon = "✅" if sd and sd.get("status") == "ok" else "⚠️"
+        dep_icon = "✅" if dep and dep.get("status") == "ok" else "—"
+        lines.append(f"\n<b>L1 status:</b> system-doctor {sd_icon} · weekly-dep {dep_icon}")
+
+        # Git diff context
+        if diff["files"]:
+            lines.append(f"<b>Uncommitted changes:</b> {len(diff['files'])} files" +
+                         (f" ⚠️ {len(diff['critical'])} critical" if diff["critical"] else ""))
+
+        # Issues
+        if issues:
+            lines.append(f"\n<b>Correlated issues:</b> {len(issues)}")
+            for i in issues[:5]:
+                lines.append(f"• [{i['severity']}] {i['description']}")
+
+        # Actions
+        if actions_taken:
+            lines.append(f"\n<b>Actions taken:</b>")
+            for a in actions_taken[:5]:
+                lines.append(f"✅ {a[:120]}")
+
+        if deployed:
+            lines.append(f"\n🚀 Deployed backend-rag")
+
+        if pending_human:
+            lines.append(f"\n<b>Needs human:</b>")
+            for p in pending_human[:5]:
+                lines.append(f"⚠️ {p}")
+
+        if not actions_taken and not pending_human and not issues:
+            lines.append("\n✅ All quiet.")
+
+        return "\n".join(lines)
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(TechOrchestrator)

--- a/scripts/cron-agent-python/tech_orchestrator.py
+++ b/scripts/cron-agent-python/tech_orchestrator.py
@@ -71,17 +71,27 @@ def diff_size_check() -> dict:
     """Returns {safe: bool, files: list, critical: list}."""
     try:
         r = subprocess.run(
-            ["git", "-C", str(Path.home() / "Desktop" / "nuzantara"),
+            ["git", "-C", str(Path.home() / "nuzantara"),
              "diff", "--name-only", "HEAD", "--", "apps/backend-rag/backend/"],
             capture_output=True, text=True, timeout=10,
         )
         # task #17/#20 fail-open fix (2026-07-26): `subprocess.run` here had no
         # `check=True`, so a nonzero returncode (dead/unreadable path — a stale
-        # `~/Desktop/nuzantara` compat symlink is the only thing standing
-        # between this and a permanently-open gate) never raised, and empty
-        # stdout on a failed `git diff` is byte-identical to empty stdout on a
-        # genuinely clean tree: `files = []` -> `safe = True`. A gate that
-        # cannot measure the diff must not authorise a deploy.
+        # compat-symlink target is the only thing standing between this and a
+        # permanently-open gate) never raised, and empty stdout on a failed
+        # `git diff` is byte-identical to empty stdout on a genuinely clean
+        # tree: `files = []` -> `safe = True`. A gate that cannot measure the
+        # diff must not authorise a deploy.
+        #
+        # Path fixed 2026-07-27 (#3259 antidotes): this HOME-fork promotion
+        # (task #17) had faithfully carried the live copy's old TCC-protected
+        # path literal (the repo's pre-2026-07-16 location, under the
+        # user's home Desktop folder), re-importing the exact TCC hazard
+        # (W84) that the repo's move to its current home-relative location
+        # exists to remove — promoting a HOME script does not make it a
+        # repo script; it still carries the environment it was written for.
+        # scripts/lint_tcc_desktop_paths.py is the standing gate that
+        # caught it.
         if r.returncode != 0:
             return {"safe": False, "files": [], "critical": [], "error": f"git diff exited {r.returncode}: {r.stderr.strip()}"}
         files = [f for f in r.stdout.strip().split("\n") if f]

--- a/scripts/cron-agent-python/vision_doc_extractor.py
+++ b/scripts/cron-agent-python/vision_doc_extractor.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""
+Vision Doc Extractor — hourly OCR-grade extraction from Bali Zero sources.
+
+# Organo: vision-doc-extractor (cron-agent-python) → produce:
+#         JSON strutturato + push NB-2 (NotebookLM Operations) via `nlm`
+#         CLI + Telegram alert su conflitto con knowledge esistente
+# Consuma da: ~/.intel_scraper/inbox/ (PDF/PNG/JPG da monitor pipeline)
+#
+# Ruolo: estrae dati strutturati da documenti normativi
+#         (Permen/Perpres/SE Imigrasi/OSS/Pajak) usando Opus 4.7 vision HD.
+#         Zero pricing governativo (solo rimando a PricingTool Bali Zero).
+
+Input:
+  - ~/.intel_scraper/inbox/<file.pdf|png|jpg>
+  - State file ~/.cron-agent-python/vision-doc-extractor.state.json con hash MD5
+
+Pipeline per file:
+  1. Hash MD5 → skip se gia' processato
+  2. Se PDF → convert first page a PNG (pdf2image, ~300 DPI)
+  3. Resize lato lungo max 2576px (Vision HD cap) senza downscale
+  4. base64 encode + invia a Opus 4.7 con prompt strutturato
+  5. Parse JSON output con Pydantic schema (ExtractedDoc)
+  6. Push a NB-2 via `nlm source add <NB_OPS_ID env var> --text "<JSON>" --title "<filename>"`
+  7. Alert Telegram se chiavi critiche (article_text) contengono conflict markers
+
+Env required (no hardcoded fallback — task #17 redaction, 2026-07-26: a literal
+NotebookLM UUID and Telegram chat ID were fallback defaults in source; removed
+because a docstring-adjacent literal has no credential SHAPE and is invisible
+to pattern-based secret scans):
+  - NB_OPS_ID (NotebookLM Operations notebook UUID)
+  - TELEGRAM_BOT_TOKEN (via ~/.nuzantara-secrets.env)
+  - TELEGRAM_ALERT_CHAT (chat id for conflict alerts)
+
+Config via agent_config.py:
+  - model: claude-opus-4-7
+  - effort: xhigh (downgrade a high su CLI)
+  - task_budget: 100k (ignorato su OAuth Max, ok)
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_job import AgentJob, RunResult, WITA, main
+
+
+INBOX_DIR = Path.home() / ".intel_scraper" / "inbox"
+PROCESSED_DIR = Path.home() / ".intel_scraper" / "processed"
+OUTPUT_DIR = Path.home() / ".intel_scraper" / "extracted"
+MAX_EDGE_PX = 2576  # Opus 4.7 vision HD cap
+MAX_FILES_PER_RUN = 5
+# task #17 redaction (2026-07-26): both used to carry a literal fallback default
+# (a NotebookLM notebook UUID, a Telegram chat id) — deleted, not just "made
+# optional". No credential SHAPE means a pattern-based secret scan never sees
+# them; only the docstring three lines above said what they pointed to. Both
+# are now required at point of use and fail loud when unset, rather than
+# silently falling back to a value that shipped in cleartext source.
+
+CONFLICT_MARKERS = (
+    # If the model flags a contradiction with prior knowledge in its output,
+    # these substrings trigger a Telegram alert.
+    "CONFLICT",
+    "contradicts",
+    "superseded",
+    "cabut",
+    "dicabut",
+    "repealed",
+)
+
+EXTRACTION_PROMPT = """You are a Bali Zero legal-document extractor. The image is a
+page from an Indonesian regulatory source (Permen / Perpres / SE Imigrasi /
+peraturan OSS / peraturan Pajak).
+
+Extract strictly-structured data. Respond with a SINGLE JSON object, no prose,
+no markdown fences. Schema:
+
+{
+  "doc_type": "Permen|Perpres|PP|UU|SE|Surat Edaran|Pengumuman|Unknown",
+  "number": "string or empty",
+  "year": "string or empty",
+  "issued_date": "YYYY-MM-DD or empty",
+  "issuing_authority": "string (Kementerian/Ditjen/Instansi)",
+  "title": "headline in Bahasa Indonesia",
+  "key_articles": [
+    {"article": "Pasal X", "text": "verbatim Bahasa, max 500 chars"}
+  ],
+  "durations": [
+    {"subject": "string (e.g. Visa C1)", "days": "integer", "extendable": "boolean or null"}
+  ],
+  "nominal_costs": [
+    {"type": "PNBP|biaya|retribusi", "amount_idr": "string", "source_article": "Pasal X"}
+  ],
+  "expiry_deadlines": [
+    {"what": "string", "by_date": "YYYY-MM-DD or empty"}
+  ],
+  "supersedes": "string (citation if this document repeals/amends a prior one)",
+  "notes": "string (max 300 chars, verbatim only, zero speculation)"
+}
+
+Rules:
+- Zero pricing speculation. Only verbatim nominal amounts shown in the image.
+- If a field is not present in the image, use empty string "" or empty list [].
+- Do not invent article numbers. Only quote articles visible in the image.
+- If the image is blurry/illegible, set "title" to "ILLEGIBLE" and other fields empty.
+- If this document appears to CONFLICT with or SUPERSEDE a prior regulation, mention it in "supersedes".
+"""
+
+
+@dataclass
+class ExtractedDoc:
+    """Loose schema — Pydantic stricter validation happens at parse time."""
+    doc_type: str
+    number: str
+    year: str
+    title: str
+    raw_json: dict[str, Any]
+
+
+class VisionDocExtractorJob(AgentJob):
+    name = "vision-doc-extractor"
+    timeout_s = 600
+    requires_side_effects = False  # only fires if new documents found
+
+    async def run(self) -> RunResult:
+        INBOX_DIR.mkdir(parents=True, exist_ok=True)
+        PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
+        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+        seen_hashes = self._load_state()
+
+        # Gather candidate files
+        candidates = [
+            p for p in sorted(INBOX_DIR.iterdir())
+            if p.is_file() and p.suffix.lower() in {".pdf", ".png", ".jpg", ".jpeg"}
+        ]
+        if not candidates:
+            self.log_step("inbox_empty")
+            return RunResult(
+                status="ok",
+                duration_s=self._elapsed(),
+                side_effects=self._side_effects,
+                output="inbox_empty",
+            )
+
+        processed = 0
+        pushed = 0
+        alerts = 0
+        errors = 0
+
+        for path in candidates[:MAX_FILES_PER_RUN]:
+            try:
+                file_hash = self._file_hash(path)
+                if file_hash in seen_hashes:
+                    self.log_step("skip_seen", inputs={"file": path.name, "hash": file_hash})
+                    continue
+
+                image_bytes, mime = self._load_as_image(path)
+                self.log_step(
+                    "image_loaded",
+                    inputs={"file": path.name, "bytes": len(image_bytes), "mime": mime},
+                )
+
+                extracted = await self._extract(image_bytes, mime)
+                if not extracted:
+                    errors += 1
+                    continue
+
+                # Persist JSON
+                out_path = OUTPUT_DIR / f"{path.stem}.json"
+                out_path.write_text(json.dumps(extracted.raw_json, indent=2, ensure_ascii=False))
+                self.log_step(
+                    "json_written",
+                    outputs={"file": out_path.name, "doc_type": extracted.doc_type},
+                    side_effect=f"extracted:{out_path.name}",
+                )
+
+                # Push to NB-2
+                ok_push = self._push_to_nb2(extracted, path.name)
+                if ok_push:
+                    pushed += 1
+
+                # Conflict check
+                if self._has_conflict(extracted.raw_json):
+                    await self._alert_conflict(path.name, extracted)
+                    alerts += 1
+
+                # Move to processed
+                shutil.move(str(path), str(PROCESSED_DIR / path.name))
+                seen_hashes[file_hash] = {
+                    "file": path.name,
+                    "ts": int(time.time()),
+                    "doc_type": extracted.doc_type,
+                }
+                processed += 1
+            except Exception as e:
+                self.logger.error("extract_error", file=path.name, error=str(e))
+                errors += 1
+
+        self._save_state(seen_hashes)
+
+        self.log_step(
+            "run_summary",
+            outputs={
+                "processed": processed,
+                "pushed_nb2": pushed,
+                "alerts": alerts,
+                "errors": errors,
+            },
+        )
+
+        return RunResult(
+            status="ok" if errors == 0 else "error",
+            duration_s=self._elapsed(),
+            side_effects=self._side_effects,
+            output=json.dumps({
+                "processed": processed, "pushed": pushed, "alerts": alerts, "errors": errors,
+            }),
+            error=None if errors == 0 else f"{errors} file(s) failed extraction",
+        )
+
+    # ── State ────────────────────────────────────────────────────────────
+
+    def _load_state(self) -> dict[str, dict]:
+        if not self.state_file.exists():
+            return {}
+        try:
+            data = json.loads(self.state_file.read_text())
+            return data.get("seen_hashes", {}) or {}
+        except Exception:
+            return {}
+
+    def _save_state(self, seen_hashes: dict[str, dict]) -> None:
+        # Preserve last result payload written by AgentJob._write_state
+        existing = {}
+        if self.state_file.exists():
+            try:
+                existing = json.loads(self.state_file.read_text())
+            except Exception:
+                pass
+        existing["seen_hashes"] = seen_hashes
+        self.state_file.write_text(json.dumps(existing, indent=2))
+
+    def _file_hash(self, path: Path) -> str:
+        h = hashlib.md5()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    # ── Image prep ───────────────────────────────────────────────────────
+
+    def _load_as_image(self, path: Path) -> tuple[bytes, str]:
+        """Return (bytes, mime_type). PDFs: first page rasterized at max 2576px."""
+        suffix = path.suffix.lower()
+        if suffix == ".pdf":
+            from pdf2image import convert_from_path
+            pages = convert_from_path(str(path), first_page=1, last_page=1, dpi=300)
+            if not pages:
+                raise ValueError(f"pdf2image returned no pages for {path.name}")
+            img = pages[0]
+        else:
+            from PIL import Image
+            img = Image.open(str(path))
+            img.load()
+
+        # Clamp to MAX_EDGE_PX on long side only (no downscale otherwise)
+        from PIL import Image
+        if max(img.size) > MAX_EDGE_PX:
+            ratio = MAX_EDGE_PX / float(max(img.size))
+            new_size = (int(img.size[0] * ratio), int(img.size[1] * ratio))
+            img = img.resize(new_size, Image.LANCZOS)
+
+        buf = io.BytesIO()
+        # Always emit PNG for fidelity
+        img.convert("RGB").save(buf, format="PNG", optimize=True)
+        return buf.getvalue(), "image/png"
+
+    # ── Vision call via Claude Agent SDK ────────────────────────────────
+
+    async def _extract(self, image_bytes: bytes, mime: str) -> ExtractedDoc | None:
+        """Call Opus 4.7 with image + prompt, return parsed ExtractedDoc."""
+        from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
+        from agent_config import get_config, MODEL_OPUS_47
+
+        cfg = get_config(self.name)
+        resolved_model = cfg["model"]
+        resolved_effort = cfg["effort"]
+        if resolved_effort == "xhigh":
+            resolved_effort = "high"  # CLI compat
+
+        opts_kwargs: dict[str, Any] = {
+            "max_turns": 1,
+            "effort": resolved_effort,
+            "model": resolved_model,
+            "tools": [],
+            "allowed_tools": [],
+            "permission_mode": "bypassPermissions",
+            "setting_sources": [],
+            "system_prompt": (
+                "You are a strict JSON-only extraction system. Output a single JSON "
+                "object matching the schema. No prose, no markdown fences."
+            ),
+        }
+        if cfg.get("task_budget") and resolved_model == MODEL_OPUS_47:
+            opts_kwargs["task_budget"] = {"total": int(cfg["task_budget"])}
+        if cfg.get("betas"):
+            opts_kwargs["betas"] = list(cfg["betas"])
+
+        opts = ClaudeAgentOptions(**opts_kwargs)
+
+        b64 = base64.standard_b64encode(image_bytes).decode("ascii")
+        message = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": mime, "data": b64},
+                    },
+                    {"type": "text", "text": EXTRACTION_PROMPT},
+                ],
+            },
+            "parent_tool_use_id": None,
+            "session_id": "default",
+        }
+
+        async def _stream():
+            yield message
+
+        chunks: list[str] = []
+        try:
+            async with ClaudeSDKClient(options=opts) as client:
+                await client.query(_stream())
+                async for msg in client.receive_response():
+                    content = getattr(msg, "content", None)
+                    if isinstance(content, list):
+                        for block in content:
+                            text = getattr(block, "text", None)
+                            if text:
+                                chunks.append(text)
+                    elif isinstance(content, str):
+                        chunks.append(content)
+        except Exception as e:
+            self.logger.error("vision_sdk_error", error=str(e))
+            return None
+
+        raw = "\n".join(chunks).strip()
+        # Strip accidental fences
+        if raw.startswith("```"):
+            raw = raw.split("```", 2)[1]
+            if raw.lstrip().startswith("json"):
+                raw = raw.split("\n", 1)[1] if "\n" in raw else raw
+            raw = raw.rsplit("```", 1)[0]
+        raw = raw.strip()
+
+        try:
+            parsed = json.loads(raw)
+        except Exception as e:
+            self.logger.error("json_parse_error", error=str(e), raw_preview=raw[:200])
+            return None
+
+        return ExtractedDoc(
+            doc_type=str(parsed.get("doc_type", "Unknown")),
+            number=str(parsed.get("number", "")),
+            year=str(parsed.get("year", "")),
+            title=str(parsed.get("title", "")),
+            raw_json=parsed,
+        )
+
+    # ── NB-2 push via nlm CLI ────────────────────────────────────────────
+
+    def _push_to_nb2(self, doc: ExtractedDoc, source_filename: str) -> bool:
+        nb_id = os.environ.get("NB_OPS_ID")
+        if not nb_id:
+            raise RuntimeError(
+                "NB_OPS_ID env var is required (no hardcoded fallback, task #17) — "
+                "set it before running vision-doc-extractor"
+            )
+        title = f"{doc.doc_type} {doc.number}/{doc.year} — {source_filename}".strip()
+        body = json.dumps(doc.raw_json, ensure_ascii=False, indent=2)
+        try:
+            result = subprocess.run(
+                ["nlm", "source", "add", nb_id, "--text", body, "--title", title[:200]],
+                capture_output=True, text=True, timeout=120,
+            )
+            ok = result.returncode == 0
+            self.log_step(
+                "nb2_push",
+                outputs={"ok": ok, "title": title[:100]},
+                side_effect=f"nb2:{source_filename}" if ok else None,
+                error=None if ok else (result.stderr or result.stdout)[:500],
+            )
+            return ok
+        except Exception as e:
+            self.logger.error("nb2_push_error", error=str(e))
+            return False
+
+    # ── Conflict detection + Telegram ────────────────────────────────────
+
+    def _has_conflict(self, parsed: dict) -> bool:
+        blob = json.dumps(parsed, ensure_ascii=False).lower()
+        supersedes = str(parsed.get("supersedes", "")).strip()
+        if supersedes and supersedes.lower() not in ("", "none", "n/a"):
+            return True
+        return any(marker.lower() in blob for marker in CONFLICT_MARKERS)
+
+    async def _alert_conflict(self, filename: str, doc: ExtractedDoc) -> None:
+        supersedes = str(doc.raw_json.get("supersedes", ""))[:300]
+        msg = (
+            f"⚠️ <b>Vision Doc Extractor</b> — possibile conflitto knowledge\n"
+            f"{datetime.now(WITA).strftime('%Y-%m-%d %H:%M WITA')}\n\n"
+            f"File: <code>{filename}</code>\n"
+            f"Tipo: {doc.doc_type} {doc.number}/{doc.year}\n"
+            f"Titolo: {doc.title[:200]}\n\n"
+            f"Supersedes/repeal flag:\n<code>{supersedes}</code>\n\n"
+            f"Controlla JSON in <code>~/.intel_scraper/extracted/</code>"
+        )
+        # Route to the configured alert chat per plan §5.
+        chat_id = os.environ.get("TELEGRAM_ALERT_CHAT")
+        if not chat_id:
+            raise RuntimeError(
+                "TELEGRAM_ALERT_CHAT env var is required (no hardcoded fallback, task #17) — "
+                "set it before running vision-doc-extractor"
+            )
+        await self.send_telegram(msg, chat_id=chat_id)
+
+    def _elapsed(self) -> float:
+        return time.time() - self.started_at
+
+
+if __name__ == "__main__":
+    main(VisionDocExtractorJob)


### PR DESCRIPTION
## Summary
- Promotes 15 previously-live-only cron-agent-python job files into the repo so `lint_home_fork.py` can track them (they had no repo twin before — invisible to the HOME-fork lint entirely).
- Appends 15 matching entries to `infra/home-fork/declared-pairs.json` (surgical text-level edit, existing formatting preserved — 90 insertions, 0 deletions).
- Fixes applied while porting (documented in full in the commit body): vision_doc_extractor.py redactions, path fixes in pajak/oss/imigrasi_monitor.py, tech_orchestrator.py's diff_size_check fail-open fix, tdd_pipeline.py's success-logging asymmetry fix.
- 6 files intentionally left out of scope (documented in commit body).

Task #17.

## Test plan
- [x] Pre-push suite passed (verified via detached retry after an unrelated load-sensitive flaky-test rejection — see task #58)
- [x] `infra/home-fork/declared-pairs.json` diff reviewed surgically (90 insertions, 0 deletions vs a prior bad json.dump-based reformat that was reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)