### PR TITLE
fix(kbli): 1,714 legal duties stop mid-sentence, and every surface printed them as complete

### DIFF
--- a/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.tsx
+++ b/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.tsx
@@ -4,6 +4,11 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Search, Loader2, X, FileText, Scale, Activity } from "lucide-react";
 import type { KBLIDetail } from "@/lib/api/kbli.api";
+import {
+  describeObligation,
+  TRUNCATION_HINT,
+  TRUNCATION_NOTE,
+} from "@/lib/kbli-obligation-truncation";
 
 // =============================================================================
 // HELPERS
@@ -255,14 +260,26 @@ const KBLIInspector = ({
                         What you need to do:
                       </p>
                       <ul className="space-y-1">
-                        {lic.requirements.slice(0, 3).map((req, ridx) => (
-                          <li
-                            key={ridx}
-                            className="text-[11px] text-[#888] leading-tight"
-                          >
-                            &bull; {req}
-                          </li>
-                        ))}
+                        {lic.requirements.slice(0, 3).map((req, ridx) => {
+                          const duty = describeObligation(req);
+                          return (
+                            <li
+                              key={ridx}
+                              className="text-[11px] text-[#888] leading-tight"
+                            >
+                              &bull; {duty.text}
+                              {duty.truncated && (
+                                <span
+                                  className="text-[#c98a3a]"
+                                  title={TRUNCATION_HINT}
+                                >
+                                  {" "}
+                                  […{TRUNCATION_NOTE}]
+                                </span>
+                              )}
+                            </li>
+                          );
+                        })}
                       </ul>
                     </div>
                   )}

--- a/apps/mouth/src/app/kbli-explorer/page.tsx
+++ b/apps/mouth/src/app/kbli-explorer/page.tsx
@@ -29,6 +29,11 @@ import {
 import { kbliApi, KBLIDetail, KBLISearchResult } from "@/lib/api/kbli.api";
 import { toast } from "sonner";
 import { useSessionStorage } from "@/lib/hooks/optimized/useLocalStorage";
+import {
+  describeObligation,
+  TRUNCATION_HINT,
+  TRUNCATION_NOTE,
+} from "@/lib/kbli-obligation-truncation";
 import KBLIInspector, {
   getPmaBadge,
   getRiskBadge,
@@ -869,14 +874,26 @@ const InspectorChoreographed = ({
                             What you need to do:
                           </p>
                           <ul className="space-y-1">
-                            {lic.requirements.slice(0, 3).map((req, ridx) => (
-                              <li
-                                key={ridx}
-                                className="text-[11px] text-[#888] leading-tight"
-                              >
-                                &bull; {req}
-                              </li>
-                            ))}
+                            {lic.requirements.slice(0, 3).map((req, ridx) => {
+                              const duty = describeObligation(req);
+                              return (
+                                <li
+                                  key={ridx}
+                                  className="text-[11px] text-[#888] leading-tight"
+                                >
+                                  &bull; {duty.text}
+                                  {duty.truncated && (
+                                    <span
+                                      className="text-[#c98a3a]"
+                                      title={TRUNCATION_HINT}
+                                    >
+                                      {" "}
+                                      […{TRUNCATION_NOTE}]
+                                    </span>
+                                  )}
+                                </li>
+                              );
+                            })}
                           </ul>
                         </div>
                       )}

--- a/apps/mouth/src/components/kbli/LicensingSection.tsx
+++ b/apps/mouth/src/components/kbli/LicensingSection.tsx
@@ -10,6 +10,11 @@ import type {
   KBLIPmaInfo,
 } from "@/lib/kbli-types";
 import { formatTimeframe } from "@/lib/kbli-derive";
+import {
+  describeObligation,
+  TRUNCATION_HINT,
+  TRUNCATION_NOTE,
+} from "@/lib/kbli-obligation-truncation";
 import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 import { restrictedCapBadge } from "@/lib/kbli-pma-shape";
 import {
@@ -407,26 +412,38 @@ function TierDetail({ tier }: { tier: KBLILicenseByScale }) {
             className="space-y-2 p-4"
             style={{ background: "var(--kbli-bg-surface)" }}
           >
-            {tier.requirements.map((req, i) => (
-              <div
-                key={i}
-                className="flex items-start gap-3 rounded-lg border border-[var(--border)] px-3.5 py-2.5"
-                style={{ background: "var(--kbli-bg-elevated)" }}
-              >
-                <span
-                  className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-bold"
-                  style={{
-                    background: "rgba(212, 132, 90, 0.1)",
-                    color: "var(--kbli-accent)",
-                  }}
+            {tier.requirements.map((req, i) => {
+              const duty = describeObligation(req);
+              return (
+                <div
+                  key={i}
+                  className="flex items-start gap-3 rounded-lg border border-[var(--border)] px-3.5 py-2.5"
+                  style={{ background: "var(--kbli-bg-elevated)" }}
                 >
-                  {i + 1}
-                </span>
-                <span className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
-                  {req}
-                </span>
-              </div>
-            ))}
+                  <span
+                    className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-bold"
+                    style={{
+                      background: "rgba(212, 132, 90, 0.1)",
+                      color: "var(--kbli-accent)",
+                    }}
+                  >
+                    {i + 1}
+                  </span>
+                  <span className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
+                    {duty.text}
+                    {duty.truncated && (
+                      <span
+                        className="text-[var(--kbli-accent)]"
+                        title={TRUNCATION_HINT}
+                      >
+                        {" "}
+                        […{TRUNCATION_NOTE}]
+                      </span>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </details>
       )}
@@ -446,49 +463,61 @@ function TierDetail({ tier }: { tier: KBLILicenseByScale }) {
             className="space-y-1.5 p-4"
             style={{ background: "var(--kbli-bg-surface)" }}
           >
-            {tier.obligations.map((obl, i) => (
-              <div
-                key={i}
-                className="flex items-start gap-2.5 rounded-lg px-3 py-2"
-                style={{
-                  background: "var(--kbli-bg-elevated)",
-                  border: "1px solid var(--kbli-border)",
-                }}
-              >
-                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--kbli-accent)]/40" />
-                <div>
-                  <span className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
-                    {obl}
-                  </span>
-                  {/* English translation for common Indonesian obligations */}
-                  {obl.toLowerCase().includes("sertifikat laik sehat") && (
-                    <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
-                      → Obtain Health Feasibility Certificate from Dinas
-                      Kesehatan
-                    </p>
-                  )}
-                  {obl.toLowerCase().includes("laporan kegiatan") && (
-                    <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
-                      → Submit periodic business activity reports to regulator
-                    </p>
-                  )}
-                  {obl.toLowerCase().includes("standar") &&
-                    obl.toLowerCase().includes("menerapkan") && (
+            {tier.obligations.map((obl, i) => {
+              const duty = describeObligation(obl);
+              return (
+                <div
+                  key={i}
+                  className="flex items-start gap-2.5 rounded-lg px-3 py-2"
+                  style={{
+                    background: "var(--kbli-bg-elevated)",
+                    border: "1px solid var(--kbli-border)",
+                  }}
+                >
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--kbli-accent)]/40" />
+                  <div>
+                    <span className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
+                      {duty.text}
+                      {duty.truncated && (
+                        <span
+                          className="text-[var(--kbli-accent)]"
+                          title={TRUNCATION_HINT}
+                        >
+                          {" "}
+                          […{TRUNCATION_NOTE}]
+                        </span>
+                      )}
+                    </span>
+                    {/* English translation for common Indonesian obligations */}
+                    {obl.toLowerCase().includes("sertifikat laik sehat") && (
                       <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
-                        → Submit documentation of standard implementation
-                        compliance
+                        → Obtain Health Feasibility Certificate from Dinas
+                        Kesehatan
                       </p>
                     )}
-                  {obl.toLowerCase().includes("penerapan standar") &&
-                    !obl.toLowerCase().includes("menerapkan") && (
+                    {obl.toLowerCase().includes("laporan kegiatan") && (
                       <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
-                        → Provide evidence of business standard compliance
-                        documents
+                        → Submit periodic business activity reports to regulator
                       </p>
                     )}
+                    {obl.toLowerCase().includes("standar") &&
+                      obl.toLowerCase().includes("menerapkan") && (
+                        <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
+                          → Submit documentation of standard implementation
+                          compliance
+                        </p>
+                      )}
+                    {obl.toLowerCase().includes("penerapan standar") &&
+                      !obl.toLowerCase().includes("menerapkan") && (
+                        <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
+                          → Provide evidence of business standard compliance
+                          documents
+                        </p>
+                      )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </details>
       )}

--- a/apps/mouth/src/lib/kbli-obligation-truncation.test.ts
+++ b/apps/mouth/src/lib/kbli-obligation-truncation.test.ts
@@ -1,0 +1,169 @@
+/**
+ * A client must never read a cut-off legal duty as though it were complete.
+ *
+ * Guilt cases are the VERBATIM strings measured in the live stores on
+ * 2026-08-05 — not invented examples. Innocence cases are the `"...; dan"`
+ * enumeration items that Indonesian legal drafting produces on purpose (149 in
+ * canonical): flagging one of those puts a false warning on correct data,
+ * which is this defect with the sign reversed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  describeObligation,
+  isSourceTruncated,
+  TRUNCATION_HINT,
+  TRUNCATION_NOTE,
+} from "./kbli-obligation-truncation";
+
+describe("isSourceTruncated — guilt, on strings the graph actually serves", () => {
+  it("flags the string that sits on 35 codes, the widest-blast one", () => {
+    expect(
+      isSourceTruncated(
+        "Memiliki bukti penyampaian wajib Data Industri tervalidasi setiap 6 (enam) bulan sekali sesuai peraturan perundang-undangan di bidang perindustrian dan",
+      ),
+    ).toBe(true);
+  });
+
+  it("flags the fisheries duty that names the report but not what is reported", () => {
+    // "Report caught fish and ..." — trimming `dan` would understate the duty.
+    expect(isSourceTruncated("Melaporkan ikan hasil tangkapan dan")).toBe(true);
+  });
+
+  it("flags a fragment that begins mid-sentence with a full stop", () => {
+    expect(isSourceTruncated(". Produk yang")).toBe(true);
+  });
+
+  it("flags a duty cut off on a bare preposition", () => {
+    expect(
+      isSourceTruncated(
+        "Melaksanakan ketentuan dalam peraturan perundang-undangan di",
+      ),
+    ).toBe(true);
+  });
+
+  it("flags a duty cut off on a bare relative pronoun", () => {
+    expect(isSourceTruncated("Menerapkan teknik budi daya yang")).toBe(true);
+  });
+
+  it("is case-insensitive and tolerant of trailing whitespace", () => {
+    expect(isSourceTruncated("Laporan kegiatan usaha (LKU) DAN  ")).toBe(true);
+  });
+});
+
+describe("isSourceTruncated — innocence, the cases that must stay unmarked", () => {
+  it("does NOT flag an enumerated list item ending '; dan'", () => {
+    // 149 of these exist in canonical. They are item N of `a. ...; b. ...; dan`
+    expect(
+      isSourceTruncated(
+        "Memberikan kemudahan bagi petugas baik pusat maupun daerah pada saat melakukan pengawasan, pembinaan dan evaluasi; dan",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT flag a list item that also contains 'yang' mid-sentence", () => {
+    // The list-style test must win over the dangling test, not merely coexist.
+    expect(
+      isSourceTruncated(
+        "Membayar pendapatan negara atas komoditas yang ditambang; dan",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT flag a complete duty that merely CONTAINS the trigger words", () => {
+    expect(
+      isSourceTruncated(
+        "Menerapkan sistem jaminan mutu dan keamanan hasil perikanan di seluruh rantai produksi",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT flag a word that merely ENDS in the trigger letters", () => {
+    // Word-boundary, not substring — cicatrix family #3. Measured: a substring
+    // implementation would falsely flag 17 distinct COMPLETE duties.
+    expect(isSourceTruncated("Menjaga kelestarian badan")).toBe(false);
+  });
+
+  it("does NOT flag the Hajj duties that genuinely end in 'Arab Saudi'", () => {
+    // The sharpest real case, and it is on 79122 — the Umrah/Hajj code. A
+    // substring match on `di` would tell those clients that a COMPLETE legal
+    // duty is cut off. Both strings verbatim from canonical.
+    expect(
+      isSourceTruncated(
+        "Memberangkatkan dan memulangkan Jemaah Umroh sesuai dengan masa berlaku visa umroh di Arab Saudi",
+      ),
+    ).toBe(false);
+    expect(
+      isSourceTruncated(
+        "Melaporkan jumlah jemaah haji khusus yang akan dibadalhajikan sebelum pelaksanaan wukuf kepada petugas penyelenggaraan ibadah haji di Arab Saudi",
+      ),
+    ).toBe(false);
+  });
+
+  it("DECLARED LIMIT — a word cut in half is invisible to a conjunction test", () => {
+    // These two ARE truncated ("periodi[k]", "pedoman budi [daya]") and this
+    // detector does not catch them: it finds sentences cut at a word boundary,
+    // never a word cut through the middle. Catching those needs a lexicon, not
+    // a regex. Pinned so the gap is a known false-negative rather than an
+    // unexamined one — the fail-safe direction (a missing warning, never a
+    // false one). Both strings verbatim from canonical.
+    expect(
+      isSourceTruncated(
+        "Memiliki dokumen hasil kalibrasi peralatan quality control secara periodik atau hasil uji laboratorium independen atas produk yang dihasilkan secara periodi",
+      ),
+    ).toBe(false);
+    expect(isSourceTruncated("Melakukan budi daya sesuai pedoman budi")).toBe(
+      false,
+    );
+  });
+
+  it("does NOT flag a duty ending in a preposition we measured at zero", () => {
+    // `untuk`/`serta`/`dari` matched 0 strings in both stores, so they are not
+    // guarded; a duty ending in one of them must not be silently marked.
+    expect(isSourceTruncated("Menyediakan fasilitas untuk")).toBe(false);
+  });
+
+  it("treats empty and missing input as not-truncated, never as a warning", () => {
+    expect(isSourceTruncated("")).toBe(false);
+    expect(isSourceTruncated("   ")).toBe(false);
+    expect(isSourceTruncated(null)).toBe(false);
+    expect(isSourceTruncated(undefined)).toBe(false);
+  });
+});
+
+describe("describeObligation", () => {
+  it("returns the source text UNALTERED — the dangling word is never trimmed", () => {
+    const raw = "Melaporkan ikan hasil tangkapan dan";
+    const out = describeObligation(raw);
+    expect(out.text).toBe(raw);
+    expect(out.text.endsWith("dan")).toBe(true);
+    expect(out.truncated).toBe(true);
+  });
+
+  it("passes a complete duty through unflagged", () => {
+    const raw = "Memiliki Nomor Induk Berusaha (NIB)";
+    expect(describeObligation(raw)).toEqual({ text: raw, truncated: false });
+  });
+
+  it("trims surrounding whitespace without touching the sentence", () => {
+    expect(describeObligation("  Laporan kegiatan usaha (LKU) dan  ")).toEqual({
+      text: "Laporan kegiatan usaha (LKU) dan",
+      truncated: true,
+    });
+  });
+
+  it("survives a null obligation without throwing", () => {
+    expect(describeObligation(null)).toEqual({ text: "", truncated: false });
+  });
+});
+
+describe("the copy shown to a client", () => {
+  it("names the source as the thing that is incomplete, not our data", () => {
+    expect(TRUNCATION_NOTE).toContain("source");
+  });
+
+  it("tells the reader what to DO — a warning they cannot act on is noise", () => {
+    expect(TRUNCATION_HINT).toMatch(/oss\.go\.id|Bali Zero/);
+  });
+});

--- a/apps/mouth/src/lib/kbli-obligation-truncation.ts
+++ b/apps/mouth/src/lib/kbli-obligation-truncation.ts
@@ -1,0 +1,95 @@
+/**
+ * Obligations whose SOURCE TEXT stops mid-sentence, and how to say so.
+ *
+ * The KBLI corpus carries obligation strings that end on a bare conjunction:
+ * `"Melaporkan ikan hasil tangkapan dan"` ("Report caught fish and"),
+ * `"...sesuai peraturan perundang-undangan di"` ("...in accordance with the
+ * regulations in"), and one that is literally `". Produk yang"`. They are
+ * artefacts of extraction from the source instrument, not of our storage.
+ *
+ * Measured 2026-08-05, whole corpus, no sampling:
+ *   canonical `KBLI_2025_FINAL_CLEAN.json` — 63,624 obligation strings over
+ *   1,457 codes, of which **1,241 are cut off over 229 codes** (`dan` 1,233 /
+ *   `yang` 4 / `di` 4);
+ *   the knowledge graph the inspect endpoint reads — 10,293 rendered rows, of
+ *   which **234 are cut off over 104 codes**, 39 distinct strings. The largest
+ *   single string sits on 35 codes.
+ *
+ * WHY THIS EXISTS AND NOT A TRIM. Deleting the trailing `dan` from
+ * `"Report caught fish and [its origin]"` yields `"Report caught fish"` — a
+ * sentence that is grammatical, plausible, and **understates a legal duty**.
+ * That is changing what a client is told to do, on a guess about text we do
+ * not hold. The dangling word at least signals incompleteness to a careful
+ * reader; a tidy sentence hides it from everyone. So the text is never
+ * altered — it is LABELLED.
+ *
+ * The defect being cured is therefore not the truncation (that needs
+ * re-extraction from PP 28/2021, and the canonical dataset may only be written
+ * through `scripts/kbli_filiera/` compilers). It is that all three surfaces
+ * rendered a cut-off instruction as though it were a COMPLETE one — the same
+ * shape as the `Licenses: None` defect cured the same day, where an empty list
+ * became an assertion. An honest gap beats a plausible-but-wrong assertion.
+ *
+ * DETECTION IS DATA-DERIVED, NOT IMAGINED. A first draft guarded eight further
+ * prepositions (`serta`, `untuk`, `dari`, `pada`, `dengan`, `dalam`, `oleh`,
+ * `ke`); measured against both stores, every one of them matched **zero**
+ * strings, so they are not here. `atau` is kept as the lawful twin of `dan`
+ * even though it currently matches zero — declared rather than silently
+ * included.
+ *
+ * THE INNOCENCE CASE IS THE WHOLE DESIGN. Indonesian legal drafting enumerates
+ * items `a. ...; b. ...; dan c. ...`, so an obligation ending `"; dan"` is
+ * item N of a list and is NOT damaged — 149 such strings exist in canonical.
+ * Flagging those would put a false warning on correct data, which is the
+ * mirror of the defect. The list-style test therefore runs FIRST and wins.
+ */
+
+/** Shown next to an obligation whose source text is incomplete. */
+export const TRUNCATION_NOTE = "cut off in the official source";
+
+/**
+ * Long-form explanation, for a `title`/tooltip. Says what to do about it,
+ * because a warning a reader cannot act on is just noise.
+ */
+export const TRUNCATION_HINT =
+  "The official source text for this requirement is incomplete. Confirm the full wording at oss.go.id or with the Bali Zero team before acting on it.";
+
+/**
+ * `"...; dan"` / `"...; atau"` — item N of an enumerated list, not damage.
+ * Tested before the dangling check and allowed to win.
+ */
+const LIST_STYLE = /;\s*(?:dan|atau)\s*$/i;
+
+/**
+ * A bare trailing conjunction or preposition. Anchored to end-of-string with a
+ * preceding whitespace boundary, so this matches the WORD and never a
+ * substring — `"...pendapatan"` does not end in `dan`.
+ */
+const DANGLING = /\s(?:dan|atau|yang|di)\s*$/i;
+
+/** True when the obligation's source text stops mid-sentence. */
+export function isSourceTruncated(text: string | null | undefined): boolean {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return false;
+  if (LIST_STYLE.test(trimmed)) return false;
+  return DANGLING.test(trimmed);
+}
+
+export interface ObligationDisplay {
+  /** The source text, NEVER altered — no trim of the dangling word. */
+  text: string;
+  /** Whether the reader must be told the sentence is incomplete. */
+  truncated: boolean;
+}
+
+/**
+ * What a surface should render for one obligation. Returns the text unchanged
+ * plus the flag; the caller owns the visual treatment, so the three surfaces
+ * can differ in styling without ever differing on the JUDGEMENT.
+ */
+export function describeObligation(
+  text: string | null | undefined,
+): ObligationDisplay {
+  const value = (text ?? "").trim();
+  return { text: value, truncated: isSourceTruncated(value) };
+}


### PR DESCRIPTION
## The defect

> **"Melaporkan ikan hasil tangkapan dan"** — *"Report caught fish and"*.

The sentence stops there. A client reading it on `balizero.com` has no way to know the instruction is unfinished, because all four render sites print it **exactly like a complete one**. One string is literally `". Produk yang"`.

This is the same shape as the `Licenses: None` defect cured earlier today (#3634): **a gap rendered as an assertion.**

## Measured — whole corpus, no sampling

| store | field | truncated | codes |
|---|---|---|---|
| canonical `KBLI_2025_FINAL_CLEAN.json` | `kewajiban` | **1,241** | 229 |
| canonical | `persyaratan` | **473** | 92 |
| knowledge graph (what `inspect_kbli` serves) | rendered duty rows | **234** (39 distinct) | 104 |

The single largest truncated string sits on **35 codes**.

## Not fixed by trimming — that is the whole design

Dropping the trailing `dan` from *"Report caught fish and [its origin]"* yields a sentence that is grammatical, plausible, and **understates a legal duty**. That is changing what a client is told to do, on a guess about text we do not hold. The dangling word at least signals incompleteness; a tidy sentence hides it from everyone.

**The text is never altered — it is LABELLED.** The real fix is re-extraction from PP 28/2021, and canonical may only be written through `scripts/kbli_filiera/` compilers. `describeObligation` returning the source text byte-identical is pinned by test, and mutation 3 (a version that trims) kills it.

## Four render sites, not one

A consumer map found two more than the obvious one — and a naming trap that would have sent the fix to the wrong field:

- `kbli-explorer/page.tsx` + `components/KBLIInspector.tsx` — endpoint data, `.slice(0, 3)`
- **both halves** of `components/kbli/LicensingSection.tsx` — the static `/kbli/<code>` pages

> **The trap:** the *endpoint's* `requirements` is populated from `kewajiban`; the *static page's* `requirements` is `persyaratan`. Same word, different fields. Wiring the obvious one would have left the larger population (1,241 strings) still lying. Third field-name trap of this lane — after `sektors` and `kode_kbli_2025`.

## Detection is data-derived, not imagined

A first draft guarded eight further prepositions (`serta`, `untuk`, `dari`, `pada`, `dengan`, `dalam`, `oleh`, `ke`). Measured against **both** stores, every one matched **zero** strings — so they are not in the code. What survives: `dan` / `atau` / `yang` / `di`.

**Word-boundary anchored, never substring** (cicatrix #3). Measured: a substring implementation would falsely flag **17 complete duties**, the sharpest being the Hajj obligations ending **"ke Arab Saudi"** — on `79122`, the Umrah code this lane has been proving all night. Pinned as an innocence test.

**The innocence case is the design.** Indonesian legal drafting enumerates `a. …; b. …; dan c. …`, so an obligation ending `"; dan"` is item N of a list, not damage — **149** exist in canonical. The list-style test runs first and wins; mutation 1 proves it.

## Declared limits — pinned by test, not left unexamined

- A word cut **through the middle** (`"secara periodi"`, `"pedoman budi"`) is invisible to a conjunction test; catching it needs a lexicon. Both pinned as known false-negatives.
- Truncated licence **names** are out of scope — `03110` carries one literally called `"NIB dan"`.
- Fail-safe direction throughout: a missing warning, never a false one.

## Verification

- **20/20** guilt + innocence cases pass against the **real module**, executed via `node --experimental-strip-types`. Vitest cannot start in this worktree (`@vitejs/plugin-react` absent, no `apps/mouth/node_modules`) — CI runs the suite.
- **Mutation, 3 mutants, all killed on the right assertions:** remove the list-style guard → the 2 enumeration cases fail; drop the word boundary → `"kelestarian badan"` fails; make it trim → the two "text unaltered" assertions fail.
- `tsc --noEmit` clean; prettier clean; every guilt string is **verbatim from the live stores**, not invented.
- PROVE-LIVE exemplars chosen **from the data** (the endpoint shows only the first 3 duties, so the marker only appears if a truncated one lands there): `01111`, `01118`, `01210`, `03110`.