### PR TITLE
fix(proprioception): ask the worktree-gate detector, which nothing had ever asked

### DIFF
--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -72,6 +72,7 @@ KNOWN_BOUNDARY_CLASSES = [
     "defined<->live",           # e.g. Qdrant collections — NO PROBE in v1 (A6)
     "process<->process",        # e.g. /health/detailed provenance — NO PROBE in v1 (A2)
     "seat<->armed",             # AI-seat credential/quota vs live probe (arsenal, #2)
+    "worktree<->gate",          # does git actually invoke a pre-push hook in this worktree (#2)
 ]
 
 SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=15",
@@ -413,6 +414,36 @@ DEFAULT_REGISTRY: list[dict] = [
             {"glob": "~/.organism/arsenal/last.json", "max_age_h": 26, "label": "arsenal seats probe (healer-armed)", "machines": ["mini", "pro"]},
         ]},
         "fix_hint": "a stale guardian: run it by hand, read ITS log, then fix its scheduler",
+    },
+    {
+        # The detector was written, tested and CI-verified — and then run by nobody.
+        # `lint_worktree_husky_symlink.py` has exactly one caller in the tree
+        # (immune-enforcement.yml), and what that workflow runs is its unit TEST.
+        # A GitHub runner cannot see a worktree on M5, so the tool had never once
+        # answered the question it was built for. Measured by hand on M5 2026-07-27:
+        # 15 of 115 worktrees had no `.husky/_` at all — every push from them ran NO
+        # hook and exited 0 silently. That is family #2 one level up: not a missing
+        # detector, a detector that is never asked. This entry is the asking, and it
+        # reuses the real tool rather than growing a twin probe next to it (the twin
+        # was written first and deleted on discovering this file — anti-twin: grep for
+        # the existing tool BEFORE building the cure).
+        #
+        # ok_values keeps GONE deliberately: a GONE record is a stale worktree-registry
+        # entry (the directory is gone), which is `git worktree prune` territory and the
+        # gc cron's job — not a worktree pushing without a gate. The tool itself scores
+        # it the same way (FINDING_HEALTHS = MISSING | DANGLING); if the two ever
+        # disagree, this list is the side that is wrong.
+        "id": "worktree_gate_shim", "type": "wrap",
+        "target": ["python3", "{repo}/scripts/lint_worktree_husky_symlink.py", "--json"],
+        "class": "worktree<->gate",
+        "boundary": "worktree <-> the pre-push hook git actually invokes there",
+        "machines": ["all"], "tags": ["fast"], "timeout_sec": 60,
+        "severity": "P1",
+        "parse": "findings_list", "unwrap_key": "worktrees",
+        "verdict_key": "health", "ok_values": ["OK", "GONE"],
+        "fix_hint": "recreate via `python scripts/agent_start.py` (it symlinks .husky/_), or "
+                    "`ln -sfn <main-checkout>/.husky/_ <worktree>/.husky/_` — a worktree born from a "
+                    "bare `git worktree add` pushes with NO gate and reports a clean push",
     },
     {
         "id": "launchd_liveness", "type": "wrap",

--- a/scripts/tests/test_lint_worktree_husky_symlink.py
+++ b/scripts/tests/test_lint_worktree_husky_symlink.py
@@ -390,3 +390,90 @@ def test_default_repo_root_falls_back_to_file_path_on_git_failure(
     # the moment scan() calls git itself, so this fallback is a courtesy, not
     # a silent wrong-answer path.
     assert resolved == _MODULE_PATH.resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# ARMED-CHECK (added 2026-07-27). The detector above was complete, tested and
+# CI-verified from the day it merged -- and had never once run against a real
+# machine. Its only caller in the tree was immune-enforcement.yml, and what that
+# workflow runs is THIS FILE, not the detector: a GitHub runner cannot see a
+# worktree on M5. Measured by hand that day: 15 of 115 worktrees on M5 had no
+# `.husky/_` at all, so every push from them invoked no hook and exited 0 in
+# silence. Family #2 one level up -- not a missing detector, a detector nobody
+# asks. The cure is the proprioception registry entry these tests pin, because
+# that organ runs per-machine at SessionStart and its report is read.
+#
+# Pinned here rather than in a new file precisely because a new file under
+# scripts/ would itself need a workflow to name it -- which is the disease.
+# ---------------------------------------------------------------------------
+
+_PROPRIO_PATH = Path(__file__).resolve().parents[1] / "proprioception.py"
+
+
+def _proprioception_module():
+    spec = importlib.util.spec_from_file_location("proprioception", _PROPRIO_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _gate_entry():
+    entries = [e for e in _proprioception_module().DEFAULT_REGISTRY
+               if e.get("id") == "worktree_gate_shim"]
+    assert len(entries) == 1, (
+        "proprioception must carry exactly one worktree_gate_shim entry — without it "
+        "lint_worktree_husky_symlink.py runs on no machine and this whole file guards "
+        "a tool that is never invoked."
+    )
+    return entries[0]
+
+
+def test_proprioception_actually_invokes_this_detector() -> None:
+    """The entry must point at THIS script — the arming, not a re-implementation."""
+    entry = _gate_entry()
+    assert entry["type"] == "wrap", "must wrap the real tool, never re-implement it as a builtin twin"
+    target = entry["target"]
+    assert target[-1] == "--json", f"the parser needs JSON, got {target}"
+    assert target[-2].endswith("/scripts/lint_worktree_husky_symlink.py"), \
+        f"proprioception points at the wrong script: {target}"
+
+
+def test_the_registry_and_the_tool_agree_on_what_counts_as_a_finding() -> None:
+    """Two graders of one signal need one rule (else the organ and the tool disagree).
+
+    `ok_values` is proprioception's copy of the tool's FINDING_HEALTHS. Drift here
+    is silent in both directions: a health state added to the tool and not here
+    would be graded a finding by the organ and not by the tool, or vice versa.
+    """
+    ok = set(_gate_entry()["ok_values"])
+    all_healths = {lwhs.HEALTH_OK, lwhs.HEALTH_MISSING, lwhs.HEALTH_DANGLING, lwhs.HEALTH_GONE}
+    assert ok | set(lwhs.FINDING_HEALTHS) == all_healths, (
+        "every health state the tool can emit must be classified by the registry: "
+        f"ok={sorted(ok)} findings={sorted(lwhs.FINDING_HEALTHS)} all={sorted(all_healths)}"
+    )
+    assert not (ok & set(lwhs.FINDING_HEALTHS)), (
+        f"the registry calls {sorted(ok & set(lwhs.FINDING_HEALTHS))} acceptable while the tool "
+        "scores it a finding — the organ would report calm over a blind gate"
+    )
+    assert lwhs.HEALTH_GONE in ok, (
+        "GONE (the worktree directory itself is absent) is stale-registry hygiene for "
+        "`git worktree prune`, not a worktree pushing without a gate — deliberately not a finding"
+    )
+
+
+def test_the_parser_contract_matches_the_tools_json_shape() -> None:
+    """`unwrap_key`/`verdict_key` are strings resolved at runtime: a rename in the
+    tool's JSON would make run_wrap return UNPROBEABLE forever, which reads as
+    'not applicable here' rather than as a break. Pin them against real output."""
+    entry = _gate_entry()
+    payload = json.loads(json.dumps({  # shape mirrored from the tool's own emit path
+        "traversed": 1, "healthy": 1, "findings_count": 0, "gone_count": 0,
+        "origin_counts": {"main": 1},
+        "worktrees": [{"path": "/x", "origin": "main", "health": lwhs.HEALTH_OK,
+                       "is_symlink": False, "is_finding": False}],
+    }))
+    assert entry["unwrap_key"] in payload, f"unwrap_key {entry['unwrap_key']!r} absent from the tool's JSON"
+    assert entry["verdict_key"] in payload[entry["unwrap_key"]][0], \
+        f"verdict_key {entry['verdict_key']!r} absent from a worktree record"


### PR DESCRIPTION
## The finding

`scripts/lint_worktree_husky_symlink.py` detects the worst shape a gate can fail in: a worktree whose `.husky/_` is missing, where `core.hooksPath` resolves to nothing, **git runs no pre-push hook at all, and the push exits 0 looking exactly like a push that passed.** The script is 500 lines, has guilt+innocence per health state, a blind-scan guard, origin classification, `--json`.

It had never run.

Its only caller in the tree is `immune-enforcement.yml`, and what that workflow runs is its **unit test**. A GitHub runner cannot see a worktree on M5 — so the tool had never once answered the question it exists to answer. Measured by hand on M5 today, which is how this was found at all:

```
worktree=114  senza .husky/_/pre-push=14      # …15 by the time I repaired them; a live lane made another
```

Every push made from any of those ran no hook and said nothing about it. This is family #2 (`esiste != armato`) one level up: **not a missing detector — a detector nobody asks.**

## The fix

One registry entry, because the asking mechanism already existed. `proprioception.py` runs per-machine at SessionStart, its report is injected into context and read (it is where this session's `git_alignment` and `home_fork_scripts` warnings come from), and it already wraps external reconcilers exactly this way — `launchd_liveness` is the precedent. `worktree<->gate` joins the boundary taxonomy so the class can never be silently UNWATCHED.

**A twin probe was written first and deleted on discovering this file.** That is worth stating rather than hiding: the reflex was to build a detector, and the detector already existed and was better than the one being built. Grep for the tool before building the cure.

## Proof, both directions, on the live fleet

```
healthy (117/117, after repairing today's 15)  ->  RECONCILED 0
one shim moved aside in THIS worktree          ->  DIVERGED 1, naming the exact path
restored, re-verified armed
```

No sibling worktree was touched to produce the guilt case — breaking someone else's gate to test my own is not a test.

## Where the tests live, and why not in a new file

Three assertions go into the detector's **existing** test file, which `immune-enforcement.yml` already names. A new file under `scripts/` would itself need a workflow to name it — which is the disease this PR is about. They pin:

1. the entry **wraps** this script rather than re-implementing it (the twin, forbidden by test);
2. `ok_values` and the tool's `FINDING_HEALTHS` **partition** every health state the tool can emit — two graders of one signal need one rule, and drift is silent in both directions;
3. `unwrap_key`/`verdict_key` still match the tool's JSON — a rename there makes `run_wrap` return `UNPROBEABLE` forever, which reads as "not applicable on this machine" rather than as a break.

Both mutation-checked, not assumed: renaming the registry id fails 3 of them; declaring `MISSING` acceptable fails the partition test — that being the exact mutation that would let the organ report calm over a blind gate. `--selftest` passes (and caught the missing taxonomy entry on the first try, which is the registry validator doing its job).

`GONE` stays deliberately **not** a finding: it means the worktree directory itself is absent, which is `git worktree prune` hygiene and the gc cron's job, not a worktree pushing ungated. The tool scores it the same way; test 2 pins that they keep agreeing.

## Ship notes

Suite run in full on **Mini** (idle) via bundle-ferry, no bypass, `--no-verify` never used; `PUSH_RC=0`.