### PR TITLE
docs(visa-oracle): correct #3407 — "arm MATCH" was wrong, the 07-24 runbook was right

### DIFF
--- a/.agents/skills/visaoracle/SKILL.md
+++ b/.agents/skills/visaoracle/SKILL.md
@@ -51,8 +51,8 @@ gate — a green gate certifies the engine as it was measured, not future edits.
   recorded drill: flip ENFORCE, then flip back to OFF, confirm the public surface stops consulting the
   engine immediately — no redeploy, no cache lag). ENFORCE is never armed without a proven kill-switch.
 
-**GATE STATUS: 🔴 RED (2026-07-28 — collection is LIVE and MEASURED; the lane that is collecting cannot
-pass, the lane that can is OFF).** Receipt: `research/visa/2026-07-28-shadow-gate-measurement.md`
+**GATE STATUS: 🔴 RED (2026-07-28 — collection is LIVE and MEASURED; NEITHER of the two counted lanes can
+currently mature G-a, for two different reasons).** Receipt: `research/visa/2026-07-28-shadow-gate-measurement.md`
 (re-runnable SQL inline). Measured on prod `visa_decisions`: **1,483 rows / 14 distinct fingerprints /
 4 days / 3 categories / 0 distinct visa codes**, every row `HUMAN_REVIEW_REQUIRED` with an EMPTY
 `candidate_summary` — G-a red on every component.
@@ -66,8 +66,10 @@ fingerprint is `SHA-256` of a per-submission RANDOM token (`shadow.py:399`, `rep
 1,000-distinct threshold is traffic-bounded, NOT interview-bounded), and the collector counts it
 (`EVIDENCE_ENGINE_SURFACES={"MATCH","RECOMMEND"}`). It has ZERO rows because it is off: `fly secrets list`
 (run 07-28) shows TRUST_STORE / DRIVER_TOKEN / EVALUATE_MODE / FINGERPRINT_KEYS deployed and **no
-`VISA_ENGINE_MATCH_MODE`**, which defaults OFF (`shadow.py:207`). **⇒ Arming MATCH is the highest-value
-single step.** Also: 1,464 rows are THREE byte-identical payloads at 3-4s cadence, all labelled
+`VISA_ENGINE_MATCH_MODE`**, which defaults OFF (`shadow.py:207`). **⇒ BUT DO NOT JUST ARM IT — see the
+07-28 correction below: the MATCH writer does not label its rows, so they would land `traffic_source
+IS NULL` = legacy = counted toward NEITHER G-a gate. Arming alone is a **G-a** no-op (those rows DO
+still feed G-c, which is deliberately not split by provenance).** Also: 1,464 rows are THREE byte-identical payloads at 3-4s cadence, all labelled
 `traffic_source='real'` (the 07-27 contamination defect, 3 orders of magnitude larger) — G-a-vol is not
 measuring adoption until that label is split. **On ENFORCE, correcting a wrong first reading:** the
 authoritative render IS unbuilt (`resolve_response_mode()` returns literal `CURATED`,
@@ -472,6 +474,30 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
   itself was checked, and its `MATCH_MODE never set` objection was right on method (inference from a zero
   count) even though the conclusion survived once real Fly evidence replaced the inference.
   GATE STATUS updated above: 🔴 RED, now with numbers and with the right reason.
+- 2026-07-28 (M5, same session, hours later): **CORRECTION TO THE ENTRY ABOVE — "arm MATCH" was wrong, and
+  the 07-24 runbook was right.** Caught while executing it, before the `fly secrets set`. Two facts, both
+  verified: (1) `shadow.py`'s MATCH writer does NOT include `traffic_source` in its INSERT column list
+  (`shadow.py:538-547`) and the column has **no default and is nullable** (checked on the live prod schema,
+  not just the migration) — so every MATCH row would land NULL = **legacy = counted toward NEITHER G-a
+  gate** (`shadow_evidence.py:296-303`, fail-closed). Arming MATCH without first teaching the writer to
+  label its rows is a **G-a no-op** — precisely: those rows cannot advance G-a-vol or G-a-breadth, but they
+  DO flow into G-c, which is deliberately not split by provenance (`shadow_evidence.py:28-29`), so they can
+  still move a criterion. **Why no test caught it:** the MATCH writer's fixtures layer only migrations
+  252+255 (`test_shadow_match.py:505-518`) — 256 is never applied, so `traffic_source` is not even a column
+  in the schema those tests assert against. (2) `research/visa/2026-07-24-shadow-arming-runbook.md:40`
+  had already recorded "leave `VISA_ENGINE_MATCH_MODE` OFF" as a deliberate **plan decision** — the window's
+  evidence is to be **full-fact only**, since MATCH carries 3 of 40 facts. That decision is not mine to flip
+  unilaterally: a 3-fact corpus certifies a thinner engine than the one ENFORCE would arm. **So the fork is
+  an owner call**: (A) keep MATCH dark and fix the RECOMMEND interview → slower, full-fact evidence, matches
+  the plan; (B) label MATCH rows `real` + arm → faster volume, thin-fact evidence. Do NOT execute (B)
+  without a ruling.
+  **METHOD NOTE — the lesson that keeps costing:** I read the COLLECTOR's surface allow-list
+  (`EVIDENCE_ENGINE_SURFACES={"MATCH","RECOMMEND"}`) and concluded MATCH rows would count. But **a row is
+  counted only if the WRITER labels it** — reader-accepts-the-surface ≠ writer-emits-the-label. Check the
+  INSERT column list and the column default on the LIVE schema, not the migration file, before calling any
+  lane "evidence". Same shape as the earlier two refutations this session: a property verified at one end of
+  a pipe, asserted about the whole pipe. And: **before executing a step, grep the runbooks for a recorded
+  decision about it** — the 07-24 rationale was one file away.
 
 ## TRACKS — parallel work groups (multi-session coordination)
 

--- a/research/visa/2026-07-28-shadow-gate-measurement.md
+++ b/research/visa/2026-07-28-shadow-gate-measurement.md
@@ -4,7 +4,7 @@ domain: visa
 client_case: none
 author: Claude Opus 5 (Air-M5) — ENFORCE-GATE measurement against the live SHADOW substrate
 adversarial_review: codex
-status: MEASURED — the collecting lane is the one that cannot mature; the lane that can is OFF
+status: MEASURED — NEITHER lane can currently mature G-a, for two different reasons
 sources:
   - prod `visa_decisions` (read-only role `nuzantara_readonly`, queries reproduced below)
   - `fly secrets list -a nuzantara-rag` (run 2026-07-28)
@@ -13,15 +13,17 @@ sources:
   - apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-001.source.json
 ---
 
-# SHADOW gate measurement — the collecting lane is not the lane that can pass
+# SHADOW gate measurement — neither lane can currently mature G-a
 
 The corner's GATE STATUS has said 🔴 RED since 2026-07-21 with the reason "production
 collection is still dark". Collection has in fact been writing since 2026-07-25. This is the
 first read of *what it wrote*, from the production audit log rather than from the ledger's
 narration of it.
 
-The headline is not "the gate is far away". It is that **the surface currently feeding the
-audit log structurally cannot satisfy G-a, while the surface that could is switched off.**
+The headline is not "the gate is far away". It is that **neither of the two surfaces the
+collector counts can currently mature G-a**, for two unrelated reasons: the one that is
+collecting abstains by construction (§2), and the one that has the right facts and the right
+traffic does not label its rows, so they would be discarded from both G-a gates (§7).
 
 ## 1. What the audit log contains (measured 2026-07-28)
 
@@ -105,7 +107,7 @@ open. What is not open is the label: these rows carry `traffic_source='real'`, t
 production adoption. Same defect class as the one flagged on 2026-07-27, three orders of
 magnitude larger.
 
-## 4. The lane that can actually pass the gate is OFF
+## 4. The other lane has the right facts and the right traffic — and is OFF
 
 The MATCH shadow twin (STEP-6c, #2916) is a different story on every axis that blocks
 RECOMMEND:
@@ -149,9 +151,10 @@ So G-d is *drillable now*; what is missing is the ENGINE render path the flip wo
 
 ## 6. Ordering that follows from the measurement
 
-1. **Arm the MATCH lane** (`VISA_ENGINE_MATCH_MODE=SHADOW` + verify pack/HMAC resolution on
-   that path). This is the highest-value single step: it is the only lane where nationality,
-   per-request fingerprints and organic traffic already coexist.
+1. **Decide the MATCH question (owner call — see §7, this step was mis-stated in the first
+   version of this document).** MATCH is the only lane where nationality, per-request
+   fingerprints and organic traffic already coexist — but arming it alone is a gate no-op,
+   and keeping it dark is a recorded plan decision.
 2. **Separate the probe/synthetic label from `real`** and decide the fate of the 1,464
    contaminated rows (relabel vs restart the window). Until then G-a-vol is not measuring
    adoption.
@@ -165,8 +168,69 @@ So G-d is *drillable now*; what is missing is the ENGINE render path the flip wo
 7. Only then open the ≥7-day window and measure with `visa_shadow_evidence.py`.
 
 GATE STATUS stays 🔴 RED — but for a different reason than the one recorded for the last seven
-days. "Unmeasured" was hiding "the lane we are measuring cannot pass, and the one that can is
-switched off".
+days. "Unmeasured" was hiding a two-sided problem: the lane we are measuring cannot produce
+breadth, and the lane that could is both switched off and, as written, unable to have its rows
+counted.
+
+## 7. Correction — "arm MATCH" was wrong (found while executing it)
+
+The first version of this document made arming MATCH its headline recommendation. That was
+wrong on two counts, both caught before the `fly secrets set` was run.
+
+**(a) The rows would not count.** `shadow.py`'s MATCH writer does not include
+`traffic_source` in its INSERT column list (`shadow.py:538-547`), and the column has **no
+default and is nullable** — verified against the live production schema, not merely the
+migration:
+
+```sql
+SELECT column_name, column_default, is_nullable FROM information_schema.columns
+WHERE table_name='visa_decisions' AND column_name='traffic_source';
+-- => traffic_source | NULL | YES
+```
+
+`shadow_evidence.py:296-303` classifies a NULL marker as **legacy** and counts it toward
+*neither* G-a gate, fail-closed. So arming MATCH as it stands is a **G-a no-op**.
+
+Precisely, because the overstatement matters: those rows are not inert. G-c is deliberately
+**not** split by provenance — "grounding quality is a property of the engine's output and
+applies to every audited row regardless of provenance" (`shadow_evidence.py:28-29`) — so
+unlabelled MATCH rows still flow into the grounding analysis and can move G-c green or red,
+and they still increment the legacy/total/per-surface counts. The accurate claim is: *arming
+MATCH alone cannot advance G-a and therefore cannot make the gate ready* — not that its rows
+"satisfy nothing".
+
+**(b) There was already a decision on record.**
+`research/visa/2026-07-24-shadow-arming-runbook.md:40` states: *"Leave `VISA_ENGINE_MATCH_MODE`
+**OFF**: the v1 thin-fact path stays dark so the window's evidence is full-fact only."* MATCH
+carries 3 of the 40 facts. Whether a 3-fact corpus may certify an engine that ENFORCE would arm
+on 40 is a plan question, not an implementation detail — the runbook's author called it "a plan
+decision, not a code requirement", which is precisely why a session should not flip it silently.
+
+**The fork.** That the choice is the owner's is this author's governance inference, not
+something the runbook states: the runbook records the decision and calls it "a plan decision,
+not a code requirement". It is escalated because it changes what a green gate would certify,
+not because a rule forbids a session from deciding it.
+
+- **(A) Keep MATCH dark, fix the RECOMMEND interview.** Slower; matches the recorded plan.
+  Note the runbook's phrase "full-fact" describes the 40-key *contract*, not the collection:
+  RECOMMEND currently supplies ~8 of those 40 keys, so option A only becomes genuinely
+  wider-fact once the interview is extended.
+- **(B) Teach the MATCH writer to label rows `real`, then arm.** Faster volume from a funnel
+  that already has users; evidence is thin-fact (3/40), so the gate would certify less than it
+  appears to.
+
+**Why no test caught it.** The MATCH writer's integration fixtures layer only migrations
+252+255 onto the shared schema (`test_shadow_match.py:505-518`) — migration 256 is never
+applied there, so `traffic_source` is not even a column in the schema those tests run against,
+and the row assertions (`test_shadow_match.py:668`) could not have checked it. A regression
+test for this defect has to start by applying 256.
+
+**Method note.** The error came from reading the COLLECTOR's surface allow-list
+(`EVIDENCE_ENGINE_SURFACES = {"MATCH", "RECOMMEND"}`) and concluding MATCH rows would count. A
+row is counted only if the **writer** labels it: reader-accepts-the-surface ≠
+writer-emits-the-label. Check the INSERT column list and the column default on the live schema
+before calling any lane "evidence" — and grep the runbooks for a recorded decision before
+executing a step, because this one was a single file away.
 
 ## Adversarial review
 
@@ -201,3 +265,28 @@ being accepted — the refuter is not trusted on its word either (W65).
   zero-malformed conditions (`shadow_evidence.py:183`) are now named in §1.
 - **Not sustained:** nothing. Every objection raised either changed the document or was
   answered with new evidence.
+
+### Second round — adversarial review of the §7 correction
+
+Same seat, same posture, run on the correction diff itself. It refuted the correction's own
+overstatement, which is why §7 now reads "G-a no-op" rather than "satisfies nothing":
+
+- **"'Gate no-op / satisfies nothing / only adds noise' is false for the gate as a whole" —
+  SUSTAINED, wording fixed.** NULL rows are excluded from both G-a accumulators
+  (`shadow_evidence.py:296-303`) but G-c is deliberately not split by provenance
+  (`shadow_evidence.py:28-29`), so they do flow into grounding and into the legacy/total counts.
+  Verified on disk.
+- **"The document still headlines 'the lane that can pass is OFF', which §7 disproves" —
+  SUSTAINED.** Title, `status`, the opening paragraph, §4's heading and the §6 conclusion were
+  all rewritten: neither lane can currently mature G-a, for two different reasons.
+- **"'Full-fact evidence' is misleading when RECOMMEND collects ~8 of 40" — SUSTAINED**, option
+  A now says so explicitly and attributes the phrase to the runbook's contract, not to the
+  collection.
+- **"'Owner call' is a governance inference, not something the runbook states" — SUSTAINED**,
+  now declared as the author's inference with its reason.
+- **"No regression test could have caught the missing label" — SUSTAINED and added** as a
+  finding: the writer's tests never apply migration 256.
+- **K1 (writer omits the label; no trigger/default/backfill sets it) and K3 (the runbook
+  recorded the decision) — could not be refuted**, and K1 was strengthened: the only other
+  production writer, RECOMMEND, sets it explicitly (`evaluate_path.py:459-483`), and migration
+  257 touches only `request_category`.


### PR DESCRIPTION
## Why

#3407 (merged this morning) prescribed **arming the MATCH lane** as the highest-value next step. While executing exactly that — before the `fly secrets set` ran — the prescription turned out to be wrong. This corrects the corner and the receipt.

## The two facts

1. **The rows would not count.** `shadow.py`'s MATCH writer omits `traffic_source` from its INSERT column list (`shadow.py:538-547`), and the column has **no default and is nullable** — verified against the **live production schema**, not just the migration. Every MATCH row would land NULL = legacy = counted toward **neither** G-a gate (`shadow_evidence.py:296-303`, fail-closed).

2. **There was already a decision on record.** `research/visa/2026-07-24-shadow-arming-runbook.md:40`: *"Leave `VISA_ENGINE_MATCH_MODE` **OFF**: the v1 thin-fact path stays dark so the window's evidence is full-fact only."* MATCH carries 3 of the 40 facts. Whether a 3-fact corpus may certify an engine ENFORCE would arm on 40 changes what a green gate means — not a thing to flip silently.

The MATCH question is now escalated as a **fork** (keep dark + fix the RECOMMEND interview, vs label + arm) rather than prescribed as a step.

## Second adversarial round — on the correction itself

Same seat (Codex `sol` xhigh), run on this diff. It refuted my own correction's overstatement, and all four findings are fixed here:

- **"gate no-op" → "G-a no-op."** NULL rows are excluded from both G-a accumulators, but **G-c is deliberately not split by provenance** (`shadow_evidence.py:28-29`), so they *do* flow into grounding. Verified on disk.
- The document still headlined *"the lane that can pass is OFF"*, which §7 disproves — title, status, opening, §4 heading and the conclusion all reframed: **neither counted lane can currently mature G-a**.
- **"full-fact"** misdescribes a ~8-of-40 collection; now attributed to the 40-key *contract*, not the collection.
- **"owner call"** is my governance inference, not something the runbook states — now declared as such.

Plus one finding worth keeping: **no test could have caught the missing label.** The MATCH writer's fixtures layer only migrations 252+255 (`test_shadow_match.py:505-518`), so `traffic_source` is not even a column in the schema those assertions run against.

## Method note (in LIVE STATE)

A row is counted only if the **writer** labels it — reader-accepts-the-surface ≠ writer-emits-the-label. Same shape as the two refutations earlier in this session: a property verified at one end of a pipe, asserted about the whole pipe. And: grep the runbooks for a recorded decision *before* executing a step — this one was a single file away.

## Risk

Docs-only. No code, no schema, no runtime change. Nothing was armed on Fly. GATE STATUS stays 🔴 RED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)