### PR TITLE
chore(nb-health): add 2026-07-28 daily NB arsenal health + Press dedup report

### DIFF
--- a/research/nb-health/2026-07-28-health.md
+++ b/research/nb-health/2026-07-28-health.md
@@ -1,0 +1,66 @@
+# NB Arsenal Health Report — 2026-07-28 (daily, Mode B+C)
+
+Source: `nb-inventory-live.json` (generated 2026-07-27T20:02Z, pre-gathered — no live `nlm` calls this pass).
+
+## Summary
+- Total: **58 NBs, 5,698 sources**
+- Healthy: 57 | Empty/broken: 1 | Stale (notebook not updated >30d): 1
+- Near-cap (500/500 ceiling): **3** — NB-INTEL-AIResearch, NB-INTEL-AIResearch-2 (overflow), NB-INTEL-Press
+
+## Gap notice
+No daily pass logged in memory since 2026-06-16 (42-day gap). Notebook count 86→58 (-28) and
+sources ~3,873→5,698 — large swing likely reflects manual consolidation/archival during the gap
+(WA-* scaffolds, PROBE dirs no longer present). Not independently diffed today (out of scope per
+hard limits) — treat as unverified until a mid-gap report is read.
+
+## Empty (archive candidate)
+- **"Labor Law Research May 2025"** (`bafceb4f…`) — 0 sources, health=empty. Superseded by
+  "Labor Law Research 2025-2026" (`4561782a…`, 10 src, populated).
+
+## Stale (>30d no update)
+- **NB-LAB-AGENT-ENGINEERING-2026** (`dff45303…`) — last updated 2026-06-16, 42 days. 395 src,
+  healthy but frozen; feeder/curation likely paused.
+
+## NB-INTEL snapshot
+| NB | Src | Health | Near-cap |
+|---|---|---|---|
+| Immigration | 194 | healthy | no |
+| Tax | 193 | healthy | no |
+| Regulation | 125 | healthy | no |
+| Press | 500 | healthy | **YES (capped)** — overflow Press-2 exists, only 1 src |
+| AIResearch | 500 | healthy | **YES (capped)** — overflow AIResearch-2 (069f009c) itself now also 500/500, capped |
+
+## Mode C — Press dedup/summarize proposals (today's scope: Press only)
+
+**Near-dup / repeated-title clusters** (titles-only eyeball, no URL field read this pass):
+1. "Investasi Vila di Bali Tak Cukup Andalkan Lokasi…" — 2x identical title
+2. "KBLI 2025 dan pelajaran tentang kepatuhan usaha - ANTARA News" — 2x identical title
+3. "Silmy : Imigrasi tertibkan penyalahgunaan visa dan ITAS investor…" — 3x identical title
+4. "Menkumham Yasonna Laoly resmikan kebijakan visa rumah kedua gaet investor global…" — 2x identical title
+5. 5 distinct URL-as-title sources each appearing exactly 3x (finance.detik.com/misbakhun-pfii,
+   katadata.co.id/karpet-merah-pajak-pfii, megapolitan.kompas.com/10-wn-china,
+   expat.com/hsbc-kita-forum, letsmoveindonesia ×3 articles) — likely re-ingested under separate
+   source IDs; recommend URL-canonical re-check before merge (may not be true exact-dup if the
+   deterministic pre-step already ran and reported 0 exact-URL dups today).
+
+**Summarization bundle candidates (≥10 sources, topic cluster):**
+6. "Golden Visa policy coverage" — ~12+ sources (Konawe, Menkumham ×2 launches, Menparekraf,
+   Prabowo/Jokowi "tertinggal" ×2, PFII residency-golden-visa ×2, Yunani property-golden-visa ×2).
+   Propose synthetic master doc (offline Ollama), Antonello approves before removal.
+7. "Visa-free entry tightening / BVK cuts" — ~9-10 sources (87% BVK rejection, Indonesia
+   Slashes/Tightens Visa-Free Entry, Bebas Visa Dikurangi, Menkumham hentikan 159 negara,
+   Pengawasan Orang Asing Diperketat) — borderline threshold, flag for review not auto-bundle.
+
+No stale-source (>90d) check possible this pass — source `updated_at`/date fields not present in
+titles-only sample; would need `nlm source list --json` per source (out of read budget today).
+
+## Operator actions
+- [ ] Archive "Labor Law Research May 2025" (empty, 0 src)
+- [ ] Check NB-LAB-AGENT-ENGINEERING-2026 feeder (42d stale)
+- [ ] Review Press dedup clusters #1-5, run `nlm rm` manually after confirming URLs differ/match
+- [ ] Decide on Press summarization for #6 (Golden Visa) and #7 (visa-tightening)
+- [ ] AIResearch-2 overflow itself now at 500/500 — plan third overflow NB or dedup-then-refeed
+
+No Telegram sent — 1 empty NB is below the 3+ broken threshold; no new gap_warning pattern detected.
+
+SUMMARY: broken=1 stale=1 proposals=7 press_new=7


### PR DESCRIPTION
The nb-curator daily pass produced its 2026-07-28 report and pushed the branch, but
no PR was ever opened for it — so the report sat on `origin` while every other day's
landed. Main already carries 17 files under `research/nb-health/`, including
2026-07-25, -26 and -27 (the last via #3254). This is the same artifact, same shape,
one day later.

One new file, 66 lines, docs only. Nothing else changes.

Worth noting because the report says so itself: it flags a **42-day gap** with no daily
pass logged since 2026-06-16, a notebook count that moved 86 -> 58 while sources went
~3,873 -> 5,698, and it explicitly declines to call that swing verified ("Not
independently diffed today ... treat as unverified until a mid-gap report is read").
Landing it puts that open question in the tree where the next curator pass can pick it
up, instead of leaving it on a branch nobody reads.

Also flagged inside: 3 notebooks at the 500/500 ceiling (NB-INTEL-AIResearch,
-AIResearch-2, -Press) and one empty notebook superseded by a populated twin.