### PR TITLE
perf(ci): stop paying 2.3 GB per run in ten more required gates

### DIFF
--- a/.github/workflows/guard-conformance.yml
+++ b/.github/workflows/guard-conformance.yml
@@ -49,6 +49,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the path-diff sees the PR base
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       - name: Did guard surfaces change?
         id: relevant

--- a/.github/workflows/hook-innocence-gate.yml
+++ b/.github/workflows/hook-innocence-gate.yml
@@ -55,6 +55,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the path-diff sees the PR base
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       # W69 sentinel: decide whether hook-relevant paths changed in this PR.
       # Dependency-free git diff (no third-party action). On push (already

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -32,6 +32,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       - name: Detect immune-relevant changes (sentinel path check)
         id: paths

--- a/.github/workflows/migration-lint.yml
+++ b/.github/workflows/migration-lint.yml
@@ -40,6 +40,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       - name: Detect added/modified migrations on this PR
         id: changed

--- a/.github/workflows/organ-conformance.yml
+++ b/.github/workflows/organ-conformance.yml
@@ -44,6 +44,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the path-diff sees the PR base
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       - name: Did organ surfaces change?
         id: relevant

--- a/.github/workflows/p1s2-mutation-incremental.yml
+++ b/.github/workflows/p1s2-mutation-incremental.yml
@@ -52,6 +52,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so git diff sees the PR changes
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       # BUCO #1 sentinel: decide whether this gate's RELEVANT paths changed in
       # this PR. Dependency-free git diff (no third-party action — TIER-1

--- a/.github/workflows/p7-lesson-harvester.yml
+++ b/.github/workflows/p7-lesson-harvester.yml
@@ -32,6 +32,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the sentinel git diff sees PR changes
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       # BUCO #1 sentinel (pattern: p1s2-mutation-incremental.yml). The regex is
       # the EXACT original pull_request `paths:` list, each anchored ^...$.

--- a/.github/workflows/p8-brand-api.yml
+++ b/.github/workflows/p8-brand-api.yml
@@ -28,6 +28,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the sentinel git diff sees PR changes
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       # BUCO #1 sentinel (pattern: p1s2-mutation-incremental.yml). The regex is
       # the EXACT original pull_request `paths:` list, each anchored ^...$.

--- a/.github/workflows/p9-cost-breaker.yml
+++ b/.github/workflows/p9-cost-breaker.yml
@@ -35,6 +35,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the sentinel git diff sees PR changes
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       # BUCO #1 sentinel (pattern: p1s2-mutation-incremental.yml). The regex is
       # the EXACT original pull_request `paths:` list, each anchored ^...$.

--- a/.github/workflows/verify-the-verifiers.yml
+++ b/.github/workflows/verify-the-verifiers.yml
@@ -40,6 +40,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the path-diff sees the PR base
+          # blob:none — partial clone: every commit and tree, no file contents (fetched on
+          # demand). `fetch-depth: 0` is KEPT, so this gate's `git diff --name-only` resolves
+          # exactly as before; only blob DELIVERY becomes lazy. Measured on this repository:
+          # a full clone moves 2,289 MB, blob:none moves 23.3 MB in 21s.
+          # Not a tidy-up: on 2026-07-27 this same checkout ate 297s of a 300s job budget in
+          # adversarial-review-gate and 597s of 600s in P6 and was KILLED, so those gates never
+          # ran. A timeout kill reports `cancelled`, and a cancelled REQUIRED check EJECTS the
+          # merge-queue entry, which then sits open with auto-merge off. See #3375 for the
+          # measurement and for why the flag's presence in the fetch log — not a green check —
+          # is the proof (an unsupported input is silently ignored by Actions).
+          filter: blob:none
 
       # BUCO #1 sentinel: decide whether the meta-verifier's RELEVANT paths
       # changed in this PR. Dependency-free git diff (no third-party action — this


### PR DESCRIPTION
## Third ejection tonight, same cause — and this one is in the class below

#3375 proved the mechanism and the cure on the two gates whose failure was measured. While it was in the queue, a **third** required gate died exactly the same way:

| gate (required) | budget | `actions/checkout` | outcome |
|---|---|---|---|
| `adversarial-review-gate` | 300s | 297s | killed → `cancelled` (#3375) |
| `P6 federation` | 600s | 597s | killed → `cancelled` (#3375) |
| **`Hook innocence gate`** (`Prove hooks bite only the guilty`) | 600s | **598s** | killed → `cancelled` → **#3372's queue entry went UNMERGEABLE** |

Every step after the checkout is `skipped` in all three: the gates never ran. `hook-innocence-gate.yml` is in the class this pull request cures, which is why it is no longer worth staging behind anything.

Worth recording because it explains why this looked like queue flakiness for so long: in the *other* group building at the same moment, the same two checkouts took **59s and 60s** and passed comfortably. The 297/597/598s runs are tail events, roughly 5–10× the ~61s mean. The defect was always present; it only bites when the runner is slow. Intermittent, not random.

## The class, audited rather than swept

Every git invocation in each of these ten workflows was listed — not sampled. All ten use `git diff --name-only` and nothing else that reads history (plus `merge-base`, `fetch`, `ls-files`). None reads a historical file **body**, so omitting blobs cannot change a verdict, only how it is delivered. `fetch-depth: 0` is **kept** everywhere.

`guard-conformance` · `hook-innocence-gate` · `immune-enforcement` · `migration-lint` · `organ-conformance` · `p1s2-mutation-incremental` · `p7-lesson-harvester` · `p8-brand-api` · `p9-cost-breaker` · `verify-the-verifiers`

## Excluded on purpose, each with its reason

So these read as decisions, not oversights:

- `sonarqube.yml` — SonarQube attributes issues via `git blame`, which reads historical blob contents line by line. The one place `blob:none` could be **slower**.
- `hot-zone-pr-gate.yml` — required, and its enumerator carries the W102 scar. It gets its own focused change, never a batch.
- `token-lint.yml` — `git diff --unified=0 base...HEAD` reads content.
- `wr2-master-template-guard.yml` — `git show` reads a blob at a rev.
- `ai-pr-review.yml` — feeds a content diff to an LLM.
- `docs-guardian.yml`, `docs-inventory-refresh.yml` — `git diff --stat` reads content.
- `p3-sandbox-gates.yml` — `git diff --quiet origin/<base> -- <path>` compares **content**, so it is not in the name-only class.
- `codex-autofix-reaper.yml`, `doc-freshness.yml`, `docs-inventory-refresh-liveness.yml` — no git in the workflow; the scripts they call were **not** audited, so they are not claimed safe.

## Verification

- Verified per file by **parsing the YAML**, not grepping it: each checkout step carries `fetch-depth: 0` together with `filter: blob:none` inside its own `with:` block. 10/10.
- `actionlint` clean on all ten.
- The generator **refuses** any file whose anchor count is not exactly one rather than skipping it — a partial sweep that reports success is the failure this repo keeps paying for.
- No conflict with the three pull requests in flight: `immune-enforcement.yml` is also touched by #3372, but at lines 117 and 228 against this change's line 34.

**Acceptance criterion, and it is not the green check:** an input `actions/checkout` does not support is silently *ignored* by Actions — green, zero effect. The proof is `--filter=blob:none` in each gate's git fetch log. On #3375 that was confirmed in both the `pull_request` runs and inside the merge group, where the checkout fell to 24s and 23s.
