### PR TITLE
docs(index): resync INDEX.md after admin-dashboard description drift

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -103,7 +103,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 
 | App | Ruolo |
 | --- | ----- |
-| `admin-dashboard` | Local-only ops dashboard. Runs on port 3002 via `start_dashboard.sh`. |
+| `admin-dashboard` | A standalone Next.js application to inspect and control Nuzantara data. |
 | `admin-dashboard-local` | Pro-only LLM cost dashboard. **Not deployed anywhere.** |
 | `autonomous-lab` |  |
 | `backend-rag` | **Production-Ready AI-Powered RAG System for Business Intelligence** |


### PR DESCRIPTION
## Summary
- Proprioception's `docs_sync` probe flagged INDEX.md as DIVERGED (P3) — `apps/admin-dashboard/README.md` had drifted from the derived table without a same-commit regen (W86 class).
- Mechanical `python3 scripts/docs_sync.py` regen, single-line diff, no logic touched.

## Test plan
- [x] `python3 scripts/docs_sync.py --check` → `DOCSYNC OK (no changes)` after regen
- [x] Pre-commit + pre-push hooks passed locally

Healer autonomous tick (Mini-Pro2, perimeter: docs/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)