### PR TITLE
fix(crm): sync required document mutations

### DIFF
--- a/apps/mouth/src/lib/hooks/useRequiredDocuments.test.tsx
+++ b/apps/mouth/src/lib/hooks/useRequiredDocuments.test.tsx
@@ -1,0 +1,113 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RequiredDocument } from "@/lib/types/required-documents";
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMock,
+}));
+
+import { useRequiredDocuments } from "./useRequiredDocuments";
+
+const existingDocument: RequiredDocument = {
+  id: 10,
+  practice_id: 771,
+  document_type: "passport",
+  document_label: "Passport",
+  description: "Valid passport copy",
+  is_required: true,
+  uploaded_by_client: false,
+  uploaded_file_id: null,
+  uploaded_at: null,
+  client_notes: null,
+  team_member_notes: null,
+  status: "pending",
+  created_at: "2026-07-27T12:00:00Z",
+  updated_at: "2026-07-27T12:00:00Z",
+};
+
+describe("useRequiredDocuments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.get.mockResolvedValue([existingDocument]);
+  });
+
+  it("shows a newly added document from the mutation response even when a refetch would be stale", async () => {
+    const addedDocument: RequiredDocument = {
+      ...existingDocument,
+      id: 11,
+      document_type: "photo",
+      document_label: "Recent photo",
+    };
+    apiMock.post.mockResolvedValue(addedDocument);
+
+    const { result } = renderHook(() =>
+      useRequiredDocuments({ practiceId: 771 }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.documents).toEqual([existingDocument]),
+    );
+
+    await act(async () => {
+      await result.current.addDocument({
+        document_type: "photo",
+        document_label: "Recent photo",
+      });
+    });
+
+    expect(result.current.documents).toEqual([existingDocument, addedDocument]);
+  });
+
+  it("shows an updated document from the mutation response even when a refetch would be stale", async () => {
+    const updatedDocument: RequiredDocument = {
+      ...existingDocument,
+      status: "verified",
+      team_member_notes: "Checked",
+      updated_at: "2026-07-27T12:05:00Z",
+    };
+    apiMock.patch.mockResolvedValue(updatedDocument);
+
+    const { result } = renderHook(() =>
+      useRequiredDocuments({ practiceId: 771 }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.documents).toEqual([existingDocument]),
+    );
+
+    await act(async () => {
+      await result.current.updateDocument(existingDocument.id, {
+        status: "verified",
+        team_member_notes: "Checked",
+      });
+    });
+
+    expect(result.current.documents).toEqual([updatedDocument]);
+  });
+
+  it("removes a deleted document immediately without depending on a refetch", async () => {
+    apiMock.delete.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useRequiredDocuments({ practiceId: 771 }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.documents).toEqual([existingDocument]),
+    );
+
+    await act(async () => {
+      await result.current.deleteDocument(existingDocument.id);
+    });
+
+    expect(result.current.documents).toEqual([]);
+  });
+});

--- a/apps/mouth/src/lib/hooks/useRequiredDocuments.ts
+++ b/apps/mouth/src/lib/hooks/useRequiredDocuments.ts
@@ -80,18 +80,29 @@ export function useRequiredDocuments(
 
       setIsLoading(true);
       try {
-        await api.post<RequiredDocument>(
+        const created = await api.post<RequiredDocument>(
           `/api/crm/practices/${practiceId}/required-documents`,
           data,
         );
-        await fetchPracticeDocuments();
+        setDocuments((current) => {
+          const existingIndex = current.findIndex(
+            (document) => document.id === created.id,
+          );
+          if (existingIndex === -1) {
+            return [...current, created];
+          }
+
+          return current.map((document, index) =>
+            index === existingIndex ? created : document,
+          );
+        });
       } catch (err) {
         throw err;
       } finally {
         setIsLoading(false);
       }
     },
-    [practiceId, fetchPracticeDocuments],
+    [practiceId],
   );
 
   // Update a required document (team member review)
@@ -101,18 +112,22 @@ export function useRequiredDocuments(
 
       setIsLoading(true);
       try {
-        await api.patch<RequiredDocument>(
+        const updated = await api.patch<RequiredDocument>(
           `/api/crm/practices/${practiceId}/required-documents/${docId}`,
           data,
         );
-        await fetchPracticeDocuments();
+        setDocuments((current) =>
+          current.map((document) =>
+            document.id === updated.id ? updated : document,
+          ),
+        );
       } catch (err) {
         throw err;
       } finally {
         setIsLoading(false);
       }
     },
-    [practiceId, fetchPracticeDocuments],
+    [practiceId],
   );
 
   // Delete a required document
@@ -125,14 +140,16 @@ export function useRequiredDocuments(
         await api.delete<void>(
           `/api/crm/practices/${practiceId}/required-documents/${docId}`,
         );
-        await fetchPracticeDocuments();
+        setDocuments((current) =>
+          current.filter((document) => document.id !== docId),
+        );
       } catch (err) {
         throw err;
       } finally {
         setIsLoading(false);
       }
     },
-    [practiceId, fetchPracticeDocuments],
+    [practiceId],
   );
 
   // Client uploads a document


### PR DESCRIPTION
## Summary
- keep required-document UI state aligned with successful POST, PATCH, and DELETE mutation responses
- avoid a stale follow-up GET leaving the staff workflow one operation behind
- add regression coverage for add, update, and delete state transitions

## Production evidence
The live retest on completed process #771 showed that the mutation succeeded but the immediate follow-up GET could still return the prior snapshot, even with `cache: no-store`. A manual reload then showed the mutation. This change uses the authoritative mutation response/local success result instead.

## Verification
- TDD red: 3/3 new tests failed on the previous hook behavior for the expected stale-state reason
- TDD green: 3/3 new tests pass
- affected suite: 44/44 tests pass
- TypeScript typecheck passes
- pre-commit and pre-push hooks pass
- full local frontend run: 296/299 files pass, 2686 tests pass; 50 unrelated existing failures are limited to duplicate React instances in `visa/match/page.test.tsx`, `process/__tests__/page.test.tsx`, and `settings/appearance/page.test.tsx`

No external client communications were sent.