### PR TITLE
fix(kbli): the index card blamed the moratorium for 111 codes blocked by something else

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { getAllCodes, getSections } from "@/lib/kbli-data";
+import { baliBlockedHint } from "@/lib/kbli-bali-block";
 import { KBLISearch } from "@/components/kbli/KBLISearch";
 import { KBLISectorGrid } from "@/components/kbli/KBLISectorGrid";
 import { ZantaraChat } from "@/components/kbli/ZantaraChat";
@@ -193,7 +194,7 @@ export default async function KBLIHomePage({
             {
               num: `~${baliBlockedPct}%`,
               label: "Blocked in Bali",
-              hint: "Bali Zero's conservative posture on the 13 May 2026 provincial moratorium: low and medium-low-risk activities are treated as closed to foreign-owned companies (PT PMA) pending clearer national guidance — a working assessment, not a certified legal determination. Every code page shows our current verdict.",
+              hint: baliBlockedHint(allCodes),
             },
             { num: "AI", label: "Powered by Zantara" },
           ].map((t) => (

--- a/apps/mouth/src/lib/kbli-bali-block.test.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.test.ts
@@ -480,6 +480,45 @@ describe("baliBlockedHint — the index card must not blame the moratorium for e
     expect(b).toContain("21 of 100");
   });
 
+  it("never enumerates the non-moratorium causes, because an enumeration goes stale", () => {
+    // The defect an adversarial review caught before ship: the first version
+    // listed "an ownership restriction ... no Usaha Besar scale row, or a
+    // sector regulator's own closure" — three of the FIVE statuses that occur,
+    // silently dropping CHIUSO_BALI (70209) and CHIUSO_BALI_PROPOSTO (79110).
+    // A new claim written while correcting an old one, unverified (W113).
+    //
+    // Built from the REAL status census, not from one fabricated status, which
+    // is why the original test suite could not have caught it.
+    const census: Array<[string, number]> = [
+      ["BLOCCATO_CLASSE_RISCHIO", 372],
+      ["CHIUSO_MORATORIA_BALI", 35],
+      ["TERTUTUP", 68],
+      ["CHIUSO_PMA_NO_BESAR", 39],
+      ["CHIUSO_REGOLATORE_SETTORIALE", 2],
+      ["CHIUSO_BALI", 1],
+      ["CHIUSO_BALI_PROPOSTO", 1],
+    ];
+    const codes = census.flatMap(([status, n]) =>
+      Array.from({ length: n }, () => ({ baliL4: { status, blocked: true } })),
+    );
+    const hint = baliBlockedHint([...codes, ...open(1041)]);
+    expect(hint).toContain("518 of 1559");
+    expect(hint).toContain("407");
+    expect(hint).toContain("111");
+    // No partial cause list may appear — naming some causes implies the set is
+    // complete, and it never is for long.
+    expect(hint).not.toMatch(/ownership restriction/i);
+    expect(hint).not.toMatch(/Usaha Besar scale row/i);
+    expect(hint).not.toMatch(/sector regulator/i);
+  });
+
+  it("says nothing at all rather than '0 of 0' when handed no codes", () => {
+    // Also from the same review: an empty array rendered "0 of 0 codes are
+    // treated as closed ... all of them under the moratorium", which is not a
+    // degraded sentence but a false one.
+    expect(baliBlockedHint([])).toBe("");
+  });
+
   it("agrees with the served dataset — 518 blocked, 111 not by the moratorium", () => {
     // Anchors the two figures to the real records rather than to my arithmetic,
     // so a future overlay change fails here instead of silently making the

--- a/apps/mouth/src/lib/kbli-bali-block.test.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.test.ts
@@ -8,6 +8,7 @@ import {
   containsItalian,
   isProposalOnly,
   narratesUnverifiedRoute,
+  baliBlockedHint,
 } from "./kbli-bali-block";
 import rawData from "../../data/KBLI_2025_FINAL_CLEAN.json";
 import goldData from "../../data/kbli-gold-all.json";
@@ -400,5 +401,100 @@ describe("the FAQ + FAQPage JSON-LD — the THIRD render site in this file, FIFT
     const onlyFaq = faq.filter((r) => !bannerCodes.has(r.kode_kbli_2025));
     expect(onlyFaq).toHaveLength(0);
     expect(banner.length - faq.length).toBe(1);
+  });
+});
+
+describe("baliBlockedHint — the index card must not blame the moratorium for every block", () => {
+  // The card said "low and medium-low-risk activities are treated as closed"
+  // over a percentage covering 518 codes, 111 of which are blocked by something
+  // else entirely. That is the same over-attribution `isMoratoriumBasis` was
+  // added to prevent on the per-code page (cured 2026-07-27); the card was
+  // missed, so the cure covered one consumer of the same fact and not the other.
+  const moratorium = (n: number) =>
+    Array.from({ length: n }, () => ({
+      baliL4: { status: "BLOCCATO_CLASSE_RISCHIO", blocked: true },
+    }));
+  const scale = (n: number) =>
+    Array.from({ length: n }, () => ({
+      baliL4: { status: "CHIUSO_PMA_NO_BESAR", blocked: true },
+    }));
+  const open = (n: number) =>
+    Array.from({ length: n }, () => ({
+      baliL4: { status: "OK", blocked: false },
+    }));
+
+  it("names the non-moratorium codes instead of folding them into the risk tier", () => {
+    // Guilt: this is the shape that was being misdescribed.
+    const hint = baliBlockedHint([
+      ...moratorium(407),
+      ...scale(111),
+      ...open(1041),
+    ]);
+    expect(hint).toContain("407");
+    expect(hint).toContain("111");
+    expect(hint).toContain("518 of 1559");
+    // and it must NOT present the risk tier as the reason for all of them
+    expect(hint).not.toMatch(
+      /low and medium-low-risk activities are treated as closed/i,
+    );
+  });
+
+  it("keeps the qualifier that made the original sentence honest", () => {
+    // Innocence: the old copy's one virtue — it refused to pass as a legal
+    // finding — must survive the rewrite. Losing it would be a regression
+    // dressed as a correction.
+    //
+    // Case-INSENSITIVE on purpose. The first version of this assertion used
+    // toContain("A working assessment"), which the old hardcoded sentence
+    // failed on nothing but its lowercase "a" — i.e. it was asserting
+    // capitalisation while claiming to assert substance, and it "caught" a
+    // mutant that had the property it was testing for. Judge the entity, not
+    // the form (superscar #3), especially in the assertion meant to protect
+    // what must NOT change.
+    const hint = baliBlockedHint([
+      ...moratorium(407),
+      ...scale(111),
+      ...open(1041),
+    ]);
+    expect(hint).toMatch(
+      /a working assessment, not a certified legal determination/i,
+    );
+  });
+
+  it("does not invent a second cause when every block IS the moratorium", () => {
+    // Innocence: the "the other N for a different reason" clause must not fire
+    // on a population where it would be false.
+    const hint = baliBlockedHint([...moratorium(50), ...open(50)]);
+    expect(hint).toContain("all of them");
+    expect(hint).not.toMatch(/for a different reason/i);
+  });
+
+  it("derives the counts from the data it is given, not from a frozen constant", () => {
+    // The original went wrong by stating a rule in prose that the data later
+    // contradicted. Two different populations must produce two different
+    // sentences (W106: a constant is a measurement that stopped being taken).
+    const a = baliBlockedHint([...moratorium(10), ...scale(5), ...open(85)]);
+    const b = baliBlockedHint([...moratorium(20), ...scale(1), ...open(79)]);
+    expect(a).not.toEqual(b);
+    expect(a).toContain("15 of 100");
+    expect(b).toContain("21 of 100");
+  });
+
+  it("agrees with the served dataset — 518 blocked, 111 not by the moratorium", () => {
+    // Anchors the two figures to the real records rather than to my arithmetic,
+    // so a future overlay change fails here instead of silently making the
+    // card wrong again.
+    const codes = (
+      rawData as {
+        data: Array<{ l4_bali?: { status?: string; blocked?: boolean } }>;
+      }
+    ).data.map((r) => ({
+      baliL4: r.l4_bali
+        ? { status: r.l4_bali.status, blocked: r.l4_bali.blocked }
+        : null,
+    }));
+    const hint = baliBlockedHint(codes);
+    expect(hint).toContain("518 of 1559");
+    expect(hint).toContain("111");
   });
 });

--- a/apps/mouth/src/lib/kbli-bali-block.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.ts
@@ -208,3 +208,59 @@ export function narratesUnverifiedRoute(
   if (!text) return false;
   return TIER_NAME_RE.test(text) && ROUTE_SPECIFIC_RE.test(text);
 }
+
+/**
+ * The "Blocked in Bali" trust-bar hint on /kbli.
+ *
+ * It used to be one hardcoded sentence attributing the whole percentage to the
+ * 13 May 2026 risk-tier moratorium: "low and medium-low-risk activities are
+ * treated as closed to foreign-owned companies (PT PMA)". That is the SAME
+ * over-attribution `isMoratoriumBasis` exists to prevent one surface away — the
+ * per-code page was cured on 2026-07-27 and this card was missed, so the index
+ * kept telling readers that the risk tier is why every blocked code is blocked.
+ *
+ * Two things were wrong with it, both measured on the served dataset:
+ *
+ *  - **Cause.** Of 518 blocked codes, 407 are moratorium-based
+ *    (BLOCCATO_CLASSE_RISCHIO 372 + CHIUSO_MORATORIA_BALI 35) and **111 are
+ *    not** — 68 TERTUTUP (an ownership restriction on the activity itself),
+ *    39 CHIUSO_PMA_NO_BESAR (no Usaha Besar scale row), 2 closed by their
+ *    sector's own regulator, 2 by Bali's announced sectoral closures. That 111
+ *    is the same figure this module's own comment already names.
+ *
+ *  - **Rule.** Read as a rule, "low and medium-low-risk activities are treated
+ *    as closed" is far wider than what we do: 405 codes carry only low or
+ *    medium-low risk and 22 of them render closed under the scale status.
+ *
+ * So the counts are DERIVED here rather than restated in prose, and the
+ * qualifier that made the old sentence honest — a working assessment, not a
+ * certified legal determination — is kept verbatim. Deriving them also means
+ * the sentence cannot go stale the next time the overlay moves, which is how
+ * the original became wrong.
+ */
+export function baliBlockedHint(
+  codes: ReadonlyArray<{
+    baliL4?: { status?: string | null; blocked?: boolean } | null;
+  }>,
+): string {
+  const blocked = codes.filter((c) => c.baliL4?.blocked);
+  const moratorium = blocked.filter((c) =>
+    MORATORIUM_STATUSES.has(c.baliL4?.status ?? ""),
+  ).length;
+  const other = blocked.length - moratorium;
+
+  const causes =
+    other > 0
+      ? `${moratorium} of them under Bali Zero's conservative reading of the 13 May 2026 provincial ` +
+        `risk-tier moratorium, pending clearer national guidance; the other ${other} for a different ` +
+        `reason entirely — an ownership restriction on the activity, no Usaha Besar scale row, or a ` +
+        `sector regulator's own closure.`
+      : `all of them under Bali Zero's conservative reading of the 13 May 2026 provincial risk-tier ` +
+        `moratorium, pending clearer national guidance.`;
+
+  return (
+    `${blocked.length} of ${codes.length} codes are treated as closed to a foreign-owned company ` +
+    `(PT PMA) in Bali — ${causes} A working assessment, not a certified legal determination. ` +
+    `Every code page states which of these applies to it.`
+  );
+}

--- a/apps/mouth/src/lib/kbli-bali-block.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.ts
@@ -243,24 +243,43 @@ export function baliBlockedHint(
     baliL4?: { status?: string | null; blocked?: boolean } | null;
   }>,
 ): string {
+  if (codes.length === 0) return "";
+
   const blocked = codes.filter((c) => c.baliL4?.blocked);
   const moratorium = blocked.filter((c) =>
     MORATORIUM_STATUSES.has(c.baliL4?.status ?? ""),
   ).length;
   const other = blocked.length - moratorium;
 
+  // NOTE the deliberate absence of a cause LIST for the `other` group.
+  //
+  // The first version of this function enumerated them — "an ownership
+  // restriction on the activity, no Usaha Besar scale row, or a sector
+  // regulator's own closure" — which named three of the FIVE statuses that
+  // actually occur, silently dropping CHIUSO_BALI (70209) and
+  // CHIUSO_BALI_PROPOSTO (79110). An adversarial review caught it before ship.
+  //
+  // That is the same failure as the sentence being replaced, one turn later: a
+  // NEW claim written while correcting an old one, and never verified against
+  // the data (superscar #6 / W113). A hand-written enumeration is a claim with
+  // an expiry date — it silently becomes wrong the next time a status is added,
+  // which is exactly how the original text rotted. So the count is derived and
+  // the causes are not asserted here at all; `baliBlockClause` already states
+  // the right one per code, on the page that has the code in front of it.
+  //
+  // CHIUSO_BALI_PROPOSTO is the sharpest reason not to summarise: that closure
+  // is proposed and NOT in force, so listing it beside settled bars would be a
+  // third wrong statement, not a more complete one.
   const causes =
     other > 0
       ? `${moratorium} of them under Bali Zero's conservative reading of the 13 May 2026 provincial ` +
-        `risk-tier moratorium, pending clearer national guidance; the other ${other} for a different ` +
-        `reason entirely — an ownership restriction on the activity, no Usaha Besar scale row, or a ` +
-        `sector regulator's own closure.`
+        `risk-tier moratorium, pending clearer national guidance; the other ${other} for reasons that ` +
+        `have nothing to do with the risk tier, stated individually on each code's page.`
       : `all of them under Bali Zero's conservative reading of the 13 May 2026 provincial risk-tier ` +
         `moratorium, pending clearer national guidance.`;
 
   return (
     `${blocked.length} of ${codes.length} codes are treated as closed to a foreign-owned company ` +
-    `(PT PMA) in Bali — ${causes} A working assessment, not a certified legal determination. ` +
-    `Every code page states which of these applies to it.`
+    `(PT PMA) in Bali — ${causes} A working assessment, not a certified legal determination.`
   );
 }


### PR DESCRIPTION
**Visible product change**, client-facing. `/kbli`'s "Blocked in Bali" trust-bar card.

## What was wrong

The card carried one hardcoded sentence attributing the whole percentage to the 13 May 2026
risk-tier moratorium:

> "Bali Zero's conservative posture on the 13 May 2026 provincial moratorium: **low and
> medium-low-risk activities are treated as closed** to foreign-owned companies (PT PMA)…"

That is the **same over-attribution `isMoratoriumBasis` exists to prevent one surface away**. The
per-code page was cured on 2026-07-27 — `kbli-bali-block.ts`'s own comment already names *"the 111
codes blocked by something else"* — and this card was missed. A pattern fix covering one consumer of
a fact and not the other only moves which surface lies (W107).

Two defects, both measured on the served dataset:

| | |
|---|---|
| **Cause** | Of **518** blocked codes, **407** are moratorium-based (`BLOCCATO_CLASSE_RISCHIO` 372 + `CHIUSO_MORATORIA_BALI` 35) and **111 are not** — 68 `TERTUTUP`, 39 `CHIUSO_PMA_NO_BESAR`, 2 sector-regulator closures, 2 Bali sectoral closures. |
| **Rule** | Read as a rule, "low and medium-low-risk activities are treated as closed" is far wider than what we do: **405** codes carry only low/medium-low risk and **22** render closed. |

## What it says now

> "518 of 1559 codes are treated as closed to a foreign-owned company (PT PMA) in Bali — 407 of them
> under Bali Zero's conservative reading of the 13 May 2026 provincial risk-tier moratorium, pending
> clearer national guidance; the other 111 for reasons that have nothing to do with the risk tier,
> stated individually on each code's page. A working assessment, not a certified legal
> determination."

Counts are **derived** from the same records the card counts, so the sentence cannot go stale the
next time the overlay moves — which is how the original became wrong (W106: a constant is a
measurement that stopped being taken). The qualifier that made the old copy honest is kept.

## The adversarial gate changed this diff

Generator≠grader: an independent cross-family review (Codex, instructed to default to defective)
found **three real defects in my own fix**, all reproduced on disk before being believed.

1. **My replacement sentence enumerated 3 of the 5 statuses** — "an ownership restriction… no Usaha
   Besar scale row, or a sector regulator's own closure" — silently dropping `CHIUSO_BALI` (`70209`)
   and `CHIUSO_BALI_PROPOSTO` (`79110`). **The same failure as the sentence I was replacing, one
   turn later**: a new claim written while correcting an old one, never verified (W113). The cure is
   not a longer list — the causes are no longer asserted here at all. `CHIUSO_BALI_PROPOSTO` is the
   sharpest reason: that closure is *proposed and not in force*, so listing it beside settled bars
   would be a third wrong statement, not a more complete one.
2. **Empty input rendered "0 of 0 … all of them under the moratorium"** — not degraded, false. Now
   returns `""`.
3. **The tests could not have caught defect 1**: they fabricated all 111 as a single status.
   Replaced with a test built from the real census (372/35/68/39/2/1/1) that forbids any partial
   cause list, plus one for empty input.

## Verification

- 38 tests pass; `tsc --noEmit` clean on the touched files.
- **Mutation-verified twice.** Against the original hardcoded string: 4 guilt tests fail, and the
  innocence test **passes** — because the old sentence did carry the qualifier. Against the version
  this review rejected: the 2 new tests fail.
- One more correction, in my own corpus: the innocence assertion first used
  `toContain("A working assessment")` and failed the mutant on nothing but a lowercase "a" — it
  asserted capitalisation while claiming to assert substance, and "caught" a mutant that had the
  property it tested for. Now case-insensitive, with the reason recorded in the test.

No verdict changes: every code's own status and badge are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)