### PR TITLE
fix(kbli): the PMA cure reached the flat field and not the blob the retriever hands the LLM — an arms factory still reads 100% open

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_qdrant_pma_sync.py
+++ b/apps/backend-rag/backend/scripts/kbli_qdrant_pma_sync.py
@@ -100,7 +100,7 @@ import json
 import logging
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -120,7 +120,12 @@ CODE_KEY = "kode_kbli"
 _SCROLL_PAGE_LIMIT = 256
 
 
-LAYERS = ("pma", "bali")
+LAYERS = ("pma", "bali", "whatchanged")
+
+# The blob the RETRIEVER hands to the LLM. Stored under two keys that
+# `reindex_kbli_2025_final.py::build_payload` fills with the SAME string, so both
+# are rewritten from the same source and neither is left behind.
+PROSE_KEYS = ("content", "text")
 
 
 @dataclass(frozen=True)
@@ -136,6 +141,10 @@ class Target:
     code: str
     layer: str
     fields: dict[str, Any]
+    # The canonical record itself, carried so the prose repair reads the SAME
+    # source as the flat fields. Two lookups of one record is how the two
+    # representations end up disagreeing.
+    record: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -146,6 +155,14 @@ class CodePlan:
     target: Target
     point_ids: list[Any]
     current: dict[Any, dict[str, Any]]
+    # pid -> {payload key -> repaired blob}. Empty for layers that own no prose,
+    # and empty for a point already carrying the truthful prose.
+    prose: dict[Any, dict[str, str]] = field(default_factory=dict)
+    # Points whose blob is not shaped the way the repair assumes. Reported and
+    # NEVER written: a blob we cannot locate the block in is a blob we do not
+    # understand, and overwriting it would be a guess (W84 — a refusal is not
+    # an empty finding).
+    unshaped: list[Any] = field(default_factory=list)
 
     @property
     def found(self) -> bool:
@@ -153,14 +170,25 @@ class CodePlan:
 
     def stale_points(self) -> list[Any]:
         """Point ids whose payload disagrees with the canonical on ANY field of
-        the layer. Judging on one field would leave the others uncured — that is
-        how a point ends up reading TERBATAS at 100%."""
+        the layer, OR whose prose still carries the old wording. Judging on one
+        field would leave the others uncured — that is how a point ends up
+        reading TERBATAS at 100%, and how a point ends up reading TERBATAS in
+        its flat field while its blob still says TERBUKA / 100."""
         out = []
         for pid in self.point_ids:
             cur = self.current.get(pid, {})
             if any(cur.get(key) != value for key, value in self.target.fields.items()):
                 out.append(pid)
+            elif self.prose.get(pid):
+                out.append(pid)
         return out
+
+    def payload_for(self, pid: Any) -> dict[str, Any]:
+        """What to `set_payload` on ONE point: the layer's flat fields plus, when
+        this point needed it, the repaired blob. Per-point because the blob is
+        per-point — a single shared body would copy one point's prose onto every
+        other point of the code."""
+        return {**self.target.fields, **self.prose.get(pid, {})}
 
 
 def _pma_fields(rec: dict) -> tuple[dict[str, Any] | None, str | None]:
@@ -190,7 +218,151 @@ def _bali_fields(rec: dict) -> tuple[dict[str, Any] | None, str | None]:
     }, None
 
 
-_LAYER_READERS = {"pma": _pma_fields, "bali": _bali_fields}
+def _whatchanged_fields(rec: dict) -> tuple[dict[str, Any] | None, str | None]:
+    """A PROSE-ONLY layer: `whatChanged` has no flat payload key at all.
+
+    Measured 2026-08-05 on `kbli_2025_final_hybrid`: the payload carries 29 flat
+    keys and `whatChanged` is not among them — the sentence exists only inside
+    the `content`/`text` blob, under `## Intelligence 2026`. So this layer owns
+    no flat field and returns an empty mapping; everything it repairs is prose.
+    """
+    intel = rec.get("intel_2026")
+    if not isinstance(intel, dict) or not intel.get("whatChanged"):
+        return None, "canonical record carries no intel_2026.whatChanged — nothing authoritative to sync"
+    return {}, None
+
+
+_LAYER_READERS = {
+    "pma": _pma_fields,
+    "bali": _bali_fields,
+    "whatchanged": _whatchanged_fields,
+}
+
+
+# ---------------------------------------------------------------------------
+# PROSE REPAIR — the same fact, in the other representation
+#
+# WHY THIS EXISTS (measured on prod 2026-08-05, during the prove-live of the
+# whatChanged cure):
+#
+#   `--layer pma` synced the FLAT keys and stopped there. But the payload also
+#   holds `content`/`text` — `build_embedding_text(record)`, the blob the
+#   retriever hands to the LLM verbatim — and that blob still opened with
+#
+#       ## Status PMA: TERBUKA
+#       - Kepemilikan asing maksimal: 100
+#
+#   on all 20 codes the Perpres 49/2021 cure had capped. Among them `25200`
+#   (arms and ammunition, real cap 49%) and `79122` (Umrah/Hajj travel, real cap
+#   **0%**). `inspect_kbli` reads the flat field and was cured; the RAG channel
+#   reads the blob and was not. TWO REPRESENTATIONS OF ONE FACT, and the cure
+#   reached one of them — the same shape as every other scar in this lane.
+#
+#   So the fact's owner repairs BOTH. Putting the blob repair in a second tool
+#   is exactly the two-writers arrangement the module docstring above forbids:
+#   they would disagree precisely when it matters.
+#
+# FIDELITY TO THE GENERATOR: these renderers must emit what a full re-index
+# would emit, character for character, or the next re-index silently reverts the
+# cure and the two disagree again. That is asserted, not asserted-by-comment:
+# `test_prose_repair_matches_the_real_generator` runs the REAL
+# `build_embedding_text` over canonical records and requires the repair to be a
+# no-op on its fresh output. The trap it caught: `build_embedding_text` writes
+# the cap line under `if entry.get("pma_max_asing")`, so a cap of **0 is falsy**
+# and the line is OMITTED — for `79122` the truthful blob has no cap line at all,
+# and a repair that wrote `- Kepemilikan asing maksimal: 0` would diverge.
+#
+# WHAT IS NOT CLAIMED: the VECTOR is not re-computed (the embedding model is
+# FROZEN). The old sentence still shapes retrieval RANKING; what changes is the
+# text the model is given once the point is retrieved. Ranking drift is a
+# re-index question, ledgered separately — but a wrong sentence in the context
+# window is what reaches a client, and that is what this removes.
+# ---------------------------------------------------------------------------
+
+_PMA_HEADING = "## Status PMA:"
+_WHATCHANGED_PREFIX = "- whatChanged: "
+
+
+def render_pma_block(rec: dict) -> list[str]:
+    """The `## Status PMA:` block exactly as `build_embedding_text` writes it.
+
+    FIVE lines, not two. The first draft rendered only status + cap and the
+    generator-fidelity organ failed on the very first record (`01131`): the real
+    block also carries `- Kondisi:`, `- Prioritas:` and `- Nota:`, so a repair
+    that knew about two of them would have DELETED a priority-sector note from
+    every point it touched — silent data loss dressed as a cure. Any field added
+    to the generator's block must be added here, and that test is what says so.
+    """
+    lines = [f"{_PMA_HEADING} {rec.get('pma_status')}"]
+    if rec.get("pma_max_asing"):  # 0 is falsy THERE, so it must be falsy HERE
+        lines.append(f"- Kepemilikan asing maksimal: {rec['pma_max_asing']}")
+    if rec.get("pma_kondisi"):
+        lines.append(f"- Kondisi: {rec['pma_kondisi']}")
+    if rec.get("pma_prioritas"):
+        lines.append(f"- Prioritas: {rec['pma_prioritas']}")
+    if rec.get("pma_nota"):
+        lines.append(f"- Nota: {rec['pma_nota']}")
+    return lines
+
+
+def _replace_block(blob: str, start_pred, stop_pred, new_lines: list[str]) -> str | None:
+    """Swap one contiguous run of lines. Returns None when the block is absent —
+    a caller must treat that as "this point is not shaped the way I assume" and
+    refuse, never as "nothing to do"."""
+    lines = blob.split("\n")
+    try:
+        i = next(n for n, ln in enumerate(lines) if start_pred(ln))
+    except StopIteration:
+        return None
+    j = i + 1
+    while j < len(lines) and not stop_pred(lines[j]):
+        j += 1
+    return "\n".join(lines[:i] + new_lines + lines[j:])
+
+
+def rewrite_pma_prose(rec: dict, blob: str) -> str | None:
+    return _replace_block(
+        blob,
+        lambda ln: ln.startswith(_PMA_HEADING),
+        lambda ln: not ln.startswith("- "),
+        render_pma_block(rec),
+    )
+
+
+def rewrite_whatchanged_prose(rec: dict, blob: str) -> str | None:
+    """Replace EXACTLY ONE line.
+
+    `build_embedding_text` emits each intel entry as a single `- {k}: {v}` part,
+    and measured on canonical 2026-08-05 **zero** of the 1,559 `whatChanged`
+    values contain a newline (longest 665 chars) — so the block is one line and
+    a multi-line span rule is not just unnecessary, it is wrong: the first draft
+    consumed lines until the next `- `/`## `, which on `20112` swallowed the
+    generator's own truncation marker `(... dipotong untuk batas panjang.)`.
+
+    A value that DID contain a newline would silently break the round trip, so
+    it is refused rather than written.
+
+    Refusing when the line is absent matters just as much: for 101 of 1,559
+    records the generator truncates before `## Intelligence 2026` ever appears,
+    and appending a line there would put content AFTER a marker that tells the
+    reader the document stopped.
+    """
+    text = (rec.get("intel_2026") or {}).get("whatChanged")
+    if not text or "\n" in text:
+        return None
+    lines = blob.split("\n")
+    for n, ln in enumerate(lines):
+        if ln.startswith(_WHATCHANGED_PREFIX):
+            lines[n] = f"{_WHATCHANGED_PREFIX}{text}"
+            return "\n".join(lines)
+    return None
+
+
+_LAYER_PROSE = {
+    "pma": rewrite_pma_prose,
+    "bali": None,  # the Bali block is not repaired here — see the ledger line
+    "whatchanged": rewrite_whatchanged_prose,
+}
 
 
 def build_targets(
@@ -219,7 +391,7 @@ def build_targets(
         if fields is None:
             refusals.append(f"{code}: {why}")
             continue
-        targets[code] = Target(code=code, layer=layer, fields=fields)
+        targets[code] = Target(code=code, layer=layer, fields=fields, record=rec)
     return targets, refusals
 
 
@@ -282,7 +454,36 @@ def build_plan(code: str, target: Target, points: list[dict]) -> CodePlan:
         p["id"]: {key: (p.get("payload") or {}).get(key) for key in target.fields}
         for p in points
     }
-    return CodePlan(code=code, target=target, point_ids=ids, current=current)
+    rewrite = _LAYER_PROSE.get(target.layer)
+    prose: dict[Any, dict[str, str]] = {}
+    unshaped: list[Any] = []
+    if rewrite is not None:
+        for p in points:
+            payload = p.get("payload") or {}
+            repaired: dict[str, str] = {}
+            for key in PROSE_KEYS:
+                blob = payload.get(key)
+                if not isinstance(blob, str) or not blob:
+                    continue
+                new = rewrite(target.record, blob)
+                if new is None:
+                    # The block this layer owns is not in the blob. Not "already
+                    # correct" — unknown. Recorded so the run says so out loud.
+                    unshaped.append(p["id"])
+                    repaired = {}
+                    break
+                if new != blob:
+                    repaired[key] = new
+            if repaired:
+                prose[p["id"]] = repaired
+    return CodePlan(
+        code=code,
+        target=target,
+        point_ids=ids,
+        current=current,
+        prose=prose,
+        unshaped=unshaped,
+    )
 
 
 def _describe(values: dict[str, Any]) -> str:
@@ -302,10 +503,21 @@ def apply_plan(
         logger.info("  %s: NOT FOUND — no point matches %s=%s", plan.code, CODE_KEY, plan.code)
         return 0
 
+    for pid in plan.unshaped:
+        logger.warning(
+            "  %s: point %s carries no %r block in its blob — REFUSING to rewrite prose "
+            "we cannot locate (the point is left exactly as found)",
+            plan.code,
+            pid,
+            plan.target.layer,
+        )
+
     stale = plan.stale_points()
     if not stale:
         logger.info(
-            "  %s: already agrees with canonical (%s)", plan.code, _describe(plan.target.fields)
+            "  %s: already agrees with canonical (%s)",
+            plan.code,
+            _describe(plan.target.fields) or f"{plan.target.layer} prose",
         )
         return 0
 
@@ -324,17 +536,32 @@ def apply_plan(
 
     for pid in stale:
         cur = plan.current.get(pid, {})
+        repaired = plan.prose.get(pid, {})
         logger.info(
-            "  %s: point %s  %s -> %s%s",
+            "  %s: point %s  %s -> %s%s%s",
             plan.code,
             pid,
             _describe({k: cur.get(k) for k in plan.target.fields}),
             _describe(plan.target.fields),
+            f"  [+prose: {', '.join(sorted(repaired))}]" if repaired else "",
             "" if apply else "  (dry-run, not written)",
         )
 
     if not apply:
         return 0
+
+    # One request per point when prose is involved — the blob is per-point, and a
+    # single shared body would stamp one point's repaired text onto every other
+    # point of the same code.
+    if plan.prose:
+        for pid in stale:
+            resp = http.post(
+                f"{url_base}/collections/{collection}/points/payload",
+                headers=headers,
+                json={"payload": plan.payload_for(pid), "points": [pid]},
+            )
+            resp.raise_for_status()
+        return len(stale)
 
     resp = http.post(
         f"{url_base}/collections/{collection}/points/payload",
@@ -365,9 +592,11 @@ def main() -> int:
         choices=LAYERS,
         default="pma",
         help="which payload layer to sync: 'pma' (national ownership: pma_status, "
-        "pma_max_asing) or 'bali' (provincial verdict: bali_status, bali_blocked, "
-        "bali_reason, has_bali_l4). One layer per run, on purpose — the two answer "
-        "different questions from different instruments.",
+        "pma_max_asing, AND the '## Status PMA:' block inside the content/text blob), "
+        "'bali' (provincial verdict: bali_status, bali_blocked, bali_reason, "
+        "has_bali_l4) or 'whatchanged' (prose-only: the '- whatChanged:' line inside "
+        "the blob, which has no flat payload key). One layer per run, on purpose — "
+        "they answer different questions from different instruments.",
     )
     args = ap.parse_args()
 

--- a/apps/backend-rag/backend/tests/scripts/test_kbli_qdrant_pma_sync.py
+++ b/apps/backend-rag/backend/tests/scripts/test_kbli_qdrant_pma_sync.py
@@ -286,3 +286,232 @@ def test_the_pma_layer_is_unchanged_by_the_generalisation():
     targets, _ = build_targets([_rec("25200", "TERBATAS", 49)], ["25200"])
     assert targets["25200"].layer == "pma"
     assert targets["25200"].fields == {"pma_status": "TERBATAS", "pma_max_asing": 49}
+
+
+# ---------------------------------------------------------------------------
+# PROSE REPAIR — the same fact in the blob the retriever hands to the LLM.
+#
+# Measured on prod 2026-08-05: 20 codes had the flat keys cured by `--layer pma`
+# and their `content`/`text` blob still opened `## Status PMA: TERBUKA` /
+# `- Kepemilikan asing maksimal: 100` — including `25200` (arms, real cap 49)
+# and `79122` (Umrah travel, real cap 0). One fact, two representations, one
+# cured. These tests exist so that cannot recur silently.
+# ---------------------------------------------------------------------------
+
+from backend.scripts.kbli_qdrant_pma_sync import (  # noqa: E402
+    PROSE_KEYS,
+    render_pma_block,
+    rewrite_pma_prose,
+    rewrite_whatchanged_prose,
+)
+
+_BLOB_OPEN = """[CONTEXT: KBLI 2025 - Kode 25200 - Industri Senjata dan Amunisi]
+
+# KBLI 25200: Industri Senjata dan Amunisi
+
+## Deskripsi (BPS)
+Kelompok ini mencakup pembuatan senjata dan amunisi.
+
+**Sektor:** I.C
+
+## Status PMA: TERBUKA
+- Kepemilikan asing maksimal: 100
+
+## Perizinan per Skala Usaha (PP 28/2025)
+### Skala: Besar
+- Kategori risiko: Tinggi
+
+## Intelligence 2026
+- whatItMeans: Making weapons and ammunition.
+- whatChanged: Direct 1:1 match from KBLI 2020 - code and scope unchanged.
+- baliContext: Not a Bali activity.
+"""
+
+
+def _blob_point(pid: Any, blob: str, status: str = "TERBUKA", cap: Any = 100) -> dict:
+    payload: dict[str, Any] = {"pma_status": status, "pma_max_asing": cap}
+    for key in PROSE_KEYS:
+        payload[key] = blob
+    return {"id": pid, "payload": payload}
+
+
+def test_the_blob_still_saying_terbuka_100_is_repaired_not_left_behind():
+    """The P0 this whole section exists for: an arms factory advertised at 100%
+    foreign ownership in the text the LLM is handed, while the flat field
+    already said 49."""
+    rec = _rec("25200", status="TERBATAS", cap=49)
+    point = _blob_point("p1", _BLOB_OPEN, status="TERBATAS", cap=49)  # flat ALREADY cured
+    plan = build_plan("25200", Target("25200", "pma", {"pma_status": "TERBATAS", "pma_max_asing": 49}, rec), [point])
+
+    assert plan.stale_points() == ["p1"], "a cured flat field must not excuse an uncured blob"
+    for key in PROSE_KEYS:
+        new = plan.prose["p1"][key]
+        assert "## Status PMA: TERBATAS" in new
+        assert "- Kepemilikan asing maksimal: 49" in new
+        assert "TERBUKA" not in new
+        assert "maksimal: 100" not in new
+        # everything outside the owned block survives untouched
+        assert "Industri Senjata dan Amunisi" in new
+        assert "## Perizinan per Skala Usaha (PP 28/2025)" in new
+        assert "- whatItMeans: Making weapons and ammunition." in new
+
+
+def test_a_zero_percent_cap_omits_the_line_because_the_generator_omits_it():
+    """`build_embedding_text` writes the cap line under `if
+    entry.get("pma_max_asing")`, so 0 is FALSY and the line is absent. `79122`
+    (Umrah/Hajj travel) is capped at 0: a repair that wrote `maksimal: 0` would
+    diverge from the next re-index and re-open this exact gap."""
+    rec = _rec("79122", status="TERBATAS", cap=0)
+    out = rewrite_pma_prose(rec, _BLOB_OPEN)
+    assert "## Status PMA: TERBATAS" in out
+    assert "Kepemilikan asing maksimal" not in out
+    assert render_pma_block(rec) == ["## Status PMA: TERBATAS"]
+
+
+def test_a_point_whose_blob_already_tells_the_truth_is_not_rewritten():
+    """Innocence: the repair must be a no-op on a truthful blob, or every run
+    would rewrite the whole collection and the diff would stop meaning anything."""
+    rec = _rec("25200", status="TERBATAS", cap=49)
+    cured = rewrite_pma_prose(rec, _BLOB_OPEN)
+    point = _blob_point("p1", cured, status="TERBATAS", cap=49)
+    plan = build_plan("25200", Target("25200", "pma", {"pma_status": "TERBATAS", "pma_max_asing": 49}, rec), [point])
+    assert plan.prose == {}
+    assert plan.stale_points() == []
+
+
+def test_a_blob_without_the_owned_block_is_REFUSED_not_guessed_at():
+    """A blob we cannot locate the block in is a blob we do not understand.
+    Refusing is the whole point — writing into it would be a guess about a
+    client-facing store."""
+    rec = _rec("25200", status="TERBATAS", cap=49)
+    point = _blob_point("p1", "# KBLI 25200\n\nno pma section here at all\n", status="TERBATAS", cap=49)
+    plan = build_plan("25200", Target("25200", "pma", {"pma_status": "TERBATAS", "pma_max_asing": 49}, rec), [point])
+    assert plan.unshaped == ["p1"]
+    assert plan.prose == {}
+    assert plan.stale_points() == [], "an unshaped point must not be written"
+
+
+def test_the_whatchanged_layer_replaces_only_its_own_line():
+    rec = {
+        "kode_kbli_2025": "25200",
+        "intel_2026": {"whatChanged": "Our records do not support this code number carrying over."},
+    }
+    out = rewrite_whatchanged_prose(rec, _BLOB_OPEN)
+    assert "- whatChanged: Our records do not support this code number carrying over." in out
+    assert "Direct 1:1 match" not in out
+    # the neighbours in the same section are untouched
+    assert "- whatItMeans: Making weapons and ammunition." in out
+    assert "- baliContext: Not a Bali activity." in out
+    # and it does not touch the PMA block it does not own
+    assert "## Status PMA: TERBUKA" in out
+
+
+def test_the_whatchanged_layer_owns_no_flat_key():
+    """It has none in the live payload (29 flat keys, measured 2026-08-05), so a
+    run must not invent one — writing `whatChanged` as a flat field would create
+    a second representation nobody reads and nobody keeps in step."""
+    targets, refusals = build_targets(
+        [{"kode_kbli_2025": "25200", "intel_2026": {"whatChanged": "x"}}], ["25200"], layer="whatchanged"
+    )
+    assert refusals == []
+    assert targets["25200"].fields == {}
+
+
+def test_a_record_without_whatchanged_is_refused_not_blanked():
+    _, refusals = build_targets(
+        [{"kode_kbli_2025": "25200", "intel_2026": {}}], ["25200"], layer="whatchanged"
+    )
+    assert len(refusals) == 1 and "whatChanged" in refusals[0]
+
+
+def test_each_point_gets_its_OWN_repaired_blob_never_a_shared_body():
+    """The blob is per-point. A single shared `set_payload` body would stamp one
+    point's text onto its siblings — silently replacing another point's content
+    with a near-copy."""
+    rec = _rec("25200", status="TERBATAS", cap=49)
+    other = _BLOB_OPEN.replace("Industri Senjata dan Amunisi", "SIBLING CHUNK")
+    points = [_blob_point("p1", _BLOB_OPEN, "TERBATAS", 49), _blob_point("p2", other, "TERBATAS", 49)]
+    plan = build_plan("25200", Target("25200", "pma", {"pma_status": "TERBATAS", "pma_max_asing": 49}, rec), points)
+    fake = FakeQdrant({})
+    with fake.client() as http:
+        written = apply_plan(http, _BASE, _HEADERS, _COLLECTION, plan, apply=True)
+    assert written == 2
+    bodies = fake.payload_writes
+    assert [b["points"] for b in bodies] == [["p1"], ["p2"]]
+    assert "SIBLING CHUNK" in bodies[1]["payload"]["content"]
+    assert "SIBLING CHUNK" not in bodies[0]["payload"]["content"]
+
+
+def test_the_prose_repair_matches_the_real_generator_on_real_canonical_records():
+    """THE ORGAN. These renderers must emit exactly what a full re-index emits,
+    or the next re-index reverts the cure and the two disagree again.
+
+    So this loads the REAL canonical dataset, runs the REAL
+    `build_embedding_text`, and requires both repairs to be no-ops on its fresh
+    output. It is what caught the falsy-zero trap: `build_embedding_text` omits
+    the cap line when the cap is 0, and a repair that emitted `maksimal: 0`
+    passes every hand-written test above and still diverges in production.
+    """
+    import pathlib
+    import types
+
+    here = pathlib.Path(__file__).resolve()
+    root = next(
+        (p for p in here.parents if (p / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json").is_file()),
+        None,
+    )
+    assert root is not None, f"canonical dataset not found walking up from {here}"
+
+    gen_path = root / "apps/backend-rag/backend/scripts/reindex_kbli_2025_final.py"
+    mod = types.ModuleType("rix_for_test")
+    # The module derives a dataset path from __file__ with parents[4]; give it a
+    # deep enough stand-in rather than importing it for real (it would also try
+    # to read that path at import time).
+    mod.__dict__["__file__"] = "/a/b/c/d/e/reindex.py"
+    exec(compile(gen_path.read_text(encoding="utf-8"), str(gen_path), "exec"), mod.__dict__)
+    build_embedding_text = mod.build_embedding_text
+
+    records = json.loads(
+        (root / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json").read_text(encoding="utf-8")
+    )["data"]
+
+    checked_pma = checked_wc = truncated = 0
+    zero_cap_seen = False
+    for rec in records:
+        fresh = build_embedding_text(rec)
+        if rec.get("pma_status"):
+            assert rewrite_pma_prose(rec, fresh) == fresh, (
+                f"{rec['kode_kbli_2025']}: the PMA repair is not a no-op on freshly generated text — "
+                "it would fight the next re-index"
+            )
+            checked_pma += 1
+            if rec.get("pma_max_asing") in (0, None):
+                zero_cap_seen = True
+        if (rec.get("intel_2026") or {}).get("whatChanged"):
+            out = rewrite_whatchanged_prose(rec, fresh)
+            if "\n- whatChanged: " not in fresh:
+                # The generator CAPS the embedding text (`build_embedding_text`
+                # truncates long per_skala blocks with "... dipotong untuk batas
+                # panjang"), so for 101 of 1,559 records the Intelligence 2026
+                # section never makes it into the blob at all. There is no line
+                # to repair, and the tool must REFUSE rather than append one —
+                # appending would put text past a truncation marker, where a
+                # reader has been told the document stops.
+                assert out is None, (
+                    f"{rec['kode_kbli_2025']}: repaired a whatChanged line into a blob that has none"
+                )
+                truncated += 1
+                continue
+            assert out == fresh, (
+                f"{rec['kode_kbli_2025']}: the whatChanged repair is not a no-op on freshly generated text"
+            )
+            checked_wc += 1
+
+    assert checked_pma > 1400 and checked_wc > 1400, (
+        f"corpus too thin to mean anything: pma={checked_pma} whatChanged={checked_wc}"
+    )
+    assert zero_cap_seen, "no zero/absent cap in the corpus — the falsy-zero branch went untested"
+    assert truncated > 0, (
+        "no truncated record in the corpus — the refusal branch went untested, and it is the "
+        "branch that stops the tool inventing content past a truncation marker"
+    )


### PR DESCRIPTION
## 🔴 What is live right now

`--layer pma` synced `pma_status` / `pma_max_asing` and stopped there. The same Qdrant point also carries `content`/`text` — `build_embedding_text(record)`, **the blob the retriever injects into the LLM context verbatim** — and measured on prod today that blob still opens:

```
## Status PMA: TERBUKA
- Kepemilikan asing maksimal: 100
```

on **all twenty** codes the Perpres 49/2021 cure (#3515) capped:

| code | activity | real cap | blob says |
|---|---|---:|---:|
| `25200` | Industri Senjata dan Amunisi | 49% | 100% |
| `30400` | military vehicles | 49% | 100% |
| `51101`/`51102` | scheduled air transport | 49% | 100% |
| `79122` | Biro Perjalanan Ibadah Umrah dan Haji | **0%** | 100% |
| `16221` | — | **0%** | 100% |
| +15 sea-transport codes | | 49% | 100% |

`inspect_kbli` reads the flat field and was cured. WhatsApp and webchat read the blob and were not. **One fact, two representations, and the cure reached one of them** — the shape of every scar in this lane.

So the layer that *owns* the fact now repairs both representations. Putting the blob repair in a second tool is exactly the two-writers arrangement this module's own docstring forbids: they would disagree precisely when it matters (W105).

## `--layer whatchanged`, a prose-only layer

`whatChanged` has **no flat payload key at all** (29 flat keys measured; none of them it). So the retracted-continuity sentence cured in #3610/#3619 across canonical, the KG, the website and the LLM corpus is still the OLD text in Qdrant for all 16 codes — `96210` tells the RAG channel *"Hair salons have been consistently classified across both KBLI versions"* while every other surface now says our records do not support that.

## What the generator-fidelity organ caught, before any of this shipped

The repair must emit what a full re-index emits **character for character**, or the next re-index reverts it and the two disagree again. `test_prose_repair_matches_the_real_generator` loads the REAL `build_embedding_text` and runs it over all 1,559 canonical records, requiring the repair to be a **no-op on its fresh output**. It failed three times:

1. **On the very first record.** The PMA block also carries `- Kondisi:`, `- Prioritas:` and `- Nota:`. A repair that knew only status+cap would have **deleted a priority-sector note** from every point it touched — silent data loss dressed as a cure.
2. **`0` is falsy.** `build_embedding_text` writes the cap line under `if entry.get("pma_max_asing")`, so a 0% cap **omits the line entirely**. For `79122` the truthful blob has no cap line at all; writing `maksimal: 0` passes every hand-written test and diverges from the generator forever.
3. **The generator truncates.** For **101 of 1,559** records the `## Intelligence 2026` section never reaches the blob. The first draft's multi-line span rule swallowed the truncation marker `(... dipotong untuk batas panjang.)` itself. Measured: **zero** of 1,559 `whatChanged` values contain a newline, so the block is exactly one line — and a blob with no line to repair is **refused**, never appended to. Appending would put content after a marker that told the reader the document stopped.

Measured and stated: all 36 target codes (20 PMA + 16 whatChanged) are curable; the 101 truncated records are refusals, not silent skips.

## Refusals and blast radius

- A blob whose owned block cannot be located is **reported and left exactly as found** — a refusal is not an empty finding (W84).
- Writes are **per-point** when prose is involved, because the blob is per-point; one shared `set_payload` body would stamp one point's text onto its siblings.
- The `bali` layer gets no prose repair here; that is a declared gap, not an oversight.

## Not claimed

**The vector is not recomputed** — the embedding model is FROZEN. The old sentence still shapes retrieval *ranking*; what changes is the text the model is handed once a point is retrieved. That is the half that reaches a client.

The wider blob drift — **1,457 of 1,559 blobs differ** from what canonical would now generate, mostly canonical having *grown* (`editorial`, `_l3_gap_disclosure`, risk-tier disclosures) — is a re-index question. Measured, ledgered, deliberately not done here.

Nothing is written to Qdrant by this PR. The apply is the next step and is reported separately.

## Verification

30/30 tests. **Mutation-verified 7/7** — falsy-zero guard, the Prioritas/Nota lines, unshaped-as-nothing-to-do, prose-blind staleness, shared payload body, the multi-line span, and appending past a truncation marker. (An eighth attempt did not match its needle and was re-run with the correct one rather than counted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)