### PR TITLE
perf(ci): the last two REQUIRED gates were still paying 2.3 GB per run

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
+          filter: blob:none
       - name: Build review input (untrusted diff → file, never inlined)
         id: input
         if: steps.guard.outputs.has_token == 'true'

--- a/.github/workflows/codex-autofix-reaper.yml
+++ b/.github/workflows/codex-autofix-reaper.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
+          filter: blob:none
       - name: Set up Python
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # git-history ages (same requirement as docs-guardian)
+          filter: blob:none
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/docs-guardian.yml
+++ b/.github/workflows/docs-guardian.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # needed for `git log -1 --format=%ct` mtime derivation
+          filter: blob:none
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/docs-inventory-refresh.yml
+++ b/.github/workflows/docs-inventory-refresh.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # needed for docs_audit.py mtime derivation (git log -1 --format=%ct)
+          filter: blob:none
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -74,7 +74,7 @@ jobs:
           # For pull_request: github.event.pull_request.base.sha
           ref: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
           fetch-depth: 0
-
+          filter: blob:none
       # ---------------------------------------------------------------------
       # Step 1bis — Self-test the changed-file enumerator (guilt + innocence)
       #

--- a/.github/workflows/p3-sandbox-gates.yml
+++ b/.github/workflows/p3-sandbox-gates.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the sentinel git diff sees PR changes
+          filter: blob:none
 
       # BUCO #1 sentinel (pattern: p1s2-mutation-incremental.yml). The regex is
       # the EXACT original pull_request `paths:` list, each anchored ^...$.

--- a/.github/workflows/token-lint.yml
+++ b/.github/workflows/token-lint.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the PR base ref is resolvable for the diff
+          filter: blob:none
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/worker-plane-review-tests.yml
+++ b/.github/workflows/worker-plane-review-tests.yml
@@ -70,6 +70,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so the PR base is resolvable for the sentinel diff
+          filter: blob:none
 
       - name: Did worker-plane review surfaces change?
         id: relevant

--- a/.github/workflows/wr2-master-template-guard.yml
+++ b/.github/workflows/wr2-master-template-guard.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
+          filter: blob:none
       - name: Detect TEMPLATE_DESIGN_ID change
         id: detect
         run: |


### PR DESCRIPTION
#3375 and #3376 gave `filter: blob:none` to twelve gates. Asking the **tree** rather than
the memory of that change, twelve MORE workflows still checked out with a bare
`fetch-depth: 0` — and two of them produce **REQUIRED** contexts:

- `Hot-zone enforcement` (`hot-zone-pr-gate.yml`)
- `P3 static validation (enforcing)` (`p3-sandbox-gates.yml`)

Those two are not merely slow. A required gate whose checkout can outlive its own
`timeout-minutes` is killed, reports `cancelled`, and **a cancelled REQUIRED check ejects
the merge-queue entry** — leaving the PR open with its auto-merge request already consumed
and nothing to restore it. That is the exact chain measured on 2026-07-27 (297 s of a 300 s
budget spent inside the checkout).

`fetch-depth: 0` moves 2,289 MB here; with `filter: blob:none` the same fetch is 23.3 MB in
21 s. Both keys stay — depth is *how much history*, filter is *whether file contents come
along*. Blobs arrive on demand for whatever actually reads them, and these jobs read trees
(`git diff --name-only`, base-ref resolution, `git log -1 --format=%ct`), not history
contents.

### Two things the sweep learned about itself

1. **The applier REFUSES rather than skips.** Its first pass reported "0 anchors" for eight
   files — which is *not* "already fine": seven of them write
   `fetch-depth: 0 # full history so ...`, and a `$`-anchored pattern cannot see a trailing
   comment. A silent skip here is how a sweep comes to claim coverage it does not have.
2. **`docs-inventory-refresh-liveness.yml` was a false positive** of my own `grep -l`: it
   matched the *comment* `# No fetch-depth: 0 — this script never touches git history`. It
   is correctly the one file the applier still refuses. A comment is not a declaration.

### Deliberately excluded: `sonarqube.yml`

It is the one job here whose work plausibly reads **historical** blobs (JGit SCM blame),
where partial-clone lazy fetch is an unknown rather than a saving. It is not a required
context, so its clone cost blocks nothing, and trading a certain 2.3 GB for a
possibly-broken analyser is the wrong trade. Left at full clone **on purpose**, not
overlooked.

### Verification

By **parsing** every workflow, not by grepping the text just written: all 23
`actions/checkout` steps carrying `fetch-depth: 0` now also carry `filter: blob:none`
inside their **own** `with:` block — a grep would happily accept the two keys landing in
two different steps. `actionlint` raises nothing on the added key (the 30 issues it reports
are pre-existing shellcheck style findings `main` is already green with).

> Reviewer note: **a green run does not prove the flag took effect.** An unrecognised
> `actions/checkout` input is silently ignored — no warning, no failure, just a full clone.
> The proof is the literal `--filter=blob:none` in each run's *Fetching the repository* log.