### PR TITLE
docs(kbli): correct which reader feeds the 1,559 pages — prod rendered "undefined% Open"

### DIFF
--- a/apps/mouth/src/lib/kbli-pma-cap.ts
+++ b/apps/mouth/src/lib/kbli-pma-cap.ts
@@ -2,14 +2,27 @@
  * Single resolver for a KBLI record's foreign-ownership cap.
  *
  * Why this file exists: the cap was read in TWO places with DIFFERENT defaults —
- * `kbli-data.server.ts` used `raw.pma_max_asing || 0` (the 1,559 static
- * `/kbli/<code>` pages, the gold API, the sitemap) while `kbli-data.ts` used
- * `raw.pma_max_asing` bare (the /kbli index, the sector pages, the OG image).
+ * `kbli-data.ts` used `raw.pma_max_asing` bare, while `kbli-data.server.ts`
+ * used `raw.pma_max_asing || 0`. The two readers disagreed about the same
+ * record, so one of them had to be lying; both were.
+ *
  * On the one record that carries no cap field — `01122` "Pertanian Padi
- * Inbrida", `pma_status: TERBUKA`, i.e. fully open to foreign ownership — the
- * `|| 0` coercion turned "absent" into "0", and the page rendered the
- * self-contradicting string **"0% Open"**. The two readers disagreed about the
- * same record, so one of them had to be lying.
+ * Inbrida", `pma_status: TERBUKA`, i.e. fully open to foreign ownership —
+ * each reader produced its own wrong answer: `undefined` from the bare read,
+ * `0` from the coercion, on a code that is 100% open.
+ *
+ * Which reader feeds which surface was verified against the live page, not
+ * assumed: `/kbli/[code]/page.tsx` imports `getCode` from `kbli-data.ts`
+ * (it takes only `getGoldContent`/`getKbliDatasetLastModified` from the
+ * `.server` module), so the **1,559 detail pages are on the bare read** and
+ * prod rendered the self-contradicting string **"undefined% Open"**. The
+ * `|| 0` reader feeds the sitemap and the `/api/kbli/gold` routes, where the
+ * same record reported a flat `0`.
+ *
+ * (An earlier version of this comment had those two roles swapped and named
+ * the symptom as "0% Open". The fix was right and covers both readers; the
+ * attribution was wrong, and a wrong attribution sends the next reader
+ * grepping for a string that was never on the page.)
  *
  * A rule that decides one fact belongs in ONE module, and the interaction is
  * what gets tested — not each reader in isolation.


### PR DESCRIPTION
## The resolver's docstring named the wrong reader, and the wrong symptom

Follow-up to #3317. **The fix in that PR is correct and unchanged** — `resolvePmaCap`
already covers both readers. What was wrong is the comment explaining *why it exists*, and
it was wrong in a way that misdirects the next person who reads it.

### Measured, not reasoned

Prove-live on the merged fix meant curling the page. The cured value is not there yet
(Vercel had not rebuilt), so what prod still served was the **pre-fix** render — which is
exactly the evidence the original claim needed and never had:

```
<span class="text-sm font-semibold ...">undefined% Open
```

`undefined`, not `0`. And `|| 0` cannot produce `undefined`, so the detail pages were never
on the reader the docstring blamed.

Verified at the import, not inferred: `apps/mouth/src/app/kbli/[code]/page.tsx` takes
`getCode` from `@/lib/kbli-data` (the **bare** read) and takes only `getGoldContent` /
`getKbliDatasetLastModified` from `@/lib/kbli-data.server`.

| Reader | Default on a record with no cap | Surfaces it actually feeds |
|---|---|---|
| `kbli-data.ts` (bare) | `undefined` | **the 1,559 `/kbli/<code>` detail pages**, index, sectors, OG |
| `kbli-data.server.ts` (`\|\| 0`) | `0` | sitemap, `/api/kbli/gold` routes |

Both were wrong on `01122` (`pma_status: TERBUKA`, the one record in 1,559 with no
`pma_max_asing` key), each in its own way. Both are fixed. The docstring simply had the two
roles swapped and named a string — `"0% Open"` — that was never on the page.

### Why this is worth a PR of its own

A wrong attribution in a comment is not cosmetic: it sends the next reader grepping for a
string that never existed, in a module that never fed that surface. The comment now also
records **how** the mapping was established (an import, and a live curl), so it can be
re-checked instead of re-trusted.

Comment-only change. `tsc --noEmit` clean.

*(Honest note on verification: `vitest` would not start in this worktree — its config hits a
`MODULE_NOT_FOUND` on a missing dependency, an environment fault, not a test failure. The
change touches only a comment block, and `tsc` parsed it.)*
