### PR TITLE
chore(ci): bump the last actions/checkout@v4 on main to v7

### DIFF
--- a/.github/workflows/watcher-coverage.yml
+++ b/.github/workflows/watcher-coverage.yml
@@ -32,7 +32,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"


### PR DESCRIPTION
One line. `watcher-coverage.yml` is the **single remaining `actions/checkout@v4`** in the repo, measured against the real main tree rather than a working directory:

```
$ for f in $(git ls-tree -r --name-only origin/main -- .github/workflows/); do
    git show "origin/main:$f" | grep -o 'actions/checkout@v[0-9]*' | sort -u; done | sort | uniq -c
   1 actions/checkout@v4
  65 actions/checkout@v7
```

## Why not just merge #3355

Dependabot opened #3355 for exactly this line. It is DIRTY and carries a `Balizero1987` commit, and **Dependabot declines `@dependabot rebase` on a PR edited by someone else** — which is true of every DIRTY Dependabot PR on the board right now (#3355, #3357, #3360, #3361, #3363). None of them can self-heal; the session has to act. For a one-line bump, shipping the line is cheaper than resurrecting the branch. #3355 gets closed pointing here once this lands.

## Why the measurement is spelled out in the commit message

I first closed #3355 as "already landed", citing `grep -rl 'actions/checkout@v4' .github/workflows/` returning zero files. That grep ran in the **M5 main checkout, which is 225 commits behind `origin/main`** — so it described a tree that is not main. The authoritative probe was in the very same command block and already said `35: actions/checkout@v4`; I acted on the wrong one and read the right one afterwards. Correction is posted on #3355, and this branch was cut fresh (`0` commits behind origin/main) so its own `grep` confirms the `@v4` line independently.

Superscar #9 / W106b: a checkout is a proxy for *what the repo says*, and it lies whenever it is behind. The lesson `on M5 read from a worktree, never from the main checkout` was written this morning — this is the day it got tested.

## Verification

- `actionlint .github/workflows/watcher-coverage.yml` → rc=0
- No untrusted-input interpolation in this workflow (`github.event.*` / `github.head_ref` / `ref: ${{ }}`) — checked, since the diff touches a checkout step
- Pre-push classifier routed it as innocent (`allowlist v6`, 1/1 file) and skipped the backend suite — a workflow file is never imported by our code

Auto-merge armed: this is a version bump, not a change to a guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
