### PR TITLE
perf(kbli): scope decorative blur orbs and SVG pattern to desktop-only

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -48,7 +48,7 @@ export default async function KBLIHomePage({
         <div className="relative -mx-4 overflow-hidden rounded-3xl sm:-mx-6 lg:-mx-8 bg-[#141416]">
           {/* Balinese ornamental pattern */}
           <div
-            className="absolute inset-0 opacity-100"
+            className="hidden lg:block absolute inset-0 opacity-100"
             style={{
               backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Crect width='200' height='200' fill='none'/%3E%3Crect x='0' y='0' width='200' height='200' fill='none' stroke='rgba(255,255,255,0.04)' stroke-width='0.5'/%3E%3Ccircle cx='100' cy='100' r='50' fill='none' stroke='rgba(255,255,255,0.03)' stroke-width='0.5'/%3E%3Ccircle cx='100' cy='100' r='30' fill='none' stroke='rgba(255,255,255,0.025)' stroke-width='0.5'/%3E%3Ccircle cx='100' cy='100' r='8' fill='none' stroke='rgba(255,255,255,0.04)' stroke-width='0.5'/%3E%3Ccircle cx='100' cy='100' r='2' fill='rgba(255,255,255,0.05)'/%3E%3Cpath d='M100,50 Q120,70 100,90 Q80,70 100,50Z' fill='none' stroke='rgba(255,255,255,0.03)' stroke-width='0.5'/%3E%3Cpath d='M100,150 Q120,130 100,110 Q80,130 100,150Z' fill='none' stroke='rgba(255,255,255,0.03)' stroke-width='0.5'/%3E%3Cpath d='M50,100 Q70,120 90,100 Q70,80 50,100Z' fill='none' stroke='rgba(255,255,255,0.03)' stroke-width='0.5'/%3E%3Cpath d='M150,100 Q130,120 110,100 Q130,80 150,100Z' fill='none' stroke='rgba(255,255,255,0.03)' stroke-width='0.5'/%3E%3C/svg%3E")`,
               backgroundSize: "200px 200px",
@@ -64,19 +64,19 @@ export default async function KBLIHomePage({
           />
           {/* Ambient orbs — subtle red and white for Indonesian flag feel */}
           <div
-            className="absolute top-[-15%] left-[10%] w-[500px] h-[500px] rounded-full opacity-[0.06] blur-[120px]"
+            className="hidden lg:block absolute top-[-15%] left-[10%] w-[500px] h-[500px] rounded-full opacity-[0.06] blur-[120px]"
             style={{
               background: "radial-gradient(circle, #dc2626, transparent)",
             }}
           />
           <div
-            className="absolute top-[-10%] right-[15%] w-[400px] h-[400px] rounded-full opacity-[0.04] blur-[100px]"
+            className="hidden lg:block absolute top-[-10%] right-[15%] w-[400px] h-[400px] rounded-full opacity-[0.04] blur-[100px]"
             style={{
               background: "radial-gradient(circle, #ffffff, transparent)",
             }}
           />
           <div
-            className="absolute bottom-[-15%] right-[-5%] w-[350px] h-[350px] rounded-full opacity-[0.05] blur-[100px]"
+            className="hidden lg:block absolute bottom-[-15%] right-[-5%] w-[350px] h-[350px] rounded-full opacity-[0.05] blur-[100px]"
             style={{
               background: "radial-gradient(circle, #dc2626, transparent)",
             }}


### PR DESCRIPTION
## Insight
Mobile LCP on `/kbli` measured at 8.2s (CWV baseline 6 Aug 2026). Root cause: 4 decorative elements — 1 SVG data-URI ornamental pattern and 3 heavy CSS blur orbs (blur-[100px]/blur-[120px]) — were rendered unconditionally including on mobile, creating significant GPU paint cost before the LCP element (`<h1>KBLI 2025</h1>`) could be painted. Desktop CWV passed at 0.7–1.4s, confirming the issue is device-specific rendering cost, not a structural DOM bug.

## Studio
(a) No visual change to desktop users — all decorative elements remain fully rendered on lg+ viewports. Mobile users will see a flatter hero background (no blur orbs, no SVG pattern) while H1, subtitle, CTA button, and trust bar remain unchanged. (b) `apps/mouth/src/app/kbli/page.tsx` — Hero section decorative layer divs, lines 50–56 (SVG pattern) and 66–83 (3x ambient blur orbs). Zone: VERDE.

## Source
- CWV baseline: `/kbli` mobile LCP 8.2s, desktop LCP 0.7s (measured 5 Aug 2026)
- Phase 1 audit (Antigravity): identified 5 decorative layers rendering before LCP candidate
- `apps/mouth/src/app/kbli/page.tsx` lines 50–83

## Methodology
Applied Tailwind responsive prefix `hidden lg:block` to the 4 expensive decorative elements. Radial vignette (lines 58–64) retained on mobile as it uses native CSS `radial-gradient` without filter — negligible GPU cost. Video/tablet preview column already scoped to `hidden lg:flex` by parent container — no change needed.

## Raw Observations
- 3x ambient orbs: `blur-[120px]` and `blur-[100px]` — extremely expensive on mobile GPU
- SVG data-URI pattern: triggers SVG decode + tiled background-image paint on every frame
- LCP candidate confirmed as `<h1>KBLI 2025</h1>` — text element, not image
- Desktop unaffected: all elements remain visible at lg breakpoint

## Reasoning Path
Desktop passes CWV → issue is not structural → mobile GPU cannot handle blur filters before LCP paint → solution: gate expensive decoratives behind `lg:` breakpoint → mobile LCP candidate (H1 text) can paint immediately with only cheap vignette gradient in background.

## Risk
- Low: purely additive CSS class change, no logic change
- Mobile hero background appears flatter — acceptable trade-off for LCP improvement
- No shared component touched (packages/core/ untouched)

## Implication
Expected mobile LCP improvement: 8.2s → target sub-4s (pending CWV field data, 28-day window). Desktop experience unchanged. CLS unaffected (no layout shifts introduced).

## Recommendation
Merge. Monitor CWV field data in GSC after 2–3 weeks. If mobile LCP still above 2.5s threshold, next investigation: TTFB and render-blocking JS on `/kbli` route.

## Next Action
1. Merge this PR
2. Verify deployment via `curl -s https://balizero.com/api/health`
3. Check `/kbli` mobile in Brave DevTools (throttled CPU) — H1 should paint visibly faster
4. Record new CWV baseline in 28 days via GSC Core Web Vitals report