### PR TITLE
fix(deps): four manifests still permit a next below the security floor

### DIFF
--- a/apps/bali-zero-magazine/package.json
+++ b/apps/bali-zero-magazine/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@cf-wasm/photon": "0.3.7",
     "drizzle-orm": "0.45.2",
-    "next": "16.2.6",
+    "next": "^16.2.12",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },

--- a/apps/kbli-navigator/package.json
+++ b/apps/kbli-navigator/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "clsx": "^2.1.0",
     "lucide-react": "^0.475.0",
-    "next": "^16.1.0",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.0",

--- a/apps/osint-nexus-ui/package.json
+++ b/apps/osint-nexus-ui/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "^16.0.0",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "framer-motion": "^12.0.0",

--- a/apps/wa-dashboard/package.json
+++ b/apps/wa-dashboard/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "http-proxy": "^1.18.1",
     "lucide-react": "^0.469.0",
-    "next": "^16.2.5",
+    "next": "^16.2.12",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-virtuoso": "^4.12.3",


### PR DESCRIPTION
Dependabot has 8 open HIGH advisories; four of them are one package — `next` — and all resolve to the same shape: a declared range that **admits** a version below 16.2.11.

| manifest | declared | admits |
|---|---|---|
| `apps/bali-zero-magazine` | `16.2.6` (exact pin) | vulnerable by construction |
| `apps/kbli-navigator` | `^16.1.0` | 16.1.x |
| `apps/osint-nexus-ui` | `^16.0.0` | 16.0.x |
| `apps/wa-dashboard` | `^16.2.5` | 16.2.5 … 16.2.10 |

The rest of the fleet is already at `^16.2.12` (admin-dashboard, -local, autonomous-lab, mouth, web) or pinned at the patched floor (`packages/core` 16.2.11). These four are laggards, not a different decision.

**Scope — verified, not assumed.** None of the four is in the root `workspaces` array and none carries a lock of its own, so this changes no resolved dependency graph and needs no lockfile regeneration. It raises the floor so a fresh install in those apps cannot land on a vulnerable `next`.

**Class-audit, not one instance.** Every `"next":` declaration in the repo was enumerated *with its path* before editing; only the four below the floor were touched. (An earlier pass of mine corrupted all four JSON files with a stray perl `\Q…\E` — caught by a `JSON.parse` validation step, restored, redone. The validation is why you are not reading a broken manifest.)

---

*Landing note, for whoever hits it next:* this branch took three full backend-suite runs to push. `apps/**/package.json` is not on the pre-push allowlist, so a 4-line JSON diff classifies as `full`; and pushing from Pro/Mini over SSH dies with `Connection to github.com closed by remote host` because `git push` opens the transport for ref-discovery **before** running the hook, so the connection sits idle for ~15 minutes and GitHub closes it — the suite then goes green on a dead transport and the log ends with `✅ All pre-push checks passed!` on a push that never happened. `GIT_SSH_COMMAND='ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=40'` is what finally landed it.