### PR TITLE
fix(kbli): the annex numbers its items two ways and the parent reader saw one

### DIFF
--- a/data/kbli-filiera/perpres-umkm-reservation.json
+++ b/data/kbli-filiera/perpres-umkm-reservation.json
@@ -187,7 +187,7 @@
    "column": "dialokasikan",
    "page": 2,
    "text": "Industri pemindangan ikan",
-   "parent_heading": "Pemungutan hasil hutan",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -979,7 +979,7 @@
    "column": "dialokasikan",
    "page": 14,
    "text": "Hotel Bintang I",
-   "parent_heading": null,
+   "parent_heading": "Jasa Penginapan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -988,7 +988,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Hotel Melati",
-   "parent_heading": null,
+   "parent_heading": "Jasa Penginapan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -997,7 +997,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Pondok Wisata",
-   "parent_heading": null,
+   "parent_heading": "Jasa Penginapan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1006,7 +1006,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Vila",
-   "parent_heading": null,
+   "parent_heading": "Jasa Penginapan",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1015,7 +1015,7 @@
    "column": "dialokasikan",
    "page": 15,
    "text": "Guest House",
-   "parent_heading": null,
+   "parent_heading": "Jasa Penginapan",
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -1276,7 +1276,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Pengalengan ikan",
-   "parent_heading": "Usaha pengolahan hasil perikanan (UPI)",
+   "parent_heading": null,
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1366,7 +1366,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri               briket kela",
-   "parent_heading": null,
+   "parent_heading": "Industri kelapa",
    "read_from": "text-layer",
    "title_corroborated": false
   },
@@ -1420,7 +1420,7 @@
    "column": "kemitraan",
    "page": 18,
    "text": "Industri serat sabut kelapa",
-   "parent_heading": null,
+   "parent_heading": "Industri kelapa",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1582,7 +1582,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "gedung perkantoran gedung industri",
-   "parent_heading": null,
+   "parent_heading": "Konstruksi gedung",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1591,7 +1591,7 @@
    "column": "kemitraan",
    "page": 20,
    "text": "gedung industri",
-   "parent_heading": null,
+   "parent_heading": "Konstruksi gedung",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1600,7 +1600,7 @@
    "column": "kemitraan",
    "page": 21,
    "text": "Konstruksi jembatan dan jalan layang yang menggunakan",
-   "parent_heading": null,
+   "parent_heading": "Konstruksi gedung",
    "read_from": "text-layer",
    "title_corroborated": true
   },
@@ -1681,7 +1681,7 @@
    "column": "dialokasikan",
    "page": 22,
    "text": "Peralatan komunikasi",
-   "parent_heading": null,
+   "parent_heading": "Rqprasi peralatan",
    "read_from": "text-layer",
    "title_corroborated": true
   }

--- a/scripts/kbli_filiera/parse_perpres_lampiran2.py
+++ b/scripts/kbli_filiera/parse_perpres_lampiran2.py
@@ -213,11 +213,27 @@ def cell_at(line: str, tick_x: int) -> str:
 # processing, item `3.`) was carrying `Pemungutan hasil hutan` — forest
 # harvesting, item 2 — as its parent.
 #
-# Measured before the fix, both directions: of 76 line-positions whose
-# governing parent changes, ZERO lose a restricting parent and ZERO gain one.
-# So no verdict moved — the defect was live and had not yet bitten. That is the
-# reason to fix it now rather than the reason not to.
-_NUMBERED_ITEM_RE = re.compile(r"^\s{0,14}\d{1,3}\.?\s{1,}(\S.*?)\s*$")
+# Measured on the emitted artifact, both directions, and re-derived independently
+# by a cross-family review of this diff: of the 13 ROWS whose governing parent
+# changes, ZERO lose a restricting parent and ZERO gain one; `parent-qualified`
+# is 19 before and 19 after. So no verdict moved — the defect was live and had
+# not yet bitten. That is the reason to fix it now rather than the reason not to.
+# (An earlier draft of this note said "76 line-positions". That is a different
+# unit — positions inside `governing_headings`, not emitted rows — and it was
+# never re-measured, so it is stated here in the unit the claim is checked in.)
+# Two admitted forms, and they do NOT share a spacing rule. `48.` may be followed
+# by a single space; a bare `49` still demands two, exactly as before. Collapsing
+# both to `\.?\s{1,}` was the first draft and an independent review named the
+# cost: it also admits `"2 body"` under a parent, which closes that parent on a
+# line the annex never numbered. Zero such lines exist in the vaulted PDF today —
+# which is the argument for spending one alternation now rather than discovering
+# it in a re-issue.
+#
+# `(?!\d)` on the heading is the second half of the same care: `1. 500 juta
+# rupiah:` would otherwise become a parent named "500 juta rupiah". No real item
+# heading in this annex begins with a digit — asserted on the artifact, not
+# assumed.
+_NUMBERED_ITEM_RE = re.compile(r"^\s{0,14}\d{1,3}(?:\.\s{1,}|\s{2,})(?!\d)(\S.*?)\s*$")
 
 
 def governing_headings(text: str) -> dict[tuple[int, int], str | None]:

--- a/scripts/kbli_filiera/parse_perpres_lampiran2.py
+++ b/scripts/kbli_filiera/parse_perpres_lampiran2.py
@@ -203,7 +203,21 @@ def cell_at(line: str, tick_x: int) -> str:
 # amount of care further down can recover what was never in the row. Measured
 # 2026-08-06 against the vaulted PDF: three parents carry such a qualifier
 # ("... kurang dari 25 Ha", and twice "... teknologi sederhana dan madya").
-_NUMBERED_ITEM_RE = re.compile(r"^\s{0,14}\d{1,3}\s{2,}(\S.*?)\s*$")
+# The annex numbers its items in BOTH forms, interleaved and with no pattern:
+# `48.   Jasa Penginapan:` and `49     Aktivitas konsultansi ...` sit two rows
+# apart. Requiring whitespace immediately after the digits saw only the second,
+# which cost twice over: 4 colon-terminated PARENTS were invisible (`Jasa
+# Penginapan:` governs the whole accommodation family — hotels, homestays,
+# villas), and, worse, a dotted item no longer CLOSED the parent above it, so
+# its rows inherited a heading that does not govern them. `10214` (fish
+# processing, item `3.`) was carrying `Pemungutan hasil hutan` — forest
+# harvesting, item 2 — as its parent.
+#
+# Measured before the fix, both directions: of 76 line-positions whose
+# governing parent changes, ZERO lose a restricting parent and ZERO gain one.
+# So no verdict moved — the defect was live and had not yet bitten. That is the
+# reason to fix it now rather than the reason not to.
+_NUMBERED_ITEM_RE = re.compile(r"^\s{0,14}\d{1,3}\.?\s{1,}(\S.*?)\s*$")
 
 
 def governing_headings(text: str) -> dict[tuple[int, int], str | None]:

--- a/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
+++ b/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
@@ -621,17 +621,60 @@ def test_guilt_a_dotted_item_CLOSES_the_parent_above_it():
 
 
 def test_innocence_the_undotted_form_still_governs_its_children():
-    """The fix must not trade one form for the other."""
+    """The fix must not trade one form for the other.
+
+    This one passes against the OLD rule too, and that is what an innocence test
+    is for — it pins behaviour the change must leave alone. It has no power to
+    catch a regression of the DOTTED form; do not read it as a guard for that.
+    The two `test_guilt_…` cases above are the guards.
+    """
     text = "   4   Industri pengolahan kedelai:\n       Industri tempe kedelai  10391  V\n"
     h = governing_headings(text)
     assert h[(1, 1)] == "Industri pengolahan kedelai"
 
 
-def test_innocence_a_dotted_line_that_is_not_an_item_number_is_not_a_heading():
-    """`1.500` in a row's text, or a page number, must not become a parent."""
-    text = "        Nilai investasi 1. 500 juta rupiah:\n        Sesuatu   12345   V\n"
+def test_innocence_a_decimal_amount_at_the_head_of_a_line_is_not_an_item():
+    """The widened boundary's own hazard, exercised where it actually lives.
+
+    An earlier version of this test began the line with `Nilai`, so `^\\s*\\d`
+    never matched and it could not have failed however the rule was written — it
+    asserted a condition on a literal string instead of an outcome of the parser
+    (named by an independent review of this diff). These three lines all BEGIN
+    with digits, which is the only place the rule can be fooled:
+
+      `1.500  juta`  — a dot with no space after it is a decimal separator
+      `1. 500 juta:` — a dot WITH a space is the shape the fix admits, and the
+                       heading it would open starts with a digit, which no real
+                       item in this annex does
+      `12 Besar`     — a bare number needs two spaces, as it always did
+    """
+    text = (
+        "   1.500  juta rupiah:\n"
+        "   1. 500 juta rupiah:\n"
+        "   12 Besar saja:\n"
+        "        Sesuatu   12345   V\n"
+    )
     h = governing_headings(text)
-    assert h[(1, 0)] is None and h[(1, 1)] is None
+    assert h[(1, 3)] is None, f"a row after three non-items must be parentless, got {h[(1, 3)]!r}"
+
+
+def test_guilt_a_bare_number_with_one_space_does_not_close_a_parent():
+    """The tightening, and why it is not cosmetic.
+
+    Written as `\\d{1,3}\\.?\\s{1,}` the rule admits a bare `2 body` — a line the
+    annex never numbered — and a numbered item ALWAYS closes the parent above it.
+    So the child on the following line would be orphaned by a false sibling. The
+    dotted form gets the single space; the bare form still demands two.
+    """
+    text = (
+        "   7   Jasa Penginapan:\n"
+        "   2 keterangan lanjutan\n"
+        "        Hotel Melati    55120   V\n"
+    )
+    h = governing_headings(text)
+    assert h[(1, 2)] == "Jasa Penginapan", (
+        "a line that is not an item number must not close the heading above it"
+    )
 
 
 def test_the_live_artifact_attributes_the_accommodation_family_and_not_the_fish():

--- a/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
+++ b/scripts/kbli_filiera/tests/test_perpres_umkm_reservation.py
@@ -32,10 +32,12 @@ from parse_perpres_lampiran2 import (  # noqa: E402
     SUBSTITUTIONS,
     content_words,
     decode,
+    governing_headings,
     parse,
 )
 from perpres_umkm_reservation_relation import (  # noqa: E402
     RELATION,
+    _PARENT_QUALIFIER_RE,
     classify,
     live_heirs,
     load_canonical,
@@ -589,6 +591,67 @@ def test_the_live_artifact_carries_the_parent_that_was_missing():
     assert {r["code"] for r in qualified} == {
         "01111", "01113", "01114", "01115", "01121", "01122",
     }
+
+
+def test_guilt_a_dotted_item_number_is_a_heading_like_any_other():
+    """The annex numbers items BOTH ways, two rows apart: `48.  Jasa Penginapan:`
+    and `49  Aktivitas konsultansi ...`. A rule that required whitespace right
+    after the digits saw only the second, and `Jasa Penginapan:` — the heading
+    that governs every hotel, homestay, guest house and villa row in Lampiran II
+    — was invisible."""
+    text = "  48.   Jasa Penginapan:\n       - Hotel Bintang I    55110    V\n"
+    h = governing_headings(text)
+    assert h[(1, 1)] == "Jasa Penginapan"
+
+
+def test_guilt_a_dotted_item_CLOSES_the_parent_above_it():
+    """The worse half, and the one that put a false fact in the data rather than
+    merely omitting a true one. A numbered item always ends the previous parent;
+    when the dotted form was not recognised as an item, its rows kept inheriting
+    the heading above. Live instance: `10214` (fish processing, item `3.`) was
+    carrying `Pemungutan hasil hutan` — forest harvesting, item 2."""
+    text = (
+        "   2   Pemungutan hasil hutan:\n"
+        "        Rotan                  02302   V\n"
+        "   3.   Industri pemindangan ikan   10214   V\n"
+    )
+    h = governing_headings(text)
+    assert h[(1, 1)] == "Pemungutan hasil hutan", "the child of item 2 keeps its parent"
+    assert h[(1, 2)] is None, "item 3. is its own item and inherits nothing"
+
+
+def test_innocence_the_undotted_form_still_governs_its_children():
+    """The fix must not trade one form for the other."""
+    text = "   4   Industri pengolahan kedelai:\n       Industri tempe kedelai  10391  V\n"
+    h = governing_headings(text)
+    assert h[(1, 1)] == "Industri pengolahan kedelai"
+
+
+def test_innocence_a_dotted_line_that_is_not_an_item_number_is_not_a_heading():
+    """`1.500` in a row's text, or a page number, must not become a parent."""
+    text = "        Nilai investasi 1. 500 juta rupiah:\n        Sesuatu   12345   V\n"
+    h = governing_headings(text)
+    assert h[(1, 0)] is None and h[(1, 1)] is None
+
+
+def test_the_live_artifact_attributes_the_accommodation_family_and_not_the_fish():
+    """TRIPWIRE on the DATA for both halves of the dotted-number defect, on the
+    rows that carry commercial weight: the accommodation family is Bali Zero's
+    own market, and `Jasa Penginapan` is what says these rows are a family at
+    all. It carries NO restricting qualifier — which is the point: recovering a
+    parent is not the same as finding a restriction, and this test asserts the
+    parent is present AND that it does not narrow anything."""
+    rows = load_relation()["rows"]
+    by = {}
+    for r in rows:
+        by.setdefault(r["code"], []).append(r)
+    for code in ("55110", "55120", "55130", "55193", "55199"):
+        assert all(r.get("parent_heading") == "Jasa Penginapan" for r in by[code]), code
+    assert not _PARENT_QUALIFIER_RE.search("Jasa Penginapan"), (
+        "a recovered parent must not be assumed restrictive"
+    )
+    # …and the phantom is gone: item `3.` inherits nothing from item 2.
+    assert all(r.get("parent_heading") is None for r in by["10214"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was wrong

Perpres 49/2021 Lampiran II writes its item numbers in **two forms, interleaved with no pattern** — `48.   Jasa Penginapan:` and `49     Aktivitas konsultansi …` sit two rows apart on the same page. `_NUMBERED_ITEM_RE` required whitespace *immediately* after the digits, so it saw only the second form.

That cost us in **both** directions:

**4 colon-terminated PARENTS were invisible.** The biggest is `Jasa Penginapan:`, which governs the entire accommodation family — Hotel Bintang I, Hotel Melati, Pondok Wisata, Vila, Guest House. Also `Industri kelapa:`, `Konstruksi gedung:`, and `Rqprasi peralatan:` (the annex's own text layer mangles *Reparasi* — transcribed as the source gives it, not corrected).

**Worse: a dotted item no longer CLOSED the heading above it,** so its rows inherited a parent that does not govern them:

| row | wrongly inherited | after |
|---|---|---|
| `Industri pemindangan ikan` (item `3.`) | `Pemungutan hasil hutan` — *forest harvesting* | none |
| `Pengalengan ikan` (item `66.`) | `Usaha pengolahan hasil perikanan (UPI)` | none |

Fish under forestry is the tell: item `3.` is its own numbered *bidang usaha*, not a child of item `2.`

## No verdict moves — measured, not argued

Of the **13 rows** whose `parent_heading` changes:

- **0** lose a qualifier-carrying parent (`kurang dari` / `sederhana` / `madya` / …)
- **0** gain one
- parent-qualified rows: **19 before, 19 after**

Recovering a parent is not the same as finding a restriction. `Jasa Penginapan` narrows nothing — the tempting misreading of "the accommodation family finally has its parent" is that the parent restricts something. It does not.

## Guilt is mutation-verified

Restoring the old regex turns two of the five new tests red, the second reporting the live defect verbatim:

```
FAILED test_guilt_a_dotted_item_number_is_a_heading_like_any_other
FAILED test_guilt_a_dotted_item_CLOSES_the_parent_above_it
E   AssertionError: item 3. is its own item and inherits nothing
E   assert 'Pemungutan hasil hutan' is None
```

95 tests pass across `test_perpres_umkm_reservation.py` + `test_perpres_body_default.py`.

## Declared

- The M5 pre-push backend gate did not run (no local PostgreSQL) — CI and the merge queue are the first things to judge this diff.
- `Rqprasi peralatan` is kept as the annex's text layer emits it; it is an OCR artifact of *Reparasi*, not a word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)