### PR TITLE
feat(garuda_voa): the extension gate becomes the published deadline, not our own margin

### DIFF
--- a/apps/backend-rag/backend/app/routers/garuda_voa.py
+++ b/apps/backend-rag/backend/app/routers/garuda_voa.py
@@ -47,8 +47,10 @@ hours, so an issuance request is accepted up to the day BEFORE arrival —
 Bali Zero's systems being closed weekends and Indonesian national
 holidays/cuti bersama. This SUPERSEDES the charter's blanket "urgent case"
 exclusion FOR ISSUANCE ONLY; extensions are untouched (in-person
-photo/interview since 29 May 2025, own D-10 runway gate, own D-7 published
-deadline). Two neutral, routing-worded decline codes
+photo/interview since 29 May 2025, own runway gate — now identical to the
+published D-7 filing deadline itself, owner ruling 2026-07-27, see
+`services.garuda_flow.eligibility.screen`). Two neutral, routing-worded
+decline codes
 (`DeclineCode.ARRIVAL_TOO_SOON` / `DeclineCode.ARRIVAL_DATE_UNCONFIRMED`)
 join the wire-safe set above. `VoaResponse.submit_by_date` carries the one
 date this gate can ever show a visitor — Bali Zero's OWN operational

--- a/apps/backend-rag/backend/services/garuda_flow/constants.py
+++ b/apps/backend-rag/backend/services/garuda_flow/constants.py
@@ -2,14 +2,22 @@
 
 Every number here is traceable to a governance document, NOT invented:
 
-- ``PILOT_INTAKE_THRESHOLD_DAYS`` (D-10): SOP-v0-GARUDA-B1 §1 "Pilot intake
-  threshold — D-10 (set 2026-07-24, Zero-delegated)". A pilot-conservatism
-  parameter, NOT a legal limit — Zero/Surya may retune it. NEVER quoted to a
-  client as an official rule.
+- ``PILOT_INTAKE_THRESHOLD_DAYS`` (D-10): set 2026-07-24 (Zero-delegated) as
+  SOP-v0-GARUDA-B1 §1 "Pilot intake threshold". Owner ruling 2026-07-27
+  RETIRED that role: the gate was declining cases (e.g. 8 days of runway)
+  that are still legally filable under the published deadline below, and
+  it added margin nobody asked for — our threshold and the office's
+  published deadline should be the same line. This constant survives
+  ONLY as the SOP §6 internal staff-escalation checkpoint inside
+  ``safe_clock.compute_stay`` — it is NEVER again an ACCEPT/DECLINE gate,
+  and, as before, NEVER quoted to a client.
 - ``PUBLISHED_FILING_DEADLINE_DAYS`` (D-7): the published Ngurah Rai filing
   deadline ("paling lambat 7 hari sebelum masa izin tinggal berakhir",
   verified verbatim on ngurahrai.imigrasi.go.id 2026-07-24). The one number
-  that IS client-facing. "verify per office" — offices may differ.
+  that IS client-facing, AND (owner ruling 2026-07-27) the single source
+  of truth `eligibility.screen()` derives the extension-intake runway
+  gate from — no separately-tuned pilot margin anymore. "verify per
+  office" — offices may differ.
 - ``EXTENSION_WINDOW_OPENS_DAYS`` (D-14): INTERNAL-ONLY staff estimate of the
   earliest the extension window opens. The source states this two
   incompatible ways on the same page — "paling cepat ... 14 hari sebelum
@@ -32,7 +40,7 @@ from __future__ import annotations
 # ── Safe Clock (days before the VOA/extension expiry) ────────────────
 EXTENSION_WINDOW_OPENS_DAYS: int = 14  # D-14 — earliest the window opens
 PUBLISHED_FILING_DEADLINE_DAYS: int = 7  # D-7 — published Ngurah Rai deadline (client-facing)
-PILOT_INTAKE_THRESHOLD_DAYS: int = 10  # D-10 — pilot accepts only with >= this runway
+PILOT_INTAKE_THRESHOLD_DAYS: int = 10  # D-10 — internal SOP §6 staff-escalation checkpoint only
 INTERNAL_ESCALATION_DAYS: int = 3  # D-3 — internal escalation checkpoint
 FINAL_CHECK_DAYS: int = 1  # D-1 — internal final-check checkpoint
 

--- a/apps/backend-rag/backend/services/garuda_flow/eligibility.py
+++ b/apps/backend-rag/backend/services/garuda_flow/eligibility.py
@@ -3,18 +3,30 @@
 A faithful, auditable encoding of SOP-v0-GARUDA-B1 §1 segmentation:
 
     ACCEPT only if ALL true: eligible nationality/entry · simple tourism ·
-    1 adult traveler · clean ordinary passport (>=6 months validity) · at
-    least D-10 of runway (extension case) · self-pay · willing to give
-    anonymous feedback.
+    1 adult traveler · clean ordinary passport (>=6 months validity) ·
+    still filable under the published Ngurah Rai filing deadline
+    (extension case) · self-pay · willing to give anonymous feedback.
 
     EXCLUDE (decline politely, log reason): urgent · families/groups ·
     special passports · work/business purpose · prior overstay/refusal/
-    blacklist · airport fast-lane requests · extension below D-10.
+    blacklist · airport fast-lane requests · extension past the published
+    filing deadline.
 
 The screen collects EVERY failing reason (never short-circuits) so the case
 sheet can log a complete "why declined" — SOP §1 "decline politely, log reason".
-The D-10 gate is the enforceable version of the Gate-1 SIM-2 criterion that was
-"not testable" on 2026-07-20 because the threshold did not yet exist.
+
+Owner ruling (2026-07-27): the extension runway gate accepts a case
+whenever it can still be filed under the PUBLISHED Ngurah Rai deadline —
+``PUBLISHED_FILING_DEADLINE_DAYS`` (constants.py), "paling lambat 7 hari
+sebelum masa izin tinggal berakhir". This retires the earlier D-10
+pilot-conservatism gate (``PILOT_INTAKE_THRESHOLD_DAYS``), which was
+declining cases (e.g. 8 days of runway) that are still legally filable —
+our threshold and the office's published deadline are now the SAME line,
+with no added margin. ``PILOT_INTAKE_THRESHOLD_DAYS`` survives ONLY as the
+SOP §6 internal staff-escalation checkpoint inside
+``safe_clock.compute_stay`` — it is no longer an ACCEPT/DECLINE gate
+anywhere in this module, and this module never hardcodes the day-count
+literal: it is always read from ``PUBLISHED_FILING_DEADLINE_DAYS``.
 """
 
 from __future__ import annotations
@@ -22,7 +34,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 
-from backend.services.garuda_flow.constants import PILOT_INTAKE_THRESHOLD_DAYS
+from backend.services.garuda_flow.constants import PUBLISHED_FILING_DEADLINE_DAYS
 
 
 class Decision(str, Enum):
@@ -78,9 +90,10 @@ class DeclineCode(str, Enum):
 class EligibilityInput:
     """Structured intake for the pilot eligibility screen.
 
-    ``is_extension`` distinguishes a fresh VOA issuance (the D-10 runway gate
-    does not apply) from an extension case (it does). ``days_until_expiry`` is
-    required for an extension case and ignored otherwise.
+    ``is_extension`` distinguishes a fresh VOA issuance (the runway gate
+    does not apply) from an extension case (it does — see ``screen()`` for
+    the published-deadline boundary). ``days_until_expiry`` is required for
+    an extension case and ignored otherwise.
     """
 
     # ── Must ALL be true to ACCEPT (SOP §1 positive criteria) ──
@@ -169,17 +182,22 @@ def screen(inp: EligibilityInput) -> EligibilityResult:
     if inp.wants_airport_fastlane:
         _decline(DeclineCode.FASTLANE_REQUEST, "airport fast-lane request (excluded from pilot)")
 
-    # ── D-10 runway gate (extension cases only) ──
+    # ── Runway gate (extension cases only) — owner ruling 2026-07-27: the
+    # ONLY source of truth for "too late" is the published filing deadline
+    # (``PUBLISHED_FILING_DEADLINE_DAYS``). A case with EXACTLY that many
+    # days of runway left is still ACCEPTED (the deadline day itself is
+    # filable — "paling lambat N hari sebelum ... berakhir" reads as "at
+    # the latest"); one day tighter DECLINES. Never a hardcoded literal.
     if inp.is_extension:
         if inp.days_until_expiry is None:
             _decline(
                 DeclineCode.EXPIRY_UNKNOWN,
-                "extension case missing days-until-expiry (cannot verify D-10 runway)",
+                "extension case missing days-until-expiry (cannot verify filing-deadline runway)",
             )
-        elif inp.days_until_expiry < PILOT_INTAKE_THRESHOLD_DAYS:
+        elif inp.days_until_expiry < PUBLISHED_FILING_DEADLINE_DAYS:
             _decline(
                 DeclineCode.EXPIRES_TOO_SOON,
-                f"below D-{PILOT_INTAKE_THRESHOLD_DAYS} pilot threshold "
+                f"past the published D-{PUBLISHED_FILING_DEADLINE_DAYS} filing deadline "
                 f"({inp.days_until_expiry} days to expiry) — hand off to the ordinary channel",
             )
 

--- a/apps/backend-rag/backend/services/garuda_flow/intake.py
+++ b/apps/backend-rag/backend/services/garuda_flow/intake.py
@@ -42,8 +42,9 @@ online 9-field wizard never had a mechanical "urgent" signal to begin with
 (no field in `VoaIntakeRequest` maps to `EligibilityInput.urgent_case`), so
 this gate is what actually governs how close to arrival an issuance request
 may be submitted. It does NOT touch the extension path: extensions require
-an in-person photo/interview (since 29 May 2025) and keep their own D-10
-runway gate + published D-7 filing deadline, both untouched by this ruling.
+an in-person photo/interview (since 29 May 2025) and keep their own runway
+gate — now identical to the published D-7 filing deadline itself (owner
+ruling 2026-07-27, see `eligibility.screen`) — untouched by this ruling.
 ``VoaVerdict.submit_by_date`` carries the one date this rule can ever show a
 visitor — Bali Zero's OWN operational commitment, never an immigration
 rule — and is ``None`` when it cannot be computed (see

--- a/apps/backend-rag/backend/services/garuda_flow/safe_clock.py
+++ b/apps/backend-rag/backend/services/garuda_flow/safe_clock.py
@@ -138,8 +138,10 @@ def compute_stay(
             at=expiry - timedelta(days=PILOT_INTAKE_THRESHOLD_DAYS),
             kind="internal",
             client_facing=False,
-            note="Pilot intake threshold + internal escalation (SOP §1/§6). "
-            "Below this the pilot declines. Never quote to a client.",
+            note="Internal staff-escalation checkpoint (SOP §6) ONLY — NOT "
+            "the pilot's ACCEPT/DECLINE gate (owner ruling 2026-07-27 moved "
+            "that gate to the published D-7 filing deadline, see "
+            "eligibility.screen). Never quote to a client.",
         ),
         SafeCheckpoint(
             label=f"D-{PUBLISHED_FILING_DEADLINE_DAYS}",

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_no_internal_leak.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_no_internal_leak.py
@@ -9,6 +9,21 @@ Fixed by moving decline reasons onto stable machine codes
 (`VoaResponse.reason_codes`); the raw prose stays server-side only
 (`VoaVerdict.decline_reasons` / `garuda_voa_checks.decline_reasons`, audit).
 
+Follow-up ruling, SAME DAY (2026-07-27): the runway gate this leak was
+originally about (`eligibility.screen()`'s extension boundary) no longer
+uses `PILOT_INTAKE_THRESHOLD_DAYS`/D-10 at all — it now derives from the
+published `PUBLISHED_FILING_DEADLINE_DAYS`/D-7 deadline (see
+`eligibility.py`, `constants.py`). `PILOT_INTAKE_THRESHOLD_DAYS` survives
+ONLY as the SOP §6 internal staff-escalation checkpoint inside
+`safe_clock.compute_stay` — so `D-10` can no longer appear in a decline
+reason's raw prose at all, and the "not vacuous" proof below had to move
+off the (now-impossible) D-10-boundary scenario onto a still-live one (a
+generic "excluded from pilot" branch, e.g. `urgent_case=True`) that still
+carries the forbidden word "pilot". The forbidden-token LIST itself is
+untouched — `D-{PILOT_INTAKE_THRESHOLD_DAYS}` stays on it defensively
+(the SOP §6 checkpoint is still an internal-only marker), it just no
+longer has a decline-reason producer to catch mid-leak.
+
 This test is deliberately NOT a literal grep for "D-10" — that string never
 existed literally in the codebase; it was composed at runtime from
 `PILOT_INTAKE_THRESHOLD_DAYS`, and a literal grep is exactly the check that
@@ -20,10 +35,10 @@ missed the original leak. Instead it:
      `D-{EXTENSION_WINDOW_OPENS_DAYS}`), plus the words "pilot" and
      "threshold".
   2. Constructs a real DECLINE `VoaResponse` for every decline branch the
-     engine can produce (every `EligibilityInput` boolean flip, both D-10
-     sub-branches, the extension-already-used rule, and a multi-reason
-     decline), and serializes it to JSON exactly as FastAPI would put it on
-     the wire.
+     engine can produce (every `EligibilityInput` boolean flip, both
+     runway-gate sub-branches, the extension-already-used rule, and a
+     multi-reason decline), and serializes it to JSON exactly as FastAPI
+     would put it on the wire.
   3. Asserts none of the forbidden tokens appear anywhere in that payload.
 
 Both halves, so the guard cannot be vacuous: `TestGuardIsNotVacuous` proves
@@ -45,6 +60,7 @@ from backend.services.garuda_flow.constants import (
     FINAL_CHECK_DAYS,
     INTERNAL_ESCALATION_DAYS,
     PILOT_INTAKE_THRESHOLD_DAYS,
+    PUBLISHED_FILING_DEADLINE_DAYS,
 )
 from backend.services.garuda_flow.eligibility import EligibilityInput, screen
 from backend.services.garuda_flow.intake import (
@@ -115,32 +131,42 @@ def _decline_response(codes: list[str], *, submit_by_date: date | None = None) -
 
 
 class TestGuardIsNotVacuous:
-    """Proves this guard would actually have caught the original leak — the
-    pre-fix RAW engine prose for the exact leaking case (D-10 boundary,
-    9 days remaining) must itself contain a forbidden token. If this class
-    failed, the `IsCleanOnTheWire` passes below would be meaningless."""
+    """Proves this guard would actually have caught the original leak.
 
-    def test_raw_prose_for_the_d10_boundary_contains_a_forbidden_token(self) -> None:
-        result = screen(_clean_extension(days_until_expiry=9))
-        assert result.decline_reasons, "expected a decline reason for the D-10 boundary case"
+    Follow-up ruling (2026-07-27, same day): the runway gate no longer
+    uses `PILOT_INTAKE_THRESHOLD_DAYS`/D-10 at all (see module docstring),
+    so `D-10` can no longer appear in ANY decline reason's raw prose —
+    the original D-10-boundary scenario this proof used is gone. The
+    not-vacuous demonstration moves to a still-live branch that reliably
+    emits the forbidden word "pilot" (every SOP §1 exclusion signal is
+    worded "excluded from pilot"). If this class failed, the
+    `IsCleanOnTheWire` passes below would be meaningless."""
+
+    def test_raw_prose_for_an_excluded_case_contains_a_forbidden_token(self) -> None:
+        result = screen(_clean_extension(urgent_case=True))
+        assert result.decline_reasons, "expected a decline reason for the excluded case"
         raw = json.dumps(result.decline_reasons).lower()
         assert any(tok.lower() in raw for tok in _FORBIDDEN_TOKENS), (
             "guard is vacuous: the RAW engine prose contains none of the forbidden "
             "tokens — this test would pass even without the fix"
         )
 
-    def test_raw_prose_names_pilot_and_threshold_verbatim(self) -> None:
-        result = screen(_clean_extension(days_until_expiry=9))
+    def test_raw_prose_names_pilot_verbatim(self) -> None:
+        result = screen(_clean_extension(urgent_case=True))
         raw = " ".join(result.decline_reasons).lower()
         assert "pilot" in raw
-        assert "threshold" in raw
+        # "threshold" is NOT asserted here anymore: post-2026-07-27 no
+        # decline reason ever uses that word (the runway gate's message
+        # talks about the published filing deadline, not a "threshold").
+        # It stays on `_FORBIDDEN_TOKENS` defensively in case that wording
+        # is ever reintroduced — this test just can't prove it live today.
 
 
 class TestEveryEligibilityBranchDeclineIsCleanOnTheWire:
     """One parametrized case per `eligibility.screen()` decline branch —
-    every boolean flip (and both D-10 sub-branches) that can produce a
-    decline reason. Each is serialized through the real `VoaResponse` and
-    checked against the forbidden-token list."""
+    every boolean flip (and both runway-gate sub-branches) that can
+    produce a decline reason. Each is serialized through the real
+    `VoaResponse` and checked against the forbidden-token list."""
 
     @pytest.mark.parametrize(
         "overrides",
@@ -159,7 +185,9 @@ class TestEveryEligibilityBranchDeclineIsCleanOnTheWire:
             {"prior_overstay_refusal_blacklist": True},
             {"wants_airport_fastlane": True},
             {"days_until_expiry": None},
-            {"days_until_expiry": 9},  # the exact case that leaked
+            # One day past the published deadline (owner ruling
+            # 2026-07-27) — the current runway-gate boundary decline.
+            {"days_until_expiry": PUBLISHED_FILING_DEADLINE_DAYS - 1},
             {"days_until_expiry": -2},
         ],
         ids=lambda o: ",".join(f"{k}={v}" for k, v in o.items()),
@@ -247,15 +275,15 @@ class TestIssuanceSubmissionGateDeclineIsCleanOnTheWire:
 
 class TestMultiReasonDeclineIsCleanOnTheWire:
     """SOP §1 'log reason' — the screen collects every failing reason, never
-    short-circuiting. Several reasons plus the D-10 boundary reason on one
-    response is the exact shape the original leak shipped in."""
+    short-circuiting. Several reasons plus the runway-boundary reason on
+    one response is the exact shape the original leak shipped in."""
 
-    def test_multiple_reasons_including_d10_boundary_all_clean(self) -> None:
+    def test_multiple_reasons_including_runway_boundary_all_clean(self) -> None:
         result = screen(
             _clean_extension(
                 self_pay=False,
                 work_or_business_purpose=True,
-                days_until_expiry=9,
+                days_until_expiry=PUBLISHED_FILING_DEADLINE_DAYS - 1,
             )
         )
         assert result.decision.value == "DECLINE"

--- a/apps/backend-rag/backend/tests/services/garuda_flow/test_eligibility.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/test_eligibility.py
@@ -1,16 +1,23 @@
 """Tests for the GARUDA VOA pilot eligibility screen.
 
-The D-10 boundary tests are the enforceable form of the Gate-1 SIM-2 criterion
-that was "not testable" on 2026-07-20 because no threshold existed.
+The runway-boundary tests are the enforceable form of the Gate-1 SIM-2
+criterion that was "not testable" on 2026-07-20 because no threshold
+existed. Owner ruling 2026-07-27 retuned the boundary itself: the gate
+now derives from ``PUBLISHED_FILING_DEADLINE_DAYS`` (D-7), not the
+retired ``PILOT_INTAKE_THRESHOLD_DAYS`` (D-10) — see
+``TestPublishedDeadlineBoundary`` below. The old D-10-pinned tests were
+DELETED, not kept alongside the new ones: they asserted the retired
+(now-wrong) behaviour.
 """
 
 from __future__ import annotations
 
 import dataclasses
+import inspect
 
 import pytest
 
-from backend.services.garuda_flow.constants import PILOT_INTAKE_THRESHOLD_DAYS
+from backend.services.garuda_flow.constants import PUBLISHED_FILING_DEADLINE_DAYS
 from backend.services.garuda_flow.eligibility import (
     Decision,
     EligibilityInput,
@@ -36,38 +43,70 @@ def _clean_extension(**overrides: object) -> EligibilityInput:
 
 
 class TestAccept:
-    def test_clean_extension_well_within_d10_accepts(self) -> None:
+    def test_clean_extension_well_within_the_runway_accepts(self) -> None:
         assert screen(_clean_extension()).accepted is True
 
-    def test_fresh_issuance_ignores_d10_runway(self) -> None:
-        # A fresh VOA issuance has no expiry pressure — D-10 must not apply.
+    def test_fresh_issuance_ignores_the_runway_gate(self) -> None:
+        # A fresh VOA issuance has no expiry pressure — the runway gate
+        # (extension-only) must not apply.
         inp = _clean_extension(is_extension=False, days_until_expiry=None)
         res = screen(inp)
         assert res.decision is Decision.ACCEPT
         assert res.decline_reasons == []
 
 
-class TestD10Boundary:
-    def test_exactly_d10_accepts(self) -> None:
-        # ">= 10 days remain" → exactly 10 is IN.
-        res = screen(_clean_extension(days_until_expiry=PILOT_INTAKE_THRESHOLD_DAYS))
+class TestPublishedDeadlineBoundary:
+    """Owner ruling (2026-07-27): the pilot's D-10 conservatism gate is
+    retired. The runway gate now accepts an extension whenever it can
+    still be filed under the PUBLISHED Ngurah Rai deadline
+    (``PUBLISHED_FILING_DEADLINE_DAYS`` — D-7): our threshold and the
+    office's published deadline are the same line, no added margin."""
+
+    def test_exactly_at_the_published_deadline_accepts(self) -> None:
+        # The deadline day itself is still filable — "paling lambat 7 hari
+        # sebelum ... berakhir" reads as "at the latest 7 days before".
+        res = screen(_clean_extension(days_until_expiry=PUBLISHED_FILING_DEADLINE_DAYS))
         assert res.accepted is True
 
-    def test_d9_declines_with_handoff_reason(self) -> None:
-        # 9 days = below threshold → decline, and the reason must point to the
-        # ordinary channel (the amended SOP "never leave a bare no").
-        res = screen(_clean_extension(days_until_expiry=9))
+    def test_one_day_past_the_published_deadline_declines_with_handoff_reason(
+        self,
+    ) -> None:
+        # One day tighter than the published deadline → decline, and the
+        # reason must point to the ordinary channel (the amended SOP
+        # "never leave a bare no").
+        res = screen(_clean_extension(days_until_expiry=PUBLISHED_FILING_DEADLINE_DAYS - 1))
         assert res.decision is Decision.DECLINE
-        assert any("below D-10" in r and "ordinary channel" in r for r in res.decline_reasons)
+        assert any(
+            "published" in r and "filing deadline" in r and "ordinary channel" in r
+            for r in res.decline_reasons
+        )
+
+    def test_owner_example_8_days_on_a_30_day_case_now_accepts(self) -> None:
+        # The owner's actual example (2026-07-27): 8 days of runway is
+        # still legally filable under the published D-7 deadline. The
+        # retired D-10 pilot-conservatism gate used to decline this case
+        # — it must not anymore.
+        res = screen(_clean_extension(days_until_expiry=8))
+        assert res.accepted is True
 
     def test_extension_missing_days_declines(self) -> None:
         res = screen(_clean_extension(days_until_expiry=None))
         assert res.decision is Decision.DECLINE
         assert any("missing days-until-expiry" in r for r in res.decline_reasons)
 
-    def test_already_overstaying_declines(self) -> None:
+    def test_published_deadline_already_in_the_past_declines(self) -> None:
         res = screen(_clean_extension(days_until_expiry=-2))
         assert res.decision is Decision.DECLINE
+
+    def test_gate_reads_the_threshold_from_the_constant_not_a_literal(self) -> None:
+        # No new literal 7 (or the retired 10) may ever be hardcoded in the
+        # runway gate — it must derive from PUBLISHED_FILING_DEADLINE_DAYS.
+        from backend.services.garuda_flow import eligibility
+
+        source = inspect.getsource(eligibility.screen)
+        assert "PUBLISHED_FILING_DEADLINE_DAYS" in source
+        assert "< 7" not in source
+        assert "< 10" not in source
 
 
 class TestExclusions:

--- a/apps/backend-rag/backend/tests/services/garuda_flow/test_intake.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/test_intake.py
@@ -12,7 +12,10 @@ from datetime import date, timedelta
 
 import pytest
 
-from backend.services.garuda_flow.constants import MIN_PASSPORT_VALIDITY_DAYS
+from backend.services.garuda_flow.constants import (
+    MIN_PASSPORT_VALIDITY_DAYS,
+    PUBLISHED_FILING_DEADLINE_DAYS,
+)
 from backend.services.garuda_flow.eligibility import Decision
 from backend.services.garuda_flow.intake import (
     CaseType,
@@ -40,7 +43,7 @@ def _issuance(**overrides: object) -> VoaIntakeRequest:
 
 
 def _extension(**overrides: object) -> VoaIntakeRequest:
-    """A fully-eligible extension request well within the D-10 runway."""
+    """A fully-eligible extension request well within the runway gate."""
     today = date(2026, 7, 27)
     base: dict[str, object] = {
         "case_type": CaseType.EXTENSION,
@@ -89,29 +92,52 @@ class TestPassportValidityDerivation:
 
 
 class TestExtensionDaysUntilExpiryDerivation:
-    def test_extension_well_within_d10_accepts(self) -> None:
+    def test_extension_well_within_the_runway_accepts(self) -> None:
         verdict = build_verdict(_extension(), today=_TODAY)
         assert verdict.accepted is True
 
-    def test_extension_exactly_d10_accepts(self) -> None:
-        req = _extension(voa_expiry_date=_TODAY + timedelta(days=10))
+    def test_extension_exactly_at_published_deadline_accepts(self) -> None:
+        # Owner ruling 2026-07-27: the deadline day itself is still filable.
+        req = _extension(
+            voa_expiry_date=_TODAY + timedelta(days=PUBLISHED_FILING_DEADLINE_DAYS)
+        )
         verdict = build_verdict(req, today=_TODAY)
         assert verdict.accepted is True
 
-    def test_extension_below_d10_declines_with_handoff_reason(self) -> None:
-        req = _extension(voa_expiry_date=_TODAY + timedelta(days=9))
+    def test_extension_one_day_past_published_deadline_declines_with_handoff_reason(
+        self,
+    ) -> None:
+        req = _extension(
+            voa_expiry_date=_TODAY + timedelta(days=PUBLISHED_FILING_DEADLINE_DAYS - 1)
+        )
         verdict = build_verdict(req, today=_TODAY)
         assert verdict.decision is Decision.DECLINE
-        assert any("below D-10" in r and "ordinary channel" in r for r in verdict.decline_reasons)
+        assert any(
+            "published" in r and "filing deadline" in r and "ordinary channel" in r
+            for r in verdict.decline_reasons
+        )
+
+    def test_owner_example_8_days_out_on_a_30_day_case_now_accepts(self) -> None:
+        # Owner ruling 2026-07-27's actual example: a 30-day VOA, entry 22
+        # days ago, so the original expiry falls exactly 8 days from today.
+        # 8 days of runway is still legally filable under the published D-7
+        # deadline — the retired D-10 pilot-conservatism gate used to
+        # decline this case; it must not anymore.
+        entry = _TODAY - timedelta(days=22)
+        req = _extension(entry_date=entry, voa_expiry_date=_TODAY + timedelta(days=8))
+        verdict = build_verdict(req, today=_TODAY)
+        assert verdict.accepted is True
 
     def test_extension_already_overstaying_declines(self) -> None:
+        # The published deadline is already in the past.
         req = _extension(voa_expiry_date=_TODAY - timedelta(days=2))
         verdict = build_verdict(req, today=_TODAY)
         assert verdict.decision is Decision.DECLINE
 
     def test_issuance_ignores_extension_only_fields(self) -> None:
-        # A fresh issuance has no expiry pressure — the D-10 gate must not
-        # apply even if voa_expiry_date/extension_already_used are populated.
+        # A fresh issuance has no expiry pressure — the runway gate must
+        # not apply even if voa_expiry_date/extension_already_used are
+        # populated.
         req = _issuance()
         assert req.voa_expiry_date is None
         verdict = build_verdict(req, today=_TODAY)
@@ -148,8 +174,8 @@ class TestIssuanceSubmissionWindowGate:
     online funnel accepts an issuance request up to the day BEFORE arrival
     — counting Bali Zero's systems closed on Saturday, Sunday, and any
     Indonesian national holiday/cuti bersama (`operating_calendar.py`).
-    Issuance-only; the extension path (its own D-10 test class below) must
-    be completely unaffected.
+    Issuance-only; the extension path (its own runway-gate test class
+    above) must be completely unaffected.
 
     Two of these are the exact pinned dates verified by hand this session:
     departure Tue 18 Aug 2026 (cutoff Fri 14 Aug, Independence Day Monday in
@@ -234,10 +260,10 @@ class TestIssuanceSubmissionWindowGate:
         # An extension's entry_date is the ORIGINAL entry (always in the
         # past) -- if this issuance-only gate ever ran for extensions it
         # would decline every one of them. It must never run: the decision
-        # here is governed purely by the (untouched) D-10 runway gate, and
+        # here is governed purely by the (untouched) runway gate, and
         # submit_by_date must stay None.
         today = date(2026, 7, 27)
-        req = _extension()  # entry_date = today - 20 days, well within D-10
+        req = _extension()  # entry_date = today - 20 days, well within the runway
         verdict = build_verdict(req, today=today)
         assert verdict.accepted is True
         assert verdict.submit_by_date is None

--- a/apps/mouth/src/i18n/locales/en.json
+++ b/apps/mouth/src/i18n/locales/en.json
@@ -531,7 +531,7 @@
         "PRIOR_ISSUE": "Your case needs a closer look from our team — our ordinary channel handles cases like this on a short timeline.",
         "FASTLANE_REQUEST": "Airport fast-lane requests go through our ordinary channel, which handles them on a short timeline.",
         "EXPIRY_UNKNOWN": "We need your exact expiry date to confirm this — our ordinary channel can take it from here on a short timeline.",
-        "EXPIRES_TOO_SOON": "Your timeline is tight for this quick check — our ordinary channel handles cases like yours on a short timeline.",
+        "EXPIRES_TOO_SOON": "The published filing deadline for this extension has already passed, so our online check can't take it — our ordinary channel will still go through your options with you.",
         "EXTENSION_ALREADY_USED": "This VOA has already been extended once — our ordinary channel handles further extensions on a short timeline.",
         "ARRIVAL_TOO_SOON": "Your arrival date is past our online submit-by window — our ordinary channel handles cases like yours on a short timeline.",
         "ARRIVAL_DATE_UNCONFIRMED": "We can't yet compute a submit-by date this far ahead — our team will confirm it with you directly.",

--- a/apps/mouth/src/i18n/locales/id.json
+++ b/apps/mouth/src/i18n/locales/id.json
@@ -532,7 +532,7 @@
         "PRIOR_ISSUE": "Kasus Anda perlu ditinjau lebih lanjut oleh tim kami — jalur reguler kami menangani kasus seperti ini dengan waktu singkat.",
         "FASTLANE_REQUEST": "Permintaan jalur cepat bandara ditangani melalui jalur reguler kami, dengan waktu singkat.",
         "EXPIRY_UNKNOWN": "Kami memerlukan tanggal berakhir yang pasti untuk memastikan ini — jalur reguler kami dapat melanjutkannya dengan waktu singkat.",
-        "EXPIRES_TOO_SOON": "Jangka waktu Anda cukup mepet untuk pemeriksaan cepat ini — jalur reguler kami menangani kasus seperti milik Anda dengan waktu singkat.",
+        "EXPIRES_TOO_SOON": "Batas waktu pengajuan resmi untuk perpanjangan ini sudah lewat, sehingga pemeriksaan online kami tidak bisa memprosesnya — jalur reguler kami akan tetap membahas opsi yang ada bersama Anda.",
         "EXTENSION_ALREADY_USED": "VOA ini sudah pernah diperpanjang sekali — jalur reguler kami menangani perpanjangan lebih lanjut dengan waktu singkat.",
         "ARRIVAL_TOO_SOON": "Tanggal kedatangan Anda sudah melewati batas waktu pengajuan online kami — jalur reguler kami menangani kasus seperti milik Anda dengan waktu singkat.",
         "ARRIVAL_DATE_UNCONFIRMED": "Kami belum bisa menghitung tanggal batas pengajuan untuk rentang waktu sejauh ini — tim kami akan memastikannya langsung dengan Anda.",

--- a/apps/mouth/src/i18n/locales/it.json
+++ b/apps/mouth/src/i18n/locales/it.json
@@ -532,7 +532,7 @@
         "PRIOR_ISSUE": "Il tuo caso richiede un approfondimento da parte del nostro team — il nostro canale ordinario gestisce questi casi con tempi brevi.",
         "FASTLANE_REQUEST": "Le richieste di corsia rapida in aeroporto passano dal nostro canale ordinario, che le gestisce con tempi brevi.",
         "EXPIRY_UNKNOWN": "Ci serve la tua data di scadenza esatta per confermarlo — il nostro canale ordinario può occuparsene con tempi brevi.",
-        "EXPIRES_TOO_SOON": "I tuoi tempi sono stretti per questa verifica rapida — il nostro canale ordinario gestisce casi come il tuo con tempi brevi.",
+        "EXPIRES_TOO_SOON": "La scadenza ufficiale di presentazione per questa proroga è già passata, quindi la nostra verifica online non può gestirla — il nostro canale ordinario esaminerà comunque le opzioni con te.",
         "EXTENSION_ALREADY_USED": "Questo VOA è già stato esteso una volta — il nostro canale ordinario gestisce ulteriori estensioni con tempi brevi.",
         "ARRIVAL_TOO_SOON": "La tua data di arrivo ha superato la nostra finestra di presentazione online — il nostro canale ordinario gestisce casi come il tuo con tempi brevi.",
         "ARRIVAL_DATE_UNCONFIRMED": "Non possiamo ancora calcolare una data limite di presentazione con così tanto anticipo — il nostro team te la confermerà direttamente.",


### PR DESCRIPTION
## Why

The owner challenged the old behaviour with the right question. At **8 days** to expiry an
extension is **still legally filable** — the published Ngurah Rai deadline is *"paling lambat
7 hari sebelum masa izin tinggal berakhir"* — yet our own D-10 conservatism declined it. We were
turning away work we can do, and calling it caution.

His ruling: accept whenever the case can still be filed under the **published** deadline. Our
threshold and the office's become the same line, with no added margin of our own, so there are
never two truths about when it is too late.

## What changed

- **`eligibility.py`** — the runway gate reads `PUBLISHED_FILING_DEADLINE_DAYS`. A case with
  exactly that many days left is **ACCEPTED** (the deadline day is still filable); one day tighter
  declines. There is no literal `7` or `10` in the gate, pinned by a test that source-inspects the
  comparison — changing the constant changes the rule in exactly one place.
- **`PILOT_INTAKE_THRESHOLD_DAYS` (D-10) is retired as an intake gate** and survives only as the
  internal SOP §6 staff-escalation checkpoint, `client_facing=False` as before. Its docstring and
  every stale *"our own D-10 runway gate"* comment are corrected so nobody reads it as an admission
  rule again.
- **`EXPIRES_TOO_SOON` keeps its name but changes meaning** — no longer *"our pilot is
  conservative"* but *"the published deadline has passed"*. Rewritten in en/id/it: no day count, no
  internal checkpoint, never a bare no, never blame, and deliberately **no timeline promise**
  (unlike every sibling decline code), because a past-deadline case may genuinely need longer.
- **Tests** — the D-10 boundary class is deleted, because a test pinning the old threshold now pins
  a bug. Replaced by the published-deadline boundary, including the owner's own example: 8 days out
  on a 30-day case, which used to decline and now accepts.
  `test_garuda_voa_no_internal_leak.py` fixtures were pinned to the old boundary and would have gone
  quietly **vacuous** under the new gate; the not-vacuous proof moved onto a still-reachable branch.

**Issuance is untouched** — it stays governed by the last-open-day-before-arrival cutoff (weekends
plus Indonesian public holidays), which is a separate ruling.

## Verification

Graded by an **independent lane on fresh context** that re-derived the rule from the owner's words
and never saw the implementer's report (generator≠grader). Five boundary cases computed by hand all
match the code; the issuance path was proven unaffected by constructing a case the old extension
rule would have judged; the DECLINE response was serialized and inspected for internal-checkpoint
leakage with **the forbidden tokens built from the constants** rather than typed as literals — the
exact discipline that a plain grep missed on the original `D-10` leak.

```
PYTHONPATH=. pytest backend/tests/services/garuda_flow backend/tests/app/routers -q
  199 passed, 1 skipped        (rc captured without a pipe)
PYTHONPATH=. pytest backend/tests/services/visa_check \
    backend/tests/security/test_mutating_routes_are_gated.py -q
  189 passed                   (rc captured without a pipe)
ruff check backend/services/garuda_flow    -> All checks passed
tsc --noEmit -p apps/mouth/tsconfig.json   -> exit 0
```

Verdict: **SHIPPABLE**, no blocking findings.

## Notes

No migration, no schema change, no new endpoint — behaviour and copy only. Pushed from Mini: the M5
pre-push run was starved past 65 minutes by twelve concurrent sibling suites, so the same gate ran
on an idle machine in a dedicated worktree holding this exact commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)