### PR TITLE
perf(prepush): allowlist .agents/** markdown and scripts/ci shell (v5, measured)

### DIFF
--- a/scripts/prepush_classify.py
+++ b/scripts/prepush_classify.py
@@ -217,7 +217,12 @@ VERDICT_SKIP = "skip-backend"
 # pushes to it. Innocence measured on disk (no backend test opens a file
 # under apps/mouth); .mdx deliberately excluded because a real reader
 # exists. See the allowlist table's `apps/mouth/src/**` entry.
-ALLOWLIST_VERSION = 4
+# v5 (2026-07-27, measured load-41 fleet night): added .agents/skills
+# (.md) and scripts/ci (.sh) — two more path classes measured (not
+# assumed) innocent w.r.t. `pytest backend/tests/`. See the allowlist
+# table's v5 section below for the 9-concurrent-suite / 7-of-9-zero-backend
+# measurement and the innocence method for both entries.
+ALLOWLIST_VERSION = 5
 
 # ---------------------------------------------------------------------------
 # NEVER_INNOCENT_EXACT_PATHS — checked FIRST, unconditionally, before any
@@ -355,6 +360,71 @@ NEVER_INNOCENT_BASENAMES: frozenset[str] = frozenset(
 #                         dataset copies (37MB canonical + gold), which are
 #                         data-plane artifacts and must keep forcing full.
 #
+#   v5 (2026-07-27) — MEASURED, not hypothetical: load average 41 on M5,
+#   9 concurrent full `pytest backend/tests/` suites (~17k tests, 40-60min
+#   each under this contention; one had been running 1h21m). Tracing each
+#   running suite to its worktree and merge-base diff found 7 of the 9
+#   guarded diffs contained ZERO backend files. Two were pure markdown-only
+#   diffs whose ONLY changed file sits under `.agents/skills/` — a prefix
+#   the allowlist did not yet recognize; a third was blocked solely by
+#   `scripts/ci/setup_merge_queue_ruleset.sh`. Both added below, same
+#   innocence method as v3/v4: grep `apps/backend-rag/backend/`
+#   (tests + modules) for the DIRECTORY-BOUNDARY-ANCHORED path string
+#   (`.agents/` / `scripts/ci/`, trailing slash) — a bare substring grep
+#   without the anchor false-positives on Python dotted-module paths
+#   (`backend.app.agents.graph`) and unrelated files
+#   (`apps/backend-rag/scripts/ci_bootstrap_schema.py`), which is exactly
+#   the guard-over-match failure mode cicatrix-superscar.md #3 warns
+#   against for a *test* of innocence, not just the guard itself.
+#
+#   .agents/skills/**   Scoped to `.md` ONLY. `.agents/skills/README.md`
+#                       (verified on disk) states this tree is the
+#                       CANONICAL cross-agent skill store, established
+#                       2026-07-23 (skill-unification lane) — NOT a
+#                       duplicate of `.claude/skills/`. Proof: 4 of the 8
+#                       `.claude/skills/<name>` entries
+#                       (bot/kbli-navigator/visaoracle/wr2, verified via
+#                       `git ls-tree` mode 120000) are literal symlinks to
+#                       `../../.agents/skills/<name>`, so editing their
+#                       content through either path produces a `git diff`
+#                       on the REAL blob at `.agents/skills/<name>/…` — the
+#                       pre-v5 `.claude/skills` (.md) rule never covered
+#                       that path, which is why the two live worktrees in
+#                       the v5 measurement each paid a full suite for a
+#                       single SKILL.md edit. 15 tracked files total under
+#                       `.agents/`, all under `.agents/skills/`: 14 `.md` +
+#                       1 `.json` (`wr2/_research/…replay-metrics.json`,
+#                       correctly excluded by suffix scoping, falls to
+#                       "unknown -> full"). No `.agents/rules`,
+#                       `.agents/commands`, or `.agents/agents` tree exists
+#                       on disk today, so none of those prefixes are added
+#                       — an entry for a directory that does not exist is a
+#                       phantom, worse than a missing one. Innocence
+#                       MEASURED: zero matches for the anchored path string
+#                       `.agents/` anywhere under `apps/backend-rag/backend/`
+#                       (tests or modules); the only nearby hits are the
+#                       backend's OWN unrelated "skill" domain
+#                       (`skill_coach`, `catalog_initial_skills.py`, the
+#                       `skill` router — a DB-backed learner-skill entity,
+#                       not a filesystem SKILL.md corner), none of which
+#                       reference `.agents/` at all.
+#   scripts/ci/**       Scoped to `.sh` ONLY. Mirrors the DECLARED-choice
+#                       precedent of `infra/launchagents` (.sh is an
+#                       accepted innocent class there already). 5 tracked
+#                       files today: 3 `.sh` (`hotzone_changed_files.sh`,
+#                       `l5_2_phase2b_trigger_wrapper.sh`,
+#                       `test_hotzone_changed_files.sh`) + 2 `.py`
+#                       (`l5_2_phase2b_auto_analyzer.py`,
+#                       `redis_lease_check.py`) — the `.py` pair stays OUT
+#                       by suffix scoping, falls to "unknown -> full" like
+#                       any other `.py` change here would. Innocence
+#                       MEASURED: zero matches for the anchored path string
+#                       `scripts/ci/` under `apps/backend-rag/backend/`
+#                       (tests or modules), and zero basename-only hits for
+#                       any of the 3 `.sh` files individually (in case a
+#                       test subprocess-invokes one without the directory
+#                       prefix).
+#
 # Deliberately NOT `.claude/**` wholesale: `.claude/hooks/` (control-plane —
 # contains codex-spalla-trigger.sh, verified on disk), `.claude/scripts/`,
 # `.claude/settings.json` + `.claude/settings.local.json` (+ .bak-*
@@ -380,6 +450,8 @@ ALLOWLIST_PREFIX_SUFFIX_PAIRS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (".github/workflows", (".yml",)),
     ("scripts/tests", (".py",)),
     ("apps/mouth/src", (".ts", ".tsx", ".css")),
+    (".agents/skills", (".md",)),
+    ("scripts/ci", (".sh",)),
 )
 
 

--- a/scripts/tests/test_prepush_classify.py
+++ b/scripts/tests/test_prepush_classify.py
@@ -955,6 +955,138 @@ def test_allowlist_version_bumped_for_the_new_entry() -> None:
     rules change that does not bump it makes the log line unattributable."""
     assert pc.ALLOWLIST_VERSION >= 4
     assert ("apps/mouth/src", (".ts", ".tsx", ".css")) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+
+
+# ===========================================================================
+# v5 — .agents/skills (.md) and scripts/ci (.sh)
+#
+# Why these entries exist: measured live 2026-07-27 on M5, load average 41,
+# 9 concurrent full `pytest backend/tests/` suites (one 1h21m in). Tracing
+# each running suite to its worktree/merge-base diff found 7 of the 9
+# guarded diffs contained ZERO backend files — two were pure markdown-only
+# diffs whose ONLY changed file sits under `.agents/skills/`, a third was
+# blocked solely by `scripts/ci/setup_merge_queue_ruleset.sh`.
+#
+# Why .agents/skills is safe: `.agents/skills/README.md` (verified on disk)
+# states this tree is the CANONICAL cross-agent skill store (established
+# 2026-07-23) — `.claude/skills/<name>` is a SYMLINK to it for 4 of 8
+# corners (bot/kbli-navigator/visaoracle/wr2, `git ls-tree` mode 120000
+# verified), so a SKILL.md edit through either path lands its `git diff` on
+# the `.agents/skills/**` blob, which the pre-v5 `.claude/skills` rule never
+# covered. Innocence measured on disk: zero matches for the DIRECTORY-
+# ANCHORED string `.agents/` anywhere under apps/backend-rag/backend/
+# (tests or modules) — a bare `\.agents` grep instead false-positives on
+# Python dotted-module paths like `backend.app.agents.graph`.
+#
+# Why scripts/ci is safe: mirrors the DECLARED .sh precedent already
+# accepted for infra/launchagents. Innocence measured on disk: zero matches
+# for the DIRECTORY-ANCHORED string `scripts/ci/` under
+# apps/backend-rag/backend/ — a bare `scripts/ci` grep instead
+# false-positives on the unrelated `apps/backend-rag/scripts/ci_bootstrap_
+# schema.py`. Also zero basename-only hits for each of the 3 real .sh
+# files, in case a test subprocess-invokes one without the dir prefix.
+# ===========================================================================
+
+
+def test_innocence_agents_skills_md_skips() -> None:
+    """The two live-worktree shapes the v5 measurement actually caught:
+    one-file SKILL.md-only diffs under the canonical .agents/skills store."""
+    for path in (
+        ".agents/skills/bot/SKILL.md",
+        ".agents/skills/kbli-navigator/SKILL.md",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_SKIP, f"{path} should skip, got {verdict}"
+        assert unknown == []
+
+
+def test_innocence_scripts_ci_setup_merge_queue_ruleset_skips() -> None:
+    """The third v5-measurement diff: blocked solely by this one .sh file."""
+    verdict, unknown = pc.classify(["scripts/ci/setup_merge_queue_ruleset.sh"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_real_agents_one_file_diffs_skip() -> None:
+    """The two REAL one-file diffs measured live 2026-07-27
+    (docs-kbli-night-findings, ops-bot-corner-refresh worktrees) — each
+    changed exactly one .agents/skills/**/SKILL.md file and each had been
+    paying a full backend suite before this entry existed."""
+    for path in (
+        ".agents/skills/kbli-navigator/SKILL.md",
+        ".agents/skills/bot/SKILL.md",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_SKIP
+        assert unknown == []
+
+
+def test_innocence_real_pr_c_three_file_list_skips() -> None:
+    """PR-C's real 3-file diff — a workflow + a runbook + this PR's new
+    scripts/ci .sh entry, all three now provably innocent together."""
+    verdict, unknown = pc.classify(
+        [
+            ".github/workflows/merge-queue-watch.yml",
+            "docs/runbooks/merge-queue-discipline.md",
+            "scripts/ci/setup_merge_queue_ruleset.sh",
+        ]
+    )
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_guilt_agents_non_md_forces_full() -> None:
+    """Suffix scoping is the mechanism — the one real non-.md file that
+    lives under .agents/skills/ today must NOT be admitted just because its
+    directory is."""
+    path = ".agents/skills/wr2/_research/2026-07-21-ir-phase1-replay-metrics.json"
+    verdict, unknown = pc.classify([path])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == [path]
+
+
+def test_guilt_scripts_ci_py_forces_full() -> None:
+    """Suffix scoping again — the 2 real .py utilities in scripts/ci/ stay
+    OUT, same shape as the infra/launchagents .py exclusion above."""
+    for path in (
+        "scripts/ci/l5_2_phase2b_auto_analyzer.py",
+        "scripts/ci/redis_lease_check.py",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_FULL, f"{path} must force full"
+        assert unknown == [path]
+
+
+def test_guilt_agents_mixed_with_backend_forces_full() -> None:
+    """One backend file anywhere in the diff still forces the full suite,
+    even alongside an otherwise-innocent .agents/skills edit."""
+    verdict, unknown = pc.classify(
+        [
+            ".agents/skills/bot/SKILL.md",
+            "apps/backend-rag/backend/services/rag/reasoning.py",
+        ]
+    )
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == ["apps/backend-rag/backend/services/rag/reasoning.py"]
+
+
+def test_guilt_prepush_classify_itself_forces_full() -> None:
+    """This very PR's own diff touches scripts/prepush_classify.py, a
+    NEVER_INNOCENT_EXACT_PATHS entry — correct by design, so this PR's own
+    push pays the full suite it is trying to spare OTHER diffs from."""
+    verdict, unknown = pc.classify(["scripts/prepush_classify.py"])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == ["scripts/prepush_classify.py"]
+
+
+def test_allowlist_version_bumped_to_5_for_the_v5_entries() -> None:
+    """The skip-banner logs the allowlist version that approved a skip, so a
+    rules change that does not bump it makes the log line unattributable."""
+    assert pc.ALLOWLIST_VERSION >= 5
+    assert (".agents/skills", (".md",)) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+    assert ("scripts/ci", (".sh",)) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+
+
 # ---------------------------------------------------------------------------
 # The gate's INPUT, not its rules: `.husky/pre-push` must enumerate changed
 # files against the MERGE-BASE with origin/main, never against $remote_sha.


### PR DESCRIPTION
## Measurement that justifies this PR

Measured live 2026-07-27 09:31 WITA on M5, load average **41→68**, up to **12 concurrent full
`pytest backend/tests/` suites** (~17k tests, 40-60min each under contention; some past 1h20m).
Traced each running suite to its worktree and its merge-base diff: **7 of 9 guarded diffs
contained ZERO backend files**. Two of those were single-file markdown diffs under
`.agents/skills/` — a prefix the allowlist did not know (only `.claude/skills/**` was allowlisted,
even though `.agents/skills/` is a real tracked tree of 14 `.md` files). A third case was blocked
solely by a shell script under `scripts/ci/`.

## What changed

- `ALLOWLIST_VERSION` 4 → 5.
- New entries in `ALLOWLIST_PREFIX_SUFFIX_PAIRS`: `(".agents/skills", (".md",))` and
  `("scripts/ci", (".sh",))`, mirroring the existing `.claude/*` and `infra/launchagents` pattern.
- Innocence measured, not assumed (this is a guard **widening**): grepped the backend test tree
  and backend modules for references to `.agents` and `scripts/ci` before allowlisting — no
  backend test/module reads files under either path. `.py`/other suffixes under `scripts/ci`
  and non-`.md` files under `.agents/skills` still fall to `unknown -> full` (suffix-scoped, not
  a blanket directory exemption).
- New guilt+innocence tests in `scripts/tests/test_prepush_classify.py` for both entries,
  including a non-vacuous guilt arm (a non-`.md` file under `.agents/`, a `.py` under
  `scripts/ci`, and a mixed diff with one backend file — all must still classify `full`).

## Verification

- `python3 -m pytest scripts/tests/test_prepush_classify.py -q` green.
- Full `pytest backend/tests/` suite run for real on this very diff (NEVER_INNOCENT path,
  `scripts/prepush_classify.py` itself) — pushed from Pro (idle, load ~5) instead of M5 (load
  41-68 at the time, pushes were dying mid-suite from resource contention): **suite completed
  clean in 9m19s** wall time, vs the 40-60min+ (or outright kill) it would have taken on M5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)