### PR TITLE
fix(mouth): add top-level /terms page, killing the blog catch-all soft-404

### DIFF
--- a/apps/mouth/src/app/terms/page.tsx
+++ b/apps/mouth/src/app/terms/page.tsx
@@ -1,0 +1,182 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "The terms governing Bali Zero's visa, company setup, tax, and property services in Indonesia — engagement, fees, refunds, AI disclaimer, and governing law.",
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <div
+      className="min-h-screen"
+      style={{
+        background: "var(--bz-base, #0c0c0e)",
+        color: "var(--bz-text-1, #f5f5f5)",
+      }}
+    >
+      <div className="max-w-3xl mx-auto px-6 py-16 space-y-10">
+        <header>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Terms of Service
+          </h1>
+          <p
+            className="mt-2 text-sm"
+            style={{ color: "var(--bz-text-2, #a0a0a0)" }}
+          >
+            Last updated: April 2026
+          </p>
+        </header>
+
+        <section className="space-y-4">
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            1. Services
+          </h2>
+          <p>
+            Bali Zero provides visa processing, company setup (PT PMA), tax
+            compliance, and property due diligence services in Indonesia. All
+            services are delivered by licensed Indonesian professionals. Our AI
+            assistant (Zantara) provides information and drafts; licensed staff
+            review and sign all filings.
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            2. Engagement
+          </h2>
+          <p>
+            A service engagement begins when you confirm a scope of work and
+            make payment. Timelines are estimates; Indonesian government
+            processing times are outside our control. We commit to keeping you
+            informed at every step via your chosen channel (WhatsApp, email,
+            Telegram).
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            3. Fees and Payments
+          </h2>
+          <ul className="list-disc ml-6 space-y-2 text-sm">
+            <li>
+              All fees are listed on our service pages in USD. Government fees
+              are passed through at cost.
+            </li>
+            <li>
+              Payment is due before filing unless otherwise agreed in writing.
+            </li>
+            <li>
+              <strong>Refund policy:</strong> if we cannot deliver the service
+              due to our error, we refund the service fee in full. Government
+              fees paid on your behalf are non-refundable.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-4">
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            4. Your Responsibilities
+          </h2>
+          <ul className="list-disc ml-6 space-y-1 text-sm">
+            <li>Provide accurate, complete documents and information.</li>
+            <li>Respond to our requests within reasonable timeframes.</li>
+            <li>
+              Comply with Indonesian law — we do not assist with applications
+              that violate regulations.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-4">
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            5. AI Disclaimer
+          </h2>
+          <p>
+            Zantara AI provides information based on Indonesian regulations and
+            our knowledge base. AI-generated content is reviewed by licensed
+            staff before any filing. AI answers are informational, not legal
+            advice. For binding legal opinions, we connect you with our licensed
+            notary or tax consultant.
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            6. Limitation of Liability
+          </h2>
+          <p>
+            Our liability is limited to the fees paid for the specific service
+            in question. We are not liable for delays caused by Indonesian
+            government agencies, incomplete documents from clients, or changes
+            in regulation after filing.
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            7. Governing Law
+          </h2>
+          <p>
+            These terms are governed by the laws of the Republic of Indonesia.
+            Disputes shall be resolved through the Denpasar District Court
+            (Pengadilan Negeri Denpasar).
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+          >
+            8. Contact
+          </h2>
+          <p className="text-sm">
+            <strong>Questions about these terms:</strong>{" "}
+            <a
+              href="mailto:legal@balizero.com"
+              className="underline"
+              style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+            >
+              legal@balizero.com
+            </a>
+          </p>
+          <p className="text-sm">
+            <strong>Privacy and personal data:</strong> see our{" "}
+            <a
+              href="/privacy"
+              className="underline"
+              style={{ color: "var(--bz-accent-warm, #d4845a)" }}
+            >
+              Privacy Policy
+            </a>
+          </p>
+          <p className="text-sm" style={{ color: "var(--bz-text-2, #a0a0a0)" }}>
+            Bali Zero · Bali, Indonesia
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## The defect (measured live, 2026-07-30)

`/terms` had no route of its own, so the `(blog)/[category]` dynamic segment
swallowed it and served the blog listing:

```
https://balizero.com/terms   -> 200  "Terms Insights | Bali Zero"      <- wrong page
https://balizero.com/privacy -> 200  "Privacy Policy | Bali Zero"      <- correct
```

A soft-404: HTTP 200, wrong content, indexable. The portal footer shipped in
#3472 links to `/terms`, so that link landed on the blog listing.

## Why a new page and not a repointed link

Two other URLs carry terms copy, and neither is right for a site-wide footer link:

- `/visa/terms` is scoped to the visa funnel — wrong for a global footer.
- `/v2/terms` is `robots: { index: false }`, a preview-tree page depending on the
  v2 `NavShell`/`Footer`.

Repointing the link would also leave the soft-404 live and indexable. Adding the
missing route fixes both at once.

**Legal text**: the `/v2/terms` copy, ruled authoritative by Zero — it is the
generic one, already titled "Terms of Service". No new legal language was written.
Page structure mirrors the standalone `/privacy` precedent: same `--bz-*` tokens,
same section rhythm, no v2 component dependency, and indexable.

## Verification

Local `next dev --webpack`, guilt **and** innocence:

| route | result |
|---|---|
| `/terms` | 200 · `Terms of Service \| Bali Zero` · h1 correct · governing-law clause present |
| `/regulatory-update` | 200 · `Regulatory-update Insights` — catch-all still matches everything else |
| `/privacy` | 200 · `Privacy Policy` — unchanged |

`tsc --noEmit` clean · prettier clean · `(blog)/[category]` has no
`generateStaticParams`, so a static `terms/` segment simply wins — the same
position `privacy/` already occupies and resolves correctly in production.

## Deliberately not done

Not added to `sitemap.ts`: `/privacy` is not in it either, and an asymmetry
between the two legal pages would be the odd choice, not the fix.