### PR TITLE
fix(wa-attention): the masker was defeated by its own fallback, in four places

### DIFF
--- a/scripts/tests/test_wa_attention_pii_envelope.py
+++ b/scripts/tests/test_wa_attention_pii_envelope.py
@@ -1,0 +1,181 @@
+"""The masker was defeated by its own fallback, in three places.
+
+`wa-mirror-attention-telegram.py` opens by declaring its own contract:
+
+    OSINT-safe: Telegram message contains only:
+    - contact display_name + phone (last 4 digits masked)
+
+Measured against the code, that promise was false for the case the alerter
+exists to surface. Both realtime compose paths did:
+
+    display = it.get("crm_name") or f"+{phone}"
+    ...
+    f"{display} — {mask_phone(phone)}"
+
+For a contact the CRM does not know — a NEW LEAD — `display` fell back to the
+FULL number, and the masked form was printed right beside it:
+
+    +6281312415572 — +6281****5572
+
+The masking was never bypassed. It was made pointless by a fallback standing
+next to it. The digest path had the same defect and worse: no `mask_phone()`
+alongside at all, so the raw number was the ONLY rendering — in a mode whose
+docstring says "Always sends", twice a day. And `mask_phone` itself returned
+`f"+{phone}"` for anything shorter than 6 digits: the one function whose job is
+not to emit a bare number emitted one, from inside its own guard clause.
+
+Why the digest site survived the first pass, recorded because it is the
+reusable part: the census grepped for the FORM of the line already found
+(`display`, `phone`). The digest says `name` and `it['phone']`. A pattern
+written from the instance you found catches the instance you found (W113). It
+took an AST sweep — every f-string that renders anything named `phone` — to see
+all four, and that sweep is now a test, so the next site cannot hide behind a
+different variable name.
+
+UU PDP Art. 67-68 / SYMBIOSIS Law 2. The severity here does not rest on a
+reading of the law: the file's own docstring already promised masking, so this
+is a breach of a declared contract, not a judgement call.
+
+NOT changed, and deliberately so: the client's CRM `full_name` still appears.
+That is the alerter's whole purpose — an alert that cannot say WHO needs
+attention is not an alert — and narrowing it is a business call (Legge 5), not
+a defect to fix unilaterally.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "scripts" / "wa-mirror-attention-telegram.py"
+
+
+@pytest.fixture(scope="module")
+def wa(tmp_path_factory):
+    """Import the hyphenated script by path, in a throwaway world.
+
+    HOME is redirected before the import because this module does real work at
+    import time: it reads ~/.wa-mirror.env and mkdirs ~/.cache for its state
+    file. A test must never touch production state (W96), and here that is not
+    theoretical — the state file it would create is the live 4h dedup ledger.
+
+    WA_MIRROR_DATABASE_URL is a throwaway string. Nothing in this corpus opens
+    a connection; the variable exists only because the module exits at import
+    without it. That exit, plus a config reader that consulted only the env
+    FILE, is exactly why this file had no tests until now.
+    """
+    home = tmp_path_factory.mktemp("home")
+    prev = {k: os.environ.get(k) for k in ("HOME", "WA_MIRROR_DATABASE_URL")}
+    os.environ["HOME"] = str(home)
+    os.environ["WA_MIRROR_DATABASE_URL"] = "postgresql://test/none"
+    try:
+        spec = importlib.util.spec_from_file_location("wa_attention", SRC)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["wa_attention"] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except ImportError as exc:  # asyncpg absent on a bare runner
+            pytest.skip(f"dependency missing: {exc}")
+        assert Path(mod.STATE_PATH).is_relative_to(home), (
+            f"the import escaped the throwaway HOME: {mod.STATE_PATH}")
+        yield mod
+    finally:
+        for k, v in prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# --------------------------------------------------------------------- guilt
+def test_a_contact_the_crm_does_not_know_is_never_rendered_in_the_clear(wa):
+    """THE defect, verbatim: a new lead has no crm_name, and that is exactly
+    the contact this alerter is for."""
+    label = wa.contact_label({"phone": "6281312415572", "crm_name": None, "crm_id": None})
+    assert "6281312415572" not in label, f"the full number reached the alert: {label}"
+    assert "****" in label, f"nothing was masked: {label}"
+
+
+def test_a_short_number_is_masked_more_not_less(wa):
+    """`mask_phone` returned the whole string when it was too short to apply
+    prefix(4)+suffix(4) — the masker leaking from inside its own guard."""
+    out = wa.mask_phone("12345")
+    assert "12345" not in out, f"a short number came back in the clear: {out}"
+    assert wa.mask_phone("") == "+?"
+
+
+def test_the_realtime_alert_never_carries_a_full_number(wa):
+    """End-to-end through the real composer, single-contact AND roster: the
+    two branches are separate code paths and the leak lived in both."""
+    lead = {"phone": "6281312415572", "crm_name": None, "crm_id": None,
+            "n_high": 2, "reasons": ["refund"]}
+    known = {"phone": "6289988776655", "crm_name": "Test Client", "crm_id": 11580,
+             "n_high": 1, "reasons": ["deadline"]}
+    single = wa._compose_realtime_alert([("k1", lead, ["refund"])])
+    roster = wa._compose_realtime_alert(
+        [("k1", lead, ["refund"]), ("k2", known, ["deadline"])])
+    for name, msg in (("single", single), ("roster", roster)):
+        assert "6281312415572" not in msg, f"{name} branch leaked the full number:\n{msg}"
+        assert "6289988776655" not in msg, f"{name} branch leaked the full number:\n{msg}"
+
+
+def test_every_fstring_that_renders_a_phone_goes_through_a_masker(wa):
+    """The sweep that found the digest site, kept as the guard.
+
+    Grepping for the line shape that had already been found could only ever
+    re-find it. This walks the AST instead and asks a question about the
+    ENTITY: does anything named `phone` reach an f-string without passing a
+    masker? The one permitted exception is the LOCAL 4h dedup state key, which
+    never leaves the machine — Law 2 draws the line at output, not at local
+    processing, and that boundary is declared in the source.
+    """
+    allowed = ("mask", "contact_label", "distinct_phones", "phone[:4]", "phone[-4:]")
+    offenders = []
+    for node in ast.walk(ast.parse(SRC.read_text())):
+        if not isinstance(node, ast.JoinedStr):
+            continue
+        for value in node.values:
+            if not isinstance(value, ast.FormattedValue):
+                continue
+            rendered = ast.unparse(value.value)
+            if "phone" in rendered and not any(a in rendered for a in allowed):
+                offenders.append((node.lineno, rendered))
+    # line 228-ish: the local state key, declared in the source as deliberate.
+    local_state = [o for o in offenders if o[1] == "phone"]
+    leaks = [o for o in offenders if o not in local_state]
+    assert not leaks, f"an unmasked phone reaches a message: {leaks}"
+    assert len(local_state) == 1, (
+        f"the local-state exception moved or multiplied: {local_state}")
+
+
+# ----------------------------------------------------------------- innocence
+def test_a_known_client_is_still_named(wa):
+    """INNOCENCE, and it is the point of the whole organ: an alert that cannot
+    say WHO needs attention is not an alert. Masking the phone must not turn
+    the roster into a list of anonymous stubs."""
+    label = wa.contact_label({"phone": "6289988776655", "crm_name": "Test Client",
+                              "crm_id": 11580})
+    assert label.startswith("Test Client"), f"the client stopped being named: {label}"
+    assert "6655" in label, "the last-4 tail is the operator's handle — keep it"
+
+
+def test_the_masked_tail_still_identifies_the_contact(wa):
+    """INNOCENCE: two different numbers must still LOOK different after
+    masking, or the operator cannot tell two unnamed leads apart and the fix
+    has traded a privacy defect for a usability one."""
+    a = wa.contact_label({"phone": "6281312415572", "crm_name": None})
+    b = wa.contact_label({"phone": "6281399990000", "crm_name": None})
+    assert a != b, "two distinct leads collapsed into one indistinguishable label"
+
+
+def test_the_header_promise_matches_the_code(wa):
+    """The docstring is the contract this file is judged against, so it must
+    not drift back into describing behaviour the code no longer has."""
+    head = SRC.read_text().split('"""')[1]
+    assert "masked" in head, "the file stopped promising masking"

--- a/scripts/wa-mirror-attention-telegram.py
+++ b/scripts/wa-mirror-attention-telegram.py
@@ -34,7 +34,22 @@ ENV_FILE = Path.home() / ".wa-mirror.env"
 
 
 def read_env_file(path: Path) -> dict[str, str]:
+    """Missing file = empty config, not an import-time crash.
+
+    This used to be a bare `path.read_text()`, so importing this module on any
+    machine without ~/.wa-mirror.env raised FileNotFoundError before a single
+    line of logic ran. That is why this file had NO test corpus and why a PII
+    leak sat in it unreviewed: the module could not be imported to be examined
+    except on the one host that happens to have the file.
+
+    Degrading is safe here because every consumer already has a fallback:
+    DASHBOARD_URL goes through first_nonempty() to a literal default, and
+    DB_URL being None fails loudly at the asyncpg call — a clear "no database
+    configured" instead of a stack trace at line 38 of an import.
+    """
     values: dict[str, str] = {}
+    if not path.is_file():
+        return values
     for raw_line in path.read_text().splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
@@ -52,7 +67,16 @@ def first_nonempty(*values: str | None) -> str:
 
 
 ENV_VALUES = read_env_file(ENV_FILE)
-DB_URL = ENV_VALUES.get("WA_MIRROR_DATABASE_URL")
+# os.environ FIRST, matching how DASHBOARD_URL is already resolved below. Only
+# the env FILE was consulted here, so there was no way to point this module at
+# anything but the one host's live database — which, combined with the hard
+# sys.exit(2) under it, made the module impossible to import for inspection
+# anywhere else. A file that cannot be imported cannot be reviewed, and this
+# one carried an unreviewed PII leak for a month.
+DB_URL = first_nonempty(
+    os.environ.get("WA_MIRROR_DATABASE_URL"),
+    ENV_VALUES.get("WA_MIRROR_DATABASE_URL"),
+)
 if not DB_URL:
     print("ERR: WA_MIRROR_DATABASE_URL missing", file=sys.stderr)
     sys.exit(2)
@@ -69,10 +93,42 @@ DEDUP_WINDOW = timedelta(hours=4)
 
 
 def mask_phone(phone: str) -> str:
-    """+62812****7456 — keep prefix(4) + suffix(4)."""
-    if not phone or len(phone) < 6:
-        return f"+{phone}"
+    """+62812****7456 — keep prefix(4) + suffix(4).
+
+    A number too SHORT for that rule gets masked MORE, not less. The previous
+    branch returned `f"+{phone}"` — the whole thing, in the clear, out of
+    the function whose only job is not to do that. The masker was defeated by
+    its own fallback, which is the same defect its callers had.
+    """
+    if not phone:
+        return "+?"
+    if len(phone) < 6:
+        return "+" + "*" * len(phone)
     return f"+{phone[:4]}****{phone[-4:]}"
+
+
+def contact_label(item: dict) -> str:
+    """How a contact is NAMED in an alert. One rule, one place.
+
+    Both compose paths (single contact / roster) inlined
+    `display = crm_name or f"+{phone}"` and then printed `mask_phone(phone)`
+    right after it. For a contact the CRM does not know — a NEW LEAD, i.e.
+    exactly the case this alerter exists to surface — that rendered the FULL
+    number and its masked form side by side:
+
+        +6281312415572 — +6281****5572
+
+    The masking was not bypassed; it was made pointless by the fallback
+    standing next to it. This file's own docstring already promised "phone
+    (last 4 digits masked)", so the leak breached its declared contract — it
+    is not a judgement call (UU PDP Art. 67-68 / SYMBIOSIS Law 2).
+
+    Two writers of one field means the rule lives in ONE function, so a third
+    call site cannot reintroduce the leak by copying the old inline form.
+    """
+    masked = mask_phone(item.get("phone") or "")
+    name = item.get("crm_name")
+    return f"{name} — {masked}" if name else masked
 
 
 def send_telegram(text: str, tier: str = "p0", dedup_key: str = "") -> bool:
@@ -193,6 +249,13 @@ async def cmd_realtime(force: bool = False):
         if not critical:
             continue
         phone = it["phone"]
+        # DELIBERATE, not an oversight: this key is the LOCAL 4h dedup state in
+        # ~/.cache/wa-mirror-attention-state.json. It never reaches Telegram and
+        # never reaches the gateway spool — the wire key is the sha256 set
+        # signature below. CLAUDE.md §14 / SYMBIOSIS Law 2 draw the line at
+        # OUTPUT, not at local processing: "il processing PII resta
+        # locale-sovrano sul Pro". Recorded here so the next reader can tell a
+        # considered boundary from a missed one.
         key = f"{phone}:{sorted(critical)[0]}"
         last_ts_str = last_alerted.get(key)
         if last_ts_str and not force:
@@ -232,23 +295,19 @@ def _compose_realtime_alert(due: list) -> str:
     """
     if len(due) == 1:
         _, it, critical = due[0]
-        phone = it["phone"]
-        display = it.get("crm_name") or f"+{phone}"
         crm_tag = f"CRM #{it['crm_id']}" if it["crm_id"] else "new lead"
         return (
             "🚨 HIGH attention\n"
-            f"{display} — {mask_phone(phone)}\n"
+            f"{contact_label(it)}\n"
             f"{crm_tag} · {it['n_high']} unresolved msg\n"
             f"Reasons: {', '.join(critical)}\n"
             f"→ {DASHBOARD_URL}"
         )
     lines = [f"🚨 HIGH attention — {len(due)} contacts"]
     for _, it, critical in due:
-        phone = it["phone"]
-        display = it.get("crm_name") or f"+{phone}"
         crm_tag = f"CRM #{it['crm_id']}" if it["crm_id"] else "new lead"
         lines.append(
-            f"• {display} — {mask_phone(phone)}\n"
+            f"• {contact_label(it)}\n"
             f"  {crm_tag} · {it['n_high']} unresolved · {', '.join(critical)}"
         )
     lines.append(f"→ {DASHBOARD_URL}")
@@ -279,7 +338,15 @@ async def cmd_digest():
         lines.append("")
         lines.append("🚨 Needs your attention:")
         for it in items[:8]:  # cap to 8 to keep msg readable
-            name = it.get("crm_name") or f"+{it['phone']}"
+            # The digest path had the SAME leak as the realtime one and was
+            # worse: here there is no mask_phone() alongside, so for a contact
+            # the CRM does not know the raw number was the ONLY rendering — and
+            # this mode "always sends", twice a day. It survived the first pass
+            # because the census looked for the FORM of the line already found
+            # (`display` / `phone`); this one says `name` / `it['phone']`.
+            # A pattern written from the instance you found catches the
+            # instance you found.
+            name = contact_label(it)
             crm_marker = "" if it["crm_id"] else " (new lead)"
             crit = [r for r in (it["reasons"] or []) if r in CRITICAL_REASONS]
             unanswered = "unanswered_thread_3plus" in (it["reasons"] or [])


### PR DESCRIPTION
## What was wrong

The file opens by declaring its own contract:

> OSINT-safe: Telegram message contains only:
> - contact display_name + phone (last 4 digits masked)

That promise was false for the one case this alerter exists to surface. Both realtime compose paths did `display = crm_name or f"+{phone}"` and then printed `mask_phone(phone)` beside it, so a contact the CRM does not know — a **new lead** — rendered as:

```
+6281312415572 — +6281****5572
```

The masking was never bypassed. It was made **pointless by a fallback standing next to it**.

Four sites, one rule:

| Site | Defect |
|---|---|
| `_compose_realtime_alert` single | raw number beside its own masked form |
| `_compose_realtime_alert` roster | same |
| digest path | **worse** — no `mask_phone()` alongside at all, raw number is the ONLY rendering, in a mode whose docstring says "Always sends", twice a day |
| `mask_phone` itself | returned `f"+{phone}"` for anything under 6 digits — the one function whose job is not to emit a bare number, emitting one from inside its own guard clause |

Fixed by giving the rule ONE home (`contact_label`), so a fourth call site cannot reintroduce it by copying the old inline form.

## Why the digest site survived the first pass

Recorded because it is the reusable part: the census grepped for the **form of the line already found** (`display`, `phone`). The digest says `name` and `it['phone']`. A pattern written from the instance you found catches the instance you found (W113). An AST sweep over every f-string that renders anything named `phone` found all four — and that sweep is now a test, so the next site cannot hide behind a different variable name.

## Two enabling defects — why this sat unreviewed for a month

`read_env_file` did a bare `read_text()`, and `DB_URL` consulted only the env FILE and then `sys.exit(2)`. Importing this module was therefore impossible on any machine but the one host that has `~/.wa-mirror.env`. **A file that cannot be imported cannot be tested**, and it had no test corpus at all. Both now degrade the way the file's own `DASHBOARD_URL` already did.

## Measured, not assumed

The raw phone numbers observed in gateway dedup keys (`wa-attention:6281…:deadline`, 560 spool rows) **stop on 2026-07-26** — the day the grouping fix replaced them with a sha256 set signature. That leak is already cured; the rows remain on disk, local-only.

The per-contact 4h state key still carries the phone and **stays**: it never leaves the machine, and Law 2 draws the line at output, not at local processing (`CLAUDE.md` §14: *"il processing PII resta locale-sovrano sul Pro"*). Declared in the source so the next reader can tell a considered boundary from a missed one.

## Not changed, deliberately

The client's CRM `full_name` still appears. An alert that cannot say WHO needs attention is not an alert, and narrowing that is a business call (Legge 5), not a defect to fix unilaterally.

## Verification

- 7 tests, guilt + innocence (innocence matters here: masking must not turn the roster into indistinguishable stubs)
- Mutation set **8/8 killed**
- Sealed against W96 — HOME is redirected before import, because this module mkdirs its live 4h dedup state file at import time

🤖 Generated with [Claude Code](https://claude.com/claude-code)