### PR TITLE
docs(ci): correct my own undercount in the verdict-corpus comment

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -282,11 +282,18 @@ jobs:
       - name: Telegram delivery verdict corpus (guilt + innocence + fail-closed)
         if: steps.paths.outputs.relevant == 'true'
         run: |
-          # W104 on the CI surface: 12 of the 14 `curl .../sendMessage` calls in this
-          # repo judged their own delivery by curl's EXIT CODE, which is 0 whenever the
-          # server answers — including HTTP 401 with a well-formed
+          # W104 on the CI surface: 25 of the 28 `curl .../sendMessage` calls in this
+          # repo's workflows judged their own delivery by curl's EXIT CODE, which is 0
+          # whenever the server answers — including HTTP 401 with a well-formed
           # {"ok":false,"description":"Unauthorized"} after a token rotation. Every one
           # of those alarms was, by construction, unable to report its own silence.
+          #
+          # (An earlier draft of this comment said "12 of 14". That was my own
+          # undercount from a line-anchored grep, blind to the prevailing shape in this
+          # repo — `curl -sS -X POST \` with the URL on the NEXT line. The real figures
+          # come from joining continuations before scanning: 28 sites, 18 files. Left
+          # recorded rather than quietly overwritten, because a wrong census is exactly
+          # what the widened `lint_tg_direct_senders.py` scan exists to prevent.)
           #
           # What this pins: 401/403/400/429 are refusals, `"ok":false` under an HTTP 200
           # is a refusal (the status line is not the authority, the body is), the word


### PR DESCRIPTION
Follow-up to #3390 (merged).

The `Telegram delivery verdict corpus` step's comment said **"12 of the 14"** `curl .../sendMessage` calls. That was the figure from my first, line-anchored grep — blind to the shape that actually prevails in this repo:

```
curl -sS -X POST \
  "https://api.telegram.org/bot${BOT}/sendMessage" \
```

Joining continuations before scanning gives the real census, the one #3390 shipped and enrolled: **28 sites across 18 workflow files, 25 of them naked.**

Corrected in place, with the wrong number left on the record rather than quietly overwritten — a comment that undercounts by half, sitting inside the very step that guards against undercounting, is the defect #3390 is about.

### Why this is a separate PR

By the time the correction was ready, #3390 had **already been accepted by the merge queue**. Pushing to a queued PR ejects it, so a one-line comment would have cost a full cycle. The push was killed mid-pre-push (before any transfer — verified: `ls-remote` and `headRefOid` unchanged) and redone from fresh main.

It costs nothing here: `.github/workflows/*.yml` is on the pre-push v6 innocent allowlist, so this branch skips the backend suite entirely — the push took seconds instead of ~15 minutes. That only works because the branch is based on current main; the classifier scopes to `origin/main...HEAD`, not to the commit.

`actionlint` clean.