### PR TITLE
fix(tests): kill non-deterministic collection — the pytest-xdist blocker

### DIFF
--- a/apps/backend-rag/backend/tests/compliance/test_no_clock_in_parametrize.py
+++ b/apps/backend-rag/backend/tests/compliance/test_no_clock_in_parametrize.py
@@ -22,6 +22,18 @@ starts life green rather than as a backlog.
 
 Scope note: the ban is on decorator arguments only. Reading the clock inside a
 test, a fixture, or a helper is normal and must keep passing.
+
+Extended 2026-07-27 to cover the clock's twin: random/UUID values in the same
+position. Found while probing pytest-xdist for `backend/tests/` — the same
+mechanism (evaluated once at collection) breaks a DIFFERENT thing for a
+random source than for a clock. A frozen timestamp ages; a frozen UUID is
+merely wrong-but-stable within a single process, so it never bit the
+single-process suite. It bites `-n auto`: each xdist worker is a separate
+process, so a `uuid.uuid4()` read at collection mints a different value per
+worker, giving each worker a different generated test ID for the same
+logical test — pytest-xdist refuses the entire run with "Different tests
+were collected between gwN and gwM" before executing a single test. See
+`_NONDETERMINISTIC_NAMES` below for the guard's own docstring on this half.
 """
 
 from __future__ import annotations
@@ -44,6 +56,61 @@ _TEST_ROOTS = (
 _CLOCK_ATTRS = frozenset(
     {"now", "utcnow", "today", "time", "monotonic", "perf_counter"}
 )
+
+# The clock's twin (2026-07-27, found while probing pytest-xdist): a decorator
+# argument that mints a RANDOM value is non-deterministic in the same way a
+# clock read is, and it breaks something the clock case did not. pytest-xdist
+# requires every worker to collect a byte-identical test list; each worker is a
+# separate Python process, so a `uuid.uuid4()` in a parametrize list produces a
+# different value — and therefore a different generated test ID — per worker.
+# xdist then refuses the whole run with "Different tests were collected between
+# gw2 and gw3", before executing a single test. Measured live: three sites in
+# backend/tests/routers/test_intake_review.py, 22 differing collection lines
+# across two plain processes.
+#
+# Matched on BOTH a bare name (`uuid4()` after `from uuid import uuid4`) and an
+# attribute (`uuid.uuid4()`), unlike the clock set above which only matches the
+# attribute form — these names are distinctive enough that a bare call is not
+# plausibly a local helper, whereas a bare `time()` could be.
+_NONDETERMINISTIC_NAMES = frozenset(
+    {
+        "uuid1",
+        "uuid4",
+        "random",
+        "randint",
+        "randrange",
+        "choice",
+        "shuffle",
+        "sample",
+        "getrandbits",
+        "token_hex",
+        "token_bytes",
+        "token_urlsafe",
+    }
+)
+
+
+def _nondeterministic_calls_in_decorators(source: str) -> list[int]:
+    """Line numbers of random-value reads inside any decorator expression."""
+    tree = ast.parse(source)
+    found: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            continue
+        for decorator in node.decorator_list:
+            for sub in ast.walk(decorator):
+                if not isinstance(sub, ast.Call):
+                    continue
+                name = None
+                if isinstance(sub.func, ast.Attribute):
+                    name = sub.func.attr
+                elif isinstance(sub.func, ast.Name):
+                    name = sub.func.id
+                if name in _NONDETERMINISTIC_NAMES:
+                    found.append(sub.lineno)
+    return sorted(set(found))
 
 
 def _clock_calls_in_decorators(source: str) -> list[int]:
@@ -154,5 +221,109 @@ def test_no_test_decorator_reads_the_clock() -> None:
         "frozen there ages while the rest of the suite runs and the case starts "
         "failing for how long the suite took (see this file's docstring). "
         "Parametrize an offset and build the absolute time inside the test:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_guard_flags_a_random_uuid_in_parametrize() -> None:
+    """GUILT: the exact shape that broke pytest-xdist collection.
+
+    Live case, `backend/tests/routers/test_intake_review.py`: a bare
+    `f"...{uuid.uuid4()}"` inside a parametrize list. Minted once per Python
+    process at collection time — a different value (and therefore a
+    different generated test ID) in every xdist worker.
+    """
+    guilty = textwrap.dedent(
+        """
+        import uuid
+
+        import pytest
+
+        @pytest.mark.parametrize(
+            "release_url",
+            [f"/api/intake/review/42/release?claim_token={uuid.uuid4()}"],
+        )
+        def test_release(release_url):
+            assert release_url
+        """
+    )
+    assert _nondeterministic_calls_in_decorators(guilty) == [8]
+
+
+def test_guard_flags_a_bare_import_of_the_random_call() -> None:
+    """GUILT (bare-name form): `from uuid import uuid4` then a naked call."""
+    guilty = textwrap.dedent(
+        """
+        from uuid import uuid4
+
+        import pytest
+
+        @pytest.mark.parametrize("token", [str(uuid4())])
+        def test_token(token):
+            assert token
+        """
+    )
+    assert _nondeterministic_calls_in_decorators(guilty) == [6]
+
+
+def test_guard_does_not_flag_random_values_inside_a_test_or_fixture() -> None:
+    """INNOCENCE: minting a fresh UUID per test run is the correct pattern.
+
+    This is the post-fix shape of the live offender — parametrize carries a
+    FIXED constant (still a syntactically valid, deliberately-wrong token,
+    so semantics are preserved), the fresh one is built inside the test body
+    where it is re-evaluated for every worker/run and never poisons
+    collection.
+    """
+    innocent = textwrap.dedent(
+        """
+        import uuid
+
+        import pytest
+
+        @pytest.fixture
+        def claim_token():
+            return uuid.uuid4()
+
+        @pytest.mark.parametrize(
+            "release_url",
+            ["/api/intake/review/42/release?claim_token=00000000-0000-0000-0000-000000000000"],
+        )
+        def test_release(release_url, claim_token):
+            assert release_url
+            assert claim_token
+        """
+    )
+    assert _nondeterministic_calls_in_decorators(innocent) == []
+
+
+def test_no_test_decorator_reads_a_random_value() -> None:
+    """The real sweep over both collected test trees, random-value twin."""
+    sources = _iter_test_sources()
+    assert len(sources) > 100, (
+        f"expected to scan the whole backend test tree, found {len(sources)} "
+        f"files under {[str(r) for r in _TEST_ROOTS]} — the roots are wrong"
+    )
+
+    offenders: list[str] = []
+    for path in sources:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):  # pragma: no cover - unreadable file
+            continue
+        try:
+            lines = _nondeterministic_calls_in_decorators(source)
+        except SyntaxError:  # pragma: no cover - not this guard's job to police
+            continue
+        for line in lines:
+            offenders.append(f"{path.relative_to(_BACKEND_RAG_ROOT)}:{line}")
+
+    assert not offenders, (
+        "a decorator argument is evaluated once at COLLECTION — a random/UUID "
+        "value minted there is a different value (and therefore a different "
+        "generated test ID) in every process, which is exactly what makes "
+        "pytest-xdist refuse the run with 'Different tests were collected "
+        "between gwN and gwM'. Use a fixed constant in parametrize and mint "
+        "the real random value inside the test body:\n  "
         + "\n  ".join(offenders)
     )

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -38,6 +38,20 @@ ADMIN = {"id": "1", "email": "zero@balizero.com", "role": "admin"}
 TEAM_OWNER = {"id": "2", "email": "owner@balizero.com", "role": "user"}
 TEAM_OTHER = {"id": "3", "email": "other@balizero.com", "role": "user"}
 
+# A syntactically valid but wrong claim token — good enough anywhere a
+# parametrize list needs "some token" or "a token guaranteed not to match a
+# real one" (its version nibble is 0, so no `uuid.uuid4()` call can ever
+# produce it). NOT `uuid.uuid4()`: a decorator argument is evaluated ONCE, at
+# collection, in whichever process pytest-xdist forked for that worker — a
+# fresh random value there mints a different value (and therefore a
+# different generated test ID) in every worker, and xdist refuses the whole
+# run with "Different tests were collected between gwN and gwM" before
+# running a single test. Twin of the `datetime.now()`-in-parametrize bug
+# fixed in this same file (see the comment above
+# test_active_claim_guard_rejects_missing_expired_foreign_and_malformed_claims);
+# both are guarded by backend/tests/compliance/test_no_clock_in_parametrize.py.
+_FIXED_CLAIM_TOKEN = "00000000-0000-0000-0000-000000000000"
+
 
 pytestmark = pytest.mark.asyncio
 
@@ -243,10 +257,10 @@ async def test_own_chat_guard_fails_closed_without_both_email_identities(
         ("GET", "/api/intake/review/42", None),
         ("GET", "/api/intake/review/42/blob", None),
         ("POST", "/api/intake/review/42/claim", None),
-        ("POST", f"/api/intake/review/42/release?claim_token={uuid.uuid4()}", None),
+        ("POST", f"/api/intake/review/42/release?claim_token={_FIXED_CLAIM_TOKEN}", None),
         ("POST", "/api/intake/review/42/recover", None),
-        ("POST", "/api/intake/review/42/approve", {"claim_token": str(uuid.uuid4())}),
-        ("POST", "/api/intake/review/42/reject", {"claim_token": str(uuid.uuid4())}),
+        ("POST", "/api/intake/review/42/approve", {"claim_token": _FIXED_CLAIM_TOKEN}),
+        ("POST", "/api/intake/review/42/reject", {"claim_token": _FIXED_CLAIM_TOKEN}),
     ],
 )
 async def test_review_endpoints_reject_non_admin_without_email_before_database_access(
@@ -617,7 +631,7 @@ async def test_claim_steal_expired_lease(pool, seed):
         (timedelta(minutes=-1), TEAM_OWNER["email"], None, 409),
         (timedelta(minutes=5), TEAM_OTHER["email"], None, 403),
         (timedelta(minutes=5), TEAM_OWNER["email"], "not-a-uuid", 400),
-        (timedelta(minutes=5), " ", str(uuid.uuid4()), 403),
+        (timedelta(minutes=5), " ", _FIXED_CLAIM_TOKEN, 403),
     ],
 )
 async def test_active_claim_guard_rejects_missing_expired_foreign_and_malformed_claims(
@@ -753,7 +767,7 @@ async def test_approve_live_claim_owned_by_other_rejected_without_write(pool, se
 
 @pytest.mark.parametrize(
     ("claim_token", "expected_status"),
-    [("not-a-uuid", 400), (str(uuid.uuid4()), 403)],
+    [("not-a-uuid", 400), (_FIXED_CLAIM_TOKEN, 403)],
 )
 async def test_approve_rejects_malformed_and_wrong_claim_tokens(
     pool,

--- a/apps/backend-rag/backend/tests/services/crm/test_practice_state_machine.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_practice_state_machine.py
@@ -115,7 +115,16 @@ class TestInvalidTransitions:
 class TestSameStateNoop:
     """Same state transitions should always pass (no-op)."""
 
-    @pytest.mark.parametrize("state", list(ALL_STATES))
+    # sorted(), not list(): ALL_STATES is a frozenset, and frozenset iteration
+    # order depends on PYTHONHASHSEED — a decorator argument is evaluated ONCE,
+    # at collection, in whichever process pytest-xdist forked for that worker.
+    # Measured live: PYTHONHASHSEED=1 vs 999 on this file alone produced 11
+    # diff lines (same 44 tests, different generated test IDs) — the exact
+    # shape that makes pytest-xdist refuse a run with "Different tests were
+    # collected between gwN and gwM". Production's ALL_STATES stays a
+    # frozenset (backend/services/crm/practice_state_machine.py) — only the
+    # test-collection order needs to be fixed.
+    @pytest.mark.parametrize("state", sorted(ALL_STATES))
     def test_same_state_is_noop(self, state: str) -> None:
         assert validate_transition(state, state) is True
 


### PR DESCRIPTION
## What

Two sites in the backend test tree mint a value **at import time inside a `@pytest.mark.parametrize` list**. pytest evaluates decorator arguments **once, at collection**, in whichever process is collecting — so the value is frozen per-process.

A single-process run never notices: the value is merely frozen, not wrong. `pytest-xdist` does notice. Each worker is a separate Python process, so the same logical test gets a **different generated test ID in every worker**, and xdist refuses the entire run with `Different tests were collected between gwN and gwM` before executing a single test.

This is the blocking prerequisite for parallelising the suite — it is not itself the parallelisation.

## The two sites

| File | Site | Defect |
|---|---|---|
| `backend/tests/routers/test_intake_review.py` | 246, 248, 249, 620, 756 | `uuid.uuid4()` in parametrize lists → different token per process |
| `backend/tests/services/crm/test_practice_state_machine.py` | 118 | `list(ALL_STATES)` over a **frozenset** → iteration order depends on `PYTHONHASHSEED` |

The sweep found **5** UUID sites, not the 3 first identified: 246/620/756 affect the generated ID, while 248/249 are dict-embedded and render as `json_body6/7`. The dict ones do **not** change the pytest ID — they were fixed anyway rather than carving a "only if it reaches the ID" exception into the guard, which would have been a fragile predicate on form rather than on the defect.

Production's `ALL_STATES` stays a `frozenset` (`backend/services/crm/practice_state_machine.py:35`); only the test's collection order is pinned.

## Guard: extended, not duplicated

`backend/tests/compliance/test_no_clock_in_parametrize.py` was written **earlier the same day** for the identical defect class in the identical position — `datetime.now()` in a parametrize list, in this very same intake file. Its subject was the clock; this finding is its twin. So the existing guard was **extended** rather than a parallel guard stood up next to it.

The twin breaks something the clock case did not, which is why it stayed latent: a frozen timestamp **ages** (and eventually fails a single-process run, which is how the clock one was caught), whereas a frozen UUID is wrong-but-stable within one process and therefore invisible until there are several.

Matched on **both** call forms — `uuid.uuid4()` (attribute) and a bare `uuid4()` after `from uuid import uuid4` (name) — unlike the clock half, which matches the attribute form only. Deliberate asymmetry, documented in the source: these names are distinctive enough that a bare call is not plausibly a local helper, whereas a bare `time()` could be.

Per `cicatrix-superscar.md` #3 (*"nessuna guardia mergiata senza un test di innocenza E di colpevolezza"*) the new half ships with both, and with the innocence case being the **post-fix shape of the real offender**:

- **guilt** — the live `f"...{uuid.uuid4()}"` shape, and the bare-import `uuid4()` shape
- **innocence** — a fixture that mints a fresh UUID per test, plus parametrize carrying a fixed constant; neither may be flagged
- **blind-scan guard** — the tree sweep asserts it walked >100 files, so wrong roots fail loudly instead of passing green (W84 class: 0 files traversed ≠ clean)

No entry needed in `infra/guard-conformance/registry.json`: that registry censuses the runtime `_guard_*` reply guards in `scripts/openclaw_whatsapp_bridge.py`, not compliance tests. Verified, not assumed.

## Acceptance — measured, both halves

1. **Cross-process**: two independent `--collect-only` runs of the full tree, diffed → only the timing line differs. 20989 tests, 20991 lines each. (Before: 22 differing node-id lines.)
2. **The behavioural check, which had been deferred**: full tree collected under `PYTHONHASHSEED=1` vs `PYTHONHASHSEED=4242`, diffed → identical, again only the timing line. This is the half that catches classes no AST pattern anticipates, so it was worth doing now rather than filing.

Trap worth recording for whoever repeats this: **do not pass `-q`**. `pytest.ini` `addopts` already contains it, so an extra one makes `-qq`, which prints per-file *counts* instead of node ids — a diff of two `-qq` runs is silently empty and looks like proof.

## Not in this PR

`-n auto` itself. Its prerequisites were measured and none are satisfied yet:

- **`pytest-xdist` is not in CI.** `.github/workflows/tests.yml:155` installs `pytest pytest-cov pytest-asyncio pytest-mock fakeredis`, and pytest-xdist appears in no requirements or lock file. It is present locally (3.8.0), which means a local `-n` probe proves nothing about CI. It must be added, pinned.
- **One DB, not N.** CI builds a single `nuzantara_test` (`tests.yml:200`); per-worker isolation needs template clones plus a conftest deriving the URL from `PYTEST_XDIST_WORKER`.
- **`-x` and `--cov`** both sit on the 18-minute step (`tests.yml:223`) and interact with xdist (fail-fast timing, coverage combining). To be re-checked, not assumed.

## Test plan

```
PYTHONPATH=. pytest backend/tests/compliance/test_no_clock_in_parametrize.py -q   # 8/8
PYTHONPATH=. pytest backend/tests/services/crm/test_practice_state_machine.py -q  # 44/44
PYTHONPATH=. pytest backend/tests/routers/test_intake_review.py -q                # 33 passed, 42 skipped (no local intake DB)
```

Full pre-push suite ran on this exact commit and passed; the path-aware classifier correctly demanded the FULL suite (3/3 changed files off the innocent allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
