### PR TITLE
fix(mouth): twelve more pages said "Bali Zero" twice — and my own guard excused one

### DIFF
--- a/apps/mouth/src/app/(blog)/contact/layout.tsx
+++ b/apps/mouth/src/app/(blog)/contact/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 const baseUrl = process.env.NEXT_PUBLIC_PUBLIC_URL || "https://balizero.com";
 
 export const metadata: Metadata = {
-  title: "Contact Bali Zero | Free Visa & Business Consultation",
+  title: "Contact — Free Visa & Business Consultation",
   description:
     "Contact Bali Zero for a free consultation on Indonesia visas, company setup, tax compliance, and property investment. WhatsApp, email, or visit our Bali office.",
   openGraph: {

--- a/apps/mouth/src/app/(blog)/contact/page.tsx
+++ b/apps/mouth/src/app/(blog)/contact/page.tsx
@@ -5,7 +5,7 @@ import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
 import { RUMAH_VARS, RUMAH_CLASS } from "@/lib/theme/rumahVars";
 
 export const metadata: Metadata = {
-  title: "Contact · Bali Zero",
+  title: "Contact",
   description:
     "Talk to the Bali Zero team in Kerobokan. WhatsApp, email, office — every channel staffed by licensed Indonesian consultants.",
 };

--- a/apps/mouth/src/app/(blog)/services/page.tsx
+++ b/apps/mouth/src/app/(blog)/services/page.tsx
@@ -14,7 +14,7 @@ import { GoogleReviewsBlock } from "../_components/GoogleReviewsBlock";
 import { RUMAH_VARS, RUMAH_CLASS } from "@/lib/theme/rumahVars";
 
 export const metadata: Metadata = {
-  title: "Services · Bali Zero",
+  title: "Services",
   description:
     "Visa, PT PMA, tax, property — handled in Bali by a licensed Indonesian team since 2006.",
 };

--- a/apps/mouth/src/app/(blog)/team/page.tsx
+++ b/apps/mouth/src/app/(blog)/team/page.tsx
@@ -8,7 +8,7 @@ import { RUMAH_VARS, RUMAH_CLASS } from "@/lib/theme/rumahVars";
 import { rosterBySlug, initialsOf } from "@/data/team-roster";
 
 export const metadata: Metadata = {
-  title: "Team · Bali Zero",
+  title: "Team",
   description:
     "The Bali Zero team — licensed founders, consultants, tax specialists, notaries and marketing. Real people handling real cases in Bali since 2006.",
 };

--- a/apps/mouth/src/app/(book)/book/[chapter]/page.tsx
+++ b/apps/mouth/src/app/(book)/book/[chapter]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CHAPTERS } from "@/components/book/book-data";
+import { chapterTitleMetadata } from "@/components/book/book-title";
 import { BookPage } from "../BookPage";
 
 interface Props {
@@ -17,7 +18,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!chapter) return {};
 
   return {
-    title: chapter.title,
+    // The (book) layout appends ` — Bali Zero` to every chapter title, and the
+    // cover chapter is literally titled "Bali Zero" — the append produced
+    // `Bali Zero — Bali Zero`, measured live 2026-07-29. The rule lives in
+    // book-title.ts so book-title.test.ts can compose it against the REAL
+    // chapter data instead of asserting about this line.
+    title: chapterTitleMetadata(chapter.title),
     description: chapter.subtitle,
     openGraph: {
       title: `${chapter.title} — Bali Zero`,

--- a/apps/mouth/src/app/(book)/layout.tsx
+++ b/apps/mouth/src/app/(book)/layout.tsx
@@ -1,41 +1,49 @@
-import type { Metadata } from 'next';
-import { League_Spartan, Montserrat } from 'next/font/google';
-import '@/app/globals.css';
-import { I18nProvider } from '@/i18n';
+import type { Metadata } from "next";
+import { League_Spartan, Montserrat } from "next/font/google";
+import "@/app/globals.css";
+import { I18nProvider } from "@/i18n";
 
 const leagueSpartan = League_Spartan({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-spartan',
-  weight: ['400', '600', '700', '800', '900'],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-spartan",
+  weight: ["400", "600", "700", "800", "900"],
 });
 
 const montserrat = Montserrat({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-montserrat',
-  weight: ['400', '500', '600'],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-montserrat",
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {
   title: {
-    template: '%s — Bali Zero',
-    default: 'Bali Zero — The story',
+    template: "%s — Bali Zero",
+    // NOT 'Bali Zero — The story'. `default` is a title declared in a CHILD of
+    // the app-root layout, so the root's own `%s | Bali Zero` applies to it —
+    // and /book served `Bali Zero — The story | Bali Zero`, measured in
+    // production 2026-07-29. The brand arrives from above; do not carry it here.
+    default: "The story",
   },
   description:
     "From CV Bayu Santero (2006) to Bali Zero (2020). 5,000+ clients. Indonesia's only AI-first agency.",
   openGraph: {
-    type: 'website',
-    siteName: 'Bali Zero',
+    type: "website",
+    siteName: "Bali Zero",
   },
 };
 
-export default function BookLayout({ children }: { children: React.ReactNode }) {
+export default function BookLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <I18nProvider>
       <div
         className={`${leagueSpartan.variable} ${montserrat.variable} min-h-screen text-[#edeae4]`}
-        style={{ background: 'var(--book-bg, #0d0d14)' }}
+        style={{ background: "var(--book-bg, #0d0d14)" }}
       >
         {/*
         Nebula stellar background — CSS only, no images.
@@ -46,10 +54,10 @@ export default function BookLayout({ children }: { children: React.ReactNode }) 
         <div
           aria-hidden="true"
           style={{
-            position: 'fixed',
+            position: "fixed",
             inset: 0,
             zIndex: 0,
-            pointerEvents: 'none',
+            pointerEvents: "none",
             background: `
             radial-gradient(ellipse 80% 60% at 15% 20%, rgba(62, 40, 96, 0.35) 0%, transparent 65%),
             radial-gradient(ellipse 60% 50% at 85% 80%, rgba(40, 32, 80, 0.40) 0%, transparent 60%),
@@ -62,23 +70,24 @@ export default function BookLayout({ children }: { children: React.ReactNode }) 
         <div
           aria-hidden="true"
           style={{
-            position: 'fixed',
+            position: "fixed",
             inset: 0,
             zIndex: 0,
-            pointerEvents: 'none',
+            pointerEvents: "none",
             backgroundImage: `
             radial-gradient(circle, rgba(255,255,255,0.35) 1px, transparent 1px),
             radial-gradient(circle, rgba(255,255,255,0.20) 1px, transparent 1px),
             radial-gradient(circle, rgba(212,132,90,0.25) 1px, transparent 1px)
           `,
-            backgroundSize: '340px 340px, 220px 220px, 480px 480px',
-            backgroundPosition: '0 0, 110px 80px, 200px 160px',
-            maskImage: 'radial-gradient(ellipse 100% 100% at 50% 50%, black 0%, transparent 100%)',
+            backgroundSize: "340px 340px, 220px 220px, 480px 480px",
+            backgroundPosition: "0 0, 110px 80px, 200px 160px",
+            maskImage:
+              "radial-gradient(ellipse 100% 100% at 50% 50%, black 0%, transparent 100%)",
             WebkitMaskImage:
-              'radial-gradient(ellipse 100% 100% at 50% 50%, black 0%, transparent 100%)',
+              "radial-gradient(ellipse 100% 100% at 50% 50%, black 0%, transparent 100%)",
           }}
         />
-        <div style={{ position: 'relative', zIndex: 1 }}>{children}</div>
+        <div style={{ position: "relative", zIndex: 1 }}>{children}</div>
       </div>
     </I18nProvider>
   );

--- a/apps/mouth/src/app/(tax-calendar)/tax-calendar/layout.tsx
+++ b/apps/mouth/src/app/(tax-calendar)/tax-calendar/layout.tsx
@@ -6,7 +6,7 @@ import { MobileNav } from "@/app/v2/_components/MobileNav";
 import { getFunnelNavItems } from "@/components/funnel/funnel-nav";
 
 export const metadata: Metadata = {
-  title: "Tax Compliance Calendar · Bali Zero",
+  title: "Tax Compliance Calendar",
   description: "Deadlines, reminders and compliance for businesses in Bali.",
 };
 

--- a/apps/mouth/src/app/exclusive/page.tsx
+++ b/apps/mouth/src/app/exclusive/page.tsx
@@ -1,8 +1,8 @@
-import type { Metadata } from 'next';
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: 'Bali Zero',
-  description: '',
+  title: { absolute: "Bali Zero" },
+  description: "",
   robots: { index: false, follow: false },
 };
 
@@ -10,25 +10,25 @@ export default function ExclusivePage() {
   return (
     <div
       style={{
-        minHeight: '100dvh',
-        background: '#0a0a0a',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '24px',
+        minHeight: "100dvh",
+        background: "#0a0a0a",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px",
       }}
     >
       {/* Logo */}
       <div
         style={{
-          marginBottom: '32px',
-          fontSize: '11px',
+          marginBottom: "32px",
+          fontSize: "11px",
           fontWeight: 700,
-          letterSpacing: '0.3em',
-          textTransform: 'uppercase',
-          color: '#C9A84C',
-          fontFamily: 'system-ui, sans-serif',
+          letterSpacing: "0.3em",
+          textTransform: "uppercase",
+          color: "#C9A84C",
+          fontFamily: "system-ui, sans-serif",
         }}
       >
         Bali Zero
@@ -37,13 +37,13 @@ export default function ExclusivePage() {
       {/* Video container — 9:16 portrait, max 420px wide */}
       <div
         style={{
-          width: '100%',
-          maxWidth: '420px',
-          aspectRatio: '9/16',
-          borderRadius: '12px',
-          overflow: 'hidden',
-          background: '#111',
-          boxShadow: '0 32px 80px rgba(0,0,0,0.7)',
+          width: "100%",
+          maxWidth: "420px",
+          aspectRatio: "9/16",
+          borderRadius: "12px",
+          overflow: "hidden",
+          background: "#111",
+          boxShadow: "0 32px 80px rgba(0,0,0,0.7)",
         }}
       >
         <video
@@ -52,18 +52,23 @@ export default function ExclusivePage() {
           playsInline
           autoPlay
           muted
-          style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            display: "block",
+          }}
         />
       </div>
 
       {/* Subtle footer */}
       <div
         style={{
-          marginTop: '28px',
-          fontSize: '11px',
-          color: 'rgba(255,255,255,0.2)',
-          fontFamily: 'system-ui, sans-serif',
-          letterSpacing: '0.05em',
+          marginTop: "28px",
+          fontSize: "11px",
+          color: "rgba(255,255,255,0.2)",
+          fontFamily: "system-ui, sans-serif",
+          letterSpacing: "0.05em",
         }}
       >
         zantara@balizero.com

--- a/apps/mouth/src/app/metadata-title-template.test.ts
+++ b/apps/mouth/src/app/metadata-title-template.test.ts
@@ -3,31 +3,69 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 /**
- * Brand-suffix guard for page titles (2026-07-28).
+ * Brand-suffix guard for page titles (2026-07-28, widened 2026-07-29).
  *
  * TRAUMA: the root layout sets `title.template = "%s | Bali Zero"`, so Next.js
- * appends the brand to every page title automatically. Eleven pages appended it
- * a second time by hand, and shipped a stutter to production:
+ * appends the brand to a page title on its own. Pages appended it a second time
+ * by hand and shipped a stutter to production:
  *
  *   <title>Careers — Bali Zero | Bali Zero</title>
- *   <title>Zoning Check — Verifikasi Zonasi Properti Bali Anda | Bali Zero | Bali Zero</title>
+ *   <title>Terms of Service — Bali Zero — Visa | Bali Zero</title>
  *
- * Measured live on 5 of 5 pages sampled before the fix. Nobody noticed because
- * each page looks right in isolation — the defect only exists in the COMPOSITION
- * of the page's title with a template declared in a different file. It cost real
- * estate too: Google shows ~60 characters, and the repeat burned twelve of them.
+ * Nobody noticed because each page looks right in isolation — the defect exists
+ * only in the COMPOSITION of the page title with a template declared in another
+ * file. It costs real estate too: Google renders ~60 characters and the repeat
+ * burned twelve of them.
  *
- * The guard checks the composition, so the twelfth page cannot repeat it.
+ * ---
+ * ROUND 1 (07-28) cured eleven pages and left THREE holes, all measured live:
  *
- * Deliberately NOT flagged: a title that mentions the brand mid-string (e.g.
- * "Terms of Service — Bali Zero — Visa"). That is editorial phrasing, not the
- * mechanical stutter — the innocence case below pins that it stays legal.
+ *   1. it read `title: "…"` only, so `title: { template, default }` was
+ *      invisible. `(book)/layout.tsx` shipped `default: 'Bali Zero — The story'`
+ *      → /book served `Bali Zero — The story | Bali Zero`.
+ *   2. it matched double-quoted literals only. `privacy/page.tsx` uses single
+ *      quotes → /privacy served `Privacy Policy — Bali Zero | Bali Zero`.
+ *   3. worst, it asserted as INNOCENCE that a mid-string brand is fine —
+ *      naming `"Terms of Service — Bali Zero — Visa"` as the legitimate case.
+ *      That is not a hypothetical, it is `visa/terms/page.tsx`, and live it
+ *      served `… — Visa | Bali Zero`. A guard's innocence case can excuse a
+ *      real defect: the position of the brand never mattered, only whether the
+ *      composed title carries it twice.
+ *
+ * So the rule is on the COMPOSITION, not the shape: a title the template will
+ * touch must not contain the brand at all. A page that genuinely needs the
+ * brand inside its own title says so with `absolute`, which is exactly what
+ * `absolute` is for.
+ *
+ * ---
+ * WHICH titles the template actually touches — measured, not assumed. The root
+ * template is consumed by the FIRST descendant title it meets and does not
+ * cascade past it:
+ *
+ *   /privacy             → Privacy Policy — Bali Zero | Bali Zero   (templated)
+ *   /assessment          → Assessment | Bali Zero                   (templated)
+ *   /assessment/briefing → Briefing — Bali Zero Assessment          (NOT: the
+ *       `(assessment)/assessment/layout.tsx` title already consumed it)
+ *
+ * so a file under an ancestor layout that declares its own title is exempt —
+ * flagging it would be an over-match, and `/assessment/briefing` is pinned
+ * below as the innocence case that proves the walk is real.
+ *
+ * DECLARED LIMIT: static `export const metadata` only. A title built inside
+ * `generateMetadata()` is invisible here — `(book)/book/[chapter]` is the one
+ * that does it, and it is covered by `components/book/book-title.test.ts`.
+ * A surface excluded "for later" is a surface covered never.
  */
 
 const APP_DIR = path.dirname(fileURLToPath(import.meta.url));
+const BRAND = "Bali Zero";
 
-/** Trailing `| Bali Zero`, `— Bali Zero`, `- Bali Zero` — with any spacing. */
-const TRAILING_BRAND = /\s*[|—–-]\s*Bali Zero\s*$/;
+/** `"…"` or `'…'`, with escapes — both quote styles occur in this tree. */
+const QUOTED = String.raw`"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'`;
+
+function unquote(literal: string): string {
+  return literal.slice(1, -1).replace(/\\(.)/g, "$1");
+}
 
 function tsxFiles(dir: string): string[] {
   const out: string[] = [];
@@ -39,24 +77,68 @@ function tsxFiles(dir: string): string[] {
   return out;
 }
 
-/** Top-level static `title:` string literals from `export const metadata` objects. */
-function staticTitles(): { file: string; title: string }[] {
-  const found: { file: string; title: string }[] = [];
+type Declared = { title: string; kind: string } | null;
+
+/**
+ * The top-level static title a file declares, if any.
+ *
+ * `title: { absolute: … }` returns null on purpose: `absolute` ignores any
+ * ancestor template by definition, so nothing can be appended to it.
+ */
+function declaredTitle(file: string): Declared {
+  if (!fs.existsSync(file)) return null;
+  const src = fs.readFileSync(file, "utf8");
+  const decl = /export const metadata[^=]*=\s*\{/.exec(src);
+  if (!decl) return null;
+  const tail = src.slice(decl.index + decl[0].length);
+
+  // two-space indent = first level of the metadata object; a nested
+  // openGraph/twitter title is indented deeper and is NOT templated by Next.
+  const asString =
+    new RegExp(String.raw`^ {2}title:\s*(${QUOTED})`, "m").exec(tail) ??
+    new RegExp(String.raw`^ {2}title:\s*\n\s+(${QUOTED})`, "m").exec(tail);
+  if (asString) return { title: unquote(asString[1]), kind: "title" };
+
+  const asObject = /^ {2}title:\s*\{([\s\S]*?)^ {2}\}/m.exec(tail);
+  if (!asObject) return null;
+  const body = asObject[1];
+  if (/\babsolute:/.test(body)) return null;
+  const def = new RegExp(String.raw`\bdefault:\s*(${QUOTED})`).exec(body);
+  return def ? { title: unquote(def[1]), kind: "title.default" } : null;
+}
+
+/**
+ * True when the app-root template still reaches this file — i.e. no layout
+ * STRICTLY ABOVE the file's own segment already consumed it.
+ *
+ * The walk starts at the file's grandparent directory, and that is measured,
+ * not stylistic: a layout in the SAME segment does not consume the template for
+ * its sibling page — `(blog)/contact/` holds both a layout title and a page
+ * title, and live it is the PAGE's title that renders, templated. Starting the
+ * walk one level lower would also let a layout exempt itself, which is how the
+ * first draft of this function read clean while six offenders sat under it.
+ */
+function isTemplated(file: string): boolean {
+  let dir = path.dirname(path.dirname(file));
+  while (dir !== APP_DIR && dir.startsWith(APP_DIR)) {
+    if (declaredTitle(path.join(dir, "layout.tsx"))) return false;
+    dir = path.dirname(dir);
+  }
+  return true;
+}
+
+/** Every static title the root template will append the brand to. */
+function templatedTitles(): { file: string; title: string; kind: string }[] {
+  const found: { file: string; title: string; kind: string }[] = [];
   for (const file of tsxFiles(APP_DIR)) {
-    const src = fs.readFileSync(file, "utf8");
-    const decl = /export const metadata[^=]*=\s*\{/.exec(src);
-    if (!decl) continue;
-    const tail = src.slice(decl.index + decl[0].length);
-    // two-space indent = first level of the metadata object; a nested
-    // openGraph/twitter title is indented deeper and is NOT templated by Next.
-    const m =
-      /^ {2}title:\s*("(?:[^"\\]|\\.)*")/m.exec(tail) ??
-      /^ {2}title:\s*\n\s+("(?:[^"\\]|\\.)*")/m.exec(tail);
-    if (!m) continue;
-    found.push({
-      file: path.relative(APP_DIR, file),
-      title: JSON.parse(m[1]) as string,
-    });
+    const rel = path.relative(APP_DIR, file);
+    // The app-root layout's own default is what the template appends TO.
+    if (rel === "layout.tsx") continue;
+    const d = declaredTitle(file);
+    if (!d) continue;
+    // A layout's own title is judged against its PARENT chain, not its own.
+    if (!isTemplated(file)) continue;
+    found.push({ file: rel, title: d.title, kind: d.kind });
   }
   return found;
 }
@@ -65,31 +147,73 @@ describe("page titles vs the root title template", () => {
   it("finds titles to check (the probe can produce a positive)", () => {
     // An empty scan would make the assertion below vacuously true — the
     // failure mode where a guard passes because it looked at nothing.
-    expect(staticTitles().length).toBeGreaterThanOrEqual(8);
+    expect(templatedTitles().length).toBeGreaterThanOrEqual(20);
   });
 
-  it("no page appends the brand the template already appends", () => {
-    const offenders = staticTitles()
-      .filter((t) => TRAILING_BRAND.test(t.title))
-      .map((t) => `${t.file}: ${t.title}`);
+  it("reads BOTH title shapes and BOTH quote styles", () => {
+    // Round 1 saw only double-quoted `title: "…"`, and both blind spots shipped
+    // a stutter. If a refactor narrows the scan back, pin it here.
+    const kinds = new Set(templatedTitles().map((t) => t.kind));
+    expect([...kinds].sort()).toEqual(["title", "title.default"]);
+    expect(
+      declaredTitle(path.join(APP_DIR, "privacy/page.tsx")),
+    ).not.toBeNull();
+  });
+
+  it("no templated title carries the brand the template already appends", () => {
+    const offenders = templatedTitles()
+      .filter((t) => t.title.includes(BRAND))
+      .map((t) => `${t.file} (${t.kind}): ${t.title}`);
     expect(offenders).toEqual([]);
   });
 
-  it("a brand mention mid-title is left alone (innocence)", () => {
-    expect(TRAILING_BRAND.test("Terms of Service — Bali Zero — Visa")).toBe(
-      false,
+  it("exempts the shapes no template touches (innocence)", () => {
+    const scanned = templatedTitles().map((t) => t.file);
+
+    // 1. the app-root layout's own default — nothing appends to it
+    expect(scanned).not.toContain("layout.tsx");
+
+    // 2. `title: { absolute: … }` — opts out of the parent template
+    const marketing = path.join(APP_DIR, "(marketing)/page.tsx");
+    expect(fs.readFileSync(marketing, "utf8")).toMatch(
+      /absolute:\s*["']Bali Zero \|/,
     );
-    expect(TRAILING_BRAND.test("Bali Zero is here to help")).toBe(false);
+    expect(declaredTitle(marketing)).toBeNull();
+
+    // 3. a page under a layout that already consumed the template. Measured
+    //    live: /assessment/briefing renders WITHOUT ` | Bali Zero`, so its
+    //    in-title brand is legitimate and flagging it would be an over-match.
+    const briefing = "(assessment)/assessment/briefing/page.tsx";
+    expect(declaredTitle(path.join(APP_DIR, briefing))?.title).toContain(BRAND);
+    expect(scanned).not.toContain(briefing);
   });
 
-  it("catches every separator the codebase actually used (guilt)", () => {
-    for (const bad of [
-      "Careers — Bali Zero",
-      "Visa Oracle — Prototype | Bali Zero",
-      "Login - Bali Zero",
-      "Something | Bali Zero ",
-    ]) {
-      expect(TRAILING_BRAND.test(bad)).toBe(true);
+  it("still judges a layout by its OWN ancestors, not by itself (guilt)", () => {
+    // `(assessment)/assessment/layout.tsx` declares a title, which exempts its
+    // CHILDREN — it must not exempt itself, or a layout could carry the brand
+    // freely. It is scanned; it just happens to be clean.
+    expect(templatedTitles().map((t) => t.file)).toContain(
+      "(assessment)/assessment/layout.tsx",
+    );
+  });
+
+  it("catches every form the codebase actually shipped (guilt)", () => {
+    const shipped = [
+      "Careers — Bali Zero", // trailing, round 1
+      "Login - Bali Zero", // trailing, hyphen
+      "Privacy Policy — Bali Zero", // trailing, single-quoted source
+      "Terms of Service — Bali Zero — Visa", // MID-string: round 1 excused this
+      "Contact · Bali Zero", // mid/interpunct
+      "About Bali Zero", // brand inside the phrase
+      "Bali Zero — The story", // a `title.default`, brand FIRST
+      "Bali Zero", // the whole title is the brand
+    ];
+    for (const bad of shipped) expect(bad.includes(BRAND)).toBe(true);
+  });
+
+  it("a title with no brand at all is left alone (innocence)", () => {
+    for (const ok of ["Careers", "Assessment", "The story", "Zoning Check"]) {
+      expect(ok.includes(BRAND)).toBe(false);
     }
   });
 });

--- a/apps/mouth/src/app/privacy/page.tsx
+++ b/apps/mouth/src/app/privacy/page.tsx
@@ -1,38 +1,63 @@
-import type { Metadata } from 'next';
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: 'Privacy Policy — Bali Zero',
-  description: 'How Bali Zero collects, processes, and protects your personal data under Indonesian law (UU PDP No. 27/2022).',
+  title: "Privacy Policy",
+  description:
+    "How Bali Zero collects, processes, and protects your personal data under Indonesian law (UU PDP No. 27/2022).",
 };
 
 export default function PrivacyPolicyPage() {
   return (
-    <div className="min-h-screen" style={{ background: 'var(--bz-base, #0c0c0e)', color: 'var(--bz-text-1, #f5f5f5)' }}>
+    <div
+      className="min-h-screen"
+      style={{
+        background: "var(--bz-base, #0c0c0e)",
+        color: "var(--bz-text-1, #f5f5f5)",
+      }}
+    >
       <div className="max-w-3xl mx-auto px-6 py-16 space-y-10">
         <header>
           <h1 className="text-3xl font-bold tracking-tight">Privacy Policy</h1>
-          <p className="mt-2 text-sm" style={{ color: 'var(--bz-text-2, #a0a0a0)' }}>
+          <p
+            className="mt-2 text-sm"
+            style={{ color: "var(--bz-text-2, #a0a0a0)" }}
+          >
             Last updated: March 2026 · Effective: October 17, 2024
           </p>
         </header>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>1. Who We Are</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            1. Who We Are
+          </h2>
           <p>
-            Bali Zero (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;) provides immigration, business registration, tax, and property
-            services for foreign nationals and companies in Indonesia. Our AI assistant Zantara processes your inquiries
-            across WhatsApp, Telegram, Web, Instagram, and other channels.
+            Bali Zero (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;) provides
+            immigration, business registration, tax, and property services for
+            foreign nationals and companies in Indonesia. Our AI assistant
+            Zantara processes your inquiries across WhatsApp, Telegram, Web,
+            Instagram, and other channels.
           </p>
           <p>
-            Under the Indonesian Personal Data Protection Law (UU PDP No. 27/2022), we act as the <strong>Personal Data Controller</strong> for
-            the data we collect and process.
+            Under the Indonesian Personal Data Protection Law (UU PDP No.
+            27/2022), we act as the <strong>Personal Data Controller</strong>{" "}
+            for the data we collect and process.
           </p>
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>2. Data We Collect</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            2. Data We Collect
+          </h2>
 
-          <h3 className="font-medium mt-4">General Personal Data (Art. 4(2))</h3>
+          <h3 className="font-medium mt-4">
+            General Personal Data (Art. 4(2))
+          </h3>
           <ul className="list-disc ml-6 space-y-1 text-sm">
             <li>Full name, email address, phone number</li>
             <li>Nationality, date of birth, gender</li>
@@ -41,30 +66,59 @@ export default function PrivacyPolicyPage() {
             <li>Communication history (messages across all channels)</li>
           </ul>
 
-          <h3 className="font-medium mt-4">Specific Personal Data (Art. 4(1))</h3>
+          <h3 className="font-medium mt-4">
+            Specific Personal Data (Art. 4(1))
+          </h3>
           <ul className="list-disc ml-6 space-y-1 text-sm">
             <li>Passport photograph (biometric data when processed via OCR)</li>
             <li>KTP (Indonesian ID card) scans</li>
             <li>NPWP (tax identification number) documents</li>
-            <li>Financial information (salary, investment amounts for visa applications)</li>
+            <li>
+              Financial information (salary, investment amounts for visa
+              applications)
+            </li>
           </ul>
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>3. Legal Basis for Processing</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            3. Legal Basis for Processing
+          </h2>
           <ul className="list-disc ml-6 space-y-2 text-sm">
-            <li><strong>Contract performance (Art. 20(b)):</strong> Processing necessary to fulfill our immigration and business services</li>
-            <li><strong>Explicit consent (Art. 21):</strong> For specific personal data (passport scans, KTP, biometric processing)</li>
-            <li><strong>Legal obligation (Art. 20(c)):</strong> Tax record retention as required by Indonesian tax law</li>
-            <li><strong>Legitimate interest (Art. 20(f)):</strong> Pre-contractual inquiries via WhatsApp/chat</li>
+            <li>
+              <strong>Contract performance (Art. 20(b)):</strong> Processing
+              necessary to fulfill our immigration and business services
+            </li>
+            <li>
+              <strong>Explicit consent (Art. 21):</strong> For specific personal
+              data (passport scans, KTP, biometric processing)
+            </li>
+            <li>
+              <strong>Legal obligation (Art. 20(c)):</strong> Tax record
+              retention as required by Indonesian tax law
+            </li>
+            <li>
+              <strong>Legitimate interest (Art. 20(f)):</strong> Pre-contractual
+              inquiries via WhatsApp/chat
+            </li>
           </ul>
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>4. How We Use Your Data</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            4. How We Use Your Data
+          </h2>
           <ul className="list-disc ml-6 space-y-1 text-sm">
             <li>Processing visa applications and company registrations</li>
-            <li>Document verification via OCR (optical character recognition)</li>
+            <li>
+              Document verification via OCR (optical character recognition)
+            </li>
             <li>AI-powered assistance for your inquiries</li>
             <li>Tax filing and compliance monitoring</li>
             <li>Communication about your active services</li>
@@ -73,55 +127,128 @@ export default function PrivacyPolicyPage() {
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>5. Data Storage and Cross-Border Transfer</h2>
-          <p>Your data is stored on servers in <strong>Singapore</strong> (Fly.io, Qdrant Cloud) and processed by:</p>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            5. Data Storage and Cross-Border Transfer
+          </h2>
+          <p>
+            Your data is stored on servers in <strong>Singapore</strong>{" "}
+            (Fly.io, Qdrant Cloud) and processed by:
+          </p>
           <ul className="list-disc ml-6 space-y-1 text-sm">
-            <li><strong>Fly.io</strong> (Singapore) — Application hosting and PostgreSQL database</li>
-            <li><strong>Qdrant Cloud</strong> (US) — Vector search database</li>
-            <li><strong>Google</strong> (global) — Google Drive for document storage, Gemini for AI processing</li>
-            <li><strong>Upstash</strong> (global) — Redis cache (temporary, 5-minute TTL)</li>
-            <li><strong>Local processing</strong> (Bali) — Ollama AI for document OCR (no cross-border transfer)</li>
+            <li>
+              <strong>Fly.io</strong> (Singapore) — Application hosting and
+              PostgreSQL database
+            </li>
+            <li>
+              <strong>Qdrant Cloud</strong> (US) — Vector search database
+            </li>
+            <li>
+              <strong>Google</strong> (global) — Google Drive for document
+              storage, Gemini for AI processing
+            </li>
+            <li>
+              <strong>Upstash</strong> (global) — Redis cache (temporary,
+              5-minute TTL)
+            </li>
+            <li>
+              <strong>Local processing</strong> (Bali) — Ollama AI for document
+              OCR (no cross-border transfer)
+            </li>
           </ul>
           <p className="text-sm mt-2">
-            Cross-border transfers are protected by standard contractual clauses and data processing agreements
-            with each provider, in compliance with Art. 56 of UU PDP.
+            Cross-border transfers are protected by standard contractual clauses
+            and data processing agreements with each provider, in compliance
+            with Art. 56 of UU PDP.
           </p>
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>6. Data Retention</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            6. Data Retention
+          </h2>
           <ul className="list-disc ml-6 space-y-1 text-sm">
-            <li><strong>Active service data:</strong> Duration of our engagement + 5 years</li>
-            <li><strong>Tax records:</strong> 7 years (Indonesian tax law requirement)</li>
-            <li><strong>Communication history:</strong> 2 years after last interaction</li>
-            <li><strong>Document scans:</strong> 5 years after visa/permit expiry</li>
-            <li><strong>Cache data:</strong> 5 minutes (automatically deleted)</li>
+            <li>
+              <strong>Active service data:</strong> Duration of our engagement +
+              5 years
+            </li>
+            <li>
+              <strong>Tax records:</strong> 7 years (Indonesian tax law
+              requirement)
+            </li>
+            <li>
+              <strong>Communication history:</strong> 2 years after last
+              interaction
+            </li>
+            <li>
+              <strong>Document scans:</strong> 5 years after visa/permit expiry
+            </li>
+            <li>
+              <strong>Cache data:</strong> 5 minutes (automatically deleted)
+            </li>
           </ul>
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>7. Your Rights (UU PDP Art. 5-12)</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            7. Your Rights (UU PDP Art. 5-12)
+          </h2>
           <p>You have the right to:</p>
           <ul className="list-disc ml-6 space-y-1 text-sm">
-            <li><strong>Access:</strong> Request a copy of your personal data</li>
-            <li><strong>Rectification:</strong> Correct inaccurate data</li>
-            <li><strong>Erasure:</strong> Request deletion of your data (within 72 hours)</li>
-            <li><strong>Portability:</strong> Receive your data in a structured format</li>
-            <li><strong>Withdraw consent:</strong> Revoke previously given consent at any time</li>
-            <li><strong>Object:</strong> Object to automated decision-making</li>
+            <li>
+              <strong>Access:</strong> Request a copy of your personal data
+            </li>
+            <li>
+              <strong>Rectification:</strong> Correct inaccurate data
+            </li>
+            <li>
+              <strong>Erasure:</strong> Request deletion of your data (within 72
+              hours)
+            </li>
+            <li>
+              <strong>Portability:</strong> Receive your data in a structured
+              format
+            </li>
+            <li>
+              <strong>Withdraw consent:</strong> Revoke previously given consent
+              at any time
+            </li>
+            <li>
+              <strong>Object:</strong> Object to automated decision-making
+            </li>
           </ul>
           <p className="text-sm mt-2">
-            To exercise your rights, contact our Data Protection Officer at{' '}
-            <a href="mailto:privacy@balizero.com" className="underline" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>
+            To exercise your rights, contact our Data Protection Officer at{" "}
+            <a
+              href="mailto:privacy@balizero.com"
+              className="underline"
+              style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+            >
               privacy@balizero.com
             </a>
           </p>
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>8. Data Security</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            8. Data Security
+          </h2>
           <ul className="list-disc ml-6 space-y-1 text-sm">
-            <li>Encryption at rest (database-level and column-level for sensitive fields)</li>
+            <li>
+              Encryption at rest (database-level and column-level for sensitive
+              fields)
+            </li>
             <li>PII detection and redaction in AI-generated responses</li>
             <li>Immutable audit logging of all data access</li>
             <li>Role-based access control (RBAC)</li>
@@ -130,29 +257,48 @@ export default function PrivacyPolicyPage() {
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>9. Breach Notification</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            9. Breach Notification
+          </h2>
           <p className="text-sm">
-            In the event of a data breach affecting your personal data, we will notify you and the relevant
-            Indonesian authorities (MOCD/Lembaga PDP) within <strong>72 hours</strong> (3 x 24 hours) of discovery,
+            In the event of a data breach affecting your personal data, we will
+            notify you and the relevant Indonesian authorities (MOCD/Lembaga
+            PDP) within <strong>72 hours</strong> (3 x 24 hours) of discovery,
             as required by Art. 46 of UU PDP.
           </p>
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>10. Contact</h2>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            10. Contact
+          </h2>
           <p className="text-sm">
-            <strong>Data Protection Officer:</strong>{' '}
-            <a href="mailto:privacy@balizero.com" className="underline" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>
+            <strong>Data Protection Officer:</strong>{" "}
+            <a
+              href="mailto:privacy@balizero.com"
+              className="underline"
+              style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+            >
               privacy@balizero.com
             </a>
           </p>
           <p className="text-sm">
-            <strong>General inquiries:</strong>{' '}
-            <a href="mailto:hello@balizero.com" className="underline" style={{ color: 'var(--bz-accent-warm, #d4845a)' }}>
+            <strong>General inquiries:</strong>{" "}
+            <a
+              href="mailto:hello@balizero.com"
+              className="underline"
+              style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+            >
               hello@balizero.com
             </a>
           </p>
-          <p className="text-sm" style={{ color: 'var(--bz-text-2, #a0a0a0)' }}>
+          <p className="text-sm" style={{ color: "var(--bz-text-2, #a0a0a0)" }}>
             Bali Zero · Bali, Indonesia · PSE Registration: [Pending]
           </p>
         </section>

--- a/apps/mouth/src/app/property/eligibility/layout.tsx
+++ b/apps/mouth/src/app/property/eligibility/layout.tsx
@@ -6,7 +6,7 @@ import { MobileNav } from "@/app/v2/_components/MobileNav";
 import { getFunnelNavItems } from "@/components/funnel/funnel-nav";
 
 export const metadata: Metadata = {
-  title: "Idoneità Immobile · Bali Zero",
+  title: "Idoneità Immobile",
   description:
     "Zoning, struttura legale, tassazione e punteggio di rischio per immobili a Bali.",
 };

--- a/apps/mouth/src/app/v2/company/about/page.tsx
+++ b/apps/mouth/src/app/v2/company/about/page.tsx
@@ -7,7 +7,7 @@ import { Footer } from "../../_components/Footer";
 import { rosterBySlug } from "@/data/team-roster";
 
 export const metadata: Metadata = {
-  title: "About Bali Zero",
+  title: { absolute: "About Bali Zero" },
   robots: { index: false, follow: false },
 };
 

--- a/apps/mouth/src/app/v2/page.tsx
+++ b/apps/mouth/src/app/v2/page.tsx
@@ -20,7 +20,7 @@ export const dynamic = "force-dynamic";
 // Phase 1 reference homepage — "safe" palette variant (#0B0B10 night).
 // Compare with /v2-aubergine which uses the contrarian #1A1520.
 export const metadata: Metadata = {
-  title: "Bali Zero v2 · Design System Preview",
+  title: { absolute: "Bali Zero v2 · Design System Preview" },
   robots: { index: false, follow: false },
 };
 

--- a/apps/mouth/src/app/visa/privacy/page.tsx
+++ b/apps/mouth/src/app/visa/privacy/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy — Bali Zero — Visa",
+  title: { absolute: "Privacy Policy — Bali Zero — Visa" },
   description:
     "How Bali Zero — Visa handles your data and protects your privacy.",
   robots: { index: false, follow: false },

--- a/apps/mouth/src/app/visa/terms/page.tsx
+++ b/apps/mouth/src/app/visa/terms/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms of Service — Bali Zero — Visa",
+  title: { absolute: "Terms of Service — Bali Zero — Visa" },
   description:
     "Terms and conditions for using Bali Zero — Visa, an AI-powered Indonesian visa guidance tool.",
   robots: { index: false, follow: false },

--- a/apps/mouth/src/components/book/book-title.test.ts
+++ b/apps/mouth/src/components/book/book-title.test.ts
@@ -1,0 +1,64 @@
+import { CHAPTERS } from "./book-data";
+import {
+  BOOK_BRAND,
+  chapterTitleMetadata,
+  renderedChapterTitle,
+} from "./book-title";
+
+/**
+ * Composition guard for the book chapter titles (2026-07-29).
+ *
+ * The sibling guard `src/app/metadata-title-template.test.ts` reads STATIC
+ * `export const metadata` only, so it is structurally blind to a title built
+ * inside `generateMetadata()` — which is what `(book)/book/[chapter]` does.
+ * That blind spot is where the second stutter lived: measured in production,
+ *
+ *   /book/cover → <title>Bali Zero — Bali Zero</title>
+ *
+ * because the cover chapter's title IS the brand and the layout template
+ * appends it again. So this file covers the shape the other one declares it
+ * cannot see — a surface excluded "for later" is a surface covered never.
+ *
+ * It asserts against the REAL chapter data, not a fixture: a future chapter
+ * titled with the brand fails here on the day it is written.
+ */
+
+describe("book chapter titles vs the (book) template", () => {
+  it("has chapters to check (the probe can produce a positive)", () => {
+    expect(CHAPTERS.length).toBeGreaterThan(3);
+  });
+
+  it("no chapter renders the brand twice", () => {
+    const offenders = CHAPTERS.filter(
+      (c) => renderedChapterTitle(c.title).split(BOOK_BRAND).length - 1 > 1,
+    ).map((c) => `${c.id}: ${renderedChapterTitle(c.title)}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("every chapter still shows the brand once", () => {
+    // The cure must not swing the other way: opting out of the template is
+    // only correct when the title already carries the brand itself.
+    const missing = CHAPTERS.filter(
+      (c) => !renderedChapterTitle(c.title).includes(BOOK_BRAND),
+    ).map((c) => c.id);
+    expect(missing).toEqual([]);
+  });
+
+  it("the cover — the chapter that shipped the stutter — is pinned (guilt)", () => {
+    const cover = CHAPTERS.find((c) => c.id === "cover");
+    expect(cover?.title).toBe(BOOK_BRAND);
+    expect(chapterTitleMetadata(cover!.title)).toEqual({
+      absolute: BOOK_BRAND,
+    });
+    expect(renderedChapterTitle(cover!.title)).toBe(BOOK_BRAND);
+  });
+
+  it("an ordinary chapter keeps the template (innocence)", () => {
+    expect(chapterTitleMetadata("The meeting that changed everything")).toBe(
+      "The meeting that changed everything",
+    );
+    expect(renderedChapterTitle("The meeting that changed everything")).toBe(
+      "The meeting that changed everything — Bali Zero",
+    );
+  });
+});

--- a/apps/mouth/src/components/book/book-title.ts
+++ b/apps/mouth/src/components/book/book-title.ts
@@ -1,0 +1,40 @@
+/**
+ * How a book chapter's title becomes the page title.
+ *
+ * `(book)/layout.tsx` declares `title.template = '%s — Bali Zero'`, so Next.js
+ * appends the brand to every chapter title on its own. One chapter — the cover —
+ * is literally titled "Bali Zero", and the append produced a stutter that was
+ * live in production until 2026-07-29:
+ *
+ *   /book/cover → <title>Bali Zero — Bali Zero</title>
+ *
+ * It lives here, not inline in the route, so the rule can be composed against
+ * the real chapter data in a test instead of being asserted about itself.
+ */
+
+/** The brand the (book) layout's title template appends. */
+export const BOOK_BRAND = "Bali Zero";
+
+/** The `— Bali Zero` suffix that template adds. */
+export const BOOK_TITLE_SUFFIX = ` — ${BOOK_BRAND}`;
+
+/**
+ * The `title` a chapter page should export.
+ *
+ * A title that already carries the brand opts out of the parent template via
+ * `absolute` (Next.js: `absolute` ignores any ancestor `template`); every other
+ * chapter returns a plain string and keeps the template.
+ */
+export function chapterTitleMetadata(
+  chapterTitle: string,
+): string | { absolute: string } {
+  return chapterTitle.includes(BOOK_BRAND)
+    ? { absolute: chapterTitle }
+    : chapterTitle;
+}
+
+/** What Next.js will actually render for that chapter — the composed title. */
+export function renderedChapterTitle(chapterTitle: string): string {
+  const meta = chapterTitleMetadata(chapterTitle);
+  return typeof meta === "string" ? meta + BOOK_TITLE_SUFFIX : meta.absolute;
+}


### PR DESCRIPTION
Round 2 of the class fixed in #3414. That PR cured eleven pages and declared the class closed. **It was not.** Measured on production today, **twelve more titles** carry the brand and receive it again from the root template:

```
/privacy      → Privacy Policy — Bali Zero | Bali Zero
/visa/terms   → Terms of Service — Bali Zero — Visa | Bali Zero
/visa/privacy → Privacy Policy — Bali Zero — Visa | Bali Zero
/contact      → Contact · Bali Zero | Bali Zero
/services     → Services · Bali Zero | Bali Zero
/team         → Team · Bali Zero | Bali Zero
/tax-calendar → Tax Compliance Calendar · Bali Zero | Bali Zero
/exclusive    → Bali Zero | Bali Zero
/v2           → Bali Zero v2 · Design System Preview | Bali Zero
/v2/company/about → About Bali Zero | Bali Zero
/property/eligibility → Idoneità Immobile · Bali Zero | Bali Zero
/book         → Bali Zero — The story | Bali Zero
/book/cover   → Bali Zero — Bali Zero
```

Eleven render twice live; the twelfth (`(blog)/contact/layout.tsx`) is overridden by its sibling page — dead metadata, fixed anyway.

## Why the first guard missed them — three holes, all mine

1. It read `title: "…"` **strings only**, so the object shape `title: { template, default }` was invisible. A nested layout's `default` *is* a title declared in a child segment, so the root template applies to it. That is `/book`.
2. It matched **double-quoted** literals only. `privacy/page.tsx` uses single quotes and sat there in plain sight.
3. Worst: it asserted as **INNOCENCE** that a mid-string brand is fine, naming `"Terms of Service — Bali Zero — Visa"` as the legitimate case. That string is not a hypothetical — it is `visa/terms/page.tsx`, live, rendering the brand twice. **A guard's innocence case can excuse a real defect.** Position never mattered; only whether the COMPOSED title carries the brand twice.

## The rule now sits on the composition

A title the template will touch must not contain the brand at all. A page that genuinely needs the brand inside its own title says so with `absolute` — which is what `absolute` is for, and what the five product-name titles (`Bali Zero — Visa`, `About Bali Zero`, …) now use.

**Which titles the template touches is measured, not assumed.** The root template is consumed by the first descendant title it meets and does not cascade past it: `/assessment/briefing` renders *without* the brand because the assessment layout already consumed it. The guard walks the ancestor chain to model this, and that page is the innocence case pinning the walk — the first draft of the walk let a layout exempt itself and read clean over six offenders.

## The surface the guard declares it cannot see

`generateMetadata()` is outside a static scan's reach, and that is exactly where the `/book/cover` stutter lived. Rather than leave it "for later" (= never), the composition rule for chapters moved into `components/book/book-title.ts`, and `book-title.test.ts` composes it against the **real** chapter data — a future chapter titled with the brand fails on the day it is written.

## Verification

- **Mutation-verified on all three historical shapes** — trailing (`privacy`), mid-string (`visa/terms`), `title.default` (`book/layout`): each turns the guard red and each **names its own file**. Restored after.
- `apps/mouth`: **303 files / 2757 tests pass**, `tsc --noEmit` clean, prettier clean.