### PR TITLE
fix(observability): the spool cure missed a fourth writer, and its test carried the complete claim

### DIFF
--- a/scripts/tests/test_spool_is_private.py
+++ b/scripts/tests/test_spool_is_private.py
@@ -78,16 +78,36 @@ def spool(tmp_path, monkeypatch):
 
 # --------------------------------------------------------------------- guilt
 def test_every_file_the_gateway_writes_is_private(spool):
-    """One pass through the real gateway, then read the modes off disk."""
+    """One pass through BOTH real programs, then read the modes off disk.
+
+    ROUND 2 (2026-08-06, found in PROVE-LIVE). This test carried exactly this
+    name while running only `tg_notify.py` — never the flush. On Pro, hours
+    after #3684 shipped, `last_flush.json` was still 0644 and had been rewritten
+    that same afternoon: the flush writes it at THREE sites (silent-healthy,
+    send-failed, sent) and none was hardened. A test whose name says "every
+    file the gateway writes" while exercising one of the two programs is read
+    downstream as the complete claim it is not — the same shape as counting a
+    subset and reporting it as the population.
+
+    The assertion is deliberately unenumerated: whatever lands in the spool
+    directory must be private. A future fourth writer is covered without anyone
+    remembering to add it here.
+    """
     subprocess.run([sys.executable, str(GATEWAY), "--tier", "digest",
                     "--source", "t", "--", "hello"], check=True,
                    capture_output=True, env={**os.environ})
     subprocess.run([sys.executable, str(GATEWAY), "--tier", "p0",
                     "--source", "t", "--", "fire"], check=True,
                    capture_output=True, env={**os.environ})
-    written = [p for p in spool.iterdir() if p.is_file()]
-    assert written, "the gateway wrote nothing — the probe measured its own setup"
-    leaky = {p.name: _mode(p) for p in written if _group_or_other_readable(p)}
+    subprocess.run([sys.executable, str(FLUSH)], capture_output=True, text=True)
+
+    written = [p for p in spool.rglob("*") if p.is_file()]
+    assert written, "nothing was written — the probe measured its own setup"
+    assert any(p.name == "last_flush.json" for p in written), (
+        "the flush did not run, so its three write sites were never exercised "
+        "— the exact blind spot this test was widened to cover")
+    leaky = {str(p.relative_to(spool)): _mode(p)
+             for p in written if _group_or_other_readable(p)}
     assert not leaky, f"spool files readable beyond the owner: {leaky}"
 
 
@@ -142,6 +162,40 @@ def test_an_existing_loose_file_is_repaired(spool):
         f"setup failed: born {_mode(victim)}, not loose — nothing was measured")
     tg_notify.harden(victim)
     assert not _group_or_other_readable(victim), f"still {_mode(victim)}"
+
+
+# ------------------------------------------------- guilt: the other two branches
+# The flush writes last_flush.json at THREE sites and the corpus above reaches
+# exactly one — the happy "sent" path. Mutation found that: un-hardening either
+# other site survived the whole suite. Three write sites, one exercised, is how
+# a fix looks complete while two thirds of it is unproven.
+
+
+def test_the_silent_healthy_heartbeat_is_private(spool):
+    """Branch 1: an EMPTY spool still stamps last_flush.json (the self-probe
+    needs it to tell healthy-silence from death). Never reached above, because
+    the corpus always spools something first."""
+    r = subprocess.run([sys.executable, str(FLUSH)], capture_output=True, text=True)
+    assert "spool empty" in r.stdout, f"wrong branch: {r.stdout}{r.stderr}"
+    stamp = spool / "last_flush.json"
+    assert stamp.exists(), "no heartbeat written — nothing measured"
+    assert not _group_or_other_readable(stamp), f"{_mode(stamp)}"
+
+
+def test_the_send_failed_stamp_is_private(spool, monkeypatch):
+    """Branch 2: with no credentials, `bool(token and chat)` is False, the send
+    is judged failed, the spool is preserved and last_flush.json records the
+    error. Hermetic — this path never touches the network."""
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_OWNER_CHAT_ID", raising=False)
+    monkeypatch.delenv("TG_DRY_RUN", raising=False)
+    subprocess.run([sys.executable, str(GATEWAY), "--tier", "digest",
+                    "--source", "t", "--", "will fail"], check=True, capture_output=True)
+    r = subprocess.run([sys.executable, str(FLUSH)], capture_output=True, text=True)
+    assert r.returncode == 3, f"wrong branch (rc={r.returncode}): {r.stdout}{r.stderr}"
+    stamp = spool / "last_flush.json"
+    assert stamp.exists(), "no failure stamp written — nothing measured"
+    assert not _group_or_other_readable(stamp), f"{_mode(stamp)}"
 
 
 # ----------------------------------------------------------------- innocence

--- a/scripts/tg_digest_flush.py
+++ b/scripts/tg_digest_flush.py
@@ -180,7 +180,7 @@ def flush(dry_run: bool = False) -> int:
     if not records:
         # heartbeat for the self-probe even when silent-healthy;
         # claims are empty by construction here (anything with content was adopted)
-        (spool / "last_flush.json").write_text(
+        harden(spool / "last_flush.json").write_text(
             json.dumps({"ts": time.time(), "sent": False, "events": 0})
         )
         for c in claim_files:
@@ -205,7 +205,7 @@ def flush(dry_run: bool = False) -> int:
             _restore(spool, records)
         for c in claim_files:
             c.unlink(missing_ok=True)
-        (spool / "last_flush.json").write_text(
+        harden(spool / "last_flush.json").write_text(
             json.dumps({"ts": time.time(), "sent": False, "events": len(records), "error": "send-failed"})
         )
         print("tg_digest_flush: SEND FAILED — spool preserved", file=sys.stderr)
@@ -215,7 +215,7 @@ def flush(dry_run: bool = False) -> int:
         _archive(spool, records)
     for c in claim_files:
         c.unlink(missing_ok=True)
-    (spool / "last_flush.json").write_text(
+    harden(spool / "last_flush.json").write_text(
         json.dumps({"ts": time.time(), "sent": True, "events": len(records)})
     )
     print(f"tg_digest_flush: sent digest with {len(records)} events")
@@ -245,6 +245,10 @@ def selftest() -> int:
             {"ts": 2, "tier": "digest", "source": "fly-watcher", "text": "still green"},
             {"ts": 3, "tier": "p0", "source": "dlq", "text": "late", "p0_overflow": True},
         ]
+        # NOT hardened, and deliberately: every write below lands in the
+        # TemporaryDirectory above, never in the real spool. `harden` states a
+        # production invariant — using it on fixtures would blur which writes
+        # actually carry alert content.
         with (spool / "pending.jsonl").open("w") as fh:
             for r in recs:
                 fh.write(json.dumps(r) + "\n")


### PR DESCRIPTION
Round 2 on my own #3684, found in PROVE-LIVE — not by re-reading the diff, by measuring the disk on Pro.

## What was measured

Hours after #3684 merged, on Pro:

```
-rw-r--r--@  6 ago 17:56  ~/.organism/tg_spool/last_flush.json
```

Written **that same afternoon**, still world-readable. The cure had enumerated three writers (`_append`, `_save_state`, `_archive`) and missed the digest flush, which stamps `last_flush.json` at **three** sites: silent-healthy, send-failed, sent.

## Why the corpus did not catch it

`test_every_file_the_gateway_writes_is_private` carried exactly that name while running **only** `tg_notify.py` — never the flush. A subset measured and reported as the population. The name was the claim; the body was one of the two programs.

## The fix

- `harden()` on all three `last_flush.json` sites in `flush()`
- the test now runs the FLUSH too, walks with `rglob`, and **asserts `last_flush.json` exists** — so "the flush never ran" can no longer read as clean (the failure mode that produced this PR)
- two new guilt tests for branches the corpus never reached: the empty-spool heartbeat and the send-failed stamp

## Mutation

**3/3** killed. Before the two branch tests it was **1/3**: un-hardening either of the other two sites survived the entire suite, because the corpus always spooled something first and the send always succeeded. Three write sites, one exercised, is how a fix looks complete while two thirds of it is unproven.

Corpus 10/10, `--selftest` PASS.

## Declared, not hidden

The two remaining un-hardened writes in `selftest()` land in a `TemporaryDirectory`, never the real spool — comment added in place so the next reader does not "fix" it. Census of producers (`grep -rl TG_SPOOL_DIR`) returns exactly two programs; both are now covered.

## Still open, and this PR does not do it

The **32 historical archive files** on Pro dated 2026-08-05 and earlier are still 0644. `harden()` heals on write and a daily archive is never rewritten, so those will **never** self-heal. That needs a one-shot repair pass, which I run separately — it is a repair, not a cure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)