### PR TITLE
fix(kg): the PMA check tested itself in a vocabulary the store has never spoken

### DIFF
--- a/apps/backend-rag/backend/services/rag/kg_subgraph_company.py
+++ b/apps/backend-rag/backend/services/rag/kg_subgraph_company.py
@@ -9,6 +9,7 @@ Date: 2026-02-09
 Reference: memory/langgraph-kg-evolution-plan.md (Phase 3)
 """
 
+import json
 import logging
 from typing import Any, TypedDict
 
@@ -46,6 +47,100 @@ class CompanyState(TypedDict, total=False):
     licensing_requirements: list[dict]  # NIB, OSS, sector licenses
     shareholders: list[dict]  # For PT PMA
     legal_structure_recommendations: list[dict]
+
+
+# ============================================================================
+# PMA eligibility vocabulary
+# ============================================================================
+#
+# Censused on the live KG 2026-08-03 (`kg_nodes`, ids matching `kbli:NNNNN`):
+#   TERBUKA 1464 · TERTUTUP 61 · TERBATAS 29 · "Verify at OSS" 4
+# Not ONE row speaks the English vocabulary this module used to test itself
+# against ("allowed" / "open" / "restricted"), so the old
+# `pma_status in ["allowed", "open"]` evaluated False for EVERY code in the
+# store — including all 1464 fully open ones. The English keys are kept below
+# because this module's own docstrings promise them and an older loader may
+# still write them; they are not what production speaks.
+#
+# `eligible` is deliberately TRI-STATE. TERBATAS means "open to foreign
+# ownership up to a CAP": answering False there is the L2.11 defect (denying a
+# lawful 49% stake), answering True hides the cap. This store carries no cap at
+# all — `pma_max_asing` / `pma_official_basis` / `pma_cap_verified` are absent
+# from all 13,633 kbli nodes (verified 2026-08-03) — so the cap has to come
+# from the canonical dataset via `backend/services/kbli_eye.py`. Undetermined
+# is the honest answer here, and it is also the fallback for any status this
+# table does not name: an unrecognised status NEVER yields a silent False.
+# The verdict is carried by a STRING state, and the tri-state bool is derived
+# from it in exactly one place. Two renderings of one fact, one writer.
+#
+# The bool exists because `eligible` is the field this node has always emitted
+# — but a bool cannot express "undetermined" safely: a consumer writing the
+# natural `if not detail["eligible"]` treats None exactly like False, which is
+# the L2.11 defect back again (denying a lawful capped stake) arriving through
+# a downstream truthiness test instead of through this table. Consumers should
+# branch on `eligibility_state`; the bool is for `is True` / `is False` /
+# `is None` only. This hazard was named by the adversarial review of this diff.
+PMA_STATE_OPEN = "open"
+PMA_STATE_CLOSED = "closed"
+PMA_STATE_UNDETERMINED = "undetermined"
+
+_ELIGIBLE_BY_STATE: dict[str, bool | None] = {
+    PMA_STATE_OPEN: True,
+    PMA_STATE_CLOSED: False,
+    PMA_STATE_UNDETERMINED: None,
+}
+
+_PMA_ELIGIBILITY: dict[str, tuple[str, str]] = {
+    "TERBUKA": (PMA_STATE_OPEN, "pma_status=TERBUKA — open to foreign ownership"),
+    "TERTUTUP": (PMA_STATE_CLOSED, "pma_status=TERTUTUP — closed to foreign ownership"),
+    "TERBATAS": (
+        PMA_STATE_UNDETERMINED,
+        "pma_status=TERBATAS — open to foreign ownership up to a cap; the KG "
+        "carries no cap field, read it from the canonical dataset "
+        "(backend/services/kbli_eye.py) before answering a client",
+    ),
+    "VERIFY AT OSS": (
+        PMA_STATE_UNDETERMINED,
+        "pma_status='Verify at OSS' — undetermined, check OSS",
+    ),
+    # Legacy English tokens named by this module's docstrings. Absent from the
+    # live store as of the census above.
+    "OPEN": (PMA_STATE_OPEN, "pma_status=open — open to foreign ownership"),
+    "ALLOWED": (PMA_STATE_OPEN, "pma_status=allowed — open to foreign ownership"),
+    "CLOSED": (PMA_STATE_CLOSED, "pma_status=closed — closed to foreign ownership"),
+    "RESTRICTED": (
+        PMA_STATE_UNDETERMINED,
+        "pma_status=restricted — capped, not closed; read the cap from the "
+        "canonical dataset (backend/services/kbli_eye.py)",
+    ),
+}
+
+
+def resolve_pma_eligibility(raw_status: object) -> tuple[str, bool | None, str]:
+    """
+    Map a raw KG ``pma_status`` to ``(state, eligible, basis)``.
+
+    ``state`` is the authoritative verdict (``open`` / ``closed`` /
+    ``undetermined``); ``eligible`` is derived from it here and nowhere else.
+
+    Anything the table above does not name — including a missing status —
+    resolves to ``undetermined``. Never ``closed`` by default: "we do not
+    know" and "closed to foreigners" are different answers, and this store is
+    only entitled to the first one when it is silent.
+    """
+    key = str(raw_status or "").strip().upper()
+    if not key:
+        state, basis = PMA_STATE_UNDETERMINED, "no pma_status on the KG node — undetermined"
+    else:
+        verdict = _PMA_ELIGIBILITY.get(key)
+        if verdict is None:
+            state, basis = (
+                PMA_STATE_UNDETERMINED,
+                f"pma_status={raw_status!r} not recognised — undetermined",
+            )
+        else:
+            state, basis = verdict
+    return (state, _ELIGIBLE_BY_STATE[state], basis)
 
 
 # ============================================================================
@@ -154,8 +249,12 @@ async def check_pma_eligibility_node(state: CompanyState, db_pool: asyncpg.Pool)
     Check if business activity is eligible for foreign investment (PMA).
 
     Queries KG for:
-    - KBLI codes with pma_status = "allowed" or "restricted"
+    - KBLI codes with pma_status (TERBUKA / TERTUTUP / TERBATAS / Verify at OSS)
     - DNI (Daftar Negatif Investasi) restrictions
+
+    Every emitted detail carries a TRI-STATE ``eligible`` (True / False /
+    None) plus the ``eligibility_basis`` that produced it — see
+    ``resolve_pma_eligibility``. None means undetermined, never "closed".
 
     Args:
         state: Current CompanyState
@@ -180,28 +279,70 @@ async def check_pma_eligibility_node(state: CompanyState, db_pool: asyncpg.Pool)
         return state
 
     async with db_pool.acquire() as conn:
-        # Query KBLI nodes for PMA status
+        # Query KBLI nodes for PMA status.
+        #
+        # Keyed on entity_id ALONE, deliberately. The caller already supplies
+        # exact ids (`kbli:NNNNN`) and that id IS the entity; the old
+        # `entity_type = 'kbli'` filter added no protection and silently
+        # dropped rows. Measured 2026-08-03: the `kbli:` id namespace holds
+        # 1,568 codes across TWO types — 1,558 as `kbli` and 10 filed as
+        # `kbli_code`, with zero overlap. Those 10 are 47721 / 55111 / 56101 /
+        # 62011 / 62021 / 68110 / 70201 / 73110 / 74100 / 79110 — i.e. the
+        # restaurant, hotel and travel-agency codes this product is asked
+        # about most, every one of them invisible to the old filter.
         results = await conn.fetch(
             """
-            SELECT entity_id, name, properties
+            SELECT entity_id, entity_type, name, properties
             FROM kg_nodes
             WHERE entity_id = ANY($1::text[])
-              AND entity_type = 'kbli'
             """,
             kbli_codes,
         )
 
         pma_info = []
+        answered: set[str] = set()
         for row in results:
-            props = row.get("properties", {})
-            pma_status = props.get("pma_status", "unknown")
+            props = row["properties"]
+            if isinstance(props, str):  # pool without a jsonb codec
+                try:
+                    props = json.loads(props)
+                except (TypeError, ValueError):
+                    props = {}
+            if not isinstance(props, dict):
+                props = {}
+
+            pma_status = props.get("pma_status")
+            state_str, eligible, basis = resolve_pma_eligibility(pma_status)
+            answered.add(row["entity_id"])
 
             pma_info.append(
                 {
                     "kbli_code": row["entity_id"],
                     "business_name": row["name"],
-                    "pma_status": pma_status,
-                    "eligible": pma_status in ["allowed", "open"],
+                    "pma_status": pma_status if pma_status else "unknown",
+                    # Branch on this. "open" / "closed" / "undetermined".
+                    "eligibility_state": state_str,
+                    # Tri-state: True open · False closed · None undetermined.
+                    # Compare with `is`, never with truthiness — None is not False.
+                    "eligible": eligible,
+                    "eligibility_basis": basis,
+                    "source_entity_type": row["entity_type"],
+                },
+            )
+
+        # A code the KG has never heard of must say so. Reporting nothing at
+        # all reads downstream as "no restrictions found", which is the same
+        # wrong answer as False with fewer places to catch it.
+        for missing in [c for c in kbli_codes if c not in answered]:
+            pma_info.append(
+                {
+                    "kbli_code": missing,
+                    "business_name": None,
+                    "pma_status": "unknown",
+                    "eligibility_state": PMA_STATE_UNDETERMINED,
+                    "eligible": None,
+                    "eligibility_basis": "no node in the KG for this code — undetermined",
+                    "source_entity_type": None,
                 },
             )
 

--- a/apps/backend-rag/backend/tests/services/rag/test_kg_subgraphs.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_kg_subgraphs.py
@@ -125,13 +125,17 @@ async def test_check_pma_eligibility(mock_db_pool):
     """Test: Check PMA eligibility for KBLI codes."""
     pool, conn = mock_db_pool
 
-    # Mock database response
+    # Mock database response. `56101` really is filed under
+    # `entity_type='kbli_code'` in the live KG (measured 2026-08-03) — the mock
+    # says so rather than inventing a shape, and it carries every column the
+    # query selects, so a mock that drifts from the query fails loudly.
     conn.fetch = AsyncMock(
         return_value=[
             {
                 "entity_id": "kbli:56101",
+                "entity_type": "kbli_code",
                 "name": "Restoran",
-                "properties": {"pma_status": "allowed"},
+                "properties": {"pma_status": "TERBUKA"},
             },
         ],
     )

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_kg_subgraph_company.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_kg_subgraph_company.py
@@ -210,6 +210,7 @@ class TestCheckPMAEligibility:
             return_value=[
                 {
                     "entity_id": "kbli:47111",
+                    "entity_type": "kbli",
                     "name": "Perdagangan Eceran",
                     "properties": {"pma_status": "allowed"},
                 }
@@ -227,12 +228,21 @@ class TestCheckPMAEligibility:
         assert req["details"][0]["eligible"] is True
 
     @pytest.mark.asyncio
-    async def test_kbli_restricted(self, mock_db_pool):
+    async def test_kbli_restricted_is_undetermined_not_closed(self, mock_db_pool):
+        """
+        "restricted" (the English of TERBATAS) means capped, NOT closed.
+
+        This assertion used to read ``is False`` — it PINNED the L2.11 defect:
+        a capped code answered as ineligible denies a lawful foreign stake
+        (the sea-cabotage codes allow 49%). The KG carries no cap field, so
+        the honest answer from this store is "undetermined, go read the cap".
+        """
         conn = mock_db_pool._mock_conn
         conn.fetch = AsyncMock(
             return_value=[
                 {
                     "entity_id": "kbli:01111",
+                    "entity_type": "kbli",
                     "name": "Pertanian Padi",
                     "properties": {"pma_status": "restricted"},
                 }
@@ -245,7 +255,230 @@ class TestCheckPMAEligibility:
         )
         result = await check_pma_eligibility_node(state, mock_db_pool)
         pma_detail = result["licensing_requirements"][-1]["details"][0]
-        assert pma_detail["eligible"] is False
+        assert pma_detail["eligible"] is None
+        assert "cap" in pma_detail["eligibility_basis"]
+
+
+class TestPmaEligibilityVocabulary:
+    """
+    The store speaks Indonesian; the old code tested itself in English.
+
+    Censused on the live KG 2026-08-03: TERBUKA 1464 · TERTUTUP 61 ·
+    TERBATAS 29 · "Verify at OSS" 4, and ZERO rows carrying "allowed" /
+    "open" / "restricted". The old ``pma_status in ["allowed", "open"]``
+    therefore answered False for every code in production, including all
+    1,464 fully open ones — and both existing tests passed, because they
+    invented a vocabulary to be right about.
+    """
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            ("TERBUKA", True),
+            ("TERTUTUP", False),
+            ("TERBATAS", None),
+            ("Verify at OSS", None),
+            ("terbuka", True),  # case/whitespace must not decide a verdict
+            ("  TERBUKA  ", True),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_live_vocabulary(self, mock_db_pool, status, expected):
+        conn = mock_db_pool._mock_conn
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "entity_id": "kbli:56101",
+                    "entity_type": "kbli_code",
+                    "name": "Restaurant",
+                    "properties": {"pma_status": status},
+                }
+            ]
+        )
+        state = _base_state(is_foreign_investor=True, kbli_codes=["kbli:56101"])
+        result = await check_pma_eligibility_node(state, mock_db_pool)
+        assert result["licensing_requirements"][-1]["details"][0]["eligible"] is expected
+
+    @pytest.mark.parametrize("status", ["", None, "OPEN-ISH", "TERBUK", 42])
+    @pytest.mark.asyncio
+    async def test_unknown_status_is_never_a_silent_false(self, mock_db_pool, status):
+        """An unrecognised or missing status is undetermined, never "closed"."""
+        conn = mock_db_pool._mock_conn
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "entity_id": "kbli:56101",
+                    "entity_type": "kbli",
+                    "name": "Restaurant",
+                    "properties": {"pma_status": status},
+                }
+            ]
+        )
+        state = _base_state(is_foreign_investor=True, kbli_codes=["kbli:56101"])
+        result = await check_pma_eligibility_node(state, mock_db_pool)
+        assert result["licensing_requirements"][-1]["details"][0]["eligible"] is None
+
+    @pytest.mark.parametrize(
+        "code", ["kbli:55111", "kbli:62011", "kbli:62021", "kbli:68110", "kbli:73110", "kbli:74100"]
+    )
+    @pytest.mark.asyncio
+    async def test_reachable_node_without_pma_layer_is_undetermined(self, mock_db_pool, code):
+        """
+        These six are REAL rows this query now reaches and cannot answer.
+
+        Measured 2026-08-03: of the 1,568 ids matching `kbli:NNNNN`, 1,562
+        carry a `pma_status` and SIX do not — 55111 / 62011 / 62021 / 68110 /
+        73110 / 74100, all filed as `kbli_code`. They are exactly the rows the
+        old `entity_type = 'kbli'` filter dropped, so widening the query makes
+        them reachable for the first time; each must answer "undetermined".
+
+        (An earlier version of this test justified itself with the 12,075
+        kbli nodes that carry no PMA layer — true, but IRRELEVANT: their ids
+        are `kbli_kbli_NNNNN`-shaped and this query can never reach them. Real
+        test, wrong reason.)
+        """
+        conn = mock_db_pool._mock_conn
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "entity_id": code,
+                    "entity_type": "kbli_code",
+                    "name": f"KBLI {code.split(':')[1]}",
+                    "properties": {},
+                }
+            ]
+        )
+        state = _base_state(is_foreign_investor=True, kbli_codes=[code])
+        result = await check_pma_eligibility_node(state, mock_db_pool)
+        detail = result["licensing_requirements"][-1]["details"][0]
+        assert detail["eligible"] is None
+        assert detail["eligibility_state"] == "undetermined"
+        assert detail["pma_status"] == "unknown"
+
+    @pytest.mark.parametrize(
+        ("status", "expected_state"),
+        [
+            ("TERBUKA", "open"),
+            ("TERTUTUP", "closed"),
+            ("TERBATAS", "undetermined"),
+            ("Verify at OSS", "undetermined"),
+            ("wat", "undetermined"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_state_string_and_bool_can_never_disagree(
+        self, mock_db_pool, status, expected_state
+    ):
+        """
+        One writer, two renderings.
+
+        `eligible` is derived from `eligibility_state` in a single place; this
+        pins that they cannot drift apart, and that a consumer branching on
+        the string gets the same verdict as one comparing the bool with `is`.
+        """
+        conn = mock_db_pool._mock_conn
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "entity_id": "kbli:56101",
+                    "entity_type": "kbli_code",
+                    "name": "Restaurant",
+                    "properties": {"pma_status": status},
+                }
+            ]
+        )
+        state = _base_state(is_foreign_investor=True, kbli_codes=["kbli:56101"])
+        result = await check_pma_eligibility_node(state, mock_db_pool)
+        detail = result["licensing_requirements"][-1]["details"][0]
+        assert detail["eligibility_state"] == expected_state
+        assert detail["eligible"] is {"open": True, "closed": False, "undetermined": None}[
+            expected_state
+        ]
+
+    @pytest.mark.asyncio
+    async def test_truthiness_hazard_is_documented_by_a_failing_consumer(self, mock_db_pool):
+        """
+        A consumer writing `if not detail["eligible"]` denies a CAPPED code.
+
+        This is the L2.11 defect arriving through a downstream truthiness test
+        rather than through this module's table, and it is why the string
+        state exists. The test pins BOTH halves: the naive read is wrong, and
+        the state string gives the consumer a way to be right.
+        """
+        conn = mock_db_pool._mock_conn
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "entity_id": "kbli:79110",  # TERBATAS on the live KG
+                    "entity_type": "kbli_code",
+                    "name": "Travel Agency",
+                    "properties": {"pma_status": "TERBATAS"},
+                }
+            ]
+        )
+        state = _base_state(is_foreign_investor=True, kbli_codes=["kbli:79110"])
+        result = await check_pma_eligibility_node(state, mock_db_pool)
+        detail = result["licensing_requirements"][-1]["details"][0]
+
+        # The naive consumer would deny a lawful capped stake...
+        assert not detail["eligible"]
+        # ...while the honest verdict is "we do not know the cap from here".
+        assert detail["eligible"] is not False
+        assert detail["eligibility_state"] == "undetermined"
+
+    @pytest.mark.asyncio
+    async def test_jsonb_returned_as_string_still_reads(self, mock_db_pool):
+        """A pool without a jsonb codec hands back str — must not crash."""
+        conn = mock_db_pool._mock_conn
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "entity_id": "kbli:56101",
+                    "entity_type": "kbli",
+                    "name": "Restaurant",
+                    "properties": '{"pma_status": "TERTUTUP"}',
+                }
+            ]
+        )
+        state = _base_state(is_foreign_investor=True, kbli_codes=["kbli:56101"])
+        result = await check_pma_eligibility_node(state, mock_db_pool)
+        assert result["licensing_requirements"][-1]["details"][0]["eligible"] is False
+
+    @pytest.mark.asyncio
+    async def test_code_absent_from_kg_is_reported_not_dropped(self, mock_db_pool):
+        """
+        Silence reads downstream as "no restriction found".
+
+        A requested code the KG has no row for must come back as an explicit
+        undetermined entry, not as an absent one.
+        """
+        conn = mock_db_pool._mock_conn
+        conn.fetch = AsyncMock(return_value=[])
+        state = _base_state(is_foreign_investor=True, kbli_codes=["kbli:99999"])
+        result = await check_pma_eligibility_node(state, mock_db_pool)
+        details = result["licensing_requirements"][-1]["details"]
+        assert len(details) == 1
+        assert details[0]["kbli_code"] == "kbli:99999"
+        assert details[0]["eligible"] is None
+        assert "no node in the KG" in details[0]["eligibility_basis"]
+
+    @pytest.mark.asyncio
+    async def test_query_is_not_filtered_by_entity_type(self, mock_db_pool):
+        """
+        The 10 highest-traffic codes are filed as `kbli_code`, not `kbli`.
+
+        Measured 2026-08-03: 47721 / 55111 / 56101 / 62011 / 62021 / 68110 /
+        70201 / 73110 / 74100 / 79110 live ONLY under `entity_type='kbli_code'`
+        (zero overlap with the 1,558 filed as `kbli`), so the old
+        `AND entity_type = 'kbli'` made the restaurant code invisible.
+        """
+        conn = mock_db_pool._mock_conn
+        conn.fetch = AsyncMock(return_value=[])
+        state = _base_state(is_foreign_investor=True, kbli_codes=["kbli:56101"])
+        await check_pma_eligibility_node(state, mock_db_pool)
+        sql = conn.fetch.await_args.args[0]
+        assert "entity_type = 'kbli'" not in sql
+        assert "entity_id = ANY" in sql
 
     @pytest.mark.asyncio
     async def test_extract_kbli_from_entities(self, mock_db_pool):


### PR DESCRIPTION
## The defect

`check_pma_eligibility_node` decided foreign-ownership eligibility with
`pma_status in ["allowed", "open"]`.

Censused on the live KG (2026-08-03), `pma_status` reads **TERBUKA 1464 ·
TERTUTUP 61 · TERBATAS 29 · "Verify at OSS" 4** — and **zero** rows carry
`allowed` / `open` / `restricted`. So `eligible` was `False` for every code in
the store, the 1,464 fully open ones included.

Both existing tests passed, because they fed the node an English vocabulary
that exists nowhere but in those tests.

## Three defects, one cause — a verdict derived from the wrong shape

**1. The vocabulary.** Table now keyed on what the store actually says; the
English tokens survive as legacy aliases, labelled as absent from production.

**2. `eligible` was a binary derived from a ternary** — the same conceptual
defect as L2.11 (`kbli_eye.py`), surviving in a second place (W107:
pattern-fix = class-audit). TERBATAS means *open up to a CAP*: `False` denies a
lawful stake, `True` hides the cap. This store carries no cap at all —
`pma_max_asing` / `pma_official_basis` / `pma_cap_verified` are absent from all
13,633 kbli nodes — so the honest answer is **undetermined**, with a basis
string pointing at the canonical dataset. An unrecognised or missing status
resolves the same way: never a silent `False`.

**3. `AND entity_type = 'kbli'` silently dropped rows.** The `kbli:NNNNN` id
namespace spans **1,568 codes across two types** — 1,558 as `kbli`, 10 as
`kbli_code`, zero overlap. Those 10 are `47721 55111 56101 62011 62021 68110
70201 73110 74100 79110`: restaurant, hotel, travel agency — the codes this
product is asked about most. The id *is* the entity; the filter added no
protection. A requested code with no row is now reported as undetermined rather
than omitted, because silence reads downstream as "no restriction found".

## Latent, not live — stated plainly

`pma_info` flows into `state["licensing_requirements"]`, which has **no consumer
outside this file and its tests** (grep-verified, positive control run). The
subgraph *is* mounted (`"kbli": "company_subgraph"`), but the orchestrator never
reads that key. **Nothing client-facing changes today.** This closes the trap
before the first consumer arrives.

## What the adversarial gate changed

Codex, cross-family, told to default to defective. It changed the diff twice.

- **Named a truthiness hazard the tri-state bool cannot defend against**: a
  consumer writing `if not detail["eligible"]` treats `None` exactly like
  `False` — L2.11 arriving through a downstream test instead of through this
  table. Cured with an authoritative `eligibility_state` string
  (`open`/`closed`/`undetermined`) from which the bool is derived in exactly one
  place. One writer, two renderings; pinned by a test that they can never
  disagree, plus one that documents the naive read failing.
- **Its other objection was refuted on disk** (`kbli:56101` as `kbli_code` *does*
  carry TERBUKA) and traced to an imprecision in my own prompt — but chasing it
  surfaced a real gap it had not named: **6 of those 10 codes** (55111, 62011,
  62021, 68110, 73110, 74100) carry no `pma_status`, are newly reachable, and my
  test for that shape justified itself by citing the 12,075 nodes this query can
  *never* reach. Real test, wrong reason — reason and coverage both fixed.

## Verification

**Mutation-verified 8/8 with a green control**: old binary verdict · restored
`entity_type` filter · unknown→False · TERBATAS→False · dropped missing-code
reporting · undetermined→False derivation · dropped state field · TERBUKA→closed.

The 5 failures in `services/rag/agentic/` are **pre-existing suite-ordering
pollution** — measured identical with and without this diff (they pass when run
alone, in both worlds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)