### PR TITLE
fix(kbli): the citation check demanded an ownership basis from 173 codes whose citation states none

### DIFF
--- a/scripts/kbli_filiera/kbli_surface_conformance.py
+++ b/scripts/kbli_filiera/kbli_surface_conformance.py
@@ -97,7 +97,22 @@ PHANTOM_MARKER = "NOT_IN_KBLI_2025"
 # applied uniformly wherever no annex names the code — never flagged here,
 # because flagging it would just restate the pre-existing "no annex" default,
 # not surface new information.
-SPECIFIC_CITATION_BUCKETS = {"named-in-annex", "priority-lampiran-i"}
+#
+# `priority-lampiran-i` was in this set until 2026-08-06 and FAILED that very
+# test. Measured on the artifact: its 175 codes carry **exactly one distinct
+# cite** between them — "Perpres 49/2021 Lampiran I — priority business field
+# (Pasal 3(1)(a))" — which names no code, no percentage, no ownership treatment
+# (0 of its cites mention asing/%/foreign/modal). `named-in-annex` by contrast
+# has **61 distinct cites across 270 codes**, several carrying the KBLI-2020
+# crosswalk that earned the entry ("… via KBLI-2020 47911").
+#
+# So the check was demanding an adjudicated FOREIGN-OWNERSHIP basis for 173
+# codes whose citation asserts nothing about ownership — judging by which
+# bucket a code sits in rather than by what its citation actually says
+# (superscar #3). The compiler already knew: `perpres_body_default_relation.py`
+# records that priority listing "incentivises, it never restricts". A backlog
+# of 414 was really 241.
+SPECIFIC_CITATION_BUCKETS = {"named-in-annex"}
 
 SNAPSHOT_SQL = """
 SELECT coalesce(json_agg(json_build_object(

--- a/scripts/kbli_filiera/tests/test_kbli_surface_conformance.py
+++ b/scripts/kbli_filiera/tests/test_kbli_surface_conformance.py
@@ -291,12 +291,26 @@ def test_guilt_named_in_annex_with_no_canonical_basis():
     assert report["specific_citation_codes"] == 1
 
 
-def test_guilt_priority_lampiran_i_with_no_canonical_basis():
+def test_innocence_priority_lampiran_i_is_not_an_ownership_citation():
+    """This test asserted the OPPOSITE until 2026-08-06, and it was wrong.
+
+    Being listed in Lampiran I means the activity is a PRIORITY business field
+    — it attracts incentives; it states nothing about how much of it a foreigner
+    may own. `perpres_body_default_relation.py` says so in its own words
+    ("priority incentivises, it never restricts"), and the artifact agrees: all
+    175 codes in the bucket share ONE cite, which names no code, no percentage
+    and no ownership treatment.
+
+    So flagging them as "a citation the website shows and canonical lacks" was
+    demanding an adjudicated foreign-ownership basis for a fact nobody asserts
+    — 173 entries of a 414-entry backlog that were never real work.
+    """
     report = C.plan_citation_propagation(
-        store(canon("10211")),  # no pma_official_basis
+        store(canon("10211")),  # no pma_official_basis, and correctly not asked for
         {"10211": loc("priority-lampiran-i")},
     )
-    assert [d["code"] for d in report["citation_not_propagated"]] == ["10211"]
+    assert report["citation_not_propagated"] == []
+    assert report["specific_citation_codes"] == 0
 
 
 def test_innocence_generic_default_bucket_is_never_flagged():
@@ -370,3 +384,59 @@ def test_citation_not_propagated_folds_into_the_cli_exit_code(tmp_path):
         ]
     )
     assert rc == C.EXIT_DIVERGENCE
+
+
+# ---------------------------------------------------------------------------
+# The eligibility set must judge what a citation SAYS, not which bucket it is
+#
+# `priority-lampiran-i` sat in SPECIFIC_CITATION_BUCKETS until 2026-08-06 and
+# failed the very definition the constant's comment states. Its 175 codes share
+# ONE cite naming no code and no ownership treatment, so the detector demanded
+# an adjudicated foreign-ownership basis for 173 codes whose citation asserts
+# nothing about ownership. The structural test below is the general form: a
+# bucket whose codes all repeat a single string is generic BY MEASUREMENT,
+# whatever it is called, so the next such bucket cannot be added silently.
+# ---------------------------------------------------------------------------
+
+
+def _real_locators():
+    path = C.REPO_ROOT / "apps/mouth/data/perpres-locators.json"
+    if not path.exists():  # pragma: no cover - artifact always shipped
+        return None
+    return C.load_locators(path)
+
+
+def test_priority_listing_is_not_an_ownership_citation():
+    """GUILT, pinned on the live artifact: the excluded bucket really is the
+    degenerate case, and it really says nothing about foreign ownership."""
+    locators = _real_locators()
+    assert locators, "artifact missing — this pin cannot verify"
+
+    priority = [v for v in locators.values() if v.get("bucket") == "priority-lampiran-i"]
+    assert priority, "bucket vanished — re-derive this pin before deleting it"
+    assert len({v["cite"] for v in priority}) == 1, "no longer degenerate"
+    assert not any(
+        w in v["cite"].lower()
+        for v in priority
+        for w in ("asing", "%", "foreign", "modal", "ownership")
+    ), "priority cites now assert ownership — re-open the exclusion"
+    assert "priority-lampiran-i" not in C.SPECIFIC_CITATION_BUCKETS
+
+
+def test_every_eligible_bucket_is_code_named_by_measurement():
+    """INNOCENCE for the narrowing, and the tripwire for the NEXT bucket: what
+    stays in the set must earn it on the artifact, not by being named there.
+
+    `named-in-annex` passes with 61 distinct cites across 270 codes, several
+    carrying the KBLI-2020 crosswalk that earned the entry.
+    """
+    locators = _real_locators()
+    assert locators, "artifact missing — this pin cannot verify"
+
+    assert C.SPECIFIC_CITATION_BUCKETS, "an empty set would silently pass"
+    for bucket in C.SPECIFIC_CITATION_BUCKETS:
+        cites = {v["cite"] for v in locators.values() if v.get("bucket") == bucket}
+        assert len(cites) > 1, (
+            f"{bucket}: {len(cites)} distinct cite(s) — a single repeated string "
+            "is a generic default, not a code-named citation"
+        )


### PR DESCRIPTION
## The defect

`plan_citation_propagation` flags a code when the website shows a Perpres
citation that canonical's `pma_official_basis` lacks. It decided eligibility by
**bucket membership**, and `priority-lampiran-i` was in the eligible set.

**Measured on the shipped artifact, not argued:**

| bucket | codes | distinct cites | mentions ownership? |
|---|---|---|---|
| `priority-lampiran-i` | 175 | **1** | **0** of them (no `asing` / `%` / `foreign` / `modal`) |
| `named-in-annex` | 270 | **61** | yes — several carry the KBLI-2020 crosswalk that earned the entry |

Being listed in Lampiran I means the activity is a **priority business field** —
it attracts incentives. It says nothing about how much of it a foreigner may
own, and the compiler already records exactly that: *"priority incentivises, it
never restricts"* (`perpres_body_default_relation.py`).

The constant's own comment defines the set as buckets carrying *"a SPECIFIC,
code-named regulatory citation"*. **One string repeated across 175 codes fails
that definition on its face** — the check was judging by which bucket a code
sits in rather than by what its citation asserts (superscar #3).

## Effect

Backlog **445 eligible → 270**, **414 missing → 241**. The 173 that vanished
were never work: carrying a "priority business field" line into a
foreign-ownership basis field would have asserted something no instrument says
— on a client-facing surface.

## How it was found

I set out to do the **opposite** change — propagate the locator into canonical —
and sent the plan to a cross-family seat instructed to refute it. It returned
DEFECTIVE and pointed here, at a third thing neither of us had been looking at.
It also corrected two of my own premises (I called the 33 existing values
uniformly rich; ~20 are terse `Lampiran III entry #N`. I claimed 228 identical
`named-in-annex` cites; the real figure is 138 sharing the plain Lampiran II
text out of 61 distinct).

**I then re-derived the 175/1 and 270/61 counts on disk myself** rather than act
on the verdict — a refuter's verdict is a lead, not evidence (W65).

## Guards

- The existing `test_guilt_priority_lampiran_i_with_no_canonical_basis`
  **asserted the defect**. Rewritten as an innocence test with the reason
  recorded, not deleted.
- New **structural tripwire** pinning the general form: every bucket left in
  the eligible set must have **>1 distinct cite on the live artifact**, so a
  bucket that is generic *by measurement* cannot be re-added by being named.
- **Mutation-verified**: restoring the old set turns the suite red.
- 63 tests green.

## Not done here, and named

The 241 real `named-in-annex` gaps are still unpropagated, and the DB-backed
channels still cannot cite what the website shows. That work needs a consumer
map first (KG properties · the `inspect` response schema, which has no locator
field today · the Qdrant flat payload, read independently by chat · cache
eviction), so it is a separate PR rather than a rider on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)