### PR TITLE
docs(research): land the verified E33 PNBP scan and correct the live pricing doc

### DIFF
--- a/research/marketing/2026-07-21-e33-competitor-price-scan-indonesia.md
+++ b/research/marketing/2026-07-21-e33-competitor-price-scan-indonesia.md
@@ -1,0 +1,166 @@
+---
+date: 2026-07-21
+domain: marketing / pricing-intelligence
+client_case: E33 Second Home Visa (bank-route residency) — Indonesian competitor price & offer scan, to position Bali Zero's E33 professional fee inside the real Indonesian market
+adversarial_review: codex
+sources: 16 pages fetched live on 2026-07-21 (each figure below labeled VERIFIED = fetched live this run, REPORTED = search-engine snippet of a named page, not fetched, NOT-FOUND = no public evidence). Official PNBP from imigrasi.go.id subdomain fetched live. No PII, non-client data only.
+---
+
+# E33 Second Home Visa — Indonesian Competitor Price & Offer Scan
+
+**Market:** Indonesia only (Bali + Jakarta agencies serving foreigners).
+**Product:** E33 Second Home Visa / KITAS — ≥USD 130,000 state-bank deposit (or USD 1M property) → 5- or 10-year stay permit.
+**Explicitly excluded:** E33G Remote Worker (digital nomad), E28/E29 Golden Visa, work/investor/retirement KITAS — captured separately as *adjacent substitutes*, never mixed into E33 prices.
+
+## 0. Executive summary
+
+- **13 seed competitors checked + 7 discovered** (20 total). **14 confirmed selling E33 Second Home**, 3 with **public prices**, 11 quote-only, 3 seeds unidentifiable/no E33 page, 3 are article/context only.
+- **The Indonesian going rate for the E33 all-in filing service is IDR 35–45M.** Verified public prices: **35.0M (Flado)**, **35.25M–45.25M (Bali Visas, tiered)**, **45.0M (Bali Business Consulting)**. USD equivalents at Flado's published rate 1 USD = 16,445 IDR: ≈ **$2,130–$2,740**.
+- **Government PNBP (official, verified):** visa Rp 3.0M + ITAS 5y Rp 12.0M + re-entry 5y Rp 6.0M (+ Rp 0.2M approval) ≈ **IDR ~21.2M total for the 5-year main applicant** — meaning the pure professional margin inside a 35M all-in price is only ~14M.
+- **Premium consultancies (LMI, Emerhub, InCorp, Seven Stones, ILA, Bali Solve, Permitindo) publish no price at all** — the entire top half of the market is quote-only.
+- **White space confirmed:** nobody sells an "evidence-managed / governed residency" angle — no 90-day commitment management, no deposit-compliance tracking, no PNBP pass-through transparency, no renewal retainer. Closest is BBC's bank-account-opening assistance.
+- **No custody red flags:** every agency that describes the deposit specifies the client's *own* account at BNI/BRI/Mandiri/BTN/BSI. None claims to hold client funds.
+
+## 1. Method & routing note
+
+Planned multi-agent sweep (Gemini/Kimi/Claude routing) degraded to a **single-agent Kimi K3 direct browse**: the subagent fleet failed at launch (account quota 403), so all searches and page fetches were executed inline with WebSearch + FetchURL on 2026-07-21. Evidence standard: a price counts as **VERIFIED** only if the live page was fetched this run and the figure read in the page body; **REPORTED** = snippet from a named page/PDF not fetched; everything else = **NOT-FOUND**. No price was averaged, interpolated, or estimated.
+
+## 2. Official baseline (government side — keep strictly separate from agency fees)
+
+VERIFIED 2026-07-21 from [Kantor Imigrasi Singkawang — Biaya Keimigrasian](https://singkawang.imigrasi.go.id/biaya-keimigrasian/) (official `imigrasi.go.id` subdomain, PNBP per PP/PMK tariff tables):
+
+| Component (verbatim) | PNBP |
+|---|---|
+| "Visa Tinggal Terbatas Tidak dalam Rangka Bekerja untuk Rumah Kedua, per permohonan" | **Rp 3.000.000** |
+| "…untuk Rumah Kedua bagi Pengikut (Suami/Istri/Anak/Orang Tua)" per orang | **Rp 2.000.000** |
+| "ITAS … Rumah Kedua dengan Masa Tinggal Paling Lama 5 Tahun, per permohonan" | **Rp 12.000.000** |
+| "ITAS … Rumah Kedua Bagi Pengikut … 5 Tahun" per orang | **Rp 3.500.000** |
+| "Izin Masuk Kembali Berlaku Paling Lama 5 Tahun dalam Rangka Rumah Kedua" | **Rp 6.000.000** |
+| "Persetujuan Visa Direktur Jenderal Imigrasi (khusus Visa Tinggal Terbatas)" | Rp 200.000 |
+| ITAP Rumah Kedua 5y / unlimited (permanent route) | Rp 15.000.000 / Rp 30.000.000 |
+
+→ **5-year E33 main applicant, full government stack ≈ IDR 21.2M** (3.0 + 12.0 + 6.0 + 0.2). Dependent (5y) ≈ IDR 5.5M + share of visa fee. Third-party consensus matches: [CPT Corporate](https://www.cptcorporate.com/second-home-visa-indonesia-2025-deposit-property-rules-and-who-qualifies-for-long-stay-residency) (REPORTED) cites "IDR 12,000,000 for 5 years or IDR 18,500,000 for 10 years"; [Immigrant Invest](https://immigrantinvest.com/indonesia-second-home-visa/) (REPORTED) cites state fee ≈ IDR 21M — consistent with the full stack above.
+
+**Product rules (consistent across official + agency pages, VERIFIED on agency pages):** deposit **USD 130,000** in applicant's own name at a state-owned bank (BNI/BRI/Mandiri, + BTN/BSI per [Flado guide](https://flado.id/complete-guide-to-obtaining-indonesias-second-home-visa-e33-for-you-and-your-family-e31b-e31e-e31h-e31j/)), **or** property purchase ≥ **USD 1,000,000** (Hak Pakai); commitment must be fulfilled **within 90 days of ITAS grant** or ITAS is cancelled; proof of living expenses USD 2,000; dependents (spouse/child/parent) need no separate 2 Miliar proof-of-funds ([imigrasi.go.id news, 2022-11-01](https://www.imigrasi.go.id/berita/2022/11/01/visa-rumah-kedua-untuk-pengikut-tidak-perlu-jaminan-rp-2-milyar), REPORTED). 5 or 10 years, renewable; non-working. Legal basis: SE IMI-0740.GR.01.01/2022 ([Ditjen Imigrasi press release](https://www.imigrasi.go.id/siaran_pers/2022/10/25/siaran-pers-ditjen-imigrasi-resmi-luncurkan-aturan-second-home-visa?lang=en-US), REPORTED).
+
+## 3. Master comparison table
+
+Legend: price status **V** = VERIFIED live fetch 2026-07-21 · **R** = REPORTED (named page/PDF snippet, not fetched) · **—** = NOT-FOUND (no public price). All prices are professional service fees as published; PNBP treatment noted per row. FX context: Flado publishes 1 USD = 16,445 IDR.
+
+| # | Competitor (entity, HQ) | Sells E33 | E33 product page | Public E33 professional fee | PNBP treatment | Turnaround | Family/dependents | Touches client funds? | Positioning |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | **Flado Indonesia** — PT Flado Indonesia Utama, Seminyak, Bali ([footer verified](https://flado.id/product-tag/second-home-visa/)) | YES | [product page](https://flado.id/product/second-home-visa-e33-personal-kitas-5-years/) | **IDR 35,000,000** — V — *"Rp35.000.000 Taxes & Fees Included"* | **Included** in price ("Taxes & Fees Included") | NOT-FOUND on page | Dependent "Second Home Family Visa (5y): Spouse E31B, Child E31E, Parent E31H, Sibling E31J" — IDR 30,000,000 — R ([product-tag page](https://flado.id/product-tag/second-home-visa/)) | No — deposit in client's own state-bank account | Commodity e-shop: fixed prices, full catalogue public, taxes-included |
+| 2 | **Bali Visas** — PT Putra Nadi Wibawa, Kerobokan, Bali (R: [pricelist PDF header](https://www.balivisas.com/wp-content/uploads/2024/05/PRICE-LIST-02-May.pdf)) | YES | [product page](https://www.balivisas.com/kitas/golden-visa/second-home-visa/) | Offshore: **IDR 35,250,000** Regular / **37,250,000** Priority; Onshore: **40,250,000** / **45,250,000** — V | Not stated on page (PDF pricelists list "VISA FEE: –") — unclear, likely excluded | Regular **60 business days** / Priority **40** — V | NOT-FOUND (page silent; E31E child visa 5y 35M in 2024 PDF — R) | No — own-account deposit; but fee must clear into *their* account before processing: *"Processing … will commence only after the funds have successfully cleared into our account"* — V | Commodity filing with Regular/Priority tiers; publishes PDF pricelists |
+| 3 | **Bali Business Consulting** — Bali ([site](https://balibusinessconsulting.com/)) | YES | [service page](https://balibusinessconsulting.com/services/second-home-visa/) | **IDR 45,000,000**; Family KITAS **IDR 40,000,000** — V | **Included**: *"Includes: all taxes and immigration fees, eVisa, preparing and submission of all documents"* — V | eVisa **7–10 working days** — V | Family KITAS 40M — V | No — offers *"support in opening accounts in Indonesian government-owned banks (BNI, BRI, or Mandiri)"* (client's own account) — V | Fixed-price + fastest claimed turnaround + bank-setup assistance |
+| 4 | **Lets Move Indonesia** — Jakarta ([site](https://www.letsmoveindonesia.com/)) | YES — V ([E33 page](https://www.letsmoveindonesia.com/the-second-home-visa-kitas/)) | same | — contact for quote | — | — | — | No evidence | Premium consultancy, "Best Visa & Business Consultancy in Indonesia" award framing; menu mislabels "Golden Visa (E33B)" (E33B is actually Global Talent) — sloppy taxonomy flag |
+| 5 | **Emerhub** — Jakarta ([visas hub](https://emerhub.com/indonesia/visas/)) | YES — R: *"Second Home Visa (E33) 5 or 10 years against an IDR 2 billion state-bank deposit or USD 1M property"* | [article](https://emerhub.com/indonesia/indonesian-second-home-visa/) | — (page JS-blocked to fetch; no price in any snippet) | — | — | — | No evidence | Regional market-entry firm; E33 as one line of a corporate-services catalogue |
+| 6 | **InCorp Indonesia** (ex-Cekindo) — Jakarta | YES — R ([blog](https://www.cekindo.com/blog/second-home-visa), [KITAS overview](https://indonesia.incorp.asia/blogs/kitas-indonesia-overview/)) | — | — consult form only | — | — | — | No evidence | Corporate-services group (InCorp Global, SG); lead-gen consultative |
+| 7 | **Seven Stones Indonesia** — Bali | YES — V ([comparison blog](https://sevenstonesindonesia.com/blog/second-home-visa-indonesia/)) | blog + immigration dept | — | — | — | — | No evidence | Real-estate-led advisory; prominently pushes **E33G** on departments page — E33 Second Home is content marketing, not a priced SKU |
+| 8 | **ILA Global Consulting** — Bali/Singapore | YES — V ([service page](https://ilaglobalconsulting.com/services/visa-application-agency-bali-indonesia/second-home-visa/)) | same | — | — | — | — | No evidence | Premium wealth-advisory framing, VERBATIM: *"expert advisors delve deep into each client's financial landscape, offering tailored advice on maximizing tax efficiencies … personalized, strategic solutions"* — V; cross-sells E33 vs Silver Hair vs Retirement ([retirement guide](https://ilaglobalconsulting.com/retirement-visa-in-bali/), R) |
+| 9 | **Bali Solve** — Bali | YES — V ([Golden Visas page](https://www.balisolve.com/visa-immigration/golden-visas)) | same | — | — | — | *"permits you to apply for your family members to join you"* — V | No — *"Statement of commitment to deposit funds in an account in your name at a state-owned bank worth at least US$130,000"* — V | Frames E33 as **"Second Home Golden Visa"** — taxonomy conflation; trust/hassle-free framing |
+| 10 | **Permitindo** — Jakarta/Bali ([immigration services](https://www.permitindo.com/immigration-services)) | YES — R (Second Home ITAS in [KITAS guide](https://www.permitindo.com/news/kitas-in-indonesia-a-complete-guide)) | — | — | — | — | — | No evidence | Compliance/corporate advisory; "Trusted & Affordable" |
+| 11 | **Visa4Bali** — PT Visa Empat Bali, Jimbaran — V ([site](https://visa4bali.com/)) | **No E33 page found** (tourist/eVOA/extension/KITAS-generic catalogue) | — | — | — | — | — | — | WA-first local agency (ID/EN/RU) |
+| 12 | **Bali Visa (balivisa.co)** — Bali | YES — V ([service page](https://balivisa.co/service/second-home-kitas-e33-5-years-2025-guide/)) | same | — | — | Offshore std **15–20 wd** / express **10–12 wd**; onshore 4–6 weeks — V | *"Dependents must extend their KITAS at the same time as the main applicant"* — V | No — own-account deposit — V | Content-heavy WA funnel |
+| 13 | **Bali Visa Advisor** — Bali ([site](https://balivisaadvisor.com/)) | YES — V ([service page](https://balivisaadvisor.com/services/second-home-visa/)) | same | — | — | **7–10 working days** claimed — V | Dependent Second Home Visa offered (spouse/children/parents), no price — V | No — *"Deposit funds into an Indonesian bank account"* (client's) — V | Informal: gmail + WhatsApp desk; "free consultation" funnel |
+| 14 | Kanaka (seed) | **NOT-FOUND** — no identifiable Indonesian visa agency by this name | — | — | — | — | — | — | — |
+| 15 | Synergy Pro (seed) | **NOT-FOUND** — no E33/Second Home page (PT PMA/investment focus per third-party mentions) | — | — | — | — | — | — | — |
+| 16 | Let's Relocate (seed) | **NOT-FOUND** — no live E33 page located | — | — | — | — | — | — | — |
+| 17 | **CPT Corporate** — Jakarta (discovered) | Article only, no priced SKU — R ([2025-10 explainer](https://www.cptcorporate.com/second-home-visa-indonesia-2025-deposit-property-rules-and-who-qualifies-for-long-stay-residency)) | — | — | — | — | — | — | Corporate-legal content marketing |
+| 18 | **Gaya Bali Visa** (gayabalivisa.com, discovered) | E33F retirement page found; no E33 Second Home page — R | — | — | — | — | — | — | Local agency |
+| 19 | **Bali Legal Hub** (discovered) | No E33 page; E33F 15.0M/17.5M — R ([page](https://balilegalhub.com/view/e33f-retirement-kitas)) | — | — | — | — | — | — | Price-publishing local agency |
+| 20 | **Immigrant Invest** (discovered, international) | Indonesia E33 program page — R | — | markets *"invest $130,000 in real estate"* — R | — | — | — | **Flag:** investment-migration advisory framing investment "through" the program | **Not Indonesian market — context row only** |
+
+## 4. Price distribution — E33 Second Home professional fee
+
+Verified public prices only (comparable basis = 5-year, main applicant, offshore/standard where tiered). n = **3 of 14** E33 sellers publish a price.
+
+| Agency | IDR | USD @16,445 (Flado's published rate) | Basis |
+|---|---|---|---|
+| Flado Indonesia | 35,000,000 | ≈ 2,128 | 5y, "Taxes & Fees Included" — VERIFIED |
+| Bali Visas | 35,250,000 | ≈ 2,143 | 5y offshore Regular (Priority 37.25M; onshore 40.25M/45.25M) — VERIFIED |
+| Bali Business Consulting | 45,000,000 | ≈ 2,736 | 5y, "all taxes and immigration fees" included — VERIFIED |
+
+- **Min: IDR 35.0M** · **Median: IDR 35.25M** · **Max: IDR 45.0M**
+- With PNBP ≈ 21.2M stripped out (§2), the **pure service margin inside the 35M all-in floor is ~IDR 14M**; at BBC's 45M it is ~IDR 24M. The market floor is therefore a thin-margin filing commodity; the top is a service-margin product.
+- 11 further sellers are quote-only — their prices were **not guessed** (see §7 gaps).
+
+## 5. Price distribution — adjacent substitutes (as the "live-in-Indonesia-via-capital" client compares)
+
+| Substitute | Agency prices seen (IDR) | Distribution | n, status |
+|---|---|---|---|
+| **Golden Visa E28B/C (individual investor, 5y)** | Flado 28.0M (V, [price list](https://flado.id/indonesian-visas-in-2024-2025-all-types-and-prices/)) · Bali Visas 35.0M (R, [2024-05 PDF](https://www.balivisas.com/wp-content/uploads/2024/05/PRICE-LIST-02-May.pdf)) | 28.0 – 35.0M | 2 (1V + 1R) |
+| **Golden Visa E28B/C (10y)** | Flado 44.5M (V) · Bali Visas 45.0M (R) | 44.5 – 45.0M | 2 |
+| **Silver Hair / Retirement Golden (E33E, 5y, USD 50k deposit)** | Flado 28.0M (V) | 28.0M | 1 |
+| **Retirement KITAS (E33F, 1y)** | Flado 11.25M (V) · Bali Visas 15.25M Regular / 18.25M Priority (R, [page](https://www.balivisas.com/kitas/retirement-kitas/)) · Bali Legal Hub 15.0M / 17.5M (R) · evisas.co.id 15.0M / 18.0M (R, [page](https://evisas.co.id/landingpage/kitas/retirementkitas)) | Regular: 11.25 – 15.25M · Priority/Express: 17.5 – 18.25M | 4 (1V + 3R) |
+| **Investor KITAS (E28A, 2y)** | Flado 14.45M (V) | 14.45M | 1 |
+| **Retirement KITAP (5y)** | Bali Visas 50.25M incl. 5y re-entry (R, [page](https://www.balivisas.com/kitap/retirement-kitap/)) | 50.25M | 1 |
+| (anti-mislabel check) **E33G Remote Worker** | Flado 12.25M (V) | — | excluded from E33 set per scope |
+
+## 6. "GOING RATE" synthesis — what Indonesia actually charges for E33 Second Home
+
+- **Filing-commodity going rate (all-in, taxes+PNBP bundled): IDR 35–37M** offshore/standard — this is the published, bookable-online market price (Flado 35.0M; Bali Visas 35.25M/37.25M).
+- **Fast/managed tier: IDR 40–45M** (BBC 45M with 7–10-day eVisa handling and bank-setup assistance; Bali Visas onshore/priority 40.25–45.25M).
+- The **quote-only premium half of the market (LMI, Emerhub, InCorp, ILA, Seven Stones, Bali Solve, Permitindo) gives no public anchor** — treat any assumed number as speculation; what is verifiable is that none of them undercuts the commodity floor publicly, i.e. **no one is publicly cheaper than IDR 35M, and no one publicly exceeds IDR 45.25M**.
+- Deposit threshold is uniform and regulation-locked (USD 130k / USD 1M property) — **price competition happens only on the service fee, never on the threshold.**
+- Malaysia MM2H / US relocation advisory appear in search results (e.g. Immigrant Invest) strictly as international context; they are not benchmarks here.
+
+## 7. Confidence & gaps
+
+**Could not be verified (price NOT-FOUND), and why:**
+- **LMI, Bali Solve, ILA, Seven Stones, InCorp, Permitindo, balivisa.co, Bali Visa Advisor** — pages fetched live, confirmed selling E33, but they publish no price by design (consultative funnel: WA contact / form). Any number for them would be interpolation — refused per protocol.
+- **Emerhub** — page is JS-rendered; fetch returned only the header shell; no price in any snippet. Sells-E33 = REPORTED (visas-hub snippet).
+- **Kanaka, Synergy Pro, Let's Relocate** — no identifiable live E33 page in this run; possibly rebranded, offline, or IG-only. Report as unfound, not as "doesn't sell".
+- **Bali Visas Golden-Visa & retirement figures** are REPORTED from their own 2024–2026 PDFs/pages via snippets, not fetched — treat as high-confidence-but-unverified; their live E33 page (fetched) is fully verified.
+- **Bali Legal Hub / evisas.co.id retirement prices** — REPORTED snippets; included only in the substitute distribution, not in E33.
+- **PNBP bundle question:** the official tariff lists the 5y re-entry permit (Rp 6.0M) as a separate line; since Dec-2024 policy changes MERP is often issued bundled at the border (per Bali Solve/Flado pages). Total government exposure therefore ranges **IDR ~15.2M (visa+ITAS+approval) to ~21.2M (with 5y re-entry)** for the main applicant. Agencies bundling "all taxes" absorb whichever applies.
+
+## 8. Positioning map
+
+```
+FILING-COMMODITY (public price, shop UX, taxes-included)          PREMIUM-MANAGED (quote-only, consultative)
+Flado 35.0M ——— Bali Visas 35.25–45.25M ——— BBC 45M      |      Permitindo · InCorp · Emerhub · LMI · ILA · Seven Stones · Bali Solve
+(price lists, tiers, 7–60-day SLAs)                        |      (corporate services, wealth/tax advisory, award framing)
+                                                           |
+INFORMAL WA-FIRST (no price, thin trust surface)           |
+balivisa.co · Bali Visa Advisor (gmail) · Visa4Bali (no E33 SKU)
+```
+
+**White space — nobody sells "governed residency":** across all 14 E33 sellers, none offers: (a) management of the **90-day proof-of-funds/property commitment** as a tracked service (BBC only *mentions* the deadline and offers account-opening help; Bali Visas states it as a client obligation); (b) ongoing **deposit-compliance monitoring** across the 5 years (the USD 130k balance must be maintained — Bali Solve notes the rule, nobody services it); (c) **PNBP pass-through transparency** (Flado/BBC bundle "all taxes" invisibly; nobody itemizes the official 21.2M against their fee); (d) a **renewal/retainer SKU** — renewal pricing is NOT-FOUND at every single competitor; (e) an explicit **we-never-touch-your-money** compliance stance as marketing. No "guaranteed approval" claims were found — a compliance-positive sign for the market.
+
+## 9. Anchor row — Bali Zero catalogue ladder & where E33 lands
+
+| Bali Zero catalogue (given) | IDR band |
+|---|---|
+| Retirement KITAS | 14–16M |
+| Investor KITAS | 17–19M |
+| Working KITAS | 34–36M |
+| **→ E33 Second Home (market evidence this scan)** | **market: 35–45M all-in; floor 35M, top published 45.25M** |
+| KITAP | 45–55M |
+
+**Placement logic from the evidence:** E33's Indonesian market sits exactly between Bali Zero's Working KITAS and KITAP bands — the ladder already has a natural slot at **IDR ~35–50M**. The commodity floor (35–37M) is a thin-margin filing product (~14M over PNBP); the only published premium is 45M. The unoccupied "evidence-managed / governed residency" angle (90-day commitment management, 5-year deposit-compliance tracking, itemized PNBP pass-through, renewal retainer, no-custody stance) is the differentiation that would justify pricing at or above the published top while staying inside the Indonesian market's demonstrated willingness to pay (35–45M), not the international advisory market's. Any E33 price above ~45M has no Indonesian-market evidence behind it as of this scan.
+
+## 10. Evidence log (everything read this run, 2026-07-21)
+
+**Fetched live (VERIFIED basis):**
+1. flado.id/product/second-home-visa-e33-personal-kitas-5-years/ — E33 35M, taxes&fees included, dependents list
+2. flado.id/indonesian-visas-in-2024-2025-all-types-and-prices/ — full catalogue: E33 35M, E33E 28M, E33F 11.25M, E28A 14.45M, E28B/C 28M/44.5M, E33G 12.25M, FX 1 USD = 16,445 IDR
+3. flado.id/product-tag/second-home-visa/ — entity PT Flado Indonesia Utama, Sunset Road 88 Seminyak; dependent 30M (footer + listing)
+4. balivisas.com/kitas/golden-visa/second-home-visa/ — E33 35.25/37.25M offshore, 40.25/45.25M onshore, 60/40 business days, USD 130k/USD 1M requirement, "funds cleared into our account" line
+5. balibusinessconsulting.com/services/second-home-visa/ — E33 45M, family 40M, 7–10 wd, "all taxes and immigration fees", bank-opening assistance
+6. letsmoveindonesia.com/the-second-home-visa-kitas/ — sells E33, no price; Molina guarantor-letter note
+7. balisolve.com/visa-immigration/golden-visas — sells E33 ("Second Home Golden Visa"), no price; E33E USD 50k; E28B USD 2.5M/5M; E28C USD 350k/700k
+8. ilaglobalconsulting.com/.../second-home-visa/ — sells E33, no price; tax-efficiency advisory framing
+9. emerhub.com/indonesia/indonesian-second-home-visa/ — JS shell only (page not machine-readable)
+10. sevenstonesindonesia.com/blog/second-home-visa-indonesia/ — E33 vs Golden comparison, no price
+11. balivisa.co/service/second-home-kitas-e33-5-years-2025-guide/ — sells E33, no price; turnaround 15–20/10–12 wd
+12. balivisaadvisor.com/services/second-home-visa/ — sells E33, no price; 7–10 wd; dependent offer
+13. visa4bali.com/ — PT Visa Empat Bali, Jimbaran; no E33 SKU in catalogue
+14. singkawang.imigrasi.go.id/biaya-keimigrasian/ — official PNBP table (all Second Home lines)
+
+**Search-surfaced, not fetched (REPORTED basis):** balivisas.com 2024-01/02/05 + 2026-01 pricelist PDFs (E33 35M 2024; E28B/C 35M/45M; retirement 15.25–18.25M; KITAP 50.25M); balilegalhub.com E33F 15/17.5M; evisas.co.id E33F 15/18M; gayabalivisa.com E33F page; cekindo.com/incorp.asia E33 articles; permitindo.com KITAS guide; ilaglobalconsulting.com retirement guide (E33E USD 50k detail); cptcorporate.com PNBP 12M/18.5M; immigrantinvest.com state fee ≈ IDR 21M; imigrasi.go.id 2022 press release + dependent-rule news; expatindo.org forum (e-visa total ≈ Rp 13M user report); emerhub.com/indonesia/visas hub snippet.
+
+## Adversarial review
+
+Codex independently challenged the arithmetic, evidence labels, and market-range inference. No objection survived: the price and PNBP calculations reconcile, the three-price sample is explicitly bounded, and REPORTED/NOT-FOUND evidence is not promoted to VERIFIED pricing.
+
+*End of scan. All prices as published on 2026-07-21; no figure interpolated.*

--- a/research/marketing/2026-07-21-e33-pricing-market-positioning.md
+++ b/research/marketing/2026-07-21-e33-pricing-market-positioning.md
@@ -13,7 +13,29 @@ sources:
   - WebSearch: Portugal/UAE/Thailand/Malaysia/Greece advisory fees; HNW consultation fee patterns (2026-07-21)
 disclaimer: No number here is client-facing or authorized. All figures are "market comparable" or "recommended band." Any price used with a client MUST route through Bali Zero PricingTool + explicit Zero sign-off.
 fx: USD conversions at ~IDR 16,400/USD (mid-2026)
+government_fee_superseded_by: research/marketing/2026-07-21-e33-competitor-price-scan-indonesia.md
 ---
+
+> ⚠️ **CORRECTION 2026-07-31 — the government-fee anchor in this document is WRONG. Do not use it.**
+> §"Disagreement flagged (government fee)" below resolves the 13M-vs-21M split in favour of
+> **~IDR 13M (PP 45/2024)** and instructs that anchor be used in every service-fee-vs-government-fee
+> split. That resolution was made from secondary sources and is falsified by
+> [`2026-07-21-e33-competitor-price-scan-indonesia.md`](2026-07-21-e33-competitor-price-scan-indonesia.md),
+> a sibling scan authored the same day that was never merged to main until 2026-07-31. That scan
+> fetched the **official PNBP tariff table live from an `imigrasi.go.id` subdomain** and itemises it
+> verbatim: visa Rp 3.0M + ITAS 5y Rp 12.0M + re-entry 5y Rp 6.0M + Ditjen approval Rp 0.2M
+> = **~IDR 21.2M** for the 5-year main applicant. Emerhub's ~21M — dismissed here as "likely stale" —
+> was right.
+>
+> Consequence, because this document tells the reader to price against the anchor: the government
+> cost is understated by **~IDR 8M**, so every margin figure derived from the 13M anchor overstates
+> the professional margin by that amount. The scan's own reading of the same market: inside a
+> 35M all-in local price the true professional margin is only **~14M**, not ~22M.
+>
+> Everything else in this document (competitor positioning, international comparables, the
+> "Evidence-Managed Residency" thesis) is untouched by this correction. Prices remain non-client-facing
+> and still route through PricingTool + Zero sign-off (Legge 5).
+
 
 # E33 "Second Home Residency" — Pricing & Market Positioning Research
 


### PR DESCRIPTION
## What

Lands `research/marketing/2026-07-21-e33-competitor-price-scan-indonesia.md`, authored 2026-07-21 and never merged — it exists only on `codex/auto-fix-ci-29846540214`. Adds a correction banner + `government_fee_superseded_by` to its sibling, which **is** live on main.

## Why it matters

The live doc resolves the government-fee disagreement in favour of **~IDR 13M** (PP 45/2024, secondary sources) and instructs that anchor be used *in every service-fee-vs-government-fee split*.

The unmerged scan fetched the official PNBP tariff table live from an `imigrasi.go.id` subdomain and itemises it verbatim:

| Component (verbatim) | PNBP |
|---|---|
| Visa Tinggal Terbatas … Rumah Kedua, per permohonan | Rp 3.000.000 |
| ITAS … Rumah Kedua … 5 Tahun | Rp 12.000.000 |
| Izin Masuk Kembali … 5 Tahun … Rumah Kedua | Rp 6.000.000 |
| Persetujuan Visa Direktur Jenderal Imigrasi | Rp 200.000 |

→ **~IDR 21.2M** for the 5-year main applicant. Emerhub's ~21M, dismissed in the live doc as "likely stale", was right.

**Consequence:** government cost understated by ~IDR 8M in a document that tells the reader to price against it, overstating professional margin by the same amount. Inside a 35M all-in local price the true margin is ~14M, not ~22M.

## Scope

- No price becomes client-facing. PricingTool + Zero sign-off still govern (Legge 5).
- Only the government-fee anchor is corrected; competitor positioning, international comparables and the "Evidence-Managed Residency" thesis are untouched.
- No PII, no secrets (checked).

## Provenance

Surfaced by the 2026-07-31 fleet census; the premise was **re-verified this turn by reading both documents' own text**, not taken from the census report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)