### PR TITLE
fix(kbli): the prose detector was counting the phrasings it happened to know

### DIFF
--- a/scripts/kbli_filiera/editorial_record_conformance.py
+++ b/scripts/kbli_filiera/editorial_record_conformance.py
@@ -151,6 +151,26 @@ _STATUSES = frozenset({"TERBUKA", "TERTUTUP", "TERBATAS"})
 # word is not evidence of a false claim, and letting one through costs nothing
 # because the sidebar cells are checked independently.
 _SENTENCE = re.compile(r"[^.!?\n]+")
+
+# Splitting on every `.` breaks a sentence in half at "Perpres No. 7 of 2025" or
+# "3.5", and this predicate needs the national scope word and the openness claim
+# in the SAME sentence — so an abbreviation between them is a silent miss, in
+# the one direction that reaches a client. Measured in the live catalogue: 50
+# abbreviation dots and 109 decimal dots. Both are masked before splitting and
+# restored after, so the sentence a human would read is the sentence tested.
+_ABBREV_DOT = re.compile(
+    r"\b(?:art|no|nos|pp|uu|perpres|permen|perka|kepmen|cf|vs|etc|approx|ltd|jl|dr|mr|ms|st|inc)\.",
+    re.IGNORECASE,
+)
+_DECIMAL_DOT = re.compile(r"(?<=\d)\.(?=\d)")
+_DOT_HOLD = "\x00"
+
+
+def _sentences(text: str) -> list[str]:
+    """Sentences, without breaking on a legal abbreviation or a decimal point."""
+    masked = _ABBREV_DOT.sub(lambda m: m.group(0)[:-1] + _DOT_HOLD, text)
+    masked = _DECIMAL_DOT.sub(_DOT_HOLD, masked)
+    return [frag.replace(_DOT_HOLD, ".") for frag in _SENTENCE.findall(masked)]
 _NATIONAL_SCOPE = re.compile(r"national(?:ly)?", re.IGNORECASE)
 
 # The second half of the claim vocabulary, added 2026-08-06 after enumerating
@@ -169,15 +189,57 @@ _NATIONAL_SCOPE = re.compile(r"national(?:ly)?", re.IGNORECASE)
 # predicate already requires a national scope word, and a Bali-scoped sentence
 # that also says "nationally TERBUKA" on a capped record is making exactly the
 # claim this module exists to find.
+#
+# A cross-family reviewer, told to refute, named three more families and built
+# a sentence for each. All three reproduced against this file, so they are here
+# rather than in a ledger: `wholly/entirely/completely foreign-owned` (a whole
+# synonym family the list had no word for), `ceiling is 100%` (the noun this
+# module's own stat card uses — `Foreign-ownership ceiling` — which the prose
+# predicate could not read), and `unrestricted`. Live in the catalogue that is
+# one further code, `50223`.
 _OPENNESS_CLAIM = re.compile(
-    r"open\s+(?:to|nationally|for)|nationally\s+open|open\s+national|"
+    r"open\s+(?:to|nationally|for|and)|nationally\s+open|open\s+national|"
     r"100\s*%\s*(?:national|foreign)|full\s+foreign\s+ownership|"
     r"\bTERBUKA\b|fully\s+open|national\s+opening|PMA[-\s]open|"
-    r"maximum\s+is\s+100\s*%|up\s+to\s+100\s*%",
+    r"maximum\s+is\s+100\s*%|up\s+to\s+100\s*%|"
+    r"ceiling\s+is\s+100\s*%|\bunrestricted\b|"
+    r"(?:wholly|entirely|completely)\s+foreign[-\s]owned",
     re.IGNORECASE,
 )
 
-_NEGATION = re.compile(r"\b(?:not|no|never|cannot|can't|isn't|does\s+not|nor)\b", re.IGNORECASE)
+# WHERE the negation sits decides, exactly as it does for the contrast below —
+# and getting this wrong was the single largest blind spot in the module, found
+# by a reviewer hunting something else.
+#
+# Scanning the WHOLE sentence means an unrelated later clause acquits the claim.
+# The house style of this catalogue puts the two facts side by side:
+#
+#   "…nationally open to PMA and NOT blocked by Bali's moratorium record"  (30400)
+#   "…with a fully open national foreign-ownership position and NO Bali
+#    moratorium block"                                                     (79122)
+#
+# The sentence asserts the falsehood in its first half and is acquitted by its
+# innocent second. Measured on the live catalogue: **42 sentences on 22 codes**,
+# every one of them a genuine assertion of national openness on a record capped
+# at 0 or 49 — military combat vehicles, chartered flights, couriers, Umrah and
+# Hajj travel. Not one was a denial. The rule is therefore positional: a
+# negation acquits only when it precedes the claim it is supposed to be denying.
+_NEGATION = re.compile(
+    # `no(?!\.)` and not a bare `no`: masking abbreviations for the splitter
+    # newly keeps "regulation No. 7 of 2025" inside its sentence, and a bare
+    # `\bno\b` reads that regulation NUMBER as the word "no" and acquits the
+    # claim after it. The fix for one half of superscar #3 handed the other half
+    # a new instance in the same edit.
+    r"\b(?:not|no(?!\.)|never|cannot|can't|isn't|does\s+not|nor|"
+    # English also denies by DEGREE, and these read as assertions to a pattern
+    # that only knows "not": "the national position is anything but open".
+    # `without` is deliberately only in its `without being` form — bare
+    # `without` would acquit "without a local partner, this is nationally open
+    # to 100%", which is the dangerous direction. Newly acquits 0 live
+    # sentences; this is relief for prose not yet written.
+    r"anything\s+but|hardly|barely|far\s+from|without\s+being)\b",
+    re.IGNORECASE,
+)
 
 # English denies a claim by CONTRAST as often as by "not", and the contrastive
 # forms carried no weight here at all — so widening the claim list newly
@@ -197,6 +259,30 @@ _NEGATION = re.compile(r"\b(?:not|no|never|cannot|can't|isn't|does\s+not|nor)\b"
 # matched positionally rather than as a blanket acquittal — the entity, not the
 # form, one layer below where that rule usually gets applied.
 _CONTRAST = re.compile(r"\b(?:rather\s+than|instead\s+of|as\s+opposed\s+to)\b", re.IGNORECASE)
+
+# …and "after the marker" is not enough on its own, which the same reviewer
+# showed and the live catalogue confirmed on `41020`:
+#
+#   "the conclusion is aligned RATHER THAN contradictory: nationally open, and
+#    not blocked for PMA registration in Bali"
+#
+# The contrast is between `aligned` and `contradictory`. The openness sits after
+# the marker and is nonetheless ASSERTED, because a clause boundary ends the
+# contrast before it gets there. So the marker must DIRECTLY govern the claim:
+# no colon, semicolon or dash may stand between them.
+# The comma is in this class for the FRONTED contrast, which is ordinary English
+# and not an edge case: "RATHER THAN being capped, this activity is nationally
+# open" puts the asserted side after the marker, and only the comma says where
+# the rejected side ended. It changes no live verdict today — it is here because
+# the next sentence somebody writes is as likely to be fronted as trailing.
+_CLAUSE_BREAK = re.compile(r"[:;—–,]")
+
+
+def _contrast_rejects(sentence: str, contrast: re.Match, claim: re.Match) -> bool:
+    """Is the openness the alternative being REJECTED, rather than asserted?"""
+    if claim.start() < contrast.end():
+        return False  # the claim sits before the marker — it is the asserted side
+    return not _CLAUSE_BREAK.search(sentence[contrast.end() : claim.start()])
 
 
 def load_records(path: Path = CANONICAL) -> list[dict[str, Any]]:
@@ -305,14 +391,15 @@ def classify(record: dict[str, Any]) -> dict[str, Any]:
     capped = isinstance(cap, int) and cap < 100
     if capped:
         for path, text in _prose_fields(record):
-            for sentence in _SENTENCE.findall(text):
-                if not (_NATIONAL_SCOPE.search(sentence) and _OPENNESS_CLAIM.search(sentence)):
+            for sentence in _sentences(text):
+                claim = _OPENNESS_CLAIM.search(sentence)
+                if not (claim and _NATIONAL_SCOPE.search(sentence)):
                     continue
-                if _NEGATION.search(sentence):
+                negation = _NEGATION.search(sentence)
+                if negation and negation.start() < claim.start():
                     continue
                 contrast = _CONTRAST.search(sentence)
-                if contrast and not _OPENNESS_CLAIM.search(sentence[: contrast.start()]):
-                    # the openness is the alternative being REJECTED, not asserted
+                if contrast and _contrast_rejects(sentence, contrast, claim):
                     continue
                 out["body_asserts_national_openness"] = True
                 out["offending_fields"].append(

--- a/scripts/kbli_filiera/editorial_record_conformance.py
+++ b/scripts/kbli_filiera/editorial_record_conformance.py
@@ -152,12 +152,51 @@ _STATUSES = frozenset({"TERBUKA", "TERTUTUP", "TERBATAS"})
 # because the sidebar cells are checked independently.
 _SENTENCE = re.compile(r"[^.!?\n]+")
 _NATIONAL_SCOPE = re.compile(r"national(?:ly)?", re.IGNORECASE)
+
+# The second half of the claim vocabulary, added 2026-08-06 after enumerating
+# what the corpus ACTUALLY says instead of imagining phrasings. The first list
+# was built from the sentences the first version happened to catch, which is
+# circular — a pattern written from the instances you found catches the
+# instances you found (W113). Reading the not-yet-caught sentences on capped
+# records surfaced four families it had no words for:
+#
+#   TERBUKA as a bare status word   "the record marks the activity as TERBUKA"   (18)
+#   a maximum stated as a number    "the code is PMA-open up to 100%"            (10)
+#   "fully open"                    "Nationally, foreign ownership is fully open" (8)
+#   openness as a NOUN              "the real line between a national opening…"   (1)
+#
+# `\bTERBUKA\b` is deliberately not scoped to "national TERBUKA": the sentence
+# predicate already requires a national scope word, and a Bali-scoped sentence
+# that also says "nationally TERBUKA" on a capped record is making exactly the
+# claim this module exists to find.
 _OPENNESS_CLAIM = re.compile(
     r"open\s+(?:to|nationally|for)|nationally\s+open|open\s+national|"
-    r"100\s*%\s*(?:national|foreign)|full\s+foreign\s+ownership",
+    r"100\s*%\s*(?:national|foreign)|full\s+foreign\s+ownership|"
+    r"\bTERBUKA\b|fully\s+open|national\s+opening|PMA[-\s]open|"
+    r"maximum\s+is\s+100\s*%|up\s+to\s+100\s*%",
     re.IGNORECASE,
 )
+
 _NEGATION = re.compile(r"\b(?:not|no|never|cannot|can't|isn't|does\s+not|nor)\b", re.IGNORECASE)
+
+# English denies a claim by CONTRAST as often as by "not", and the contrastive
+# forms carried no weight here at all — so widening the claim list newly
+# convicted `50126`, which says the true thing:
+#
+#   "…foreign ownership is capped at 49%, RATHER THAN being fully open"
+#
+# But adding these to `_NEGATION` was an over-match the moment it was written,
+# and this module's own test caught it on `50135`:
+#
+#   "…may hold the activity with full foreign ownership, RATHER THAN under a
+#    lower foreign-equity ceiling"
+#
+# Same two words, opposite meanings. What separates them is not the marker, it
+# is WHICH SIDE of it the openness claim sits on: before the contrast it is the
+# alternative being ASSERTED, after it the one being REJECTED. So the marker is
+# matched positionally rather than as a blanket acquittal — the entity, not the
+# form, one layer below where that rule usually gets applied.
+_CONTRAST = re.compile(r"\b(?:rather\s+than|instead\s+of|as\s+opposed\s+to)\b", re.IGNORECASE)
 
 
 def load_records(path: Path = CANONICAL) -> list[dict[str, Any]]:
@@ -270,6 +309,10 @@ def classify(record: dict[str, Any]) -> dict[str, Any]:
                 if not (_NATIONAL_SCOPE.search(sentence) and _OPENNESS_CLAIM.search(sentence)):
                     continue
                 if _NEGATION.search(sentence):
+                    continue
+                contrast = _CONTRAST.search(sentence)
+                if contrast and not _OPENNESS_CLAIM.search(sentence[: contrast.start()]):
+                    # the openness is the alternative being REJECTED, not asserted
                     continue
                 out["body_asserts_national_openness"] = True
                 out["offending_fields"].append(

--- a/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
+++ b/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
@@ -257,7 +257,7 @@ def test_the_live_run_writes_the_real_catalogue_into_a_copy_and_changes_only_cel
     p.write_text(json.dumps(original, ensure_ascii=False), encoding="utf-8")
 
     authored_before = E.report(original["data"])["needs_an_author"]["codes"]
-    assert len(authored_before) == 31, "the prose backlog only a human can shrink"
+    assert len(authored_before) == 34, "the prose backlog, re-measured after the claim vocabulary was widened"
 
     # The catalogue is already cured, so this run is the IDEMPOTENCE check: a
     # second pass must find nothing, write nothing, and leave the document

--- a/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
+++ b/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
@@ -335,6 +335,138 @@ def test_innocence_english_denies_by_contrast_as_well_as_by_not(sentence):
     assert E.classify(r)["body_asserts_national_openness"] is False
 
 
+@pytest.mark.parametrize(
+    ("sentence", "code"),
+    [
+        # military combat vehicles, capped at 49% by Perpres 49/2021
+        (
+            "KBLI 30400 covers the manufacture and rebuilding of military combat "
+            "vehicles, nationally open to PMA and not blocked by Bali's moratorium record",
+            "30400",
+        ),
+        # Umrah and Hajj travel, capped at 0%
+        (
+            "This activity covers the assembly and sale of Umrah and special-Hajj "
+            "travel packages, with a fully open national foreign-ownership position "
+            "and no Bali moratorium block",
+            "79122",
+        ),
+        # couriers, capped at 49%
+        (
+            "From parcel pickup to doorstep delivery, this activity spans domestic "
+            "and international courier work across every listed scale, with full "
+            "foreign ownership open nationally and no Bali moratorium block",
+            "53200",
+        ),
+    ],
+)
+def test_guilt_a_later_unrelated_negation_does_not_acquit_the_claim(sentence, code):
+    """The largest blind spot this module ever had, and it was found by accident.
+
+    A cross-family reviewer, asked to attack the CONTRAST rule, noted in passing
+    that scanning the whole sentence for a negation lets an unrelated clause
+    acquit the claim. The house style of this catalogue puts the two facts side
+    by side — "nationally open to PMA AND NOT blocked by Bali's moratorium" —
+    so the sentence asserts the falsehood in its first half and is excused by
+    its innocent second.
+
+    Measured before the rule changed: 42 sentences on 22 codes, every one a
+    genuine assertion of national openness on a record capped at 0 or 49, and
+    not one a denial. These three are live text, on codes whose caps come from
+    the Perpres annex adjudicated by this lane.
+    """
+    assert E.classify(rec(cap=49, body=sentence + "."))["body_asserts_national_openness"] is True
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        "There is no national opening for a PT PMA that a Bali registration narrows",
+        "This activity is not open to foreign ownership nationally",
+        "That ceiling is the national limit: foreign participation is possible only "
+        "within that stated maximum, not on an unrestricted basis",
+    ],
+)
+def test_innocence_a_negation_that_precedes_the_claim_still_acquits(sentence):
+    """The other half of the same rule, and the reason it is POSITIONAL.
+
+    A negation before the claim is denying it; a negation after it is talking
+    about something else. All three of these are live text — `95291` and
+    `50121` say the true thing and must not be sent to an author.
+    """
+    assert E.classify(rec(cap=0, body=sentence + "."))["body_asserts_national_openness"] is False
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        "Rather than being capped, this activity is nationally open to full foreign ownership",
+        "The record, rather than confirming a cap, shows the activity is nationally "
+        "open to foreign investment",
+        # live on 41020: the contrast is between "aligned" and "contradictory",
+        # and a colon ends it before the openness is reached
+        "The honest conclusion is aligned rather than contradictory: nationally "
+        "open, and not blocked for PMA registration in Bali",
+    ],
+)
+def test_guilt_a_contrast_that_does_not_govern_the_claim_does_not_acquit_it(sentence):
+    """"After the marker" was not enough, and English is why.
+
+    The fronted contrast — "RATHER THAN being capped, this activity is
+    nationally open" — is ordinary English, not an edge case, and it puts the
+    ASSERTED side after the marker. What ends the contrast is a clause boundary:
+    a comma for the fronted form, a colon for `41020`. So the marker must
+    DIRECTLY govern the claim, with nothing between them that closes its clause.
+    """
+    assert E.classify(rec(cap=49, body=sentence + "."))["body_asserts_national_openness"] is True
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        "The national position is anything but open to foreign ownership",
+        "The national picture is hardly open to foreign ownership",
+        "Without being nationally open, the activity operates under a special permit",
+    ],
+)
+def test_innocence_english_also_denies_by_degree_not_only_by_not(sentence):
+    """Downtoners read as assertions to a pattern that only knows "not".
+
+    These acquit ZERO live sentences today — they are relief for prose not yet
+    written, and they are here rather than in a ledger because the alternative
+    is discovering them when a correct sentence is sent to an author. `without`
+    is deliberately only in its `without being` form: bare `without` would
+    acquit "without a local partner, this is nationally open to 100%", which is
+    the dangerous direction.
+    """
+    assert E.classify(rec(cap=49, body=sentence + "."))["body_asserts_national_openness"] is False
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        "The national rule per art. 12 states the activity is open to foreign ownership",
+        "Under national regulation No. 7 of 2025, the activity is open to foreign ownership",
+        "The national rate is 3.5 and the activity is open to foreign ownership",
+    ],
+)
+def test_guilt_an_abbreviation_or_a_decimal_does_not_end_the_sentence(sentence):
+    """A period that is not a full stop split the claim away from its scope.
+
+    This predicate needs the national scope word and the openness claim in the
+    SAME sentence, so "Perpres No. 7 of 2025" or "3.5" between them was a silent
+    miss — in the one direction that reaches a client. The corpus is regulatory
+    prose: 50 abbreviation dots and 109 decimal dots live.
+
+    The `No.` case is here for a second reason. Masking abbreviations so the
+    splitter keeps them newly put "regulation No. 7" INSIDE the sentence, where
+    a bare `\\bno\\b` read the regulation NUMBER as the word "no" and acquitted
+    the claim after it. Curing one half of superscar #3 handed the other half a
+    fresh instance in the same edit — so `no` now refuses a following period.
+    """
+    assert E.classify(rec(cap=49, body=sentence + "."))["body_asserts_national_openness"] is True
+
+
 def test_a_bali_sentence_that_also_states_the_national_position_is_still_guilty():
     """Not an over-match, and worth pinning because it looks like one.
 
@@ -403,16 +535,29 @@ def test_the_live_populations_are_pinned():
     # move, which is this module's whole subject.
     assert len(rep["needs_an_author"]["codes"]) == 34
 
-    # WHERE the prose lies. Pinned because the total alone hid the defect that
-    # produced these numbers: the first version read three fields and reported
-    # 20, and `whatYouNeed` — the field that carries a client's filing
-    # instructions — was the largest offender and was never opened.
+    # WHERE the prose lies, and this is the number that matters — not the code
+    # count above, which a cross-family refutation left UNMOVED at 34 while
+    # changing what a cure would have to touch by half:
+    #
+    #     editorial.standfirst   6 -> 22
+    #     editorial.pullQuote    0 -> 11      (an entire field, invisible)
+    #     whatYouNeed           23 -> 26
+    #     total field-hits      69 -> 102
+    #
+    # The 34 codes were already known. What was hidden is that most of them lie
+    # in MORE THAN ONE field, and a cure driven by the pre-refutation verdict
+    # would have rewritten 69 sentences and left 33 standing ON THE SAME PAGES —
+    # a page that reads cured with its standfirst still asserting the opposite.
+    # Pinned by field for that reason: the total alone hid the first defect too,
+    # when three fields were read and reported as "the bodies".
     assert rep["needs_an_author"]["by_field"] == {
-        "editorial.body": 26,
-        "whatYouNeed": 23,
-        "editorial.headline": 13,
-        "editorial.standfirst": 6,
+        "editorial.body": 27,
+        "whatYouNeed": 26,
+        "editorial.standfirst": 22,
+        "editorial.headline": 14,
+        "editorial.pullQuote": 11,
         "whoThisIsFor": 1,
+        "zantaraOpener": 1,
     }
 
 

--- a/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
+++ b/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
@@ -18,6 +18,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _FILIERA = str(Path(__file__).resolve().parents[1])
 if _FILIERA not in sys.path:
     sys.path.insert(0, _FILIERA)
@@ -160,12 +162,14 @@ def test_the_capped_narrowing_now_protects_exactly_one_live_code():
             return False
         for _path, text in E._prose_fields(record):
             for sentence in E._SENTENCE.findall(text):
-                if (
-                    E._NATIONAL_SCOPE.search(sentence)
-                    and E._OPENNESS_CLAIM.search(sentence)
-                    and not E._NEGATION.search(sentence)
-                ):
-                    return True
+                if not (
+                    E._NATIONAL_SCOPE.search(sentence) and E._OPENNESS_CLAIM.search(sentence)
+                ) or E._NEGATION.search(sentence):
+                    continue
+                contrast = E._CONTRAST.search(sentence)
+                if contrast and not E._OPENNESS_CLAIM.search(sentence[: contrast.start()]):
+                    continue
+                return True
         return False
 
     protected = {r["kode_kbli_2025"] for r in records if broad(r)} - narrow
@@ -275,6 +279,79 @@ def test_the_walk_reaches_prose_nested_below_the_top_level():
 
 
 # --------------------------------------------------------------------------
+# THE CLAIM VOCABULARY — widened from the corpus, not from imagination
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        # the status word asserted bare — 18 live sentences, the largest family
+        "Nationally, the foreign-investment position is clean: the record marks the activity as TERBUKA",
+        # a maximum stated as a number, with no "open to" anywhere
+        "Nationally, the code is PMA-open up to 100%",
+        "For a foreign-owned registration, the national picture is simple: it is open and the maximum is 100%",
+        # "fully open"
+        "Nationally, foreign ownership is fully open",
+        # openness as a NOUN
+        "That is the real line between a national opening and a Bali filing",
+    ],
+)
+def test_guilt_the_four_phrasings_the_first_vocabulary_had_no_words_for(sentence):
+    """Each of these is live text on a capped record, and each used to pass.
+
+    The first claim list was assembled from the sentences it already caught,
+    which cannot find a family it has no word for — a pattern written from the
+    instances you found catches the instances you found (W113). These five come
+    from reading the sentences on capped records that the predicate did NOT
+    flag, which is the only place a missing family can be seen.
+    """
+    r = rec(cap=0, status="TERTUTUP", body=sentence + ".")
+    assert E.classify(r)["body_asserts_national_openness"] is True
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        # THE live sentence that made the negation list grow with the claim list
+        "Nationally, the activity is TERBATAS: foreign ownership is capped at 49%, "
+        "rather than being fully open",
+        "The national position is a 49% cap instead of full foreign ownership",
+        "It is treated as restricted, as opposed to nationally open",
+    ],
+)
+def test_innocence_english_denies_by_contrast_as_well_as_by_not(sentence):
+    """Widening the claim list without handling contrast convicts correct prose.
+
+    `50126` says the true thing — capped at 49%, RATHER THAN fully open — and
+    `fully\\s+open` made it newly catchable. But a BLANKET acquittal on the
+    contrastive marker was itself an over-match, caught by this file's own
+    `50135` test: there the same two words introduce the REJECTED alternative,
+    so "full foreign ownership, rather than a lower ceiling" asserts openness.
+    The marker is therefore read positionally — see `_CONTRAST` — and these
+    three are innocent because the claim sits AFTER it.
+    """
+    r = rec(cap=49, status="TERBATAS", body=sentence + ".")
+    assert E.classify(r)["body_asserts_national_openness"] is False
+
+
+def test_a_bali_sentence_that_also_states_the_national_position_is_still_guilty():
+    """Not an over-match, and worth pinning because it looks like one.
+
+    "Nationally TERBUKA, but blocked in Bali" on a capped record is making the
+    false national claim inside a sentence whose subject is Bali. The Bali
+    exclusion in this module is about CELL LABELS — a `Bali PMA status` cell
+    describes a different fact — and does not extend to prose that asserts the
+    national position while discussing Bali."""
+    r = rec(
+        cap=0,
+        status="TERBATAS",
+        body="Nationally the activity is TERBUKA, but Bali blocks PMA registration.",
+    )
+    assert E.classify(r)["body_asserts_national_openness"] is True
+
+
+# --------------------------------------------------------------------------
 # THE LIVE CATALOGUE — populations, and the separation that is the product
 # --------------------------------------------------------------------------
 
@@ -324,15 +401,15 @@ def test_the_live_populations_are_pinned():
     # 27 -> 31 when #3673 restricted four codes and left their prose saying the
     # opposite — the cure moved the record and the sentences beside it did not
     # move, which is this module's whole subject.
-    assert len(rep["needs_an_author"]["codes"]) == 31
+    assert len(rep["needs_an_author"]["codes"]) == 34
 
     # WHERE the prose lies. Pinned because the total alone hid the defect that
     # produced these numbers: the first version read three fields and reported
     # 20, and `whatYouNeed` — the field that carries a client's filing
     # instructions — was the largest offender and was never opened.
     assert rep["needs_an_author"]["by_field"] == {
-        "whatYouNeed": 19,
-        "editorial.body": 16,
+        "editorial.body": 26,
+        "whatYouNeed": 23,
         "editorial.headline": 13,
         "editorial.standfirst": 6,
         "whoThisIsFor": 1,
@@ -415,7 +492,11 @@ def test_the_relationship_to_both_existing_lint_rules_is_pinned():
         "this module no longer finds anything L10 misses — if that is real, it is "
         "redundant and should be retired rather than maintained"
     )
-    assert l10 - mine == {"41011", "52292", "53200"}, (
+    # Was {41011, 52292, 53200}. Widening the claim vocabulary on 2026-08-06
+    # closed `53200` — it stated a maximum as a bare number ("the maximum is
+    # 100%"), a family the first vocabulary had no word for. The gap SHRANK by
+    # being measured, not by being redefined.
+    assert l10 - mine == {"41011", "52292"}, (
         "the DECLARED gap in this module — numeric claims L10 catches and a "
         f"sentence-level openness predicate does not: {sorted(l10 - mine)}"
     )


### PR DESCRIPTION
## What this changes

The detector that finds editorial prose contradicting its own record reported **31 codes / 55 sentences**. That number measured the vocabulary I had written, not the catalogue. Enumerating what the corpus actually says raised it to **34 codes / 69 sentences**.

Then a cross-family seat was handed the diff with orders to refute it, and found something bigger than the thing it was pointed at.

## The refutation, and what survived it

It built a sentence for each defect it claimed. **All thirteen reproduced against the file.** Five are fixed here.

### 1. A later, unrelated negation acquitted the claim — 42 sentences on 22 codes

`_NEGATION` scanned the whole sentence. The house style of this catalogue puts the two facts side by side:

> …nationally open to PMA **and not** blocked by Bali's moratorium record
>
> …with a fully open national foreign-ownership position **and no** Bali moratorium block

The sentence asserts the falsehood in its first half and is excused by its innocent second. Measured live: **42 sentences on 22 codes**, every one a genuine assertion of national openness on a record capped at 0 or 49 — military combat vehicles (`30400`), chartered flights (`51102`), couriers (`53200`), Umrah and Hajj travel (`79122`) — and **not one a denial**.

The rule is now positional: a negation acquits only when it **precedes** the claim it is meant to deny.

### 2. A contrast marker before the claim is not enough

The fronted form — *"**Rather than** being capped, this activity is nationally open"* — is ordinary English and puts the **asserted** side after the marker. What ends the contrast is a clause boundary: a comma for the fronted form, a colon for `41020` live (*"aligned rather than contradictory: nationally open"*). The marker must now directly govern the claim.

### 3. Three more phrasings, one of them our own noun

`wholly/entirely/completely foreign-owned` · `unrestricted` · `ceiling is 100%` — the last being the exact word this module's own stat card uses (`Foreign-ownership ceiling`) while the prose predicate could not read it.

### 4. A period that is not a full stop

50 abbreviation dots and 109 decimal dots live. *"Perpres No. 7 of 2025"* between the scope word and the claim was a silent miss, in the one direction that reaches a client.

### 5. …and that fix bred its own twin, in the same edit

Keeping *"regulation No. 7"* inside the sentence let a bare `\bno\b` read the **regulation number** as the word "no" and acquit the claim after it. Superscar #3, handed a fresh instance by the cure for its other half. `no` now refuses a following period.

## What actually changed, and what did not

The **code count does not move** — 34, before and after. The **field count** does:

| field | before | after |
|---|---|---|
| `editorial.standfirst` | 6 | **22** |
| `editorial.pullQuote` | 0 | **11** |
| `whatYouNeed` | 23 | 26 |
| `editorial.body` | 26 | 27 |
| **total field-hits** | **69** | **102** |

The 34 codes were already known. What was hidden is that most of them lie in **more than one field**. A cure driven by the pre-refutation verdict would have rewritten 69 sentences and left 33 standing **on the same pages** — a page that reads cured with its standfirst still asserting the opposite.

## Two of the reviewer's cases are deliberately not fixed as framed

- Bare `without` is excluded from the downtoners: it would acquit *"without a local partner, this is nationally open to 100%"*, which is the dangerous direction. Only `without being`.
- The `no cap` / `no restriction` family is left out of the claim vocabulary because it fights the negation rule.

Both limits are stated in the code, not in a ledger.

## Verification

Five new rules, five mutations, each **verified to have applied** before its result was read — a surviving mutant can mean the mutation never took (W116, which bit an earlier round of this same PR).

| mutation | failures |
|---|---|
| negation back to whole-sentence | 5 |
| comma out of the clause break | 2 |
| downtoners removed | 3 |
| splitter back to naive | 3 |
| bare `no` restored | 1 |
| **restored control** | **43 passed** |

Full directory suite: **944 passed**.

Pins now state properties rather than backlog sizes: `mechanically_correctable == []` (a new one is a regression), `needs_an_author` pinned **by field**, and the relationship to the neighbouring L10 lint pinned as a **set** so a divergence names the codes.

## Not in this PR

The 34 codes still hold the contradicting prose. Sentence-level patching was already refuted — one body carries four national-openness sentences — so the rewrite is at field level, and it is graded cross-family before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)