### PR TITLE
fix(kbli): the heir check asked one direction — a 2025 code can be broader than the row it inherits

### DIFF
--- a/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
+++ b/research/compliance/2026-08-06-kumkm-lampiran-ii-85-code-adjudication.md
@@ -254,10 +254,25 @@ each, including the ones that did not survive:
    that decision stands; the document simply never said so, so it contradicted
    its own artifact. A reader would have found four 0% verdicts on codes the
    text called unresolved. Moot under the withdrawal, fixed in the re-write.
-4. **Semantic check on the seven 2020→2025 mappings — UPHELD as insufficient.**
-   The applier verified cardinality (exactly one heir) and not identity of
-   perimeter. `55120` "Hotel Melati" → `55106` "Aktivitas Hotel Nonbintang" is a
-   single heir and not obviously the same activity.
+4. **Semantic check on the seven 2020→2025 mappings — UPHELD, and MEASURED.**
+   The applier asked one direction only: did the 2020 activity SPLIT (exactly
+   one heir)? It never asked the reverse — did the 2025 code MERGE several 2020
+   activities, making it broader than the single row the annex reserves? Run
+   against canonical: **six of the seven are 1:1, and `79110` (Aktivitas Agen
+   Perjalanan) absorbs THREE 2020 codes — `79111`, `79112`, `79119`.** Reserving
+   all of `79110` on `79111`'s row would close activities the annex never named,
+   which is exactly the ground the 28 REFUSE_BROADER verdicts stand on.
+
+   That code was already out of the spec — but for an unrelated reason (a
+   competing determination living in `test_kbli_eye.py`), i.e. by luck rather
+   than by any rule. It is now a refusal in the applier, with the failure named:
+   `79110: judged on 2020 79111, but this 2025 code also absorbs ['79112',
+   '79119'] — broader than the reserved activity`. Mutation-verified.
+
+   What is still NOT checked, and is a different question: whether a 1:1 heir
+   is the same ACTIVITY rather than merely the same lineage. `55120` "Hotel
+   Melati" → `55106` "Aktivitas Hotel Nonbintang" is 1:1 by the crosswalk and a
+   renaming this session has not verified against BPS. Ledgered, not claimed.
 5. **`42912` — UPHELD on the evidence, and it is a second parser defect.** Its
    activity cell reads `"pelabuhan bukan perikanan pelabuhan perikanan"`: two
    distinct annex cells run together. Ledgered, not fixed here.

--- a/scripts/kbli_filiera/apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/apply_umkm_reservations.py
@@ -135,6 +135,28 @@ def check(
                 )
                 continue
 
+            # …and the OTHER direction, which the rule above cannot see. "One
+            # heir" says the 2020 activity did not split; it says nothing about
+            # whether the 2025 code MERGED several 2020 activities, in which
+            # case the code is BROADER than the one row the annex reserves and
+            # belongs with the 28 refused for exactly that (Pasal 5(5): the
+            # allocation attaches to the named bidang usaha).
+            #
+            # Measured on the seven vintage rows: six are 1:1, and `79110`
+            # (Aktivitas Agen Perjalanan) absorbs THREE 2020 codes — 79111,
+            # 79112, 79119 — so reserving all of it on 79111's row would close
+            # an activity the annex never named. That one was already out of the
+            # spec, but for an unrelated reason (a competing determination in a
+            # test), i.e. it was luck, not this rule. Now it is this rule.
+            ancestors = (record.get("bps_2020_ancestors") or {}).get("codes") or []
+            others = [str(a) for a in ancestors if str(a) != judged]
+            if others:
+                refusals.append(
+                    f"{code}: judged on 2020 {judged}, but this 2025 code also "
+                    f"absorbs {others} — broader than the reserved activity"
+                )
+                continue
+
         existing = record.get("pma_official_basis")
         if existing and existing != item["locator"]:
             refusals.append(f"{code}: already carries a different pma_official_basis")

--- a/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
@@ -47,6 +47,32 @@
       "row_text_changed_by_the_fusion_cure": ["42912", "95299"],
       "evidence_unchanged": 26,
       "meaning": "Re-adjudication is THIRTEEN codes, not sixty-eight. For the other 26 the lanes read exactly what the annex says and their verdicts rest on it. That is NOT an instruction to revive those 26: two known axes are still unchecked on them — whether a 1:1 crosswalk heir is the same ACTIVITY or only the same lineage, and the OCR-damaged locators. Naming the 13 keeps the re-adjudication from starting at 'recheck everything', which is how a small real defect turns into a large vague one."
+    },
+    "readjudication_2026_08_06": {
+      "scope": "the 13 codes named in evidence_delta_2026_08_06",
+      "method": "per-family fan-out, Claude proposes from the corrected pack, Codex re-derives BLIND (cross-family, W100); a fourth verdict REFUSE_SEGMENT was added because the first round had no box for 'the annex reserves only a slice of this code'",
+      "agreement": "13 of 13",
+      "verdicts": {
+        "REFUSE_SEGMENT": [
+          "01111",
+          "01113",
+          "01114",
+          "01115",
+          "01121",
+          "01122",
+          "43215",
+          "43221",
+          "43222",
+          "43224",
+          "43303"
+        ],
+        "REFUSE_BROADER": ["42912"],
+        "PATCH_ZERO": ["95299"]
+      },
+      "outcome": "ELEVEN of the 13 flip from PATCH to REFUSE. The withdrawal was right, and the parent heading is what changed the answer.",
+      "declared_weakness": "The prompt's CRITICAL STRUCTURE section used the 25-Ha crops as its worked example, i.e. it handed both lanes the conclusion for that family. Their agreement on the six crops is therefore weaker evidence than their agreement on the tech-grade five and on 42912/95299, where the framing was generic. Stated rather than left for a reader to notice.",
+      "95299_scrutiny": "Checked on disk rather than taken from the verdict (W65). canonical shows `95400` also listing 2020 `95299` among its ancestors, which looked like a split the pack had hidden — the pack carried ancestors (reverse) but not siblings (forward), the very two directions armed in the applier a few hours earlier. Resolved in the verdict's favour: 95400 is 'Jasa Intermediasi Reparasi' with TEN ancestors, an intermediation platform, not the repair activity the annex reserves. Sometimes verification confirms.",
+      "limit_found_while_checking": "live_heirs() lets IDENTITY win where the 2020 number survives into 2025, by a documented and cross-family-reviewed decision (the edge file carries spurious edges such as 14111->17091). Consequence never written down until now: when a surviving number ALSO spawns a second 2025 code, the split is invisible and the row still reports as whole-row. Not a bug — a limit, and 'whole-row' therefore never means 'no other 2025 code inherited this activity'."
     }
   },
   "withdrawn_items": [

--- a/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_2026_08_06.json
@@ -28,7 +28,26 @@
     ],
     "count_tainted": 11,
     "count_total": 39,
-    "next": "Re-adjudicate from the corrected relation, which now carries parent_heading per row and a 'parent-qualified' bucket. Not a re-run of the same prompts: the 11 tainted codes need the parent's limit stated in the evidence, and the rest need re-confirming against rows they were judged on before the field existed."
+    "next": "Re-adjudicate from the corrected relation, which now carries parent_heading per row and a 'parent-qualified' bucket. Not a re-run of the same prompts: the 11 tainted codes need the parent's limit stated in the evidence, and the rest need re-confirming against rows they were judged on before the field existed.",
+    "evidence_delta_2026_08_06": {
+      "method": "compared each withdrawn verdict's annex row BEFORE the parent/fusion cures against the row now",
+      "restricting_parent_was_hidden": [
+        "01111",
+        "01113",
+        "01114",
+        "01115",
+        "01121",
+        "01122",
+        "43215",
+        "43221",
+        "43222",
+        "43224",
+        "43303"
+      ],
+      "row_text_changed_by_the_fusion_cure": ["42912", "95299"],
+      "evidence_unchanged": 26,
+      "meaning": "Re-adjudication is THIRTEEN codes, not sixty-eight. For the other 26 the lanes read exactly what the annex says and their verdicts rest on it. That is NOT an instruction to revive those 26: two known axes are still unchecked on them — whether a 1:1 crosswalk heir is the same ACTIVITY or only the same lineage, and the OCR-damaged locators. Naming the 13 keeps the re-adjudication from starting at 'recheck everything', which is how a small real defect turns into a large vague one."
+    }
   },
   "withdrawn_items": [
     {

--- a/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
@@ -221,3 +221,19 @@ def test_the_two_directions_are_different_questions():
     assert heirs["79111"] == ["79110"], "forward check passes: one heir"
     todo, refusals = run([item("79110", judged_as="79111")], records)
     assert todo == [] and refusals, "reverse check refuses"
+
+
+def test_the_readjudication_scope_is_named_and_small():
+    """The withdrawal's own follow-up scope, pinned so it cannot drift back into
+    "recheck all 68". Measured by diffing each verdict's annex row before and
+    after the parent/fusion cures: 11 had a restricting parent hidden from the
+    lane, 2 had their row text change, 26 read exactly what the annex says."""
+    d = json.loads(A.SPEC.read_text(encoding="utf-8"))["withdrawn"]["evidence_delta_2026_08_06"]
+    hidden = d["restricting_parent_was_hidden"]
+    changed = d["row_text_changed_by_the_fusion_cure"]
+    assert len(hidden) + len(changed) == 13, "the re-adjudication is thirteen codes"
+    assert d["evidence_unchanged"] == 26
+    assert "42912" in changed, "the fused-cell row is one of the two"
+    # …and 26 unchanged is NOT a licence to revive them; the spec has to keep
+    # saying which axes are still open on that group.
+    assert "same ACTIVITY" in d["meaning"] and "OCR" in d["meaning"]

--- a/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
@@ -187,3 +187,37 @@ def test_the_withdrawal_names_the_codes_whose_evidence_was_short():
     assert len(tainted) == w["count_tainted"] > 0
     assert "01111" in tainted, "the 25-Ha food crops are the clearest members"
     assert "43215" in tainted, "so is the simple/intermediate technology grade"
+
+
+def test_guilt_a_2025_code_that_absorbs_other_2020_codes_is_refused():
+    """`79110` (Aktivitas Agen Perjalanan) is the live shape: the annex reserves
+    the 2020 row `79111`, but the 2025 code also absorbs `79112` and `79119`, so
+    a 0% verdict on it closes activities the annex never named."""
+    todo, refusals = run(
+        [item("79110", judged_as="79111")],
+        [rec("79110", ancestors=["79111", "79112", "79119"])],
+    )
+    assert todo == []
+    assert "broader than the reserved activity" in refusals[0]
+    assert "79112" in refusals[0], "the refusal must name what makes it broader"
+
+
+def test_innocence_a_clean_one_to_one_carry_over_still_applies():
+    """Six of the seven vintage rows ARE 1:1 (`55193`->`55203` villa). A rule
+    that refused those too would withdraw six real determinations to catch one."""
+    todo, refusals = run(
+        [item("55203", judged_as="55193")],
+        [rec("55203", ancestors=["55193"])],
+    )
+    assert refusals == [] and [i["code"] for i in todo] == ["55203"]
+
+
+def test_the_two_directions_are_different_questions():
+    """Forward: did the 2020 activity SPLIT? Reverse: did the 2025 code MERGE?
+    A record can pass one and fail the other, which is why both are asked — the
+    first rule was there from the start and could not have caught 79110."""
+    records = [rec("79110", ancestors=["79111", "79112", "79119"])]
+    heirs = A.heirs_of(records)
+    assert heirs["79111"] == ["79110"], "forward check passes: one heir"
+    todo, refusals = run([item("79110", judged_as="79111")], records)
+    assert todo == [] and refusals, "reverse check refuses"

--- a/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
@@ -237,3 +237,20 @@ def test_the_readjudication_scope_is_named_and_small():
     # …and 26 unchanged is NOT a licence to revive them; the spec has to keep
     # saying which axes are still open on that group.
     assert "same ACTIVITY" in d["meaning"] and "OCR" in d["meaning"]
+
+
+def test_the_readjudication_overturned_eleven_of_the_thirteen():
+    """The 13 named codes, re-judged on evidence that finally carries the parent
+    bidang usaha. Pinned because it is the reason the withdrawal was right: the
+    six 25-Ha crops and the five simple/intermediate-technology grades are
+    reserved only as a SEGMENT, not as whole codes."""
+    r = json.loads(A.SPEC.read_text(encoding="utf-8"))["withdrawn"]["readjudication_2026_08_06"]
+    v = r["verdicts"]
+    assert len(v["REFUSE_SEGMENT"]) == 11
+    assert v["PATCH_ZERO"] == ["95299"] and v["REFUSE_BROADER"] == ["42912"]
+    assert sum(len(x) for x in v.values()) == 13
+    # 01111 is the worked example of the whole defect; it must not drift back
+    # into a whole-code reservation without this test failing.
+    assert "01111" in v["REFUSE_SEGMENT"]
+    # …and the run's own weakness stays written down next to its result.
+    assert "handed both lanes the conclusion" in r["declared_weakness"]


### PR DESCRIPTION
Follow-up to #3659, which merged while this commit was still local: a branch in
the merge queue rejects further pushes (GH006), so this rides its own PR.

## The gap

`apply_umkm_reservations.check()` verified that a KBLI-2020 activity did not
**split** — exactly one 2025 heir. It never asked the reverse: did the 2025 code
**merge** several 2020 activities? If it did, the code is broader than the single
row the annex reserves, and it belongs with the 28 verdicts already refused for
exactly that (**Pasal 5(5)**: the allocation attaches to the named *bidang
usaha*, not to the code number).

## Measured, not reasoned

Run against canonical on the seven vintage rows: **six are 1:1**, and **`79110`
(Aktivitas Agen Perjalanan) absorbs THREE 2020 codes — `79111`, `79112`,
`79119`**. Reserving all of `79110` on `79111`'s row would close activities the
annex never named.

That code was already out of the spec — but for an unrelated reason (a competing
determination living in `test_kbli_eye.py`), i.e. **by luck, not by any rule**.
Now it is a rule, and the refusal names what makes it broader:

```
79110: judged on 2020 79111, but this 2025 code also absorbs
       ['79112', '79119'] — broader than the reserved activity
```

## Tests

Guilt (the live `79110` shape is refused, and the message names `79112`),
innocence (the six real 1:1 carry-overs still apply — a rule that refused those
too would withdraw six determinations to catch one), and one test that states
plainly why both directions are asked: a record can pass the forward check and
fail the reverse, which `79110` does. **Mutation-verified**: disabling the
branch turns the guilt test red. 854 filiera tests pass.

## Declared, not implied

Whether a 1:1 heir is the same **activity** or merely the same **lineage** is a
different question and is **not** checked here. `55120` "Hotel Melati" → `55106`
"Aktivitas Hotel Nonbintang" is 1:1 by the crosswalk and a renaming nobody in
this lane has verified against BPS. Recorded in the research file rather than
left to look covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)