### PR TITLE
feat(kbli): flag named-annex citations that never propagated to kbli_documents

### DIFF
--- a/scripts/kbli_filiera/kbli_surface_conformance.py
+++ b/scripts/kbli_filiera/kbli_surface_conformance.py
@@ -47,6 +47,10 @@ misread as "the surface is clean":
       NOT been neutralised as a retired KBLI-2020 phantom.
     - a row is marked `NOT_IN_KBLI_2025` while canonical DOES carry the code —
       a live activity advertised to clients as retired.
+    - a code the website cites from a NAMED Perpres annex (locator bucket
+      `named-in-annex`/`priority-lampiran-i`) has no canonical `pma_official_basis`
+      — the DB-backed channels (chat_kbli, WhatsApp, webchat) stay blind to a
+      citation the website already shows on `/kbli/<code>`.
 
   DECLARED ONLY (counted, never fails)
     - `judul` text differences. 1,423 rows still carry the original UPPERCASE
@@ -75,6 +79,7 @@ from _coverage_basis import CODE_FIELD  # noqa: E402
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CANONICAL = REPO_ROOT / "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
 DEFAULT_PSQL_WRAPPER = REPO_ROOT / "scripts/pg.sh"
+DEFAULT_LOCATORS = REPO_ROOT / "apps" / "mouth" / "data" / "perpres-locators.json"
 
 EXIT_OK = 0
 EXIT_DIVERGENCE = 1
@@ -85,6 +90,14 @@ PRINT_SAMPLE = 20
 # Marker written by `kbli_documents_phantom_cure.py` onto rows for KBLI-2020
 # codes that 2025 retired. Such a row legitimately has no canonical record.
 PHANTOM_MARKER = "NOT_IN_KBLI_2025"
+
+# `perpres-locators.json` bucket names that carry a SPECIFIC, code-named
+# regulatory citation (a named Perpres annex entry). Every other bucket
+# (`residual-besar-*`, `body-*`) is a generic default-provision fallback
+# applied uniformly wherever no annex names the code — never flagged here,
+# because flagging it would just restate the pre-existing "no annex" default,
+# not surface new information.
+SPECIFIC_CITATION_BUCKETS = {"named-in-annex", "priority-lampiran-i"}
 
 SNAPSHOT_SQL = """
 SELECT coalesce(json_agg(json_build_object(
@@ -103,6 +116,18 @@ def load_canonical(path: Path) -> dict[str, dict[str, Any]]:
     if not isinstance(records, list) or not records:
         raise ValueError(f"{path}: expected a non-empty record list")
     return {str(r[CODE_FIELD]): r for r in records}
+
+
+def load_locators(path: Path) -> dict[str, dict[str, Any]]:
+    """Loads `perpres-locators.json` and unwraps its `locators` sub-dict — the
+    same shape `apps/mouth/src/app/kbli/[code]/page.tsx` reads to render the
+    "Basis: ..." citation. Raises loudly on anything malformed; the caller
+    turns that into CANNOT VERIFY rather than a silently skipped check."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    locators = payload["locators"] if isinstance(payload, dict) else payload
+    if not isinstance(locators, dict) or not locators:
+        raise ValueError(f"{path}: expected a non-empty 'locators' mapping")
+    return locators
 
 
 def fetch_table_snapshot(psql_wrapper: Path) -> list[dict[str, Any]]:
@@ -203,6 +228,54 @@ def plan_conformance(
     }
 
 
+def plan_citation_propagation(
+    canonical: dict[str, dict[str, Any]], locators: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    """Pure. A THIRD data source, judged independently of the Postgres table
+    this file otherwise checks: does the website's per-code Perpres citation
+    (`apps/mouth/data/perpres-locators.json`) propagate to canonical's
+    adjudicated `pma_official_basis` field?
+
+    Only the two SPECIFIC buckets carry code-named regulatory information
+    (`SPECIFIC_CITATION_BUCKETS`); every other bucket is a generic
+    default-provision fallback and is never flagged — see that constant's
+    docstring.
+
+    `locators` is already unwrapped (the caller passes `payload["locators"]`,
+    same as `load_locators` returns).
+    """
+    specific_citation_codes = 0
+    citation_not_propagated: list[dict[str, Any]] = []
+
+    for code, locator in locators.items():
+        bucket = locator.get("bucket")
+        if bucket not in SPECIFIC_CITATION_BUCKETS:
+            continue
+        specific_citation_codes += 1
+
+        record = canonical.get(code)
+        if record is None:
+            # Informational-only oddity — locators is meant to be a subset of
+            # the 1,559-code canonical universe of record. Never crash on it,
+            # just skip it from this check.
+            continue
+
+        if not record.get("pma_official_basis"):
+            citation_not_propagated.append(
+                {
+                    "code": code,
+                    "bucket": bucket,
+                    "cite": locator.get("cite"),
+                    "canonical_pma_status": record.get("pma_status"),
+                }
+            )
+
+    return {
+        "specific_citation_codes": specific_citation_codes,
+        "citation_not_propagated": sorted(citation_not_propagated, key=lambda d: d["code"]),
+    }
+
+
 def render(report: dict[str, Any]) -> str:
     lines = [
         "kbli_documents conformance vs canonical",
@@ -235,6 +308,21 @@ def render(report: dict[str, Any]) -> str:
                 lines.append(f"      {item}")
         if len(items) > PRINT_SAMPLE:
             lines.append(f"      ... showing {PRINT_SAMPLE} of {len(items)}")
+
+    citation = report.get("citation_propagation", {})
+    cnp = citation.get("citation_not_propagated", [])
+    lines.append(
+        f"  citation_not_propagated: {len(cnp)} "
+        f"(of {citation.get('specific_citation_codes', 0)} codes with a named-annex Perpres citation)"
+    )
+    for item in cnp[:PRINT_SAMPLE]:
+        lines.append(
+            f"      {item['code']}  bucket={item['bucket']} "
+            f"canonical_pma_status={item['canonical_pma_status']}"
+        )
+    if len(cnp) > PRINT_SAMPLE:
+        lines.append(f"      ... showing {PRINT_SAMPLE} of {len(cnp)}")
+
     declared = report["declared_only"]
     lines += [
         "",
@@ -250,6 +338,7 @@ def main(argv: list[str] | None = None) -> int:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("--canonical", type=Path, default=DEFAULT_CANONICAL)
+    parser.add_argument("--locators", type=Path, default=DEFAULT_LOCATORS)
     parser.add_argument("--psql-wrapper", type=Path, default=DEFAULT_PSQL_WRAPPER)
     parser.add_argument("--table-json", type=Path, default=None, help="use a snapshot file instead of the DB")
     parser.add_argument("--emit-sql", action="store_true", help="print the snapshot query and exit")
@@ -267,6 +356,12 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_CANNOT_VERIFY
 
     try:
+        locators = load_locators(args.locators)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        print(f"CANNOT VERIFY: locators unreadable ({args.locators}): {exc}")
+        return EXIT_CANNOT_VERIFY
+
+    try:
         if args.table_json:
             table = json.loads(args.table_json.read_text(encoding="utf-8"))
         else:
@@ -280,8 +375,13 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_CANNOT_VERIFY
 
     report = plan_conformance(canonical, table)
+    citation_report = plan_citation_propagation(canonical, locators)
+    report["citation_propagation"] = citation_report
+
     print(json.dumps(report, indent=2, sort_keys=True) if args.json else render(report))
-    return EXIT_DIVERGENCE if report["enforced_divergences"] else EXIT_OK
+
+    total_enforced = report["enforced_divergences"] + len(citation_report["citation_not_propagated"])
+    return EXIT_DIVERGENCE if total_enforced else EXIT_OK
 
 
 if __name__ == "__main__":

--- a/scripts/kbli_filiera/tests/test_kbli_surface_conformance.py
+++ b/scripts/kbli_filiera/tests/test_kbli_surface_conformance.py
@@ -45,6 +45,22 @@ def store(*records) -> dict:
     return {r[B.CODE_FIELD]: r for r in records}
 
 
+def loc(bucket: str, cite: str = "some cite") -> dict:
+    return {"bucket": bucket, "basis": "Pasal 3 ayat (1)", "cite": cite, "besar": "observed"}
+
+
+def neutral_locators_file(tmp_path: Path) -> Path:
+    """A `--locators` fixture with zero SPECIFIC-bucket codes, so CLI-level
+    tests that don't care about citation-propagation stay hermetic — decoupled
+    from whatever `apps/mouth/data/perpres-locators.json` says about "01111"
+    on the day the suite runs (it does, live, carry `named-in-annex`)."""
+    path = tmp_path / "locators.json"
+    path.write_text(
+        json.dumps({"locators": {"00000": loc("residual-besar-observed")}}), encoding="utf-8"
+    )
+    return path
+
+
 # --------------------------------------------------------------------------
 # scope — the property that makes this tool different from every cure before it
 # --------------------------------------------------------------------------
@@ -189,7 +205,16 @@ def test_empty_snapshot_is_cannot_verify_never_clean(tmp_path, capsys):
     canonical.write_text(json.dumps({"data": [canon("01111")]}), encoding="utf-8")
     snap = tmp_path / "s.json"
     snap.write_text("[]", encoding="utf-8")
-    rc = C.main(["--canonical", str(canonical), "--table-json", str(snap)])
+    rc = C.main(
+        [
+            "--canonical",
+            str(canonical),
+            "--locators",
+            str(neutral_locators_file(tmp_path)),
+            "--table-json",
+            str(snap),
+        ]
+    )
     assert rc == C.EXIT_CANNOT_VERIFY
     assert "not a clean bill" in capsys.readouterr().out
 
@@ -197,7 +222,16 @@ def test_empty_snapshot_is_cannot_verify_never_clean(tmp_path, capsys):
 def test_unreachable_database_is_cannot_verify_not_divergence(tmp_path, capsys):
     canonical = tmp_path / "c.json"
     canonical.write_text(json.dumps({"data": [canon("01111")]}), encoding="utf-8")
-    rc = C.main(["--canonical", str(canonical), "--psql-wrapper", str(tmp_path / "no-such-pg.sh")])
+    rc = C.main(
+        [
+            "--canonical",
+            str(canonical),
+            "--locators",
+            str(neutral_locators_file(tmp_path)),
+            "--psql-wrapper",
+            str(tmp_path / "no-such-pg.sh"),
+        ]
+    )
     assert rc == C.EXIT_CANNOT_VERIFY
     assert "CANNOT VERIFY" in capsys.readouterr().out
 
@@ -207,7 +241,19 @@ def test_conformant_stores_exit_zero(tmp_path):
     canonical.write_text(json.dumps({"data": [canon("01111")]}), encoding="utf-8")
     snap = tmp_path / "s.json"
     snap.write_text(json.dumps([row("01111")]), encoding="utf-8")
-    assert C.main(["--canonical", str(canonical), "--table-json", str(snap)]) == C.EXIT_OK
+    assert (
+        C.main(
+            [
+                "--canonical",
+                str(canonical),
+                "--locators",
+                str(neutral_locators_file(tmp_path)),
+                "--table-json",
+                str(snap),
+            ]
+        )
+        == C.EXIT_OK
+    )
 
 
 def test_divergent_stores_exit_one(tmp_path):
@@ -215,4 +261,112 @@ def test_divergent_stores_exit_one(tmp_path):
     canonical.write_text(json.dumps({"data": [canon("01111", pma_status="TERTUTUP")]}), encoding="utf-8")
     snap = tmp_path / "s.json"
     snap.write_text(json.dumps([row("01111", pma_status="TERBUKA")]), encoding="utf-8")
-    assert C.main(["--canonical", str(canonical), "--table-json", str(snap)]) == C.EXIT_DIVERGENCE
+    assert (
+        C.main(
+            [
+                "--canonical",
+                str(canonical),
+                "--locators",
+                str(neutral_locators_file(tmp_path)),
+                "--table-json",
+                str(snap),
+            ]
+        )
+        == C.EXIT_DIVERGENCE
+    )
+
+
+# --------------------------------------------------------------------------
+# citation propagation — a THIRD surface (locators vs canonical only),
+# independent of the kbli_documents table checks above
+# --------------------------------------------------------------------------
+
+
+def test_guilt_named_in_annex_with_no_canonical_basis():
+    report = C.plan_citation_propagation(
+        store(canon("01111")),  # no pma_official_basis
+        {"01111": loc("named-in-annex")},
+    )
+    assert [d["code"] for d in report["citation_not_propagated"]] == ["01111"]
+    assert report["specific_citation_codes"] == 1
+
+
+def test_guilt_priority_lampiran_i_with_no_canonical_basis():
+    report = C.plan_citation_propagation(
+        store(canon("10211")),  # no pma_official_basis
+        {"10211": loc("priority-lampiran-i")},
+    )
+    assert [d["code"] for d in report["citation_not_propagated"]] == ["10211"]
+
+
+def test_innocence_generic_default_bucket_is_never_flagged():
+    """residual-besar-* is the generic Pasal 3(1)(d)+(2) fallback, not a
+    code-specific citation — flagging it would just restate the pre-existing
+    "no annex" default, not surface anything new."""
+    report = C.plan_citation_propagation(
+        store(canon("01112")),  # no pma_official_basis either
+        {"01112": loc("residual-besar-observed")},
+    )
+    assert report["citation_not_propagated"] == []
+    assert report["specific_citation_codes"] == 0
+
+
+def test_innocence_already_propagated_citation_is_not_flagged():
+    report = C.plan_citation_propagation(
+        store(canon("01111", pma_official_basis="Perpres 49/2021 Lampiran II")),
+        {"01111": loc("named-in-annex")},
+    )
+    assert report["citation_not_propagated"] == []
+    assert report["specific_citation_codes"] == 1
+
+
+def test_edge_locator_code_absent_from_canonical_does_not_crash():
+    """canonical is the 1,559-code universe of record; a locator code outside
+    it is a separate informational-only oddity — never crash, never flag."""
+    report = C.plan_citation_propagation(
+        store(canon("11111")),
+        {"99999": loc("named-in-annex")},
+    )
+    assert report["citation_not_propagated"] == []
+    assert report["specific_citation_codes"] == 1
+
+
+def test_malformed_locators_path_is_cannot_verify_not_a_crash(tmp_path, capsys):
+    canonical = tmp_path / "c.json"
+    canonical.write_text(json.dumps({"data": [canon("01111")]}), encoding="utf-8")
+    snap = tmp_path / "s.json"
+    snap.write_text(json.dumps([row("01111")]), encoding="utf-8")
+    rc = C.main(
+        [
+            "--canonical",
+            str(canonical),
+            "--locators",
+            str(tmp_path / "no-such-locators.json"),
+            "--table-json",
+            str(snap),
+        ]
+    )
+    assert rc == C.EXIT_CANNOT_VERIFY
+    assert "CANNOT VERIFY" in capsys.readouterr().out
+
+
+def test_citation_not_propagated_folds_into_the_cli_exit_code(tmp_path):
+    """Wiring check: an otherwise-conformant kbli_documents snapshot must
+    still fail the gate if the citation-propagation check finds a gap."""
+    canonical = tmp_path / "c.json"
+    canonical.write_text(json.dumps({"data": [canon("01111")]}), encoding="utf-8")
+    snap = tmp_path / "s.json"
+    snap.write_text(json.dumps([row("01111")]), encoding="utf-8")
+    locators = tmp_path / "locators.json"
+    locators.write_text(json.dumps({"locators": {"01111": loc("named-in-annex")}}), encoding="utf-8")
+    rc = C.main(
+        [
+            "--canonical",
+            str(canonical),
+            "--locators",
+            str(locators),
+            "--table-json",
+            str(snap),
+        ]
+    )
+    assert rc == C.EXIT_DIVERGENCE


### PR DESCRIPTION
## Summary
- `perpres-locators.json` (the source `/kbli/<code>` reads for its "Basis: ..." citation) names 445 codes with a specific Perpres annex citation (`named-in-annex` / `priority-lampiran-i` buckets).
- Measured live against prod: **414 of those 445 have no canonical `pma_official_basis`** — the DB-backed channels (`chat_kbli`, WhatsApp, webchat) stay blind to a citation the website already shows.
- Adds `plan_citation_propagation()` as a third, independent check (locators-vs-canonical only), folds its count into the CLI exit code (`total_enforced = enforced_divergences + len(citation_not_propagated)`), and documents it in `--help` as ENFORCED (not DECLARED-only).
- Generic default-provision buckets (`residual-besar-*`, `body-*`) are never flagged — flagging them would just restate the pre-existing "no annex" default.
- `--locators` load failure is `CANNOT VERIFY` (exit 4), never silently skipped (W84 discipline).

## Test plan
- [x] Guilt: `named-in-annex`/`priority-lampiran-i` with no canonical basis → flagged
- [x] Innocence: generic bucket never flagged / already-propagated not flagged / locator code absent from canonical doesn't crash
- [x] Edge: malformed `--locators` path → CANNOT VERIFY, not a crash
- [x] CLI wiring: `citation_not_propagated` folds into the exit code (otherwise-conformant snapshot still fails the gate)
- [x] `python3 -m pytest scripts/kbli_filiera/tests/test_kbli_surface_conformance.py -q` — 25 passed
- [x] `ruff check` clean
- [x] **Prove-live**: ran against real prod via `scripts/pg.sh` (default `--locators`/`--canonical`) — confirms 445 specific-citation codes / 414 unpropagated, `enforced_divergences=28` (pre-existing) + 414 = exit 1 as expected. No CI workflow or other module calls this script's new API surface (grepped repo-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)