### PR TITLE
fix(portal): the footer "Terms of Service" link points at a soft-404

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/layout.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/layout.tsx
@@ -270,8 +270,16 @@ export default function PortalLayout({
                 Privacy Policy
               </a>
               <span className="mx-2">·</span>
+              {/* `/terms` has no route of its own: the top-level blog catch-all
+                  `(blog)/[category]` swallows it and answers HTTP 200 with a category
+                  page titled "Terms Insights", so a status code cannot reveal the
+                  breakage — only the rendered content can. `/v2/terms` IS the real
+                  general Terms of Service (title "Terms of Service | Bali Zero",
+                  governing-law text, verified live). `/privacy` above needs no such
+                  target because `app/privacy/page.tsx` exists; `app/terms/page.tsx`
+                  was simply never created, and that asymmetry is the whole defect. */}
               <a
-                href="/terms"
+                href="/v2/terms"
                 className="hover:underline"
                 style={{ color: "var(--text-secondary)" }}
               >


### PR DESCRIPTION
Follow-up to #3472, which merged at 10:24 today — so this defect is **live for authenticated clients right now**. `/privacy` is correct; `/terms` is not a route at all.

## Measured live, with a control experiment

A status code cannot show this, so the control line is the point:

```
/privacy                    HTTP 200  <title>Privacy Policy | Bali Zero</title>
/terms                      HTTP 200  <title>Terms Insights | Bali Zero</title>
/zzz-not-a-real-category    HTTP 200  <title>Zzz-not-a-real-category Insights | Bali Zero</title>
```

An obviously nonexistent path answers **200** with the same templated title. `/terms` is being absorbed by the top-level blog catch-all `(blog)/[category]`, so a client clicking "Terms of Service" lands on a blog category listing.

There is no `apps/mouth/src/app/terms/page.tsx` — only `visa/terms` and `v2/terms`. `app/privacy/page.tsx` **does** exist, and that asymmetry is the whole defect: whoever added the general top-level privacy page never added the terms one.

## The fix, and why this target

Retargeted to `/v2/terms`, verified live **before** pointing anything at it: HTTP 200, `<title>Terms of Service | Bali Zero</title>`, contains governing-law text. It is the general Terms — not the visa-scoped page at `/visa/terms`, whose title is literally "Terms of Service — Bali Zero — Visa".

**Deliberately NOT done here:** authoring `app/terms/page.tsx`. That means writing or relocating legal copy, which is a business decision and not mine to make. This change makes the live link true today without inventing terms. If a portal-scoped ToS is wanted at a top-level URL, that is a separate, content-owning change.

## Verification

- `tsc --noEmit` over `apps/mouth` passed in the pre-commit (the comment is a JSX `{/* */}` block in children position, not `//` inside the opening tag — I moved it after checking rather than assuming the latter parses).
- `prettier --check` clean.
- Full pre-push gate green.
- One file, one attribute changed, plus the comment that explains why a future reader must not "tidy" it back to `/terms`.

## Filed separately, because it is much larger than this link

Every unknown top-level path on the public site returns **200**. Any link checker, uptime monitor, or QA step that judges a page by status code is therefore blind to every broken first-level link on the site. The candidate cure is `notFound()` in `(blog)/[category]` when the segment is not one of its own declared categories — but that turns todays soft-404s into hard-404s, so it needs a sweep of existing top-level hrefs first. Not bundled here.