### PR TITLE
fix(docs): the INDEX.md app blurb is generated — put the text in the source README

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -103,7 +103,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `garuda_index`/`gar
 
 | App | Ruolo |
 | --- | ----- |
-| `admin-dashboard` | Local-only ops dashboard. Runs on port 3002 via `start_dashboard.sh`. |
+| `admin-dashboard` | A standalone Next.js application to inspect and control Nuzantara data. Starts on port 3002 via `start_dashboard.sh`. |
 | `admin-dashboard-local` | Pro-only LLM cost dashboard. **Not deployed anywhere.** |
 | `autonomous-lab` |  |
 | `backend-rag` | **Production-Ready AI-Powered RAG System for Business Intelligence** |

--- a/apps/admin-dashboard/README.md
+++ b/apps/admin-dashboard/README.md
@@ -1,6 +1,6 @@
 # Nuzantara Admin Dashboard
 
-A standalone Next.js application to inspect and control Nuzantara data.
+A standalone Next.js application to inspect and control Nuzantara data. Starts on port 3002 via `start_dashboard.sh`.
 
 ## Features
 


### PR DESCRIPTION
`check-docs-sync` is **red on main** since `fdd227e842` (#3437), and stays red on every PR that touches a triggering path. This makes it green by fixing the cause, not the symptom.

## The row is generated, and it was edited by hand

`docs_sync.list_apps()` builds each row of the INDEX.md app table from the **first non-heading, non-blank line of `apps/<app>/README.md`**, capped at 120 chars. #3437 improved the `admin-dashboard` blurb by editing INDEX.md directly — so the next regen reverts it, and until someone regenerates, the gate is red forever.

Editing a generated file is not a small mistake with a small effect: it is a **no-op that arms a permanent failure**. The fix is to say it at the source.

## What the new sentence claims

| Claim | Status |
|---|---|
| starts on port 3002 via `start_dashboard.sh` | **verified** — `start_dashboard.sh:40` exports `PORT=3002`, line 33 prints `http://localhost:3002` |
| "Local-only" (from #3437) | **not carried over** — `apps/admin-dashboard/fly.toml` declares app `nuzantara-admin`, so the claim is at least unproven |
| the pre-existing wording | **untouched** — not this PR's to litigate |

Whether that Fly app is dormant is a real question; this PR does not answer it and asserts nothing either way. Note the *sibling* app `admin-dashboard-local` is the one documented as never deployed — a plausible source of the conflation.

117 chars, under the 120-char cap, so nothing truncates.

## The innocence check is the diff itself

Regenerating moves **exactly one line** of INDEX.md. Had this machine disagreed with CI on any other counter in that file, the regen would have moved those lines too. `--check` then returns 0.

## For the next person who sees "green locally, red in CI"

On a clean tree the gate reproduces **exactly**: `INDEX.md: 0dc820537b6a → 32940c91eb0a`, byte-identical to the CI log.

My first pass could not reproduce it, and the reason is worth writing down: an earlier run of the *writer* had already repaired my working tree, so I was interrogating a probe I had contaminated myself. `git status` showed `M INDEX.md` the whole time. Before concluding "CI and I disagree on identical inputs", check the inputs are still identical.

Scar family #9 (state-schema drift), **W86 verbatim**: a generated contract left stale on main fails the *next*, innocent PR. The antidote already on the books — regen in the same commit as the change — assumes the change went through the generator at all; this one did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
