### PR TITLE
fix(kbli): the explorer's copy button told clients an iron-sand mine needs no licence

### DIFF
--- a/apps/mouth/src/app/kbli-explorer/page.tsx
+++ b/apps/mouth/src/app/kbli-explorer/page.tsx
@@ -42,6 +42,7 @@ import { useTypewriter } from "./hooks/useTypewriter";
 import LegacyAlert from "./components/LegacyAlert";
 import BlackBookModal from "./components/BlackBookModal";
 import { KBLI_CONCORDANCE_2025 } from "./concordance";
+import { summariseLicences } from "@/lib/kbli-licence-summary";
 
 // =============================================================================
 // CONSTANTS & HELPERS
@@ -660,7 +661,13 @@ const InspectorChoreographed = ({
 
   // Copy/Export (2C)
   const handleCopy = () => {
-    const licList = data.licenses.map((l) => l.type).join(", ") || "None";
+    // `|| "None"` here asserted "no licence required" out of an EMPTY list —
+    // 284 codes render `licenses: []` and canonical states obligations for 125
+    // of them. The resolver declares the gap instead. See kbli-licence-summary.
+    const licList = summariseLicences(
+      data.licenses.map((l) => l.type),
+      data.licensing_status,
+    );
     const text = `KBLI ${data.code} — ${data.title} | PMA: ${pmaBadge.label} | Risk: ${getRiskBadge(data.risk_profile).label} | Licenses: ${licList} | Sector: ${data.sector}`;
     navigator.clipboard.writeText(text).then(() => {
       toast.success("Copied to clipboard");

--- a/apps/mouth/src/lib/kbli-licence-summary.test.ts
+++ b/apps/mouth/src/lib/kbli-licence-summary.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  summariseLicences,
+  LICENCE_GAP_LABEL,
+  LICENCE_NONE_LABEL,
+} from "./kbli-licence-summary";
+
+describe("summariseLicences", () => {
+  // GUILT — the defect this file exists for. An empty list on a REGULATED code
+  // must never be reported as "None"; 07101 (iron sand mining, REGULATED,
+  // risk Tinggi) rendered exactly that in the clipboard export.
+  it("never says None for a REGULATED code with no licence rows", () => {
+    const out = summariseLicences([], "REGULATED");
+    expect(out).toBe(LICENCE_GAP_LABEL);
+    expect(out.toLowerCase()).not.toContain("none");
+  });
+
+  it.each(["PENDING_REGULATION", "NOT_IN_KBLI_2025", null, undefined])(
+    "declares a gap rather than absence for status %s",
+    (status) => {
+      expect(summariseLicences([], status)).toBe(LICENCE_GAP_LABEL);
+    },
+  );
+
+  // INNOCENCE — the one status where "none required" is the truth, and the
+  // ordinary case where we do hold rows, must both keep working.
+  it("reports none required only for NOT_APPLICABLE_OSS", () => {
+    expect(summariseLicences([], "NOT_APPLICABLE_OSS")).toBe(
+      LICENCE_NONE_LABEL,
+    );
+  });
+
+  it("joins the licence types it actually holds", () => {
+    expect(
+      summariseLicences(["NIB dan Izin", "Sertifikat Standar"], "REGULATED"),
+    ).toBe("NIB dan Izin, Sertifikat Standar");
+  });
+
+  it("keeps the real rows even when the status says none are required", () => {
+    expect(summariseLicences(["Izin Usaha"], "NOT_APPLICABLE_OSS")).toBe(
+      "Izin Usaha",
+    );
+  });
+
+  // A list of blanks is an empty list, not a licence named "" — otherwise the
+  // join emits a bare comma and reads as two unnamed licences.
+  it("treats blank and null entries as no rows at all", () => {
+    expect(summariseLicences(["", "   ", null, undefined], "REGULATED")).toBe(
+      LICENCE_GAP_LABEL,
+    );
+  });
+
+  it("drops blanks but keeps the named rows beside them", () => {
+    expect(summariseLicences(["", "NIB", null], "REGULATED")).toBe("NIB");
+  });
+});

--- a/apps/mouth/src/lib/kbli-licence-summary.ts
+++ b/apps/mouth/src/lib/kbli-licence-summary.ts
@@ -1,0 +1,43 @@
+/**
+ * Single resolver for the licence line the KBLI explorer copies to a client's
+ * clipboard.
+ *
+ * Why this file exists: `kbli-explorer/page.tsx` built that line as
+ * `data.licenses.map((l) => l.type).join(", ") || "None"`. That fallback is an
+ * ASSERTION — "this business needs no licence" — manufactured out of the
+ * ABSENCE of data, and unlike a rendered page it TRAVELS: the string is pasted
+ * into emails, quotes and chat threads, far from any caveat on screen.
+ *
+ * Measured on prod 2026-08-05: **284 of 1,559 codes render `licenses: []`**, and
+ * canonical states obligations for **125** of them — so for those the duties are
+ * known to us and the copied line still said "None". `07101` (iron sand mining)
+ * is the sharp case: `licensing_status: REGULATED`, `risk_profile: Tinggi`,
+ * `licenses: []` → `Licenses: None`.
+ *
+ * Only ONE status means "genuinely no OSS licence": `NOT_APPLICABLE_OSS` (75
+ * codes). `REGULATED` (1,266), `PENDING_REGULATION` (217), `NOT_IN_KBLI_2025`
+ * (4) and a null status (6) all mean we merely hold no licence rows — a gap, to
+ * be DECLARED rather than asserted away. Same doctrine as `_resolve_risk_profile`
+ * returning "Not classified" instead of a made-up "Low" (Zero, 2026-07-17):
+ * honest gap over false reassurance.
+ */
+
+/** Shown when we hold no licence rows and cannot say none are required. */
+export const LICENCE_GAP_LABEL = "Not listed in our data";
+
+/** Shown only for the one status that genuinely means no OSS licence applies. */
+export const LICENCE_NONE_LABEL = "None (outside OSS licensing)";
+
+/** The only `licensing_status` under which an empty list means "none required". */
+export const STATUS_NO_LICENCE_REQUIRED = "NOT_APPLICABLE_OSS";
+
+export function summariseLicences(
+  types: readonly (string | null | undefined)[],
+  licensingStatus?: string | null,
+): string {
+  const named = types.map((t) => (t ?? "").trim()).filter(Boolean);
+  if (named.length > 0) return named.join(", ");
+  return licensingStatus === STATUS_NO_LICENCE_REQUIRED
+    ? LICENCE_NONE_LABEL
+    : LICENCE_GAP_LABEL;
+}


### PR DESCRIPTION
## The defect
`kbli-explorer/page.tsx` built its clipboard export as:

```ts
data.licenses.map((l) => l.type).join(", ") || "None"
```

An **empty** licence list became the assertion **"None"**. Unlike text on a page, that string **travels** — clients paste it into emails, quotes and chat threads where no on-screen caveat follows it.

## Measured on prod, not inferred
- **284 of 1,559** codes render `licenses: []`.
- Canonical states obligations for **125** of them — we hold the duties and the export said "None".
- Sharpest case: **`07101` IRON SAND MINING**, which the *same* response flags `licensing_status: REGULATED` and `risk_profile: Tinggi`. The copied line read `Licenses: None`.

## Why the fix keys on `licensing_status`
Enumerated live in the KG: `REGULATED` 1,266 · `PENDING_REGULATION` 217 · `NOT_APPLICABLE_OSS` 75 · null 6 · `NOT_IN_KBLI_2025` 4.

Only **`NOT_APPLICABLE_OSS`** genuinely means "no OSS licence required". The rest mean we merely hold no rows — so they now **declare the gap** instead of asserting absence. Same doctrine as `_resolve_risk_profile` returning `"Not classified"` rather than a made-up `"Low"` (Zero, 2026-07-17): honest gap over false reassurance.

## Verification
- Logic extracted to a pure resolver beside the other `kbli-*` lib resolvers, with **guilt** tests (empty + `REGULATED` must never say "None") and **innocence** tests (rows still joined; `NOT_APPLICABLE_OSS` still reports none required; blank/null entries are not a licence named `""`).
- Executed against the **real module**, not a reimplementation — 9/9 pass.
- **Mutation-checked**: reverting the fix to `|| "None"` fails **5 of 9** assertions while all **4 innocence** cases correctly survive, which is the right signature for a mutant that only touches the empty-list branch.
- `tsc --noEmit` clean.

> Note: vitest cannot start in this worktree (`@vitejs/plugin-react` is not installed here, no `apps/mouth/node_modules`), so the suite runs in CI. The assertions above were executed via Node type-stripping against the actual file.

## Scope
Class-audited rather than patched where it bit: this is the **only** site in `apps/mouth` and `apps/kbli-navigator` that asserts an empty KBLI licence list. `docs_sync --check` is green.

Follows #3625 (KG contradicted-obligations cure, applied) and #3630 (corner).