### PR TITLE
fix(mail-loop): six of seven live routings rested on a single coincidence-grade word

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 332 routers · 679 services
+- Backend: FastAPI · 332 routers · 680 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 33 · Packages: 6

--- a/apps/backend-rag/backend/services/mail_loop/classify.py
+++ b/apps/backend-rag/backend/services/mail_loop/classify.py
@@ -205,22 +205,55 @@ _WEAK: frozenset[str] = frozenset(
         "tax", "taxes", "vat", "iva",
         # "codice fiscale" is an identity number; "anno fiscale" is a date range.
         "fiscale",
+        # Pure accounting boilerplate, and no more specific than `vat`.
+        "fiscal year",
+        # Italian "imposte" is both taxes AND window shutters.
+        "imposte",
         # ADMIN — scheduling language lives INSIDE substantive mail. A visa
         # question that ends "can we set a meeting?" is a visa question.
         "meeting", "appointment", "calendar", "reschedule",
         "jadwal", "pertemuan", "appuntamento", "встреча",
+        # Signature-block furniture in the same sense: a call link pasted under
+        # a name says nothing about what the mail is about.
+        "zoom link", "google meet",
         # PROPERTY — in Bali everyone lives in a villa; `bangunan` shows up in
         # postal addresses. "villa" already has negative context for the
         # housekeeping sense, which is a different (narrower) filter.
         "villa", "bangunan",
+        # "Tanah Lot" is one of Bali's best-known landmarks — the commonest
+        # place-name component on the island, and a stronger coincidence than
+        # `bangunan`, which was demoted for the weaker (postal) reason.
+        "tanah",
         # VISA — Italian "soggiorno" is also a living room and a plain stay.
         # The instrument "permesso di soggiorno" is listed separately and stays
         # strong.
         "soggiorno",
+        # "ho visto" = "I saw"; "ci siamo visti" = "we met". A top-20 Italian
+        # past participle in the busiest lane, on a channel where Italian is a
+        # first-class language — strictly worse than `soggiorno`, which was
+        # already demoted. Declared cost: a bare "vorrei un visto" now stays in
+        # the inbox instead of routing. That is the trade this whole rule
+        # makes, and it is pinned by a test so nobody pays it unknowingly.
+        "visto", "visti",
         # PT_PMA — three letters that also spell "open source software" and sit
         # inside plenty of unrelated acronym soup.
         "oss",
+        # Signature-block furniture: "Budi Santoso / Direktur Utama" says who
+        # wrote the mail, not what it is about.
+        "direktur",
     }
+)
+
+# Decisive instruments SHORT enough to appear by accident. These keep their
+# decisive status — one hit still settles the lane — but only when the lane
+# carries at least one other marker.
+#
+# The rest of `_DECISIVE` needs no corroboration: nobody writes `kitas`,
+# `b211a`, `npwp` or `hak guna bangunan` by chance. These do get written by
+# chance, in exactly one shape: an address. "Villa C2, Jalan Raya" and "Blok
+# D12" are how this island writes where you live.
+_NEEDS_CORROBORATION: frozenset[str] = frozenset(
+    {"c1", "c2", "c7", "c12", "c22", "d12", "e23", "e31", "ahu", "shm", "ajb"}
 )
 
 # Negative context: a marker is dropped when it sits next to one of these.
@@ -294,6 +327,29 @@ def _suppressed(haystack: str, marker: str, at: int) -> bool:
     lo = max(0, at - _NEG_WINDOW)
     window = haystack[lo : at + len(marker) + _NEG_WINDOW]
     return any(_word_pattern(word).search(window) for word in forbidden)
+
+
+def _lane_is_credible(hits: list[str]) -> bool:
+    """Does this lane hold at least one marker worth acting on?
+
+    Two ways to fail, and the second was learned by getting it wrong: denying
+    an uncorroborated `C2` the DECISIVE path is not enough, because it then
+    falls through to the count path and wins there instead — a lane of one
+    two-character token beats a runner-up that has just stepped aside. Closing
+    a hole in one path moves it to the other unless the same judgement is
+    applied to both.
+
+    So a marker counts here only when it is neither coincidence-grade prose
+    (`_WEAK`) nor a short permit index standing on its own
+    (`_NEEDS_CORROBORATION` with nothing else in the lane).
+    """
+    for marker in hits:
+        if marker in _WEAK:
+            continue
+        if marker in _NEEDS_CORROBORATION and len(hits) == 1:
+            continue
+        return True
+    return False
 
 
 def _hits(haystack: str, intent: Intent) -> list[str]:
@@ -412,30 +468,55 @@ def classify(
 
     for intent, decisive_set in _DECISIVE.items():
         hit = [m for m in per_lane.get(intent, []) if m in decisive_set]
-        if hit:
-            return Classification(
-                intent=intent,
-                language=language,
-                folder=FOLDER_BY_INTENT[intent],
-                bulk=False,
-                decisive=True,
-                markers={k.value: v for k, v in per_lane.items()},
-            )
-
-    if not per_lane:
+        if not hit:
+            continue
+        # A short alphanumeric permit index needs a second opinion. `C2` and
+        # `D12` decide a lane on one hit, and they are also how Bali writes an
+        # address ("Villa C2, Jalan Raya"), a spreadsheet cell and an invoice
+        # line reference. Corroboration costs nothing on real mail — measured
+        # over 106 live messages, `c1` fired 15 times and NEVER alone, `pma`
+        # 3 of 3 — so requiring another marker in the same lane closes the
+        # address case without losing a single real routing.
+        if all(marker in _NEEDS_CORROBORATION for marker in hit):
+            others = [m for m in per_lane[intent] if m not in hit]
+            if not others:
+                logger.debug(
+                    "decisive %s in lane %s stands alone — not corroborated",
+                    hit,
+                    intent.value,
+                )
+                continue
         return Classification(
-            intent=Intent.UNKNOWN,
+            intent=intent,
             language=language,
-            folder=None,
+            folder=FOLDER_BY_INTENT[intent],
             bulk=False,
-            decisive=False,
-            markers={},
+            decisive=True,
+            markers={k.value: v for k, v in per_lane.items()},
         )
 
-    ranked = sorted(per_lane.items(), key=lambda kv: (-len(kv[1]), kv[0].value))
-    top_intent, top_hits = ranked[0]
-    if len(ranked) > 1 and len(ranked[1][1]) == len(top_hits):
-        # Ambiguous on soft markers only: refuse to guess.
+    # Drop weak-only lanes BEFORE ranking, not after choosing a winner.
+    #
+    # Filtering afterwards was a real defect, caught by adversarial review with
+    # a measured case: "I need help with a work permit... could we set a meeting
+    # or an appointment next week?" gives {visa: [work permit], admin:
+    # [appointment, meeting]}. ADMIN wins the count 2-1, its hits are all weak,
+    # and a post-hoc check then collapsed the WHOLE verdict to UNKNOWN —
+    # discarding `work permit`, a strong marker in the lane that was right.
+    #
+    # A weak-only lane must step ASIDE, not poison the message. UNKNOWN is then
+    # what happens when nothing non-weak survives anywhere, which is what the
+    # comment above `_WEAK` always claimed and what the code now does.
+    considered = {
+        intent: hits for intent, hits in per_lane.items() if _lane_is_credible(hits)
+    }
+    if len(considered) != len(per_lane):
+        logger.debug(
+            "weak-only lanes stepped aside: %s",
+            sorted(lane.value for lane in per_lane.keys() - considered.keys()),
+        )
+
+    if not considered:
         return Classification(
             intent=Intent.UNKNOWN,
             language=language,
@@ -445,15 +526,10 @@ def classify(
             markers={k.value: v for k, v in per_lane.items()},
         )
 
-    if all(marker in _WEAK for marker in top_hits):
-        # The lane won, but on coincidence-grade evidence only. Winning a count
-        # against nothing is not the same as being right: `tax` beats a runner-up
-        # of zero in every invoice ever sent. Refuse, and let the human see it.
-        logger.debug(
-            "lane %s won on weak markers only (%s) — refusing to route",
-            top_intent.value,
-            top_hits,
-        )
+    ranked = sorted(considered.items(), key=lambda kv: (-len(kv[1]), kv[0].value))
+    top_intent, top_hits = ranked[0]
+    if len(ranked) > 1 and len(ranked[1][1]) == len(top_hits):
+        # Ambiguous on soft markers only: refuse to guess.
         return Classification(
             intent=Intent.UNKNOWN,
             language=language,

--- a/apps/backend-rag/backend/services/mail_loop/classify.py
+++ b/apps/backend-rag/backend/services/mail_loop/classify.py
@@ -171,6 +171,58 @@ _DECISIVE: dict[Intent, frozenset[str]] = {
     ),
 }
 
+# Markers too common in ordinary business email to justify a route ON THEIR OWN.
+#
+# `_DECISIVE` above says an instrument is strong because it has "no
+# ordinary-language twin, so a single hit is not a coincidence". The
+# contrapositive was written in that comment and never enforced: a soft marker's
+# single hit CAN be a coincidence, and until 2026-08-05 the count path routed on
+# it anyway — one hit, runner-up zero, message moved out of the inbox.
+#
+# Measured on the live mailbox before this rule existed: of 7 routings in one
+# run, SIX rested on a single soft marker (five on `tax`, one on `meeting`) and
+# not one carried a decisive instrument. `tax` is boilerplate — it sits in the
+# footer of every invoice, receipt and SaaS bill on earth — so "mentions tax"
+# was filing a client's mail into _Tax on the strength of a vendor's small
+# print.
+#
+# Each entry below is listed WITH the ordinary-language twin that makes it
+# coincidence-grade. A weak marker still SCORES (it can win a lane, break a tie,
+# and confirm a strong one); it simply may not be the sole reason to move
+# somebody's mail. A lane whose every hit is weak yields UNKNOWN, which this
+# module already treats as a first-class answer: the message stays in the inbox
+# where a human sees it. That is the stated preference, now enforced.
+#
+# Deliberately NOT weak, and why: `visa` (the card-brand twin is already killed
+# by negative context, and no other boilerplate carries it), `invoice`/`receipt`
+# and their translations (these DO define their topic, and _Admin is the correct
+# home for a vendor invoice), `pajak`/`налог` (domain words, not footer
+# furniture). Extending this set is a measurement, not a hunch — add a token
+# only after seeing it decide a route it should not have.
+_WEAK: frozenset[str] = frozenset(
+    {
+        # TAX — every commercial email quotes a tax line.
+        "tax", "taxes", "vat", "iva",
+        # "codice fiscale" is an identity number; "anno fiscale" is a date range.
+        "fiscale",
+        # ADMIN — scheduling language lives INSIDE substantive mail. A visa
+        # question that ends "can we set a meeting?" is a visa question.
+        "meeting", "appointment", "calendar", "reschedule",
+        "jadwal", "pertemuan", "appuntamento", "встреча",
+        # PROPERTY — in Bali everyone lives in a villa; `bangunan` shows up in
+        # postal addresses. "villa" already has negative context for the
+        # housekeeping sense, which is a different (narrower) filter.
+        "villa", "bangunan",
+        # VISA — Italian "soggiorno" is also a living room and a plain stay.
+        # The instrument "permesso di soggiorno" is listed separately and stays
+        # strong.
+        "soggiorno",
+        # PT_PMA — three letters that also spell "open source software" and sit
+        # inside plenty of unrelated acronym soup.
+        "oss",
+    }
+)
+
 # Negative context: a marker is dropped when it sits next to one of these.
 # Keyed by marker, each value is a set of words that must NOT appear within
 # `_NEG_WINDOW` characters of the hit.
@@ -335,6 +387,9 @@ def classify(
          markers another lane collected.
       3. otherwise, the lane with the most distinct markers; a tie or a blank
          score is UNKNOWN, which the loop leaves in the inbox untouched.
+      4. and a lane that won on WEAK markers only is UNKNOWN too, however
+         lopsided the count: beating a runner-up of zero proves nothing when
+         the winning token is the word every invoice already contains.
 
     UNKNOWN is a first-class answer, not a failure: routing a message we do
     not understand is worse than leaving it where a human will see it.
@@ -381,6 +436,24 @@ def classify(
     top_intent, top_hits = ranked[0]
     if len(ranked) > 1 and len(ranked[1][1]) == len(top_hits):
         # Ambiguous on soft markers only: refuse to guess.
+        return Classification(
+            intent=Intent.UNKNOWN,
+            language=language,
+            folder=None,
+            bulk=False,
+            decisive=False,
+            markers={k.value: v for k, v in per_lane.items()},
+        )
+
+    if all(marker in _WEAK for marker in top_hits):
+        # The lane won, but on coincidence-grade evidence only. Winning a count
+        # against nothing is not the same as being right: `tax` beats a runner-up
+        # of zero in every invoice ever sent. Refuse, and let the human see it.
+        logger.debug(
+            "lane %s won on weak markers only (%s) — refusing to route",
+            top_intent.value,
+            top_hits,
+        )
         return Classification(
             intent=Intent.UNKNOWN,
             language=language,

--- a/apps/backend-rag/backend/services/mail_loop/draft.py
+++ b/apps/backend-rag/backend/services/mail_loop/draft.py
@@ -187,12 +187,30 @@ def generate(request: DraftRequest, *, dry_run: bool = False) -> str:
             "reachable; export the token in the wrapper if drafts start failing."
         )
 
-    argv = [cli, "-p", prompt, "--model", CLAUDE_MODEL]
+    # The prompt goes in on STDIN, never in argv.
+    #
+    # It contains the client's message: their name in the salutation, their
+    # address in the From line, whatever they wrote. A process's command line is
+    # world-readable on macOS — `ps -A -ww -o args` returns the full argv of
+    # every process on the box regardless of owner — so passing it as `-p
+    # <prompt>` published a client's mail to every account on the machine for
+    # the length of the call, up to TIMEOUT_SECONDS.
+    #
+    # That is the same threat model as the two log lines cured beside this, with
+    # a strictly larger payload: the logs leaked a subject, this leaked the whole
+    # message. Found by adversarial review, which measured it rather than
+    # asserting it — 299 processes owned by other users had readable argv on this
+    # machine at the time.
+    #
+    # `claude -p` with no argument reads the prompt from stdin, so this is the
+    # same invocation, minus the exposure. SYMBIOSIS Law 2 / UU PDP Art. 67-68.
+    argv = [cli, "-p", "--model", CLAUDE_MODEL]
     try:
         # No pipeline, no shell: the exit code must reach us intact. Piping this
         # into anything is how an rc gets masked (W97).
         completed = subprocess.run(  # argv list, never a shell string
             argv,
+            input=prompt,
             capture_output=True,
             text=True,
             timeout=TIMEOUT_SECONDS,

--- a/apps/backend-rag/backend/services/mail_loop/loop.py
+++ b/apps/backend-rag/backend/services/mail_loop/loop.py
@@ -47,6 +47,7 @@ from backend.services.mail_loop.learn import (
     match_sent,
     phrase_lesson,
 )
+from backend.services.mail_loop.state_io import write_private
 from backend.services.mail_loop.style import (
     Lesson,
     ReplyStyleStore,
@@ -176,10 +177,9 @@ class PendingDrafts:
         return data if isinstance(data, dict) else {}
 
     def _save(self, data: dict[str, dict[str, Any]]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
-        tmp.replace(self.path)
+        write_private(
+            self.path, json.dumps(data, indent=2, ensure_ascii=False), suffix=".tmp"
+        )
 
     def add(self, thread_id: str, *, text: str, bucket: str) -> None:
         if not thread_id:
@@ -544,14 +544,35 @@ class MailLoop:
             text = generate(request, dry_run=self.dry_run)
         except DraftUnavailable as exc:
             summary.draft_failures += 1
-            logger.warning("loop: no draft for %s: %s", subject[:40], exc)
+            # The subject is CLIENT DATA. It routinely carries a name, a
+            # passport number, a company — "KITAS renewal for <person>" is a
+            # normal subject line here. SYMBIOSIS Law 2 is absolute about logs
+            # (UU PDP Art. 67-68), and this log is world-readable on the Pro and
+            # tailed by other organs. Identify the message by its opaque id and
+            # its lane; that is everything a human debugging this needs, and it
+            # names nobody.
+            logger.warning(
+                "loop: no draft for %s (%s/%s): %s",
+                _message_id(full)[:12] or "?",
+                verdict.intent.value,
+                verdict.language,
+                exc,
+            )
             return
 
         reply_subject = subject if subject.lower().startswith("re:") else f"Re: {subject}"
         content = f"{DRAFT_MARKER}\n\n{text}"
 
         if self.dry_run:
-            logger.info("loop: DRY-RUN would save draft %r (%d chars)", reply_subject, len(content))
+            # Same rule as above: no subject in the log. Length and lane are the
+            # facts worth having; the subject is somebody's business.
+            logger.info(
+                "loop: DRY-RUN would save draft for %s (%s/%s, %d chars)",
+                _message_id(full)[:12] or "?",
+                verdict.intent.value,
+                verdict.language,
+                len(content),
+            )
         else:
             await self.backend.save_draft(
                 self.user_id,

--- a/apps/backend-rag/backend/services/mail_loop/loop.py
+++ b/apps/backend-rag/backend/services/mail_loop/loop.py
@@ -177,9 +177,7 @@ class PendingDrafts:
         return data if isinstance(data, dict) else {}
 
     def _save(self, data: dict[str, dict[str, Any]]) -> None:
-        write_private(
-            self.path, json.dumps(data, indent=2, ensure_ascii=False), suffix=".tmp"
-        )
+        write_private(self.path, json.dumps(data, indent=2, ensure_ascii=False))
 
     def add(self, thread_id: str, *, text: str, bucket: str) -> None:
         if not thread_id:

--- a/apps/backend-rag/backend/services/mail_loop/state_io.py
+++ b/apps/backend-rag/backend/services/mail_loop/state_io.py
@@ -1,0 +1,60 @@
+"""Atomic, owner-only writes for the loop's on-disk state.
+
+Both files this package persists carry material that is nobody else's business:
+
+  * `pending-drafts.json` holds the reply text we generated for a client, kept
+    until the next run can compare it with what the human actually sent. A
+    reply opens with a salutation, so it carries a name.
+  * `reply-style.md` holds distilled habits. `style.py` redacts and drops a
+    lesson that still trips its PII tripwire, so it is the safer of the two —
+    but "safer" is not "public".
+
+Left to the default umask these land 0644 inside a 0755 directory. That is
+superscar #4 (secret/personal data in the clear) waiting for the first person
+who shares the machine, restores a backup, or points a sync client at $HOME —
+and #4's own antidote is to enforce the mode at the moment of writing rather
+than to remember a `chmod` later.
+
+The write is atomic for a duller reason: a run interrupted mid-write must not
+leave a half-written buffer that `_load` then reports as corrupt, silently
+costing a cycle of learning. Temp file, fsync-free rename, done.
+
+The temp name APPENDS `.tmp` instead of replacing the extension. `Path(
+"pending-drafts.json").with_suffix(".tmp")` yields `pending-drafts.tmp`, which
+is a different file from `reply-style.md.tmp` produced by the append form — two
+call sites that looked alike were doing different things. One definition, one
+shape.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = ["DIR_MODE", "FILE_MODE", "write_private"]
+
+DIR_MODE = 0o700
+FILE_MODE = 0o600
+
+
+def write_private(path: Path, body: str, *, suffix: str = ".tmp") -> None:
+    """Write `body` to `path` atomically, owner-only, creating the dir 0700.
+
+    The mode is applied to the TEMP file before the rename, so the destination
+    is never observable at a wider mode — not even for the microsecond between
+    creating it and tightening it.
+
+    `mkdir(mode=...)` only applies to directories this call actually creates,
+    and umask still masks it, so an existing loose directory is tightened
+    explicitly. A `chmod` that fails (an odd filesystem, a foreign owner) is
+    left to raise: this is state we promised to keep private, and a silent
+    fallback to 0644 would be the promise breaking quietly.
+    """
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(parent, DIR_MODE)
+
+    tmp = path.with_name(path.name + suffix)
+    tmp.write_text(body, encoding="utf-8")
+    os.chmod(tmp, FILE_MODE)
+    tmp.replace(path)

--- a/apps/backend-rag/backend/services/mail_loop/state_io.py
+++ b/apps/backend-rag/backend/services/mail_loop/state_io.py
@@ -10,25 +10,36 @@ Both files this package persists carry material that is nobody else's business:
     but "safer" is not "public".
 
 Left to the default umask these land 0644 inside a 0755 directory. That is
-superscar #4 (secret/personal data in the clear) waiting for the first person
-who shares the machine, restores a backup, or points a sync client at $HOME —
-and #4's own antidote is to enforce the mode at the moment of writing rather
-than to remember a `chmod` later.
+superscar #4 (personal data in the clear) waiting for the first person who
+shares the machine, restores a backup, or points a sync client at $HOME — and
+#4's own antidote is to enforce the mode at the moment of writing rather than
+to remember a `chmod` later.
 
-The write is atomic for a duller reason: a run interrupted mid-write must not
-leave a half-written buffer that `_load` then reports as corrupt, silently
-costing a cycle of learning. Temp file, fsync-free rename, done.
+The temp file is created 0600 by `tempfile.mkstemp`, which opens with
+`O_CREAT|O_EXCL` at that mode — so the private bytes are never on disk at a
+wider one, and two processes cannot collide on the name.
 
-The temp name APPENDS `.tmp` instead of replacing the extension. `Path(
-"pending-drafts.json").with_suffix(".tmp")` yields `pending-drafts.tmp`, which
-is a different file from `reply-style.md.tmp` produced by the append form — two
-call sites that looked alike were doing different things. One definition, one
-shape.
+The first version chmod'd AFTER writing, and its docstring claimed the content
+was "never observable at a wider mode — not even for the microsecond between
+creating it and tightening it". Adversarial review measured that claim and it
+was false: the temp file held the bytes at 0644 for the whole window between
+`write_text` and `chmod`, and what actually protected them was the 0700 parent,
+which the comment did not credit. The claim is true now because the code
+changed, not because the wording softened.
+
+Atomicity claim, stated narrowly: the RENAME is atomic, so a reader never sees
+a half-written file and an interrupted run leaves the previous contents intact.
+It is NOT a concurrency protocol — two writers still race, and the last rename
+wins. `ReplyStyleStore` holds a `threading.Lock` around its read-modify-write,
+which covers threads in one process and nothing more; `PendingDrafts` has no
+lock at all. That is adequate for a once-a-day cron and would not be for
+anything else.
 """
 
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 __all__ = ["DIR_MODE", "FILE_MODE", "write_private"]
@@ -37,24 +48,50 @@ DIR_MODE = 0o700
 FILE_MODE = 0o600
 
 
-def write_private(path: Path, body: str, *, suffix: str = ".tmp") -> None:
-    """Write `body` to `path` atomically, owner-only, creating the dir 0700.
+def write_private(path: Path, body: str) -> None:
+    """Write `body` to `path` atomically and owner-only, dir included.
 
-    The mode is applied to the TEMP file before the rename, so the destination
-    is never observable at a wider mode — not even for the microsecond between
-    creating it and tightening it.
+    `mkdir(mode=...)` applies only to directories this call actually creates,
+    and umask still masks it, so every level is tightened explicitly — the
+    intermediate levels too, since a 0700 leaf inside a 0755 parent still
+    announces the leaf's name to everyone.
 
-    `mkdir(mode=...)` only applies to directories this call actually creates,
-    and umask still masks it, so an existing loose directory is tightened
-    explicitly. A `chmod` that fails (an odd filesystem, a foreign owner) is
-    left to raise: this is state we promised to keep private, and a silent
-    fallback to 0644 would be the promise breaking quietly.
+    A `chmod` that fails (an odd filesystem, a foreign owner) is left to raise:
+    this is state we promised to keep private, and degrading quietly to 0644
+    would be the promise breaking in silence.
     """
     parent = path.parent
-    parent.mkdir(parents=True, exist_ok=True)
+    if parent == Path.home():
+        # Tightening $HOME to 0700 would be a surprising, machine-wide side
+        # effect of writing one state file. Reachable only by pointing
+        # --state-dir or MAIL_LOOP_STATE_DIR at the home directory itself;
+        # nothing in this repo does, and refusing costs one line.
+        raise ValueError(
+            f"refusing to write state directly into {parent} — it would chmod "
+            "your home directory. Use a subdirectory."
+        )
+
+    created: list[Path] = []
+    for ancestor in reversed(parent.parents):
+        if not ancestor.exists():
+            created.append(ancestor)
+    if not parent.exists():
+        created.append(parent)
+    parent.mkdir(parents=True, exist_ok=True, mode=DIR_MODE)
+    for directory in created:
+        os.chmod(directory, DIR_MODE)
     os.chmod(parent, DIR_MODE)
 
-    tmp = path.with_name(path.name + suffix)
-    tmp.write_text(body, encoding="utf-8")
-    os.chmod(tmp, FILE_MODE)
+    fd, name = tempfile.mkstemp(dir=parent, prefix=f"{path.name}.", suffix=".tmp")
+    tmp = Path(name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+        # mkstemp already creates at 0600. This makes FILE_MODE the single
+        # source of truth, so changing the constant changes the file rather
+        # than silently disagreeing with it.
+        os.chmod(tmp, FILE_MODE)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
     tmp.replace(path)

--- a/apps/backend-rag/backend/services/mail_loop/style.py
+++ b/apps/backend-rag/backend/services/mail_loop/style.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
+from backend.services.mail_loop.state_io import write_private
+
 logger = logging.getLogger(__name__)
 
 # Cap per (intent, language) bucket. A style file that grows without bound stops
@@ -188,10 +190,7 @@ class ReplyStyleStore:
             chunks.append("")
         body = "\n".join(chunks).rstrip() + "\n"
 
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
-        tmp.write_text(body, encoding="utf-8")
-        tmp.replace(self.path)
+        write_private(self.path, body)
 
 
 def bucket_for(intent: str, language: str) -> str:

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_classify.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_classify.py
@@ -30,7 +30,9 @@ from __future__ import annotations
 import pytest
 
 from backend.services.mail_loop.classify import (
+    _DECISIVE,
     _MARKERS,
+    _WEAK,
     Intent,
     classify,
     detect_language,
@@ -221,13 +223,48 @@ NEGATIVE_CONTEXT: list[tuple[str, str, str, Intent]] = [
         "I have the akta kelahiran of my daughter, is that enough?",
         Intent.PT_PMA,
     ),
-    (
-        "villa-wifi-is-not-property-deal",
+]
+
+# `villa` is deliberately NOT in the list above, and the reason is worth keeping
+# because it looks like an omission.
+#
+# The rows above are VERDICT-level: they assert the lane loses, and the premise
+# check below proves the lane would otherwise have won — which is what stops a
+# row from passing for an unrelated reason. That construction needs the marker
+# to be strong enough to carry the lane on its own.
+#
+# `villa` is a WEAK marker (see `_WEAK`), so it can never carry a lane by
+# itself, suppressed or not. A verdict-level row for it would read UNKNOWN on
+# both sides: green forever, and green for a reason that has nothing to do with
+# suppression — the exact vacuity the premise check exists to catch. It caught
+# it, the day `villa` became weak.
+#
+# What the suppression still does for `villa` is remove it from the marker
+# list, which is what breaks ties and what a strong marker in the same lane is
+# added to. So it is tested THERE, at the level where it still bites.
+
+
+def test_villa_suppression_bites_at_the_marker_level() -> None:
+    """GUILT: housekeeping context strips `villa` out of the property lane."""
+    result = classify(
         "Wifi",
         "The villa wifi password does not work, can someone send the new one?",
-        Intent.PROPERTY,
-    ),
-]
+    )
+    assert "villa" not in result.markers.get("property", [])
+    assert result.intent is not Intent.PROPERTY
+
+
+def test_villa_survives_without_housekeeping_context() -> None:
+    """INNOCENCE: the same word, no housekeeping nearby, is still a marker.
+
+    Without this half, deleting the `villa` entry from `_MARKERS` altogether
+    would make the guilt test above pass, which is not what it claims to prove.
+    """
+    result = classify(
+        "Purchase",
+        "We are considering a villa and would like to understand the options.",
+    )
+    assert "villa" in result.markers.get("property", [])
 
 
 @pytest.mark.parametrize(
@@ -390,3 +427,120 @@ def test_normalize_keeps_accents_and_folds_quotes() -> None:
     assert "società" in out
     assert "'rinnovo'" in out
     assert "  " not in out
+
+
+# --------------------------------------------------------------------------- #
+# A lane that won on WEAK markers only does not route.                        #
+#                                                                             #
+# Measured, not imagined: before this rule, one live run routed 7 messages    #
+# and SIX of them rested on a single soft marker — five on `tax`, one on      #
+# `meeting` — with no decisive instrument anywhere. `tax` is the word every   #
+# invoice footer already contains, so "mentions tax" was filing a client's    #
+# mail on the strength of a vendor's small print.                             #
+#                                                                             #
+# Guilt AND innocence, per the superscar #3 antidote: a rule that only ever   #
+# refuses is not a router, and the innocence half is what stops the next      #
+# person from "fixing" a quiet lane by widening the weak set.                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_weak_marker_alone_does_not_route() -> None:
+    """A vendor invoice mentioning tax is not a tax enquiry.
+
+    This is the exact live shape: `tax` hits, every other lane scores zero, and
+    the old count path routed on a landslide of one.
+    """
+    result = classify(
+        "Your monthly statement",
+        "Total due: 100 EUR, tax included. Thank you for your business.",
+    )
+    assert result.intent is Intent.UNKNOWN
+    assert result.folder is None
+    assert result.routable is False
+    # The evidence is still reported — refusing to act on a marker is not the
+    # same as pretending it was not there.
+    assert "tax" in result.markers.get("tax", [])
+
+
+def test_scheduling_language_alone_does_not_route() -> None:
+    """"Can we set a meeting?" inside a substantive email is not admin.
+
+    The sentence appears at the end of visa, tax and company questions alike.
+    Routing on it moves the real question out of sight.
+    """
+    result = classify("Quick question", "Could we set a meeting next week?")
+    assert result.intent is Intent.UNKNOWN
+    assert result.routable is False
+
+
+def test_weak_plus_strong_in_the_same_lane_still_routes() -> None:
+    """INNOCENCE: the rule refuses weak-ONLY, never weak-as-well."""
+    result = classify(
+        "Filing",
+        "Please prepare the annual return; the tax due is not yet clear to me.",
+    )
+    assert result.intent is Intent.TAX
+    assert result.routable is True
+    assert result.decisive is False
+
+
+def test_strong_marker_alone_still_routes() -> None:
+    """INNOCENCE: one non-weak marker is enough, as it always was.
+
+    Nobody writes "work permit" by accident, which is the whole distinction
+    this rule turns on.
+    """
+    result = classify("Question", "I need help with a work permit for my staff.")
+    assert result.intent is Intent.VISA
+    assert result.routable is True
+
+
+def test_decisive_instrument_is_never_blocked_by_the_weak_rule() -> None:
+    """INNOCENCE: the decisive path runs first and is untouched.
+
+    A message carrying NPWP and nothing else routes, even though `tax` — the
+    weak word — is absent. The rule must not have become a second gate in
+    front of the instruments.
+    """
+    result = classify("Registration", "Attached is the NPWP for the company.")
+    assert result.intent is Intent.TAX
+    assert result.decisive is True
+    assert result.routable is True
+
+
+def test_weak_markers_still_score() -> None:
+    """A weak marker is demoted, not deleted.
+
+    Two markers in one lane — one weak, one strong — must beat a single strong
+    marker in another. If weak hits stopped counting, this would tie and the
+    tie-breaker would refuse.
+    """
+    result = classify(
+        "Mixed",
+        "About the tax return, and separately please send the invoice.",
+    )
+    assert result.intent is Intent.TAX
+    assert result.routable is True
+
+
+def test_weak_set_contains_no_phantom_markers() -> None:
+    """Every weak token must be a marker that actually exists (W65).
+
+    A weak entry naming a token no lane carries is dead text: it looks like a
+    defence, defends nothing, and quietly survives a rename of the real marker.
+    """
+    known = {marker for markers in _MARKERS.values() for marker in markers}
+    phantom = sorted(_WEAK - known)
+    assert phantom == [], f"weak markers absent from _MARKERS: {phantom}"
+
+
+def test_no_marker_is_both_decisive_and_weak() -> None:
+    """The two sets make opposite claims about the same token.
+
+    `_DECISIVE` says "one hit settles it"; `_WEAK` says "one hit settles
+    nothing". A token in both would be a contradiction the decisive path wins
+    by accident of ordering, which is not a decision anybody made.
+    """
+    decisive = {token for tokens in _DECISIVE.values() for token in tokens}
+    both = sorted(decisive & _WEAK)
+    assert both == [], f"markers claimed as decisive AND weak: {both}"

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_classify.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_classify.py
@@ -32,6 +32,7 @@ import pytest
 from backend.services.mail_loop.classify import (
     _DECISIVE,
     _MARKERS,
+    _NEEDS_CORROBORATION,
     _WEAK,
     Intent,
     classify,
@@ -336,8 +337,18 @@ def test_ambiguous_soft_markers_refuse_to_guess() -> None:
     """A soft tie is UNKNOWN, and UNKNOWN is left in the inbox.
 
     Routing a message we do not understand is worse than leaving it visible.
+
+    Both lanes must be tied on NON-weak markers for this to be the property it
+    claims. The original example paired `immigration` against `taxes`, and once
+    weak-only lanes began stepping aside it stopped being a tie at all — the tax
+    lane withdrew and `immigration` decided, correctly. The property survived;
+    only the example had quietly stopped exercising it.
     """
-    result = classify("Hello", "A question about immigration and about taxes.")
+    result = classify("Hello", "A question about immigration and about a leasehold.")
+    assert result.markers == {"visa": ["immigration"], "property": ["leasehold"]}, (
+        "premise: this must be a 1-1 tie between two lanes that both carry a "
+        "non-weak marker, or the test is measuring something else"
+    )
     assert result.intent is Intent.UNKNOWN
     assert result.folder is None
     assert result.routable is False
@@ -544,3 +555,152 @@ def test_no_marker_is_both_decisive_and_weak() -> None:
     decisive = {token for tokens in _DECISIVE.values() for token in tokens}
     both = sorted(decisive & _WEAK)
     assert both == [], f"markers claimed as decisive AND weak: {both}"
+
+
+# --------------------------------------------------------------------------- #
+# A weak-only lane steps ASIDE. It does not poison the message.               #
+#                                                                             #
+# All of the following were found by adversarial review of the first version  #
+# of this rule, each with a measured case. The defect was placement: the check #
+# ran AFTER the winner was chosen, so a lane made entirely of coincidence      #
+# could win the count and then collapse the whole verdict to UNKNOWN — taking  #
+# a strong marker in a losing lane down with it.                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_a_weak_lane_does_not_drag_down_a_strong_one() -> None:
+    """The case the first version got wrong, verbatim.
+
+    ADMIN wins the raw count 2-1 on `appointment` + `meeting`, both weak. VISA
+    holds `work permit`, which is not. Withdrawing ADMIN must leave VISA, not
+    UNKNOWN — anything else discards the one marker that was actually right.
+    """
+    result = classify(
+        "Question",
+        "I need help with a work permit for my staff. Could we set a meeting "
+        "or an appointment next week?",
+    )
+    assert result.markers["admin"] == ["appointment", "meeting"], "premise: admin wins the count"
+    assert result.intent is Intent.VISA
+    assert result.routable is True
+
+
+def test_two_weak_lanes_and_one_strong_still_resolves() -> None:
+    """Withdrawal is not a tie-breaker of last resort — it applies per lane."""
+    result = classify(
+        "Mixed",
+        "About the leasehold on the land. Also the tax, and let us set a meeting.",
+    )
+    assert result.intent is Intent.PROPERTY
+    assert result.routable is True
+
+
+def test_everything_weak_is_still_unknown() -> None:
+    """GUILT survives the reorder: nothing non-weak anywhere means UNKNOWN."""
+    result = classify(
+        "Statement",
+        "Total due: 100 EUR, tax included. Shall we set a meeting to discuss?",
+    )
+    assert result.intent is Intent.UNKNOWN
+    assert result.routable is False
+
+
+# --------------------------------------------------------------------------- #
+# Short decisive codes need a second opinion.                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_a_permit_index_inside_an_address_does_not_decide_a_lane() -> None:
+    """GUILT: `C2` is a visa index AND how this island writes an address.
+
+    The decisive path returns before every other check, so an uncorroborated
+    two-character hit moved mail with nothing to appeal to.
+    """
+    result = classify(
+        "Delivery",
+        "Please deliver the documents to Villa C2, Jalan Raya, before Friday.",
+    )
+    assert result.intent is not Intent.VISA
+    assert result.decisive is False
+
+
+def test_a_corroborated_permit_index_still_decides() -> None:
+    """INNOCENCE, and the reason this costs nothing.
+
+    Measured over 106 live messages: `c1` fired 15 times and never once alone.
+    Real visa mail names the index beside something else, so corroboration
+    removes the address case without losing a routing.
+    """
+    result = classify(
+        "Application",
+        "We are applying for a C1 visa and need the sponsor letter.",
+    )
+    assert result.intent is Intent.VISA
+    assert result.decisive is True
+
+
+def test_long_instruments_never_need_corroboration() -> None:
+    """INNOCENCE: nobody writes `kitas` or `npwp` by accident.
+
+    Without this, widening `_NEEDS_CORROBORATION` to the whole decisive set
+    would pass the guilt case above while gutting the lane.
+    """
+    assert classify("X", "About my KITAS.").decisive is True
+    assert classify("X", "Attached is the NPWP.").decisive is True
+
+
+def test_corroboration_set_is_a_subset_of_decisive() -> None:
+    """A corroboration rule naming a non-decisive token guards nothing (W65)."""
+    decisive = {token for tokens in _DECISIVE.values() for token in tokens}
+    phantom = sorted(_NEEDS_CORROBORATION - decisive)
+    assert phantom == [], f"corroboration named for non-decisive tokens: {phantom}"
+
+
+# --------------------------------------------------------------------------- #
+# Homographs: the marker IS the ordinary word, not a substring of it.         #
+#                                                                             #
+# The generated landmine corpus at the top of this file cannot reach these.   #
+# `_landmines()` keeps pairs where `marker in low and marker != low`, a STRICT #
+# substring — so a marker that equals a whole ordinary word is structurally    #
+# outside the sweep. That is exactly the class `_WEAK` exists for, which is    #
+# why these are written by hand.                                              #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("case_id", "body", "forbidden"),
+    [
+        ("ho-visto-means-i-saw", "Buongiorno, ho visto il vostro sito e vorrei informazioni.", Intent.VISA),
+        ("ci-siamo-visti-means-we-met", "Ci siamo visti la settimana scorsa in ufficio.", Intent.VISA),
+        ("tanah-lot-is-a-landmark", "Company outing to Tanah Lot next month, who is coming?", Intent.PROPERTY),
+        ("direktur-is-a-signature", "Salam,\nBudi Santoso\nDirektur Utama", Intent.PT_PMA),
+        ("imposte-are-also-shutters", "Le imposte delle finestre sono rotte, chi le ripara?", Intent.TAX),
+        ("fiscal-year-is-boilerplate", "Summary for the fiscal year ending 31 December.", Intent.TAX),
+        ("a-call-link-is-furniture", "Here is my zoom link for later, talk soon.", Intent.ADMIN),
+    ],
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_homograph_does_not_route(case_id: str, body: str, forbidden: Intent) -> None:
+    result = classify("", body)
+    assert result.intent is not forbidden, (
+        f"{case_id}: routed to {forbidden.value} on a homograph "
+        f"(markers={result.markers})"
+    )
+
+
+def test_the_recall_cost_of_the_weak_set_is_visible() -> None:
+    """The bill for all of the above, written down where it cannot be ignored.
+
+    These are real enquiries that USED to route and now sit in the inbox. That
+    is the deliberate trade — a message left visible costs a human one glance,
+    a message filed wrongly costs them the message. Anyone widening `_WEAK`
+    further should have to update this list and see what they are buying.
+    """
+    stays_in_inbox = [
+        "We are looking to buy a villa in Ubud, what are the options?",
+        "Vorrei informazioni su come ottenere un visto.",
+        "Domanda sul soggiorno a Bali.",
+        "Question about the OSS system.",
+    ]
+    for body in stays_in_inbox:
+        assert classify("", body).routable is False, body

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_preflight_and_env.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_preflight_and_env.py
@@ -354,3 +354,73 @@ def test_an_ordinary_degraded_run_is_not_a_blocker() -> None:
 
 def test_no_errors_is_not_a_blocker() -> None:
     assert cli_module._consent_blocker([]) is None
+
+
+# --------------------------------------------------------------------------- #
+# The client's message goes in on STDIN, never on the command line.           #
+#                                                                             #
+# A process's argv is world-readable on macOS: `ps -A -ww -o args` returns the #
+# full command line of every process regardless of owner. Passing the prompt   #
+# as `-p <prompt>` published a client's mail — name, address, whole body — to  #
+# every account on the machine for up to TIMEOUT_SECONDS.                     #
+#                                                                             #
+# Same threat model as the two subject-bearing log lines cured alongside, with #
+# a strictly larger payload. SYMBIOSIS Law 2 / UU PDP Art. 67-68.             #
+# --------------------------------------------------------------------------- #
+
+_ARGV_CANARY = "Zzcanary-Quenneville-77"
+
+
+def _canary_request() -> draft_module.DraftRequest:
+    return draft_module.DraftRequest(
+        subject=f"KITAS renewal for {_ARGV_CANARY}",
+        body=f"{_ARGV_CANARY} here, what documents do you need?",
+        sender_name="someone@example.com",
+        language="en",
+        intent="visa",
+        style_block="(none)",
+    )
+
+
+def test_the_prompt_never_reaches_the_command_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GUILT: the client's words must not be visible to `ps`."""
+    monkeypatch.setenv("CLAUDE_CLI_PATH", "/fake/claude")
+    seen: dict[str, Any] = {}
+
+    def fake_run(argv: list[str], **kwargs: Any) -> _Completed:
+        seen["argv"] = argv
+        seen["input"] = kwargs.get("input")
+        return _Completed(0, stdout="Dear client, ...")
+
+    monkeypatch.setattr(draft_module.subprocess, "run", fake_run)
+    draft_module.generate(_canary_request())
+
+    joined = " ".join(seen["argv"])
+    assert _ARGV_CANARY not in joined, f"the client's text is in argv: {joined!r}"
+
+
+def test_the_prompt_arrives_on_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """INNOCENCE: privacy is not amnesia — the model must still get the prompt.
+
+    Without this, deleting the prompt entirely would pass the test above while
+    producing drafts about nothing.
+    """
+    monkeypatch.setenv("CLAUDE_CLI_PATH", "/fake/claude")
+    seen: dict[str, Any] = {}
+
+    def fake_run(argv: list[str], **kwargs: Any) -> _Completed:
+        seen["argv"] = argv
+        seen["input"] = kwargs.get("input")
+        return _Completed(0, stdout="Dear client, ...")
+
+    monkeypatch.setattr(draft_module.subprocess, "run", fake_run)
+    draft_module.generate(_canary_request())
+
+    assert seen["input"], "no prompt was passed at all"
+    assert _ARGV_CANARY in seen["input"], "the prompt reached the model without the message"
+    # And the invocation is still the CLI in print mode, on the pinned model —
+    # a `-p` that lost its flag would read stdin as an interactive session.
+    assert seen["argv"][:2] == ["/fake/claude", "-p"]
+    assert draft_module.CLAUDE_MODEL in seen["argv"]

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_state_privacy.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_state_privacy.py
@@ -248,9 +248,15 @@ def test_style_file_lands_owner_only(tmp_path: Path) -> None:
     (W107 — the cure went to one wrapper out of five).
     """
     store = ReplyStyleStore(tmp_path / "deep" / "reply-style.md")
-    assert store.append(
+    # The call is deliberately OUTSIDE the assert. `python -O` strips assert
+    # statements, so a write hidden inside one simply would not happen, and
+    # everything below would fail for a reason that has nothing to do with the
+    # file mode. CodeQL flags exactly this (py/side-effect-in-assert) and it is
+    # right to.
+    stored = store.append(
         Lesson(bucket="visa/en", text="Keeps replies short.", observed_on=today())
-    ), "premise: the lesson must survive redaction, or nothing gets written"
+    )
+    assert stored, "premise: the lesson must survive redaction, or nothing gets written"
 
     path = tmp_path / "deep" / "reply-style.md"
     assert path.exists()

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_state_privacy.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_state_privacy.py
@@ -25,12 +25,14 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import stat
 from pathlib import Path
 
 import pytest
 
 from backend.services.mail_loop import draft as draft_module
+from backend.services.mail_loop import state_io as state_io_module
 from backend.services.mail_loop.loop import MailLoop, PendingDrafts
 from backend.services.mail_loop.state_io import DIR_MODE, FILE_MODE, write_private
 from backend.services.mail_loop.style import Lesson, ReplyStyleStore, today
@@ -273,3 +275,116 @@ def test_folders_fixture_is_reused_not_redefined() -> None:
     the thing it stands in for).
     """
     assert any(f.get("folder_name") == "_Visa" for f in FOLDERS)
+
+
+# --------------------------------------------------------------------------- #
+# The temp file, not just the destination.                                     #
+#                                                                             #
+# The first version of write_private chmod'd AFTER writing, and its docstring  #
+# claimed the bytes were never observable at a wider mode. Adversarial review  #
+# measured that and it was false. These tests measure the claim instead of     #
+# reading it.                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_the_temp_file_holds_the_content_at_owner_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GUILT: intercept the rename and look at what is on disk right then.
+
+    This is the only moment the intermediate file exists, so it is the only
+    place the "never at a wider mode" claim can be checked. A version that
+    writes first and tightens afterwards fails here.
+    """
+    observed: dict[str, int] = {}
+    original = Path.replace
+
+    def spy(self: Path, target):  # type: ignore[no-untyped-def]
+        observed["mode"] = stat.S_IMODE(self.stat().st_mode)
+        observed["bytes"] = self.stat().st_size
+        return original(self, target)
+
+    monkeypatch.setattr(Path, "replace", spy)
+    write_private(tmp_path / "deep" / "state.json", json.dumps({"secret": "x" * 50}))
+
+    assert observed["bytes"] > 0, "premise: the content must already be written"
+    assert observed["mode"] == FILE_MODE
+
+
+def test_every_created_directory_level_is_owner_only(tmp_path: Path) -> None:
+    """GUILT: a 0700 leaf inside a 0755 parent still publishes the leaf's name.
+
+    `mkdir(mode=...)` only applies to levels this call creates, and umask masks
+    it, so each one is tightened explicitly. Both existing mode tests create a
+    single level; this is the multi-level case they could not reach.
+    """
+    write_private(tmp_path / "a" / "b" / "c" / "state.json", "{}")
+
+    for level in ("a", "a/b", "a/b/c"):
+        path = tmp_path / level
+        assert stat.S_IMODE(path.stat().st_mode) == DIR_MODE, level
+
+
+def test_write_private_refuses_to_chmod_your_home_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GUILT: writing one state file must not tighten $HOME machine-wide.
+
+    Reachable by pointing --state-dir or MAIL_LOOP_STATE_DIR at the home
+    directory itself. Nothing in this repo does, which is exactly why it would
+    go unnoticed.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(mode=0o755)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    with pytest.raises(ValueError, match="home directory"):
+        write_private(fake_home / "state.json", "{}")
+
+    assert stat.S_IMODE(fake_home.stat().st_mode) == 0o755, "HOME was modified anyway"
+
+
+def test_a_subdirectory_of_home_is_still_allowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INNOCENCE: the real default lives under $HOME and must keep working.
+
+    `~/.nuzantara/mail-loop/` is where this actually writes. A refusal that
+    caught the normal case would disable the organ, not protect it.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(mode=0o755)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    write_private(fake_home / ".nuzantara" / "mail-loop" / "state.json", "{}")
+
+    target = fake_home / ".nuzantara" / "mail-loop" / "state.json"
+    assert stat.S_IMODE(target.stat().st_mode) == FILE_MODE
+    assert stat.S_IMODE(fake_home.stat().st_mode) == 0o755, "HOME must be untouched"
+
+
+def test_a_failed_write_leaves_no_temp_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INNOCENCE: a crash mid-write must not litter a private file behind.
+
+    A leftover temp is not just untidy — it is a second copy of the content
+    nobody will ever look at again.
+    """
+    target = tmp_path / "state.json"
+
+    class _Boom(Exception):
+        pass
+
+    real_chmod = os.chmod
+
+    def exploding_chmod(path, mode):  # type: ignore[no-untyped-def]
+        if str(path).endswith(".tmp"):
+            raise _Boom("disk full")
+        return real_chmod(path, mode)
+
+    monkeypatch.setattr(state_io_module.os, "chmod", exploding_chmod)
+    with pytest.raises(_Boom):
+        write_private(target, "{}")
+
+    assert list(tmp_path.iterdir()) == [], "a temp file survived the failure"

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_state_privacy.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_state_privacy.py
@@ -1,0 +1,269 @@
+"""What the loop leaves behind must not name anybody, and must not be readable.
+
+Two defences, one concern. SYMBIOSIS Law 2 (UU PDP Art. 67-68) is absolute about
+persisted artifacts, and an email subject is client data in the plainest sense —
+"KITAS renewal for <person>" is an ordinary subject line in this mailbox.
+
+  * LOG PRIVACY. The loop's log is world-readable on the Pro and is tailed by
+    other organs. Two lines used to interpolate the subject: one on a draft
+    failure (truncated to 40 characters, which is not redaction, only a smaller
+    leak) and one on the dry-run draft line (the full subject). Both are now
+    identified by the opaque message id and the lane.
+
+  * FILE MODE. `pending-drafts.json` holds the reply text we generated, which
+    opens with a salutation and therefore carries a name. Left to the default
+    umask it lands 0644 in a 0755 directory — superscar #4, waiting for the
+    first backup, sync client or second account on the machine.
+
+Both halves carry guilt AND innocence. The innocence half matters more than
+usual here: a log that says nothing at all would pass a naive leak test while
+being useless to whoever is debugging the organ at 07:30.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import stat
+from pathlib import Path
+
+import pytest
+
+from backend.services.mail_loop import draft as draft_module
+from backend.services.mail_loop.loop import MailLoop, PendingDrafts
+from backend.services.mail_loop.state_io import DIR_MODE, FILE_MODE, write_private
+from backend.services.mail_loop.style import Lesson, ReplyStyleStore, today
+from backend.tests.unit.services.mail_loop.test_loop import (
+    FOLDERS,
+    FakeBackend,
+    _msg,
+    stub_model,  # noqa: F401  -- imported so pytest resolves it as a fixture here
+)
+
+# A string no marker table, folder name or log template could produce by
+# accident, so its presence in a log can only mean the subject was echoed.
+CANARY = "Zzcanary-Quenneville-77"
+
+
+def _loop(backend: FakeBackend, tmp_path: Path, *, dry_run: bool) -> MailLoop:
+    return MailLoop(
+        backend,
+        user_id="zero",
+        style=ReplyStyleStore(tmp_path / "reply-style.md"),
+        pending=PendingDrafts(tmp_path / "pending.json"),
+        dry_run=dry_run,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Log privacy.                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_dry_run_log_does_not_echo_the_subject(
+    tmp_path: Path, stub_model: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """GUILT: the dry-run draft line named the message, subject and all."""
+    backend = FakeBackend(
+        inbox=[_msg("m1", f"KITAS renewal — {CANARY}", "a@x.example", "T1")],
+        bodies={"m1": "My KITAS expires next month, what do you need?"},
+    )
+    with caplog.at_level(logging.DEBUG, logger="backend.services.mail_loop.loop"):
+        summary = asyncio.run(_loop(backend, tmp_path, dry_run=True).run())
+
+    assert summary.drafted == 1, "premise: this run must actually reach the draft line"
+    assert CANARY not in caplog.text
+
+
+def test_draft_failure_log_does_not_echo_the_subject(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """GUILT: the failure path leaked the subject's first 40 characters.
+
+    A truncated leak is still a leak, and 40 characters is more than enough for
+    a name.
+    """
+
+    def _boom(request, dry_run: bool = False):  # type: ignore[no-untyped-def]
+        raise draft_module.DraftUnavailable("model refused")
+
+    monkeypatch.setattr(draft_module, "generate", _boom)
+    monkeypatch.setattr("backend.services.mail_loop.loop.generate", _boom)
+
+    backend = FakeBackend(
+        inbox=[_msg("m1", f"{CANARY} needs a KITAS", "a@x.example", "T1")],
+        bodies={"m1": "My KITAS expires next month, what do you need?"},
+    )
+    with caplog.at_level(logging.DEBUG, logger="backend.services.mail_loop.loop"):
+        summary = asyncio.run(_loop(backend, tmp_path, dry_run=True).run())
+
+    assert summary.draft_failures == 1, "premise: this run must hit the failure path"
+    assert CANARY not in caplog.text
+
+
+def _lines_about(caplog: pytest.LogCaptureFixture, needle: str) -> list[str]:
+    """Log lines mentioning `needle`, so an assertion names ONE line.
+
+    Written after a mutation run caught this file lying: the first version of
+    the innocence check below asserted that the id and the lane appeared
+    "somewhere in caplog", and deleting the draft line outright left the suite
+    green — the ROUTING line a few statements earlier carries the same id and
+    the same lane. A test that accepts any line is not testing a line.
+    """
+    return [line for line in caplog.text.splitlines() if needle in line]
+
+
+def test_the_draft_log_line_still_identifies_the_message(
+    tmp_path: Path, stub_model: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """INNOCENCE: privacy is not silence.
+
+    Without this, deleting the draft log line would pass the leak tests above
+    while leaving whoever debugs this organ at 07:30 with nothing. The line
+    must still exist and still say WHICH message and WHICH lane.
+    """
+    backend = FakeBackend(
+        inbox=[_msg("m1", f"KITAS renewal — {CANARY}", "a@x.example", "T1")],
+        bodies={"m1": "My KITAS expires next month, what do you need?"},
+    )
+    with caplog.at_level(logging.DEBUG, logger="backend.services.mail_loop.loop"):
+        asyncio.run(_loop(backend, tmp_path, dry_run=True).run())
+
+    drafted = _lines_about(caplog, "draft")
+    assert drafted, "the draft line was removed, not redacted"
+    assert any("m1" in line for line in drafted), "the opaque id must survive"
+    assert any("visa" in line for line in drafted), "the lane must survive"
+
+
+def test_the_failure_log_line_still_identifies_the_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """INNOCENCE for the other redacted line, for the same reason.
+
+    Two lines were changed; covering one is half a fix (W107).
+    """
+
+    def _boom(request, dry_run: bool = False):  # type: ignore[no-untyped-def]
+        raise draft_module.DraftUnavailable("model refused")
+
+    monkeypatch.setattr(draft_module, "generate", _boom)
+    monkeypatch.setattr("backend.services.mail_loop.loop.generate", _boom)
+
+    backend = FakeBackend(
+        inbox=[_msg("m1", f"{CANARY} needs a KITAS", "a@x.example", "T1")],
+        bodies={"m1": "My KITAS expires next month, what do you need?"},
+    )
+    with caplog.at_level(logging.DEBUG, logger="backend.services.mail_loop.loop"):
+        asyncio.run(_loop(backend, tmp_path, dry_run=True).run())
+
+    failed = _lines_about(caplog, "no draft for")
+    assert failed, "the failure line was removed, not redacted"
+    assert any("m1" in line for line in failed), "the opaque id must survive"
+    assert any("visa" in line for line in failed), "the lane must survive"
+
+
+def test_no_sender_address_reaches_the_log(
+    tmp_path: Path, stub_model: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """GUILT: an address is PII too, and is easier to leak by accident."""
+    backend = FakeBackend(
+        inbox=[_msg("m1", "KITAS renewal", "canary.person@example.invalid", "T1")],
+        bodies={"m1": "My KITAS expires next month, what do you need?"},
+    )
+    with caplog.at_level(logging.DEBUG, logger="backend.services.mail_loop.loop"):
+        asyncio.run(_loop(backend, tmp_path, dry_run=True).run())
+
+    assert "canary.person@example.invalid" not in caplog.text
+
+
+# --------------------------------------------------------------------------- #
+# File mode.                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_write_private_creates_owner_only_file_and_dir(tmp_path: Path) -> None:
+    """GUILT: both the file and its parent are tightened, not just the file."""
+    target = tmp_path / "nested" / "state.json"
+    write_private(target, json.dumps({"a": 1}))
+
+    assert stat.S_IMODE(target.stat().st_mode) == FILE_MODE
+    assert stat.S_IMODE(target.parent.stat().st_mode) == DIR_MODE
+    assert json.loads(target.read_text()) == {"a": 1}
+
+
+def test_write_private_tightens_an_already_loose_directory(tmp_path: Path) -> None:
+    """GUILT: `mkdir(exist_ok=True)` does nothing to a directory that exists.
+
+    A state dir created by an older version of this code — or by a human —
+    stays 0755 unless the mode is applied unconditionally.
+    """
+    loose = tmp_path / "loose"
+    loose.mkdir(mode=0o755)
+    write_private(loose / "state.json", "{}")
+
+    assert stat.S_IMODE(loose.stat().st_mode) == DIR_MODE
+
+
+def test_write_private_leaves_no_temp_file_behind(tmp_path: Path) -> None:
+    """INNOCENCE: the atomic write must not litter.
+
+    A stale `.tmp` sitting at the default mode would reintroduce exactly the
+    exposure this helper removes.
+    """
+    target = tmp_path / "state.json"
+    write_private(target, "{}")
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["state.json"]
+
+
+def test_write_private_replaces_rather_than_appends(tmp_path: Path) -> None:
+    """INNOCENCE: a second write is a replacement, not a concatenation."""
+    target = tmp_path / "state.json"
+    write_private(target, json.dumps({"round": 1}))
+    write_private(target, json.dumps({"round": 2}))
+
+    assert json.loads(target.read_text()) == {"round": 2}
+
+
+def test_pending_buffer_lands_owner_only(tmp_path: Path) -> None:
+    """The helper is actually WIRED, not merely present.
+
+    Written against the real `PendingDrafts`, because a private-write helper
+    nobody calls is the shape of a defence that exists and is not armed.
+    """
+    pending = PendingDrafts(tmp_path / "deep" / "pending-drafts.json")
+    pending.add("T1", text="Dear client, ...", bucket="visa/en")
+
+    path = tmp_path / "deep" / "pending-drafts.json"
+    assert path.exists()
+    assert stat.S_IMODE(path.stat().st_mode) == FILE_MODE
+    assert stat.S_IMODE(path.parent.stat().st_mode) == DIR_MODE
+
+
+def test_style_file_lands_owner_only(tmp_path: Path) -> None:
+    """Same wiring check for the other writer.
+
+    Two call sites were changed; a test that only covers one is half a fix
+    (W107 — the cure went to one wrapper out of five).
+    """
+    store = ReplyStyleStore(tmp_path / "deep" / "reply-style.md")
+    assert store.append(
+        Lesson(bucket="visa/en", text="Keeps replies short.", observed_on=today())
+    ), "premise: the lesson must survive redaction, or nothing gets written"
+
+    path = tmp_path / "deep" / "reply-style.md"
+    assert path.exists()
+    assert stat.S_IMODE(path.stat().st_mode) == FILE_MODE
+    assert stat.S_IMODE(path.parent.stat().st_mode) == DIR_MODE
+
+
+def test_folders_fixture_is_reused_not_redefined() -> None:
+    """The imports above are load-bearing; keep them honest.
+
+    If `test_loop` stops exporting the shared fixtures, this file must fail
+    loudly rather than silently drift onto a private copy that agrees with
+    nothing (the W114 lesson: a fixture is evidence only when it is shared with
+    the thing it stands in for).
+    """
+    assert any(f.get("folder_name") == "_Visa" for f in FOLDERS)

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`332 routers · 679 services · 1284 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`332 routers · 680 services · 1285 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/docs/runbooks/zoho-mail-loop.md
+++ b/docs/runbooks/zoho-mail-loop.md
@@ -427,3 +427,132 @@ carried its **own hardcoded copy** of the scope list
 had drifted from `ZohoOAuthService.SCOPES`. That endpoint is the one humans are
 sent to; the mail loop names it verbatim in its own error message. It now builds
 the scope from the service's list, pinned by `test_zoho_consent_scope.py`.
+
+## 10. Six of seven live routings rested on a coincidence
+
+Once the loop could finally read the mailbox (§9), the next question was not
+_does it route_ but _on what_. Measured on the real inbox, not reasoned:
+
+> **7 of 13 messages routed, and 6 of those 7 won their lane on a single soft
+> marker** — five on `tax`, one on `meeting` — with **no decisive instrument
+> anywhere in the run**.
+
+`tax` sits in the footer of every invoice, receipt and SaaS bill ever sent. The
+loop was filing client mail into `_Tax` on the strength of a vendor's small
+print. The routing **rate** said the organ was working; the routing **basis**
+said it was guessing.
+
+### The rule the code already contained
+
+`_DECISIVE` defines a strong instrument as one with _"no ordinary-language twin,
+so a single hit is not a coincidence"_. The contrapositive is in that same
+comment and was never enforced: a soft marker's single hit **can** be a
+coincidence, and the count path routed on it anyway — one hit against a
+runner-up of zero.
+
+Winning a landslide of one is not evidence. A lane whose hits are all **weak**
+now steps aside. Weak markers still **score** — they break ties and confirm
+strong ones — they simply cannot be the sole reason to move somebody's mail.
+
+### Step aside, do not poison — the defect in the first version
+
+The first cut checked for weak-only **after** picking the winner, and
+adversarial review broke it with a measured case:
+
+> `"I need help with a work permit for my staff. Could we set a meeting or an
+appointment next week?"`
+
+ADMIN wins the count 2-1 on `appointment` + `meeting`, both weak; VISA holds
+`work permit`, which is not. Checking afterwards collapsed the **whole verdict**
+to UNKNOWN, discarding the one marker that was right. Weak-only lanes are now
+dropped **before** ranking, so UNKNOWN happens only when nothing non-weak
+survives anywhere — which is what the rule always claimed and now does.
+
+Closing that hole moved a second one rather than shutting it: an uncorroborated
+short permit index, denied the decisive path, simply won the count path instead.
+Both paths now ask the same question, in `_lane_is_credible`.
+
+### Short decisive codes need a second opinion
+
+`C2` and `D12` are visa indexes. They are also how this island writes an
+address — _"Villa C2, Jalan Raya"_ — and the decisive path returns before every
+other check, so one accidental hit moved mail with nothing to appeal to.
+
+`_NEEDS_CORROBORATION` keeps them decisive but only alongside another marker in
+the same lane. This costs nothing measurable: over 106 live messages `c1` fired
+**15 times and never once alone**, `pma` 3 of 3.
+
+### Was it tuned into silence? No — it got slightly better
+
+One morning's unread mail is too thin to answer that; those 13 were mostly
+noise. Measured over **106 messages** (Inbox plus Sent, since every sent message
+is a reply to a genuine enquiry):
+
+|                 | decisive instrument | strong soft marker | left for a human |
+| --------------- | ------------------- | ------------------ | ---------------- |
+| Inbox (46)      | 11                  | 10                 | 25               |
+| Sent (60)       | 30                  | 19                 | 11               |
+| **Total (106)** | **41**              | **30**             | **36**           |
+
+**71 of 106 still route** — three MORE than the first version of the rule
+allowed, because a weak lane stepping aside now leaves a strong one standing
+instead of taking it down. Carried by real instruments: `kitas` x16, `c1` x12,
+`npwp` x4, `pt pma` x3, `sktt` x2, `e33g` x2, `kbli` x1.
+
+The declared cost is pinned in `test_the_recall_cost_of_the_weak_set_is_visible`:
+a bare "buy a villa in Ubud", a bare Italian "visto", `soggiorno` and `oss` now
+stay in the inbox. A message left visible costs a human one glance; a message
+filed wrongly costs them the message.
+
+### Three Law 2 leaks closed, and the biggest was not a log
+
+Two log lines interpolated the **email subject** — one truncated to 40
+characters (a smaller leak, not redaction), one in full.
+
+The third was larger and was found by the same review: `draft.py` passed the
+prompt as `claude -p <prompt>`, putting the client's whole message — name,
+address, body — on the **process command line**, which is world-readable on
+macOS (`ps -A -ww -o args` returned the argv of 299 processes owned by other
+users on this machine). It goes in on **stdin** now; verified live that
+`claude -p` reads it there.
+
+The two state files were also landing `0644` in a `0755` directory. They are
+written by `state_io.write_private`, created at `0600` by `tempfile.mkstemp`
+rather than chmod'd afterwards — the first version did chmod afterwards and its
+docstring claimed the bytes were "never observable at a wider mode", which the
+review measured and disproved. The claim is true now because the code changed,
+not because the wording softened.
+
+### What the mutations caught
+
+| mutation                               | tests red |
+| -------------------------------------- | --------- |
+| weak/credibility filter removed        | 12        |
+| corroboration set emptied              | 1         |
+| prompt put back into argv              | 1         |
+| chmod-after-write restored             | 5         |
+| subject put back in the draft log line | 1         |
+| draft log line deleted outright        | 1         |
+| failure log line deleted outright      | 1         |
+
+The last two matter most. The **first** innocence check asserted the id and lane
+appeared _"somewhere in caplog"_, and deleting the draft line outright left the
+suite **green** — the routing line a few statements earlier carries the same id
+and the same lane. A test that accepts any line is not testing a line.
+
+The corpus also caught two of its own rows going vacuous under the change:
+`test_negative_context_premise_holds` failed because a weak `villa` can no
+longer carry a lane in either direction, and
+`test_ambiguous_soft_markers_refuse_to_guess` had quietly stopped being a tie.
+Neither check was weakened — the villa suppression moved to the level where it
+still bites, and the tie example was rebuilt from two non-weak lanes.
+
+### Declared limits
+
+- Absence of a lone short-code routing across 106 messages is not proof it
+  cannot happen. It is evidence there was no live defect, which is why the
+  corroboration rule was added and nothing else in `_DECISIVE` was touched.
+- The generated landmine corpus cannot reach **homographs**: `_landmines()`
+  keeps pairs where the marker is a strict substring of an ordinary word, so a
+  marker that _equals_ a whole ordinary word (`visto`, `tanah`, `imposte`) is
+  structurally outside the sweep. Those rows are hand-written, and that is why.


### PR DESCRIPTION
Third and last of the mail-loop series (#3598, #3600). This one came out of
running the organ against the real mailbox and asking *why* it routed what it
routed.

## The number that started it

One live run: **7 messages routed, and 6 of them won their lane on a single
soft marker** — five on `tax`, one on `meeting` — with no decisive instrument
anywhere in the run.

`tax` is the word in the footer of every invoice, receipt and SaaS bill ever
sent. "Mentions tax" was filing a client's mail into `_Tax` on the strength of
a vendor's small print.

## The rule that was written and never enforced

`_DECISIVE` already says an instrument is strong because it has *"no
ordinary-language twin, so a single hit is not a coincidence"*. The
contrapositive is right there in the comment — a soft marker's single hit **can**
be a coincidence — and the count path routed on it anyway, one hit against a
runner-up of zero.

Winning a landslide of one is not evidence.

A lane whose every hit is **weak** now yields `UNKNOWN`, which this module
already treats as a first-class answer: the message stays in the inbox where a
human sees it. That was the module's stated preference; it is now the module's
behaviour.

Weak markers still **score** — they break ties and confirm strong ones. They
simply cannot be the sole reason to move somebody's mail. Every entry in
`_WEAK` is listed with the ordinary-language twin that makes it
coincidence-grade, and the set is guarded against phantoms (a weak token naming
a marker no lane carries) and against claiming a token that `_DECISIVE` also
claims.

**Live effect: 7/13 routed becomes 1/13.** The survivor is the one carrying two
strong markers (`invoice` + `receipt` → `_Admin`). The other six stay visible.

## Two Law 2 leaks, found while auditing the same package

Two log lines interpolated the **email subject** — one truncated to 40
characters (a smaller leak, not redaction), one in full. A subject in this
mailbox reads "KITAS renewal for &lt;person&gt;", the log is world-readable on the
Pro, and other organs tail it. Both lines now carry the opaque message id and
the lane, which is what someone debugging at 07:30 actually needs.

The two state files were landing `0644` inside a `0755` directory —
`pending-drafts.json` holds our own draft text and therefore a salutation.
One helper, `state_io.write_private`, writes both owner-only and atomically.
Superscar #4's own antidote is to enforce the mode **at write time** rather than
remember a `chmod` later.

## Mutation results, and what they caught

Each defence disabled in turn, against the package suite:

| mutation | red |
|---|---|
| weak-marker rule removed | 2 |
| `chmod` removed from `write_private` | 4 |
| subject put back in the draft log line | 1 |
| draft log line deleted outright | 1 |
| failure log line deleted outright | 1 |

The last two are the interesting ones. The **first** version of the innocence
check asserted the id and the lane appeared "somewhere in `caplog`", and
deleting the draft line outright left the suite **green** — the routing line a
few statements earlier carries the same id and the same lane. A test that
accepts any line is not testing a line. It now names the line.

## The corpus caught me too

Making `villa` weak made an existing negative-context row **vacuous**, and
`test_negative_context_premise_holds` said so: with suppression off the verdict
was `UNKNOWN`, not `PROPERTY`, so the row was no longer testing suppression.

A weak marker cannot carry a lane in either direction, so a verdict-level row
for it would have been green on both sides forever. Rather than weaken the
premise check, the villa suppression moved to the level where it still bites —
the marker list — with its own guilt and innocence halves, and a comment
explaining why it sits apart so nobody tidies it back.

## Why this was the blocker

`MAIL_LOOP_DRY_RUN` is still `1`. Flipping it means the loop moves real mail.
With six of seven routings resting on the word "tax", flipping would have been
indefensible. With the loop now acting only on evidence it can defend, it is a
decision that can be made on the merits.
