### PR TITLE
test(kbli): prove the PAGE's reader surfaces the citation, not just the file

### DIFF
--- a/apps/mouth/src/lib/kbli-perpres-locator.test.ts
+++ b/apps/mouth/src/lib/kbli-perpres-locator.test.ts
@@ -76,3 +76,34 @@ describe("Perpres citation on the KBLI page", () => {
     expect(parsed.codes).toBe(1559);
   });
 });
+
+describe("the page's own reader surfaces the citation", () => {
+  it("exposes it on kbli.pma.citation for the code the page requests", async () => {
+    // The artifact holding the data and the PAGE showing it are two different
+    // claims. `page.tsx` renders `kbli.pma.citation` from `getCode()` in
+    // kbli-data.ts — so this exercises that path rather than the file, which
+    // is the difference between "the data exists" and "the page can reach it".
+    const { getCode } = await import("./kbli-data");
+    const restaurant = getCode("56101");
+    expect(restaurant?.pma.citation).toContain("Pasal 3(1)(d)");
+    const villa = getCode("55203");
+    expect(villa?.pma.citation).toContain("via KBLI-2020 55193");
+  });
+
+  it("agrees between the two readers, on every code", async () => {
+    // The invariant is not "the server says X", it is that the two modules
+    // never diverge — the cap was once read in both with different defaults
+    // and rendered "0% Open" on a live page. Comparing them to each other is
+    // the property; comparing each to a hardcoded string is a copy of the
+    // answer, and two copies of a wrong answer still agree.
+    const { getCode } = await import("./kbli-data");
+    const { getCode: getServerCode } = await import("./kbli-data.server");
+    const codes = (rawData as { data: { kode_kbli_2025: string }[] }).data.map(
+      (r) => String(r.kode_kbli_2025),
+    );
+    const disagreements = codes.filter(
+      (c) => getCode(c)?.pma.citation !== getServerCode(c)?.pma.citation,
+    );
+    expect(disagreements).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up to #3532, which put `Basis: <article>` on all 1,559 KBLI pages. That PR proved the
artifact holds a citation for every code and that the locator module agrees with the instrument.
It did not prove the thing a reader actually depends on: that the **page's own reader** reaches it.

Two tests, +31 lines, no production code touched (7 -> 9 `it()` in the file; both new ones run —
`vitest run src/lib/kbli-perpres-locator.test.ts` reports 9 passed).

1. **`getCode()` surfaces it.** `page.tsx` renders `kbli.pma.citation` from `kbli-data.ts`, not from
   the JSON. Asserting on the file is "the data exists"; asserting through `getCode()` is "the page
   can reach it" — a different claim, and the one that fails if an import or a field name drifts.
2. **The two readers agree on every code.** `kbli-data.ts` and `kbli-data.server.ts` both populate
   `citation`, and this repo has already paid for two readers of one field diverging: the PMA cap was
   read with different defaults in exactly these two modules and rendered "0% Open" on a live page
   (L2.11). The property asserted is that they never disagree — compared to **each other**, over all
   1,559 codes. An earlier draft of this test compared each to a hardcoded string, which is a copy of
   the answer: two copies of a wrong answer still agree.

Consumer map, measured rather than recalled — the citation reaches **two** surfaces, not one:
`/kbli/<code>` renders the visible line (`page.tsx:347`), and `/api/kbli/gold/<code>` serializes the
whole `pma` object (`route.ts:31`), so the field rides along into that JSON. Prove-live covers both.

Gate: test-only additive diff on already-shipped behaviour, so the machine gates are the
verification here; the substantive cross-family adversarial review sits on #3532, where it caught two
legal-reading errors no test in this repo could have caught. R1 checked locally: no research files in
scope.