### PR TITLE
fix(token-lint): exempt palette/swatch DATA records from the hex gate

### DIFF
--- a/scripts/tests/test_token_lint.py
+++ b/scripts/tests/test_token_lint.py
@@ -43,6 +43,10 @@ WORKSPACE_PAGE = "apps/mouth/src/app/(workspace)/accounting/page.tsx"
 PORTAL_PAGE = "apps/mouth/src/app/portal/dashboard/page.tsx"
 MARKETING_PAGE = "apps/mouth/src/app/(marketing)/page.tsx"
 TOKEN_FILE = "packages/core/tokens/semantic.css"
+# Task #12 fixture (team-lead's assignment, 2026-07-26): the real file whose
+# `accentColors` array — an accent-colour PICKER's option list — triggered
+# the false positive. Real path, verified on disk in this repo.
+APPEARANCE_PAGE = "apps/mouth/src/app/(workspace)/settings/appearance/page.tsx"
 
 
 def make_diff(path: str, added: list[str], *, start: int = 1, new_file: bool = True) -> str:
@@ -397,6 +401,85 @@ def test_innocence_4_out_of_scope_marketing_page() -> None:
     result = tl.scan(make_diff(MARKETING_PAGE, ['const C = "#d4845a";']), [MARKETING_PAGE])
     assert result.violations == []
     assert result.scanned_file_count == 0
+
+
+def test_innocence_5_palette_record_accent_colors_array() -> None:
+    """Innocence-5 / task #12 (2026-07-26): the exact violating shape from
+    PR #3165 — six `{ id: ..., label: ..., color: "#hex" }` swatch entries
+    in the accentColors picker array. The old gate flagged 2 of 6 (only the
+    ones that happened to land in that diff); a CORRECT rule flags all six
+    or none — this asserts none, since the hex values are the picker's data,
+    not styling. This is the acceptance test from the task."""
+    lines = [
+        '  { id: "cyan",   label: "Cyan",   color: "#22D3EE" },',
+        '  { id: "purple", label: "Purple", color: "#A78BFA" },',
+        '  { id: "blue",   label: "Blue",   color: "#60A5FA" },',
+        '  { id: "green",  label: "Green",  color: "#34D399" },',
+        '  { id: "amber",  label: "Amber",  color: "#FBBF24" },',
+        '  { id: "pink",   label: "Pink",   color: "#F472B6" },',
+    ]
+    result = tl.scan(make_diff(APPEARANCE_PAGE, lines, start=28), [APPEARANCE_PAGE])
+    assert result.violations == []
+
+
+def test_innocence_palette_record_single_line_id_label_order_independent() -> None:
+    """The id/label signature does not depend on key order in the object
+    literal."""
+    line = '{ color: "#22D3EE", label: "Cyan", id: "cyan" }'
+    result = tl.scan(make_diff(APPEARANCE_PAGE, [line]), [APPEARANCE_PAGE])
+    assert result.violations == []
+
+
+def test_guilt_color_key_without_id_label_still_flagged() -> None:
+    """A hex on a `color:`-keyed line WITHOUT sibling id/label is NOT a
+    palette record — the lone-`color:`-key case must still trip, since
+    `color:` alone is also a legitimate style-object key (this is the AND
+    requirement, exercised with NO style=/className= prop present at all,
+    so it proves the id+label check itself gates the exemption — not the
+    separate style-wins branch covered elsewhere)."""
+    line = '{ color: "#22D3EE" }'
+    result = tl.scan(make_diff(APPEARANCE_PAGE, [line]), [APPEARANCE_PAGE])
+    assert [v.hex for v in result.violations] == ["#22D3EE"]
+
+
+def test_guilt_style_prop_position_in_appearance_page_still_flagged() -> None:
+    """Guilt fixture for task #12 (same file as the innocence case): a hex
+    literal in an actual `style=` position must still trip — this is the
+    swatch button's inline background, i.e. genuine styling, not the picker
+    array's data."""
+    line = '<div style={{ backgroundColor: "#22D3EE" }} />'
+    result = tl.scan(make_diff(APPEARANCE_PAGE, [line], start=161), [APPEARANCE_PAGE])
+    assert [v.hex for v in result.violations] == ["#22D3EE"]
+
+
+def test_guilt_classname_arbitrary_hex_still_flagged() -> None:
+    """Guilt fixture: a Tailwind arbitrary-value hex in `className=` must
+    still trip — className is a styling context even without `style=`."""
+    line = '<div className="bg-[#22D3EE]" />'
+    result = tl.scan(make_diff(APPEARANCE_PAGE, [line]), [APPEARANCE_PAGE])
+    assert [v.hex for v in result.violations] == ["#22D3EE"]
+
+
+def test_guilt_id_label_with_style_prop_guilt_wins() -> None:
+    """Corner case the exemption defends against: id/label attrs overloaded
+    onto a STYLED element on one line — style/className wins over the
+    id/label signature, so this is still flagged rather than silently
+    exempted."""
+    line = '<div id="cyan" label="Cyan" style={{ color: "#22D3EE" }} />'
+    result = tl.scan(make_diff(APPEARANCE_PAGE, [line]), [APPEARANCE_PAGE])
+    assert [v.hex for v in result.violations] == ["#22D3EE"]
+
+
+def test_innocence_is_palette_record_line_pure_function() -> None:
+    """Direct unit coverage of the exemption predicate, independent of the
+    scan()-level integration tests above."""
+    assert tl.is_palette_record_line('{ id: "cyan", label: "Cyan", color: "#22D3EE" }')
+    assert not tl.is_palette_record_line('style={{ color: "#22D3EE" }}')
+    assert not tl.is_palette_record_line('{ id: "cyan", color: "#22D3EE" }')  # no label
+    assert not tl.is_palette_record_line('{ label: "Cyan", color: "#22D3EE" }')  # no id
+    assert not tl.is_palette_record_line(
+        'id="cyan" label="Cyan" style={{ color: "#22D3EE" }}'
+    )  # style wins
 
 
 def test_innocence_non_color_shapes_not_flagged() -> None:

--- a/scripts/token_lint.py
+++ b/scripts/token_lint.py
@@ -60,6 +60,26 @@ EXEMPTIONS (each one has a dedicated innocence test):
      NON-EMPTY reason (e.g. `// token-lint-ok: brand logo asset`). A bare
      `token-lint-ok` without colon+reason does NOT exempt — the reason is
      the audit trail, and requiring it is what keeps the marker honest.
+  4. Palette/swatch DATA records — a line carrying sibling `id:`/`label:`
+     string-literal object keys (task #12, 2026-07-26: PR #3165 flagged 2 of
+     6 identical `{ id: "cyan", label: "Cyan", color: "#22D3EE" }`-shaped
+     entries in an accent-colour PICKER array — the hex values ARE the
+     content, not styling; the other 4 sibling entries were already on main
+     and unflagged only because they hadn't landed in that diff, which is
+     the tell that the old gate judged the DIFF, not the construct). The
+     `id`+`label` pair is the swatch-record signature from the concrete
+     violating shape; a lone `color:`/hex is NOT enough on its own (`color:`
+     is also a legitimate style-object key) so this exemption never fires
+     without both siblings present. GUILT STILL WINS: if the same line also
+     carries a `style=`/`className=` JSX prop, it is judged as styling, not
+     data — protects against a (found-nowhere-in-this-repo, but possible)
+     line that overloads `id`/`label` HTML attrs onto a styled element.
+     Known limit, documented not fixed: this is still per-LINE (the module's
+     one-line-at-a-time contract, see CONTRACT below) — a record split
+     across multiple lines is judged by its own line's content only, so a
+     hex on a continuation line without id/label siblings on THAT line is
+     still flagged. All six `accentColors` entries in this repo are
+     single-line, so this does not bite the fixture it was built for.
 
 WHAT IS FLAGGED: `#` followed by 3, 4, 6, or 8 hex digits, word-boundary
 aware (longest-match first; `#d4845a00` matches once as 8 digits; `#fffff`
@@ -174,6 +194,16 @@ HEX_RE = re.compile(
 
 # Marker requires a colon AND a non-empty reason: `token-lint-ok: <reason>`.
 OK_MARKER_RE = re.compile(r"token-lint-ok\s*:\s*\S+")
+
+# Exemption 4 (task #12, 2026-07-26): palette/swatch data-record siblings.
+# `\b` keeps `id:`/`label:` from matching inside a longer identifier
+# (e.g. `validId: "..."`); the value must be quote-opened, so `id: someVar`
+# (a reference, not a literal) does not count as the record signature.
+_PALETTE_ID_KEY_RE = re.compile(r"\bid\s*:\s*[\"']")
+_PALETTE_LABEL_KEY_RE = re.compile(r"\blabel\s*:\s*[\"']")
+# Guilt wins over the data-record signature: a style/className JSX prop on
+# the SAME line means the line is judged as styling regardless of id/label.
+_JSX_STYLE_PROP_RE = re.compile(r"\b(?:style|className)\s*=")
 
 COMMENT_PREFIXES: tuple[str, ...] = ("//", "/*", "<!--", "{/*")
 
@@ -562,6 +592,23 @@ def has_ok_marker(content: str) -> bool:
     return OK_MARKER_RE.search(content) is not None
 
 
+def is_palette_record_line(content: str) -> bool:
+    """True iff the (effective) line looks like a palette/swatch DATA record
+    — an object literal carrying sibling `id:`/`label:` string keys, the
+    shape team-lead specified from the concrete PR #3165 finding (task #12,
+    2026-07-26) — rather than a style/className context. A hex on such a
+    line is the swatch's own value, not styling, and must not be flagged.
+
+    GUILT STILL WINS: a `style=`/`className=` JSX prop on the same line
+    means the line is judged as styling regardless of id/label — this is
+    what keeps a hex inside an actual style/class position from ever being
+    exempted by this rule (the guilt fixture in
+    scripts/tests/test_token_lint.py proves it)."""
+    if _JSX_STYLE_PROP_RE.search(content):
+        return False
+    return bool(_PALETTE_ID_KEY_RE.search(content) and _PALETTE_LABEL_KEY_RE.search(content))
+
+
 def find_hexes(content: str) -> list[str]:
     """All hex-color matches on the line, first-occurrence order, deduped
     (a repeated identical hex on one line is ONE reported violation)."""
@@ -627,6 +674,8 @@ def scan(
             continue
         if has_ok_marker(effective):
             continue
+        if is_palette_record_line(effective):
+            continue
         for hex_value in find_hexes(effective):
             violations.append(Violation(path, added.line, hex_value))
 
@@ -661,6 +710,8 @@ def scan(
             if is_comment_line(effective):
                 continue
             if has_ok_marker(effective):
+                continue
+            if is_palette_record_line(effective):
                 continue
             for hex_value in find_hexes(effective):
                 violations.append(


### PR DESCRIPTION
## Commits

- **fix(token-lint): exempt palette/swatch DATA records from the hex gate**

token_lint.py flagged 2 of 6 identical accentColors entries in PR #3165's
accent-colour picker (apps/mouth/.../settings/appearance/page.tsx) — it
judged which lines happened to land in the DIFF, not whether the construct
was a violation (cicatrix-superscar.md #3, guard-over-match: form, not
entity). The array's hex values ARE the picker's content, not styling.

Fix: a new exemption (#4) recognizes a swatch/palette DATA record by its
sibling `id:`/`label:` string-literal object keys (the shape of the
concrete violating entries) and skips hex judgment on that line — but only
when the line carries no `style=`/`className=` JSX prop, so an id/label
pair overloaded onto an actually-styled element still trips the gate
(guilt wins over the data-record signature).

Guilt+innocence proof per cicatrix-superscar.md #3 doctrine: the exact
6-entry accentColors array now flags 0 (was 2/6 asymmetric), a bare
`color:`-keyed hex without id/label siblings still trips, a hex in a real
`style=`/`className=` position in the SAME file still trips, and the
id/label-overloaded-onto-styling corner case still trips (guilt wins).
7 new tests, 71/71 passing (up from 63).

Verified scripts/tests/test_token_lint.py already has a CI executor
(.github/workflows/token-lint.yml:104 + watched by
verify-the-verifiers.yml) — not among the orphaned scripts/tests/ files.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


## Auto-merge is deliberately NOT armed

This diff touches a GUARD (a CI workflow / a lint gate), which is one of the
auto-merge-OFF classes: a change to the thing that judges other changes gets its own
gate first, then a session merges it — never the codeowner.

Per `cicatrix-superscar.md` #3, a guard may not land without BOTH a guilt test (it
still fires on the case it exists for) and an innocence test (it does NOT fire on the
adjacent legitimate case). Reviewer: check the corpus covers both directions before
arming. A change that only EXEMPTS cases needs the innocence half most.

## Why this had no PR until now

Committed and pushed, never opened — stranded when its push was killed mid-suite on a
saturated M5. Commits are the original author's, unchanged.

Verified before opening: no live process in the worktree, tree clean, diff NOT already
on main by content (blob-per-file, never three-dot — W88), and `git merge-tree` against
the CURRENT origin/main reports a clean merge (checked against main, not against the
other stranded branches — comparing branches to each other was the wrong comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
