### PR TITLE
feat(kbli): find where the article contradicts the record it was written from

### DIFF
--- a/scripts/kbli_filiera/editorial_record_conformance.py
+++ b/scripts/kbli_filiera/editorial_record_conformance.py
@@ -57,6 +57,34 @@ Bali-scoped cells. So the label's SCOPE is resolved first and Bali-scoped cells
 are excluded by name, with the exclusion counted and reported rather than left
 silent.
 
+THERE IS ALREADY A GUARD FOR THIS, AND IT WATCHES THE OTHER DIRECTION
+---------------------------------------------------------------------
+`kbli_dataset_lint.py` rule L9 calls `validate_pma_consistency`, which is a
+blocking lint and looks like this module's twin. Measured on the live
+catalogue, the two sets are DISJOINT: L9 finds 2 codes, this module finds 27,
+and the overlap is empty.
+
+The reason is structural rather than a matter of degree. L9 is two literal
+substring tests:
+
+    pma_status == "TERTUTUP" and "100% foreign" in text     # record closed, prose open
+    pma_status == "TERBUKA"  and "closed to foreign" in text # record open, prose closed
+
+Its two live findings (`43110`, `86201`) are both TERBUKA/100 caught by the
+SECOND test — a page understating what a client may do, which costs him an
+opportunity he could ask about. The first test guards the expensive direction,
+and it cannot reach this population: 26 of the 27 are **TERBATAS**, a status the
+condition never admits, and the 27th says it in words the substring does not
+contain ("nationally open to full foreign ownership"). So a client told he may
+wholly own an arms factory was never in range of the guard that exists.
+
+Left in place rather than folded together, deliberately: L9 owns the mirror
+case, and widening it here would turn a blocking lint red on a 27-item backlog
+(W95 — a gate armed on live debt makes every unrelated PR red). Reconciling them
+so that two tools cannot answer the same question two ways (W105) is a
+follow-up, and it belongs on the side of the LINT consuming this report, the way
+`kbli_documents_cure.py` consumes `kbli_surface_conformance.py --json`.
+
 IT REPORTS, IT DOES NOT DECIDE
 ------------------------------
 `--check` exits 0 while divergences exist, like its siblings in this directory.

--- a/scripts/kbli_filiera/editorial_record_conformance.py
+++ b/scripts/kbli_filiera/editorial_record_conformance.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Where the ARTICLE contradicts the RECORD it was written from.
+
+Every KBLI code page leads with an authored article — `intel_2026.editorial`:
+a headline, a standfirst, a "By the numbers" sidebar of label/value cells, and
+a markdown body. It was written by narrating the JSON record, and the renderer
+prints it VERBATIM. So it is not a consumer of the PMA fields in the ordinary
+sense; it is a SECOND, INDEPENDENT ASSERTION of the same facts, stored beside
+them.
+
+That is the whole problem. A consumer that READS a field moves when the field
+moves. A parallel assertion never moves at all. Nine codes were restricted on
+2026-08-06 and their pages kept a sidebar cell reading "Foreign-ownership
+ceiling: 100%" under a headline reading "Closed to Foreign Investment" — one
+page, two answers, and the wrong one is the one shaped like a number.
+
+WHY THIS IS NOT A WEB PROBLEM
+-----------------------------
+`reindex_kbli_2025_final.py` stringifies the WHOLE `intel_2026` dict into the
+embedding text (`for k, v in intel.items(): parts.append(f"- {k}: {v}")`), so
+the same contradicted sentences are in Qdrant and reachable by the RAG. A
+client asking on WhatsApp about `79122` — Umrah/Hajj travel, adjudicated cap
+0% — can be handed retrieved context asserting 100%. Curing this in the
+renderer would leave that untouched. It is a DATA defect and it is fixed at the
+source or not at all.
+
+TWO KINDS OF CONTRADICTION, AND ONLY ONE IS MECHANICAL
+------------------------------------------------------
+* A `byTheNumbers` CELL is a restatement of a field we own. "Foreign-ownership
+  ceiling: 100%" against `pma_max_asing == 0` is not a difference of opinion;
+  it is a stale copy. Correcting it asserts nothing new.
+* The BODY is authored narrative. "This activity is nationally open to full
+  foreign ownership" is wrong in the same way, but replacing a sentence means
+  writing one, and what to say instead is an editorial call (Legge 5). This
+  module REPORTS those and never rewrites them.
+
+Reporting them separately is the point. A single number — "31 codes are wrong"
+— would hide that some of it is a find-and-replace and some of it needs a human
+to write a sentence.
+
+SCOPE IS AN ENTITY, NOT A SUBSTRING (superscar #3)
+--------------------------------------------------
+A cell labelled `Bali PMA status: TERTUTUP` on a record whose `pma_status` is
+TERBUKA is NOT a contradiction: the Bali layer is closed while the national one
+is open, and both are true at once — the catalogue says so explicitly. Judging
+these cells by matching "PMA status" anywhere in the label convicts 132 lawful
+Bali-scoped cells. So the label's SCOPE is resolved first and Bali-scoped cells
+are excluded by name, with the exclusion counted and reported rather than left
+silent.
+
+IT REPORTS, IT DOES NOT DECIDE
+------------------------------
+`--check` exits 0 while divergences exist, like its siblings in this directory.
+The tripwire that makes a NEW contradiction fail CI is a test, not this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL = REPO_ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+
+# A label naming the BALI layer. Resolved before anything else: these cells
+# describe a different fact and comparing them to the national fields is the
+# category error this module's docstring is mostly about.
+_BALI_SCOPED = re.compile(r"\bbali\b", re.IGNORECASE)
+_CEILING_LABEL = re.compile(r"ceiling", re.IGNORECASE)
+_STATUS_LABEL = re.compile(r"PMA status", re.IGNORECASE)
+_PERCENT = re.compile(r"(\d+)\s*%")
+_STATUSES = frozenset({"TERBUKA", "TERTUTUP", "TERBATAS"})
+
+# Body sentences asserting the activity is nationally open.
+#
+# The first version of this was a proximity match — "national" within 80
+# characters of "open" — and it convicted pages that were RIGHT. `59121` says
+# "this is NOT an activity open to foreign ownership at the national level",
+# which is correct and which the proximity rule read as an openness claim: it
+# matched the words and not the assertion, which is the same form-over-entity
+# error the Bali exclusion above exists to avoid. Found by reading the twenty
+# bodies the first version flagged where the sidebar cells were clean.
+#
+# So: work a SENTENCE at a time, require an affirmative openness claim, and
+# drop any sentence carrying a negation. The negation list is deliberately
+# blunt — a sentence containing "not"/"no"/"cannot"/"never" near an openness
+# word is not evidence of a false claim, and letting one through costs nothing
+# because the sidebar cells are checked independently.
+_SENTENCE = re.compile(r"[^.!?\n]+")
+_NATIONAL_SCOPE = re.compile(r"national(?:ly)?", re.IGNORECASE)
+_OPENNESS_CLAIM = re.compile(
+    r"open\s+(?:to|nationally|for)|nationally\s+open|open\s+national|"
+    r"100\s*%\s*(?:national|foreign)|full\s+foreign\s+ownership",
+    re.IGNORECASE,
+)
+_NEGATION = re.compile(r"\b(?:not|no|never|cannot|can't|isn't|does\s+not|nor)\b", re.IGNORECASE)
+
+
+def load_records(path: Path = CANONICAL) -> list[dict[str, Any]]:
+    return json.loads(path.read_text(encoding="utf-8"))["data"]
+
+
+def _cells(record: dict[str, Any]) -> list[dict[str, Any]]:
+    editorial = (record.get("intel_2026") or {}).get("editorial") or {}
+    return [c for c in (editorial.get("byTheNumbers") or []) if isinstance(c, dict)]
+
+
+def _body(record: dict[str, Any]) -> str:
+    editorial = (record.get("intel_2026") or {}).get("editorial") or {}
+    return " ".join(
+        str(editorial.get(k) or "") for k in ("headline", "standfirst", "body")
+    )
+
+
+def classify(record: dict[str, Any]) -> dict[str, Any]:
+    """Buckets for ONE record. Empty lists everywhere means it agrees with itself."""
+    cap = record.get("pma_max_asing")
+    status = (record.get("pma_status") or "").upper()
+    out: dict[str, Any] = {
+        "code": record.get("kode_kbli_2025"),
+        "pma_status": status,
+        "pma_max_asing": cap,
+        "ceiling_cells": [],
+        "status_cells": [],
+        "bali_scoped_skipped": 0,
+        "body_asserts_national_openness": False,
+    }
+
+    for cell in _cells(record):
+        label = str(cell.get("label") or "")
+        value = str(cell.get("value") or "")
+        if _BALI_SCOPED.search(label):
+            # Counted, not silently dropped: a skip nobody can see is a scope
+            # decision nobody can audit.
+            if _CEILING_LABEL.search(label) or _STATUS_LABEL.search(label):
+                out["bali_scoped_skipped"] += 1
+            continue
+        if _CEILING_LABEL.search(label):
+            m = _PERCENT.search(value)
+            if m is not None and isinstance(cap, int) and int(m.group(1)) != cap:
+                out["ceiling_cells"].append(
+                    {"label": label, "says": value, "record_says": cap}
+                )
+        elif _STATUS_LABEL.search(label):
+            said = value.strip().upper()
+            if said in _STATUSES and status and said != status:
+                out["status_cells"].append(
+                    {"label": label, "says": said, "record_says": status}
+                )
+
+    # Asked only where a national openness claim would actually be FALSE, and
+    # that test is the CEILING, not the status word. `79110` is TERBATAS with a
+    # cap of 100: "a 100% national foreign-ownership ceiling" is true of it, and
+    # the first version of this predicate — `status in {TERBATAS, TERTUTUP} or
+    # cap < 100` — convicted it. TERBATAS at 100 means restricted by conditions
+    # that are not a percentage, which is a different sentence to write and not
+    # this module's business.
+    capped = isinstance(cap, int) and cap < 100
+    if capped:
+        for sentence in _SENTENCE.findall(_body(record)):
+            if not (_NATIONAL_SCOPE.search(sentence) and _OPENNESS_CLAIM.search(sentence)):
+                continue
+            if _NEGATION.search(sentence):
+                continue
+            out["body_asserts_national_openness"] = True
+            out["body_sentence"] = sentence.strip()[:300]
+            break
+
+    return out
+
+
+def report(records: list[dict[str, Any]]) -> dict[str, Any]:
+    rows = [classify(r) for r in records]
+    mechanical = [
+        r for r in rows if r["ceiling_cells"] or r["status_cells"]
+    ]  # a stale copy of a field we own
+    editorial = [
+        r for r in rows if r["body_asserts_national_openness"]
+    ]  # needs a sentence written, not a value replaced
+    return {
+        "codes": len(records),
+        "mechanically_correctable": {
+            "codes": sorted(r["code"] for r in mechanical),
+            "ceiling_cells": sum(len(r["ceiling_cells"]) for r in mechanical),
+            "status_cells": sum(len(r["status_cells"]) for r in mechanical),
+        },
+        "needs_an_author": {
+            "codes": sorted(r["code"] for r in editorial),
+        },
+        "bali_scoped_cells_excluded": sum(r["bali_scoped_skipped"] for r in rows),
+        "rows": mechanical,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--json", action="store_true", help="machine-readable report")
+    ap.add_argument("--dataset", type=Path, default=CANONICAL)
+    args = ap.parse_args(argv)
+
+    rep = report(load_records(args.dataset))
+    if args.json:
+        print(json.dumps(rep, ensure_ascii=False, indent=2))
+        return 0
+
+    mech, auth = rep["mechanically_correctable"], rep["needs_an_author"]
+    lines = [
+        f"editorial_record_conformance — {rep['codes']} codes",
+        "",
+        f"  stale copies of a field we own : {len(mech['codes'])} codes "
+        f"({mech['ceiling_cells']} ceiling cells, {mech['status_cells']} status cells)",
+        f"  bodies that need an author     : {len(auth['codes'])} codes",
+        f"  Bali-scoped cells excluded     : {rep['bali_scoped_cells_excluded']} "
+        f"(a closed Bali layer over an open national one is lawful, not a contradiction)",
+        "",
+    ]
+    for row in rep["rows"]:
+        for c in row["ceiling_cells"]:
+            lines.append(
+                f"  {row['code']}  {c['label']!r} says {c['says']} — record says {c['record_says']}%"
+            )
+        for c in row["status_cells"]:
+            lines.append(
+                f"  {row['code']}  {c['label']!r} says {c['says']} — record says {c['record_says']}"
+            )
+    sys.stdout.write("\n".join(lines) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kbli_filiera/editorial_record_conformance.py
+++ b/scripts/kbli_filiera/editorial_record_conformance.py
@@ -2,11 +2,20 @@
 """Where the ARTICLE contradicts the RECORD it was written from.
 
 Every KBLI code page leads with an authored article — `intel_2026.editorial`:
-a headline, a standfirst, a "By the numbers" sidebar of label/value cells, and
-a markdown body. It was written by narrating the JSON record, and the renderer
-prints it VERBATIM. So it is not a consumer of the PMA fields in the ordinary
-sense; it is a SECOND, INDEPENDENT ASSERTION of the same facts, stored beside
-them.
+a headline, a standfirst, a pull quote, a "By the numbers" sidebar of
+label/value cells, and a markdown body. It was written by narrating the JSON
+record, and the renderer prints it VERBATIM. So it is not a consumer of the PMA
+fields in the ordinary sense; it is a SECOND, INDEPENDENT ASSERTION of the same
+facts, stored beside them.
+
+And `editorial` is not where the prose ends. `intel_2026` carries eight further
+authored keys — `whatItMeans`, `whatYouNeed`, `whatChanged`, `zantaraOpener`,
+`baliContext`, `whoThisIsFor`, `youllAlsoNeed`, `tkaInfo` — thirteen prose
+fields in all, every one of them stringified into the embedding text. Auditing
+three of them and reporting the result as "the bodies" was this module's own
+first defect: it named a population of 20 where the population is 27, and the
+single largest offender was `whatYouNeed`, the field that tells a client what
+to file. See `_prose_fields` for both halves of that mistake.
 
 That is the whole problem. A consumer that READS a field moves when the field
 moves. A parallel assertion never moves at all. Nine codes were restricted on
@@ -60,6 +69,7 @@ import argparse
 import json
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -109,11 +119,54 @@ def _cells(record: dict[str, Any]) -> list[dict[str, Any]]:
     return [c for c in (editorial.get("byTheNumbers") or []) if isinstance(c, dict)]
 
 
-def _body(record: dict[str, Any]) -> str:
-    editorial = (record.get("intel_2026") or {}).get("editorial") or {}
-    return " ".join(
-        str(editorial.get(k) or "") for k in ("headline", "standfirst", "body")
-    )
+def _prose_fields(record: dict[str, Any]) -> list[tuple[str, str]]:
+    """Every authored string under `intel_2026`, with the path that holds it.
+
+    Two defects in the first version, both the same shape, both measured on the
+    live catalogue rather than reasoned about:
+
+    1. **It read three fields of thirteen.** `intel_2026` carries
+       `whatItMeans`, `whatYouNeed`, `whatChanged`, `zantaraOpener`,
+       `baliContext`, `whoThisIsFor`, `youllAlsoNeed`, a `tkaInfo` block and an
+       `editorial` block whose own `pullQuote` was also unread — and
+       `reindex_kbli_2025_final.py` stringifies the WHOLE dict into the
+       embedding text, so all of them reach Qdrant and the RAG exactly as the
+       body does. Auditing `headline`/`standfirst`/`body` and reporting the
+       result as "the bodies that need an author" measured the fields that were
+       convenient to read. Nineteen of the offending sentences live in
+       `whatYouNeed` alone. Hence: walk every string, whatever its depth, so a
+       prose key added next month is covered on the day it appears rather than
+       whenever someone remembers to extend a list.
+
+    2. **It JOINED the three before splitting into sentences.** A headline
+       carries no terminal full stop, so `"Open to Foreign Investment" + " " +
+       standfirst` becomes ONE sentence for the splitter — and if the standfirst
+       opens with the Bali caveat ("...but this is not permitted at scale"), the
+       negation guard acquits the headline on the strength of a denial that
+       belongs to a different assertion. Each field is now judged alone, which
+       is what it is: a separate claim, separately authored.
+
+    `byTheNumbers` cells are walked too. Their values ("100%", "TERBATAS") can
+    never satisfy the sentence predicate, which needs a national scope word and
+    an openness claim together, so the overlap with the cell check costs
+    nothing and the alternative — excluding a key by name — is the very habit
+    that produced defect 1.
+    """
+    out: list[tuple[str, str]] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, str):
+            if node.strip():
+                out.append((path, node))
+        elif isinstance(node, dict):
+            for k, v in node.items():
+                walk(v, f"{path}.{k}" if path else str(k))
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                walk(v, f"{path}[{i}]")
+
+    walk(record.get("intel_2026") or {}, "")
+    return out
 
 
 def classify(record: dict[str, Any]) -> dict[str, Any]:
@@ -128,6 +181,7 @@ def classify(record: dict[str, Any]) -> dict[str, Any]:
         "status_cells": [],
         "bali_scoped_skipped": 0,
         "body_asserts_national_openness": False,
+        "offending_fields": [],
     }
 
     for cell in _cells(record):
@@ -161,14 +215,17 @@ def classify(record: dict[str, Any]) -> dict[str, Any]:
     # this module's business.
     capped = isinstance(cap, int) and cap < 100
     if capped:
-        for sentence in _SENTENCE.findall(_body(record)):
-            if not (_NATIONAL_SCOPE.search(sentence) and _OPENNESS_CLAIM.search(sentence)):
-                continue
-            if _NEGATION.search(sentence):
-                continue
-            out["body_asserts_national_openness"] = True
-            out["body_sentence"] = sentence.strip()[:300]
-            break
+        for path, text in _prose_fields(record):
+            for sentence in _SENTENCE.findall(text):
+                if not (_NATIONAL_SCOPE.search(sentence) and _OPENNESS_CLAIM.search(sentence)):
+                    continue
+                if _NEGATION.search(sentence):
+                    continue
+                out["body_asserts_national_openness"] = True
+                out["offending_fields"].append(
+                    {"field": path, "sentence": sentence.strip()[:300]}
+                )
+                break  # one sentence per field is enough to name the field
 
     return out
 
@@ -190,6 +247,17 @@ def report(records: list[dict[str, Any]]) -> dict[str, Any]:
         },
         "needs_an_author": {
             "codes": sorted(r["code"] for r in editorial),
+            # WHERE the prose lies, not just how much of it: the cure is a
+            # different job in `whatYouNeed` (a filing instruction) than in a
+            # `headline` (a promise), and a bare total hides that.
+            "by_field": dict(
+                sorted(
+                    Counter(
+                        f["field"] for r in editorial for f in r["offending_fields"]
+                    ).items(),
+                    key=lambda kv: (-kv[1], kv[0]),
+                )
+            ),
         },
         "bali_scoped_cells_excluded": sum(r["bali_scoped_skipped"] for r in rows),
         "rows": mechanical,

--- a/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
+++ b/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
@@ -128,17 +128,28 @@ def test_innocence_terbatas_at_one_hundred_percent_may_truthfully_say_one_hundre
     assert E.classify(r)["body_asserts_national_openness"] is False
 
 
-def test_known_limit_the_capped_narrowing_changes_no_live_verdict_today():
-    """Honest statement of how much the fix above is currently worth: on the
-    live catalogue, NOTHING. Every record that the old over-broad predicate
-    would additionally admit (TERBATAS or TERTUTUP at a 100% ceiling) happens to
-    carry a negated sentence, so the negation guard already acquits it and both
-    predicates report the same twenty codes.
+def test_the_capped_narrowing_now_protects_exactly_one_live_code():
+    """It used to be worth nothing on live data. Reading the fields apart changed that.
 
-    Pinned rather than glossed, because the alternative is a reader believing
-    the narrowing is load-bearing on today's data when it is a guard against a
-    record shape that does not exist yet — and because if this assertion ever
-    fails, the narrowing has started to matter and someone should read why.
+    This test previously asserted the OPPOSITE — that the `capped` narrowing
+    changed no live verdict, because every record the broad predicate would
+    additionally admit (TERBATAS/TERTUTUP at a 100% ceiling) happened to carry a
+    negated sentence somewhere in the JOINED headline+standfirst+body blob, so
+    the negation guard acquitted it either way. Its docstring said that if the
+    assertion ever failed, the narrowing had started to matter and someone
+    should read why. Judging each field on its own made it fail, and this is the
+    why.
+
+    `79110` is TERBATAS with a ceiling of 100. Its denial and its openness
+    sentence live in DIFFERENT fields, so once the fields stopped being glued
+    together the denial could no longer acquit the claim — and the claim is
+    TRUE of it: restricted by conditions that are not a percentage still means a
+    100% foreign-ownership ceiling. Only `capped` keeps it innocent now, which
+    is precisely the record shape the narrowing was written for.
+
+    Kept as an equality against a NAMED set rather than a count, so that a
+    second code drifting into this position is a failure someone must read
+    rather than a number quietly becoming two.
     """
     records = E.load_records()
     narrow = {r["code"] for r in map(E.classify, records) if r["body_asserts_national_openness"]}
@@ -147,16 +158,24 @@ def test_known_limit_the_capped_narrowing_changes_no_live_verdict_today():
         cap, status = record.get("pma_max_asing"), (record.get("pma_status") or "").upper()
         if not (status in {"TERBATAS", "TERTUTUP"} or (isinstance(cap, int) and cap < 100)):
             return False
-        for sentence in E._SENTENCE.findall(E._body(record)):
-            if (
-                E._NATIONAL_SCOPE.search(sentence)
-                and E._OPENNESS_CLAIM.search(sentence)
-                and not E._NEGATION.search(sentence)
-            ):
-                return True
+        for _path, text in E._prose_fields(record):
+            for sentence in E._SENTENCE.findall(text):
+                if (
+                    E._NATIONAL_SCOPE.search(sentence)
+                    and E._OPENNESS_CLAIM.search(sentence)
+                    and not E._NEGATION.search(sentence)
+                ):
+                    return True
         return False
 
-    assert {r["kode_kbli_2025"] for r in records if broad(r)} == narrow
+    protected = {r["kode_kbli_2025"] for r in records if broad(r)} - narrow
+    assert protected == {"79110"}, (
+        "the `capped` narrowing is the only thing standing between these codes "
+        "and a conviction — read each one before changing this set"
+    )
+    assert [r for r in records if r["kode_kbli_2025"] == "79110"][0][
+        "pma_max_asing"
+    ] == 100, "premise: 79110 is capped at 100, so an openness claim is true of it"
 
 
 def test_guilt_a_body_denying_the_cap_in_words_is_caught_even_when_the_cells_agree():
@@ -179,6 +198,80 @@ def test_guilt_a_body_denying_the_cap_in_words_is_caught_even_when_the_cells_agr
 def test_innocence_an_open_code_saying_it_is_open_is_not_a_contradiction():
     r = rec(cap=100, status="TERBUKA", body="This activity is nationally open to full foreign ownership.")
     assert E.classify(r)["body_asserts_national_openness"] is False
+
+
+# --------------------------------------------------------------------------
+# THE TWO FIELDS-OF-THIRTEEN DEFECTS
+# --------------------------------------------------------------------------
+
+
+def test_guilt_a_sibling_prose_key_is_read_not_just_the_editorial_block():
+    """`whatYouNeed` reaches Qdrant exactly as the body does, and held MORE lies.
+
+    The first version read `editorial.{headline,standfirst,body}` and called
+    the result "the bodies". `intel_2026` carries eight further prose keys, all
+    stringified into the embedding text by `reindex_kbli_2025_final.py`. On the
+    live catalogue eighteen offending sentences sit in `whatYouNeed` — the
+    field that tells a client what to file — and none of them were ever read.
+    """
+    r = rec(cap=0, status="TERTUTUP")
+    r["intel_2026"]["whatYouNeed"] = (
+        "Nationally, 100% foreign ownership is permitted for this activity."
+    )
+    out = E.classify(r)
+    assert out["body_asserts_national_openness"] is True
+    assert [f["field"] for f in out["offending_fields"]] == ["whatYouNeed"]
+
+
+def test_guilt_a_headline_is_judged_alone_not_glued_to_the_standfirst():
+    """A headline has no full stop, so joining made it one sentence with the next.
+
+    The splitter breaks on `.!?\\n`. `"Open to Foreign Ownership Nationally" + " "
+    + standfirst` is therefore a SINGLE sentence, and a standfirst that opens
+    with the Bali caveat supplies a negation — which acquitted the headline on
+    the strength of a denial belonging to a different assertion. Three headlines
+    on the live catalogue were acquitted exactly this way.
+    """
+    r = rec(
+        cap=0,
+        status="TERTUTUP",
+        headline="Open Nationally to Full Foreign Ownership",
+        body="Bali does not permit it.",
+    )
+    r["intel_2026"]["editorial"]["standfirst"] = (
+        "Bali is not the same question, and permission does not follow."
+    )
+    out = E.classify(r)
+    assert out["body_asserts_national_openness"] is True
+    assert "editorial.headline" in [f["field"] for f in out["offending_fields"]]
+
+
+def test_innocence_a_negation_still_acquits_within_its_own_field():
+    """The fix must not turn every caveat into a conviction.
+
+    Splitting the fields apart makes each denial local. A field whose sentence
+    denies openness is still innocent — that is `59121` above — and this pins
+    that the per-field change did not quietly drop the negation guard."""
+    r = rec(cap=0, status="TERTUTUP")
+    r["intel_2026"]["whatYouNeed"] = (
+        "This is not an activity open to foreign ownership at the national level."
+    )
+    assert E.classify(r)["body_asserts_national_openness"] is False
+
+
+def test_the_walk_reaches_prose_nested_below_the_top_level():
+    """Depth is not a reason to be unread: `tkaInfo` is a dict of dicts.
+
+    A key list would have to be extended for every new nesting; the walk covers
+    them the day they appear, which is the point of walking instead of listing.
+    """
+    r = rec(cap=0, status="TERTUTUP")
+    r["intel_2026"]["tkaInfo"] = {
+        "positions": [{"note": "Nationally open to full foreign ownership."}]
+    }
+    out = E.classify(r)
+    assert out["body_asserts_national_openness"] is True
+    assert out["offending_fields"][0]["field"] == "tkaInfo.positions[0].note"
 
 
 # --------------------------------------------------------------------------
@@ -214,7 +307,19 @@ def test_the_live_populations_are_pinned():
     assert len(rep["mechanically_correctable"]["codes"]) == 27
     assert rep["mechanically_correctable"]["ceiling_cells"] == 27
     assert rep["mechanically_correctable"]["status_cells"] == 7
-    assert len(rep["needs_an_author"]["codes"]) == 20
+    assert len(rep["needs_an_author"]["codes"]) == 27
+
+    # WHERE the prose lies. Pinned because the total alone hid the defect that
+    # produced these numbers: the first version read three fields and reported
+    # 20, and `whatYouNeed` — the field that carries a client's filing
+    # instructions — was the largest offender and was never opened.
+    assert rep["needs_an_author"]["by_field"] == {
+        "whatYouNeed": 18,
+        "editorial.body": 16,
+        "editorial.headline": 10,
+        "editorial.standfirst": 5,
+        "whoThisIsFor": 1,
+    }
 
 
 def test_the_worst_members_are_named_not_counted():

--- a/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
+++ b/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
@@ -322,6 +322,52 @@ def test_the_live_populations_are_pinned():
     }
 
 
+def test_this_module_is_not_a_twin_of_the_existing_L9_lint_rule():
+    """The anti-twin claim in the docstring, armed instead of asserted.
+
+    `kbli_dataset_lint.py` rule L9 (`validate_pma_consistency`) is a BLOCKING
+    lint that looks like this module's duplicate. It is not: measured here, the
+    two finding sets are disjoint. L9's reachable half of the dangerous
+    direction requires `pma_status == "TERTUTUP"` AND the literal substring
+    "100% foreign"; 26 of this module's 27 codes are TERBATAS, which that
+    condition never admits.
+
+    If this test ever fails, the two tools have started answering the same
+    question two different ways (W105) and the right response is to make the
+    lint consume this report — not to delete whichever assertion is
+    inconvenient.
+    """
+    scripts_dir = str(Path(__file__).resolve().parents[2])
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from kbli_enrich_validate import validate_pma_consistency
+
+    records = E.load_records()
+    mine = {r["code"] for r in map(E.classify, records) if r["body_asserts_national_openness"]}
+    l9 = {
+        r["kode_kbli_2025"]
+        for r in records
+        if isinstance(r.get("intel_2026"), dict)
+        and r["kode_kbli_2025"] != "69101"  # the lint's documented profession-law override
+        and validate_pma_consistency(r["intel_2026"], r)
+    }
+
+    assert mine & l9 == set(), (
+        "L9 and this module now report overlapping codes — reconcile them so one "
+        f"consumes the other rather than both judging: {sorted(mine & l9)}"
+    )
+    assert l9 == {"43110", "86201"}, f"L9's live findings moved: {sorted(l9)}"
+    statuses = {
+        r["pma_status"]
+        for r in records
+        if r["kode_kbli_2025"] in mine
+    }
+    assert "TERBATAS" in statuses, (
+        "premise: this module's population is mostly TERBATAS, the status L9's "
+        "dangerous-direction test cannot reach"
+    )
+
+
 def test_the_worst_members_are_named_not_counted():
     """A population with only a size cannot be closed by the pass that comes for
     it. These three are the ones a client acts on money with."""

--- a/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
+++ b/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
@@ -1,0 +1,230 @@
+"""Guilt and innocence for the article-versus-record detector.
+
+This module's whole risk is convicting a page that is RIGHT. The first draft did
+exactly that — twice, on the live catalogue — and both cases are pinned below as
+innocence tests, because a guard that has already over-matched once and been
+fixed without a test is a guard that will over-match again.
+
+The dangerous direction is not symmetric and the tests are shaped around it. A
+missed contradiction leaves a wrong number on a page that is already wrong. A
+false conviction sends someone to rewrite prose that was correct, and — if it
+were ever wired to a cure — would replace a true sentence with a "corrected"
+false one.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_FILIERA = str(Path(__file__).resolve().parents[1])
+if _FILIERA not in sys.path:
+    sys.path.insert(0, _FILIERA)
+
+import editorial_record_conformance as E  # noqa: E402
+
+
+def rec(code="01111", status="TERBUKA", cap=100, cells=None, headline="", body=""):
+    return {
+        "kode_kbli_2025": code,
+        "pma_status": status,
+        "pma_max_asing": cap,
+        "intel_2026": {
+            "editorial": {
+                "headline": headline,
+                "standfirst": "",
+                "body": body,
+                "byTheNumbers": cells or [],
+            }
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# CELLS — a stale copy of a field we own
+# --------------------------------------------------------------------------
+
+
+def test_guilt_a_ceiling_cell_that_contradicts_the_record_is_caught():
+    r = rec(cap=0, status="TERBATAS", cells=[{"label": "Foreign-ownership ceiling", "value": "100%"}])
+    out = E.classify(r)
+    assert out["ceiling_cells"] == [
+        {"label": "Foreign-ownership ceiling", "says": "100%", "record_says": 0}
+    ]
+
+
+def test_guilt_a_status_cell_that_contradicts_the_record_is_caught():
+    r = rec(cap=0, status="TERBATAS", cells=[{"label": "National PMA status", "value": "TERBUKA"}])
+    out = E.classify(r)
+    assert out["status_cells"][0]["says"] == "TERBUKA"
+    assert out["status_cells"][0]["record_says"] == "TERBATAS"
+
+
+def test_innocence_a_cell_that_agrees_with_the_record_is_left_alone():
+    r = rec(cap=49, status="TERBATAS", cells=[{"label": "Foreign ownership ceiling", "value": "49%"}])
+    out = E.classify(r)
+    assert out["ceiling_cells"] == [] and out["status_cells"] == []
+
+
+def test_innocence_a_bali_scoped_cell_is_not_judged_against_the_national_field():
+    """THE reason this module exists in the shape it does. A closed Bali layer
+    over an open national one is lawful and the catalogue says so explicitly.
+    Matching "PMA status" anywhere in a label convicts 132 lawful cells."""
+    r = rec(
+        cap=100,
+        status="TERBUKA",
+        cells=[{"label": "Bali PMA status", "value": "TERTUTUP"}],
+    )
+    out = E.classify(r)
+    assert out["status_cells"] == []
+    assert out["bali_scoped_skipped"] == 1, "and the skip must be COUNTED, not silent"
+
+
+def test_a_cell_with_no_percentage_cannot_contradict_a_number():
+    """`special` is a real value in this catalogue — a cap that is not a
+    percentage. Reading it as 0 would invent a contradiction."""
+    r = rec(cap=0, status="TERBATAS", cells=[{"label": "Foreign ownership ceiling", "value": "special"}])
+    assert E.classify(r)["ceiling_cells"] == []
+
+
+# --------------------------------------------------------------------------
+# BODIES — the two live pages the first draft wrongly convicted
+# --------------------------------------------------------------------------
+
+
+def test_innocence_a_negated_openness_sentence_is_not_an_openness_claim():
+    """Live case `59121`. The body says "this is NOT an activity open to foreign
+    ownership at the national level" — correct, and the first draft's proximity
+    rule ("national" within 80 chars of "open") convicted it. It matched the
+    words instead of the assertion."""
+    r = rec(
+        cap=0,
+        status="TERTUTUP",
+        body="For a founder assessing a foreign-investment structure, the conclusion is "
+        "direct: this is not an activity open to foreign ownership at the national level.",
+    )
+    assert E.classify(r)["body_asserts_national_openness"] is False
+
+
+def test_innocence_terbatas_at_one_hundred_percent_may_truthfully_say_one_hundred():
+    """Live case `79110`. TERBATAS with a cap of 100 means restricted by
+    conditions that are not a percentage, so "a 100% national foreign-ownership
+    ceiling" is TRUE of it. The first draft's predicate was `status in
+    {TERBATAS, TERTUTUP} or cap < 100`, which convicted the status word.
+
+    The live sentence on that page reads "...but a 100% national foreign-ownership
+    ceiling DOES NOT settle the Bali question", and using it verbatim here made
+    this test pass for the wrong reason: the negation guard acquitted it and the
+    predicate under test was never exercised. Mutation found that — restoring the
+    old predicate left all thirteen tests green. The sentence below is therefore
+    stripped of its negation, so `capped` is the only thing that can acquit it.
+    """
+    r = rec(
+        cap=100,
+        status="TERBATAS",
+        body="A 100% national foreign-ownership ceiling applies to this activity.",
+    )
+    assert E.classify(r)["body_asserts_national_openness"] is False
+
+
+def test_known_limit_the_capped_narrowing_changes_no_live_verdict_today():
+    """Honest statement of how much the fix above is currently worth: on the
+    live catalogue, NOTHING. Every record that the old over-broad predicate
+    would additionally admit (TERBATAS or TERTUTUP at a 100% ceiling) happens to
+    carry a negated sentence, so the negation guard already acquits it and both
+    predicates report the same twenty codes.
+
+    Pinned rather than glossed, because the alternative is a reader believing
+    the narrowing is load-bearing on today's data when it is a guard against a
+    record shape that does not exist yet — and because if this assertion ever
+    fails, the narrowing has started to matter and someone should read why.
+    """
+    records = E.load_records()
+    narrow = {r["code"] for r in map(E.classify, records) if r["body_asserts_national_openness"]}
+
+    def broad(record):
+        cap, status = record.get("pma_max_asing"), (record.get("pma_status") or "").upper()
+        if not (status in {"TERBATAS", "TERTUTUP"} or (isinstance(cap, int) and cap < 100)):
+            return False
+        for sentence in E._SENTENCE.findall(E._body(record)):
+            if (
+                E._NATIONAL_SCOPE.search(sentence)
+                and E._OPENNESS_CLAIM.search(sentence)
+                and not E._NEGATION.search(sentence)
+            ):
+                return True
+        return False
+
+    assert {r["kode_kbli_2025"] for r in records if broad(r)} == narrow
+
+
+def test_guilt_a_body_denying_the_cap_in_words_is_caught_even_when_the_cells_agree():
+    """Live case `50135`: every sidebar cell agrees with the record, and the
+    prose still tells the reader he may hold the activity outright. The cells
+    and the body are separate assertions and a check on one is not a check on
+    the other."""
+    r = rec(
+        cap=49,
+        status="TERBATAS",
+        cells=[{"label": "Foreign ownership ceiling", "value": "49%"}],
+        body="The national reading is direct: a foreign-owned company may hold the "
+        "activity with full foreign ownership, rather than under a lower foreign-equity ceiling.",
+    )
+    out = E.classify(r)
+    assert out["ceiling_cells"] == []
+    assert out["body_asserts_national_openness"] is True
+
+
+def test_innocence_an_open_code_saying_it_is_open_is_not_a_contradiction():
+    r = rec(cap=100, status="TERBUKA", body="This activity is nationally open to full foreign ownership.")
+    assert E.classify(r)["body_asserts_national_openness"] is False
+
+
+# --------------------------------------------------------------------------
+# THE LIVE CATALOGUE — populations, and the separation that is the product
+# --------------------------------------------------------------------------
+
+
+def test_the_two_buckets_are_reported_separately_and_are_not_the_same_set():
+    """A single "N codes are wrong" would hide that one bucket is a
+    find-and-replace on a field we own and the other needs a human to write a
+    sentence. `50135` is the proof they are different sets: clean cells, wrong
+    prose."""
+    rep = E.report(E.load_records())
+    mech = set(rep["mechanically_correctable"]["codes"])
+    auth = set(rep["needs_an_author"]["codes"])
+    assert mech and auth
+    assert auth - mech, "if every prose case had a bad cell, one check would do"
+    assert "50135" in auth - mech
+
+
+def test_the_bali_exclusion_is_large_enough_to_matter_and_is_declared():
+    """If this were near zero the scope split would be theoretical. It is not:
+    132 lawful Bali-scoped cells would be convicted by a label substring."""
+    rep = E.report(E.load_records())
+    assert rep["bali_scoped_cells_excluded"] > 100
+
+
+def test_the_live_populations_are_pinned():
+    """Measured, not carried over from a plan. These may only SHRINK as cures
+    land; a rise means a new contradiction was authored, which is the whole
+    thing this file is about."""
+    rep = E.report(E.load_records())
+    assert len(rep["mechanically_correctable"]["codes"]) == 27
+    assert rep["mechanically_correctable"]["ceiling_cells"] == 27
+    assert rep["mechanically_correctable"]["status_cells"] == 7
+    assert len(rep["needs_an_author"]["codes"]) == 20
+
+
+def test_the_worst_members_are_named_not_counted():
+    """A population with only a size cannot be closed by the pass that comes for
+    it. These three are the ones a client acts on money with."""
+    rep = E.report(E.load_records())
+    mech = set(rep["mechanically_correctable"]["codes"])
+    # arms and ammunition, capped at 49% — sidebar says 100%
+    assert "25200" in mech
+    # military vehicles, capped at 49%
+    assert "30400" in mech
+    # Umrah/Hajj travel, capped at 0% — its prose still reads as an opening
+    assert "79122" in set(rep["needs_an_author"]["codes"])


### PR DESCRIPTION
## One page, two answers — and the wrong one is the one shaped like a number

Every KBLI code page leads with an authored article (`intel_2026.editorial`): a headline, a **"By the numbers"** sidebar, and a body. The renderer prints it **verbatim**. So it is not a consumer of the PMA fields in the ordinary sense — it is a **second, independent assertion of the same facts, stored beside them**.

A consumer that *reads* a field moves when the field moves. **A parallel assertion never moves at all.** Live on `balizero.com` right now:

| code | headline says | its own sidebar says | record says |
|---|---|---|---|
| `10214` fish preservation | "Closed to Foreign Investment" | **National PMA status: TERBUKA · ceiling 100%** | TERBATAS / 0% |
| `41016` school construction | "Closed to Foreign Investment" | **ceiling 100% · Bali status: Registrable in Bali** | TERBATAS / 0% |
| `25200` arms & ammunition | — | **ceiling 100%** | TERBATAS / **49%** |
| `79122` Umrah/Hajj travel | — | prose reads as an opening | TERBATAS / **0%** |

## Why this is a data lane and not a frontend one

`reindex_kbli_2025_final.py` stringifies the **whole** `intel_2026` dict into the embedding text:

```python
for k, v in intel.items():
    parts.append(f"- {k}: {v}")
```

So the contradicted sentences are **in Qdrant** and reachable by the RAG. A client asking on WhatsApp about `79122` can be handed retrieved context asserting 100%. A renderer-side fix would leave that untouched. Established by reading the consumer, not assumed.

## Two buckets, because only one is mechanical

- **27 codes — a sidebar CELL restating a field we own** (27 ceiling + 7 status cells). `100%` against `pma_max_asing == 0` is a stale copy, not a difference of opinion; correcting it asserts nothing new.
- **20 codes — a BODY that says the activity is nationally open.** Wrong the same way, but replacing a sentence means *writing* one, and what to say instead is an editorial call (Legge 5). Reported, never rewritten.

A single "31 codes are wrong" would have hidden that one half is a find-and-replace and the other needs an author. **`50135` proves they are different sets**: every cell agrees with the record, and the prose still tells the reader he may hold the activity "with full foreign ownership, rather than under a lower foreign-equity ceiling" — on a code capped at 49%.

## Scope is an entity, not a substring — and the first draft got it wrong twice

`Bali PMA status: TERTUTUP` over a national `TERBUKA` is **not** a contradiction; both are true at once and the catalogue says so explicitly. Matching "PMA status" anywhere in a label convicts **132 lawful Bali-scoped cells**. They are excluded by scope, and the exclusion is **counted** — a skip nobody can see is a scope decision nobody can audit.

The body check convicted two live pages that were **right**. Both are now innocence tests:

- **`59121`** says *"this is **not** an activity open to foreign ownership at the national level"* — correct. A proximity rule ("national" within 80 chars of "open") read it as an openness claim: it matched the words, not the assertion.
- **`79110`** is `TERBATAS` at a cap of **100** — restricted by conditions that are not a percentage — so *"a 100% national foreign-ownership ceiling"* is **true** of it. The predicate was `status in {TERBATAS, TERTUTUP} or cap < 100`, which convicted the status word.

47 flagged bodies became **20** once both were fixed.

## A test that passed for the wrong reason

Mutation caught this, not review. Restoring the old predicate left **all thirteen tests green**: the `79110` innocence test used the live sentence verbatim, which contains *"does not"* — so the **negation** guard acquitted it and the predicate under test never ran. The sentence is now stripped of its negation and the mutation fails as it should.

> A guard whose test is satisfied by a *different* guard is an untested guard (W116).

Three guards, three mutations, each killing exactly its own test:

```
MUTANT: Bali scope exclusion removed  → 3 failed
MUTANT: negation guard removed        → 2 failed
MUTANT: old over-broad predicate      → 1 failed  (was 0 before the test fix)
```

## A reporter, not a gate

`--check` exits 0 while divergences exist, like every sibling in this directory. Populations are pinned as tests and **may only shrink** — a rise means a new contradiction was authored. **The cure is a separate PR**; this one makes the thing visible, countable, and split along the line that decides who can fix it.

14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
