### PR TITLE
fix(mail-loop): a quiet day is not a broken day, and the first two fixes were each wrong in a different way

### DIFF
--- a/apps/backend-rag/backend/services/mail_loop/cli.py
+++ b/apps/backend-rag/backend/services/mail_loop/cli.py
@@ -23,6 +23,11 @@ import logging
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # annotation only — `_amain` imports the real thing lazily so
+    # that `--help` keeps working without the backend's dependency tree.
+    from backend.services.mail_loop.loop import RunSummary
 
 logger = logging.getLogger("mail_loop")
 
@@ -235,6 +240,16 @@ async def _amain(args: argparse.Namespace) -> int:
     # which is precisely what makes it stop being parseable.
     print(json.dumps(summary.as_dict(), indent=2, ensure_ascii=False))  # noqa: T201
 
+    return _report(summary)
+
+
+def _report(summary: RunSummary) -> int:
+    """Turn a finished run into the process's exit code, and say why.
+
+    Pulled out of `_amain` so the wording is reachable without a database: the
+    thing worth testing here is not the arithmetic, it is that the line a human
+    finds at 07:30 names the reason for the verdict it announces.
+    """
     blocking = _consent_blocker(summary.errors)
     if blocking is not None:
         # Deliberately does NOT recite which scopes the stored grant holds.
@@ -256,21 +271,29 @@ async def _amain(args: argparse.Namespace) -> int:
         return 2
 
     if summary.degraded:
+        # Every term of `degraded` appears here. A verdict whose reason is not
+        # in the line it prints sends whoever finds it at 07:30 looking for a
+        # cause among the fields that happen to be shown — which is how
+        # `unaccounted` (silent, and the only one with no other symptom) would
+        # read as "routed nothing, no idea why".
         logger.warning(
             "run DEGRADED: routed=%d drafted=%d draft_failures=%d missing_folders=%s "
-            "errors=%d",
+            "errors=%d unaccounted=%d",
             summary.routed,
             summary.drafted,
             summary.draft_failures,
             summary.missing_folders,
             len(summary.errors),
+            summary.unaccounted,
         )
         return 1
 
     logger.info(
-        "run clean: seen=%d routed=%d drafted=%d left_in_inbox=%d lessons=%d%s",
+        "run clean: seen=%d routed=%d unroutable=%d drafted=%d left_in_inbox=%d "
+        "lessons=%d%s",
         summary.seen,
         summary.routed,
+        summary.unroutable,
         summary.drafted,
         summary.left_in_inbox,
         summary.lessons_learned,

--- a/apps/backend-rag/backend/services/mail_loop/cli.py
+++ b/apps/backend-rag/backend/services/mail_loop/cli.py
@@ -6,7 +6,8 @@ Exit codes are the contract with the wrapper, because the wrapper is what turns
 a bad run into an alert and a shell only ever sees a number:
 
     0  clean run
-    1  ran, but degraded (a folder is missing, drafting failed, nothing routed)
+    1  ran, but degraded (a folder is missing, a message errored, drafting
+       failed, or a message reached no recorded ending — see RunSummary.degraded)
     2  could not run at all (no DB, no Zoho token, no such user)
 
 There is no exit code that means "probably fine". A run that half-worked must be

--- a/apps/backend-rag/backend/services/mail_loop/loop.py
+++ b/apps/backend-rag/backend/services/mail_loop/loop.py
@@ -31,6 +31,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass, field
+from enum import Enum
 from html import unescape
 from pathlib import Path
 from typing import Any, Protocol
@@ -109,6 +110,20 @@ class MailBackend(Protocol):
     ) -> dict[str, Any]: ...
 
 
+class _Ending(Enum):
+    """How one message finished. Raising out of `_handle_one` is the third.
+
+    Deliberately NOT exhaustive over "everything that can happen to a message":
+    a draft that fails after the move does not get a member here, because the
+    message's ending was settled when it moved. Endings are what the
+    conservation law counts; failures downstream of an ending are reported
+    separately and must not be counted twice.
+    """
+
+    ROUTED = "routed"
+    LEFT_IN_INBOX = "left_in_inbox"
+
+
 @dataclass
 class RunSummary:
     """What one run actually accomplished. Read by the wrapper, not by a human."""
@@ -127,12 +142,29 @@ class RunSummary:
 
     @property
     def unaccounted(self) -> int:
-        """Seen messages that reached no recorded outcome. Must always be 0.
+        """Seen messages that reached no recorded ending. Zero on a healthy run.
 
         Every message the run picks up ends in exactly one place: it moved
         (`routed`), it stayed on purpose (`left_in_inbox` — declined by the
         classifier, or its folder was missing), or handling it raised
         (`message_errors`). Nothing else is a legal ending.
+
+        "Exactly one" is enforced structurally, not by care: those three
+        counters are incremented in a single `if/elif` in `_route_and_draft`,
+        driven by what `_handle_one` returns. `_handle_one` itself never
+        touches them.
+
+        That was not true when this property was written, and adversarial
+        review measured it: `routed` was incremented inside `_handle_one`
+        BEFORE drafting, and a drafting crash (Zoho refusing to save, the
+        pending buffer failing to write) then propagated to the caller's
+        per-message handler, which added `message_errors` for a message it had
+        already counted as routed — a live path, reproduced, giving
+        `unaccounted == -1`. A negative value is truthy, so the run still read
+        degraded; the real damage is that a sum can CANCEL, so that -1 would
+        have silently absorbed a genuine +1 elsewhere in the same run and
+        reported balanced. A conservation law that can net out is not a
+        conservation law.
         """
         return self.seen - self.routed - self.left_in_inbox - self.message_errors
 
@@ -161,11 +193,14 @@ class RunSummary:
         something that looks armed and is not.
 
         What that branch was really reaching for is a conservation law, and
-        that is what stands here instead. `unaccounted` is reachable, it is
-        zero on every path this code has today, and it turns non-zero the day
-        someone adds a fourth way for a message to end — the silent
-        `return` that would otherwise let a half-run report success. It costs
-        one counter and it cannot go dead the way its predecessor did.
+        that is what stands here instead. `unaccounted` is reachable, and it
+        turns non-zero the day someone adds a fourth way for a message to end —
+        the silent `return` that would otherwise let a half-run report success.
+        It costs one counter and it cannot go dead the way its predecessor did.
+
+        A first version of it could also read NEGATIVE, which is worse than
+        dead: see `unaccounted`. The cure was not a bigger check but a smaller
+        surface — one increment site per counter, in the caller.
         """
         if self.errors or self.missing_folders:
             return True
@@ -458,12 +493,29 @@ class MailLoop:
                 summary.message_errors += 1
                 summary.errors.append("a message arrived without an id, skipped")
                 continue
+            # The ONLY place the law's three counters are incremented. Keeping
+            # them here — rather than scattered through `_handle_one` — is what
+            # makes "exactly one ending per message" structural instead of a
+            # property somebody has to keep remembering.
             try:
-                await self._handle_one(message_id, message, folders, summary, inbox_id)
+                ending = await self._handle_one(
+                    message_id, message, folders, summary, inbox_id
+                )
             except Exception as exc:  # broad on purpose: one bad message must not
                 # abort the run: the remaining mail still deserves routing.
                 summary.message_errors += 1
                 summary.errors.append(f"message {message_id[:12]}: {exc}")
+                continue
+
+            if ending is _Ending.ROUTED:
+                summary.routed += 1
+            elif ending is _Ending.LEFT_IN_INBOX:
+                summary.left_in_inbox += 1
+            # No `else`. An ending nobody mapped — a new member of `_Ending`, or
+            # the silent `return None` of a guard added in a hurry — falls
+            # through to no counter at all, which is precisely what
+            # `unaccounted` exists to notice. An `else` here would swallow the
+            # thing the law is for.
 
     async def _handle_one(
         self,
@@ -472,7 +524,16 @@ class MailLoop:
         folders: list[dict[str, Any]],
         summary: RunSummary,
         inbox_id: str,
-    ) -> None:
+    ) -> _Ending | None:
+        """Decide what happens to one message. RAISING is the third ending.
+
+        This function does not touch `routed`, `left_in_inbox` or
+        `message_errors` — its caller does, in one place, from the value
+        returned here. That separation is the whole point: the counters that
+        the conservation law subtracts must have exactly one increment site
+        each, or the law can be fed two endings for one message and read
+        balanced.
+        """
         # Read the body without disturbing the mailbox.
         #
         # The obvious call here is `get_email`, and it is the wrong one: it marks
@@ -514,27 +575,28 @@ class MailLoop:
         verdict = classify(subject, body, headers=headers or None)
 
         if not verdict.routable:
+            # `unroutable` is a REASON, not an ending: it explains a quiet day
+            # in the log and takes no part in the conservation law, so counting
+            # it here cannot unbalance anything.
             summary.unroutable += 1
-            summary.left_in_inbox += 1
             logger.info(
                 "loop: message %s is %s — left in inbox for a human",
                 message_id[:12],
                 verdict.intent.value,
             )
-            return
+            return _Ending.LEFT_IN_INBOX
 
         folder_name = verdict.folder or ""
         target = _folder_id(folders, folder_name)
         if target is None:
             if folder_name not in summary.missing_folders:
                 summary.missing_folders.append(folder_name)
-            summary.left_in_inbox += 1
             logger.warning(
                 "loop: folder %r does not exist in Zoho — message left in inbox "
                 "rather than moved somewhere arbitrary",
                 folder_name,
             )
-            return
+            return _Ending.LEFT_IN_INBOX
 
         if self.dry_run:
             logger.info(
@@ -546,12 +608,33 @@ class MailLoop:
             )
         else:
             await self.backend.move_to_folder(self.user_id, [message_id], target)
-        summary.routed += 1
 
+        # From here the message's ending is settled: it moved. Anything that
+        # goes wrong below is a DRAFTING failure, and drafting is downstream of
+        # the ending — a message does not become un-routed because Zoho refused
+        # to store the reply, or because the pending buffer could not be
+        # written. Letting those propagate is what made `unaccounted` reach -1:
+        # the caller recorded an error for a message it had already recorded as
+        # routed, and the law read balanced while hiding two facts.
         if verdict.intent is Intent.NOISE:
-            return  # nothing to answer
+            return _Ending.ROUTED  # nothing to answer
 
-        await self._draft_reply(full, listed, verdict, summary)
+        try:
+            await self._draft_reply(full, listed, verdict, summary)
+        except Exception as exc:
+            # `_draft_reply` handles `DraftUnavailable` itself, so anything
+            # arriving here is the mailbox or the disk failing, not the model.
+            summary.draft_failures += 1
+            summary.errors.append(f"draft for {message_id[:12]}: {exc}")
+            logger.warning(
+                "loop: draft step failed for %s (%s/%s) after the message was "
+                "already moved: %s",
+                message_id[:12],
+                verdict.intent.value,
+                verdict.language,
+                exc,
+            )
+        return _Ending.ROUTED
 
     async def _draft_reply(
         self,

--- a/apps/backend-rag/backend/services/mail_loop/loop.py
+++ b/apps/backend-rag/backend/services/mail_loop/loop.py
@@ -149,10 +149,15 @@ class RunSummary:
         classifier, or its folder was missing), or handling it raised
         (`message_errors`). Nothing else is a legal ending.
 
-        "Exactly one" is enforced structurally, not by care: those three
-        counters are incremented in a single `if/elif` in `_route_and_draft`,
-        driven by what `_handle_one` returns. `_handle_one` itself never
-        touches them.
+        "Exactly one" is enforced structurally, not by care: all three counters
+        are incremented ONLY inside `_route_and_draft`, never in `_handle_one`.
+        `routed` and `left_in_inbox` come from one `if/elif` driven by what
+        `_handle_one` returns; `message_errors` has two sites (a message with
+        no id, and the per-message `except`) and each is followed immediately
+        by `continue`, so no message can reach the `if/elif` after one of them.
+        The property is "one increment per message", which is not the same as
+        "one increment site per counter" — an earlier version of this docstring
+        claimed the latter and it was never true.
 
         That was not true when this property was written, and adversarial
         review measured it: `routed` was incremented inside `_handle_one`
@@ -200,7 +205,7 @@ class RunSummary:
 
         A first version of it could also read NEGATIVE, which is worse than
         dead: see `unaccounted`. The cure was not a bigger check but a smaller
-        surface — one increment site per counter, in the caller.
+        surface — every increment moved into the caller, one per message.
         """
         if self.errors or self.missing_folders:
             return True
@@ -528,11 +533,10 @@ class MailLoop:
         """Decide what happens to one message. RAISING is the third ending.
 
         This function does not touch `routed`, `left_in_inbox` or
-        `message_errors` — its caller does, in one place, from the value
-        returned here. That separation is the whole point: the counters that
-        the conservation law subtracts must have exactly one increment site
-        each, or the law can be fed two endings for one message and read
-        balanced.
+        `message_errors` — its caller does, from the value returned here. That
+        separation is the whole point: the counters the conservation law
+        subtracts must be incremented at most once PER MESSAGE, or the law can
+        be fed two endings for one message and read balanced.
         """
         # Read the body without disturbing the mailbox.
         #

--- a/apps/backend-rag/backend/services/mail_loop/loop.py
+++ b/apps/backend-rag/backend/services/mail_loop/loop.py
@@ -87,9 +87,7 @@ class MailBackend(Protocol):
         is_unread: bool | None = None,
     ) -> dict[str, Any]: ...
 
-    async def get_message_content(
-        self, user_id: str, folder_id: str, message_id: str
-    ) -> str: ...
+    async def get_message_content(self, user_id: str, folder_id: str, message_id: str) -> str: ...
 
     async def get_message_headers(
         self, user_id: str, folder_id: str, message_id: str
@@ -118,6 +116,8 @@ class RunSummary:
     seen: int = 0
     routed: int = 0
     left_in_inbox: int = 0
+    unroutable: int = 0
+    message_errors: int = 0
     drafted: int = 0
     draft_failures: int = 0
     lessons_learned: int = 0
@@ -126,15 +126,50 @@ class RunSummary:
     dry_run: bool = False
 
     @property
+    def unaccounted(self) -> int:
+        """Seen messages that reached no recorded outcome. Must always be 0.
+
+        Every message the run picks up ends in exactly one place: it moved
+        (`routed`), it stayed on purpose (`left_in_inbox` — declined by the
+        classifier, or its folder was missing), or handling it raised
+        (`message_errors`). Nothing else is a legal ending.
+        """
+        return self.seen - self.routed - self.left_in_inbox - self.message_errors
+
+    @property
     def degraded(self) -> bool:
         """True when the run technically completed but did half its job.
 
         Drafting nothing while there was mail to answer is the shape that must
         never read as success.
+
+        "Routed nothing" is NOT that shape on its own, and the first week live
+        proved it: the second real run saw 12 messages, understood none of them,
+        left all 12 where a human would see them — the correct outcome — and
+        reported DEGRADED with a P0. Some days the inbox simply holds nothing
+        this router can defend a lane for. An alarm that fires on the correct
+        outcome is an alarm nobody reads, which is how a real one gets missed;
+        the gateway had already spooled a P0 for budget overflow the same night.
+
+        The narrowing that fixed that first read `routed == 0 and unroutable <
+        seen`. Mutation-testing refused it: deleting the whole branch changed
+        no test, and the reason was not a missing test — the branch had become
+        UNREACHABLE. With `routed == 0` and neither `errors` nor
+        `missing_folders`, every seen message must have been counted
+        `unroutable`, so `unroutable < seen` is false by construction. It was
+        dead code that read like a guard, which is the shape of superscar #2:
+        something that looks armed and is not.
+
+        What that branch was really reaching for is a conservation law, and
+        that is what stands here instead. `unaccounted` is reachable, it is
+        zero on every path this code has today, and it turns non-zero the day
+        someone adds a fourth way for a message to end — the silent
+        `return` that would otherwise let a half-run report success. It costs
+        one counter and it cannot go dead the way its predecessor did.
         """
         if self.errors or self.missing_folders:
             return True
-        if self.seen and self.routed == 0:
+        if self.unaccounted:
             return True
         return bool(self.draft_failures) and self.drafted == 0
 
@@ -143,6 +178,9 @@ class RunSummary:
             "seen": self.seen,
             "routed": self.routed,
             "left_in_inbox": self.left_in_inbox,
+            "unroutable": self.unroutable,
+            "message_errors": self.message_errors,
+            "unaccounted": self.unaccounted,
             "drafted": self.drafted,
             "draft_failures": self.draft_failures,
             "lessons_learned": self.lessons_learned,
@@ -385,9 +423,7 @@ class MailLoop:
 
     # -- routing ---------------------------------------------------------- #
 
-    async def _route_and_draft(
-        self, folders: list[dict[str, Any]], summary: RunSummary
-    ) -> None:
+    async def _route_and_draft(self, folders: list[dict[str, Any]], summary: RunSummary) -> None:
         # No fallback to the literal "inbox" here, and that is deliberate. Zoho
         # wants a numeric folder id; handing it a word produces
         # UNABLE_TO_PARSE_DATA_TYPE, so the old `or "inbox"` did not rescue an
@@ -419,12 +455,14 @@ class MailLoop:
         for message in messages:
             message_id = _message_id(message)
             if not message_id:
+                summary.message_errors += 1
                 summary.errors.append("a message arrived without an id, skipped")
                 continue
             try:
                 await self._handle_one(message_id, message, folders, summary, inbox_id)
             except Exception as exc:  # broad on purpose: one bad message must not
                 # abort the run: the remaining mail still deserves routing.
+                summary.message_errors += 1
                 summary.errors.append(f"message {message_id[:12]}: {exc}")
 
     async def _handle_one(
@@ -444,18 +482,14 @@ class MailLoop:
         # blind to exactly the mail it was supposed to file. It also re-lists
         # fifty messages per fetch to rebuild metadata `listed` already carries.
         folder_id = _folder_of(listed) or inbox_id
-        raw_body = await self.backend.get_message_content(
-            self.user_id, folder_id, message_id
-        )
+        raw_body = await self.backend.get_message_content(self.user_id, folder_id, message_id)
 
         # Headers are evidence, not a requirement: `is_bulk` treats their absence
         # as "no evidence of bulk", never as "not bulk". So a header fetch that
         # fails must not cost us the message — it costs us one signal.
         headers: dict[str, str] = {}
         try:
-            headers = await self.backend.get_message_headers(
-                self.user_id, folder_id, message_id
-            )
+            headers = await self.backend.get_message_headers(self.user_id, folder_id, message_id)
         except Exception as exc:
             logger.warning(
                 "loop: no headers for %s (%s) — classifying without the bulk signal",
@@ -480,6 +514,7 @@ class MailLoop:
         verdict = classify(subject, body, headers=headers or None)
 
         if not verdict.routable:
+            summary.unroutable += 1
             summary.left_in_inbox += 1
             logger.info(
                 "loop: message %s is %s — left in inbox for a human",
@@ -648,9 +683,7 @@ class MailLoop:
 
             if lesson_text is None:
                 continue
-            if self.style.append(
-                Lesson(bucket=bucket, text=lesson_text, observed_on=today())
-            ):
+            if self.style.append(Lesson(bucket=bucket, text=lesson_text, observed_on=today())):
                 learned += 1
                 logger.info("learn: new lesson in %s", bucket)
 

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_loop.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_loop.py
@@ -570,3 +570,78 @@ def test_unroutable_is_reported_so_a_quiet_day_is_explicable(
     reported = summary.as_dict()
     assert reported["unroutable"] == 1
     assert reported["unaccounted"] == 0
+
+
+def test_a_draft_that_crashes_after_the_move_does_not_unbalance_the_law(
+    tmp_path: Path, stub_model: None
+) -> None:
+    """GUILT: the shape that made `unaccounted` read -1, reproduced.
+
+    The message moves, then Zoho refuses to store the reply. Before the fix
+    `routed` was incremented inside `_handle_one` and the crash propagated to
+    the caller's per-message handler, which added `message_errors` on top —
+    two endings for one message, `unaccounted == -1`.
+
+    A negative value is truthy, so the run still read degraded and the defect
+    was invisible. What it really costs is cancellation: a `-1` here silently
+    absorbs a genuine `+1` elsewhere in the same run, and the law reports
+    balanced while hiding both.
+    """
+
+    class RefusesToSaveDrafts(FakeBackend):
+        async def save_draft(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("Zoho API 500 while saving draft")
+
+    backend = RefusesToSaveDrafts(
+        inbox=[_msg("m1", "KITAS renewal", "a@x.example", "T1")],
+        bodies={"m1": "My KITAS expires next month, what do you need?"},
+    )
+    summary = asyncio.run(_loop(backend, tmp_path).run())
+
+    assert backend.moves == [(["m1"], "F-VISA")], "premise: the message DID move"
+    assert summary.errors, "premise: the draft step DID fail"
+    assert summary.routed == 1
+    assert summary.message_errors == 0, "a moved message is not also an error-ending"
+    assert summary.unaccounted == 0
+    assert summary.draft_failures == 1
+    assert summary.degraded is True  # via errors + drafted==0, not via the law
+
+
+def test_the_law_cannot_net_out(tmp_path: Path, stub_model: None) -> None:
+    """Two messages, one crashing after its move and one silently skipped.
+
+    This is the run the cancellation would hide: before the fix the crash gave
+    -1 and the skip gave +1, so `unaccounted` read 0 and a run that lost a
+    message reported balanced. Each defect must now be visible on its own.
+    """
+
+    class RefusesToSaveDrafts(FakeBackend):
+        async def save_draft(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("Zoho API 500 while saving draft")
+
+    backend = RefusesToSaveDrafts(
+        inbox=[
+            _msg("m1", "KITAS renewal", "a@x.example", "T1"),
+            _msg("m2", "PT PMA setup", "b@x.example", "T2"),
+        ],
+        bodies={
+            "m1": "My KITAS expires next month, what do you need?",
+            "m2": "I want to open a PT PMA, what is required?",
+        },
+    )
+    loop = _loop(backend, tmp_path)
+    real_handle_one = loop._handle_one
+
+    async def _skip_the_second(
+        message_id: str, *args: Any, **kwargs: Any
+    ) -> Any:
+        if message_id == "m2":
+            return None  # the fourth ending nobody recorded
+        return await real_handle_one(message_id, *args, **kwargs)
+
+    loop._handle_one = _skip_the_second  # type: ignore[method-assign]
+    summary = asyncio.run(loop.run())
+
+    assert summary.seen == 2
+    assert summary.unaccounted == 1, "the skipped message must still show"
+    assert summary.degraded is True

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_loop.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_loop.py
@@ -419,3 +419,154 @@ def test_corrupt_pending_buffer_does_not_break_routing(
     summary = asyncio.run(_loop(backend, tmp_path).run())
     assert summary.routed == 1
     assert summary.lessons_learned == 0
+
+
+# --------------------------------------------------------------------------- #
+# A quiet day is not a broken day.                                            #
+#                                                                             #
+# Measured live on 2026-08-05, the second real run: 12 messages seen, 12       #
+# declined by the classifier, 12 left where a human would see them — the       #
+# correct outcome — reported as DEGRADED with a P0. An alarm that fires on the #
+# correct outcome is an alarm nobody reads, and the gateway had already        #
+# spooled a P0 for budget overflow that same night.                           #
+#                                                                             #
+# The first narrowing read "something WAS routable and none of it moved".      #
+# Mutation-testing killed it: deleting the branch changed no test, because it   #
+# had become UNREACHABLE — with routed==0 and no errors/missing folders, every  #
+# seen message is necessarily counted unroutable. What replaced it is a         #
+# conservation law (`unaccounted`), and the guilt half below aims at THAT,      #
+# not at a branch that fires earlier.                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_a_run_that_understood_nothing_is_clean(tmp_path: Path, stub_model: None) -> None:
+    """INNOCENCE: every message declined, nothing moved — not degraded."""
+    backend = FakeBackend(
+        inbox=[
+            _msg("m1", "Re: lunch", "a@x.example", "T1"),
+            _msg("m2", "Photos from Sunday", "b@x.example", "T2"),
+        ],
+        bodies={
+            "m1": "Are we still on for Thursday? Let me know.",
+            "m2": "Sending the pictures we took, hope you like them.",
+        },
+    )
+    summary = asyncio.run(_loop(backend, tmp_path).run())
+
+    assert summary.seen == 2
+    assert summary.routed == 0
+    assert summary.unroutable == 2, "premise: the classifier must have DECLINED both"
+    assert summary.left_in_inbox == 2
+    assert summary.unaccounted == 0
+    assert summary.degraded is False
+    assert backend.moves == [], "a clean quiet day must still mutate nothing"
+
+
+def test_a_message_that_reached_no_outcome_is_degraded(
+    tmp_path: Path, stub_model: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GUILT: the conservation law, aimed at the ending that does not exist yet.
+
+    Today every message ends routed, left-in-inbox or errored, so this shape is
+    only reachable by simulating the edit that would introduce a fourth: a
+    silent `return` out of `_handle_one` that touches no counter — a filter on
+    message age, a "skip anything from ourselves", a guard added in a hurry.
+    That is precisely the run that would otherwise report success while doing
+    nothing, so the test injects it rather than waiting for someone to write it.
+    """
+    backend = FakeBackend(
+        inbox=[_msg("m1", "KITAS renewal", "a@x.example", "T1")],
+        bodies={"m1": "My KITAS expires next month, what do you need?"},
+    )
+    loop = _loop(backend, tmp_path)
+
+    async def _silently_skip(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(loop, "_handle_one", _silently_skip)
+    summary = asyncio.run(loop.run())
+
+    assert summary.seen == 1
+    assert not summary.errors, "premise: nothing raised"
+    assert not summary.missing_folders, "premise: no folder was missing"
+    assert summary.unaccounted == 1
+    assert summary.degraded is True
+
+
+def test_a_message_that_raised_is_accounted_for(
+    tmp_path: Path, stub_model: None
+) -> None:
+    """A crash is a legal ending — it must not ALSO read as unaccounted.
+
+    Otherwise the conservation law would double-count the shape the errors
+    branch already reports, and `unaccounted` would stop meaning "nobody
+    noticed this message".
+    """
+    backend = FakeBackend(
+        inbox=[_msg("m1", "KITAS renewal", "a@x.example", "T1")],
+        bodies={},  # get_message_content will raise KeyError
+    )
+    summary = asyncio.run(_loop(backend, tmp_path).run())
+
+    assert summary.seen == 1
+    assert summary.message_errors == 1
+    assert summary.errors, "premise: the message must have raised"
+    assert summary.unaccounted == 0
+    assert summary.degraded is True  # via the errors branch, not the law
+
+
+def test_a_missing_folder_is_accounted_for(tmp_path: Path, stub_model: None) -> None:
+    """The other legal non-move: routable, but its folder is gone.
+
+    It lands in `left_in_inbox`, so the law stays quiet and `missing_folders`
+    does the reporting. Pins that the two guards do not overlap.
+    """
+    backend = FakeBackend(
+        inbox=[_msg("m1", "KITAS renewal", "a@x.example", "T1")],
+        bodies={"m1": "My KITAS expires next month, what do you need?"},
+        folders=[f for f in FOLDERS if f.get("folder_name") != "_Visa"],
+    )
+    summary = asyncio.run(_loop(backend, tmp_path).run())
+
+    assert summary.routed == 0
+    assert summary.unroutable == 0, "premise: the message WAS routable"
+    assert summary.missing_folders == ["_Visa"]
+    assert summary.unaccounted == 0
+    assert summary.degraded is True
+
+
+def test_mixed_day_with_one_routed_is_clean(tmp_path: Path, stub_model: None) -> None:
+    """INNOCENCE: one defensible routing among declines is a good day."""
+    backend = FakeBackend(
+        inbox=[
+            _msg("m1", "KITAS renewal", "a@x.example", "T1"),
+            _msg("m2", "Re: lunch", "b@x.example", "T2"),
+        ],
+        bodies={
+            "m1": "My KITAS expires next month, what do you need?",
+            "m2": "Are we still on for Thursday?",
+        },
+    )
+    summary = asyncio.run(_loop(backend, tmp_path).run())
+
+    assert summary.routed == 1
+    assert summary.unroutable == 1
+    assert summary.degraded is False
+
+
+def test_unroutable_is_reported_so_a_quiet_day_is_explicable(
+    tmp_path: Path, stub_model: None
+) -> None:
+    """The wrapper's log must be able to say WHY a run moved nothing.
+
+    Without the count in the summary, "routed 0, clean" and "routed 0, broken"
+    read identically to whoever finds the log at 07:30.
+    """
+    backend = FakeBackend(
+        inbox=[_msg("m1", "Re: lunch", "a@x.example", "T1")],
+        bodies={"m1": "Are we still on for Thursday?"},
+    )
+    summary = asyncio.run(_loop(backend, tmp_path).run())
+    reported = summary.as_dict()
+    assert reported["unroutable"] == 1
+    assert reported["unaccounted"] == 0

--- a/apps/backend-rag/backend/tests/unit/services/mail_loop/test_preflight_and_env.py
+++ b/apps/backend-rag/backend/tests/unit/services/mail_loop/test_preflight_and_env.py
@@ -424,3 +424,58 @@ def test_the_prompt_arrives_on_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
     # a `-p` that lost its flag would read stdin as an interactive session.
     assert seen["argv"][:2] == ["/fake/claude", "-p"]
     assert draft_module.CLAUDE_MODEL in seen["argv"]
+
+
+# --------------------------------------------------------------------------- #
+# 4. The verdict must name its own cause.                                      #
+#                                                                              #
+# `degraded` has four terms. Three of them leave a second trace a reader can   #
+# find (a missing folder, an error list, a draft failure). `unaccounted` does  #
+# not: it is silent by construction — a message nobody recorded. If the        #
+# DEGRADED line omits it, the run that most needs explaining is the one that   #
+# prints `routed=0 drafted=0 draft_failures=0 missing_folders=[] errors=0` and #
+# no reason at all. That is the mute alarm this repo keeps re-learning.        #
+# --------------------------------------------------------------------------- #
+
+
+def _summary(**overrides: Any) -> Any:
+    from backend.services.mail_loop.loop import RunSummary
+
+    return RunSummary(**overrides)
+
+
+def test_a_silent_degradation_still_says_why(caplog: pytest.LogCaptureFixture) -> None:
+    """GUILT: the only term with no other symptom must appear in the line."""
+    summary = _summary(seen=3, routed=0, left_in_inbox=0, message_errors=0)
+    assert summary.unaccounted == 3, "premise: this run is degraded ONLY by the law"
+    assert not summary.errors and not summary.missing_folders
+
+    with caplog.at_level("WARNING", logger="mail_loop"):
+        code = cli_module._report(summary)
+
+    assert code == 1
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert warnings, "a degraded run must warn"
+    assert "unaccounted=3" in warnings[0], (
+        "the DEGRADED line names every term of the verdict, or the reader is "
+        f"left guessing: {warnings[0]!r}"
+    )
+
+
+def test_a_clean_run_says_how_many_it_declined(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A quiet day is clean — and the log must let a human tell it from a dead one.
+
+    Same exit code, same `routed=0`: without the count, "understood nothing and
+    said so" and "did nothing at all" read identically at 07:30.
+    """
+    summary = _summary(seen=4, routed=0, unroutable=4, left_in_inbox=4)
+    assert summary.degraded is False, "premise: a fully-declined day is not degraded"
+
+    with caplog.at_level("INFO", logger="mail_loop"):
+        code = cli_module._report(summary)
+
+    assert code == 0
+    infos = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+    assert infos and "unroutable=4" in infos[0], infos

--- a/docs/runbooks/zoho-mail-loop.md
+++ b/docs/runbooks/zoho-mail-loop.md
@@ -640,17 +640,56 @@ missing), or handling it raised (`message_errors`). So:
 unaccounted = seen - routed - left_in_inbox - message_errors
 ```
 
-must be `0`, and a non-zero value is degraded. This is reachable, it is zero on
-every path the code has today, and it turns non-zero **the day someone adds a
-fourth ending** — the silent `return` (skip old mail, skip our own address, a
-guard added in a hurry) that would otherwise let a half-run report success.
-It cannot go dead the way its predecessor did, because it is not a statement
-about today's branches.
+must be `0`, and a non-zero value is degraded. It turns non-zero **the day
+someone adds a fourth ending** — the silent `return` (skip old mail, skip our
+own address, a guard added in a hurry) that would otherwise let a half-run
+report success. It cannot go dead the way its predecessor did, because it is
+not a statement about today's branches.
 
 Its guilt test injects that fourth ending rather than waiting for it: it
 monkeypatches `_handle_one` into a silent no-op and asserts the run is reported
 degraded with `errors` and `missing_folders` both empty — the branch under
 test, and no other.
+
+### The law's first version could read −1, which is worse than dead
+
+The paragraph above originally continued "it is zero on every path the code has
+today". Adversarial review measured that claim and reproduced the opposite on a
+live path:
+
+```
+seen 1  routed 1  left_in_inbox 0  message_errors 1
+unaccounted = -1
+moves [(['m1'], 'F-VISA')]
+errors ['message m1: Zoho API 500 while saving draft']
+```
+
+`routed += 1` sat inside `_handle_one`, **before** drafting. `_draft_reply`
+handles `DraftUnavailable` itself, but anything else — Zoho refusing to store
+the reply, the pending buffer failing to write — propagated to the caller's
+per-message handler, which added `message_errors` for a message it had already
+counted as routed. Two endings, one message.
+
+The negative was truthy, so that particular run still read degraded. The real
+damage is that **a sum can cancel**: a `−1` here silently absorbs a genuine
+`+1` elsewhere in the same run, and the law reports balanced while hiding two
+distinct defects. A conservation law that can net out is not a conservation
+law — and it fails quiet, where the dead branch it replaced at least failed
+loud under mutation.
+
+The cure was not a bigger check but a **smaller surface**. `_handle_one` now
+returns an ending and touches none of the three counters; the caller increments
+exactly one of them, in a single `if/elif`, and a crash after the move is
+reported as a draft failure because the message's ending was settled when it
+moved. There is deliberately **no `else`** on that mapping: an unmapped ending
+falls through to no counter, which is exactly what `unaccounted` is for.
+
+`unroutable` stays where it is because it is a _reason_, not an ending — it
+takes no part in the subtraction and cannot unbalance it.
+
+Both shapes are now pinned: the post-move crash (`routed == 1`,
+`message_errors == 0`, `unaccounted == 0`) and a run carrying one of each
+defect, which must read `unaccounted == 1` rather than netting to zero.
 
 ### And the verdict now names its own cause
 
@@ -675,13 +714,20 @@ worth a test, and it was unreachable without a database.
 | a declined message not counted as left | 4                |
 | DEGRADED line drops `unaccounted`      | 1                |
 | clean line drops `unroutable`          | 1                |
+| post-move draft crash propagates again | 1                |
+| `else` swallows the unmapped ending    | 2                |
+| `routed` incremented in both places    | 9                |
 
 ### Declared limits
 
-- `unaccounted` cannot go negative on any path today (no ending increments two
-  counters), but nothing enforces that; if a future edit double-counts, a
-  negative value is truthy in Python and would read as degraded. The failure
-  mode is a false alarm, not a silent success — the safe direction.
 - The law says a message reached _an_ ending, never that it was the _right_
   one. Routing a tax question into `_Visa` is accounted for and clean; that is
   §10's problem, not this one's.
+- `unaccounted` can no longer go negative _by construction_ — one increment
+  site per counter — but nothing mechanically forbids a future edit from adding
+  a second site. What would catch it is the same corpus: the post-move-crash
+  test asserts `message_errors == 0` on a routed message, and the net-out test
+  asserts a run carrying one defect of each sign reads `1`, not `0`.
+- The wrapper reads only the exit code, so `unaccounted` reaches a human
+  through the log line and the JSON, not through a distinct alert. A run
+  degraded _only_ by the law raises the same P0 as any other.

--- a/docs/runbooks/zoho-mail-loop.md
+++ b/docs/runbooks/zoho-mail-loop.md
@@ -723,11 +723,18 @@ worth a test, and it was unreachable without a database.
 - The law says a message reached _an_ ending, never that it was the _right_
   one. Routing a tax question into `_Visa` is accounted for and clean; that is
   §10's problem, not this one's.
-- `unaccounted` can no longer go negative _by construction_ — one increment
-  site per counter — but nothing mechanically forbids a future edit from adding
-  a second site. What would catch it is the same corpus: the post-move-crash
-  test asserts `message_errors == 0` on a routed message, and the net-out test
-  asserts a run carrying one defect of each sign reads `1`, not `0`.
+- `unaccounted` can no longer go negative _by construction_, but the
+  construction is **one increment per message**, not "one increment site per
+  counter" — `message_errors` has two sites (a message with no id, and the
+  per-message `except`), each followed immediately by `continue` so the
+  `if/elif` below is unreachable after either. An earlier draft of this section
+  and of the docstrings claimed the stronger property; it was never true, and
+  round-2 review caught it in the very commit whose message said the
+  overclaiming docstrings had been corrected. Nothing mechanically forbids a
+  future edit from adding an increment that is not followed by `continue`; what
+  would catch it is the same corpus — the post-move-crash test asserts
+  `message_errors == 0` on a routed message, and the net-out test asserts a run
+  carrying one defect of each sign reads `1`, not `0`.
 - The wrapper reads only the exit code, so `unaccounted` reaches a human
   through the log line and the JSON, not through a distinct alert. A run
   degraded _only_ by the law raises the same P0 as any other.

--- a/docs/runbooks/zoho-mail-loop.md
+++ b/docs/runbooks/zoho-mail-loop.md
@@ -384,6 +384,9 @@ PYTHONPATH=. .venv/bin/python -m backend.services.mail_loop.cli --dry-run
   "seen": 13,
   "routed": 7,
   "left_in_inbox": 6,
+  "unroutable": 6,
+  "message_errors": 0,
+  "unaccounted": 0,
   "drafted": 7,
   "draft_failures": 0,
   "missing_folders": [],
@@ -395,6 +398,12 @@ PYTHONPATH=. .venv/bin/python -m backend.services.mail_loop.cli --dry-run
 The six left in the inbox are the ones the classifier refuses to guess about;
 leaving them where a human sees them is the intended behaviour, not a shortfall.
 Note that `missing_folders` only became trustworthy in this change — see §9.
+
+`unaccounted` must always read `0`. It is `seen - routed - left_in_inbox -
+message_errors`: every message the run picks up ends in exactly one of those
+three places, so a non-zero value means one ended somewhere nobody recorded —
+and the run is reported degraded. See §11 for why that counter exists and what
+it replaced.
 
 3. Then §3.4 (install the plist) and §3.5 (flip `MAIL_LOOP_DRY_RUN` to 0).
 
@@ -574,3 +583,105 @@ still bites, and the tie example was rebuilt from two non-weak lanes.
   keeps pairs where the marker is a strict substring of an ordinary word, so a
   marker that _equals_ a whole ordinary word (`visto`, `tanah`, `imposte`) is
   structurally outside the sweep. Those rows are hand-written, and that is why.
+
+---
+
+## 11. An alarm that fires on the correct outcome
+
+**Measured 2026-08-05, the second non-dry-run.** The run saw 12 messages,
+classified all 12 as unroutable, left all 12 in the inbox — the intended
+behaviour — and reported:
+
+```json
+{
+  "seen": 12,
+  "routed": 0,
+  "left_in_inbox": 12,
+  "drafted": 0,
+  "draft_failures": 0,
+  "errors": [],
+  "degraded": true
+}
+```
+
+Exit **1**, heartbeat `degraded`, a P0 to the gateway. Nothing was wrong. The
+rule read `if self.seen and self.routed == 0: return True` — written when
+"routed nothing" could only mean the router was stuck, and untrue the first
+morning the inbox simply held nothing this classifier can defend a lane for.
+
+An alarm that fires on the correct outcome is an alarm nobody reads, which is
+how the next real one gets missed. The same night the gateway had already
+spooled a P0 for budget overflow.
+
+### The first fix was dead code, and mutation said so
+
+The narrowing was `routed == 0 and unroutable < seen`, with a new `unroutable`
+counter. It passed guilt and innocence. Then deleting **the whole branch**
+changed no test — and the reason was not a missing test:
+
+> with `routed == 0` and neither `errors` nor `missing_folders`, every seen
+> message has necessarily been counted `unroutable`, so `unroutable < seen` is
+> false by construction.
+
+The branch was **unreachable**. It read like a guard, ran on every run, and
+could never fire — superscar #2 in miniature, inside the fix for something
+else. Worse, its guilt test passed through the `errors or missing_folders`
+branch a few lines above: the premise was vacuous and the assertion still
+green. A guilt test that reaches the verdict by another road proves nothing
+about the road it names.
+
+### What replaced it: a conservation law
+
+Every message the run picks up ends in exactly one place — it moved
+(`routed`), it stayed on purpose (`left_in_inbox`: declined, or its folder was
+missing), or handling it raised (`message_errors`). So:
+
+```
+unaccounted = seen - routed - left_in_inbox - message_errors
+```
+
+must be `0`, and a non-zero value is degraded. This is reachable, it is zero on
+every path the code has today, and it turns non-zero **the day someone adds a
+fourth ending** — the silent `return` (skip old mail, skip our own address, a
+guard added in a hurry) that would otherwise let a half-run report success.
+It cannot go dead the way its predecessor did, because it is not a statement
+about today's branches.
+
+Its guilt test injects that fourth ending rather than waiting for it: it
+monkeypatches `_handle_one` into a silent no-op and asserts the run is reported
+degraded with `errors` and `missing_folders` both empty — the branch under
+test, and no other.
+
+### And the verdict now names its own cause
+
+`unaccounted` is the only term of `degraded` with no second symptom: no folder
+in the list, no error string, no failed draft. A DEGRADED line that omits it
+prints `routed=0 drafted=0 draft_failures=0 missing_folders=[] errors=0` and
+leaves the reader guessing. The line carries every term of the verdict it
+announces, and the clean line carries `unroutable` so a quiet day can be told
+from a dead one at a glance — same exit code, same `routed=0`, opposite
+meaning.
+
+`cli._report()` was pulled out of `_amain` for exactly this: the wording is
+worth a test, and it was unreachable without a database.
+
+### Mutation table
+
+| mutant                                 | tests turned red |
+| -------------------------------------- | ---------------- |
+| conservation branch deleted            | 1                |
+| `unaccounted` hardcoded to 0           | 1                |
+| a crashed message not accounted for    | 1                |
+| a declined message not counted as left | 4                |
+| DEGRADED line drops `unaccounted`      | 1                |
+| clean line drops `unroutable`          | 1                |
+
+### Declared limits
+
+- `unaccounted` cannot go negative on any path today (no ending increments two
+  counters), but nothing enforces that; if a future edit double-counts, a
+  negative value is truthy in Python and would read as degraded. The failure
+  mode is a false alarm, not a silent success — the safe direction.
+- The law says a message reached _an_ ending, never that it was the _right_
+  one. Routing a tax question into `_Visa` is accounted for and clean; that is
+  §10's problem, not this one's.


### PR DESCRIPTION
## What fired

The second non-dry-run of the Zoho mail loop saw 12 messages, classified all 12 as unroutable, left all 12 in the inbox — **the intended behaviour** — and reported `degraded=true`, exit 1, heartbeat `degraded`, a P0 to the gateway.

```json
{ "seen": 12, "routed": 0, "left_in_inbox": 12, "drafted": 0,
  "draft_failures": 0, "errors": [], "degraded": true }
```

The rule was `seen and routed == 0`, written when "routed nothing" could only mean the router was stuck. An alarm that fires on the correct outcome is an alarm nobody reads — which is how the next real one gets missed. The gateway had already spooled a P0 for budget overflow the same night.

## Three commits, because the first two fixes were each wrong

**1. The narrowing was dead code.** `routed == 0 and unroutable < seen` passed guilt and innocence. Mutation then deleted the whole branch and nothing turned red — not a missing test: with `routed == 0` and no `errors`/`missing_folders`, every seen message is *necessarily* counted `unroutable`, so the condition is false by construction. **Unreachable.** Its guilt test had been reaching `degraded is True` through the `errors or missing_folders` branch above it — a vacuous premise with a green assertion.

Replaced by a conservation law: `unaccounted = seen - routed - left_in_inbox - message_errors`, which must be 0. Reachable, and non-zero **the day someone adds a fourth ending** — the silent `return` that would otherwise let a half-run report success. Its guilt test injects that fourth ending rather than waiting for it.

**2. The law could read −1, and a sum that cancels is not a law.** Adversarial review reproduced it live: `routed += 1` sat inside `_handle_one` *before* drafting, and a non-`DraftUnavailable` crash (Zoho refusing to store the reply, the pending buffer failing to write) propagated to the caller, which added `message_errors` for a message already counted as routed. The negative is truthy so that run still read degraded — the damage is that **a −1 silently absorbs a genuine +1 in the same run** and the law reports balanced while hiding two defects. Worse than the dead branch it replaced: dead code fails loud under mutation, this failed quiet.

Cure: a smaller surface, not a bigger check. `_handle_one` returns an `_Ending` and touches none of the three counters; the caller increments one, with deliberately **no `else`** so an unmapped ending falls through to `unaccounted`. A crash after the move is a draft failure — the ending was settled when the message moved.

**3. "One increment site per counter" was itself an overclaim**, caught by round-2 review in the very commit whose message said the overclaiming docstrings had been corrected. `message_errors` has two sites; the real property is one increment *per message*. Corrected in all four places, plus `cli.py`'s exit table which still listed "nothing routed" as a cause of exit 1.

## Also

`unaccounted` is the only term of `degraded` with no second symptom, so the DEGRADED line now carries it; the clean line carries `unroutable` so a quiet day can be told from a dead one — same exit code, same `routed=0`, opposite meaning. `cli._report()` was extracted from `_amain` because that wording deserves a test and was unreachable without a database.

## Verification

Full suite green (162 tests, rc=0). **Mutation-verified 9/9** — every defence measured by switching it off:

| mutant | tests turned red |
| --- | --- |
| conservation branch deleted | 1 |
| `unaccounted` hardcoded to 0 | 1 |
| a crashed message not accounted for | 1 |
| a declined message not counted as left | 4 |
| DEGRADED line drops `unaccounted` | 1 |
| clean line drops `unroutable` | 1 |
| post-move draft crash propagates again | 1 |
| `else` swallows the unmapped ending | 2 |
| `routed` incremented in both places | 9 |

Two independent adversarial rounds (generator≠grader); round 2 found no blockers and verified `asyncio.CancelledError` is `BaseException` in this venv rather than assuming it. Runbook §11 records the trap, both wrong fixes, the mutation table and the declared limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)