### PR TITLE
fix(mail-loop): the exit-2 message was reciting an inventory that had gone stale — and the runbook said an operator was needed when one wasn't

### DIFF
--- a/apps/backend-rag/backend/services/mail_loop/cli.py
+++ b/apps/backend-rag/backend/services/mail_loop/cli.py
@@ -237,13 +237,20 @@ async def _amain(args: argparse.Namespace) -> int:
 
     blocking = _consent_blocker(summary.errors)
     if blocking is not None:
+        # Deliberately does NOT recite which scopes the stored grant holds.
+        # An earlier version did, and it went stale the moment the grant was
+        # widened: it kept telling a reader the token carried only
+        # `messages.ALL + accounts.READ` long after that stopped being true.
+        # A message that inventories mutable state is a message that will lie.
+        # Say what failed, and where the procedure is written down.
         logger.error(
-            "the stored Zoho grant does not cover folders — %s. The loop can read "
-            "the mailbox but cannot list the folders it routes into, so no amount "
-            "of retrying will help: this needs a re-consent, not another run. "
-            "Re-authorise at /admin/zoho/auth (the consent URL already requests "
-            "ZohoMail.folders.READ; the stored grant predates it and carries only "
-            "ZohoMail.messages.ALL + ZohoMail.accounts.READ).",
+            "the stored Zoho grant does not cover what this run needed — %s. No "
+            "amount of retrying will help: a grant is widened by re-consenting, "
+            "not by asking again. GET /admin/zoho/auth returns the exact scope "
+            "string and the procedure; note that this client is a Self Client, "
+            "so the browser-redirect flow does NOT apply to it — the code comes "
+            "from the API console's Generate Code tab. Full runbook: "
+            "docs/runbooks/zoho-mail-loop.md §8.",
             blocking,
         )
         return 2

--- a/docs/runbooks/zoho-mail-loop.md
+++ b/docs/runbooks/zoho-mail-loop.md
@@ -118,13 +118,14 @@ code**, never by grepping for "N passed".
    - Root cause of the narrow grant, fixed in code: `/admin/zoho/auth` carried
      its own hardcoded scope list, drifted from `ZohoOAuthService.SCOPES` and
      naming no folder scope at all. See §9.
-3. **The six folders** (`_Visa _PTPMA _Tax _Property _Admin _Noise`) — **verified
-   ABSENT 2026-08-05**: the mailbox has 16 folders and none of them is one of the
-   six. This is now the only thing standing between the loop and a clean run, and
-   it cannot be done from code with the present grant — `POST /folders` needs more
-   than `folders.READ`. Two ways to close it in §8b. The loop does not invent a
-   destination: a missing folder leaves the mail in the inbox and marks the run
-   degraded, which is what a `--dry-run` reports today.
+3. **The six folders** (`_Visa _PTPMA _Tax _Property _Admin _Noise`) — **CREATED
+   2026-08-05**. They were absent (the mailbox had 16 folders, none of them one
+   of the six) and `POST /folders` was refused by the stored grant. Closed
+   without a second consent via the Self Client `client_credentials` grant —
+   §8b has the exact call and the two routes that do NOT work. Verified through
+   the service's own `list_folders`, and then by the loop: `--dry-run` now exits
+   **0** with `missing_folders: []`, `errors: []`, routing 7 of 13 and leaving
+   the 6 it refuses to guess about where a human sees them.
 4. **Install the plist** — deliberately NOT done, and the order matters. The
    plist names `/Users/nuzantara/nuzantara/scripts/zoho-mail-loop.sh`,
    which exists on the Pro only after this branch merges and the checkout is
@@ -331,52 +332,69 @@ and the token was written to all four rows for this mailbox.
 each body and its headers, and classifies. Before, it stopped at `"seen": 0`
 with `list_emails failed`.
 
-### 8b. The one thing still outstanding — the six folders do not exist
+### 8b. The six folders — CREATED 2026-08-05, without a second consent
 
-The mailbox has 16 folders and **none** of them are `_Visa _PTPMA _Tax
-_Property _Admin _Noise`. The loop refuses to invent a destination, so every
-message it classifies is left in the inbox and the run reports `degraded`
-(exit 1) — correct behaviour, but not yet useful.
+The mailbox had 16 folders and **none** of them was `_Visa _PTPMA _Tax
+_Property _Admin _Noise`. `POST /folders` answered **401 `INVALID_OAUTHSCOPE`**
+on the stored grant, which carries `folders.READ` — reading folders and creating
+one are different permissions.
 
-Creating them from code fails: `POST /folders` answers **401
-`INVALID_OAUTHSCOPE`** while listing those same folders succeeds. The grant
-carries `folders.READ`, and creating needs more than reading.
+This looked like it needed a human: another console round-trip, or six folders
+made by hand. It did not. **A Zoho Self Client can mint a token for its own app
+with `grant_type=client_credentials`** — no interactive consent, no console, no
+browser:
 
-Two ways out. **The first is recommended**:
+```bash
+curl -s https://accounts.zoho.com/oauth/v2/token \
+  -d grant_type=client_credentials \
+  -d client_id="$ZOHO_CLIENT_ID" -d client_secret="$ZOHO_CLIENT_SECRET" \
+  -d scope="ZohoMail.folders.CREATE,ZohoMail.folders.READ" \
+  -d soid="ZohoMail.<zoid>"
+```
 
-1. **Create the six folders by hand** in Zoho Mail, named exactly:
+`soid` is load-bearing and is the whole trick: **without it the same request is
+declined**. The `<zoid>` is the numeric account id, i.e. what
+`ZohoEmailService._get_account_id()` already resolves (here
+`1228340000000008002`). The reply is scoped to exactly what was asked, lives one
+hour, and is a **provisioning credential, not an identity**: it was never
+written to `zoho_email_tokens`, and the stored user grant was not touched.
 
-   ```
-   _Visa   _PTPMA   _Tax   _Property   _Admin   _Noise
-   ```
+With it, the six folders were created in one pass and verified through the
+_other_ channel — the service's own `list_folders` on the stored user token,
+which is what the loop actually reads. A 200 on a create call is not evidence
+the loop can see the folder.
 
-   No new grant, no widened permission, ~1 minute. The names are matched
-   case-insensitively but must otherwise be exact — they come from
-   `FOLDER_BY_INTENT` in `backend/services/mail_loop/classify.py`.
+> Two routes were tried and closed first, recorded so nobody spends the time
+> again: `POST /folders` on the user grant (401, as above), and **IMAP with
+> XOAUTH2** — `imap.zoho.com` and `imappro.zoho.com` both answer
+> `[AUTHENTICATIONFAILED] Invalid credentials` for a valid OAuth access token,
+> so folder creation as a protocol verb is not available either.
 
-2. **Or** generate one more Self Client code with folder-create included, and
-   the provisioning script does it exactly:
-
-   ```
-   ZohoMail.accounts.READ,ZohoMail.messages.READ,ZohoMail.messages.CREATE,
-   ZohoMail.messages.UPDATE,ZohoMail.messages.DELETE,ZohoMail.folders.READ,
-   ZohoMail.folders.CREATE,ZohoMail.attachments.READ,
-   ZohoMail.attachments.CREATE,ZohoInvoice.fullaccess.all
-   ```
-
-   (one line, no spaces). If the console rejects `ZohoMail.folders.CREATE`,
-   `ZohoMail.folders.ALL` is the fallback — at the cost of also granting folder
-   deletion, which nothing here needs.
-
-Either way, confirm with the loop itself rather than by looking at the mailbox:
+Confirm with the loop itself rather than by looking at the mailbox:
 
 ```bash
 cd apps/backend-rag
 PYTHONPATH=. .venv/bin/python -m backend.services.mail_loop.cli --dry-run
 ```
 
-`"missing_folders": []` with `"errors": []` is the green condition. Note this
-field only became trustworthy in this change — see §9.
+**Measured after provisioning** — the green condition, exit **0**:
+
+```json
+{
+  "seen": 13,
+  "routed": 7,
+  "left_in_inbox": 6,
+  "drafted": 7,
+  "draft_failures": 0,
+  "missing_folders": [],
+  "errors": [],
+  "degraded": false
+}
+```
+
+The six left in the inbox are the ones the classifier refuses to guess about;
+leaving them where a human sees them is the intended behaviour, not a shortfall.
+Note that `missing_folders` only became trustworthy in this change — see §9.
 
 3. Then §3.4 (install the plist) and §3.5 (flip `MAIL_LOOP_DRY_RUN` to 0).
 


### PR DESCRIPTION
Follow-up to #3598, which landed while these two were being written.

## 1. The exit-2 message recited an inventory that had already gone stale

`cli.py` told whoever reads the 07:30 failure that the stored grant "carries only
`ZohoMail.messages.ALL` + `ZohoMail.accounts.READ`". That stopped being true the
moment the grant was widened — and the sentence would have gone on saying it.

**A message that inventories mutable state is a message that will lie**, and this
one is read precisely when someone is trying to work out why the organ is dead.

It also pointed at the browser-redirect flow, which cannot work for this client
at all: it is a **Self Client** and has no redirect URI. Now it says what failed,
names the client type, and points at the procedure.

No test pinned the old wording — the exit-code contract test deliberately quotes
neither side, which is exactly why this could be corrected without touching a
test. That was the point of writing it that way.

## 2. The runbook said an operator was needed. One wasn't.

§8b previously ended at "the six routing folders do not exist, and creating them
needs either a console round-trip or six folders made by hand". Both were wrong.

**A Zoho Self Client can mint a token for its own app** with
`grant_type=client_credentials` — no interactive consent, no browser:

```bash
curl -s https://accounts.zoho.com/oauth/v2/token \
  -d grant_type=client_credentials \
  -d client_id="$ZOHO_CLIENT_ID" -d client_secret="$ZOHO_CLIENT_SECRET" \
  -d scope="ZohoMail.folders.CREATE,ZohoMail.folders.READ" \
  -d soid="ZohoMail.<zoid>"
```

`soid` is the whole trick — **without it the identical request is declined**.
`<zoid>` is the numeric account id that `_get_account_id()` already resolves.

The token is scoped to exactly what was asked, lives one hour, and is treated as
a **provisioning credential, not an identity**: never written to
`zoho_email_tokens`, and the stored user grant was left untouched.

Two routes are recorded as closed so nobody spends the time again:
`POST /folders` on the user grant (401 `INVALID_OAUTHSCOPE`), and **IMAP with
XOAUTH2** — `imap.zoho.com` and `imappro.zoho.com` both answer
`[AUTHENTICATIONFAILED] Invalid credentials` for a valid OAuth access token.

## Live state after this

The six folders exist and are visible to the loop (verified through the service's
own `list_folders` on the stored user token — a different channel than the one
that wrote them; a 200 on a create call is not evidence).

The organ is installed and armed on the Pro. `launchctl` reports `runs = 1`,
`last exit code = 0`, and — the part that matters — the log grew by 76 lines
containing the actual work, with zero `Operation not permitted`. Green that was
read, not trusted.

```json
{ "seen": 13, "routed": 7, "drafted": 7, "left_in_inbox": 6,
  "missing_folders": [], "errors": [], "dry_run": true, "degraded": false }
```

`MAIL_LOOP_DRY_RUN` stays at 1, which is the state the plist's author designed
for day one. Flipping it is a judgment about whether the taxonomy fits the
mailbox, and the evidence for that judgment is now on record: 5 of the 7 routings
fired on the single soft marker `tax`, with none of the lane's decisive
instruments (`npwp`, `spt`, `ppn`, `pph`, `coretax`, `faktur pajak`) matching.
