### PR TITLE
fix(nb-curator): the gate would have stamped "not a research deliverable" on a research deliverable

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -75,6 +75,8 @@ jobs:
               scripts/lint_plist_keepalive.py|\
               scripts/arsenal_probe.py|\
               scripts/check_adversarial_review.py|\
+              scripts/nb_curator_artifact_gate.py|\
+              scripts/tests/test_nb_curator_artifact_gate.py|\
               scripts/jules_dispatch.py|\
               scripts/lint_test_reward_hacking.py|\
               scripts/test_lint_test_reward_hacking.py|\
@@ -183,6 +185,7 @@ jobs:
             scripts/tests/test_lint_plist_keepalive.py \
             scripts/tests/test_arsenal_probe.py \
             scripts/tests/test_adversarial_review_gate.py \
+            scripts/tests/test_nb_curator_artifact_gate.py \
             scripts/tests/test_jules_dispatch.py \
             scripts/tests/test_codex_autofix_selector.py \
             scripts/tests/test_tri_llm_claude_seat_token.py \

--- a/research/nb-health/2026-05-22-health.md
+++ b/research/nb-health/2026-05-22-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-05-22 (weekly)
 
 > Mode B run by nb-curator agent. Read-only — no NB mutations.

--- a/research/nb-health/2026-05-29-health.md
+++ b/research/nb-health/2026-05-29-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-05-29 (daily run)
 
 > Mode B + Mode C run by nb-curator agent. Read-only — no NB mutations.

--- a/research/nb-health/2026-05-31-health.md
+++ b/research/nb-health/2026-05-31-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-05-31 (daily)
 
 > Mode B+C run by nb-curator agent. Read-only — no NB mutations.

--- a/research/nb-health/2026-06-10-health.md
+++ b/research/nb-health/2026-06-10-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-06-10 (daily)
 
 > Mode B+C run by nb-curator agent. Read-only — no NB mutations.

--- a/research/nb-health/2026-06-11-health.md
+++ b/research/nb-health/2026-06-11-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-06-11 (daily)
 
 > Mode B+C run by nb-curator agent. Read-only — no NB mutations.

--- a/research/nb-health/2026-06-12-health.md
+++ b/research/nb-health/2026-06-12-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-06-12 (daily)
 
 > Mode B+C run by nb-curator agent. Read-only — no NB mutations.

--- a/research/nb-health/2026-06-13-health.md
+++ b/research/nb-health/2026-06-13-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-06-13 (daily)
 
 > Mode B+C run by nb-curator agent. Read-only — no NB mutations.

--- a/research/nb-health/2026-06-14-health.md
+++ b/research/nb-health/2026-06-14-health.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report — 2026-06-14 (daily)
 
 > Mode B+C run by nb-curator agent. Read-only — no NB mutations.

--- a/research/nb-health/2026-06-15-curation.md
+++ b/research/nb-health/2026-06-15-curation.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health Report + Mode C Curation — 2026-06-15
 
 **Run**: 2026-06-15 ~05:30 WITA | Mode B (full) + Mode C (Monday full pass)

--- a/research/nb-health/2026-07-27-curation.md
+++ b/research/nb-health/2026-07-27-curation.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)
+---
+
 # NB Arsenal Health + Curation Report — 2026-07-27 (daily + Mode C full pass)
 
 ## Health Summary

--- a/scripts/nb_curator_artifact_gate.py
+++ b/scripts/nb_curator_artifact_gate.py
@@ -52,6 +52,7 @@ and --fix was not given.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -70,6 +71,32 @@ EXEMPT_VALUE = (
 )
 EXEMPT_LINE = f"adversarial_review: {EXEMPT_VALUE}"
 DELIM = "---"
+
+# The exemption above is not a formality — it is a CLAIM about the document:
+# "generated artifact, not a research deliverable". Stamping it on a document
+# that is a deliverable makes this gate write something false, and the R1 gate
+# then passes it on that false basis.
+#
+# Not hypothetical. research/nb-health/ is the curator's OUTPUT directory, and
+# it also holds 2026-05-28-nb3-kbli-corrections.md — a human-facing correction
+# report on KBLI 2025, verified against a 623-page primary source, carrying an
+# explicit "decision → operator" line. It has frontmatter without the R1 key,
+# which is precisely the shape --fix rewrites. A backfill over the directory
+# would have stamped "generated artifact" on it, and been green.
+#
+# So: judge the DOCUMENT, never its location (superscar #3 — location is a form,
+# deliverable-ness is the entity). The research-capture convention (CLAUDE.md
+# §15) makes these keys mandatory for a real deliverable and absent from a
+# machine snapshot, so their presence is the discriminator.
+#
+# LIMIT, declared: this can only see a document that HAS frontmatter. A
+# deliverable with no frontmatter at all is indistinguishable from a health
+# snapshot here and would still be stamped. The live path is unaffected (the
+# wrapper passes the one report it just wrote); the exposure is bulk/backfill
+# runs, where the operator reads the refusals.
+DELIVERABLE_KEY_RE = re.compile(
+    r"^\s*(sources|client_case|discovered_by)\s*:", re.IGNORECASE
+)
 
 OK = 0
 USAGE = 2
@@ -142,6 +169,19 @@ def evaluate(report: Path) -> Tuple[int, str, Optional[str]]:
             "refusing to guess where the header ends",
             None,
         )
+
+    if fm_lines is not None and not _has_key(fm_lines):
+        claimed = [ln.split(":", 1)[0].strip() for ln in fm_lines if DELIVERABLE_KEY_RE.match(ln)]
+        if claimed:
+            return (
+                REFUSED,
+                f"REFUSING TO EXEMPT {report.name}: its frontmatter declares "
+                f"{', '.join(sorted(set(claimed)))} — that is a research deliverable, and the "
+                "machine exemption asserts the opposite ('generated artifact, not a research "
+                "deliverable'). Stamping it would make this gate write a false statement and the "
+                "R1 gate pass on it. It needs a real adversarial review, by a seat, by hand.",
+                None,
+            )
 
     if fm_lines is not None and _has_key(fm_lines):
         verdict = r1.evaluate_file(report)

--- a/scripts/tests/test_nb_curator_artifact_gate.py
+++ b/scripts/tests/test_nb_curator_artifact_gate.py
@@ -117,6 +117,44 @@ def test_frontmatter_without_the_key_gets_the_key_inside_the_existing_block(tmp_
     assert _r1_verdict(report).returncode == 0
 
 
+def test_a_research_deliverable_is_REFUSED_not_stamped_as_a_machine_artifact(tmp_path):
+    """The exemption CLAIMS "generated artifact, not a research deliverable". On a
+    document that cites sources that claim is false, and the R1 gate would then
+    pass it on a false basis.
+
+    Shape taken from the real one: research/nb-health/2026-05-28-nb3-kbli-corrections.md
+    is a human correction report verified against a 623-page primary source, sitting
+    in the curator's own OUTPUT directory with frontmatter but no R1 key — exactly
+    the shape --fix rewrites. Judged by location it is a machine artifact; judged by
+    what it IS, it is not.
+    """
+    report = _report(tmp_path, "r.md")
+    original = (
+        "---\ndate: 2026-05-28\ndomain: nb-health\ntype: correction-report\n"
+        "discovered_by: deep-researcher\nsources:\n  - PRIMARY: Peraturan BPS 7/2025\n"
+        f"---\n\n{BODY}"
+    )
+    report.write_text(original, encoding="utf-8")
+
+    proc = _run_gate(report, "--fix")
+    assert proc.returncode == REFUSED
+    assert "REFUSING TO EXEMPT" in proc.stderr
+    assert "sources" in proc.stderr and "discovered_by" in proc.stderr
+    assert report.read_text(encoding="utf-8") == original, "a deliverable must not be stamped"
+
+
+def test_a_plain_health_snapshot_is_still_repaired(tmp_path):
+    """Innocence for the refusal above: the discriminator must not swallow the
+    ordinary case the gate exists for — frontmatter, no R1 key, no deliverable
+    markers — or the refusal has quietly disarmed the whole organ."""
+    report = _report(tmp_path, "r.md")
+    report.write_text(f"---\ndate: 2026-07-27\ndomain: nb-health\n---\n\n{BODY}", encoding="utf-8")
+
+    assert _run_gate(report, "--fix").returncode == 0
+    assert "adversarial_review: exempt-machine-report" in report.read_text(encoding="utf-8")
+    assert _r1_verdict(report).returncode == 0
+
+
 def test_a_declaration_the_gate_rejects_is_REFUSED_not_laundered(tmp_path):
     """`adversarial_review: glm` is an attestation that a seat reviewed this file
     (2026-07-25 and 07-26 carry exactly that). Overwriting a broken one with a


### PR DESCRIPTION
## What bit

#3418 (merged today) gave the nb-curator a gate that repairs its daily report so it passes the required R1 check. Proving it live on Pro, I ran it across the curator's whole output directory. It handled 15 of 16 files correctly.

The 16th is `research/nb-health/2026-05-28-nb3-kbli-corrections.md` — **not a health snapshot**. It is a human correction report on KBLI 2025, verified against a 623-page primary source (Peraturan BPS 7/2025), carrying `sources:`, `discovered_by:`, and an explicit *"Decisione su correzione → operatore"* line.

It has frontmatter without the R1 key — exactly the shape `--fix` rewrites. The gate would have written into it:

> `adversarial_review: exempt-machine-report # nb-curator daily health snapshot (generated artifact, not a research deliverable)`

…and the required R1 gate would then have passed it **on that false statement**. Superscar #3 on a gate shipped yesterday: it judged the file by **where it lives**, not by **what it is**.

## Cure

Refuse (exit 4, file untouched) any document whose frontmatter declares `sources` / `client_case` / `discovered_by` — the keys `CLAUDE.md` §15 makes mandatory for a real deliverable and that a machine snapshot never carries. Same refusal shape the gate already had for an existing attestation, one class wider.

**Limit, declared in the code:** this only sees documents that *have* frontmatter. A deliverable with none is still indistinguishable from a snapshot. The live path was never exposed (the wrapper passes the single report it just wrote); bulk/backfill is.

## Backfill it can honestly do

10 of 16 reports carried no R1 declaration at all — every one a latent block on any future PR that touches it, failing on a file that PR did not break. Repaired **by the organ itself**, not by hand. 5 were already compliant. 1 is the refusal above and stays untouched: it needs a real adversarial review by a seat, and fabricating one here is the exact laundering this PR adds a guard against. Tracked, not silently dropped.

## Arming

The gate's 16 tests ran only in `scripts/tests/ sweep` — `continue-on-error: true`, in no required check. A guard whose only executor cannot go red is the "exists ≠ armed" shape it was written to catch. Added to `immune-enforcement`'s guilt+innocence loop **and** its sentinel paths (the trigger-symmetry test that exists for exactly this mistake is green).

## Verification

- new refusal: guilt (real-world shape → exit 4, byte-identical file) + innocence (a plain snapshot is still repaired)
- 16/16 tests pass; `actionlint` + trigger-symmetry green
- run against the real file: refused, untouched, message names `sources, discovered_by`
- after backfill, R1 over the directory fails on exactly one file — the deliverable, correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)