### PR TITLE
fix(tests): widen fixed wall-clock deadlines in 5 more load-sensitive tests (#58)

### DIFF
--- a/apps/backend-rag/backend/tests/services/intake/test_intake_worker.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_worker.py
@@ -131,20 +131,45 @@ async def _statuses(pool: asyncpg.Pool, qids: list[int]) -> dict[str, int]:
     return {r["status"]: r["c"] for r in rows}
 
 
-async def _drive_to_done(workers, qids, pool, timeout=60.0):
-    """Run workers cooperatively until all qids are 'done'/'dead' or timeout."""
+async def _drive_to_done(workers, qids, pool, timeout=60.0, stall_timeout=20.0):
+    """Run workers cooperatively until all qids are 'done'/'dead'.
+
+    W58 (2026-07-27): a fixed wall-clock `timeout` for a fixed amount of work
+    is an assertion about the scheduler, not about the code under test — it
+    rejects genuinely correct, still-converging work under CPU contention
+    that has nothing to do with the diff being pushed (measured live: this
+    exact test failed once at "89 done, 9 pending, 2 extracted" under a busy
+    box, then passed in full on retry under *heavier* contention — the
+    relation is probabilistic, not a threshold). Fix: extend the deadline as
+    long as forward progress (more jobs reaching a terminal state) keeps
+    happening, so a slow-but-correct run gets the time it needs. Only a real
+    STALL — `stall_timeout` seconds with zero new terminal jobs — is treated
+    as a failure, which still catches a genuine hang/deadlock/lost-job bug
+    (the thing this test exists to guard). `timeout` remains a hard outer
+    ceiling against a truly wedged run.
+    """
     loop = asyncio.get_event_loop()
-    deadline = loop.time() + timeout
+    hard_deadline = loop.time() + timeout
+    last_terminal = -1
+    last_progress_at = loop.time()
 
     # Each worker keeps calling run_once until no work, then we re-check.
     async def drain(w):
-        while loop.time() < deadline:
+        nonlocal last_terminal, last_progress_at
+        while loop.time() < hard_deadline:
             did = await w.run_once()
             if not did:
                 # check if everything terminal
                 st = await _statuses(pool, qids)
-                if (st.get("done", 0) + st.get("dead", 0)) == len(qids):
+                terminal = st.get("done", 0) + st.get("dead", 0)
+                if terminal == len(qids):
                     return
+                now = loop.time()
+                if terminal != last_terminal:
+                    last_terminal = terminal
+                    last_progress_at = now
+                elif now - last_progress_at > stall_timeout:
+                    return  # genuine stall, not scheduling noise — let the caller's assert fail loud
                 await asyncio.sleep(0.05)
 
     await asyncio.gather(*(drain(w) for w in workers))
@@ -169,7 +194,7 @@ async def test_exactly_once_two_workers_100_jobs(pool, tmp_path):
         )
         w1 = IntakeWorker(pool, config=cfg, worker_id="w1")
         w2 = IntakeWorker(pool, config=cfg, worker_id="w2")
-        await _drive_to_done([w1, w2], qids, pool, timeout=90.0)
+        await _drive_to_done([w1, w2], qids, pool, timeout=180.0)  # W58: generous outer ceiling; stall_timeout does the real discriminating
 
         st = await _statuses(pool, qids)
         assert st.get("done", 0) == n, f"not all done: {st}"
@@ -245,7 +270,7 @@ async def test_kill9_reclaim_no_job_lost(pool, tmp_path):
 
         # Wait out the lease, then the live worker reclaims + completes.
         await asyncio.sleep(lease_ttl + 0.5)
-        await _drive_to_done([live], qids, pool, timeout=30.0)
+        await _drive_to_done([live], qids, pool, timeout=60.0)  # W58: generous outer ceiling; stall_timeout does the real discriminating
 
         st = await _statuses(pool, qids)
         assert st.get("done", 0) == 1, f"job lost / not reclaimed: {st}"

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_worker_scheduler.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_worker_scheduler.py
@@ -48,10 +48,15 @@ async def test_fast_lane_reclaims_before_slowest_sibling_finishes(
     monkeypatch.setattr(worker, "run_once", run_once)
     runner = asyncio.create_task(worker.run_forever())
     try:
-        await asyncio.wait_for(fast_lane_reclaimed.wait(), timeout=0.5)
+        # W58 (2026-07-27): pure in-process Event coordination (no real I/O,
+        # run_once is mocked, poll_interval=1ms) — a genuine scheduling
+        # regression means fast_lane_reclaimed never fires, not that it fires
+        # late; a generous bound loses no discriminating power and removes
+        # dependence on the box getting CPU time for this task within 0.5s.
+        await asyncio.wait_for(fast_lane_reclaimed.wait(), timeout=5.0)
         assert not slow_lane_release.is_set()
         assert call_count >= 3
     finally:
         slow_lane_release.set()
         worker.stop()
-        await asyncio.wait_for(runner, timeout=1.0)
+        await asyncio.wait_for(runner, timeout=5.0)

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_memory_handler.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_memory_handler.py
@@ -291,7 +291,12 @@ async def test_save_concurrent_different_sessions_not_serialized(
             # Second entrant flips the barrier so both can complete.
             both_entered.set()
         try:
-            await asyncio.wait_for(both_entered.wait(), timeout=1.0)
+            # W58 (2026-07-27): a genuine serialization regression means
+            # both_entered NEVER fires (only one branch ever enters), not that
+            # it fires late — a generous bound preserves full discriminating
+            # power while removing dependence on both coroutines getting CPU
+            # time within 1s under contention.
+            await asyncio.wait_for(both_entered.wait(), timeout=5.0)
         except asyncio.TimeoutError as exc:
             raise AssertionError(
                 "Session-scoped saves were serialized unexpectedly; "

--- a/apps/backend-rag/backend/tests/unit/agents/test_confirmation_service.py
+++ b/apps/backend-rag/backend/tests/unit/agents/test_confirmation_service.py
@@ -274,13 +274,22 @@ class TestRedisPersistence:
             )
 
         task = asyncio.create_task(check_redis_then_resolve())
+        # W58 (2026-07-27): `timeout` here bounds asyncio.wait_for(future, ...) in
+        # request_and_wait — the background task only needs ~0.05s plus an
+        # in-process fakeredis round-trip (no real network I/O), but under CPU
+        # contention the event loop itself can go unscheduled for seconds, which
+        # is scheduler noise, not test signal. Unlike a "buggy code does 2x the
+        # work" case, a genuine wiring bug here means the future is NEVER
+        # resolved — any finite timeout still catches that identically, so a
+        # generous value loses no discriminating power (measured: this test hit
+        # ConfirmationTimeout on a busy box with a 5.0s bound).
         await service.request_and_wait(
             tool_name="image_generation",
             args={"prompt": "test"},
             user_email="damar@balizero.com",
             preview="test preview",
             emitter=emitter,
-            timeout=5.0,
+            timeout=30.0,
         )
         await task
 

--- a/apps/backend-rag/backend/tests/unit/services/common/test_background.py
+++ b/apps/backend-rag/backend/tests/unit/services/common/test_background.py
@@ -27,7 +27,10 @@ async def test_spawn_returns_task_and_executes_coroutine():
 
     task = background.spawn(work())
     assert isinstance(task, asyncio.Task)
-    await asyncio.wait_for(executed.wait(), timeout=1.0)
+    # W58 (2026-07-27): work() is a trivial no-I/O coroutine — a real spawn()
+    # regression means the task never gets scheduled at all, not that it runs
+    # late, so a generous bound preserves full discriminating power.
+    await asyncio.wait_for(executed.wait(), timeout=5.0)
     await task  # ensure done
 
 

--- a/apps/backend-rag/backend/tests/unit/services/test_event_bus.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_event_bus.py
@@ -289,7 +289,12 @@ class TestRealPGNotificationRouting:
         notify_conn = None
         try:
             await bus.start()
-            for _ in range(30):
+            # W58 (2026-07-27): a real "listener never opens" regression means
+            # bus._conn stays None forever, not that it opens late — a generous
+            # ceiling (10s @ 0.1s poll) preserves full discriminating power
+            # while removing dependence on the connection getting scheduled
+            # within the old 3.0s ceiling under DB-pool contention.
+            for _ in range(100):
                 if bus._conn is not None:
                     break
                 await asyncio.sleep(0.1)
@@ -310,7 +315,9 @@ class TestRealPGNotificationRouting:
                 ),
             )
 
-            await asyncio.wait_for(done.wait(), timeout=3.0)
+            # Same reasoning: a broken NOTIFY/LISTEN wiring never delivers, it
+            # doesn't deliver late — generous bound, no lost discrimination.
+            await asyncio.wait_for(done.wait(), timeout=15.0)
         finally:
             if notify_conn is not None:
                 await notify_conn.close()


### PR DESCRIPTION
Same family as the already-known 3 instances: an assertion that a fixed
amount of work completes inside a fixed wall-clock deadline is a claim about
the scheduler, not about the code under test, and trips under CPU contention
unrelated to the diff being pushed.

Fixed:
- test_intake_worker.py::_drive_to_done — replaced the fixed absolute
  deadline with a stall-based one: extend as long as forward progress (more
  jobs reaching a terminal state) is observed, only fail after
  stall_timeout (20s) with ZERO new terminal jobs. Preserves full
  discriminating power against a genuine hang/deadlock/lost-job bug while
  no longer penalizing a slow-but-correct convergence under contention.
  Outer ceilings also raised (90s->180s, 30s->60s) as a generous backstop.
- test_confirmation_service.py, test_intake_worker_scheduler.py (x2),
  test_background.py, test_memory_handler.py, test_event_bus.py (x2) —
  widened literal timeouts. Each was audited for whether a REAL regression
  in the code under test manifests as "resolves late" (margin-erosion risk,
  must NOT blindly widen) vs "never resolves" (any finite generous timeout
  preserves full power) — all 7 are the latter: broken lock/event/notify
  wiring hangs forever, it does not resolve 2x slower. Confirmed via the

---
Ferried to origin from an idle fleet node (M5 was at load 55 with 10 concurrent pre-push suites; this branch had committed work that was never pushed and never became a PR).

**The local pre-push suite did NOT actually run for this branch** — Mini decides `running FULL suite` and then skips every Python test because `nuzantara_test` was unprovisioned there, printing `All pre-push checks passed`. Being provisioned now. Verification for this diff is therefore the merge queue, which re-tests every entry against main across all 25 required contexts.

Not armed for auto-merge: authored by another session, so it wants a read before arming (generator != grader).