### PR TITLE
fix(deps): bump brace-expansion 5.0.8 → 5.0.9 (GHSA-rgw5-rvv9-x895, high, production)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12894,9 +12894,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
**This unblocks every PR in the repo, not just mine.**

A high-severity advisory on a **production** dependency landed between two CI runs this
evening. The `npm audit` step in `tests.yml` runs *before* the tests, so the whole frontend
suite is **skipped** — the red says nothing about the code under review.

**Evidence it is time and not a diff:** #3576 **passes** `Frontend Tests (Next.js) (mouth)`
and #3579 **fails** it, on the same lockfile — neither PR touches `package.json` or
`package-lock.json`.

| | |
|---|---|
| Advisory | [`GHSA-rgw5-rvv9-x895`](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |
| Vulnerable | `4.0.0 – 5.0.8` |
| In tree | exactly **one** instance, at the root, on `5.0.8` |
| After | `5.0.9`, `npm audit --audit-level=high --omit=dev` → **0 vulnerabilities** |

## Why the diff is three lines

`npm audit fix --package-lock-only` produced the bump **and** dropped
`@img/sharp-wasm32@0.34.5` — an unrelated optional dev dependency npm re-resolved away
because this worktree has no root `node_modules` to resolve against. Nobody asked for that,
and a silently pruned platform binary is what bites on some *other* machine's build. The
lockfile was restored and only the `brace-expansion` record edited by hand.

The integrity hash was verified against the registry (`npm view brace-expansion@5.0.9
dist.integrity`) rather than copied from the diff that generated it — the tool that produces
a value is not evidence for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)