### PR TITLE
feat(wa-dashboard-m1): mount the Meta Inbox as a sixth tab, so the desk has one WhatsApp interface

### DIFF
--- a/apps/wa-dashboard-m1/server.cjs
+++ b/apps/wa-dashboard-m1/server.cjs
@@ -2,6 +2,7 @@
 "use strict";
 
 const express = require("express");
+const nodeHttp = require("http");
 const { Pool } = require("pg");
 const fs = require("fs");
 const path = require("path");
@@ -1294,6 +1295,58 @@ app.use((req, res, next) => {
 app.get("/favicon.ico", (_req, res) => {
   res.status(204).end();
 });
+
+// ── Meta Inbox (numero aziendale Meta) montato dentro questa dashboard ──
+// Perche' un proxy e non un iframe verso 127.0.0.1:7791: questa dashboard
+// ascolta su 0.0.0.0 ed e' raggiungibile dalla LAN Tailscale, mentre il
+// meta-inbox ascolta SOLO su localhost. Un iframe verso 127.0.0.1 si
+// risolverebbe sul browser del visitatore e apparirebbe vuoto da ogni
+// macchina che non sia il Pro. Il proxy fa la richiesta lato server, quindi
+// funziona da ovunque la dashboard sia raggiungibile.
+// Il suo HTML chiama path ASSOLUTI (/api/threads, /api/send, ...), per questo
+// serve anche /api/* — prefisso che questa dashboard non usa per nulla.
+const META_INBOX_URL = process.env.WA_META_INBOX_URL || "http://127.0.0.1:7791";
+
+function proxyToMetaInbox(req, res, targetPath) {
+  const target = new URL(targetPath, META_INBOX_URL);
+  const headers = { ...req.headers };
+  delete headers.host; // altrimenti il target vede l'host di questa dashboard
+  const upstream = nodeHttp.request(
+    {
+      protocol: target.protocol,
+      hostname: target.hostname,
+      port: target.port,
+      path: target.pathname + target.search,
+      method: req.method,
+      headers,
+    },
+    (up) => {
+      res.status(up.statusCode || 502);
+      for (const [k, v] of Object.entries(up.headers)) {
+        if (k.toLowerCase() === "transfer-encoding") continue;
+        res.setHeader(k, v);
+      }
+      up.pipe(res);
+    },
+  );
+  upstream.on("error", (err) => {
+    // Fallire in modo LEGGIBILE: un 502 muto qui si legge come "il Meta Inbox
+    // non ha messaggi", che e' esattamente il fraintendimento da evitare.
+    if (res.headersSent) return res.end();
+    res
+      .status(502)
+      .type("text/plain")
+      .send(
+        `Meta Inbox non raggiungibile su ${META_INBOX_URL} (${err.code || err.message}).\n` +
+          `Il LaunchAgent com.balizero.wa-meta-inbox e' spento o in errore.\n` +
+          `Questo NON significa che non ci siano conversazioni.`,
+      );
+  });
+  req.pipe(upstream);
+}
+
+app.get("/meta", (req, res) => proxyToMetaInbox(req, res, "/"));
+app.all(/^\/api\//, (req, res) => proxyToMetaInbox(req, res, req.originalUrl));
 
 function dbUrlHost() {
   try {

--- a/apps/wa-dashboard-m1/viewer.html
+++ b/apps/wa-dashboard-m1/viewer.html
@@ -749,6 +749,7 @@
     <button class="view-tab" data-view="training">Training academy</button>
     <button class="view-tab" data-view="metrics">Team</button>
     <button class="view-tab" data-view="intake">Intake</button>
+    <button class="view-tab" data-view="meta">Meta Inbox</button>
 
   </div>
   <div class="meta">
@@ -851,6 +852,10 @@
   <div id="t-root">
     <div class="loader">Caricamento training…</div>
   </div>
+</section>
+<section id="view-meta" class="meta-view" style="display:none">
+  <iframe id="meta-frame" title="Meta Inbox — numero aziendale BALI ZERO"
+          style="width:100%;height:calc(100vh - 132px);border:0;background:#fff"></iframe>
 </section>
 <script>
 let DATA = null;
@@ -1919,7 +1924,7 @@ let METRICS = null;
 let INTAKE_LOADING = false;
 let INTAKE_PROMISE = null;
 let CURRENT_VIEW = "convs";
-const VALID_VIEWS = new Set(["convs", "captain", "metrics", "intake", "training"]);
+const VALID_VIEWS = new Set(["convs", "captain", "metrics", "intake", "training", "meta"]);
 
 function normalizeView(view) {
   return VALID_VIEWS.has(view) ? view : "convs";
@@ -1949,12 +1954,14 @@ function switchView(view, options = {}) {
   document.getElementById("view-metrics").style.display = view === "metrics" ? "" : "none";
   document.getElementById("view-intake").style.display = view === "intake" ? "" : "none";
   document.getElementById("view-training").style.display = view === "training" ? "" : "none";
+  document.getElementById("view-meta").style.display = view === "meta" ? "" : "none";
 
   for (const b of document.querySelectorAll(".view-tab")) b.classList.toggle("active", b.dataset.view === view);
   if (view === "captain") renderCaptain();
   if (view === "metrics") renderMetrics();
   if (view === "intake") renderIntake();
   if (view === "training") renderTraining();
+  if (view === "meta") renderMetaInbox();
 
 }
 
@@ -2418,6 +2425,18 @@ function renderTrainingPanel() {
     </div>`;
   subEl.textContent = `${filtered.length} di ${TRAINING.artifact_count || 0} summary · ${TRAINING.categories.length || 0} categorie · ${TRAINING.base_dir}`;
   wireTrainingControls();
+}
+
+// Il Meta Inbox e' servito da questa stessa origine via il proxy /meta del
+// server, quindi le sue chiamate assolute (/api/threads, /api/send, ...)
+// atterrano sul proxy e non su questa dashboard. Carichiamo il riquadro solo
+// alla prima apertura della scheda: e' un'altra app, non deve girare a vuoto
+// dietro le altre viste.
+function renderMetaInbox() {
+  const frame = document.getElementById("meta-frame");
+  if (!frame || frame.dataset.loaded === "1") return;
+  frame.dataset.loaded = "1";
+  frame.src = "/meta";
 }
 
 async function renderTraining(force) {


### PR DESCRIPTION
## Why

The Pro desktop carried **two** WhatsApp apps, and they are not duplicates:

- **`WA Dashboard.app` → 7790** — mirrors the seven personal team numbers, read-only, 5 tabs
- **`WA Meta Inbox.app` → 7791** — the company Meta number where Zantara answers, with *take over / release to bot / send*

Two icons for one question ("what is happening on WhatsApp") is the confusion. The fix is one window, not one less feature — the Meta Inbox is the only place a human can take a client conversation back from the bot.

## A proxy, not an iframe

The obvious move — an iframe pointed at `127.0.0.1:7791` — is wrong here. This dashboard listens on `0.0.0.0` and is reachable across the Tailscale LAN; the meta-inbox binds **localhost only**. An iframe URL resolves on the *visitor's* machine, so the panel would render empty from anywhere but the Pro itself, and look like "no conversations".

The proxy issues the request server-side, so the tab works wherever the dashboard already works.

Its HTML calls **absolute** paths (`/api/threads`, `/api/send`, `/api/takeover`, `/api/release`), so `/api/*` is proxied too. That prefix is used by **none** of this dashboard's twelve routes (verified by grep) — nothing is shadowed.

The upstream error path returns a **readable 502 naming the LaunchAgent** rather than failing silently: a blank panel would read as "no conversations", the exact class of misreading this cleanup is about. The iframe also loads lazily on first tab open — it is a separate app and shouldn't run behind the other five views.

## Verification

Ran a copy on port **7899** on the Pro, production untouched on 7790:

| Check | Result |
|---|---|
| `/meta` vs serving 7791 directly | **byte-identical** (`cmp -s`) |
| `/api/threads` through the proxy | HTTP 200, real threads |
| 5 original data routes | all **200** |
| dashboard routes under `/api` | **0** — no shadowing |
| errors in test log | **0** |

`/intake-summary.json` takes ~20s — but production takes **19.2s** for the same 13027 bytes. Pre-existing slowness, not a regression; deliberately left alone rather than folded into this diff.

## Follow-up, not in this PR

Once merged, `WA Meta Inbox.app` can come off the desk (the LaunchAgent on 7791 must stay — it is what the proxy talks to). Holding that until the tab is confirmed working for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)