### PR TITLE
fix(mouth): the api client discarded the HTTP status, so consumers guessed it from the message text

### DIFF
--- a/apps/mouth/src/app/(workspace)/process/[id]/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Practice } from "@/lib/api/crm/crm.types";
+import { ApiError } from "@/lib/api/error-handler";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -565,6 +566,31 @@ describe("CaseDetailPage", () => {
     expect(
       screen.getByRole("heading", { name: "KITAS APPLICATION #42" }),
     ).toBeInTheDocument();
+  });
+
+  // Covers the STATUS path: the api client throws ApiError, so this is what the
+  // page actually receives in production. The test below it keeps a plain Error
+  // to cover the fallback for errors that never went through the client.
+  it("maps a 403 ApiError to a user-safe message by status", async () => {
+    mocks.updatePractice.mockRejectedValueOnce(
+      new ApiError("Operation not permitted for this role", 403, {}),
+    );
+    const user = await renderLoaded();
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    const modal = screen.getByRole("heading", { name: "Edit Process #42" })
+      .parentElement?.parentElement as HTMLElement;
+    await user.click(within(modal).getByRole("button", { name: "↑ High" }));
+    await user.click(
+      within(modal).getByRole("button", { name: "Save Changes" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Error",
+        "You do not have permission to update this process.",
+      );
+    });
   });
 
   it("maps authorization errors from edit requests to a user-safe message", async () => {

--- a/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
@@ -23,7 +23,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
 import { toast as sonnerToast } from "sonner";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import type { Practice } from "@/lib/api/crm/crm.types";
 import {
   STATUS_LABELS as STATUS_DROPDOWN_LABELS,
@@ -553,10 +553,14 @@ export default function CaseDetailPage() {
 
       // Check for specific error types and provide user-friendly messages
       let errorMessage = "Failed to update process details.";
+      // Status comes from ApiError.statusCode. The message tests remain only as a
+      // fallback for errors that never went through the api client; a bare
+      // `message.includes("404")` would also fire on a process id containing 404.
       if (err instanceof Error) {
+        const status = err instanceof ApiError ? err.statusCode : undefined;
         if (
-          err.message.includes("401") ||
-          err.message.includes("Unauthorized")
+          status === 401 ||
+          (status === undefined && err.message.includes("Unauthorized"))
         ) {
           errorMessage = "Authentication failed. Please login again.";
           logger.error(
@@ -567,8 +571,8 @@ export default function CaseDetailPage() {
             },
           );
         } else if (
-          err.message.includes("403") ||
-          err.message.includes("Forbidden")
+          status === 403 ||
+          (status === undefined && err.message.includes("Forbidden"))
         ) {
           errorMessage = "You do not have permission to update this process.";
           logger.error("Authorization error - user may not have permission", {
@@ -576,8 +580,8 @@ export default function CaseDetailPage() {
             action: "updateCase",
           });
         } else if (
-          err.message.includes("404") ||
-          err.message.includes("Not Found")
+          status === 404 ||
+          (status === undefined && err.message.includes("Not Found"))
         ) {
           errorMessage = "Process not found. It may have been deleted.";
           logger.error("Case not found - may have been deleted", {

--- a/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/process/[id]/page.tsx
@@ -23,7 +23,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
 import { toast as sonnerToast } from "sonner";
-import { api, ApiError } from "@/lib/api";
+import { api } from "@/lib/api";
+// Imported from its own module, not the "@/lib/api" barrel: several suites
+// replace that barrel with a hand-written `vi.mock` factory listing only the
+// `api` methods they need, so pulling ApiError through it makes the class
+// `undefined` under test and `instanceof` throws inside the catch block.
+import { ApiError } from "@/lib/api/error-handler";
 import type { Practice } from "@/lib/api/crm/crm.types";
 import {
   STATUS_LABELS as STATUS_DROPDOWN_LABELS,

--- a/apps/mouth/src/app/portal/(authenticated)/layout.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/layout.tsx
@@ -7,7 +7,7 @@ import { AppSidebar } from "@/components/workspace/AppSidebar";
 import { PortalHeader } from "@/components/portal/PortalHeader";
 import { PortalErrorBoundary } from "@/components/portal/PortalErrorBoundary";
 import { ToastProvider } from "@/components/ui/toast";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import { portalNavigation } from "@/types/navigation";
 import { AdminImpersonationProvider } from "@/contexts/AdminImpersonationContext";
@@ -98,7 +98,10 @@ export default function PortalLayout({
         try {
           await loadUserProfile();
         } catch (error) {
-          if (error instanceof Error && error.message.includes("401")) {
+          // Branch on the HTTP status, never on the message text. This read
+          // `error.message.includes("401")`, which is also true of "Practice
+          // 4012 not found" — so a 404 could sign a client out of the portal.
+          if (error instanceof ApiError && error.statusCode === 401) {
             router.push("/portal/login");
             return;
           }

--- a/apps/mouth/src/app/portal/(authenticated)/layout.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/layout.tsx
@@ -7,7 +7,10 @@ import { AppSidebar } from "@/components/workspace/AppSidebar";
 import { PortalHeader } from "@/components/portal/PortalHeader";
 import { PortalErrorBoundary } from "@/components/portal/PortalErrorBoundary";
 import { ToastProvider } from "@/components/ui/toast";
-import { api, ApiError } from "@/lib/api";
+import { api } from "@/lib/api";
+// From its own module, not the barrel: layout.test.tsx replaces "@/lib/api"
+// with a partial vi.mock, which would make ApiError undefined under test.
+import { ApiError } from "@/lib/api/error-handler";
 import { logger } from "@/lib/logger";
 import { portalNavigation } from "@/types/navigation";
 import { AdminImpersonationProvider } from "@/contexts/AdminImpersonationContext";

--- a/apps/mouth/src/hooks/useDashboardData.ts
+++ b/apps/mouth/src/hooks/useDashboardData.ts
@@ -8,6 +8,7 @@ import {
   dashboardApi,
   type DashboardData,
 } from "@/lib/api/dashboard/dashboard.api";
+import { ApiError } from "@/lib/api/error-handler";
 import { logger } from "@/lib/logger";
 
 const DASHBOARD_QUERY_ROOTS = new Set([
@@ -63,19 +64,24 @@ export function useDashboardData(identity: string) {
           err instanceof Error ? err : new Error(String(err)),
         );
 
-        // Check for specific error types
+        // Check for specific error types.
+        // Status comes from ApiError.statusCode; the message tests below stay only
+        // as a fallback for errors that never passed through the api client (raw
+        // fetch/network). They must not be the primary signal: "401"/"403" as a
+        // substring also matches ids and amounts inside an unrelated message.
         if (err instanceof Error) {
+          const status = err instanceof ApiError ? err.statusCode : undefined;
           if (
-            err.message.includes("401") ||
-            err.message.includes("Unauthorized")
+            status === 401 ||
+            (status === undefined && err.message.includes("Unauthorized"))
           ) {
             logger.warn("Authentication error - user may need to login again", {
               component: "useDashboardData",
               action: "getDashboardSummary",
             });
           } else if (
-            err.message.includes("403") ||
-            err.message.includes("Forbidden")
+            status === 403 ||
+            (status === undefined && err.message.includes("Forbidden"))
           ) {
             logger.warn("Authorization error - user may not have permission", {
               component: "useDashboardData",

--- a/apps/mouth/src/lib/api/__tests__/api-error-status.test.ts
+++ b/apps/mouth/src/lib/api/__tests__/api-error-status.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The api client used to throw a bare `Error`, discarding `response.status`.
+ * Every consumer that needed to branch on 401/403/404 therefore sniffed
+ * substrings out of `error.message` — and a substring is not a status:
+ * `"Practice 4012 not found".includes("401")` is TRUE.
+ *
+ * These tests are the corpus for that fix, in the guilt/innocence shape this
+ * repo requires of any guard:
+ *   GUILT     — a real 401/403/404 is recognised by status.
+ *   INNOCENCE — a 404 whose message merely CONTAINS "401" is not read as auth,
+ *               and a 500 whose detail mentions 404 is not read as not-found.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { ApiError } from "../error-handler";
+import { ApiClientBase } from "../client";
+
+vi.mock("@/lib/utils/storage", () => ({
+  safeStorage: {
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(() => true),
+    removeItem: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+/** Minimal stand-in for the shape client.ts throws. */
+function thrownByClient(
+  status: number,
+  detail: string,
+  extra: Record<string, unknown> = {},
+) {
+  const body = { detail, ...extra };
+  return new ApiError(detail || `HTTP ${status}`, status, body);
+}
+
+describe("ApiError carries the HTTP status", () => {
+  it("GUILT: a 401 is a 401 by status, not by text", () => {
+    const err = thrownByClient(401, "Session expired. Please login again.");
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.statusCode).toBe(401);
+  });
+
+  it("stays an Error, so pre-existing consumers do not break", () => {
+    const err = thrownByClient(500, "boom");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("boom");
+    expect(err.name).toBe("ApiError");
+  });
+
+  it("lifts detail and code out of the body (what the old interface promised)", () => {
+    const err = thrownByClient(429, "Rate limited", { code: "QUOTA_EXCEEDED" });
+    expect(err.detail).toBe("Rate limited");
+    expect(err.code).toBe("QUOTA_EXCEEDED");
+    expect(err.statusCode).toBe(429);
+  });
+
+  it("keeps INVALID_METHOD's message while now also carrying 405", () => {
+    const err = new ApiError("INVALID_METHOD", 405, {});
+    expect(err.message).toBe("INVALID_METHOD");
+    expect(err.statusCode).toBe(405);
+  });
+});
+
+describe("INNOCENCE: the substring trap that motivated the fix", () => {
+  const notFoundWith401InText = thrownByClient(404, "Practice 4012 not found");
+
+  it("the old substring test WOULD have misfired — proving the trap is real", () => {
+    // This asserts the defect, not the cure: if this ever stops being true the
+    // test above it is no longer guarding anything meaningful.
+    expect(notFoundWith401InText.message.includes("401")).toBe(true);
+  });
+
+  it("status-based branching does NOT read it as auth", () => {
+    expect(notFoundWith401InText.statusCode).toBe(404);
+    expect(notFoundWith401InText.statusCode === 401).toBe(false);
+  });
+
+  it("a 5xx that mentions 404 in its detail is not not-found", () => {
+    const upstream = thrownByClient(502, "upstream returned 404 from OSS");
+    expect(upstream.message.includes("404")).toBe(true); // the trap
+    expect(upstream.statusCode).toBe(502); // the cure
+    expect(upstream.statusCode === 404).toBe(false);
+  });
+});
+
+describe("ApiClientBase.request throws ApiError with the real status", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  /**
+   * Exercises the real client, not a hand-built ApiError, so this goes red if
+   * client.ts ever reverts to `throw new Error(...)`.
+   */
+  it("a 404 whose detail contains '401' surfaces statusCode 404", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Practice 4012 not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new ApiClientBase("https://api.example.com");
+
+    let caught: unknown;
+    try {
+      await client.request("/api/crm/practices/4012");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).statusCode).toBe(404);
+    // The trap, pinned: the old code path would have read this as auth.
+    expect((caught as ApiError).message).toContain("401");
+  });
+
+  it("a 422 keeps its Validation error message AND carries 422", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: [{ loc: ["body", "email"], msg: "invalid", type: "value" }],
+        }),
+        { status: 422, headers: { "content-type": "application/json" } },
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new ApiClientBase("https://api.example.com");
+
+    let caught: unknown;
+    try {
+      await client.request("/api/crm/clients");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).statusCode).toBe(422);
+    expect((caught as ApiError).message).toContain("Validation error");
+  });
+});

--- a/apps/mouth/src/lib/api/client.ts
+++ b/apps/mouth/src/lib/api/client.ts
@@ -3,6 +3,7 @@ import type { IApiClient, ApiRequestOptions } from "./types/api-client.types";
 import { safeStorage } from "@/lib/utils/storage";
 import { isTokenExpired } from "@/lib/utils/token";
 import { logger } from "@/lib/logger";
+import { ApiError } from "./error-handler";
 
 /** FastAPI validation error structure */
 interface FastAPIValidationError {
@@ -348,7 +349,14 @@ export class ApiClientBase implements IApiClient {
         const error = await response
           .json()
           .catch(() => ({ detail: "Authentication required" }));
-        throw new Error(error.detail || "Session expired. Please login again.");
+        // Messages below are unchanged on purpose: ApiError extends Error, so
+        // every existing `instanceof Error` / `.message` consumer keeps working.
+        // What is new is `statusCode` — the thing callers actually need.
+        throw new ApiError(
+          error.detail || "Session expired. Please login again.",
+          response.status,
+          error,
+        );
       }
 
       // Allow 204 as success even if ok is false (defensive)
@@ -365,15 +373,23 @@ export class ApiClientBase implements IApiClient {
               return `${field}: ${err.msg}`;
             })
             .join(", ");
-          throw new Error(`Validation error: ${validationErrors}`);
+          throw new ApiError(
+            `Validation error: ${validationErrors}`,
+            response.status,
+            error,
+          );
         }
 
         // Handle 405 Method Not Allowed - convert to INVALID_METHOD for consistency
         if (response.status === 405) {
-          throw new Error("INVALID_METHOD");
+          throw new ApiError("INVALID_METHOD", response.status, error);
         }
 
-        throw new Error(error.detail || `HTTP ${response.status}`);
+        throw new ApiError(
+          error.detail || `HTTP ${response.status}`,
+          response.status,
+          error,
+        );
       }
 
       // Handle empty responses (204 No Content, etc.)

--- a/apps/mouth/src/lib/api/crm/crm.api.test.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { CrmApi } from "./crm.api";
 import { ApiClientBase } from "../client";
+import { ApiError } from "../error-handler";
 import type { Practice, Interaction, RenewalAlert } from "./crm.types";
 
 describe("CrmApi", () => {
@@ -443,8 +444,14 @@ describe("CrmApi", () => {
         expect(result).toEqual(mockClient);
       });
 
+      // These two now use ApiError with a real status, because that is what the
+      // only IApiClient implementation (ApiClientBase) throws. They previously
+      // used plain Errors whose MESSAGE contained "404"/"500", which is the
+      // substring contract this method no longer relies on.
       it("should return null when client not found", async () => {
-        const error = new Error("404 Not Found");
+        const error = new ApiError("Client not found", 404, {
+          detail: "Client not found",
+        });
         (crmApi as any).client.request.mockRejectedValue(error);
 
         const result = await crmApi.getClientByEmail("notfound@example.com");
@@ -452,13 +459,25 @@ describe("CrmApi", () => {
         expect(result).toBeNull();
       });
 
+      it("does NOT return null for a 5xx whose detail mentions 404", async () => {
+        // Innocence: the old `message.includes("404")` test read this as
+        // not-found and returned null, reporting "no such client" for a service
+        // failure. It must propagate.
+        const error = new ApiError("upstream returned 404 from OSS", 502, {});
+        (crmApi as any).client.request.mockRejectedValue(error);
+
+        await expect(
+          crmApi.getClientByEmail("someone@example.com"),
+        ).rejects.toThrow("upstream returned 404 from OSS");
+      });
+
       it("should throw error for non-404 errors", async () => {
-        const error = new Error("500 Server Error");
+        const error = new ApiError("Server Error", 500, {});
         (crmApi as any).client.request.mockRejectedValue(error);
 
         await expect(
           crmApi.getClientByEmail("error@example.com"),
-        ).rejects.toThrow("500 Server Error");
+        ).rejects.toThrow("Server Error");
       });
     });
   });

--- a/apps/mouth/src/lib/api/crm/crm.api.ts
+++ b/apps/mouth/src/lib/api/crm/crm.api.ts
@@ -1,4 +1,5 @@
 import type { IApiClient } from "../types/api-client.types";
+import { ApiError } from "../error-handler";
 import type {
   Practice,
   Interaction,
@@ -497,8 +498,12 @@ export class CrmApi {
         `/api/crm/clients/by-email/${encodeURIComponent(email)}`,
       );
     } catch (error) {
-      // 404 means client not found - return null instead of throwing
-      if (error instanceof Error && error.message.includes("404")) {
+      // 404 means client not found - return null instead of throwing.
+      // Must be the STATUS, not the message: `message.includes("404")` also
+      // matches a 5xx whose detail happens to mention 404 (e.g. an upstream
+      // error), and returning null there reports "no such client" for what was
+      // actually a service failure.
+      if (error instanceof ApiError && error.statusCode === 404) {
         return null;
       }
       throw error;

--- a/apps/mouth/src/lib/api/error-handler.ts
+++ b/apps/mouth/src/lib/api/error-handler.ts
@@ -9,6 +9,20 @@ import { createLogger } from "../utils/console";
 const logger = createLogger("API");
 
 export class ApiError extends Error {
+  /**
+   * Backend-supplied `detail` (FastAPI convention) and machine-readable `code`,
+   * lifted out of the response body so callers do not have to re-parse `data`.
+   *
+   * These two fields exist because `lib/api/index.ts` used to declare a SECOND,
+   * competing `ApiError` — a structural interface carrying `detail`/`code` but no
+   * status — while this class carried `statusCode` and was never thrown by
+   * anything. Consumers imported the interface, found no status on it, and fell
+   * back to sniffing substrings out of `error.message`. The two types are now one,
+   * and this class is a superset of what that interface promised.
+   */
+  readonly detail?: string;
+  readonly code?: string;
+
   constructor(
     message: string,
     public statusCode: number,
@@ -16,6 +30,9 @@ export class ApiError extends Error {
   ) {
     super(message);
     this.name = "ApiError";
+    const body = data as { detail?: unknown; code?: unknown } | undefined;
+    if (typeof body?.detail === "string") this.detail = body.detail;
+    if (typeof body?.code === "string") this.code = body.code;
   }
 }
 

--- a/apps/mouth/src/lib/api/index.ts
+++ b/apps/mouth/src/lib/api/index.ts
@@ -39,12 +39,13 @@ import type {
   InteractionStats,
 } from "./crm/crm.types";
 
-// Re-export ApiError type
-export interface ApiError extends Error {
-  detail?: string;
-  code?: string;
-  message: string;
-}
+// ApiError — the CLASS from ./error-handler, which is what the client actually
+// throws. This used to be a separate structural interface declared right here
+// with `detail`/`code` and no status field, so `catch` blocks that imported it
+// could not branch on 401/403/404 and resorted to `error.message.includes("401")`
+// — a substring test that also fires on "Practice 4012 not found". Read
+// `statusCode` instead. Exported as a value too, so `instanceof ApiError` works.
+export { ApiError } from "./error-handler";
 
 // Export API client interface for type-safe dependency injection
 export type { IApiClient, ApiRequestOptions } from "./types/api-client.types";


### PR DESCRIPTION
Closes the root cause that makes #3474's headline capability dead code.

## The defect

`ApiClientBase.request` threw a bare `Error`, dropping `response.status`. Every caller that needed to branch on 401/403/404 therefore sniffed substrings out of `error.message`. A substring is not a status:

```js
"Practice 4012 not found".includes("401")   // true
```

Two consequences that reach clients:

| site | what the substring test did |
|---|---|
| `portal/(authenticated)/layout.tsx` | `message.includes("401")` → a **404 could sign a client out of the portal** |
| `crm.api.ts::getClientByEmail` | `message.includes("404")` → returned `null` ("no such client") for **any 5xx whose detail mentions 404** |

Family #3 (guard-over-match) outside the regexes: judging by FORM where the ENTITY was available and had been thrown away.

## Why nobody just read the status

Two `ApiError` types existed and neither worked:

- the **class** in `error-handler.ts` carried `statusCode` — and was never thrown by anything
- the **interface** declared in `lib/api/index.ts` carried `detail`/`code` and **no status** — and that is the one consumers imported

So a caller that did the right thing (`import { type ApiError }`) found no status on it and fell back to the message. Unified here: the barrel re-exports the class, which now also lifts `detail`/`code` out of the response body, making it a superset of what the interface promised. `instanceof ApiError` works.

## Backward compatibility

Messages are **unchanged at every throw site**, and `ApiError extends Error`. No existing `instanceof Error` / `.message` consumer changes behaviour — including the `INVALID_METHOD` sentinel, which keeps its exact message and now also carries 405. What is new is that `statusCode` is there to read.

Consumers migrated (4 files, 7 sites). The two hooks keep a `status === undefined` fallback on the WORD forms (`"Unauthorized"`/`"Forbidden"`/`"Not Found"`) for errors that never passed through the api client; the **digit substrings are gone everywhere**.

## Verification

Guilt **and** innocence, per the guard-conformance discipline:

- **guilt** — a real 401/403/404 is recognised by status; a 404 response whose detail contains `"401"` surfaces `statusCode 404`, exercised through the **real client**, so the test goes red if `client.ts` ever reverts to `throw new Error(...)`
- **innocence** — a 502 mentioning 404 propagates instead of becoming `null`
- **the trap is pinned** (`message.includes("401") === true` asserted explicitly), so the guilt test cannot quietly stop guarding anything
- **mutation-verified** — reverting the generic throw to `new Error(...)` turns the 404 test red (1 failed / 8 passed), and only that one. The 422 branch correctly stayed green because the mutation did not touch it.

Two pre-existing crm tests asserted the OLD contract with plain `Error`s whose message contained `"404"`/`"500"`. Updated to `ApiError` with real statuses — `ApiClientBase` is the only `IApiClient` implementation, so that is what the method actually receives — and the missing innocence case added beside them.

**792 tests / 80 files pass · `tsc --noEmit` clean.**

## Declared limit

This does not itself fix #3474; it removes the reason its `is403` branch can never be reached. That PR still needs its author to consume `statusCode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)