### PR TITLE
fix(connectome): the freshness warning went to a log; the alert kept lying

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -118,6 +118,8 @@ jobs:
               .husky/pre-push|\
               scripts/tests/test_prepush_failclosed.sh|\
               scripts/tests/test_prepush_tip_drift.sh|\
+              scripts/verify_connectome_run.sh|\
+              scripts/tests/test_connectome_alert_honesty.sh|\
               scripts/ci/prepush_tip_drift.sh|\
               scripts/docs_audit.py|\
               scripts/docs_inventory_refresh_liveness.py|\
@@ -289,6 +291,28 @@ jobs:
           # anywhere. All three exits are asserted — a fix that covers only the path
           # that bit you is half a fix.
           bash scripts/test_cron_runner_alert.sh
+
+      - name: Connectome alert honesty corpus (freshness + truncation + delivery)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # verify-connectome is the guardian of the guardians, and until now NO
+          # workflow named it at all — its wrapper had zero CI coverage while
+          # carrying a P0 Telegram path. Three ways its alert could mislead the
+          # only person who reads it, each pinned with guilt AND innocence here:
+          #   freshness  — M5's checkout is stale BY DESIGN (258 commits behind on
+          #                2026-07-29, pulling races ~45 live worktrees), so the
+          #                weekly run judges against an old census. The warning
+          #                added earlier that day went to stderr only; the alert
+          #                itself read identically at 0 and at 258 behind.
+          #   truncation — `head -10` on 23 regressions renders as a complete list
+          #                unless it declares "showing 10 of 23" (W97).
+          #   delivery   — a bare `curl -sS` exits 0 for HTTP 200 {"ok":false} and
+          #                for 401 after a rotation, so the alarm could not report
+          #                its own silence (W104). The send now goes through
+          #                scripts/tg_notify.py; a fake curl on PATH proves the
+          #                bare path is unreachable, not merely unused.
+          # Mutation-verified: reverting each cure turns the matching case red.
+          bash scripts/tests/test_connectome_alert_honesty.sh
 
       - name: Backup phase composition corpus (one dead phase must not kill the other)
         if: steps.paths.outputs.relevant == 'true'

--- a/infra/tg-gateway/grandfathered.json
+++ b/infra/tg-gateway/grandfathered.json
@@ -156,7 +156,6 @@
     "scripts/sota_fase0_final_check.py",
     "scripts/supervisor_autofix_tier2.sh",
     "scripts/system_doctor.py",
-    "scripts/verify_connectome_run.sh",
     "scripts/verify_home_bridge_sync.sh",
     "scripts/wa_army_watcher.sh",
     "scripts/wa_corpus_daily_run.sh",

--- a/scripts/tests/test_connectome_alert_honesty.sh
+++ b/scripts/tests/test_connectome_alert_honesty.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# test_connectome_alert_honesty.sh — the connectome alert must not lie to its reader.
+#
+# Three properties, each with guilt AND innocence, exercised on the REAL wrapper
+# inside a fake world (fake repo, fake verifier, fake gateway, fake curl, fake
+# HOME). Nothing here asserts that the script CONTAINS a string: every case runs
+# scripts/verify_connectome_run.sh and reads the message it actually built.
+#
+#   1. FRESHNESS  — a verdict judged on a checkout behind origin/main must say so
+#                   IN THE ALERT, not only on stderr. The stderr warning shipped
+#                   earlier the same day went to a log nobody reads while the
+#                   Telegram message stayed identical at 0 and at 258 commits
+#                   behind.
+#   2. TRUNCATION — `head -10` is a display cap; 10 of 23 rendered as a bare list
+#                   reads as the complete set (W97). Say "showing 10 of 23".
+#   3. DELIVERY   — the send goes through scripts/tg_notify.py, which judges the
+#                   reply body, never a bare curl that judges its own delivery by
+#                   an exit code that is 0 even for {"ok":false} (W104). A fake
+#                   curl on PATH proves the bare path is not merely unused but
+#                   unreachable.
+#
+# Exit 0 = all pass. Any failure prints what it expected and what it got.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/verify_connectome_run.sh"
+FAILURES=0
+CASES=0
+
+fail() {
+    FAILURES=$((FAILURES + 1))
+    echo "  ✗ FAIL: $1"
+    [[ $# -gt 1 ]] && printf '    %s\n' "${@:2}"
+}
+pass() { echo "  ✓ $1"; }
+
+if [[ ! -x "$WRAPPER" && ! -f "$WRAPPER" ]]; then
+    echo "FATAL: wrapper not found at $WRAPPER"
+    exit 2
+fi
+
+# The alarm resolves an absolute interpreter (W108). If this box has none of the
+# three, say so instead of reporting a green built on an untaken branch.
+SYS_PY=""
+for c in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+    [[ -x "$c" ]] && { SYS_PY="$c"; break; }
+done
+if [[ -z "$SYS_PY" ]]; then
+    echo "FATAL: no absolute python3 on this machine — the corpus cannot exercise the gateway branch"
+    exit 2
+fi
+
+# ─────────────────────────────────────────────────────────── fake world builder
+# Returns a dir containing: origin/ (bare-ish source), work/ (the checkout the
+# wrapper runs against), home/ (fake HOME), bin/ (fake curl), out/ (recordings).
+build_world() {
+    local behind="$1" n_regressed="$2" with_gateway="$3"
+    local root; root="$(mktemp -d)"
+    mkdir -p "$root/out" "$root/bin" "$root/home"
+
+    # --- origin repo -------------------------------------------------------
+    local origin="$root/origin"
+    mkdir -p "$origin/docs/connectome/edges" "$origin/scripts" "$origin/apps/backend-rag/.venv/bin"
+    echo "edges: []" > "$origin/docs/connectome/edges/fake.yaml"
+    cp "$WRAPPER" "$origin/scripts/verify_connectome_run.sh"
+
+    # Fake verifier, invoked as "$PYBIN scripts/verify_connectome.py ...".
+    # PYBIN is the venv python; making THAT the emitter keeps the fake world free
+    # of any PyYAML dependency (the wrapper's system-python fallback demands it).
+    cat > "$origin/apps/backend-rag/.venv/bin/python3" <<EOF
+#!/bin/bash
+for i in \$(seq 1 $n_regressed); do
+  echo "REGRESSED edge-\$i: declared ALIVE, probe failed"
+done
+exit 1
+EOF
+    chmod +x "$origin/apps/backend-rag/.venv/bin/python3"
+    : > "$origin/scripts/verify_connectome.py"
+
+    if [[ "$with_gateway" == "yes" ]]; then
+        # Fake gateway: records argv + message, exits 0 like the real contract.
+        cat > "$origin/scripts/tg_notify.py" <<EOF
+#!/usr/bin/env python3
+import sys, pathlib
+out = pathlib.Path("$root/out")
+(out / "gateway_argv.txt").write_text("\n".join(sys.argv[1:]))
+msg = sys.argv[-1] if len(sys.argv) > 1 else ""
+(out / "gateway_msg.txt").write_text(msg)
+sys.exit(0)
+EOF
+        chmod +x "$origin/scripts/tg_notify.py"
+    fi
+
+    git -C "$origin" init -q -b main
+    git -C "$origin" -c user.email=t@t -c user.name=t add -A >/dev/null
+    git -C "$origin" -c user.email=t@t -c user.name=t commit -qm base
+
+    # --- the checkout the wrapper runs against -----------------------------
+    git clone -q "$origin" "$root/work"
+    git -C "$root/work" checkout -q -B main origin/main
+
+    # Advance origin so the checkout trails it by exactly $behind commits.
+    local i
+    for ((i = 0; i < behind; i++)); do
+        git -C "$origin" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "ahead $i"
+    done
+    git -C "$root/work" fetch -q origin main
+    git -C "$root/work" update-ref refs/remotes/origin/main "$(git -C "$origin" rev-parse main)"
+
+    # --- fake curl: any bare-curl path would leave this marker -------------
+    cat > "$root/bin/curl" <<EOF
+#!/bin/bash
+echo "BARE CURL CALLED: \$*" >> "$root/out/curl_called.txt"
+exit 0
+EOF
+    chmod +x "$root/bin/curl"
+
+    echo "$root"
+}
+
+run_wrapper() {  # $1=world root  → stdout+stderr into out/run.log, rc into out/run.rc
+    local root="$1"
+    (
+        cd "$root/work" || exit 2
+        PATH="$root/bin:$PATH" HOME="$root/home" REPO_ROOT="$root/work" \
+            bash "$root/work/scripts/verify_connectome_run.sh" > "$root/out/run.log" 2>&1
+        echo $? > "$root/out/run.rc"
+    )
+}
+
+msg_of() { cat "$1/out/gateway_msg.txt" 2>/dev/null || true; }
+
+# ══════════════════════════════════════════════════ 1. FRESHNESS — guilt
+CASES=$((CASES + 1))
+W="$(build_world 3 2 yes)"; run_wrapper "$W"; MSG="$(msg_of "$W")"
+if [[ -z "$MSG" ]]; then
+    fail "freshness/guilt: the gateway was never invoked" "run.log:" "$(cat "$W/out/run.log")"
+elif [[ "$MSG" != *"3 commits behind origin/main"* ]]; then
+    fail "freshness/guilt: alert does not name the staleness" "got:" "$MSG"
+else
+    pass "freshness/guilt — a 3-behind checkout says so IN the alert"
+fi
+rm -rf "$W"
+
+# ══════════════════════════════════════════════════ 2. FRESHNESS — innocence
+CASES=$((CASES + 1))
+W="$(build_world 0 2 yes)"; run_wrapper "$W"; MSG="$(msg_of "$W")"
+if [[ -z "$MSG" ]]; then
+    fail "freshness/innocence: the gateway was never invoked" "run.log:" "$(cat "$W/out/run.log")"
+elif [[ "$MSG" == *"behind origin/main"* || "$MSG" == *"freshness UNKNOWN"* ]]; then
+    fail "freshness/innocence: a level checkout was branded stale" "got:" "$MSG"
+else
+    pass "freshness/innocence — a level checkout adds no caveat"
+fi
+rm -rf "$W"
+
+# ══════════════════════════════════════════════════ 3. TRUNCATION — guilt
+CASES=$((CASES + 1))
+W="$(build_world 0 23 yes)"; run_wrapper "$W"; MSG="$(msg_of "$W")"
+if [[ "$MSG" != *"showing 10 of 23"* ]]; then
+    fail "truncation/guilt: 23 regressions shown as a bare list of 10" "got:" "$MSG"
+else
+    pass "truncation/guilt — 23 regressions declare 'showing 10 of 23'"
+fi
+rm -rf "$W"
+
+# ══════════════════════════════════════════════════ 4. TRUNCATION — innocence
+CASES=$((CASES + 1))
+W="$(build_world 0 3 yes)"; run_wrapper "$W"; MSG="$(msg_of "$W")"
+if [[ "$MSG" == *"showing"* ]]; then
+    fail "truncation/innocence: 3 regressions claimed a truncation" "got:" "$MSG"
+else
+    pass "truncation/innocence — 3 regressions claim no truncation"
+fi
+rm -rf "$W"
+
+# ══════════════════════════════════════════════════ 5. DELIVERY — via gateway only
+CASES=$((CASES + 1))
+W="$(build_world 0 2 yes)"; run_wrapper "$W"
+ARGV="$(cat "$W/out/gateway_argv.txt" 2>/dev/null || true)"
+if [[ -f "$W/out/curl_called.txt" ]]; then
+    fail "delivery: a bare curl was reached" "$(cat "$W/out/curl_called.txt")"
+elif [[ "$ARGV" != *"--tier"$'\n'"p0"* ]]; then
+    fail "delivery: gateway not invoked as a p0" "argv:" "$ARGV"
+elif [[ "$ARGV" != *"--dedup-key"* ]]; then
+    fail "delivery: no dedup key — a weekly-red guardian would repeat forever" "argv:" "$ARGV"
+else
+    pass "delivery — gateway as p0 with a dedup key, zero bare curl"
+fi
+rm -rf "$W"
+
+# ══════════════════════════════════════════════════ 6. GATEWAY MISSING — loud
+CASES=$((CASES + 1))
+W="$(build_world 0 2 no)"; run_wrapper "$W"
+LOG="$(cat "$W/out/run.log")"; RC="$(cat "$W/out/run.rc")"
+if [[ "$LOG" != *"alert gateway is unusable"* ]]; then
+    fail "missing-gateway: silent about being armed to nothing" "log:" "$LOG"
+elif [[ "$LOG" != *"connectome REGRESSED on"* ]]; then
+    fail "missing-gateway: the alert body was not preserved in the log" "log:" "$LOG"
+elif [[ "$RC" != "1" ]]; then
+    fail "missing-gateway: exit code changed" "expected 1, got $RC"
+else
+    pass "missing-gateway — says which half is missing, keeps body, still exits 1"
+fi
+rm -rf "$W"
+
+echo
+if (( FAILURES > 0 )); then
+    echo "FAIL: $FAILURES of $CASES connectome-alert cases"
+    exit 1
+fi
+echo "PASS: $CASES/$CASES connectome-alert honesty cases"

--- a/scripts/verify_connectome_run.sh
+++ b/scripts/verify_connectome_run.sh
@@ -50,7 +50,14 @@ fi
 # above). So the count is measured against the last-known origin/main in the
 # local object store, which is itself a lower bound — say so rather than imply
 # precision the measurement does not have.
+#
+# FRESHNESS_NOTE carries the same caveat to the ALERT. Writing it only to stderr
+# put it in a log nobody reads, while the Telegram message — the one surface a
+# human actually sees — stayed identical whether the census was today's or 258
+# commits old: a confident P0 judged on an old map, with nothing saying so. The
+# caveat has to travel with the verdict, not sit next to it.
 BEHIND=""
+FRESHNESS_NOTE=""
 if [[ "$BRANCH" == "main" || "$BRANCH" == "deploy/main" ]]; then
     BEHIND="$(git -C "$REPO_ROOT" rev-list --count HEAD..origin/main 2>/dev/null || echo "")"
 fi
@@ -58,8 +65,12 @@ if [[ -z "$BEHIND" ]]; then
     # No origin/main ref locally, or git failed. CANNOT-VERIFY is not CLEAN:
     # never let "I could not check" read as "nothing to report" (W106b).
     echo "$LOG_PREFIX WARN: could not measure checkout distance from origin/main — verdicts below are of UNKNOWN freshness" >&2
+    FRESHNESS_NOTE="⚠️ checkout freshness UNKNOWN (could not compare to origin/main) — these verdicts may be stale
+"
 elif (( BEHIND > 0 )); then
     echo "$LOG_PREFIX WARN: $REPO_ROOT is >= $BEHIND commits behind origin/main — every verdict below is judged against THAT vintage of the census, not today's. Do NOT pull here (sibling-race): refresh the checkout from an interactive session on this machine." >&2
+    FRESHNESS_NOTE="⚠️ judged on a census >= $BEHIND commits behind origin/main — a cured edge can still show here
+"
 fi
 
 # ── python: backend venv first (PyYAML guaranteed), else system if yaml works ─
@@ -84,26 +95,55 @@ if [[ $RC -eq 2 ]]; then
     exit 2
 fi
 
-# ── Telegram alert on REGRESSED (deadman convention — never hardcode token) ──
+# ── alert on REGRESSED — through the ONE gateway, never a bare curl ──────────
+#
+# What the bare curl got wrong, beyond duplicating the token chain:
+#   * it judged DELIVERY BY EXIT CODE. `curl -sS` (no --fail) exits 0 whenever
+#     the server answers at all — including HTTP 200 carrying
+#     {"ok":false,"description":"chat not found"} and 401 after a token
+#     rotation. A REFUSED alert read as a delivered one; the alarm was, by
+#     construction, unable to report its own silence (W104).
+#   * a weekly guardian that stays red re-sends the identical message every
+#     Monday until nobody reads any of them. tg_notify dedups by key.
+# The gateway judges the reply body, spools an unsendable P0 as `p0_unsent` for
+# the next digest, and is contracted never to fail its caller.
 if [[ $RC -eq 1 ]]; then
-    if [[ -f "$HOME/.nuzantara-secrets.env" ]]; then
-        # shellcheck disable=SC1091
-        source "$HOME/.nuzantara-secrets.env"
+    # `head` is a DISPLAY cap. Printing 10 of 23 with nothing saying so is how a
+    # truncated list gets read as a complete one (W97) — so count first, cap
+    # second, and declare the gap when there is one.
+    REGRESSED_ALL="$(printf '%s\n' "$OUT" | grep -a 'REGRESSED ')"
+    N_REGRESSED="$(printf '%s\n' "$REGRESSED_ALL" | grep -ac . || true)"
+    SHOWN=10
+    REGRESSED_LINES="$(printf '%s\n' "$REGRESSED_ALL" | head -"$SHOWN")"
+    TRUNC_NOTE=""
+    if (( N_REGRESSED > SHOWN )); then
+        TRUNC_NOTE=" (showing $SHOWN of $N_REGRESSED)"
     fi
-    TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-${BALIZEROBOT_TOKEN:-}}"
-    TELEGRAM_CHAT_ID="${TELEGRAM_OWNER_CHAT_ID:-${TELEGRAM_ADMIN_CHAT_ID:-${TELEGRAM_CHAT_ID:-1125336968}}}"
-    REGRESSED_LINES="$(printf '%s\n' "$OUT" | grep -a 'REGRESSED ' | head -10)"
-    if [[ -n "$TELEGRAM_BOT_TOKEN" && -n "$TELEGRAM_CHAT_ID" ]]; then
-        MSG="connectome REGRESSED on $(hostname -s) $(date '+%Y-%m-%d %H:%M')
-${REGRESSED_LINES}
+
+    MSG="connectome REGRESSED on $(hostname -s) $(date '+%Y-%m-%d %H:%M')${TRUNC_NOTE}
+${FRESHNESS_NOTE}${REGRESSED_LINES}
 state: ~/.agent/decisions/state/verify_connectome.json"
-        curl -sS -m 15 -X POST \
-            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            -d "chat_id=${TELEGRAM_CHAT_ID}" \
-            --data-urlencode "text=${MSG}" >/dev/null \
-            || echo "$LOG_PREFIX WARN: telegram send failed" >&2
+
+    # The alarm must not run on the interpreter whose breakage it may have to
+    # report: PYBIN above can BE the venv under test, and resolving `python3`
+    # from PATH after touching it is how an alarm inherits the failure mode of
+    # the thing it reports (W108). Absolute, system-first, stdlib is all the
+    # gateway needs.
+    NOTIFY_PY=""
+    for _cand in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+        if [[ -x "$_cand" ]]; then NOTIFY_PY="$_cand"; break; fi
+    done
+    NOTIFY="$REPO_ROOT/scripts/tg_notify.py"
+
+    if [[ -z "$NOTIFY_PY" || ! -f "$NOTIFY" ]]; then
+        # Armed to nothing is worse than unarmed if it is silent about it (W81):
+        # say WHICH half is missing, and put the alert in the log at least.
+        echo "$LOG_PREFIX WARN: REGRESSED but the alert gateway is unusable (python3=${NOTIFY_PY:-NOT-FOUND} gateway=$NOTIFY) — log-only below" >&2
+        printf '%s\n' "$MSG" >&2
     else
-        echo "$LOG_PREFIX WARN: REGRESSED but no TELEGRAM_BOT_TOKEN — log-only" >&2
+        "$NOTIFY_PY" "$NOTIFY" --tier p0 --source verify-connectome \
+            --dedup-key "connectome-regressed-$(hostname -s)" "$MSG" \
+            || echo "$LOG_PREFIX WARN: tg_notify exited non-zero, which its contract forbids — treat the alert as possibly lost" >&2
     fi
 fi
 


### PR DESCRIPTION
Earlier today #3434 taught this wrapper to notice that its checkout can be
behind origin/main. It wrote that on stderr — and stopped there. The one
surface a human actually reads, the Telegram P0, went out identical whether
the census was today's or 258 commits old: a confident verdict on an old map
with nothing saying so. Half the defect, cured; the half that reaches a person,
untouched.

Three ways this alert could mislead its only reader, all now closed:

1. FRESHNESS. The caveat travels WITH the verdict (FRESHNESS_NOTE in the message
   body), not next to it. Both non-clean states are carried: "behind by >= N"
   and "freshness UNKNOWN" — because could-not-check is not clean (W106b).
   This matters most on M5, whose checkout is stale BY DESIGN: pulling it races
   ~45 live worktrees, so the weekly run will keep judging against an old census
   forever. That is acceptable only if the alert says so.

2. TRUNCATION. `head -10` is a display cap. Ten of twenty-three regressions,
   printed as a bare list, reads as the complete set — the exact shape of W97.
   Now counted first, capped second, and the gap declared: "showing 10 of 23".

3. DELIVERY. The bare `curl -sS` judged its own delivery BY EXIT CODE, which is
   0 whenever the server answers at all — including HTTP 200 carrying
   {"ok":false,"description":"chat not found"} and 401 after a token rotation.
   The alarm was, by construction, unable to report its own silence (W104). The
   send now goes through scripts/tg_notify.py, which judges the reply body,
   spools an unsendable P0 as p0_unsent, and dedups — so a guardian that stays
   red on a Monday stops re-sending the identical message until nobody reads
   any of them. This removes the file from infra/tg-gateway/grandfathered.json:
   the register drops 155 -> 154, which is the only direction its lint allows.

The gateway is invoked with an ABSOLUTE interpreter, never `python3` from PATH:
PYBIN above can be the very venv under test, and an alarm that runs on the
interpreter whose breakage it must report shares the failure mode of the thing
it reports (W108). If either half is missing — no absolute python3, or no
tg_notify.py — it says WHICH half and prints the alert body to the log, because
armed-to-nothing in silence is worse than unarmed (W81).

ARMED, not just written: no workflow named verify_connectome at all, so the
guardian of the guardians had zero CI coverage while carrying a P0 path. The new
corpus runs in immune-enforcement's `antidotes` job (a required context) and the
two files are added to its sentinel path list, so it wakes on the only diffs
that could violate it.

scripts/tests/test_connectome_alert_honesty.sh — six cases, guilt AND innocence
on each property, executed against the REAL wrapper in a fake world (fake repo
at a chosen distance from origin/main, fake verifier, fake gateway recorder,
fake curl on PATH, fake HOME so nothing touches real state). Nothing asserts
that the script CONTAINS a string. Mutation-verified: dropping FRESHNESS_NOTE
reddens freshness/guilt, dropping TRUNC_NOTE reddens truncation/guilt, and
restoring the bare curl reddens the delivery case — restore green 6/6.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>