### PR TITLE
docs(ci): a cron expression is a request, not an interval — measure before promising

### DIFF
--- a/.github/workflows/frontend-live-sentinel.yml
+++ b/.github/workflows/frontend-live-sentinel.yml
@@ -52,8 +52,21 @@ on:
       - "vercel.json"
       - "apps/mouth/vercel.json"
   schedule:
-    # Every 30 minutes. The job is a shallow-ish clone plus a curl; the cost of running it is
-    # far below the cost of one more silent stale night.
+    # DECLARED every 30 minutes. DELIVERED far less often, and the gap is not a detail anyone
+    # sizing an incident response should have to discover the hard way.
+    #
+    # Measured on this repo 2026-07-28, on a workflow that has asked for `*/15` for months
+    # (cron-fly-restart-detector.yml): over 16 continuous hours its scheduled runs arrive at a
+    # MEDIAN interval of 91 minutes — 63, 64, 65, 77, 90, 94, 111, 150, 157. Six times slower
+    # than declared, worst case ten. GitHub documents that scheduled workflows are delayed
+    # under load and may be dropped entirely; with 86 workflows here, that is the steady state,
+    # not a bad night. GitHub Status reported Actions fully operational throughout.
+    #
+    # So: a `cron:` expression is a request, never an interval, and this sentinel's real
+    # worst-case detection latency is roughly an hour — still two orders of magnitude better
+    # than the 13-hour silence it exists to prevent, but do not promise 30 minutes to anyone.
+    # The `push` trigger above is what fires promptly; the schedule is the backstop that
+    # notices a silence, and a backstop is allowed to be slow.
     - cron: "*/30 * * * *"
   workflow_dispatch:
 


### PR DESCRIPTION
The `Frontend Live Sentinel` merged an hour ago declaring `*/30` with a comment reading
"Every 30 minutes". Waiting for its first scheduled run turned up something worth writing
down rather than working around.

Measured on this repo today, on a workflow that has been asking for `*/15` for months
(`cron-fly-restart-detector.yml`), across 16 continuous hours of its own run history:

| intervals between scheduled runs (min) | median |
|---|---|
| 63 · 64 · 65 · 77 · 90 · 94 · 111 · 150 · 157 | **91** |

Six times slower than declared, worst case ten — and it is *every* interval in the window,
not a spike. GitHub Status reported Actions fully operational throughout, and push-triggered
runs (PR #3389's own, the merge queue's) were prompt. So this is scheduled-event delivery
specifically, which GitHub documents as delayed under load and droppable outright; with 86
workflows in this repo it is the steady state.

**Nothing to fix in the schedule itself** — asking more often is not delivered more often.
What needed fixing is the CLAIM. Anyone sizing an incident response off "we would know within
30 minutes" would be wrong by an hour and would find out during the outage. The comment now
carries the measurement and states plainly that `push` is what fires promptly while the
schedule is the slow backstop that notices a silence — and a backstop is allowed to be slow.

Comment-only: no trigger, step, or verdict change. `actionlint` clean; the suite that extracts
the guard's two decisions from this file passes unchanged (6/6).

Wider implication, recorded here because it is not specific to this workflow: every
frequency-dependent guard in this repo is running at roughly a sixth of its declared rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)