### PR TITLE
ci(workflows): merge_group readiness for merge queue (Lot 1-3 + queue-safe concurrency)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,13 +23,14 @@ name: actionlint
 
 on:
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
   group: actionlint-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   lint:

--- a/.github/workflows/adversarial-review-gate.yml
+++ b/.github/workflows/adversarial-review-gate.yml
@@ -17,6 +17,7 @@ name: adversarial-review-gate
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   gate:
@@ -34,14 +35,29 @@ jobs:
 
       - name: Fetch base ref
         env:
-          BASE_REF: ${{ github.base_ref }}
+          # merge_group readiness (2026-07-27): github.base_ref is a branch
+          # NAME, populated only for pull_request/pull_request_target — empty
+          # under merge_group, which made this fetch a no-op and the next
+          # step's `origin/${BASE_REF}` resolve to `origin/` (REF-BREAKAGE:
+          # check_adversarial_review.py's git-diff subprocess raises
+          # CalledProcessError -> main() exit 2 -> the R1 gate fails on every
+          # single queue entry, not just changed ones). SHA-fallback mirrors
+          # the pattern already proven in hot-zone-pr-gate.yml, and also
+          # sidesteps the base-advanced race this step already guards below.
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
         # NO --depth=1 here: a shallow fetch re-points origin/<base> to a tip with
         # severed history, so if base advanced between checkout and this step the
         # merge-base with HEAD is unreachable -> "fatal: no merge base" (seen live
         # on PR #2033, high-traffic day). Full fetch is cheap after fetch-depth: 0.
-        run: git fetch origin "$BASE_REF" || true
+        run: git fetch origin "$BASE_SHA" || true
 
       - name: R1 gate — adversarial review present
         env:
-          BASE_REF: ${{ github.base_ref }}
-        run: python scripts/check_adversarial_review.py --diff "origin/${BASE_REF}"
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+        # scripts/check_adversarial_review.py --diff shells out to
+        # `git diff --name-only ... "{base}...HEAD"` (_git_diff_files) — base
+        # is an opaque git revision never string-parsed for an "origin/<name>"
+        # shape, so a bare SHA is a valid --diff argument (verified on disk
+        # 2026-07-27, no origin/ prefix required; three-dot diff resolves the
+        # merge-base from either a branch name or a SHA identically).
+        run: python scripts/check_adversarial_review.py --diff "$BASE_SHA"

--- a/.github/workflows/asyncpg-lint.yml
+++ b/.github/workflows/asyncpg-lint.yml
@@ -15,6 +15,7 @@ name: asyncpg-lint
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main
@@ -24,7 +25,7 @@ permissions:
 
 concurrency:
   group: asyncpg-lint-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   asyncpg-lint:

--- a/.github/workflows/guard-conformance.yml
+++ b/.github/workflows/guard-conformance.yml
@@ -18,6 +18,7 @@ name: Guard conformance (superscar #3 enforcement)
 
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -37,7 +38,7 @@ on:
 
 concurrency:
   group: guard-conformance-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   conformance:

--- a/.github/workflows/hook-innocence-gate.yml
+++ b/.github/workflows/hook-innocence-gate.yml
@@ -29,6 +29,7 @@ name: Hook innocence gate (vaccine)
 
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -43,7 +44,7 @@ on:
 
 concurrency:
   group: hook-innocence-gate-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   innocence:

--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -36,7 +36,7 @@ on:
 # Concurrency: cancel stale runs on the same PR ref so latest commit wins
 concurrency:
   group: hot-zone-pr-gate-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -18,10 +18,11 @@ name: Immune enforcement (superscar antidotes)
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
 
 concurrency:
   group: immune-enforcement-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   antidotes:

--- a/.github/workflows/npm-lock-sync.yml
+++ b/.github/workflows/npm-lock-sync.yml
@@ -32,6 +32,7 @@ name: npm lock sync
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 
@@ -40,7 +41,7 @@ permissions:
 
 concurrency:
   group: npm-lock-sync-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   lock-honors-manifest:

--- a/.github/workflows/organ-conformance.yml
+++ b/.github/workflows/organ-conformance.yml
@@ -17,6 +17,7 @@ name: Organ conformance (DNA genome — genes at birth)
 
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -32,7 +33,7 @@ on:
 
 concurrency:
   group: organ-conformance-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   conformance:
@@ -52,8 +53,23 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "push" ]; then
-            echo "hit=true" >> "$GITHUB_OUTPUT"; exit 0
+          # merge_group readiness (2026-07-27): the old guard only special-cased
+          # "push" — under merge_group, BASE/HEAD (pull_request.* fields) are
+          # empty, `git diff --name-only "" ""` failed, and a blind `|| true`
+          # swallowed that failure into hit=false, skipping every gate step
+          # while still reporting SUCCESS (silent-green, cicatrix family #2).
+          # Fix mirrors the proven fail-open sentinel (verify-the-verifiers.yml
+          # and siblings): ANY non-pull_request event runs the full gate, and a
+          # pull_request event with an unusable diff now fails CLOSED instead of
+          # pretending nothing changed.
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "hit=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::non-PR event ($EVENT_NAME) — running full organ-conformance gate"
+            exit 0
+          fi
+          if [[ -z "$BASE" || -z "$HEAD" ]]; then
+            echo "::error::pull_request event with empty BASE/HEAD sha — cannot compute diff, failing closed"
+            exit 1
           fi
           CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- \
             'infra/organ-conformance/' 'infra/home-fork/declared-pairs.json' \
@@ -62,7 +78,7 @@ jobs:
             'scripts/healer_receptor_registry.py' \
             '.github/workflows/organ-conformance.yml' \
             '*.plist' '**/*.plist' \
-            'infra/launchagents/' 'infra/healer/' || true)
+            'infra/launchagents/' 'infra/healer/')
           if [ -n "$CHANGED" ]; then
             echo "organ surfaces changed:"; echo "$CHANGED"
             echo "hit=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/p1s2-mutation-incremental.yml
+++ b/.github/workflows/p1s2-mutation-incremental.yml
@@ -30,6 +30,7 @@ name: P1 STRATO-2 incremental mutation gate
 # The push trigger keeps its paths filter (push only fires when work is needed).
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   push:
     branches:
       - main
@@ -40,7 +41,7 @@ on:
 
 concurrency:
   group: p1s2-mutation-incremental-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   mutation-gate:

--- a/.github/workflows/p3-sandbox-gates.yml
+++ b/.github/workflows/p3-sandbox-gates.yml
@@ -22,6 +22,7 @@ name: P3 Sandbox Gates
 # "Did relevant paths change?" step; on a path-miss PR the job ENDS success.
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   workflow_dispatch:
 
 jobs:
@@ -65,13 +66,21 @@ jobs:
       - name: P3 static gates
         if: steps.relevant.outputs.run == 'true'
         continue-on-error: false
+        env:
+          # merge_group readiness (2026-07-27): github.base_ref is a branch
+          # NAME, populated only for pull_request/pull_request_target — empty
+          # under merge_group, which made `git diff --quiet origin/ -- ...`
+          # ref-ambiguous and this step failed CLOSED for every queue entry
+          # (REF-BREAKAGE, the polar opposite of silent-green). SHA-fallback
+          # mirrors the pattern already proven in hot-zone-pr-gate.yml.
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           echo "== compose files parse =="
           python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['apps/backend-rag/docker-compose.test.yml','apps/backend-rag/docker-compose.sandbox.yml']]; print('parse OK')"
           echo "== base file UNTOUCHED (gate G2 by construction) =="
-          git fetch origin ${{ github.base_ref }} --depth=1
-          if ! git diff --quiet origin/${{ github.base_ref }} -- apps/backend-rag/docker-compose.test.yml; then
+          git fetch origin "$BASE_SHA" --depth=1
+          if ! git diff --quiet "$BASE_SHA" -- apps/backend-rag/docker-compose.test.yml; then
             echo "FAIL: docker-compose.test.yml was modified — breaks the integration suite (G2)."
             exit 1
           fi

--- a/.github/workflows/p6-federation-parallelize.yml
+++ b/.github/workflows/p6-federation-parallelize.yml
@@ -23,6 +23,7 @@ name: P6 federation parallelize-hypothesis gate
 # "Did relevant paths change?" step; on a path-miss PR the job ENDS success.
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   push:
     branches:
       - main
@@ -34,7 +35,7 @@ on:
 
 concurrency:
   group: p6-federation-parallelize-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   parallelize-gate:

--- a/.github/workflows/p7-lesson-harvester.yml
+++ b/.github/workflows/p7-lesson-harvester.yml
@@ -18,6 +18,7 @@ name: P7 LEARN Shadow Harvester Gate
 # "Did relevant paths change?" step; on a path-miss PR the job ENDS success.
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/p8-brand-api.yml
+++ b/.github/workflows/p8-brand-api.yml
@@ -14,6 +14,7 @@ name: P8 Brand-API Gate
 # "Did relevant paths change?" step; on a path-miss PR the job ENDS success.
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/p9-cost-breaker.yml
+++ b/.github/workflows/p9-cost-breaker.yml
@@ -12,6 +12,7 @@ name: P9 Cost Breaker (GOVERN)
 # "Did relevant paths change?" step; on a path-miss PR the job ENDS success.
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   push:
     branches:
       - main
@@ -24,7 +25,7 @@ on:
 
 concurrency:
   group: p9-cost-breaker-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   cost-breaker-tests:

--- a/.github/workflows/root-guard.yml
+++ b/.github/workflows/root-guard.yml
@@ -4,12 +4,13 @@ on:
   pull_request:
     # Run on every PR — the check is fast (~0.2s) and catches root-pollution
     # attempts that slip past pre-commit (e.g. someone commits with --no-verify).
+  merge_group:
   push:
     branches: [main]
 
 concurrency:
   group: root-guard-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   root-guard:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
   schedule:
     - cron: "0 0 * * 0" # Weekly scan on Sunday
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
   workflow_dispatch:
   # Task #37 (2026-07-26). STRUCTURAL claim, not a snapshot of one night:
   # `cancel-in-progress: false` (below) protects a run that has already
@@ -67,9 +68,22 @@ on:
 # head". Do not "fix" this to match main's `false` — that was tried
 # nowhere, noted here only because the asymmetry looks like a bug at a
 # glance.
+#
+# merge_group readiness (2026-07-27): under merge_group, github.ref resolves
+# to the queue's own temporary ref (refs/heads/gh-readonly-queue/...), which
+# is != 'refs/heads/main' — so the expression above would evaluate to `true`
+# for a queue entry, cancelling an in-flight required-check run every time a
+# newer commit joined the queue (the exact starvation this block exists to
+# prevent for main, just relocated to the queue). This is a composed fix, not
+# the mechanical `cancel-in-progress: ${{ github.event_name != 'merge_group' }}`
+# used on the other 13 required-context workflows: that blanket replacement
+# would have discarded the schedule-vs-push asymmetry documented above. AND-ing
+# `github.event_name != 'merge_group'` onto the existing expression preserves
+# every other branch (push-to-main stays false, PR refs and schedule keep
+# cancelling) and forces false only for the new merge_group case.
 concurrency:
   group: tests-${{ github.event_name == 'schedule' && 'schedule-main' || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'schedule' || github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ (github.event_name == 'schedule' || github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
 
 jobs:
   backend-tests:

--- a/.github/workflows/verify-the-verifiers.yml
+++ b/.github/workflows/verify-the-verifiers.yml
@@ -16,6 +16,7 @@ name: Verify the Verifiers (meta-gate)
 # The push trigger keeps its paths filter (push only fires when work is needed).
 on:
   pull_request: # NO top-level paths: — always trigger (sentinel gates the work)
+  merge_group:
   push:
     branches: [main]
     paths:
@@ -29,7 +30,7 @@ on:
 
 concurrency:
   group: verify-the-verifiers-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   verify-the-verifiers:


### PR DESCRIPTION
## Summary

Makes all 25 required-check workflows (19 files) correct under GitHub's `merge_group` event, per `research/operations/2026-07-17-merge-queue-readiness-manifest.md`. Zero behavior change today — no queue exists yet, so GitHub never emits `merge_group` and none of these triggers fire. The two semantic fixes (Lot 2, Lot 3) are also correct improvements under `pull_request` today (byte-equivalent behavior, see guilt/innocence below).

Manifest reference: `research/operations/2026-07-17-merge-queue-readiness-manifest.md` §3 (25-context table), §4 (5 worst instances), §10 (recommended fix ordering — this PR executes steps 1-2 of that ordering).

## Lot 1 — mechanical trigger additions (15 files)

Added bare `merge_group:` to `on:` right after the existing `pull_request:` entry, no other change to triggers, paths, or `if:` conditions:

`tests.yml` · `security.yml` · `root-guard.yml` · `p1s2-mutation-incremental.yml` · `verify-the-verifiers.yml` · `asyncpg-lint.yml` · `p7-lesson-harvester.yml` · `p8-brand-api.yml` · `p9-cost-breaker.yml` · `p6-federation-parallelize.yml` · `immune-enforcement.yml` · `npm-lock-sync.yml` · `actionlint.yml` · `guard-conformance.yml` · `hook-innocence-gate.yml`

**Deviation from brief**: the brief's actionlint.yml note ("uses pull_request_target — add merge_group alongside, do not alter the pull_request_target config") does not match the file on disk — verified via `grep -n pull_request .github/workflows/actionlint.yml`: it triggers on plain `pull_request:`. The string `pull_request_target` only appears in a *comment* describing a bug class this gate catches in a *different* file (`ai-pr-review.yml`). Treated it like the other 14 clean Lot-1 files.

## Lot 2 — `organ-conformance.yml`: fix guard before adding trigger

**Guilt (what failed under merge_group before this fix):** the relevant-paths guard checked `EVENT_NAME == "push"` only. Under `merge_group`, `github.event.pull_request.base.sha`/`.head.sha` are empty, so `git diff --name-only "" ""` failed; a blind `|| true` swallowed that failure into `CHANGED=""`; every downstream step is gated on `hit == 'true'` and got skipped; the job reported **SUCCESS having verified nothing** — silent-green (cicatrix superscar #2).

**Fix:** mirrors the proven fail-open sentinel already used by `verify-the-verifiers.yml` and its siblings — `if [[ "$EVENT_NAME" != "pull_request" ]]; then hit=true; exit 0; fi` (any non-PR event, including `merge_group` *and* `push`, runs the full gate). The blind `|| true` on the `git diff` is removed; a `pull_request` event with empty `BASE`/`HEAD` now hits an explicit `echo "::error::..."; exit 1` before ever reaching `git diff`, so the failure mode for a genuinely broken PR event is a loud, fail-closed error instead of a silent pass.

**Innocence (why `pull_request` behavior is byte-equivalent today):** for a real `pull_request` event, `BASE`/`HEAD` are always populated by GitHub, so the new `-z` check never trips; the `git diff` call and its downstream `hit=true`/`hit=false` branches are byte-identical to before. The only behavior change is on non-`pull_request` events, where the old code had no `merge_group` case at all (this file gets its `merge_group:` trigger in the same commit) and would have hit the exact silent-green failure mode above the moment someone added the trigger without reading this far — this PR closes that window before it opens.

## Lot 3 — REF-BREAKAGE fixes before adding triggers (2 files)

Both used `github.base_ref` (a branch **name**, populated only for `pull_request`/`pull_request_target`) — empty under `merge_group`.

**`p3-sandbox-gates.yml`** (P3 static validation, ENFORCING step): `git fetch origin ${{ github.base_ref }} --depth=1` + `git diff --quiet origin/${{ github.base_ref }} -- apps/backend-rag/docker-compose.test.yml`. Under `merge_group` this becomes `git fetch origin  --depth=1` (empty ref) → the subsequent `git diff --quiet origin/ -- ...` is ref-ambiguous → the step fails under `set -euo pipefail`. **Guilt:** this is a guaranteed hard-FAIL for every queue entry, not just ones touching the compose file — a self-DoS of the queue, the polar opposite of silent-green. **Fix:** `BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}` env var (mirrors the pattern already proven in `hot-zone-pr-gate.yml:75`), then `git fetch origin "$BASE_SHA" --depth=1` and `git diff --quiet "$BASE_SHA" -- ...`. **Innocence:** for `pull_request`, `github.event.pull_request.base.sha` is the SHA of the base branch tip at event time — same base the old `origin/${base_ref}` resolved to after the fetch, so the G2 "base file untouched" check evaluates the identical comparison; only the ref *form* changed (SHA vs branch name), not what it points at.

**`adversarial-review-gate.yml`** (R1 generator≠grader gate): `env: BASE_REF: ${{ github.base_ref }}` then `git fetch origin "$BASE_REF" || true` and `python scripts/check_adversarial_review.py --diff "origin/${BASE_REF}"`. Under `merge_group`, `BASE_REF` is empty, so `--diff "origin/"` is passed. **Guilt, verified on disk, not assumed:** `check_adversarial_review.py::_git_diff_files` runs `git diff --name-only --diff-filter=AM "{base_ref}...HEAD" -- research/**/*.md` under `subprocess.run(..., check=True)`; `git diff --name-only ... "origin/...HEAD"` raises `CalledProcessError`, caught in `main()` and turned into `sys.exit(2)`. This is the R1 gate everything else in the repo's ship-lifecycle depends on (CLAUDE.md §6/§13, generator≠grader) — breaking it in queue would silently remove the "author never gates their own diff" invariant for every merge-queue PR, without anyone noticing a missing adversarial review, only a git plumbing error. **Fix:** same `BASE_SHA` env pattern as above; `git fetch origin "$BASE_SHA" || true`; `--diff "$BASE_SHA"`.
  - **Verified the script accepts a bare SHA** (brief's explicit ask, not inferred from reading alone): `grep -n "origin/\|base_ref\|args.diff"` over the whole script shows `base_ref` is used *only* as an opaque revision substituted into the three-dot diff — never string-parsed for an `origin/<name>` shape. Ran it live: `python3 scripts/check_adversarial_review.py --diff "$(git rev-parse HEAD~5)"` on this branch computed the diff correctly (found 2 real research files changed in the last 5 commits, evaluated their frontmatter, exited 1 on a genuine content finding) — proof the SHA path runs `git diff` successfully end-to-end rather than crashing on ref resolution.
  - **Innocence:** `github.event.pull_request.base.sha` identifies the same base commit `origin/${base_ref}` did after the explicit fetch; the "NO --depth=1" comment's race-avoidance reasoning is preserved verbatim (full fetch of that exact SHA, not a shallow one).

## Queue-safe concurrency guard

For the 13 files with a plain `concurrency.cancel-in-progress: true`, changed to `cancel-in-progress: ${{ github.event_name != 'merge_group' }}` so a queue verification run is never cancelled mid-flight by a newer commit joining the queue behind it (PR/push/schedule behavior unchanged — the expression is `true` for every other event, identical to before):

`root-guard.yml` · `p1s2-mutation-incremental.yml` · `verify-the-verifiers.yml` · `asyncpg-lint.yml` · `p9-cost-breaker.yml` · `p6-federation-parallelize.yml` · `immune-enforcement.yml` · `npm-lock-sync.yml` · `actionlint.yml` · `guard-conformance.yml` · `hook-innocence-gate.yml` · `organ-conformance.yml` · `hot-zone-pr-gate.yml`

**`tests.yml` — composed fix, not the mechanical replacement above.** This file already has a hand-tuned, heavily-commented `cancel-in-progress` expression (`${{ github.event_name == 'schedule' || github.ref != 'refs/heads/main' }}`) that deliberately protects push-to-main runs from cancellation (a documented anti-starvation fix, task #37) while still cancelling stale PR and schedule runs. Under `merge_group`, `github.ref` resolves to the queue's own temporary ref (`refs/heads/gh-readonly-queue/...`), which is `!= 'refs/heads/main'` — so the existing expression would evaluate `true` for a queue entry, reproducing the exact starvation this block exists to prevent, just relocated to the queue. Applying the blanket `${{ github.event_name != 'merge_group' }}` here would have silently discarded the schedule-vs-push asymmetry. Instead, AND'ed `github.event_name != 'merge_group'` onto the existing expression: every other branch (push-to-main stays `false`, PR refs and schedule keep cancelling) is preserved byte-for-byte; only the new `merge_group` case is forced to `false`.

**`security.yml`** already has `cancel-in-progress: false` (never cancels, any event) — already queue-safe, left untouched.
**`p7-lesson-harvester.yml`, `p8-brand-api.yml`, `p3-sandbox-gates.yml`, `adversarial-review-gate.yml`** have no `concurrency:` block — left untouched per brief (no block = nothing to guard).

**`hot-zone-pr-gate.yml`**: already had `merge_group:` in `on:`; applied only the concurrency guard. Left the cosmetic `PR_NUMBER`/`PR_URL` fallback (brief's "if trivial" item) **unaddressed** — see Deviations.

## Deviations from the brief

1. **Worktree lane**: brief said `--lane ci`, which isn't a recognized lane in `scripts/agent_start.py` (`unknown lane 'ci'. Known: backend-rag, cell, cicatrix-fix, db, docs, frontend, infra, intel, mata-garuda, mouth, ops, organism, wr2, wr3`). Used `--lane infra` instead (closest semantic match for CI/workflow-config work) — worktree created at `.worktrees/infra-mergegroup-readiness`, branch `agent/air-m5/infra/mergegroup-readiness`.
2. **actionlint.yml pull_request_target note** — inaccurate, see Lot 1 above; file uses plain `pull_request:`.
3. **`tests.yml` concurrency** — composed AND-fix instead of the mechanical replacement, to avoid destroying the existing anti-starvation logic. See rationale above.
4. **`hot-zone-pr-gate.yml` PR_NUMBER/PR_URL cosmetic fallback (lines ~159-160 per manifest, actually ~202-203 on current disk — the file grew since the manifest was written 2026-07-17) — SKIPPED, not trivial.** The brief's own instruction was conditional ("include if trivial"). Checked: `github.event.merge_group` has no `.number` or `.html_url` field (unlike `base_sha`/`head_sha`, which map directly) — the PR number only exists embedded inside the queue ref string (`gh-readonly-queue/<base>/pr-<N>-<sha>`), which would need string-parsing, not a simple `||` fallback. Per the brief's own conditional, left as-is; this only degrades Telegram alert text (missing PR number/URL) in the CODEOWNERS-self-mod-by-non-owner branch under `merge_group` — the actual gate decision (`ACTOR != "Balizero1987"` → `exit 1`) is unaffected, since `github.actor` is populated for `merge_group` events.
5. **Manifest/brief line-number drift**: `p3-sandbox-gates.yml`'s REF-BREAKAGE lines were cited as "~72-73"; on current disk they're 73-74 (off by one — file had a small unrelated edit since 07-17). `hot-zone-pr-gate.yml`'s PR_NUMBER/PR_URL were cited as "~159-160"; on current disk they're ~202-203 (file grew ~40 lines with the Step-1bis self-test corpus added 2026-07-24, per its own code comment). Found and edited by content match, not line number, per brief's own instruction to verify current state.
6. **Pre-push full suite ran twice** (not a brief deviation, but worth recording): the local pre-push hook classified `tests.yml` as not on the "innocent" allowlist and ran the full backend pytest suite (~40 min) rather than a targeted subset — correct behavior for a `.github/workflows/tests.yml` change, not a bug. First attempt failed on 2 tests unrelated to this diff (`test_observability.py::test_module_import_under_150ms` — a hardcoded 150ms budget blown under a measured 12–22 system load average from concurrent sibling agent work, confirmed via a standalone import measuring 19.4ms; and `test_confirmation_service.py::TestRedisPersistence` — an asyncio-scheduling timeout race under the same load, not a real Redis dependency since the test uses `fakeredis`). Zero Python files are touched by this PR. Retried once; passed clean.

## Validation performed

- `python3 -c "import yaml; ..."` — all 19 changed files parse as valid YAML.
- `actionlint` v1.7.12 (same version pinned in `actionlint.yml`'s own gate) against all 19 changed files — clean, zero warnings/errors.
- `check_adversarial_review.py --diff <bare-SHA>` — ran live against this branch, confirmed a bare SHA resolves and diffs correctly (see Lot 3 above).
- Local pre-commit + pre-push hooks passed (lease-check, anti-reward-hacking lint, secret scan, Prettier, ruff, full backend pytest suite on retry).

## Note

Triggers are dormant until a merge queue exists — no queue means GitHub never emits `merge_group`, so this PR is behavior-neutral today on every file except the Lot 2/Lot 3 semantic fixes, which are also correct (byte-equivalent) improvements under `pull_request` right now.

Per brief: **auto-merge NOT armed** — this is a guardrail-class CI change; the orchestrating session merges it after gates, per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
