### PR TITLE
fix(kbli): nine codes said "100% foreign-owned" about activities the annex reserves for Koperasi and UMKM

### DIFF
--- a/apps/backend-rag/backend/tests/unit/services/test_kbli_eye.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_kbli_eye.py
@@ -176,17 +176,23 @@ def test_cap_is_always_a_percentage_or_a_declared_gap(records: list[dict]) -> No
 
 
 def test_umkm_reserved_is_tri_state_and_rare(records: list[dict]) -> None:
-    """2 reserved / 1468 open / 89 undetermined — NOT 71 blanket True.
+    """11 reserved / 1459 open / 89 undetermined — NOT 71 blanket True.
 
     The split was 1488/69 until 2026-08-02, when the Perpres 49/2021 Lampiran III
     cure moved 20 codes out of TERBUKA (arms and ammunition, military vehicles,
     commercial air transport, the ferry family, couriers, umrah travel). They
     became `None` — undetermined — which is the honest verdict: leaving TERBUKA
     says nothing at all about a K-UMKM reservation.
+
+    2 -> 11 on 2026-08-06: the Lampiran II re-adjudication. Nine codes are now
+    named as ALLOCATED to Koperasi/UMKM, so `True` here is a read of the annex
+    and not a guess. `None` does not move — the nine came out of the `False`
+    population, which is the shape that says the reader changed its mind about
+    codes it had positively examined, rather than filling silence.
     """
     verdicts = [KBLIEye._umkm_reserved(r) for r in records]
-    assert verdicts.count(True) == 2
-    assert verdicts.count(False) == 1468
+    assert verdicts.count(True) == 11
+    assert verdicts.count(False) == 1459
     assert verdicts.count(None) == 89
     # The counts above are population pins and will move again with the data.
     # This one is the invariant underneath them, and it must not: `False` means
@@ -223,8 +229,12 @@ def test_the_cure_only_ever_shrinks_the_rejected_bucket(records: list[dict]) -> 
     new_rejected = {
         r["kode_kbli_2025"] for r in records if KBLIEye._foreign_cap(r)[0] == 0
     }
-    assert len(old_rejected) == 91
-    assert len(new_rejected) == 64
+    # 2026-08-06: both grew by the same nine (91->100, 64->73) because the
+    # Lampiran II re-adjudication moves a code out of TERBUKA *and* sets its cap
+    # to 0 in the same write. The DIFFERENCE is unchanged at 27, which is the
+    # real content of this test's name: nothing new became wrongly-rejected.
+    assert len(old_rejected) == 100
+    assert len(new_rejected) == 73
     assert len(old_rejected - new_rejected) == 27
     # The counts above move with the data; THIS is the property that must not.
     assert new_rejected <= old_rejected, "the cure must never REJECT something new"

--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
   "lastModified": "2026-08-05",
-  "datasetSha256": "sha256:76b31f95a06262aefc659a90f6c624be17b215ef9c69c7f043f2575038e5d4a7",
+  "datasetSha256": "sha256:170a6e0d669c133544b14accf45b1f120e21b69f80c98e795c3cecab0b3d4ed6",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/apps/mouth/public/llms-kbli.txt
+++ b/apps/mouth/public/llms-kbli.txt
@@ -184,7 +184,7 @@
 10211 | Pengolahan dan Pengawetan Ikan dengan Penggaraman atau Pengeringan | TERBUKA | 100% | Menengah Rendah
 10212 | Pengolahan dan Pengawetan Ikan dengan Pengasapan atau Pemanggangan | TERBUKA | 100% | Menengah Rendah
 10213 | Pengolahan dan Pengawetan Ikan dengan Pembekuan | TERBUKA | 100% | Menengah Rendah / Menengah Tinggi
-10214 | Pengolahan dan Pengawetan Ikan dengan Pemindangan | TERBUKA | 100% | Menengah Rendah
+10214 | Pengolahan dan Pengawetan Ikan dengan Pemindangan | TERBATAS | 0% | Menengah Rendah
 10215 | Pengolahan dan Pengawetan Ikan dengan Fermentasi | TERBUKA | 100% | Rendah / Tinggi
 10216 | Pengolahan dan Pengawetan Ikan dengan Pelumatan | TERBUKA | 100% | Menengah Rendah / Tinggi
 10217 | Pengolahan dan Pengawetan Ikan dengan Pengalengan | TERBUKA | 100% | Menengah Tinggi / Tinggi
@@ -247,7 +247,7 @@
 10636 | Industri Minyak dari Beras dan Jagung | TERBUKA | 100% | Menengah Rendah / Tinggi
 10710 | Industri Produk Bakeri | TERBUKA | 100% | Rendah / Tinggi
 10721 | Industri Gula Pasir | TERBUKA | 100% | Tinggi
-10722 | Industri Gula Merah | TERBUKA | 100% | Rendah / Tinggi
+10722 | Industri Gula Merah | TERBATAS | 0% | Rendah / Tinggi
 10723 | Industri Sirop | TERBUKA | 100% | Menengah Tinggi
 10729 | Industri Gula Lainnya | TERBUKA | 100% | Rendah / Tinggi
 10731 | Industri Pengolahan Kakao | TERBUKA | 100% | Tinggi
@@ -422,7 +422,7 @@
 21024 | Industri Bahan Baku Obat Bahan Alam untuk Hewan | TERBUKA | 100% | Tinggi
 22111 | Industri Ban Luar dan Ban Dalam | TERBUKA | 100% | Menengah Tinggi
 22112 | Industri Pembentukan Kembali Ban dan Vulkanisasi Ban | TERBUKA | 100% | Menengah Rendah / Menengah Tinggi
-22121 | Industri Karet Asap | TERBUKA | 100% | Rendah / Tinggi
+22121 | Industri Karet Asap | TERBATAS | 0% | Rendah / Tinggi
 22122 | Industri Karet Lembaran dan Crepe Rubber | TERBUKA | 100% | Rendah / Tinggi
 22123 | Industri Karet Remah (Crumb Rubber) | TERBUKA | 100% | Rendah / Tinggi
 22129 | Industri Karet Setengah Jadi Lainnya | TERBUKA | 100% | Rendah / Tinggi
@@ -680,11 +680,11 @@
 41013 | Konstruksi Konvensional Gedung Industri | TERBUKA | 100% | Menengah Tinggi
 41014 | Konstruksi Konvensional Gedung Perbelanjaan | TERBUKA | 100% | Menengah Tinggi
 41015 | Konstruksi Konvensional Gedung Kesehatan | TERBUKA | 100% | Menengah Tinggi
-41016 | Konstruksi Konvensional Gedung Pendidikan | TERBUKA | 100% | Menengah Tinggi
+41016 | Konstruksi Konvensional Gedung Pendidikan | TERBATAS | 0% | Menengah Tinggi
 41017 | Konstruksi Konvensional Gedung Penginapan | TERBUKA | 100% | Menengah Tinggi
-41018 | Konstruksi Konvensional Gedung Hiburan dan Olahraga | TERBUKA | 100% | Menengah Tinggi
+41018 | Konstruksi Konvensional Gedung Hiburan dan Olahraga | TERBATAS | 0% | Menengah Tinggi
 41019 | Konstruksi Konvensional Gedung Lainnya | TERBUKA | 100% | Menengah Tinggi
-41020 | Konstruksi Prapabrikasi Bangunan Gedung | TERBUKA | 100% | Menengah Tinggi
+41020 | Konstruksi Prapabrikasi Bangunan Gedung | TERBATAS | 0% | Menengah Tinggi
 42101 | Konstruksi Jalan pada Permukaan Tanah | TERBUKA | 100% | Menengah Tinggi
 42102 | Konstruksi Bangunan Sipil Jembatan, Jalan Layang, Fly Over, dan Underpass | TERBUKA | 100% | Menengah Tinggi
 42103 | Konstruksi Jalan Rel | TERBUKA | 100% | Menengah Tinggi
@@ -1549,11 +1549,11 @@
 95101 | Reparasi dan Pemeliharaan Komputer dan Peralatan Sejenisnya | TERBUKA | 100% | Rendah / Menengah Rendah
 95102 | Reparasi dan Pemeliharaan Peralatan Komunikasi | TERBUKA | 100% | Rendah / Menengah Rendah
 95210 | Reparasi dan Pemeliharaan Alat-alat Elektronik Konsumen | TERBUKA | 100% | Rendah / Menengah Rendah
-95220 | Reparasi dan Pemeliharaan Peralatan Rumah Tangga dan Peralatan Rumah dan Kebun | TERBUKA | 100% | Rendah / Menengah Rendah
+95220 | Reparasi dan Pemeliharaan Peralatan Rumah Tangga dan Peralatan Rumah dan Kebun | TERBATAS | 0% | Rendah / Menengah Rendah
 95230 | Reparasi dan Pemeliharaan Alas Kaki dan Barang dari Kulit | TERBUKA | 100% | Rendah / Menengah Rendah
 95240 | Reparasi dan Pemeliharaan Furnitur Dan Perlengkapan Rumah | TERBUKA | 100% | Rendah / Menengah Rendah
-95291 | Aktivitas Vermak Pakaian | TERBUKA | 100% | Rendah
-95299 | Reparasi dan Pemeliharaan Barang Keperluan Pribadi dan Perlengkapan Rumah Tangga Lainnya | TERBUKA | 100% | Rendah
+95291 | Aktivitas Vermak Pakaian | TERBATAS | 0% | Rendah
+95299 | Reparasi dan Pemeliharaan Barang Keperluan Pribadi dan Perlengkapan Rumah Tangga Lainnya | TERBATAS | 0% | Rendah
 95311 | Reparasi Mobil | TERBUKA | 100% | Menengah Rendah
 95312 | Pencucian dan Salon Mobil | TERBUKA | 100% | Rendah
 95320 | Reparasi dan Perawatan Sepeda Motor | TERBUKA | 100% | Menengah Rendah

--- a/apps/mouth/src/lib/kbli-bali-block.test.ts
+++ b/apps/mouth/src/lib/kbli-bali-block.test.ts
@@ -354,10 +354,23 @@ describe("the PMA verdict banner — the SECOND render site", () => {
     // they are all still Bali-blocked, so this is a re-attribution, not an
     // opening. If a future change moves `notice` too, that is a different
     // event and this test should fail rather than absorb it.
-    expect(notice.length).toBe(455);
-    expect(msme.length).toBe(7);
-    // 448 pages carry the notice for a cause other than an MSME reservation.
-    expect(notice.length - msme.length).toBe(448);
+    //
+    // 455 -> 451 and 7 -> 6 on 2026-08-06, and this is the "different event"
+    // the paragraph above demanded be argued rather than absorbed. The Lampiran
+    // II re-adjudication reserved nine codes at 0% foreign; FOUR of them
+    // (10214, 95220, 95291, 95299) are also Bali-blocked, so by the same rule
+    // that removed 16221 they now leave a notice whose whole job is to explain
+    // a BALI-specific cause — theirs is national.
+    //
+    // The msme drop is the one worth reading: 95291 carried
+    // CHIUSO_PMA_NO_BESAR, i.e. the Bali layer already said "reserved for
+    // Koperasi/UMKM" while the national layer published it 100% open. That
+    // contradiction is what the cure closed. The code did not become freer; the
+    // two layers stopped disagreeing, and the national one now carries it.
+    expect(notice.length).toBe(451);
+    expect(msme.length).toBe(6);
+    // 445 pages carry the notice for a cause other than an MSME reservation.
+    expect(notice.length - msme.length).toBe(445);
   });
 
   it("the count above is a SUBTRACTION, and names what it subtracted", () => {
@@ -374,7 +387,12 @@ describe("the PMA verdict banner — the SECOND render site", () => {
     const blocked = RECORDS.filter((r) => r.l4_bali?.blocked === true);
     const excluded = blocked.filter(nationallyClosed);
     expect(excluded.map((r) => r.kode_kbli_2025)).toContain("16221");
-    expect(blocked.length - excluded.length).toBe(455);
+    // …and the four the Lampiran II cure sent the same way, for the same
+    // reason: a 0% national cap outranks a Bali-scoped explanation.
+    for (const code of ["10214", "95220", "95291", "95299"]) {
+      expect(excluded.map((r) => r.kode_kbli_2025)).toContain(code);
+    }
+    expect(blocked.length - excluded.length).toBe(451);
     // and it left by CAP, not by status — the status is TERBATAS, which the
     // banner's guard does not look at
     const woodBuilding = RECORDS.find((r) => r.kode_kbli_2025 === "16221");
@@ -452,12 +470,20 @@ describe("the FAQ + FAQPage JSON-LD — the THIRD render site in this file, FIFT
     // no-Usaha-Besar-row inference was withdrawn and each of the 39 codes was
     // adjudicated against the annex. This site reaches the SAME seven, by a
     // different predicate — which is what makes it worth pinning separately.
-    expect(answers.length).toBe(454);
-    expect(msme.length).toBe(7);
-    // 447 answers carry the block for a cause other than an MSME reservation —
+    //
+    // 454 -> 450 and 7 -> 6 on 2026-08-06: the SAME four codes as the banner
+    // (10214, 95220, 95291, 95299), and again by the other predicate — there
+    // they left because their cap became 0, here because their status became
+    // TERBATAS. The two guards agreeing on all four is once more a property of
+    // this particular cure, which writes both fields in one go, and not
+    // evidence that the populations have merged. The subset test below still
+    // proves they have not.
+    expect(answers.length).toBe(450);
+    expect(msme.length).toBe(6);
+    // 444 answers carry the block for a cause other than an MSME reservation —
     // in the visible Q&A and in the FAQPage JSON-LD, the copy that leaves the
     // site.
-    expect(answers.length - msme.length).toBe(447);
+    expect(answers.length - msme.length).toBe(444);
   });
 
   it("this site is a SUBSET of the banner's — a cure for one is not a cure for the other", () => {
@@ -651,11 +677,26 @@ describe("isNationalClosure — the banner and the FAQ must not send a client to
     expect(national.length).toBeGreaterThan(0);
     for (const r of national) {
       expect(isNationalClosure(r.l4_bali?.status)).toBe(true);
-      // …and each one is exactly the shape that fooled the old derivation:
-      // the national signals still read open.
-      expect(r.pma_status).toBe("TERBUKA");
-      expect(r.pma_max_asing).toBe(100);
     }
+    // The shape that fooled the old derivation was: a national cause recorded
+    // in the Bali field while the NATIONAL signals still read wide open. That
+    // used to be all nine. On 2026-08-06 the Lampiran II re-adjudication fixed
+    // exactly one of them at the source — 95291 now reads TERBATAS/0 — so the
+    // property is no longer universal, and asserting it as universal would make
+    // this test fail every time the catalogue gets MORE honest.
+    //
+    // What is pinned instead is the size of the remaining contradiction. It may
+    // only shrink: a new member means a code gained a national cause in the
+    // Bali field while still publishing 100%, which is the bug this file is
+    // about.
+    const stillContradictory = national.filter(
+      (r) => r.pma_status === "TERBUKA" && r.pma_max_asing === 100,
+    );
+    expect(stillContradictory.length).toBe(8);
+    expect(national.map((r) => r.kode_kbli_2025)).toContain("95291");
+    expect(stillContradictory.map((r) => r.kode_kbli_2025)).not.toContain(
+      "95291",
+    );
   });
 
   it("INNOCENCE: no Bali-scoped block is turned into a national one", () => {

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "bb2b8d12a25bfc8eba11ef481a8d3ef9eaa5a55a",
-  "canonical_sha256": "76b31f95a06262aefc659a90f6c624be17b215ef9c69c7f043f2575038e5d4a7",
+  "canonical_revision": "1d7ced9c756aefd54f00cca905d001c6a39179de",
+  "canonical_sha256": "170a6e0d669c133544b14accf45b1f120e21b69f80c98e795c3cecab0b3d4ed6",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/scripts/kbli_filiera/apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/apply_umkm_reservations.py
@@ -24,24 +24,38 @@ Two articles that are NOT this one, and must not be conflated with it:
 
 WHAT IS IN THE SPEC, AND WHAT DELIBERATELY IS NOT
 --------------------------------------------------
-`cure_specs/umkm_lampiran_ii_2026_08_06.json` carries only codes where two
-INDEPENDENT passes of different model families agreed on PATCH — a Claude lane
-proposing from the annex row and an OpenAI lane re-deriving the same codes
-blind, with the bias stated against restricting ("a wrongly-restricted code
-costs a client a business they could lawfully run; that is not a safer error,
-it is a different error").
+`cure_specs/umkm_lampiran_ii_readjudicated_2026_08_06.json` carries NINE codes,
+each one where two INDEPENDENT passes of different model families agreed on
+PATCH — a Claude lane proposing from the annex row and an OpenAI lane
+re-deriving the same code blind, with the bias stated against restricting ("a
+wrongly-restricted code costs a client a business they could lawfully run; that
+is not a safer error, it is a different error" — and refusing is NOT the safe
+direction either: the opposite error tells a client he may wholly own an
+activity the annex reserves).
 
-Excluded by construction, and none of it is a silent drop: 13 codes where the
-two families disagreed, 3 both called unclear, 1 whose annex text the OCR
-destroyed on the token that sets its scope, and 28 both refused as BROADER than
-the reserved activity — Pasal 5 ayat (5) attaches the allocation to the named
-bidang usaha, never to the code number.
+It replaces `umkm_lampiran_ii_2026_08_06.json`, which was WITHDRAWN whole before
+merge: the evidence handed to its 21 adjudicating agents had the scope qualifier
+stripped out, because Lampiran II writes the scope on a numbered PARENT row and
+the parser emitted only the indented child. That spec stays on disk, still
+carrying its verdicts, and this tool refuses it BY NAME (see `WITHDRAWN_SPEC`).
 
-Seven spec rows were judged on a KBLI-2020 number that is not a 2025 code
-(`55193` villa, `10391` tempe, …). Each resolves to EXACTLY ONE 2025 heir with
-the same activity name, so the determination is applied to the heir and the
-row records `judged_as`. This tool re-derives that heir itself and refuses if
-the spec's target disagrees — the vintage trap has bitten this catalogue twice
+The re-adjudication ran in two rounds over the 68 `whole-row` codes and kept
+what survived both: 11 refused as SEGMENT-only (reserved just below 25 Ha, or
+only at simple/intermediate technology grade), 9 refused as BROADER than the
+reserved activity, 13 where the families disagreed, 3+2 called unclear, 1 whose
+annex text the OCR destroyed on the token that sets its scope, and 6 vintage
+carries whose 1:1 heir has not yet been checked for ACTIVITY identity (lineage
+is not identity). None of that is a silent drop — every population is named in
+the spec's `excluded` block and pinned by a test.
+
+Round 2's evidence pack carried, for the first time, BOTH the parent bidang
+usaha and the SIBLING 2025 codes that share each ancestor. That second field is
+what moved eight verdicts from PATCH to REFUSE_BROADER: a 2025 code that also
+absorbs 2020 activities the annex never named is wider than the reservation.
+
+A spec row judged on a KBLI-2020 number that is not a 2025 code records
+`judged_as`. This tool re-derives that heir itself, in BOTH directions, and
+refuses if either disagrees — the vintage trap has bitten this catalogue twice
 in one day and a written-down mapping is a proxy, not the fact.
 
 REFUSES RATHER THAN GUESSES
@@ -52,18 +66,40 @@ a spec row's `judged_as` does not resolve to its stated target through
 (someone adjudicated it by hand and this tool is not the later word); or the
 observed `pma_status`/`pma_max_asing` differ from what the spec recorded when it
 was built, which means the world moved under the adjudication.
+
+AND IT REACHES THE CONSUMERS, WHICH IT USED NOT TO
+---------------------------------------------------
+Writing canonical is not shipping. `apps/mouth` (balizero.com/kbli),
+`apps/kbli-navigator` and the RAG's own copy each hold a physical duplicate, and
+a vitest guard fails when the dataset hash moves without the sidecar version
+file moving with it. Every sibling cure compiler runs `sync_kbli_dataset.sh` and
+re-hashes that sidecar; this one did not, so its cure landed on canonical alone
+and the drift check would have failed the NEXT innocent PR (W86). `--apply` now
+does both, and refuses if a consumer copy still differs afterwards.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CANONICAL = REPO_ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
-SPEC = Path(__file__).resolve().parent / "cure_specs" / "umkm_lampiran_ii_2026_08_06.json"
+CURE_SPECS = Path(__file__).resolve().parent / "cure_specs"
+SPEC = CURE_SPECS / "umkm_lampiran_ii_readjudicated_2026_08_06.json"
+
+# Kept on disk on purpose. It still carries the 39 verdicts and the record of WHY
+# they were withdrawn; `main()` refuses it by its own `withdrawn` marker, so
+# pointing `--spec` at it is a loud refusal rather than a silent 39-code write.
+WITHDRAWN_SPEC = CURE_SPECS / "umkm_lampiran_ii_2026_08_06.json"
+
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync_kbli_dataset.sh"
+SIDECAR_VERSION = REPO_ROOT / "apps" / "mouth" / "data" / "kbli-dataset-version.json"
+SIDECAR_DATASET = REPO_ROOT / "apps" / "mouth" / "data" / "KBLI_2025_FINAL_CLEAN.json"
 
 VINTAGE = "2021-05-25"
 KONDISI = (
@@ -176,6 +212,46 @@ def check(
     return todo, refusals
 
 
+def propagate(dry: bool = False) -> list[str]:
+    """Push canonical to every consumer copy and re-stamp the version sidecar.
+
+    Returns the list of problems; empty means the fleet agrees with canonical.
+    Separated from `main()` so a test can drive it without a 37MB write.
+    """
+    problems: list[str] = []
+    result = subprocess.run(
+        ["bash", str(SYNC_SCRIPT), "sync"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        problems.append(f"sync_kbli_dataset.sh exited {result.returncode}: {result.stderr[-400:]}")
+        return problems
+
+    # Prove the propagation instead of trusting the exit code (superscar #2).
+    check = subprocess.run(
+        ["bash", str(SYNC_SCRIPT), "--check"], capture_output=True, text=True
+    )
+    if check.returncode != 0:
+        problems.append(f"consumer copies still differ after sync: {check.stdout[-400:]}")
+        return problems
+
+    if not SIDECAR_DATASET.exists():
+        problems.append(f"sidecar dataset copy missing: {SIDECAR_DATASET}")
+        return problems
+
+    digest = "sha256:" + hashlib.sha256(SIDECAR_DATASET.read_bytes()).hexdigest()
+    sidecar = json.loads(SIDECAR_VERSION.read_text(encoding="utf-8"))
+    if sidecar.get("datasetSha256") == digest:
+        return problems  # content did not move; nothing to bump
+
+    if not dry:
+        sidecar["datasetSha256"] = digest
+        SIDECAR_VERSION.write_text(
+            json.dumps(sidecar, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+    print(f"  sidecar version -> {digest}")
+    return problems
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--apply", action="store_true", help="write (default: dry-run)")
@@ -240,6 +316,24 @@ def main(argv: list[str] | None = None) -> int:
         print(f"WROTE BUT READ BACK WRONG on {len(wrong)}: {wrong[:10]}")
         return EXIT_REFUSED
     print(f"\napplied and verified on re-read: {len(todo)} code(s)")
+
+    # Propagation is a statement about CANONICAL. Run against any other dataset —
+    # a test sandbox, a scratch copy — pushing canonical to the fleet would be a
+    # side effect nobody asked for, and under `--check` it would report on a file
+    # this run never touched. Say so instead of doing it.
+    if path.resolve() != CANONICAL.resolve():
+        print(f"not canonical ({path}) — skipping consumer propagation")
+        return EXIT_OK
+
+    problems = propagate()
+    for p in problems:
+        print(f"  PROPAGATION FAILED: {p}")
+    if problems:
+        # Canonical is already cured; stopping here is honest, not tidy. A cure
+        # that reached one store and not the others is exactly the state that
+        # must be visible rather than reported as success.
+        return EXIT_REFUSED
+    print("consumer copies in sync with canonical")
     return EXIT_OK
 
 

--- a/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_readjudicated_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/umkm_lampiran_ii_readjudicated_2026_08_06.json
@@ -1,0 +1,182 @@
+{
+  "instrument": "Perpres 10/2021 as amended by 49/2021, Lampiran II",
+  "adjudicated": "2026-08-06, two rounds, generator!=grader, cross-family (Claude proposes from the annex row, Codex re-derives blind). Round 2 evidence carried, for the first time, BOTH the parent bidang usaha and the sibling 2025 codes sharing each ancestor.",
+  "supersedes": "umkm_lampiran_ii_2026_08_06.json, withdrawn whole",
+  "items": [
+    {
+      "code": "10214",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p2, row \"Industri pemindangan ikan\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 2,
+      "parent_heading": null
+    },
+    {
+      "code": "10722",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p2, row \"Industri gula merah\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 2,
+      "parent_heading": null
+    },
+    {
+      "code": "22121",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p4, row \"Industri pengasapan karet\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 2,
+      "parent_heading": null
+    },
+    {
+      "code": "41016",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p7, row \"gedung pendidikan meliputi sarana pendidikan, tempat kursus, laboratorium dan bangunan penunjang pendidikan lainnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 2,
+      "parent_heading": null
+    },
+    {
+      "code": "41018",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p7, row \"gedung tempat hiburan dan olahraga meliputi bioskop, gedung kebudayaan/kesenian, gedung wisata dan rekreasi serta gedung olahraga\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 2,
+      "parent_heading": null
+    },
+    {
+      "code": "41020",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p7, row \"jasa pekerjaan konstruksi prafabrikasi bangunan gedung meliputi pemasangan bahan hasil produksi pabrik seperti beton pracetak, baja, plastik, karet, dan hasil produksi pabrik lainnya dengan metode pabrikasi, erection, dan/atau perakitan untuk bangunan gedung\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 2,
+      "parent_heading": null
+    },
+    {
+      "code": "95220",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p16, row \"Reparasi peralatan: Peralatan rumah tangga dan Peralatan rumah dan kebun\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 2,
+      "parent_heading": null
+    },
+    {
+      "code": "95291",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p16, row \"Vermak pakaian\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 2,
+      "parent_heading": null
+    },
+    {
+      "code": "95299",
+      "judged_as": null,
+      "locator": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM), p16, row \"Industri reparasi barang rumah tangga dan pribadi lainnya\" — allocated to Koperasi/UMKM per Pasal 3(1)(b) + Pasal 5; the whole 2025 code is the reserved bidang usaha (Pasal 5(5)); max foreign 0%.",
+      "was": {
+        "pma_status": "TERBUKA",
+        "pma_max_asing": 100
+      },
+      "agreed_by": [
+        "claude-sonnet-5 (proposer)",
+        "codex-gpt-5.6 (blind re-derivation)"
+      ],
+      "round": 1,
+      "parent_heading": null
+    }
+  ],
+  "excluded": {
+    "disagreements": 13,
+    "agreed_unclear": 3,
+    "ocr_illegible": ["47722"],
+    "refuse_segment_round2": [
+      "01111",
+      "01113",
+      "01114",
+      "01115",
+      "01121",
+      "01122",
+      "43215",
+      "43221",
+      "43222",
+      "43224",
+      "43303"
+    ],
+    "refuse_broader_round2": [
+      "10794",
+      "42202",
+      "43309",
+      "47241",
+      "47242",
+      "47244",
+      "47249",
+      "47712",
+      "42912"
+    ],
+    "diverged_round2": ["42913", "43902"],
+    "unclear_round2": ["43904", "16293"],
+    "vintage_carry_not_yet_semantically_checked": [
+      "10307",
+      "10308",
+      "55106",
+      "55201",
+      "55203",
+      "79903"
+    ]
+  },
+  "bias_stated_to_both_lanes": "A wrongly-restricted code costs a client a business they could lawfully run; that is not a safer error, it is a different error. REFUSE_UNCLEAR was a real option. Refusing is NOT the safe direction — the opposite error tells a client he may wholly own a reserved activity."
+}

--- a/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
+++ b/scripts/kbli_filiera/tests/test_apply_umkm_reservations.py
@@ -139,13 +139,12 @@ def test_patch_states_zero_foreign_and_names_its_basis():
     assert p["pma_cap_verified"] is True
 
 
-def test_the_shipped_spec_carries_only_unanimous_verdicts():
-    """Structural pin on the real artifact: the excluded populations must still
-    be declared in it, so a future regeneration cannot quietly absorb the
-    disagreements into the patch set. Reads `withdrawn_items` when the spec has
-    been withdrawn — the verdicts are still a record worth pinning even though
-    none of them may be applied."""
-    spec = json.loads(A.SPEC.read_text(encoding="utf-8"))
+def test_the_withdrawn_spec_still_declares_its_excluded_populations():
+    """Structural pin on the withdrawn artifact: the excluded populations must
+    still be declared in it, so a future regeneration cannot quietly absorb the
+    disagreements into a patch set. Reads `withdrawn_items` — the verdicts are
+    still a record worth pinning even though none of them may be applied."""
+    spec = json.loads(A.WITHDRAWN_SPEC.read_text(encoding="utf-8"))
     ex = spec["excluded"]
     assert ex["disagreements"] > 0 and ex["agreed_unclear"] > 0
     assert ex["ocr_illegible"], "the illegible row must stay named, not vanish"
@@ -156,24 +155,49 @@ def test_the_shipped_spec_carries_only_unanimous_verdicts():
         assert "Lampiran II" in i["locator"] and "Pasal 3(1)(b)" in i["locator"]
 
 
+def _sandbox_dataset(tmp_path):
+    """A one-record stand-in for canonical.
+
+    Both refusal tests below run with `--apply`, because the claim is that the
+    refusal precedes the WRITE — a dry-run would prove something weaker. That
+    makes the dataset argument load-bearing: with the guard mutated away, the
+    run reaches the write, and pointed at the default it would rewrite the real
+    37MB catalogue from inside pytest (W96). It writes here instead.
+    """
+    d = tmp_path / "canonical.json"
+    d.write_text(json.dumps({"data": [rec("01111")]}), encoding="utf-8")
+    return d
+
+
 def test_guilt_a_withdrawn_spec_is_refused_before_anything_is_read(tmp_path, capsys):
-    """The shipped spec IS withdrawn, so this is the live path. `items: []` alone
-    would make the run a silent no-op that prints "applied 0 codes" — which reads
-    like success. The refusal has to name itself."""
+    """`items: []` alone would make the run a silent no-op that prints "applied 0
+    codes" — which reads like success. The refusal has to name itself."""
     p = tmp_path / "s.json"
     p.write_text(json.dumps({
         "withdrawn": {"date": "2026-08-06", "by": "review", "reason": "why", "next": "what"},
         "items": [], "withdrawn_items": [], "excluded": {},
     }), encoding="utf-8")
-    assert A.main(["--apply", "--spec", str(p)]) == A.EXIT_REFUSED
+    d = _sandbox_dataset(tmp_path)
+    assert A.main(["--apply", "--spec", str(p), "--dataset", str(d)]) == A.EXIT_REFUSED
     assert "REFUSING" in capsys.readouterr().out
 
 
-def test_innocence_a_spec_without_that_marker_still_runs():
-    """The guard must not turn every spec into a refusal — the tool has to stay
-    usable for the re-adjudicated spec that replaces this one."""
+def test_guilt_the_real_withdrawn_spec_on_disk_is_still_refused(tmp_path, capsys):
+    """Not a tmp fixture: the ACTUAL withdrawn artifact. Now that the default spec
+    has moved to its replacement, nothing else would notice if someone deleted the
+    `withdrawn` block and revived 39 codes whose evidence was measured short."""
+    assert A.WITHDRAWN_SPEC.exists(), "the withdrawn spec must stay on disk as a record"
+    d = _sandbox_dataset(tmp_path)
+    rc = A.main(["--apply", "--spec", str(A.WITHDRAWN_SPEC), "--dataset", str(d)])
+    assert rc == A.EXIT_REFUSED
+    assert "REFUSING" in capsys.readouterr().out
+
+
+def test_innocence_the_default_spec_is_not_withdrawn_and_runs():
+    """The guard must not turn every spec into a refusal — the DEFAULT is now the
+    re-adjudicated replacement, and it has to be applicable."""
     spec = json.loads(A.SPEC.read_text(encoding="utf-8"))
-    assert "withdrawn" in spec, "the shipped spec is the withdrawn one"
+    assert "withdrawn" not in spec, "the default spec must be the live one"
     todo, refusals = run([item("01111")], [rec("01111")])
     assert refusals == [] and [i["code"] for i in todo] == ["01111"]
 
@@ -182,7 +206,7 @@ def test_the_withdrawal_names_the_codes_whose_evidence_was_short():
     """Not a count: the eleven codes judged under a restricting parent are named,
     so the re-adjudication cannot start from "39 codes, re-check them all" and
     lose which ones were actually compromised."""
-    w = json.loads(A.SPEC.read_text(encoding="utf-8"))["withdrawn"]
+    w = json.loads(A.WITHDRAWN_SPEC.read_text(encoding="utf-8"))["withdrawn"]
     tainted = w["codes_judged_under_a_restricting_parent"]
     assert len(tainted) == w["count_tainted"] > 0
     assert "01111" in tainted, "the 25-Ha food crops are the clearest members"
@@ -228,7 +252,7 @@ def test_the_readjudication_scope_is_named_and_small():
     "recheck all 68". Measured by diffing each verdict's annex row before and
     after the parent/fusion cures: 11 had a restricting parent hidden from the
     lane, 2 had their row text change, 26 read exactly what the annex says."""
-    d = json.loads(A.SPEC.read_text(encoding="utf-8"))["withdrawn"]["evidence_delta_2026_08_06"]
+    d = json.loads(A.WITHDRAWN_SPEC.read_text(encoding="utf-8"))["withdrawn"]["evidence_delta_2026_08_06"]
     hidden = d["restricting_parent_was_hidden"]
     changed = d["row_text_changed_by_the_fusion_cure"]
     assert len(hidden) + len(changed) == 13, "the re-adjudication is thirteen codes"
@@ -244,7 +268,7 @@ def test_the_readjudication_overturned_eleven_of_the_thirteen():
     bidang usaha. Pinned because it is the reason the withdrawal was right: the
     six 25-Ha crops and the five simple/intermediate-technology grades are
     reserved only as a SEGMENT, not as whole codes."""
-    r = json.loads(A.SPEC.read_text(encoding="utf-8"))["withdrawn"]["readjudication_2026_08_06"]
+    r = json.loads(A.WITHDRAWN_SPEC.read_text(encoding="utf-8"))["withdrawn"]["readjudication_2026_08_06"]
     v = r["verdicts"]
     assert len(v["REFUSE_SEGMENT"]) == 11
     assert v["PATCH_ZERO"] == ["95299"] and v["REFUSE_BROADER"] == ["42912"]
@@ -254,3 +278,104 @@ def test_the_readjudication_overturned_eleven_of_the_thirteen():
     assert "01111" in v["REFUSE_SEGMENT"]
     # …and the run's own weakness stays written down next to its result.
     assert "handed both lanes the conclusion" in r["declared_weakness"]
+
+
+# --------------------------------------------------------------------------
+# The REPLACEMENT spec — nine codes, and the populations it must keep naming
+# --------------------------------------------------------------------------
+
+
+def test_the_live_spec_is_the_nine_that_survived_both_rounds():
+    """Of the 39 codes the withdrawn patch would have written, nine survive. The
+    list is pinned by NAME, not by count: a count alone would let a substitution
+    pass, and every one of these publishes a 0%-foreign verdict to clients."""
+    spec = json.loads(A.SPEC.read_text(encoding="utf-8"))
+    codes = [i["code"] for i in spec["items"]]
+    assert codes == [
+        "10214", "10722", "22121", "41016", "41018", "41020",
+        "95220", "95291", "95299",
+    ]
+    assert len(codes) == len(set(codes)), "a code patched twice"
+    for i in spec["items"]:
+        assert "Lampiran II" in i["locator"] and "Pasal 3(1)(b)" in i["locator"]
+        assert len(i["agreed_by"]) == 2, "one lane's word is not an adjudication"
+
+
+def test_the_live_spec_names_every_population_it_left_behind():
+    """The honest half of the cure. A spec that patches nine out of sixty-eight
+    and does not say where the other fifty-nine went is a silent drop."""
+    ex = json.loads(A.SPEC.read_text(encoding="utf-8"))["excluded"]
+    for key in (
+        "refuse_segment_round2",
+        "refuse_broader_round2",
+        "diverged_round2",
+        "unclear_round2",
+        "vintage_carry_not_yet_semantically_checked",
+        "ocr_illegible",
+    ):
+        assert ex[key], f"{key} must stay named, not vanish"
+    assert ex["disagreements"] > 0 and ex["agreed_unclear"] > 0
+    # The six vintage carries are held for a reason that must stay written down:
+    # a 1:1 crosswalk edge proves LINEAGE, never that the heir is the same
+    # ACTIVITY the annex reserved.
+    assert set(ex["vintage_carry_not_yet_semantically_checked"]) == {
+        "10307", "10308", "55106", "55201", "55203", "79903",
+    }
+
+
+def test_guilt_no_patched_code_is_also_on_a_refusal_list():
+    """The tripwire that matters: a code cannot be both reserved and refused. If
+    a future edit moves one back into `items` without taking it off its refusal
+    list, this fails rather than shipping a contradiction to clients."""
+    spec = json.loads(A.SPEC.read_text(encoding="utf-8"))
+    patched = {i["code"] for i in spec["items"]}
+    ex = spec["excluded"]
+    refused = set()
+    for key in (
+        "refuse_segment_round2",
+        "refuse_broader_round2",
+        "diverged_round2",
+        "unclear_round2",
+        "vintage_carry_not_yet_semantically_checked",
+        "ocr_illegible",
+    ):
+        refused |= set(ex[key])
+    assert not (patched & refused), f"both patched and refused: {sorted(patched & refused)}"
+
+
+def test_the_live_spec_supersedes_the_withdrawn_one_by_name():
+    """A replacement that does not name what it replaces leaves the next reader
+    to guess which of the two files on disk is the live one."""
+    spec = json.loads(A.SPEC.read_text(encoding="utf-8"))
+    assert A.WITHDRAWN_SPEC.name in spec["supersedes"]
+    assert "sibling" in spec["adjudicated"], "round 2's added evidence must be stated"
+
+
+def test_the_propagation_targets_are_the_ones_the_sync_script_knows():
+    """`--apply` is only half a cure if it writes canonical and stops. This pins
+    that the tool reaches for the SAME propagation the rest of the family uses,
+    rather than a private list that can drift from it."""
+    assert A.SYNC_SCRIPT.exists(), "the sync script the cure depends on must exist"
+    assert A.SIDECAR_VERSION.exists() and A.SIDECAR_DATASET.exists()
+    body = A.SYNC_SCRIPT.read_text(encoding="utf-8")
+    assert str(A.SIDECAR_DATASET.relative_to(A.REPO_ROOT)) in body, (
+        "the mouth copy this tool re-hashes must be one the sync script actually writes"
+    )
+
+
+def test_guilt_a_non_canonical_dataset_does_not_trigger_a_fleet_sync(tmp_path, capsys, monkeypatch):
+    """Found by mutation, not by reasoning: with the withdrawal guard deleted, the
+    refusal tests ran on to `propagate()` and shelled out to the REAL repo-wide
+    sync. Sandboxing the dataset was not enough — the propagation had its own
+    path to production (W96). A run that did not write canonical must not push
+    canonical anywhere."""
+    called = []
+    monkeypatch.setattr(A, "propagate", lambda *a, **k: called.append(1) or [])
+    spec = tmp_path / "s.json"
+    spec.write_text(json.dumps({"items": [item("01111")], "excluded": {}}), encoding="utf-8")
+    d = _sandbox_dataset(tmp_path)
+    assert A.main(["--apply", "--spec", str(spec), "--dataset", str(d)]) == A.EXIT_OK
+    assert called == [], "a scratch dataset must not propagate to the fleet"
+    assert "skipping consumer propagation" in capsys.readouterr().out
+    # …and the write itself still happened, so this is a scope guard, not a no-op.
+    assert json.loads(d.read_text())["data"][0]["pma_max_asing"] == 0

--- a/scripts/kbli_filiera/tests/test_perpres_body_default.py
+++ b/scripts/kbli_filiera/tests/test_perpres_body_default.py
@@ -248,8 +248,8 @@ def test_the_barred_but_open_list_reads_across_every_bucket(rep):
     A locator-partitioned reading found only 14; reading across every bucket
     found 23.
 
-    It went to 19 for a few hours on 2026-08-06 and is back at 23, and the round
-    trip is worth more than either number. The Lampiran II cure had restricted
+    It went to 19 for a few hours on 2026-08-06, back to 23, and now sits at 22.
+    The round trip is worth more than any of the three numbers. The Lampiran II cure had restricted
     `55201` (homestay), `55203` (villa), `79110` (travel agent) and `95291`
     (clothing alterations) for a stronger and different reason — the annex
     allocates those activities to Koperasi/UMKM — so they stopped publishing as
@@ -266,7 +266,7 @@ def test_the_barred_but_open_list_reads_across_every_bucket(rep):
     "cleared", but unadjudicated on evidence that was never complete.
     """
     rows = pasal7_review_flags(rep)
-    assert len(rows) == 23
+    assert len(rows) == 22
     codes = {r["code"] for r in rows}
     assert {"96210", "96220"} <= codes           # annex-named AND Besar-less
     assert {"56304", "70201", "86995"} <= codes  # residual AND Besar-less
@@ -282,7 +282,23 @@ def test_the_barred_but_open_list_reads_across_every_bucket(rep):
     # TERBATAS, so it is not "barred but open" and this list has no claim on it.
     # A code can leave a queue for a reason that has nothing to do with the cure
     # you are writing about.
-    assert {"55201", "55203", "95291"} <= codes
+    #
+    # 2026-08-06, second movement: `95291` is OUT again, and this time on
+    # evidence that was complete. The re-adjudication re-ran the annex rows with
+    # the parent bidang usaha attached AND with the sibling 2025 codes sharing
+    # each ancestor; two families agreed independently that the whole of `95291`
+    # (Reparasi Pakaian dan Tekstil) is the reserved activity, with no
+    # restricting parent and no absorbed sibling to widen it. So it is reserved,
+    # not merely unadjudicated, and it does not belong in a queue for
+    # unexplained openness. `55201` (homestay) and `55203` (villa) STAY here:
+    # both are vintage carries whose 1:1 crosswalk edge proves lineage and not
+    # activity identity, and that check has not been done.
+    #
+    # This assertion existing is why the movement had to be argued rather than
+    # absorbed: the tripwire fired on the apply and sent the reader back to the
+    # withdrawal, which is exactly the job it was written for.
+    assert {"55201", "55203"} <= codes
+    assert "95291" not in codes
     assert "79110" not in codes
     assert all(r["besar"] == "absent" for r in rows)
 


### PR DESCRIPTION
Perpres 10/2021 as amended by 49/2021, **Lampiran II** allocates a *bidang usaha* to Indonesian cooperatives and MSMEs. A foreign investor can be neither, so for an allocated activity the lawful foreign share is **0%**. Nine codes published the opposite — on `balizero.com/kbli`, in the RAG's answers, and in the native app.

`10214` salted/boiled fish · `10722` palm sugar · `22121` smoked sheet rubber · `41016` school buildings · `41018` entertainment and sports buildings · `41020` prefabricated buildings · `95220` household appliance repair · `95291` clothing and textile repair · `95299` other household goods repair

## Why nine and not thirty-nine

A 39-code patch for the same annex was **withdrawn before merge** (#3659): the evidence handed to its adjudicating agents had the scope qualifier stripped out, because Lampiran II writes the scope on a numbered **parent** row and the parser emitted only the indented child.

Re-adjudicated over two rounds, cross-family, generator≠grader — a Claude lane proposing from the annex row, an OpenAI lane re-deriving each code blind. **Round 2's evidence pack carried, for the first time, the parent bidang usaha AND the sibling 2025 codes sharing each ancestor.** That second field moved eight verdicts from PATCH to REFUSE: a 2025 code that also absorbs 2020 activities the annex never named is wider than the reservation (Pasal 5(5) attaches the allocation to the named activity, never to the code number).

Refusing is **not** the safe direction, and the bias was stated to both lanes as such: restricting wrongly costs a client a business he could lawfully run; publishing 100% on a reserved activity costs him a rejected investment.

Every code that did not survive is **named** in the spec's `excluded` block and pinned by a test: 11 reserved only as a segment (below 25 Ha, or at simple/intermediate technology grade) · 9 broader than the reserved activity · 13 where the families disagreed · 5 unclear · 1 whose annex text the OCR destroyed · 6 vintage carries whose 1:1 crosswalk edge proves **lineage**, not that the heir is the same **activity**.

## The applier now reaches the consumers

Writing canonical is not shipping. Every sibling cure compiler runs `sync_kbli_dataset.sh` and re-stamps the version sidecar; this one did not, so its cure would have landed on canonical alone and the drift check would have failed the next innocent PR (W86). `--apply` now propagates and proves it, and refuses if a consumer copy still differs.

It also **skips propagation when the dataset is not canonical** — found by mutation, not by reasoning: with the withdrawal guard deleted, the refusal tests ran on and shelled out to the real repo-wide sync (W96).

## The pins that moved, each argued rather than absorbed

- `test_the_barred_but_open_list_reads_across_every_bucket` **23 → 22** — this is the tripwire built when the 39 were withdrawn, and it fired exactly as designed. `95291` leaves on complete evidence; `55201`/`55203` stay, being vintage carries still unchecked for activity identity.
- `kbli_eye`: umkm-reserved **2 → 11**, rejected bucket **91 → 100** and **64 → 73**. Declared population pins; both invariants underneath hold unchanged (nothing new became wrongly rejected — the difference stays 27).
- `kbli-bali-block`: notice **455 → 451**, MSME-reserved **7 → 6**. Four of the nine are also Bali-blocked, so a 0% national cap now outranks a Bali-scoped explanation. The msme drop is `95291`, where the Bali layer already said "reserved for Koperasi/UMKM" while the national layer published 100% open — **that contradiction is what closed; the code did not become freer.**
- The "national statuses still read open" assertion is no longer universal — asserting it as universal would fail every time the catalogue gets *more* honest. Pinned instead: the remaining contradiction, **8**, which may only shrink.

## Verification

- Applier suite **26 passed**, withdrawal guard and propagation-scope guard both **mutation-verified** (mutant → 2 red, real dataset and real sync untouched).
- Filiera suite **863 passed** · `test_kbli_eye.py` **20 passed** · mouth KBLI suites green.
- Proven on all three tracked consumer copies **by content**, with `10761` (coffee without a geographical indication — correctly open) as an unmoved control and `01111` (maize, reserved only below 25 Ha) still open, which is the whole point of the withdrawal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)