### PR TITLE
fix(nb-curator): the report was verified by a prompt, and the exit code was always 0

### DIFF
--- a/infra/tg-gateway/grandfathered.json
+++ b/infra/tg-gateway/grandfathered.json
@@ -157,7 +157,6 @@
     "scripts/mini-migration/idempotent-runner.sh",
     "scripts/mini-migration/overlap-detector.sh",
     "scripts/mini/mini-git-pull.sh",
-    "scripts/nb-curator-daily.sh",
     "scripts/nextdns-weekly-digest.sh",
     "scripts/nextdns_tamper_detect.py",
     "scripts/nlm_activation/nlm_shadow_run_all.sh",

--- a/scripts/nb-curator-daily.sh
+++ b/scripts/nb-curator-daily.sh
@@ -24,7 +24,19 @@ unset ANTHROPIC_API_KEY
 unset ANTHROPIC_API_KEY
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
-LOCK_FILE="/tmp/nb-curator.lock"
+# Sibling scripts resolve from THIS file's own directory, never from $HOME: the
+# gate and the notification gateway must be the versions that ship with this
+# wrapper, or the wrapper is verifying itself against a copy it did not bring
+# (superscar #1 — HOME-fork). OUTPUT_DIR deliberately stays $HOME-anchored: the
+# reports belong to the machine's checkout, not to whatever worktree happens to
+# be executing.
+SCRIPT_DIR="${0:A:h}"
+ARTIFACT_GATE="$SCRIPT_DIR/nb_curator_artifact_gate.py"
+TG_NOTIFY="$SCRIPT_DIR/tg_notify.py"
+# Overridable so a test can take its OWN lock instead of the machine-wide one —
+# a test that grabs /tmp/nb-curator.lock would block (or be blocked by) the real
+# 04:00 cron on Pro (W96: tests must never touch production state).
+LOCK_FILE="${NB_CURATOR_LOCK_FILE:-/tmp/nb-curator.lock}"
 LOG="$HOME/logs/nb-curator.log"
 OUTPUT_DIR="$HOME/nuzantara/research/nb-health"
 DEDUP_SCRIPT="$HOME/nuzantara/apps/bali-intel-scraper/scripts/nb_dedup_exact_url.py"
@@ -32,19 +44,57 @@ DATE_STR=$(TZ=Asia/Makassar date +%Y-%m-%d)
 MONTH_STR=$(TZ=Asia/Makassar date +%Y-%m)
 DOW=$(TZ=Asia/Makassar date +%u)   # 1=Mon..7=Sun
 DAY=$(TZ=Asia/Makassar date +%-d)  # day-of-month
-TG_CHAT="1125336968"
+# (TG_CHAT removed: the gateway resolves the destination. A hardcoded chat_id
+# left behind here would read like a knob and change nothing when turned.)
 
 mkdir -p "$HOME/logs" "$OUTPUT_DIR"
 
 # ── flock — prevent overlapping runs ──────────────────────────────────────────
+# `flock` is NOT a macOS builtin — it arrives via homebrew util-linux and is
+# present on Pro (/opt/homebrew/bin/flock) and absent on M5 (measured
+# 2026-07-28). The old form was `flock -n 9 || { log "already running"; exit 0; }`,
+# so on a machine without the binary the 127 took the same branch as a held lock:
+# every run would log "already running, skipping" and exit 0 having done nothing,
+# green and inert (superscar #2 — the guard's own failure is indistinguishable
+# from the state it guards). Missing binary now degrades LOUDLY to an unlocked
+# run; only a genuinely held lock skips.
 exec 9>"$LOCK_FILE"
-flock -n 9 || {
-    echo "$(TZ=Asia/Makassar date '+%Y-%m-%dT%H:%M:%S WITA'): nb-curator already running, skipping" >> "$LOG"
-    exit 0
-}
+if command -v flock >/dev/null 2>&1; then
+    flock -n 9 || {
+        echo "$(TZ=Asia/Makassar date '+%Y-%m-%dT%H:%M:%S WITA'): nb-curator already running, skipping" >> "$LOG"
+        exit 0
+    }
+else
+    echo "$(TZ=Asia/Makassar date '+%Y-%m-%dT%H:%M:%S WITA'): WARN: flock not found — running WITHOUT the overlap lock (brew install util-linux)" >> "$LOG"
+fi
 
 log() { echo "$(TZ=Asia/Makassar date '+%Y-%m-%dT%H:%M:%S WITA'): $*" >> "$LOG"; }
 log "nb-curator-daily started (DOW=$DOW DAY=$DAY)"
+
+# ── Telegram: through the gateway, never a naked curl ─────────────────────────
+# `curl … >/dev/null 2>&1` makes a 401, a wrong chat_id and a delivered message
+# indistinguishable — judge the REPLY, never the exit code (W104) — and it needs
+# TELEGRAM_BOT_TOKEN to already be in this process's environment, which on a
+# launchd cron is exactly the thing that goes missing. tg_notify.py owns the
+# token chain (env -> ~/.nuzantara-secrets.env -> ssh relay -> spool) and never
+# fails its caller; the one thing it cannot do is exist when it is absent, so
+# THAT case is the loud one — an alarm that cannot be delivered still leaves a
+# trace in the log instead of evaporating.
+tg() {  # tg <tier> <text...>
+    local tier="$1"; shift
+    if [ ! -f "$TG_NOTIFY" ]; then
+        log "ALERT NOT SENT — gateway missing at $TG_NOTIFY [$tier]: $*"
+        return 1
+    fi
+    local out rc
+    if out=$(/usr/bin/python3 "$TG_NOTIFY" --tier "$tier" --source nb-curator "$*" 2>&1); then
+        rc=0
+    else
+        rc=$?
+    fi
+    log "tg[$tier] rc=$rc ${out:-<no output>}"
+    return $rc
+}
 
 # ── Step 1: deterministic exact-URL dedup (auto-apply, cap 20) ────────────────
 DEDUP_DELETED=0
@@ -54,9 +104,7 @@ if [ -f "$DEDUP_SCRIPT" ]; then
     DEDUP_DELETED=$(echo "$DEDUP_OUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('deleted',0))" 2>/dev/null || echo 0)
     # cap-exceeded (exit 2) → alert: anomaly, possible matching bug
     if echo "$DEDUP_OUT" | grep -q 'aborted_cap'; then
-        curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            -d "chat_id=${TG_CHAT}" \
-            -d "text=⚠️ nb-curator dedup ABORT: planned deletes > cap 20 (possible matching bug). Check ~/logs/nb-curator.log" >/dev/null 2>&1
+        tg p0 "⚠️ nb-curator dedup ABORT: planned deletes > cap 20 (possible matching bug). Check ~/logs/nb-curator.log"
     fi
 else
     log "WARN: dedup script missing at $DEDUP_SCRIPT"
@@ -76,9 +124,7 @@ if [ "${NB_CURATOR_CHALLENGE_SWEEP_ENABLED:-true}" = "true" ] && [ -f "$DEDUP_SC
     log "challenge-sweep: $SWEEP_OUT"
     CHALLENGE_DELETED=$(echo "$SWEEP_OUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('challenge_deleted',0))" 2>/dev/null || echo 0)
     if echo "$SWEEP_OUT" | grep -q 'aborted_cap'; then
-        curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            -d "chat_id=${TG_CHAT}" \
-            -d "text=⚠️ nb-curator challenge-sweep ABORT: planned deletes > cap 20 (possible title-match bug). Check ~/logs/nb-curator.log" >/dev/null 2>&1
+        tg p0 "⚠️ nb-curator challenge-sweep ABORT: planned deletes > cap 20 (possible title-match bug). Check ~/logs/nb-curator.log"
     fi
 else
     log "challenge-sweep skipped (NB_CURATOR_CHALLENGE_SWEEP_ENABLED!=true or script missing)"
@@ -188,6 +234,28 @@ fi
 log "brain used: $BRAIN_USED (exit=$EXIT)"
 cat "$TMPOUT" >> "$LOG"
 
+# ── Step 3b: ARTIFACT GATE — did the brain actually write the report? ─────────
+# Everything below this line reads the brain's STDOUT. Nothing read the FILE.
+# A run whose brain prints a flawless `SUMMARY:` line and writes no report at all
+# used to land here as "OK — no action/anomaly" with a green cron receipt, and
+# the R1 frontmatter that the prompt mandates verbatim was enforced by nothing
+# but the model's compliance — which measured 3-of-4 on the reports that reached
+# main (2026-07-27 arrived with no frontmatter; PR #3254 merged with the required
+# R1 check RED; #3416 was blocked by it). This step is the deterministic half.
+# `|| GATE_RC=$?` is the errexit-immune capture (W101): a bare assignment aborts
+# the script under `set -e` BEFORE the verdict can be read, which is exactly how
+# a fail-closed branch gets decapitated.
+GATE_RC=0
+if [ -f "$ARTIFACT_GATE" ]; then
+    /usr/bin/python3 "$ARTIFACT_GATE" --report "$REPORT_PATH" --fix >>"$LOG" 2>&1 || GATE_RC=$?
+    log "artifact gate rc=$GATE_RC on $REPORT_PATH"
+else
+    # Not a silent skip: an absent gate means the artifact is unverified, and
+    # "unverified" must never read the same as "verified clean" (superscar #2).
+    GATE_RC=127
+    log "ARTIFACT GATE MISSING at $ARTIFACT_GATE — report NOT verified"
+fi
+
 # ── Step 4: Telegram digest ONLY if action/anomaly ────────────────────────────
 SUMMARY_LINE=$(grep -oE 'SUMMARY: broken=[0-9]+ stale=[0-9]+ proposals=[0-9]+ press_new=[0-9]+' "$TMPOUT" | tail -1)
 rm -f "$TMPOUT"
@@ -197,16 +265,26 @@ PROPOSALS=$(echo "$SUMMARY_LINE" | grep -oE 'proposals=[0-9]+' | cut -d= -f2); P
 
 if [ "$EXIT" -ne 0 ]; then
     log "nb-curator ALL TIERS FAILED (exit=$EXIT)"
-    curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-        -d "chat_id=${TG_CHAT}" \
-        -d "text=⚠️ nb-curator daily FAILED (exit=$EXIT). Log: ~/logs/nb-curator.log" >/dev/null 2>&1
+    tg p0 "⚠️ nb-curator daily FAILED (exit=$EXIT). Log: ~/logs/nb-curator.log"
+elif [ "$GATE_RC" -ne 0 ]; then
+    # The brain said it succeeded and the artifact says otherwise. Believing the
+    # brain here is the whole disease: green receipt, no report.
+    log "nb-curator ARTIFACT GATE FAILED (rc=$GATE_RC) despite brain exit=0"
+    tg p0 "⚠️ nb-curator $DATE_STR: brain OK but the report failed the artifact gate (rc=$GATE_RC) — ${REPORT_PATH##*/}. Log: ~/logs/nb-curator.log"
 elif [ "$DEDUP_DELETED" -gt 0 ] || [ "$CHALLENGE_DELETED" -gt 0 ] || [ "$BROKEN" -gt 0 ] || [ "$PROPOSALS" -gt 0 ]; then
     MSG="🗂 nb-curator $DATE_STR: ${DEDUP_DELETED} exact-dup + ${CHALLENGE_DELETED} challenge removed · ${BROKEN} broken · ${PROPOSALS} proposals. Report: ${REPORT_PATH##*/}"
-    curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-        -d "chat_id=${TG_CHAT}" -d "text=$MSG" >/dev/null 2>&1
-    log "Telegram sent: $MSG"
+    tg digest "$MSG"
 else
     log "nb-curator daily OK — no action/anomaly, no Telegram (dedup=0 challenge=0 broken=0 proposals=0)"
 fi
 
+# The old unconditional `exit 0` made every cron receipt green, including the
+# runs that reported ALL TIERS FAILED two lines above — the receipt is the only
+# thing a downstream watcher reads (W107: five wrapper families write receipts,
+# and a job that never fails is a job nobody ever looks at).
+if [ "$EXIT" -ne 0 ]; then
+    exit 1
+elif [ "$GATE_RC" -ne 0 ]; then
+    exit 2
+fi
 exit 0

--- a/scripts/nb_curator_artifact_gate.py
+++ b/scripts/nb_curator_artifact_gate.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""nb_curator_artifact_gate.py — prove the nb-curator actually WROTE its report,
+and that the artifact carries an R1 declaration the repo's own gate accepts.
+
+WHY THIS EXISTS (measured 2026-07-28, not reasoned)
+---------------------------------------------------
+`nb-curator-daily.sh` mandates the R1 frontmatter *inside the prompt*, verbatim,
+with the reason spelled out to the model ("every prior report missing this failed
+R1 on the PR that harvested it"). That contract is enforced by an LLM's
+compliance and nothing else. Compliance is not total — measured on the reports
+actually on `main`, in the era where the mandate existed:
+
+  2026-07-10 / 07-11 / 07-12 ... mandated block present in the add-commit  (3 ok)
+  2026-07-27 .................... NO frontmatter at all                    (1 miss)
+
+The 07-27 miss is not theoretical: the PR that harvested it (#3254) merged with
+the REQUIRED check "R1 gate — adversarial review present" RED, and the next PR to
+re-harvest the same file (#3416) was blocked by that same gate.
+
+Worse than the missing line: **nothing downstream looks at the artifact at all.**
+The wrapper greps its `SUMMARY:` line out of the brain's STDOUT, never out of the
+report file, and ends on an unconditional `exit 0`. A run whose brain prints a
+perfect SUMMARY and writes no file whatsoever reports "OK — no action/anomaly"
+and leaves a green cron receipt (superscar #2: the receipt is green, the organ
+produced nothing).
+
+WHAT THIS DOES (deterministic; policy, never judgment)
+------------------------------------------------------
+  * report absent / empty / undecodable      -> exit 3, loudly, no write
+  * report present, no frontmatter           -> --fix prepends the exemption block
+  * report present, frontmatter w/o the key  -> --fix inserts the key IN that block
+  * report present, declaration already ok   -> exit 0, file untouched (idempotent)
+  * report present, declaration NOT accepted -> exit 4, file untouched
+
+The last row is the one that matters for honesty: a report carrying
+`adversarial_review: glm` is an ATTESTATION that a seat reviewed it (2026-07-25
+and 07-26 carry exactly that, with a real `## Adversarial review` section written
+by a session). This gate will never overwrite one with a machine exemption —
+downgrading a claimed review to "exempt" would launder a broken attestation into
+a green one. It refuses and says so.
+
+Validity is NOT re-implemented here. It is delegated to
+`scripts/check_adversarial_review.py::evaluate_file` — the very code the required
+CI gate runs. A second, independent notion of "valid R1 frontmatter" would drift
+from the first one and the drift would be invisible (superscar #9).
+
+Exit codes: 0 ok · 2 usage · 3 artifact missing/empty/undecodable ·
+4 present but carries a declaration this gate refuses to touch · 5 needs a fix
+and --fix was not given.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_adversarial_review as r1  # noqa: E402  (path set above, on purpose)
+
+# Kept textually equal to what nb-curator-daily.sh asks the brain for, so a
+# hand-read diff of two reports (one written by the brain, one repaired here)
+# shows nothing. They are NOT coupled for correctness: both are valid because
+# `evaluate_file` says so, and that is the only judge either of them answers to.
+EXEMPT_VALUE = (
+    "exempt-machine-report # nb-curator daily health snapshot "
+    "(generated artifact, not a research deliverable)"
+)
+EXEMPT_LINE = f"adversarial_review: {EXEMPT_VALUE}"
+DELIM = "---"
+
+OK = 0
+USAGE = 2
+MISSING = 3
+REFUSED = 4
+NEEDS_FIX = 5
+
+
+def _split_frontmatter(text: str) -> Tuple[Optional[List[str]], Optional[int]]:
+    """Return (frontmatter_lines, index_of_closing_delimiter).
+
+    (None, None)  -> the file has no frontmatter block at all (line 1 != '---')
+    (lines, None) -> line 1 IS '---' but no closing '---' was found: MALFORMED,
+                     the caller must refuse rather than guess where the header
+                     ends.
+    """
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != DELIM:
+        return None, None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == DELIM:
+            return lines[1:i], i
+    return lines[1:], None
+
+
+def _has_key(fm_lines: List[str]) -> bool:
+    return any(r1.FRONTMATTER_KEY_RE.match(ln.strip()) for ln in fm_lines)
+
+
+def _prepend_block(text: str) -> str:
+    body = text.lstrip("\n")
+    return f"{DELIM}\n{EXEMPT_LINE}\n{DELIM}\n\n{body}"
+
+
+def _insert_key(text: str, close_idx: int) -> str:
+    lines = text.split("\n")
+    lines.insert(close_idx, EXEMPT_LINE)
+    return "\n".join(lines)
+
+
+def evaluate(report: Path) -> Tuple[int, str, Optional[str]]:
+    """Return (exit_code, human_message, repaired_text_or_None).
+
+    Pure: never writes. `repaired_text` is non-None exactly when a --fix run
+    would rewrite the file.
+    """
+    if not report.exists():
+        return (
+            MISSING,
+            f"ARTIFACT MISSING: the brain reported success but wrote no report at {report}",
+            None,
+        )
+    try:
+        raw = report.read_bytes()
+    except OSError as exc:  # unreadable is as bad as absent, and just as silent
+        return MISSING, f"ARTIFACT UNREADABLE: {report}: {exc}", None
+    if not raw.strip():
+        return MISSING, f"ARTIFACT EMPTY: {report} exists but has no content", None
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return REFUSED, f"ARTIFACT NOT UTF-8: {report}: {exc}", None
+
+    fm_lines, close_idx = _split_frontmatter(text)
+
+    if fm_lines is not None and close_idx is None:
+        return (
+            REFUSED,
+            f"MALFORMED FRONTMATTER: {report} opens with '---' and never closes it — "
+            "refusing to guess where the header ends",
+            None,
+        )
+
+    if fm_lines is not None and _has_key(fm_lines):
+        verdict = r1.evaluate_file(report)
+        if verdict.ok:
+            return OK, f"OK: {report.name} already declares — {verdict.reason}", None
+        return (
+            REFUSED,
+            f"DECLARATION PRESENT BUT REJECTED by the R1 gate: {verdict.reason}. "
+            "Refusing to overwrite it: an existing adversarial_review value is an "
+            "attestation that a seat reviewed this file, and replacing it with a "
+            "machine exemption would launder a broken attestation into a green one. "
+            "Fix the declaration (or the missing '## Adversarial review' section) by hand.",
+            None,
+        )
+
+    if fm_lines is None:
+        repaired = _prepend_block(text)
+        what = "no frontmatter block — prepending the machine-report exemption"
+    else:
+        repaired = _insert_key(text, close_idx)
+        what = "frontmatter without adversarial_review — inserting the exemption key"
+
+    return NEEDS_FIX, f"{report.name}: {what}", repaired
+
+
+def _verify_after_write(report: Path) -> Tuple[bool, str]:
+    verdict = r1.evaluate_file(report)
+    return verdict.ok, verdict.reason
+
+
+def run(report: Path, fix: bool) -> int:
+    code, msg, repaired = evaluate(report)
+
+    if code == OK:
+        print(msg)
+        return OK
+    if code in (MISSING, REFUSED):
+        print(msg, file=sys.stderr)
+        return code
+
+    # code == NEEDS_FIX
+    if not fix:
+        print(f"NEEDS FIX (run with --fix): {msg}", file=sys.stderr)
+        return NEEDS_FIX
+
+    assert repaired is not None
+    report.write_text(repaired, encoding="utf-8")
+    ok, reason = _verify_after_write(report)
+    if not ok:
+        # The repair must satisfy the same judge the CI gate uses. If it does
+        # not, saying "fixed" would be the lie this whole file exists to stop.
+        print(
+            f"REPAIR DID NOT SATISFY THE R1 GATE: {report} — {reason}",
+            file=sys.stderr,
+        )
+        return REFUSED
+    print(f"REPAIRED: {msg} — now passes R1 ({reason})")
+    return OK
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--report", required=True, help="path to the report the brain was told to write")
+    p.add_argument(
+        "--fix",
+        action="store_true",
+        help="repair a missing declaration in place (never overwrites an existing one)",
+    )
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    return run(Path(args.report).expanduser(), fix=args.fix)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_nb_curator_artifact_gate.py
+++ b/scripts/tests/test_nb_curator_artifact_gate.py
@@ -1,0 +1,307 @@
+"""Guilt + innocence for the nb-curator artifact gate, and a fake-world proof
+that the wrapper actually WIRES it (W107: a cure you only wrote is not a cure
+you armed — run it in a fake world and watch it bite).
+
+The unit half pins the gate's five verdicts. The wrapper half runs the REAL
+`scripts/nb-curator-daily.sh` with $HOME redirected to tmp and a fake brain
+planted at $HOME/.local/bin/agy, so the whole "brain -> artifact -> alarm ->
+exit code" chain executes without one live nlm call, one Telegram, or one token.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+GATE = REPO / "scripts/nb_curator_artifact_gate.py"
+WRAPPER = REPO / "scripts/nb-curator-daily.sh"
+
+BODY = "# NB Arsenal Health Report — 2026-07-27\n\n## Health Summary\n- Total: 58 notebooks\n"
+MANDATED = (
+    "---\nadversarial_review: exempt-machine-report # nb-curator daily health "
+    "snapshot (generated artifact, not a research deliverable)\n---\n"
+)
+
+MISSING, REFUSED, NEEDS_FIX = 3, 4, 5
+
+
+def _run_gate(report: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(GATE), "--report", str(report), *extra],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+
+
+def _r1_verdict(report: Path) -> subprocess.CompletedProcess:
+    """Ask the REAL required CI gate, not our idea of it.
+
+    `--files` is mandatory (a bare positional exits 2 = argparse usage error,
+    which is NOT a rejection — an early draft of this test read that 2 as "R1
+    rejects it" and its preconditions passed for the wrong reason). And every
+    fixture MUST live under a path containing `research/`: `is_in_scope` silently
+    passes anything else, so a fixture outside it would make these assertions
+    green without the gate ever looking at the file.
+    """
+    assert "research" in report.parts, "fixture is out of R1 scope — the check would be vacuous"
+    return subprocess.run(
+        [sys.executable, str(REPO / "scripts/check_adversarial_review.py"), "--files", str(report)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+
+
+def _report(tmp_path: Path, name: str) -> Path:
+    """A fixture path R1 actually considers in scope."""
+    d = tmp_path / "research" / "nb-health"
+    d.mkdir(parents=True, exist_ok=True)
+    return d / name
+
+
+# --------------------------------------------------------------- GUILT (unit)
+
+
+def test_absent_report_is_a_failure_not_a_shrug(tmp_path):
+    """The disease in one line: the brain printed SUMMARY, wrote nothing, and the
+    old wrapper called that OK."""
+    proc = _run_gate(_report(tmp_path, "2026-07-27-health.md"), "--fix")
+    assert proc.returncode == MISSING
+    assert "ARTIFACT MISSING" in proc.stderr
+    assert "2026-07-27-health.md" in proc.stderr
+
+
+def test_empty_report_is_a_failure(tmp_path):
+    report = _report(tmp_path, "r.md")
+    report.write_text("\n   \n", encoding="utf-8")
+    proc = _run_gate(report, "--fix")
+    assert proc.returncode == MISSING
+    assert "ARTIFACT EMPTY" in proc.stderr
+
+
+def test_report_without_frontmatter_is_repaired_and_then_passes_the_real_r1_gate(tmp_path):
+    """The measured 2026-07-27 case: report written, no frontmatter, PR #3254
+    merged with the required R1 check red."""
+    report = _report(tmp_path, "2026-07-27-curation.md")
+    report.write_text(BODY, encoding="utf-8")
+
+    assert _r1_verdict(report).returncode != 0, "precondition: R1 must reject it before the fix"
+
+    proc = _run_gate(report, "--fix")
+    assert proc.returncode == 0, proc.stderr
+    assert "REPAIRED" in proc.stdout
+
+    fixed = report.read_text(encoding="utf-8")
+    assert fixed.startswith(MANDATED)
+    assert BODY in fixed, "the body must survive the repair byte-for-byte"
+    assert _r1_verdict(report).returncode == 0, "the repair must satisfy the gate that blocks PRs"
+
+
+def test_frontmatter_without_the_key_gets_the_key_inside_the_existing_block(tmp_path):
+    report = _report(tmp_path, "r.md")
+    report.write_text(f"---\ndate: 2026-07-27\ndomain: nb-health\n---\n\n{BODY}", encoding="utf-8")
+
+    assert _run_gate(report, "--fix").returncode == 0
+    fixed = report.read_text(encoding="utf-8")
+
+    assert fixed.count("---\n") == 2, "one frontmatter block, not two stacked ones"
+    assert "date: 2026-07-27" in fixed and "domain: nb-health" in fixed
+    assert "adversarial_review: exempt-machine-report" in fixed
+    assert _r1_verdict(report).returncode == 0
+
+
+def test_a_declaration_the_gate_rejects_is_REFUSED_not_laundered(tmp_path):
+    """`adversarial_review: glm` is an attestation that a seat reviewed this file
+    (2026-07-25 and 07-26 carry exactly that). Overwriting a broken one with a
+    machine exemption would turn a failed review into a green one."""
+    report = _report(tmp_path, "r.md")
+    original = f"---\nadversarial_review: glm\n---\n\n{BODY}"
+    report.write_text(original, encoding="utf-8")
+
+    proc = _run_gate(report, "--fix")
+    assert proc.returncode == REFUSED
+    assert "Refusing to overwrite" in proc.stderr
+    assert report.read_text(encoding="utf-8") == original, "must not touch an attestation"
+
+
+def test_unclosed_frontmatter_is_refused_rather_than_guessed(tmp_path):
+    report = _report(tmp_path, "r.md")
+    original = f"---\ndate: 2026-07-27\n\n{BODY}"
+    report.write_text(original, encoding="utf-8")
+
+    proc = _run_gate(report, "--fix")
+    assert proc.returncode == REFUSED
+    assert "MALFORMED FRONTMATTER" in proc.stderr
+    assert report.read_text(encoding="utf-8") == original
+
+
+# ----------------------------------------------------------- INNOCENCE (unit)
+
+
+def test_a_report_that_already_declares_is_left_byte_identical(tmp_path):
+    report = _report(tmp_path, "r.md")
+    original = f"{MANDATED}\n{BODY}"
+    report.write_text(original, encoding="utf-8")
+
+    proc = _run_gate(report, "--fix")
+    assert proc.returncode == 0
+    assert "already declares" in proc.stdout
+    assert report.read_text(encoding="utf-8") == original
+
+
+def test_a_real_seat_review_with_its_section_survives_untouched(tmp_path):
+    """Innocence for the OTHER valid shape: a session did review it."""
+    report = _report(tmp_path, "r.md")
+    original = (
+        f"---\nadversarial_review: glm\n---\n\n{BODY}\n"
+        "## Adversarial review\n\nSeat: GLM, probed live before dispatch.\n"
+    )
+    report.write_text(original, encoding="utf-8")
+
+    proc = _run_gate(report, "--fix")
+    assert proc.returncode == 0
+    assert report.read_text(encoding="utf-8") == original
+
+
+def test_fix_is_idempotent(tmp_path):
+    report = _report(tmp_path, "r.md")
+    report.write_text(BODY, encoding="utf-8")
+
+    assert _run_gate(report, "--fix").returncode == 0
+    once = report.read_text(encoding="utf-8")
+    assert _run_gate(report, "--fix").returncode == 0
+    assert report.read_text(encoding="utf-8") == once
+
+
+def test_check_mode_never_writes(tmp_path):
+    report = _report(tmp_path, "r.md")
+    report.write_text(BODY, encoding="utf-8")
+
+    proc = _run_gate(report)  # no --fix
+    assert proc.returncode == NEEDS_FIX
+    assert report.read_text(encoding="utf-8") == BODY
+
+
+# ------------------------------------------------------- FAKE WORLD (wrapper)
+
+FAKE_AGY = """#!/usr/bin/env python3
+# Fake brain. Reads the prompt on stdin, obeys FAKE_AGY_MODE, prints a SUMMARY.
+import os, re, sys, pathlib
+
+prompt = sys.stdin.read()
+mode = os.environ.get("FAKE_AGY_MODE", "good")
+m = re.search(r"Write report to: (\\S+)", prompt)
+if m and mode != "noreport":
+    p = pathlib.Path(m.group(1))
+    p.parent.mkdir(parents=True, exist_ok=True)
+    body = "# NB Arsenal Health Report\\n\\n## Health Summary\\n- Total: 58 notebooks\\n"
+    if mode == "good":
+        body = ("---\\nadversarial_review: exempt-machine-report # nb-curator daily "
+                "health snapshot (generated artifact, not a research deliverable)\\n"
+                "---\\n\\n") + body
+    p.write_text(body, encoding="utf-8")
+
+print("SUMMARY: broken=0 stale=0 proposals=0 press_new=0")
+"""
+
+
+def _fake_world(tmp_path: Path, mode: str, *, wrapper: Path) -> subprocess.CompletedProcess:
+    home = tmp_path / "home"
+    (home / ".local/bin").mkdir(parents=True)
+    (home / "scripts").mkdir(parents=True)
+    (home / "logs").mkdir(parents=True)
+
+    agy = home / ".local/bin/agy"
+    agy.write_text(FAKE_AGY, encoding="utf-8")
+    agy.chmod(0o755)
+
+    cascade = home / "scripts/claude-cascade.sh"
+    cascade.write_text("#!/bin/sh\necho 'SUMMARY: broken=0 stale=0 proposals=0 press_new=0'\n")
+    cascade.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        HOME=str(home),
+        FAKE_AGY_MODE=mode,
+        NB_CURATOR_LOCK_FILE=str(tmp_path / "nb-curator.lock"),
+        TG_DRY_RUN="1",
+        TG_SPOOL_DIR=str(tmp_path / "spool"),
+        TELEGRAM_BOT_TOKEN="fake-token-never-sent",
+        TELEGRAM_OWNER_CHAT_ID="0",
+    )
+    return subprocess.run([shutil.which("zsh") or "/bin/zsh", str(wrapper)],
+                          capture_output=True, text=True, env=env, timeout=180)
+
+
+def _log(tmp_path: Path) -> str:
+    p = tmp_path / "home/logs/nb-curator.log"
+    return p.read_text(encoding="utf-8") if p.exists() else ""
+
+
+def _spooled(tmp_path: Path) -> str:
+    spool = tmp_path / "spool"
+    if not spool.exists():
+        return ""
+    return "\n".join(f.read_text(encoding="utf-8") for f in spool.glob("*.jsonl"))
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="wrapper is a zsh script")
+def test_wrapper_FAILS_when_the_brain_writes_no_report(tmp_path):
+    """The exact run the old wrapper called OK: brain exit 0, SUMMARY printed,
+    no artifact. Now: rc=2, a P0 in the spool, and the reason in the log."""
+    proc = _fake_world(tmp_path, "noreport", wrapper=WRAPPER)
+    log = _log(tmp_path)
+
+    assert proc.returncode == 2, f"expected artifact-gate exit 2, got {proc.returncode}\n{log}"
+    assert "ARTIFACT GATE FAILED" in log
+    assert "artifact gate rc=3" in log, "rc=3 is 'the report was never written'"
+    assert "brain OK but the report failed the artifact gate" in _spooled(tmp_path)
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="wrapper is a zsh script")
+def test_wrapper_REPAIRS_a_report_written_without_the_mandated_frontmatter(tmp_path):
+    proc = _fake_world(tmp_path, "nofrontmatter", wrapper=WRAPPER)
+    log = _log(tmp_path)
+    assert proc.returncode == 0, f"a repairable report is not a failure\n{log}"
+
+    reports = list((tmp_path / "home/nuzantara/research/nb-health").glob("*.md"))
+    assert len(reports) == 1, f"expected exactly one report, got {reports}"
+    assert _r1_verdict(reports[0]).returncode == 0, "the wrapper must leave an R1-clean artifact"
+    assert "artifact gate rc=0" in log
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="wrapper is a zsh script")
+def test_wrapper_is_silent_and_green_on_a_compliant_run(tmp_path):
+    """Innocence: the happy path must not start alarming."""
+    proc = _fake_world(tmp_path, "good", wrapper=WRAPPER)
+    log = _log(tmp_path)
+    assert proc.returncode == 0, log
+    assert "no action/anomaly" in log
+    assert "ARTIFACT GATE FAILED" not in log
+    assert _spooled(tmp_path) == "", "a clean run must send nothing"
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="wrapper is a zsh script")
+def test_a_missing_gate_and_a_missing_gateway_both_leave_a_TRACE(tmp_path):
+    """Copy the wrapper somewhere with no siblings: the artifact goes unverified
+    and the alarm cannot be delivered. Neither may look like success — an alarm
+    guarded by an `if` that merely does nothing is the failure mode this whole
+    change exists to remove."""
+    lonely = tmp_path / "lonely"
+    lonely.mkdir()
+    copy = lonely / "nb-curator-daily.sh"
+    shutil.copy2(WRAPPER, copy)
+
+    proc = _fake_world(tmp_path, "good", wrapper=copy)
+    log = _log(tmp_path)
+
+    assert proc.returncode == 2, log
+    assert "ARTIFACT GATE MISSING" in log
+    assert "ALERT NOT SENT — gateway missing" in log


### PR DESCRIPTION
## What bit

`scripts/nb-curator-daily.sh` asks the brain, **verbatim inside `MODE_PROMPT`**, for the three-line R1 exemption frontmatter — and then nothing checks. Enforcement was the model's compliance. Measured on the reports that actually reached `main`, in the era where the mandate existed:

| report | mandated block in the add-commit |
|---|---|
| 2026-07-10 / 07-11 / 07-12 | present |
| **2026-07-27** | **absent** |

That miss is not cosmetic. PR **#3254** carried it to main with the required check *"R1 gate — adversarial review present"* **RED**, and **#3416** was blocked by that same gate when it re-harvested the file.

Underneath sat the bigger hole: **every downstream step reads the brain's STDOUT and none reads the FILE.** `SUMMARY_LINE` is grepped out of `$TMPOUT`, so a run whose brain prints a flawless `SUMMARY:` and writes no report at all logged `OK — no action/anomaly` and — thanks to an unconditional `exit 0` on the last line — left a **green cron receipt**. Superscar #2: the receipt says the organ worked, the organ produced nothing.

## Cure (deterministic, no judgment)

- **`scripts/nb_curator_artifact_gate.py`** — asserts the artifact EXISTS, repairs a missing declaration in place, and **refuses to touch an existing one**. That last rule is load-bearing: 07-25 and 07-26 carry `adversarial_review: glm` with a real `## Adversarial review` section a *session* wrote, and overwriting a broken attestation with a machine exemption would launder a failed review into a green one.
  Validity is **not re-implemented** — it is delegated to `check_adversarial_review.evaluate_file`, the same code the required CI gate runs, so the two can never drift (#9).
- **Honest exit code** — 1 on brain failure, 2 on artifact failure. The receipt is the only thing a downstream watcher reads (W107).
- **Three naked `curl … >/dev/null 2>&1` → `scripts/tg_notify.py`**, and the file leaves the tg-gateway grandfather register: **174 → 173**. A naked curl needs `TELEGRAM_BOT_TOKEN` already in the process env — on a launchd cron, exactly what goes missing — and makes a 401 indistinguishable from a delivered message (W104).
- **flock** — `flock -n 9 || skip` treated a **missing binary** the same as a held lock. `flock` is homebrew-only on macOS: present on Pro (`/opt/homebrew/bin/flock`), **absent on M5** (measured). Running this wrapper on M5 would have logged *"already running, skipping"* and exited 0 forever. Missing binary now degrades **loudly** to an unlocked run.

## Proof

**14 tests, guilt + innocence, mutation-verified.**

| mutation | result |
|---|---|
| gate neutered (`return OK` first line) | **10 of 14 fail** |
| unconditional `exit 0` restored | **exactly the 2 that assert the exit code fail** |
| both restored | 14/14 green, sha256-verified restore |

Four tests run the **real wrapper in a fake world** — `$HOME` on tmp, a fake brain at `$HOME/.local/bin/agy` that parses the report path out of the prompt it is given, `TG_DRY_RUN=1`, its own lock file. No live `nlm` call, no Telegram, no token, zero P0 budget.

Every fixture lives under a path containing `research/`, because `is_in_scope` silently passes anything else. An early draft of this test asserted against a bare positional arg and read argparse's exit 2 as *"R1 rejects it"* — a precondition that passed for the wrong reason. Both traps are pinned in the test's own docstring.

## Not in scope

The 18 other cron wrappers whose alarm sits inside `if [ -n "$TOKEN" ]` (task #39) — this PR converts only the file it touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)