### PR TITLE
fix(kbli): a licence type literally called "NIB dan" reached 21 code pages, Google structured data and the page title

### DIFF
--- a/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.tsx
+++ b/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.tsx
@@ -4,6 +4,11 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Search, Loader2, X, FileText, Scale, Activity } from "lucide-react";
 import type { KBLIDetail } from "@/lib/api/kbli.api";
+import {
+  describeObligation,
+  TRUNCATION_HINT,
+  TRUNCATION_NOTE,
+} from "@/lib/kbli-obligation-truncation";
 
 // =============================================================================
 // HELPERS
@@ -255,14 +260,26 @@ const KBLIInspector = ({
                         What you need to do:
                       </p>
                       <ul className="space-y-1">
-                        {lic.requirements.slice(0, 3).map((req, ridx) => (
-                          <li
-                            key={ridx}
-                            className="text-[11px] text-[#888] leading-tight"
-                          >
-                            &bull; {req}
-                          </li>
-                        ))}
+                        {lic.requirements.slice(0, 3).map((req, ridx) => {
+                          const duty = describeObligation(req);
+                          return (
+                            <li
+                              key={ridx}
+                              className="text-[11px] text-[#888] leading-tight"
+                            >
+                              &bull; {duty.text}
+                              {duty.truncated && (
+                                <span
+                                  className="text-[#c98a3a]"
+                                  title={TRUNCATION_HINT}
+                                >
+                                  {" "}
+                                  […{TRUNCATION_NOTE}]
+                                </span>
+                              )}
+                            </li>
+                          );
+                        })}
                       </ul>
                     </div>
                   )}

--- a/apps/mouth/src/app/kbli-explorer/page.tsx
+++ b/apps/mouth/src/app/kbli-explorer/page.tsx
@@ -29,6 +29,11 @@ import {
 import { kbliApi, KBLIDetail, KBLISearchResult } from "@/lib/api/kbli.api";
 import { toast } from "sonner";
 import { useSessionStorage } from "@/lib/hooks/optimized/useLocalStorage";
+import {
+  describeObligation,
+  TRUNCATION_HINT,
+  TRUNCATION_NOTE,
+} from "@/lib/kbli-obligation-truncation";
 import KBLIInspector, {
   getPmaBadge,
   getRiskBadge,
@@ -869,14 +874,26 @@ const InspectorChoreographed = ({
                             What you need to do:
                           </p>
                           <ul className="space-y-1">
-                            {lic.requirements.slice(0, 3).map((req, ridx) => (
-                              <li
-                                key={ridx}
-                                className="text-[11px] text-[#888] leading-tight"
-                              >
-                                &bull; {req}
-                              </li>
-                            ))}
+                            {lic.requirements.slice(0, 3).map((req, ridx) => {
+                              const duty = describeObligation(req);
+                              return (
+                                <li
+                                  key={ridx}
+                                  className="text-[11px] text-[#888] leading-tight"
+                                >
+                                  &bull; {duty.text}
+                                  {duty.truncated && (
+                                    <span
+                                      className="text-[#c98a3a]"
+                                      title={TRUNCATION_HINT}
+                                    >
+                                      {" "}
+                                      […{TRUNCATION_NOTE}]
+                                    </span>
+                                  )}
+                                </li>
+                              );
+                            })}
                           </ul>
                         </div>
                       )}

--- a/apps/mouth/src/components/kbli/LicensingSection.tsx
+++ b/apps/mouth/src/components/kbli/LicensingSection.tsx
@@ -10,6 +10,11 @@ import type {
   KBLIPmaInfo,
 } from "@/lib/kbli-types";
 import { formatTimeframe } from "@/lib/kbli-derive";
+import {
+  describeObligation,
+  TRUNCATION_HINT,
+  TRUNCATION_NOTE,
+} from "@/lib/kbli-obligation-truncation";
 import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
 import { restrictedCapBadge } from "@/lib/kbli-pma-shape";
 import {
@@ -407,26 +412,38 @@ function TierDetail({ tier }: { tier: KBLILicenseByScale }) {
             className="space-y-2 p-4"
             style={{ background: "var(--kbli-bg-surface)" }}
           >
-            {tier.requirements.map((req, i) => (
-              <div
-                key={i}
-                className="flex items-start gap-3 rounded-lg border border-[var(--border)] px-3.5 py-2.5"
-                style={{ background: "var(--kbli-bg-elevated)" }}
-              >
-                <span
-                  className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-bold"
-                  style={{
-                    background: "rgba(212, 132, 90, 0.1)",
-                    color: "var(--kbli-accent)",
-                  }}
+            {tier.requirements.map((req, i) => {
+              const duty = describeObligation(req);
+              return (
+                <div
+                  key={i}
+                  className="flex items-start gap-3 rounded-lg border border-[var(--border)] px-3.5 py-2.5"
+                  style={{ background: "var(--kbli-bg-elevated)" }}
                 >
-                  {i + 1}
-                </span>
-                <span className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
-                  {req}
-                </span>
-              </div>
-            ))}
+                  <span
+                    className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-bold"
+                    style={{
+                      background: "rgba(212, 132, 90, 0.1)",
+                      color: "var(--kbli-accent)",
+                    }}
+                  >
+                    {i + 1}
+                  </span>
+                  <span className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
+                    {duty.text}
+                    {duty.truncated && (
+                      <span
+                        className="text-[var(--kbli-accent)]"
+                        title={TRUNCATION_HINT}
+                      >
+                        {" "}
+                        […{TRUNCATION_NOTE}]
+                      </span>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </details>
       )}
@@ -446,49 +463,61 @@ function TierDetail({ tier }: { tier: KBLILicenseByScale }) {
             className="space-y-1.5 p-4"
             style={{ background: "var(--kbli-bg-surface)" }}
           >
-            {tier.obligations.map((obl, i) => (
-              <div
-                key={i}
-                className="flex items-start gap-2.5 rounded-lg px-3 py-2"
-                style={{
-                  background: "var(--kbli-bg-elevated)",
-                  border: "1px solid var(--kbli-border)",
-                }}
-              >
-                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--kbli-accent)]/40" />
-                <div>
-                  <span className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
-                    {obl}
-                  </span>
-                  {/* English translation for common Indonesian obligations */}
-                  {obl.toLowerCase().includes("sertifikat laik sehat") && (
-                    <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
-                      → Obtain Health Feasibility Certificate from Dinas
-                      Kesehatan
-                    </p>
-                  )}
-                  {obl.toLowerCase().includes("laporan kegiatan") && (
-                    <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
-                      → Submit periodic business activity reports to regulator
-                    </p>
-                  )}
-                  {obl.toLowerCase().includes("standar") &&
-                    obl.toLowerCase().includes("menerapkan") && (
+            {tier.obligations.map((obl, i) => {
+              const duty = describeObligation(obl);
+              return (
+                <div
+                  key={i}
+                  className="flex items-start gap-2.5 rounded-lg px-3 py-2"
+                  style={{
+                    background: "var(--kbli-bg-elevated)",
+                    border: "1px solid var(--kbli-border)",
+                  }}
+                >
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--kbli-accent)]/40" />
+                  <div>
+                    <span className="text-sm leading-relaxed text-[var(--foreground-secondary)]">
+                      {duty.text}
+                      {duty.truncated && (
+                        <span
+                          className="text-[var(--kbli-accent)]"
+                          title={TRUNCATION_HINT}
+                        >
+                          {" "}
+                          […{TRUNCATION_NOTE}]
+                        </span>
+                      )}
+                    </span>
+                    {/* English translation for common Indonesian obligations */}
+                    {obl.toLowerCase().includes("sertifikat laik sehat") && (
                       <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
-                        → Submit documentation of standard implementation
-                        compliance
+                        → Obtain Health Feasibility Certificate from Dinas
+                        Kesehatan
                       </p>
                     )}
-                  {obl.toLowerCase().includes("penerapan standar") &&
-                    !obl.toLowerCase().includes("menerapkan") && (
+                    {obl.toLowerCase().includes("laporan kegiatan") && (
                       <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
-                        → Provide evidence of business standard compliance
-                        documents
+                        → Submit periodic business activity reports to regulator
                       </p>
                     )}
+                    {obl.toLowerCase().includes("standar") &&
+                      obl.toLowerCase().includes("menerapkan") && (
+                        <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
+                          → Submit documentation of standard implementation
+                          compliance
+                        </p>
+                      )}
+                    {obl.toLowerCase().includes("penerapan standar") &&
+                      !obl.toLowerCase().includes("menerapkan") && (
+                        <p className="mt-0.5 text-xs text-[var(--foreground-muted)]">
+                          → Provide evidence of business standard compliance
+                          documents
+                        </p>
+                      )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </details>
       )}

--- a/apps/mouth/src/lib/kbli-derive.test.ts
+++ b/apps/mouth/src/lib/kbli-derive.test.ts
@@ -35,6 +35,38 @@ describe("resolveLicenseType (explicit value wins, else derive)", () => {
     expect(resolveLicenseType(null, "Rendah")).toBe("NIB");
   });
 
+  // A licence NAME cut off mid-sentence is unusable and must not be shown.
+  // Measured 2026-08-05: canonical carries `"NIB dan"` on 21 codes — literally
+  // "NIB and" — and it reached TEN render sites including the page <title> and
+  // the schema.org JSON-LD Google reads.
+  it("treats a truncated licence NAME as absent and derives instead", () => {
+    expect(resolveLicenseType("NIB dan", "Menengah Tinggi")).toBe(
+      "NIB + Sertifikat Standar",
+    );
+    expect(resolveLicenseType("NIB dan", "Tinggi")).toBe("NIB + Izin");
+    expect(
+      resolveLicenseType("Sertifikasi Cara Budi Daya Ternak Yang", "Rendah"),
+    ).toBe("NIB");
+  });
+
+  it("INNOCENCE — a COMPLETE name containing 'dan' is kept untouched", () => {
+    // The whole risk of the rule above: "NIB dan Sertifikat Standar" contains
+    // `dan` but ends on `Standar`, so it is not truncated and must survive.
+    // (Also asserted by the first test in this block, deliberately twice.)
+    expect(resolveLicenseType("NIB dan Sertifikat Standar", "Rendah")).toBe(
+      "NIB dan Sertifikat Standar",
+    );
+    expect(resolveLicenseType("NIB dan Izin", "Tinggi")).toBe("NIB dan Izin");
+  });
+
+  it("drops only the truncated entries from the array form", () => {
+    expect(
+      resolveLicenseType(["NIB dan", "NIB dan Sertifikat Standar"], "Tinggi"),
+    ).toBe("NIB dan Sertifikat Standar");
+    // ...and derives when every entry is unusable, rather than showing nothing.
+    expect(resolveLicenseType(["NIB dan", "  "], "Tinggi")).toBe("NIB + Izin");
+  });
+
   // The real dataset stores perizinan as an ARRAY on ~99.5% of scales (often empty []).
   // A naive (perizinan || "").trim() crashed at runtime — these guard that regression.
   it("handles the array form: joins distinct non-empty entries", () => {

--- a/apps/mouth/src/lib/kbli-derive.ts
+++ b/apps/mouth/src/lib/kbli-derive.ts
@@ -22,6 +22,8 @@
  * differently; here we derive once in the transformer).
  */
 
+import { isSourceTruncated } from "./kbli-obligation-truncation";
+
 /** License type derived from the risk tier when the explicit `perizinan` is empty (Pasal 124(4)). */
 export function licenseForRisk(risk: string | null | undefined): string {
   const r = (risk || "").trim();
@@ -35,13 +37,40 @@ export function licenseForRisk(risk: string | null | undefined): string {
 }
 
 /**
+ * A licence NAME that stops mid-sentence is unusable, and is treated exactly
+ * like an absent one so the risk-derived fallback below fires.
+ *
+ * Measured 2026-08-05: canonical carries **`"NIB dan"` on 21 codes** (and the
+ * knowledge graph on 12, plus `"Sertifikasi Cara Budi Daya Ternak Yang"` on 2).
+ * `"NIB dan"` — literally *"NIB and"* — was rendered as the licence type at TEN
+ * sites, including `KBLIStructuredData` (schema.org JSON-LD that reaches Google)
+ * and `kbli-meta` (the page `<title>`).
+ *
+ * WHY THE FALLBACK AND NOT THE `[cut off]` LABEL used for obligation TEXT: two
+ * of those ten sites are metadata, where a UI annotation would be actively
+ * wrong — you do not put "[cut off in the official source]" inside a page title
+ * or structured data. `licenseForRisk` is not a guess at what the truncated
+ * string said: it applies the documented OSS-RBA rule risk-tier → licence-tier,
+ * which is already this product's behaviour for the ~1,338 codes whose
+ * `perizinan` is empty. Treating an unusable name as absent reuses that
+ * established path rather than inventing a second one.
+ */
+function usableLicenceName(value: string | null | undefined): string {
+  const trimmed = (value || "").trim();
+  // Innocence: a COMPLETE name that merely contains `dan` — "NIB dan
+  // Sertifikat Standar" — ends on `Standar` and is kept, pinned by test.
+  return trimmed && !isSourceTruncated(trimmed) ? trimmed : "";
+}
+
+/**
  * Resolve the license type for a scale: the explicit value if present, else derived from risk.
  *
  * IMPORTANT: in the real dataset `perizinan` is an ARRAY on ~99.5% of scales (the legacy
  * `string` type in kbli-types was a lie — it is a `string[]`, frequently empty `[]`), and a
  * bare `string` on the ~20 legacy records. Handle BOTH: join the distinct non-empty array
- * entries; fall back to the scalar; and when nothing is explicit (empty array / empty string),
- * derive from the risk tier. Mirrors the Swift app's permitText (scalar → array → derive).
+ * entries; fall back to the scalar; and when nothing is explicit (empty array / empty string /
+ * a name truncated mid-sentence), derive from the risk tier. Mirrors the Swift app's permitText
+ * (scalar → array → derive).
  */
 export function resolveLicenseType(
   perizinan: string | string[] | null | undefined,
@@ -49,12 +78,12 @@ export function resolveLicenseType(
 ): string {
   if (Array.isArray(perizinan)) {
     const distinct = Array.from(
-      new Set(perizinan.map((x) => (x || "").trim()).filter(Boolean)),
+      new Set(perizinan.map(usableLicenceName).filter(Boolean)),
     );
     if (distinct.length > 0) return distinct.join(" · ");
     return licenseForRisk(risk);
   }
-  const p = (perizinan || "").trim();
+  const p = usableLicenceName(perizinan);
   if (p) return p;
   return licenseForRisk(risk);
 }

--- a/apps/mouth/src/lib/kbli-obligation-truncation.test.ts
+++ b/apps/mouth/src/lib/kbli-obligation-truncation.test.ts
@@ -1,0 +1,169 @@
+/**
+ * A client must never read a cut-off legal duty as though it were complete.
+ *
+ * Guilt cases are the VERBATIM strings measured in the live stores on
+ * 2026-08-05 — not invented examples. Innocence cases are the `"...; dan"`
+ * enumeration items that Indonesian legal drafting produces on purpose (149 in
+ * canonical): flagging one of those puts a false warning on correct data,
+ * which is this defect with the sign reversed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  describeObligation,
+  isSourceTruncated,
+  TRUNCATION_HINT,
+  TRUNCATION_NOTE,
+} from "./kbli-obligation-truncation";
+
+describe("isSourceTruncated — guilt, on strings the graph actually serves", () => {
+  it("flags the string that sits on 35 codes, the widest-blast one", () => {
+    expect(
+      isSourceTruncated(
+        "Memiliki bukti penyampaian wajib Data Industri tervalidasi setiap 6 (enam) bulan sekali sesuai peraturan perundang-undangan di bidang perindustrian dan",
+      ),
+    ).toBe(true);
+  });
+
+  it("flags the fisheries duty that names the report but not what is reported", () => {
+    // "Report caught fish and ..." — trimming `dan` would understate the duty.
+    expect(isSourceTruncated("Melaporkan ikan hasil tangkapan dan")).toBe(true);
+  });
+
+  it("flags a fragment that begins mid-sentence with a full stop", () => {
+    expect(isSourceTruncated(". Produk yang")).toBe(true);
+  });
+
+  it("flags a duty cut off on a bare preposition", () => {
+    expect(
+      isSourceTruncated(
+        "Melaksanakan ketentuan dalam peraturan perundang-undangan di",
+      ),
+    ).toBe(true);
+  });
+
+  it("flags a duty cut off on a bare relative pronoun", () => {
+    expect(isSourceTruncated("Menerapkan teknik budi daya yang")).toBe(true);
+  });
+
+  it("is case-insensitive and tolerant of trailing whitespace", () => {
+    expect(isSourceTruncated("Laporan kegiatan usaha (LKU) DAN  ")).toBe(true);
+  });
+});
+
+describe("isSourceTruncated — innocence, the cases that must stay unmarked", () => {
+  it("does NOT flag an enumerated list item ending '; dan'", () => {
+    // 149 of these exist in canonical. They are item N of `a. ...; b. ...; dan`
+    expect(
+      isSourceTruncated(
+        "Memberikan kemudahan bagi petugas baik pusat maupun daerah pada saat melakukan pengawasan, pembinaan dan evaluasi; dan",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT flag a list item that also contains 'yang' mid-sentence", () => {
+    // The list-style test must win over the dangling test, not merely coexist.
+    expect(
+      isSourceTruncated(
+        "Membayar pendapatan negara atas komoditas yang ditambang; dan",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT flag a complete duty that merely CONTAINS the trigger words", () => {
+    expect(
+      isSourceTruncated(
+        "Menerapkan sistem jaminan mutu dan keamanan hasil perikanan di seluruh rantai produksi",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT flag a word that merely ENDS in the trigger letters", () => {
+    // Word-boundary, not substring — cicatrix family #3. Measured: a substring
+    // implementation would falsely flag 17 distinct COMPLETE duties.
+    expect(isSourceTruncated("Menjaga kelestarian badan")).toBe(false);
+  });
+
+  it("does NOT flag the Hajj duties that genuinely end in 'Arab Saudi'", () => {
+    // The sharpest real case, and it is on 79122 — the Umrah/Hajj code. A
+    // substring match on `di` would tell those clients that a COMPLETE legal
+    // duty is cut off. Both strings verbatim from canonical.
+    expect(
+      isSourceTruncated(
+        "Memberangkatkan dan memulangkan Jemaah Umroh sesuai dengan masa berlaku visa umroh di Arab Saudi",
+      ),
+    ).toBe(false);
+    expect(
+      isSourceTruncated(
+        "Melaporkan jumlah jemaah haji khusus yang akan dibadalhajikan sebelum pelaksanaan wukuf kepada petugas penyelenggaraan ibadah haji di Arab Saudi",
+      ),
+    ).toBe(false);
+  });
+
+  it("DECLARED LIMIT — a word cut in half is invisible to a conjunction test", () => {
+    // These two ARE truncated ("periodi[k]", "pedoman budi [daya]") and this
+    // detector does not catch them: it finds sentences cut at a word boundary,
+    // never a word cut through the middle. Catching those needs a lexicon, not
+    // a regex. Pinned so the gap is a known false-negative rather than an
+    // unexamined one — the fail-safe direction (a missing warning, never a
+    // false one). Both strings verbatim from canonical.
+    expect(
+      isSourceTruncated(
+        "Memiliki dokumen hasil kalibrasi peralatan quality control secara periodik atau hasil uji laboratorium independen atas produk yang dihasilkan secara periodi",
+      ),
+    ).toBe(false);
+    expect(isSourceTruncated("Melakukan budi daya sesuai pedoman budi")).toBe(
+      false,
+    );
+  });
+
+  it("does NOT flag a duty ending in a preposition we measured at zero", () => {
+    // `untuk`/`serta`/`dari` matched 0 strings in both stores, so they are not
+    // guarded; a duty ending in one of them must not be silently marked.
+    expect(isSourceTruncated("Menyediakan fasilitas untuk")).toBe(false);
+  });
+
+  it("treats empty and missing input as not-truncated, never as a warning", () => {
+    expect(isSourceTruncated("")).toBe(false);
+    expect(isSourceTruncated("   ")).toBe(false);
+    expect(isSourceTruncated(null)).toBe(false);
+    expect(isSourceTruncated(undefined)).toBe(false);
+  });
+});
+
+describe("describeObligation", () => {
+  it("returns the source text UNALTERED — the dangling word is never trimmed", () => {
+    const raw = "Melaporkan ikan hasil tangkapan dan";
+    const out = describeObligation(raw);
+    expect(out.text).toBe(raw);
+    expect(out.text.endsWith("dan")).toBe(true);
+    expect(out.truncated).toBe(true);
+  });
+
+  it("passes a complete duty through unflagged", () => {
+    const raw = "Memiliki Nomor Induk Berusaha (NIB)";
+    expect(describeObligation(raw)).toEqual({ text: raw, truncated: false });
+  });
+
+  it("trims surrounding whitespace without touching the sentence", () => {
+    expect(describeObligation("  Laporan kegiatan usaha (LKU) dan  ")).toEqual({
+      text: "Laporan kegiatan usaha (LKU) dan",
+      truncated: true,
+    });
+  });
+
+  it("survives a null obligation without throwing", () => {
+    expect(describeObligation(null)).toEqual({ text: "", truncated: false });
+  });
+});
+
+describe("the copy shown to a client", () => {
+  it("names the source as the thing that is incomplete, not our data", () => {
+    expect(TRUNCATION_NOTE).toContain("source");
+  });
+
+  it("tells the reader what to DO — a warning they cannot act on is noise", () => {
+    expect(TRUNCATION_HINT).toMatch(/oss\.go\.id|Bali Zero/);
+  });
+});

--- a/apps/mouth/src/lib/kbli-obligation-truncation.ts
+++ b/apps/mouth/src/lib/kbli-obligation-truncation.ts
@@ -1,0 +1,95 @@
+/**
+ * Obligations whose SOURCE TEXT stops mid-sentence, and how to say so.
+ *
+ * The KBLI corpus carries obligation strings that end on a bare conjunction:
+ * `"Melaporkan ikan hasil tangkapan dan"` ("Report caught fish and"),
+ * `"...sesuai peraturan perundang-undangan di"` ("...in accordance with the
+ * regulations in"), and one that is literally `". Produk yang"`. They are
+ * artefacts of extraction from the source instrument, not of our storage.
+ *
+ * Measured 2026-08-05, whole corpus, no sampling:
+ *   canonical `KBLI_2025_FINAL_CLEAN.json` — 63,624 obligation strings over
+ *   1,457 codes, of which **1,241 are cut off over 229 codes** (`dan` 1,233 /
+ *   `yang` 4 / `di` 4);
+ *   the knowledge graph the inspect endpoint reads — 10,293 rendered rows, of
+ *   which **234 are cut off over 104 codes**, 39 distinct strings. The largest
+ *   single string sits on 35 codes.
+ *
+ * WHY THIS EXISTS AND NOT A TRIM. Deleting the trailing `dan` from
+ * `"Report caught fish and [its origin]"` yields `"Report caught fish"` — a
+ * sentence that is grammatical, plausible, and **understates a legal duty**.
+ * That is changing what a client is told to do, on a guess about text we do
+ * not hold. The dangling word at least signals incompleteness to a careful
+ * reader; a tidy sentence hides it from everyone. So the text is never
+ * altered — it is LABELLED.
+ *
+ * The defect being cured is therefore not the truncation (that needs
+ * re-extraction from PP 28/2021, and the canonical dataset may only be written
+ * through `scripts/kbli_filiera/` compilers). It is that all three surfaces
+ * rendered a cut-off instruction as though it were a COMPLETE one — the same
+ * shape as the `Licenses: None` defect cured the same day, where an empty list
+ * became an assertion. An honest gap beats a plausible-but-wrong assertion.
+ *
+ * DETECTION IS DATA-DERIVED, NOT IMAGINED. A first draft guarded eight further
+ * prepositions (`serta`, `untuk`, `dari`, `pada`, `dengan`, `dalam`, `oleh`,
+ * `ke`); measured against both stores, every one of them matched **zero**
+ * strings, so they are not here. `atau` is kept as the lawful twin of `dan`
+ * even though it currently matches zero — declared rather than silently
+ * included.
+ *
+ * THE INNOCENCE CASE IS THE WHOLE DESIGN. Indonesian legal drafting enumerates
+ * items `a. ...; b. ...; dan c. ...`, so an obligation ending `"; dan"` is
+ * item N of a list and is NOT damaged — 149 such strings exist in canonical.
+ * Flagging those would put a false warning on correct data, which is the
+ * mirror of the defect. The list-style test therefore runs FIRST and wins.
+ */
+
+/** Shown next to an obligation whose source text is incomplete. */
+export const TRUNCATION_NOTE = "cut off in the official source";
+
+/**
+ * Long-form explanation, for a `title`/tooltip. Says what to do about it,
+ * because a warning a reader cannot act on is just noise.
+ */
+export const TRUNCATION_HINT =
+  "The official source text for this requirement is incomplete. Confirm the full wording at oss.go.id or with the Bali Zero team before acting on it.";
+
+/**
+ * `"...; dan"` / `"...; atau"` — item N of an enumerated list, not damage.
+ * Tested before the dangling check and allowed to win.
+ */
+const LIST_STYLE = /;\s*(?:dan|atau)\s*$/i;
+
+/**
+ * A bare trailing conjunction or preposition. Anchored to end-of-string with a
+ * preceding whitespace boundary, so this matches the WORD and never a
+ * substring — `"...pendapatan"` does not end in `dan`.
+ */
+const DANGLING = /\s(?:dan|atau|yang|di)\s*$/i;
+
+/** True when the obligation's source text stops mid-sentence. */
+export function isSourceTruncated(text: string | null | undefined): boolean {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return false;
+  if (LIST_STYLE.test(trimmed)) return false;
+  return DANGLING.test(trimmed);
+}
+
+export interface ObligationDisplay {
+  /** The source text, NEVER altered — no trim of the dangling word. */
+  text: string;
+  /** Whether the reader must be told the sentence is incomplete. */
+  truncated: boolean;
+}
+
+/**
+ * What a surface should render for one obligation. Returns the text unchanged
+ * plus the flag; the caller owns the visual treatment, so the three surfaces
+ * can differ in styling without ever differing on the JUDGEMENT.
+ */
+export function describeObligation(
+  text: string | null | undefined,
+): ObligationDisplay {
+  const value = (text ?? "").trim();
+  return { text: value, truncated: isSourceTruncated(value) };
+}


### PR DESCRIPTION
> **Stacked on #3637** (base is that branch, not `main`) — it imports `isSourceTruncated` from the module #3637 adds. Re-target to `main` once #3637 lands.

## The defect

**`"NIB dan"` is Indonesian for *"NIB and"*.** The name stops there, and it was rendered as **the licence a business must obtain**.

| string | canonical | knowledge graph |
|---|---:|---:|
| `NIB dan` | **21 codes** | 12 codes |
| `Sertifikasi Cara Budi Daya Ternak Yang` | — | 2 codes |

Deferred out of #3637 as "out of scope", then measured: small, but it reaches further than anything else in this lane.

## Why the cure is at the data layer, not the render sites

A licence name reaches **ten** render sites — and two of them are not UI:

- `KBLIStructuredData.tsx` → the **schema.org JSON-LD Google reads**
- `kbli-meta.ts` → the page **`<title>`**

So the `[cut off in the official source]` label used for obligation *text* in #3637 would be **actively wrong here** — you do not put a UI annotation inside a page title or structured data.

Both `kbli-data.ts` and `kbli-data.server.ts` already route through `resolveLicenseType`, so **one change covers all ten sites**.

## Why the fallback is a derivation, not a guess

`licenseForRisk` does not try to reconstruct what the truncated string said. It applies the documented **OSS-RBA rule risk-tier → licence-tier** (PP 28/2025 Pasal 124(4)), which is *already* this product's behaviour for the ~1,338 codes whose `perizinan` is empty. Treating an unusable name as absent **reuses that established path** rather than inventing a second one.

So `"NIB dan"` on a Menengah-Tinggi code becomes `NIB + Sertifikat Standar` — from the risk tier, not from completing the sentence.

## The innocence case is the whole risk, and it is asserted twice

`"NIB dan Sertifikat Standar"` **contains** `dan` but **ends on** `Standar` — not truncated, must survive untouched. It was already pinned by a pre-existing test in this file; a second assertion was added deliberately rather than relying on the old one. Same for `"NIB dan Izin"`.

The array form drops **only** the unusable entries (`["NIB dan", "NIB dan Sertifikat Standar"]` → the complete one) and derives only when **every** entry is unusable.

## Verification

- **10/10** against the real module via `node --experimental-strip-types`. Vitest cannot start in this worktree; CI runs the suite.
- **Mutation** — making the truncation check a no-op kills exactly the **5 guilt** cases while all **5 innocence/regression** cases survive. That is the correct signature: the guard is load-bearing and it is not over-reaching.
- `tsc --noEmit` clean, prettier clean.
- Harness note: node ESM needs the explicit `.ts` extension where tsc does not — the first run failed on module resolution, **not** on an assertion. Recorded because on #3634 exactly this shape produced a mutant that "died" for the wrong reason.