### PR TITLE
fix(portal): make required document uploads reliable

### DIFF
--- a/apps/mouth/public/sw.js
+++ b/apps/mouth/public/sw.js
@@ -2,49 +2,17 @@
  * Bali Zero Service Worker
  *
  * Minimal PWA shell:
- *   - /api/* → Stale-While-Revalidate (cached JSON reused instantly, refreshed
- *     in background)
- *   - everything else → NOT intercepted (browser/CDN handle it)
+ *   - authenticated API responses are NEVER cached or intercepted
+ *   - page requests and static assets are left to the browser/CDN
  *
- * Previous iterations tried to cache static chunks/fonts/images. That caused
- * Chrome to hit ERR_INSUFFICIENT_RESOURCES under parallel load because the
- * SW-mediated cache.open + match + fetch pipeline exceeds the per-origin
- * socket budget when Next.js hydrates dozens of chunks in parallel. We keep
- * the SW scope tight to pure API data now.
+ * Previous iterations cached every /api/* GET with stale-while-revalidate.
+ * Besides replaying stale CRM rows after mutations, that policy could retain
+ * authenticated responses across sessions on a shared browser. The service
+ * worker stays installed for PWA discoverability, but deliberately owns no
+ * response cache.
  */
 
-const VERSION = "v8";
-const API_CACHE = `balizero-api-${VERSION}`;
-
-function isAPIRequest(url) {
-  return url.pathname.startsWith("/api/");
-}
-
-async function staleWhileRevalidate(request, cacheName) {
-  const cache = await caches.open(cacheName);
-  const cached = await cache.match(request);
-
-  const fetchPromise = fetch(request)
-    .then((networkResponse) => {
-      if (networkResponse.ok) {
-        cache.put(request, networkResponse.clone());
-      }
-      return networkResponse;
-    })
-    .catch(
-      () =>
-        cached ||
-        new Response(
-          JSON.stringify({ error: "offline", detail: "Network unavailable" }),
-          {
-            status: 503,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-    );
-
-  return cached || fetchPromise;
-}
+const VERSION = "v9";
 
 self.addEventListener("install", () => {
   // Nothing to pre-cache. skipWaiting so updated SWs take effect on reload.
@@ -52,32 +20,20 @@ self.addEventListener("install", () => {
 });
 
 self.addEventListener("activate", (event) => {
-  // Drop any cache from older SW versions so they don't leak memory.
+  // Purge all historical Bali Zero caches, including authenticated API data
+  // written by v8 and earlier.
   event.waitUntil(
     caches
       .keys()
       .then((names) =>
         Promise.all(
           names
-            .filter((n) => n.startsWith("balizero-") && n !== API_CACHE)
+            .filter((name) => name.startsWith("balizero-"))
             .map((n) => caches.delete(n)),
         ),
       ),
   );
   self.clients.claim();
-});
-
-self.addEventListener("fetch", (event) => {
-  const { request } = event;
-  const url = new URL(request.url);
-
-  if (request.method !== "GET") return;
-  if (url.protocol === "chrome-extension:") return;
-  if (url.origin !== self.location.origin) return;
-  if (url.searchParams.has("_rsc")) return;
-  if (!isAPIRequest(url)) return;
-
-  event.respondWith(staleWhileRevalidate(request, API_CACHE));
 });
 
 self.addEventListener("message", (event) => {

--- a/apps/mouth/src/app/manifest.ts
+++ b/apps/mouth/src/app/manifest.ts
@@ -8,8 +8,8 @@ import type { MetadataRoute } from "next";
  * client portal (my.balizero.com) installable to a phone home screen and gives
  * it a standalone, app-like shell on launch.
  *
- * The service worker (public/sw.js, registered in layout.tsx) handles offline
- * API caching; this manifest is the install/appearance half of the PWA contract.
+ * The service worker (public/sw.js, registered in layout.tsx) keeps the portal
+ * installable without caching authenticated API responses.
  *
  * `start_url` points at the portal: an installed icon should land the client in
  * their self-service area, not the public marketing site. Colours match the

--- a/apps/mouth/src/app/portal/(authenticated)/process/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/page.test.tsx
@@ -125,6 +125,14 @@ const pendingDocument: ClientRequiredDocument = {
   team_member_notes: null,
 };
 
+const secondPendingDocument: ClientRequiredDocument = {
+  ...pendingDocument,
+  id: 98,
+  document_type: "kaiser_live_browser_loop_photo",
+  document_label: "Kaiser Live QA Passport Photo",
+  description: "Recent passport photo",
+};
+
 class MockFileReader {
   result = "data:application/pdf;base64,a2Fpc2Vy";
   onloadend: (() => void) | null = null;
@@ -224,6 +232,91 @@ describe("PortalProcessPage", () => {
         },
       ]);
     });
+  });
+
+  it("guides the client through every pending document in one upload flow", async () => {
+    const user = userEvent.setup();
+    mockGetMyRequiredDocuments.mockResolvedValue([
+      pendingDocument,
+      secondPendingDocument,
+    ]);
+
+    const { default: PortalProcessPage } = await import("./page");
+    render(<PortalProcessPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Upload documents" }),
+    );
+
+    let dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Document 1 of 2")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText("Kaiser Live QA Address Statement"),
+    ).toBeInTheDocument();
+
+    await user.click(
+      within(dialog).getByRole("button", { name: /select test file/i }),
+    );
+    await user.click(
+      within(dialog).getByRole("button", { name: "Upload & continue" }),
+    );
+
+    await waitFor(() => {
+      expect(mockUploadClientDocument).toHaveBeenCalledTimes(1);
+    });
+
+    dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Document 2 of 2")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText("Kaiser Live QA Passport Photo"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("button", { name: "Upload last document" }),
+    ).toBeDisabled();
+
+    await user.click(
+      within(dialog).getByRole("button", { name: /select test file/i }),
+    );
+    await user.click(
+      within(dialog).getByRole("button", { name: "Upload last document" }),
+    );
+
+    await waitFor(() => {
+      expect(mockUploadClientDocument).toHaveBeenCalledTimes(2);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(mockUploadClientDocument).toHaveBeenNthCalledWith(2, 603, {
+      required_doc_id: 98,
+      file: "data:application/pdf;base64,a2Fpc2Vy",
+      file_name: "kaiser-address-statement.pdf",
+      notes: "",
+    });
+  });
+
+  it("clears the selected file when an upload is cancelled", async () => {
+    const user = userEvent.setup();
+    mockGetMyRequiredDocuments.mockResolvedValue([pendingDocument]);
+
+    const { default: PortalProcessPage } = await import("./page");
+    render(<PortalProcessPage />);
+
+    await user.click(await screen.findByRole("button", { name: /^upload$/i }));
+    let dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /select test file/i }),
+    );
+    expect(
+      within(dialog).getByRole("button", { name: /^upload$/i }),
+    ).toBeEnabled();
+
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^upload$/i }));
+    dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByRole("button", { name: /^upload$/i }),
+    ).toBeDisabled();
   });
 
   it("drives practice/doc status styling from semantic --state-* tokens (WS3 day pass)", async () => {

--- a/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
@@ -178,12 +178,16 @@ function DocumentUploadModal({
   onClose,
   onUpload,
   isUploading,
+  flowPosition,
+  flowTotal,
 }: {
   document: ClientRequiredDocument | null;
   isOpen: boolean;
   onClose: () => void;
   onUpload: (file: string, fileName: string, notes: string) => Promise<void>;
   isUploading: boolean;
+  flowPosition?: number;
+  flowTotal?: number;
 }) {
   const [file, setFile] = useState<File | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
@@ -220,13 +224,37 @@ function DocumentUploadModal({
 
   if (!document) return null;
 
+  const isUploadFlow = Boolean(flowPosition && flowTotal);
+  const hasNextDocument =
+    isUploadFlow && (flowPosition as number) < (flowTotal as number);
+  const submitLabel = isUploadFlow
+    ? hasNextDocument
+      ? "Upload & continue"
+      : "Upload last document"
+    : "Upload";
+
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Upload Document</DialogTitle>
+          <DialogTitle>
+            {isUploadFlow ? "Upload documents" : "Upload required document"}
+          </DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
+          {isUploadFlow && (
+            <div
+              className="flex items-center justify-between text-sm"
+              aria-live="polite"
+            >
+              <span className="font-medium">
+                Document {flowPosition} of {flowTotal}
+              </span>
+              <span style={{ color: "var(--bz-text-2)" }}>
+                One file for each requirement
+              </span>
+            </div>
+          )}
           <div
             className="p-3 rounded-lg backdrop-blur-md"
             style={{ background: "var(--glass-rim)" }}
@@ -246,8 +274,10 @@ function DocumentUploadModal({
             maxSize={10 * 1024 * 1024}
             onFileSelect={handleFileSelect}
             error={fileError}
-            compact
           />
+          <p className="text-xs" style={{ color: "var(--bz-text-2)" }}>
+            Accepted formats: PDF, JPG or PNG. Maximum file size: 10 MB.
+          </p>
 
           <div>
             <label
@@ -271,7 +301,11 @@ function DocumentUploadModal({
           </div>
 
           <div className="flex gap-2 justify-end">
-            <Button variant="outline" onClick={onClose} disabled={isUploading}>
+            <Button
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isUploading}
+            >
               Cancel
             </Button>
             <Button onClick={handleSubmit} disabled={!file || isUploading}>
@@ -283,7 +317,7 @@ function DocumentUploadModal({
               ) : (
                 <>
                   <Upload className="w-4 h-4 mr-2" />
-                  Upload
+                  {submitLabel}
                 </>
               )}
             </Button>
@@ -591,6 +625,10 @@ export default function PortalProcessPage() {
   const [uploadDoc, setUploadDoc] = useState<ClientRequiredDocument | null>(
     null,
   );
+  const [uploadFlow, setUploadFlow] = useState<{
+    position: number;
+    total: number;
+  } | null>(null);
 
   // Load profile and documents — stable reference, no toast dependency in deps
   const loadData = useCallback(
@@ -635,6 +673,31 @@ export default function PortalProcessPage() {
     loadData();
   }, [loadData]);
 
+  const pendingUploadDocuments = documents.filter(
+    (doc) => doc.status === "pending" || doc.status === "rejected",
+  );
+
+  const openSingleDocumentUpload = (doc: ClientRequiredDocument) => {
+    setUploadFlow(null);
+    setUploadDoc(doc);
+  };
+
+  const closeDocumentUpload = () => {
+    setUploadDoc(null);
+    setUploadFlow(null);
+  };
+
+  const startDocumentUploadFlow = () => {
+    const firstPendingDocument = pendingUploadDocuments[0];
+    if (!firstPendingDocument) return;
+
+    setUploadFlow({
+      position: 1,
+      total: pendingUploadDocuments.length,
+    });
+    setUploadDoc(firstPendingDocument);
+  };
+
   // Handle document upload
   const handleUpload = async (
     file: string,
@@ -643,10 +706,11 @@ export default function PortalProcessPage() {
   ) => {
     if (!uploadDoc) return;
 
+    const currentUploadDoc = uploadDoc;
     setIsUploading(true);
     try {
-      await api.crm.uploadClientDocument(uploadDoc.practice_id, {
-        required_doc_id: uploadDoc.id,
+      await api.crm.uploadClientDocument(currentUploadDoc.practice_id, {
+        required_doc_id: currentUploadDoc.id,
         file,
         file_name: fileName,
         notes,
@@ -654,7 +718,7 @@ export default function PortalProcessPage() {
 
       setDocuments((currentDocuments) =>
         currentDocuments.map((doc) =>
-          doc.id === uploadDoc.id
+          doc.id === currentUploadDoc.id
             ? {
                 ...doc,
                 uploaded_by_client: true,
@@ -664,12 +728,27 @@ export default function PortalProcessPage() {
             : doc,
         ),
       );
+
+      const nextDocument = uploadFlow
+        ? pendingUploadDocuments.find((doc) => doc.id !== currentUploadDoc.id)
+        : undefined;
       toastRef.current.success(
         "Document uploaded",
-        "Your document has been submitted for review",
+        nextDocument
+          ? "Select the next required document"
+          : "Your document has been submitted for review",
       );
-      setUploadDoc(null);
-      void loadData({ showLoading: false, showErrorToast: false });
+
+      if (nextDocument && uploadFlow) {
+        setUploadFlow({
+          position: uploadFlow.position + 1,
+          total: uploadFlow.total,
+        });
+        setUploadDoc(nextDocument);
+      } else {
+        closeDocumentUpload();
+        void loadData({ showLoading: false, showErrorToast: false });
+      }
     } catch (err) {
       toastRef.current.error("Upload failed", "Please try again");
       logger.error("Failed to upload document", {}, err as Error);
@@ -838,33 +917,43 @@ export default function PortalProcessPage() {
         <div className="space-y-4">
           {pendingDocs > 0 && (
             <div
-              className="rounded-lg p-4 flex items-start gap-3"
+              className="rounded-lg p-4 flex flex-col gap-4 sm:flex-row sm:items-center"
               style={{
                 background: "var(--bz-card)",
                 border:
                   "1px solid color-mix(in srgb, var(--state-warning) 30%, transparent)",
               }}
             >
-              <AlertTriangle
-                className="w-5 h-5 shrink-0 mt-0.5"
-                style={{ color: "var(--state-warning)" }}
-              />
-              <div>
-                <p
-                  className="font-medium"
+              <div className="flex flex-1 items-start gap-3">
+                <AlertTriangle
+                  className="w-5 h-5 shrink-0 mt-0.5"
                   style={{ color: "var(--state-warning)" }}
-                >
-                  Documents Required
-                </p>
-                <p
-                  className="text-sm"
-                  style={{ color: "var(--state-warning)" }}
-                >
-                  You have {pendingDocs} document{pendingDocs > 1 ? "s" : ""}{" "}
-                  waiting to be uploaded. Please upload them to proceed with
-                  your process.
-                </p>
+                />
+                <div>
+                  <p
+                    className="font-medium"
+                    style={{ color: "var(--state-warning)" }}
+                  >
+                    Documents Required
+                  </p>
+                  <p
+                    className="text-sm"
+                    style={{ color: "var(--state-warning)" }}
+                  >
+                    You have {pendingDocs} document
+                    {pendingDocs > 1 ? "s" : ""} waiting to be uploaded. Please
+                    upload them to proceed with your process.
+                  </p>
+                </div>
               </div>
+              <Button
+                type="button"
+                className="w-full sm:w-auto"
+                onClick={startDocumentUploadFlow}
+              >
+                <Upload className="w-4 h-4 mr-2" />
+                Upload {pendingDocs > 1 ? "documents" : "document"}
+              </Button>
             </div>
           )}
 
@@ -872,7 +961,7 @@ export default function PortalProcessPage() {
             <ProcessCard
               key={process.practiceId}
               process={process}
-              onUploadClick={setUploadDoc}
+              onUploadClick={openSingleDocumentUpload}
             />
           ))}
         </div>
@@ -880,11 +969,14 @@ export default function PortalProcessPage() {
 
       {/* Upload Modal */}
       <DocumentUploadModal
+        key={uploadDoc?.id ?? "closed"}
         document={uploadDoc}
         isOpen={!!uploadDoc}
-        onClose={() => setUploadDoc(null)}
+        onClose={closeDocumentUpload}
         onUpload={handleUpload}
         isUploading={isUploading}
+        flowPosition={uploadFlow?.position}
+        flowTotal={uploadFlow?.total}
       />
     </div>
   );

--- a/apps/mouth/src/lib/service-worker-cache-policy.test.ts
+++ b/apps/mouth/src/lib/service-worker-cache-policy.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+type ServiceWorkerListener = (event: {
+  request?: { method: string; url: string };
+  respondWith?: ReturnType<typeof vi.fn>;
+  waitUntil?: ReturnType<typeof vi.fn>;
+}) => void;
+
+function loadServiceWorker() {
+  const listeners = new Map<string, ServiceWorkerListener>();
+  const cache = {
+    match: vi.fn(),
+    put: vi.fn(),
+  };
+  const caches = {
+    open: vi.fn().mockResolvedValue(cache),
+    keys: vi.fn().mockResolvedValue(["balizero-api-v8"]),
+    delete: vi.fn().mockResolvedValue(true),
+  };
+  const self = {
+    location: { origin: "https://my.balizero.com" },
+    skipWaiting: vi.fn(),
+    clients: { claim: vi.fn() },
+    addEventListener: vi.fn((type: string, listener: ServiceWorkerListener) => {
+      listeners.set(type, listener);
+    }),
+  };
+
+  const source = readFileSync(join(process.cwd(), "public", "sw.js"), "utf8");
+  runInNewContext(source, {
+    self,
+    caches,
+    fetch: vi.fn(),
+    URL,
+    Response,
+    console: { log: vi.fn() },
+  });
+
+  return { listeners, caches };
+}
+
+describe("service worker cache policy", () => {
+  it("never intercepts authenticated portal API reads", () => {
+    const { listeners, caches } = loadServiceWorker();
+    const respondWith = vi.fn();
+
+    listeners.get("fetch")?.({
+      request: {
+        method: "GET",
+        url: "https://my.balizero.com/api/portal/process/required-documents?as_client=12177",
+      },
+      respondWith,
+    });
+
+    expect(respondWith).not.toHaveBeenCalled();
+    expect(caches.open).not.toHaveBeenCalled();
+  });
+
+  it("deletes legacy API caches during activation", async () => {
+    const { listeners, caches } = loadServiceWorker();
+    let activation: Promise<unknown> | undefined;
+
+    listeners.get("activate")?.({
+      waitUntil: vi.fn((promise: Promise<unknown>) => {
+        activation = promise;
+      }),
+    });
+    await activation;
+
+    expect(caches.delete).toHaveBeenCalledWith("balizero-api-v8");
+  });
+});


### PR DESCRIPTION
## Summary
- disable service-worker response caching for authenticated/API traffic and purge legacy Bali Zero runtime caches
- add a prominent required-document CTA and a guided multi-document upload flow
- reset selected files and notes between documents and when cancelling the modal
- make accepted formats and the 10 MB limit explicit

## Verification
- 8 targeted Vitest tests passed
- TypeScript typecheck passed
- full protected pre-push suite passed
- local Next.js production build reached Google Fonts retrieval but the Air-M5 network timed out fetching Cormorant Garamond, Inter, and Montserrat; no source compilation failure was observed

## Safety
- no external communications
- production retest uses only synthetic QA assets and will be cleaned up after verification