### PR TITLE
fix(observability): the Drive watchdog cried "can't connect" 65 times while the token it guards expired

### DIFF
--- a/scripts/drive_token_watchdog.py
+++ b/scripts/drive_token_watchdog.py
@@ -275,10 +275,49 @@ def _send_telegram(text: str, bot_token: str) -> bool:
         return False
 
 
-def _check_drive_token_via_fly() -> dict | None:
+# Cron's PATH is /usr/bin:/bin:/usr/sbin:/sbin — Homebrew is NOT on it, and
+# flyctl lives in /opt/homebrew/bin. Calling bare "fly" therefore worked in
+# every interactive test and failed on every scheduled run, which is how this
+# watchdog sent 65 identical "impossibile connettersi" alerts over 24 days
+# while the thing it guards silently expired underneath (2026-08-06).
+# Reproduced both ways before fixing, on Pro:
+#   PATH=/usr/bin:/bin:/usr/sbin:/sbin      -> None
+#   PATH=/opt/homebrew/bin:/usr/bin:/bin    -> {'expires_at': '2026-07-25 ...'}
+# `which` first so an operator's own install still wins; the absolute list is
+# the fallback for exactly the impoverished environment cron provides.
+_FLY_CANDIDATES = (
+    "/opt/homebrew/bin/flyctl",
+    "/opt/homebrew/bin/fly",
+    "/usr/local/bin/flyctl",
+    "/usr/local/bin/fly",
+    str(Path.home() / ".fly" / "bin" / "flyctl"),
+    str(Path.home() / ".fly" / "bin" / "fly"),
+)
+
+
+def _resolve_fly() -> str | None:
+    """Absolute path to flyctl, or None if it genuinely is not installed."""
+    import shutil
+
+    found = shutil.which("fly") or shutil.which("flyctl")
+    if found:
+        return found
+    for cand in _FLY_CANDIDATES:
+        if os.access(cand, os.X_OK):
+            return cand
+    return None
+
+
+def _check_drive_token_via_fly() -> tuple[dict | None, str | None]:
     """
     Interroga google_drive_tokens via fly ssh console sul backend Fly.io.
-    Restituisce dict con expires_at (ISO string) oppure None.
+
+    Restituisce `(data, failure_reason)`: esattamente uno dei due è non-None.
+    La ragione esiste perché il messaggio d'allarme deve NOMINARE la causa —
+    quello vecchio diceva "verifica che fly ssh funzioni", indirizzando chi
+    legge verso l'autenticazione mentre il problema era che `fly` non era
+    nemmeno risolvibile. Una diagnosi che punta lontano dalla causa costa più
+    del silenzio (W106: cura e messaggio scadono insieme).
     """
     code = (
         "import asyncio, asyncpg, os, json\n"
@@ -298,8 +337,16 @@ def _check_drive_token_via_fly() -> dict | None:
     )
     import base64
     code_b64 = base64.b64encode(code.encode()).decode()
+
+    fly = _resolve_fly()
+    if fly is None:
+        return None, (
+            "il binario <code>fly</code> non è sul PATH di questo processo "
+            f"(PATH={os.environ.get('PATH', '')[:120]})"
+        )
+
     cmd = [
-        "fly", "ssh", "console",
+        fly, "ssh", "console",
         "--app", "nuzantara-rag",
         "--command",
         f"python3 -c \"import base64,os; exec(base64.b64decode('{code_b64}').decode())\"",
@@ -312,10 +359,15 @@ def _check_drive_token_via_fly() -> dict | None:
         for line in output.splitlines():
             line = line.strip()
             if line.startswith("{"):
-                return json.loads(line)
+                return json.loads(line), None
+        # Ran, produced no JSON: report what it actually said, never a guess.
+        detail = (result.stderr or result.stdout).strip().replace("\n", " ")[:180]
+        return None, f"<code>fly ssh</code> è uscito {result.returncode}: {detail or '(nessun output)'}"
+    except subprocess.TimeoutExpired:
+        return None, "<code>fly ssh</code> non ha risposto entro 60s"
     except Exception as e:
         log(f"fly ssh fallito: {e}")
-    return None
+        return None, f"{type(e).__name__}: {e}"
 
 
 def _check_sa_key_age() -> int | None:
@@ -396,16 +448,24 @@ def main() -> int:
 
     # --- Check 1: Drive OAuth token with tier system ---
     log("Controllo Drive OAuth token...")
-    token_data = _check_drive_token_via_fly()
+    token_data, token_read_error = _check_drive_token_via_fly()
 
     new_oauth_tier: Optional[str] = None  # set if classification succeeds
     new_oauth_days_left: Optional[int] = None  # last computed days_left (sensor input)
 
     if token_data is None:
-        # Connection failure — separate from tier system; always alert.
+        # Read failure — separate from the tier system; always alert.
+        #
+        # The message NAMES the measured cause instead of prescribing a guess.
+        # It also says out loud what the reader cannot otherwise know: while
+        # this branch is firing, the expiry check is NOT running, so silence
+        # from the tier system means "blind", not "fine". That is the whole
+        # damage this defect did — the token expired 2026-07-25 and the one
+        # alert that mattered was never sent.
         alerts.append(
-            "⚠️ <b>Drive Watchdog</b>: impossibile connettersi al backend Fly.io\n"
-            "Verifica che <code>fly ssh</code> funzioni."
+            "⚠️ <b>Drive Watchdog</b>: non ho potuto LEGGERE lo stato del token\n"
+            f"Causa: {token_read_error or 'sconosciuta'}\n"
+            "<b>Mentre vedi questo, la scadenza NON è sorvegliata.</b>"
         )
     elif token_data.get("expires_at") is None:
         # Same effect as expired — fold into TIER_EXPIRED with synthetic message.

--- a/scripts/tests/test_drive_watchdog_fly_path.py
+++ b/scripts/tests/test_drive_watchdog_fly_path.py
@@ -1,0 +1,150 @@
+"""The Drive watchdog called bare `fly`, so it only ever worked interactively.
+
+TRAUMA (2026-08-06). `scripts/drive_token_watchdog.py` exists to warn 7 days
+before the Drive OAuth token expires. It ran every 6h from cron and sent
+"impossibile connettersi al backend Fly.io" 65 times over 24 days. Meanwhile,
+measured on the live production DB this turn:
+
+    google_drive_tokens.expires_at = 2026-07-25 20:02:03+00   (11.5 days ago)
+
+The one alert the organ exists to send was never sent. The noise defect was
+not merely noise: it MASKED the failure it was built to catch.
+
+Cause, reproduced both ways on Pro before touching anything:
+
+    PATH=/usr/bin:/bin:/usr/sbin:/sbin            -> _check_drive_token_via_fly() = None
+    PATH=/opt/homebrew/bin:/usr/bin:/bin:/sbin    -> {'expires_at': '2026-07-25 ...'}
+
+cron's PATH has no Homebrew; flyctl lives in /opt/homebrew/bin. Same shape as
+W108 one level up: the tool the alarm depends on is resolved through an
+environment the alarm's own author never ran in.
+
+Second defect, and the one that kept it alive for 24 days: the message said
+"Verifica che `fly ssh` funzioni", pointing every reader at fly's auth — which
+was fine. A diagnosis aimed away from the cause costs more than silence
+(W106: cure and message expire together).
+
+    GUILT      — under cron's PATH the read still succeeds (absolute fallback)
+    GUILT      — with flyctl genuinely absent, the failure NAMES the PATH
+    GUILT      — a non-zero fly exit is reported with fly's OWN words
+    INNOCENCE  — a normal environment is unaffected and returns data
+    INNOCENCE  — the operator's own `which fly` still wins over the fallback
+    CONTRACT   — the alert text never again prescribes "check that fly ssh works"
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "drive_token_watchdog.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("drive_token_watchdog", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    # Registered BEFORE exec: the module defines a @dataclass, and dataclasses
+    # resolves annotations through sys.modules[cls.__module__] — absent that
+    # entry it dies on AttributeError before a single test body runs.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def wd():
+    return _load()
+
+
+# ------------------------------------------------------------------- guilt
+def test_resolves_fly_under_crons_impoverished_path(wd, monkeypatch, tmp_path):
+    """THE defect. cron gives /usr/bin:/bin:/usr/sbin:/sbin and nothing else."""
+    fake = tmp_path / "flyctl"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+    monkeypatch.setattr(wd, "_FLY_CANDIDATES", (str(fake),))
+
+    assert wd._resolve_fly() == str(fake), (
+        "with Homebrew off PATH the absolute fallback must still find flyctl — "
+        "this is the exact environment in which the watchdog ran 65 times")
+
+
+def test_a_genuinely_absent_fly_names_the_path_not_ssh(wd, monkeypatch):
+    """When flyctl really is missing, the reason must say so — and must not
+    send the reader to fly's authentication, which is what the old text did."""
+    monkeypatch.setenv("PATH", "/nonexistent")
+    monkeypatch.setattr(wd, "_FLY_CANDIDATES", ())
+
+    data, reason = wd._check_drive_token_via_fly()
+    assert data is None
+    assert "PATH" in reason, reason
+    assert "ssh" not in reason.lower(), (
+        f"the reason blames ssh again: {reason!r}")
+
+
+def test_a_failing_fly_is_reported_in_flys_own_words(wd, monkeypatch, tmp_path):
+    """A fly that runs and fails must surface fly's message, never a guess."""
+    fake = tmp_path / "flyctl"
+    fake.write_text("#!/bin/sh\necho 'Error: Could not find App nuzantara-rag' >&2\nexit 1\n")
+    fake.chmod(0o755)
+    monkeypatch.setattr(wd, "_resolve_fly", lambda: str(fake))
+
+    data, reason = wd._check_drive_token_via_fly()
+    assert data is None
+    assert "Could not find App" in reason, reason
+
+
+# --------------------------------------------------------------- innocence
+def test_a_healthy_environment_still_returns_the_token(wd, monkeypatch, tmp_path):
+    """INNOCENCE: the happy path is untouched — and the tuple's data slot is
+    what the caller reads. A fix that broke this would blind the organ the
+    other way."""
+    fake = tmp_path / "flyctl"
+    fake.write_text(
+        "#!/bin/sh\n"
+        "echo 'Connecting to fdaa:...'\n"
+        "echo '{\"expires_at\": \"2026-12-01 00:00:00+00:00\", \"created_at\": \"2026-09-01\"}'\n"
+    )
+    fake.chmod(0o755)
+    monkeypatch.setattr(wd, "_resolve_fly", lambda: str(fake))
+
+    data, reason = wd._check_drive_token_via_fly()
+    assert reason is None, reason
+    assert data["expires_at"].startswith("2026-12-01")
+
+
+def test_an_installed_fly_on_path_wins_over_the_fallback(wd, monkeypatch, tmp_path):
+    """INNOCENCE: the absolute list is a FALLBACK, not an override. An operator
+    who installs flyctl elsewhere must not be silently routed to a stale one."""
+    onpath = tmp_path / "bin"
+    onpath.mkdir()
+    real = onpath / "fly"
+    real.write_text("#!/bin/sh\nexit 0\n")
+    real.chmod(0o755)
+    decoy = tmp_path / "decoy-flyctl"
+    decoy.write_text("#!/bin/sh\nexit 0\n")
+    decoy.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{onpath}:/usr/bin:/bin")
+    monkeypatch.setattr(wd, "_FLY_CANDIDATES", (str(decoy),))
+
+    assert wd._resolve_fly() == str(real)
+
+
+# ---------------------------------------------------------------- contract
+def test_the_alert_text_no_longer_prescribes_checking_fly_ssh():
+    """The sentence that misdirected every reader for 24 days is gone, and the
+    replacement warns that expiry is unguarded while it fires — the fact whose
+    absence let a real expiry pass unnoticed."""
+    src = SCRIPT.read_text()
+    assert "Verifica che <code>fly ssh</code> funzioni" not in src, (
+        "the misdirecting diagnosis is back")
+    assert "la scadenza NON è sorvegliata" in src, (
+        "the alert must say the expiry check is blind while this fires")


### PR DESCRIPTION
The organ exists to warn 7 days before the Drive OAuth token expires. Measured
on the live production DB this turn:

    google_drive_tokens.expires_at = 2026-07-25 20:02:03+00   (11.5 days ago)

The warning was never sent. Instead the watchdog sent "impossibile connettersi
al backend Fly.io" every 6h for 24 days. The noise was not merely noise: it
MASKED the exact failure the organ was built to catch. The re-auth itself is an
operator action (GUI OAuth) and is reported separately; this diff is the code
half.

CAUSE, reproduced both ways on Pro before touching anything:

    PATH=/usr/bin:/bin:/usr/sbin:/sbin           -> _check_drive_token_via_fly() = None
    PATH=/opt/homebrew/bin:/usr/bin:/bin:/sbin   -> {'expires_at': '2026-07-25 ...'}

It called bare `fly`. cron's PATH has no Homebrew and flyctl lives in
/opt/homebrew/bin, so the call worked in every interactive test and failed on
every scheduled run — W108 one level up: the tool the alarm depends on is
resolved through an environment its author never ran in. `shutil.which` first
so an operator's own install still wins, absolute candidates as the fallback
for exactly the impoverished environment cron provides.

SECOND DEFECT, and the reason this survived 24 days: the message read "Verifica
che `fly ssh` funzioni", pointing every reader at fly's authentication — which
was healthy. A diagnosis aimed away from the cause costs more than silence
(W106: the cure and its message expire together). The function now returns
(data, reason) and the alert NAMES the measured cause in fly's own words, plus
the sentence whose absence let a real expiry slip past: "while you see this,
the expiry is NOT being watched."

Corpus 6/6 — guilt under cron's exact PATH, guilt on genuinely-absent flyctl,
guilt on a failing fly, innocence on a healthy env, innocence that an installed
fly still beats the fallback, and a contract test that the misdirecting
sentence cannot come back. Mutation 6/6 killed, including restoring the bare
`fly` and restoring the old blame-ssh text.

PROVEN LIVE on Pro with cron's exact PATH before this commit: resolves to
/opt/homebrew/bin/flyctl and returns the real row. Next tick after deploy it
will finally send the alert that matters — the token is expired.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)