### PR TITLE
fix(ci): the frontend sentinel could only speak while someone was pushing

### DIFF
--- a/.github/workflows/frontend-live-sentinel.yml
+++ b/.github/workflows/frontend-live-sentinel.yml
@@ -19,6 +19,27 @@ name: Frontend Live Sentinel
 #
 # No new credentials: it reads a public endpoint.
 # Scar family #2 (exists != armed), plus the W88 rule — verify by content, never by proxy.
+#
+# ---------------------------------------------------------------------------------------
+# 2026-07-28, three changes, each paid for by something measured the night before.
+#
+# A SCHEDULE, because a push trigger cannot see a silence. The App is still uninstalled —
+# vercel[bot]'s last GitHub Deployment is 2026-07-26T20:07:27Z, none since. Overnight,
+# production sat 6 hours and 8 commits behind main and this workflow never ran once: none of
+# those commits touched a frontend path, so nothing woke it. A sentinel that can only speak
+# when the thing it guards is being changed is blind exactly when the change stops arriving.
+#
+# THE VERDICT IS "DOES PRODUCTION INCLUDE THIS COMMIT", NOT "DOES IT EQUAL THIS SHA". The
+# equality test demanded a deploy for commits that cannot change the built app: at 17:19Z it
+# went red for a commit that touched only apps/mouth/e2e/**. Now the expected commit is the
+# newest one touching a path that actually reaches the bundle (e2e excluded), and the test is
+# ancestry — production may legitimately be AHEAD of it, never behind. Ancestry is the right
+# semantic here and not a W88-style lying proxy: both shas live on main's linear history, and
+# a served sha that is absent from history fails closed rather than passing.
+#
+# ONE ALERT PER STALE COMMIT. At */30 a permanent outage would send 48 Telegrams a day, and a
+# channel that always shouts is a channel nobody reads (the P0 budget is 12/day). The cache
+# key is the expected sha, so a NEW stale commit still speaks immediately.
 
 on:
   push:
@@ -30,10 +51,17 @@ on:
       - "package-lock.json"
       - "vercel.json"
       - "apps/mouth/vercel.json"
+  schedule:
+    # Every 30 minutes. The job is a shallow-ish clone plus a curl; the cost of running it is
+    # far below the cost of one more silent stale night.
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
 
 concurrency:
-  # A newer push makes this wait irrelevant: only the latest sha on main matters.
-  group: frontend-live-sentinel-${{ github.ref }}
+  # A newer push makes this wait irrelevant: only the latest sha on main matters. The event
+  # name is part of the group on purpose — a scheduled tick must never cancel an in-flight
+  # push run: a cancelled run reports neither pass nor fail, which is how a red turns silent.
+  group: frontend-live-sentinel-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:
@@ -45,39 +73,95 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Poll balizero.com until it serves this sha
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history: the ancestry test needs both shas present
+          # blob:none — every commit and tree, file contents fetched on demand. A full clone
+          # of this repo moves 2,289 MB and has already eaten an entire job budget elsewhere.
+          filter: blob:none
+
+      - name: Which commit must production include?
+        id: expected
         env:
-          SHA: ${{ github.sha }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          # Paths that can change what the browser receives. apps/mouth/e2e is excluded: those
+          # specs run in CI and never reach the bundle, so demanding a deploy for them
+          # manufactures a red with no user-visible referent.
+          sha=$(git log -1 --format=%H -- \
+            apps/mouth packages package.json package-lock.json vercel.json \
+            ':(exclude)apps/mouth/e2e')
+          if [ -z "$sha" ]; then
+            echo "::warning::no commit touches the deploy-relevant paths — nothing to assert"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          age_s=$(( $(date -u +%s) - $(git show -s --format=%ct "$sha") ))
+          echo "expected  : $sha"
+          echo "age       : $(( age_s / 60 )) min"
+          echo "event     : $EVENT"
+
+          # One decision, one write per key: a duplicated key in $GITHUB_OUTPUT is a coin toss
+          # nobody should have to reason about.
+          skip=false
+          attempts=3
+          if [ "$EVENT" = "push" ]; then
+            # A frontend build plus alias assignment normally lands in 3-6 minutes.
+            # 18 attempts x 60s = 18 minutes of grace before shouting.
+            attempts=18
+          elif [ "$age_s" -lt 2700 ]; then
+            # Younger than 45 min on a scheduled tick: a deploy may still be in flight, and
+            # the push-triggered run is the one that owns that window. Do not double-shout.
+            echo "::notice::expected commit is $(( age_s / 60 )) min old — inside the deploy window, deferring to the push run"
+            skip=true
+          fi
+
+          {
+            echo "skip=$skip"
+            echo "sha=$sha"
+            echo "age_min=$(( age_s / 60 ))"
+            echo "attempts=$attempts"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Poll balizero.com until it includes that commit
+        id: probe
+        if: steps.expected.outputs.skip != 'true'
+        env:
+          SHA: ${{ steps.expected.outputs.sha }}
+          ATTEMPTS: ${{ steps.expected.outputs.attempts }}
         run: |
           set -uo pipefail
           URL="https://balizero.com/api/health"
           seen=""
-          # A frontend build plus alias assignment normally lands in 3-6 minutes.
-          # 18 attempts x 60s = 18 minutes of grace before shouting.
-          for i in $(seq 1 18); do
+          for i in $(seq 1 "$ATTEMPTS"); do
             # Capture the exit code directly — never through a pipe, which reports the pipe's.
             body=$(curl -sS --max-time 25 "$URL" 2>&1); rc=$?
             if [ "$rc" -ne 0 ]; then
-              echo "attempt $i/18 - curl rc=$rc: ${body:0:160}"
+              echo "attempt $i/$ATTEMPTS - curl rc=$rc: ${body:0:160}"
               sleep 60; continue
             fi
             live=$(printf '%s' "$body" | jq -r '.commit // empty')
             if [ -z "$live" ]; then
               # Field absent: production predates the change that introduces it, or someone
               # removed it. Neither is evidence of health, so this is not a pass.
-              echo "attempt $i/18 - /api/health exposes no .commit (production older than this probe?)"
+              echo "attempt $i/$ATTEMPTS - /api/health exposes no .commit (production older than this probe?)"
               seen="(no .commit field)"
               sleep 60; continue
             fi
             seen="$live"
-            echo "attempt $i/18 - production serves ${live:0:8}, expected ${SHA:0:8}"
-            if [ "$live" = "$SHA" ]; then
+            # Ancestor-or-equal: production is allowed to be AHEAD of the expected commit
+            # (a later e2e-only or CI-only commit deployed with something else), never behind.
+            # An unknown sha makes this exit non-zero, which is a fail — deliberately closed.
+            if git merge-base --is-ancestor "$SHA" "$live" 2>/dev/null; then
+              echo "attempt $i/$ATTEMPTS - production serves ${live:0:8}, which includes ${SHA:0:8}"
               echo "OK - balizero.com is serving this commit."
               exit 0
             fi
+            echo "attempt $i/$ATTEMPTS - production serves ${live:0:8}, which does NOT include ${SHA:0:8}"
             sleep 60
           done
-          echo "::error::After 18 minutes balizero.com is NOT serving $SHA (last seen: ${seen:-no response})."
+          echo "::error::balizero.com does NOT include $SHA (last seen: ${seen:-no response})."
           echo "The public frontend is stale: balizero.com AND every subdomain share one Vercel project."
           echo "Two known causes, likeliest first:"
           echo "  1) The Vercel GitHub App is not installed/authorised on the repo, so no deployment"
@@ -85,23 +169,35 @@ jobs:
           echo "     -> Configure -> grant access to this repository."
           echo "  2) A deployment was created and went READY, but the custom domains were not"
           echo "     repointed. Fix: POST /v10/projects/<projectId>/promote/<deploymentId>."
-          echo "Manual deploy meanwhile: POST /v13/deployments with gitSource, then promote —"
+          echo "Manual deploy meanwhile: scripts/vercel_prod_deploy.py (gitSource + promote) —"
           echo "that path keeps working even when the project's git link is gone."
           exit 1
 
-      - name: Tell Telegram once the silence is confirmed
+      # Dedup lives between the failure and the alert, never inside the alert: the cache is
+      # keyed by the expected sha, so a permanent outage speaks once and a NEW stale commit
+      # speaks again immediately.
+      - name: Has this stale commit already been announced?
+        id: announced
         if: failure()
+        uses: actions/cache/restore@v4
+        with:
+          path: .stale-alert-marker
+          key: frontend-stale-alert-${{ steps.expected.outputs.sha }}
+
+      - name: Tell Telegram once the silence is confirmed
+        if: failure() && steps.announced.outputs.cache-hit != 'true'
         env:
           TG_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TG_CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
-          SHA: ${{ github.sha }}
+          SHA: ${{ steps.expected.outputs.sha }}
+          AGE_MIN: ${{ steps.expected.outputs.age_min }}
         run: |
           set -uo pipefail
           if [ -z "${TG_TOKEN:-}" ] || [ -z "${TG_CHAT:-}" ]; then
             echo "::warning::Telegram secrets absent - no alert sent"
             exit 0
           fi
-          MSG="[FRONTEND STALE] balizero.com is not serving ${SHA:0:8} after 18 min. Every subdomain (kita/my/prime/visa/tax/zantara) shares that Vercel project, so they are stale too. Likely fix: github.com/apps/vercel -> Configure -> grant repo access."
+          MSG="[FRONTEND STALE] balizero.com does not include ${SHA:0:8} (${AGE_MIN} min old). Every subdomain (kita/my/prime/visa/tax/zantara) shares that Vercel project, so they are stale too. Fix: github.com/apps/vercel -> Configure -> grant repo access. Stopgap: python3 scripts/vercel_prod_deploy.py"
           # Judge the REPLY, not the exit code: curl exits 0 even when Telegram refuses.
           resp=$(curl -sS --max-time 20 -X POST "https://api.telegram.org/bot$TG_TOKEN/sendMessage" \
             --data-urlencode "chat_id=$TG_CHAT" --data-urlencode "text=$MSG" 2>&1); rc=$?
@@ -111,5 +207,15 @@ jobs:
           fi
           case "$resp" in
             *'"ok":true'*) echo "Telegram alert delivered" ;;
-            *) echo "::warning::Telegram REFUSED the alert: ${resp:0:200}" ;;
+            *) echo "::warning::Telegram REFUSED the alert: ${resp:0:200}"; exit 0 ;;
           esac
+          date -u +%FT%TZ > .stale-alert-marker
+
+      # Saved only when an alert actually went out, so a refused Telegram does not buy silence
+      # for the next 30 minutes.
+      - name: Remember that this stale commit was announced
+        if: failure() && steps.announced.outputs.cache-hit != 'true' && hashFiles('.stale-alert-marker') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: .stale-alert-marker
+          key: frontend-stale-alert-${{ steps.expected.outputs.sha }}

--- a/scripts/tests/test_frontend_live_sentinel.py
+++ b/scripts/tests/test_frontend_live_sentinel.py
@@ -1,0 +1,168 @@
+"""Tests for .github/workflows/frontend-live-sentinel.yml — the "is production stale?" guard.
+
+The guard is two decisions written in shell inside a workflow, so both are EXTRACTED from
+the workflow text here rather than retyped: a retyped copy would pass forever while the
+real gate rots (W65 — never build on a citation you did not re-read).
+
+  1. WHICH commit must production include — a `git log -1` pathspec. It must exclude
+     apps/mouth/e2e/**: on 2026-07-27 17:19Z the sentinel went red for a commit that
+     touched only e2e specs, which cannot change what the browser receives.
+  2. WHETHER production includes it — `git merge-base --is-ancestor "$SHA" "$live"`.
+     Argument ORDER is the whole meaning: reversed, it asserts that production is BEHIND,
+     which passes on exactly the outage this guard exists to catch.
+
+Superscar #3 discipline: guilt (it fires on a genuinely stale production) AND innocence
+(it stays quiet when production is legitimately AHEAD, and an e2e-only commit never becomes
+the thing demanded). Plus fail-closed on a sha that is not in history — an unknown commit
+is not evidence of health.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "frontend-live-sentinel.yml"
+)
+
+
+def _workflow_text() -> str:
+    assert WORKFLOW.exists(), f"workflow missing at {WORKFLOW}"
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _extract_pathspec() -> list[str]:
+    """The pathspec the workflow actually uses to pick the expected commit."""
+    text = _workflow_text()
+    match = re.search(
+        r"git log -1 --format=%H -- \\\n(.*?)\)\n",
+        text,
+        re.DOTALL,
+    )
+    assert match, "could not find the `git log -1 --format=%H --` pathspec in the workflow"
+    raw = match.group(1).replace("\\\n", " ")
+    args = [a.strip().strip("'") for a in raw.split() if a.strip() and a.strip() != "\\"]
+    assert args, "extracted an empty pathspec — the extraction, not the guard, is broken"
+    return args
+
+
+def _extract_ancestor_args() -> tuple[str, str]:
+    """The two operands of --is-ancestor, in the order the workflow passes them."""
+    text = _workflow_text()
+    match = re.search(r'git merge-base --is-ancestor "(\$\w+)" "(\$\w+)"', text)
+    assert match, "could not find `git merge-base --is-ancestor` in the workflow"
+    return match.group(1), match.group(2)
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True
+    )
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A synthetic history: a bundle-relevant commit, then an e2e-only one on top."""
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "t@example.com")
+    _git(r, "config", "user.name", "t")
+
+    def commit(rel: str, message: str) -> str:
+        p = r / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(message, encoding="utf-8")
+        _git(r, "add", "-A")
+        _git(r, "commit", "-q", "-m", message)
+        return _git(r, "rev-parse", "HEAD")
+
+    commit("README.md", "base")
+    relevant = commit("apps/mouth/app/page.tsx", "ships to the browser")
+    e2e_only = commit("apps/mouth/e2e/smoke.spec.ts", "runs in CI only")
+    unrelated = commit("docs/notes.md", "no bundle impact")
+
+    (r / ".shas").write_text(f"{relevant}\n{e2e_only}\n{unrelated}\n", encoding="utf-8")
+    return r
+
+
+def _expected_commit(repo: Path) -> str:
+    return _git(repo, "log", "-1", "--format=%H", "--", *_extract_pathspec())
+
+
+def _includes(repo: Path, expected: str, served: str) -> bool:
+    """Exactly what the workflow asks git, operands in the workflow's own order."""
+    first, second = _extract_ancestor_args()
+    assert (first, second) == ("$SHA", "$live"), (
+        f"--is-ancestor operand order changed: got ({first}, {second}). "
+        "Reversed, the guard asserts production is BEHIND and passes on the real outage."
+    )
+    return (
+        subprocess.run(
+            ["git", "-C", str(repo), "merge-base", "--is-ancestor", expected, served]
+        ).returncode
+        == 0
+    )
+
+
+def test_pathspec_excludes_e2e_specs() -> None:
+    """INNOCENCE: a spec file cannot change the bundle, so it must not demand a deploy."""
+    args = _extract_pathspec()
+    assert ":(exclude)apps/mouth/e2e" in args, (
+        f"the e2e exclusion is gone from the pathspec: {args}. "
+        "Without it, a test-only commit makes production look stale."
+    )
+    assert "apps/mouth" in args, f"apps/mouth dropped from the pathspec: {args}"
+
+
+def test_expected_commit_is_the_last_bundle_relevant_one(repo: Path) -> None:
+    """INNOCENCE: the newest commit is e2e-only + docs; neither may be what we demand."""
+    relevant, e2e_only, unrelated = (repo / ".shas").read_text().split()
+    expected = _expected_commit(repo)
+    assert expected == relevant, (
+        f"expected {relevant[:9]} (the page.tsx commit), got {expected[:9]}"
+    )
+    assert expected not in (e2e_only, unrelated)
+
+
+def test_guilt_production_behind_the_relevant_commit_is_flagged(repo: Path) -> None:
+    """GUILT: production on the pre-change commit does NOT include it — the real outage."""
+    relevant, _e2e, _docs = (repo / ".shas").read_text().split()
+    before = _git(repo, "rev-parse", f"{relevant}~1")
+    assert _includes(repo, relevant, before) is False
+
+
+def test_innocence_production_ahead_still_passes(repo: Path) -> None:
+    """INNOCENCE: production carrying a LATER commit includes the expected one.
+
+    This is the case equality got wrong: a deploy that happened to ship a newer sha was
+    reported stale purely because the strings differed.
+    """
+    relevant, e2e_only, unrelated = (repo / ".shas").read_text().split()
+    assert _includes(repo, relevant, relevant) is True
+    assert _includes(repo, relevant, e2e_only) is True
+    assert _includes(repo, relevant, unrelated) is True
+
+
+def test_fail_closed_on_a_commit_absent_from_history(repo: Path) -> None:
+    """A served sha git has never seen is unknown, and unknown is not healthy."""
+    relevant, _e2e, _docs = (repo / ".shas").read_text().split()
+    assert _includes(repo, relevant, "0" * 40) is False
+
+
+def test_schedule_trigger_is_present() -> None:
+    """The 2026-07-28 hole: with only a push trigger, a silence produces no run at all.
+
+    Production sat 6 hours and 8 commits stale overnight and this workflow never ran.
+    """
+    text = _workflow_text()
+    assert re.search(r"^\s+schedule:", text, re.MULTILINE), (
+        "the schedule trigger is gone — the sentinel can only speak when someone pushes "
+        "frontend code, which is exactly not the failure it guards"
+    )
+    assert re.search(r'cron:\s*"\*/\d+ \* \* \* \*"', text), "no recurring cron expression found"

--- a/scripts/vercel_prod_deploy.py
+++ b/scripts/vercel_prod_deploy.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Deploy the `mouth` project to production without the Vercel GitHub App.
+
+WHY THIS EXISTS
+---------------
+The Vercel GitHub App lost its installation on Bali-Zero/Teman2 on 2026-07-26. Its last
+GitHub Deployment is timestamped 2026-07-26T20:07:27Z and there has been none since, so a
+push to main creates no Vercel deployment at all. Re-installing it is a GUI-only action
+(GitHub does not expose App installation to a PAT), and until that happens every production
+deploy has to be made by hand.
+
+`POST /v13/deployments` with a `gitSource` keeps working WITHOUT the project's git link —
+repo access lives at team/integration level, not at project-link level. That asymmetry is
+the whole reason this script can exist. What does NOT work:
+
+  * `vercel deploy --prod` — no .vercelignore, so it uploads the entire monorepo; measured
+    at >25 minutes without producing a deployment on a loaded machine.
+  * Deploy Hooks — refused outright: "This project is not connected to a Git repository,
+    so it cannot have deploy hooks."
+
+ONE PROJECT, EIGHT DOMAINS
+--------------------------
+balizero.com and every subdomain (www, kita, my, prime, visa, tax, zantara) are served by
+the single `mouth` project. A stale frontend is stale everywhere, never on one page.
+
+THE ALIAS IS NOT AUTOMATIC HERE
+-------------------------------
+Measured 2026-07-28: a deployment created with `gitSource.ref = <sha>` reached READY with
+`aliasAssigned: false` and production kept serving the previous build until an explicit
+`POST /v10/projects/<id>/promote/<dpl>`. A deployment created with `ref = "main"` on
+2026-07-27 self-aliased within 30s. So promote is attempted whenever the probe still shows
+the old commit — and `aliasAssigned` is never read as the verdict: during a build it is
+false for every deployment, and even at READY it has been observed disagreeing with what
+the domains actually serve. The arbiter is the behavioural probe (W88: verify by content).
+
+CREDENTIAL
+----------
+Reads the Vercel CLI's OAuth token from its auth.json and never prints it. `expiresAt` in
+that file is in SECONDS, not milliseconds — treating it as ms makes an expired token look
+valid until the year 58000. Refresh with `vercel whoami`, which renews silently.
+
+Usage:
+    python3 scripts/vercel_prod_deploy.py            # deploy main HEAD if production is behind
+    python3 scripts/vercel_prod_deploy.py --force    # deploy even if production is current
+    python3 scripts/vercel_prod_deploy.py --dry-run  # report the gap, change nothing
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+TEAM_ID = "team_jX3mEbUemBs0Zy4i8aFYZsjS"  # nuzantara-2026
+PROJECT_ID = "prj_LcXb9ZgeUvWpxaIM9K47tQYPeuee"  # mouth
+REPO_ORG = "Bali-Zero"
+REPO_NAME = "Teman2"
+HEALTH_URL = "https://balizero.com/api/health"
+AUTH_JSON = "~/Library/Application Support/com.vercel.cli/auth.json"
+
+BUILD_TIMEOUT_S = 600
+POLL_S = 20
+
+
+def _token() -> str:
+    path = os.path.expanduser(AUTH_JSON)
+    if not os.path.exists(path):
+        sys.exit(f"no Vercel CLI credential at {AUTH_JSON} — run `vercel login` on this machine")
+    with open(path) as fh:
+        data = json.load(fh)
+    expires_at = data.get("expiresAt")  # SECONDS
+    if expires_at and expires_at < time.time():
+        sys.exit("Vercel token expired — run `vercel whoami` to refresh it, then retry")
+    token = data.get("token")
+    if not token:
+        sys.exit(f"{AUTH_JSON} holds no token — run `vercel login` on this machine")
+    return str(token)
+
+
+def _api(method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    url = f"https://api.vercel.com{path}"
+    url += ("&" if "?" in url else "?") + f"teamId={TEAM_ID}"
+    payload = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=payload, method=method)
+    req.add_header("Authorization", f"Bearer {_token()}")
+    if payload:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return resp.status, json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read() or b"{}")
+
+
+def _main_head() -> str:
+    out = subprocess.run(
+        ["gh", "api", f"/repos/{REPO_ORG}/{REPO_NAME}/commits/main", "--jq", ".sha"],
+        capture_output=True, text=True, check=True,
+    )
+    return out.stdout.strip()
+
+
+def _served_commit() -> str | None:
+    """What commit is production actually running? None on any failure — a failed probe is
+    never evidence of health."""
+    try:
+        with urllib.request.urlopen(HEALTH_URL, timeout=25) as resp:
+            return json.loads(resp.read()).get("commit")
+    except Exception as exc:  # noqa: BLE001 — every failure mode means "unknown", identically
+        print(f"  probe failed: {exc}")
+        return None
+
+
+def _wait_terminal(deployment_id: str) -> tuple[str | None, bool]:
+    deadline = time.time() + BUILD_TIMEOUT_S
+    state: str | None = None
+    alias_assigned = False
+    while time.time() < deadline:
+        time.sleep(POLL_S)
+        status, body = _api("GET", f"/v13/deployments/{deployment_id}")
+        if status != 200:
+            print(f"  poll HTTP {status}: {json.dumps(body)[:200]}")
+            continue
+        state = body.get("readyState")
+        alias_assigned = bool(body.get("aliasAssigned"))
+        print(f"  state={state} aliasAssigned={alias_assigned}")
+        if state in ("READY", "ERROR", "CANCELED"):
+            break
+    return state, alias_assigned
+
+
+def _probe_until(sha: str, attempts: int) -> bool:
+    for i in range(attempts):
+        live = _served_commit()
+        print(f"  probe {i + 1}/{attempts}: production serves {live}")
+        if live == sha:
+            return True
+        if i + 1 < attempts:
+            time.sleep(15)
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--force", action="store_true", help="deploy even when production is already current")
+    parser.add_argument("--dry-run", action="store_true", help="report the gap and exit without deploying")
+    parser.add_argument("--ref", default=None, help="commit sha to deploy (default: main HEAD)")
+    args = parser.parse_args()
+
+    sha = args.ref or _main_head()
+    live = _served_commit()
+    print(f"main HEAD       : {sha}")
+    print(f"production runs : {live}")
+
+    if live == sha and not args.force:
+        print("production is already serving this commit — nothing to do")
+        return 0
+    if args.dry_run:
+        print("dry-run: would deploy, but changing nothing")
+        return 0
+
+    status, deployment = _api("POST", "/v13/deployments", {
+        "name": "mouth",
+        "project": PROJECT_ID,
+        "target": "production",
+        "gitSource": {"type": "github", "org": REPO_ORG, "repo": REPO_NAME, "ref": sha},
+    })
+    if status not in (200, 201):
+        print(f"CREATE FAILED HTTP {status}: {json.dumps(deployment)[:600]}")
+        return 1
+    deployment_id = deployment["id"]
+    print(f"created         : {deployment_id} ({deployment.get('readyState')})")
+
+    state, _alias = _wait_terminal(deployment_id)
+    if state != "READY":
+        print(f"deployment ended {state} — build logs: vercel inspect --logs {deployment_id}")
+        return 1
+
+    if _probe_until(sha, attempts=8):
+        print(f"OK — balizero.com serves {sha[:9]} (deployment {deployment_id})")
+        return 0
+
+    # READY but the domains never moved: the alias did not follow. This is the documented
+    # fallback, not the normal path — and it is the observed path for a sha-ref deployment.
+    print("production still on the old build at terminal READY → promote")
+    status, body = _api("POST", f"/v10/projects/{PROJECT_ID}/promote/{deployment_id}", {})
+    print(f"promote HTTP {status}: {json.dumps(body)[:300]}")
+    if status not in (200, 201, 202):
+        return 1
+    if _probe_until(sha, attempts=8):
+        print(f"OK after promote — balizero.com serves {sha[:9]}")
+        return 0
+
+    print(f"::error::deployment {deployment_id} is READY but the domains still do not serve {sha[:9]}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The Vercel GitHub App is still uninstalled on this repo. `vercel[bot]`'s last GitHub
Deployment is **2026-07-26T20:07:27Z** and there has been none in the 26 hours since, so a
push to `main` creates no Vercel deployment at all. Re-installing it is GUI-only and is
already tracked in the ledger as `operator[gui]`.

This PR does not fix that. It fixes the two things that let the outage stay *quiet* — both
measured overnight, neither inferred.

## 1. The sentinel could only speak while someone was pushing

`Frontend Live Sentinel` triggers on `push` with frontend `paths:`. Overnight, production sat
**6 hours and 8 commits** behind `main` and the workflow **never ran once** — none of those
commits touched a frontend path, so nothing woke it. A guard that speaks only while the thing
it guards is being changed is blind exactly when the change stops arriving.

Adds a `*/30` schedule with the same probe, plus a 45-minute grace on scheduled ticks so it
never shouts over an in-flight deploy that the push run already owns.

## 2. The verdict was equality, and equality is the wrong question

At 17:19Z the sentinel went red for a commit touching only `apps/mouth/e2e/**` — specs that
run in CI and can never reach the bundle. The expected commit is now the newest one touching
a path that can change what the browser receives (e2e excluded), and the test is **ancestry**:
production may legitimately be AHEAD of it, never behind.

Ancestry is safe here and is not a W88-style lying proxy — both shas live on `main`'s linear
history, and a served sha absent from history makes `--is-ancestor` exit non-zero, which fails
closed.

## 3. An alarm that always fires is not an alarm

At `*/30`, a permanent outage would send 48 Telegrams a day against a P0 budget of 12. Dedup
is an `actions/cache` entry keyed by the expected sha: a permanent outage speaks **once**, a
NEW stale commit speaks immediately. The marker is written only after Telegram answers
`"ok":true`, so a refused alert cannot buy thirty minutes of silence.

The concurrency group now includes the event name — a scheduled tick must never cancel an
in-flight push run, because a cancelled run reports neither pass nor fail.

## Plus: the manual valve, as a script instead of folklore

`scripts/vercel_prod_deploy.py` — the stopgap was being reconstructed from a memory note each
time, always at the moment production was already stale. Three things it encodes, each
measured today:

- `POST /v13/deployments` with `gitSource` works **without** the project's git link (repo
  access lives at team/integration level). That asymmetry is the only reason a stopgap exists.
- A deployment created with `gitSource.ref = <sha>` reached READY with `aliasAssigned: false`
  and production kept serving the old build until an explicit **promote**; one created with
  `ref = "main"` on 07-27 self-aliased in 30s. So promote is attempted whenever the probe
  still shows the old commit.
- The verdict is the behavioural probe (`/api/health` → `.commit`), never `readyState` or
  `aliasAssigned`.

Two alternatives tried and **refused by the platform**, recorded so nobody re-derives them:
`vercel deploy --prod` uploads the whole monorepo with no `.vercelignore` (>25 min, no
deployment), and Deploy Hooks answer *"This project is not connected to a Git repository, so
it cannot have deploy hooks"* — the hook needs the very link that is missing.

## Verification

Both workflow decisions are **extracted from the YAML by the test**, not retyped — a retyped
copy passes forever while the real gate rots. Mutation-checked, with the workflow restored
byte-identical afterwards:

| mutation | tests that fail |
|---|---|
| `--is-ancestor` operands reversed | 3 |
| e2e exclusion removed from the pathspec | 2 |
| `schedule:` trigger removed | 1 |

`actionlint` clean. `python3 scripts/vercel_prod_deploy.py --dry-run` run live against
production this session (correctly reported the 8-commit gap and changed nothing); the deploy
path itself was exercised for real earlier today — production went from `b19f364f` to
`27dcd030`, and the promote fallback is in this script because that run needed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
