### PR TITLE
fix(ci): unbreak main — two never-run tests armed by #3227 broke both required suites

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -143,6 +143,7 @@ jobs:
             scripts/tests/test_docs_inventory_refresh_liveness.py \
             scripts/tests/test_docs_inventory_regen.py \
             scripts/tests/test_fly_backup_timeouts.py \
+            scripts/tests/test_no_import_time_chdir_in_tests.py \
             scripts/test_lint_test_reward_hacking.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"

--- a/apps/backend-rag/backend/tests/integration/zantara/test_tier1_fallback.py
+++ b/apps/backend-rag/backend/tests/integration/zantara/test_tier1_fallback.py
@@ -19,13 +19,28 @@ os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/tes
 os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
 os.environ.setdefault("ENVIRONMENT", "test")
 
-# Add backend to Python path
+# Add backend to Python path. This is what makes `import backend` work here —
+# and it is enough on its own.
+#
+# There used to be an `os.chdir(backend_path / "backend")` on the next line,
+# labelled "change to backend directory for imports". It was never needed for
+# the imports, and because it ran at MODULE scope it fired during pytest
+# COLLECTION and moved the cwd of the whole session, permanently, for every
+# test collected after it. Any later test that resolves something relative to
+# the cwd then resolves it against `apps/backend-rag/backend` instead of
+# `apps/backend-rag`. Not hypothetical: it broke
+# `tests/test_sentry_lazy_import.py`, which spawns a subprocess inheriting the
+# cwd and CI's relative `PYTHONPATH=.` — the child looked for `backend/` inside
+# `backend/` and died with `ModuleNotFoundError: No module named 'backend'`,
+# turning main red for every PR in the repo. It passed in isolation and failed
+# in the suite, which is the signature of exactly this class of defect.
+#
+# Never chdir at import scope in a test module. If a test genuinely needs a
+# different cwd, use `monkeypatch.chdir(...)` inside it, which restores.
+# Enforced by scripts/tests/test_no_import_time_chdir_in_tests.py.
 backend_path = Path(__file__).parent.parent.parent.parent.parent
 if str(backend_path) not in sys.path:
     sys.path.insert(0, str(backend_path))
-
-# Change to backend directory for imports
-os.chdir(str(backend_path / "backend"))
 
 from backend.services.rag.agentic.reasoning import ReasoningEngine
 from backend.services.rag.agentic.reasoning_utils import (

--- a/apps/mouth/src/app/(workspace)/process/[id]/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.test.tsx
@@ -108,11 +108,30 @@ vi.mock("./RequiredDocumentsCard", () => ({
   ),
 }));
 
-vi.mock("@balizero/core/utils", () => ({
-  formatIDR: (amount: number) => `IDR ${amount}`,
-}));
+// NOTE: do not mock the money formatter here. There used to be a
+// `vi.mock("@balizero/core/utils", ...)` returning `IDR ${amount}`, and the two
+// price assertions below looked for that string. It never took effect: the page
+// renders prices through `<Money>` (`@balizero/core`), and `Money.tsx` imports
+// `formatIDR` from the RELATIVE `../utils/currency` — a different module id than
+// the one being mocked, so the real formatter always ran. The assertions were
+// therefore looking for text nothing on the page ever produced, and the suite
+// went red the moment this file was armed in CI (#3227).
+//
+// Assert against the real formatter instead, so a deliberate change to the
+// canonical money notation shows up here as a considered edit rather than a
+// mystery.
+
+import { formatIDR } from "@balizero/core/utils";
 
 import CaseDetailPage from "./page";
+
+/**
+ * `formatIDR` emits a NON-BREAKING space after "Rp" (Intl id-ID currency
+ * output). Testing Library's default normalizer collapses it to a plain space
+ * before matching, so the expected string has to be normalized the same way —
+ * passing `formatIDR(n)` raw would silently never match.
+ */
+const money = (amount: number) => formatIDR(amount).replace(/\u00a0/g, " ");
 
 const profile = {
   id: "user-1",
@@ -253,7 +272,7 @@ describe("CaseDetailPage", () => {
       "https://wa.me/62812345",
     );
     expect(screen.getByText("Zero Tester")).toBeInTheDocument();
-    expect(screen.getAllByText("IDR 1750000")).toHaveLength(2);
+    expect(screen.getAllByText(money(1_750_000))).toHaveLength(2);
     expect(screen.getByTestId("required-documents")).toHaveTextContent(
       "Documents for 42",
     );
@@ -402,7 +421,7 @@ describe("CaseDetailPage", () => {
         quoted_price: 2_000_000,
       });
     });
-    expect(await screen.findByText("IDR 2000000")).toBeInTheDocument();
+    expect(await screen.findByText(money(2_000_000))).toBeInTheDocument();
   });
 
   it("closes an unchanged edit and submits changed fields with a reload", async () => {

--- a/scripts/tests/test_no_import_time_chdir_in_tests.py
+++ b/scripts/tests/test_no_import_time_chdir_in_tests.py
@@ -1,0 +1,159 @@
+"""Tripwire: no test module may change the process cwd at IMPORT time.
+
+WHY THIS EXISTS
+---------------
+`apps/backend-rag/backend/tests/integration/zantara/test_tier1_fallback.py` used
+to call `os.chdir(...)` at module scope, labelled "change to backend directory
+for imports". Module scope means it fired during pytest **collection**, so it
+moved the cwd of the entire session — permanently, for every test collected
+after it, in file order, in a way nothing announced.
+
+The victim was `apps/backend-rag/tests/test_sentry_lazy_import.py`, which spawns
+a subprocess that inherits both the cwd and CI's relative `PYTHONPATH=.`. With
+the cwd moved one level down, `.` no longer named `apps/backend-rag`, so the
+child died with `ModuleNotFoundError: No module named 'backend'`. `Backend Tests
+(Python)` is a required check, so main went red and every open PR in the repo
+was blocked by a defect none of them contained.
+
+The signature to remember: **green in isolation, red in the suite**. That is
+almost never the failing test's fault — it is something earlier in the session
+having mutated process-global state. cwd is the easiest one to mutate by
+accident and the hardest to see, because nothing in the failure message
+mentions it.
+
+THE RULE
+--------
+A test module (or conftest) may not call `chdir` anywhere that executes on
+import. Inside a test or fixture body is fine — `monkeypatch.chdir()` is better
+still, because it restores. Scoped chdir is deliberately NOT flagged here; the
+defect is the unrestorable one.
+
+Scope: first-party test roots only. `vendor/` is excluded — it is third-party
+code we do not edit, and its suites do not share a pytest session with ours.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PRUNE_DIRS = {
+    ".git",
+    ".venv",
+    ".worktrees",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "vendor",
+}
+
+TEST_FILE_GLOBS = ("test_*.py", "*_test.py", "conftest.py")
+
+
+def _iter_test_files(root: Path) -> list[Path]:
+    """Every first-party test/conftest file under `root`, pruned dirs skipped."""
+    found: list[Path] = []
+    for path in root.rglob("*.py"):
+        if any(part in PRUNE_DIRS for part in path.relative_to(root).parts):
+            continue
+        if any(path.match(pattern) for pattern in TEST_FILE_GLOBS):
+            found.append(path)
+    return found
+
+
+def _import_time_chdir_lines(source: str, filename: str = "<probe>") -> list[int]:
+    """Line numbers of `chdir(...)` calls that run when the module is imported.
+
+    Descends through module-level `if` / `try` / `with` / `for` / class bodies —
+    those all execute at import — but NOT into function bodies, which do not.
+
+    `filename` is passed to `ast.parse` only so that any SyntaxWarning a scanned
+    file provokes names that file instead of `<unknown>`.
+    """
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return []
+
+    hits: list[int] = []
+
+    def walk(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue  # body runs on call, not on import
+            if isinstance(child, ast.Call):
+                func = child.func
+                name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+                if name == "chdir":
+                    hits.append(child.lineno)
+            walk(child)
+
+    walk(tree)
+    return hits
+
+
+# --- INNOCENCE: scoped chdir is legitimate and must NOT be flagged ------------
+
+
+def test_chdir_inside_a_function_body_is_not_flagged() -> None:
+    source = (
+        "import os\n"
+        "def test_thing(tmp_path):\n"
+        "    os.chdir(tmp_path)\n"
+        "def test_other(monkeypatch, tmp_path):\n"
+        "    monkeypatch.chdir(tmp_path)\n"
+    )
+    assert _import_time_chdir_lines(source) == []
+
+
+# --- GUILT: the exact shape that broke main must be caught --------------------
+
+
+def test_module_level_chdir_is_flagged() -> None:
+    source = "import os\nfrom pathlib import Path\nos.chdir(str(Path('backend')))\n"
+    assert _import_time_chdir_lines(source) == [3]
+
+
+def test_chdir_hidden_in_a_module_level_if_is_flagged() -> None:
+    """The original could as easily have been guarded — it would still fire."""
+    source = "import os\nif True:\n    os.chdir('backend')\n"
+    assert _import_time_chdir_lines(source) == [3]
+
+
+def test_bare_chdir_import_is_flagged() -> None:
+    """`from os import chdir` hides the `os.` prefix a naive grep looks for."""
+    source = "from os import chdir\nchdir('backend')\n"
+    assert _import_time_chdir_lines(source) == [2]
+
+
+# --- The live assertion over the real tree ------------------------------------
+
+
+def test_no_first_party_test_file_chdirs_at_import_time() -> None:
+    files = _iter_test_files(REPO_ROOT)
+
+    # Blind-scan guard: zero files walked means the probe is broken, not that
+    # the tree is clean (the lesson of W84 / the secrets-audit exit 2).
+    assert len(files) > 500, (
+        f"probe walked only {len(files)} test files under {REPO_ROOT} — "
+        "it is blind, not the tree clean"
+    )
+
+    offenders: list[str] = []
+    for path in files:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line in _import_time_chdir_lines(source, filename=str(path)):
+            offenders.append(f"{path.relative_to(REPO_ROOT)}:{line}")
+
+    assert not offenders, (
+        "these run chdir at import time, which moves the cwd for every test "
+        "collected after them in the same pytest session:\n  "
+        + "\n  ".join(offenders)
+        + "\nMove the chdir inside the test and use monkeypatch.chdir()."
+    )


### PR DESCRIPTION
## What this fixes

`main` is red, and it has been since **#3227** merged at 03:51 today. That PR did a good and
overdue thing — it armed test files that no workflow had ever executed — but two of the files it
armed had never been green, so arming them broke two **required** checks at once:

- `Backend Tests (Python)`
- `Frontend Tests (Next.js) (mouth, true)`

Both are required, so **every open PR in the repo is blocked**, not just the ones that touch these
areas. That is why this is one PR and not two: a PR that cures only one of the two is still
blocked by the other, and neither could ever merge.

---

### 1. An import-time `os.chdir` was poisoning the whole pytest session

`backend/tests/integration/zantara/test_tier1_fallback.py` called
`os.chdir(backend_path / "backend")` at **module scope**, labelled "change to backend directory
for imports". Module scope means it ran during pytest **collection**, so it moved the cwd of the
entire session — permanently, for every test collected after it, in file order.

The victim was `apps/backend-rag/tests/test_sentry_lazy_import.py`, which spawns a subprocess that
inherits both the cwd and CI's relative `PYTHONPATH=.`. With the cwd one level down, `.` no longer
named `apps/backend-rag`, so the child died with `ModuleNotFoundError: No module named 'backend'`.

The chdir was never needed — the `sys.path.insert` two lines above is what makes `import backend`
work. Removed, with the reason written where the next person will be tempted to re-add it.

**Verified by reproduction, not by reasoning:**

| run | result |
|---|---|
| sentry test alone | ✅ green (innocence) |
| `tier1_fallback` **then** sentry | ❌ both sentry tests fail, same `ModuleNotFoundError` as CI (guilt) |
| same pair, after this change | ✅ 6 passed, rc 0 |

Note the signature: **green in isolation, red in the suite.** That is almost never the failing
test's fault — it is something earlier in the session having mutated process-global state.

**Class-audit** (a pattern fix is a class fix): an AST sweep of **2364** first-party test/conftest
files found exactly one import-time chdir — this one. The other 7 `chdir` call sites are inside
function bodies, restore or are scoped, and are deliberately untouched.

**Tripwire** — `scripts/tests/test_no_import_time_chdir_in_tests.py`:
- guilt: module-level `chdir`, `chdir` hidden inside a module-level `if`, and bare
  `from os import chdir` are all flagged;
- innocence: `chdir` inside a test or fixture body is not (scoped chdir is legitimate;
  `monkeypatch.chdir` restores);
- a live sweep over the real tree, with a **blind-scan guard** so an empty walk fails loudly
  instead of reading as clean.

It is added to the `immune-enforcement` runner **in the same commit** — a test no workflow names
is not armed, and that is the defect class that produced this outage in the first place.

### 2. A phantom mock made `CaseDetailPage` assert text nothing renders

`page.test.tsx` mocked `@balizero/core/utils` to return `` `IDR ${amount}` `` and asserted
`"IDR 1750000"` / `"IDR 2000000"`. **The mock never took effect**: the page renders prices through
`<Money>` from `@balizero/core`, and `Money.tsx` imports `formatIDR` from the *relative*
`../utils/currency` — a different module id than the one being mocked. The real formatter always
ran, so both assertions looked for text the page never produced.

Now it asserts against the real formatter. One trap worth naming, because the naive fix fails
silently: `formatIDR` emits a **non-breaking space** after "Rp" (Intl `id-ID` currency output —
`packages/core/utils/currency.test.ts` carries an `nbsp()` helper for the same reason), while
Testing Library's default normalizer collapses it to a plain space before comparing. Passing
`formatIDR(n)` raw would never match. The local `money()` helper normalizes the same way, written
as an explicit `\u00a0` escape rather than a literal invisible character an editor could eat.

**Verified:** 14/14 pass in `apps/mouth` (vitest, this file); `main` has 2 failing.

---

## Verification notes

- Both fixes were reproduced and re-run locally before this PR; no fix here rests on reading a log.
- The push ran the full backend suite through the real `pre-push` hook on Pro (worktree created via
  `scripts/agent_start.py`, so `.husky/_` is symlinked and the gate actually executes — a bare
  `git worktree add` leaves it absent and the hook silently does not run).
- The gate initially blocked on two `test_intake_gate.py` failures. Those were **pre-existing and
  environmental**, proven by checking out pure `origin/main` in the same worktree on the same
  machine and getting the identical failure: Pro's persistent `nuzantara_test` DB had never
  received `migrations_v2/258_alert_outcomes_acknowledged.sql` (a separate migration family from
  the one `backend.db.migrate apply-all` walks), so its `ck_alert_outcomes_outcome` still rejected
  `acknowledged`. CI never sees this because it builds a fresh DB. Repaired on Pro; unrelated to
  this diff.

## Known gap this exposes (not fixed here)

The local `pre-push` gate runs `pytest backend/tests/ --ignore=backend/tests/e2e`. CI now runs
that **plus** `tests/test_sentry_lazy_import.py`, `tests/test_sentry_pii_redaction.py` and
`tests/kb/test_politics_hierarchical.py`. So the local gate is structurally blind to exactly the
three files whose arming broke `main` — no amount of running it would have caught this before the
push.

Also worth knowing when reading the CI log for this outage: the suite runs with `-x`, so it
stopped at the first failure and could not report whether the two files *after* the failing one
were healthy. I ran them directly rather than infer it: both green.

Aligning the gate's file set with CI's belongs in `.husky/pre-push`, which #3264 is already
editing — folding it in here would conflict. Left as an explicit follow-up rather than a silent
omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
