### PR TITLE
fix(deps): close two HIGH transformers advisories — the huggingface-hub cap was never required

### DIFF
--- a/apps/backend-rag/backend/tests/services/rag/test_reranker.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_reranker.py
@@ -124,9 +124,6 @@ class TestCrossEncoderRerankerInit:
             assert reranker.enabled is True
 
 
-@pytest.mark.skip(
-    reason="huggingface-hub version conflict in venv — requires manual pip install -e. Run full test suite with clean venv."
-)
 class TestCrossEncoderRerankerModelLoading:
     """Tests for model loading functionality."""
 

--- a/apps/backend-rag/requirements.lock.txt
+++ b/apps/backend-rag/requirements.lock.txt
@@ -700,6 +700,7 @@ click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
     --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
     # via
+    #   huggingface-hub
     #   litellm
     #   uvicorn
 cloudpathlib==0.24.0 \
@@ -1086,7 +1087,6 @@ filelock==3.31.1 \
     #   python-discovery
     #   tldextract
     #   torch
-    #   transformers
     #   virtualenv
 frozenlist==1.8.0 \
     --hash=sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686 \
@@ -1614,6 +1614,7 @@ httpx==0.28.1 \
     #   anthropic
     #   datasets
     #   google-genai
+    #   huggingface-hub
     #   langfuse
     #   langgraph-sdk
     #   langsmith
@@ -1626,9 +1627,9 @@ httpx-sse==0.4.3 \
     --hash=sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc \
     --hash=sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d
     # via mcp
-huggingface-hub==0.36.2 \
-    --hash=sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a \
-    --hash=sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270
+huggingface-hub==1.25.1 \
+    --hash=sha256:004d4e70350517e24c68a7dbb7dc5e40b2b6aefef8f94bf7a85f6f9835102ea5 \
+    --hash=sha256:21129595ca7a753be479b319913e22cc8808361ac118bd76cc413db831b28a99
     # via
     #   -r requirements.txt
     #   datasets
@@ -3937,7 +3938,6 @@ requests==2.34.2 \
     #   google-cloud-bigquery
     #   google-cloud-storage
     #   google-genai
-    #   huggingface-hub
     #   langsmith
     #   opentelemetry-exporter-otlp-proto-http
     #   requests-file
@@ -3946,7 +3946,6 @@ requests==2.34.2 \
     #   spacy
     #   tiktoken
     #   tldextract
-    #   transformers
     #   twilio
     #   webdriver-manager
 requests-file==3.0.1 \
@@ -4736,10 +4735,12 @@ tqdm==4.69.0 \
     #   sentence-transformers
     #   spacy
     #   transformers
-transformers==4.57.6 \
-    --hash=sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550 \
-    --hash=sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3
-    # via sentence-transformers
+transformers==5.14.1 \
+    --hash=sha256:60d196c27781eacf8637e2b533f517582907ad6f9ae142046d6b69431a5b2173 \
+    --hash=sha256:9db974c4079ede2d1a3ea7ca5a240df33f2cc26fc2b36ba64c5f2a4f43b6e725
+    # via
+    #   -r requirements.txt
+    #   sentence-transformers
 trio==0.33.0 \
     --hash=sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b \
     --hash=sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970
@@ -4759,6 +4760,7 @@ typer==0.27.0 \
     --hash=sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1
     # via
     #   spacy
+    #   transformers
     #   weasel
 typing-extensions==4.16.0 \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -37,7 +37,8 @@ anthropic>=0.117.0  # Upgraded for httpx 0.28+ compatibility
 # PyTorch 2.2.0+ required for transformers compatibility (register_pytree_node)
 torch>=2.13.0  # Security: RCE via torch.load fixed in 2.6.0 (CVE-2025-32434)
 sentence-transformers>=5.6.0  # Updated 2026-03-14: tested compatible, CrossEncoder API stable, sparse embeddings support
-huggingface-hub>=0.34.0,<1.0  # Required by sentence-transformers CrossEncoder model loading
+transformers>=5.5.0  # Security: HIGH GHSA-fgcw-684q-jj6r (<5.5.0) + GHSA-29pf-2h5f-8g72 (<5.3.0), fixed 5.5.0
+huggingface-hub>=1.5.0,<2.0  # transformers>=5.5.0 requires hub>=1.5.0,<2.0; sentence-transformers itself has no upper cap (verified via wheel METADATA)
 tiktoken>=0.5.0  # For accurate token estimation (optional, has fallback)
 
 # PII Detection (UU PDP compliance)


### PR DESCRIPTION
Closes the two open HIGH advisories on `transformers` — `GHSA-fgcw-684q-jj6r` (vulnerable `<5.5.0`) and `GHSA-29pf-2h5f-8g72` (`<5.3.0`) — and supersedes #3278, which could never pass.

## Why the Dependabot PR was unmergeable by construction

#3278 bumped **only** `transformers` in the lock. But `transformers==5.5.0` requires `huggingface-hub>=1.5.0`, and the manifest capped `huggingface-hub<1.0`, so `uv` failed to resolve in ~5 seconds:

```
Because transformers==5.5.0 depends on huggingface-hub>=1.5.0 and you
require huggingface-hub==0.36.2, we can conclude that your requirements
and transformers==5.5.0 are incompatible.
```

**A lock-only bump can never satisfy a manifest cap.** Two required checks were red for that single reason.

## The cap was never justified

The manifest carried:

```
huggingface-hub>=0.34.0,<1.0  # Required by sentence-transformers CrossEncoder model loading
```

Read from wheel METADATA (`Requires-Dist`), not recollection:

| package | declares |
|---|---|
| sentence-transformers 5.6.0 / 5.6.1 | `huggingface-hub>=0.23.0` — **no upper cap** |
| transformers 5.5.0 | `huggingface-hub<2.0,>=1.5.0`, `tokenizers<=0.23.0,>=0.22.0` |
| datasets 4.8.5 | `huggingface-hub<2.0,>=0.25.0` |

sentence-transformers never required `<1.0`. That comment is what made the advisory look unfixable. `tokenizers` needs no bump — 5.5.0 declares the same range 4.57.6 did.

## The change

Manifest raised to `huggingface-hub>=1.5.0,<2.0` plus an explicit `transformers>=5.5.0` security floor; the lock regenerated **in the same commit** (`test_lock_honors_requirements.py` green — a lock that disagrees with its manifest is the W98 scar). Resolved: `transformers 5.14.1`, `huggingface-hub 1.25.1`; `sentence-transformers`, `tokenizers`, `torch`, `datasets` unchanged.

## Production is NOT exposed — stated plainly so nobody infers an incident

`requirements-prod.lock.txt` contains **zero** lines naming transformers; `requirements-prod.txt` mentions it only in a comment explaining it is deliberately excluded in favour of OpenAI API embeddings; and the Dockerfile installs from the prod lock. The vulnerable package reaches developer machines and CI, not the production image. Worth closing — not a production incident.

## Verified

* Full `uv pip install -r requirements.lock.txt` succeeded; every module referencing transformers imported cleanly (`backend.services.rag.reranker`, `_integration`, `_registry`, `backend.core.embeddings`, `backend.app.core.config`, `backend.app.setup.router_registration`, `backend.services.search.search_service`).
* `backend/tests/services/rag/test_reranker.py` passes (37 tests).
* The frozen embedding invariant is untouched: `text-embedding-3-small` / 1536 dims, and no CrossEncoder model ID changed. The diff contains no line mentioning the embedding model.

## Test coverage restored by the second commit

`backend/tests/services/rag/test_reranker.py:127` carried an **unconditional** `@pytest.mark.skip(reason="huggingface-hub version conflict in venv …")` on `TestCrossEncoderRerankerModelLoading`. This change removes that stated cause, so the skip's justification became false — and a skip whose reason is false is never revisited, so the CrossEncoder model-loading path would have stayed untested indefinitely.

The decorator is deleted in the follow-up commit (three lines; the class, its docstring and its tests are untouched). That returns **6** tests to execution:

`test_load_model_success` · `test_load_model_uses_cache` · `test_load_model_import_error` · `test_load_model_generic_error` · `test_model_property_lazy_loading` · `test_model_property_when_disabled`

To be precise about the number, since an earlier draft of this description was ambiguous: **36 is the total number of tests in the file**, all of which pass under the new resolution. **6** is how many of them were previously skipped and now run. No `@pytest.mark.skip` remains in the file.
