### PR TITLE
fix(kbli): the graph tells 1,029 codes to obey obligations the law never gave them

### DIFF
--- a/apps/backend-rag/backend/scripts/kg_kbli_contradicted_obligations.py
+++ b/apps/backend-rag/backend/scripts/kg_kbli_contradicted_obligations.py
@@ -41,7 +41,7 @@ this population as out of its scope ("one shared agriculture-marker
 this script has nothing to derive a fix from"); canonical now carries per-scale
 `kewajiban` for 1,341 of 1,559 codes, which is the thing to derive it from.
 
-THE PREDICATE (pure, `edge_verdict` below — five outcomes, only ONE deletable):
+THE PREDICATE (pure, `edge_verdict` below — six outcomes, only ONE deletable):
 
   SUPPORTED                     ≥1 of the target's obligations appears in the
                                 code's canonical obligations. KEEP.
@@ -51,15 +51,18 @@ THE PREDICATE (pure, `edge_verdict` below — five outcomes, only ONE deletable)
   CANNOT_JUDGE_NODE_SILENT      the target states no obligations at all
                                 (`license:nib`, document nodes, …). Nothing to
                                 compare; this script has no opinion. KEEP.
+  CANNOT_JUDGE_NODE_UNREADABLE  `kewajiban` is neither a list nor absent (a bare
+                                string, a dict, …). A shape we cannot read is
+                                not evidence — see `_obligation_list`. KEEP.
   CANNOT_JUDGE_CANONICAL_SILENT canonical states no obligation for this code.
                                 Absence of a statement is not a denial, and
                                 deleting here would remove the only obligation
                                 text we hold. KEEP.
   CANNOT_JUDGE_CODE_ABSENT      the code is not in the canonical dataset. KEEP.
 
-Both sides are compared through the SAME `_norm` (HTML stripped, whitespace
-collapsed, lowercased) — one normaliser, so the two sides cannot drift apart
-into disagreeing about the same string.
+Both sides are compared through the SAME `_norm` (tags stripped, HTML entities
+decoded, whitespace collapsed, lowercased) — one normaliser, so the two sides
+cannot drift apart into disagreeing about the same string.
 
 MEASURED SCOPE at the time of writing, this module replayed over the live graph
 — **per ROW**: SUPPORTED 2,093 · CONTRADICTED 1,711 · node-silent 11,249 ·
@@ -91,10 +94,25 @@ AUDIT PARITY (never silent-delete, same discipline as the sibling script): the
 `(target, first obligation)` pairs about to be detached are archived on the
 `kbli:<code>` node itself, under `properties._disputed_requires_obligations`,
 BEFORE the edges go — so the removal is auditable by reading the node. Re-runs
-merge into that archive by target and never blank it.
+merge into that archive by target and never blank it. Two consequences that an
+earlier draft got wrong and a cross-family review caught:
+
+  * If there is NO `kbli:<code>` node, there is nowhere to archive to, so the
+    delete is REFUSED and counted, not performed with a warning. "Never
+    silent-delete" has to bind on the path where archiving is impossible, or
+    it is decoration.
+  * Archive and delete run in ONE transaction per code. Separately committed,
+    a delete that fails after the archive leaves the node asserting a
+    detachment that never happened — an audit trail that lies is worse than
+    no audit trail.
 
 Target nodes are never deleted, only the edges: those nodes are shared across
 many codes and several of their edges are SUPPORTED elsewhere.
+
+CONCURRENCY (declared, not guarded): the archive is a read-modify-write of the
+whole `properties` document, so two of these running at once on the same code
+can lose each other's archive entries. This is an operator-run, one-at-a-time
+cure; it is stated here rather than defended against.
 
 USAGE (dry-run is the default; nothing is written without --apply):
     fly ssh console -a nuzantara-rag -C \
@@ -107,6 +125,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import html
 import json
 import logging
 import os
@@ -129,6 +148,7 @@ ARCHIVE_KEY = "_disputed_requires_obligations"
 SUPPORTED = "SUPPORTED"
 CONTRADICTED = "CONTRADICTED"
 CANNOT_JUDGE_NODE_SILENT = "CANNOT_JUDGE_NODE_SILENT"
+CANNOT_JUDGE_NODE_UNREADABLE = "CANNOT_JUDGE_NODE_UNREADABLE"
 CANNOT_JUDGE_CANONICAL_SILENT = "CANNOT_JUDGE_CANONICAL_SILENT"
 CANNOT_JUDGE_CODE_ABSENT = "CANNOT_JUDGE_CODE_ABSENT"
 
@@ -139,10 +159,35 @@ _WS_RE = re.compile(r"\s+")
 def _norm(value: object) -> str:
     """Normalise one obligation string. BOTH sides of the comparison go through
     this single function — two normalisers would be two opinions about the same
-    string, and the disagreement would surface as a phantom CONTRADICTED."""
+    string, and the disagreement would surface as a phantom CONTRADICTED.
+
+    Tags are stripped first, THEN entities decoded: markup goes away, and what
+    survives is compared as the text a human reads. Decoding first would turn a
+    literal `&lt;` back into `<` and let the tag-stripper eat the prose after it.
+    Entity decoding is load-bearing, not cosmetic — 108 canonical obligation
+    strings carry entities and no KG node string does, so without it the SAME
+    sentence reads CONTRADICTED and the edge is deleted (measured: 0 verdicts
+    flip on today's data, so this is a latent false-delete, not a live one)."""
     if not isinstance(value, str):
         return ""
-    return _WS_RE.sub(" ", _TAG_RE.sub(" ", value)).strip().lower()
+    return _WS_RE.sub(" ", html.unescape(_TAG_RE.sub(" ", value))).strip().lower()
+
+
+def _obligation_list(value: object) -> list | None:
+    """The obligations of one node, or None when the shape is unreadable.
+
+    `properties.kewajiban` arrives as unvalidated JSON. A bare STRING is the
+    dangerous shape: iterating it yields CHARACTERS, so a canonical set holding
+    a one-letter entry would read SUPPORTED, and otherwise the whole node reads
+    CONTRADICTED and gets deleted on the strength of a misparse. A shape we
+    cannot read is not evidence of anything — it becomes a refusal, never a
+    delete. (Measured 2026-08-05: every live value is a list or absent, so this
+    is a guard against tomorrow's data, not today's.)"""
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return None
 
 
 def canonical_obligations(record: dict | None) -> set[str] | None:
@@ -168,7 +213,10 @@ def edge_verdict(canon: set[str] | None, node_kewajiban: list | None) -> str:
     dataset, empty set = present but stating no obligation.
     `node_kewajiban` is the target node's raw `properties.kewajiban`.
     """
-    node = [n for n in (_norm(x) for x in (node_kewajiban or [])) if n]
+    items = _obligation_list(node_kewajiban)
+    if items is None:
+        return CANNOT_JUDGE_NODE_UNREADABLE
+    node = [n for n in (_norm(x) for x in items) if n]
     if not node:
         return CANNOT_JUDGE_NODE_SILENT
     if canon is None:
@@ -276,6 +324,12 @@ async def main() -> int:
     dataset = await load_dataset(args.dataset)
     by_code = {str(r.get("kode_kbli_2025")): r for r in dataset}
 
+    # Bound before the try so the summary after `finally` can never read an
+    # unbound name on the very path where the summary matters most: a crash.
+    acting: list[CodePlan] = []
+    deleted_rows = 0
+    unarchivable = 0
+
     conn = await asyncpg.connect(dsn)
     try:
         if args.only:
@@ -316,7 +370,7 @@ async def main() -> int:
             for verdict in plan.verdicts.values():
                 tally[verdict] = tally.get(verdict, 0) + 1
 
-        acting = [p for p in plans if p.detach]
+        acting[:] = [p for p in plans if p.detach]
         logger.info(
             "scanned %d code(s) / %d REQUIRES edge(s) — verdicts: %s",
             len(plans),
@@ -331,11 +385,8 @@ async def main() -> int:
             sum(len(p.verdicts) for p in plans) - sum(len(p.detach) for p in acting),
         )
 
-        deleted_rows = 0
         for plan in acting:
-            logger.info(
-                "  %s: detach %d, keep %d", plan.code, len(plan.detach), plan.kept
-            )
+            logger.info("  %s: detach %d, keep %d", plan.code, len(plan.detach), plan.kept)
             for target_id in plan.detach:
                 logger.info("    -> %s :: %s", target_id, plan.archive[target_id][:90])
             if not args.apply:
@@ -344,7 +395,24 @@ async def main() -> int:
             node = await conn.fetchrow(
                 "SELECT properties FROM kg_nodes WHERE entity_id = $1", f"kbli:{plan.code}"
             )
-            if node is not None:
+            if node is None:
+                # No node means no place to archive to, and "archive BEFORE the
+                # delete" is the whole audit contract — a delete here would be
+                # exactly the silent-delete this script says it never does.
+                # Refuse, count it, and let the summary name it.
+                logger.warning(
+                    "  %s: REFUSED — no kg_nodes row, so the detachment could not be "
+                    "archived; edges left in place",
+                    plan.code,
+                )
+                unarchivable += 1
+                continue
+
+            # One transaction per code: the archive and the delete it documents
+            # land together or not at all. Without it a delete that fails after
+            # the archive leaves the node asserting a detachment that never
+            # happened — an audit trail that lies is worse than none.
+            async with conn.transaction():
                 props = _as_dict(node["properties"])
                 props[ARCHIVE_KEY] = merge_archive(props.get(ARCHIVE_KEY), plan.archive)
                 # W89 jsonb double-encoding class-guard: pre-serialise and cast
@@ -355,20 +423,20 @@ async def main() -> int:
                     f"kbli:{plan.code}",
                     json.dumps(props, ensure_ascii=False),
                 )
-            else:
-                logger.warning(
-                    "  %s: no kg_nodes row — edges detached WITHOUT an archive", plan.code
+                result = await conn.execute(
+                    "DELETE FROM kg_edges WHERE source_entity_id = $1 "
+                    "AND target_entity_id = ANY($2) AND relationship_type = 'REQUIRES'",
+                    f"kbli:{plan.code}",
+                    plan.detach,
                 )
-            result = await conn.execute(
-                "DELETE FROM kg_edges WHERE source_entity_id = $1 "
-                "AND target_entity_id = ANY($2) AND relationship_type = 'REQUIRES'",
-                f"kbli:{plan.code}",
-                plan.detach,
-            )
             deleted_rows += int(result.rsplit(" ", 1)[-1] or 0)
     finally:
         await conn.close()
 
+    if args.apply and unarchivable:
+        logger.warning(
+            "REFUSED on %d code(s): no kg_nodes row to archive the detachment on", unarchivable
+        )
     if args.apply:
         # rows can exceed pairs: 25 (code, target) pairs carry duplicate rows.
         logger.info(

--- a/apps/backend-rag/backend/scripts/kg_kbli_contradicted_obligations.py
+++ b/apps/backend-rag/backend/scripts/kg_kbli_contradicted_obligations.py
@@ -1,0 +1,386 @@
+"""
+kg_kbli_contradicted_obligations.py — detach the `kg_edges` REQUIRES rows whose
+target node states obligations (`properties.kewajiban`) that CANONICAL does not
+attribute to that KBLI code.
+
+WHY (2026-08-05, live finding): `kbli_notebook.py:466` renders each REQUIRES
+target's `properties.kewajiban` verbatim as the code's `requirements`, so a
+wrongly-attached target tells a client to do something the law does not ask of
+their business. Measured on prod before this script existed:
+
+  * `perizinan:0bf540b11cf6` ("NIB dan Sertifikat Standar", first obligation
+    "Menerapkan cara budi daya tanaman pangan yang baik (good agriculture
+    practices)…") is REQUIRES-linked from **778** KBLI codes.
+  * `perizinan:55be853cd247` ("NIB dan Izin", first obligation "Menerapkan
+    teknologi pembukaan lahan tanpa bakar…" — slash-and-burn-free land
+    clearing) from **293**.
+  * Two smaller siblings, `c7cd8d6c86e5` (36) and `41a60205c6c0` (22, whose
+    single "obligation" is the bare word `skala`).
+
+Concretely: `inspect_kbli 62110` (computer-game development) was told to apply
+good agriculture practices, and `inspect_kbli 79122` (Umrah/Hajj travel agency)
+to clear plantation land without burning.
+
+THIS IS AN **EDGE** DEFECT, NOT A CANONICAL ONE. The canonical dataset is clean
+for these codes — 62110 carries 6 obligations (SARA-free content, after-sales
+SOP…), 79122 carries 29 (pilgrimage guides, accreditation every 5 years…). The
+lie is produced by the graph edge, so the cure removes the edge and never
+touches the canonical record.
+
+RELATION TO `kg_kbli_license_fix.py` (deliberately a SEPARATE script, not a new
+flag on that one): its cure is "canonical `per_skala == []` → the code has NO
+licensing at all → delete EVERY REQUIRES edge of that code". That is a
+whole-code verdict driven by an empty canonical block. This one is a
+**per-edge** verdict driven by a NON-empty canonical block: the same code keeps
+the targets canonical does support and loses only the ones it does not. On
+79122 that is the difference between deleting all 6 targets and deleting the 1
+that is wrong. Folding two different predicates into one entry point is how a
+future reader applies the wrong one. That script's own docstring already NAMED
+this population as out of its scope ("one shared agriculture-marker
+`perizinan:*` node alone is REQUIRES-linked from ~68% of the KG's KBLI codes …
+this script has nothing to derive a fix from"); canonical now carries per-scale
+`kewajiban` for 1,341 of 1,559 codes, which is the thing to derive it from.
+
+THE PREDICATE (pure, `edge_verdict` below — five outcomes, only ONE deletable):
+
+  SUPPORTED                     ≥1 of the target's obligations appears in the
+                                code's canonical obligations. KEEP.
+  CONTRADICTED                  canonical states obligations for this code and
+                                NONE of the target's appears among them.
+                                DELETABLE — the only outcome that is.
+  CANNOT_JUDGE_NODE_SILENT      the target states no obligations at all
+                                (`license:nib`, document nodes, …). Nothing to
+                                compare; this script has no opinion. KEEP.
+  CANNOT_JUDGE_CANONICAL_SILENT canonical states no obligation for this code.
+                                Absence of a statement is not a denial, and
+                                deleting here would remove the only obligation
+                                text we hold. KEEP.
+  CANNOT_JUDGE_CODE_ABSENT      the code is not in the canonical dataset. KEEP.
+
+Both sides are compared through the SAME `_norm` (HTML stripped, whitespace
+collapsed, lowercased) — one normaliser, so the two sides cannot drift apart
+into disagreeing about the same string.
+
+MEASURED SCOPE at the time of writing, this module replayed over the live graph
+— **per ROW**: SUPPORTED 2,093 · CONTRADICTED 1,711 · node-silent 11,249 ·
+canonical-silent 2 = 15,055. **Per (code, target) PAIR**, which is what the
+DELETE acts on: 2,076 / 1,707 / 11,245 / 2 = 15,030; the 25-row difference is
+duplicate rows on the same pair (17 SUPPORTED, 4 CONTRADICTED, 4 node-silent),
+which is why the apply log reports rows AND pairs rather than one number. The
+dangerous "delete the only obligation text we hold" class is those **2**
+canonical-silent edges over 1 code, and the refusal above already covers them.
+The four nodes named above account for 1,118 of the contradicted pairs; the rest
+are spread over other targets, so this is a class, not four rows.
+
+Ordering note (so a future reader is not surprised by an empty bucket): the
+node-silent test runs BEFORE the code-absent one, so the 15 edges whose code is
+missing from canonical report as `CANNOT_JUDGE_NODE_SILENT` — measured, all 15
+point at targets that state no obligation at all. Both outcomes are KEEP, so the
+label differs and the action does not.
+
+DECLARED LIMIT (measured, not assumed): the comparison is exact-match after
+normalisation, so a canonical obligation RE-WORDED in the KG reads CONTRADICTED.
+490 of the 1,019 distinct obligation strings carried by contradicted targets do
+appear verbatim in canonical elsewhere — the two vocabularies genuinely align —
+and the other 529 are dominated by truncated/garbled extractions ("…good
+agriculture practices) dan", "mengusahaka n lahan", the bare "skala"), i.e. text
+canonical never states for ANY code. Against that residual risk the archive
+below is the backstop: nothing is destroyed, only detached.
+
+AUDIT PARITY (never silent-delete, same discipline as the sibling script): the
+`(target, first obligation)` pairs about to be detached are archived on the
+`kbli:<code>` node itself, under `properties._disputed_requires_obligations`,
+BEFORE the edges go — so the removal is auditable by reading the node. Re-runs
+merge into that archive by target and never blank it.
+
+Target nodes are never deleted, only the edges: those nodes are shared across
+many codes and several of their edges are SUPPORTED elsewhere.
+
+USAGE (dry-run is the default; nothing is written without --apply):
+    fly ssh console -a nuzantara-rag -C \
+        "python backend/scripts/kg_kbli_contradicted_obligations.py --only 79122"
+    fly ssh console -a nuzantara-rag -C \
+        "python backend/scripts/kg_kbli_contradicted_obligations.py --all-contradicted --apply"
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import asyncpg
+import httpx
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("kg_kbli_contradicted_obligations")
+
+RAW_BASE = "https://raw.githubusercontent.com/Balizero1987/Teman2/main"
+DATASET_URL = f"{RAW_BASE}/data/source_documents/KBLI_2025_FINAL_CLEAN.json"
+
+ARCHIVE_KEY = "_disputed_requires_obligations"
+
+SUPPORTED = "SUPPORTED"
+CONTRADICTED = "CONTRADICTED"
+CANNOT_JUDGE_NODE_SILENT = "CANNOT_JUDGE_NODE_SILENT"
+CANNOT_JUDGE_CANONICAL_SILENT = "CANNOT_JUDGE_CANONICAL_SILENT"
+CANNOT_JUDGE_CODE_ABSENT = "CANNOT_JUDGE_CODE_ABSENT"
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+def _norm(value: object) -> str:
+    """Normalise one obligation string. BOTH sides of the comparison go through
+    this single function — two normalisers would be two opinions about the same
+    string, and the disagreement would surface as a phantom CONTRADICTED."""
+    if not isinstance(value, str):
+        return ""
+    return _WS_RE.sub(" ", _TAG_RE.sub(" ", value)).strip().lower()
+
+
+def canonical_obligations(record: dict | None) -> set[str] | None:
+    """Union of `per_skala[*].kewajiban` for one canonical record.
+
+    Returns None when the record itself is absent (a different verdict from "the
+    record exists and states nothing", which is an empty set)."""
+    if record is None:
+        return None
+    out: set[str] = set()
+    for entry in record.get("per_skala") or []:
+        for item in entry.get("kewajiban") or []:
+            normalised = _norm(item)
+            if normalised:
+                out.add(normalised)
+    return out
+
+
+def edge_verdict(canon: set[str] | None, node_kewajiban: list | None) -> str:
+    """Pure decision for ONE (code, target) pair — no I/O.
+
+    `canon` is `canonical_obligations(record)`: None = code absent from the
+    dataset, empty set = present but stating no obligation.
+    `node_kewajiban` is the target node's raw `properties.kewajiban`.
+    """
+    node = [n for n in (_norm(x) for x in (node_kewajiban or [])) if n]
+    if not node:
+        return CANNOT_JUDGE_NODE_SILENT
+    if canon is None:
+        return CANNOT_JUDGE_CODE_ABSENT
+    if not canon:
+        return CANNOT_JUDGE_CANONICAL_SILENT
+    if any(n in canon for n in node):
+        return SUPPORTED
+    return CONTRADICTED
+
+
+def is_deletable(verdict: str) -> bool:
+    """CONTRADICTED is the ONLY deletable outcome. Written as its own function so
+    a future outcome added to `edge_verdict` is not silently swept into the
+    delete set by an `!= SUPPORTED` test somewhere."""
+    return verdict == CONTRADICTED
+
+
+@dataclass
+class CodePlan:
+    code: str
+    verdicts: dict[str, str] = field(default_factory=dict)  # target_entity_id -> verdict
+    detach: list[str] = field(default_factory=list)  # target_entity_ids to detach
+    archive: dict[str, str] = field(default_factory=dict)  # target -> first obligation
+
+    @property
+    def kept(self) -> int:
+        return len(self.verdicts) - len(self.detach)
+
+
+def plan_code(
+    code: str,
+    record: dict | None,
+    targets: dict[str, list],
+) -> CodePlan:
+    """Pure per-code plan. `targets` maps target_entity_id -> its raw kewajiban."""
+    canon = canonical_obligations(record)
+    plan = CodePlan(code=code)
+    for target_id, node_kewajiban in sorted(targets.items()):
+        verdict = edge_verdict(canon, node_kewajiban)
+        plan.verdicts[target_id] = verdict
+        if is_deletable(verdict):
+            plan.detach.append(target_id)
+            first = next((_norm(x) for x in (node_kewajiban or []) if _norm(x)), "")
+            plan.archive[target_id] = first[:300]
+    return plan
+
+
+def merge_archive(existing: object, additions: dict[str, str]) -> dict[str, str]:
+    """Merge new detachments into whatever archive the node already carries.
+
+    Idempotent and never blanking: an earlier run's entries survive, and a
+    re-detach of the same target overwrites only its own key. A non-dict legacy
+    value is preserved under a reserved key rather than dropped."""
+    merged: dict[str, str] = {}
+    if isinstance(existing, dict):
+        merged.update({str(k): str(v) for k, v in existing.items()})
+    elif existing:
+        merged["_legacy"] = json.dumps(existing, ensure_ascii=False)[:300]
+    merged.update(additions)
+    return merged
+
+
+def _looks_like_local_path(source: str) -> bool:
+    return not source.startswith(("http://", "https://")) and Path(source).exists()
+
+
+async def load_dataset(source: str) -> list[dict]:
+    if _looks_like_local_path(source):
+        logger.info("dataset: reading local file %s", source)
+        return json.loads(Path(source).read_text(encoding="utf-8"))["data"]
+    logger.info("dataset: fetching %s", source)
+    async with httpx.AsyncClient(timeout=60) as http:
+        response = await http.get(source)
+        response.raise_for_status()
+        return response.json()["data"]
+
+
+def _as_dict(value: object) -> dict:
+    if isinstance(value, str):
+        try:
+            return json.loads(value) or {}
+        except json.JSONDecodeError:
+            return {}
+    return value or {}  # type: ignore[return-value]
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="write changes (default: dry-run)")
+    parser.add_argument("--only", help="comma-separated 5-digit codes")
+    parser.add_argument(
+        "--all-contradicted",
+        action="store_true",
+        help="every kbli code holding at least one CONTRADICTED edge",
+    )
+    parser.add_argument("--dataset", default=DATASET_URL)
+    args = parser.parse_args()
+
+    if bool(args.only) == bool(args.all_contradicted):
+        logger.error("choose exactly one selector: --only <codes> OR --all-contradicted")
+        return 2
+
+    dsn = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+    dataset = await load_dataset(args.dataset)
+    by_code = {str(r.get("kode_kbli_2025")): r for r in dataset}
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        if args.only:
+            wanted = [c.strip() for c in args.only.split(",") if c.strip()]
+            edge_rows = await conn.fetch(
+                "SELECT source_entity_id, target_entity_id FROM kg_edges "
+                "WHERE relationship_type = 'REQUIRES' AND source_entity_id = ANY($1)",
+                [f"kbli:{c}" for c in wanted],
+            )
+        else:
+            edge_rows = await conn.fetch(
+                "SELECT source_entity_id, target_entity_id FROM kg_edges "
+                "WHERE relationship_type = 'REQUIRES' AND source_entity_id LIKE 'kbli:%'"
+            )
+
+        target_ids = sorted({r["target_entity_id"] for r in edge_rows})
+        node_kewajiban: dict[str, list] = {}
+        if target_ids:
+            for row in await conn.fetch(
+                "SELECT entity_id, properties FROM kg_nodes WHERE entity_id = ANY($1)", target_ids
+            ):
+                props = _as_dict(row["properties"])
+                node_kewajiban[row["entity_id"]] = props.get("kewajiban") or []
+
+        by_source: dict[str, dict[str, list]] = {}
+        for row in edge_rows:
+            by_source.setdefault(row["source_entity_id"], {})[row["target_entity_id"]] = (
+                node_kewajiban.get(row["target_entity_id"], [])
+            )
+
+        plans = [
+            plan_code(src.split(":", 1)[1], by_code.get(src.split(":", 1)[1]), targets)
+            for src, targets in sorted(by_source.items())
+        ]
+
+        tally: dict[str, int] = {}
+        for plan in plans:
+            for verdict in plan.verdicts.values():
+                tally[verdict] = tally.get(verdict, 0) + 1
+
+        acting = [p for p in plans if p.detach]
+        logger.info(
+            "scanned %d code(s) / %d REQUIRES edge(s) — verdicts: %s",
+            len(plans),
+            sum(len(p.verdicts) for p in plans),
+            ", ".join(f"{k}={v}" for k, v in sorted(tally.items())),
+        )
+        logger.info(
+            "deletable (%s only): %d edge(s) over %d code(s); the other %d edge(s) are KEPT",
+            CONTRADICTED,
+            sum(len(p.detach) for p in acting),
+            len(acting),
+            sum(len(p.verdicts) for p in plans) - sum(len(p.detach) for p in acting),
+        )
+
+        deleted_rows = 0
+        for plan in acting:
+            logger.info(
+                "  %s: detach %d, keep %d", plan.code, len(plan.detach), plan.kept
+            )
+            for target_id in plan.detach:
+                logger.info("    -> %s :: %s", target_id, plan.archive[target_id][:90])
+            if not args.apply:
+                continue
+
+            node = await conn.fetchrow(
+                "SELECT properties FROM kg_nodes WHERE entity_id = $1", f"kbli:{plan.code}"
+            )
+            if node is not None:
+                props = _as_dict(node["properties"])
+                props[ARCHIVE_KEY] = merge_archive(props.get(ARCHIVE_KEY), plan.archive)
+                # W89 jsonb double-encoding class-guard: pre-serialise and cast
+                # text->jsonb exactly once.
+                await conn.execute(
+                    "UPDATE kg_nodes SET properties = $2::text::jsonb, updated_at = now() "
+                    "WHERE entity_id = $1",
+                    f"kbli:{plan.code}",
+                    json.dumps(props, ensure_ascii=False),
+                )
+            else:
+                logger.warning(
+                    "  %s: no kg_nodes row — edges detached WITHOUT an archive", plan.code
+                )
+            result = await conn.execute(
+                "DELETE FROM kg_edges WHERE source_entity_id = $1 "
+                "AND target_entity_id = ANY($2) AND relationship_type = 'REQUIRES'",
+                f"kbli:{plan.code}",
+                plan.detach,
+            )
+            deleted_rows += int(result.rsplit(" ", 1)[-1] or 0)
+    finally:
+        await conn.close()
+
+    if args.apply:
+        # rows can exceed pairs: 25 (code, target) pairs carry duplicate rows.
+        logger.info(
+            "APPLIED: %d edge ROW(s) deleted across %d pair(s) on %d code(s)",
+            deleted_rows,
+            sum(len(p.detach) for p in acting),
+            len(acting),
+        )
+    else:
+        logger.info("dry-run complete — rerun with --apply to write")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kg_kbli_contradicted_obligations.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kg_kbli_contradicted_obligations.py
@@ -146,6 +146,45 @@ def test_non_string_obligations_are_dropped_rather_than_crashing():
     assert mod.edge_verdict(canon, [None, 42, {"a": 1}]) == mod.CANNOT_JUDGE_NODE_SILENT
 
 
+def test_an_html_entity_does_not_manufacture_a_contradiction():
+    """108 canonical obligation strings carry HTML entities and no KG node string
+    does, so without decoding the SAME sentence reads CONTRADICTED and the edge
+    is deleted. Found by a cross-family review, measured 0 live flips today."""
+    canon = mod.canonical_obligations(record("Memenuhi syarat A & B"))
+    assert mod.edge_verdict(canon, ["Memenuhi syarat A &amp; B"]) == mod.SUPPORTED
+
+
+def test_entities_are_decoded_on_the_canonical_side_too():
+    canon = mod.canonical_obligations(record("Memenuhi syarat A &amp; B"))
+    assert mod.edge_verdict(canon, ["Memenuhi syarat A & B"]) == mod.SUPPORTED
+
+
+# --- a shape we cannot read is a refusal, never a delete -----------------
+
+
+def test_a_bare_string_kewajiban_is_refused_not_iterated_character_by_character():
+    """`properties.kewajiban` is unvalidated JSON. Iterating a STRING yields
+    CHARACTERS: with canonical holding a one-letter entry the node would read
+    SUPPORTED off a misparse, and otherwise the whole node would be DELETED on
+    one. Neither verdict is evidence about the law."""
+    canon = mod.canonical_obligations(record("a"))
+    verdict = mod.edge_verdict(canon, "abc")
+    assert verdict == mod.CANNOT_JUDGE_NODE_UNREADABLE
+    assert not mod.is_deletable(verdict)
+
+
+def test_a_dict_kewajiban_is_refused_rather_than_judged_on_its_keys():
+    canon = mod.canonical_obligations(record(PILGRIM_GUIDE))
+    assert mod.edge_verdict(canon, {PILGRIM_GUIDE: 1}) == mod.CANNOT_JUDGE_NODE_UNREADABLE
+
+
+def test_absent_kewajiban_is_silent_not_unreadable():
+    """None must stay distinguishable from a broken shape — the first is the
+    ordinary `license:nib` case, the second is a data defect worth seeing."""
+    assert mod._obligation_list(None) == []
+    assert mod._obligation_list("abc") is None
+
+
 # --- only CONTRADICTED is deletable --------------------------------------
 
 
@@ -155,6 +194,7 @@ def test_non_string_obligations_are_dropped_rather_than_crashing():
         (mod.CONTRADICTED, True),
         (mod.SUPPORTED, False),
         (mod.CANNOT_JUDGE_NODE_SILENT, False),
+        (mod.CANNOT_JUDGE_NODE_UNREADABLE, False),
         (mod.CANNOT_JUDGE_CANONICAL_SILENT, False),
         (mod.CANNOT_JUDGE_CODE_ABSENT, False),
     ],
@@ -163,22 +203,22 @@ def test_is_deletable_admits_exactly_one_outcome(verdict, deletable):
     assert mod.is_deletable(verdict) is deletable
 
 
-def test_plan_code_detaches_exactly_the_verdicts_is_deletable_admits():
-    """Wiring pin: the plan must not grow its own opinion about what to delete.
-    If a sixth verdict is ever added, this fails unless `is_deletable` rules on
-    it — rather than the plan quietly sweeping it in."""
+def test_plan_code_asks_is_deletable_instead_of_holding_its_own_opinion(monkeypatch):
+    """Wiring pin, made non-tautological after a cross-family review: comparing
+    `plan.detach` against `is_deletable(plan.verdicts[...])` passes just as well
+    when `plan_code` hard-codes `== CONTRADICTED`, because the two agree today.
+    Redefining `is_deletable` to admit SUPPORTED instead is the only way to show
+    which of the two the plan actually consults."""
+    monkeypatch.setattr(mod, "is_deletable", lambda verdict: verdict == mod.SUPPORTED)
     plan = mod.plan_code(
         "79122",
         record(ACCREDITATION, PILGRIM_GUIDE),
         {
-            "perizinan:55be853cd247": [LAND_CLEARING],
-            "perizinan:7a471f5d56b8": [PILGRIM_GUIDE],
-            "license:nib": [],
+            "perizinan:55be853cd247": [LAND_CLEARING],  # CONTRADICTED
+            "perizinan:7a471f5d56b8": [PILGRIM_GUIDE],  # SUPPORTED
         },
     )
-    assert set(plan.detach) == {
-        t for t, v in plan.verdicts.items() if mod.is_deletable(v)
-    }
+    assert plan.detach == ["perizinan:7a471f5d56b8"]
 
 
 # --- the per-code plan ----------------------------------------------------

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kg_kbli_contradicted_obligations.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kg_kbli_contradicted_obligations.py
@@ -1,0 +1,230 @@
+"""Guilt + innocence for the contradicted-obligations edge cure.
+
+The shapes below are the ones measured on prod on 2026-08-05, because the whole
+value of this cure is that it separates the wrong edge from the right one ON THE
+SAME CODE — `79122` (Umrah/Hajj travel) was being told to clear plantation land
+without burning while ALSO carrying its genuine pilgrimage duties. A whole-code
+cure would have taken both; the innocence tests here are what pin that it does
+not.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "kg_kbli_contradicted_obligations.py"
+)
+_spec = importlib.util.spec_from_file_location("kg_kbli_contradicted_obligations", _MODULE_PATH)
+assert _spec and _spec.loader
+mod = importlib.util.module_from_spec(_spec)
+# Register BEFORE exec: @dataclass resolves annotations via
+# sys.modules[cls.__module__], which is None for an unregistered module.
+sys.modules[_spec.name] = mod
+_spec.loader.exec_module(mod)
+
+
+# --- the live strings this cure exists for --------------------------------
+FARMING = "Menerapkan cara budi daya tanaman pangan yang baik (good agriculture practices) dan"
+LAND_CLEARING = (
+    "Menerapkan teknologi pembukaan lahan tanpa bakar dan mengelola sumber daya alam secara lestari"
+)
+PILGRIM_GUIDE = "Menyediakan paling sedikit 1 (satu) orang pembimbing ibadah dari setiap rombongan"
+ACCREDITATION = "Memperoleh akreditasi setiap 5 (lima) tahun"
+INDUSTRY_DATA = "Memiliki bukti penyampaian wajib Data Industri tervalidasi setiap 6 (enam) bulan"
+SARA_FREE = "Menjamin konten dalam produk tidak mengandung konten SARA dan"
+
+
+def record(*obligations: str, scales: int = 1) -> dict:
+    """A canonical record whose per_skala entries carry `obligations`."""
+    return {
+        "kode_kbli_2025": "00000",
+        "per_skala": [{"skala_usaha": ["Besar"], "kewajiban": list(obligations)}] * scales,
+    }
+
+
+# --- guilt ----------------------------------------------------------------
+
+
+def test_a_pilgrimage_agency_told_to_clear_land_without_burning_is_contradicted():
+    canon = mod.canonical_obligations(record(ACCREDITATION, PILGRIM_GUIDE))
+    assert mod.edge_verdict(canon, [LAND_CLEARING]) == mod.CONTRADICTED
+
+
+def test_a_game_studio_told_to_apply_good_agriculture_practices_is_contradicted():
+    canon = mod.canonical_obligations(record(SARA_FREE))
+    assert mod.edge_verdict(canon, [FARMING]) == mod.CONTRADICTED
+
+
+def test_the_bare_word_skala_is_not_an_obligation_this_code_holds():
+    canon = mod.canonical_obligations(record(SARA_FREE))
+    assert mod.edge_verdict(canon, ["skala"]) == mod.CONTRADICTED
+
+
+# --- innocence: the same code keeps what canonical does support -----------
+
+
+def test_the_pilgrimage_agency_keeps_its_own_pilgrimage_duty():
+    canon = mod.canonical_obligations(record(ACCREDITATION, PILGRIM_GUIDE))
+    assert mod.edge_verdict(canon, [PILGRIM_GUIDE]) == mod.SUPPORTED
+
+
+def test_the_game_studio_keeps_its_industry_data_reporting_duty():
+    canon = mod.canonical_obligations(record(SARA_FREE, INDUSTRY_DATA))
+    assert mod.edge_verdict(canon, [INDUSTRY_DATA]) == mod.SUPPORTED
+
+
+def test_one_matching_obligation_is_enough_even_beside_unmatched_ones():
+    """A target legitimately bundles several duties; canonical need only confirm
+    that the target belongs to this code, not every line it carries."""
+    canon = mod.canonical_obligations(record(PILGRIM_GUIDE))
+    assert mod.edge_verdict(canon, ["something canonical never says", PILGRIM_GUIDE]) == (
+        mod.SUPPORTED
+    )
+
+
+# --- the three refusals ---------------------------------------------------
+
+
+def test_a_target_stating_no_obligation_is_never_judged():
+    """`license:nib` and the document nodes carry no `kewajiban` — there is
+    nothing to compare, so this cure has no opinion and must not delete."""
+    canon = mod.canonical_obligations(record(SARA_FREE))
+    verdict = mod.edge_verdict(canon, [])
+    assert verdict == mod.CANNOT_JUDGE_NODE_SILENT
+    assert not mod.is_deletable(verdict)
+
+
+def test_a_canonical_record_that_states_nothing_never_authorises_a_delete():
+    """Absence of a statement is not a denial — and deleting here would remove
+    the only obligation text we hold for that code."""
+    verdict = mod.edge_verdict(mod.canonical_obligations(record()), [FARMING])
+    assert verdict == mod.CANNOT_JUDGE_CANONICAL_SILENT
+    assert not mod.is_deletable(verdict)
+
+
+def test_a_code_absent_from_canonical_never_authorises_a_delete():
+    verdict = mod.edge_verdict(mod.canonical_obligations(None), [FARMING])
+    assert verdict == mod.CANNOT_JUDGE_CODE_ABSENT
+    assert not mod.is_deletable(verdict)
+
+
+def test_canonical_obligations_distinguishes_absent_record_from_silent_one():
+    """None and set() must not collapse: they drive two different refusals."""
+    assert mod.canonical_obligations(None) is None
+    assert mod.canonical_obligations(record()) == set()
+
+
+# --- one normaliser, both sides ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "node_form",
+    [
+        f"<strong>{PILGRIM_GUIDE}</strong>",
+        PILGRIM_GUIDE.upper(),
+        f"  {PILGRIM_GUIDE}\n\n ",
+        PILGRIM_GUIDE.replace(" ", "  "),
+    ],
+)
+def test_markup_case_and_whitespace_do_not_manufacture_a_contradiction(node_form):
+    canon = mod.canonical_obligations(record(PILGRIM_GUIDE))
+    assert mod.edge_verdict(canon, [node_form]) == mod.SUPPORTED
+
+
+def test_the_canonical_side_is_normalised_too_not_just_the_node_side():
+    canon = mod.canonical_obligations(record(f"<li>{PILGRIM_GUIDE}</li>"))
+    assert mod.edge_verdict(canon, [PILGRIM_GUIDE]) == mod.SUPPORTED
+
+
+def test_non_string_obligations_are_dropped_rather_than_crashing():
+    canon = mod.canonical_obligations(record(PILGRIM_GUIDE))
+    assert mod.edge_verdict(canon, [None, 42, {"a": 1}]) == mod.CANNOT_JUDGE_NODE_SILENT
+
+
+# --- only CONTRADICTED is deletable --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "verdict,deletable",
+    [
+        (mod.CONTRADICTED, True),
+        (mod.SUPPORTED, False),
+        (mod.CANNOT_JUDGE_NODE_SILENT, False),
+        (mod.CANNOT_JUDGE_CANONICAL_SILENT, False),
+        (mod.CANNOT_JUDGE_CODE_ABSENT, False),
+    ],
+)
+def test_is_deletable_admits_exactly_one_outcome(verdict, deletable):
+    assert mod.is_deletable(verdict) is deletable
+
+
+def test_plan_code_detaches_exactly_the_verdicts_is_deletable_admits():
+    """Wiring pin: the plan must not grow its own opinion about what to delete.
+    If a sixth verdict is ever added, this fails unless `is_deletable` rules on
+    it — rather than the plan quietly sweeping it in."""
+    plan = mod.plan_code(
+        "79122",
+        record(ACCREDITATION, PILGRIM_GUIDE),
+        {
+            "perizinan:55be853cd247": [LAND_CLEARING],
+            "perizinan:7a471f5d56b8": [PILGRIM_GUIDE],
+            "license:nib": [],
+        },
+    )
+    assert set(plan.detach) == {
+        t for t, v in plan.verdicts.items() if mod.is_deletable(v)
+    }
+
+
+# --- the per-code plan ----------------------------------------------------
+
+
+def test_the_wrong_target_goes_and_the_right_ones_stay_on_the_same_code():
+    plan = mod.plan_code(
+        "79122",
+        record(ACCREDITATION, PILGRIM_GUIDE),
+        {
+            "perizinan:55be853cd247": [LAND_CLEARING],
+            "perizinan:7a471f5d56b8": [PILGRIM_GUIDE],
+            "license:nib": [],
+        },
+    )
+    assert plan.detach == ["perizinan:55be853cd247"]
+    assert plan.kept == 2
+    assert plan.verdicts["perizinan:7a471f5d56b8"] == mod.SUPPORTED
+    assert plan.verdicts["license:nib"] == mod.CANNOT_JUDGE_NODE_SILENT
+
+
+def test_a_detached_target_is_archived_with_the_obligation_that_condemned_it():
+    plan = mod.plan_code("79122", record(ACCREDITATION), {"perizinan:55be853cd247": [LAND_CLEARING]})
+    assert plan.archive["perizinan:55be853cd247"] == mod._norm(LAND_CLEARING)
+
+
+def test_a_code_whose_canonical_is_silent_produces_no_detachments_at_all():
+    plan = mod.plan_code("00000", record(), {"perizinan:0bf540b11cf6": [FARMING]})
+    assert plan.detach == []
+    assert plan.archive == {}
+
+
+# --- the archive never loses what an earlier run wrote --------------------
+
+
+def test_merge_archive_keeps_an_earlier_runs_entries():
+    merged = mod.merge_archive({"perizinan:aaa": "old"}, {"perizinan:bbb": "new"})
+    assert merged == {"perizinan:aaa": "old", "perizinan:bbb": "new"}
+
+
+def test_merge_archive_is_idempotent_on_a_re_detach():
+    first = mod.merge_archive(None, {"perizinan:aaa": "why"})
+    assert mod.merge_archive(first, {"perizinan:aaa": "why"}) == first
+
+
+def test_merge_archive_does_not_blank_a_legacy_non_dict_value():
+    merged = mod.merge_archive(["perizinan:legacy"], {"perizinan:aaa": "why"})
+    assert merged["perizinan:aaa"] == "why"
+    assert "perizinan:legacy" in merged["_legacy"]

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`332 routers · 680 services · 1285 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`332 routers · 680 services · 1286 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What a client sees today

`kbli_notebook.py:466` renders every REQUIRES-edge target's `properties.kewajiban`
verbatim as the code's `requirements`. Measured on prod this morning:

| target node | its first obligation | KBLI codes linked |
|---|---|---|
| `perizinan:0bf540b11cf6` | *Menerapkan cara budi daya tanaman pangan yang baik (good agriculture practices)* | **778** |
| `perizinan:55be853cd247` | *Menerapkan teknologi pembukaan lahan tanpa bakar* | **293** |
| `perizinan:c7cd8d6c86e5` | (same land-clearing text) | 36 |
| `perizinan:41a60205c6c0` | the bare word `skala` | 22 |

So `inspect_kbli 62110` — computer-game development — is told to apply good
agriculture practices, and `inspect_kbli 79122` — an Umrah/Hajj travel agency —
to clear plantation land without burning.

**Canonical is clean for both.** 62110 carries 6 obligations (SARA-free content,
after-sales SOP…), 79122 carries 29 (pilgrimage guides, accreditation every five
years…). The lie is produced by the graph edge, so this cure removes edges only —
never the canonical record, never the shared target nodes.

## The predicate: five outcomes, exactly one deletable

| outcome | meaning | action |
|---|---|---|
| `SUPPORTED` | ≥1 of the target's obligations is in the code's canonical set | KEEP |
| `CONTRADICTED` | canonical **states** obligations here and none of the target's is among them | **DELETE** |
| `CANNOT_JUDGE_NODE_SILENT` | the target states no obligation (`license:nib`, document nodes) | KEEP |
| `CANNOT_JUDGE_CANONICAL_SILENT` | canonical states nothing for this code | KEEP |
| `CANNOT_JUDGE_CODE_ABSENT` | the code is not in canonical | KEEP |

Absence of a statement is not a denial — the three refusals exist so this cure
cannot remove the only obligation text we hold. Both sides compare through one
`_norm`, so they cannot drift into disagreeing about the same string.

## Why not a flag on `kg_kbli_license_fix.py`

That cure is a **whole-code** verdict driven by an *empty* canonical block: delete
every REQUIRES edge. This is a **per-edge** verdict driven by a *non-empty* one.
On 79122 that is the difference between deleting all 6 targets and deleting the 1
that is wrong. Its docstring already named this population as beyond its scope
("this script has nothing to derive a fix from") — canonical now carries per-scale
`kewajiban` for 1,341 of 1,559 codes, which is the thing it lacked.

## Measured by replaying this module over the live graph

Per **row**: SUPPORTED 2,093 · CONTRADICTED 1,711 · node-silent 11,249 ·
canonical-silent 2 = **15,055**.
Per **(code, target) pair**, which is what the DELETE acts on: 2,076 · 1,707 ·
11,245 · 2 = **15,030**. The 25-row difference is duplicate rows on the same pair
(17 SUPPORTED, 4 CONTRADICTED, 4 node-silent) — which is why the apply log reports
rows *and* pairs rather than one number.

The dangerous "delete the only obligation text we hold" class is **2 edges over 1
code**, and the refusal already covers them. The four nodes above account for 1,118
of the contradicted pairs; the rest are spread over other targets — a class, not
four rows.

## Verification

- **28 tests**, guilt + innocence **on the same code**: 79122 loses land-clearing
  and keeps its pilgrimage duty; 62110 loses farming and keeps industry-data
  reporting. A whole-code cure would have taken both.
- **Mutation-verified 6/6** — admitting any non-SUPPORTED verdict, deleting on
  canonical-silent, deleting on node-silent, dropping the HTML strip, collapsing
  absent-record into silent-record, and forgetting an earlier run's archive each
  turn the corpus red.
- Detachments are archived on the `kbli:<code>` node under
  `properties._disputed_requires_obligations` **before** the edges go, merging
  with (never blanking) an earlier run's archive.

## Declared limit

Exact-match after normalisation, so a canonical obligation **re-worded** in the KG
reads CONTRADICTED. 490 of the 1,019 distinct obligation strings carried by
contradicted targets do appear verbatim in canonical elsewhere — the vocabularies
genuinely align — and the other 529 are dominated by truncated/garbled extractions
("…good agriculture practices) **dan**", "mengusahaka n lahan", the bare "skala"),
i.e. text canonical never states for any code. The archive is the backstop against
that residual: nothing is destroyed, only detached.

## Not claimed

**Nothing is written to the database by this PR.** Dry-run is the default; the
apply is a separate step and will be reported with its own before/after
measurement on the live graph and on `inspect_kbli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Adversarial review (generator≠grader) — verdict was DEFECTIVE

The diff deletes rows from a production table and I wrote it, so it was handed to
a **cross-family seat** (Codex GPT-5.6, `--sandbox read-only`) with the
instruction to refute it and default to "defective". It did. Four of its five
findings were real; each was re-measured against the live graph before being
accepted, and all four are fixed in `0aeee4d1c`.

1. **HTML entities were not decoded — a real false-DELETE.** Canonical `"A & B"`
   vs a node's `"A &amp; B"` read CONTRADICTED. Measured: **108** canonical
   obligation strings carry entities, **0** node strings do — exactly the
   asymmetry that bites. Also measured: **0 verdicts flip** on today's data, so
   it was latent, not live. Fixed by decoding *after* tag-stripping.
2. **A non-list `kewajiban` was iterated character by character.** A bare string
   yields CHARACTERS, so a one-letter canonical entry reads SUPPORTED off a
   misparse — or the node is deleted on one. New sixth outcome
   `CANNOT_JUDGE_NODE_UNREADABLE`: a shape we cannot read is a refusal, never a
   delete. (Measured: every live value today is a list or absent.)
3. **"Never silent-delete" did not bind where archiving is impossible.** With no
   `kbli:<code>` node the old code warned and deleted anyway — contradicting this
   file's own claim. Now refused, counted and named. Archive+delete also now run
   in **one transaction per code**: separately committed, a delete failing after
   the archive leaves the node asserting a detachment that never happened.
4. **The wiring pin was tautological.** It compared `plan.detach` against
   `is_deletable(plan.verdicts[...])`, which passes just as well if `plan_code`
   hard-codes `== CONTRADICTED`. Replaced with a monkeypatch that redefines
   `is_deletable` to admit SUPPORTED — the only way to show which the plan
   actually consults.
5. *(true, not fixed)* Concurrent runs can lose each other's archive entries
   (whole-document read-modify-write). This is a one-at-a-time operator cure, so
   it is **declared** in the docstring rather than defended against.

**34 tests, mutation-verified 10/10.** Scope re-measured on the live graph after
the fixes: unchanged at **1,707 deletable pairs over 1,029 codes**.
