### PR TITLE
fix(crm): keep live workflow state consistent

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients_documents.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients_documents.py
@@ -893,7 +893,7 @@ async def get_client_required_documents(
                 FROM practice_required_documents prd
                 JOIN practices p ON prd.practice_id = p.id
                 LEFT JOIN practice_types pt ON p.practice_type_id = pt.id
-                WHERE p.client_id = $1 AND p.status NOT IN ('completed', 'cancelled')
+                WHERE p.client_id = $1 AND p.status != 'cancelled'
                 ORDER BY prd.is_required DESC, prd.created_at DESC
                 """,
                 client_id,

--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -1018,7 +1018,7 @@ async def get_required_documents(
                 FROM practice_required_documents prd
                 JOIN practices p ON prd.practice_id = p.id
                 LEFT JOIN practice_types pt ON p.practice_type_id = pt.id
-                WHERE p.client_id = $1 AND p.status NOT IN ('completed', 'cancelled')
+                WHERE p.client_id = $1 AND p.status != 'cancelled'
                 ORDER BY prd.is_required DESC, prd.created_at DESC
                 """,
                 client_id,

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_clients_documents_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_clients_documents_coverage.py
@@ -790,6 +790,67 @@ async def test_get_client_required_documents_success(mock_db_pool, mock_current_
 
 
 @pytest.mark.asyncio
+async def test_get_client_required_documents_keeps_completed_process_history(
+    mock_db_pool,
+    mock_current_user,
+):
+    from backend.app.routers.crm_clients_documents import get_client_required_documents
+
+    completed_doc = {
+        "id": 2,
+        "practice_id": 11,
+        "process_name": "Completed KITAS",
+        "process_status": "completed",
+        "document_type": "passport",
+        "document_label": "Archived passport request",
+        "description": "Historical requirement",
+        "is_required": True,
+        "uploaded_by_client": False,
+        "status": "pending",
+        "client_notes": None,
+        "team_member_notes": None,
+    }
+
+    async def fetch_visible_documents(
+        query: str,
+        client_id: int,
+    ) -> list[dict[str, object]]:
+        assert client_id == 1
+        if "p.status NOT IN ('completed', 'cancelled')" in query:
+            return []
+        return [completed_doc]
+
+    mock_db_pool._mock_conn.fetch.side_effect = fetch_visible_documents
+
+    with patch(
+        "backend.app.routers.crm_clients_documents.verify_client_access",
+        new=AsyncMock(),
+    ):
+        result = await get_client_required_documents(
+            client_id=1,
+            current_user=mock_current_user,
+            db_pool=mock_db_pool,
+        )
+
+    assert result == [
+        {
+            "id": 2,
+            "practice_id": 11,
+            "process_name": "Completed KITAS",
+            "process_status": "completed",
+            "document_type": "passport",
+            "document_label": "Archived passport request",
+            "description": "Historical requirement",
+            "is_required": True,
+            "uploaded_by_client": False,
+            "status": "pending",
+            "client_notes": None,
+            "team_member_notes": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_get_client_required_documents_empty(mock_db_pool, mock_current_user):
     from backend.app.routers.crm_clients_documents import get_client_required_documents
 

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal.py
@@ -555,6 +555,48 @@ class TestTimeline:
 
 
 # ============================================
+# PROCESS DOCUMENT TESTS
+# ============================================
+
+
+class TestProcessDocuments:
+    """Tests for GET /api/portal/process/required-documents."""
+
+    def test_completed_process_documents_remain_visible(self, client, mock_db_pool):
+        """Completed matters retain their document history in the client portal."""
+        completed_doc = {
+            "id": 7,
+            "practice_id": 81,
+            "process_name": "Completed KITAS",
+            "process_status": "completed",
+            "document_type": "passport",
+            "document_label": "Passport copy",
+            "description": "Historical requirement",
+            "is_required": True,
+            "uploaded_by_client": False,
+            "status": "pending",
+            "client_notes": None,
+            "team_member_notes": None,
+        }
+
+        async def fetch_visible_documents(
+            query: str,
+            client_id: int,
+        ) -> list[dict[str, object]]:
+            assert client_id == 42
+            if "p.status NOT IN ('completed', 'cancelled')" in query:
+                return []
+            return [completed_doc]
+
+        mock_db_pool._mock_conn.fetch.side_effect = fetch_visible_documents
+
+        response = client.get("/api/portal/process/required-documents")
+
+        assert response.status_code == 200
+        assert response.json()["data"] == [completed_doc]
+
+
+# ============================================
 # PROFILE TESTS
 # ============================================
 

--- a/apps/mouth/src/components/portal/SuperuserImpersonationBar.test.tsx
+++ b/apps/mouth/src/components/portal/SuperuserImpersonationBar.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SuperuserImpersonationBar } from "./SuperuserImpersonationBar";
+
+const { useAdminImpersonationMock } = vi.hoisted(() => ({
+  useAdminImpersonationMock: vi.fn(),
+}));
+
+vi.mock("@/contexts/AdminImpersonationContext", () => ({
+  useAdminImpersonation: useAdminImpersonationMock,
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getToken: vi.fn(() => null),
+  },
+}));
+
+describe("SuperuserImpersonationBar palette", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    });
+  });
+
+  it("uses the text-safe copper token for the active client label", () => {
+    useAdminImpersonationMock.mockReturnValue({
+      isSuperuser: true,
+      target: {
+        id: 42,
+        email: "synthetic@example.com",
+        fullName: "Synthetic Client",
+      },
+      setTarget: vi.fn(),
+    });
+
+    render(<SuperuserImpersonationBar />);
+
+    const activeLabel = screen.getByText(/Viewing as: Synthetic Client/i);
+    expect(activeLabel).toHaveClass("text-[var(--bz-copper-text)]");
+    expect(activeLabel).toHaveClass("bg-[var(--bz-copper)]/10");
+    expect(activeLabel).toHaveClass("border-[var(--bz-copper)]");
+  });
+
+  it("uses themed surfaces for the search field and results panel", () => {
+    useAdminImpersonationMock.mockReturnValue({
+      isSuperuser: true,
+      target: null,
+      setTarget: vi.fn(),
+    });
+
+    render(<SuperuserImpersonationBar />);
+
+    const input = screen.getByPlaceholderText("Search client to impersonate…");
+    expect(input).toHaveClass("bg-[var(--glass-highlight)]");
+
+    fireEvent.change(input, { target: { value: "sy" } });
+
+    expect(screen.getByText("Searching…").parentElement).toHaveClass(
+      "bg-[var(--bz-elevated)]",
+    );
+  });
+});

--- a/apps/mouth/src/components/portal/SuperuserImpersonationBar.tsx
+++ b/apps/mouth/src/components/portal/SuperuserImpersonationBar.tsx
@@ -69,7 +69,7 @@ export function SuperuserImpersonationBar() {
     return (
       <div className="flex items-center gap-2">
         <span
-          className="flex items-center gap-1.5 px-2 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wider bg-[var(--bz-copper)]/20 text-[var(--bz-copper)] border border-[var(--bz-copper)]/40"
+          className="flex items-center gap-1.5 px-2 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wider bg-[var(--bz-copper)]/10 text-[var(--bz-copper-text)] border border-[var(--bz-copper)]"
           title={target.email ?? ""}
         >
           Viewing as: {label}
@@ -105,10 +105,10 @@ export function SuperuserImpersonationBar() {
           setTimeout(() => setIsOpen(false), 120);
         }}
         placeholder="Search client to impersonate…"
-        className="w-56 md:w-72 bg-[rgba(255,255,255,0.05)] border border-[var(--glass-rim)] rounded-lg px-3 py-1.5 text-sm text-[var(--tx-pure)] placeholder:text-[var(--tx-secondary)]/60 focus:outline-none focus:border-[var(--bz-copper)]/60"
+        className="w-56 md:w-72 bg-[var(--glass-highlight)] border border-[var(--bz-border)] rounded-lg px-3 py-1.5 text-sm text-[var(--tx-pure)] placeholder:text-[var(--tx-secondary)] focus:outline-none focus:border-[var(--bz-copper)]"
       />
       {isOpen && (query.length >= 2 || loading) && (
-        <div className="absolute top-full mt-1 right-0 left-0 z-40 max-h-80 overflow-y-auto rounded-lg border border-[var(--glass-rim)] bg-[rgba(29,39,59,0.95)] backdrop-blur-[24px] shadow-xl">
+        <div className="absolute top-full mt-1 right-0 left-0 z-40 max-h-80 overflow-y-auto rounded-lg border border-[var(--bz-border)] bg-[var(--bz-elevated)] backdrop-blur-[24px] shadow-xl">
           {loading && (
             <div className="px-3 py-2 text-xs text-[var(--tx-secondary)]">
               Searching…

--- a/apps/mouth/src/lib/api/client.test.ts
+++ b/apps/mouth/src/lib/api/client.test.ts
@@ -256,7 +256,22 @@ describe("ApiClientBase", () => {
       if (callArgs[1]) {
         expect(callArgs[1].method || "GET").toBe("GET");
         expect(callArgs[1].credentials).toBe("include");
+        expect(callArgs[1].cache).toBe("no-store");
       }
+    });
+
+    it("should preserve an explicit GET cache policy", async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      });
+
+      await (client as any).request("/test", { cache: "force-cache" });
+
+      const callArgs = (global.fetch as any).mock.calls[0];
+      expect(callArgs[1].cache).toBe("force-cache");
     });
 
     it("should add Authorization header when token exists", async () => {

--- a/apps/mouth/src/lib/api/client.ts
+++ b/apps/mouth/src/lib/api/client.ts
@@ -290,6 +290,11 @@ export class ApiClientBase implements IApiClient {
     try {
       const response = await fetch(`${this.baseUrl}${endpoint}`, {
         ...options,
+        // React Query owns API response caching. Browser HTTP caching can replay
+        // stale rows immediately after a successful CRM mutation.
+        ...(method === "GET" && options.cache === undefined
+          ? { cache: "no-store" }
+          : {}),
         headers,
         credentials: "include", // CRITICAL: Send httpOnly cookies
         signal: controller.signal,


### PR DESCRIPTION
## Summary
- disable browser HTTP caching for API GETs unless a caller explicitly opts in
- keep required-document history visible for completed processes while excluding cancelled processes
- restore accessible light-theme contrast for the portal impersonation search and active identity indicator

## Root causes
- browser fetch caching could return stale CRM state immediately after mutations
- document queries filtered both completed and cancelled process records
- the impersonation dropdown mixed a hardcoded dark background with light-theme text tokens

## Verification
- frontend API client suites: 76 passed
- portal impersonation component tests: 2 passed
- backend affected router suites: 76 passed
- full TypeScript typecheck, ESLint/Prettier, Ruff, pre-commit and repository pre-push gate passed
- contrast: dropdown 16.00:1; active identity pill 4.51:1

No external communications are sent by these changes.