### PR TITLE
fix(connectome): the wrapper checked WHICH branch, never HOW FAR behind

### DIFF
--- a/scripts/verify_connectome_run.sh
+++ b/scripts/verify_connectome_run.sh
@@ -38,6 +38,30 @@ if [[ "$BRANCH" != "main" && "$BRANCH" != "deploy/main" ]]; then
     echo "$LOG_PREFIX WARN: $REPO_ROOT on branch '$BRANCH' (not main) — verifier may be stale" >&2
 fi
 
+# Being ON main says nothing about being CURRENT with it, and that gap is not
+# hypothetical: on 2026-07-29 the M5 checkout sat 248 commits behind while the
+# census fix that cleared 5 false REGRESSED was already merged — so this cron
+# would have kept reporting cured edges as regressions, with no line anywhere
+# saying the map was old. The branch check above could never catch it: the
+# branch was main the whole time. Read the DISTANCE, not the name.
+#
+# Report-only by construction. It never fetches (a cron that reaches the network
+# to decide its own freshness is a new failure mode) and never pulls (the scar
+# above). So the count is measured against the last-known origin/main in the
+# local object store, which is itself a lower bound — say so rather than imply
+# precision the measurement does not have.
+BEHIND=""
+if [[ "$BRANCH" == "main" || "$BRANCH" == "deploy/main" ]]; then
+    BEHIND="$(git -C "$REPO_ROOT" rev-list --count HEAD..origin/main 2>/dev/null || echo "")"
+fi
+if [[ -z "$BEHIND" ]]; then
+    # No origin/main ref locally, or git failed. CANNOT-VERIFY is not CLEAN:
+    # never let "I could not check" read as "nothing to report" (W106b).
+    echo "$LOG_PREFIX WARN: could not measure checkout distance from origin/main — verdicts below are of UNKNOWN freshness" >&2
+elif (( BEHIND > 0 )); then
+    echo "$LOG_PREFIX WARN: $REPO_ROOT is >= $BEHIND commits behind origin/main — every verdict below is judged against THAT vintage of the census, not today's. Do NOT pull here (sibling-race): refresh the checkout from an interactive session on this machine." >&2
+fi
+
 # ── python: backend venv first (PyYAML guaranteed), else system if yaml works ─
 PYBIN="$REPO_ROOT/apps/backend-rag/.venv/bin/python3"
 if [[ ! -x "$PYBIN" ]]; then


### PR DESCRIPTION
The guardian's wrapper warned when the checkout was off `main`, but being ON main says nothing about being CURRENT with it. Measured 2026-07-29: the M5 checkout sat **251 commits behind** `origin/main` while #3415 — the census fix that cleared 5 false REGRESSED — was already merged and already proven live on Pro. This cron would have kept reporting cured edges as regressions with no line saying the map was old, and the branch check could never catch it: the branch was `main` throughout.

Reads the DISTANCE, not the name. Report-only by construction: never fetches (a cron reaching the network to judge its own freshness is a new failure mode; offline is natural here, Law 6), never pulls (the sibling-race scar commented three lines above stays), so the count is a **lower bound** against the last-known `origin/main` in the local object store — the message says `>= N` rather than implying precision the measurement lacks. A failed measurement warns CANNOT-VERIFY instead of staying silent: "I could not check" must never read as "nothing to report" (W106b).

Guilt and innocence run against the real script, not an extracted copy:
- `REPO_ROOT=~/nuzantara` (251 behind) → WARN fires, names 251
- `REPO_ROOT=<aligned worktree>` (0 behind) → zero "behind" lines

No unit test, stated as a choice: the cheap one would assert the script *contains* the check — form instead of entity, the anti-pattern this repo keeps paying for — and an honest one would run the full verifier in CI. (Independently relevant: 175/258 tests under `scripts/tests/` are executed by no workflow today.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)