### PR TITLE
fix(kbli): treat a truncated licence NAME as unusable in resolveLicenseType (defence-in-depth — the live occurrence is on the endpoint path, not this one)

### DIFF
--- a/apps/mouth/src/lib/kbli-derive.test.ts
+++ b/apps/mouth/src/lib/kbli-derive.test.ts
@@ -35,6 +35,38 @@ describe("resolveLicenseType (explicit value wins, else derive)", () => {
     expect(resolveLicenseType(null, "Rendah")).toBe("NIB");
   });
 
+  // A licence NAME cut off mid-sentence is unusable and must not be shown.
+  // Measured 2026-08-05: canonical carries `"NIB dan"` on 21 codes — literally
+  // "NIB and" — and it reached TEN render sites including the page <title> and
+  // the schema.org JSON-LD Google reads.
+  it("treats a truncated licence NAME as absent and derives instead", () => {
+    expect(resolveLicenseType("NIB dan", "Menengah Tinggi")).toBe(
+      "NIB + Sertifikat Standar",
+    );
+    expect(resolveLicenseType("NIB dan", "Tinggi")).toBe("NIB + Izin");
+    expect(
+      resolveLicenseType("Sertifikasi Cara Budi Daya Ternak Yang", "Rendah"),
+    ).toBe("NIB");
+  });
+
+  it("INNOCENCE — a COMPLETE name containing 'dan' is kept untouched", () => {
+    // The whole risk of the rule above: "NIB dan Sertifikat Standar" contains
+    // `dan` but ends on `Standar`, so it is not truncated and must survive.
+    // (Also asserted by the first test in this block, deliberately twice.)
+    expect(resolveLicenseType("NIB dan Sertifikat Standar", "Rendah")).toBe(
+      "NIB dan Sertifikat Standar",
+    );
+    expect(resolveLicenseType("NIB dan Izin", "Tinggi")).toBe("NIB dan Izin");
+  });
+
+  it("drops only the truncated entries from the array form", () => {
+    expect(
+      resolveLicenseType(["NIB dan", "NIB dan Sertifikat Standar"], "Tinggi"),
+    ).toBe("NIB dan Sertifikat Standar");
+    // ...and derives when every entry is unusable, rather than showing nothing.
+    expect(resolveLicenseType(["NIB dan", "  "], "Tinggi")).toBe("NIB + Izin");
+  });
+
   // The real dataset stores perizinan as an ARRAY on ~99.5% of scales (often empty []).
   // A naive (perizinan || "").trim() crashed at runtime — these guard that regression.
   it("handles the array form: joins distinct non-empty entries", () => {

--- a/apps/mouth/src/lib/kbli-derive.ts
+++ b/apps/mouth/src/lib/kbli-derive.ts
@@ -22,6 +22,8 @@
  * differently; here we derive once in the transformer).
  */
 
+import { isSourceTruncated } from "./kbli-obligation-truncation";
+
 /** License type derived from the risk tier when the explicit `perizinan` is empty (Pasal 124(4)). */
 export function licenseForRisk(risk: string | null | undefined): string {
   const r = (risk || "").trim();
@@ -35,13 +37,40 @@ export function licenseForRisk(risk: string | null | undefined): string {
 }
 
 /**
+ * A licence NAME that stops mid-sentence is unusable, and is treated exactly
+ * like an absent one so the risk-derived fallback below fires.
+ *
+ * Measured 2026-08-05: canonical carries **`"NIB dan"` on 21 codes** (and the
+ * knowledge graph on 12, plus `"Sertifikasi Cara Budi Daya Ternak Yang"` on 2).
+ * `"NIB dan"` — literally *"NIB and"* — was rendered as the licence type at TEN
+ * sites, including `KBLIStructuredData` (schema.org JSON-LD that reaches Google)
+ * and `kbli-meta` (the page `<title>`).
+ *
+ * WHY THE FALLBACK AND NOT THE `[cut off]` LABEL used for obligation TEXT: two
+ * of those ten sites are metadata, where a UI annotation would be actively
+ * wrong — you do not put "[cut off in the official source]" inside a page title
+ * or structured data. `licenseForRisk` is not a guess at what the truncated
+ * string said: it applies the documented OSS-RBA rule risk-tier → licence-tier,
+ * which is already this product's behaviour for the ~1,338 codes whose
+ * `perizinan` is empty. Treating an unusable name as absent reuses that
+ * established path rather than inventing a second one.
+ */
+function usableLicenceName(value: string | null | undefined): string {
+  const trimmed = (value || "").trim();
+  // Innocence: a COMPLETE name that merely contains `dan` — "NIB dan
+  // Sertifikat Standar" — ends on `Standar` and is kept, pinned by test.
+  return trimmed && !isSourceTruncated(trimmed) ? trimmed : "";
+}
+
+/**
  * Resolve the license type for a scale: the explicit value if present, else derived from risk.
  *
  * IMPORTANT: in the real dataset `perizinan` is an ARRAY on ~99.5% of scales (the legacy
  * `string` type in kbli-types was a lie — it is a `string[]`, frequently empty `[]`), and a
  * bare `string` on the ~20 legacy records. Handle BOTH: join the distinct non-empty array
- * entries; fall back to the scalar; and when nothing is explicit (empty array / empty string),
- * derive from the risk tier. Mirrors the Swift app's permitText (scalar → array → derive).
+ * entries; fall back to the scalar; and when nothing is explicit (empty array / empty string /
+ * a name truncated mid-sentence), derive from the risk tier. Mirrors the Swift app's permitText
+ * (scalar → array → derive).
  */
 export function resolveLicenseType(
   perizinan: string | string[] | null | undefined,
@@ -49,12 +78,12 @@ export function resolveLicenseType(
 ): string {
   if (Array.isArray(perizinan)) {
     const distinct = Array.from(
-      new Set(perizinan.map((x) => (x || "").trim()).filter(Boolean)),
+      new Set(perizinan.map(usableLicenceName).filter(Boolean)),
     );
     if (distinct.length > 0) return distinct.join(" · ");
     return licenseForRisk(risk);
   }
-  const p = (perizinan || "").trim();
+  const p = usableLicenceName(perizinan);
   if (p) return p;
   return licenseForRisk(risk);
 }


### PR DESCRIPTION
> **CORRECTED before merge — the original title and body were wrong, and I dequeued this from the merge queue to fix them.** It claimed to fix *"21 code pages, Google structured data and the page title"*. It does not. Measured on the live site **before** deploying: those pages render `"NIB dan"` **zero** times and already show the derived `NIB + …` form.

## What was wrong with my own claim

I measured `"NIB dan"` on 21 codes with a **recursive** walk of canonical, then assumed it reached `resolveLicenseType`. It does not. The exact path is:

```
per_skala_legacy.[].perizinan     ← 21 codes
```

`per_skala_legacy` is written **for audit** by `build_kbli_l2_oss_risk.py` and read by nothing that renders — `kbli-data.ts` maps `licensing[]` from `per_skala`, where `"NIB dan"` appears on **0** codes. So on the static pages the string is archival and was never shown.

The live before-state said so plainly and I nearly talked past it: `62110`, `47301`, `96100`, `15112` all returned **0** occurrences of `"NIB dan"` and 18/14/1/14 occurrences of the derived `NIB + …`. **The zero was the answer, not a probe failure.**

## What this PR actually is

Correct, cheap **defence-in-depth**: if a licence name that stops mid-sentence ever *does* reach `resolveLicenseType`, it is treated as absent so the documented risk-tier → licence-tier fallback fires, rather than being printed as the licence a business must obtain. The rule and its innocence case are documented by the tests either way.

It is **inert today** — stated here rather than left for a future reader to discover, because an inert guard with passing tests is exactly the thing that makes someone believe a case is handled everywhere.

## Where the defect is actually live — separate PR

The endpoint builds `licenses[].type` straight from the KG node name (`kbli_notebook.py`: `type=lic["name"]`), which no derivation touches. Measured on prod:

| licence node name | KBLI codes |
|---|---:|
| `NIB dan` | **10** — `03110, 15112, 15113, 20293, 25119, 25933, 28171, 61901, 62110, 62191` |
| `Sertifikasi Cara Budi Daya Ternak Yang` | **2** — `01445, 01469` |

Those reach the explorer's licence cards **and** the clipboard export cured in #3634 — the one that travels into client emails. That is the real fix, and it belongs in the backend.

## Verification (unchanged, and still valid for what it covers)

- **10/10** against the real module via `node --experimental-strip-types`; CI runs the vitest suite.
- **Mutation:** making the truncation check a no-op kills exactly the **5 guilt** cases while all **5 innocence/regression** cases survive.
- Innocence, asserted twice: `"NIB dan Sertifikat Standar"` contains `dan` but ends on `Standar` — not truncated, survives untouched.