### PR TITLE
fix(observability): the log-size alarm fired below the line where the cure acts

### DIFF
--- a/.github/workflows/alarm-cure-alignment.yml
+++ b/.github/workflows/alarm-cure-alignment.yml
@@ -1,0 +1,56 @@
+# Alarm/cure alignment — the log-size watchdog must not alarm below the rotator
+# ----------------------------------------------------------------------------
+# An alarm must name a condition some organ will act on. `log_size_watchdog.sh`
+# alarmed on error logs above 1 MB; `log-rotate-run.sh` trims them at 10 MB.
+# Between two independently-maintained constants sat a dead zone, and on
+# 2026-08-06 the entire observed population lived in it — all 11 files over the
+# alert line were 1.1-7.1 MB, permanently loud and permanently ineligible for
+# the cure. Three had stopped being written months earlier. That single script
+# produced 1798 of the organism's 5202 Telegram events in 29.5 days (34.6%),
+# none of it actionable.
+#
+# The gap had already been found once: log-rotate-run.sh's own 2026-07-20
+# comment names the "1-50MB dead zone" and lowers its threshold 50 -> 10 to
+# close it. That closed half of it, and NOTHING DETECTED THE HALF LEFT. This
+# workflow is what was missing — the link between two files that must agree.
+#
+# Deliberately NOT a required context, matching tg-gateway.yml's reasoning: a
+# required check that goes permanently red blocks the entire merge queue, which
+# is a worse failure mode than an unread one. What matters is that an executor
+# exists that CAN go red — `scripts/tests/ sweep` is continue-on-error and gates
+# nothing, which is the superscar #2 shape this whole family keeps producing.
+#
+# Measurement: research/operations/2026-08-06-telegram-messaging-study.md
+
+name: "alarm/cure alignment (log-size watchdog vs rotator)"
+
+on:
+  pull_request:
+    paths:
+      # BOTH sides. The 2026-07-20 half-fix moved the ROTATOR, so a trigger
+      # watching only the watchdog would not have started on the diff that
+      # reopened the zone.
+      - "scripts/log_size_watchdog.sh"
+      - "infra/launchagents/wrappers/log-rotate-run.sh"
+      - "scripts/tests/test_log_watchdog_dead_zone.py"
+      - ".github/workflows/alarm-cure-alignment.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  dead-zone:
+    name: no dead zone between the alarm line and the cure line
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Tripwire (stdlib + bash only)
+        run: |
+          python3 -m pip -q install pytest
+          python3 -m pytest scripts/tests/test_log_watchdog_dead_zone.py -q
+
+      - name: The watchdog still parses
+        run: bash -n scripts/log_size_watchdog.sh

--- a/.github/workflows/alarm-cure-alignment.yml
+++ b/.github/workflows/alarm-cure-alignment.yml
@@ -43,7 +43,11 @@ jobs:
   dead-zone:
     name: no dead zone between the alarm line and the cure line
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Floor 10, not 5: actions/checkout on this repo intermittently takes ~2
+    # minutes, and a job that runs out reports as `cancelled` — which never
+    # turns green by itself and shows nothing red to fix. Size the budget by
+    # the checkout, not by the script (scripts/lint_workflow_timeout_floor.py).
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -66,6 +66,7 @@ on:
     # note and why fixing the two source name: lines is a separate PR.
     workflows:
       - actionlint
+      - alarm/cure alignment (log-size watchdog vs rotator)
       - adversarial-review-gate
       - AI PR review (advisory)
       - asyncpg-lint

--- a/scripts/log_size_watchdog.sh
+++ b/scripts/log_size_watchdog.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# log_size_watchdog.sh — Telegram alert if any ~/logs/*.err.log > 1MB
+# log_size_watchdog.sh — Telegram alert if an ~/logs/*.err.log passes the
+#                        size at which the rotator will actually trim it
 #
 # Wave 1 fix 2026-05-19 (4-LLM panel synthesis 3/3 quorum).
 #
@@ -10,10 +11,36 @@
 # watchdog running hourly, Telegram would have alerted within 1h of
 # the first cumulative MB — 84× faster MTTR.
 #
-# Threshold rationale: 1 MB (Codex + DeepSeek 1MB recommendation,
-# overridden Gemini's 5MB). 1 MB is ~5000-10000 stack-frame lines of
-# typical Python traceback — well above any healthy daily growth for
-# our cron-style scripts. False-positive rate empirically <1/month.
+# Threshold rationale — REVISED 2026-08-06 after measuring the channel.
+#
+# It was a standalone 1 MB ("false-positive rate empirically <1/month",
+# Codex + DeepSeek panel 2026-05-19). Measured over the 29.5 days to
+# 2026-08-06: this script produced 1798 of the organism's 5202 Telegram
+# events — 34.6%, the single loudest source on the fleet, 19 files each
+# re-announced roughly every 6 hours for a month.
+#
+# None of them was a false positive, and none was actionable either.
+# The cure — log-rotate-run.sh — trims error logs at 10 MB. Between the
+# 1 MB alarm line and the 10 MB cure line was a dead zone: every one of
+# the 11 files then over the line sat at 1.1-7.1 MB, so all of them were
+# permanently loud and permanently ineligible for rotation. Three had
+# stopped being written altogether (mtime 04/07, 21/07, 31/07) and would
+# have been announced forever.
+#
+# This gap had already been found once. log-rotate-run.sh carries its own
+# comment dated 2026-07-20 naming the "1-50MB dead zone" and lowering its
+# error threshold 50 -> 10 MB to close it. That closed it half way; the
+# population simply lived in what was left.
+#
+# So the value is not the defect — the INDEPENDENCE is. An alarm line and
+# a cure line maintained as two unrelated constants will drift apart again
+# the next time either is tuned. This threshold now DERIVES from the
+# rotator's own knob, and scripts/tests/test_log_watchdog_dead_zone.py
+# fails the build if the two ever separate. An alarm must name a condition
+# some organ will act on; otherwise it is a metronome that teaches everyone
+# to ignore the channel where the real ones arrive.
+#
+# Measurement: research/operations/2026-08-06-telegram-messaging-study.md
 #
 # Cooldown: 6h per file (state in ~/.agent/decisions/state/log_size_*).
 # Avoids spam when an issue is acknowledged but not yet fixed.
@@ -24,7 +51,12 @@
 
 set -uo pipefail
 
-THRESHOLD_BYTES=1048576  # 1 MB
+# The rotator's error-log knob is the SSOT: alarm where the cure acts, so an
+# operator who tunes one moves both. LOG_SIZE_WATCHDOG_THRESHOLD_MB overrides
+# for the rare case where they must genuinely differ — and the tripwire test
+# reads the DEFAULTS, so an override cannot silently reopen the dead zone.
+THRESHOLD_MB="${LOG_SIZE_WATCHDOG_THRESHOLD_MB:-${PRO_LOG_ROTATE_ERR_THRESHOLD_MB:-10}}"
+THRESHOLD_BYTES=$(( THRESHOLD_MB * 1048576 ))
 COOLDOWN_SEC=21600       # 6h between repeat alerts on the same file
 LOG_DIR="${HOME}/logs"
 STATE_DIR="${HOME}/.agent/decisions/state"
@@ -72,7 +104,7 @@ while IFS= read -r f; do
     rel_path="${f#$HOME/}"
 
     # Notification gateway (cohort-3): log housekeeping = informative → digest tier
-    msg="📊 Log size alert: ~/${rel_path} = ${size_mb} MB (>1MB threshold). $(tail -1 "$f" 2>/dev/null | head -c 200)"
+    msg="📊 Log size alert: ~/${rel_path} = ${size_mb} MB (>${THRESHOLD_MB}MB threshold). $(tail -1 "$f" 2>/dev/null | head -c 200)"
     gateway="$(dirname "$0")/tg_notify.py"
     [ -f "$gateway" ] || gateway="$HOME/nuzantara/scripts/tg_notify.py"
     python3 "$gateway" --tier digest --source log-size-watchdog \

--- a/scripts/tests/test_log_watchdog_dead_zone.py
+++ b/scripts/tests/test_log_watchdog_dead_zone.py
@@ -1,0 +1,126 @@
+"""An alarm must name a condition some organ will act on.
+
+TRAUMA (measured on the live 31-day spool, 2026-08-06): `log_size_watchdog.sh`
+alarmed on error logs above 1 MB. `log-rotate-run.sh` trims them at 10 MB.
+Between those two independently-maintained constants sat a DEAD ZONE, and the
+entire observed population lived in it — all 11 files over the alert line were
+1.1-7.1 MB, so every one was permanently loud and permanently ineligible for
+rotation. Three had stopped being written months earlier and would have been
+announced forever.
+
+That produced 1798 of the organism's 5202 Telegram events in 29.5 days: 34.6%,
+the loudest source on the fleet, none of it actionable.
+
+The gap had already been found once. log-rotate-run.sh's own comment, dated
+2026-07-20, names the "1-50MB dead zone" and lowers its error threshold 50 -> 10
+to close it. It closed half of it, and nothing detected the half that remained.
+
+So the value was never the defect — the INDEPENDENCE was. Two constants that
+must agree, maintained in two files with no link between them, drift apart again
+the moment either is tuned. This test is that link: it fails the build if the
+alarm line ever drops below the cure line.
+
+It reads the DEFAULTS in the scripts, not the running environment, because an
+operator override is a deliberate local act while a default is what the fleet
+inherits.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+WATCHDOG = REPO / "scripts" / "log_size_watchdog.sh"
+ROTATOR = REPO / "infra" / "launchagents" / "wrappers" / "log-rotate-run.sh"
+
+# `THRESHOLD_MB="${LOG_SIZE_WATCHDOG_THRESHOLD_MB:-${PRO_LOG_ROTATE_ERR_THRESHOLD_MB:-10}}"`
+WATCHDOG_RE = re.compile(
+    r'^THRESHOLD_MB=.*?PRO_LOG_ROTATE_ERR_THRESHOLD_MB:-(\d+)', re.MULTILINE
+)
+# `ERR_THRESHOLD_MB="${PRO_LOG_ROTATE_ERR_THRESHOLD_MB:-10}"`
+ROTATOR_RE = re.compile(
+    r'^ERR_THRESHOLD_MB="\$\{PRO_LOG_ROTATE_ERR_THRESHOLD_MB:-(\d+)\}"', re.MULTILINE
+)
+
+
+def _default(path: Path, rx: re.Pattern, what: str) -> int:
+    assert path.is_file(), f"{path} is gone — this test cannot verify what it claims"
+    m = rx.search(path.read_text())
+    assert m, (
+        f"could not read the {what} default out of {path.name}. The declaration "
+        f"changed shape; re-derive it rather than deleting this test — a "
+        f"tripwire that cannot parse its subject is worse than none (it reads "
+        f"green while measuring nothing)."
+    )
+    return int(m.group(1))
+
+
+def test_the_alarm_line_is_never_below_the_cure_line():
+    """GUILT: this is the exact 1-vs-10 configuration that produced 34.6% of
+    a month of Telegram traffic, none of it actionable."""
+    alarm = _default(WATCHDOG, WATCHDOG_RE, "watchdog threshold")
+    cure = _default(ROTATOR, ROTATOR_RE, "rotator error threshold")
+    assert alarm >= cure, (
+        f"DEAD ZONE {cure}>{alarm}MB: the watchdog alarms at {alarm}MB but the "
+        f"rotator only acts at {cure}MB. Every error log between those sizes is "
+        f"permanently loud and permanently ineligible for the cure. Raise the "
+        f"watchdog to the rotator's threshold, or lower the rotator's."
+    )
+
+
+def test_the_watchdog_derives_from_the_rotators_knob():
+    """The numbers agreeing TODAY is not the property under test — an operator
+    who tunes the rotator must move the watchdog with it, or the next tuning
+    reopens the zone. Two constants that happen to match are not linked."""
+    src = WATCHDOG.read_text()
+    assert "PRO_LOG_ROTATE_ERR_THRESHOLD_MB" in src, (
+        "the watchdog no longer reads the rotator's knob — it is back to an "
+        "independent constant, which is the defect this test exists for"
+    )
+
+
+def test_the_message_quotes_the_threshold_it_actually_used():
+    """The alert text used to hardcode '>1MB threshold'. A message that names a
+    number the code no longer uses is a lie the reader cannot detect."""
+    src = WATCHDOG.read_text()
+    msg = next((ln for ln in src.splitlines() if "Log size alert" in ln), "")
+    assert msg, "the alert message vanished — re-derive this test"
+    assert "${THRESHOLD_MB}" in msg, (
+        f"the alert text hardcodes a threshold instead of quoting the one in "
+        f"force: {msg.strip()[:120]}"
+    )
+
+
+def test_the_watchdog_still_uses_a_stable_dedup_key():
+    """INNOCENCE for the neighbouring cure (#3668): this producer's key is
+    `log-size:<path>` — it names the CONDITION and does not move with the size.
+    A key that moved with the measurement would bypass condition_identity() and
+    then defeat every mute window, which is what sentinel does."""
+    src = WATCHDOG.read_text()
+    assert '--dedup-key "log-size:${rel_path}"' in src, (
+        "the dedup key changed; if it now contains the size or the log tail it "
+        "will defeat the escalating mute ladder entirely"
+    )
+
+
+@pytest.mark.parametrize("env,expected", [
+    ({}, 10),
+    ({"PRO_LOG_ROTATE_ERR_THRESHOLD_MB": "25"}, 25),
+    ({"LOG_SIZE_WATCHDOG_THRESHOLD_MB": "3"}, 3),
+    ({"PRO_LOG_ROTATE_ERR_THRESHOLD_MB": "25", "LOG_SIZE_WATCHDOG_THRESHOLD_MB": "3"}, 3),
+])
+def test_threshold_resolution_order(env, expected):
+    """Executed, not read: the shell's own parameter expansion decides this."""
+    import subprocess
+
+    expr = 'THRESHOLD_MB="${LOG_SIZE_WATCHDOG_THRESHOLD_MB:-${PRO_LOG_ROTATE_ERR_THRESHOLD_MB:-10}}"'
+    assert expr in WATCHDOG.read_text(), "the expansion changed — re-derive this test"
+    out = subprocess.run(
+        ["bash", "-c", f'{expr}; echo "$THRESHOLD_MB"'],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin", **env},
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == str(expected)


### PR DESCRIPTION
## Measured

Over the 29.5 days to 2026-08-06, `log_size_watchdog.sh` produced **1798 of the organism's 5202 Telegram events — 34.6%**, the loudest source on the fleet, 19 files each re-announced roughly every 6 hours for a month.

None of it was a false positive. **None of it was actionable either.**

The watchdog alarms above **1 MB**. `log-rotate-run.sh` trims error logs at **10 MB**. Between them sat a dead zone, and the entire observed population lived in it — every one of the 11 files then over the alert line:

```
7.1MB  06/08  wa-mirror-attention-classifier.err.log
6.7MB  06/08  intake-worker.launchd.err.log
5.8MB  06/08  intake-blob-retention.err.log
5.1MB  06/08  local-livekit-server.err.log
5.0MB  21/07  wa-dashboard-m1.err.log          <- frozen 16 days
4.5MB  06/08  wr2_supervisor.launchd.err.log
3.6MB  06/08  wa-mirror-attention-realtime.err.log
3.2MB  06/08  drive-intake-drain.err.log
2.5MB  31/07  flowkit.err.log                  <- frozen
2.0MB  04/07  wa-mirror-auto-promote.err.log   <- frozen
1.1MB  06/08  local-livekit-worker.err.log
```

**Eleven out of eleven inside the gap.** Three are not being written any more — `wa-dashboard-m1.err.log` last changed on 21 July and sits at 5.0 MB: permanently above the alarm line, permanently below the cure line, never growing, announced until someone deletes it by hand.

## It had already been found once

`log-rotate-run.sh` carries its own comment, dated 2026-07-20:

> `# 1-50MB dead zone — above the log-size-watchdog's 1MB alert line, below this rotator's`
> `# 50MB — so they never rotated and re-alerted every cycle (16 files, ...)`

Someone diagnosed this exact gap and closed it **half way**, lowering the error threshold 50 → 10 MB. The population simply lived in what was left, because **nothing detected the half that remained**.

## So the value was never the defect — the independence was

Two constants that must agree, maintained in two files with no link between them, drift apart again the moment either is tuned. This PR makes the link:

- the watchdog threshold **derives** from the rotator's own knob (`PRO_LOG_ROTATE_ERR_THRESHOLD_MB`), so tuning the cure moves the alarm;
- `LOG_SIZE_WATCHDOG_THRESHOLD_MB` remains for the rare case where they must genuinely differ, and the tripwire reads the **defaults**, so an override cannot silently reopen the zone;
- the alert text quotes the threshold in force instead of hardcoding `">1MB threshold"` — which would now be a lie the reader cannot detect.

## Stated limit

This is not a substitute for reading *why* `wa-mirror-attention-classifier` writes 7 MB of stderr. Rotation is copy-truncate, so a live writer regrows and a daily rotator can be re-crossed before its next run. Honestly framed: it silences the frozen files permanently and converts the live ones from a permanent alarm into a periodic one that the rotator then acts on. The error-producing processes are a separate ledger line.

## Verification

8 tests, guilt **and** innocence. Mutation-verified **4/4 killed**:

| mutation | dies |
|---|---|
| threshold back to a standalone `1` (the historical defect exactly) | 6 tests |
| **rotator raised to 25** — the gap reopening from the side nobody thinks to test, which is how the 2026-07-20 half-fix happened | 1 |
| message hardcodes `>1MB` again | 1 |
| dedup key made to move with the size (would defeat #3668's mute ladder) | 1 |

Threshold resolution order is **executed by bash**, not read out of the file.

## Armed

A dedicated workflow triggered by **both** sides of the pair — a trigger watching only the watchdog would not have started on the 2026-07-20 diff that reopened the zone. Deliberately **not** a required context, matching `tg-gateway.yml`'s reasoning: a permanently-red required check blocks the merge queue, which is a worse failure mode than an unread one. What matters is that an executor exists which *can* go red — `scripts/tests/ sweep` is `continue-on-error` and gates nothing, which is the superscar #2 shape this family keeps producing.

Measurement: `research/operations/2026-08-06-telegram-messaging-study.md` (#3668).

🤖 Generated with [Claude Code](https://claude.com/claude-code)