### PR TITLE
fix(rag): never append the KG workflow prose to a refusal

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
@@ -1443,14 +1443,6 @@ class OrchestratorCore:
             reasoning=langgraph_reasoning,
         )
 
-        # 12. Also append KG LangGraph workflow text to answer for visibility
-        if langgraph_workflow:
-            workflow_text = self._format_workflow_for_prompt(langgraph_workflow)
-            result.answer = result.answer.rstrip() + "\n\n" + workflow_text
-            logger.info(
-                f"🔗 [KG LangGraph] Workflow included in response: {langgraph_workflow.get('type')}",
-            )
-
         # 12b. E33 Second Home claim guard: flags registry-forbidden E33
         # claims in the generated answer and appends a safe fallback note.
         # The note-append is unconditional and non-blocking — never rewrites
@@ -1458,6 +1450,56 @@ class OrchestratorCore:
         # abstain/HUMAN_REVIEW is gated by _E33_CLAIM_GUARD_ENFORCE (see
         # flag definition above for the full rationale).
         _apply_e33_claim_guard(result)
+
+        # 12c. KG LangGraph workflow prose — appended for visibility, but NEVER
+        # onto a refusal (2026-07-27).
+        #
+        # This append used to sit at step 12 and run unconditionally, so a reply
+        # that had just abstained still carried a confident workflow underneath
+        # it. Measured live, asking (in Italian) what to do after an E23 KITAS
+        # was REJECTED: abstain=true, abstain_reason="no_relevant_context",
+        # sources=[], the correct refusal — and then "## SUGGESTED WORKFLOW
+        # (from visa_subgraph, confidence: 78%)" listing the normal APPLICATION
+        # steps to someone whose application had been refused, closing with
+        # "Always verify current requirements with the user", a line addressed
+        # to the model rather than the client (the helper is, as its name says,
+        # `_format_workflow_for_prompt`).
+        #
+        # It lives HERE, after `_apply_e33_claim_guard`, and reads `result.abstain`
+        # — the decision itself — rather than recomputing a refusal from the
+        # evidence score. Two reasons, both from adversarial review:
+        #   * the E33 guard above can still turn an answer into an abstention,
+        #     so anything deciding earlier decides on stale state;
+        #   * `evidence_score == 0.0` does NOT mean "refused": trusted-tool and
+        #     pricing bypasses (and skip_rag) can authorise an answer without
+        #     ever updating the score, so gating on the score would strip the
+        #     workflow from replies the system chose to deliver.
+        #
+        # Deliberately NOT claimed: that nothing is lost. The structured
+        # `workflow` field is returned by the API, but the web chat and Prime
+        # adapters forward only `answer` and `sources`, and blog/Oracle drop it —
+        # so for those surfaces this prose IS the workflow. That is precisely why
+        # the withholding is scoped to refusals, where the prose contradicts the
+        # very sentence above it, and not widened to evidenced answers.
+        #
+        # Still open, deliberately out of scope here: the KG fast-path builds its
+        # answer FROM this prose (so it cannot simply be dropped there), the
+        # streaming path emits the workflow as metadata unconditionally and
+        # before reading any score, and `whatsapp_chat.py` sends `result.answer`
+        # without honouring `abstain` at all.
+        if langgraph_workflow and not result.abstain:
+            workflow_text = self._format_workflow_for_prompt(langgraph_workflow)
+            result.answer = result.answer.rstrip() + "\n\n" + workflow_text
+            logger.info(
+                f"🔗 [KG LangGraph] Workflow included in response: {langgraph_workflow.get('type')}",
+            )
+        elif langgraph_workflow:
+            logger.info(
+                "🔗 [KG LangGraph] Workflow prose withheld — the answer is an "
+                "abstention (reason=%s); the structured `workflow` field is "
+                "still returned.",
+                result.abstain_reason,
+            )
 
         # 13. R5 Phase 6: NLM Enrichment merge removed — nlm_task/nlm_domain always None
         evidence_score = getattr(state, "evidence_score", None)

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave2.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave2.py
@@ -35,6 +35,7 @@ if str(backend_path) not in sys.path:
 
 from backend.services.llm_clients.pricing import TokenUsage
 from backend.services.rag.agentic.orchestrator import AgenticRAGOrchestrator
+from backend.services.rag.agentic.orchestrator_response import OrchestratorResponseBuilder
 from backend.services.rag.agentic.query_gates import QueryGates
 from backend.services.rag.agentic.schema import CoreResult
 from backend.services.tools.definitions import AgentState, BaseTool
@@ -639,3 +640,111 @@ class TestTier1RegenExceptionContract:
 
         with pytest.raises(RuntimeError, match="ReAct loop failed"):
             await orch.process_query("visto KITAS?", "user@test.com")
+
+
+# =============================================================================
+# O24 — KG workflow prose must not ride along on a refusal (2026-07-27)
+# =============================================================================
+
+
+class TestWorkflowScaffoldNotAppendedToRefusal:
+    """Step 12 appends `_format_workflow_for_prompt` text to the answer.
+
+    That append used to be unconditional, so a reply that had just abstained
+    still carried a confident workflow underneath it. Measured live 2026-07-27
+    (E23 KITAS rejection question): abstain=true, "non ho trovato informazioni
+    rilevanti", immediately followed by "## SUGGESTED WORKFLOW … confidence:
+    78%" listing the normal APPLICATION steps to someone whose application had
+    been refused — and closing with "Always verify current requirements with
+    the user", a line addressed to the model, not the client.
+
+    The withholding is scoped to refusals ON PURPOSE. It would be wrong to
+    claim nothing is lost: the API does return a structured `workflow` field,
+    but the web chat and Prime adapters forward only `answer` and `sources`
+    and blog/Oracle drop it, so on those surfaces this prose IS the workflow.
+    On a refusal it contradicts the sentence above it, which is why only that
+    case is withheld.
+
+    The check reads `result.abstain` AFTER the E33 guard rather than
+    recomputing a refusal from `evidence_score`: the guard can still turn an
+    answer into an abstention, and a 0.0 score does not mean "refused" —
+    trusted-tool/pricing bypasses can authorise an answer without updating it.
+
+    NOTE these drive the real `process_query` path. The pre-existing
+    `test_workflow_appended_to_answer` in test_kg_langgraph_integration.py does
+    the concatenation by hand and asserts its own arithmetic, so it could never
+    have caught this.
+    """
+
+    _WORKFLOW = {
+        "id": "visa_processing:kitas",
+        "type": "visa_processing",
+        "name": "KITAS Visa Processing",
+        "source": "visa_subgraph",
+        "confidence": 0.78,
+        "steps": [{"step": 1, "action": "Apply for TKA allocation quota via SPKP"}],
+    }
+
+    @classmethod
+    def _arm_workflow(cls, orch):
+        """Make prepare_query_context yield a KG workflow, leaving the rest.
+
+        Also restores the REAL response builder. The shared fixture leaves
+        `core.response_builder` a MagicMock, which means `result.abstain` is
+        never computed and comes back False on every path — measured while
+        writing these tests, and the same reason `result.workflow` reads None
+        there. A test about behaviour on a refusal cannot run against a harness
+        that can never produce one.
+        """
+        orch.core.response_builder = OrchestratorResponseBuilder()
+        original = orch.core.prepare_query_context
+
+        async def _with_workflow(**kwargs):
+            user_ctx, history, entities, ctx, _ = await original(**kwargs)
+            return user_ctx, history, entities, ctx, dict(cls._WORKFLOW)
+
+        orch.core.prepare_query_context = _with_workflow
+
+    async def test_low_evidence_withholds_the_workflow_prose(
+        self,
+        orch,
+        _stub_final_state,
+    ):
+        """GUILT: below the abstain label gate the prose must be withheld —
+        while the STRUCTURED workflow field is still returned, so no consumer
+        loses data, only the contradictory prose."""
+        # A LOW SCORE IS NOT A REFUSAL. `trusted_tools_used` (the fixture's
+        # default) authorises the answer regardless of the score, and
+        # `result.abstain` then comes back False even at 0.05 — measured right
+        # here while building this test. That is exactly why the check reads the
+        # decision and not the score: an earlier draft gated on
+        # `label_abstains(evidence_score)` and would have stripped the workflow
+        # from answers the system had chosen to deliver.
+        _stub_final_state.evidence_score = 0.05
+        _stub_final_state.trusted_tools_used = False
+        self._arm_workflow(orch)
+
+        result = await orch.process_query("Cosa faccio adesso?", "user@test.com")
+
+        assert result.abstain is True
+        assert result.abstain_reason is not None
+        assert "SUGGESTED WORKFLOW" not in result.answer
+        assert "Always verify current requirements" not in result.answer
+        # the structured field is untouched by the withholding
+        assert result.workflow is None or isinstance(result.workflow, dict)
+
+    async def test_evidenced_answer_still_carries_the_workflow_prose(
+        self,
+        orch,
+        _stub_final_state,
+    ):
+        """INNOCENCE: with real evidence the append is unchanged — this fix
+        narrows the 2026-07-25 'may be legitimate for other consumers'
+        assumption only where it was provably wrong (a refusal)."""
+        _stub_final_state.evidence_score = 0.8
+        self._arm_workflow(orch)
+
+        result = await orch.process_query("Come funziona il KITAS?", "user@test.com")
+
+        assert result.abstain is False
+        assert "SUGGESTED WORKFLOW" in result.answer


### PR DESCRIPTION
## Commits

- **fix(rag): never append the KG workflow prose to a refusal**

Measured live on 2026-07-27, asking in Italian what to do after an E23 KITAS
was REJECTED. The bot abstained correctly — abstain=true,
abstain_reason="no_relevant_context", sources=[] — and then printed, directly
underneath, "## SUGGESTED WORKFLOW (from visa_subgraph, confidence: 78%)" with
the five steps of a normal APPLICATION, to someone whose application had just
been refused. It closes with "Always verify current requirements with the
user": a line addressed to the model, shown to the client. The helper is called
_format_workflow_for_prompt, and that is exactly what it is.

The check sits AFTER _apply_e33_claim_guard and reads result.abstain — the
decision — rather than recomputing a refusal from the evidence score. Both
placements are load-bearing, and adversarial review supplied both reasons:
the E33 guard can still turn an answer into an abstention, so anything deciding
earlier decides on stale state; and evidence_score == 0.0 does NOT mean
"refused" — trusted-tool and pricing bypasses can authorise an answer without
ever updating the score, so a score-based gate would have stripped the workflow
from replies the system chose to deliver. That is not hypothetical: an earlier
draft of this fix did gate on the score, and the harness returned abstain=False
at 0.05.

NOT claimed: that nothing is lost. The API does return a structured `workflow`
field, but the web chat and Prime adapters forward only `answer` and `sources`,
and blog/Oracle drop it — so on those surfaces this prose IS the workflow. That
is why the withholding is scoped to refusals, where the prose contradicts the
sentence above it, and not widened to evidenced answers.

Deliberately out of scope, recorded in the code so it is not mistaken for
coverage: the KG fast-path builds its answer FROM this prose and cannot simply
drop it; the streaming path emits the workflow as metadata unconditionally and
before reading any score; whatsapp_chat.py sends result.answer without honouring
abstain at all.

Tests drive the real process_query path and assert the decision, not just the
text. They also restore the REAL OrchestratorResponseBuilder: the shared fixture
leaves it a MagicMock, so result.abstain is never computed and reads False on
every path — a test about refusal behaviour cannot run on a harness that can
never produce a refusal. Verified to FAIL against the pre-change source.


## Why this had no PR until now

Work committed and pushed but never opened as a PR — stranded when its push was
killed mid-suite on a saturated M5 (measured today: ~10 concurrent 21k-test suites,
load peaking at 70, pushes SIGTERM-killed with the commits invisible to every view).
The commits above are the original author's, unchanged; this PR only publishes them.
Verified before opening: no live process in the worktree, tree clean, and the diff is
NOT already on main by content (blob-per-file against the merge-base, never three-dot
— W88).

Judged by the required checks and the merge queue, as every PR is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
