### PR TITLE
fix(mouth): eleven pages said "Bali Zero" twice in the browser tab

### DIFF
--- a/apps/mouth/src/app/(assessment)/assessment/layout.tsx
+++ b/apps/mouth/src/app/(assessment)/assessment/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Assessment — Bali Zero",
+  title: "Assessment",
   description: "Technical-Strategic Assessment for Bali Zero candidates",
   robots: { index: false, follow: false },
 };

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.tsx
@@ -5,7 +5,7 @@ import "./oracle.css";
 // No NavShell, no site chrome: an immersive, standalone full-viewport
 // experience with its own footer disclaimer (rendered by OracleShell).
 export const metadata: Metadata = {
-  title: "Visa Oracle — Prototype | Bali Zero",
+  title: "Visa Oracle — Prototype",
   description:
     "A demonstration decision tree for Indonesian visa eligibility. Sample data only — not a government service, not an approval.",
   robots: { index: false, follow: false },

--- a/apps/mouth/src/app/kbli/builder/page.tsx
+++ b/apps/mouth/src/app/kbli/builder/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { KBLIBuilderCTA } from "./_components/KBLIBuilderCTA";
 
 export const metadata: Metadata = {
-  title:
-    "KBLI Builder — Susun Struktur Kode KBLI untuk PT PMA Anda | Bali Zero",
+  title: "KBLI Builder — Susun Struktur Kode KBLI untuk PT PMA Anda",
   description:
     "Mau mendirikan PT PMA di Bali? Tim Bali Zero menyusun struktur kode KBLI 2025 yang tepat untuk proses inkorporasi dan kepatuhan investasi asing Anda.",
   alternates: {

--- a/apps/mouth/src/app/kbli/decoder/page.tsx
+++ b/apps/mouth/src/app/kbli/decoder/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { KBLIDecoderCTA } from "./_components/KBLIDecoderCTA";
 
 export const metadata: Metadata = {
-  title: "KBLI Decoder — Temukan Kode Klasifikasi Bisnis Anda | Bali Zero",
+  title: "KBLI Decoder — Temukan Kode Klasifikasi Bisnis Anda",
   description:
     "Tidak yakin kode KBLI mana yang sesuai untuk bisnis Anda? Tim Bali Zero menganalisis aktivitas usaha Anda dan menemukan klasifikasi KBLI 2025 yang tepat untuk pendaftaran PT PMA.",
   alternates: {

--- a/apps/mouth/src/app/metadata-title-template.test.ts
+++ b/apps/mouth/src/app/metadata-title-template.test.ts
@@ -1,0 +1,95 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Brand-suffix guard for page titles (2026-07-28).
+ *
+ * TRAUMA: the root layout sets `title.template = "%s | Bali Zero"`, so Next.js
+ * appends the brand to every page title automatically. Eleven pages appended it
+ * a second time by hand, and shipped a stutter to production:
+ *
+ *   <title>Careers — Bali Zero | Bali Zero</title>
+ *   <title>Zoning Check — Verifikasi Zonasi Properti Bali Anda | Bali Zero | Bali Zero</title>
+ *
+ * Measured live on 5 of 5 pages sampled before the fix. Nobody noticed because
+ * each page looks right in isolation — the defect only exists in the COMPOSITION
+ * of the page's title with a template declared in a different file. It cost real
+ * estate too: Google shows ~60 characters, and the repeat burned twelve of them.
+ *
+ * The guard checks the composition, so the twelfth page cannot repeat it.
+ *
+ * Deliberately NOT flagged: a title that mentions the brand mid-string (e.g.
+ * "Terms of Service — Bali Zero — Visa"). That is editorial phrasing, not the
+ * mechanical stutter — the innocence case below pins that it stays legal.
+ */
+
+const APP_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Trailing `| Bali Zero`, `— Bali Zero`, `- Bali Zero` — with any spacing. */
+const TRAILING_BRAND = /\s*[|—–-]\s*Bali Zero\s*$/;
+
+function tsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...tsxFiles(p));
+    else if (e.name.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+/** Top-level static `title:` string literals from `export const metadata` objects. */
+function staticTitles(): { file: string; title: string }[] {
+  const found: { file: string; title: string }[] = [];
+  for (const file of tsxFiles(APP_DIR)) {
+    const src = fs.readFileSync(file, "utf8");
+    const decl = /export const metadata[^=]*=\s*\{/.exec(src);
+    if (!decl) continue;
+    const tail = src.slice(decl.index + decl[0].length);
+    // two-space indent = first level of the metadata object; a nested
+    // openGraph/twitter title is indented deeper and is NOT templated by Next.
+    const m =
+      /^ {2}title:\s*("(?:[^"\\]|\\.)*")/m.exec(tail) ??
+      /^ {2}title:\s*\n\s+("(?:[^"\\]|\\.)*")/m.exec(tail);
+    if (!m) continue;
+    found.push({
+      file: path.relative(APP_DIR, file),
+      title: JSON.parse(m[1]) as string,
+    });
+  }
+  return found;
+}
+
+describe("page titles vs the root title template", () => {
+  it("finds titles to check (the probe can produce a positive)", () => {
+    // An empty scan would make the assertion below vacuously true — the
+    // failure mode where a guard passes because it looked at nothing.
+    expect(staticTitles().length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("no page appends the brand the template already appends", () => {
+    const offenders = staticTitles()
+      .filter((t) => TRAILING_BRAND.test(t.title))
+      .map((t) => `${t.file}: ${t.title}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("a brand mention mid-title is left alone (innocence)", () => {
+    expect(TRAILING_BRAND.test("Terms of Service — Bali Zero — Visa")).toBe(
+      false,
+    );
+    expect(TRAILING_BRAND.test("Bali Zero is here to help")).toBe(false);
+  });
+
+  it("catches every separator the codebase actually used (guilt)", () => {
+    for (const bad of [
+      "Careers — Bali Zero",
+      "Visa Oracle — Prototype | Bali Zero",
+      "Login - Bali Zero",
+      "Something | Bali Zero ",
+    ]) {
+      expect(TRAILING_BRAND.test(bad)).toBe(true);
+    }
+  });
+});

--- a/apps/mouth/src/app/portal/login-upgraded/layout.tsx
+++ b/apps/mouth/src/app/portal/login-upgraded/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Login — Bali Zero",
+  title: "Login",
   robots: { index: false, follow: false },
 };
 

--- a/apps/mouth/src/app/taxes/gap/page.tsx
+++ b/apps/mouth/src/app/taxes/gap/page.tsx
@@ -3,8 +3,7 @@ import type { Metadata } from "next";
 import { TaxGapCTA } from "./_components/TaxGapCTA";
 
 export const metadata: Metadata = {
-  title:
-    "Tax Gap Analysis — Periksa & Optimalkan Pajak Bisnis Anda | Bali Zero",
+  title: "Tax Gap Analysis — Periksa & Optimalkan Pajak Bisnis Anda",
   description:
     "Evaluasi kepatuhan pajak dan temukan potensi penghematan serta risiko pajak PT PMA Anda di Indonesia dengan analisis Tax Gap dari Bali Zero.",
   alternates: {

--- a/apps/mouth/src/app/v2/company/careers/page.tsx
+++ b/apps/mouth/src/app/v2/company/careers/page.tsx
@@ -4,7 +4,7 @@ import { BZLogo } from "@balizero/core/components/BZLogo";
 import { Footer } from "../../_components/Footer";
 
 export const metadata: Metadata = {
-  title: "Careers — Bali Zero",
+  title: "Careers",
   description:
     "Join the team building the infrastructure for foreigners to thrive in Bali.",
   robots: { index: false, follow: false },

--- a/apps/mouth/src/app/v2/company/press/page.tsx
+++ b/apps/mouth/src/app/v2/company/press/page.tsx
@@ -4,7 +4,7 @@ import { BZLogo } from "@balizero/core/components/BZLogo";
 import { Footer } from "../../_components/Footer";
 
 export const metadata: Metadata = {
-  title: "Press — Bali Zero",
+  title: "Press",
   description:
     "Media enquiries and press resources for Bali Zero — Indonesia's leading expat services firm.",
   robots: { index: false, follow: false },

--- a/apps/mouth/src/app/visa/second-home/page.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.tsx
@@ -4,7 +4,7 @@ import { SECOND_HOME_FAQS } from "@/lib/seo/faq-data";
 import { SecondHomeLanding } from "./SecondHomeLanding";
 
 export const metadata: Metadata = {
-  title: "E33 Second Home Visa Indonesia 2026 | Free Fit Memo | Bali Zero",
+  title: "E33 Second Home Visa Indonesia 2026 | Free Fit Memo",
   description:
     "Indonesia's Second Home Visa (E33): up to 5 years of long-term residence via a USD 130,000 own-name deposit at a state-owned Indonesian bank or USD 1,000,000 completed strata-title property. Free fit memo from Bali Zero.",
   openGraph: {

--- a/apps/mouth/src/app/visa/voa/layout.tsx
+++ b/apps/mouth/src/app/visa/voa/layout.tsx
@@ -17,8 +17,7 @@ import { I18nProvider } from "@/i18n";
 // (guaranteed approval / guaranteed turnaround / fully-online extension) binds
 // SEO copy exactly as it binds the page body.
 export const metadata: Metadata = {
-  title:
-    "Visa on Arrival (B1) Indonesia — eligibility, dates, price | Bali Zero",
+  title: "Visa on Arrival (B1) Indonesia — eligibility, dates, price",
   description:
     "Check a Visa on Arrival or its extension in 7 questions: whether the case is straightforward, your stay window, the published filing deadline, and our all-inclusive fee. No documents to upload, no payment to check.",
   openGraph: {

--- a/apps/mouth/src/app/zoning/page.tsx
+++ b/apps/mouth/src/app/zoning/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { ZoningCheckCTA } from "./_components/ZoningCheckCTA";
 
 export const metadata: Metadata = {
-  title: "Zoning Check — Verifikasi Zonasi Properti Bali Anda | Bali Zero",
+  title: "Zoning Check — Verifikasi Zonasi Properti Bali Anda",
   description:
     "Pastikan properti atau lahan Anda di Bali sesuai zonasi yang berlaku sebelum membeli atau membangun. Tim Bali Zero memverifikasi status zonasi dan risiko regulasi untuk PT PMA dan investor asing.",
   alternates: {


### PR DESCRIPTION
## What

The root layout declares `title.template = "%s | Bali Zero"`, so Next.js appends the brand to every page title on its own. **Eleven pages appended it a second time by hand** and shipped the stutter to production:

```
<title>Careers — Bali Zero | Bali Zero</title>
<title>Zoning Check — Verifikasi Zonasi Properti Bali Anda | Bali Zero | Bali Zero</title>
```

Confirmed live on **5 of 5** pages sampled before this PR.

## How it was found, and why the whole class

Found while proving #3397 live — the new `/visa/voa` title had the same defect. The class is older than that PR, so this fixes the class rather than only my own line (*pattern-fix = class-audit*, W107).

Each page looks correct **in isolation**: the defect only exists in the COMPOSITION of the page title with a template declared in a different file. A guard that reads one file cannot see it. `metadata-title-template.test.ts` therefore walks every `export const metadata` in the app tree, extracts the **top-level** `title` (a nested `openGraph.title` is NOT templated by Next and is deliberately skipped), and fails on a trailing brand suffix with any separator the codebase actually used.

## Guard corpus (family #3 antibody: guilt + innocence, never one alone)

- **guilt** — all four separators found in the tree: `—`, `|`, `-`, and a trailing space
- **innocence** — a mid-string brand mention (`"Terms of Service — Bali Zero — Visa"`) stays legal; that is editorial phrasing, not the mechanical stutter
- **non-vacuity** — the scan must find `>= 8` titles, so an empty walk cannot make the assertion pass by looking at nothing

**Mutation-verified**: restoring `title: "Careers — Bali Zero"` fails the guard naming the file; restored after.

## Verification

- `vitest run src/app` — 95 files, 883 tests, all pass
- `tsc --noEmit` — 0 errors
- prettier clean on all 12 touched files

## Cost, not just tidiness

Google renders ~60 characters of a title. The repeat burned twelve of them on eleven pages.