### PR TITLE
fix(secrets-audit): the auditor judged by mode alone, and certified 'clean' over a directory it never opened

### DIFF
--- a/scripts/secrets_permissions_audit.py
+++ b/scripts/secrets_permissions_audit.py
@@ -258,6 +258,57 @@ def _iter_candidate_paths(
 # --------------------------------------------------------------------------
 
 
+def _dir_traversal(directory: str, _cache: dict = {}) -> Tuple[bool, bool]:
+    """(group_can_traverse, other_can_traverse) for ONE directory.
+
+    On any stat error the answer is (True, True): a guard that could not
+    verify must never absolve (W106b — CANNOT-VERIFY is not the same as
+    clean). Cached because a fleet scan walks ~90k files over a few hundred
+    directories.
+    """
+    hit = _cache.get(directory)
+    if hit is not None:
+        return hit
+    try:
+        mode = stat.S_IMODE(os.stat(directory).st_mode)
+        result = (bool(mode & stat.S_IXGRP), bool(mode & stat.S_IXOTH))
+    except OSError:
+        result = (True, True)
+    _cache[directory] = result
+    return result
+
+
+def reachable_by(path: Path) -> Tuple[bool, bool]:
+    """(group, other) — can each actually walk down to this file?
+
+    A 0644 file inside a 0700 directory is NOT in the clear: nobody but the
+    owner can reach it. Judging the file's own mode alone answers a narrower
+    question than the one this tool exists to ask, and the gap is not
+    academic — it shows up as a permanent stream of findings for files that
+    cannot be read by anyone, which is precisely how a guard's output stops
+    being read at all (superscar #2). Every directory from the file up to the
+    root must permit traversal, so one tight directory anywhere in the chain
+    is enough to close the path.
+
+    DECLARED LIMIT: this follows the resolved path only. A hard link to the
+    same inode from a permissive directory would still be reachable and this
+    function cannot see it — hard links are outside what a path-based audit
+    can answer, and saying so here is cheaper than implying otherwise.
+    """
+    group = other = True
+    try:
+        directory = path.parent.resolve()
+    except OSError:
+        return (True, True)
+    while True:
+        can_group, can_other = _dir_traversal(str(directory))
+        group = group and can_group
+        other = other and can_other
+        if not (group or other) or directory.parent == directory:
+            return (group, other)
+        directory = directory.parent
+
+
 def scan(
     roots: Iterable[Path],
     max_depth: int = DEFAULT_MAX_DEPTH,
@@ -290,7 +341,16 @@ def scan(
             continue  # symlink, socket, fifo, etc. — skip, never follow
 
         mode_bits = stat.S_IMODE(lst.st_mode)
-        if mode_bits & 0o077:
+        if not mode_bits & 0o077:
+            continue
+
+        # The mode says who MAY read; the directory chain says who can get
+        # here at all. Both have to be true for the file to be exposed.
+        can_group, can_other = reachable_by(candidate)
+        exposed = (bool(mode_bits & 0o070) and can_group) or (
+            bool(mode_bits & 0o007) and can_other
+        )
+        if exposed:
             findings.append(Finding(path=candidate, mode=mode_bits))
 
     findings.sort(key=lambda f: str(f.path))

--- a/scripts/secrets_permissions_audit.py
+++ b/scripts/secrets_permissions_audit.py
@@ -224,7 +224,16 @@ def _iter_candidate_paths(
     A root may itself be a regular file (e.g. an expanded `~/.env*` glob
     hit) rather than a directory — handled directly rather than via
     os.walk (which yields nothing for a non-directory top). Roots that do
-    not exist are skipped. Root-level symlinks are not followed.
+    not exist are skipped.
+
+    A root that IS a symlink is resolved once and its target audited. A
+    root is NAMED by the caller; a link met during the walk is not, and
+    only the latter is a way for the walk to be lured out of the tree it
+    was asked to audit. Dropping a named root silently is how this tool
+    certified "clean" for the fleet's own memory directory — reached
+    through two symlinks — while looking at zero files: with no root
+    counted, the blind-scan guard could not fire either. Broken or
+    looping links are treated exactly like a path that does not exist.
     """
     seen_dirs: set = set()
     for raw_root in roots:
@@ -235,12 +244,17 @@ def _iter_candidate_paths(
             continue  # doesn't exist — skip per spec
 
         if stat.S_ISLNK(root_lstat.st_mode):
-            continue  # never follow symlinks, including at the root level
+            try:
+                resolved = Path(os.path.realpath(root))
+                root_lstat = os.stat(resolved)
+            except OSError:
+                continue  # broken or looping — same as a missing path
+            root = resolved
 
         if stats is not None:
             stats["roots_existing"] = stats.get("roots_existing", 0) + 1
         if stat.S_ISDIR(root_lstat.st_mode):
-            key = os.path.abspath(root)
+            key = os.path.realpath(root)
             if key in seen_dirs:
                 continue
             seen_dirs.add(key)

--- a/scripts/secrets_permissions_audit.py
+++ b/scripts/secrets_permissions_audit.py
@@ -272,27 +272,36 @@ def _iter_candidate_paths(
 # --------------------------------------------------------------------------
 
 
-def _dir_traversal(directory: str, _cache: dict = {}) -> Tuple[bool, bool]:
+def _dir_traversal(
+    directory: str, cache: Optional[dict] = None
+) -> Tuple[bool, bool]:
     """(group_can_traverse, other_can_traverse) for ONE directory.
 
     On any stat error the answer is (True, True): a guard that could not
     verify must never absolve (W106b — CANNOT-VERIFY is not the same as
-    clean). Cached because a fleet scan walks ~90k files over a few hundred
-    directories.
+    clean).
+
+    `cache` is supplied by the caller and lives for exactly one scan — a
+    fleet walk crosses ~90k files over a few hundred directories, so the
+    saving is real, but a cache that outlived the scan would be a stored
+    answer about a world that can change under it. Same reason the default
+    is None rather than a shared dict.
     """
-    hit = _cache.get(directory)
-    if hit is not None:
-        return hit
+    if cache is not None:
+        hit = cache.get(directory)
+        if hit is not None:
+            return hit
     try:
         mode = stat.S_IMODE(os.stat(directory).st_mode)
         result = (bool(mode & stat.S_IXGRP), bool(mode & stat.S_IXOTH))
     except OSError:
         result = (True, True)
-    _cache[directory] = result
+    if cache is not None:
+        cache[directory] = result
     return result
 
 
-def reachable_by(path: Path) -> Tuple[bool, bool]:
+def reachable_by(path: Path, cache: Optional[dict] = None) -> Tuple[bool, bool]:
     """(group, other) — can each actually walk down to this file?
 
     A 0644 file inside a 0700 directory is NOT in the clear: nobody but the
@@ -315,7 +324,7 @@ def reachable_by(path: Path) -> Tuple[bool, bool]:
     except OSError:
         return (True, True)
     while True:
-        can_group, can_other = _dir_traversal(str(directory))
+        can_group, can_other = _dir_traversal(str(directory), cache)
         group = group and can_group
         other = other and can_other
         if not (group or other) or directory.parent == directory:
@@ -339,6 +348,7 @@ def scan(
     """
     findings: List[Finding] = []
     seen_files: set = set()
+    traversal_cache: dict = {}  # one scan's worth — see _dir_traversal
 
     for candidate in _iter_candidate_paths(roots, max_depth, stats):
         key = os.path.abspath(candidate)
@@ -360,7 +370,7 @@ def scan(
 
         # The mode says who MAY read; the directory chain says who can get
         # here at all. Both have to be true for the file to be exposed.
-        can_group, can_other = reachable_by(candidate)
+        can_group, can_other = reachable_by(candidate, traversal_cache)
         exposed = (bool(mode_bits & 0o070) and can_group) or (
             bool(mode_bits & 0o007) and can_other
         )

--- a/scripts/tests/test_secrets_permissions_audit.py
+++ b/scripts/tests/test_secrets_permissions_audit.py
@@ -41,7 +41,7 @@ def _load_module(open_chain: bool = True) -> ModuleType:
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     if open_chain:
-        module.reachable_by = lambda path: (True, True)
+        module.reachable_by = lambda path, cache=None: (True, True)
     return module
 
 
@@ -341,7 +341,9 @@ def test_non_blind_clean_scan_exits_0(tmp_path, capsys):
 def _chain(module: ModuleType, monkeypatch: pytest.MonkeyPatch, table: dict) -> None:
     """Declare (group_x, other_x) per directory; anything absent is 0755."""
     monkeypatch.setattr(
-        module, "_dir_traversal", lambda d, _t=table: _t.get(d, (True, True))
+        module,
+        "_dir_traversal",
+        lambda d, cache=None, _t=table: _t.get(d, (True, True)),
     )
 
 
@@ -412,11 +414,11 @@ def test_scan_skips_a_readable_file_that_nobody_can_reach(tmp_path: Path) -> Non
     module = _load_module()
     secret = tmp_path / "credentials.env"
     secret.write_text("x")
-    os.chmod(secret, 0o644)
+    secret.chmod(0o644)
 
     monkeypatch = pytest.MonkeyPatch()
     try:
-        monkeypatch.setattr(module, "reachable_by", lambda p: (False, False))
+        monkeypatch.setattr(module, "reachable_by", lambda p, cache=None: (False, False))
         findings = module.scan([tmp_path])
     finally:
         monkeypatch.undo()
@@ -438,7 +440,7 @@ def test_a_symlinked_root_is_audited_not_silently_dropped(tmp_path: Path) -> Non
     real_dir.mkdir()
     secret = real_dir / "creds.env"
     secret.write_text("x")
-    os.chmod(secret, 0o644)
+    secret.chmod(0o644)
     link = tmp_path / "link"
     link.symlink_to(real_dir)
 
@@ -462,7 +464,7 @@ def test_a_symlink_met_during_the_walk_is_still_not_followed(tmp_path: Path) -> 
     outside.mkdir()
     outside_secret = outside / "creds.env"
     outside_secret.write_text("x")
-    os.chmod(outside_secret, 0o644)
+    outside_secret.chmod(0o644)
 
     root = tmp_path / "root"
     root.mkdir()
@@ -493,7 +495,7 @@ def test_the_real_root_and_its_symlink_are_walked_once(tmp_path: Path) -> None:
     real_dir.mkdir()
     secret = real_dir / "creds.env"
     secret.write_text("x")
-    os.chmod(secret, 0o644)
+    secret.chmod(0o644)
     link = tmp_path / "link"
     link.symlink_to(real_dir)
 
@@ -513,11 +515,11 @@ def test_scan_still_reports_the_same_file_when_the_chain_is_open(
     module = _load_module()
     secret = tmp_path / "credentials.env"
     secret.write_text("x")
-    os.chmod(secret, 0o644)
+    secret.chmod(0o644)
 
     monkeypatch = pytest.MonkeyPatch()
     try:
-        monkeypatch.setattr(module, "reachable_by", lambda p: (True, True))
+        monkeypatch.setattr(module, "reachable_by", lambda p, cache=None: (True, True))
         findings = module.scan([tmp_path])
     finally:
         monkeypatch.undo()

--- a/scripts/tests/test_secrets_permissions_audit.py
+++ b/scripts/tests/test_secrets_permissions_audit.py
@@ -18,7 +18,21 @@ import pytest
 _MODULE_PATH = Path(__file__).parents[1] / "secrets_permissions_audit.py"
 
 
-def _load_module() -> ModuleType:
+def _load_module(open_chain: bool = True) -> ModuleType:
+    """Load the auditor.
+
+    `open_chain=True` (the default) declares that every directory above the
+    file under test permits traversal. That is not decoration: macOS puts
+    pytest's `tmp_path` under a 0700 `/var/folders/.../T`, so a file written
+    there is unreachable BY CONSTRUCTION and `scan()` rightly ignores it.
+    Tests about name matching, mode bits, depth caps or output shape are not
+    tests about reachability — they say so here, rather than letting the
+    machine's own filesystem quietly decide their result (which would make
+    them pass in Linux CI and fail on every developer's Mac).
+
+    The reachability tests themselves pass `open_chain=False` and exercise
+    the real function.
+    """
     spec = importlib.util.spec_from_file_location(
         "secrets_permissions_audit", _MODULE_PATH
     )
@@ -26,6 +40,8 @@ def _load_module() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
+    if open_chain:
+        module.reachable_by = lambda path: (True, True)
     return module
 
 
@@ -308,3 +324,125 @@ def test_non_blind_clean_scan_exits_0(tmp_path, capsys):
     payload = _json.loads(capsys.readouterr().out)
     assert payload["blind"] is False
     assert payload["files_traversed"] >= 1
+
+
+# --------------------------------------------------------------------------
+# Effective reachability (2026-08-06): the mode says who MAY read, the
+# directory chain says who can get there. Both must hold for exposure.
+#
+# These tests declare the chain instead of inheriting the machine's, on
+# purpose: on macOS `/var/folders/.../T` is 0700, so anything written under
+# pytest's tmp_path is unreachable by construction. A test built on it would
+# pass its innocence case for a reason that has nothing to do with the code,
+# and fail its guilt case on every developer machine.
+# --------------------------------------------------------------------------
+
+
+def _chain(module: ModuleType, monkeypatch: pytest.MonkeyPatch, table: dict) -> None:
+    """Declare (group_x, other_x) per directory; anything absent is 0755."""
+    monkeypatch.setattr(
+        module, "_dir_traversal", lambda d, _t=table: _t.get(d, (True, True))
+    )
+
+
+def test_one_tight_directory_anywhere_in_the_chain_closes_the_path() -> None:
+    """INNOCENCE: the walk must go all the way up, not one level."""
+    module = _load_module(open_chain=False)
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        # The file's own directory is wide open; its GRANDparent is not.
+        _chain(module, monkeypatch, {"/a": (False, False)})
+        monkeypatch.setattr(Path, "resolve", lambda self: self)
+        group, other = module.reachable_by(Path("/a/b/c/creds.env"))
+    finally:
+        monkeypatch.undo()
+
+    assert (group, other) == (False, False)
+
+
+def test_a_fully_permissive_chain_stays_reachable() -> None:
+    """GUILT: without this the innocence test above could pass vacuously."""
+    module = _load_module(open_chain=False)
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        _chain(module, monkeypatch, {})
+        monkeypatch.setattr(Path, "resolve", lambda self: self)
+        group, other = module.reachable_by(Path("/a/b/c/creds.env"))
+    finally:
+        monkeypatch.undo()
+
+    assert (group, other) == (True, True)
+
+
+def test_group_and_other_are_judged_separately() -> None:
+    """A chain can admit the group and refuse everyone else."""
+    module = _load_module(open_chain=False)
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        _chain(module, monkeypatch, {"/a": (True, False)})
+        monkeypatch.setattr(Path, "resolve", lambda self: self)
+        group, other = module.reachable_by(Path("/a/b/creds.env"))
+    finally:
+        monkeypatch.undo()
+
+    assert group is True
+    assert other is False
+
+
+def test_unstattable_directory_is_treated_as_reachable() -> None:
+    """FAIL-CLOSED: cannot-verify is not clean (W106b).
+
+    A guard that answers 'unreachable' when it simply could not look would
+    absolve exactly the file it exists to catch.
+    """
+    module = _load_module(open_chain=False)
+
+    assert module._dir_traversal("/definitely/not/a/real/directory/xyzzy") == (
+        True,
+        True,
+    )
+
+
+def test_scan_skips_a_readable_file_that_nobody_can_reach(tmp_path: Path) -> None:
+    """INNOCENCE, end to end: 0644 under an unreachable chain is not a finding.
+
+    This is the class that made every fleet run report the same documentation
+    files forever, which is how a guard stops being read.
+    """
+    module = _load_module()
+    secret = tmp_path / "credentials.env"
+    secret.write_text("x")
+    os.chmod(secret, 0o644)
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(module, "reachable_by", lambda p: (False, False))
+        findings = module.scan([tmp_path])
+    finally:
+        monkeypatch.undo()
+
+    assert findings == []
+
+
+def test_scan_still_reports_the_same_file_when_the_chain_is_open(
+    tmp_path: Path,
+) -> None:
+    """GUILT, end to end, same file: only the chain differs.
+
+    Paired with the test above so that neither can pass because the file was
+    never a candidate in the first place.
+    """
+    module = _load_module()
+    secret = tmp_path / "credentials.env"
+    secret.write_text("x")
+    os.chmod(secret, 0o644)
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(module, "reachable_by", lambda p: (True, True))
+        findings = module.scan([tmp_path])
+    finally:
+        monkeypatch.undo()
+
+    assert [f.path.name for f in findings] == ["credentials.env"]
+    assert findings[0].mode == 0o644

--- a/scripts/tests/test_secrets_permissions_audit.py
+++ b/scripts/tests/test_secrets_permissions_audit.py
@@ -424,6 +424,84 @@ def test_scan_skips_a_readable_file_that_nobody_can_reach(tmp_path: Path) -> Non
     assert findings == []
 
 
+def test_a_symlinked_root_is_audited_not_silently_dropped(tmp_path: Path) -> None:
+    """GUILT: the caller NAMED this root; auditing nothing is not 'clean'.
+
+    Live case that found this: the memory directory every runbook cites,
+    `~/.claude/projects/<project>/memory`, is reached through two symlinks.
+    Auditing it returned count 0, roots_existing 0, exit 0 — a clean verdict
+    over zero files, with the blind-scan guard unable to fire because it
+    requires at least one root to exist.
+    """
+    module = _load_module()
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    secret = real_dir / "creds.env"
+    secret.write_text("x")
+    os.chmod(secret, 0o644)
+    link = tmp_path / "link"
+    link.symlink_to(real_dir)
+
+    stats: dict = {}
+    findings = module.scan([link], stats=stats)
+
+    assert [f.path.name for f in findings] == ["creds.env"]
+    assert stats["roots_existing"] == 1
+    assert stats["files_traversed"] == 1
+
+
+def test_a_symlink_met_during_the_walk_is_still_not_followed(tmp_path: Path) -> None:
+    """INNOCENCE: resolving a NAMED root must not loosen the walk itself.
+
+    Paired with the test above: a link the caller named is audited, a link
+    the walk stumbles into is not — that asymmetry is the whole point, and
+    without this test the fix could quietly become 'follow every symlink'.
+    """
+    module = _load_module()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_secret = outside / "creds.env"
+    outside_secret.write_text("x")
+    os.chmod(outside_secret, 0o644)
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "escape").symlink_to(outside)
+
+    findings = module.scan([root])
+
+    assert findings == []
+
+
+def test_a_broken_symlink_root_is_treated_as_a_missing_path(tmp_path: Path) -> None:
+    """A link to nowhere is the documented missing-root case, not a crash."""
+    module = _load_module()
+    dangling = tmp_path / "dangling"
+    dangling.symlink_to(tmp_path / "does-not-exist")
+
+    stats: dict = {}
+    findings = module.scan([dangling], stats=stats)
+
+    assert findings == []
+    assert stats.get("roots_existing", 0) == 0
+
+
+def test_the_real_root_and_its_symlink_are_walked_once(tmp_path: Path) -> None:
+    """Naming a directory twice, once through a link, must not double-report."""
+    module = _load_module()
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    secret = real_dir / "creds.env"
+    secret.write_text("x")
+    os.chmod(secret, 0o644)
+    link = tmp_path / "link"
+    link.symlink_to(real_dir)
+
+    findings = module.scan([real_dir, link])
+
+    assert len(findings) == 1
+
+
 def test_scan_still_reports_the_same_file_when_the_chain_is_open(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Two defects in the same guardian, found one from the other.

---

## 1. Exposure was judged by the file's mode alone

A `0644` file inside a `0700` directory is **not** in the clear — nobody but the owner can walk down to it. The mode says who *may* read; the directory chain says who can *get there*. Only both together answer the question this tool exists to ask.

The gap is not academic: it is what makes a guard emit the same unreadable files forever, until its output stops being read (superscar #2).

- `reachable_by(path)` walks every directory up to the root, returning `(group, other)` **separately**; one tight directory anywhere closes the path.
- `scan()` reports a file only when its mode grants a class **and** that class can traverse to it.
- `_dir_traversal()` answers `(True, True)` on any stat error — a guard that could not verify must never absolve (W106b: cannot-verify is not clean).
- **Declared limit, in the docstring rather than implied away**: this follows the resolved path only. A hard link from a permissive directory would still be reachable, and a path-based audit cannot see it.

### Proof

| | |
|---|---|
| mutation — chain walk replaced by `(True, True)` | **2 tests red** |
| mutation — reachability dropped from the `scan()` gate | **1 test red** |

**Control on a constructed pair** (home `0750`), two `0644` `creds.env`, one under a `0755` dir and one under `0700`:

```
OLD: 2 findings — both      NEW: 1 finding — the 0755 one only
```

**Control on the real surface**, a genuine memory file inside the `0700` memory dir, temporarily set to `0644` and restored:

```
OLD: 1 finding              NEW: 0 findings
```

The file it stops reporting is precisely the unreachable one; its reachable twin is still reported. Without that positive arm the innocence case would pass vacuously.

---

## 2. A symlinked root was dropped in silence — and the blind guard could not fire

Found while proving #1 on a real surface. Auditing `~/.claude/projects/<project>/memory` — the path CLAUDE.md, the `/subhi` skill and every runbook cite — returned:

```
count 0 · roots_existing 0 · blind false · exit 0
```

That directory is reached through **two** symlinks, and a symlink root was skipped with `continue` **before** the `roots_existing` counter. So the scan certified *clean* having opened nothing, and the blind-scan guard that exists to prevent exactly that could not fire, because its condition is `roots_existing > 0`.

A root is **named by the caller**; a link met during the walk is not, and only the latter can lure the walk out of the tree it was asked to audit. A root symlink is now resolved once and its target audited; everything met inside the walk is still never followed. Broken or looping links stay the documented missing-path case.

### Proof

| | |
|---|---|
| mutation — symlink roots dropped again | guilt test **red** |
| mutation — `os.walk(followlinks=True)` | innocence test **red** |

The second arm is not decoration: a fix for a false negative breeds the mirror false positive (W94). Without it this change could quietly become "follow everything".

**Live, same path, both arms:**

```
old: roots_existing 0, files_traversed 0,    exit 0   ← clean over nothing
new: roots_existing 1, files_traversed 1276, 0 findings
```

**Scope, measured rather than assumed**: no default root is a symlink on M5, Pro or Mini, so the fleet's default scans were never blind for this reason. The hole bit `--root` on the documented memory path.

---

## Why the reachability tests declare their chain

The four `_load_module(open_chain=False)` tests monkeypatch the per-directory answer. That is load-bearing: macOS puts pytest's `tmp_path` under a `0700` `/var/folders/.../T`, so anything written there is unreachable **by construction**. Left implicit, tests about name matching, mode bits, depth caps and output shape would have gone green in Linux CI and red on every Mac — for a reason with nothing to do with the code.

30 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)