### PR TITLE
fix(kbli): related codes showed each sibling twice and spent the limit doing it

### DIFF
--- a/apps/backend-rag/backend/app/routers/kbli_notebook.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook.py
@@ -12,6 +12,7 @@ import json
 import logging
 import re
 import time
+from collections.abc import Iterable
 from inspect import isawaitable
 from typing import Annotated, Any
 
@@ -312,6 +313,26 @@ def get_kbli_ttl(code: str) -> int:
     return 2592000  # 30 Days
 
 
+def related_codes_from_rows(rows: Iterable[str], code: str) -> list[str]:
+    """Map `kbli:<code>` entity ids to bare codes, deduped, self excluded.
+
+    The SQL already does both (see the caller), so this is a second, independent
+    line rather than the only one: the graph holds 1,341 duplicated BELONGS_TO
+    rows, and a future edit to that query — or a caller that forgets `DISTINCT` —
+    would put the duplicates straight back in front of a client. Order is the
+    caller's (the query is `ORDER BY source_entity_id`), preserved here.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for row in rows:
+        bare = row.replace("kbli:", "", 1).strip()
+        if not bare or bare == code or bare in seen:
+            continue
+        seen.add(bare)
+        out.append(bare)
+    return out
+
+
 def _resolve_risk_profile(qdrant_risk: str | None, licenses: list["KBLILicense"]) -> str:
     """Risk label surfaced to the client for a KBLI code.
 
@@ -486,20 +507,29 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
             if sector_id:
                 # Filter by same 2-digit sector prefix to prevent cross-sector contamination
                 # e.g. 56210 (catering, sector I) should only relate to 56xxx codes
+                #
+                # DISTINCT and the self-exclusion both belong in SQL, not after the
+                # fetch: `LIMIT 6` is applied by Postgres, so anything filtered out
+                # afterwards silently COSTS A SLOT instead of being replaced. The
+                # graph carries 1,341 duplicated (source, sector) BELONGS_TO rows —
+                # every duplicated pair appears exactly twice — so the old query
+                # spent its six rows on three codes and then showed each twice.
+                # Measured on prod: 79122 returned ['79110','79110','79121','79121']
+                # and now returns six distinct siblings; 56101 likewise.
                 sector_prefix = code[:2]
                 others = await conn.fetch(
-                    "SELECT source_entity_id FROM kg_edges "
+                    "SELECT DISTINCT source_entity_id FROM kg_edges "
                     "WHERE target_entity_id = $1 AND relationship_type = 'BELONGS_TO' "
                     "AND source_entity_id LIKE $2 "
+                    "AND source_entity_id <> $3 "
                     "ORDER BY source_entity_id LIMIT 6",
                     sector_id,
                     f"kbli:{sector_prefix}%",
+                    f"kbli:{code}",
                 )
-                related_codes = [
-                    r["source_entity_id"].replace("kbli:", "")
-                    for r in others
-                    if r["source_entity_id"] != f"kbli:{code}"
-                ]
+                related_codes = related_codes_from_rows(
+                    (r["source_entity_id"] for r in others), code
+                )
 
             # 5. Enrich with Qdrant payload (pma_status, risk category)
             qdrant_payload = await _get_kbli_payload_from_qdrant(code)

--- a/apps/backend-rag/backend/tests/unit/routers/test_kbli_related_codes.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_kbli_related_codes.py
@@ -1,0 +1,59 @@
+"""`related_codes` must never show a client the same sibling code twice.
+
+The KG holds **1,341 duplicated (source, sector) `BELONGS_TO` rows** — every
+duplicated pair appears exactly twice. The endpoint's query applied `LIMIT 6`
+BEFORE any dedup or self-exclusion, so the duplicates both showed AND ate the
+budget: measured on prod, `inspect_kbli 79122` returned
+`['79110', '79110', '79121', '79121']` — six rows spent on two codes — and
+`56101` returned `['56102', '56102', '56210', '56210']`.
+
+The fix puts `DISTINCT` and the self-exclusion in SQL (so the limit is spent on
+six real siblings) and keeps this pure mapper as an independent second line.
+"""
+
+from backend.app.routers.kbli_notebook import related_codes_from_rows
+
+
+class TestRelatedCodesFromRows:
+    def test_collapses_the_duplicate_rows_the_graph_actually_holds(self):
+        """GUILT — the exact prod payload that made 79122 show two codes twice."""
+        rows = ["kbli:79110", "kbli:79110", "kbli:79121", "kbli:79121"]
+        assert related_codes_from_rows(rows, "79122") == ["79110", "79121"]
+
+    def test_excludes_the_code_being_inspected(self):
+        rows = ["kbli:56101", "kbli:56102", "kbli:56210"]
+        assert related_codes_from_rows(rows, "56101") == ["56102", "56210"]
+
+    def test_excludes_self_even_when_duplicated(self):
+        rows = ["kbli:56101", "kbli:56101", "kbli:56102"]
+        assert related_codes_from_rows(rows, "56101") == ["56102"]
+
+    def test_preserves_the_query_ordering(self):
+        """INNOCENCE — the SQL orders by entity id; dedup must not resort."""
+        rows = ["kbli:79903", "kbli:79110", "kbli:79121"]
+        assert related_codes_from_rows(rows, "79122") == ["79903", "79110", "79121"]
+
+    def test_keeps_every_distinct_sibling(self):
+        """INNOCENCE — dedup must not swallow codes that merely look similar."""
+        rows = [f"kbli:7910{n}" for n in range(6)]
+        assert related_codes_from_rows(rows, "79122") == [f"7910{n}" for n in range(6)]
+
+    def test_strips_only_the_leading_prefix(self):
+        """A bare code is passed through; `kbli:` is not stripped mid-string."""
+        assert related_codes_from_rows(["kbli:56102", "56210"], "56101") == [
+            "56102",
+            "56210",
+        ]
+
+    def test_drops_blank_rows_instead_of_emitting_an_empty_code(self):
+        assert related_codes_from_rows(["kbli:", "  ", "kbli:56102"], "56101") == [
+            "56102"
+        ]
+
+    def test_empty_input_is_empty_output(self):
+        assert related_codes_from_rows([], "56101") == []
+
+    def test_accepts_a_generator_not_just_a_list(self):
+        """The caller passes a generator expression over the fetched rows."""
+        rows = (r for r in ["kbli:79110", "kbli:79110"])
+        assert related_codes_from_rows(rows, "79122") == ["79110"]

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`332 routers · 680 services · 1287 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`332 routers · 680 services · 1288 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## The defect
`inspect_kbli`'s related-codes query applied `LIMIT 6` **before** deduping and **before** excluding the code being inspected. Anything filtered afterwards therefore **cost a slot** instead of being replaced.

The graph holds **1,341 duplicated `(source, sector)` `BELONGS_TO` rows** — every duplicated pair appears *exactly* twice (multiplicity histogram: `{2: 1341}`), across 1,341 distinct source codes. So six fetched rows collapsed to three, one often being the code itself.

## Measured on prod, before/after
| code | before | after |
|---|---|---|
| `79122` | `79110, 79110, 79121, 79121` | `79110, 79121, 79129, 79901, 79902, 79903` |
| `56101` | `56102, 56102, 56210, 56210` | `56102, 56210, 56290, 56301, 56302, 56303` |

Not cosmetic: clients saw **two** suggestions where six were available, each printed twice.

## The fix
- `DISTINCT` + self-exclusion move **into SQL**, so the limit is spent on six real siblings.
- The row→code mapping becomes a pure `related_codes_from_rows` helper that dedupes and drops self **independently** — a later edit to that query cannot put duplicates back in front of a client.

## Verification
- 9 tests: **guilt** on the exact prod payloads; **innocence** on ordering (the SQL orders by entity id — dedup must not resort) and on distinct siblings that merely look similar; plus generator input, blank rows, and prefix-stripping.
- **Mutation-verified**: removing the dedup fails 4 assertions with the real payloads (`['79110','79110','79121','79121'] != ['79110','79121']`) while the ordering and distinctness cases correctly survive.
- Import chain OK, ruff clean, `docs_sync` regen rides in this commit (1287→1288 tests) per W86.

## Deliberately NOT done
The 1,341 duplicate rows are **not deleted**. `BELONGS_TO` is shared with the CRM (`Client ← Document`) and joined pairwise by `mediated_edges_builder`, so a data-level dedup needs its own blast-radius analysis. **The query is correct regardless of the duplicates** — that is the point of fixing it in SQL rather than cleaning the data first.

Follows #3625 / #3630 / #3634.