### PR TITLE
fix(home-fork): four pairs named a machine that does not have the file, and one named no machine at all

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -4,17 +4,20 @@
     {
       "live": "~/.fly/bin/fly_pg_tunnel_supervisor.sh",
       "repo": "scripts/fly_pg_tunnel_supervisor.sh",
-      "machines": ["all"]
+      "machines": ["m5"],
+      "_note": "Measured on all three machines 2026-08-06 (the skipped-pairs diagnostic of #3681, first live run, is what surfaced it): this live path exists on M5 only. Was 'all', which made --check chase a pair that is not there on Pro/Mini — the same mistake the regulatory-watcher entry already records. On Pro the payload runs from a repo path (the LaunchAgent's ProgramArguments name no plist references it on Pro at all), not from a HOME copy, so there is nothing to mirror there."
     },
     {
       "live": "~/.nuzantara-cron/agent_worktree_cleanup_cron.sh",
       "repo": "scripts/agent_worktree_cleanup_cron.sh",
-      "machines": ["all"]
+      "machines": ["m5"],
+      "_note": "Measured on all three machines 2026-08-06 (the skipped-pairs diagnostic of #3681, first live run, is what surfaced it): this live path exists on M5 only. Was 'all', which made --check chase a pair that is not there on Pro/Mini — the same mistake the regulatory-watcher entry already records. On Pro the payload runs from a repo path (the LaunchAgent's ProgramArguments name ~/nuzantara/scripts/agent_worktree_cleanup_cron.sh), not from a HOME copy, so there is nothing to mirror there."
     },
     {
       "live": "~/.nuzantara-cron/verify_connectome_run.sh",
       "repo": "scripts/verify_connectome_run.sh",
-      "machines": ["all"]
+      "machines": ["m5"],
+      "_note": "Measured on all three machines 2026-08-06 (the skipped-pairs diagnostic of #3681, first live run, is what surfaced it): this live path exists on M5 only. Was 'all', which made --check chase a pair that is not there on Pro/Mini — the same mistake the regulatory-watcher entry already records. On Pro the payload runs from a repo path (the LaunchAgent's ProgramArguments name ~/nuzantara-deploy/scripts/verify_connectome_run.sh), not from a HOME copy, so there is nothing to mirror there."
     },
     {
       "live": "~/scripts/regulatory-watcher-run.sh",
@@ -605,14 +608,8 @@
     {
       "live": "~/scripts/wa-mirror-launcher/api_server.py",
       "repo": "apps/wa-mirror/scripts/api_server.py",
-      "machines": ["pro"],
-      "_note": "wa-mirror launcher. The repo's supervise-launcher.sh — what the LaunchAgent actually runs — delegates to ~/scripts/wa-mirror-launcher/start-all.sh BY DESIGN, so the HOME copy is the EXECUTED one and its repo twin drifted unwatched. Declared 2026-08-06. Never tracked before 2026-08-06."
-    },
-    {
-      "live": "~/scripts/wa-mirror-launcher/nuzantara_control_center.html",
-      "repo": "apps/wa-mirror/scripts/nuzantara_control_center.html",
-      "machines": ["pro"],
-      "_note": "wa-mirror launcher. The repo's supervise-launcher.sh — what the LaunchAgent actually runs — delegates to ~/scripts/wa-mirror-launcher/start-all.sh BY DESIGN, so the HOME copy is the EXECUTED one and its repo twin drifted unwatched. Declared 2026-08-06. Never tracked before 2026-08-06. Pro only: M5 carries a partial copy of this launcher that does not include this file at all."
+      "machines": ["m5"],
+      "_note": "wa-mirror launcher. The repo's supervise-launcher.sh — what the LaunchAgent actually runs — delegates to ~/scripts/wa-mirror-launcher/start-all.sh BY DESIGN, so the HOME copy is the EXECUTED one and its repo twin drifted unwatched. Declared 2026-08-06. Never tracked before 2026-08-06. Rescoped pro->m5 the same day: Pro's live copy was moved to ~/scripts/.attic-20260806/ (sha-identical to what #3671 committed), so the declared path is empty there; M5 still has one and it was still the PRE-CURE file — 14253B, no roster_account(), the startswith() containment, and a hardcoded production DSN at mode 0644 — i.e. #3671 cured the repo and left the running copy vulnerable. Realigned to origin/main 2026-08-06 (0 credential literals, roster_account present). The html twin of this pair was REMOVED, not rescoped: after Pro's attic it exists on no machine, and a declared pair with no live copy anywhere is the false-drift chase this file already warns about."
     },
     {
       "live": "~/Library/LaunchAgents/com.nuzantara.web-lead-funnel.plist",


### PR DESCRIPTION
## What #3681 caught on its first live run

`a423e3a2de` (#3681) landed this morning and made the home-fork check say how many pairs it **skipped**. Its first run on Pro turned `111 declared, clean` into the truth: **85 verified, 5 never looked at**.

Measured on all three machines:

| declared live path | M5 | Pro | Mini | declared as | → |
|---|---|---|---|---|---|
| `~/.fly/bin/fly_pg_tunnel_supervisor.sh` | ✅ | ❌ | ❌ | `all` | `m5` |
| `~/.nuzantara-cron/agent_worktree_cleanup_cron.sh` | ✅ | ❌ | ❌ | `all` | `m5` |
| `~/.nuzantara-cron/verify_connectome_run.sh` | ✅ | ❌ | ❌ | `all` | `m5` |
| `~/scripts/wa-mirror-launcher/api_server.py` | ✅ | ❌ | ❌ | `pro` | `m5` |
| `~/scripts/wa-mirror-launcher/nuzantara_control_center.html` | ❌ | ❌ | ❌ | `pro` | **removed** |

`all` is the mistake this file **already records** for `regulatory-watcher` ("Was 'all', which made lint --check chase a nonexistent Mini pair"). Same error, three more times — and before #3681 it was chased in silence.

On Pro those payloads do run, but from **repo** paths: the LaunchAgents' `ProgramArguments` name `~/nuzantara/scripts/agent_worktree_cleanup_cron.sh` and `~/nuzantara-deploy/scripts/verify_connectome_run.sh` (both present, `last exit code = 0`). No HOME copy there, so nothing to mirror and nothing to declare. I first read the plists as *armed at nothing* — wrong: my grep had matched them by **basename** and I inferred the path instead of reading it.

## The wa-mirror pair was a live defect, not bad metadata

Pro's two copies were moved to `~/scripts/.attic-20260806/` (sha-identical to what #3671 committed), so the declared path is empty there. **M5 still had `api_server.py`, and it was the pre-cure file**: 14253B, no `roster_account()`, the `startswith()` containment CodeQL flagged, and a hardcoded production DSN at mode `0644`. #3671 cured the repo and left the running copy vulnerable — the "merged ≠ live" half-step this registry exists to catch.

Realigned M5's live copy to `origin/main` **before** opening this PR, proven by content: sha == `origin/main`, `postgresql://` literals `1 → 0`, `roster_account()` present, dead `~/Desktop` path gone. Nothing was executing it (`pgrep` empty; no plist, no crontab, and `start-all.sh` does not invoke it).

The html twin is **removed** rather than rescoped: after Pro's attic it exists on no machine, and a declared pair with no live copy anywhere is precisely the false-drift chase the file warns about. The repo copy stays canonical; the reason is recorded in the sibling entry's `_note` so it is not lost.

## Verification

- `lint_home_fork.py --check` on M5 with the corrected registry: `99 declared, machine=m5`, **clean, rc 0**.
- Guilt/innocence on the same guardian, same session: with a stale copy restored it exits **1** and names the stale side; with the cured copy it exits **0**.
- `prettier --check` clean (the file was clean before; it stays clean).
- JSON re-parses; `111 → 110` pairs.

## Not in this diff (measured, ledgered)

- `~/.claude/agents/` holds 35 files on M5 and the registry declares **one**; 6 `wr2-*` specs diverge from the repo, and on 3 of them Pro is a **third** version. Dormant — the WR2 cron sets `WorkingDirectory=/Users/nuzantara/nuzantara`, so the repo shadows — and largely Prettier reflow (live-only lines drop 17→5, 12→2 ignoring whitespace). Wants a per-file read, not a sweep.
- The `regulatory-watcher` entry says `machines: ["pro","m5"]` with a note that Mini must not have it; **Mini has it**, aligned to `origin/main`.
- `~/.openclaw/bin/wr2/wr2-cron-wrapper.sh` is sha-identical to its repo twin and undeclared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)