### PR TITLE
fix(tg-gateway): the spool has three writers and only one made its files private

### DIFF
--- a/scripts/tests/test_spool_is_private.py
+++ b/scripts/tests/test_spool_is_private.py
@@ -126,14 +126,21 @@ def test_a_brand_new_archive_file_is_born_private(spool):
 def test_an_existing_loose_file_is_repaired(spool):
     """33 days of 0644 archives are already on Pro. The fix must heal them on
     the next write, not only protect what it creates — otherwise the exposure
-    survives the cure and needs a separate repair pass nobody will run."""
-    from tg_notify import harden
+    survives the cure and needs a separate repair pass nobody will run.
+
+    The loose file is made the way the REAL ones were made — an ordinary write
+    under the 0022 umask, not an explicit chmod. That is both truer to the
+    trauma and avoids planting a world-readable literal in the corpus. The
+    setup assertion is load-bearing: if the umask ever stopped producing 0644
+    this test would otherwise pass while measuring nothing (W108).
+    """
+    import tg_notify
 
     victim = spool / "already-loose.jsonl"
     victim.write_text("{}\n")
-    os.chmod(victim, 0o644)
-    assert _group_or_other_readable(victim), "setup failed: the file is not loose"
-    harden(victim)
+    assert _group_or_other_readable(victim), (
+        f"setup failed: born {_mode(victim)}, not loose — nothing was measured")
+    tg_notify.harden(victim)
     assert not _group_or_other_readable(victim), f"still {_mode(victim)}"
 
 
@@ -157,11 +164,11 @@ def test_harden_does_not_truncate(spool):
     """INNOCENCE: harden() opens the file to create it privately. O_CREAT
     without O_TRUNC — if that ever became O_TRUNC the spool would be silently
     emptied on every append, which is worse than the leak it fixes."""
-    from tg_notify import harden
+    import tg_notify
 
     f = spool / "has-content.jsonl"
     f.write_text('{"a": 1}\n{"b": 2}\n')
-    harden(f)
+    tg_notify.harden(f)
     assert f.read_text() == '{"a": 1}\n{"b": 2}\n', "harden() ate the spool"
 
 

--- a/scripts/tests/test_spool_is_private.py
+++ b/scripts/tests/test_spool_is_private.py
@@ -1,0 +1,183 @@
+"""The spool has three writers and only one applied the restriction.
+
+Measured on Pro, 2026-08-06:
+
+    archive-p0.jsonl        -rw-------    written by tg_notify._append
+    state.json              -rw-r--r--    written by tg_notify._save_state
+    archive/2026-*.jsonl    -rw-r--r--    written by tg_digest_flush._archive
+                                          1.6 MB, 33 days, EVERY event
+
+`_append` opens with `0o600` and the flock file is `0o600`, so the author knew
+the rule. `_save_state` used `Path.write_text` and `_archive` used `open("a")`
+— both take the umask. Superscar #4: the restriction lands where the author was
+thinking about it and is missed where a different idiom was used.
+
+The two unprotected paths are the LARGER exposure, not the smaller. state.json
+carries `last_text` — 200 characters of every alert, which for wa-attention
+includes a client's name. The daily archive is the complete record and still
+holds 560 rows whose dedup key carries a raw client phone number, from before
+the 2026-07-26 grouping fix replaced it with a set signature.
+
+The cure carried the shape of the disease and this corpus is why that was
+caught: the first version of `harden()` only chmod'd, so it repaired files that
+already existed and let each new day's archive be BORN 0644 under the umask via
+`open("a")`. `test_a_brand_new_archive_file_is_born_private` is that bug.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+GATEWAY = REPO / "scripts" / "tg_notify.py"
+FLUSH = REPO / "scripts" / "tg_digest_flush.py"
+
+
+def _mode(p: Path) -> str:
+    return oct(stat.S_IMODE(p.stat().st_mode))
+
+
+def _group_or_other_readable(p: Path) -> bool:
+    return bool(p.stat().st_mode & 0o077)
+
+
+@pytest.fixture
+def spool(tmp_path, monkeypatch):
+    """A throwaway spool with a PERMISSIVE umask, so a missing mode shows up.
+
+    Under a 0077 umask every file would come out 0600 by accident and the whole
+    corpus would pass against unfixed code — a test measuring the environment
+    instead of the code. 0022 is what Pro actually runs.
+    """
+    d = tmp_path / "spool"
+    d.mkdir()
+    monkeypatch.setenv("TG_SPOOL_DIR", str(d))
+    monkeypatch.setenv("TG_DRY_RUN", "1")
+    monkeypatch.setenv("TG_SECRETS_FILE", "/dev/null")
+    # Dummy credentials: the digest flush refuses to archive unless a send
+    # SUCCEEDS, and `bool(token and chat)` is checked before TG_DRY_RUN is even
+    # consulted. Without these the archive is never written and the test would
+    # be measuring its own missing config, not the file mode (W108).
+    # DRY_RUN short-circuits send_telegram before any network call; the
+    # hermeticity is asserted, not assumed, in the archive test below.
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token-never-used")
+    monkeypatch.setenv("TELEGRAM_OWNER_CHAT_ID", "0")
+    old = os.umask(0o022)
+    yield d
+    os.umask(old)
+
+
+# --------------------------------------------------------------------- guilt
+def test_every_file_the_gateway_writes_is_private(spool):
+    """One pass through the real gateway, then read the modes off disk."""
+    subprocess.run([sys.executable, str(GATEWAY), "--tier", "digest",
+                    "--source", "t", "--", "hello"], check=True,
+                   capture_output=True, env={**os.environ})
+    subprocess.run([sys.executable, str(GATEWAY), "--tier", "p0",
+                    "--source", "t", "--", "fire"], check=True,
+                   capture_output=True, env={**os.environ})
+    written = [p for p in spool.iterdir() if p.is_file()]
+    assert written, "the gateway wrote nothing — the probe measured its own setup"
+    leaky = {p.name: _mode(p) for p in written if _group_or_other_readable(p)}
+    assert not leaky, f"spool files readable beyond the owner: {leaky}"
+
+
+def test_state_json_is_private(spool):
+    """state.json is singled out because it is the one that carries CONTENT:
+    `last_text` keeps 200 characters of every alert. It was 0644 on Pro."""
+    subprocess.run([sys.executable, str(GATEWAY), "--tier", "digest",
+                    "--source", "t", "--", "x"], check=True, capture_output=True)
+    st = spool / "state.json"
+    assert st.exists(), "no state written — nothing was measured"
+    assert not _group_or_other_readable(st), f"state.json is {_mode(st)}"
+
+
+def test_a_brand_new_archive_file_is_born_private(spool):
+    """The bug THIS fix had on its first draft.
+
+    A chmod-only `harden()` repairs files that already exist. The daily archive
+    file does not exist until the first flush of the day, so `open("a")`
+    created it under the umask and it was 0644 for its whole life — every day,
+    forever, on the largest file in the spool. Protecting only what is already
+    there is not protection.
+    """
+    subprocess.run([sys.executable, str(GATEWAY), "--tier", "digest",
+                    "--source", "t", "--", "spool me"], check=True, capture_output=True)
+    r = subprocess.run([sys.executable, str(FLUSH)], capture_output=True, text=True)
+    adir = spool / "archive"
+    assert adir.is_dir(), f"nothing archived, so nothing measured: {r.stdout}{r.stderr}"
+    created = list(adir.glob("*.jsonl"))
+    assert created, f"the archive is empty: {r.stdout}{r.stderr}"
+    assert (spool / "sent-dry.jsonl").exists(), (
+        "the flush took the REAL send path — this test was not hermetic")
+    leaky = {p.name: _mode(p) for p in created if _group_or_other_readable(p)}
+    assert not leaky, f"a NEW archive file was born world-readable: {leaky}"
+
+
+def test_an_existing_loose_file_is_repaired(spool):
+    """33 days of 0644 archives are already on Pro. The fix must heal them on
+    the next write, not only protect what it creates — otherwise the exposure
+    survives the cure and needs a separate repair pass nobody will run."""
+    from tg_notify import harden
+
+    victim = spool / "already-loose.jsonl"
+    victim.write_text("{}\n")
+    os.chmod(victim, 0o644)
+    assert _group_or_other_readable(victim), "setup failed: the file is not loose"
+    harden(victim)
+    assert not _group_or_other_readable(victim), f"still {_mode(victim)}"
+
+
+# ----------------------------------------------------------------- innocence
+def test_hardening_never_takes_down_the_alert_it_carries(spool, monkeypatch):
+    """INNOCENCE, and it is the whole reason this swallows OSError: a spool the
+    process cannot chmod (foreign owner, read-only mount) must degrade, never
+    raise. An alerter that dies because it could not tidy its own permissions
+    has traded a privacy defect for a silence defect."""
+    import tg_notify
+
+    def boom(*a, **k):
+        raise PermissionError("Operation not permitted")
+
+    monkeypatch.setattr(tg_notify.os, "chmod", boom)
+    monkeypatch.setattr(tg_notify.os, "open", boom)
+    assert tg_notify.harden(spool / "whatever.jsonl") == spool / "whatever.jsonl"
+
+
+def test_harden_does_not_truncate(spool):
+    """INNOCENCE: harden() opens the file to create it privately. O_CREAT
+    without O_TRUNC — if that ever became O_TRUNC the spool would be silently
+    emptied on every append, which is worse than the leak it fixes."""
+    from tg_notify import harden
+
+    f = spool / "has-content.jsonl"
+    f.write_text('{"a": 1}\n{"b": 2}\n')
+    harden(f)
+    assert f.read_text() == '{"a": 1}\n{"b": 2}\n', "harden() ate the spool"
+
+
+def test_the_gateway_still_works_at_all(spool):
+    """INNOCENCE: the selftest is the gateway's own guilt+innocence corpus.
+    If hardening broke a write path, this is where it shows."""
+    r = subprocess.run([sys.executable, str(GATEWAY), "--selftest"],
+                       capture_output=True, text=True)
+    assert "SELFTEST PASS" in r.stdout, r.stdout + r.stderr
+
+
+def test_the_records_are_still_readable_after_hardening(spool):
+    """INNOCENCE: 0600 must not mean 0000 — the owner still reads its own
+    spool, and tg_digest_flush is the owner."""
+    subprocess.run([sys.executable, str(GATEWAY), "--tier", "digest",
+                    "--source", "t", "--", "readable?"], check=True, capture_output=True)
+    pending = spool / "pending.jsonl"
+    rows = [json.loads(l) for l in pending.read_text().splitlines() if l.strip()]
+    assert rows and rows[0]["text"] == "readable?"

--- a/scripts/tg_digest_flush.py
+++ b/scripts/tg_digest_flush.py
@@ -30,7 +30,7 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from tg_notify import _spool_lock, resolve_credentials, send_telegram  # noqa: E402
+from tg_notify import _spool_lock, harden, resolve_credentials, send_telegram  # noqa: E402
 
 MAX_CHARS = 3500
 
@@ -91,7 +91,9 @@ def _archive(spool: Path, records: list[dict]) -> None:
     day = time.strftime("%Y-%m-%d")
     adir = spool / "archive"
     adir.mkdir(parents=True, exist_ok=True)
-    with (adir / f"{day}.jsonl").open("a") as fh:
+    # harden() not open(0o600): `open("a")` on a file that already exists keeps
+    # its mode, and 33 days of these were written 0644 before this.
+    with harden(adir / f"{day}.jsonl").open("a") as fh:
         for r in records:
             fh.write(json.dumps(r, ensure_ascii=False) + "\n")
 
@@ -107,7 +109,7 @@ def _archive_log_only(spool: Path) -> int:
     adir = spool / "archive"
     adir.mkdir(parents=True, exist_ok=True)
     lines = [ln for ln in logf.read_text(errors="replace").splitlines() if ln.strip()]
-    with (adir / f"{day}.log-only.jsonl").open("a") as fh:
+    with harden(adir / f"{day}.log-only.jsonl").open("a") as fh:
         for ln in lines:
             fh.write(ln + "\n")
     logf.unlink()

--- a/scripts/tg_notify.py
+++ b/scripts/tg_notify.py
@@ -304,6 +304,12 @@ def harden(path: Path) -> Path:
         if path.stat().st_mode & 0o077:
             os.chmod(path, 0o600)
     except OSError:
+        # Swallowed ON PURPOSE, and pinned by an innocence test
+        # (test_hardening_never_takes_down_the_alert_it_carries): a spool the
+        # process cannot chmod — foreign owner, read-only mount — must degrade
+        # to a looser file, never abort the send. An alerter that dies because
+        # it could not tidy its own permissions has traded a privacy defect for
+        # a silence defect, which is the worse of the two.
         pass
     return path
 

--- a/scripts/tg_notify.py
+++ b/scripts/tg_notify.py
@@ -235,7 +235,12 @@ def _save_state(spool: Path, state: dict) -> None:
     p = spool / "state.json"
     tmp = p.with_suffix(f".json.tmp{os.getpid()}")
     tmp.write_text(json.dumps(state, indent=1, sort_keys=True))
+    # The temp file inherits the umask and `replace` carries ITS mode onto the
+    # destination, so hardening `p` afterwards would be undone by the next
+    # save. Harden the source of the rename.
+    harden(tmp)
     tmp.replace(p)
+    harden(p)
 
 
 class _spool_lock:
@@ -259,11 +264,55 @@ class _spool_lock:
         return False
 
 
+def harden(path: Path) -> Path:
+    """Force 0600 on a spool file, self-healing whatever mode it already has.
+
+    THE one place this rule lives, because the spool has three writers and only
+    one of them was applying it. `_append` below opens with 0o600 and the flock
+    file is 0o600 — so the author knew — but `_save_state` used
+    `Path.write_text` and `tg_digest_flush._archive` used `open("a")`, both of
+    which take the umask (0644 on Pro). Measured 2026-08-06:
+
+        archive-p0.jsonl        -rw-------   (the one that used _append)
+        state.json              -rw-r--r--
+        archive/2026-*.jsonl    -rw-r--r--   1.6 MB, 33 days, every event
+
+    The unprotected two are the bigger exposure, not the smaller: state.json
+    carries `last_text` (200 chars of every alert) and the daily archive is the
+    complete record, including 560 rows whose dedup key still carries a raw
+    client phone number from before the 2026-07-26 grouping fix. Superscar #4 —
+    the restriction is applied where the author was thinking about it and
+    missed where a different idiom was used.
+
+    O_CREAT's mode argument only applies when the file is CREATED, so a chmod
+    is what repairs the files already on disk. Doing it on every write costs a
+    syscall and needs no separate repair pass — the next flush heals the spool.
+    Never raises: a spool the process cannot chmod (foreign owner) must not
+    take down the alert it is carrying.
+
+    Two steps, and the first one is the one this fix originally got WRONG:
+    a chmod alone protects only files that ALREADY exist, so the first write of
+    each new day still went through `open("a")` and was born 0644 under the
+    umask — the cure carrying the shape of the disease. Creating the file
+    privately first closes that, and the chmod then repairs the ones already on
+    disk. Both are needed; neither is sufficient.
+    """
+    try:
+        # O_CREAT without O_EXCL: creates at 0600, or opens an existing file
+        # and changes nothing. Closed immediately — the caller does the writing.
+        os.close(os.open(str(path), os.O_CREAT | os.O_WRONLY, 0o600))
+        if path.stat().st_mode & 0o077:
+            os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return path
+
+
 def _append(spool: Path, name: str, record: dict) -> None:
     spool.mkdir(parents=True, exist_ok=True)
     line = json.dumps(record, ensure_ascii=False)
     # O_APPEND single-write keeps concurrent senders line-atomic (<4k).
-    fd = os.open(str(spool / name), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    fd = os.open(str(harden(spool / name)), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
     try:
         os.write(fd, (line + "\n").encode())
     finally:


### PR DESCRIPTION
## Measured on Pro, 2026-08-06

| file | mode | writer |
|---|---|---|
| `archive-p0.jsonl` | `-rw-------` | `tg_notify._append` |
| `state.json` | `-rw-r--r--` | `tg_notify._save_state` |
| `archive/2026-*.jsonl` | `-rw-r--r--` | `tg_digest_flush._archive` — **1.6 MB, 33 days, every event** |

`_append` opens with `0o600` and the flock file is `0o600`, so **the author knew the rule**. `_save_state` used `Path.write_text` and `_archive` used `open("a")` — both take the umask. Superscar #4: the restriction lands where the author was thinking about it and is missed where a different idiom was used.

## The unprotected two are the LARGER exposure

- `state.json` carries `last_text` — 200 characters of **every** alert, which for `wa-attention` includes a client's name.
- The daily archive is the complete record, and still holds **560 rows** whose dedup key carries a raw client phone number, from before the 2026-07-26 grouping fix replaced it with a sha256 set signature.

## One rule, one home

`harden()` lives in `tg_notify` and is imported by `tg_digest_flush`, which already imports from it. Two steps, and **both are needed**:

1. **create privately** — `os.open(..., O_CREAT, 0o600)` before the caller's `open("a")`
2. **chmod** — repairs the 33 days already on disk, self-healing on the next write

The first draft only did step 2. That repairs what already exists and lets **each new day's archive be born 0644**, forever, on the largest file in the spool — the cure carrying the shape of the disease. `test_a_brand_new_archive_file_is_born_private` is that bug, and the mutation set kills it.

## Not added, deliberately: retention

The archive has none and grows ~50 KB/day, which reads like a defect until you ask what it is FOR. It is the only historical record of what the organism said, and it is what made this entire messaging study possible. Deleting it to save 50 KB/day is a bad trade. **The exposure was the mode, not the existence.**

## Verification

- 8 tests, guilt + innocence. Innocence matters: `harden()` must never take down the alert it carries (swallows `OSError`), must never truncate (`O_CREAT` without `O_TRUNC` — an accident there would silently empty the spool on every append), and 0600 must not mean 0000.
- Mutation set **6/6 killed**, including the born-0644 bug above.
- The fixture forces `umask 0022`. Under a restrictive umask every file comes out 0600 by accident and the whole corpus would pass against unfixed code — a probe measuring the environment instead of the code (W108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)