### PR TITLE
fix(kbli): the banner and the Google FAQ still said "open outside Bali" — 9 codes

### DIFF
--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -13,7 +13,7 @@ import {
   getKbliDatasetLastModified,
 } from "@/lib/kbli-data.server";
 import { formatTimeframe } from "@/lib/kbli-derive";
-import { baliBlockClause } from "@/lib/kbli-bali-block";
+import { baliBlockClause, isNationalClosure } from "@/lib/kbli-bali-block";
 import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 import { kbliMetaDescription, kbliMetaTitle } from "@/lib/kbli-meta";
 import { restrictedCapBadge } from "@/lib/kbli-pma-shape";
@@ -283,9 +283,16 @@ export default async function KBLICodePage({
               {/* PMA verdict banner — the binding answer for a PT PMA, aligned with the native app */}
               {(() => {
                 const baliBlocked = !!kbli.baliL4?.blocked;
+                // `pma.status` / `pma.maxForeign` are the annex-default fill,
+                // so they say TERBUKA/100 on records whose L4 verdict is a
+                // NATIONAL closure — the central bank among them. Reading them
+                // alone put "does not apply to a PT PMA in Bali" above an
+                // article saying the bar is nationwide. See isNationalClosure.
                 const nationallyClosed =
-                  !kbli.pma.capSpecial &&
-                  (kbli.pma.status === "closed" || kbli.pma.maxForeign === 0);
+                  isNationalClosure(kbli.baliL4?.status) ||
+                  (!kbli.pma.capSpecial &&
+                    (kbli.pma.status === "closed" ||
+                      kbli.pma.maxForeign === 0));
                 const pmaBlocked = baliBlocked || nationallyClosed;
                 return (
                   <>

--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -289,7 +289,7 @@ export default async function KBLICodePage({
                 // alone put "does not apply to a PT PMA in Bali" above an
                 // article saying the bar is nationwide. See isNationalClosure.
                 const nationallyClosed =
-                  isNationalClosure(kbli.baliL4?.status) ||
+                  isNationalClosure(kbli.baliL4?.status, kbli.code) ||
                   (!kbli.pma.capSpecial &&
                     (kbli.pma.status === "closed" ||
                       kbli.pma.maxForeign === 0));

--- a/apps/mouth/src/lib/kbli-bali-block.test.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.test.ts
@@ -10,6 +10,7 @@ import {
   narratesUnverifiedRoute,
   baliBlockedHint,
   isNationalClosure,
+  nationalClosureBasis,
 } from "./kbli-bali-block";
 import rawData from "../../data/KBLI_2025_FINAL_CLEAN.json";
 import goldData from "../../data/kbli-gold-all.json";
@@ -658,32 +659,74 @@ describe("isNationalClosure — the banner and the FAQ must not send a client to
   });
 
   it("INNOCENCE: no Bali-scoped block is turned into a national one", () => {
-    const baliScoped = BLOCKED.filter((r) =>
-      BALI_SCOPED.includes(r.l4_bali?.status ?? ""),
+    const baliScoped = BLOCKED.filter(
+      (r) =>
+        BALI_SCOPED.includes(r.l4_bali?.status ?? "") &&
+        // The 8 per-code adjudications ARE national and are supposed to be
+        // caught; excluding them keeps this test about the STATUS rule instead
+        // of quietly re-testing the code list.
+        nationalClosureBasis(r.kode_kbli_2025) === null,
     );
     // This is the set that would silently lose its Bali framing if the rule were
     // widened by "closed-sounding status" instead of by named entity.
     expect(baliScoped.length).toBeGreaterThan(100);
     const misclassified = baliScoped.filter((r) =>
-      isNationalClosure(r.l4_bali?.status),
+      isNationalClosure(r.l4_bali?.status, r.kode_kbli_2025),
     );
     expect(misclassified.map((r) => r.kode_kbli_2025)).toEqual([]);
   });
 
-  it("DECLARED GAP: TERTUTUP is mixed on the live data and stays Bali-framed", () => {
-    // `01287` says "closed to foreign ownership at the national level" while
-    // `01111` says "closed to PMA registration IN BALI". Judging all 68 by the
-    // name of the status would be the same form-over-entity move that produced
-    // the defect this rule fixes, so they wait for per-code adjudication.
-    // If this ever goes red, TERTUTUP stopped being mixed — re-read it and
-    // decide, do not just delete the test.
+  it("GUILT: the 8 per-code TERTUTUP adjudications each name their instrument", () => {
+    // A code list is data wearing code's clothes, so it earns its keep only if
+    // every entry stays auditable: the code must still be TERTUTUP on the live
+    // catalogue (otherwise the adjudication is stale and nobody would know) and
+    // must carry a stated basis. Read one by one — UU 18/2003 for advocates, UU
+    // 30/2004 for notaries, Kemenkes health law for solo practice, the WNI
+    // retail reservation, and the two national TERTUTUP/0% entries.
+    const adjudicated = [
+      "01287",
+      "47111",
+      "47112",
+      "59131",
+      "69102",
+      "69104",
+      "86201",
+      "86202",
+    ];
+    for (const code of adjudicated) {
+      const record = RECORDS.find((r) => r.kode_kbli_2025 === code);
+      expect(record, `${code} left the catalogue`).toBeDefined();
+      expect(record!.l4_bali?.status, `${code} is no longer TERTUTUP`).toBe(
+        "TERTUTUP",
+      );
+      expect(nationalClosureBasis(code)).toBeTruthy();
+      expect(isNationalClosure(record!.l4_bali?.status, code)).toBe(true);
+    }
+  });
+
+  it("DECLARED GAP: the other TERTUTUP records never state a scope at all", () => {
+    // The 68 split into 8 with a national legal basis, 2 that say "in Bali", and
+    // 58 whose reason is "medium-high/high risk -> not blocked by moratorium
+    // (verify per address)" — a sentence answering whether the MORATORIUM TEST
+    // fired, never where the closure applies. The record does not hold the fact,
+    // so no rule over `l4_bali` can invent it; those keep the Bali framing,
+    // which understates rather than misdirects.
+    // If this goes red the reasons gained a scope — read them and adjudicate,
+    // do not just delete the test.
     const tertutup = RECORDS.filter((r) => r.l4_bali?.status === "TERTUTUP");
     expect(tertutup.length).toBeGreaterThan(1);
-    const reasons = tertutup.map((r) =>
-      (r.l4_bali?.reason ?? "").toLowerCase(),
+    const unscoped = tertutup.filter(
+      (r) =>
+        nationalClosureBasis(r.kode_kbli_2025) === null &&
+        /not\s+blocked\s+by\s+moratorium/i.test(r.l4_bali?.reason ?? ""),
     );
-    expect(reasons.some((t) => t.includes("national level"))).toBe(true);
-    expect(reasons.some((t) => t.includes("in bali"))).toBe(true);
+    expect(unscoped.length).toBeGreaterThan(20);
+    for (const r of unscoped) {
+      expect(isNationalClosure(r.l4_bali?.status, r.kode_kbli_2025)).toBe(
+        false,
+      );
+    }
+    // …and the status ALONE still never nationalises anything.
     expect(isNationalClosure("TERTUTUP")).toBe(false);
   });
 
@@ -708,12 +751,33 @@ describe("the FAQ answer for a national closure", () => {
       ),
     );
     expect(national.length).toBeGreaterThan(0);
-    for (const r of national) {
+    // …plus the per-code adjudications, whose headline case is the notary page
+    // that started this whole lane.
+    const byCode = RECORDS.filter(
+      (r) => nationalClosureBasis(r.kode_kbli_2025) !== null,
+    );
+    expect(byCode.map((r) => r.kode_kbli_2025)).toContain("69104");
+    // Split by BRANCH, because only the `pma.status === "open"` records ever
+    // reached the defective answer. Measured on the live catalogue: of the 8
+    // per-code adjudications, 3 (`01287`, `59131` TERTUTUP/0 and `47111`
+    // TERBATAS/0) were ALREADY answered correctly off `pma_status`, and 5
+    // (`47112`, `69102`, `69104`, `86201`, `86202`) carry TERBUKA/100 — the
+    // absence-from-the-annex default — and are what this rule actually changes.
+    // They stay in the list regardless: the point is to stop depending on a
+    // default fill that can move underneath us.
+    let changed = 0;
+    for (const r of [...national, ...byCode]) {
       const answer = buildKbliFaq(toKbliCodeForFaq(r))[0].answer.toLowerCase();
-      expect(answer).not.toContain("outside bali it is open");
-      expect(answer).not.toContain("nationally yes");
-      expect(answer).toContain("everywhere in indonesia");
+      // No branch, ever, may route the reader to another province.
+      expect(answer, r.kode_kbli_2025).not.toContain("outside bali it is open");
+      expect(answer, r.kode_kbli_2025).not.toContain("nationally yes");
+      if (r.pma_status === "TERBUKA" && (r.pma_max_asing ?? 0) > 0) {
+        expect(answer, r.kode_kbli_2025).toContain("everywhere in indonesia");
+        changed += 1;
+      }
     }
+    // Premise: if this ever hits 0 the loop above is asserting nothing.
+    expect(changed).toBeGreaterThanOrEqual(5);
   });
 
   it("INNOCENCE: a genuine Bali-only block keeps the 'nationally yes' answer", () => {

--- a/apps/mouth/src/lib/kbli-bali-block.test.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.test.ts
@@ -9,9 +9,12 @@ import {
   isProposalOnly,
   narratesUnverifiedRoute,
   baliBlockedHint,
+  isNationalClosure,
 } from "./kbli-bali-block";
 import rawData from "../../data/KBLI_2025_FINAL_CLEAN.json";
 import goldData from "../../data/kbli-gold-all.json";
+import { buildKbliFaq } from "./kbli-faq";
+import type { KBLICode } from "./kbli-types";
 
 interface RawL4 {
   blocked?: boolean;
@@ -31,6 +34,42 @@ const BLOCKED = RECORDS.filter((r) => r.l4_bali?.blocked === true);
 const GOLD = goldData as unknown as Record<string, { whatYouNeed?: string }>;
 
 const MORATORIUM_SENTENCE = "under the 13 May 2026 moratorium";
+
+// The FAQ reads a transformed `KBLICode`, and `transformCode` is module-private
+// in the loader. Rather than export internals for a test, this builds the exact
+// subset `buildKbliFaq` touches — and takes every load-bearing value FROM THE
+// LIVE RECORD, so the fixture cannot drift into fiction while the catalogue moves
+// underneath it. The fields the PMA answer does not read are inert placeholders.
+function toKbliCodeForFaq(r: RawRecord): KBLICode {
+  return {
+    code: r.kode_kbli_2025,
+    titleId: "(judul)",
+    titleEn: "(title)",
+    titleEnIsReal: false,
+    section: "A",
+    licensing: [],
+    transition: { mappingStatus: null, mappingNote: null, previousCodes: [] },
+    pma: {
+      status:
+        r.pma_status === "TERBUKA"
+          ? "open"
+          : r.pma_status === "TERBATAS"
+            ? "restricted"
+            : "closed",
+      maxForeign: r.pma_max_asing ?? null,
+      capVerified: false,
+      capSpecial: r.pma_cap_special ?? false,
+      condition: null,
+    },
+    baliL4: r.l4_bali?.status
+      ? {
+          status: r.l4_bali.status,
+          reason: r.l4_bali.reason ?? null,
+          blocked: r.l4_bali.blocked ?? false,
+        }
+      : null,
+  } as unknown as KBLICode;
+}
 
 describe("baliBlockClause — the cause is derived, never defaulted", () => {
   it("GUILT: a non-moratorium block never claims the moratorium", () => {
@@ -581,5 +620,108 @@ describe("baliBlockedHint — the index card must not blame the moratorium for e
     // sentence might gain later, which is how a pin stops pinning.
     expect(hint).toContain("420 of them");
     expect(hint).toContain("the other 98");
+  });
+});
+
+// =============================================================================
+// isNationalClosure — a national bar recorded in the Bali-scoped field
+// =============================================================================
+
+describe("isNationalClosure — the banner and the FAQ must not send a client to Jakarta", () => {
+  // The two statuses whose recorded reason is national on EVERY member, read one
+  // by one off the live catalogue: a sectoral regulator / State monopoly, and a
+  // Perpres 49/2021 Lampiran II allocation to Koperasi/UMKM.
+  const NATIONAL = ["CHIUSO_REGOLATORE_SETTORIALE", "CHIUSO_PMA_NO_BESAR"];
+  // Everything else `l4_bali` can carry while blocked. These are Bali-scoped (or
+  // mixed, in TERTUTUP's case) and must keep the Bali framing.
+  const BALI_SCOPED = [
+    "BLOCCATO_CLASSE_RISCHIO",
+    "CHIUSO_MORATORIA_BALI",
+    "CHIUSO_BALI",
+    "CHIUSO_BALI_PROPOSTO",
+    "TERTUTUP",
+  ];
+
+  it("GUILT: every live record carrying a national status is recognised", () => {
+    const national = RECORDS.filter((r) =>
+      NATIONAL.includes(r.l4_bali?.status ?? ""),
+    );
+    // Premise first: an empty set would make every assertion below vacuous.
+    expect(national.length).toBeGreaterThan(0);
+    for (const r of national) {
+      expect(isNationalClosure(r.l4_bali?.status)).toBe(true);
+      // …and each one is exactly the shape that fooled the old derivation:
+      // the national signals still read open.
+      expect(r.pma_status).toBe("TERBUKA");
+      expect(r.pma_max_asing).toBe(100);
+    }
+  });
+
+  it("INNOCENCE: no Bali-scoped block is turned into a national one", () => {
+    const baliScoped = BLOCKED.filter((r) =>
+      BALI_SCOPED.includes(r.l4_bali?.status ?? ""),
+    );
+    // This is the set that would silently lose its Bali framing if the rule were
+    // widened by "closed-sounding status" instead of by named entity.
+    expect(baliScoped.length).toBeGreaterThan(100);
+    const misclassified = baliScoped.filter((r) =>
+      isNationalClosure(r.l4_bali?.status),
+    );
+    expect(misclassified.map((r) => r.kode_kbli_2025)).toEqual([]);
+  });
+
+  it("DECLARED GAP: TERTUTUP is mixed on the live data and stays Bali-framed", () => {
+    // `01287` says "closed to foreign ownership at the national level" while
+    // `01111` says "closed to PMA registration IN BALI". Judging all 68 by the
+    // name of the status would be the same form-over-entity move that produced
+    // the defect this rule fixes, so they wait for per-code adjudication.
+    // If this ever goes red, TERTUTUP stopped being mixed — re-read it and
+    // decide, do not just delete the test.
+    const tertutup = RECORDS.filter((r) => r.l4_bali?.status === "TERTUTUP");
+    expect(tertutup.length).toBeGreaterThan(1);
+    const reasons = tertutup.map((r) =>
+      (r.l4_bali?.reason ?? "").toLowerCase(),
+    );
+    expect(reasons.some((t) => t.includes("national level"))).toBe(true);
+    expect(reasons.some((t) => t.includes("in bali"))).toBe(true);
+    expect(isNationalClosure("TERTUTUP")).toBe(false);
+  });
+
+  it("an unknown or absent status is never treated as national", () => {
+    for (const s of [
+      undefined,
+      null,
+      "",
+      "OK_or_HIGHER_RISK",
+      "SOMETHING_NEW",
+    ]) {
+      expect(isNationalClosure(s)).toBe(false);
+    }
+  });
+});
+
+describe("the FAQ answer for a national closure", () => {
+  it("GUILT: it never tells the reader the activity is open outside Bali", () => {
+    const national = RECORDS.filter((r) =>
+      ["CHIUSO_REGOLATORE_SETTORIALE", "CHIUSO_PMA_NO_BESAR"].includes(
+        r.l4_bali?.status ?? "",
+      ),
+    );
+    expect(national.length).toBeGreaterThan(0);
+    for (const r of national) {
+      const answer = buildKbliFaq(toKbliCodeForFaq(r))[0].answer.toLowerCase();
+      expect(answer).not.toContain("outside bali it is open");
+      expect(answer).not.toContain("nationally yes");
+      expect(answer).toContain("everywhere in indonesia");
+    }
+  });
+
+  it("INNOCENCE: a genuine Bali-only block keeps the 'nationally yes' answer", () => {
+    const baliOnly = BLOCKED.filter(
+      (r) => r.l4_bali?.status === "CHIUSO_MORATORIA_BALI",
+    );
+    expect(baliOnly.length).toBeGreaterThan(0);
+    const answer = buildKbliFaq(toKbliCodeForFaq(baliOnly[0]))[0].answer;
+    expect(answer).toContain("Nationally yes");
   });
 });

--- a/apps/mouth/src/lib/kbli-bali-block.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.ts
@@ -49,6 +49,48 @@ export function isProposalOnly(status?: string | null): boolean {
 }
 
 /**
+ * The closure is NATIONAL, even though it is recorded in a Bali-scoped field.
+ *
+ * `l4_bali` is where the L4 layer records its verdict, and for some codes that
+ * verdict has nothing to do with Bali: the activity is shut everywhere in
+ * Indonesia. Nothing downstream could tell the two apart, because the only
+ * national signals the renderer read — `pma_status` / `pma_max_asing` — are the
+ * ABSENCE-from-the-annex default fill and still say `TERBUKA` / `100` on every
+ * one of these records. So the banner rendered "National procedure — does not
+ * apply to a PT PMA in Bali" and the FAQ published, in the FAQPage JSON-LD that
+ * Google ingests, "Outside Bali it is open to a PT PMA with no local partner
+ * required" — on the central bank, on radioactive-waste collection, and on seven
+ * bidang usaha a presidential annex allocates to Koperasi/UMKM nationwide.
+ *
+ * Two statuses, and only two, are national by their own recorded reason —
+ * verified one by one on the live catalogue (all 9, `confidence: HIGH`,
+ * `needs_review: false`, each with a locator):
+ *
+ *   CHIUSO_REGOLATORE_SETTORIALE (2) — a sectoral regulator or State monopoly:
+ *     `64110` Bank Sentral (Bank Indonesia), `38122` radioactive waste (BAPETEN).
+ *   CHIUSO_PMA_NO_BESAR (7) — allocated to Koperasi/UMKM by Perpres 49/2021
+ *     Lampiran II, "a PT PMA cannot take this bidang usaha", with page and entry.
+ *
+ * DELIBERATELY NOT `TERTUTUP`, and this is the whole reason the rule is a named
+ * SET rather than a "closed-sounding status" test. That status is MIXED on the
+ * live catalogue: `01287` reads "closed to foreign ownership at the national
+ * level", but `01111` reads "closed to PMA registration IN BALI" and `11010`
+ * carries a sentence that is not a closure at all. Convicting all 68 on the
+ * strength of the name would be judging the FORM of the status instead of the
+ * entity it records — the same move that produced the defect above. The
+ * nationally-closed members of `TERTUTUP` need per-code adjudication; until then
+ * they keep the Bali framing, which understates rather than misdirects.
+ */
+const NATIONAL_CLOSURE_STATUSES = new Set<string>([
+  "CHIUSO_REGOLATORE_SETTORIALE",
+  "CHIUSO_PMA_NO_BESAR",
+]);
+
+export function isNationalClosure(status?: string | null): boolean {
+  return NATIONAL_CLOSURE_STATUSES.has(status ?? "");
+}
+
+/**
  * The clause completing "In Bali, this activity is currently …".
  *
  * Total over the statuses above. The fallback is deliberately CAUSE-FREE: an

--- a/apps/mouth/src/lib/kbli-bali-block.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.ts
@@ -86,8 +86,67 @@ const NATIONAL_CLOSURE_STATUSES = new Set<string>([
   "CHIUSO_PMA_NO_BESAR",
 ]);
 
-export function isNationalClosure(status?: string | null): boolean {
-  return NATIONAL_CLOSURE_STATUSES.has(status ?? "");
+/**
+ * The per-code adjudication of `TERTUTUP` the comment above says is required.
+ *
+ * A CODE list, not a status rule, because the status cannot carry the answer:
+ * censused on the live catalogue, the 68 `TERTUTUP` records split into 8 whose
+ * reason names a national legal basis, 2 that say "in Bali" explicitly, and
+ * 58 — every one of them — whose reason is "medium-high/high risk → not blocked
+ * by moratorium (verify per address)". That sentence answers whether the
+ * MORATORIUM TEST fired; it never says where the closure applies. So for 58
+ * codes the record does not hold the fact, and no rule over `l4_bali` can
+ * invent it. They keep the Bali framing, which understates rather than
+ * misdirects, and fixing them means fixing the DATA — a lane of its own.
+ *
+ * Each entry below was read individually and carries the instrument that closes
+ * it nationwide. None is a guess from the code number or the title:
+ */
+const NATIONAL_CLOSURE_CODES = new Map<string, string>([
+  [
+    "01287",
+    "narcotics/medicinal-plant cultivation — TERTUTUP/0% at the national level",
+  ],
+  [
+    "47111",
+    "minimarket/supermarket retail — reserved to Indonesian citizens (WNI)",
+  ],
+  [
+    "47112",
+    "minimarket/supermarket retail — reserved to Indonesian citizens (WNI)",
+  ],
+  ["59131", "film/video distribution — TERTUTUP/0% at the national level"],
+  [
+    "69102",
+    "legal consultancy — reserved to Indonesian-licensed advocates, UU 18/2003",
+  ],
+  [
+    "69104",
+    "notary/PPAT — a personal State office, WNI only, UU 30/2004 as am. UU 2/2014",
+  ],
+  [
+    "86201",
+    "solo doctor's practice — closed to foreign nationals under Kemenkes health law",
+  ],
+  [
+    "86202",
+    "solo specialist practice — closed to foreign nationals under Kemenkes health law",
+  ],
+]);
+
+/** Why this code is closed nationwide, or null when it is not (audit surface). */
+export function nationalClosureBasis(code?: string | null): string | null {
+  return NATIONAL_CLOSURE_CODES.get(code ?? "") ?? null;
+}
+
+export function isNationalClosure(
+  status?: string | null,
+  code?: string | null,
+): boolean {
+  return (
+    NATIONAL_CLOSURE_STATUSES.has(status ?? "") ||
+    NATIONAL_CLOSURE_CODES.has(code ?? "")
+  );
 }
 
 /**

--- a/apps/mouth/src/lib/kbli-faq.ts
+++ b/apps/mouth/src/lib/kbli-faq.ts
@@ -1,6 +1,10 @@
 import type { KBLICode } from "@/lib/kbli-types";
 import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
-import { baliBlockClause, shouldShowReason } from "@/lib/kbli-bali-block";
+import {
+  baliBlockClause,
+  isNationalClosure,
+  shouldShowReason,
+} from "@/lib/kbli-bali-block";
 import { pmaCapShape } from "@/lib/kbli-pma-shape";
 
 export interface KbliFaqEntry {
@@ -62,26 +66,40 @@ export function buildKbliFaq(code: KBLICode): KbliFaqEntry[] {
   // applicability is genuinely unresolved, not "open" or "blocked".
   const baliNonClassifiable = code.baliL4?.status === "NON_CLASSIFICABILE";
 
+  // A NATIONAL closure recorded in the Bali-scoped `l4_bali` field. Without this
+  // branch the answer below ends "Outside Bali it is open to a PT PMA with no
+  // local partner required" — published in the FAQPage JSON-LD Google ingests —
+  // for the central bank, radioactive-waste collection, and seven bidang usaha a
+  // presidential annex allocates to Koperasi/UMKM nationwide. The TERBUKA/100%
+  // it leans on is the absence-from-the-annex default fill, not a permission.
+  const nationallyClosed = isNationalClosure(code.baliL4?.status);
+
   const pmaAnswer =
     code.pma.status === "open"
-      ? baliBlocked
-        ? // The cause is DERIVED, and the record's own reason is gated by the same
-          // rule the licensing frame uses. Both were hardcoded here: the clause
-          // named UMKM and the 2026 moratorium together for EVERY blocking status
-          // (the literal is asserted absent by test, so it is not repeated here),
-          // and the reason was spliced unconditionally. Measured on the canonical of
-          // 2026-07-27: 455 pages reach this branch, 416 of them carry a status the
-          // hardcoded clause misnames, and `69104` served Italian ("Notaio/PPAT è
-          // ufficio personale e statale, solo WNI…") — in the visible answer AND in
-          // the FAQPage JSON-LD, which is the copy Google ingests.
-          `Nationally yes — but NOT in Bali. KBLI ${code.code} (${code.titleId}) is TERBUKA (100% foreign ownership) at the national level, but in Bali it is ${baliBlockClause(code.baliL4?.status)}.${
+      ? nationallyClosed
+        ? `No — and not only in Bali. KBLI ${code.code} (${code.titleId}) is ${baliBlockClause(code.baliL4?.status)}, and that closure applies everywhere in Indonesia, so registering the activity in another province does not change the answer.${
             shouldShowReason(code.baliL4?.status, code.baliL4?.reason)
               ? ` ${code.baliL4?.reason}`
               : ""
-          } Outside Bali it is open to a PT PMA with no local partner required.`
-        : baliNonClassifiable
-          ? `Nationally yes — but Bali applicability cannot be determined yet. KBLI ${code.code} (${code.titleId}) is TERBUKA (100% foreign ownership) at the national level; whether Bali's PMA moratorium applies to this specific activity is not yet classifiable, pending re-derivation of the correct risk tier. Verify with the Bali Zero team before planning a Bali setup.`
-          : `Yes. KBLI ${code.code} (${code.titleId}) is TERBUKA — open to 100% foreign ownership via PT PMA. No local Indonesian partner required.`
+          } Our records carry no confirmed national foreign-ownership ceiling for this activity: the 100% some rows display is a default applied when the investment list holds no specific entry, not a recorded permission.`
+        : baliBlocked
+          ? // The cause is DERIVED, and the record's own reason is gated by the same
+            // rule the licensing frame uses. Both were hardcoded here: the clause
+            // named UMKM and the 2026 moratorium together for EVERY blocking status
+            // (the literal is asserted absent by test, so it is not repeated here),
+            // and the reason was spliced unconditionally. Measured on the canonical of
+            // 2026-07-27: 455 pages reach this branch, 416 of them carry a status the
+            // hardcoded clause misnames, and `69104` served Italian ("Notaio/PPAT è
+            // ufficio personale e statale, solo WNI…") — in the visible answer AND in
+            // the FAQPage JSON-LD, which is the copy Google ingests.
+            `Nationally yes — but NOT in Bali. KBLI ${code.code} (${code.titleId}) is TERBUKA (100% foreign ownership) at the national level, but in Bali it is ${baliBlockClause(code.baliL4?.status)}.${
+              shouldShowReason(code.baliL4?.status, code.baliL4?.reason)
+                ? ` ${code.baliL4?.reason}`
+                : ""
+            } Outside Bali it is open to a PT PMA with no local partner required.`
+          : baliNonClassifiable
+            ? `Nationally yes — but Bali applicability cannot be determined yet. KBLI ${code.code} (${code.titleId}) is TERBUKA (100% foreign ownership) at the national level; whether Bali's PMA moratorium applies to this specific activity is not yet classifiable, pending re-derivation of the correct risk tier. Verify with the Bali Zero team before planning a Bali setup.`
+            : `Yes. KBLI ${code.code} (${code.titleId}) is TERBUKA — open to 100% foreign ownership via PT PMA. No local Indonesian partner required.`
       : code.pma.status === "restricted"
         ? restrictedPmaAnswer(code)
         : `No. KBLI ${code.code} (${code.titleId}) is TERTUTUP — closed to foreign investment. Reserved for Indonesian nationals only.`;

--- a/apps/mouth/src/lib/kbli-faq.ts
+++ b/apps/mouth/src/lib/kbli-faq.ts
@@ -72,7 +72,7 @@ export function buildKbliFaq(code: KBLICode): KbliFaqEntry[] {
   // for the central bank, radioactive-waste collection, and seven bidang usaha a
   // presidential annex allocates to Koperasi/UMKM nationwide. The TERBUKA/100%
   // it leans on is the absence-from-the-annex default fill, not a permission.
-  const nationallyClosed = isNationalClosure(code.baliL4?.status);
+  const nationallyClosed = isNationalClosure(code.baliL4?.status, code.code);
 
   const pmaAnswer =
     code.pma.status === "open"


### PR DESCRIPTION
## What the page said, until this PR

`#3599`, `#3606` and `#3609` cured the **prose** on the codes whose national closure is
recorded in a Bali-scoped field. They did not cure the page's own **chrome** — and
`#3606` understated the gap as *"the bot will still answer 100% open"*. It is worse than
that: the banner and the FAQ **contradicted the article they framed**.

On **`/kbli/64110` — Bank Sentral, i.e. Bank Indonesia** — the page rendered

> **National procedure — does not apply to a PT PMA in Bali**

directly above an article saying the activity is shut everywhere in Indonesia. And the
generated FAQ answered:

> Nationally yes — but NOT in Bali … **Outside Bali it is open to a PT PMA with no local
> partner required.**

That sentence is not only on the page. `kbli-faq.ts`'s own comment records that it is
embedded in the **FAQPage JSON-LD, which is the copy Google ingests**. So our structured
data told search engines a foreigner may wholly own the central bank outside Bali. Same
shape on radioactive-waste collection (BAPETEN) and on seven *bidang usaha* a presidential
annex allocates to Koperasi/UMKM nationwide.

## Why both surfaces believed it

The only national signals either surface read are `pma_status` / `pma_max_asing` — and on
all nine those are `TERBUKA` / `100`, the **absence-from-the-annex default fill**, not a
permission anybody granted:

```ts
const nationallyClosed =
  !kbli.pma.capSpecial &&
  (kbli.pma.status === "closed" || kbli.pma.maxForeign === 0);
```

A national bar recorded in `l4_bali` was invisible to that.

## The vocabulary already carried the scope; nobody read it

Two statuses, and only two, are national on **every** member — verified one by one on the
live catalogue (all nine `confidence: HIGH`, `needs_review: false`, each with a locator):

| status | n | what the record's own reason says |
|---|---|---|
| `CHIUSO_REGOLATORE_SETTORIALE` | 2 | sectoral regulator / State monopoly — `64110` Bank Indonesia, `38122` BAPETEN |
| `CHIUSO_PMA_NO_BESAR` | 7 | Perpres 49/2021 Lampiran II allocation, with page and entry: *"a PT PMA cannot take this bidang usaha"* |

**One rule, in one module** (`isNationalClosure`, in `kbli-bali-block.ts`, which already
owns this vocabulary), consumed by **both** the banner and the FAQ — two surfaces that
must not invent two answers to the same question.

## Deliberately NOT `TERTUTUP`

That is the whole reason the rule is a **named set** rather than a "closed-sounding status"
test. `TERTUTUP` is **mixed** on the live data:

- `01287` — *"closed to foreign ownership at the **national level**"*
- `01111` — *"closed to PMA registration **in Bali**"*
- `11010` — a sentence that is not a closure at all

Convicting all 68 on the strength of the name would be judging the **form** of a status
instead of the **entity** it records — the same move that produced this defect. Those wait
for per-code adjudication and keep the Bali framing, which **understates rather than
misdirects**. Pinned by a test that goes red if `TERTUTUP` ever stops being mixed.

## Verification

- **44** tests in this file, **76** across the KBLI mouth suite.
- **Mutation, both directions:**
  - force `isNationalClosure` to `false` → the two **GUILT** tests die.
  - add `TERTUTUP` + `CHIUSO_MORATORIA_BALI` to the set → the two **INNOCENCE** tests and
    the declared-gap test die.
- The FAQ tests build their fixture **from the live record**, not by hand, so it cannot
  drift into fiction as the catalogue moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)