### PR TITLE
fix(prepush): stop labelling the exact-match entry as a directory glob

### DIFF
--- a/scripts/prepush_classify.py
+++ b/scripts/prepush_classify.py
@@ -609,6 +609,22 @@ def _innocent_reason(path: str) -> str | None:
         return "root-level *.md"
     for prefix, suffixes in ALLOWLIST_PREFIX_SUFFIX_PAIRS:
         if (path == prefix or path.startswith(prefix + "/")) and path.endswith(suffixes):
+            # The MATCH condition above is one uniform mechanism (v6 kept it
+            # deliberately so — see the table's v6 section). Only the human-facing
+            # LABEL branches, because the two arms of that `or` describe different
+            # rules and one string cannot honestly name both:
+            #   - `path == prefix` is an EXACT file rule. Rendering it as
+            #     `<prefix>/**` invents a DIRECTORY that does not exist — the v6
+            #     `.gitignore` entry printed `.gitignore/** (.gitignore)`, which
+            #     reads as "any .gitignore under a .gitignore/ directory" and
+            #     actively misleads anyone asking whether a NESTED .gitignore
+            #     skips (it does not — that is the whole point of root-exact).
+            #   - `path.startswith(prefix + "/")` really is a directory rule.
+            # Same defect class as W106's anchored diagnosis: the verdict was
+            # right, the explanation named the wrong thing, and the explanation
+            # is what the next reader acts on.
+            if path == prefix:
+                return f"{prefix} (exact match)"
             return f"{prefix}/** ({'/'.join(suffixes)})"
     return None
 

--- a/scripts/tests/test_prepush_classify.py
+++ b/scripts/tests/test_prepush_classify.py
@@ -1394,3 +1394,97 @@ def test_merge_base_range_excludes_mains_files_while_remote_sha_range_does_not(
     assert "mains_file.txt" in changed(remote_sha)
     # INNOCENCE: the merge-base anchor sees only what the branch contributes.
     assert changed(merge_base) == {"branch_file.txt"}
+
+
+# ---------------------------------------------------------------------------
+# The REASON LABEL (added 2026-07-27, after proving v6 live on main).
+#
+# The matching condition `(path == prefix or path.startswith(prefix + "/"))`
+# is ONE mechanism covering two different rule shapes. It classifies both
+# correctly, but the reason string rendered `<prefix>/**` for BOTH — so the
+# v6 root-exact entry printed `.gitignore/** (.gitignore)`, naming a
+# `.gitignore/` DIRECTORY that does not exist and cannot exist as a rule
+# here. Discovered by reading the shipped tool's real output during
+# PROVE-LIVE, not from the diff.
+#
+# Why this is worth pinning rather than shrugging at: the message is the
+# only thing a human reads when asking "why was my suite skipped / why was
+# it NOT skipped?". A reader who takes `.gitignore/**` at face value
+# concludes the rule is directory-shaped and reasons wrongly about whether
+# `apps/backend-rag/backend/data/.gitignore` skips (it must NOT — that
+# guilt case is what makes root-exact the safe shape). Same defect class as
+# W106: the verdict was right and the DIAGNOSIS was anchored to the wrong
+# thing, and the diagnosis is what the next reader acts on.
+#
+# These tests are about the LABEL only. The verdict tests above are the
+# regression guard that this cosmetic change moved no classification.
+# ---------------------------------------------------------------------------
+
+
+def test_label_exact_match_entry_does_not_invent_a_directory() -> None:
+    """GUILT on the old label: the root `.gitignore` entry must NOT render as
+    `.gitignore/**`, which describes a directory rule this table has never
+    had."""
+    reason = pc._innocent_reason(".gitignore")
+    assert reason is not None, "root .gitignore must still be innocent"
+    assert "/**" not in reason, (
+        f"exact-match entry rendered a directory glob: {reason!r} — this is the "
+        "misleading form the label fix exists to remove"
+    )
+    assert reason == ".gitignore (exact match)"
+
+
+def test_label_directory_entry_still_renders_the_glob() -> None:
+    """INNOCENCE: the fix must not swing the other way and strip `/**` from
+    entries that genuinely ARE directory-scoped."""
+    reason = pc._innocent_reason("infra/home-fork/declared-pairs.json")
+    assert reason is not None
+    assert reason == "infra/home-fork/** (.json)"
+
+
+def test_label_change_moved_no_verdict_for_either_v6_class() -> None:
+    """The label branch must be provably cosmetic: both v6 classes still SKIP,
+    alone and together, and the load-bearing nested-.gitignore guilt case
+    still forces FULL. If a label edit ever changes one of these, the edit
+    was not cosmetic."""
+    for files in (
+        [".gitignore"],
+        ["infra/home-fork/declared-pairs.json"],
+        [".gitignore", "infra/home-fork/declared-pairs.json"],
+    ):
+        verdict, unknown = pc.classify(files)
+        assert verdict == pc.VERDICT_SKIP, f"{files} should skip, got {verdict}"
+        assert unknown == []
+
+    for files in (
+        ["apps/backend-rag/backend/data/.gitignore"],
+        ["apps/mouth/.gitignore"],
+        ["x.gitignore"],
+        ["infra/home-fork/README.md"],
+        ["infra/home-fork-extra/declared-pairs.json"],
+    ):
+        verdict, _ = pc.classify(files)
+        assert verdict == pc.VERDICT_FULL, f"{files} should force full, got {verdict}"
+
+
+def test_label_every_allowlist_entry_gets_a_reason_naming_its_own_prefix() -> None:
+    """Sweep the WHOLE table rather than only the entry that bit us (the
+    SYMMETRY clause from the fly-backup scar: a fix that covers only the case
+    that bit you is half a fix). For each entry, a representative matching
+    path must produce a reason that names that entry's prefix and does not
+    invent a directory for exact-match entries."""
+    for prefix, suffixes in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS:
+        suffix = suffixes[0]
+        exact_shaped = prefix.endswith(suffix)
+        sample = prefix if exact_shaped else f"{prefix}/probe{suffix}"
+        reason = pc._innocent_reason(sample)
+        if reason is None:
+            # A NEVER_INNOCENT_* net legitimately outranks the table for some
+            # samples; that is a different rule, not a label defect.
+            continue
+        assert prefix in reason, f"reason {reason!r} does not name its prefix {prefix!r}"
+        if sample == prefix:
+            assert "/**" not in reason, (
+                f"entry {prefix!r} matched EXACTLY but was labelled with a "
+                f"directory glob: {reason!r}"
+            )


### PR DESCRIPTION
fix(prepush): stop labelling the exact-match entry as a directory glob

Found by reading the shipped v6 classifier's real output while proving
#3345 live, not from the diff: a root-exact allowlist entry printed
`.gitignore  <-  .gitignore/** (.gitignore)`. The classification was
correct in every case (3/3 innocent classes skip, 6/6 guilt cases force
full, verified against origin/main's copy) — but the explanation named a
`.gitignore/` DIRECTORY rule that does not and cannot exist here, which
is precisely the opposite of what root-exact means. A reader trusting
that line would conclude the rule is directory-shaped and reason wrongly
about whether `apps/backend-rag/backend/data/.gitignore` skips; it must
not, and that guilt case is the reason root-exact is the safe shape.

Same defect class as the fly-credential scar: the verdict was right and
the DIAGNOSIS was anchored to the wrong thing — and the diagnosis is what
the next reader acts on.

The single matching condition is untouched (v6 deliberately kept one
uniform mechanism); only the human-facing label branches, because the two
arms of that `or` describe different rule shapes and one string cannot
honestly name both. Tests: 2 guilt (exact entry must not render `/**`;
whole-table sweep, per the symmetry clause — not only the entry that bit
us) + 2 innocence (directory entries still render their glob; no verdict
moved for any v6 class). Mutation-verified: reverting the label branch
turns both guilt tests red and leaves the innocence tests green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
