### PR TITLE
fix(seo): the phone Google reads was a departed employee's, not the CTA

### DIFF
--- a/apps/backend-rag/tests/integration/utils/test_response_sanitizer_integration.py
+++ b/apps/backend-rag/tests/integration/utils/test_response_sanitizer_integration.py
@@ -148,7 +148,7 @@ class TestResponseSanitizerIntegration:
         """Test that contact info is not duplicated"""
         from backend.utils.response_sanitizer import add_contact_if_appropriate
 
-        response = "Info here. Contact us on WhatsApp +62 859 0436 9574"
+        response = "Info here. Contact us on WhatsApp +62 821 3454 721"
         result = add_contact_if_appropriate(response, "business")
         # Should not add duplicate contact
         assert result.count("+62") == 1

--- a/apps/mouth/src/components/seo/DynamicJsonLd.tsx
+++ b/apps/mouth/src/components/seo/DynamicJsonLd.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import { SERVICES_DATA } from "@/data/services_data";
+import { WA_NUMBER } from "@/lib/whatsapp-utm";
 import { useEffect, useState } from "react";
 
 interface PageSchema {
@@ -39,7 +40,7 @@ export function DynamicJsonLd() {
           logo: `${baseUrl}/assets/logo/balizero-logo.png`,
           contactPoint: {
             "@type": "ContactPoint",
-            telephone: "+62-859-0436-9574",
+            telephone: `+${WA_NUMBER}`,
             contactType: "customer service",
             availableLanguage: ["English", "Indonesian"],
           },
@@ -121,7 +122,7 @@ export function DynamicJsonLd() {
           contactPoint: [
             {
               "@type": "ContactPoint",
-              telephone: "+62-859-0436-9574",
+              telephone: `+${WA_NUMBER}`,
               contactType: "customer service",
               availableLanguage: ["English", "Indonesian"],
               areaServed: "ID",

--- a/apps/mouth/src/components/seo/JsonLd.tsx
+++ b/apps/mouth/src/components/seo/JsonLd.tsx
@@ -6,6 +6,8 @@
  * to ensure JSON-LD is present in the static HTML for Googlebot and validators.
  */
 
+import { WA_NUMBER } from "@/lib/whatsapp-utm";
+
 const baseUrl = process.env.NEXT_PUBLIC_PUBLIC_URL || "https://balizero.com";
 
 // Organization schema - for brand presence
@@ -26,7 +28,7 @@ export function OrganizationJsonLd() {
     ],
     contactPoint: {
       "@type": "ContactPoint",
-      telephone: "+62-859-0436-9574",
+      telephone: `+${WA_NUMBER}`,
       contactType: "customer service",
       availableLanguage: ["English", "Indonesian"],
     },
@@ -60,7 +62,7 @@ export function LocalBusinessJsonLd() {
     name: "Bali Zero",
     image: `${baseUrl}/static/balizero-logo-clean.png`,
     url: baseUrl,
-    telephone: "+62-859-0436-9574",
+    telephone: `+${WA_NUMBER}`,
     email: "info@balizero.com",
     address: {
       "@type": "PostalAddress",

--- a/apps/mouth/src/lib/whatsapp-utm.ts
+++ b/apps/mouth/src/lib/whatsapp-utm.ts
@@ -9,7 +9,13 @@
  * Plan: docs/superpowers/plans/2026-04-19-seo-cell-A-prenatal-foundation.md Task 5
  */
 
-const WA_NUMBER = "628213454721";
+/**
+ * The public WhatsApp number, digits-only. Exported because the JSON-LD
+ * components need it as an E.164 `telephone` value: the number Google reads
+ * out of structured data has to be the same one the CTA buttons dial, and
+ * before this was shared they had drifted onto two different people.
+ */
+export const WA_NUMBER = "628213454721";
 
 export type Funnel = "home" | "visa" | "kbli" | "tax" | "property";
 


### PR DESCRIPTION
Every page on balizero.com served `schema.org` `contactPoint.telephone` = **`+62-859-0436-9574`**.

That number belongs to **Sahira**, whose `team_members` row reads `active=false` — she has left Bali Zero. So the number Google, Bing and every AI crawler ingest as the company's official phone has been an ex-employee's line, while the buttons on the same page dialled someone else.

**Live-proven before the fix**: `curl https://balizero.com | grep '"telephone"'` → `"telephone":"+62-859-0436-9574"` ×2, and 100% of the site's structured-data telephone values were this number.

## Why #3594 missed it

That sweep hunted *one number's digits*. This was a *different* number, in a field nobody classifies as a CTA. Four sites: `JsonLd.tsx:29` (Organization), `:63` (ProfessionalService), `DynamicJsonLd.tsx:42` (service pages) and `:124` (`/contact`).

## The shape of the fix

Rather than type the digits a fifth time, this **exports the `WA_NUMBER` constant `whatsapp-utm.ts` already holds** — the same one 14 CTA call-sites use — and renders it E.164. The structured data and the buttons can no longer drift onto two different people, which is precisely how this defect was born.

Also fixes the response-sanitizer integration fixture, which used the departed employee's number as its "response already contains a contact" sample.

**Left alone**: two dated 2026-03-27 brand-book documents that record the number as specified then.

## Verification

- `rg` separator-agnostic residual sweep outside `docs/`: **zero**
- `tsc --noEmit` on apps/mouth: pass
- pre-commit: prettier, ruff, import-chain, anti-reward-hacking, secrets: pass

## Found by the same census, NOT fixed here — these need the owner's ruling

A full phone-number census (5 lenses + attribution + 3 adversarial refuters) found the system carries **26 distinct numbers**, and four more live client-facing ones are unattributed:

| Number | Where | Why it needs a ruling |
|---|---|---|
| `628113990045` | **182 occurrences / 93 files**, 91 published articles in 5 languages, carrying most of the site's tappable `wa.me` links | exists in **zero** code/config/docs/tests/oracle — only in generated article prose. Same signature as the fabricated number already caught in #3594 |
| `6281338051876` | **342 occurrences / 142 files**, 124 articles + `llms.txt` (the AI-crawler surface) | documented as a *superseded* "Numero Principale — Meta API" and flagged `_RETIRED_WHATSAPP` in a tripwire, yet still advertised |
| `628213107363` | `visa_oracle.py` router, 25 occurrences, 7 languages | emitted to clients exactly when the Oracle abstains — the hottest lead moment. #3594 touched the *service*, not the *router* |
| `6285954680980` | WR2 Canva elegant-close slide default | stamped onto published Instagram carousels; contradicts the brand constitution, which names a different number for the same slide |

Two further findings recorded for follow-up: editing the MDX articles is a **no-op on the bot surface** without re-indexing the `balizero_news` Qdrant collection, and the published brochure PDF (Vino's number, 8×) is also base64-attached to every client welcome email from a second host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)