### PR TITLE
docs(kbli): the corner recorded one of tonight's three cures, and read as if it were all of them

### DIFF
--- a/.agents/skills/kbli-navigator/SKILL.md
+++ b/.agents/skills/kbli-navigator/SKILL.md
@@ -119,6 +119,61 @@ code's `requirements`.
   and `~/.fly/config.yml` is the live one — the **inverse** of the 2026-07-26 W106 reading. Probe by
   doing the work (`machines list`), never `auth whoami`, and never hardcode which side wins.
 
+**🟢 2026-08-05 — TWO MORE DEFECTS ON THE SAME ENDPOINT, BOTH SHIPPED AND PROVEN LIVE.** Reading
+`kbli_notebook.py` to cure the edges above surfaced two independent lies in what it returns. Neither
+was found by a report: both by asking "what does this field say when the data is EMPTY?".
+
+- **#3634 — `Licenses: None` was an ASSERTION built out of a data gap** (merged `55548f24`,
+  PROMOTED, proven in the served chunk). The `kbli-explorer` copy button built
+  `licenses.map(l=>l.type).join(", ") || "None"`. Unlike text on a page this line **travels** —
+  clients paste it into emails and quotes, where no on-screen caveat follows. Measured: **284 of
+  1,559** codes render `licenses: []` and canonical states obligations for **125** of them; sharpest
+  is **`07101` iron-sand mining**, which the SAME response flags `REGULATED` / risk `Tinggi` while
+  the copied line read `Licenses: None`. Live `licensing_status`: `REGULATED` 1,266 ·
+  `PENDING_REGULATION` 217 · `NOT_APPLICABLE_OSS` 75 · null 6 · `NOT_IN_KBLI_2025` 4 — **only
+  `NOT_APPLICABLE_OSS` genuinely means no OSS licence is required**, the rest mean we hold no rows.
+  Cure is a pure resolver (`apps/mouth/src/lib/kbli-licence-summary.ts`) with guilt+innocence tests,
+  so the two labels are one decision instead of a ternary inline in a click handler.
+- **#3635 — `related_codes` showed each sibling twice, and the limit paid for it** (merged
+  `10060600`, deployed 11:59:58Z, proven live). The KG holds **1,341 duplicated `(source, sector)`
+  `BELONGS_TO` rows** — histogram exactly `{2: 1341}`, every duplicated pair twice, never three
+  times. `LIMIT 6` ran BEFORE any dedup, so `79122` returned `['79110','79110','79121','79121']`:
+  six rows spent on two codes. After the cure (DISTINCT + self-exclusion in SQL, plus
+  `related_codes_from_rows` as an independent second line): `79122` → six distinct siblings,
+  `56101` → six. **The 1,341 duplicate ROWS are deliberately still there** — `BELONGS_TO` is shared
+  with CRM and joined pairwise by `mediated_edges_builder`, so a data-level dedup needs its own
+  blast-radius analysis. Curing the READER first was the reversible half.
+
+**MEASURED LIMITS OF THIS ENDPOINT — declared, deliberately NOT "fixed", each with its number.**
+Every one of these was a candidate cure that the measurement talked me out of:
+
+- **Why the 11,245 node-silent edges are not curable with data we hold** (the gap the KG block
+  above declares): the predicate would need licence TYPES, and canonical names one in **6 of 1,559**
+  rows. A full scan of the Qdrant OSS collection — **10,825 of 10,825 points, no sampling** — yields
+  **160** (1.5%). **58** codes carry a defence permit; sorting those is per-code legal judgment
+  (Legge 5), not a script. So `62110` video games stays REQUIRES-linked to `Izin Industri
+Pertahanan` until someone rules on it, and saying so is more honest than a heuristic.
+- **222 codes render `sector: "N/A"` and `related_codes: []`** — no `BELONGS_TO` edge at all.
+  Canonical can place **42** of them, and **all 42 are multi-sector** — there are exactly 42
+  multi-sector codes in the whole corpus, so the KG builder skipped every code it could not assign
+  to ONE sector. `"N/A"` asserts nothing false; inventing one sector for a two-sector code would be
+  the plausible-but-wrong assertion. **Field-name trap paid here:** asking canonical for `sektor_id`
+  / `sektor` gives "5 of 222"; the real key is **`sektors`** (plural, a list) and gives 42.
+- **877 `kewajiban` strings end in a bare dangling conjunction** across ~169 codes
+  (`"Melaporkan ikan hasil tangkapan dan"`), and `62110` carries a licence literally named
+  `"NIB dan"`. Split from the 127 that are legitimate Indonesian list style (`"…; dan"` = item N).
+  **NOT trimmed:** dropping `dan` yields a grammatical sentence that **understates a legal duty** —
+  the dangling word at least signals incompleteness. The real fix is re-extraction from PP 28/2021.
+- **`_resolve_risk_profile` falls back to `licenses[0].risk_level` with no `ORDER BY`** — a latent
+  fragility, not a live defect: **218** codes lack a Qdrant risk (159 have no licence edges at all,
+  59 have edges that all AGREE, **0 disagree**). Self-audit of the edge cure's blast radius:
+  **0 of the 218** were touched.
+
+**Method note that outlived both fixes:** the post-promote PROVE-LIVE for #3634 returned a
+believable **zero across all 31 chunks** — the edge was serving cached pre-promote HTML pointing at
+the OLD chunk hash. Twenty seconds later the hash had moved and both labels were there. **Compare
+the chunk hash before believing a post-deploy zero**, and always run a positive control.
+
 **🟢 2026-08-05 — THE `whatChanged` LANE: FOUR STORES, AND THE CURE ITSELF LEFT A CONTRADICTION IN
 THREE OF THEM.** #3610 cured 13 codes still telling clients _"Direct 1:1 match from KBLI 2020 — code
 and scope unchanged"_ on records whose own crosswalk denies it. Promoting it (prod was serving a

--- a/.agents/skills/kbli-navigator/SKILL.md
+++ b/.agents/skills/kbli-navigator/SKILL.md
@@ -174,6 +174,42 @@ believable **zero across all 31 chunks** — the edge was serving cached pre-pro
 the OLD chunk hash. Twenty seconds later the hash had moved and both labels were there. **Compare
 the chunk hash before believing a post-deploy zero**, and always run a positive control.
 
+**THE ENDPOINT IS NOW SWEPT FIELD BY FIELD — every one of `KBLIDetail`'s twelve has a number.** Both
+cures above were found by asking one question of one field ("what does this say when the data is
+EMPTY?"), which is a reason to ask it of ALL of them rather than stop at the two that bit. Enumerated
+from the response model, not from a sample of responses — the field you did not enumerate is where
+the lie survives.
+
+| field                        | state                                            | number                                                                           |
+| ---------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `code`/`title`/`description` | identity                                         | —                                                                                |
+| `pma_status`                 | cured (perpres caps, earlier lanes)              | 20 patched, 14 deliberately unadjudicated                                        |
+| `licensing_status`           | enumerated                                       | REGULATED 1,266 · PENDING 217 · `NOT_APPLICABLE_OSS` 75 · null 6 · not-in-2025 4 |
+| `sector`                     | honest gap                                       | 222 `"N/A"`; the 42 placeable are the 42 multi-sector codes                      |
+| `risk_profile`               | latent fragility, ledgered                       | 218 without Qdrant risk; **0** with disagreeing licences                         |
+| `licenses`                   | **cured** #3625 (obligations) + #3634 (gap≠None) | 1,707 pairs detached · 284 empty lists relabelled                                |
+| `related_requirements`       | **sound — audited, no defect**                   | see below                                                                        |
+| `related_codes`              | **cured** #3635                                  | 1,341 duplicate rows collapsed at the reader                                     |
+| `expert_legal`               | universally absent                               | **0 of 1,568** kbli nodes carry it — always `null`, asserts nothing              |
+
+**`related_requirements` got the closest look and came back clean, which is worth recording as
+loudly as a defect** — it renders the SAME REQUIRES edges the cure above deleted from, so it was the
+obvious place for the lie to have a second door. It does not: it renders target NAMES only, never
+their `kewajiban`, so no obligation text travels through it. And `kbli_requires_kind.py` carries the
+W106 signature in its own docstring — _"this classification was derived from a census, and a census
+is a snapshot"_ — with nothing re-measuring it, so it was re-measured here:
+
+- **35 distinct target entity types reach that list today; the classifier knows 30.** The census HAS
+  drifted — 6 types have appeared since: `fasilitas`, `pekerja`, `kbli`, `entity`, `parameter`,
+  `jabatan`, totalling **16 edge rows** over 8 target names.
+- **The fail-safe direction held, and that is the finding.** All 8 are things a business _is_ or
+  _has_ — a port facility, ship crew (`Awak Kapal`), a Regent's office (`Bupati/Walikota`), an R&D
+  activity, a consumer-complaint service, `UMKM`. **Not one is a permit that got demoted to
+  `other`**, which is the only drift that would cost a client something (a licence they are never
+  shown). A missing badge on 16 edges is the acceptable failure the module designed for.
+- Mapped-but-unused: `pasal` has a bucket and **0** live rows. Harmless; noted so a future reader
+  does not read its absence as a bug.
+
 **🟢 2026-08-05 — THE `whatChanged` LANE: FOUR STORES, AND THE CURE ITSELF LEFT A CONTRADICTION IN
 THREE OF THEM.** #3610 cured 13 codes still telling clients _"Direct 1:1 match from KBLI 2020 — code
 and scope unchanged"_ on records whose own crosswalk denies it. Promoting it (prod was serving a


### PR DESCRIPTION
## What this is

The `/kbli-navigator` corner is the project brain — it is loaded into every session and every Codex dispatch that touches KBLI. It recorded the KG edge cure (#3625) and then stopped, while two more client-facing defects on the **same endpoint** were found, shipped and proven live in the same run.

This lane already wrote a lesson about exactly this shape ([[lesson_the_corner_that_lists_consumers_is_the_one_that_hides_the_missing_one]]): a corner that lists *some* of the work reads as if it lists *all* of it. Leaving it stale would be that failure, committed by the session that named it.

## What it records

**#3634 — `Licenses: None` was an ASSERTION built out of a data gap** (merged `55548f24`, promoted, proven in the served chunk). 284 of 1,559 codes render `licenses: []`; canonical states obligations for 125 of them. `07101` iron-sand mining carried `Licenses: None` in the clipboard export while the *same response* flagged `REGULATED` / risk `Tinggi`. Only `NOT_APPLICABLE_OSS` (75 codes) genuinely means no OSS licence is required.

**#3635 — `related_codes` showed each sibling twice, and the limit paid for it** (merged `10060600`, deployed, proven live). The graph holds **1,341 duplicated `BELONGS_TO` rows**, histogram exactly `{2: 1341}`. The duplicate rows are deliberately left in place — `BELONGS_TO` is shared with CRM and joined pairwise by `mediated_edges_builder`, so a data-level dedup needs its own blast-radius analysis. Curing the reader first was the reversible half.

**Four measured limits, each a cure the measurement talked me out of:**

| Limit | Number | Why not cured |
|---|---|---|
| 11,245 node-silent edges | canonical names licence types in **6 of 1,559** rows; full Qdrant scan **10,825/10,825 → 160** | no predicate over our data can tell a shared licence from a wrong one; the 58 defence-permit codes are per-code legal judgment (Legge 5) |
| 222 codes render `sector: "N/A"` | canonical places **42**, and all 42 are the corpus's **42 multi-sector** codes | `"N/A"` asserts nothing false; inventing one sector for a two-sector code would not |
| 877 obligations end mid-sentence (~169 codes) | split from the 127 that are legitimate `"…; dan"` list style | trimming `dan` yields a grammatical sentence that **understates a legal duty** |
| unordered risk fallback | **218** codes lack Qdrant risk: 159 no edges, 59 agree, **0 disagree** | ordering can only change the answer where licences disagree, and none do; which licence is first is a product decision |

## Verification

- **Prettier is a real gate on this path** (`--file-info` → `"ignored": false`), and main was clean before this edit. Ran `--write`, then compared every inline-code span before and after: **1,679 → 1,679, zero lost, zero new**. W112 is the reason that check exists — the formatter is a writer nobody reviews, and it has silently mangled tokens in a cicatrix file before.
- Every number above was re-read from its measurement this turn, not recalled.
- `docs_sync.py --check` → `DOCSYNC OK (no changes)`.

Docs-only; no executable surface.