### PR TITLE
docs(agent-library): keep the topology rule, drop the cause the paper rejects

### DIFF
--- a/.claude/agents/wr2-design-architect-resources/deep-research.md
+++ b/.claude/agents/wr2-design-architect-resources/deep-research.md
@@ -161,6 +161,14 @@ Anti-patterns observed in academic and industry literature, with mitigations:
 6. **Single-critic blind spot** — generator and critic share same model's biases. _Mitigation_: persona-based multi-critic (typography + brand + copy + marketing-result), cross-model panel (Claude main, Gemini cross-check, NotebookLM ground-truth) — the **bipolar verifier** pattern already in use at Bali Zero.
 7. **Agent error compounding in multi-agent systems** — Google's 2025 study found independent multi-agent systems amplify errors **17.2×** vs single-agent baselines unless centralized state management is added. _Mitigation_: orchestrator agent owns canonical state, sub-agents are stateless functions that read shared state and emit deltas. **No autonomous peer-to-peer hand-offs in production.**
 
+   > **⚠️ CORRECTION 2026-08-02 (the finding above is a historical record; this is the current reading).**
+   > The 17.2× is real and verbatim in arXiv:2512.08296v3 — but the paper's own regression finds error
+   > amplification **not statistically significant** after controls (β̂=0.014, p=0.658; interaction with
+   > tool count p=0.332) and concludes the architecture differences "are better explained by other
+   > coordination mechanisms, particularly efficiency and overhead, rather than error propagation per
+   > se". **The mitigation stands** — Independent remains the worst-measured topology and centralized
+   > orchestration the best — but error compounding is not the mechanism. Do not cite 17.2× as a cause.
+
 ---
 
 ## 9. Sintesi: design agent architecture per Bali Zero
@@ -200,7 +208,7 @@ For Bali Zero specifically, given constraints (solo-dev, agency-scale ~10–30 c
 4. Diffusion-variance hallucination check on any generated raster.
 5. Human review queue for final go/no-go on publish.
 
-**Single agent vs multi-agent verdict**: multi-agent **with strict orchestrator** is correct because specialist roles are genuinely different competencies; but Google's 17.2× error-amplification finding is a serious warning — architecture must be **centralized state, stateless workers**, not peer-to-peer. Avoid temptation to give each sub-agent its own memory.
+**Single agent vs multi-agent verdict**: multi-agent **with strict orchestrator** is correct because specialist roles are genuinely different competencies; and Google's study still measures Independent (peer-to-peer, no coordination) as the worst topology — architecture must be **centralized state, stateless workers**, not peer-to-peer. Avoid temptation to give each sub-agent its own memory. (Corrected 2026-08-02: the warning used to be attributed to the 17.2× error-amplification figure; per the paper's own regression that effect is not significant after controls — the driver is coordination efficiency and overhead. See the correction note at item 7.)
 
 **Don't build (yet)**:
 

--- a/.claude/agents/wr2-design-architect.md
+++ b/.claude/agents/wr2-design-architect.md
@@ -406,7 +406,7 @@ These rules cannot be overridden by user request without explicit Antonello appr
 
 ## Hard guardrails (process-level)
 
-- **Centralized state**: you are the orchestrator. Subagents (critic, future layout-composer, future brief-interpreter) are stateless workers reading shared files. NEVER let subagents talk to each other peer-to-peer (Google's 17.2× error-amplification finding).
+- **Centralized state**: you are the orchestrator. Subagents (critic, future layout-composer, future brief-interpreter) are stateless workers reading shared files. NEVER let subagents talk to each other peer-to-peer. (Reason corrected 2026-08-02: this used to cite "Google's 17.2× error-amplification finding". The 17.2× is real and verbatim in arXiv:2512.08296v3, but that paper's own regression finds error amplification **not** statistically significant after controls — p=0.658 — and attributes the architecture gap to coordination **efficiency and overhead** instead. Independent is still the worst-measured topology; error propagation is not why. Do not restore the old reason.)
 - **Human-in-loop on publish**: you do NOT publish to Instagram. Damar publishes manually. Your output stops at Canva (via existing wr2-canva-apply skill).
 - **No autonomous skill writes to main**: skill changes go to `_proposed/`. Antonello commits to main weekly.
 - **Cost = zero**: only OAuth Claude (Opus/Sonnet/Haiku via subagents), free Gemini CLI for cross-check, NotebookLM for ground-truth RAG, Kimi CLI (`~/.kimi-code/bin/kimi`, flat subscription — DeepSeek API retired 2026-07-19). NEVER use ANTHROPIC_API_KEY, OpenAI API, Vertex AI billed runtime.

--- a/agent-library/02-patterns.md
+++ b/agent-library/02-patterns.md
@@ -249,9 +249,26 @@ Pre-publish artifact: `~/.claude/agents/devils-advocate.md` ("find the legal fla
 
 **Status**: implemented (superpowers:dispatching-parallel-agents skill + cap 4 documented operational rule)
 
-**Quando usarlo**: ≥2 task indipendenti senza shared state né dipendenze sequenziali. Orchestrator dispatcha N agent paralleli (cf. `superpowers:dispatching-parallel-agents`). Topology centralized (orchestrator-led) preferita: error amplification 4.4× vs independent (no-coord) 17.2× (Kim et al. 2025 arxiv 2512.08296).
+**Quando usarlo**: ≥2 task indipendenti senza shared state né dipendenze sequenziali. Orchestrator dispatcha N agent paralleli (cf. `superpowers:dispatching-parallel-agents`). Topology centralized (orchestrator-led) preferita — **ma NON per il motivo che citavamo**: vedi la nota qui sotto.
 
-**Anti-pattern**: >4 sessioni parallele se ≥1 tocca prod esterna (LLM provider capacity exhaustion wave-level); brainstorm cap >3 scambi (gonfiamento scope FASE 2 wave 2026-05-07); scope esterno-irreversibile in wave parallela (prod deploy concorrente); independent topology (peer-to-peer no coordination → 17.2× error).
+> **Citazione corretta 2026-08-02 — non ripristinare la vecchia motivazione.** Fino a oggi questa riga
+> diceva «centralized preferita: error amplification 4.4× vs independent 17.2× (Kim et al.
+> arxiv 2512.08296)». I due numeri **esistono davvero** nel paper (v3, verbatim: _"Independent systems
+> amplify trace-level errors 17.2× … Centralized coordination, however, contains this to 4.4×"_) — ma
+> il paper stesso, **dopo i controlli, li dichiara non significativi**: _"neither the main effect of
+> error amplification (β̂=0.014, p=0.658) nor its interaction with tool count (β̂=0.022, p=0.332)
+> reaches statistical significance"_, e conclude che le differenze fra architetture _"are better
+> explained by other coordination mechanisms, particularly efficiency and overhead, rather than error
+> propagation per se"_. Citare il 17.2× come **causa** della preferenza per centralized afferma
+> esattamente ciò che la fonte rifiuta.
+>
+> La preferenza per centralized **resta** — è la topologia che il paper misura come migliore sui suoi
+> benchmark — ma il meccanismo da citare è **efficienza e overhead di coordinamento**, non
+> l'amplificazione d'errore. Storia: questo repo aveva ledgerizzato a giugno che «il 17.2× non è nel
+> paper, è un commento TDS». **Quella nota era il fantasma**: il numero c'è. Il difetto era un altro e
+> peggiore. Verificato alla fonte 2026-08-02 su arXiv:2512.08296v3.
+
+**Anti-pattern**: >4 sessioni parallele se ≥1 tocca prod esterna (LLM provider capacity exhaustion wave-level); brainstorm cap >3 scambi (gonfiamento scope FASE 2 wave 2026-05-07); scope esterno-irreversibile in wave parallela (prod deploy concorrente); independent topology (peer-to-peer no coordination — la topologia che il paper misura peggio, per overhead ed efficienza di coordinamento; **non** citare il 17.2× come sua causa).
 
 **Esempio concreto**: `~/.claude/projects/-Users-nuzantara-Desktop-nuzantara/memory/lessons_wave_pacing_design_rigor.md`
 

--- a/agent-library/03-lessons.md
+++ b/agent-library/03-lessons.md
@@ -196,8 +196,19 @@ single file).
 
 ### 19. Multi-agent topology Kim 2025
 
-**Sintesi**: Kim et al. arxiv 2512.08296 (Google DeepMind+MIT, Dec 2025). 5 topology controlled study, 180 configs. SAS=1× baseline, **Centralized (orchestrator-led)=4.4×**, **Independent (parallel no-coord)=17.2×** error amplification. Centralized preferito per task indipendenti parallelizzabili.
-**Quando applica**: design wave/cron multi-LLM cross-tool; scelta topology fra single-agent vs orchestrator-led vs peer-to-peer.
+**Sintesi**: Kim et al. arXiv:2512.08296 (**Google Research + Google DeepMind + MIT**, dic 2025, v3 apr 2026). Studio controllato su **260 configurazioni**, 6 benchmark agentici, 5 architetture (SAS + Independent/Centralized/Decentralized/Hybrid), 3 famiglie LLM. **Centralized (orchestrator-led) preferito** per task indipendenti parallelizzabili.
+
+**⚠️ Correzione 2026-08-02 — il MOTIVO che citavamo era sbagliato, e i numeri erano tre volte imprecisi.** Questa voce diceva «Google DeepMind+MIT, **180 configs**, Centralized=4.4× / Independent=17.2× **error amplification**» e usava quei due numeri come causa della preferenza. Verificato alla fonte su arXiv:2512.08296v3:
+
+- Le configurazioni sono **260**, non 180.
+- Le affiliazioni sono **tre** (Google Research, Google DeepMind, MIT), non due.
+- **4.4× e 17.2× ESISTONO** e sono verbatim (_"Independent systems amplify trace-level errors 17.2× … Centralized coordination, however, contains this to 4.4×"_) — **ma il paper li dichiara non significativi dopo i controlli**: _"neither the main effect of error amplification (β̂=0.014, p=0.658) nor its interaction with tool count (β̂=0.022, p=0.332) reaches statistical significance"_, e conclude che le differenze fra architetture _"are better explained by other coordination mechanisms, particularly efficiency and overhead, rather than error propagation per se"_.
+
+**Quindi**: la preferenza per centralized regge, ma il meccanismo da citare è **efficienza e overhead di coordinamento**. Il 17.2× **non** è la ragione, ed è scorretto usarlo come tale.
+
+**Nota sulla nostra memoria**: a giugno avevamo ledgerizzato che «il 17.2× non è nel paper, è un commento TDS». **Quella nota era essa stessa il fantasma** — il numero c'è, verbatim. Una nota che ci scriviamo noi ha lo stesso statuto di un report altrui: è un LEAD, non un fatto (cfr. `lessons_hallucinating_tool_output_is_diabolical`).
+
+**Quando applica**: design wave/cron multi-LLM cross-tool; scelta topology fra single-agent vs orchestrator-led vs peer-to-peer. E come promemoria: prima di citare un numero di un paper come **causa**, controlla se il paper lo tratta come tale.
 **Fonte primaria**: `~/.claude/projects/-Users-nuzantara-Desktop-nuzantara/memory/lessons_multi_agent_topology_kim_2025.md`
 **Pattern correlato**: `02-patterns.md#8` (parallel wave + capacity caps)
 


### PR DESCRIPTION
## What

Four live surfaces cited **"Google's 17.2× error-amplification finding"** as the *reason* to prefer a centralized orchestrator over peer-to-peer subagents. Verified at source on `arXiv:2512.08296v3`:

- **17.2× (Independent) and 4.4× (Centralized) ARE in the paper**, verbatim: *"Independent systems amplify trace-level errors 17.2× … Centralized coordination, however, contains this to 4.4×"*.
- **But the paper's own regression finds the effect not significant after controls**: *"neither the main effect of error amplification (β̂=0.014, p=0.658) nor its interaction with tool count (β̂=0.022, p=0.332) reaches statistical significance"*.
- And it concludes the architecture gap is *"better explained by other coordination mechanisms, particularly efficiency and overhead, rather than error propagation per se"*.

Citing 17.2× as the **cause** asserts what the source explicitly declines to support.

## What is NOT changed

**The rule.** Independent remains the worst-measured topology and centralized orchestration the best. Only the cited mechanism is corrected — from error propagation to coordination efficiency/overhead. Every edit carries a do-not-restore note.

## Class audit — the claim lived on more than the two ledgered files

| Surface | Treatment |
|---|---|
| `agent-library/02-patterns.md` (pattern 8 + anti-pattern line) | rewritten |
| `agent-library/03-lessons.md` (lesson 19) | rewritten |
| `.claude/agents/wr2-design-architect.md` | **live orchestrator instruction** — rewritten |
| `.claude/agents/wr2-design-architect-resources/deep-research.md` | dated research record — **annotated, not rewritten** |

Memory corrected in the same pass (untracked here): the primary-source lessons file, the nb-agents reference rule, and the June capture ledger line.

## Two more wrong numbers, found while in there

Lesson 19 also claimed **180 configurations** (the study covers **260**) and **"Google DeepMind + MIT"** (it is **Google Research + Google DeepMind + MIT**). Both corrected at source.

## The uncomfortable part

This repo had ledgered in June that *"17.2× is not in the paper, it's a TDS commentary"*. **That note was itself the phantom** — the number is in the paper. It most likely came from the Towards-Data-Science article listed among the sources of our own primary-source memory file.

A note we write ourselves has the same standing as anyone else's report: **a LEAD, not a fact.**

## Traps avoided (worth recording)

- `CLAUDE.md` matched `17.2` — it was **Postgres 17.2**. The first probe grepped the digits, not the claim (W107); it also matched CSS and PNGs.
- The first probe **missed** `wr2-design-architect.md`, because it filtered on "contains the DOI" and that line cites the number *without* one. Our own memory file is what flagged it.
- Prettier rejected the first commit. `--write` was **not** run blind (W112 — the formatter rewrites content): the diff was inspected first (only `*italic*` → `_italic_`), and the load-bearing tokens were re-verified afterwards — `β̂=0.014`, `p=0.658`, `17.2×` ×9, `260` ×2 all intact.

Closes the last ledgered instance of the citation family opened by #3509 and documented in #3511.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>