### PR TITLE
chore(deps): raise the fsspec ignore to >2026.4.0 now that datasets 5 landed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,22 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "sentence-transformers"
         update-types: ["version-update:semver-major"]
-      # datasets==4.8.5 caps fsspec at <=2026.2.0; a group bump that raises
-      # fsspec past the cap makes the WHOLE minor-and-patch group unsatisfiable
-      # (uv resolver error -> one failed install cascades into 4 red required
-      # checks; see closed group PR #2062). Drop this ignore when datasets
-      # raises its fsspec ceiling - dependabot will then move the pair together.
+      # datasets caps fsspec, and a group bump that raises fsspec past the cap
+      # makes the WHOLE minor-and-patch group unsatisfiable (uv resolver error ->
+      # one failed install cascades into 4 red required checks; see closed group
+      # PR #2062). The ceiling MOVES with datasets, so this bound is raised in
+      # step with it, never dropped: removing it lets dependabot propose the next
+      # fsspec release the current datasets forbids, which is the same outage.
+      #
+      # 2026-07-28, after datasets 4.8.5 -> 5.0.0 landed (#3366): measured on
+      # PyPI, datasets 5.0.0 declares `fsspec[http]<=2026.4.0,>=2023.1.0`, so the
+      # bound goes 2026.2.0 -> 2026.4.0. (The lock still resolves fsspec==2026.2.0;
+      # this ignore is what keeps the gap between the lock and the cap safe to
+      # cross.) Re-measure the ceiling at the NEXT datasets major before touching
+      # this line — the note the previous bump left said "drop this when datasets
+      # raises its ceiling", which would have been the wrong move.
       - dependency-name: "fsspec"
-        versions: [">2026.2.0"]
+        versions: [">2026.4.0"]
       # presidio 2.2.363 REGRESSED its cryptography ceiling to <47.0.0 —
       # colliding with OUR deliberate CVE floor cryptography>=48.0.1
       # (requirements.txt, GHSA-537c-gmf6-5ccf; prod lock runs 49.x fine with


### PR DESCRIPTION
## Why raise and not drop

`datasets` 4.8.5 capped fsspec at `<=2026.2.0`. The ignore existed so a group bump could not raise fsspec past that cap and make the **whole** `minor-and-patch` group unsatisfiable — one uv resolution error cascades into 4 red required checks (closed group PR #2062).

#3366 moved datasets to 5.0.0. Measured on PyPI, not inferred:

```
$ curl -s https://pypi.org/pypi/datasets/5.0.0/json | jq -r '.info.requires_dist[]|select(startswith("fsspec"))'
fsspec[http]<=2026.4.0,>=2023.1.0
```

So the bound follows it up: **2026.2.0 → 2026.4.0**.

The comment the previous bump left behind said *"drop this ignore when datasets raises its fsspec ceiling"*. That would have been wrong — **the ceiling did not disappear, it moved**. Dropping the entry lets dependabot propose the first fsspec release datasets 5 still forbids, which reproduces the exact cascade the ignore was added for. The comment now says raise, says why, and says to re-measure at the next datasets major.

The lock still resolves `fsspec==2026.2.0`; this bound is what makes the gap between the lock and the cap safe to cross.

## Verification

- `yaml.safe_load` parses the file and the fsspec entry asserts to exactly `{'dependency-name': 'fsspec', 'versions': ['>2026.4.0']}`
- prettier clean
- full pre-push suite green (`.github/dependabot.yml` is not on the v6 innocent allowlist, so it ran in full)