### PR TITLE
docs(research): SLHS Bali market & competitor landscape (Lane C)

### DIFF
--- a/research/compliance/2026-07-29-slhs-lane-c-market.md
+++ b/research/compliance/2026-07-29-slhs-lane-c-market.md
@@ -25,6 +25,18 @@ sources:
   - https://balitaxadvisor.com/indonesia-fb-permits/ (2026-07-29)
   - https://bali.bps.go.id/en/statistics-table/2/Mzg1IzI=/banyaknya-restoran-dan-rumah-makan-dirinci-menurut-kabupaten-kota-di-bali.html (403 to fetch tool 2026-07-29, cited via secondary source below)
   - https://solusidigitalusaha.biz.id/2/ARTICLES/209/menelusuri-ribuan-restoran-dan-kafe-di-bali (secondary citation of BPS 2023 figures, 2026-07-29)
+  - https://sites.google.com/kek.go.id/sop-perizinan/pb-umku/slhs (2026-07-29)
+  - https://dinaspmptsp.pemalangkab.go.id/2022/06/sosialisasi-perizinan-berusaha-untuk-menunjang-kegiatan-usaha-pb-umku-sertifikat-laik-higiene-sanitasi-slhs-pada-sistem-oss-rba-16-juni-2022/ (2026-07-29)
+  - https://oss.go.id/en/umku (2026-07-29)
+  - https://pbumku.com/ (2026-07-29, via search snippet — direct fetch 403)
+  - https://baliefata.com/jasa-pengurusan-izin-oss-nib-di-bali.php (2026-07-29)
+  - https://bapelkesmas-diskes.baliprov.go.id/pelatihan-keamanan-pangan-siap-saji-bagi-penjamah-makanan-di-tempat-pengelolaan-pangan-tpp-uptd-bapelkesmas-dinas-kesehatan-provinsi-bali-24-s-d-26-maret-2025/ (2026-07-29)
+  - https://bapelkesmas-diskes.baliprov.go.id/pelatihan-surveilans-dan-pengendalian-vektor-dan-binatang-pembawa-penyakit-entomologi-kesehatan-di-puskesmas-kabupaten-karangasem-uptd-bapelkesmas-dinas-kesehatan-provinsi-bali-2-s-d-7-februari-2026/ (2026-07-29, schedule-existence only)
+  - https://dinkes.bulelengkab.go.id/informasi/detail/berita/48_pelatihan-keamanan-pangan-siap-saji-bagi-penjamah-pangan-untuk-tingkatkan-mutu-dan-keamanan-produk-pangan (2026-07-29, via search snippet — June 2026 Buleleng PKP session at Bapelkesmas venue)
+  - https://www.phitagoras.co.id/training-haccp-sertifikasi-bnsp.html (2026-07-29, via search snippet)
+  - https://apkepi.or.id/products/okupasi-nasional-penjamah-makanan-food-handler-by-lsp-jmkp (2026-07-29)
+  - https://www.dreamlegalofficial.com/legalitas-bisnis-fb-panduan-lengkap-izin-dokumen-dan-biaya/ (2026-07-29, via search snippet — direct fetch inconclusive)
+adversarial_review: codex
 ---
 
 # SLHS Lane C — Market & Competitor Landscape (Bali, 2026-07-29)
@@ -32,8 +44,23 @@ sources:
 Scope: who sells SLHS (Sertifikat Laik Higiene Sanitasi) in/around Bali, at what price, packaged how, and
 where the white space is. Public-read research only — no outreach, no forms, no PII.
 
+**Amendment 2026-07-29 (post-review):** the initial version of this file was written and a PR opened, but
+the PR never merged — the R1 CI gate (adversarial-review-required) failed silently on this file and no one
+followed up, so the file sat on an open branch, not on `main`, while earlier team-lead communication
+reported it as delivered. That was wrong to report as done. This revision (1) fixes the merge blocker, and
+(2) adds two lines of research the team lead specifically asked for after reviewing findings from the other
+lanes: SLHS's status as a PB-UMKU hung off the NIB (§0) and the PKP food-safety-training bottleneck,
+including the first real prices found for the paid alternative to the free government course (§7).
+
 ## TL;DR return value
 
+- **SLHS is not a freestanding permit — it's a PB-UMKU hung off the NIB inside OSS-RBA** (§0). Almost no
+  competitor markets it that way; everyone still talks about it as if it were a standalone license.
+- **The PKP food-safety training bottleneck** (§7): the government course (UPTD Bapelkesmas Provinsi Bali)
+  runs batch sessions with no published fee and evidence that private restaurants already self-register
+  directly — but a parallel PAID market of private BNSP/HACCP-track food-safety trainers DOES publish
+  prices, from **Rp 6.0–7.0 million (online) to Rp 11.8 million/participant (offline)** — the single most
+  concrete pricing find in this update.
 - **Price table** below — real numbers exist but only for 5 of ~12 researched sellers; the rest are
   "contact us."
 - **3 dominant packaging patterns**: (1) SLHS sold as a sequential add-on gated behind a bigger
@@ -51,6 +78,34 @@ where the white space is. Public-read research only — no outreach, no forms, n
   table blocked the fetch tool with 403; the Dinas Pariwisata 2025 PDF didn't parse). Only a secondary-source
   citation of BPS 2023 data survives — flagged as such, not as verified.
 - Full file: `research/compliance/2026-07-29-slhs-lane-c-market.md`
+
+---
+
+## 0. Framing: SLHS is a PB-UMKU hung off the NIB, not a standalone permit
+
+This matters for how it's sold, not just how it's obtained. Under OSS-RBA, SLHS is one instance of
+**PB-UMKU** ("Perizinan Berusaha untuk Menunjang Kegiatan Usaha" — business licensing to support business
+activity, the operational/commercial-stage layer of licensing). The **NIB is a hard prerequisite**: a
+business logs into OSS with its NIB, opens a new PB-UMKU application, selects the KBLI the NIB was issued
+under, then picks SLHS from the PB-UMKU menu and uploads supporting documents (sites.google.com/kek.go.id;
+dinaspmptsp.pemalangkab.go.id; oss.go.id/en/umku — all 2026-07-29). This is also the government-fee
+finding from §1 Fascia C generalized beyond Denpasar: **pbumku.com states PB-UMKU services for food
+establishments (jasa boga/catering, restaurants, food processing) are free of charge nationally**, not
+just under Denpasar's city regulation — a second, independent confirmation of the Rp 0 government-fee
+floor.
+
+**Does anyone sell it *inside* a company-setup/NIB/F&B-licensing package, explicitly?** Searched for this
+directly (queries on "paket lengkap PB-UMKU F&B", checked baliefata.com's dedicated Bali OSS/NIB page).
+Result: **still mostly opaque.** baliefata.com ("Jasa Pengurusan Izin OSS DAN NIB di Bali") explicitly
+lists restaurant/hotel/villa permit handling but its page gives **no breakdown of whether SLHS/PB-UMKU is
+bundled into the NIB service or sold separately, and no price**. Generic bahasa guides (e.g.
+dreamlegalofficial.com's F&B legality guide) *describe* the requirement chain (NIB → Sertifikat Standar →
+PB-UMKU incl. SLHS → SKPL alcohol clearance → PIRT/BPOM if packaged goods) without quoting bundle pricing.
+**Net**: the technical fact that SLHS is subordinate to the NIB is well documented; no competitor turns
+that fact into an explicit "NIB+SLHS bundle" sales pitch with a price. This reinforces, from a different
+angle, the §3 finding that SLHS is either an invisible line item inside a general retainer or absent
+altogether — nobody sells the NIB→PB-UMKU→SLHS *pipeline* as a named, priced product, even though that
+pipeline is exactly what the regulation requires everyone to go through in order.
 
 ---
 
@@ -134,6 +189,16 @@ publish zero pricing anywhere for SLHS — either because they don't sell it as 
 opacity is the deliberate positioning (high-touch consulting norm across this whole competitive set, not
 SLHS-specific).
 
+**Caveat added post-review, do not skip**: the balivisa.co ~Rp 22,000,000 figure and the Merdeka.com
+Rp 9–30,000,000 broker-markup figure should NOT be treated as clean, mutually-comparable price anchors.
+The former is numerically identical to a different competitor's price for a different, broader certificate
+(§1 reading) — it may be a genuine coincidence, a copied/rumored industry number, or a conflation, and
+which is true is unresolved. The latter is evidence from a **different government program** (SPPG/MBG
+nutrition kitchens, not general restaurant SLHS) and is included here only as a *pattern* anchor (broker
+opacity/markup exists as a phenomenon in Indonesian SLHS-adjacent licensing), not as a *number* directly
+transferable to what a Bali restaurant would pay a broker. Anyone using this table for a client-facing
+price comparison should treat only the legalindonesia.id, riksa.co.id, and INVARR rows as load-bearing.
+
 ---
 
 ## 3. Packaging patterns (the important question)
@@ -216,7 +281,58 @@ regulation before Bali Zero commits to either cadence in a pitch.
 
 ---
 
-## 6. White space — verified vs refuted vs unverified
+## 6. PKP (Penyuluhan Keamanan Pangan) training — the flagged bottleneck, and who prices it
+
+**Caveat up front (post-review)**: "bottleneck" is the team lead's framing, and this section can confirm
+the training exists, is batch-delivered, and has undisclosed private-company pricing — it cannot confirm
+capacity constraints, rejection rates, or how hard it actually is to get a seat, from public sources alone.
+One participant-list data point (below) shows access is possible; it doesn't measure how easy.
+
+The team lead flagged this as the operative chokepoint: the food-handler competency training that feeds
+into SLHS (called PKP — Penyuluhan Keamanan Pangan — or KHSM/HSP depending on source) is delivered in
+**batches by UPTD Bapelkesmas Provinsi Bali** (the provincial health-training unit, Jl. Gumitir No. 135,
+Denpasar Timur), and no public source states what it costs a private company. Findings:
+
+- **The government channel is real, scheduled, and — as far as any page discloses — free.** Confirmed
+  sessions: 17–19 May 2022, 24–26 March 2025 ("Pelatihan Keamanan Pangan Siap Saji bagi Penjamah Makanan
+  di Tempat Pengelolaan Pangan"), and an 8–10 June 2026 Buleleng-regency session held at the same
+  Bapelkesmas venue (dinkes.bulelengkab.go.id). **No registration fee is mentioned on any of these pages.**
+- **Private F&B businesses already attend directly, not just government/healthcare orgs.** The 24–26 March
+  2025 session's participant list — recovered via fetch, not just search snippet — names **"Jaan Bali
+  Restaurant"** alongside five hospitals (RSU Puri Raharja, RSU Bali Royal, RS Prima Medika, RS Balimed
+  Denpasar, RSU Ganesha, RSIA Bunda Denpasar). This is direct evidence a real Bali restaurant sent staff to
+  the official batch training, undercutting any assumption that private F&B operators can't self-register
+  or need a broker to get a seat.
+- **What we could NOT find**: an explicit registration fee for a private company on any Bapelkesmas/Dinkes
+  page, and no full 2026 master schedule (only individual session announcements). If Bali Zero wants a firm
+  number, that's a call to UPTD Bapelkesmas directly, or an FOI-style query — not resolvable from public
+  pages searched here.
+- **The valuable find: a parallel PAID market exists, and it does publish prices.** These are not literally
+  resold seats in the government PKP batch — they're private BNSP/HACCP-track food-safety-competency
+  trainers occupying the same functional slot (satisfying the same "food handler / person-in-charge
+  training certificate" requirement cited by every SLHS guide in §1). Two with public pricing:
+  - **Phitagoras Training** — online HACCP/food-safety certification, **Rp 6,999,000, discounted to
+    Rp 5,999,000** (phitagoras.co.id, via search snippet, direct fetch 403).
+  - **BMD Training Centre** — offline, **Rp 11,800,000 per participant**, excludes tax and certificate
+    shipping (via search snippet).
+  - **Kualita Konsultan** — no fixed price, quotes per company size/branch count/scope (bespoke).
+  - **APKEPI / LSP JMKP** ("Sertifikasi Kompetensi Penjamah Pangan") sells a BNSP-accredited food-handler
+    competency certification as a named product (apkepi.or.id) — existence confirmed, price not fetched
+    this pass.
+- **Reading**: there is a real price gap between "government batch training, no fee disclosed, but a real
+  restaurant got in" and "private BNSP-track alternative at Rp 6–11.8 million per participant." That gap —
+  and the fact that NONE of the Fascia A/B competitors in §1 mention PKP/food-handler training as a
+  distinctly priced line separate from their SLHS bundle (balivisa.co's Rp 1,750,000/staff figure is the
+  only training-specific number found anywhere in Fascia A, and it's far below both private BNSP options
+  above, suggesting either a different/lighter course or an optimistic estimate) — is itself a second,
+  adjacent white-space candidate: nobody positions "we get your staff into the free government PKP batch
+  reliably and on schedule" as a service, despite batches being infrequent, regionally scattered
+  (Denpasar/Bangli/Buleleng sessions found, not a rolling calendar), and evidently open to private
+  registrants who know to ask.
+
+---
+
+## 7. White space — verified vs refuted vs unverified
 
 | Candidate (from the brief) | Verdict | Evidence |
 |---|---|---|
@@ -226,6 +342,47 @@ regulation before Bali Zero commits to either cadence in a pitch.
 | Nobody links SLHS to KBLI choice upstream | **Real gap, but in positioning not fact** | The KBLI-SLHS technical link is well documented in government/explainer sources (you must select the correct food-business KBLI in OSS before SLHS can be filed) — but no commercial competitor markets this as a consulting angle ("we pick your KBLI so your SLHS path is clean"). Genuinely open positioning territory. |
 | *(new, found not briefed)* Bali-local konsultan don't carry SLHS as a product at all | **Verified** | Both Bali-based general perizinan sites checked (licenselead.id, konsultanperizinanbali.com) omit SLHS entirely from their service menus |
 | *(new, found not briefed)* No Bali-specific, price-transparent standalone SLHS page exists in either language | **Verified across ~25 sources checked** | See §4 |
+| *(new, added 2026-07-29 per team-lead steer)* Nobody markets "we get your staff into the free government PKP batch" as a scheduling/access service | **Verified as absent from public marketing; not verified as a genuine unmet need** | Batches are infrequent and regionally scattered (Denpasar/Bangli/Buleleng sessions found, no rolling calendar); a real restaurant (Jaan Bali) got a seat directly, so the "need a broker" framing is only partly supported — see §6 |
+
+---
+
+## Adversarial review
+
+Reviewer: **Codex** (`gpt-5.2-codex` via `mcp__codex-redteam`, read-only sandbox), 2026-07-29. Reviewed the
+document's claims and evidence structure (not a fresh independent web search — a critique of this
+document's reasoning and calibration, per the R1 gate's generator≠grader intent: author is Sonnet 5, seat
+is a different model family). Full critique preserved verbatim in the PR discussion; summary below.
+
+**Findings accepted and acted on in this revision:**
+- The balivisa.co ~Rp 22M figure and the Merdeka.com Rp 9–30M broker figure were being used too close to
+  the compact price table as if they were clean, comparable anchors. Added an explicit caveat (§2) marking
+  only legalindonesia.id/riksa.co.id/INVARR as load-bearing for price comparison; the other two are pattern
+  evidence, not numbers to quote to a client.
+- "PKP bottleneck" language in §6 overstated what one participant list proves. It shows a real restaurant
+  attended one session — it does not establish availability, capacity, or that this is *the* bottleneck.
+  Read §6 as "one confirmed data point that private access is possible," not a capacity claim.
+- Private-training prices (Phitagoras, BMD) rest on search snippets, not direct fetches (both attempted,
+  both 403'd) — already disclosed per-line in §6, flagged again here as a reason not to quote those numbers
+  without independent verification before using them competitively.
+
+**Findings noted, not further acted on (stand as open caveats)**:
+- "Almost no competitor markets it that way" (§0) and "majority absorbed invisibly" (§3) are pattern
+  readings across a sampled set (~11 named competitors), not an exhaustive census with a defined coding
+  method — treat as directional, not a statistically verified majority.
+- The market-size section (§5) is flagged by the reviewer as **unusable, not merely uncertain**, given the
+  internal inconsistency (regency subtotals exceeding the province total) — this document already says so;
+  restated here for anyone skimming straight to the review section.
+- "Verified" in the §7 white-space table means "checked against the specific named competitors reached in
+  this pass and not found" — absence-of-evidence, not a formal exhaustive-market claim. Treat every
+  "Verified" row as bounded by the source list in the frontmatter, not as a closed finding.
+
+**Verdict**: the reviewer found calibration better than average (contradictions and fetch failures are
+disclosed throughout) but flagged that disclosure alone doesn't cure reliance on snippet-only or
+internally-inconsistent evidence for decision-grade pricing. This revision tightens the two most
+actionable points (price-anchor conflation, PKP-bottleneck overstatement); the market-size and
+majority-pattern caveats were already present and are restated, not newly fixed, because fixing them
+requires data this pass could not retrieve (BPS table access, an exhaustive competitor census) rather than
+a wording change.
 
 ---
 

--- a/research/compliance/2026-07-29-slhs-lane-c-market.md
+++ b/research/compliance/2026-07-29-slhs-lane-c-market.md
@@ -1,0 +1,243 @@
+---
+date: 2026-07-29
+domain: compliance
+client_case: none-product-research
+sources:
+  - https://balivisa.co/secure-your-hygiene-and-sanitation-certificate-in-indonesia-2026/ (404 direct, content recovered via cache search 2026-07-29)
+  - https://balivisa.co/secure-your-edge-in-balis-fb-scene-before-2026-crowds/ (2026-07-29)
+  - https://legalindonesia.id/restaurant-licensing-in-bali/ (2026-07-29)
+  - https://invarr.org/collections/food-hygiene-sanitation (2026-07-29)
+  - https://invarr.org/pages/sertifikasi-laik-higiene-sanitasi-slhs-assistance (2026-07-29)
+  - https://riksa.co.id/jasa-izin-slhs-terbaik/ (2026-07-29)
+  - https://licenselead.id/ (2026-07-29)
+  - https://konsultanperizinanbali.com/ (2026-07-29)
+  - https://www.dinkes.denpasarkota.go.id/page/pelayanan-penerbitan-sertifikat-laik-hygiene-sanitasi-slhs-untuk-tempat-pengelolaan-pangan-tpp (2026-07-29)
+  - https://associe.co.id/legalitas/apa-itu-slhs/ (2026-07-29)
+  - https://readmore.id/administrasi/slhs-adalah-syarat-cara-daftar-sertifikat-laik-higiene (2026-07-29)
+  - https://legalitas.org/tulisan/panduan-mengurus-sertifikat-laik-hygiene-sanitasi-slhs (2026-07-29)
+  - https://www.merdeka.com/peristiwa/terungkap-calo-slhs-patok-harga-pengurusan-sertifikat-hingga-rp-30-juta-harga-aslinya-cuma-rp2-juta-495650-mvk.html (2026-07-29)
+  - https://www.cekindo.com/blog/business-license-bali (2026-07-29)
+  - https://sevenstonesindonesia.com/services/business-license/ (2026-07-29)
+  - https://www.letsmoveindonesia.com/ (2026-07-29, no dedicated SLHS page indexed)
+  - https://www.permitindo.com/business-licenses (2026-07-29)
+  - https://www.balisolve.com/ (2026-07-29)
+  - https://emerhub.com/indonesia/starting-a-restaurant-in-indonesia-a-guide-for-foreign-investors/ (2026-07-29)
+  - https://balitaxadvisor.com/indonesia-fb-permits/ (2026-07-29)
+  - https://bali.bps.go.id/en/statistics-table/2/Mzg1IzI=/banyaknya-restoran-dan-rumah-makan-dirinci-menurut-kabupaten-kota-di-bali.html (403 to fetch tool 2026-07-29, cited via secondary source below)
+  - https://solusidigitalusaha.biz.id/2/ARTICLES/209/menelusuri-ribuan-restoran-dan-kafe-di-bali (secondary citation of BPS 2023 figures, 2026-07-29)
+---
+
+# SLHS Lane C — Market & Competitor Landscape (Bali, 2026-07-29)
+
+Scope: who sells SLHS (Sertifikat Laik Higiene Sanitasi) in/around Bali, at what price, packaged how, and
+where the white space is. Public-read research only — no outreach, no forms, no PII.
+
+## TL;DR return value
+
+- **Price table** below — real numbers exist but only for 5 of ~12 researched sellers; the rest are
+  "contact us."
+- **3 dominant packaging patterns**: (1) SLHS sold as a sequential add-on gated behind a bigger
+  compliance-certificate sale, not standalone; (2) SLHS entirely absent from Bali-local Indonesian-language
+  konsultan menus — it's a byline inside "restaurant licensing" guides, not a product; (3) the few
+  standalone SLHS specialists that DO name a price are national (Jakarta/Bekasi/Manado), not Bali-based.
+- **Verified competitor weaknesses**: price opacity is the norm (7 of 9 Fascia-A brands publish nothing);
+  the two Bali-English blogs that DO publish a price (legalindonesia.id Rp 8.5jt, balivisa.co ~Rp 22jt)
+  disagree with each other by ~2.5x and both are far above the real government-fee-plus-lab-cost floor —
+  transparency-in-name, confusion-in-fact.
+- **One candidate white space REFUTED**: "nobody pre-audits the kitchen before submitting" is false — at
+  least 3 sellers (legalindonesia.id, balivisa.co, INVARR) explicitly sell a kitchen/facility audit as
+  part of the package.
+- **Market size**: no authoritative, current, Bali-specific restaurant count could be retrieved live (BPS
+  table blocked the fetch tool with 403; the Dinas Pariwisata 2025 PDF didn't parse). Only a secondary-source
+  citation of BPS 2023 data survives — flagged as such, not as verified.
+- Full file: `research/compliance/2026-07-29-slhs-lane-c-market.md`
+
+---
+
+## 1. Who sells SLHS — three tiers
+
+### Fascia A — International/expat-facing agencies
+
+| Agency | Sells SLHS as named product? | English name used | Price published? | Bundled? |
+|---|---|---|---|---|
+| **legalindonesia.id** | Yes, dedicated section | "Sanitary Certificate" | **Yes — Rp 8,500,000** agent fee | Sequential: sold AFTER their "Business Standard Compliance Certificate" (Rp 22,000,000) — see §2 |
+| **balivisa.co** | Yes, dedicated blog post + F&B roundup | "Hygiene and Sanitation Certificate" | **Yes — ~Rp 22,000,000** for "restaurant certification" + Rp 1,750,000/staff for training | Presented inside a general "F&B compliance budget" list, not a discrete standalone SKU |
+| Seven Stones Indonesia | Mentioned in blog content ("gold standard...national safety standards") | "Hygiene & Sanitation Eligibility Certificate" | No — no price anywhere found | Part of general "business license" service, not itemized |
+| Emerhub | Mentioned only inside a "Starting a Restaurant" guide, no dedicated SLHS page | "SLHS / Hygiene Sanitation Certification" | No | Folded into general restaurant-setup consulting |
+| Cekindo / InCorp | Listed as one bullet ("hygiene license") among 5 Bali business licenses | "hygiene license" | No | No |
+| Permitindo | Mentioned as a required supporting doc ("health certificate"), not sold as own line | "health certificate" | No | No |
+| Lets Move Indonesia | No dedicated page indexed at all | — | No | Unknown — likely handled ad hoc under general licensing retainer |
+| Bali Solve | Not mentioned anywhere in their public service pages | — | No | — |
+| "Flado" | **Could not confirm this business exists** under that name in Bali — zero hits across 3 search attempts. Treat as unverified/possibly mis-named in the brief. | — | — | — |
+
+**Reading**: SLHS is a checkbox line-item for 7 of 9 Fascia-A names, not a marketed product. Only 2 of 9
+publish a price, and those two disagree with each other by roughly 2.5x on what "SLHS" even costs — which
+suggests at least one of them is quoting a bundled/adjacent certificate cost (see §2) rather than SLHS alone.
+
+### Fascia B — Local/national konsultan perizinan (Indonesian-language)
+
+| Provider | Based in | Price | Included | Excluded |
+|---|---|---|---|---|
+| **riksa.co.id** | Bekasi (HQ) + Manado branch — **not Bali** | **Starting Rp 12,000,000** | SLHS/SLS filing per Permenkes 17/2024 | Training for penanggung jawab, worker training, lab testing — all extra |
+| **INVARR (invarr.org)** | Jakarta-based, national | Rp 1,000,000 (consultation) / **Rp 19,900,000** (full technical assistance) | Facility/kitchen audit, lab test coordination, training/competency-cert facilitation, OSS submission supervision | — both SKUs currently marked **sold out** |
+| irakonsultan.co.id | Unknown | Page returned 404 at time of check | — | — |
+| **licenselead.id** ("Jasa Perizinan Usaha No 1 di Bali") | **Bali-based** | No price anywhere (pure "call us") | NIB, PBG, SLF, immigration docs, property permits, contracts | **SLHS is not listed as a service at all** |
+| **konsultanperizinanbali.com** | **Bali-based** | No price | Business certification, alcohol permits, BPOM, visa/work permits, money-changer license | **SLHS is not listed as a service at all** |
+
+**Reading — this is the sharpest finding of the whole lane**: the two Bali-based, Indonesian-language
+perizinan generalists found do NOT carry SLHS as a named SKU at all. The only sellers who DO price it as a
+dedicated named product (riksa.co.id, INVARR) are national players headquartered outside Bali. This means
+Bali's local konsultan market for SLHS specifically is thin-to-absent in public listings — it's either
+handled informally/word-of-mouth, folded silently into a general "urus izin usaha" retainer, or genuinely
+underserved.
+
+**Broker markup, documented (adjacent segment, useful anchor)**: an investigative piece (Merdeka.com,
+national) on the SPPG/MBG government kitchen program found brokers ("calo") charging **Rp 9–30 million**
+for SLHS filing when the real official cost is **~Rp 2 million** — a 4.5×–15× markup. This is a different
+program (government nutrition-kitchen certification, not general restaurant SLHS) but it is hard,
+documented evidence that SLHS pricing in Indonesia is broker-opaque and markup-prone as a general pattern,
+which lines up with what we see in Fascia A/B above.
+
+### Fascia C — DIY
+
+| Step | Cost | Source |
+|---|---|---|
+| Government application fee (via OSS, Denpasar) | **Rp 0 — free** ("Tanpa biaya (Gratis)", per Perwali 16/2014 halting retribution at city level) | dinkes.denpasarkota.go.id |
+| Processing time (official) | **7 working days** from application to recommendation letter | dinkes.denpasarkota.go.id |
+| Lab testing (water/food samples) | **Rp 300,000 – 2,000,000**, depending on parameter count | readmore.id |
+| Food-handler/KHSM competency certificate | **Rp 150,000 – 500,000** per national generic source; **Rp 1,750,000/person** per balivisa.co's Bali-specific (likely private/expedited) course | readmore.id vs balivisa.co — flagged as a real discrepancy, not resolved here |
+| Process (self-service) | Submit via oss.go.id → e-verification → scheduled on-site inspection → evaluation notice → download recommendation letter via OSS | dinkes.denpasarkota.go.id |
+
+**Realistic DIY floor for a small single-outlet operation**: roughly **Rp 500,000 – 3,000,000** all-in
+(one lab test + one staff certificate), against the official Rp 0 filing fee — versus Rp 8.5–22 million
+(Fascia A) or Rp 12–30 million (Fascia B/broker). That's a genuine **5×–40× markup range** between DIY-real
+and agency-quoted, and it is the single most defensible number in this report because it triangulates from
+three independent source types (city government page, a generic bahasa explainer, and the Merdeka.com
+exposé on brokers).
+
+---
+
+## 2. Price table (compact)
+
+| Fascia | Provider | Price (IDR) | Total vs service fee? | Timeline | Source + date |
+|---|---|---|---|---|---|
+| A | legalindonesia.id | 8,500,000 | Service fee (excl. gov component, which is Rp 0) | ~1 month | legalindonesia.id, 2026-07-29 |
+| A | balivisa.co | ~22,000,000 (+ 1,750,000/staff) | Ambiguous — likely conflates SLHS with a broader "Sertifikat Standar"/compliance bundle | Not stated | balivisa.co, 2026-07-29 |
+| B | riksa.co.id | from 12,000,000 | Service fee, excludes training + lab | 2–4 weeks | riksa.co.id, 2026-07-29 |
+| B | INVARR | 19,900,000 (full) / 1,000,000 (consult) | Service fee; both SOLD OUT at check time | Not stated | invarr.org, 2026-07-29 |
+| B (broker, adjacent program) | "calo" (unnamed) | 9,000,000–30,000,000 | Pure markup over a ~2,000,000 real cost | Not stated | Merdeka.com, national exposé, undated article accessed 2026-07-29 |
+| C | DIY (self-filed) | ~500,000–3,000,000 all-in (gov fee = 0) | Real cost, no service fee | 7 working days (gov step only) | dinkes.denpasarkota.go.id + readmore.id, 2026-07-29 |
+
+**"Contact us" is itself a data point.** Seven of the ~11 named Fascia A/B competitors (Seven Stones,
+Emerhub, Cekindo, Permitindo, Lets Move Indonesia, Bali Solve, licenselead.id, konsultanperizinanbali.com)
+publish zero pricing anywhere for SLHS — either because they don't sell it as a discrete line, or because
+opacity is the deliberate positioning (high-touch consulting norm across this whole competitive set, not
+SLHS-specific).
+
+---
+
+## 3. Packaging patterns (the important question)
+
+Three patterns are visible, ranked by how many verified instances each has:
+
+1. **Sequential gate behind a bigger certificate** (1 clear instance: legalindonesia.id). SLHS is sold as
+   stage two, only reachable after the client has already bought their "Business Standard Compliance
+   Certificate" (Rp 22,000,000). This is a classic funnel structure — SLHS isn't the product, it's the
+   upsell.
+2. **Absorbed/invisible inside a general licensing retainer** (majority pattern — Seven Stones, Emerhub,
+   Cekindo, Permitindo, Lets Move Indonesia, both Bali-local konsultan checked). No dedicated SKU, no
+   price, handled as "we'll take care of it" inside a broader company-setup or F&B-licensing engagement.
+3. **Standalone named product with a real price tag** (riksa.co.id, INVARR) — but neither is Bali-based,
+   and INVARR's are both sold out, suggesting either genuinely finite capacity or a discontinued/paused
+   product line.
+
+**Not observed anywhere**: a subscription/retainer model that includes proactive SLHS renewal (annual or
+3-yearly, depending on which validity-period source is correct — see caveat below). No agency in either
+fascia advertises "we track your expiry and refile automatically." This absence is suggestive but not
+proof of a gap — silence in public marketing copy doesn't rule out the service existing informally for
+existing clients.
+
+**Regulatory ambiguity found, not resolved here (flag for Lane A/norma)**: sources disagree on SLHS
+validity — associe.co.id says 1 year; a Denpasar-specific secondary source (bbkkdenpasar.com) and
+legalindonesia.id both say 3 years (legalindonesia.id adds a 75%-of-original annual evaluation fee on top);
+riksa.co.id cites "Permenkes No. 17 Tahun 2024" as the current legal basis. This directly affects whether
+a "renewal reminder" product is an annual or triennial touchpoint — worth Lane A confirming the current
+regulation before Bali Zero commits to either cadence in a pitch.
+
+---
+
+## 4. SEO / demand landscape (qualitative — no volume tool used)
+
+- **English query cluster** ("hygiene certificate bali restaurant", "SLHS restaurant bali"): SERP is
+  dominated by long-form "how to open a restaurant in Bali" pillar-guides from exactly the Fascia-A
+  competitors above (legalindonesia.id, balivisa.co, Seven Stones, Cekindo, Emerhub, evisabali.com,
+  investinasia.id). SLHS appears as one subsection inside a 1,500+ word guide, essentially never as its
+  own dedicated, price-anchored landing page. legalindonesia.id and balivisa.co are the closest to a
+  standalone treatment and even they fold it into "F&B licensing" or "2026 compliance budget" framing.
+- **Bahasa query cluster** ("sertifikat laik higiene sanitasi", "SLHS restoran"): SERP is dominated by
+  **government/informational sources** — city Dinkes pages, DPMPTSP/MPP portals, and generic legal-explainer
+  content sites (legalitas.org, associe.co.id, readmore.id, legalyn.id) that rank for informational intent
+  but monetize adjacent services (PT/CV incorporation) rather than SLHS itself.
+- **Net finding**: across roughly 25 pages fetched/searched for this lane, **no single Bali-specific,
+  price-transparent, standalone "SLHS" product landing page was found in either language.** Every priced
+  data point we have came from a subsection of a bigger guide (legalindonesia.id, balivisa.co) or a
+  non-Bali national specialist (riksa.co.id, INVARR). That gap — a genuinely dedicated, price-honest,
+  Bali-anchored SLHS page — is the cleanest content/SEO opportunity this research surfaced, precisely
+  because the SERP for both language clusters currently rewards "part of a bigger guide," not "the
+  product itself."
+
+---
+
+## 5. Market size — what could and couldn't be verified live
+
+- The official BPS Bali statistics table (`bali.bps.go.id`, "Banyaknya Restoran dan Rumah Makan Dirinci
+  Menurut Kabupaten/Kota") returned **HTTP 403** to the fetch tool — could not read it directly this
+  session.
+- The Dinas Pariwisata Provinsi Bali "Statistik Pariwisata 2025" PDF (5.5MB) downloaded but did not parse
+  into extractable text with the tool available — the specific by-regency restaurant/hotel/villa
+  breakdown inside it is **not verified** here.
+- The only figure recoverable was a **secondary citation** (solusidigitalusaha.biz.id, referencing BPS)
+  claiming **3,868 restoran/rumah makan** registered in Bali as of **2023**, with Badung alone at
+  "more than 2,900" and the Gianyar/Ubud area at "more than 1,200." **These regency subtotals sum to more
+  than the province total**, which means either the sub-figures use a looser definition (e.g. including
+  cafes/warungs the province total excludes) or the secondary source is internally inconsistent. **Flagging
+  this rather than reconciling it** — it should not be quoted as a clean number without going back to the
+  primary BPS table (which needs a browser session or authenticated fetch, not the plain WebFetch tool).
+- **Annual new-restaurant openings**: no figure found.
+- **Expat-owned share of the segment**: no figure found anywhere. Do not assume a percentage — state
+  plainly that Bali Zero's actual addressable segment size (foreign-owned/PT PMA F&B operators specifically,
+  as opposed to the full Indonesian-owned universe) is **unknown from public sources** and would need either
+  a Dinas Penanaman Modal (BPKM/DPMPTSP) foreign-investment-by-sector cut, or a KBLI 56xxx cross-reference
+  against PT PMA registrations — neither attempted in this pass.
+- **What's missing from every count above**: cafes, hotel/villa in-house restaurants, and catering
+  operations are a materially larger population than the "restoran/rumah makan" statistical category alone,
+  and every one of them also needs SLHS. The true addressable universe is larger than any number in this
+  section — by how much is unknown.
+
+---
+
+## 6. White space — verified vs refuted vs unverified
+
+| Candidate (from the brief) | Verdict | Evidence |
+|---|---|---|
+| Nobody manages proactive renewal | **Unverified (plausible, not proven)** | No agency advertises it; absence of marketing copy ≠ absence of the service for existing clients |
+| Nobody pre-audits the premises before submitting | **REFUTED** | legalindonesia.id, balivisa.co, and INVARR all explicitly sell a kitchen/facility-readiness audit as part of their package |
+| Nobody sells in English with price transparency | **Partially verified, with a twist** | True for 7/9 Fascia-A brands (no price at all). False for 2/9 (legalindonesia.id, balivisa.co) — but those two disagree by ~2.5x on what SLHS costs, so the "transparency" that exists is internally inconsistent, which is arguably worse than silence for a prospective client comparing quotes |
+| Nobody links SLHS to KBLI choice upstream | **Real gap, but in positioning not fact** | The KBLI-SLHS technical link is well documented in government/explainer sources (you must select the correct food-business KBLI in OSS before SLHS can be filed) — but no commercial competitor markets this as a consulting angle ("we pick your KBLI so your SLHS path is clean"). Genuinely open positioning territory. |
+| *(new, found not briefed)* Bali-local konsultan don't carry SLHS as a product at all | **Verified** | Both Bali-based general perizinan sites checked (licenselead.id, konsultanperizinanbali.com) omit SLHS entirely from their service menus |
+| *(new, found not briefed)* No Bali-specific, price-transparent standalone SLHS page exists in either language | **Verified across ~25 sources checked** | See §4 |
+
+---
+
+## Method notes / limitations
+
+- Public read-only search + fetch only (WebSearch + WebFetch). No forms submitted, no contact made, no
+  Instagram/Tokopedia/Shopee/OLX listing individually opened (an IG post surfaced in search but wasn't
+  visited — treat its existence as a signal that IG is a real distribution channel for this service, not as
+  a priced data point).
+- Several fetches failed outright: `balivisa.co/secure-your-hygiene-and-sanitation-certificate-in-indonesia-2026/`
+  (404 on direct fetch — content instead recovered from a different balivisa.co page with overlapping
+  numbers), `irakonsultan.co.id/jasa-pengurusan-slhs/` (404), `bali.bps.go.id` table (403), Dinas
+  Pariwisata PDF (downloaded but not machine-readable with the tool used).
+- No personal/individual data collected — every entity above is a company/agency and a public price or
+  absence thereof.


### PR DESCRIPTION
## Summary
- Public-read research (no PII, no outreach) mapping who sells SLHS (Sertifikat Laik Higiene Sanitasi) around Bali across 3 tiers: international/expat-facing agencies, local konsultan perizinan, and DIY.
- Compact price table, 3 dominant packaging patterns, qualitative SEO/demand landscape, and a white-space verdict table (verified / refuted / unverified) against the briefed candidates.
- File: `research/compliance/2026-07-29-slhs-lane-c-market.md`

## Test plan
- [x] Pre-commit + pre-push hooks passed locally (docs-only path, allowlist-skipped backend suite)
- [ ] CI required checks green
- [x] Frontmatter present (date/domain/client_case/sources) per CLAUDE.md §15 research capture convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)