### PR TITLE
fix(admin-dashboard): close the critical SSRF that PR #3430 shipped to main (CodeQL #8318)

### DIFF
--- a/apps/admin-dashboard/app/api/portal/invite/route.ts
+++ b/apps/admin-dashboard/app/api/portal/invite/route.ts
@@ -5,6 +5,20 @@ export const dynamic = "force-dynamic";
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
 
+/**
+ * The backend keys client invitations on an integer primary key
+ * (`portal_invite.py::get_client_invitations(client_id: int)`), so anything that is
+ * not a plain positive integer is not a client id — it is a path segment trying to
+ * escape the endpoint it was interpolated into.
+ *
+ * Without this, `?clientId=../../../../<path>` is normalised away by `fetch` and the
+ * proxy calls an arbitrary backend route while forwarding the caller's authorization
+ * and cookie headers (CodeQL js/request-forgery, alert #8318).
+ */
+export function isValidClientId(raw: string | null): raw is string {
+  return raw !== null && /^[1-9][0-9]{0,17}$/.test(raw);
+}
+
 export async function POST(request: Request) {
   try {
     const body = await request.json();
@@ -36,8 +50,11 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const clientId = searchParams.get("clientId");
-    if (!clientId) {
-      return NextResponse.json({ error: "clientId required" }, { status: 400 });
+    if (!isValidClientId(clientId)) {
+      return NextResponse.json(
+        { error: "clientId must be a positive integer" },
+        { status: 400 },
+      );
     }
 
     const authHeader = request.headers.get("authorization") ?? "";

--- a/apps/admin-dashboard/tests/portal-invite-clientid.test.ts
+++ b/apps/admin-dashboard/tests/portal-invite-clientid.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidClientId } from "@/app/api/portal/invite/route";
+
+/**
+ * Guard for CodeQL alert #8318 (js/request-forgery), introduced by PR #3430 and
+ * merged to main before it was fixed.
+ *
+ * `clientId` is interpolated into `${BACKEND_URL}/api/portal/invite/client/${clientId}`
+ * while the route forwards the caller's `authorization` and `cookie` headers. If a
+ * caller can put path separators or traversal segments into it, `fetch` normalises
+ * them away and the proxy becomes an authenticated gateway to any backend route.
+ *
+ * Per repo convention every guard proves GUILT (it rejects the attack) and
+ * INNOCENCE (it does not reject legitimate input).
+ */
+describe("isValidClientId — GUILT: rejects anything that could redirect the request", () => {
+  const attacks: [string, string][] = [
+    ["parent traversal", "../../../../admin/secrets"],
+    ["single traversal", ".."],
+    ["encoded traversal", "%2e%2e%2f"],
+    ["leading slash", "/admin"],
+    ["embedded slash", "1/../../admin"],
+    ["absolute url", "http://evil.example.com/"],
+    ["protocol-relative url", "//evil.example.com"],
+    ["query smuggling", "1?admin=true"],
+    ["fragment smuggling", "1#/admin"],
+    ["newline injection", "1\n/admin"],
+    ["backslash", "1\\admin"],
+    ["semicolon param", "1;a=b"],
+    ["at-sign host swap", "1@evil.example.com"],
+  ];
+
+  it.each(attacks)("rejects %s", (_label, raw) => {
+    expect(isValidClientId(raw)).toBe(false);
+  });
+
+  it("rejects null (no clientId supplied)", () => {
+    expect(isValidClientId(null)).toBe(false);
+  });
+
+  it("rejects the empty string", () => {
+    expect(isValidClientId("")).toBe(false);
+  });
+
+  it("rejects non-integer shapes the backend could not key on", () => {
+    for (const raw of [
+      "0",
+      "-1",
+      "1.5",
+      "1e3",
+      " 1",
+      "1 ",
+      "+1",
+      "abc",
+      "007",
+    ]) {
+      expect(isValidClientId(raw)).toBe(false);
+    }
+  });
+});
+
+describe("isValidClientId — INNOCENCE: accepts real client ids", () => {
+  it("accepts the id shape the backend keys on (positive integer)", () => {
+    for (const raw of ["1", "42", "12028", "999999"]) {
+      expect(isValidClientId(raw)).toBe(true);
+    }
+  });
+
+  it("accepts an id at the top of the real table without truncating it", () => {
+    // `clients` held 12,028 rows when this guard was written; the guard must not
+    // cap legitimate growth, only reject non-integers.
+    expect(isValidClientId("123456789012345678")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`apps/admin-dashboard/app/api/portal/invite/route.ts` interpolated `clientId` — taken straight from
the query string — into the backend path while forwarding the caller's `authorization` and `cookie`
headers. The only guard was a non-empty check.

That makes the proxy an **authenticated gateway to any backend route**: `?clientId=../../../../<path>`
is normalised away by `fetch`, and the caller's own credentials travel to a destination the caller
chose.

CodeQL flagged it as **critical** (`js/request-forgery`, alert #8318) three minutes after PR #3430
opened. #3430 merged 66 minutes later, still at one commit, unfixed. The alert is `state: open`,
`fixed_at: null`.

## The fix

Validate the shape against what the backend actually keys on — `portal_invite.py::get_client_invitations(client_id: int)`
takes an integer primary key, so anything that is not a plain positive integer is not a client id:

```ts
export function isValidClientId(raw: string | null): raw is string {
  return raw !== null && /^[1-9][0-9]{0,17}$/.test(raw);
}
```

The regex is deliberately stricter than `Number()` coercion: it rejects `1e3`, `007`, `0x10`, `" 1"`,
and passes the original string through unchanged, so an id near `Number.MAX_SAFE_INTEGER` cannot lose
precision on the way to the backend.

## Verification

18 cases, guilt **and** innocence per repo convention:

- **Guilt** — 13 attack vectors rejected: parent + encoded traversal, leading and embedded slash,
  absolute and protocol-relative URL, query / fragment / newline / backslash / semicolon smuggling,
  at-sign host swap. Plus null, empty, and 9 non-integer shapes.
- **Innocence** — positive integers pass, including an 18-digit one, so the guard does not cap
  legitimate growth of a table that already holds 12,028 rows.

Full admin-dashboard suite: **44/44 pass**. Mutation-checked: restoring the pre-fix handler makes
**14 of the 18 fail** — the test bites.

## Known gap, being closed next

These tests exercise the `isValidClientId` predicate, not the `GET` handler. Deleting the line that
*calls* the guard would leave them green. A route-level test — mock `fetch`, assert the backend is
never reached and the proxied URL never escapes the `/api/portal/invite/` prefix — is the correct
regression guard and lands next.

## Not in scope

The second finding on #3430 is untouched here: `app/clients/page.tsx:35` consumes the pre-existing
`/api/postgres/query?table=clients`, which runs `SELECT *` over 63 columns and 12,028 rows with no
projection, no `deleted_at` filter and no `assigned_to` RBAC. That endpoint pre-dates #3430 and
carries its own `js/sql-injection` alert open since 2026-02-13; it needs a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)