### PR TITLE
fix(kbli): the channel cure tool was dead in production, and --only died with it

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -150,9 +150,45 @@ GAP_FALLBACK_TEXT = (
 # script does not re-derive that predicate: it asks the detector and consumes
 # its verdict. Two tools that must agree on the same fact do not get to invent
 # two answers (W105) — and the detector is the one with the corpus that pins it.
-CONFORMANCE_SCRIPT = (
-    Path(__file__).resolve().parents[4] / "scripts" / "kbli_filiera" / "kbli_surface_conformance.py"
-)
+CONFORMANCE_MARKER = Path("scripts") / "kbli_filiera" / "kbli_surface_conformance.py"
+
+
+def find_conformance_script(start: Path | None = None) -> Path | None:
+    """Locate the detector by WALKING UP for its marker, never by a fixed index.
+
+    This file lives at two different depths: `apps/backend-rag/backend/scripts/`
+    in the repo (4 levels under the root) and `/app/backend/scripts/` in the
+    deployed image (2). A hardcoded `parents[4]` is therefore an IndexError in
+    production — raised at MODULE level, so the script could not even be
+    imported there, which killed `--only` too: the one path that can run inside
+    the container, and the path the 2026-08-01 prod cure actually used.
+
+    Returns None when no repo layout is found. That is the EXPECTED state inside
+    the image, which ships neither `scripts/kbli_filiera/` nor `pg.sh`, and it
+    must read as "no selector available here" — never as a crash, and never as
+    an empty scope (W84: absence of a reading is not a clean bill).
+    """
+    here = (start or Path(__file__)).resolve()
+    for ancestor in here.parents:
+        candidate = ancestor / CONFORMANCE_MARKER
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+CONFORMANCE_SCRIPT = find_conformance_script()
+
+# A refusal must be legible to a CALLER, not only to a human reading stderr.
+# The detector below is scrupulous about this ("judged by EXIT CODE, never by
+# did it print something") and this script used to drop that discipline on the
+# floor for its own caller: the refusal branch did a bare `return`, so
+# `sys.exit(main())` exited 0 and "I refused to cure anything" was
+# indistinguishable from "I cured everything" (the W104 shape).
+# 3, not 2: argparse spends exit 2 on a usage error, and the caller this
+# exists for — automation — would then read 'you passed bad flags' and
+# 'I refused to cure anything' as the same event. 0/1/4 belong to the
+# detector's own vocabulary and are left alone.
+EXIT_REFUSED = 3
 # Mirrors kbli_surface_conformance.py's own exit vocabulary. 4 is CANNOT-VERIFY
 # and it is NOT a clean bill: a detector that could not read the table reports
 # zero divergences, which is indistinguishable from a healthy fleet unless the
@@ -295,7 +331,7 @@ def rebuild_reason(code: str, content: str | None, canonical_rows: int) -> str |
     return None
 
 
-def fetch_conformance_report(script: Path) -> dict:
+def fetch_conformance_report(script: Path | None) -> dict:
     """I/O. Runs the detector and returns its JSON report.
 
     Judged by EXIT CODE, never by "did it print something": exit 4 means the
@@ -303,6 +339,13 @@ def fetch_conformance_report(script: Path) -> dict:
     zero divergences — the exact shape of a healthy fleet. Consuming that as
     "nothing to cure" is how a cure silently becomes a no-op (W84). Anything
     outside {0, 1, 4} is also a refusal: an unknown exit is not a verdict."""
+    if script is None:
+        raise RuntimeError(
+            "conformance detector not found by walking up from this file — no repo layout "
+            "here. That is the expected state inside the deployed image, which ships neither "
+            "scripts/kbli_filiera/ nor pg.sh: --all-licensing-absent is a repo-side selector. "
+            "Run it where the repo is, or pass --only <codes> (which needs no detector)"
+        )
     if not script.is_file():
         raise RuntimeError(
             f"conformance detector not found at {script} — refusing to guess scope from a "
@@ -514,7 +557,7 @@ async def load_dataset(source: str) -> list[dict]:
         return r.json()["data"]
 
 
-async def main() -> None:
+async def main() -> int | None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--apply", action="store_true", help="write changes (default: dry-run)")
     ap.add_argument(
@@ -571,7 +614,7 @@ async def main() -> None:
             report = fetch_conformance_report(args.conformance_script)
         except (RuntimeError, OSError, json.JSONDecodeError) as exc:
             logger.error("refusing to cure: %s", exc)
-            return
+            return EXIT_REFUSED
         codes = licensing_absent_codes(report)
         canonical_rows_by_code = {
             str(d["code"]): int(d.get("canonical_rows", 0))

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -609,3 +609,118 @@ def test_rebuild_reason_does_not_fire_when_canonical_has_no_rows():
 
 def test_rebuild_reason_refuses_an_absent_row():
     assert rebuild_reason("01122", None, 8) is None
+
+
+# ---------------------------------------------------------------------------
+# Deployment-layout tolerance (2026-08-03)
+#
+# Found by RUNNING the tool where it actually cures, not by reading it: on the
+# Fly machine this module died at IMPORT with `IndexError: 4`, because the
+# 2026-08-02 selector added a module-level `parents[4]`. The same file lives at
+# two depths — `apps/backend-rag/backend/scripts/` in the repo (4 levels under
+# the root) and `/app/backend/scripts/` in the image (2) — so no fixed index is
+# right in both. The blast radius was not the new selector: an import-time crash
+# took `--only` down too, i.e. the ONLY path that can run in the container and
+# the one the 2026-08-01 production cure actually used.
+#
+# Guilt = the real production layout resolves to None instead of raising.
+# Innocence = the repo layout still finds the real detector (a "fix" that
+# always returned None would silence the crash and disarm the selector).
+# ---------------------------------------------------------------------------
+
+import asyncio as _asyncio
+import sys as _sys
+from pathlib import Path as _Path
+
+from backend.scripts import kbli_documents_cure as _cure
+
+
+def test_repo_layout_resolves_to_the_real_detector():
+    """INNOCENCE: where the repo exists, the selector must still find its owner."""
+    found = _cure.find_conformance_script()
+    assert found is not None
+    assert found.is_file()
+    assert found.name == "kbli_surface_conformance.py"
+    assert found.parent.name == "kbli_filiera"
+
+
+def test_container_layout_resolves_to_none_instead_of_raising():
+    """GUILT: the exact path the deployed image uses. Must be a value, not a crash."""
+    assert _cure.find_conformance_script(_Path("/app/backend/scripts/kbli_documents_cure.py")) is None
+
+
+def test_a_fixed_parent_index_would_still_crash_on_the_container_layout():
+    """SCAR PIN: this is WHY the walk-up exists. If a future refactor goes back
+    to counting levels, this test states the cost in one line."""
+    container = _Path("/app/backend/scripts/kbli_documents_cure.py").resolve()
+    with pytest.raises(IndexError):
+        _ = container.parents[4]
+
+
+def test_module_level_constant_is_never_an_import_time_crash():
+    """The defect was at MODULE level: importing was enough to die. Re-running
+    the same resolution the module runs at import must be exception-free for
+    any depth, including a file sitting at the filesystem root."""
+    for probe in ("/x.py", "/a/b.py", "/app/backend/scripts/c.py"):
+        found = _cure.find_conformance_script(_Path(probe))
+        # Never a phantom path: either a detector that is really there, or None.
+        # A resolver that returned a plausible-but-absent path would push the
+        # failure down into fetch_conformance_report as a confusing "not found
+        # at <made-up path>" instead of the honest "no repo layout here".
+        assert found is None or found.is_file()
+
+
+def test_detector_absent_refusal_names_the_path_that_still_works():
+    """A refusal that does not say what to do instead reads as breakage."""
+    with pytest.raises(RuntimeError) as exc:
+        _cure.fetch_conformance_report(None)
+    assert "--only" in str(exc.value)
+
+
+def test_refusal_is_visible_to_a_caller_as_a_nonzero_exit(monkeypatch):
+    """GUILT for the W104 shape: the refusal branch used a bare `return`, so
+    `sys.exit(main())` exited 0 and 'I cured nothing' was indistinguishable
+    from 'I cured everything'. Driven through main(), not asserted on the
+    constant — a constant cannot regress, a branch can."""
+    monkeypatch.setattr(_sys, "argv", ["cure", "--all-licensing-absent"])
+
+    async def _no_network(_source):
+        return []
+
+    def _detector_down(_script):
+        raise RuntimeError("conformance detector not found")
+
+    monkeypatch.setattr(_cure, "load_dataset", _no_network)
+    monkeypatch.setattr(_cure, "fetch_conformance_report", _detector_down)
+
+    rc = _asyncio.run(_cure.main())
+    assert rc == _cure.EXIT_REFUSED
+    assert rc != 0
+
+
+def test_importing_this_module_under_the_deployed_layout_does_not_crash():
+    """The one test that actually kills the regression.
+
+    The three above exercise `find_conformance_script`; none of them binds the
+    MODULE to using it. Proof: reverting the module-level constant to
+    `parents[4]` left the whole suite green, because on a repo checkout that
+    index resolves — the corpus was measuring the layout it happened to run on,
+    not the property it claimed (W110: prove the binding took, not that the
+    helper works).
+
+    So execute this module's real source with `__file__` set to the deployed
+    path. Under the walk-up it yields None; under any fixed index it raises,
+    which is exactly how production died."""
+    import types as _types
+
+    source = _Path(_cure.__file__).read_text()
+    deployed = "/app/backend/scripts/kbli_documents_cure.py"
+    name = "kbli_documents_cure_container_probe"
+    probe = _types.ModuleType(name)
+    probe.__file__ = deployed
+    _sys.modules[name] = probe  # dataclass resolves sys.modules[cls.__module__]
+    try:
+        exec(compile(source, deployed, "exec"), probe.__dict__)  # noqa: S102
+        assert probe.CONFORMANCE_SCRIPT is None
+    finally:
+        _sys.modules.pop(name, None)


### PR DESCRIPTION
## What

`apps/backend-rag/backend/scripts/kbli_documents_cure.py` raises `IndexError: 4` **at import** on the Fly machine. Found by running it, not by reading it:

```
File "/app/backend/scripts/kbli_documents_cure.py", line 154, in <module>
    Path(__file__).resolve().parents[4] / "scripts" / "kbli_filiera" / "kbli_surface_conformance.py"
IndexError: 4
```

The 2026-08-02 state-selector introduced that module-level index. It is correct in the repo (`apps/backend-rag/backend/scripts/` = 4 levels under the root) and wrong in the image (`/app/backend/scripts/` = 2). Because it runs at **module** level the blast radius is not the new selector — **`--only` dies too**, and `--only` is the only path that can run inside the container, the one the 2026-08-01 production cure actually used.

Live consequence: **80 codes** where canonical holds verified OSS-2025 licensing rows and `kbli_documents` serves none are still answering `Perizinan: N/A` on WhatsApp/webchat, and the tool that would cure them cannot start.

## Cure

1. **Walk up for the marker, never count levels** — the same file legitimately lives at two depths. Measured in the container: it ships neither `scripts/kbli_filiera/` nor `pg.sh`, so `None` there is the honest answer, and the `--all-licensing-absent` refusal now names the path that still works (`--only`).
2. **The refusal is visible to a caller.** It did a bare `return`, so `sys.exit(main())` exited **0** — "I refused to cure anything" was indistinguishable from "I cured everything" (W104 shape, in a script whose own detector is scrupulous about *"judged by EXIT CODE, never by did it print something"*). Now `EXIT_REFUSED = 3` — deliberately not 2, which argparse spends on usage errors, so automation can tell a refusal from bad flags.

## Verification

Mutation-verified **4/4** with a green control, judged by exit code with `--color=no`:

| mutation | result |
|---|---|
| refusal back to bare `return` | killed |
| module constant back to `parents[4]` | killed |
| `find_conformance_script` always `None` | killed |
| drop the `script is None` guard | killed |

**The first corpus did not catch the regression that caused this.** Reverting the module-level constant to `parents[4]` left the suite **green**, because on a repo checkout that index resolves — the tests were measuring the layout they ran on, not the property they claimed (W110). The binding is now pinned by `exec`-ing the module's real source with `__file__` set to the deployed path.

Independent review: **GLM 5.2** (generator ≠ grader) returned SOUND; its one substantive point — exit-2 colliding with argparse — is what moved the code to 3. The pre-commit anti-reward-hacking linter separately caught a genuinely weak test of mine (no assertion, relying on "must not raise"); it now asserts that the resolver never returns a phantom path.

## Not claimed

Nothing has been written to the database by this PR. The apply is a separate step and needs this fix deployed first.