### PR TITLE
docs(ci): say what the merge_group cancel-in-progress guard actually does

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,17 +27,37 @@ concurrency:
   # main every security scan still runs to completion, because a cancelled
   # scan on a commit that LANDS would leave a gap in the security record.
   #
-  # merge_group readiness (2026-07-27): under merge_group, github.ref resolves
-  # to the queue's own temporary ref (refs/heads/gh-readonly-queue/...), which
-  # is != 'refs/heads/main' — so the expression above would evaluate `true`
-  # for a queue entry, cancelling an in-flight required-check run every time a
-  # newer commit joined the queue behind it (this workflow owns 4 of the 25
-  # required contexts — exactly the starvation the concurrency block above
-  # fixed for PR branches, just relocated to the queue). Composed fix, same
-  # pattern as tests.yml: AND `github.event_name != 'merge_group'` onto the
-  # existing expression rather than replacing it, so the PR-vs-main asymmetry
-  # above is preserved byte-for-byte; only the new merge_group case is forced
-  # to false.
+  # merge_group readiness (2026-07-27). Under merge_group, github.ref resolves
+  # to the queue's own temporary ref, which is != 'refs/heads/main', so the
+  # expression above evaluates TRUE for a queue entry and leaves
+  # cancel-in-progress armed on a run that owns 4 of the 25 required contexts.
+  #
+  # HONEST SCOPE, because the first draft of this comment claimed a failure
+  # this cannot actually produce and a wrong diagnosis in a debugging surface
+  # costs more than no comment (W106). It said a newer entry joining the queue
+  # behind this one would cancel it. It cannot: the concurrency GROUP above is
+  # keyed on github.ref, and a queue entry's ref carries its own PR number and
+  # SHA. Measured on this repo the same day —
+  # `gh-readonly-queue/main/pr-3302-23dcbfe78add…`, 4 distinct refs across 60
+  # merge_group runs — so two entries are never in the same group and cannot
+  # cancel each other.
+  #
+  # What this guard is actually for, which is still worth having:
+  #   1. UNIFORMITY. Twelve sibling workflows carry this exact composed form
+  #      (PR #3285). Being the one exception means every future reader has to
+  #      re-derive why, and the derivation above is not obvious.
+  #   2. It survives the group key changing. The safety here is a property of
+  #      `group:`, not of this line — coarsen the key (say to a PR number or a
+  #      ref_name) and parallel queue builds WOULD start cancelling each other,
+  #      silently, because a cancelled run reports no failure at all. This line
+  #      makes that mistake non-fatal.
+  # It is defence in depth, not a live bug fix. Do not delete it, and do not
+  # cite it as evidence that the queue was ever losing verdicts.
+  #
+  # Composed, same pattern as tests.yml: AND `github.event_name != 'merge_group'`
+  # onto the existing expression rather than replacing it, so the PR-vs-main
+  # asymmetry above is preserved byte-for-byte; only the merge_group case is
+  # forced to false.
   cancel-in-progress: ${{ (github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
 
 jobs:


### PR DESCRIPTION
## Summary

Re-lands `61211bec65`, orphaned when #3303 merged at a stale head (task #97/#98)
and killed a stray push before it could fork history against a live sibling
(task #98). Cherry-picked clean onto current `origin/main`, no rebase conflicts.

Docs-only correction to `.github/workflows/security.yml`'s `cancel-in-progress`
comment — the author of #3303 correcting their own comment. The expression is
byte-identical; only the justification changes.

The original comment claimed a newer merge_group entry joining the queue
behind this one would cancel its in-flight required checks. It cannot: the
`concurrency: group:` is keyed on `github.ref`, and a queue entry's ref
carries its own PR number and SHA — measured on this repo via
`gh run list --event merge_group`, 60 runs share only 4 distinct refs, one
per entry. Two entries are never in the same concurrency group.

A wrong diagnosis parked in a CI debugging surface is worse than no comment
(scar W106: the cure and its explanation expire together) — it sends the
next reader chasing a mechanism that doesn't exist. The replacement text
states honestly why the guard is still worth keeping: uniformity with 12
sibling workflows from #3285, and it protects against someone coarsening the
`group:` key later, which WOULD make queue entries cancel each other
silently (relevant now that `max_entries_to_build` went 1→5, widening the
blast radius of that mistake from one run to five).

## Verification

- `actionlint .github/workflows/security.yml` — clean (rc=0)
- `python3 -c "import yaml; yaml.safe_load(...)"` — parses
- Diff confirms the `cancel-in-progress:` expression line is unchanged;
  only comment lines above it differ
- Pre-push classifier: `skip-backend` (workflow-only change, allowlist v5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>