### PR TITLE
fix(deploy): NodeSource started answering 403 and took production deploys with it

### DIFF
--- a/apps/backend-rag/Dockerfile
+++ b/apps/backend-rag/Dockerfile
@@ -72,31 +72,44 @@ WORKDIR /app
 FROM python:3.11-slim
 
 # Install runtime dependencies:
-# - curl + ca-certificates: healthcheck + HTTPS to Node repo
-# - gnupg (build-only, removed after): Node.js repo GPG verification
-# - nodejs 20.x: required by the `claude` CLI (Claude Code),
-#   used by backend/llm/claude_oauth_client.py for Max OAuth calls.
+# - curl + ca-certificates: healthcheck
+# - nodejs + npm: required by the `claude` CLI (Claude Code), used by
+#   backend/llm/claude_oauth_client.py for Max OAuth calls.
 # - @anthropic-ai/claude-code: Claude CLI installed globally.
 #
 # Project policy forbids ANTHROPIC_API_KEY (see
 # memory/feedback_claude_oauth_only.md) — Max plan OAuth via `claude -p`
 # subprocess is the only approved Claude transport.
-# Image-size impact: Node.js ~90MB + CLI ~40MB ≈ +130MB on ~2GB base.
+#
+# NODE COMES FROM DEBIAN, NOT NODESOURCE (changed 2026-07-28). The third-party
+# NodeSource APT repo started answering 403 that evening and broke this build —
+# and therefore every production deploy, since `fly deploy` builds this exact
+# Dockerfile. Measured rather than inferred: `Snyk Docker Security` succeeded 7
+# times through 19:39 and failed from 19:58 on, always at the same line, with
+# `curl: (22) The requested URL returned error: 403` immediately after curl was
+# installed. Probed from outside CI, so it is not a runner artifact:
+#
+#   403  https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+#   403  https://deb.nodesource.com/node_20.x/dists/nodistro/Release
+#   200  https://deb.nodesource.com/            <- the site itself is up
+#   200  https://deb.nodesource.com/setup_20.x
+#
+# Note what that scope rules out: vendoring the GPG key would NOT have fixed it,
+# because the repository path is 403 too. The dependency itself is the defect.
+#
+# Debian trixie (this image's base — confirmed by the `deb13uN` package suffixes
+# in the build log, not assumed) ships nodejs 20.19.2, exactly the 20.x this CLI
+# needs, so the whole keyring dance is unnecessary. `npm` is a SEPARATE package
+# in Debian and must be named explicitly. Side benefit worth keeping: one fewer
+# third-party APT source in a production image is a smaller supply-chain
+# surface, not just a shorter build.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg \
-    && mkdir -p /etc/apt/keyrings \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
-        > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends nodejs \
+        curl ca-certificates nodejs npm \
     && npm install -g @anthropic-ai/claude-code \
     && npm cache clean --force \
-    && apt-get remove -y gnupg \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* /root/.npm \
-    && which claude && claude --version
+    && node --version && which claude && claude --version
 
 # Create non-root user for security
 RUN useradd -m -u 1000 nuzantara && \


### PR DESCRIPTION
## Production deploys are blocked, and nothing said so

`apps/backend-rag/Dockerfile` fetched Node 20 from the third-party NodeSource APT repo. That repo began answering **403** on the evening of 2026-07-28 and the image stopped building.

That is not merely a red check: **`fly deploy` builds this exact Dockerfile**, so deploys of `nuzantara-rag` are blocked.

**The part worth pausing on:** the check that sees this — `Snyk Docker Security` — is **not** among the 26 required contexts. So CI stays green, PRs merge normally, and production simply stops receiving updates with no alarm anywhere. The build breakage is the smaller half of this; the silence is the larger one.

## Measured, not inferred

`Snyk Docker Security` succeeded **7 consecutive times through 19:39** and failed from **19:58** on, always at the same line, with `curl: (22) The requested URL returned error: 403` landing immediately after curl was installed.

Probed from outside CI, so it is not a runner artifact:

```
403  https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
403  https://deb.nodesource.com/node_20.x/dists/nodistro/Release
200  https://deb.nodesource.com/            <- the site itself is up
200  https://deb.nodesource.com/setup_20.x
```

**That scope chose the cure.** Vendoring the GPG key — the obvious first idea — would **not** have worked: the repository path is 403 too. The key was never the problem; the third-party dependency is.

## The fix

Debian trixie is this image's base — confirmed from the `deb13uN` package suffixes in the build log, not assumed — and ships **nodejs 20.19.2**, exactly the 20.x the `claude` CLI needs. So the keyring / sources.list dance is unnecessary.

`npm` is a **separate package** in Debian and is named explicitly; missing that is how this change fails silently for anyone repeating it.

Nothing about the Claude transport changes: the CLI is still installed globally and `ANTHROPIC_API_KEY` remains forbidden, Max-plan OAuth via `claude -p` being the only approved path.

Side benefit kept on purpose: one fewer third-party APT source in a production image is a smaller supply-chain surface, not just a shorter build.

## Verification, including its limit

- No test or lint anywhere anchors on the removed `nodesource` / `keyrings` lines (grepped).
- `scripts/tests/test_prepush_classify.py` — the only test naming this Dockerfile — passes **123/123**.
- **Docker is not installed on this machine, so the build itself is NOT verified locally.** The `Snyk Docker Security` job on this PR builds the image and is the real proof. Its verdict here is the acceptance criterion and must be green before this is called done.

## Follow-up, not in this PR

A deploy-blocking condition that no required check reports deserves its own alarm. Filed separately rather than smuggled into a one-file fix.
