### PR TITLE
docs(atlas): cure the docs-sync staleness at its SOURCE — supersedes #3453, which reverts the facts

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -103,7 +103,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 
 | App | Ruolo |
 | --- | ----- |
-| `admin-dashboard` | Local-only ops dashboard. Runs on port 3002 via `start_dashboard.sh`. |
+| `admin-dashboard` | Local-only Next.js dashboard to inspect and control Nuzantara data. Runs on port 3002 via `start_dashboard.sh`. |
 | `admin-dashboard-local` | Pro-only LLM cost dashboard. **Not deployed anywhere.** |
 | `autonomous-lab` |  |
 | `backend-rag` | **Production-Ready AI-Powered RAG System for Business Intelligence** |

--- a/apps/admin-dashboard/README.md
+++ b/apps/admin-dashboard/README.md
@@ -1,6 +1,6 @@
 # Nuzantara Admin Dashboard
 
-A standalone Next.js application to inspect and control Nuzantara data.
+Local-only Next.js dashboard to inspect and control Nuzantara data. Runs on port 3002 via `start_dashboard.sh`.
 
 ## Features
 


### PR DESCRIPTION
## The state right now

`main` is DOCSYNC-STALE: `python3 scripts/docs_sync.py --check` exits **1** on `origin/main`. The required-check story is worse than it looks — `check-docs-sync` is currently **advisory** (measured via GraphQL `isRequired`: `opt`), so nothing blocked it, and the next PR touching a watched path would have eaten the red as an innocent bystander. That is W86, verbatim.

## The cause

#3437 improved the `admin-dashboard` row **by hand-editing `INDEX.md`** — a *generated* file. `docs_sync.list_apps()` derives that row from the first non-heading line of `apps/<app>/README.md`.

So the improvement was **correct in substance and unreachable in mechanism**. And its half-life is not "until someone regenerates": `.husky/post-commit` runs

```sh
python3 scripts/docs_sync.py --quiet 2>/dev/null &
```

— the **regeneration**, backgrounded and stderr-silenced, after **every commit in every worktree**. I watched it happen live: committing an unrelated KBLI component fix in a different worktree silently reverted that row and left it as a dirty file. Nobody typed a command.

## Why this supersedes #3453

#3453 (healer autonomous tick, Mini-Pro2) regenerates `INDEX.md` and lands exactly that reversion:

```diff
-| `admin-dashboard` | Local-only ops dashboard. Runs on port 3002 via `start_dashboard.sh`. |
+| `admin-dashboard` | A standalone Next.js application to inspect and control Nuzantara data. |
```

It does make `--check` return 0 — and it **destroys both facts the hand-edit added** (local-only, and how you actually start it). Its own summary has the direction backwards: *"`apps/admin-dashboard/README.md` had drifted from the derived table"*. The README did not drift; the derived table was hand-edited. The healer knew **that** two copies differed, never **which** side was authoritative, and its prescribed cure destroyed the newer information — the W106b shape one level up. Its auto-merge is disarmed pending this.

## The cure

Put the content where regeneration will **reproduce** it. `apps/admin-dashboard/README.md` line 3 now carries the two facts the hand-edit added plus what the README already said:

> Local-only Next.js dashboard to inspect and control Nuzantara data. Runs on port 3002 via `start_dashboard.sh`.

**111 chars**, under the extractor's 120-char cap (`docs_sync.py:138-168` truncates to 117 + `…` beyond it), so it lands in `INDEX.md` untruncated — verified: zero `…` anywhere in the regenerated file.

Regenerating now reproduces the good row instead of destroying it.

## Verification

| | result |
|---|---|
| `docs_sync.py --check` on `origin/main` | **RC=1** (stale) |
| `docs_sync.py --check` on this branch | **RC=0** — `DOCSYNC OK (no changes)` |
| `grep -c '…' INDEX.md` | **0** (nothing truncated) |

Two files, both markdown. No logic touched.

## Follow-ups filed, not smuggled in here

- Promote `check-docs-sync` to **required** — but only *after* this lands, since promoting it while main is stale hard-blocks every open PR.
- The post-commit regen's `2>/dev/null &` means a `docs_sync` crash leaves no trace at all (family #2). At minimum its rc should reach somewhere a human reads.