### PR TITLE
fix(wr2): close the fact-checker rubber-stamp hole + hard-gate no-source drafts

### DIFF
--- a/scripts/tests/test_wr2_fact_checker.py
+++ b/scripts/tests/test_wr2_fact_checker.py
@@ -191,7 +191,7 @@ def test_persist_checked_pass_advances_to_drafts_imaged_checked(fc):
     conn.execute = AsyncMock()
     asyncio.run(
         fc._persist_checked(
-            conn, draft_id, {"claims": []}, "pass"
+            conn, draft_id, {"claims": []}, "pass", fc.PROVENANCE_SUPPORTED_BY_SOURCE_ARTICLE
         )
     )
     conn.execute.assert_awaited_once()
@@ -207,25 +207,69 @@ def test_persist_checked_fail_advances_to_fact_check_failed(fc):
     conn.execute = AsyncMock()
     asyncio.run(
         fc._persist_checked(
-            conn, draft_id, {"claims": [{"verdict": "contradicted"}]}, "fail"
+            conn, draft_id, {"claims": [{"verdict": "contradicted"}]}, "fail",
+            fc.PROVENANCE_SOURCE_ABSENT,
         )
     )
     args = conn.execute.call_args[0]
     assert args[4] == "fact_check_failed"
 
 
-def test_persist_checked_degraded_still_proceeds_to_canva_apply(fc):
-    """degraded is NOT a terminal state — canva-apply consumes it."""
+def test_persist_checked_degraded_supported_still_proceeds_to_canva_apply(fc):
+    """degraded + provenance=supported_by_source_article is NOT terminal —
+    canva-apply consumes it. This provenance value cannot actually be
+    produced alongside fact_check_status='degraded' by _aggregate_provenance
+    (degraded implies an unverifiable/no-external-truth claim, which always
+    yields source_absent/claim_unparseable) — this test exercises
+    _persist_checked's OWN routing logic in isolation, independent of how
+    the caller derives provenance."""
     draft_id = uuid.uuid4()
     conn = MagicMock()
     conn.execute = AsyncMock()
     asyncio.run(
         fc._persist_checked(
-            conn, draft_id, {"claims": [{"verdict": "unverifiable"}]}, "degraded"
+            conn, draft_id, {"claims": [{"verdict": "unverifiable"}]}, "degraded",
+            fc.PROVENANCE_SUPPORTED_BY_SOURCE_ARTICLE,
         )
     )
     args = conn.execute.call_args[0]
     assert args[4] == "drafts_imaged_checked"
+    assert args[3] == "degraded"
+
+
+def test_persist_checked_degraded_source_absent_now_blocked(fc):
+    """2026-08-03 Change 3 (the fix under test): degraded + provenance=
+    source_absent must NOT reach drafts_imaged_checked anymore — this is the
+    fail-open hole being closed. It is held at fact_check_failed instead,
+    same as a genuine contradiction (wr2_supervisor.py tells them apart for
+    alerting purposes without re-opening the canva-eligible gate)."""
+    draft_id = uuid.uuid4()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(
+        fc._persist_checked(
+            conn, draft_id, {"claims": [{"verdict": "unverifiable"}]}, "degraded",
+            fc.PROVENANCE_SOURCE_ABSENT,
+        )
+    )
+    args = conn.execute.call_args[0]
+    assert args[4] == "fact_check_failed"
+    assert args[3] == "degraded"
+
+
+def test_persist_checked_degraded_claim_unparseable_now_blocked(fc):
+    """Same as above for the claim_unparseable provenance bucket."""
+    draft_id = uuid.uuid4()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(
+        fc._persist_checked(
+            conn, draft_id, {"claims": [{"verdict": "unverifiable"}]}, "degraded",
+            fc.PROVENANCE_CLAIM_UNPARSEABLE,
+        )
+    )
+    args = conn.execute.call_args[0]
+    assert args[4] == "fact_check_failed"
     assert args[3] == "degraded"
 
 
@@ -402,3 +446,232 @@ def test_process_one_draft_verifies_number_only_in_brief_json(fc):
     args = conn.execute.call_args[0]
     assert args[3] == "pass"  # not "fail"
     assert args[4] == "drafts_imaged_checked"  # not "fact_check_failed"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 2026-08-03 — provenance labels (Change 2) + the slide-exclusion fix
+# (Change 1) + the hard gate (Change 3). See
+# research/marketing/2026-07-18-wr2-fact-check-degraded-root-cause.md.
+# ─────────────────────────────────────────────────────────────────────────
+
+# --- _claim_defect_class / _aggregate_provenance direct unit coverage -----
+
+def test_claim_defect_class_word_number_is_unparseable(fc):
+    claim = {"verdict": "unverifiable", "note": "no extractable number in claim"}
+    assert fc._claim_defect_class(claim) == fc.PROVENANCE_CLAIM_UNPARSEABLE
+
+
+def test_claim_defect_class_word_date_is_unparseable(fc):
+    claim = {"verdict": "unverifiable", "note": "no extractable date in claim"}
+    assert fc._claim_defect_class(claim) == fc.PROVENANCE_CLAIM_UNPARSEABLE
+
+
+def test_claim_defect_class_law_no_citation_is_source_absent(fc):
+    """'law claim has no matchable citation' is NOT one of the two literal
+    representation-failure notes this file's spec names — it is a claim that
+    genuinely carries nothing to corroborate, so it buckets as source_absent,
+    not claim_unparseable (deliberate: matches the task's exact-string
+    contract, not the broader repr/starvation split the 2026-07-18 root-cause
+    report used for a different purpose)."""
+    claim = {"verdict": "unverifiable", "note": "law claim has no matchable citation"}
+    assert fc._claim_defect_class(claim) == fc.PROVENANCE_SOURCE_ABSENT
+
+
+def test_claim_defect_class_token_overlap_is_source_absent(fc):
+    claim = {"verdict": "unverifiable", "note": "token overlap 1/5 <60%"}
+    assert fc._claim_defect_class(claim) == fc.PROVENANCE_SOURCE_ABSENT
+
+
+def test_aggregate_provenance_empty_claims_is_supported(fc):
+    """Vacuous case mirrors _aggregate_status's vacuous 'pass'."""
+    assert fc._aggregate_provenance([]) == fc.PROVENANCE_SUPPORTED_BY_SOURCE_ARTICLE
+
+
+def test_aggregate_provenance_source_absent_wins_over_unparseable(fc):
+    claims = [
+        {"verdict": "unverifiable", "note": "no extractable number in claim"},
+        {"verdict": "unverifiable", "note": "token overlap 1/5 <60%"},
+    ]
+    assert fc._aggregate_provenance(claims, has_external_truth=True) == fc.PROVENANCE_SOURCE_ABSENT
+
+
+def test_aggregate_provenance_all_unparseable(fc):
+    claims = [
+        {"verdict": "unverifiable", "note": "no extractable number in claim"},
+        {"verdict": "unverifiable", "note": "no extractable date in claim"},
+    ]
+    assert (
+        fc._aggregate_provenance(claims, has_external_truth=True)
+        == fc.PROVENANCE_CLAIM_UNPARSEABLE
+    )
+
+
+def test_aggregate_provenance_all_verified_no_external_truth_is_source_absent(fc):
+    """All claims 'verified' but only against the draft's own thin/absent
+    source (self-reference) — same 'not trusted' case _aggregate_status caps
+    at 'degraded'."""
+    claims = [{"verdict": "verified"}]
+    assert (
+        fc._aggregate_provenance(claims, has_external_truth=False)
+        == fc.PROVENANCE_SOURCE_ABSENT
+    )
+
+
+def test_aggregate_provenance_all_verified_with_external_truth_is_supported(fc):
+    claims = [{"verdict": "verified"}]
+    assert (
+        fc._aggregate_provenance(claims, has_external_truth=True)
+        == fc.PROVENANCE_SUPPORTED_BY_SOURCE_ARTICLE
+    )
+
+
+# --- End-to-end GUILT / INNOCENCE cases ------------------------------------
+
+def test_process_one_draft_non_law_claim_self_slide_match_is_unverifiable(fc):
+    """GUILT (Change 1): a non-law claim matching ONLY the draft's own
+    slides — absent from research_json/brief_json/council_debate_json —
+    must be 'unverifiable', NOT 'verified'. Before Change 1, `_verify_claim`
+    was handed slide-inclusive `source_text` for every non-law claim type, so
+    this exact case self-verified (the rubber-stamp hole the root-cause
+    report calls out at wr2_fact_checker.py:662/676)."""
+    draft_id = uuid.uuid4()
+    row = {
+        "id": draft_id,
+        "topic": "T",
+        "register": "pedagogico",
+        "slides_json": {
+            "slides": [
+                {"index": 1, "title": "X", "body": "Bali Zero opens a branch in Canggu next month"}
+            ]
+        },
+        "research_json": {"text": "completely unrelated external content about something else entirely"},
+        "brief_json": {"article_summary": "completely unrelated external content about something else entirely"},
+        "council_debate_json": None,
+        "fact_check_json": {
+            "claims": [
+                {"claim": "Bali Zero opens a branch in Canggu", "slide_index": 1, "type": "other", "context": ""},
+            ]
+        },
+    }
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    args = conn.execute.call_args[0]
+    persisted = json.loads(args[2])
+    assert persisted["claims"][0]["verdict"] == "unverifiable"
+
+
+def test_process_one_draft_no_external_source_blocked_from_canva(fc):
+    """GUILT (Change 3): a draft whose only claim is verifiable ONLY against
+    itself (no external truth at all — research/brief/council all empty)
+    must NOT reach status='drafts_imaged_checked' anymore. Before Change 3
+    this was today's silent-'degraded' fail-open: fact_check_status stayed
+    'degraded' but status still advanced to the canva-eligible value."""
+    draft_id = uuid.uuid4()
+    row = {
+        "id": draft_id,
+        "topic": "T",
+        "register": "pedagogico",
+        "slides_json": {"slides": [{"index": 1, "title": "X", "body": "PP 28/2025"}]},
+        "research_json": None,
+        "brief_json": None,
+        "council_debate_json": None,
+        "fact_check_json": {
+            "claims": [{"claim": "PP 28/2025", "slide_index": 1, "type": "law", "context": ""}],
+        },
+    }
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    args = conn.execute.call_args[0]
+    assert args[3] == "degraded"  # fact_check_status unchanged by Change 3
+    assert args[4] == "fact_check_failed"  # but status is now held, not canva-eligible
+    persisted = json.loads(args[2])
+    assert persisted["provenance"] == fc.PROVENANCE_SOURCE_ABSENT
+
+
+def test_process_one_draft_law_citation_not_found_gives_source_absent_provenance(fc):
+    """GUILT: a law citation not found anywhere in the external source →
+    draft provenance = source_absent."""
+    draft_id = uuid.uuid4()
+    row = _make_facted_row(
+        draft_id,
+        [{"claim": "PP 99/2099 governs this", "slide_index": 1, "type": "law", "context": ""}],
+        "PMK 81/2024 establishes unrelated rules",
+    )
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    args = conn.execute.call_args[0]
+    persisted = json.loads(args[2])
+    assert persisted["provenance"] == fc.PROVENANCE_SOURCE_ABSENT
+    assert args[4] == "fact_check_failed"
+
+
+def test_process_one_draft_word_number_gives_claim_unparseable_provenance(fc):
+    """GUILT: a claim whose ONLY defect is 'no extractable number in claim'
+    (the number was expressed as a word) → draft provenance =
+    claim_unparseable."""
+    draft_id = uuid.uuid4()
+    row = _make_facted_row(
+        draft_id,
+        [{"claim": "the fee doubled this year", "slide_index": 1, "type": "number", "context": ""}],
+        "PMK 81/2024 sets the fee at four times the base rate",
+    )
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    args = conn.execute.call_args[0]
+    persisted = json.loads(args[2])
+    assert persisted["claims"][0]["note"] == "no extractable number in claim"
+    assert persisted["provenance"] == fc.PROVENANCE_CLAIM_UNPARSEABLE
+    assert args[4] == "fact_check_failed"
+
+
+def test_process_one_draft_all_claims_match_external_gives_supported_provenance(fc):
+    """INNOCENCE: genuine external corroboration must NOT be over-tightened
+    into a hold — the healthy path still reaches drafts_imaged_checked, and
+    its provenance is honestly labeled supported_by_source_article (fidelity
+    to the source article), never independently_corroborated."""
+    draft_id = uuid.uuid4()
+    src = "PP 28/2025 establishes 1.5% rate for 2026"
+    row = _make_facted_row(
+        draft_id,
+        [
+            {"claim": "PP 28/2025", "slide_index": 1, "type": "law", "context": ""},
+            {"claim": "rate 1.5", "slide_index": 1, "type": "number", "context": ""},
+        ],
+        src,
+    )
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    ok = asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    assert ok is True
+    args = conn.execute.call_args[0]
+    persisted = json.loads(args[2])
+    assert persisted["provenance"] == fc.PROVENANCE_SUPPORTED_BY_SOURCE_ARTICLE
+    assert args[3] == "pass"
+    assert args[4] == "drafts_imaged_checked"
+
+
+def test_process_one_draft_contradiction_unaffected_by_provenance_gate(fc):
+    """INNOCENCE: a genuinely contradicted claim still produces
+    fact_check_status='fail' -> status='fact_check_failed', unconditionally
+    — Change 2 (provenance labels) and Change 3 (the new gate) must not
+    touch this path. Same fixture as test_process_one_draft_fail, asserted
+    here explicitly against the provenance-aware gate."""
+    draft_id = uuid.uuid4()
+    src = "actual rate is 1.5 percent"
+    row = _make_facted_row(
+        draft_id,
+        [{"claim": "rate 999 percent", "slide_index": 1, "type": "number", "context": ""}],
+        src,
+    )
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    with patch.object(fc, "_send_telegram", lambda *_a, **_kw: None):
+        ok = asyncio.run(fc._process_one_draft(conn, row, llm_enabled=False))
+    assert ok is False
+    args = conn.execute.call_args[0]
+    assert args[3] == "fail"
+    assert args[4] == "fact_check_failed"

--- a/scripts/tests/test_wr2_fact_checker.py
+++ b/scripts/tests/test_wr2_fact_checker.py
@@ -274,6 +274,67 @@ def test_persist_checked_degraded_claim_unparseable_now_blocked(fc):
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# WR2_PROVENANCE_HARD_GATE_ENABLED — the emergency bypass kill-switch
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_hard_gate_enabled_by_default(fc):
+    assert fc.WR2_PROVENANCE_HARD_GATE_ENABLED is True
+
+
+def test_persist_checked_source_absent_bypassed_when_hard_gate_disabled(fc):
+    """With the kill-switch off, provenance=source_absent reverts to the
+    pre-Change-3 routing: it no longer blocks a 'degraded' draft from
+    reaching 'drafts_imaged_checked'."""
+    fc.WR2_PROVENANCE_HARD_GATE_ENABLED = False
+    draft_id = uuid.uuid4()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(
+        fc._persist_checked(
+            conn, draft_id, {"claims": [{"verdict": "unverifiable"}]}, "degraded",
+            fc.PROVENANCE_SOURCE_ABSENT,
+        )
+    )
+    args = conn.execute.call_args[0]
+    assert args[4] == "drafts_imaged_checked"
+    assert args[3] == "degraded"
+
+
+def test_persist_checked_claim_unparseable_bypassed_when_hard_gate_disabled(fc):
+    fc.WR2_PROVENANCE_HARD_GATE_ENABLED = False
+    draft_id = uuid.uuid4()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(
+        fc._persist_checked(
+            conn, draft_id, {"claims": [{"verdict": "unverifiable"}]}, "degraded",
+            fc.PROVENANCE_CLAIM_UNPARSEABLE,
+        )
+    )
+    args = conn.execute.call_args[0]
+    assert args[4] == "drafts_imaged_checked"
+    assert args[3] == "degraded"
+
+
+def test_persist_checked_fail_still_blocks_when_hard_gate_disabled(fc):
+    """The kill-switch only reverts the provenance-based block — an active
+    'fail' status must still terminate at fact_check_failed regardless."""
+    fc.WR2_PROVENANCE_HARD_GATE_ENABLED = False
+    draft_id = uuid.uuid4()
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    asyncio.run(
+        fc._persist_checked(
+            conn, draft_id, {"claims": [{"verdict": "contradicted"}]}, "fail",
+            fc.PROVENANCE_SOURCE_ABSENT,
+        )
+    )
+    args = conn.execute.call_args[0]
+    assert args[4] == "fact_check_failed"
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # End-to-end per-draft pipeline
 # ─────────────────────────────────────────────────────────────────────────
 

--- a/scripts/tests/test_wr2_supervisor.py
+++ b/scripts/tests/test_wr2_supervisor.py
@@ -261,6 +261,67 @@ async def test_telegram_alert_on_rendered(sup):
 
 
 @pytest.mark.asyncio
+async def test_telegram_alert_on_genuine_contradiction(sup):
+    """GUILT: 2026-08-03 — 'fact_check_failed' is now ALSO reached by
+    source_absent/claim_unparseable provenance holds (wr2_fact_checker.py
+    Change 3), not only genuine contradictions. A REAL contradiction
+    (fact_check_status='fail') must still fire the Telegram alert."""
+    conn = MagicMock()
+
+    async def fake_fetchval(query, *_args):
+        if "fact_check_status" in query:
+            return "fail"
+        return "fact_check_failed"  # the plain `status` re-read
+
+    conn.fetchval = AsyncMock(side_effect=fake_fetchval)
+
+    with patch.object(sup, "_telegram", new=AsyncMock()) as mock_tg:
+        with patch.object(sup, "_kickstart"):
+            await sup._handle_payload(
+                {"draft_id": "77777777-7777-7777-7777-777777777777",
+                 "old_status": "drafts_imaged_facted", "new_status": "fact_check_failed"},
+                conn,
+            )
+    assert mock_tg.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_telegram_alert_suppressed_for_source_absent_hold(sup):
+    """INNOCENCE: a source_absent/claim_unparseable hold — fact_check_status
+    stays 'degraded' (additive design, wr2_fact_checker.py) — must NOT fire
+    the Telegram alert. Reusing 'fact_check_failed' for this WITHOUT this
+    suppression would be ~79/86 drafts of P0 Telegram noise historically
+    (root-cause report 2026-07-18), the exact regression the checker's own
+    fail-alert avoids for the old silent-'degraded' branch."""
+    conn = MagicMock()
+
+    async def fake_fetchval(query, *_args):
+        if "fact_check_status" in query:
+            return "degraded"
+        return "fact_check_failed"  # the plain `status` re-read
+
+    conn.fetchval = AsyncMock(side_effect=fake_fetchval)
+
+    with patch.object(sup, "_telegram", new=AsyncMock()) as mock_tg:
+        with patch.object(sup, "_kickstart"):
+            await sup._handle_payload(
+                {"draft_id": "66666666-6666-6666-6666-666666666666",
+                 "old_status": "drafts_imaged_facted", "new_status": "fact_check_failed"},
+                conn,
+            )
+    assert mock_tg.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_is_genuine_contradiction_fails_open_on_read_error(sup):
+    """Fail-open toward ALERTING (not silence) on a DB read error — missing
+    a real contradiction alert is worse than an occasional spurious one."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(side_effect=OSError("boom"))
+    assert await sup._is_genuine_contradiction(conn, "dummy-id") is True
+
+
+@pytest.mark.asyncio
 async def test_malformed_payload_skipped(sup):
     conn = MagicMock()
     with patch.object(sup, "_kickstart") as mock_ks:

--- a/scripts/wr2_fact_checker.py
+++ b/scripts/wr2_fact_checker.py
@@ -8,8 +8,31 @@ each claim previously extracted by `wr2_fact_extractor.py`, then sets:
                       = 'degraded'  → some unverifiable but no contradiction
                       = 'fail'      → at least one claim contradicts source
 
-    status            = 'drafts_imaged_checked'  (pass / degraded)
-                      = 'fact_check_failed'      (fail)
+    fact_check_json.provenance (2026-08-03, additive — see the
+    PROVENANCE_* module constants) classifies WHICH kind of truth (if any)
+    backed a 'pass'/'degraded' verdict:
+        supported_by_source_article   → verified against a real external
+                                         source (research_json/brief_json/
+                                         council_debate_json) — today's
+                                         healthy case, NOT the same as
+                                         independent corroboration
+        independently_corroborated    → never emitted today (deferred,
+                                         requires check-time oracle re-query)
+        source_absent                 → some claim genuinely has no
+                                         corroborating external source
+        claim_unparseable             → some claim's number/date was
+                                         expressed as a word ("Four"), so the
+                                         checker never got a token to compare
+
+    status            = 'drafts_imaged_checked'  (provenance ∈
+                            {supported_by_source_article,
+                             independently_corroborated})
+                      = 'fact_check_failed'      (fail — OR provenance ∈
+                            {source_absent, claim_unparseable}: held for
+                            manual review same as an active contradiction —
+                            2026-08-03 Change 3 closes the fail-open hole
+                            where 'degraded' silently reached canva-eligible
+                            status with zero independent truth behind it)
 
 This is a NET-NEW build — the original wr2_fact_checker.py was never
 written. Re-enables the chain so canva-apply only renders fact-checked
@@ -85,6 +108,35 @@ MAX_DRAFTS_PER_RUN = int(os.environ.get("WR2_FACT_CHECKER_BATCH", "3"))
 DEFAULT_MODEL = os.environ.get("WR2_FACT_CHECKER_MODEL", "claude-opus-4-7")
 DEFAULT_TIMEOUT_S = int(os.environ.get("WR2_FACT_CHECKER_TIMEOUT_S", "120"))
 TELEMETRY_PATH = Path.home() / "logs" / "wr2_fact_checker_telemetry.jsonl"
+
+# Provenance labels (2026-08-03 — root-cause report
+# research/marketing/2026-07-18-wr2-fact-check-degraded-root-cause.md,
+# recommendation #2). Replace the false verified/degraded binary with an
+# honest label for WHICH kind of truth (if any) a draft's claims were
+# actually checked against. Stored ADDITIVELY in
+# `fact_check_json['provenance']` — `fact_check_status` itself keeps its 3
+# existing values (pass/degraded/fail) unchanged. Verified 2026-08-03: grepped
+# every consumer of `fact_check_status` in this repo (wr2_supervisor.py,
+# wr2_html_render_apply.py, wr2_daily_reconciler.py, wr2_carousel_import.py,
+# canva_renderer_v2/_pg.py) — none branches on the literal 'degraded' string
+# outside this file, so retiring it would have cost nothing either way;
+# additive was chosen because it is less schema drift (cicatrix #9 —
+# changing a shared format from only one side breaks readers who weren't
+# updated), not because retiring it was unsafe.
+PROVENANCE_INDEPENDENTLY_CORROBORATED = "independently_corroborated"
+PROVENANCE_SUPPORTED_BY_SOURCE_ARTICLE = "supported_by_source_article"
+PROVENANCE_SOURCE_ABSENT = "source_absent"
+PROVENANCE_CLAIM_UNPARSEABLE = "claim_unparseable"
+# PROVENANCE_INDEPENDENTLY_CORROBORATED is NOT reachable by any code path in
+# this file today — it requires re-querying an oracle/RAG per-claim at CHECK
+# time against a source the composer never saw (root-cause report
+# recommendation #1, explicitly deferred — RAG-data-plane work, out of scope
+# here). It is defined now for forward-compatibility, so that eventual fix
+# has a label to land on without another migration. Nothing in this module
+# emits it — do not fake it (e.g. by treating `has_external_truth` as
+# independent corroboration; it is not — see `_has_external_truth`'s own
+# docstring: brief_json is BOTH the corpus the composer wrote from AND what
+# this checker verifies against).
 
 # Law regexes — compiled once.
 # 2026-06-04 (WR2 autopsy P-5): added Permenkumham / Permenimipas / Permen* /
@@ -521,17 +573,32 @@ async def _persist_checked(
     draft_id: UUID,
     fact_check_json: dict[str, Any],
     fact_check_status: str,
+    provenance: str,
 ) -> None:
     """Record verdicts + advance status.
 
-    pass | degraded → status = 'drafts_imaged_checked' (canva-apply consumes)
-    fail            → status = 'fact_check_failed' (terminal — manual review)
+    fail                                             → 'fact_check_failed' (terminal — manual review)
+    provenance in {source_absent, claim_unparseable}  → 'fact_check_failed' (terminal — manual
+        review, SAME status as an active contradiction — closes the fail-open
+        hole where 'degraded' silently reached canva-eligible status with no
+        independent truth behind it; see root-cause report 2026-07-18 +
+        wr2_supervisor.py's alert-suppression for how these are told apart
+        downstream WITHOUT Telegram noise)
+    supported_by_source_article | independently_corroborated → 'drafts_imaged_checked'
+
+    `provenance` is REQUIRED (no default) — 2026-08-03, Change 3: the whole
+    point of this gate is that provenance decides eligibility independently
+    of fact_check_status for the old 'degraded' case, so a caller must always
+    compute and pass it deliberately rather than fall through to a silent
+    default.
     """
-    new_status = (
-        "fact_check_failed"
-        if fact_check_status == "fail"
-        else "drafts_imaged_checked"
-    )
+    if fact_check_status == "fail" or provenance in (
+        PROVENANCE_SOURCE_ABSENT,
+        PROVENANCE_CLAIM_UNPARSEABLE,
+    ):
+        new_status = "fact_check_failed"
+    else:
+        new_status = "drafts_imaged_checked"
     await conn.execute(
         """
         UPDATE war_room_drafts
@@ -552,6 +619,87 @@ async def _persist_checked(
 # ─────────────────────────────────────────────────────────────────────────
 # Per-draft pipeline
 # ─────────────────────────────────────────────────────────────────────────
+
+_UNPARSEABLE_NOTES = frozenset(
+    {
+        "no extractable number in claim",
+        "no extractable date in claim",
+    }
+)
+
+
+def _claim_defect_class(claim: dict[str, Any]) -> str:
+    """Classify an 'unverifiable' claim's defect for provenance labeling.
+
+    Only meaningful for claims whose verdict is 'unverifiable' — callers
+    check that first. Two buckets (2026-08-03, root-cause report
+    recommendation #2):
+
+    - PROVENANCE_CLAIM_UNPARSEABLE: the checker found no digit/date token to
+      compare AT ALL (the number/date was expressed as a word — "Four",
+      "double" — see the 2026-07-18 root-cause report). A REPRESENTATION
+      failure, not a truth failure: the claim was never given a fair chance
+      to match anything.
+    - PROVENANCE_SOURCE_ABSENT: every other unverifiable verdict (law
+      citation not found, quote not found, token overlap <60%, a partial
+      number/date match, "no external source" for a law claim). The claim
+      WAS parseable; nothing in the external source corroborates it — a
+      genuine non-corroboration.
+
+    Exact-string match on `note` (not substring/startswith) — this is a
+    guard classifying claims, and cicatrix family #3 (guard-over-match) is
+    exactly "substring instead of entity"; the two notes this must catch are
+    fixed literals emitted by `_verify_number_or_date_claim`.
+    """
+    note = str(claim.get("note", ""))
+    if note in _UNPARSEABLE_NOTES:
+        return PROVENANCE_CLAIM_UNPARSEABLE
+    return PROVENANCE_SOURCE_ABSENT
+
+
+def _aggregate_provenance(
+    verified_claims: list[dict[str, Any]], *, has_external_truth: bool = True
+) -> str:
+    """Classify draft-level evidentiary provenance (the 4 labels, additive).
+
+    Distinct from `_aggregate_status` (unchanged pass/degraded/fail — still
+    the value stored in `fact_check_status` and read by this file's own
+    Telegram fail-alert). This is the honest replacement for the old binary
+    collapse (root-cause report 2026-07-18, recommendation #2): instead of
+    every non-contradicted-but-imperfect draft reading as an undifferentiated
+    'degraded', it says WHICH kind of truth (if any) backed the check.
+
+    `PROVENANCE_INDEPENDENTLY_CORROBORATED` is never returned here — see the
+    module-level constant's docstring; it requires check-time re-querying an
+    oracle the composer never saw (deferred, RAG-data-plane work).
+    """
+    if not verified_claims:
+        # Vacuous pass (no claims to mis-verify) — the same "nothing to
+        # worry about" case _aggregate_status already treats as clean 'pass'.
+        return PROVENANCE_SUPPORTED_BY_SOURCE_ARTICLE
+
+    has_source_absent = False
+    has_claim_unparseable = False
+    for c in verified_claims:
+        verdict = str(c.get("verdict", "unverifiable")).lower()
+        if verdict != "unverifiable":
+            continue
+        if _claim_defect_class(c) == PROVENANCE_CLAIM_UNPARSEABLE:
+            has_claim_unparseable = True
+        else:
+            has_source_absent = True
+
+    if has_source_absent:
+        return PROVENANCE_SOURCE_ABSENT
+    if has_claim_unparseable:
+        return PROVENANCE_CLAIM_UNPARSEABLE
+    if not has_external_truth:
+        # All claims "verified", but only against the draft's own thin/absent
+        # source (self-reference — root-cause report layer 1). Same
+        # "not trusted" case _aggregate_status caps at 'degraded'.
+        return PROVENANCE_SOURCE_ABSENT
+    return PROVENANCE_SUPPORTED_BY_SOURCE_ARTICLE
+
 
 def _aggregate_status(
     verified_claims: list[dict[str, Any]], *, has_external_truth: bool = True
@@ -635,12 +783,14 @@ async def _process_one_draft(
     ) or []
 
     # brief_json is the corpus the production pipeline actually populates
-    # (research_json is probe/smoke-only), so it is threaded into every source
-    # extraction below — including the EXTERNAL view used for law matching and
-    # the external-truth gate, otherwise live drafts would have no corpus.
-    source_text = _extract_source_text(research, council, slides, brief_json=brief)
-    # Law citations are matched against the EXTERNAL source only (no slides),
-    # so a citation cannot self-verify just by appearing in the draft.
+    # (research_json is probe/smoke-only), so it is threaded into the EXTERNAL
+    # view below — used for law matching, the external-truth gate, AND (since
+    # 2026-08-03, Change 1) every other claim type's verification. Slides are
+    # EXCLUDED: a claim can never self-verify purely because it appears in the
+    # draft's own slides (root-cause report 2026-07-18, layer 2 — before this
+    # fix only law claims got this treatment; non-law claims were handed
+    # slide-inclusive `source_text` and didn't bite only because most had no
+    # digit/token to match).
     external_text = _extract_source_text(
         research, council, slides, brief_json=brief, include_slides=False
     )
@@ -660,20 +810,23 @@ async def _process_one_draft(
     for claim in claims_in:
         verified.append(
             _verify_claim(
-                claim, source_text, source_laws, has_external_truth=has_external_truth
+                claim, external_text, source_laws, has_external_truth=has_external_truth
             )
         )
 
     # Pass 2 (optional): LLM cross-check for any 'unverifiable' claims to
     # see if they're actually 'verified' (paraphrase) or 'contradicted'
     # (drift). Skipped when llm_enabled=False (fast deterministic path).
-    # 2026-06-05 (panel fix, defense-in-depth): feed the LLM the EXTERNAL
-    # source (slides excluded) so it cannot "verify" a claim by paraphrase-
-    # matching the draft's own slides — the same self-reference class the
-    # fail-closed cap guards against. With no external truth, external_text is
-    # thin and the LLM correctly returns 'unverifiable' (and the cap forces
-    # 'degraded' anyway).
-    llm_source = source_text if has_external_truth else external_text
+    # 2026-06-05 (panel fix, defense-in-depth); reaffirmed 2026-08-03 (Change
+    # 1): ALWAYS feed the LLM the EXTERNAL source (slides excluded),
+    # unconditionally — never the slide-inclusive view, regardless of
+    # has_external_truth. The old `source_text if has_external_truth else
+    # external_text` was BACKWARDS: when has_external_truth is True is
+    # exactly when a slide-inclusive rubber-stamp is most dangerous (there is
+    # real content to falsely "match" against). With no external truth,
+    # external_text is thin and the LLM correctly returns 'unverifiable' (and
+    # the cap forces 'degraded' anyway).
+    llm_source = external_text
     if llm_enabled:
         for c in verified:
             if c.get("verdict") != "unverifiable":
@@ -701,6 +854,7 @@ async def _process_one_draft(
 
     duration = time.time() - t0
     fact_check_status = _aggregate_status(verified, has_external_truth=has_external_truth)
+    provenance = _aggregate_provenance(verified, has_external_truth=has_external_truth)
 
     fact_check_payload = {
         "claims": verified,
@@ -708,18 +862,20 @@ async def _process_one_draft(
         "checked_at": datetime.now(timezone.utc).isoformat(),
         "verifier": "wr2_fact_checker",
         "llm_enabled": llm_enabled,
+        "provenance": provenance,
     }
 
-    await _persist_checked(conn, draft_id, fact_check_payload, fact_check_status)
+    await _persist_checked(conn, draft_id, fact_check_payload, fact_check_status, provenance)
 
     logger.info(
-        "Draft %s checked — status=%s claims=%d duration=%.1fs",
-        draft_id, fact_check_status, len(verified), duration,
+        "Draft %s checked — status=%s provenance=%s claims=%d duration=%.1fs",
+        draft_id, fact_check_status, provenance, len(verified), duration,
     )
     _log_telemetry(
         {
             "draft_id": str(draft_id),
             "outcome": fact_check_status,
+            "provenance": provenance,
             "duration_s": round(duration, 1),
             "claims_count": len(verified),
             "llm_enabled": llm_enabled,

--- a/scripts/wr2_fact_checker.py
+++ b/scripts/wr2_fact_checker.py
@@ -109,6 +109,21 @@ DEFAULT_MODEL = os.environ.get("WR2_FACT_CHECKER_MODEL", "claude-opus-4-7")
 DEFAULT_TIMEOUT_S = int(os.environ.get("WR2_FACT_CHECKER_TIMEOUT_S", "120"))
 TELEMETRY_PATH = Path.home() / "logs" / "wr2_fact_checker_telemetry.jsonl"
 
+# Emergency bypass for the 2026-08-03 Change 3 hard gate (provenance ∈
+# {source_absent, claim_unparseable} → fact_check_failed). Default ON — the
+# gate is the whole point of today's change. Flip to "false" only if the
+# gate turns out to be blocking a healthy pipeline at a rate operations
+# cannot tolerate (e.g. an upstream research_json regression starving every
+# draft of external truth) — it reverts _persist_checked to the PRE-Change-3
+# routing (only an active `fail` blocks; source_absent/claim_unparseable
+# fall through to 'drafts_imaged_checked' same as before today). Does NOT
+# affect what gets computed and recorded in fact_check_json.provenance —
+# only which status the draft advances to — so disabling it is a fast,
+# reversible operational lever, not a silent data loss.
+WR2_PROVENANCE_HARD_GATE_ENABLED = (
+    os.environ.get("WR2_PROVENANCE_HARD_GATE_ENABLED", "true").lower() != "false"
+)
+
 # Provenance labels (2026-08-03 — root-cause report
 # research/marketing/2026-07-18-wr2-fact-check-degraded-root-cause.md,
 # recommendation #2). Replace the false verified/degraded binary with an
@@ -591,10 +606,16 @@ async def _persist_checked(
     of fact_check_status for the old 'degraded' case, so a caller must always
     compute and pass it deliberately rather than fall through to a silent
     default.
+
+    Emergency bypass: `WR2_PROVENANCE_HARD_GATE_ENABLED=false` reverts the
+    provenance-based block to the pre-Change-3 routing (only an active
+    `fail` blocks) — see the module-level constant's docstring. The
+    provenance label is still computed and persisted in fact_check_json
+    either way; only the STATUS the draft advances to is affected.
     """
-    if fact_check_status == "fail" or provenance in (
-        PROVENANCE_SOURCE_ABSENT,
-        PROVENANCE_CLAIM_UNPARSEABLE,
+    if fact_check_status == "fail" or (
+        WR2_PROVENANCE_HARD_GATE_ENABLED
+        and provenance in (PROVENANCE_SOURCE_ABSENT, PROVENANCE_CLAIM_UNPARSEABLE)
     ):
         new_status = "fact_check_failed"
     else:

--- a/scripts/wr2_supervisor.py
+++ b/scripts/wr2_supervisor.py
@@ -20,7 +20,8 @@ This daemon LISTENs via the local pg-proxy (port 15432). On every payload:
   5. `launchctl kickstart` the next plist — NEVER with `-k` (would kill
      a running stage; workers always drain via bulk SELECT, so a no-op
      kickstart on an already-running stage is fine)
-  6. Telegram-alert on rendered / fact_check_failed
+  6. Telegram-alert on rendered / fact_check_failed (the latter ONLY when
+     it's a genuine contradiction — see _is_genuine_contradiction, 2026-08-03)
 
 Reconciliation
 --------------
@@ -102,6 +103,8 @@ TRANSITIONS: dict[tuple[str | None, str], str | None] = {
 }
 
 ALERT_STATUSES = {"rendered", "fact_check_failed"}
+# 2026-08-03: a 'fact_check_failed' transition is only alerted for a REAL
+# contradiction — see _is_genuine_contradiction, invoked in _handle_payload.
 
 # Reconciliation map: which non-terminal statuses need a re-kick if stalled.
 # Sprint B B-bis: full chain restored. Each pre-canva-apply state has a
@@ -264,6 +267,42 @@ async def _current_status(conn: asyncpg.Connection, draft_id: str) -> str | None
         )
 
 
+async def _is_genuine_contradiction(conn: asyncpg.Connection, draft_id: str) -> bool:
+    """True only if a 'fact_check_failed' transition is a REAL contradiction.
+
+    2026-08-03: wr2_fact_checker.py Change 3 routes THREE outcomes to the
+    same `status='fact_check_failed'` — an active contradiction
+    (`fact_check_status='fail'`) AND the two "no corroborating source"
+    provenance holds (`source_absent` / `claim_unparseable`, which keep
+    `fact_check_status='degraded'` — additive design, see that file's
+    PROVENANCE_* constants). Only the first is alert-worthy; alerting on the
+    other two would be ~79/86 drafts of P0 Telegram noise (root-cause report
+    2026-07-18).
+
+    Fail-open toward ALERTING (not toward silence) on any read error or
+    unexpected value: missing a real contradiction alert is a worse failure
+    mode than an occasional spurious one, and the noise this guards against
+    is a known, narrow bucket, not the default assumption.
+    """
+    async with _get_conn_lock():
+        try:
+            fc_status = await conn.fetchval(
+                "SELECT fact_check_status FROM war_room_drafts WHERE id = $1::uuid",
+                draft_id,
+            )
+        except (
+            asyncpg.PostgresError,
+            asyncpg.InterfaceError,  # W34: sibling of PostgresError, NOT subclass
+            OSError,
+        ) as e:
+            logger.warning(
+                "draft %s: cannot read fact_check_status (%s) — alerting (fail-open)",
+                draft_id, e,
+            )
+            return True
+    return fc_status != "degraded"
+
+
 async def _ack_outbox_if_present(payload: dict[str, Any], conn: asyncpg.Connection) -> bool:
     """Ack durable wr2_status_change rows carried by live NOTIFY payloads."""
     raw_outbox_id = payload.get("_outbox_id")
@@ -334,7 +373,23 @@ async def _handle_payload(payload: dict[str, Any], conn: asyncpg.Connection) -> 
 
         # Telegram alerts
         if new in ALERT_STATUSES:
-            await _telegram(f"WR2 {new}\nDraft: {draft_id}\nFrom: {old}")
+            if new == "fact_check_failed" and not await _is_genuine_contradiction(
+                conn, draft_id
+            ):
+                # 2026-08-03 (wr2_fact_checker.py Change 3): 'fact_check_failed'
+                # is now ALSO the terminal status for source_absent /
+                # claim_unparseable provenance holds (no corroborating
+                # external source found — ~79/86 drafts historically), not
+                # only genuine contradictions. Alerting on every one of those
+                # would recreate the exact P0 Telegram-noise problem the
+                # checker's own fail-alert (wr2_fact_checker.py:~865) was
+                # designed to avoid for the old silent-'degraded' branch.
+                # Only a REAL contradiction (fact_check_status == 'fail') is
+                # alert-worthy here; the two "no source" holds stay silent,
+                # same as they were silent before as 'degraded'.
+                pass
+            else:
+                await _telegram(f"WR2 {new}\nDraft: {draft_id}\nFrom: {old}")
 
         # Resolve next stage
         target = _resolve_transition(old, new)


### PR DESCRIPTION
## Summary
Per `research/marketing/2026-07-18-wr2-fact-check-degraded-root-cause.md` (CADE'd root-cause report, "no witness independent of the author"):

1. **Rubber-stamp hole (Change 1)**: non-law claims were verified — both the deterministic pass and the LLM cross-check — against slide-**inclusive** `source_text`, so a claim could self-verify by matching the draft's own slides. Now every claim type uses slide-**excluded** `external_text`, same treatment law claims already got.
2. **Provenance labels (Change 2, additive)**: `fact_check_json.provenance` replaces the uninformative pass/degraded binary with 4 states describing WHICH kind of truth (if any) backed the verdict — `supported_by_source_article`, `source_absent`, `claim_unparseable`, and `independently_corroborated` (reserved, unreachable today — requires a check-time oracle re-query, explicitly deferred/out of scope). `fact_check_status` keeps its 3 existing values unchanged — verified no consumer branches on the literal `'degraded'` string repo-wide.
3. **Hard gate (Change 3)**: a draft whose provenance is `source_absent`/`claim_unparseable` now holds at `status=fact_check_failed` instead of silently advancing to `drafts_imaged_checked` as `'degraded'`. `wr2_supervisor.py` tells these apart from a genuine contradiction (`fact_check_status='fail'`) so only real contradictions fire the Telegram alert — reusing it for the ~79/86 historical source_absent drafts would recreate the exact P0-noise regression the checker's own alert was designed to avoid.

## Test plan
- [x] 79 tests pass (48 fact-checker + 31 supervisor) — guilt+innocence for both the slide-exclusion fix and the new gate, plus direct unit coverage of `_claim_defect_class`/`_aggregate_provenance`
- [x] `ruff check` clean on all 4 touched files
- [x] Broader WR2 suite (1040 passed) — the only failures (`test_wr2_canva_apply_persist_race.py`, 4 errors, missing `scripts/wr2_canva_apply.py`) reproduced identically on a stash of this branch's changes → confirmed pre-existing (Wave-1 canva-renderer purge left a dead test file), out of scope
- [x] Read-only 86-draft regression check via `scripts/pg.sh`: today's 106 already-checked drafts are correctly unaffected — `_fetch_ready_drafts` only re-processes `fact_check_status IS NULL` rows, so this fix only changes behavior for drafts checked from here forward; no fixture existed for the historical set, none was fabricated

🤖 Generated with [Claude Code](https://claude.com/claude-code)