### PR TITLE
fix(kbli): 38 stat cards printed a ceiling their own record denies, on 31 pages

### DIFF
--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
-  "lastModified": "2026-08-05",
-  "datasetSha256": "sha256:66df104726dd658261420df3ff7065c1a6b2c3120d953a18adb1fbe1cf7cc9ee",
+  "lastModified": "2026-08-06",
+  "datasetSha256": "sha256:551823ac49cfc150082b4755dbbb3ed55be1509de24a37a7c0e8b38d0593bcc6",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "017287dbe8837b559b995969095e7e0e1ee72060",
-  "canonical_sha256": "66df104726dd658261420df3ff7065c1a6b2c3120d953a18adb1fbe1cf7cc9ee",
+  "canonical_revision": "570f6fd5de2c6d9e16c290992087fa6ab80d966d",
+  "canonical_sha256": "551823ac49cfc150082b4755dbbb3ed55be1509de24a37a7c0e8b38d0593bcc6",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/scripts/kbli_filiera/cure_editorial_cells_from_record.py
+++ b/scripts/kbli_filiera/cure_editorial_cells_from_record.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""cure_editorial_cells_from_record.py — make the stat card agree with the record.
+
+WHAT IT FIXES, AND WHY THAT IS NOT AN EDITORIAL ACT
+---------------------------------------------------
+`intel_2026.editorial.byTheNumbers` is a list of label/value stat cards that
+live IN THE DATA and are rendered verbatim. A cell reading
+`Foreign-ownership ceiling · 100%` on a record whose `pma_max_asing` is 0 is not
+a difference of opinion and not a sentence anybody chose: it is a stale COPY of
+a field we own, left behind when the field moved. Restoring the copy asserts
+nothing new, which is what makes this mechanical and what separates it from
+`cure_national_ceiling_framing.py`, whose replacements had to be written by
+someone and refuted by a cross-family seat before they could land.
+
+Measured before writing this: all 27 affected records carry
+`pma_cap_verified: true` and an integer cap. So the number being copied is one
+the organism has already stood behind — the cure does not launder an unverified
+value into a place it looks authoritative.
+
+IT DOES NOT DECIDE WHICH CELLS ARE WRONG
+----------------------------------------
+The predicate lives in `editorial_record_conformance.py` and this module
+CONSUMES its verdict rather than re-deriving it. Two tools that must agree about
+the same fact do not get to invent two answers (W105) — and the predicate is
+subtle in exactly the way that bites: a cell labelled `Bali PMA status` is
+lawfully TERTUTUP over an open national record, and re-implementing "is this
+cell wrong" here would eventually drift into rewriting 132 correct cells.
+
+THE PROSE IS NOT TOUCHED, AND THAT IS ASSERTED, NOT PROMISED
+-------------------------------------------------------------
+27 further codes carry prose that contradicts the record. Replacing a sentence
+means writing one (Legge 5), so this module leaves every string alone — and
+proves it did, by re-running the detector on the patched document IN MEMORY and
+requiring that the `needs_an_author` set comes out byte-identical. A cure that
+silently improved a body would be authoring under cover of a mechanical pass.
+
+FAIL-CLOSED, AND PROVEN BEFORE IT WRITES
+-----------------------------------------
+Nothing is written unless the patched document reports ZERO stale cells. A cure
+that half-works is worse than one that refuses: it leaves a page consistent
+enough to be believed and wrong where it counts. Any cell whose value cannot be
+rewritten unambiguously — a ceiling holding two percentages, a status cell whose
+text is not the stale status verbatim — is REFUSED and named, never guessed at.
+
+USAGE (dry-run is the default; nothing is written without --apply):
+
+    python3 scripts/kbli_filiera/cure_editorial_cells_from_record.py
+    python3 scripts/kbli_filiera/cure_editorial_cells_from_record.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+_FILIERA = str(Path(__file__).resolve().parent)
+if _FILIERA not in sys.path:
+    sys.path.insert(0, _FILIERA)
+
+import editorial_record_conformance as E  # noqa: E402
+
+from scripts.kbli_filiera.cure_l4_withdrawn_umkm_prose import (  # noqa: E402
+    reconcile_sidecar,
+    run_sync_script,
+)
+
+CANONICAL = REPO_ROOT / "data" / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
+
+logger = logging.getLogger("cure_editorial_cells")
+
+_PERCENT = re.compile(r"(\d+)\s*%")
+
+
+def _cells_of(record: dict[str, Any]) -> list[dict[str, Any]]:
+    editorial = (record.get("intel_2026") or {}).get("editorial") or {}
+    return [c for c in (editorial.get("byTheNumbers") or []) if isinstance(c, dict)]
+
+
+def plan_for(record: dict[str, Any], verdict: dict[str, Any]) -> tuple[list[dict], list[str]]:
+    """What to rewrite on ONE record, and what this refuses to touch.
+
+    `verdict` is `editorial_record_conformance.classify(record)` — the flagged
+    cells are identified by their label, which is the only stable handle a cell
+    has (the list has no ids and its order is not a contract).
+    """
+    edits: list[dict[str, Any]] = []
+    refusals: list[str] = []
+    code = record.get("kode_kbli_2025")
+    cap = record.get("pma_max_asing")
+    status = (record.get("pma_status") or "").upper()
+
+    stale_ceiling = {c["label"] for c in verdict["ceiling_cells"]}
+    stale_status = {c["label"]: c["says"] for c in verdict["status_cells"]}
+
+    for cell in _cells_of(record):
+        label = str(cell.get("label") or "")
+        value = str(cell.get("value") or "")
+
+        if label in stale_ceiling:
+            if not isinstance(cap, int):
+                refusals.append(f"{code}: {label!r} — record cap is {cap!r}, not a number")
+                continue
+            if len(_PERCENT.findall(value)) != 1:
+                refusals.append(
+                    f"{code}: {label!r} — value {value!r} holds "
+                    f"{len(_PERCENT.findall(value))} percentages, cannot rewrite one"
+                )
+                continue
+            edits.append(
+                {
+                    "code": code,
+                    "label": label,
+                    "cell": cell,
+                    "was": value,
+                    "now": _PERCENT.sub(f"{cap}%", value, count=1),
+                }
+            )
+        elif label in stale_status:
+            if value.strip().upper() != stale_status[label]:
+                refusals.append(
+                    f"{code}: {label!r} — value {value!r} is not the stale status "
+                    f"{stale_status[label]!r} verbatim"
+                )
+                continue
+            edits.append(
+                {"code": code, "label": label, "cell": cell, "was": value, "now": status}
+            )
+
+    return edits, refusals
+
+
+def run(canonical_path: Path, apply: bool) -> int:
+    doc = json.loads(canonical_path.read_text(encoding="utf-8"))
+    records = doc["data"]
+
+    before = E.report(records)
+    authored_before = list(before["needs_an_author"]["codes"])
+    logger.info(
+        "before: %d code(s) with stale cells (%d ceiling, %d status), %d needing an author",
+        len(before["mechanically_correctable"]["codes"]),
+        before["mechanically_correctable"]["ceiling_cells"],
+        before["mechanically_correctable"]["status_cells"],
+        len(authored_before),
+    )
+
+    patched = copy.deepcopy(records)
+    all_edits: list[dict[str, Any]] = []
+    all_refusals: list[str] = []
+    for record in patched:
+        verdict = E.classify(record)
+        if not (verdict["ceiling_cells"] or verdict["status_cells"]):
+            continue
+        edits, refusals = plan_for(record, verdict)
+        all_edits.extend(edits)
+        all_refusals.extend(refusals)
+
+    for edit in all_edits:
+        edit["cell"]["value"] = edit["now"]
+
+    for edit in all_edits:
+        logger.info("  %s  %-34s %s -> %s", edit["code"], edit["label"], edit["was"], edit["now"])
+    for refusal in all_refusals:
+        logger.warning("  REFUSED %s", refusal)
+
+    after = E.report(patched)
+    remaining = len(after["mechanically_correctable"]["codes"])
+    authored_after = list(after["needs_an_author"]["codes"])
+
+    logger.info(
+        "%s: %d cell(s) on %d code(s); %d refused; stale cells after: %d",
+        "APPLY" if apply else "DRY-RUN",
+        len(all_edits),
+        len({e["code"] for e in all_edits}),
+        len(all_refusals),
+        remaining,
+    )
+
+    # The two conditions that make this safe to write, checked on the PATCHED
+    # document rather than hoped for. Both are refusals, not warnings.
+    if remaining:
+        logger.error(
+            "refusing to write: %d code(s) still hold a stale cell — a half-cure "
+            "leaves a page consistent enough to be believed and wrong where it counts",
+            remaining,
+        )
+        return 1
+    if authored_after != authored_before:
+        logger.error(
+            "refusing to write: the set of codes needing an author changed "
+            "(%d -> %d) — this pass must not touch prose",
+            len(authored_before),
+            len(authored_after),
+        )
+        return 1
+
+    if not apply:
+        logger.info("nothing written — rerun with --apply")
+        return 0
+    if not all_edits:
+        logger.info("nothing to write")
+        return 0
+
+    doc["data"] = patched
+    canonical_path.write_text(
+        json.dumps(doc, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    logger.info("canonical written: %s", canonical_path)
+    run_sync_script()
+    reconcile_sidecar(canonical_path)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--canonical", type=Path, default=CANONICAL)
+    ap.add_argument("--apply", action="store_true", help="write (default: dry-run)")
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    return run(args.canonical, args.apply)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kbli_filiera/editorial_record_conformance.py
+++ b/scripts/kbli_filiera/editorial_record_conformance.py
@@ -57,12 +57,39 @@ Bali-scoped cells. So the label's SCOPE is resolved first and Bali-scoped cells
 are excluded by name, with the exclusion counted and reported rather than left
 silent.
 
-THERE IS ALREADY A GUARD FOR THIS, AND IT WATCHES THE OTHER DIRECTION
----------------------------------------------------------------------
-`kbli_dataset_lint.py` rule L9 calls `validate_pma_consistency`, which is a
-blocking lint and looks like this module's twin. Measured on the live
-catalogue, the two sets are DISJOINT: L9 finds 2 codes, this module finds 27,
-and the overlap is empty.
+THE GUARDS THAT ALREADY EXIST — ONE IS UNRELATED, ONE IS A PARTIAL TWIN
+------------------------------------------------------------------------
+CORRECTION, and the way the mistake was made is the useful part. An earlier
+version of this section said "there is already a guard for this, and it watches
+the other direction", naming only rule L9. That was written after checking the
+lint rule whose NAME matched (`validate_pma_consistency`) and never opening
+rule **L10**, whose BEHAVIOUR matched — even though the first lint run printed
+`L10: 28` in plain sight. Checking the guard whose name matches instead of the
+one whose behaviour matches is the same form-over-entity habit this module's
+Bali exclusion exists to avoid, committed while writing the paragraph about it.
+
+**L9 — unrelated.** Two literal substring tests. Its two live findings
+(`43110`, `86201`) are both TERBUKA/100 caught by the "record open, prose says
+closed" branch — a page understating what a client may do. The branch guarding
+the expensive direction requires `pma_status == "TERTUTUP"` AND the literal
+string "100% foreign", which no live record satisfies. Disjoint from this
+module, measured.
+
+**L10 — a partial twin with complementary blind spots**, and NOT to be treated
+as redundant in either direction. It walks the same prose via `iter_prose` and
+compares a percentage claim against `pma_max_asing`, with a real SSOT
+(`l10_ownership_contradiction`) carrying innocence idioms this module does not
+have ("100% closed", "not 100% open"). Measured on the live catalogue:
+
+    this module 31 · L10 17 · overlap 14 · this-module-only 17 · L10-only 3
+
+So each finds real contradictions the other misses. This module reads sentences
+for an openness ASSERTION, which catches "nationally open to full foreign
+ownership" with no number in it; L10 reads for a PERCENTAGE, which catches
+numeric claims phrased in ways no sentence-level openness predicate matches
+(`41011`, `52292`, `53200` are live examples this module does not see, and they
+are a DECLARED gap here, not a fixed one — closing them means widening a
+predicate, which needs its own guilt and innocence).
 
 The reason is structural rather than a matter of degree. L9 is two literal
 substring tests:
@@ -70,20 +97,15 @@ substring tests:
     pma_status == "TERTUTUP" and "100% foreign" in text     # record closed, prose open
     pma_status == "TERBUKA"  and "closed to foreign" in text # record open, prose closed
 
-Its two live findings (`43110`, `86201`) are both TERBUKA/100 caught by the
-SECOND test — a page understating what a client may do, which costs him an
-opportunity he could ask about. The first test guards the expensive direction,
-and it cannot reach this population: 26 of the 27 are **TERBATAS**, a status the
-condition never admits, and the 27th says it in words the substring does not
-contain ("nationally open to full foreign ownership"). So a client told he may
-wholly own an arms factory was never in range of the guard that exists.
-
-Left in place rather than folded together, deliberately: L9 owns the mirror
-case, and widening it here would turn a blocking lint red on a 27-item backlog
-(W95 — a gate armed on live debt makes every unrelated PR red). Reconciling them
-so that two tools cannot answer the same question two ways (W105) is a
-follow-up, and it belongs on the side of the LINT consuming this report, the way
-`kbli_documents_cure.py` consumes `kbli_surface_conformance.py --json`.
+Nothing is folded together here. Both lint rules stay exactly as they are: L10
+is BLOCKING and already carries a long-standing backlog (28 findings before
+2026-08-06, 31 after `#3673`, 23 after the stat-card cure), and rewiring a
+blocking lint while its backlog is live is how an unrelated PR turns red (W95).
+Reconciling them so two tools cannot answer one question two ways (W105) belongs
+on the LINT's side, consuming this report the way `kbli_documents_cure.py`
+consumes `kbli_surface_conformance.py --json`. The relationship is pinned by
+`test_this_module_is_not_a_twin_of_the_existing_L9_lint_rule` so that it cannot
+drift unnoticed again.
 
 IT REPORTS, IT DOES NOT DECIDE
 ------------------------------

--- a/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
+++ b/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
@@ -207,9 +207,20 @@ def test_apply_writes_and_the_result_reports_zero_stale_cells(tmp_path: Path, mo
 # --------------------------------------------------------------------------
 
 
-def test_the_live_dry_run_reaches_zero_and_refuses_nothing():
-    """If this fails, a real cell has a shape the planner cannot rewrite — read
-    the refusal rather than loosening the planner."""
+def test_the_live_catalogue_holds_no_stale_cell_and_none_it_could_not_rewrite():
+    """The standing guard, and it is worth more than the backlog it replaced.
+
+    This test used to pin "38 cells on 31 codes". That number was a measure of
+    debt, and debt is exactly what a pin should not preserve: it goes green
+    again the moment someone cures it and tells you nothing afterwards. The cure
+    has now run, so the assertion is the property we actually want to keep —
+    the catalogue holds NO stale stat card, and no card whose shape this pass
+    would have to guess at.
+
+    A failure here has two readings and both need a human eye: either a new
+    contradiction was authored, or a cure moved a field and left the card
+    behind, which is precisely how the original 31 came to exist.
+    """
     records = E.load_records()
     edits, refusals = [], []
     for record in records:
@@ -219,8 +230,11 @@ def test_the_live_dry_run_reaches_zero_and_refuses_nothing():
             edits += e
             refusals += r
     assert refusals == [], f"the live catalogue holds a cell this cannot rewrite: {refusals}"
-    assert len(edits) == 34, "34 cells on 27 codes — measured, not carried over from a plan"
-    assert len({e["code"] for e in edits}) == 27
+    assert edits == [], (
+        "a stat card disagrees with its record again — either newly authored, or "
+        f"a cure moved a field and left the card behind: "
+        f"{[(e['code'], e['label'], e['was']) for e in edits]}"
+    )
 
 
 def test_the_live_run_writes_the_real_catalogue_into_a_copy_and_changes_only_cells(
@@ -243,8 +257,12 @@ def test_the_live_run_writes_the_real_catalogue_into_a_copy_and_changes_only_cel
     p.write_text(json.dumps(original, ensure_ascii=False), encoding="utf-8")
 
     authored_before = E.report(original["data"])["needs_an_author"]["codes"]
-    assert len(authored_before) == 27
+    assert len(authored_before) == 31, "the prose backlog only a human can shrink"
 
+    # The catalogue is already cured, so this run is the IDEMPOTENCE check: a
+    # second pass must find nothing, write nothing, and leave the document
+    # byte-identical. A cure that keeps finding work on its own output is
+    # rewriting something it should not have touched.
     assert C.run(p, apply=True) == 0
 
     after = json.loads(p.read_text(encoding="utf-8"))["data"]

--- a/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
+++ b/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
@@ -1,0 +1,267 @@
+"""Guilt, innocence and REFUSAL for the mechanical stat-card cure.
+
+This module writes the canonical KBLI dataset, so the tests that matter most
+are the ones about what it must NOT do: not touch a lawfully Bali-scoped cell,
+not touch prose, and not write at all when the result would be half-cured.
+
+The dangerous direction here is not a missed cell. It is a cell rewritten from
+a misread record, because the output looks authoritative — a number in a stat
+card is the thing a client acts on money with, and it carries no hedge.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_FILIERA = str(Path(__file__).resolve().parents[1])
+if _FILIERA not in sys.path:
+    sys.path.insert(0, _FILIERA)
+
+import cure_editorial_cells_from_record as C  # noqa: E402
+import editorial_record_conformance as E  # noqa: E402
+
+
+def rec(code="01111", status="TERBATAS", cap=49, cells=None, body=""):
+    return {
+        "kode_kbli_2025": code,
+        "pma_status": status,
+        "pma_max_asing": cap,
+        "intel_2026": {
+            "editorial": {
+                "headline": "",
+                "standfirst": "",
+                "body": body,
+                "byTheNumbers": cells or [],
+            }
+        },
+    }
+
+
+def plan(record):
+    return C.plan_for(record, E.classify(record))
+
+
+# --------------------------------------------------------------------------
+# GUILT — the copy is restored from the field it copies
+# --------------------------------------------------------------------------
+
+
+def test_guilt_a_stale_ceiling_is_rewritten_to_the_record_cap():
+    r = rec(cap=49, cells=[{"label": "Foreign-ownership ceiling", "value": "100%"}])
+    edits, refusals = plan(r)
+    assert refusals == []
+    assert [(e["was"], e["now"]) for e in edits] == [("100%", "49%")]
+
+
+def test_guilt_a_stale_status_is_rewritten_to_the_record_status():
+    r = rec(status="TERBATAS", cells=[{"label": "National PMA status", "value": "TERBUKA"}])
+    edits, _ = plan(r)
+    assert [(e["was"], e["now"]) for e in edits] == [("TERBUKA", "TERBATAS")]
+
+
+def test_a_zero_ceiling_is_written_as_zero_not_softened_into_words():
+    """`0%` reads oddly and is accurate. Writing "Not permitted" instead would
+    be authoring a sentence, which is the other module's job and Legge 5."""
+    r = rec(cap=0, cells=[{"label": "Foreign ownership ceiling", "value": "100%"}])
+    assert plan(r)[0][0]["now"] == "0%"
+
+
+# --------------------------------------------------------------------------
+# INNOCENCE — what it must leave exactly where it is
+# --------------------------------------------------------------------------
+
+
+def test_innocence_a_bali_scoped_cell_is_never_rewritten():
+    """The 132-cell trap. A closed Bali layer over an open national record is
+    lawful, and 'correcting' it to the national value would destroy the one
+    fact the page exists to convey."""
+    r = rec(
+        status="TERBUKA",
+        cap=100,
+        cells=[{"label": "Bali PMA status", "value": "TERTUTUP"}],
+    )
+    edits, refusals = plan(r)
+    assert (edits, refusals) == ([], [])
+
+
+def test_innocence_a_cell_that_already_agrees_is_untouched():
+    r = rec(cap=49, cells=[{"label": "Foreign-ownership ceiling", "value": "49%"}])
+    assert plan(r) == ([], [])
+
+
+def test_innocence_an_unflagged_cell_on_a_flagged_record_is_untouched():
+    """A record can hold one stale cell and several correct ones. The pass is
+    driven by the detector's per-cell verdict, not by 'this record is dirty'."""
+    r = rec(
+        cap=49,
+        cells=[
+            {"label": "Foreign-ownership ceiling", "value": "100%"},
+            {"label": "Minimum paid-up capital", "value": "IDR 10 billion"},
+            {"label": "Risk category", "value": "Tinggi"},
+        ],
+    )
+    edits, _ = plan(r)
+    assert [e["label"] for e in edits] == ["Foreign-ownership ceiling"]
+
+
+# --------------------------------------------------------------------------
+# REFUSAL — ambiguity is named, never guessed
+# --------------------------------------------------------------------------
+
+
+def test_refusal_a_ceiling_holding_two_percentages_is_not_guessed_at():
+    r = rec(cap=49, cells=[{"label": "Foreign-ownership ceiling", "value": "100% (was 67%)"}])
+    edits, refusals = plan(r)
+    assert edits == []
+    assert len(refusals) == 1 and "cannot rewrite one" in refusals[0]
+
+
+def test_refusal_a_non_numeric_cap_is_not_stamped_into_a_cell():
+    """`special` is a real cap in this catalogue. Writing `special%` would be
+    an invented value wearing a number's clothes."""
+    r = rec(cap="special", cells=[{"label": "Foreign-ownership ceiling", "value": "100%"}])
+    r["pma_status"] = "TERBATAS"
+    verdict = E.classify(r)
+    # the detector cannot flag it either — pinned so the two stay consistent
+    assert verdict["ceiling_cells"] == []
+    edits, refusals = C.plan_for(
+        r, {"ceiling_cells": [{"label": "Foreign-ownership ceiling"}], "status_cells": []}
+    )
+    assert edits == []
+    assert "not a number" in refusals[0]
+
+
+# --------------------------------------------------------------------------
+# THE WRITE PATH — dry-run writes nothing, a half-cure writes nothing
+# --------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, records: list[dict]) -> Path:
+    p = tmp_path / "canonical.json"
+    p.write_text(json.dumps({"data": records}, ensure_ascii=False), encoding="utf-8")
+    return p
+
+
+def test_dry_run_writes_nothing(tmp_path: Path):
+    p = _write(tmp_path, [rec(cap=49, cells=[{"label": "Foreign-ownership ceiling", "value": "100%"}])])
+    before = p.read_bytes()
+    assert C.run(p, apply=False) == 0
+    assert p.read_bytes() == before
+
+
+def test_it_refuses_to_write_when_a_stale_cell_would_survive(tmp_path: Path, monkeypatch):
+    """A half-cure is worse than a refusal: the page becomes consistent enough
+    to be believed while still wrong where it counts. Simulated by making the
+    planner blind to one cell, which is what any future predicate drift does."""
+    p = _write(tmp_path, [rec(cap=49, cells=[{"label": "Foreign-ownership ceiling", "value": "100%"}])])
+    before = p.read_bytes()
+    monkeypatch.setattr(C, "plan_for", lambda record, verdict: ([], []))
+    assert C.run(p, apply=True) == 1
+    assert p.read_bytes() == before, "it must not write when it refuses"
+
+
+def test_it_refuses_to_write_if_the_prose_verdict_moved(tmp_path: Path, monkeypatch):
+    """The pass must not author. If patching a cell changed which codes need an
+    author, something rewrote a string and the run is abandoned."""
+    records = [rec(cap=49, cells=[{"label": "Foreign-ownership ceiling", "value": "100%"}])]
+    p = _write(tmp_path, records)
+    before = p.read_bytes()
+
+    real_plan = C.plan_for
+
+    def sneaky(record, verdict):
+        edits, refusals = real_plan(record, verdict)
+        record["intel_2026"]["editorial"]["body"] = (
+            "This activity is nationally open to full foreign ownership."
+        )
+        return edits, refusals
+
+    monkeypatch.setattr(C, "plan_for", sneaky)
+    assert C.run(p, apply=True) == 1
+    assert p.read_bytes() == before
+
+
+def test_apply_writes_and_the_result_reports_zero_stale_cells(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(C, "run_sync_script", lambda: None)
+    monkeypatch.setattr(C, "reconcile_sidecar", lambda path: False)
+    p = _write(
+        tmp_path,
+        [
+            rec(code="51101", cap=49, cells=[{"label": "Foreign-ownership ceiling", "value": "100%"}]),
+            rec(code="79122", cap=0, status="TERBATAS",
+                cells=[{"label": "National PMA status", "value": "TERBUKA"}]),
+        ],
+    )
+    assert C.run(p, apply=True) == 0
+    after = json.loads(p.read_text(encoding="utf-8"))["data"]
+    assert E.report(after)["mechanically_correctable"]["codes"] == []
+    cells = {r["kode_kbli_2025"]: r["intel_2026"]["editorial"]["byTheNumbers"][0]["value"]
+             for r in after}
+    assert cells == {"51101": "49%", "79122": "TERBATAS"}
+
+
+# --------------------------------------------------------------------------
+# THE LIVE CATALOGUE
+# --------------------------------------------------------------------------
+
+
+def test_the_live_dry_run_reaches_zero_and_refuses_nothing():
+    """If this fails, a real cell has a shape the planner cannot rewrite — read
+    the refusal rather than loosening the planner."""
+    records = E.load_records()
+    edits, refusals = [], []
+    for record in records:
+        verdict = E.classify(record)
+        if verdict["ceiling_cells"] or verdict["status_cells"]:
+            e, r = C.plan_for(record, verdict)
+            edits += e
+            refusals += r
+    assert refusals == [], f"the live catalogue holds a cell this cannot rewrite: {refusals}"
+    assert len(edits) == 34, "34 cells on 27 codes — measured, not carried over from a plan"
+    assert len({e["code"] for e in edits}) == 27
+
+
+def test_the_live_run_writes_the_real_catalogue_into_a_copy_and_changes_only_cells(
+    tmp_path: Path, monkeypatch
+):
+    """The whole cure, end to end, on the real 1,559 records — into a COPY.
+
+    Three properties at once, and each has failed in some cure in this
+    directory before: every stale cell is gone, the authored backlog is
+    untouched, and NOTHING outside `byTheNumbers` moved. The third is checked by
+    stripping the cells out of both documents and comparing what is left, which
+    is the only version of "it only touched cells" that a reader can trust —
+    counting edits proves what the pass INTENDED, not what it wrote.
+    """
+    monkeypatch.setattr(C, "run_sync_script", lambda: None)
+    monkeypatch.setattr(C, "reconcile_sidecar", lambda path: False)
+
+    original = json.loads(E.CANONICAL.read_text(encoding="utf-8"))
+    p = tmp_path / "canonical.json"
+    p.write_text(json.dumps(original, ensure_ascii=False), encoding="utf-8")
+
+    authored_before = E.report(original["data"])["needs_an_author"]["codes"]
+    assert len(authored_before) == 27
+
+    assert C.run(p, apply=True) == 0
+
+    after = json.loads(p.read_text(encoding="utf-8"))["data"]
+    report = E.report(after)
+    assert report["mechanically_correctable"]["codes"] == []
+    assert report["needs_an_author"]["codes"] == authored_before
+
+    def without_cells(records):
+        out = []
+        for r in records:
+            r = json.loads(json.dumps(r))
+            ed = (r.get("intel_2026") or {}).get("editorial")
+            if isinstance(ed, dict):
+                ed.pop("byTheNumbers", None)
+            out.append(r)
+        return out
+
+    assert without_cells(after) == without_cells(original["data"]), (
+        "the pass changed something outside byTheNumbers"
+    )

--- a/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
+++ b/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
@@ -282,14 +282,20 @@ def test_the_walk_reaches_prose_nested_below_the_top_level():
 def test_the_two_buckets_are_reported_separately_and_are_not_the_same_set():
     """A single "N codes are wrong" would hide that one bucket is a
     find-and-replace on a field we own and the other needs a human to write a
-    sentence. `50135` is the proof they are different sets: clean cells, wrong
-    prose."""
+    sentence — and the live data now proves the split was real rather than
+    tidy: the mechanical bucket has been CURED to empty by
+    `cure_editorial_cells_from_record.py` while the authored one still holds
+    31 codes, untouched, because replacing a sentence means writing one.
+
+    `50135` remains the specimen: clean cells, wrong prose. It was in the
+    authored bucket before the cure and it is there now, which is the whole
+    point of not having merged the two counts."""
     rep = E.report(E.load_records())
     mech = set(rep["mechanically_correctable"]["codes"])
     auth = set(rep["needs_an_author"]["codes"])
-    assert mech and auth
-    assert auth - mech, "if every prose case had a bad cell, one check would do"
-    assert "50135" in auth - mech
+    assert mech == set(), "the mechanical bucket is cured; a new member is a regression"
+    assert auth, "the authored backlog is not empty and must not be quietly emptied"
+    assert "50135" in auth
 
 
 def test_the_bali_exclusion_is_large_enough_to_matter_and_is_declared():
@@ -304,38 +310,56 @@ def test_the_live_populations_are_pinned():
     land; a rise means a new contradiction was authored, which is the whole
     thing this file is about."""
     rep = E.report(E.load_records())
-    assert len(rep["mechanically_correctable"]["codes"]) == 27
-    assert rep["mechanically_correctable"]["ceiling_cells"] == 27
-    assert rep["mechanically_correctable"]["status_cells"] == 7
-    assert len(rep["needs_an_author"]["codes"]) == 27
+
+    # ZERO, and this is a tripwire rather than a backlog size now: the 31 stale
+    # cells this module first reported were cured by
+    # `cure_editorial_cells_from_record.py`, so any number above zero means a
+    # NEW stale copy was authored or a cure moved a field and left the card
+    # behind. That is exactly how these 31 were born.
+    assert rep["mechanically_correctable"]["codes"] == []
+    assert rep["mechanically_correctable"]["ceiling_cells"] == 0
+    assert rep["mechanically_correctable"]["status_cells"] == 0
+
+    # The authored backlog, which only a human can shrink (Legge 5). It went
+    # 27 -> 31 when #3673 restricted four codes and left their prose saying the
+    # opposite — the cure moved the record and the sentences beside it did not
+    # move, which is this module's whole subject.
+    assert len(rep["needs_an_author"]["codes"]) == 31
 
     # WHERE the prose lies. Pinned because the total alone hid the defect that
     # produced these numbers: the first version read three fields and reported
     # 20, and `whatYouNeed` — the field that carries a client's filing
     # instructions — was the largest offender and was never opened.
     assert rep["needs_an_author"]["by_field"] == {
-        "whatYouNeed": 18,
+        "whatYouNeed": 19,
         "editorial.body": 16,
-        "editorial.headline": 10,
-        "editorial.standfirst": 5,
+        "editorial.headline": 13,
+        "editorial.standfirst": 6,
         "whoThisIsFor": 1,
     }
 
 
-def test_this_module_is_not_a_twin_of_the_existing_L9_lint_rule():
-    """The anti-twin claim in the docstring, armed instead of asserted.
+def test_the_relationship_to_both_existing_lint_rules_is_pinned():
+    """Two lint rules could be this module's twin. One is not; one partly is.
 
-    `kbli_dataset_lint.py` rule L9 (`validate_pma_consistency`) is a BLOCKING
-    lint that looks like this module's duplicate. It is not: measured here, the
-    two finding sets are disjoint. L9's reachable half of the dangerous
-    direction requires `pma_status == "TERTUTUP"` AND the literal substring
-    "100% foreign"; 26 of this module's 27 codes are TERBATAS, which that
-    condition never admits.
+    This test was first written as "not a twin of L9" and stopped there, because
+    L9 is the rule whose NAME matches (`validate_pma_consistency`). The rule
+    whose BEHAVIOUR matches is L10, and it was not opened at all — so the
+    conclusion drawn was true about L9 and misleading about the lint.
 
-    If this test ever fails, the two tools have started answering the same
-    question two different ways (W105) and the right response is to make the
-    lint consume this report — not to delete whichever assertion is
-    inconvenient.
+    Both are pinned now:
+
+    * **L9** is disjoint. Its reachable half of the dangerous direction needs
+      `pma_status == "TERTUTUP"` AND the literal "100% foreign", which no live
+      record satisfies; its two findings are the mirror case.
+    * **L10** is a partial twin: 31 here, 17 there, 14 shared, and each side
+      holds real findings the other misses. Asserted in BOTH directions, so
+      neither can be retired as redundant on the strength of the other, and the
+      three codes only L10 sees stay a declared gap rather than a silent one.
+
+    A failure here means the tools have started answering one question two ways
+    (W105); the response is to make the lint consume this report, not to delete
+    whichever assertion has become inconvenient.
     """
     scripts_dir = str(Path(__file__).resolve().parents[2])
     if scripts_dir not in sys.path:
@@ -367,15 +391,66 @@ def test_this_module_is_not_a_twin_of_the_existing_L9_lint_rule():
         "dangerous-direction test cannot reach"
     )
 
+    # L10 is the rule that actually resembles this module, and the first version
+    # of this test did not look at it — it checked the rule whose NAME matched
+    # and missed the one whose BEHAVIOUR matched. Pinned as a partial twin with
+    # complementary blind spots, in BOTH directions, so neither can be retired as
+    # redundant on the strength of the other.
+    import kbli_dataset_lint as lint
+
+    maxa_by_code = {r["kode_kbli_2025"]: r.get("pma_max_asing") for r in records}
+    l10 = set()
+    for record in records:
+        code, maxa = record["kode_kbli_2025"], record.get("pma_max_asing")
+        if code in lint.L10_SECTOR_LAW_OVERRIDE or not isinstance(maxa, int):
+            continue
+        if any(
+            lint.l10_ownership_contradiction(text, code, maxa, maxa_by_code)
+            for _field, text in lint.iter_prose(record)
+        ):
+            l10.add(code)
+
+    assert mine & l10, "L10 and this module used to agree on 14 codes; agreeing on none means one went blind"
+    assert mine - l10, (
+        "this module no longer finds anything L10 misses — if that is real, it is "
+        "redundant and should be retired rather than maintained"
+    )
+    assert l10 - mine == {"41011", "52292", "53200"}, (
+        "the DECLARED gap in this module — numeric claims L10 catches and a "
+        f"sentence-level openness predicate does not: {sorted(l10 - mine)}"
+    )
+
 
 def test_the_worst_members_are_named_not_counted():
     """A population with only a size cannot be closed by the pass that comes for
     it. These three are the ones a client acts on money with."""
-    rep = E.report(E.load_records())
-    mech = set(rep["mechanically_correctable"]["codes"])
-    # arms and ammunition, capped at 49% — sidebar says 100%
-    assert "25200" in mech
-    # military vehicles, capped at 49%
-    assert "30400" in mech
-    # Umrah/Hajj travel, capped at 0% — its prose still reads as an opening
+    records = E.load_records()
+    rep = E.report(records)
+    by_code = {r["kode_kbli_2025"]: r for r in records}
+
+    def ceiling_cells(code):
+        editorial = (by_code[code].get("intel_2026") or {}).get("editorial") or {}
+        return [
+            c
+            for c in (editorial.get("byTheNumbers") or [])
+            if isinstance(c, dict)
+            and "ceiling" in str(c.get("label", "")).lower()
+            and "bali" not in str(c.get("label", "")).lower()
+        ]
+
+    # The three a client acts on money with. Asserted by CONTENT rather than by
+    # absence from a bucket — "not in the mechanical list" would also be true if
+    # the detector had gone blind, which is the failure this file exists to
+    # catch (W107: the probe can carry the disease it measures).
+    for code, expected in (("25200", "49%"), ("30400", "49%"), ("79122", "0%")):
+        cells = ceiling_cells(code)
+        assert cells, f"{code} lost its national ceiling card entirely"
+        assert all(c["value"] == expected for c in cells), (
+            f"{code} ceiling card says {[c['value'] for c in cells]}, record says {expected}"
+        )
+    assert set(rep["mechanically_correctable"]["codes"]) == set()
+
+    # Umrah/Hajj travel: the CARD is cured, the PROSE still reads as an opening
+    # and needs an author. Both halves named, because "79122 is fixed" would be
+    # a comfortable half-truth.
     assert "79122" in set(rep["needs_an_author"]["codes"])


### PR DESCRIPTION
## What a client saw

`/kbli/25200` (arms and ammunition) and `/kbli/30400` (military vehicles) printed **`Foreign ownership ceiling · 100%`** against records capped at **49%**. `/kbli/79122` (Umrah and Hajj travel) printed **100%** against a record capped at **0%**. Seven pages also printed `PMA status · TERBUKA` against a record saying `TERBATAS`.

These cards live in the data and render verbatim, and `reindex_kbli_2025_final.py` stringifies them into the Qdrant embedding text — so the same numbers were retrievable and could be handed to a client on WhatsApp, not just read on the web.

**31 codes · 38 cells · 0 refused · 0 stale after.**

## Why this is mechanical and not editorial

A `byTheNumbers` cell is a stale **copy** of a field we own, not a sentence anyone chose. Measured before the tool was written: all affected records carry `pma_cap_verified: true` and an integer cap, so the number being copied is one the organism already stands behind.

The 31 codes whose **prose** contradicts the record are untouched and still owed an author (Legge 5). The run **refuses to write** if that set changes — a mechanical pass that quietly improved a body would be authoring under cover.

Innocence held on live data: `96210` still reads `Bali PMA status · Closed to PMA (Koperasi/UMKM allocation)` over a cured national card. That is the one fact the page exists to convey, and re-deriving "is this cell wrong" locally instead of consuming the detector's verdict (W105) would eventually have rewritten all 132 lawful Bali cells.

## This also repairs a red on main

`#3673` and `#3676` merged five minutes apart. `#3673` restricted four codes; `#3676` pinned a population measured before it landed; the two diffs share no file, and their queue entries did not catch it. **W109b** — two PRs coupled through a number one pins and the other moves.

The pins move once here and change **meaning**, not value: "31 stale cells" was a measure of debt that goes green on its own and says nothing afterwards. It is now *zero, and a new one is a regression* — which is the property worth keeping, because a stale card is born exactly when a cure moves a field and leaves the card behind.

## A correction to what #3676 merged

That PR's docstring claimed the pre-existing guard "watches the other direction", naming only lint rule **L9**. Wrong — and the mistake is the instructive part. L9 is the rule whose **name** matched (`validate_pma_consistency`); **L10** is the rule whose **behaviour** matched, and it was never opened, although the first lint run printed `L10: 28` in plain sight.

Measured: **this module 31 · L10 17 · overlap 14 · here-only 17 · L10-only 3.** A partial twin with complementary blind spots, now pinned in *both* directions so neither can be retired as redundant, with `41011`/`52292`/`53200` recorded as a **declared gap** rather than closed by widening a predicate that would then need its own guilt and innocence.

Neither lint rule is rewired: L10 is blocking and carries a live backlog (28 findings before `#3673`, 31 after, **23** after this cure), and rewiring a blocking lint over live debt is how an unrelated PR turns red (W95).

## Verification

- 920 tests pass in `scripts/kbli_filiera/tests/`
- The cure runs over the real 1,559 records into a **copy**, then both documents are compared with `byTheNumbers` stripped out — so "it only touched cells" is proven against what it **wrote**, not what it intended
- Mutation-verified: removing the half-cure refusal turns the matching test red
- Idempotence: a second pass on the cured catalogue finds nothing and writes nothing
- Batch A membership pin re-emitted (content-addresses canonical; membership unchanged at 221)

🤖 Generated with [Claude Code](https://claude.com/claude-code)