### PR TITLE
feat(ops): PENDING-ARMS PR-merged probe + zero-population monitor (megatopics-1-5 #1)

### DIFF
--- a/scripts/pending_arms_report.py
+++ b/scripts/pending_arms_report.py
@@ -56,6 +56,40 @@ conflict-marker-shaped line is also refused as a continuation (CONFLICT_MARKER_R
 rather than silently absorbed into whatever entry is being built, and is surfaced as
 its own MALFORMED entry instead of vanishing without a trace.
 
+PR-ALREADY-MERGED rule (added 2026-08-03, megatopics-1-5 action plan #1): an entry
+whose artifact/missing_step/proof cites a `PR #NNN` reference that `gh pr
+view` now reports as MERGED is a CANDIDATE for "its owner is still waiting on
+something that already landed" — but measured against the real 312-entry
+ledger the SAME day this shipped, this is a noisy, low-confidence signal, not
+a verdict, and the report/JSON label it as such. Two false-positive classes
+found live: (1) a bare `#NNN` token is not always a PR — `(#6860, #2837,
+#2836)` in one real entry are CodeQL ALERT numbers sitting next to an
+unrelated file:line list, so the regex requires a literal `PR` immediately
+before the hash (cuts the naive match count roughly 3x on this ledger); (2)
+even with that anchor, this ledger's own authoring convention is to cite a
+merged PR as historical/precedent context ("cured via PR #3524", "mirroring
+PR #2921's design") far more often than as a live blocker — of every
+PR-anchored hit manually reviewed against this ledger, none were a genuine
+"still waiting, and now it merged" case; every one was the author already
+knowing and stating the PR's status while the entry stays open for an
+UNRELATED reason. A reliable version of "is this specific entry's remaining
+work blocked on this specific PR" needs semantic judgment (Tier-2, explicitly
+out of scope for this Tier-1 signaler) or a git-blame correlation this file
+does not attempt. Treat this section as a skim list for a human's own
+judgment, never as an actionable alert — it is why `--strict`'s exit code
+never reads `merged_pr_refs`/CLASS_PR_ALREADY_MERGED, only entry.cls.
+
+This check is OPT-IN via --check-pr-refs (default off)
+because it needs network + `gh` auth, which the existing test suite and any
+offline/shallow-checkout run cannot assume; when the flag is not passed,
+every entry's merged_pr_refs stays empty and this rule never fires, so
+behavior is byte-for-byte unchanged from before this feature existed. A PR
+reference `gh` could not verify (missing binary, auth failure, timeout,
+non-zero exit, unparseable JSON) is NEVER treated as merged — same "judge the
+reply, never assume success" discipline as _ledger_freshness (W104): an
+unverifiable ref just doesn't count toward merged_pr_refs, it does not crash
+the report and it is not silently promoted to "merged" either.
+
 Usage:
     python3 scripts/pending_arms_report.py [--ledger PATH] [--now YYYY-MM-DD] [--json]
                                            [--strict] [--strict-phantom]
@@ -79,7 +113,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 # 48h at day-precision: the ledger records opened-dates, not timestamps, so "overdue"
 # is age_days >= 2 (i.e. the entry has survived at least one full day beyond the day
@@ -100,6 +134,11 @@ CLASS_NATURAL_WAIT = "NATURAL-WAIT"
 CLASS_OPERATOR_GATED = "OPERATOR-GATED"
 CLASS_TECH_DEBT = "TECH-DEBT"
 CLASS_PHANTOM_OPERATOR = "PHANTOM-OPERATOR"
+# Not a parse_entry() classification like the others above — this bucket is
+# derived AFTER parsing, only when --check-pr-refs ran annotate_pr_refs() and
+# found a cited #NNN PR reference that `gh pr view` reports MERGED. See
+# PR-ALREADY-MERGED rule in the module docstring.
+CLASS_PR_ALREADY_MERGED = "PR-ALREADY-MERGED"
 
 # The ONLY categories for which owner=operator is legitimate — actions a session
 # structurally cannot take (feedback_no_operator_lane_io_sono_te_2026_07_06). Anything
@@ -168,15 +207,29 @@ class Entry:
     age_days: Optional[int] = None
     overdue: bool = False
     cls: str = CLASS_TECH_DEBT
+    # Populated ONLY by annotate_pr_refs() (--check-pr-refs). Empty on every
+    # entry otherwise, so the bucket property below never fires this branch
+    # unless that opt-in check actually ran — the default path is unaffected.
+    pr_refs: List[str] = field(default_factory=list)
+    merged_pr_refs: List[str] = field(default_factory=list)
 
     @property
     def bucket(self) -> str:
-        """Report/JSON grouping key: MALFORMED > PHANTOM-OPERATOR > FIREBREAK > {cls}-OVERDUE > FRESH."""
+        """Report/JSON grouping key: MALFORMED > PHANTOM-OPERATOR > PR-ALREADY-MERGED
+        > FIREBREAK > NATURAL-WAIT > {cls}-OVERDUE > FRESH."""
         if self.cls == CLASS_MALFORMED:
             return CLASS_MALFORMED
         if self.cls == CLASS_PHANTOM_OPERATOR:
             # never FRESH: a phantom is wrong the moment it is written, not after 48h.
             return CLASS_PHANTOM_OPERATOR
+        if self.merged_pr_refs:
+            # Provably wrong RIGHT NOW (gh says the cited PR is already merged) —
+            # ranked with MALFORMED/PHANTOM-OPERATOR rather than merely aged
+            # debt, but below both: an unparseable/phantom ledger line is a
+            # worse defect than a stale-but-well-formed one. Only ever
+            # non-empty when --check-pr-refs ran annotate_pr_refs(); otherwise
+            # dead code and behavior is unchanged (empty list by default).
+            return CLASS_PR_ALREADY_MERGED
         if self.cls == CLASS_FIREBREAK:
             return CLASS_FIREBREAK
         if self.cls == CLASS_NATURAL_WAIT:
@@ -512,9 +565,108 @@ def load_entries(ledger_path: Path, now: date) -> List[Entry]:
     return [parse_entry(raw, now) for raw in extract_open_entries(text)]
 
 
-def compute_counts(entries: List[Entry]) -> Dict[str, int]:
+# -----------------------------------------------------------------------------
+# PR-ALREADY-MERGED (megatopics-1-5 action plan #1, added 2026-08-03) — OPT-IN,
+# only ever exercised behind --check-pr-refs. See the module docstring's
+# "PR-ALREADY-MERGED rule" for the full rationale.
+# -----------------------------------------------------------------------------
+
+# Requires a literal `PR` immediately before the hash — a bare `#NNN` in this
+# ledger is frequently NOT a pull request (measured live 2026-08-03: CodeQL
+# alert numbers cited next to a file:line list, e.g. "telegram_webhook.py:147
+# (#6860, #2837, #2836)" — none of those are PRs). `PR\s*#` anchors on the
+# entity a reader would call a PR, not on the digit shape. 3-5 digits with a
+# trailing word-boundary so a longer digit run fails to match rather than
+# silently truncating to its first 5 digits and citing the wrong PR.
+PR_REF_RE = re.compile(r"\bPR\s*#(\d{3,5})\b", re.IGNORECASE)
+
+
+def extract_pr_refs(entry: Entry) -> List[str]:
+    """`PR #123`-style references cited in an entry's artifact/missing_step/proof.
+
+    Order-preserving, deduplicated across all three fields. Even with the `PR`
+    anchor this is a noisy signal on this ledger — see the module docstring's
+    PR-ALREADY-MERGED rule for the measured false-positive rate before trusting
+    a hit here as anything more than a candidate for a human to skim.
+    """
+    seen: Dict[str, None] = {}
+    for text in (entry.artifact, entry.missing_step, entry.proof):
+        for m in PR_REF_RE.finditer(text or ""):
+            seen.setdefault(m.group(1), None)
+    return list(seen.keys())
+
+
+def _check_pr_merged(pr_number: str) -> Dict[str, Any]:
+    """Best-effort `gh pr view <n> --json state,mergedAt`. Never raises.
+
+    Returns {"checked": bool, "merged": bool, "detail": str}. "checked" False
+    means the call could not be trusted (gh missing, timeout, non-zero exit,
+    unparseable JSON) — the caller must NEVER treat that as "merged" (same
+    "judge the reply, never assume success" discipline as _ledger_freshness,
+    W104: a bare non-crash is not proof of anything either way).
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--json", "state,mergedAt"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        return {"checked": False, "merged": False, "detail": "gh not on PATH"}
+    except (subprocess.SubprocessError, OSError) as exc:
+        return {
+            "checked": False,
+            "merged": False,
+            "detail": f"gh invocation failed: {type(exc).__name__}",
+        }
+
+    if proc.returncode != 0:
+        reason = (proc.stderr or "").strip().splitlines()
+        return {
+            "checked": False,
+            "merged": False,
+            "detail": reason[-1] if reason else f"gh exited {proc.returncode}",
+        }
+
+    try:
+        payload = json.loads(proc.stdout or "")
+    except json.JSONDecodeError:
+        return {"checked": False, "merged": False, "detail": "unparseable gh output"}
+
+    if not isinstance(payload, dict):
+        return {"checked": False, "merged": False, "detail": "unexpected gh payload shape"}
+
+    state = payload.get("state")
+    return {"checked": True, "merged": state == "MERGED", "detail": state or "unknown state"}
+
+
+def annotate_pr_refs(
+    entries: List[Entry],
+    checker: Callable[[str], Dict[str, Any]] = _check_pr_merged,
+) -> None:
+    """Mutate each Entry in place: set .pr_refs and .merged_pr_refs.
+
+    Only ever called from main() behind --check-pr-refs — never on the
+    default path, so the rest of the report is unaffected unless this ran.
+    An unverifiable ref (checker returns checked=False) is left OUT of
+    merged_pr_refs — "cannot verify" is never silently "merged" (W104).
+    Never touches the ledger file; this remains a pure signaler.
+    """
+    for entry in entries:
+        refs = extract_pr_refs(entry)
+        entry.pr_refs = refs
+        merged: List[str] = []
+        for ref in refs:
+            result = checker(ref)
+            if result.get("checked") and result.get("merged"):
+                merged.append(ref)
+        entry.merged_pr_refs = merged
+
+
+def compute_counts(entries: List[Entry], check_pr_refs: bool = False) -> Dict[str, int]:
     buckets = [e.bucket for e in entries]
-    return {
+    counts = {
         "total": len(entries),
         "phantom_operator": buckets.count(CLASS_PHANTOM_OPERATOR),
         "tech_debt_overdue": buckets.count(f"{CLASS_TECH_DEBT}-OVERDUE"),
@@ -524,6 +676,12 @@ def compute_counts(entries: List[Entry]) -> Dict[str, int]:
         "fresh": buckets.count("FRESH"),
         "malformed": buckets.count(CLASS_MALFORMED),
     }
+    if check_pr_refs:
+        # Additive: only present when --check-pr-refs ran, so every default
+        # (offline) call site's dict shape stays byte-for-byte unchanged —
+        # required so the pre-existing exact-equality tests never break.
+        counts["pr_already_merged"] = buckets.count(CLASS_PR_ALREADY_MERGED)
+    return counts
 
 
 def _freshness_line(freshness: Optional[Dict[str, Any]]) -> str:
@@ -544,8 +702,9 @@ def render_report(
     now: date,
     entries: List[Entry],
     freshness: Optional[Dict[str, Any]] = None,
+    check_pr_refs: bool = False,
 ) -> str:
-    counts = compute_counts(entries)
+    counts = compute_counts(entries, check_pr_refs=check_pr_refs)
     lines: List[str] = []
     lines.append("# PENDING-ARMS reconciliation report")
     lines.append("")
@@ -555,12 +714,15 @@ def render_report(
         f"- now: {now.isoformat()} (day-precision dates; overdue = age_days >= "
         f"{OVERDUE_AGE_DAYS}, the closest day-precision proxy for >48h)"
     )
-    lines.append(
+    summary = (
         "- counts: total={total} phantom_operator={phantom_operator} "
         "tech_debt_overdue={tech_debt_overdue} "
         "operator_gated_overdue={operator_gated_overdue} firebreak={firebreak} "
-        "natural_wait={natural_wait} fresh={fresh} malformed={malformed}".format(**counts)
-    )
+        "natural_wait={natural_wait} fresh={fresh} malformed={malformed}"
+    ).format(**counts)
+    if check_pr_refs:
+        summary += " pr_already_merged={pr_already_merged}".format(**counts)
+    lines.append(summary)
     lines.append("")
 
     def fmt_entry(e: Entry) -> str:
@@ -595,6 +757,15 @@ def render_report(
         by_bucket.get(CLASS_PHANTOM_OPERATOR, []),
         fmt_entry,
     )
+    if check_pr_refs:
+        section(
+            "PR-ALREADY-MERGED — LOW CONFIDENCE, SKIM ONLY (cites a `PR #N` that `gh` "
+            "reports merged; measured live 2026-08-03 that most hits here are the entry "
+            "already knowing and stating that, staying open for an unrelated reason — "
+            "not proof of staleness, never gates --strict)",
+            by_bucket.get(CLASS_PR_ALREADY_MERGED, []),
+            fmt_entry,
+        )
     section(
         "TECH-DEBT overdue (>48h)",
         by_bucket.get(f"{CLASS_TECH_DEBT}-OVERDUE", []),
@@ -626,24 +797,31 @@ def build_json(
     now: date,
     entries: List[Entry],
     freshness: Optional[Dict[str, Any]] = None,
+    check_pr_refs: bool = False,
 ) -> Dict[str, Any]:
+    def _entry_dict(e: Entry) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "opened": e.opened_date.isoformat() if e.opened_date else None,
+            "age_days": e.age_days,
+            "artifact": e.artifact,
+            "owner": e.owner,
+            "class": e.cls,
+            "overdue": e.overdue,
+            "raw_head": e.raw[:80],
+        }
+        if check_pr_refs:
+            # Additive-only: absent unless --check-pr-refs ran, so the default
+            # entry schema stays byte-for-byte unchanged.
+            d["pr_refs"] = e.pr_refs
+            d["merged_pr_refs"] = e.merged_pr_refs
+        return d
+
     return {
         "now": now.isoformat(),
         "ledger": str(ledger_path),
         "freshness": freshness if freshness is not None else {"state": "unknown", "behind": None, "detail": "not checked"},
-        "counts": compute_counts(entries),
-        "entries": [
-            {
-                "opened": e.opened_date.isoformat() if e.opened_date else None,
-                "age_days": e.age_days,
-                "artifact": e.artifact,
-                "owner": e.owner,
-                "class": e.cls,
-                "overdue": e.overdue,
-                "raw_head": e.raw[:80],
-            }
-            for e in entries
-        ],
+        "counts": compute_counts(entries, check_pr_refs=check_pr_refs),
+        "entries": [_entry_dict(e) for e in entries],
     }
 
 
@@ -791,6 +969,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "for innocent PRs."
         ),
     )
+    parser.add_argument(
+        "--check-pr-refs",
+        action="store_true",
+        help=(
+            "Extract 'PR #NNN' references from every open entry's artifact/"
+            "missing_step/proof and check via `gh pr view` whether each is "
+            "already merged (network + gh auth required — best-effort, off by "
+            "default so the suite runs offline). Flags a PR-ALREADY-MERGED "
+            "bucket, LOW CONFIDENCE — measured live on this ledger's own prose, "
+            "most hits cite a merged PR as historical context, not a live "
+            "blocker; skim it, don't trust it, never gates --strict. Never "
+            "mutates the ledger."
+        ),
+    )
     return parser
 
 
@@ -817,12 +1009,22 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 2
 
     entries = load_entries(ledger_path, now)
+    if args.check_pr_refs:
+        annotate_pr_refs(entries)
     freshness = _ledger_freshness(ledger_path)
 
     if args.json:
-        print(json.dumps(build_json(ledger_path, now, entries, freshness), indent=2))
+        print(
+            json.dumps(
+                build_json(ledger_path, now, entries, freshness, check_pr_refs=args.check_pr_refs),
+                indent=2,
+            )
+        )
     else:
-        print(render_report(ledger_path, now, entries, freshness), end="")
+        print(
+            render_report(ledger_path, now, entries, freshness, check_pr_refs=args.check_pr_refs),
+            end="",
+        )
 
     has_phantom = any(e.cls == CLASS_PHANTOM_OPERATOR for e in entries)
     # --strict is the "I am about to rely on this verdict" mode, so a ledger that

--- a/scripts/tests/test_pending_arms_report.py
+++ b/scripts/tests/test_pending_arms_report.py
@@ -1145,3 +1145,261 @@ def test_freshness_appears_in_json_payload(tmp_path, capsys):
     assert par.main(["--ledger", str(led), "--now", "2026-07-05", "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["freshness"]["state"] in {"current", "stale", "unknown"}
+
+
+# -----------------------------------------------------------------------------
+# PR-ALREADY-MERGED (megatopics-1-5 action plan #1, 2026-08-03) — OPT-IN via
+# --check-pr-refs. gh is always mocked here (subprocess.run monkeypatched, the
+# established pattern in scripts/tests/test_arsenal_probe.py) — no test in
+# this file ever needs real network/gh auth.
+# -----------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_extract_pr_refs_finds_refs_across_all_three_fields(tmp_path):
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-05 | artifact PR #111 | step referencing PR #222 "
+        "| me | proof mentions PR #333 and PR #222 again",
+    )
+    assert par.extract_pr_refs(e) == ["111", "222", "333"]
+
+
+def test_extract_pr_refs_rejects_too_short_and_too_long_numbers(tmp_path):
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-05 | short PR #12 ref | long PR #123456789 ref | me | proof",
+    )
+    assert par.extract_pr_refs(e) == []
+
+
+def test_extract_pr_refs_empty_when_no_hash_present(entries):
+    e = _by_artifact(entries, "fresh me artifact")
+    assert par.extract_pr_refs(e) == []
+
+
+def test_extract_pr_refs_ignores_bare_hash_numbers_without_pr_prefix(tmp_path):
+    # Guilt-of-the-guard regression (measured live 2026-08-03 on the real
+    # ledger): CodeQL alert numbers cited next to a file:line list —
+    # "telegram_webhook.py:147,155,174 (#6860, #2837, #2836)" — are NOT pull
+    # requests. Without the `PR` anchor these were extracted and (because gh
+    # happens to report some coincidentally-numbered real PR as MERGED)
+    # falsely flagged the entry as PR-ALREADY-MERGED.
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-05 | telegram_webhook.py:147,155,174 (#6860, #2837, #2836) "
+        "| me | intel_scraper.py:1217,1218 (#7798, #7799)",
+    )
+    assert par.extract_pr_refs(e) == []
+
+
+def test_extract_pr_refs_accepts_lowercase_pr_prefix(tmp_path):
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-05 | artifact pr #444 | step | me | proof",
+    )
+    assert par.extract_pr_refs(e) == ["444"]
+
+
+def test_guilt_pr_ref_already_merged_is_flagged(tmp_path, monkeypatch):
+    seen_cmds = []
+
+    def fake_run(cmd, **kwargs):
+        seen_cmds.append(cmd)
+        assert cmd[:3] == ["gh", "pr", "view"]
+        assert cmd[3] == "3552"
+        return _FakeProc(0, '{"state":"MERGED","mergedAt":"2026-08-01T00:00:00Z"}', "")
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-20 | stale pr ref artifact "
+        "| merge PR #3552 to unblock this | me | pending merge of #3552",
+    )
+    par.annotate_pr_refs([e])
+    assert e.pr_refs == ["3552"]
+    assert e.merged_pr_refs == ["3552"]
+    assert e.bucket == par.CLASS_PR_ALREADY_MERGED
+    assert len(seen_cmds) == 1  # deduplicated: #3552 appears in both fields
+
+
+def test_innocence_pr_ref_still_open_is_not_flagged(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return _FakeProc(0, '{"state":"OPEN","mergedAt":null}', "")
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-06-20 | genuinely open pr artifact "
+        "| merge PR #4001 to unblock | me | still under review",
+    )
+    par.annotate_pr_refs([e])
+    assert e.merged_pr_refs == []
+    assert e.bucket != par.CLASS_PR_ALREADY_MERGED
+    assert e.bucket == par.CLASS_TECH_DEBT + "-OVERDUE"
+
+
+def test_innocence_entry_with_no_pr_ref_is_unaffected(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakeProc(0, '{"state":"MERGED"}', "")
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-20 | no pr ref artifact | some step | me | some proof",
+    )
+    par.annotate_pr_refs([e])
+    assert calls == []  # never even called gh: nothing to check
+    assert e.merged_pr_refs == []
+    assert e.bucket != par.CLASS_PR_ALREADY_MERGED
+
+
+def test_guilt_gh_missing_degrades_to_cannot_verify_never_merged(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError("gh: command not found")
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-20 | unverifiable pr artifact | merge PR #5005 | me | proof",
+    )
+    par.annotate_pr_refs([e])
+    assert e.merged_pr_refs == []  # NEVER silently treated as merged
+    assert e.bucket != par.CLASS_PR_ALREADY_MERGED
+
+
+def test_guilt_gh_non_zero_exit_degrades_to_cannot_verify(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return _FakeProc(1, "", "gh: pull request not found\n")
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-20 | notfound pr artifact | merge PR #9999 | me | proof",
+    )
+    par.annotate_pr_refs([e])
+    assert e.merged_pr_refs == []
+    assert e.bucket != par.CLASS_PR_ALREADY_MERGED
+
+
+def test_guilt_gh_unparseable_json_degrades_to_cannot_verify(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return _FakeProc(0, "not json at all", "")
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-20 | garbled pr artifact | merge PR #6006 | me | proof",
+    )
+    par.annotate_pr_refs([e])
+    assert e.merged_pr_refs == []
+
+
+def test_guilt_gh_timeout_degrades_to_cannot_verify(tmp_path, monkeypatch):
+    import subprocess as real_subprocess
+
+    def fake_run(cmd, **kwargs):
+        raise real_subprocess.TimeoutExpired(cmd, 15)
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-20 | timeout pr artifact | merge PR #7007 | me | proof",
+    )
+    par.annotate_pr_refs([e])
+    assert e.merged_pr_refs == []
+
+
+def test_default_off_check_pr_refs_never_calls_gh(ledger_path, monkeypatch, capsys):
+    """The core byte-for-byte-identical-when-off requirement: without
+    --check-pr-refs, annotate_pr_refs is never invoked at all (main() still
+    calls _ledger_freshness via `git` regardless — this only spies on the
+    gh-calling path, so it must not intercept that unrelated subprocess use)."""
+    calls = []
+    monkeypatch.setattr(par, "annotate_pr_refs", lambda entries, **kwargs: calls.append(entries))
+    code = par.main(["--ledger", str(ledger_path), "--now", NOW])
+    assert code == 0
+    assert calls == []
+
+
+def test_default_off_counts_dict_has_no_pr_already_merged_key(ledger_path):
+    now = par._parse_now(NOW)
+    entries = par.load_entries(ledger_path, now)
+    counts = par.compute_counts(entries)
+    assert "pr_already_merged" not in counts
+
+
+def test_default_off_json_entries_have_no_pr_ref_fields(ledger_path, capsys):
+    code = par.main(["--ledger", str(ledger_path), "--now", NOW, "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "pr_already_merged" not in payload["counts"]
+    for entry in payload["entries"]:
+        assert "pr_refs" not in entry
+        assert "merged_pr_refs" not in entry
+
+
+def test_default_off_report_has_no_pr_already_merged_section(ledger_path, capsys):
+    code = par.main(["--ledger", str(ledger_path), "--now", NOW])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "PR-ALREADY-MERGED" not in out
+
+
+def test_check_pr_refs_cli_end_to_end_flags_merged_pr(tmp_path, monkeypatch, capsys):
+    def fake_run(cmd, **kwargs):
+        return _FakeProc(0, '{"state":"MERGED","mergedAt":"2026-08-01T00:00:00Z"}', "")
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    ledger = (
+        "- opened 2026-07-20 | cli merged pr artifact | merge PR #3552 | me | pending\n"
+        "\n## closed\n"
+    )
+    p = tmp_path / "PENDING-ARMS.md"
+    p.write_text(ledger, encoding="utf-8")
+
+    code = par.main(["--ledger", str(p), "--now", NOW, "--check-pr-refs", "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["pr_already_merged"] == 1
+    entry = payload["entries"][0]
+    assert entry["merged_pr_refs"] == ["3552"]
+
+
+def test_check_pr_refs_report_section_appears_and_lists_entry(tmp_path, monkeypatch, capsys):
+    def fake_run(cmd, **kwargs):
+        return _FakeProc(0, '{"state":"MERGED","mergedAt":"2026-08-01T00:00:00Z"}', "")
+
+    monkeypatch.setattr(par.subprocess, "run", fake_run)
+
+    ledger = (
+        "- opened 2026-07-20 | report merged pr artifact | merge PR #3552 | me | pending\n"
+        "\n## closed\n"
+    )
+    p = tmp_path / "PENDING-ARMS.md"
+    p.write_text(ledger, encoding="utf-8")
+
+    code = par.main(["--ledger", str(p), "--now", NOW, "--check-pr-refs"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "## PR-ALREADY-MERGED" in out
+    assert "report merged pr artifact" in out
+    assert out.index("## PHANTOM-OPERATOR") < out.index("## PR-ALREADY-MERGED")
+    assert out.index("## PR-ALREADY-MERGED") < out.index("## TECH-DEBT overdue")

--- a/scripts/tests/test_zero_population_monitor.py
+++ b/scripts/tests/test_zero_population_monitor.py
@@ -1,0 +1,401 @@
+"""Tests for scripts/zero_population_monitor.py — the generalized "kill switch
+off + table never written" probe (megatopics-1-5 action plan #1, 2026-08-03).
+
+Module is imported via importlib.util.spec_from_file_location (not a package
+import) because scripts/ is a flat bag of standalone tools — matching the
+existing test_pending_arms_report.py convention. Every test here injects a
+fake query_fn (or monkeypatches the module-level default) — none of them
+touch a real database.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess as real_subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "zero_population_monitor.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("zero_population_monitor", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+zpm = _load_module()
+
+ENTRY = {
+    "name": "e33_guarantee_scan",
+    "switch_key": "e33_guarantee_scan_enabled",
+    "table": "e33_cases",
+}
+
+
+def _outcome(ok: bool, rows=None, detail: str = ""):
+    return zpm.QueryOutcome(ok=ok, rows=rows or [], detail=detail)
+
+
+# ---------------------------------------------------------------------------
+# Registry seed — the one real, verified finding (VCR §1, 2026-08-03)
+# ---------------------------------------------------------------------------
+
+
+def test_default_registry_has_exactly_one_e33_entry():
+    assert zpm.DEFAULT_REGISTRY == [ENTRY]
+
+
+# ---------------------------------------------------------------------------
+# Guilt: unprovisioned + zero rows — the live E33 shape
+# ---------------------------------------------------------------------------
+
+
+def test_guilt_unprovisioned_and_empty_table_alerts():
+    calls = []
+
+    def fake_query(sql: str):
+        calls.append(sql)
+        if "system_settings" in sql:
+            return _outcome(True, rows=[])  # no row at all -> unprovisioned
+        return _outcome(True, rows=[["0"]])  # zero rows
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["checked"] is True
+    assert result["provisioned"] is False
+    assert result["table_empty"] is True
+    assert result["alert"] is True
+    assert "UNPROVISIONED_AND_EMPTY" in result["reason"]
+    assert len(calls) == 2
+
+
+def test_guilt_falsy_switch_value_counts_as_unprovisioned():
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["false"]])
+        return _outcome(True, rows=[["0"]])
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["provisioned"] is False
+    assert result["alert"] is True
+    assert "UNPROVISIONED_AND_EMPTY" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Guilt: provisioned but STILL empty — documented widening decision (see
+# module docstring's ALERT RULE). This is the deliberate design choice the
+# task asked to be made explicit: a provisioned-but-never-written organ is
+# ALSO flagged, not silently passed as "half the conditions held".
+# ---------------------------------------------------------------------------
+
+
+def test_guilt_provisioned_but_empty_table_also_alerts_documented_decision():
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(True, rows=[["0"]])
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["checked"] is True
+    assert result["provisioned"] is True
+    assert result["table_empty"] is True
+    assert result["alert"] is True  # documented widening: also alert here
+    assert "PROVISIONED_BUT_EMPTY" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Innocence: populated table never alerts, regardless of provisioning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("switch_rows", [[], [["false"]], [["true"]]])
+def test_innocence_populated_table_no_alert_regardless_of_provisioning(switch_rows):
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=switch_rows)
+        return _outcome(True, rows=[["42"]])
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["checked"] is True
+    assert result["table_empty"] is False
+    assert result["alert"] is False
+    assert "healthy" in result["reason"]
+
+
+def test_innocence_provisioned_and_populated_is_the_healthy_baseline():
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(True, rows=[["7"]])
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["provisioned"] is True
+    assert result["table_empty"] is False
+    assert result["alert"] is False
+
+
+# ---------------------------------------------------------------------------
+# "Cannot verify" must never be silently "clean" (W84)
+# ---------------------------------------------------------------------------
+
+
+def test_guilt_switch_query_failure_reports_cannot_verify_not_clean():
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(False, detail="connection refused")
+        return _outcome(True, rows=[["0"]])
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["checked"] is False
+    assert result["alert"] is False
+    assert result["provisioned"] is None
+    assert "connection refused" in result["detail"]
+
+
+def test_guilt_table_query_failure_reports_cannot_verify_not_clean():
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(False, detail="timeout")
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["checked"] is False
+    assert result["alert"] is False
+    assert result["provisioned"] is True  # the switch check DID succeed
+    assert "timeout" in result["detail"]
+
+
+def test_guilt_unparseable_row_count_reports_cannot_verify():
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(True, rows=[["not-a-number"]])
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["checked"] is False
+    assert result["alert"] is False
+
+
+def test_guilt_empty_count_rows_reports_cannot_verify():
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(True, rows=[])  # count(*) always returns one row; empty is a parse defect
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["checked"] is False
+    assert result["alert"] is False
+
+
+# ---------------------------------------------------------------------------
+# SQL-construction safety: unsafe identifiers/keys are refused, never queried
+# ---------------------------------------------------------------------------
+
+
+def test_guilt_unsafe_table_identifier_refused_without_querying():
+    calls = []
+
+    def fake_query(sql: str):
+        calls.append(sql)
+        return _outcome(True, rows=[["true"]])
+
+    bad_entry = {"name": "x", "switch_key": "x_enabled", "table": "e33_cases; DROP TABLE users;"}
+    result = zpm.check_entry(bad_entry, query_fn=fake_query)
+    assert result["checked"] is False
+    assert calls == []  # never even attempted a query
+
+
+def test_guilt_unsafe_switch_key_refused_without_querying():
+    calls = []
+
+    def fake_query(sql: str):
+        calls.append(sql)
+        return _outcome(True, rows=[["true"]])
+
+    bad_entry = {"name": "x", "switch_key": "x' OR '1'='1", "table": "e33_cases"}
+    result = zpm.check_entry(bad_entry, query_fn=fake_query)
+    assert result["checked"] is False
+    assert calls == []
+
+
+def test_innocence_real_registry_entry_identifiers_are_accepted():
+    # Sanity check that the safety regexes aren't so strict they reject the
+    # actual seeded entry.
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(True, rows=[["5"]])
+
+    result = zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert result["checked"] is True
+
+
+# ---------------------------------------------------------------------------
+# SQL shape: switch_key is quote-escaped; table name interpolated as-is (safe
+# only because it was validated as a plain identifier above)
+# ---------------------------------------------------------------------------
+
+
+def test_switch_sql_quotes_the_key_literal():
+    seen_sql = {}
+
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            seen_sql["switch"] = sql
+            return _outcome(True, rows=[["true"]])
+        seen_sql["count"] = sql
+        return _outcome(True, rows=[["1"]])
+
+    zpm.check_entry(ENTRY, query_fn=fake_query)
+    assert "'e33_guarantee_scan_enabled'" in seen_sql["switch"]
+    assert "FROM e33_cases" in seen_sql["count"]
+
+
+def test_sql_quote_literal_escapes_single_quotes():
+    assert zpm._sql_quote_literal("a'b") == "'a''b'"
+
+
+# ---------------------------------------------------------------------------
+# run() over a registry list
+# ---------------------------------------------------------------------------
+
+
+def test_run_over_registry_returns_one_result_per_entry():
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(True, rows=[["3"]])
+
+    results = zpm.run([ENTRY, ENTRY], query_fn=fake_query)
+    assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# main(): exit codes + precedence (cannot-verify beats alert beats clean)
+# ---------------------------------------------------------------------------
+
+
+def test_main_exit_0_when_clean(monkeypatch, capsys):
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(True, rows=[["9"]])
+
+    monkeypatch.setattr(zpm, "_default_query_fn", fake_query)
+    assert zpm.main([]) == 0
+    out = capsys.readouterr().out
+    assert "alert=False" in out
+
+
+def test_main_exit_1_when_any_entry_alerts(monkeypatch, capsys):
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[])
+        return _outcome(True, rows=[["0"]])
+
+    monkeypatch.setattr(zpm, "_default_query_fn", fake_query)
+    assert zpm.main([]) == 1
+    out = capsys.readouterr().out
+    assert "alert=True" in out
+
+
+def test_main_exit_2_when_any_entry_cannot_be_checked(monkeypatch, capsys):
+    def fake_query(sql: str):
+        return _outcome(False, detail="db down")
+
+    monkeypatch.setattr(zpm, "_default_query_fn", fake_query)
+    assert zpm.main([]) == 2
+
+
+def test_main_exit_2_takes_precedence_over_exit_1(monkeypatch):
+    # Two registry entries: one alerts (unprovisioned+empty), one cannot be
+    # checked at all — "cannot verify" must win, never masked by an alert
+    # found elsewhere in the same run.
+    call_count = {"n": 0}
+
+    def fake_query(sql: str):
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            if "system_settings" in sql:
+                return _outcome(True, rows=[])
+            return _outcome(True, rows=[["0"]])
+        return _outcome(False, detail="connection refused")
+
+    second_entry = {"name": "other", "switch_key": "other_enabled", "table": "other_table"}
+    monkeypatch.setattr(zpm, "_default_query_fn", fake_query)
+    monkeypatch.setattr(zpm, "DEFAULT_REGISTRY", [ENTRY, second_entry])
+    assert zpm.main([]) == 2
+
+
+def test_main_json_output_is_valid_json_and_names_the_entry(monkeypatch, capsys):
+    def fake_query(sql: str):
+        if "system_settings" in sql:
+            return _outcome(True, rows=[["true"]])
+        return _outcome(True, rows=[["1"]])
+
+    monkeypatch.setattr(zpm, "_default_query_fn", fake_query)
+    assert zpm.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["name"] == "e33_guarantee_scan"
+    assert payload[0]["alert"] is False
+
+
+# ---------------------------------------------------------------------------
+# _default_query_fn: the real gh-of-postgres plumbing degrades safely
+# ---------------------------------------------------------------------------
+
+
+def test_default_query_fn_missing_pg_sh_reports_ok_false(tmp_path, monkeypatch):
+    # Point __file__ at a directory with no pg.sh so the real subprocess call
+    # exercises the FileNotFoundError branch — no real Fly proxy/Postgres
+    # touched.
+    monkeypatch.setattr(zpm, "__file__", str(tmp_path / "zero_population_monitor.py"))
+    outcome = zpm._default_query_fn("SELECT 1;")
+    assert outcome.ok is False
+    assert "not found" in outcome.detail
+
+
+def test_default_query_fn_non_zero_exit_reports_ok_false(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        class _FakeProc:
+            returncode = 1
+            stdout = ""
+            stderr = "psql: error: connection refused\n"
+
+        return _FakeProc()
+
+    monkeypatch.setattr(zpm.subprocess, "run", fake_run)
+    outcome = zpm._default_query_fn("SELECT 1;")
+    assert outcome.ok is False
+    assert "connection refused" in outcome.detail
+
+
+def test_default_query_fn_parses_pipe_delimited_rows(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        class _FakeProc:
+            returncode = 0
+            stdout = "a|b\nc|d\n"
+            stderr = ""
+
+        return _FakeProc()
+
+    monkeypatch.setattr(zpm.subprocess, "run", fake_run)
+    outcome = zpm._default_query_fn("SELECT 1;")
+    assert outcome.ok is True
+    assert outcome.rows == [["a", "b"], ["c", "d"]]
+
+
+def test_default_query_fn_timeout_reports_ok_false(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise real_subprocess.TimeoutExpired(cmd, 30)
+
+    monkeypatch.setattr(zpm.subprocess, "run", fake_run)
+    outcome = zpm._default_query_fn("SELECT 1;")
+    assert outcome.ok is False

--- a/scripts/zero_population_monitor.py
+++ b/scripts/zero_population_monitor.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""zero_population_monitor.py — generalized "kill switch off + table never
+written" probe (megatopics-1-5 action plan #1, part 2; 2026-08-03).
+
+Origin: the E33 guarantee-scan finding from the VCR reconciliation
+(research/operations/2026-08-03-verified-claim-reconciliation.md) — a cron
+has posted HTTP 200 `{"status":"blocked",...}` every day of its life because
+its kill switch (`e33_guarantee_scan_enabled`) has NO ROW AT ALL in
+`system_settings` (never provisioned) and its target table (`e33_cases`) has
+0 rows: green, doing nothing (scar family #2, "esiste != armato" —
+`.claude/rules/cicatrix-superscar.md`). Confirmed live via
+`scripts/pg.sh -c "SELECT ..."` on 2026-08-03. This script generalizes that
+ONE finding into a reusable, declared-registry probe so the next instance of
+this shape doesn't need its own investigation.
+
+Pure signaler: it never writes to the ledger, the switch, or the target
+table. It only reads and reports. The only way it affects control flow is
+its own exit code.
+
+Exit codes:
+    0   clean — every registry entry checked successfully and none alert
+    1   >=1 registry entry alerts (see ALERT RULE below) — never returned if
+        any entry could not be checked (see exit 2, which takes precedence)
+    2   >=1 registry entry's query genuinely could not run (DB connection
+        failure, pg.sh missing, timeout, unparseable output, or an unsafe
+        registry identifier refused before querying). "Could not check" is
+        NEVER silently reported as "clean" (W84 — a scan that could not look
+        is not a clean scan) and never masked by an alert found elsewhere in
+        the same run: an unverifiable entry makes the WHOLE verdict
+        untrustworthy.
+
+ALERT RULE (documented design decision — read before "fixing" this):
+    The megatopics plan states the base rule as "alert if BOTH (switch
+    unprovisioned) AND (table has zero rows) hold" — matching the live E33
+    case exactly. This script alerts on that case
+    (UNPROVISIONED_AND_EMPTY). It ALSO alerts when the switch IS provisioned
+    (truthy) but the table is STILL empty (PROVISIONED_BUT_EMPTY) — a
+    documented widening, not an oversight: a provisioned-but-never-written
+    organ is arguably a WORSE finding than an unprovisioned one (the switch
+    says "on", so whatever is supposed to write here should have fired at
+    least once by now — the classic scar-family-#2 shape, "green cron that
+    does nothing"). Silently NOT flagging that shape would leave exactly the
+    failure mode this probe exists to catch sitting one field short of
+    detection. A populated table NEVER alerts either way, regardless of
+    provisioning — this probe is scoped to "has anything EVER landed here",
+    not to auditing row correctness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+# Registry entry shape: {"name": str, "switch_key": str, "table": str}.
+# Seeded 2026-08-03 with the one live, verified finding (VCR §1): the kill
+# switch has NO row in system_settings and the target table has 0 rows
+# (both confirmed live via scripts/pg.sh SELECT, 2026-08-03).
+DEFAULT_REGISTRY: List[Dict[str, str]] = [
+    {
+        "name": "e33_guarantee_scan",
+        "switch_key": "e33_guarantee_scan_enabled",
+        "table": "e33_cases",
+    },
+]
+
+# Both patterns are deliberately conservative (word-chars, dot, dash, colon,
+# underscore). The registry is a small, internally-declared, reviewed list —
+# not user input — but a SQL identifier/literal built by string interpolation
+# gets validated anyway as defense-in-depth (this org's own "match the
+# entity, not a substring" discipline — family #3's antidote, applied here to
+# SQL construction instead of a text guard).
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_SWITCH_KEY_RE = re.compile(r"^[a-zA-Z0-9_.:-]+$")
+
+
+@dataclass
+class QueryOutcome:
+    """Result of one query_fn(sql) call. Never raise — degrade to ok=False."""
+
+    ok: bool
+    rows: List[List[str]] = field(default_factory=list)
+    detail: str = ""
+
+
+def _sql_quote_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _default_query_fn(sql: str) -> QueryOutcome:
+    """Shell out to scripts/pg.sh -A -t -F'|' -c "<sql>" (read-only Fly proxy).
+
+    -A -t -F'|' = unaligned, tuples-only, pipe-delimited: each output line is
+    one row, columns pipe-split, no header noise to strip. Never raises: a
+    missing pg.sh, a connection failure, a timeout, or a non-zero exit all
+    collapse to ok=False with the diagnosis in .detail — the caller must
+    treat that as "could not check", never as "zero rows" (W104: judge the
+    reply, never assume success from bare non-crash).
+    """
+    pg_sh = Path(__file__).resolve().parent / "pg.sh"
+    try:
+        proc = subprocess.run(
+            [str(pg_sh), "-A", "-t", "-F|", "-c", sql],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        return QueryOutcome(ok=False, detail=f"{pg_sh} not found")
+    except (subprocess.SubprocessError, OSError) as exc:
+        return QueryOutcome(ok=False, detail=f"pg.sh invocation failed: {type(exc).__name__}")
+
+    if proc.returncode != 0:
+        reason = (proc.stderr or "").strip().splitlines()
+        return QueryOutcome(ok=False, detail=reason[-1] if reason else f"pg.sh exited {proc.returncode}")
+
+    rows = [line.split("|") for line in (proc.stdout or "").splitlines() if line.strip() != ""]
+    return QueryOutcome(ok=True, rows=rows, detail="ok")
+
+
+def _is_truthy_setting(raw: str) -> bool:
+    """system_settings.value is stored as free-text; treat common truthy spellings.
+
+    Anything else (including a present-but-explicitly-falsy value like
+    'false'/'0'/'off'/'no') counts as NOT provisioned-on — a row existing
+    with a falsy value is functionally the same as no row for this probe's
+    purposes: the switch is not actually letting the organ run.
+    """
+    return raw.strip().lower() in {"true", "t", "1", "yes", "on", "enabled"}
+
+
+def check_entry(
+    entry: Dict[str, str],
+    query_fn: Callable[[str], QueryOutcome] = _default_query_fn,
+) -> Dict[str, Any]:
+    """Check ONE registry entry. Never raises.
+
+    Returns a dict: name, checked, provisioned, table_empty, alert, reason,
+    detail. "checked" False means a query genuinely could not run (or an
+    unsafe identifier was refused before ever querying) — provisioned/
+    table_empty are then None and alert is always False; the caller must not
+    read that as "clean" (see module docstring, exit code 2).
+    """
+    name = entry.get("name", "?")
+
+    def _cannot_verify(detail: str, provisioned: Optional[bool] = None) -> Dict[str, Any]:
+        return {
+            "name": name,
+            "checked": False,
+            "provisioned": provisioned,
+            "table_empty": None,
+            "alert": False,
+            "reason": "cannot-verify",
+            "detail": detail,
+        }
+
+    table = entry.get("table", "")
+    switch_key = entry.get("switch_key", "")
+    if not _IDENTIFIER_RE.match(table):
+        return _cannot_verify(f"refusing unsafe table identifier {table!r}")
+    if not _SWITCH_KEY_RE.match(switch_key):
+        return _cannot_verify(f"refusing unsafe switch_key {switch_key!r}")
+
+    switch_sql = f"SELECT value FROM system_settings WHERE key = {_sql_quote_literal(switch_key)} LIMIT 1;"
+    switch_result = query_fn(switch_sql)
+    if not switch_result.ok:
+        return _cannot_verify(f"switch check failed: {switch_result.detail}")
+    provisioned = (
+        bool(switch_result.rows)
+        and bool(switch_result.rows[0])
+        and _is_truthy_setting(switch_result.rows[0][0])
+    )
+
+    count_sql = f"SELECT count(*) FROM {table};"
+    count_result = query_fn(count_sql)
+    if not count_result.ok:
+        return _cannot_verify(f"table count failed: {count_result.detail}", provisioned=provisioned)
+
+    try:
+        row_count = int(count_result.rows[0][0]) if count_result.rows and count_result.rows[0] else None
+    except (ValueError, TypeError):
+        row_count = None
+    if row_count is None:
+        return _cannot_verify(f"unparseable row count from {table!r}", provisioned=provisioned)
+
+    table_empty = row_count == 0
+
+    if not table_empty:
+        # A populated table never alerts, regardless of provisioning — this
+        # probe is scoped to "has anything EVER landed here", not row
+        # auditing.
+        reason = "healthy (table has rows)"
+        alert = False
+    elif not provisioned:
+        reason = "UNPROVISIONED_AND_EMPTY (kill switch has no row / falsy value — the live E33 shape)"
+        alert = True
+    else:
+        # Documented widening (see module docstring ALERT RULE): provisioned
+        # but still zero rows also alerts — a provisioned-but-never-written
+        # organ is at least as suspicious as an unprovisioned one.
+        reason = "PROVISIONED_BUT_EMPTY (switch is on, table has never been written)"
+        alert = True
+
+    return {
+        "name": name,
+        "checked": True,
+        "provisioned": provisioned,
+        "table_empty": table_empty,
+        "alert": alert,
+        "reason": reason,
+        "detail": "ok",
+    }
+
+
+def run(
+    registry: List[Dict[str, str]],
+    query_fn: Callable[[str], QueryOutcome] = _default_query_fn,
+) -> List[Dict[str, Any]]:
+    return [check_entry(entry, query_fn) for entry in registry]
+
+
+def render_report(results: List[Dict[str, Any]]) -> str:
+    lines = ["# zero-population-monitor report", ""]
+    for r in results:
+        lines.append(
+            f"- {r['name']}: checked={r['checked']} provisioned={r['provisioned']} "
+            f"table_empty={r['table_empty']} alert={r['alert']} — "
+            f"{r['reason']} ({r['detail']})"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="zero_population_monitor.py",
+        description=(
+            "Pure signaler: for each declared {name, switch_key, table} triple, "
+            "alert if a kill-switch-gated organ's target table has zero rows "
+            "(generalizes the 2026-08-03 E33 finding). Never mutates anything."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of a markdown report.")
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    # NOTE: calls the module-global `_default_query_fn` by name (not
+    # check_entry's/run's own default-parameter binding) so tests can
+    # monkeypatch this module's `_default_query_fn` attribute and have it
+    # actually take effect on the CLI path — a default-parameter value is
+    # captured once at `def` time and would NOT observe a later monkeypatch.
+    results = run(DEFAULT_REGISTRY, query_fn=_default_query_fn)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        print(render_report(results), end="")
+
+    # Precedence: "could not check" beats "found a problem" beats "clean" —
+    # an unverifiable entry makes the whole verdict untrustworthy (W84: a
+    # scan that could not look is not a clean scan), so it must never be
+    # masked by an alert found elsewhere in the same run.
+    if any(not r["checked"] for r in results):
+        return 2
+    if any(r["alert"] for r in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `scripts/pending_arms_report.py --check-pr-refs` (opt-in, default off): flags a ledger entry citing a `PR #N` that `gh pr view` now reports MERGED. Never gates `--strict`'s exit code — see the Verify section for why.
- `scripts/zero_population_monitor.py` (new): generalizes the E33 finding (megatopic 0) — declared `{name, switch_key, table}` registry, alerts when a kill-switch-gated organ's target table has zero rows.

## Verify (measured live against the real 312-entry ledger + prod during build — read carefully, this is the load-bearing part)
- `zero_population_monitor.py` correctly reproduces the known live finding: `e33_guarantee_scan` → UNPROVISIONED_AND_EMPTY, exit 1.
- The PR-ref probe's naive design (bare `#NNN`, all 3 entry fields) false-positived on **93/312** entries. Root-caused live: (1) bare `#NNN` also matches non-PR numbers — e.g. CodeQL alert IDs cited next to a file:line list — so the regex now requires a literal `PR` before the hash; (2) even anchored on `PR #`, this ledger's own convention cites a merged PR as historical/precedent context far more often than as a live blocker — every manually-reviewed hit was the entry already knowing and stating the PR's status while staying open for an unrelated reason.
- Fix shipped: tightened regex (removes the non-PR-number false positives, a real correctness fix) + the report/docs/help text now say LOW CONFIDENCE / skim-only, and `--strict` was never wired to this bucket in the first place. A reliable version needs semantic judgment (Tier-2, explicitly out of scope for this Tier-1 signaler).
- New regression test pins the CodeQL-alert-number false positive as an innocence case.

## Test plan
- [x] 118/118 tests pass locally (`pytest scripts/tests/test_pending_arms_report.py scripts/tests/test_zero_population_monitor.py`)
- [x] `zero_population_monitor.py` run against real prod via `scripts/pg.sh` — reproduces the known E33 finding
- [x] `pending_arms_report.py --check-pr-refs` run against the real ledger + `gh` — clean run, honest output
- [x] Guilt + innocence tests for both new checks, including a real-world false-positive regression

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>