### PR TITLE
test(kbli): corroborate the Lampiran III caps with an instrument that did not write them

### DIFF
--- a/.agents/skills/kbli-navigator/SKILL.md
+++ b/.agents/skills/kbli-navigator/SKILL.md
@@ -1852,6 +1852,62 @@ Zero** (the "unverified cap" qualifier, the 17 `CHIUSO_PMA_NO_BESAR` codes, the 
 on a disowned basis, the FATAL-2 re-label). Those questions exist because we have no locator. With a
 locator they are not decided — they are answered.
 
+#### 🟢 F2 LIVE STATE (2026-08-02) — step 1 DONE for both operative annexes
+
+**The instrument was in no vault, and step 1 above said "the vaulted Perpres" as if it were.** Measured
+2026-08-02: the vault held 22 PDFs (21 PP-28 lampiran + one BPS table) and **zero** naming either
+Perpres, while `perpres-foreign-caps.json` recorded `transcribed_from: "page images rendered at
+200dpi"` with no path, no URL, no sha256, and no `fetch-log.jsonl` line anywhere mentioned the
+instrument. So the module whose docstring promises the PMA axis "a checkable source" named a source
+nobody could reach. `vault_fetch_perpres.py` (PR #3529) pins all six BPK downloads —
+`161562`-`161565` (49/2021 body + its three replacement annexes) and `154474`/`154475` (10/2021, the
+annex zip marked `superseded`, arts. 3-5 replaced it) — with the declared role cross-checked against
+the filename the server actually returns.
+
+**Lampiran II (Koperasi/UMKM reservation) is COMPILED, not transcribed** —
+`parse_perpres_lampiran2.py` → `data/kbli-filiera/perpres-umkm-reservation.json`: **181 rows from 180
+ticks, 0 unresolved** (one tick carries two codes; `ticks` and `rows_emitted` are separate fields
+because folded into one the output read "181 of 180"). The text layer is corrupted _deterministically_
+and both halves of the inversion are derived from evidence, not assumed: the substitution table by
+unique-candidate resolution (consistent over 33 observations, `t`→`1` twenty times and never anything
+else), the DIALOKASIKAN/KEMITRAAN split inside a measured empty band (no tick between x=101 and 107).
+
+`perpres_umkm_reservation_relation.py --check` buckets it — **and the buckets are the product, a flat
+"N codes are wrong" would be the third defect this axis has produced**:
+
+| bucket              | n      | what it means                                                                                        |
+| ------------------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| `whole-row`         | **67** | live code, one readable activity, no grade qualifier, published open → **Zero's question (Legge 5)** |
+| `segment-qualified` | 25     | reserves a construction grade, not the code                                                          |
+| `retired-2020-code` | 30     | no 2025 descendant, no live page renders it                                                          |
+| `kemitraan-no-bar`  | 57     | a partnership duty is **NOT** a foreign-ownership bar                                                |
+| `agree`             | 2      | `47111`, `47222` — the two `kbli_eye` already names reserved                                         |
+
+Those 2 in `agree` are the innocence control: the relation **corroborates what is already
+known-correct** before naming 67 divergences. `segment-qualified` is a declared FLOOR — a qualifier can
+live in the numbered parent heading (row 35 governs `42911`/`42912`/`42913`) and those rows are left in
+the owner's list on purpose, because withdrawing a question on an inference is worse than asking one
+too many.
+
+**Lampiran III's 41 transcribed caps are now CORROBORATED by a second instrument** (PR #3530). Its
+text layer is usable after all — same deterministic corruption, so invertible with the Lampiran II
+table — and it is a different reader on a different day, which is what W100 demands (same-family
+agreement certified 7 false-clean of 8 on this very programme). Result, asserted by MEMBERSHIP and not
+by count: **40/40 codes agree in both directions**, and **37/40 caps** are positionally reachable and
+all 37 match; the other three (`26513`, `30300`, `30400`) sit in a five-code stack and were read off
+page 1 directly, so they are NOT claimed as cross-instrument. Standing guard:
+`tests/test_perpres_l3_cross_instrument.py`, which SKIPS with an explicit CANNOT-VERIFY naming the
+fetch command when the vault is absent.
+
+**NEXT (step 3), and the correction that governs it**: the negative-locator join — "absent from both
+operative annexes ⇒ 100% by the body's default" — is **wrong for the 24 codes with a populated
+`per_skala` and no Besar row** ([[discovery_no_besar_scale_means_no_pma_and_17_of_those_verdicts_rest_on_an_empty_array_2026_08_02]]).
+Their honest verdict is neither 100% nor TERTUTUP: it is "a PMA cannot operate this at all", a third
+state — and a fourth `pma_status` value would render as **"Open"** on all 1,559 pages
+(`kbli-data.server.ts:365` returns `"open"` for anything but TERBATAS/TERTUTUP), so it must be a
+separate axis, never a new enum value. Any join must consult `per_skala` for a Besar row BEFORE
+writing a 100% default.
+
 ### 5.4 F3 — the two decisions that survive, and they come AFTER F2
 
 - **(a)** the **560** codes rendering two different predecessors side by side (official BPS vs the

--- a/data/kbli-filiera/perpres-foreign-caps.json
+++ b/data/kbli-filiera/perpres-foreign-caps.json
@@ -2,6 +2,11 @@
  "instrument": "Perpres 49/2021 Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu)",
  "vintage": "2021-05-25",
  "transcribed_from": "page images rendered at 200dpi; the PDF text layer corrupts codes and percentages",
+ "source": {
+  "vault_id": 161565,
+  "vault_rel_path": "perpres/161565__Perpres Nomor 49 Tahun 2021 - Lampiran III.pdf",
+  "fetcher": "scripts/kbli_filiera/vault_fetch_perpres.py"
+ },
  "unit": "(bidang usaha, KBLI-2020) pair — the cap does not attach to the code alone",
  "rows": [
   {

--- a/scripts/kbli_filiera/perpres_foreign_cap_relation.py
+++ b/scripts/kbli_filiera/perpres_foreign_cap_relation.py
@@ -69,6 +69,15 @@ OUT_PATH = REPO_ROOT / "data" / "kbli-filiera" / "perpres-foreign-caps.json"
 INSTRUMENT = "Perpres 49/2021 Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu)"
 VINTAGE = "2021-05-25"
 
+# The artifact these 41 rows were read from. Until 2026-08-02 it was in NO vault
+# — 22 PDFs held, none naming either Perpres — so `transcribed_from` below named
+# a rendering of a file nobody could reach, and the docstring's promise that this
+# module gives the PMA axis "a checkable source" could not be honoured by anyone
+# who tried. `vault_fetch_perpres.py` pins it; naming the id here is what turns
+# the promise into something a reader can act on.
+VAULT_ID = 161565
+VAULT_REL = "perpres/161565__Perpres Nomor 49 Tahun 2021 - Lampiran III.pdf"
+
 # (entry, bidang_usaha, kbli_2020, foreign_cap_pct, condition)
 # Transcribed from the 4 rendered pages. `foreign_cap_pct` is the FOREIGN share:
 # "Modal dalam negeri 100%" (100% domestic capital) is therefore 0, not 100 —
@@ -238,6 +247,8 @@ def main(argv: list[str] | None = None) -> int:
         OUT_PATH.write_text(json.dumps(
             {"instrument": INSTRUMENT, "vintage": VINTAGE,
              "transcribed_from": "page images rendered at 200dpi; the PDF text layer corrupts codes and percentages",
+             "source": {"vault_id": VAULT_ID, "vault_rel_path": VAULT_REL,
+                        "fetcher": "scripts/kbli_filiera/vault_fetch_perpres.py"},
              "unit": "(bidang usaha, KBLI-2020) pair — the cap does not attach to the code alone",
              "rows": rows}, indent=1, ensure_ascii=False) + "\n")
         print(f"\nwrote {OUT_PATH.relative_to(REPO_ROOT)}")

--- a/scripts/kbli_filiera/tests/test_perpres_l3_cross_instrument.py
+++ b/scripts/kbli_filiera/tests/test_perpres_l3_cross_instrument.py
@@ -1,0 +1,184 @@
+"""Corroborate the Lampiran III transcription with an instrument that did not write it.
+
+WHY THIS EXISTS
+---------------
+`perpres_foreign_cap_relation.py` holds 41 hand-transcribed rows — the foreign
+ownership caps under `Perpres 49/2021 Lampiran III` — read off page images by an
+earlier session. Its own test file opens by saying so: *"a transcription that no
+machine can re-derive"*. Everything downstream of the PMA axis rests on those 41
+rows, and until 2026-08-02 the artifact they were read from was in no vault, so
+nobody could check them even in principle.
+
+Now the PDF is pinned (`vault_fetch_perpres.py`, BPK id 161565) and its text
+layer turns out to be usable after all: corrupted in the same deterministic way
+as Lampiran II, hence invertible with the substitution table derived there. That
+gives a SECOND instrument — different reader, different failure modes, different
+day — and the point of this file is to make it disagree if it can.
+
+W100 is the reason this is not optional: same-family agreement certified 7
+false-clean of 8 on this very programme. Reading the images again would be the
+same instrument twice. The text layer is a different one.
+
+WHAT IT PROVES, AND WHAT IT DOES NOT
+-------------------------------------
+Proven, and asserted by MEMBERSHIP rather than by count — two same-size sets are
+not the same set:
+
+* every code in the shipped table is recoverable from the layer, and
+* the layer yields no code the table lacks (the direction that would mean a
+  whole entry was missed when the images were read), and
+* for every code whose clause the layer can reach, the CAP agrees.
+
+Not proven here, declared instead: three codes (`26513`, `30300`, `30400`) sit
+in a five-code stack whose single clause is too far from their line for a
+positional read. They were verified by reading page 1 directly — the clause is
+"Modal asing maksimal 49%; atau … dengan persetujuan Menteri Pertahanan" — but
+that is the IMAGE again, so this file does not claim them as cross-instrument.
+It asserts only that they are the known three, so a fourth appearing is a change
+someone must look at.
+
+The vault is not in the repo, so on CI this SKIPS. A skip is a declared absence
+of evidence, never a pass — the assertions below are worthless if nobody ever
+runs them, which is why the skip message names the command that does.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_FILIERA_DIR = str(Path(__file__).resolve().parents[1])
+if _FILIERA_DIR not in sys.path:
+    sys.path.insert(0, _FILIERA_DIR)
+
+from parse_perpres_lampiran2 import SUBSTITUTIONS, decode  # noqa: E402
+from perpres_foreign_cap_relation import VAULT_REL, relation_rows  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VAULT_PDF = Path.home() / "nuzantara-vault" / VAULT_REL
+CROSSWALK = REPO_ROOT / "data" / "kbli-filiera" / "bps-crosswalk" / "edges-lampiran5.json"
+CANONICAL = REPO_ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+
+# Codes whose clause is out of positional reach — see the module docstring.
+CLAUSE_OUT_OF_REACH = {"26513", "30300", "30400"}
+
+_DOMESTIC_ONLY = re.compile(r"Modal\s+dalam\s+negeri", re.IGNORECASE)
+_FOREIGN_ALLOWED = re.compile(r"Modal\s+asing", re.IGNORECASE)
+
+
+def _skip_without_vault() -> None:
+    if not VAULT_PDF.is_file():
+        pytest.skip(
+            f"{VAULT_PDF} absent — CANNOT VERIFY, not verified. "
+            "Run: python scripts/kbli_filiera/vault_fetch_perpres.py"
+        )
+
+
+def _layer_text() -> str:
+    proc = subprocess.run(["pdftotext", "-layout", str(VAULT_PDF), "-"],
+                          capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        pytest.skip(f"pdftotext unavailable or failed ({proc.returncode}) — CANNOT VERIFY")
+    return proc.stdout
+
+
+def _known_codes() -> frozenset[str]:
+    codes = {str(e["kbli_2020"]) for e in json.loads(CROSSWALK.read_text()) if e.get("kbli_2020")}
+    codes |= {str(r["kode_kbli_2025"]) for r in json.loads(CANONICAL.read_text())["data"]}
+    return frozenset(codes)
+
+
+def _token_re() -> re.Pattern[str]:
+    """Derived from the substitution table, never hand-copied.
+
+    Writing the character class out by hand omitted `r` on the first attempt and
+    the run reported "the layer misses 1 code" — a defect in the probe read as a
+    defect in the source. The class has one definition, and it is the table.
+    """
+    alphabet = "0-9" + "".join(sorted(SUBSTITUTIONS))
+    return re.compile(rf"(?<![0-9A-Za-z])([{alphabet}](?:\s?[{alphabet}]){{4}})(?![0-9A-Za-z])")
+
+
+def _codes_from_layer(text: str, known: frozenset[str]) -> set[str]:
+    out = set()
+    for match in _token_re().finditer(text):
+        code = decode(re.sub(r"\s", "", match.group(1)))
+        if code.isdigit() and code in known:
+            out.add(code)
+    return out
+
+
+def _caps_from_layer(text: str, known: frozenset[str]) -> dict[str, int]:
+    """Cap per code, by reading the clause at or just below the code's own line."""
+    caps: dict[str, int] = {}
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        codes = [c for c in (decode(re.sub(r"\s", "", m.group(1))) for m in _token_re().finditer(line))
+                 if c.isdigit() and c in known]
+        if not codes:
+            continue
+        for j in range(i, min(i + 6, len(lines))):
+            if _DOMESTIC_ONLY.search(lines[j]):
+                caps.update({c: 0 for c in codes if c not in caps})
+                break
+            if _FOREIGN_ALLOWED.search(lines[j]):
+                caps.update({c: 49 for c in codes if c not in caps})
+                break
+    return caps
+
+
+def test_the_probe_can_decode_the_corruptions_this_annex_actually_contains():
+    """POSITIVE CONTROL, first. Every assertion below is of the form "the two
+    instruments agree"; a decoder that silently produced nothing would make all
+    of them vacuously true. This one fails if the alphabet regresses."""
+    assert decode("to76r") == "10761"   # the code the docstring names as corrupted
+    assert decode("265L3") == "26513"
+
+
+def test_every_transcribed_code_is_recoverable_from_the_text_layer():
+    _skip_without_vault()
+    known = _known_codes()
+    table = {row["kbli_2020"] for row in relation_rows()}
+    layer = _codes_from_layer(_layer_text(), known)
+    assert table - layer == set(), "transcribed but unfindable in the source"
+
+
+def test_the_text_layer_yields_no_code_the_transcription_lacks():
+    """The direction that would mean an entry was MISSED when the images were
+    read — a silent under-count of the restricted list, which reads as freedom
+    the law does not grant."""
+    _skip_without_vault()
+    known = _known_codes()
+    table = {row["kbli_2020"] for row in relation_rows()}
+    layer = _codes_from_layer(_layer_text(), known)
+    assert layer - table == set(), "present in the source, absent from the transcription"
+
+
+def test_every_reachable_cap_agrees_between_the_two_instruments():
+    _skip_without_vault()
+    known = _known_codes()
+    table = {row["kbli_2020"]: row["foreign_cap_pct"] for row in relation_rows()}
+    layer = _caps_from_layer(_layer_text(), known)
+    disagreements = {c: (table[c], layer[c]) for c in table.keys() & layer.keys() if table[c] != layer[c]}
+    assert disagreements == {}, f"table vs layer: {disagreements}"
+
+
+def test_the_codes_whose_clause_is_out_of_reach_are_the_known_three():
+    """Not an assertion that they are right — an assertion that the set of
+    codes this file cannot speak for has not grown. A fourth appearing means the
+    layout moved and someone has to read the page again."""
+    _skip_without_vault()
+    known = _known_codes()
+    table = {row["kbli_2020"] for row in relation_rows()}
+    layer = _caps_from_layer(_layer_text(), known)
+    assert table - layer.keys() == CLAUSE_OUT_OF_REACH
+
+
+def test_the_transcription_names_the_artifact_it_was_read_from():
+    """The defect that made all of the above impossible until today."""
+    assert VAULT_REL.endswith("Lampiran III.pdf") and "161565" in VAULT_REL


### PR DESCRIPTION
> **Stacked on #3529** (base `feat/kbli-perpres-vault`). It needs the substitution table that PR derives, and GitHub retargets this to `main` automatically when #3529 merges.

## The claim this checks

`perpres_foreign_cap_relation.py` holds the 41 foreign-ownership caps under `Perpres 49/2021 Lampiran III`. They were read off page images by an earlier session, and that module's own test file opens by admitting it: *"a transcription that no machine can re-derive"*. **Everything on the PMA axis rests on those rows** — and until #3529 the artifact they were read from was in no vault, so nobody could check them even in principle.

## A second instrument, chosen because it is a different one

With the PDF pinned (BPK id `161565`) its text layer turns out to be usable after all — corrupted in the same deterministic way as Lampiran II, hence invertible with the substitution table derived there. Different reader, different failure modes, different day.

**W100 is why this is not optional**: same-family agreement certified 7 false-clean of 8 on this very programme. Re-reading the images would be the same instrument twice.

## Result — asserted by MEMBERSHIP, never by count

Two same-size sets are not the same set, so both directions are asserted separately:

| assertion | result |
|---|---|
| every transcribed code is recoverable from the layer | **40/40** |
| the layer yields no code the transcription lacks | **40/40**, `layer − table` empty |
| every positionally reachable cap agrees | **37/37**, zero disagreements |

The second row is the one that matters most: a code present in the source and absent from the transcription would be a **missed restricted entry**, which reads to a client as freedom the law does not grant.

`26513`, `30300`, `30400` sit in a five-code stack whose single clause is too far from their line for a positional read. They were verified by reading page 1 directly (*"Modal asing maksimal 49%; atau … dengan persetujuan Menteri Pertahanan"*), but that is the **image again** — so this file does **not** claim them as cross-instrument. It asserts only that the unreachable set has not grown, so a fourth appearing is a change someone must look at.

## Two things it refuses to do quietly

**A skip is not a pass.** The vault is not in the repo, so on CI these skip — with a message that says `CANNOT VERIFY, not verified` and names the command that fixes it. A silent skip is how a suite reports "no evidence" as "passed".

**A positive control runs first.** Every assertion has the form *"the two instruments agree"*, so a decoder that produced nothing would make all of them vacuously true. That is not hypothetical: the first run of this cross-check hand-wrote the token character class, omitted `r`, and reported *"the layer is missing a code"* — the **probe** was missing it. The class is now derived from the substitution table, which has one definition.

## Also in this PR

- `perpres-foreign-caps.json` now names the artifact: `source.vault_id: 161565` + rel-path + fetcher. `transcribed_from` said "page images rendered at 200dpi" with no path, no URL and no sha256, and there was no vaulted file it could have meant.
- The `/kbli-navigator` corner records F2 step 1 as measured — **including what the plan asserted falsely**: step 1 read *"parser over the vaulted Perpres lampiran"* as though the instrument were vaulted, teaching the next session a world state that did not exist.

## Verification

6 tests. **Mutation-verified**: a wrong cap → the cap-agreement assertion; a missed entry → the no-missing-code assertion; a phantom code → three assertions at once (correctly — it violates several invariants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
