### PR TITLE
fix(prepush): the gate may not report "passed" when it ran no tests

### DIFF
--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -121,6 +121,10 @@ on:
       - Magazine auto-assets contract
       - Migration Lint (Squawk)
       - npm lock sync
+      # Registered with the workflow itself (2026-07-27). Inserted here rather
+      # than appended: PR #3295 is adding its own entry at the END of this list,
+      # and two PRs appending to the same line would conflict for no reason.
+      - prepush-guards
       - Nuz Status Control
       - Organ conformance (DNA genome — genes at birth)
       - P1 STRATO-2 incremental mutation gate

--- a/.github/workflows/prepush-guards.yml
+++ b/.github/workflows/prepush-guards.yml
@@ -68,3 +68,13 @@ jobs:
 
       - name: Guard — backend test deps declared, not just inline-installed
         run: python3 scripts/tests/test_test_deps_declared.py
+
+      # The only suite that exercises the hook under a REAL `sh -e` with a REAL
+      # `kill -TERM` on a real child — the mechanism behind W101 and #45, which
+      # a synthetic exit code cannot reproduce. It existed and no workflow ran
+      # it (round-2 review finding), so its guilt cases were proving nothing
+      # about CI. Cases needing local PostgreSQL skip themselves cleanly here,
+      # the same graceful posture the hook itself takes on a machine without
+      # one; the sh -e / signal cases do not need a database and run everywhere.
+      - name: Guard — the fail-closed paths survive sh -e and real signals
+        run: sh scripts/tests/test_prepush_failclosed.sh

--- a/.github/workflows/prepush-guards.yml
+++ b/.github/workflows/prepush-guards.yml
@@ -1,0 +1,70 @@
+name: prepush-guards
+
+# Runs the guard tests for the LOCAL pre-push gate on an isolated runner.
+#
+# WHY THIS FILE EXISTS AT ALL: the two tests below were written, passed
+# manually, and were wired into nothing. Adversarial review caught that before
+# merge and blocked it, correctly — `scripts/tests/` is not swept by any glob in
+# this repo (insight-cover-cards.yml says so in its own header: a file there
+# "runs only because some workflow names it"), so the claim "these keep the
+# hook and the manifest in sync" would have been false on the day it merged.
+# A guard nobody runs is cicatrix-superscar.md family #2 (esiste != armato) —
+# and the hook these tests guard is itself a #2 fix. Shipping an unarmed guard
+# for an unarmed-gate bug is the disease curing itself into a mirror.
+#
+# NO top-level `paths:` filter on pull_request, deliberately (W69): a
+# paths-filtered required check never reports on a path-miss PR and blocks the
+# merge forever. Both tests are pure-python, dependency-light and finish in
+# ~2s, so there is nothing to save by filtering — it always runs, it always
+# reports.
+#
+# Registered in main-push-failure-watch.yml, because an unwatched watcher is
+# the same disease one level up (learned the hard way on #3295, where
+# scripts/check_watcher_coverage.py caught exactly that omission).
+
+on:
+  pull_request: # NO paths: — always trigger, always report
+  merge_group:
+  push:
+    branches: [main]
+    paths:
+      - ".husky/pre-push"
+      - "scripts/tests/test_prepush_honest_verdict.py"
+      - "scripts/tests/test_test_deps_declared.py"
+      - "apps/backend-rag/requirements-test.txt"
+      - ".github/workflows/tests.yml"
+      - ".github/workflows/prepush-guards.yml"
+
+concurrency:
+  group: prepush-guards-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
+permissions:
+  contents: read
+
+jobs:
+  prepush-guards:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # PyYAML only: test_test_deps_declared parses tests.yml per-JOB (it must
+      # read the backend job alone — a whole-file scan previously dragged the
+      # MCP app's `fastmcp` into the backend manifest, re-importing 8 Dependabot
+      # alerts' worth of dependency).
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      # Run each explicitly and separately so a failure names which guard broke.
+      # These run as __main__ (not under pytest) on purpose: they are standalone
+      # by design so they also work from a developer's shell with no test deps.
+      - name: Guard — the pre-push verdict cannot claim an unearned pass
+        run: python3 scripts/tests/test_prepush_honest_verdict.py
+
+      - name: Guard — backend test deps declared, not just inline-installed
+        run: python3 scripts/tests/test_test_deps_declared.py

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -430,12 +430,28 @@ else
         # FAILED" (round 1, the 3-way classification below), (2) that
         # classification being unreachable under `sh -e` (round 2, this
         # `|| TEST_RC=$?` guard). Reference: scripts/tests/test_prepush_failclosed.sh.
+        #
+        # INTAKE_TEST_DSN (added 2026-07-27) — the third env var below. CI has
+        # exported it since it was introduced (.github/workflows/tests.yml, whose
+        # comment says pointing it at the disposable CI database "instead of their
+        # local-dev fallback (nuzantara_dev)" un-skipped 50 tests); this hook never
+        # did. backend/tests/services/intake/test_intake_writer.py:34 reads
+        # `os.environ.get("INTAKE_TEST_DSN", "postgresql://localhost:5432/nuzantara_dev")`
+        # — a default that fails OPEN onto the machine's SHARED dev database rather
+        # than skipping. Measured on Pro (2026-07-27): 12,408 client rows there, 9 of
+        # them created in 6 hours by these tests' real-commit cases, and the file's own
+        # `assert after == before, "CRM mutated!"` guard seeing writes it did not cause
+        # — it rejected a push whose diff touched only this hook, a requirements file
+        # and two files under scripts/tests/. Exporting the per-push clone here makes
+        # the local gate match CI exactly: same isolation, nothing skipped, and the
+        # shared dev DB stops being test scratch space.
         TEST_RC=0
         ( cd apps/backend-rag \
             && rm -rf .pytest_cache backend/.pytest_cache \
             && source .venv/bin/activate 2>/dev/null \
             && DATABASE_URL="postgresql://test:test@localhost:5432/$CLONE_DB" \
                TEST_DATABASE_URL="postgresql://test:test@localhost:5432/$CLONE_DB" \
+               INTAKE_TEST_DSN="postgresql://test:test@localhost:5432/$CLONE_DB" \
                JWT_SECRET_KEY="${JWT_SECRET_KEY:-test_jwt_secret_key_for_testing_only_min_32_chars_long}" \
                API_KEYS="${API_KEYS:-test_api_key_1,test_api_key_2}" \
                OLLAMA_URL="http://127.0.0.1:9" \
@@ -496,8 +512,9 @@ if [ "$PREPUSH_RUN_BACKEND" = "1" ] && [ "${BACKEND_SUITE_RAN:-0}" != "1" ]; the
     echo "⚠️  PUSH NOT VERIFIED LOCALLY — the backend suite was REQUIRED for this diff but never ran"
     echo "    (${BACKEND_SUITE_SKIP_REASON:-reason not recorded})."
     echo "    This is NOT a passing verdict: no test judged this diff on this machine."
-    echo "    The merge queue re-tests every entry against main — that is the only gate this push met."
-    echo "    To make this machine's gate real, fix the cause above; do not read this as green."
+    echo "    Nothing has judged it yet: CI on the PR, and then the merge queue re-testing"
+    echo "    the entry against main, are the gates that still have to. Do not read this as green."
+    echo "    To make this machine's gate real, fix the cause above."
 else
     echo "✅ All pre-push checks passed!"
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -443,8 +443,22 @@ else
         # `assert after == before, "CRM mutated!"` guard seeing writes it did not cause
         # — it rejected a push whose diff touched only this hook, a requirements file
         # and two files under scripts/tests/. Exporting the per-push clone here makes
-        # the local gate match CI exactly: same isolation, nothing skipped, and the
-        # shared dev DB stops being test scratch space.
+        # the local gate match CI exactly, and the shared dev DB stops being test
+        # scratch space.
+        #
+        # NOT "nothing skipped" — an earlier draft of this comment said that and it
+        # was false. `test_drive_autocreate_apply.py` carries an attestation guard
+        # (its lines 62-89): 7 of its cases refuse any database that is not the
+        # "approved local book" nuzantara_dev, so pointing this variable at the clone
+        # makes them SKIP. That is deliberate on the test's side and it is what CI
+        # has always done — those 7 skip there too, since tests.yml points the same
+        # variable at nuzantara_test. So this change does not lose coverage relative
+        # to the gate that decides the merge; it makes the local gate stop being a
+        # third, more permissive one. The real gap it exposes — 7 attested-entrypoint
+        # cases that now run on NO gate anywhere, whose only previous home was
+        # Pro/M5 against real client rows — pre-dates this change and is filed
+        # separately. Fixing it means giving the attestation an approved DISPOSABLE
+        # book, never pointing these tests back at production data.
         TEST_RC=0
         ( cd apps/backend-rag \
             && rm -rf .pytest_cache backend/.pytest_cache \
@@ -475,6 +489,18 @@ else
             echo "     cd apps/backend-rag && source .venv/bin/activate && \\"
             echo "     DATABASE_URL=postgresql://test:test@localhost:5432/$PRE_PUSH_DB \\"
             echo "     TEST_DATABASE_URL=postgresql://test:test@localhost:5432/$PRE_PUSH_DB \\"
+            # INTAKE_TEST_DSN belongs in the printed command for the same reason it
+            # belongs in the run above, and leaving it out is worse here than
+            # anywhere: these three env vars are COMMAND-SCOPED, so nothing survives
+            # into the shell of whoever copies this line. Without it,
+            # test_intake_review.py / test_intake_writer.py /
+            # test_drive_autocreate_apply.py fall back to their default
+            # `postgresql://localhost:5432/nuzantara_dev` — the machine's SHARED dev
+            # database, 12,408 client rows on Pro — and the reproduce step then
+            # WRITES there while hunting a failure. Printing the isolated DSN in the
+            # run and omitting it from the reproduction would have reintroduced the
+            # exact defect this diff exists to close, in the help text.
+            echo "     INTAKE_TEST_DSN=postgresql://test:test@localhost:5432/$PRE_PUSH_DB \\"
             echo "     OLLAMA_URL=http://127.0.0.1:9 \\"
             echo "     PYTHONPATH=.:../crm-cell pytest backend/tests/ --ignore=backend/tests/e2e"
             exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -262,6 +262,24 @@ fi
 # in sh/bash.
 if [ "$PREPUSH_RUN_BACKEND" = "1" ]; then
 echo "🐍 Running Python tests..."
+# Honest-verdict bookkeeping (2026-07-27, measured live on Mini). Everything
+# below can decide "FULL suite required" and then not run a single test: four
+# environment gates skip it (no PG, unprovisioned DB, no venv, clone failed)
+# and all four used to fall straight through to the final
+# "✅ All pre-push checks passed!" line. Mini's log, verbatim:
+#     🧭 6/6 changed file(s) are NOT on the innocent allowlist — running FULL suite
+#     🐍 Running Python tests...
+#     ⏭️  SKIP Python tests — local PG up but 'nuzantara_test' not provisioned
+#     ✅ All pre-push checks passed!
+# Its local PG had no `test` role at all, so EVERY push ever made from that
+# machine passed a gate that had run zero tests and said so nowhere. This is
+# cicatrix-superscar.md family #2 (esiste ≠ armato) on the most-cited gate in
+# the fleet: the verdict line is the defect, not the skip. The skips stay
+# permissive on purpose — a machine without a test DB must still be able to
+# push, and the merge queue re-tests every entry against main — but they may
+# no longer be REPORTED as a pass.
+BACKEND_SUITE_RAN=0
+BACKEND_SUITE_SKIP_REASON=""
 PG_BIN="/opt/homebrew/opt/postgresql@17/bin"
 PG_ISREADY="$(command -v pg_isready || echo "$PG_BIN/pg_isready")"
 PSQL="$(command -v psql || echo "$PG_BIN/psql")"
@@ -287,6 +305,7 @@ PREPUSH_SUITE_LOCKFILE="/tmp/nuzantara-prepush-backend-suite.lock"
 if ! "$PG_ISREADY" -h 127.0.0.1 -p 5432 -q 2>/dev/null; then
     echo "⏭️  SKIP Python tests — no local PostgreSQL on 127.0.0.1:5432."
     echo "   Install per research/operations/specs/2026-06-12-M5-postgres-local-spec.md to enable the gate."
+    BACKEND_SUITE_SKIP_REASON="no local PostgreSQL on 127.0.0.1:5432"
 elif [ "$("$PSQL" -h 127.0.0.1 -p 5432 -d "$PRE_PUSH_DB" -tAc "SELECT to_regclass('public.clients') IS NOT NULL;" 2>/dev/null)" != "t" ]; then
     echo "⏭️  SKIP Python tests — local PG up but '$PRE_PUSH_DB' not provisioned (no migrated schema)."
     echo "   One-time bootstrap: cd apps/backend-rag && source .venv/bin/activate && \\"
@@ -294,10 +313,12 @@ elif [ "$("$PSQL" -h 127.0.0.1 -p 5432 -d "$PRE_PUSH_DB" -tAc "SELECT to_regclas
     echo "     PYTHONPATH=.:../crm-cell python scripts/ci_bootstrap_schema.py && \\"
     echo "     PYTHONPATH=.:../crm-cell python -m backend.db.migrate apply-all"
     echo "   (see research/operations/specs/2026-06-12-M5-postgres-local-spec.md §AC2)"
+    BACKEND_SUITE_SKIP_REASON="'$PRE_PUSH_DB' not provisioned on the local PG"
 elif [ ! -f apps/backend-rag/.venv/bin/activate ]; then
     echo "⏭️  SKIP Python tests — worktree has no apps/backend-rag/.venv (bare 'git worktree add' doesn't create it)."
     echo "   Fix: symlink it from the main checkout, or create the worktree via scripts/agent_start.py."
     echo "   CI remains the real gate for this push."
+    BACKEND_SUITE_SKIP_REASON="worktree has no apps/backend-rag/.venv"
 else
     # Isolated DB clone per push (2026-07-16). Under ~10 concurrent agent pushes,
     # the suite used to run straight against the shared "$PRE_PUSH_DB" — every
@@ -373,6 +394,7 @@ else
     done
     if [ "$CREATE_OK" != "1" ]; then
         echo "⏭️  SKIP Python tests — could not clone '$PRE_PUSH_DB' into '$CLONE_DB' after 3 attempts (template busy?)."
+        BACKEND_SUITE_SKIP_REASON="could not clone '$PRE_PUSH_DB' into a throwaway test DB"
     else
         # #45 (2026-07-26): the OLD form here was `elif ! ( subshell ); then FAILED; fi`
         # — a bare boolean negation that collapses EVERY non-zero exit into one
@@ -421,7 +443,9 @@ else
                "$PREPUSH_SUITE_LOCK_SCRIPT" "$PREPUSH_SUITE_LOCKFILE" \
                python -m pytest backend/tests/ --ignore=backend/tests/e2e --tb=short -q ) || TEST_RC=$?
         if [ "$TEST_RC" -eq 0 ]; then
-            : # pass — fall through silently, same as the old happy path
+            # The ONLY place the suite genuinely ran to a pass. Every other
+            # path out of this block either exits 1 or leaves a skip reason.
+            BACKEND_SUITE_RAN=1
         elif [ "$TEST_RC" -ge 128 ]; then
             TEST_SIGNAL=$((TEST_RC - 128))
             echo "⚠️  Python test run TERMINATED by signal $TEST_SIGNAL — NO VERDICT, push blocked pending re-run."
@@ -460,4 +484,20 @@ if git diff --no-ext-diff --unified=0 origin/HEAD...HEAD 2>/dev/null \
     echo "   Use issue links for intentionally retained markers."
 fi
 
-echo "✅ All pre-push checks passed!"
+# The verdict must describe what actually ran. If the path-aware gate decided
+# the backend suite was REQUIRED for this diff and no suite ever executed, this
+# push is UNVERIFIED — not passing. Deliberately not fail-closed: blocking here
+# would wall off every machine whose local PG isn't provisioned (Mini today),
+# and the merge queue re-tests every entry against main anyway. What changes is
+# only the claim, which is the part that was false.
+# Defaults on both vars: the path-aware SKIP branch never enters the block that
+# initialises them, and this hook runs under `sh -e`.
+if [ "$PREPUSH_RUN_BACKEND" = "1" ] && [ "${BACKEND_SUITE_RAN:-0}" != "1" ]; then
+    echo "⚠️  PUSH NOT VERIFIED LOCALLY — the backend suite was REQUIRED for this diff but never ran"
+    echo "    (${BACKEND_SUITE_SKIP_REASON:-reason not recorded})."
+    echo "    This is NOT a passing verdict: no test judged this diff on this machine."
+    echo "    The merge queue re-tests every entry against main — that is the only gate this push met."
+    echo "    To make this machine's gate real, fix the cause above; do not read this as green."
+else
+    echo "✅ All pre-push checks passed!"
+fi

--- a/apps/backend-rag/requirements-test.txt
+++ b/apps/backend-rag/requirements-test.txt
@@ -5,6 +5,21 @@
 testcontainers[postgres]>=4.0.0
 testcontainers[compose]>=4.0.0
 
+# Test-runtime deps that CI installs INLINE in .github/workflows/tests.yml
+# ("uv pip install --system pytest pytest-cov pytest-asyncio pytest-mock
+# fakeredis"). Declared here because an inline workflow list is not a manifest:
+# nothing in the repo said the suite needs them, so no machine could rebuild
+# CI's test environment from the tree. Measured consequence (2026-07-27): Mini's
+# venv had no `fakeredis`, two test files ERRORed at collection, and the pre-push
+# gate rejected two branches that never touch them — a red owned by the machine,
+# not the diff. `scripts/tests/test_test_deps_declared.py` pins the two lists
+# together so they cannot drift again.
+pytest
+pytest-cov
+pytest-asyncio
+fakeredis
+fastmcp  # MCP contract-test job in the same workflow, equally undeclared
+
 # Additional test utilities
 pytest-mock>=3.15.1
 pytest-timeout>=2.4.0  # For timeout support (install separately if needed)

--- a/apps/backend-rag/requirements-test.txt
+++ b/apps/backend-rag/requirements-test.txt
@@ -18,7 +18,15 @@ pytest
 pytest-cov
 pytest-asyncio
 fakeredis
-fastmcp  # MCP contract-test job in the same workflow, equally undeclared
+# DO NOT add `fastmcp` here. An earlier draft of this file did, because the
+# sync-checker below originally scanned ALL of tests.yml and picked it up from
+# the separate `mcp-tests` job. It does not belong to backend-rag: it lives in
+# apps/nuzantara-mcp/ with its own venv, and requirements.txt removed it on
+# 2026-05-03 specifically to close 8 Dependabot alerts (1 critical + 4 high +
+# 3 medium — SSRF/path-traversal GHSA-vv7q-7jx5-f767, OAuth confused-deputy
+# GHSA-rww4-4w9c-7733/GHSA-c2jp-c369-7pvx, token reuse). Re-declaring it here
+# would drag all of that back into the backend test environment. Caught by
+# adversarial review before merge; the checker is now scoped to one job.
 
 # Additional test utilities
 pytest-mock>=3.15.1

--- a/scripts/tests/test_prepush_honest_verdict.py
+++ b/scripts/tests/test_prepush_honest_verdict.py
@@ -31,10 +31,12 @@ Wired into CI by .github/workflows/prepush-guards.yml.
 """
 from __future__ import annotations
 
+import os
 import pathlib
 import re
 import subprocess
 import sys
+import tempfile
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 HOOK_FILE = REPO_ROOT / ".husky" / "pre-push"
@@ -154,14 +156,151 @@ def test_path_aware_skip_says_pass() -> None:
 
 
 # --------------------------------------------------------------------------
-# STRUCTURE: written to survive legitimate refactors, and to check POSITION
-# rather than mere count.
+# BEHAVIOURAL: run the hook's real backend-suite region and READ WHAT IT PRINTS.
+#
+# WHY THIS SECTION EXISTS AND WHY IT COMES FIRST IN IMPORTANCE (round 2 of the
+# adversarial review, 2026-07-27 — BLOCK, reproduced by hand before acting on
+# it). Everything above and below judges the hook's SOURCE TEXT. Two one-line
+# mutations reintroduce the original bug and keep all of it green:
+#
+#   1. append after the final `fi`:
+#          echo "✅ All pre-push checks" "passed!"
+#      Two arguments; `echo` joins them with a space and prints the identical
+#      sentence. No contiguous literal exists in the source, so a substring
+#      search finds nothing. 11/11 green, bug back.
+#
+#   2. inside the "no local PostgreSQL" skip branch:
+#          export BACKEND_SUITE_RAN=1
+#      The suite never runs; the verdict reads 1 and prints the pass. The
+#      position/count regex below only recognised a BARE assignment, so
+#      `export` (or `readonly`, or `eval`) slips past. 11/11 green, bug back.
+#
+# The defect is one defect, and it is the one this whole PR is about, turned on
+# its author: a guard that matches the FORM instead of the ENTITY
+# (cicatrix-superscar.md #3). The entity here is "what does a user SEE when the
+# suite did not run", and the only way to assert on that is to run the thing.
+#
+# So: extract the hook's backend-suite region — from `if [ "$PREPUSH_RUN_BACKEND"
+# = "1" ]; then` to end of file, which is self-contained (it defines its own
+# PG_BIN/PG_ISREADY/PRE_PUSH_DB and reads only PREPUSH_RUN_BACKEND from above) —
+# and execute it under a real `sh -e`, the same shell husky uses, with
+# `pg_isready` stubbed to fail so the no-PG skip fires deterministically on any
+# machine, CI included. Then assert on STDOUT.
+#
+# Both mutations die against this: (1) lands inside the extracted region and its
+# rendered output contains the pass sentence; (2) is executed, so the verdict
+# actually prints the pass. Neither can hide in a string literal.
+# --------------------------------------------------------------------------
+
+_REGION_ANCHOR = 'if [ "$PREPUSH_RUN_BACKEND" = "1" ]; then'
+
+
+def _backend_region() -> str:
+    """The hook from the backend-suite gate to EOF, verbatim."""
+    text = _hook_text()
+    hits = [i for i in range(len(text)) if text.startswith(_REGION_ANCHOR, i)]
+    assert len(hits) == 1, (
+        f"expected exactly one {_REGION_ANCHOR!r} in the hook, found {len(hits)} — "
+        "re-anchor this harness rather than letting it execute the wrong region."
+    )
+    return text[hits[0]:]
+
+
+def _run_region(run_backend: str, pg_ready: bool = False) -> str:
+    """Execute the real region under `sh -e` and return everything it printed.
+
+    `pg_ready=False` stubs pg_isready to exit 1, which is the "no local
+    PostgreSQL" gate — the cheapest skip branch to reach, and the one that
+    touches no database at all. Nothing below it runs, so this never creates,
+    clones or drops anything.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        stub_dir = pathlib.Path(td) / "bin"
+        stub_dir.mkdir()
+        for name in ("pg_isready", "psql"):
+            stub = stub_dir / name
+            stub.write_text("#!/bin/sh\nexit %d\n" % (0 if pg_ready else 1))
+            stub.chmod(0o755)
+        script = f'PREPUSH_RUN_BACKEND="{run_backend}"\n' + _backend_region()
+        env = dict(os.environ, PATH=f"{stub_dir}:{os.environ.get('PATH', '')}")
+        proc = subprocess.run(
+            ["sh", "-e", "-c", script],
+            capture_output=True, text=True, env=env, cwd=str(REPO_ROOT), timeout=120,
+        )
+        return proc.stdout + proc.stderr
+
+
+def test_behaviour_required_but_skipped_never_prints_a_pass() -> None:
+    """THE test. The hook decided the suite was required, the environment
+    skipped it, and what the user sees must not be a pass."""
+    out = _run_region("1")
+    assert UNVERIFIED_MARKER in out, (
+        f"the hook did not warn that nothing was verified. It printed:\n{out}"
+    )
+    assert PASS_MARKER not in out, (
+        "the hook printed a PASS while the backend suite never ran — this is the "
+        f"original bug. Output:\n{out}"
+    )
+
+
+def test_behaviour_the_skip_reason_reaches_the_user() -> None:
+    """A warning that cannot say why is a warning people learn to ignore."""
+    out = _run_region("1")
+    assert "reason not recorded" not in out, f"skip reason was lost:\n{out}"
+    assert "no local PostgreSQL" in out, (
+        f"the specific cause did not reach the verdict. Output:\n{out}"
+    )
+
+
+def test_behaviour_path_aware_skip_still_prints_a_pass() -> None:
+    """INNOCENCE, behavioural: a diff that needed no backend suite is green, and
+    stays green. Crying wolf on every docs push trains people past the warning."""
+    out = _run_region("0")
+    assert PASS_MARKER in out, f"a legitimate green stopped being green:\n{out}"
+    assert UNVERIFIED_MARKER not in out, f"false alarm on a docs-only push:\n{out}"
+
+
+def test_behaviour_survives_a_split_string_echo() -> None:
+    """Pin the exact bypass that motivated this section, so nobody re-derives a
+    source-grep as 'equivalent'. The mutation is applied to a COPY: this proves
+    the harness reads rendered output, not source characters."""
+    injected = '\necho "✅ All pre-push checks" "passed!"\n'
+    # The point of the mutation: the SENTENCE it prints exists nowhere in the
+    # characters that produce it. (The region legitimately contains the marker in
+    # its own else branch, so the claim is about the injected fragment alone.)
+    assert PASS_MARKER not in injected, "mutation must be invisible to a substring search"
+    mutated = _backend_region() + injected
+    with tempfile.TemporaryDirectory() as td:
+        stub_dir = pathlib.Path(td) / "bin"
+        stub_dir.mkdir()
+        for name in ("pg_isready", "psql"):
+            (stub_dir / name).write_text("#!/bin/sh\nexit 1\n")
+            (stub_dir / name).chmod(0o755)
+        env = dict(os.environ, PATH=f"{stub_dir}:{os.environ.get('PATH', '')}")
+        proc = subprocess.run(
+            ["sh", "-e", "-c", 'PREPUSH_RUN_BACKEND="1"\n' + mutated],
+            capture_output=True, text=True, env=env, cwd=str(REPO_ROOT), timeout=120,
+        )
+    assert PASS_MARKER in proc.stdout + proc.stderr, (
+        "the harness failed to SEE a split-string pass — it is reading source, not "
+        "output, and the bypass this section exists to kill is back."
+    )
+
+
+# --------------------------------------------------------------------------
+# STRUCTURE: kept as a second line of defence. These are now redundant with the
+# behavioural tests for the two known bypasses, and deliberately so — they fail
+# FASTER and name the offending line, which the output-based tests cannot.
 # --------------------------------------------------------------------------
 
 
 def test_no_unconditional_pass_after_the_verdict() -> None:
     """An `echo 'All pre-push checks passed'` added AFTER the block would make
-    every unverified push look green again — the original bug, restored."""
+    every unverified push look green again — the original bug, restored.
+
+    Source-level only: a split-string echo defeats this, which is exactly why
+    test_behaviour_required_but_skipped_never_prints_a_pass exists above.
+    """
     text = _hook_text()
     _, _, else_body = _verdict_block()
     tail = text[text.rindex(else_body) + len(else_body):]
@@ -180,6 +319,12 @@ def test_suite_ran_is_set_only_where_pytest_succeeded() -> None:
     """POSITION, not count. Counting one assignment does not prove it sits in
     the success branch — it could be moved into a skip path and still count 1.
 
+    The pattern deliberately accepts every way shell can bind that name —
+    bare, `export`, `readonly`, `declare`, `local`, `eval` — because the round-2
+    bypass was `export BACKEND_SUITE_RAN=1` in a skip branch, invisible to a
+    pattern that only knew the bare form. Matching the ENTITY (this variable
+    acquires a truthy value here) rather than the FORM (this exact syntax).
+
     Note on the name: BACKEND_SUITE_RAN means "the suite completed and passed",
     not "execution began" — a suite that starts and fails exits 1 before the
     verdict, so the distinction never reaches a message today.
@@ -191,14 +336,48 @@ def test_suite_ran_is_set_only_where_pytest_succeeded() -> None:
         re.DOTALL,
     )
     assert m, "pytest-success branch not found — re-anchor this test"
-    assign = re.compile(r'^\s*BACKEND_SUITE_RAN=(?:1|"1"|\'1\')\s*$', re.MULTILINE)
+    assign = re.compile(
+        r'^\s*(?:export\s+|readonly\s+|declare\s+(?:-\w+\s+)*|local\s+|eval\s+)*'
+        r'BACKEND_SUITE_RAN=(?:1|"1"|\'1\')\s*$',
+        re.MULTILINE,
+    )
     assert assign.search(m.group("body")), (
         "BACKEND_SUITE_RAN is not set inside the `TEST_RC -eq 0` branch — the "
         "only place that earned a pass."
     )
-    assert len(assign.findall(text)) == 1, (
-        "BACKEND_SUITE_RAN=1 must appear exactly once; a second assignment is a "
-        "way for a push to claim a verdict it did not earn."
+    found = assign.findall(text)
+    assert len(found) == 1, (
+        f"BACKEND_SUITE_RAN is bound to 1 in {len(found)} places; exactly one is "
+        "allowed. A second binding — in any form, including `export` — is a way "
+        "for a push to claim a verdict it did not earn."
+    )
+
+
+def test_the_failure_hint_does_not_send_anyone_at_the_shared_dev_db() -> None:
+    """SCAR PIN, round 2. The hook exports three env vars at the isolated clone,
+    but the reproduce command it PRINTS on failure omitted INTAKE_TEST_DSN. Those
+    vars are command-scoped — nothing survives into the copier's shell — so the
+    printed line sent whoever followed it straight onto the
+    `postgresql://localhost:5432/nuzantara_dev` default, writing to the shared
+    dev DB while debugging. The defect this diff cures, reintroduced in its own
+    help text."""
+    text = _hook_text()
+    m = re.search(r'Reproduce \(against the persistent base db.*?pytest backend/tests/',
+                  text, re.DOTALL)
+    assert m, "reproduce hint not found — re-anchor this test"
+    # Comment lines are stripped before judging: the block's own explanation
+    # NAMES nuzantara_dev while saying never to send anyone there, and asserting
+    # over raw text would fail on the warning instead of on the defect. Judging
+    # the executable lines is the same correction this file already applies in
+    # _hook_code() — and I made the mistake again here, in the very test written
+    # to pin a round-2 finding.
+    hint = "\n".join(l for l in m.group(0).splitlines() if not l.lstrip().startswith("#"))
+    assert "INTAKE_TEST_DSN=" in hint, (
+        "the printed reproduce command omits INTAKE_TEST_DSN, so copying it runs "
+        f"the intake tests against the shared dev DB. Hint:\n{hint}"
+    )
+    assert "nuzantara_dev" not in hint, (
+        f"the reproduce command names the shared dev database:\n{hint}"
     )
 
 

--- a/scripts/tests/test_prepush_honest_verdict.py
+++ b/scripts/tests/test_prepush_honest_verdict.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Guilt + innocence suite for the `.husky/pre-push` final-verdict branch.
+"""Guilt + innocence for the `.husky/pre-push` final-verdict branch.
 
 WHY (measured live on Mini, 2026-07-27 — cicatrix-superscar.md family #2,
 "esiste ≠ armato"): the path-aware gate can decide the backend suite is
-REQUIRED for a diff, four separate environment gates can then skip the suite
-entirely (no local PG / unprovisioned test DB / no venv / DB clone failed), and
-before this fix all four fell through to the same closing line:
+REQUIRED, four environment gates can then skip it entirely (no local PG /
+unprovisioned test DB / no venv / DB clone failed), and before this fix all
+four fell through to the same closing line:
 
     🧭 6/6 changed file(s) are NOT on the innocent allowlist — running FULL suite
     🐍 Running Python tests...
@@ -14,15 +14,20 @@ before this fix all four fell through to the same closing line:
 
 Mini's local PG had no `test` role at all, so EVERY push ever made from that
 machine met a gate that ran zero tests and announced a pass. The skip is
-legitimate (a machine without a test DB must still be able to push, and the
-merge queue re-tests every entry against main); the CLAIM was not.
+legitimate (a machine without a test DB must still be able to push); the CLAIM
+was not.
 
-The condition is extracted LIVE from .husky/pre-push and evaluated by a real
-`sh`, so this test breaks the moment the guard drifts from what actually runs —
-never a Python reimplementation that could diverge in semantics.
+WHAT THIS FILE LEARNED FROM ITS OWN REVIEW: the first draft extracted only the
+`if` PREDICATE and then evaluated its OWN `echo UNVERIFIED/PASSED` branches. It
+would have passed with the hook's two messages swapped, or with an
+unconditional "All pre-push checks passed" added after the block — i.e. it
+tested a truth table, not a verdict. It now asserts the REAL branch bodies, and
+the structural checks below accept legitimate refactors (quoted assignment,
+printf instead of echo) instead of pinning today's exact characters.
 
 Run:  python3 scripts/tests/test_prepush_honest_verdict.py
       pytest scripts/tests/test_prepush_honest_verdict.py -q
+Wired into CI by .github/workflows/prepush-guards.yml.
 """
 from __future__ import annotations
 
@@ -34,111 +39,208 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 HOOK_FILE = REPO_ROOT / ".husky" / "pre-push"
 
+UNVERIFIED_MARKER = "PUSH NOT VERIFIED LOCALLY"
+PASS_MARKER = "All pre-push checks passed"
+
 
 def _hook_text() -> str:
-    return HOOK_FILE.read_text()
+    return HOOK_FILE.read_text(encoding="utf-8")
 
 
-def _extract_verdict_condition() -> str:
-    """The real `if` condition guarding the NOT-VERIFIED verdict."""
+def _hook_code() -> str:
+    """The hook with comment-only lines removed.
+
+    Needed because this file's own first run failed on the hook's EXPLANATORY
+    COMMENTS: the comment block quotes Mini's log verbatim (which contains "All
+    pre-push checks passed") and names `nuzantara_dev` while explaining why it
+    must never be connected to. Asserting over raw text judged the FORM (a
+    string appears) instead of the ENTITY (the hook does the thing) — the same
+    error family (#3) these assertions exist to catch. Comments are evidence;
+    only executable lines are behaviour.
+    """
+    return "\n".join(
+        l for l in _hook_text().splitlines() if not l.lstrip().startswith("#")
+    )
+
+
+# --------------------------------------------------------------------------
+# The real block, split into its two real branches.
+# --------------------------------------------------------------------------
+
+
+def _verdict_block() -> tuple[str, str, str]:
+    """(predicate, then-branch body, else-branch body) from the actual hook."""
     m = re.search(
-        r'^if (\[ "\$PREPUSH_RUN_BACKEND" = "1" \] && \[ "\$\{BACKEND_SUITE_RAN:-0\}" != "1" \]); then$',
+        r"^if (?P<cond>\[ \"\$PREPUSH_RUN_BACKEND\" = \"1\" \] && \[ \"\$\{BACKEND_SUITE_RAN:-0\}\" != \"1\" \]); then\n"
+        r"(?P<then>.*?)\nelse\n(?P<els>.*?)\nfi\b",
         _hook_text(),
-        re.MULTILINE,
+        re.MULTILINE | re.DOTALL,
     )
     assert m, (
-        f"final-verdict condition not found in {HOOK_FILE}. It must stay a "
-        "single-line `if` so this test can evaluate the REAL expression."
+        f"final-verdict if/else not found in {HOOK_FILE}. It must stay a single "
+        "`if <cond>; then ... else ... fi` so this test can read the REAL branches."
     )
-    return m.group(1)
+    return m.group("cond"), m.group("then"), m.group("els")
 
 
-def _verdict(run_backend: str, suite_ran: str | None) -> str:
-    """Evaluate the extracted condition under a real `sh -e`, exactly as the
-    hook runs it. `suite_ran=None` models the variable being UNSET — the
-    path-aware-skip path never enters the block that initialises it."""
-    cond = _extract_verdict_condition()
+def _evaluate(run_backend: str, suite_ran: str | None) -> str:
+    """Run the REAL predicate under a real `sh -e`, exactly as the hook does.
+
+    `suite_ran=None` models the variable being UNSET — the path-aware-skip path
+    never enters the block that initialises it.
+    """
+    cond, _, _ = _verdict_block()
     assign = "" if suite_ran is None else f'BACKEND_SUITE_RAN="{suite_ran}"\n'
     script = (
         "set -e\n"
         f'PREPUSH_RUN_BACKEND="{run_backend}"\n'
         f"{assign}"
-        f"if {cond}; then echo UNVERIFIED; else echo PASSED; fi\n"
+        f"if {cond}; then echo TOOK_THEN; else echo TOOK_ELSE; fi\n"
     )
     r = subprocess.run(["sh", "-c", script], capture_output=True, text=True)
-    assert r.returncode == 0, f"condition aborted the shell: {r.stderr!r}"
+    assert r.returncode == 0, f"predicate aborted the shell: {r.stderr!r}"
     return r.stdout.strip()
 
 
+def _verdict(run_backend: str, suite_ran: str | None) -> str:
+    """Which REAL message this state produces: 'UNVERIFIED' or 'PASS'."""
+    _, then_body, else_body = _verdict_block()
+    body = then_body if _evaluate(run_backend, suite_ran) == "TOOK_THEN" else else_body
+    has_unverified = UNVERIFIED_MARKER in body
+    has_pass = PASS_MARKER in body
+    assert has_unverified != has_pass, (
+        f"a verdict branch must say exactly one of the two things; got "
+        f"unverified={has_unverified} pass={has_pass} in:\n{body}"
+    )
+    return "UNVERIFIED" if has_unverified else "PASS"
+
+
 # --------------------------------------------------------------------------
-# GUILT: the exact Mini shape must NOT be reported as a pass.
+# GUILT: the exact Mini shape must not produce a passing message.
 # --------------------------------------------------------------------------
 
 
-def test_required_but_never_ran_is_not_a_pass() -> None:
+def test_required_but_never_ran_says_unverified() -> None:
     assert _verdict("1", "0") == "UNVERIFIED"
 
 
-def test_required_but_variable_left_unset_is_not_a_pass() -> None:
-    """Fail-safe direction: if some future skip path forgets to touch the
-    bookkeeping at all, the verdict must still refuse to claim a pass."""
+def test_required_but_variable_unset_says_unverified() -> None:
+    """Fail-safe direction: a future skip path that forgets the bookkeeping
+    entirely must still not claim a pass."""
     assert _verdict("1", None) == "UNVERIFIED"
 
 
-# --------------------------------------------------------------------------
-# INNOCENCE: the two legitimate greens must stay green.
-# --------------------------------------------------------------------------
-
-
-def test_suite_actually_ran_is_a_pass() -> None:
-    assert _verdict("1", "1") == "PASSED"
-
-
-def test_path_aware_skip_is_a_pass() -> None:
-    """A diff with no backend-relevant paths never needed the suite: reporting
-    it as unverified would cry wolf on every docs/frontend push and train
-    people to ignore the warning."""
-    assert _verdict("0", None) == "PASSED"
+def test_branches_are_not_swapped() -> None:
+    """Kills the mutation the first draft of this file could not see."""
+    _, then_body, else_body = _verdict_block()
+    assert UNVERIFIED_MARKER in then_body and PASS_MARKER not in then_body
+    assert PASS_MARKER in else_body and UNVERIFIED_MARKER not in else_body
 
 
 # --------------------------------------------------------------------------
-# STRUCTURE: every skip path must record WHY, and exactly one path may claim
-# the suite ran. These are the invariants a 5th skip branch could break.
+# INNOCENCE: the two legitimate greens stay green.
 # --------------------------------------------------------------------------
+
+
+def test_suite_actually_passed_says_pass() -> None:
+    assert _verdict("1", "1") == "PASS"
+
+
+def test_path_aware_skip_says_pass() -> None:
+    """A diff with no backend-relevant paths never needed the suite. Reporting
+    it unverified would cry wolf on every docs/frontend push and train people
+    to ignore the warning."""
+    assert _verdict("0", None) == "PASS"
+
+
+# --------------------------------------------------------------------------
+# STRUCTURE: written to survive legitimate refactors, and to check POSITION
+# rather than mere count.
+# --------------------------------------------------------------------------
+
+
+def test_no_unconditional_pass_after_the_verdict() -> None:
+    """An `echo 'All pre-push checks passed'` added AFTER the block would make
+    every unverified push look green again — the original bug, restored."""
+    text = _hook_text()
+    _, _, else_body = _verdict_block()
+    tail = text[text.rindex(else_body) + len(else_body):]
+    assert PASS_MARKER not in tail, (
+        f"{PASS_MARKER!r} appears after the verdict block — it must only ever be "
+        f"reachable through the else branch. Trailing text:\n{tail}"
+    )
+
+
+def test_the_pass_claim_exists_only_inside_the_verdict_block() -> None:
+    _, _, else_body = _verdict_block()
+    assert _hook_code().count(PASS_MARKER) == else_body.count(PASS_MARKER) == 1
+
+
+def test_suite_ran_is_set_only_where_pytest_succeeded() -> None:
+    """POSITION, not count. Counting one assignment does not prove it sits in
+    the success branch — it could be moved into a skip path and still count 1.
+
+    Note on the name: BACKEND_SUITE_RAN means "the suite completed and passed",
+    not "execution began" — a suite that starts and fails exits 1 before the
+    verdict, so the distinction never reaches a message today.
+    """
+    text = _hook_text()
+    m = re.search(
+        r'if \[ "\$TEST_RC" -eq 0 \]; then\n(?P<body>.*?)\n\s*elif ',
+        text,
+        re.DOTALL,
+    )
+    assert m, "pytest-success branch not found — re-anchor this test"
+    assign = re.compile(r'^\s*BACKEND_SUITE_RAN=(?:1|"1"|\'1\')\s*$', re.MULTILINE)
+    assert assign.search(m.group("body")), (
+        "BACKEND_SUITE_RAN is not set inside the `TEST_RC -eq 0` branch — the "
+        "only place that earned a pass."
+    )
+    assert len(assign.findall(text)) == 1, (
+        "BACKEND_SUITE_RAN=1 must appear exactly once; a second assignment is a "
+        "way for a push to claim a verdict it did not earn."
+    )
 
 
 def test_every_suite_skip_branch_records_a_reason() -> None:
+    """Accepts echo or printf, and any helper that assigns the reason — what
+    matters is that each skip leaves one, so the verdict can name the cause
+    instead of saying 'reason not recorded'."""
     text = _hook_text()
-    skips = len(re.findall(r'echo "⏭️\s+SKIP Python tests', text))
+    skips = len(re.findall(r'(?:echo|printf)\s+"⏭️\s+SKIP Python tests', text))
     reasons = len(re.findall(r"^\s*BACKEND_SUITE_SKIP_REASON=", text, re.MULTILINE))
     assert skips > 0, "no 'SKIP Python tests' branches found — re-anchor this test"
-    # One initialiser (empty) + one assignment per skip branch.
     assert reasons == skips + 1, (
-        f"{skips} 'SKIP Python tests' branches but {reasons} "
-        "BACKEND_SUITE_SKIP_REASON assignments (expected skips + 1 initialiser). "
-        "A skip branch that records no reason produces the verdict "
-        "'reason not recorded', which is the vague-alert failure mode: it tells "
-        "the reader something is wrong but not what to fix."
+        f"{skips} skip branches but {reasons} BACKEND_SUITE_SKIP_REASON "
+        "assignments (expected skips + 1 initialiser)."
     )
 
 
-def test_only_the_passing_suite_claims_it_ran() -> None:
-    text = _hook_text()
-    assert len(re.findall(r"^\s*BACKEND_SUITE_RAN=1$", text, re.MULTILINE)) == 1, (
-        "BACKEND_SUITE_RAN=1 must be set in exactly ONE place — the branch "
-        "where pytest exited 0. Any second assignment is a way for a push to "
-        "claim a verdict it never earned."
+def test_signal_death_cannot_reach_a_pass() -> None:
+    """A SIGTERM'd suite (TEST_RC >= 128 — the contention failure this fleet
+    hits) must exit before the verdict, never fall through to it."""
+    m = re.search(
+        r"TERMINATED by signal \$TEST_SIGNAL.*?\n(.*?)\n\s*else", _hook_text(), re.DOTALL
     )
-
-
-def test_signal_death_does_not_claim_the_suite_ran() -> None:
-    """A SIGTERM'd suite (TEST_RC >= 128, the contention failure this fleet
-    hits) exits 1 before reaching the verdict — it must never be able to fall
-    through to a pass."""
-    text = _hook_text()
-    m = re.search(r'TERMINATED by signal \$TEST_SIGNAL.*?\n(.*?)\n\s*else', text, re.DOTALL)
     assert m, "signal-classification branch not found — re-anchor this test"
     assert "exit 1" in m.group(1)
+
+
+def test_intake_dsn_is_isolated_to_the_per_push_clone() -> None:
+    """SCAR PIN (2026-07-27). test_intake_writer.py defaults INTAKE_TEST_DSN to
+    the machine's SHARED nuzantara_dev (12,408 client rows on Pro): a default
+    that fails OPEN onto real data instead of skipping. CI has exported the
+    disposable DB since the var existed; this hook must too, or the local suite
+    both writes to that DB and goes red on writes it did not cause."""
+    text = _hook_text()
+    assert re.search(r'INTAKE_TEST_DSN="postgresql://[^"]*\$CLONE_DB"', text), (
+        "the hook must export INTAKE_TEST_DSN pointing at the per-push clone "
+        "($CLONE_DB), mirroring .github/workflows/tests.yml"
+    )
+    assert "nuzantara_dev" not in _hook_code(), (
+        "no EXECUTABLE line may name the shared dev DB (the comment that explains "
+        "why is not only allowed, it is the evidence)"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_prepush_honest_verdict.py
+++ b/scripts/tests/test_prepush_honest_verdict.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Guilt + innocence suite for the `.husky/pre-push` final-verdict branch.
+
+WHY (measured live on Mini, 2026-07-27 — cicatrix-superscar.md family #2,
+"esiste ≠ armato"): the path-aware gate can decide the backend suite is
+REQUIRED for a diff, four separate environment gates can then skip the suite
+entirely (no local PG / unprovisioned test DB / no venv / DB clone failed), and
+before this fix all four fell through to the same closing line:
+
+    🧭 6/6 changed file(s) are NOT on the innocent allowlist — running FULL suite
+    🐍 Running Python tests...
+    ⏭️  SKIP Python tests — local PG up but 'nuzantara_test' not provisioned
+    ✅ All pre-push checks passed!
+
+Mini's local PG had no `test` role at all, so EVERY push ever made from that
+machine met a gate that ran zero tests and announced a pass. The skip is
+legitimate (a machine without a test DB must still be able to push, and the
+merge queue re-tests every entry against main); the CLAIM was not.
+
+The condition is extracted LIVE from .husky/pre-push and evaluated by a real
+`sh`, so this test breaks the moment the guard drifts from what actually runs —
+never a Python reimplementation that could diverge in semantics.
+
+Run:  python3 scripts/tests/test_prepush_honest_verdict.py
+      pytest scripts/tests/test_prepush_honest_verdict.py -q
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+HOOK_FILE = REPO_ROOT / ".husky" / "pre-push"
+
+
+def _hook_text() -> str:
+    return HOOK_FILE.read_text()
+
+
+def _extract_verdict_condition() -> str:
+    """The real `if` condition guarding the NOT-VERIFIED verdict."""
+    m = re.search(
+        r'^if (\[ "\$PREPUSH_RUN_BACKEND" = "1" \] && \[ "\$\{BACKEND_SUITE_RAN:-0\}" != "1" \]); then$',
+        _hook_text(),
+        re.MULTILINE,
+    )
+    assert m, (
+        f"final-verdict condition not found in {HOOK_FILE}. It must stay a "
+        "single-line `if` so this test can evaluate the REAL expression."
+    )
+    return m.group(1)
+
+
+def _verdict(run_backend: str, suite_ran: str | None) -> str:
+    """Evaluate the extracted condition under a real `sh -e`, exactly as the
+    hook runs it. `suite_ran=None` models the variable being UNSET — the
+    path-aware-skip path never enters the block that initialises it."""
+    cond = _extract_verdict_condition()
+    assign = "" if suite_ran is None else f'BACKEND_SUITE_RAN="{suite_ran}"\n'
+    script = (
+        "set -e\n"
+        f'PREPUSH_RUN_BACKEND="{run_backend}"\n'
+        f"{assign}"
+        f"if {cond}; then echo UNVERIFIED; else echo PASSED; fi\n"
+    )
+    r = subprocess.run(["sh", "-c", script], capture_output=True, text=True)
+    assert r.returncode == 0, f"condition aborted the shell: {r.stderr!r}"
+    return r.stdout.strip()
+
+
+# --------------------------------------------------------------------------
+# GUILT: the exact Mini shape must NOT be reported as a pass.
+# --------------------------------------------------------------------------
+
+
+def test_required_but_never_ran_is_not_a_pass() -> None:
+    assert _verdict("1", "0") == "UNVERIFIED"
+
+
+def test_required_but_variable_left_unset_is_not_a_pass() -> None:
+    """Fail-safe direction: if some future skip path forgets to touch the
+    bookkeeping at all, the verdict must still refuse to claim a pass."""
+    assert _verdict("1", None) == "UNVERIFIED"
+
+
+# --------------------------------------------------------------------------
+# INNOCENCE: the two legitimate greens must stay green.
+# --------------------------------------------------------------------------
+
+
+def test_suite_actually_ran_is_a_pass() -> None:
+    assert _verdict("1", "1") == "PASSED"
+
+
+def test_path_aware_skip_is_a_pass() -> None:
+    """A diff with no backend-relevant paths never needed the suite: reporting
+    it as unverified would cry wolf on every docs/frontend push and train
+    people to ignore the warning."""
+    assert _verdict("0", None) == "PASSED"
+
+
+# --------------------------------------------------------------------------
+# STRUCTURE: every skip path must record WHY, and exactly one path may claim
+# the suite ran. These are the invariants a 5th skip branch could break.
+# --------------------------------------------------------------------------
+
+
+def test_every_suite_skip_branch_records_a_reason() -> None:
+    text = _hook_text()
+    skips = len(re.findall(r'echo "⏭️\s+SKIP Python tests', text))
+    reasons = len(re.findall(r"^\s*BACKEND_SUITE_SKIP_REASON=", text, re.MULTILINE))
+    assert skips > 0, "no 'SKIP Python tests' branches found — re-anchor this test"
+    # One initialiser (empty) + one assignment per skip branch.
+    assert reasons == skips + 1, (
+        f"{skips} 'SKIP Python tests' branches but {reasons} "
+        "BACKEND_SUITE_SKIP_REASON assignments (expected skips + 1 initialiser). "
+        "A skip branch that records no reason produces the verdict "
+        "'reason not recorded', which is the vague-alert failure mode: it tells "
+        "the reader something is wrong but not what to fix."
+    )
+
+
+def test_only_the_passing_suite_claims_it_ran() -> None:
+    text = _hook_text()
+    assert len(re.findall(r"^\s*BACKEND_SUITE_RAN=1$", text, re.MULTILINE)) == 1, (
+        "BACKEND_SUITE_RAN=1 must be set in exactly ONE place — the branch "
+        "where pytest exited 0. Any second assignment is a way for a push to "
+        "claim a verdict it never earned."
+    )
+
+
+def test_signal_death_does_not_claim_the_suite_ran() -> None:
+    """A SIGTERM'd suite (TEST_RC >= 128, the contention failure this fleet
+    hits) exits 1 before reaching the verdict — it must never be able to fall
+    through to a pass."""
+    text = _hook_text()
+    m = re.search(r'TERMINATED by signal \$TEST_SIGNAL.*?\n(.*?)\n\s*else', text, re.DOTALL)
+    assert m, "signal-classification branch not found — re-anchor this test"
+    assert "exit 1" in m.group(1)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {name}: {exc}")
+    sys.exit(1 if failures else 0)

--- a/scripts/tests/test_test_deps_declared.py
+++ b/scripts/tests/test_test_deps_declared.py
@@ -1,28 +1,39 @@
 #!/usr/bin/env python3
-"""Every test dependency CI installs INLINE must also be declared in
+"""Every test dependency the BACKEND CI job installs inline must be declared in
 apps/backend-rag/requirements-test.txt.
 
 WHY (measured 2026-07-27, cicatrix-superscar.md family #2 "esiste ≠ armato"):
-`.github/workflows/tests.yml` installs the suite's test-runtime deps as a bare
-inline list —
+the `backend-tests` job in `.github/workflows/tests.yml` installs its
+test-runtime deps as a bare inline list —
 
     uv pip install --system pytest pytest-cov pytest-asyncio pytest-mock fakeredis
 
-— while `requirements-test.txt` knew about only one of them. An inline workflow
-list is not a manifest: nothing in the tree stated that the suite needs
-`fakeredis`, so a fleet machine provisioned from the repo could not reproduce
-CI's environment. Mini's venv duly lacked it; two test files ERRORed at
-COLLECTION; and the pre-push gate blocked two branches that do not touch those
-files at all — a red owned by the machine, reported as a verdict on the diff.
+— while `requirements-test.txt` knew about one of them. An inline workflow list
+is not a manifest: nothing in the tree stated that the suite needs `fakeredis`,
+so a fleet machine provisioned from the repo could not reproduce CI's
+environment. Mini's venv duly lacked it; two test files ERRORed at COLLECTION
+(module-level `import fakeredis.aioredis`, no importorskip); and the pre-push
+gate rejected two branches that do not touch those files at all — a red owned
+by the machine, reported as a verdict on the diff.
 
-Declaring the deps fixes today. This test is what keeps it fixed: the next
-person who adds a package to that inline list gets a failure here unless they
-also declare it. Direction matters — the manifest must COVER the installer, not
-the reverse: requirements-test.txt is allowed extra entries (mypy, testcontainers
-are dev-only and deliberately not in the Backend Tests job).
+SCOPE IS LOAD-BEARING, NOT A DETAIL. This checker reads ONLY the backend job.
+The first draft scanned the whole file and swept up `fastmcp` from the separate
+`mcp-tests` job, which led to `fastmcp` being added to the BACKEND manifest —
+a package that lives in apps/nuzantara-mcp/ with its own venv and that
+requirements.txt deliberately removed on 2026-05-03 to close 8 Dependabot
+alerts (1 critical + 4 high + 3 medium). Adversarial review caught it before
+merge. One job owns one manifest: a whole-file scan is manifest-ownership
+laundering, not thoroughness.
+
+Direction is also deliberate: the manifest must COVER the installer, never the
+reverse. `mypy` and `testcontainers` are dev/pre-commit tooling the backend job
+does not install; a check written the other way would fail on them and teach
+people to delete real declarations.
 
 Run:  python3 scripts/tests/test_test_deps_declared.py
       pytest scripts/tests/test_test_deps_declared.py -q
+Wired into CI by .github/workflows/prepush-guards.yml (a test that no gate runs
+is the very disease this file exists to prevent).
 """
 from __future__ import annotations
 
@@ -30,73 +41,89 @@ import pathlib
 import re
 import sys
 
+import yaml
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
 MANIFEST = REPO_ROOT / "apps" / "backend-rag" / "requirements-test.txt"
+BACKEND_JOB = "backend-tests"
 
-# Flags/arguments that mean "this token is not a plain package name".
-_NON_PACKAGE_PREFIXES = ("-", "$", "{", '"', "'")
+# Tokens that are flags, shell/expression syntax, or paths — never package names.
+_NOT_A_PACKAGE_PREFIX = ("-", "$", "{", '"', "'", "#", "\\", "|", "&", ">", "<")
+_ARG_TAKING_FLAGS = {"-r", "-e", "-c", "--requirement", "--editable", "--constraint",
+                     "--index-url", "-i", "--extra-index-url", "--find-links", "-f"}
+# `pip`/`uv` bootstrapping themselves is not a test dependency.
+_INSTALLER_SELF = {"pip", "uv", "setuptools", "wheel"}
+
+_INSTALL_RE = re.compile(
+    r"""(?:^|[;&|]\s*|\brun:\s*)      # command position: line start, after a
+                                      # separator, or right after a YAML `run:`
+        (?:python[0-9.]*\s+-m\s+)?    # optional `python -m` form
+        (?:uv\s+pip|pip[0-9]*)        # the installer
+        \s+install\b(?P<args>.*)$""",
+    re.VERBOSE,
+)
 
 
 def _normalise(name: str) -> str:
-    """Canonical comparison form: PEP 503 name, extras and specifiers stripped.
-
-    `pytest-cov`, `pytest_cov`, `PyTest-Cov`, `testcontainers[postgres]>=4.0.0`
-    must all compare as their base distribution name.
-    """
+    """PEP 503 comparison form: extras and version specifiers stripped."""
     base = re.split(r"[\[<>=!~;]", name, maxsplit=1)[0]
     return re.sub(r"[-_.]+", "-", base).strip().lower()
 
 
-def inline_installed_packages() -> set[str]:
-    """Bare package names installed by `pip/uv pip install` lines in tests.yml.
+def _backend_job_run_blocks() -> list[str]:
+    """Every `run:` script belonging to the backend job — and nothing else."""
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    jobs = (doc or {}).get("jobs") or {}
+    job = jobs.get(BACKEND_JOB)
+    if job is None:
+        raise AssertionError(
+            f"job '{BACKEND_JOB}' not found in {WORKFLOW} (jobs: {sorted(jobs)}). "
+            "It was renamed or removed — re-anchor this checker rather than "
+            "letting it silently scan nothing."
+        )
+    return [s["run"] for s in (job.get("steps") or []) if isinstance(s, dict) and s.get("run")]
 
-    Only tokens that are plain names count: `-r requirements.lock.txt`,
-    `-e ../../packages/cell-core`, `--system`, `--upgrade` and shell/expression
-    tokens are all excluded — this test is about packages named nowhere else,
-    not about requirement files (which are manifests already).
 
-    Anchored on the COMMAND, not on the substring: an `install` must open the
-    shell line (or follow `&&` / `;`), and comment lines are dropped first.
-    The first cut of this parser searched for `pip install` anywhere in the
-    line and duly harvested 40-odd English words out of the workflow's own
-    comments about pip installs — over-match on form instead of entity, the
-    same defect this repo files under cicatrix-superscar.md family #3, written
-    here by the person quoting it.
-    """
-    text = WORKFLOW.read_text()
+def _packages_in(script: str) -> set[str]:
     found: set[str] = set()
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("#"):
+    # Join `\`-continued lines first: a package on the second line of a
+    # continuation is still installed by the same command.
+    script = re.sub(r"\\\s*\n\s*", " ", script)
+    for raw_line in script.splitlines():
+        line = raw_line.strip()
+        if line.startswith("#"):
             continue
-        m = re.search(r"(?:^|&&\s*|;\s*)(?:uv\s+pip|pip3?)\s+install\b(.*)$", stripped)
+        line = line.split(" #", 1)[0]  # drop trailing shell comment
+        m = _INSTALL_RE.search(line)
         if not m:
             continue
-        tail = m.group(1)
-        # A `-r`/`-e`/`--requirement` argument consumes its value; drop both.
-        tokens = tail.split()
         skip_next = False
-        for tok in tokens:
+        for tok in m.group("args").split():
             if skip_next:
                 skip_next = False
                 continue
-            if tok in ("-r", "-e", "--requirement", "--editable", "-c", "--constraint"):
+            if tok in _ARG_TAKING_FLAGS:
                 skip_next = True
                 continue
-            if tok.startswith(_NON_PACKAGE_PREFIXES):
+            if tok.startswith(_NOT_A_PACKAGE_PREFIX) or "/" in tok or tok.endswith(".txt"):
                 continue
-            if "/" in tok or tok.endswith(".txt"):
-                continue
-            if tok in ("pip", "uv"):  # bootstrap of the installer itself
-                continue
-            found.add(_normalise(tok))
+            n = _normalise(tok)
+            if n and n not in _INSTALLER_SELF:
+                found.add(n)
     return found
+
+
+def inline_installed_packages() -> set[str]:
+    out: set[str] = set()
+    for block in _backend_job_run_blocks():
+        out |= _packages_in(block)
+    return out
 
 
 def declared_packages() -> set[str]:
     out: set[str] = set()
-    for raw in MANIFEST.read_text().splitlines():
+    for raw in MANIFEST.read_text(encoding="utf-8").splitlines():
         line = raw.split("#", 1)[0].strip()
         if not line or line.startswith("-"):
             continue
@@ -104,56 +131,86 @@ def declared_packages() -> set[str]:
     return out
 
 
-def test_workflow_is_readable() -> None:
-    """Fail LOUD rather than vacuously pass if either file moves.
+# --------------------------------------------------------------------------
+# Fail LOUD rather than vacuously: an empty parse would make the coverage
+# assertion trivially true (blind-scan, superscar #2 / W84 — zero items
+# traversed is not the same as nothing to find).
+# --------------------------------------------------------------------------
 
-    An empty inline-package set would make the coverage assertion below
-    trivially true — the blind-scan failure mode (superscar #2 / W84): zero
-    items traversed is not the same as nothing to find.
-    """
+
+def test_inputs_are_readable_and_non_empty() -> None:
     assert WORKFLOW.is_file(), f"missing {WORKFLOW}"
     assert MANIFEST.is_file(), f"missing {MANIFEST}"
+    assert _backend_job_run_blocks(), f"job '{BACKEND_JOB}' has no run: steps"
     assert inline_installed_packages(), (
-        f"no inline-installed packages parsed out of {WORKFLOW} — the install "
-        "step was renamed or reformatted, and this test would silently pass "
+        f"no inline-installed packages parsed out of the '{BACKEND_JOB}' job — "
+        "the install step was reformatted and this test would silently pass "
         "against an empty set. Re-anchor the parser."
     )
 
 
 def test_every_inline_installed_dep_is_declared() -> None:
-    """GUILT: an inline-installed package absent from the manifest fails."""
+    """GUILT: a package the backend job installs but nothing declares."""
     missing = sorted(inline_installed_packages() - declared_packages())
     assert not missing, (
-        "these packages are installed by .github/workflows/tests.yml but are "
-        f"declared in no manifest: {missing}. Add them to "
-        "apps/backend-rag/requirements-test.txt — otherwise no machine can "
-        "rebuild CI's test env from the repo, and the local suite fails with "
-        "collection ERRORs that look like a defect in whatever diff is being "
-        "pushed (measured on Mini, 2026-07-27)."
+        f"installed by the '{BACKEND_JOB}' job in {WORKFLOW.name} but declared "
+        f"in no manifest: {missing}. Add them to requirements-test.txt — "
+        "otherwise no machine can rebuild CI's test env from the repo, and the "
+        "local suite fails with collection ERRORs that look like a defect in "
+        "whatever diff is being pushed (measured on Mini, 2026-07-27)."
     )
 
 
 def test_manifest_may_declare_extras() -> None:
-    """INNOCENCE: manifest-only entries are legitimate, not a violation.
-
-    `mypy` and `testcontainers` are dev/pre-commit tooling that the Backend
-    Tests job deliberately does not install. A check written in the other
-    direction would fail on them and teach people to delete real declarations.
-    """
+    """INNOCENCE: manifest-only entries are legitimate, not a violation."""
     extras = declared_packages() - inline_installed_packages()
-    assert extras, (
-        "expected requirements-test.txt to declare more than the CI inline "
-        "list (mypy/testcontainers at minimum); if that is no longer true, "
-        "this test's premise changed — re-read it, don't delete it."
+    assert "mypy" in extras and "testcontainers" in extras, (
+        "expected dev-only tooling (mypy, testcontainers) to be declared and NOT "
+        "installed by the backend job. If that changed, re-read this test's "
+        "premise — do not delete the declarations to make it green."
     )
-    assert "mypy" in declared_packages()
 
 
-def test_the_dep_that_bit_us_is_declared() -> None:
-    """SCAR PIN: fakeredis specifically. Two test files import it at module
-    level (`import fakeredis.aioredis`, no importorskip), so its absence is a
-    collection ERROR, not a skip."""
-    assert "fakeredis" in declared_packages()
+def test_scope_excludes_other_jobs() -> None:
+    """SCOPE GUARD: the checker must not drag another job's deps in here.
+
+    `fastmcp` is installed by the `mcp-tests` job and belongs to
+    apps/nuzantara-mcp. If it ever appears in this checker's view again, the
+    scoping regressed and the backend manifest is about to re-acquire 8
+    Dependabot alerts' worth of dependency.
+    """
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    other_jobs = [j for j in ((doc or {}).get("jobs") or {}) if j != BACKEND_JOB]
+    assert other_jobs, "expected tests.yml to define jobs besides the backend one"
+    assert "fastmcp" not in inline_installed_packages()
+    assert "fastmcp" not in declared_packages(), (
+        "fastmcp must NOT be declared in the backend manifest — it lives in "
+        "apps/nuzantara-mcp/ and requirements.txt removed it on 2026-05-03 to "
+        "close 8 Dependabot alerts."
+    )
+
+
+def test_parser_handles_the_forms_this_repo_actually_uses() -> None:
+    """The tokenizer is the weak point; pin its behaviour on real shapes.
+
+    Every string below appears in, or is one edit away from, this repo's
+    workflows. The first draft of this parser missed three of them.
+    """
+    cases = {
+        "uv pip install --system pytest pytest-cov fakeredis": {"pytest", "pytest-cov", "fakeredis"},
+        "run: pip install pytest pytest-cov httpx": {"pytest", "pytest-cov", "httpx"},
+        "python -m pip install module-package": {"module-package"},
+        "pip install alpha-package # human note": {"alpha-package"},
+        "uv pip install --system -r requirements.lock.txt": set(),
+        "uv pip install --system -e ../../packages/cell-core": set(),
+        "pip install --upgrade pip uv": set(),
+        "# pip install commented-out-package": set(),
+        "pip install \\\n  first-package \\\n  second-package": {"first-package", "second-package"},
+    }
+    for script, expected in cases.items():
+        assert _packages_in(script) == expected, (
+            f"parser mis-read {script!r}: got {_packages_in(script)}, want {expected}"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_test_deps_declared.py
+++ b/scripts/tests/test_test_deps_declared.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import pathlib
 import re
+import shlex
 import sys
 
 import yaml
@@ -48,21 +49,24 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
 MANIFEST = REPO_ROOT / "apps" / "backend-rag" / "requirements-test.txt"
 BACKEND_JOB = "backend-tests"
 
-# Tokens that are flags, shell/expression syntax, or paths — never package names.
-_NOT_A_PACKAGE_PREFIX = ("-", "$", "{", '"', "'", "#", "\\", "|", "&", ">", "<")
-_ARG_TAKING_FLAGS = {"-r", "-e", "-c", "--requirement", "--editable", "--constraint",
-                     "--index-url", "-i", "--extra-index-url", "--find-links", "-f"}
-# `pip`/`uv` bootstrapping themselves is not a test dependency.
+# Flags that CONSUME the next token — its value is never a package name.
+# `--target/-t`, `--prefix`, `--root` were added after an adversarial review
+# showed `pip install --target vendor new-backend-dep` yielding {'vendor', ...}.
+_ARG_TAKING_FLAGS = {
+    "-r", "--requirement", "-c", "--constraint", "-e", "--editable",
+    "-i", "--index-url", "--extra-index-url", "-f", "--find-links",
+    "-t", "--target", "--prefix", "--root", "--python", "--cache-dir",
+    "--log", "--proxy", "--platform", "--abi", "--implementation",
+    "--python-version", "--only-binary", "--no-binary", "--report",
+}
+# Installing pip/uv/setuptools/wheel is bootstrapping, not a test dependency.
 _INSTALLER_SELF = {"pip", "uv", "setuptools", "wheel"}
-
-_INSTALL_RE = re.compile(
-    r"""(?:^|[;&|]\s*|\brun:\s*)      # command position: line start, after a
-                                      # separator, or right after a YAML `run:`
-        (?:python[0-9.]*\s+-m\s+)?    # optional `python -m` form
-        (?:uv\s+pip|pip[0-9]*)        # the installer
-        \s+install\b(?P<args>.*)$""",
-    re.VERBOSE,
-)
+# Tokens that open a new command context — an installer AFTER one of these is
+# still an install (`if pip install x; then`, `a && pip install x`).
+_SEGMENT_BREAKS = {"&&", "||", ";", "|", "&", "(", ")", "{", "}",
+                   "if", "then", "elif", "else", "do", "while", "until", "!"}
+# Wrappers that may precede the installer without changing what it does.
+_TRANSPARENT = {"sudo", "time", "nohup", "command", "exec", "xargs", "env"}
 
 
 def _normalise(name: str) -> str:
@@ -85,32 +89,82 @@ def _backend_job_run_blocks() -> list[str]:
     return [s["run"] for s in (job.get("steps") or []) if isinstance(s, dict) and s.get("run")]
 
 
+def _is_installer_at(tokens: list[str], i: int) -> int | None:
+    """If an install command starts at tokens[i], return the index just past
+    `install`; else None. Handles `pip`, `pip3`, `uv pip`, `python -m pip`."""
+    t = tokens[i]
+    if t == "uv" and i + 1 < len(tokens) and tokens[i + 1] in ("pip", "pip3"):
+        i += 2
+    elif re.fullmatch(r"python[0-9.]*", t) and tokens[i + 1:i + 3] == ["-m", "pip"]:
+        i += 3
+    elif re.fullmatch(r"pip[0-9]*", t):
+        i += 1
+    else:
+        return None
+    # allow global options between the installer and the subcommand
+    while i < len(tokens) and tokens[i].startswith("-"):
+        if tokens[i] in _ARG_TAKING_FLAGS:
+            i += 1
+        i += 1
+    return i + 1 if i < len(tokens) and tokens[i] == "install" else None
+
+
 def _packages_in(script: str) -> set[str]:
+    """Packages an install command in `script` would install.
+
+    shlex, not `.split()` — the round-2 review found five shapes the naive
+    tokenizer got WRONG, and every one of them was a FALSE NEGATIVE, which is
+    the dangerous direction here: a dep installed in CI that this checker cannot
+    see is a dep nobody has to declare.
+
+        pip install "new-backend-dep>=1"                 -> [] (quote char rejected)
+        if pip install new-backend-dep; then :; fi       -> [] (not at line start)
+        env X=1 pip install new-backend-dep              -> [] (same)
+        pip install a && pip install "new-dep>=1"        -> ['a', 'install']
+        pip install --target vendor new-backend-dep      -> [..., 'vendor']
+    """
     found: set[str] = set()
-    # Join `\`-continued lines first: a package on the second line of a
-    # continuation is still installed by the same command.
-    script = re.sub(r"\\\s*\n\s*", " ", script)
+    script = re.sub(r"\\\s*\n\s*", " ", script)  # join `\`-continued lines
     for raw_line in script.splitlines():
         line = raw_line.strip()
-        if line.startswith("#"):
+        if not line or line.startswith("#"):
             continue
-        line = line.split(" #", 1)[0]  # drop trailing shell comment
-        m = _INSTALL_RE.search(line)
-        if not m:
+        try:
+            tokens = shlex.split(line, comments=True)
+        except ValueError:
+            # unbalanced quotes (a YAML fragment, an expression): fail LOUD by
+            # skipping only this line, never by pretending the file is clean —
+            # the non-empty assertion in the test below is what catches a
+            # wholesale parse failure.
             continue
-        skip_next = False
-        for tok in m.group("args").split():
-            if skip_next:
-                skip_next = False
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            # Step over anything that can legitimately precede an installer:
+            # a segment break, a transparent wrapper, or a `VAR=value` prefix.
+            if (tok in _SEGMENT_BREAKS or tok in _TRANSPARENT
+                    or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tok)):
+                i += 1
                 continue
-            if tok in _ARG_TAKING_FLAGS:
-                skip_next = True
+            after = _is_installer_at(tokens, i)
+            if after is None:
+                i += 1
                 continue
-            if tok.startswith(_NOT_A_PACKAGE_PREFIX) or "/" in tok or tok.endswith(".txt"):
-                continue
-            n = _normalise(tok)
-            if n and n not in _INSTALLER_SELF:
-                found.add(n)
+            j, skip_next = after, False
+            while j < len(tokens) and tokens[j] not in _SEGMENT_BREAKS:
+                a = tokens[j]
+                if skip_next:
+                    skip_next = False
+                elif a in _ARG_TAKING_FLAGS:
+                    skip_next = True
+                elif a.startswith("-") or "/" in a or a.endswith(".txt") or a.startswith("$"):
+                    pass
+                else:
+                    n = _normalise(a)
+                    if n and n not in _INSTALLER_SELF:
+                        found.add(n)
+                j += 1
+            i = j
     return found
 
 
@@ -193,10 +247,14 @@ def test_scope_excludes_other_jobs() -> None:
 def test_parser_handles_the_forms_this_repo_actually_uses() -> None:
     """The tokenizer is the weak point; pin its behaviour on real shapes.
 
-    Every string below appears in, or is one edit away from, this repo's
-    workflows. The first draft of this parser missed three of them.
+    The five marked ROUND 2 are the ones an adversarial review found the naive
+    `.split()` tokenizer getting wrong — every one a FALSE NEGATIVE, i.e. a
+    package CI installs that the checker could not see and nobody would have to
+    declare. That is the dangerous direction: a false positive annoys someone,
+    a false negative is the bug this file exists to prevent, silently.
     """
     cases = {
+        # shapes already present in this repo's workflows
         "uv pip install --system pytest pytest-cov fakeredis": {"pytest", "pytest-cov", "fakeredis"},
         "run: pip install pytest pytest-cov httpx": {"pytest", "pytest-cov", "httpx"},
         "python -m pip install module-package": {"module-package"},
@@ -206,11 +264,28 @@ def test_parser_handles_the_forms_this_repo_actually_uses() -> None:
         "pip install --upgrade pip uv": set(),
         "# pip install commented-out-package": set(),
         "pip install \\\n  first-package \\\n  second-package": {"first-package", "second-package"},
+        # ROUND 2 — each of these returned the wrong answer before shlex
+        'pip install "quoted-dep>=1"': {"quoted-dep"},                       # quote char rejected the token
+        "if pip install conditional-dep; then :; fi": {"conditional-dep"},   # installer not at line start
+        "env FOO=1 pip install env-prefixed-dep": {"env-prefixed-dep"},      # same
+        'pip install alpha && pip install "beta>=1"': {"alpha", "beta"},     # second install lost, 'install' harvested
+        "pip install --target vendor targeted-dep": {"targeted-dep"},        # flag VALUE read as a package
     }
     for script, expected in cases.items():
         assert _packages_in(script) == expected, (
             f"parser mis-read {script!r}: got {_packages_in(script)}, want {expected}"
         )
+
+
+def test_the_parser_fails_loud_rather_than_quiet_on_a_broken_line() -> None:
+    """An unparseable line is skipped, never treated as 'no installs here' for
+    the whole file: test_inputs_are_readable_and_non_empty above is what turns a
+    wholesale parse failure into a red. Pinned so the two stay a pair."""
+    assert _packages_in('pip install "unterminated') == set()
+    assert inline_installed_packages(), (
+        "the real workflow still parses to a non-empty set — if this ever goes "
+        "empty, the coverage assertion below becomes vacuously true"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_test_deps_declared.py
+++ b/scripts/tests/test_test_deps_declared.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Every test dependency CI installs INLINE must also be declared in
+apps/backend-rag/requirements-test.txt.
+
+WHY (measured 2026-07-27, cicatrix-superscar.md family #2 "esiste ≠ armato"):
+`.github/workflows/tests.yml` installs the suite's test-runtime deps as a bare
+inline list —
+
+    uv pip install --system pytest pytest-cov pytest-asyncio pytest-mock fakeredis
+
+— while `requirements-test.txt` knew about only one of them. An inline workflow
+list is not a manifest: nothing in the tree stated that the suite needs
+`fakeredis`, so a fleet machine provisioned from the repo could not reproduce
+CI's environment. Mini's venv duly lacked it; two test files ERRORed at
+COLLECTION; and the pre-push gate blocked two branches that do not touch those
+files at all — a red owned by the machine, reported as a verdict on the diff.
+
+Declaring the deps fixes today. This test is what keeps it fixed: the next
+person who adds a package to that inline list gets a failure here unless they
+also declare it. Direction matters — the manifest must COVER the installer, not
+the reverse: requirements-test.txt is allowed extra entries (mypy, testcontainers
+are dev-only and deliberately not in the Backend Tests job).
+
+Run:  python3 scripts/tests/test_test_deps_declared.py
+      pytest scripts/tests/test_test_deps_declared.py -q
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+MANIFEST = REPO_ROOT / "apps" / "backend-rag" / "requirements-test.txt"
+
+# Flags/arguments that mean "this token is not a plain package name".
+_NON_PACKAGE_PREFIXES = ("-", "$", "{", '"', "'")
+
+
+def _normalise(name: str) -> str:
+    """Canonical comparison form: PEP 503 name, extras and specifiers stripped.
+
+    `pytest-cov`, `pytest_cov`, `PyTest-Cov`, `testcontainers[postgres]>=4.0.0`
+    must all compare as their base distribution name.
+    """
+    base = re.split(r"[\[<>=!~;]", name, maxsplit=1)[0]
+    return re.sub(r"[-_.]+", "-", base).strip().lower()
+
+
+def inline_installed_packages() -> set[str]:
+    """Bare package names installed by `pip/uv pip install` lines in tests.yml.
+
+    Only tokens that are plain names count: `-r requirements.lock.txt`,
+    `-e ../../packages/cell-core`, `--system`, `--upgrade` and shell/expression
+    tokens are all excluded — this test is about packages named nowhere else,
+    not about requirement files (which are manifests already).
+
+    Anchored on the COMMAND, not on the substring: an `install` must open the
+    shell line (or follow `&&` / `;`), and comment lines are dropped first.
+    The first cut of this parser searched for `pip install` anywhere in the
+    line and duly harvested 40-odd English words out of the workflow's own
+    comments about pip installs — over-match on form instead of entity, the
+    same defect this repo files under cicatrix-superscar.md family #3, written
+    here by the person quoting it.
+    """
+    text = WORKFLOW.read_text()
+    found: set[str] = set()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        m = re.search(r"(?:^|&&\s*|;\s*)(?:uv\s+pip|pip3?)\s+install\b(.*)$", stripped)
+        if not m:
+            continue
+        tail = m.group(1)
+        # A `-r`/`-e`/`--requirement` argument consumes its value; drop both.
+        tokens = tail.split()
+        skip_next = False
+        for tok in tokens:
+            if skip_next:
+                skip_next = False
+                continue
+            if tok in ("-r", "-e", "--requirement", "--editable", "-c", "--constraint"):
+                skip_next = True
+                continue
+            if tok.startswith(_NON_PACKAGE_PREFIXES):
+                continue
+            if "/" in tok or tok.endswith(".txt"):
+                continue
+            if tok in ("pip", "uv"):  # bootstrap of the installer itself
+                continue
+            found.add(_normalise(tok))
+    return found
+
+
+def declared_packages() -> set[str]:
+    out: set[str] = set()
+    for raw in MANIFEST.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        out.add(_normalise(line))
+    return out
+
+
+def test_workflow_is_readable() -> None:
+    """Fail LOUD rather than vacuously pass if either file moves.
+
+    An empty inline-package set would make the coverage assertion below
+    trivially true — the blind-scan failure mode (superscar #2 / W84): zero
+    items traversed is not the same as nothing to find.
+    """
+    assert WORKFLOW.is_file(), f"missing {WORKFLOW}"
+    assert MANIFEST.is_file(), f"missing {MANIFEST}"
+    assert inline_installed_packages(), (
+        f"no inline-installed packages parsed out of {WORKFLOW} — the install "
+        "step was renamed or reformatted, and this test would silently pass "
+        "against an empty set. Re-anchor the parser."
+    )
+
+
+def test_every_inline_installed_dep_is_declared() -> None:
+    """GUILT: an inline-installed package absent from the manifest fails."""
+    missing = sorted(inline_installed_packages() - declared_packages())
+    assert not missing, (
+        "these packages are installed by .github/workflows/tests.yml but are "
+        f"declared in no manifest: {missing}. Add them to "
+        "apps/backend-rag/requirements-test.txt — otherwise no machine can "
+        "rebuild CI's test env from the repo, and the local suite fails with "
+        "collection ERRORs that look like a defect in whatever diff is being "
+        "pushed (measured on Mini, 2026-07-27)."
+    )
+
+
+def test_manifest_may_declare_extras() -> None:
+    """INNOCENCE: manifest-only entries are legitimate, not a violation.
+
+    `mypy` and `testcontainers` are dev/pre-commit tooling that the Backend
+    Tests job deliberately does not install. A check written in the other
+    direction would fail on them and teach people to delete real declarations.
+    """
+    extras = declared_packages() - inline_installed_packages()
+    assert extras, (
+        "expected requirements-test.txt to declare more than the CI inline "
+        "list (mypy/testcontainers at minimum); if that is no longer true, "
+        "this test's premise changed — re-read it, don't delete it."
+    )
+    assert "mypy" in declared_packages()
+
+
+def test_the_dep_that_bit_us_is_declared() -> None:
+    """SCAR PIN: fakeredis specifically. Two test files import it at module
+    level (`import fakeredis.aioredis`, no importorskip), so its absence is a
+    collection ERROR, not a skip."""
+    assert "fakeredis" in declared_packages()
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {name}: {exc}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## What this fixes

Measured live on Mini. The hook's own log, verbatim:

```
🧭 path-aware (allowlist v3): 6/6 changed file(s) are NOT on the innocent allowlist — running FULL suite
🐍 Running Python tests...
⏭️  SKIP Python tests — local PG up but 'nuzantara_test' not provisioned
✅ All pre-push checks passed!
```

It decides the full suite is required, runs zero tests, and announces a pass. Mini's local PG had no `test` role and no `nuzantara_test` database at all — never provisioned — so **every push ever made from that machine** met a gate that had tested nothing and said so nowhere. Four environment gates skip the suite (no PG / unprovisioned DB / no venv / clone failed) and all four fell through to the same closing line. Family #2 of `cicatrix-superscar.md` (esiste != armato) on the most-cited gate in the fleet.

Deliberately **not** fail-closed: a machine without a test DB must still be able to push, and the merge queue re-tests every entry against main. What changes is only the *claim*, which is the part that was false. `BACKEND_SUITE_RAN` is set in exactly one place — the branch where pytest exited 0 — and the closing verdict becomes `PUSH NOT VERIFIED LOCALLY` with the specific reason.

Second half: **undeclared test dependencies.** CI installs them as a bare inline list in `.github/workflows/tests.yml` (`uv pip install --system pytest pytest-cov pytest-asyncio pytest-mock fakeredis`) while `requirements-test.txt` knew about one. An inline workflow list is not a manifest — nothing in the tree said the suite needs `fakeredis`, so no machine could rebuild CI's test env from the repo. Mini's venv duly lacked it, two test files ERRORed at collection (module-level `import fakeredis.aioredis`, no `importorskip`), and the newly-armed gate rejected two branches that do not touch those files. `scripts/tests/test_test_deps_declared.py` pins the two lists together. Direction is deliberate: the manifest must COVER the installer, never the reverse — `mypy`/`testcontainers` are dev-only and legitimately absent from the Backend Tests job.

## Verification, and its honest limits

Both new tests carry guilt AND innocence, and both were **mutation-checked** rather than assumed:
- removing the `fakeredis` line makes `test_test_deps_declared` fail (RC 1, two assertions);
- the verdict condition is extracted live from the hook and evaluated by a real `sh` across all four (required, ran) combinations, including the variable being unset.

**What actually ran for this branch, stated plainly:** the full backend suite passed on Mini. It did **not** pass on Pro — Pro rejected it on `test_intake_writer.py::test_approve_dry_run_returns_commit_plan` ("CRM mutated! {'clients': 12412, ...}"), which this diff cannot touch. Root cause: that file's DSN defaults to the machine's **shared** `nuzantara_dev` (12,408 client rows on Pro), and the hook isolated `DATABASE_URL`/`TEST_DATABASE_URL` but not `INTAKE_TEST_DSN`, so its own `assert after == before` guard saw writes it did not cause. The same file returns RC=0 run alone on clean `origin/main`. Three test files carry that default, not one.

**Correction to an earlier revision of this description, because I asserted it as verified and it was not.** I wrote that the same fixture skips in CI, "verified against `tests.yml`, which creates only `nuzantara_test`". That is false, and the grep behind it had run against a main checkout **15 commits behind**. `tests.yml` exports `INTAKE_TEST_DSN: postgresql://test:test@localhost:5432/nuzantara_test` in two places (lines 277 and 295), the second with a comment stating that pointing it at the disposable CI database "instead of their local-dev fallback (`nuzantara_dev`)" is what un-skipped 50 tests. So CI has been isolated all along and **only this hook never was** — which makes the cure a two-line export rather than a defect to file, and it is now in this diff (`INTAKE_TEST_DSN` joins `DATABASE_URL`/`TEST_DATABASE_URL` on the per-push clone, pinned by `test_intake_dsn_is_isolated_to_the_per_push_clone`). The related claim that the cure was "measured broken on `UndefinedColumnError: document_category`" was the same error one layer down: that measurement was against Pro's **stale** test-DB template (142 migrations, a hand-created 13-column `documents`), not against the cure. Pro's template has been re-bootstrapped and migrated to 261; the column is there.

Co-authored-by note: the first cut of the workflow parser in `test_test_deps_declared.py` matched `pip install` anywhere in a line and harvested 40 English words out of the workflow's own comments — over-match on form instead of entity, family #3, committed while quoting it. It is now anchored to the command position with comment lines dropped; the mistake is in the commit message, not hidden.
