### PR TITLE
ci(security): merge_group-safe concurrency for security.yml (PR-B follow-up)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,19 @@ concurrency:
   # 'refs/heads/main'` form), deliberately copied rather than reinvented: on
   # main every security scan still runs to completion, because a cancelled
   # scan on a commit that LANDS would leave a gap in the security record.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  #
+  # merge_group readiness (2026-07-27): under merge_group, github.ref resolves
+  # to the queue's own temporary ref (refs/heads/gh-readonly-queue/...), which
+  # is != 'refs/heads/main' — so the expression above would evaluate `true`
+  # for a queue entry, cancelling an in-flight required-check run every time a
+  # newer commit joined the queue behind it (this workflow owns 4 of the 25
+  # required contexts — exactly the starvation the concurrency block above
+  # fixed for PR branches, just relocated to the queue). Composed fix, same
+  # pattern as tests.yml: AND `github.event_name != 'merge_group'` onto the
+  # existing expression rather than replacing it, so the PR-vs-main asymmetry
+  # above is preserved byte-for-byte; only the new merge_group case is forced
+  # to false.
+  cancel-in-progress: ${{ (github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
 
 jobs:
   snyk-python:


### PR DESCRIPTION
## Summary

Closes the one remaining gap from PR #3285 (merge_group readiness across 19 required-check workflows). `security.yml` needed a rebase before merge because #3261 landed on `main` between this work starting and finishing — that PR rewrote `security.yml`'s concurrency block from a flat `cancel-in-progress: false` to `${{ github.ref != 'refs/heads/main' }}` (same pattern `tests.yml` already had). #3285 got merged with the rebase still in flight (background push kept losing a race against sustained high machine load — 3 SIGTERM kills + 1 genuine flaky-test failure across ~2.5 hours of retries), so the composed fix never landed. This PR is that fix, isolated and reapplied cleanly against current `main`.

## The gap

`security.yml`'s new concurrency expression (`github.ref != 'refs/heads/main'`) is exactly the merge_group vulnerability #3285 fixed everywhere else: under a `merge_group` event, `github.ref` resolves to the queue's temporary ref (`refs/heads/gh-readonly-queue/...`), which is `!= 'refs/heads/main'` — so the expression evaluates `true` and would cancel an in-flight required-check run every time a newer commit joined the queue behind it. `security.yml` owns 4 of the 25 required contexts (CodeQL ×2, Detect Secrets, Bandit).

## Fix

Same composed-fix pattern already applied to `tests.yml` in #3285 (which has an analogous hand-tuned expression): AND `github.event_name != 'merge_group'` onto the existing expression rather than replacing it wholesale, so #3261's documented PR-vs-main asymmetry (cancel on PR branches, never on main) is preserved byte-for-byte — only the new merge_group case is forced to `false`.

```diff
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ (github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
```

## Validation

- `python3 -c "import yaml; ..."` — parses clean.
- `actionlint` v1.7.12 — exits 0.
- Scope: single file, `.github/workflows/security.yml`, 13 insertions (mostly the explanatory comment) / 1 deletion.

Note: triggers are dormant until a merge queue exists — no queue means GitHub never emits `merge_group`, so this is behavior-neutral today, same as #3285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
