### PR TITLE
fix(ci): a broken production image reported the run as green, and told no one

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -167,8 +167,31 @@ jobs:
     name: Snyk Docker Security
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Advisory-only: see snyk-python job comment.
-    continue-on-error: true
+    # This job does TWO different things and they deserve different verdicts:
+    # it BUILDS the production image, and then it SCANS the result.
+    #
+    # A vulnerability finding stays advisory — a CVE in the base image should not
+    # block every pull request — and that is handled where it belongs, by the
+    # step-level `continue-on-error` on "Run Snyk (Docker)" below.
+    #
+    # A BUILD failure is not a finding. It means the production image cannot be
+    # produced at all, and `fly deploy` builds this very Dockerfile. So the
+    # job-level `continue-on-error: true` that used to sit here was removed
+    # (2026-07-28): measured, it let the workflow RUN report `success` while
+    # `Build Docker image` had failed — run 30302472020 (a merge_group!) and run
+    # 30301159955 both concluded green with a broken image. The job's own check
+    # went red either way, but nothing that watches "did security.yml pass" could
+    # see it, and this check cannot be made required because it needs SNYK_TOKEN
+    # (a required context that needs a secret is impassable for Dependabot).
+    #
+    # Removing it changes no gating: `Snyk Docker Security` is not a required
+    # context and the run conclusion is not one either. It only stops the run from
+    # claiming success over a broken build.
+    #
+    # The comment previously here said "Advisory-only: see snyk-python job
+    # comment" — a pointer that had outlived its target: snyk-python is now
+    # documented as a BLOCKING gate, so the reference argued the opposite of what
+    # it was cited for. Stating the reason locally instead of pointing elsewhere.
 
     steps:
       - name: Checkout code
@@ -181,12 +204,33 @@ jobs:
 
       - name: Run Snyk (Docker)
         uses: snyk/actions/docker@master
-        continue-on-error: true
+        continue-on-error: true # vulnerability findings stay advisory (see job comment)
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: nuzantara-rag:${{ github.sha }}
           args: --severity-threshold=high
+
+      # A red check on a pull request is seen by its author. A red check on MAIN is
+      # seen by nobody: none of this workflow's eight jobs alarmed, while fly-deploy
+      # and six cron-* workflows all carry `if: failure()` Telegram steps on the same
+      # channel. That asymmetry is why the 2026-07-27 NodeSource 403s — intermittent
+      # failures at 19:57, 19:58, 20:06, 20:20 and 20:24, recovering by 20:42 — broke
+      # the production image build repeatedly without anyone being told.
+      #
+      # Restricted to pushes on main on purpose: on a pull request the author already
+      # has the signal, and duplicating it there would only train people to ignore the
+      # channel. `secrets.*` is available on main pushes.
+      - name: Telegram alert — production image failed to BUILD on main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -s "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d "chat_id=${{ secrets.TELEGRAM_OWNER_CHAT_ID }}" \
+            -d "parse_mode=HTML" \
+            -d "text=🐳 <b>nuzantara-rag image failed to BUILD on main</b>%0A%0A<code>${SHA:0:8}</code>%0A%0A<code>fly deploy</code> builds this same Dockerfile, so a deploy attempted now would fail too. This check is advisory for CVEs, never for a build break.%0A%0A${RUN_URL}"
 
   codeql:
     name: CodeQL Analysis


### PR DESCRIPTION
## A broken production image reported the run as green, and told no one

`snyk-docker` does two different things and they were sharing one verdict: it **builds** the production image, then **scans** the result. A job-level `continue-on-error: true` covered both.

Measured, not reasoned — two runs isolate it. `Build Docker image` **failed** and the workflow **run** still concluded `success`:

| run | event | build step | job | **run** |
|---|---|---|---|---|
| 30302472020 | `merge_group` | failure | failure | **success** |
| 30301159955 | `pull_request` | failure | failure | **success** |
| 30300605069 | `pull_request` | failure | failure | failure |

A `merge_group` among them: the queue saw green over an image that could not be built. The job's own check went red either way, but nothing watching *"did security.yml pass on main"* could see it — and this check can never be made required, because it needs `SNYK_TOKEN`, and a required context that needs a secret is impassable for Dependabot.

## Two changes, matching the two things the job does

**1. Job-level `continue-on-error` removed.** A vulnerability finding stays advisory — a CVE in the base image must not block every pull request — and that is handled where it belongs, by the *step-level* flag on `Run Snyk (Docker)`. A build failure is not a finding: it means `fly deploy`, which builds this same Dockerfile, would fail too.

Changes no gating: `Snyk Docker Security` is not a required context, and the run conclusion is not one either. `security-summary` carries `if: always()`, so it still runs (checked). Dependabot is unaffected: the part that fails without a secret is the Snyk *step*, which keeps its own `continue-on-error`.

**2. A Telegram alarm on `if: failure()`, restricted to pushes on main.** A red check on a pull request is seen by its author. A red check on main was seen by nobody: none of this workflow's eight jobs alarmed, while `fly-deploy` and six `cron-*` workflows all carry the same `if: failure()` Telegram step on the same channel. Not duplicated onto pull requests on purpose — that would only train people to ignore the channel.

## Corrected while here

The comment justifying "advisory-only" pointed at the `snyk-python` job — which is now documented as a **blocking gate**. The pointer had outlived its target and argued the opposite of what it was cited for. The reason is now stated locally instead of by reference.

## Two of my own earlier claims, corrected

- I said a deploy-blocking failure was *reported by no required check, so production silently stops updating*. **`fly-deploy` is in fact well alarmed** — `if: failure()` Telegram steps on the pre-deploy gate, both migration jobs and post-deploy health, plus a dedicated `deploy-failure-alert` job gated on `always() && (needs.run-migrations.result == 'failure' || needs.deploy.result == 'failure')`, which is the correct pattern since a skipped job is not a failure. Nothing to fix there. The gap was only here, in `security.yml`.
- I said the NodeSource 403 *blocked deploys*. It was **intermittent**: failures at 19:57, 19:58, 20:06, 20:20 and 20:24, building again by 20:42 — on main, still with the old Dockerfile. I had measured a window of failures and read it as a steady state without checking for recovery. That is exactly the shape this alarm is for: a break that comes and goes leaves no lasting red for anyone to notice.

## Verification

- Verified by **parsing** the YAML, not grepping: `snyk-docker` has no job-level `continue-on-error`; `Run Snyk (Docker)` keeps its step-level one; the alarm step carries `if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'`. No other job in the file was touched.
- `actionlint` clean. One file, 47 insertions / 3 deletions.
- No untrusted input in the alarm step: only `github.sha`, `github.run_id`, `github.repository`, `github.server_url`, passed via `env:`.

**Limit, stated:** this pull request cannot prove the alarm fires — that needs a real build failure on main, which is not something to manufacture. What it does prove is that a build failure now fails the run instead of being reported as success. The alarm's delivery should be treated as unproven until the first genuine firing.
