### PR TITLE
fix(kbli): withdraw the 39-code K-UMKM patch — Lampiran II writes the scope on the parent row, and we only read the child

### DIFF
--- a/.agents/skills/kbli-navigator/SKILL.md
+++ b/.agents/skills/kbli-navigator/SKILL.md
@@ -888,9 +888,10 @@ promised; it now has a number.
 
 **THE STRUCTURAL FINDING, bigger than the 35: the cap attaches to the (bidang usaha, KBLI) PAIR, never
 to the code.** Entry 7 caps `30111` at 49% as a warship yard; entry 8 caps **the same code** at 0% as a
-builder of pinisi, cadik and traditional wooden vessels — and the body says so explicitly (art. 3(3):
-where one KBLI spans several bidang usaha, the requirement applies only to the bidang usaha named in the
-column). Our single `pma_max_asing` integer cannot express that, nor a phase-dependent cap (`58130`: 0%
+builder of pinisi, cadik and traditional wooden vessels — and the body says so explicitly (**Pasal 6 ayat (3)** for
+Lampiran III; the twin for Lampiran II is Pasal 5 ayat (5)): where one KBLI covers more than one bidang
+usaha, the requirement applies only to the bidang usaha named in that column. (Corrected 2026-08-06 at the
+source — this said `art. 3(3)`, which does not exist; Pasal 3 has two ayat.) Our single `pma_max_asing` integer cannot express that, nor a phase-dependent cap (`58130`: 0%
 at establishment, 49% via the capital market for expansion; broadcasting 20% likewise), nor a
 conditional one. **Any future cure that picks one number for such a code is asserting something the
 instrument does not say** — those codes are reported `ambiguous` and are not auto-patchable by

--- a/apps/backend-rag/backend/tests/unit/services/test_kbli_eye.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_kbli_eye.py
@@ -176,17 +176,25 @@ def test_cap_is_always_a_percentage_or_a_declared_gap(records: list[dict]) -> No
 
 
 def test_umkm_reserved_is_tri_state_and_rare(records: list[dict]) -> None:
-    """2 reserved / 1468 open / 89 undetermined — NOT 71 blanket True.
+    """41 reserved / 1429 open / 89 undetermined — NOT 71 blanket True.
 
     The split was 1488/69 until 2026-08-02, when the Perpres 49/2021 Lampiran III
     cure moved 20 codes out of TERBUKA (arms and ammunition, military vehicles,
     commercial air transport, the ferry family, couriers, umrah travel). They
     became `None` — undetermined — which is the honest verdict: leaving TERBUKA
     says nothing at all about a K-UMKM reservation.
+
+    2026-08-06: the Lampiran II cure NAMED 39 more codes as allocated, so True
+    goes 2 -> 41 and False 1468 -> 1429. `None` returning to 89 rather than
+    growing is the check that mattered: the first attempt wrote the marker as
+    `Dialokasikan` while `UMKM_ALLOCATION_MARKER` is `DIALOKASIKAN`, so all 39
+    read as UNDETERMINED — the fact was known and the data failed to say it.
+    Two writers of one vocabulary is how that happens; the reader's spelling is
+    the contract.
     """
     verdicts = [KBLIEye._umkm_reserved(r) for r in records]
-    assert verdicts.count(True) == 2
-    assert verdicts.count(False) == 1468
+    assert verdicts.count(True) == 41
+    assert verdicts.count(False) == 1429
     assert verdicts.count(None) == 89
     # The counts above are population pins and will move again with the data.
     # This one is the invariant underneath them, and it must not: `False` means
@@ -223,21 +231,45 @@ def test_the_cure_only_ever_shrinks_the_rejected_bucket(records: list[dict]) -> 
     new_rejected = {
         r["kode_kbli_2025"] for r in records if KBLIEye._foreign_cap(r)[0] == 0
     }
-    assert len(old_rejected) == 91
-    assert len(new_rejected) == 64
+    # 2026-08-06: the Perpres 49/2021 Lampiran II cure moved 39 codes out of
+    # TERBUKA at a 0% cap (activities the annex allocates to Koperasi/UMKM), so
+    # both buckets grew by the same 39: 91 -> 130 and 64 -> 103. The set that
+    # stops being wrongly rejected is untouched at 27, which is the point — the
+    # cure added restrictions the instrument states, it did not un-reject
+    # anything, and it did not reject anything the OLD rule would have passed.
+    assert len(old_rejected) == 130
+    assert len(new_rejected) == 103
     assert len(old_rejected - new_rejected) == 27
     # The counts above move with the data; THIS is the property that must not.
     assert new_rejected <= old_rejected, "the cure must never REJECT something new"
 
 
-def test_missing_cap_falls_back_to_status_not_to_zero(records: list[dict]) -> None:
-    """01122 (TERBUKA) carries no cap field — it must not read as 0%."""
-    no_cap = [r for r in records if "pma_max_asing" not in r]
-    assert len(no_cap) == 1
-    cap, basis, verified = KBLIEye._foreign_cap(no_cap[0])
+def test_missing_cap_falls_back_to_status_not_to_zero() -> None:
+    """A TERBUKA record with no cap field must read as 100%, never as 0%.
+
+    This used to run against `01122`, the one live record missing the field.
+    The 2026-08-06 Lampiran II cure wrote a cap onto it (Pertanian Padi Inbrida
+    is allocated to Koperasi/UMKM), so the catalogue now has **zero** such
+    records — and a test whose whole subject is "the field is absent" cannot be
+    pinned to a population a cure is free to empty. It is the FALLBACK RULE that
+    must hold, not one code's luck, so the record is now constructed here.
+
+    The live-population check moved to its own test below, which asserts the
+    count without depending on it being non-zero.
+    """
+    cap, basis, verified = KBLIEye._foreign_cap({"kode_kbli_2025": "00000", "pma_status": "TERBUKA"})
     assert cap == 100
     assert verified is False, "a status-derived figure is not an adjudicated one"
     assert basis is not None
+
+
+def test_every_live_record_now_carries_an_explicit_cap(records: list[dict]) -> None:
+    """Innocence for the cure above: it filled the last gap rather than leaving
+    a mixed population where some codes answer from a field and others from a
+    fallback. If a future record arrives without the field this goes red, which
+    is the signal to check that the fallback still reaches it."""
+    no_cap = [r["kode_kbli_2025"] for r in records if "pma_max_asing" not in r]
+    assert no_cap == [], f"records missing pma_max_asing: {no_cap[:5]}"
 
 
 # --------------------------------------------------------------------------

--- a/apps/backend-rag/backend/tests/unit/services/test_kbli_eye.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_kbli_eye.py
@@ -176,25 +176,17 @@ def test_cap_is_always_a_percentage_or_a_declared_gap(records: list[dict]) -> No
 
 
 def test_umkm_reserved_is_tri_state_and_rare(records: list[dict]) -> None:
-    """41 reserved / 1429 open / 89 undetermined — NOT 71 blanket True.
+    """2 reserved / 1468 open / 89 undetermined — NOT 71 blanket True.
 
     The split was 1488/69 until 2026-08-02, when the Perpres 49/2021 Lampiran III
     cure moved 20 codes out of TERBUKA (arms and ammunition, military vehicles,
     commercial air transport, the ferry family, couriers, umrah travel). They
     became `None` — undetermined — which is the honest verdict: leaving TERBUKA
     says nothing at all about a K-UMKM reservation.
-
-    2026-08-06: the Lampiran II cure NAMED 39 more codes as allocated, so True
-    goes 2 -> 41 and False 1468 -> 1429. `None` returning to 89 rather than
-    growing is the check that mattered: the first attempt wrote the marker as
-    `Dialokasikan` while `UMKM_ALLOCATION_MARKER` is `DIALOKASIKAN`, so all 39
-    read as UNDETERMINED — the fact was known and the data failed to say it.
-    Two writers of one vocabulary is how that happens; the reader's spelling is
-    the contract.
     """
     verdicts = [KBLIEye._umkm_reserved(r) for r in records]
-    assert verdicts.count(True) == 41
-    assert verdicts.count(False) == 1429
+    assert verdicts.count(True) == 2
+    assert verdicts.count(False) == 1468
     assert verdicts.count(None) == 89
     # The counts above are population pins and will move again with the data.
     # This one is the invariant underneath them, and it must not: `False` means
@@ -231,45 +223,21 @@ def test_the_cure_only_ever_shrinks_the_rejected_bucket(records: list[dict]) -> 
     new_rejected = {
         r["kode_kbli_2025"] for r in records if KBLIEye._foreign_cap(r)[0] == 0
     }
-    # 2026-08-06: the Perpres 49/2021 Lampiran II cure moved 39 codes out of
-    # TERBUKA at a 0% cap (activities the annex allocates to Koperasi/UMKM), so
-    # both buckets grew by the same 39: 91 -> 130 and 64 -> 103. The set that
-    # stops being wrongly rejected is untouched at 27, which is the point — the
-    # cure added restrictions the instrument states, it did not un-reject
-    # anything, and it did not reject anything the OLD rule would have passed.
-    assert len(old_rejected) == 130
-    assert len(new_rejected) == 103
+    assert len(old_rejected) == 91
+    assert len(new_rejected) == 64
     assert len(old_rejected - new_rejected) == 27
     # The counts above move with the data; THIS is the property that must not.
     assert new_rejected <= old_rejected, "the cure must never REJECT something new"
 
 
-def test_missing_cap_falls_back_to_status_not_to_zero() -> None:
-    """A TERBUKA record with no cap field must read as 100%, never as 0%.
-
-    This used to run against `01122`, the one live record missing the field.
-    The 2026-08-06 Lampiran II cure wrote a cap onto it (Pertanian Padi Inbrida
-    is allocated to Koperasi/UMKM), so the catalogue now has **zero** such
-    records — and a test whose whole subject is "the field is absent" cannot be
-    pinned to a population a cure is free to empty. It is the FALLBACK RULE that
-    must hold, not one code's luck, so the record is now constructed here.
-
-    The live-population check moved to its own test below, which asserts the
-    count without depending on it being non-zero.
-    """
-    cap, basis, verified = KBLIEye._foreign_cap({"kode_kbli_2025": "00000", "pma_status": "TERBUKA"})
+def test_missing_cap_falls_back_to_status_not_to_zero(records: list[dict]) -> None:
+    """01122 (TERBUKA) carries no cap field — it must not read as 0%."""
+    no_cap = [r for r in records if "pma_max_asing" not in r]
+    assert len(no_cap) == 1
+    cap, basis, verified = KBLIEye._foreign_cap(no_cap[0])
     assert cap == 100
     assert verified is False, "a status-derived figure is not an adjudicated one"
     assert basis is not None
-
-
-def test_every_live_record_now_carries_an_explicit_cap(records: list[dict]) -> None:
-    """Innocence for the cure above: it filled the last gap rather than leaving
-    a mixed population where some codes answer from a field and others from a
-    fallback. If a future record arrives without the field this goes red, which
-    is the signal to check that the fallback still reaches it."""
-    no_cap = [r["kode_kbli_2025"] for r in records if "pma_max_asing" not in r]
-    assert no_cap == [], f"records missing pma_max_asing: {no_cap[:5]}"
 
 
 # --------------------------------------------------------------------------

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "bb2b8d12a25bfc8eba11ef481a8d3ef9eaa5a55a",
-  "canonical_sha256": "76b31f95a06262aefc659a90f6c624be17b215ef9c69c7f043f2575038e5d4a7",
+  "canonical_revision": "a3a924916832791be251fb844be2dc5de6db66b7",
+  "canonical_sha256": "4a11b1c01d858e3b3837dc43cb2a8bf376765d3cb58de93910cfc0f3f695261b",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "1edc0829b8191a7128ada82a67e562e062aeec28",
-  "canonical_sha256": "b7d38c628fb749dc82aece71c8275cd8feae71640b2eca50d09b10de3895644b",
+  "canonical_revision": "32a9ca6d2fa7f7921ebac40c7966f9f86c22b613",
+  "canonical_sha256": "16629d893301d677a2a1000fb7f91c6ac1e361fd81cac5cd3fe0ccec811a71b5",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "32a9ca6d2fa7f7921ebac40c7966f9f86c22b613",
-  "canonical_sha256": "16629d893301d677a2a1000fb7f91c6ac1e361fd81cac5cd3fe0ccec811a71b5",
+  "canonical_revision": "bb2b8d12a25bfc8eba11ef481a8d3ef9eaa5a55a",
+  "canonical_sha256": "76b31f95a06262aefc659a90f6c624be17b215ef9c69c7f043f2575038e5d4a7",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "a3a924916832791be251fb844be2dc5de6db66b7",
-  "canonical_sha256": "4a11b1c01d858e3b3837dc43cb2a8bf376765d3cb58de93910cfc0f3f695261b",
+  "canonical_revision": "1edc0829b8191a7128ada82a67e562e062aeec28",
+  "canonical_sha256": "b7d38c628fb749dc82aece71c8275cd8feae71640b2eca50d09b10de3895644b",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/data/kbli-filiera/perpres-umkm-reservation.json
+++ b/data/kbli-filiera/perpres-umkm-reservation.json
@@ -61,6 +61,7 @@
    "column": "dialokasikan",
    "page": 1,
    "text": "Jagung",
+   "parent_heading": "Pertanian tanaman pangan dengan luas kurang dari 25 Ha",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -69,6 +70,7 @@
    "column": "dialokasikan",
    "page": 1,
    "text": "Kedelai",
+   "parent_heading": "Pertanian tanaman pangan dengan luas kurang dari 25 Ha",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -77,6 +79,7 @@
    "column": "dialokasikan",
    "page": 1,
    "text": "Kacang tanah",
+   "parent_heading": "Pertanian tanaman pangan dengan luas kurang dari 25 Ha",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -85,6 +88,7 @@
    "column": "dialokasikan",
    "page": 1,
    "text": "Kacang hijau",
+   "parent_heading": "Pertanian tanaman pangan dengan luas kurang dari 25 Ha",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -93,6 +97,7 @@
    "column": "dialokasikan",
    "page": 1,
    "text": "Padi hibrida",
+   "parent_heading": "Pertanian tanaman pangan dengan luas kurang dari 25 Ha",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -101,6 +106,7 @@
    "column": "dialokasikan",
    "page": 1,
    "text": "Padi inbrida",
+   "parent_heading": "Pertanian tanaman pangan dengan luas kurang dari 25 Ha",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -109,6 +115,7 @@
    "column": "dialokasikan",
    "page": 1,
    "text": "Getah pinus",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -117,6 +124,7 @@
    "column": "dialokasikan",
    "page": 1,
    "text": "Bambu SK I.Jo 054161C",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -125,6 +133,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Rotan",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -133,6 +142,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Daun kayu putih",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -141,6 +151,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Kokon/kepompong ulat sutra (persutraan alam)",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -149,6 +160,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Damar",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -157,6 +169,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Madu",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -165,6 +178,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "kulit kayu lawang, kayu manis, getah-getahan lainya, sarang burung walet di alam dan perlebahan lain-lain",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -173,6 +187,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Industri pemindangan ikan",
+   "parent_heading": "Pemungutan hasil hutan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -181,6 +196,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Industri tempe kedelai",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -189,6 +205,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Industri tahu kedelai",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -197,6 +214,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Industri gula merah",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -205,6 +223,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Industri makanan dan masakan olahan: Rendang",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -213,6 +232,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "mendapatkan indikasi geografis: Garam Amed Bali",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -221,6 +241,7 @@
    "column": "dialokasikan",
    "page": 3,
    "text": "Industri kerupuk, keripik, peyek dan seienisnya (pabrikan dan non pabrikan)",
+   "parent_heading": null,
    "read_from": "page-image",
    "title_corroborated": true
   },
@@ -229,6 +250,7 @@
    "column": "dialokasikan",
    "page": 3,
    "text": "Industri pertenunan cual Industri pertenunan ulap doyo Industri pertenunan tenun grinsing Industri tenun tapis",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -237,6 +259,7 @@
    "column": "dialokasikan",
    "page": 3,
    "text": "Industri kain tenun ikat",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -245,6 +268,7 @@
    "column": "dialokasikan",
    "page": 3,
    "text": "Industri batik: Industri batik tulis Industri batik kombinasi tulis dan cap l2    Industri kain sulaman/ bordir, yaitu: Industri kain karawo",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -253,6 +277,7 @@
    "column": "dialokasikan",
    "page": 3,
    "text": "Industri kain karancang Industri kain sulam usus Industri kain sulaman/bordir lainnya yang dikerjakan tidak dengan mesin",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -261,6 +286,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "Industri ikat kepala tradisional Industri ikat pinggang tradisional Industri pembuatan mukena",
+   "parent_heading": null,
    "read_from": "page-image",
    "title_corroborated": false
   },
@@ -269,6 +295,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "Industri ikat kepala tradisional Industri ikat pinggang tradisional Industri pembuatan mukena",
+   "parent_heading": null,
    "read_from": "page-image",
    "title_corroborated": false
   },
@@ -277,6 +304,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "Rotan dan bambu Anyaman dari tanaman pandan, agel, mendong, ketak,",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -285,6 +313,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "purun, eceng gondok, keladi air Industri alat-alat dapur dari kayu, rotan dan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -293,6 +322,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "Industri kerajinan ukiran dari kayu bukan mebeller ukiran kayu, relief, topeng, patung, wayang",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -301,6 +331,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "bambu",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -309,6 +340,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "lainnya YTDL t7     Usaha bidang obat tradisional (usaha kecil obat",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -317,6 +349,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "tradisional/UKoT dan usaha mikro obat tradisional/UMOT)",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -325,6 +358,7 @@
    "column": "dialokasikan",
    "page": 4,
    "text": "Industri pengasapan karet",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -333,6 +367,7 @@
    "column": "dialokasikan",
    "page": 5,
    "text": "5 DLALOI T'I No.                          BIDAI{G USAHA                                 I{BLI KOPERA TI t9    Industri perlengkapan rumah tangga dari tanah liat/keramik, berupa: Gerabah Keramik hias",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -341,6 +376,7 @@
    "column": "dialokasikan",
    "page": 5,
    "text": "Bajak Garu Sabit Ani-ani Dodos Egreg Pisau sadap karet 2l    Industri alat potong dan perkakas tangan pertukangan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -349,6 +385,7 @@
    "column": "dialokasikan",
    "page": 5,
    "text": "Perkakas tangan yang diproses secara manual atau semi mekanik untuk pertukangan dan pemotongarn",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -357,6 +394,7 @@
    "column": "dialokasikan",
    "page": 5,
    "text": "Keris Rencong Mandau",
+   "parent_heading": "Industri peralatan umum, berupa",
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -365,6 +403,7 @@
    "column": "dialokasikan",
    "page": 6,
    "text": "Dambus dari Bangka Belitung Kolintang dari Minahasa Gendang Beleq dari NTB Sasando dari NTT Tifa dari Papua",
+   "parent_heading": "Industri alat musik tradisional antara lain",
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -373,6 +412,7 @@
    "column": "dialokasikan",
    "page": 6,
    "text": "Penyediaan tenaga listrik untuk pembangkit listrik < 1 MW",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -381,6 +421,7 @@
    "column": "dialokasikan",
    "page": 6,
    "text": "madya: geduns tempat tinegal gedung perbelanjaan meliputi toserba, toko, rumah toko (ruko) dan warung",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -389,6 +430,7 @@
    "column": "dialokasikan",
    "page": 6,
    "text": "geduns tempat tinegal gedung perbelanjaan meliputi toserba, toko, rumah toko (ruko) dan warung gedung kesehatan meliputi puskesmas, balai pengobatan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -397,6 +439,7 @@
    "column": "dialokasikan",
    "page": 6,
    "text": "dan gedung pelayanan kesehatan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -405,6 +448,7 @@
    "column": "dialokasikan",
    "page": 7,
    "text": "gedung pendidikan meliputi sarana pendidikan, tempat kursus, laboratorium dan bangunan penunjang pendidikan lainnya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -413,6 +457,7 @@
    "column": "dialokasikan",
    "page": 7,
    "text": "gedung penginapan meliputi hostel dan losmen",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -421,6 +466,7 @@
    "column": "dialokasikan",
    "page": 7,
    "text": "gedung tempat hiburan dan olahraga meliputi bioskop, gedung kebudayaan/kesenian, gedung wisata dan rekreasi serta gedung olahraga",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -429,6 +475,7 @@
    "column": "dialokasikan",
    "page": 7,
    "text": "gedung lainnya meliputi tempat ibadah, gedung balai pertemuan, gudang, gedung genset, rumah pompa, depo, gedung gardu listrik, dan gedung gardu sinyal",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -437,6 +484,7 @@
    "column": "dialokasikan",
    "page": 7,
    "text": "jasa pekerjaan konstruksi prafabrikasi bangunan gedung meliputi pemasangan bahan hasil produksi pabrik seperti beton pracetak, baja, plastik, karet, dan hasil produksi pabrik lainnya dengan metode pabrikasi, erection, dan/atau perakitan untuk bangunan gedung",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -445,6 +493,7 @@
    "column": "dialokasikan",
    "page": 7,
    "text": "Konstruksi bangunan sipil jalan meliputi pemeliharaan, bangunan jalan raya yang menggunakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -453,6 +502,7 @@
    "column": "dialokasikan",
    "page": 7,
    "text": "Konstruksi jaringan irigasi yang menggunakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -461,6 +511,7 @@
    "column": "dialokasikan",
    "page": 8,
    "text": "bangunan pengolahan, penyaluran dan penampungan air minum",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -469,6 +520,7 @@
    "column": "dialokasikan",
    "page": 8,
    "text": "penampungan air limbah dan/atau risiko kecil dan sedang",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -477,6 +529,7 @@
    "column": "dialokasikan",
    "page": 8,
    "text": "sederhana dan 3l( No 054181 C",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -485,6 +538,7 @@
    "column": "dialokasikan",
    "page": 8,
    "text": "Konstruksi telekomunikasi navigasi udara yang menggunakan teknologi sederhana dan madya Konstruksi sinyal dan telekomunikasi kereta api yang mengglrnakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -493,6 +547,7 @@
    "column": "dialokasikan",
    "page": 8,
    "text": "sederhana dan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -501,6 +556,7 @@
    "column": "dialokasikan",
    "page": 8,
    "text": "sederhana dan       'a",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -509,6 +565,7 @@
    "column": "dialokasikan",
    "page": 9,
    "text": "Pemasangan bangunan prafabrikasi untuk konstruksi jaringan saluran irigasi, komunikasi dan limbah yang menggunakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -517,6 +574,7 @@
    "column": "dialokasikan",
    "page": 9,
    "text": "Konstruksi bangunan yang menggunakan teknologi sederhana dan madya: sumber daya air pelabuhan bukan perikanan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -525,6 +583,7 @@
    "column": "dialokasikan",
    "page": 9,
    "text": "pelabuhan bukan perikanan pelabuhan perikanan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -533,6 +592,7 @@
    "column": "dialokasikan",
    "page": 9,
    "text": "pelabuhan perikanan",
+   "parent_heading": null,
    "read_from": "page-image",
    "title_corroborated": true
   },
@@ -541,6 +601,7 @@
    "column": "dialokasikan",
    "page": 9,
    "text": "Pemasangan bangunan prafabrikasi untuk konstruksi bangunan sipil lainnya yang menggunakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -549,6 +610,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -557,6 +619,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -565,6 +628,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "instalasi penyediaan tenaga listrik: Tegangan rendah/menengah",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -573,6 +637,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "Instalasi yang menggunakan teknologi sederhana dan madya: telekomunikasi sinyal dan telekomunikasi kereta api",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -581,6 +646,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "elektronika saluran air Qtlambingl",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -589,6 +655,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "sinyal dan telekomunikasi kereta api",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -597,6 +664,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "sinyal dan rambu-rambu jalan raya elektronika",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -605,6 +673,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "saluran air Qtlambingl pemanas dan geotermal",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -613,6 +682,7 @@
    "column": "dialokasikan",
    "page": 10,
    "text": "pemanas dan geotermal",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -621,6 +691,7 @@
    "column": "dialokasikan",
    "page": 11,
    "text": "11 DIALO U I[o.                          BIDA!5G USNIA                                KBLI KOPER T minyak dan gas pendingin dan ventilasi udara",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -629,6 +700,7 @@
    "column": "dialokasikan",
    "page": 11,
    "text": "pendingin dan ventilasi udara mekanikal",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -637,6 +709,7 @@
    "column": "dialokasikan",
    "page": 11,
    "text": "mekanikal konstruksi lainnya YTDL meliputi pemasangan dan pemeliharaan instalasi fasilitas pertambangan dan manufaktur seperti loading and discharging stations,",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "page-image",
    "title_corroborated": true
   },
@@ -645,6 +718,7 @@
    "column": "dialokasikan",
    "page": 11,
    "text": "winding shafis, chemical plants, ironfoundaies, blast furnaces dan coke ouen; pemasangan instalasi sistem pengolahan dan peralatan pemurnian air laut, air payau, air tawar menjadi air murni pada pembangkit listrik",
+   "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -653,6 +727,7 @@
    "column": "dialokasikan",
    "page": 11,
    "text": "Pengerjaan yang menggunakan teknologi sederhana dan madya: pemasangan kaca dan aluminium lantai, dinding, peralatan saniter dan plafon",
+   "parent_heading": "Pengerjaan yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -661,6 +736,7 @@
    "column": "dialokasikan",
    "page": 11,
    "text": "lantai, dinding, peralatan saniter dan plafon pengecatan",
+   "parent_heading": "Pengerjaan yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -669,6 +745,7 @@
    "column": "dialokasikan",
    "page": 11,
    "text": "pengecatan",
+   "parent_heading": "Pengerjaan yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -677,6 +754,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "Dekorasi yang menggunakan teknologi sederhana dan madya lnterior Eksterior",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -685,6 +763,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "Eksterior Penyelesaian konstruksi bangunan lainnya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -693,6 +772,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "Penyelesaian konstruksi bangunan lainnya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -701,6 +781,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "Pemasangan kontruksi yang menggunakan teknologi sederhana dan madya: Pemasangan pondasi dan tiang pancang Pemasangan perancah (steigefi",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -709,6 +790,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "Pemasangan perancah (steigefi Pemasangan atap I roof coueing",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -717,6 +799,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "Pemasangan atap I roof coueing Kerangka baja",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -725,6 +808,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "Kerangka baja Penyewaan alat konstruksi dengan operator yang",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -733,6 +817,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "Penyewaan alat konstruksi dengan operator yang menggunakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -741,6 +826,7 @@
    "column": "dialokasikan",
    "page": 12,
    "text": "sederhana dan madya yang belum diklasifikasikan dalam kelompok 43901 s.d.",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -749,6 +835,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "yang terintegrasi dengan bidang usaha penjualan sepeda motor",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -757,6 +844,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Minimarket",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -765,6 +853,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Bukan di toserba atau departement store",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -773,6 +862,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Minuman tidak beralkohol",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -781,6 +871,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Beras",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -789,6 +880,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Roti, kue kering, serta kue basah dan sejenisnya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -797,6 +889,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Kopi, gula pasir dan gula merah",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -805,6 +898,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Tahu, tempe, tauco dan oncom",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -813,6 +907,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Daging dan ikan olahan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -821,6 +916,7 @@
    "column": "dialokasikan",
    "page": 13,
    "text": "Barang dan obat farmasi untuk manusia di apotik",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -829,6 +925,7 @@
    "column": "dialokasikan",
    "page": 14,
    "text": "Makanan lainnya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -837,6 +934,7 @@
    "column": "dialokasikan",
    "page": 14,
    "text": "Alas kaki",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -845,6 +943,7 @@
    "column": "dialokasikan",
    "page": 14,
    "text": "'B\"rt\"t dan obat farmasi untuk manusia bukan di apotik",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -853,6 +952,7 @@
    "column": "dialokasikan",
    "page": 14,
    "text": "minuman, tembakau, kimia, farmasi, kosmetik dan alat laboratorium",
+   "parent_heading": null,
    "read_from": "page-image",
    "title_corroborated": true
   },
@@ -861,6 +961,7 @@
    "column": "dialokasikan",
    "page": 14,
    "text": "Perdagangan eceran melalui media untuk komoditi tekstil, pakaian, alas kaki, dan barang keperluan pribadi",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -869,6 +970,7 @@
    "column": "dialokasikan",
    "page": 14,
    "text": "Perdagangan eceran melalui media untuk barang perlengkapan rumah tangga dan perlengkapan dapur",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -877,6 +979,7 @@
    "column": "dialokasikan",
    "page": 14,
    "text": "Hotel Bintang I",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -885,6 +988,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Hotel Melati",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -893,6 +997,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Pondok Wisata",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -901,6 +1006,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Vila",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -909,6 +1015,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Guest House",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -917,6 +1024,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -925,6 +1033,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -933,6 +1042,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Aktivitas keinsinyuran dan konsultansi teknis YBDI yang menggunakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -941,6 +1051,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Jasa pengujian laboratorium yang menggunakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -949,6 +1060,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "penyediaan tenaga listrik atau pemanfaatan tenaga listrik: Tenaga listrik tegangan rendah/ menengah",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -957,6 +1069,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Jasa inspeksi teknik instalasi yang menggunakan teknologi sederhana dan madya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -965,6 +1078,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Aktivitas agen perialanan wisata",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -973,6 +1087,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Jasa pramuwisata",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -981,6 +1096,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Aktivitas jasa Foto kopi, penyiapan dokumen dan jasa khusus penuniang kantor lainnya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -989,6 +1105,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "(residential health seruices) dan sarana pelayanan kesehatan dasar",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -997,6 +1114,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Reparasi peralatan: Peralatan rumah tangga dan Peralatan rumah dan kebun",
+   "parent_heading": "Reparasi peralatan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1005,6 +1123,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Vermak pakaian",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1013,6 +1132,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Industri reparasi barang rumah tangga dan pribadi lainnya St( No 054256 C",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1021,6 +1141,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Pangkas rambut/ barber shop",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1029,6 +1150,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Salon kecantikan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1037,6 +1159,7 @@
    "column": "dialokasikan",
    "page": 16,
    "text": "Penatu",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1045,6 +1168,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Budidaya ayarn ras pedaginC FS)",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -1053,6 +1177,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Ikan laut",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1061,6 +1186,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Ikan laut",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1069,6 +1195,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Ikan air tawar",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1077,6 +1204,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Ikan air tawar",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1085,6 +1213,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Ikan air payau",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1093,6 +1222,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Ikan air payau",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1101,6 +1231,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Usaha produksi/ ekstraksi garam",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1109,6 +1240,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "perairan lainnya",
+   "parent_heading": "Usaha pengolahan hasil perikanan (UPI)",
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -1117,6 +1249,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Pengasapan ikan dan biota perairan lainnya Peragian/fermentasi ikan dan produk masak lainnya (untuk",
+   "parent_heading": "Usaha pengolahan hasil perikanan (UPI)",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1125,6 +1258,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "Peragian/fermentasi ikan dan produk masak lainnya (untuk usaha ekstraksi dan ielly ikan) Industri berbasis daging lumatan dan surimi",
+   "parent_heading": "Usaha pengolahan hasil perikanan (UPI)",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1133,6 +1267,7 @@
    "column": "kemitraan",
    "page": 17,
    "text": "usaha ekstraksi dan ielly ikan) Industri berbasis daging lumatan dan surimi",
+   "parent_heading": "Usaha pengolahan hasil perikanan (UPI)",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1141,6 +1276,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Pengalengan ikan",
+   "parent_heading": "Usaha pengolahan hasil perikanan (UPI)",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1149,6 +1285,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri             buah-buahan dan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1157,6 +1294,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri kopra",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1165,6 +1303,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri pengolahan suqu bubuk dan susu kental",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1173,6 +1312,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -1181,6 +1321,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "7l     lnQustri kecap",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1189,6 +1330,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "kecgp, tempe dan tahu",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1197,6 +1339,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri kayu gergajian dengan kapasitas produksi sampai {engan kurang dari 2OO0 m3 per tahun",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1205,6 +1348,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "qqle4isnya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -1213,6 +1357,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri pengollrhan rotan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1221,6 +1366,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri               briket kela",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -1229,6 +1375,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri minyak atsiri",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1237,6 +1384,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri alat kesehatan kelas A",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1245,6 +1393,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri batu bata dan tanah      keramik",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1253,6 +1402,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri barang lainnya dari tanah liat/keramik",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1261,6 +1411,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri kapur",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1269,6 +1420,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri serat sabut kelapa",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1277,6 +1429,7 @@
    "column": "kemitraan",
    "page": 19,
    "text": "Industri barang-barang dari semen",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1285,6 +1438,7 @@
    "column": "kemitraan",
    "page": 19,
    "text": "Industri barang-barang dari kapur",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1293,6 +1447,7 @@
    "column": "kemitraan",
    "page": 19,
    "text": "Industri barang-barang dari semen dan kapur lainnya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1301,6 +1456,7 @@
    "column": "kemitraan",
    "page": 19,
    "text": "Industri paku, mur, dan baut",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1309,6 +1465,7 @@
    "column": "kemitraan",
    "page": 19,
    "text": "Industri komponen dan suku cadang mesin dan turbin",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1317,6 +1474,7 @@
    "column": "kemitraan",
    "page": 19,
    "text": "Industri pompa lainnya, kompressor, kran, dan klep/katup",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1325,6 +1483,7 @@
    "column": "kemitraan",
    "page": 19,
    "text": "dan kotak kemudi; suku cadang dan aksesori untuk bodi karoseri kendaraan bermotor, seperti sabuk pengaman, pintu, bamper, airbag; tempat duduk mobil; peralatan listrik kendaraan bermotor, seperti generator, alternator, bus| ignition wiing hnrnesses/ starter, sistem buka tutup pintu dan jendela otomatis, pemasangan argometer ke dalam panel instrumen, penRatur uoltase",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1333,6 +1492,7 @@
    "column": "kemitraan",
    "page": 19,
    "text": "Industri komponen dan perlengkapan kendaraan bermotor roda dua dan tiga",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1341,6 +1501,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "Industri peralatan dan perlengkapan kapal kayu untuk wisata bahari dan penangkapan ikan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1349,6 +1510,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "Industri permata",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1357,6 +1519,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "dari logam mulia",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1365,6 +1528,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "Industri barang perhiasan berharga bukan untuk keperluan pribadi dari losam mulia",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1373,6 +1537,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "Industri perhiasan imitasi dan barang seienis",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1381,6 +1546,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "Industri kerajinan yang tidak diklasifikasikan di tempat lain",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1389,6 +1555,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "Jasa reparasi kapal, perahu dan bangunan terapung",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1397,6 +1564,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "Jasa reparasi alat angkutan lainnya, bukan kendaraan bermotor",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1405,6 +1573,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "Industri daur ulang barang-barang bukan logam",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1413,6 +1582,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "gedung perkantoran gedung industri",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1421,6 +1591,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "gedung industri SK tJo 05,1024C",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1429,6 +1600,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "Konstruksi jembatan dan jalan layang yang menggunakan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1437,6 +1609,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "dan ekspor hasil perikanan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1445,6 +1618,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "ro2.   Aktivitas agen kurir",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1453,6 +1627,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "Konsultasi di bidang instalasi tenaga listrik",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1461,6 +1636,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "Alat transportasi darat (rental tuithaut operatofl",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1469,6 +1645,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "Mesin pertanian dan peralatannya",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1477,6 +1654,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "Mesin kantor dan peralatannya Mesin lainnya dan peralatannya yang tidak diklasifikasikan di",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1485,6 +1663,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "tempat lain (pembangkit tenaga listrik, tekstil, pengolahan/ pengerjaan logam/ kayu, percetakan, dan las listrik)",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -1493,6 +1672,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "Laboratorium kesehatan klinik",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1501,6 +1681,7 @@
    "column": "dialokasikan",
    "page": 22,
    "text": "Peralatan komunikasi",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   }

--- a/data/kbli-filiera/perpres-umkm-reservation.json
+++ b/data/kbli-filiera/perpres-umkm-reservation.json
@@ -37,7 +37,7 @@
   "unresolved": 0,
   "dialokasikan": 124,
   "kemitraan": 57,
-  "title_corroborated": 159,
+  "title_corroborated": 158,
   "text_cell_missing": 0
  },
  "tick_x_histogram": {
@@ -573,7 +573,7 @@
    "code": "42911",
    "column": "dialokasikan",
    "page": 9,
-   "text": "Konstruksi bangunan yang menggunakan teknologi sederhana dan madya: sumber daya air pelabuhan bukan perikanan",
+   "text": "Konstruksi bangunan yang menggunakan teknologi sederhana dan madya: sumber daya air",
    "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
@@ -582,7 +582,7 @@
    "code": "42912",
    "column": "dialokasikan",
    "page": 9,
-   "text": "pelabuhan bukan perikanan pelabuhan perikanan",
+   "text": "pelabuhan bukan perikanan",
    "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
@@ -636,7 +636,7 @@
    "code": "43212",
    "column": "dialokasikan",
    "page": 10,
-   "text": "Instalasi yang menggunakan teknologi sederhana dan madya: telekomunikasi sinyal dan telekomunikasi kereta api",
+   "text": "telekomunikasi sinyal dan telekomunikasi kereta api",
    "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
@@ -690,7 +690,7 @@
    "code": "43223",
    "column": "dialokasikan",
    "page": 11,
-   "text": "11 DIALO U I[o.                          BIDA!5G USNIA                                KBLI KOPER T minyak dan gas pendingin dan ventilasi udara",
+   "text": "DIALO U I[o.                          BIDA!5G USNIA                                KBLI KOPER T minyak dan gas pendingin dan ventilasi udara",
    "parent_heading": "Instalasi yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
@@ -726,7 +726,7 @@
    "code": "43301",
    "column": "dialokasikan",
    "page": 11,
-   "text": "Pengerjaan yang menggunakan teknologi sederhana dan madya: pemasangan kaca dan aluminium lantai, dinding, peralatan saniter dan plafon",
+   "text": "pemasangan kaca dan aluminium lantai, dinding, peralatan saniter dan plafon",
    "parent_heading": "Pengerjaan yang menggunakan teknologi sederhana dan madya",
    "read_from": "text-layer",
    "title_corroborated": true
@@ -753,10 +753,10 @@
    "code": "43304",
    "column": "dialokasikan",
    "page": 12,
-   "text": "Dekorasi yang menggunakan teknologi sederhana dan madya lnterior Eksterior",
+   "text": "lnterior Eksterior",
    "parent_heading": null,
    "read_from": "text-layer",
-   "title_corroborated": true
+   "title_corroborated": false
   },
   {
    "code": "43305",
@@ -1131,7 +1131,7 @@
    "code": "95299",
    "column": "dialokasikan",
    "page": 16,
-   "text": "Industri reparasi barang rumah tangga dan pribadi lainnya St( No 054256 C",
+   "text": "Industri reparasi barang rumah tangga dan pribadi lainnya",
    "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
@@ -1590,7 +1590,7 @@
    "code": "41013",
    "column": "kemitraan",
    "page": 20,
-   "text": "gedung industri SK tJo 05,1024C",
+   "text": "gedung industri",
    "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true

--- a/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
+++ b/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
@@ -1,0 +1,158 @@
+---
+date: 2026-08-06
+domain: compliance
+client_case: none — catalogue-wide determination affecting every PT PMA enquiry on these activities
+adversarial_review: cross-family blind re-derivation (Sonnet proposes, Codex re-derives without sight of the proposal) over all 85 codes, plus a final on-disk check by the conductor which overturned 7 of 41
+sources:
+  - Perpres 10/2021 as amended by Perpres 49/2021, Lampiran II (vaulted PDF 161564, 180 ticks, 0 unresolved)
+  - scripts/kbli_filiera/perpres_umkm_reservation_relation.py --json
+  - data/source_documents/KBLI_2025_FINAL_CLEAN.json (bps_2020_ancestors, published pma_status)
+---
+
+# Lampiran II K-UMKM reservations: 85 codes adjudicated one by one
+
+## What was found
+
+`perpres_umkm_reservation_relation.py` reads the annex that allocates activities
+to cooperatives and MSMEs. It sorts 181 rows into five buckets; the one that
+matters is **`whole-row` — 85 codes where the live KBLI code IS the reserved
+row**. Of those, **84 are published on our surfaces as `TERBUKA` with
+`pma_max_asing: 100`** — fully open to foreign ownership.
+
+The other buckets are the reason this is not a sweep: **57 `kemitraan-no-bar`**
+(a duty to partner with K-UMKM, which an open PMA discharges — not a bar),
+**12 `split-heirs`** (the annex reserves *Hotel Bintang I*, not all five star
+ratings), **25 `segment-qualified`**. Restricting those would be as wrong as
+leaving the 85 open.
+
+## How each code was judged
+
+Ten batches, two independent passes, generator ≠ grader: a Claude lane proposed
+a verdict from the annex row, an OpenAI lane re-derived the same codes **blind**,
+and disagreements were kept as disagreements rather than reconciled. The rule
+given to both put the bias **against** restricting:
+
+> a wrongly-restricted code costs a client a business they could lawfully run;
+> that is not a safer error, it is a different error
+
+with `REFUSE_UNCLEAR` a real option rather than a fallback.
+
+**Result: agree 72 · disagree 13 · missing 0.** Agreed verdicts: PATCH 41,
+REFUSE_BROADER 28, REFUSE_UNCLEAR 3. Arithmetic re-verified independently
+(72+13 = 85, 85 unique codes, all source codes present, recomputed counts match).
+
+## What the final check overturned, and why it matters
+
+**18 of the 85 codes are not KBLI-2025 codes at all** — they are 2020 numbers
+the crosswalk never resolved. Seven of them sat among the PATCH verdicts, and
+**both families had agreed on all seven**, because neither was ever asked
+whether the code exists and the record handed to them did not say. Agreement
+measures fidelity to the evidence supplied, not truth.
+
+Each of the seven resolves to **exactly one** 2025 heir with the same activity
+name, so the determination transfers to the heir rather than being lost:
+
+| 2020 (judged) | 2025 (real) | activity |
+|---|---|---|
+| `10391` | `10307` | Pembuatan Tempe Kedelai |
+| `10392` | `10308` | Pembuatan Tahu Kedelai |
+| `55120` | `55106` | Aktivitas Hotel Nonbintang |
+| `55130` | `55201` | Rumah Tinggal Sewa (Homestay) |
+| `55193` | `55203` | Aktivitas Vila |
+| `79111` | `79110` | Aktivitas Agen Perjalanan |
+| `79921` | `79903` | Jasa Pramuwisata |
+
+None of the seven heirs was already in the 85, so no code is counted twice.
+
+One further PATCH is withdrawn: **`47722`** rests on annex text the OCR
+destroyed (`'B"rt"t dan obat farmasi...`), and the corrupted token is the one
+that sets the scope. A verdict on illegible evidence is an unclear verdict.
+
+**Actionable set: 40 codes, not 41.**
+
+## Nothing has been written to the dataset
+
+This document is the determination, not the patch. Section A is held for a
+ruling; sections B and C are stated so the next session does not re-derive them.
+
+## A. Accommodation & tourism — determination HELD for a ruling (5 codes)
+
+These are Bali Zero's own market. The determination is the same as section B;
+what differs is the consequence of being wrong, in both directions.
+
+| 2025 code | activity | annex row (Lampiran II) | p | reached via 2020 |
+|---|---|---|---|---|
+| `55106` | Aktivitas Hotel Nonbintang | Hotel Melati | 15 | 55120 |
+| `55201` | Aktivitas Rumah Tinggal Sewa (Homestay) | Pondok Wisata | 15 | 55130 |
+| `55203` | Aktivitas Vila | Vila | 15 | 55193 |
+| `79110` | Aktivitas Agen Perjalanan | Aktivitas agen perialanan wisata | 16 | 79111 |
+| `79903` | Jasa Pramuwisata | Jasa pramuwisata | 16 | 79921 |
+
+## B. Determination stands (35 codes)
+
+| 2025 code | activity | annex row | p | via 2020 |
+|---|---|---|---|---|
+| `01111` | Pertanian Jagung | Jagung | 1 | — |
+| `01113` | Pertanian Kedelai | Kedelai | 1 | — |
+| `01114` | Pertanian Kacang Tanah | Kacang tanah | 1 | — |
+| `01115` | Pertanian Kacang Hijau | Kacang hijau | 1 | — |
+| `01121` | Pertanian Padi Hibrida | Padi hibrida | 1 | — |
+| `01122` | Pertanian Padi Inbrida | Padi inbrida | 1 | — |
+| `10214` | Pengolahan dan Pengawetan Ikan dengan Pe | Industri pemindangan ikan | 2 | — |
+| `10307` | Pembuatan Tempe Kedelai | Industri tempe kedelai | 2 | 10391 |
+| `10308` | Pembuatan Tahu Kedelai | Industri tahu kedelai | 2 | 10392 |
+| `10722` | Industri Gula Merah | Industri gula merah | 2 | — |
+| `10794` | Industri Kerupuk, Keripik, Peyek, dan Se | Industri kerupuk, keripik, peyek dan s | 3 | — |
+| `16293` | Industri Kerajinan Ukiran dari Kayu Buka | Industri kerajinan ukiran dari kayu bu | 4 | — |
+| `22121` | Industri Karet Asap | Industri pengasapan karet | 4 | — |
+| `41016` | Konstruksi Konvensional Gedung Pendidika | gedung pendidikan meliputi sarana pend | 7 | — |
+| `41018` | Konstruksi Konvensional Gedung Hiburan d | gedung tempat hiburan dan olahraga mel | 7 | — |
+| `41020` | Konstruksi Prapabrikasi Bangunan Gedung | jasa pekerjaan konstruksi prafabrikasi | 7 | — |
+| `42202` | Konstruksi Bangunan Sipil Pengolahan Air | bangunan pengolahan, penyaluran dan pe | 8 | — |
+| `42912` | Konstruksi Bangunan Pelabuhan Bukan Peri | pelabuhan bukan perikanan pelabuhan pe | 9 | — |
+| `42913` | Konstruksi Bangunan Pelabuhan Perikanan | pelabuhan perikanan | 9 | — |
+| `43215` | Pemasangan Sistem Persinyalan dan Teleko | sinyal dan telekomunikasi kereta api | 10 | — |
+| `43221` | Pemasangan Saluran Air (Plumbing) | saluran air Qtlambingl pemanas dan geo | 10 | — |
+| `43222` | Pemasangan Sistem Pemanas dan Geotermal | pemanas dan geotermal | 10 | — |
+| `43224` | Pemasangan Pendingin dan Ventilasi Udara | pendingin dan ventilasi udara mekanika | 11 | — |
+| `43303` | Pengecatan | pengecatan | 11 | — |
+| `43309` | Penyelesaian Konstruksi Bangunan Lainnya | Penyelesaian konstruksi bangunan lainn | 12 | — |
+| `43902` | Pemasangan Perancah (Steger) | Pemasangan perancah (steigefi Pemasang | 12 | — |
+| `43904` | Pemasangan Kerangka Baja | Kerangka baja Penyewaan alat konstruks | 12 | — |
+| `47241` | Perdagangan Eceran Beras | Beras | 13 | — |
+| `47242` | Perdagangan Eceran Roti, Kue Kering, ser | Roti, kue kering, serta kue basah dan  | 13 | — |
+| `47244` | Perdagangan Eceran Tahu, Tempe, Tauco, d | Tahu, tempe, tauco dan oncom | 13 | — |
+| `47249` | Perdagangan Eceran Makanan Lainnya | Makanan lainnya | 14 | — |
+| `47712` | Perdagangan Eceran Sepatu, Sandal, dan A | Alas kaki | 14 | — |
+| `95220` | Reparasi dan Pemeliharaan Peralatan Ruma | Reparasi peralatan: Peralatan rumah ta | 16 | — |
+| `95291` | Aktivitas Vermak Pakaian | Vermak pakaian | 16 | — |
+| `95299` | Reparasi dan Pemeliharaan Barang Keperlu | Industri reparasi barang rumah tangga  | 16 | — |
+
+## C. For Zero — 13 split verdicts + 3 unclear + 1 illegible (17)
+
+| code | activity | Sonnet | Codex |
+|---|---|---|---|
+| `16291` | Industri Barang Anyaman dari Rotan | REFUSE_UNCLEAR | PATCH |
+| `16294` | Industri Alat Dapur dan Alat Makan | REFUSE_UNCLEAR | PATCH |
+| `41014` | Konstruksi Konvensional Gedung Per | REFUSE_UNCLEAR | PATCH |
+| `41015` | Konstruksi Konvensional Gedung Kes | REFUSE_UNCLEAR | PATCH |
+| `41019` | Konstruksi Konvensional Gedung Lai | PATCH | REFUSE_BROADER |
+| `43216` | Pemasangan Perlengkapan Jalan Berb | PATCH | REFUSE_BROADER |
+| `43291` | Pemasangan Perlengkapan Mekanikal  | REFUSE_BROADER | REFUSE_UNCLEAR |
+| `43302` | Pengerjaan Lantai, Dinding, dan Pl | PATCH | REFUSE_UNCLEAR |
+| `43903` | Pemasangan Rangka dan Atap/Roof Co | PATCH | REFUSE_BROADER |
+| `47192` | Perdagangan Eceran Berbagai Macam  | REFUSE_BROADER | REFUSE_UNCLEAR |
+| `47245` | Perdagangan Eceran Daging Olahan | PATCH | REFUSE_UNCLEAR |
+| `47721` | Perdagangan Eceran Sediaan Farmasi | PATCH | REFUSE_UNCLEAR |
+| `86103` | Aktivitas Rumah Sakit Swasta | REFUSE_BROADER | REFUSE_UNCLEAR |
+| `43213` | Pemasangan Sistem Elektronika | UNCLEAR | UNCLEAR |
+| `43223` | Pemasangan Jaringan Penyaluran Gas | UNCLEAR | UNCLEAR |
+| `95120` | Reparasi dan Pemeliharaan Peralata | UNCLEAR | UNCLEAR |
+| `47722` | Perdagangan Eceran Sediaan Farmasi | PATCH | PATCH — **held, annex text OCR-corrupted** |
+
+## D. Refused as broader than the reserved activity (28 codes)
+
+Both families agreed the 2025 code covers more than the annex reserves.
+Pasal 3(3): the requirement attaches to the named *bidang usaha*, never to the code number.
+
+Codes: `02302`, `02303`, `02304`, `02305`, `02306`, `02307`, `02308`, `02309`, `10750`, `13121`, `13122`, `13134`, `13912`, `14111`, `14131`, `16292`, `23932`, `25931`, `25932`, `25934`, `32201`, `35111`, `41017`, `43211`, `43299`, `47243`, `55199`, `71204`

--- a/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
+++ b/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
@@ -11,6 +11,45 @@ sources:
 
 # Lampiran II K-UMKM reservations: 85 codes adjudicated one by one
 
+> ## ⛔ WITHDRAWN THE SAME DAY — the 39-code patch was never applied
+>
+> An independent cross-family review of this finished document (Codex GPT-5.6,
+> instructed to refute) returned **DEFECTIVE**, and its first point held up at
+> the source PDF: the annex reserves food crops only **"dengan luas kurang dari
+> 25 Ha"**. Nothing in the evidence given to the 21 adjudicating agents said so
+> — because **Lampiran II is not a flat table**. A numbered PARENT bidang usaha
+> carries the scope, and the rows indented under it carry a bare name:
+>
+> ```
+> 1   Pertanian tanaman pangan dengan luas kurang dari 25 Ha:
+>        Padi hibrida        01121   V
+>        Jagung              01111   V
+> ```
+>
+> Our parser emitted the child cell only. A lane judging `01111` saw `"Jagung"`
+> and had no way to learn about the 25 hectares, so both families agreed to
+> reserve the whole code — agreement measuring fidelity to the evidence supplied,
+> exactly as W100 says. **Eleven of the 39 codes this document proposed to patch
+> sit under a restricting parent** (`01111 01113 01114 01115 01121 01122 43215
+> 43221 43222 43224 43303` — the 25-Ha crops, and the "teknologi sederhana dan
+> madya" installation/works grades). Publishing 0% on them would tell a client
+> they cannot run an activity they lawfully can.
+>
+> **Nothing reached a client**: the patch was withdrawn before merge and the
+> canonical dataset is untouched. What ships instead is the cure for the cause —
+> `parse_perpres_lampiran2` now emits `parent_heading` on every row, and the
+> classifier has a named **`parent-qualified`** bucket (17 rows), which moves
+> `whole-row` from **85 to 68**. Every count below that derives from 85 is
+> therefore superseded; the verdicts are kept as the record of what was decided
+> on what evidence, not as a queue to apply.
+>
+> The sharpest part is not that the parser was thin — it is that
+> `perpres_umkm_reservation_relation.py` **already said so**, in its own
+> docstring, and deliberately left such rows in `whole-row` so a human would ask
+> about them. That caveat was true, load-bearing, and invisible to every reader
+> who consumed the DATA instead of the module. A limitation that lives only in a
+> comment does not travel with the rows.
+
 ## What was found
 
 `perpres_umkm_reservation_relation.py` reads the annex that allocates activities
@@ -162,3 +201,54 @@ Both families agreed the 2025 code covers more than the annex reserves.
 Pasal 3(3): the requirement attaches to the named *bidang usaha*, never to the code number.
 
 Codes: `02302`, `02303`, `02304`, `02305`, `02306`, `02307`, `02308`, `02309`, `10750`, `13121`, `13122`, `13134`, `13912`, `14111`, `14131`, `16292`, `23932`, `25931`, `25932`, `25934`, `32201`, `35111`, `41017`, `43211`, `43299`, `47243`, `55199`, `71204`
+
+## Adversarial review
+
+**Seat**: Codex GPT-5.6 (`gpt-5.6-terra`, read-only sandbox), given this
+document, the cure spec and the applier, and told to refute the determination
+and default to DEFECTIVE. It did not write any of the work it reviewed
+(generator ≠ grader). **Verdict: DEFECTIVE.** Seven points; what happened to
+each, including the ones that did not survive:
+
+1. **The 25-Ha qualifier — UPHELD, and it withdrew the cure.** Re-verified here
+   at the vaulted PDF rather than taken on the reviewer's word (W65: a refuter's
+   verdict is a lead). `pdftotext -layout` page 1 shows the parent row verbatim.
+   Codex named 6 codes; the parent-aware re-parse measures **11**, because the
+   two "teknologi sederhana dan madya" headings restrict a second family the
+   reviewer did not reach. The refuter was right about the disease and short
+   about its extent — which is the normal shape, and the reason the count in a
+   finding gets re-derived rather than quoted.
+2. **Pasal 3(3) vs Pasal 5(5) — OPEN, not silently accepted.** Codex says the
+   granularity rule is Pasal 5(5). The locators written into the spec cite
+   3(1)(b) and 5; the surrounding prose cites 3(3). Both articles are cited
+   from secondary sources on both sides and the withdrawal makes it moot for
+   now, so it is recorded as a question for the re-adjudication rather than
+   "corrected" on an equally unverified basis — swapping one unchecked citation
+   for another is not a fix (W113: the sentence written while correcting is a
+   new claim).
+3. **`55106`/`55201`/`55203`/`79903` were in the spec while the text called them
+   HELD — UPHELD as a defect of the RECORD.** The hold was lifted deliberately
+   by the owner ("fai il tuo lavoro senza importartene dei clienti e di noi") and
+   that decision stands; the document simply never said so, so it contradicted
+   its own artifact. A reader would have found four 0% verdicts on codes the
+   text called unresolved. Moot under the withdrawal, fixed in the re-write.
+4. **Semantic check on the seven 2020→2025 mappings — UPHELD as insufficient.**
+   The applier verified cardinality (exactly one heir) and not identity of
+   perimeter. `55120` "Hotel Melati" → `55106` "Aktivitas Hotel Nonbintang" is a
+   single heir and not obviously the same activity.
+5. **`42912` — UPHELD on the evidence, and it is a second parser defect.** Its
+   activity cell reads `"pelabuhan bukan perikanan pelabuhan perikanan"`: two
+   distinct annex cells run together. Ledgered, not fixed here.
+6. **OCR-contaminated locators — PARTLY UPHELD.** The consistency argument is
+   sound (holding `47722` for illegible OCR while accepting other damaged
+   strings is incoherent), but the specific list was asserted, not measured; a
+   loose "over-long cell" probe flags 74 rows, which is too blunt to act on.
+   Recorded as a limit, not a finding.
+7. **Harden the applier — PARTLY ADOPTED.** It now refuses a withdrawn spec by
+   name (`test_guilt_a_withdrawn_spec_is_refused_before_anything_is_read`); the
+   perimeter and atomicity points belong with the re-adjudication.
+
+**What this review did not do**: it did not read the rendered annex images, so
+none of the above is image-grounded (W100 asks for that on content claims). The
+25-Ha finding was confirmed against the PDF text layer plus the parent-aware
+re-parse — two readings of the same artifact, not two independent witnesses.

--- a/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
+++ b/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
@@ -198,7 +198,8 @@ what differs is the consequence of being wrong, in both directions.
 ## D. Refused as broader than the reserved activity (28 codes)
 
 Both families agreed the 2025 code covers more than the annex reserves.
-Pasal 3(3): the requirement attaches to the named *bidang usaha*, never to the code number.
+**Pasal 5 ayat (5)**: where one KBLI covers more than one *bidang usaha*, the Lampiran II
+allocation applies only to the *bidang usaha* named in that column — never to the code number.
 
 Codes: `02302`, `02303`, `02304`, `02305`, `02306`, `02307`, `02308`, `02309`, `10750`, `13121`, `13122`, `13134`, `13912`, `14111`, `14131`, `16292`, `23932`, `25931`, `25932`, `25934`, `32201`, `35111`, `41017`, `43211`, `43299`, `47243`, `55199`, `71204`
 
@@ -218,14 +219,35 @@ each, including the ones that did not survive:
    reviewer did not reach. The refuter was right about the disease and short
    about its extent — which is the normal shape, and the reason the count in a
    finding gets re-derived rather than quoted.
-2. **Pasal 3(3) vs Pasal 5(5) — OPEN, not silently accepted.** Codex says the
-   granularity rule is Pasal 5(5). The locators written into the spec cite
-   3(1)(b) and 5; the surrounding prose cites 3(3). Both articles are cited
-   from secondary sources on both sides and the withdrawal makes it moot for
-   now, so it is recorded as a question for the re-adjudication rather than
-   "corrected" on an equally unverified basis — swapping one unchecked citation
-   for another is not a fix (W113: the sentence written while correcting is a
-   new claim).
+2. **The granularity article — UPHELD, and SETTLED at the source the same day:
+   the `Pasal 3(3)` this document cited does not exist; the rule is Pasal 5(5).** Read in the vaulted body of Perpres 10/2021 (`154474`) rather than
+   swapped for the reviewer's number, because replacing one unchecked citation
+   with another is not a fix (W113). What the text says:
+
+   - **Pasal 3 has two ayat.** `Pasal 3(3)` does not exist. It was a phantom.
+   - **Pasal 5(5)** — *"Dalam hal Klasifikasi Baku Lapangan Usaha Indonesia …
+     meliputi lebih dari satu Bidang Usaha, ketentuan mengenai alokasi dan
+     kemitraan … dalam **Lampiran II** hanya berlaku bagi Bidang Usaha yang
+     tercantum dalam kolom Bidang Usaha tersebut."* This is our article.
+   - **Pasal 6(3)** is its twin for **Lampiran III** (the foreign-cap annex),
+     word-for-word the same rule with `persyaratan` in place of `alokasi dan
+     kemitraan`.
+
+   So the granularity rule is written **once per annex**, and one remembered
+   number cannot serve both — which is exactly how the phantom propagated to
+   **five** places: this document, `apply_umkm_reservations.py`, the
+   already-merged `perpres_foreign_cap_relation.py` (2026-08-01), the
+   `kbli-navigator` corner skill that every KBLI session loads, and the modus
+   ledger. All five corrected to the article of their own annex, with a
+   tripwire (`test_the_granularity_article_is_per_annex`) so the phantom cannot
+   come back. Inherited, not invented here — and it had been in the corner
+   skill for five days.
+
+   Pasal 5(2) also explains WHY the annex headings carry the qualifiers this
+   review turned on: allocation to K-UMKM is defined by criteria — *no or
+   simple technology*, special/labour-intensive/heritage processes, or capital
+   not exceeding Rp10bn excluding land and buildings. "teknologi sederhana dan
+   madya" in a heading is that criterion, written into the list.
 3. **`55106`/`55201`/`55203`/`79903` were in the spec while the text called them
    HELD — UPHELD as a defect of the RECORD.** The hold was lifted deliberately
    by the owner ("fai il tuo lavoro senza importartene dei clienti e di noi") and

--- a/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
+++ b/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
@@ -2,7 +2,7 @@
 date: 2026-08-06
 domain: compliance
 client_case: none — catalogue-wide determination affecting every PT PMA enquiry on these activities
-adversarial_review: cross-family blind re-derivation (Sonnet proposes, Codex re-derives without sight of the proposal) over all 85 codes, plus a final on-disk check by the conductor which overturned 7 of 41
+adversarial_review: codex
 sources:
   - Perpres 10/2021 as amended by Perpres 49/2021, Lampiran II (vaulted PDF 161564, 180 ticks, 0 unresolved)
   - scripts/kbli_filiera/perpres_umkm_reservation_relation.py --json
@@ -68,7 +68,13 @@ One further PATCH is withdrawn: **`47722`** rests on annex text the OCR
 destroyed (`'B"rt"t dan obat farmasi...`), and the corrupted token is the one
 that sets the scope. A verdict on illegible evidence is an unclear verdict.
 
-**Actionable set: 40 codes, not 41.**
+**Actionable set: 39 codes, not 41.**
+
+A further removal came from CI, not from this reading: `79110` (travel agent) is
+asserted at **100%, never 0** by `test_kbli_eye.py`, a determination that lives
+in a TEST rather than in `pma_official_basis` — so the applier's own
+refuse-on-prior-adjudication rule could not see it. Two in-repo determinations
+disagree; that is Zero's to settle, not a silent overwrite.
 
 ## Nothing has been written to the dataset
 

--- a/scripts/kbli_filiera/apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/apply_umkm_reservations.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Apply the Lampiran II K-UMKM reservation to canonical, from an adjudicated spec.
+
+WHAT THIS ASSERTS, AND ON WHAT
+-------------------------------
+Perpres 10/2021 as amended by 49/2021, **Lampiran II**, allocates a *bidang
+usaha* to Indonesian cooperatives and MSMEs (the DIALOKASIKAN column). A foreign
+investor cannot be a Koperasi or a UMKM, so for the allocated activity the
+lawful foreign share is 0% — the reading our own catalogue already carries, once,
+hand-adjudicated, on `47111` (minimarket).
+
+Two articles that are NOT this one, and must not be conflated with it:
+
+* **Pasal 7 ayat (1)** ("Penanam Modal asing hanya dapat melakukan kegiatan
+  usaha pada Usaha Besar dengan nilai investasi lebih dari Rp10.000.000.000,00")
+  conditions the INVESTOR and its project, not the activity. It can stop a
+  particular PMA that cannot qualify as large; it does not open or close an
+  activity, and it does not dissolve a Lampiran II allocation. Reading the
+  Rp10B threshold as "so a PMA is above the reservation anyway" inverts a
+  reservation into a permission and is wrong.
+* **KEMITRAAN**, the other column of the same annex, is a duty to PARTNER with
+  K-UMKM, which an open PMA discharges. 57 codes sit there and NONE of them
+  appear in this spec.
+
+WHAT IS IN THE SPEC, AND WHAT DELIBERATELY IS NOT
+--------------------------------------------------
+`cure_specs/umkm_lampiran_ii_2026_08_06.json` carries only codes where two
+INDEPENDENT passes of different model families agreed on PATCH — a Claude lane
+proposing from the annex row and an OpenAI lane re-deriving the same codes
+blind, with the bias stated against restricting ("a wrongly-restricted code
+costs a client a business they could lawfully run; that is not a safer error,
+it is a different error").
+
+Excluded by construction, and none of it is a silent drop: 13 codes where the
+two families disagreed, 3 both called unclear, 1 whose annex text the OCR
+destroyed on the token that sets its scope, and 28 both refused as BROADER than
+the reserved activity — Pasal 3 ayat (3) attaches the requirement to the named
+bidang usaha, never to the code number.
+
+Seven spec rows were judged on a KBLI-2020 number that is not a 2025 code
+(`55193` villa, `10391` tempe, …). Each resolves to EXACTLY ONE 2025 heir with
+the same activity name, so the determination is applied to the heir and the
+row records `judged_as`. This tool re-derives that heir itself and refuses if
+the spec's target disagrees — the vintage trap has bitten this catalogue twice
+in one day and a written-down mapping is a proxy, not the fact.
+
+REFUSES RATHER THAN GUESSES
+----------------------------
+`--apply` aborts, writing nothing, if: a spec code is absent from the dataset;
+a spec row's `judged_as` does not resolve to its stated target through
+`bps_2020_ancestors`; a record already carries a DIFFERENT `pma_official_basis`
+(someone adjudicated it by hand and this tool is not the later word); or the
+observed `pma_status`/`pma_max_asing` differ from what the spec recorded when it
+was built, which means the world moved under the adjudication.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL = REPO_ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+SPEC = Path(__file__).resolve().parent / "cure_specs" / "umkm_lampiran_ii_2026_08_06.json"
+
+VINTAGE = "2021-05-25"
+KONDISI = (
+    "Bidang usaha dialokasikan untuk Koperasi dan UMKM (Perpres 49/2021 "
+    "Lampiran II) — foreign ownership 0%"
+)
+
+EXIT_OK = 0
+EXIT_REFUSED = 2
+
+
+def load(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]], str]:
+    text = path.read_text(encoding="utf-8")
+    payload = json.loads(text)
+    records = payload["data"] if isinstance(payload, dict) else payload
+    if not isinstance(records, list) or not records:
+        raise ValueError(f"{path}: expected a non-empty record list")
+    return payload, records, text
+
+
+def heirs_of(records: list[dict[str, Any]]) -> dict[str, list[str]]:
+    """2020 code -> the 2025 codes that record it as an ancestor."""
+    out: dict[str, list[str]] = {}
+    for r in records:
+        anc = r.get("bps_2020_ancestors")
+        codes = anc.get("codes") if isinstance(anc, dict) else None
+        for c in codes or []:
+            out.setdefault(str(c), []).append(str(r["kode_kbli_2025"]))
+    return out
+
+
+def patch_for(item: dict[str, Any]) -> dict[str, Any]:
+    """Pure — the field-level patch for one adjudicated code."""
+    return {
+        "pma_max_asing": 0,
+        "pma_status": "TERBATAS",
+        "pma_official_basis": item["locator"],
+        "pma_cap_verified": True,
+        "pma_source_vintage": VINTAGE,
+        "pma_kondisi": KONDISI,
+    }
+
+
+def check(
+    spec: dict[str, Any], records: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Returns (applicable items, refusals). A refusal aborts the whole run:
+    a spec that is wrong about one code is not trustworthy about the rest."""
+    by_code = {str(r["kode_kbli_2025"]): r for r in records}
+    heirs = heirs_of(records)
+    refusals: list[str] = []
+    todo: list[dict[str, Any]] = []
+
+    for item in spec["items"]:
+        code = item["code"]
+        record = by_code.get(code)
+        if record is None:
+            refusals.append(f"{code}: not in the dataset")
+            continue
+
+        judged = item.get("judged_as")
+        if judged:
+            # Re-derive rather than trust the spec's own mapping.
+            found = heirs.get(judged, [])
+            if found != [code]:
+                refusals.append(
+                    f"{code}: judged on 2020 {judged}, which resolves to "
+                    f"{found or 'no 2025 heir'} — not this code alone"
+                )
+                continue
+
+        existing = record.get("pma_official_basis")
+        if existing and existing != item["locator"]:
+            refusals.append(f"{code}: already carries a different pma_official_basis")
+            continue
+
+        was = item.get("was") or {}
+        now = {
+            "pma_status": record.get("pma_status"),
+            "pma_max_asing": record.get("pma_max_asing"),
+        }
+        if was and was != now:
+            refusals.append(f"{code}: moved since adjudication — spec {was}, now {now}")
+            continue
+
+        todo.append(item)
+
+    return todo, refusals
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true", help="write (default: dry-run)")
+    ap.add_argument("--dataset", default=str(CANONICAL))
+    ap.add_argument("--spec", default=str(SPEC))
+    args = ap.parse_args(argv)
+
+    spec = json.loads(Path(args.spec).read_text(encoding="utf-8"))
+    path = Path(args.dataset)
+    payload, records, original = load(path)
+
+    todo, refusals = check(spec, records)
+
+    print(f"spec items {len(spec['items'])} · applicable {len(todo)} · refused {len(refusals)}")
+    print(f"excluded by the adjudication itself: {spec['excluded']}")
+    for r in refusals:
+        print(f"  REFUSE {r}")
+    if refusals:
+        print("\nrefusing to write: a spec wrong about one code is not trusted for the rest")
+        return EXIT_REFUSED
+
+    for item in todo:
+        via = f" (judged as {item['judged_as']})" if item.get("judged_as") else ""
+        print(f"  {item['code']}{via}: {item['was']} -> TERBATAS/0")
+
+    if not args.apply:
+        print("\ndry-run — rerun with --apply to write")
+        return EXIT_OK
+
+    by_code = {str(r["kode_kbli_2025"]): r for r in records}
+    for item in todo:
+        by_code[item["code"]].update(patch_for(item))
+
+    body = json.dumps(payload, ensure_ascii=False, indent=2)
+    path.write_text(body + ("\n" if original.endswith("\n") else ""), encoding="utf-8")
+
+    # Read back and prove the write, rather than trusting that it happened.
+    _, again, _ = load(path)
+    fresh = {str(r["kode_kbli_2025"]): r for r in again}
+    wrong = [
+        i["code"]
+        for i in todo
+        if fresh[i["code"]].get("pma_max_asing") != 0
+        or fresh[i["code"]].get("pma_status") != "TERBATAS"
+    ]
+    if wrong:
+        print(f"WROTE BUT READ BACK WRONG on {len(wrong)}: {wrong[:10]}")
+        return EXIT_REFUSED
+    print(f"\napplied and verified on re-read: {len(todo)} code(s)")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kbli_filiera/apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/apply_umkm_reservations.py
@@ -34,7 +34,7 @@ it is a different error").
 Excluded by construction, and none of it is a silent drop: 13 codes where the
 two families disagreed, 3 both called unclear, 1 whose annex text the OCR
 destroyed on the token that sets its scope, and 28 both refused as BROADER than
-the reserved activity — Pasal 3 ayat (3) attaches the requirement to the named
+the reserved activity — Pasal 5 ayat (5) attaches the allocation to the named
 bidang usaha, never to the code number.
 
 Seven spec rows were judged on a KBLI-2020 number that is not a 2025 code

--- a/scripts/kbli_filiera/apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/apply_umkm_reservations.py
@@ -162,6 +162,21 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     spec = json.loads(Path(args.spec).read_text(encoding="utf-8"))
+
+    # A withdrawn spec is not an empty one, and the difference must not depend on
+    # a reader noticing that `items` happens to be []. The 2026-08-06 spec was
+    # withdrawn whole after a cross-family review found its evidence had the
+    # scope qualifier stripped out; running it would publish a 0% foreign cap on
+    # activities the annex reserves only below 25 Ha, or only at simple and
+    # intermediate technology grade. Refuse loudly, name the reason, write nothing.
+    withdrawn = spec.get("withdrawn")
+    if withdrawn:
+        print(f"REFUSING: this spec was withdrawn on {withdrawn.get('date')}.")
+        print(f"  by:     {withdrawn.get('by')}")
+        print(f"  reason: {withdrawn.get('reason')}")
+        print(f"  next:   {withdrawn.get('next')}")
+        return EXIT_REFUSED
+
     path = Path(args.dataset)
     payload, records, original = load(path)
 

--- a/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
@@ -1,0 +1,452 @@
+{
+  "instrument": "Perpres 10/2021 as amended by Perpres 49/2021, Lampiran II",
+  "vintage": "2021-05-25",
+  "method": "two independent passes (Sonnet propose / Codex blind re-derive) over 85 whole-row codes; only unanimous PATCH verdicts appear here",
+  "excluded": {
+    "disagreements": 13,
+    "agreed_unclear": 3,
+    "ocr_illegible": ["47722"]
+  },
+  "items": [
+    {
+      "code": "01111",
+      "judged_as": null,
+      "annex_row": "Jagung",
+      "page": 1,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Jagung\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "01113",
+      "judged_as": null,
+      "annex_row": "Kedelai",
+      "page": 1,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "01114",
+      "judged_as": null,
+      "annex_row": "Kacang tanah",
+      "page": 1,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Kacang tanah\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "01115",
+      "judged_as": null,
+      "annex_row": "Kacang hijau",
+      "page": 1,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Kacang hijau\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "01121",
+      "judged_as": null,
+      "annex_row": "Padi hibrida",
+      "page": 1,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Padi hibrida\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "01122",
+      "judged_as": null,
+      "annex_row": "Padi inbrida",
+      "page": 1,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Padi inbrida\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": null
+      }
+    },
+    {
+      "code": "10214",
+      "judged_as": null,
+      "annex_row": "Industri pemindangan ikan",
+      "page": 2,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p2, row \"Industri pemindangan ikan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "10307",
+      "judged_as": "10391",
+      "annex_row": "Industri tempe kedelai",
+      "page": 2,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p2, row \"Industri tempe kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 10391, applied to its single 2025 heir 10307 (same activity name).",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "10308",
+      "judged_as": "10392",
+      "annex_row": "Industri tahu kedelai",
+      "page": 2,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p2, row \"Industri tahu kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 10392, applied to its single 2025 heir 10308 (same activity name).",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "10722",
+      "judged_as": null,
+      "annex_row": "Industri gula merah",
+      "page": 2,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p2, row \"Industri gula merah\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "10794",
+      "judged_as": null,
+      "annex_row": "Industri kerupuk, keripik, peyek dan seienisnya (pabrikan dan non pabrikan)",
+      "page": 3,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p3, row \"Industri kerupuk, keripik, peyek dan seienisnya (pabrikan dan non pabr\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "16293",
+      "judged_as": null,
+      "annex_row": "Industri kerajinan ukiran dari kayu bukan mebeller ukiran kayu, relief, topeng, patung, wayang",
+      "page": 4,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p4, row \"Industri kerajinan ukiran dari kayu bukan mebeller ukiran kayu, relief\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "22121",
+      "judged_as": null,
+      "annex_row": "Industri pengasapan karet",
+      "page": 4,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p4, row \"Industri pengasapan karet\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "41016",
+      "judged_as": null,
+      "annex_row": "gedung pendidikan meliputi sarana pendidikan, tempat kursus, laboratorium dan bangunan penunjang pendidikan lainnya",
+      "page": 7,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p7, row \"gedung pendidikan meliputi sarana pendidikan, tempat kursus, laborator\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "41018",
+      "judged_as": null,
+      "annex_row": "gedung tempat hiburan dan olahraga meliputi bioskop, gedung kebudayaan/kesenian, gedung wisata dan rekreasi serta gedung olahraga",
+      "page": 7,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p7, row \"gedung tempat hiburan dan olahraga meliputi bioskop, gedung kebudayaan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "41020",
+      "judged_as": null,
+      "annex_row": "jasa pekerjaan konstruksi prafabrikasi bangunan gedung meliputi pemasangan bahan hasil produksi pabrik seperti beton pracetak, baja, plastik, karet, dan hasil produksi pabrik lainnya dengan metode pabrikasi, erection, dan/atau perakitan untuk bangunan gedung",
+      "page": 7,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p7, row \"jasa pekerjaan konstruksi prafabrikasi bangunan gedung meliputi pemasa\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "42202",
+      "judged_as": null,
+      "annex_row": "bangunan pengolahan, penyaluran dan penampungan air minum",
+      "page": 8,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p8, row \"bangunan pengolahan, penyaluran dan penampungan air minum\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "42912",
+      "judged_as": null,
+      "annex_row": "pelabuhan bukan perikanan pelabuhan perikanan",
+      "page": 9,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p9, row \"pelabuhan bukan perikanan pelabuhan perikanan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "42913",
+      "judged_as": null,
+      "annex_row": "pelabuhan perikanan",
+      "page": 9,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p9, row \"pelabuhan perikanan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "43215",
+      "judged_as": null,
+      "annex_row": "sinyal dan telekomunikasi kereta api",
+      "page": 10,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p10, row \"sinyal dan telekomunikasi kereta api\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "43221",
+      "judged_as": null,
+      "annex_row": "saluran air Qtlambingl pemanas dan geotermal",
+      "page": 10,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p10, row \"saluran air Qtlambingl pemanas dan geotermal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "43222",
+      "judged_as": null,
+      "annex_row": "pemanas dan geotermal",
+      "page": 10,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p10, row \"pemanas dan geotermal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "43224",
+      "judged_as": null,
+      "annex_row": "pendingin dan ventilasi udara mekanikal",
+      "page": 11,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p11, row \"pendingin dan ventilasi udara mekanikal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "43303",
+      "judged_as": null,
+      "annex_row": "pengecatan",
+      "page": 11,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p11, row \"pengecatan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "43309",
+      "judged_as": null,
+      "annex_row": "Penyelesaian konstruksi bangunan lainnya",
+      "page": 12,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p12, row \"Penyelesaian konstruksi bangunan lainnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "43902",
+      "judged_as": null,
+      "annex_row": "Pemasangan perancah (steigefi Pemasangan atap I roof coueing",
+      "page": 12,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p12, row \"Pemasangan perancah (steigefi Pemasangan atap I roof coueing\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "43904",
+      "judged_as": null,
+      "annex_row": "Kerangka baja Penyewaan alat konstruksi dengan operator yang",
+      "page": 12,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p12, row \"Kerangka baja Penyewaan alat konstruksi dengan operator yang\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "47241",
+      "judged_as": null,
+      "annex_row": "Beras",
+      "page": 13,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p13, row \"Beras\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "47242",
+      "judged_as": null,
+      "annex_row": "Roti, kue kering, serta kue basah dan sejenisnya",
+      "page": 13,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p13, row \"Roti, kue kering, serta kue basah dan sejenisnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "47244",
+      "judged_as": null,
+      "annex_row": "Tahu, tempe, tauco dan oncom",
+      "page": 13,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p13, row \"Tahu, tempe, tauco dan oncom\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "47249",
+      "judged_as": null,
+      "annex_row": "Makanan lainnya",
+      "page": 14,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p14, row \"Makanan lainnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "47712",
+      "judged_as": null,
+      "annex_row": "Alas kaki",
+      "page": 14,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p14, row \"Alas kaki\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "55106",
+      "judged_as": "55120",
+      "annex_row": "Hotel Melati",
+      "page": 15,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p15, row \"Hotel Melati\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55120, applied to its single 2025 heir 55106 (same activity name).",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "55201",
+      "judged_as": "55130",
+      "annex_row": "Pondok Wisata",
+      "page": 15,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p15, row \"Pondok Wisata\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55130, applied to its single 2025 heir 55201 (same activity name).",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "55203",
+      "judged_as": "55193",
+      "annex_row": "Vila",
+      "page": 15,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p15, row \"Vila\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55193, applied to its single 2025 heir 55203 (same activity name).",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "79110",
+      "judged_as": "79111",
+      "annex_row": "Aktivitas agen perialanan wisata",
+      "page": 16,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Aktivitas agen perialanan wisata\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 79111, applied to its single 2025 heir 79110 (same activity name).",
+      "was": {
+        "pma_status": "TERBATAS",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "79903",
+      "judged_as": "79921",
+      "annex_row": "Jasa pramuwisata",
+      "page": 16,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Jasa pramuwisata\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 79921, applied to its single 2025 heir 79903 (same activity name).",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "95220",
+      "judged_as": null,
+      "annex_row": "Reparasi peralatan: Peralatan rumah tangga dan Peralatan rumah dan kebun",
+      "page": 16,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Reparasi peralatan: Peralatan rumah tangga dan Peralatan rumah dan keb\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "95291",
+      "judged_as": null,
+      "annex_row": "Vermak pakaian",
+      "page": 16,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Vermak pakaian\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    },
+    {
+      "code": "95299",
+      "judged_as": null,
+      "annex_row": "Industri reparasi barang rumah tangga dan pribadi lainnya St( No 054256 C",
+      "page": 16,
+      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Industri reparasi barang rumah tangga dan pribadi lainnya St( No 05425\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      }
+    }
+  ]
+}

--- a/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
@@ -5,7 +5,9 @@
   "excluded": {
     "disagreements": 13,
     "agreed_unclear": 3,
-    "ocr_illegible": ["47722"]
+    "ocr_illegible": ["47722"],
+    "contested_by_prior_in_repo_adjudication": ["79110"],
+    "note_79110": "test_kbli_eye.test_travel_agency_terbatas_carries_full_cap asserts '79110 is TERBATAS but the adjudicated cap is 100% - never 0'. That determination lives in a TEST, not in pma_official_basis, so this applier's refuse-on-prior-basis rule could not see it. Two in-repo determinations disagree; resolving it needs #3317's history read, not a silent overwrite."
   },
   "items": [
     {
@@ -390,17 +392,6 @@
       "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p15, row \"Vila\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55193, applied to its single 2025 heir 55203 (same activity name).",
       "was": {
         "pma_status": "TERBUKA",
-        "pma_max_asing": 100
-      }
-    },
-    {
-      "code": "79110",
-      "judged_as": "79111",
-      "annex_row": "Aktivitas agen perialanan wisata",
-      "page": 16,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Aktivitas agen perialanan wisata\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 79111, applied to its single 2025 heir 79110 (same activity name).",
-      "was": {
-        "pma_status": "TERBATAS",
         "pma_max_asing": 100
       }
     },

--- a/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
@@ -15,7 +15,7 @@
       "judged_as": null,
       "annex_row": "Jagung",
       "page": 1,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Jagung\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p1, row \"Jagung\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -26,7 +26,7 @@
       "judged_as": null,
       "annex_row": "Kedelai",
       "page": 1,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p1, row \"Kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -37,7 +37,7 @@
       "judged_as": null,
       "annex_row": "Kacang tanah",
       "page": 1,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Kacang tanah\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p1, row \"Kacang tanah\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -48,7 +48,7 @@
       "judged_as": null,
       "annex_row": "Kacang hijau",
       "page": 1,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Kacang hijau\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p1, row \"Kacang hijau\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -59,7 +59,7 @@
       "judged_as": null,
       "annex_row": "Padi hibrida",
       "page": 1,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Padi hibrida\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p1, row \"Padi hibrida\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -70,7 +70,7 @@
       "judged_as": null,
       "annex_row": "Padi inbrida",
       "page": 1,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p1, row \"Padi inbrida\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p1, row \"Padi inbrida\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": null
@@ -81,7 +81,7 @@
       "judged_as": null,
       "annex_row": "Industri pemindangan ikan",
       "page": 2,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p2, row \"Industri pemindangan ikan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p2, row \"Industri pemindangan ikan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -92,7 +92,7 @@
       "judged_as": "10391",
       "annex_row": "Industri tempe kedelai",
       "page": 2,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p2, row \"Industri tempe kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 10391, applied to its single 2025 heir 10307 (same activity name).",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p2, row \"Industri tempe kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 10391, applied to its single 2025 heir 10307 (same activity name).",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -103,7 +103,7 @@
       "judged_as": "10392",
       "annex_row": "Industri tahu kedelai",
       "page": 2,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p2, row \"Industri tahu kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 10392, applied to its single 2025 heir 10308 (same activity name).",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p2, row \"Industri tahu kedelai\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 10392, applied to its single 2025 heir 10308 (same activity name).",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -114,7 +114,7 @@
       "judged_as": null,
       "annex_row": "Industri gula merah",
       "page": 2,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p2, row \"Industri gula merah\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p2, row \"Industri gula merah\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -125,7 +125,7 @@
       "judged_as": null,
       "annex_row": "Industri kerupuk, keripik, peyek dan seienisnya (pabrikan dan non pabrikan)",
       "page": 3,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p3, row \"Industri kerupuk, keripik, peyek dan seienisnya (pabrikan dan non pabr\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p3, row \"Industri kerupuk, keripik, peyek dan seienisnya (pabrikan dan non pabr\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -136,7 +136,7 @@
       "judged_as": null,
       "annex_row": "Industri kerajinan ukiran dari kayu bukan mebeller ukiran kayu, relief, topeng, patung, wayang",
       "page": 4,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p4, row \"Industri kerajinan ukiran dari kayu bukan mebeller ukiran kayu, relief\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p4, row \"Industri kerajinan ukiran dari kayu bukan mebeller ukiran kayu, relief\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -147,7 +147,7 @@
       "judged_as": null,
       "annex_row": "Industri pengasapan karet",
       "page": 4,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p4, row \"Industri pengasapan karet\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p4, row \"Industri pengasapan karet\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -158,7 +158,7 @@
       "judged_as": null,
       "annex_row": "gedung pendidikan meliputi sarana pendidikan, tempat kursus, laboratorium dan bangunan penunjang pendidikan lainnya",
       "page": 7,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p7, row \"gedung pendidikan meliputi sarana pendidikan, tempat kursus, laborator\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p7, row \"gedung pendidikan meliputi sarana pendidikan, tempat kursus, laborator\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -169,7 +169,7 @@
       "judged_as": null,
       "annex_row": "gedung tempat hiburan dan olahraga meliputi bioskop, gedung kebudayaan/kesenian, gedung wisata dan rekreasi serta gedung olahraga",
       "page": 7,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p7, row \"gedung tempat hiburan dan olahraga meliputi bioskop, gedung kebudayaan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p7, row \"gedung tempat hiburan dan olahraga meliputi bioskop, gedung kebudayaan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -180,7 +180,7 @@
       "judged_as": null,
       "annex_row": "jasa pekerjaan konstruksi prafabrikasi bangunan gedung meliputi pemasangan bahan hasil produksi pabrik seperti beton pracetak, baja, plastik, karet, dan hasil produksi pabrik lainnya dengan metode pabrikasi, erection, dan/atau perakitan untuk bangunan gedung",
       "page": 7,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p7, row \"jasa pekerjaan konstruksi prafabrikasi bangunan gedung meliputi pemasa\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p7, row \"jasa pekerjaan konstruksi prafabrikasi bangunan gedung meliputi pemasa\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -191,7 +191,7 @@
       "judged_as": null,
       "annex_row": "bangunan pengolahan, penyaluran dan penampungan air minum",
       "page": 8,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p8, row \"bangunan pengolahan, penyaluran dan penampungan air minum\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p8, row \"bangunan pengolahan, penyaluran dan penampungan air minum\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -202,7 +202,7 @@
       "judged_as": null,
       "annex_row": "pelabuhan bukan perikanan pelabuhan perikanan",
       "page": 9,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p9, row \"pelabuhan bukan perikanan pelabuhan perikanan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p9, row \"pelabuhan bukan perikanan pelabuhan perikanan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -213,7 +213,7 @@
       "judged_as": null,
       "annex_row": "pelabuhan perikanan",
       "page": 9,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p9, row \"pelabuhan perikanan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p9, row \"pelabuhan perikanan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -224,7 +224,7 @@
       "judged_as": null,
       "annex_row": "sinyal dan telekomunikasi kereta api",
       "page": 10,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p10, row \"sinyal dan telekomunikasi kereta api\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p10, row \"sinyal dan telekomunikasi kereta api\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -235,7 +235,7 @@
       "judged_as": null,
       "annex_row": "saluran air Qtlambingl pemanas dan geotermal",
       "page": 10,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p10, row \"saluran air Qtlambingl pemanas dan geotermal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p10, row \"saluran air Qtlambingl pemanas dan geotermal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -246,7 +246,7 @@
       "judged_as": null,
       "annex_row": "pemanas dan geotermal",
       "page": 10,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p10, row \"pemanas dan geotermal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p10, row \"pemanas dan geotermal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -257,7 +257,7 @@
       "judged_as": null,
       "annex_row": "pendingin dan ventilasi udara mekanikal",
       "page": 11,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p11, row \"pendingin dan ventilasi udara mekanikal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p11, row \"pendingin dan ventilasi udara mekanikal\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -268,7 +268,7 @@
       "judged_as": null,
       "annex_row": "pengecatan",
       "page": 11,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p11, row \"pengecatan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p11, row \"pengecatan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -279,7 +279,7 @@
       "judged_as": null,
       "annex_row": "Penyelesaian konstruksi bangunan lainnya",
       "page": 12,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p12, row \"Penyelesaian konstruksi bangunan lainnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p12, row \"Penyelesaian konstruksi bangunan lainnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -290,7 +290,7 @@
       "judged_as": null,
       "annex_row": "Pemasangan perancah (steigefi Pemasangan atap I roof coueing",
       "page": 12,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p12, row \"Pemasangan perancah (steigefi Pemasangan atap I roof coueing\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p12, row \"Pemasangan perancah (steigefi Pemasangan atap I roof coueing\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -301,7 +301,7 @@
       "judged_as": null,
       "annex_row": "Kerangka baja Penyewaan alat konstruksi dengan operator yang",
       "page": 12,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p12, row \"Kerangka baja Penyewaan alat konstruksi dengan operator yang\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p12, row \"Kerangka baja Penyewaan alat konstruksi dengan operator yang\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -312,7 +312,7 @@
       "judged_as": null,
       "annex_row": "Beras",
       "page": 13,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p13, row \"Beras\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p13, row \"Beras\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -323,7 +323,7 @@
       "judged_as": null,
       "annex_row": "Roti, kue kering, serta kue basah dan sejenisnya",
       "page": 13,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p13, row \"Roti, kue kering, serta kue basah dan sejenisnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p13, row \"Roti, kue kering, serta kue basah dan sejenisnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -334,7 +334,7 @@
       "judged_as": null,
       "annex_row": "Tahu, tempe, tauco dan oncom",
       "page": 13,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p13, row \"Tahu, tempe, tauco dan oncom\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p13, row \"Tahu, tempe, tauco dan oncom\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -345,7 +345,7 @@
       "judged_as": null,
       "annex_row": "Makanan lainnya",
       "page": 14,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p14, row \"Makanan lainnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p14, row \"Makanan lainnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -356,7 +356,7 @@
       "judged_as": null,
       "annex_row": "Alas kaki",
       "page": 14,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p14, row \"Alas kaki\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p14, row \"Alas kaki\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -367,7 +367,7 @@
       "judged_as": "55120",
       "annex_row": "Hotel Melati",
       "page": 15,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p15, row \"Hotel Melati\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55120, applied to its single 2025 heir 55106 (same activity name).",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p15, row \"Hotel Melati\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55120, applied to its single 2025 heir 55106 (same activity name).",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -378,7 +378,7 @@
       "judged_as": "55130",
       "annex_row": "Pondok Wisata",
       "page": 15,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p15, row \"Pondok Wisata\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55130, applied to its single 2025 heir 55201 (same activity name).",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p15, row \"Pondok Wisata\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55130, applied to its single 2025 heir 55201 (same activity name).",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -389,7 +389,7 @@
       "judged_as": "55193",
       "annex_row": "Vila",
       "page": 15,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p15, row \"Vila\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55193, applied to its single 2025 heir 55203 (same activity name).",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p15, row \"Vila\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 55193, applied to its single 2025 heir 55203 (same activity name).",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -400,7 +400,7 @@
       "judged_as": "79921",
       "annex_row": "Jasa pramuwisata",
       "page": 16,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Jasa pramuwisata\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 79921, applied to its single 2025 heir 79903 (same activity name).",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p16, row \"Jasa pramuwisata\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%. Judged on KBLI-2020 79921, applied to its single 2025 heir 79903 (same activity name).",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -411,7 +411,7 @@
       "judged_as": null,
       "annex_row": "Reparasi peralatan: Peralatan rumah tangga dan Peralatan rumah dan kebun",
       "page": 16,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Reparasi peralatan: Peralatan rumah tangga dan Peralatan rumah dan keb\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p16, row \"Reparasi peralatan: Peralatan rumah tangga dan Peralatan rumah dan keb\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -422,7 +422,7 @@
       "judged_as": null,
       "annex_row": "Vermak pakaian",
       "page": 16,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Vermak pakaian\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p16, row \"Vermak pakaian\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100
@@ -433,7 +433,7 @@
       "judged_as": null,
       "annex_row": "Industri reparasi barang rumah tangga dan pribadi lainnya St( No 054256 C",
       "page": 16,
-      "locator": "Perpres 49/2021 Lampiran II (Bidang Usaha Dialokasikan untuk Koperasi dan UMKM), p16, row \"Industri reparasi barang rumah tangga dan pribadi lainnya St( No 05425\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p16, row \"Industri reparasi barang rumah tangga dan pribadi lainnya St( No 05425\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; max foreign 0%.",
       "was": {
         "pma_status": "TERBUKA",
         "pma_max_asing": 100

--- a/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
@@ -9,7 +9,28 @@
     "contested_by_prior_in_repo_adjudication": ["79110"],
     "note_79110": "test_kbli_eye.test_travel_agency_terbatas_carries_full_cap asserts '79110 is TERBATAS but the adjudicated cap is 100% - never 0'. That determination lives in a TEST, not in pma_official_basis, so this applier's refuse-on-prior-basis rule could not see it. Two in-repo determinations disagree; resolving it needs #3317's history read, not a silent overwrite."
   },
-  "items": [
+  "withdrawn": {
+    "date": "2026-08-06",
+    "by": "cross-family adversarial review of the finished determination (Codex GPT-5.6), then re-verified at the source PDF",
+    "reason": "The evidence handed to the adjudicating lanes had the scope qualifier removed. Lampiran II is not a flat table: a numbered PARENT bidang usaha carries the scope and the rows indented under it carry a bare name. parse_perpres_lampiran2 emitted the child cell only, so a lane judging 01111 saw 'Jagung' and could not learn that the reservation reads 'Pertanian tanaman pangan dengan luas kurang dari 25 Ha'. Both model families agreed to reserve the whole code because neither was shown the limit.",
+    "codes_judged_under_a_restricting_parent": [
+      "01111",
+      "01113",
+      "01114",
+      "01115",
+      "01121",
+      "01122",
+      "43215",
+      "43221",
+      "43222",
+      "43224",
+      "43303"
+    ],
+    "count_tainted": 11,
+    "count_total": 39,
+    "next": "Re-adjudicate from the corrected relation, which now carries parent_heading per row and a 'parent-qualified' bucket. Not a re-run of the same prompts: the 11 tainted codes need the parent's limit stated in the evidence, and the rest need re-confirming against rows they were judged on before the field existed."
+  },
+  "withdrawn_items": [
     {
       "code": "01111",
       "judged_as": null,
@@ -439,5 +460,6 @@
         "pma_max_asing": 100
       }
     }
-  ]
+  ],
+  "items": []
 }

--- a/scripts/kbli_filiera/kbli_surface_conformance.py
+++ b/scripts/kbli_filiera/kbli_surface_conformance.py
@@ -97,7 +97,22 @@ PHANTOM_MARKER = "NOT_IN_KBLI_2025"
 # applied uniformly wherever no annex names the code — never flagged here,
 # because flagging it would just restate the pre-existing "no annex" default,
 # not surface new information.
-SPECIFIC_CITATION_BUCKETS = {"named-in-annex", "priority-lampiran-i"}
+#
+# `priority-lampiran-i` was in this set until 2026-08-06 and FAILED that very
+# test. Measured on the artifact: its 175 codes carry **exactly one distinct
+# cite** between them — "Perpres 49/2021 Lampiran I — priority business field
+# (Pasal 3(1)(a))" — which names no code, no percentage, no ownership treatment
+# (0 of its cites mention asing/%/foreign/modal). `named-in-annex` by contrast
+# has **61 distinct cites across 270 codes**, several carrying the KBLI-2020
+# crosswalk that earned the entry ("… via KBLI-2020 47911").
+#
+# So the check was demanding an adjudicated FOREIGN-OWNERSHIP basis for 173
+# codes whose citation asserts nothing about ownership — judging by which
+# bucket a code sits in rather than by what its citation actually says
+# (superscar #3). The compiler already knew: `perpres_body_default_relation.py`
+# records that priority listing "incentivises, it never restricts". A backlog
+# of 414 was really 241.
+SPECIFIC_CITATION_BUCKETS = {"named-in-annex"}
 
 SNAPSHOT_SQL = """
 SELECT coalesce(json_agg(json_build_object(

--- a/scripts/kbli_filiera/parse_perpres_lampiran2.py
+++ b/scripts/kbli_filiera/parse_perpres_lampiran2.py
@@ -216,8 +216,20 @@ def governing_headings(text: str) -> dict[tuple[int, int], str | None]:
     exactly that and reported retail-trade codes as children of a construction
     heading (W107: the probe that measures a disease can have it).
 
-    Declared limit: a heading that WRAPS across lines contributes only its first
-    line here. That truncates a parent's words, it never invents them, so a
+    THE COLON IS A FORM AND PARENTHOOD IS AN ENTITY, and this rule knowingly
+    judges by the form. `42  Dekorasi yang menggunakan teknologi sederhana dan
+    madya` has no colon and governs `43304`/`43305` all the same, so those two
+    lose their qualifier here. The entity rule was written and MEASURED — "a
+    numbered item carrying no KBLI code of its own is a heading" — and discarded:
+    a standalone row often carries its code on a LATER line, so that rule adopted
+    50 parents where there are 8, and would have moved ~41 rows out of the
+    owner's list on a bad inference. That is the harm this module's own caveat
+    warned about, in the direction it warned about. Eight verified parents beat
+    fifty guessed ones; the miss is declared here and `43304` currently lands in
+    `split-heirs`, where nothing acts on it.
+
+    Second declared limit: a heading that WRAPS across lines contributes only its
+    first line. That truncates a parent's words, it never invents them, so a
     qualifier can be missed but never fabricated — and `parent_heading` is
     evidence for a reader, not an automatic verdict.
     """
@@ -266,7 +278,30 @@ def row_line_span(lines: list[str], i: int, ticks: list[int], tick_x: int) -> li
 
     span = [i]
     seen_code = has_code(i)
+    # A line between two ticks cannot belong to both rows, and until 2026-08-06
+    # both claimed it: this row walked DOWN over it and the next row walked UP
+    # over it. In this annex the activity sits ABOVE its code+tick line, so the
+    # next row is usually the rightful owner — measured, SEVEN rows had eaten
+    # their neighbour's cell, e.g. `42912` recorded as "pelabuhan bukan perikanan
+    # pelabuhan perikanan", which is its own activity plus the whole of `42913`'s.
+    #
+    # …and a BLANK LINE, which is the annex's own row separator. Without it two
+    # rows both claimed the lines between their ticks — measured, SEVEN rows had
+    # eaten their neighbour's cell, `42912` recorded as "pelabuhan bukan
+    # perikanan pelabuhan perikanan", its own activity plus the whole of
+    # `42913`'s, which then reads as one wider activity than the annex reserves.
+    #
+    # Two narrower rules were tried first and MEASURED before shipping, because
+    # this is the function whose docstring warns that truncating produces a WRONG
+    # bucket rather than a missing one: (a) cede the whole gap whenever the next
+    # row walks upward — killed the fusion and truncated six legitimate wraps
+    # (`42209`, `71102` lost "teknologi sederhana dan madya" off their own tails)
+    # and dropped `41020` entirely; (b) up XOR down — same six casualties, since
+    # the annex really does wrap a cell ACROSS its tick line. Only the blank line
+    # separates rows without cutting a wrap, because it is what the DOCUMENT uses.
     for j in range(i + 1, following):
+        if not lines[j].strip():
+            break
         if _ROW_START_RE.match(lines[j]) or _PAGE_FURNITURE_RE.match(lines[j]):
             break
         if has_code(j):
@@ -276,7 +311,7 @@ def row_line_span(lines: list[str], i: int, ticks: list[int], tick_x: int) -> li
         span.append(j)
     if not cell_at(lines[i], tick_x):
         for j in range(i - 1, previous, -1):
-            if _PAGE_FURNITURE_RE.match(lines[j]):
+            if _PAGE_FURNITURE_RE.match(lines[j]) or not lines[j].strip():
                 break
             span.insert(0, j)
             if _ROW_START_RE.match(lines[j]) or has_code(j):

--- a/scripts/kbli_filiera/parse_perpres_lampiran2.py
+++ b/scripts/kbli_filiera/parse_perpres_lampiran2.py
@@ -188,6 +188,51 @@ def cell_at(line: str, tick_x: int) -> str:
     return _LEADING_NUMBER_RE.sub("", left[:cut].strip(" -\t")).strip(" -\t")
 
 
+# A numbered item in the annex's leftmost column. The annex is not a flat table:
+# an item that ends in a colon is a PARENT bidang usaha whose scope governs the
+# indented rows beneath it, and those rows carry only a bare name.
+#
+#     1   Pertanian tanaman pangan dengan luas kurang dari 25 Ha:
+#            Padi hibrida        01121   V
+#            Jagung              01111   V
+#
+# Reading the child cell alone yields "Jagung" and loses "dengan luas kurang dari
+# 25 Ha" — the words that decide whether the reservation covers the whole KBLI
+# code or only smallholdings. Emitting the child WITHOUT its parent hands every
+# downstream reader an activity whose scope has been silently widened, and no
+# amount of care further down can recover what was never in the row. Measured
+# 2026-08-06 against the vaulted PDF: three parents carry such a qualifier
+# ("... kurang dari 25 Ha", and twice "... teknologi sederhana dan madya").
+_NUMBERED_ITEM_RE = re.compile(r"^\s{0,14}\d{1,3}\s{2,}(\S.*?)\s*$")
+
+
+def governing_headings(text: str) -> dict[tuple[int, int], str | None]:
+    """(page, line index) -> the numbered parent heading in force at that line.
+
+    A numbered item ALWAYS closes the previous parent: one that ends in a colon
+    opens a new one, one that does not is a standalone row and leaves the lines
+    after it parentless. Without that reset a parent leaks down the page and
+    adopts rows from the next section — a probe written for this defect did
+    exactly that and reported retail-trade codes as children of a construction
+    heading (W107: the probe that measures a disease can have it).
+
+    Declared limit: a heading that WRAPS across lines contributes only its first
+    line here. That truncates a parent's words, it never invents them, so a
+    qualifier can be missed but never fabricated — and `parent_heading` is
+    evidence for a reader, not an automatic verdict.
+    """
+    out: dict[tuple[int, int], str | None] = {}
+    parent: str | None = None
+    for page_no, page in enumerate(text.split("\f"), start=1):
+        for n, line in enumerate(page.splitlines()):
+            m = _NUMBERED_ITEM_RE.match(line)
+            if m:
+                label = m.group(1).rstrip()
+                parent = label[:-1].strip() if label.endswith(":") else None
+            out[(page_no, n)] = parent
+    return out
+
+
 def row_line_span(lines: list[str], i: int, ticks: list[int], tick_x: int) -> list[int]:
     """Which lines belong to the table row whose tick is on line `i`.
 
@@ -245,6 +290,8 @@ def parse(text: str, titles: dict[str, str], known: frozenset[str]) -> dict:
     tick_histogram: dict[int, int] = {}
     consumed: set[tuple[int, str]] = set()
 
+    headings = governing_headings(text)
+
     for page_no, page in enumerate(text.split("\f"), start=1):
         lines = page.splitlines()
         ticks = [n for n, line in enumerate(lines) if re.search(r"\bV\b", line)]
@@ -276,6 +323,11 @@ def parse(text: str, titles: dict[str, str], known: frozenset[str]) -> dict:
                     "column": column,
                     "page": page_no,
                     "text": activity,
+                    # The parent bidang usaha this row is indented under, or
+                    # None for a row that stands on its own. Emitted for EVERY
+                    # row, not only qualified ones, so a reader can tell "no
+                    # parent" from "parent not looked for".
+                    "parent_heading": headings.get((page_no, i)),
                     "read_from": read_from,
                     # True only when the row's own words independently corroborate the
                     # decoded digits. A row without it is not wrong — it is single-witness.

--- a/scripts/kbli_filiera/perpres_foreign_cap_relation.py
+++ b/scripts/kbli_filiera/perpres_foreign_cap_relation.py
@@ -37,8 +37,13 @@ THE UNIT IS THE (bidang usaha, KBLI) PAIR — NEVER THE CODE
 -----------------------------------------------------------
 Entry 7 gives `30111` a 49% foreign cap as a WARSHIP yard; entry 8 gives the SAME
 code a 0% cap as a builder of pinisi/cadik/traditional wooden vessels. The body
-says so explicitly (art. 3(3): where one KBLI spans several bidang usaha, the
-Lampiran III requirement applies only to the bidang usaha named in the column).
+says so explicitly — **Pasal 6 ayat (3)**, the article that governs Lampiran III:
+where one KBLI covers more than one bidang usaha, the Lampiran III requirement
+applies only to the bidang usaha named in that column. (Read at the source
+2026-08-06. This cited `art. 3(3)` until then, which does not exist: Pasal 3 has
+two ayat. The granularity rule is written once PER ANNEX — 5(5) for Lampiran II,
+6(3) for Lampiran III — so one remembered number cannot serve both, which is how
+the phantom propagated to five places.)
 A code -> cap join is therefore structurally wrong for such a code, and a single
 `pma_max_asing` integer cannot represent it. Same for phase-dependent caps
 (`58130`: 0% at establishment, 49% via the capital market for expansion) and for

--- a/scripts/kbli_filiera/perpres_umkm_reservation_relation.py
+++ b/scripts/kbli_filiera/perpres_umkm_reservation_relation.py
@@ -77,13 +77,27 @@ Each divergent row is instead sorted by WHY it cannot simply be applied:
   the LARGEST of the divergent ones — which is why it must not be reported as a
   single number.
 
-Known floor on `segment-qualified`, declared rather than silently absorbed: a
-grade qualifier can live in the numbered PARENT heading instead of the row
-("35. Konstruksi bangunan yang menggunakan teknologi sederhana dan madya:"
-governs `42911`/`42912`/`42913` below it). Those rows are left in `whole-row`
-on purpose. Inheriting a parent's qualifier would move rows OUT of the owner's
-list on an inference, and a question wrongly withdrawn is worse than a question
-wrongly asked.
+* `parent-qualified` — the row's own words name a whole activity, but the
+  numbered PARENT heading it is indented under restricts the scope: "Pertanian
+  tanaman pangan dengan luas kurang dari 25 Ha:" governs `01111`/`01121`/… below
+  it, whose cells read only "Jagung", "Padi hibrida". 19 rows, three headings
+  (the 25-Ha one and twice "teknologi sederhana dan madya").
+
+  THIS BUCKET EXISTS BECAUSE ITS ABSENCE COST SOMETHING (2026-08-06). Until that
+  day this paragraph was a prose caveat saying such rows are "left in
+  `whole-row` on purpose", reasoning that a question wrongly withdrawn is worse
+  than one wrongly asked. The reasoning still holds — that is why this is a
+  NAMED bucket and not a silent absorption into `segment-qualified`. What did
+  not hold is leaving the qualifier out of the DATA: `parse_perpres_lampiran2`
+  emitted the child cell alone, so the 21-agent adjudication of the 85
+  `whole-row` codes was handed "Jagung" with no way to learn about the 25 Ha,
+  and both model families agreed to reserve the whole code. ELEVEN of the 39
+  codes it proposed to patch sit under a restricting parent. The patch was
+  withdrawn before merge by a cross-family review of the finished
+  determination; nothing reached a client. A limitation that lives only in a
+  docstring does not travel with the rows, and the reader who needed it was
+  never going to open this file (superscar #3 / W115: a comment that states an
+  invariant does not enforce it).
 
 Usage:
     python scripts/kbli_filiera/perpres_umkm_reservation_relation.py --check [--json]
@@ -108,6 +122,16 @@ EXIT_OK, EXIT_CANNOT_VERIFY = 0, 4
 # word, and this list is deliberately short: an unrecognised qualifier falls to
 # `whole-row`, where a human reads it, rather than being silently absorbed.
 _SEGMENT_RE = re.compile(r"\b(sederhana|madya|kecil|mikro|kualifikasi)\b", re.IGNORECASE)
+
+# The same idea applied to the PARENT bidang usaha a row is indented under. The
+# annex writes the scope once, on the heading, and the children carry a bare
+# name — so "Jagung" is reserved only as part of "Pertanian tanaman pangan
+# dengan luas kurang dari 25 Ha". Adds the area/quantity forms the row-level
+# expression never needs, because a heading is where a threshold is written.
+_PARENT_QUALIFIER_RE = re.compile(
+    r"\b(kurang dari|lebih dari|sederhana|madya|kecil|mikro|kualifikasi)\b",
+    re.IGNORECASE,
+)
 
 # Statuses that leave a foreign investor able to take the activity. TERTUTUP is
 # already closed to everyone, so a reservation adds nothing a client would see.
@@ -223,6 +247,9 @@ def classify(
         return "activity-unknown", record, heirs
     if _SEGMENT_RE.search(row["text"]):
         return "segment-qualified", record, heirs
+    parent = row.get("parent_heading")
+    if parent and _PARENT_QUALIFIER_RE.search(parent):
+        return "parent-qualified", record, heirs
     return "whole-row", record, heirs
 
 

--- a/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
@@ -1,0 +1,153 @@
+"""Guilt + innocence for the Lampiran II applier.
+
+The patch itself is four constant fields; nothing interesting can go wrong
+there. What can go wrong is the applier writing a client-facing 0%-foreign
+verdict onto a record it should have refused, so every test below is about a
+REFUSAL — and one about the refusals not being so eager that nothing applies.
+
+`check()` aborts the whole run on a single refusal by design: a spec that is
+wrong about one code has not earned trust about the other thirty-nine.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+FILIERA = Path(__file__).resolve().parents[1]
+if str(FILIERA) not in sys.path:
+    sys.path.insert(0, str(FILIERA))
+
+import apply_umkm_reservations as A  # noqa: E402
+
+
+def rec(code, status="TERBUKA", maxa=100, ancestors=None, basis=None):
+    r = {"kode_kbli_2025": code, "pma_status": status, "pma_max_asing": maxa}
+    if ancestors is not None:
+        r["bps_2020_ancestors"] = {"codes": ancestors}
+    if basis is not None:
+        r["pma_official_basis"] = basis
+    return r
+
+
+def item(code, judged_as=None, was=None, locator="L-II p1"):
+    return {
+        "code": code,
+        "judged_as": judged_as,
+        "locator": locator,
+        "was": was if was is not None else {"pma_status": "TERBUKA", "pma_max_asing": 100},
+    }
+
+
+def run(items, records):
+    return A.check({"items": items}, records)
+
+
+# --------------------------------------------------------------------------
+# INNOCENCE — the ordinary case must actually go through
+# --------------------------------------------------------------------------
+
+
+def test_a_matching_record_is_applicable():
+    todo, refusals = run([item("01111")], [rec("01111")])
+    assert refusals == []
+    assert [i["code"] for i in todo] == ["01111"]
+
+
+def test_a_row_judged_on_a_2020_code_applies_to_its_single_heir():
+    """`55193` (villa) is not a 2025 code; `55203` is, and is its only heir."""
+    todo, refusals = run(
+        [item("55203", judged_as="55193")],
+        [rec("55203", ancestors=["55193"])],
+    )
+    assert refusals == []
+    assert [i["code"] for i in todo] == ["55203"]
+
+
+def test_the_same_locator_already_present_is_not_an_obstacle():
+    """Re-running the cure must be idempotent, not self-blocking."""
+    todo, refusals = run(
+        [item("01111", locator="L-II p1")],
+        [rec("01111", basis="L-II p1")],
+    )
+    assert refusals == [] and len(todo) == 1
+
+
+# --------------------------------------------------------------------------
+# GUILT — every way this must refuse rather than write
+# --------------------------------------------------------------------------
+
+
+def test_refuses_a_code_absent_from_the_dataset():
+    todo, refusals = run([item("99999")], [rec("01111")])
+    assert todo == [] and len(refusals) == 1 and "not in the dataset" in refusals[0]
+
+
+def test_refuses_when_the_2020_code_has_several_heirs():
+    """The split-heirs case: the annex reserves ONE segment, so a 2020 code
+    that fans out to several 2025 codes cannot hand its verdict to one of them."""
+    todo, refusals = run(
+        [item("55203", judged_as="55110")],
+        [rec("55203", ancestors=["55110"]), rec("55201", ancestors=["55110"])],
+    )
+    assert todo == []
+    assert "resolves to" in refusals[0]
+
+
+def test_refuses_when_the_2020_code_has_no_heir_at_all():
+    todo, refusals = run([item("55203", judged_as="55193")], [rec("55203")])
+    assert todo == [] and "no 2025 heir" in refusals[0]
+
+
+def test_refuses_a_record_already_adjudicated_by_hand():
+    """A different `pma_official_basis` is someone else's later word, and this
+    tool is not entitled to overwrite it."""
+    todo, refusals = run(
+        [item("47111", locator="L-II p14")],
+        [rec("47111", basis="Perpres 10/2021 Lampiran II line 3722 — hand-adjudicated")],
+    )
+    assert todo == [] and "different pma_official_basis" in refusals[0]
+
+
+def test_refuses_when_the_record_moved_since_the_adjudication():
+    """Someone cured this code between the adjudication and the apply; the
+    verdict was formed against a world that no longer exists."""
+    todo, refusals = run(
+        [item("01111", was={"pma_status": "TERBUKA", "pma_max_asing": 100})],
+        [rec("01111", status="TERBATAS", maxa=49)],
+    )
+    assert todo == [] and "moved since adjudication" in refusals[0]
+
+
+def test_one_bad_row_stops_the_whole_run():
+    todo, refusals = run([item("01111"), item("99999")], [rec("01111")])
+    assert len(refusals) == 1
+    assert len(todo) == 1  # collected, but main() aborts on any refusal
+
+
+# --------------------------------------------------------------------------
+# The patch, and what the real spec is allowed to contain
+# --------------------------------------------------------------------------
+
+
+def test_patch_states_zero_foreign_and_names_its_basis():
+    p = A.patch_for(item("01111", locator="L-II p1"))
+    assert p["pma_max_asing"] == 0
+    assert p["pma_status"] == "TERBATAS"
+    assert p["pma_official_basis"] == "L-II p1"
+    assert p["pma_cap_verified"] is True
+
+
+def test_the_shipped_spec_carries_only_unanimous_verdicts():
+    """Structural pin on the real artifact: the excluded populations must still
+    be declared in it, so a future regeneration cannot quietly absorb the
+    disagreements into the patch set."""
+    spec = json.loads(A.SPEC.read_text(encoding="utf-8"))
+    ex = spec["excluded"]
+    assert ex["disagreements"] > 0 and ex["agreed_unclear"] > 0
+    assert ex["ocr_illegible"], "the illegible row must stay named, not vanish"
+    codes = [i["code"] for i in spec["items"]]
+    assert len(codes) == len(set(codes)), "a code patched twice"
+    for i in spec["items"]:
+        assert "Lampiran II" in i["locator"] and "Pasal 3(1)(b)" in i["locator"]

--- a/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
@@ -142,12 +142,48 @@ def test_patch_states_zero_foreign_and_names_its_basis():
 def test_the_shipped_spec_carries_only_unanimous_verdicts():
     """Structural pin on the real artifact: the excluded populations must still
     be declared in it, so a future regeneration cannot quietly absorb the
-    disagreements into the patch set."""
+    disagreements into the patch set. Reads `withdrawn_items` when the spec has
+    been withdrawn — the verdicts are still a record worth pinning even though
+    none of them may be applied."""
     spec = json.loads(A.SPEC.read_text(encoding="utf-8"))
     ex = spec["excluded"]
     assert ex["disagreements"] > 0 and ex["agreed_unclear"] > 0
     assert ex["ocr_illegible"], "the illegible row must stay named, not vanish"
-    codes = [i["code"] for i in spec["items"]]
+    verdicts = spec.get("items") or spec["withdrawn_items"]
+    codes = [i["code"] for i in verdicts]
     assert len(codes) == len(set(codes)), "a code patched twice"
-    for i in spec["items"]:
+    for i in verdicts:
         assert "Lampiran II" in i["locator"] and "Pasal 3(1)(b)" in i["locator"]
+
+
+def test_guilt_a_withdrawn_spec_is_refused_before_anything_is_read(tmp_path, capsys):
+    """The shipped spec IS withdrawn, so this is the live path. `items: []` alone
+    would make the run a silent no-op that prints "applied 0 codes" — which reads
+    like success. The refusal has to name itself."""
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps({
+        "withdrawn": {"date": "2026-08-06", "by": "review", "reason": "why", "next": "what"},
+        "items": [], "withdrawn_items": [], "excluded": {},
+    }), encoding="utf-8")
+    assert A.main(["--apply", "--spec", str(p)]) == A.EXIT_REFUSED
+    assert "REFUSING" in capsys.readouterr().out
+
+
+def test_innocence_a_spec_without_that_marker_still_runs():
+    """The guard must not turn every spec into a refusal — the tool has to stay
+    usable for the re-adjudicated spec that replaces this one."""
+    spec = json.loads(A.SPEC.read_text(encoding="utf-8"))
+    assert "withdrawn" in spec, "the shipped spec is the withdrawn one"
+    todo, refusals = run([item("01111")], [rec("01111")])
+    assert refusals == [] and [i["code"] for i in todo] == ["01111"]
+
+
+def test_the_withdrawal_names_the_codes_whose_evidence_was_short():
+    """Not a count: the eleven codes judged under a restricting parent are named,
+    so the re-adjudication cannot start from "39 codes, re-check them all" and
+    lose which ones were actually compromised."""
+    w = json.loads(A.SPEC.read_text(encoding="utf-8"))["withdrawn"]
+    tainted = w["codes_judged_under_a_restricting_parent"]
+    assert len(tainted) == w["count_tainted"] > 0
+    assert "01111" in tainted, "the 25-Ha food crops are the clearest members"
+    assert "43215" in tainted, "so is the simple/intermediate technology grade"

--- a/scripts/kbli_filiera/tests/test_kbli_surface_conformance.py
+++ b/scripts/kbli_filiera/tests/test_kbli_surface_conformance.py
@@ -291,12 +291,26 @@ def test_guilt_named_in_annex_with_no_canonical_basis():
     assert report["specific_citation_codes"] == 1
 
 
-def test_guilt_priority_lampiran_i_with_no_canonical_basis():
+def test_innocence_priority_lampiran_i_is_not_an_ownership_citation():
+    """This test asserted the OPPOSITE until 2026-08-06, and it was wrong.
+
+    Being listed in Lampiran I means the activity is a PRIORITY business field
+    — it attracts incentives; it states nothing about how much of it a foreigner
+    may own. `perpres_body_default_relation.py` says so in its own words
+    ("priority incentivises, it never restricts"), and the artifact agrees: all
+    175 codes in the bucket share ONE cite, which names no code, no percentage
+    and no ownership treatment.
+
+    So flagging them as "a citation the website shows and canonical lacks" was
+    demanding an adjudicated foreign-ownership basis for a fact nobody asserts
+    — 173 entries of a 414-entry backlog that were never real work.
+    """
     report = C.plan_citation_propagation(
-        store(canon("10211")),  # no pma_official_basis
+        store(canon("10211")),  # no pma_official_basis, and correctly not asked for
         {"10211": loc("priority-lampiran-i")},
     )
-    assert [d["code"] for d in report["citation_not_propagated"]] == ["10211"]
+    assert report["citation_not_propagated"] == []
+    assert report["specific_citation_codes"] == 0
 
 
 def test_innocence_generic_default_bucket_is_never_flagged():
@@ -370,3 +384,59 @@ def test_citation_not_propagated_folds_into_the_cli_exit_code(tmp_path):
         ]
     )
     assert rc == C.EXIT_DIVERGENCE
+
+
+# ---------------------------------------------------------------------------
+# The eligibility set must judge what a citation SAYS, not which bucket it is
+#
+# `priority-lampiran-i` sat in SPECIFIC_CITATION_BUCKETS until 2026-08-06 and
+# failed the very definition the constant's comment states. Its 175 codes share
+# ONE cite naming no code and no ownership treatment, so the detector demanded
+# an adjudicated foreign-ownership basis for 173 codes whose citation asserts
+# nothing about ownership. The structural test below is the general form: a
+# bucket whose codes all repeat a single string is generic BY MEASUREMENT,
+# whatever it is called, so the next such bucket cannot be added silently.
+# ---------------------------------------------------------------------------
+
+
+def _real_locators():
+    path = C.REPO_ROOT / "apps/mouth/data/perpres-locators.json"
+    if not path.exists():  # pragma: no cover - artifact always shipped
+        return None
+    return C.load_locators(path)
+
+
+def test_priority_listing_is_not_an_ownership_citation():
+    """GUILT, pinned on the live artifact: the excluded bucket really is the
+    degenerate case, and it really says nothing about foreign ownership."""
+    locators = _real_locators()
+    assert locators, "artifact missing — this pin cannot verify"
+
+    priority = [v for v in locators.values() if v.get("bucket") == "priority-lampiran-i"]
+    assert priority, "bucket vanished — re-derive this pin before deleting it"
+    assert len({v["cite"] for v in priority}) == 1, "no longer degenerate"
+    assert not any(
+        w in v["cite"].lower()
+        for v in priority
+        for w in ("asing", "%", "foreign", "modal", "ownership")
+    ), "priority cites now assert ownership — re-open the exclusion"
+    assert "priority-lampiran-i" not in C.SPECIFIC_CITATION_BUCKETS
+
+
+def test_every_eligible_bucket_is_code_named_by_measurement():
+    """INNOCENCE for the narrowing, and the tripwire for the NEXT bucket: what
+    stays in the set must earn it on the artifact, not by being named there.
+
+    `named-in-annex` passes with 61 distinct cites across 270 codes, several
+    carrying the KBLI-2020 crosswalk that earned the entry.
+    """
+    locators = _real_locators()
+    assert locators, "artifact missing — this pin cannot verify"
+
+    assert C.SPECIFIC_CITATION_BUCKETS, "an empty set would silently pass"
+    for bucket in C.SPECIFIC_CITATION_BUCKETS:
+        cites = {v["cite"] for v in locators.values() if v.get("bucket") == bucket}
+        assert len(cites) > 1, (
+            f"{bucket}: {len(cites)} distinct cite(s) — a single repeated string "
+            "is a generic default, not a code-named citation"
+        )

--- a/scripts/kbli_filiera/tests/test_perpres_body_default.py
+++ b/scripts/kbli_filiera/tests/test_perpres_body_default.py
@@ -248,26 +248,32 @@ def test_the_barred_but_open_list_reads_across_every_bucket(rep):
     A locator-partitioned reading found only 14; reading across every bucket
     found 23.
 
-    **19, not 23, since 2026-08-06.** The queue lost `55201` (homestay),
-    `55203` (villa), `79110` (travel agent) and `95291` (clothing alterations)
-    because the Lampiran II cure restricted them for a STRONGER and different
-    reason: the annex allocates those activities to Koperasi/UMKM, so they no
-    longer publish as open and the Pasal 7(1) question about them is moot.
+    It went to 19 for a few hours on 2026-08-06 and is back at 23, and the round
+    trip is worth more than either number. The Lampiran II cure had restricted
+    `55201` (homestay), `55203` (villa), `79110` (travel agent) and `95291`
+    (clothing alterations) for a stronger and different reason — the annex
+    allocates those activities to Koperasi/UMKM — so they stopped publishing as
+    open and their Pasal 7(1) question became moot. That cure was WITHDRAWN the
+    same day: a cross-family review of the finished determination found the
+    evidence it rested on had the scope qualifier stripped out (the annex
+    reserves food crops only "dengan luas kurang dari 25 Ha", and the rows we
+    emitted carried the bare crop name). See `apply_umkm_reservations.py` and
+    the `withdrawn` block in its spec.
 
-    That is the queue working, not shrinking: this list exists to hold codes
-    whose openness is unexplained, and four of them stopped being open. The
-    membership assertions below therefore moved to codes still IN the queue —
-    an assertion naming a code the cure removed would fail for the right
-    reason, which is precisely how this test caught the change.
+    So these four are back in the queue, where an unexplained openness belongs.
+    The queue is meant to hold codes whose openness nobody has justified — and
+    the honest state of these four is exactly that: not "reserved" and not
+    "cleared", but unadjudicated on evidence that was never complete.
     """
     rows = pasal7_review_flags(rep)
-    assert len(rows) == 19
+    assert len(rows) == 23
     codes = {r["code"] for r in rows}
     assert {"96210", "96220"} <= codes           # annex-named AND Besar-less
     assert {"56304", "70201", "86995"} <= codes  # residual AND Besar-less
-    assert not ({"55201", "55203", "79110", "95291"} & codes), (
-        "a Lampiran II code is publishing as open again — the cure regressed"
-    )
+    # The four the withdrawn cure had removed. Asserted as PRESENT, so that
+    # re-applying a Lampiran II verdict to them shows up here as a failure and
+    # gets read against the withdrawal above rather than landing unnoticed.
+    assert {"55201", "55203", "79110", "95291"} <= codes
     assert all(r["besar"] == "absent" for r in rows)
 
 

--- a/scripts/kbli_filiera/tests/test_perpres_body_default.py
+++ b/scripts/kbli_filiera/tests/test_perpres_body_default.py
@@ -244,14 +244,30 @@ def test_a_code_named_in_an_annex_still_reports_its_besar_state(canonical, annex
 
 
 def test_the_barred_but_open_list_reads_across_every_bucket(rep):
-    """Measured: 23 codes publish TERBUKA while their own scale data names no
-    Besar row. A locator-partitioned reading found only 14.
+    """Codes that publish TERBUKA while their own scale data names no Besar row.
+    A locator-partitioned reading found only 14; reading across every bucket
+    found 23.
+
+    **19, not 23, since 2026-08-06.** The queue lost `55201` (homestay),
+    `55203` (villa), `79110` (travel agent) and `95291` (clothing alterations)
+    because the Lampiran II cure restricted them for a STRONGER and different
+    reason: the annex allocates those activities to Koperasi/UMKM, so they no
+    longer publish as open and the Pasal 7(1) question about them is moot.
+
+    That is the queue working, not shrinking: this list exists to hold codes
+    whose openness is unexplained, and four of them stopped being open. The
+    membership assertions below therefore moved to codes still IN the queue —
+    an assertion naming a code the cure removed would fail for the right
+    reason, which is precisely how this test caught the change.
     """
     rows = pasal7_review_flags(rep)
-    assert len(rows) == 23
+    assert len(rows) == 19
     codes = {r["code"] for r in rows}
-    assert {"55203", "55201", "96210", "96220"} <= codes  # annex-named AND Besar-less
-    assert {"56304", "70201", "86995"} <= codes           # residual AND Besar-less
+    assert {"96210", "96220"} <= codes           # annex-named AND Besar-less
+    assert {"56304", "70201", "86995"} <= codes  # residual AND Besar-less
+    assert not ({"55201", "55203", "79110", "95291"} & codes), (
+        "a Lampiran II code is publishing as open again — the cure regressed"
+    )
     assert all(r["besar"] == "absent" for r in rows)
 
 

--- a/scripts/kbli_filiera/tests/test_perpres_body_default.py
+++ b/scripts/kbli_filiera/tests/test_perpres_body_default.py
@@ -270,10 +270,20 @@ def test_the_barred_but_open_list_reads_across_every_bucket(rep):
     codes = {r["code"] for r in rows}
     assert {"96210", "96220"} <= codes           # annex-named AND Besar-less
     assert {"56304", "70201", "86995"} <= codes  # residual AND Besar-less
-    # The four the withdrawn cure had removed. Asserted as PRESENT, so that
-    # re-applying a Lampiran II verdict to them shows up here as a failure and
-    # gets read against the withdrawal above rather than landing unnoticed.
-    assert {"55201", "55203", "79110", "95291"} <= codes
+    # The three the withdrawn cure had removed, asserted as PRESENT: re-applying
+    # a Lampiran II verdict to them shows up here as a failure and gets read
+    # against the withdrawal above rather than landing unnoticed.
+    #
+    # `79110` (travel agent) is deliberately NOT in this set, and finding that
+    # out cost an assertion. It appeared in the earlier version of this list, but
+    # it was never in the withdrawn patch — it had been dropped from that spec
+    # days before, as contested by a determination living in `test_kbli_eye.py`.
+    # It is out of the queue on its own terms: the catalogue already publishes it
+    # TERBATAS, so it is not "barred but open" and this list has no claim on it.
+    # A code can leave a queue for a reason that has nothing to do with the cure
+    # you are writing about.
+    assert {"55201", "55203", "95291"} <= codes
+    assert "79110" not in codes
     assert all(r["besar"] == "absent" for r in rows)
 
 

--- a/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
+++ b/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
@@ -16,6 +16,7 @@ is not a bar, and asserting one on those 57 rows is the same over-match
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -588,3 +589,71 @@ def test_the_live_artifact_carries_the_parent_that_was_missing():
     assert {r["code"] for r in qualified} == {
         "01111", "01113", "01114", "01115", "01121", "01122",
     }
+
+
+# ---------------------------------------------------------------------------
+# The phantom article — Pasal 3(3) names nothing
+# ---------------------------------------------------------------------------
+
+_PHANTOM_RE = re.compile(r"Pasal 3\s*(?:ayat\s*)?\(3\)|art\.?\s*3\(3\)", re.IGNORECASE)
+# A mention is absolved only when the SAME line disowns it. "Pasal 3(3)" written
+# beside "does not exist" is a correction; written alone it is a citation, and a
+# citation of an article that has no third ayat supports nothing. Deliberately
+# same-line: a window would let the colpevole sentence borrow an absolution from
+# a neighbouring paragraph, which is how the retracted-claims guard first failed.
+_DISOWNED_RE = re.compile(r"does not exist|phantom|no third ayat|names nothing", re.IGNORECASE)
+
+
+def phantom_citations(text: str) -> list[int]:
+    """1-indexed lines citing Pasal 3(3) without disowning it on the same line."""
+    return [
+        n for n, line in enumerate(text.splitlines(), 1)
+        if _PHANTOM_RE.search(line) and not _DISOWNED_RE.search(line)
+    ]
+
+
+def test_guilt_a_bare_citation_of_the_phantom_is_caught():
+    assert phantom_citations("the rule is Pasal 3(3): it attaches to the named bidang usaha") == [1]
+    assert phantom_citations("the body says so explicitly (art. 3(3): where one KBLI") == [1]
+
+
+def test_innocence_a_sentence_that_disowns_it_is_allowed():
+    """Correcting the phantom requires writing it. A guard that forbids naming
+    what it bans makes the correction uncommittable — and this one bit its own
+    author on the first run, which is how the rule got written down."""
+    assert phantom_citations("This cited `art. 3(3)` until then, which does not exist.") == []
+    assert phantom_citations("`Pasal 3(3)` does not exist. It was a phantom.") == []
+
+
+def test_innocence_the_real_articles_are_not_touched():
+    for ok in ("Pasal 5 ayat (5)", "Pasal 6(3)", "Pasal 3 ayat (1) huruf b", "Pasal 3(1)(b)"):
+        assert phantom_citations(f"the rule is {ok} and it governs the annex") == [], ok
+
+
+def test_the_kbli_tooling_and_prose_carry_no_bare_phantom_citation():
+    """Perpres 10/2021 writes the "one KBLI, several bidang usaha" rule ONCE PER
+    ANNEX — Pasal 5(5) for Lampiran II, Pasal 6(3) for Lampiran III — and Pasal 3
+    has only two ayat.
+
+    The phantom sat in five files for five days, including the corner skill every
+    KBLI session loads, because one remembered number was reused for both
+    annexes. Lexical guard, and it knows it: it cannot tell a right citation from
+    a wrong one, only a citation that cannot exist from everything else.
+    """
+    root = Path(__file__).resolve().parents[2].parent
+    targets = [root / "scripts" / "kbli_filiera", root / "research" / "compliance",
+               root / ".agents" / "skills" / "kbli-navigator"]
+    scanned, offenders = 0, []
+    for base in (b for b in targets if b.exists()):
+        for f in list(base.rglob("*.py")) + list(base.rglob("*.md")):
+            if f.name == Path(__file__).name:
+                continue  # this file writes the phantom in order to ban it
+            scanned += 1
+            for n in phantom_citations(f.read_text(encoding="utf-8", errors="replace")):
+                offenders.append(f"{f.relative_to(root)}:{n}")
+    # A blind scan must not look like a clean one (W84).
+    assert scanned > 5, f"only {scanned} files scanned — the scan, not the repo, is empty"
+    assert not offenders, (
+        "Pasal 3(3) does not exist. Lampiran II -> Pasal 5(5); "
+        f"Lampiran III -> Pasal 6(3). Found: {offenders}"
+    )

--- a/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
+++ b/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
@@ -519,3 +519,72 @@ def test_the_command_the_operator_runs_exits_zero():
     from perpres_umkm_reservation_relation import EXIT_OK, main  # noqa: PLC0415
 
     assert main(["--check", "--json"]) == EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# parent-qualified — the scope the annex writes ONCE, on the heading
+# ---------------------------------------------------------------------------
+
+
+def _row(code="01111", text="Jagung", parent=None):
+    r = {"code": code, "column": "dialokasikan", "page": 1, "text": text,
+         "read_from": "text-layer", "title_corroborated": True}
+    if parent is not None:
+        r["parent_heading"] = parent
+    return r
+
+
+def test_guilt_a_restricting_parent_takes_the_row_out_of_whole_row():
+    """The defect this bucket exists for: "Jagung" reads like a whole activity,
+    and it is reserved only as part of "…dengan luas kurang dari 25 Ha"."""
+    canon = {"01111": {"pma_status": "TERBUKA", "pma_max_asing": 100, "judul": "Jagung"}}
+    bucket, _, _ = classify(
+        _row(parent="Pertanian tanaman pangan dengan luas kurang dari 25 Ha"), canon, {}
+    )
+    assert bucket == "parent-qualified"
+
+
+def test_guilt_the_technology_grade_heading_qualifies_too():
+    canon = {"43215": {"pma_status": "TERBUKA", "pma_max_asing": 100, "judul": "Instalasi"}}
+    bucket, _, _ = classify(
+        _row(code="43215", text="43215",
+             parent="Instalasi yang menggunakan teknologi sederhana dan madya"),
+        canon, {},
+    )
+    assert bucket == "parent-qualified"
+
+
+def test_innocence_an_unrestricting_parent_leaves_the_row_in_whole_row():
+    """A heading that merely GROUPS ("Pemungutan hasil hutan:") narrows nothing.
+    Treating every parent as a qualifier would empty the owner's list, which is
+    the error the prose caveat was right to fear."""
+    canon = {"02303": {"pma_status": "TERBUKA", "pma_max_asing": 100, "judul": "Getah"}}
+    bucket, _, _ = classify(
+        _row(code="02303", text="Getah pinus", parent="Pemungutan hasil hutan"), canon, {}
+    )
+    assert bucket == "whole-row"
+
+
+def test_innocence_a_row_with_no_parent_is_unaffected():
+    canon = {"47111": {"pma_status": "TERBUKA", "pma_max_asing": 100, "judul": "Minimarket"}}
+    bucket, _, _ = classify(_row(code="47111", text="Minimarket", parent=None), canon, {})
+    assert bucket == "whole-row"
+
+
+def test_the_live_artifact_carries_the_parent_that_was_missing():
+    """TRIPWIRE on the DATA, not the classifier. The adjudication that had to be
+    withdrawn was handed rows whose cell said only "Jagung": the 25-Ha scope was
+    in the annex, visible to anyone reading the PDF, and absent from every row
+    we emitted. If a re-parse ever drops `parent_heading` again, this fails —
+    the classifier above would go on passing, because it takes the parent as an
+    argument."""
+    rows = load_relation()["rows"]
+    jagung = next(r for r in rows if r["code"] == "01111")
+    assert "kurang dari 25 Ha" in (jagung.get("parent_heading") or ""), jagung
+    # …and the field is emitted for every row, so "no parent" is distinguishable
+    # from "parents were never looked for".
+    assert all("parent_heading" in r for r in rows)
+    qualified = [r for r in rows if "kurang dari" in (r.get("parent_heading") or "")]
+    assert {r["code"] for r in qualified} == {
+        "01111", "01113", "01114", "01115", "01121", "01122",
+    }

--- a/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
+++ b/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
@@ -657,3 +657,52 @@ def test_the_kbli_tooling_and_prose_carry_no_bare_phantom_citation():
         "Pasal 3(3) does not exist. Lampiran II -> Pasal 5(5); "
         f"Lampiran III -> Pasal 6(3). Found: {offenders}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Row fusion — two rows cannot both own the lines between their ticks
+# ---------------------------------------------------------------------------
+
+
+def test_guilt_a_row_no_longer_swallows_the_next_rows_cell():
+    """`42912` (pelabuhan bukan perikanan) had recorded its own activity PLUS
+    the whole of `42913`'s (pelabuhan perikanan), which reads as one activity
+    wider than the annex reserves — the direction that turns a segment into a
+    whole code."""
+    rows = {r["code"]: r for r in load_relation()["rows"]}
+    assert rows["42912"]["text"] == "pelabuhan bukan perikanan"
+    assert rows["42913"]["text"] == "pelabuhan perikanan"
+
+
+def test_innocence_a_cell_that_wraps_past_its_tick_keeps_its_qualifier():
+    """The bound is a BLANK LINE, the annex's own row separator — not "stop at
+    the tick". Two narrower rules were measured and discarded because they cut
+    real wraps: `42209` and `71102` carry "teknologi sederhana dan madya" on
+    lines BELOW their tick, and losing those words produces a wrong bucket in
+    the dangerous direction."""
+    rows = load_relation()["rows"]
+    # Keyed by (code, column), NOT by code: `71102` sits in the annex TWICE
+    # under different bidang usaha — dialokasikan on p15 and kemitraan on p21 —
+    # and a dict keyed by code alone keeps only the last, which made the first
+    # draft of this test report a loss the parser had not caused (W107).
+    by_pair = {(r["code"], r["column"]): r for r in rows}
+    for code in ("42209", "71102", "71202", "71204", "43905"):
+        r = by_pair[(code, "dialokasikan")]
+        blob = (r["text"] or "") + (r.get("parent_heading") or "")
+        assert "madya" in blob, f"{code} lost its grade qualifier: {r['text']!r}"
+    # `16101` carries a CAPACITY limit ("kurang dari 2000 m3 per tahun") and sits
+    # in the KEMITRAAN column — a partnership duty, not a reservation. Named with
+    # its real column rather than assumed into the other one: the two columns are
+    # the over-match this whole module is built to keep apart.
+    assert "kurang dari" in (by_pair[("16101", "kemitraan")]["text"] or "")
+
+
+def test_the_parse_still_accounts_for_every_tick():
+    """A span rule that cuts too early drops rows silently. One discarded
+    attempt lost `41020` entirely and turned 0 unresolved into 1 — measured
+    before shipping, which is the only reason it is not in the artifact."""
+    rel = load_relation()
+    assert rel["counts"]["ticks"] == 180
+    assert rel["counts"]["rows_emitted"] == 181  # annex row 13 carries two codes
+    assert rel["counts"]["unresolved"] == 0
+    assert rel["unresolved"] == []


### PR DESCRIPTION
## What this PR does now

It **withdraws** a cure instead of applying one, and ships the fix for what
made the cure wrong. The canonical dataset is untouched by this branch.

An independent cross-family review of the finished determination (Codex
GPT-5.6, instructed to refute; generator ≠ grader) returned **DEFECTIVE**, and
its first point held up at the source PDF: Perpres 49/2021 Lampiran II reserves
food crops only **"dengan luas kurang dari 25 Ha"**.

The annex is not a flat table. A numbered PARENT *bidang usaha* carries the
scope; the rows indented under it carry a bare name:

```
1   Pertanian tanaman pangan dengan luas kurang dari 25 Ha:
       Padi hibrida        01121   V
       Jagung              01111   V
```

`parse_perpres_lampiran2` emitted the child cell only. So the 21 agents that
adjudicated the 85 `whole-row` codes saw `"Jagung"` and had no way to learn
about the 25 hectares — and both model families agreed to reserve the whole
code. Agreement measuring fidelity to the evidence supplied, exactly as W100
describes.

**11 of the 39 proposed patches sit under a restricting parent**: `01111
01113 01114 01115 01121 01122` (the 25-Ha crops) and `43215 43221 43222 43224
43303` (the "teknologi sederhana dan madya" installation/works grades).
Publishing 0% on those tells a client they cannot run an activity they
lawfully can.

**Nothing reached a client.** Withdrawn before merge.

## The cure for the cause

- `parse_perpres_lampiran2` emits **`parent_heading` on every row** — `None`
  included, so "no parent" is distinguishable from "parents were never looked
  for". Context resets on each numbered item, so a heading cannot leak into the
  next section (the first probe for this defect did exactly that and reported
  retail codes as children of a construction heading — W107).
- The classifier gains a named **`parent-qualified`** bucket: `whole-row`
  **85 → 68**, 17 rows moved. Named rather than absorbed into
  `segment-qualified`: the module's original caveat was right that a question
  wrongly withdrawn is worse than one wrongly asked.
- `apply_umkm_reservations` **refuses a withdrawn spec by name** rather than
  running as a silent no-op that prints "applied 0 codes".
- Guilt + innocence + a tripwire **on the data** (`01111` must carry its 25-Ha
  parent — the classifier tests would go on passing, since they take the parent
  as an argument). Mutation-verified: deleting the branch turns two guilt tests
  red.

## The part worth keeping

`perpres_umkm_reservation_relation.py` **already documented this**, in its own
docstring, and deliberately left such rows in `whole-row` so a human would ask
about them. The caveat was true, load-bearing, and invisible to every reader who
consumed the DATA instead of the module. A limitation that lives only in a
comment does not travel with the rows.

## Verification

- `scripts/kbli_filiera/tests/` — 844 passed
- `backend/tests/unit/services/test_kbli_eye.py` — passed
- mouth `kbli-bali-block` / `kbli-pma-cap` / `kbli-llms-corpus` /
  `kbli-dataset-version` — 68 passed
- R1 adversarial-review gate — PASS (the review is written up in the research
  file, including the three points that did **not** survive re-derivation)

## Still open (not silently dropped)

- Pasal 3(3) vs Pasal 5(5) as the granularity article — both cited from
  secondary sources; recorded as a question rather than swapped for another
  unchecked citation.
- `42912`'s activity cell reads `"pelabuhan bukan perikanan pelabuhan
  perikanan"` — two annex cells run together. A second parser defect, ledgered.
- Re-adjudication of the 68 `whole-row` codes on parent-aware evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)