### PR TITLE
perf(prepush): allowlist v6 — root .gitignore (exact) + infra/home-fork (.json), 24 flips measured over 3458 commits

### DIFF
--- a/scripts/prepush_classify.py
+++ b/scripts/prepush_classify.py
@@ -222,7 +222,13 @@ VERDICT_SKIP = "skip-backend"
 # assumed) innocent w.r.t. `pytest backend/tests/`. See the allowlist
 # table's v5 section below for the 9-concurrent-suite / 7-of-9-zero-backend
 # measurement and the innocence method for both entries.
-ALLOWLIST_VERSION = 5
+# v6 (2026-07-27): added the root `.gitignore` (exact) and infra/home-fork
+# (.json) — the two classes a 3458-commit replay measured as still paying
+# the full backend suite for a diff `pytest backend/tests/` cannot see. See
+# the allowlist table's v6 section for the replay method, the per-entry
+# innocence measurement, and why the `.gitignore` entry is deliberately
+# root-EXACT rather than by basename.
+ALLOWLIST_VERSION = 6
 
 # ---------------------------------------------------------------------------
 # NEVER_INNOCENT_EXACT_PATHS — checked FIRST, unconditionally, before any
@@ -425,6 +431,81 @@ NEVER_INNOCENT_BASENAMES: frozenset[str] = frozenset(
 #                       test subprocess-invokes one without the directory
 #                       prefix).
 #
+#   v6 (2026-07-27) — found by REPLAY, not by getting bitten: every
+#   non-merge commit of the last 90 days (3458 of them) had its file list
+#   classified twice, once against the live v5 table and once against
+#   v5+candidates, counting only the commits whose verdict FLIPS full ->
+#   skip. Result: 813 already skipped under v5, 2465 stay full under v6
+#   (correctly — they carry backend/Python/data), and exactly **24 flip**.
+#   That is the honest size of this change: ~3% more diffs skipping, not a
+#   revolution — but the 24 are concentrated in two shapes this fleet
+#   produces constantly, and one of them (f1254477cb) paid a full backend
+#   suite for 19 files of pure launchd config. The replay is reproducible;
+#   it is a per-COMMIT measurement, which is a proxy for per-push (a push
+#   bundling one such commit with a backend file still, correctly, goes
+#   full).
+#
+#   .gitignore          Root file ONLY, matched EXACTLY. 15 of the 24 flips
+#                       are this entry: 10 commits changed the root
+#                       `.gitignore` and NOTHING else, and 5 more paired it
+#                       only with classes already allowlisted (research/**
+#                       .md, docs/** .md, infra/launchagents/** .plist,
+#                       .claude/skills+commands/** .md, root *.md). All 15
+#                       ran ~17k backend tests for a file git reads and
+#                       pytest does not.
+#                       WHY EXACT, NOT BY BASENAME — this distinction is
+#                       load-bearing, not caution theatre: 22 `.gitignore`
+#                       files are tracked repo-wide, and one of them is
+#                       `apps/backend-rag/backend/data/.gitignore`, i.e.
+#                       INSIDE the tree whose tests we would be skipping. A
+#                       basename rule would have admitted it. This entry
+#                       cannot: the prefix test is satisfied only by
+#                       `path == ".gitignore"` (or a path under a
+#                       `.gitignore/` DIRECTORY, which does not and cannot
+#                       exist here), so every nested `.gitignore` still
+#                       falls to "unknown -> full".
+#                       ON THE SHAPE `(".gitignore", (".gitignore",))` —
+#                       prefix = the file, suffix = its own name. It looks
+#                       odd on purpose: it is how the ONE uniform mechanism
+#                       expresses an exact root-level match, and using it
+#                       means v6 adds ZERO new code paths to
+#                       `_innocent_reason`. Do not "tidy" it into a second
+#                       exact-match allowlist set — a second mechanism is
+#                       precisely what the v2 MUST-FIX removed. Pinned by
+#                       test_innocence_root_gitignore_skips (innocence) +
+#                       test_guilt_nested_gitignore_under_backend_forces_full
+#                       (guilt).
+#                       Innocence MEASURED with the v5 anchored method: 3
+#                       files under `apps/backend-rag/backend/` contain the
+#                       string "gitignore" at all — two are PROSE in a
+#                       docstring/comment ("ops-populated and gitignored
+#                       per…", "The gitignored…") with zero IO, and the
+#                       third IS the nested `.gitignore` above, which this
+#                       entry does not admit. No backend test opens the
+#                       root `.gitignore`.
+#   infra/home-fork/**  Scoped to `.json` ONLY. 10 of the 24 flips are this
+#                       entry. Exactly 1 tracked file today,
+#                       `declared-pairs.json` — the HOME-fork guard's
+#                       registry of live-copy↔repo pairs (superscar #1),
+#                       31 commits in its lifetime and still growing
+#                       (latest 2026-07-25, #3115). It travels WITH plists
+#                       and wrappers, which are already innocent, so those
+#                       diffs were failing the unanimity test on a single
+#                       JSON declaration. Its only readers are
+#                       `scripts/lint_home_fork.py` and
+#                       `scripts/proprioception.py`, neither reachable from
+#                       `pytest backend/tests/`. Innocence MEASURED with
+#                       the v5 anchored method: zero hits for the
+#                       directory-anchored `infra/home-fork/` anywhere under
+#                       `apps/backend-rag/backend/`, and — checked
+#                       separately, because an anchored grep can hide a
+#                       basename reference — zero hits for bare `home-fork`
+#                       and zero for `declared-pairs` there too. Scoped to
+#                       `.json` so a future `.py` helper or `.md` note
+#                       dropped in this directory falls to
+#                       "unknown -> full" rather than inheriting a blessing
+#                       measured on a JSON data file.
+#
 # Deliberately NOT `.claude/**` wholesale: `.claude/hooks/` (control-plane —
 # contains codex-spalla-trigger.sh, verified on disk), `.claude/scripts/`,
 # `.claude/settings.json` + `.claude/settings.local.json` (+ .bak-*
@@ -452,6 +533,11 @@ ALLOWLIST_PREFIX_SUFFIX_PAIRS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("apps/mouth/src", (".ts", ".tsx", ".css")),
     (".agents/skills", (".md",)),
     ("scripts/ci", (".sh",)),
+    # v6 — root .gitignore, matched EXACTLY (prefix == the file, suffix ==
+    # its own name). Deliberately not a basename rule: 22 .gitignore files
+    # are tracked, one of them inside apps/backend-rag/backend/data/.
+    (".gitignore", (".gitignore",)),
+    ("infra/home-fork", (".json",)),
 )
 
 

--- a/scripts/tests/test_prepush_classify.py
+++ b/scripts/tests/test_prepush_classify.py
@@ -1087,6 +1087,188 @@ def test_allowlist_version_bumped_to_5_for_the_v5_entries() -> None:
     assert ("scripts/ci", (".sh",)) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
 
 
+# ===========================================================================
+# v6 — the root `.gitignore` (exact) and infra/home-fork (.json)
+#
+# Found by REPLAY rather than by being bitten: all 3458 non-merge commits of
+# the last 90 days had their file lists classified twice, once against v5 and
+# once against v5+these two entries, counting only verdict FLIPS full->skip.
+# 813 already skipped, 2465 correctly stay full, exactly 24 flip — 15 of them
+# on `.gitignore`, 10 on infra/home-fork, one commit (2b5d2b915e) on both.
+#
+# The lists asserted below are the REAL file lists of flipped commits, not
+# hand-authored plausible ones. `f1254477cb` is the extreme case: 19 files of
+# pure launchd config plus one JSON declaration, paying a full ~17k-test
+# backend suite.
+#
+# The `.gitignore` entry is deliberately root-EXACT, never by basename: 22
+# `.gitignore` files are tracked repo-wide and one of them lives at
+# `apps/backend-rag/backend/data/.gitignore`, INSIDE the tree whose tests the
+# skip would spare. Guilt+innocence for exactly that distinction below —
+# without the guilt half, a "tidying" edit to a basename rule would look
+# green.
+# ===========================================================================
+
+
+def test_innocence_root_gitignore_skips() -> None:
+    """10 of the 24 replayed flips are literally this one-file diff."""
+    verdict, unknown = pc.classify([".gitignore"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_home_fork_declared_pairs_skips() -> None:
+    """The HOME-fork guard's pair registry (superscar #1) — the only tracked
+    file under infra/home-fork/ today, 31 commits in its lifetime."""
+    verdict, unknown = pc.classify(["infra/home-fork/declared-pairs.json"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_real_v6_replay_flips_skip() -> None:
+    """Four REAL flipped commits from the 90-day replay, verbatim file lists.
+
+    Each of these paid a full backend suite for a diff containing zero
+    Python and zero backend files.
+    """
+    real_flips = {
+        # f1254477cb — 19 files: launchd canon reconcile.
+        "f1254477cb": [
+            "infra/home-fork/declared-pairs.json",
+            "infra/launchagents/com.balizero.codex-spalla-calibrate.plist",
+            "infra/launchagents/com.nuzantara.merge-train.plist",
+            "infra/launchagents/wrappers/fly-pg-proxy-wrapper.sh",
+            "infra/launchagents/wrappers/wa-media-pull-run.sh",
+        ],
+        # 17eed8ebbd — .gitignore riding along with a research capture.
+        "17eed8ebbd": [
+            ".gitignore",
+            "research/visa/2026-06-01-c5a-local-ban-sources.md",
+        ],
+        # b2f7264824 — .gitignore plus one LaunchAgent plist.
+        "b2f7264824": [
+            ".gitignore",
+            "infra/launchagents/com.balizero.wr2.html-apply.plist",
+        ],
+        # 70db573245 — the ledger plus the pair declaration.
+        "70db573245": [
+            ".claude/skills/modus/PENDING-ARMS.md",
+            "infra/home-fork/declared-pairs.json",
+        ],
+    }
+    for sha, files in real_flips.items():
+        verdict, unknown = pc.classify(files)
+        assert verdict == pc.VERDICT_SKIP, f"{sha} should skip, got {verdict} ({unknown})"
+        assert unknown == []
+
+
+def test_guilt_nested_gitignore_under_backend_forces_full() -> None:
+    """THE load-bearing guilt test for v6.
+
+    `apps/backend-rag/backend/data/.gitignore` is a real tracked file
+    (verified on disk). A basename-shaped rule would have admitted it — i.e.
+    a file inside the backend tree would have authorised skipping the backend
+    tests. The root-exact entry must not.
+    """
+    path = "apps/backend-rag/backend/data/.gitignore"
+    verdict, unknown = pc.classify([path])
+    assert verdict == pc.VERDICT_FULL, "a .gitignore INSIDE the backend tree must force full"
+    assert unknown == [path]
+
+
+def test_guilt_non_root_gitignore_anywhere_forces_full() -> None:
+    """The same rule outside the backend tree: nested `.gitignore` files are
+    not admitted either. 22 are tracked; only the root one is allowlisted, so
+    this is the general case and the test above is its worst instance."""
+    for path in (
+        "apps/mouth/.gitignore",
+        "apps/backend-rag/.gitignore",
+        "packages/core/.gitignore",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_FULL, f"{path} must force full"
+        assert unknown == [path]
+
+
+def test_guilt_gitignore_lookalike_names_force_full() -> None:
+    """The `(".gitignore", (".gitignore",))` shape must match the FILE, not
+    names that merely start with it — the prefix test admits only equality or
+    a `.gitignore/` DIRECTORY, and the suffix test only the exact name."""
+    for path in (
+        ".gitignore.bak",
+        ".gitignore-old",
+        ".gitignoreignore",
+        ".gitignore.save/.gitignore",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_FULL, f"{path} must force full"
+        assert unknown == [path]
+
+
+def test_guilt_home_fork_non_json_forces_full() -> None:
+    """Suffix scoping is the mechanism: a future .py helper or .md note in
+    infra/home-fork/ must not inherit a blessing measured on a JSON data
+    file."""
+    for path in (
+        "infra/home-fork/sync.py",
+        "infra/home-fork/README.md",
+        "infra/home-fork/realign.sh",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_FULL, f"{path} must force full"
+        assert unknown == [path]
+
+
+def test_guilt_home_fork_lookalike_prefix_forces_full() -> None:
+    """Directory-boundary anchoring: `infra/home-fork-legacy/x.json` starts
+    with the prefix as a STRING but is a different directory."""
+    for path in (
+        "infra/home-fork-legacy/old.json",
+        "infra/home-forked/pairs.json",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_FULL, f"{path} must force full"
+        assert unknown == [path]
+
+
+def test_guilt_v6_entries_mixed_with_backend_force_full() -> None:
+    """Unanimity is unchanged: one backend file in the diff still forces the
+    full suite, alongside either new entry."""
+    backend = "apps/backend-rag/backend/services/rag/reasoning.py"
+    for extra in (".gitignore", "infra/home-fork/declared-pairs.json"):
+        verdict, unknown = pc.classify([extra, backend])
+        assert verdict == pc.VERDICT_FULL
+        assert unknown == [backend]
+
+
+def test_allowlist_version_bumped_to_6_for_the_v6_entries() -> None:
+    """The skip-banner logs the version that approved a skip; a rules change
+    without a bump makes the log line unattributable."""
+    assert pc.ALLOWLIST_VERSION >= 6
+    assert (".gitignore", (".gitignore",)) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+    assert ("infra/home-fork", (".json",)) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+
+
+def test_edge_v6_added_no_second_allowlist_mechanism() -> None:
+    """ANTI-DRIFT. The odd-looking `(".gitignore", (".gitignore",))` shape is
+    the price of keeping ONE uniform mechanism. The tempting "tidy" is a
+    second exact-match allowlist container — which is exactly what the v2
+    MUST-FIX removed (`ALLOWLIST_INNOCENT_PREFIXES`). Same self-check as
+    test_edge_allowlist_prefixes_have_no_trailing_slash, one generation on.
+    """
+    for forbidden in (
+        "ALLOWLIST_INNOCENT_PREFIXES",
+        "ALLOWLIST_EXACT_PATHS",
+        "ALLOWLIST_INNOCENT_EXACT_PATHS",
+        "ROOT_LEVEL_INNOCENT_EXACT",
+    ):
+        assert not hasattr(pc, forbidden), (
+            f"{forbidden} exists — a second allowlist mechanism reintroduces the "
+            "class of bug v2 removed; express exact matches through "
+            "ALLOWLIST_PREFIX_SUFFIX_PAIRS instead"
+        )
+
+
 # ---------------------------------------------------------------------------
 # The gate's INPUT, not its rules: `.husky/pre-push` must enumerate changed
 # files against the MERGE-BASE with origin/main, never against $remote_sha.

--- a/scripts/tests/test_prepush_classify.py
+++ b/scripts/tests/test_prepush_classify.py
@@ -1162,6 +1162,21 @@ def test_innocence_real_v6_replay_flips_skip() -> None:
         assert unknown == []
 
 
+def test_innocence_both_v6_entries_in_one_diff_skip() -> None:
+    """COMPOSITION, not just each entry alone.
+
+    Ported from the stranded `99-allowlist-v6-gitignore-homefork` branch,
+    which reached the same two-entry design independently — this was the one
+    case its corpus had that the replay-driven corpus here did not. W94's
+    lesson: a corpus that tests each rule in isolation misses the shape where
+    two of them have to agree, and commit 2b5d2b915e is exactly that shape
+    (both entries in one diff).
+    """
+    verdict, unknown = pc.classify([".gitignore", "infra/home-fork/declared-pairs.json"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
 def test_guilt_nested_gitignore_under_backend_forces_full() -> None:
     """THE load-bearing guilt test for v6.
 


### PR DESCRIPTION
## What

Two entries on the pre-push innocent allowlist: the **root `.gitignore`** (matched exactly) and **`infra/home-fork/**` scoped to `.json`**. Version bumped 5 → 6 so the skip banner stays attributable.

## Found by replay, not by being bitten

Rather than wait for the next 40-minute suite paid on a diff pytest cannot see, I replayed the decision. Every non-merge commit of the last 90 days — **3458** of them — had its file list classified twice: once against the live v5 table, once against v5 + these two candidates, counting only the verdicts that **flip `full` → `skip`**.

```
commits scanned:        3458  (last 90d, no merges)
already skip under v5:   813
still full under v6:    2465   (correctly — they carry backend/Python/data)
FLIPPED full -> skip:     24
```

**24.** That is the honest size of this change — roughly 3% more diffs skipping, not a revolution. What makes it worth landing is *which* 24: they are the two shapes this fleet produces constantly. 15 flips are the root `.gitignore` (10 of them one-file diffs); 10 are `infra/home-fork/declared-pairs.json`; one commit is both. The extreme case, `f1254477cb`, paid a full ~17k-test backend suite for **19 files of pure launchd config** plus one JSON declaration.

The replay is a per-COMMIT measurement, which is a proxy for per-push — a push that bundles one of these commits together with a backend file still, correctly, goes full. `test_guilt_v6_entries_mixed_with_backend_force_full` pins that.

## `.gitignore` is root-EXACT, never by basename

This is load-bearing, not caution theatre. **22 `.gitignore` files are tracked repo-wide**, and one of them is `apps/backend-rag/backend/data/.gitignore` — *inside the very tree whose tests the skip would spare*. A basename rule would have admitted it. This entry cannot: the prefix test is satisfied only by `path == ".gitignore"`, so every nested one still falls to "unknown → full". `test_guilt_nested_gitignore_under_backend_forces_full` is that exact case; `test_guilt_non_root_gitignore_anywhere_forces_full` is its general form.

**On the shape `(".gitignore", (".gitignore",))`** — prefix = the file, suffix = its own name. It looks odd on purpose: it is how the ONE uniform mechanism expresses an exact root-level match, which means v6 adds **zero new code paths** to `_innocent_reason`. The tempting tidy-up is a second, exact-match allowlist container — and a second allowlist mechanism is precisely what the v2 round-1 MUST-FIX removed (`ALLOWLIST_INNOCENT_PREFIXES`, the bare-prefix list that made the allowlist extension-blind). `test_edge_v6_added_no_second_allowlist_mechanism` pins that it stays gone, in the same idiom as the existing v2 self-check one generation up.

## `infra/home-fork` is scoped to `.json`

One tracked file today: `declared-pairs.json`, the HOME-fork guard's registry of live-copy↔repo pairs (superscar #1) — 31 commits in its lifetime, latest 2026-07-25 (#3115), still growing. It travels *with* plists and wrappers, which are already innocent, so those diffs were failing the unanimity test on a single JSON declaration. Its only readers are `scripts/lint_home_fork.py` and `scripts/proprioception.py`, neither reachable from `pytest backend/tests/`.

Scoped to `.json` so a future `.py` helper or `.md` note dropped in that directory falls back to full rather than inheriting a blessing that was measured on a data file.

## Innocence measured, with the v5 anchored method

Not assumed, and not by bare substring — v5's own note explains why a bare grep false-positives (`backend.app.agents.graph` for `.agents`, `apps/backend-rag/scripts/ci_bootstrap_schema.py` for `scripts/ci`), which is the guard-over-match failure mode (superscar #3) applied to a *test* of innocence rather than to the guard:

- `infra/home-fork` — zero hits for the directory-anchored `infra/home-fork/` anywhere under `apps/backend-rag/backend/`; and, checked separately because an anchored grep can hide a basename reference, zero hits for bare `home-fork` and zero for `declared-pairs` there too.
- `.gitignore` — exactly 3 files under `apps/backend-rag/backend/` contain the string "gitignore" at all. Two are **prose** in a docstring/comment ("ops-populated and gitignored per…", "The gitignored…") with zero IO calls. The third **is** the nested `.gitignore` above, which this entry does not admit. No backend test opens the root `.gitignore`.

## Corpus (guilt AND innocence, both halves)

9 new tests in `scripts/tests/test_prepush_classify.py`, which `.github/workflows/immune-enforcement.yml` already runs on a real pytest line (verified — armed, not merely written):

**Innocence** — root `.gitignore` alone; `declared-pairs.json` alone; and the **verbatim file lists of four real flipped commits** (`f1254477cb`, `17eed8ebbd`, `b2f7264824`, `70db573245`), not hand-authored plausible ones.

**Guilt** — the nested backend `.gitignore`; nested `.gitignore` anywhere; lookalike names (`.gitignore.bak`, `.gitignore-old`, `.gitignoreignore`, `.gitignore.save/.gitignore`); non-`.json` under `infra/home-fork/`; lookalike prefixes (`infra/home-fork-legacy/`, `infra/home-forked/`); unanimity with a backend file; and the no-second-mechanism pin.

**Non-vacuity proved empirically, not argued**: reverting `scripts/prepush_classify.py` to `origin/main` turns the 3 innocence tests **and** the version pin red (5 failures) while every pure-guilt test stays green — so the innocence half genuinely depends on this diff, and the guilt half genuinely holds in both worlds.

```
pytest scripts/tests/test_prepush_classify.py -q        # 118 passed
```

## Notes

- **This diff pays the full suite itself.** `scripts/prepush_classify.py` is a `NEVER_INNOCENT_EXACT_PATHS` entry — correct by design, and `test_guilt_prepush_classify_itself_forces_full` asserts it. The PR that makes other diffs cheaper does not make itself cheap.
- **No arming step, no ledger entry.** The hook resolves the classifier from the pushing worktree, so a worktree gets v6 when it rebases onto main — ordinary branch freshness, not suspended armament. Older copies degrade the safe way: they run *more* suites, never fewer.
- Not a hot-zone path (verified against `hot-zone-pr-gate.yml`'s case list), so no hot-zone gate involvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
