### PR TITLE
fix(rag): turn Phase-6 multi-agent OFF by default — it invented a fee in prod

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
@@ -152,6 +152,48 @@ _CURATED_QA_TOP_K = 2
 # threshold — safe only because injection is now domain-filtered (below).
 _CURATED_QA_SCORE_THRESHOLD = float(os.getenv("CURATED_QA_SCORE_THRESHOLD", "0.58"))
 
+# Phase-6 multi-agent coordination — DEFAULT OFF since 2026-07-27.
+#
+# The branch it guards (see `requires_multi_agent` below in process_query_core)
+# returns a CoreResult with a hardcoded `sources=[]`, and returns it BEFORE the
+# abstain gate and before the only `_log_query_analytics` call. So its answers
+# carry no citations, cannot abstain, and are invisible to `query_analytics` —
+# which holds 6771 rows and not one `multi-agent-coordinator` (that measures the
+# blindness, not the rarity: the row is never written).
+#
+# Measured live in prod on 2026-07-27, asking the cost AND timeline of an E23
+# KITAS — the exact shape `requires_multi_agent` is built to catch: the reply
+# came back `sources=[] context_length=0 evidence_score=0 abstain=false` and
+# asserted a government fee reaching "IDR 1.2 billion" beside the real
+# PricingTool figure, split the all-inclusive price against the 2026-07-17
+# ruling, and invented a 38-60 day phase breakdown matching TimelineAgent's
+# prompt template ("1. Document preparation: X days") line for line. With an
+# empty grounding block `_synthesize_outputs` degrades to "be specific" and
+# nothing on the path can answer "I don't know".
+#
+# REJECTED ALTERNATIVE (adversarial review, 2026-07-27): gating the branch on a
+# non-empty curated_qa hit instead of a flag. It reads as a safety gate but is
+# a silent deletion — `research/operations/2026-07-17-full-domain-cache-design.md`
+# makes price-adjacent questions ("how much does X cost") explicitly OUT of
+# scope for that corpus, so for this branch's own trigger population a curated
+# hit is structurally unlikely. Disabling a feature honestly beats disabling it
+# by side effect while claiming behaviour is preserved.
+#
+# Turning this back on is not a flag flip alone: the branch first needs to
+# carry a real evidence bundle (its own sources) and pass through the same
+# finalization as every other answer, so it can be scored, can abstain, and
+# gets logged. Until then the queries fall through to the ReAct loop, which
+# retrieves, abstains, and is measured. Set MULTI_AGENT_COORDINATOR_ENABLED=true
+# to restore the old behaviour verbatim.
+_MULTI_AGENT_COORDINATOR_ENABLED = os.getenv(
+    "MULTI_AGENT_COORDINATOR_ENABLED",
+    "false",
+).strip().lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
 
 class OrchestratorCore:
     """
@@ -1233,8 +1275,15 @@ class OrchestratorCore:
         if curated_qa_context:
             system_context_for_prompt += curated_qa_context
 
-        # 3b. Phase 6: Check if multi-agent coordination is needed
-        if self._multi_agent_coordinator and requires_multi_agent(query):
+        # 3b. Phase 6: Check if multi-agent coordination is needed.
+        # OFF by default — see _MULTI_AGENT_COORDINATOR_ENABLED for why (it
+        # answered with no sources, could not abstain, and fabricated a fee in
+        # prod). When enabled, everything below is unchanged.
+        if (
+            _MULTI_AGENT_COORDINATOR_ENABLED
+            and self._multi_agent_coordinator
+            and requires_multi_agent(query)
+        ):
             try:
                 logger.info("🔀 [Phase 6] Multi-agent query detected, delegating to coordinator")
                 ma_result = await self._multi_agent_coordinator.process(

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/WAVE2_NOTES.md
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/WAVE2_NOTES.md
@@ -8,21 +8,21 @@
 
 ## Outcome summary
 
-| Area | Status | Tests added | Source LOC changed |
-|------|--------|-------------|--------------------|
-| O2 QueryPlanner active | ✅ | 1 | 0 (no code change) |
-| O9 MultiAgent fast-path | ✅ | 1 | 0 |
-| O10 MultiAgent exception fallback | ✅ | 1 | 0 |
-| O11 SpecializedServiceRouter (3 branches) | ✅ | 3 | 0 |
-| O13-partial NLM task creation / skip | ✅ | 2 | 0 |
-| O16-sync ReAct raise propagation | ✅ | 2 | 0 |
-| O20 Cautious NLM await + merge | ✅ | 1 | 0 |
-| O21 Non-cautious NLM cancel (I-O4) | ✅ | 1 | 0 |
-| O24 KG Auto-Expansion gate | ✅ | 2 (pos + neg) | 0 |
-| **U1** Tier1 narrow exception | ✅ Docstring + 2 tripwire | 2 | +9 (docstring) |
-| **U3** NLM cancel-path swallow | ✅ Log visibility | 0 | +14 (logging) |
-| **U5** Stream vs non-stream unification | ✅ Option A helper | 5 | +54 net (extract + rewire) |
-| **U6** Parallel step overshoot | ✅ In-code invariant comment | 0 | +10 (docstring) |
+| Area                                      | Status                       | Tests added   | Source LOC changed         |
+| ----------------------------------------- | ---------------------------- | ------------- | -------------------------- |
+| O2 QueryPlanner active                    | ✅                           | 1             | 0 (no code change)         |
+| O9 MultiAgent fast-path                   | ✅                           | 1             | 0                          |
+| O10 MultiAgent exception fallback         | ✅                           | 1             | 0                          |
+| O11 SpecializedServiceRouter (3 branches) | ✅                           | 3             | 0                          |
+| O13-partial NLM task creation / skip      | ✅                           | 2             | 0                          |
+| O16-sync ReAct raise propagation          | ✅                           | 2             | 0                          |
+| O20 Cautious NLM await + merge            | ✅                           | 1             | 0                          |
+| O21 Non-cautious NLM cancel (I-O4)        | ✅                           | 1             | 0                          |
+| O24 KG Auto-Expansion gate                | ✅                           | 2 (pos + neg) | 0                          |
+| **U1** Tier1 narrow exception             | ✅ Docstring + 2 tripwire    | 2             | +9 (docstring)             |
+| **U3** NLM cancel-path swallow            | ✅ Log visibility            | 0             | +14 (logging)              |
+| **U5** Stream vs non-stream unification   | ✅ Option A helper           | 5             | +54 net (extract + rewire) |
+| **U6** Parallel step overshoot            | ✅ In-code invariant comment | 0             | +10 (docstring)            |
 
 **Total new tests:** 21 (14 outer pipeline + 2 U1 tripwire + 5 U5 helper unit tests).
 **Total LOC changed:** ~87 additions, ~25 deletions in source (reasoning.py + _reasoning_policy.py + orchestrator_core.py).
@@ -46,9 +46,15 @@ returns a shared `_stub_final_state` that individual tests mutate in-place
 KG-expansion paths.
 
 Notable points:
+
 - **O9/O10** use the real `requires_multi_agent` detection (cost + timeline
-  keywords), no monkey-patching — we actually trigger the branch with a real
-  query string, confirming the entry-point predicate still works.
+  keywords) — we actually trigger the branch with a real query string,
+  confirming the entry-point predicate still works. Since 2026-07-27 the branch
+  is OFF by default (`_MULTI_AGENT_COORDINATOR_ENABLED`), so both tests enable
+  it explicitly via `patch.object`; that is the ONLY monkey-patching, and it
+  turns the feature on rather than faking the evidence that would let the
+  branch be entered. The default-off path has its own test
+  (`test_multi_agent_is_off_by_default_and_falls_through_to_react`).
 - **O20 (cautious merge)** uses a real `asyncio.create_task`-spawning
   coroutine (not a pre-resolved Future) so the `asyncio.wait_for(nlm_task)`
   path inside `process_query_core` is exercised for real.
@@ -65,6 +71,7 @@ Notable points:
 File: `test_abstain_bypass_policy.py` — new class `TestApplySharedTrustedFlippers` appended.
 
 Locks the contract of the new helper:
+
 - Early-True preserved (never flips True→False).
 - Pricing marker flips True on empty-tools gateway.
 - Has-tools + final_answer flips True without pricing.
@@ -76,6 +83,7 @@ Locks the contract of the new helper:
 File: `test_orchestrator_state_machine_wave2.py` — class `TestTier1RegenExceptionContract`.
 
 Locks the narrow catch on Tier1 regen:
+
 - ServiceUnavailable (in tuple) → abstain stub fallback (I-R2 preserved).
 - TypeError (NOT in tuple) → propagates → wrapped as `RuntimeError("ReAct loop failed: ...")` by `orchestrator_core.execute_react_loop`.
 
@@ -87,7 +95,7 @@ tuple, the first test (and the pre-existing Wave 1 test) fails.
 
 ## U5 decision: Option A — minimal helper extraction
 
-**Chosen:** partial Option A. Extract the *shared* portion only; document the
+**Chosen:** partial Option A. Extract the _shared_ portion only; document the
 stream-only pre-flippers as intentional widening.
 
 ### Rationale
@@ -107,11 +115,12 @@ streaming author didn't intend. Hiding the divergence behind a
 drift.
 
 Instead, we extracted **only the pair that IS identical** (pricing-in-answer
-+ LLM-had-tools) into `apply_shared_trusted_flippers(trusted_tools_used,
+
+- LLM-had-tools) into `apply_shared_trusted_flippers(trusted_tools_used,
 final_answer, llm_gateway) -> bool`. Both pipelines now call this helper,
-so that pair cannot drift. The stream-only pre-flippers stay in
-`execute_react_loop_stream` with a long docstring flagging them as a
-deliberate streaming-only widening with a cross-reference to this note.
+  so that pair cannot drift. The stream-only pre-flippers stay in
+  `execute_react_loop_stream` with a long docstring flagging them as a
+  deliberate streaming-only widening with a cross-reference to this note.
 
 ### What Option A delivered
 
@@ -164,6 +173,7 @@ hide real programmer errors (`TypeError`, `KeyError`, `AttributeError`)
 behind a graceful-looking abstain stub.
 
 The two tripwire tests fail loudly if either direction is changed:
+
 - `test_tier1_regen_service_unavailable_caught_and_stubbed` — narrowing
   breaks this.
 - `test_tier1_regen_typeerror_propagates_as_runtime` — widening to
@@ -190,6 +200,7 @@ response) while making a misbehaving NLM provider diagnosable with
 
 Kept the `state.current_step += len(tool_calls) - 1` as-is. Added a multi-line
 comment above the statement that:
+
 - Calls out the §U6 flag in docs/audits/2026-04-22-orchestrator-state-machine.md.
 - Explains the budget-enforcement intent (5 parallel tools = 5 units consumed
   even if all run in one physical iteration).
@@ -228,13 +239,13 @@ will see the rationale before touching it.
 
 ## Test results
 
-| Suite | Before Wave 2 | After Wave 2 | Delta |
-|-------|---------------|--------------|-------|
-| `test_orchestrator_state_machine_wave1.py` | 15 pass | 15 pass | 0 |
-| `test_orchestrator_coverage.py` | 37 pass / 7 skip | 37 pass / 7 skip | 0 |
-| `test_reasoning*.py` | — | — | 0 regressions |
-| `test_abstain_bypass_policy.py` | 31 pass | 36 pass | +5 |
-| `test_orchestrator_state_machine_wave2.py` | — | **16 pass** | +16 |
+| Suite                                       | Before Wave 2      | After Wave 2           | Delta                 |
+| ------------------------------------------- | ------------------ | ---------------------- | --------------------- |
+| `test_orchestrator_state_machine_wave1.py`  | 15 pass            | 15 pass                | 0                     |
+| `test_orchestrator_coverage.py`             | 37 pass / 7 skip   | 37 pass / 7 skip       | 0                     |
+| `test_reasoning*.py`                        | —                  | —                      | 0 regressions         |
+| `test_abstain_bypass_policy.py`             | 31 pass            | 36 pass                | +5                    |
+| `test_orchestrator_state_machine_wave2.py`  | —                  | **16 pass**            | +16                   |
 | **Full `tests/unit/services/rag/agentic/`** | 925 pass / 30 skip | **946 pass / 30 skip** | **+21, 0 regression** |
 
 ---
@@ -250,7 +261,7 @@ Not in scope for this PR but natural follow-ups:
    `tool_execution_counter["count"]` is monotonic across an entire
    pipeline invocation. One observational test would lock it.
 3. **ARCH-4 cross-notebook correlator** — the `resolve_multi_notebook`
-   >=2 match branch spawns a `cross_notebook_correlator` task; not tested.
+   > =2 match branch spawns a `cross_notebook_correlator` task; not tested.
 4. **Grading gates ACTIVE** — §U4 clamp behavior in active mode is
    tested at the unit level (Wave 1 clamp patch) but no integration test
    runs the full pipeline with `_ENABLE_GRADING_GATES=True`.

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_curated_qa_grounding_injection.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_curated_qa_grounding_injection.py
@@ -627,9 +627,21 @@ async def test_process_query_core_threads_curated_grounding_into_multi_agent_pro
     mock_coordinator.process = AsyncMock(return_value={"final_answer": "x"})
     core._multi_agent_coordinator = mock_coordinator
 
-    with patch(
-        "backend.services.rag.agentic.orchestrator_core.requires_multi_agent",
-        return_value=True,
+    # The branch is OFF by default since 2026-07-27
+    # (`_MULTI_AGENT_COORDINATOR_ENABLED` — it answered with no sources and
+    # could not abstain). This test is about what the branch RECEIVES once
+    # entered, so it enables the feature explicitly; the default-off behaviour
+    # is covered in test_orchestrator_state_machine_wave2.py.
+    with (
+        patch(
+            "backend.services.rag.agentic.orchestrator_core.requires_multi_agent",
+            return_value=True,
+        ),
+        patch.object(
+            orchestrator_core_module,
+            "_MULTI_AGENT_COORDINATOR_ENABLED",
+            True,
+        ),
     ):
         result = await core.process_query_core(
             query="What is the E33 deposit amount?",

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave2.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave2.py
@@ -34,6 +34,7 @@ if str(backend_path) not in sys.path:
     sys.path.insert(0, str(backend_path))
 
 from backend.services.llm_clients.pricing import TokenUsage
+from backend.services.rag.agentic import orchestrator_core as orchestrator_core_module
 from backend.services.rag.agentic.orchestrator import AgenticRAGOrchestrator
 from backend.services.rag.agentic.query_gates import QueryGates
 from backend.services.rag.agentic.schema import CoreResult
@@ -336,17 +337,59 @@ class TestMultiAgent:
         )
         orch.core._multi_agent_coordinator = mock_coord
 
+        # The branch is OFF by default since 2026-07-27 (it answered with no
+        # sources and could not abstain — see _MULTI_AGENT_COORDINATOR_ENABLED).
+        # O9 is about what the branch DOES once entered, so the feature is
+        # enabled explicitly here. The entry predicate itself is still the real
+        # `requires_multi_agent` against a real cost+timeline query string, and
+        # the default-off behaviour has its own test below.
         # "cost and timeline" query triggers requires_multi_agent
-        result = await orch.process_query(
-            "How much does a KITAS cost and how long does it take?",
-            "user@test.com",
-        )
+        with patch.object(
+            orchestrator_core_module,
+            "_MULTI_AGENT_COORDINATOR_ENABLED",
+            True,
+        ):
+            result = await orch.process_query(
+                "How much does a KITAS cost and how long does it take?",
+                "user@test.com",
+            )
 
         assert result.model_used == "multi-agent-coordinator"
         assert "Rp 15M" in result.answer
         mock_coord.process.assert_called_once()
         # ReAct loop MUST NOT have been invoked
         orch.reasoning_engine.execute_react_loop.assert_not_called()
+
+    async def test_multi_agent_is_off_by_default_and_falls_through_to_react(self, orch):
+        """DEFAULT-OFF (2026-07-27): the same cost+timeline query that O9 routes
+        into the branch must, with no flag set, never reach the coordinator and
+        must be answered by the ReAct loop instead.
+
+        Why the branch is off rather than gated on evidence: it returns
+        `sources=[]` before the abstain gate and before the analytics write, so
+        its answers cannot be cited, cannot abstain, and cannot be measured. In
+        prod on 2026-07-27 that produced an invented government fee of "up to
+        IDR 1.2 billion" on an E23 cost+timeline question. Falling through means
+        the query is served by the path that retrieves, abstains and is logged.
+
+        This test would FAIL before the change: the old code called the
+        coordinator whenever `requires_multi_agent` matched.
+        """
+        mock_coord = MagicMock()
+        mock_coord.process = AsyncMock(
+            return_value={"final_answer": "ungrounded multi-agent answer"},
+        )
+        orch.core._multi_agent_coordinator = mock_coord
+
+        result = await orch.process_query(
+            "How much does a KITAS cost and how long does it take?",
+            "user@test.com",
+        )
+
+        mock_coord.process.assert_not_awaited()
+        assert result.model_used != "multi-agent-coordinator"
+        assert "ungrounded multi-agent answer" not in result.answer
+        orch.reasoning_engine.execute_react_loop.assert_called_once()
 
     async def test_multi_agent_exception_falls_back_to_react(self, orch):
         """O10: coordinator.process raises → logged warning + ReAct fallback.
@@ -356,10 +399,17 @@ class TestMultiAgent:
         mock_coord.process = AsyncMock(side_effect=RuntimeError("agent graph error"))
         orch.core._multi_agent_coordinator = mock_coord
 
-        result = await orch.process_query(
-            "How much does a KITAS cost and how long does it take?",
-            "user@test.com",
-        )
+        # Same explicit enablement as O9 — this test is about the exception
+        # fallback, so the branch must be allowed to run in order to raise.
+        with patch.object(
+            orchestrator_core_module,
+            "_MULTI_AGENT_COORDINATOR_ENABLED",
+            True,
+        ):
+            result = await orch.process_query(
+                "How much does a KITAS cost and how long does it take?",
+                "user@test.com",
+            )
 
         # Coordinator tried, exception captured
         mock_coord.process.assert_called_once()


### PR DESCRIPTION
## Commits

- **fix(rag): turn Phase-6 multi-agent OFF by default — it invented a fee in prod**

Measured live on 2026-07-27, asking the cost AND timeline of an E23 KITAS —
the exact shape `requires_multi_agent` exists to catch. The reply came back
`sources=[] context_length=0 evidence_score=0 abstain=false` and asserted a
government fee reaching "IDR 1.2 billion" beside the real PricingTool figure,
split the all-inclusive price against the 2026-07-17 ruling, and invented a
38-60 day phase breakdown matching TimelineAgent's prompt template ("1.
Document preparation: X days") line for line.

The branch cannot do better by construction: it returns a CoreResult with a
hardcoded sources=[], and returns it BEFORE the abstain gate and before the
only _log_query_analytics call. Its answers cannot be cited, cannot abstain,
and are invisible to query_analytics — 6771 rows there, zero
multi-agent-coordinator, which measures the blindness, not the rarity.

Rejected alternative, killed by adversarial review: gating the branch on a
non-empty curated_qa hit. It reads as a safety gate but is a silent deletion —
research/operations/2026-07-17-full-domain-cache-design.md puts price-adjacent
questions explicitly OUT of scope for that corpus, so for this branch's own
trigger population a curated hit is structurally unlikely. Disabling a feature
honestly beats disabling it by side effect while claiming behaviour is
preserved.

Not claimed: that this is a frequent question. Measured on the real inbound
corpus it is 2 of 59 WhatsApp messages with text; the severity is in WHAT it
answers (prices, legal deadlines) with zero evidence. Nor is a cost saving
claimed: the coordinator itself runs up to four LLM calls, so falling through
to ReAct is not obviously more expensive.

Re-enabling is not a flag flip alone: the branch first needs its own evidence
bundle and must pass through the same finalization as every other answer, so
it can be scored, can abstain, and gets logged. MULTI_AGENT_COORDINATOR_ENABLED=true
restores the old behaviour verbatim in the meantime.

Tests: a default-off test drives the full process_query path and proves the
coordinator is not awaited AND that the ReAct loop ran instead — verified to
FAIL against the pre-change source ("Expected process to not have been
awaited. Awaited 1 times."). O9/O10 and the 2026-07-18 curated-grounding wiring
test now enable the feature explicitly rather than being weakened; WAVE2_NOTES
updated to say so.


## Why this had no PR until now

Work committed and pushed but never opened as a PR — stranded when its push was
killed mid-suite on a saturated M5 (measured today: ~10 concurrent 21k-test suites,
load peaking at 70, pushes SIGTERM-killed with the commits invisible to every view).
The commits above are the original author's, unchanged; this PR only publishes them.
Verified before opening: no live process in the worktree, tree clean, and the diff is
NOT already on main by content (blob-per-file against the merge-base, never three-dot
— W88).

Judged by the required checks and the merge queue, as every PR is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
