### PR TITLE
feat(kbli): the obligations builder reached zero rows — add the table-selected scope that delivers it

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -346,6 +346,61 @@ def is_machine_template(code: str, content: str | None) -> bool:
     return bool(sections) and sections <= MACHINE_TEMPLATE_SECTIONS
 
 
+def selector_conflict(
+    *, quarantined: bool, licensing_absent: bool, machine_template: bool
+) -> str | None:
+    """Pure. The refusal message when more than one scope selector is on, or None.
+
+    The three selectors choose populations three different WAYS — a canonical
+    marker, a detector's verdict about live state, and the stored text itself —
+    so a union has no single sentence that describes what acted, and the run
+    report is the only record of a write to a client-facing table. They also
+    carry OPPOSITE duties: the quarantine scope deliberately destroys stored
+    content (it is fabricated by definition) while the table scope refuses to.
+    Silently letting one win is how a run destroys prose under a flag the
+    operator thought meant something narrower.
+
+    Pure and out here because the refusal lives in `main`, which no test can
+    execute (it opens a real connection) — inline, a mutation disabling the
+    check survived the whole suite.
+    """
+    chosen = [
+        name
+        for name, on in (
+            ("--all-quarantined", quarantined),
+            ("--all-licensing-absent", licensing_absent),
+            ("--all-machine-template", machine_template),
+        )
+        if on
+    ]
+    if len(chosen) < 2:
+        return None
+    return (
+        f"{' and '.join(chosen)} select DIFFERENT populations DIFFERENT ways (marker vs detector "
+        "state vs stored text) — refusing to union them, because the run report could no longer "
+        "say which scope acted. Run them separately."
+    )
+
+
+def select_machine_template_rows(
+    codes: list[str], table_rows: dict[str, dict]
+) -> tuple[list[str], int]:
+    """Pure. The `--all-machine-template` population: of the codes queried, the
+    rows the table actually holds, narrowed to the ones whose STORED TEXT is a
+    machine seed. Returns (kept, how many were present) so the caller can print
+    N of M rather than a bare N (W97).
+
+    It lives out here, and `main` does nothing but call it, on purpose: while it
+    was three lines inlined in `main` a mutation that replaced the predicate with
+    `True` — rebuild every row present, including 316 pieces of hand-written
+    editorial prose — SURVIVED the whole suite, because the test re-implemented
+    the filter instead of calling it. A decision that only exists inside an
+    un-runnable function is a decision nothing tests.
+    """
+    present = [c for c in codes if c in table_rows]
+    return [c for c in present if is_machine_template(c, table_rows[c]["content"])], len(present)
+
+
 def rebuild_reason(code: str, content: str | None, canonical_rows: int) -> str | None:
     """Pure. Why this row may be rebuilt wholesale — or None to refuse it.
 
@@ -761,6 +816,18 @@ async def main() -> int | None:
         "1,423 rows no --only list ever named. Refuses if the detector cannot verify.",
     )
     ap.add_argument(
+        "--all-machine-template",
+        action="store_true",
+        help="rebuild every row the table itself shows to be a machine-seed document, i.e. every "
+        "row `is_machine_template` accepts (299 of 1,563 measured 2026-08-05). TABLE-selected: "
+        "the population is a property of the stored text, not of a marker or a detector, so this "
+        "is the only selector that can DELIVER a change to the builder — the other three each "
+        "answer a narrower question and together they reach a few dozen rows. Lossless by "
+        "construction: a machine-seed row is regenerated from the same canonical fields it was "
+        "built from. The other 1,264 rows keep their hand-written prose and are named, not "
+        "silently skipped.",
+    )
+    ap.add_argument(
         "--conformance-script",
         type=Path,
         default=CONFORMANCE_SCRIPT,
@@ -796,15 +863,25 @@ async def main() -> int | None:
     dataset = await load_dataset(args.dataset)
 
     canonical_rows_by_code: dict[str, int] = {}
-    if args.all_quarantined and args.all_licensing_absent:
-        logger.error(
-            "--all-quarantined and --all-licensing-absent are two DIFFERENT populations selected "
-            "two different ways (marker vs state) — refusing to union them, because the run "
-            "report could no longer say which scope acted. Run them separately."
-        )
+    conflict = selector_conflict(
+        quarantined=args.all_quarantined,
+        licensing_absent=args.all_licensing_absent,
+        machine_template=args.all_machine_template,
+    )
+    if conflict:
+        logger.error("%s", conflict)
         return
 
-    if args.all_quarantined:
+    if args.all_machine_template:
+        # Every code the canonical carries. The table-shaped narrowing happens
+        # below, after the rows are read — the predicate is a property of the
+        # STORED TEXT, so it cannot be evaluated before the fetch, and it is the
+        # SAME `rebuild_reason` the other gate calls rather than a second copy
+        # of it (two predicates for one decision is how they start disagreeing).
+        codes = [str(r.get("kode_kbli_2025")) for r in dataset if r.get("kode_kbli_2025")]
+        if args.only:
+            logger.warning("--only ignored: --all-machine-template takes precedence")
+    elif args.all_quarantined:
         codes = quarantined_codes(dataset)
         if args.only:
             logger.warning("--only ignored: --all-quarantined takes precedence")
@@ -869,7 +946,28 @@ async def main() -> int | None:
         # revoked regulation), so "preserve what a human wrote" would preserve
         # exactly what the cure exists to destroy. Same code, opposite duty,
         # decided by which selector chose the row.
-        if args.all_licensing_absent:
+        if args.all_machine_template:
+            # Table-selected: keep ONLY rows whose stored text is a machine seed.
+            # `contradicted-licensing-claim` is deliberately NOT admitted here —
+            # that reason needs the detector's per-code `canonical_rows`, which
+            # this path does not have, and inventing a second count for it is
+            # exactly the drift W105 describes. A broad rebuild must be the
+            # lossless case and nothing else.
+            keep, n_present = select_machine_template_rows(codes, table_rows)
+            logger.info(
+                "table-selected scope: %d machine-seed row(s) of %d present in the table "
+                "(%d canonical codes queried); the other %d keep hand-written prose and are NOT "
+                "rebuilt — closing them needs prose re-authored around the new rows, not a script",
+                len(keep),
+                n_present,
+                len(codes),
+                n_present - len(keep),
+            )
+            codes = keep
+            if not codes:
+                logger.warning("no machine-seed row in the table — nothing to do")
+                return
+        elif args.all_licensing_absent:
             keep, refused = [], []
             for code in codes:
                 row = table_rows.get(code)

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -1011,6 +1011,7 @@ from backend.scripts.kbli_documents_cure import (  # noqa: E402
     build_cured_content,
     build_kewajiban_section,
     is_machine_template,
+    select_machine_template_rows,
 )
 
 
@@ -1165,3 +1166,163 @@ def test_the_obligations_are_actually_wired_into_the_document_the_channel_reads(
     assert "Sertifikat Laik Sehat" in content, (
         "the document the client is answered from does not carry the obligation"
     )
+
+
+# ---------------------------------------------------------------------------
+# --all-machine-template — the DELIVERY selector.
+#
+# Measured on the live table 2026-08-05: 1,563 rows, of which 299 are machine
+# seeds, 316 are the 2026-02-17 editorial prose (`KBLI 55203: AKTIVITAS VILA` /
+# `WHAT IT MEANS:` — no `#` heading, no `##` sections at all) and 948 carry a
+# section outside the seed's. Without this selector the obligations builder
+# reaches ZERO rows: the other three selectors together name a few dozen.
+#
+# The danger it must not have: a sectionless document makes
+# "every `##` section is one of ours" VACUOUSLY TRUE, so a predicate written
+# only as a subset test would classify all 316 pieces of hand-written editorial
+# copy as machine template and destroy them.
+# ---------------------------------------------------------------------------
+
+_EDITORIAL_2026_02_17 = (
+    "KBLI 55203: AKTIVITAS VILA\n\n"
+    "WHAT IT MEANS:\n"
+    "Villas - private houses exclusively rented out to tourists.\n\n"
+    "BALI CONTEXT:\n"
+    "The provincial moratorium applies.\n"
+)
+
+
+def test_the_sectionless_editorial_rows_are_not_swept_up_as_machine_template():
+    """316 live rows look like this. A subset test alone says True on the empty
+    set, so the predicate must ALSO require the machine heading — and these have
+    `KBLI 55203:` with a colon and no `#`, which is not it."""
+    assert is_machine_template("55203", _EDITORIAL_2026_02_17) is False
+    assert rebuild_reason("55203", _EDITORIAL_2026_02_17, canonical_rows=4) is None
+
+
+def test_a_document_with_the_heading_but_no_sections_is_still_refused():
+    """The vacuous-truth case in isolation: right heading, zero sections.
+    Nothing about it says the machine wrote it, so it is not rebuildable."""
+    assert is_machine_template("55203", "# KBLI 55203 - Aktivitas Vila\n\nsome prose\n") is False
+
+
+def test_the_delivery_selector_keeps_only_machine_seeds_and_names_the_rest():
+    """The selector's whole job: pick the lossless population out of the table
+    and leave the rest, rather than picking a code list by hand."""
+    canonical = _canonical_by_code()
+    machine = build_cured_content("96230", canonical["96230"])
+    rows = {
+        "96230": {"content": machine},
+        "55203": {"content": _EDITORIAL_2026_02_17},
+        "47401": {"content": "# KBLI 47401 - Retail\n\n## Informasi Umum\nx\n\n## Sejarah\nhand-written\n"},
+    }
+    kept, n_present = select_machine_template_rows(list(rows), rows)
+    assert n_present == 3
+    assert kept == ["96230"], (
+        "the selector must keep the machine seed, refuse the sectionless editorial row, "
+        "and refuse the row carrying a section outside the seed's"
+    )
+
+
+def test_the_delivered_document_is_the_one_that_carries_the_obligations():
+    """Ties the selector to the point of the exercise: the rows this scope
+    rebuilds are exactly the rows that gain `## Kewajiban`."""
+    canonical = _canonical_by_code()
+    content = build_cured_content("96230", canonical["96230"])
+    assert is_machine_template("96230", content), "a delivered row must stay re-curable"
+    assert "## Kewajiban" in content
+    assert "Sertifikat Laik Sehat" in content
+
+
+def test_a_code_the_table_does_not_hold_is_not_counted_as_present():
+    """`--all-machine-template` queries every canonical code (1,559) against a
+    table that holds 1,563 rows but not necessarily the same set. Counting a
+    missing code as "present" both inflates the denominator the run reports and
+    walks straight into a KeyError on the row lookup."""
+    canonical = _canonical_by_code()
+    rows = {"96230": {"content": build_cured_content("96230", canonical["96230"])}}
+    kept, n_present = select_machine_template_rows(["96230", "00000", "99999"], rows)
+    assert kept == ["96230"]
+    assert n_present == 1, "only the row the table actually holds is present"
+
+
+def test_main_uses_the_selector_rather_than_its_own_inline_filter():
+    """A WIRING PIN, and labelled as one — not a behavioural test.
+
+    `main()` opens a real asyncpg connection, so nothing in this suite executes
+    it, and mutation testing proved the consequence: replacing the selector call
+    in `main` with `list(codes)` — rebuild every row, editorial prose included —
+    leaves all 81 tests green. This asserts, at the AST level, that the
+    machine-template branch delegates to `select_machine_template_rows` instead
+    of re-deriving the population inline, which is the only part of that
+    mutation this suite can see.
+
+    DECLARED GAP, measured not guessed: `main()` has no behavioural coverage, so
+    this pin sees that the call EXISTS and not that its result is used. Mutation
+    `if conflict:` -> `if False:` still SURVIVES the suite — the call remains,
+    its verdict is dropped, and two scope selectors would silently be ranked
+    instead of refused. Left as a declared gap rather than papered over with an
+    AST rule about the shape of an `if`: what actually protects the rows is the
+    selector's own tests plus this pin. Closing it needs `main` to take an
+    injected connection, which is a refactor, not a test.
+    """
+    import ast
+
+    src = _Path_obl(__file__).resolve()
+    root = _repo_root_obl()
+    tree = ast.parse(
+        (root / "apps/backend-rag/backend/scripts/kbli_documents_cure.py").read_text(encoding="utf-8")
+    )
+    main_fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == "main"
+    )
+    called = {
+        n.func.id
+        for n in ast.walk(main_fn)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    }
+    for fn_name, what in (
+        ("select_machine_template_rows", "an inline filter there is invisible to every test here"),
+        ("selector_conflict", "an inline union check there is invisible to every test here"),
+    ):
+        assert fn_name in called, f"main() no longer calls {fn_name} ({src.name} pins this): {what}"
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        {"quarantined": True, "licensing_absent": True, "machine_template": False},
+        {"quarantined": True, "licensing_absent": False, "machine_template": True},
+        {"quarantined": False, "licensing_absent": True, "machine_template": True},
+        {"quarantined": True, "licensing_absent": True, "machine_template": True},
+    ],
+)
+def test_two_scope_selectors_together_are_refused_never_silently_ranked(flags):
+    """They carry OPPOSITE duties — the quarantine scope destroys stored content
+    on purpose, the table scope refuses to — so letting the if/elif chain pick a
+    winner would destroy prose under a flag the operator thought was narrower."""
+    from backend.scripts.kbli_documents_cure import selector_conflict
+
+    msg = selector_conflict(**flags)
+    assert msg is not None
+    assert "refusing to union them" in msg
+    for name, on in (("--all-quarantined", flags["quarantined"]),
+                     ("--all-licensing-absent", flags["licensing_absent"]),
+                     ("--all-machine-template", flags["machine_template"])):
+        assert (name in msg) is on, "the refusal must name exactly the selectors that were on"
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        {"quarantined": False, "licensing_absent": False, "machine_template": False},
+        {"quarantined": True, "licensing_absent": False, "machine_template": False},
+        {"quarantined": False, "licensing_absent": True, "machine_template": False},
+        {"quarantined": False, "licensing_absent": False, "machine_template": True},
+    ],
+)
+def test_one_selector_alone_is_never_refused(flags):
+    from backend.scripts.kbli_documents_cure import selector_conflict
+
+    assert selector_conflict(**flags) is None


### PR DESCRIPTION
#3622 fixed the builder and the round trip. **It changed nothing a client can read.**

The three existing selectors between them name a few dozen codes: `--only` is a hand-written list, `--all-quarantined` reads canonical markers, `--all-licensing-absent` consumes the conformance detector's verdict — and the 55 rows that last one covered on 2026-08-03 are *no longer licensing-absent*, because that run cured them. Measured on the live table just now: **1,563 rows, 0 serving `## Kewajiban`**.

## `--all-machine-template`

Selects by the **stored text**: every row `is_machine_template` accepts — i.e. every row this tool wrote and can rewrite losslessly from the same canonical fields it was built from. The run prints N of M rather than a bare N (W97):

| population | rows | outcome |
|---|---:|---|
| machine seeds | **299** | rebuilt (gain `## Kewajiban`) |
| refused by the heading check | 316 | keep hand-written prose |
| refused for a section outside the seed's | 948 | keep hand-written prose |
| **total** | **1,563** | |

The 1,264 refused are **named in the log**, not silently skipped. Closing them needs prose re-authored around the new rows — editorial work, not a script.

## The danger this selector had to not have

The 316 are the 2026-02-17 editorial documents — `KBLI 55203: AKTIVITAS VILA` / `WHAT IT MEANS:` / `BALI CONTEXT:` — with **no `##` sections at all**.

*"Every `##` section is one of ours"* is **vacuously true on the empty set.** A predicate written only as a subset test would have classified all 316 pieces of hand-written editorial copy as machine template and destroyed them.

`is_machine_template` already guards both ends (`bool(sections)` **and** the `# KBLI <code> -` heading, which these fail with their colon and missing `#`). This PR adds the tests that say so, and mutation confirms that removing *either* guard turns the suite red.

## Two decisions moved out of `main`, because mutation showed they were untestable where they were

- **`select_machine_template_rows`** — inlined, a mutation replacing the predicate with `True` (rebuild every row present, editorial prose included) **SURVIVED all 81 tests**, because the test re-implemented the filter instead of calling it. Third time today the surviving mutant was the *wiring*, not the logic.
- **`selector_conflict`** — the refusal when two scope selectors are on. They carry **opposite duties**: the quarantine scope destroys stored content on purpose (it is fabricated by definition), this one refuses to. Letting the `if/elif` chain quietly pick a winner would destroy prose under a flag the operator thought was narrower.

## Verification

**91/91 tests. Mutation: 8 of 9 killed.**

The survivor is **declared**, in the docstring of the test that pins it: `if conflict:` → `if False:` still passes. `main()` opens a real asyncpg connection and no test executes it, so the AST pin can see that the call *exists* but not that its verdict is *used*. Closing that needs `main` to take an injected connection — a refactor, not a test. Written down rather than papered over with an AST rule about the shape of an `if` (an antibody guarding nothing is decorative, W104).

Two further mutation attempts did not match their needles and were **re-run with the correct ones** rather than counted as killed.

## Not claimed

Nothing is written to the database by this PR. The apply — `--all-machine-template --apply` from the deployed image — is the next step and will be reported with its own before/after measurement on the live table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)