### PR TITLE
test(perf): stop two wall-clock assertions from blocking every push under load

### DIFF
--- a/apps/backend-rag/backend/tests/services/kg_monitoring/test_kg_performance.py
+++ b/apps/backend-rag/backend/tests/services/kg_monitoring/test_kg_performance.py
@@ -17,38 +17,49 @@ import pytest
 class TestQueryPerformance:
     """Test KG query performance metrics"""
 
-    @pytest.mark.asyncio
-    async def test_simple_query_performance(self):
-        """Test performance of simple KG queries"""
-        mock_kg = AsyncMock()
+    # NOTE (2026-07-27): the two tests below used to carry wall-clock
+    # assertions — `duration < 0.1` and `duration < 1.0`. Both were removed
+    # because they measured the HARNESS, not the system: there is no KG here,
+    # only an AsyncMock, so the first timed how long Python takes to await a
+    # mock, and the second timed its own `asyncio.sleep(0.2)`. Neither could
+    # ever fail for a real performance regression, and the first DID block a
+    # push for 1h22 at `0.31 < 0.1` while the machine was running 21
+    # concurrent pushes — a pure false positive whose rate scales with fleet
+    # contention. A check that cannot detect the fault it names, but can fail
+    # for unrelated reasons, is worse than no check.
+    #
+    # A genuine KG latency budget needs a real (or containerised) graph and a
+    # machine that is not contended — it belongs in a dedicated serialized job,
+    # not in the pre-push suite. Tracked separately; deliberately NOT faked
+    # here with a looser bound, which would only make the no-signal permanent.
+    # What survives is what these tests can honestly assert: the call shape.
 
-        start = time.time()
+    @pytest.mark.asyncio
+    async def test_simple_query_returns_rows(self):
+        """A simple KG query is awaited and yields rows."""
+        mock_kg = AsyncMock()
         mock_kg.query.return_value = [{"id": "node1"}]
-        result = await mock_kg.query("MATCH (n:Visa) RETURN n LIMIT 10")
-        duration = time.time() - start
 
-        # Simple queries should be fast
-        assert duration < 0.1
+        result = await mock_kg.query("MATCH (n:Visa) RETURN n LIMIT 10")
+
         assert len(result) > 0
+        mock_kg.query.assert_awaited_once_with("MATCH (n:Visa) RETURN n LIMIT 10")
 
     @pytest.mark.asyncio
-    async def test_complex_query_performance(self):
-        """Test performance of complex KG queries"""
+    async def test_complex_query_returns_rows_with_relations(self):
+        """A multi-hop KG query is awaited and yields rows carrying relations."""
         mock_kg = AsyncMock()
 
-        # Simulate slower complex query
         async def slow_query(cypher):
-            await asyncio.sleep(0.2)
+            await asyncio.sleep(0)  # yield to the loop; no wall-clock claim
             return [{"id": "node1", "relations": []}]
 
         mock_kg.query = slow_query
 
-        start = time.time()
-        await mock_kg.query("MATCH (n)-[r*1..3]->(m) RETURN n,r,m")
-        duration = time.time() - start
+        result = await mock_kg.query("MATCH (n)-[r*1..3]->(m) RETURN n,r,m")
 
-        # Complex queries can be slower but should have threshold
-        assert duration < 1.0
+        assert len(result) == 1
+        assert "relations" in result[0]
 
     def test_query_complexity_scoring(self):
         """Test scoring query complexity"""

--- a/apps/backend-rag/backend/tests/unit/core/test_chunker_page_aware.py
+++ b/apps/backend-rag/backend/tests/unit/core/test_chunker_page_aware.py
@@ -235,17 +235,33 @@ class TestPerfRegression:
         chunker = _chunker(chunk_size=200)
         text = ("paragraph with some words. " * 50 + "\n\n") * 20  # ~28K chars
 
-        # Direct semantic_chunk — upper bound on fallback cost.
-        t0 = time.perf_counter()
+        # INTERLEAVED and MIN-of-N, not two sequential means. Measured
+        # 2026-07-27: this test blocked a push at "41.11ms vs 1.72ms" — a 24x
+        # ratio — on a laptop running 21 concurrent pushes, while passing in
+        # isolation on the same tree moments later.
+        #
+        # The old shape timed all 5 baselines, THEN all 5 fallbacks, and
+        # averaged each. That is robust to STEADY load but not to load that
+        # CHANGES between the two windows, which is exactly what a fleet of
+        # starting/finishing pushes produces. Averaging makes it worse: a mean
+        # absorbs every descheduling spike into the number it reports.
+        #
+        # Interleaving puts both operations under the same load regime, and the
+        # minimum is the right estimator here because timing noise is
+        # ONE-SIDED — contention can only ever make a run slower, never faster,
+        # so min() is the closest thing to the true cost. The regression signal
+        # is fully preserved: real added overhead in chunk_by_pages raises its
+        # MINIMUM too, and no amount of quiet machine hides it.
+        baseline = float("inf")
+        fallback = float("inf")
         for _ in range(5):
+            t0 = time.perf_counter()
             chunker.semantic_chunk(text)
-        baseline = (time.perf_counter() - t0) / 5
+            baseline = min(baseline, time.perf_counter() - t0)
 
-        # chunk_by_pages with no markers — same call path internally.
-        t0 = time.perf_counter()
-        for _ in range(5):
+            t0 = time.perf_counter()
             chunker.chunk_by_pages(text, page_markers=None)
-        fallback = (time.perf_counter() - t0) / 5
+            fallback = min(fallback, time.perf_counter() - t0)
 
         # Allow 3x slack for CI noise; the two should be effectively identical.
         assert fallback < baseline * 3 + 0.01, (


### PR DESCRIPTION
Two tests carried wall-clock assertions that measured the machine, not the system, and blocked pushes under fleet contention.

**`test_kg_performance.py`** — `duration < 0.1` and `duration < 1.0` both timed an `AsyncMock`: there is no KG in the test, so the first measured how long Python takes to await a mock and the second measured its own `asyncio.sleep(0.2)`. Neither could ever fail for a real performance regression, and the first *did* block a push for 1h22 at `0.31 < 0.1` while the machine was running 21 concurrent pushes. A check that cannot detect the fault it names, but can fail for unrelated reasons, is worse than no check. What survives is what these tests can honestly assert: the call shape. A genuine KG latency budget needs a real graph and an uncontended machine — deliberately NOT faked here with a looser bound, which would only make the no-signal permanent.

**`test_chunker_page_aware.py`** — the fallback-vs-baseline comparison timed all 5 baselines, then all 5 fallbacks, and averaged each. That is robust to steady load but not to load that *changes* between the two windows, which is exactly what a fleet of starting and finishing pushes produces; averaging makes it worse, since a mean absorbs every descheduling spike. Measured failure: "41.11ms vs 1.72ms", a 24x ratio, while passing in isolation on the same tree moments later. Now interleaved and min-of-N: interleaving puts both operations under the same load regime, and the minimum is the right estimator because timing noise is one-sided — contention can only make a run slower. The regression signal is fully preserved: real overhead in `chunk_by_pages` raises its minimum too.

Verified: 12 repetitions at load 61, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)