### PR TITLE
feat(admin-dashboard): invite to portal button [GIALLO]

### DIFF
--- a/apps/admin-dashboard/app/api/portal/invite/route.ts
+++ b/apps/admin-dashboard/app/api/portal/invite/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const authHeader = request.headers.get("authorization") ?? "";
+    const cookieHeader = request.headers.get("cookie") ?? "";
+
+    const res = await fetch(`${BACKEND_URL}/api/portal/invite/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(authHeader ? { authorization: authHeader } : {}),
+        ...(cookieHeader ? { cookie: cookieHeader } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    logger.error("Portal invite proxy error:", error);
+    return NextResponse.json(
+      { error: "Failed to send invitation" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const clientId = searchParams.get("clientId");
+    if (!clientId) {
+      return NextResponse.json({ error: "clientId required" }, { status: 400 });
+    }
+
+    const authHeader = request.headers.get("authorization") ?? "";
+    const cookieHeader = request.headers.get("cookie") ?? "";
+
+    const res = await fetch(
+      `${BACKEND_URL}/api/portal/invite/client/${clientId}`,
+      {
+        headers: {
+          ...(authHeader ? { authorization: authHeader } : {}),
+          ...(cookieHeader ? { cookie: cookieHeader } : {}),
+        },
+      },
+    );
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    logger.error("Portal invite history proxy error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch invite history" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin-dashboard/app/clients/page.tsx
+++ b/apps/admin-dashboard/app/clients/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Users,
+  Search,
+  RefreshCw,
+  ChevronLeft,
+  ChevronRight,
+  Mail,
+} from "lucide-react";
+import { Button, Badge } from "@/components/ui/primitives";
+import { InviteClientButton } from "@/components/InviteClientButton";
+import { logger } from "@/lib/logger";
+
+interface ClientRow {
+  id: number;
+  full_name?: string;
+  email?: string;
+  phone?: string;
+  status?: string;
+  created_at?: string;
+  [key: string]: unknown;
+}
+
+export default function ClientsPage() {
+  const [clients, setClients] = useState<ClientRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const fetchClients = async (p = 1) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/postgres/query?table=clients&page=${p}`);
+      const data = await res.json();
+      setClients(data.rows ?? []);
+    } catch (e) {
+      logger.error("Failed to fetch clients:", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchClients(page);
+  }, [page]);
+
+  const filtered = search.trim()
+    ? clients.filter((c) => {
+        const q = search.toLowerCase();
+        return (
+          c.full_name?.toLowerCase().includes(q) ||
+          c.email?.toLowerCase().includes(q) ||
+          String(c.id).includes(q)
+        );
+      })
+    : clients;
+
+  return (
+    <div className="flex flex-col h-screen overflow-hidden">
+      <div className="border-b p-4 flex items-center justify-between bg-background">
+        <div className="flex items-center gap-3">
+          <Users className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-bold tracking-tight">Clients</h1>
+            <p className="text-xs text-muted-foreground">
+              Manage portal invitations for clients
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <input
+              className="bg-background border rounded-md pl-9 pr-4 py-2 text-sm focus:ring-2 focus:ring-primary focus:outline-none w-64"
+              placeholder="Search by name, email, or ID..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fetchClients(page)}
+          >
+            <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+          </Button>
+          <div className="flex items-center gap-1 border rounded-md">
+            <Button
+              variant="ghost"
+              size="icon"
+              disabled={page <= 1}
+              onClick={() => setPage(page - 1)}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm px-2 min-w-[3rem] text-center">
+              Pg {page}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setPage(page + 1)}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto p-4">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            Loading clients...
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            {search ? "No clients match your search." : "No clients found."}
+          </div>
+        ) : (
+          <div className="rounded-md border">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm text-left">
+                <thead className="bg-muted/50 sticky top-0 z-10 shadow-sm">
+                  <tr className="border-b">
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      ID
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      Name
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      Email
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      Status
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      Created
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      <div className="flex items-center gap-1">
+                        <Mail className="h-3 w-3" /> Portal Invite
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {filtered.map((client) => (
+                    <tr
+                      key={client.id}
+                      className="hover:bg-muted/30 transition-colors"
+                    >
+                      <td className="p-4 font-mono text-xs text-muted-foreground">
+                        {client.id}
+                      </td>
+                      <td className="p-4 font-medium">
+                        {client.full_name ?? "—"}
+                      </td>
+                      <td className="p-4 text-muted-foreground">
+                        {client.email ?? "—"}
+                      </td>
+                      <td className="p-4">
+                        {client.status ? (
+                          <Badge variant="outline" className="text-xs">
+                            {client.status}
+                          </Badge>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="p-4 text-xs text-muted-foreground whitespace-nowrap">
+                        {client.created_at
+                          ? new Date(client.created_at).toLocaleDateString()
+                          : "—"}
+                      </td>
+                      <td className="p-4">
+                        {client.email ? (
+                          <InviteClientButton
+                            clientId={client.id}
+                            clientEmail={client.email}
+                            clientName={client.full_name}
+                          />
+                        ) : (
+                          <span className="text-xs text-muted-foreground italic">
+                            No email
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-dashboard/components/InviteClientButton.tsx
+++ b/apps/admin-dashboard/components/InviteClientButton.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Send,
+  RotateCcw,
+  CheckCircle,
+  AlertCircle,
+  Loader2,
+} from "lucide-react";
+import { Button, Badge } from "@/components/ui/primitives";
+import { cn } from "@/lib/utils";
+import { logger } from "@/lib/logger";
+
+interface Invitation {
+  id: number;
+  status: "pending" | "used" | "expired";
+  created_at: string;
+  email: string;
+}
+
+interface InviteClientButtonProps {
+  clientId: number;
+  clientEmail: string;
+  clientName?: string;
+}
+
+type ButtonState = "idle" | "loading" | "success" | "error" | "already_sent";
+
+const STATUS_COLORS: Record<Invitation["status"], string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  used: "bg-green-100 text-green-800",
+  expired: "bg-red-100 text-red-800",
+};
+
+export function InviteClientButton({
+  clientId,
+  clientEmail,
+}: InviteClientButtonProps) {
+  const [state, setState] = useState<ButtonState>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [historyLoaded, setHistoryLoaded] = useState(false);
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      try {
+        const res = await fetch(`/api/portal/invite?clientId=${clientId}`);
+        if (res.ok) {
+          const data = await res.json();
+          const list: Invitation[] = data?.data ?? [];
+          setInvitations(list);
+          if (list.some((i) => i.status === "pending"))
+            setState("already_sent");
+        }
+      } catch (e) {
+        logger.error("Failed to load invite history", e);
+      } finally {
+        setHistoryLoaded(true);
+      }
+    };
+    fetchHistory();
+  }, [clientId]);
+
+  const sendInvite = async () => {
+    setState("loading");
+    setErrorMsg(null);
+    try {
+      const res = await fetch("/api/portal/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id: clientId, email: clientEmail }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.detail ?? data.error ?? "Unknown error");
+      }
+      setState("success");
+      const histRes = await fetch(`/api/portal/invite?clientId=${clientId}`);
+      if (histRes.ok) {
+        const histData = await histRes.json();
+        setInvitations(histData?.data ?? []);
+      }
+      setTimeout(() => setState("already_sent"), 3000);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to send invitation";
+      logger.error("Invite send failed:", e);
+      setErrorMsg(msg);
+      setState("error");
+      setTimeout(
+        () =>
+          setState(
+            invitations.some((i) => i.status === "pending")
+              ? "already_sent"
+              : "idle",
+          ),
+        4000,
+      );
+    }
+  };
+
+  if (!historyLoaded) {
+    return (
+      <Button variant="outline" size="sm" disabled>
+        <Loader2 className="h-3 w-3 animate-spin mr-1" />
+        <span className="text-xs">Loading...</span>
+      </Button>
+    );
+  }
+
+  if (invitations.some((i) => i.status === "used")) {
+    return (
+      <Badge className="bg-green-100 text-green-800 text-xs">
+        <CheckCircle className="h-3 w-3 mr-1" />
+        Portal Active
+      </Badge>
+    );
+  }
+
+  if (state === "success") {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        disabled
+        className="text-green-700 border-green-300"
+      >
+        <CheckCircle className="h-3 w-3 mr-1" />
+        <span className="text-xs">Invite Sent!</span>
+      </Button>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <div className="flex flex-col gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={sendInvite}
+          className="text-red-700 border-red-300"
+        >
+          <AlertCircle className="h-3 w-3 mr-1" />
+          <span className="text-xs">Retry</span>
+        </Button>
+        {errorMsg && (
+          <span className="text-[10px] text-red-600 max-w-[180px] truncate">
+            {errorMsg}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (state === "already_sent") {
+    return (
+      <div className="flex items-center gap-2">
+        <Badge className={cn("text-xs", STATUS_COLORS.pending)}>Pending</Badge>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={sendInvite}
+          title="Resend invite"
+        >
+          <RotateCcw className="h-3 w-3" />
+          <span className="text-xs ml-1">Resend</span>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={sendInvite}
+      disabled={state === "loading"}
+      className="hover:border-blue-400 hover:text-blue-700"
+    >
+      {state === "loading" ? (
+        <Loader2 className="h-3 w-3 animate-spin mr-1" />
+      ) : (
+        <Send className="h-3 w-3 mr-1" />
+      )}
+      <span className="text-xs">Invite to Portal</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## 1. Insight
Backend endpoint `POST /api/portal/invite/send` and receiving side `portal/register` were fully built but no ops-side UI existed to trigger invitations. Team had to invoke the API manually.

## 2. Studio
No visual change to end users (portal clients). Ops-side only: new `/clients` page in admin-dashboard with an **Invite to Portal** button per row. States: idle → loading → sent / pending+resend / active (Portal Active badge). Files: `app/clients/page.tsx` + `components/InviteClientButton.tsx` — admin-dashboard only, GIALLO zone.

## 3. Source
- `apps/backend-rag/backend/app/routers/portal_invite.py` — existing `POST /api/portal/invite/send` + `GET /api/portal/invite/client/{id}`
- `apps/mouth/src/app/portal/register/page.tsx` — existing receiving side (untouched)
- `apps/admin-dashboard/app/users/page.tsx` — UI pattern reference

## 4. Methodology
Thin Next.js proxy route (`app/api/portal/invite/route.ts`) forwards team auth headers to backend. Component fetches invite history on mount to determine initial state. No new backend logic — wires existing endpoints only.

## 5. Raw Observations
- `portal_invite.py` fully implements send, resend, validate, complete — nothing to add backend-side
- No dedicated clients page existed in admin-dashboard — only generic postgres table viewer
- Pre-existing TS error in `app/layout.tsx` (React 19 ReactNode bigint mismatch) — confirmed present before this PR via git stash test

## 6. Reasoning Path
Backend ready + receiving side ready → gap = ops UI only → thin proxy + stateful button component + clients page → zero backend changes needed.

## 7. Risk
- `BACKEND_URL` env var must be set in admin-dashboard deployment — fallback to `localhost:8000`
- `clients` table name assumed from postgres query pattern — needs Antonello confirmation
- Pre-existing `layout.tsx` TS error blocks `npm run build` — not introduced here, needs separate fix

## 8. Implication
Ops team can send portal invitations directly from admin-dashboard. Resend available for pending/expired invites. Portal Active badge shows when client has completed registration.

## 9. Recommendation
Merge after Antonello confirms: (1) correct table name for clients, (2) `BACKEND_URL` set in admin-dashboard env.

## 10. Next Action
- Antonello: confirm `clients` table name + `BACKEND_URL` env
- Follow-up PR: add `/clients` link to admin-dashboard sidebar nav