### PR TITLE
fix(ci): arm the Vercel ignore-step corpus, and delete the root vercel.json that was lying

### DIFF
--- a/.github/workflows/guard-conformance.yml
+++ b/.github/workflows/guard-conformance.yml
@@ -72,7 +72,7 @@ jobs:
           fi
           base="${{ github.event.pull_request.base.sha }}"
           if git diff --name-only "$base"...HEAD | grep -qE \
-            '^(infra/guard-conformance/|infra/claude-hooks/|scripts/hooks/|scripts/openclaw_whatsapp_bridge\.py|apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script\.py|scripts/guardrails_static_core\.py|scripts/test_guardrails_(core_)?overmatch\.py|infra/scar-gates/|scripts/wr2_html_renderer/designer_loop\.py|scripts/wr2_editorial_pregate\.py|scripts/tests/test_wr2_editorial_pregate\.py|\.github/workflows/guard-conformance\.yml)'; then
+            '^(infra/guard-conformance/|infra/claude-hooks/|scripts/hooks/|scripts/openclaw_whatsapp_bridge\.py|apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script\.py|scripts/guardrails_static_core\.py|scripts/test_guardrails_(core_)?overmatch\.py|infra/scar-gates/|scripts/wr2_html_renderer/designer_loop\.py|scripts/wr2_editorial_pregate\.py|scripts/tests/test_wr2_editorial_pregate\.py|scripts/ci/vercel_(should_build|ignore_build_step)\.sh|scripts/tests/test_vercel_should_build\.sh|\.github/workflows/guard-conformance\.yml)'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -172,6 +172,24 @@ jobs:
         run: |
           set -euo pipefail
           python3 infra/claude-hooks/test_subagent_stop_verify.py
+
+      # Vercel's Ignored Build Step. A guard in the #3 sense — it decides, on a substring-ish
+      # signal (changed paths), whether the public site gets rebuilt — so it owes guilt AND
+      # innocence like any other. It lands here rather than in scripts-tests-sweep.yml because
+      # that workflow says of itself "this job never blocks a PR (not in required_status_checks)":
+      # a corpus nothing can fail on is the W81 theater this workflow exists to prevent. Hosting
+      # it in an ALREADY-required job also avoids minting a new required context, which would
+      # freeze every branch created before it.
+      # What is actually being protected: the pointer, not the guard. On 2026-07-29 the project's
+      # commandForIgnoringBuildStep invoked the guard directly before it existed on main; bash
+      # exited 127; Vercel treats every status except 0 and 1 as a FAILED DEPLOYMENT, and nine
+      # deployments errored. The corpus executes the literal pointer string against script-absent,
+      # syntax-error, 127 and signal-kill.
+      - name: Vercel ignore-step guard + pointer (guilt, innocence, exit contract)
+        if: steps.relevant.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          bash scripts/tests/test_vercel_should_build.sh
 
       - name: Sentinel success (no guard surfaces changed)
         if: steps.relevant.outputs.run != 'true'

--- a/scripts/ci/vercel_ignore_build_step.sh
+++ b/scripts/ci/vercel_ignore_build_step.sh
@@ -1,0 +1,23 @@
+# The exact string held in the Vercel project's `commandForIgnoringBuildStep`.
+#
+# It lives here for one reason: on 2026-07-29 that field held a bare invocation of
+# scripts/ci/vercel_should_build.sh, the script was not on main yet, bash exited 127, and
+# 9 deployments went to ERROR in half an hour. The field is dashboard/API state — nothing in
+# the repo described it, so nothing could review it and no test could run against it.
+#
+# Vercel's contract for this command is: exit 0 = skip the build, exit 1 = build,
+# ANY OTHER EXIT CODE = the deployment fails. So the command must never let an unexpected
+# status escape: a missing file, a syntax error, or a signal all have to become exit 1.
+# That is the whole job of the wrapper below, and scripts/tests/test_vercel_should_build.sh
+# executes this exact line against those three cases.
+#
+# Constraint: the API rejects the field over 256 characters (`invalid_command_for_ignoring_build_step`).
+# The single non-comment line below is the payload; the test asserts both its length and its
+# behaviour. Keep it to one line — the extractor reads exactly one.
+#
+# To apply after changing it:
+#   PATCH https://api.vercel.com/v9/projects/<id>?teamId=<team>  {"commandForIgnoringBuildStep": "<line>"}
+# and only once scripts/ci/vercel_should_build.sh is on the production branch — that ordering
+# is the part that was skipped.
+
+S="$(git rev-parse --show-toplevel)/scripts/ci/vercel_should_build.sh"; [ -f "$S" ] || exit 1; bash "$S"; [ $? = 0 ] && exit 0 || exit 1

--- a/scripts/ci/vercel_should_build.sh
+++ b/scripts/ci/vercel_should_build.sh
@@ -3,10 +3,32 @@
 # receives. Wired into the project's `commandForIgnoringBuildStep`, which is capped at 256
 # characters, so the field holds only a pointer to this file and the reasoning lives here.
 #
-# CONTRACT (inverted, and easy to get backwards):
+# CONTRACT — read this twice, it is not the usual shell convention:
+#   exit 0  -> SKIP the build
 #   exit 1  -> BUILD
-#   exit 0  -> SKIP
-# Every failure path exits 1. A build we did not need costs minutes; a build we needed and
+#   ANY OTHER EXIT CODE -> the DEPLOYMENT FAILS. Not "build", not "skip": ERROR.
+#
+# That third line cost 9 failed deployments on 2026-07-29 between 06:26Z and 06:55Z. The first
+# version of the project's ignore setting pointed straight at this file with
+# `bash "$(git rev-parse --show-toplevel)/scripts/ci/vercel_should_build.sh"`, wired up BEFORE
+# the file existed on main, on the reasoning that a missing script exits 127, and 127 is
+# non-zero, and non-zero means build. It does not. `bash: No such file or directory` errored
+# every deployment for half an hour — main included — until the setting was rolled back.
+# (Production itself never went stale: a failed deployment does not replace the live one, and
+# no frontend-relevant commit landed in the window. Vercel's commit status went red but is not
+# among main's required checks.) Vercel documents this precisely — "the build continues if the
+# command exits with code 1, and is ignored if it exits with 0" — and the doc had been read in
+# the same session. The error was generalising "1" to "non-zero".
+#
+# Two consequences, both load-bearing:
+#   1. Every path in this file exits 0 or 1 and nothing else. Pinned by a test that greps for
+#      any other literal exit code, because a `exit 2` added later would look harmless.
+#   2. The project setting must NORMALISE, never point here bare:
+#        S="$(git rev-parse --show-toplevel)/scripts/ci/vercel_should_build.sh"; [ -f "$S" ] || exit 1; bash "$S"; [ $? = 0 ] && exit 0 || exit 1
+#      so a missing file, a syntax error, or a signal all become BUILD instead of ERROR. And it
+#      is armed only AFTER this file is on main — the ordering that was skipped.
+#
+# Every failure path builds. A build we did not need costs minutes; a build we needed and
 # skipped leaves the entire public surface — balizero.com plus kita/my/prime/visa/tax/zantara,
 # all one Vercel project — serving stale code. Those are not symmetric, so this is fail-open
 # by construction and never "clever" at the margin.

--- a/scripts/ci/vercel_should_build.sh
+++ b/scripts/ci/vercel_should_build.sh
@@ -60,6 +60,11 @@ set -u
 
 # Paths that can change the built app. `vercel.json` is included because build settings live
 # there; the previous command omitted it, so a change to how the app is built did not rebuild it.
+# The repo-root `vercel.json` is gone as of this change — the project's Root Directory is
+# `apps/mouth`, so Vercel read `apps/mouth/vercel.json` and the root file was inert. Proven from
+# a real build log, not from the setting: the build ran `next build --webpack` (the apps/mouth
+# value), never the root file's `npm run build -w apps/mouth`. It is still matched here on
+# purpose — if a root `vercel.json` ever comes back, rebuilding on it is the fail-open answer.
 FRONTEND_RE='^(apps/mouth/|packages/|package\.json|package-lock\.json|vercel\.json|apps/mouth/vercel\.json)'
 
 PROD_BRANCH="${VERCEL_GIT_PROD_BRANCH:-main}"

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -130,6 +130,72 @@ VERCEL_GIT_COMMIT_REF=docs/ledger VERCEL_GIT_PREVIOUS_SHA="$PREV" \
   run BUILD "second deploy, frontend delta"
 
 echo
+echo "=== THE EXIT CONTRACT: nothing may leave this script with a status other than 0 or 1"
+# Vercel reads exit 0 as skip and exit 1 as build. Every OTHER status fails the deployment
+# outright — which is what happened on 2026-07-29, 9 deployments in ERROR, because a missing
+# file exited 127 and 127 was assumed to mean "build". A later edit adding `exit 2` for some
+# third outcome would look entirely reasonable and would break production deploys, so the
+# statuses are pinned statically rather than left to review.
+BAD=$(grep -oE '(^|[;{[:space:]])exit [0-9]+' "$SCRIPT" | grep -oE '[0-9]+$' | grep -vE '^[01]$' | sort -u)
+if [ -z "$BAD" ]; then
+  PASS=$((PASS+1)); printf '  ok    %-58s %s\n' "guard exits only 0 or 1" "clean"
+else
+  FAIL=$((FAIL+1)); printf '  FAIL  %-58s found: %s\n' "guard exits only 0 or 1" "$(echo "$BAD" | tr '\n' ' ')"
+fi
+
+echo
+echo "=== THE POINTER: the command pasted into Vercel must normalise every other status to 1"
+# scripts/ci/vercel_ignore_build_step.sh holds the literal value of the project's
+# commandForIgnoringBuildStep. Testing the guard alone would have caught none of the incident:
+# the guard was innocent, the pointer was the defect, and the pointer was dashboard state that
+# no file described. It is executed here against exactly the cases that broke production.
+POINTER_FILE="$(dirname "$SCRIPT")/vercel_ignore_build_step.sh"
+[ -f "$POINTER_FILE" ] || { echo "FATAL: pointer file not found at $POINTER_FILE"; exit 2; }
+POINTER=$(grep -vE '^\s*(#|$)' "$POINTER_FILE")
+POINTER_LINES=$(printf '%s\n' "$POINTER" | grep -c .)
+
+if [ "$POINTER_LINES" -eq 1 ]; then
+  PASS=$((PASS+1)); printf '  ok    %-58s %s\n' "pointer file holds exactly one command" "1 line"
+else
+  FAIL=$((FAIL+1)); printf '  FAIL  %-58s got %s lines\n' "pointer file holds exactly one command" "$POINTER_LINES"
+fi
+
+# The API rejects >256 chars with invalid_command_for_ignoring_build_step, and rejects the
+# WHOLE PATCH body with it — a second setting sent alongside is silently lost too.
+PLEN=${#POINTER}
+if [ "$PLEN" -le 256 ]; then
+  PASS=$((PASS+1)); printf '  ok    %-58s %s chars\n' "pointer fits the 256-char API limit" "$PLEN"
+else
+  FAIL=$((FAIL+1)); printf '  FAIL  %-58s %s chars (API rejects >256)\n' "pointer fits the 256-char API limit" "$PLEN"
+fi
+
+run_pointer() { # run_pointer <expected: BUILD|SKIP> <label> <script-body|MISSING>
+  local want="$1" label="$2" body="$3" dir got rc
+  dir=$(mktemp -d "$ROOT/ptr.XXXXXX")
+  git init -q -b main "$dir"
+  mkdir -p "$dir/scripts/ci"
+  if [ "$body" != "MISSING" ]; then
+    printf '%s\n' "$body" > "$dir/scripts/ci/vercel_should_build.sh"
+  fi
+  ( cd "$dir" && eval "$POINTER" >/dev/null 2>&1 ); rc=$?
+  case $rc in 1) got=BUILD ;; 0) got=SKIP ;; *) got="rc=$rc (DEPLOYMENT ERROR)" ;; esac
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1)); printf '  ok    %-58s %s\n' "$label" "$got"
+  else
+    FAIL=$((FAIL+1)); printf '  FAIL  %-58s want %s, got %s\n' "$label" "$want" "$got"
+  fi
+}
+
+# The incident, reproduced. Before the wrapper this was rc=127 and every deployment failed.
+run_pointer BUILD "script absent (the 2026-07-29 incident)"            MISSING
+run_pointer BUILD "script with a syntax error (bash exits 2)"          'if then fi'
+run_pointer BUILD "script exiting 127 for any other reason"            'exit 127'
+run_pointer BUILD "script killed by a signal"                          'kill -TERM $$'
+# And the two legitimate verdicts must still pass through untouched.
+run_pointer BUILD "script says build"                                  'exit 1'
+run_pointer SKIP  "script says skip"                                   'exit 0'
+
+echo
 echo "-------------------------------------------------------------"
 printf 'passed %d, failed %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -22,6 +22,13 @@
 #     which is the thing that matters. Removing both does fail, above.
 #   * grep exiting >=2                       -> 0 fail. Genuinely UNCOVERED: this corpus has no
 #     way to make grep itself error. The branch is written fail-open and reviewed, not proven.
+#   * pointer reverted to a bare invocation  -> 4 fail, every one as `rc=127 (DEPLOYMENT ERROR)`.
+#     That IS the 2026-07-29 incident, reproduced. See scripts/ci/vercel_ignore_build_step.sh.
+#   * `git init` dropped from the pointer sandbox -> 4 fail as "sandbox leaked". Worth stating
+#     why that check exists at all: setting TMPDIR inside the repo does NOT trip it, because each
+#     sandbox runs its own `git init` and therefore is its own toplevel. So the corpus cannot
+#     produce a positive by placement alone, and the guard is proven only by this mutation — it
+#     defends against a future refactor dropping the init, not against a hostile TMPDIR.
 
 set -uo pipefail
 
@@ -176,6 +183,17 @@ run_pointer() { # run_pointer <expected: BUILD|SKIP> <label> <script-body|MISSIN
   mkdir -p "$dir/scripts/ci"
   if [ "$body" != "MISSING" ]; then
     printf '%s\n' "$body" > "$dir/scripts/ci/vercel_should_build.sh"
+  fi
+  # The pointer resolves its target through `git rev-parse --show-toplevel`. If this temp repo
+  # were nested inside the real checkout — a CI runner whose TMPDIR lives under the workspace
+  # would do it — that call would resolve to the REAL repo, the "script absent" case would
+  # silently execute the REAL guard, and all six cases would pass while testing nothing.
+  # Assert the sandbox is the sandbox instead of assuming it.
+  local top
+  top=$( cd "$dir" && git rev-parse --show-toplevel 2>/dev/null )
+  if [ "$(cd "$dir" && pwd -P)" != "$(cd "$top" 2>/dev/null && pwd -P)" ]; then
+    FAIL=$((FAIL+1)); printf '  FAIL  %-58s sandbox leaked: toplevel=%s\n' "$label" "$top"
+    return
   fi
   ( cd "$dir" && eval "$POINTER" >/dev/null 2>&1 ); rc=$?
   case $rc in 1) got=BUILD ;; 0) got=SKIP ;; *) got="rc=$rc (DEPLOYMENT ERROR)" ;; esac

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run build -w apps/mouth",
-  "outputDirectory": "apps/mouth/.next",
-  "framework": "nextjs",
-  "installCommand": "npm install",
-  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- apps/mouth && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- packages && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- package.json && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- package-lock.json && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- vercel.json"
-}


### PR DESCRIPTION
Follow-up to #3433, which landed the guard and its corpus. Three gaps that PR left open.

## 1. The corpus could not fail anything

The only workflow that runs `scripts/tests/*.sh` is `scripts-tests-sweep.yml`, which states of
itself: *"this job never blocks a PR (not in required_status_checks)"*. A guard corpus nothing can
fail on is the W81 theater this repo keeps paying for.

It moves into `guard-conformance.yml` — **already required**, so this mints no new required context
(a new one freezes every branch created before it). Its paths are added to that job's `relevant`
filter too: without that the step would exist and never run, which is the same defect wearing a
different hat.

## 2. The pointer — the thing that actually broke — is now under test

Vercel's contract is `exit 0` = skip, `exit 1` = build, **any other status = the deployment fails**.
On 2026-07-29 the project's `commandForIgnoringBuildStep` invoked the guard directly *before it was
on main*; bash exited 127; nine deployments errored between 06:26Z and 06:55Z, `main` included,
until the field was rolled back.

Blast radius, measured rather than assumed: production kept serving its existing commit throughout
(a failed deployment does not replace the live one), no frontend-relevant commit landed in the
window, and Vercel is not among main's required contexts, so no PR was blocked.

The guard was innocent throughout. The defect lived in dashboard state, where no review and no test
could reach it. So `scripts/ci/vercel_ignore_build_step.sh` now holds the literal field value, wraps
the guard so a missing file, a syntax error (2) and a signal (143) all become exit 1, and the corpus
**executes that string** against exactly those cases.

Mutation-checked: reverting the pointer to the bare invocation fails 4 cases, each as
`rc=127 (DEPLOYMENT ERROR)` — the incident, reproduced. The guard's exit codes are pinned statically
too, because a later `exit 2` for some third outcome would read as entirely reasonable.

One check is recorded as barely-provable rather than counted as coverage: the sandbox-isolation
assertion does **not** trip when TMPDIR is placed inside the repo, because each sandbox runs its own
`git init` and is therefore its own toplevel. It only bites if a refactor drops that init, which is
how it was mutation-proven. Said so in the header instead of claiming coverage.

## 3. The repo-root `vercel.json` was inert, and lying

Root Directory is `apps/mouth`, so Vercel reads `apps/mouth/vercel.json`. Proven from a real build
log rather than from the setting: the build runs `next build --webpack` (the apps/mouth value) and
never the root file's `npm run build -w apps/mouth`.

That dead file still carried the OLD `ignoreCommand` — the first-deploy-always-builds logic this
lane replaces — so a reader would believe the fixed thing was still broken, or would "fix" it there
and see no effect. It has already misled one review: the 2026-04-29 crash audit reasoned about the
build from this file. Removed. The guard still matches `vercel.json` on purpose: if a root one ever
returns, rebuilding on it is the fail-open answer.

## After this lands

The project setting gets armed via API — **only** once these files are on main, which is precisely
the ordering that caused the incident. Expected saving at the measured rate: ~12,000 build-minutes
per month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
