### PR TITLE
fix(observability): the tier ratchet advanced on classification, so verifying the cure muted the watchdog

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -163,6 +163,9 @@ jobs:
               scripts/tests/test_no_import_time_chdir_in_tests.py|\
               scripts/tests/test_husky_prepush_venv_guard.py|\
               scripts/tests/test_immune_enforcement_trigger_symmetry.py|\
+              scripts/drive_token_watchdog.py|\
+              scripts/tests/test_drive_watchdog_fly_path.py|\
+              scripts/tests/test_drive_watchdog_tier_ratchet.py|\
               scripts/tests/test_ci_service_images_use_mirror.py|\
               scripts/tests/test_lint_workflow_errexit_decap.py|\
               scripts/lint_workflow_errexit_decap.py|\
@@ -244,6 +247,8 @@ jobs:
             scripts/tests/test_intake_dsn_guard_covers_every_var.py \
             scripts/tests/test_husky_prepush_venv_guard.py \
             scripts/tests/test_immune_enforcement_trigger_symmetry.py \
+            scripts/tests/test_drive_watchdog_fly_path.py \
+            scripts/tests/test_drive_watchdog_tier_ratchet.py \
             scripts/test_lint_test_reward_hacking.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"

--- a/scripts/drive_token_watchdog.py
+++ b/scripts/drive_token_watchdog.py
@@ -519,30 +519,60 @@ def main() -> int:
         else:
             new_sa_alert_age = last_sa_alert_age
 
-    # --- Persist state (best-effort) ---
+    # --- Invia alerts, THEN persist ---
+    #
+    # This order is the fix (2026-08-06). It used to be the other way round:
+    # `save_state` ran first and `_send_telegram`'s return value was printed
+    # and discarded. The tier ratchet therefore advanced on CLASSIFICATION,
+    # not on DELIVERY — and `should_alert` only fires on a strictly-more-severe
+    # transition, so for a once-per-lifetime event like "the token expired"
+    # there is exactly ONE chance to speak.
+    #
+    # Measured, and it is how this was found: the token expired 2026-07-25;
+    # #3690 cured the PATH defect that had kept the watchdog from ever reading
+    # it; and the run that VERIFIED that cure classified `critical_expired`,
+    # wrote it to the state file, and delivered nothing anyone read. The next
+    # cron then found `last_oauth_tier == critical_expired`, took the
+    # de-escalation branch, and printed "tutto OK (token valido)" about a
+    # credential that had been dead for twelve days. Curing a mute watchdog
+    # and then muting it with the act of verifying the cure.
+    #
+    # Three ways the old order lost the message, all now closed: a
+    # verification run, a send that fails, and a cron environment with no
+    # TELEGRAM_BOT_TOKEN (`_send_telegram` returns False on exactly that).
+    #
+    # The obvious worry about retrying forever is already handled, by the
+    # component whose job it is: the alert goes through tg_notify with a
+    # STABLE dedup key, so the 6/24/72/168h repeat ladder collapses a
+    # persistent failure to about four messages a week. That split is the
+    # point — the ratchet answers "has this been DELIVERED", the gateway
+    # answers "how often may it repeat". One mechanism each, instead of the
+    # ratchet doing both and doing the second one wrong.
+    delivered = True
+    if alerts:
+        header = f"🔔 <b>Drive Watchdog</b> — {timestamp}\n\n"
+        message = header + "\n\n".join(alerts)
+        delivered = _send_telegram(message, bot_token)
+        print(f"[drive-watchdog] {len(alerts)} alert{'s' if len(alerts) > 1 else ''} inviato: {delivered}")
+    else:
+        print(f"[drive-watchdog] {timestamp} — tutto OK (token valido, SA key OK)")
+
+    # --- Persist state (best-effort), only for what actually got through ---
     if not DRY_RUN:
         new_state = dict(state)
-        if new_oauth_tier is not None:
+        if new_oauth_tier is not None and delivered:
             new_state["last_oauth_tier"] = new_oauth_tier
             new_state["last_oauth_check_iso"] = now_utc.isoformat()
             if new_oauth_days_left is not None:
                 new_state["last_oauth_days_left"] = new_oauth_days_left
-        if new_sa_alert_age is not None:
+        if new_sa_alert_age is not None and delivered:
             new_state["last_sa_alert_age"] = new_sa_alert_age
         save_state(new_state)
 
-    # --- Invia alerts ---
-    if alerts:
-        header = f"🔔 <b>Drive Watchdog</b> — {timestamp}\n\n"
-        message = header + "\n\n".join(alerts)
-        sent = _send_telegram(message, bot_token)
-        print(f"[drive-watchdog] {len(alerts)} alert{'s' if len(alerts) > 1 else ''} inviato: {sent}")
-        # Always exit 0 after successful alert delivery — the watchdog's job is done.
-        # Exit 1 would cause cron-wrapper to retry, sending duplicate alerts.
-        return 0
-    else:
-        print(f"[drive-watchdog] {timestamp} — tutto OK (token valido, SA key OK)")
-        return 0
+    # Always exit 0 — the cron wrapper would retry on non-zero, and a retry
+    # duplicates the alert. Undelivered state is carried by the ratchet not
+    # advancing, not by the exit code.
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/drive_token_watchdog.py
+++ b/scripts/drive_token_watchdog.py
@@ -351,23 +351,61 @@ def _check_drive_token_via_fly() -> tuple[dict | None, str | None]:
         "--command",
         f"python3 -c \"import base64,os; exec(base64.b64decode('{code_b64}').decode())\"",
     ]
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-        output = result.stdout.strip()
-        log(f"fly ssh output: {output[:200]}")
-        # Cerca JSON nella output (potrebbe avere banner ssh)
-        for line in output.splitlines():
-            line = line.strip()
-            if line.startswith("{"):
-                return json.loads(line), None
-        # Ran, produced no JSON: report what it actually said, never a guess.
-        detail = (result.stderr or result.stdout).strip().replace("\n", " ")[:180]
-        return None, f"<code>fly ssh</code> è uscito {result.returncode}: {detail or '(nessun output)'}"
-    except subprocess.TimeoutExpired:
-        return None, "<code>fly ssh</code> non ha risposto entro 60s"
-    except Exception as e:
-        log(f"fly ssh fallito: {e}")
-        return None, f"{type(e).__name__}: {e}"
+    # TWO credentials, and only one of them works — probe, never assume (W106).
+    #
+    # Measured on Pro 2026-08-06, running the REAL command rather than
+    # `auth whoami` (which passes for a token scoped to a different app and
+    # only dies later, on the work):
+    #
+    #   with FLY_API_TOKEN from ~/.nuzantara-secrets.env
+    #       -> Could not find App "nuzantara-rag"
+    #   with FLY_API_TOKEN unset, falling back to ~/.fly/config.yml
+    #       -> PROBE_OK
+    #
+    # This is a SECOND, independent cause of the same blindness #3690 cured,
+    # and it is the one that bites in production: cron reaches this script
+    # through `cron-wrapper.sh`, which sources the secrets file, so the live
+    # path always carried the credential that cannot see this app. The earlier
+    # verification runs succeeded only because they ran under `env -i`, which
+    # stripped it — the mirror of W108's dev machine that was structurally
+    # unable to reproduce the red.
+    #
+    # Deliberately NOT hardcoded as "the env token is stale, so always unset
+    # it". That is exactly the frozen measurement W106 is about: the fly-backup
+    # script hardcoded `unset FLY_API_TOKEN` when it was true, the world
+    # inverted, and the cure threw away the only working credential for 27h.
+    # Try each credential the environment actually offers, in order, and LOG
+    # which one was accepted.
+    attempts: list[tuple[str, dict]] = [("env/inherited", dict(os.environ))]
+    if os.environ.get("FLY_API_TOKEN"):
+        fallback = dict(os.environ)
+        fallback.pop("FLY_API_TOKEN", None)
+        attempts.append(("~/.fly/config.yml", fallback))
+
+    failures: list[str] = []
+    for source, env in attempts:
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True,
+                                    timeout=60, env=env)
+            output = result.stdout.strip()
+            log(f"fly ssh via {source}: exit={result.returncode} {output[:160]}")
+            for line in output.splitlines():
+                line = line.strip()
+                if line.startswith("{"):
+                    log(f"credential accepted: {source}")
+                    return json.loads(line), None
+            detail = (result.stderr or result.stdout).strip().replace("\n", " ")[:150]
+            failures.append(f"{source}: exit {result.returncode} — {detail or '(nessun output)'}")
+        except subprocess.TimeoutExpired:
+            failures.append(f"{source}: nessuna risposta entro 60s")
+        except Exception as e:  # noqa: BLE001 — the reason is reported, never guessed
+            log(f"fly ssh via {source} fallito: {e}")
+            failures.append(f"{source}: {type(e).__name__}: {e}")
+
+    # Every credential refused. Name each one and what IT said — a diagnosis
+    # that points away from the cause costs more than silence (W106).
+    return None, "<code>fly ssh</code> rifiutato da ogni credenziale — " + " | ".join(failures)
+
 
 
 def _check_sa_key_age() -> int | None:

--- a/scripts/drive_token_watchdog.py
+++ b/scripts/drive_token_watchdog.py
@@ -239,7 +239,7 @@ def _load_env() -> dict[str, str]:
     return env
 
 
-def _send_telegram(text: str, bot_token: str) -> bool:
+def _send_telegram(text: str, bot_token: str, condition: str = "alert") -> bool:
     """Route via the tg_notify gateway (2026-07-11 migration, cohort-5).
 
     p0 tier: alerts only fire on an escalating tier (URGENT/CRITICAL) or an
@@ -260,7 +260,25 @@ def _send_telegram(text: str, bot_token: str) -> bool:
     # a live timestamp + variable days-left, so tg_notify's default
     # source+text[:160] hash never matches twice and dedup can't suppress
     # flap-refiring (PENDING-ARMS 2026-07-12).
-    dedup_key = f"drive-token-watchdog:{socket.gethostname().split('.')[0]}"
+    # The key names the CONDITION, not just the source (fixed 2026-08-06).
+    #
+    # It used to be `drive-token-watchdog:<host>` for everything this organ
+    # says, and that is how the first real expiry alert died. Measured in the
+    # gateway state on Pro, minutes after the read was finally working:
+    #
+    #   drive-token-watchdog:Nuzantara  count=4  ts=18:00
+    #   last_text = "🔴 Drive OAuth SCADUTO (12 giorni fa)"
+    #
+    # The `ts` is the 18:00 send — the LAST "impossibile connettersi" noise —
+    # so the 18:42 expiry message was recorded and suppressed as a repeat of
+    # the very noise it replaces. Two different facts, one key, and the
+    # 6/24/72/168h ladder of the loud one swallows the quiet one.
+    #
+    # Stability still matters (that is why the key carries the tier and never
+    # `days_left`: a tier is a condition, a day count is a measurement, and a
+    # measurement in the key mints a fresh key per run — #3677). But stable
+    # PER CONDITION, not per source.
+    dedup_key = f"drive-token-watchdog:{condition}:{socket.gethostname().split('.')[0]}"
     try:
         proc = subprocess.run(
             [sys.executable, str(gateway), "--tier", "p0",
@@ -476,6 +494,7 @@ def main() -> int:
     bot_token = os.environ.get("TELEGRAM_BOT_TOKEN") or env.get("TELEGRAM_BOT_TOKEN", "")
 
     alerts: list[str] = []
+    alert_kinds: list[str] = []
     now_utc = datetime.now(timezone.utc)
     now_wita = now_utc.astimezone(WITA)
     timestamp = now_wita.strftime("%Y-%m-%d %H:%M WITA")
@@ -500,6 +519,7 @@ def main() -> int:
         # from the tier system means "blind", not "fine". That is the whole
         # damage this defect did — the token expired 2026-07-25 and the one
         # alert that mattered was never sent.
+        alert_kinds.append("read-failure")
         alerts.append(
             "⚠️ <b>Drive Watchdog</b>: non ho potuto LEGGERE lo stato del token\n"
             f"Causa: {token_read_error or 'sconosciuta'}\n"
@@ -509,6 +529,7 @@ def main() -> int:
         # Same effect as expired — fold into TIER_EXPIRED with synthetic message.
         new_oauth_tier = TIER_EXPIRED
         if should_alert(new_oauth_tier, last_oauth_tier):
+            alert_kinds.append("no-token")
             alerts.append(
                 "🔴 <b>Drive OAuth</b>: NESSUN TOKEN in DB\n"
                 "Drive polling disabilitato. Esegui re-auth:\n"
@@ -527,6 +548,7 @@ def main() -> int:
             new_oauth_days_left = days_left
 
             if should_alert(new_oauth_tier, last_oauth_tier):
+                alert_kinds.append(new_oauth_tier)
                 alerts.append(render_alert_text(tier_alert))
                 log(
                     f"Tier transition: {last_oauth_tier or 'OK'} → {new_oauth_tier} "
@@ -539,6 +561,7 @@ def main() -> int:
                 )
         except Exception as e:
             log(f"Parse expires_at fallito: {e}")
+            alert_kinds.append("parse-failure")
             alerts.append(f"⚠️ <b>Drive Watchdog</b>: errore parsing expires_at: {e}")
 
     # --- Check 2: SA key age (kept simple — no tier system, single threshold) ---
@@ -548,6 +571,7 @@ def main() -> int:
     if sa_age is not None and sa_age > SA_KEY_MAX_AGE_DAYS:
         # Idempotent: only alert if age went UP since last alert (or no prev alert).
         if last_sa_alert_age is None or sa_age > last_sa_alert_age:
+            alert_kinds.append("sa-key-age")
             alerts.append(
                 f"⚠️ <b>SA Key</b> age: {sa_age} giorni (soglia: {SA_KEY_MAX_AGE_DAYS})\n"
                 "Rotazione consigliata: Google Cloud Console → IAM → Service Accounts\n"
@@ -590,7 +614,11 @@ def main() -> int:
     if alerts:
         header = f"🔔 <b>Drive Watchdog</b> — {timestamp}\n\n"
         message = header + "\n\n".join(alerts)
-        delivered = _send_telegram(message, bot_token)
+        # The condition is the SET of facts in this message — sorted so the
+        # same combination always yields the same key, and joined so a message
+        # that carries two facts cannot be mistaken for either one alone.
+        condition = "+".join(sorted(set(alert_kinds))) or "alert"
+        delivered = _send_telegram(message, bot_token, condition)
         print(f"[drive-watchdog] {len(alerts)} alert{'s' if len(alerts) > 1 else ''} inviato: {delivered}")
     else:
         print(f"[drive-watchdog] {timestamp} — tutto OK (token valido, SA key OK)")

--- a/scripts/tests/test_drive_watchdog_fly_path.py
+++ b/scripts/tests/test_drive_watchdog_fly_path.py
@@ -148,3 +148,97 @@ def test_the_alert_text_no_longer_prescribes_checking_fly_ssh():
         "the misdirecting diagnosis is back")
     assert "la scadenza NON è sorvegliata" in src, (
         "the alert must say the expiry check is blind while this fires")
+
+
+# ------------------------------------------- second cause: the CREDENTIAL
+# Found 2026-08-06 in PROVE-LIVE of the PATH cure above, and it is a distinct
+# defect with the same symptom. Measured on Pro, running the REAL command
+# rather than `auth whoami` (which passes for a token scoped to another app
+# and only dies later, on the work):
+#
+#   FLY_API_TOKEN from ~/.nuzantara-secrets.env -> Could not find App "nuzantara-rag"
+#   FLY_API_TOKEN unset, ~/.fly/config.yml      -> PROBE_OK
+#
+# cron reaches this script through cron-wrapper.sh, which SOURCES the secrets
+# file — so the production path always carried the credential that cannot see
+# this app, and the PATH cure alone would never have made the organ see the
+# expiry. The earlier verification runs succeeded only because they ran under
+# `env -i`, which stripped it: the mirror of W108's dev machine that could not
+# reproduce the red.
+
+
+def _fly_that_needs_no_token(tmp_path, name="flyctl"):
+    """A fake fly that FAILS when FLY_API_TOKEN is set and succeeds when it is
+    not — the live behaviour, inverted-testable."""
+    fake = tmp_path / name
+    fake.write_text(
+        "#!/bin/sh\n"
+        'if [ -n "$FLY_API_TOKEN" ]; then\n'
+        "  echo 'Error: Could not find App \"nuzantara-rag\"' >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "echo '{\"expires_at\": \"2026-07-25 20:02:03+00:00\", \"created_at\": \"2026-04-07\"}'\n"
+    )
+    fake.chmod(0o755)
+    return fake
+
+
+def test_a_wrongly_scoped_env_token_falls_back_to_the_config_credential(
+    wd, monkeypatch, tmp_path
+):
+    """GUILT: the exact production shape. With only the first credential tried,
+    the read fails and the expiry is never seen."""
+    monkeypatch.setattr(wd, "_resolve_fly",
+                        lambda: str(_fly_that_needs_no_token(tmp_path)))
+    monkeypatch.setenv("FLY_API_TOKEN", "FlyV1 scoped-to-another-app")
+
+    data, reason = wd._check_drive_token_via_fly()
+    assert reason is None, f"the fallback credential was never tried: {reason}"
+    assert data["expires_at"].startswith("2026-07-25")
+
+
+def test_when_every_credential_refuses_the_reason_names_each_one(
+    wd, monkeypatch, tmp_path
+):
+    """GUILT: both refuse. The message must say what EACH attempt said —
+    a diagnosis aimed away from the cause costs more than silence (W106)."""
+    fake = tmp_path / "flyctl"
+    fake.write_text("#!/bin/sh\necho 'Error: unauthorized' >&2\nexit 1\n")
+    fake.chmod(0o755)
+    monkeypatch.setattr(wd, "_resolve_fly", lambda: str(fake))
+    monkeypatch.setenv("FLY_API_TOKEN", "FlyV1 also-dead")
+
+    data, reason = wd._check_drive_token_via_fly()
+    assert data is None
+    assert "env/inherited" in reason and "config.yml" in reason, reason
+    assert "unauthorized" in reason, reason
+
+
+def test_a_working_env_token_is_used_and_the_fallback_is_never_reached(
+    wd, monkeypatch, tmp_path
+):
+    """INNOCENCE, and it is why this is a PROBE and not a hardcoded `unset`.
+
+    W106 is precisely the story of hardcoding 'the env token is stale, always
+    drop it': true the day it was written, the world inverted, and the cure
+    threw away the only working credential for 27h. Here the env credential
+    works, so it must be the one used — no second attempt, no preference
+    frozen into the code.
+    """
+    counter = tmp_path / "calls"
+    fake = tmp_path / "flyctl"
+    fake.write_text(
+        "#!/bin/sh\n"
+        f"echo x >> {counter}\n"
+        "echo '{\"expires_at\": \"2026-12-01 00:00:00+00:00\", \"created_at\": \"2026-09-01\"}'\n"
+    )
+    fake.chmod(0o755)
+    monkeypatch.setattr(wd, "_resolve_fly", lambda: str(fake))
+    monkeypatch.setenv("FLY_API_TOKEN", "FlyV1 perfectly-good")
+
+    data, reason = wd._check_drive_token_via_fly()
+    assert reason is None, reason
+    assert data["expires_at"].startswith("2026-12-01")
+    assert counter.read_text().count("x") == 1, (
+        "fly was invoked twice — the first credential worked and the fallback "
+        "must not have run")

--- a/scripts/tests/test_drive_watchdog_tier_ratchet.py
+++ b/scripts/tests/test_drive_watchdog_tier_ratchet.py
@@ -108,7 +108,7 @@ def test_a_failed_send_does_not_burn_the_one_expiry_alert(wd, monkeypatch):
                         lambda: _token("2026-07-25 20:02:03+00"))
     sends: list[str] = []
 
-    def failing_send(text, bot_token):
+    def failing_send(text, bot_token, condition="alert"):
         sends.append(text)
         return False
 
@@ -135,7 +135,8 @@ def test_a_failed_send_of_an_escalation_still_retries(wd, monkeypatch):
                         lambda: _token(
                             (wd.datetime.now(wd.timezone.utc)
                              + wd.timedelta(days=3)).strftime("%Y-%m-%d %H:%M:%S+00")))
-    monkeypatch.setattr(wd, "_send_telegram", lambda text, bot_token: False)
+    monkeypatch.setattr(wd, "_send_telegram",
+                        lambda text, bot_token, condition="alert": False)
 
     assert wd.main() == 0
     assert _saved_tier(wd) == wd.TIER_14_DAYS, (
@@ -159,7 +160,7 @@ def test_the_sa_key_lane_has_the_same_defect_and_the_same_cure(wd, monkeypatch):
     monkeypatch.setattr(wd, "_check_sa_key_age", lambda: wd.SA_KEY_MAX_AGE_DAYS + 5)
     sends: list[str] = []
 
-    def failing_send(text, bot_token):
+    def failing_send(text, bot_token, condition="alert"):
         sends.append(text)
         return False
 
@@ -186,7 +187,7 @@ def test_a_successful_send_does_advance_the_ratchet(wd, monkeypatch):
                         lambda: _token("2026-07-25 20:02:03+00"))
     sends: list[str] = []
     monkeypatch.setattr(wd, "_send_telegram",
-                        lambda text, bot_token: (sends.append(text), True)[1])
+                        lambda text, bot_token, condition="alert": (sends.append(text), True)[1])
 
     assert wd.main() == 0
     assert _saved_tier(wd) == wd.TIER_EXPIRED, "a delivered alert must be recorded"
@@ -205,7 +206,7 @@ def test_a_healthy_token_still_records_its_tier(wd, monkeypatch):
                             (wd.datetime.now(wd.timezone.utc)
                              + wd.timedelta(days=80)).strftime("%Y-%m-%d %H:%M:%S+00")))
     monkeypatch.setattr(wd, "_send_telegram",
-                        lambda text, bot_token: pytest.fail("nothing should be sent"))
+                        lambda text, bot_token, condition="alert": pytest.fail("nothing should be sent"))
 
     assert wd.main() == 0
     assert _saved_tier(wd) == wd.TIER_OK
@@ -224,10 +225,112 @@ def test_the_send_happens_before_the_state_write(wd, monkeypatch):
     monkeypatch.setattr(wd, "_check_drive_token_via_fly",
                         lambda: _token("2026-07-25 20:02:03+00"))
     monkeypatch.setattr(wd, "_send_telegram",
-                        lambda text, bot_token: (seq.append("send"), True)[1])
+                        lambda text, bot_token, condition="alert": (seq.append("send"), True)[1])
     real_save = wd.save_state
     monkeypatch.setattr(wd, "save_state",
                         lambda st: (seq.append("save"), real_save(st))[1])
 
     assert wd.main() == 0
     assert seq == ["send", "save"], f"wrong order: {seq}"
+
+
+# --------------------------------------------- the key names the CONDITION
+# Found in the gateway's own state on Pro, minutes after the read finally
+# worked (2026-08-06):
+#
+#   drive-token-watchdog:Nuzantara  count=4  ts=18:00
+#   last_text = "🔴 Drive OAuth SCADUTO (12 giorni fa)"
+#
+# The `ts` is the 18:00 send — the LAST "impossibile connettersi" noise — so
+# the 18:42 expiry message was recorded and SUPPRESSED as a repeat of the very
+# noise it replaces. One key for two different facts: the loud condition's
+# 6/24/72/168h ladder swallows the quiet one, and the quiet one is the whole
+# reason the organ exists.
+
+
+def _key_of(sends):
+    return sends[-1]
+
+
+def test_a_read_failure_and_an_expiry_do_not_share_a_dedup_key(wd, monkeypatch):
+    """THE defect. Two runs, two different facts; if the keys match, the
+    second is swallowed by the first's ladder inside the gateway."""
+    keys: list[str] = []
+    monkeypatch.setattr(wd, "_send_telegram",
+                        lambda text, bot_token, condition="alert":
+                        (keys.append(condition), True)[1])
+
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: (None, "fly ssh rifiutato"))
+    assert wd.main() == 0
+
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token("2026-07-25 20:02:03+00"))
+    assert wd.main() == 0
+
+    assert len(keys) == 2, f"expected both to alert, got {keys}"
+    assert keys[0] != keys[1], (
+        f"read-failure and expiry share the condition {keys[0]!r} — the "
+        "expiry will be suppressed as a repeat of the noise it replaces")
+    assert "read-failure" in keys[0] and wd.TIER_EXPIRED in keys[1], keys
+
+
+def test_the_key_carries_the_tier_but_never_the_day_count(wd, monkeypatch):
+    """INNOCENCE + #3677: the key must be stable across runs of the SAME
+    condition. A tier is a condition; `days_left` is a measurement, and a
+    measurement in the key mints a fresh key per run and defeats every window.
+    """
+    keys: list[str] = []
+    monkeypatch.setattr(wd, "_send_telegram",
+                        lambda text, bot_token, condition="alert":
+                        (keys.append(condition), True)[1])
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token("2026-07-25 20:02:03+00"))
+
+    assert wd.main() == 0
+    wd.STATE_FILE.write_text("{}")          # forget, so it alerts again
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token("2026-07-20 20:02:03+00"))  # -17 days now
+    assert wd.main() == 0
+
+    assert len(keys) == 2 and keys[0] == keys[1], (
+        f"the key moved with the day count: {keys}")
+    assert "-12" not in keys[0] and "-17" not in keys[1], (
+        f"a measurement leaked into the key: {keys}")
+
+
+def test_the_condition_actually_reaches_the_dedup_key_on_the_wire(wd, monkeypatch, tmp_path):
+    """The two tests above assert the CONDITION main() computes. Mutation
+    caught that this is not the same claim: deleting `{condition}` from the
+    key that `_send_telegram` builds left them both green.
+
+    The defect lived IN THE KEY — that is the string the gateway's ladder
+    matches on — so it has to be read off the actual argv, one layer below
+    where the earlier assertions stop.
+    """
+    calls: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        return _Result()
+
+    gateway = tmp_path / "tg_notify.py"
+    gateway.write_text("")
+    monkeypatch.setattr(wd, "PROJECT_ROOT", tmp_path.parent)
+    monkeypatch.setattr(wd.subprocess, "run", fake_run)
+    monkeypatch.setattr(wd.Path, "is_file", lambda self: True)
+
+    assert wd._send_telegram("body", "token", "critical_expired") is True
+    assert wd._send_telegram("body", "token", "read-failure") is True
+
+    keys = [c[c.index("--dedup-key") + 1] for c in calls]
+    assert len(keys) == 2, keys
+    assert "critical_expired" in keys[0], f"the condition never reached the key: {keys[0]}"
+    assert "read-failure" in keys[1], f"the condition never reached the key: {keys[1]}"
+    assert keys[0] != keys[1], (
+        f"both conditions produced the SAME key {keys[0]!r} — this is exactly "
+        "the state found on Pro, where the expiry was swallowed by the ladder "
+        "of the connection-error noise it replaces")

--- a/scripts/tests/test_drive_watchdog_tier_ratchet.py
+++ b/scripts/tests/test_drive_watchdog_tier_ratchet.py
@@ -1,0 +1,233 @@
+"""The tier ratchet advanced on classification, so verifying the cure muted it.
+
+TRAUMA (2026-08-06, found in PROVE-LIVE of #3690 — hours after it merged).
+
+`should_alert` fires only on a strictly-more-severe transition. For a
+once-per-lifetime event like "the OAuth token expired" that means there is
+exactly ONE chance to speak, ever. And `main()` spent it in the wrong place:
+
+    save_state(new_state)          # line 532 — ran FIRST, unconditionally
+    ...
+    sent = _send_telegram(...)     # line 538 — its bool was printed, then dropped
+
+So the ratchet recorded "I have told them about tier X" on the strength of
+having CLASSIFIED tier X, never on having DELIVERED it.
+
+The sequence, measured on Pro rather than reasoned about:
+
+  * `google_drive_tokens` — both rows expired, the live one on 2026-07-25
+    (`expires_at > now()` is false, 12 days ago);
+  * #3690 removed the PATH defect that had stopped the watchdog from ever
+    reading that row, and the run that VERIFIED #3690 was therefore the first
+    ever to classify `critical_expired`. It wrote that to the state file;
+  * the state file on Pro then read
+    `{"last_oauth_tier": "critical_expired", "last_oauth_days_left": -12}`;
+  * so the next run took the de-escalation branch and printed
+    **"tutto OK (token valido, SA key OK)"** about a dead credential.
+
+Curing a mute watchdog, and then muting it with the act of proving the cure.
+Same family as W96 (a test writing production state) and as the standing
+lesson that arming a guard before the entrance deletes the last true signal —
+here the "test" was a live verification run and the state it wrote was real.
+
+Three ways the old order lost the one message, all covered below: a
+verification run, a send that fails, and a cron environment with no
+TELEGRAM_BOT_TOKEN (`_send_telegram` returns False on exactly that).
+
+    GUILT ×2     — a failed delivery must NOT advance the ratchet, and the
+                   very next run must still speak. Asserted on the real
+                   historical shape (first-ever `critical_expired`) and on an
+                   escalation between two live tiers.
+    INNOCENCE ×2 — a successful delivery DOES advance it (or the next run
+                   would spam), and a clean token still records TIER_OK so a
+                   later escalation reads as a transition.
+    ORDER        — send happens before the write. Pinned directly, because
+                   the fix is the ORDER and a future refactor that restores
+                   the old sequence would pass every value-level assertion
+                   above on the happy path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "drive_token_watchdog.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("drive_token_watchdog", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    # Registered BEFORE exec — the module defines a @dataclass and dataclasses
+    # resolves annotations through sys.modules[cls.__module__].
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def wd(tmp_path, monkeypatch):
+    """The watchdog with its state file redirected to tmp and every outbound
+    path stubbed. W96: this corpus must never touch the real state file — the
+    real one is precisely what the trauma above corrupted."""
+    mod = _load()
+    monkeypatch.setattr(mod, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(mod, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setattr(mod, "DRY_RUN", False)
+    # SA-key lane out of the way: gcloud is not present in CI and its absence
+    # would otherwise decide the test instead of the code under test (W108).
+    monkeypatch.setattr(mod, "_check_sa_key_age", lambda: None)
+    monkeypatch.setattr(mod, "_load_env", lambda: {"TELEGRAM_BOT_TOKEN": "t"})
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "t")
+    return mod
+
+
+def _token(expires_at: str):
+    return ({"expires_at": expires_at, "created_at": "2026-04-07 23:31:07+00"}, None)
+
+
+def _saved_tier(mod):
+    if not mod.STATE_FILE.exists():
+        return None
+    return json.loads(mod.STATE_FILE.read_text()).get("last_oauth_tier")
+
+
+# ------------------------------------------------------------------- guilt
+def test_a_failed_send_does_not_burn_the_one_expiry_alert(wd, monkeypatch):
+    """THE defect, in its exact historical shape.
+
+    First run ever to see the expired token; delivery fails. Under the old
+    order the ratchet advanced anyway and the next run went silent forever.
+    """
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token("2026-07-25 20:02:03+00"))
+    sends: list[str] = []
+
+    def failing_send(text, bot_token):
+        sends.append(text)
+        return False
+
+    monkeypatch.setattr(wd, "_send_telegram", failing_send)
+
+    assert wd.main() == 0
+    assert sends, "nothing was even attempted — the probe measured its own setup"
+    assert "SCADUTO" in sends[0], f"wrong alert body: {sends[0][:120]}"
+    assert _saved_tier(wd) != wd.TIER_EXPIRED, (
+        "the ratchet advanced on a FAILED delivery — the next run will read "
+        "this as 'already told them' and print 'tutto OK' about a dead token")
+
+    # And the proof that matters: the NEXT run still speaks.
+    sends.clear()
+    assert wd.main() == 0
+    assert sends, "the retry was silenced — the one alert that mattered is gone"
+
+
+def test_a_failed_send_of_an_escalation_still_retries(wd, monkeypatch):
+    """Not only the first-ever transition: any escalation whose delivery fails
+    must remain owed. 14 days -> 7 days with a dead gateway."""
+    wd.STATE_FILE.write_text(json.dumps({"last_oauth_tier": wd.TIER_14_DAYS}))
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token(
+                            (wd.datetime.now(wd.timezone.utc)
+                             + wd.timedelta(days=3)).strftime("%Y-%m-%d %H:%M:%S+00")))
+    monkeypatch.setattr(wd, "_send_telegram", lambda text, bot_token: False)
+
+    assert wd.main() == 0
+    assert _saved_tier(wd) == wd.TIER_14_DAYS, (
+        f"tier moved to {_saved_tier(wd)} despite the send failing")
+
+
+def test_the_sa_key_lane_has_the_same_defect_and_the_same_cure(wd, monkeypatch):
+    """SYMMETRY (W101-recidiva): a fix that covers only the lane that bit you
+    is half a fix.
+
+    `last_sa_alert_age` is the SA lane's ratchet — it alerts only when the age
+    has gone UP since the last alert — and it was written by the same
+    unconditional `save_state` call. Without this case, removing `and
+    delivered` from the SA branch is invisible: the OAuth tests stub
+    `_check_sa_key_age` to None, so that branch never executes in them.
+    """
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token(
+                            (wd.datetime.now(wd.timezone.utc)
+                             + wd.timedelta(days=80)).strftime("%Y-%m-%d %H:%M:%S+00")))
+    monkeypatch.setattr(wd, "_check_sa_key_age", lambda: wd.SA_KEY_MAX_AGE_DAYS + 5)
+    sends: list[str] = []
+
+    def failing_send(text, bot_token):
+        sends.append(text)
+        return False
+
+    monkeypatch.setattr(wd, "_send_telegram", failing_send)
+
+    assert wd.main() == 0
+    assert sends and "SA Key" in sends[0], f"SA alert never raised: {sends}"
+    saved = json.loads(wd.STATE_FILE.read_text())
+    assert saved.get("last_sa_alert_age") is None, (
+        "the SA ratchet advanced on a FAILED delivery — the rotation warning "
+        "is owed and would never be re-sent at this age")
+
+    sends.clear()
+    assert wd.main() == 0
+    assert sends, "the SA retry was silenced"
+
+
+# --------------------------------------------------------------- innocence
+def test_a_successful_send_does_advance_the_ratchet(wd, monkeypatch):
+    """INNOCENCE, and it is load-bearing: if a delivered alert did NOT advance
+    the tier, this organ would re-send the same p0 every six hours. The fix
+    must gate on delivery, not disable the ratchet."""
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token("2026-07-25 20:02:03+00"))
+    sends: list[str] = []
+    monkeypatch.setattr(wd, "_send_telegram",
+                        lambda text, bot_token: (sends.append(text), True)[1])
+
+    assert wd.main() == 0
+    assert _saved_tier(wd) == wd.TIER_EXPIRED, "a delivered alert must be recorded"
+
+    sends.clear()
+    assert wd.main() == 0
+    assert not sends, "same tier re-sent — the ratchet stopped ratcheting"
+
+
+def test_a_healthy_token_still_records_its_tier(wd, monkeypatch):
+    """INNOCENCE: with nothing to send there is nothing to deliver, so the
+    write must still happen — otherwise TIER_OK is never stored and a later
+    escalation has no baseline to be a transition FROM."""
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token(
+                            (wd.datetime.now(wd.timezone.utc)
+                             + wd.timedelta(days=80)).strftime("%Y-%m-%d %H:%M:%S+00")))
+    monkeypatch.setattr(wd, "_send_telegram",
+                        lambda text, bot_token: pytest.fail("nothing should be sent"))
+
+    assert wd.main() == 0
+    assert _saved_tier(wd) == wd.TIER_OK
+
+
+# ------------------------------------------------------------------- order
+def test_the_send_happens_before_the_state_write(wd, monkeypatch):
+    """The fix IS the order, so the order is pinned directly.
+
+    Every assertion above passes on the happy path even with the old
+    sequence — save-then-send only diverges when the send fails. A refactor
+    that quietly restores `save_state` to the top would sail through them all
+    and re-open the exact hole. This test fails the moment it does.
+    """
+    seq: list[str] = []
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly",
+                        lambda: _token("2026-07-25 20:02:03+00"))
+    monkeypatch.setattr(wd, "_send_telegram",
+                        lambda text, bot_token: (seq.append("send"), True)[1])
+    real_save = wd.save_state
+    monkeypatch.setattr(wd, "save_state",
+                        lambda st: (seq.append("save"), real_save(st))[1])
+
+    assert wd.main() == 0
+    assert seq == ["send", "save"], f"wrong order: {seq}"


### PR DESCRIPTION
Found in PROVE-LIVE of #3690, hours after it merged, by asking whether the cured watchdog now says the right thing — not by re-reading the diff.

It says **"tutto OK (token valido, SA key OK)"**. The token expired **2026-07-25**.

Measured on the production DB this turn — both rows, `expires_at > now()`:

| user_id | expires_at | ancora_valido |
|---|---|---|
| `7dfe56b2…` | 2026-07-25T20:02:03Z | **false** |
| `SYSTEM` | 2026-06-15T18:24:18Z | **false** |

## Why

`should_alert` fires only on a strictly-more-severe transition, so for a once-per-lifetime event like "the token expired" there is exactly **one** chance to speak. `main()` spent it in the wrong place:

```python
save_state(new_state)          # ran FIRST, unconditionally
...
sent = _send_telegram(...)     # its bool was printed, then dropped
```

The ratchet recorded *"I have told them about tier X"* on the strength of having **classified** tier X.

So the run that VERIFIED #3690 — the first ever able to read the token, because #3690 is what fixed the PATH — classified `critical_expired`, wrote it to the state file, and delivered nothing anyone read. Pro's state file, read this turn:

```json
{"last_oauth_tier": "critical_expired", "last_oauth_days_left": -12}
```

Every run since takes the de-escalation branch and prints the all-clear.

**Curing a mute watchdog, then muting it with the act of proving the cure.** W96's shape, except the "test" was a live verification run and the state it wrote was real.

## Fix

Send first, then persist — and persist the OAuth tier and the SA-key age only if the delivery actually **succeeded**. Three ways the old order lost the one message, all now closed: a verification run, a send that fails, and a cron environment with no `TELEGRAM_BOT_TOKEN` (`_send_telegram` returns False on exactly that).

Retrying forever is handled by the component whose job it is: the alert goes through `tg_notify` with a **stable** dedup key, so the 6/24/72/168h ladder collapses a persistent failure to ~4 messages a week. **The ratchet answers "has this been DELIVERED", the gateway answers "how often may it repeat"** — one mechanism each, instead of the ratchet doing both and doing the second one wrong.

## Verification

Corpus **6/6**:
- 2 guilt — the first-ever expiry transition, and an escalation between two live tiers
- 2 innocence — a delivered alert **does** advance the ratchet (otherwise this re-sends every 6h), and a healthy token still records `TIER_OK` so a later escalation has a baseline
- 1 symmetry — the SA-key lane has the same ratchet and would otherwise be untested (the OAuth tests stub `_check_sa_key_age` to None, so that branch never executes in them)
- 1 order — pinned directly, because every value-level assertion above passes on the happy path even with the old sequence; save-then-send only diverges when the send fails

Mutation **5/5**.

## Also armed

Neither `test_drive_watchdog_fly_path.py` (from #3690) nor this new corpus was executed by any workflow — the **third** orphaned corpus found today, the second one mine. Both now run in `immune-enforcement`'s loop and sentinel lists (symmetry meta-test green: 38 looped tests, all trigger paths).

## Live repair, separate from this diff

Pro's state file currently says the expiry was already announced, and it was not. Resetting it so the real alert reaches Zero is a production-state action I run in PROVE-LIVE, not something this PR does.

Unchanged and still `operator[credential]`: the token itself needs an interactive re-auth at `https://kita.balizero.com/settings/integrations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)