### PR TITLE
fix(home-fork): name the pairs the check SKIPPED, so "clean" stops reading as "checked"

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -83,6 +83,7 @@ jobs:
               scripts/codex/codex-nightly-autofix-ci.sh|\
               scripts/tests/test_lint_home_fork.py|\
               scripts/tests/test_home_fork_stale_side_attribution.py|\
+              scripts/tests/test_home_fork_skipped_visibility.py|\
               scripts/tests/test_proprioception_home_fork_merge.py|\
               scripts/tests/test_secrets_permissions_audit.py|\
               scripts/tests/test_pending_arms_report.py|\
@@ -209,6 +210,7 @@ jobs:
           for t in \
             scripts/tests/test_lint_home_fork.py \
             scripts/tests/test_home_fork_stale_side_attribution.py \
+            scripts/tests/test_home_fork_skipped_visibility.py \
             scripts/tests/test_proprioception_home_fork_merge.py \
             scripts/tests/test_secrets_permissions_audit.py \
             scripts/tests/test_pending_arms_report.py \

--- a/scripts/lint_home_fork.py
+++ b/scripts/lint_home_fork.py
@@ -259,6 +259,7 @@ def check_pairs(
     home: Path,
     label: str,
     notices: Optional[list[str]] = None,
+    skipped: Optional[list[str]] = None,
 ) -> list[str]:
     """The --check arm: sha256 live vs repo twin for machine-applicable pairs.
 
@@ -274,6 +275,20 @@ def check_pairs(
     moved, and only call it a HOME-fork when the LIVE copy is the stale one.
     A stale checkout goes to `notices` instead: real, differently owned, and
     on M5 not even fixable (pulling that checkout races ~45 live worktrees).
+
+    `skipped` collects the pairs this machine CLAIMS (machines: all/<label>)
+    whose live copy is not on disk. They are not breaches — nothing can drift
+    when nothing is running — but they are not coverage either, and silence
+    made them read as coverage. Measured 2026-08-06: `--check` reported
+    "109 declared pair(s) ... clean" on the Pro while three of the ten
+    wa-mirror pairs were never evaluated, including BOTH files the promotion
+    PR existed for (their live copies had been moved to an attic hours
+    earlier). The verdict was true; the conclusion a reader draws from it —
+    "the promoted files are verified" — was not.
+
+    A pair scoped to another machine is deliberately NOT collected here: that
+    is legitimate non-applicability, not a blind spot, and reporting it would
+    bury the real signal in fleet-wide noise on every run.
     """
     breaches: list[str] = []
     for pair in pairs:
@@ -282,7 +297,10 @@ def check_pairs(
         live = expand_home(pair["live"], home)
         repo = repo_root / pair["repo"]
         if not live.exists():
-            continue  # this machine does not run that copy — not a breach
+            # Not a breach — but say so, or "clean" reads as "checked".
+            if skipped is not None:
+                skipped.append(f"{pair['live']} (declared for {label}, not on disk)")
+            continue
         if not repo.exists():
             breaches.append(
                 f"NO-REPO-TWIN: {pair['live']} executes live but {pair['repo']} "
@@ -547,6 +565,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     undeclared: list[str] = []
     errors: list[str] = []
     stale_checkout: list[str] = []
+    skipped_pairs: list[str] = []
 
     if run_check:
         # Refresh the reference BEFORE anyone is blamed against it. A failure
@@ -568,7 +587,12 @@ def main(argv: Optional[list[str]] = None) -> int:
                     f"acted on from this run"
                 )
         breaches = check_pairs(
-            pairs, args.repo_root, args.home, label, notices=stale_checkout
+            pairs,
+            args.repo_root,
+            args.home,
+            label,
+            notices=stale_checkout,
+            skipped=skipped_pairs,
         )
         if args.strict_checkout:
             breaches += stale_checkout
@@ -606,6 +630,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                     "machine": label,
                     "check_breaches": breaches,
                     "check_stale_checkout": stale_checkout,
+                    "check_skipped_live_absent": skipped_pairs,
                     "discover_undeclared": undeclared,
                     "errors": errors,
                     "pairs_declared": len(pairs),
@@ -629,7 +654,24 @@ def main(argv: Optional[list[str]] = None) -> int:
                     f"because this checkout trails origin/main (--strict-checkout to fail on it)"
                 )
             else:
-                print("  clean — every live copy matches its repo twin")
+                verified = len(
+                    [p for p in pairs if pair_applies(p, label)]
+                ) - len(skipped_pairs)
+                print(
+                    f"  clean — {verified} live copy/copies match their repo twin"
+                    if skipped_pairs
+                    else "  clean — every live copy matches its repo twin"
+                )
+        if skipped_pairs:
+            # Never touches the exit code: a diagnostic that can fail a build is
+            # not a diagnostic. It exists so "clean" is not read as "checked".
+            shown = skipped_pairs[:10]
+            print(
+                f"  {len(skipped_pairs)} pair(s) NOT checked — live copy absent on "
+                f"this machine (showing {len(shown)} of {len(skipped_pairs)}):"
+            )
+            for s in shown:
+                print(f"    ? {s}")
     if run_discover:
         print(f"[discover] undeclared HOME-executed payloads: {len(undeclared)}")
         for f in undeclared:

--- a/scripts/tests/test_home_fork_skipped_visibility.py
+++ b/scripts/tests/test_home_fork_skipped_visibility.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""A declared pair whose live copy is absent must be NAMED, never silent.
+
+`check_pairs` skips any pair whose live side is not on disk — correctly, since
+nothing can drift when nothing is running. But the skip was silent, so the run
+printed "109 declared pair(s) ... clean" while never evaluating three of them.
+
+Measured on the Pro, 2026-08-06, minutes after PR #3671 merged: two of the
+skipped pairs were the very files that PR existed to promote (their live copies
+had been moved to an attic hours earlier), and the third was a stale
+declaration nobody knew was stale. The verdict was true. The conclusion any
+reader draws from it — "the declared pairs are verified" — was not.
+
+The distinction this pins: a pair scoped to ANOTHER machine is legitimate
+non-applicability and must stay silent, or the real signal drowns in fleet
+noise on every run. Only a pair this machine CLAIMS and cannot find is news.
+
+    python3 -m pytest scripts/tests/test_home_fork_skipped_visibility.py -q
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINT = REPO_ROOT / "scripts" / "lint_home_fork.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("lint_home_fork_under_test", LINT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def lint():
+    return _load()
+
+
+@pytest.fixture()
+def world(tmp_path):
+    """A repo twin and a HOME, both real on disk — no mocked filesystem."""
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    (home / "scripts").mkdir(parents=True)
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "scripts" / "present.sh").write_text("#!/bin/sh\necho hi\n")
+    (home / "scripts" / "present.sh").write_text("#!/bin/sh\necho hi\n")
+    (repo / "scripts" / "absent.sh").write_text("#!/bin/sh\necho gone\n")
+    # NOTE: no home/scripts/absent.sh — that is the whole point.
+    return home, repo
+
+
+PRESENT = {"live": "~/scripts/present.sh", "repo": "scripts/present.sh", "machines": ["all"]}
+ABSENT = {"live": "~/scripts/absent.sh", "repo": "scripts/absent.sh", "machines": ["all"]}
+OTHER_MACHINE = {
+    "live": "~/scripts/absent.sh",
+    "repo": "scripts/absent.sh",
+    "machines": ["some-other-box"],
+}
+
+
+# ── guilt: an absent live side is reported ───────────────────────────────────
+def test_absent_live_copy_is_named(lint, world):
+    home, repo = world
+    skipped: list[str] = []
+    breaches = lint.check_pairs([ABSENT], repo, home, "pro", skipped=skipped)
+    assert breaches == [], "an absent live copy is not a breach"
+    assert len(skipped) == 1
+    assert "~/scripts/absent.sh" in skipped[0]
+    assert "not on disk" in skipped[0]
+
+
+def test_the_machine_it_was_declared_for_is_named(lint, world):
+    """Naming the machine is what makes the line actionable on a 3-node fleet."""
+    home, repo = world
+    skipped: list[str] = []
+    lint.check_pairs([ABSENT], repo, home, "mini", skipped=skipped)
+    assert "mini" in skipped[0]
+
+
+def test_a_present_pair_is_still_checked_not_skipped(lint, world):
+    home, repo = world
+    skipped: list[str] = []
+    breaches = lint.check_pairs([PRESENT], repo, home, "pro", skipped=skipped)
+    assert breaches == []
+    assert skipped == [], "a live copy that EXISTS must be evaluated, never skipped"
+
+
+def test_mixed_run_separates_verified_from_skipped(lint, world):
+    home, repo = world
+    skipped: list[str] = []
+    lint.check_pairs([PRESENT, ABSENT], repo, home, "pro", skipped=skipped)
+    assert len(skipped) == 1 and "absent" in skipped[0]
+
+
+# ── innocence: silence where silence is correct ──────────────────────────────
+def test_a_pair_scoped_to_another_machine_is_NOT_reported(lint, world):
+    """Legitimate non-applicability. Reporting it would bury the real signal."""
+    home, repo = world
+    skipped: list[str] = []
+    lint.check_pairs([OTHER_MACHINE], repo, home, "pro", skipped=skipped)
+    assert skipped == []
+
+
+def test_no_sink_offered_means_no_crash(lint, world):
+    """Every existing caller passes no `skipped=` — they must keep working."""
+    home, repo = world
+    assert lint.check_pairs([ABSENT, PRESENT], repo, home, "pro") == []
+
+
+# ── the exit code must not move ──────────────────────────────────────────────
+def test_a_skipped_pair_never_changes_the_verdict(lint, world):
+    """A diagnostic that can fail a build is not a diagnostic.
+
+    Guilt and innocence both land on `breaches`, because that is what the exit
+    code is computed from: skipped pairs contribute nothing to it, in either
+    direction.
+    """
+    home, repo = world
+    skipped: list[str] = []
+    assert lint.check_pairs([ABSENT], repo, home, "pro", skipped=skipped) == []
+    assert skipped, "…and yet it was reported"
+
+    # A real divergence still breaches, with a skipped pair alongside it.
+    (home / "scripts" / "present.sh").write_text("#!/bin/sh\necho DRIFTED\n")
+    skipped2: list[str] = []
+    breaches = lint.check_pairs([PRESENT, ABSENT], repo, home, "pro", skipped=skipped2)
+    assert len(breaches) == 1 and "DIVERGED" in breaches[0]
+    assert len(skipped2) == 1
+
+
+def test_missing_repo_twin_is_still_a_breach_not_a_skip(lint, world):
+    """The absent side decides which it is: live absent = skip, repo absent = breach."""
+    home, repo = world
+    (repo / "scripts" / "present.sh").unlink()
+    skipped: list[str] = []
+    breaches = lint.check_pairs([PRESENT], repo, home, "pro", skipped=skipped)
+    assert skipped == []
+    assert len(breaches) == 1 and "NO-REPO-TWIN" in breaches[0]


### PR DESCRIPTION
Closes the gap ledgered in #3679, and the diagnostic found three more on its first run.

## The gap

`check_pairs` skips any declared pair whose live copy is absent — correctly, since nothing
can drift when nothing is running. The skip was **silent**.

Measured on the Pro minutes after #3671 merged: `--check` printed `109 declared pair(s) ...
clean` with RC=0, while never evaluating five of them — including **both files that PR
existed to promote**, whose live copies had been moved to an attic hours earlier. The
verdict was true. The conclusion a reader draws from it was not.

## After

```
[check] 109 declared pair(s), machine=pro
  clean — 83 live copy/copies match their repo twin
  5 pair(s) NOT checked — live copy absent on this machine (showing 5 of 5):
    ? ~/.fly/bin/fly_pg_tunnel_supervisor.sh (declared for pro, not on disk)
    ? ~/.nuzantara-cron/agent_worktree_cleanup_cron.sh (declared for pro, not on disk)
    ? ~/.nuzantara-cron/verify_connectome_run.sh (declared for pro, not on disk)
    ? ~/scripts/wa-mirror-launcher/api_server.py (declared for pro, not on disk)
    ? ~/scripts/wa-mirror-launcher/nuzantara_control_center.html (declared for pro, not on disk)
```

83, not 109 — the clean line now says how many were actually verified. **The exit code is
untouched**, asserted by a test: a diagnostic that can fail a build is not a diagnostic.

A pair scoped to another machine stays silent. That is legitimate non-applicability, not a
blind spot, and reporting it would bury the signal in fleet-wide noise on every run — it is
the innocence case, and the mutation that removes the distinction goes red.

## What it found beyond the two it was written for

Three stale declarations nobody knew were stale. I checked each rather than assuming a dead
cron, and **none is at risk today**:

| declared live path | what launchd actually runs | state |
|---|---|---|
| `~/.nuzantara-cron/verify_connectome_run.sh` | `~/nuzantara-deploy/scripts/…` | on main at `2ae9c09e7`, 0 behind, byte-identical; ran today 07:30 with real output |
| `~/.nuzantara-cron/agent_worktree_cleanup_cron.sh` | `~/nuzantara/scripts/…` (the checkout) | exists |
| `~/.fly/bin/fly_pg_tunnel_supervisor.sh` | nothing — 0 invocations | fully stale |

So three guards were watching phantom paths while reading as coverage. Ledgered rather than
deleted here: removing a declaration is a judgement about what *should* be guarded, not a
diagnostic fix.

Two corrections to my own first reading, both caught before they reached this description:
`~/nuzantara-deploy` **exists** (I had read a missing dir into the W81 pattern), and the
cleanup plist is **valid** — `plutil -lint` says OK; it was my Python 3.9 `plistlib` that
choked, the probe measuring its own limitation rather than the file.

## Mutation

| mutation | result |
|---|---|
| cure removed (skip silent again) | 4 failed |
| report other machines' pairs too (the over-match twin) | 1 failed |
| make a skipped pair a breach (exit code moves) | 3 failed |

Armed in `immune-enforcement.yml` beside its siblings — in the path filter **and** the
runner list, because a test named only in a filter runs nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)