### PR TITLE
fix(kbli): the channel dropped the obligations 98% of records carry, and the cure could not re-cure its own output

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -221,8 +221,33 @@ CONFORMANCE_EXIT_CANNOT_VERIFY = 4
 # machine template earns a rebuild. Measured 2026-08-02: all 50 machine-shaped
 # rows in the live divergent set carry exactly these three sections and nothing
 # else, so a row with a hand-added section is refused rather than overwritten.
+#
+# THE CURE COULD NOT RE-CURE ITS OWN OUTPUT (measured 2026-08-05).
+#
+# This set held the three sections of the 2026-02-18 SEED. But `build_content`
+# also writes `## Perizinan` (always) and `## Catatan Verifikasi` (when there is
+# a data note) — sections the seed never had. So every row this tool wrote
+# failed its own `is_machine_template` and was refused on the next run as
+# hand-written prose that must not be destroyed: prose the machine itself wrote.
+# Measured on the live table: of the 55 rows cured on 2026-08-03, **0** were
+# still recognised — all 55 were frozen against any future licensing update.
+#
+# The listed constant is now the seed's three PLUS everything the builder emits,
+# and `test_the_builders_own_output_is_recognised_by_the_recogniser` regenerates
+# real content and asserts the round trip — so adding a section to
+# `build_content` without declaring it here fails CI instead of silently
+# freezing the rows it writes.
 MACHINE_TEMPLATE_SECTIONS = frozenset(
-    {"Informasi Umum", "Deskripsi Kegiatan Usaha", "Investasi Asing (PMA)"}
+    {
+        # the 2026-02-18 seed
+        "Informasi Umum",
+        "Deskripsi Kegiatan Usaha",
+        "Investasi Asing (PMA)",
+        # emitted by build_content — see the round-trip test
+        "Perizinan",
+        "Kewajiban",
+        "Catatan Verifikasi",
+    }
 )
 _SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.M)
 
@@ -458,6 +483,93 @@ def _render_per_skala_entry(entry: dict) -> str:
     )
 
 
+# The extraction carries markup on ~1.8% of obligation strings (1,524 of 86,241
+# requirement+obligation entries, measured 2026-08-05). Stripped, never
+# rendered: this text is read by an LLM and spoken to a client, and `<strong>`
+# is not a fact.
+_HTML_TAG_RE = re.compile(r"<[a-zA-Z/][^>]*>")
+
+# Beyond this, the obligation block would dominate the document it is part of.
+# Measured on canonical: 1,490 of 1,559 records (95.6%) fit whole; 69 do not,
+# and those say so IN THE TEXT rather than being quietly cut (W97 — a silent
+# truncation reads downstream as "this is everything").
+KEWAJIBAN_BLOCK_MAX_CHARS = 8000
+
+
+def _scale_label(entry: dict) -> str:
+    label = _join(entry.get("skala_usaha"))
+    scope = entry.get("scope_uraian")
+    return f"{label} ({scope})" if scope else label
+
+
+def build_kewajiban_section(record: dict) -> list[str]:
+    """The statutory obligations, grouped by the scales that share them.
+
+    WHY THIS EXISTS (measured on canonical 2026-08-05, 9,095 per-scale rows):
+
+        perizinan    non-empty in     17 rows  (0.19%)
+        persyaratan  non-empty in  5,369 rows  (59%)
+        kewajiban    non-empty in  8,951 rows  (98%)
+
+    `## Perizinan` renders `perizinan` and nothing else — the ONE field that is
+    empty 99.8% of the time — so the channel's answer about what a business must
+    actually do was `Perizinan: N/A` for practically the whole catalogue, while
+    the field carrying the real obligations was dropped. On `96230` (a day spa)
+    canonical holds "Memiliki Sertifikat Standar Usaha Pariwisata" and "Memiliki
+    Sertifikat Laik Sehat (SLS)" — the SLHS itself — and the channel was telling
+    clients the requirements were "still pending". The WEBSITE already renders
+    them (`balizero.com/kbli/96230` prints "Laik Sehat"), so this is the same
+    shape as the rest of this lane: the page tells the truth, the channel does not.
+
+    GROUPED, not per-scale-repeated, because the same obligation is usually
+    carried by every scale: rendering it once per row costs 3.5M characters
+    catalogue-wide against 1.1M grouped, and a client does not need "Sertifikat
+    Laik Sehat" four times. The scales are NAMED on each group, because 912 of
+    1,341 records genuinely differ by scale — collapsing them to one block would
+    lose which scale an obligation belongs to.
+
+    `persyaratan` is deliberately NOT rendered here: 6% of its entries are
+    multi-line OSS document checklists (max 6,622 chars) whose bounded shape is
+    a separate design question, ledgered rather than guessed at. Stating that is
+    the point — an omission nobody wrote down reads as "there was nothing".
+    """
+    groups: dict[tuple[str, ...], list[str]] = {}
+    for entry in record.get("per_skala") or []:
+        if not isinstance(entry, dict):
+            continue
+        raw = entry.get("kewajiban") or []
+        if not isinstance(raw, list):
+            raw = [raw]
+        cleaned = tuple(
+            text
+            for text in (_HTML_TAG_RE.sub("", str(v)).strip() for v in raw if v)
+            if text
+        )
+        if not cleaned:
+            continue
+        groups.setdefault(cleaned, []).append(_scale_label(entry))
+
+    if not groups:
+        return []
+
+    lines: list[str] = []
+    budget = KEWAJIBAN_BLOCK_MAX_CHARS
+    dropped = 0
+    for obligations, scales in groups.items():
+        bullet = f"- **{', '.join(scales)}**: " + "; ".join(obligations)
+        if len(bullet) > budget and lines:
+            dropped += 1
+            continue
+        budget -= len(bullet)
+        lines.append(bullet)
+    if dropped:
+        lines.append(
+            f"- _({dropped} ulteriori kelompok kewajiban tidak ditampilkan di sini "
+            f"karena panjang — tanyakan skala usaha tertentu untuk rinciannya.)_"
+        )
+    return ["", "## Kewajiban", *lines]
+
+
 def build_perizinan_section(record: dict) -> str:
     """The licensing section — the ONLY place licensing/risk facts can enter
     the cured content. Two branches, both provenance-bound:
@@ -504,6 +616,7 @@ def build_cured_content(code: str, record: dict) -> str:
     if pma_nota:
         lines.append(f"- Catatan PMA: {pma_nota}")
     lines += ["", "## Perizinan", build_perizinan_section(record)]
+    lines += build_kewajiban_section(record)
     if data_note:
         lines += ["", "## Catatan Verifikasi", data_note]
     return "\n".join(lines).strip() + "\n"

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -987,3 +987,181 @@ def test_no_snapshot_means_the_detector_queries_the_db_as_before(monkeypatch, tm
     monkeypatch.setattr("backend.scripts.kbli_documents_cure.subprocess.run", _run)
     fetch_conformance_report(script)
     assert "--table-json" not in seen["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# THE OBLIGATIONS THE CHANNEL WAS DROPPING — and the cure that could not
+# re-cure its own output (2026-08-05)
+#
+# Measured on canonical, 9,095 per-scale rows:
+#     perizinan    non-empty in     17 rows  (0.19%)
+#     persyaratan  non-empty in  5,369 rows  (59%)
+#     kewajiban    non-empty in  8,951 rows  (98%)
+#
+# `## Perizinan` rendered `perizinan` and nothing else — the one field that is
+# empty 99.8% of the time — so the channel answered `Perizinan: N/A` about a
+# catalogue whose obligations we hold. The website already renders them.
+# ---------------------------------------------------------------------------
+
+import json as _json_obl
+from pathlib import Path as _Path_obl
+
+from backend.scripts.kbli_documents_cure import (  # noqa: E402
+    KEWAJIBAN_BLOCK_MAX_CHARS,
+    build_cured_content,
+    build_kewajiban_section,
+    is_machine_template,
+)
+
+
+def _repo_root_obl() -> _Path_obl:
+    """Walk up to the checkout root rather than counting directories — a depth
+    constant silently reads the wrong tree the day this file moves, and a
+    missing canonical would turn the organ below into a green no-op."""
+    here = _Path_obl(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json").is_file():
+            return parent
+    raise AssertionError(f"canonical dataset not found walking up from {here}")
+
+
+_CANONICAL_OBL = (
+    _repo_root_obl() / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+)
+
+
+def _canonical_by_code():
+    payload = _json_obl.loads(_CANONICAL_OBL.read_text(encoding="utf-8"))
+    return {r["kode_kbli_2025"]: r for r in payload["data"]}
+
+
+def _scale(skala, kewajiban, scope=None):
+    entry = {"skala_usaha": [skala], "kategori_risiko": "Rendah", "kewajiban": kewajiban}
+    if scope:
+        entry["scope_uraian"] = scope
+    return entry
+
+
+def test_the_spa_obligation_the_channel_was_hiding_is_rendered():
+    """96230 — canonical holds the SLHS and the channel said "requirements pending"."""
+    record = _canonical_by_code()["96230"]
+    block = "\n".join(build_kewajiban_section(record))
+    assert "Sertifikat Laik Sehat" in block
+    assert "Sertifikat Standar Usaha Pariwisata" in block
+
+
+def test_scales_sharing_an_obligation_are_named_together_and_the_text_appears_once():
+    record = {
+        "per_skala": [
+            _scale("Mikro", ["Lapor ke Menteri"]),
+            _scale("Kecil", ["Lapor ke Menteri"]),
+            _scale("Besar", ["Sertifikat Laik Sehat"]),
+        ]
+    }
+    block = "\n".join(build_kewajiban_section(record))
+    assert block.count("Lapor ke Menteri") == 1, "the same obligation rendered per scale again"
+    assert "**Mikro, Kecil**" in block
+    assert "**Besar**" in block
+
+
+def test_a_record_with_no_obligations_gets_no_section_at_all():
+    """INNOCENCE. An empty section headed `Kewajiban` would repeat the very
+    defect this fixes — an absent field dressed up as an answer."""
+    record = {"per_skala": [_scale("Mikro", []), {"skala_usaha": ["Besar"]}]}
+    assert build_kewajiban_section(record) == []
+    assert build_kewajiban_section({}) == []
+
+
+def test_no_obligation_is_ever_rendered_as_not_available():
+    for record in ({"per_skala": [_scale("Mikro", [])]}, {"per_skala": []}, {}):
+        assert "N/A" not in "\n".join(build_kewajiban_section(record))
+
+
+def test_markup_from_the_extraction_never_reaches_the_client():
+    record = {"per_skala": [_scale("Besar", ["<strong>Sertifikat</strong> Laik Sehat"])]}
+    block = "\n".join(build_kewajiban_section(record))
+    assert "<strong>" not in block and "</strong>" not in block
+    assert "Sertifikat Laik Sehat" in block
+
+
+def test_an_oversized_block_declares_its_truncation_instead_of_being_cut_quietly():
+    """W97 — a silent cut reads downstream as "this is everything"."""
+    record = {
+        "per_skala": [_scale(f"S{i}", ["x" * 900 + str(i)]) for i in range(40)]
+    }
+    block = "\n".join(build_kewajiban_section(record))
+    assert "tidak ditampilkan di sini" in block
+    assert len(block) <= KEWAJIBAN_BLOCK_MAX_CHARS + 2000, "the cap did not bound the block"
+
+
+def test_the_whole_catalogue_stays_within_the_declared_bound():
+    over = []
+    for record in _canonical_by_code().values():
+        block = "\n".join(build_kewajiban_section(record))
+        if len(block) > KEWAJIBAN_BLOCK_MAX_CHARS + 2000:
+            over.append(record["kode_kbli_2025"])
+    assert over == [], f"obligation block exceeded its bound on: {over}"
+
+
+def test_the_builders_own_output_is_recognised_by_the_recogniser():
+    """THE ORGAN. `build_cured_content` writes sections the 2026-02-18 seed never
+    had (`## Perizinan`, and now `## Kewajiban`), while `is_machine_template` —
+    which decides whether a row may be rebuilt — listed only the seed's three.
+
+    So the cure could not re-cure its own output: measured on the live table,
+    of the 55 rows it wrote on 2026-08-03, ZERO were still recognised. Every one
+    was frozen against any future licensing update, protected as "hand-written
+    prose" that the machine itself had written.
+
+    Adding a section to the builder without declaring it in
+    MACHINE_TEMPLATE_SECTIONS fails HERE instead of silently freezing rows.
+    """
+    unrecognised = []
+    for code, record in _canonical_by_code().items():
+        if not is_machine_template(code, build_cured_content(code, record)):
+            unrecognised.append(code)
+    assert unrecognised == [], (
+        "the cure writes content its own rebuild predicate refuses — those rows "
+        f"can never be re-cured: {unrecognised[:10]} ({len(unrecognised)} total)"
+    )
+
+
+def test_scar_pin_a_row_shaped_like_the_2026_08_03_cure_is_still_rebuildable():
+    """The exact live regression, pinned as a fixture: sections observed on the
+    real row `01122` after that run — seed sections PLUS `## Perizinan`."""
+    content = (
+        "# KBLI 01122 — Something\n\n"
+        "## Deskripsi Kegiatan Usaha\nx\n\n"
+        "## Investasi Asing (PMA)\n- Status PMA: TERBUKA\n\n"
+        "## Perizinan\n- **[Mikro] (Seluruh)** — Risiko: Rendah\n"
+    )
+    assert is_machine_template("01122", content) is True
+
+
+def test_a_hand_added_section_is_still_refused():
+    """INNOCENCE for the widening: declaring the builder's own sections must not
+    turn the predicate into a blanket yes — editorial prose still refuses."""
+    content = (
+        "# KBLI 96230 — Spa\n\n"
+        "## Deskripsi Kegiatan Usaha\nx\n\n"
+        "## Perizinan\n- row\n\n"
+        "## BALI CONTEXT\nBali is globally famous for spas.\n"
+    )
+    assert is_machine_template("96230", content) is False
+
+
+def test_the_obligations_are_actually_wired_into_the_document_the_channel_reads():
+    """`chat_kbli` injects `content` verbatim — so the section being CORRECT is
+    worth nothing unless `build_cured_content` emits it.
+
+    Added because mutation testing killed five of six mutants and this one
+    SURVIVED: deleting the one line that appends the section left the whole
+    corpus green, since every other test calls the renderer directly and the
+    round-trip organ passes whether or not the section is there. Second time in
+    one day that the surviving mutant was the WIRING, not the logic.
+    """
+    content = build_cured_content("96230", _canonical_by_code()["96230"])
+    assert "## Kewajiban" in content
+    assert "Sertifikat Laik Sehat" in content, (
+        "the document the client is answered from does not carry the obligation"
+    )


### PR DESCRIPTION
Two defects on the same builder — `kbli_documents_cure.py`, which writes the document `chat_kbli` injects verbatim into the LLM context on WhatsApp and webchat.

## 1. The one licensing field we render is the one that is almost always empty

Measured on canonical (`KBLI_2025_FINAL_CLEAN.json`, 9,095 per-scale rows):

| field | non-empty rows | share |
|---|---:|---:|
| `perizinan` | 17 | **0.19%** |
| `persyaratan` | 5,369 | 59% |
| `kewajiban` | 8,951 | **98%** |

`## Perizinan` renders `perizinan` and nothing else. So for practically the whole catalogue the channel answered **"Perizinan: N/A"** while the field carrying the actual statutory obligations was dropped on the floor.

Concretely, `96230` (day spa): canonical holds *"Memiliki Sertifikat Standar Usaha Pariwisata yang diterbitkan oleh LSPr"* and *"Memiliki Sertifikat Laik Sehat (SLS)"* — the SLHS the `/slhs` lane exists for — and the channel told clients the requirements were still pending. `balizero.com/kbli/96230` **already prints them**. Same shape as the rest of this lane: the page tells the truth, the channel does not.

### Rendering choices, each measured

- **Grouped by the scales that share an obligation**, not repeated per scale: 3.5M chars catalogue-wide per-scale against 1.1M grouped, and a client does not need "Sertifikat Laik Sehat" four times.
- **Scales NAMED on each group**, because 912 of 1,341 records genuinely differ by scale — collapsing to one block would lose which scale an obligation belongs to.
- **HTML stripped** — 1,524 of 86,241 entries carry markup, and `<strong>` is not a fact when an LLM reads it aloud.
- **Capped at 8,000 chars, and the cap DECLARES itself in the rendered text** (W97). 1,490 of 1,559 records fit whole; the 69 that do not print `(N ulteriori kelompok kewajiban tidak ditampilkan…)`. `61108` goes 128,416 → 7,724 chars with its truncation stated.
- **`persyaratan` deliberately NOT rendered**, and said so in the docstring: 6% of its entries are multi-line OSS document checklists up to 6,622 chars whose bounded shape is a separate design question. An omission nobody wrote down reads downstream as "there was nothing".

## 2. The cure could not re-cure its own output

`MACHINE_TEMPLATE_SECTIONS` listed the three sections of the 2026-02-18 seed. But `build_cured_content` also emits `## Perizinan` (always) and `## Catatan Verifikasi` (when there is a data note). So **every row this tool wrote failed its own `is_machine_template` on the next run** and was refused as hand-written prose that must not be destroyed — prose the machine itself had written.

Measured on the live table: of the **55 rows cured on 2026-08-03, 0 were still recognised**. All 55 were frozen against any future licensing update, and nobody would have noticed until a cure silently skipped them.

The round trip is now asserted by a test that regenerates real content from canonical and feeds it back to the recogniser, so adding a section to the builder without declaring it fails CI instead of quietly freezing the rows it writes.

## Effect on the whole catalogue

- records gaining `## Kewajiban`: **1,341**
- records declaring a truncation: **68**
- own output not recognised by the recogniser: **55 → 0**
- obligation block size: median 1,467 · max 8,482 chars

## Verification

- 77/77 in `test_kbli_documents_cure.py`, including guilt (the spa obligation renders), innocence (a hand-added section is STILL refused — the widening did not weaken the guard), grouping, HTML, the cap, and a scar-pin that a row shaped like the 2026-08-03 cure is rebuildable again.
- **Mutation-verified 6/6.** The survivor was the WIRING: deleting the single line that appends the section left the corpus green, because every other test calls the renderer directly and the round-trip organ passes either way. Same survivor shape as #3619 earlier today, closed the same way — a cure disconnected from its only caller never runs on the next record.

## Not claimed

Nothing is written to the database by this PR. The rows still serve the old content until the apply step runs (needs a write DSN, so it runs from Pro). That is the next action in this lane, not a done thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)