### PR TITLE
fix(kbli): 336 code pages state a licence type that belongs to a different code

### DIFF
--- a/apps/mouth/src/lib/kbli-meta.test.ts
+++ b/apps/mouth/src/lib/kbli-meta.test.ts
@@ -56,6 +56,7 @@ function makeLicensing(
 
 function makeProvenance(
   status: KBLILicensingProvenanceStatus = "oss_native",
+  contentInheritedFrom: string[] | null = null,
 ): KBLIProvenance {
   return {
     state: status === "oss_native" ? "verified" : "pending",
@@ -65,6 +66,7 @@ function makeProvenance(
       locator: status === "oss_native" ? "OSS_RBA_resiko_2025" : null,
       vintage: status === "oss_native" ? "2025" : "2020",
       noOssScope: status === "pending_crosswalk",
+      contentInheritedFrom,
     },
     pma: { source: null, vintage: "2020", status: "pending_crosswalk" },
     dataNote: null,
@@ -375,5 +377,94 @@ describe("real dataset: the gate binds, and v3 actually differentiates", () => {
     });
 
     expect(offenders.map((c) => c.code)).toEqual([]);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// PP 28 content inherited from OTHER codes (2026-08-06)
+//
+// `isLicensingVerifiedForBareClaim` reads `_l2_source`, which names the OSS-RBA
+// RISK source. `pp28_sources` separately records where the PP 28 licensing rows
+// came from, and on 337 codes the two disagree: risk genuinely 2025-native,
+// licensing content carried from other codes. 62110 (video game development) is
+// sourced from five 62xxx computer-programming codes and inherits three
+// defence-industry permits that way.
+//
+// The gate is deliberately asymmetric — it withdraws the LICENCE claim and
+// leaves the RISK claim standing, because only one of the two is inherited.
+// -----------------------------------------------------------------------------
+
+describe("inherited PP 28 content withdraws the licence claim, not the risk", () => {
+  it("GUILT: an inherited-content record states its risk and NOT its licence", () => {
+    const kbli = makeCode({
+      provenance: makeProvenance("oss_native", ["62011", "62019", "62015"]),
+    });
+
+    // The risk gate is untouched: the tier is OSS-2025-native and still stated.
+    expect(isLicensingVerifiedForBareClaim(kbli)).toBe(true);
+    expect(verifiedRiskLabel(kbli)).toBe("High");
+    // ...and the licence type, which may belong to another code, goes silent.
+    expect(verifiedLicenseType(kbli)).toBeNull();
+
+    const description = kbliMetaDescription(kbli, "Restaurant");
+    expect(description).toContain("High risk.");
+    expect(description).not.toContain("license:");
+    // The title only ever carried the risk, so it must be unchanged — a gate
+    // that also moved the title would be suppressing a fact it does not judge.
+    expect(kbliMetaTitleSuffix(kbli)).toBe("100% Foreign Ownership, High Risk");
+  });
+
+  it("INNOCENCE: a self-sourced record still states both facts", () => {
+    const kbli = makeCode({ provenance: makeProvenance("oss_native", null) });
+
+    expect(verifiedLicenseType(kbli)).toBe("NIB + Izin");
+    expect(kbliMetaDescription(kbli, "Restaurant")).toContain(
+      "High risk, license: NIB + Izin.",
+    );
+  });
+
+  it("INNOCENCE: inheritance cannot RESURRECT a claim the risk gate withheld", () => {
+    // Both gates must hold. A pending_crosswalk record with no inheritance is
+    // still silent on both facts — the new condition only ever subtracts.
+    const kbli = makeCode({
+      provenance: makeProvenance("pending_crosswalk", null),
+    });
+
+    expect(verifiedRiskLabel(kbli)).toBeNull();
+    expect(verifiedLicenseType(kbli)).toBeNull();
+    const description = kbliMetaDescription(kbli, "Restaurant");
+    expect(description).not.toContain("risk");
+    expect(description).not.toContain("license:");
+  });
+
+  it("real dataset: the gate binds, and on how many codes is pinned", () => {
+    const codes = getAllCodes();
+    const inherited = codes.filter(
+      (c) => c.provenance?.licensing?.contentInheritedFrom != null,
+    );
+    const inheritedAndOssNative = inherited.filter(
+      (c) => c.provenance?.licensing?.status === "oss_native",
+    );
+
+    // Measured on the 1,559-code canonical 2026-08-06. Pinned so a dataset
+    // rebuild that widens or narrows the set fails loudly instead of quietly
+    // re-labelling pages.
+    expect(inherited.length).toBe(390);
+    // 336, not the 337 a raw `_l2_source === "OSS_RBA_resiko_2025"` count
+    // gives: `49213` (Angkutan Perkotaan, sourced from 49214/49219/49413)
+    // carries a `per_skala_disputed_pp28_collision` block, so `deriveProvenance`
+    // resolves it to `detached` BEFORE it can reach `oss_native`. The marker and
+    // the derived status are different questions — this pin asserts the derived
+    // one, because the derived one is what gates the page.
+    expect(inheritedAndOssNative.length).toBe(336);
+
+    // ...and the gate actually bites: every one of those 336 would have stated
+    // a licence type before this change and states none now.
+    for (const c of inheritedAndOssNative) {
+      expect(verifiedLicenseType(c), `code ${c.code}`).toBeNull();
+    }
+    // Innocence at dataset scale: SOME code still states a licence, or the
+    // gate is not a gate but a blanket.
+    expect(codes.some((c) => verifiedLicenseType(c) !== null)).toBe(true);
   });
 });

--- a/apps/mouth/src/lib/kbli-meta.ts
+++ b/apps/mouth/src/lib/kbli-meta.ts
@@ -40,9 +40,24 @@ export function verifiedRiskLabel(kbli: KBLICode): string | null {
   return riskLabelEn(kbli.licensing[0]?.riskCategory);
 }
 
-/** License type safe to state bare, or null. Only ever paired with the risk. */
+/**
+ * License type safe to state bare, or null. Only ever paired with the risk.
+ *
+ * The second gate is NOT redundant with the first. `isLicensingVerifiedForBareClaim`
+ * reads `_l2_source`, which names the OSS-RBA **risk** source; `pp28_sources`
+ * separately records where the PP 28 licensing rows came from, and the two
+ * disagree on **337** codes — risk genuinely 2025-native, licensing content
+ * carried from other codes. `62110` (video game development) is sourced from
+ * five 62xxx computer-programming codes and inherits three defence-industry
+ * permits that way.
+ *
+ * So the risk label survives (it is verified) and the licence type goes silent
+ * (it may belong to another code). One flag for both would suppress a true fact
+ * to qualify a different one.
+ */
 export function verifiedLicenseType(kbli: KBLICode): string | null {
   if (!verifiedRiskLabel(kbli)) return null;
+  if (kbli.provenance?.licensing?.contentInheritedFrom) return null;
   return kbli.licensing[0]?.licenseType || "NIB";
 }
 
@@ -134,7 +149,15 @@ export function kbliMetaDescription(
     `${metaTitleEn} (KBLI ${kbli.code}): ${kbliPmaLabel(kbli)}${
       baliBlocked ? " nationally — blocked for a PT PMA in Bali (2026)" : ""
     }.`,
-    risk && license ? `${risk} risk, license: ${license}.` : null,
+    // Degrade one fact at a time. `risk && license ? … : null` dropped BOTH
+    // when only the licence was ungated, so the 337 inherited-content codes
+    // would have lost a risk tier that is verified — silence about what we
+    // cannot back, not silence about everything near it.
+    risk && license
+      ? `${risk} risk, license: ${license}.`
+      : risk
+        ? `${risk} risk.`
+        : null,
     "KBLI 2025 rules + Bali notes by Bali Zero.",
   ]
     .filter(Boolean)

--- a/apps/mouth/src/lib/kbli-provenance.ts
+++ b/apps/mouth/src/lib/kbli-provenance.ts
@@ -99,6 +99,30 @@ function hasRecorded2020Ancestry(raw: KBLIRawCode): boolean {
   return (raw.pp28_sources ?? []).length > 0;
 }
 
+/**
+ * The OTHER codes this record's PP 28 licensing content was carried from, or
+ * null when it is self-sourced or records no PP 28 source at all.
+ *
+ * Structured field only (cicatrix #3), and by ENTITY rather than truthiness:
+ * membership of the record's OWN code in `pp28_sources` is what distinguishes
+ * "this row is mine" from "this row is someone else's". A record that lists
+ * its own code alongside others is NOT treated as inherited — it has a row of
+ * its own, and the extra entries are supplements.
+ *
+ * Absence is not evidence: `pp28_sources` empty (175 codes) returns null, the
+ * same answer as self-sourced, because there is nothing recorded to inherit
+ * FROM. That is deliberately the permissive branch — this signal exists to
+ * withdraw a claim, and withdrawing one on missing data would be asserting
+ * inheritance we cannot show.
+ */
+export function pp28ContentInheritedFrom(raw: KBLIRawCode): string[] | null {
+  const sources = (raw.pp28_sources ?? []).map(String).filter(Boolean);
+  if (sources.length === 0) return null;
+  const own = String(raw.kode_kbli_2025 ?? "");
+  if (own && sources.includes(own)) return null;
+  return sources;
+}
+
 /** Provenance of the foreign-ownership verdict — DERIVED, not a constant.
  *
  * The Perpres 10/2021 + 49/2021 annexes are KBLI-2020-vintage across the catalog
@@ -127,6 +151,10 @@ export function deriveProvenance(raw: KBLIRawCode): KBLIProvenance {
   // unverifiable — it beats every other licensing reading except a detach
   // (Codex gate F6: even alongside no_oss_risk, don't claim PP28/2020).
   const unknownL2 = raw._l2_source != null && !ossNative;
+  // Independent of every marker above: WHERE the PP 28 rows came from. Computed
+  // once and attached to all FOUR licensing branches (detached,
+  // unverified_source, pending_crosswalk, oss_native) so none can omit it.
+  const contentInheritedFrom = pp28ContentInheritedFrom(raw);
 
   const state = disputed
     ? "not_classifiable"
@@ -149,6 +177,7 @@ export function deriveProvenance(raw: KBLIRawCode): KBLIProvenance {
             locator: null,
             vintage: null,
             noOssScope: noOssRisk,
+            contentInheritedFrom,
           }
         : state === "pending"
           ? unknownL2 || !noOssRisk
@@ -161,6 +190,7 @@ export function deriveProvenance(raw: KBLIRawCode): KBLIProvenance {
                 locator: null,
                 vintage: null,
                 noOssScope: noOssRisk,
+                contentInheritedFrom,
               }
             : {
                 status: "pending_crosswalk",
@@ -171,12 +201,14 @@ export function deriveProvenance(raw: KBLIRawCode): KBLIProvenance {
                 // are special/sectoral-regime — there is no row to vintage.
                 vintage: (raw.per_skala ?? []).length > 0 ? "2020" : null,
                 noOssScope: true,
+                contentInheritedFrom,
               }
           : {
               status: "oss_native",
               locator: OSS_NATIVE_L2,
               vintage: "2025",
               noOssScope: noOssRisk,
+              contentInheritedFrom,
             },
     pma: pmaProvenance(raw),
     dataNote: raw._data_note ?? null,

--- a/apps/mouth/src/lib/kbli-types.ts
+++ b/apps/mouth/src/lib/kbli-types.ts
@@ -235,6 +235,29 @@ export interface KBLIProvenance {
     vintage: "2025" | "2020" | null;
     /** true when `_l2_status === "no_oss_risk"` (OSS ruang-lingkup 404) */
     noOssScope: boolean;
+    /**
+     * The OTHER KBLI codes this record's PP 28/2025 licensing CONTENT was
+     * carried from, or null when the record is self-sourced (or records no
+     * PP 28 source at all).
+     *
+     * `status`/`locator`/`vintage` above are derived from `_l2_source`, which
+     * names the OSS-RBA **risk** source. `pp28_sources` is a different field
+     * recording where the PP 28 rows came from, and the two disagree on **337**
+     * codes: `_l2_source === "OSS_RBA_resiko_2025"` (so the risk tier is
+     * genuinely 2025-native and `status` is `oss_native`) while every entry of
+     * `pp28_sources` names a DIFFERENT code. **217** of those inherit a
+     * `pb_umku` permit that way.
+     *
+     * `62110` (video game development) is the case that surfaced it: sourced
+     * from `["62011","62019","62015","62013","62012"]`, and its inherited
+     * `pb_umku` lists three defence-industry permits.
+     *
+     * Deliberately a SEPARATE field rather than a new `status` value: the risk
+     * claim on these codes is verified and must keep being stated; only the
+     * licensing CONTENT is inherited. Folding both into one flag would suppress
+     * a true fact to qualify a different one.
+     */
+    contentInheritedFrom: string[] | null;
   };
   /** Foreign-ownership layer — Perpres 10/2021 + 49/2021 (KBLI-2020 vintage).
    *


### PR DESCRIPTION
`/kbli/62110` (VIDEO GAME DEVELOPMENT) has been telling Google — in its indexed `<meta description>` — a licence type derived from PP 28 rows that belong to **five other codes**. The page never said so, because nothing in the provenance layer looked at where the licensing CONTENT came from.

## The two provenance questions that were being answered by one field

- `isLicensingVerifiedForBareClaim` reads **`_l2_source`**, which names the OSS-RBA **risk** source. On these codes it is honestly `OSS_RBA_resiko_2025` — the risk tier really is 2025-native.
- **`pp28_sources`** separately records where the **PP 28 licensing rows** came from. It was read only by `pmaProvenance`, never by the licensing branch.

They disagree on **336 codes** as the gate resolves them. `62110.pp28_sources` = `["62011","62019","62015","62013","62012"]` — a new 2025 code with no PP 28 row of its own, filled from its KBLI-2020 ancestors — and its inherited `pb_umku` lists three defence-industry permits.

Across the catalogue: **390 of 1,559** codes are sourced ONLY from other codes, and **217** of those inherit a `pb_umku` permit that way. The ancestry can be wrong on its face — `02101 Pengelolaan Hutan` (forest management) is sourced from `['63111']` (data processing / hosting).

## The gate is deliberately asymmetric

`verifiedRiskLabel` is **untouched**: the risk tier on these codes is verified and must keep being stated. Only `verifiedLicenseType` goes silent.

One flag for both would suppress a true fact in order to qualify a different one — the same over-suppression this module already warns about in the opposite direction.

`kbliMetaDescription` had `risk && license ? … : null`, which dropped **both** facts as soon as one was ungated. It now falls back to the risk sentence alone: silence about what we cannot back, not silence about everything near it.

## Correctness details worth reading

- `contentInheritedFrom` is attached to **all four** licensing branches (`detached`, `unverified_source`, `pending_crosswalk`, `oss_native`), not just the one that motivated it.
- **Absence is not evidence**: `pp28_sources` empty (175 codes) returns `null`, the same as self-sourced. This signal exists to *withdraw* a claim, and withdrawing one on missing data would assert inheritance we cannot show.
- A record listing **its own code alongside others** is not inherited — it has a row of its own and the extras are supplements.
- The dataset pin is **336, not 337**. A raw `_l2_source === "OSS_RBA_resiko_2025"` count gives 337; `49213` (Angkutan Perkotaan) carries a `per_skala_disputed_pp28_collision` block, so `deriveProvenance` resolves it to `detached` before it can reach `oss_native`. The marker and the derived status are different questions, and the test pins the derived one because the derived one is what gates the page. *(My own first count said 337 — the probe measured the marker, not the gate.)*

## Verification

- `vitest run src/lib` — **97 files, 1,247 tests, all pass**. `tsc --noEmit` clean.
- Guilt: an inherited record keeps `High risk.`, loses `license:`, and its `<title>` is unchanged.
- Innocence: a self-sourced record keeps both; and the new condition can only subtract — it never resurrects a claim the risk gate already withheld.
- Dataset invariant pinned at 390 inherited / 336 gated, plus "some code still states a licence" so the gate cannot silently become a blanket.
- **Mutation-verified**: deleting the new line turns 2 tests red (fixture guilt + dataset pin); restoring it returns 23/23.

## Declared scope

Web `<meta>` only. Two consuming surfaces are named and NOT cured here:

1. **The page body.** It renders the same inherited licence type through `resolveLicenseType`, so today the meta goes silent while the body still asserts. The correct behaviour there is the opposite of the meta's — a body CAN qualify, so it should keep the licence and add an inheritance note next to it. **Correction to an earlier draft of this paragraph, which said it "would need it in 5 locales": it would not.** `/kbli/[code]` generates one page per code with no locale segment, and neither the page nor `LicensingSection` uses i18n — measured, not assumed. It is a small follow-up, and the reason it is not in this diff is scope, not size.
2. **`inspect_kbli`**, which renders the inherited `pb_umku` permits as licences to the bot and the MCP. Measured blocker: `kg_nodes` for `kbli:62110` and `kbli:56101` carry no `pp28_sources` property at all, so the router has nothing to read — closing it needs a sync that writes the field onto the nodes first, and that write runs from Pro.

Both are in the corner's ledger.
