### PR TITLE
fix(kbli): a licence literally called "NIB dan" is shown as a requirement on 10 codes, and it is copied into client emails

### DIFF
--- a/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.tsx
+++ b/apps/mouth/src/app/kbli-explorer/components/KBLIInspector.tsx
@@ -236,7 +236,16 @@ const KBLIInspector = ({
                 >
                   <div className="flex justify-between items-start mb-2">
                     <span className="text-sm font-medium text-silver group-hover:text-white transition-colors">
-                      {lic.type}
+                      {describeObligation(lic.type).text}
+                      {describeObligation(lic.type).truncated && (
+                        <span
+                          className="text-[#c98a3a]"
+                          title={TRUNCATION_HINT}
+                        >
+                          {" "}
+                          […{TRUNCATION_NOTE}]
+                        </span>
+                      )}
                     </span>
                     <span className="text-[10px] uppercase px-2 py-1 rounded-full bg-[#151921] text-[#888] border border-white/5">
                       {lic.sla}

--- a/apps/mouth/src/app/kbli-explorer/page.tsx
+++ b/apps/mouth/src/app/kbli-explorer/page.tsx
@@ -850,7 +850,16 @@ const InspectorChoreographed = ({
                         <span
                           className={`font-medium text-silver group-hover:text-white transition-colors ${idx === 0 ? "text-sm" : "text-xs"}`}
                         >
-                          {lic.type}
+                          {describeObligation(lic.type).text}
+                          {describeObligation(lic.type).truncated && (
+                            <span
+                              className="text-[#c98a3a]"
+                              title={TRUNCATION_HINT}
+                            >
+                              {" "}
+                              […{TRUNCATION_NOTE}]
+                            </span>
+                          )}
                         </span>
                         <span className="text-[10px] uppercase px-2 py-1 rounded-full bg-[#151921] text-[#888] border border-white/5">
                           {lic.sla}

--- a/apps/mouth/src/lib/kbli-licence-summary.test.ts
+++ b/apps/mouth/src/lib/kbli-licence-summary.test.ts
@@ -53,4 +53,25 @@ describe("summariseLicences", () => {
   it("drops blanks but keeps the named rows beside them", () => {
     expect(summariseLicences(["", "NIB", null], "REGULATED")).toBe("NIB");
   });
+  // A licence NAME can itself stop mid-sentence. Measured on prod 2026-08-05:
+  // the graph holds a licence node literally called "NIB dan" reachable from 10
+  // KBLI codes. This line is COPIED into client emails, so the caveat has to
+  // travel with it — the name is labelled, never trimmed and never replaced.
+  it("labels a licence name that stops mid-sentence, without altering it", () => {
+    const out = summariseLicences(["NIB dan"], "REGULATED");
+    expect(out).toContain("NIB dan");
+    expect(out).toContain("cut off in the official source");
+  });
+
+  it("INNOCENCE — a complete name containing 'dan' is copied verbatim", () => {
+    expect(summariseLicences(["NIB dan Sertifikat Standar"], "REGULATED")).toBe(
+      "NIB dan Sertifikat Standar",
+    );
+  });
+
+  it("labels only the truncated entry when several are copied together", () => {
+    const out = summariseLicences(["NIB dan", "Izin Usaha"], "REGULATED");
+    expect(out.match(/cut off in the official source/g)).toHaveLength(1);
+    expect(out).toContain("Izin Usaha");
+  });
 });

--- a/apps/mouth/src/lib/kbli-licence-summary.ts
+++ b/apps/mouth/src/lib/kbli-licence-summary.ts
@@ -22,6 +22,25 @@
  * honest gap over false reassurance.
  */
 
+import {
+  isSourceTruncated,
+  TRUNCATION_NOTE,
+} from "./kbli-obligation-truncation";
+
+/**
+ * A licence NAME can itself stop mid-sentence: measured on prod 2026-08-05, the
+ * knowledge graph holds a licence node literally called **`"NIB dan"`** ("NIB
+ * and") reachable from **10** KBLI codes, and `"Sertifikasi Cara Budi Daya
+ * Ternak Yang"` from 2 more. The endpoint sets `licenses[].type` straight from
+ * that node name (`kbli_notebook.py`: `type=lic["name"]`), so it reaches the
+ * licence cards AND this clipboard line — which travels into client emails.
+ *
+ * A truncated name is LABELLED, never trimmed and never replaced: "NIB dan" is
+ * a real fragment of a real requirement, and inventing its ending would be the
+ * plausible-but-wrong assertion. Same rule and same detector as the obligation
+ * text (`kbli-obligation-truncation.ts`), so the two cannot drift apart.
+ */
+
 /** Shown when we hold no licence rows and cannot say none are required. */
 export const LICENCE_GAP_LABEL = "Not listed in our data";
 
@@ -35,7 +54,10 @@ export function summariseLicences(
   types: readonly (string | null | undefined)[],
   licensingStatus?: string | null,
 ): string {
-  const named = types.map((t) => (t ?? "").trim()).filter(Boolean);
+  const named = types
+    .map((t) => (t ?? "").trim())
+    .filter(Boolean)
+    .map((t) => (isSourceTruncated(t) ? `${t} [\u2026${TRUNCATION_NOTE}]` : t));
   if (named.length > 0) return named.join(", ");
   return licensingStatus === STATUS_NO_LICENCE_REQUIRED
     ? LICENCE_NONE_LABEL


### PR DESCRIPTION
## The defect

The knowledge graph holds a licence node named **`"NIB dan"`** — Indonesian for *"NIB and"*. The name stops there, and `kbli_notebook.py` sets `licenses[].type` **straight from that node name**, so it reaches the explorer's licence cards **and** the clipboard line — which travels into client emails, far from any caveat on screen.

Measured on prod, reachable from a KBLI code by a `REQUIRES` edge:

| licence node name | codes |
|---|---|
| `NIB dan` | **10** — `03110 15112 15113 20293 25119 25933 28171 61901 62110 62191` |
| `Sertifikasi Cara Budi Daya Ternak Yang` | **2** — `01445 01469` |

## This is the path my earlier attempt missed

**#3639 guards `resolveLicenseType`, and that guard can never fire.** It is fed from `per_skala[].perizinan`, where `"NIB dan"` appears on **zero** codes. The 21 canonical occurrences live under:

```
per_skala_legacy.[].perizinan
```

— written **for audit** by `build_kbli_l2_oss_risk.py` and read by nothing that renders.

**The live before-state said so and I nearly talked past it.** Before deploying anything I checked `62110`, `47301`, `96100`, `15112`: **zero** occurrences of `"NIB dan"`, and 18/14/1/14 occurrences of the derived `NIB + …`. I had been about to read that zero as "already fine" instead of "you are measuring the wrong path". #3639 has been dequeued and its description corrected; it stays as honest, inert defence-in-depth.

## Labelled — never trimmed, never replaced

`"NIB dan"` is a real fragment of a real requirement:

- **Trimming** it to `"NIB"` would state a weaker licence than the law requires.
- **Replacing** it with a derived name would invent the ending — the plausible-but-wrong assertion this navigator exists to eliminate.
- **Dropping** it would hide a licence the business actually needs.

So it renders as `NIB dan […cut off in the official source]`, using the **same detector as the obligation text** (`kbli-obligation-truncation.ts`) so the two rules cannot drift apart.

## Innocence is the whole risk, and it is asserted directly

`"NIB dan Sertifikat Standar"` **contains** `dan` but **ends on** `Standar` — not truncated, copied verbatim. With several licences copied together, **only** the truncated one is labelled (asserted by count, not by presence).

## Verification

- **8/8** against the real module via `node --experimental-strip-types`; CI runs the vitest suite.
- **Mutation:** removing the labelling kills exactly the **2** assertions that depend on it, while all **6** innocence/regression cases survive.
- `tsc --noEmit` clean, prettier clean, pre-commit typecheck green.
- Every figure measured this session against prod, not recalled.