### PR TITLE
fix(tests): drop the import-time chdir that broke a subprocess three trees away

### DIFF
--- a/apps/backend-rag/backend/tests/integration/zantara/test_tier1_fallback.py
+++ b/apps/backend-rag/backend/tests/integration/zantara/test_tier1_fallback.py
@@ -24,9 +24,14 @@ backend_path = Path(__file__).parent.parent.parent.parent.parent
 if str(backend_path) not in sys.path:
     sys.path.insert(0, str(backend_path))
 
-# Change to backend directory for imports
-os.chdir(str(backend_path / "backend"))
-
+# NO os.chdir here. This module used to chdir into backend/ "for imports" at import
+# time — but the sys.path.insert above is what makes `from backend...` resolve, and a
+# module-level chdir is never undone: it moves the cwd of the WHOLE pytest process for
+# every test collected after it. Anything that then reads a relative path in a child
+# process breaks. That is exactly how `PYTHONPATH=.` in CI came to mean
+# apps/backend-rag/backend, so tests/test_sentry_lazy_import.py's `python -c` subprocess
+# died on `ModuleNotFoundError: No module named 'backend'` — a test three directories
+# away, failing for a line in this file. test_no_global_cwd_mutation.py pins it.
 from backend.services.rag.agentic.reasoning import ReasoningEngine
 from backend.services.rag.agentic.reasoning_utils import (
     get_critical_domain_type,

--- a/apps/backend-rag/backend/tests/test_no_global_cwd_mutation.py
+++ b/apps/backend-rag/backend/tests/test_no_global_cwd_mutation.py
@@ -1,0 +1,125 @@
+"""No test module may move the process working directory at import time.
+
+A module-level ``os.chdir`` runs during *collection* and is never undone, so it
+relocates the cwd of the whole pytest process for every test collected after it.
+Nothing in-process usually notices — imports already resolved through ``sys.path``
+— which is why this survived a long time. Subprocesses do notice: they re-resolve
+relative paths, and the CI command exports ``PYTHONPATH=.``.
+
+Lived instance: ``backend/tests/integration/zantara/test_tier1_fallback.py`` chdir'd
+into ``backend/`` at import time, so ``PYTHONPATH=.`` came to mean
+``apps/backend-rag/backend``, and the ``python -c`` child spawned by
+``tests/test_sentry_lazy_import.py`` died on ``ModuleNotFoundError: No module named
+'backend'`` — a test in another tree, failing for a line it never touches. It only
+surfaced when #3227 added that file to the CI pytest invocation for the first time.
+
+Inside a test body ``monkeypatch.chdir`` is fine: pytest restores it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+TEST_TREES = ("backend/tests", "tests")
+
+
+def _module_level_chdirs(source: str, label: str = "<inline>") -> list[str]:
+    """Return ``label:lineno`` for every ``*.chdir(...)`` reachable at import time.
+
+    Walks only the module's top-level statements, so a call nested in a function or
+    method body — which runs when that test runs, under pytest's fixtures — is not
+    reported. Matches on the attribute name rather than on ``os.chdir`` specifically:
+    ``from os import chdir as cd`` and ``pathlib``-flavoured aliases mutate the same
+    process state, and matching the import spelling would be exactly the over-match
+    that lets the next instance through.
+    """
+    hits: list[str] = []
+
+    def visit(node: ast.AST) -> None:
+        # `ast.walk` would descend into function bodies, which do NOT run at import
+        # time — that reads every fixture's scoped chdir as an offence. Recurse by
+        # hand and stop at anything deferred to call time. A ClassDef body is not
+        # deferred, so it stays in scope.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            return
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "chdir"
+        ):
+            hits.append(f"{label}:{node.lineno}")
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+
+    for stmt in ast.parse(source, label).body:
+        visit(stmt)
+    return hits
+
+
+def test_no_test_module_chdirs_at_import_time() -> None:
+    """The real suite carries no import-time chdir."""
+    offenders: list[str] = []
+    scanned = 0
+    for tree in TEST_TREES:
+        root = BACKEND_ROOT / tree
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*.py"):
+            try:
+                source = path.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+            scanned += 1
+            offenders += _module_level_chdirs(
+                source, str(path.relative_to(BACKEND_ROOT))
+            )
+
+    # A scan that walked nothing is not a clean scan (W84): fail loudly instead of
+    # reporting an empty offender list as success.
+    assert scanned > 100, f"only {scanned} test modules scanned — the walk is broken"
+    assert not offenders, (
+        "module-level chdir moves the cwd for the entire pytest process and is never "
+        "restored; use monkeypatch.chdir inside the test instead: " + ", ".join(offenders)
+    )
+
+
+def test_detector_flags_an_import_time_chdir() -> None:
+    """Guilt: the shape this guard exists to catch is caught."""
+    guilty = "import os\nbackend_path = '/x'\nos.chdir(backend_path)\n"
+    assert _module_level_chdirs(guilty) == ["<inline>:3"]
+
+    aliased = "from os import chdir\nimport pathlib\npathlib.os.chdir('/x')\n"
+    assert _module_level_chdirs(aliased) == ["<inline>:3"]
+
+    guarded = "import os\nif True:\n    os.chdir('/x')\n"
+    assert _module_level_chdirs(guarded) == ["<inline>:3"], (
+        "a chdir under a module-level `if` still runs at import time"
+    )
+
+
+def test_detector_leaves_scoped_chdir_alone() -> None:
+    """Innocence: a chdir that runs per-test, restored by pytest, is not an offence."""
+    scoped = (
+        "import os\n"
+        "def test_thing(tmp_path, monkeypatch):\n"
+        "    monkeypatch.chdir(tmp_path)\n"
+        "    assert os.getcwd()\n"
+    )
+    assert _module_level_chdirs(scoped) == []
+
+    in_fixture = (
+        "import os\n"
+        "import pytest\n"
+        "@pytest.fixture\n"
+        "def somewhere_else(tmp_path):\n"
+        "    old = os.getcwd()\n"
+        "    os.chdir(tmp_path)\n"
+        "    yield tmp_path\n"
+        "    os.chdir(old)\n"
+    )
+    assert _module_level_chdirs(in_fixture) == []
+
+    mentioned_only = "CHDIR_IS_BANNED = 'os.chdir'\n"
+    assert _module_level_chdirs(mentioned_only) == []

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 666 services · 1256 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 666 services · 1258 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

`main` is red on **Backend Tests (Python)**:

```
FAILED tests/test_sentry_lazy_import.py::test_sentry_config_import_skips_sentry_sdk_when_disabled
  ModuleNotFoundError: No module named 'backend'
```

## Why

`backend/tests/integration/zantara/test_tier1_fallback.py` called

```python
os.chdir(str(backend_path / "backend"))   # module level, "for imports"
```

at **import time**. That runs during collection and is never undone, so it moves the cwd
of the whole pytest process for every test collected afterwards. In-process nothing
noticed — the `sys.path.insert` two lines above is what actually resolves
`from backend...`, and that is cwd-independent, which is why the line survived so long.

Subprocesses notice. CI exports `PYTHONPATH=.`, and after the chdir that `.` means
`apps/backend-rag/backend`, so the `python -c` child spawned by
`tests/test_sentry_lazy_import.py` cannot find `backend` at all.

Reproduced verbatim, no CI required:

```
cd apps/backend-rag         && PYTHONPATH=. python3 -c "import backend"   ->  OK
cd apps/backend-rag/backend && PYTHONPATH=. python3 -c "import backend"   ->  ModuleNotFoundError: No module named 'backend'
```

The landmine is old; it only went off now because #3227 added
`tests/test_sentry_lazy_import.py` to the CI pytest invocation — it is the only
subprocess-spawning test in the newly armed set, so it is the first thing ever to observe
the corrupted cwd.

## Fix

- Delete the chdir (the file uses no cwd-relative path — checked).
- Add `backend/tests/test_no_global_cwd_mutation.py`, which AST-scans both test trees for
  import-time `chdir`.

The guard asserts **guilt** (module-level `os.chdir`, an aliased `pathlib.os.chdir`, and
one under a module-level `if`), **innocence** (`monkeypatch.chdir` in a test body, a
fixture that chdirs and restores, and the bare string `'os.chdir'`), and refuses a
blind scan (`scanned > 100`, W84). It was also run against the **pre-fix** file and
reports `:28` — a guard that cannot catch the bug it was written for is decoration.

Worth recording: the first draft used `ast.walk`, which descends into function bodies, so
it flagged every fixture's scoped chdir. The innocence case caught it before it shipped —
which is the whole argument for requiring one.

## Scope

Class-audited: this was the **only** import-time chdir in `backend/tests/` or `tests/`.
`AI_ONBOARDING.md`'s test count is regenerated in the same commit, not a follow-up (W86).

Not run under pytest locally — this worktree has no backend venv — but the guard itself is
pure stdlib and was executed directly (3/3 plus the control), and the root cause was
reproduced with the shell commands above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)