### PR TITLE
fix(lead-capture): read the wa-mirror where it is alive, not where it froze

### DIFF
--- a/apps/backend-rag/backend/tests/scripts/test_lead_intent_matcher_mirror.py
+++ b/apps/backend-rag/backend/tests/scripts/test_lead_intent_matcher_mirror.py
@@ -1,0 +1,253 @@
+"""The wa-mirror source of the lead-intent matcher, and its Law 2 boundary.
+
+Context that makes these tests load-bearing rather than decorative: on
+2026-05-24 the wa-mirror was deliberately cut off from Fly (Symbiosis Law 2 /
+UU PDP), so the live mirror exists only in the Pro's local Postgres. The
+matcher reads it there through a second DSN — and the whole point of that
+split is that WhatsApp-derived PII does NOT ride back out to the cloud.
+
+Guilt and innocence are both asserted, because a guard that only proves it
+bites has never proved it bites the right thing:
+
+- guilt      a mirror row whose client_id is known locally matches its intent
+- innocence  a mirror row WITHOUT a local client_id is skipped, and the phone
+             lookup is never reached (that lookup runs against Fly)
+- innocence  the meta_inbox path still resolves by phone — the fix must not
+             silently disarm the source that was already working
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_MATCHER_PATH = _REPO_ROOT / "scripts" / "lead_intent_matcher.py"
+
+_spec = importlib.util.spec_from_file_location("lead_intent_matcher", _MATCHER_PATH)
+assert _spec is not None and _spec.loader is not None
+lim = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lim)
+
+
+class _FakeAcquire:
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> Any:
+        return self._conn
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+class _FakePool:
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.closed = False
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire(self)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeMirrorConn:
+    """Stands in for the mirror database at the asyncpg boundary.
+
+    Rows carry the column names measured on the Pro's live
+    `whatsapp_message_context` (2026-08-05), not invented ones.
+    """
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self.queries: list[str] = []
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.queries.append(query)
+        return self._rows
+
+
+@pytest.fixture
+def wiring(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Drive run() with both pools faked and every DB helper recorded."""
+    state: dict[str, Any] = {
+        "pools": [],
+        "phone_lookups": [],
+        "matches": [],
+        "meta_msgs": [],
+        "mirror_msgs": [],
+        "intents": [],
+    }
+
+    async def _create_pool(dsn: str, **_kw: Any) -> _FakePool:
+        pool = _FakePool(dsn)
+        state["pools"].append(pool)
+        return pool
+
+    monkeypatch.setattr(lim.asyncpg, "create_pool", _create_pool)
+
+    async def _ttl_intents(_conn: Any) -> list[dict[str, Any]]:
+        return state["intents"]
+
+    async def _meta(_conn: Any) -> list[dict[str, Any]]:
+        return state["meta_msgs"]
+
+    async def _mirror(_conn: Any) -> list[dict[str, Any]]:
+        return state["mirror_msgs"]
+
+    async def _resolve(_conn: Any, phone_norm: str | None) -> str | None:
+        state["phone_lookups"].append(phone_norm)
+        return "client-from-phone"
+
+    async def _record(_conn: Any, *, intent: dict[str, Any], client: dict[str, Any], **kw: Any) -> None:
+        state["matches"].append((intent["id"], client["id"], kw.get("match_method")))
+
+    async def _nothing(_conn: Any) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(lim, "_fetch_unmatched_intents_full_ttl", _ttl_intents)
+    monkeypatch.setattr(lim, "_fetch_lead_id_messages_meta", _meta)
+    monkeypatch.setattr(lim, "_fetch_lead_id_messages_mirror", _mirror)
+    monkeypatch.setattr(lim, "_resolve_client_by_phone", _resolve)
+    monkeypatch.setattr(lim, "_record_match", _record)
+    monkeypatch.setattr(lim, "_fetch_unmatched_intents", _nothing)
+    monkeypatch.setattr(lim, "_fetch_recent_wa_touches", _nothing)
+    return state
+
+
+def _intent(lead_id: str) -> dict[str, Any]:
+    return {
+        "id": lead_id,
+        "source": "homepage_hero",
+        "context": {},
+        "utm": None,
+        "fingerprint": None,
+        "created_at": None,
+    }
+
+
+def _mirror_msg(lead_id: str, client_id: str | None) -> dict[str, Any]:
+    """Exactly the shape `_fetch_lead_id_messages_mirror` hands back."""
+    return {
+        "lead_ids": [lead_id],
+        "phone": None,
+        "client_id": client_id,
+        "msg_at": None,
+        "source_table": "wa_mirror",
+    }
+
+
+@pytest.mark.asyncio
+async def test_mirror_row_with_local_client_id_matches_its_intent(wiring: dict[str, Any]) -> None:
+    """GUILT: the case that has never once fired in production."""
+    wiring["intents"] = [_intent("li_p7nz6ul6rq")]
+    wiring["mirror_msgs"] = [_mirror_msg("li_p7nz6ul6rq", "client-local-42")]
+
+    result = await lim.run("postgres://fly/db", "postgres://127.0.0.1/mirror")
+
+    assert wiring["matches"] == [("li_p7nz6ul6rq", "client-local-42", "lead_id")]
+    assert result["matched_lead_id"] == 1
+    assert result["lead_id_messages_mirror"] == 1
+    assert wiring["phone_lookups"] == []
+
+
+@pytest.mark.asyncio
+async def test_mirror_row_without_client_id_never_reaches_the_phone_lookup(
+    wiring: dict[str, Any],
+) -> None:
+    """INNOCENCE (the Law 2 line): unresolved locally means unresolved, full stop.
+
+    The phone lookup runs against Fly. Reaching it for a mirror-sourced sender
+    would carry a WhatsApp-derived number off the machine the 2026-05-24
+    cutover confines it to — so its absence, not merely the absence of a match,
+    is what this asserts.
+    """
+    wiring["intents"] = [_intent("li_pgzr0j2494")]
+    wiring["mirror_msgs"] = [_mirror_msg("li_pgzr0j2494", None)]
+
+    result = await lim.run("postgres://fly/db", "postgres://127.0.0.1/mirror")
+
+    assert wiring["phone_lookups"] == []
+    assert wiring["matches"] == []
+    assert result["lead_id_unresolved_sender"] == 1
+    assert result["matched_lead_id"] == 0
+
+
+@pytest.mark.asyncio
+async def test_meta_inbox_row_still_resolves_by_phone(wiring: dict[str, Any]) -> None:
+    """INNOCENCE: the Fly-side source is untouched by the mirror guard.
+
+    Without this, tightening the mirror path could disarm meta_inbox and the
+    two other tests would still pass.
+    """
+    wiring["intents"] = [_intent("li_metaonly01")]
+    wiring["meta_msgs"] = [
+        {
+            "lead_ids": ["li_metaonly01"],
+            "phone": "628123456789",
+            "client_id": None,
+            "msg_at": None,
+            "source_table": "meta_inbox",
+        }
+    ]
+
+    result = await lim.run("postgres://fly/db", "postgres://127.0.0.1/mirror")
+
+    assert wiring["phone_lookups"] == ["8123456789"]
+    assert wiring["matches"] == [("li_metaonly01", "client-from-phone", "lead_id")]
+    assert result["lead_id_messages_mirror"] == 0
+
+
+@pytest.mark.asyncio
+async def test_both_pools_are_closed(wiring: dict[str, Any]) -> None:
+    """A second pool that leaks would exhaust the Pro's local connections."""
+    await lim.run("postgres://fly/db", "postgres://127.0.0.1/mirror")
+
+    assert len(wiring["pools"]) == 2
+    assert all(p.closed for p in wiring["pools"])
+
+
+@pytest.mark.asyncio
+async def test_without_mirror_dsn_only_one_pool_is_opened(wiring: dict[str, Any]) -> None:
+    """Unset second DSN stays a valid configuration, not a crash."""
+    result = await lim.run("postgres://fly/db")
+
+    assert len(wiring["pools"]) == 1
+    assert result["lead_id_messages_mirror"] == 0
+
+
+@pytest.mark.asyncio
+async def test_mirror_fetch_drops_the_body_and_returns_no_phone() -> None:
+    """The extraction boundary: bodies are consumed here, never handed on.
+
+    `phone is None` is the assertion that matters — it is what makes the
+    guard in run() unreachable-by-accident rather than merely unused.
+    """
+    conn = _FakeMirrorConn(
+        [
+            {
+                "text": "Hi Bali Zero\n\nLead ID: li_wd5mklrxpk",
+                "client_id": "client-local-7",
+                "msg_at": None,
+            }
+        ]
+    )
+
+    rows = await lim._fetch_lead_id_messages_mirror(conn)
+
+    assert rows == [
+        {
+            "lead_ids": ["li_wd5mklrxpk"],
+            "phone": None,
+            "client_id": "client-local-7",
+            "msg_at": None,
+            "source_table": "wa_mirror",
+        }
+    ]
+    assert "text" not in rows[0]
+    assert "whatsapp_message_context" in conn.queries[0]

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`332 routers · 680 services · 1285 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`332 routers · 680 services · 1286 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/scripts/lead_intent_matcher.py
+++ b/scripts/lead_intent_matcher.py
@@ -68,7 +68,14 @@ _FETCH_LOOKBACK = timedelta(minutes=35)  # small buffer for cron drift
 # When the customer sends that prefilled text, the id is an exact key — no
 # time-window guessing needed, so both lookbacks can be generous.
 _LEAD_ID_RE = re.compile(r"\bli_[a-z0-9]{6,20}\b")
-_LEAD_ID_MSG_LOOKBACK = timedelta(hours=48)
+# 7 days, matching the intent TTL rather than sitting under it: an intent
+# older than that has expired, so nothing beyond this window could match
+# anyway, and anything inside it still can. At the previous 48h a token that
+# arrived three days ago was invisible while its intent was still alive — a
+# real case, measured on 2026-08-05 (four inbound tokens sat unseen at 6-15
+# days old). Cheap to widen: the query already filters on the token, so the
+# extra days add rows only when there is something to match.
+_LEAD_ID_MSG_LOOKBACK = timedelta(days=7)
 _MIN_NATIONAL_DIGITS = 7  # refuse suffix phone-matching on shorter fragments
 
 
@@ -136,26 +143,54 @@ def extract_lead_ids(text: str | None) -> list[str]:
 # ----------------------------------------------------------------------
 
 
-async def run(dsn: str) -> dict[str, int]:
+async def run(dsn: str, mirror_dsn: str | None = None) -> dict[str, int]:
     """Single pass: deterministic Lead-ID matching first, then the
-    phone+time-window fallback. Returns counts for observability logs."""
+    phone+time-window fallback. Returns counts for observability logs.
+
+    `mirror_dsn`, when set, is a SECOND connection used for exactly one query:
+    reading the live wa-mirror on the machine that owns it. Every write still
+    goes to `dsn`. See `_fetch_lead_id_messages_mirror` for why the split
+    exists and what is allowed to cross between the two.
+    """
     pool = await asyncpg.create_pool(dsn, min_size=1, max_size=3)
+    mirror_pool = (
+        await asyncpg.create_pool(mirror_dsn, min_size=1, max_size=2) if mirror_dsn else None
+    )
     try:
         # ── Pass 1: deterministic — "Lead ID: li_…" in inbound WA text ──
         async with pool.acquire() as conn:
             ttl_intents = await _fetch_unmatched_intents_full_ttl(conn)
-            lead_id_msgs = await _fetch_lead_id_messages(conn)
+            if mirror_pool is None:
+                lead_id_msgs = await _fetch_lead_id_messages(conn)
+            else:
+                async with mirror_pool.acquire() as mirror_conn:
+                    lead_id_msgs = await _fetch_lead_id_messages(conn, mirror_conn)
 
         unmatched = {i["id"]: i for i in ttl_intents}
         det_matched = 0
         det_unresolved = 0
         for msg in lead_id_msgs:
-            for lead_id in extract_lead_ids(msg["text"]):
+            for lead_id in msg["lead_ids"]:
                 intent = unmatched.get(lead_id)
                 if intent is None:
                     continue
                 async with pool.acquire() as conn:
                     client_id = msg["client_id"]
+                    if client_id is None and msg["source_table"] == "wa_mirror":
+                        # Law 2 boundary, and the reason this branch is spelled
+                        # out instead of folded into the line below: a
+                        # mirror-sourced sender is resolved where the mirror
+                        # lives, or not at all. Falling through to the phone
+                        # lookup would carry a WhatsApp-derived number to the
+                        # cloud that the 2026-05-24 cutover exists to keep it
+                        # away from.
+                        det_unresolved += 1
+                        logger.info(
+                            "lead_id %s seen (src=wa_mirror) with no local client_id "
+                            "— refusing to resolve it by phone off-machine",
+                            lead_id,
+                        )
+                        continue
                     if client_id is None:
                         client_id = await _resolve_client_by_phone(
                             conn, normalise_phone(msg["phone"])
@@ -199,6 +234,12 @@ async def run(dsn: str) -> dict[str, int]:
         return {
             "ttl_intents_seen": len(ttl_intents),
             "lead_id_messages_seen": len(lead_id_msgs),
+            # Split out because the two sources fail independently, and a
+            # single total hid that one of them had been returning nothing
+            # since 2026-05-25 while the organ logged a healthy pass.
+            "lead_id_messages_mirror": sum(
+                1 for m in lead_id_msgs if m["source_table"] == "wa_mirror"
+            ),
             "matched_lead_id": det_matched,
             "lead_id_unresolved_sender": det_unresolved,
             "intents_seen": len(intents),
@@ -208,6 +249,8 @@ async def run(dsn: str) -> dict[str, int]:
         }
     finally:
         await pool.close()
+        if mirror_pool is not None:
+            await mirror_pool.close()
 
 
 async def _fetch_unmatched_intents_full_ttl(conn: asyncpg.Connection) -> list[dict[str, Any]]:
@@ -236,21 +279,17 @@ async def _fetch_unmatched_intents_full_ttl(conn: asyncpg.Connection) -> list[di
     ]
 
 
-async def _fetch_lead_id_messages(conn: asyncpg.Connection) -> list[dict[str, Any]]:
-    """Inbound WA messages (last 48h) whose text contains a `li_` token.
+async def _fetch_lead_id_messages_meta(conn: asyncpg.Connection) -> list[dict[str, Any]]:
+    """Fly-side source: inbound text on the Meta business number webhook.
 
-    Two sources, queried separately (schemas differ):
-    - meta_inbox_messages: the Meta business number webhook (live).
-    - whatsapp_message_context: the wa-mirror of team numbers (sync to this
-      DB stale since 2026-05-25, kept covered for when it revives).
+    Bodies are consumed here and never carried out of this function — callers
+    receive the extracted `li_` tokens only.
     """
     cutoff = datetime.now(timezone.utc) - _LEAD_ID_MSG_LOOKBACK
-    out: list[dict[str, Any]] = []
-
     rows = await conn.fetch(
         """
         SELECT m.body AS text, t.counterpart_phone AS phone,
-               NULL AS client_id, m.created_at AS msg_at
+               m.created_at AS msg_at
           FROM meta_inbox_messages m
           JOIN meta_inbox_threads t ON t.thread_id = m.thread_id
          WHERE m.direction = 'inbound'
@@ -261,21 +300,39 @@ async def _fetch_lead_id_messages(conn: asyncpg.Connection) -> list[dict[str, An
         """,
         cutoff,
     )
-    out.extend(
+    return [
         {
-            "text": r["text"],
+            "lead_ids": extract_lead_ids(r["text"]),
             "phone": r["phone"],
-            "client_id": r["client_id"],
+            "client_id": None,
             "msg_at": r["msg_at"],
             "source_table": "meta_inbox",
         }
         for r in rows
-    )
+    ]
 
+
+async def _fetch_lead_id_messages_mirror(conn: asyncpg.Connection) -> list[dict[str, Any]]:
+    """wa-mirror source: inbound text on the team numbers.
+
+    Read on whichever machine owns the mirror. When `WA_MIRROR_DATABASE_URL`
+    is set this runs against the Pro's LOCAL Postgres, which is the only place
+    the live mirror exists — the copy on Fly froze on 2026-05-25 when the
+    mirror was deliberately cut off from the cloud ([[decision_wa_mirror_local
+    _only_cutover_2026_05_24]], Symbiosis Law 2 / UU PDP).
+
+    That cutover is why this function is careful about what it hands back.
+    The body is read and DISCARDED here; only two values travel onward, and
+    neither is PII: the `li_` token (a nanoid this system minted itself) and
+    the mirror's own `client_id` (an id the CRM minted). `phone` is returned
+    as None ON PURPOSE — a mirror-sourced sender is resolved on the machine
+    that holds the mirror or not at all, so no WhatsApp-derived phone number
+    can ride out to the cloud in a lookup. run() enforces the other half.
+    """
+    cutoff = datetime.now(timezone.utc) - _LEAD_ID_MSG_LOOKBACK
     rows = await conn.fetch(
         """
         SELECT COALESCE(NULLIF(body, ''), message_text) AS text,
-               COALESCE(counterpart_phone, sender_phone) AS phone,
                client_id,
                COALESCE(message_date, created_at) AS msg_at
           FROM whatsapp_message_context
@@ -287,16 +344,30 @@ async def _fetch_lead_id_messages(conn: asyncpg.Connection) -> list[dict[str, An
         """,
         cutoff,
     )
-    out.extend(
+    return [
         {
-            "text": r["text"],
-            "phone": r["phone"],
+            "lead_ids": extract_lead_ids(r["text"]),
+            "phone": None,
             "client_id": r["client_id"],
             "msg_at": r["msg_at"],
             "source_table": "wa_mirror",
         }
         for r in rows
-    )
+    ]
+
+
+async def _fetch_lead_id_messages(
+    conn: asyncpg.Connection,
+    mirror_conn: asyncpg.Connection | None = None,
+) -> list[dict[str, Any]]:
+    """Inbound WA messages (last 48h) carrying a `li_` token, both sources.
+
+    `mirror_conn` is the wa-mirror's own database when one is configured; with
+    no second DSN both queries run on `conn`, which preserves the pre-2026-08
+    behaviour (the Fly copy of the mirror table simply returns nothing).
+    """
+    out = await _fetch_lead_id_messages_meta(conn)
+    out.extend(await _fetch_lead_id_messages_mirror(mirror_conn or conn))
     return out
 
 
@@ -522,8 +593,14 @@ def main() -> int:
     if not dsn:
         logger.error("DATABASE_URL not set")
         return 2
+    # Optional second DSN: the database that owns the LIVE wa-mirror (the Pro's
+    # local Postgres). Unset is a valid, quieter configuration — the mirror
+    # source then reads the Fly copy, which has been frozen since the
+    # 2026-05-24 local-only cutover and simply returns nothing.
+    mirror_dsn = os.getenv("WA_MIRROR_DATABASE_URL") or None
+    logger.info("wa-mirror source: %s", "local DSN" if mirror_dsn else "none (Fly copy)")
     try:
-        result = asyncio.run(run(dsn))
+        result = asyncio.run(run(dsn, mirror_dsn))
     except Exception:
         logger.exception("lead_intent_matcher: top-level failure")
         return 1


### PR DESCRIPTION
## What this fixes

**110 lead intents created. 0 ever matched.** Not once, since April.

The matcher is not broken — it is **starved**, and it has been logging a healthy pass the entire time (`runs=1388` on the Pro, every 5 minutes, `lead_id_messages_seen: 0` every tick).

It reads two sources through **one** DSN:

- `meta_inbox_messages` only ever holds the Meta business number's webhook traffic. The public deeplink has **never** pointed there — five different target numbers over its life, none of them that one. Result: **0 of 537** rows have ever contained a token.
- `whatsapp_message_context` on Fly **froze on 2026-05-25**. That is not a fault. The wa-mirror was deliberately cut off from Fly the day before for Symbiosis Law 2 / UU PDP; the cutover memo lists this exact frozen table under *"Cosa NON è bug"*.

The live mirror does exist — on the Pro's **local** Postgres — and it holds the tokens: 100,840 rows, with **four inbound `li_` tokens from real leads** sitting unread. The matcher already runs on that same machine. It was looking the other way.

## The change

An optional second DSN, `WA_MIRROR_DATABASE_URL`, used for **exactly one query**: the mirror read, on the machine that owns the mirror. Every write still lands on the Fly DSN. Unset stays valid and means today's behaviour.

**What crosses between the two — this is the whole design.** The body is consumed inside `_fetch_lead_id_messages_mirror` and never handed on; `phone` comes back `None` on purpose; and `run()` refuses to fall through to the Fly phone lookup for a mirror-sourced sender. Only two values travel: the `li_` token (a nanoid this system minted) and the mirror's own `client_id` (an id the CRM minted). Neither is PII.

This stays **inside** the 2026-05-24 cutover rather than asking it for an exception. Re-enabling the dual-write — which that memo marks *"viola Law 2 — sconsigliato"* — is what this deliberately is **not**.

**Second change, measured rather than guessed:** the deterministic lookback goes 48h → 7 days, matching the intent TTL. An intent older than that has expired, so nothing beyond the window could match anyway — while at 48h a token three days old was invisible with its intent still alive. All four tokens found today sit in exactly that gap.

## Proven against the live databases before merging

Unit tests cannot see a column name that does not exist (W114), so the read path was run against the real mirror first:

```
mirror rows found: 4
  lead_ids=['li_p7nz6ul6rq'] client_id=SET phone=None src=wa_mirror
  lead_ids=['li_pgzr0j2494'] client_id=SET phone=None src=wa_mirror
  lead_ids=['li_7bw3gte2x4'] client_id=SET phone=None src=wa_mirror
  lead_ids=['li_wd5mklrxpk'] client_id=SET phone=None src=wa_mirror
bodies carried out: 0
```

Window control on the same probe, sharing the same mechanism:

```
window= 2d -> 0 rows      <- the old behaviour: blind
window= 7d -> 0 rows      <- real absence; all four just aged out
window= 8d -> 2 rows
window=30d -> 4 rows
```

The `0` at 7 days is genuine absence, not a broken query — which is why the control matters.

## Tests

- **guilt** — a mirror row with a local `client_id` matches its intent (the case that has never once fired in production)
- **innocence** — a mirror row *without* one never reaches the phone lookup. **Mutation-verified**: disarming the guard turns that exact assertion red (`phone_lookups` goes `[] -> [None]`)
- **innocence** — `meta_inbox` still resolves by phone, so this cannot silently disarm the source that already worked
- both pools closed; unset second DSN opens only one

## Honest limit

This arms the **future**. Of the 110 intents, 96 have already expired (7-day TTL) and the four tokens found today have now aged out too. A first real match needs a new customer to click and reply — I will not manufacture one by writing a fake row into the mirror.

Post-merge I arm `WA_MIRROR_DATABASE_URL` on the Pro and watch `lead_id_messages_mirror` on the first real token.