### PR TITLE
fix(seo): unknown top-level paths returned 200 with an invented title

### DIFF
--- a/apps/mouth/src/app/(blog)/[category]/layout.test.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/layout.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * `(blog)/[category]` is top-level `/:something` — a route group contributes
+ * nothing to the URL — so it matches every unmatched single-segment path on
+ * every domain this project serves. It used to render the category page with an
+ * empty article list and return HTTP 200, and `generateMetadata` title-cased
+ * whatever was in the URL ("Zzz-nonsense Insights"). That is an unbounded set of
+ * indexable soft-404s.
+ *
+ * Guilt: junk 404s. Innocence: all six real categories still render.
+ */
+import { describe, expect, it } from "vitest";
+
+import CategoryLayout, { generateMetadata } from "./layout";
+import type { ArticleCategory } from "@/lib/blog/types";
+
+const REAL_CATEGORIES: ArticleCategory[] = [
+  "visas",
+  "business",
+  "taxes",
+  "property",
+  "living",
+  "trends",
+];
+
+// Measured live on 2026-07-30, all returning 200 with an invented title.
+const JUNK = [
+  "zzz-nonsense",
+  "slhs",
+  "cases",
+  "id",
+  "it",
+  "this-path-does-not-exist-4711",
+];
+
+// `hasOwnProperty` rather than `in`: with `in`, every Object.prototype member
+// passes the allow-list and /constructor would render as a category.
+const PROTOTYPE_KEYS = [
+  "constructor",
+  "toString",
+  "hasOwnProperty",
+  "valueOf",
+  "__proto__",
+];
+
+const call = (category: string) =>
+  CategoryLayout({
+    children: "children" as unknown as React.ReactNode,
+    params: Promise.resolve({ category }),
+  });
+
+describe("(blog)/[category] layout: unknown categories must 404, not 200", () => {
+  for (const category of JUNK) {
+    it(`guilt: /${category} calls notFound()`, async () => {
+      await expect(call(category)).rejects.toThrow();
+    });
+  }
+
+  for (const category of PROTOTYPE_KEYS) {
+    it(`guilt: /${category} is not a category just because Object has that key`, async () => {
+      await expect(call(category)).rejects.toThrow();
+    });
+  }
+
+  for (const category of REAL_CATEGORIES) {
+    it(`innocence: /${category} still renders`, async () => {
+      await expect(call(category)).resolves.toBe("children");
+    });
+  }
+
+  it("guilt: metadata for an unknown category is noindex and invents no title", async () => {
+    const meta = await generateMetadata({
+      params: Promise.resolve({ category: "zzz-nonsense" }),
+    });
+    expect(meta.title).toBe("Page not found");
+    expect(meta.robots).toEqual({ index: false, follow: false });
+    // The old behaviour, pinned so it cannot come back.
+    expect(JSON.stringify(meta)).not.toContain("Zzz-nonsense");
+    expect(JSON.stringify(meta)).not.toContain("zzz-nonsense");
+  });
+
+  it("innocence: metadata for a real category keeps its SEO title and canonical", async () => {
+    const meta = await generateMetadata({
+      params: Promise.resolve({ category: "visas" }),
+    });
+    expect(meta.title).toBe("Immigration & Visa Guides Bali 2026");
+    expect(meta.alternates?.canonical).toContain("/visas");
+    expect(meta.robots).toBeUndefined();
+  });
+});

--- a/apps/mouth/src/app/(blog)/[category]/layout.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/layout.tsx
@@ -1,12 +1,22 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { ArticleCategory } from "@/lib/blog/types";
 
 const baseUrl = process.env.NEXT_PUBLIC_PUBLIC_URL || "https://balizero.com";
 
 /**
  * SEO-optimized metadata for each category page.
  * Unique titles, descriptions, and canonicals per category.
+ *
+ * This is also the routing allow-list — see the default export. Typed
+ * `Record<ArticleCategory, …>` rather than `Record<string, …>` on purpose: the
+ * key set and `ArticleCategory` can no longer drift apart without a compile
+ * error, which is what makes it safe to 404 on anything absent from it.
  */
-const CATEGORY_SEO: Record<string, { title: string; description: string }> = {
+const CATEGORY_SEO: Record<
+  ArticleCategory,
+  { title: string; description: string }
+> = {
   visas: {
     title: "Immigration & Visa Guides Bali 2026",
     description:
@@ -17,7 +27,7 @@ const CATEGORY_SEO: Record<string, { title: string; description: string }> = {
     description:
       "Complete guides to PT PMA company setup, KBLI codes, business licenses, OSS registration. Expert advice for foreign entrepreneurs in Bali.",
   },
-  "taxes": {
+  taxes: {
     title: "Indonesia Tax & Legal Compliance Guides 2026",
     description:
       "Tax compliance guides for expats and businesses in Indonesia. Personal tax, corporate tax, Coretax system, deadlines, and legal requirements.",
@@ -45,12 +55,19 @@ export async function generateMetadata({
   params: Promise<{ category: string }>;
 }): Promise<Metadata> {
   const { category } = await params;
-  const seo = CATEGORY_SEO[category];
+  const seo = CATEGORY_SEO[category as ArticleCategory];
 
   if (!seo) {
+    // This branch used to title-case whatever was in the URL and describe it as
+    // a subject we cover: /zzz-nonsense became "Zzz-nonsense Insights — Expert
+    // guides and insights about zzz-nonsense in Indonesia and Bali", served 200.
+    // That is machine-generated SEO junk for arbitrary input, on an unbounded
+    // number of URLs. The layout now 404s these (see the default export); this
+    // metadata is what a crawler sees in the meantime, so it must not invite
+    // indexing.
     return {
-      title: `${category.charAt(0).toUpperCase() + category.slice(1)} Insights`,
-      description: `Expert guides and insights about ${category} in Indonesia and Bali.`,
+      title: "Page not found",
+      robots: { index: false, follow: false },
     };
   }
 
@@ -87,10 +104,37 @@ export async function generateMetadata({
   };
 }
 
-export default function CategoryLayout({
+/**
+ * `[category]` sits inside the `(blog)` route group, and a route group adds
+ * nothing to the URL — so this segment is top-level `/:something` and matches
+ * EVERY unmatched single-segment path on every domain the project serves.
+ * Without a guard, `/zzz-nonsense`, `/cases`, `/id` and any typo all rendered
+ * the category page with an empty article list and returned HTTP **200**: a
+ * soft-404, which search engines treat as a real page and index.
+ *
+ * Anything outside the allow-list now 404s properly, rendering
+ * `(blog)/not-found.tsx`. Deliberately an allow-list and not a deny-list: the
+ * set of valid categories is closed and known, while the set of junk paths is
+ * infinite.
+ *
+ * Verified before choosing to 404 rather than carve out exceptions: the sitemap
+ * advertises 16 single-segment URLs and none is a locale root; no page emits any
+ * hreflang; no component navigates to a locale-prefixed path (switching is
+ * client-side). So `/id` and `/it` — which used to render "Id Insights" — are
+ * linked from nowhere, and a 404 is strictly better than inventing a page.
+ * Path-based locales are a separate, tracked change; when they land they get
+ * real route segments, which take precedence over this dynamic one.
+ */
+export default async function CategoryLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: Promise<{ category: string }>;
 }) {
+  const { category } = await params;
+  if (!Object.prototype.hasOwnProperty.call(CATEGORY_SEO, category)) {
+    notFound();
+  }
   return children;
 }


### PR DESCRIPTION
## The whole site returns 200 for paths that do not exist

`apps/mouth/src/app/(blog)/[category]` sits in a **route group**, and a route
group contributes nothing to the URL — so that segment is top-level
`/:something` and matches every unmatched single-segment path, on every domain
this one Vercel project serves. Measured live on balizero.com before this fix:

```
200  /zzz-nonsense                 "Zzz-nonsense Insights | Bali Zero"
200  /slhs                         "Slhs Insights | Bali Zero"
200  /cases                        "Cases Insights | Bali Zero"
200  /id                           "Id Insights | Bali Zero"
200  /it                           "It Insights | Bali Zero"
200  /this-path-does-not-exist     "This-path-does-not-exist Insights | ..."
```

Two defects with one cause:

1. **The status lied.** The body rendered "Page Not Found" while the response
   said `200`. That is a soft-404 — search engines treat it as a real page and
   index it, on an unbounded set of URLs.
2. **The metadata invented a subject.** `generateMetadata`'s fallback
   title-cased the URL segment and described it as something we cover: *"Expert
   guides and insights about zzz-nonsense in Indonesia and Bali."* Attacker- or
   typo-supplied input became plausible-looking SEO copy under our brand.

## Fix

The layout is the one layer that can still set the status, so the guard goes
there: it becomes `async`, reads `params`, and calls `notFound()` for anything
outside the allow-list — rendering the `(blog)/not-found.tsx` that already
exists, with a real 404. The metadata fallback returns
`robots: { index: false, follow: false }` and no invented title.

`CATEGORY_SEO` is retyped from `Record<string, …>` to
`Record<ArticleCategory, …>`, so the allow-list and the category type can no
longer drift apart without a compile error. That is what makes it safe to 404 on
absence.

**`hasOwnProperty`, not `in`.** With `in`, every `Object.prototype` member
passes an allow-list — `/constructor`, `/toString`, `/__proto__` would each have
rendered as a category. Mutation-verified: swapping in `in` fails exactly those
five tests.

Allow-list rather than deny-list, because the set of real categories is closed
and known while the set of junk paths is infinite.

## Why 404 instead of carving out exceptions

Checked before deciding, since `/id` and `/it` look like locale roots:

- the sitemap advertises **16** single-segment URLs and **none** is a locale root
- **no** page emits any `hreflang` at all
- **no** component navigates to a locale-prefixed path — locale switching is client-side

So `/id` and `/it` are linked from nowhere, and a 404 beats serving "Id
Insights". Path-based locales are a separate tracked change
(`i18n/content-locale.ts:55` says so); when they land they get real route
segments, which take precedence over this dynamic one.

## Verification

- guilt: the six measured junk paths + the five prototype keys all 404
- innocence: all six real categories still render, metadata and canonical intact
- both metadata directions, with the old invented title pinned as forbidden
- **mutation-verified**: removing the guard fails 11 of 19; `in` for
  `hasOwnProperty` fails 5
- 310 files / 2859 tests pass, `tsc` RC=0

## Found while measuring, not fixed here

`/visa` (singular — and it **is** in the sitemap) serves the homepage. That is
duplicate content under a second URL, a different defect from this one, so it is
not bundled in.
