### PR TITLE
fix(ci): the clone ate the whole job budget — two required gates never ran

### DIFF
--- a/.github/workflows/adversarial-review-gate.yml
+++ b/.github/workflows/adversarial-review-gate.yml
@@ -28,6 +28,26 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the PR base ref is resolvable for the diff
+          # blob:none — a partial clone that keeps EVERY commit and tree and omits
+          # only file contents, fetching them on demand. `fetch-depth: 0` above is
+          # deliberately untouched: the history this gate needs (merge-base with a
+          # base ref that may have advanced) is unchanged, so the semantics the
+          # comment above defends are unchanged too. Only blob DELIVERY becomes lazy.
+          #
+          # This is not a speed tidy-up. On 2026-07-27 this checkout consumed 297s of
+          # this job's 300s budget and was killed: the gate itself never ran, the kill
+          # reported `cancelled`, and a cancelled REQUIRED check EJECTS the merge-queue
+          # entry — which then sits open with auto-merge off and nothing retrying it.
+          # Same mechanism killed P6 at 597s of 600s on the same pull request. Measured
+          # locally on this repository: a full clone moves 2,289 MB, blob:none moves
+          # 23.3 MB in 21s — 99% of what every workflow downloads is blobs nobody reads.
+          #
+          # `git diff --name-only` still gets exact results here: rename detection is
+          # the only thing that wants contents, and it wants them only for the files
+          # this pull request touched, which git fetches on demand. If a future step
+          # needs to read many historical file bodies, that step is the thing to
+          # reconsider — do NOT "fix" it by deleting this line and paying 2.3 GB again.
+          filter: blob:none
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/p6-federation-parallelize.yml
+++ b/.github/workflows/p6-federation-parallelize.yml
@@ -46,6 +46,18 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the sentinel git diff sees PR changes
+          # blob:none — keep every commit and tree, omit file contents, fetch them on
+          # demand. `fetch-depth: 0` above is untouched, so the sentinel's
+          # `git diff --name-only "$base"...HEAD` resolves exactly as before.
+          #
+          # Why, measured: on 2026-07-27 this checkout burned 597s of this job's 600s
+          # budget and was killed before the sentinel ran at all. The kill is reported
+          # as `cancelled`, and a cancelled REQUIRED check ejects the merge-queue entry,
+          # which then sits open with auto-merge off and nothing retrying it. The
+          # adversarial-review gate died the same way at 297s of 300s on the same pull
+          # request — one cause, two victims. A full clone here moves 2,289 MB; blob:none
+          # moves 23.3 MB. See the longer note in adversarial-review-gate.yml.
+          filter: blob:none
 
       # BUCO #1 sentinel (pattern: p1s2-mutation-incremental.yml). The regex is
       # the EXACT original pull_request `paths:` list, each anchored ^...$.


### PR DESCRIPTION
## The queue was not flaky — cloning this repository costs more than the gates do

Two merge-queue ejections on 2026-07-27. Same mechanism both times, and in both cases the gate **never executed one of its own steps**:

| gate (required) | `timeout-minutes` | `actions/checkout` took | outcome |
|---|---|---|---|
| `adversarial-review-gate` | 5 (300s) | **297s** | killed → `cancelled` |
| `P6 federation` | 10 (600s) | **597s** | killed → `cancelled` |

Every step after the checkout is recorded as `skipped`. `fetch-depth: 0` on this repository downloads **2,289 MB**, and that is the entire job budget.

**Why an ejection and not just a slow run.** A `timeout-minutes` kill is reported as `cancelled`, not `failed`. A cancelled REQUIRED check ejects the merge-queue entry. The ejected pull request is then left OPEN and MERGEABLE with auto-merge **OFF**, and nothing restores it. So the surface symptom was "the queue keeps dropping things", while the fault was upstream of every gate.

Worth naming because it sent me the wrong way first: the visible red on those runs was `Security Scanning`, twelve minutes later and in a different workflow. CodeQL had finished its analysis cleanly and then failed *uploading* to `gh-readonly-queue/…`, a ref the queue had already destroyed. Read without ordering, that reads as a security failure.

## The fix

`filter: blob:none` — a partial clone that keeps **every commit and tree** and omits only file contents, fetching them on demand. Measured on this repository: **2,289 MB → 23.3 MB in 21s**. 99% of what every workflow downloads is blobs nothing reads.

`fetch-depth: 0` is **deliberately kept** on both. Each gate's existing comment defends full history for a merge-base against a base ref that may have advanced mid-run (one cites a live "fatal: no merge base" on #2033) — that history is unchanged here. Only blob *delivery* becomes lazy.

Both gates run `git diff --name-only`. Rename detection is the only thing that wants contents, and only for files this pull request touched, which git fetches on demand.

## Scope, chosen not defaulted

Two workflows, not all 82 checkouts in this repo. These are the two whose failure was **measured**, and the same two whose recovery this pull request can prove. Widening comes after that proof.

## Verification, and its limit

- `actionlint` clean on both files; both parse, both carry `{fetch-depth: 0, filter: blob:none}`.
- Local evidence for the numbers: a `--filter=blob:none` clone of this repo fetched 23.3 MB in 21s and `merge-base`, `diff --name-only` and `git show HEAD:CLAUDE.md` all resolved correctly against it.
- The R1 gate scopes to `research/**/*.md` only, so this diff is trivially in-scope-empty for it.

**A green run does not prove this worked.** An input `actions/checkout` does not support is silently *ignored* by GitHub Actions — no error, green check, zero effect. The acceptance criterion is therefore the run log of this pull request showing **`--filter=blob:none` in the git fetch invocation**, together with the checkout step's duration on both gates. If the flag is absent from the log, this change did nothing and must not be called done.
