### PR TITLE
fix(ci): a spec --grep skips is still IMPORTED, so no credential at module scope

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -793,6 +793,38 @@ jobs:
           npm_config_fetch_retry_mintimeout: 20000
           npm_config_fetch_retries: 3
 
+      - name: E2E specs must collect with no credentials present
+        # Playwright IMPORTS every spec file to build its test list — including the
+        # ones the --grep below excludes from running. Until 2026-07-27 seven specs
+        # read the E2E credential at module scope (`const CONFIG = { email:
+        # e2eEmail() }`), so collection threw wherever the secrets are absent, and
+        # the whole job died with "0 tests in 0 files". Absent is not hypothetical:
+        # GitHub withholds repository secrets from Dependabot, so this required
+        # check was permanently unpassable for every dependency update — which is
+        # exactly how a poisoned pin reaches prod behind green checks (W98).
+        # The credentials are emptied ON PURPOSE even when they exist: a guard that
+        # only runs where the thing it guards against cannot happen is decorative.
+        env:
+          E2E_TEST_EMAIL: ""
+          E2E_TEST_PIN: ""
+        run: |
+          cd apps/mouth
+          # Errexit-immune capture (W101): a bare assignment aborts before the check.
+          out=$(npx playwright test --config=playwright.config.ts --list 2>&1) || {
+            echo "❌ E2E collection failed with the credentials absent."
+            echo "   A spec is reading E2E_TEST_EMAIL/PIN at module scope; make it lazy"
+            echo "   (a getter, or move the read inside the test) — see e2e/support/credentials.ts."
+            echo "$out"
+            exit 1
+          }
+          echo "$out" | tail -1
+          # Non-vacuity: "collected nothing" and "collected everything cleanly" both exit 0.
+          echo "$out" | grep -qE "Total: [1-9][0-9]* tests" || {
+            echo "❌ collection reported no tests — a green here would be vacuous"
+            echo "$out" | tail -20
+            exit 1
+          }
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
@@ -808,7 +840,10 @@ jobs:
         run: |
           cd apps/mouth
           # smoke/smoke.spec.ts hardcodes kita.balizero.com/fly.dev (production smoke),
-          # excluded here via grep-invert on the describe block name.
+          # so --grep keeps its tests out of this run. "Excluded" means excluded from
+          # RUNNING, never from being IMPORTED — Playwright loads every spec to build
+          # the list. That distinction is why the step above exists: a file --grep
+          # skips can still fail the job at module scope.
           # zantara/ and mission_simulation use process.env.PLAYWRIGHT_BASE_URL so
           # they pick up localhost:3000 correctly.
           # Run deterministic page-load smoke tests plus the explicitly mocked

--- a/apps/mouth/e2e/smoke/smoke.spec.ts
+++ b/apps/mouth/e2e/smoke/smoke.spec.ts
@@ -23,8 +23,16 @@ import { e2eEmail, e2ePin } from "../support/credentials";
  */
 
 const CONFIG = {
-  email: e2eEmail(),
-  pin: e2ePin(),
+  // Lazy on purpose: Playwright IMPORTS every spec during collection, even the
+  // ones --grep will not run. Calling e2eEmail() here demanded the credential at
+  // import time and failed the whole job wherever the secret is absent. Getters
+  // keep every CONFIG.email call site unchanged and move the throw to first use.
+  get email() {
+    return e2eEmail();
+  },
+  get pin() {
+    return e2ePin();
+  },
   baseUrl: process.env.E2E_BASE_URL || "https://kita.balizero.com",
 };
 

--- a/apps/mouth/e2e/zantara/ai-capabilities.spec.ts
+++ b/apps/mouth/e2e/zantara/ai-capabilities.spec.ts
@@ -20,8 +20,16 @@ import { e2eEmail, e2ePin } from "../support/credentials";
 
 // Test configuration
 const TEST_CONFIG = {
-  email: e2eEmail(),
-  pin: e2ePin(),
+  // Lazy on purpose: Playwright IMPORTS every spec during collection, even the
+  // ones --grep will not run. Calling e2eEmail() here demanded the credential at
+  // import time and failed the whole job wherever the secret is absent. Getters
+  // keep every CONFIG.email call site unchanged and move the throw to first use.
+  get email() {
+    return e2eEmail();
+  },
+  get pin() {
+    return e2ePin();
+  },
   baseUrl: process.env.PLAYWRIGHT_BASE_URL || "https://kita.balizero.com",
   apiUrl: process.env.NUZANTARA_API_URL || "https://nuzantara-rag.fly.dev",
   responseTimeout: 60000, // 60s for AI responses (no timeout issues)

--- a/apps/mouth/e2e/zantara/benchmark.spec.ts
+++ b/apps/mouth/e2e/zantara/benchmark.spec.ts
@@ -7,8 +7,16 @@ import { e2eEmail, e2ePin } from "../support/credentials";
  */
 
 const TEST_CONFIG = {
-  email: e2eEmail(),
-  pin: e2ePin(),
+  // Lazy on purpose: Playwright IMPORTS every spec during collection, even the
+  // ones --grep will not run. Calling e2eEmail() here demanded the credential at
+  // import time and failed the whole job wherever the secret is absent. Getters
+  // keep every CONFIG.email call site unchanged and move the throw to first use.
+  get email() {
+    return e2eEmail();
+  },
+  get pin() {
+    return e2ePin();
+  },
   baseUrl: "https://kita.balizero.com", // Production
 };
 

--- a/apps/mouth/e2e/zantara/memory-debug.spec.ts
+++ b/apps/mouth/e2e/zantara/memory-debug.spec.ts
@@ -7,8 +7,16 @@ import { e2eEmail, e2ePin } from "../support/credentials";
  */
 
 const TEST_CONFIG = {
-  email: e2eEmail(),
-  pin: e2ePin(),
+  // Lazy on purpose: Playwright IMPORTS every spec during collection, even the
+  // ones --grep will not run. Calling e2eEmail() here demanded the credential at
+  // import time and failed the whole job wherever the secret is absent. Getters
+  // keep every CONFIG.email call site unchanged and move the throw to first use.
+  get email() {
+    return e2eEmail();
+  },
+  get pin() {
+    return e2ePin();
+  },
   baseUrl: process.env.PLAYWRIGHT_BASE_URL || "https://kita.balizero.com",
   responseTimeout: 60000,
   waitBetweenMessages: 3000, // Wait 3 seconds between messages to ensure save completes

--- a/apps/mouth/e2e/zantara/memory-direct-test.spec.ts
+++ b/apps/mouth/e2e/zantara/memory-direct-test.spec.ts
@@ -10,8 +10,16 @@ import { e2eEmail, e2ePin } from "../support/credentials";
  */
 
 const TEST_CONFIG = {
-  email: e2eEmail(),
-  pin: e2ePin(),
+  // Lazy on purpose: Playwright IMPORTS every spec during collection, even the
+  // ones --grep will not run. Calling e2eEmail() here demanded the credential at
+  // import time and failed the whole job wherever the secret is absent. Getters
+  // keep every CONFIG.email call site unchanged and move the throw to first use.
+  get email() {
+    return e2eEmail();
+  },
+  get pin() {
+    return e2ePin();
+  },
   baseUrl: process.env.PLAYWRIGHT_BASE_URL || "https://kita.balizero.com",
   apiUrl: process.env.NUZANTARA_API_URL || "https://nuzantara-rag.fly.dev",
   responseTimeout: 60000,

--- a/apps/mouth/e2e/zantara/surf-camp-analysis.spec.ts
+++ b/apps/mouth/e2e/zantara/surf-camp-analysis.spec.ts
@@ -2,8 +2,16 @@ import { test, expect, Page } from "@playwright/test";
 import { e2eEmail, e2ePin } from "../support/credentials";
 
 const TEST_CONFIG = {
-  email: e2eEmail(),
-  pin: e2ePin(),
+  // Lazy on purpose: Playwright IMPORTS every spec during collection, even the
+  // ones --grep will not run. Calling e2eEmail() here demanded the credential at
+  // import time and failed the whole job wherever the secret is absent. Getters
+  // keep every CONFIG.email call site unchanged and move the throw to first use.
+  get email() {
+    return e2eEmail();
+  },
+  get pin() {
+    return e2ePin();
+  },
   baseUrl: "https://kita.balizero.com",
 };
 

--- a/apps/mouth/e2e/zantara/ui-verification.spec.ts
+++ b/apps/mouth/e2e/zantara/ui-verification.spec.ts
@@ -2,8 +2,16 @@ import { test, expect, Page } from "@playwright/test";
 import { e2eEmail, e2ePin } from "../support/credentials";
 
 const TEST_CONFIG = {
-  email: e2eEmail(),
-  pin: e2ePin(),
+  // Lazy on purpose: Playwright IMPORTS every spec during collection, even the
+  // ones --grep will not run. Calling e2eEmail() here demanded the credential at
+  // import time and failed the whole job wherever the secret is absent. Getters
+  // keep every CONFIG.email call site unchanged and move the throw to first use.
+  get email() {
+    return e2eEmail();
+  },
+  get pin() {
+    return e2ePin();
+  },
   baseUrl: "https://kita.balizero.com",
 };
 


### PR DESCRIPTION
## The check that no dependency update could ever pass

`E2E Tests (Playwright)` is a **required** check. Right now **9+ of the 13 open Dependabot PRs are red on it** — three of them pure `actions/checkout` / `setup-node` / `setup-python` version bumps that cannot plausibly break a browser test. That improbability is what made it worth reading the log instead of re-running the job.

### Cause, measured

Playwright **imports every spec file** to build its test list. `--grep` then decides which of the *collected* tests **run**. Seven specs read the credential in a module-scope object literal:

```ts
const CONFIG = { email: e2eEmail(), pin: e2ePin(), ... };
```

`e2eEmail()` throws when the env var is absent — deliberately, since #3346 removed the committed `|| "zero@balizero.com"` fallbacks from this **public** repo. So the throw lands during **collection**, before any filtering, and the job dies with `Total: 0 tests in 0 files`.

GitHub **withholds repository secrets from Dependabot**, so the variable is always absent there. The check was not flaky for dependency updates — it was **structurally unpassable**.

That matters beyond the annoyance: a required gate no dependency PR can satisfy is the channel **W98** came through (a poisoned `fastapi` pin reaching prod behind green checks). "Dependency updates cannot merge" is a security posture, not a chore.

The seven guilty files were identified from the **runtime's own stack traces** in the CI log (`at Object.<anonymous>` = module scope), not from a static heuristic — an earlier brace-depth scan called `smoke.spec.ts` safe because it counted the *object literal's* brace as a function body.

### Cure

**Lazy getters.** Every `CONFIG.email` call site stays byte-identical; the throw moves from import to first read. Fail-loud is preserved and was verified, not assumed — the getter still throws with the var unset, just later.

The helper had already documented both the intent and the trap in its own header:

> *"Everything here resolves LAZILY. Reading these at module scope would make a missing variable explode on import for every spec in the suite, including the ones that never authenticate."*

The design was right; seven call sites defeated it.

### Armed, so it cannot come back

A new `tests.yml` step runs collection with the credentials **deliberately emptied even where the secrets exist** — a guard that only runs where its failure mode cannot occur is decorative. It uses an errexit-immune capture (**W101**) and asserts non-vacuity on the total, since *"collected nothing"* and *"collected everything"* otherwise both exit 0.

The workflow comment claiming smoke.spec.ts was *"excluded here via grep-invert"* is corrected in place — that belief is what hid this. **Excluded from running is not excluded from being imported.**

### Proof — real mechanism, same command, same empty env

| content | result |
|---|---|
| pristine `origin/main` | `RC=1`, `Total: 0 tests in 0 files`, message names the guilty file |
| with this diff | `RC=0`, **`Total: 992 tests in 48 files`** |
| with credentials **present** | identical count — nothing else moved |

`actionlint` clean · `tsc --noEmit` clean · prettier already satisfied.

### Not fixed here

- **#3357** is red for a real, unrelated reason: its lock pins `anthropic==0.117.0` while `langchain-anthropic 1.5.2` needs `>=0.120.0`.
- **#3359** additionally fails Shared Core + Frontend Tests (29 package updates).
- **#3363**'s backend red is `Initialize containers` / `registry-1.docker.io` timeouts — that one is #3349's territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
