### PR TITLE
fix(seo): the VOA funnel was live and unreachable — no link, no sitemap, no title

### DIFF
--- a/apps/mouth/src/app/sitemap.test.ts
+++ b/apps/mouth/src/app/sitemap.test.ts
@@ -1,0 +1,110 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Findability guard for the visa funnel (2026-07-28).
+ *
+ * TRAUMA: `/visa/voa` shipped on 2026-07-27 — engine, public route, wizard,
+ * result page, 107 backend tests — and spent a full day LIVE AND UNREACHABLE:
+ * zero inbound links anywhere in `src/`, and absent from this sitemap, which
+ * listed its four siblings. Everything about the page worked; nobody could
+ * arrive at it. Nothing failed, because nothing was watching for the absence.
+ *
+ * So this test enumerates the funnel's real static routes from the filesystem
+ * and demands each one be either listed in the sitemap or named in
+ * INTENTIONALLY_UNLISTED with a reason. A new funnel page fails this test
+ * until someone makes that choice deliberately — the point is not to force
+ * every page into the sitemap, it is to make omission a decision instead of
+ * an oversight.
+ *
+ * Dynamic `[hash]` result routes are excluded structurally (they are one
+ * visitor's ephemeral answer, and they canonicalise to their funnel entry —
+ * see visa/voa/layout.tsx), and the innocence case below pins that they never
+ * leak into the sitemap.
+ */
+
+// Heavy data sources — this test is about route coverage, not content.
+// Each of these is consumed inside a try/catch in sitemap.ts, so an empty
+// result exercises the static/visa branches without touching the corpus.
+vi.mock("@/lib/blog/articles", () => ({
+  getAllArticles: vi.fn(async () => []),
+  getNoIndexSlugs: vi.fn(async () => []),
+}));
+vi.mock("@/lib/kbli-data.server", () => ({
+  getAllCodes: vi.fn(() => []),
+  getSections: vi.fn(() => []),
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import sitemap from "./sitemap";
+
+const APP_DIR = path.dirname(fileURLToPath(import.meta.url));
+const VISA_DIR = path.join(APP_DIR, "visa");
+const BASE = "https://balizero.com";
+
+/**
+ * Routes that exist under /visa but deliberately stay out of the sitemap.
+ * Add here ONLY with a reason — an entry without one is a silent omission
+ * wearing a permission slip.
+ */
+const INTENTIONALLY_UNLISTED: Record<string, string> = {
+  "/visa/privacy": "legal boilerplate, no search intent to serve",
+  "/visa/terms": "legal boilerplate, no search intent to serve",
+};
+
+/** Static (non-dynamic) route paths under /visa, derived from the tree. */
+function staticVisaRoutes(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string, urlPath: string) => {
+    if (fs.existsSync(path.join(dir, "page.tsx"))) out.push(urlPath);
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      // `[hash]` / `[...slug]` — dynamic, never enumerable in a sitemap
+      if (entry.name.startsWith("[")) continue;
+      walk(path.join(dir, entry.name), `${urlPath}/${entry.name}`);
+    }
+  };
+  walk(VISA_DIR, "/visa");
+  return out.sort();
+}
+
+describe("sitemap — visa funnel findability", () => {
+  it("has a route tree to check (the probe can produce a positive)", () => {
+    // Guard against the empty-set failure mode: a walk that finds nothing
+    // would make every assertion below vacuously true.
+    const routes = staticVisaRoutes();
+    expect(routes.length).toBeGreaterThanOrEqual(4);
+    expect(routes).toContain("/visa/voa");
+  });
+
+  it("lists every static visa route, or names it as deliberately unlisted", async () => {
+    const urls = new Set((await sitemap()).map((e) => e.url));
+    const missing = staticVisaRoutes().filter(
+      (r) => !urls.has(`${BASE}${r}`) && !(r in INTENTIONALLY_UNLISTED),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("lists /visa/voa specifically (the route this guard was born from)", async () => {
+    const urls = (await sitemap()).map((e) => e.url);
+    expect(urls).toContain(`${BASE}/visa/voa`);
+  });
+
+  it("does NOT list per-visitor result pages", async () => {
+    const urls = (await sitemap()).map((e) => e.url);
+    const leaked = urls.filter((u) =>
+      /\/visa\/(voa|match|clock)\/[^/]+$/.test(u),
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("does not list a route that was deliberately excluded (innocence)", async () => {
+    const urls = new Set((await sitemap()).map((e) => e.url));
+    for (const excluded of Object.keys(INTENTIONALLY_UNLISTED)) {
+      expect(urls.has(`${BASE}${excluded}`)).toBe(false);
+    }
+  });
+});

--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -146,6 +146,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/visa/match",
     "/visa/clock",
     "/visa/second-home",
+    // `/visa/voa` shipped 2026-07-27 and was live-but-unreachable for a day:
+    // no inbound link anywhere in the site AND absent here, so the only way
+    // in was typing the URL. Result pages `/visa/voa/<hash>` stay out — they
+    // are per-visitor and canonicalise to this entry (see voa/layout.tsx).
+    "/visa/voa",
   ];
   routes.push(...visaPaths.map((p) => ({ url: `${baseUrl}${p}` })));
 

--- a/apps/mouth/src/app/visa/page.tsx
+++ b/apps/mouth/src/app/visa/page.tsx
@@ -118,6 +118,23 @@ export default function VisaEntryPage() {
           onSelect={(opt) => tracker.branchSelected(opt.id)}
         />
 
+        {/* Secondary entries. These are not branches of the question above:
+            the VOA funnel serves BOTH arriving and already-here visitors, so
+            it cannot sit inside the "are you already in Indonesia?" binary. */}
+        <p
+          style={{
+            textAlign: "center",
+            fontSize: "var(--text-sm, 0.88rem)",
+            color: "var(--color-text-muted)",
+            margin: 0,
+          }}
+        >
+          Arriving on a Visa on Arrival, or extending one?{" "}
+          <Link href="/visa/voa" style={{ color: "var(--accent-funnel)" }}>
+            Check your VOA (B1) →
+          </Link>
+        </p>
+
         <p
           style={{
             textAlign: "center",

--- a/apps/mouth/src/app/visa/voa/layout.tsx
+++ b/apps/mouth/src/app/visa/voa/layout.tsx
@@ -1,4 +1,36 @@
+import type { Metadata } from "next";
 import { I18nProvider } from "@/i18n";
+
+// Metadata lives in the LAYOUT, not in page.tsx: the wizard page is a client
+// component ("use client"), which cannot export metadata. Sibling precedent
+// (visa/second-home) splits a server page.tsx from a client landing component;
+// this segment does not need that split just to carry a title.
+//
+// The canonical deliberately points at the funnel entry and is INHERITED by
+// `voa/[hash]` result pages. That is the intent, not an oversight: a result
+// page is one visitor's ephemeral answer, so the indexable representative of
+// the whole segment is the entry page.
+//
+// No price in this copy — prices come from PricingTool server-side per request
+// (golden rule 11); a number hardcoded here would go stale silently. No claim
+// about timing or approval either: the charter's forbidden-claims list
+// (guaranteed approval / guaranteed turnaround / fully-online extension) binds
+// SEO copy exactly as it binds the page body.
+export const metadata: Metadata = {
+  title:
+    "Visa on Arrival (B1) Indonesia — eligibility, dates, price | Bali Zero",
+  description:
+    "Check a Visa on Arrival or its extension in 7 questions: whether the case is straightforward, your stay window, the published filing deadline, and our all-inclusive fee. No documents to upload, no payment to check.",
+  openGraph: {
+    title: "Check your Visa on Arrival — Bali Zero",
+    description:
+      "Seven questions, then your stay window, the filing deadline that applies, and an all-inclusive price. Nothing to upload, nothing to pay to find out.",
+    type: "website",
+  },
+  alternates: {
+    canonical: "https://balizero.com/visa/voa",
+  },
+};
 
 export default function GarudaVoaLayout({
   children,


### PR DESCRIPTION
## What was wrong

`/visa/voa` shipped on 2026-07-27 — engine, public route, wizard, result page,
107 backend tests, prices from PricingTool, proven live in a browser. It then
spent a full day **live and unreachable**:

- `git grep` over `apps/mouth/src`: **zero inbound links** anywhere on the site.
- `sitemap.ts` listed `/visa`, `/visa/match`, `/visa/clock`, `/visa/second-home`
  — and not `/visa/voa`. Google would never see it.
- No title or description of its own (`page.tsx` is `"use client"`, the layout
  exported no metadata), so sharing the link rendered the generic site preview.

The only way in was typing the URL. Nothing failed, because nothing was watching
for the absence.

## What this changes

| File | Change |
|---|---|
| `sitemap.ts` | add `/visa/voa`. `/visa/voa/<hash>` stays out — one visitor's ephemeral answer |
| `visa/voa/layout.tsx` | metadata (title / description / OG / canonical) |
| `visa/page.tsx` | secondary entry line on the funnel hub |
| `sitemap.test.ts` | **new** — structural findability guard |

Two deliberate calls worth reviewing:

- **Metadata lives in the layout**, not in a server `page.tsx` wrapper. The
  sibling `second-home` route splits a server page from a client landing
  component; that is more refactor than a title is worth here. The consequence
  is that the canonical is inherited by `[hash]` result pages — which is the
  intent, not an oversight: the entry page IS the indexable representative of
  the segment.
- **The hub link is not a third branch option.** The VOA funnel serves both
  arriving and already-here visitors, so it cannot sit inside the "are you
  already in Indonesia?" binary. It clones the Second Home secondary-line
  pattern instead.

Copy constraints honoured: no price (PricingTool is the only source — golden
rule 11 — and a number here would go stale in silence) and no timing or
approval claim (the charter's forbidden-claims list binds SEO copy exactly as
it binds the page body).

## The guard

`sitemap.test.ts` enumerates the funnel's static routes **from the filesystem**
and demands each be listed in the sitemap or named in `INTENTIONALLY_UNLISTED`
with a reason. Adding a funnel page now fails this test until someone makes
that call deliberately — the goal is not to force every page into the sitemap,
it is to make omission a decision instead of an oversight.

**Mutation-verified**: removing the `/visa/voa` line fails 2 of 5 tests,
including the structural one, which names the route in its failure. It also
pins the innocence cases (result pages never leak in; excluded routes stay
excluded) and asserts the route walk is non-empty **first**, so an empty set
cannot make the suite vacuously green.

## Verification

- `npx vitest run src/app/visa src/app/sitemap.test.ts` → **18/18 passed**
- `npx tsc --noEmit` → **0 errors**
- pre-commit: lint, prettier, typecheck, secrets, off-limits — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)