### PR TITLE
docs(wa-mirror): the consent documents promised a company number that is now a colleague's phone

### DIFF
--- a/apps/backend-rag/scripts/generate_brochure.py
+++ b/apps/backend-rag/scripts/generate_brochure.py
@@ -4,6 +4,36 @@ Bali Zero — Company Brochure PDF Generator v3
 One-time script. Run when services/prices change.
 Output: data/assets/brochure_balizero_en.pdf
 
+⚠️  THIS IS NOT THE SOURCE OF THE PUBLISHED BROCHURE (checked 2026-08-05).
+    The brochure clients actually receive is served from
+    ``apps/mouth/public/static/brochure_balizero_en.pdf`` (fetched over HTTP by
+    ``welcome_email_service.py`` and base64-attached to every welcome email).
+    That file is a hand-made binary with no source in this repo: it was
+    committed on 2026-04-01, five days AFTER this "v3" script was written on
+    2026-03-27, in a commit that touched nothing else. The version labels are
+    inverted with respect to time — "v2" is the newer artifact.
+
+    Do not "just regenerate and copy over". The two have diverged on FACTS, and
+    the published one is the truthful side on every one of them:
+
+        published            this script
+        10,000+ clients      5,000+
+        22 years in Bali     10+
+        Bayu Santero Group   "since 2014"
+          (2003) / BZ 2020
+        Kerobokan            Canggu
+        zantara@balizero.com info@balizero.com
+
+    The one thing this script has right and the published PDF has wrong is the
+    contact number: the published brochure still shows a team member's personal
+    line (8 occurrences), which is why it was audited here. Fixing that means
+    rebuilding the brochure from a real source, not running this.
+
+    Two more traps if you do run it: FONT_DIR below is hardcoded to one
+    machine's home, so on any other machine the brand fonts silently fall back
+    to Helvetica; and OUTPUT_PATH writes to a path that is not served and does
+    not exist in this repo.
+
 Usage:
     cd apps/backend-rag
     python scripts/generate_brochure.py

--- a/apps/wa-mirror/README.md
+++ b/apps/wa-mirror/README.md
@@ -16,7 +16,7 @@ After this bridge: each team member's WhatsApp is registered as a **WhatsApp Web
 ## What is NOT this bridge
 
 - **NOT** a reply bot. Team members keep using WhatsApp normally. v1 captures the one-to-one message stream for audit/continuity and does not send messages.
-- **NOT** a replacement for the Meta Cloud API at `backend/channels/whatsapp/` — that handles the official Bali Zero number `+62 822 3010 2328`. wa-mirror handles the **personal numbers** of the team in parallel.
+- **NOT** a replacement for the Meta Cloud API at `backend/channels/whatsapp/` — that handles the Meta-verified Bali Zero business line, the one the bot answers on (`SUPPORT_WHATSAPP` in `backend/app/core/config.py` is the SSOT; the line it names is not the same one this README used to claim). wa-mirror handles the **work numbers** of the team in parallel.
 - **NOT** a Meta API integration. Uses Baileys (reverse-engineered WhatsApp Web protocol). Operates within the standard "Linked Devices" surface — see "Risks" below.
 
 ## Architecture

--- a/apps/wa-mirror/docs/PKWT_CLAUSE.md
+++ b/apps/wa-mirror/docs/PKWT_CLAUSE.md
@@ -1,7 +1,29 @@
 # Klausul PKWT / Employment Contract Clause
 
+**Versi 1.1 — 2026-08-05** (versi sebelumnya tidak bernomor; lihat "Perubahan" di bawah)
+
 **Untuk ditambahkan di bagian "Alat Kerja" / "Tools" pada PKWT baru atau
 addendum PKWT yang sudah berjalan.**
+
+> **Perubahan dari versi sebelumnya / Change from the previous version.**
+> Versi lama menjanjikan bahwa klien yang ditangani karyawan dapat dialihkan
+> ke "nomor resmi perusahaan". Sejak 2026-08-05 nomor WhatsApp publik Bali
+> Zero adalah **nomor kerja milik salah satu anggota tim**, bukan nomor
+> terpisah milik perusahaan — jadi rumusan lama tidak lagi menggambarkan
+> keadaan sebenarnya, dan bagi pemilik nomor publik itu sendiri rumusan lama
+> menjadi melingkar. Klausul ini tidak menambah kewajiban apa pun bagi
+> karyawan; yang berubah hanya deskripsi mekanisme kelangsungan layanan.
+> Klausul ini juga sengaja **tidak mencantumkan nomor telepon**, supaya tidak
+> menjadi usang lagi ketika nomor berubah.
+>
+> The previous version promised that clients handled by an employee could be
+> routed to "the company's official number". Since 2026-08-05 the public Bali
+> Zero WhatsApp number is **a team member's own work line**, not a separate
+> company-held number — so the old wording no longer describes reality, and for
+> the holder of that public line it was circular. This clause adds no obligation
+> on the employee; only the description of the continuity mechanism changes. It
+> also deliberately **carries no phone number**, so it cannot go stale again the
+> next time the number moves.
 
 ---
 
@@ -23,9 +45,11 @@ klien Bali Zero. Percakapan pribadi tidak dicatat dan tidak dapat diakses
 oleh perusahaan.
 
 Karyawan berhak mencabut hubungan ini kapan saja melalui pengaturan
-WhatsApp pribadi. Pencabutan tidak menjadi alasan PHK atau penalti, namun
-perusahaan dapat menyalurkan klien yang ditangani karyawan ke nomor resmi
-perusahaan untuk kelangsungan layanan.
+WhatsApp pribadi. Pencabutan tidak menjadi alasan PHK atau penalti. Namun,
+karena percakapan yang tidak tercatat memutus jejak layanan di CRM,
+perusahaan dapat mengalihkan klien yang ditangani karyawan kepada rekan
+kerja yang nomor kerjanya tertaut, atau ke nomor bisnis Bali Zero yang
+dikelola melalui dashboard, demi kelangsungan layanan.
 
 ---
 
@@ -48,5 +72,8 @@ accessed by the company.
 
 The employee has the right to revoke this link at any time via their
 personal WhatsApp settings. Revocation does not constitute grounds for
-termination or penalty, however the company may route clients handled
-by the employee to the company's official number for service continuity.
+termination or penalty. However, because conversations that are not logged
+break the service trail in the CRM, the company may reassign the clients
+handled by the employee to a colleague whose work number is linked, or to
+the Bali Zero business number managed through the dashboard, for service
+continuity.

--- a/apps/wa-mirror/docs/PRIVACY_CONTRACT_TEAM.md
+++ b/apps/wa-mirror/docs/PRIVACY_CONTRACT_TEAM.md
@@ -1,7 +1,35 @@
 # Bali Zero WA-Mirror — Persetujuan Anggota Tim / Team Member Consent
 
-**Versi 1.0 — 2026-05-13**
+**Versi 1.1 — 2026-08-05** (menggantikan Versi 1.0 — 2026-05-13)
 **Tertulis di Bahasa Indonesia + English. Ditandatangani sebelum bridge aktif.**
+
+> ⚠️ **Tanda tangan pada Versi 1.0 hanya berlaku untuk teks Versi 1.0.**
+> Bagian "Konsekuensi jika Anda menolak" berubah secara substantif, jadi
+> anggota tim yang sudah menandatangani v1.0 perlu menandatangani ulang atau
+> menandatangani adendum. Hak karyawan **tidak berkurang** — pencabutan tetap
+> tanpa PHK dan tanpa penalti.
+>
+> **Perubahan dari v1.0.** v1.0 menyebut satu nomor tertentu sebagai "nomor
+> resmi Bali Zero yang diakses lewat dashboard" dan menjanjikan peralihan
+> bertahap ke nomor itu. Peralihan itu tidak terjadi seperti yang
+> digambarkan: sejak 2026-08-05 nomor WhatsApp publik Bali Zero adalah
+> **nomor kerja milik salah satu anggota tim** yang tertaut ke CRM, bukan
+> nomor terpisah milik perusahaan. Karena itu bagian tersebut ditulis ulang
+> agar sesuai kenyataan, dan versi ini sengaja **tidak menyebut nomor telepon
+> mana pun**, supaya dokumen tidak menjadi usang lagi ketika nomor berubah.
+>
+> ⚠️ **A signature on Version 1.0 covers the Version 1.0 text only.** The
+> "If you decline" section changed substantively, so team members who already
+> signed v1.0 need to re-sign or sign an addendum. No employee right is
+> narrowed — revocation still carries no termination and no penalty.
+>
+> **Change from v1.0.** v1.0 named one specific number as "the official Bali
+> Zero number accessed via dashboard" and promised a gradual move onto it.
+> That move did not happen as described: since 2026-08-05 the public Bali Zero
+> WhatsApp number is **a team member's own work line** linked to the CRM, not
+> a separate company-held number. That section is therefore rewritten to match
+> reality, and this version deliberately **names no phone number at all**, so
+> the document cannot go stale again the next time the number moves.
 
 ---
 
@@ -61,12 +89,21 @@ sudah ada di sistem,
 
 ### Konsekuensi jika Anda menolak
 
-Tidak ada konsekuensi PHK atau penalti. Namun ke depan, Bali Zero akan secara
-bertahap meminta semua komunikasi klien dilakukan via nomor resmi Bali Zero
-(+62 822 3010 2328) yang diakses via dashboard, bukan via nomor pribadi.
-Penolakan saat ini = transisi lebih cepat ke nomor resmi untuk Anda.
+Tidak ada konsekuensi PHK atau penalti, dan penolakan tidak dicatat sebagai
+penilaian kinerja.
+
+Yang terjadi hanyalah ini: percakapan Anda dengan klien tidak masuk ke CRM,
+sehingga tidak ada jejak layanan ketika Anda cuti, sakit, atau berhalangan.
+Untuk menjaga kelangsungan layanan, Bali Zero dapat mengalihkan klien yang
+Anda tangani kepada rekan kerja yang nomor kerjanya tertaut, atau ke nomor
+bisnis Bali Zero yang dikelola melalui dashboard. Pengalihan itu menyangkut
+klien, bukan status kepegawaian Anda.
 
 ### Tanda tangan
+
+**Versi dokumen yang ditandatangani: 1.1 (2026-08-05)** — tulis nomor versi ini
+pada salinan yang Anda tanda tangani, supaya di kemudian hari jelas teks mana
+yang Anda setujui.
 
 Nama: `______________________________`
 
@@ -135,12 +172,20 @@ existing "Linked Devices" feature of WhatsApp. Goal:
 
 ### If you decline
 
-No PHK / no penalty. However, going forward, Bali Zero will gradually
-require all client communications to happen via the official Bali Zero
-number (+62 822 3010 2328) accessed via dashboard, not via personal
-numbers. Declining today = faster transition to the official number for you.
+No PHK / no penalty, and declining is not recorded as a performance
+judgement.
+
+What happens is only this: your conversations with clients do not reach the
+CRM, so there is no service trail when you are on leave, sick, or otherwise
+unavailable. To keep service continuous, Bali Zero may reassign the clients
+you handle to a colleague whose work number is linked, or to the Bali Zero
+business number managed through the dashboard. That reassignment concerns
+clients, not your employment status.
 
 ### Signature
+
+**Document version signed: 1.1 (2026-08-05)** — write this version number on
+the copy you sign, so it stays clear later which text you agreed to.
 
 Name: `______________________________`
 

--- a/docs/WHATSAPP_STRATEGY_2026.md
+++ b/docs/WHATSAPP_STRATEGY_2026.md
@@ -3,6 +3,15 @@
 **Date:** 2026-02-12
 **Issue:** Meta WhatsApp Business API limita l'uso di Claude Max e Gemini CLI per risposte manuali del team
 
+> ⚠️ **Stale on the numbers (noted 2026-08-05).** This is a February snapshot and
+> its reasoning is kept as written, but every phone number in it has since moved.
+> The diagram below still labels `+62 813 3805 1876` the "Numero Principale": that
+> line is **retired**. Today the Meta-verified bot line is whatever
+> `SUPPORT_WHATSAPP` names in `apps/backend-rag/backend/app/core/config.py`, and
+> the public CTA on balizero.com is a team member's work line
+> (`WA_NUMBER` in `apps/mouth/src/lib/whatsapp-utm.ts`). Read the architecture
+> here, never the digits.
+
 ---
 
 ## 🔍 Situazione Attuale


### PR DESCRIPTION
Moving the public WhatsApp CTA onto a team member's working line (#3594,
#3604, #3605) quietly broke the premise these documents are built on. Both
of them draw a line between "the company's official number" and "personal
numbers", and offer the second as the remedy for the first. That line no
longer exists: the number the public dials is now one team member's own
work phone.

For that team member the revocation clause was circular -- decline the
mirror, and the promised remedy is "we route your clients to the official
number", which is his number. No grep would have found this: PKWT_CLAUSE.md
contains no digits at all.

So this is a factual rewrite with a version bump, not a digit swap:

- PRIVACY_CONTRACT_TEAM.md 1.0 -> 1.1. "If you decline" no longer names a
  number or promises a migration that did not happen; it describes what
  actually follows (conversations do not reach the CRM, so clients may be
  reassigned to a colleague whose line is linked, or to the dashboard
  business line). The document was SIGNED on 2026-05-13, so v1.1 says
  plainly that a v1.0 signature covers v1.0 text only and that signers need
  an addendum or a re-signature, and the signature block now carries the
  version. No employee right is narrowed -- revocation still carries no
  termination and no penalty, and declining is stated not to be a
  performance judgement.
- PKWT_CLAUSE.md gains a version (1.1) and the same correction.
- Both now deliberately carry NO phone number. A number printed inside a
  document people sign is the thing that went stale here; naming the role
  and pointing at the SSOT cannot rot the same way.

Two siblings found while checking who else holds the same premise:

- apps/wa-mirror/README.md said the Meta Cloud API handles
  "+62 822 3010 2328". It does not, and did not: that is the owner's
  personal line. The Meta-verified business line is the one SUPPORT_WHATSAPP
  names in backend/app/core/config.py, corroborated in four independent
  places (wa-tester-core.ts, docs/wa-tester.md, patch_pricing_contact_block.py,
  config.py). Fixed by role + SSOT pointer.
- docs/WHATSAPP_STRATEGY_2026.md is a February snapshot whose diagram still
  labels the retired +62 813 3805 1876 the "Numero Principale". Rewriting a
  569-line strategy document would be inventing strategy, so it gets a
  staleness banner naming the two SSOTs instead.

Deliberately untouched: the COMMENT ON COLUMN in migration 173 says
"official Bali Zero number via Meta Cloud API" without naming digits -- true
as a role description, and an applied migration is not edited in place.

What is NOT mine to do: putting v1.1 in front of the team for signature is a
business action (Legge 5), and so is deciding whether existing signers get an
addendum or a fresh signature.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)