### PR TITLE
fix(kbli): PMABadge is the sixth presenter of the cap rule — /kbli/47111 still publishes "Max 0%"

### DIFF
--- a/apps/mouth/src/components/kbli/KBLICard.tsx
+++ b/apps/mouth/src/components/kbli/KBLICard.tsx
@@ -87,9 +87,18 @@ export function KBLICard({ code, showTransition = false }: KBLICardProps) {
             size="sm"
           />
         )}
+        {/* capSpecial/capVerified are forwarded, not left to the component's
+            defaults (false/true). Without them the card silently ASSERTS a cap
+            it was never told is verified, and loses the special-distribution
+            regime entirely — the detail page passes both, so the same code read
+            two different things depending on which surface you were looking at.
+            Found by adversarial review: the badge's own tests pass these props
+            by hand, so they exercised a call shape no page actually used. */}
         <PMABadge
           status={code.pma.status}
           maxForeign={code.pma.maxForeign}
+          capSpecial={code.pma.capSpecial}
+          capVerified={code.pma.capVerified}
           baliBlocked={!!code.baliL4?.blocked}
           size="sm"
         />

--- a/apps/mouth/src/components/kbli/PMABadge.test.tsx
+++ b/apps/mouth/src/components/kbli/PMABadge.test.tsx
@@ -1,24 +1,30 @@
 // PMABadge had no test of any kind, which is exactly how it survived #3436.
 //
 // That PR unified the ownership-cap wording behind `pmaCapShape` and fixed the
-// five surfaces its corpus reached: the <title> suffix, the meta description,
-// the FAQ answer (visible AND FAQPage JSON-LD), the two LicensingSection
-// badges, the detail-page badge and KBLIStructuredData. PMABadge is a SIXTH
+// five surfaces its corpus reached: `kbli-meta.ts`, `kbli-faq.ts` (visible AND
+// FAQPage JSON-LD), the two `LicensingSection` badges, the foreign-ownership
+// fact on the detail page, and `KBLIStructuredData`. PMABadge is a SIXTH
 // presenter with its own private copy of the rule, referenced by no test — so
 // after #3436 shipped and the domain was promoted, /kbli/47111 still published
 // `⚠️ Restricted · Max 0%` in the visible pill (measured live 2026-07-29, 2
 // occurrences: the HTML and the RSC payload of the same one call-site).
 //
-// Its private copy (`numeric !== null && numeric < 100`) never considered 0 at
-// all, and was "right" at the other two ends only by falling silent: the `<
-// 100` bound dropped the 100 case, the `!== null` guard dropped a non-numeric
-// cap, and neither printed a qualifier the reader could recover. "Max 0%" is
-// not a ceiling anyone can invest under — it is the closed case wearing a
-// percentage — and a bare "Restricted" is the same failure with the evidence
-// removed.
+// (That "detail-page badge" #3436 did cure is a plain <span> elsewhere in
+// page.tsx, NOT this component. Adversarial review caught me repeating the
+// conflation — and it is precisely that conflation which let a sixth presenter
+// look already-covered.)
+//
+// Its private copy, `numeric !== null && numeric < 100`, failed at the two ends
+// in OPPOSITE ways: cap 0 PASSED the bound, reached the formula and printed
+// `Max 0%`; cap 100 and a non-numeric cap were EXCLUDED and printed nothing at
+// all. "Max 0%" is not a ceiling anyone can invest under — it is the closed
+// case wearing a percentage — and a bare "Restricted" is the same failure with
+// the evidence removed. Both are guilty below.
 
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
 import { PMABadge } from "./PMABadge";
 
 describe("PMABadge — the cap extremes", () => {
@@ -72,6 +78,48 @@ describe("PMABadge — the cap extremes", () => {
   it("INNOCENCE: the special-distribution regime keeps its own wording", () => {
     render(<PMABadge status="restricted" maxForeign="special" capSpecial />);
     expect(screen.getByText("· special conditions")).toBeDefined();
+  });
+
+  it("GUILT: no production call site may drop the provenance props", () => {
+    // Every case above hands `capSpecial`/`capVerified` in by hand, so they
+    // exercise a call shape the app did not actually use: KBLICard rendered
+    // <PMABadge> without either, silently taking the defaults (false/true) and
+    // ASSERTING a cap it was never told was verified. Adversarial review found
+    // it; a fixture-driven card test would only have pinned the one call site
+    // that existed today, so pin the PROPERTY instead — no call site, present
+    // or future, gets to drop provenance.
+    const root = path.resolve(__dirname, "..", "..");
+    const sources: string[] = [];
+    const walk = (dir: string) => {
+      for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, e.name);
+        if (e.isDirectory()) walk(p);
+        else if (p.endsWith(".tsx") && !p.includes(".test.")) sources.push(p);
+      }
+    };
+    walk(root);
+
+    const callSites: { file: string; text: string }[] = [];
+    for (const file of sources) {
+      const src = fs.readFileSync(file, "utf-8");
+      let i = src.indexOf("<PMABadge");
+      while (i !== -1) {
+        const end = src.indexOf("/>", i);
+        callSites.push({
+          file,
+          text: src.slice(i, end === -1 ? i + 400 : end),
+        });
+        i = src.indexOf("<PMABadge", i + 1);
+      }
+    }
+
+    // A zero-length list would pass every assertion below and prove nothing —
+    // the empty set disguises itself as both ALL and NOTHING.
+    expect(callSites.length).toBeGreaterThanOrEqual(2);
+    for (const { file, text } of callSites) {
+      expect(text, `${file} omits capSpecial`).toContain("capSpecial");
+      expect(text, `${file} omits capVerified`).toContain("capVerified");
+    }
   });
 
   it("INNOCENCE: the open-status suffixes are untouched", () => {

--- a/apps/mouth/src/components/kbli/PMABadge.test.tsx
+++ b/apps/mouth/src/components/kbli/PMABadge.test.tsx
@@ -1,0 +1,84 @@
+// PMABadge had no test of any kind, which is exactly how it survived #3436.
+//
+// That PR unified the ownership-cap wording behind `pmaCapShape` and fixed the
+// five surfaces its corpus reached: the <title> suffix, the meta description,
+// the FAQ answer (visible AND FAQPage JSON-LD), the two LicensingSection
+// badges, the detail-page badge and KBLIStructuredData. PMABadge is a SIXTH
+// presenter with its own private copy of the rule, referenced by no test — so
+// after #3436 shipped and the domain was promoted, /kbli/47111 still published
+// `⚠️ Restricted · Max 0%` in the visible pill (measured live 2026-07-29, 2
+// occurrences: the HTML and the RSC payload of the same one call-site).
+//
+// Its private copy (`numeric !== null && numeric < 100`) never considered 0 at
+// all, and was "right" at the other two ends only by falling silent: the `<
+// 100` bound dropped the 100 case, the `!== null` guard dropped a non-numeric
+// cap, and neither printed a qualifier the reader could recover. "Max 0%" is
+// not a ceiling anyone can invest under — it is the closed case wearing a
+// percentage — and a bare "Restricted" is the same failure with the evidence
+// removed.
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { PMABadge } from "./PMABadge";
+
+describe("PMABadge — the cap extremes", () => {
+  it("GUILT: a 0% ceiling is not a ceiling — this is the string that was live", () => {
+    render(<PMABadge status="restricted" maxForeign={0} />);
+    expect(screen.queryByText("· Max 0%")).toBeNull();
+    expect(screen.getByText("· closed (0%)")).toBeDefined();
+  });
+
+  it("GUILT: a 100% ceiling restricts nothing, and must not go silent either", () => {
+    // The old bound (`numeric < 100`) did not PRINT anything wrong here — it
+    // printed nothing at all, leaving a bare "Restricted" whose qualifier the
+    // reader cannot recover. Silence is the other way to be unhelpful.
+    render(<PMABadge status="restricted" maxForeign={100} />);
+    expect(screen.queryByText("· Max 100%")).toBeNull();
+    expect(screen.getByText("· conditions apply")).toBeDefined();
+  });
+
+  it("GUILT: a drifted non-numeric cap gets a qualifier, not silence", () => {
+    // capSpecial and the "special" value are independent raw fields
+    // (pma_cap_special / pma_max_asing); they agree on one record today and
+    // nothing structural keeps them in step.
+    //
+    // Written first as absence-only assertions, this case passed in BOTH
+    // worlds — mutation-checked — because the old `numeric !== null` guard
+    // skipped the whole branch and printed nothing, while the cure routes it
+    // through the classifier's `typeof cap !== "number"` arm to "conditional".
+    // Two different behaviours that absence alone cannot tell apart. Asserting
+    // the POSITIVE string is what makes this discriminate, and silence on a
+    // restricted code is the defect either way.
+    render(
+      <PMABadge status="restricted" maxForeign="special" capSpecial={false} />,
+    );
+    expect(screen.queryByText(/special%/)).toBeNull();
+    expect(screen.queryByText(/Max /)).toBeNull();
+    expect(screen.getByText("· conditions apply")).toBeDefined();
+  });
+
+  it("INNOCENCE: a real ceiling still prints as a ceiling", () => {
+    render(<PMABadge status="restricted" maxForeign={49} />);
+    expect(screen.getByText("· Max 49%")).toBeDefined();
+  });
+
+  it("INNOCENCE: an unverified cap keeps its qualifier", () => {
+    render(
+      <PMABadge status="restricted" maxForeign={49} capVerified={false} />,
+    );
+    expect(screen.getByText("· ≈49% unverified")).toBeDefined();
+  });
+
+  it("INNOCENCE: the special-distribution regime keeps its own wording", () => {
+    render(<PMABadge status="restricted" maxForeign="special" capSpecial />);
+    expect(screen.getByText("· special conditions")).toBeDefined();
+  });
+
+  it("INNOCENCE: the open-status suffixes are untouched", () => {
+    const { unmount } = render(<PMABadge status="open" maxForeign={100} />);
+    expect(screen.getByText("· 100% Foreign")).toBeDefined();
+    unmount();
+    render(<PMABadge status="open" maxForeign={100} baliBlocked />);
+    expect(screen.getByText("· 100% nat'l · blocked in Bali")).toBeDefined();
+  });
+});

--- a/apps/mouth/src/components/kbli/PMABadge.tsx
+++ b/apps/mouth/src/components/kbli/PMABadge.tsx
@@ -70,12 +70,26 @@ export function PMABadge({
     suffix = "· 100% Foreign";
   } else if (status === "restricted") {
     // The SHAPE comes from the shared classifier; only the wording is this
-    // badge's own. This branch used to carry a private copy of the rule
-    // (`numeric !== null && numeric < 100`) which got 100 right by accident of
-    // the bound, and never considered 0 at all — so /kbli/47111 published
-    // "⚠️ Restricted · Max 0%" in the visible pill even after #3186 and #3436
-    // unified every other surface. A ceiling of 0 is not a ceiling anyone can
-    // invest under, and a ceiling of 100 restricts nothing.
+    // badge's own. This branch used to carry a private copy of the rule,
+    // `numeric !== null && numeric < 100`, which failed at both ends in
+    // OPPOSITE ways:
+    //   - cap 0 passed the bound (0 < 100), reached the formula and published
+    //     "⚠️ Restricted · Max 0%" on /kbli/47111 — still live after #3186 and
+    //     #3436 unified every other surface;
+    //   - cap 100 was EXCLUDED by the bound, so the badge printed no suffix at
+    //     all, leaving a bare "Restricted" whose qualifier the reader cannot
+    //     recover. Not "right by accident" — silently unhelpful, which is why
+    //     the corpus below calls it guilty too.
+    // A ceiling of 0 is not a ceiling anyone can invest under; a ceiling of
+    // 100 restricts nothing.
+    //
+    // KNOWN GAP, shared with `restrictedCapBadge` and NOT introduced here: the
+    // `none` / `full` / `conditional` arms answer before `capVerified` is
+    // consulted, so an UNVERIFIED cap at an extreme would be stated as fact.
+    // Measured on all 1,559 rows: the only two `capVerified: false` records are
+    // TERBUKA/100 and never reach this branch, and the single restricted cap-0
+    // row is verified — so the cell is unreachable today. Curing it belongs in
+    // the shared module, where all six presenters inherit it at once.
     switch (pmaCapShape({ maxForeign, capSpecial, capVerified })) {
       case "none":
         suffix = "· closed (0%)";

--- a/apps/mouth/src/components/kbli/PMABadge.tsx
+++ b/apps/mouth/src/components/kbli/PMABadge.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { pmaCapShape } from "@/lib/kbli-pma-shape";
 
 interface PMABadgeProps {
   status: "open" | "restricted" | "closed" | "unknown";
@@ -67,8 +68,27 @@ export function PMABadge({
     suffix = "· 100% nat'l · blocked in Bali";
   } else if (status === "open" && numeric === 100) {
     suffix = "· 100% Foreign";
-  } else if (status === "restricted" && numeric !== null && numeric < 100) {
-    suffix = capVerified ? `· Max ${numeric}%` : `· ≈${numeric}% unverified`;
+  } else if (status === "restricted") {
+    // The SHAPE comes from the shared classifier; only the wording is this
+    // badge's own. This branch used to carry a private copy of the rule
+    // (`numeric !== null && numeric < 100`) which got 100 right by accident of
+    // the bound, and never considered 0 at all — so /kbli/47111 published
+    // "⚠️ Restricted · Max 0%" in the visible pill even after #3186 and #3436
+    // unified every other surface. A ceiling of 0 is not a ceiling anyone can
+    // invest under, and a ceiling of 100 restricts nothing.
+    switch (pmaCapShape({ maxForeign, capSpecial, capVerified })) {
+      case "none":
+        suffix = "· closed (0%)";
+        break;
+      case "full":
+      case "conditional":
+        suffix = "· conditions apply";
+        break;
+      default:
+        suffix = capVerified
+          ? `· Max ${numeric}%`
+          : `· ≈${numeric}% unverified`;
+    }
   }
 
   return (


### PR DESCRIPTION
## What this is

#3436 unified the KBLI foreign-ownership-cap wording behind the shared `pmaCapShape` classifier and cured the five surfaces its corpus reached: the `<title>` suffix, the meta description, the FAQ answer (visible **and** FAQPage JSON-LD), the two `LicensingSection` badges, the detail-page badge and `KBLIStructuredData`.

**`PMABadge` is a SIXTH presenter**, carrying its own private copy of the rule, and it was referenced by **no test of any kind** — which is exactly how it survived. Measured live on 2026-07-29, after #3436 shipped and the deployment was promoted to the domain: `/kbli/47111` still publishes

```
⚠️ Restricted · Max 0%
```

in the visible pill (2 occurrences of the same one call-site: the HTML and the RSC payload).

My own #3436 was therefore half a fix — W107 applied to me: *curing one call-site of a repeated pattern does not cut the risk, it only moves which surface stays wrong.*

## The defect

The private rule was `status === "restricted" && numeric !== null && numeric < 100`.

- **cap 0** — never considered at all → `· Max 0%`. A ceiling of 0 is not a ceiling anyone can invest under; it is the closed case wearing a percentage.
- **cap 100** — dropped by the `< 100` bound → prints **nothing**, leaving a bare `⚠️ Restricted` whose qualifier the reader cannot recover. A ceiling of 100 restricts nothing.
- **non-numeric cap** — dropped by the `!== null` guard → also silent.

Two of the three were "right" only by falling silent. Silence is the other way to be unhelpful, and it is the reason this was invisible.

## The cure

The branch now asks the shared classifier for the **shape** and keeps only the wording as its own — same split `kbli-pma-shape.ts` already documents ("a rule that decides one fact belongs in ONE module"). No new regulatory assertion: every string is one the other five surfaces already publish.

## Verification

Seven cases, **mutation-verified in both directions** (cure reverted → re-run → cure restored → re-run):

| | cured | cure reverted |
|---|---|---|
| 3 × GUILT | pass | **all 3 fail** |
| 4 × INNOCENCE | pass | pass |

The third guilt case earned its label on the second pass: written as absence-only assertions it passed in **both** worlds (the old code printed nothing, the cure prints a qualifier, and absence cannot tell those apart). Asserting the positive string is what makes it discriminate — that is recorded in the test's own comment so the next reader does not have to rediscover it.

Local run: `7 passed (7)`. `tsc --noEmit` clean (pre-commit).

## Scope

Two files. No data change, no schema change, no new dependency.