### PR TITLE
fix(connectome): retry the ssh transport so one mDNS blip cannot blank the census

### DIFF
--- a/scripts/tests/test_verify_connectome_retry.py
+++ b/scripts/tests/test_verify_connectome_retry.py
@@ -1,0 +1,180 @@
+"""verify_connectome._run retries the ssh TRANSPORT, and nothing else.
+
+Guilt: an ssh probe whose transport fails (exit 255, timeout, spawn error) is
+retried, and a link that comes back on attempt 2 reports ok — the case that
+matters, because one failed `ssh true` in ssh_reachable() blanks every edge on
+that machine. Measured on m5 during a real mDNS blip: 1 false REGRESSED
+("Could not resolve hostname") and 194 of 354 edges SKIPPED.
+
+Innocence: a probe that actually RAN and returned non-zero is an answer, not a
+flap, and is never retried — `launchctl list | grep -F <label>` exits 1 when the
+label is absent, which is exactly the death this verifier exists to report. Nor
+are local probes retried: there is no transport to flap.
+
+Run:  python3 -m pytest scripts/tests/test_verify_connectome_retry.py -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = REPO_ROOT / "scripts" / "verify_connectome.py"
+_spec = importlib.util.spec_from_file_location("verify_connectome", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+vc = importlib.util.module_from_spec(_spec)
+# Register before exec: @dataclass resolves its own module via sys.modules, so a
+# file-loaded module that skips this dies at import with a bare AttributeError.
+sys.modules[_spec.name] = vc
+_spec.loader.exec_module(vc)  # type: ignore[union-attr]
+
+
+class _Proc:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backoff must not make the suite wait for wall-clock seconds."""
+    monkeypatch.setattr(vc.time, "sleep", lambda _s: None)
+
+
+def _spy(monkeypatch: pytest.MonkeyPatch, outcomes: list) -> list:
+    """Feed `outcomes` (a _Proc or an exception instance) to successive calls."""
+    calls: list = []
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        calls.append(cmd)
+        nxt = outcomes[min(len(calls) - 1, len(outcomes) - 1)]
+        if isinstance(nxt, BaseException):
+            raise nxt
+        return nxt
+
+    monkeypatch.setattr(vc.subprocess, "run", fake_run)
+    return calls
+
+
+# --------------------------------------------------------------------------- guilt
+
+
+def test_ssh_transport_failure_is_retried_and_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _spy(
+        monkeypatch,
+        [
+            _Proc(vc.SSH_TRANSPORT_RC, stderr="ssh: Could not resolve hostname"),
+            _Proc(0, stdout="pong"),
+        ],
+    )
+    res = vc._run("true", "ssh:pro-lan", no_ssh=False)
+    assert res.ok is True
+    assert len(calls) == 2, "a 255 must be retried, not reported"
+    assert "after 2 attempts" in res.detail, "a papered-over flap must still be visible"
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [
+        subprocess.TimeoutExpired(cmd="ssh", timeout=30),
+        OSError("no such file"),
+    ],
+)
+def test_transport_exceptions_are_retried(
+    monkeypatch: pytest.MonkeyPatch, boom: BaseException
+) -> None:
+    calls = _spy(monkeypatch, [boom])
+    res = vc._run("true", "ssh:pro-lan", no_ssh=False)
+    assert res.ok is False
+    assert len(calls) == vc.PROBE_SSH_ATTEMPTS
+    assert "transport failed" in res.detail
+
+
+def test_persistent_transport_failure_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retrying must not turn a genuinely dead link green."""
+    calls = _spy(monkeypatch, [_Proc(vc.SSH_TRANSPORT_RC, stderr="no route to host")])
+    res = vc._run("true", "ssh:pro-lan", no_ssh=False)
+    assert res.ok is False
+    assert len(calls) == vc.PROBE_SSH_ATTEMPTS
+
+
+# ----------------------------------------------------------------------- innocence
+
+
+def test_remote_nonzero_is_an_answer_not_a_flap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`launchctl list | grep` exiting 1 = the label is gone. Report it at once."""
+    calls = _spy(monkeypatch, [_Proc(1, stdout="")])
+    res = vc._run("launchctl list | grep -F com.example", "ssh:pro-lan", no_ssh=False)
+    assert res.ok is False
+    assert len(calls) == 1, "a real remote verdict must not be retried"
+    assert "transport failed" not in res.detail
+
+
+def test_local_cmd_that_shells_out_to_ssh_is_still_ssh_bearing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real ssh_link edges are `type: cmd` with no `via:` — they run local.
+
+    Keying the retry off `via` alone silently skipped the exact edge whose flap
+    motivated this (`probe: {type: cmd, cmd: "ssh -o ConnectTimeout=8 pro-lan
+    true"}`), which a live run caught: same REGRESSED, no retry banner.
+    """
+    calls = _spy(
+        monkeypatch,
+        [_Proc(vc.SSH_TRANSPORT_RC, stderr="ssh: Could not resolve hostname"),
+         _Proc(0, stdout="")],
+    )
+    res = vc._run("ssh -o ConnectTimeout=8 pro-lan true", "local", no_ssh=False)
+    assert res.ok is True
+    assert len(calls) == 2
+
+
+@pytest.mark.parametrize(
+    "cmd,expected",
+    [
+        ("ssh -o ConnectTimeout=8 pro-lan true", True),
+        ("launchctl list | ssh mini cat", True),
+        ("test -e /x && ssh mini true", True),
+        # over-match guard: the letters appear, the invocation does not
+        ("test -e ~/.ssh/config", False),
+        ("grep -qE 'ssh' /etc/hosts", False),
+        ("md5 -q /tmp/sshd_config", False),
+        ("launchctl list | grep -F com.example", False),
+    ],
+)
+def test_ssh_bearing_matches_invocations_not_spellings(cmd: str, expected: bool) -> None:
+    assert vc._ssh_bearing(cmd, "local") is expected
+
+
+def test_local_probe_is_never_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _spy(monkeypatch, [_Proc(1, stderr="nope")])
+    res = vc._run("test -e /nope", "local", no_ssh=False)
+    assert res.ok is False
+    assert len(calls) == 1
+
+
+def test_local_success_is_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _spy(monkeypatch, [_Proc(0, stdout="ok")])
+    res = vc._run("true", "local", no_ssh=False)
+    assert res.ok is True
+    assert len(calls) == 1
+    assert res.detail == "ok", "the happy path must not grow an attempt banner"
+
+
+def test_no_ssh_flag_short_circuits_without_spawning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _spy(monkeypatch, [_Proc(0)])
+    res = vc._run("true", "ssh:pro-lan", no_ssh=True)
+    assert res.ok is False
+    assert calls == [], "--no-ssh must not reach subprocess at all"

--- a/scripts/verify_connectome.py
+++ b/scripts/verify_connectome.py
@@ -79,6 +79,12 @@ SSH_HOSTS: dict[str, str] = {
 
 PROBE_TIMEOUT_S = 30
 
+# ssh's own failures (name resolution, connect, auth) exit 255; anything else is
+# the remote command's status passed through. Only the former is a flap.
+SSH_TRANSPORT_RC = 255
+PROBE_SSH_ATTEMPTS = 3
+PROBE_RETRY_BACKOFF_S = 1.0
+
 
 def detect_machine() -> str:
     user = getpass.getuser()
@@ -137,7 +143,53 @@ class EdgeReport:
     source_file: str = ""
 
 
+_SSH_INVOCATION_RE = re.compile(r"(?:^|[|;&]\s*|\bthen\s+|\bdo\s+)ssh\s")
+
+
+def _ssh_bearing(cmd: str, via: str) -> bool:
+    """Does this probe cross the network via ssh — however it was spelled?
+
+    `via: ssh:<host>` is the obvious half. The other half is a `type: cmd` probe
+    that shells out to ssh itself and therefore runs with via=local, which is how
+    the ssh_link edges are actually declared:
+
+        probe: { type: cmd, cmd: "ssh -o ConnectTimeout=8 pro-lan true" }
+
+    Keying the retry off `via` alone missed exactly the edge whose flap motivated
+    it. Anchored to a command position (start of line, after a pipe/semicolon/&,
+    after then/do) and requiring trailing whitespace, so a path that merely
+    contains the letters — `test -e ~/.ssh/config` — is not mistaken for an
+    invocation.
+    """
+    return via.startswith("ssh:") or bool(_SSH_INVOCATION_RE.search(cmd))
+
+
 def _run(cmd: str, via: str, no_ssh: bool) -> ProbeResult:
+    """Run one probe, retrying only when the ssh TRANSPORT failed.
+
+    A single attempt makes this verifier report the network instead of the
+    organism. This fleet's aliases resolve over mDNS, which blips: one failed
+    `ssh true` in ssh_reachable() marks the whole machine unreachable, so every
+    edge on it becomes SKIPPED and any ssh-probed edge declared healthy flips to
+    REGRESSED — a false alarm plus a silently blanked census. Measured on m5
+    during a real blip: 1 REGRESSED (`Could not resolve hostname`) and 194 of 354
+    edges SKIPPED, from that one name lookup.
+
+    What is retried is deliberately narrow. ssh reserves exit 255 for its OWN
+    failures and otherwise passes the remote command's status through, so 255 /
+    timeout / spawn-error are the transport, while any other non-zero is a real
+    verdict from a probe that actually ran (`launchctl list | grep` exiting 1
+    means the label is absent — retrying that would only make a true negative
+    slow). Probes that never touch ssh are never retried: no transport to flap.
+
+    Retrying does not make a dead link green — measured the same day: pro-lan
+    failed 5/5 real attempts with rc 255, and stays REGRESSED. What changes is
+    that a link which comes back on attempt 2 no longer costs the census a
+    machine.
+
+    Every retry is recorded in the returned detail — a verifier that quietly
+    papers over a flaky link is the disease it exists to catch (cicatrix #8).
+    """
     if via.startswith("ssh:"):
         if no_ssh:
             return ProbeResult(False, "ssh disabled (--no-ssh)")
@@ -145,16 +197,39 @@ def _run(cmd: str, via: str, no_ssh: bool) -> ProbeResult:
         full = ["ssh", "-o", "ConnectTimeout=8", host, cmd]
     else:
         full = ["/bin/bash", "-lc", cmd]
-    try:
-        proc = subprocess.run(
-            full, capture_output=True, text=True, timeout=PROBE_TIMEOUT_S
-        )
-    except subprocess.TimeoutExpired:
-        return ProbeResult(False, f"timeout {PROBE_TIMEOUT_S}s")
-    except OSError as exc:
-        return ProbeResult(False, f"spawn error: {exc}")
-    out = (proc.stdout or "") + (proc.stderr or "")
-    return ProbeResult(proc.returncode == 0, out.strip()[:300])
+
+    is_ssh = _ssh_bearing(cmd, via)
+    attempts = PROBE_SSH_ATTEMPTS if is_ssh else 1
+    detail = ""
+
+    for attempt in range(1, attempts + 1):
+        transport_failed = False
+        try:
+            proc = subprocess.run(
+                full, capture_output=True, text=True, timeout=PROBE_TIMEOUT_S
+            )
+        except subprocess.TimeoutExpired:
+            detail, transport_failed = f"timeout {PROBE_TIMEOUT_S}s", True
+        except OSError as exc:
+            detail, transport_failed = f"spawn error: {exc}", True
+        else:
+            out = (proc.stdout or "") + (proc.stderr or "")
+            detail = out.strip()[:300]
+            if proc.returncode == 0:
+                if attempt > 1:
+                    detail = f"[ok after {attempt} attempts] {detail}".strip()
+                return ProbeResult(True, detail)
+            # Remote command ran and said no — that is an answer, not a flap.
+            if not (is_ssh and proc.returncode == SSH_TRANSPORT_RC):
+                return ProbeResult(False, detail)
+            transport_failed = True
+
+        if not transport_failed or attempt == attempts:
+            break
+        time.sleep(PROBE_RETRY_BACKOFF_S * attempt)
+
+    suffix = f" [transport failed {attempts}x]" if attempts > 1 else ""
+    return ProbeResult(False, (detail + suffix).strip()[:300])
 
 
 def _expand(path: str, via: str) -> str:


### PR DESCRIPTION
## What

`verify_connectome.py` ran each probe once. An `ssh` probe that hit a transient mDNS/Tailscale
blip returned rc 255 and was recorded as a REGRESSED edge — one blip, and the census reads as
a dead link.

Probes that are ssh-bearing (either `via: ssh:*` or an `ssh` invocation anywhere in the command)
now retry up to 3 times with backoff, and **only** for transport-shaped failures: rc 255,
timeout, or spawn error. A probe that runs and returns a real non-zero verdict is not retried —
that is a finding, not a blip. Recovery appends `[ok after N attempts]`; persistent failure
appends `[transport failed Nx]`, so neither case is silent.

An earlier draft keyed the retry on `via.startswith("ssh:")` alone and was **decorative**: the
ssh_link edges carry no `via:` at all, they are `probe: {type: cmd, cmd: "ssh ... pro-lan true"}`.
Prove-live caught it (same REGRESSED, no retry banner). Hence `_ssh_bearing()`, which reads the
command too.

## Tests

16 new cases in `scripts/tests/test_verify_connectome_retry.py`, guilt + innocence — including
that `test -e ~/.ssh/config`, `grep -qE 'ssh' /etc/hosts` and `md5 -q /tmp/sshd_config` are **not**
treated as ssh-bearing (substring `ssh` inside another token must not arm the retry — superscar #3).

## ⚠️ This push did NOT run the local pre-push gate

M5 was saturated (9 waiters, two 75-minute timeouts), so this branch was landed from Pro via
`git bundle`, which is what the saturation message itself prescribes. That worktree turned out to
have **no `.husky/_/pre-push`** — the file is gitignored and generated by husky's install, so a
manually-created worktree has no hook at all and the push is ungated. The push took 2 seconds.

So: the suite ran on M5 (16/16 for this diff) but the gate did not run for this push. **CI and the
merge queue are the only gates that have judged it.** Do not read the green push as verification.

Separately ledgered: four pre-existing `codex-*` runtime worktrees on Pro are unarmed the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)