### PR TITLE
fix(redirects): add 301 for /id/insights/pbb-property-tax-indonesia

### DIFF
--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -240,6 +240,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/id/insights/pbb-property-tax-indonesia",
+        destination: "/taxes/pbb-property-tax-indonesia",
+        permanent: true,
+      },
+      {
         source: "/it/tax-for-freelancers-indonesia-2026",
         destination: "/it/taxes/freelancer-tax-guide",
         permanent: true,


### PR DESCRIPTION
## Insight
GSC Coverage report (24 Jul 2026) shows URL \`/id/insights/pbb-property-tax-indonesia\` returning 404, first detected 17 Aug 2022. The correct content exists at \`/taxes/pbb-property-tax-indonesia\` (HTTP 200 verified). No redirect existed for this legacy \`/id/insights/\` path pattern.

## Studio
No visual change to end users. This PR adds a server-side 301 redirect — users hitting the old URL are silently forwarded to the correct page. File: \`apps/mouth/next.config.ts\`, redirects array, line ~241. Zone: VERDE.

## Source
- GSC Coverage → Not found (404) report: \`https://balizero.com/id/insights/pbb-property-tax-indonesia\`
- Verified target: \`curl -s -o /dev/null -w "%{http_code}" https://balizero.com/taxes/pbb-property-tax-indonesia\` → 200
- Existing pattern reference: \`next.config.ts:238\` (\`/id/tax-for-freelancers-indonesia-2026\` redirect)

## Methodology
Added single \`permanent: true\` redirect entry in \`next.config.ts\` redirects array, consistent with existing \`/id/*\` redirect pattern already present in the file.

## Raw Observations
- \`/id/insights/pbb-property-tax-indonesia\` → 404 (no redirect)
- \`/insights/pbb-property-tax-indonesia\` → 301 → \`/pbb-property-tax-indonesia\` → 200 (separate chain, unrelated)
- \`/taxes/pbb-property-tax-indonesia\` → 200 (correct target)
- No duplicate entry in next.config.ts (verified before patch)

## Reasoning Path
URL 404 in GSC → verify target exists → target confirmed at /taxes/ → add 301 redirect → build pass → PR.

## Risk
Low. Single redirect entry addition. No existing redirect chain conflict. next.config.ts redirects are evaluated at request time — no build-time side effects beyond config parsing.

## Implication
Recovers link equity from any external links pointing to the old \`/id/insights/\` URL. GSC will re-crawl and remove the 404 from Coverage report after validation.

## Recommendation
Merge. Low risk, high confidence target URL.

## Next Action
1. Merge and verify deployment via \`curl -s https://balizero.com/api/health\`
2. Verify redirect live: \`curl -s -o /dev/null -w "%{http_code} %{redirect_url}" https://balizero.com/id/insights/pbb-property-tax-indonesia\`
3. Click "Validate Fix" in GSC Coverage → Not found (404) report