### PR TITLE
fix(kbli): --only bypasses the content-preservation gate silently

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -62,6 +62,15 @@ SCOPE DISCIPLINE (mirrors `kg_kbli_license_fix.py`): `--only` is MANDATORY
 unless `--all-quarantined` is passed explicitly — this script NEVER sweeps
 the full ~1,559-row table.
 
+`--only` DOES NOT GET THE CONTENT-PRESERVATION GATE. That gate is scoped to
+`--all-licensing-absent`, so passing the same population as a hand-written
+`--only` list cures every code the gate would have REFUSED — on 2026-08-02
+that was 25 of 80 rows of hand-written client-facing prose. `--only` is also
+the only selector that runs inside the deployed image, which is what makes the
+substitution tempting. It is not blocked (the Perpres-cap lane legitimately
+replaces prose) but it is now REPORTED: a run logs which rows it is about to
+overwrite. Read that line before `--apply`.
+
 WHAT `--only` ACTUALLY GATES ON (corrected 2026-08-01 — this paragraph used
 to claim the opposite, and a session relied on the path it denied). The
 `per_skala_disputed_*` marker selects the `--all-quarantined` population and
@@ -692,6 +701,40 @@ async def main() -> int | None:
             if not codes:
                 logger.warning("gate refused every selected row — nothing to do")
                 return
+        elif not args.all_quarantined:
+            # `--only` BYPASSES the gate above, and that is the trap this block
+            # exists to make loud. The gate cannot run here: a hand-written
+            # scope means the operator, not a predicate, chose these codes, and
+            # the legitimate `--only` lane (the Perpres-cap cures) exists
+            # precisely to replace prose. So this REPORTS and never refuses.
+            #
+            # It matters because `--only` is also the ONLY selector that runs
+            # inside the deployed image, which makes it the path most likely to
+            # be handed a state-selected list by hand — exactly how the 25 rows
+            # the gate protected on 2026-08-02 nearly went out anyway.
+            #
+            # canonical_rows is 0 on purpose: the detector's count does not
+            # exist on this path, and deriving a second one for the same fact is
+            # how two tools start disagreeing about it (W105). A
+            # contradicted-licensing-claim row therefore reports as plain
+            # hand-written — true, and the loud direction.
+            overwritten = []
+            for code in codes:
+                row = table_rows.get(code)
+                if row is None:
+                    continue  # nothing stored to overwrite
+                if rebuild_reason(code, row["content"], 0) is None:
+                    overwritten.append(code)
+            if overwritten:
+                logger.warning(
+                    "--only bypasses the content-preservation gate: %d of %d selected row(s) "
+                    "carry hand-written prose this run will OVERWRITE (%s). The pre-cure text "
+                    "goes to kbli_documents_archive, but ON CONFLICT DO NOTHING makes that "
+                    "ONE-SHOT per code — a second cure of the same row preserves nothing.",
+                    len(overwritten),
+                    len(codes),
+                    ", ".join(overwritten),
+                )
 
         plans: list[DocumentCurePlan] = []
         for code in codes:

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -629,6 +629,7 @@ def test_rebuild_reason_refuses_an_absent_row():
 # ---------------------------------------------------------------------------
 
 import asyncio as _asyncio
+import logging as _logging
 import sys as _sys
 from pathlib import Path as _Path
 
@@ -724,3 +725,129 @@ def test_importing_this_module_under_the_deployed_layout_does_not_crash():
         assert probe.CONFORMANCE_SCRIPT is None
     finally:
         _sys.modules.pop(name, None)
+
+
+# --- `--only` bypasses the content-preservation gate: report it, never silently act ---
+
+
+class _FakeConn:
+    """Minimal asyncpg stand-in: enough to reach the selector-scoped warning."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, *_args, **_kwargs):
+        return "OK"
+
+    async def fetch(self, _sql, codes):
+        return [r for r in self._rows if r["kode_kbli"] in codes]
+
+    async def close(self):
+        return None
+
+
+def _row(code, content):
+    return {
+        "kode_kbli": code,
+        "judul": f"KBLI {code}",
+        "content": content,
+        "metadata": {},
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+_HAND_WRITTEN = (
+    "# KBLI 86995 - Aktivitas Pijat\n\n"
+    "## Informasi Umum\nmachine-shaped head...\n\n"
+    "## Bagaimana Membedakannya dari 86991\n"
+    "Hand-written disambiguation canonical cannot regenerate.\n"
+)
+_MACHINE_SEED = (
+    "# KBLI 74191 - Aktivitas Konsultasi\n\n"
+    "## Informasi Umum\nx\n\n"
+    "## Deskripsi Kegiatan Usaha\ny\n\n"
+    "## Investasi Asing (PMA)\nz\n"
+)
+
+
+def _drive_only(monkeypatch, argv, rows, dataset=()):
+    """Run main() with the DB faked, returning the log records it emitted.
+
+    `dataset` defaults to empty, which is fine for `--only` (the scope comes
+    from the flag). It is NOT fine for `--all-quarantined`, whose scope is
+    DERIVED from the dataset: with no canonical records main() returns at
+    "empty code list" long before the branch under test. That poverty let a
+    real mutation (`elif not args.all_quarantined` → `else`) survive."""
+    monkeypatch.setattr(_sys, "argv", argv)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://fake/fake")
+
+    async def _dataset(_source):
+        return list(dataset)
+
+    async def _connect(_dsn):
+        return _FakeConn(rows)
+
+    monkeypatch.setattr(_cure, "load_dataset", _dataset)
+    monkeypatch.setattr(_cure.asyncpg, "connect", _connect)
+    return _asyncio.run(_cure.main())
+
+
+def test_only_warns_that_it_will_overwrite_hand_written_prose(monkeypatch, caplog):
+    """GUILT. The gate lives under `--all-licensing-absent`; handing the SAME
+    population to `--only` cures every row the gate would have refused (25 of 80
+    on 2026-08-02). Not blocked — the Perpres-cap lane legitimately replaces
+    prose — but it must not be silent."""
+    with caplog.at_level(_logging.WARNING, logger=_cure.logger.name):
+        _drive_only(monkeypatch, ["cure", "--only", "86995"], [_row("86995", _HAND_WRITTEN)])
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= _logging.WARNING]
+    assert any("bypasses the content-preservation gate" in m for m in warnings), warnings
+    assert any("86995" in m for m in warnings), warnings
+
+
+def test_only_is_silent_on_a_machine_seed_row(monkeypatch, caplog):
+    """INNOCENCE. A 2026-02-18 machine-seed row loses nothing on rebuild —
+    warning about it would train the reader to skip the line that matters."""
+    with caplog.at_level(_logging.WARNING, logger=_cure.logger.name):
+        _drive_only(monkeypatch, ["cure", "--only", "74191"], [_row("74191", _MACHINE_SEED)])
+    assert not [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= _logging.WARNING and "content-preservation gate" in r.getMessage()
+    ]
+
+
+def test_only_does_not_claim_to_overwrite_a_row_that_does_not_exist(monkeypatch, caplog):
+    """INNOCENCE. A code absent from `kbli_documents` has no stored prose, so
+    naming it would be a fabricated casualty — `content=None` alone fails the
+    machine-template predicate, which is why this needs its own branch."""
+    with caplog.at_level(_logging.WARNING, logger=_cure.logger.name):
+        _drive_only(monkeypatch, ["cure", "--only", "99999"], [])
+    assert not [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= _logging.WARNING and "content-preservation gate" in r.getMessage()
+    ]
+
+
+def test_quarantine_scope_is_exempt_from_the_overwrite_warning(monkeypatch, caplog):
+    """INNOCENCE. Under `--all-quarantined` the stored content is FABRICATED by
+    definition, so 'hand-written prose will be overwritten' would be a false
+    alarm about the very text the cure exists to destroy.
+
+    The dataset is REQUIRED here: `--all-quarantined` derives its scope from
+    the `per_skala_disputed_*` marker, so without a marked record the run ends
+    at "empty code list" and this test proves nothing (mutation-verified)."""
+    marked = [{"kode_kbli_2025": "86995", "per_skala_disputed_2026_02": True, "per_skala": []}]
+    with caplog.at_level(_logging.WARNING, logger=_cure.logger.name):
+        _drive_only(
+            monkeypatch,
+            ["cure", "--all-quarantined"],
+            [_row("86995", _HAND_WRITTEN)],
+            dataset=marked,
+        )
+    assert not [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= _logging.WARNING and "content-preservation gate" in r.getMessage()
+    ]


### PR DESCRIPTION
## What

The content-preservation gate — the one that REFUSES to rebuild hand-written,
client-facing prose — is scoped to `--all-licensing-absent`. Hand the **same
population** to `--only` and every row the gate would have refused gets cured.
On 2026-08-02 that was **25 of 80** rows.

The substitution is tempting rather than exotic: `--only` is the **only**
selector that runs inside the deployed image (which ships neither
`scripts/kbli_filiera/` nor `pg.sh`), so an operator working in the container
reaches for it by necessity.

## Why a reporter and not a refusal

The legitimate `--only` lane — the Perpres foreign-cap cures — exists precisely
to replace prose. A refusal here would break the one caller that wants this
behaviour. So the run now **names the rows it is about to overwrite**, and says
the archive is `ON CONFLICT DO NOTHING`, i.e. one-shot per code: a second cure
of the same row preserves nothing.

`canonical_rows` is passed as `0` on this path deliberately. The detector's
count does not exist here, and deriving a second source for the same fact is
how two tools start disagreeing about it (W105). A `contradicted-licensing-claim`
row therefore reports as plain hand-written — true, and the loud direction.

## Corpus

- **GUILT** — a hand-written row under `--only` is named in a WARNING.
- **INNOCENCE ×3** — a machine-seed row stays silent; a code absent from the
  table is not claimed as a casualty; `--all-quarantined` is exempt, because
  there the stored content is fabricated by definition.

Mutation-verified **3/3** (disarm the predicate · drop the absent-row guard ·
widen `elif not args.all_quarantined` to `else`).

**The quarantine innocence test survived its mutation on the first pass.** With
an empty dataset, `--all-quarantined` derives an empty scope and `main()`
returns at "empty code list" before ever reaching the branch — the test was
measuring its own poverty, not the property it claimed. It now seeds a
`per_skala_disputed_*` record and kills the mutation.

Follow-up to #3548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)