### PR TITLE
fix(kbli): a capital threshold is not a permit — inspect_kbli called 35 entity types "licenses"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 332 routers · 669 services
+- Backend: FastAPI · 332 routers · 670 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 33 · Packages: 6

--- a/apps/backend-rag/backend/app/routers/kbli_notebook.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook.py
@@ -25,6 +25,7 @@ from backend.app.dependencies import (
     get_search_service,
 )
 from backend.core.collection_registry import resolve_collection_name
+from backend.services.kbli_requires_kind import classify_requires_target
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,11 @@ class KBLIDetail(BaseModel):
     sector: str
     risk_profile: str
     licenses: list[KBLILicense]
+    # REQUIRES-edge targets that are NOT permits, bucketed by what they are
+    # (costs / durations / obligations / regulations / documents / entity_forms
+    # / immigration / systems / other). Additive and defaulted, so a cached
+    # payload written before this field existed still validates on read.
+    related_requirements: dict[str, list[str]] = {}
     related_codes: list[str] = []
     expert_legal: dict | None = None
 
@@ -387,9 +393,17 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
                 else node["properties"]
             )
 
-            # 3. Fetch Related Licenses (REQUIRES edges)
+            # 3. Fetch REQUIRES-edge targets.
+            #
+            # These are NOT all licences. The graph hangs costs, durations,
+            # obligations, regulations, company forms and the OSS system itself
+            # off the same relationship — 35 distinct target entity types were
+            # measured on prod. Rendering every one of them as a licence told a
+            # restaurant client that "10 Billion IDR" and "PT PMA" were permits
+            # to obtain. `entity_type` is now selected and classified; see
+            # `backend/services/kbli_requires_kind.py` for the reasoning.
             license_query = """
-                SELECT n.*, e.properties as edge_props
+                SELECT n.*, n.entity_type AS target_entity_type, e.properties as edge_props
                 FROM kg_nodes n
                 JOIN kg_edges e ON n.entity_id = e.target_entity_id
                 WHERE e.source_entity_id = $1 AND e.relationship_type = 'REQUIRES'
@@ -397,12 +411,24 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
             licenses_raw = await conn.fetch(license_query, f"kbli:{code}")
 
             licenses = []
+            related_requirements: dict[str, list[str]] = {}
             for lic in licenses_raw:
                 lic_props = (
                     json.loads(lic["properties"])
                     if isinstance(lic["properties"], str)
                     else lic["properties"]
                 )
+                # A node whose `properties` is a scalar (67 such rows exist for
+                # entity_type='kbli' alone) must not crash the lookup.
+                if not isinstance(lic_props, dict):
+                    lic_props = {}
+
+                kind = classify_requires_target(lic["target_entity_type"])
+                if kind != "license":
+                    # Kept, never silently dropped — bucketed so a reader can
+                    # still see what the graph attached to this code.
+                    related_requirements.setdefault(kind, []).append(lic["name"])
+                    continue
 
                 licenses.append(
                     KBLILicense(
@@ -413,6 +439,12 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
                         requirements=lic_props.get("kewajiban", []),
                     ),
                 )
+
+            # Stable order per bucket: the endpoint is cached, and a set-like
+            # jitter between calls would look like data churn to a consumer.
+            related_requirements = {
+                bucket: sorted(set(names)) for bucket, names in sorted(related_requirements.items())
+            }
 
             # 4. Fetch Related KBLI
             sector_query = """
@@ -475,6 +507,7 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
                 sector=sector_id.replace("sektor:", "") if sector_id else "N/A",
                 risk_profile=risk_profile,
                 licenses=licenses,
+                related_requirements=related_requirements,
                 related_codes=related_codes,
                 expert_legal=props.get("expert_legal"),
             )

--- a/apps/backend-rag/backend/services/kbli_requires_kind.py
+++ b/apps/backend-rag/backend/services/kbli_requires_kind.py
@@ -1,0 +1,123 @@
+"""What a REQUIRES edge out of a KBLI node actually points at.
+
+`inspect_kbli` built its `licenses[]` by walking every `REQUIRES` edge and
+appending the target node's *name* as a licence type, with no notion of what
+the target IS. The knowledge graph does not only hang permits off a KBLI code
+— it hangs costs, durations, obligations, regulations, company forms and the
+OSS system itself off the same relationship. Measured on prod, **35 distinct
+target entity types** reach that list.
+
+So the endpoint told a client opening a restaurant (`56101`) that the permits
+to obtain included:
+
+    "10 Billion IDR" · "2.5 Billion IDR" · "Rp 2.5 miliar" · "IDR 10 billion"
+    · "IDR 10 miliar" · "Rp10.000.000.000,00" · "Modal Disetor" · "PT PMA"
+
+— six renderings of the same two *capital thresholds*, plus the company form —
+and one entry whose obligations were "cara budi daya tanaman pangan yang baik"
+(good crop-cultivation practice) with reporting to the Minister of Agriculture,
+because a `permen` node describing farming practice is `REQUIRES`-linked to a
+restaurant code.
+
+A capital threshold is not a permit. Presenting one as a permit is the
+plausible-but-wrong assertion this navigator exists to eliminate.
+
+DESIGN — two rules, both learned the hard way in this repo:
+
+1. **Nothing is dropped silently.** Non-permit targets are not discarded; they
+   are bucketed and returned alongside, so the endpoint loses no information
+   and a reader can see what the graph actually attached. A cure that quietly
+   deletes 7,369 `dokumen` edges would be a second defect wearing the shape of
+   a fix.
+
+2. **An unknown type is never promoted.** The graph gains entity types over
+   time (this classification was derived from a census, and a census is a
+   snapshot). An unrecognised type therefore falls to `other` — visible, but
+   never asserted to be a permit. The failure mode is a missing badge, never an
+   invented licence. This is the fail-safe direction, and it is pinned by test.
+
+The classification is by ENTITY TYPE, never by matching substrings in the
+node's name — cicatrix family #3 has bitten this repo repeatedly on exactly
+that pattern, and the names here are precisely where the noise lives
+("NIB dan Izin (Izin Operasi Penyimpanan Karbon)" vs "Biaya izin ...").
+"""
+
+from __future__ import annotations
+
+# Types that genuinely denote something a business must OBTAIN — a permit, a
+# registration, a standards certificate, a formal determination. Verified
+# against the live node names, not assumed from the type label:
+#   perizinan   → "NIB dan Izin (IUJP)", "NIB dan Izin (Izin Eksplorasi ...)"
+#   izin_usaha  → "Akreditasi Rumah Sakit", "addendum Perizinan Berusaha"
+#   license     → "Izin", "NIB", "NPWP", "Sertifikat Standar"
+#   nib         → "NIB", "Nomor Induk Berusaha", "SERTIFIKAT STANDAR"
+#   permit_type → permit taxonomy nodes
+#   penetapan   → "Penetapan Pusat Penyedia" (a formal designation)
+PERMIT_TYPES: frozenset[str] = frozenset(
+    {
+        "perizinan",
+        "izin_usaha",
+        "license",
+        "nib",
+        "permit_type",
+        "penetapan",
+    },
+)
+
+# Everything else, bucketed so it stays visible. The bucket name is what a
+# reader of the API sees, so it is written for that reader, not for the graph.
+_BUCKETS: dict[str, str] = {
+    # Money. NEVER a permit — this is the defect that started this module.
+    "biaya": "costs",
+    # Time windows ("10 Hari", "1 Tahun") — an SLA or a validity, not a thing
+    # you apply for.
+    "jangka_waktu": "durations",
+    # Duties you carry once operating: reports, monitoring, guarantees.
+    "kewajiban": "obligations",
+    "kewajiban_perpajakan": "obligations",
+    "tanggung_jawab_sosial_lingkungan": "obligations",
+    "alih_teknologi": "obligations",
+    "sanksi": "obligations",
+    # The legal instruments themselves. A regulation is the SOURCE of a duty,
+    # never a permit to obtain — and `permen` is where the farming-practice
+    # text that surfaced on a restaurant lives.
+    "undang_undang": "regulations",
+    "peraturan_pemerintah": "regulations",
+    "permen": "regulations",
+    "perda": "regulations",
+    "surat_edaran": "regulations",
+    "pasal": "regulations",
+    # Papers you supply as evidence — required, but not licences.
+    "dokumen": "documents",
+    # Corporate form / counterparties.
+    "company_type": "entity_forms",
+    "pt_pmdn": "entity_forms",
+    "perusahaan": "entity_forms",
+    "organisasi": "entity_forms",
+    # Immigration artefacts travel their own path in this product.
+    "immigration_doc": "immigration",
+    "vitas": "immigration",
+    "kitas": "immigration",
+    # Systems and channels ("Online Single Submission", "NOT_APPLICABLE_OSS").
+    "oss": "systems",
+    "sistem": "systems",
+    "sistem_manajemen_usaha": "systems",
+}
+
+
+def classify_requires_target(entity_type: str | None) -> str:
+    """Return `"license"` for permit-bearing targets, else the bucket name.
+
+    Unknown / missing types fall to `"other"`: visible, never a licence.
+    """
+    if not entity_type:
+        return "other"
+    key = entity_type.strip().lower()
+    if key in PERMIT_TYPES:
+        return "license"
+    return _BUCKETS.get(key, "other")
+
+
+def is_permit_type(entity_type: str | None) -> bool:
+    """True only for target types that denote something to OBTAIN."""
+    return classify_requires_target(entity_type) == "license"

--- a/apps/backend-rag/backend/tests/unit/services/test_kbli_requires_kind.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_kbli_requires_kind.py
@@ -1,0 +1,168 @@
+"""A capital threshold is not a permit.
+
+`inspect_kbli` appended every REQUIRES-edge target to `licenses[]` using the
+target node's name, with no notion of what the target was. On `56101`
+(restaurant — one of the highest-traffic questions this product receives) a
+client was shown, as permits to obtain: six renderings of the same two capital
+thresholds, the company form "PT PMA", and an entry whose obligations were
+good crop-cultivation practice with reporting to the Minister of Agriculture.
+
+These tests pin BOTH directions, because a classifier that only proves guilt is
+how a cure becomes the next defect (cicatrix family #3): the permit types must
+still pass, and the non-permit types must not.
+"""
+
+import pytest
+
+from backend.services.kbli_requires_kind import (
+    PERMIT_TYPES,
+    classify_requires_target,
+    is_permit_type,
+)
+
+# The full census of REQUIRES-edge target types measured on prod
+# (source_entity_id LIKE 'kbli:%'), with the edge count, so a future reader can
+# see this was derived from the graph rather than imagined.
+PROD_TARGET_TYPES: dict[str, int] = {
+    "dokumen": 7369,
+    "perizinan": 3808,
+    "izin_usaha": 1935,
+    "license": 1167,
+    "kewajiban": 174,
+    "permen": 116,
+    "nib": 100,
+    "peraturan_pemerintah": 96,
+    "oss": 52,
+    "jangka_waktu": 47,
+    "biaya": 44,
+    "pt_pmdn": 26,
+    "company_type": 25,
+    "undang_undang": 20,
+    "penetapan": 10,
+    "permit_type": 9,
+    "perusahaan": 9,
+    "organisasi": 7,
+    "immigration_doc": 7,
+    "sistem": 7,
+    "fasilitas": 4,
+    "sistem_manajemen_usaha": 3,
+    "pekerja": 3,
+    "kbli": 3,
+    "entity": 3,
+    "parameter": 2,
+    "vitas": 1,
+    "jabatan": 1,
+    "kewajiban_perpajakan": 1,
+    "kitas": 1,
+    "perda": 1,
+    "sanksi": 1,
+    "surat_edaran": 1,
+    "tanggung_jawab_sosial_lingkungan": 1,
+    "alih_teknologi": 1,
+}
+
+
+# --- GUILT: the types that produced the live defect must not be licences ----
+
+@pytest.mark.parametrize(
+    ("entity_type", "expected_bucket"),
+    [
+        ("biaya", "costs"),  # "10 Billion IDR", "Rp10.000.000.000,00"
+        ("company_type", "entity_forms"),  # "PT PMA"
+        ("permen", "regulations"),  # "Cara budi daya tanaman pangan yang baik"
+        ("jangka_waktu", "durations"),  # "10 Hari", "1 Tahun"
+        ("kewajiban", "obligations"),  # "Laporan Hasil Monitoring"
+        ("undang_undang", "regulations"),
+        ("peraturan_pemerintah", "regulations"),
+        ("dokumen", "documents"),  # "Akta Pendirian"
+        ("oss", "systems"),  # "Online Single Submission"
+        ("sanksi", "obligations"),
+    ],
+)
+def test_non_permit_types_are_never_licences(entity_type: str, expected_bucket: str) -> None:
+    assert not is_permit_type(entity_type)
+    assert classify_requires_target(entity_type) == expected_bucket
+
+
+def test_the_capital_threshold_defect_specifically() -> None:
+    """Pin the exact shape that reached a client on 56101."""
+    assert classify_requires_target("biaya") == "costs"
+    assert "biaya" not in PERMIT_TYPES
+
+
+# --- INNOCENCE: real permits must still reach licenses[] -------------------
+
+@pytest.mark.parametrize(
+    "entity_type",
+    ["perizinan", "izin_usaha", "license", "nib", "permit_type", "penetapan"],
+)
+def test_permit_types_still_pass(entity_type: str) -> None:
+    """The three biggest permit buckets carry 6,910 of the edges between them.
+
+    A cure that suppressed these would empty the licence list on most codes —
+    a different failure, not a fix.
+    """
+    assert is_permit_type(entity_type)
+    assert classify_requires_target(entity_type) == "license"
+
+
+def test_case_and_whitespace_do_not_change_the_verdict() -> None:
+    assert is_permit_type("  Perizinan ")
+    assert not is_permit_type("BIAYA")
+
+
+# --- FAIL-SAFE: an unknown type is visible, never promoted ------------------
+
+@pytest.mark.parametrize("entity_type", [None, "", "   ", "a_type_invented_next_year"])
+def test_unknown_types_fall_to_other_and_are_never_licences(entity_type: str | None) -> None:
+    """The graph gains types over time; this classification is a snapshot.
+
+    The failure mode must be a missing badge, never an invented licence.
+    """
+    assert classify_requires_target(entity_type) == "other"
+    assert not is_permit_type(entity_type)
+
+
+# --- COVERAGE: every type actually observed on prod has a verdict ----------
+
+def test_every_prod_target_type_is_classified() -> None:
+    """`other` is a legitimate destination, but it should be a decision.
+
+    Any type here that lands in `other` is one nobody has adjudicated — this
+    test does not fail on that (the fail-safe already covers the risk), it
+    reports them, so the list stays honest as the graph grows.
+    """
+    unadjudicated = sorted(
+        t for t in PROD_TARGET_TYPES if classify_requires_target(t) == "other"
+    )
+    # These are the tail types (≤7 edges each) deliberately left to `other`:
+    # they are neither permits nor cleanly bucketable, and `other` states that.
+    assert unadjudicated == [
+        "entity",
+        "fasilitas",
+        "jabatan",
+        "kbli",
+        "parameter",
+        "pekerja",
+    ], f"the `other` set changed: {unadjudicated}"
+
+
+def test_the_permit_set_is_a_minority_of_types_but_the_majority_of_edges() -> None:
+    """Sanity on the shape of the fix: it must not gut the licence list.
+
+    Of the 35 observed types only 6 are permits — but they carry **7,029 of the
+    15,055** edges (46.7%), so nearly half of what the endpoint used to call a
+    licence really was one. The other 8,026 were not, and `dokumen` alone
+    (7,369) is the single largest non-permit bucket — which is why those go to
+    `documents` rather than being dropped.
+
+    (These totals are asserted rather than described because the first draft of
+    this test carried a hand-summed 14,875 and the test caught it. A number in
+    a docstring is a claim; a number in an assert is a measurement.)
+    """
+    permit_edges = sum(n for t, n in PROD_TARGET_TYPES.items() if is_permit_type(t))
+    total_edges = sum(PROD_TARGET_TYPES.values())
+    assert permit_edges == 7029
+    assert total_edges == 15055
+    assert total_edges - permit_edges == 8026
+    assert permit_edges > total_edges / 3

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`332 routers · 669 services · 1268 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`332 routers · 670 services · 1269 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## A capital threshold is not a permit

`inspect_kbli` walked every `REQUIRES` edge out of a KBLI node and appended the target's
**name** to `licenses[]`, with no notion of what the target *was*. The graph does not only hang
permits off a KBLI code. Measured on prod: **35 distinct target entity types** reach that list,
and **8,026 of the 15,055 edges are not permits at all**.

### What a restaurant client was shown

`56101` — one of the highest-traffic questions this product receives — returned **23 "licenses"**.
Eight of them were not licences:

| target type | rendered as a permit to obtain |
|---|---|
| `biaya` ×7 | `10 Billion IDR` · `2.5 Billion IDR` · `Rp 2.5 miliar` · `IDR 10 billion` · `IDR 10 miliar` · `Modal Disetor` · `Rp10.000.000.000,00` |
| `company_type` ×1 | `PT PMA` |

Six renderings of the same two **capital thresholds**, plus the **company form**, presented as
things to apply for.

### The cure

Classify by **entity type**, never by matching substrings in the node name — the names are
exactly where the noise lives (`"NIB dan Izin (Izin Operasi Penyimpanan Karbon)"` vs
`"Biaya izin ..."`, both containing "izin"). Two rules this repo has already paid for:

1. **Nothing is dropped.** Non-permit targets are bucketed into a new additive
   `related_requirements` field (`costs` / `durations` / `obligations` / `regulations` /
   `documents` / `entity_forms` / `immigration` / `systems` / `other`). Quietly deleting 7,369
   `dokumen` edges would be a second defect wearing the shape of a fix.
2. **An unknown type is never promoted.** The graph gains types over time and this
   classification is a snapshot, so an unrecognised type falls to `other` — visible, never
   asserted to be a permit. The failure mode is a missing badge, never an invented licence.

**Effect on `56101`, computed from the real edge set:** `licenses[]` goes **23 → 9**
(4 `izin_usaha` + 1 `license` + 4 `perizinan`). The four `perizinan` rows share a name but carry
different `skala_usaha` (Mikro / Kecil / Menengah / Besar) — they are legitimately distinct and
are deliberately **not** deduplicated.

### What this does NOT fix — stated so nobody assumes it does

The same `56101` response carries obligations about *"cara budi daya tanaman pangan yang baik"*
with reporting to the **Minister of Agriculture**, on a restaurant. That is **not** a mis-typed
edge: it lives in the `kewajiban` property of a legitimate `perizinan` node named
`"NIB dan Sertifikat Standar"`, which this classifier correctly keeps. Contamination *inside* a
permit node is a separate defect on a separate axis and survives this PR untouched.

*(An earlier draft of the commit message blamed a `permen` node for that text. Verified against
the edge set: `56101` has no `permen` edge at all. Corrected before the branch was pushed.)*

### Verification

**24 tests.** Guilt on every type that produced the live defect (`biaya`, `company_type`,
`permen`, `jangka_waktu`, `kewajiban`, regulations, `dokumen`, `oss`, `sanksi`). Innocence on all
six permit types — they carry **7,029 edges (46.7%)**, so a cure that suppressed them would empty
the licence list on most codes rather than fix it. Fail-safe on `None` / blank / a type invented
next year. A coverage pin over the full 35-type prod census, so a new type shows up in `other`
rather than silently becoming a licence.

One number in that test was hand-summed wrong (14,875 for what is really 15,055) and **the test
caught it** — the totals are now asserted rather than described, which is the point: a number in
a docstring is a claim, a number in an `assert` is a measurement.

Also hardens a latent crash: a node whose `properties` is a **scalar** rather than an object
(67 such rows exist for `entity_type='kbli'` alone) no longer reaches `.get()`.

DOCSYNC regenerated in the same commit per W86.
