### PR TITLE
feat(kbli): the page body now says WHERE an inherited licence came from, instead of asserting it silently

### DIFF
--- a/apps/mouth/src/components/kbli/LicensingSection.tsx
+++ b/apps/mouth/src/components/kbli/LicensingSection.tsx
@@ -15,7 +15,10 @@ import {
   TRUNCATION_HINT,
   TRUNCATION_NOTE,
 } from "@/lib/kbli-obligation-truncation";
-import { isLicensingVerificationPending } from "@/lib/kbli-provenance";
+import {
+  isLicensingVerificationPending,
+  licensingContentInheritedFrom,
+} from "@/lib/kbli-provenance";
 import { restrictedCapBadge } from "@/lib/kbli-pma-shape";
 import {
   baliBlockClause,
@@ -1063,6 +1066,23 @@ export function LicensingSection({ kbli, gold }: LicensingSectionProps) {
               <p className="text-[11px] text-[var(--foreground-muted)]">
                 ⏳ All licensing values below await KBLI-2025 crosswalk
                 verification — see Sources &amp; Verification.
+              </p>
+            )}
+            {/* A DIFFERENT provenance question from the line above. That one asks
+                whether the KBLI-2025 crosswalk has been verified; this one asks
+                where the PP 28/2025 rows came from in the first place. 336 codes
+                have no PP 28 row of their own and were filled from KBLI-2020
+                ancestors — 62110 (video games) inherits three defence-industry
+                permits that way. The indexed <meta> goes SILENT on the licence
+                type for these (kbli-meta.ts); a body can qualify, so it keeps the
+                value and names the source instead. */}
+            {licensingContentInheritedFrom(kbli) && (
+              <p className="text-[11px] text-[var(--foreground-muted)]">
+                ↩ This code has no PP 28/2025 licensing row of its own — the
+                values below were carried over from KBLI code
+                {licensingContentInheritedFrom(kbli)!.length > 1 ? "s " : " "}
+                {licensingContentInheritedFrom(kbli)!.join(", ")}. Confirm the
+                licence type with the Bali Zero team before acting on it.
               </p>
             )}
             {/* Tier tabs */}

--- a/apps/mouth/src/lib/kbli-provenance.test.ts
+++ b/apps/mouth/src/lib/kbli-provenance.test.ts
@@ -13,6 +13,8 @@ import {
   getDisputedLicensing,
   isBaliL4BlockVerifiedForBareClaim,
   isLicensingVerifiedForBareClaim,
+  licensingContentInheritedFrom,
+  pp28ContentInheritedFrom,
 } from "./kbli-provenance";
 import type {
   KBLICode,
@@ -489,5 +491,123 @@ describe("bare-claim gates", () => {
     expect(
       isBaliL4BlockVerifiedForBareClaim(codeWith(rows, undefined, undefined)),
     ).toBe(false);
+  });
+});
+
+// =============================================================================
+// licensingContentInheritedFrom (2026-08-06) — the BODY complement of the meta
+// gate. The indexed <meta> goes silent on an inherited licence type; a body can
+// qualify, so it keeps the value and names the source. Opposite behaviours from
+// the same fact, which is why they are two helpers.
+// =============================================================================
+
+describe("licensingContentInheritedFrom", () => {
+  function codeWithProv(
+    licensing: KBLICode["licensing"],
+    contentInheritedFrom: string[] | null,
+  ): KBLICode {
+    return {
+      licensing,
+      provenance: {
+        licensing: {
+          status: "oss_native",
+          locator: null,
+          vintage: "2025",
+          noOssScope: false,
+          contentInheritedFrom,
+        },
+      },
+    } as KBLICode;
+  }
+
+  const someRows = [{ riskCategory: "Tinggi" }] as KBLICode["licensing"];
+
+  it("GUILT: returns the source codes when rows are served and inherited", () => {
+    expect(
+      licensingContentInheritedFrom(
+        codeWithProv(someRows, ["62011", "62019", "62015"]),
+      ),
+    ).toEqual(["62011", "62019", "62015"]);
+  });
+
+  it("INNOCENCE: null for a self-sourced record", () => {
+    expect(
+      licensingContentInheritedFrom(codeWithProv(someRows, null)),
+    ).toBeNull();
+  });
+
+  it("INNOCENCE: null when no rows are served — nothing on screen to qualify", () => {
+    expect(
+      licensingContentInheritedFrom(
+        codeWithProv([] as KBLICode["licensing"], ["62011"]),
+      ),
+    ).toBeNull();
+  });
+
+  it("fails CLOSED — not by throwing — on a missing/malformed provenance block", () => {
+    expect(() =>
+      licensingContentInheritedFrom({ licensing: someRows } as KBLICode),
+    ).not.toThrow();
+    expect(
+      licensingContentInheritedFrom({ licensing: someRows } as KBLICode),
+    ).toBeNull();
+    expect(
+      licensingContentInheritedFrom({
+        licensing: someRows,
+        provenance: {},
+      } as unknown as KBLICode),
+    ).toBeNull();
+  });
+});
+
+describe("pp28ContentInheritedFrom (raw-record derivation)", () => {
+  it("GUILT: sources naming only OTHER codes are inheritance", () => {
+    expect(
+      pp28ContentInheritedFrom(
+        makeRaw({ kode_kbli_2025: "62110", pp28_sources: ["62011", "62019"] }),
+      ),
+    ).toEqual(["62011", "62019"]);
+  });
+
+  it("INNOCENCE: a record listing its OWN code has a row of its own", () => {
+    expect(
+      pp28ContentInheritedFrom(
+        makeRaw({ kode_kbli_2025: "56101", pp28_sources: ["56101", "56102"] }),
+      ),
+    ).toBeNull();
+  });
+
+  it("INNOCENCE: an empty source list is absence, not inheritance", () => {
+    // 175 codes record no PP 28 source at all. Withdrawing a claim on missing
+    // data would be asserting inheritance we cannot show.
+    expect(
+      pp28ContentInheritedFrom(
+        makeRaw({ kode_kbli_2025: "99999", pp28_sources: [] }),
+      ),
+    ).toBeNull();
+  });
+
+  it("real dataset: 390 inherited, and deriveProvenance carries it on every branch", () => {
+    const parsed = JSON.parse(
+      fs.readFileSync(
+        path.join(process.cwd(), "data", "KBLI_2025_FINAL_CLEAN.json"),
+        "utf-8",
+      ),
+    ) as KBLIRawDataFile;
+
+    const inherited = parsed.data.filter(
+      (r) => pp28ContentInheritedFrom(r) !== null,
+    );
+    expect(inherited.length).toBe(390);
+
+    // The field must survive derivation on EVERY record, not only the branch
+    // that motivated it — a branch that dropped it would read as self-sourced.
+    for (const r of parsed.data) {
+      const prov = deriveProvenance(r);
+      expect(
+        prov.licensing.contentInheritedFrom,
+        `code ${r.kode_kbli_2025}`,
+      ).toEqual(pp28ContentInheritedFrom(r));
+    }
   });
 });

--- a/apps/mouth/src/lib/kbli-provenance.ts
+++ b/apps/mouth/src/lib/kbli-provenance.ts
@@ -71,6 +71,24 @@ export function isLicensingVerificationPending(code: KBLICode): boolean {
 }
 
 /**
+ * The other KBLI codes this code's licensing rows were carried from, for a
+ * surface that CAN qualify a claim — or null when there is nothing to declare.
+ *
+ * Complement of the `verifiedLicenseType` gate in `kbli-meta.ts`, and
+ * deliberately the opposite behaviour: an indexed `<title>`/`<meta>` has no room
+ * for a qualifier, so it goes SILENT; a page body has room, so it KEEPS the
+ * licence type and says where it came from. Same fact, two surfaces, opposite
+ * correct answers — which is why they are two helpers and not one flag.
+ *
+ * Requires rows to be served: a code with no licensing rows has no inherited
+ * claim on screen to qualify, whatever `pp28_sources` says.
+ */
+export function licensingContentInheritedFrom(code: KBLICode): string[] | null {
+  if ((code.licensing?.length ?? 0) === 0) return null;
+  return code.provenance?.licensing?.contentInheritedFrom ?? null;
+}
+
+/**
  * Derive the full provenance object for a raw KBLI record.
  *
  * State partition (exhaustive over the 1,559 catalog):


### PR DESCRIPTION
#3645 is live and **proven**: `/kbli/62110`'s indexed description went from *"Medium-Low risk, **license: NIB + Sertifikat Standar**."* to *"Medium-Low risk."*, while `56101` and `01111` — both self-sourced — kept theirs unchanged. Measured before and after on prod, served commit `9a0a8e8adc` = #3645's own merge commit.

But the **body** of the same page renders that licence type through `resolveLicenseType` and kept asserting it. So the two surfaces disagreed, and the body was the one still making the unqualified claim.

## They should disagree — in the opposite direction

A `<title>`/`<meta>` has no room for a qualifier, so it stays **silent**. A body has room, so it **keeps** the licence type and **names the source**. Same fact, two surfaces, opposite correct answers — which is why `licensingContentInheritedFrom` is a second helper rather than a reuse of the meta gate.

The note sits beside the existing *"awaits KBLI-2025 crosswalk verification"* line and answers a **different** question: that one asks whether the crosswalk is verified, this one asks where the rows came from at all. On `62110` it reads:

> ↩ This code has no PP 28/2025 licensing row of its own — the values below were carried over from KBLI codes 62011, 62019, 62015, 62013, 62012. Confirm the licence type with the Bali Zero team before acting on it.

## Correctness

- **Requires rows to be served.** A code with no licensing rows has no inherited claim on screen to qualify, whatever `pp28_sources` says.
- **Fails closed, without throwing**, on a missing or malformed provenance block — a crash on an indexed page is not fail-closed, it is a 500.
- **Dataset invariant**: `deriveProvenance` must carry `contentInheritedFrom` identically to the raw derivation on **all 1,559** records. A branch that dropped it would read as self-sourced, which is the failure that matters.

## Verification

`tsc --noEmit` clean · **97 files, 1,255 tests** in `src/lib` pass · guilt + innocence (self-sourced, and rows-absent) · **mutation-verified**: deleting the rows-served guard turns its test red.

## Correction carried over from #3645

An earlier draft of #3645's body said this follow-up "would need it in 5 locales". **It does not** — `/kbli/[code]` generates one page per code with no locale segment, and neither the page nor `LicensingSection` uses i18n. Measured, not assumed; #3645's body was corrected before it merged.

## Still open, measured not guessed

`inspect_kbli` renders the inherited `pb_umku` permits as licences to the bot and the MCP. Two facts bound the fix: the backend Dockerfile copies `backend`/`scripts`/`training-data`/`*.py` but **not `data/`**, so the router cannot read canonical from disk; and `kg_nodes` for `kbli:62110`/`kbli:56101` carry **no `pp28_sources` property**. So it needs a sync writing the field onto the nodes (the pattern `kg_kbli_resync.py` already uses for `pma_status`), applied from Pro — not a second derived copy inside the backend, which would drift.