### PR TITLE
fix(portal): arm operative-light theme + keyboard focus indicator

### DIFF
--- a/apps/mouth/src/app/globals.css
+++ b/apps/mouth/src/app/globals.css
@@ -428,6 +428,13 @@
   --kbli-text-muted: #7a8aa6;
   --kbli-border: rgba(9, 9, 11, 0.08);
   --kbli-border-hover: rgba(9, 9, 11, 0.14);
+
+  /* Focus indicator — universal keyboard navigation (WCAG 2.1.1 + 2.4.7)
+     Scoped to operative-light only — cannot leak into kita/dark theme. */
+  *:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
 }
 
 /* ───────────────────────────────────────────────────────────────────────────

--- a/apps/mouth/src/app/portal/(authenticated)/layout.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/layout.tsx
@@ -36,6 +36,17 @@ export default function PortalLayout({
     avatar: undefined as string | undefined,
   });
 
+  // Arm operative-light theme: sets data-theme on <html> so the
+  // [data-theme="operative-light"] block in globals.css activates.
+  // Without this, :root dark values apply (--tx-pure: #ffffff → invisible
+  // on cream background, WCAG contrast 1.05:1).
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", "operative-light");
+    return () => {
+      document.documentElement.removeAttribute("data-theme");
+    };
+  }, []);
+
   // Load user profile
   // Uses portal-scoped endpoint (/api/portal/profile) because /api/auth/profile
   // 500s for role=client — see commit history. Falls back to storedProfile name


### PR DESCRIPTION
## 1. Insight
Portal rendered with dark :root CSS tokens despite being a light-surface domain. The `[data-theme="operative-light"]` block in globals.css was never activated because no code set the attribute on `<html>`. Result: `--tx-pure` resolved to `#ffffff` (white on cream, 1.05:1 contrast) and no universal focus ring existed.

## 2. Studio
No visual change to anonymous visitors — portal requires auth. Authenticated users on `my.balizero.com/portal/*` will see: (a) all text previously invisible (#ffffff on cream) now renders in navy #16213a, and (b) a copper outline ring on every focused interactive element during keyboard navigation. Scoped to `[data-theme="operative-light"]` — cannot affect kita. Files: `apps/mouth/src/app/portal/(authenticated)/layout.tsx` + `apps/mouth/src/app/globals.css`. Zone: VERDE.

## 3. Source
- globals.css L282 + L339–431: token definitions confirmed via grep
- layout.tsx: zero existing data-theme logic confirmed via grep
- UI/UX Audit my.balizero.com/portal (28 Jul 2026)

## 4. Methodology
Token trace diagnosis: --tx-pure correctly defined under operative-light but selector never activated. Fix at layout level via single useEffect (mount/unmount) — avoids touching 20+ component files. Focus ring added as universal CSS rule scoped to same theme block.

## 5. Raw Observations
- grep: --tx-pure has two values — :root #ffffff, operative-light #16213a
- grep: zero data-theme references in layout.tsx before fix
- .focus-ring at L804 is opt-in utility class, not universal selector
- Pre-existing ESLint 10.3.0 tooling error unrelated to this PR

## 6. Reasoning Path
No data-theme set → operative-light block inactive → --tx-pure = #ffffff → white text on cream → 1.05:1 contrast (WCAG fail). Fix: setAttribute on mount, removeAttribute on unmount prevents bleed to non-portal routes.

## 7. Risk
Low. useEffect cleanup prevents attribute bleed. Scoped CSS cannot affect kita.balizero.com. Build verified clean (1752 static pages generated, TypeScript pass).

## 8. Implication
Fixes two WCAG failures simultaneously: 1.4.3 (contrast minimum) and 2.4.7 (focus visible). No backend changes. No new lead sources. No CI parity concern.

## 9. Recommendation
Merge immediately — both issues severity KRITIS per audit, due 2026-07-29, zero blast radius.

## 10. Next Action
After merge: DevTools Elements → html tag must show data-theme=operative-light. Tab 5x through Settings page — copper ring must appear on every focused element.