### PR TITLE
fix(ci): SonarQube has never scanned, and pays 20-30 minutes per PR for it

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -31,9 +31,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Is the scanner even reachable? Measured 2026-08-06 over the last 29 COMPLETED
+  # runs of this workflow: 16 success, 13 cancelled, and the `SonarQube Scan` step
+  # succeeded **0 times**. `SONAR_TOKEN` has never been configured, so both
+  # terminal steps were skipped by their own `if:` on every run — while the two
+  # steps that FEED them were not gated and ran anyway: the full Python suite with
+  # coverage (1228s on run 31037626312) plus the frontend suite (211s), thrown
+  # away. The 13 cancellations are that work overrunning `timeout-minutes: 30`;
+  # on that run the scan step was skipped 8 seconds after the tests finished.
+  #
+  # A whole job of "exists but has never once done the thing it exists for"
+  # (cicatrix #2), costing 20-30 minutes of shared runner per PR. This gate makes
+  # the cost zero when the token is absent and changes nothing when it is present.
+  #
+  # It must be a separate JOB: GitHub exposes neither `secrets` nor `env` to
+  # `jobs.<id>.if`, only `github`/`needs`/`vars`/`inputs` — which is why the
+  # existing hoist into job-level `env` reaches step-level `if:` but could never
+  # gate the job itself. `needs.<job>.outputs` is the supported way in.
+  preflight:
+    name: SonarQube preflight (is the scanner configured?)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      configured: ${{ steps.probe.outputs.configured }}
+    steps:
+      # No checkout: this job exists to avoid paying for one.
+      - id: probe
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${SONAR_TOKEN:-}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+            echo "SONAR_TOKEN is set — running the analysis job."
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "SONAR_TOKEN is NOT set — skipping the analysis job entirely."
+            echo "Nothing is silently degraded: with no token the scan step was"
+            echo "already skipped on every run; this only stops paying for the"
+            echo "test+coverage steps that fed it. Set the secret to re-enable."
+          fi
+
   sonarqube:
     name: SonarQube Code Analysis
     runs-on: ubuntu-latest
+    needs: preflight
+    if: needs.preflight.outputs.configured == 'true'
     timeout-minutes: 30
     # Advisory-only: quality-gate thresholds (code smells, coverage,
     # duplication) are policy decisions the maintainer must own. The


### PR DESCRIPTION
## It has never scanned. Not once.

Measured over the last **29 completed** jobs of this workflow:

| conclusion | n |
|---|---|
| success | 16 |
| cancelled | 13 |
| **runs where the `SonarQube Scan` step succeeded** | **0** |

`SONAR_TOKEN` has never been configured, so `SonarQube Scan` and `SonarQube
Quality Gate Check` are skipped by their own `if: env.SONAR_TOKEN != ''` on every
run — **including the 16 that report success.**

## What it charges for that

The two steps that FEED the scan are not gated. From run `31037626312`:

```
Checkout code                        76s
Install Python dependencies         130s
Run Python tests with coverage     1228s   ← 20.5 min, result discarded
Run Frontend tests with coverage    211s
SonarQube Scan                      skipped
```

Total 1808s against `timeout-minutes: 30` — the scan step was skipped **8 seconds**
after the tests finished. That is what the 13 cancellations are.

So every PR touching a `.py`/`.ts` file pays 20-30 minutes of shared runner for a
result that is thrown away. Cicatrix #2: a job that exists and has never once done
the thing it exists for. The contention is not free either — this repo's checkouts
already have a heavy tail (11% over 60s, measured separately), and this is one of
the largest avoidable consumers on the pool.

## Why a preflight JOB and not a job-level `if:`

GitHub exposes neither `secrets` nor `env` to `jobs.<id>.if` — only
`github`/`needs`/`vars`/`inputs`. That is exactly why the existing hoist of the
secret into job-level `env` reaches *step*-level `if:` but could never gate the
job itself. `needs.<job>.outputs` is the supported way in.

The preflight deliberately does **not** check out: avoiding the 1,090 MiB checkout
is half the saving.

## Nothing is silently degraded

With no token the scan was **already** skipped on every run — this removes only
the cost of the steps that fed it. Set `SONAR_TOKEN` and the workflow behaves
exactly as designed. The preflight prints which branch it took, in words, on every
run, so "skipped" never has to be inferred.

Non-required workflow, so skipping it cannot leave a PR at "Expected — waiting for
status" (verified: not among the 26 required contexts on `main`).

## A harm I suspected, and measured away

`Comment PR with results` is **not** gated by the token, and its body asserts
"📊 SonarQube Analysis Complete / ✅ Code analysis completed". I expected to find
that false claim posted on every PR. Searched the comments of #3643–#3650:
**0 occurrences** — the step carries `continue-on-error: true` and fails on
missing `pull-requests: write`, exactly as its own inline comment predicts, so the
API reports it `success` while it posted nothing. No reviewer was ever told a scan
happened. **The waste is real; the lie is not** — recorded so nobody re-derives it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
