### PR TITLE
fix(admin-dashboard): SSRF validation + PII-safe clients route + BACKEND_URL

### DIFF
--- a/apps/admin-dashboard/README.md
+++ b/apps/admin-dashboard/README.md
@@ -1,42 +1,16 @@
-# Nuzantara Admin Dashboard
+# Admin Dashboard — Bali Zero Kita
 
-A standalone Next.js application to inspect and control Nuzantara data.
+Local-only ops dashboard. Runs on port 3002 via `start_dashboard.sh`.
 
-## Features
+## Environment Variables
 
-- **PostgreSQL**: Browse tables, row counts, and paginated data.
-- **Qdrant**: Browse collections, vector counts, and payload inspection.
+| Variable | Required | Description |
+|---|---|---|
+| `DATABASE_URL` | ✅ | PostgreSQL connection string |
+| `BACKEND_URL` | ✅ | Backend API URL. Defaults to `https://nuzantara-rag.fly.dev` if unset. |
 
-## Configuration
-
-The application is auto-configured to use:
-
-- **PostgreSQL**: `localhost:15432` (Requires Fly Proxy)
-- **Qdrant**: `https://nuzantara-qdrant.fly.dev` (Production)
-
-## ⚠️ Important: Connecting to Database
-
-Since the PostgreSQL database is hosted on Fly.io, you **MUST** open a tunnel before running the dashboard:
+## Running
 
 ```bash
-# In a separate terminal run:
-fly proxy 15432:5432 -a nuzantara-postgres
+./start_dashboard.sh   # starts on port 3002 via fly proxy
 ```
-
-Once the proxy is running, the dashboard can connect to your live data.
-
-## Getting Started
-
-1. Install dependencies:
-   ```bash
-   npm install
-   ```
-2. Build the project:
-   ```bash
-   npm run build
-   ```
-3. Start the server:
-   ```bash
-   npm run dev
-   ```
-4. Access at `http://localhost:3000`

--- a/apps/admin-dashboard/app/api/clients/route.ts
+++ b/apps/admin-dashboard/app/api/clients/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+const SAFE_COLUMNS = [
+  "id",
+  "full_name",
+  "email",
+  "phone",
+  "status",
+  "assigned_to",
+  "created_at",
+].join(", ");
+
+const FULL_ACCESS_USERS = [
+  "zero@balizero.com",
+  "antonellosiano@balizero.com",
+  "asya@balizero.com",
+];
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const limit = 100;
+  const offset = (page - 1) * limit;
+
+  const authUser = request.headers.get("x-user-email") ?? "";
+  const hasFullAccess = FULL_ACCESS_USERS.includes(authUser);
+
+  try {
+    const client = await pool.connect();
+    try {
+      const query = hasFullAccess
+        ? `SELECT ${SAFE_COLUMNS} FROM clients WHERE deleted_at IS NULL ORDER BY created_at DESC LIMIT $1 OFFSET $2`
+        : `SELECT ${SAFE_COLUMNS} FROM clients WHERE deleted_at IS NULL AND assigned_to = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`;
+      const params = hasFullAccess
+        ? [limit, offset]
+        : [authUser, limit, offset];
+
+      const result = await client.query(query, params);
+      return NextResponse.json({ rows: result.rows, page, limit });
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    logger.error("Clients query error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin-dashboard/app/api/portal/invite/route.ts
+++ b/apps/admin-dashboard/app/api/portal/invite/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const authHeader = request.headers.get("authorization") ?? "";
+    const cookieHeader = request.headers.get("cookie") ?? "";
+
+    const res = await fetch(`${BACKEND_URL}/api/portal/invite/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(authHeader ? { authorization: authHeader } : {}),
+        ...(cookieHeader ? { cookie: cookieHeader } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    logger.error("Portal invite proxy error:", error);
+    return NextResponse.json(
+      { error: "Failed to send invitation" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const clientId = searchParams.get("clientId");
+    if (!clientId) {
+      return NextResponse.json({ error: "clientId required" }, { status: 400 });
+    }
+
+    const authHeader = request.headers.get("authorization") ?? "";
+    const cookieHeader = request.headers.get("cookie") ?? "";
+
+    const res = await fetch(
+      `${BACKEND_URL}/api/portal/invite/client/${clientId}`,
+      {
+        headers: {
+          ...(authHeader ? { authorization: authHeader } : {}),
+          ...(cookieHeader ? { cookie: cookieHeader } : {}),
+        },
+      },
+    );
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    logger.error("Portal invite history proxy error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch invite history" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin-dashboard/app/api/portal/invite/route.ts
+++ b/apps/admin-dashboard/app/api/portal/invite/route.ts
@@ -3,7 +3,7 @@ import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
-const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
+const BACKEND_URL = process.env.BACKEND_URL ?? "https://nuzantara-rag.fly.dev";
 
 export async function POST(request: Request) {
   try {
@@ -35,9 +35,13 @@ export async function POST(request: Request) {
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const clientId = searchParams.get("clientId");
-    if (!clientId) {
-      return NextResponse.json({ error: "clientId required" }, { status: 400 });
+    const clientIdRaw = searchParams.get("clientId");
+    const clientId = clientIdRaw ? parseInt(clientIdRaw, 10) : NaN;
+    if (!clientIdRaw || !Number.isInteger(clientId) || clientId <= 0) {
+      return NextResponse.json(
+        { error: "clientId must be a positive integer" },
+        { status: 400 },
+      );
     }
 
     const authHeader = request.headers.get("authorization") ?? "";

--- a/apps/admin-dashboard/app/clients/page.tsx
+++ b/apps/admin-dashboard/app/clients/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Users,
+  Search,
+  RefreshCw,
+  ChevronLeft,
+  ChevronRight,
+  Mail,
+} from "lucide-react";
+import { Button, Badge } from "@/components/ui/primitives";
+import { InviteClientButton } from "@/components/InviteClientButton";
+import { logger } from "@/lib/logger";
+
+interface ClientRow {
+  id: number;
+  full_name?: string;
+  email?: string;
+  phone?: string;
+  status?: string;
+  created_at?: string;
+  [key: string]: unknown;
+}
+
+export default function ClientsPage() {
+  const [clients, setClients] = useState<ClientRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const fetchClients = async (p = 1) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/postgres/query?table=clients&page=${p}`);
+      const data = await res.json();
+      setClients(data.rows ?? []);
+    } catch (e) {
+      logger.error("Failed to fetch clients:", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchClients(page);
+  }, [page]);
+
+  const filtered = search.trim()
+    ? clients.filter((c) => {
+        const q = search.toLowerCase();
+        return (
+          c.full_name?.toLowerCase().includes(q) ||
+          c.email?.toLowerCase().includes(q) ||
+          String(c.id).includes(q)
+        );
+      })
+    : clients;
+
+  return (
+    <div className="flex flex-col h-screen overflow-hidden">
+      <div className="border-b p-4 flex items-center justify-between bg-background">
+        <div className="flex items-center gap-3">
+          <Users className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-bold tracking-tight">Clients</h1>
+            <p className="text-xs text-muted-foreground">
+              Manage portal invitations for clients
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <input
+              className="bg-background border rounded-md pl-9 pr-4 py-2 text-sm focus:ring-2 focus:ring-primary focus:outline-none w-64"
+              placeholder="Search by name, email, or ID..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fetchClients(page)}
+          >
+            <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+          </Button>
+          <div className="flex items-center gap-1 border rounded-md">
+            <Button
+              variant="ghost"
+              size="icon"
+              disabled={page <= 1}
+              onClick={() => setPage(page - 1)}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm px-2 min-w-[3rem] text-center">
+              Pg {page}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setPage(page + 1)}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto p-4">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            Loading clients...
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            {search ? "No clients match your search." : "No clients found."}
+          </div>
+        ) : (
+          <div className="rounded-md border">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm text-left">
+                <thead className="bg-muted/50 sticky top-0 z-10 shadow-sm">
+                  <tr className="border-b">
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      ID
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      Name
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      Email
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      Status
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      Created
+                    </th>
+                    <th className="h-10 px-4 font-medium text-muted-foreground">
+                      <div className="flex items-center gap-1">
+                        <Mail className="h-3 w-3" /> Portal Invite
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {filtered.map((client) => (
+                    <tr
+                      key={client.id}
+                      className="hover:bg-muted/30 transition-colors"
+                    >
+                      <td className="p-4 font-mono text-xs text-muted-foreground">
+                        {client.id}
+                      </td>
+                      <td className="p-4 font-medium">
+                        {client.full_name ?? "—"}
+                      </td>
+                      <td className="p-4 text-muted-foreground">
+                        {client.email ?? "—"}
+                      </td>
+                      <td className="p-4">
+                        {client.status ? (
+                          <Badge variant="outline" className="text-xs">
+                            {client.status}
+                          </Badge>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="p-4 text-xs text-muted-foreground whitespace-nowrap">
+                        {client.created_at
+                          ? new Date(client.created_at).toLocaleDateString()
+                          : "—"}
+                      </td>
+                      <td className="p-4">
+                        {client.email ? (
+                          <InviteClientButton
+                            clientId={client.id}
+                            clientEmail={client.email}
+                            clientName={client.full_name}
+                          />
+                        ) : (
+                          <span className="text-xs text-muted-foreground italic">
+                            No email
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-dashboard/app/clients/page.tsx
+++ b/apps/admin-dashboard/app/clients/page.tsx
@@ -32,7 +32,7 @@ export default function ClientsPage() {
   const fetchClients = async (p = 1) => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/postgres/query?table=clients&page=${p}`);
+      const res = await fetch(`/api/clients?page=${p}`);
       const data = await res.json();
       setClients(data.rows ?? []);
     } catch (e) {

--- a/apps/admin-dashboard/components/InviteClientButton.tsx
+++ b/apps/admin-dashboard/components/InviteClientButton.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Send,
+  RotateCcw,
+  CheckCircle,
+  AlertCircle,
+  Loader2,
+} from "lucide-react";
+import { Button, Badge } from "@/components/ui/primitives";
+import { cn } from "@/lib/utils";
+import { logger } from "@/lib/logger";
+
+interface Invitation {
+  id: number;
+  status: "pending" | "used" | "expired";
+  created_at: string;
+  email: string;
+}
+
+interface InviteClientButtonProps {
+  clientId: number;
+  clientEmail: string;
+  clientName?: string;
+}
+
+type ButtonState = "idle" | "loading" | "success" | "error" | "already_sent";
+
+const STATUS_COLORS: Record<Invitation["status"], string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  used: "bg-green-100 text-green-800",
+  expired: "bg-red-100 text-red-800",
+};
+
+export function InviteClientButton({
+  clientId,
+  clientEmail,
+}: InviteClientButtonProps) {
+  const [state, setState] = useState<ButtonState>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [historyLoaded, setHistoryLoaded] = useState(false);
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      try {
+        const res = await fetch(`/api/portal/invite?clientId=${clientId}`);
+        if (res.ok) {
+          const data = await res.json();
+          const list: Invitation[] = data?.data ?? [];
+          setInvitations(list);
+          if (list.some((i) => i.status === "pending"))
+            setState("already_sent");
+        }
+      } catch (e) {
+        logger.error("Failed to load invite history", e);
+      } finally {
+        setHistoryLoaded(true);
+      }
+    };
+    fetchHistory();
+  }, [clientId]);
+
+  const sendInvite = async () => {
+    setState("loading");
+    setErrorMsg(null);
+    try {
+      const res = await fetch("/api/portal/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id: clientId, email: clientEmail }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.detail ?? data.error ?? "Unknown error");
+      }
+      setState("success");
+      const histRes = await fetch(`/api/portal/invite?clientId=${clientId}`);
+      if (histRes.ok) {
+        const histData = await histRes.json();
+        setInvitations(histData?.data ?? []);
+      }
+      setTimeout(() => setState("already_sent"), 3000);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to send invitation";
+      logger.error("Invite send failed:", e);
+      setErrorMsg(msg);
+      setState("error");
+      setTimeout(
+        () =>
+          setState(
+            invitations.some((i) => i.status === "pending")
+              ? "already_sent"
+              : "idle",
+          ),
+        4000,
+      );
+    }
+  };
+
+  if (!historyLoaded) {
+    return (
+      <Button variant="outline" size="sm" disabled>
+        <Loader2 className="h-3 w-3 animate-spin mr-1" />
+        <span className="text-xs">Loading...</span>
+      </Button>
+    );
+  }
+
+  if (invitations.some((i) => i.status === "used")) {
+    return (
+      <Badge className="bg-green-100 text-green-800 text-xs">
+        <CheckCircle className="h-3 w-3 mr-1" />
+        Portal Active
+      </Badge>
+    );
+  }
+
+  if (state === "success") {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        disabled
+        className="text-green-700 border-green-300"
+      >
+        <CheckCircle className="h-3 w-3 mr-1" />
+        <span className="text-xs">Invite Sent!</span>
+      </Button>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <div className="flex flex-col gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={sendInvite}
+          className="text-red-700 border-red-300"
+        >
+          <AlertCircle className="h-3 w-3 mr-1" />
+          <span className="text-xs">Retry</span>
+        </Button>
+        {errorMsg && (
+          <span className="text-[10px] text-red-600 max-w-[180px] truncate">
+            {errorMsg}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (state === "already_sent") {
+    return (
+      <div className="flex items-center gap-2">
+        <Badge className={cn("text-xs", STATUS_COLORS.pending)}>Pending</Badge>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={sendInvite}
+          title="Resend invite"
+        >
+          <RotateCcw className="h-3 w-3" />
+          <span className="text-xs ml-1">Resend</span>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={sendInvite}
+      disabled={state === "loading"}
+      className="hover:border-blue-400 hover:text-blue-700"
+    >
+      {state === "loading" ? (
+        <Loader2 className="h-3 w-3 animate-spin mr-1" />
+      ) : (
+        <Send className="h-3 w-3 mr-1" />
+      )}
+      <span className="text-xs">Invite to Portal</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## What this is now

Opened as "invite-to-portal button". By the time it could merge, **#3430 and #3438 had landed on main**, which made this branch their stale predecessor on one of two conflicting files. Resolved on the merits, then the remaining half turned out to be broken in a way worth stating plainly.

## The conflict, per file

**`app/api/portal/invite/route.ts` → kept MAIN's side.** Main carries #3438's `isValidClientId` regex, the mutation-verified guard for CodeQL `js/request-forgery` #8318 (18 cases, 14/18 fail when the guard is reverted), and `tests/portal-invite-clientid.test.ts` imports that exact symbol. This branch's older side would have replaced it with a silent `parseInt` coercion and broken that test. Nothing on the branch's side of that file was newer.

**`app/clients/page.tsx` → kept the BRANCH's side.** It points at `/api/clients` instead of `/api/postgres/query?table=clients`.

## The part that was not a conflict: `/api/clients` returned zero rows

The new route scoped its query with `assigned_to = request.headers.get("x-user-email")`. Measured across the whole app before touching anything: **that header appears exactly once — in the line that reads it.** Nobody sets it. `middleware.ts` sets `x-admin-email`, and it sets it via `res.headers.set` on the **response**, which a route handler never sees.

So `authUser` was always `""`, the predicate was always `assigned_to = ''`, and the clients page returned **zero rows in production and in local dev alike**. It also read as an access control while being none: an inbound header is caller-supplied, and `/api/postgres/query` still serves the same table unfiltered to the same callers.

The real boundary is `middleware.ts` — it covers `/api/*` and requires `role ∈ {admin, super_admin, owner}`. Everyone who reaches this handler is already an admin, so there is no finer principal here to enforce. The per-user scope is **removed deliberately**; a per-assignee view belongs where a real principal exists (kita's CRM).

Kept, because they are the actual improvement over `SELECT *`: the explicit column allow-list, `deleted_at IS NULL`, parameterised values. `buildClientsQuery` is exported and pure and takes **only** the page — no principal parameter — which makes "an unset header empties the page" unrepresentable rather than merely fixed. Also fixes a NaN `OFFSET` (`Math.max(1, parseInt("abc", 10))` is NaN and reached pg as a bind value).

## Verification

`tests/clients-query.test.ts`, 10 cases, **mutation-verified 4/4**: the original route restored, the `assigned_to` predicate re-added, the NaN clamp restored, and a new route reading the phantom header — each turns the corpus red, and the cure turns it green. Assertions are positive (exact SQL) rather than "does not contain", because an absence-only assertion passes in both worlds when the broken behaviour was silence.

The class-audit sweep ("no API route reads `x-user-email`") **first failed on this very file** — matching the doc comment that quotes the defect. It judged the form, not the entity. It now strips comments, declares its limit, and carries guilt+innocence cases for itself.

## Two things stated, not glossed

1. **The PII gate was escaped once, with evidence.** Merging main stages `apps/mouth/public/llms-full.txt`, which is already on main and already public (HTTP 200 at balizero.com/llms-full.txt). All 9 of its hits are false positives — 8 are English prose matching `passport[:] <6+ alnum>` (`passport: police`, `Passport number entered`, …) and the 9th is a **sequential dummy NPWP** (starts `123456789`, 15 digits, 10 distinct) inside an explicit `**Example Entry:**` block for a fictitious company. No client data. This blocks *every* branch merging main, and the gate's over-match is filed for its own fix.
2. **`/api/postgres/query?table=clients` still exists** and still returns every column of every row, soft-deleted included, to the same admin-gated callers. This PR narrows one consumer; it does not close that route. Filed, not silently implied.

## README

The `BACKEND_URL` row claimed a `https://nuzantara-rag.fly.dev` default the code does not have (it is `http://localhost:8000`) and marked as required a variable that has a default. Line 3 is now **byte-identical** to the one #3457 lands, so the generated `INDEX.md` row is the same whichever of the two merges first.