### PR TITLE
fix(mouth): redirect legacy portal dashboard

### DIFF
--- a/apps/mouth/e2e/portal-client-ready.spec.ts
+++ b/apps/mouth/e2e/portal-client-ready.spec.ts
@@ -660,7 +660,7 @@ test.describe("portal client ready smoke", () => {
     expect(errors).toEqual([]);
   });
 
-  test("overview combines bureaucracy recap with Bali Zero Dispatch", async ({
+  test("@offline legacy dashboard URL preserves the query and opens the portal home", async ({
     context,
     page,
   }) => {
@@ -668,22 +668,12 @@ test.describe("portal client ready smoke", () => {
     const unhandledApiCalls: string[] = [];
     await mockPortalApi(context, unhandledApiCalls);
 
-    await page.goto("/portal/dashboard");
+    await page.goto("/portal/dashboard?source=legacy");
 
+    await expect(page).toHaveURL(/\/portal\?source=legacy$/);
     await expect(
-      page.getByRole("heading", { name: "My Overview" }),
+      page.getByRole("heading", { name: "Welcome Back" }),
     ).toBeVisible();
-    await expect(
-      page.getByRole("main").getByText("Ari Test Client"),
-    ).toBeVisible();
-    await expect(page.getByText(/Since your last visit/)).toBeVisible();
-    await expect(page.getByLabel("The Bali Zero Dispatch")).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /KITAS renewal checklist/i }),
-    ).toHaveAttribute(
-      "href",
-      "https://balizero.com/visas/kitas-renewal-checklist",
-    );
 
     await assertNoHorizontalOverflow(page);
     expect(unhandledApiCalls).toEqual([]);
@@ -760,7 +750,6 @@ test.describe("portal client ready smoke", () => {
 
     const sections = [
       { path: "/portal", text: "Welcome Back" },
-      { path: "/portal/dashboard", text: "My Overview" },
       { path: "/portal/matters", text: "Your matters" },
       { path: "/portal/matters/101", text: "Investor KITAS Renewal" },
       { path: "/portal/process", text: "My Processes" },

--- a/apps/mouth/src/app/portal/dashboard/route.test.ts
+++ b/apps/mouth/src/app/portal/dashboard/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "./route";
+
+describe("GET /portal/dashboard", () => {
+  it("permanently redirects the legacy dashboard URL to the portal home", () => {
+    const response = GET(
+      new Request("https://my.balizero.com/portal/dashboard?source=legacy"),
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "https://my.balizero.com/portal?source=legacy",
+    );
+  });
+});

--- a/apps/mouth/src/app/portal/dashboard/route.ts
+++ b/apps/mouth/src/app/portal/dashboard/route.ts
@@ -1,0 +1,6 @@
+export function GET(request: Request): Response {
+  const target = new URL(request.url);
+  target.pathname = "/portal";
+
+  return Response.redirect(target, 308);
+}


### PR DESCRIPTION
## Summary
- permanently redirect the legacy My Bali Zero /portal/dashboard URL to /portal
- preserve query parameters and bypass the dynamic article catch-all
- align the mocked portal smoke test and include it in the CI offline gate

## Root cause
The legacy route no longer had an explicit App Router handler, so the dynamic blog catch-all rendered Article not found instead of forwarding signed-in clients to the canonical portal home.

## Validation
- targeted Vitest suite: 70 passed
- TypeScript typecheck: passed
- Prettier and targeted ESLint: passed
- Playwright Chromium with the exact CI grep: 1 passed; legacy response 308, canonical response 200
- repository pre-push gate, including the full Python suite: passed
- independent review: PASS, no residual findings

## Live diagnostic
The separate Kita CELL status endpoint currently returns HTTP 200 in about 605 ms and reports green health, so this PR intentionally makes no speculative CELL changes.