### PR TITLE
fix(kbli): three live pages published an ownership cap that means nothing

### DIFF
--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -16,6 +16,7 @@ import { formatTimeframe } from "@/lib/kbli-derive";
 import { baliBlockClause } from "@/lib/kbli-bali-block";
 import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 import { kbliMetaDescription, kbliMetaTitle } from "@/lib/kbli-meta";
+import { restrictedCapBadge } from "@/lib/kbli-pma-shape";
 import { KBLIBreadcrumb } from "@/components/kbli/KBLIBreadcrumb";
 import { PMABadge } from "@/components/kbli/PMABadge";
 import { RiskBadge } from "@/components/kbli/RiskBadge";
@@ -855,9 +856,7 @@ export default async function KBLICodePage({
                               : kbli.pma.status === "open"
                                 ? `${kbli.pma.maxForeign}% Open`
                                 : kbli.pma.status === "restricted"
-                                  ? kbli.pma.capVerified
-                                    ? `Max ${kbli.pma.maxForeign}%`
-                                    : `≈${kbli.pma.maxForeign}% (unverified)`
+                                  ? restrictedCapBadge(kbli.pma)
                                   : "Closed"}
                           </span>
                         </div>

--- a/apps/mouth/src/components/kbli/KBLIStructuredData.tsx
+++ b/apps/mouth/src/components/kbli/KBLIStructuredData.tsx
@@ -1,6 +1,29 @@
 import type { KBLICode } from "@/lib/kbli-types";
 import { buildKbliFaq } from "@/lib/kbli-faq";
 import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
+import { pmaCapShape } from "@/lib/kbli-pma-shape";
+
+/**
+ * The TERBATAS ownership clause for structured data.
+ *
+ * This surface interpolated `max ${maxForeign}%` unconditionally and — unlike
+ * the visible answer and the FAQ builder — never checked `capSpecial`, so
+ * /kbli/47221 published the literal string "Restricted to max special% foreign
+ * ownership (TERBATAS)" in both JSON-LD blocks (measured live 2026-07-29). That
+ * is the same visible-vs-JSON-LD drift the header of `kbli-faq.ts` already
+ * records having happened once; one shared classifier is what stops a third.
+ */
+function restrictedPmaStructuredLabel(code: KBLICode): string {
+  switch (pmaCapShape(code.pma)) {
+    case "none":
+      return "Closed to foreign ownership in practice — 0% ceiling (TERBATAS)";
+    case "full":
+    case "conditional":
+      return "Restricted by conditions rather than an ownership ceiling (TERBATAS)";
+    default:
+      return `Restricted to max ${code.pma.maxForeign}% foreign ownership (TERBATAS)`;
+  }
+}
 
 export function KBLICodeJsonLd({
   code,
@@ -46,7 +69,7 @@ export function KBLICodeJsonLd({
     code.pma.status === "open"
       ? `100% foreign ownership allowed (TERBUKA)${baliNat}`
       : code.pma.status === "restricted"
-        ? `Restricted to max ${code.pma.maxForeign}% foreign ownership (TERBATAS)`
+        ? restrictedPmaStructuredLabel(code)
         : "Closed to foreign investment (TERTUTUP)"
   }${pmaAttribution}`;
 

--- a/apps/mouth/src/components/kbli/LicensingSection.tsx
+++ b/apps/mouth/src/components/kbli/LicensingSection.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@/lib/kbli-types";
 import { formatTimeframe } from "@/lib/kbli-derive";
 import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
+import { restrictedCapBadge } from "@/lib/kbli-pma-shape";
 import {
   baliBlockClause,
   shouldShowReason,
@@ -224,7 +225,7 @@ function KeyFacts({
               ? "100% nat'l · blocked in Bali"
               : "100% Open"
             : pma.status === "restricted"
-              ? `Max ${pma.maxForeign}%`
+              ? restrictedCapBadge(pma)
               : "Closed (0%)",
         accent:
           pma.status === "open" && !baliBlocked
@@ -292,7 +293,7 @@ function KeyFacts({
             ? "100% nat'l · blocked in Bali"
             : "100% Open"
           : pma.status === "restricted"
-            ? `Max ${pma.maxForeign}%`
+            ? restrictedCapBadge(pma)
             : "Closed (0%)",
       accent:
         pma.status === "open" && !baliBlocked

--- a/apps/mouth/src/lib/kbli-faq.ts
+++ b/apps/mouth/src/lib/kbli-faq.ts
@@ -1,6 +1,7 @@
 import type { KBLICode } from "@/lib/kbli-types";
 import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 import { baliBlockClause, shouldShowReason } from "@/lib/kbli-bali-block";
+import { pmaCapShape } from "@/lib/kbli-pma-shape";
 
 export interface KbliFaqEntry {
   question: string;
@@ -13,22 +14,46 @@ const KBLI_2025_POST_DEADLINE_NOTE =
 const KBLI_2025_MIGRATION_OVERDUE_NOTE =
   "The June 2026 KBLI 2025 transition window has closed. If an NIB still relies on legacy KBLI 2020 mappings, treat the migration as overdue and verify/remediate the OSS record before new license applications, amendments, LKPM, import approvals, or investor/worker sponsorship.";
 
+/** Condition prose, spliced as its own sentence. */
+function conditionClause(code: KBLICode): string {
+  const c = code.pma.condition;
+  if (!c) return "";
+  // The splice used to run straight into the next sentence — live on /kbli/47111
+  // as "Condition: UMKM only An Indonesian partner holds…". The dataset's
+  // condition strings carry no terminal punctuation, so it is added here.
+  return ` Condition: ${/[.!?]$/.test(c.trim()) ? c.trim() : `${c.trim()}.`}`;
+}
+
 /**
- * Single source of truth for the per-code FAQ.
+ * The TERBATAS answer, split out of the nested ternary it used to live in so the
+ * extremes can be handled and tested.
  *
- * Feeds BOTH the FAQPage JSON-LD (KBLIFaqJsonLd) and the visible
- * "Common Questions" section (KBLICommonQuestions). Google requires
- * FAQPage markup content to be visible on the page — before this module
- * the JSON-LD was emitted on every page while the visible Q&A only
- * existed on non-Gold layouts, and the two texts had drifted apart
- * (the JSON-LD carried the Bali-block qualification, the visible answer
- * did not; the visible answer handled capSpecial, the JSON-LD did not).
- * One builder = the markup is honest by construction.
- *
- * Every fact below comes from dataset fields already rendered elsewhere
- * on the same page (PMA verdict banner, licensing table, transition
- * note) — no new regulatory claims.
+ * The old single string said "foreign ownership is capped at {cap}% … An
+ * Indonesian partner holds the remaining shares" for EVERY restricted code. On
+ * the two extremes that trailing clause is not merely clumsy: at 100% there are
+ * no remaining shares, so the sentence was false — in the visible answer AND in
+ * the FAQPage JSON-LD, which is the copy Google ingests (measured live on
+ * /kbli/79110, 2026-07-29).
  */
+function restrictedPmaAnswer(code: KBLICode): string {
+  const head = `KBLI ${code.code} (${code.titleId})`;
+  const cond = conditionClause(code);
+
+  if (code.pma.capSpecial) {
+    return `Conditionally. ${head} is TERBATAS with special distribution conditions (open to foreign ownership but subject to a special distribution-network/location requirement — verify the exact terms in OSS).${cond}`;
+  }
+
+  switch (pmaCapShape(code.pma)) {
+    case "none":
+      return `No. ${head} is TERBATAS, but the ceiling for foreign capital is 0% — in practice the activity is not available to a PT PMA and is held by an Indonesian-owned company.${cond}`;
+    case "full":
+    case "conditional":
+      return `Yes, with conditions. ${head} is TERBATAS, but the restriction is not an ownership ceiling — foreign ownership may reach 100%. Verify the applicable conditions in OSS.${cond}`;
+    default:
+      return `Partially. ${head} is TERBATAS — foreign ownership is ${code.pma.capVerified ? "capped" : "indicatively capped (unverified)"} at ${code.pma.maxForeign}%.${cond} An Indonesian partner holds the remaining shares.`;
+  }
+}
+
 export function buildKbliFaq(code: KBLICode): KbliFaqEntry[] {
   const baliBlocked = !!code.baliL4?.blocked;
   // GARUDA-FILIERA Fase-1 cure #4 (2026-07-17): the risk tier the earlier
@@ -58,9 +83,7 @@ export function buildKbliFaq(code: KBLICode): KbliFaqEntry[] {
           ? `Nationally yes — but Bali applicability cannot be determined yet. KBLI ${code.code} (${code.titleId}) is TERBUKA (100% foreign ownership) at the national level; whether Bali's PMA moratorium applies to this specific activity is not yet classifiable, pending re-derivation of the correct risk tier. Verify with the Bali Zero team before planning a Bali setup.`
           : `Yes. KBLI ${code.code} (${code.titleId}) is TERBUKA — open to 100% foreign ownership via PT PMA. No local Indonesian partner required.`
       : code.pma.status === "restricted"
-        ? code.pma.capSpecial
-          ? `Conditionally. KBLI ${code.code} (${code.titleId}) is TERBATAS with special distribution conditions (open to foreign ownership but subject to a special distribution-network/location requirement — verify the exact terms in OSS).${code.pma.condition ? ` Condition: ${code.pma.condition}` : ""}`
-          : `Partially. KBLI ${code.code} (${code.titleId}) is TERBATAS — foreign ownership is ${code.pma.capVerified ? "capped" : "indicatively capped (unverified)"} at ${code.pma.maxForeign}%.${code.pma.condition ? ` Condition: ${code.pma.condition}` : ""} An Indonesian partner holds the remaining shares.`
+        ? restrictedPmaAnswer(code)
         : `No. KBLI ${code.code} (${code.titleId}) is TERTUTUP — closed to foreign investment. Reserved for Indonesian nationals only.`;
 
   // PMA source attribution with vintage (FATAL-2 axis): the investment-list

--- a/apps/mouth/src/lib/kbli-meta.ts
+++ b/apps/mouth/src/lib/kbli-meta.ts
@@ -27,6 +27,7 @@
 // =============================================================================
 
 import { riskLabelEn } from "./kbli-derive";
+import { pmaCapShape } from "./kbli-pma-shape";
 import {
   isBaliL4BlockVerifiedForBareClaim,
   isLicensingVerifiedForBareClaim,
@@ -62,9 +63,16 @@ export function kbliPmaLabel(kbli: KBLICode): string {
   if (kbli.pma.status !== "restricted") return "Closed to Foreign Investment";
   if (kbli.pma.capSpecial)
     return "Restricted (special distribution conditions)";
-  return kbli.pma.capVerified
-    ? `Restricted (max ${kbli.pma.maxForeign}% foreign)`
-    : "Restricted for foreign ownership";
+  if (!kbli.pma.capVerified) return "Restricted for foreign ownership";
+  switch (pmaCapShape(kbli.pma)) {
+    case "none":
+      return "Closed to Foreign Investment";
+    case "full":
+    case "conditional":
+      return "Restricted (conditions apply, no ownership cap)";
+    default:
+      return `Restricted (max ${kbli.pma.maxForeign}% foreign)`;
+  }
 }
 
 /**
@@ -85,10 +93,24 @@ export function kbliMetaTitleSuffix(kbli: KBLICode): string {
       : "100% Foreign Ownership";
   }
   if (kbli.pma.status === "restricted") {
+    // Order is load-bearing and unchanged: a special-distribution regime has no
+    // percentage at all, so the percentage's provenance flag cannot speak to it.
     if (kbli.pma.capSpecial) return "Foreign Ownership With Conditions";
-    return kbli.pma.capVerified
-      ? `Max ${kbli.pma.maxForeign}% Foreign Ownership`
-      : "Foreign Ownership Restricted";
+    if (!kbli.pma.capVerified) return "Foreign Ownership Restricted";
+    switch (pmaCapShape(kbli.pma)) {
+      // A 0% ceiling is not a share on offer. Outcome-identical to the 61
+      // TERTUTUP codes, which already say exactly this — 47111 missed the
+      // wording only because it is classified TERBATAS.
+      case "none":
+        return "Closed to Foreign Investment";
+      // "Max 100%" restricts nothing. Whatever binds here is a condition, so
+      // it borrows the phrasing capSpecial already uses.
+      case "full":
+      case "conditional":
+        return "Foreign Ownership With Conditions";
+      default:
+        return `Max ${kbli.pma.maxForeign}% Foreign Ownership`;
+    }
   }
   return "Closed to Foreign Investment";
 }

--- a/apps/mouth/src/lib/kbli-pma-shape.test.ts
+++ b/apps/mouth/src/lib/kbli-pma-shape.test.ts
@@ -1,0 +1,217 @@
+// Corpus for the ownership-cap extremes.
+//
+// GUILT is the three strings that were LIVE on balizero.com on 2026-07-29:
+//   /kbli/47111  "Max 0% Foreign Ownership"                       (cap 0)
+//   /kbli/79110  "Max 100% Foreign Ownership"                     (cap 100)
+//   /kbli/47221  "Restricted to max special% foreign ownership"   (cap "special")
+// INNOCENCE is the seven codes that were always right (cap 49) plus the
+// provenance gate: an UNVERIFIED cap must still refuse to state a figure, and
+// that refusal must not be re-opened by any of the branches added here.
+//
+// The reason this file exists at all: kbli-meta.test.ts exercised the cap with
+// 100 (on an `open` code) and 67 — the middle of the range and nothing else, so
+// the formula was proven exactly where it was already correct.
+
+import { describe, expect, it } from "vitest";
+import type { KBLICode } from "./kbli-types";
+import { pmaCapShape, restrictedCapBadge } from "./kbli-pma-shape";
+import { kbliMetaTitleSuffix, kbliPmaLabel } from "./kbli-meta";
+import { buildKbliFaq } from "./kbli-faq";
+
+function restricted(overrides: Partial<KBLICode["pma"]> = {}): KBLICode {
+  return {
+    code: "47111",
+    titleId: "Perdagangan Eceran Swalayan",
+    titleEn: "Supermarket / Hypermarket",
+    titleEnMeta: "Supermarket / Hypermarket",
+    description: "Test description",
+    section: "G",
+    sectionName: "Wholesale and Retail Trade",
+    pma: {
+      status: "restricted",
+      maxForeign: 49,
+      condition: null,
+      isPriority: false,
+      note: null,
+      source: "Perpres 10/2021",
+      capSpecial: false,
+      capVerified: true,
+      routeTo: null,
+      ...overrides,
+    },
+    licensing: [],
+    transition: {
+      mappingStatus: "MATCH_LANGSUNG",
+      previousCodes: [],
+      kbli2020Source: null,
+      mappingNote: null,
+      aggregationNote: null,
+    },
+    tier: "silver",
+    keywords: [],
+  } as unknown as KBLICode;
+}
+
+const pmaAnswerOf = (code: KBLICode) =>
+  buildKbliFaq(code).find((q) => /foreign|PMA|own/i.test(q.question))?.answer ??
+  "";
+
+describe("pmaCapShape", () => {
+  it("classifies the middle of the range as a real percentage", () => {
+    expect(pmaCapShape(restricted({ maxForeign: 49 }).pma)).toBe("partial");
+    expect(pmaCapShape(restricted({ maxForeign: 1 }).pma)).toBe("partial");
+    expect(pmaCapShape(restricted({ maxForeign: 99 }).pma)).toBe("partial");
+  });
+
+  it("treats both extremes as NOT a percentage", () => {
+    expect(pmaCapShape(restricted({ maxForeign: 0 }).pma)).toBe("none");
+    expect(pmaCapShape(restricted({ maxForeign: 100 }).pma)).toBe("full");
+  });
+
+  it("treats a non-numeric cap as conditional even when the flag disagrees", () => {
+    // `capSpecial` and the "special" cap value come from two INDEPENDENT raw
+    // fields (pma_cap_special / pma_max_asing). They agree on exactly one
+    // record today; nothing structural keeps them in step, and this arm is what
+    // stops a literal "Max special%" if they ever drift apart.
+    expect(
+      pmaCapShape(restricted({ maxForeign: "special", capSpecial: false }).pma),
+    ).toBe("conditional");
+  });
+});
+
+describe("the <title> suffix", () => {
+  it("GUILT: a 0% ceiling is not a share on offer", () => {
+    const suffix = kbliMetaTitleSuffix(restricted({ maxForeign: 0 }));
+    expect(suffix).not.toContain("Max 0%");
+    expect(suffix).toBe("Closed to Foreign Investment");
+  });
+
+  it("GUILT: a 100% ceiling restricts nothing", () => {
+    const suffix = kbliMetaTitleSuffix(restricted({ maxForeign: 100 }));
+    expect(suffix).not.toContain("Max 100%");
+    expect(suffix).toBe("Foreign Ownership With Conditions");
+  });
+
+  it("GUILT: a drifted non-numeric cap never reaches the page as a number", () => {
+    const suffix = kbliMetaTitleSuffix(
+      restricted({ maxForeign: "special", capSpecial: false }),
+    );
+    expect(suffix).not.toContain("special%");
+    expect(suffix).not.toMatch(/Max /);
+  });
+
+  it("INNOCENCE: the seven cap-49 codes are untouched", () => {
+    expect(kbliMetaTitleSuffix(restricted({ maxForeign: 49 }))).toBe(
+      "Max 49% Foreign Ownership",
+    );
+  });
+
+  it("INNOCENCE: the capSpecial regime keeps its own wording", () => {
+    expect(
+      kbliMetaTitleSuffix(
+        restricted({ maxForeign: "special", capSpecial: true }),
+      ),
+    ).toBe("Foreign Ownership With Conditions");
+  });
+
+  it("INNOCENCE: an unverified cap still states nothing — at ANY shape", () => {
+    // The provenance gate predates this change and must survive it. If a future
+    // edit reorders the branches so a shape answers before capVerified, an
+    // unverified 0 would start asserting "Closed to Foreign Investment" as fact.
+    for (const cap of [0, 49, 100] as const) {
+      expect(
+        kbliMetaTitleSuffix(
+          restricted({ maxForeign: cap, capVerified: false }),
+        ),
+      ).toBe("Foreign Ownership Restricted");
+    }
+  });
+});
+
+describe("the <meta description> label", () => {
+  it("GUILT: degrades at both extremes instead of printing them", () => {
+    expect(kbliPmaLabel(restricted({ maxForeign: 0 }))).toBe(
+      "Closed to Foreign Investment",
+    );
+    expect(kbliPmaLabel(restricted({ maxForeign: 100 }))).not.toContain(
+      "max 100%",
+    );
+  });
+
+  it("INNOCENCE: still prints a genuine ceiling, and still hides an unverified one", () => {
+    expect(kbliPmaLabel(restricted({ maxForeign: 49 }))).toBe(
+      "Restricted (max 49% foreign)",
+    );
+    expect(
+      kbliPmaLabel(restricted({ maxForeign: 49, capVerified: false })),
+    ).toBe("Restricted for foreign ownership");
+  });
+});
+
+describe("the FAQ answer — visible copy AND FAQPage JSON-LD", () => {
+  it("GUILT: at 100% there are no remaining shares for a partner to hold", () => {
+    const answer = pmaAnswerOf(restricted({ maxForeign: 100 }));
+    expect(answer).not.toContain("remaining shares");
+    expect(answer).not.toContain("capped at 100%");
+  });
+
+  it("GUILT: at 0% the answer is no, not a cap", () => {
+    const answer = pmaAnswerOf(restricted({ maxForeign: 0 }));
+    expect(answer).not.toContain("capped at 0%");
+    expect(answer).not.toContain("remaining shares");
+    expect(answer.startsWith("No.")).toBe(true);
+  });
+
+  it("INNOCENCE: a real ceiling keeps the partner clause that is true for it", () => {
+    const answer = pmaAnswerOf(restricted({ maxForeign: 49 }));
+    expect(answer).toContain("capped at 49%");
+    expect(answer).toContain(
+      "An Indonesian partner holds the remaining shares",
+    );
+  });
+
+  it("splices the condition as its own sentence", () => {
+    // Live on /kbli/47111 as "Condition: UMKM only An Indonesian partner…" —
+    // the dataset's condition strings carry no terminal punctuation.
+    const answer = pmaAnswerOf(
+      restricted({ maxForeign: 49, condition: "UMKM only" }),
+    );
+    expect(answer).toContain("Condition: UMKM only.");
+    expect(answer).not.toContain("UMKM only An");
+  });
+
+  it("does not double the punctuation when the condition already ends a sentence", () => {
+    const answer = pmaAnswerOf(
+      restricted({ maxForeign: 49, condition: "Kemitraan dengan UMKM." }),
+    );
+    expect(answer).toContain("Condition: Kemitraan dengan UMKM.");
+    expect(answer).not.toContain("UMKM..");
+  });
+});
+
+describe("the visible badge", () => {
+  it("GUILT: never renders a percentage that is not one", () => {
+    expect(restrictedCapBadge(restricted({ maxForeign: 0 }).pma)).toBe(
+      "Closed (0%)",
+    );
+    expect(restrictedCapBadge(restricted({ maxForeign: 100 }).pma)).toBe(
+      "Conditions apply",
+    );
+    expect(
+      restrictedCapBadge(
+        restricted({ maxForeign: "special", capSpecial: false }).pma,
+      ),
+    ).not.toContain("special%");
+  });
+
+  it("INNOCENCE: keeps the ceiling, and keeps the unverified qualifier", () => {
+    expect(restrictedCapBadge(restricted({ maxForeign: 49 }).pma)).toBe(
+      "Max 49%",
+    );
+    expect(
+      restrictedCapBadge(
+        restricted({ maxForeign: 49, capVerified: false }).pma,
+      ),
+    ).toBe("≈49% (unverified)");
+  });
+});

--- a/apps/mouth/src/lib/kbli-pma-shape.ts
+++ b/apps/mouth/src/lib/kbli-pma-shape.ts
@@ -1,0 +1,119 @@
+// =============================================================================
+// kbli-pma-shape.ts — what a foreign-ownership cap MEANS, once the extremes are
+// taken seriously.
+//
+// `kbli-pma-cap.ts` is the single resolver for the cap's VALUE, and its header
+// already states the hard part:
+//
+//     "pma_status is unambiguous only at its two extremes. TERBATAS ('limited')
+//      spans 0%, 49%, 100% and a non-percentage regime, so it can never be
+//      turned into a figure."
+//
+// That resolver honours it. Every PRESENTER then interpolated the value into
+// `Max ${cap}%` without asking whether the figure meant anything, so a range
+// the data layer knows is heterogeneous was rendered as if it were uniform.
+// Measured on the live site 2026-07-29, after #3186 shipped the v3 titles:
+//
+//   /kbli/47221  "special" → `Max special%` ×5, one of them VISIBLE body text
+//                and two inside JSON-LD ("Restricted to max special% foreign
+//                ownership (TERBATAS)"). `KBLIStructuredData` never checked
+//                `capSpecial` — the exact recurrence `kbli-faq.ts` already
+//                records as having happened once ("the visible answer handled
+//                capSpecial, the JSON-LD did not").
+//   /kbli/47111  cap 0    → `Max 0%` ×9, and an FAQ answer reading "capped at
+//                0% … An Indonesian partner holds the remaining shares".
+//   /kbli/79110  cap 100  → `Max 100%` ×7, same trailing clause — which at 100%
+//                is not awkward but FALSE, in FAQPage JSON-LD that Google
+//                ingests.
+//
+// Three codes of 1,559. The other seven TERBATAS rows (cap 49) render exactly
+// right, which is the point: the formula is correct in its middle and wrong at
+// both ends. So the fix is not new phrasing sprinkled per call-site — it is one
+// classifier the presenters share, for the same reason `resolvePmaCap` exists:
+// a rule that decides one fact belongs in ONE module.
+//
+// WHAT THIS MODULE DELIBERATELY DOES NOT DO: it never reads `pma_kondisi` /
+// `pma.condition`. The condition text is ungated free prose (e.g. "UMKM only");
+// promoting it into a <title> or JSON-LD would be a NEW regulatory assertion on
+// an indexed surface, which is precisely what `kbli-meta.ts` exists to prevent.
+// The shape below is derived only from values the existing provenance gates
+// already cover.
+// =============================================================================
+
+/**
+ * Structural shape, mirroring `PmaCapSource` in kbli-pma-cap.ts: the presenters
+ * that need this are split between ones holding a whole `KBLICode` and ones
+ * handed only the `pma` sub-object, and a classifier that only half of them can
+ * call is how per-call-site phrasing gets reinvented in the first place.
+ */
+export interface PmaShapeSource {
+  maxForeign: number | "special";
+  capSpecial: boolean;
+  capVerified: boolean;
+}
+
+/**
+ * What the cap says about foreign capital, independent of how any surface
+ * chooses to word it.
+ *
+ * - `none`        — the ceiling is 0%: no foreign capital, whatever the status
+ *                   label says. Outcome-identical to TERTUTUP for a PT PMA.
+ * - `partial`     — a real ceiling strictly between 0 and 100. The percentage
+ *                   IS the answer; this is the case the v3 formula was written
+ *                   for (49% cabotage, and it reads perfectly).
+ * - `full`        — the ceiling is 100%: whatever restricts this activity, it
+ *                   is not a share of ownership. "Max 100%" restricts nothing.
+ * - `conditional` — no usable figure at all: the special-distribution regime,
+ *                   or any value that is not a finite number. Never render a
+ *                   percentage for this.
+ */
+export type PmaCapShape = "none" | "partial" | "full" | "conditional";
+
+/**
+ * Classify a restricted code's cap.
+ *
+ * Only meaningful when `kbli.pma.status === "restricted"` — `open` and `closed`
+ * carry their answer in the status itself and never reach here.
+ *
+ * The `typeof !== "number"` arm is load-bearing, not defensive noise. Today
+ * `capSpecial` and the `"special"` cap value agree on exactly one record
+ * (47221, verified across all 1,559), but they come from two INDEPENDENT raw
+ * fields — `pma_cap_special` and `pma_max_asing` — so nothing structurally
+ * keeps them in step. If they ever drift, this arm is what stops a literal
+ * `Max special%` from reaching a public page again.
+ */
+export function pmaCapShape(pma: PmaShapeSource): PmaCapShape {
+  if (pma.capSpecial) return "conditional";
+
+  const cap = pma.maxForeign;
+  if (typeof cap !== "number" || !Number.isFinite(cap)) return "conditional";
+
+  if (cap <= 0) return "none";
+  if (cap >= 100) return "full";
+  return "partial";
+}
+
+/**
+ * The compact label the visible badges show for a TERBATAS code.
+ *
+ * Three call-sites rendered this independently — `LicensingSection` twice and
+ * the detail page once — and they had already drifted: the page qualified an
+ * unverified cap as `≈N% (unverified)`, the two badges printed a bare `Max N%`
+ * for the same record. This adopts the page's (more careful) behaviour for all
+ * three. Live delta today is zero: no restricted code carries
+ * `pma_cap_verified: false` — the only two rows that do, 02101 and 03120, are
+ * TERBUKA and never reach this branch.
+ */
+export function restrictedCapBadge(pma: PmaShapeSource): string {
+  switch (pmaCapShape(pma)) {
+    case "none":
+      return "Closed (0%)";
+    case "full":
+    case "conditional":
+      return "Conditions apply";
+    default:
+      return pma.capVerified
+        ? `Max ${pma.maxForeign}%`
+        : `≈${pma.maxForeign}% (unverified)`;
+  }
+}


### PR DESCRIPTION
## What this is

Found by reading the **rendered** titles during the prove-live of #3186 — not by reading the diff. Every string below was measured on the live public site after that deploy landed, and then against the 1,559-code dataset.

`resolvePmaCap` already states the hard part in its own header:

> "`pma_status` is unambiguous only at its two extremes. TERBATAS ('limited') spans 0%, 49%, 100% and a non-percentage regime, so it can never be turned into a figure."

It honours that. **Every presenter then interpolated the value into `Max ${cap}%` without asking whether the figure meant anything.** The data layer knew the range was heterogeneous; the six surfaces that render it did not.

## Live on balizero.com before this PR

Counts are `grep -o | wc -l` on the fetched HTML.

| page | string | count |
|---|---|---|
| `/kbli/47221` | `Max special%` / `Restricted to max special% foreign ownership (TERBATAS)` | **5**, one VISIBLE (`<span>Max special%</span>`), two inside JSON-LD |
| `/kbli/47111` | `Max 0%` (cap 0, `pma_kondisi: "UMKM only"`) | **9** |
| `/kbli/79110` | `Max 100%` | **7** |

Two of these are worse than clumsy:

- `KBLIStructuredData.tsx` **never checked `capSpecial` at all**, so a literal `special%` went into structured data. That is the exact visible-vs-JSON-LD drift the header of `kbli-faq.ts` already records having happened once ("the visible answer handled capSpecial, the JSON-LD did not").
- The FAQ answer ends `"…An Indonesian partner holds the remaining shares."` for **every** restricted code. At 100% there are no remaining shares — so that sentence was **false**, in FAQPage JSON-LD, which is the copy Google ingests.

## Three codes of 1,559

The whole TERBATAS set is 10. The other seven (`50111`/`50112`/`50113`/`50121`/`50122`/`50123`/`50126`, cap 49) were always right and are untouched — cap 49 is exactly what the v3 formula was written for. **The formula is correct in its middle and wrong at both ends plus the non-numeric case.**

So this is not new phrasing sprinkled per call-site. It is one classifier the presenters share, for the same reason `resolvePmaCap` exists — a rule that decides one fact belongs in one module.

| shape | condition | rendered as |
|---|---|---|
| `none` | cap ≤ 0 | "Closed to Foreign Investment" — what the 61 TERTUTUP codes already say; 47111 missed the wording only because it is classified TERBATAS |
| `full` | cap ≥ 100 | the conditions phrasing `capSpecial` already uses |
| `conditional` | non-numeric | same; never renders a percentage |
| `partial` | otherwise | unchanged `Max N%` |

The **provenance gate is preserved and comes FIRST** on every surface: an unverified cap still refuses to state anything, at any shape. Pinned by a test that loops all three shapes, so a future reorder cannot let an unverified `0` start asserting "Closed to Foreign Investment" as fact.

The `typeof !== "number"` arm is load-bearing, not defensive noise: `capSpecial` and the `"special"` cap value come from two **independent** raw fields (`pma_cap_special` / `pma_max_asing`). They agree on exactly one record today (verified across all 1,559); nothing structural keeps them in step.

## Why it survived review

`kbli-meta.test.ts` (379 lines, shipped in #3186) exercises the cap branch with **100 and 67** — and the 100 case is on an `open` code, never a restricted one. Neither extreme of the restricted branch, and never the `"special"` value, had a test. The formula was proven exactly where it was already correct.

## Verification

- **18 new cases**: guilt (each of the three live strings, on each surface that published it) + innocence (cap 49 on every surface, `capSpecial`, and the unverified gate).
- **Mutation-verified**: with the classifier disarmed to always answer `"partial"` — i.e. the pre-fix world — **7 of 18 fail**; restored, **18/18 pass**.
- Existing KBLI suites: **82/82**, no regressions.
- `tsc --noEmit` clean (also re-run by the pre-commit hook).

**Not verified locally, stated rather than hidden:** apps/mouth's React component tests could not run on this machine — the shared `node_modules` at the checkout root is damaged (`express-rate-limit` exists as a non-directory, so `npm` exits ENOTDIR and the vitest config cannot load its react plugin). The lib tests above are pure functions and unaffected. Neither `LicensingSection` nor `KBLIStructuredData` has a test file, so nothing regresses there either way. CI runs the full suite.

## Deliberately NOT done — measured, not skipped

- `KBLIStructuredData` still does not apply the `capVerified` gate its sibling surfaces apply. Adding it would change **nothing today**: the only two rows with `pma_cap_verified: false` are `02101` and `03120`, both TERBUKA, which never reach this branch. An unmeasured behaviour change stays out.
- `50111` and `50112` carry `pma_kondisi: "Hanya PMDN (100% domestik)"` (domestic capital only) while their cap says 49% foreign. Both facts are ours to publish and they **contradict each other**. 49% is the known cabotage ceiling, so the kondisi text is the likelier stale side — but that is a regulatory-content call for the KBLI lane, not a presentation fix, and a guess must not be encoded into an indexed page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
