### PR TITLE
docs(nb-health): the KBLI corrections report diagnosed version-drift, then became it

### DIFF
--- a/research/nb-health/2026-05-28-nb3-kbli-corrections.md
+++ b/research/nb-health/2026-05-28-nb3-kbli-corrections.md
@@ -7,6 +7,7 @@ type: correction-report
 severity: P2
 discovered_by: deep-researcher (primary-source verification, Peraturan BPS 7/2025 PDF 623pp letto direttamente)
 trigger: Antonello challenge "hanno cercato nel KBLI 2025? e la legge BPS di dicembre 2025?"
+adversarial_review: codex
 sources:
   - research/company/2026-05-28-kbli-2025-bps-december-verify.md
   - research/visa/2026-05-28-e33g-kbli-content-creator-pivot.md
@@ -14,6 +15,14 @@ sources:
 ---
 
 # NB-3 — Segnalazione imprecisioni KBLI 2025 (2 errori + 1 nota)
+
+> ⛔ **SCADUTO COME CONSIGLIO OPERATIVO — leggi §Adversarial review prima di agire.**
+> Questo documento è del **2026-05-28** e parla al presente di maggio 2026. La
+> scadenza che descrive come futura — **18 giugno 2026**, transizione KBLI
+> 2020→2025 — **è passata**. Al 2026-07-29 la riga "OSS registra ancora con
+> KBLI 2020, si converte dopo" **non va più seguita** per una PT PMA nuova.
+> Il reperto storico (NB-3 aveva 2 imprecisioni) resta valido; la *raccomandazione*
+> no. Vale anche la conferma §CONFERMATO: la catena di fonti che cita è rotta.
 
 Discovered durante verifica fonte primaria del KBLI 2025 per il pivot carosello content creator. NB-3 (Company Setup Indonesia) ground-truth ha 2 imprecisioni materiali + 1 nota di contesto. Nessuna è "bugia": NB-3 cita documenti reali, ma datati/versionati male.
 
@@ -73,3 +82,77 @@ Discovered durante verifica fonte primaria del KBLI 2025 per il pivot carosello 
 **Fonte data per aggiungere a NB-3 se l'operatore approva**: Peraturan BPS No. 7 Tahun 2025 (KBLI 2025, ISIC Rev. 5, 17 dic 2025, transizione 18 giu 2026). Codici creator 2025: 59112 (vlog/podcast verbatim), 60103/60203 (streaming), 60390 (social), 90113 (jurnalis independen), 90200 (influencer-as-talent), 74194 (gim).
 
 **Pattern meta**: NB-3 cita documenti reali ma con versione/data sbagliata (Lampiran Perpres 2020 spacciato per KBLI 2025; tempistica OSS ottimistica). Il rischio NB non è hallucination ma **version-drift su normativa che cambia** — il KBLI è passato da 2020 a 2025 a dicembre e NB-3 non ha catturato la transizione. Suggerimento per nb-curator: flag delle entry KBLI come "version-sensitive — verify against latest BPS Peraturan".
+
+---
+
+## Adversarial review
+
+**Seat**: `codex` (`gpt-5.6-terra`, effort high, sandbox read-only), eseguito il
+**2026-07-29** — **due mesi** dopo la stesura, e questo è il punto: il brief
+chiedeva esplicitamente di giudicare il documento *come lo leggerebbe un collega
+OGGI*, non come era corretto il giorno in cui è nato.
+Generator ≠ grader: il documento l'ha scritto un seat Claude (`deep-researcher`),
+il refuter è di famiglia diversa. **Un solo seat**: `kimi-k3` provato e morto
+(HTTP 403, quota esaurita), Gemini a crediti esauriti — quindi soglia minima, non
+accordo (W100). Non è stampato con l'esenzione macchina del gate nb-curator:
+questo è un deliverable di ricerca e viene giudicato come tale.
+
+**Sette obiezioni sopravvissute.** Le due più gravi le ho ri-verificate io prima
+di trascriverle (W65: anche il refuter allucina).
+
+1. **⛔ Il consiglio operativo è SCADUTO.** «OSS registra ancora con KBLI 2020 a
+   maggio 2026 · coesistenza fino al 18 giu 2026 · conversione automatica dopo»
+   era vero alla data di stesura. Dal **18 giugno 2026** le pratiche OSS nuove
+   girano su KBLI 2025: al 29 luglio, indirizzare una PT PMA nuova verso codici
+   2020 è sbagliato. Il documento deve dire "usa KBLI 2025 e verifica il codice
+   nel flusso OSS corrente", e trattare la conversione automatica solo come
+   disciplina delle posizioni **esistenti**.
+2. **La catena di fonti del §CONFERMATO è rotta** — e il §CONFERMATO era la
+   parte che il documento dichiarava *verificata corretta*. Il cap 49% su
+   **73100 (Periklanan)** è attribuito a «Perpres 10/2021 jo 49/2021 jo
+   **14/2024**». **Verificato da me in questo turno**: il
+   [Perpres 14/2024](https://peraturan.go.id/id/perpres-no-14-tahun-2024) è
+   *Penyelenggaraan Kegiatan Penangkapan dan Penyimpanan Karbon* — carbon capture
+   & storage. Non tocca la Daftar Positif Investasi. Il numero può restare vero,
+   ma **non è sostenuto dalla fonte citata**: va sostituito con la riga precisa
+   dell'allegato vigente o della scheda OSS che riporta codice, limite e
+   condizione di kemitraan. (La lezione dentro la lezione: la parte "confermata"
+   è quella che nessuno ha ri-controllato.)
+3. **«conversione automatica, non a carico del cliente» è troppo assoluto.**
+   Pasal 393 dispone l'aggiornamento automatico del PBBR, ma la disciplina
+   ufficiale distingue il puro cambio numerico (automatico) dalle modifiche
+   sostanziali di *maksud/tujuan* o *ruang lingkup*, che richiedono un
+   adeguamento a carico del soggetto. La condizione va scritta.
+4. **`ditetapkan` ≠ `diundangkan`.** Il documento dà 17 dicembre 2025 in un punto
+   e costruisce i "6 mesi → 18 giugno 2026" in un altro. L'aritmetica regge solo
+   dalla **promulgazione del 18**; le due date vanno dichiarate entrambe e mai
+   usate come sinonimi.
+5. **«74149 è stato assorbito verso 74199»** — l'assenza di `74149` nel testo
+   2025 e l'elenco dei codici 7419 non provano da soli una corrispondenza: le
+   transizioni possono essere one-to-many. O si cita la riga della tabella di
+   conversione BPS 2020→2025, o ci si limita a «74149 non è un codice KBLI 2025».
+6. **«grep esaustivo su PDF 623pp» non è verificabile da chi legge.** È
+   un'asserzione di provenienza non falsificabile: mancano URL canonico, data di
+   download, SHA-256 del PDF, comando di estrazione, output delle query e
+   riferimenti di pagina. Sostiene un'**assenza** (`74149` → 0 match), che è la
+   classe di affermazione che più ha bisogno di apparato.
+7. **«I veri codici creator 2025 sono 59112/60103/60203/60390/90113/90200/74194»**
+   — "creator" non è una categoria giuridica, e l'elenco presenta come
+   intercambiabili codici con perimetri diversi. Serve, per ciascuno, la
+   descrizione e le esclusioni ufficiali, e vanno tenute separate quattro cose
+   che il documento fonde: classificazione KBLI, ammissibilità PMA, rischio OSS,
+   titolo di soggiorno.
+
+**Disposizione.** Il documento resta come **reperto storico** — i due errori che
+segnalava a NB-3 erano reali e restano reali. Ciò che non sopravvive è il suo
+uso come guida operativa: l'avviso in testa lo dice, e le obiezioni 2/3/4/5/7
+vanno discharged prima che una qualunque di queste righe raggiunga un cliente o
+finisca in `apps/backend-rag/data/curated_qa/`.
+
+**Il pattern, che vale più delle sette obiezioni.** Il documento stesso diagnostica
+NB-3 con: *«il rischio NB non è hallucination ma **version-drift** su normativa che
+cambia»*. Aveva ragione, e poi è caduto nella stessa malattia: due mesi dopo, è
+lui la fonte con la versione vecchia. Una capture con consiglio operativo
+time-bound ha bisogno di una **data di scadenza dichiarata**, non di una data di
+stesura — altrimenti l'unica cosa che distingue il reperto valido dal consiglio
+marcio è che qualcuno si ricordi di rileggerlo.


### PR DESCRIPTION
The one `research/nb-health/` file the nb-curator artifact gate refuses to exempt is refused **correctly**: it declares `sources:` and `discovered_by:`, so it is a research deliverable, not a machine health snapshot. A machine stamp would have been a lie about what the file is. What it was owed instead was a real adversarial review — cross-family, and briefed to judge the document as a colleague would read it **today**, not on the day it was written.

Both gates are now green for the right reason: the nb-curator gate reports `already declares — seat=codex, section present` (not the machine exemption), and the R1 gate passes on a genuine declaration.

## Seven objections survived. Two I re-verified myself before transcribing (W65)

**1 — the operative advice has expired.** The report says *"OSS still registers with KBLI 2020 in May 2026, coexistence until 18 June 2026, automatic conversion after"*. That deadline passed six weeks ago. On 2026-07-29, steering a new PT PMA toward 2020 codes is wrong. The historical finding — NB-3 really did carry two inaccuracies — stands. The recommendation does not. Hence the ⛔ banner under the H1.

**2 — the section it labelled CONFIRMED-CORRECT is the one with a broken source chain.** The 49% foreign cap on KBLI 73100 (Periklanan) is attributed to "Perpres 10/2021 jo 49/2021 jo **14/2024**". [Perpres 14/2024](https://peraturan.go.id/id/perpres-no-14-tahun-2024) is *Penyelenggaraan Kegiatan Penangkapan dan Penyimpanan Karbon* — carbon capture and storage. It does not touch the Positive Investment List. The 49% may well be right; it is **not supported by the law cited**. The part nobody re-checked was the part labelled verified.

The other five, in the file: `ditetapkan` (17 Dec) used interchangeably with `diundangkan` (18 Dec) while the six-month arithmetic only works from the 18th · "74149 was absorbed into 74199" asserted from an *absence* rather than from the BPS conversion table (transitions can be one-to-many) · "exhaustive grep of a 623pp PDF" as an unfalsifiable provenance claim supporting an absence, with no URL, no SHA-256, no page refs · a "real 2025 creator codes" list presenting different-scoped codes as interchangeable while fusing KBLI classification, PMA eligibility, OSS risk and residence permit.

## Why this one was worth the run

The report's own closing diagnosis of NB-3 reads: *"the NB risk is not hallucination but **version-drift** on regulation that changes."* It was right — and then became the stale source itself, two months later, by exactly that mechanism. A capture carrying time-bound operative advice needs a **declared expiry**, not just a creation date; otherwise the only thing separating a valid finding from rotten advice is someone remembering to re-read it.

Single seat, declared in the section: `kimi-k3` is 403 quota-dead and Gemini's credits are exhausted. One seat is a floor, not agreement (W100).

Docs-only. No code, no data, no client-facing surface touched.