### PR TITLE
perf(prepush): serialize the backend suite per machine, fail-closed (measured: 12 parallel suites, load 68)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -266,6 +266,24 @@ PG_BIN="/opt/homebrew/opt/postgresql@17/bin"
 PG_ISREADY="$(command -v pg_isready || echo "$PG_BIN/pg_isready")"
 PSQL="$(command -v psql || echo "$PG_BIN/psql")"
 PRE_PUSH_DB="${PRE_PUSH_TEST_DB:-nuzantara_test}"
+
+# Machine-wide backend-suite lock (2026-07-27, measured: 12 concurrent
+# 17k-test suites on M5, load 68, pushes SIGTERM-killed mid-suite — see
+# scripts/prepush_suite_lock.sh's own header for the full measurement and
+# the primitive-choice rationale). Wraps ONLY the `python -m pytest` call
+# below — not the DB clone (already isolated per-push via CLONE_DB=$$, and
+# concurrent CREATE DATABASE...TEMPLATE off an unconnected template is fine
+# per the comment above it), not the venv/PG gates above, not anything about
+# WHICH tests run. At most one backend suite runs per machine at a time;
+# everyone else waits with a visible heartbeat, bounded, fail-closed.
+# Absolute path: this variable is read INSIDE a `cd apps/backend-rag`
+# subshell below, so a relative path here would resolve against the wrong
+# directory by the time it's used.
+#
+# Kill switch: NUZ_PREPUSH_SUITE_LOCK=0 disables the lock entirely (straight
+# to unserialized behavior, i.e. today's).
+PREPUSH_SUITE_LOCK_SCRIPT="$(pwd)/scripts/prepush_suite_lock.sh"
+PREPUSH_SUITE_LOCKFILE="/tmp/nuzantara-prepush-backend-suite.lock"
 if ! "$PG_ISREADY" -h 127.0.0.1 -p 5432 -q 2>/dev/null; then
     echo "⏭️  SKIP Python tests — no local PostgreSQL on 127.0.0.1:5432."
     echo "   Install per research/operations/specs/2026-06-12-M5-postgres-local-spec.md to enable the gate."
@@ -399,7 +417,9 @@ else
                JWT_SECRET_KEY="${JWT_SECRET_KEY:-test_jwt_secret_key_for_testing_only_min_32_chars_long}" \
                API_KEYS="${API_KEYS:-test_api_key_1,test_api_key_2}" \
                OLLAMA_URL="http://127.0.0.1:9" \
-               PYTHONPATH=.:../crm-cell python -m pytest backend/tests/ --ignore=backend/tests/e2e --tb=short -q ) || TEST_RC=$?
+               PYTHONPATH=.:../crm-cell \
+               "$PREPUSH_SUITE_LOCK_SCRIPT" "$PREPUSH_SUITE_LOCKFILE" \
+               python -m pytest backend/tests/ --ignore=backend/tests/e2e --tb=short -q ) || TEST_RC=$?
         if [ "$TEST_RC" -eq 0 ]; then
             : # pass — fall through silently, same as the old happy path
         elif [ "$TEST_RC" -ge 128 ]; then

--- a/scripts/prepush_suite_lock.sh
+++ b/scripts/prepush_suite_lock.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+# prepush_suite_lock.sh — serialize a heavy command to at most ONE runner per
+# machine, fail-closed with an actionable message on timeout.
+#
+# WHY THIS EXISTS (measured live on M5, 2026-07-27 09:31->09:57 WITA): load
+# average 68, 12 concurrent `python -m pytest backend/tests/` processes from
+# 12 different agent worktrees' pre-push hooks, ~124MB free memory. Nine
+# near-identical ~17k-test suites contending for the same CPU/memory made
+# each run ~3x slower (40-60min instead of ~12), and pushes were being
+# SIGTERM-killed mid-suite as a result — silent work loss (a killed push
+# leaves committed work that never becomes a PR, invisible to `gh pr list`).
+# This wrapper makes the backend suite single-flight per machine: a second
+# concurrent pusher waits for the first to finish rather than racing it for
+# the same CPU.
+#
+# PRIMITIVE CHOICE (verified empirically on Air-M5, Darwin 27.0.0, 2026-07-27):
+#   - `flock(1)` is ABSENT on stock macOS (`command -v flock` exits 1 — it's a
+#     Linux util-linux tool, never shipped in the BSD userland macOS uses).
+#   - `shlock(1)` IS present (/usr/bin/shlock) but its own man page flags it
+#     DEPRECATED in favor of lockf(1), and it exits immediately on a held
+#     lock (verify-then-report) with no poll point of our own to hook a
+#     heartbeat into.
+#   - `lockf(1)` IS present and would work, but `lockf -t N` blocks SILENTLY
+#     for up to N seconds — no visibility while waiting. This hook's own
+#     pre-push comment block already documents silence-during-a-long-wait as
+#     indistinguishable from a hang, and a hang is exactly what gets a push
+#     killed (the failure this wrapper exists to stop).
+#   - `mkdir` is POSIX-guaranteed atomic (EEXIST on collision, no TOCTOU
+#     window) and, because WE own the poll loop, gives a heartbeat for free.
+#     Chosen primitive: `mkdir` for the lock itself + a PID file inside it
+#     for stale-holder detection via `kill -0` (POSIX, universally available,
+#     the same mechanism shlock uses internally).
+#
+# STALE-LOCK SAFETY (the single most important correctness property here):
+# the PID recorded in the lock is THIS wrapper process's own PID, and this
+# process stays alive for the full duration of the wrapped command (it backgrounds
+# the command and `wait`s on it — never a detached/forked "acquire and exit").
+# If the holder dies for ANY reason (including the exact SIGTERM this fleet
+# is seeing today), `kill -0 <holder_pid>` starts failing immediately, and
+# the NEXT waiter reclaims the lock on its very next poll — a killed suite
+# does not wedge the machine. Known residual risk: PID reuse after a reboot
+# could in theory make a dead holder look alive to `kill -0`; the bounded
+# wait + fail-closed timeout below is the backstop for that case (and for
+# the ordinary case of more than one predecessor queued) — either way this
+# wrapper degrades to a bounded wait with a message, never an infinite wedge.
+#
+# Usage:  prepush_suite_lock.sh <lockfile> <command> [args...]
+#
+# Env:
+#   NUZ_PREPUSH_SUITE_LOCK=0             kill switch — bypass locking
+#                                         entirely, run <command> directly
+#                                         (documented escape hatch).
+#   NUZ_PREPUSH_SUITE_LOCK_TIMEOUT=<s>   max wait in seconds before failing
+#                                         closed (default 4500 = 75min).
+#                                         Test-only override in practice.
+#   NUZ_PREPUSH_SUITE_LOCK_POLL=<s>      poll interval in seconds (default 2).
+#                                         Test-only override.
+#
+# Exit code: on success, propagates <command>'s own exit code UNCHANGED
+# (including a 128+N signal-death code, so an outer `TEST_RC -ge 128`
+# classification still works). On a timed-out lock acquisition, exits 1
+# itself with an actionable message — the wrapped command never even starts;
+# this NEVER silently skips the lock and runs anyway (cicatrix-superscar.md
+# family #2, "esiste != armato" — a guard that can silently disarm itself
+# is not a guard).
+
+set -u
+
+LOCKFILE="${1:?prepush_suite_lock.sh: missing <lockfile> argument}"
+shift
+
+if [ "$#" -eq 0 ]; then
+    echo "prepush_suite_lock.sh: missing <command> argument" >&2
+    exit 2
+fi
+
+if [ "${NUZ_PREPUSH_SUITE_LOCK:-1}" = "0" ]; then
+    echo "🔓 NUZ_PREPUSH_SUITE_LOCK=0 — backend-suite lock disabled, running directly."
+    "$@"
+    exit $?
+fi
+
+TIMEOUT="${NUZ_PREPUSH_SUITE_LOCK_TIMEOUT:-4500}"
+POLL_INTERVAL="${NUZ_PREPUSH_SUITE_LOCK_POLL:-2}"
+HEARTBEAT_EVERY=30
+
+START_TS=$(date +%s)
+LAST_HEARTBEAT=$START_TS
+
+while :; do
+    if mkdir "$LOCKFILE" 2>/dev/null; then
+        chmod 700 "$LOCKFILE" 2>/dev/null
+        echo $$ > "$LOCKFILE/pid" 2>/dev/null
+        break
+    fi
+
+    HOLDER_PID="$(cat "$LOCKFILE/pid" 2>/dev/null || true)"
+    if [ -n "$HOLDER_PID" ] && ! kill -0 "$HOLDER_PID" 2>/dev/null; then
+        # Holder is dead (SIGTERM'd suite, crashed shell, etc.) — reclaim
+        # immediately rather than waiting out the clock behind a corpse.
+        echo "♻️  backend-suite lock: holder PID $HOLDER_PID is dead — reclaiming stale lock."
+        rm -rf "$LOCKFILE" 2>/dev/null
+        continue
+    fi
+
+    NOW=$(date +%s)
+    ELAPSED=$((NOW - START_TS))
+
+    if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+        TIMEOUT_MIN=$((TIMEOUT / 60))
+        echo "❌ machine saturated — suite lock not acquired in ${TIMEOUT_MIN}m. Do NOT use --no-verify. Either retry later, or land this branch from an idle fleet machine (git bundle + push from pro/mini)." >&2
+        exit 1
+    fi
+
+    if [ $((NOW - LAST_HEARTBEAT)) -ge "$HEARTBEAT_EVERY" ]; then
+        HELD_MIN=$((ELAPSED / 60))
+        echo "⏳ waiting for this machine's backend-suite lock (held by PID ${HOLDER_PID:-unknown} for ${HELD_MIN}m)"
+        LAST_HEARTBEAT=$NOW
+    fi
+
+    sleep "$POLL_INTERVAL"
+done
+
+# CHILD_PID starts unset: if this wrapper is killed between acquiring the
+# lock and backgrounding the command below, cleanup must only drop the lock,
+# not try to signal a child that was never started.
+CHILD_PID=""
+cleanup() {
+    if [ -n "$CHILD_PID" ]; then
+        # A signal that targets only THIS wrapper's PID (not the whole
+        # foreground process group) must not leave the wrapped suite running
+        # as an orphan after the lock is already released underneath it.
+        kill -TERM "$CHILD_PID" 2>/dev/null
+    fi
+    rm -rf "$LOCKFILE" 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+"$@" &
+CHILD_PID=$!
+wait "$CHILD_PID"
+RC=$?
+exit "$RC"

--- a/scripts/tests/test_prepush_suite_lock.sh
+++ b/scripts/tests/test_prepush_suite_lock.sh
@@ -1,0 +1,222 @@
+#!/bin/sh
+# test_prepush_suite_lock.sh — regression test for scripts/prepush_suite_lock.sh,
+# the machine-wide backend-suite serialization wrapper wired into
+# .husky/pre-push (2026-07-27).
+#
+# Measured live on M5, 2026-07-27 09:31->09:57 WITA: load average 68, 12
+# concurrent `python -m pytest backend/tests/` processes, ~124MB free memory,
+# pushes SIGTERM-killed mid-suite. This wrapper makes the backend suite
+# single-flight per machine. Its own header (scripts/prepush_suite_lock.sh)
+# documents the primitive choice (mkdir, not flock/shlock/lockf — verified
+# empirically absent/deprecated/silent-while-waiting respectively) and why
+# stale-lock reclamation is the single most important correctness property:
+# a lock must never outlive its holder, or a killed suite wedges the machine
+# forever instead of just failing that one push.
+#
+# Five cases, mirroring the brief's guilt/innocence/stale/timeout/kill-switch
+# split and this repo's own test_prepush_failclosed.sh style (real kills and
+# real dead PIDs over synthetic conditions wherever the property under test
+# is about a REAL process's fate, not just arithmetic).
+#
+# Run:  sh scripts/tests/test_prepush_suite_lock.sh
+# Exit: 0 all pass, 1 any failure.
+
+fail=0
+pass=0
+
+note_pass() { pass=$((pass + 1)); echo "PASS - $1"; }
+note_fail() { fail=$((fail + 1)); echo "FAIL - $1"; }
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/prepush_suite_lock.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+    note_fail "setup — $SCRIPT not found or not executable, cannot run any case"
+    echo "---"
+    echo "$pass passed, $fail failed"
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d 2>/dev/null)"
+if [ -z "$WORKDIR" ]; then
+    note_fail "setup — mktemp -d failed, cannot run any case"
+    echo "---"
+    echo "$pass passed, $fail failed"
+    exit 1
+fi
+cleanup_workdir() { rm -rf "$WORKDIR"; }
+trap cleanup_workdir EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Case 1 (innocence): a single acquirer with no contender must run
+# essentially immediately — no added latency beyond process-spawn noise.
+# ---------------------------------------------------------------------------
+LOCK1="$WORKDIR/innocence.lock"
+T0=$(date +%s)
+OUT1="$("$SCRIPT" "$LOCK1" sh -c 'echo ran')"
+RC1=$?
+T1=$(date +%s)
+ELAPSED1=$((T1 - T0))
+if [ "$OUT1" = "ran" ] && [ "$RC1" -eq 0 ] && [ "$ELAPSED1" -le 3 ]; then
+    note_pass "innocence — single acquirer ran immediately (${ELAPSED1}s, rc=$RC1, out='$OUT1')"
+else
+    note_fail "innocence — expected immediate run + rc=0 + out=ran, got elapsed=${ELAPSED1}s rc=$RC1 out='$OUT1'"
+fi
+if [ -e "$LOCK1" ]; then
+    note_fail "innocence — lock directory not cleaned up after a normal exit ($LOCK1 still exists)"
+else
+    note_pass "innocence — lock directory cleaned up after a normal exit"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2 (guilt): two concurrent acquirers on the SAME lockfile — the second
+# must wait for the first to release, never run in parallel. Proved
+# observably via timestamps written to a shared marker file by each holder
+# itself (not by reading the wrapper's code): holder A records its start
+# time then holds the lock for 3s; holder B (launched 0.5s later, well
+# inside A's hold) records its own start time the moment IT acquires. If
+# serialization holds, B's start must land at least ~2s after A's (allowing
+# margin below A's full 3s hold for scheduling/poll-interval noise) — b
+# starting anywhere near A's own start would mean they ran concurrently.
+# ---------------------------------------------------------------------------
+LOCK2="$WORKDIR/guilt.lock"
+MARKER2="$WORKDIR/guilt.marker"
+: > "$MARKER2"
+
+"$SCRIPT" "$LOCK2" sh -c "echo \"A \$(date +%s)\" >> \"$MARKER2\"; sleep 3" &
+PID_A=$!
+sleep 0.5
+"$SCRIPT" "$LOCK2" sh -c "echo \"B \$(date +%s)\" >> \"$MARKER2\"" &
+PID_B=$!
+wait "$PID_A"
+wait "$PID_B"
+
+A_TS="$(grep '^A ' "$MARKER2" | awk '{print $2}')"
+B_TS="$(grep '^B ' "$MARKER2" | awk '{print $2}')"
+if [ -n "$A_TS" ] && [ -n "$B_TS" ]; then
+    DIFF=$((B_TS - A_TS))
+else
+    DIFF=-1
+fi
+if [ "$DIFF" -ge 2 ]; then
+    note_pass "guilt — second acquirer waited for the first (B started ${DIFF}s after A, holder A slept 3s)"
+else
+    note_fail "guilt — expected B to start >=2s after A (serialized), got diff=${DIFF}s (marker: $(cat "$MARKER2" 2>/dev/null))"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 (stale): a lock whose recorded PID is dead must be reclaimed, not
+# waited out. Uses a REAL PID that is GUARANTEED dead — a child process
+# started and explicitly waited-for to completion (same discipline as
+# test_prepush_failclosed.sh Case 8: a real process's fate, not a magic
+# number that merely looks plausible) — pre-seeded as the lock's holder
+# before the wrapper is ever invoked.
+# ---------------------------------------------------------------------------
+LOCK3="$WORKDIR/stale.lock"
+sh -c 'exit 0' &
+DEAD_PID=$!
+wait "$DEAD_PID" 2>/dev/null
+mkdir -p "$LOCK3"
+echo "$DEAD_PID" > "$LOCK3/pid"
+
+T0=$(date +%s)
+OUT3="$("$SCRIPT" "$LOCK3" sh -c 'echo reclaimed' 2>&1)"
+RC3=$?
+T1=$(date +%s)
+ELAPSED3=$((T1 - T0))
+
+if printf '%s' "$OUT3" | grep -q 'reclaimed' \
+   && printf '%s' "$OUT3" | grep -qi 'stale' \
+   && [ "$RC3" -eq 0 ] \
+   && [ "$ELAPSED3" -le 5 ]; then
+    note_pass "stale — dead-PID lock ($DEAD_PID) reclaimed and command ran (${ELAPSED3}s, rc=$RC3)"
+else
+    note_fail "stale — expected fast reclaim + 'reclaimed' output + a stale-lock message, got elapsed=${ELAPSED3}s rc=$RC3 out='$OUT3'"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4 (timeout): a lock held by a LIVE PID, with the wait capped to ~1s
+# (NUZ_PREPUSH_SUITE_LOCK_TIMEOUT), must produce a NON-ZERO exit and an
+# actionable message naming the fleet-machine alternative — never silently
+# skip the suite and run anyway (that would disarm the guard, cicatrix
+# family #2). The holder PID is a real long-running `sleep` so `kill -0`
+# genuinely reports it alive throughout the test.
+# ---------------------------------------------------------------------------
+LOCK4="$WORKDIR/timeout.lock"
+sleep 30 &
+LIVE_PID=$!
+mkdir -p "$LOCK4"
+echo "$LIVE_PID" > "$LOCK4/pid"
+
+OUT4="$(NUZ_PREPUSH_SUITE_LOCK_TIMEOUT=1 NUZ_PREPUSH_SUITE_LOCK_POLL=0.3 "$SCRIPT" "$LOCK4" sh -c 'echo SHOULD_NOT_RUN' 2>&1)"
+RC4=$?
+kill "$LIVE_PID" 2>/dev/null
+
+if [ "$RC4" -ne 0 ] \
+   && ! printf '%s' "$OUT4" | grep -q 'SHOULD_NOT_RUN' \
+   && printf '%s' "$OUT4" | grep -q -- '--no-verify' \
+   && printf '%s' "$OUT4" | grep -q 'pro/mini'; then
+    note_pass "timeout — held lock + capped wait produced non-zero exit (rc=$RC4) with fleet-machine guidance, wrapped command never ran"
+else
+    note_fail "timeout — expected non-zero exit + guidance message + command never running, got rc=$RC4 out='$OUT4'"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5 (kill switch): NUZ_PREPUSH_SUITE_LOCK=0 must bypass locking
+# entirely — proved by pre-seeding a lock that is BOTH held (a live PID)
+# AND would time out almost instantly if the wrapper touched it at all, then
+# confirming the command still runs immediately and the pre-seeded lock is
+# left completely untouched (still exists, PID file unchanged) — evidence
+# the wrapper never even looked at it.
+# ---------------------------------------------------------------------------
+LOCK5="$WORKDIR/killswitch.lock"
+sleep 30 &
+LIVE_PID5=$!
+mkdir -p "$LOCK5"
+echo "$LIVE_PID5" > "$LOCK5/pid"
+BEFORE_PID_CONTENT="$(cat "$LOCK5/pid")"
+
+T0=$(date +%s)
+OUT5="$(NUZ_PREPUSH_SUITE_LOCK=0 NUZ_PREPUSH_SUITE_LOCK_TIMEOUT=1 "$SCRIPT" "$LOCK5" sh -c 'echo bypassed')"
+RC5=$?
+T1=$(date +%s)
+ELAPSED5=$((T1 - T0))
+AFTER_PID_CONTENT="$(cat "$LOCK5/pid" 2>/dev/null)"
+kill "$LIVE_PID5" 2>/dev/null
+
+if printf '%s' "$OUT5" | grep -q '^bypassed$' && [ "$RC5" -eq 0 ] && [ "$ELAPSED5" -le 3 ] \
+   && [ "$AFTER_PID_CONTENT" = "$BEFORE_PID_CONTENT" ]; then
+    note_pass "kill switch — NUZ_PREPUSH_SUITE_LOCK=0 ran immediately (${ELAPSED5}s) despite a held+would-timeout lock, and left it untouched"
+else
+    note_fail "kill switch — expected immediate bypass + untouched lock, got elapsed=${ELAPSED5}s rc=$RC5 out='$OUT5' before='$BEFORE_PID_CONTENT' after='$AFTER_PID_CONTENT'"
+fi
+rm -rf "$LOCK5"
+
+# ---------------------------------------------------------------------------
+# Case 6 (tripwire): the LIVE hook must actually call the wrapper around the
+# pytest invocation — a correct standalone script that nobody wires in
+# protects nothing (cicatrix family #2, "esiste != armato").
+# ---------------------------------------------------------------------------
+HOOK_FILE="$REPO_ROOT/.husky/pre-push"
+if [ ! -f "$HOOK_FILE" ]; then
+    note_fail "tripwire — $HOOK_FILE not found (cannot verify it's wired in)"
+else
+    if grep -q 'PREPUSH_SUITE_LOCK_SCRIPT' "$HOOK_FILE" \
+       && grep -q 'PREPUSH_SUITE_LOCKFILE' "$HOOK_FILE" \
+       && grep -q '"\$PREPUSH_SUITE_LOCK_SCRIPT" "\$PREPUSH_SUITE_LOCKFILE"' "$HOOK_FILE" \
+       && grep -q 'python -m pytest backend/tests/' "$HOOK_FILE"; then
+        note_pass "tripwire — .husky/pre-push wires the lock wrapper around the pytest invocation"
+    else
+        note_fail "tripwire — .husky/pre-push does not reference the lock wrapper as expected"
+    fi
+fi
+
+echo "---"
+echo "$pass passed, $fail failed"
+
+if [ "$fail" -eq 0 ]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
## The measured problem

Measured live on M5, 2026-07-27 09:31→09:57 WITA: load average **68**, **12 concurrent
`python -m pytest backend/tests/` processes** (one per agent worktree's pre-push hook), ~124MB free
memory. Nine near-identical ~17k-test suites contending for the same CPU made each run ~3x slower
(40-60min instead of ~12), and pushes were being **SIGTERM-killed mid-suite** — silent work loss:
**13+ worktrees held committed work that never became a PR**, invisible to `gh pr list`.

Twelve parallel copies of one collaudo is not twelve verifications; it is one verification performed
twelve times badly, and the way it fails (killed at 66%, at 90%) is worse than the risk it covers.

## The change

`scripts/prepush_suite_lock.sh` wraps **only** the heavy `python -m pytest backend/tests/`
invocation in `.husky/pre-push` — not the whole hook, not the path-aware classifier, not the
venv/PG/DB-clone gates, and nothing about WHICH tests run. At most one backend suite runs per
machine; everyone else waits with a visible heartbeat, bounded, fail-closed.

- **Primitive**: `mkdir` (POSIX-atomic) + a PID file for stale-holder detection via `kill -0`.
  Verified empirically on Air-M5/Darwin 27.0.0: `flock(1)` is absent from macOS; `shlock(1)` exists
  but is deprecated by its own man page; `lockf(1)` exists but blocks **silently**, and silence
  during a long wait is precisely what gets pushes killed today.
- **Stale-lock safety** (the load-bearing property): the lock records the wrapper's own PID and that
  process stays alive for the whole suite, so a holder killed by SIGTERM is detected dead on the
  next poll and reclaimed immediately — a killed suite never wedges the machine.
- **Bounded wait, fail-closed**: 75min default (one predecessor's measured 40-60min worst case plus
  buffer). On timeout the push is REFUSED with guidance naming the alternative (land from an idle
  fleet machine via bundle transfer) — never a silent skip of the suite (cicatrix family #2).
- The `|| TEST_RC=$?` errexit-immune capture and the three-way 128+N signal classification (W101,
  #3230) are preserved untouched, so a signal-killed suite still reports "NO VERDICT" rather than
  blaming the diff.
- **Kill switch**: `NUZ_PREPUSH_SUITE_LOCK=0`.

## Verification (run by the reviewing session, not only by the author)

- `scripts/tests/test_prepush_suite_lock.sh` — **7/7 passed in 6.6s**, re-executed independently:
  innocence (single acquirer, no added latency; lock cleaned up on normal exit), guilt (second
  acquirer demonstrably waited, proven by timestamps a holder writes itself), stale (a lock held by
  a real waited-for-dead PID is reclaimed), timeout (held lock + 1s cap → non-zero exit with the
  fleet-machine message, wrapped command never started), kill switch (bypasses even a held lock and
  leaves it untouched), and a **tripwire that the wrapper is actually wired into `.husky/pre-push`**
  (esiste ≠ armato).
- **Live integration proof**: this very branch was pushed from Pro with the new hook active — the
  full backend suite ran *under the lock* and passed, `✅ All pre-push checks passed!` in **8m34s**
  wall time, versus the 40-60min-or-killed it was taking on the contended machine.

## Known follow-up (not blocking, degrades to today's behavior)

The stale-reclamation path has a narrow TOCTOU window: two waiters observing the same corpse can
both `rm -rf` the lock, and the second removal could delete a lock a third process has just
acquired. Worst case is two parallel suites — i.e. exactly today's unserialized behavior — never a
wedge and never a false pass. Narrowing it (re-read the PID file immediately before removal, or
reclaim by atomic rename) is a follow-up rather than a blocker, since the machine needs the relief
now and the failure mode is strictly no worse than the status quo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)