### PR TITLE
fix(mouth): add CSS fallback behind NewsHero carousel images

### DIFF
--- a/apps/mouth/src/app/v2/_components/NewsHero.tsx
+++ b/apps/mouth/src/app/v2/_components/NewsHero.tsx
@@ -170,6 +170,11 @@ export function NewsHero({ articles }: { articles: ArticleListItem[] }) {
                     pointerEvents: i === active ? "auto" : "none",
                   }}
                 >
+                  <div className="absolute inset-0 flex items-center justify-center bg-[var(--surface-muted)]">
+                    <span className="text-[var(--text-tertiary)] text-[11px] font-semibold uppercase tracking-[0.15em]">
+                      {s.category ?? "Bali Zero"}
+                    </span>
+                  </div>
                   <Image
                     src={s.coverImage as string}
                     alt={s.title || ""}


### PR DESCRIPTION
## Insight
NewsHero carousel used Next.js \`<Image>\` with \`onError\` that only called \`display = 'none'\`, leaving the container visually blank when images failed to load. No fallback content existed behind the image layer.

## Studio
(a) NewsHero carousel slots now show a muted background with category label (e.g. "immigration", "tax") when a cover image fails to load — instead of a blank gray box. Images that load successfully are unaffected.
(b) \`apps/mouth/src/app/v2/_components/NewsHero.tsx\` → slide container div → Zone VERDE.

## Source
Phase 1–4 audit: file images confirmed present on disk, paths confirmed correct, Next.js config confirmed valid. Root cause isolated to missing fallback behind \`<Image>\` when \`display:none\` is applied on error.

## Methodology
Added a fallback \`<div>\` as a sibling element rendered before \`<Image>\` in DOM order. The div sits at \`absolute inset-0\` and is always rendered. When \`<Image>\` hides itself via \`onError\`, the fallback div becomes visible automatically — no state, no \`useEffect\`, no \`"use client"\` required.

## Raw Observations
- \`BZImage.tsx\` already had proper fallback pattern (onError + state) — NewsHero did not use BZImage
- NewsHero onError: \`e.currentTarget.style.display = "none"\` — no replacement rendered
- 9+ image slots affected (4 carousel + 5 latest news)
- File images: confirmed present at \`public/static/insights/...\`
- Path format: relative with leading slash — matches Next.js static serving convention

## Reasoning Path
Image files exist → paths are correct → Next.js config valid → problem is purely frontend: nothing fills the container after image hides → add always-rendered div behind image layer → image hides → fallback visible.

## Risk
Low. Change is purely additive — a div added before existing \`<Image>\`. No props changed, no component signature changed, no shared components touched. Fallback only visible when image fails.

## Implication
Homepage carousel no longer shows blank slots. Trust signal restored for first-time visitors arriving from organic search.

## Recommendation
Merge immediately. VERDE zone, CI gate sufficient.

## Next Action
1. Verify live after Vercel deploy — open balizero.com, check carousel slots have images or category fallback (no blank boxes)
2. Proceed to Ask Zantara GIALLO escalation — draft WA to Antonello