### PR TITLE
fix(ci): anchor venv-guard ordering test to real anchors, arm it in CI

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -156,6 +156,7 @@ jobs:
             scripts/tests/test_docs_inventory_regen.py \
             scripts/tests/test_fly_backup_timeouts.py \
             scripts/tests/test_no_import_time_chdir_in_tests.py \
+            scripts/tests/test_husky_prepush_venv_guard.py \
             scripts/test_lint_test_reward_hacking.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"

--- a/scripts/tests/test_husky_prepush_venv_guard.py
+++ b/scripts/tests/test_husky_prepush_venv_guard.py
@@ -31,9 +31,43 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 HOOK_FILE = REPO_ROOT / ".husky" / "pre-push"
 GUARD_ELIF_LINE = "elif [ ! -f apps/backend-rag/.venv/bin/activate ]; then"
 
+# ---------------------------------------------------------------------------
+# ORDERING ANCHORS (cicatrix-superscar.md #3 lineage, own family).
+#
+# Found 2026-07-27: the hook's own prose comments reference `CLONE_DB=$$`
+# and `` `python -m pytest` `` as EXPLANATION (line ~291-292, "wraps ONLY the
+# `python -m pytest` call below — not the DB clone, already isolated
+# per-push via CLONE_DB=$$"), sitting textually BEFORE the real venv-guard
+# `elif` line. A bare `text.find("CLONE_DB=")` / `text.find("python -m
+# pytest")` matches those comment mentions, not the real assignment/
+# invocation, and reports a false ordering: guard AFTER "clone" AFTER
+# "pytest" — the opposite of the truth, which is guard(317) < clone(356) <
+# pytest(505) by LINE NUMBER. The test was red on main with a green hook.
+#
+# Anchored on the ACTUAL executable forms instead of a bare label a comment
+# can also contain:
+#   - the real assignment: `CLONE_DB="..."` (regex, start-of-line, so a
+#     mid-comment "CLONE_DB=$$" — no quote character right after the equals
+#     sign — cannot match)
+#   - the real invocation: `python -m pytest backend/tests/` (the comment
+#     only ever says the BARE phrase `python -m pytest`, never followed by
+#     the argument list the real call always carries)
+# ---------------------------------------------------------------------------
+_CLONE_DB_ASSIGNMENT_RE = re.compile(r'^\s*CLONE_DB="', re.MULTILINE)
+_PYTEST_INVOCATION_NEEDLE = "python -m pytest backend/tests/"
+
 
 def _hook_text() -> str:
     return HOOK_FILE.read_text()
+
+
+def _ordering_anchors(text: str) -> tuple[int, int, int]:
+    """(guard_idx, clone_idx, pytest_idx), each -1 if not found."""
+    guard_idx = text.find(GUARD_ELIF_LINE)
+    m = _CLONE_DB_ASSIGNMENT_RE.search(text)
+    clone_idx = m.start() if m else -1
+    pytest_idx = text.find(_PYTEST_INVOCATION_NEEDLE)
+    return guard_idx, clone_idx, pytest_idx
 
 
 def _extract_venv_guard_test_expr() -> str:
@@ -87,9 +121,7 @@ def main() -> int:
     # missing venv still burns a Postgres clone (or worse, still reaches
     # pytest) before anyone finds out — the whole point is to short-circuit
     # early and cheaply.
-    guard_idx = text.find(GUARD_ELIF_LINE)
-    clone_idx = text.find("CLONE_DB=")
-    pytest_idx = text.find("python -m pytest")
+    guard_idx, clone_idx, pytest_idx = _ordering_anchors(text)
     if guard_idx == -1 or clone_idx == -1 or pytest_idx == -1:
         failures.append(
             f"  ORDERING: could not locate all 3 anchors (guard={guard_idx} clone={clone_idx} pytest={pytest_idx})"
@@ -122,16 +154,73 @@ def test_venv_guard_does_not_fire_when_venv_present():
 
 
 def test_venv_guard_precedes_db_clone_and_pytest_invocation():
-    text = _hook_text()
-    guard_idx = text.find(GUARD_ELIF_LINE)
-    clone_idx = text.find("CLONE_DB=")
-    pytest_idx = text.find("python -m pytest")
+    guard_idx, clone_idx, pytest_idx = _ordering_anchors(_hook_text())
     assert guard_idx != -1 and clone_idx != -1 and pytest_idx != -1
     assert guard_idx < clone_idx < pytest_idx
 
 
 def test_venv_guard_skip_message_present():
     assert "SKIP Python tests — worktree has no apps/backend-rag/.venv" in _hook_text()
+
+
+# ---------------------------------------------------------------------------
+# GUILT + INNOCENCE on the ordering anchors THEMSELVES (superscar #3: this
+# is the guardian of the guardian — the anchor logic needs its own proof
+# that it does not repeat the exact false-red it was just cured of).
+# ---------------------------------------------------------------------------
+
+
+def test_innocence_a_comment_mentioning_clone_db_before_the_guard_does_not_trip_ordering():
+    """Reproduces the false-red verbatim: a prose comment that says
+    `CLONE_DB=$$` and `python -m pytest` (no arguments, backtick-quoted)
+    sitting textually BEFORE the guard must NOT be read as "clone/pytest
+    happen before the guard". This is what the live hook actually contains,
+    which is exactly why the un-anchored version was red on a correct hook.
+    """
+    synthetic = (
+        "# some explanatory comment mentioning CLONE_DB=$$ and the\n"
+        "# `python -m pytest` call, written for a human, above the guard.\n"
+        f"{GUARD_ELIF_LINE}\n"
+        "    echo SKIP\n"
+        "else\n"
+        '    CLONE_DB="real_assignment_here"\n'
+        "    ...\n"
+        "    python -m pytest backend/tests/ --ignore=backend/tests/e2e -q\n"
+        "fi\n"
+    )
+    guard_idx, clone_idx, pytest_idx = _ordering_anchors(synthetic)
+    assert guard_idx != -1 and clone_idx != -1 and pytest_idx != -1
+    assert guard_idx < clone_idx < pytest_idx
+
+
+def test_guilt_a_genuinely_reordered_hook_still_fails():
+    """SCAR-PIN: if the real assignment/invocation were moved BEFORE the
+    guard, this must still be caught — the fix must not have swung to the
+    opposite failure mode of never firing at all."""
+    synthetic = (
+        '    CLONE_DB="real_assignment_here"\n'
+        "    python -m pytest backend/tests/ --ignore=backend/tests/e2e -q\n"
+        f"{GUARD_ELIF_LINE}\n"
+        "    echo SKIP\n"
+        "fi\n"
+    )
+    guard_idx, clone_idx, pytest_idx = _ordering_anchors(synthetic)
+    assert guard_idx != -1 and clone_idx != -1 and pytest_idx != -1
+    assert not (guard_idx < clone_idx < pytest_idx)
+
+
+def test_guilt_missing_real_assignment_is_reported_as_not_found():
+    """A hook with only the comment mention and no real assignment must
+    report clone_idx == -1, not silently match the comment as if it were
+    real — the -1 sentinel is what test_venv_guard_precedes_db_clone_and_
+    pytest_invocation's own guard clause depends on."""
+    synthetic = (
+        "# a comment mentioning CLONE_DB=$$ but never actually assigning it\n"
+        f"{GUARD_ELIF_LINE}\n"
+        "    echo SKIP\n"
+    )
+    _, clone_idx, _ = _ordering_anchors(synthetic)
+    assert clone_idx == -1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix(ci): anchor venv-guard ordering test to real anchors, arm it in CI

test_venv_guard_precedes_db_clone_and_pytest_invocation was red on a
correct .husky/pre-push: bare text.find("CLONE_DB=") / text.find("python
-m pytest") matched prose comments at lines 291-292 that explain the
guard, sitting textually BEFORE the real elif — reporting the opposite
ordering of the truth (guard(317) < clone(356) < pytest(505) by line
number). Anchor on the real executable forms instead: a start-of-line
regex for the CLONE_DB="..." assignment, and the full invocation string
"python -m pytest backend/tests/" that only the real call ever carries.
Added guilt/innocence tests on the anchor logic itself so it cannot
regress into the same false-red it was just cured of, and a guilt test
that a genuinely reordered hook still fails.

Second half: this whole test file was armed by zero workflows, so the
false red sat on main unnoticed. Add it to immune-enforcement.yml's
existing unit-test loop.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
