### PR TITLE
docs(federation): cite the study that measures this rule, not the wrong row

### DIFF
--- a/research/operations/specs/P6-parallelize-gate.md
+++ b/research/operations/specs/P6-parallelize-gate.md
@@ -1,3 +1,17 @@
+---
+date: 2026-08-01
+domain: operations
+adversarial_review: codex
+adversarial_review_note: >-
+  Codex GPT-5.6-Sol, xhigh, cross-family, 2026-08-01. Verdict on the FIRST draft
+  of the 2026-08-01 citation fix: DO-NOT-SHIP, 3 CONFIRMED-DEFECTs — (1) an
+  absolute prohibition is not supported by a -30% average; (2) CooperBench
+  measures separate-workspace overlapping features, not same-artifact
+  co-editing, so the replacement citation was stretched too; (3) the 3-4 ceiling
+  is budget-derived, not coder-specific. All three are reworked into §0 below;
+  none was waived. Findings independently re-verified at source before use.
+---
+
 # PEZZO 6 — Gate "SE parallelizzare" + BUILD∥ in sicurezza
 
 > **Spec studio (non implementazione).** Ciclo calibrato: reuse-first (disk-state VERIFICATO) +
@@ -8,6 +22,35 @@
 > degradano (breadth-ricerca + specialist-ruoli-diversi), **mai coder paralleli sullo stesso
 > artefatto**. La richiesta dell'utente ("dove si può in parallelo") è coerente con l'evidenza — perché
 > "dove si può" = esattamente quei tipi.
+
+---
+
+## Adversarial review
+
+**Seat**: Codex GPT-5.6-Sol, `xhigh`, `--sandbox read-only`, cross-family (l'autore
+del diff è Claude Opus 5; generator ≠ grader). **Data**: 2026-08-01. **Mandato**:
+refutare, con default a «refuted» in caso di dubbio.
+
+**6 obiezioni sollevate, 3 CONFIRMED-DEFECT + 2 PLAUSIBLE sopravvissute, 1 respinta.
+Verdetto sulla prima stesura: DO-NOT-SHIP.** Nessuna è stata derogata: tutte
+rilavorate in §0 e nel docstring del modulo. Ogni numero del refuter è stato
+ri-verificato alla fonte prima di usarlo (W65 — anche il refuter allucina).
+
+| # | Obiezione | Esito |
+|---|---|---|
+| 1 | Un −30% medio non regge una proibizione **assoluta** senza scappatoie; il codice asserisce più di quanto l'evidenza sostenga | **CONFIRMED** — e verificato sul codice: `_estimate_merge_cost` ritorna `HIGH` sull'overlap **prima** di leggere `has_explicit_contract` (righe 255-257), quindi il contratto non può ribattere. Riscritto: la regola è dichiarata **policy operativa nostra**, non invariante stabilito dalla ricerca |
+| 2 | CooperBench non misura il caso di questa riga: due feature **diverse** in container **separati**, patch mergiate dopo — non co-editing dello stesso file | **CONFIRMED** — sostituivo un numero stirato con un altro numero stirato. Riscritto: setup dichiarato per esteso, e detto esplicitamente che nessuno studio letto misura il caso letterale |
+| 3 | Il −70,0% è davvero *sequential planning* e non coding? | **NOT-A-DEFECT** — la riclassificazione è corretta (unico punto in cui il refuter ha confermato la stesura) |
+| 4 | Il ceiling 3-4 è mis-scoped: deriva dalla crescita dei turni sotto budget di reasoning fisso (4.800 token), non è specifico dei coder né della concorrenza CPU | **CONFIRMED** — aggiunto caveat esplicito: la citazione è verbatim, l'applicazione ai coder è **estrapolazione nostra** |
+| 5 | Il «−30%» nudo nasconde metrica e aggregazione (abstract 30% successo medio; retention pooled 0,59 = «41% della capacità solo persa»; modelli di punta ~25% in coop) | **PLAUSIBLE** — metriche ora esplicitate tutte e tre invece di una costante senza contesto |
+| 6 | Il «do-not-restore» congela un'interpretazione che dovrebbe restare falsificabile | **PLAUSIBLE** — la nota ora fissa la **versione** dei paper (2512.08296v3, 2601.13295v2) e dichiara che cosa la riaprirebbe |
+
+**Cosa NON è stato affrontato qui** (dichiarato, non nascosto): il refuter osserva che
+CooperBench documenta anche pattern di coordinamento *riusciti* con contratti su
+interfacce e punti di inserimento. Renderne la proibizione **ribattibile** (permettere
+il parallelo su artefatto condiviso quando esiste un contratto formale a monte) è un
+cambio di **comportamento** del gate, non di citazione — fuori dallo scope di questa
+correzione, e va a ledger.
 
 ---
 
@@ -22,19 +65,36 @@ brief lo aveva tradotto in "BUILD∥ default". Il council ha smontato l'enunciat
 | **Breadth-di-ricerca** (esplorazione, fan-out di letture) | **NO** (+90.2% Anthropic su research) | i 5 angoli della deep-research di questo ciclo |
 | **Specialist con RUOLI diversi** | **NO** (è il regime dove multi-agent vince) | federation: gemini-search ∥ codex-sandbox ∥ claude-redteam |
 | **Pezzi del sistema strutturalmente indipendenti** | **NO se davvero indipendenti** | modulo A e modulo B con zero file/contratti condivisi |
-| **Coder paralleli sullo STESSO artefatto** | **SÌ, −30%** (CooperBench, arXiv 2601.13295) + failure-mode Devin | 3 agenti che editano lo stesso file/feature |
+| **Coder paralleli sullo STESSO artefatto** | **assunto\*** (nessuno studio lo misura direttamente) | 3 agenti che editano lo stesso file/feature |
 
-> **Citazione corretta 2026-08-01 — non ripristinare il numero vecchio.** Questa riga
-> citava `−70% (Google 2512.08296)`. Verificato alla fonte: quel −70,0% è **sequential
-> planning** (PlanCraft, topologia Independent), non coding; sul benchmark di coding
-> dello stesso paper (SWE-bench Verified) le topologie multi-agent stanno fra −2,1% e
-> −14,9%, e misurano N agenti sulla **stessa** issue. Lo studio che misura davvero il
-> caso di questa riga — lavoro **diverso ma sovrapposto** nello stesso repo — è
-> **CooperBench** (Khatua et al., Stanford, 2026-01-19): 600+ task collaborativi, 12
-> librerie, 4 linguaggi, test scritti da esperti; due agenti che cooperano riescono in
-> media il **30% in meno** di un solo agente che fa entrambi i task. Il ceiling 3-4
-> agenti (riga 56) resta di 2512.08296 ed è verbatim: era solo il −70% a venire dalla
-> riga sbagliata.
+> **Citazione corretta 2026-08-01 — non ripristinare il numero vecchio, e non
+> sostituirlo con un altro numero che non misura questa riga.** Questa riga citava
+> `−70% (Google 2512.08296)`. Verificato alla fonte (arXiv:2512.08296v3): quel −70,0% è
+> **sequential planning** (PlanCraft, topologia Independent), non coding; sul benchmark
+> di coding dello stesso paper (SWE-bench Verified) le topologie stanno fra −2,1% e
+> −14,9%, e misurano N agenti sulla **stessa issue**.
+>
+> **\* «assunto»** — e va detto, perché il gate è incondizionato. La review avversariale
+> del 2026-08-01 (Codex GPT-5.6-Sol, xhigh, cross-family) ha bocciato la prima stesura
+> di questa correzione proprio qui: sostituivo un numero stirato con un altro numero
+> stirato. **CooperBench** (Khatua et al., arXiv 2601.13295v2, 2026-01-19) è l'evidenza
+> più vicina che abbiamo — 600+ task, 12 librerie, 4 linguaggi, test scritti da esperti,
+> **−30% di successo medio**, retention pooled 0,59 («41% della capacità solo persa»),
+> modelli di punta al ~25% in cooperativa — ma il suo setup è **due feature diverse, due
+> container separati, patch mergiate dopo** (77,3% dei task ha ground-truth in
+> conflitto). È la forma della **nostra flottiglia di worktree**, non due agenti che
+> editano lo stesso file. Nessuno studio che abbiamo letto misura il caso letterale di
+> questa riga.
+>
+> Quindi la proibizione assoluta è una **policy operativa nostra**, non un invariante
+> stabilito dalla ricerca: il caso più difficile lo assumiamo peggiore di quello più
+> facile già misurato, e preferiamo un falso-negativo (seriale evitabile, costa tempo) a
+> un falso-positivo (parallelo sbagliato, costa un conflitto semantico silenzioso).
+> L'inferenza è nostra, non del paper. Il ceiling 3-4 agenti (riga ~56) è verbatim in
+> 2512.08296, ma deriva dalla crescita dei turni sotto **budget di reasoning fisso
+> (4.800 token)**: non è un ceiling specifico dei coder né della concorrenza CPU —
+> applicarlo ai coder esentando gli agenti infra I/O-bound è ancora estrapolazione
+> nostra.
 
 > **"Dove si può" (utente) = i primi tre tipi.** Il quarto è ciò che l'evidenza vieta. La contraddizione
 > desiderio-vs-evidenza è **apparente**: si scioglie limitando il fan-out ai tipi che non degradano.

--- a/research/operations/specs/P6-parallelize-gate.md
+++ b/research/operations/specs/P6-parallelize-gate.md
@@ -22,7 +22,19 @@ brief lo aveva tradotto in "BUILD∥ default". Il council ha smontato l'enunciat
 | **Breadth-di-ricerca** (esplorazione, fan-out di letture) | **NO** (+90.2% Anthropic su research) | i 5 angoli della deep-research di questo ciclo |
 | **Specialist con RUOLI diversi** | **NO** (è il regime dove multi-agent vince) | federation: gemini-search ∥ codex-sandbox ∥ claude-redteam |
 | **Pezzi del sistema strutturalmente indipendenti** | **NO se davvero indipendenti** | modulo A e modulo B con zero file/contratti condivisi |
-| **Coder paralleli sullo STESSO artefatto** | **SÌ, −70%** (Google 2512.08296) + failure-mode Devin | 3 agenti che editano lo stesso file/feature |
+| **Coder paralleli sullo STESSO artefatto** | **SÌ, −30%** (CooperBench, arXiv 2601.13295) + failure-mode Devin | 3 agenti che editano lo stesso file/feature |
+
+> **Citazione corretta 2026-08-01 — non ripristinare il numero vecchio.** Questa riga
+> citava `−70% (Google 2512.08296)`. Verificato alla fonte: quel −70,0% è **sequential
+> planning** (PlanCraft, topologia Independent), non coding; sul benchmark di coding
+> dello stesso paper (SWE-bench Verified) le topologie multi-agent stanno fra −2,1% e
+> −14,9%, e misurano N agenti sulla **stessa** issue. Lo studio che misura davvero il
+> caso di questa riga — lavoro **diverso ma sovrapposto** nello stesso repo — è
+> **CooperBench** (Khatua et al., Stanford, 2026-01-19): 600+ task collaborativi, 12
+> librerie, 4 linguaggi, test scritti da esperti; due agenti che cooperano riescono in
+> media il **30% in meno** di un solo agente che fa entrambi i task. Il ceiling 3-4
+> agenti (riga 56) resta di 2512.08296 ed è verbatim: era solo il −70% a venire dalla
+> riga sbagliata.
 
 > **"Dove si può" (utente) = i primi tre tipi.** Il quarto è ciò che l'evidenza vieta. La contraddizione
 > desiderio-vs-evidenza è **apparente**: si scioglie limitando il fan-out ai tipi che non degradano.

--- a/scripts/federation_parallelize.py
+++ b/scripts/federation_parallelize.py
@@ -25,8 +25,23 @@ Design contract (spec ``research/operations/specs/P6-parallelize-gate.md``):
   ambiguous/high-risk tasks is *optional and documented*, NOT implemented here —
   this module stays deterministic so the gate tests are falsifiable.
 * **Coders on the same artifact are NEVER parallelized** (spec §4 cond. 2,
-  Google arXiv 2512.08296 ``−70%`` on sequential coding). This is the one hard
-  prohibition the estimator enforces structurally, not heuristically.
+  CooperBench ``−30%`` on overlapping code — Khatua et al., *"CooperBench: Why
+  Coding Agents Cannot be Your Teammates Yet"*, arXiv 2601.13295, 2026-01-19:
+  600+ collaborative tasks across 12 libraries in 4 languages with
+  expert-written tests; two agents working together average **30% lower**
+  success than one agent performing both tasks individually). This is the one
+  hard prohibition the estimator enforces structurally, not heuristically.
+
+  CITATION CORRECTED 2026-08-01 — do not "restore" the old number. This rule
+  used to cite ``Google arXiv 2512.08296 −70% on sequential coding``. Verified
+  at source: that paper's −70.0% is **sequential planning** (PlanCraft,
+  Independent topology), not coding at all; on its own coding benchmark
+  (SWE-bench Verified) every multi-agent topology lands between −2.1% and
+  −14.9%, and that measures N agents on the SAME issue, not two agents on
+  different-but-overlapping work. CooperBench is the study that actually
+  measures THIS rule's case. The 3–4 coder ceiling below is genuinely from
+  2512.08296 and is quoted verbatim there — only the −70% was borrowed from
+  the wrong row.
 
 The four kinds of parallelism (spec §0):
 
@@ -36,7 +51,7 @@ kind                              degrades?   estimator verdict
 breadth-of-research               no          may be True
 specialist roles (disjoint)       no          may be True
 structurally-independent pieces   no          may be True (if disjoint)
-coders on the SAME artifact       yes (−70%)  ALWAYS False
+coders on the SAME artifact       yes (−30%)  ALWAYS False
 ================================  ==========  ===========================
 """
 
@@ -50,7 +65,9 @@ from enum import Enum
 # Constants — the bayesian prior cap (spec §3.3) and merge-cost bands (§3.5).
 # ─────────────────────────────────────────────────────────────────────────────
 
-#: Initial coder-concurrency ceiling (Google arXiv 2512.08296 hard 3-4 ceiling).
+#: Initial coder-concurrency ceiling (Google arXiv 2512.08296 hard 3-4 ceiling —
+#: verified verbatim at source 2026-08-01: "beyond 3-4 agents, creating a hard
+#: resource ceiling where communication cost dominates reasoning capability").
 #: Applies to CPU-bound concurrent *coders*, NOT to short I/O-bound infra agents
 #: (search/explore). A bayesian *prior*, updatable with local feedback — never a
 #: dogma (spec §3.3, §3.6). The gate enforces it as a ceiling, not a target.

--- a/scripts/federation_parallelize.py
+++ b/scripts/federation_parallelize.py
@@ -24,24 +24,46 @@ Design contract (spec ``research/operations/specs/P6-parallelize-gate.md``):
 * **No LLM call on the conservative path** (spec §3.1). Escalation-to-Claude for
   ambiguous/high-risk tasks is *optional and documented*, NOT implemented here —
   this module stays deterministic so the gate tests are falsifiable.
-* **Coders on the same artifact are NEVER parallelized** (spec §4 cond. 2,
-  CooperBench ``−30%`` on overlapping code — Khatua et al., *"CooperBench: Why
-  Coding Agents Cannot be Your Teammates Yet"*, arXiv 2601.13295, 2026-01-19:
-  600+ collaborative tasks across 12 libraries in 4 languages with
-  expert-written tests; two agents working together average **30% lower**
-  success than one agent performing both tasks individually). This is the one
-  hard prohibition the estimator enforces structurally, not heuristically.
+* **Coders on the same artifact are NEVER parallelized** (spec §4 cond. 2).
+  This is an **operational safety policy of this repo, not a research-established
+  invariant** — say it plainly, because the code enforces it unconditionally:
+  ``_estimate_merge_cost`` returns ``HIGH`` on artifact overlap *before*
+  ``has_explicit_contract`` is ever read (that flag can only lift MED→LOW on work
+  already proven disjoint). We choose a false-negative (a serial run that could
+  have been parallel) over a false-positive, because a wrong parallel run costs a
+  silent semantic conflict and a serial one costs only time. No published study
+  we have read establishes an absolute prohibition; the evidence below supports
+  strong caution, and we round caution up to a rule on purpose.
 
-  CITATION CORRECTED 2026-08-01 — do not "restore" the old number. This rule
-  used to cite ``Google arXiv 2512.08296 −70% on sequential coding``. Verified
-  at source: that paper's −70.0% is **sequential planning** (PlanCraft,
-  Independent topology), not coding at all; on its own coding benchmark
-  (SWE-bench Verified) every multi-agent topology lands between −2.1% and
-  −14.9%, and that measures N agents on the SAME issue, not two agents on
-  different-but-overlapping work. CooperBench is the study that actually
-  measures THIS rule's case. The 3–4 coder ceiling below is genuinely from
-  2512.08296 and is quoted verbatim there — only the −70% was borrowed from
-  the wrong row.
+  WHAT THE EVIDENCE ACTUALLY SAYS (each measured on a *different* shape — do not
+  collapse them into one number):
+
+  - **CooperBench** — Khatua et al., *"Why Coding Agents Cannot be Your Teammates
+    Yet"*, arXiv 2601.13295, 2026-01-19. 600+ tasks, 12 libraries, 4 languages,
+    expert-written tests. Two agents get two *different* features, each in its own
+    docker container, and the patches are merged afterwards; 77.3% of tasks have
+    conflicting ground-truth solutions. Headline: **30% lower average success**
+    than one agent doing both; pooled retention 0.59, i.e. "41% of Solo capability
+    is lost when agents must coordinate"; leading models reach only ~25% in the
+    cooperative setting. NOTE THE SHAPE: this is *separate-workspace parallel
+    features whose patches collide later* — which is our worktree fleet — and NOT
+    two agents co-editing one file. It is the closest evidence we have, and it is
+    still not a measurement of this rule's literal case.
+  - **SWE-bench Verified** (inside arXiv 2512.08296): N agents on the *same*
+    issue. Every topology degrades, mildly — −2.1% (Hybrid) to −14.9%
+    (Independent) — and individual cells sometimes beat the single-agent
+    baseline. Conditional caution, not universality.
+  - **NOT applicable**: that paper's **−70.0%** is PlanCraft *sequential
+    planning*, Independent topology. It is not a coding result.
+
+  CITATION CORRECTED 2026-08-01, and the correction is itself falsifiable.
+  Until 2026-08-01 this rule cited ``arXiv 2512.08296 −70% on sequential
+  coding``; verified against arXiv:2512.08296v3 and arXiv:2601.13295v2, that
+  −70% is planning. Do not restore it. What WOULD reopen this: a study measuring
+  concurrent edits to one artifact directly, a revision of either paper changing
+  the cited tables, or local telemetry from our own fleet. The prohibition is a
+  policy and policies are revisable — what is not revisable is attributing it to
+  a number the source does not support.
 
 The four kinds of parallelism (spec §0):
 
@@ -51,8 +73,13 @@ kind                              degrades?   estimator verdict
 breadth-of-research               no          may be True
 specialist roles (disjoint)       no          may be True
 structurally-independent pieces   no          may be True (if disjoint)
-coders on the SAME artifact       yes (−30%)  ALWAYS False
+coders on the SAME artifact       assumed*    ALWAYS False (policy)
 ================================  ==========  ===========================
+
+\\* "assumed": no study we have read measures concurrent edits to ONE artifact.
+The nearest evidence (CooperBench, −30% on separate-workspace overlapping
+features) is a strictly easier setting and still degrades, so we treat the
+harder case as worse and refuse it. That inference is ours, not the paper's.
 """
 
 from __future__ import annotations
@@ -65,9 +92,15 @@ from enum import Enum
 # Constants — the bayesian prior cap (spec §3.3) and merge-cost bands (§3.5).
 # ─────────────────────────────────────────────────────────────────────────────
 
-#: Initial coder-concurrency ceiling (Google arXiv 2512.08296 hard 3-4 ceiling —
-#: verified verbatim at source 2026-08-01: "beyond 3-4 agents, creating a hard
-#: resource ceiling where communication cost dominates reasoning capability").
+#: Initial coder-concurrency ceiling. arXiv 2512.08296 says verbatim: "beyond
+#: 3-4 agents, creating a hard resource ceiling where communication cost
+#: dominates reasoning capability" (verified at source 2026-08-01). CAVEAT, so
+#: nobody over-reads it: that result comes from cross-domain turn growth under a
+#: FIXED total reasoning budget (4,800 tokens) — it is not a coder-specific nor
+#: a CPU-concurrency ceiling, and the paper calls larger collectives an open
+#: question. Applying it to concurrent coders while exempting short I/O-bound
+#: infra agents is OUR extrapolation (spec §3.3), which is exactly why it is a
+#: bayesian prior updatable with local feedback and never a dogma (§3.6).
 #: Applies to CPU-bound concurrent *coders*, NOT to short I/O-bound infra agents
 #: (search/explore). A bayesian *prior*, updatable with local feedback — never a
 #: dogma (spec §3.3, §3.6). The gate enforces it as a ceiling, not a target.


### PR DESCRIPTION
## What

`scripts/federation_parallelize.py` founds its **one hard prohibition** — *coders on the same artifact are NEVER parallelized* — on `Google arXiv 2512.08296 −70% on sequential coding`.

Read at source: that paper's **−70.0% is sequential PLANNING** (PlanCraft, Independent topology). It is not a coding result.

The rule is correct. The number came from the wrong row.

## Three measurements were being collapsed into one

| Number | What it actually measures |
|---|---|
| **−70.0%** | PlanCraft, sequential planning, Independent topology. Not coding. |
| **−2.1% … −14.9%** | SWE-bench Verified: N agents on the **same** issue (all topologies degrade, mildly). |
| **−30%** | **CooperBench**: two agents on **different-but-overlapping** work in one repo. ← *this rule's actual case* |

[CooperBench](https://arxiv.org/abs/2601.13295) (Khatua et al., *"Why Coding Agents Cannot be Your Teammates Yet"*, Stanford, 2026-01-19): 600+ collaborative tasks across 12 libraries in 4 languages with expert-written tests; two agents working together average **30% lower** success than one agent performing both tasks individually.

## Also fixed: the spec the module implements

`research/operations/specs/P6-parallelize-gate.md` line 25 carried the identical false claim. Worth noting — **the spec already said "sequential" correctly in three other places** (lines 69, 237, 254); the single row that said "coding" is the one that got copied into the code.

Scope stops there. The other 9 files citing 2512.08296 invoke it for different claims (error-amplification ratios, the ceiling, "three of four kinds are free") and were not touched.

## What is NOT changed

The **3–4 coder-concurrency ceiling stays**. It genuinely is from 2512.08296 and is quoted verbatim there: *"beyond 3-4 agents, creating a hard resource ceiling where communication cost dominates reasoning capability"*. Only the −70% was borrowed from the wrong row.

Both edits carry an explicit **do-not-restore** note so a future reader does not "fix" the citation back to the old number.

## Verification

- No behaviour change: docstrings + one spec table cell. `ast.parse` OK.
- `scripts/test_federation_parallelize_gate.py`: **20 passed, 4 failed**.
- Those 4 failures are **pre-existing, not from this diff** — proven by running the same file from a pristine `git archive origin/main` checkout: identical `4 failed, 20 passed`. They fail on `import federation_orchestrator` (ModuleNotFoundError) in this environment, which a docstring cannot cause.
- Full pre-push suite green.

Superscar **#6 (phantom citation)** — this one was inside our own guardrail.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>