### PR TITLE
feat(wa-mirror): alarm on per-line mirror silence, because a green PID is not a live session

### DIFF
--- a/scripts/tests/test_wa_session_liveness.py
+++ b/scripts/tests/test_wa_session_liveness.py
@@ -1,0 +1,183 @@
+"""Tests per scripts/wa_session_liveness.py.
+
+Ogni cosa che questo organo afferma deve avere il suo test di COLPEVOLEZZA e
+il suo test di INNOCENZA: un guardiano senza il secondo e un allarme che urla,
+uno senza il primo e un allarme decorativo. Piu una terza famiglia che qui e
+la piu importante: **non-ho-potuto-guardare non e "va tutto bene"**.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_MODULE_PATH = Path(__file__).parents[1] / "wa_session_liveness.py"
+NOW = datetime(2026, 8, 6, 12, 0, tzinfo=timezone.utc)
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("wa_session_liveness", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+wa = _load()
+
+
+# --------------------------------------------------------------------- classify
+
+
+def test_guilt_a_line_silent_past_the_threshold_is_stale() -> None:
+    """Il caso vero: vino, ferma 10 giorni, che nessuno aveva visto."""
+    status = wa.classify("vino", NOW - timedelta(days=10), NOW)
+    assert status.status == wa.STALE
+    assert status.hours_silent == pytest.approx(240.0)
+
+
+def test_innocence_a_line_quiet_over_a_weekend_is_not_stale() -> None:
+    """48h di silenzio esiste in natura: misurato sui 60 giorni precedenti.
+
+    Senza questo test la soglia potrebbe scendere a 24h e l'organo urlerebbe
+    ogni lunedi, che e il modo piu rapido per non essere piu letto.
+    """
+    assert wa.classify("asya", NOW - timedelta(hours=47.5), NOW).status == wa.OK
+
+
+def test_the_threshold_boundary_is_inclusive() -> None:
+    assert wa.classify("x", NOW - timedelta(hours=72), NOW).status == wa.STALE
+    assert wa.classify("x", NOW - timedelta(hours=71.9), NOW).status == wa.OK
+
+
+def test_a_line_that_never_mirrored_anything_is_stale_not_ok() -> None:
+    """Nessun dato non e salute: una sessione mai funzionante va vista."""
+    status = wa.classify("nuovo", None, NOW)
+    assert status.status == wa.STALE
+    assert status.hours_silent is None
+
+
+def test_the_threshold_is_configurable_and_actually_used() -> None:
+    silent = NOW - timedelta(hours=50)
+    assert wa.classify("x", silent, NOW, stale_hours=72).status == wa.OK
+    assert wa.classify("x", silent, NOW, stale_hours=48).status == wa.STALE
+
+
+# ------------------------------------------------------------------- boundary
+
+
+def test_the_alert_never_contains_a_phone_number() -> None:
+    """Law 2: un numero di telefono non entra in un messaggio Telegram."""
+    stale = [wa.classify("ari", NOW - timedelta(days=8), NOW)]
+    message = wa.format_alert(stale, "Nuzantara", 72)
+    assert "ari" in message
+    assert not any(chunk.isdigit() and len(chunk) > 8 for chunk in message.split())
+    assert "628" not in message
+
+
+def test_the_alert_says_the_pid_is_not_the_proof() -> None:
+    """Il messaggio deve portare la lezione, non solo il fatto: chi lo legge
+    andrebbe a guardare `ps` e lo troverebbe verde."""
+    message = wa.format_alert([wa.classify("vino", None, NOW)], "Nuzantara", 72)
+    assert "PID" in message
+    assert "re-pair" in message
+
+
+# --------------------------------------------------- CANNOT-VERIFY (la parte critica)
+
+
+def test_missing_accounts_file_is_cannot_verify_not_clean(tmp_path: Path) -> None:
+    with pytest.raises(wa.CannotVerify):
+        wa.read_active_lines(tmp_path / "non-esiste.json")
+
+
+def test_accounts_file_without_any_e164_is_cannot_verify(tmp_path: Path) -> None:
+    """Zero linee sorvegliate NON e 'zero problemi' — e cecita (W84)."""
+    path = tmp_path / "acc.json"
+    path.write_text(json.dumps({"accounts": [{"name": "Ari"}]}))
+    with pytest.raises(wa.CannotVerify):
+        wa.read_active_lines(path)
+
+
+def test_accounts_file_is_parsed_when_it_is_well_formed(tmp_path: Path) -> None:
+    """INNOCENZA del test sopra: un file valido non deve alzare."""
+    path = tmp_path / "acc.json"
+    path.write_text(json.dumps({"accounts": [{"name": "Ari", "e164": "+628213454721"}]}))
+    assert wa.read_active_lines(path) == {"Ari": "628213454721"}
+
+
+def test_missing_dsn_is_cannot_verify(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(wa.DSN_VAR, raising=False)
+    empty = tmp_path / "secrets.env"
+    empty.write_text("ALTRA_COSA=1\n")
+    with pytest.raises(wa.CannotVerify):
+        wa.read_dsn(empty)
+
+
+def test_dsn_is_read_when_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(wa.DSN_VAR, raising=False)
+    path = tmp_path / "secrets.env"
+    path.write_text(f'ALTRA=1\n{wa.DSN_VAR}="postgres://u@127.0.0.1/db"\n')
+    assert wa.read_dsn(path) == "postgres://u@127.0.0.1/db"
+
+
+def test_main_exits_2_and_says_so_when_it_could_not_look(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Il ramo piu importante: un DB irraggiungibile NON deve stampare 7 linee
+    verdi. Questo e il difetto che ha lasciato due sessioni morte per giorni.
+    """
+    def boom(_hours):
+        raise wa.CannotVerify("query mirror fallita (ConnectionError)")
+
+    monkeypatch.setattr(wa, "run", boom)
+    rc = main_rc = wa.main(["--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == wa.EXIT_CANNOT_VERIFY == 2
+    assert payload["lines"] == []
+    assert "cannot_verify" in payload
+    assert main_rc != wa.EXIT_OK
+
+
+def test_main_exits_0_when_it_could_look(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """INNOCENZA del test sopra, stesso meccanismo: senza questo, un `run` che
+    alza SEMPRE farebbe passare il test di sopra per la ragione sbagliata."""
+    monkeypatch.setattr(
+        wa, "run", lambda _h: [wa.classify("ari", NOW, NOW)]
+    )
+    rc = wa.main(["--json", "--no-alert"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == wa.EXIT_OK
+    assert payload["stale"] == 0
+    assert len(payload["lines"]) == 1
+
+
+def test_stale_lines_still_exit_0_because_the_verdict_travels_by_alert(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Un cron chiamante non deve fallire perche una linea e ferma: il 2 resta
+    riservato al non-ho-visto, altrimenti i due casi diventano indistinguibili."""
+    monkeypatch.setattr(
+        wa, "run", lambda _h: [wa.classify("vino", NOW - timedelta(days=10), NOW)]
+    )
+    rc = wa.main(["--json", "--no-alert"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == wa.EXIT_OK
+    assert payload["stale"] == 1
+
+
+def test_selftest_passes_on_a_healthy_organ(capsys: pytest.CaptureFixture) -> None:
+    assert wa.selftest() == wa.EXIT_OK
+    assert "OK" in capsys.readouterr().out

--- a/scripts/wa_session_liveness.py
+++ b/scripts/wa_session_liveness.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""wa_session_liveness.py — dice quando una linea wa-mirror ha smesso di catturare.
+
+WHY (2026-08-06): una sessione WhatsApp revocata NON ha nessun guardiano. Il
+processo resta `already running`, il PID è vivo, launchd è verde — e la linea
+non registra piu una riga. Misurato quel giorno: **due linee su sette erano
+morte**, Ari da 8 giorni e vino da 10, e nessun segnale e mai partito. Ari e
+stata scoperta solo perche il CTA dei lead le puntava contro; vino non
+l'avrebbe trovata nessuno. Il PID non e la prova: la riga scritta si.
+
+COSA MISURA — il LAVORO, non lo stato:
+  `max(message_date)` per linea su `whatsapp_message_context`, cioe l'ultima
+  volta che quella linea ha effettivamente mirrorato qualcosa. NON legge
+  `whatsapp_team_sessions`: quella tabella registra le TRANSIZIONI, e leggerne
+  una riga storica come stato corrente e gia costato una diagnosi sbagliata
+  (contro-ritrattazione del 6/8 nel memo deeplink). E non legge nemmeno il
+  process table: e li che nasce l'illusione.
+
+SOGLIA — misurata, non inventata. Sui 60 giorni precedenti, per le 7 linee
+vive: p50 fra due messaggi = 0.01h, p95 = 0.2-0.6h, e i silenzi naturali piu
+lunghi (weekend/festivi) arrivano a ~48h. Tutto cio che superava 72h nel
+campione erano periodi di morte veri — inclusi due che nessuno aveva notato
+(198h su una linea, 81h su un'altra). 72h separa le due popolazioni con
+margine su entrambi i lati.
+
+COSA DICE E COSA NON DICE: riporta un FATTO — "questa linea non mirrora da N
+ore" — non una diagnosi. Le cause possibili sono la sessione revocata (serve
+re-pair QR, gesto fisico) oppure una linea legittimamente ferma. Distinguerle
+richiede il telefono in mano; l'allarme porta fin li e si ferma.
+
+FAIL-VISIBLE (W84/W106b): se il file account manca, il DSN manca, il driver
+manca o il DB non risponde, questo organo esce **2 = CANNOT-VERIFY** e lo dice.
+Non ha una modalita "sembra tutto a posto" quando non ha potuto guardare: e
+esattamente il modo in cui un guardiano diventa decorativo.
+
+BOUNDARY (Law 2 / scar #4): non stampa MAI un numero di telefono, ne in stdout
+ne nell'alert ne nel JSON — solo il NOME dell'account. Non legge il contenuto
+dei messaggi: solo il timestamp piu recente.
+
+USO:
+  wa_session_liveness.py                 # misura, alert se serve
+  wa_session_liveness.py --json          # machine-readable, nessun alert
+  wa_session_liveness.py --no-alert      # dry-run
+  wa_session_liveness.py --hours 48      # soglia diversa
+  wa_session_liveness.py --selftest      # verifica che l'organo stesso sia sano
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional, Sequence
+
+REPO = Path(__file__).resolve().parents[1]
+
+DEFAULT_STALE_HOURS = 72
+
+ACCOUNTS_PATH = Path("~/.wa-mirror.accounts.json").expanduser()
+SECRETS_PATH = Path("~/.nuzantara-secrets.env").expanduser()
+DSN_VAR = "WA_MIRROR_DATABASE_URL"
+
+OK = "OK"
+STALE = "STALE"
+
+EXIT_OK = 0
+EXIT_CANNOT_VERIFY = 2
+
+
+class CannotVerify(Exception):
+    """Non ho potuto guardare. Non e la stessa cosa di 'va tutto bene'."""
+
+
+@dataclass(frozen=True)
+class LineStatus:
+    name: str
+    status: str
+    hours_silent: Optional[float]
+    last_seen: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Logica pura — nessun I/O, ed e qui che vivono i test
+# ---------------------------------------------------------------------------
+
+
+def classify(
+    name: str,
+    last_seen: Optional[datetime],
+    now: datetime,
+    stale_hours: float = DEFAULT_STALE_HOURS,
+) -> LineStatus:
+    """Una linea senza NESSUNA riga e STALE, non OK.
+
+    Il caso `last_seen is None` e quello di una linea appena aggiunta o mai
+    catturata: trattarlo come OK ("nessun dato, nessun problema") e il modo
+    piu diretto per non vedere mai una sessione che non ha mai funzionato.
+    """
+    if last_seen is None:
+        return LineStatus(name, STALE, None, None)
+    delta_h = (now - last_seen).total_seconds() / 3600.0
+    status = STALE if delta_h >= stale_hours else OK
+    return LineStatus(name, status, round(delta_h, 1), last_seen.isoformat())
+
+
+def format_alert(stale: Sequence[LineStatus], host: str, stale_hours: float) -> str:
+    """Solo NOMI: nessun numero di telefono entra in un alert (Law 2)."""
+    head = (
+        f"\U0001f4f5 wa-mirror [{host}] — {len(stale)} linea/e non mirrorano "
+        f"da oltre {stale_hours:g}h:"
+    )
+    body = []
+    for line in stale:
+        when = (
+            "mai una riga"
+            if line.hours_silent is None
+            else f"ferma da {line.hours_silent:.0f}h"
+        )
+        body.append(f"\n• {line.name}: {when}")
+    body.append(
+        "\n\nIl processo puo essere vivo lo stesso: il PID non e la prova."
+        "\nSe la sessione e revocata serve un re-pair QR (gesto fisico):"
+        "\n  apps/wa-mirror/scripts/start-one.sh <nome>  → scansione dal telefono"
+    )
+    return head + "".join(body)
+
+
+# ---------------------------------------------------------------------------
+# I/O — ogni ramo che non puo vedere ALZA, non ritorna un vuoto
+# ---------------------------------------------------------------------------
+
+
+def read_active_lines(path: Path = ACCOUNTS_PATH) -> dict:
+    """{nome: e164} dagli account wa-mirror. Il file E la fonte di verita su
+    chi e attivo: un ex-membro sparisce da qui e smette di essere sorvegliato.
+    """
+    try:
+        raw = json.loads(path.read_text())
+    except OSError as exc:
+        raise CannotVerify(f"account file illeggibile ({type(exc).__name__})") from exc
+    except json.JSONDecodeError as exc:
+        raise CannotVerify("account file non e JSON valido") from exc
+
+    items = raw if isinstance(raw, list) else raw.get("accounts", raw)
+    if isinstance(items, dict):
+        items = [
+            dict(v, name=k) if isinstance(v, dict) else {"name": k}
+            for k, v in items.items()
+        ]
+    lines = {}
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        number = (entry.get("e164") or entry.get("phone") or entry.get("number") or "")
+        number = str(number).lstrip("+")
+        name = entry.get("name") or entry.get("label")
+        if number and name:
+            lines[str(name)] = number
+    if not lines:
+        raise CannotVerify("nessun account con E.164 nel file: non c'e niente da sorvegliare")
+    return lines
+
+
+def read_dsn(path: Path = SECRETS_PATH, var: str = DSN_VAR) -> str:
+    """Legge SOLO la riga del DSN. Il file non viene mai stampato ne loggato."""
+    env = os.environ.get(var)
+    if env:
+        return env
+    try:
+        with path.open() as handle:
+            for line in handle:
+                if line.startswith(f"{var}="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError as exc:
+        raise CannotVerify(f"secrets file illeggibile ({type(exc).__name__})") from exc
+    raise CannotVerify(f"{var} assente: il mirror locale non e configurato qui")
+
+
+def fetch_last_seen(dsn: str, lines: dict) -> dict:
+    """{nome: datetime|None}. Un errore di connessione ALZA CannotVerify."""
+    try:
+        import asyncpg  # noqa: PLC0415 — import tardivo: assente = CANNOT-VERIFY
+    except ImportError as exc:
+        raise CannotVerify("driver asyncpg assente in questo interprete") from exc
+    import asyncio
+
+    query = (
+        "select max(coalesce(message_date, created_at)) "
+        "from whatsapp_message_context "
+        "where regexp_replace(coalesce(team_member_phone,''),'[^0-9]','','g') "
+        "like '%'||$1||'%'"
+    )
+
+    async def _run() -> dict:
+        conn = await asyncpg.connect(dsn)
+        try:
+            return {name: await conn.fetchval(query, num) for name, num in lines.items()}
+        finally:
+            await conn.close()
+
+    try:
+        return asyncio.run(_run())
+    except Exception as exc:  # noqa: BLE001 — qualunque guaio DB = non ho visto
+        raise CannotVerify(f"query mirror fallita ({type(exc).__name__})") from exc
+
+
+def hostname() -> str:
+    return socket.gethostname().split(".")[0]
+
+
+def emit_alert(stale: Sequence[LineStatus], host: str, stale_hours: float) -> bool:
+    """Stessa catena degli altri sentinel: alerter (dedup) → tg_notify."""
+    if not stale:
+        return False
+    message = format_alert(stale, host, stale_hours)
+    try:
+        sys.path.insert(0, str(REPO / "scripts"))
+        from sentinel_lib import alerter  # noqa: PLC0415
+
+        return bool(alerter.send_alert(message, level="WARNING"))
+    except Exception:  # noqa: BLE001 — fallback diretto al gateway
+        import subprocess
+
+        gateway = REPO / "scripts" / "tg_notify.py"
+        if not gateway.exists():
+            return False
+        subprocess.run(
+            [sys.executable, str(gateway), "--tier", "p0", "--source", "wa-session-liveness",
+             "--dedup-key", f"wa-session-{host}", message],
+            check=False,
+        )
+        return True
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def run(stale_hours: float) -> list[LineStatus]:
+    lines = read_active_lines()
+    dsn = read_dsn()
+    last = fetch_last_seen(dsn, lines)
+    now = datetime.now(timezone.utc)
+    return sorted(
+        (classify(name, last.get(name), now, stale_hours) for name in lines),
+        key=lambda s: (s.status != STALE, s.name),
+    )
+
+
+def selftest() -> int:
+    """Un guardiano silenzioso-quando-sano deve saper dimostrare di essere vivo."""
+    problems = []
+    now = datetime(2026, 8, 6, 12, 0, tzinfo=timezone.utc)
+    if classify("x", now - timedelta(hours=100), now).status != STALE:
+        problems.append("classify non marca STALE una linea ferma da 100h")
+    if classify("x", now - timedelta(hours=1), now).status != OK:
+        problems.append("classify non marca OK una linea fresca")
+    if classify("x", None, now).status != STALE:
+        problems.append("classify tratta 'mai vista' come sana")
+    if not (REPO / "scripts" / "tg_notify.py").exists():
+        problems.append("tg_notify.py assente: l'allarme non avrebbe dove uscire")
+    for problem in problems:
+        print(f"  ✗ {problem}")
+    print(f"selftest: {'OK' if not problems else str(len(problems)) + ' problemi'}")
+    return EXIT_OK if not problems else EXIT_CANNOT_VERIFY
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="wa-mirror line liveness guardian")
+    parser.add_argument("--json", action="store_true", help="machine-readable, nessun alert")
+    parser.add_argument("--no-alert", action="store_true", help="misura e riporta, mai Telegram")
+    parser.add_argument("--selftest", action="store_true", help="verifica l'organo stesso")
+    parser.add_argument(
+        "--hours",
+        type=float,
+        default=float(os.environ.get("WA_SESSION_STALE_HOURS", DEFAULT_STALE_HOURS)),
+        help=f"ore di silenzio oltre le quali una linea e STALE (default {DEFAULT_STALE_HOURS})",
+    )
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return selftest()
+
+    host = hostname()
+    try:
+        statuses = run(args.hours)
+    except CannotVerify as exc:
+        payload = {"host": host, "cannot_verify": str(exc), "lines": []}
+        print(json.dumps(payload) if args.json else
+              f"CANNOT-VERIFY [{host}]: {exc}\n"
+              "Non e un verdetto di salute: questo organo non ha potuto guardare.")
+        return EXIT_CANNOT_VERIFY
+
+    stale = [s for s in statuses if s.status == STALE]
+
+    if args.json:
+        print(json.dumps({"host": host, "stale_hours": args.hours,
+                          "stale": len(stale),
+                          "lines": [asdict(s) for s in statuses]}))
+    else:
+        print(f"wa-mirror liveness [{host}] — soglia {args.hours:g}h")
+        for line in statuses:
+            icon = "🔴" if line.status == STALE else "🟢"
+            when = "mai una riga" if line.hours_silent is None else f"{line.hours_silent:.1f}h fa"
+            print(f"  {icon} {line.name:<10} {line.status:<5} ultima riga {when}")
+        if not args.no_alert:
+            sent = emit_alert(stale, host, args.hours)
+            print(f"\nalert: {'inviato' if sent else 'nessuno'} ({len(stale)} STALE)")
+
+    # exit 0 anche con linee STALE: il verdetto viaggia via alert, non via
+    # exit-code, come gli altri sentinel. Il 2 e riservato al non-ho-visto.
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Perché

Due sessioni wa-mirror sono morte e **nessuna sonda se n'è accorta**:

| linea | ultima riga specchiata | scoperta |
|---|---|---|
| **vino** | `2026-07-27 01:35:41 UTC` (10 giorni) | oggi, a mano, durante una passata |
| **ari** | morta 30/07 → 06/08 13:02 | oggi, dopo il re-pair QR |

Per tutto quel tempo il processo era su, il LaunchAgent caricato, `ps` verde, exit 0. Una sessione Baileys **revocata non perde il PID**: il PID prova che il launcher è partito, non che WhatsApp ci parli ancora. È superscar **#2 (esiste ≠ armato)** nella forma più cattiva — l'organo che dovrebbe accorgersene non esisteva.

## Cosa fa

Legge le linee attive da `~/.wa-mirror.accounts.json` e chiede l'unica cosa che nessuna sonda chiedeva: **quando questa linea ha scritto l'ultima riga?** — `max(coalesce(message_date, created_at))` per linea.

## Soglia 72h — misurata, non scelta

Sulla finestra specchiata: mediana **0.01h**, p95 **0.2–0.6h**, massimo silenzio naturale (weekend) **~48h**. Ogni buco >72h nel campione era una morte vera, incluso krisna a 198.8h e damar a 81.4h. A 24h avrebbe urlato ogni lunedì, che è il modo più rapido per non essere più letto.

## Scelte load-bearing

- **`exit 2` è riservato a CANNOT-VERIFY** (file accounts assente, nessun E.164, DSN assente, query fallita). Un DB irraggiungibile **non deve stampare sette linee verdi** — è esattamente la cecità che questo organo esiste per chiudere (W84). Una linea ferma esce **0**: il verdetto viaggia per allarme, e un cron che fallisce perché un collega è in ferie insegna a tutti a ignorarlo.
- **"mai vista" è STALE, non OK.** Una sessione che non ha mai funzionato è un finding.
- L'allarme porta **i nomi, mai i numeri** (Law 2) e dice a voce alta che `ps` sembrerà verde e che la cura è un **re-pair QR** — altrimenti chi legge va a guardare il PID, cioè la cosa che ha già fallito.
- **`--selftest`** prova che il gateway esiste **prima** che serva, e ritorna 2 se `tg_notify.py` non è sotto `REPO`: un organo installato dove non può allarmare lo dice invece di girare muto (W108).

## Prove

Colpevolezza **e** innocenza su ogni affermazione, più la terza famiglia che qui conta di più: *non-ho-potuto-guardare ≠ va-tutto-bene*. 16 test.

Tutte e quattro le mutazioni uccise:

| mutazione | esito |
|---|---|
| "mai vista" trattata come sana | 2 failed, 14 passed |
| soglia inefficace | 5 failed, 11 passed |
| cieco riportato come sano | 1 failed, 15 passed |
| zero linee = zero problemi | 1 failed, 15 passed |
| *ripristinato* | 16 passed |

**PROVE-LIVE su Pro prima del commit** — ha trovato vino da solo:

```
wa-mirror liveness [Nuzantara] — soglia 72h
  🔴 Vino       STALE ultima riga 246.6h fa
  🟢 Adit       OK    ultima riga 0.0h fa
  🟢 Ari        OK    ultima riga 0.0h fa
  🟢 Asya       OK    ultima riga 0.3h fa
  🟢 Damar      OK    ultima riga 0.2h fa
  🟢 Krisna     OK    ultima riga 0.3h fa
  🟢 Surya      OK    ultima riga 0.2h fa
```

## Ambito dichiarato

Questo PR **costruisce** l'organo. L'installazione del cron su Pro (e la prova che spara davvero) è il passo successivo dello stesso mandato — costruito ≠ armato, W81, e non lo dichiaro chiuso finché non ha suonato in produzione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)