### PR TITLE
docs(onboarding): regen quick-numbers to match origin/main

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`332 routers · 680 services · 1286 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`332 routers · 680 services · 1287 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- proprioception `docs_sync` probe flagged `docs/AI_ONBOARDING.md` stale (6edc746d0c4d -> 78b8df24aeab)
- regenerated via `scripts/docs_sync.py`: test count 1286 -> 1287

## Test plan
- [x] `scripts/docs_sync.py` regen output verified (single-number diff)
- [x] pre-commit/pre-push hooks green

Healer autonomous tick (Mini-Pro2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)