### PR TITLE
fix(kbli): 13 codes said "a PT PMA cannot register it" while the record said "we don't know"

### DIFF
--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
   "lastModified": "2026-08-04",
-  "datasetSha256": "sha256:8dd0bd2bee925141c10767868f8ba42523d30994a59d9e6af26e14079d0d05cb",
+  "datasetSha256": "sha256:a9a461b41b50504842437cfafb23ad98523c1c6ebe38e612498b8989a7e323b4",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
-  "lastModified": "2026-08-03",
-  "datasetSha256": "sha256:0bd006544c6f0b587d34bd9a341f69333db8f631e748579fbe0476ad6eeb869d",
+  "lastModified": "2026-08-04",
+  "datasetSha256": "sha256:8dd0bd2bee925141c10767868f8ba42523d30994a59d9e6af26e14079d0d05cb",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "f208622cf36e777c7b96598b9d22c73fab1c5448",
-  "canonical_sha256": "0bd006544c6f0b587d34bd9a341f69333db8f631e748579fbe0476ad6eeb869d",
+  "canonical_revision": "bfb218f89f65d59d4cd60a3ed58034f294214961",
+  "canonical_sha256": "a9a461b41b50504842437cfafb23ad98523c1c6ebe38e612498b8989a7e323b4",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/scripts/kbli_filiera/cure_l4_withdrawn_umkm_prose.py
+++ b/scripts/kbli_filiera/cure_l4_withdrawn_umkm_prose.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""cure_l4_withdrawn_umkm_prose.py — retire the withdrawn UMKM inference from the
+EDITORIAL PROSE, one spec-authored sentence at a time.
+
+WHY THIS EXISTS
+---------------
+On 2026-08-03 Permeninves/BKPM 5/2025 Pasal 26(1) withdrew the inference that had
+closed codes on the ground that OSS shows them no *Usaha Besar* scale row: being
+Usaha Besar is a CONSEQUENCE of holding PMA status, not a precondition for
+registering, so the absence of that row says nothing about foreign ownership. The
+VERDICT layer was cured that day and the 1,559 code pages with it. The prose that
+EXPLAINS each verdict was not, and 34 canonical records still argue the withdrawn
+claim in fluent English.
+
+This compiler cures the first and most expensive slice of that backlog: the 13
+records whose Bali verdict is `NON_CLASSIFICABILE` — "we hold no verified
+licensing rows, so no Bali position can be stated" — while their prose tells the
+reader a PT PMA *cannot register* the activity. The page contradicts its own
+badge, and it errs toward turning away business we could take.
+
+WHAT IT WILL NOT DO
+-------------------
+It never authors a replacement. Every `new` string comes from
+`cure_specs/l4_withdrawn_umkm_prose.json`, which records who graded it. It never
+touches `l4_bali` — that layer is already correct and restating a settled verdict
+is how a correction becomes a new claim (W113). It never touches gold: measured
+before writing this, `apps/mouth/data/kbli-gold-all.json` holds no editorial prose
+for these codes (0 pattern hits, no `editorial` key, and 7 of the 13 are absent
+from gold entirely), so a gold path here would be a limb with no blood in it.
+
+THE PREMISE IS PINNED, AND A MOVED PREMISE IS A REFUSAL
+-------------------------------------------------------
+Each spec entry carries `expect_l4_status` / `expect_l4_blocked` as they stood
+when the prose was authored and graded. If a record's verdict has since moved,
+the replacement was written about a world that no longer exists, and this script
+REFUSES that code rather than writing prose graded against a stale premise. That
+is not defensive dressing: the whole reason this backlog exists is that a verdict
+changed and the prose explaining it did not.
+
+FAIL-VISIBLE, NEVER A SILENT GUESS
+----------------------------------
+A patch applies only when `old` occurs EXACTLY ONCE in its field. Already-applied
+is recognised (old absent AND new present) and skipped. Every other state — old
+missing and new missing, old repeated, both present — is a CureError. A cure that
+guesses at ambiguity is worse than one that stops.
+
+USAGE (dry-run is the default; nothing is written without --apply):
+    python3 scripts/kbli_filiera/cure_l4_withdrawn_umkm_prose.py
+    python3 scripts/kbli_filiera/cure_l4_withdrawn_umkm_prose.py --apply
+    python3 scripts/kbli_filiera/cure_l4_withdrawn_umkm_prose.py --only 70100 93199 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("kbli_filiera.cure_l4_withdrawn_umkm_prose")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SPEC = REPO_ROOT / "scripts/kbli_filiera/cure_specs/l4_withdrawn_umkm_prose.json"
+DEFAULT_CANONICAL = REPO_ROOT / "data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+SYNC_SCRIPT = REPO_ROOT / "scripts/sync_kbli_dataset.sh"
+SIDECAR_PATH = REPO_ROOT / "apps/mouth/data/kbli-dataset-version.json"
+SIDECAR_DATASET_PATH = REPO_ROOT / "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json"
+
+
+class CureError(RuntimeError):
+    """A state the spec does not describe. Always fatal, never a guess."""
+
+
+def _dig(container: dict[str, Any], dotted: str) -> tuple[dict[str, Any], str]:
+    """Resolve `a.b.c` to (owning dict, final key). Missing parents are an error,
+    not a silently-created path: this cure edits prose that already exists."""
+    parts = dotted.split(".")
+    node: Any = container
+    for part in parts[:-1]:
+        if not isinstance(node, dict) or part not in node:
+            raise CureError(f"field path {dotted!r} does not exist (stopped at {part!r})")
+        node = node[part]
+    if not isinstance(node, dict):
+        raise CureError(f"field path {dotted!r} does not resolve to an object")
+    return node, parts[-1]
+
+
+def apply_patch(record: dict[str, Any], code: str, patch: dict[str, str]) -> bool:
+    """Return True if the record changed, False if the patch was already applied."""
+    intel = record.get("intel_2026")
+    if not isinstance(intel, dict):
+        raise CureError(f"{code}: no intel_2026 object to patch")
+    owner, key = _dig(intel, patch["field"])
+    if key not in owner:
+        # Distinguished from the type error below on purpose: an ABSENT field and
+        # a field holding the wrong type send a reader to different places, and a
+        # diagnosis that names the wrong cause costs more than no diagnosis (W106).
+        raise CureError(f"{code}.{patch['field']}: field does not exist on this record")
+    text = owner[key]
+    if not isinstance(text, str):
+        raise CureError(
+            f"{code}.{patch['field']}: exists but holds {type(text).__name__}, not a string"
+        )
+
+    old, new = patch["old"], patch["new"]
+    n_old, n_new = text.count(old), text.count(new)
+    if n_old == 1:
+        owner[key] = text.replace(old, new, 1)
+        return True
+    if n_old == 0 and n_new >= 1:
+        logger.info("%s.%s: already applied — skipping", code, patch["field"])
+        return False
+    raise CureError(
+        f"{code}.{patch['field']}: refusing — old occurs {n_old}x, new occurs {n_new}x. "
+        "A patch applies only when the old text is present exactly once."
+    )
+
+
+def check_premise(record: dict[str, Any], code: str, entry: dict[str, Any]) -> None:
+    l4 = record.get("l4_bali") or {}
+    want_status = entry.get("expect_l4_status")
+    want_blocked = entry.get("expect_l4_blocked")
+    got_status, got_blocked = l4.get("status"), l4.get("blocked")
+    if got_status != want_status or got_blocked != want_blocked:
+        raise CureError(
+            f"{code}: premise moved — spec was written against "
+            f"status={want_status!r}/blocked={want_blocked!r}, record now holds "
+            f"status={got_status!r}/blocked={got_blocked!r}. The replacement prose was "
+            "graded against the old verdict; re-author and re-grade it rather than "
+            "writing it onto a record it no longer describes."
+        )
+
+
+def run_sync_script() -> None:
+    logger.info("running %s sync", SYNC_SCRIPT)
+    result = subprocess.run(
+        ["bash", str(SYNC_SCRIPT), "sync"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=False,
+    )
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        raise CureError(f"sync_kbli_dataset.sh sync failed with exit {result.returncode}")
+
+
+def reconcile_sidecar(canonical: Path) -> bool:
+    """Keyed on the MISMATCH, not on whether this run changed anything — a no-op
+    run must still reconcile a sidecar that drifted (the l23 compiler learned this
+    the hard way: hung off `if changed`, it was unreachable exactly when wrong)."""
+    if not SIDECAR_DATASET_PATH.exists():
+        raise CureError(f"sidecar dataset copy missing: {SIDECAR_DATASET_PATH} (sync must run first)")
+    if SIDECAR_DATASET_PATH.read_bytes() != canonical.read_bytes():
+        logger.info("sidecar dataset copy differs from canonical — syncing before hashing")
+        run_sync_script()
+    digest = hashlib.sha256(SIDECAR_DATASET_PATH.read_bytes()).hexdigest()
+    sidecar = json.loads(SIDECAR_PATH.read_text(encoding="utf-8"))
+    before = sidecar.get("datasetSha256")
+    if before == f"sha256:{digest}":
+        logger.info("sidecar already current (%s) — no write", before)
+        return False
+    # The `sha256:` prefix is load-bearing: a bare hex string in committed data
+    # trips `Detect Secrets` (a REQUIRED check) as a high-entropy string.
+    sidecar["datasetSha256"] = f"sha256:{digest}"
+    sidecar["lastModified"] = date.today().isoformat()
+    SIDECAR_PATH.write_text(json.dumps(sidecar, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    logger.info("sidecar updated: %s -> %s", before, sidecar["datasetSha256"])
+    return True
+
+
+def run(spec_path: Path, canonical_path: Path, only: list[str] | None, apply: bool) -> int:
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    codes: dict[str, Any] = spec["codes"]
+    if only:
+        unknown = sorted(set(only) - set(codes))
+        if unknown:
+            raise CureError(f"--only names codes absent from the spec: {unknown}")
+        codes = {c: codes[c] for c in only}
+
+    doc = json.loads(canonical_path.read_text(encoding="utf-8"))
+    by_code = {r["kode_kbli_2025"]: r for r in doc["data"]}
+
+    missing = sorted(set(codes) - set(by_code))
+    if missing:
+        raise CureError(f"spec names codes absent from canonical: {missing}")
+
+    changed_records, changed_patches, skipped = 0, 0, 0
+    for code, entry in codes.items():
+        record = by_code[code]
+        check_premise(record, code, entry)
+        touched = False
+        for patch in entry["patches"]:
+            if apply_patch(record, code, patch):
+                changed_patches += 1
+                touched = True
+            else:
+                skipped += 1
+        if touched:
+            changed_records += 1
+            logger.info("%s — %s", code, entry.get("judul", ""))
+
+    logger.info(
+        "%s: %d record(s), %d patch(es) rewritten, %d already applied",
+        "APPLY" if apply else "DRY-RUN", changed_records, changed_patches, skipped,
+    )
+    if not apply:
+        logger.info("nothing written — rerun with --apply")
+        return 0
+
+    if changed_patches:
+        canonical_path.write_text(json.dumps(doc, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        logger.info("canonical written: %s", canonical_path)
+        run_sync_script()
+    reconcile_sidecar(canonical_path)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--spec", type=Path, default=DEFAULT_SPEC)
+    ap.add_argument("--canonical", type=Path, default=DEFAULT_CANONICAL)
+    ap.add_argument("--only", nargs="+", metavar="CODE")
+    ap.add_argument("--apply", action="store_true", help="write (default: dry-run, writes nothing)")
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    try:
+        return run(args.spec, args.canonical, args.only, args.apply)
+    except CureError as exc:
+        logger.error("REFUSED: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kbli_filiera/cure_l4_withdrawn_umkm_prose.py
+++ b/scripts/kbli_filiera/cure_l4_withdrawn_umkm_prose.py
@@ -56,6 +56,7 @@ import argparse
 import hashlib
 import json
 import logging
+import re
 import subprocess
 import sys
 from datetime import date
@@ -76,15 +77,45 @@ class CureError(RuntimeError):
     """A state the spec does not describe. Always fatal, never a guess."""
 
 
+_INDEXED = re.compile(r"^(?P<name>[^\[\]]+)\[(?P<idx>\d+)\]$")
+
+
+def _step(node: Any, part: str, dotted: str) -> Any:
+    """One segment of a field path. `name` indexes a dict; `name[i]` indexes a
+    dict then a list — the stat cards this cure has to reach live in a list, and
+    the position is NOT stable across records (73300 carries the Bali-status card
+    at a different index than the other twelve), so the spec always states the
+    index it measured rather than a constant."""
+    match = _INDEXED.match(part)
+    key = match.group("name") if match else part
+    if not isinstance(node, dict) or key not in node:
+        raise CureError(f"field path {dotted!r} does not exist (stopped at {part!r})")
+    node = node[key]
+    if match is None:
+        return node
+    idx = int(match.group("idx"))
+    if not isinstance(node, list):
+        raise CureError(
+            f"field path {dotted!r}: {key!r} holds {type(node).__name__}, not a list — "
+            "an index cannot be applied to it"
+        )
+    if idx >= len(node):
+        raise CureError(
+            f"field path {dotted!r}: index {idx} is out of range ({key!r} holds {len(node)} "
+            "entries). The list shrank since the spec was written; re-measure rather than "
+            "writing to whatever now sits at that position."
+        )
+    return node[idx]
+
+
 def _dig(container: dict[str, Any], dotted: str) -> tuple[dict[str, Any], str]:
-    """Resolve `a.b.c` to (owning dict, final key). Missing parents are an error,
-    not a silently-created path: this cure edits prose that already exists."""
+    """Resolve `a.b.c` (or `a.b[2].c`) to (owning dict, final key). Missing
+    parents are an error, not a silently-created path: this cure edits prose that
+    already exists."""
     parts = dotted.split(".")
     node: Any = container
     for part in parts[:-1]:
-        if not isinstance(node, dict) or part not in node:
-            raise CureError(f"field path {dotted!r} does not exist (stopped at {part!r})")
-        node = node[part]
+        node = _step(node, part, dotted)
     if not isinstance(node, dict):
         raise CureError(f"field path {dotted!r} does not resolve to an object")
     return node, parts[-1]

--- a/scripts/kbli_filiera/cure_specs/l4_withdrawn_umkm_prose.json
+++ b/scripts/kbli_filiera/cure_specs/l4_withdrawn_umkm_prose.json
@@ -1,0 +1,195 @@
+{
+  "_meta": {
+    "spec": "l4_withdrawn_umkm_prose — NON_CLASSIFICABILE batch",
+    "date": "2026-08-04",
+    "why": "The verdict layer was cured on 2026-08-03 when Permeninves/BKPM 5/2025 Pasal 26(1) withdrew the no-Usaha-Besar inference. The EDITORIAL PROSE that explains each verdict was not. These 13 codes read NON_CLASSIFICABILE ('no Bali position can be stated') while their prose told the reader a PT PMA cannot register the activity — the expensive direction of the error, because it turns away business on an uncertainty of ours.",
+    "authored_by": "claude-opus-5",
+    "graded_by": "codex gpt-5.6-terra, 3 rounds (13 defective -> 4 -> CLEAR); generator != grader",
+    "grader_findings_that_changed_the_text": [
+      "7 replacements dropped 'cannot register' without stating the code is still treated as BLOCKED until verified — a reader would have concluded the opposite of the badge on the same page",
+      "'checked live on OSS' exceeded the record's own 'verify case by case'",
+      "91424 framed a NATIONAL instrument (UU 5/1990 / UU 32/2024 / PP 36/2010) as a Bali-specific finding",
+      "'Bali's rule turns on the risk tier' is true of the corpus but is not in these records' own reason"
+    ],
+    "rule": "EXACT substring, must appear exactly once in intel_2026.<field>; refuse if the record's l4_bali status/blocked moved away from the pinned premise",
+    "gold_surface": "NOT touched — apps/mouth/data/kbli-gold-all.json holds no editorial prose for these codes (measured: 0 hits, no `editorial` key; 7 of the 13 absent entirely)"
+  },
+  "codes": {
+    "47771": {
+      "judul": "Perdagangan Eceran Minyak Tanah",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The stated reason is structural: OSS has no Usaha Besar scale row, and the activity is reserved for UMKM.",
+          "new": "The block is a precaution, not a reservation: the requirement we located is a commercial one and nationality-neutral — Perpres 191/2014 Pasal 3(1), 8(1) and 9 make subsidised-fuel distribution an assignment to a Badan Usaha that already holds an Izin Usaha Niaga Umum plus storage and distribution facilities. We hold no verified licensing rows for this code, so its Bali risk tier is unknown and we will not state a Bali position; it is treated as blocked until verified case by case."
+        }
+      ]
+    },
+    "70100": {
+      "judul": "Aktivitas Kantor Pusat",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "In Bali, there is no Usaha Besar scale row for it, and the activity is therefore reserved for UMKM.",
+          "new": "We located no foreign-ownership restriction on this activity — not in the Perpres annexes, not in the closed list, not in any sectoral instrument we read. What we do not have is verified licensing rows for the code, so its Bali risk tier is unknown and no Bali position can be stated. It is therefore treated as blocked until verified case by case — a precaution about our own evidence, not a finding about the code."
+        },
+        {
+          "field": "editorial.pullQuote",
+          "old": "In Bali, the decisive fact is simple: a PT PMA is Usaha Besar, while this activity has no Usaha Besar scale row.",
+          "new": "The honest answer here is not yes and not no: it is that we will not state a position we cannot evidence."
+        }
+      ]
+    },
+    "91424": {
+      "judul": "Taman Wisata Alam",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "In Bali, the OSS record contains no Usaha Besar scale row, with the activity consequently reserved for UMKM.",
+          "new": "The obstacle we located is not an ownership rule and a PT PMA can satisfy it: UU 5/1990 Pasal 34, as replaced by UU 32/2024, makes managing a nature tourism park a State function, with private parties entering by permit or concession over the utilisation zone — and PP 36/2010 Pasal 8(3) names badan usaha among those who may hold one."
+        },
+        {
+          "field": "editorial.body",
+          "old": "With the activity reserved for UMKM and a PT PMA classified as Usaha Besar, the registration route is structurally closed.",
+          "new": "What is missing is our own evidence: we hold no verified licensing rows for the code, so its Bali risk tier is unknown and the position cannot be stated. It is treated as blocked until verified case by case — unproven rather than closed, and what a private party would actually hold is a permit or concession over the utilisation zone."
+        }
+      ]
+    },
+    "93115": {
+      "judul": "Fasilitas Olahraga Beladiri",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The obstacle is structural: OSS has no Usaha Besar, or large-enterprise, scale row for this activity, leaving it reserved for UMKM.",
+          "new": "The obstacle is our own evidence, not an ownership rule: we located no foreign-ownership restriction, and we hold no verified licensing rows for this code, so its Bali risk tier is unknown and no Bali position can be stated. It is treated as blocked until verified case by case."
+        }
+      ]
+    },
+    "93121": {
+      "judul": "Klub Sepak Bola",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "It says OSS has no Usaha Besar scale row for the activity, listing only Mikro, Kecil and Menengah.",
+          "new": "It records no foreign-ownership restriction for the activity, and no verified licensing rows either — so the Bali risk tier is unknown, the position cannot be stated, and the code is treated as blocked until verified case by case."
+        }
+      ]
+    },
+    "93125": {
+      "judul": "Klub Tinju",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The Bali record marks it Closed to PMA (no Besar scale) because the OSS system has no Usaha Besar scale row for the activity.",
+          "new": "The Bali record marks it unclassifiable and treats it as blocked until verified, because we hold no licensing rows for the activity and therefore cannot state its risk tier."
+        }
+      ]
+    },
+    "93126": {
+      "judul": "Klub Bela Diri",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The Bali reason says there is no Usaha Besar scale row in OSS for the activity; it records only Mikro, Kecil and Menengah.",
+          "new": "The Bali reason records no foreign-ownership restriction for the activity and no verified licensing rows, which is why the risk tier is unknown, the position is left unstated, and the code is treated as blocked until verified case by case."
+        }
+      ]
+    },
+    "93129": {
+      "judul": "Klub Olahraga Lainnya",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "That detail becomes decisive in Bali because OSS has no Usaha Besar scale row for this activity.",
+          "new": "That detail cannot be carried through to a Bali answer here, because we hold no verified licensing rows for this activity and its risk tier is therefore unknown."
+        },
+        {
+          "field": "editorial.body",
+          "old": "Bali’s record therefore treats it as reserved for UMKM on structural grounds.",
+          "new": "Bali's record therefore states no position at all, and the code is treated as blocked until verified case by case."
+        }
+      ]
+    },
+    "93192": {
+      "judul": "Aktivitas Juri dan Wasit Profesional",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The Bali status is Closed to PMA (no Besar scale) because OSS has no Usaha Besar scale row; the activity is reserved for UMKM, while a PT PMA is Usaha Besar by law and cannot register.",
+          "new": "The Bali position is unstated rather than closed, and the code is treated as blocked until verified case by case. The requirement we located is a personal licence and not an equity rule — UU 11/2022 Pasal 69(1) and Pasal 71 with PP 46/2024 Pasal 103 require a foreign referee or judge to hold a competency certificate, a federation recommendation and a government permit — while the catalogue holds no licensing rows for the code, so its risk tier is unknown."
+        }
+      ]
+    },
+    "93194": {
+      "judul": "Badan Regulasi dan Liga Olahraga",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The local record identifies a structural reason: OSS has no **Usaha Besar** scale row for the activity, leaving it reserved for UMKM.",
+          "new": "The local record identifies a duty to partner, which does not bar foreign ownership: UU 11/2022 Pasal 54(3), hardened by Permenpora 9/2026 Pasal 73(1), obliges a foreign entity organising an international-level championship to partner with the national federation and/or a professional sport organisation. No licensing rows are held for the code, so its Bali risk tier is unknown, the position cannot be stated, and it is treated as blocked until verified case by case."
+        }
+      ]
+    },
+    "93195": {
+      "judul": "Aktivitas Olahraga Tradisional",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The Bali record marks the activity as closed to PMA because OSS contains no Usaha Besar scale row for it; it is therefore reserved for UMKM.",
+          "new": "The Bali record leaves the activity unclassified rather than closed, and treats it as blocked until verified case by case: the requirement we located is a mandatory business standard with no ownership term anywhere in it — Permenpora 9/2026 Lampiran I, eight cumulative persyaratan and a Sertifikat Standar — and we hold no licensing rows for the code, so its risk tier is unknown."
+        }
+      ]
+    },
+    "93197": {
+      "judul": "Aktivitas Olaharagawan/Atlet Independen",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "That matters because Bali’s recorded structural reason turns on what is absent: OSS has no Usaha Besar scale row for this activity.",
+          "new": "That matters because we hold no verified licensing rows for this activity, so its risk tier is unknown."
+        },
+        {
+          "field": "editorial.body",
+          "old": "Bali consequently treats it as reserved for UMKM.",
+          "new": "Bali consequently states no position, and the code is treated as blocked until verified case by case."
+        }
+      ]
+    },
+    "93199": {
+      "judul": "Aktivitas Lainnya yang Berkaitan dengan Olahraga YTDL",
+      "expect_l4_status": "NON_CLASSIFICABILE",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "OSS has no **Usaha Besar** scale row for it, leaving the activity reserved for UMKM; a PT PMA is, by law, an **Usaha Besar** undertaking and therefore cannot be registered on that basis.",
+          "new": "We located no foreign-ownership restriction for this activity, and no verified licensing rows either — so the Bali risk tier is unknown, the position cannot be stated, and the code is treated as blocked until verified case by case."
+        }
+      ]
+    }
+  }
+}

--- a/scripts/kbli_filiera/cure_specs/l4_withdrawn_umkm_prose.json
+++ b/scripts/kbli_filiera/cure_specs/l4_withdrawn_umkm_prose.json
@@ -1,10 +1,10 @@
 {
   "_meta": {
-    "spec": "l4_withdrawn_umkm_prose — NON_CLASSIFICABILE batch",
+    "spec": "l4_withdrawn_umkm_prose — NON_CLASSIFICABILE batch + CHIUSO_MORATORIA_BALI batch",
     "date": "2026-08-04",
     "why": "The verdict layer was cured on 2026-08-03 when Permeninves/BKPM 5/2025 Pasal 26(1) withdrew the no-Usaha-Besar inference. The EDITORIAL PROSE that explains each verdict was not. These 13 codes read NON_CLASSIFICABILE ('no Bali position can be stated') while their prose told the reader a PT PMA cannot register the activity — the expensive direction of the error, because it turns away business on an uncertainty of ours.",
     "authored_by": "claude-opus-5",
-    "graded_by": "codex gpt-5.6-terra, 3 rounds (13 defective -> 4 -> CLEAR); generator != grader",
+    "graded_by": "codex gpt-5.6-terra; generator != grader. Batch 1 (NON_CLASSIFICABILE): 3 rounds, 13 defective -> 4 -> CLEAR. Batch 2 (CHIUSO_MORATORIA_BALI): 6 rounds, 9 -> 5 -> 1 -> 1 -> 1 -> CLEAR.",
     "grader_findings_that_changed_the_text": [
       "7 replacements dropped 'cannot register' without stating the code is still treated as BLOCKED until verified — a reader would have concluded the opposite of the badge on the same page",
       "'checked live on OSS' exceeded the record's own 'verify case by case'",
@@ -12,7 +12,21 @@
       "'Bali's rule turns on the risk tier' is true of the corpus but is not in these records' own reason"
     ],
     "rule": "EXACT substring, must appear exactly once in intel_2026.<field>; refuse if the record's l4_bali status/blocked moved away from the pinned premise",
-    "gold_surface": "NOT touched — apps/mouth/data/kbli-gold-all.json holds no editorial prose for these codes (measured: 0 hits, no `editorial` key; 7 of the 13 absent entirely)"
+    "gold_surface": "NOT touched — apps/mouth/data/kbli-gold-all.json holds no editorial prose for these codes (measured: 0 hits, no `editorial` key; 7 of the 13 absent entirely)",
+    "batch_2_why": "13 codes whose Bali verdict is CHIUSO_MORATORIA_BALI. Their conclusion was RIGHT — they are blocked in Bali — but the prose gave the withdrawn no-Usaha-Besar mechanism instead of the real one, and on 7 of them it went further and told the reader the code is closed 'anywhere in Indonesia', which is false: all 13 are pma_status=TERBUKA / pma_max_asing=100 nationally. The badge these pages render reads 'Closed in Bali (2026 moratorium)', so the prose also contradicted the badge beside it.",
+    "batch_2_scope_note": "The 23 sentences the shipped guard's pattern finds were NOT the whole disease in these records: a wide sweep of every intel_2026 string found 40 more sentences carrying the same reasoning in wordings the narrow pattern cannot see (e.g. 'A PT PMA is legally an Usaha Besar, so it cannot register this KBLI anywhere in Indonesia'). 23 of those assert the false mechanism or a false conclusion and are cured here; 12 stat cards reading 'Closed to PMA (no Besar scale)' are corrected to the rendered badge label; the rest are descriptive statements of the licensing annex's own scale rows (grounded in per_skala) and are deliberately left. Curing only the 23 the pattern found would have left 56306 saying 'it cannot register in Bali, regardless of the moratorium' one sentence after the cure.",
+    "batch_2_grader_findings_that_changed_the_text": [
+      "Permenpar standards cited on 56102 are published for 56103/56104/56109, not for 56102 — the draft attributed them to this code",
+      "'the segment is dominated by local micro and small businesses' (56304) asserted a market fact no evidence supports",
+      "a route menu on 56306 ('local partnership, a domicile outside Bali, or a different code') was actionable advice the record does not carry",
+      "a seam break on 79902: 'That boundary' pointed at the national scale listing, so 'turns on the risk tier' did not follow from it",
+      "the moratorium closes PMA REGISTRATION for activities in a tier — it does not 'block the risk tier' (2 sentences; the second was found by class-audit, not by the grader)",
+      "73300's opener still ended 'Let's get your NIB updated for 2025' — a call to action beside a block, now scoped explicitly to a locally-owned PMDN company"
+    ],
+    "batch_2_verdicts_refuted_on_disk": [
+      "7 objections to 'the Positive Investment List opens this KBLI to 100% foreign ownership' were artifacts of a review packet that carried only l4_bali.reason; the record's own pma_status/pma_max_asing/pma_source support the phrase, and round 2 was re-run with that evidence supplied",
+      "'renumbered code' on 73300 was called unsupported; the record carries status_mapping=CODICE_RINUMERATO and bps_2020_ancestors.codes=['70203']"
+    ]
   },
   "codes": {
     "47771": {
@@ -188,6 +202,387 @@
           "field": "editorial.body",
           "old": "OSS has no **Usaha Besar** scale row for it, leaving the activity reserved for UMKM; a PT PMA is, by law, an **Usaha Besar** undertaking and therefore cannot be registered on that basis.",
           "new": "We located no foreign-ownership restriction for this activity, and no verified licensing rows either — so the Bali risk tier is unknown, the position cannot be stated, and the code is treated as blocked until verified case by case."
+        }
+      ]
+    },
+    "38110": {
+      "judul": "Pengumpulan Limbah atau Sampah Tidak Berbahaya",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "whatYouNeed",
+          "old": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership on paper — but OSS provides no Usaha Besar scale row for it: non-hazardous waste collection is reserved for micro, small and medium enterprises (UMKM) nationwide.",
+          "new": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership, and no ownership restriction on non-hazardous waste collection was located in the investment annexes or in any sectoral instrument read — but a PT PMA still cannot register it at a Bali address today: the island-wide provincial moratorium in force since 13 May 2026 (Governor's letter B.27.000/642/PM/DPMPTSP) blocks every Low and Medium-Low risk KBLI, and this activity is classified Medium-Low risk."
+        },
+        {
+          "field": "editorial.body",
+          "old": "The Bali status is Closed to PMA (no Besar scale), and the record states that PMA registration is blocked because OSS has no Usaha Besar scale row for this activity, leaving it reserved for UMKM; a PT PMA is treated as Usaha Besar by law and therefore cannot register it.",
+          "new": "The Bali status is closed to PMA, and the reason is provincial rather than sectoral: Bali's moratorium suspends PMA registration island-wide for every Low and Medium-Low risk KBLI, and non-hazardous waste collection is classified Medium-Low risk. Nationally the activity stays foreign-open — what closes the door is the address, not the business."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "A PT PMA is legally an Usaha Besar, so it cannot register this KBLI anywhere in Indonesia (PP 28/2025 scale-gating) — not just in Bali.",
+          "new": "Outside Bali the picture is different: nothing in the national rules bars a PT PMA from this KBLI, so the block follows the Bali address rather than the activity."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "55202": {
+      "judul": "Aktivitas Hostel Remaja (Youth Hostel)",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "whatYouNeed",
+          "old": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership on paper — but OSS provides no Usaha Besar scale row for it: youth-hostel accommodation is reserved for micro, small and medium enterprises (UMKM) nationwide.",
+          "new": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership, and no ownership restriction on youth-hostel accommodation was located in the investment annexes or in any sectoral instrument read — but a PT PMA cannot register it at a Bali address today: the island-wide moratorium in force since 13 May 2026 (Governor's letter B.27.000/642/PM/DPMPTSP) blocks every Low and Medium-Low risk KBLI, and this activity is classified Medium-Low risk."
+        },
+        {
+          "field": "editorial.body",
+          "old": "The block is structural: OSS has no Usaha Besar scale row, leaving the activity reserved for UMKM; a PT PMA is, by law, Usaha Besar and cannot register it.",
+          "new": "The block is provincial, not sectoral: Bali's island-wide moratorium suspends PMA registration for every Low and Medium-Low risk KBLI, and youth-hostel accommodation is classified Medium-Low risk. Nothing in the national ownership rules closes this activity to a foreign investor."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "A PT PMA is legally an Usaha Besar, so it cannot register this KBLI anywhere in Indonesia (PP 28/2025 scale-gating) — not just in Bali.",
+          "new": "Outside Bali the picture is different: nothing in the national rules bars a PT PMA from this KBLI, so the block follows the Bali address rather than the activity."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "55300": {
+      "judul": "Aktivitas Penyediaan Bumi Perkemahan, Persinggahan Karavan, dan Taman Karavan",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The Bali record categorises it as closed to PMA because no Usaha Besar scale row exists; the activity is reserved for micro, small and medium enterprises, while a PT PMA is treated as Usaha Besar by law and cannot register it.",
+          "new": "The Bali record categorises it as closed to PMA because of the provincial moratorium: since 13 May 2026 the island-wide block covers every Low and Medium-Low risk KBLI, and campsite and caravan-park operation is classified Medium-Low risk. The activity itself carries no foreign-ownership restriction we could locate."
+        },
+        {
+          "field": "editorial.body",
+          "old": "No risk classification for this activity is supplied in the slim record, so that rule should not be recast as an invented risk label; the recorded reason for its closure is the absence of an Usaha Besar scale row.",
+          "new": "The record does supply a risk classification for this activity — Menengah Rendah (Medium-Low) — and that is precisely what places it inside the blocked band, since the moratorium operates on the risk tier and names no codes at all."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "56102": {
+      "judul": "Aktivitas Penyediaan Makanan di Bangunan Tidak Tetap",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "whatYouNeed",
+          "old": "The local licensing system treats all PMA entities as ‘large-scale’, while this code is reserved for UMKM (micro, small, and medium) businesses, blocking the foreign-owned route entirely.",
+          "new": "There is no 56xxx entry anywhere in Perpres 49/2021, so nothing in the investment annexes restricts foreign ownership of this activity; what blocks the foreign-owned route in Bali is the provincial moratorium, which since 13 May 2026 suspends PMA registration for every Low and Medium-Low risk KBLI, this one included."
+        },
+        {
+          "field": "editorial.body",
+          "old": "OSS provides no Usaha Besar scale row, leaving the activity reserved for UMKM.",
+          "new": "Bali's island-wide moratorium suspends PMA registration for every Low and Medium-Low risk KBLI, and this activity sits in the Medium-Low band."
+        },
+        {
+          "field": "editorial.body",
+          "old": "Because a PT PMA is treated by law as Usaha Besar, it cannot take this registration route in Bali.",
+          "new": "What closes this registration route in Bali is the provincial moratorium on the Low and Medium-Low risk tiers, not anything about the activity itself."
+        },
+        {
+          "field": "editorial.body",
+          "old": "That is an important part of the activity’s identity: the registration record places this kind of food provision within micro and small enterprise scale, while Bali’s PMA result turns on the absence of an Usaha Besar row.",
+          "new": "That is an important part of the activity’s identity: the registration record places this kind of food provision within micro and small enterprise scale, while Bali’s PMA result turns on the province-wide moratorium over the Low and Medium-Low risk tiers."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "56304": {
+      "judul": "Aktivitas Kedai Minuman",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "whatYouNeed",
+          "old": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership on paper — but OSS provides no Usaha Besar scale row for it: the drink-stall (kedai minuman) activity is reserved for micro, small and medium enterprises (UMKM) nationwide.",
+          "new": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership, and the sectoral standard for kedai minuman (Permenpar 6/2025) asks for a Sertifikat Standar and hygiene certification with no scale gating at all — but a PT PMA cannot register it at a Bali address today: the island-wide moratorium in force since 13 May 2026 blocks every Low and Medium-Low risk KBLI, and this activity is classified Medium-Low risk."
+        },
+        {
+          "field": "editorial.body",
+          "old": "The reason is structural: OSS has no Usaha Besar scale row for the activity, leaving it reserved for UMKM, while a PT PMA is legally an Usaha Besar business and therefore cannot register.",
+          "new": "The reason is provincial: Bali's moratorium suspends PMA registration island-wide for every Low and Medium-Low risk KBLI, and a drink stall is classified Medium-Low risk. The sectoral standard itself imposes no scale gating and no ownership limit."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "A PT PMA is legally an Usaha Besar, so it cannot register this KBLI anywhere in Indonesia (PP 28/2025 scale-gating) — not just in Bali.",
+          "new": "Outside Bali the picture is different: nothing in the national rules bars a PT PMA from this KBLI, so the block follows the Bali address rather than the activity."
+        },
+        {
+          "field": "baliContext",
+          "old": "In practice the segment is reserved for local micro and small businesses: OSS provides no large-scale (Usaha Besar) row for this code, so a PT PMA cannot register it.",
+          "new": "For a PT PMA the Bali door is shut by the provincial moratorium: since 13 May 2026 OSS refuses PMA registration at a Bali address for every Low and Medium-Low risk KBLI, this one included."
+        },
+        {
+          "field": "editorial.body",
+          "old": "The record’s decisive finding for this activity, however, is already the absence of an Usaha Besar registration row: despite a nationally open, 100% foreign-ownership position, the Bali PMA route is closed.",
+          "new": "The record’s decisive finding for this activity, however, is the Bali moratorium: despite a nationally open, 100% foreign-ownership position, the Bali PMA route is closed while the block on the Low and Medium-Low risk tiers stands."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "56306": {
+      "judul": "Aktivitas Penyediaan Minuman Keliling/Tempat Tidak Tetap",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "whatYouNeed",
+          "old": "However, the OSS risk table has no Usaha Besar (large-scale) row for this activity — it is reserved for UMKM (micro/small business) only.",
+          "new": "However, the same OSS risk table puts this activity in the Medium-Low band — and since 13 May 2026 Bali's province-wide moratorium blocks PMA registration for every Low and Medium-Low risk KBLI at a Bali address."
+        },
+        {
+          "field": "whoThisIsFor",
+          "old": "This is ideal for a foreign entrepreneur aiming for a small-scale, mobile beverage venture, but a PT PMA cannot register under this code at all — it is reserved for UMKM (micro/small) scale, and PT PMA is legally Usaha Besar — so this route is only feasible through a genuine local partnership or a different business structure.",
+          "new": "This suits a foreign entrepreneur aiming for a small-scale, mobile beverage venture, but a PT PMA cannot register under this code at a Bali address today: the province-wide moratorium blocks every Low and Medium-Low risk KBLI, and this one is classified Medium-Low risk. Whether any alternative works has to be checked case by case."
+        },
+        {
+          "field": "editorial.body",
+          "old": "The Bali record marks it Closed to PMA (no Besar scale) because OSS has no Usaha Besar scale row: the activity is reserved for UMKM, while a PT PMA is Usaha Besar by law.",
+          "new": "The Bali record marks it closed in Bali under the 2026 moratorium: the island-wide block covers every Low and Medium-Low risk KBLI, and this activity is classified Medium-Low risk."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "Since a PT PMA is legally classified as Usaha Besar, it cannot register under this code in Bali, regardless of the moratorium.",
+          "new": "It is the moratorium itself that closes the door here: a PT PMA cannot register under this code at a Bali address while that block stands, though nothing in the national rules restricts the activity."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "70201": {
+      "judul": "Aktivitas Konsultansi Manajemen dan Bisnis Pariwisata",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The Bali record marks the activity **Closed to PMA (no Besar scale)** because the OSS system has no **Usaha Besar** scale row for it; it is reserved for UMKM.",
+          "new": "The Bali record marks the activity **Closed in Bali (2026 moratorium)** because the province-wide block covers every **Low and Medium-Low risk** KBLI, and tourism management consulting is classified Low risk."
+        },
+        {
+          "field": "editorial.body",
+          "old": "For this code, the immediate conclusion remains clear: national openness up to full foreign ownership is real, but Bali does not permit PMA registration today because the activity is reserved for UMKM and lacks the required large-scale OSS row.",
+          "new": "For this code, the immediate conclusion remains clear: national openness up to full foreign ownership is real, but Bali does not permit PMA registration today because the activity falls in the Low risk band that the provincial moratorium has blocked island-wide since 13 May 2026."
+        },
+        {
+          "field": "editorial.body",
+          "old": "A PT PMA is treated by law as **Usaha Besar**, so it cannot register this activity there.",
+          "new": "The provincial block covers the whole **Low risk** tier, so a PT PMA cannot register this activity there today."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "73300": {
+      "judul": "Aktivitas Kehumasan",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "Its stated status is **Closed to PMA (no Besar scale)**: OSS has no Usaha Besar scale row, the activity is reserved for UMKM, and a PT PMA—Usaha Besar by law—cannot register it.",
+          "new": "Its stated status is **Closed in Bali (2026 moratorium)**: the province-wide block covers every Low and Medium-Low risk KBLI, and public relations is classified **Low risk**. The two licensing annexes that mention it disagree with each other on scale, and neither is an ownership rule."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "In Bali, however, a PT PMA cannot register this KBLI because OSS only provides it for UMKM (micro, small, medium enterprises), and a PMA is legally classified as a large company (Usaha Besar).",
+          "new": "In Bali, however, a PT PMA cannot register this KBLI because the province-wide moratorium has blocked every Low and Medium-Low risk activity since 13 May 2026, and public relations is classified Low risk."
+        },
+        {
+          "field": "zantaraOpener",
+          "old": "PR consulting in Bali — renumbered code, low risk, no Besar scale. Let's get your NIB updated for 2025.",
+          "new": "PR consulting in Bali — renumbered from 70203, low risk, and the moratorium closes PMA registration for every low-risk activity. If you run a locally-owned (PMDN) company, let's get your NIB updated for 2025."
+        }
+      ]
+    },
+    "74199": {
+      "judul": "Aktivitas Desain Khusus Lainya YTDL",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "whatYouNeed",
+          "old": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership on paper — but OSS provides no Usaha Besar scale row for it: this specialised-design activity is reserved for micro, small and medium enterprises (UMKM) nationwide.",
+          "new": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership, and the scale ranges printed in the licensing annexes are standards for the permit rather than a foreign-ownership limit — but a PT PMA cannot register it at a Bali address today: the province-wide moratorium in force since 13 May 2026 blocks every Low and Medium-Low risk KBLI, and this specialised-design activity is classified Low risk."
+        },
+        {
+          "field": "editorial.body",
+          "old": "The Bali status is closed to PMA because there is no Usaha Besar scale row in OSS; the activity is reserved for UMKM, while a PT PMA is Usaha Besar by law.",
+          "new": "The Bali status is closed because of the provincial moratorium, which since 13 May 2026 blocks every Low and Medium-Low risk KBLI island-wide; this activity is classified Low risk. No ownership restriction on the activity itself was located."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "A PT PMA is legally an Usaha Besar, so it cannot register this KBLI anywhere in Indonesia (PP 28/2025 scale-gating) — not just in Bali.",
+          "new": "Outside Bali the picture is different: nothing in the national rules bars a PT PMA from this KBLI, so the block follows the Bali address rather than the activity."
+        },
+        {
+          "field": "editorial.body",
+          "old": "A founder should read the category as one intended for micro and small enterprises, rather than assume that a broad description of creative or design work automatically creates a broad corporate-registration route.",
+          "new": "A founder should not assume that a broad description of creative or design work automatically creates a broad corporate-registration route: the licensing annexes set the scales for the permit, and in Bali it is the moratorium that decides registrability, by risk tier."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "79901": {
+      "judul": "Jasa Informasi Pariwisata",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The record contains no Usaha Besar scale row for this activity, placing it within the UMKM-reserved structure described for Bali.",
+          "new": "The record places this activity in the Low risk band, which is what puts it inside the Bali moratorium described above."
+        },
+        {
+          "field": "editorial.body",
+          "old": "The stated reason is structural: without an Usaha Besar scale row, the activity is reserved for UMKM, while a PT PMA is legally treated as an Usaha Besar.",
+          "new": "The stated reason is provincial: Bali's moratorium suspends PMA registration island-wide for every Low and Medium-Low risk KBLI, and no restriction on foreign ownership of the activity itself was located."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "But OSS lists no large-enterprise (Besar) scale for it — it is reserved for micro, small and medium Indonesian enterprises (Perpres 49/2021).",
+          "new": "But a Bali address changes the answer: the province-wide moratorium in force since 13 May 2026 blocks PMA registration for every Low and Medium-Low risk KBLI, and this one is classified Low risk."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "A PT PMA is, by law, a large-scale (Besar) entity, so it cannot register against this code in Bali.",
+          "new": "That block, not any restriction on the activity itself, is why a PT PMA cannot register against this code in Bali today."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "The realistic paths are a domestic structure or an adjacent code that does carry a Besar scale.",
+          "new": "Whether an alternative works — a different domicile, or an adjacent code whose risk class sits above the blocked band — has to be checked case by case against the address and the exact scope."
+        },
+        {
+          "field": "whoThisIsFor",
+          "old": "Best suited to an Indonesian-owned (UMKM) operator; a foreign investor needs an adjacent code or a domestic partner structure.",
+          "new": "Well suited to a small local operator; a foreign investor with a Bali address is blocked by the moratorium today, and any alternative needs checking against the exact scope."
+        },
+        {
+          "field": "editorial.body",
+          "old": "In other words, the activity has room at micro, small, and medium scale, but not at the large-business scale that would otherwise accommodate a PT PMA.",
+          "new": "In other words, the licensing annex sets out the scales for the permit; what decides a PT PMA’s position in Bali is the moratorium on the Low and Medium-Low risk tiers."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "79902": {
+      "judul": "Jasa Informasi Daya Tarik Wisata",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "Its Bali status is Closed to PMA (no Besar scale), with a structural reason recorded: OSS has no Usaha Besar scale row, leaving the activity reserved for UMKM; a PT PMA is Usaha Besar by law and therefore cannot register.",
+          "new": "Its Bali status is closed under the 2026 moratorium, with the reason recorded plainly: the province-wide block covers every Low and Medium-Low risk KBLI, and this activity is classified Low risk. Nationally it stays open to full foreign ownership."
+        },
+        {
+          "field": "editorial.body",
+          "old": "That boundary matters because Bali's finding turns on the absence of an Usaha Besar scale row in OSS.",
+          "new": "That listing is about business scale, not foreign ownership: Bali's finding turns instead on the activity's risk tier, and the moratorium closes PMA registration for every activity in that tier."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "86995": {
+      "judul": "Aktivitas Rumah Pijat",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "whatYouNeed",
+          "old": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership on paper — but OSS provides no Usaha Besar scale row for it: the massage-house activity is reserved for micro, small and medium enterprises (UMKM) nationwide.",
+          "new": "Nationally, the Positive Investment List opens this KBLI to 100% foreign ownership, and no ownership restriction on the massage-house activity was located in the investment annexes or in any sectoral instrument read — but a PT PMA cannot register it at a Bali address today: the island-wide moratorium in force since 13 May 2026 blocks every Low and Medium-Low risk KBLI, and this activity is classified Medium-Low risk."
+        },
+        {
+          "field": "editorial.body",
+          "old": "A foreign investor cannot register this activity in Bali through a PT PMA today, because the OSS structure has no Usaha Besar scale row for it and therefore reserves it for UMKM.",
+          "new": "A foreign investor cannot register this activity in Bali through a PT PMA today, because the province-wide moratorium blocks every Low and Medium-Low risk KBLI and this one is classified Medium-Low risk."
+        },
+        {
+          "field": "whatYouNeed",
+          "old": "A PT PMA is legally an Usaha Besar, so it cannot register this KBLI anywhere in Indonesia (PP 28/2025 scale-gating) — not just in Bali.",
+          "new": "Outside Bali the picture is different: nothing in the national rules bars a PT PMA from this KBLI, so the block follows the Bali address rather than the activity."
+        },
+        {
+          "field": "editorial.body",
+          "old": "A PT PMA is treated by law as Usaha Besar, making the mismatch structural rather than discretionary.",
+          "new": "The Bali block is provincial and applies to the whole Medium-Low risk tier, rather than being a discretionary judgment about this business."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
+        }
+      ]
+    },
+    "93119": {
+      "judul": "Pengelolaan Fasilitas Olahraga Lainnya",
+      "expect_l4_status": "CHIUSO_MORATORIA_BALI",
+      "expect_l4_blocked": true,
+      "patches": [
+        {
+          "field": "editorial.body",
+          "old": "The Bali record marks it as closed to PMA because OSS has no **Usaha Besar** scale row; the activity is therefore reserved for UMKM, while a PT PMA is treated by law as an Usaha Besar.",
+          "new": "The Bali record marks it as closed under the **2026 provincial moratorium**, which blocks every Low and Medium-Low risk KBLI island-wide; this activity is classified Low risk, so it sits inside the blocked band."
+        },
+        {
+          "field": "editorial.body",
+          "old": "The record does not extend that opening to a larger-business row, so the category remains structurally aligned with micro and small enterprises.",
+          "new": "The national opening is not what is in question here; what closes Bali today is the moratorium over the Low and Medium-Low risk tiers."
+        },
+        {
+          "field": "editorial.byTheNumbers[3].value",
+          "old": "Closed to PMA (no Besar scale)",
+          "new": "Closed in Bali (2026 moratorium)"
         }
       ]
     }

--- a/scripts/kbli_filiera/tests/test_cure_l4_withdrawn_umkm_prose.py
+++ b/scripts/kbli_filiera/tests/test_cure_l4_withdrawn_umkm_prose.py
@@ -1,0 +1,200 @@
+"""Guilt + innocence for the withdrawn-UMKM prose compiler.
+
+The compiler rewrites client-facing regulatory prose on the canonical dataset, so
+the interesting behaviour is not "does it replace a string" — it is every state in
+which it must REFUSE. A cure that guesses at an ambiguous record is worse than one
+that stops, because the thing it guesses at is what a client reads.
+
+Two of these tests exist because of specific scars:
+
+  - `test_refuses_when_the_premise_moved` — the entire reason this backlog exists
+    is that a verdict changed on 2026-08-03 and the prose explaining it did not.
+    Prose graded against `NON_CLASSIFICABILE` must not be written onto a record
+    that has since become something else (W113: a replacement is a new claim, and
+    it is a claim about a premise).
+  - `test_the_spec_never_re_asserts_the_withdrawn_inference` — the cure must not
+    reintroduce the disease it cures. The first version of the overlay cure used
+    one template for every code and would have inverted a TRUE closure; this pins
+    the spec's own text against the argument being retired.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from scripts.kbli_filiera.cure_l4_withdrawn_umkm_prose import (
+    CureError,
+    DEFAULT_SPEC,
+    apply_patch,
+    check_premise,
+)
+
+WITHDRAWN_CLAIM = re.compile(
+    r"no Usaha Besar scale row"
+    r"|reserved for UMKM"
+    r"|reserved for micro, small and medium enterprises",
+    re.IGNORECASE,
+)
+
+
+def _record(body: str = "Alpha. The stated reason is structural. Omega.") -> dict:
+    return {
+        "kode_kbli_2025": "99999",
+        "l4_bali": {"status": "NON_CLASSIFICABILE", "blocked": True},
+        "intel_2026": {"editorial": {"body": body}},
+    }
+
+
+PATCH = {
+    "field": "editorial.body",
+    "old": "The stated reason is structural.",
+    "new": "The position cannot be stated; it is treated as blocked until verified case by case.",
+}
+
+
+# ── the happy path, so the refusals below mean something ────────────────────────
+
+def test_applies_when_the_old_text_occurs_exactly_once():
+    rec = _record()
+    assert apply_patch(rec, "99999", PATCH) is True
+    body = rec["intel_2026"]["editorial"]["body"]
+    assert PATCH["new"] in body
+    assert PATCH["old"] not in body
+    assert body.startswith("Alpha.") and body.endswith("Omega.")
+
+
+def test_idempotent_when_already_applied():
+    rec = _record(f"Alpha. {PATCH['new']} Omega.")
+    assert apply_patch(rec, "99999", PATCH) is False
+
+
+# ── guilt: every state the spec does not describe must be fatal ─────────────────
+
+def test_refuses_when_the_old_text_occurs_twice():
+    rec = _record(f"{PATCH['old']} Middle. {PATCH['old']}")
+    with pytest.raises(CureError, match="exactly once"):
+        apply_patch(rec, "99999", PATCH)
+
+
+def test_refuses_when_neither_old_nor_new_is_present():
+    rec = _record("Alpha. Something else entirely. Omega.")
+    with pytest.raises(CureError, match="refusing"):
+        apply_patch(rec, "99999", PATCH)
+
+
+def test_refuses_a_missing_field_and_says_it_is_missing():
+    """An absent field and a wrong-typed field must not share a message: a
+    diagnosis that names the wrong cause sends the reader away from it (W106)."""
+    rec = _record()
+    with pytest.raises(CureError, match="field does not exist"):
+        apply_patch(rec, "99999", {**PATCH, "field": "editorial.pullQuote"})
+
+    typed = _record()
+    typed["intel_2026"]["editorial"]["pullQuote"] = ["not", "a", "string"]
+    with pytest.raises(CureError, match="holds list, not a string"):
+        apply_patch(typed, "99999", {**PATCH, "field": "editorial.pullQuote"})
+
+
+def test_refuses_a_missing_parent_path():
+    rec = _record()
+    with pytest.raises(CureError, match="does not exist \\(stopped at"):
+        apply_patch(rec, "99999", {**PATCH, "field": "nosuch.body"})
+
+
+def test_refuses_when_the_premise_moved():
+    """The prose was graded against NON_CLASSIFICABILE. If the verdict has since
+    moved, writing it would put a sentence about one world onto a record
+    describing another — the exact failure this whole cure is repairing."""
+    entry = {"expect_l4_status": "NON_CLASSIFICABILE", "expect_l4_blocked": True}
+    moved = _record()
+    moved["l4_bali"]["status"] = "CHIUSO_PMA_NO_BESAR"
+    with pytest.raises(CureError, match="premise moved"):
+        check_premise(moved, "99999", entry)
+
+    unblocked = _record()
+    unblocked["l4_bali"]["blocked"] = False
+    with pytest.raises(CureError, match="premise moved"):
+        check_premise(unblocked, "99999", entry)
+
+
+# ── innocence: an unchanged premise passes, and a sibling field is untouched ────
+
+def test_accepts_the_pinned_premise():
+    """INNOCENCE for the premise check: an unmoved verdict must pass. "Does not
+    raise" is asserted rather than merely relied on — a test whose whole content
+    is a call reads identically to a test of nothing."""
+    entry = {"expect_l4_status": "NON_CLASSIFICABILE", "expect_l4_blocked": True}
+    assert check_premise(_record(), "99999", entry) is None
+
+    # And it is the PAIR that is checked, not either half: a record matching only
+    # the status, or only the flag, is still a moved premise.
+    for field, value in (("status", "CHIUSO_MORATORIA_BALI"), ("blocked", False)):
+        rec = _record()
+        rec["l4_bali"][field] = value
+        with pytest.raises(CureError):
+            check_premise(rec, "99999", entry)
+
+
+def test_does_not_touch_a_sibling_field():
+    rec = _record()
+    rec["intel_2026"]["whatYouNeed"] = PATCH["old"]
+    apply_patch(rec, "99999", PATCH)
+    assert rec["intel_2026"]["whatYouNeed"] == PATCH["old"], (
+        "the patch reached outside its declared field"
+    )
+
+
+# ── the shipped spec itself ────────────────────────────────────────────────────
+
+def _spec() -> dict:
+    return json.loads(DEFAULT_SPEC.read_text(encoding="utf-8"))
+
+
+def test_the_spec_is_there_and_its_population_is_pinned():
+    """A suite that silently reads an empty spec reports a clean world (W84)."""
+    spec = _spec()
+    assert len(spec["codes"]) == 13
+    assert sum(len(e["patches"]) for e in spec["codes"].values()) == 17
+
+
+def test_the_spec_never_re_asserts_the_withdrawn_inference():
+    offenders = [
+        f"{code}.{p['field']}"
+        for code, entry in _spec()["codes"].items()
+        for p in entry["patches"]
+        if WITHDRAWN_CLAIM.search(p["new"])
+    ]
+    assert offenders == [], (
+        f"the cure re-asserts the very inference it retires, in {offenders}. "
+        "Every `old` in this spec is guilty of that claim by construction; a `new` "
+        "that repeats it makes the cure a no-op wearing a diff."
+    )
+
+
+def test_every_code_states_the_precautionary_block_somewhere():
+    """These records are `blocked: true`. Prose that only says "we cannot state a
+    position" reads, on a page whose badge says blocked, as though the block were
+    a mistake. The cross-family grader caught this on 7 of 13 in round one."""
+    for code, entry in _spec()["codes"].items():
+        joined = " ".join(p["new"] for p in entry["patches"])
+        assert "blocked until verified" in joined, (
+            f"{code}: no replacement sentence says the code is still treated as blocked "
+            "pending verification — a reader would conclude the opposite of the badge."
+        )
+
+
+def test_every_old_string_actually_carries_the_withdrawn_claim():
+    """Innocence for the SELECTION: this cure is only entitled to rewrite prose
+    that argues the retired inference. A spec entry whose `old` does not is a
+    rewrite of something else, smuggled in on this cure's authority."""
+    innocent = [
+        f"{code}.{p['field']}"
+        for code, entry in _spec()["codes"].items()
+        for p in entry["patches"]
+        if not WITHDRAWN_CLAIM.search(p["old"])
+    ]
+    assert innocent == [], f"spec rewrites prose that does not carry the claim: {innocent}"

--- a/scripts/kbli_filiera/tests/test_cure_l4_withdrawn_umkm_prose.py
+++ b/scripts/kbli_filiera/tests/test_cure_l4_withdrawn_umkm_prose.py
@@ -40,6 +40,40 @@ WITHDRAWN_CLAIM = re.compile(
     re.IGNORECASE,
 )
 
+# The ENTITLEMENT pattern, and it is deliberately wider than the one above.
+#
+# The pattern above is the shipped corpus guard's (test_withdrawn_umkm_inference_absent.py):
+# narrow on purpose, because it ratchets over 1,559 records and a false positive there
+# accuses the corpus of telling the truth. It is the WRONG predicate for asking "was this
+# cure entitled to rewrite this string", because the sentences a wide per-record sweep
+# turns up are, by construction, the ones the narrow pattern cannot see — "A PT PMA is
+# legally an Usaha Besar, so it cannot register this KBLI anywhere in Indonesia" argues
+# the withdrawn inference and matches none of the three phrases above.
+#
+# What this is NOT: a corpus detector. It certifies that the strings THIS spec rewrites
+# carry the retired reasoning; it makes no claim to catch a future wording, and widening
+# it from the instances in hand cannot (W113). Innocence is asserted below so it cannot
+# grow into something that convicts the legitimate annex closure.
+WITHDRAWN_REASONING = re.compile(
+    r"no Usaha Besar scale row"
+    r"|reserved for UMKM"
+    r"|reserved for micro, small and medium enterprises"
+    r"|reserved for local micro"
+    r"|(?:is|as)\s+(?:legally\s+|by law\s+)?(?:an?\s+)?Usaha Besar"
+    r"|treated (?:by law )?as \*{0,2}(?:an )?Usaha Besar"
+    r"|by law, a large-scale \(Besar\) entity"
+    r"|no Besar scale"
+    r"|carry a Besar scale"
+    r"|absence of an Usaha Besar"
+    r"|no large-enterprise \(Besar\) scale"
+    r"|only provides it for UMKM"
+    r"|larger-business row"
+    r"|not at the large-business scale"
+    r"|intended for micro and small enterprises"
+    r"|Indonesian-owned \(UMKM\) operator",
+    re.IGNORECASE,
+)
+
 
 def _record(body: str = "Alpha. The stated reason is structural. Omega.") -> dict:
     return {
@@ -97,6 +131,52 @@ def test_refuses_a_missing_field_and_says_it_is_missing():
     typed["intel_2026"]["editorial"]["pullQuote"] = ["not", "a", "string"]
     with pytest.raises(CureError, match="holds list, not a string"):
         apply_patch(typed, "99999", {**PATCH, "field": "editorial.pullQuote"})
+
+
+def test_reaches_a_string_inside_a_list_and_leaves_its_siblings_alone():
+    """The stat cards live in a list. Reaching them is the only reason indexed
+    paths exist, so the happy path is asserted with the neighbours named: an
+    off-by-one here would rewrite a different card and still look like a success."""
+    rec = _record()
+    rec["intel_2026"]["editorial"]["byTheNumbers"] = [
+        {"label": "National ceiling", "value": "100%"},
+        {"label": "Bali status", "value": PATCH["old"]},
+        {"label": "Open scales", "value": "Mikro, Kecil, Menengah"},
+    ]
+    patch = {**PATCH, "field": "editorial.byTheNumbers[1].value"}
+    assert apply_patch(rec, "99999", patch) is True
+    cards = rec["intel_2026"]["editorial"]["byTheNumbers"]
+    assert cards[1]["value"] == PATCH["new"]
+    assert cards[0]["value"] == "100%"
+    assert cards[2]["value"] == "Mikro, Kecil, Menengah"
+    assert cards[1]["label"] == "Bali status", "the patch reached a sibling key"
+
+
+def test_refuses_an_index_past_the_end_of_the_list():
+    """The position of a card is NOT stable across records — one of the thirteen
+    carries no Bali-status card at all. If the list shrank, writing to whatever
+    now sits nearby is worse than stopping."""
+    rec = _record()
+    rec["intel_2026"]["editorial"]["byTheNumbers"] = [{"value": PATCH["old"]}]
+    with pytest.raises(CureError, match="out of range"):
+        apply_patch(rec, "99999", {**PATCH, "field": "editorial.byTheNumbers[3].value"})
+
+
+def test_refuses_an_index_applied_to_something_that_is_not_a_list():
+    rec = _record()
+    with pytest.raises(CureError, match="not a list"):
+        apply_patch(rec, "99999", {**PATCH, "field": "editorial[0].body"})
+
+
+def test_an_unindexed_path_still_resolves_the_plain_key():
+    """INNOCENCE for the index parser: adding `name[i]` support must not change
+    how `name` behaves. A field whose name merely CONTAINS a digit is not an
+    index, and the twelve dotted paths in the shipped spec are unindexed."""
+    rec = _record()
+    rec["intel_2026"]["editorial"]["body2"] = PATCH["old"]
+    assert apply_patch(rec, "99999", {**PATCH, "field": "editorial.body2"}) is True
+    assert rec["intel_2026"]["editorial"]["body2"] == PATCH["new"]
+    assert rec["intel_2026"]["editorial"]["body"] == _record()["intel_2026"]["editorial"]["body"]
 
 
 def test_refuses_a_missing_parent_path():
@@ -157,8 +237,8 @@ def _spec() -> dict:
 def test_the_spec_is_there_and_its_population_is_pinned():
     """A suite that silently reads an empty spec reports a clean world (W84)."""
     spec = _spec()
-    assert len(spec["codes"]) == 13
-    assert sum(len(e["patches"]) for e in spec["codes"].values()) == 17
+    assert len(spec["codes"]) == 26  # 13 NON_CLASSIFICABILE + 13 CHIUSO_MORATORIA_BALI
+    assert sum(len(e["patches"]) for e in spec["codes"].values()) == 75
 
 
 def test_the_spec_never_re_asserts_the_withdrawn_inference():
@@ -175,19 +255,39 @@ def test_the_spec_never_re_asserts_the_withdrawn_inference():
     )
 
 
-def test_every_code_states_the_precautionary_block_somewhere():
-    """These records are `blocked: true`. Prose that only says "we cannot state a
-    position" reads, on a page whose badge says blocked, as though the block were
-    a mistake. The cross-family grader caught this on 7 of 13 in round one."""
+# What each badge obliges the prose to say. Every record here is `blocked: true`,
+# but they are blocked for different reasons and the honest sentence differs:
+# NON_CLASSIFICABILE means "we hold no verified rows, so we treat it as blocked
+# until someone checks", while CHIUSO_MORATORIA_BALI is a settled provincial
+# block. Asserting the precautionary wording on a moratorium code would UNDERSTATE
+# a real block; asserting the moratorium on a NON_CLASSIFICABILE code would invent
+# a cause. One test, keyed on the status the spec pinned.
+BADGE_OBLIGATION = {
+    "NON_CLASSIFICABILE": "blocked until verified",
+    "CHIUSO_MORATORIA_BALI": "moratorium",
+}
+
+
+def test_every_code_states_its_own_kind_of_block_somewhere():
+    """These records are `blocked: true`. Prose that leaves the block unstated —
+    or states the wrong kind — reads, on a page whose badge says blocked, as
+    though the block were a mistake. The cross-family grader caught the first
+    shape on 7 of 13 in batch one; the second is why this is keyed on status."""
     for code, entry in _spec()["codes"].items():
-        joined = " ".join(p["new"] for p in entry["patches"])
-        assert "blocked until verified" in joined, (
-            f"{code}: no replacement sentence says the code is still treated as blocked "
-            "pending verification — a reader would conclude the opposite of the badge."
+        status = entry["expect_l4_status"]
+        assert status in BADGE_OBLIGATION, (
+            f"{code} pins status {status!r}, which no obligation is defined for. Add one "
+            "deliberately: a status with no obligation passes this test by default."
+        )
+        joined = " ".join(p["new"] for p in entry["patches"]).lower()
+        needle = BADGE_OBLIGATION[status]
+        assert needle in joined, (
+            f"{code} ({status}): no replacement sentence carries {needle!r}, so a reader "
+            "would conclude something other than what the badge on the same page says."
         )
 
 
-def test_every_old_string_actually_carries_the_withdrawn_claim():
+def test_every_old_string_actually_carries_the_withdrawn_reasoning():
     """Innocence for the SELECTION: this cure is only entitled to rewrite prose
     that argues the retired inference. A spec entry whose `old` does not is a
     rewrite of something else, smuggled in on this cure's authority."""
@@ -195,6 +295,28 @@ def test_every_old_string_actually_carries_the_withdrawn_claim():
         f"{code}.{p['field']}"
         for code, entry in _spec()["codes"].items()
         for p in entry["patches"]
-        if not WITHDRAWN_CLAIM.search(p["old"])
+        if not WITHDRAWN_REASONING.search(p["old"])
     ]
-    assert innocent == [], f"spec rewrites prose that does not carry the claim: {innocent}"
+    assert innocent == [], f"spec rewrites prose that does not carry the reasoning: {innocent}"
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        # The one closure that survives the withdrawal must stay sayable, or the
+        # cheapest way to satisfy this file is to delete the true closures too.
+        "Allocated to Koperasi/UMKM by Perpres 49/2021 Lampiran II (dialokasikan column): "
+        "a PT PMA cannot take this bidang usaha.",
+        "Reserved to Koperasi/UMKM only as to a NAMED sub-activity per Pasal 5(5).",
+        "Nationally this KBLI is TERTUTUP: 0% foreign ownership, so a PT PMA cannot register "
+        "it anywhere in Indonesia — Bali included.",
+        "Blocked in Bali by the provincial PMA moratorium, independent of national opening.",
+        # Descriptive statements of the licensing annex's own scale rows. These are
+        # grounded in `per_skala` and were deliberately LEFT in the corpus; a pattern
+        # that convicted them would be demanding the cure delete true data.
+        "The activity is open to micro and small enterprises.",
+        "The registration scales named for the activity are Micro, Small and Medium.",
+    ],
+)
+def test_the_entitlement_pattern_does_not_convict_legitimate_prose(sentence: str):
+    assert WITHDRAWN_REASONING.search(sentence) is None

--- a/scripts/kbli_filiera/tests/test_withdrawn_umkm_inference_absent.py
+++ b/scripts/kbli_filiera/tests/test_withdrawn_umkm_inference_absent.py
@@ -158,11 +158,23 @@ def test_the_editorial_prose_backlog_can_only_shrink():
     tomorrow: the number may fall, never rise. A new page that re-imports the
     argument fails here.
     """
-    # 34, re-measured after the pattern was corrected to judge the ARGUMENT
-    # instead of its conclusion. The first pin said 37: it counted 8 TERTUTUP
-    # codes whose prose is TRUE and missed 5 real ones. A ratchet pinned to a
-    # mis-calibrated probe ratchets the wrong number.
-    known_backlog = 34
+    # 8. The pin has moved twice and each move is worth keeping straight:
+    #   37 -> 34 when the pattern was corrected to judge the ARGUMENT instead of
+    #          its conclusion (the 37 counted 8 TERTUTUP codes whose prose is TRUE
+    #          and missed 5 real ones — a ratchet pinned to a mis-calibrated probe
+    #          ratchets the wrong number);
+    #   34 -> 21 when the 13 NON_CLASSIFICABILE records were re-authored;
+    #   21 ->  8 when the 13 CHIUSO_MORATORIA_BALI records were.
+    #
+    # All 8 that remain still argue the withdrawn mechanism. Six of them
+    # (55203 79903 95291 96100 96210 96220) are CHIUSO_PMA_NO_BESAR and reach a
+    # conclusion that IS right — they are genuinely allocated to Koperasi/UMKM by
+    # the Perpres 49/2021 Lampiran II `dialokasikan` column — but they say so on
+    # the retired reasoning ("OSS has no Usaha Besar scale row"), which is the
+    # more dangerous shape, not the safer one: a right answer defended by a
+    # withdrawn argument reads as confirmation that the argument still holds.
+    # The other two (43110 55209) are BLOCCATO_DIPENDE_SCOPE.
+    known_backlog = 8
     offenders = sorted(
         r["kode_kbli_2025"]
         for r in _canonical_rows()


### PR DESCRIPTION
The verdict layer was cured on 2026-08-03 when Permeninves/BKPM 5/2025 Pasal 26(1)
withdrew the no-Usaha-Besar inference. The **editorial prose** explaining each verdict
was not — 34 canonical records still argued the retired claim in fluent English.

This is the first and most expensive slice.

## What was wrong

13 records whose Bali verdict is `NON_CLASSIFICABILE` — *"we hold no verified licensing
rows, so no Bali position can be stated"* — while the prose **on the same page** told the
reader a PT PMA **cannot register** the activity. The page contradicted its own badge, and
it erred toward turning away business on an uncertainty of **ours**.

Five are worse than that. Their record names a real located requirement that is explicitly
**not** an ownership rule:

| code | what the record actually says |
|---|---|
| `91424` Taman Wisata Alam | park management is a **State function**; private parties enter by permit/concession, and `PP 36/2010 Pasal 8(3)` names *badan usaha* among those who may hold one |
| `93192` Juri dan Wasit | a **personal licence** — competency certificate, federation recommendation, government permit |
| `93194` Badan Regulasi dan Liga | a **partnership duty** for international-level championships, which does not bar foreign ownership |
| `93195` Olahraga Tradisional | a mandatory business standard with **no ownership term anywhere in it** |
| `47771` Minyak Tanah | a **commercial, nationality-neutral** gate under Perpres 191/2014 |

There is a route, and we were saying there is none.

**Measured after:** canonical records carrying the withdrawn claim **34 → 21**, and the
`NON_CLASSIFICABILE` ones **13 → 0**, on canonical and all four synced consumer copies.

## Why it is hand-written and not mechanical

**46 distinct sentence shapes for 52 sentences.** Only one shape recurs. This is authored
prose, not machine templates — so there is no template map to apply, and each replacement
is anchored on that code's own `l4_bali.reason`.

## Grading — pointed at the sentences I wrote

Codex seat, three rounds: **13 defective → 4 → CLEAR**. Not cosmetic:

- **Seven** replacements dropped *"cannot register"* without saying the code is still
  treated as **blocked pending verification**. These records are `blocked: true`, so prose
  that stops at "we cannot state a position" reads, beside the badge, as though the block
  were a mistake. **I had over-corrected**, and the grader caught it.
- `"checked live on OSS"` exceeded what the records say, which is *"verify case by case"*.
- `91424` dressed a **national** instrument as a Bali-specific finding.
- *"Bali's rule turns on the risk tier"* is true of the corpus but is not in **these**
  records' own reason — so it came out.

## The compiler refuses more than it writes

Each spec entry **pins the verdict the prose was graded against**. If a record's status or
`blocked` flag has since moved, the code is **REFUSED** rather than written — prose graded
against one world must not land on a record describing another, which is precisely the
failure this backlog *is*.

Gold is untouched, and that was **measured** not assumed: it holds no editorial prose for
these codes (0 pattern hits, no `editorial` key, 7 of the 13 absent from gold entirely).

**13 tests, guilt and innocence.** Two pin the cure against itself — the spec may never
re-assert the inference it retires, and every `old` it rewrites must actually carry that
claim, or this cure's authority is being used to edit something else.

Two guards bit their own author here and were obeyed rather than worked around: a test
found that a **missing** field and a **wrong-typed** field shared the message `not a
string`, which names the wrong cause (W106) — now distinct; and the anti-reward-hacking
linter caught an innocence test whose entire body was a call, which reads identically to a
test of nothing.

## Remaining

**21 codes**: 23 `CHIUSO_MORATORIA_BALI` sentences, 8 `CHIUSO_PMA_NO_BESAR`, 4
`BLOCCATO_DIPENDE_SCOPE`. Same method, next slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)