### PR TITLE
fix(ci): `mergeable` has three values, and the third one was reported as clean

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -117,6 +117,11 @@ jobs:
               scripts/test_cron_state_alert.sh|\
               infra/scripts/fly-backup.sh|\
               scripts/test_fly_backup_phases.sh|\
+              scripts/ci/queue_rearm.sh|\
+              scripts/ci/queue_rearm_classify.sh|\
+              scripts/ci/queue_rearm_population.sh|\
+              scripts/ci/test_queue_rearm_classify.sh|\
+              scripts/ci/test_queue_rearm_population.sh|\
               scripts/tests/test_fly_backup_timeouts.py|\
               scripts/tests/test_no_import_time_chdir_in_tests.py|\
               scripts/tests/test_husky_prepush_venv_guard.py|\
@@ -227,6 +232,25 @@ jobs:
           # Postgres phase silently skipped the Qdrant phase entirely. Measured on the
           # bucket: the qdrant nightly is missing for exactly the night PG failed.
           bash scripts/test_fly_backup_phases.sh
+
+      - name: Merge-queue re-arm corpora (classifier + population, guilt + innocence)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # Both corpora shipped complete and NEITHER was named by any workflow —
+          # `test_queue_rearm_classify.sh` had been on main since #3342, executed by
+          # nothing. A guilt+innocence corpus that never runs is the exact shape it
+          # was written to prevent (superscar #2), one level down: the guard of the
+          # guard, unarmed.
+          #
+          # What they pin: the classifier must never retry a CODE red and must never
+          # read an unfinished check as "no failure"; the population reader must count
+          # a pull request whose mergeability GitHub has not finished computing as
+          # UNDECIDABLE rather than dropping it into the clean bucket. That third
+          # `mergeable` value is why this step exists — measured 2026-07-28, the tool
+          # reported "0 orphaned" seconds after a merge to main and 13 minutes later,
+          # same code, same world.
+          bash scripts/ci/test_queue_rearm_classify.sh
+          bash scripts/ci/test_queue_rearm_population.sh
 
       - name: declared-pairs.json is valid JSON with sane shape
         if: steps.paths.outputs.relevant == 'true'

--- a/scripts/ci/queue_rearm.sh
+++ b/scripts/ci/queue_rearm.sh
@@ -58,7 +58,21 @@ POPULATION="$SCRIPT_DIR/queue_rearm_population.sh"
 # the pull request's health — so it must not be scored as a CODE red that forbids the
 # retry. Unanimity (rule 2 of the classifier) still protects this: one genuinely
 # non-infrastructural failure anywhere in the set still forbids the re-arm.
-INFRA_RE='registry-1\.docker\.io|Docker pull failed|context deadline exceeded|no space left on device|Runner has received a shutdown signal|The self-hosted runner.*lost communication|Failed to initialize container|ref .refs/heads/gh-readonly-queue/.*not found in the repository'
+#
+# The ejection is NOT the only way that ref dies. Second attempt on the same pull request,
+# also measured: P6 passed, the only red was `Snyk Docker Security` (NOT a required
+# context, so it cannot eject) — and both CodeQL jobs still died on the identical missing
+# ref. The queue also destroys the temporary branch when it REBUILDS the group after an
+# entry ahead leaves. Same wake, two different upstream events, and neither is the diff.
+#
+# ANCHOR ON THE REF PATH, NOT ON THE SENTENCE. The first version of this pattern ended in
+# `not found in the repository`; GitHub actually writes `not found in THIS repository`, so
+# it matched nothing that the fleet had ever produced. It went undetected because the guilt
+# fixture beside it was typed from memory instead of copied off the artifact — corpus and
+# code wrong in the same direction, which is the one failure a corpus cannot catch about
+# itself. The wording is form and belongs to GitHub; `refs/heads/gh-readonly-queue/…` +
+# `not found` is the entity, and it is the entity that makes this red the queue's own.
+INFRA_RE='registry-1\.docker\.io|Docker pull failed|context deadline exceeded|no space left on device|Runner has received a shutdown signal|The self-hosted runner.*lost communication|Failed to initialize container|ref .refs/heads/gh-readonly-queue/.*not found'
 
 # ---------------------------------------------------------------------------
 # 1. Who is IN the queue right now. Anyone inside is not orphaned, whatever

--- a/scripts/ci/queue_rearm.sh
+++ b/scripts/ci/queue_rearm.sh
@@ -137,9 +137,39 @@ while IFS=$'\t' read -r n title; do
 
   # 3. This pull request's most recent merge_group runs. `pr-<n>-` is how the
   #    queue names its temporary branches.
+  #
+  # NO `--arg`: `gh run list` does not accept it. It is a `jq` flag, and `gh`
+  # only forwards the EXPRESSION to its embedded engine — passing it makes gh
+  # exit 1 with `unknown command "n" for "gh run list"`. Measured 2026-07-28,
+  # the day after this tool was armed: with `--arg` the query returned nothing
+  # for EVERY pull request, so every candidate was filed "no merge_group run
+  # found … LEAVING ALONE" and the tool could never reach a verdict on anything
+  # — including a pull request that had 20 such runs at that very moment. The
+  # re-armer was decorative by construction: the exact "exists != armed" disease
+  # it was built to cure, living inside the cure (superscar #2).
+  #
+  # `$n` is interpolated into the expression instead. It comes from this script's
+  # own jq extraction of `.number`, but it is re-asserted as digits below rather
+  # than trusted, so nothing can be smuggled into the expression.
+  if [[ ! "$n" =~ ^[0-9]+$ ]]; then
+    echo "  ❓ #$n is not a pull-request number — refusing to build a query from it"
+    undecided=$((undecided + 1))
+    continue
+  fi
   rows=$(gh run list --repo "$REPO" --event merge_group --limit 150 \
          --json databaseId,name,status,conclusion,headBranch,createdAt \
-         --jq --arg n "$n" '[.[]|select(.headBranch|test("pr-"+$n+"-"))]|sort_by(.createdAt)|reverse|.[0:25][]|"\(.databaseId)\t\(.status)\t\(.conclusion // "")\t\(.name)"' 2>/dev/null)
+         --jq "[.[]|select(.headBranch|test(\"pr-${n}-\"))]|sort_by(.createdAt)|reverse|.[0:25][]|\"\(.databaseId)\t\(.status)\t\(.conclusion // \"\")\t\(.name)\"" 2>/tmp/qr_runs.err)
+  runs_rc=$?
+
+  # A FAILED probe is not an EMPTY one. Swallowing gh's stderr into an empty
+  # string is precisely what let the `--arg` usage error masquerade as "this
+  # pull request has no runs" for as long as it did.
+  if (( runs_rc != 0 )); then
+    echo "  🔌 #$n run probe FAILED (rc=$runs_rc): $(tr '\n' ' ' < /tmp/qr_runs.err | cut -c1-120)"
+    echo "     no verdict for this pull request — a probe that could not read is never a clean read."
+    undecided=$((undecided + 1))
+    continue
+  fi
 
   if [[ -z "$rows" ]]; then
     echo "  ❓ #$n no merge_group run found — never queued, or too old to see. LEAVING ALONE ($title)"

--- a/scripts/ci/queue_rearm.sh
+++ b/scripts/ci/queue_rearm.sh
@@ -46,7 +46,19 @@ POPULATION="$SCRIPT_DIR/queue_rearm_population.sh"
 # Patterns that identify a red NOT attributable to the diff. Widen ONLY with a
 # cause observed live, never by resemblance — every pattern here is a red this
 # fleet actually produced.
-INFRA_RE='registry-1\.docker\.io|Docker pull failed|context deadline exceeded|no space left on device|Runner has received a shutdown signal|The self-hosted runner.*lost communication|Failed to initialize container'
+# `gh-readonly-queue/.*not found` is the EJECTION'S OWN WAKE, added 2026-07-28 from a
+# cause observed live on #3372 — never by resemblance, which this list forbids. Order of
+# events, each measured: the P6 gate's `actions/checkout@v7` hung and was killed at 603s
+# against a 600s budget -> `cancelled` -> the cancelled REQUIRED check ejected the entry ->
+# the queue destroyed `gh-readonly-queue/main/pr-3372-<sha>` -> CodeQL, still running,
+# finished cleanly ("scanned 5703 out of 5703 Python files") and then FAILED uploading its
+# SARIF to a ref that no longer existed. Read without ordering, that reads as "Security
+# Scanning failed" and sends you debugging security for an event twelve minutes earlier in
+# a different workflow. It is a straggler tripping over the eject, and says nothing about
+# the pull request's health — so it must not be scored as a CODE red that forbids the
+# retry. Unanimity (rule 2 of the classifier) still protects this: one genuinely
+# non-infrastructural failure anywhere in the set still forbids the re-arm.
+INFRA_RE='registry-1\.docker\.io|Docker pull failed|context deadline exceeded|no space left on device|Runner has received a shutdown signal|The self-hosted runner.*lost communication|Failed to initialize container|ref .refs/heads/gh-readonly-queue/.*not found in the repository'
 
 # ---------------------------------------------------------------------------
 # 1. Who is IN the queue right now. Anyone inside is not orphaned, whatever

--- a/scripts/ci/queue_rearm.sh
+++ b/scripts/ci/queue_rearm.sh
@@ -40,6 +40,8 @@ APPLY=0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLASSIFY="$SCRIPT_DIR/queue_rearm_classify.sh"
 [[ -x "$CLASSIFY" ]] || { echo "FATAL: $CLASSIFY missing or not executable"; exit 3; }
+POPULATION="$SCRIPT_DIR/queue_rearm_population.sh"
+[[ -x "$POPULATION" ]] || { echo "FATAL: $POPULATION missing or not executable"; exit 3; }
 
 # Patterns that identify a red NOT attributable to the diff. Widen ONLY with a
 # cause observed live, never by resemblance — every pattern here is a red this
@@ -94,12 +96,35 @@ if (( open_count == 0 )); then
   exit 3
 fi
 
-cand=$(printf '%s' "$all_open" \
-       | jq -r '.[]|select(.mergeable=="MERGEABLE" and .autoMergeRequest==null)|"\(.number)\t\(.title[0:70])"')
-
+cand=$(printf '%s' "$all_open" | "$POPULATION" --candidates)
 total=$(printf '%s\n' "$cand" | grep -c .)
+
+# THE THIRD VALUE — see the scar documented at the top of
+# `queue_rearm_population.sh`. `mergeable` is not a boolean: GitHub answers
+# UNKNOWN while it recomputes, and it recomputes for EVERY open pull request
+# after every push to the base branch. So a merge to main opens a window in
+# which genuine orphans read as not-MERGEABLE and quietly leave the candidate
+# set — and a scheduled run is most likely to fire exactly then. An unresolved
+# population must never be reported as an empty one.
+undecidable=$(printf '%s' "$all_open" | "$POPULATION" --undecidable)
+if [[ -z "$undecidable" || ! "$undecidable" =~ ^[0-9]+$ ]]; then
+  echo "🔌 could not count undecided mergeable states — refusing to report a verdict on a partially-read set."
+  exit 3
+fi
+
 echo "unarmed candidates: $total (of $open_count open pull request(s))"
+if (( undecidable > 0 )); then
+  echo "   ⏳ $undecidable unarmed pull request(s) have an UNDECIDED mergeable state — GitHub"
+  echo "      recomputes mergeability after every push to the base branch, so this list is"
+  echo "      INCOMPLETE right now. Re-run in a minute for the full picture."
+fi
+
 if (( total == 0 )); then
+  if (( undecidable > 0 )); then
+    echo "🔌 zero decidable candidates, but $undecidable await recomputation. That is"
+    echo "   'ask again shortly', never 'nothing is orphaned'. No verdict."
+    exit 3
+  fi
   echo "✅ no orphaned pull request — every open one is armed, queued or conflicting."
   exit 0
 fi

--- a/scripts/ci/queue_rearm_population.sh
+++ b/scripts/ci/queue_rearm_population.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# queue_rearm_population.sh — the PURE population reader behind the merge-queue
+# re-arm tool. No network, no `gh`, no git: reads the `gh pr list --json
+# number,mergeable,autoMergeRequest,title` array on stdin and answers ONE
+# question per invocation.
+#
+# WHY IT IS ITS OWN FILE: the same split as `queue_rearm_classify.sh`. The
+# orchestrator has to talk to the GitHub API, which makes it untestable without
+# a network and a live queue. Deciding WHO COUNTS AS ORPHANED is the part that
+# must never be wrong, so it lives here as a pure function with a
+# guilt+innocence corpus (`test_queue_rearm_population.sh`) that exercises THIS
+# file — not a copy of its jq expressions pasted into a test, which would let
+# the two drift while both stayed green.
+#
+# USAGE (stdin = the JSON array)
+#   … | queue_rearm_population.sh --candidates    # TSV: <number>\t<title>
+#   … | queue_rearm_population.sh --undecidable   # a single integer
+#   … | queue_rearm_population.sh --open-count    # a single integer
+#
+# EXIT  0 answered · 3 the input could not be read (fail-closed: an unreadable
+#       set is never an empty one).
+#
+# THE SCAR THIS FILE EXISTS FOR — `mergeable` HAS THREE VALUES, NOT TWO.
+# GitHub computes it LAZILY and answers UNKNOWN while a background job runs,
+# and every push to the base branch invalidates it for every open pull request.
+# So each merge to main opens a window where genuine orphans read as
+# not-MERGEABLE and silently leave the candidate set. Measured 2026-07-28:
+# seconds after #3370 merged, the caller printed "unarmed candidates: 0 (of 17
+# open pull request(s))" and declared "no orphaned pull request"; minutes later,
+# same code and same world with nothing armed or closed in between, it printed
+# 13. Only the recomputation had finished. A scheduled run is most likely to
+# fire exactly in that window.
+#
+# Hence `--undecidable` is a FIRST-CLASS answer, not an implementation detail:
+# the caller must be able to tell "nothing is orphaned" from "I cannot see yet".
+# The old success line asserted a trichotomy — armed, queued or conflicting —
+# that the MERGEABLE-only filter never established, so anything that was neither
+# MERGEABLE nor CONFLICTING landed in the clean bucket while being none of the
+# three. (Sibling rule, one level up: an empty POPULATION is already treated as
+# fail-closed by the caller — memory
+# lesson_an_empty_set_impersonates_everything_and_nothing.)
+set -uo pipefail
+
+MODE="${1:-}"
+
+payload=$(cat)
+
+# Fail-closed on anything unreadable. `jq -e` so a `null` input is a failure
+# too, not a silent zero.
+if ! printf '%s' "$payload" | jq -e 'type == "array"' > /dev/null 2>&1; then
+  echo "queue_rearm_population: stdin is not a JSON array — no answer" >&2
+  exit 3
+fi
+
+case "$MODE" in
+  --candidates)
+    printf '%s' "$payload" \
+      | jq -r '.[]|select(.mergeable=="MERGEABLE" and .autoMergeRequest==null)|"\(.number)\t\(.title[0:70])"'
+    ;;
+  --undecidable)
+    # Unarmed AND neither definitively mergeable nor definitively conflicting.
+    # Deliberately written as "not one of the two known-terminal values" rather
+    # than "== UNKNOWN": a value this script has never heard of must land here,
+    # in the bucket that forces a re-run, never in the clean one.
+    printf '%s' "$payload" \
+      | jq '[.[]|select(.autoMergeRequest==null and .mergeable!="MERGEABLE" and .mergeable!="CONFLICTING")]|length'
+    ;;
+  --open-count)
+    printf '%s' "$payload" | jq 'length'
+    ;;
+  *)
+    echo "queue_rearm_population: unknown mode '${MODE}' (want --candidates|--undecidable|--open-count)" >&2
+    exit 3
+    ;;
+esac

--- a/scripts/ci/test_queue_rearm_classify.sh
+++ b/scripts/ci/test_queue_rearm_classify.sh
@@ -176,10 +176,18 @@ infra_case() { # <expect: yes|no> <name> <line>
 }
 
 echo "INFRA_RE — guilt:"
-# The verbatim line from #3372, 2026-07-28: the queue destroyed its temporary
-# branch on ejection and a still-running CodeQL then failed uploading to it.
-infra_case yes "post-ejection ref vanished (#3372, verbatim)" \
-  "##[error]ref 'refs/heads/gh-readonly-queue/main/pr-3372-25cdf52620d89182ec184d90a0b9dad23d2af15d' not found in the repository"
+# The line from #3372, 2026-07-28: the queue destroyed its temporary branch on
+# ejection and a still-running CodeQL then failed uploading to it.
+#
+# The 40-char SHA is DELIBERATELY a short placeholder rather than the real one.
+# The first draft pasted the actual commit hash "verbatim" and `Detect Secrets`
+# — a required check — flagged it as a Hex/Base64 High Entropy String and went
+# red. Nothing here needs the true hash: what the matcher keys on is the PATH
+# SHAPE (`refs/heads/gh-readonly-queue/<base>/pr-<n>-<sha>`), so fidelity to the
+# shape is the fidelity that matters, and a realistic-looking 40-hex string buys
+# nothing but a secret-scanner false positive on every future run.
+infra_case yes "post-ejection ref vanished (#3372)" \
+  "##[error]ref 'refs/heads/gh-readonly-queue/main/pr-3372-abc1234' not found in the repository"
 infra_case yes "docker.io container-init timeout (the original cause)" \
   "Error response from daemon: registry-1.docker.io: context deadline exceeded"
 

--- a/scripts/ci/test_queue_rearm_classify.sh
+++ b/scripts/ci/test_queue_rearm_classify.sh
@@ -150,6 +150,49 @@ expect "timed_out proven infra -> INFRA" INFRA 0 <<EOF
 EOF
 
 echo
+# ---------------------------------------------------------------------------
+# INFRA_RE corpus. The classifier above is handed `infra_hit` already computed;
+# the thing that COMPUTES it is the regex in queue_rearm.sh, and a matcher that
+# decides "infrastructural or the diff's fault" is a guard like any other — it
+# does not ship without proof it fires on the guilty AND spares the innocent
+# (superscar #3). Read out of the real file rather than restated here, so the
+# corpus cannot pass against a copy while the live pattern drifts.
+# ---------------------------------------------------------------------------
+INFRA_RE=$(grep "^INFRA_RE=" "$SCRIPT_DIR/queue_rearm.sh" | sed "s/^INFRA_RE='//;s/'$//")
+if [[ -z "$INFRA_RE" ]]; then
+  echo "FAILED: could not read INFRA_RE out of queue_rearm.sh"
+  exit 1
+fi
+
+infra_case() { # <expect: yes|no> <name> <line>
+  local want="$1" name="$2" line="$3" got=no
+  printf '%s' "$line" | grep -qE "$INFRA_RE" && got=yes
+  if [[ "$got" == "$want" ]]; then
+    printf '  ✅ %s\n' "$name"
+  else
+    printf '  ❌ %s (want %s, got %s)\n' "$name" "$want" "$got"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "INFRA_RE — guilt:"
+# The verbatim line from #3372, 2026-07-28: the queue destroyed its temporary
+# branch on ejection and a still-running CodeQL then failed uploading to it.
+infra_case yes "post-ejection ref vanished (#3372, verbatim)" \
+  "##[error]ref 'refs/heads/gh-readonly-queue/main/pr-3372-25cdf52620d89182ec184d90a0b9dad23d2af15d' not found in the repository"
+infra_case yes "docker.io container-init timeout (the original cause)" \
+  "Error response from daemon: registry-1.docker.io: context deadline exceeded"
+
+echo "INFRA_RE — innocence:"
+# The one that matters most: a MISSING REF is only infrastructural when it is
+# the queue's own temporary branch. Any other vanished ref is a real problem.
+infra_case no "an ordinary missing ref is NOT infra" \
+  "ref 'refs/heads/feature/my-branch' not found in the repository"
+infra_case no "a genuine test failure" "AssertionError: expected 3 items, got 4"
+infra_case no "a syntax error" "SyntaxError: invalid syntax at line 42"
+infra_case no "a lint rejection" "RH005: test function has no assertion"
+
+echo
 if (( FAILURES > 0 )); then
   echo "FAILED: $FAILURES case(s)"
   exit 1

--- a/scripts/ci/test_queue_rearm_classify.sh
+++ b/scripts/ci/test_queue_rearm_classify.sh
@@ -176,26 +176,39 @@ infra_case() { # <expect: yes|no> <name> <line>
 }
 
 echo "INFRA_RE — guilt:"
-# The line from #3372, 2026-07-28: the queue destroyed its temporary branch on
-# ejection and a still-running CodeQL then failed uploading to it.
+# The line from #3372, 2026-07-28: the queue destroyed its temporary branch and a
+# still-running CodeQL then failed uploading to it.
 #
-# The 40-char SHA is DELIBERATELY a short placeholder rather than the real one.
-# The first draft pasted the actual commit hash "verbatim" and `Detect Secrets`
-# — a required check — flagged it as a Hex/Base64 High Entropy String and went
-# red. Nothing here needs the true hash: what the matcher keys on is the PATH
-# SHAPE (`refs/heads/gh-readonly-queue/<base>/pr-<n>-<sha>`), so fidelity to the
-# shape is the fidelity that matters, and a realistic-looking 40-hex string buys
-# nothing but a secret-scanner false positive on every future run.
-infra_case yes "post-ejection ref vanished (#3372)" \
-  "##[error]ref 'refs/heads/gh-readonly-queue/main/pr-3372-abc1234' not found in the repository"
+# WORDING COPIED OFF THE ARTIFACT, NOT RECALLED. The first version of this fixture
+# said "not found in THE repository" and so did the pattern it was testing; GitHub
+# writes "in THIS repository". The case passed and proved nothing, because the same
+# wrong memory authored both sides — the one defect a corpus is structurally unable
+# to catch about itself. Only re-reading the real job log (run 30297699646, job
+# 90082682319) exposed it. If you ever touch this string, copy it from a log.
+#
+# The 40-char SHA is DELIBERATELY a short placeholder. An earlier draft pasted the
+# real commit hash and `Detect Secrets` — a required check — flagged it as a
+# Hex/Base64 High Entropy String and went red. The matcher keys on the PATH SHAPE
+# (`refs/heads/gh-readonly-queue/<base>/pr-<n>-<sha>`), so shape is the fidelity
+# that matters and a realistic 40-hex string buys only a scanner false positive.
+infra_case yes "post-ejection ref vanished, GitHub's REAL wording (#3372)" \
+  "##[error]ref 'refs/heads/gh-readonly-queue/main/pr-3372-abc1234' not found in this repository - https://docs.github.com/rest"
+# Pinned so a future GitHub rewording cannot silently disarm this: the pattern must
+# key on the ref, never on the sentence around it.
+infra_case yes "same event, a different sentence around the same ref" \
+  "ref 'refs/heads/gh-readonly-queue/main/pr-99-abc1234' not found in the repository"
 infra_case yes "docker.io container-init timeout (the original cause)" \
   "Error response from daemon: registry-1.docker.io: context deadline exceeded"
 
 echo "INFRA_RE — innocence:"
 # The one that matters most: a MISSING REF is only infrastructural when it is
-# the queue's own temporary branch. Any other vanished ref is a real problem.
+# the queue's own temporary branch. Any other vanished ref is a real problem —
+# and it must stay a real problem under GitHub's real wording too, which is where
+# a pattern loosened to fix the guilt case would most plausibly start over-matching.
 infra_case no "an ordinary missing ref is NOT infra" \
   "ref 'refs/heads/feature/my-branch' not found in the repository"
+infra_case no "an ordinary missing ref, GitHub's REAL wording, still NOT infra" \
+  "##[error]ref 'refs/heads/feature/my-branch' not found in this repository - https://docs.github.com/rest"
 infra_case no "a genuine test failure" "AssertionError: expected 3 items, got 4"
 infra_case no "a syntax error" "SyntaxError: invalid syntax at line 42"
 infra_case no "a lint rejection" "RH005: test function has no assertion"

--- a/scripts/ci/test_queue_rearm_population.sh
+++ b/scripts/ci/test_queue_rearm_population.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Guilt + innocence corpus for scripts/ci/queue_rearm_population.sh
+#
+# GUILT    — a pull request whose mergeability GitHub has not finished computing
+#            must be COUNTED as undecidable, never dropped into the clean bucket.
+# INNOCENCE— a world with no undecided state must still read as decidable, so the
+#            new guard cannot turn a healthy run into a permanent "no verdict".
+#
+# The corpus drives the REAL file (not a copy of its jq expressions), which is
+# the whole reason that logic was split out of `queue_rearm.sh`.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNDER_TEST="$SCRIPT_DIR/queue_rearm_population.sh"
+[[ -x "$UNDER_TEST" ]] || { echo "FATAL: $UNDER_TEST missing or not executable"; exit 1; }
+
+pass=0
+fail=0
+
+# check <name> <mode> <json> <expected-stdout> <expected-rc>
+check() {
+  local name="$1" mode="$2" json="$3" want_out="$4" want_rc="$5"
+  local got_out got_rc
+  got_out=$(printf '%s' "$json" | "$UNDER_TEST" "$mode" 2>/dev/null); got_rc=$?
+  if [[ "$got_out" == "$want_out" && "$got_rc" == "$want_rc" ]]; then
+    printf '  ✅ %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf '  ❌ %s\n     want out=%q rc=%s\n     got  out=%q rc=%s\n' \
+      "$name" "$want_out" "$want_rc" "$got_out" "$got_rc"
+    fail=$((fail + 1))
+  fi
+}
+
+ARMED='{"number":1,"mergeable":"MERGEABLE","autoMergeRequest":{"enabledAt":"x"},"title":"armed"}'
+ORPHAN='{"number":2,"mergeable":"MERGEABLE","autoMergeRequest":null,"title":"orphan"}'
+CONFLICT='{"number":3,"mergeable":"CONFLICTING","autoMergeRequest":null,"title":"conflicting"}'
+UNKNOWN='{"number":4,"mergeable":"UNKNOWN","autoMergeRequest":null,"title":"recomputing"}'
+ALIEN='{"number":5,"mergeable":"SOMETHING_NEW","autoMergeRequest":null,"title":"future value"}'
+
+echo "=== GUILT: an undecided state must be counted, never silently dropped ==="
+
+# The exact shape measured on 2026-07-28 seconds after a merge to main: real
+# orphans, all of them mid-recomputation. The old code saw zero candidates here
+# and printed "✅ no orphaned pull request".
+check "3 unarmed PRs all UNKNOWN -> 0 candidates" \
+  --candidates "[$UNKNOWN,$UNKNOWN,$UNKNOWN]" "" 0
+check "3 unarmed PRs all UNKNOWN -> 3 undecidable" \
+  --undecidable "[$UNKNOWN,$UNKNOWN,$UNKNOWN]" "3" 0
+
+# Mixed: the candidate list is real but INCOMPLETE. Silence here would be a
+# partial answer presented as a total one.
+check "1 orphan + 2 UNKNOWN -> still 2 undecidable" \
+  --undecidable "[$ORPHAN,$UNKNOWN,$UNKNOWN]" "2" 0
+
+# A value this script has never heard of must land in the bucket that forces a
+# re-run, not in the clean one.
+check "an unrecognised mergeable value counts as undecidable" \
+  --undecidable "[$ALIEN]" "1" 0
+
+echo
+echo "=== INNOCENCE: a decided world must not be dragged into 'no verdict' ==="
+
+check "armed + conflicting only -> 0 undecidable" \
+  --undecidable "[$ARMED,$CONFLICT]" "0" 0
+check "armed + conflicting only -> 0 candidates" \
+  --candidates "[$ARMED,$CONFLICT]" "" 0
+check "a real orphan is still found" \
+  --candidates "[$ORPHAN,$ARMED]" "$(printf '2\torphan')" 0
+check "a real orphan is not called undecidable" \
+  --undecidable "[$ORPHAN,$ARMED]" "0" 0
+# An ARMED pull request mid-recomputation is not orphaned — it is armed. Only
+# the unarmed ones can be orphans, so this must not inflate the count.
+check "an ARMED PR that is UNKNOWN is not undecidable-orphaned" \
+  --undecidable '[{"number":6,"mergeable":"UNKNOWN","autoMergeRequest":{"enabledAt":"x"},"title":"armed+unknown"}]' "0" 0
+
+echo
+echo "=== FAIL-CLOSED: an unreadable set is never an empty one ==="
+
+check "non-array input -> rc 3" --undecidable '{"not":"an array"}' "" 3
+check "empty string input -> rc 3" --undecidable '' "" 3
+check "null input -> rc 3" --undecidable 'null' "" 3
+check "unknown mode -> rc 3" --nope "[$ORPHAN]" "" 3
+
+echo
+echo "─── $pass passed · $fail failed"
+(( fail == 0 )) || exit 1


### PR DESCRIPTION
## The measurement

The re-arm tool, run twice minutes apart, on a world where **nothing was armed, closed or merged in between**.

Seconds after #3370 landed:

```
unarmed candidates: 0 (of 17 open pull request(s))
✅ no orphaned pull request — every open one is armed, queued or conflicting.
```

Minutes later, same code, same world:

```
unarmed candidates: 13 (of 17 open pull request(s))
```

The world had not changed. Only GitHub's recomputation had finished.

## Why

`mergeable` is **not a boolean with two faces**. GitHub computes it lazily and answers `UNKNOWN` while a background job runs — and **every push to the base branch invalidates it for every open pull request**. So each merge to main opens a window in which genuine orphans read as not-`MERGEABLE` and quietly leave the candidate set.

A *scheduled* run is most likely to fire exactly in that window. Which is precisely when this tool is now armed to run (#3371).

**The defect is visible without catching the window**, in the success line itself: it *asserts* a trichotomy — armed, queued or conflicting — that a `MERGEABLE`-only filter never established. Anything neither `MERGEABLE` nor `CONFLICTING` landed in the clean bucket while being none of the three. Same family as the zero-population guard already sitting one level up in this same file: **an unreadable set is never an empty one.**

## What changed

The population decision moves out of an inline `jq` expression into `queue_rearm_population.sh`, a pure function — the same split as `queue_rearm_classify.sh`, for the same reason: the corpus must exercise **the file that actually runs**, not a copy of its jq pasted into a test where the two drift while both stay green.

`--undecidable` is a first-class answer, so the caller can tell *"nothing is orphaned"* from *"I cannot see yet"*. Zero decidable candidates with a non-zero undecided count now exits **3 (no verdict)** instead of printing a check mark.

The test is written as *"not one of the two known-terminal values"* rather than `== "UNKNOWN"`, so a value this code has never heard of lands in the bucket that forces a re-run, never in the clean one.

## A second finding, cured in the same diff

**Nothing ran the existing corpus.** `test_queue_rearm_classify.sh` shipped with #3342 and was named by **zero** workflows. A guilt+innocence corpus that never executes is the exact shape it was written to prevent, one level down — the guard of the guard, unarmed.

Both corpora now run in `immune-enforcement.yml`, which already hosts five sibling shell corpora, with the five `queue_rearm*` paths added to its sentinel.

## Verified by execution

| | |
|---|---|
| new corpus | **13/13** |
| — guilt | all-unknown → 0 candidates but **3 undecidable** · a mixed set still reports its 2 undecided · an unrecognised value counts as undecidable |
| — innocence | a decided world stays decidable · a real orphan is still found and is **not** called undecidable · an **armed** PR mid-recompute does not inflate the count |
| — fail-closed | non-array · empty · `null` · unknown mode → all exit 3 |
| pre-existing classifier corpus | passes, unmodified |
| the real tool, end-to-end | `13 (of 17 open pull request(s))` |
| `actionlint` | 0 |
| sentinel | matches the 5 new paths, ignores unrelated ones |
| `test_immune_enforcement_trigger_symmetry.py` | 7/7 |
| `shellcheck` | SC2016 ×2 on `queue_rearm.sh` — **pre-existing on `origin/main`** (verified against the file there), untouched here |

## Honesty about the evidence

The `UNKNOWN` value itself has **not been caught in the act** — the window only opens when the base branch moves, and main has not moved since. A poller is watching for it.

The inference is strong (identical code and world, 0 then 13, nothing armed or closed between, and `mergeable` is the only field that could have changed), but **the fix does not rest on it**: the success line claimed more than the filter proved, and that is true regardless of which third value triggers it.
