### PR TITLE
fix(prepush): the branch could move under the gate, and git named the old sha

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -111,6 +111,8 @@ jobs:
               scripts/tests/test_prepush_classify.py|\
               .husky/pre-push|\
               scripts/tests/test_prepush_failclosed.sh|\
+              scripts/tests/test_prepush_tip_drift.sh|\
+              scripts/ci/prepush_tip_drift.sh|\
               scripts/docs_audit.py|\
               scripts/docs_inventory_refresh_liveness.py|\
               scripts/docs_inventory_regen.sh|\
@@ -235,6 +237,16 @@ jobs:
           # file is on main, so absent means deleted, and a deleted corpus
           # must go red rather than quietly pass.
           bash scripts/tests/test_prepush_failclosed.sh
+
+      - name: tip-drift corpus — the branch cannot move under the gate (guilt + innocence + W84)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # Same POSIX-sh reasoning as the step above: its own step, exit code
+          # read directly, no `if [ -f ]` skip. `prepush-guards.yml` runs this
+          # corpus too and is the REQUIRED context; this second executor is
+          # deliberate — the guard it covers is what makes that context mean
+          # anything, and a single executor is a single point of silence.
+          bash scripts/tests/test_prepush_tip_drift.sh
 
       - name: cron-state failure alert corpus (guilt + innocence + fail-open)
         if: steps.paths.outputs.relevant == 'true'

--- a/.github/workflows/prepush-guards.yml
+++ b/.github/workflows/prepush-guards.yml
@@ -27,9 +27,19 @@ on:
   merge_group:
   push:
     branches: [main]
+    # One entry per corpus this job actually runs, plus the surfaces they read.
+    # The list used to name 2 of the 5 — a register that does not declare the
+    # same scope it enforces (#3390): a main-push touching only an unlisted
+    # corpus re-ran nothing, and the green that followed described a job that
+    # never looked. `pull_request` above is deliberately unfiltered (W69), so
+    # this gap only ever showed on the push side, which is why it survived.
     paths:
       - ".husky/pre-push"
+      - "scripts/ci/prepush_tip_drift.sh"
       - "scripts/tests/test_prepush_honest_verdict.py"
+      - "scripts/tests/test_prepush_failclosed.sh"
+      - "scripts/tests/test_prepush_tip_drift.sh"
+      - "scripts/tests/test_prepush_suite_lock.sh"
       - "scripts/tests/test_test_deps_declared.py"
       - "apps/backend-rag/requirements-test.txt"
       - ".github/workflows/tests.yml"
@@ -78,3 +88,19 @@ jobs:
       # one; the sh -e / signal cases do not need a database and run everywhere.
       - name: Guard — the fail-closed paths survive sh -e and real signals
         run: sh scripts/tests/test_prepush_failclosed.sh
+
+      # Measured 2026-07-28: the hook validated f3bf5632 while a commit landed
+      # on the branch mid-run, and GitHub recorded ONE PushEvent ending at
+      # d45c116e — so the tree that landed is not the tree this gate judged,
+      # and git's own summary line named the old sha. `prepush-guards` is a
+      # REQUIRED context built on top of that gate, which is why the bypass
+      # matters enough to have its own corpus.
+      - name: Guard — the branch cannot move under the gate unnoticed
+        run: sh scripts/tests/test_prepush_tip_drift.sh
+
+      # Found while arming the line above: this corpus existed and NO workflow
+      # ran it — the same "it exists, therefore it protects" reading that
+      # superscar #2 is made of. Arming it is one line; leaving it unarmed
+      # would have kept a green board describing a test nobody executes.
+      - name: Guard — the suite lock cannot be taken twice
+        run: sh scripts/tests/test_prepush_suite_lock.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -601,7 +601,15 @@ if [ -n "${PREPUSH_REFS:-}" ] && [ -x scripts/ci/prepush_tip_drift.sh ]; then
     TIP_RC=0
     TIP_OUT=$(sh scripts/ci/prepush_tip_drift.sh "$PREPUSH_REFS" 2>&1) || TIP_RC=$?
     case "$TIP_RC" in
-        0) : ;;  # every pushed ref still points where the gate judged it
+        0)
+            # Print the receipt. Measured on this check's OWN first real push:
+            # it passed and emitted nothing, so 238KB of push log contained no
+            # evidence it had run at all — a hook without this block produces
+            # the identical silence. The rc=2 branch below already refuses to
+            # be silent for exactly this reason; the same argument applies to
+            # the happy path, where it is easier to forget and cheaper to fix.
+            printf '%s\n' "$TIP_OUT"
+            ;;
         1)
             printf '%s\n' "$TIP_OUT"
             rm -f "$PREPUSH_REFS"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -77,6 +77,21 @@ echo "✅ Skipping full test suite (covered by pre-commit hooks)"
 # ============================================================================
 PREPUSH_RUN_BACKEND=1
 
+# ---------------------------------------------------------------------------
+# The pre-push protocol stream, captured ONCE, before any branch below.
+#
+# It used to be consumed inside the path-aware gate's `else` arm, which meant
+# the two bypass branches (PREPUSH_FULL / PREPUSH_PATHAWARE=0) never saw it at
+# all. Two readers need it now — that gate, and the tip-drift check at the very
+# end of this file — and a stream can only be read once, so it is slurped to a
+# file here and both read the FILE. Capturing it unconditionally also means the
+# drift check still runs on the bypass paths, which is exactly where a gate is
+# most worth having.
+PREPUSH_REFS="$(mktemp 2>/dev/null || true)"
+if [ -n "$PREPUSH_REFS" ]; then
+    cat > "$PREPUSH_REFS" || true
+fi
+
 if [ "${PREPUSH_FULL:-0}" = "1" ]; then
     echo "🧭 PREPUSH_FULL=1 — path-aware gate bypassed, full suite unconditionally."
 elif [ "${PREPUSH_PATHAWARE:-1}" = "0" ]; then
@@ -107,9 +122,10 @@ else
         DIFF_ERROR=1
     else
         : > "$UNION_FILE"
-        # Reads THIS hook's own stdin (the git pre-push protocol stream) —
-        # must happen before anything else below reads stdin. Nothing later
-        # in this file does, so consuming it fully here is safe.
+        # Reads the pre-push protocol lines captured at the top of this file
+        # (they used to be read straight off stdin here; a second reader — the
+        # tip-drift check at the end — now needs them too, and a stream serves
+        # exactly one reader).
         while read -r local_ref local_sha remote_ref remote_sha; do
             [ -z "$local_ref" ] && continue  # trailing blank line safety
             REFS_SEEN=$((REFS_SEEN + 1))
@@ -171,8 +187,11 @@ else
                 DIFF_ERROR=1
                 break
             fi
-        done
+        done < "${PREPUSH_REFS:-/dev/null}"
 
+        # An unreadable capture is indistinguishable from an empty push here,
+        # and both must fail closed — which the REFS_SEEN test below already
+        # does, since /dev/null yields zero lines.
         [ "$REFS_SEEN" -eq 0 ] && DIFF_ERROR=1
     fi
 
@@ -565,6 +584,41 @@ fi
 # only the claim, which is the part that was false.
 # Defaults on both vars: the path-aware SKIP branch never enters the block that
 # initialises them, and this hook runs under `sh -e`.
+# ---------------------------------------------------------------------------
+# TIP-DRIFT — did the branch move while everything above was running?
+#
+# Everything above judged the sha git handed this hook on stdin. If a commit
+# landed on the branch in the meantime, that verdict describes a DIFFERENT tree
+# than the one about to be sent — measured 2026-07-28: the hook validated
+# f3bf5632, GitHub recorded a single PushEvent 418d187c -> d45c116e, and git's
+# own summary line still named f3bf5632. Rationale, evidence and the reason
+# this one REFUSES (unlike the softer verdict below it) are in the checker.
+#
+# Errexit-immune capture on purpose: a bare `TIP_RC=$(...)` under this hook's
+# `sh -e` would abort here on the very exit code it exists to read — W101, the
+# scar whose fourth instance shipped the same week.
+if [ -n "${PREPUSH_REFS:-}" ] && [ -x scripts/ci/prepush_tip_drift.sh ]; then
+    TIP_RC=0
+    TIP_OUT=$(sh scripts/ci/prepush_tip_drift.sh "$PREPUSH_REFS" 2>&1) || TIP_RC=$?
+    case "$TIP_RC" in
+        0) : ;;  # every pushed ref still points where the gate judged it
+        1)
+            printf '%s\n' "$TIP_OUT"
+            rm -f "$PREPUSH_REFS"
+            exit 1
+            ;;
+        *)
+            # CANNOT-VERIFY (deletion-only push, vanished ref, unreadable
+            # capture). Not drift, so it must not block — but it must not be
+            # silent either: an unverified push that reads like a verified one
+            # is the whole failure mode this check exists for.
+            echo "⚠️  tip-drift check could not verify this push (rc=$TIP_RC):"
+            printf '%s\n' "$TIP_OUT" | sed 's/^/    /'
+            ;;
+    esac
+fi
+[ -n "${PREPUSH_REFS:-}" ] && rm -f "$PREPUSH_REFS"
+
 if [ "$PREPUSH_RUN_BACKEND" = "1" ] && [ "${BACKEND_SUITE_RAN:-0}" != "1" ]; then
     echo "⚠️  PUSH NOT VERIFIED LOCALLY — the backend suite was REQUIRED for this diff but never ran"
     echo "    (${BACKEND_SUITE_SKIP_REASON:-reason not recorded})."

--- a/scripts/ci/prepush_tip_drift.sh
+++ b/scripts/ci/prepush_tip_drift.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# Did the branch move under the gate while the gate was running?
+#
+# THE DEFECT THIS EXISTS TO CATCH (measured 2026-07-28, M5, PR #3399):
+#
+#   1. `git push origin <branch>` started with the local tip at f3bf563244.
+#   2. The pre-push hook was handed f3bf563244 on stdin — the only two SHAs
+#      anywhere in its 439-line log are 418d187ccf (the old remote tip) and
+#      f3bf563244 — and ran the full suite against it for ~15 minutes, green.
+#   3. At 04:19:39Z, WHILE the hook was still running, a commit d45c116e45
+#      landed on the same branch.
+#   4. git printed `418d187ccf..f3bf563244  <branch> -> <branch>`.
+#   5. GitHub recorded exactly ONE PushEvent on that ref: 418d187c -> d45c116e.
+#   6. The remote tip is d45c116e45, per three independent probes
+#      (`git ls-remote`, `GET /git/ref/heads/…`, `GET /commits/<sha>`).
+#
+# So what landed was neither what the gate validated nor what git reported.
+# That is the observation. The MECHANISM is deliberately not named here: from
+# outside the process I cannot distinguish late refspec re-resolution from
+# anything else, and naming a mechanism I cannot see is the phantom-citation
+# failure the scars file exists to punish (W78).
+#
+# It does not matter which mechanism it is. This check compares the two things
+# that must agree — "the SHA the gate judged" and "the SHA this ref points at
+# now" — and refuses when they diverge. If some other explanation is the true
+# one, the comparison simply never fires; it accuses nothing on its own.
+#
+# WHY REFUSE RATHER THAN WARN. The neighbouring "backend suite was REQUIRED but
+# never ran" branch at the end of the hook deliberately only downgrades its
+# CLAIM instead of blocking, because that condition is environmental (a machine
+# without local PG can do nothing about it) and walling those machines off would
+# be worse. This one is the opposite: it is always the pusher's own action, it
+# is always fixable in one step (push again — the new tip then gets gated), and
+# leaving it unblocked means the pre-push gate, plus the `prepush-guards`
+# REQUIRED context built on top of it, can be bypassed by an entirely ordinary
+# accident whose window is as wide as the suite's runtime.
+#
+# CONTRACT
+#   argv[1]  file holding the git pre-push protocol lines, verbatim:
+#              <local_ref> <local_sha> <remote_ref> <remote_sha>
+#   exit 0   every pushed ref still points where the gate judged it
+#   exit 1   at least one ref DRIFTED — the push must not proceed
+#   exit 2   cannot verify (no file, unreadable, or zero usable lines).
+#            An empty read is never a clean read (W84): the caller decides
+#            what to do with "I could not look", but it is never "all clear".
+#
+# Refs whose local_sha is the all-zero SHA are deletions: no commit to compare,
+# skipped, and they do NOT count towards the "zero usable lines" test on their
+# own — a delete-only push is legitimately unverifiable by this check and says
+# so with exit 2 rather than pretending.
+
+ZERO_SHA="0000000000000000000000000000000000000000"
+
+REFS_FILE="${1:-}"
+
+if [ -z "$REFS_FILE" ] || [ ! -r "$REFS_FILE" ]; then
+    echo "tip-drift: no readable pre-push ref file ('${REFS_FILE:-<unset>}') — CANNOT VERIFY" >&2
+    exit 2
+fi
+
+comparable=0
+drifted=0
+
+# `sh -e` may be in force in the caller's context; every command substitution
+# below is written errexit-immune on purpose. A bare `now=$(git rev-parse …)`
+# aborts the whole script the moment the ref does not resolve — which is W101,
+# the exact scar that produced the sibling fix this check ships alongside. The
+# guard against a decapitated guard is to never write the decapitating form.
+while read -r local_ref local_sha _remote_ref _remote_sha; do
+    [ -z "$local_ref" ] && continue
+    [ -z "$local_sha" ] && continue
+    [ "$local_sha" = "$ZERO_SHA" ] && continue   # deletion: nothing to compare
+
+    now=""
+    now=$(git rev-parse --verify --quiet "$local_ref" 2>/dev/null) || now=""
+
+    if [ -z "$now" ]; then
+        # The ref vanished locally between the push starting and now. That is
+        # not evidence of drift, and accusing on it would be an over-match on
+        # absence. Report it, do not count it as verified.
+        echo "tip-drift: '$local_ref' no longer resolves locally — not verified" >&2
+        continue
+    fi
+
+    comparable=$((comparable + 1))
+
+    if [ "$now" != "$local_sha" ]; then
+        drifted=$((drifted + 1))
+        echo "tip-drift: $local_ref"
+        echo "    gate judged : $local_sha"
+        echo "    now points  : $now"
+    fi
+done < "$REFS_FILE"
+
+if [ "$comparable" -eq 0 ]; then
+    echo "tip-drift: zero comparable refs in '$REFS_FILE' — CANNOT VERIFY" >&2
+    exit 2
+fi
+
+if [ "$drifted" -gt 0 ]; then
+    echo ""
+    echo "❌ The branch moved while the pre-push gate was running."
+    echo "   The suite that just passed judged a DIFFERENT tree than the one git"
+    echo "   is about to send, and git's own summary line names the OLD sha — so"
+    echo "   the push log would confirm a commit that is not what lands."
+    echo ""
+    echo "   Fix: run the push again. The new tip gets gated on its own merits."
+    echo "   Rule: never commit on a branch while a push from it is in flight."
+    exit 1
+fi
+
+echo "tip-drift: $comparable ref(s) still at the sha the gate judged"
+exit 0

--- a/scripts/tests/test_prepush_honest_verdict.py
+++ b/scripts/tests/test_prepush_honest_verdict.py
@@ -422,6 +422,30 @@ def test_intake_dsn_is_isolated_to_the_per_push_clone() -> None:
     )
 
 
+def test_the_tip_drift_check_is_not_silent_when_it_passes() -> None:
+    """MEASURED on this check's own first real push (2026-07-28): the guard ran,
+    passed, and printed nothing — so 238KB of push log held no evidence it had
+    executed, and a hook WITHOUT the block produces byte-identical silence. A
+    pass nobody can observe is indistinguishable from a guard that never ran,
+    which is superscar #2 inside the guard written to close a #2-adjacent hole.
+    The rc=2 branch already argues this in its own comment; the rc=0 branch is
+    where it is easy to forget, so it is pinned here rather than trusted."""
+    text = _hook_text()
+    m = re.search(
+        r"TIP_OUT=\$\(sh scripts/ci/prepush_tip_drift\.sh.*?\n\s*case \"\$TIP_RC\" in\n(.*?)\n\s*esac",
+        text,
+        re.DOTALL,
+    )
+    assert m, "tip-drift case block not found in the hook — re-anchor this test"
+    # Only the rc=0 arm, up to the next arm label at the same indentation.
+    zero_arm = re.search(r"^\s*0\)(.*?)^\s{8}\d\)", m.group(1) + "\n        1)", re.DOTALL | re.MULTILINE)
+    assert zero_arm, "the rc=0 arm of the tip-drift case is not shaped as expected"
+    assert "$TIP_OUT" in zero_arm.group(1), (
+        "the tip-drift SUCCESS arm must print $TIP_OUT. Swallowing it makes a "
+        "verified push look exactly like one where the check never ran."
+    )
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/scripts/tests/test_prepush_tip_drift.sh
+++ b/scripts/tests/test_prepush_tip_drift.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Guilt + innocence corpus for scripts/ci/prepush_tip_drift.sh.
+#
+# A guard merged without BOTH halves is half a guard (superscar #3). The guilt
+# cases prove it still bites the drift it was written for; the innocence cases
+# prove it does not bite the ordinary push, the deletion, or the ref it simply
+# cannot see — the three shapes where accusing would be an over-match.
+#
+# Each case builds a REAL throwaway git repo and drives the checker with a real
+# pre-push protocol file. Nothing is mocked: the thing under test resolves refs
+# with `git rev-parse`, so a fake would only prove the fake.
+#
+# Run:  sh scripts/tests/test_prepush_tip_drift.sh
+
+set -u
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+CHECK="$HERE/scripts/ci/prepush_tip_drift.sh"
+
+[ -x "$CHECK" ] || { echo "FATAL: $CHECK missing or not executable"; exit 1; }
+
+PASS=0
+FAIL=0
+
+# Every assertion prints the observed rc, so a wrong-reason pass is visible.
+expect_rc() {
+    _want=$1; _got=$2; _what=$3
+    if [ "$_want" = "$_got" ]; then
+        PASS=$((PASS + 1)); echo "  ok   $_what (rc=$_got)"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL $_what — wanted rc=$_want, got rc=$_got"
+    fi
+}
+
+expect_mentions() {
+    _needle=$1; _out=$2; _what=$3
+    case "$_out" in
+        *"$_needle"*) PASS=$((PASS + 1)); echo "  ok   $_what" ;;
+        *) FAIL=$((FAIL + 1)); echo "  FAIL $_what — output never mentions '$_needle'" ;;
+    esac
+}
+
+WORK=$(mktemp -d) || exit 1
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# --- a real repo with two commits on one branch ----------------------------
+REPO="$WORK/repo"
+mkdir -p "$REPO"
+cd "$REPO" || exit 1
+git init -q -b work .
+git config user.email t@t.t
+git config user.name t
+echo one > f && git add f && git commit -qm one
+SHA_OLD=$(git rev-parse HEAD)
+echo two > f && git add f && git commit -qm two
+SHA_NEW=$(git rev-parse HEAD)
+ZERO="0000000000000000000000000000000000000000"
+
+# ---------------------------------------------------------------------------
+# GUILT — the gate judged SHA_OLD, the branch now sits at SHA_NEW
+# ---------------------------------------------------------------------------
+printf 'refs/heads/work %s refs/heads/work %s\n' "$SHA_OLD" "$ZERO" > "$WORK/drift.txt"
+OUT=$(sh "$CHECK" "$WORK/drift.txt" 2>&1); RC=$?
+expect_rc 1 "$RC" "guilt: a commit landed while the gate ran"
+expect_mentions "refs/heads/work" "$OUT" "guilt: names the ref that drifted"
+expect_mentions "$SHA_NEW" "$OUT" "guilt: reports the sha that will actually land"
+
+# GUILT-2 — drift on ONE ref out of two must still refuse
+printf 'refs/heads/work %s refs/heads/work %s\nrefs/heads/other %s refs/heads/other %s\n' \
+    "$SHA_NEW" "$ZERO" "$SHA_OLD" "$ZERO" > "$WORK/mixed.txt"
+git branch -q other "$SHA_NEW"   # 'other' resolves, but to a different sha
+OUT=$(sh "$CHECK" "$WORK/mixed.txt" 2>&1); RC=$?
+expect_rc 1 "$RC" "guilt: one clean ref does not excuse a drifted sibling"
+
+# ---------------------------------------------------------------------------
+# INNOCENCE — the ordinary push, and the two shapes that must not be accused
+# ---------------------------------------------------------------------------
+printf 'refs/heads/work %s refs/heads/work %s\n' "$SHA_NEW" "$SHA_OLD" > "$WORK/clean.txt"
+OUT=$(sh "$CHECK" "$WORK/clean.txt" 2>&1); RC=$?
+expect_rc 0 "$RC" "innocence: nothing moved — the ordinary push"
+expect_mentions "1 ref(s) still at the sha" "$OUT" "innocence: says what it verified"
+
+# A branch DELETION carries the all-zero local sha: no commit to compare. It is
+# legitimate, so it must not be called drift — and with nothing else in the push
+# there is also nothing verified, which is exit 2, not a silent 0 (W84).
+printf 'refs/heads/work %s refs/heads/work %s\n' "$ZERO" "$SHA_NEW" > "$WORK/del.txt"
+OUT=$(sh "$CHECK" "$WORK/del.txt" 2>&1); RC=$?
+expect_rc 2 "$RC" "innocence: a delete-only push is unverifiable, not drifted"
+
+# A ref that no longer resolves locally is absence, not evidence. Accusing on it
+# would be the over-match twin of the bug this guard exists for.
+printf 'refs/heads/ghost %s refs/heads/ghost %s\n' "$SHA_OLD" "$ZERO" > "$WORK/ghost.txt"
+OUT=$(sh "$CHECK" "$WORK/ghost.txt" 2>&1); RC=$?
+expect_rc 2 "$RC" "innocence: a vanished ref is not verified and not accused"
+expect_mentions "no longer resolves" "$OUT" "innocence: says WHY it could not verify"
+
+# Deletion + a genuinely clean ref: the clean one is comparable, so verdict 0.
+printf 'refs/heads/gone %s refs/heads/gone %s\nrefs/heads/work %s refs/heads/work %s\n' \
+    "$ZERO" "$SHA_OLD" "$SHA_NEW" "$SHA_OLD" > "$WORK/mixdel.txt"
+OUT=$(sh "$CHECK" "$WORK/mixdel.txt" 2>&1); RC=$?
+expect_rc 0 "$RC" "innocence: a deletion alongside an unmoved ref still passes"
+
+# ---------------------------------------------------------------------------
+# W84 — an empty read is never a clean read
+# ---------------------------------------------------------------------------
+: > "$WORK/empty.txt"
+OUT=$(sh "$CHECK" "$WORK/empty.txt" 2>&1); RC=$?
+expect_rc 2 "$RC" "blind: an EMPTY ref file is 'cannot verify', never 'clean'"
+
+OUT=$(sh "$CHECK" "$WORK/does-not-exist.txt" 2>&1); RC=$?
+expect_rc 2 "$RC" "blind: a MISSING ref file is 'cannot verify'"
+
+OUT=$(sh "$CHECK" 2>&1); RC=$?
+expect_rc 2 "$RC" "blind: no argument at all is 'cannot verify'"
+
+# ---------------------------------------------------------------------------
+# W101 — the guard must not decapitate itself under errexit
+# ---------------------------------------------------------------------------
+# The ghost case makes `git rev-parse` exit non-zero INSIDE the loop. Under a
+# caller running `sh -e`, a bare assignment there would abort the script before
+# its own verdict — the precise scar this check ships beside. Running it with
+# -e must still produce the honest exit 2, not a silent death.
+OUT=$(sh -e "$CHECK" "$WORK/ghost.txt" 2>&1); RC=$?
+expect_rc 2 "$RC" "W101: survives a failing rev-parse under 'sh -e'"
+
+echo ""
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## The defect, measured (2026-07-28, M5, during the push of #3399)

1. `git push origin <branch>` started with the local tip at `f3bf563244`.
2. The pre-push hook was handed `f3bf563244` on stdin — the only two SHAs anywhere in its 439-line log are `418d187ccf` (the old remote tip) and `f3bf563244` — and ran the full suite against it for ~15 minutes, green.
3. At 04:19:39Z, **while the hook was still running**, commit `d45c116e45` landed on the same branch.
4. git printed `418d187ccf..f3bf563244  <branch> -> <branch>`.
5. GitHub recorded exactly **one** PushEvent on that ref: `418d187c -> d45c116e`.
6. The remote tip is `d45c116e45`, per three independent probes (`git ls-remote`, `GET /git/ref/heads/…`, `GET /commits/<sha>`).

So what landed was **neither what the gate validated nor what git reported**. `prepush-guards` is a REQUIRED context built on top of that gate, so the bypass window is as wide as the suite's runtime (~15 min), and it opens on an entirely ordinary accident.

**The mechanism is deliberately not named** anywhere in this diff. From outside the process I cannot distinguish late refspec re-resolution from anything else, and naming a mechanism I cannot see is the phantom-citation failure the scars file exists to punish (W78). The check does not need to know: it compares the two things that must agree — *the SHA the gate judged* and *the SHA this ref points at now* — and refuses when they diverge. If some other explanation is the true one, the comparison simply never fires.

## What ships

- **`scripts/ci/prepush_tip_drift.sh`** — exit `0` clean / `1` drifted / `2` cannot-verify. An empty read is never a clean read (W84). Deletions (all-zero local sha) are skipped, not accused. A ref that no longer resolves locally is *absence*, not evidence.
- **`.husky/pre-push`** captures the protocol lines to a temp file (the stdin loop now reads from it) and runs the check before the final verdict.
- **`scripts/tests/test_prepush_tip_drift.sh`** — 14 assertions in real throwaway git repos: 2 guilt (drift; one clean ref does not excuse a drifted sibling), 6 innocence (unmoved / delete-only / vanished ref / deletion+clean), 3 W84 blind-read (empty file, missing file, no argument — all exit 2), 1 W101 pin (survives a failing `rev-parse` under `sh -e`). Mutation-verified: replacing the comparison with `if false` drops exactly 4 assertions.
- **`prepush-guards.yml`** arms this corpus **and** `test_prepush_suite_lock.sh`, which existed and no workflow ran (superscar #2, found while arming this). Its `push:` paths list grew from 2 entries to 6 + the checker — a register that does not declare the same scope it enforces (#3390).
- **`immune-enforcement.yml`** gains the sentinel entries and an execution step.

### Why it REFUSES rather than warns

The neighbouring "backend suite was REQUIRED but never ran" branch only downgrades its *claim*, because that condition is environmental (a machine with no local PG can do nothing about it) and walling those machines off would be worse. This one is the opposite: it is always the pusher's own action, always fixable in one step (push again — the new tip gets gated on its own merits), and leaving it unblocked means the gate plus the required context above it can be bypassed by accident.

## Second commit: the guard passed on a real push and left no trace

Then the check's **own first real push** produced the next finding. It ran, it passed, and it printed nothing — 238 KB of push log held no evidence it had executed, and a hook *without* the block produces byte-identical silence. I had to stat the script and re-read the hook to convince myself it had fired. A pass nobody can observe is indistinguishable from a guard that never ran: superscar #2, inside the guard written to close a #2-adjacent hole.

The rc=2 branch already argues exactly this in its own comment — *"it must not be silent either: an unverified push that reads like a verified one is the whole failure mode this check exists for."* I had applied that reasoning to rc=2 and not to rc=0, where it is easier to forget and cheaper to fix.

`rc=0` now prints the receipt, pinned by `test_the_tip_drift_check_is_not_silent_when_it_passes` (anchored to the rc=0 arm specifically, mutation-verified: restoring `0) : ;;` fails it).

## PROVE-LIVE

The push that carries this commit emitted, on a real push:

```
tip-drift: 1 ref(s) still at the sha the gate judged
```

Landing verified with `git ls-remote` (`8f87628303a6`), never the push stdout — which is the very thing this PR proves can lie.

## Verification run locally

| gate | result |
|---|---|
| `test_prepush_tip_drift.sh` | 14 passed, 0 failed (+ mutation-verified) |
| `test_prepush_failclosed.sh` | 19 passed, 0 failed (rc=0) |
| `test_prepush_suite_lock.sh` | 7 passed, 0 failed |
| `test_prepush_honest_verdict.py` | all passed, incl. the new pin |
| `test_husky_prepush_venv_guard.py` | 7 passed |
| `test_prepush_classify.py` | 123 passed |
| `actionlint` on both workflows | rc=0 |
| guard-conformance / plist-lint | rc=0 |

**Not registered in `infra/guard-conformance/registry.json`**, deliberately: that registry's own `_doc` scopes it to *textual* guards (superscar #3) and this is a SHA comparison (family #2). Out of declared scope, not forgotten.

**Auto-merge is NOT armed at open**: `.husky/pre-push` is a guardrail hook, so per `feedback_arm_automerge_default_not_leave_to_operator` the session merges it after its own gate rather than arming it on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
