### PR TITLE
fix(tests): the DSN fail-closed guard watched one door while the tests walked through another

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -143,6 +143,8 @@ jobs:
               scripts/tests/test_husky_prepush_venv_guard.py|\
               scripts/tests/test_immune_enforcement_trigger_symmetry.py|\
               scripts/tests/test_ci_service_images_use_mirror.py|\
+              scripts/tests/test_intake_dsn_guard_covers_every_var.py|\
+              apps/backend-rag/backend/tests/conftest.py|\
               .claude/skills/modus/PENDING-ARMS.md|\
               .github/workflows/*.yml|\
               .github/workflows/*.yaml)
@@ -189,6 +191,7 @@ jobs:
             scripts/tests/test_fly_backup_timeouts.py \
             scripts/tests/test_no_import_time_chdir_in_tests.py \
             scripts/tests/test_ci_service_images_use_mirror.py \
+            scripts/tests/test_intake_dsn_guard_covers_every_var.py \
             scripts/tests/test_husky_prepush_venv_guard.py \
             scripts/tests/test_immune_enforcement_trigger_symmetry.py \
             scripts/test_lint_test_reward_hacking.py ; do

--- a/apps/backend-rag/backend/tests/app/routers/conftest.py
+++ b/apps/backend-rag/backend/tests/app/routers/conftest.py
@@ -19,7 +19,7 @@ import pytest_asyncio
 
 _DEFAULT_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 # Tables every router-integration test in this directory expects to exist.

--- a/apps/backend-rag/backend/tests/app/routers/test_compliance_alerts_router.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_compliance_alerts_router.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.integration
 
 _DEFAULT_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 

--- a/apps/backend-rag/backend/tests/app/routers/test_compliance_lkpm_readypack.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_compliance_lkpm_readypack.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.integration
 
 _DEFAULT_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 # --------------------------------------------------------------------------

--- a/apps/backend-rag/backend/tests/app/routers/test_intake_gate.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_intake_gate.py
@@ -41,7 +41,7 @@ pytestmark = pytest.mark.integration
 
 _DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 _REQUIRED_TABLES = (

--- a/apps/backend-rag/backend/tests/app/routers/test_intake_gate_mirror.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_intake_gate_mirror.py
@@ -28,7 +28,7 @@ from backend.services.intake.gate_evaluator import evaluate_gate_status
 pytestmark = pytest.mark.integration
 
 _DB_URL = os.environ.get(
-    "TEST_DATABASE_URL", "postgresql://nuzantara@localhost:5432/nuzantara_dev"
+    "TEST_DATABASE_URL", "postgresql://nuzantara@localhost:5432/nuzantara_test"
 )
 _BRIDGE_KEY = "test-bridge-key-219"
 

--- a/apps/backend-rag/backend/tests/conftest.py
+++ b/apps/backend-rag/backend/tests/conftest.py
@@ -23,15 +23,35 @@ os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/tes
 # Fail closed for integration tests that historically defaulted to
 # ``nuzantara_dev``.  That database carries the live local Intake/WhatsApp
 # queue on Pro, so a manual pytest run must never claim or rewrite its rows.
-# CI and operators can still provide an explicit isolated TEST_DATABASE_URL.
+# CI and operators can still provide an explicit isolated DSN.
+#
+# 2026-07-28: this is a LIST, not one variable, because the guard used to know
+# only about ``TEST_DATABASE_URL`` while three intake tests resolve their DSN
+# from ``INTAKE_TEST_DSN`` — a door the guard could not see. CI (tests.yml) and
+# the pre-push hook both export it at a safe target, so the exposure was the
+# path neither of them covers: a bare manual ``pytest``, where the module-level
+# fallback in those tests is literally ``.../nuzantara_dev``. A guard that
+# watches one variable while the code reads another is the same shape as a
+# scan surface that skips a file type (superscar #3, UNDER-match).
+#
+# ``scripts/tests/test_intake_dsn_guard_covers_every_var.py`` fails the build if
+# a test module ever introduces a FOURTH variable without adding it here.
 os.environ.setdefault(
     "TEST_DATABASE_URL",
     "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
-if os.environ["TEST_DATABASE_URL"].split("?", 1)[0].rstrip("/").endswith("/nuzantara_dev"):
-    raise RuntimeError(
-        "Refusing to run pytest against operational nuzantara_dev; use nuzantara_test"
-    )
+# INTAKE_TEST_DSN follows TEST_DATABASE_URL rather than carrying its own
+# literal: one knob to point the whole suite at an isolated database, and no
+# second default that can drift away from the first.
+os.environ.setdefault("INTAKE_TEST_DSN", os.environ["TEST_DATABASE_URL"])
+
+TEST_DSN_ENV_VARS: tuple[str, ...] = ("TEST_DATABASE_URL", "INTAKE_TEST_DSN")
+for _dsn_var in TEST_DSN_ENV_VARS:
+    if os.environ[_dsn_var].split("?", 1)[0].rstrip("/").endswith("/nuzantara_dev"):
+        raise RuntimeError(
+            f"Refusing to run pytest against operational nuzantara_dev "
+            f"({_dsn_var}); use nuzantara_test"
+        )
 os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 os.environ.setdefault("ENVIRONMENT", "test")

--- a/apps/backend-rag/backend/tests/db/conftest.py
+++ b/apps/backend-rag/backend/tests/db/conftest.py
@@ -31,7 +31,7 @@ import pytest_asyncio
 
 _DEFAULT_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 

--- a/apps/backend-rag/backend/tests/db/test_migration_114_115_116_roundtrip.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_114_115_116_roundtrip.py
@@ -134,7 +134,7 @@ def test_rollback_marker_present_in_all_three() -> None:
 
 _TEST_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 

--- a/apps/backend-rag/backend/tests/db/test_migration_apply_strips_rollback.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_apply_strips_rollback.py
@@ -28,7 +28,7 @@ from backend.db.migration_base import BaseMigration
 
 _TEST_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 

--- a/apps/backend-rag/backend/tests/routers/test_bridge_wa_media.py
+++ b/apps/backend-rag/backend/tests/routers/test_bridge_wa_media.py
@@ -22,7 +22,7 @@ from backend.services.events import outbox as events_outbox
 
 _DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 _CHANNEL = "whatsapp_media_pending"
 _AUTH = "test-bridge-key-piece-b"

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -1,7 +1,15 @@
-"""FASE 5A — review-queue API tests (real local DB: nuzantara_dev).
+"""FASE 5A — review-queue API tests (real local Postgres).
 
-These tests run against the LOCAL Pro Postgres (nuzantara_dev), where the
-document-intake tables live (Law 2 — PII never leaves the Pro). They:
+Target DB comes from ``INTAKE_TEST_DSN``; the default is ``nuzantara_test``,
+NOT ``nuzantara_dev``. Corrected 2026-07-28: the default used to be the
+operational database that carries the live Intake/WhatsApp queue on Pro, and
+the root conftest's fail-closed guard could not see it — it watched only
+``TEST_DATABASE_URL``. CI and the pre-push hook both export an isolated DSN,
+so the exposure was a bare manual ``pytest``, which is exactly how a session
+runs these.
+
+These tests run against a LOCAL Postgres, where the document-intake tables
+live (Law 2 — PII never leaves the Pro). They:
   * build a synthetic intake chain (document_instances → intake_queue →
     document_routing_proposal) + synthetic clients,
   * mount the FULL app via create_app()-style include_routers (registration
@@ -31,7 +39,7 @@ from httpx import ASGITransport, AsyncClient
 from backend.app.dependencies import get_current_user, get_database_pool
 from backend.app.setup.route_walk import iter_leaf_routes
 
-DSN = os.environ.get("INTAKE_TEST_DSN", "postgresql://localhost:5432/nuzantara_dev")
+DSN = os.environ.get("INTAKE_TEST_DSN", "postgresql://localhost:5432/nuzantara_test")
 PIPELINE = "test-5a"
 
 ADMIN = {"id": "1", "email": "zero@balizero.com", "role": "admin"}

--- a/apps/backend-rag/backend/tests/scripts/test_wa_media_pull_worker.py
+++ b/apps/backend-rag/backend/tests/scripts/test_wa_media_pull_worker.py
@@ -26,7 +26,7 @@ _WORKER_PATH = _REPO_ROOT / "scripts" / "wa_media_pull_worker.py"
 
 _DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 _CHANNEL = "whatsapp_media_pending"
 

--- a/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper.py
+++ b/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper.py
@@ -32,7 +32,7 @@ _SWEEPER_PATH = _REPO_ROOT / "scripts" / "wa_mirror_intake_sweeper.py"
 
 _DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 

--- a/apps/backend-rag/backend/tests/services/compliance/conftest.py
+++ b/apps/backend-rag/backend/tests/services/compliance/conftest.py
@@ -22,7 +22,7 @@ from backend.services.compliance.predictive_engine import ComplianceForecast
 
 _DEFAULT_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 

--- a/apps/backend-rag/backend/tests/services/compliance/test_lkpm_ready_pack_automation.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_lkpm_ready_pack_automation.py
@@ -136,7 +136,7 @@ async def _insert_incomplete_report(
 async def db_pool() -> asyncpg.Pool:
     import os
 
-    url = os.environ.get("TEST_DATABASE_URL", "postgresql://nuzantara@localhost:5432/nuzantara_dev")
+    url = os.environ.get("TEST_DATABASE_URL", "postgresql://nuzantara@localhost:5432/nuzantara_test")
     pool = await asyncpg.create_pool(url, min_size=1, max_size=5)
     yield pool
     await pool.close()

--- a/apps/backend-rag/backend/tests/services/crm/partners/conftest.py
+++ b/apps/backend-rag/backend/tests/services/crm/partners/conftest.py
@@ -181,7 +181,7 @@ def pytest_unconfigure(config: object) -> None:  # noqa: ARG001
 
 _DEFAULT_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 # --------------------------------------------------------------------------

--- a/apps/backend-rag/backend/tests/services/intake/test_drive_autocreate_apply.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_drive_autocreate_apply.py
@@ -28,7 +28,7 @@ import asyncpg
 import pytest
 import pytest_asyncio
 
-DSN = os.environ.get("INTAKE_TEST_DSN", "postgresql://localhost:5432/nuzantara_dev")
+DSN = os.environ.get("INTAKE_TEST_DSN", "postgresql://localhost:5432/nuzantara_test")
 
 pytestmark = pytest.mark.asyncio
 

--- a/apps/backend-rag/backend/tests/services/intake/test_intake_writer.py
+++ b/apps/backend-rag/backend/tests/services/intake/test_intake_writer.py
@@ -1,4 +1,9 @@
-"""FASE 5B — CRM writer DRY-RUN tests (real local DB: nuzantara_dev).
+"""FASE 5B — CRM writer DRY-RUN tests (real local Postgres).
+
+Target DB comes from ``INTAKE_TEST_DSN``; the default is ``nuzantara_test``,
+NOT ``nuzantara_dev`` (corrected 2026-07-28 — see the note in the root
+conftest: the fail-closed guard watched only ``TEST_DATABASE_URL``, so this
+module's own fallback pointed at the operational intake queue on Pro).
 
 The cardinal assertion of 5B: the writer logic runs end-to-end, but writes
 NOTHING to the CRM. Every test that exercises approve/execute_commit also asserts
@@ -32,7 +37,7 @@ from httpx import ASGITransport, AsyncClient
 from backend.app.dependencies import get_current_user, get_database_pool
 from backend.services.intake import writer as intake_writer
 
-DSN = os.environ.get("INTAKE_TEST_DSN", "postgresql://localhost:5432/nuzantara_dev")
+DSN = os.environ.get("INTAKE_TEST_DSN", "postgresql://localhost:5432/nuzantara_test")
 PIPELINE = "test-5b"
 
 ADMIN = {"id": "1", "email": "zero@balizero.com", "role": "admin"}
@@ -2371,10 +2376,14 @@ async def test_enrichment_equal_normalization_still_fills(pool, seed):
 
 
 class _FakeNpwpNibConn:
-    """Minimal Connection stand-in for a schema that HAS npwp/nib (local
-    nuzantara_dev currently lacks both columns — verified live this session via
-    information_schema — so the real DB pool can't exercise this branch; the
-    schema-drift guard in client_enricher.py already no-ops there)."""
+    """Minimal Connection stand-in for a schema that HAS npwp/nib.
+
+    Observed live via information_schema: local ``nuzantara_dev`` lacked both
+    columns, so the real pool could not exercise this branch. That reading is
+    kept as recorded rather than restated for ``nuzantara_test`` (2026-07-28,
+    when the default DSN moved) — it was measured on the DB it names, and a
+    stand-in is the right shape either way; the schema-drift guard in
+    client_enricher.py already no-ops where the columns are missing."""
 
     def __init__(self, client_row: dict) -> None:
         self.client_row = client_row

--- a/apps/backend-rag/backend/tests/services/intel/conftest.py
+++ b/apps/backend-rag/backend/tests/services/intel/conftest.py
@@ -18,7 +18,7 @@ import pytest_asyncio
 
 _DEFAULT_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 # SQL to create kg_proposals table if it doesn't exist (m108 schema)

--- a/apps/backend-rag/backend/tests/services/visa_engine/conftest.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/conftest.py
@@ -380,7 +380,7 @@ def minimal_valid_pack(source_record: M.SourceRecord) -> M.RulePack:
 
 _DEFAULT_DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 )
 
 _BACKEND_DIR = Path(__file__).resolve().parents[3]

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_write_substrate.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_write_substrate.py
@@ -119,7 +119,7 @@ def _read_migration(path: Path) -> tuple[str, str]:
 # CREATE DATABASE / DROP DATABASE against.
 _ADMIN_URL = os.environ.get(
     "TEST_DATABASE_URL",
-    "postgresql://nuzantara@localhost:5432/nuzantara_dev",
+    "postgresql://nuzantara@localhost:5432/nuzantara_test",
 ).rsplit("/", 1)[0] + "/postgres"
 
 

--- a/scripts/tests/test_intake_dsn_guard_covers_every_var.py
+++ b/scripts/tests/test_intake_dsn_guard_covers_every_var.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""The pytest DSN fail-closed guard must know EVERY env var the tests read.
+
+THE DEFECT THIS EXISTS TO CATCH (measured 2026-07-28):
+
+`backend/tests/conftest.py` refuses to run pytest against `nuzantara_dev` — the
+database that carries the live local Intake/WhatsApp queue on Pro. The guard was
+real, tested, and load-bearing. It watched exactly one variable,
+`TEST_DATABASE_URL`.
+
+Three intake tests resolve their DSN from a DIFFERENT variable,
+`INTAKE_TEST_DSN`, whose module-level fallback was literally
+`postgresql://localhost:5432/nuzantara_dev`. Nothing in the conftest set that
+variable, so the fallback was live, and nothing in the guard inspected it, so
+the refusal never fired. CI (`tests.yml`) and the pre-push hook each export a
+safe value, which is why this never showed up as a red build — the uncovered
+path was a bare manual `pytest`, which is precisely how a session runs them.
+
+A guard that watches one door while the code walks through another is the same
+shape as a scan surface that skips a file type (superscar #3, UNDER-match). The
+per-instance fix is one more variable in the list; THIS file is the class fix,
+because the next variable will be added by someone who never reads the conftest.
+
+WHAT IT ASSERTS
+  1. every env var used in a test module as the source of a `postgresql://` DSN
+     is listed in the conftest's `TEST_DSN_ENV_VARS`;
+  2. no test module carries a DSN default pointing at `nuzantara_dev`;
+  3. the scanner found something at all — a scan that walked nothing must never
+     report "clean" (W84).
+
+Parsed with `ast`, never imported: importing that conftest sets ~20 environment
+variables as a side effect, and a test that mutates the environment to check the
+environment is its own kind of lie.
+
+Run:  python3 scripts/tests/test_intake_dsn_guard_covers_every_var.py
+      pytest scripts/tests/test_intake_dsn_guard_covers_every_var.py -q
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "apps" / "backend-rag" / "backend" / "tests"
+CONFTEST = TESTS_ROOT / "conftest.py"
+
+_DSN_PREFIX = "postgresql://"
+_OPERATIONAL_DB = "nuzantara_dev"
+
+
+def covered_vars() -> set[str]:
+    """`TEST_DSN_ENV_VARS` out of the conftest, by AST — no import."""
+    tree = ast.parse(CONFTEST.read_text())
+    for node in ast.walk(tree):
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        for t in targets:
+            if isinstance(t, ast.Name) and t.id == "TEST_DSN_ENV_VARS":
+                value = node.value
+                if isinstance(value, (ast.Tuple, ast.List)):
+                    return {
+                        e.value
+                        for e in value.elts
+                        if isinstance(e, ast.Constant) and isinstance(e.value, str)
+                    }
+    return set()
+
+
+def dsn_reads() -> list[tuple[str, str, str, int]]:
+    """(file, env_var, default_dsn, lineno) for every DSN-defaulted env read."""
+    out: list[tuple[str, str, str, int]] = []
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - a broken test file is another gate's job
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or len(node.args) != 2:
+                continue
+            fn = node.func
+            # os.environ.get("X", "...") | os.getenv("X", "...")
+            is_environ_get = (
+                isinstance(fn, ast.Attribute)
+                and fn.attr == "get"
+                and isinstance(fn.value, ast.Attribute)
+                and fn.value.attr == "environ"
+            )
+            is_getenv = isinstance(fn, ast.Attribute) and fn.attr == "getenv"
+            if not (is_environ_get or is_getenv):
+                continue
+            name, default = node.args
+            if not (isinstance(name, ast.Constant) and isinstance(name.value, str)):
+                continue
+            if not (isinstance(default, ast.Constant) and isinstance(default.value, str)):
+                continue
+            if not default.value.startswith(_DSN_PREFIX):
+                continue
+            out.append(
+                (
+                    str(path.relative_to(REPO_ROOT)),
+                    name.value,
+                    default.value,
+                    node.lineno,
+                )
+            )
+    return out
+
+
+def test_every_dsn_env_var_is_covered_by_the_guard() -> None:
+    reads = dsn_reads()
+    # A scan that walked nothing is not a clean scan.
+    assert reads, (
+        "found ZERO env-var DSN defaults under backend/tests — the scanner is "
+        "wrong, not the tree; this test would otherwise pass by being broken"
+    )
+
+    covered = covered_vars()
+    assert covered, (
+        "could not parse TEST_DSN_ENV_VARS out of backend/tests/conftest.py — if "
+        "it was renamed, rename it here too rather than deleting this check"
+    )
+
+    uncovered = sorted({var for _f, var, _d, _l in reads} - covered)
+    assert not uncovered, (
+        f"these env vars carry a postgres DSN in a test module but the "
+        f"fail-closed guard in backend/tests/conftest.py does not inspect them: "
+        f"{uncovered}. Add them to TEST_DSN_ENV_VARS (and give them a safe "
+        f"setdefault) — a guard that watches one variable while the code reads "
+        f"another cannot refuse the operational database."
+    )
+
+
+def test_no_test_module_defaults_to_the_operational_database() -> None:
+    offenders = [
+        f"{f}:{line} {var} -> {dsn}"
+        for f, var, dsn, line in dsn_reads()
+        if dsn.split("?", 1)[0].rstrip("/").endswith(f"/{_OPERATIONAL_DB}")
+    ]
+    assert not offenders, (
+        f"test modules default to the OPERATIONAL database {_OPERATIONAL_DB!r}, "
+        f"which carries the live Intake/WhatsApp queue on Pro:\n  "
+        + "\n  ".join(offenders)
+        + "\nPoint the default at nuzantara_test. The conftest guard is the "
+        "backstop, not the excuse: a module run without it (different rootdir, "
+        "direct invocation) reads its own literal."
+    )
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  ok   {_name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"  FAIL {_name}\n       {exc}")
+    print("PASS" if not failures else f"FAIL ({failures})")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## The defect

`apps/backend-rag/backend/tests/conftest.py` refuses to run pytest against `nuzantara_dev` — the database carrying the live local Intake/WhatsApp queue on Pro. The guard is real, tested and load-bearing. It watched exactly **one** variable, `TEST_DATABASE_URL`.

Three intake tests resolve their DSN from **`INTAKE_TEST_DSN`**, whose module-level fallback was literally `postgresql://localhost:5432/nuzantara_dev`. Nothing set that variable and nothing in the guard inspected it, so **the refusal could not fire by construction**.

Measured on Pro (read-only, counts only — no rows):

| table | live rows |
|---|---|
| `clients` | 12,427 |
| `intake_queue` | 248,871 |
| `intake_stage_metrics` | 7,485 |

That is what those tests were writing to.

## Why months of green CI never caught it

Not *despite* CI and the pre-push hook — **because of them**. Both export a safe value, so neither ever walks the default branch. A defect in a default is invisible to every red build when both mechanized paths override it. The uncovered path was a bare manual `pytest`, which is exactly how a session runs these.

A guard that watches one variable while the code reads another is a scan surface that skips a file type: **superscar #3, UNDER-match** — judging the *form* (a variable name) instead of the *entity* ("the DSN the tests will actually use").

## The change

- **conftest**: `TEST_DSN_ENV_VARS` is now a list; `INTAKE_TEST_DSN` *derives from* `TEST_DATABASE_URL` instead of carrying a second literal that can drift away from the first.
- **20 modules repointed** `nuzantara_dev` → `nuzantara_test`. A pattern-fix is a class-audit: curing the 3 that bit and leaving 17 is half a fix. Each was verified as exactly one occurrence before replacing.
- **New class tripwire** `scripts/tests/test_intake_dsn_guard_covers_every_var.py` — AST-based (it never imports the conftest, which sets ~20 env vars as a side effect; a test that mutates the environment to check the environment is its own kind of lie). Asserts (1) every DSN-defaulted env var is covered by the guard, (2) no module defaults to the operational DB, (3) the scan found something at all (W84 blind-scan guard). **It found the 17 extra files itself.**
- **Armed** in `immune-enforcement.yml` on *both* the sentinel and the loop lists, plus the guarded conftest as a trigger path — trigger symmetry test passes (28 looped / 77 sentinel), actionlint clean.

## Proof

Mutation-tested against both failure shapes, each caught then reverted:

| mutation | expected | got |
|---|---|---|
| one module repointed back to `nuzantara_dev` | `test_no_test_module_defaults_to_the_operational_database` FAILs | FAIL ✅ |
| a fourth DSN env var introduced | `test_every_dsn_env_var_is_covered_by_the_guard` FAILs, naming it | FAIL ✅ |

Intake suite on M5 against `nuzantara_test`: **RC=0, 0 failures, 8 skips** — 7 are the documented attestation gate and 1 is the live-Qdrant opt-in.

**No coverage lost.** `nuzantara_dev` does not exist on M5, so those 7 already skipped as unreachable; on Pro it exists and is the live book, which is the defect this closes.

## Deliberately NOT done

The 7 skips are `APPROVED_DATABASE = "nuzantara_dev"`, hardcoded in `apps/backend-rag/scripts/intake_drive_contact_autocreate.py`. The test file's own docstring already warns: *"never widen APPROVED_DATABASE to make CI green: that deletes the property under test."* The right cure is an **attested disposable book**, not a widened constant — it needs its own guilt+innocence corpus and stays on the ledger as a separate line.

## Ledger

Closes the PENDING-ARMS entry opened **2026-07-18**, anchored by its text, not by a line number:

> `open 2026-07-18 | intake writer tests run against LIVE nuzantara_dev (INTAKE_TEST_DSN default …) | W96-family … | TECH-DEBT: repoint the default DSN + prove the full intake suite green on nuzantara_test | owner: any session`

Both halves are now done. (The commit message cites "line 445"; the entry is actually at line 430 today — a line number in a growing ledger is itself a proxy that lies, which is why the anchor here is the text. The ledger line is struck through in a follow-up so this branch does not re-run the 15-minute suite for a one-line docs edit.)
