### PR TITLE
fix(kbli): the bot called 77 national closures "a Bali restriction" and read out our internal codes

### DIFF
--- a/apps/backend-rag/backend/app/routers/kbli_notebook.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook.py
@@ -112,6 +112,19 @@ class KBLISearchResult(BaseModel):
     bali_status: str | None = None
     bali_blocked: bool | None = None
     bali_reason: str = ""
+    # The national foreign-ownership CEILING, carried on the same flat payload.
+    # `pma_status` is a word ("TERBUKA"/"TERBATAS"/"TERTUTUP") and it is the only
+    # ownership fact the context line prints; the ceiling is the number, and the
+    # two can disagree in the direction that matters. Measured 2026-08-05 on the
+    # canonical: `79122` (Umrah/Hajj travel) reads `TERBATAS` with a ceiling of
+    # **0** — closed to foreign capital outright — while its Bali verdict is "not
+    # blocked". A reader shown only the word hears "restricted, so find a local
+    # partner"; the number says there is nothing to partner into.
+    #
+    # `None` means the payload carried no ceiling. It is NOT zero: an absent cap
+    # is stored as `""` by the indexer, and reading absence as 0% would invent a
+    # closure on every point written before the field existed.
+    pma_max_asing: int | str | None = None
 
 
 class KBLINotebookChatRequest(BaseModel):
@@ -171,6 +184,7 @@ def _result_from_payload(payload: dict[str, Any], score: float) -> "KBLISearchRe
         + "...",
         score=round(score, 4),
         pma_status=_payload_value(payload, "pma_status", default="UNKNOWN"),
+        pma_max_asing=_payload_value(payload, "pma_max_asing"),
         risk_category=_payload_value(payload, "kategori_risiko", default="Unknown"),
     )
 

--- a/apps/backend-rag/backend/app/routers/kbli_notebook_chat.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook_chat.py
@@ -204,6 +204,12 @@ async def _fill_bali_verdicts(results: list["KBLISearchResult"]) -> None:
             continue
         if not payload:
             continue
+        # Filled BEFORE the verdict gate on purpose: the national ceiling is a
+        # different fact from the Bali verdict, and a point that carries the cap
+        # but not the Bali layer must still hand the cap over. Never overwritten
+        # — the two payload-built constructors already set it from the same read.
+        if result.pma_max_asing is None:
+            result.pma_max_asing = _payload_value(payload, "pma_max_asing")
         blocked = _payload_value(payload, "bali_blocked")
         if blocked is None:
             continue
@@ -216,6 +222,149 @@ async def _fill_bali_verdicts(results: list["KBLISearchResult"]) -> None:
             result.bali_status,
             result.bali_blocked,
         )
+
+
+# --------------------------------------------------------------- national scope
+#
+# WHY THIS EXISTS. The note below used to open EVERY block with "This is a
+# PROVINCIAL restriction ... an activity can be 100% open nationally and still be
+# unregistrable in Bali." That is true of the Bali moratorium and false of the
+# rest: measured 2026-08-05 on `data/source_documents/KBLI_2025_FINAL_CLEAN.json`,
+# 518 codes carry `l4_bali.blocked` and **77** of them are closed to a PT PMA
+# everywhere in Indonesia. Asked about 64110 in production, the bot was right on
+# the substance and then framed a Bank Indonesia State monopoly as a provincial
+# rule — an answer whose natural next step for the reader is "then I will
+# register it in Jakarta".
+#
+# THE RULE IS DELIBERATELY THE PAGE'S RULE, code for code and status for status
+# (`apps/mouth/src/lib/kbli-bali-block.ts::isNationalClosure`). Two surfaces
+# answering the same question from the same record must not each grow their own
+# list — that is how `/kbli/69104` came to say one thing while WhatsApp said
+# another. They cannot share a module across Python and TypeScript, so the
+# identity is pinned by a test that reads the TypeScript file instead.
+#
+# The third input, the national ceiling, is the page's `nationallyClosed`
+# derivation: `pma_status == TERTUTUP` or a ceiling of 0%. It carries 63 of the
+# 77 on its own; the status set and the code list exist for the 14 where
+# `pma_status` says TERBUKA/100 while the activity is reserved by name.
+_NATIONAL_CLOSURE_STATUSES: dict[str, str] = {
+    "CHIUSO_REGOLATORE_SETTORIALE": "a sectoral regulator reserves the activity nationwide",
+    "CHIUSO_PMA_NO_BESAR": (
+        "the activity is allocated to Koperasi/UMKM by Perpres 49/2021 Lampiran II, "
+        "a bidang usaha a PT PMA cannot take"
+    ),
+}
+
+_NATIONAL_CLOSURE_CODES: dict[str, str] = {
+    "01287": "narcotics/medicinal-plant cultivation, TERTUTUP nationally",
+    "47111": "minimarket/supermarket retail, reserved to Indonesian citizens (WNI)",
+    "47112": "minimarket/supermarket retail, reserved to Indonesian citizens (WNI)",
+    "59131": "film/video distribution, TERTUTUP nationally",
+    "69102": "legal consultancy, reserved to Indonesian-licensed advocates (UU 18/2003)",
+    "69104": "notary/PPAT, a personal State office open to WNI only (UU 30/2004 as am. UU 2/2014)",
+    "86201": "a solo doctor's practice, closed to foreign nationals under Kemenkes health law",
+    "86202": "a solo specialist practice, closed to foreign nationals under Kemenkes health law",
+}
+
+
+# The pipeline's own vocabulary, rendered in words — a SECOND route into the
+# same leak, and the measurement is stated exactly because it is not the route
+# that was bleeding.
+#
+# The live leak was the note's own `Verdict code: {bali_status}` suffix: 450 of
+# the 518 blocked codes handed the model a symbol, and production repeated
+# `CHIUSO_REGOLATORE_SETTORIALE` to a client. Deleting that suffix is the cure.
+#
+# This helper covers the other way in: `bali_reason` is quoted to the model
+# verbatim, so a symbol written INSIDE a reason sentence would leak just the
+# same. Measured 2026-08-05 on the canonical: 9 reasons quote a symbol
+# (`OK_or_HIGHER_RISK` x6, `CHIUSO_MORATORIA_BALI` x2, `pma_cap_verified` x1)
+# and **none of the 9 is on a blocked code**, so today this guards a population
+# of ZERO — said plainly rather than counted as nine fixes. It is here because
+# the reason text is rewritten by cure lanes most weeks and a blocked code's
+# reason is one edit away from carrying one; its own mutation test proves it
+# bites, so it is defence-in-depth, not decoration.
+#
+# The sentence is still passed through; only the tokens are spoken. The fallback
+# — underscores to spaces — is what makes it fail-CLOSED: a symbol nobody has
+# mapped yet degrades to readable words instead of reaching a client.
+_INTERNAL_SYMBOL_RE = re.compile(r"\b[A-Za-z]+(?:_[A-Za-z]+)+\b")
+
+_SYMBOL_PLAIN_TEXT: dict[str, str] = {
+    "OK_or_HIGHER_RISK": "not reached by the moratorium",
+    "APERTO_BALI_RISCHIO_ALTO": "open in Bali at a higher risk tier",
+    "BLOCCATO_CLASSE_RISCHIO": "blocked by its risk class",
+    "BLOCCATO_DIPENDE_SCOPE": "blocked depending on the declared scope",
+    "CHIUSO_BALI": "closed in Bali",
+    "CHIUSO_BALI_PROPOSTO": "proposed for closure in Bali",
+    "CHIUSO_MORATORIA_BALI": "closed by the Bali moratorium",
+    "CHIUSO_PMA_NO_BESAR": "allocated to Koperasi/UMKM, not open to a PT PMA",
+    "CHIUSO_REGOLATORE_SETTORIALE": "closed by the sectoral regulator",
+    "NON_CLASSIFICABILE": "not classifiable from the data we hold",
+    "pma_cap_verified": "foreign-ownership cap verified",
+}
+
+
+def _speak_internal_symbols(text: object) -> str:
+    """Render pipeline enum tokens as words, leaving the sentence otherwise intact.
+
+    Takes `object`, not `str`, deliberately. This runs on EVERY answer, and the
+    reason is ASSIGNED onto the model from a Qdrant payload — Pydantic does not
+    validate on assignment, so a point storing a number there would hand `re.sub`
+    a non-string and 500 the answer. The first draft did exactly that and took 8
+    sibling tests down with it; a cosmetic step must never be able to kill the
+    answer it decorates.
+    """
+    if not isinstance(text, str):
+        text = str(text)
+    return _INTERNAL_SYMBOL_RE.sub(
+        lambda m: _SYMBOL_PLAIN_TEXT.get(m.group(0), m.group(0).replace("_", " ")),
+        text,
+    )
+
+
+def _is_zero_ceiling(value: object) -> bool:
+    """True only for a REAL 0% cap — absence must never read as a closure.
+
+    The indexer writes an absent cap as `""` and `_payload_value` maps `""`/None
+    to the default, so absence arrives as `None`. Comparing either to 0 is
+    already False in Python; this helper exists so that a later "tidy-up" to
+    `int(value or 0)` — which would turn every point without the field into a
+    national closure — has to argue with a named function and its test.
+
+    A digit STRING counts. The canonical stores integers and a string should not
+    occur, but if one ever does, the failure has to land on the safe side: `"0"`
+    read as "no ceiling recorded" is the reading that tells a client an activity
+    closed to foreign capital is open.
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value == 0
+    if isinstance(value, str):
+        text = value.strip()
+        return text.isdigit() and int(text) == 0  # "" is not a digit string
+    return False
+
+
+def _national_closure_basis(result: "KBLISearchResult") -> str | None:
+    """Why this activity is closed to a PT PMA nationwide, or None if it is not.
+
+    Returns a PHRASE, not a boolean, because the note has to tell the reader what
+    closed it: "closed nationally" with no basis is the kind of assertion this
+    lane keeps having to withdraw.
+    """
+    by_code = _NATIONAL_CLOSURE_CODES.get(result.code)
+    if by_code:
+        return by_code
+    by_status = _NATIONAL_CLOSURE_STATUSES.get(result.bali_status or "")
+    if by_status:
+        return by_status
+    if (result.pma_status or "").strip().upper() == "TERTUTUP":
+        return "the national PMA list closes the activity (TERTUTUP)"
+    if _is_zero_ceiling(result.pma_max_asing):
+        return "the national foreign-ownership ceiling is 0%"
+    return None
 
 
 def _bali_verdict_context_note(result: "KBLISearchResult") -> str:
@@ -238,20 +387,69 @@ def _bali_verdict_context_note(result: "KBLISearchResult") -> str:
     * **The reason is passed through, never re-worded.** It is the sentence the
       adjudication wrote, and it already names its own instrument — a summary
       here would be a second opinion drifting away from the page.
+
+    Two more, added 2026-08-05 (see `_national_closure_basis` above):
+
+    * **Scope before wording.** A block is described as provincial only when it
+      IS provincial. 77 of the 518 are national, and calling those "a Bali
+      restriction" hands the reader the wrong next step.
+    * **No internal symbol reaches the model.** The note used to end with
+      `Verdict code: CHIUSO_REGOLATORE_SETTORIALE`, and production repeated that
+      token to a client. The vocabulary of the pipeline is not the vocabulary of
+      an answer — the page has held that line since 2026-07-25
+      (`kbli-status-labels.ts::INTERNAL_ENUM_LABELS`); this was the surface that
+      had not. The symbol still goes to the log, where it belongs.
+
+    NOT handled here, and measured rather than assumed: an activity that is
+    nationally closed and carries NO Bali verdict at all. Today that set is
+    empty (0 of 1,559), and widening the silence-on-absence contract to cover a
+    population of zero would trade a proven innocence property for nothing.
     """
     if result.bali_blocked is None:
         return ""
+
+    national = _national_closure_basis(result)
+    # Coerce BEFORE `.strip()`, not after: `(42 or "").strip()` raises, and that
+    # ordering bug predates this change — it has been one malformed payload away
+    # from a 500 since the field was added.
+    reason = _speak_internal_symbols(result.bali_reason or "").strip()
+
     if not result.bali_blocked:
+        if national:
+            # 79122 today, and the shape is what matters: the moratorium does not
+            # reach it, so the old text said "NOT blocked" and stopped — a
+            # sentence whose only reading is "go ahead" on an activity closed to
+            # foreign capital outright. "Not blocked in Bali" is not permission.
+            return (
+                "NOT blocked by the Bali provincial moratorium — but this activity is "
+                "closed to a foreign-owned company (PT PMA) at the NATIONAL level "
+                f"({national}), so the absence of a Bali block is NOT permission. You "
+                "MUST NOT present it as registrable by a PT PMA."
+            )
         return (
             "BALI: this activity is NOT blocked for a PT PMA by the Bali provincial "
             "moratorium. National ownership rules still apply separately."
         )
-    reason = (result.bali_reason or "").strip()
+
+    if national:
+        note = (
+            "CLOSED TO A FOREIGN-OWNED COMPANY (PT PMA) — NATIONALLY, not only in Bali. "
+            f"The closure is {national}, so it applies everywhere in Indonesia: "
+            "registering the activity in another province does NOT change the answer, "
+            "and there is no Jakarta route around it."
+        )
+        if reason:
+            note = f"{note} Stated cause: {reason}"
+        return (
+            f"{note} You MUST say a PT PMA cannot register this activity anywhere in "
+            "Indonesia and give this cause. Do NOT describe it as a Bali-only "
+            "restriction and do NOT offer another province as an alternative."
+        )
+
     note = (
         "BALI — BLOCKED FOR A FOREIGN-OWNED COMPANY (PT PMA). This is a PROVINCIAL "
         "restriction and it is independent of the national PMA status above: an "
-        f"activity can be 100% open nationally and still be unregistrable in Bali. "
-        f"Verdict code: {result.bali_status}."
+        "activity can be 100% open nationally and still be unregistrable in Bali."
     )
     if reason:
         note = f"{note} Stated cause: {reason}"
@@ -431,12 +629,16 @@ async def _generate_kbli_explanation_gemini(
 
 @cached(
     ttl=43200,
-    prefix="kbli_explain_v28",
+    prefix="kbli_explain_v29",
 )  # Cache explanations for 12 hours.
 # v28 (2026-08-03): the Bali provincial verdict now reaches the model. The bump is
 # NOT cosmetic — this cache is 12h deep and keyed on the prefix, so every answer
 # already stored under v27 was generated blind to the Bali block and would keep
 # being served for half a day after the deploy. A cure the cache hides is not live.
+# v29 (2026-08-05): 77 national closures are no longer framed as Bali-provincial,
+# and no internal verdict symbol reaches the model. Same reason for the bump, and
+# it bites harder here: an answer cached under v28 is one that told a client to
+# try another province, and it would keep saying so for 12 hours after deploy.
 async def _generate_kbli_explanation(
     query: str,
     results: list[KBLISearchResult],
@@ -1131,6 +1333,12 @@ async def chat_kbli(
                         + "...",
                         score=round(r.get("score", 0.0), 4),
                         pma_status=_payload_value(p, "pma_status", default="Verify at OSS"),
+                        # No default: absence must stay None, never 0% (see the
+                        # field's own comment). This is the ONE constructor that
+                        # fills the Bali verdict itself, so the choke-point
+                        # backfill skips it — the cap has to be taken here or it
+                        # is never taken at all.
+                        pma_max_asing=_payload_value(p, "pma_max_asing"),
                         risk_category=_payload_value(p, "kategori_risiko", default="Verify at OSS"),
                         bali_status=_payload_value(p, "bali_status"),
                         # No default: a missing field must stay None so the note

--- a/apps/backend-rag/backend/tests/unit/routers/test_kbli_bali_verdict_reaches_the_model.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_kbli_bali_verdict_reaches_the_model.py
@@ -58,7 +58,11 @@ def test_a_blocked_code_produces_a_note_the_model_cannot_read_as_permission():
         ),
     )
     assert "BLOCKED FOR A FOREIGN-OWNED COMPANY" in note
-    assert "CHIUSO_MORATORIA_BALI" in note
+    # This line read `assert "CHIUSO_MORATORIA_BALI" in note` until 2026-08-05,
+    # which pinned a leak as if it were a feature: the note ended with
+    # `Verdict code: <symbol>` and production read that symbol out to a client.
+    # The stated cause carries the meaning; the symbol carried our vocabulary.
+    assert "CHIUSO_MORATORIA_BALI" not in note
     assert "Menengah Rendah" in note
     assert "Do not answer that it can be registered in Bali." in note
 
@@ -203,8 +207,8 @@ def test_the_explanation_cache_prefix_moved_with_this_change():
     # arithmetic across a worktree is its own way to fail while looking fine.
     source = Path(inspect.getsourcefile(mod))
     text = source.read_text(encoding="utf-8")
-    assert 'prefix="kbli_explain_v28"' in text
-    assert 'prefix="kbli_explain_v27"' not in text
+    assert 'prefix="kbli_explain_v29"' in text
+    assert 'prefix="kbli_explain_v28"' not in text
 
 
 def test_the_fill_runs_inside_the_function_every_answer_passes_through():
@@ -216,3 +220,383 @@ def test_the_fill_runs_inside_the_function_every_answer_passes_through():
 
     fn = getattr(_generate_kbli_explanation, "__wrapped__", _generate_kbli_explanation)
     assert "_fill_bali_verdicts(results)" in inspect.getsource(fn)
+
+
+# ================================================================== national scope
+#
+# ADDED 2026-08-05. The note above reached the model, and then told 77 codes'
+# readers the wrong thing about WHERE the closure applies. Asked about 64110
+# (Bank Sentral) in production, the bot was right on the substance and framed a
+# Bank Indonesia State monopoly as a Bali provincial rule — whose natural next
+# step for a client is "then I will register it in Jakarta". It also printed the
+# internal verdict symbol.
+#
+# The corpus below pulls in three directions, because there are three ways to be
+# wrong here: calling a national closure provincial (the bug), calling a
+# provincial one national (the over-correction, which would tell a client Bali's
+# moratorium reaches Java), and reading an ABSENT field as a closure.
+
+import json  # noqa: E402
+import re  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from backend.app.routers.kbli_notebook_chat import (  # noqa: E402
+    _NATIONAL_CLOSURE_CODES,
+    _NATIONAL_CLOSURE_STATUSES,
+    _is_zero_ceiling,
+    _national_closure_basis,
+)
+
+_PROVINCIAL_SENTENCE = "This is a PROVINCIAL restriction"
+_NATIONAL_SENTENCE = "NATIONALLY, not only in Bali"
+
+# backend/tests/unit/routers/ -> repo root (the same arithmetic
+# test_kbli_hardcoded_fallback_matches_catalogue.py already uses).
+_CANONICAL = (
+    Path(__file__).resolve().parents[6] / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+)
+
+# An underscore-joined token is pipeline vocabulary by construction. No allow
+# list: the point is to cover the symbol nobody has invented yet.
+_SYMBOL_RE = re.compile(r"\b[A-Za-z]+(?:_[A-Za-z]+)+\b")
+
+
+@pytest.fixture(scope="module")
+def catalogue() -> list[dict]:
+    """The real 1,559-code canonical. A missing file FAILS rather than skips —
+    a gate that quietly stops running is the failure mode this repo pays for
+    most often (superscar #2)."""
+    assert _CANONICAL.is_file(), f"canonical dataset not found at {_CANONICAL}"
+    records = json.loads(_CANONICAL.read_text(encoding="utf-8"))["data"]
+    assert len(records) > 1000, f"catalogue looks truncated: {len(records)} records"
+    return records
+
+
+def _result_for(record: dict) -> KBLISearchResult:
+    """A search result carrying exactly what the Qdrant payload carries."""
+    l4 = record.get("l4_bali") or {}
+    return KBLISearchResult(
+        code=record["kode_kbli_2025"],
+        title=record.get("judul") or "",
+        description="",
+        score=1.0,
+        pma_status=record.get("pma_status") or "UNKNOWN",
+        pma_max_asing=record.get("pma_max_asing"),
+        bali_status=l4.get("status"),
+        bali_blocked=l4.get("blocked"),
+        bali_reason=l4.get("reason") or "",
+    )
+
+
+# --------------------------------------------------------------- guilt: national
+
+
+def test_a_state_monopoly_is_not_described_as_a_bali_restriction():
+    """64110, the code that produced the wrong answer in production."""
+    note = _bali_verdict_context_note(
+        _result(
+            "64110",
+            title="Bank Sentral",
+            pma_status="TERBUKA",
+            pma_max_asing=100,
+            bali_blocked=True,
+            bali_status="CHIUSO_REGOLATORE_SETTORIALE",
+            bali_reason="Bank Sentral — exclusive State monopoly operated by Bank Indonesia.",
+        ),
+    )
+    assert _NATIONAL_SENTENCE in note
+    assert _PROVINCIAL_SENTENCE not in note
+    assert "another province does NOT change the answer" in note
+    assert "Bank Indonesia" in note  # the stated cause still passes through
+    assert "CHIUSO_REGOLATORE_SETTORIALE" not in note
+
+
+def test_a_code_reserved_by_name_is_national_even_when_pma_status_says_open():
+    """69104 (notary/PPAT) reads TERBUKA/100 on the record — the ownership fields
+    never learned about the reservation. Without the code list the note would
+    call a personal State office a Bali problem."""
+    note = _bali_verdict_context_note(
+        _result(
+            "69104",
+            pma_status="TERBUKA",
+            pma_max_asing=100,
+            bali_blocked=True,
+            bali_status="TERTUTUP",
+            bali_reason="Notary/PPAT is a personal State office, WNI only (UU 30/2004).",
+        ),
+    )
+    assert _NATIONAL_SENTENCE in note
+    assert _PROVINCIAL_SENTENCE not in note
+    assert "notary/PPAT" in note
+
+
+def test_a_tertutup_pma_status_makes_the_closure_national():
+    note = _bali_verdict_context_note(
+        _result(
+            "01287",
+            pma_status="TERTUTUP",
+            pma_max_asing=0,
+            bali_blocked=True,
+            bali_status="TERTUTUP",
+            bali_reason="Closed to foreign ownership at the national level.",
+        ),
+    )
+    assert _NATIONAL_SENTENCE in note
+    assert _PROVINCIAL_SENTENCE not in note
+
+
+def test_a_zero_ceiling_makes_the_closure_national_even_under_a_terbatas_label():
+    """The word says "restricted", the number says 0%. A reader shown only the
+    word hears "find a local partner"; there is nothing to partner into."""
+    note = _bali_verdict_context_note(
+        _result(
+            "16221",
+            pma_status="TERBATAS",
+            pma_max_asing=0,
+            bali_blocked=True,
+            bali_status="BLOCCATO_CLASSE_RISCHIO",
+            bali_reason="blocked in Bali by the PMA moratorium",
+        ),
+    )
+    assert _NATIONAL_SENTENCE in note
+    assert "ceiling is 0%" in note
+
+
+def test_not_blocked_in_bali_is_not_permission_when_the_national_door_is_shut():
+    """79122 — Umrah/Hajj travel. TERBATAS with a ceiling of 0, and the Bali
+    moratorium does not reach it, so the old note said "NOT blocked" and stopped.
+    That sentence has exactly one reading, and it is the wrong one."""
+    note = _bali_verdict_context_note(
+        _result(
+            "79122",
+            title="Biro Perjalanan Ibadah Umrah dan Haji Khusus",
+            pma_status="TERBATAS",
+            pma_max_asing=0,
+            bali_blocked=False,
+            bali_status="OK_or_HIGHER_RISK",
+        ),
+    )
+    assert "NOT permission" in note
+    assert "NATIONAL level" in note
+    assert "MUST NOT present it as registrable" in note
+
+
+# ------------------------------------------------------------ innocence: provincial
+
+
+def test_a_real_moratorium_block_is_still_called_provincial():
+    """86995, the case the previous lane shipped. Over-correcting here would tell
+    a client that Bali's moratorium reaches Java."""
+    note = _bali_verdict_context_note(
+        _result(
+            bali_blocked=True,
+            bali_status="CHIUSO_MORATORIA_BALI",
+            bali_reason="blocked in Bali by the PMA moratorium: risk tier ['Menengah Rendah']",
+            pma_status="TERBUKA",
+            pma_max_asing=100,
+        ),
+    )
+    assert _PROVINCIAL_SENTENCE in note
+    assert _NATIONAL_SENTENCE not in note
+    assert "can be 100% open nationally" in note
+
+
+def test_an_open_code_that_is_not_blocked_gets_no_national_warning():
+    note = _bali_verdict_context_note(
+        _result(bali_blocked=False, bali_status="OK_or_HIGHER_RISK", pma_status="TERBUKA", pma_max_asing=100),
+    )
+    assert "NOT blocked" in note
+    assert "NOT permission" not in note
+    assert "NATIONAL level" not in note
+
+
+# -------------------------------------------- innocence: absence is not a closure
+
+
+def test_an_absent_ceiling_is_never_read_as_zero_percent():
+    """The indexer writes an absent cap as `""`. Reading absence as 0% would
+    invent a national closure on every point written before the field existed —
+    the same inference this lane spent a week withdrawing from `bali_blocked`."""
+    for absent in (None, "", "  "):
+        assert not _is_zero_ceiling(absent), f"{absent!r} must not read as a 0% ceiling"
+        note = _bali_verdict_context_note(
+            _result(
+                bali_blocked=True,
+                bali_status="BLOCCATO_CLASSE_RISCHIO",
+                bali_reason="risk class",
+                pma_status="TERBUKA",
+                pma_max_asing=absent,
+            ),
+        )
+        assert _PROVINCIAL_SENTENCE in note
+        assert _NATIONAL_SENTENCE not in note
+
+
+def test_the_ceiling_test_reads_a_real_zero_in_either_shape_and_never_a_boolean():
+    assert _is_zero_ceiling(0) is True
+    assert _is_zero_ceiling("0") is True  # a digit string still means 0%
+    assert _is_zero_ceiling(False) is False  # bool is an int in Python; not a cap
+    assert _is_zero_ceiling(100) is False
+    assert _is_zero_ceiling("100") is False
+
+
+def test_an_absent_verdict_still_produces_silence_after_the_national_branch():
+    """The silence-on-absence contract is the innocence property the previous
+    lane shipped; the national branch must not have opened a hole in it."""
+    assert _bali_verdict_context_note(_result(pma_status="TERTUTUP", pma_max_asing=0)) == ""
+
+
+# ------------------------------------------------------ the pipeline's vocabulary
+
+
+def test_a_symbol_written_inside_a_reason_is_spoken_not_quoted():
+    """The `Verdict code:` suffix was the leak that bled. This is the OTHER route
+    in: `bali_reason` is passed to the model verbatim, so a symbol inside the
+    sentence would leak just the same. Measured 2026-08-05, 9 reasons quote a
+    symbol and none is on a blocked code — so this guards a population of zero
+    today and exists because reasons are rewritten most weeks."""
+    note = _bali_verdict_context_note(
+        _result(
+            bali_blocked=True,
+            bali_status="BLOCCATO_CLASSE_RISCHIO",
+            bali_reason="tier carried over from OK_or_HIGHER_RISK; see pma_cap_verified",
+            pma_status="TERBUKA",
+            pma_max_asing=100,
+        ),
+    )
+    assert "OK_or_HIGHER_RISK" not in note
+    assert "pma_cap_verified" not in note
+    assert "not reached by the moratorium" in note
+    assert "foreign-ownership cap verified" in note
+
+
+def test_an_unmapped_symbol_degrades_to_words_rather_than_reaching_a_client():
+    """Fail-CLOSED: the next symbol nobody has mapped must not leak while waiting
+    for someone to notice it."""
+    note = _bali_verdict_context_note(
+        _result(
+            bali_blocked=True,
+            bali_status="BLOCCATO_CLASSE_RISCHIO",
+            bali_reason="verdict CHIUSO_QUALCOSA_DI_NUOVO applies",
+            pma_status="TERBUKA",
+            pma_max_asing=100,
+        ),
+    )
+    assert "CHIUSO_QUALCOSA_DI_NUOVO" not in note
+    assert "CHIUSO QUALCOSA DI NUOVO" in note
+
+
+# ---------------------------------------------------------- the whole catalogue
+
+
+def test_no_note_in_the_whole_catalogue_hands_the_model_an_internal_symbol(catalogue):
+    """Measured on the REAL canonical, not on fixtures, and stated as a PROPERTY
+    rather than a frozen count — the dataset is edited by cure lanes most weeks,
+    and a gate that breaks on every data PR is a gate that gets deleted.
+
+    Deliberately NOT an allow list of the symbols we know: an underscore-joined
+    token is pipeline vocabulary by construction, so a symbol invented tomorrow
+    is covered the day it appears. `TERTUTUP` and `TERBATAS` carry no underscore
+    and are official regulatory words — they are not, and must not become, leaks.
+    """
+    offenders = []
+    for record in catalogue:
+        note = _bali_verdict_context_note(_result_for(record))
+        offenders.extend((record["kode_kbli_2025"], sym) for sym in _SYMBOL_RE.findall(note))
+    assert offenders == [], f"internal symbols reaching the model: {offenders[:10]}"
+
+
+def test_every_national_closure_in_the_catalogue_refuses_the_provincial_wording(catalogue):
+    national = provincial = 0
+    for record in catalogue:
+        result = _result_for(record)
+        note = _bali_verdict_context_note(result)
+        if not note:
+            continue
+        if _national_closure_basis(result):
+            assert _PROVINCIAL_SENTENCE not in note, record["kode_kbli_2025"]
+            national += 1
+        elif _PROVINCIAL_SENTENCE in note:
+            provincial += 1
+    # Both populations must be non-empty. A dataset shift that empties either one
+    # would leave the assertions above trivially true — this makes that loud
+    # instead of silent, without freezing a count the cure lanes move weekly.
+    # Measured 2026-08-05: 78 national (77 blocked + 79122), 441 provincial.
+    assert national > 0, "no national closure found — the gate would be vacuous"
+    assert provincial > 0, "no provincial block found — the gate would be vacuous"
+
+
+def test_a_non_string_reason_is_survived_rather_than_500ing_the_answer():
+    """Two defects, one assertion, and the split is stated because measuring it
+    changed the story.
+
+    `bali_reason` is ASSIGNED onto the model from a Qdrant payload and Pydantic
+    does not validate on assignment, so a point storing a number there reaches
+    the formatter. `(42 or "").strip()` raises — and that ordering has been on
+    main since the field was added, one malformed payload away from a 500 on a
+    real question. NOT a regression: a latent defect this change had to walk past.
+
+    What WAS mine: the first draft handed the value straight to `re.sub`, which
+    also rejects the MagicMock the sibling suite uses as a double. The control
+    said it plainly — 42 passed on origin/main, 8 failed with my file."""
+    from backend.app.routers.kbli_notebook_chat import _speak_internal_symbols
+
+    assert _speak_internal_symbols(123) == "123"
+    assert _speak_internal_symbols(None) == "None"
+
+    result = _result(bali_blocked=True, bali_status="BLOCCATO_CLASSE_RISCHIO")
+    result.bali_reason = 42  # what a malformed payload would put there
+    note = _bali_verdict_context_note(result)  # must not raise
+    assert "BLOCKED FOR A FOREIGN-OWNED COMPANY" in note
+
+
+# ------------------------------------------------- one verdict, two surfaces
+
+_PAGE_RULE = (
+    Path(__file__).resolve().parents[6]
+    / "apps"
+    / "mouth"
+    / "src"
+    / "lib"
+    / "kbli-bali-block.ts"
+)
+
+
+def _page_rule_source() -> str:
+    """A missing file is a FAILURE, never a skip. "I could not check" read as
+    "clean" is how this repo loses gates (W106b: cannot-verify is its own state,
+    and it is not innocence)."""
+    assert _PAGE_RULE.is_file(), f"the page's rule is not where this test expects it: {_PAGE_RULE}"
+    return _PAGE_RULE.read_text(encoding="utf-8")
+
+
+def test_the_backend_and_the_page_name_the_same_national_closure_statuses():
+    """`/kbli/69104` and WhatsApp answer the same question from the same record.
+    They cannot share a module across TypeScript and Python, so the identity is
+    asserted instead — otherwise each surface grows its own list and a client
+    gets two answers, which is the defect this whole lane exists to remove."""
+    block = re.search(
+        r"NATIONAL_CLOSURE_STATUSES\s*=\s*new Set<string>\(\[(.*?)\]\)",
+        _page_rule_source(),
+        re.S,
+    )
+    assert block, "could not find NATIONAL_CLOSURE_STATUSES in the page's rule"
+    page = set(re.findall(r'"([A-Z_]+)"', block.group(1)))
+    assert page, "parsed the page's status set as EMPTY — the parser, not the rule, is broken"
+    assert page == set(_NATIONAL_CLOSURE_STATUSES), (
+        f"page={sorted(page)} backend={sorted(_NATIONAL_CLOSURE_STATUSES)}"
+    )
+
+
+def test_the_backend_and_the_page_name_the_same_national_closure_codes():
+    block = re.search(
+        r"NATIONAL_CLOSURE_CODES\s*=\s*new Map<string, string>\(\[(.*?)\n\]\);",
+        _page_rule_source(),
+        re.S,
+    )
+    assert block, "could not find NATIONAL_CLOSURE_CODES in the page's rule"
+    page = set(re.findall(r'\[\s*\n?\s*"(\d{4,5})"', block.group(1)))
+    assert page, "parsed the page's code list as EMPTY — the parser, not the rule, is broken"
+    assert page == set(_NATIONAL_CLOSURE_CODES), (
+        f"page={sorted(page)} backend={sorted(_NATIONAL_CLOSURE_CODES)}"
+    )


### PR DESCRIPTION
## What a client was told

Asked in production whether a foreign-owned company could register **KBLI 64110 (Bank Sentral)**, `chat_kbli` was right on the substance — and then framed a **Bank Indonesia State monopoly as a PROVINCIAL restriction**, whose natural next step for the reader is *"then I will register it in Jakarta."* It also ended the note with `Verdict code: CHIUSO_REGOLATORE_SETTORIALE`, and the model repeated that token to a client.

This is the fifth consuming surface of the same fact. The website was cured in #3609 and #3612; WhatsApp and webchat still said the old thing.

## The measurement

`_bali_verdict_context_note` opened **every** block with *"This is a PROVINCIAL restriction … an activity can be 100% open nationally and still be unregistrable in Bali."* True of the Bali moratorium, false of the rest. On `data/source_documents/KBLI_2025_FINAL_CLEAN.json`:

| | codes |
|---|---|
| carry `l4_bali.blocked` | 518 |
| …of which closed to a PT PMA **nationwide** | **77** |
| …of which invisible to a `pma_status` check (record reads TERBUKA/100) | 14 |
| still correctly provincial | 441 |

The 77 include notary/PPAT, solo medical and specialist practice, legal consultancy, minimarket retail, the Koperasi/UMKM-allocated set, and Bank Sentral.

**The worse half is the code the moratorium does NOT reach.** `79122` (Umrah/Hajj travel) reads `TERBATAS` with a foreign-ownership ceiling of **0** and `bali_blocked: false` — so the note said *"NOT blocked for a PT PMA by the Bali provincial moratorium"* and stopped. That sentence has exactly one reading, on an activity closed to foreign capital outright.

## The rule is the page's rule

Deliberately identical, code for code and status for status, to `apps/mouth/src/lib/kbli-bali-block.ts` (#3612). Two surfaces answering the same question from the same record must not each grow their own list — that is how `/kbli/69104` came to say one thing while WhatsApp said another. They cannot share a module across Python and TypeScript, so **two tests parse the TypeScript and assert the identity**.

## Also fixed, and stated separately because measuring it changed the story

`(result.bali_reason or "").strip()` raises on a non-string, and `bali_reason` is **assigned** from a Qdrant payload where Pydantic does not validate on assignment. That has been one malformed point away from a 500 since the field was added — **it predates this change**; it is not a regression this PR caused.

Cache prefix `v28 → v29`: a 12h-deep cache keyed on the prefix would keep serving *"try another province"* for half a day after deploy.

## Verification

- **27 tests**, guilt and innocence in both directions: a real moratorium block is still called provincial (over-correcting would tell a client Bali's rules reach Java); an **absent** ceiling is never read as 0%; an absent verdict still produces silence.
- **Mutation-verified 5/5** — disabling the national rule, the symbol speaker, the zero-ceiling test, or either half of the cross-surface parity turns the corpus red. The first run of one mutation was a no-op from a bug in my own script and is not counted as a pass.
- **Catalogue-wide property gate** over the real 1,559 records: **0** internal symbols reach the model, 78 national notes refuse the provincial wording, 441 provincial notes keep it. Properties, not frozen counts — the dataset is edited weekly and a gate that breaks on every data PR is a gate that gets deleted.
- The first draft broke **8 sibling tests**; a control on `origin/main` proved they were mine (42 passed there, 8 failed here). Cured and pinned by a test.

## Not covered, measured rather than assumed

An activity nationally closed with **no** Bali verdict at all: that set is empty today (0 of 1,559). Widening the silence-on-absence contract for a population of zero would trade a proven innocence property for nothing.

Local pre-push backend suite did **not** run on this machine — M5 has no local PostgreSQL on 5432, and the hook says so rather than reading green. The suites above were run by hand; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)