### PR TITLE
fix(ci): the armed ignore-step was inert on its main case — the fetch fails in Vercel builds

### DIFF
--- a/scripts/ci/vercel_should_build.sh
+++ b/scripts/ci/vercel_should_build.sh
@@ -74,20 +74,67 @@ BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
 log() { printf 'should-build: %s\n' "$1" >&2; }
 
 if [ -z "$BASE" ]; then
-  # No previous deployment on this ref.
+  # No previous deployment on this ref — this is the case that matters. Measured on the real
+  # billing data, first deployments are 89% of the waste: most PRs here are one or two commits
+  # on a fresh branch, so `VERCEL_GIT_PREVIOUS_SHA` is empty and there is nothing to diff against.
+  #
+  # The first version of this block went straight to `git fetch origin main` and, when that
+  # failed, built. Armed on 2026-07-29 it turned out to fail EVERY time in Vercel's build
+  # container — `should-build: cannot fetch main -> BUILD (fail-open)` — so the entire
+  # first-deployment optimisation never fired and the projected saving was not being collected.
+  # The guard was safe (it built too much, never too little) but effectively inert on its main case.
+  #
+  # Worse, the reason was unknowable: the fetch's stderr went to /dev/null, so the log said
+  # "cannot fetch" and nothing else. A fail-open branch that does not say WHY it opened cannot
+  # be repaired from its own evidence. So: cheapest-first resolution, each path announcing
+  # itself, and the fetch's actual error surfaced.
   if [ "$REF" = "$PROD_BRANCH" ]; then
     log "production branch with no previous deployment -> BUILD (never risk a stale production)"
     exit 1
   fi
-  if ! git fetch --no-tags --depth=200 origin "$PROD_BRANCH" >/dev/null 2>&1; then
-    log "cannot fetch $PROD_BRANCH -> BUILD (fail-open)"
-    exit 1
+
+  # (1) The merge queue puts the BASE COMMIT in the ref name:
+  #     gh-readonly-queue/<base-branch>/pr-<n>-<base-sha>
+  # That is exact, needs no network, and covers every queue deployment. Only trust it if the
+  # object is actually present in this clone.
+  case "$REF" in
+    gh-readonly-queue/*)
+      cand=${REF##*-}
+      if [ ${#cand} -eq 40 ] && git cat-file -e "${cand}^{commit}" 2>/dev/null; then
+        BASE=$cand
+        log "queue ref carries its base -> ${BASE:0:9} (no network)"
+      fi
+      ;;
+  esac
+
+  # (2) A remote-tracking main already in the clone.
+  if [ -z "$BASE" ] && git rev-parse --verify --quiet "refs/remotes/origin/$PROD_BRANCH" >/dev/null 2>&1; then
+    if BASE=$(git merge-base "origin/$PROD_BRANCH" HEAD 2>/dev/null) && [ -n "$BASE" ]; then
+      log "origin/$PROD_BRANCH present -> merge-base ${BASE:0:9} (no network)"
+    else
+      BASE=
+    fi
   fi
-  if ! BASE=$(git merge-base FETCH_HEAD HEAD 2>/dev/null) || [ -z "$BASE" ]; then
-    log "no merge-base with $PROD_BRANCH (shallow clone?) -> BUILD (fail-open)"
-    exit 1
+
+  # (3) Only now pay for the network — and keep the error, which is the whole point.
+  if [ -z "$BASE" ]; then
+    if fetch_err=$(git fetch --no-tags --depth=200 origin "$PROD_BRANCH" 2>&1); then
+      if BASE=$(git merge-base FETCH_HEAD HEAD 2>/dev/null) && [ -n "$BASE" ]; then
+        log "fetched $PROD_BRANCH -> merge-base ${BASE:0:9}"
+      else
+        BASE=
+        log "fetched $PROD_BRANCH but no merge-base (shallow clone?) -> BUILD (fail-open)"
+        exit 1
+      fi
+    else
+      # One line, truncated: enough to diagnose auth vs network vs missing remote, without
+      # dumping a wall of git output into every build log.
+      log "cannot fetch $PROD_BRANCH -> BUILD (fail-open). git said: $(printf '%s' "$fetch_err" | tr '\n' ' ' | cut -c1-200)"
+      exit 1
+    fi
   fi
-  log "first deployment of '$REF' -> comparing against merge-base ${BASE:0:9}"
+
+  log "first deployment of '$REF' -> base ${BASE:0:9}"
 fi
 
 HEAD_SHA=$(git rev-parse HEAD 2>/dev/null) || { log "cannot resolve HEAD -> BUILD"; exit 1; }

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -24,6 +24,12 @@
 #     way to make grep itself error. The branch is written fail-open and reviewed, not proven.
 #   * pointer reverted to a bare invocation  -> 4 fail, every one as `rc=127 (DEPLOYMENT ERROR)`.
 #     That IS the 2026-07-29 incident, reproduced. See scripts/ci/vercel_ignore_build_step.sh.
+#   * queue-ref base resolution removed     -> 1 fails.  Worth recording HOW: written naively these
+#     cases passed with that whole path deleted, because the origin/main path resolved them —
+#     three tests that proved nothing. They only bite now because the block deletes the tracking
+#     ref and breaks the remote first, so a SKIP can come from nowhere else. A new path needs its
+#     OTHER routes removed, or the corpus measures the fallback instead.
+#   * origin/main base resolution removed   -> 1 fails.
 #   * `git init` dropped from the pointer sandbox -> 4 fail as "sandbox leaked". Worth stating
 #     why that check exists at all: setting TMPDIR inside the repo does NOT trip it, because each
 #     sandbox runs its own `git init` and therefore is its own toplevel. So the corpus cannot
@@ -113,13 +119,58 @@ VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$MAIN_TIP" \
   run BUILD "main against its own tip (base == HEAD)"
 
 echo
-echo "=== FAIL-OPEN: anything unresolvable builds"
-git -C "$WORK" checkout -q -b weird/norem main
-commit "docs/x.md" "docs only, but the remote is unreachable"
+echo "=== OFFLINE BASE RESOLUTION (added 2026-07-30 after the armed guard proved inert)"
+# The first version fetched origin/main and, when the fetch failed, built. Armed in production it
+# failed EVERY time — `cannot fetch main -> BUILD (fail-open)` in every first deployment — so the
+# 89%-of-waste case never fired. These cases pin the two network-free paths that replaced it.
+
+# (1) The merge queue encodes the base commit in the ref: gh-readonly-queue/main/pr-<n>-<base-sha>.
+#
+# ISOLATED ON PURPOSE. Written naively these three cases passed with the queue path deleted —
+# path (2) resolved them and the mutation showed 0 failures, i.e. they tested nothing. So the
+# other two routes are removed for this block: no origin/main tracking ref, unreachable remote.
+# A SKIP here can only come from the ref name.
+git -C "$WORK" update-ref -d refs/remotes/origin/main
 git -C "$WORK" remote set-url origin "$ROOT/does-not-exist.git"
-VERCEL_GIT_COMMIT_REF=weird/norem VERCEL_GIT_PREVIOUS_SHA= \
-  run BUILD "unreachable origin (docs-only, yet still builds)"
+
+git -C "$WORK" checkout -q -b docs/queued main
+commit "docs/queued.md" "docs only, deployed through the merge queue"
+VERCEL_GIT_COMMIT_REF="gh-readonly-queue/main/pr-4242-$MAIN_TIP" VERCEL_GIT_PREVIOUS_SHA= \
+  run SKIP "queue ref carries its base sha — docs-only skips with NO network"
+
+git -C "$WORK" checkout -q -b feat/queued main
+commit "apps/mouth/app/queued.tsx" "frontend, through the merge queue"
+VERCEL_GIT_COMMIT_REF="gh-readonly-queue/main/pr-4243-$MAIN_TIP" VERCEL_GIT_PREVIOUS_SHA= \
+  run BUILD "same path, frontend delta — still builds (guilt)"
+
+# A queue ref whose trailing sha is NOT in this clone must not be trusted into a skip.
+VERCEL_GIT_COMMIT_REF="gh-readonly-queue/main/pr-4244-deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" \
+VERCEL_GIT_PREVIOUS_SHA= \
+  run BUILD "queue ref naming a sha this clone does not have -> falls through"
+
 git -C "$WORK" remote set-url origin "$UPSTREAM"
+git -C "$WORK" fetch -q origin main:refs/remotes/origin/main
+
+# (2) A remote-tracking origin/main already in the clone resolves offline. A STALE one is safe by
+# direction: being behind moves the merge-base EARLIER, which widens the diff and biases to BUILD.
+git -C "$WORK" checkout -q -b docs/offline main
+commit "docs/offline.md" "docs only, remote unreachable but origin/main is local"
+git -C "$WORK" remote set-url origin "$ROOT/does-not-exist.git"
+VERCEL_GIT_COMMIT_REF=docs/offline VERCEL_GIT_PREVIOUS_SHA= \
+  run SKIP "unreachable remote but origin/main present -> resolved offline"
+
+echo
+echo "=== FAIL-OPEN: genuinely unresolvable still builds"
+# The real unresolvable case, which the old "unreachable origin" test only appeared to cover: no
+# remote-tracking ref AND no reachable remote. Without this, dropping BOTH offline paths would
+# leave the suite green.
+git -C "$WORK" checkout -q -b weird/norem main
+commit "docs/x.md" "docs only, and nothing can establish a base"
+git -C "$WORK" update-ref -d refs/remotes/origin/main
+VERCEL_GIT_COMMIT_REF=weird/norem VERCEL_GIT_PREVIOUS_SHA= \
+  run BUILD "no origin/main ref and unreachable remote (docs-only, yet builds)"
+git -C "$WORK" remote set-url origin "$UPSTREAM"
+git -C "$WORK" fetch -q origin main:refs/remotes/origin/main
 
 VERCEL_GIT_COMMIT_REF=docs/ledger VERCEL_GIT_PREVIOUS_SHA=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef \
   run BUILD "previous SHA that git does not know"


### PR DESCRIPTION
The ignore step armed by #3441 was **measured in production and found inert on the case it exists for**.

## What the build logs say

Not inferred from the setting — read from two real deployments after arming:

| deployment | guard line |
|---|---|
| `main`, repeat deploy | `should-build: no frontend path in 6 changed file(s) -> SKIP` ✅ |
| any **first** deployment of a branch | `should-build: cannot fetch main -> BUILD (fail-open)` ❌ |

`git fetch --no-tags --depth=200 origin main` fails inside Vercel's build container, every time. So
the guard only skipped where `VERCEL_GIT_PREVIOUS_SHA` was already set, and fell open on every first
deployment — which is where the waste is: across 970 PR branches, **89% of first deploys built vs 59%
of later ones**, and most PRs here are one or two commits on a fresh branch.

It was safe the whole time — it built too much, never too little — but the projected ~12,000
build-minutes/month were not being collected. Correcting that claim is the point of this PR.

## The design error underneath

The fetch's stderr went to `/dev/null`. The log could therefore say `cannot fetch` and nothing more.
**A fail-open branch that does not say why it opened cannot be repaired from its own evidence** — I
had to reach for a second deployment's log to even learn which branch had been taken.

## The fix: cheapest-first, and every path announces itself

1. **The merge queue carries its own base**: `gh-readonly-queue/main/pr-<n>-<base-sha>`. Exact, zero
   network, covers every queue deployment. Trusted only if the object is present in the clone.
2. **A remote-tracking `origin/main`** already in the clone → merge-base offline. A *stale* one is
   safe by direction: being behind moves the base earlier, which widens the diff and biases to BUILD.
3. **Only then the fetch** — with its error captured and logged, truncated to one line, so the next
   failure is diagnosable (auth vs network vs missing remote) instead of mute.
4. Still unresolvable → BUILD, exactly as before.

## Corpus: 20 → 24 cases, and two results recorded rather than smoothed over

- The old *"unreachable origin still builds"* case now SKIPs, because path 2 resolves it offline.
  I did **not** relax the assertion to match my change. It is replaced by the genuinely unresolvable
  case — no tracking ref **and** no reachable remote — without which deleting *both* offline paths
  would leave the suite green, plus a case that pins the offline resolution itself.
- The queue-ref cases, written naively, **passed with the queue path deleted**: path 2 was answering
  them, so all three tested nothing. They now delete the tracking ref and break the remote first, and
  fail under mutation as they should. A new path needs its other routes removed, or the corpus
  measures the fallback instead of the thing you wrote.

Mutation-verified: queue-ref path removed → 1 fails; origin/main path removed → 1 fails; exit
contract inverted → 7 fail; pointer reverted to a bare invocation → 4 fail as
`rc=127 (DEPLOYMENT ERROR)`, the 2026-07-29 incident reproduced.

## After this lands

Nothing to arm — the project already points at this script. The proof is the next first-deployment
log: it must name path 1 or 2 instead of `cannot fetch`. If it still cannot resolve, the new log line
will say what git actually reported, which is the thing that was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
