### PR TITLE
fix(kbli): inspect_kbli served 390 codes' licences without saying they belong to other codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 332 routers · 680 services
+- Backend: FastAPI · 332 routers · 681 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 33 · Packages: 6

--- a/apps/backend-rag/backend/app/routers/kbli_notebook.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook.py
@@ -416,7 +416,14 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
     """Retrieve deep KG metadata with dynamic TTL based on sector volatility."""
     from backend.core.cache import get_cache_service
 
-    cache_key = f"kbli_inspect_v2_{code}"
+    # v2 → v3 (2026-08-06): the payload gained the inherited-licensing
+    # disclosure. A cached v2 entry validates on read — the new fields simply
+    # default to None — so a carried code would keep answering WITHOUT the note
+    # for up to the 30-day TTL, and a shipped cure invisible for a month is
+    # indistinguishable from one that never shipped. Bumping the version evicts
+    # atomically at deploy instead of depending on someone remembering to run
+    # the per-code cache-bust for the right 390 codes.
+    cache_key = f"kbli_inspect_v3_{code}"
     ttl = get_kbli_ttl(code)
 
     # Try manual cache check

--- a/apps/backend-rag/backend/app/routers/kbli_notebook.py
+++ b/apps/backend-rag/backend/app/routers/kbli_notebook.py
@@ -26,6 +26,7 @@ from backend.app.dependencies import (
     get_search_service,
 )
 from backend.core.collection_registry import resolve_collection_name
+from backend.services.kbli_pp28_provenance import licensing_disclosure
 from backend.services.kbli_requires_kind import classify_requires_target
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,18 @@ class KBLIDetail(BaseModel):
     related_requirements: dict[str, list[str]] = {}
     related_codes: list[str] = []
     expert_legal: dict | None = None
+    # WHOSE licences these are. A KBLI-2025 code that is new in the 2025
+    # numbering has no PP 28/2025 row of its own; the canonical fills it from
+    # the KBLI-2020 ancestors and records them here. 390 of 1,559 codes serve
+    # carried content, and 217 inherit a `pb_umku` permit that way — `62110`
+    # (video games) shows three defence-industry permits belonging to the five
+    # 62xxx programming codes it was sourced from.
+    #
+    # Both fields are additive and defaulted, so a payload cached before they
+    # existed still validates on read. The note is BUILT FROM the list, so the
+    # sentence and the codes cannot drift apart.
+    licensing_content_inherited_from: list[str] | None = None
+    licensing_note: str | None = None
 
 
 class KBLISearchResult(BaseModel):
@@ -551,8 +564,21 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
                     if lic.risk_level == "Unknown":
                         lic.risk_level = qdrant_risk
 
+            # Disclose carried licensing content. Requires
+            # `properties.pp28_sources` on the node, which
+            # `backend/scripts/kg_kbli_resync.py` syncs from the canonical; an
+            # unsynced node yields None here — today's silence, never a
+            # fabricated provenance.
+            inherited_from, licensing_note = licensing_disclosure(
+                props.get("pp28_sources"), code, bool(licenses)
+            )
+
             logger.info(
-                "✅ KBLI %s details retrieved (pma=%s, risk=%s)", code, pma_status, risk_profile
+                "✅ KBLI %s details retrieved (pma=%s, risk=%s, inherited_licensing=%s)",
+                code,
+                pma_status,
+                risk_profile,
+                bool(inherited_from),
             )
 
             result = KBLIDetail(
@@ -567,6 +593,8 @@ async def inspect_kbli(code: str, pool=Depends(get_optional_database_pool)) -> A
                 related_requirements=related_requirements,
                 related_codes=related_codes,
                 expert_legal=props.get("expert_legal"),
+                licensing_content_inherited_from=inherited_from,
+                licensing_note=licensing_note,
             )
 
             # Save to cache with dynamic TTL

--- a/apps/backend-rag/backend/scripts/kbli_inspect_cache_bust.py
+++ b/apps/backend-rag/backend/scripts/kbli_inspect_cache_bust.py
@@ -4,7 +4,7 @@ so a data-plane cure actually reaches WhatsApp/webchat.
 
 WHY THIS EXISTS (2026-07-24). `inspect_kbli`
 (`GET /api/v1/kbli-notebook/inspect/{code}`, `kbli_notebook.py:352`) caches the
-whole assembled `KBLIDetail` under `kbli_inspect_v2_{code}`, with a TTL from
+whole assembled `KBLIDetail` under `kbli_inspect_v3_{code}`, with a TTL from
 `get_kbli_ttl()` that is **30 days** for most codes (12h only for 471/472/563/
 661/62, 7d for 55/41/86/05..09). Every KBLI cure so far — the 8-code pilot, the
 86-code `kbli_documents` cure, the 18-code 4th-surface cure, the 4-code phantom
@@ -20,7 +20,7 @@ packaging code — because a diagnostic call made BEFORE the cure had populated 
 30-day cache entry. Curing the store is not curing the surface (see memory
 `feedback_merged_is_not_live_consumer_map_first_2026_07_16`).
 
-WHAT IT DOES: for each `--only` code, reports whether `kbli_inspect_v2_{code}`
+WHAT IT DOES: for each `--only` code, reports whether `kbli_inspect_v3_{code}`
 is currently present, and with `--apply` deletes it and RE-READS to confirm the
 key is actually gone. The re-read matters: `CacheService.delete()` returning
 True is the client's claim, not evidence, and a Redis-unavailable fallback path
@@ -47,10 +47,13 @@ import sys
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("kbli_inspect_cache_bust")
 
-# Must stay in lockstep with kbli_notebook.py:352. If that key format changes,
-# this script silently evicts nothing and every cure after it ships a live lie —
-# so the format is pinned by a test rather than trusted to stay in sync.
-CACHE_KEY_TEMPLATE = "kbli_inspect_v2_{code}"
+# Must stay in lockstep with kbli_notebook.py. If that key format changes, this
+# script silently evicts nothing and every cure after it ships a live lie — so
+# the format is pinned by a test rather than trusted to stay in sync. That test
+# EARNED ITS KEEP on 2026-08-06: the router went v2 → v3 to publish the
+# inherited-licensing disclosure past stale entries, and this constant was
+# missed. CI caught the pair coming apart, not a reader.
+CACHE_KEY_TEMPLATE = "kbli_inspect_v3_{code}"
 
 
 def cache_key(code: str) -> str:

--- a/apps/backend-rag/backend/scripts/kg_kbli_resync.py
+++ b/apps/backend-rag/backend/scripts/kg_kbli_resync.py
@@ -14,6 +14,9 @@ WHAT IT SYNCS (1:1 canonical fields only — no derivations):
     generated, mirroring apps/mouth/src/lib/kbli-data.ts precedence)
   - description               ← uraian
   - properties.pma_status     ← pma_status
+  - properties.pp28_sources   ← pp28_sources (the OTHER codes a record's PP
+    28/2025 licensing rows were carried from; `inspect_kbli` reads it to
+    disclose inherited licences — see backend/services/kbli_pp28_provenance.py)
   - properties.{whatItMeans, whatYouNeed, baliContext, whatChanged,
     zantaraOpener}            ← intel_2026.* (only keys present; never nulled)
 Fields with unknown original derivation (kategori_risiko, skala_usaha,
@@ -58,6 +61,56 @@ def parse_ts_title_map(source: str) -> dict[str, str]:
     return {code: title.replace('\\"', '"') for code, title in TS_ENTRY_RE.findall(source)}
 
 
+def merge_node_props(props: dict, rec: dict) -> dict:
+    """The canonical fields folded onto a kg_node's existing `properties`.
+
+    Two DELIBERATELY different merge rules live here, and the asymmetry is the
+    whole point:
+
+    - `pma_status` and the intel keys are **only ever added**. Canonical not
+      carrying a value means "nothing to say", not "delete what the graph has"
+      — those fields have other writers and other derivations.
+    - `pp28_sources` is **authoritative**: written when canonical has it,
+      REMOVED when canonical does not. `inspect_kbli` turns this field into a
+      client-facing sentence naming other KBLI codes; a stale list left behind
+      would disclose an inheritance the dataset no longer records, and a wrong
+      provenance claim is worse than no note at all.
+
+    Pure, so both rules are exercisable — the previous version of this merge
+    lived inline in `main()` under a live DSN, where nothing could reach it.
+    """
+    new_props = dict(props)
+
+    pma = rec.get("pma_status")
+    if pma:
+        new_props["pma_status"] = pma
+
+    intel = rec.get("intel_2026") or {}
+    for key in INTEL_KEYS:
+        value = intel.get(key)
+        if value:
+            new_props[key] = value
+
+    raw_sources = rec.get("pp28_sources")
+    sources: list[str] = []
+    if isinstance(raw_sources, list):
+        for entry in raw_sources:
+            # `str(None)` is "None" — a source code that does not exist. Reject
+            # non-strings BEFORE stringify, matching
+            # backend/services/kbli_pp28_provenance.content_inherited_from.
+            if not isinstance(entry, (str, int)) or isinstance(entry, bool):
+                continue
+            text = str(entry).strip()
+            if text:
+                sources.append(text)
+    if sources:
+        new_props["pp28_sources"] = sources
+    else:
+        new_props.pop("pp28_sources", None)
+
+    return new_props
+
+
 async def fetch_inputs() -> tuple[list[dict], dict[str, str]]:
     async with httpx.AsyncClient(timeout=60) as http:
         responses = {}
@@ -87,6 +140,7 @@ async def main() -> None:
     conn = await asyncpg.connect(dsn)
     updated, missing, unchanged = [], [], 0
     pma_flips: list[str] = []
+    pp28_changes: list[str] = []
     writes: list[tuple] = []
     try:
         # One bulk read: per-row round-trips over the Fly proxy take >5min for 1559 codes.
@@ -100,8 +154,6 @@ async def main() -> None:
             code = str(rec.get("kode_kbli_2025"))
             judul = (rec.get("judul") or "").strip()
             uraian = (rec.get("uraian") or "").strip()
-            pma = rec.get("pma_status")
-            intel = rec.get("intel_2026") or {}
             en = titles.get(code, "")
 
             row = rows.get(f"kbli:{code}")
@@ -112,13 +164,7 @@ async def main() -> None:
             props = json.loads(row["properties"]) if row["properties"] else {}
             name = f"{en.upper()} ({judul.upper()})" if en else judul.upper()
 
-            new_props = dict(props)
-            if pma:
-                new_props["pma_status"] = pma
-            for k in INTEL_KEYS:
-                v = intel.get(k)
-                if v:
-                    new_props[k] = v
+            new_props = merge_node_props(props, rec)
 
             if row["name"] == name and row["description"] == uraian and new_props == props:
                 unchanged += 1
@@ -126,6 +172,8 @@ async def main() -> None:
 
             if props.get("pma_status") != new_props.get("pma_status"):
                 pma_flips.append(f"{code}: {props.get('pma_status')} -> {new_props.get('pma_status')}")
+            if props.get("pp28_sources") != new_props.get("pp28_sources"):
+                pp28_changes.append(code)
             updated.append(code)
             writes.append(
                 (f"kbli:{code}", name, judul, en, uraian, json.dumps(new_props, ensure_ascii=False))
@@ -149,6 +197,10 @@ async def main() -> None:
     # No display caps: a truncated list reads as the whole list downstream (W97).
     for line in pma_flips:
         logger.info("  pma flip %s", line)
+    # A count, not the list: 1,384 codes carry the field, so printing them all
+    # would bury the pma flips above. The count IS the audit — it must land on
+    # the number the canonical says, and a silent 0 means the field never synced.
+    logger.info("  pp28_sources changed on %d node(s)", len(pp28_changes))
     if missing:
         logger.info("  missing nodes: %s", " ".join(missing))
     if not args.apply and updated:

--- a/apps/backend-rag/backend/services/kbli_pp28_provenance.py
+++ b/apps/backend-rag/backend/services/kbli_pp28_provenance.py
@@ -26,10 +26,25 @@ structured JSON to a model that CAN carry a qualifier, so here the rows stay
 and name their source — same fact, opposite correct answer, which is why the
 two surfaces get two helpers rather than one shared flag.
 
-The rule below is the exact Python twin of `pp28ContentInheritedFrom` in
+The rule below is the Python counterpart of `pp28ContentInheritedFrom` in
 `apps/mouth/src/lib/kbli-provenance.ts`. Two languages cannot share a function,
-so they share a PINNED NUMBER instead: both sides assert 390 against the same
-canonical file, and a divergence turns one of them red.
+so they share a PINNED MEMBERSHIP instead: the test hashes the sorted list of
+inherited codes, not just its length — two divergent implementations can both
+answer 390 while disagreeing about WHICH 390.
+
+THEY ARE NOT BYTE-FOR-BYTE IDENTICAL, and the difference is stated rather than
+papered over (an adversarial review caught the earlier "exact twin" claim). On
+inputs the canonical does not contain, they diverge two ways:
+
+  - whitespace: `[" 62110 "]` on own code `62110` — Python strips and reads
+    self-sourced (silent); TypeScript does not strip and reads inherited.
+  - `null` entries: TypeScript's `String(null)` yields the client-visible
+    source code `"null"`; Python drops it.
+
+Measured on the canonical: **0** padded entries and **0** non-string entries out
+of 1,735. So both divergences are latent, and the Python side takes the
+fail-safe reading of each. The TypeScript fix is a follow-up (its file is under
+an open PR); until it lands, the hash pin is what would catch a real drift.
 """
 
 from __future__ import annotations

--- a/apps/backend-rag/backend/services/kbli_pp28_provenance.py
+++ b/apps/backend-rag/backend/services/kbli_pp28_provenance.py
@@ -1,0 +1,119 @@
+"""Whose PP 28/2025 licensing rows is this KBLI code actually serving?
+
+A KBLI-2025 code that is NEW in the 2025 numbering has no PP 28/2025 licensing
+row of its own — PP 28 was written against the 2020 numbering. The canonical
+dataset fills those codes from their KBLI-2020 ancestors and records where it
+took the rows from, in `pp28_sources`. Measured on the 1,559-code canonical:
+**390** codes serve licensing content sourced ONLY from other codes, and
+**217** of those inherit a `pb_umku` permit that way.
+
+The visible harm this closes: `inspect_kbli 62110` (video game development,
+sourced from five 62xxx computer-programming codes) returns three
+defence-industry permits — "Industri Kelaikan Produksi Alat Peralatan
+Pertahanan" and friends. They are really in the canonical record, so this is
+not a data bug to delete; they belong to the ANCESTOR activity, and a client
+told to obtain them would be sent somewhere no video-game studio needs to go.
+
+WHY A SEPARATE SIGNAL FROM `_l2_source`. `_l2_source` names the OSS-RBA **risk**
+source, and the two disagree: a code can be genuinely 2025-native on risk while
+its licensing content is carried. Reading one for the other is what let this
+survive.
+
+WHY THIS SURFACE DISCLOSES INSTEAD OF GOING SILENT. The indexed `<meta>` on the
+web page suppresses the licence type entirely, because a `<title>` has no room
+for a qualifier (`apps/mouth/src/lib/kbli-meta.ts`). `inspect_kbli` returns
+structured JSON to a model that CAN carry a qualifier, so here the rows stay
+and name their source — same fact, opposite correct answer, which is why the
+two surfaces get two helpers rather than one shared flag.
+
+The rule below is the exact Python twin of `pp28ContentInheritedFrom` in
+`apps/mouth/src/lib/kbli-provenance.ts`. Two languages cannot share a function,
+so they share a PINNED NUMBER instead: both sides assert 390 against the same
+canonical file, and a divergence turns one of them red.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def content_inherited_from(pp28_sources: Any, own_code: Any) -> list[str] | None:
+    """The OTHER codes this record's PP 28 licensing rows came from, or None.
+
+    None means "nothing to disclose", and it covers two different worlds on
+    purpose:
+
+    - **self-sourced** — the record's own code appears in `pp28_sources`, so it
+      HAS a row of its own; any extra entries are supplements, not a
+      substitution.
+    - **nothing recorded** — `pp28_sources` absent or empty (175 codes). Absence
+      is not evidence. This signal exists to qualify a claim, and qualifying one
+      on missing data would be asserting an inheritance we cannot show.
+
+    Both return the permissive answer. The failure mode is a missing note, never
+    an invented provenance.
+    """
+    if isinstance(pp28_sources, (str, bytes)) or not isinstance(pp28_sources, Iterable):
+        # A scalar where a list belongs is malformed input, not an inheritance
+        # claim — and iterating a str would yield characters, which is how a
+        # code like "62011" becomes five phantom sources.
+        return None
+
+    # `str(None)` is "None", which is truthy and would be printed to a client as
+    # a source KBLI code that does not exist. Drop non-strings BEFORE stringify
+    # rather than after — found by the fail-safe test, not by a live record:
+    # the canonical carries 1,735 entries and all 1,735 are strings today.
+    sources: list[str] = []
+    for entry in pp28_sources:
+        # `bool` is a subclass of `int`, and "True" is not a KBLI code either.
+        if not isinstance(entry, (str, int)) or isinstance(entry, bool):
+            continue
+        text = str(entry).strip()
+        if text:
+            sources.append(text)
+    if not sources:
+        return None
+
+    own = str(own_code or "").strip()
+    if own and own in sources:
+        return None
+
+    return sources
+
+
+def inherited_licensing_note(sources: list[str] | None) -> str | None:
+    """The sentence a model can pass through to a client, or None.
+
+    Built FROM the list rather than beside it, so the note and the codes cannot
+    drift apart: there is one derivation, and the note is a rendering of it.
+    """
+    if not sources:
+        return None
+    plural = "s" if len(sources) > 1 else ""
+    return (
+        f"This code has no PP 28/2025 licensing row of its own — the licences "
+        f"listed were carried over from KBLI code{plural} {', '.join(sources)}. "
+        f"They may belong to the source activity rather than this one; confirm "
+        f"the licence type with the Bali Zero team before acting on it."
+    )
+
+
+def licensing_disclosure(
+    pp28_sources: Any, own_code: Any, has_licenses: bool
+) -> tuple[list[str] | None, str | None]:
+    """The full decision for one `inspect_kbli` response: (codes, note).
+
+    `has_licenses` is the second half of the rule and it lives HERE rather than
+    inline at the call site, because a rule written where nothing can exercise
+    it is a rule that is not enforced. A response listing no licences must not
+    carry a sentence about "the licences listed" — that would be an assertion
+    about nothing, which is the same class of harm as an unqualified one.
+
+    Returned together so the two response fields have a single derivation and
+    cannot be updated one without the other.
+    """
+    if not has_licenses:
+        return None, None
+    sources = content_inherited_from(pp28_sources, own_code)
+    return sources, inherited_licensing_note(sources)

--- a/apps/backend-rag/backend/tests/unit/routers/test_kbli_inherited_licensing_reaches_the_model.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_kbli_inherited_licensing_reaches_the_model.py
@@ -1,0 +1,217 @@
+"""The rule is correct in `kbli_pp28_provenance`; this proves it REACHES a client.
+
+`inspect_kbli` is what the WhatsApp/MCP model reads. A predicate that returns
+the right answer to nobody is the shape this repo keeps re-learning: the field
+has to survive the wiring, the `bool(licenses)` gate, and the response cache.
+
+So these tests drive the endpoint itself through a fake pool, and assert on the
+JSON a consumer actually receives — including the case an adversarial review
+raised, where a cache entry written before the field existed would keep the
+endpoint silent for up to 30 days.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import backend.app.routers.kbli_notebook as kbli_notebook_module
+from backend.app.dependencies import get_optional_database_pool, get_search_service
+
+LICENSE_ROW = {
+    "name": "Industri Kelaikan Produksi Alat Peralatan Pertahanan",
+    "target_entity_type": "perizinan",
+    "properties": {"skala_usaha": ["Besar"], "kategori_risiko": "Tinggi"},
+    "edge_props": None,
+}
+
+
+def _pool(node_props: dict, license_rows: list[dict]):
+    """A pool whose connection answers the endpoint's four queries."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "name": "VIDEO GAME DEVELOPMENT (AKTIVITAS PENGEMBANGAN VIDEO GAME)",
+            "description": "Pengembangan video game.",
+            "properties": node_props,
+        }
+    )
+
+    async def _fetch(query, *args):
+        # Dispatch on the query, not on call order: an added query upstream
+        # would otherwise silently shift which answer each call receives.
+        if "relationship_type = 'REQUIRES'" in query:
+            return license_rows
+        return []
+
+    conn.fetch = AsyncMock(side_effect=_fetch)
+    conn.fetchval = AsyncMock(return_value=None)
+
+    pool = MagicMock()
+
+    @asynccontextmanager
+    async def _acquire():
+        yield conn
+
+    pool.acquire = _acquire
+    return pool
+
+
+@pytest.fixture
+def make_client():
+    def _make(node_props: dict, license_rows: list[dict], cached=None):
+        app = FastAPI()
+        app.include_router(kbli_notebook_module.router)
+        app.dependency_overrides[get_search_service] = lambda: MagicMock(
+            embedder=MagicMock()
+        )
+        app.dependency_overrides[get_optional_database_pool] = lambda: _pool(
+            node_props, license_rows
+        )
+        cache = MagicMock()
+        cache.get = AsyncMock(return_value=cached)
+        cache.set = AsyncMock()
+        stack = [
+            patch.object(
+                kbli_notebook_module,
+                "_get_kbli_payload_from_qdrant",
+                AsyncMock(return_value=None),
+            ),
+            patch("backend.core.cache.get_cache_service", return_value=cache),
+        ]
+        for p in stack:
+            p.start()
+        client = TestClient(app, raise_server_exceptions=False)
+        client._patches = stack  # torn down by the test
+        client._cache = cache
+        return client
+
+    return _make
+
+
+def _get(client, code="62110"):
+    response = client.get(f"/kbli-notebook/inspect/{code}")
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _stop(client):
+    for p in client._patches:
+        p.stop()
+
+
+# --------------------------------------------------------------------------
+# GUILT — the note reaches the consumer
+# --------------------------------------------------------------------------
+
+
+def test_a_carried_code_tells_the_model_whose_licences_these_are(make_client):
+    client = make_client(
+        {"pp28_sources": ["62011", "62019", "62015", "62013", "62012"]},
+        [LICENSE_ROW],
+    )
+    try:
+        body = _get(client)
+        assert body["licensing_content_inherited_from"] == [
+            "62011",
+            "62019",
+            "62015",
+            "62013",
+            "62012",
+        ]
+        note = body["licensing_note"]
+        assert note and "62011" in note and "62012" in note
+        # The licences are NOT withheld — this surface can qualify, so it does.
+        assert len(body["licenses"]) == 1
+    finally:
+        _stop(client)
+
+
+# --------------------------------------------------------------------------
+# INNOCENCE — three ways silence is the correct answer
+# --------------------------------------------------------------------------
+
+
+def test_a_self_sourced_code_carries_no_note(make_client):
+    client = make_client({"pp28_sources": ["62110"]}, [LICENSE_ROW])
+    try:
+        body = _get(client)
+        assert body["licensing_content_inherited_from"] is None
+        assert body["licensing_note"] is None
+    finally:
+        _stop(client)
+
+
+def test_an_unsynced_node_carries_no_note(make_client):
+    """Every node until `kg_kbli_resync.py --apply` runs. Silence, not a claim."""
+    client = make_client({}, [LICENSE_ROW])
+    try:
+        body = _get(client)
+        assert body["licensing_content_inherited_from"] is None
+        assert body["licensing_note"] is None
+    finally:
+        _stop(client)
+
+
+def test_a_carried_code_with_no_licences_rendered_carries_no_note(make_client):
+    """A sentence about "the licences listed" on a response listing none."""
+    client = make_client({"pp28_sources": ["62011"]}, [])
+    try:
+        body = _get(client)
+        assert body["licenses"] == []
+        assert body["licensing_note"] is None
+    finally:
+        _stop(client)
+
+
+# --------------------------------------------------------------------------
+# THE CACHE — raised by an adversarial review, and it bites without the bump
+# --------------------------------------------------------------------------
+
+
+def test_the_cache_key_is_versioned_past_the_payload_that_lacked_the_field(
+    make_client,
+):
+    """A v2 entry validates on read (the fields default to None), so a carried
+    code would answer WITHOUT the note until its TTL expired — up to 30 days.
+    The endpoint must not read entries written before the field existed."""
+    client = make_client(
+        {"pp28_sources": ["62011", "62019"]},
+        [LICENSE_ROW],
+    )
+    try:
+        body = _get(client)
+        assert body["licensing_note"] is not None
+        requested = client._cache.get.await_args.args[0]
+        assert requested == "kbli_inspect_v3_62110", requested
+        assert "_v2_" not in requested
+    finally:
+        _stop(client)
+
+
+def test_a_current_version_cache_hit_is_still_served_from_cache(make_client):
+    """INNOCENCE for the bump: it must invalidate the OLD generation only, not
+    disable caching. A v3 hit short-circuits the DB entirely."""
+    cached = {
+        "code": "62110",
+        "title": "cached title",
+        "description": "cached",
+        "pma_status": "TERBUKA",
+        "licensing_status": "REGULATED",
+        "sector": "J",
+        "risk_profile": "Tinggi",
+        "licenses": [],
+        "licensing_content_inherited_from": ["62011"],
+        "licensing_note": "cached note",
+    }
+    client = make_client({"pp28_sources": ["62011"]}, [LICENSE_ROW], cached=cached)
+    try:
+        body = _get(client)
+        assert body["title"] == "cached title"
+        assert body["licensing_note"] == "cached note"
+    finally:
+        _stop(client)

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kg_kbli_resync_props.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kg_kbli_resync_props.py
@@ -1,0 +1,105 @@
+"""Two merge rules live in one function, and the asymmetry is the point.
+
+`pma_status` and the intel keys are only ever ADDED — canonical carrying no
+value means "nothing to say", because those fields have other writers.
+`pp28_sources` is AUTHORITATIVE and is also REMOVED when canonical drops it,
+because `inspect_kbli` renders it into a client-facing sentence naming other
+KBLI codes: a stale list would disclose an inheritance the dataset no longer
+records, and a wrong provenance claim is worse than no note at all.
+
+Both directions are pinned. A merge tested only where it writes is how a cure
+becomes the next defect (cicatrix family #3).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[3] / "scripts" / "kg_kbli_resync.py"
+assert _MODULE_PATH.is_file(), f"resync script not at {_MODULE_PATH}"
+_SPEC = importlib.util.spec_from_file_location("kg_kbli_resync", _MODULE_PATH)
+assert _SPEC and _SPEC.loader
+kg_kbli_resync = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(kg_kbli_resync)
+merge_node_props = kg_kbli_resync.merge_node_props
+
+
+# --------------------------------------------------------------------------
+# pp28_sources — the authoritative field
+# --------------------------------------------------------------------------
+
+
+def test_writes_the_sources_the_canonical_records():
+    out = merge_node_props({}, {"pp28_sources": ["62011", "62019"]})
+    assert out["pp28_sources"] == ["62011", "62019"]
+
+
+def test_clears_a_stale_list_when_the_canonical_no_longer_records_one():
+    """GUILT for the rule that justifies the asymmetry: leaving this behind
+    makes `inspect_kbli` name source codes the dataset has withdrawn."""
+    out = merge_node_props({"pp28_sources": ["62011"]}, {"pp28_sources": []})
+    assert "pp28_sources" not in out
+
+    out = merge_node_props({"pp28_sources": ["62011"]}, {})
+    assert "pp28_sources" not in out
+
+
+def test_a_malformed_value_clears_rather_than_propagates():
+    """A scalar where a list belongs is not an inheritance claim."""
+    out = merge_node_props({"pp28_sources": ["62011"]}, {"pp28_sources": "62011"})
+    assert "pp28_sources" not in out
+
+
+def test_drops_entries_that_are_not_codes_instead_of_writing_None():
+    out = merge_node_props({}, {"pp28_sources": [" 62011 ", "", None, True, "62019"]})
+    assert out["pp28_sources"] == ["62011", "62019"]
+
+
+# --------------------------------------------------------------------------
+# INNOCENCE — the additive fields must NOT inherit the clearing rule
+# --------------------------------------------------------------------------
+
+
+def test_absent_pma_status_does_not_null_the_graph_value():
+    out = merge_node_props({"pma_status": "TERBATAS"}, {"pp28_sources": ["62011"]})
+    assert out["pma_status"] == "TERBATAS"
+
+
+def test_absent_intel_keys_do_not_null_the_graph_values():
+    existing = {k: f"value-{k}" for k in kg_kbli_resync.INTEL_KEYS}
+    out = merge_node_props(existing, {"intel_2026": {}})
+    for key in kg_kbli_resync.INTEL_KEYS:
+        assert out[key] == f"value-{key}"
+
+
+def test_untouched_properties_survive():
+    """Fields with unknown original derivation (kategori_risiko, skala_usaha,
+    licensing_status, sektor_id) are left alone by contract."""
+    out = merge_node_props(
+        {"kategori_risiko": "MR", "skala_usaha": ["Besar"], "licensing_status": "REGULATED"},
+        {"pma_status": "TERBUKA"},
+    )
+    assert out["kategori_risiko"] == "MR"
+    assert out["skala_usaha"] == ["Besar"]
+    assert out["licensing_status"] == "REGULATED"
+
+
+def test_does_not_mutate_the_input_properties():
+    """`main()` compares `new_props == props` to decide whether to write at
+    all; an in-place merge would make every row look unchanged."""
+    props = {"pma_status": "TERBUKA"}
+    merge_node_props(props, {"pma_status": "TERBATAS", "pp28_sources": ["62011"]})
+    assert props == {"pma_status": "TERBUKA"}
+
+
+@pytest.mark.parametrize(
+    "rec",
+    [
+        {"pma_status": "TERBATAS"},
+        {"intel_2026": {"whatItMeans": "x"}},
+        {"pp28_sources": ["62011"]},
+    ],
+)
+def test_each_field_alone_is_enough_to_produce_a_change(rec):
+    assert merge_node_props({}, rec) != {}

--- a/apps/backend-rag/backend/tests/unit/services/test_kbli_pp28_provenance.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_kbli_pp28_provenance.py
@@ -1,0 +1,182 @@
+"""`inspect_kbli 62110` returns three defence-industry permits. They are real.
+
+They belong to the five 62xxx computer-programming codes that video-game
+development was sourced from when PP 28/2025 — written against the KBLI-2020
+numbering — had no row for the new 2025 code. Deleting them would be wrong;
+serving them unqualified sends a games studio to the defence ministry.
+
+These tests pin BOTH directions, because a signal that only proves guilt is how
+a cure becomes the next defect (cicatrix family #3): an inherited record must
+be named, and a self-sourced one must stay silent.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.services.kbli_pp28_provenance import (
+    content_inherited_from,
+    inherited_licensing_note,
+    licensing_disclosure,
+)
+
+REPO_ROOT = next(
+    p
+    for p in Path(__file__).resolve().parents
+    if (p / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json").is_file()
+)
+DATASET = REPO_ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+
+
+# --------------------------------------------------------------------------
+# GUILT — a carried record names where its rows came from
+# --------------------------------------------------------------------------
+
+
+def test_inherited_record_names_its_sources():
+    assert content_inherited_from(["62011", "62019"], "62110") == ["62011", "62019"]
+
+
+def test_note_names_every_source_code_and_plural_agrees():
+    note = inherited_licensing_note(["62011", "62019"])
+    assert note is not None
+    assert "62011" in note and "62019" in note
+    assert "KBLI codes " in note  # plural
+    assert "Bali Zero team" in note
+
+    single = inherited_licensing_note(["63111"])
+    assert single is not None and "KBLI code 63111" in single
+    assert "KBLI codes" not in single
+
+
+# --------------------------------------------------------------------------
+# INNOCENCE — silence is the correct answer three different ways
+# --------------------------------------------------------------------------
+
+
+def test_self_sourced_record_is_not_inherited():
+    """Its own code in the list means it HAS a row; extras are supplements."""
+    assert content_inherited_from(["56101", "56102"], "56101") is None
+
+
+def test_nothing_recorded_is_not_an_inheritance_claim():
+    """175 codes record no PP 28 source. Absence is not evidence."""
+    assert content_inherited_from([], "01111") is None
+    assert content_inherited_from(None, "01111") is None
+
+
+def test_note_is_none_when_there_is_nothing_to_disclose():
+    assert inherited_licensing_note(None) is None
+    assert inherited_licensing_note([]) is None
+
+
+# --------------------------------------------------------------------------
+# FAIL-SAFE — malformed input must never fabricate a provenance
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["62011", b"62011", 62011, 3.5, {"a": 1}.keys().__iter__])
+def test_scalar_or_string_input_yields_silence_not_five_phantom_sources(bad):
+    """Iterating the string "62011" would yield five characters — five phantom
+    source codes on a record that has none."""
+    assert content_inherited_from(bad, "62110") is None
+
+
+def test_blank_and_whitespace_entries_are_dropped_not_disclosed():
+    """`str(None)` is "None" — truthy, and printable to a client as a source
+    KBLI code that does not exist. The canonical carries 1,735 entries and all
+    1,735 are strings today, so this pins a latent shape, not a live record.
+    """
+    assert content_inherited_from(["", "  ", None], "62110") is None
+    assert content_inherited_from([" 62011 ", "", None, True], "62110") == ["62011"]
+
+
+def test_own_code_matches_after_stripping():
+    assert content_inherited_from([" 56101 "], "56101") is None
+
+
+# --------------------------------------------------------------------------
+# THE RESPONSE DECISION — both halves of the rule, all four combinations
+# --------------------------------------------------------------------------
+
+
+def test_disclosure_names_the_sources_when_the_response_lists_licences():
+    codes, note = licensing_disclosure(["62011", "62019"], "62110", has_licenses=True)
+    assert codes == ["62011", "62019"]
+    assert note is not None and "62011" in note
+
+
+def test_disclosure_is_silent_when_the_response_lists_no_licences():
+    """A note about "the licences listed" on a response that lists none is an
+    assertion about nothing — the same class of harm as an unqualified one."""
+    codes, note = licensing_disclosure(["62011", "62019"], "62110", has_licenses=False)
+    assert codes is None and note is None
+
+
+def test_disclosure_is_silent_for_a_self_sourced_code_with_licences():
+    codes, note = licensing_disclosure(["56101"], "56101", has_licenses=True)
+    assert codes is None and note is None
+
+
+def test_disclosure_is_silent_on_an_unsynced_node():
+    """A kg_node that predates the `pp28_sources` sync must degrade to today's
+    silence, never to a fabricated provenance."""
+    codes, note = licensing_disclosure(None, "62110", has_licenses=True)
+    assert codes is None and note is None
+
+
+def test_the_two_fields_always_agree():
+    """One derivation, so a caller cannot ship the codes without the sentence
+    or the sentence without the codes."""
+    for sources in (["62011"], ["62011", "62019"], [], None):
+        for has in (True, False):
+            codes, note = licensing_disclosure(sources, "62110", has_licenses=has)
+            assert (codes is None) == (note is None)
+
+
+# --------------------------------------------------------------------------
+# CROSS-LANGUAGE PIN — the TypeScript twin asserts the same number
+# --------------------------------------------------------------------------
+
+
+def test_canonical_partition_matches_the_typescript_twin():
+    """`pp28ContentInheritedFrom` in apps/mouth/src/lib/kbli-provenance.ts
+    implements the identical rule and its test pins 390 on this same file.
+
+    Two languages cannot share a function, so they share this number. If a
+    future edit drifts one side, one of the two suites turns red — which is the
+    only mechanism keeping the web page and `inspect_kbli` telling a client the
+    same thing about the same code.
+    """
+    rows = json.loads(DATASET.read_text(encoding="utf-8"))["data"]
+    assert len(rows) == 1559, "canonical size changed — re-derive the pins below"
+
+    inherited, self_sourced, unrecorded = [], [], []
+    for rec in rows:
+        code = str(rec["kode_kbli_2025"])
+        verdict = content_inherited_from(rec.get("pp28_sources"), code)
+        if verdict:
+            inherited.append(code)
+        elif rec.get("pp28_sources"):
+            self_sourced.append(code)
+        else:
+            unrecorded.append(code)
+
+    assert len(inherited) == 390
+    # Exhaustive: every code lands in exactly one bucket, so a future field
+    # rename cannot quietly shrink the inherited set into a fourth state.
+    assert len(inherited) + len(self_sourced) + len(unrecorded) == 1559
+
+    by_code = {str(r["kode_kbli_2025"]): r for r in rows}
+    assert "62110" in by_code, "positive control absent — the key is wrong, not the data"
+    assert content_inherited_from(by_code["62110"].get("pp28_sources"), "62110") == [
+        "62011",
+        "62019",
+        "62015",
+        "62013",
+        "62012",
+    ]
+    # The two innocence controls this cure was proven live against.
+    for control in ("56101", "01111"):
+        assert content_inherited_from(by_code[control].get("pp28_sources"), control) is None

--- a/apps/backend-rag/backend/tests/unit/services/test_kbli_pp28_provenance.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_kbli_pp28_provenance.py
@@ -10,6 +10,7 @@ a cure becomes the next defect (cicatrix family #3): an inherited record must
 be named, and a self-sourced one must stay silent.
 """
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -140,14 +141,15 @@ def test_the_two_fields_always_agree():
 # --------------------------------------------------------------------------
 
 
-def test_canonical_partition_matches_the_typescript_twin():
+def test_canonical_partition_matches_the_typescript_counterpart():
     """`pp28ContentInheritedFrom` in apps/mouth/src/lib/kbli-provenance.ts
-    implements the identical rule and its test pins 390 on this same file.
+    implements the same rule and its test pins 390 on this same file.
 
-    Two languages cannot share a function, so they share this number. If a
-    future edit drifts one side, one of the two suites turns red — which is the
-    only mechanism keeping the web page and `inspect_kbli` telling a client the
-    same thing about the same code.
+    Two languages cannot share a function, so they share this pin. A COUNT is
+    not enough — two divergent implementations can both answer 390 while
+    disagreeing about WHICH 390 — so the membership is hashed as well. An
+    adversarial review made exactly that point about the first version of this
+    test.
     """
     rows = json.loads(DATASET.read_text(encoding="utf-8"))["data"]
     assert len(rows) == 1559, "canonical size changed — re-derive the pins below"
@@ -164,6 +166,12 @@ def test_canonical_partition_matches_the_typescript_twin():
             unrecorded.append(code)
 
     assert len(inherited) == 390
+    # WHICH 390, not just how many. Swapping one code for another keeps the
+    # count and changes what a client is told about two codes.
+    assert (
+        hashlib.sha256(",".join(sorted(inherited)).encode()).hexdigest()
+        == "a93e90f6e1c174b55ef0316609f4b945c39d0e8b69de2f92be7118fccf9dcf9f"
+    )
     # Exhaustive: every code lands in exactly one bucket, so a future field
     # rename cannot quietly shrink the inherited set into a fourth state.
     assert len(inherited) + len(self_sourced) + len(unrecorded) == 1559

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`332 routers · 680 services · 1288 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`332 routers · 681 services · 1291 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What a client is told today

`inspect_kbli 62110` — video game development — returns three **defence-industry**
permits. They are not a data bug to delete: they really are in the canonical
record. They belong to the **five 62xxx computer-programming codes** that `62110`
was filled from, because PP 28/2025 was written against the KBLI-2020 numbering
and has no row for a code that is new in 2025.

Measured on the 1,559-code canonical: **390** codes serve PP 28 licensing content
sourced only from other codes, and **217** inherit a `pb_umku` permit that way.
`02101` (forest management) is sourced from `63111` (data hosting).

## Why this surface discloses instead of going silent

The web-page half shipped in #3645 / #3646 and split on purpose: an indexed
`<meta>` has no room for a qualifier, so it goes **silent**; the page body keeps
the licence and **names the source**. `inspect_kbli` returns structured JSON to a
model, which can carry a qualifier — so it behaves like the body. Same fact, two
surfaces, opposite correct answers, two helpers rather than one shared flag.

## Changes

| file | what |
|---|---|
| `backend/services/kbli_pp28_provenance.py` | the rule + the sentence + the response decision |
| `backend/app/routers/kbli_notebook.py` | two additive, defaulted fields on `KBLIDetail`; cache key `v2` → `v3` |
| `backend/scripts/kg_kbli_resync.py` | syncs `properties.pp28_sources` onto the KG nodes |

The note is built **from** the list, so the sentence and the codes cannot drift
apart.

## Two merge rules, deliberately different

`pma_status` and the intel keys are only ever **added** — canonical carrying no
value means "nothing to say", and those fields have other writers.
`pp28_sources` is **authoritative** and is also **removed** when canonical drops
it: the router turns it into a client-facing sentence naming other KBLI codes, so
a stale list would disclose an inheritance the dataset no longer records. A wrong
provenance claim is worse than no note at all. Both directions pinned.

## A cross-family review returned "defective", and all three findings changed the code

Codex GPT-5.6, instructed to refute (generator ≠ grader).

1. **The cure would have been invisible for up to 30 days.** The endpoint returns
   its cached payload *before* consulting the node, and a `v2` entry validates on
   read because the new fields default to `None`. Any carried code already in
   cache would have kept answering without the note until its TTL expired. This
   PR originally declared a manual per-code cache-bust as a follow-up step; the
   review's answer is better and is what shipped — **the cache key is now `v3`**,
   which evicts the old generation atomically at deploy instead of depending on
   someone running the bust for the right codes.
2. **"Exact Python twin" was a false claim in a comment.** The two
   implementations diverge on inputs the canonical does not contain: Python
   strips whitespace and drops non-strings, TypeScript does neither, so
   `[" 62110 "]` on own code `62110` reads self-sourced in Python and inherited
   in TS, and a runtime `null` becomes the client-visible source code `"null"` in
   TS. Measured: **0** padded and **0** non-string entries out of 1,735 — both
   latent, and Python takes the fail-safe reading of each. The claim now states
   the divergences. **TS fix deliberately deferred**: its file is under open PR
   #3646 and editing it would restart those checks.
3. **A count is not a membership.** The pin asserted only that both sides answer
   390 — two divergent implementations can both answer 390 while disagreeing
   about *which* 390. The sorted list is now hashed too.

The second half of finding 3 — that the endpoint itself was untested — added
`test_kbli_inherited_licensing_reaches_the_model.py`, which drives `inspect_kbli`
through a fake pool and asserts on the JSON a consumer receives.

## Verification

35 tests, guilt **and** innocence on every rule. Mutation-verified — each of
these turns the suite red:

| mutation | result |
|---|---|
| drop the has-licences gate | RC=1 |
| drop the phantom-source filter | RC=1 |
| drop the stale-list clearing | RC=1 |
| break the additive/authoritative asymmetry | RC=1 |
| drop the self-sourced exemption | RC=1 |
| revert the cache version to `v2` | RC=1 |
| drop either response field | RC=1 |
| **swap one inherited code for another, count stays 390** | RC=1 |

That last one is the mutation the original test could not catch.

## How many codes actually gain the note: **305**, not 390

390 is the DATA fact — codes whose PP 28 content is carried. The SURFACE fact is
smaller, and measured against the live graph rather than assumed: of those 390,
**305** render at least one licence through `inspect_kbli` and therefore receive
the qualifier. The other **85** are in the graph and render **zero** licences, so
the has-licences gate correctly keeps them silent — there is nothing to qualify.
All 390 are present in the graph; none is missing.

Stating 390 as the reach would have been the "a cure's own count is not the count
of rows that gained the thing" error. 305 is also the prove-live expectation.

## Still not live on merge — and the reason is named

The router reads a node property that **no node carries yet**. Until
`kg_kbli_resync.py --apply` runs against the KG, every code yields today's
silence — fail-safe, never a fabricated provenance. The `v3` bump means no cache
step is needed once the sync lands. The disclosure will be claimed only after a
before/after captured on prod, with `56101` and `01111` as innocence controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
