### PR TITLE
feat(kbli): give the PMA cure a path to the store inspect_kbli actually reads

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_qdrant_pma_sync.py
+++ b/apps/backend-rag/backend/scripts/kbli_qdrant_pma_sync.py
@@ -1,0 +1,354 @@
+"""
+kbli_qdrant_pma_sync.py — sync the `pma_status` / `pma_max_asing` Qdrant payload
+fields of KBLI points from the canonical dataset.
+
+WHY THIS EXISTS, AND WHY THE KG-SIDE CURE WAS NOT ENOUGH (2026-08-02, found
+during the prove-live of the Perpres 49/2021 Lampiran III cure, #3515):
+`inspect_kbli` resolves the PMA verdict with Qdrant FIRST and the KG node only
+as a fallback (`backend/app/routers/kbli_notebook.py`):
+
+    pma_status = (
+        (_payload_value(qdrant_payload, "pma_status") if qdrant_payload else None)
+        or props.get("pma_status")      # <- the kg_nodes property
+        ...
+    )
+
+So `kg_kbli_resync.py` — whose own docstring exists *because* `inspect_kbli`
+served a stale `pma_status` — cannot move that field on this endpoint while
+Qdrant carries any value at all. Measured live: after the cure, `kg_nodes` said
+TERBATAS on all twenty codes and `inspect_kbli 51101` still answered TERBUKA,
+because the Qdrant payload still read `TERBUKA / 100`. A cure that stops at the
+KG is a cure the channel never sees.
+
+WHAT IT WRITES: exactly two flat keys, `pma_status` and `pma_max_asing`, via
+`set_payload` — a payload MERGE that touches nothing else. Never
+`overwrite_payload`, never `delete_payload`, never a vector. **The embedding
+model is FROZEN** (`text-embedding-3-small`, 93k+ vectors — CLAUDE.md §9); a
+re-index to change two scalars would put that invariant at risk for no reason.
+
+SCOPE DISCIPLINE (mirrors `kbli_qdrant_risk_clear.py` and
+`kg_kbli_license_fix.py`): `--codes` is MANDATORY. No code is ever
+auto-discovered or swept.
+
+`--collection` IS ALSO MANDATORY, and that is deliberate. The physical name is
+`kbli_2025_final_hybrid`; the logical name `kbli_2025_final` **does not exist**
+as a collection, and `kbli_2025_final_oss` (10,825 points) answers to none of
+the code keys the router tries. Writing a default here would freeze a measure of
+the world into a constant — the exact shape that took production down for 27h in
+W106 — so the caller states it and the guard below checks it.
+
+THE WRONG-COLLECTION GUARD: if not one of the requested codes matches a single
+point, the run exits 2 instead of reporting a tidy "0 updated". A probe pointed
+at a collection that does not carry `kode_kbli` returns a clean, believable zero
+for every code you ask about, including codes you know exist — that is how this
+defect was nearly mis-diagnosed on the day this script was written.
+
+USAGE (dry-run is the default; nothing is written without --apply):
+    cd /app && python backend/scripts/kbli_qdrant_pma_sync.py \\
+        --collection kbli_2025_final_hybrid --codes 51101,25200
+
+    cd /app && python backend/scripts/kbli_qdrant_pma_sync.py \\
+        --collection kbli_2025_final_hybrid --codes 51101,25200 --apply
+
+Deliberately import-free of `backend.*`: the two cure tools that already run in
+this image (`kbli_documents_cure.py`, `kg_kbli_resync.py`) read their config
+from the environment and fetch the canonical over HTTP, and `PYTHONPATH=.` in
+this container REPLACES site-packages rather than extending it (it has already
+cost one `ModuleNotFoundError: asyncpg`). Same shape here, for the same reason.
+
+AFTER APPLYING, EVICT THE CACHE: `inspect_kbli` caches its assembled payload
+under `kbli_inspect_v2_<code>` for up to 30 days, so a cured Qdrant payload is
+invisible on the channel until `kbli_inspect_cache_bust.py --only <codes>
+--apply` has run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("kbli_qdrant_pma_sync")
+
+RAW_BASE = "https://raw.githubusercontent.com/Balizero1987/Teman2/main"
+DATASET_URL = f"{RAW_BASE}/data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+
+# The flat KBLI payload invariant (CLAUDE.md §9) — the code lives in
+# `kode_kbli`, never nested. Points are always resolved through this filter,
+# never through a point-id assumption.
+CODE_KEY = "kode_kbli"
+
+_SCROLL_PAGE_LIMIT = 256
+
+
+@dataclass(frozen=True)
+class Target:
+    """What the canonical says this code's PMA fields should be."""
+
+    code: str
+    pma_status: str
+    pma_max_asing: Any
+
+
+@dataclass
+class CodePlan:
+    """Pure decision record for one code — no I/O, so it unit-tests directly."""
+
+    code: str
+    target: Target
+    point_ids: list[Any]
+    current: dict[Any, dict[str, Any]]
+
+    @property
+    def found(self) -> bool:
+        return bool(self.point_ids)
+
+    def stale_points(self) -> list[Any]:
+        """Point ids whose payload disagrees with the canonical on either field."""
+        out = []
+        for pid in self.point_ids:
+            cur = self.current.get(pid, {})
+            if (
+                cur.get("pma_status") != self.target.pma_status
+                or cur.get("pma_max_asing") != self.target.pma_max_asing
+            ):
+                out.append(pid)
+        return out
+
+
+def build_targets(records: list[dict], codes: list[str]) -> tuple[dict[str, Target], list[str]]:
+    """Read the canonical verdict for each requested code.
+
+    A code the canonical does not carry is a REFUSAL, not a skip: writing a
+    guessed or inherited PMA figure onto a client-facing store is the whole
+    class of defect this lane exists to remove.
+    """
+    by_code = {str(r.get("kode_kbli_2025")): r for r in records}
+    targets: dict[str, Target] = {}
+    refusals: list[str] = []
+    for code in codes:
+        rec = by_code.get(code)
+        if rec is None:
+            refusals.append(f"{code}: absent from the canonical dataset — refusing to write a PMA figure for it")
+            continue
+        status = rec.get("pma_status")
+        if not status:
+            refusals.append(f"{code}: canonical record carries no pma_status — nothing authoritative to sync")
+            continue
+        targets[code] = Target(code=code, pma_status=str(status), pma_max_asing=rec.get("pma_max_asing"))
+    return targets, refusals
+
+
+def load_dataset(source: str) -> list[dict]:
+    """Local path or URL — the same two-mode source the sibling cure tools take."""
+    if source.startswith(("http://", "https://")):
+        logger.info("dataset: fetching %s", source)
+        with httpx.Client(timeout=120) as http:
+            resp = http.get(source)
+            resp.raise_for_status()
+            payload = resp.json()
+    else:
+        logger.info("dataset: reading %s", source)
+        payload = json.loads(Path(source).read_text(encoding="utf-8"))
+    return payload["data"]
+
+
+def qdrant_headers(api_key: str | None) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["api-key"] = api_key
+    return headers
+
+
+def find_points_for_code(
+    http: httpx.Client, url_base: str, headers: dict[str, str], collection: str, code: str
+) -> list[dict]:
+    """Scroll every point in `collection` whose flat `kode_kbli` equals `code`."""
+    records: list[dict] = []
+    offset = None
+    while True:
+        body: dict[str, Any] = {
+            "filter": {"must": [{"key": CODE_KEY, "match": {"value": code}}]},
+            "limit": _SCROLL_PAGE_LIMIT,
+            "with_payload": True,
+            "with_vector": False,
+        }
+        if offset is not None:
+            body["offset"] = offset
+        resp = http.post(
+            f"{url_base}/collections/{collection}/points/scroll", headers=headers, json=body
+        )
+        resp.raise_for_status()
+        result = resp.json().get("result", {})
+        records.extend(result.get("points", []))
+        offset = result.get("next_page_offset")
+        if offset is None:
+            break
+    return records
+
+
+def build_plan(code: str, target: Target, points: list[dict]) -> CodePlan:
+    """Turn scrolled points into a plan — pure, no I/O."""
+    ids = [p["id"] for p in points]
+    current = {
+        p["id"]: {
+            "pma_status": (p.get("payload") or {}).get("pma_status"),
+            "pma_max_asing": (p.get("payload") or {}).get("pma_max_asing"),
+        }
+        for p in points
+    }
+    return CodePlan(code=code, target=target, point_ids=ids, current=current)
+
+
+def apply_plan(
+    http: httpx.Client,
+    url_base: str,
+    headers: dict[str, str],
+    collection: str,
+    plan: CodePlan,
+    apply: bool,
+) -> int:
+    """Report (always) and write (only when `apply`). Returns points written."""
+    if not plan.found:
+        logger.info("  %s: NOT FOUND — no point matches %s=%s", plan.code, CODE_KEY, plan.code)
+        return 0
+
+    stale = plan.stale_points()
+    if not stale:
+        logger.info(
+            "  %s: already agrees with canonical (%s / %s)",
+            plan.code,
+            plan.target.pma_status,
+            plan.target.pma_max_asing,
+        )
+        return 0
+
+    if not isinstance(plan.target.pma_max_asing, int):
+        # 47221 carries the string "special" — a non-percentage regime. Passed
+        # through verbatim rather than coerced, but said out loud: a payload
+        # field that changes type is exactly what a downstream reader does not
+        # expect, and a silent coercion here would invent a number.
+        logger.warning(
+            "  %s: canonical cap is %r (%s), not an int — writing it verbatim",
+            plan.code,
+            plan.target.pma_max_asing,
+            type(plan.target.pma_max_asing).__name__,
+        )
+
+    for pid in stale:
+        cur = plan.current.get(pid, {})
+        logger.info(
+            "  %s: point %s  %s/%s -> %s/%s%s",
+            plan.code,
+            pid,
+            cur.get("pma_status"),
+            cur.get("pma_max_asing"),
+            plan.target.pma_status,
+            plan.target.pma_max_asing,
+            "" if apply else "  (dry-run, not written)",
+        )
+
+    if not apply:
+        return 0
+
+    resp = http.post(
+        f"{url_base}/collections/{collection}/points/payload",
+        headers=headers,
+        json={
+            "payload": {
+                "pma_status": plan.target.pma_status,
+                "pma_max_asing": plan.target.pma_max_asing,
+            },
+            "points": stale,
+        },
+    )
+    resp.raise_for_status()
+    return len(stale)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="write changes (default: dry-run)")
+    ap.add_argument(
+        "--codes",
+        required=True,
+        help="comma-separated KBLI codes to sync (never auto-discovered or swept)",
+    )
+    ap.add_argument(
+        "--collection",
+        required=True,
+        help="physical Qdrant collection, e.g. kbli_2025_final_hybrid. Mandatory on "
+        "purpose: a default here would freeze a measure of the world into a constant.",
+    )
+    ap.add_argument("--dataset", default=DATASET_URL, help="canonical dataset: local path or URL")
+    args = ap.parse_args()
+
+    codes = [c.strip() for c in args.codes.split(",") if c.strip()]
+    if not codes:
+        logger.error("--codes produced an empty list, nothing to do")
+        return 2
+
+    targets, refusals = build_targets(load_dataset(args.dataset), codes)
+    if refusals:
+        for r in refusals:
+            logger.error("REFUSED %s", r)
+        logger.error("refusing the whole run — nothing written")
+        return 2
+
+    url_base = os.environ["QDRANT_URL"].rstrip("/")
+    headers = qdrant_headers(os.environ.get("QDRANT_API_KEY"))
+
+    written = 0
+    found = 0
+    agreed = 0
+    with httpx.Client(timeout=60) as http:
+        plans = []
+        for code in codes:
+            points = find_points_for_code(http, url_base, headers, args.collection, code)
+            plans.append(build_plan(code, targets[code], points))
+
+        if not any(p.found for p in plans):
+            # A collection that does not carry `kode_kbli` returns a clean zero
+            # for every code, including ones you know exist. Never report that
+            # as "nothing to do".
+            logger.error(
+                "not one of the %d requested codes matched a point in %r on key %r — "
+                "wrong collection? (the KBLI points live in kbli_2025_final_hybrid)",
+                len(codes),
+                args.collection,
+                CODE_KEY,
+            )
+            return 2
+
+        for plan in plans:
+            if plan.found:
+                found += 1
+                if not plan.stale_points():
+                    agreed += 1
+            written += apply_plan(http, url_base, headers, args.collection, plan, args.apply)
+
+    verb = "APPLIED" if args.apply else "DRY-RUN"
+    logger.info(
+        "%s: %d/%d code(s) found | %d already agreed | %d point(s) %s",
+        verb,
+        found,
+        len(codes),
+        agreed,
+        written if args.apply else sum(len(p.stale_points()) for p in plans if p.found),
+        "written" if args.apply else "would be written",
+    )
+    if not args.apply:
+        logger.info("dry-run complete — rerun with --apply to write")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/backend-rag/backend/tests/scripts/test_kbli_qdrant_pma_sync.py
+++ b/apps/backend-rag/backend/tests/scripts/test_kbli_qdrant_pma_sync.py
@@ -1,0 +1,175 @@
+"""Tests for kbli_qdrant_pma_sync.
+
+The dangerous failure here is not a missed update: it is writing a PMA figure
+that the canonical does not carry, onto the store `inspect_kbli` prefers over
+the KG. So most of this file is refusal and innocence.
+
+Qdrant is mocked entirely via a fake httpx transport — no live Qdrant needed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from backend.scripts.kbli_qdrant_pma_sync import (
+    CODE_KEY,
+    Target,
+    apply_plan,
+    build_plan,
+    build_targets,
+    find_points_for_code,
+)
+
+_COLLECTION = "kbli_2025_final_hybrid"
+_BASE = "http://qdrant.test"
+_HEADERS = {"Content-Type": "application/json"}
+
+
+def _rec(code: str, status: str = "TERBUKA", cap: Any = 100) -> dict:
+    return {"kode_kbli_2025": code, "pma_status": status, "pma_max_asing": cap}
+
+
+def _point(pid: Any, status: str = "TERBUKA", cap: Any = 100) -> dict:
+    return {"id": pid, "payload": {"pma_status": status, "pma_max_asing": cap, "judul": "x"}}
+
+
+class FakeQdrant:
+    """Serves /points/scroll from a code->pages map and records payload writes."""
+
+    def __init__(self, pages_by_code: dict[str, list[list[dict]]]) -> None:
+        self._pages = pages_by_code
+        self.payload_writes: list[dict[str, Any]] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if request.url.path.endswith("/points/scroll"):
+            code = body["filter"]["must"][0]["match"]["value"]
+            assert body["filter"]["must"][0]["key"] == CODE_KEY
+            pages = self._pages.get(code, [[]])
+            idx = body.get("offset") or 0
+            page = pages[idx] if idx < len(pages) else []
+            nxt = idx + 1 if idx + 1 < len(pages) else None
+            return httpx.Response(200, json={"result": {"points": page, "next_page_offset": nxt}})
+        if request.url.path.endswith("/points/payload"):
+            self.payload_writes.append(body)
+            return httpx.Response(200, json={"result": {}, "status": "ok"})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    def client(self) -> httpx.Client:
+        return httpx.Client(transport=httpx.MockTransport(self.handler))
+
+
+# --- refusal: the whole point ------------------------------------------------
+
+
+def test_a_code_absent_from_the_canonical_is_refused_not_skipped():
+    targets, refusals = build_targets([_rec("25200")], ["25200", "99999"])
+    assert "25200" in targets
+    assert any("99999" in r and "absent from the canonical" in r for r in refusals)
+
+
+def test_a_canonical_record_without_a_status_is_refused():
+    targets, refusals = build_targets([{"kode_kbli_2025": "25200"}], ["25200"])
+    assert targets == {}
+    assert any("no pma_status" in r for r in refusals)
+
+
+# --- guilt -------------------------------------------------------------------
+
+
+def test_a_stale_point_is_rewritten_to_the_canonical_verdict():
+    fake = FakeQdrant({"25200": [[_point(7)]]})
+    with fake.client() as http:
+        points = find_points_for_code(http, _BASE, _HEADERS, _COLLECTION, "25200")
+        plan = build_plan("25200", Target("25200", "TERBATAS", 49), points)
+        n = apply_plan(http, _BASE, _HEADERS, _COLLECTION, plan, apply=True)
+    assert n == 1
+    assert fake.payload_writes == [
+        {"payload": {"pma_status": "TERBATAS", "pma_max_asing": 49}, "points": [7]}
+    ]
+
+
+def test_every_point_of_a_code_is_rewritten_across_scroll_pages():
+    """Pagination is not decoration — a code with points on page 2 must not be
+    half-cured, which would leave the same code answering two ways."""
+    fake = FakeQdrant({"51102": [[_point(1)], [_point(2)], []]})
+    with fake.client() as http:
+        points = find_points_for_code(http, _BASE, _HEADERS, _COLLECTION, "51102")
+        assert [p["id"] for p in points] == [1, 2]
+        plan = build_plan("51102", Target("51102", "TERBATAS", 49), points)
+        apply_plan(http, _BASE, _HEADERS, _COLLECTION, plan, apply=True)
+    assert fake.payload_writes[0]["points"] == [1, 2]
+
+
+# --- innocence ---------------------------------------------------------------
+
+
+def test_dry_run_writes_nothing():
+    fake = FakeQdrant({"25200": [[_point(7)]]})
+    with fake.client() as http:
+        points = find_points_for_code(http, _BASE, _HEADERS, _COLLECTION, "25200")
+        plan = build_plan("25200", Target("25200", "TERBATAS", 49), points)
+        n = apply_plan(http, _BASE, _HEADERS, _COLLECTION, plan, apply=False)
+    assert n == 0 and fake.payload_writes == []
+
+
+def test_a_point_already_agreeing_is_left_alone():
+    """Idempotence with teeth: a second run must not re-write, so a diff of
+    'points written' stays a real signal rather than a constant."""
+    fake = FakeQdrant({"25200": [[_point(7, "TERBATAS", 49)]]})
+    with fake.client() as http:
+        points = find_points_for_code(http, _BASE, _HEADERS, _COLLECTION, "25200")
+        plan = build_plan("25200", Target("25200", "TERBATAS", 49), points)
+        assert plan.stale_points() == []
+        assert apply_plan(http, _BASE, _HEADERS, _COLLECTION, plan, apply=True) == 0
+    assert fake.payload_writes == []
+
+
+def test_a_code_with_no_points_never_writes_and_never_crashes():
+    fake = FakeQdrant({})
+    with fake.client() as http:
+        points = find_points_for_code(http, _BASE, _HEADERS, _COLLECTION, "62010")
+        plan = build_plan("62010", Target("62010", "TERBUKA", 100), points)
+        assert not plan.found
+        assert apply_plan(http, _BASE, _HEADERS, _COLLECTION, plan, apply=True) == 0
+    assert fake.payload_writes == []
+
+
+def test_only_the_two_pma_keys_are_ever_sent():
+    """`set_payload` is a MERGE; the request must carry nothing but the two
+    fields this tool owns, or it silently becomes an editor of the rest of the
+    flat payload."""
+    fake = FakeQdrant({"25200": [[_point(7)]]})
+    with fake.client() as http:
+        points = find_points_for_code(http, _BASE, _HEADERS, _COLLECTION, "25200")
+        plan = build_plan("25200", Target("25200", "TERBATAS", 49), points)
+        apply_plan(http, _BASE, _HEADERS, _COLLECTION, plan, apply=True)
+    assert set(fake.payload_writes[0]["payload"]) == {"pma_status", "pma_max_asing"}
+
+
+@pytest.mark.parametrize("cap", [0, 49, 100, "special", None])
+def test_the_canonical_cap_is_written_verbatim_never_coerced(cap):
+    """0 must stay 0 (`|| 100`-style coercion is how a closed code became
+    "100% open" elsewhere in this codebase), and "special" must stay a string
+    rather than becoming an invented number."""
+    fake = FakeQdrant({"47221": [[_point(3, "TERBUKA", 100)]]})
+    with fake.client() as http:
+        points = find_points_for_code(http, _BASE, _HEADERS, _COLLECTION, "47221")
+        plan = build_plan("47221", Target("47221", "TERBATAS", cap), points)
+        apply_plan(http, _BASE, _HEADERS, _COLLECTION, plan, apply=True)
+    assert fake.payload_writes[0]["payload"]["pma_max_asing"] == cap
+
+
+def test_stale_is_judged_on_both_fields_not_just_the_status():
+    """A point whose status already reads TERBATAS but whose cap is still 100
+    is stale. Judging on the status alone would leave the number — the thing a
+    client actually acts on — uncured."""
+    fake = FakeQdrant({"25200": [[_point(7, "TERBATAS", 100)]]})
+    with fake.client() as http:
+        points = find_points_for_code(http, _BASE, _HEADERS, _COLLECTION, "25200")
+        plan = build_plan("25200", Target("25200", "TERBATAS", 49), points)
+    assert plan.stale_points() == [7]

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`332 routers · 673 services · 1272 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`332 routers · 673 services · 1273 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What this is

Proving #3515 live on the channels found the cure stopping one store short.

`inspect_kbli` resolves the PMA verdict **Qdrant-first**, with the `kg_nodes` property only as a fallback (`backend/app/routers/kbli_notebook.py`):

```python
pma_status = (
    (_payload_value(qdrant_payload, "pma_status") if qdrant_payload else None)
    or props.get("pma_status")      # <- the kg_nodes property
    ...
)
```

So `kg_kbli_resync.py` — which exists *because* `inspect_kbli` once served a stale `pma_status` — cannot move that field while Qdrant carries a value.

**Measured, not reasoned.** After #3515 merged and the KG resync ran, `kg_nodes` said `TERBATAS` on all twenty cured codes and `inspect_kbli 51101` still answered **`TERBUKA`** — on scheduled passenger air transport — because `kbli_2025_final_hybrid` still read `TERBUKA / 100`.

## The tool

Payload-only `set_payload` **merge** of exactly two flat keys, sourced from the canonical. **Never a re-index**: changing two scalars must not put the FROZEN embedding model near a rebuild (CLAUDE.md §9).

### Three refusals

The failure that matters is writing a figure the canonical does not carry onto a client-facing store.

| refusal | why |
|---|---|
| a code absent from the canonical, or with no `pma_status`, aborts the **whole run** (exit 2, nothing written) | never a per-code skip — a partial write leaves the catalogue answering two ways |
| `--collection` is **mandatory** | the physical name is `kbli_2025_final_hybrid`; `kbli_2025_final` does not exist as a collection and `kbli_2025_final_oss` answers to none of the code keys. A default would freeze a measure of the world into a constant — the W106 shape |
| not one requested code matching a point → exit 2, not "0 updated" | see below |

That last guard comes from an error made on the day this was written: a probe pointed at a collection name that does not exist returned `0 points` for **all four** codes asked about — including one known to exist — and read as *"Qdrant is empty"*. A clean, believable zero from a wrong key is indistinguishable from a true negative unless something refuses it.

### What it will not do

- **Staleness is judged on both fields.** A point already reading `TERBATAS` with the cap still at `100` is stale; judging on status alone would leave the number — the thing a client acts on — uncured. Mutation-verified: narrowing that check makes the test fail.
- **The cap is written verbatim, never coerced.** `0` stays `0` (a `|| 100` default is exactly how a closed code reads as "100% open" elsewhere in this repo) and `47221`'s `"special"` stays a string instead of becoming an invented percentage — with a loud log line rather than a silent type change.

## Tests

14, Qdrant mocked through an `httpx` transport — no live Qdrant.

- **refusal**: absent-from-canonical, status-less record
- **guilt**: a stale point is rewritten; every point of a code is rewritten *across scroll pages* (a half-cured code answers two ways)
- **innocence**: dry-run writes nothing · an agreeing point is left alone (idempotence with teeth, so "points written" stays a real signal) · a code with no points never crashes · the merge carries nothing but the two keys this tool owns

## After merge

The run needs `kbli_inspect_cache_bust.py --only <codes> --apply` behind it — `inspect_kbli` caches its assembled payload for up to 30 days, so a cured Qdrant payload is invisible on the channel until it is evicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)