### PR TITLE
fix(prepush): a lock timeout must not speak as a test verdict

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -526,6 +526,24 @@ else
             # The ONLY place the suite genuinely ran to a pass. Every other
             # path out of this block either exits 1 or leaves a skip reason.
             BACKEND_SUITE_RAN=1
+        elif [ "$TEST_RC" -eq 75 ]; then
+            # 75 = EX_TEMPFAIL, returned by prepush_suite_lock.sh ONLY when it
+            # never acquired the machine lock. The wrapped pytest was not even
+            # spawned, so there is nothing to reproduce and nothing to blame.
+            #
+            # Before this branch existed the timeout exited 1 — pytest's own
+            # "tests failed" — and fell through to the generic branch below,
+            # which printed "❌ Python tests FAILED" plus a reproduce command
+            # for a suite that never ran. Seen twice on 2026-07-29 on a
+            # 9-waiter M5. Third instance of the same disease as #45 and W104:
+            # the exit code is the reply, and two replies sharing one value
+            # means the verdict names something it never measured.
+            echo "⚠️  Backend suite NEVER RAN — this machine's suite lock was not acquired. NO VERDICT, push blocked."
+            echo "   Nothing here is a statement about your diff: no test judged it. Do NOT hunt a regression,"
+            echo "   and do NOT print a reproduce command — there is no failure to reproduce."
+            echo "   Retry when the queue drains. The wrapper above prints who holds the lock and how long it has"
+            echo "   actually been alive; judge staleness from THAT, not from how long you personally waited."
+            exit 1
         elif [ "$TEST_RC" -ge 128 ]; then
             TEST_SIGNAL=$((TEST_RC - 128))
             echo "⚠️  Python test run TERMINATED by signal $TEST_SIGNAL — NO VERDICT, push blocked pending re-run."

--- a/scripts/prepush_suite_lock.sh
+++ b/scripts/prepush_suite_lock.sh
@@ -55,14 +55,37 @@
 #                                         Test-only override in practice.
 #   NUZ_PREPUSH_SUITE_LOCK_POLL=<s>      poll interval in seconds (default 2).
 #                                         Test-only override.
+#   NUZ_PREPUSH_SUITE_LOCK_HEARTBEAT=<s> seconds between "still waiting"
+#                                         heartbeats (default 30). Test-only
+#                                         override — the corpus needs a
+#                                         heartbeat inside a 3s window.
 #
 # Exit code: on success, propagates <command>'s own exit code UNCHANGED
 # (including a 128+N signal-death code, so an outer `TEST_RC -ge 128`
-# classification still works). On a timed-out lock acquisition, exits 1
-# itself with an actionable message — the wrapped command never even starts;
-# this NEVER silently skips the lock and runs anyway (cicatrix-superscar.md
-# family #2, "esiste != armato" — a guard that can silently disarm itself
-# is not a guard).
+# classification still works). On a timed-out lock acquisition, exits
+# LOCK_TIMEOUT_RC (75) itself with an actionable message — the wrapped command
+# never even starts; this NEVER silently skips the lock and runs anyway
+# (cicatrix-superscar.md family #2, "esiste != armato" — a guard that can
+# silently disarm itself is not a guard).
+#
+# Why 75 and not 1 (2026-07-29, measured): it used to exit 1, which is also
+# pytest's "tests failed". The caller could not tell the two apart, so a
+# saturation timeout — with the suite NEVER STARTED — printed
+# "❌ Python tests FAILED — push blocked" plus a pytest reproduce command.
+# Observed live twice the same evening on a 9-waiter M5. Anyone reading that
+# line had grounds to hunt a regression that does not exist, and the reproduce
+# command then passes, which reads as flakiness. Exactly the defect #45 fixed
+# for signal-death (128+N) one class over: the exit code is the reply, and
+# collapsing two replies into one value throws away the bit that tells the
+# truth. 75 is EX_TEMPFAIL from sysexits.h — "temporary failure, the user is
+# invited to retry" — which is precisely this condition.
+#
+# LIMITATION, stated rather than hidden: this steals one value out of the
+# wrapped command's own exit space. A <command> that itself exits 75 will be
+# misread by a caller as a lock timeout. Safe for the only caller in the tree
+# (.husky/pre-push wraps pytest, whose codes are 0-5 and are pinned as
+# pass-through by scripts/tests/test_prepush_suite_lock.sh); re-check this
+# line before wrapping anything else.
 
 set -u
 
@@ -82,7 +105,11 @@ fi
 
 TIMEOUT="${NUZ_PREPUSH_SUITE_LOCK_TIMEOUT:-4500}"
 POLL_INTERVAL="${NUZ_PREPUSH_SUITE_LOCK_POLL:-2}"
-HEARTBEAT_EVERY=30
+HEARTBEAT_EVERY="${NUZ_PREPUSH_SUITE_LOCK_HEARTBEAT:-30}"
+# EX_TEMPFAIL. Distinct from anything pytest returns (0-5) so the caller can
+# tell "never acquired the lock" from "the suite ran and failed". See the
+# Exit code block in the header.
+LOCK_TIMEOUT_RC=75
 
 START_TS=$(date +%s)
 LAST_HEARTBEAT=$START_TS
@@ -108,13 +135,25 @@ while :; do
 
     if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
         TIMEOUT_MIN=$((TIMEOUT / 60))
-        echo "❌ machine saturated — suite lock not acquired in ${TIMEOUT_MIN}m. Do NOT use --no-verify. Either retry later, or land this branch from an idle fleet machine (git bundle + push from pro/mini)." >&2
-        exit 1
+        echo "❌ machine saturated — suite lock not acquired in ${TIMEOUT_MIN}m. The suite NEVER RAN: this is not a verdict on your diff." >&2
+        echo "   Do NOT use --no-verify, and do NOT set NUZ_PREPUSH_SUITE_LOCK=0 — the wait is the queue working, not a fault." >&2
+        echo "   Retry later, or land from an idle fleet machine — but ONLY into a worktree made by scripts/agent_start.py." >&2
+        echo "   A worktree from a bare 'git worktree add' has no .husky/_ (it is gitignored and install-generated)," >&2
+        echo "   so its push runs NO pre-push hook at all: 2 seconds, exit 0, no output. Landing there is the --no-verify" >&2
+        echo "   this message just forbade, with extra steps. Measured 2026-07-29; see agent_start.py's SYMLINK_TARGETS." >&2
+        exit "$LOCK_TIMEOUT_RC"
     fi
 
     if [ $((NOW - LAST_HEARTBEAT)) -ge "$HEARTBEAT_EVERY" ]; then
-        HELD_MIN=$((ELAPSED / 60))
-        echo "⏳ waiting for this machine's backend-suite lock (held by PID ${HOLDER_PID:-unknown} for ${HELD_MIN}m)"
+        # Two DIFFERENT quantities, so say which is which. The old line read
+        # "held by PID X for Nm" while N was ELAPSED — the WAITER's own wait.
+        # Measured 2026-07-29: one waiter said "held ... for 38m" and another,
+        # same holder same minute, said "for 1m", while `ps` put the holder at
+        # 20m. A healthy sibling suite reads as hung, and "that lock is stale,
+        # kill it" is the action that reading invites — onto live work.
+        WAITED_MIN=$((ELAPSED / 60))
+        HOLDER_AGE="$(ps -o etime= -p "${HOLDER_PID:-0}" 2>/dev/null | tr -d ' ')"
+        echo "⏳ waited ${WAITED_MIN}m for this machine's backend-suite lock (holder PID ${HOLDER_PID:-unknown}, alive ${HOLDER_AGE:-unknown})"
         LAST_HEARTBEAT=$NOW
     fi
 

--- a/scripts/tests/test_prepush_suite_lock.sh
+++ b/scripts/tests/test_prepush_suite_lock.sh
@@ -13,10 +13,17 @@
 # a lock must never outlive its holder, or a killed suite wedges the machine
 # forever instead of just failing that one push.
 #
-# Five cases, mirroring the brief's guilt/innocence/stale/timeout/kill-switch
-# split and this repo's own test_prepush_failclosed.sh style (real kills and
-# real dead PIDs over synthetic conditions wherever the property under test
-# is about a REAL process's fate, not just arithmetic).
+# Cases mirror the brief's guilt/innocence/stale/timeout/kill-switch split and
+# this repo's own test_prepush_failclosed.sh style (real kills and real dead
+# PIDs over synthetic conditions wherever the property under test is about a
+# REAL process's fate, not just arithmetic).
+#
+# 2026-07-29 added the exit-code and heartbeat honesty cases. Both pin the same
+# property from opposite sides: a message must not name a quantity it did not
+# measure. The timeout used to exit 1 (pytest's "tests failed") so saturation
+# printed "❌ Python tests FAILED" for a suite that never started, and the
+# heartbeat printed the WAITER's elapsed time as the HOLDER's hold. Each cure
+# is mutation-verified — revert it and a named case goes red.
 #
 # Run:  sh scripts/tests/test_prepush_suite_lock.sh
 # Exit: 0 all pass, 1 any failure.
@@ -153,13 +160,24 @@ OUT4="$(NUZ_PREPUSH_SUITE_LOCK_TIMEOUT=1 NUZ_PREPUSH_SUITE_LOCK_POLL=0.3 "$SCRIP
 RC4=$?
 kill "$LIVE_PID" 2>/dev/null
 
-if [ "$RC4" -ne 0 ] \
+# rc is asserted as exactly 75 (EX_TEMPFAIL), not merely non-zero: the whole
+# point of 2026-07-29's change is that "never acquired the lock" stopped
+# sharing a value with pytest's "tests failed" (1). `-ne 0` would pass again
+# the day someone reverts it to 1.
+#
+# The guidance is asserted by INTENT, not by the old literal 'pro/mini'. That
+# advice is now qualified — landing from another machine is only safe into a
+# worktree the broker made, since a bare `git worktree add` has no .husky/_
+# and pushes with no gate at all — so pinning the bare string would have
+# locked in the version of the sentence that was dangerous.
+if [ "$RC4" -eq 75 ] \
    && ! printf '%s' "$OUT4" | grep -q 'SHOULD_NOT_RUN' \
    && printf '%s' "$OUT4" | grep -q -- '--no-verify' \
-   && printf '%s' "$OUT4" | grep -q 'pro/mini'; then
-    note_pass "timeout — held lock + capped wait produced non-zero exit (rc=$RC4) with fleet-machine guidance, wrapped command never ran"
+   && printf '%s' "$OUT4" | grep -q 'NEVER RAN' \
+   && printf '%s' "$OUT4" | grep -q 'agent_start.py'; then
+    note_pass "timeout — held lock + capped wait exited 75 with never-ran + broker-qualified guidance, wrapped command never ran"
 else
-    note_fail "timeout — expected non-zero exit + guidance message + command never running, got rc=$RC4 out='$OUT4'"
+    note_fail "timeout — expected rc=75 + 'NEVER RAN' + agent_start.py guidance + command never running, got rc=$RC4 out='$OUT4'"
 fi
 
 # ---------------------------------------------------------------------------
@@ -210,6 +228,76 @@ else
     else
         note_fail "tripwire — .husky/pre-push does not reference the lock wrapper as expected"
     fi
+fi
+
+# ---------------------------------------------------------------------------
+# Case 8 (innocence): the 75 must mean ONLY "never acquired the lock". Every
+# code pytest can actually return has to survive the wrapper untouched —
+# otherwise fixing the false FAILED just invents the mirror-image lie.
+# ---------------------------------------------------------------------------
+INNOCENT_OK=1
+for code in 0 1 2 3 4 5; do
+    LOCK8="$WORKDIR/passthru-$code.lock"
+    "$SCRIPT" "$LOCK8" sh -c "exit $code" >/dev/null 2>&1 && GOT=0 || GOT=$?
+    if [ "$GOT" -ne "$code" ]; then
+        note_fail "innocence — wrapped command exiting $code was reported as $GOT"
+        INNOCENT_OK=0
+    fi
+    rm -rf "$LOCK8"
+done
+if [ "$INNOCENT_OK" -eq 1 ]; then
+    note_pass "innocence — pytest's whole exit range (0-5) passes through unchanged; 1 is still 'tests failed'"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 9 (innocence): signal death must still surface as 128+N, so the
+# caller's existing `-ge 128` NO-VERDICT branch keeps working alongside 75.
+# ---------------------------------------------------------------------------
+LOCK9="$WORKDIR/signal.lock"
+"$SCRIPT" "$LOCK9" sh -c 'kill -TERM $$' >/dev/null 2>&1 && RC9=0 || RC9=$?
+if [ "$RC9" -ge 128 ]; then
+    note_pass "innocence — signal death still propagates as 128+N (rc=$RC9), not flattened into 75"
+else
+    note_fail "innocence — expected 128+N from a signal-killed command, got rc=$RC9"
+fi
+rm -rf "$LOCK9"
+
+# ---------------------------------------------------------------------------
+# Case 10 (guilt): the heartbeat must not report the waiter's own wait as the
+# holder's. Measured 2026-07-29: two waiters on ONE holder printed "for 38m"
+# and "for 1m" while ps put the holder at 20m — and "that lock is stale, kill
+# it" is the action a 38m reading invites, onto a live sibling's suite.
+# ---------------------------------------------------------------------------
+LOCK10="$WORKDIR/heartbeat.lock"
+( "$SCRIPT" "$LOCK10" sh -c 'sleep 6' >/dev/null 2>&1 ) &
+HOLDER_JOB=$!
+sleep 2
+OUT10="$(NUZ_PREPUSH_SUITE_LOCK_TIMEOUT=3 NUZ_PREPUSH_SUITE_LOCK_POLL=1 \
+         NUZ_PREPUSH_SUITE_LOCK_HEARTBEAT=1 \
+         "$SCRIPT" "$LOCK10" sh -c 'echo late' 2>&1)" || true
+wait "$HOLDER_JOB" 2>/dev/null || true
+if echo "$OUT10" | grep -q "waited"; then
+    note_pass "guilt — heartbeat labels the number as the WAITER's wait"
+else
+    note_fail "guilt — heartbeat does not say 'waited'; the old wording blamed the holder: '$OUT10'"
+fi
+if echo "$OUT10" | grep -qE "held by PID [0-9]+ for"; then
+    note_fail "guilt — heartbeat still claims the holder HELD it for the waiter's elapsed time"
+else
+    note_pass "guilt — heartbeat no longer attributes the waiter's elapsed time to the holder"
+fi
+rm -rf "$LOCK10"
+
+# ---------------------------------------------------------------------------
+# Case 11 (tripwire): the caller must classify 75 separately. A distinct exit
+# code that nobody branches on is a rename, not a fix (family #2).
+# ---------------------------------------------------------------------------
+if [ ! -f "$HOOK_FILE" ]; then
+    note_fail "tripwire — $HOOK_FILE not found (cannot verify the 75 branch)"
+elif grep -q 'TEST_RC" -eq 75' "$HOOK_FILE" && grep -q 'NEVER RAN' "$HOOK_FILE"; then
+    note_pass "tripwire — .husky/pre-push branches on 75 and reports NO VERDICT"
+else
+    note_fail "tripwire — .husky/pre-push does not classify rc=75; saturation still reads as 'tests FAILED'"
 fi
 
 echo "---"


### PR DESCRIPTION
Two messages in the pre-push path named a quantity they had not measured. Both were measured live on a saturated M5 on 2026-07-29; both cures are mutation-verified here.

## 1. The exit code — a timeout spoke as pytest

`prepush_suite_lock.sh` exited **1** when it failed to acquire the machine's suite lock. `1` is also pytest's *"tests failed"*, so the caller could not tell the two apart and `.husky/pre-push` printed:

```
❌ Python tests FAILED — push blocked
   Reproduce: cd apps/backend-rag && ... pytest ...
```

for a suite that **never started**. Observed twice the same evening with 9 waiters queued. Anyone reading that line had grounds to hunt a regression that does not exist — and the reproduce command then *passes*, which reads as flakiness and quietly erodes the gate's credibility.

This is the same defect the `128+N` signal-death branch already fixed one case over: the exit code is the reply, and collapsing two replies into one value throws away the bit that tells the truth.

The timeout now exits **75** (`EX_TEMPFAIL`, *"temporary failure, the user is invited to retry"*), distinct from everything pytest returns (0-5). The hook gains a dedicated branch that states the suite never ran, says plainly that nothing there judges the diff, and prints **no** reproduce command — there is no failure to reproduce. It still exits 1: *no verdict is not a pass.*

The cost is real and is stated in the header rather than hidden: this steals one value from the wrapped command's exit space. Safe for the only caller in the tree; a tripwire pins that pytest's 0-5 still pass through untouched.

## 2. The heartbeat — my wait reported as someone else's hold

The waiter printed `held by PID X for Nm`, where `N` was its **own** elapsed wait. Two waiters on the same holder in the same minute said *"38m"* and *"1m"* while `ps` put the holder at 20m. A healthy sibling suite reads as hung — and *"that lock is stale, kill it"* is exactly the action that reading invites, onto live work.

Now: `waited Nm for this machine's backend-suite lock (holder PID X, alive <ps etime>)`. Two quantities, each labelled with whose it is.

## Also: the escape hatch needed a warning

The timeout advice says to land from an idle fleet machine. It now adds: **only into a worktree created by `scripts/agent_start.py`**. A bare `git worktree add` has no `.husky/_` (it is gitignored and install-generated), so `git push` from it runs **no pre-push hook at all** — 2 seconds, exit 0, no output. That is the `--no-verify` the same message forbids, with extra steps.

## Verification

`scripts/tests/test_prepush_suite_lock.sh` — **12 cases, 0 failures**, extended with pytest pass-through (0-5), signal-death (128+N), heartbeat wording, and a tripwire that the *caller* still branches on 75.

Mutation-verified, each cure independently:

| mutation | result |
|---|---|
| timeout returns to `exit 1` | 1 case red |
| heartbeat returns to the old wording | 2 cases red (both heartbeat GUILT) |
| the hook loses its 75 branch | 1 case red (tripwire) |
| restored | 12 passed, 0 failed |

Two pre-existing cases were updated rather than deleted: case 4 pinned `-ne 0` and the literal `pro/mini` advice, both of which this change supersedes.

Live fleet check while landing this: `scripts/lint_worktree_husky_symlink.py` (the detector for the unarmed-worktree hazard the new message warns about) run on M5 found **1 finding of 17** — a hand-made `mouth` worktree whose content had already landed via #3186 (verified blob-per-file against `origin/main`, W88 discipline). Reaped; M5 now reads 16/16 armed, Mini 8/8. Pro is offline (Tailscale: last seen 28m ago) and was not scanned.

## Merge discipline

Guardrail-hook class, so auto-merge is deliberately **not** armed. The session merges after the gates report, per CLAUDE.md §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)