### PR TITLE
fix(deps): anthropic must travel with langchain-anthropic or the group cannot resolve

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,21 @@ updates:
           - "openai"
           - "langchain*"
           - "tiktoken"
+          # "anthropic" travels WITH langchain-anthropic or the group cannot
+          # resolve. langchain-anthropic 1.5.2 requires anthropic<1.0.0,>=0.120.0
+          # (verified on PyPI), so a group that raises langchain-anthropic while
+          # leaving anthropic pinned at the lock's 0.117.0 is unsatisfiable as a
+          # unit — uv's exact words on PR #3357: "Because langchain-anthropic
+          # >=1.5.2 depends on anthropic>=0.120.0 and you require
+          # anthropic==0.117.0 ... your requirements are unsatisfiable."
+          # This is the same shape as the fsspec/datasets, grpcio and websockets
+          # notes above; the difference is that those were cured by IGNORING the
+          # co-constrained package, which cannot work here — the constraint is a
+          # floor that rises, not a ceiling that blocks, so freezing anthropic
+          # would freeze langchain-anthropic with it. Group them instead.
+          # Safe for the third dependent: openinference-instrumentation-anthropic
+          # 1.0.6 asks only for anthropic>=0.84.0, no upper bound.
+          - "anthropic"
         update-types:
           - "minor"
           - "patch"
@@ -88,6 +103,10 @@ updates:
           - "openai"
           - "langchain*"
           - "tiktoken"
+          # mirrors the openai-stack patterns above — a package left in both
+          # groups is claimed by whichever matches first, which makes the pairing
+          # above depend on ordering instead of on the declaration.
+          - "anthropic"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## What breaks today

Dependabot PR #3357 (`openai-stack` group) fails the **required** `Backend Tests (Python)`
check — not in a test, but in `Install dependencies (uv, lock-pinned)`. uv's verbatim words:

```
× No solution found when resolving dependencies:
╰─▶ Because langchain-anthropic>=1.5.2 depends on anthropic>=0.120.0 and you
    require anthropic==0.117.0, we can conclude that your requirements and
    langchain-anthropic>=1.5.2 are incompatible.
```

`E2E Tests (Playwright)` (also required) dies on the same install.

## Why

The `openai-stack` group captures `openai`, `langchain*` and `tiktoken` — **not** `anthropic`.
So Dependabot raises `langchain-anthropic` to 1.5.2 while the lock keeps `anthropic==0.117.0`,
and the group is unsatisfiable as a unit.

Verified on PyPI rather than inferred:

| package | constraint on `anthropic` |
|---|---|
| `langchain-anthropic` 1.5.2 | `anthropic<1.0.0,>=0.120.0` |
| `openinference-instrumentation-anthropic` 1.0.6 | `anthropic>=0.84.0` (no upper bound) |

The manifests declare `anthropic>=0.117.0` — a **floor**, not a deliberate pin. Nothing in
`ignore:` freezes it. So there is no decision being violated here, only a gap in the grouping.

## Why grouping and not another `ignore`

This is the fourth instance of a shape already recorded three times in this very file
(`fsspec`/`datasets`, `grpcio`, `websockets`): a group that bumps one half of a co-constrained
pair. Those three were cured by **ignoring** the sibling — which cannot work here. Their
constraint is a *ceiling that blocks*; `anthropic`'s is a **floor that rises**, so freezing
`anthropic` would freeze `langchain-anthropic` along with it, permanently. Grouping is the
cure that matches the direction of the constraint.

Mirrored into `minor-and-patch`'s `exclude-patterns` too: a package matched by two groups is
claimed by whichever is evaluated first, which would leave the pairing depending on ordering
instead of on the declaration.

## Verification

- `.github/dependabot.yml` parses; `openai-stack.patterns` and `minor-and-patch.exclude-patterns`
  are mirrored (4 entries each); `anthropic` is confirmed absent from the 15 `ignore:` entries.
- No code path changes. `anthropic` is imported by 3 files (2 scripts + 1 integration test);
  the sanctioned production path (`backend/llm/claude_oauth_client.py`) shells out to the
  `claude` CLI and does not import the SDK at all, so the paid-endpoint ban is untouched.

After this merges, `@dependabot recreate` on #3357 regenerates it with the pair moving together.