### PR TITLE
fix(ci): the mouth coverage gate is green by hoisting accident, not by declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "@types/node-cron": "^3.0.11",
         "@types/pg": "^8.15.6",
         "@types/supertest": "^6.0.3",
+        "@vitest/coverage-istanbul": "^4.1.10",
         "autocannon": "^8.0.0",
         "esbuild": "^0.28.1",
         "husky": "^9.1.7",
@@ -1399,31 +1400,6 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
-      }
-    },
-    "apps/mouth/node_modules/@vitest/coverage-istanbul": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.10.tgz",
-      "integrity": "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.29.0",
-        "@istanbuljs/schema": "^0.1.3",
-        "@jridgewell/gen-mapping": "^0.3.13",
-        "@jridgewell/trace-mapping": "0.3.31",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "4.1.10"
       }
     },
     "apps/mouth/node_modules/ajv": {
@@ -11549,9 +11525,9 @@
       }
     },
     "node_modules/@vitest/coverage-istanbul": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.8.tgz",
-      "integrity": "sha512-/h514nMZMKI6foh21mVgO1zlCH6pdDamwKMbla1uLU2GMxTlfp0PQMxovWozmzQdCIQYZ2XXEzg2zNZom2zAOg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.10.tgz",
+      "integrity": "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11570,7 +11546,7 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.8"
+        "vitest": "4.1.10"
       }
     },
     "node_modules/@vitest/expect": {
@@ -31080,7 +31056,7 @@
         "@testing-library/react": "16.3.2",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
-        "@vitejs/plugin-react": "^6.0.4",
+        "@vitejs/plugin-react": "6.0.4",
         "@vitest/coverage-istanbul": "4.1.8",
         "jsdom": "29.1.1",
         "lucide-react": "1.18.0",
@@ -31122,6 +31098,31 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "packages/core/node_modules/@vitest/coverage-istanbul": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.8.tgz",
+      "integrity": "sha512-/h514nMZMKI6foh21mVgO1zlCH6pdDamwKMbla1uLU2GMxTlfp0PQMxovWozmzQdCIQYZ2XXEzg2zNZom2zAOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "@jridgewell/gen-mapping": "^0.3.13",
+        "@jridgewell/trace-mapping": "0.3.31",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.8"
       }
     },
     "packages/core/node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/node-cron": "^3.0.11",
     "@types/pg": "^8.15.6",
     "@types/supertest": "^6.0.3",
+    "@vitest/coverage-istanbul": "^4.1.10",
     "autocannon": "^8.0.0",
     "esbuild": "^0.28.1",
     "husky": "^9.1.7",


### PR DESCRIPTION
`Frontend Tests (Next.js) (mouth, true)` is a **required** check. It runs:

```
cd apps/mouth && npx vitest --run --coverage
```

`npx vitest` resolves the **root-hoisted** vitest binary, and vitest resolves its coverage
provider relative to **itself** — i.e. from the root `node_modules`. Nothing declares
`@vitest/coverage-istanbul` there. On `main` it exists only because npm's hoisting happens
to leave a 4.1.8 copy at the root; no manifest asks for it.

Dependabot #3359 aligns every vitest to 4.1.10, npm dedupes, the provider moves **into**
the workspaces, and the required check dies:

```
Error: Cannot find package '@vitest/coverage-istanbul' imported from
/home/runner/work/Teman2/Teman2/node_modules/vitest/...
Serialized Error: { code: 'ERR_MODULE_NOT_FOUND' }
```

**#3359 is not the defect** — it is the first change that stops the accident from holding.
Declaring the provider at the root makes the resolution a fact of the manifest instead of a
by-product of the dependency tree's shape.

### The lock diff is three lines of meaning

| change | why |
| --- | --- |
| root `@vitest/coverage-istanbul` 4.1.8 → **4.1.10** | now a declared root devDependency, satisfying both the hoisted vitest 4.1.10 and mouth's `^4.1.10` |
| `apps/mouth/node_modules/@vitest/coverage-istanbul` removed | deduped up into the root copy |
| `packages/core/node_modules/@vitest/coverage-istanbul` 4.1.8 added | correct — that workspace pins `vitest` and the provider to an EXACT 4.1.8 pair of its own |

### One process note worth more than the diff

Regenerated with `npm install --package-lock-only` under **Node 24 / npm 11**, the same
major CI uses (`setup-node` `node-version: "24"`). Doing it with the locally-default npm 10
produced a **954-line** diff of platform-optional churn plus a bogus nested provider,
versus **31** lines under npm 11. A lock is owned by an npm major; regenerating it with a
different one rewrites far more than the change asks for.

Unblocks #3359 (the 29-update npm group) once Dependabot rebases it.