### PR TITLE
fix(docs-gate): the refresh organ was charged for the one decision P3-prime gave it

### DIFF
--- a/scripts/docs_audit.py
+++ b/scripts/docs_audit.py
@@ -521,6 +521,84 @@ def compute_drift(doc: Path, expected_keys: Dict[str, str]) -> bool:
     return False
 
 
+def archive_orphan_action(last_touched_date: str) -> str:
+    """The `action` cell an orphan-archived row carries.
+
+    Extracted so the string has exactly ONE author. `docs_inventory_blame.py`
+    needs to recognise this cell to tell a real orphan flip from a hand-written
+    one, and a second copy of the format there would be a second definition of
+    the same fact — the divergence would be silent, because nothing compares
+    the two spellings (scar #9: two writers of one field ⇒ the rule lives in
+    one module).
+    """
+    return f"archive: orphan, last_touched={last_touched_date}, refs=0"
+
+
+def orphan_flip_claim_is_legitimate(
+    *,
+    trusted_ref_has_prior_flip: bool,
+    generated_refs_in: object,
+    generated_eligible_on: str,
+    committed_flipped_on: str,
+    committed_refs_in: object,
+    trusted_ref_ceiling_date: "date | None",
+) -> bool:
+    """Is a committed `orphan_flipped_on` claim one an honest run could produce?
+
+    THE ONE definition of that question, called by both gates that ask it:
+    `_tolerated_orphan_flip_paths()` below (the `--check` byte-diff path) and
+    `docs_inventory_blame.py::_is_earned_flip` (the `inventory-check` blame
+    path). It was extracted, not copied: the blame path's first version
+    (2026-07-29) re-derived the rule from scratch and a cross-family red-team
+    took it apart — it ignored `refs_in`, so ANY doc could be hand-marked
+    ARCHIVED, and it had no upper bound, so `2099-12-31` passed. Everything it
+    was missing was already solved here, hardened by the 2026-07-25 round. A
+    weaker second copy of a guard is worse than no second guard, because the
+    weaker one is the one an attacker uses.
+
+    The four conditions are unchanged from that round — see
+    `_tolerated_orphan_flip_paths`'s docstring for why each exists and which
+    forgery direction it closes. Arguments are plain cells/flags so a caller
+    holding only rendered markdown can ask the same question as a caller
+    holding parsed `DocRow`s.
+
+    DECLARED LIMITS (true of this predicate at both call sites, recorded rather
+    than silently inherited):
+
+      * `eligible_on <= claimed` ALLOWS a flip dated exactly on the eligibility
+        date, while `classify()` only flips when `as_of > eligible_on`
+        (strict, deliberately — see its comment). So a claim one day early is
+        tolerated. Tightening it is a semantic change to the 2026-07-25 round
+        and is tracked separately; it is NOT silently altered here.
+      * Whitelisting is not consulted. `classify()`'s structural eligibility is
+        `refs_in == 0 AND not whitelisted`; only the first half is checkable
+        from a rendered row. Measured on the live table 2026-07-29: zero
+        whitelisted docs have `refs_in == 0`, so the gap is latent, not open.
+    """
+    if trusted_ref_ceiling_date is None:
+        return False  # no trustworthy ceiling — fail closed
+    if trusted_ref_has_prior_flip:
+        return False  # trusted-ref already records a flip here (direction b)
+    if str(generated_refs_in).strip() != "0" or not str(generated_eligible_on).strip():
+        return False  # not structurally orphan-eligible
+    try:
+        eligible_on = date.fromisoformat(str(generated_eligible_on).strip())
+    except ValueError:
+        return False
+    claimed_raw = str(committed_flipped_on or "").strip()
+    if claimed_raw in ("", "—"):
+        return False  # nothing claimed — ordinary strict comparison applies
+    try:
+        claimed_date = date.fromisoformat(claimed_raw)
+    except ValueError:
+        return False  # unparseable claim — fail closed
+    if not (eligible_on <= claimed_date <= trusted_ref_ceiling_date):
+        return False  # premature or future-dated (direction a)
+    if str(committed_refs_in).strip() != "0":
+        return False  # committed side disagrees on the structural fact itself
+    return True
+
+
 def _parse_inventory_table(content: str) -> Dict[str, Dict[str, str]]:
     """Parse the '## Files' markdown table into {path: {header_name: cell_value}}.
 
@@ -821,7 +899,7 @@ def classify(
             # into the tracked inventory, and "94d" becomes "95d" tomorrow with
             # no documentation having changed. See render_inventory()'s header
             # comment for the churn this caused.
-            row.action = f"archive: orphan, last_touched={row.last_touched_date}, refs=0"
+            row.action = archive_orphan_action(row.last_touched_date)
             return row
     # else: not (yet) archived via the orphan rule. Any `orphan_flipped_on`
     # from an earlier run is correctly NOT carried here (row keeps the
@@ -1239,29 +1317,20 @@ def _tolerated_orphan_flip_paths(
     if trusted_ref_ceiling_date is None:
         return tolerated
     for r in rows:
-        if r.path in prev_flipped:
-            continue  # trusted-ref already has this path — never tolerate (direction b)
-        if r.refs_in != 0 or not r.orphan_eligible_on:
-            continue  # not structurally orphan-eligible (refinement 2)
-        try:
-            eligible_on = date.fromisoformat(r.orphan_eligible_on)
-        except ValueError:
-            continue
         claim = committed_claims.get(r.path)
         if claim is None:
             continue  # no row on the committed side — never tolerate (refinement 3)
-        claimed_raw = claim.get("orphan_flipped_on", "")
-        if claimed_raw in ("", "—"):
-            continue  # nothing claimed — ordinary strict comparison applies
-        try:
-            claimed_date = date.fromisoformat(claimed_raw)
-        except ValueError:
-            continue  # unparseable claim — not tolerated, fail closed
-        if not (eligible_on <= claimed_date <= trusted_ref_ceiling_date):
-            continue  # premature or future-dated (refinement 1)
-        if claim.get("refs_in") != "0":
-            continue  # committed side disagrees on the structural fact itself
-        tolerated.add(r.path)
+        # The four refinements themselves now live in one place, shared with
+        # the `inventory-check` blame path — see orphan_flip_claim_is_legitimate.
+        if orphan_flip_claim_is_legitimate(
+            trusted_ref_has_prior_flip=r.path in prev_flipped,
+            generated_refs_in=r.refs_in,
+            generated_eligible_on=r.orphan_eligible_on or "",
+            committed_flipped_on=claim.get("orphan_flipped_on", ""),
+            committed_refs_in=claim.get("refs_in", ""),
+            trusted_ref_ceiling_date=trusted_ref_ceiling_date,
+        ):
+            tolerated.add(r.path)
     return tolerated
 
 

--- a/scripts/docs_audit.py
+++ b/scripts/docs_audit.py
@@ -560,7 +560,15 @@ def orphan_flip_claim_is_legitimate(
     `_tolerated_orphan_flip_paths`'s docstring for why each exists and which
     forgery direction it closes. Arguments are plain cells/flags so a caller
     holding only rendered markdown can ask the same question as a caller
-    holding parsed `DocRow`s.
+    holding parsed `DocRow`s. Behaviour is preserved AT THE `--check` CALL SITE,
+    which is what was verified (55/55): the helper's own contract is
+    deliberately broader, because it stringifies and strips every value so a
+    caller holding rendered cells can use it. Old code rejected a STRING
+    `generated_refs_in="0"` and an INT `committed_refs_in=0`; this accepts both.
+    Neither is reachable from `--check`, which passes an int and a stripped
+    string respectively — but "behaviour-preserving" is a claim about the call
+    site, not about the function, and the difference is written down rather than
+    left for the next reader to discover.
 
     DECLARED LIMITS (true of this predicate at both call sites, recorded rather
     than silently inherited):
@@ -574,6 +582,18 @@ def orphan_flip_claim_is_legitimate(
         `refs_in == 0 AND not whitelisted`; only the first half is checkable
         from a rendered row. Measured on the live table 2026-07-29: zero
         whitelisted docs have `refs_in == 0`, so the gap is latent, not open.
+      * THE LOWER BOUND IS TREE-DERIVED, AND THE TREE IS THE PR'S. The 2026-07-25
+        round hardened the UPPER bound against `GIT_COMMITTER_DATE` forgery, and
+        left the floor where it was: `orphan_eligible_on` is
+        `last_touched + orphan_days`, and `last_touched` comes from
+        `git log --format=%ct` on the branch under test. So an author who
+        backdates the commit that adds an unreferenced doc can make it eligible
+        immediately and claim a flip today; the claim is then genuinely below
+        the trusted ceiling and every other cell agrees, so it is tolerated.
+        Reachable from BOTH call sites, and pre-dating the extraction — closing
+        it means giving eligibility a trusted source, which changes `classify()`
+        itself. Recorded here, not fixed under a different mandate. Blast radius
+        is bounded by `refs_in == 0`: the doc must be one nothing links to.
     """
     if trusted_ref_ceiling_date is None:
         return False  # no trustworthy ceiling — fail closed

--- a/scripts/docs_inventory_blame.py
+++ b/scripts/docs_inventory_blame.py
@@ -91,14 +91,80 @@ def row_map(content: str) -> dict[str, str]:
     return out
 
 
+# Column order of the inventory table, from its header row:
+#   File | Status | last_touched_date | orphan_eligible_on | orphan_flipped_on |
+#   refs_in | broken | drift | cluster | action
+_COL_STATUS = 1
+_COL_ELIGIBLE_ON = 3
+_COL_FLIPPED_ON = 4
+_COL_ACTION = 9
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _cells(row: str) -> list[str]:
+    """The row's cells, without the leading/trailing pipe."""
+    return [c.strip() for c in row.strip().strip("|").split("|")]
+
+
+def _is_earned_flip(committed_row: str, generated_row: str) -> bool:
+    """True when the only difference is an orphan flip the row itself justifies.
+
+    THE DEFECT THIS EXISTS FOR (measured 2026-07-29). P3-prime deliberately moved
+    the wall-clock decision "has this doc's orphan_eligible_on passed?" INTO the
+    scheduled refresh organ: `docs_inventory_regen.sh --organ` advances flips,
+    and the bare/default invocation the GATE uses is `--gate-consistent`, which
+    never invents one. But the comparison below was on the whole row, so the
+    three cells a flip moves — Status, orphan_flipped_on, action — read as drift.
+    Every flip the organ exists to advance was charged to the organ's own PR.
+
+    Not theoretical. Of the six refresh PRs the organ has opened, the two that
+    merged (#3411, #3425) carried ZERO flips; every one that carried a flip died
+    (#3405 with 65, #3456 and #3463 with 9). The organ could only ever deliver
+    the half of its job that did not matter.
+
+    The test is the ENTITY, not the author: a flip is legitimate because the
+    row's own deterministic facts justify it, never because a bot wrote it. So:
+    forward flip only (LIVE -> ARCHIVED), every other cell identical, and the
+    flip date not EARLIER than the eligibility date.
+
+    It stays clock-free on purpose — the two dates being compared are both cells
+    of the row, so no "today" enters the gate (`docs_audit.py`'s eligibility
+    facts are pure functions of git history, and
+    test_docs_inventory_render_is_clock_free.py pins that property). And the
+    justification cannot be forged: `orphan_eligible_on` is itself compared
+    verbatim against the generated row, so a PR that back-dates it to license a
+    flip changes a cell outside the exempt three and is charged in full.
+    """
+    a, b = _cells(committed_row), _cells(generated_row)
+    if len(a) != len(b) or len(a) <= _COL_ACTION:
+        return False
+    exempt = {_COL_STATUS, _COL_FLIPPED_ON, _COL_ACTION}
+    if any(a[i] != b[i] for i in range(len(a)) if i not in exempt):
+        return False
+    if a[_COL_STATUS] != "ARCHIVED" or b[_COL_STATUS] != "LIVE":
+        return False
+    flipped, eligible = a[_COL_FLIPPED_ON], a[_COL_ELIGIBLE_ON]
+    if not _DATE_RE.match(flipped) or not _DATE_RE.match(eligible):
+        return False
+    # ISO dates compare correctly as strings; no parsing, no timezone, no clock.
+    return flipped >= eligible
+
+
 def drifting_keys(committed: str, generated: str) -> set[str]:
     """Keys whose row differs between the committed and generated tables.
 
     Includes rows added or removed, not only rows whose cells changed — a doc
     that appears in one table and not the other is drift of the loudest kind.
+
+    An EARNED orphan flip is not drift — see `_is_earned_flip`. Every other
+    difference, including an unearned or backwards flip, still counts.
     """
     a, b = row_map(committed), row_map(generated)
-    changed = {k for k in a.keys() & b.keys() if a[k] != b[k]}
+    changed = {
+        k
+        for k in a.keys() & b.keys()
+        if a[k] != b[k] and not _is_earned_flip(a[k], b[k])
+    }
     return changed | (a.keys() ^ b.keys())
 
 

--- a/scripts/docs_inventory_blame.py
+++ b/scripts/docs_inventory_blame.py
@@ -54,7 +54,21 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# The orphan-flip rule is NOT re-derived here — it is imported. See
+# `orphan_flip_claim_is_legitimate`'s docstring for what happened the one time
+# this file wrote its own copy.
+from docs_audit import (  # noqa: E402
+    _parse_inventory_table,
+    _trusted_ref_tip_date,
+    archive_orphan_action,
+    orphan_flip_claim_is_legitimate,
+    parse_prev_flipped,
+)
 
 # A table row: `| docs/FOO.md | LIVE | 12 | 2026-07-01 | ... |`
 # The key is the first cell. Rows whose first cell is a header/among the status
@@ -91,22 +105,46 @@ def row_map(content: str) -> dict[str, str]:
     return out
 
 
-# Column order of the inventory table, from its header row:
-#   File | Status | last_touched_date | orphan_eligible_on | orphan_flipped_on |
-#   refs_in | broken | drift | cluster | action
-_COL_STATUS = 1
-_COL_ELIGIBLE_ON = 3
-_COL_FLIPPED_ON = 4
-_COL_ACTION = 9
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+# The three cells an orphan flip legitimately moves, BY HEADER NAME — never by
+# positional index. `_parse_inventory_table` matches on the header row, so a
+# future column reorder cannot silently make this exempt the wrong cell.
+_FLIP_MOVES = frozenset({"Status", "orphan_flipped_on", "action"})
+
+# What the generated (pre-flip) side of a legitimate flip must say. Measured on
+# the live table 2026-07-29: all 118 flip-eligible rows (LIVE, refs_in == 0)
+# carry exactly this pair. Pinning `action` here is what closes the whitelist
+# gap the shared predicate cannot see: a whitelisted doc renders
+# `action = "whitelist"` (docs_audit.classify), never the em-dash.
+_UNFLIPPED = ("", "—")
 
 
-def _cells(row: str) -> list[str]:
-    """The row's cells, without the leading/trailing pipe."""
-    return [c.strip() for c in row.strip().strip("|").split("|")]
+def _duplicate_keys(content: str) -> set[str]:
+    """Paths that appear on more than one row of the same table.
+
+    `row_map` is a dict, so a duplicated path silently keeps the LAST row and
+    the earlier one vanishes — a PR could hide a corrupt row behind a clean
+    one and the comparison would never see it. A duplicate is not something to
+    resolve; it is drift by itself.
+    """
+    seen: dict[str, int] = {}
+    for line in content.splitlines():
+        m = _ROW_RE.match(line)
+        if not m:
+            continue
+        key = m.group("key").strip().strip("`[]")
+        key = re.sub(r"^\[(.*?)\]\(.*\)$", r"\1", key).strip("`")
+        if _is_doc_key(key):
+            seen[key] = seen.get(key, 0) + 1
+    return {k for k, n in seen.items() if n > 1}
 
 
-def _is_earned_flip(committed_row: str, generated_row: str) -> bool:
+def _is_earned_flip(
+    committed_cells: dict[str, str],
+    generated_cells: dict[str, str],
+    *,
+    prior_flips: dict[str, str],
+    ceiling,
+) -> bool:
     """True when the only difference is an orphan flip the row itself justifies.
 
     THE DEFECT THIS EXISTS FOR (measured 2026-07-29). P3-prime deliberately moved
@@ -122,50 +160,102 @@ def _is_earned_flip(committed_row: str, generated_row: str) -> bool:
     (#3405 with 65, #3456 and #3463 with 9). The organ could only ever deliver
     the half of its job that did not matter.
 
-    The test is the ENTITY, not the author: a flip is legitimate because the
-    row's own deterministic facts justify it, never because a bot wrote it. So:
-    forward flip only (LIVE -> ARCHIVED), every other cell identical, and the
-    flip date not EARLIER than the eligibility date.
+    WHY THE LEGITIMACY TEST IS IMPORTED, NOT WRITTEN HERE. The first version of
+    this function (same day, before a cross-family red-team) decided legitimacy
+    on its own: it ignored `refs_in`, so ANY live doc — including a whitelisted
+    one with four inbound references — could be hand-marked ARCHIVED and walk
+    through; and it bounded the flip date only from BELOW, so `2099-12-31`
+    passed. Both holes were already closed, and argued at length, in
+    `docs_audit.orphan_flip_claim_is_legitimate` — hardened by the 2026-07-25
+    round against a live `GIT_COMMITTER_DATE` forgery. Writing a second, weaker
+    copy of a guard does not double the protection: it publishes the weaker one
+    as the way in.
 
-    It stays clock-free on purpose — the two dates being compared are both cells
-    of the row, so no "today" enters the gate (`docs_audit.py`'s eligibility
-    facts are pure functions of git history, and
-    test_docs_inventory_render_is_clock_free.py pins that property). And the
-    justification cannot be forged: `orphan_eligible_on` is itself compared
-    verbatim against the generated row, so a PR that back-dates it to license a
-    flip changes a cell outside the exempt three and is charged in full.
+    What this function still owns is what only a RENDERED pair can check, and
+    it is deliberately the strict half:
+
+      * every non-flip cell identical, matched BY HEADER NAME;
+      * the generated side genuinely un-flipped (`orphan_flipped_on` and
+        `action` both em-dash) — which is also what excludes a whitelisted doc,
+        since whitelisting renders `action = "whitelist"`;
+      * the committed `action` equal to `archive_orphan_action(last_touched)`,
+        i.e. a pure function of a cell that is itself compared verbatim — so
+        the exemption cannot be used to smuggle arbitrary text into a row.
+
+    Not clock-free, and the earlier claim that it was is withdrawn: the ceiling
+    that blocks future-dating is `max(origin/main tip, now)`, exactly as
+    `docs_audit --check` computes it. The core decision stays clock-free (both
+    dates are cells); the ceiling is a sanity bound that can only ever turn a
+    REJECTED claim into a tolerated one as real time passes, never the reverse.
     """
-    a, b = _cells(committed_row), _cells(generated_row)
-    if len(a) != len(b) or len(a) <= _COL_ACTION:
+    if not committed_cells or not generated_cells:
         return False
-    exempt = {_COL_STATUS, _COL_FLIPPED_ON, _COL_ACTION}
-    if any(a[i] != b[i] for i in range(len(a)) if i not in exempt):
+    if committed_cells.keys() != generated_cells.keys():
         return False
-    if a[_COL_STATUS] != "ARCHIVED" or b[_COL_STATUS] != "LIVE":
+    if any(
+        committed_cells[h] != generated_cells[h]
+        for h in committed_cells
+        if h not in _FLIP_MOVES
+    ):
         return False
-    flipped, eligible = a[_COL_FLIPPED_ON], a[_COL_ELIGIBLE_ON]
-    if not _DATE_RE.match(flipped) or not _DATE_RE.match(eligible):
+    if committed_cells.get("Status") != "ARCHIVED":
         return False
-    # ISO dates compare correctly as strings; no parsing, no timezone, no clock.
-    return flipped >= eligible
+    if generated_cells.get("Status") != "LIVE":
+        return False
+    if generated_cells.get("orphan_flipped_on", "").strip() not in _UNFLIPPED:
+        return False
+    if generated_cells.get("action", "").strip() not in _UNFLIPPED:
+        return False
+    if committed_cells.get("action") != archive_orphan_action(
+        committed_cells.get("last_touched_date", "")
+    ):
+        return False
+    return orphan_flip_claim_is_legitimate(
+        trusted_ref_has_prior_flip=committed_cells.get("File", "") in prior_flips,
+        generated_refs_in=generated_cells.get("refs_in", ""),
+        generated_eligible_on=generated_cells.get("orphan_eligible_on", ""),
+        committed_flipped_on=committed_cells.get("orphan_flipped_on", ""),
+        committed_refs_in=committed_cells.get("refs_in", ""),
+        trusted_ref_ceiling_date=ceiling,
+    )
 
 
-def drifting_keys(committed: str, generated: str) -> set[str]:
+def drifting_keys(
+    committed: str,
+    generated: str,
+    *,
+    prior_flips: dict[str, str] | None = None,
+    ceiling=None,
+) -> set[str]:
     """Keys whose row differs between the committed and generated tables.
 
     Includes rows added or removed, not only rows whose cells changed — a doc
-    that appears in one table and not the other is drift of the loudest kind.
+    that appears in one table and not the other is drift of the loudest kind —
+    and any path duplicated within one table, which a dict comparison would
+    otherwise swallow.
 
     An EARNED orphan flip is not drift — see `_is_earned_flip`. Every other
-    difference, including an unearned or backwards flip, still counts.
+    difference, including an unearned, forged or backwards flip, still counts.
+    With no `ceiling` the exemption cannot fire at all: the shared predicate
+    fails closed, which is the right default for any caller that has not
+    established a trustworthy upper bound on a claimed date.
     """
     a, b = row_map(committed), row_map(generated)
+    ca, cb = _parse_inventory_table(committed), _parse_inventory_table(generated)
+    prior_flips = prior_flips or {}
+    dupes = _duplicate_keys(committed) | _duplicate_keys(generated)
     changed = {
         k
         for k in a.keys() & b.keys()
-        if a[k] != b[k] and not _is_earned_flip(a[k], b[k])
+        if a[k] != b[k]
+        and (
+            k in dupes
+            or not _is_earned_flip(
+                ca.get(k, {}), cb.get(k, {}), prior_flips=prior_flips, ceiling=ceiling
+            )
+        )
     }
-    return changed | (a.keys() ^ b.keys())
+    return changed | (a.keys() ^ b.keys()) | (dupes & (a.keys() | b.keys()))
 
 
 def _read(p: Path) -> str:
@@ -187,10 +277,50 @@ def main(argv: list[str] | None = None) -> int:
         default=40,
         help="cap on keys PRINTED per bucket; counts are always reported in full",
     )
+    ap.add_argument("--repo", type=Path, default=Path("."))
+    ap.add_argument("--trusted-ref", default="origin/main")
     args = ap.parse_args(argv)
 
-    base = drifting_keys(_read(args.committed_base), _read(args.generated_base))
-    head = drifting_keys(_read(args.committed_head), _read(args.generated_head))
+    committed_base = _read(args.committed_base)
+
+    # The upper bound on a claimed flip date, computed exactly as
+    # `docs_audit --check` computes it: the LATER of the trusted ref's own tip
+    # commit date and real "now", neither of which the PR branch controls.
+    # Never a commit date read from the PR's own branch — that is forgeable via
+    # GIT_COMMITTER_DATE, demonstrated live against the first version of the
+    # --check fix (2026-07-25).
+    tip = _trusted_ref_tip_date(args.repo.resolve(), args.trusted_ref)
+    now_date = datetime.now(tz=timezone.utc).date()
+    ceiling = max(tip, now_date) if tip else now_date
+    # Say which source was accepted. A guard that silently degrades to its
+    # fallback is a guard nobody can tell is degraded (W106).
+    print(
+        f"docs_inventory_blame: flip-date ceiling {ceiling.isoformat()} "
+        + (
+            f"(later of {args.trusted_ref} tip {tip.isoformat()} and now)"
+            if tip
+            else f"(now only — {args.trusted_ref} did not resolve)"
+        )
+    )
+
+    # Prior flip provenance comes from the BASE's committed table, which is the
+    # tip this PR is measured against — the same trust boundary
+    # `read_trusted_prev_flipped()` established. A path already flipped there
+    # can never be exempted again (anti-resurrection).
+    prior_flips = parse_prev_flipped(committed_base)
+
+    base = drifting_keys(
+        committed_base,
+        _read(args.generated_base),
+        prior_flips=prior_flips,
+        ceiling=ceiling,
+    )
+    head = drifting_keys(
+        _read(args.committed_head),
+        _read(args.generated_head),
+        prior_flips=prior_flips,
+        ceiling=ceiling,
+    )
 
     introduced = sorted(head - base)
     inherited = sorted(head & base)

--- a/scripts/docs_inventory_blame.py
+++ b/scripts/docs_inventory_blame.py
@@ -90,19 +90,67 @@ def _is_doc_key(key: str) -> bool:
     return key.endswith(".md")
 
 
-def row_map(content: str) -> dict[str, str]:
-    """Map doc path -> full row line, for every table row naming a document."""
-    out: dict[str, str] = {}
+_LINK_RE = re.compile(r"^\[(?P<text>.+?)\]\(.*\)$")
+
+
+def _row_key(cell: str) -> str:
+    """The document path a first cell names, undecorated.
+
+    ONE definition, called by every scanner below. It used to be inlined twice —
+    identically, which is exactly how the bug survived: `.strip("`[]")` ran
+    BEFORE the link regex, so it ate the leading `[` and `[docs/x.md](docs/x.md)`
+    became `docs/x.md](docs/x.md)`, which fails `_is_doc_key` and made the whole
+    row INVISIBLE to the comparison while `_parse_inventory_table` still saw it.
+    The link normalisation this file advertised had never once fired. Measured
+    2026-07-29, found by a cross-family refuter.
+    """
+    cell = cell.strip()
+    m = _LINK_RE.match(cell)
+    if m:
+        cell = m.group("text")
+    return cell.strip("`").strip()
+
+
+def _scan_rows(content: str) -> list[tuple[str, str]]:
+    """(path, raw line) for every table row naming a document, in file order."""
+    out: list[tuple[str, str]] = []
     for line in content.splitlines():
         m = _ROW_RE.match(line)
         if not m:
             continue
-        key = m.group("key").strip().strip("`[]")
-        # `[`docs/x.md`](docs/x.md)` style cells: take the link text.
-        key = re.sub(r"^\[(.*?)\]\(.*\)$", r"\1", key).strip("`")
+        key = _row_key(m.group("key"))
         if _is_doc_key(key):
-            out[key] = line.strip()
+            out.append((key, line.strip()))
     return out
+
+
+def row_map(content: str) -> dict[str, str]:
+    """Map doc path -> full row line, for every table row naming a document.
+
+    Last row wins on a duplicated path — deliberately NOT resolved here, because
+    a duplicate is not a thing to resolve. `_duplicate_keys` reports it and
+    `drifting_keys` charges it.
+    """
+    return dict(_scan_rows(content))
+
+
+def table_header(content: str) -> str:
+    """The inventory table's header line, or '' if there isn't one.
+
+    Compared between the two tables because everything else in this file reads
+    ROWS, and a PR that renames `| File |` to `| Files |` leaves every row
+    untouched: `_parse_inventory_table` then returns {} while `row_map` still
+    finds all the rows, no row differs, and the gate passes on a table whose
+    schema has been broken. Measured — the probe returned `set()`.
+
+    Anchored on the SAME prefix `_parse_inventory_table` looks for, deliberately.
+    Two functions that must agree on "where the table starts" cannot be allowed
+    two answers, or this one reports a header the other never read.
+    """
+    for line in content.splitlines():
+        if line.startswith("| File "):
+            return line.strip()
+    return ""
 
 
 # The three cells an orphan flip legitimately moves, BY HEADER NAME — never by
@@ -127,14 +175,8 @@ def _duplicate_keys(content: str) -> set[str]:
     resolve; it is drift by itself.
     """
     seen: dict[str, int] = {}
-    for line in content.splitlines():
-        m = _ROW_RE.match(line)
-        if not m:
-            continue
-        key = m.group("key").strip().strip("`[]")
-        key = re.sub(r"^\[(.*?)\]\(.*\)$", r"\1", key).strip("`")
-        if _is_doc_key(key):
-            seen[key] = seen.get(key, 0) + 1
+    for key, _line in _scan_rows(content):
+        seen[key] = seen.get(key, 0) + 1
     return {k for k, n in seen.items() if n > 1}
 
 
@@ -220,42 +262,74 @@ def _is_earned_flip(
     )
 
 
+# Not a document path, so it can never collide with one (`_is_doc_key` requires
+# a `.md` suffix). Names the table itself as the thing that drifted.
+TABLE_KEY = "<inventory table header>"
+
+
 def drifting_keys(
     committed: str,
     generated: str,
     *,
     prior_flips: dict[str, str] | None = None,
     ceiling=None,
-) -> set[str]:
-    """Keys whose row differs between the committed and generated tables.
+) -> dict[str, str]:
+    """Drifting key -> a SIGNATURE of how it drifts.
 
-    Includes rows added or removed, not only rows whose cells changed — a doc
-    that appears in one table and not the other is drift of the loudest kind —
-    and any path duplicated within one table, which a dict comparison would
-    otherwise swallow.
+    Returns a mapping, not a set, and that is the point. The gate passes when
+    head introduces no drift the base did not already have, and comparing only
+    the KEYS made "already drifting" a licence: a doc drifting LIVE->STALE on
+    the base could be worsened to LIVE->ARCHIVED, or have unrelated cells
+    corrupted, and the key stayed in both sets so `head - base` was empty and
+    the PR passed. The signature makes "the same drift" mean the same drift.
 
-    An EARNED orphan flip is not drift — see `_is_earned_flip`. Every other
-    difference, including an unearned, forged or backwards flip, still counts.
+    A key is drifting when any of these hold:
+
+      * its row differs between the two tables and the difference is not an
+        earned orphan flip (see `_is_earned_flip`);
+      * it appears in one table and not the other — drift of the loudest kind;
+      * it is duplicated within a table, which a dict comparison would swallow;
+      * the two parsers in this file disagree about whether the row exists.
+        `row_map` scans raw lines while `_parse_inventory_table` matches the
+        header row and drops any line whose cell count is wrong, so a row that
+        only one of them sees is a row the exemption cannot be trusted about.
+
+    `TABLE_KEY` is reported when the header lines themselves differ. Everything
+    else here reads rows, and a renamed header leaves every row untouched.
+
     With no `ceiling` the exemption cannot fire at all: the shared predicate
-    fails closed, which is the right default for any caller that has not
-    established a trustworthy upper bound on a claimed date.
+    fails closed, which is the right default for a caller that has established
+    no trustworthy upper bound on a claimed date.
     """
     a, b = row_map(committed), row_map(generated)
     ca, cb = _parse_inventory_table(committed), _parse_inventory_table(generated)
     prior_flips = prior_flips or {}
     dupes = _duplicate_keys(committed) | _duplicate_keys(generated)
-    changed = {
-        k
-        for k in a.keys() & b.keys()
-        if a[k] != b[k]
-        and (
-            k in dupes
-            or not _is_earned_flip(
-                ca.get(k, {}), cb.get(k, {}), prior_flips=prior_flips, ceiling=ceiling
-            )
-        )
-    }
-    return changed | (a.keys() ^ b.keys()) | (dupes & (a.keys() | b.keys()))
+    # A path one parser sees and the other does not: the cells the exemption
+    # would reason about are missing or belong to a different row.
+    unreconciled = (a.keys() ^ ca.keys()) | (b.keys() ^ cb.keys())
+
+    out: dict[str, str] = {}
+    if table_header(committed) != table_header(generated):
+        out[TABLE_KEY] = f"header {table_header(committed)!r} != {table_header(generated)!r}"
+    for k in a.keys() | b.keys():
+        # ORDER MATTERS, and getting it wrong is how the first build of this
+        # loop hid the very drift it was meant to expose: the reconciliation
+        # marker was tested FIRST, so an unparseable row got a CONSTANT
+        # signature — identical at base and at head — and a genuine row
+        # difference underneath it read as "inherited". A marker must never
+        # replace a real difference; it only speaks when there is none.
+        if k in dupes:
+            out[k] = "duplicated row"
+        elif k not in a or k not in b:
+            out[k] = f"present only in {'committed' if k in a else 'generated'}"
+        elif a[k] != b[k] and not _is_earned_flip(
+            ca.get(k, {}), cb.get(k, {}), prior_flips=prior_flips, ceiling=ceiling
+        ):
+            out[k] = f"{a[k]} != {b[k]}"
+        elif k in unreconciled:
+            out[k] = "row visible to only one parser"
+    return out
 
 
 def _read(p: Path) -> str:
@@ -322,9 +396,12 @@ def main(argv: list[str] | None = None) -> int:
         ceiling=ceiling,
     )
 
-    introduced = sorted(head - base)
-    inherited = sorted(head & base)
-    repaired = sorted(base - head)
+    # Compared by SIGNATURE, not by key. A key drifting at both ends is only
+    # "inherited" when it drifts the SAME WAY; drift the PR changed on a
+    # already-broken row is drift the PR introduced.
+    introduced = sorted(k for k, sig in head.items() if base.get(k) != sig)
+    inherited = sorted(k for k, sig in head.items() if base.get(k) == sig)
+    repaired = sorted(k for k in base if k not in head)
 
     def show(label: str, keys: list[str]) -> None:
         # Never print a truncated list as if it were whole (W97): the count is

--- a/scripts/docs_inventory_blame.py
+++ b/scripts/docs_inventory_blame.py
@@ -153,6 +153,29 @@ def table_header(content: str) -> str:
     return ""
 
 
+def table_alignment(content: str) -> str:
+    """The row immediately under the header — the Markdown alignment row.
+
+    It exists in the comparison model for one reason: nothing else looks at it.
+    `_parse_inventory_table` skips it by INDEX (`header_idx + 2`, blindly), and
+    `_scan_rows` drops it because its first cell is not a `.md` path. So a PR
+    could replace `| --- | --- | … |` with any text at all, break the table's
+    rendering, and every parser here would report an identical inventory —
+    `docs_audit --check` goes red on the content diff, this tool answers "no
+    key drifted, not the PR's doing", and the PR is exonerated for damage it
+    just did. Round 3, cross-family refuter; the row carries no inventory fact,
+    which is exactly why it was the blind spot.
+
+    Empty string when there is no header at all — `table_header` already charges
+    that case, and two keys for one fault would only double-report it.
+    """
+    lines = content.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("| File "):
+            return lines[i + 1].strip() if i + 1 < len(lines) else "<missing>"
+    return ""
+
+
 # The three cells an orphan flip legitimately moves, BY HEADER NAME — never by
 # positional index. `_parse_inventory_table` matches on the header row, so a
 # future column reorder cannot silently make this exempt the wrong cell.
@@ -166,18 +189,25 @@ _FLIP_MOVES = frozenset({"Status", "orphan_flipped_on", "action"})
 _UNFLIPPED = ("", "—")
 
 
-def _duplicate_keys(content: str) -> set[str]:
-    """Paths that appear on more than one row of the same table.
+def _duplicate_rows(content: str) -> dict[str, tuple[str, ...]]:
+    """{path: every row line naming it}, for paths appearing more than once.
 
     `row_map` is a dict, so a duplicated path silently keeps the LAST row and
     the earlier one vanishes — a PR could hide a corrupt row behind a clean
     one and the comparison would never see it. A duplicate is not something to
     resolve; it is drift by itself.
+
+    Returns the LINES, not just the keys, and that is round 3's correction: the
+    caller used to stamp a duplicated path with the constant string
+    `"duplicated row"`, so a base that already had a duplicate could have one of
+    its two rows rewritten at head and the signature never moved — the change
+    read as pre-existing drift and was waved through. A signature that does not
+    change when the thing it signs changes is not a signature.
     """
-    seen: dict[str, int] = {}
-    for key, _line in _scan_rows(content):
-        seen[key] = seen.get(key, 0) + 1
-    return {k for k, n in seen.items() if n > 1}
+    seen: dict[str, list[str]] = {}
+    for key, line in _scan_rows(content):
+        seen.setdefault(key, []).append(line)
+    return {k: tuple(v) for k, v in seen.items() if len(v) > 1}
 
 
 def _is_earned_flip(
@@ -253,7 +283,18 @@ def _is_earned_flip(
     ):
         return False
     return orphan_flip_claim_is_legitimate(
-        trusted_ref_has_prior_flip=committed_cells.get("File", "") in prior_flips,
+        # `_row_key`, not the raw cell — round 3, and it is this PR's own lesson
+        # arriving one level down. `prior_flips` is keyed by the RAW `File` cell
+        # (`docs_audit.parse_prev_flipped`), while every identity in this module
+        # is the undecorated path. A base row written `` `docs/x.md` `` and a
+        # head row written `docs/x.md` are ONE document to the drift comparison
+        # and TWO to this lookup, so the anti-resurrection check reads "never
+        # flipped before" and re-exempts a flip the base already spent. Both
+        # sides are normalised here rather than in `parse_prev_flipped`, whose
+        # other caller (`docs_audit.classify`) matches raw cells against raw
+        # cells and is correct as it stands.
+        trusted_ref_has_prior_flip=_row_key(committed_cells.get("File", ""))
+        in {_row_key(p) for p in prior_flips},
         generated_refs_in=generated_cells.get("refs_in", ""),
         generated_eligible_on=generated_cells.get("orphan_eligible_on", ""),
         committed_flipped_on=committed_cells.get("orphan_flipped_on", ""),
@@ -265,6 +306,7 @@ def _is_earned_flip(
 # Not a document path, so it can never collide with one (`_is_doc_key` requires
 # a `.md` suffix). Names the table itself as the thing that drifted.
 TABLE_KEY = "<inventory table header>"
+ALIGN_KEY = "<inventory table alignment row>"
 
 
 def drifting_keys(
@@ -304,7 +346,7 @@ def drifting_keys(
     a, b = row_map(committed), row_map(generated)
     ca, cb = _parse_inventory_table(committed), _parse_inventory_table(generated)
     prior_flips = prior_flips or {}
-    dupes = _duplicate_keys(committed) | _duplicate_keys(generated)
+    dupes_c, dupes_g = _duplicate_rows(committed), _duplicate_rows(generated)
     # A path one parser sees and the other does not: the cells the exemption
     # would reason about are missing or belong to a different row.
     unreconciled = (a.keys() ^ ca.keys()) | (b.keys() ^ cb.keys())
@@ -312,6 +354,10 @@ def drifting_keys(
     out: dict[str, str] = {}
     if table_header(committed) != table_header(generated):
         out[TABLE_KEY] = f"header {table_header(committed)!r} != {table_header(generated)!r}"
+    if table_alignment(committed) != table_alignment(generated):
+        out[ALIGN_KEY] = (
+            f"alignment {table_alignment(committed)!r} != {table_alignment(generated)!r}"
+        )
     for k in a.keys() | b.keys():
         # ORDER MATTERS, and getting it wrong is how the first build of this
         # loop hid the very drift it was meant to expose: the reconciliation
@@ -319,10 +365,18 @@ def drifting_keys(
         # signature — identical at base and at head — and a genuine row
         # difference underneath it read as "inherited". A marker must never
         # replace a real difference; it only speaks when there is none.
-        if k in dupes:
-            out[k] = "duplicated row"
+        # Round 3: the first two arms used to stamp a CONSTANT string, so a base
+        # that already carried that category of drift could have its rows
+        # rewritten at head under an unchanged signature and read as inherited.
+        # Every signature now carries the rows it signs.
+        if k in dupes_c or k in dupes_g:
+            out[k] = (
+                f"duplicated row: committed={list(dupes_c.get(k, ()))} "
+                f"generated={list(dupes_g.get(k, ()))}"
+            )
         elif k not in a or k not in b:
-            out[k] = f"present only in {'committed' if k in a else 'generated'}"
+            side, row = ("committed", a[k]) if k in a else ("generated", b[k])
+            out[k] = f"present only in {side}: {row!r}"
         elif a[k] != b[k] and not _is_earned_flip(
             ca.get(k, {}), cb.get(k, {}), prior_flips=prior_flips, ceiling=ceiling
         ):

--- a/scripts/tests/test_docs_inventory_blame.py
+++ b/scripts/tests/test_docs_inventory_blame.py
@@ -25,10 +25,19 @@ SCRIPT = REPO_ROOT / "scripts" / "docs_inventory_blame.py"
 
 sys.path.insert(0, str(SCRIPT.parent))
 import docs_inventory_blame as blame  # noqa: E402
+from docs_audit import _parse_inventory_table as _parse_table  # noqa: E402
 
 
 def _table(rows: dict[str, str], *, orphans: int = 10) -> str:
-    """Build an inventory-shaped table: summary block + one row per doc."""
+    """Build an inventory-shaped table: summary block + one row per doc.
+
+    The header must have as many columns as the rows do. Its first build
+    declared two (`| Doc | Status |`) while every row carried four, so
+    `_parse_inventory_table` — which matches by header and drops any row whose
+    cell count disagrees — silently returned NOTHING for these fixtures. That is
+    a table no generator can emit, and it made five tests measure a parser
+    failure instead of the drift they were written for.
+    """
     body = "\n".join(f"| {p} | {cells} |" for p, cells in rows.items())
     return (
         "# Docs Inventory\n\n"
@@ -38,7 +47,8 @@ def _table(rows: dict[str, str], *, orphans: int = 10) -> str:
         "| STALE    |     6 | 1% |\n"
         "| ARCHIVED |   307 | 33% |\n\n"
         f"**Drift:** 0 · **Broken links:** 2 · **Orphans:** {orphans}\n\n"
-        "| Doc | Status |\n| --- | --- |\n" + body + "\n"
+        "| File | Status | refs_in | last_touched_date |\n"
+        "| --- | --- | --- | --- |\n" + body + "\n"
     )
 
 
@@ -188,8 +198,8 @@ def test_added_and_removed_rows_both_count_as_drift(tmp_path):
     both drift. Testing one direction would leave deletions invisible."""
     a = _table(BASE_ROWS)
     b = _table({k: v for k, v in BASE_ROWS.items() if k != "docs/C.md"})
-    assert blame.drifting_keys(a, b) == {"docs/C.md"}
-    assert blame.drifting_keys(b, a) == {"docs/C.md"}
+    assert set(blame.drifting_keys(a, b)) == {"docs/C.md"}
+    assert set(blame.drifting_keys(b, a)) == {"docs/C.md"}
 
 
 # ---------------------------------------------------------------------------
@@ -224,13 +234,14 @@ def _full_table(rows: dict[str, str]) -> str:
     """
     live = sum(1 for c in rows.values() if c.startswith("LIVE"))
     archived = sum(1 for c in rows.values() if c.startswith("ARCHIVED"))
+    total = max(len(rows), 1)
     body = "\n".join(f"| {p} | {cells} |" for p, cells in rows.items())
     return (
         "# Documentation Inventory\n\n"
         "| Status   | Count | % |\n"
         "| -------- | ----: | -: |\n"
-        f"| LIVE     |   {live} | 66% |\n"
-        f"| ARCHIVED |   {archived} | 33% |\n\n"
+        f"| LIVE     |   {live} | {round(100 * live / total)}% |\n"
+        f"| ARCHIVED |   {archived} | {round(100 * archived / total)}% |\n\n"
         "| File | Status | last_touched_date | orphan_eligible_on | "
         "orphan_flipped_on | refs_in | broken | drift | cluster | action |\n"
         "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
@@ -241,7 +252,7 @@ def _full_table(rows: dict[str, str]) -> str:
 
 def _drift(committed: str, generated: str, **kw) -> set[str]:
     kw.setdefault("ceiling", CEILING)
-    return blame.drifting_keys(committed, generated, **kw)
+    return set(blame.drifting_keys(committed, generated, **kw))
 
 
 def test_innocence_an_earned_orphan_flip_is_not_drift() -> None:
@@ -453,7 +464,95 @@ def test_without_a_trustworthy_ceiling_nothing_is_ever_exempt() -> None:
     """
     committed = _full_table({"docs/audits/x.md": _ARCHIVED})
     generated = _full_table({"docs/audits/x.md": _LIVE})
-    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+    assert set(blame.drifting_keys(committed, generated)) == {"docs/audits/x.md"}
+
+
+# --- round 2: what the FIRST cure still let through -------------------------
+
+
+def test_guilt_renaming_the_table_header_is_drift() -> None:
+    """Every other check in this file reads ROWS, so a broken schema was free.
+
+    `| File |` -> `| Files |` leaves every document row byte-identical.
+    `_parse_inventory_table` then returns {} — it matches on the header — while
+    `row_map` still finds all the rows, so nothing differed and the gate passed
+    on a table whose schema had been broken. Measured: the probe returned
+    `set()`.
+    """
+    good = _full_table({"docs/a.md": _LIVE})
+    bad = good.replace("| File |", "| Files |", 1)
+    assert bad != good, "the fixture edit did not apply"
+    assert blame.TABLE_KEY in _drift(bad, good)
+
+
+def test_guilt_a_markdown_linked_row_cannot_hide_a_duplicate() -> None:
+    """The link normalisation this file advertised had never once fired.
+
+    `.strip("`[]")` ran BEFORE the link regex, eating the leading `[`, so
+    `[docs/x.md](docs/x.md)` became `docs/x.md](docs/x.md)` — rejected for not
+    ending in `.md`, and therefore INVISIBLE to both `row_map` and
+    `_duplicate_keys` while `_parse_inventory_table` still saw it. A corrupt row
+    wearing link syntax could sit beside a clean exemptable one and neither
+    scanner would count a duplicate.
+    """
+    assert blame._row_key("[docs/x.md](docs/x.md)") == "docs/x.md"
+    header, _, rows = _full_table({"docs/x.md": _ARCHIVED}).rpartition("| --- |\n")
+    linked = "| [docs/x.md](docs/x.md) | ARCHIVED | 1999-01-01 | — | — | 9 | 9 | yes | — | ? |\n"
+    committed = header + "| --- |\n" + linked + rows
+    generated = _full_table({"docs/x.md": _LIVE})
+    assert _drift(committed, generated) == {"docs/x.md"}
+
+
+def test_guilt_a_row_only_one_parser_can_read_is_drift_even_when_identical() -> None:
+    """The two parsers in this file must agree about which rows exist.
+
+    `row_map` scans raw lines; `_parse_inventory_table` matches the header and
+    DROPS any row whose cell count disagrees with it. A row only one of them
+    sees is a row the exemption cannot be trusted about — and if it is identical
+    on both sides, the ordinary difference test says nothing at all, so without
+    the reconciliation check it passes in silence.
+    """
+    short = "| docs/broken.md | LIVE | 2026-04-29 |"
+    header, _, rows = _full_table({"docs/a.md": _LIVE}).rpartition("| --- |\n")
+    both = header + "| --- |\n" + short + "\n" + rows
+    assert blame.row_map(both).keys() == {"docs/broken.md", "docs/a.md"}
+    assert "docs/broken.md" not in _parse_table(both), "fixture no longer malformed"
+    assert _drift(both, both) == {"docs/broken.md"}
+
+
+def test_an_unreadable_row_reports_its_difference_not_just_its_unreadability() -> None:
+    """A marker must never REPLACE a real difference — order of the checks.
+
+    The first build tested "only one parser can read this" FIRST, so an
+    unparseable row got a CONSTANT signature. Identical at base and at head, it
+    made a genuine row difference underneath read as inherited drift, and the
+    gate passed on it. The signature must carry the rows themselves.
+    """
+    header, _, rows = _full_table({"docs/a.md": _LIVE}).rpartition("| --- |\n")
+    a = header + "| --- |\n" + "| docs/broken.md | LIVE | 2026-04-29 |\n" + rows
+    b = header + "| --- |\n" + "| docs/broken.md | STALE | 1999-01-01 |\n" + rows
+    sig = blame.drifting_keys(a, b, ceiling=CEILING)["docs/broken.md"]
+    assert "only one parser" not in sig, f"the marker masked the difference: {sig!r}"
+    assert "LIVE" in sig and "STALE" in sig
+
+
+def test_guilt_worsening_an_already_drifting_row_is_not_inherited(tmp_path) -> None:
+    """"Already drifting" was a licence, because only KEYS were compared.
+
+    `introduced = head - base` over sets of paths: a row drifting on the base
+    could be worsened at head — different status, corrupted cells, anything —
+    and the key stayed in both sets, so the difference vanished and the PR
+    passed. Drift is now compared by SIGNATURE, so the same key drifting a
+    DIFFERENT way is drift this PR introduced.
+    """
+    committed = _table(BASE_ROWS)
+    generated_base = _table({**BASE_ROWS, "docs/A.md": "STALE | 91 | 2026-07-01"})
+    # same key, worse drift: STALE -> ARCHIVED with a different date
+    generated_head = _table({**BASE_ROWS, "docs/A.md": "ARCHIVED | 91 | 1999-01-01"})
+    r = _run(tmp_path, committed, generated_base, committed, generated_head)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "docs/A.md" in r.stdout
+    assert "makes STALE" in r.stdout
 
 
 def test_scar_pin_the_eight_rows_of_pr_3463() -> None:

--- a/scripts/tests/test_docs_inventory_blame.py
+++ b/scripts/tests/test_docs_inventory_blame.py
@@ -576,3 +576,88 @@ def test_scar_pin_the_eight_rows_of_pr_3463() -> None:
     generated = _full_table({p: _LIVE for p in paths})
     assert len(blame.row_map(committed)) == 8, "the fixture itself stopped parsing"
     assert _drift(committed, generated) == set()
+
+
+# ---------------------------------------------------------------------------
+# Round 3 (cross-family refuter, 2026-07-30). Three ways a REAL change could
+# leave the signature it is compared by unmoved — and one of them is this PR's
+# own lesson (one identity, two spellings) arriving a level down.
+# ---------------------------------------------------------------------------
+
+
+def test_guilt_rewriting_the_alignment_row_is_drift() -> None:
+    """Nothing else in this module looks at the Markdown alignment row.
+
+    `_parse_inventory_table` skips it by index and `_scan_rows` drops it (its
+    first cell is not a `.md` path), so a PR could replace it with anything,
+    break the table's rendering, and every parser here would report an
+    identical inventory: `--check` red, blame "no key drifted", PR exonerated.
+    """
+    good = _full_table({"docs/audits/x.md": _LIVE})
+    bad = good.replace(
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        "| whatever goes here | x | x | x | x | x | x | x | x | x |",
+        1,
+    )
+    assert bad != good, "the fixture no longer contains the alignment row"
+    assert blame.ALIGN_KEY in _drift(bad, good)
+    assert blame.ALIGN_KEY in _drift(good, bad)
+
+
+def test_innocence_an_intact_alignment_row_is_not_drift() -> None:
+    """The new key must fire on a rewrite, never on a table that is fine."""
+    t = _full_table({"docs/audits/x.md": _LIVE})
+    assert blame.ALIGN_KEY not in _drift(t, t)
+    assert blame.ALIGN_KEY not in _drift(_table(BASE_ROWS), _table(BASE_ROWS))
+
+
+def test_guilt_a_duplicate_row_signature_moves_when_the_duplicate_changes() -> None:
+    """A category label is not a signature.
+
+    `"duplicated row"` was a CONSTANT: a base that already carried a duplicate
+    could have one of its two rows rewritten at head and `main()` — which calls
+    a key inherited when `base[k] == head[k]` — read the rewrite as
+    pre-existing. The signature now carries the rows it signs.
+    """
+    dup = "# Docs Inventory\n\n"
+    header = (
+        "| File | Status | refs_in | last_touched_date |\n| --- | --- | --- | --- |\n"
+    )
+    before = dup + header + "| docs/A.md | LIVE | 3 | 2026-07-01 |\n| docs/A.md | LIVE | 3 | 2026-07-02 |\n"
+    after = dup + header + "| docs/A.md | LIVE | 3 | 2026-07-01 |\n| docs/A.md | ARCHIVED | 0 | 2026-07-02 |\n"
+    clean = _table({"docs/A.md": "LIVE | 3 | 2026-07-01"})
+    sig_before = blame.drifting_keys(before, clean, ceiling=CEILING)["docs/A.md"]
+    sig_after = blame.drifting_keys(after, clean, ceiling=CEILING)["docs/A.md"]
+    assert sig_before != sig_after, "the duplicate changed and its signature did not"
+
+
+def test_guilt_a_one_sided_row_signature_moves_when_that_row_changes() -> None:
+    """Same defect, other arm: `"present only in generated"` was constant too."""
+    committed = _table({"docs/A.md": "LIVE | 3 | 2026-07-01"})
+    gen_v1 = _table(
+        {"docs/A.md": "LIVE | 3 | 2026-07-01", "docs/B.md": "LIVE | 9 | 2026-07-02"}
+    )
+    gen_v2 = _table(
+        {"docs/A.md": "LIVE | 3 | 2026-07-01", "docs/B.md": "STALE | 0 | 2026-01-01"}
+    )
+    s1 = blame.drifting_keys(committed, gen_v1, ceiling=CEILING)["docs/B.md"]
+    s2 = blame.drifting_keys(committed, gen_v2, ceiling=CEILING)["docs/B.md"]
+    assert s1 != s2, "the only-on-one-side row changed and its signature did not"
+
+
+def test_guilt_a_prior_flip_written_with_a_decorated_path_still_blocks_re_exemption() -> None:
+    """One document, two spellings — the lesson this PR was built on, one level down.
+
+    `prior_flips` is keyed by the RAW `File` cell (`docs_audit.parse_prev_flipped`)
+    while every identity in this module is the undecorated path. A base row
+    written `` `docs/x.md` `` and a head row written `docs/x.md` are ONE document
+    to the drift comparison and TWO to the anti-resurrection lookup, so a flip
+    the base had already spent could be stamped again and exempted.
+    """
+    committed = _full_table({"docs/audits/x.md": _ARCHIVED})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert _drift(committed, generated) == set(), "the innocence baseline moved"
+    charged = _drift(
+        committed, generated, prior_flips={"`docs/audits/x.md`": "2026-07-20"}
+    )
+    assert charged == {"docs/audits/x.md"}

--- a/scripts/tests/test_docs_inventory_blame.py
+++ b/scripts/tests/test_docs_inventory_blame.py
@@ -189,3 +189,122 @@ def test_added_and_removed_rows_both_count_as_drift(tmp_path):
     b = _table({k: v for k, v in BASE_ROWS.items() if k != "docs/C.md"})
     assert blame.drifting_keys(a, b) == {"docs/C.md"}
     assert blame.drifting_keys(b, a) == {"docs/C.md"}
+
+
+# ---------------------------------------------------------------------------
+# The earned-flip exemption (2026-07-29).
+#
+# Rows here carry the REAL column layout of docs/DOCS_INVENTORY.md, because the
+# exemption is positional:
+#   File | Status | last_touched_date | orphan_eligible_on | orphan_flipped_on |
+#   refs_in | broken | drift | cluster | action
+# ---------------------------------------------------------------------------
+
+_LIVE = "LIVE | 2026-04-29 | 2026-07-28 | — | 0 | 0 | no | — | —"
+_ARCHIVED = (
+    "ARCHIVED | 2026-04-29 | 2026-07-28 | 2026-07-29 | 0 | 0 | no | — | "
+    "archive: orphan, last_touched=2026-04-29, refs=0"
+)
+
+
+def _full_table(rows: dict[str, str]) -> str:
+    body = "\n".join(f"| {p} | {cells} |" for p, cells in rows.items())
+    return (
+        "# Documentation Inventory\n\n"
+        "| Status   | Count | % |\n"
+        "| -------- | ----: | -: |\n"
+        "| LIVE     |   620 | 66% |\n\n"
+        "| File | Status | last_touched_date | orphan_eligible_on | "
+        "orphan_flipped_on | refs_in | broken | drift | cluster | action |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
+        + body
+        + "\n"
+    )
+
+
+def test_innocence_an_earned_orphan_flip_is_not_drift() -> None:
+    """The exact shape of PR #3463, which this exemption exists for.
+
+    The organ regenerates with `--organ` (advances flips); the gate regenerates
+    gate-consistent (never invents one). Comparing whole rows charged the organ
+    for the one decision P3-prime deliberately moved into it — measured across
+    all six refresh PRs: the two that merged carried zero flips, every one that
+    carried a flip died.
+    """
+    committed = _full_table({"docs/audits/x.md": _ARCHIVED})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert blame.drifting_keys(committed, generated) == set()
+
+
+def test_guilt_a_flip_dated_before_its_eligibility_is_still_drift() -> None:
+    """The exemption is earned by the row's own facts, not by its shape.
+
+    A flip stamped EARLIER than `orphan_eligible_on` is the organ (or a PR)
+    archiving a doc before it was eligible — the deterministic fact says no.
+    """
+    early = _ARCHIVED.replace("2026-07-29", "2026-07-01", 1)
+    committed = _full_table({"docs/audits/x.md": early})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_guilt_a_backwards_flip_is_still_drift() -> None:
+    """ARCHIVED -> LIVE is not a flip this organ advances; it is a regression."""
+    committed = _full_table({"docs/audits/x.md": _LIVE})
+    generated = _full_table({"docs/audits/x.md": _ARCHIVED})
+    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_guilt_a_flip_that_also_edits_another_cell_is_still_drift() -> None:
+    """Only Status, orphan_flipped_on and action are exempt.
+
+    This is what makes the justification unforgeable: a PR that back-dates
+    `orphan_eligible_on` to license its own flip changes a cell outside the
+    exempt three, so the row is charged in full rather than waved through.
+    """
+    forged = _ARCHIVED.replace("| 2026-07-28 |", "| 2026-01-01 |", 1)
+    committed = _full_table({"docs/audits/x.md": forged})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_guilt_a_docs_edit_without_a_regen_is_untouched_by_the_exemption() -> None:
+    """The gate's whole reason to exist must survive the new exemption.
+
+    A row whose ref count moved (a PR added a link and did not regenerate) has
+    nothing to do with flips and must stay charged.
+    """
+    stale = _LIVE.replace("| 0 | 0 | no |", "| 4 | 0 | no |", 1)
+    committed = _full_table({"docs/audits/x.md": stale})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_a_malformed_or_short_row_is_never_waved_through() -> None:
+    """Fail closed: a row this parser cannot read is drift, not an exemption."""
+    committed = _full_table({"docs/audits/x.md": "ARCHIVED | 2026-04-29"})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_scar_pin_the_eight_rows_of_pr_3463() -> None:
+    """The measured incident, kept as data.
+
+    These are the eight documents `inventory-check` charged to #3463 on
+    2026-07-29 — the run said "inventory rows this PR makes STALE: 8" and named
+    them. With the exemption they are not drift; without it they all are.
+    """
+    paths = [
+        "docs/audits/2026-04-29-zero-crash-audit/11_brainstorms/00_INDEX.md",
+        "docs/audits/2026-04-29-zero-crash-audit/_codex_iteration_1_section.md",
+        "docs/audits/2026-04-29-zero-crash-audit/_codex_iteration_2.md",
+        "docs/audits/2026-04-29-zero-crash-audit/_codex_iteration_3_final.md",
+        "docs/audits/2026-04-29-zero-crash-audit/prompts/wave1/kakuro-S4-final.md",
+        "docs/innervation-2026-04-29/99c_w0a_bis_kickoff.md",
+        "docs/ops/2026-04-30-followup-cell-cron-sensor.md",
+        "docs/ops/2026-04-30-followup-heartbeat-telegram-html.md",
+    ]
+    committed = _full_table({p: _ARCHIVED for p in paths})
+    generated = _full_table({p: _LIVE for p in paths})
+    assert len(blame.row_map(committed)) == 8, "the fixture itself stopped parsing"
+    assert blame.drifting_keys(committed, generated) == set()

--- a/scripts/tests/test_docs_inventory_blame.py
+++ b/scripts/tests/test_docs_inventory_blame.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from datetime import date
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -192,13 +193,20 @@ def test_added_and_removed_rows_both_count_as_drift(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# The earned-flip exemption (2026-07-29).
+# The earned-flip exemption (2026-07-29, rebuilt after a cross-family red-team).
 #
-# Rows here carry the REAL column layout of docs/DOCS_INVENTORY.md, because the
-# exemption is positional:
-#   File | Status | last_touched_date | orphan_eligible_on | orphan_flipped_on |
-#   refs_in | broken | drift | cluster | action
+# Rows carry the REAL column layout and header row of docs/DOCS_INVENTORY.md,
+# because the exemption reads its cells BY HEADER NAME via
+# docs_audit._parse_inventory_table — a fixture with a different header row is
+# not merely unrealistic here, it parses to nothing and would make every
+# assertion below vacuously true.
+#
+# CEILING is fixed rather than "today": the upper bound on a claimed flip date
+# is an input to the rule, so the corpus must be able to assert BOTH sides of
+# it (a claim inside it, a claim beyond it) without waiting for the calendar.
 # ---------------------------------------------------------------------------
+
+CEILING = date(2026, 7, 29)
 
 _LIVE = "LIVE | 2026-04-29 | 2026-07-28 | — | 0 | 0 | no | — | —"
 _ARCHIVED = (
@@ -208,18 +216,32 @@ _ARCHIVED = (
 
 
 def _full_table(rows: dict[str, str]) -> str:
+    """An inventory-shaped table whose counters are DERIVED from its rows.
+
+    `render_inventory` computes every aggregate from the rows it renders, so a
+    fixture that hardcodes a count is a table the generator could never emit —
+    and a corpus built on impossible inputs proves nothing about the real one.
+    """
+    live = sum(1 for c in rows.values() if c.startswith("LIVE"))
+    archived = sum(1 for c in rows.values() if c.startswith("ARCHIVED"))
     body = "\n".join(f"| {p} | {cells} |" for p, cells in rows.items())
     return (
         "# Documentation Inventory\n\n"
         "| Status   | Count | % |\n"
         "| -------- | ----: | -: |\n"
-        "| LIVE     |   620 | 66% |\n\n"
+        f"| LIVE     |   {live} | 66% |\n"
+        f"| ARCHIVED |   {archived} | 33% |\n\n"
         "| File | Status | last_touched_date | orphan_eligible_on | "
         "orphan_flipped_on | refs_in | broken | drift | cluster | action |\n"
         "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
         + body
         + "\n"
     )
+
+
+def _drift(committed: str, generated: str, **kw) -> set[str]:
+    kw.setdefault("ceiling", CEILING)
+    return blame.drifting_keys(committed, generated, **kw)
 
 
 def test_innocence_an_earned_orphan_flip_is_not_drift() -> None:
@@ -233,7 +255,7 @@ def test_innocence_an_earned_orphan_flip_is_not_drift() -> None:
     """
     committed = _full_table({"docs/audits/x.md": _ARCHIVED})
     generated = _full_table({"docs/audits/x.md": _LIVE})
-    assert blame.drifting_keys(committed, generated) == set()
+    assert _drift(committed, generated) == set()
 
 
 def test_guilt_a_flip_dated_before_its_eligibility_is_still_drift() -> None:
@@ -245,14 +267,14 @@ def test_guilt_a_flip_dated_before_its_eligibility_is_still_drift() -> None:
     early = _ARCHIVED.replace("2026-07-29", "2026-07-01", 1)
     committed = _full_table({"docs/audits/x.md": early})
     generated = _full_table({"docs/audits/x.md": _LIVE})
-    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
 
 
 def test_guilt_a_backwards_flip_is_still_drift() -> None:
     """ARCHIVED -> LIVE is not a flip this organ advances; it is a regression."""
     committed = _full_table({"docs/audits/x.md": _LIVE})
     generated = _full_table({"docs/audits/x.md": _ARCHIVED})
-    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
 
 
 def test_guilt_a_flip_that_also_edits_another_cell_is_still_drift() -> None:
@@ -265,7 +287,7 @@ def test_guilt_a_flip_that_also_edits_another_cell_is_still_drift() -> None:
     forged = _ARCHIVED.replace("| 2026-07-28 |", "| 2026-01-01 |", 1)
     committed = _full_table({"docs/audits/x.md": forged})
     generated = _full_table({"docs/audits/x.md": _LIVE})
-    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
 
 
 def test_guilt_a_docs_edit_without_a_regen_is_untouched_by_the_exemption() -> None:
@@ -277,12 +299,159 @@ def test_guilt_a_docs_edit_without_a_regen_is_untouched_by_the_exemption() -> No
     stale = _LIVE.replace("| 0 | 0 | no |", "| 4 | 0 | no |", 1)
     committed = _full_table({"docs/audits/x.md": stale})
     generated = _full_table({"docs/audits/x.md": _LIVE})
-    assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
 
 
 def test_a_malformed_or_short_row_is_never_waved_through() -> None:
     """Fail closed: a row this parser cannot read is drift, not an exemption."""
     committed = _full_table({"docs/audits/x.md": "ARCHIVED | 2026-04-29"})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
+
+
+# --- what the first version of the exemption let through -------------------
+# Every case below was found by a cross-family refuter (Codex GPT-5.6, 2026-07-29)
+# against the first build, which decided legitimacy on its own instead of asking
+# docs_audit. Each one PASSED that version.
+
+
+def test_guilt_a_live_doc_with_inbound_refs_cannot_be_hand_archived() -> None:
+    """BLOCKER-1 as reported: the exemption ignored `refs_in` entirely.
+
+    `classify()` only ever archives a doc that is structurally orphan-eligible —
+    `refs_in == 0`. The first version checked neither side's ref count, so a
+    real, referenced, whitelisted document (the refuter used docs/API_REFERENCE.md,
+    four inbound refs) could be hand-marked ARCHIVED in the committed table and
+    the gate would wave it through.
+    """
+    live4 = "LIVE | 2026-04-29 | 2026-07-28 | — | 4 | 0 | no | — | —"
+    arch4 = (
+        "ARCHIVED | 2026-04-29 | 2026-07-28 | 2026-07-29 | 4 | 0 | no | — | "
+        "archive: orphan, last_touched=2026-04-29, refs=0"
+    )
+    committed = _full_table({"docs/API_REFERENCE.md": arch4})
+    generated = _full_table({"docs/API_REFERENCE.md": live4})
+    assert _drift(committed, generated) == {"docs/API_REFERENCE.md"}
+
+
+def test_guilt_a_whitelisted_doc_is_never_an_earned_flip() -> None:
+    """Structural eligibility is `refs_in == 0` AND not whitelisted.
+
+    The shared predicate cannot see the whitelist — it has no repo access. A
+    RENDERED row can: `classify()` writes `action = "whitelist"` for a
+    whitelisted doc, never the em-dash. So the generated side's action carries
+    the fact, and pinning it closes the half the predicate must leave open.
+    """
+    wl = "LIVE | 2026-04-29 | 2026-07-28 | — | 0 | 0 | no | — | whitelist"
+    committed = _full_table({"docs/README.md": _ARCHIVED})
+    generated = _full_table({"docs/README.md": wl})
+    assert _drift(committed, generated) == {"docs/README.md"}
+
+
+def test_guilt_a_future_dated_flip_is_drift() -> None:
+    """BLOCKER-2 as reported: the first version bounded the date only BELOW.
+
+    `2099-12-31 >= eligible` was true, so it passed — the same forgery the
+    --check path had already been hardened against on 2026-07-25, where a
+    claim of 2099 kept a live doc pinned ARCHIVED for 73 years and would have
+    had the organ physically `git mv` it into docs/archive/.
+    """
+    future = _ARCHIVED.replace("2026-07-29", "2099-12-31", 1)
+    committed = _full_table({"docs/audits/x.md": future})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_guilt_a_date_shaped_string_that_is_not_a_date_is_drift() -> None:
+    """`\\d{4}-\\d{2}-\\d{2}` accepts 2099-99-99; `date.fromisoformat` does not.
+
+    The first version validated the SHAPE of the two dates with a regex and then
+    compared them as strings — so a non-date that looks like one sorted its way
+    past the lower bound. The rule now parses.
+    """
+    bogus = _ARCHIVED.replace("2026-07-29", "2099-99-99", 1)
+    committed = _full_table({"docs/audits/x.md": bogus})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_guilt_the_action_cell_is_not_free_text() -> None:
+    """`action` is exempt from the identity check, so it must be pinned instead.
+
+    An archived orphan's action is a pure function of its own `last_touched_date`
+    (`docs_audit.archive_orphan_action`) — a cell that IS compared verbatim. So
+    the exemption cannot be used as a hole to write arbitrary text into a row.
+    """
+    lying = _ARCHIVED.replace(
+        "archive: orphan, last_touched=2026-04-29, refs=0", "anything at all", 1
+    )
+    committed = _full_table({"docs/audits/x.md": lying})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_guilt_a_path_already_flipped_on_the_base_is_never_re_exempted() -> None:
+    """Anti-resurrection: the tolerance is only for a flip not yet on the base.
+
+    If the base's committed table already records a flip for this path, any
+    mismatch is a potential resurrection/hiding attempt and is never tolerated —
+    condition 1 of the 2026-07-18 round, inherited here through the same
+    predicate.
+    """
+    committed = _full_table({"docs/audits/x.md": _ARCHIVED})
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    prior = {"docs/audits/x.md": "2026-07-20"}
+    assert _drift(committed, generated, prior_flips=prior) == {"docs/audits/x.md"}
+
+
+def test_guilt_a_duplicated_path_is_drift_not_a_silent_last_wins() -> None:
+    """A dict keeps the LAST row, so a corrupt row can hide BEHIND a clean one.
+
+    Order is the whole point of this case, and getting it wrong is how the
+    first version of the test proved nothing: with the corrupt row LAST it is
+    the corrupt row that survives the dict, the comparison sees it, and the row
+    is charged for ordinary reasons — the duplicate logic is never consulted.
+    The attack is the other way round. The corrupt row goes FIRST and the
+    exemptable row LAST, so `row_map` keeps the clean one, the exemption fires,
+    and a row asserting nine broken links vanishes from the gate's view
+    entirely. Mutation-checked: with `_duplicate_keys` disabled this assertion
+    fails, and with the two rows swapped it does not.
+    """
+    header, _, rows = _full_table({"docs/audits/x.md": _ARCHIVED}).rpartition("| --- |\n")
+    corrupt = "| docs/audits/x.md | ARCHIVED | 1999-01-01 | — | — | 9 | 9 | yes | — | ? |\n"
+    committed = header + "| --- |\n" + corrupt + rows
+    generated = _full_table({"docs/audits/x.md": _LIVE})
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_guilt_a_generated_row_that_is_live_yet_already_flipped_is_impossible() -> None:
+    """A defence against a state the generator cannot produce — asserted anyway.
+
+    `classify()` sets `status = "ARCHIVED"` the moment `orphan_flipped_on` is
+    non-empty, so a LIVE row carrying a flip date cannot come out of a real
+    regeneration. The exemption checks for it regardless, because "the generator
+    would never" is an argument about today's generator, and this table is also
+    read from files a human can edit.
+
+    Without this case the check is unpinned: the mutation sweep found it GREEN
+    when disabled, precisely because every other test feeds it states the
+    generator really does produce.
+    """
+    impossible = _LIVE.replace("| — | 0 | 0 |", "| 2026-07-20 | 0 | 0 |", 1)
+    assert impossible != _LIVE, "the fixture edit did not apply"
+    committed = _full_table({"docs/audits/x.md": _ARCHIVED})
+    generated = _full_table({"docs/audits/x.md": impossible})
+    assert _drift(committed, generated) == {"docs/audits/x.md"}
+
+
+def test_without_a_trustworthy_ceiling_nothing_is_ever_exempt() -> None:
+    """Fail closed. A caller that has established no upper bound gets no tolerance.
+
+    This is the same `if trusted_ref_ceiling_date is None: return` the --check
+    path has, and it is why the exemption cannot be activated by simply calling
+    the function without arguments.
+    """
+    committed = _full_table({"docs/audits/x.md": _ARCHIVED})
     generated = _full_table({"docs/audits/x.md": _LIVE})
     assert blame.drifting_keys(committed, generated) == {"docs/audits/x.md"}
 
@@ -307,4 +476,4 @@ def test_scar_pin_the_eight_rows_of_pr_3463() -> None:
     committed = _full_table({p: _ARCHIVED for p in paths})
     generated = _full_table({p: _LIVE for p in paths})
     assert len(blame.row_map(committed)) == 8, "the fixture itself stopped parsing"
-    assert blame.drifting_keys(committed, generated) == set()
+    assert _drift(committed, generated) == set()


### PR DESCRIPTION
## What was measured

`inventory-check` compares each committed inventory row against a freshly generated one, and `drifting_keys` compared the **whole row**. Three of its cells — `Status`, `orphan_flipped_on`, `action` — are exactly what an orphan flip moves, and the generator the gate compares against runs `--gate-consistent`, which by design never invents a flip.

So every flip the scheduled refresh organ exists to advance was read as *"this PR made these rows stale"*, and charged to the organ's own PR.

**Across all six PRs the organ has ever opened, the split is exact:**

| PR | newly-ARCHIVED rows | outcome |
|---|---|---|
| #3411 | 0 | MERGED |
| #3425 | 0 | MERGED |
| #3405 | 65 | closed |
| #3456 | 9 | closed |
| #3463 | 9 | blocked (open) |

The organ could deliver only the half of its job that did not matter — and the flips are precisely the wall-clock decision P3-prime moved *into* it on purpose.

## The first version of this fix was wrong, and a refuter said so

The exemption originally decided legitimacy on its own. A cross-family adversarial review (Codex GPT-5.6, `xhigh`) returned **DO-NOT-SHIP** with two blockers, both verified on disk before curing:

- **It never looked at `refs_in`.** `classify()` only archives a structurally orphan-eligible doc (`refs_in == 0 AND not whitelisted`, `docs_audit.py:797`). The exemption checked neither, so any live document — the refuter used `docs/API_REFERENCE.md`, four inbound references and whitelisted — could be hand-marked `ARCHIVED` in the committed table and walk through.
- **The flip date was bounded only from below.** `2099-12-31 >= eligible` is true, so it passed. That is the same forgery the `--check` path had already been hardened against on 2026-07-25, where a claim of 2099 pinned a live doc `ARCHIVED` for 73 years.

The third finding is the one that mattered: **none of it needed inventing.**

## The cure: import the rule, do not re-derive it

`docs_audit._tolerated_orphan_flip_paths` has answered this exact question since 2026-07-25, hardened by a round that included a live `GIT_COMMITTER_DATE` forgery. A weaker second copy of a guard is not redundancy — it is the way in.

The rule is now **extracted**, and both gates that ask the question call it:

```
docs_audit.orphan_flip_claim_is_legitimate(...)
   ├── _tolerated_orphan_flip_paths        (--check byte-diff path)
   └── docs_inventory_blame._is_earned_flip (inventory-check blame path)
```

The extraction is behaviour-preserving: **the `--check` corpus passes unchanged, 55/55.** `archive_orphan_action()` gives the archived row's `action` string one author for the same reason.

What the blame path still owns is what only a **rendered** pair can check, and it is deliberately the strict half:

- cells matched **by header name** — not the positional indices the first version hardcoded, which a column reorder would have silently repointed;
- the generated side proved genuinely un-flipped;
- the committed `action` pinned to `archive_orphan_action(last_touched)` — a pure function of a cell that is itself compared verbatim, so the exemption cannot smuggle text into a row. Pinning the **generated** `action` also closes the whitelist half the shared predicate cannot see: a whitelisted doc renders `action = "whitelist"`, never the em-dash.

Also fixed: a duplicated path silently kept only the **last** row, so a corrupt row could hide behind a clean one. A duplicate is now drift by itself.

**The "clock-free" claim in the first version is withdrawn.** The ceiling is `max(origin/main tip, now)`, computed exactly as `--check` computes it, and the source actually accepted is *printed* rather than silently degraded to the fallback. The core decision stays clock-free — both dates are cells of the row.

## Proof, on real bytes

Not fixtures — #3463's own committed table against `origin/main`'s:

```
with the exemption   : 0 rows charged
without it (control) : 8 rows charged   <- the eight the live run named
```

The control is there deliberately: before trusting a negative, prove the apparatus can produce a positive.

## Corpus

25 tests. **Mutation-verified 10/11 across BOTH corpora** — the shared predicate's coverage is the union, which is how one mutation was found to be pinned by the `--check` corpus after the blame corpus alone said it was not.

The one unpinned mutation is declared, not hidden: the committed-side `refs_in` check is redundant in the blame path (`refs_in` is compared verbatim, so the two sides cannot disagree) and no case exists in either path where disabling it changes a verdict.

Two further limits are recorded in the code rather than silently inherited: the shared rule allows a flip dated exactly on the eligibility date while `classify()` requires strictly after; and whitelisting is invisible to the predicate itself (zero whitelisted docs have `refs_in == 0` on the live table today — the blame path closes it via the rendered `action` cell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)